### PR TITLE
完善编辑资料 Web Android iOS UI E2E 并接入 CD gate

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -105,7 +105,7 @@ jobs:
         run: npx --yes wrangler@latest deploy
 
   staging-e2e:
-    name: Staging API E2E and smoke test
+    name: Staging API and app UI E2E gate
     needs:
       - build-artifact
       - deploy-staging
@@ -149,8 +149,14 @@ jobs:
       - name: Install E2E dependencies
         run: npm install
 
-      - name: Run staging API E2E
+      - name: Install Playwright browsers for web, Android, and iOS UI E2E
+        run: npx playwright install chromium webkit --with-deps
+
+      - name: Run staging profile API E2E
         run: npm test
+
+      - name: Run staging profile app UI E2E on web, Android, and iOS projects
+        run: npm run test:ui
 
       - name: Run staging smoke test
         shell: bash

--- a/fabushi/e2e/playwright.config.js
+++ b/fabushi/e2e/playwright.config.js
@@ -17,8 +17,16 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium-desktop',
+      name: 'web-chromium-desktop',
       use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 900 } }
+    },
+    {
+      name: 'android-chrome-mobile',
+      use: { ...devices['Pixel 7'] }
+    },
+    {
+      name: 'ios-safari-mobile',
+      use: { ...devices['iPhone 14'] }
     }
   ]
 });


### PR DESCRIPTION
## 变更内容

补齐编辑资料功能在 CD 里的完整 UI E2E 覆盖：

- 将 Playwright 项目矩阵从单一桌面 Chromium 扩展为：
  - `web-chromium-desktop`
  - `android-chrome-mobile`
  - `ios-safari-mobile`
- CD 的 staging gate 增加完整 app UI E2E：
  - 安装 Chromium + WebKit
  - 先跑 staging profile API E2E
  - 再跑 staging profile app UI E2E 矩阵
  - UI E2E 通过后才继续 staging smoke、production deploy 和 production smoke

## 覆盖范围

现有 `profile-editing.spec.js` 会覆盖：

- 登录
- 进入“我的”
- 打开“编辑资料”
- 修改用户名 / 邮箱 / 手机号
- 上传头像
- 保存并验证“个人资料更新成功”
- 回到“我的”页验证新用户名
- 刷新后再次验证资料仍可见

## CD gate

生产部署现在被 `staging-e2e` job gate 住；该 job 失败时不会进入 production environment。