### PR TITLE
新增原生 Android iOS 包安装 smoke gate

### DIFF
--- a/.github/scripts/native-install-smoke.sh
+++ b/.github/scripts/native-install-smoke.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1:-}"
+
+android_package="${ANDROID_PACKAGE:-com.ombhrum.fabushi}"
+
+select_ios_runtime() {
+  xcrun simctl list runtimes iOS -j | python3 - <<'PY'
+import json
+import sys
+
+payload = json.load(sys.stdin)
+runtimes = [r for r in payload.get('runtimes', []) if r.get('isAvailable')]
+if not runtimes:
+    raise SystemExit('No available iOS simulator runtimes found')
+# Prefer the newest available iOS runtime.
+runtimes.sort(key=lambda r: r.get('version', '0'))
+print(runtimes[-1]['identifier'])
+PY
+}
+
+select_ios_device_type() {
+  xcrun simctl list devicetypes -j | python3 - <<'PY'
+import json
+import sys
+
+payload = json.load(sys.stdin)
+devices = payload.get('devicetypes', [])
+preferred = [
+    'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
+    'com.apple.CoreSimulator.SimDeviceType.iPhone-14',
+    'com.apple.CoreSimulator.SimDeviceType.iPhone-13',
+]
+ids = {d.get('identifier') for d in devices}
+for identifier in preferred:
+    if identifier in ids:
+        print(identifier)
+        break
+else:
+    iphones = [d for d in devices if 'iPhone' in d.get('name', '')]
+    if not iphones:
+        raise SystemExit('No iPhone simulator device types found')
+    print(iphones[-1]['identifier'])
+PY
+}
+
+android_install_smoke() {
+  local apk_path="build/app/outputs/flutter-apk/app-debug.apk"
+  test -s "$apk_path"
+
+  adb wait-for-device
+  adb install -r "$apk_path"
+  adb shell pm path "$android_package"
+  adb shell monkey -p "$android_package" -c android.intent.category.LAUNCHER 1
+  sleep 15
+  adb shell pidof "$android_package"
+  adb logcat -d -t 2000 > "${RUNNER_TEMP:-/tmp}/fabushi-android-logcat.txt" || true
+}
+
+ios_install_smoke() {
+  local runtime device_type udid app_path bundle_id screenshot_path
+
+  runtime="$(select_ios_runtime)"
+  device_type="$(select_ios_device_type)"
+  udid="$(xcrun simctl create 'Fabushi CI iPhone' "$device_type" "$runtime")"
+
+  cleanup() {
+    xcrun simctl shutdown "$udid" >/dev/null 2>&1 || true
+    xcrun simctl delete "$udid" >/dev/null 2>&1 || true
+  }
+  trap cleanup EXIT
+
+  xcrun simctl boot "$udid"
+  xcrun simctl bootstatus "$udid" -b
+
+  app_path="$(find build/ios/iphonesimulator -name Runner.app -type d | head -n 1)"
+  test -d "$app_path"
+
+  bundle_id="$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' "$app_path/Info.plist")"
+  test -n "$bundle_id"
+
+  xcrun simctl install "$udid" "$app_path"
+  xcrun simctl get_app_container "$udid" "$bundle_id" app
+  xcrun simctl launch "$udid" "$bundle_id"
+  sleep 15
+
+  screenshot_path="${RUNNER_TEMP:-/tmp}/fabushi-ios-simulator.png"
+  xcrun simctl io "$udid" screenshot "$screenshot_path" || true
+  test -s "$screenshot_path"
+}
+
+case "$platform" in
+  android)
+    android_install_smoke
+    ;;
+  ios)
+    ios_install_smoke
+    ;;
+  *)
+    echo "Usage: $0 android|ios" >&2
+    exit 64
+    ;;
+esac

--- a/.github/scripts/native-install-smoke.sh
+++ b/.github/scripts/native-install-smoke.sh
@@ -6,43 +6,43 @@ platform="${1:-}"
 android_package="${ANDROID_PACKAGE:-com.ombhrum.fabushi}"
 
 select_ios_runtime() {
-  xcrun simctl list runtimes iOS -j | python3 - <<'PY'
+  xcrun simctl list runtimes -j | python3 -c '
 import json
 import sys
 
 payload = json.load(sys.stdin)
-runtimes = [r for r in payload.get('runtimes', []) if r.get('isAvailable')]
+runtimes = [r for r in payload.get("runtimes", []) if r.get("isAvailable") and "iOS" in r.get("name", "")]
 if not runtimes:
-    raise SystemExit('No available iOS simulator runtimes found')
+    raise SystemExit("No available iOS simulator runtimes found")
 # Prefer the newest available iOS runtime.
-runtimes.sort(key=lambda r: r.get('version', '0'))
-print(runtimes[-1]['identifier'])
-PY
+runtimes.sort(key=lambda r: tuple(int(p) for p in r.get("version", "0").split(".") if p.isdigit()))
+print(runtimes[-1]["identifier"])
+'
 }
 
 select_ios_device_type() {
-  xcrun simctl list devicetypes -j | python3 - <<'PY'
+  xcrun simctl list devicetypes -j | python3 -c '
 import json
 import sys
 
 payload = json.load(sys.stdin)
-devices = payload.get('devicetypes', [])
+devices = payload.get("devicetypes", [])
 preferred = [
-    'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
-    'com.apple.CoreSimulator.SimDeviceType.iPhone-14',
-    'com.apple.CoreSimulator.SimDeviceType.iPhone-13',
+    "com.apple.CoreSimulator.SimDeviceType.iPhone-15",
+    "com.apple.CoreSimulator.SimDeviceType.iPhone-14",
+    "com.apple.CoreSimulator.SimDeviceType.iPhone-13",
 ]
-ids = {d.get('identifier') for d in devices}
+ids = {d.get("identifier") for d in devices}
 for identifier in preferred:
     if identifier in ids:
         print(identifier)
         break
 else:
-    iphones = [d for d in devices if 'iPhone' in d.get('name', '')]
+    iphones = [d for d in devices if "iPhone" in d.get("name", "")]
     if not iphones:
-        raise SystemExit('No iPhone simulator device types found')
-    print(iphones[-1]['identifier'])
-PY
+        raise SystemExit("No iPhone simulator device types found")
+    print(iphones[-1]["identifier"])
+'
 }
 
 android_install_smoke() {

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,6 +51,7 @@ jobs:
             !/fabushi/assets/built_in/**
             !/fabushi/web/assets/built_in/**
             /.github/workflows/**
+            /.github/scripts/**
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -179,11 +180,113 @@ jobs:
           path: fabushi/e2e/playwright-report
           if-no-files-found: ignore
 
+  android-native-install:
+    name: Android native package install smoke
+    needs:
+      - build-artifact
+      - staging-e2e
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout Android source and native test helper
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.build-artifact.outputs.source_sha }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/**
+            !/fabushi/assets/built_in/**
+            !/fabushi/web/assets/built_in/**
+            /.github/scripts/**
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Build Android debug APK for emulator install test
+        run: |
+          flutter pub get
+          flutter build apk --debug --target-platform android-x64
+
+      - name: Install and launch Android APK on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          script: cd fabushi && bash ../.github/scripts/native-install-smoke.sh android
+
+      - name: Upload Android native install diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-native-install-diagnostics
+          path: |
+            ${{ runner.temp }}/fabushi-android-logcat.txt
+          if-no-files-found: ignore
+
+  ios-native-install:
+    name: iOS native package install smoke
+    needs:
+      - build-artifact
+      - staging-e2e
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout iOS source and native test helper
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.build-artifact.outputs.source_sha }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/**
+            !/fabushi/assets/built_in/**
+            !/fabushi/web/assets/built_in/**
+            /.github/scripts/**
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Build iOS simulator app
+        run: |
+          flutter pub get
+          flutter build ios --debug --simulator
+
+      - name: Install and launch iOS app on simulator
+        run: bash ../.github/scripts/native-install-smoke.sh ios
+
+      - name: Upload iOS native install diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-native-install-diagnostics
+          path: |
+            ${{ runner.temp }}/fabushi-ios-simulator.png
+          if-no-files-found: ignore
+
   deploy-production:
     name: Deploy production environment
     needs:
       - build-artifact
       - staging-e2e
+      - android-native-install
+      - ios-native-install
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -212,6 +315,7 @@ jobs:
             echo ""
             echo "- Source SHA: ${{ needs.build-artifact.outputs.source_sha }}"
             echo "- Artifact: fabushi-release-${{ needs.build-artifact.outputs.source_sha }}"
+            echo "- Gates: staging API E2E, web/Android/iOS UI E2E, Android native install, iOS native install"
             echo "- URL: ${{ vars.PRODUCTION_APP_URL || 'https://flutter.ombhrum.com' }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -253,6 +357,8 @@ jobs:
       - build-artifact
       - deploy-staging
       - staging-e2e
+      - android-native-install
+      - ios-native-install
       - deploy-production
       - production-smoke
     if: failure()
@@ -271,6 +377,7 @@ jobs:
               `- Source SHA: ${sourceSha}`,
               `- Workflow run: ${runUrl}`,
               '- Failed stage: check the workflow job list for the first failed job.',
+              '- Gates include staging API E2E, web/Android/iOS UI E2E, Android native install, and iOS native install.',
               '',
               '### Rollback',
               '',


### PR DESCRIPTION
## 变更内容

在现有 Web/Android/iOS Playwright UI E2E gate 之外，新增真正的原生包安装 smoke gate：

- 新增 `.github/scripts/native-install-smoke.sh`
  - Android：安装 debug APK 到 emulator，启动 launcher activity，确认 app 进程存活，并上传 logcat 诊断
  - iOS：创建并启动 iOS simulator，安装 `Runner.app`，解析实际 bundle id，启动 app，并上传 simulator 截图诊断
- CD 新增两个 production 前置 gate：
  - `Android native package install smoke`，Ubuntu + Android emulator
  - `iOS native package install smoke`，macOS + iOS simulator
- `deploy-production` 现在同时依赖：
  - staging API E2E
  - Web / Android Chrome / iOS Safari app UI E2E
  - Android 原生安装 smoke
  - iOS 原生安装 smoke

## 覆盖目标

这不是单纯浏览器移动 viewport；它会构建并安装原生 Android APK 和 iOS simulator app，确认包能在真实 emulator/simulator 环境安装、启动并保持进程可用。