### PR TITLE
feat: add global language switch and app localization scaffold

### DIFF
--- a/fabushi/lib/l10n/app_localizations.dart
+++ b/fabushi/lib/l10n/app_localizations.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+class AppLanguageOption {
+  const AppLanguageOption({required this.code, required this.nativeName, required this.englishName, required this.locale});
+
+  final String code;
+  final String nativeName;
+  final String englishName;
+  final Locale? locale;
+}
+
+class AppLocalizations {
+  const AppLocalizations(this.localeCode);
+
+  final String localeCode;
+
+  static const systemLocaleCode = 'system';
+  static const fallbackLocaleCode = 'en';
+
+  static const languageOptions = <AppLanguageOption>[
+    AppLanguageOption(code: systemLocaleCode, nativeName: '跟随系统', englishName: 'System default', locale: null),
+    AppLanguageOption(code: 'zh-Hans', nativeName: '简体中文', englishName: 'Chinese (Simplified)', locale: Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans')),
+    AppLanguageOption(code: 'zh-Hant', nativeName: '繁體中文', englishName: 'Chinese (Traditional)', locale: Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant')),
+    AppLanguageOption(code: 'en', nativeName: 'English', englishName: 'English', locale: Locale('en')),
+    AppLanguageOption(code: 'ja', nativeName: '日本語', englishName: 'Japanese', locale: Locale('ja')),
+    AppLanguageOption(code: 'ko', nativeName: '한국어', englishName: 'Korean', locale: Locale('ko')),
+    AppLanguageOption(code: 'es', nativeName: 'Español', englishName: 'Spanish', locale: Locale('es')),
+    AppLanguageOption(code: 'fr', nativeName: 'Français', englishName: 'French', locale: Locale('fr')),
+    AppLanguageOption(code: 'de', nativeName: 'Deutsch', englishName: 'German', locale: Locale('de')),
+    AppLanguageOption(code: 'pt', nativeName: 'Português', englishName: 'Portuguese', locale: Locale('pt')),
+    AppLanguageOption(code: 'ru', nativeName: 'Русский', englishName: 'Russian', locale: Locale('ru')),
+    AppLanguageOption(code: 'hi', nativeName: 'हिन्दी', englishName: 'Hindi', locale: Locale('hi')),
+  ];
+
+  static List<Locale> get supportedLocales => languageOptions.where((option) => option.locale != null).map((option) => option.locale!).toList(growable: false);
+
+  static const delegate = _AppLocalizationsDelegate();
+
+  static const localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ];
+
+  static AppLocalizations of(BuildContext context) => Localizations.of<AppLocalizations>(context, AppLocalizations) ?? const AppLocalizations(fallbackLocaleCode);
+
+  static Locale? localeFromPreference(String code) {
+    if (code == systemLocaleCode) return null;
+    for (final option in languageOptions) {
+      if (option.code == code) return option.locale;
+    }
+    return null;
+  }
+
+  static Locale localeListResolutionCallback(List<Locale>? locales, Iterable<Locale> supportedLocales) {
+    if (locales == null || locales.isEmpty) return const Locale('en');
+    for (final locale in locales) {
+      final resolved = resolveLocale(locale, supportedLocales);
+      if (resolved != null) return resolved;
+    }
+    return const Locale('en');
+  }
+
+  static Locale? resolveLocale(Locale locale, Iterable<Locale> supportedLocales) {
+    final canonicalCode = canonicalLocaleCode(locale);
+    for (final supportedLocale in supportedLocales) {
+      if (canonicalLocaleCode(supportedLocale) == canonicalCode) return supportedLocale;
+    }
+    for (final supportedLocale in supportedLocales) {
+      if (supportedLocale.languageCode == locale.languageCode) return supportedLocale;
+    }
+    return null;
+  }
+
+  static String canonicalLocaleCode(Locale locale) {
+    final languageCode = locale.languageCode.toLowerCase();
+    final scriptCode = locale.scriptCode?.toLowerCase();
+    final countryCode = locale.countryCode?.toLowerCase();
+    if (languageCode == 'zh') {
+      if (scriptCode == 'hant' || countryCode == 'tw' || countryCode == 'hk' || countryCode == 'mo') return 'zh-Hant';
+      return 'zh-Hans';
+    }
+    for (final option in languageOptions) {
+      if (option.locale?.languageCode == languageCode) return option.code;
+    }
+    return fallbackLocaleCode;
+  }
+
+  static bool isSupportedPreference(String code) => languageOptions.any((option) => option.code == code);
+
+  static String languageNameForPreference(String code, AppLocalizations localizations) {
+    if (code == systemLocaleCode) return localizations.languageSystem;
+    for (final option in languageOptions) {
+      if (option.code == code) return option.nativeName;
+    }
+    return localizations.languageSystem;
+  }
+
+  String text(String key) => _localizedValues[localeCode]?[key] ?? _localizedValues[fallbackLocaleCode]?[key] ?? key;
+
+  String get appName => text('appName');
+  String get navHome => text('navHome');
+  String get navMeditationRoom => text('navMeditationRoom');
+  String get navProfile => text('navProfile');
+  String get settingsLanguageTitle => text('settingsLanguageTitle');
+  String get settingsLanguageSubtitle => text('settingsLanguageSubtitle');
+  String get languageSystem => text('languageSystem');
+  String get languageSystemDescription => text('languageSystemDescription');
+  String get languageChooserTitle => text('languageChooserTitle');
+  String get cancel => text('cancel');
+
+  static const _localizedValues = <String, Map<String, String>>{
+    'zh-Hans': {'appName': '大乘', 'navHome': '首页', 'navMeditationRoom': '禅室', 'navProfile': '我的', 'settingsLanguageTitle': '语言', 'settingsLanguageSubtitle': '切换应用显示语言', 'languageSystem': '跟随系统', 'languageSystemDescription': '自动使用设备首选语言', 'languageChooserTitle': '选择语言', 'cancel': '取消'},
+    'zh-Hant': {'appName': '大乘', 'navHome': '首頁', 'navMeditationRoom': '禪室', 'navProfile': '我的', 'settingsLanguageTitle': '語言', 'settingsLanguageSubtitle': '切換應用程式顯示語言', 'languageSystem': '跟隨系統', 'languageSystemDescription': '自動使用裝置首選語言', 'languageChooserTitle': '選擇語言', 'cancel': '取消'},
+    'en': {'appName': 'Mahayana', 'navHome': 'Home', 'navMeditationRoom': 'Zen Room', 'navProfile': 'Profile', 'settingsLanguageTitle': 'Language', 'settingsLanguageSubtitle': 'Change the app display language', 'languageSystem': 'System default', 'languageSystemDescription': 'Automatically use your device language', 'languageChooserTitle': 'Choose language', 'cancel': 'Cancel'},
+    'ja': {'appName': '大乗', 'navHome': 'ホーム', 'navMeditationRoom': '禅室', 'navProfile': 'マイページ', 'settingsLanguageTitle': '言語', 'settingsLanguageSubtitle': 'アプリの表示言語を変更', 'languageSystem': 'システムに合わせる', 'languageSystemDescription': '端末の優先言語を自動的に使用', 'languageChooserTitle': '言語を選択', 'cancel': 'キャンセル'},
+    'ko': {'appName': '대승', 'navHome': '홈', 'navMeditationRoom': '선실', 'navProfile': '내 정보', 'settingsLanguageTitle': '언어', 'settingsLanguageSubtitle': '앱 표시 언어 변경', 'languageSystem': '시스템 기본값', 'languageSystemDescription': '기기 기본 언어를 자동으로 사용', 'languageChooserTitle': '언어 선택', 'cancel': '취소'},
+    'es': {'appName': 'Mahayana', 'navHome': 'Inicio', 'navMeditationRoom': 'Sala Zen', 'navProfile': 'Perfil', 'settingsLanguageTitle': 'Idioma', 'settingsLanguageSubtitle': 'Cambiar el idioma de la aplicación', 'languageSystem': 'Predeterminado del sistema', 'languageSystemDescription': 'Usar automáticamente el idioma del dispositivo', 'languageChooserTitle': 'Elegir idioma', 'cancel': 'Cancelar'},
+    'fr': {'appName': 'Mahayana', 'navHome': 'Accueil', 'navMeditationRoom': 'Salle zen', 'navProfile': 'Profil', 'settingsLanguageTitle': 'Langue', 'settingsLanguageSubtitle': 'Changer la langue de l’application', 'languageSystem': 'Langue du système', 'languageSystemDescription': 'Utiliser automatiquement la langue de l’appareil', 'languageChooserTitle': 'Choisir la langue', 'cancel': 'Annuler'},
+    'de': {'appName': 'Mahayana', 'navHome': 'Start', 'navMeditationRoom': 'Zen-Raum', 'navProfile': 'Profil', 'settingsLanguageTitle': 'Sprache', 'settingsLanguageSubtitle': 'Anzeigesprache der App ändern', 'languageSystem': 'Systemstandard', 'languageSystemDescription': 'Automatisch die Gerätesprache verwenden', 'languageChooserTitle': 'Sprache wählen', 'cancel': 'Abbrechen'},
+    'pt': {'appName': 'Mahayana', 'navHome': 'Início', 'navMeditationRoom': 'Sala Zen', 'navProfile': 'Perfil', 'settingsLanguageTitle': 'Idioma', 'settingsLanguageSubtitle': 'Alterar o idioma de exibição do app', 'languageSystem': 'Padrão do sistema', 'languageSystemDescription': 'Usar automaticamente o idioma do dispositivo', 'languageChooserTitle': 'Escolher idioma', 'cancel': 'Cancelar'},
+    'ru': {'appName': 'Махаяна', 'navHome': 'Главная', 'navMeditationRoom': 'Дзен-зал', 'navProfile': 'Профиль', 'settingsLanguageTitle': 'Язык', 'settingsLanguageSubtitle': 'Изменить язык приложения', 'languageSystem': 'Как в системе', 'languageSystemDescription': 'Автоматически использовать язык устройства', 'languageChooserTitle': 'Выберите язык', 'cancel': 'Отмена'},
+    'hi': {'appName': 'महायान', 'navHome': 'होम', 'navMeditationRoom': 'ज़ेन कक्ष', 'navProfile': 'प्रोफ़ाइल', 'settingsLanguageTitle': 'भाषा', 'settingsLanguageSubtitle': 'ऐप की प्रदर्शन भाषा बदलें', 'languageSystem': 'सिस्टम डिफ़ॉल्ट', 'languageSystemDescription': 'अपने डिवाइस की भाषा अपने आप उपयोग करें', 'languageChooserTitle': 'भाषा चुनें', 'cancel': 'रद्द करें'},
+  };
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => AppLocalizations.resolveLocale(locale, AppLocalizations.supportedLocales) != null;
+
+  @override
+  Future<AppLocalizations> load(Locale locale) => SynchronousFuture(AppLocalizations(AppLocalizations.canonicalLocaleCode(locale)));
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+extension AppLocalizationsContext on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this);
+}

--- a/fabushi/lib/main.dart
+++ b/fabushi/lib/main.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'firebase_options.dart';
 import 'core/di/injection.dart';
 import 'core/config/app_config.dart';
+import 'l10n/app_localizations.dart';
 import 'models/file_transfer_model.dart';
 import 'models/settings_model.dart';
 import 'models/auth_model.dart';
@@ -125,14 +126,23 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => VideoFeedVisibilityNotifier()),
         ChangeNotifierProvider(create: (_) => TtsMuteNotifier()..initialize()),
       ],
-      child: MaterialApp(
-        title: AppConfig.appName,
-        debugShowCheckedModeBanner: false,
-        routes: {'/login': (_) => const DouyinLoginScreen()},
-        theme: AppTheme.lightTheme, // Though we prefer dark for space theme
-        darkTheme: AppTheme.darkTheme,
-        themeMode: ThemeMode.dark, // Enforce Dark/Space theme
-        home: const AppWrapper(),
+      child: Consumer<SettingsModel>(
+        builder: (context, settings, _) {
+          return MaterialApp(
+            title: AppConfig.appName,
+            onGenerateTitle: (context) => context.l10n.appName,
+            debugShowCheckedModeBanner: false,
+            locale: settings.appLocale,
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            localeListResolutionCallback: AppLocalizations.localeListResolutionCallback,
+            routes: {'/login': (_) => const DouyinLoginScreen()},
+            theme: AppTheme.lightTheme, // Though we prefer dark for space theme
+            darkTheme: AppTheme.darkTheme,
+            themeMode: ThemeMode.dark, // Enforce Dark/Space theme
+            home: const AppWrapper(),
+          );
+        },
       ),
     );
   }

--- a/fabushi/lib/models/settings_model.dart
+++ b/fabushi/lib/models/settings_model.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../l10n/app_localizations.dart';
 
 // 国家常量定义
 const String COUNTRY_ALL = 'ALL';
@@ -19,6 +22,7 @@ class SettingsModel extends ChangeNotifier {
   int _wifiSignalStrength = 80; // WiFi信号强度（百分比）
   bool _notificationsEnabled = true;
   List<String> _selectedCountries = []; // 选中的国家列表
+  String _localePreference = AppLocalizations.systemLocaleCode; // 应用显示语言
 
   // 获取深色模式状态
   bool get darkMode => _darkMode;
@@ -35,6 +39,12 @@ class SettingsModel extends ChangeNotifier {
   // 获取选中的国家列表
   List<String> get selectedCountries => _selectedCountries;
 
+  // 获取应用语言偏好，system 表示跟随系统
+  String get localePreference => _localePreference;
+
+  // 获取 MaterialApp 可直接使用的 Locale；null 表示跟随系统
+  Locale? get appLocale => AppLocalizations.localeFromPreference(_localePreference);
+
   // 构造函数
   SettingsModel() {
     _loadSettings();
@@ -49,6 +59,10 @@ class SettingsModel extends ChangeNotifier {
     _wifiSignalStrength = prefs.getInt('wifiSignalStrength') ?? 80;
     _notificationsEnabled = prefs.getBool('notificationsEnabled') ?? true;
     _selectedCountries = prefs.getStringList('selectedCountries') ?? [];
+    final savedLocalePreference = prefs.getString('localePreference') ?? AppLocalizations.systemLocaleCode;
+    _localePreference = AppLocalizations.isSupportedPreference(savedLocalePreference)
+        ? savedLocalePreference
+        : AppLocalizations.systemLocaleCode;
 
     // 加载国家发送配置
     _selectedCountry = prefs.getString('selectedCountry') ?? COUNTRY_ALL;
@@ -68,6 +82,7 @@ class SettingsModel extends ChangeNotifier {
     await prefs.setInt('wifiSignalStrength', _wifiSignalStrength);
     await prefs.setBool('notificationsEnabled', _notificationsEnabled);
     await prefs.setStringList('selectedCountries', _selectedCountries);
+    await prefs.setString('localePreference', _localePreference);
 
     // 保存国家发送配置
     await prefs.setString('selectedCountry', _selectedCountry);
@@ -105,6 +120,15 @@ class SettingsModel extends ChangeNotifier {
   void setNotificationsEnabled(bool value) {
     _notificationsEnabled = value;
     _saveSettings();
+    notifyListeners();
+  }
+
+  // 设置应用显示语言。传入 system 时跟随系统语言。
+  Future<void> setLocalePreference(String value) async {
+    final nextValue = AppLocalizations.isSupportedPreference(value) ? value : AppLocalizations.systemLocaleCode;
+    if (_localePreference == nextValue) return;
+    _localePreference = nextValue;
+    await _saveSettings();
     notifyListeners();
   }
 
@@ -152,6 +176,7 @@ class SettingsModel extends ChangeNotifier {
     _wifiSignalStrength = 80;
     _notificationsEnabled = true;
     _selectedCountries = [];
+    _localePreference = AppLocalizations.systemLocaleCode;
 
     // 重置国家相关设置
     _selectedCountry = COUNTRY_ALL;
@@ -206,6 +231,7 @@ class SettingsModel extends ChangeNotifier {
   void debugInfo() {
     if (kDebugMode) {
       print('Settings: {');
+      print('  localePreference: $localePreference,');
       print('  selectedCountry: $selectedCountry,');
       print('  isGlobalSendEnabled: $isGlobalSendEnabled,');
       print('  isWifiSendEnabled: $isWifiSendEnabled,');

--- a/fabushi/lib/screens/main_navigation_screen.dart
+++ b/fabushi/lib/screens/main_navigation_screen.dart
@@ -3,6 +3,7 @@ import 'globe_home_screen.dart';
 import 'meditation_room_screen.dart';
 import 'my_profile_screen.dart';
 import '../core/design_system/app_theme.dart';
+import '../l10n/app_localizations.dart';
 import '../widgets/space_background.dart';
 
 class MainNavigationScreen extends StatefulWidget {
@@ -104,6 +105,8 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
     return SpaceBackground(
       child: Scaffold(
         backgroundColor: Colors.transparent,
@@ -148,21 +151,21 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               backgroundColor: Colors.transparent,
               elevation: 0,
               height: 70,
-              destinations: const [
+              destinations: [
                 NavigationDestination(
-                  icon: Icon(Icons.public_outlined),
-                  selectedIcon: Icon(Icons.public),
-                  label: '首页',
+                  icon: const Icon(Icons.public_outlined),
+                  selectedIcon: const Icon(Icons.public),
+                  label: l10n.navHome,
                 ),
                 NavigationDestination(
-                  icon: Icon(Icons.self_improvement_outlined),
-                  selectedIcon: Icon(Icons.self_improvement),
-                  label: '禅室',
+                  icon: const Icon(Icons.self_improvement_outlined),
+                  selectedIcon: const Icon(Icons.self_improvement),
+                  label: l10n.navMeditationRoom,
                 ),
                 NavigationDestination(
-                  icon: Icon(Icons.person_outline),
-                  selectedIcon: Icon(Icons.person),
-                  label: '我的',
+                  icon: const Icon(Icons.person_outline),
+                  selectedIcon: const Icon(Icons.person),
+                  label: l10n.navProfile,
                 ),
               ],
             ),

--- a/fabushi/lib/screens/my_profile_screen.dart
+++ b/fabushi/lib/screens/my_profile_screen.dart
@@ -7,6 +7,8 @@ import 'edit_profile_screen.dart';
 import 'douyin_login_screen.dart';
 import 'settings_screen.dart';
 import '../core/design_system/app_theme.dart';
+import '../l10n/app_localizations.dart';
+import '../widgets/language_selector_sheet.dart';
 import '../widgets/practice_entry_card.dart';
 import '../services/meditation_session_manager.dart';
 import 'practice_record_screen.dart';
@@ -99,6 +101,11 @@ class _MyProfileScreenState extends State<MyProfileScreen> {
       pinned: true,
       backgroundColor: const Color(0xFF121212),
       actions: [
+        IconButton(
+          tooltip: context.l10n.settingsLanguageTitle,
+          icon: const Icon(Icons.language, color: Colors.white),
+          onPressed: () => LanguageSelectorSheet.show(context),
+        ),
         if (user != null)
           IconButton(
             icon: const Icon(Icons.settings_outlined, color: Colors.white),

--- a/fabushi/lib/widgets/language_selector_sheet.dart
+++ b/fabushi/lib/widgets/language_selector_sheet.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/settings_model.dart';
+
+class LanguageSelectorSheet extends StatelessWidget {
+  const LanguageSelectorSheet({super.key});
+
+  static Future<void> show(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: const Color(0xFF1E1E1E),
+      showDragHandle: true,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (_) => const LanguageSelectorSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final settings = context.watch<SettingsModel>();
+
+    return SafeArea(
+      child: FractionallySizedBox(
+        heightFactor: 0.72,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+              child: Row(
+                children: [
+                  const Icon(Icons.language, color: Colors.cyan),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      l10n.languageChooserTitle,
+                      style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: l10n.cancel,
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.close, color: Colors.white54),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView.separated(
+                itemCount: AppLocalizations.languageOptions.length,
+                separatorBuilder: (_, __) => const Divider(height: 1, color: Colors.white10, indent: 20, endIndent: 20),
+                itemBuilder: (context, index) {
+                  final option = AppLocalizations.languageOptions[index];
+                  final isSystem = option.code == AppLocalizations.systemLocaleCode;
+                  return RadioListTile<String>(
+                    value: option.code,
+                    groupValue: settings.localePreference,
+                    activeColor: Colors.cyan,
+                    onChanged: (value) async {
+                      if (value == null) return;
+                      await settings.setLocalePreference(value);
+                      if (context.mounted) Navigator.pop(context);
+                    },
+                    title: Text(
+                      isSystem ? l10n.languageSystem : option.nativeName,
+                      style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
+                    ),
+                    subtitle: Text(
+                      isSystem ? l10n.languageSystemDescription : option.englishName,
+                      style: const TextStyle(color: Colors.white54, fontSize: 13),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fabushi/lib/widgets/language_setting_item.dart
+++ b/fabushi/lib/widgets/language_setting_item.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/settings_model.dart';
+import 'language_selector_sheet.dart';
+
+class LanguageSettingItem extends StatelessWidget {
+  const LanguageSettingItem({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final settings = context.watch<SettingsModel>();
+    final selectedLanguageName = AppLocalizations.languageNameForPreference(settings.localePreference, l10n);
+
+    return Card(
+      color: const Color(0xFF1E1E1E),
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: ListTile(
+        leading: Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(color: Colors.cyan.withOpacity(0.15), borderRadius: BorderRadius.circular(8)),
+          child: const Icon(Icons.language, color: Colors.cyan, size: 24),
+        ),
+        title: Text(
+          l10n.settingsLanguageTitle,
+          style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
+        ),
+        subtitle: Text(
+          '${l10n.settingsLanguageSubtitle} · $selectedLanguageName',
+          style: const TextStyle(color: Colors.white54, fontSize: 13),
+        ),
+        trailing: const Icon(Icons.chevron_right, color: Colors.white24),
+        onTap: () => LanguageSelectorSheet.show(context),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add an app localization scaffold with supported locale resolution and fallback handling.
- Persist the user's language preference in `SettingsModel`, with `system` as the default.
- Wire Flutter localization delegates, supported locales, and selected locale into `MaterialApp`.
- Localize the bottom navigation labels.
- Add a non-floating language switch entry in the profile AppBar so both guests and logged-in users can change language.
- Add reusable `LanguageSelectorSheet` and `LanguageSettingItem` widgets for future settings-page integration.

## Supported languages
- System default
- Simplified Chinese
- Traditional Chinese
- English
- Japanese
- Korean
- Spanish
- French
- German
- Portuguese
- Russian
- Hindi

## Notes
- No floating language button is used.
- The branch is based on the latest app files; the only main-branch commit not included changes `.github/workflows/ci.yml` only, so it does not overlap with this app code change.
- CI appears to be workflow-dispatch only, so checks may need to be triggered manually.

## Testing
- Not run locally in this environment.