### PR TITLE
ci: harden delivery gates and hide model setup startup dialog

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,74 @@
+# Branch protection and release policy
+
+This repository uses a mature-team delivery model:
+
+1. Pull requests prove that a change is safe to merge.
+2. The default branch is protected and stays deployable.
+3. Production deploys happen only from `main` after staging and smoke gates pass.
+4. Fully automatic merge is explicit, label-gated, and blocked for sensitive paths.
+
+## Required GitHub settings
+
+Enable these repository settings for `main` under **Settings -> Branches -> Branch protection rules**.
+
+### Main branch protection
+
+- Require a pull request before merging.
+- Require status checks to pass before merging.
+- Require branches to be up to date before merging, or enable GitHub merge queue.
+- Require conversation resolution before merging.
+- Require linear history when practical.
+- Do not allow force pushes.
+- Do not allow deletions.
+- Restrict bypasses to maintainers only.
+
+### Required checks
+
+Require this aggregate check instead of every internal job:
+
+- `CI result`
+
+The aggregate check depends on:
+
+- `Flutter quality, tests, build, and web smoke`
+- `Cloudflare Worker syntax and deploy dry-run`
+- `Playwright E2E contract validation`
+
+### Merge queue
+
+For best protection against stale green PRs, enable GitHub merge queue for `main`.
+
+The `CI` workflow supports the `merge_group` event, so queued merge candidates are validated against the latest `main` before they land.
+
+## Automerge policy
+
+Automerge is opt-in, not global.
+
+A PR can be merged automatically only when all of these are true:
+
+- It targets `main`.
+- It is not a draft.
+- It comes from this repository, not a fork.
+- It has the `automerge` label.
+- Its latest head commit has a successful `CI` run.
+- It does not touch sensitive paths.
+
+Sensitive paths include CI/CD configuration, deployment scripts, auth, payment, and database-related files. Those changes require a human merge even when CI is green.
+
+## CD policy
+
+CD runs only after a successful `CI` workflow from a `main` push, or by explicit manual dispatch.
+
+The production path is:
+
+1. Build release artifact.
+2. Deploy staging.
+3. Run staging API and app UI E2E.
+4. Run Android native install smoke.
+5. Run iOS native install smoke.
+6. Deploy production.
+7. Run production smoke test.
+
+Production deploys are serialized with a single `cd-production-main` concurrency group. This avoids two production deployments racing each other.
+
+Manual CD dispatch accepts an optional `source_sha` for controlled redeploys and rollback validation.

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,181 @@
+name: Explicit automerge
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate for automerge.
+        required: true
+        type: number
+
+concurrency:
+  group: automerge-${{ github.event.pull_request.number || inputs.pr_number || github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  actions: read
+  checks: read
+  issues: write
+  pull-requests: write
+  statuses: read
+
+jobs:
+  automerge:
+    name: Merge explicitly authorized green PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Evaluate and merge authorized PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const autoMergeLabel = 'automerge';
+            const requiredWorkflowName = 'CI';
+            const requiredConclusion = 'success';
+            const sensitivePathPrefixes = [
+              '.github/workflows/',
+              '.github/actions/',
+              '.github/scripts/',
+            ];
+            const sensitivePathPatterns = [
+              /^fabushi\/web\/wrangler\.toml$/,
+              /^fabushi\/web\/.*\.sql$/,
+              /^fabushi\/lib\/models\/auth_model\.dart$/,
+              /^fabushi\/lib\/services\/.*auth.*\.dart$/,
+              /^fabushi\/lib\/services\/.*payment.*\.dart$/,
+              /^fabushi\/lib\/services\/.*alipay.*\.dart$/,
+              /^fabushi\/web\/.*auth.*\.js$/,
+              /^fabushi\/web\/.*payment.*\.js$/,
+              /^fabushi\/web\/.*alipay.*\.js$/,
+            ];
+
+            async function findPr() {
+              if (context.eventName === 'pull_request') {
+                return context.payload.pull_request;
+              }
+
+              if (context.eventName === 'workflow_dispatch') {
+                const pull_number = Number(core.getInput('pr_number'));
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
+                return data;
+              }
+
+              if (context.eventName === 'workflow_run') {
+                const workflowRun = context.payload.workflow_run;
+                if (workflowRun.conclusion !== requiredConclusion) {
+                  core.info(`CI conclusion is ${workflowRun.conclusion}; skipping.`);
+                  return null;
+                }
+                const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner,
+                  repo,
+                  commit_sha: workflowRun.head_sha,
+                });
+                return pulls.find((pr) => pr.state === 'open' && pr.base.ref === 'main') || null;
+              }
+
+              return null;
+            }
+
+            async function hasSuccessfulCi(headSha) {
+              const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner,
+                repo,
+                workflow_id: 'ci.yml',
+                head_sha: headSha,
+                status: 'completed',
+                per_page: 10,
+              });
+              return runs.workflow_runs.some(
+                (run) => run.name === requiredWorkflowName && run.conclusion === requiredConclusion,
+              );
+            }
+
+            async function hasSensitiveChanges(pull_number) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number,
+                per_page: 100,
+              });
+              return files.some((file) => {
+                const filename = file.filename;
+                return sensitivePathPrefixes.some((prefix) => filename.startsWith(prefix)) ||
+                  sensitivePathPatterns.some((pattern) => pattern.test(filename));
+              });
+            }
+
+            const pr = await findPr();
+            if (!pr) {
+              core.info('No open main-targeting PR found for automerge evaluation.');
+              return;
+            }
+
+            const labels = pr.labels.map((label) => label.name);
+            if (!labels.includes(autoMergeLabel)) {
+              core.info(`PR #${pr.number} does not have the ${autoMergeLabel} label; skipping.`);
+              return;
+            }
+
+            if (pr.draft) {
+              core.info(`PR #${pr.number} is a draft; skipping.`);
+              return;
+            }
+
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.info(`PR #${pr.number} comes from a fork; skipping automerge.`);
+              return;
+            }
+
+            if (await hasSensitiveChanges(pr.number)) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: 'Automerge skipped: this PR changes protected CI/CD, auth, payment, deployment, or database files and needs a human merge.',
+              });
+              core.info(`PR #${pr.number} touches sensitive paths; skipping.`);
+              return;
+            }
+
+            const freshPr = (await github.rest.pulls.get({ owner, repo, pull_number: pr.number })).data;
+            if (freshPr.mergeable === false || freshPr.mergeable_state === 'dirty') {
+              core.setFailed(`PR #${pr.number} is not mergeable: ${freshPr.mergeable_state}`);
+              return;
+            }
+
+            if (!(await hasSuccessfulCi(freshPr.head.sha))) {
+              core.info(`PR #${pr.number} head ${freshPr.head.sha} does not have a successful CI run yet.`);
+              return;
+            }
+
+            await github.rest.pulls.merge({
+              owner,
+              repo,
+              pull_number: pr.number,
+              merge_method: 'squash',
+              commit_title: freshPr.title,
+              commit_message: `Automerge PR #${pr.number} after successful CI.`,
+              sha: freshPr.head.sha,
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body: `Automerge completed after successful ${requiredWorkflowName}. CD will run from main and gate production through staging E2E and native install smoke tests.`,
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,25 +4,31 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
   push:
     branches:
       - main
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: write
   actions: read
+  checks: read
   issues: write
   pull-requests: read
+  statuses: read
 
 jobs:
   flutter:
     name: Flutter quality, tests, build, and web smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: fabushi
@@ -156,6 +162,7 @@ jobs:
   worker:
     name: Cloudflare Worker syntax and deploy dry-run
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: flutter
     defaults:
       run:
@@ -203,6 +210,7 @@ jobs:
   e2e-contract:
     name: Playwright E2E contract validation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: fabushi/e2e
@@ -228,6 +236,7 @@ jobs:
   ci-result:
     name: CI result
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - flutter
       - worker
@@ -255,6 +264,7 @@ jobs:
   notify-ci-failure:
     name: Notify CI failure
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - flutter
       - worker
@@ -272,9 +282,9 @@ jobs:
       - name: Create or update detailed CI failure issue
         uses: actions/github-script@v7
         env:
-          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          SOURCE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          SOURCE_REF: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref || github.ref_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           PR_URL: ${{ github.event.pull_request.html_url || '' }}
         with:
@@ -300,5 +310,6 @@ jobs:
                 '',
                 '- Dart format diffs are uploaded as `dart-format-patch` when formatter output differs from the committed code.',
                 '- Build and dry-run bundles are listed above when those jobs reach their upload steps.',
+                '- Merge queue runs are supported through the `merge_group` trigger.',
               ],
             });

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,9 +9,14 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Commit SHA to deploy. Leave empty to deploy the current default-branch SHA.
+        required: false
+        type: string
 
 concurrency:
-  group: cd-production-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: cd-production-main
   cancel-in-progress: false
 
 permissions:
@@ -25,8 +30,9 @@ jobs:
     name: Build release artifact
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: fabushi
@@ -36,12 +42,19 @@ jobs:
       - name: Resolve source commit
         id: source
         working-directory: .
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            echo "source_sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            source_sha="${{ github.event.workflow_run.head_sha }}"
+          elif [ -n "${INPUT_SOURCE_SHA:-}" ]; then
+            source_sha="$INPUT_SOURCE_SHA"
           else
-            echo "source_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            source_sha="${{ github.sha }}"
           fi
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved source SHA: $source_sha"
 
       - name: Checkout source
         uses: actions/checkout@v4
@@ -88,6 +101,7 @@ jobs:
     name: Deploy staging environment
     needs: build-artifact
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: development
       url: https://fabushi-flutter-web-dev.bhrumom.workers.dev
@@ -151,6 +165,7 @@ jobs:
       - build-artifact
       - deploy-staging
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: fabushi/e2e
@@ -234,6 +249,7 @@ jobs:
       - build-artifact
       - staging-e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: fabushi
@@ -290,6 +306,7 @@ jobs:
       - build-artifact
       - staging-e2e
     runs-on: macos-15
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: fabushi
@@ -336,6 +353,7 @@ jobs:
       - android-native-install
       - ios-native-install
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: production
       url: ${{ vars.PRODUCTION_APP_URL || 'https://flutter.ombhrum.com' }}
@@ -391,6 +409,7 @@ jobs:
       - build-artifact
       - deploy-production
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       PRODUCTION_APP_URL: ${{ vars.PRODUCTION_APP_URL || 'https://flutter.ombhrum.com' }}
     steps:
@@ -429,6 +448,7 @@ jobs:
       - production-smoke
     if: failure()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout failure notifier
         uses: actions/checkout@v4

--- a/fabushi/e2e/eula-storage-state.json
+++ b/fabushi/e2e/eula-storage-state.json
@@ -13,12 +13,28 @@
           "value": "\"1.0\""
         },
         {
+          "name": "flutter.is_first_launch_v2",
+          "value": "false"
+        },
+        {
+          "name": "flutter.model_setup_complete",
+          "value": "true"
+        },
+        {
           "name": "eula_accepted",
           "value": "true"
         },
         {
           "name": "eula_accepted_version",
           "value": "1.0"
+        },
+        {
+          "name": "is_first_launch_v2",
+          "value": "false"
+        },
+        {
+          "name": "model_setup_complete",
+          "value": "true"
         }
       ]
     }

--- a/fabushi/lib/widgets/app_wrapper.dart
+++ b/fabushi/lib/widgets/app_wrapper.dart
@@ -18,6 +18,10 @@ class AppWrapper extends StatefulWidget {
 }
 
 class _AppWrapperState extends State<AppWrapper> {
+  // 模型功能当前在产品内隐藏；启动时也不要再弹出模型选择引导。
+  // 后续重新开放模型功能时，将这里改为 true 即可恢复首启引导。
+  static bool get _modelSetupUiEnabled => false;
+
   bool _isInitialized = false;
   bool _initStarted = false;
   String? _initError;
@@ -57,9 +61,15 @@ class _AppWrapperState extends State<AppWrapper> {
       final needsEula = !await EulaService.isAccepted();
 
       // 5. 检查是否需要模型设置引导
-      final needsModelSetup =
-          await AppSettings.isFirstLaunch() &&
-          !await AppSettings.isModelSetupComplete();
+      final needsModelSetup = _modelSetupUiEnabled
+          ? await AppSettings.isFirstLaunch() &&
+                !await AppSettings.isModelSetupComplete()
+          : false;
+
+      if (!_modelSetupUiEnabled) {
+        await AppSettings.setFirstLaunchComplete();
+        await AppSettings.setModelSetupComplete(true);
+      }
 
       // If we are still mounted, update state to trigger rebuild to the main UI.
       if (mounted) {


### PR DESCRIPTION
## Summary
- Hide the startup model setup dialog while model features are disabled.
- Add `merge_group` support so the CI workflow can run under GitHub merge queue.
- Add explicit job timeouts to avoid hung CI/CD jobs blocking queues or deploys indefinitely.
- Serialize production deploys with a single `cd-production-main` concurrency group.
- Restrict automatic CD to successful `CI` workflow runs from `main` pushes; manual dispatch remains available.
- Add optional manual CD `source_sha` input for controlled redeploys or rollback validation.
- Add an explicit `automerge` label workflow that only merges same-repo, non-draft, green PRs and skips sensitive paths.
- Document the recommended branch protection, merge queue, automerge, and CD policy in `.github/BRANCH_PROTECTION.md`.

## Mature-team CI/CD model
- PR CI proves a change is mergeable.
- Merge queue/branch protection keeps `main` deployable.
- CD only deploys from `main` after staging E2E and native smoke gates.
- Automerge is explicit and label-gated, not global.
- Production deploys are serialized to avoid races.

## Testing
- Previous PR head CI passed before the CI/CD changes.
- The new workflow changes should be validated by PR CI on this updated head.