### PR TITLE
Fix staging profile login E2E in CD

### DIFF
--- a/fabushi/e2e/tests/profile-editing.spec.js
+++ b/fabushi/e2e/tests/profile-editing.spec.js
@@ -109,13 +109,41 @@ async function visibleTextSnapshot(page) {
 async function ensureLoginForm(page, testInfo) {
   await enableFlutterSemantics(page);
   const usernameField = page.getByPlaceholder('请输入用户名或邮箱').first();
-  if (await usernameField.isVisible({ timeout: 2500 }).catch(() => false)) return;
-  await maybeClick(page, '立即登录 / 注册');
-  if (await usernameField.isVisible({ timeout: 2500 }).catch(() => false)) return;
-  await tap(page, 0.5, 0.72);
-  if (await usernameField.isVisible({ timeout: 2500 }).catch(() => false)) return;
-  await tap(page, 0.5, 0.62);
-  if (await usernameField.isVisible({ timeout: 10000 }).catch(() => false)) return;
+  const visibleWithin = async (locator, timeout) => {
+    try {
+      await locator.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  };
+  const loginScreenMarkers = [
+    usernameField,
+    page.getByText('账号密码登录', { exact: true }).first(),
+    page.getByText('我已阅读并同意', { exact: true }).first(),
+    page.getByText('以游客身份继续', { exact: true }).first()
+  ];
+  const loginScreenReady = async (timeout = 2500) => {
+    for (const marker of loginScreenMarkers) {
+      if (await visibleWithin(marker, timeout)) return true;
+    }
+    return false;
+  };
+
+  if (await loginScreenReady()) return;
+
+  const openAttempts = [
+    () => maybeClick(page, '立即登录 / 注册'),
+    () => maybeClick(page, '立即登录'),
+    () => tap(page, 0.5, 0.72),
+    () => tap(page, 0.5, 0.62)
+  ];
+
+  for (const openLogin of openAttempts) {
+    await openLogin();
+    await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+    if (await loginScreenReady(3500)) return;
+  }
 
   const snapshot = await visibleTextSnapshot(page);
   await testInfo.attach('login-form-not-found-visible-text', {
@@ -136,6 +164,7 @@ async function fillByPlaceholderOrTap(page, placeholder, value, yRatio) {
   await tap(page, 0.5, yRatio);
   await page.keyboard.press('Control+A').catch(() => {});
   await page.keyboard.type(value, { delay: 10 });
+  await enableFlutterSemantics(page);
 }
 
 async function clickAgreementCandidates(page) {


### PR DESCRIPTION
## Summary
- make the staging profile E2E detect the login screen by stable visible markers, not only Flutter Web placeholder semantics
- add support for both `立即登录 / 注册` and `立即登录` entry points
- keep the test strict: it still logs in, edits profile, uploads avatar, and verifies stable identifiers

## Root cause
The failing CD job reached the profile guest screen and then the login route, but the test only treated the screen as ready when Playwright could see the `请输入用户名或邮箱` placeholder. In Flutter Web, `hintText` is not always exposed as an accessible placeholder even when the login screen is visibly loaded. The failure snapshot showed login-screen text such as `账号密码登录`, while the test still concluded the login form had not opened.

## Validation
- `node --check /tmp/profile-editing.spec.js`

Fixes #38