### PR TITLE
Fix CD staging E2E determinism

### DIFF
--- a/fabushi/e2e/playwright.config.js
+++ b/fabushi/e2e/playwright.config.js
@@ -7,9 +7,10 @@ const ciStorageState = process.env.CI && process.env.STAGING_APP_URL
 
 export default defineConfig({
   testDir: './tests',
-  timeout: 120000,
-  expect: { timeout: 15000 },
+  timeout: 180000,
+  expect: { timeout: 20000 },
   retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]] : 'list',
   use: {
     baseURL,

--- a/fabushi/e2e/tests/staging-profile-api.spec.js
+++ b/fabushi/e2e/tests/staging-profile-api.spec.js
@@ -18,14 +18,21 @@ function apiUrl(path) {
   return new URL(path, env('STAGING_APP_URL')).toString();
 }
 
+function safeProjectName(testInfo) {
+  return testInfo.project.name.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase();
+}
+
 test.describe('staging profile API flow', () => {
-  test('logs in with username, email, and phone, then updates profile fields without changing stable values', async ({ request }) => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('logs in with username, email, and phone, then updates profile fields without changing stable values', async ({ request }, testInfo) => {
     for (const name of requiredEnv) env(name);
 
     const login = env('STAGING_TEST_LOGIN');
     const password = env('STAGING_TEST_PASSWORD');
     const email = env('STAGING_TEST_EMAIL');
     const phone = env('STAGING_TEST_PHONE');
+    const projectMarker = `${safeProjectName(testInfo)}-${Date.now()}`;
 
     async function passwordLogin(identifier) {
       const response = await request.post(apiUrl('/api/auth/login'), {
@@ -42,7 +49,7 @@ test.describe('staging profile API flow', () => {
     const usernameLogin = await passwordLogin(login);
     expect(usernameLogin.user?.username).toBe(login);
 
-    const seedMarker = `ci-seed-${Date.now()}`;
+    const seedMarker = `ci-seed-${projectMarker}`;
     const seedProfile = await request.post(apiUrl('/api/auth/update-profile'), {
       headers: { Authorization: `Bearer ${usernameLogin.token}` },
       data: {
@@ -74,7 +81,7 @@ test.describe('staging profile API flow', () => {
     expect(before.phoneNumber).toBe(phone);
     expect(before.hasPassword).toBe(true);
 
-    const marker = `ci-${Date.now()}`;
+    const marker = `ci-${projectMarker}`;
     const update = await request.post(apiUrl('/api/auth/update-profile'), {
       headers: { Authorization: `Bearer ${seededToken}` },
       data: {


### PR DESCRIPTION
## Summary

- Serialize Playwright execution in CI to prevent shared staging test account races across browser projects.
- Increase staging E2E timeout/expect windows to better match Flutter web startup and mobile-browser timing in GitHub Actions.
- Make staging profile API avatar markers project-scoped so a failed assertion clearly belongs to the running project and is not clobbered by another project.

## Root cause

The latest CD failure happened in the staging E2E gate. The API E2E showed avatar marker clobbering between browser projects using the same staging user. The UI E2E then ran against an unstable shared profile state and intermittently got stuck around Flutter loading / guest profile login entry.

## Validation

- Ran `node --check` locally for the modified Playwright config and API spec.
- The production CD gate remains strict: staging API/UI E2E still runs before native install smoke and production deployment.

## Notes

A broader UI helper hardening pass was prepared locally, but the first safe unblock is to remove cross-project nondeterminism without weakening the deployment gate.