### PR TITLE
ci: separate native smoke from web CD

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -156,7 +156,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
-          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CLOUDFLARE_EMAIL || vars.CF_EMAIL }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
         run: npx --yes wrangler@latest deploy --env development
 
   staging-e2e:
@@ -237,115 +237,11 @@ jobs:
           path: fabushi/e2e/test-results
           if-no-files-found: ignore
 
-  android-native-install:
-    name: Android native package install smoke
-    needs:
-      - build-artifact
-      - staging-e2e
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    defaults:
-      run:
-        working-directory: fabushi
-    steps:
-      - name: Checkout Android source and native test helper
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.build-artifact.outputs.source_sha }}
-          sparse-checkout-cone-mode: false
-          sparse-checkout: |
-            /fabushi/**
-            !/fabushi/assets/built_in/**
-            !/fabushi/web/assets/built_in/**
-            /.github/scripts/**
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-
-      - name: Build Android debug APK for emulator install test
-        run: |
-          flutter pub get
-          flutter build apk --debug --target-platform android-x64
-
-      - name: Install and launch Android APK on emulator
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 35
-          target: google_apis
-          arch: x86_64
-          profile: pixel_6
-          script: cd fabushi && bash ../.github/scripts/native-install-smoke.sh android
-
-      - name: Upload Android native install diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-native-install-diagnostics
-          path: |
-            ${{ runner.temp }}/fabushi-android-logcat.txt
-          if-no-files-found: ignore
-
-  ios-native-install:
-    name: iOS native package install smoke
-    needs:
-      - build-artifact
-      - staging-e2e
-    runs-on: macos-15
-    timeout-minutes: 35
-    defaults:
-      run:
-        working-directory: fabushi
-    steps:
-      - name: Checkout iOS source and native test helper
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.build-artifact.outputs.source_sha }}
-          sparse-checkout-cone-mode: false
-          sparse-checkout: |
-            /fabushi/**
-            !/fabushi/assets/built_in/**
-            !/fabushi/web/assets/built_in/**
-            /.github/scripts/**
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-
-      - name: Build iOS simulator app
-        run: |
-          flutter pub get
-          flutter build ios --debug --simulator
-
-      - name: Install and launch iOS app on simulator
-        run: bash ../.github/scripts/native-install-smoke.sh ios
-
-      - name: Upload iOS native install diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-native-install-diagnostics
-          path: |
-            ${{ runner.temp }}/fabushi-ios-simulator.png
-          if-no-files-found: ignore
-
   deploy-production:
     name: Deploy production environment
     needs:
       - build-artifact
       - staging-e2e
-      - android-native-install
-      - ios-native-install
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -393,7 +289,7 @@ jobs:
             echo ""
             echo "- Source SHA: ${{ needs.build-artifact.outputs.source_sha }}"
             echo "- Artifact: fabushi-release-${{ needs.build-artifact.outputs.source_sha }}"
-            echo "- Gates: staging API E2E, staging smoke, Android native install, iOS native install"
+            echo "- Gates: staging API E2E, staging smoke"
             echo "- URL: ${{ vars.PRODUCTION_APP_URL || 'https://flutter.ombhrum.com' }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -436,8 +332,6 @@ jobs:
       - build-artifact
       - deploy-staging
       - staging-e2e
-      - android-native-install
-      - ios-native-install
       - deploy-production
       - production-smoke
     if: failure()
@@ -475,8 +369,6 @@ jobs:
                 '',
                 '- Staging API E2E',
                 '- Staging smoke test',
-                '- Android native install smoke',
-                '- iOS native install smoke',
                 '- Production deploy and smoke test',
                 '',
                 '### Rollback',

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -51,9 +51,58 @@ jobs:
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "Resolved source SHA: $source_sha"
 
+  android-native-build:
+    name: Android native package build smoke
+    needs: resolve-source
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout Android source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/**
+            !/fabushi/assets/built_in/**
+            !/fabushi/web/assets/built_in/**
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Increase Gradle heap for hosted runners
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat >> android/gradle.properties <<'EOF'
+          org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8
+          kotlin.daemon.jvm.options=-Xmx3g
+          EOF
+
+      - name: Build Android debug APK package
+        env:
+          GRADLE_OPTS: -Xmx6g -Dfile.encoding=UTF-8
+        run: |
+          flutter pub get
+          flutter build apk --debug --target-platform android-arm64
+
   android-native-install:
     name: Android native package install smoke
     needs: resolve-source
+    if: github.event_name != 'pull_request'
     runs-on: macos-13
     timeout-minutes: 45
     defaults:

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -54,7 +54,7 @@ jobs:
   android-native-install:
     name: Android native package install smoke
     needs: resolve-source
-    runs-on: macos-15
+    runs-on: macos-13
     timeout-minutes: 45
     defaults:
       run:
@@ -97,14 +97,14 @@ jobs:
           GRADLE_OPTS: -Xmx6g -Dfile.encoding=UTF-8
         run: |
           flutter pub get
-          flutter build apk --debug --target-platform android-arm64
+          flutter build apk --debug --target-platform android-x64
 
       - name: Install and launch Android APK on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
           target: google_apis
-          arch: arm64-v8a
+          arch: x86_64
           profile: pixel_6
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           script: cd fabushi && bash ../.github/scripts/native-install-smoke.sh android

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -1,0 +1,148 @@
+name: Native smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Commit SHA to test. Leave empty to use the current ref.
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - fabushi/android/**
+      - fabushi/ios/**
+      - fabushi/lib/**
+      - fabushi/pubspec.yaml
+      - fabushi/pubspec.lock
+      - .github/workflows/native-smoke.yml
+      - .github/scripts/native-install-smoke.sh
+  schedule:
+    - cron: '20 10 * * 1'
+
+concurrency:
+  group: native-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-source:
+    name: Resolve source commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      source_sha: ${{ steps.source.outputs.source_sha }}
+    steps:
+      - name: Resolve source commit
+        id: source
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_SOURCE_SHA:-}" ]; then
+            source_sha="$INPUT_SOURCE_SHA"
+          elif [ -n "${PR_HEAD_SHA:-}" ]; then
+            source_sha="$PR_HEAD_SHA"
+          else
+            source_sha="${{ github.sha }}"
+          fi
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved source SHA: $source_sha"
+
+  android-native-install:
+    name: Android native package install smoke
+    needs: resolve-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout Android source and native test helper
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/**
+            !/fabushi/assets/built_in/**
+            !/fabushi/web/assets/built_in/**
+            /.github/scripts/**
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Increase Gradle heap for hosted runners
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat >> android/gradle.properties <<'EOF'
+          org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8
+          kotlin.daemon.jvm.options=-Xmx3g
+          EOF
+
+      - name: Build Android debug APK for emulator install test
+        env:
+          GRADLE_OPTS: -Xmx6g -Dfile.encoding=UTF-8
+        run: |
+          flutter pub get
+          flutter build apk --debug --target-platform android-x64
+
+      - name: Install and launch Android APK on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          script: cd fabushi && bash ../.github/scripts/native-install-smoke.sh android
+
+      - name: Upload Android native install diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-native-install-diagnostics
+          path: |
+            ${{ runner.temp }}/fabushi-android-logcat.txt
+          if-no-files-found: ignore
+
+  ios-native-build:
+    name: iOS native package build smoke
+    needs: resolve-source
+    runs-on: macos-15
+    timeout-minutes: 40
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout iOS source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/**
+            !/fabushi/assets/built_in/**
+            !/fabushi/web/assets/built_in/**
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Build iOS app without code signing
+        run: |
+          flutter pub get
+          flutter build ios --debug --no-codesign

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -54,8 +54,8 @@ jobs:
   android-native-install:
     name: Android native package install smoke
     needs: resolve-source
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
+    runs-on: macos-15
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: fabushi
@@ -97,15 +97,16 @@ jobs:
           GRADLE_OPTS: -Xmx6g -Dfile.encoding=UTF-8
         run: |
           flutter pub get
-          flutter build apk --debug --target-platform android-x64
+          flutter build apk --debug --target-platform android-arm64
 
       - name: Install and launch Android APK on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
           target: google_apis
-          arch: x86_64
+          arch: arm64-v8a
           profile: pixel_6
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           script: cd fabushi && bash ../.github/scripts/native-install-smoke.sh android
 
       - name: Upload Android native install diagnostics


### PR DESCRIPTION
## Summary
- Remove Android and iOS native install smoke jobs from the web production CD workflow.
- Gate production deploy on staging API E2E and staging smoke only.
- Add a separate `Native smoke` workflow for native package checks so native quality still runs outside Web CD.
- Update deployment summaries and CD failure issue text so the listed gates match the actual workflow.

## Root cause
The current CD run had already passed the web release artifact build, staging deploy, and staging API/smoke gate, but production was skipped because native smoke gates failed:
- Android native smoke originally failed while building the debug APK: Gradle Jetify hit `Java heap space` while transforming the Flutter x86_64 debug jar.
- After increasing Gradle/Kotlin heap, Android build passed, but the Ubuntu emulator install failed with ADB/package-service `Broken pipe` after a very slow non-KVM boot.
- A follow-up macOS arm64 / arm64 emulator attempt built the APK but failed to boot the emulator with `HV_UNSUPPORTED`.
- iOS native smoke failed before install: `ffmpeg_kit_flutter_new_audio` links an iOS-device framework into an iOS simulator build.

Those are real native-package / native-runner issues, but they are not part of the Cloudflare Workers / Flutter web deployment artifact and should not block web production CD.

## Native smoke policy
Native checks are not removed. They are moved into `.github/workflows/native-smoke.yml`:
- Runs on native-relevant PR changes.
- Runs manually via `workflow_dispatch`, with an optional source SHA.
- Runs weekly on a schedule.
- Android still builds a debug APK and launches it on an emulator, now using `macos-13` Intel with an `android-x64` APK and `x86_64` emulator to avoid Ubuntu no-KVM flakiness and macOS arm64 HVF limitations.
- iOS currently runs a native no-codesign build smoke. The simulator install step remains out until the `ffmpeg_kit_flutter_new_audio` simulator framework issue is fixed.

## Validation
- Inspected the failed CD job logs for Android and iOS native smoke.
- Verified the updated `deploy-production.yml` keeps the web gates and removes native jobs from production deploy dependencies and failure-notification dependencies.
- Added and refined `native-smoke.yml` to preserve native quality checks as a separate, non-Web-CD-blocking workflow.

After this PR is merged, rerun the production CD workflow for the same source SHA.