### PR TITLE
cd: avoid mutating production worker routes

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -274,6 +274,32 @@ jobs:
           [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] && echo "Cloudflare account id configured: yes" || echo "Cloudflare account id configured: no"
           [ -n "${CLOUDFLARE_EMAIL:-}" ] && echo "Cloudflare email configured: yes" || echo "Cloudflare email configured: no"
 
+      - name: Disable production route mutation in CI
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path('wrangler.toml')
+          text = path.read_text()
+          old = '''[env.production]
+          name = "fabushi-flutter-web-prod"
+          routes = [
+            { pattern = "flutter.ombhrum.com/*", zone_name = "ombhrum.com" }
+          ]
+          workers_dev = false'''
+          new = '''[env.production]
+          name = "fabushi-flutter-web-prod"
+          # Route is pre-provisioned in Cloudflare; CI deploys code/assets only.
+          workers_dev = false'''
+          if old in text:
+              text = text.replace(old, new)
+              path.write_text(text)
+              print('Removed production route management from CI deploy artifact')
+          else:
+              print('Production route management block not found; leaving wrangler.toml unchanged')
+          PY
+
       - name: Deploy production Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}


### PR DESCRIPTION
## Summary
- Add a production CD step that removes route management from the downloaded release artifact before running `wrangler deploy --env production`.
- Keep the repository `wrangler.toml` source of truth unchanged while avoiding route mutation during CI deploys.
- Continue relying on the production smoke test against `https://flutter.ombhrum.com` to verify the pre-provisioned Cloudflare route still serves the deployed Worker.

## Root cause
The CI fix in #58 merged successfully, but the follow-up CD run failed in `Deploy production Worker`. Wrangler uploaded the Worker and assets, then attempted to update `/zones/.../workers/routes` for the custom domain route and Cloudflare returned authentication error `10000`.

The configured token is valid for deploying the Worker, but it does not have the Zone/Workers Routes permission needed to mutate routes. Route setup is an infrastructure concern and should not be required on every production deploy.

## Validation
- Inspected CD issue #59 and job `Deploy production environment` from run `25276895023`.
- Confirmed staging deploy, staging API E2E, and staging smoke succeeded.
- Confirmed production Worker upload succeeded before failing on the Cloudflare routes API call.
- This PR removes only production route mutation during CD; production smoke still validates the live domain route after deployment.