### PR TITLE
fix: force manual iOS signing in CI by overriding pbxproj

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -292,6 +292,12 @@ jobs:
           PROVISIONING_PROFILE_SPECIFIER=${profile_name}
           EOF
 
+          # Override pbxproj automatic signing for CI release builds
+          sed -i '' 's/CODE_SIGN_STYLE = Automatic;/CODE_SIGN_STYLE = Manual;/g' ios/Runner.xcodeproj/project.pbxproj
+          sed -i '' 's/CODE_SIGN_IDENTITY = "Apple Development";/CODE_SIGN_IDENTITY = "Apple Distribution";/g' ios/Runner.xcodeproj/project.pbxproj
+          sed -i '' 's/"CODE_SIGN_IDENTITY\[sdk=iphoneos\*\]" = "iPhone Developer";/"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";/g' ios/Runner.xcodeproj/project.pbxproj
+          sed -i '' "s/PROVISIONING_PROFILE_SPECIFIER = \"\";/PROVISIONING_PROFILE_SPECIFIER = \"${profile_name}\";/g" ios/Runner.xcodeproj/project.pbxproj
+
       - name: Build signed iOS IPA
         if: steps.ios-signing.outputs.configured == 'true'
         shell: bash


### PR DESCRIPTION
## Problem
`flutter build ipa` fails because `project.pbxproj` has `CODE_SIGN_STYLE = Automatic` and `CODE_SIGN_IDENTITY = Apple Development`, which overrides the xcconfig settings.

## Fix
Add `sed` commands after installing the signing identity to override pbxproj:
- `CODE_SIGN_STYLE = Automatic` → `Manual`
- `CODE_SIGN_IDENTITY = Apple Development` → `Apple Distribution`
- `CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Developer` → `Apple Distribution`
- `PROVISIONING_PROFILE_SPECIFIER` set to the profile name