### PR TITLE
fix: bump build number to 16, add Gradle fallback repos for CI

### DIFF
--- a/fabushi/android/build.gradle.kts
+++ b/fabushi/android/build.gradle.kts
@@ -4,6 +4,9 @@ buildscript {
         maven { url = uri("https://maven.aliyun.com/repository/central") }
         maven { url = uri("https://maven.aliyun.com/repository/public") }
         maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
+        // Fallback for CI when Aliyun mirrors are unreachable
+        google()
+        mavenCentral()
     }
 }
 
@@ -14,6 +17,9 @@ allprojects {
             maven { url = uri("https://maven.aliyun.com/repository/central") }
             maven { url = uri("https://maven.aliyun.com/repository/public") }
             maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
+            // Fallback for CI when Aliyun mirrors are unreachable
+            google()
+            mavenCentral()
         }
     }
 }

--- a/fabushi/android/settings.gradle.kts
+++ b/fabushi/android/settings.gradle.kts
@@ -25,7 +25,9 @@ pluginManagement {
         maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
         // 腾讯云镜像
         maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
-        // 官方仓库作为备选
+        // Fallback for CI when Chinese mirrors are unreachable
+        google()
+        mavenCentral()
         gradlePluginPortal()
     }
 }
@@ -38,6 +40,9 @@ dependencyResolutionManagement {
         maven { url = uri("https://maven.aliyun.com/repository/google") }
         maven { url = uri("https://maven.aliyun.com/repository/central") }
         maven { url = uri("https://maven.aliyun.com/repository/public") }
+        // Fallback for CI when Chinese mirrors are unreachable
+        google()
+        mavenCentral()
     }
 }
 

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: global_dharma_sharing
 description: 全球法布施 - 佛教经文全球传播应用
 publish_to: 'none'
-version: 1.0.0+15
+version: 1.0.0+16
 
 environment:
   sdk: '>=3.8.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Bump pubspec.yaml version from `1.0.0+15` to `1.0.0+16` to satisfy TestFlight upload requirement
- Add `google()` and `mavenCentral()` fallback repositories in `build.gradle.kts` and `settings.gradle.kts` for CI runners where Aliyun mirrors are unreachable

## Why
- TestFlight requires a higher bundle version than previously uploaded (15 → 16)
- Android builds fail on US-based GitHub runners because `maven.aliyun.com` returns 502

## Test plan
- [ ] Merge queue CI passes (flutter analyze + build)
- [ ] CD pipeline triggers on merge to main
- [ ] Publish workflow triggers after CD: iOS IPA builds+signed+uploads to TestFlight, Android APK/AAB builds successfully, GitHub Release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)