### PR TITLE
fix: use macos-26 runner for iOS build to meet iOS 26 SDK requirement

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -157,7 +157,7 @@ jobs:
   build-ios-package:
     name: Build signed iOS IPA
     needs: resolve-cd-context
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
     defaults:
       run:


### PR DESCRIPTION
## Summary
Upgrade iOS build job from `macos-15` to `macos-26` runner.

## Why
Apple now requires all iOS apps to be built with **iOS 26 SDK** (Xcode 26+). The `macos-15` runner has Xcode 16.4 (iOS 18.5 SDK), causing TestFlight upload to fail with:
```
SDK version issue. This app was built with the iOS 18.5 SDK.
All iOS and iPadOS apps must be built with the iOS 26 SDK or later
```

The `macos-26` runner includes **Xcode 26.2** (default) with iOS 26 SDK.

## Test plan
- [ ] CI passes
- [ ] CD pipeline triggers
- [ ] Publish workflow: iOS IPA builds, signs, and uploads to TestFlight successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)