### PR TITLE
fix: preserve core API error classification in auth flows

### DIFF
--- a/fabushi/lib/core/network/api_client.dart
+++ b/fabushi/lib/core/network/api_client.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
+
 import '../config/app_config.dart';
 import '../constants/api_constants.dart';
 import '../errors/exceptions.dart';
@@ -21,43 +24,103 @@ class ApiClient {
     if (_token != null) ApiConstants.headerAuthorization: 'Bearer $_token',
   };
 
-  Future<Map<String, dynamic>> get(String endpoint) async {
-    try {
+  Future<Map<String, dynamic>> get(String endpoint) {
+    return _sendRequest(() {
       final url = Uri.parse('${AppConfig.apiUrl}$endpoint');
-      final response = await _client
+      return _client
           .get(url, headers: _headers)
           .timeout(AppConfig.requestTimeout);
-      return _handleResponse(response);
-    } catch (e) {
-      throw NetworkException(e.toString());
-    }
+    });
   }
 
   Future<Map<String, dynamic>> post(
     String endpoint,
     Map<String, dynamic> body,
-  ) async {
-    try {
+  ) {
+    return _sendRequest(() {
       final url = Uri.parse('${AppConfig.apiUrl}$endpoint');
-      final response = await _client
+      return _client
           .post(url, headers: _headers, body: jsonEncode(body))
           .timeout(AppConfig.requestTimeout);
+    });
+  }
+
+  Future<Map<String, dynamic>> _sendRequest(
+    Future<http.Response> Function() request,
+  ) async {
+    try {
+      final response = await request();
       return _handleResponse(response);
+    } on AppException {
+      rethrow;
+    } on TimeoutException {
+      throw NetworkException('请求超时，请检查网络连接');
+    } on http.ClientException catch (e) {
+      throw NetworkException(e.message);
     } catch (e) {
       throw NetworkException(e.toString());
     }
   }
 
   Map<String, dynamic> _handleResponse(http.Response response) {
+    final parsedBody = _tryDecodeBody(response.body);
+
     if (response.statusCode >= 200 && response.statusCode < 300) {
-      return jsonDecode(response.body);
-    } else if (response.statusCode == 401) {
-      throw AuthException('认证失败');
-    } else if (response.statusCode >= 500) {
-      throw ServerException('服务器错误');
-    } else {
-      throw AppException('请求失败: ${response.statusCode}');
+      if (response.body.trim().isEmpty) {
+        return <String, dynamic>{};
+      }
+
+      if (parsedBody is Map<String, dynamic>) {
+        return parsedBody;
+      }
+
+      throw ServerException('响应格式错误');
     }
+
+    final message = _extractErrorMessage(parsedBody, response.statusCode);
+
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw AuthException(message);
+    }
+
+    if (response.statusCode == 400 || response.statusCode == 422) {
+      throw ValidationException(message);
+    }
+
+    if (response.statusCode >= 500) {
+      throw ServerException(message);
+    }
+
+    throw AppException(message);
+  }
+
+  dynamic _tryDecodeBody(String body) {
+    if (body.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      return jsonDecode(body);
+    } on FormatException {
+      return body;
+    }
+  }
+
+  String _extractErrorMessage(dynamic parsedBody, int statusCode) {
+    if (parsedBody is Map<String, dynamic>) {
+      for (final key in const ['message', 'error', 'detail']) {
+        final value = parsedBody[key];
+        if (value is String && value.trim().isNotEmpty) {
+          return value;
+        }
+      }
+    }
+
+    if (parsedBody is String && parsedBody.trim().isNotEmpty) {
+      return parsedBody;
+    }
+
+    return '请求失败: $statusCode';
   }
 
   void dispose() {

--- a/fabushi/test/unit/core/network/api_client_test.dart
+++ b/fabushi/test/unit/core/network/api_client_test.dart
@@ -1,22 +1,121 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:global_dharma_sharing/core/errors/exceptions.dart';
 import 'package:global_dharma_sharing/core/network/api_client.dart';
 
 void main() {
   group('ApiClient', () {
-    late ApiClient apiClient;
+    test('adds bearer token to outgoing requests', () async {
+      final apiClient = ApiClient(
+        client: MockClient((request) async {
+          expect(request.headers['Authorization'], 'Bearer test_token');
+          expect(request.headers['Content-Type'], 'application/json');
+          return http.Response('{}', 200);
+        }),
+      );
 
-    setUp(() {
-      apiClient = ApiClient();
+      apiClient.setToken('test_token');
+      await apiClient.get('/health');
     });
 
-    tearDown(() {
-      apiClient.dispose();
+    test('returns decoded json for successful responses', () async {
+      final apiClient = ApiClient(
+        client: MockClient(
+          (_) async => http.Response('{"user":{"username":"tester"}}', 200),
+        ),
+      );
+
+      final response = await apiClient.get('/api/auth/user-info');
+
+      expect(response['user']['username'], 'tester');
     });
 
-    test('should set token correctly', () {
-      const token = 'test_token';
-      apiClient.setToken(token);
-      expect(apiClient, isNotNull);
+    test('returns empty map for successful empty responses', () async {
+      final apiClient = ApiClient(
+        client: MockClient((_) async => http.Response('', 204)),
+      );
+
+      final response = await apiClient.post('/api/auth/logout', {});
+
+      expect(response, isEmpty);
+    });
+
+    test('preserves auth failures from the backend', () async {
+      final apiClient = ApiClient(
+        client: MockClient(
+          (_) async => http.Response('{"message":"登录已过期"}', 401),
+        ),
+      );
+
+      expect(
+        () => apiClient.get('/api/auth/user-info'),
+        throwsA(
+          isA<AuthException>().having(
+            (error) => error.message,
+            'message',
+            '登录已过期',
+          ),
+        ),
+      );
+    });
+
+    test('maps validation responses to ValidationException', () async {
+      final apiClient = ApiClient(
+        client: MockClient(
+          (_) async => http.Response('{"error":"验证码无效"}', 422),
+        ),
+      );
+
+      expect(
+        () => apiClient.post('/api/auth/register', {'code': 'bad'}),
+        throwsA(
+          isA<ValidationException>().having(
+            (error) => error.message,
+            'message',
+            '验证码无效',
+          ),
+        ),
+      );
+    });
+
+    test('maps server failures to ServerException', () async {
+      final apiClient = ApiClient(
+        client: MockClient(
+          (_) async => http.Response('{"message":"服务暂时不可用"}', 503),
+        ),
+      );
+
+      expect(
+        () => apiClient.get('/api/auth/user-info'),
+        throwsA(
+          isA<ServerException>().having(
+            (error) => error.message,
+            'message',
+            '服务暂时不可用',
+          ),
+        ),
+      );
+    });
+
+    test('maps transport failures to NetworkException', () async {
+      final apiClient = ApiClient(
+        client: MockClient(
+          (_) async => throw const http.ClientException('socket closed'),
+        ),
+      );
+
+      expect(
+        () => apiClient.get('/health'),
+        throwsA(
+          isA<NetworkException>().having(
+            (error) => error.message,
+            'message',
+            'socket closed',
+          ),
+        ),
+      );
     });
   });
 }

--- a/fabushi/test/unit/core/network/api_client_test.dart
+++ b/fabushi/test/unit/core/network/api_client_test.dart
@@ -1,9 +1,19 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
 import 'package:global_dharma_sharing/core/errors/exceptions.dart';
 import 'package:global_dharma_sharing/core/network/api_client.dart';
+
+http.Response jsonResponse(String body, int statusCode) {
+  return http.Response.bytes(
+    utf8.encode(body),
+    statusCode,
+    headers: {'content-type': 'application/json; charset=utf-8'},
+  );
+}
 
 void main() {
   group('ApiClient', () {
@@ -45,7 +55,7 @@ void main() {
     test('preserves auth failures from the backend', () async {
       final apiClient = ApiClient(
         client: MockClient(
-          (_) async => http.Response('{"message":"登录已过期"}', 401),
+          (_) async => jsonResponse('{"message":"登录已过期"}', 401),
         ),
       );
 
@@ -64,7 +74,7 @@ void main() {
     test('maps validation responses to ValidationException', () async {
       final apiClient = ApiClient(
         client: MockClient(
-          (_) async => http.Response('{"error":"验证码无效"}', 422),
+          (_) async => jsonResponse('{"error":"验证码无效"}', 422),
         ),
       );
 
@@ -83,7 +93,7 @@ void main() {
     test('maps server failures to ServerException', () async {
       final apiClient = ApiClient(
         client: MockClient(
-          (_) async => http.Response('{"message":"服务暂时不可用"}', 503),
+          (_) async => jsonResponse('{"message":"服务暂时不可用"}', 503),
         ),
       );
 
@@ -102,7 +112,7 @@ void main() {
     test('maps transport failures to NetworkException', () async {
       final apiClient = ApiClient(
         client: MockClient(
-          (_) async => throw const http.ClientException('socket closed'),
+          (_) async => throw http.ClientException('socket closed'),
         ),
       );
 


### PR DESCRIPTION
## Summary
- preserve backend auth, validation, and server exceptions in the core `ApiClient` instead of rethrowing them all as network failures
- handle empty successful responses explicitly and extract backend messages from common JSON error payload shapes
- replace the placeholder unit test with coverage for auth, validation, server, transport, empty-body, success, and auth-header cases

## Why
The highest-priority issue from the code review was in `fabushi/lib/core/network/api_client.dart`: `_handleResponse()` correctly produced `AuthException`, `ServerException`, and generic app errors, but `get()` / `post()` immediately caught those exceptions and wrapped them as `NetworkException`. That breaks core auth flows by surfacing the wrong root cause to repositories and UI state.

## Risk / Impact
- Scope is intentionally narrow: only the core API client used by the newer feature-layer auth code and its unit tests changed.
- Error semantics are now stricter and more correct, so any call sites that accidentally depended on the old incorrect `NetworkException` behavior may need follow-up adjustment.

## Validation
- Compared the branch against `main` to confirm only two files changed.
- Added unit coverage for the affected client behaviors.
- I could not run Flutter tests in this environment because the repository contents are not available as a local checkout here.

## Follow-up
- Audit and converge the legacy `lib/services/api_client.dart` transport layer so the repo no longer has two competing HTTP/error contracts.