### PR TITLE
fix: stop membership flows from treating API failures as successes

### DIFF
--- a/fabushi/lib/services/api_client.dart
+++ b/fabushi/lib/services/api_client.dart
@@ -1,27 +1,80 @@
+import 'dart:async';
 import 'dart:convert';
-import 'package:http/http.dart' as http;
+
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../core/config/app_config.dart';
 import 'app_settings.dart';
 import 'worker_config.dart';
 
+abstract class ApiRequester {
+  Future<Map<String, dynamic>> get(
+    String endpoint, {
+    Map<String, String>? headers,
+    Map<String, String>? queryParams,
+    String? token,
+  });
+
+  Future<Map<String, dynamic>> post(
+    String endpoint, {
+    Map<String, dynamic>? body,
+    Map<String, String>? headers,
+    String? token,
+  });
+
+  Future<Map<String, dynamic>> put(
+    String endpoint, {
+    Map<String, dynamic>? body,
+    Map<String, String>? headers,
+    String? token,
+  });
+
+  Future<Map<String, dynamic>> delete(
+    String endpoint, {
+    Map<String, dynamic>? body,
+    Map<String, String>? headers,
+    String? token,
+  });
+}
+
 /// 统一的 API 客户端
 /// 处理所有与 Cloudflare Worker 的 HTTP 通信
-class ApiClient {
+class ApiClient implements ApiRequester {
   static ApiClient? _instance;
   static ApiClient get instance => _instance ??= ApiClient._();
 
-  ApiClient._();
+  final http.Client _httpClient;
+  final Future<String> Function() _baseUrlResolver;
+  final Duration _timeout;
+
+  ApiClient._({
+    http.Client? httpClient,
+    Future<String> Function()? baseUrlResolver,
+    Duration? timeout,
+  }) : _httpClient = httpClient ?? http.Client(),
+       _baseUrlResolver = baseUrlResolver ?? AppSettings.getBackendUrl,
+       _timeout = timeout ?? AppConfig.requestTimeout;
 
   // 公共构造函数，用于直接实例化
-  factory ApiClient() => instance;
-
-  // 获取后端URL
-  Future<String> get baseUrl async {
-    // 优先使用统一配置，如果用户有自定义设置则使用自定义设置
-    return await AppSettings.getBackendUrl();
+  factory ApiClient({
+    http.Client? httpClient,
+    Future<String> Function()? baseUrlResolver,
+    Duration? timeout,
+  }) {
+    if (httpClient != null || baseUrlResolver != null || timeout != null) {
+      return ApiClient._(
+        httpClient: httpClient,
+        baseUrlResolver: baseUrlResolver,
+        timeout: timeout,
+      );
+    }
+    return instance;
   }
 
-  // 通用 GET 请求
+  Future<String> get baseUrl => _baseUrlResolver();
+
+  @override
   Future<Map<String, dynamic>> get(
     String endpoint, {
     Map<String, String>? headers,
@@ -29,43 +82,22 @@ class ApiClient {
     String? token,
   }) async {
     try {
-      final url = await baseUrl;
-      var uri = Uri.parse('$url$endpoint');
-
-      if (queryParams != null && queryParams.isNotEmpty) {
-        uri = uri.replace(queryParameters: queryParams);
-      }
-
-      final requestHeaders = <String, String>{
-        'Content-Type': 'application/json',
-        ...?headers,
-      };
-
-      if (token != null) {
-        requestHeaders['Authorization'] = 'Bearer $token';
-        debugPrint(
-          '🔐 ApiClient: 添加认证头 Authorization: Bearer ${token.substring(0, 20)}...',
-        );
-      } else {
-        debugPrint('⚠️ ApiClient: 没有token');
-      }
+      final uri = await _buildUri(endpoint, queryParams: queryParams);
+      final requestHeaders = _buildHeaders(headers: headers, token: token);
 
       debugPrint('🌐 GET: $uri');
 
-      final response = await http.get(uri, headers: requestHeaders);
+      final response = await _httpClient
+          .get(uri, headers: requestHeaders)
+          .timeout(_timeout);
 
       return _handleResponse(response);
     } catch (e) {
-      debugPrint('❌ GET 请求失败: $e');
-      return {
-        'success': false,
-        'error': WorkerConfig.getErrorMessage('NETWORK_ERROR'),
-        'details': e.toString(),
-      };
+      return _handleTransportError('GET', e);
     }
   }
 
-  // 通用 POST 请求
+  @override
   Future<Map<String, dynamic>> post(
     String endpoint, {
     Map<String, dynamic>? body,
@@ -73,46 +105,29 @@ class ApiClient {
     String? token,
   }) async {
     try {
-      final url = await baseUrl;
-      final uri = Uri.parse('$url$endpoint');
-
-      final requestHeaders = <String, String>{
-        'Content-Type': 'application/json',
-        ...?headers,
-      };
-
-      if (token != null) {
-        requestHeaders['Authorization'] = 'Bearer $token';
-        debugPrint(
-          '🔐 ApiClient: 添加认证头 Authorization: Bearer ${token.substring(0, 20)}...',
-        );
-      } else {
-        debugPrint('⚠️ ApiClient: 没有token');
-      }
+      final uri = await _buildUri(endpoint);
+      final requestHeaders = _buildHeaders(headers: headers, token: token);
 
       debugPrint('🌐 POST: $uri');
       if (body != null) {
         debugPrint('📤 Body: ${jsonEncode(body)}');
       }
 
-      final response = await http.post(
-        uri,
-        headers: requestHeaders,
-        body: body != null ? jsonEncode(body) : null,
-      );
+      final response = await _httpClient
+          .post(
+            uri,
+            headers: requestHeaders,
+            body: body != null ? jsonEncode(body) : null,
+          )
+          .timeout(_timeout);
 
       return _handleResponse(response);
     } catch (e) {
-      debugPrint('❌ POST 请求失败: $e');
-      return {
-        'success': false,
-        'error': WorkerConfig.getErrorMessage('NETWORK_ERROR'),
-        'details': e.toString(),
-      };
+      return _handleTransportError('POST', e);
     }
   }
 
-  // 通用 PUT 请求
+  @override
   Future<Map<String, dynamic>> put(
     String endpoint, {
     Map<String, dynamic>? body,
@@ -120,38 +135,26 @@ class ApiClient {
     String? token,
   }) async {
     try {
-      final url = await baseUrl;
-      final uri = Uri.parse('$url$endpoint');
-
-      final requestHeaders = <String, String>{
-        'Content-Type': 'application/json',
-        ...?headers,
-      };
-
-      if (token != null) {
-        requestHeaders['Authorization'] = 'Bearer $token';
-      }
+      final uri = await _buildUri(endpoint);
+      final requestHeaders = _buildHeaders(headers: headers, token: token);
 
       debugPrint('🌐 PUT: $uri');
 
-      final response = await http.put(
-        uri,
-        headers: requestHeaders,
-        body: body != null ? jsonEncode(body) : null,
-      );
+      final response = await _httpClient
+          .put(
+            uri,
+            headers: requestHeaders,
+            body: body != null ? jsonEncode(body) : null,
+          )
+          .timeout(_timeout);
 
       return _handleResponse(response);
     } catch (e) {
-      debugPrint('❌ PUT 请求失败: $e');
-      return {
-        'success': false,
-        'error': WorkerConfig.getErrorMessage('NETWORK_ERROR'),
-        'details': e.toString(),
-      };
+      return _handleTransportError('PUT', e);
     }
   }
 
-  // 通用 DELETE 请求
+  @override
   Future<Map<String, dynamic>> delete(
     String endpoint, {
     Map<String, dynamic>? body,
@@ -159,35 +162,76 @@ class ApiClient {
     String? token,
   }) async {
     try {
-      final url = await baseUrl;
-      final uri = Uri.parse('$url$endpoint');
-
-      final requestHeaders = <String, String>{
-        'Content-Type': 'application/json',
-        ...?headers,
-      };
-
-      if (token != null) {
-        requestHeaders['Authorization'] = 'Bearer $token';
-      }
+      final uri = await _buildUri(endpoint);
+      final requestHeaders = _buildHeaders(headers: headers, token: token);
 
       debugPrint('🌐 DELETE: $uri');
 
-      final response = await http.delete(
-        uri,
-        headers: requestHeaders,
-        body: body != null ? jsonEncode(body) : null,
-      );
+      final response = await _httpClient
+          .delete(
+            uri,
+            headers: requestHeaders,
+            body: body != null ? jsonEncode(body) : null,
+          )
+          .timeout(_timeout);
 
       return _handleResponse(response);
     } catch (e) {
-      debugPrint('❌ DELETE 请求失败: $e');
-      return {
-        'success': false,
-        'error': WorkerConfig.getErrorMessage('NETWORK_ERROR'),
-        'details': e.toString(),
-      };
+      return _handleTransportError('DELETE', e);
     }
+  }
+
+  Future<Uri> _buildUri(
+    String endpoint, {
+    Map<String, String>? queryParams,
+  }) async {
+    final url = await baseUrl;
+    var uri = Uri.parse('$url$endpoint');
+    if (queryParams != null && queryParams.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParams);
+    }
+    return uri;
+  }
+
+  Map<String, String> _buildHeaders({
+    Map<String, String>? headers,
+    String? token,
+  }) {
+    final requestHeaders = <String, String>{
+      'Content-Type': 'application/json',
+      ...?headers,
+    };
+
+    if (token != null && token.isNotEmpty) {
+      requestHeaders['Authorization'] = 'Bearer $token';
+      debugPrint(
+        '🔐 ApiClient: 添加认证头 Authorization: Bearer ${_safeTokenPreview(token)}',
+      );
+    } else {
+      debugPrint('⚠️ ApiClient: 没有token');
+    }
+
+    return requestHeaders;
+  }
+
+  String _safeTokenPreview(String token) {
+    final previewLength = token.length < 20 ? token.length : 20;
+    return '${token.substring(0, previewLength)}...';
+  }
+
+  Map<String, dynamic> _handleTransportError(String method, Object error) {
+    debugPrint('❌ $method 请求失败: $error');
+
+    final details = error is TimeoutException
+        ? 'Request timed out after ${_timeout.inSeconds} seconds'
+        : error.toString();
+
+    return {
+      'success': false,
+      'error': WorkerConfig.getErrorMessage('NETWORK_ERROR'),
+      'errorKey': 'NETWORK_ERROR',
+      'details': details,
+    };
   }
 
   // 处理响应
@@ -195,59 +239,85 @@ class ApiClient {
     debugPrint('📥 Response: ${response.statusCode} ${response.reasonPhrase}');
     debugPrint('📄 原始响应体: ${response.body}');
 
-    // 如果是 401 错误，打印请求头信息帮助调试
     if (response.statusCode == 401) {
       debugPrint('❌ 401 认证失败 - 请求头: ${response.request?.headers}');
     }
 
-    try {
-      final data = jsonDecode(response.body);
-      debugPrint('📊 解析后数据: $data');
+    final data = _decodeResponseBody(response.body);
+    debugPrint('📊 解析后数据: $data');
 
-      if (response.statusCode >= 200 && response.statusCode < 300) {
-        // 确保数据不为空
-        if (data == null) {
-          return {
-            'success': false,
-            'statusCode': response.statusCode,
-            'error': '服务器返回空数据',
-            'details': response.body,
-          };
-        }
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (data == null) {
+        return {'success': true, 'statusCode': response.statusCode};
+      }
 
-        // 如果数据是 Map，返回原数据；否则包装在 data 字段中
-        if (data is Map<String, dynamic>) {
-          return data;
-        } else {
-          return {
-            'success': true,
-            'statusCode': response.statusCode,
-            'data': data,
-          };
-        }
-      } else {
+      if (data is Map<String, dynamic>) {
         return {
-          'success': false,
-          'statusCode': response.statusCode,
-          'error': data is Map
-              ? (data['error'] ?? data['message'] ?? '请求失败')
-              : '请求失败',
-          'details': data,
+          ...data,
+          if (!data.containsKey('statusCode')) 'statusCode': response.statusCode,
         };
       }
-    } catch (e) {
-      debugPrint('❌ 解析响应失败: $e');
-      debugPrint('📄 原始响应: ${response.body}');
 
       return {
-        'success': false,
+        'success': true,
         'statusCode': response.statusCode,
-        'error': response.statusCode >= 500
-            ? WorkerConfig.getErrorMessage('SERVER_ERROR')
-            : '响应格式错误',
-        'details': response.body,
+        'data': data,
       };
     }
+
+    final error = _extractErrorMessage(data);
+    return {
+      'success': false,
+      'statusCode': response.statusCode,
+      'error': error,
+      'errorKey': _mapErrorKey(response.statusCode),
+      'details': data ?? response.body,
+    };
+  }
+
+  dynamic _decodeResponseBody(String body) {
+    if (body.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      return jsonDecode(body);
+    } catch (e) {
+      debugPrint('❌ 解析响应失败: $e');
+      debugPrint('📄 原始响应: $body');
+      return body;
+    }
+  }
+
+  String _extractErrorMessage(dynamic data) {
+    if (data is Map) {
+      final message = data['message'] ?? data['error'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+    }
+
+    if (data is String && data.isNotEmpty) {
+      return data;
+    }
+
+    return '请求失败';
+  }
+
+  String _mapErrorKey(int statusCode) {
+    if (statusCode == 401) {
+      return 'INVALID_TOKEN';
+    }
+    if (statusCode == 403) {
+      return 'UNAUTHORIZED';
+    }
+    if (statusCode == 400 || statusCode == 422) {
+      return 'VALIDATION_ERROR';
+    }
+    if (statusCode >= 500) {
+      return 'SERVER_ERROR';
+    }
+    return 'UNKNOWN_ERROR';
   }
 
   // 认证相关快捷方法

--- a/fabushi/lib/services/membership_service.dart
+++ b/fabushi/lib/services/membership_service.dart
@@ -1,36 +1,24 @@
-import 'dart:convert';
-import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart';
 
 import '../core/config/app_config.dart';
-import 'app_settings.dart';
 import 'api_client.dart';
-import 'worker_config.dart';
 
 class MembershipService {
-  // API 客户端实例
-  late final ApiClient _apiClient;
+  final ApiRequester _apiClient;
 
-  MembershipService() {
-    _apiClient = ApiClient();
-  }
-
-  // 获取后端URL
-  Future<String> get baseUrl async {
-    return await AppSettings.getBackendUrl();
-  }
+  MembershipService({ApiRequester? apiClient})
+    : _apiClient = apiClient ?? ApiClient();
 
   Future<Map<String, dynamic>> getMembershipStatus(String token) async {
     try {
-      // 使用 /api/stripe/membership-status 端点
       final endpoint = Uri.parse(AppConfig.stripeMembershipStatusUrl).path;
       final response = await _apiClient.get(endpoint, token: token);
 
-      if (response != null) {
-        return {'success': true, 'membership': response};
-      } else {
-        return {'success': false, 'message': '获取会员状态失败'};
+      if (_isSuccess(response) && response['membership'] != null) {
+        return {'success': true, 'membership': response['membership']};
       }
+
+      return _failureResponse(response, '获取会员状态失败');
     } catch (e) {
       debugPrint('获取会员状态失败: $e');
       return {'success': false, 'message': '网络连接失败'};
@@ -45,21 +33,19 @@ class MembershipService {
       final endpoint = Uri.parse(AppConfig.stripeCreateSubscriptionUrl).path;
       final response = await _apiClient.post(
         endpoint,
-        body: {
-          'priceType': priceType, // monthly, quarterly, yearly
-        },
+        body: {'priceType': priceType},
         token: token,
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'paymentUrl': response['paymentUrl'],
           'sessionId': response['sessionId'],
         };
-      } else {
-        return {'success': false, 'message': response['message'] ?? '创建支付会话失败'};
       }
+
+      return _failureResponse(response, '创建支付会话失败');
     } catch (e) {
       debugPrint('创建支付会话失败: $e');
       return {'success': false, 'message': '网络连接失败'};
@@ -74,13 +60,11 @@ class MembershipService {
       final endpoint = Uri.parse(AppConfig.alipayCreateOrderUrl).path;
       final response = await _apiClient.post(
         endpoint,
-        body: {
-          'plan': plan, // monthly, quarterly, yearly
-        },
+        body: {'plan': plan},
         token: token,
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'qrCode': response['qrCode'],
@@ -89,35 +73,27 @@ class MembershipService {
           'plan': response['plan'],
           'orderString': response['orderString'],
         };
-      } else {
-        return {
-          'success': false,
-          'message': response['message'] ?? '创建支付宝订单失败',
-        };
       }
+
+      return _failureResponse(response, '创建支付宝订单失败');
     } catch (e) {
       debugPrint('创建支付宝订单失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  /// 创建支付宝Web端订单（电脑网站支付）
   Future<Map<String, dynamic>> createAlipayWebOrder(
     String token,
     String plan,
   ) async {
     try {
-      final endpoint = '/api/alipay/create-order';
       final response = await _apiClient.post(
-        endpoint,
-        body: {
-          'plan': plan,
-          'platform': 'web', // 标识为Web端支付
-        },
+        '/api/alipay/create-order',
+        body: {'plan': plan, 'platform': 'web'},
         token: token,
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'paymentUrl': response['paymentUrl'],
@@ -125,39 +101,37 @@ class MembershipService {
           'amount': response['amount'],
           'plan': response['plan'],
         };
-      } else {
-        return {
-          'success': false,
-          'message': response['message'] ?? '创建支付宝Web订单失败',
-        };
       }
+
+      return _failureResponse(response, '创建支付宝Web订单失败');
     } catch (e) {
       debugPrint('创建支付宝Web订单失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  /// 查询支付宝订单状态
   Future<Map<String, dynamic>> queryAlipayOrderStatus(
     String token,
     String orderId,
   ) async {
     try {
-      final endpoint = '/api/alipay/query-order?orderId=$orderId';
-      final response = await _apiClient.get(endpoint, token: token);
+      final response = await _apiClient.get(
+        Uri.parse(AppConfig.alipayQueryOrderUrl).path,
+        token: token,
+        queryParams: {'orderId': orderId},
+      );
 
-      if (response != null) {
+      if (_isSuccess(response)) {
         return response;
-      } else {
-        return {'success': false, 'message': '查询订单状态失败'};
       }
+
+      return _failureResponse(response, '查询订单状态失败');
     } catch (e) {
       debugPrint('查询支付宝订单状态失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  /// 查询Stripe会话状态
   Future<Map<String, dynamic>> queryStripeSessionStatus(
     String token,
     String sessionId,
@@ -170,11 +144,11 @@ class MembershipService {
         queryParams: {'sessionId': sessionId},
       );
 
-      if (response != null) {
+      if (_isSuccess(response)) {
         return response;
-      } else {
-        return {'success': false, 'message': '查询Stripe会话状态失败'};
       }
+
+      return _failureResponse(response, '查询Stripe会话状态失败');
     } catch (e) {
       debugPrint('查询Stripe会话状态失败: $e');
       return {'success': false, 'message': '网络连接失败'};
@@ -190,7 +164,7 @@ class MembershipService {
         token: token,
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'message': response['message'] ?? '兑换成功',
@@ -198,9 +172,9 @@ class MembershipService {
           'expiresAt': response['expiresAt'],
           'daysAdded': response['daysAdded'],
         };
-      } else {
-        return {'success': false, 'message': response['message'] ?? '兑换失败'};
       }
+
+      return _failureResponse(response, '兑换失败');
     } catch (e) {
       debugPrint('兑换码请求失败: $e');
       return {'success': false, 'message': '网络连接失败'};
@@ -218,23 +192,23 @@ class MembershipService {
       final response = await _apiClient.post(
         endpoint,
         body: {
-          'type': codeType, // trial_7, monthly, quarterly, yearly
+          'type': codeType,
           'quantity': quantity,
           'description': description,
         },
         token: token,
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'codes': response['codes'],
           'type': response['type'],
           'message': response['message'],
         };
-      } else {
-        return {'success': false, 'message': response['message'] ?? '生成兑换码失败'};
       }
+
+      return _failureResponse(response, '生成兑换码失败');
     } catch (e) {
       debugPrint('生成兑换码失败: $e');
       return {'success': false, 'message': '网络连接失败'};
@@ -246,26 +220,22 @@ class MembershipService {
       final endpoint = Uri.parse(AppConfig.adminCheckStatusUrl).path;
       final response = await _apiClient.get(endpoint, token: token);
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'isAdmin': response['isAdmin'],
           'email': response['email'],
           'username': response['username'],
         };
-      } else {
-        return {
-          'success': false,
-          'message': response['message'] ?? '获取管理员状态失败',
-        };
       }
+
+      return _failureResponse(response, '获取管理员状态失败');
     } catch (e) {
       debugPrint('获取管理员状态失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  // 获取兑换码列表
   Future<Map<String, dynamic>> getRedeemCodes(
     String token, {
     int page = 1,
@@ -288,7 +258,7 @@ class MembershipService {
         queryParams: queryParams,
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'codes': response['codes'],
@@ -296,19 +266,15 @@ class MembershipService {
           'page': response['page'],
           'totalPages': response['totalPages'],
         };
-      } else {
-        return {
-          'success': false,
-          'message': response['message'] ?? '获取兑换码列表失败',
-        };
       }
+
+      return _failureResponse(response, '获取兑换码列表失败');
     } catch (e) {
       debugPrint('获取兑换码列表失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  /// Apple App Store Server API v2 收据验证
   Future<Map<String, dynamic>> verifyAppleReceipt(
     String token,
     String transactionId,
@@ -322,7 +288,7 @@ class MembershipService {
         token: token,
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {
           'success': true,
           'message': response['message'] ?? '会员激活成功',
@@ -330,16 +296,15 @@ class MembershipService {
           'expiresAt': response['expiresAt'],
           'alreadyProcessed': response['alreadyProcessed'] == true,
         };
-      } else {
-        return {'success': false, 'message': response['message'] ?? '收据验证失败'};
       }
+
+      return _failureResponse(response, '收据验证失败');
     } catch (e) {
       debugPrint('Apple IAP 收据验证失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  // 查询支付宝订单状态（无token版本）
   Future<Map<String, dynamic>> queryAlipayOrderPublic(String orderId) async {
     try {
       final endpoint = Uri.parse(AppConfig.alipayQueryOrderUrl).path;
@@ -348,52 +313,72 @@ class MembershipService {
         queryParams: {'orderId': orderId},
       );
 
-      if (response['success'] == true) {
+      if (_isSuccess(response)) {
         return {'success': true, 'order': response};
-      } else {
-        return {'success': false, 'message': response['message'] ?? '查询订单失败'};
       }
+
+      return _failureResponse(response, '查询订单失败');
     } catch (e) {
       debugPrint('查询支付宝订单失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  // 获取购买记录
   Future<Map<String, dynamic>> getPurchaseHistory(String token) async {
     try {
       final endpoint = Uri.parse(AppConfig.adminPurchaseHistoryUrl).path;
       final response = await _apiClient.get(endpoint, token: token);
 
-      if (response != null && response['purchases'] != null) {
+      if (_isSuccess(response) && response['purchases'] != null) {
         return {'success': true, 'purchases': response['purchases']};
-      } else {
-        return {'success': false, 'message': '获取购买记录失败'};
       }
+
+      return _failureResponse(response, '获取购买记录失败');
     } catch (e) {
       debugPrint('获取购买记录失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  // 获取兑换记录
   Future<Map<String, dynamic>> getRedeemHistory(String token) async {
     try {
       final endpoint = Uri.parse(AppConfig.adminRedeemHistoryUrl).path;
       final response = await _apiClient.get(endpoint, token: token);
 
-      if (response != null && response['redeems'] != null) {
+      if (_isSuccess(response) && response['redeems'] != null) {
         return {'success': true, 'redeems': response['redeems']};
-      } else {
-        return {'success': false, 'message': '获取兑换记录失败'};
       }
+
+      return _failureResponse(response, '获取兑换记录失败');
     } catch (e) {
       debugPrint('获取兑换记录失败: $e');
       return {'success': false, 'message': '网络连接失败'};
     }
   }
 
-  // 获取会员价格信息
+  bool _isSuccess(Map<String, dynamic> response) => response['success'] == true;
+
+  Map<String, dynamic> _failureResponse(
+    Map<String, dynamic> response,
+    String fallbackMessage,
+  ) {
+    return {
+      'success': false,
+      'message': _extractMessage(response, fallbackMessage),
+      if (response['statusCode'] != null) 'statusCode': response['statusCode'],
+      if (response['errorKey'] != null) 'errorKey': response['errorKey'],
+      if (response['details'] != null) 'details': response['details'],
+    };
+  }
+
+  String _extractMessage(
+    Map<String, dynamic> response,
+    String fallbackMessage,
+  ) {
+    final message = response['message'] ?? response['error'];
+    return message is String && message.isNotEmpty ? message : fallbackMessage;
+  }
+
   Map<String, Map<String, dynamic>> getMembershipPrices() {
     return {
       'monthly': {
@@ -417,7 +402,6 @@ class MembershipService {
     };
   }
 
-  // 获取试用会员信息
   Map<String, dynamic> getTrialMembership() {
     return {
       'name': '7天试用',

--- a/fabushi/test/unit/services/api_client_test.dart
+++ b/fabushi/test/unit/services/api_client_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:global_dharma_sharing/services/api_client.dart';
+
+void main() {
+  group('legacy services ApiClient', () {
+    test('keeps backend message and error key for auth failures', () async {
+      final apiClient = ApiClient(
+        httpClient: MockClient(
+          (_) async => http.Response('{"message":"登录已过期"}', 401),
+        ),
+        baseUrlResolver: () async => 'https://example.com',
+      );
+
+      final response = await apiClient.get('/api/auth/user-info', token: 'token');
+
+      expect(response['success'], false);
+      expect(response['error'], '登录已过期');
+      expect(response['errorKey'], 'INVALID_TOKEN');
+      expect(response['statusCode'], 401);
+    });
+
+    test('returns success for empty successful responses', () async {
+      final apiClient = ApiClient(
+        httpClient: MockClient((_) async => http.Response('', 204)),
+        baseUrlResolver: () async => 'https://example.com',
+      );
+
+      final response = await apiClient.post('/api/auth/logout');
+
+      expect(response['success'], true);
+      expect(response['statusCode'], 204);
+    });
+
+    test('does not crash when token preview is shorter than 20 chars', () async {
+      final apiClient = ApiClient(
+        httpClient: MockClient((request) async {
+          expect(request.headers['Authorization'], 'Bearer short');
+          return http.Response('{"success":true}', 200);
+        }),
+        baseUrlResolver: () async => 'https://example.com',
+      );
+
+      final response = await apiClient.get('/health', token: 'short');
+
+      expect(response['success'], true);
+    });
+
+    test('maps transport failures to network error payloads', () async {
+      final apiClient = ApiClient(
+        httpClient: MockClient(
+          (_) async => throw const http.ClientException('socket closed'),
+        ),
+        baseUrlResolver: () async => 'https://example.com',
+      );
+
+      final response = await apiClient.get('/health');
+
+      expect(response['success'], false);
+      expect(response['errorKey'], 'NETWORK_ERROR');
+      expect(response['error'], isNotEmpty);
+    });
+  });
+}

--- a/fabushi/test/unit/services/api_client_test.dart
+++ b/fabushi/test/unit/services/api_client_test.dart
@@ -1,15 +1,25 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
 import 'package:global_dharma_sharing/services/api_client.dart';
 
+http.Response jsonResponse(String body, int statusCode) {
+  return http.Response.bytes(
+    utf8.encode(body),
+    statusCode,
+    headers: {'content-type': 'application/json; charset=utf-8'},
+  );
+}
+
 void main() {
   group('legacy services ApiClient', () {
     test('keeps backend message and error key for auth failures', () async {
       final apiClient = ApiClient(
         httpClient: MockClient(
-          (_) async => http.Response('{"message":"登录已过期"}', 401),
+          (_) async => jsonResponse('{"message":"登录已过期"}', 401),
         ),
         baseUrlResolver: () async => 'https://example.com',
       );
@@ -51,7 +61,7 @@ void main() {
     test('maps transport failures to network error payloads', () async {
       final apiClient = ApiClient(
         httpClient: MockClient(
-          (_) async => throw const http.ClientException('socket closed'),
+          (_) async => throw http.ClientException('socket closed'),
         ),
         baseUrlResolver: () async => 'https://example.com',
       );

--- a/fabushi/test/unit/services/membership_service_test.dart
+++ b/fabushi/test/unit/services/membership_service_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:global_dharma_sharing/services/api_client.dart';
+import 'package:global_dharma_sharing/services/membership_service.dart';
+
+class FakeApiRequester implements ApiRequester {
+  FakeApiRequester({this.getResponse, this.postResponse});
+
+  final Map<String, dynamic>? getResponse;
+  final Map<String, dynamic>? postResponse;
+
+  @override
+  Future<Map<String, dynamic>> get(
+    String endpoint, {
+    Map<String, String>? headers,
+    Map<String, String>? queryParams,
+    String? token,
+  }) async {
+    return getResponse ?? <String, dynamic>{};
+  }
+
+  @override
+  Future<Map<String, dynamic>> post(
+    String endpoint, {
+    Map<String, dynamic>? body,
+    Map<String, String>? headers,
+    String? token,
+  }) async {
+    return postResponse ?? <String, dynamic>{};
+  }
+
+  @override
+  Future<Map<String, dynamic>> put(
+    String endpoint, {
+    Map<String, dynamic>? body,
+    Map<String, String>? headers,
+    String? token,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, dynamic>> delete(
+    String endpoint, {
+    Map<String, dynamic>? body,
+    Map<String, String>? headers,
+    String? token,
+  }) async {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  group('MembershipService', () {
+    test('does not treat failed membership lookup as success', () async {
+      final service = MembershipService(
+        apiClient: FakeApiRequester(
+          getResponse: {
+            'success': false,
+            'error': '登录已过期',
+            'statusCode': 401,
+            'errorKey': 'INVALID_TOKEN',
+          },
+        ),
+      );
+
+      final response = await service.getMembershipStatus('token');
+
+      expect(response['success'], false);
+      expect(response['message'], '登录已过期');
+      expect(response['statusCode'], 401);
+      expect(response['errorKey'], 'INVALID_TOKEN');
+    });
+
+    test('unwraps membership payload on success', () async {
+      final service = MembershipService(
+        apiClient: FakeApiRequester(
+          getResponse: {
+            'success': true,
+            'membership': {'type': 'premium', 'isActive': true},
+          },
+        ),
+      );
+
+      final response = await service.getMembershipStatus('token');
+
+      expect(response['success'], true);
+      expect(response['membership']['type'], 'premium');
+    });
+
+    test('preserves backend failure message when creating payment session', () async {
+      final service = MembershipService(
+        apiClient: FakeApiRequester(
+          postResponse: {
+            'success': false,
+            'error': '当前套餐不可购买',
+            'statusCode': 422,
+            'errorKey': 'VALIDATION_ERROR',
+          },
+        ),
+      );
+
+      final response = await service.createPaymentSession('token', 'yearly');
+
+      expect(response['success'], false);
+      expect(response['message'], '当前套餐不可购买');
+      expect(response['statusCode'], 422);
+      expect(response['errorKey'], 'VALIDATION_ERROR');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- normalize the legacy `lib/services/api_client.dart` response contract so auth, validation, server, transport, and empty-success cases are reported consistently
- make the legacy client injectable for tests and introduce an `ApiRequester` contract for service-layer consumers
- fix `MembershipService` methods that previously treated failed API responses as successes, especially membership lookup and history/payment helper flows
- add focused unit coverage for the legacy API client and membership service failure mapping

## Why
The previous review fixed the newer core API client used by feature-layer auth code. The next highest-value gap was the older service-layer transport still used by membership/payment flows. It had two concrete problems:
- the legacy client returned inconsistent payload shapes and could crash while logging short tokens
- `MembershipService` used checks like `response != null`, which meant backend failures could be surfaced as successful results

That combination makes payment and membership flows harder to debug and can hide the real reason a request failed.

## Risk / Impact
- Scope is limited to the legacy membership/payment transport path and its tests.
- Public service return shape remains map-based, so callers do not need a large refactor.
- Failure payloads now preserve more backend context (`statusCode`, `errorKey`, backend message), which may change exact UI text in some failure cases.

## Validation
- Confirmed branch diff is limited to `lib/services/api_client.dart`, `lib/services/membership_service.dart`, and two new unit test files.
- Added regression coverage for auth failure mapping, empty success responses, short-token logging safety, network failures, membership lookup failure handling, and payment-session failure handling.
- I could not run Flutter tests in this environment because the repository is not available as a local checkout here.

## Follow-up
- Audit the remaining legacy auth/service consumers and gradually converge them on one shared transport layer with the same semantics as `lib/core/network/api_client.dart`. 