### PR TITLE
fix: make production route stripping robust in CD workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -280,24 +280,34 @@ jobs:
           set -euo pipefail
           python3 - <<'PY'
           from pathlib import Path
+          import re
+
           path = Path('wrangler.toml')
           text = path.read_text()
-          old = '''[env.production]
-          name = "fabushi-flutter-web-prod"
-          routes = [
-            { pattern = "flutter.ombhrum.com/*", zone_name = "ombhrum.com" }
-          ]
-          workers_dev = false'''
-          new = '''[env.production]
-          name = "fabushi-flutter-web-prod"
-          # Route is pre-provisioned in Cloudflare; CI deploys code/assets only.
-          workers_dev = false'''
-          if old in text:
-              text = text.replace(old, new)
-              path.write_text(text)
+          pattern = re.compile(
+              r'(?ms)^(\[env\.production\]\nname = "fabushi-flutter-web-prod"\n)(?:routes = \[\n(?:  .*\n)+?\]\n)?(workers_dev = false\n)'
+          )
+          replacement = (
+              '[env.production]\n'
+              'name = "fabushi-flutter-web-prod"\n'
+              '# Route is pre-provisioned in Cloudflare; CI deploys code/assets only.\n'
+              'workers_dev = false\n'
+          )
+          new_text, count = pattern.subn(replacement, text, count=1)
+          if count == 0:
+              raise SystemExit('Could not locate [env.production] block in wrangler.toml')
+
+          production_section = new_text.split('[env.production]\n', 1)[1].split('\n[[env.production.', 1)[0]
+          if 'routes =' in production_section:
+              raise SystemExit('Production routes still present after patch')
+
+          if new_text != text:
+              path.write_text(new_text)
               print('Removed production route management from CI deploy artifact')
           else:
-              print('Production route management block not found; leaving wrangler.toml unchanged')
+              print('Production route management already absent')
+
+          print('Verified production deploy artifact no longer mutates routes')
           PY
 
       - name: Deploy production Worker


### PR DESCRIPTION
## Summary
- replace the brittle exact-string patch in `deploy-production.yml` with a regex-based rewrite of the `[env.production]` block in `wrangler.toml`
- verify after rewriting that the production section no longer contains `routes =`, so CI fails early with a clear message if route mutation is still present

## Why
Issue #59 showed that the workflow intended to disable production route mutation before `wrangler deploy --env production`, but the current patch logic depends on one exact formatting shape. The checked-in `fabushi/web/wrangler.toml` does not match that shape, so the route block survives and Wrangler still calls the Cloudflare routes API.

## Risk
- Scope is limited to the production CD workflow patch step.
- No application code or runtime behavior changes.
- If the production section layout changes again in a way this regex cannot recognize, the workflow now fails with an explicit message instead of silently leaving route mutation enabled.

## Validation
- Confirmed the current workflow step uses an exact multi-line string that does not match the current `wrangler.toml` formatting.
- Updated the step to rewrite the `[env.production]` header/body more robustly and added a post-patch assertion that `routes =` is gone from the production section.
- I could not execute the GitHub Actions workflow from this environment, so the PR relies on workflow CI for final verification.

## Follow-up
- After this PR merges, rerun the production CD workflow that failed in issue #59 to confirm deploys no longer attempt route mutation.