### PR TITLE
fix: harden social service response parsing

### DIFF
--- a/fabushi/lib/services/social_service.dart
+++ b/fabushi/lib/services/social_service.dart
@@ -1,39 +1,138 @@
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
+
 import '../core/config/app_config.dart';
 import 'http_service.dart';
+
+abstract class SocialHttpClient {
+  Future<http.Response> get(
+    String url, {
+    Map<String, String>? queryParams,
+    bool useAuth = false,
+  });
+
+  Future<http.Response> post(
+    String url, {
+    Map<String, dynamic>? body,
+    bool useAuth = false,
+  });
+}
+
+class DefaultSocialHttpClient implements SocialHttpClient {
+  @override
+  Future<http.Response> get(
+    String url, {
+    Map<String, String>? queryParams,
+    bool useAuth = false,
+  }) {
+    return HttpService.get(
+      url,
+      queryParams: queryParams,
+      useAuth: useAuth,
+    );
+  }
+
+  @override
+  Future<http.Response> post(
+    String url, {
+    Map<String, dynamic>? body,
+    bool useAuth = false,
+  }) {
+    return HttpService.post(url, body: body, useAuth: useAuth);
+  }
+}
 
 class SocialService {
   static final SocialService _instance = SocialService._internal();
   factory SocialService() => _instance;
-  SocialService._internal();
+
+  SocialService._internal() : _httpClient = DefaultSocialHttpClient();
+
+  SocialService.withClient(SocialHttpClient httpClient)
+    : _httpClient = httpClient;
+
+  final SocialHttpClient _httpClient;
 
   String get _baseUrl => '${AppConfig.currentBackendUrl}/api/social';
 
+  bool _isSuccessStatus(http.Response response) {
+    return response.statusCode >= 200 && response.statusCode < 300;
+  }
+
+  Map<String, dynamic>? _tryParseBodyAsMap(http.Response response) {
+    if (response.body.trim().isEmpty) {
+      return <String, dynamic>{};
+    }
+
+    try {
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return Map<String, dynamic>.from(decoded);
+      }
+    } catch (_) {
+      return null;
+    }
+
+    return null;
+  }
+
+  Map<String, dynamic> _buildFailurePayload(http.Response response) {
+    final parsed = _tryParseBodyAsMap(response);
+    final payload = <String, dynamic>{
+      'success': false,
+      'error': HttpService.getErrorMessage(response),
+      'statusCode': response.statusCode,
+    };
+
+    final errorKey = parsed?['errorKey'] ?? parsed?['code'];
+    if (errorKey is String && errorKey.isNotEmpty) {
+      payload['errorKey'] = errorKey;
+    }
+
+    return payload;
+  }
+
   Future<Map<String, dynamic>?> toggleFollow(String username) async {
-    final response = await HttpService.post(
+    final response = await _httpClient.post(
       '$_baseUrl/follow/toggle',
       body: {'username': username},
       useAuth: true,
     );
-    final data = jsonDecode(response.body) as Map<String, dynamic>;
-    if (response.statusCode >= 200 &&
-        response.statusCode < 300 &&
-        data['success'] == true) {
+    final data = _tryParseBodyAsMap(response);
+    if (_isSuccessStatus(response) && data != null && data['success'] == true) {
       return data;
     }
-    return null;
+    if (data != null) {
+      return _buildFailurePayload(response);
+    }
+    return {
+      'success': false,
+      'error': '服务器响应格式错误',
+      'statusCode': response.statusCode,
+    };
   }
 
   Future<Map<String, dynamic>> fetchFollowSummary({String? username}) async {
     final uri = Uri.parse('$_baseUrl/follow-summary').replace(
       queryParameters: username == null ? null : {'username': username},
     );
-    final response = await HttpService.get(uri.toString(), useAuth: true);
-    if (response.statusCode == 200) {
-      return jsonDecode(response.body) as Map<String, dynamic>;
+    final response = await _httpClient.get(uri.toString(), useAuth: true);
+    final data = _tryParseBodyAsMap(response);
+    if (response.statusCode == 200 && data != null) {
+      return data;
     }
-    return {'success': false};
+    if (data != null) {
+      return _buildFailurePayload(response);
+    }
+    return {
+      'success': false,
+      'error': '服务器响应格式错误',
+      'statusCode': response.statusCode,
+    };
   }
 
   Future<List<Map<String, dynamic>>> fetchFollowList({
@@ -49,23 +148,28 @@ class SocialService {
       if (username != null) 'username': username,
     };
     final uri = Uri.parse('$_baseUrl/follows').replace(queryParameters: params);
-    final response = await HttpService.get(uri.toString(), useAuth: true);
-    if (response.statusCode == 200) {
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final response = await _httpClient.get(uri.toString(), useAuth: true);
+    final data = _tryParseBodyAsMap(response);
+    if (response.statusCode == 200 && data != null) {
       final users = data['users'];
-      if (users is List) return List<Map<String, dynamic>>.from(users);
+      if (users is List) {
+        return List<Map<String, dynamic>>.from(users);
+      }
     }
     return [];
   }
 
   Future<Map<String, dynamic>> fetchPracticePrivacy() async {
-    final response = await HttpService.get(
+    final response = await _httpClient.get(
       '$_baseUrl/practice-privacy',
       useAuth: true,
     );
-    if (response.statusCode == 200) {
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
-      return Map<String, dynamic>.from(data['privacy'] ?? {});
+    final data = _tryParseBodyAsMap(response);
+    if (response.statusCode == 200 && data != null) {
+      final privacy = data['privacy'];
+      if (privacy is Map) {
+        return Map<String, dynamic>.from(privacy);
+      }
     }
     return {
       'isPrivate': false,
@@ -81,7 +185,7 @@ class SocialService {
     required bool showDuration,
     required bool showChantCount,
   }) async {
-    final response = await HttpService.post(
+    final response = await _httpClient.post(
       '$_baseUrl/practice-privacy',
       body: {
         'isPrivate': isPrivate,
@@ -91,8 +195,10 @@ class SocialService {
       },
       useAuth: true,
     );
-    if (response.statusCode != 200) return false;
-    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final data = _tryParseBodyAsMap(response);
+    if (response.statusCode != 200 || data == null) {
+      return false;
+    }
     return data['success'] == true;
   }
 }

--- a/fabushi/test/unit/services/social_service_test.dart
+++ b/fabushi/test/unit/services/social_service_test.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:global_dharma_sharing/services/social_service.dart';
+
+http.Response jsonResponse(String body, int statusCode) {
+  return http.Response.bytes(
+    utf8.encode(body),
+    statusCode,
+    headers: {'content-type': 'application/json; charset=utf-8'},
+  );
+}
+
+class FakeSocialHttpClient implements SocialHttpClient {
+  FakeSocialHttpClient({this.getResponse, this.postResponse});
+
+  final http.Response? getResponse;
+  final http.Response? postResponse;
+
+  @override
+  Future<http.Response> get(
+    String url, {
+    Map<String, String>? queryParams,
+    bool useAuth = false,
+  }) async {
+    return getResponse ?? http.Response('', 500);
+  }
+
+  @override
+  Future<http.Response> post(
+    String url, {
+    Map<String, dynamic>? body,
+    bool useAuth = false,
+  }) async {
+    return postResponse ?? http.Response('', 500);
+  }
+}
+
+void main() {
+  group('SocialService', () {
+    test('toggleFollow preserves backend auth failures', () async {
+      final service = SocialService.withClient(
+        FakeSocialHttpClient(
+          postResponse: jsonResponse(
+            '{"message":"登录已过期","errorKey":"INVALID_TOKEN"}',
+            401,
+          ),
+        ),
+      );
+
+      final response = await service.toggleFollow('alice');
+
+      expect(response, isNotNull);
+      expect(response!['success'], false);
+      expect(response['error'], '登录已过期');
+      expect(response['statusCode'], 401);
+      expect(response['errorKey'], 'INVALID_TOKEN');
+    });
+
+    test('fetchFollowSummary preserves backend validation failures', () async {
+      final service = SocialService.withClient(
+        FakeSocialHttpClient(
+          getResponse: jsonResponse(
+            '{"error":"用户名不存在","errorKey":"VALIDATION_ERROR"}',
+            422,
+          ),
+        ),
+      );
+
+      final response = await service.fetchFollowSummary(username: 'missing');
+
+      expect(response['success'], false);
+      expect(response['error'], '用户名不存在');
+      expect(response['statusCode'], 422);
+      expect(response['errorKey'], 'VALIDATION_ERROR');
+    });
+
+    test('fetchFollowList returns empty list for malformed response bodies', () async {
+      final service = SocialService.withClient(
+        FakeSocialHttpClient(getResponse: http.Response('upstream unavailable', 503)),
+      );
+
+      final response = await service.fetchFollowList(type: 'followers');
+
+      expect(response, isEmpty);
+    });
+
+    test('fetchPracticePrivacy falls back to defaults for invalid responses', () async {
+      final service = SocialService.withClient(
+        FakeSocialHttpClient(getResponse: jsonResponse('{"success":true}', 200)),
+      );
+
+      final response = await service.fetchPracticePrivacy();
+
+      expect(response['isPrivate'], false);
+      expect(response['showPracticeName'], true);
+      expect(response['showDuration'], true);
+      expect(response['showChantCount'], true);
+    });
+
+    test('updatePracticePrivacy returns true when backend reports success', () async {
+      final service = SocialService.withClient(
+        FakeSocialHttpClient(postResponse: jsonResponse('{"success":true}', 200)),
+      );
+
+      final response = await service.updatePracticePrivacy(
+        isPrivate: true,
+        showPracticeName: false,
+        showDuration: false,
+        showChantCount: true,
+      );
+
+      expect(response, true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- harden `SocialService` response parsing so follow and privacy APIs no longer crash on malformed JSON or silently discard backend failure details
- introduce a tiny injectable `SocialHttpClient` seam so social-service behavior can be unit tested without changing the production `HttpService` contract
- add focused unit coverage for follow toggle failure mapping, follow-summary failure mapping, malformed follow-list responses, privacy defaults, and privacy-update success handling

## Why
The repository has spent the last few iterations fixing inconsistent HTTP/error semantics across old and new service layers. `fabushi/lib/services/social_service.dart` was still a clear weak spot:
- it decoded raw response bodies directly with `jsonDecode(response.body)`
- malformed or plain-text responses could throw instead of degrading safely
- backend auth/validation failures in `toggleFollow()` and `fetchFollowSummary()` were reduced to `null` or `{success:false}` without preserving the real reason
- there was no unit coverage for this service even though social follow and practice privacy are user-facing paths

This keeps the incremental transport-hardening work moving forward on another legacy caller without widening scope into a larger refactor.

## Risk / Impact
- Scope is limited to `SocialService` and one new unit test file.
- Existing public method signatures stay the same.
- Map-returning methods now preserve backend error details (`error`, `statusCode`, optional `errorKey`) instead of collapsing them into generic empty failures.
- List/bool/default-returning methods remain conservative and still degrade safely when the backend response is malformed.

## CI/CD and Quality Gates
- No workflow file changes were required because the existing `CI` workflow already runs `flutter test` across `fabushi/test/**` on every PR, merge-queue run, and push to `main`.
- This PR strengthens that gate by adding regression tests for a previously untested legacy service path, so future response-parsing regressions in social follow/privacy flows are blocked automatically.

## Validation
- Compared the branch against `main` to confirm the diff is limited to `fabushi/lib/services/social_service.dart` and `fabushi/test/unit/services/social_service_test.dart`.
- Added regression coverage for:
  - backend auth failure mapping in `toggleFollow()`
  - backend validation failure mapping in `fetchFollowSummary()`
  - malformed follow-list response fallback
  - invalid privacy response fallback defaults
  - successful privacy update handling
- I could not run Flutter tests locally in this environment because the repository is not available as a normal local checkout here, so final execution is delegated to the existing CI workflow.

## Residual Risk
- Methods that return `List`, `bool`, or default privacy maps still trade observability for compatibility; they avoid crashes but cannot surface rich error details without changing their public contract.
- Other legacy services such as comments, likes, and user blocking still use direct response decoding or raw `http` calls and may need the same treatment.

## Follow-up
- Audit the remaining social-adjacent legacy services (`comment_service.dart`, `like_service.dart`, `user_block_service.dart`) and converge them on the same response-parsing contract.
- If the UI needs richer failure handling for follow lists or privacy fetches, introduce a typed result object instead of silent fallback values in a later, separately reviewable step.