### PR TITLE
fix: harden comment service response parsing

### DIFF
--- a/fabushi/lib/services/comment_service.dart
+++ b/fabushi/lib/services/comment_service.dart
@@ -1,21 +1,160 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import '../core/config/app_config.dart';
 import '../models/comment_model.dart';
 import 'http_service.dart';
 import 'meditation_session_manager.dart';
 
+typedef MainPracticeProvider = String? Function();
+
+abstract class CommentHttpClient {
+  Future<http.Response> get(
+    String url, {
+    Map<String, String>? queryParams,
+    bool useAuth = false,
+  });
+
+  Future<http.Response> post(
+    String url, {
+    Map<String, dynamic>? body,
+    bool useAuth = false,
+  });
+
+  Future<http.Response> delete(
+    String url, {
+    bool useAuth = false,
+  });
+}
+
+class DefaultCommentHttpClient implements CommentHttpClient {
+  @override
+  Future<http.Response> get(
+    String url, {
+    Map<String, String>? queryParams,
+    bool useAuth = false,
+  }) {
+    return HttpService.get(
+      url,
+      queryParams: queryParams,
+      useAuth: useAuth,
+    );
+  }
+
+  @override
+  Future<http.Response> post(
+    String url, {
+    Map<String, dynamic>? body,
+    bool useAuth = false,
+  }) {
+    return HttpService.post(url, body: body, useAuth: useAuth);
+  }
+
+  @override
+  Future<http.Response> delete(
+    String url, {
+    bool useAuth = false,
+  }) {
+    return HttpService.delete(url, useAuth: useAuth);
+  }
+}
+
 /// 评论服务 - 管理内容评论
 ///
 /// 使用统一的 contentId 标识内容（替代原来的 videoId）
-
 class CommentService {
   static final CommentService _instance = CommentService._internal();
   factory CommentService() => _instance;
-  CommentService._internal();
+
+  CommentService._internal()
+    : _httpClient = DefaultCommentHttpClient(),
+      _mainPracticeProvider = _defaultMainPracticeProvider;
+
+  CommentService.withDependencies({
+    required CommentHttpClient httpClient,
+    MainPracticeProvider? mainPracticeProvider,
+  }) : _httpClient = httpClient,
+       _mainPracticeProvider =
+           mainPracticeProvider ?? _defaultMainPracticeProvider;
+
+  final CommentHttpClient _httpClient;
+  final MainPracticeProvider _mainPracticeProvider;
+
+  static String? _defaultMainPracticeProvider() {
+    return MeditationSessionManager().lockedPractice?.title;
+  }
 
   // 评论数缓存（使用 contentId 作为 key）
   final Map<String, int> _commentCounts = {};
+
+  Map<String, dynamic>? _tryParseBodyAsMap(http.Response response) {
+    if (response.body.trim().isEmpty) {
+      return <String, dynamic>{};
+    }
+
+    try {
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return Map<String, dynamic>.from(decoded);
+      }
+    } catch (_) {
+      return null;
+    }
+
+    return null;
+  }
+
+  String? _extractErrorKey(Map<String, dynamic>? data) {
+    final errorKey = data?['errorKey'] ?? data?['code'];
+    if (errorKey is String && errorKey.isNotEmpty) {
+      return errorKey;
+    }
+    return null;
+  }
+
+  Map<String, dynamic> _buildFailurePayload(
+    http.Response response, {
+    String fallbackError = '操作失败',
+  }) {
+    final data = _tryParseBodyAsMap(response);
+    final payload = <String, dynamic>{
+      'success': false,
+      'error': HttpService.getErrorMessage(response),
+      'statusCode': response.statusCode,
+    };
+
+    final errorKey = _extractErrorKey(data);
+    if (errorKey != null) {
+      payload['errorKey'] = errorKey;
+    }
+
+    if ((payload['error'] as String).trim().isEmpty) {
+      payload['error'] = fallbackError;
+    }
+
+    return payload;
+  }
+
+  List<CommentModel> _parseComments(List<dynamic> commentsJson) {
+    final comments = <CommentModel>[];
+
+    for (final item in commentsJson) {
+      if (item is! Map) {
+        continue;
+      }
+
+      try {
+        comments.add(CommentModel.fromJson(Map<String, dynamic>.from(item)));
+      } catch (e) {
+        debugPrint('跳过格式错误的评论数据: $e');
+      }
+    }
+
+    return comments;
+  }
 
   // 获取缓存的评论数
   int getCommentCount(String contentId) => _commentCounts[contentId] ?? 0;
@@ -25,19 +164,28 @@ class CommentService {
     if (contentIds.isEmpty) return;
 
     try {
-      final response = await HttpService.post(
+      final response = await _httpClient.post(
         '${AppConfig.apiUrl}/api/comments/batch-counts',
         body: {'videoIds': contentIds}, // 后端兼容 videoIds 参数名
       );
 
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        final Map<String, dynamic> counts = data['counts'];
-        for (final entry in counts.entries) {
-          _commentCounts[entry.key] = entry.value as int;
-        }
-        debugPrint('获取评论数成功: ${counts.length} 个');
+      if (response.statusCode != 200) {
+        return;
       }
+
+      final data = _tryParseBodyAsMap(response);
+      final counts = data?['counts'];
+      if (counts is! Map) {
+        return;
+      }
+
+      for (final entry in counts.entries) {
+        final value = entry.value;
+        if (value is num) {
+          _commentCounts[entry.key.toString()] = value.toInt();
+        }
+      }
+      debugPrint('获取评论数成功: ${counts.length} 个');
     } catch (e) {
       debugPrint('批量获取评论数异常: $e');
     }
@@ -50,18 +198,22 @@ class CommentService {
     int pageSize = 20,
   }) async {
     try {
-      final response = await HttpService.get(
+      final response = await _httpClient.get(
         '${AppConfig.apiUrl}/api/comments?contentId=$contentId&page=$page&pageSize=$pageSize',
       );
 
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        final List<dynamic> commentsJson = data['comments'];
-        return commentsJson.map((json) => CommentModel.fromJson(json)).toList();
-      } else {
+      if (response.statusCode != 200) {
         debugPrint('获取评论失败: ${response.statusCode}');
         return [];
       }
+
+      final data = _tryParseBodyAsMap(response);
+      final commentsJson = data?['comments'];
+      if (commentsJson is List) {
+        return _parseComments(commentsJson);
+      }
+
+      return [];
     } catch (e) {
       debugPrint('获取评论异常: $e');
       return [];
@@ -103,8 +255,10 @@ class CommentService {
       final body = <String, dynamic>{
         'contentId': contentId,
         'content': content,
-        'parentId': parentId,
       };
+      if (parentId != null) {
+        body['parentId'] = parentId;
+      }
       if (tag != null) {
         body['tag'] = tag;
       }
@@ -122,32 +276,37 @@ class CommentService {
       }
 
       // 自动附带当前用户的主修功课
-      final mainPractice = MeditationSessionManager().lockedPractice?.title;
-      if (mainPractice != null) {
+      final mainPractice = _mainPracticeProvider();
+      if (mainPractice != null && mainPractice.isNotEmpty) {
         body['mainPractice'] = mainPractice;
       }
 
-      final response = await HttpService.post(
+      final response = await _httpClient.post(
         '${AppConfig.apiUrl}/api/comments',
         body: body,
         useAuth: true,
       );
 
-      if (response.statusCode == 201) {
-        final data = jsonDecode(response.body);
-        return {
-          'success': true,
-          'comment': CommentModel.fromJson(data['comment']),
-        };
-      } else {
-        debugPrint('发布评论失败: ${response.statusCode} ${response.body}');
-        try {
-          final errorData = jsonDecode(response.body);
-          return {'success': false, 'error': errorData['error'] ?? '发布失败'};
-        } catch (_) {
-          return {'success': false, 'error': '发布失败: ${response.statusCode}'};
+      final data = _tryParseBodyAsMap(response);
+      if (response.statusCode == 201 && data != null) {
+        final comment = data['comment'];
+        if (comment is Map) {
+          return {
+            'success': true,
+            'comment': CommentModel.fromJson(Map<String, dynamic>.from(comment)),
+          };
         }
       }
+
+      if (data != null) {
+        return _buildFailurePayload(response, fallbackError: '发布失败');
+      }
+
+      return {
+        'success': false,
+        'error': '服务器响应格式错误',
+        'statusCode': response.statusCode,
+      };
     } catch (e, stackTrace) {
       debugPrint('❌ 发布评论异常: $e');
       debugPrint('❌ 堆栈: $stackTrace');
@@ -158,7 +317,7 @@ class CommentService {
   // 删除评论
   Future<bool> deleteComment(int commentId) async {
     try {
-      final response = await HttpService.delete(
+      final response = await _httpClient.delete(
         '${AppConfig.apiUrl}/api/comments?id=$commentId',
         useAuth: true,
       );

--- a/fabushi/test/unit/services/comment_service_test.dart
+++ b/fabushi/test/unit/services/comment_service_test.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:global_dharma_sharing/models/comment_model.dart';
+import 'package:global_dharma_sharing/services/comment_service.dart';
+
+http.Response jsonResponse(String body, int statusCode) {
+  return http.Response.bytes(
+    utf8.encode(body),
+    statusCode,
+    headers: {'content-type': 'application/json; charset=utf-8'},
+  );
+}
+
+class FakeCommentHttpClient implements CommentHttpClient {
+  FakeCommentHttpClient({
+    this.getResponse,
+    this.postResponse,
+    this.deleteResponse,
+    this.onGet,
+    this.onPost,
+    this.onDelete,
+  });
+
+  final http.Response? getResponse;
+  final http.Response? postResponse;
+  final http.Response? deleteResponse;
+  final void Function(String url)? onGet;
+  final void Function(
+    String url,
+    Map<String, dynamic>? body,
+    bool useAuth,
+  )? onPost;
+  final void Function(String url, bool useAuth)? onDelete;
+
+  @override
+  Future<http.Response> get(
+    String url, {
+    Map<String, String>? queryParams,
+    bool useAuth = false,
+  }) async {
+    onGet?.call(url);
+    return getResponse ?? http.Response('', 500);
+  }
+
+  @override
+  Future<http.Response> post(
+    String url, {
+    Map<String, dynamic>? body,
+    bool useAuth = false,
+  }) async {
+    onPost?.call(url, body, useAuth);
+    return postResponse ?? http.Response('', 500);
+  }
+
+  @override
+  Future<http.Response> delete(
+    String url, {
+    bool useAuth = false,
+  }) async {
+    onDelete?.call(url, useAuth);
+    return deleteResponse ?? http.Response('', 500);
+  }
+}
+
+void main() {
+  group('CommentService', () {
+    test('fetchCommentCounts updates cache from valid response payload', () async {
+      final service = CommentService.withDependencies(
+        httpClient: FakeCommentHttpClient(
+          postResponse: jsonResponse(
+            '{"counts":{"content-a":3,"content-b":0,"ignored":"oops"}}',
+            200,
+          ),
+        ),
+      );
+
+      await service.fetchCommentCounts(['content-a', 'content-b']);
+
+      expect(service.getCommentCount('content-a'), 3);
+      expect(service.getCommentCount('content-b'), 0);
+      expect(service.getCommentCount('ignored'), 0);
+    });
+
+    test('getComments returns empty list for malformed response bodies', () async {
+      final service = CommentService.withDependencies(
+        httpClient: FakeCommentHttpClient(
+          getResponse: http.Response('upstream unavailable', 503),
+        ),
+      );
+
+      final comments = await service.getComments('content-a');
+
+      expect(comments, isEmpty);
+    });
+
+    test('postComment preserves backend validation failures', () async {
+      Map<String, dynamic>? capturedBody;
+      bool? capturedUseAuth;
+
+      final service = CommentService.withDependencies(
+        httpClient: FakeCommentHttpClient(
+          postResponse: jsonResponse(
+            '{"message":"评论内容过长","errorKey":"VALIDATION_ERROR"}',
+            422,
+          ),
+          onPost: (url, body, useAuth) {
+            capturedBody = body;
+            capturedUseAuth = useAuth;
+          },
+        ),
+        mainPracticeProvider: () => '心经',
+      );
+
+      final result = await service.postComment(
+        'content-a',
+        '这是一条评论',
+        contentTitle: '功课标题',
+      );
+
+      expect(result['success'], false);
+      expect(result['error'], '评论内容过长');
+      expect(result['statusCode'], 422);
+      expect(result['errorKey'], 'VALIDATION_ERROR');
+      expect(capturedUseAuth, true);
+      expect(capturedBody?['mainPractice'], '心经');
+      expect(capturedBody?['videoTitle'], '功课标题');
+    });
+
+    test('postComment returns created comment model on success', () async {
+      final service = CommentService.withDependencies(
+        httpClient: FakeCommentHttpClient(
+          postResponse: jsonResponse(
+            '{"comment":{"id":1,"content_id":"content-a","user_id":"user-1","content":"随喜赞叹","created_at":"2026-05-04T00:00:00Z"}}',
+            201,
+          ),
+        ),
+      );
+
+      final result = await service.postComment('content-a', '随喜赞叹');
+
+      expect(result['success'], true);
+      expect(result['comment'], isA<CommentModel>());
+      expect((result['comment'] as CommentModel).videoId, 'content-a');
+    });
+
+    test('deleteComment returns true on successful deletion', () async {
+      bool? capturedUseAuth;
+
+      final service = CommentService.withDependencies(
+        httpClient: FakeCommentHttpClient(
+          deleteResponse: http.Response('', 200),
+          onDelete: (url, useAuth) {
+            capturedUseAuth = useAuth;
+          },
+        ),
+      );
+
+      final result = await service.deleteComment(42);
+
+      expect(result, true);
+      expect(capturedUseAuth, true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- harden `CommentService` response parsing so comment count, comment list, create, and delete flows no longer depend on unchecked `jsonDecode(response.body)` calls
- introduce a tiny injectable `CommentHttpClient` seam plus a `mainPracticeProvider` seam so comment-service behavior can be unit tested without changing the production `HttpService` or `MeditationSessionManager` contracts
- add focused unit coverage for comment count caching, malformed list responses, backend validation failure mapping, successful comment creation, and delete success handling

## Why
Recent iterations have been closing correctness gaps in the repo's legacy service layer one service at a time. After the auth, membership, and social fixes, `fabushi/lib/services/comment_service.dart` was the next high-value weak spot on the same path:
- it still decoded raw response bodies directly in multiple methods
- malformed or plain-text responses could throw and get collapsed into generic catch blocks
- backend validation/auth failures in `postComment()` were only partially preserved and were not covered by regression tests
- the service depended directly on global singletons, which made focused unit testing difficult for a user-facing comment flow

This keeps the ongoing transport-hardening work moving forward in a small, reviewable step without widening scope into a broader refactor.

## Risk / Impact
- Scope is limited to `CommentService` and one new unit test file.
- Existing public method signatures stay the same.
- Failure responses from `postComment()` now preserve backend-provided messages, status codes, and optional error keys when the backend returns a structured payload.
- `getComments()` and `fetchCommentCounts()` now degrade safely on malformed payloads instead of relying on unchecked decoding.

## CI/CD and Quality Gates
- No workflow file changes were required because the existing `CI` workflow on `.github/workflows/ci.yml` already runs `flutter test` for `fabushi/test/**` on pull requests, merge queue runs, and pushes to `main`.
- This PR strengthens that gate by adding regression coverage for a previously untested legacy comment-service path, so future parsing and error-mapping regressions in comment flows are blocked automatically.

## Validation
- Reviewed recent repository state before implementation: there were no open `ci-failure` issues at the time of this change, and the latest merged service hardening on `main` was PR #74 on May 4, 2026.
- Compared the branch against `main` to confirm the diff is limited to:
  - `fabushi/lib/services/comment_service.dart`
  - `fabushi/test/unit/services/comment_service_test.dart`
- Added regression coverage for:
  - comment count cache updates from valid batch-count payloads
  - malformed comment-list responses returning safe empty results
  - backend validation failure mapping in `postComment()`
  - successful comment creation parsing into `CommentModel`
  - successful delete handling with auth-enabled requests
- I could not run Flutter tests locally in this environment because the repository is not available as a normal local checkout here, so final execution is delegated to the existing CI workflow.

## Residual Risk
- `deleteComment()` still returns only `bool`, so richer backend failure details are intentionally not surfaced yet.
- Other legacy engagement services such as `LikeService` still use raw `http` calls and remain outside the scope of this PR.
- This change does not yet unify `CommentService` onto the newer core transport layer; it only hardens the current legacy path and makes it testable.

## Follow-up
- Audit `LikeService` next so likes and comments share the same response-parsing and testability pattern.
- If the UI needs richer delete or list-fetch failure handling later, introduce typed result objects in a separate PR instead of widening this compatibility-focused change.
