### PR TITLE
ci: open failure issues when package release workflow fails

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -26,6 +26,7 @@ concurrency:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 env:
   FLUTTER_VERSION: '3.41.9'
@@ -517,3 +518,56 @@ jobs:
             echo ""
             find release-assets -maxdepth 1 -type f -printf '- `%f`\n' | sort
           } >> "$GITHUB_STEP_SUMMARY"
+
+  notify-release-failure:
+    name: Notify package release failure
+    needs:
+      - resolve-cd-context
+      - build-android-packages
+      - build-ios-package
+      - publish-release
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout failure notifier
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.github/scripts/**
+
+      - name: Create or update detailed package release failure issue
+        uses: actions/github-script@v7
+        env:
+          SOURCE_SHA: ${{ needs.resolve-cd-context.outputs.source_sha || github.event.workflow_run.head_sha || inputs.source_sha || github.sha }}
+          CD_RUN_ID: ${{ needs.resolve-cd-context.outputs.cd_run_id || github.event.workflow_run.id || inputs.cd_run_id || '' }}
+        with:
+          script: |
+            const { createOrUpdateFailureIssue } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/create-failure-issue.js`);
+            await createOrUpdateFailureIssue({
+              github,
+              context,
+              core,
+              kind: 'package release',
+              titlePrefix: 'Package release failed for',
+              sourceSha: process.env.SOURCE_SHA || context.sha,
+              sourceRef: 'main',
+              labelName: 'release-failure',
+              labelColor: 'b60205',
+              labelDescription: 'Native package or GitHub Release publication failed',
+              notifyJobName: 'Notify package release failure',
+              extraSections: [
+                '### Release gates',
+                '',
+                '- Completed production CD workflow artifact',
+                '- Android APK/AAB build',
+                '- Signed iOS IPA build and optional App Store Connect upload',
+                '- GitHub Release asset preparation and publish',
+                '',
+                '### Source CD context',
+                '',
+                `- CD workflow run ID: ${process.env.CD_RUN_ID || 'unknown'}`,
+                '- This workflow publishes install packages only after the main production CD workflow succeeds.',
+              ],
+            });


### PR DESCRIPTION
## Summary
- add `issues: write` permission to `publish-cd-release.yml`
- add a `notify-release-failure` job that reuses `.github/scripts/create-failure-issue.js`
- automatically create or update a structured issue when Android packaging, signed iOS packaging, App Store Connect upload, or GitHub Release publication fails

## Why
The repository already opens detailed failure issues for the main `CI` and `CD - Staging API gated production deploy` workflows, but the install-package publishing workflow had no equivalent notifier. That left a blind spot: native package build or release-publication failures could silently require manual triage even though the repo already has a proven failure-issue pattern.

## Scope
- limited to `.github/workflows/publish-cd-release.yml`
- no application code changes
- no change to the success path for package publishing

## Behavior
- on any failure in `resolve-cd-context`, Android package build, iOS package build / upload, or GitHub Release publish, the workflow now opens or updates a `release-failure` issue
- the issue includes failed jobs, failed steps, artifacts, and the source CD run id so follow-up starts from the right evidence
- successful runs behave exactly as before

## Risk
- low: this only adds a failure notification path and the minimum permission needed to write issues
- if the notifier itself fails, the underlying package build / publish result is still preserved in the workflow run

## Validation
- aligned the new notifier with the existing `notify-ci-failure` and `notify-failure` jobs already used in the repo
- reused the shared `create-failure-issue.js` helper instead of introducing another issue format or another script
- kept the new job separate from the package-build and publish jobs so the success path remains unchanged
