### PR TITLE
fix: harden like service response parsing

### DIFF
--- a/fabushi/lib/services/like_service.dart
+++ b/fabushi/lib/services/like_service.dart
@@ -1,15 +1,81 @@
 import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+
 import '../core/config/app_config.dart';
 import '../models/liked_item.dart';
+
+abstract class LikeHttpClient {
+  Future<http.Response> get(Uri url, {Map<String, String>? headers});
+
+  Future<http.Response> post(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+  });
+}
+
+class DefaultLikeHttpClient implements LikeHttpClient {
+  @override
+  Future<http.Response> get(Uri url, {Map<String, String>? headers}) {
+    return http.get(url, headers: headers);
+  }
+
+  @override
+  Future<http.Response> post(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+  }) {
+    return http.post(url, headers: headers, body: body);
+  }
+}
+
+abstract class LikeStorage {
+  Future<String?> read(String key);
+
+  Future<void> write(String key, String value);
+}
+
+class SharedPreferencesLikeStorage implements LikeStorage {
+  SharedPreferencesLikeStorage({
+    Future<SharedPreferences> Function()? preferencesProvider,
+  }) : _preferencesProvider =
+           preferencesProvider ?? SharedPreferences.getInstance;
+
+  final Future<SharedPreferences> Function() _preferencesProvider;
+
+  @override
+  Future<String?> read(String key) async {
+    final prefs = await _preferencesProvider();
+    return prefs.getString(key);
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    final prefs = await _preferencesProvider();
+    await prefs.setString(key, value);
+  }
+}
 
 class LikeService extends ChangeNotifier {
   static final LikeService _instance = LikeService._internal();
   factory LikeService() => _instance;
-  LikeService._internal();
 
+  LikeService._internal()
+    : _httpClient = DefaultLikeHttpClient(),
+      _storage = SharedPreferencesLikeStorage();
+
+  LikeService.withDependencies({
+    LikeHttpClient? httpClient,
+    LikeStorage? storage,
+  }) : _httpClient = httpClient ?? DefaultLikeHttpClient(),
+       _storage = storage ?? SharedPreferencesLikeStorage();
+
+  final LikeHttpClient _httpClient;
+  final LikeStorage _storage;
   final Map<String, LikedItem> _likedItems = {};
   final Map<String, int> _likeCounts = {};
   bool _isInitialized = false;
@@ -38,16 +104,49 @@ class LikeService extends ChangeNotifier {
     }
   }
 
+  Map<String, dynamic>? _tryParseBodyAsMap(String body) {
+    if (body.trim().isEmpty) {
+      return <String, dynamic>{};
+    }
+
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return Map<String, dynamic>.from(decoded);
+      }
+    } catch (_) {
+      return null;
+    }
+
+    return null;
+  }
+
   Future<void> _loadLikedItems() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final jsonString = prefs.getString(_getStorageKey());
-      if (jsonString != null) {
-        final List<dynamic> jsonList = jsonDecode(jsonString);
-        _likedItems.clear();
-        for (var json in jsonList) {
-          final item = LikedItem.fromJson(json);
+      final jsonString = await _storage.read(_getStorageKey());
+      if (jsonString == null || jsonString.trim().isEmpty) {
+        return;
+      }
+
+      final decoded = jsonDecode(jsonString);
+      if (decoded is! List) {
+        return;
+      }
+
+      _likedItems.clear();
+      for (final itemJson in decoded) {
+        if (itemJson is! Map) {
+          continue;
+        }
+
+        try {
+          final item = LikedItem.fromJson(Map<String, dynamic>.from(itemJson));
           _likedItems[item.id] = item;
+        } catch (e) {
+          debugPrint('跳过格式错误的点赞缓存数据: $e');
         }
       }
     } catch (e) {
@@ -57,9 +156,8 @@ class LikeService extends ChangeNotifier {
 
   Future<void> _saveLikedItems() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
       final jsonList = _likedItems.values.map((item) => item.toJson()).toList();
-      await prefs.setString(_getStorageKey(), jsonEncode(jsonList));
+      await _storage.write(_getStorageKey(), jsonEncode(jsonList));
     } catch (e) {
       debugPrint('保存点赞数据失败: $e');
     }
@@ -93,12 +191,11 @@ class LikeService extends ChangeNotifier {
     await _saveLikedItems();
     notifyListeners();
 
-    // 同步到云端，点赞时额外发送标题和文件路径
     _syncToCloud(
       item.id,
       item.contentType,
       wasLiked ? 'unlike' : 'like',
-      title: item.username, // username 字段存储的是标题
+      title: item.username,
       filePath: item.filePath,
     );
   }
@@ -107,23 +204,35 @@ class LikeService extends ChangeNotifier {
     if (_authToken == null) return;
 
     try {
-      final response = await http.get(
+      final response = await _httpClient.get(
         Uri.parse('${AppConfig.apiUrl}/api/likes/my-likes'),
         headers: {'Authorization': 'Bearer $_authToken'},
       );
 
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        if (data['success'] == true && data['likes'] != null) {
-          final List<dynamic> likes = data['likes'];
-          for (var like in likes) {
-            final item = LikedItem.fromJson(like);
-            _likedItems[item.id] = item;
-          }
-          await _saveLikedItems();
-          notifyListeners();
+      if (response.statusCode != 200) {
+        return;
+      }
+
+      final data = _tryParseBodyAsMap(response.body);
+      final likes = data?['likes'];
+      if (data?['success'] != true || likes is! List) {
+        return;
+      }
+
+      for (final like in likes) {
+        if (like is! Map) {
+          continue;
+        }
+
+        try {
+          final item = LikedItem.fromJson(Map<String, dynamic>.from(like));
+          _likedItems[item.id] = item;
+        } catch (e) {
+          debugPrint('跳过格式错误的云端点赞数据: $e');
         }
       }
+      await _saveLikedItems();
+      notifyListeners();
     } catch (e) {
       debugPrint('从云端加载点赞数据失败: $e');
     }
@@ -137,32 +246,40 @@ class LikeService extends ChangeNotifier {
     String? filePath,
   }) async {
     try {
-      final headers = {'Content-Type': 'application/json'};
+      final headers = <String, String>{'Content-Type': 'application/json'};
       if (_authToken != null) {
         headers['Authorization'] = 'Bearer $_authToken';
       }
 
-      final body = {
+      final body = <String, dynamic>{
         'contentId': contentId,
         'contentType': contentType,
         'action': action,
       };
 
-      // 点赞时额外发送标题和文件路径
       if (action == 'like') {
-        if (title != null) body['title'] = title;
-        if (filePath != null) body['filePath'] = filePath;
+        if (title != null) {
+          body['title'] = title;
+        }
+        if (filePath != null) {
+          body['filePath'] = filePath;
+        }
       }
 
-      final response = await http.post(
+      final response = await _httpClient.post(
         Uri.parse('${AppConfig.apiUrl}/api/likes/toggle'),
         headers: headers,
         body: jsonEncode(body),
       );
 
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        _likeCounts[contentId] = data['likeCount'] ?? 0;
+      if (response.statusCode != 200) {
+        return;
+      }
+
+      final data = _tryParseBodyAsMap(response.body);
+      final likeCount = data?['likeCount'];
+      if (likeCount is num) {
+        _likeCounts[contentId] = likeCount.toInt();
         notifyListeners();
       }
     } catch (e) {
@@ -174,20 +291,28 @@ class LikeService extends ChangeNotifier {
     if (contentIds.isEmpty) return;
 
     try {
-      final response = await http.post(
+      final response = await _httpClient.post(
         Uri.parse('${AppConfig.apiUrl}/api/likes/batch-counts'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({'contentIds': contentIds}),
       );
 
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        final counts = data['likeCounts'] as Map<String, dynamic>;
-        counts.forEach((key, value) {
-          _likeCounts[key] = value as int;
-        });
-        notifyListeners();
+      if (response.statusCode != 200) {
+        return;
       }
+
+      final data = _tryParseBodyAsMap(response.body);
+      final counts = data?['likeCounts'];
+      if (counts is! Map) {
+        return;
+      }
+
+      counts.forEach((key, value) {
+        if (value is num) {
+          _likeCounts[key.toString()] = value.toInt();
+        }
+      });
+      notifyListeners();
     } catch (e) {
       debugPrint('获取点赞数失败: $e');
     }
@@ -205,7 +330,6 @@ class LikeService extends ChangeNotifier {
 
   LikedItem? getLikedItem(String id) => _likedItems[id];
 
-  // 获取用户评论被点赞的总数（用于"获赞"统计）
   int _receivedLikeCount = 0;
   int get receivedLikeCount => _receivedLikeCount;
 
@@ -213,17 +337,20 @@ class LikeService extends ChangeNotifier {
     if (_authToken == null) return;
 
     try {
-      final response = await http.get(
+      final response = await _httpClient.get(
         Uri.parse('${AppConfig.apiUrl}/api/likes/received-count'),
         headers: {'Authorization': 'Bearer $_authToken'},
       );
 
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        if (data['success'] == true) {
-          _receivedLikeCount = data['receivedLikeCount'] ?? 0;
-          notifyListeners();
-        }
+      if (response.statusCode != 200) {
+        return;
+      }
+
+      final data = _tryParseBodyAsMap(response.body);
+      final receivedLikeCount = data?['receivedLikeCount'];
+      if (data?['success'] == true && receivedLikeCount is num) {
+        _receivedLikeCount = receivedLikeCount.toInt();
+        notifyListeners();
       }
     } catch (e) {
       debugPrint('获取被点赞数失败: $e');

--- a/fabushi/test/unit/services/like_service_test.dart
+++ b/fabushi/test/unit/services/like_service_test.dart
@@ -120,7 +120,9 @@ void main() {
         httpClient: FakeLikeHttpClient(
           onPost: (url, headers, body) async {
             capturedHeaders = headers;
-            capturedBody = jsonDecode(body! as String) as Map<String, dynamic>;
+            capturedBody = Map<String, dynamic>.from(
+              jsonDecode(body! as String) as Map,
+            );
             return jsonResponse('{"likeCount":9}', 200);
           },
         ),

--- a/fabushi/test/unit/services/like_service_test.dart
+++ b/fabushi/test/unit/services/like_service_test.dart
@@ -1,0 +1,183 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:global_dharma_sharing/models/liked_item.dart';
+import 'package:global_dharma_sharing/services/like_service.dart';
+
+http.Response jsonResponse(String body, int statusCode) {
+  return http.Response.bytes(
+    utf8.encode(body),
+    statusCode,
+    headers: {'content-type': 'application/json; charset=utf-8'},
+  );
+}
+
+class FakeLikeHttpClient implements LikeHttpClient {
+  FakeLikeHttpClient({this.onGet, this.onPost});
+
+  final Future<http.Response> Function(Uri url, Map<String, String>? headers)? onGet;
+  final Future<http.Response> Function(
+    Uri url,
+    Map<String, String>? headers,
+    Object? body,
+  )? onPost;
+
+  @override
+  Future<http.Response> get(Uri url, {Map<String, String>? headers}) async {
+    return onGet?.call(url, headers) ?? http.Response('', 500);
+  }
+
+  @override
+  Future<http.Response> post(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+  }) async {
+    return onPost?.call(url, headers, body) ?? http.Response('', 500);
+  }
+}
+
+class MemoryLikeStorage implements LikeStorage {
+  MemoryLikeStorage([Map<String, String>? seed]) : _values = {...?seed};
+
+  final Map<String, String> _values;
+
+  @override
+  Future<String?> read(String key) async => _values[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    _values[key] = value;
+  }
+}
+
+LikedItem buildLikedItem({
+  required String id,
+  required DateTime likedAt,
+  String? filePath,
+}) {
+  return LikedItem(
+    id: id,
+    username: '文章标题',
+    description: '随喜赞叹',
+    profileImageUrl: '',
+    likedAt: likedAt,
+    contentType: 'text',
+    filePath: filePath,
+  );
+}
+
+void main() {
+  group('LikeService', () {
+    test('initialize loads cached likes and merges cloud likes', () async {
+      final storage = MemoryLikeStorage({
+        'liked_items_user-1':
+            '[{"id":"local-1","username":"本地标题","description":"本地","profileImageUrl":"","likedAt":"2026-05-04T00:00:00Z","contentType":"text"}]',
+      });
+
+      final service = LikeService.withDependencies(
+        storage: storage,
+        httpClient: FakeLikeHttpClient(
+          onGet: (url, headers) async {
+            expect(headers?['Authorization'], 'Bearer token');
+            return jsonResponse(
+              '{"success":true,"likes":[{"id":"cloud-1","title":"云端标题","description":"云端","profileImageUrl":"","likedAt":"2026-05-04T01:00:00Z","contentType":"text"}]}',
+              200,
+            );
+          },
+        ),
+      );
+
+      service.setAuthToken('token');
+      await service.initialize(userId: 'user-1');
+
+      expect(service.isInitialized, true);
+      expect(service.likedCount, 2);
+      expect(service.isLiked('local-1'), true);
+      expect(service.isLiked('cloud-1'), true);
+    });
+
+    test('initialize ignores malformed cached payloads', () async {
+      final service = LikeService.withDependencies(
+        storage: MemoryLikeStorage({'liked_items_user-1': 'not-json'}),
+        httpClient: FakeLikeHttpClient(),
+      );
+
+      await service.initialize(userId: 'user-1');
+
+      expect(service.isInitialized, true);
+      expect(service.likedCount, 0);
+    });
+
+    test('toggleLike sends title and file path and applies returned count', () async {
+      Map<String, dynamic>? capturedBody;
+      Map<String, String>? capturedHeaders;
+
+      final service = LikeService.withDependencies(
+        storage: MemoryLikeStorage(),
+        httpClient: FakeLikeHttpClient(
+          onPost: (url, headers, body) async {
+            capturedHeaders = headers;
+            capturedBody = jsonDecode(body! as String) as Map<String, dynamic>;
+            return jsonResponse('{"likeCount":9}', 200);
+          },
+        ),
+      );
+
+      service.setAuthToken('token');
+      final item = buildLikedItem(
+        id: 'content-a',
+        likedAt: DateTime.parse('2026-05-04T02:00:00Z'),
+        filePath: '/notes/a.md',
+      );
+
+      await service.toggleLike(item);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.isLiked('content-a'), true);
+      expect(service.getLikeCount('content-a'), 9);
+      expect(capturedHeaders?['Authorization'], 'Bearer token');
+      expect(capturedBody?['title'], '文章标题');
+      expect(capturedBody?['filePath'], '/notes/a.md');
+      expect(capturedBody?['action'], 'like');
+    });
+
+    test('fetchLikeCounts updates numeric counts only', () async {
+      final service = LikeService.withDependencies(
+        storage: MemoryLikeStorage(),
+        httpClient: FakeLikeHttpClient(
+          onPost: (url, headers, body) async {
+            return jsonResponse(
+              '{"likeCounts":{"content-a":4,"content-b":0,"ignored":"oops"}}',
+              200,
+            );
+          },
+        ),
+      );
+
+      await service.fetchLikeCounts(['content-a', 'content-b', 'ignored']);
+
+      expect(service.getLikeCount('content-a'), 4);
+      expect(service.getLikeCount('content-b'), 0);
+      expect(service.getLikeCount('ignored'), 0);
+    });
+
+    test('fetchReceivedLikeCount ignores malformed payloads', () async {
+      final service = LikeService.withDependencies(
+        storage: MemoryLikeStorage(),
+        httpClient: FakeLikeHttpClient(
+          onGet: (url, headers) async {
+            return http.Response('upstream unavailable', 503);
+          },
+        ),
+      );
+
+      service.setAuthToken('token');
+      await service.fetchReceivedLikeCount();
+
+      expect(service.receivedLikeCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- harden `LikeService` so cached likes, cloud sync responses, batch count payloads, and received-like payloads no longer depend on unchecked `jsonDecode(...)` assumptions
- introduce small injectable `LikeHttpClient` and `LikeStorage` seams so the service can be unit tested without changing the production singleton contract
- add focused unit coverage for cached-like loading, malformed cache fallback, cloud sync merge behavior, toggle-like request payloads, numeric count parsing, and malformed received-like responses

## Why
This repository has spent the latest iterations tightening the legacy service layer one user-facing workflow at a time. After the merged `SocialService` and `CommentService` fixes on `main` earlier on May 4, 2026, `fabushi/lib/services/like_service.dart` remained the next closely related weak spot:
- it still decoded cached and backend payloads directly with raw `jsonDecode(...)`
- malformed cache, plain-text failures, or partially invalid backend payloads could throw or silently skip state updates in inconsistent ways
- there was no focused unit coverage for a service that backs likes, liked-item lists, and the received-like counter
- the hard dependency on global `http` and `SharedPreferences` made precise regression tests awkward

This PR keeps the current incremental hardening track moving forward in a small, reviewable step that matches the existing pattern used for recent legacy-service upgrades.

## Risk / Impact
- Scope is limited to `fabushi/lib/services/like_service.dart` and one new unit test file.
- Existing public method signatures and optimistic local toggle behavior stay the same.
- The service now ignores malformed cache entries and malformed backend payloads more deliberately instead of depending on unchecked decoding.
- Successful cloud responses still update the same in-memory state, but numeric fields are now validated before being applied.

## CI/CD and Quality Gates
- No workflow file changes were required because the existing `CI` workflow in `.github/workflows/ci.yml` already runs `flutter test` on pull requests, merge queue runs, and pushes to `main`.
- This PR strengthens that gate by adding regression coverage for another previously untested legacy engagement service, so future parsing and storage regressions in like flows are blocked automatically.

## Validation
- Reviewed recent repository state before implementation: `main` had already merged PR #74 and PR #75 on May 4, 2026, continuing the same legacy-service hardening line, and CI already included Flutter/unit coverage for `fabushi/test/**`.
- Compared the branch against `main` to confirm the diff is limited to:
  - `fabushi/lib/services/like_service.dart`
  - `fabushi/test/unit/services/like_service_test.dart`
- Added regression coverage for:
  - cached likes loading from storage plus cloud merge behavior
  - malformed cached JSON falling back safely
  - toggle-like request payload contents and returned count application
  - numeric-only parsing for batch like counts
  - malformed received-like responses leaving the counter stable
- I could not run Flutter tests locally in this environment because the repository is not available as a normal local checkout here, so final execution is delegated to the existing CI workflow.

## Residual Risk
- `toggleLike()` still performs fire-and-forget cloud sync after the optimistic local update, so transport failures remain non-blocking by design and are only visible through logs.
- `LikeService` still owns several responsibilities at once: cache persistence, optimistic UI state, and backend sync. This PR improves correctness and testability without yet splitting those concerns.
- `UserBlockService` remains another nearby legacy service with no comparable test seam or payload hardening.

## Follow-up
- Audit `UserBlockService` next so likes, comments, follow relationships, and user blocking all share the same safe-response and testability baseline.
- If the product eventually needs richer backend failure surfacing for likes, introduce typed result objects in a separate PR instead of widening this compatibility-focused service fix.
