### PR TITLE
feat: submit in-app feedback to GitHub issues

### DIFF
--- a/fabushi/lib/screens/settings_screen.dart
+++ b/fabushi/lib/screens/settings_screen.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'keep_alive_guide_screen.dart';
+import '../services/api_client.dart';
 import '../services/app_settings.dart';
 import '../services/llm_model_config.dart';
 import '../services/llm_model_manager.dart';
 import '../services/device_capability_service.dart';
+import '../services/worker_config.dart';
 import '../widgets/model_selection_dialog.dart';
 import '../models/auth_model.dart';
 
@@ -20,6 +23,7 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _defaultTtsMuted = true;
   bool _isLoading = true;
+  bool _isSubmittingFeedback = false;
 
   // 读诵匹配阈值（百分比形式，0.0 ~ 1.0）
   double _fastMatchThreshold = 0.50;
@@ -132,6 +136,203 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _setMatchThreshold(double value) async {
     setState(() => _matchThreshold = value);
     await AppSettings.setMatchThreshold(value);
+  }
+
+  String _feedbackPlatformLabel() {
+    if (kIsWeb) return 'web';
+    if (Platform.isAndroid) return 'android';
+    if (Platform.isIOS) return 'ios';
+    if (Platform.isMacOS) return 'macos';
+    if (Platform.isWindows) return 'windows';
+    if (Platform.isLinux) return 'linux';
+    return 'unknown';
+  }
+
+  Future<Map<String, dynamic>> _submitFeedback({
+    required String title,
+    required String description,
+    required String contact,
+  }) async {
+    final authModel = Provider.of<AuthModel>(context, listen: false);
+
+    return ApiClient.instance.post(
+      WorkerConfig.getEndpoint('submitFeedback'),
+      body: {
+        'title': title,
+        'description': description,
+        if (contact.trim().isNotEmpty) 'contact': contact.trim(),
+        'page': 'settings_screen',
+        'platform': _feedbackPlatformLabel(),
+      },
+      token: authModel.authToken,
+    );
+  }
+
+  Future<void> _showFeedbackDialog() async {
+    final authModel = Provider.of<AuthModel>(context, listen: false);
+    final titleController = TextEditingController();
+    final descriptionController = TextEditingController();
+    final contactController = TextEditingController(
+      text: authModel.currentUser?.email ?? '',
+    );
+    String? validationMessage;
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            Future<void> handleSubmit() async {
+              final title = titleController.text.trim();
+              final description = descriptionController.text.trim();
+              final contact = contactController.text.trim();
+
+              if (title.isEmpty) {
+                setDialogState(() => validationMessage = '请填写问题标题');
+                return;
+              }
+
+              if (description.isEmpty) {
+                setDialogState(() => validationMessage = '请填写问题描述');
+                return;
+              }
+
+              setDialogState(() => validationMessage = null);
+              if (mounted) {
+                setState(() => _isSubmittingFeedback = true);
+              }
+
+              final result = await _submitFeedback(
+                title: title,
+                description: description,
+                contact: contact,
+              );
+
+              if (!mounted) return;
+              setState(() => _isSubmittingFeedback = false);
+
+              if (Navigator.of(dialogContext).canPop()) {
+                Navigator.of(dialogContext).pop();
+              }
+
+              final success = result['success'] == true;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    success
+                        ? (result['message'] ?? '反馈已提交')
+                        : (result['error'] ?? '反馈提交失败，请稍后重试'),
+                  ),
+                  backgroundColor: success ? Colors.green : Colors.red,
+                ),
+              );
+            }
+
+            return AlertDialog(
+              backgroundColor: const Color(0xFF1E1E1E),
+              title: const Text('提交问题反馈', style: TextStyle(color: Colors.white)),
+              content: SizedBox(
+                width: 420,
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '问题会自动同步到 GitHub Issue，方便后续跟进。',
+                        style: TextStyle(color: Colors.white70, fontSize: 13),
+                      ),
+                      const SizedBox(height: 16),
+                      TextField(
+                        controller: titleController,
+                        enabled: !_isSubmittingFeedback,
+                        style: const TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          labelText: '问题标题',
+                          labelStyle: const TextStyle(color: Colors.white70),
+                          hintText: '例如：收藏后没有提示',
+                          hintStyle: const TextStyle(color: Colors.white38),
+                          filled: true,
+                          fillColor: Colors.white.withOpacity(0.04),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: descriptionController,
+                        enabled: !_isSubmittingFeedback,
+                        style: const TextStyle(color: Colors.white),
+                        minLines: 4,
+                        maxLines: 8,
+                        decoration: InputDecoration(
+                          labelText: '问题描述',
+                          labelStyle: const TextStyle(color: Colors.white70),
+                          hintText: '请尽量写清楚发生了什么、你期待什么结果。',
+                          hintStyle: const TextStyle(color: Colors.white38),
+                          filled: true,
+                          fillColor: Colors.white.withOpacity(0.04),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: contactController,
+                        enabled: !_isSubmittingFeedback,
+                        style: const TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          labelText: '联系方式（选填）',
+                          labelStyle: const TextStyle(color: Colors.white70),
+                          hintText: '邮箱、微信或其他便于回访的信息',
+                          hintStyle: const TextStyle(color: Colors.white38),
+                          filled: true,
+                          fillColor: Colors.white.withOpacity(0.04),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                      ),
+                      if (validationMessage != null) ...[
+                        const SizedBox(height: 12),
+                        Text(
+                          validationMessage!,
+                          style: const TextStyle(color: Colors.redAccent),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: _isSubmittingFeedback
+                      ? null
+                      : () => Navigator.of(dialogContext).pop(),
+                  child: const Text('取消'),
+                ),
+                FilledButton(
+                  onPressed: _isSubmittingFeedback ? null : handleSubmit,
+                  child: _isSubmittingFeedback
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('提交反馈'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    ).whenComplete(() {
+      titleController.dispose();
+      descriptionController.dispose();
+      contactController.dispose();
+    });
   }
 
   /// 显示删除模型确认对话框
@@ -252,27 +453,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     icon: Icons.help_outline,
                     iconColor: Colors.orange,
                     title: '帮助与反馈',
-                    subtitle: '联系邮箱: support@ombhrum.com',
-                    onTap: () => showDialog(
-                      context: context,
-                      builder: (context) => AlertDialog(
-                        backgroundColor: const Color(0xFF1E1E1E),
-                        title: const Text(
-                          '帮助与反馈',
-                          style: TextStyle(color: Colors.white),
-                        ),
-                        content: const Text(
-                          '如果您发现任何违规内容，或有任何建议，请联系我们：\n\n邮箱：support@ombhrum.com\n我们将会在24小时内处理您的反馈。',
-                          style: TextStyle(color: Colors.white70),
-                        ),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.pop(context),
-                            child: const Text('确定'),
-                          ),
-                        ],
-                      ),
-                    ),
+                    subtitle: '提交问题或建议，自动同步到 GitHub',
+                    onTap: _showFeedbackDialog,
                   ),
 
                   _buildSettingItem(

--- a/fabushi/lib/services/worker_config.dart
+++ b/fabushi/lib/services/worker_config.dart
@@ -40,6 +40,9 @@ class WorkerConfig {
     'alipayNotify': '/api/alipay/notify',
     'alipayMembershipStatus': '/api/alipay/check-membership',
 
+    // 用户反馈
+    'submitFeedback': '/api/feedback',
+
     // 管理员相关
     'adminCheckStatus': '/api/admin/check-status',
     'adminCreateRedeemCode': '/api/admin/create-redeem-code',

--- a/fabushi/web/src/handlers/feedback.js
+++ b/fabushi/web/src/handlers/feedback.js
@@ -1,0 +1,186 @@
+import { jsonResponse } from '../utils/response.js';
+import { verifyToken } from '../../auth-utils.js';
+
+const DEFAULT_REPO_OWNER = 'bhrumom';
+const DEFAULT_REPO_NAME = 'fabushi';
+const DEFAULT_LABEL = 'user-feedback';
+const DEFAULT_LABEL_COLOR = '0e8a16';
+const DEFAULT_LABEL_DESCRIPTION = 'User-submitted product feedback';
+
+function normalizeText(value, { maxLength = 1000 } = {}) {
+  if (typeof value !== 'string') return '';
+  return value.trim().replace(/\r\n/g, '\n').substring(0, maxLength);
+}
+
+async function resolveReporter(request, env, db) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  try {
+    const token = authHeader.substring(7);
+    const tokenData = await verifyToken(token, env);
+    if (!tokenData?.username) {
+      return null;
+    }
+
+    const user = await db.getUser(tokenData.username);
+    if (!user) {
+      return { username: tokenData.username };
+    }
+
+    return {
+      username: user.username,
+      email: user.email || '',
+      phoneNumber: user.phone_number || '',
+    };
+  } catch (error) {
+    console.warn('反馈接口解析登录用户失败，将按匿名处理:', error);
+    return null;
+  }
+}
+
+function buildIssueBody({ feedback, reporter }) {
+  const lines = [
+    '## 用户反馈',
+    '',
+    `- 标题: ${feedback.title}`,
+    `- 页面入口: ${feedback.page || 'unknown'}`,
+    `- 平台: ${feedback.platform || 'unknown'}`,
+    `- App 版本: ${feedback.appVersion || 'unknown'}`,
+    `- 联系方式: ${feedback.contact || '未提供'}`,
+    `- 提交时间: ${new Date().toISOString()}`,
+    `- 登录用户: ${reporter?.username || 'anonymous'}`,
+    reporter?.email ? `- 用户邮箱: ${reporter.email}` : null,
+    reporter?.phoneNumber ? `- 用户手机号: ${reporter.phoneNumber}` : null,
+    '',
+    '### 问题描述',
+    '',
+    feedback.description,
+    '',
+    '---',
+    '',
+    '_This issue was created automatically from the in-app feedback form._',
+  ];
+
+  return lines.filter(Boolean).join('\n');
+}
+
+async function githubRequest(env, path, init) {
+  const token = env.GITHUB_FEEDBACK_TOKEN;
+  if (!token) {
+    throw new Error('missing_feedback_token');
+  }
+
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'fabushi-feedback-worker',
+      ...init?.headers,
+    },
+  });
+
+  return response;
+}
+
+async function ensureFeedbackLabel(env) {
+  const owner = env.GITHUB_FEEDBACK_REPO_OWNER || DEFAULT_REPO_OWNER;
+  const repo = env.GITHUB_FEEDBACK_REPO_NAME || DEFAULT_REPO_NAME;
+  const label = env.GITHUB_FEEDBACK_LABEL || DEFAULT_LABEL;
+
+  const response = await githubRequest(env, `/repos/${owner}/${repo}/labels`, {
+    method: 'POST',
+    body: JSON.stringify({
+      name: label,
+      color: DEFAULT_LABEL_COLOR,
+      description: DEFAULT_LABEL_DESCRIPTION,
+    }),
+  });
+
+  if (response.ok || response.status === 422) {
+    return label;
+  }
+
+  const errorText = await response.text();
+  throw new Error(`ensure_label_failed:${response.status}:${errorText}`);
+}
+
+async function createFeedbackIssue(env, feedback, reporter) {
+  const owner = env.GITHUB_FEEDBACK_REPO_OWNER || DEFAULT_REPO_OWNER;
+  const repo = env.GITHUB_FEEDBACK_REPO_NAME || DEFAULT_REPO_NAME;
+  const label = await ensureFeedbackLabel(env);
+
+  const response = await githubRequest(env, `/repos/${owner}/${repo}/issues`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title: `[反馈] ${feedback.title}`,
+      body: buildIssueBody({ feedback, reporter }),
+      labels: [label],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`create_issue_failed:${response.status}:${errorText}`);
+  }
+
+  return response.json();
+}
+
+export async function handleSubmitFeedback(request, env, db) {
+  try {
+    if (!env.GITHUB_FEEDBACK_TOKEN) {
+      return jsonResponse({
+        success: false,
+        error: '反馈服务暂未配置完成，请稍后再试。',
+      }, 503);
+    }
+
+    const body = await request.json();
+    const feedback = {
+      title: normalizeText(body.title, { maxLength: 120 }),
+      description: normalizeText(body.description, { maxLength: 5000 }),
+      contact: normalizeText(body.contact, { maxLength: 200 }),
+      page: normalizeText(body.page, { maxLength: 80 }),
+      platform: normalizeText(body.platform, { maxLength: 80 }),
+      appVersion: normalizeText(body.appVersion, { maxLength: 80 }),
+    };
+
+    if (!feedback.title) {
+      return jsonResponse({ success: false, error: '请填写问题标题' }, 400);
+    }
+
+    if (!feedback.description) {
+      return jsonResponse({ success: false, error: '请填写问题描述' }, 400);
+    }
+
+    const reporter = await resolveReporter(request, env, db);
+    const issue = await createFeedbackIssue(env, feedback, reporter);
+
+    return jsonResponse({
+      success: true,
+      issueNumber: issue.number,
+      issueUrl: issue.html_url,
+      message: '反馈已提交，我们会尽快处理。',
+    }, 201);
+  } catch (error) {
+    console.error('提交反馈失败:', error);
+
+    const message = String(error?.message || error);
+    if (message === 'missing_feedback_token') {
+      return jsonResponse({
+        success: false,
+        error: '反馈服务暂未配置完成，请稍后再试。',
+      }, 503);
+    }
+
+    return jsonResponse({
+      success: false,
+      error: '反馈提交失败，请稍后重试。',
+    }, 502);
+  }
+}

--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -21,8 +21,8 @@ import { handleGetSyncData, handlePushSyncData, handleGetSyncState } from './han
 import { handleToggleFollow, handleGetFollowList, handleGetFollowSummary, handleGetPracticePrivacy, handleUpdatePracticePrivacy } from './handlers/social.js';
 import { handleBuiltinMigration, handleFullTextSearch, handleGetCategories as handleBuiltinCategories } from '../migrate-builtin-handler-fixed.js';
 import { handleReport, handleBlockUser, handleGetReports, handleReviewReport, handleGetBlocks } from './handlers/moderation.js';
+import { handleSubmitFeedback } from './handlers/feedback.js';
 import { jsonResponse } from './utils/response.js';
-
 
 export async function route(request, env, db, ctx) {
   const url = new URL(request.url);
@@ -86,6 +86,9 @@ export async function route(request, env, db, ctx) {
 
   // 会员API
   if (pathname === '/api/stripe/membership-status' && method === 'GET') return await handleCheckMembershipStatus(request, env, db);
+
+  // 反馈API
+  if (pathname === '/api/feedback' && method === 'POST') return await handleSubmitFeedback(request, env, db);
 
   // 兑换码API
   if (pathname === '/api/admin/create-redeem-code' && method === 'POST') return await handleCreateRedeemCode(request, env, db);

--- a/fabushi/web/tests/feedback.test.js
+++ b/fabushi/web/tests/feedback.test.js
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { handleSubmitFeedback } from '../src/handlers/feedback.js';
+
+test('handleSubmitFeedback rejects missing title', async () => {
+  const request = new Request('https://flutter.ombhrum.com/api/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ description: 'details' }),
+  });
+
+  const response = await handleSubmitFeedback(request, {
+    GITHUB_FEEDBACK_TOKEN: 'token',
+  }, {
+    getUser: async () => null,
+  });
+
+  assert.equal(response.status, 400);
+  const payload = await response.json();
+  assert.equal(payload.success, false);
+  assert.match(payload.error, /标题/);
+});
+
+test('handleSubmitFeedback rejects when GitHub feedback token is not configured', async () => {
+  const request = new Request('https://flutter.ombhrum.com/api/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: '按钮点了没反应',
+      description: '设置页反馈按钮没有响应。',
+    }),
+  });
+
+  const response = await handleSubmitFeedback(request, {}, {
+    getUser: async () => null,
+  });
+
+  assert.equal(response.status, 503);
+  const payload = await response.json();
+  assert.equal(payload.success, false);
+});
+
+test('handleSubmitFeedback creates a GitHub issue for valid feedback', async () => {
+  const calls = [];
+  const originalFetch = global.fetch;
+
+  global.fetch = async (url, init = {}) => {
+    calls.push({ url, init });
+
+    if (String(url).endsWith('/labels')) {
+      return new Response(JSON.stringify({ name: 'user-feedback' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (String(url).endsWith('/issues')) {
+      return new Response(JSON.stringify({
+        number: 123,
+        html_url: 'https://github.com/bhrumom/fabushi/issues/123',
+      }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+
+  try {
+    const request = new Request('https://flutter.ombhrum.com/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: '收藏后提示不明显',
+        description: '建议收藏成功后给一个更明确的提示。',
+        contact: 'user@example.com',
+        page: 'settings',
+        platform: 'android',
+        appVersion: '1.0.0+16',
+      }),
+    });
+
+    const response = await handleSubmitFeedback(request, {
+      GITHUB_FEEDBACK_TOKEN: 'token',
+      GITHUB_FEEDBACK_REPO_OWNER: 'bhrumom',
+      GITHUB_FEEDBACK_REPO_NAME: 'fabushi',
+    }, {
+      getUser: async () => null,
+    });
+
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+    assert.equal(payload.issueNumber, 123);
+    assert.equal(calls.length, 2);
+
+    const issueRequestBody = JSON.parse(calls[1].init.body);
+    assert.match(issueRequestBody.title, /^\[反馈\]/);
+    assert.match(issueRequestBody.body, /收藏成功/);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- replace the static settings-page feedback email dialog with an in-app feedback form that collects a title, detailed description, and optional contact info
- add a new Worker-backed `/api/feedback` endpoint that creates a GitHub issue server-side, optionally enriching the issue with the logged-in user identity from the existing auth token
- add focused Worker contract tests for feedback validation, missing-secret behavior, and successful GitHub issue creation

## Why
Right now the app only shows a support email in settings, which makes feedback collection manual and easy to lose. This change turns feedback into a trackable engineering workflow:
- users can submit issues without leaving the app
- feedback lands directly in `bhrumom/fabushi` as a labeled GitHub issue
- the GitHub token stays on the Worker side instead of being exposed in the Flutter client

This is a high-leverage, low-to-medium-risk product and engineering improvement because it shortens the path from user problem to actionable backlog item while fitting the repo’s current Flutter + Cloudflare Worker architecture.

## Main Changes
- `fabushi/lib/screens/settings_screen.dart`
  - convert the existing help/feedback action into a real feedback dialog
  - submit feedback through the existing `ApiClient`
  - pass optional auth so the Worker can attach reporter context when available
- `fabushi/lib/services/worker_config.dart`
  - register the new `submitFeedback` endpoint
- `fabushi/web/src/router.js`
  - route `POST /api/feedback` to the new feedback handler
- `fabushi/web/src/handlers/feedback.js`
  - validate payloads
  - create or reuse the `user-feedback` label
  - create a GitHub issue with the submitted details
  - degrade safely with a clear 503 when the Worker secret is not configured
- `fabushi/web/tests/feedback.test.js`
  - add Worker-level regression coverage for the new feedback flow

## Risk / Impact
- Scope is tightly limited to the settings feedback entry point, one new Worker handler, routing, endpoint config, and one new Worker test file.
- The app still behaves safely if GitHub issue creation is not configured: users get a clear failure message rather than silent data loss.
- This PR introduces one new deployment dependency: the Cloudflare Worker must have `GITHUB_FEEDBACK_TOKEN` configured as a secret before production feedback submissions will succeed.
- No GitHub credential is shipped in the app binary or frontend bundle.

## CI/CD And Deployment Notes
- No GitHub Actions workflow changes were required because the existing `CI` workflow already runs:
  - `flutter analyze`
  - `flutter test`
  - Worker `node --test tests/*.test.js`
  - Wrangler dry-run validation
- This PR strengthens those gates by adding Worker contract coverage for the new feedback handler.
- Deployment follow-up required after merge:
  - configure Cloudflare Worker secret `GITHUB_FEEDBACK_TOKEN`
  - optionally configure `GITHUB_FEEDBACK_REPO_OWNER`, `GITHUB_FEEDBACK_REPO_NAME`, and `GITHUB_FEEDBACK_LABEL` if the defaults should differ

## Validation
- Reviewed the existing settings entry point and confirmed the app already had a `帮助与反馈` slot in `SettingsScreen` that previously only showed a static email address.
- Reviewed the modular Worker router and confirmed the repo already uses Worker endpoints for app-facing APIs, so `/api/feedback` fits the current architecture.
- Added focused Worker tests covering:
  - missing title rejection
  - missing GitHub secret rejection
  - successful labeled GitHub issue creation
- I could not run Flutter or Worker tests locally in this environment because the repository is not available as a normal local checkout here, so final execution is delegated to the existing CI workflow.

## Residual Risk
- Anonymous feedback is still possible, so if spam becomes a problem the next step should add rate limiting, abuse heuristics, or lightweight verification on the Worker side.
- The issue body currently includes only a small context set (`page`, `platform`, optional contact, optional logged-in user info). If support needs richer diagnostics later, device/build metadata can be expanded in a follow-up PR.

## Follow-up
- Configure the production Worker secret so the new endpoint is live after deployment.
- If product wants better triage later, add feedback categories, screenshots, and a dedicated GitHub issue template mapping in a separate PR.
