### PR TITLE
fix: preserve CD release assets during metadata checkout

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
+match = re.search(
+    r"- name: Checkout source for version metadata\n(?P<body>.*?)\n\s*- name: Prepare release assets",
+    workflow,
+    re.DOTALL,
+)
+
+if not match:
+    sys.stderr.write('Could not find the version metadata checkout step in publish-cd-release.yml\n')
+    raise SystemExit(1)
+
+body = match.group('body')
+missing = []
+for required in ('clean: false', 'path: version-metadata'):
+    if required not in body:
+        missing.append(required)
+
+if missing:
+    sys.stderr.write(
+        'publish-cd-release.yml is missing required checkout guardrails: ' + ', '.join(missing) + '\n'
+    )
+    raise SystemExit(1)
+
+print('publish-cd-release checkout guardrails are in place')
+PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,23 @@ jobs:
       - name: Validate Playwright configuration and test discovery
         run: npx playwright test --list
 
+  workflow-guardrails:
+    name: Workflow guardrails
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout workflow files
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.github/workflows/**
+            /.github/scripts/**
+
+      - name: Validate publish release workflow guardrail
+        shell: bash
+        run: .github/scripts/check-publish-cd-release.sh
+
   ci-result:
     name: CI result
     runs-on: ubuntu-latest
@@ -237,6 +254,7 @@ jobs:
       - flutter
       - worker
       - e2e-contract
+      - workflow-guardrails
     if: always()
     steps:
       - name: Check required CI jobs
@@ -255,6 +273,10 @@ jobs:
             echo "E2E contract job failed: ${{ needs.e2e-contract.result }}"
             exit 1
           fi
+          if [ "${{ needs.workflow-guardrails.result }}" != "success" ]; then
+            echo "Workflow guardrails job failed: ${{ needs.workflow-guardrails.result }}"
+            exit 1
+          fi
           echo "All CI checks passed."
 
   notify-ci-failure:
@@ -265,6 +287,7 @@ jobs:
       - flutter
       - worker
       - e2e-contract
+      - workflow-guardrails
       - ci-result
     if: failure()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Validate publish release workflow guardrail
         shell: bash
-        run: .github/scripts/check-publish-cd-release.sh
+        run: bash .github/scripts/check-publish-cd-release.sh
 
   ci-result:
     name: CI result

--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -388,6 +388,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-cd-context.outputs.source_sha }}
+          clean: false
+          path: version-metadata
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /fabushi/pubspec.yaml
@@ -405,8 +407,8 @@ jobs:
           short_sha="${source_sha:0:12}"
 
           app_version="unknown"
-          if [ -f fabushi/pubspec.yaml ]; then
-            app_version="$(awk '/^version:/ {print $2; exit}' fabushi/pubspec.yaml)"
+          if [ -f version-metadata/fabushi/pubspec.yaml ]; then
+            app_version="$(awk '/^version:/ {print $2; exit}' version-metadata/fabushi/pubspec.yaml)"
           fi
           safe_version="$(printf '%s' "$app_version" | tr '+/' '--' | tr -cd '[:alnum:]._-')"
           if [ -z "$safe_version" ] || [ "$safe_version" = "unknown" ]; then


### PR DESCRIPTION
## Summary
- stop `publish-cd-release.yml` from deleting downloaded artifacts before release assembly by isolating the version-metadata checkout under `version-metadata/` and disabling checkout cleanup for that step
- update release asset preparation to read `pubspec.yaml` from the isolated metadata checkout instead of the workspace root
- add a dedicated CI workflow guardrail script and job so future workflow edits fail fast if those checkout protections disappear

## Why
This repository currently has a concrete CI/CD regression on `main`: issue #78 shows the `Publish validated CD packages` job failing in `Prepare release assets` because `built-native-packages/` and `downloaded-cd-artifacts/` are gone by the time the release packaging script runs.

The workflow logs point to one deterministic root cause:
- the job downloads the validated web artifact plus Android and iOS package artifacts
- it then runs `actions/checkout@v4` only to read `fabushi/pubspec.yaml`
- that checkout uses the default `clean: true`, which clears the workspace and removes the directories downloaded earlier in the same job

This is a high-value, low-risk systems fix because it restores the release path without changing app runtime behavior, and it turns a known failing automation path into one protected by CI.

## Main Changes
- `.github/workflows/publish-cd-release.yml`
  - isolate the metadata-only checkout under `version-metadata/`
  - set `clean: false` on that checkout
  - read the version from `version-metadata/fabushi/pubspec.yaml`
- `.github/scripts/check-publish-cd-release.sh`
  - add a small guardrail script that asserts the metadata checkout keeps both `clean: false` and `path: version-metadata`
- `.github/workflows/ci.yml`
  - add a `workflow-guardrails` job to run the new script on PRs, merge queue runs, pushes to `main`, and manual CI dispatches
  - make the overall `CI result` gate depend on the new guardrail job

## Risk / Impact
- Scope is limited to GitHub Actions workflow and guardrail files; no Flutter, Worker, or product code changed.
- The fix is intentionally narrow and only affects how release metadata is checked out during the package publication workflow.
- The new CI job is lightweight and should fail only when the release workflow loses the protections that keep downloaded artifacts intact.

## CI/CD And Quality Gates
- This PR directly fixes a failing production release pipeline path on `main`.
- It also strengthens the existing `CI` workflow by adding a dedicated automated guardrail for this exact regression class.
- No deployment secret or environment changes are required for this fix.

## Validation
- Reviewed current repository state, open PRs, and open failure issues before implementation.
- Confirmed issue #78 and the `Publish validated CD packages` job logs show `find: ‘built-native-packages’: No such file or directory` immediately after the metadata checkout step.
- Matched that failure to the workflow definition, where `actions/checkout@v4` was running after artifact downloads with the default clean behavior.
- Added CI automation that will fail if the release workflow no longer keeps that checkout isolated and non-cleaning.
- I could not execute the repository workflows locally in this environment because the repo is not available as a normal local checkout here, so final end-to-end verification depends on GitHub Actions running this branch.

## Residual Risk
- This PR fixes the package release failure rooted in workspace cleanup, but it does not address the separate production Worker deployment failure still tracked by issue #59.
- The guardrail is intentionally narrow and checks only the protections this failure depended on; broader workflow linting could be added later if CI/CD complexity keeps growing.

## Follow-up
- Re-run or observe the next `Publish CD packages to GitHub Release` workflow to confirm release assets publish successfully and close issue #78.
- If release publishing recovers cleanly, make the production Worker deploy failure from issue #59 the next CI/CD iteration target.
