### PR TITLE
fix: preserve downloaded assets in package release publish job

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -388,6 +388,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-cd-context.outputs.source_sha }}
+          clean: false
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /fabushi/pubspec.yaml


### PR DESCRIPTION
## Summary
- keep the `publish-release` checkout from deleting previously downloaded workflow artifacts
- fix the deterministic package release failure seen in issue #78
- keep the change scoped to one workflow input so the publish path stays easy to reason about

## Root Cause
The failing `Publish validated CD packages` job downloaded:
- the completed CD artifact into `downloaded-cd-artifacts`
- Android packages into `built-native-packages/android`
- iOS packages into `built-native-packages/ios`

It then ran `actions/checkout@v4` with the default `clean: true`. That checkout deleted the runner workspace contents created by the earlier download steps, so `Prepare release assets` later failed with:
- `find: ‘built-native-packages’: No such file or directory`
- `find: ‘downloaded-cd-artifacts’: No such file or directory`

## Fix
- set `clean: false` on the `Checkout source for version metadata` step in `.github/workflows/publish-cd-release.yml`

This preserves the already-downloaded artifacts while still checking out `fabushi/pubspec.yaml` for release naming.

## Risk
- low risk: one workflow field change in the failing job
- does not relax quality gates or skip missing-artifact failures
- does not change artifact naming, release notes generation, or publish semantics

## Validation
- reviewed failed job log `Publish validated CD packages` from run `25304134000`
- verified the failure happened after all artifact downloads succeeded and immediately after the metadata checkout
- verified the existing workflow only needs checkout for `fabushi/pubspec.yaml`, so preserving the downloaded directories is sufficient and directly tied to the observed failure

## Follow-up
- after merge, rerun failed package release workflow run `25304134000` or let the next successful main CD run exercise the fixed path
- if the repo wants stronger guardrails later, a follow-up can add a quick preflight assertion that the expected artifact directories still exist before `Prepare release assets`
