### PR TITLE
ci: harden Android package release repository fallback order

### DIFF
--- a/fabushi/android/build.gradle.kts
+++ b/fabushi/android/build.gradle.kts
@@ -1,25 +1,32 @@
-buildscript {
-    repositories {
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/central") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-        // Fallback for CI when Aliyun mirrors are unreachable
+val preferOfficialReposInCi = System.getenv("GITHUB_ACTIONS") == "true" || System.getenv("CI") == "true"
+
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.configureFabushiBuildscriptRepositories() {
+    if (preferOfficialReposInCi) {
         google()
         mavenCentral()
+    }
+
+    maven { url = uri("https://maven.aliyun.com/repository/google") }
+    maven { url = uri("https://maven.aliyun.com/repository/central") }
+    maven { url = uri("https://maven.aliyun.com/repository/public") }
+    maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
+
+    if (!preferOfficialReposInCi) {
+        google()
+        mavenCentral()
+    }
+}
+
+buildscript {
+    repositories {
+        configureFabushiBuildscriptRepositories()
     }
 }
 
 allprojects {
     buildscript {
         repositories {
-            maven { url = uri("https://maven.aliyun.com/repository/google") }
-            maven { url = uri("https://maven.aliyun.com/repository/central") }
-            maven { url = uri("https://maven.aliyun.com/repository/public") }
-            maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-            // Fallback for CI when Aliyun mirrors are unreachable
-            google()
-            mavenCentral()
+            configureFabushiBuildscriptRepositories()
         }
     }
 }

--- a/fabushi/android/settings.gradle.kts
+++ b/fabushi/android/settings.gradle.kts
@@ -1,3 +1,5 @@
+val preferOfficialReposInCi = System.getenv("GITHUB_ACTIONS") == "true" || System.getenv("CI") == "true"
+
 pluginManagement {
     val flutterSdkPath = run {
         val properties = java.util.Properties()
@@ -18,17 +20,24 @@ pluginManagement {
     }
 
     repositories {
-        // 阿里云镜像源优先（解决 dl.google.com 不可达问题）
+        if (preferOfficialReposInCi) {
+            google()
+            mavenCentral()
+            gradlePluginPortal()
+        }
+
+        // 本地开发默认保留国内镜像优先级；CI 则先试官方源，避免镜像 502 阻塞发包。
         maven { url = uri("https://maven.aliyun.com/repository/google") }
         maven { url = uri("https://maven.aliyun.com/repository/central") }
         maven { url = uri("https://maven.aliyun.com/repository/public") }
         maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-        // 腾讯云镜像
         maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
-        // Fallback for CI when Chinese mirrors are unreachable
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+
+        if (!preferOfficialReposInCi) {
+            google()
+            mavenCentral()
+            gradlePluginPortal()
+        }
     }
 }
 
@@ -37,12 +46,20 @@ dependencyResolutionManagement {
     repositories {
         maven { url = uri("https://storage.flutter-io.cn/download.flutter.io") }
         maven { url = uri("https://jitpack.io") }
+
+        if (preferOfficialReposInCi) {
+            google()
+            mavenCentral()
+        }
+
         maven { url = uri("https://maven.aliyun.com/repository/google") }
         maven { url = uri("https://maven.aliyun.com/repository/central") }
         maven { url = uri("https://maven.aliyun.com/repository/public") }
-        // Fallback for CI when Chinese mirrors are unreachable
-        google()
-        mavenCentral()
+
+        if (!preferOfficialReposInCi) {
+            google()
+            mavenCentral()
+        }
     }
 }
 


### PR DESCRIPTION
## 概要
- 让 GitHub Actions 中的 Android / Gradle 解析优先使用官方 `google()`、`mavenCentral()` 与 `gradlePluginPortal()`
- 保留本地开发当前的国内镜像优先级，避免影响已有开发环境
- 继续把阿里云与腾讯云镜像作为后备源，而不是在 CI 中作为首选源

## 根因
`Publish CD packages to GitHub Release` 最新一次失败 issue #84 的 Android job 日志显示，`flutter build apk --release` / `flutter build appbundle --release` 在解析 Kotlin/Gradle classpath 依赖时，首个命中的仓库是 `https://maven.aliyun.com/repository/google`，并收到 `502 Bad Gateway`。

由于仓库当前把阿里云镜像排在官方源之前，Gradle 会先把该镜像标记为出错并停在仓库解析阶段，导致主线发包在真正编译前就失败。这不是代码回归，而是 CI 对外部镜像可用性的隐式依赖。

## 改动
- `fabushi/android/settings.gradle.kts`
  - 增加 `preferOfficialReposInCi` 判断
  - 在 GitHub Actions / CI 环境里，把 `google()`、`mavenCentral()`、`gradlePluginPortal()` 提前到国内镜像之前
  - 本地非 CI 环境继续保留原有镜像优先顺序
- `fabushi/android/build.gradle.kts`
  - 对 buildscript 仓库解析应用同样的条件顺序，避免插件 classpath 仍先撞到阿里云镜像

## 为什么这样修
- 只调整仓库解析顺序，不改 Flutter / Android 构建产物逻辑，改动面最小
- CI 优先官方源可以直接绕开这次确认过的 502 根因
- 本地开发仍保留现有镜像优先级，避免把 CI 稳定性修复变成开发体验回退
- 即使官方源临时异常，镜像仍然保留为后备路径，不会把仓库锁死在单一仓库

## 验证
- 复核 issue #84 / run `25308679231` 的失败日志，确认第一失效点是阿里云 Maven 仓库返回 `502 Bad Gateway`
- 复核当前 Android Gradle 配置，确认 `settings.gradle.kts` 与 `build.gradle.kts` 都把阿里云仓库放在官方源之前
- 本环境没有现成的仓库工作副本与完整 Android toolchain，无法本地执行 `flutter build`；最终验证交给仓库现有 CI

## 预期结果
- 新 PR 的 `CI` 将覆盖 Android 依赖解析路径
- 修复合入后，下一次 package release 或对 issue #84 对应 run 进行失败作业重跑时，应不再因阿里云 502 在 classpath 解析阶段失败

## 关联
- 处理当前主线阻塞：#84
- 与更早的 package release 历史快照 #78 / #83 区分：本 PR 修的是新的 Android 仓库可用性根因，不是之前已修复的 checkout 清理问题