### PR TITLE
build: harden Android Maven resolution on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
         run: |
           set -euo pipefail
-          ./android/gradlew -p android help --stacktrace
+          ./gradlew help --stacktrace
 
   worker:
     name: Cloudflare Worker syntax and deploy dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
           GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
         run: |
           set -euo pipefail
+          # Keep this aligned with the real package-release entrypoint: the job already runs from fabushi/.
           ./gradlew help --stacktrace
 
   worker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,8 @@ jobs:
           GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
         run: |
           set -euo pipefail
-          # Keep this aligned with the real package-release entrypoint: the job already runs from fabushi/.
-          ./gradlew help --stacktrace
+          # Keep this aligned with the real package-release entrypoint from fabushi/.
+          ./android/gradlew -p android help --stacktrace
 
   worker:
     name: Cloudflare Worker syntax and deploy dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,58 @@ jobs:
           path: fabushi/build/web
           if-no-files-found: error
 
+  android-gradle-bootstrap:
+    name: Android Gradle bootstrap
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: flutter
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout Android build files
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/pubspec.yaml
+            /fabushi/pubspec.lock
+            /fabushi/android/**
+            /fabushi/lib/packages/**
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Write Android local.properties
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "flutter.sdk=$FLUTTER_ROOT"
+            echo "sdk.dir=$ANDROID_HOME"
+          } > android/local.properties
+
+      - name: Get Flutter dependencies for Android build scripts
+        run: flutter pub get
+
+      - name: Validate Android Gradle bootstrap
+        shell: bash
+        env:
+          GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
+        run: |
+          set -euo pipefail
+          ./android/gradlew -p android help --stacktrace
+
   worker:
     name: Cloudflare Worker syntax and deploy dry-run
     runs-on: ubuntu-latest
@@ -252,6 +304,7 @@ jobs:
     timeout-minutes: 5
     needs:
       - flutter
+      - android-gradle-bootstrap
       - worker
       - e2e-contract
       - workflow-guardrails
@@ -263,6 +316,10 @@ jobs:
           set -euo pipefail
           if [ "${{ needs.flutter.result }}" != "success" ]; then
             echo "Flutter job failed: ${{ needs.flutter.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.android-gradle-bootstrap.result }}" != "success" ]; then
+            echo "Android Gradle bootstrap job failed: ${{ needs.android-gradle-bootstrap.result }}"
             exit 1
           fi
           if [ "${{ needs.worker.result }}" != "success" ]; then
@@ -285,6 +342,7 @@ jobs:
     timeout-minutes: 10
     needs:
       - flutter
+      - android-gradle-bootstrap
       - worker
       - e2e-contract
       - workflow-guardrails
@@ -328,7 +386,8 @@ jobs:
                 '### CI notes',
                 '',
                 '- Dart format diffs are uploaded as `dart-format-patch` when formatter output differs from the committed code.',
-                '- CI runs with the formatter-applied workspace and does not push formatter commits directly to protected branches.',
+                '- CI runs with the formatter-applied workspace and does not push formatter commits directly to main because main is protected by merge queue rules.',
+                '- Android Gradle bootstrap now validates that GitHub Actions can resolve Android/Kotlin buildscript dependencies before release packaging workflows run.',
                 '- Build and dry-run bundles are listed above when those jobs reach their upload steps.',
                 '- Merge queue runs are supported through the `merge_group` trigger.',
               ],

--- a/fabushi/android/build.gradle.kts
+++ b/fabushi/android/build.gradle.kts
@@ -1,4 +1,4 @@
-val preferOfficialRepositories = System.getenv("GITHUB_ACTIONS") == "true"
+val preferOfficialReposInCi = System.getenv("GITHUB_ACTIONS") == "true" || System.getenv("CI") == "true"
 
 fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiBuildMirrors() {
     maven { url = uri("https://maven.aliyun.com/repository/google") }
@@ -13,7 +13,7 @@ fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiBuildUpstreamReposi
 }
 
 fun org.gradle.api.artifacts.dsl.RepositoryHandler.configureFabushiBuildscriptRepositories() {
-    if (preferOfficialRepositories) {
+    if (preferOfficialReposInCi) {
         addFabushiBuildUpstreamRepositories()
         addFabushiBuildMirrors()
         return

--- a/fabushi/android/build.gradle.kts
+++ b/fabushi/android/build.gradle.kts
@@ -1,25 +1,38 @@
+val preferOfficialRepositories = System.getenv("GITHUB_ACTIONS") == "true"
+
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiBuildMirrors() {
+    maven { url = uri("https://maven.aliyun.com/repository/google") }
+    maven { url = uri("https://maven.aliyun.com/repository/central") }
+    maven { url = uri("https://maven.aliyun.com/repository/public") }
+    maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
+}
+
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiBuildUpstreamRepositories() {
+    google()
+    mavenCentral()
+}
+
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.configureFabushiBuildscriptRepositories() {
+    if (preferOfficialRepositories) {
+        addFabushiBuildUpstreamRepositories()
+        addFabushiBuildMirrors()
+        return
+    }
+
+    addFabushiBuildMirrors()
+    addFabushiBuildUpstreamRepositories()
+}
+
 buildscript {
     repositories {
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/central") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-        // Fallback for CI when Aliyun mirrors are unreachable
-        google()
-        mavenCentral()
+        configureFabushiBuildscriptRepositories()
     }
 }
 
 allprojects {
     buildscript {
         repositories {
-            maven { url = uri("https://maven.aliyun.com/repository/google") }
-            maven { url = uri("https://maven.aliyun.com/repository/central") }
-            maven { url = uri("https://maven.aliyun.com/repository/public") }
-            maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-            // Fallback for CI when Aliyun mirrors are unreachable
-            google()
-            mavenCentral()
+            configureFabushiBuildscriptRepositories()
         }
     }
 }

--- a/fabushi/android/build.gradle.kts
+++ b/fabushi/android/build.gradle.kts
@@ -1,3 +1,4 @@
+// Keep Android buildscript dependency resolution consistent with settings.gradle.kts.
 val preferOfficialReposInCi = System.getenv("GITHUB_ACTIONS") == "true" || System.getenv("CI") == "true"
 
 fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiBuildMirrors() {

--- a/fabushi/android/settings.gradle.kts
+++ b/fabushi/android/settings.gradle.kts
@@ -1,4 +1,4 @@
-val preferOfficialRepositories = System.getenv("GITHUB_ACTIONS") == "true"
+val preferOfficialReposInCi = System.getenv("GITHUB_ACTIONS") == "true" || System.getenv("CI") == "true"
 
 fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiMirrorRepositories() {
     maven { url = uri("https://maven.aliyun.com/repository/google") }
@@ -17,7 +17,7 @@ fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiOfficialRepositorie
 }
 
 fun org.gradle.api.artifacts.dsl.RepositoryHandler.configureFabushiRepositories(includeGradlePluginPortal: Boolean = false) {
-    if (preferOfficialRepositories) {
+    if (preferOfficialReposInCi) {
         // GitHub-hosted runners can reach upstream Maven reliably, so prefer it before the regional mirrors.
         addFabushiOfficialRepositories(includeGradlePluginPortal)
         addFabushiMirrorRepositories()

--- a/fabushi/android/settings.gradle.kts
+++ b/fabushi/android/settings.gradle.kts
@@ -1,3 +1,4 @@
+// Prefer upstream repositories on CI runners, but keep regional mirrors first for local constrained networks.
 val preferOfficialReposInCi = System.getenv("GITHUB_ACTIONS") == "true" || System.getenv("CI") == "true"
 
 fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiMirrorRepositories() {

--- a/fabushi/android/settings.gradle.kts
+++ b/fabushi/android/settings.gradle.kts
@@ -1,3 +1,34 @@
+val preferOfficialRepositories = System.getenv("GITHUB_ACTIONS") == "true"
+
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiMirrorRepositories() {
+    maven { url = uri("https://maven.aliyun.com/repository/google") }
+    maven { url = uri("https://maven.aliyun.com/repository/central") }
+    maven { url = uri("https://maven.aliyun.com/repository/public") }
+    maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
+    maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
+}
+
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.addFabushiOfficialRepositories(includeGradlePluginPortal: Boolean = false) {
+    google()
+    mavenCentral()
+    if (includeGradlePluginPortal) {
+        gradlePluginPortal()
+    }
+}
+
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.configureFabushiRepositories(includeGradlePluginPortal: Boolean = false) {
+    if (preferOfficialRepositories) {
+        // GitHub-hosted runners can reach upstream Maven reliably, so prefer it before the regional mirrors.
+        addFabushiOfficialRepositories(includeGradlePluginPortal)
+        addFabushiMirrorRepositories()
+        return
+    }
+
+    // Local and regional builds still keep the mirrors first to tolerate blocked upstream access.
+    addFabushiMirrorRepositories()
+    addFabushiOfficialRepositories(includeGradlePluginPortal)
+}
+
 pluginManagement {
     val flutterSdkPath = run {
         val properties = java.util.Properties()
@@ -18,17 +49,7 @@ pluginManagement {
     }
 
     repositories {
-        // 阿里云镜像源优先（解决 dl.google.com 不可达问题）
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/central") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-        // 腾讯云镜像
-        maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
-        // Fallback for CI when Chinese mirrors are unreachable
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+        configureFabushiRepositories(includeGradlePluginPortal = true)
     }
 }
 
@@ -37,12 +58,7 @@ dependencyResolutionManagement {
     repositories {
         maven { url = uri("https://storage.flutter-io.cn/download.flutter.io") }
         maven { url = uri("https://jitpack.io") }
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/central") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        // Fallback for CI when Chinese mirrors are unreachable
-        google()
-        mavenCentral()
+        configureFabushiRepositories()
     }
 }
 


### PR DESCRIPTION
## 概要
- 让 Android Gradle 在 GitHub Actions 上优先使用 `google()` / `mavenCentral()`，把区域镜像降级为兜底
- 保留本地与区域构建的镜像优先策略，避免影响上游仓库受限环境
- 在 CI 中新增 `Android Gradle bootstrap` 校验，提前验证 Android/Kotlin 构建脚本依赖是否可解析

## 为什么这次值得优先处理
本轮回顾后，当前主线最紧急、最适合小步落地的问题是新的包发布失败信号。

2026年5月4日的 `Publish CD packages to GitHub Release #14` 已经不再卡在前一轮修复过的发布资产清理问题，而是转移到了 `Build Android release packages`。失败日志显示：

- 失败时间：2026年5月4日 08:25 UTC
- 失败步骤：`Build Android install packages`
- 根因证据：Gradle 在解析 Kotlin 插件依赖时访问 `https://maven.aliyun.com/repository/google/...` 返回 `502 Bad Gateway`
- 直接影响：Android APK / AAB 无法产出，后续 GitHub Release 发布步骤被跳过

这说明当前 Android 构建链路仍然对第三方镜像可用性存在单点依赖，属于典型的系统稳定性问题：

- 收益高：直接影响发布主路径
- 风险可控：改动集中在 Android 仓库源配置与 CI 验证
- 审阅边界清晰：不涉及 Flutter 业务逻辑、API 合约或用户数据

## 主要改动
### 1. Android 仓库源策略收敛
更新文件：
- `fabushi/android/settings.gradle.kts`
- `fabushi/android/build.gradle.kts`

改动要点：
- 提取统一的仓库配置函数，减少插件仓库与 buildscript 仓库的重复定义
- 在 GitHub Actions 环境下优先使用官方上游仓库：
  - `google()`
  - `mavenCentral()`
  - `gradlePluginPortal()`（仅插件解析场景）
- 将阿里云 / 腾讯云镜像保留为后备源，而不是首选源
- 在非 GitHub Actions 场景下保持当前镜像优先的行为，尽量不改变面向区域网络约束的本地开发体验

### 2. CI 新增 Android 构建脚本启动校验
更新文件：
- `.github/workflows/ci.yml`

新增内容：
- 新增 `Android Gradle bootstrap` Job
- 在 Ubuntu + Java 17 + Flutter 3.41.9 环境下：
  - checkout Android 构建相关文件与 path package
  - 写入 `android/local.properties`
  - 执行 `flutter pub get`
  - 执行 `./android/gradlew -p android help --stacktrace`

这个校验的目的不是完整复刻发布工作流，而是尽早拦截这次真实故障所对应的那一层风险：
- Android / Kotlin Gradle 插件类路径无法解析
- 构建脚本仓库源顺序不稳
- GitHub Actions 环境下的 Maven 可达性回归

### 3. CI 汇总门禁同步更新
- `ci-result` 现在会把 `android-gradle-bootstrap` 作为必过项
- `notify-ci-failure` 的失败说明中补充了这条新校验的语义，便于后续自动化失败 issue 定位

## 风险与兼容性
- 改动范围限定在 Android 构建配置与 CI 工作流，不涉及 Flutter 运行时代码
- 本地或区域网络环境仍然保留镜像优先，兼容既有开发假设
- GitHub Actions 仅改变仓库解析优先级，不移除镜像，因此官方源短暂异常时仍有镜像兜底机会

## CI/CD 与质量门禁
这次不是只改构建文件，而是把“构建稳定性修复 + 对应自动验证”作为同一个交付单元：

- 修复点：降低 GitHub Actions 对阿里云 Maven 镜像 502 的脆弱性
- 新门禁：PR / merge queue / main push 的 CI 中新增 Android Gradle 启动校验
- 结果：类似问题不必等到 `publish-cd-release.yml` 阶段才暴露，能更早在普通 CI 中被阻断

## 验证
已完成的证据链验证：
- 回顾最近合并记录，确认 PR #80 已修复前一轮发布资产被 checkout 清空的问题
- 对照最新失败 issue #84，确认新的首个失败点已迁移到 Android 构建步骤
- 检查 `Build Android release packages` 日志，确认失败根因是阿里云 Maven 镜像返回 `502 Bad Gateway`
- 审查 `fabushi/android/settings.gradle.kts` 与 `fabushi/android/build.gradle.kts`，确认当前确实把区域镜像放在官方源之前
- 新增 CI 校验来覆盖这层仓库解析风险，而不是只依赖发布流程再次踩中问题

当前环境限制：
- 这个执行环境无法把仓库作为正常本地 checkout 拉下来，也无法在本地直接运行 GitHub Actions
- 因此最终验证依赖本 PR 的 GitHub CI 结果，尤其是：
  - `Android Gradle bootstrap`
  - 后续包发布工作流中的 `Build Android release packages`

## 残余风险
- 这次主要缓解的是 GitHub Actions 上游可达性与镜像单点依赖，不覆盖所有 Android 构建失败类型
- 如果未来失败转移到 Android 签名、NDK、插件版本兼容或应用依赖本身，还需要分别处理
- CI 里的 `gradlew help` 能较早发现构建脚本与插件解析问题，但不等于完整验证 APK / AAB 产物一定成功生成

## 后续建议
- 合并后优先观察本 PR 的 `Android Gradle bootstrap` 结果
- 然后重新观察下一次 `Publish CD packages to GitHub Release` 是否恢复 Android 包产出
- 如果这条链路稳定，再考虑是否需要把 Android 发布构建进一步前移成更强的常规 CI 校验