### PR TITLE
fix: stabilize GitHub Release publishing from package workflow

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -477,26 +477,29 @@ jobs:
             echo ""
             echo "## Integrity"
             echo ""
-            echo "SHA-256 checksums are attached in `SHA256SUMS.txt`."
+            echo 'SHA-256 checksums are attached in `SHA256SUMS.txt`.'
           } > release-notes.md
 
       - name: Publish GitHub Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_REPO: ${{ github.repository }}
           TAG: ${{ steps.release-assets.outputs.tag }}
           TITLE: ${{ steps.release-assets.outputs.title }}
           SOURCE_SHA: ${{ steps.release-assets.outputs.source_sha }}
         run: |
           set -euo pipefail
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          if gh release view "$TAG" --repo "$RELEASE_REPO" >/dev/null 2>&1; then
             gh release edit "$TAG" \
+              --repo "$RELEASE_REPO" \
               --title "$TITLE" \
               --notes-file release-notes.md \
               --target "$SOURCE_SHA" \
               --latest
           else
             gh release create "$TAG" release-assets/* \
+              --repo "$RELEASE_REPO" \
               --title "$TITLE" \
               --notes-file release-notes.md \
               --target "$SOURCE_SHA" \
@@ -504,7 +507,7 @@ jobs:
             exit 0
           fi
 
-          gh release upload "$TAG" release-assets/* --clobber
+          gh release upload "$TAG" release-assets/* --repo "$RELEASE_REPO" --clobber
 
       - name: Write release summary
         shell: bash


### PR DESCRIPTION
## 概要
- 修复 `Publish validated CD packages` 在非仓库工作目录里调用 `gh release` 导致的发布失败
- 修复 release notes 生成时把 `` `SHA256SUMS.txt` `` 当成 shell 命令替换执行的脚本瑕疵
- 继续把主线发包链路往 GitHub Release 闭环推进

## 根因
主分支 package release issue `#92` 对应的失败日志已经表明，`#89` 合并后 Android APK/AAB 与 signed iOS IPA 都已成功产出，新的第一失败点已经移动到发布步骤本身：
- `Publish GitHub Release` 中直接运行 `gh release view/create/upload`，但该 step 的当前工作目录不是一个 git 仓库
- 日志明确报错：`failed to run git: fatal: not a git repository (or any of the parent directories): .git`
- 同一 job 的 `Prepare release assets` 还触发了 ``SHA256SUMS.txt: command not found``，原因是 shell 把反引号当成命令替换执行

这说明主线真正的新阻塞不再是 Android 构建，也不是 iOS/TestFlight，而是 release workflow 对执行上下文的隐式依赖。

## 改动
- 在 `gh release view/edit/create/upload` 全部显式传入 `--repo "$GITHUB_REPOSITORY"`，去掉对当前目录必须是 git 仓库的隐式假设
- 把 release notes 中的校验文件说明改为单引号包裹，避免 shell 命令替换误执行

## 为什么这样修
这次不是补一次性的环境绕路，而是把发布动作改成对工作目录无关、对 runner 布局无关的显式仓库目标调用。这样即使后续继续使用 metadata-only sparse checkout，发布步骤也不会再因为 cwd 不是仓库根而失败。

## 验证
- 已重新核对 issue `#92` 对应 workflow run `25332777496` 的失败 job `74273676380`
- 失败日志与本次修复一一对应：
  - `failed to run git: fatal: not a git repository...`
  - `SHA256SUMS.txt: command not found`
- 这条 PR 本身会重新走现有 `CI` / `Native smoke` 验证；合并后还需要继续观察主分支下一次 `Publish CD packages to GitHub Release` 是否真正产出 GitHub Release

## 后续推进
- 这条 PR 绿灯后立即合并
- 合并后继续跟踪主分支 package release、GitHub Release 与 TestFlight 链路，直到 issue `#92` 拿到明确最终结果
