### PR TITLE
ci: persist TestFlight upload status in package releases

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -214,6 +214,12 @@ jobs:
               echo "- APP_STORE_CONNECT_API_ISSUER_ID"
               echo "- APP_STORE_CONNECT_API_KEY_BASE64"
             } > ../ios-release-assets/IOS_SIGNING_NOT_CONFIGURED.txt
+            {
+              echo "status=skipped"
+              echo "reason=ios_signing_not_configured"
+              echo "source_sha=${{ needs.resolve-cd-context.outputs.source_sha }}"
+              echo "uploaded_at="
+            } > ../ios-release-assets/TESTFLIGHT_UPLOAD_STATUS.txt
             echo "configured=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -321,7 +327,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          status_file="../ios-release-assets/TESTFLIGHT_UPLOAD_STATUS.txt"
           if [ -z "${APP_STORE_CONNECT_API_KEY_ID:-}" ] || [ -z "${APP_STORE_CONNECT_API_ISSUER_ID:-}" ] || [ -z "${APP_STORE_CONNECT_API_KEY_BASE64:-}" ]; then
+            {
+              echo "status=skipped"
+              echo "reason=app_store_connect_credentials_not_configured"
+              echo "source_sha=${{ needs.resolve-cd-context.outputs.source_sha }}"
+              echo "uploaded_at="
+            } > "$status_file"
             echo "App Store Connect credentials are not configured; iOS IPA will be attached to GitHub Release only."
             exit 0
           fi
@@ -336,11 +349,27 @@ jobs:
             exit 1
           fi
 
-          xcrun altool --upload-app \
+          if xcrun altool --upload-app \
             --type ios \
             --file "$ipa_path" \
             --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
-            --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+            --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"; then
+            {
+              echo "status=uploaded"
+              echo "reason=accepted_by_app_store_connect"
+              echo "source_sha=${{ needs.resolve-cd-context.outputs.source_sha }}"
+              echo "uploaded_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            } > "$status_file"
+          else
+            status=$?
+            {
+              echo "status=failed"
+              echo "reason=app_store_connect_upload_failed"
+              echo "source_sha=${{ needs.resolve-cd-context.outputs.source_sha }}"
+              echo "uploaded_at="
+            } > "$status_file"
+            exit "$status"
+          fi
 
       - name: Upload iOS release package artifact
         if: always()
@@ -440,6 +469,12 @@ jobs:
             esac
           done < <(find built-native-packages downloaded-cd-artifacts -type f)
 
+          for metadata_file in TESTFLIGHT_UPLOAD_STATUS.txt IOS_SIGNING_NOT_CONFIGURED.txt; do
+            if [ -f "built-native-packages/ios/$metadata_file" ]; then
+              cp "built-native-packages/ios/$metadata_file" "release-assets/$metadata_file"
+            fi
+          done
+
           if [ -z "$(find release-assets -type f -print -quit)" ]; then
             echo "No release package files were found or built." >&2
             echo "Expected validated web artifact, Android APK/AAB, iOS IPA, or native package files such as .dmg, .msix, .deb, .rpm, .AppImage, .zip, .tar.gz." >&2
@@ -473,6 +508,27 @@ jobs:
               echo "- Signed iOS IPA is attached."
             else
               echo "- iOS IPA was skipped because signing secrets are not configured or no IPA was produced."
+            fi
+            if [ -f release-assets/TESTFLIGHT_UPLOAD_STATUS.txt ]; then
+              tf_status="$(awk -F= '$1 == "status" { print $2 }' release-assets/TESTFLIGHT_UPLOAD_STATUS.txt)"
+              tf_reason="$(awk -F= '$1 == "reason" { print $2 }' release-assets/TESTFLIGHT_UPLOAD_STATUS.txt)"
+              tf_uploaded_at="$(awk -F= '$1 == "uploaded_at" { print $2 }' release-assets/TESTFLIGHT_UPLOAD_STATUS.txt)"
+              case "$tf_status" in
+                uploaded)
+                  echo "- TestFlight upload: uploaded${tf_uploaded_at:+ at $tf_uploaded_at}."
+                  ;;
+                skipped)
+                  echo "- TestFlight upload: skipped ($tf_reason)."
+                  ;;
+                failed)
+                  echo "- TestFlight upload: failed ($tf_reason)."
+                  ;;
+                *)
+                  echo "- TestFlight upload: status recorded in TESTFLIGHT_UPLOAD_STATUS.txt."
+                  ;;
+              esac
+            else
+              echo "- TestFlight upload: no explicit status artifact was generated."
             fi
             echo ""
             echo "## Integrity"


### PR DESCRIPTION
## 概要
- 给 `publish-cd-release.yml` 的 iOS 上传步骤补一份持久化的 `TESTFLIGHT_UPLOAD_STATUS.txt`
- 在 GitHub Release 资产与 release notes 里显式记录 TestFlight 上传是已成功、已跳过还是失败
- 保留 `IOS_SIGNING_NOT_CONFIGURED.txt` 作为签名缺失时的旁证，一起进入 release 资产

## 为什么要做
当前主线已经有 GitHub Release 成功证据，但 TestFlight 这段虽然流程里会尝试上传，仓库里没有稳定、可复核的成功凭证。这样会带来两个问题：
- 发布门禁里很难自动证明“这次 IPA 确实已经进了 TestFlight”
- 如果上传被跳过，只能回看运行日志，后续很难快速区分是凭证缺失、签名未配置还是已经成功

这次改动不是新增功能，而是补发布链路的可验证性，让后续每次 package release 都能直接给出 TestFlight 状态证据。

## 具体改动
- iOS signing 未配置时，写出 `TESTFLIGHT_UPLOAD_STATUS.txt`，状态为 `skipped`
- App Store Connect 凭证缺失时，写出 `TESTFLIGHT_UPLOAD_STATUS.txt`，状态为 `skipped`
- `xcrun altool` 上传成功后，写出 `TESTFLIGHT_UPLOAD_STATUS.txt`，状态为 `uploaded`，并记录 UTC 时间戳
- 如果上传失败，在失败前也写出 `TESTFLIGHT_UPLOAD_STATUS.txt`，状态为 `failed`
- package release 组装资产时，把 `TESTFLIGHT_UPLOAD_STATUS.txt` 与 `IOS_SIGNING_NOT_CONFIGURED.txt` 一并纳入 `release-assets`
- release notes 会直接摘要 TestFlight 状态，而不是要求后续人工翻 Actions 日志

## 风险与范围
- 只改 `.github/workflows/publish-cd-release.yml`
- 不改应用代码，不改变 Android / Flutter / Worker 行为
- 成功路径仍然保持原有发包逻辑，只是额外留下状态证据

## 验证目标
- PR 现有 CI 绿灯
- 合并后下一次主线 package release 产物中出现 `TESTFLIGHT_UPLOAD_STATUS.txt`
- release notes 中能直接看到 TestFlight 上传状态
- 如果仓库凭证齐全，就能把“TestFlight 已上传”的证据留在 release 产物里，而不是只存在于临时日志
