### PR TITLE
ci: guard TestFlight release evidence wiring

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -7,27 +7,40 @@ import re
 import sys
 
 workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
-match = re.search(
+
+checkout_match = re.search(
     r"- name: Checkout source for version metadata\n(?P<body>.*?)\n\s*- name: Prepare release assets",
     workflow,
     re.DOTALL,
 )
-
-if not match:
+if not checkout_match:
     sys.stderr.write('Could not find the version metadata checkout step in publish-cd-release.yml\n')
     raise SystemExit(1)
 
-body = match.group('body')
+checkout_body = checkout_match.group('body')
 missing = []
 for required in ('clean: false', 'path: version-metadata'):
-    if required not in body:
+    if required not in checkout_body:
+        missing.append(required)
+
+release_asset_requirements = (
+    'TESTFLIGHT_UPLOAD_STATUS.txt',
+    'IOS_SIGNING_NOT_CONFIGURED.txt',
+    'TestFlight upload:',
+    'accepted_by_app_store_connect',
+    'app_store_connect_upload_failed',
+    'app_store_connect_credentials_not_configured',
+    'ios_signing_not_configured',
+)
+for required in release_asset_requirements:
+    if required not in workflow:
         missing.append(required)
 
 if missing:
     sys.stderr.write(
-        'publish-cd-release.yml is missing required checkout guardrails: ' + ', '.join(missing) + '\n'
+        'publish-cd-release.yml is missing required release guardrails: ' + ', '.join(missing) + '\n'
     )
     raise SystemExit(1)
 
-print('publish-cd-release checkout guardrails are in place')
+print('publish-cd-release checkout and TestFlight evidence guardrails are in place')
 PY


### PR DESCRIPTION
## 概要
- 扩展现有 `check-publish-cd-release.sh`，把新加的 TestFlight 证据链也纳入 CI guardrail
- 继续保持原有 `clean: false` / `path: version-metadata` 校验
- 防止 `TESTFLIGHT_UPLOAD_STATUS.txt`、release notes 摘要或关键状态原因在后续改动里悄悄丢失

## 为什么要做
刚刚主线已经通过 `#94` 把 TestFlight 上传状态正式固化进 GitHub Release 资产和 release notes，最新 release `v1.0.0-16-cd.ca0032af5780` 也已经留下了可复核证据。

下一步最值当的小步升级，不是再改发布逻辑本身，而是给这条新证据链补一层自动守护，避免未来有人修改 `publish-cd-release.yml` 时把这些关键线索不小心删掉，而 CI 却没有第一时间拦住。

## 具体改动
- `check-publish-cd-release.sh` 继续验证 metadata checkout guardrail：
  - `clean: false`
  - `path: version-metadata`
- 新增 release 证据 guardrail，要求 workflow 中仍然存在：
  - `TESTFLIGHT_UPLOAD_STATUS.txt`
  - `IOS_SIGNING_NOT_CONFIGURED.txt`
  - release notes 里的 `TestFlight upload:` 摘要
  - 关键状态原因：
    - `accepted_by_app_store_connect`
    - `app_store_connect_upload_failed`
    - `app_store_connect_credentials_not_configured`
    - `ios_signing_not_configured`

## 风险与范围
- 只改 `.github/scripts/check-publish-cd-release.sh`
- 不改应用代码，不改现有发包成功路径
- 这是纯 guardrail 加强，目标是更早暴露工作流回归

## 验证
- 该脚本已经被现有 `CI` workflow 的 `Workflow guardrails` job 调用
- PR 绿灯即可证明这层新约束与当前主线 workflow 一致
- 合并后如果未来有人删掉 TestFlight 证据链中的关键 wiring，CI 会直接失败而不是等到 release 门禁复发
