### PR TITLE
ci: move the main CI workflow off Node 20 action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: fabushi
     steps:
       - name: Checkout project files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload Dart formatting patch
         if: ${{ steps.dart-format.outputs.changed == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dart-format-patch
           path: fabushi/dart-format.patch
@@ -142,7 +142,7 @@ jobs:
           test -s /tmp/fabushi-smoke.png
 
       - name: Upload Flutter web build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: flutter-web-build
           path: fabushi/build/web
@@ -158,7 +158,7 @@ jobs:
         working-directory: fabushi
     steps:
       - name: Checkout Android build files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -167,7 +167,7 @@ jobs:
             !/fabushi/web/assets/built_in/**
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -212,7 +212,7 @@ jobs:
         working-directory: fabushi/web
     steps:
       - name: Checkout Worker files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -220,13 +220,13 @@ jobs:
             !/fabushi/web/assets/built_in/**
 
       - name: Download Flutter web build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: flutter-web-build
           path: fabushi/build/web
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -251,7 +251,7 @@ jobs:
         run: npx --yes wrangler@latest deploy --dry-run --outdir ../../worker-dry-run
 
       - name: Upload Worker dry-run bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: worker-dry-run-bundle
           path: worker-dry-run
@@ -266,14 +266,14 @@ jobs:
         working-directory: fabushi/e2e
     steps:
       - name: Checkout E2E files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /fabushi/e2e/**
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -289,7 +289,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout workflow files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -352,14 +352,14 @@ jobs:
     if: failure()
     steps:
       - name: Checkout failure notifier
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /.github/scripts/**
 
       - name: Create or update detailed CI failure issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           SOURCE_REF: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref || github.ref_name }}


### PR DESCRIPTION
## 概要
- 只修改主线 `CI` workflow 中的官方 GitHub Actions 版本
- 把仍停在 Node 20 action runtime 的核心 action 升到官方已支持 Node 24 的主版本
- 不改应用代码，不改 CI job 结构和业务校验逻辑

## 为什么现在做
主线发布门禁已经重新闭环，当前没有打开的 PR 或 Issue 阻塞合并、构建、发布、GitHub Release 或 TestFlight。

在这种状态下，最值当的一小步不是再动发布逻辑，而是提前消除一个已经明确出现的平台侧风险：主线工作流此前已经暴露出 GitHub JavaScript actions 的 Node 20 runtime 弃用告警。如果继续拖着不处理，后面很容易从“告警”变成真正的 CI/CD 阻塞。

这条 PR 先收敛到最核心的 `CI` workflow，让 merge gate 先离开 Node 20 runtime，再继续看是否需要把同类升级扩展到其他较低频 workflow。

## 改动
- `actions/checkout`：`v4` -> `v5`
- `actions/setup-java`：`v4` -> `v5`
- `actions/setup-node`：`v4` -> `v6`
- `actions/download-artifact`：`v4` -> `v5`
- `actions/upload-artifact`：`v4` -> `v7`
- `actions/github-script`：`v7` -> `v8`

## 风险与范围
- 只改 `.github/workflows/ci.yml`
- 不改 Flutter / Android / Worker / Playwright 的具体命令
- 这是 workflow runtime 升级，不是行为重构

## 验证
- 观察这条 PR 自身的 `CI` 是否继续绿灯
- 重点确认以下 job 行为未回归：
  - `Flutter quality, tests, build, and web smoke`
  - `Android Gradle bootstrap`
  - `Cloudflare Worker syntax and deploy dry-run`
  - `Playwright E2E contract validation`
  - `Workflow guardrails`
- 如果这条 PR 绿灯，再决定是否继续把同类 Node 24 runtime 升级扩展到 `CD` / `publish-cd-release` 等低频 workflow