### PR TITLE
feat: report startup crashes through in-app GitHub feedback

### DIFF
--- a/fabushi/lib/main.dart
+++ b/fabushi/lib/main.dart
@@ -1,121 +1,147 @@
-import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
-import 'package:provider/provider.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'package:window_manager/window_manager.dart';
+import 'dart:async';
 import 'dart:io';
-import 'firebase_options.dart';
-import 'core/di/injection.dart';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:window_manager/window_manager.dart';
+
 import 'core/config/app_config.dart';
+import 'core/design_system/app_theme.dart';
+import 'core/di/injection.dart';
+import 'core/video_feed_di/video_feed_injector.dart';
+import 'firebase_options.dart';
 import 'l10n/app_localizations.dart';
-import 'models/file_transfer_model.dart';
-import 'models/settings_model.dart';
 import 'models/auth_model.dart';
 import 'models/country_sending_model.dart';
+import 'models/file_transfer_model.dart';
 import 'models/leaderboard_model.dart';
-import 'services/app_initializer.dart';
-import 'widgets/app_wrapper.dart';
-import 'screens/douyin_login_screen.dart';
-import 'core/video_feed_di/video_feed_injector.dart';
-import 'core/design_system/app_theme.dart';
-import 'providers/video_feed_visibility_notifier.dart';
+import 'models/settings_model.dart';
 import 'providers/tts_mute_notifier.dart';
+import 'providers/video_feed_visibility_notifier.dart';
+import 'screens/douyin_login_screen.dart';
+import 'services/app_initializer.dart';
+import 'services/error_report_service.dart';
+import 'widgets/app_wrapper.dart';
 
-void main() async {
+Future<void> main() async {
   debugPrint(
     '🚀 [main] App starting... WidgetsFlutterBinding.ensureInitialized()',
   );
   WidgetsFlutterBinding.ensureInitialized();
+  await ErrorReportService.instance.initializeGlobalHandlers();
 
-  // 初始化依赖注入
-  debugPrint('🚀 [main] setupDependencies() begin');
-  setupDependencies();
-  debugPrint('🚀 [main] setupDependencies() done');
+  await runZonedGuarded(() async {
+    // 初始化依赖注入
+    debugPrint('🚀 [main] setupDependencies() begin');
+    setupDependencies();
+    debugPrint('🚀 [main] setupDependencies() done');
 
-  // 打印配置信息（仅调试模式）
-  if (kDebugMode) {
-    AppConfig.printConfigInfo();
-  }
-
-  // 桌面平台设置（Web跳过）
-  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
-    await windowManager.ensureInitialized();
-    await windowManager.setMaximizable(false);
-    await windowManager.setResizable(false);
-    await windowManager.maximize();
-  }
-
-  // Firebase初始化（Web平台延迟初始化以优化首屏速度）
-  if (!kIsWeb) {
-    try {
-      // 检查是否已初始化，避免重复初始化
-      if (Firebase.apps.isEmpty) {
-        debugPrint('🚀 [main] Firebase.initializeApp() begin');
-        await Firebase.initializeApp(
-          options: DefaultFirebaseOptions.currentPlatform,
-        ).timeout(
-          const Duration(seconds: 5),
-          onTimeout: () {
-            debugPrint('⚠️ [main] Firebase初始化超时 (5s)');
-            return null as dynamic;
-          },
-        );
-        debugPrint('✅ [main] Firebase初始化成功');
-      } else {
-        debugPrint('✅ [main] Firebase已初始化，跳过');
-      }
-    } catch (e) {
-      debugPrint('⚠️ [main] Firebase初始化失败: $e');
+    // 打印配置信息（仅调试模式）
+    if (kDebugMode) {
+      AppConfig.printConfigInfo();
     }
-  } else {
-    // Web平台：延迟Firebase初始化到用户交互后
-    Future.delayed(const Duration(seconds: 2), () async {
+
+    // 桌面平台设置（Web跳过）
+    if (!kIsWeb &&
+        (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+      await windowManager.ensureInitialized();
+      await windowManager.setMaximizable(false);
+      await windowManager.setResizable(false);
+      await windowManager.maximize();
+    }
+
+    // Firebase初始化（Web平台延迟初始化以优化首屏速度）
+    if (!kIsWeb) {
       try {
+        // 检查是否已初始化，避免重复初始化
         if (Firebase.apps.isEmpty) {
+          debugPrint('🚀 [main] Firebase.initializeApp() begin');
           await Firebase.initializeApp(
             options: DefaultFirebaseOptions.currentPlatform,
+          ).timeout(
+            const Duration(seconds: 5),
+            onTimeout: () {
+              debugPrint('⚠️ [main] Firebase初始化超时 (5s)');
+              return null as dynamic;
+            },
           );
-          debugPrint('✅ Firebase初始化成功（Web延迟）');
+          debugPrint('✅ [main] Firebase初始化成功');
+        } else {
+          debugPrint('✅ [main] Firebase已初始化，跳过');
         }
-      } catch (e) {
-        debugPrint('⚠️ Firebase初始化失败: $e');
+      } catch (error, stackTrace) {
+        debugPrint('⚠️ [main] Firebase初始化失败: $error');
+        unawaited(
+          ErrorReportService.instance.recordError(
+            error,
+            stackTrace: stackTrace,
+            stage: 'firebase_initialize',
+            source: 'main',
+            extra: {'platform': 'mobile_or_desktop'},
+          ),
+        );
+      }
+    } else {
+      // Web平台：延迟Firebase初始化到用户交互后
+      Future.delayed(const Duration(seconds: 2), () async {
+        try {
+          if (Firebase.apps.isEmpty) {
+            await Firebase.initializeApp(
+              options: DefaultFirebaseOptions.currentPlatform,
+            );
+            debugPrint('✅ Firebase初始化成功（Web延迟）');
+          }
+        } catch (error, stackTrace) {
+          debugPrint('⚠️ Firebase初始化失败: $error');
+          unawaited(
+            ErrorReportService.instance.recordError(
+              error,
+              stackTrace: stackTrace,
+              stage: 'firebase_initialize_web_delayed',
+              source: 'main',
+            ),
+          );
+        }
+      });
+    }
+
+    // 延迟异步初始化，避免阻塞启动
+    Future.delayed(const Duration(milliseconds: 100), () async {
+      debugPrint('🚀 [main] AppInitializer.initialize() begin');
+      try {
+        await AppInitializer.initialize();
+        debugPrint('🚀 [main] AppInitializer.initialize() done');
+      } catch (error, stackTrace) {
+        debugPrint('初始化失败: $error');
+        await ErrorReportService.instance.recordError(
+          error,
+          stackTrace: stackTrace,
+          stage: 'main_delayed_initializer',
+          source: 'main',
+        );
       }
     });
-  }
 
-  // 延迟异步初始化，避免阻塞启动
-  Future.delayed(const Duration(milliseconds: 100), () async {
-    debugPrint('🚀 [main] AppInitializer.initialize() begin');
-    try {
-      await AppInitializer.initialize();
-      debugPrint('🚀 [main] AppInitializer.initialize() done');
-    } catch (e) {
-      debugPrint('初始化失败: $e');
-    }
+    // 🚀 立即初始化Video Feed依赖（不阻塞）
+    debugPrint('🚀 [main] setupVideoFeedDependencies() begin');
+    setupVideoFeedDependencies();
+    debugPrint('🚀 [main] setupVideoFeedDependencies() done');
+
+    debugPrint('🚀 [main] runApp(MyApp) begin');
+    runApp(const MyApp());
+  }, (error, stackTrace) {
+    unawaited(
+      ErrorReportService.instance.recordError(
+        error,
+        stackTrace: stackTrace,
+        stage: 'run_zoned_guarded',
+        source: 'main',
+        fatal: true,
+      ),
+    );
   });
-
-  // 🚀 立即初始化Video Feed依赖（不阻塞）
-  debugPrint('🚀 [main] setupVideoFeedDependencies() begin');
-  setupVideoFeedDependencies();
-  debugPrint('🚀 [main] setupVideoFeedDependencies() done');
-
-  // 注释掉启动时的法流数据预加载，避免因自动请求引来网络排查
-  /*
-  Future.microtask(() async {
-    try {
-      final textService = videoFeedGetIt<CloudflareTextService>();
-      await textService.preloadOnAppStart();
-    } catch (e) {
-      debugPrint('⚠️ 预加载启动失败: $e');
-    }
-  });
-  */
-
-  // 语义 NLP 服务、Firebase 等重型服务的详细初始化已迁移至 AppInitializer 统一管理
-  // 旨在实现启动阶段的削峰填谷，避免内存崩溃
-
-  debugPrint('🚀 [main] runApp(MyApp) begin');
-  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
@@ -145,9 +171,9 @@ class MyApp extends StatelessWidget {
             localeListResolutionCallback:
                 AppLocalizations.localeListResolutionCallback,
             routes: {'/login': (_) => const DouyinLoginScreen()},
-            theme: AppTheme.lightTheme, // Though we prefer dark for space theme
+            theme: AppTheme.lightTheme,
             darkTheme: AppTheme.darkTheme,
-            themeMode: ThemeMode.dark, // Enforce Dark/Space theme
+            themeMode: ThemeMode.dark,
             home: const AppWrapper(),
           );
         },

--- a/fabushi/lib/services/error_report_service.dart
+++ b/fabushi/lib/services/error_report_service.dart
@@ -143,7 +143,7 @@ class ErrorReportService {
           fatal: true,
           extra: {
             if (details.context != null)
-              'context': details.context.toDescription(),
+              'context': details.context?.toDescription(),
             if (details.library != null) 'library': details.library,
           },
         ),

--- a/fabushi/lib/services/error_report_service.dart
+++ b/fabushi/lib/services/error_report_service.dart
@@ -1,0 +1,278 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+
+import '../core/constants/app_constants.dart';
+import 'api_client.dart';
+import 'worker_config.dart';
+
+class AppErrorReport {
+  AppErrorReport({
+    required this.errorText,
+    required this.stackTraceText,
+    required this.stage,
+    required this.source,
+    required this.platform,
+    required this.appVersion,
+    required this.occurredAt,
+    required this.fatal,
+    required this.deviceSummary,
+    required this.extra,
+  });
+
+  final String errorText;
+  final String stackTraceText;
+  final String stage;
+  final String source;
+  final String platform;
+  final String appVersion;
+  final DateTime occurredAt;
+  final bool fatal;
+  final String deviceSummary;
+  final Map<String, dynamic> extra;
+
+  String get summary {
+    final firstLine = errorText.split('\n').first.trim();
+    if (firstLine.isEmpty) {
+      return '应用运行异常';
+    }
+    return firstLine.length > 72 ? '${firstLine.substring(0, 72)}...' : firstLine;
+  }
+
+  String get suggestedTitle {
+    return '启动异常: $summary';
+  }
+
+  Map<String, dynamic> toDiagnosticsPayload() {
+    return {
+      'stage': stage,
+      'source': source,
+      'fatal': fatal,
+      'platform': platform,
+      'appVersion': appVersion,
+      'occurredAt': occurredAt.toIso8601String(),
+      'deviceSummary': deviceSummary,
+      'error': errorText,
+      'stackTrace': stackTraceText,
+      if (extra.isNotEmpty) 'extra': extra,
+    };
+  }
+
+  String buildFeedbackDescription(String userDescription) {
+    final lines = <String>[
+      '应用在启动过程中出现异常，以下信息由客户端自动采集。',
+      '',
+      if (userDescription.trim().isNotEmpty) ...[
+        '### 用户补充说明',
+        '',
+        userDescription.trim(),
+        '',
+      ],
+      '### 异常摘要',
+      '',
+      '- 阶段: $stage',
+      '- 来源: $source',
+      '- 平台: $platform',
+      '- 版本: $appVersion',
+      '- 时间: ${occurredAt.toIso8601String()}',
+      '- 严重级别: ${fatal ? 'fatal' : 'non-fatal'}',
+      '- 设备: $deviceSummary',
+      '',
+      '### 错误信息',
+      '',
+      '```',
+      errorText,
+      '```',
+      '',
+    ];
+
+    if (stackTraceText.trim().isNotEmpty) {
+      lines.addAll([
+        '### 堆栈信息',
+        '',
+        '```',
+        stackTraceText,
+        '```',
+        '',
+      ]);
+    }
+
+    if (extra.isNotEmpty) {
+      lines.addAll([
+        '### 附加上下文',
+        '',
+        '```json',
+        const JsonEncoder.withIndent('  ').convert(extra),
+        '```',
+      ]);
+    }
+
+    return lines.join('\n').trim();
+  }
+}
+
+class ErrorReportService {
+  ErrorReportService._();
+
+  static final ErrorReportService instance = ErrorReportService._();
+
+  final DeviceInfoPlugin _deviceInfoPlugin = DeviceInfoPlugin();
+  AppErrorReport? _lastReport;
+  bool _globalHandlersInstalled = false;
+
+  AppErrorReport? get lastReport => _lastReport;
+
+  Future<void> initializeGlobalHandlers() async {
+    if (_globalHandlersInstalled) {
+      return;
+    }
+
+    final previousOnError = FlutterError.onError;
+
+    FlutterError.onError = (details) {
+      previousOnError?.call(details);
+      unawaited(
+        recordError(
+          details.exception,
+          stackTrace: details.stack,
+          stage: 'flutter_framework',
+          source: 'FlutterError.onError',
+          fatal: true,
+          extra: {
+            if (details.context != null)
+              'context': details.context.toDescription(),
+            if (details.library != null) 'library': details.library,
+          },
+        ),
+      );
+    };
+
+    PlatformDispatcher.instance.onError = (error, stackTrace) {
+      unawaited(
+        recordError(
+          error,
+          stackTrace: stackTrace,
+          stage: 'platform_dispatcher',
+          source: 'PlatformDispatcher.onError',
+          fatal: true,
+        ),
+      );
+      return false;
+    };
+
+    _globalHandlersInstalled = true;
+  }
+
+  Future<AppErrorReport> recordError(
+    Object error, {
+    StackTrace? stackTrace,
+    required String stage,
+    required String source,
+    bool fatal = false,
+    Map<String, dynamic>? extra,
+  }) async {
+    final report = AppErrorReport(
+      errorText: error.toString(),
+      stackTraceText: stackTrace?.toString() ?? '',
+      stage: stage,
+      source: source,
+      platform: _platformLabel(),
+      appVersion: AppConstants.appVersion,
+      occurredAt: DateTime.now().toUtc(),
+      fatal: fatal,
+      deviceSummary: await _collectDeviceSummary(),
+      extra: extra ?? <String, dynamic>{},
+    );
+
+    _lastReport = report;
+    debugPrint('🧯 ErrorReportService captured error: ${report.summary}');
+    return report;
+  }
+
+  Future<Map<String, dynamic>> submitLastReport({
+    required String title,
+    required String userDescription,
+    required String contact,
+    String? authToken,
+  }) async {
+    final report = _lastReport;
+    if (report == null) {
+      return {
+        'success': false,
+        'error': '当前没有可提交的错误报告。',
+      };
+    }
+
+    return ApiClient.instance.post(
+      WorkerConfig.getEndpoint('submitFeedback'),
+      body: {
+        'title': title.trim().isEmpty ? report.suggestedTitle : title.trim(),
+        'description': report.buildFeedbackDescription(userDescription),
+        if (contact.trim().isNotEmpty) 'contact': contact.trim(),
+        'page': 'startup_failure_dialog',
+        'platform': report.platform,
+        'appVersion': report.appVersion,
+        'category': 'startup_crash',
+        'autoCollected': true,
+        'diagnostics': report.toDiagnosticsPayload(),
+      },
+      token: authToken,
+    );
+  }
+
+  String _platformLabel() {
+    if (kIsWeb) {
+      return 'web';
+    }
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return 'android';
+      case TargetPlatform.iOS:
+        return 'ios';
+      case TargetPlatform.macOS:
+        return 'macos';
+      case TargetPlatform.windows:
+        return 'windows';
+      case TargetPlatform.linux:
+        return 'linux';
+      case TargetPlatform.fuchsia:
+        return 'fuchsia';
+    }
+  }
+
+  Future<String> _collectDeviceSummary() async {
+    try {
+      if (kIsWeb) {
+        final info = await _deviceInfoPlugin.webBrowserInfo;
+        return '${info.browserName.name} on ${info.platform ?? 'web'}';
+      }
+
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+          final info = await _deviceInfoPlugin.androidInfo;
+          return '${info.brand} ${info.model} (Android ${info.version.release}, SDK ${info.version.sdkInt})';
+        case TargetPlatform.iOS:
+          final info = await _deviceInfoPlugin.iosInfo;
+          return '${info.name} ${info.model} (iOS ${info.systemVersion})';
+        case TargetPlatform.macOS:
+          final info = await _deviceInfoPlugin.macOsInfo;
+          return '${info.model} (macOS ${info.osRelease})';
+        case TargetPlatform.windows:
+          final info = await _deviceInfoPlugin.windowsInfo;
+          return '${info.productName} ${info.displayVersion}';
+        case TargetPlatform.linux:
+          final info = await _deviceInfoPlugin.linuxInfo;
+          return '${info.name} ${info.version ?? ''}'.trim();
+        case TargetPlatform.fuchsia:
+          return 'fuchsia';
+      }
+    } catch (error) {
+      debugPrint('采集设备信息失败: $error');
+      return 'unknown device';
+    }
+  }
+}

--- a/fabushi/lib/widgets/app_wrapper.dart
+++ b/fabushi/lib/widgets/app_wrapper.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import '../models/auth_model.dart';
+import '../screens/eula_screen.dart';
+import '../screens/main_navigation_screen.dart';
 import '../services/app_initializer.dart';
 import '../services/app_settings.dart';
+import '../services/error_report_service.dart';
 import '../services/eula_service.dart';
-import '../screens/main_navigation_screen.dart';
-import '../screens/eula_screen.dart';
 import '../services/platform_service.dart';
 import '../widgets/model_selection_dialog.dart';
 
@@ -18,21 +20,20 @@ class AppWrapper extends StatefulWidget {
 }
 
 class _AppWrapperState extends State<AppWrapper> {
-  // 模型功能当前在产品内隐藏；启动时也不要再弹出模型选择引导。
-  // 后续重新开放模型功能时，将这里改为 true 即可恢复首启引导。
   static bool get _modelSetupUiEnabled => false;
 
   bool _isInitialized = false;
   bool _initStarted = false;
+  bool _isSubmittingFeedback = false;
   String? _initError;
   bool _needsModelSetup = false;
   bool _needsEula = false;
+  AppErrorReport? _initReport;
   final PlatformService _platformService = PlatformServiceFactory.create();
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // Ensure initialization runs only once.
     if (!_initStarted) {
       _initStarted = true;
       _initializeApp();
@@ -41,37 +42,48 @@ class _AppWrapperState extends State<AppWrapper> {
 
   Future<void> _initializeApp() async {
     try {
-      // didChangeDependencies is the safe place to use Provider.of with context.
       final authModel = Provider.of<AuthModel>(context, listen: false);
 
-      // 1. Highest priority: check for login info in the URL hash.
       final bool loggedInFromUrl = await _processUrlHash(authModel);
 
-      // 2. If not logged in from URL, try to load from local storage.
       if (!loggedInFromUrl) {
         await authModel.loadStoredAuth();
       }
 
-      // 3. Perform other general app initializations.
       if (!AppInitializer.isInitialized) {
         await AppInitializer.initialize();
       }
 
-      // 4. 检查是否需要 EULA 同意
-      final needsEula = !await EulaService.isAccepted();
+      final needsEula = !await _guardStartupStep<bool>(
+        stage: 'check_eula_acceptance',
+        action: EulaService.isAccepted,
+        fallbackValue: true,
+      );
 
-      // 5. 检查是否需要模型设置引导
-      final needsModelSetup = _modelSetupUiEnabled
-          ? await AppSettings.isFirstLaunch() &&
-                !await AppSettings.isModelSetupComplete()
-          : false;
-
-      if (!_modelSetupUiEnabled) {
-        await AppSettings.setFirstLaunchComplete();
-        await AppSettings.setModelSetupComplete(true);
+      bool needsModelSetup = false;
+      if (_modelSetupUiEnabled) {
+        final isFirstLaunch = await _guardStartupStep<bool>(
+          stage: 'check_first_launch',
+          action: AppSettings.isFirstLaunch,
+          fallbackValue: false,
+        );
+        final isModelSetupComplete = await _guardStartupStep<bool>(
+          stage: 'check_model_setup_complete',
+          action: AppSettings.isModelSetupComplete,
+          fallbackValue: true,
+        );
+        needsModelSetup = isFirstLaunch && !isModelSetupComplete;
+      } else {
+        await _runStartupSideEffect(
+          stage: 'mark_first_launch_complete',
+          action: AppSettings.setFirstLaunchComplete,
+        );
+        await _runStartupSideEffect(
+          stage: 'mark_model_setup_complete',
+          action: () => AppSettings.setModelSetupComplete(true),
+        );
       }
 
-      // If we are still mounted, update state to trigger rebuild to the main UI.
       if (mounted) {
         setState(() {
           _isInitialized = true;
@@ -79,29 +91,67 @@ class _AppWrapperState extends State<AppWrapper> {
           _needsModelSetup = needsModelSetup;
         });
 
-        // 首先检查 EULA
         if (needsEula) {
           await _showEulaScreen();
         }
 
-        // 然后显示模型选择引导
         if (needsModelSetup && mounted) {
           _showModelSetupDialog();
         }
       }
-    } catch (e) {
-      debugPrint('Error during app initialization: $e');
+    } catch (error, stackTrace) {
+      debugPrint('Error during app initialization: $error');
+      final report = await ErrorReportService.instance.recordError(
+        error,
+        stackTrace: stackTrace,
+        stage: 'app_wrapper_initialize',
+        source: 'AppWrapper._initializeApp',
+        fatal: true,
+      );
       if (mounted) {
         setState(() {
-          _initError = e.toString();
-          _isInitialized =
-              true; // Mark as initialized to show the error screen.
+          _initError = report.errorText;
+          _initReport = report;
+          _isInitialized = true;
         });
       }
     }
   }
 
-  /// 显示 EULA 同意页面
+  Future<T> _guardStartupStep<T>({
+    required String stage,
+    required Future<T> Function() action,
+    required T fallbackValue,
+  }) async {
+    try {
+      return await action();
+    } catch (error, stackTrace) {
+      await ErrorReportService.instance.recordError(
+        error,
+        stackTrace: stackTrace,
+        stage: stage,
+        source: 'AppWrapper.startupGuard',
+      );
+      return fallbackValue;
+    }
+  }
+
+  Future<void> _runStartupSideEffect({
+    required String stage,
+    required Future<void> Function() action,
+  }) async {
+    try {
+      await action();
+    } catch (error, stackTrace) {
+      await ErrorReportService.instance.recordError(
+        error,
+        stackTrace: stackTrace,
+        stage: stage,
+        source: 'AppWrapper.startupSideEffect',
+      );
+    }
+  }
+
   Future<void> _showEulaScreen() async {
     if (!mounted) return;
 
@@ -112,9 +162,7 @@ class _AppWrapperState extends State<AppWrapper> {
     }
   }
 
-  /// 显示首次启动模型选择引导
   Future<void> _showModelSetupDialog() async {
-    // 延迟一下，确保 UI 已经完全渲染
     await Future.delayed(const Duration(milliseconds: 500));
 
     if (!mounted) return;
@@ -124,8 +172,10 @@ class _AppWrapperState extends State<AppWrapper> {
       isFirstLaunch: true,
     );
 
-    // 无论是否选择了模型，都标记首次启动已完成
-    await AppSettings.setFirstLaunchComplete();
+    await _runStartupSideEffect(
+      stage: 'mark_first_launch_complete_after_dialog',
+      action: AppSettings.setFirstLaunchComplete,
+    );
 
     if (result != null && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -143,6 +193,184 @@ class _AppWrapperState extends State<AppWrapper> {
     }
   }
 
+  Future<void> _showStartupFeedbackDialog() async {
+    final report = _initReport ?? ErrorReportService.instance.lastReport;
+    if (report == null) {
+      return;
+    }
+
+    final authModel = Provider.of<AuthModel>(context, listen: false);
+    final titleController = TextEditingController(text: report.suggestedTitle);
+    final descriptionController = TextEditingController();
+    final contactController = TextEditingController(
+      text: authModel.currentUser?.email ?? '',
+    );
+    String? validationMessage;
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            Future<void> handleSubmit() async {
+              final title = titleController.text.trim();
+              final description = descriptionController.text.trim();
+              final contact = contactController.text.trim();
+
+              if (title.isEmpty) {
+                setDialogState(() => validationMessage = '请填写问题标题');
+                return;
+              }
+
+              setDialogState(() => validationMessage = null);
+              if (mounted) {
+                setState(() => _isSubmittingFeedback = true);
+              }
+
+              final result = await ErrorReportService.instance.submitLastReport(
+                title: title,
+                userDescription: description,
+                contact: contact,
+                authToken: authModel.authToken,
+              );
+
+              if (!mounted) return;
+              setState(() => _isSubmittingFeedback = false);
+
+              if (Navigator.of(dialogContext).canPop()) {
+                Navigator.of(dialogContext).pop();
+              }
+
+              final success = result['success'] == true;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    success
+                        ? (result['message'] ?? '问题反馈已提交')
+                        : (result['error'] ?? '反馈提交失败，请稍后重试'),
+                  ),
+                  backgroundColor: success ? Colors.green : Colors.red,
+                ),
+              );
+            }
+
+            return AlertDialog(
+              backgroundColor: const Color(0xFF1E1E1E),
+              title: const Text('反馈启动异常', style: TextStyle(color: Colors.white)),
+              content: SizedBox(
+                width: 420,
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '提交后会自动创建 GitHub Issue，并附带已采集到的错误信息。',
+                        style: TextStyle(color: Colors.white70, fontSize: 13),
+                      ),
+                      const SizedBox(height: 16),
+                      TextField(
+                        controller: titleController,
+                        enabled: !_isSubmittingFeedback,
+                        style: const TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          labelText: '问题标题',
+                          labelStyle: const TextStyle(color: Colors.white70),
+                          filled: true,
+                          fillColor: Colors.white.withOpacity(0.04),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: descriptionController,
+                        enabled: !_isSubmittingFeedback,
+                        style: const TextStyle(color: Colors.white),
+                        minLines: 3,
+                        maxLines: 6,
+                        decoration: InputDecoration(
+                          labelText: '补充说明（选填）',
+                          labelStyle: const TextStyle(color: Colors.white70),
+                          hintText: '比如：点击启动后立刻出现、是否刚更新版本、是否能稳定复现。',
+                          hintStyle: const TextStyle(color: Colors.white38),
+                          filled: true,
+                          fillColor: Colors.white.withOpacity(0.04),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: contactController,
+                        enabled: !_isSubmittingFeedback,
+                        style: const TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          labelText: '联系方式（选填）',
+                          labelStyle: const TextStyle(color: Colors.white70),
+                          filled: true,
+                          fillColor: Colors.white.withOpacity(0.04),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withOpacity(0.04),
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(color: Colors.white12),
+                        ),
+                        child: Text(
+                          '已采集摘要：${report.summary}',
+                          style: const TextStyle(color: Colors.white60, fontSize: 12),
+                        ),
+                      ),
+                      if (validationMessage != null) ...[
+                        const SizedBox(height: 12),
+                        Text(
+                          validationMessage!,
+                          style: const TextStyle(color: Colors.redAccent),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: _isSubmittingFeedback
+                      ? null
+                      : () => Navigator.of(dialogContext).pop(),
+                  child: const Text('取消'),
+                ),
+                FilledButton(
+                  onPressed: _isSubmittingFeedback ? null : handleSubmit,
+                  child: _isSubmittingFeedback
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('提交反馈'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    ).whenComplete(() {
+      titleController.dispose();
+      descriptionController.dispose();
+      contactController.dispose();
+    });
+  }
+
   Future<bool> _processUrlHash(AuthModel authModel) async {
     if (kIsWeb) {
       try {
@@ -151,12 +379,9 @@ class _AppWrapperState extends State<AppWrapper> {
         if (uri.fragment.isNotEmpty) {
           final params = Uri.splitQueryString(uri.fragment);
 
-          // 处理错误情况
           if (params['error'] != null) {
-            final error = params['error'];
             final errorMessage = params['error_message'] ?? '发生未知错误';
 
-            // 显示错误信息
             if (mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
@@ -167,12 +392,10 @@ class _AppWrapperState extends State<AppWrapper> {
               );
             }
 
-            // Clean the URL hash.
             _platformService.replaceHistoryState('/');
-            return false; // 不认为登录成功
+            return false;
           }
 
-          // 处理支付宝绑定情况
           if (params['alipay_auth_code'] != null &&
               params['needs_binding'] == 'true') {
             final authCode = params['alipay_auth_code']!;
@@ -180,7 +403,6 @@ class _AppWrapperState extends State<AppWrapper> {
             final nickname = params['alipay_nickname'] ?? '';
             final avatar = params['alipay_avatar'] ?? '';
 
-            // 导航到支付宝绑定页面
             if (mounted) {
               Navigator.of(context).pushNamed(
                 '/alipay-binding',
@@ -193,23 +415,18 @@ class _AppWrapperState extends State<AppWrapper> {
               );
             }
 
-            // Clean the URL hash.
             _platformService.replaceHistoryState('/');
-            return false; // 不自动登录，等待用户绑定
+            return false;
           }
 
-          // 处理直接登录情况 - 支持支付宝登录和其他登录方式
           final token = params['token'];
           final username = params['username'];
           final loginMethod = params['login_method'] ?? 'traditional';
 
           if (token != null && username != null) {
             await authModel.setTokenDirectly(token, username);
-
-            // Clean the URL hash.
             _platformService.replaceHistoryState('/');
 
-            // 显示成功消息
             String welcomeMessage = '登录成功！欢迎 $username';
             if (loginMethod == 'alipay') {
               welcomeMessage = '支付宝登录成功！欢迎 $username';
@@ -224,14 +441,14 @@ class _AppWrapperState extends State<AppWrapper> {
               );
             }
 
-            return true; // Signal that login was handled.
+            return true;
           }
         }
       } catch (e) {
         debugPrint('Error processing URL hash: $e');
       }
     }
-    return false; // Signal that login was not handled.
+    return false;
   }
 
   @override
@@ -267,44 +484,81 @@ class _AppWrapperState extends State<AppWrapper> {
               colors: [Color(0xFF667eea), Color(0xFF764ba2)],
             ),
           ),
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Icon(Icons.error, color: Colors.white, size: 48),
-                  const SizedBox(height: 16),
-                  const Text(
-                    '应用初始化失败',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
+          child: SafeArea(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.error, color: Colors.white, size: 48),
+                    const SizedBox(height: 16),
+                    const Text(
+                      '应用初始化失败',
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    '发生了一个错误: \n$_initError',
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(color: Colors.white70),
-                  ),
-                  const SizedBox(height: 16),
-                  ElevatedButton(
-                    onPressed: () {
-                      setState(() {
-                        _initStarted = false;
-                        _isInitialized = false;
-                        _initError = null;
-                      });
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: const Color(0xFF667eea),
+                    const SizedBox(height: 8),
+                    Text(
+                      '发生了一个错误：\n$_initError',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: Colors.white70),
                     ),
-                    child: const Text('重试'),
-                  ),
-                ],
+                    if (_initReport != null) ...[
+                      const SizedBox(height: 12),
+                      Text(
+                        '已自动保存错误快照，可直接提交反馈。',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(color: Colors.white60, fontSize: 13),
+                      ),
+                    ],
+                    const SizedBox(height: 20),
+                    Wrap(
+                      alignment: WrapAlignment.center,
+                      spacing: 12,
+                      runSpacing: 12,
+                      children: [
+                        ElevatedButton(
+                          onPressed: () {
+                            setState(() {
+                              _initStarted = false;
+                              _isInitialized = false;
+                              _initError = null;
+                              _initReport = null;
+                            });
+                          },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.white,
+                            foregroundColor: const Color(0xFF667eea),
+                          ),
+                          child: const Text('重试'),
+                        ),
+                        OutlinedButton(
+                          onPressed: _isSubmittingFeedback
+                              ? null
+                              : _showStartupFeedbackDialog,
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: Colors.white,
+                            side: const BorderSide(color: Colors.white54),
+                          ),
+                          child: _isSubmittingFeedback
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                              : const Text('反馈此问题'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -312,7 +566,6 @@ class _AppWrapperState extends State<AppWrapper> {
       );
     }
 
-    // Initialization is complete, show the main screen.
     return const MainNavigationScreen();
   }
 }

--- a/fabushi/web/src/handlers/feedback.js
+++ b/fabushi/web/src/handlers/feedback.js
@@ -12,6 +12,31 @@ function normalizeText(value, { maxLength = 1000 } = {}) {
   return value.trim().replace(/\r\n/g, '\n').substring(0, maxLength);
 }
 
+function normalizeDiagnostics(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  try {
+    const json = JSON.stringify(value);
+    if (!json) {
+      return null;
+    }
+
+    if (json.length <= 12000) {
+      return JSON.parse(json);
+    }
+
+    return {
+      truncated: true,
+      preview: json.substring(0, 12000),
+    };
+  } catch (error) {
+    console.warn('无法序列化诊断信息，将忽略该字段:', error);
+    return null;
+  }
+}
+
 async function resolveReporter(request, env, db) {
   const authHeader = request.headers.get('Authorization');
   if (!authHeader?.startsWith('Bearer ')) {
@@ -42,6 +67,17 @@ async function resolveReporter(request, env, db) {
 }
 
 function buildIssueBody({ feedback, reporter }) {
+  const diagnosticsSection = feedback.diagnostics
+    ? [
+        '### 自动采集诊断信息',
+        '',
+        '```json',
+        JSON.stringify(feedback.diagnostics, null, 2),
+        '```',
+        '',
+      ]
+    : [];
+
   const lines = [
     '## 用户反馈',
     '',
@@ -49,6 +85,8 @@ function buildIssueBody({ feedback, reporter }) {
     `- 页面入口: ${feedback.page || 'unknown'}`,
     `- 平台: ${feedback.platform || 'unknown'}`,
     `- App 版本: ${feedback.appVersion || 'unknown'}`,
+    `- 分类: ${feedback.category || 'general'}`,
+    `- 自动采集: ${feedback.autoCollected ? '是' : '否'}`,
     `- 联系方式: ${feedback.contact || '未提供'}`,
     `- 提交时间: ${new Date().toISOString()}`,
     `- 登录用户: ${reporter?.username || 'anonymous'}`,
@@ -59,6 +97,7 @@ function buildIssueBody({ feedback, reporter }) {
     '',
     feedback.description,
     '',
+    ...diagnosticsSection,
     '---',
     '',
     '_This issue was created automatically from the in-app feedback form._',
@@ -109,6 +148,10 @@ async function ensureFeedbackLabel(env) {
   throw new Error(`ensure_label_failed:${response.status}:${errorText}`);
 }
 
+function issueTitlePrefix(feedback) {
+  return feedback.category === 'startup_crash' ? '[崩溃反馈]' : '[反馈]';
+}
+
 async function createFeedbackIssue(env, feedback, reporter) {
   const owner = env.GITHUB_FEEDBACK_REPO_OWNER || DEFAULT_REPO_OWNER;
   const repo = env.GITHUB_FEEDBACK_REPO_NAME || DEFAULT_REPO_NAME;
@@ -117,7 +160,7 @@ async function createFeedbackIssue(env, feedback, reporter) {
   const response = await githubRequest(env, `/repos/${owner}/${repo}/issues`, {
     method: 'POST',
     body: JSON.stringify({
-      title: `[反馈] ${feedback.title}`,
+      title: `${issueTitlePrefix(feedback)} ${feedback.title}`,
       body: buildIssueBody({ feedback, reporter }),
       labels: [label],
     }),
@@ -148,6 +191,9 @@ export async function handleSubmitFeedback(request, env, db) {
       page: normalizeText(body.page, { maxLength: 80 }),
       platform: normalizeText(body.platform, { maxLength: 80 }),
       appVersion: normalizeText(body.appVersion, { maxLength: 80 }),
+      category: normalizeText(body.category, { maxLength: 80 }),
+      autoCollected: body.autoCollected === true,
+      diagnostics: normalizeDiagnostics(body.diagnostics),
     };
 
     if (!feedback.title) {

--- a/fabushi/web/tests/feedback.test.js
+++ b/fabushi/web/tests/feedback.test.js
@@ -73,12 +73,18 @@ test('handleSubmitFeedback creates a GitHub issue for valid feedback', async () 
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        title: '收藏后提示不明显',
-        description: '建议收藏成功后给一个更明确的提示。',
+        title: 'SharedPreferences 初始化失败',
+        description: '安卓打开应用后立刻白屏，点击重试也不行。',
         contact: 'user@example.com',
-        page: 'settings',
+        page: 'startup_failure_dialog',
         platform: 'android',
         appVersion: '1.0.0+16',
+        category: 'startup_crash',
+        autoCollected: true,
+        diagnostics: {
+          stage: 'app_wrapper_initialize',
+          error: 'PlatformException(channel-error, Unable to establish connection on channel...)',
+        },
       }),
     });
 
@@ -97,8 +103,10 @@ test('handleSubmitFeedback creates a GitHub issue for valid feedback', async () 
     assert.equal(calls.length, 2);
 
     const issueRequestBody = JSON.parse(calls[1].init.body);
-    assert.match(issueRequestBody.title, /^\[反馈\]/);
-    assert.match(issueRequestBody.body, /收藏成功/);
+    assert.match(issueRequestBody.title, /^\[崩溃反馈\]/);
+    assert.match(issueRequestBody.body, /自动采集诊断信息/);
+    assert.match(issueRequestBody.body, /SharedPreferences/);
+    assert.match(issueRequestBody.body, /app_wrapper_initialize/);
   } finally {
     global.fetch = originalFetch;
   }


### PR DESCRIPTION
## 概要
- 给启动期异常补上统一错误采集与最近一次崩溃快照
- 在初始化失败页增加“反馈此问题”弹窗，允许用户一键把自动采集的错误信息提交到 GitHub Issue
- 扩展 feedback worker，把自动诊断信息写入 issue body，并补上对应测试
- 对启动阶段的 `SharedPreferences` 读取改为 guarded fallback，避免通道异常时直接卡死在壳页

## 为什么做
用户当前在 Android 端启动时直接遇到了初始化失败，截图中的核心异常是：

`PlatformException(channel-error, Unable to establish connection on channel: "dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.getAll")`

这类问题有两个痛点：
1. 出错时用户只能看到一个失败页，无法顺手把上下文带回来
2. 启动路径上对本地持久化的依赖太硬，一旦插件通道不可用，就容易把整个应用入口卡住

这条 PR 同时处理这两个问题：先尽量让应用在启动期对本地持久化错误做降级，再把仍然发生的异常自动收集并通过现有 GitHub feedback 通道送回仓库。

## 改动
- 新增 `lib/services/error_report_service.dart`
  - 统一记录最近一次异常、堆栈、设备摘要、阶段和来源
  - 接入 `FlutterError.onError` 与 `PlatformDispatcher.onError`
  - 负责把启动异常包装成 feedback 请求
- 更新 `lib/main.dart`
  - 启动时安装全局错误采集
  - 通过 `runZonedGuarded` 兜住主入口未捕获异常
  - 给 Firebase 延迟初始化和主入口延迟初始化补错误记录
- 更新 `lib/widgets/app_wrapper.dart`
  - 启动阶段的 EULA / 首启标记读取改为 guarded fallback
  - 初始化失败时保存错误快照
  - 在失败页增加“反馈此问题”弹窗和提交逻辑
- 更新 `web/src/handlers/feedback.js`
  - 支持 `category`、`autoCollected`、`diagnostics`
  - 启动异常 issue 标题使用 `[崩溃反馈]` 前缀
  - 把自动采集诊断信息写入 GitHub Issue
- 更新 `web/tests/feedback.test.js`
  - 覆盖崩溃反馈 issue 载荷与 body 结构

## 风险与范围
- Flutter 侧主要改启动入口和初始化失败页
- Worker 侧只扩展现有反馈载荷，不改变鉴权、路由或 GitHub token 使用方式
- 这条 PR 重点是提升启动异常的可恢复性和可观测性，不涉及业务接口语义变更

## 验证
- 本地执行：`node --test web/tests/feedback.test.js`
- 已确认：
  - 缺少 token 时仍返回 503
  - 启动异常反馈会生成 `[崩溃反馈]` 标题
  - 自动诊断信息会进入 issue body
- 未完成：
  - 当前环境没有完整 Flutter checkout，也没有 `dart` 命令，因此还未做 Flutter 编译级验证
  - 需要依赖 PR CI 继续验证 Flutter / Android / Worker 全链路
