### PR TITLE
ci: force Node 24 runtime in deploy and package-release workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,6 +25,9 @@ permissions:
   deployments: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build-artifact:
     name: Build release artifact
@@ -57,7 +60,7 @@ jobs:
           echo "Resolved source SHA: $source_sha"
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.source.outputs.source_sha }}
           sparse-checkout-cone-mode: false
@@ -90,7 +93,7 @@ jobs:
           printf '%s\n' "${{ steps.source.outputs.source_sha }}" > ../release-artifact/SOURCE_SHA
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fabushi-release-${{ steps.source.outputs.source_sha }}
           path: release-artifact
@@ -110,13 +113,13 @@ jobs:
         working-directory: release-artifact/fabushi/web
     steps:
       - name: Download release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fabushi-release-${{ needs.build-artifact.outputs.source_sha }}
           path: release-artifact
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -138,7 +141,7 @@ jobs:
           DEVELOPMENT_D1_DATABASE_ID: ${{ vars.DEVELOPMENT_D1_DATABASE_ID || vars.D1_DATABASE_ID || vars.CLOUDFLARE_D1_DATABASE_ID || '7b6318f0-fbc2-42f9-9887-85f878ae76d0' }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
+          python3 - <<'PY2'
           from pathlib import Path
           import os
           path = Path('wrangler.toml')
@@ -150,7 +153,7 @@ jobs:
               print('Patched development D1 database id placeholder')
           else:
               print('Development D1 database id placeholder not present')
-          PY
+          PY2
 
       - name: Deploy staging Worker
         env:
@@ -177,7 +180,7 @@ jobs:
       STAGING_TEST_PHONE: ${{ vars.STAGING_TEST_PHONE }}
     steps:
       - name: Checkout E2E files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.build-artifact.outputs.source_sha }}
           sparse-checkout-cone-mode: false
@@ -198,7 +201,7 @@ jobs:
           exit "$missing"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -223,7 +226,7 @@ jobs:
 
       - name: Upload staging E2E report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: staging-api-e2e-playwright-report
           path: fabushi/e2e/playwright-report
@@ -231,7 +234,7 @@ jobs:
 
       - name: Upload staging E2E test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: staging-api-e2e-test-results
           path: fabushi/e2e/test-results
@@ -252,13 +255,13 @@ jobs:
         working-directory: release-artifact/fabushi/web
     steps:
       - name: Download validated release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fabushi-release-${{ needs.build-artifact.outputs.source_sha }}
           path: release-artifact
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -278,7 +281,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 - <<'PY'
+          python3 - <<'PY2'
           from pathlib import Path
           import re
 
@@ -308,7 +311,7 @@ jobs:
               print('Production route management already absent')
 
           print('Verified production deploy artifact no longer mutates routes')
-          PY
+          PY2
 
       - name: Deploy production Worker
         env:
@@ -375,14 +378,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout failure notifier
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /.github/scripts/**
 
       - name: Create or update detailed CD failure issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SOURCE_SHA: ${{ needs.build-artifact.outputs.source_sha || github.event.workflow_run.head_sha || github.sha }}
         with:

--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -29,6 +29,7 @@ permissions:
   issues: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   FLUTTER_VERSION: '3.41.9'
 
 jobs:
@@ -64,7 +65,7 @@ jobs:
           echo "Resolved CD run id: $cd_run_id"
 
       - name: Download CD artifacts for source metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ steps.cd-run.outputs.cd_run_id }}
@@ -101,7 +102,7 @@ jobs:
         working-directory: fabushi
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-cd-context.outputs.source_sha }}
           sparse-checkout-cone-mode: false
@@ -111,7 +112,7 @@ jobs:
             !/fabushi/web/assets/built_in/**
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -148,7 +149,7 @@ jobs:
           cp build/app/outputs/bundle/release/app-release.aab "../android-release-assets/fabushi-android-${short_sha}.aab"
 
       - name: Upload Android release packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-android-packages
           path: android-release-assets
@@ -173,7 +174,7 @@ jobs:
       APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-cd-context.outputs.source_sha }}
           sparse-checkout-cone-mode: false
@@ -257,7 +258,7 @@ jobs:
           team_id="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$profile_plist")"
           cp "$profile_path" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
 
-          bundle_id="$(grep -m 1 'PRODUCT_BUNDLE_IDENTIFIER = ' ios/Runner.xcodeproj/project.pbxproj | sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\1/' | tr -d ' ')"
+          bundle_id="$(grep -m 1 'PRODUCT_BUNDLE_IDENTIFIER = ' ios/Runner.xcodeproj/project.pbxproj | sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\\1/' | tr -d ' ')"
           if [ -z "$bundle_id" ]; then
             echo "Could not detect PRODUCT_BUNDLE_IDENTIFIER from ios/Runner.xcodeproj/project.pbxproj" >&2
             exit 1
@@ -373,7 +374,7 @@ jobs:
 
       - name: Upload iOS release package artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-ios-packages
           path: ios-release-assets
@@ -395,26 +396,26 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Download all CD artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ needs.resolve-cd-context.outputs.cd_run_id }}
           path: downloaded-cd-artifacts
 
       - name: Download Android release packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-android-packages
           path: built-native-packages/android
 
       - name: Download iOS release packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-ios-packages
           path: built-native-packages/ios
 
       - name: Checkout source for version metadata
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-cd-context.outputs.source_sha }}
           clean: false
@@ -592,14 +593,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout failure notifier
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /.github/scripts/**
 
       - name: Create or update detailed package release failure issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SOURCE_SHA: ${{ needs.resolve-cd-context.outputs.source_sha || github.event.workflow_run.head_sha || inputs.source_sha || github.sha }}
           CD_RUN_ID: ${{ needs.resolve-cd-context.outputs.cd_run_id || github.event.workflow_run.id || inputs.cd_run_id || '' }}


### PR DESCRIPTION
## 概要
- 给 `deploy-production.yml` 和 `publish-cd-release.yml` 补上 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
- 同步把这两条低频主线工作流里的官方 GitHub JavaScript actions 升到新的主版本
- 不改业务代码，不改发布命令，只收口主线交付链路上的 Node 20 runtime 风险

## 为什么现在做
这轮主动推进里，主线 `482811c` 的仓库侧闭环已经重新拿到硬证据：
- `CI #215` success
- `CD #77` success
- 最新 GitHub Release `v1.0.0-16-cd.482811cd3662` 已生成
- release notes 已记录 `TestFlight upload: uploaded at 2026-05-05T01:49:32Z.`

在发布门禁重新闭环之后，当前最清晰的下一步系统性风险不是业务功能，而是 GitHub Actions 的 Node 20 runtime 弃用。主线 `CI` 已经先做过一轮 major 升级，但最新 `CD` / `publish release` 运行页仍然能看到 Node 20 deprecation warnings。

这条 PR 直接处理剩下的主线低频工作流，避免六月默认切换前再把告警拖成真实发布阻塞。

## 具体改动
- `deploy-production.yml`
  - 新增 workflow 级 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
  - `actions/checkout`: `v4` -> `v5`
  - `actions/setup-node`: `v4` -> `v6`
  - `actions/download-artifact`: `v4` -> `v5`
  - `actions/upload-artifact`: `v4` -> `v7`
  - `actions/github-script`: `v7` -> `v8`
- `publish-cd-release.yml`
  - 新增 workflow 级 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
  - `actions/checkout`: `v4` -> `v5`
  - `actions/setup-java`: `v4` -> `v5`
  - `actions/download-artifact`: `v4` -> `v5`
  - `actions/upload-artifact`: `v4` -> `v7`
  - `actions/github-script`: `v7` -> `v8`

## 为什么这样修
这次不是只把某几个 action 名义上升版本，而是同时处理两个层面：
1. 对已经明确有 Node 24 版本的官方 action，直接升到新的主版本
2. 对 GitHub 当前仍默认以 Node 20 运行 JavaScript action 的平台切换期，在 workflow 级显式打开 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`

这样可以把“版本升级”和“运行时选择”两个风险点一起压住，比只做其中一层更接近根因修复。

## 风险与范围
- 仅改两份 GitHub Actions workflow
- 不改 Flutter / Android / iOS / Worker 业务逻辑
- 不改变发包、部署、签名和 TestFlight 上传步骤的业务语义

## 验证重点
- PR 自身 `CI` 继续绿灯
- 合并后跟进下一次主线：
  - `CD - Staging API gated production deploy`
  - `Publish CD packages to GitHub Release`
- 重点确认：
  - 不再出现这两条 workflow 的 Node 20 runtime 告警
  - GitHub Release 仍正常生成
  - `TESTFLIGHT_UPLOAD_STATUS.txt` 与 release notes 的 TestFlight 摘要继续保留
