### PR TITLE
fix: restore iOS export bundle id mapping in package release workflow

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -258,7 +258,7 @@ jobs:
           team_id="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$profile_plist")"
           cp "$profile_path" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
 
-          bundle_id="$(grep -m 1 'PRODUCT_BUNDLE_IDENTIFIER = ' ios/Runner.xcodeproj/project.pbxproj | sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\\1/' | tr -d ' ')"
+          bundle_id="$(grep -m 1 'PRODUCT_BUNDLE_IDENTIFIER = ' ios/Runner.xcodeproj/project.pbxproj | sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\1/' | tr -d ' ')"
           if [ -z "$bundle_id" ]; then
             echo "Could not detect PRODUCT_BUNDLE_IDENTIFIER from ios/Runner.xcodeproj/project.pbxproj" >&2
             exit 1


### PR DESCRIPTION
## 概要
- 修复 `publish-cd-release.yml` 中 iOS 导出阶段提取 `PRODUCT_BUNDLE_IDENTIFIER` 的 shell 替换串
- 让 `ExportOptions.plist` 重新写入真实 bundle id，而不是错误的字面值
- 保持改动范围只限于当前已失败的 package release workflow

## 根因
主线提交 `35e6e03952699d944fd5f3b79e1657c267ffd06a` 的 package release 失败 issue `#100` 对应日志已经给出关键信号：
- `flutter build ipa` 已成功生成 archive
- 真正失败点出现在 `Building App Store IPA...`
- Xcode 报错：`exportArchive "Runner.app" requires a provisioning profile with the Sign In with Apple feature.`

对比 `#99` 的改动后可以确认，workflow 中这行从：
- `sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\1/'`

被改成了：
- `sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\\1/'`

这会让 shell 里的 `sed` 输出字面值 `\1`，而不是捕获到的真实 bundle id `com.ombhrum.fabushi`。随后生成的 `ExportOptions.plist` 里 provisioning profile 键被写错，最终在 IPA export 阶段表现成签名能力不匹配。

## 为什么这样修
这不是重配签名材料，也不是绕过 iOS 发布，而是把 bundle id 提取恢复到 merge 前已经工作的行为，让导出配置重新指向真实 app id。这样修正的是当前失败链路的直接根因，影响面最小，也最容易通过后续 package release 验证。

## 风险与范围
- 只改 `.github/workflows/publish-cd-release.yml`
- 不改 Flutter、iOS 工程源码、证书、profile、TestFlight 上传逻辑
- 不改变 Android、CD 或 GitHub Release 其他步骤

## 验证重点
- PR 自身 `CI` 继续绿灯
- 合并后继续跟进下一次主线：
  - `CD - Staging API gated production deploy`
  - `Publish CD packages to GitHub Release`
- 重点确认：
  - iOS `Build signed iOS IPA` 不再卡在 exportArchive
  - GitHub Release 恢复生成
  - `TESTFLIGHT_UPLOAD_STATUS.txt` 与 release notes 中的 TestFlight 证据继续保留
