### PR TITLE
ci: force Node 24 runtime in the main CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ permissions:
   statuses: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   FLUTTER_VERSION: '3.41.9'
 
 jobs:


### PR DESCRIPTION
## 概要
- 给主线 `CI` workflow 补上 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
- 让合并门禁里的 JavaScript actions 在当前平台切换期显式走 Node 24 runtime
- 保持改动范围只限于 `.github/workflows/ci.yml`

## 为什么现在做
这轮主动推进里，主线发布门禁已经重新闭环：
- `CI #221` success
- `CD #79` success
- `Publish CD packages to GitHub Release #24` success
- release `v1.0.0-16-cd.e80d42659d94` 已生成，并明确记录 `TestFlight upload: uploaded at 2026-05-05T04:39:45Z.`

在发布链路恢复后，下一条最清晰的小步升级不是再动业务逻辑，而是继续收口主线门禁里的平台漂移风险。最新 `CI #221` 仍在 `Cloudflare Worker syntax and deploy dry-run` job 中提示：
- `actions/download-artifact@v5` 仍按 Node 20 action runtime 发出弃用警告
- 当前 `ci.yml` 没有像 `deploy-production.yml` / `publish-cd-release.yml` 那样显式打开 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`

## 为什么这样修
这次先处理主线合并门禁本身，因为它是最常运行、最直接影响 mergeability 的 workflow。

对 `deploy-production.yml` 与 `publish-cd-release.yml`，最新成功运行已经表明它们确实在被强制切到 Node 24，但 GitHub 仍会提示 `actions/download-artifact@v5` 的 Node 20 标记。这部分更像是上游 action 元数据仍未完全消化，不适合在没有更高版本可用证据之前，贸然做超出需求的 workflow 改造。

因此这条 PR 先把当前仍缺失显式 Node 24 选择的 `CI` workflow 补齐，继续用最小改动压低下一次主线门禁复发概率。

## 风险与范围
- 只改 `.github/workflows/ci.yml`
- 不改 Flutter / Android / Worker / Playwright 具体命令
- 不改变任何业务逻辑、测试逻辑或发版逻辑

## 验证重点
- PR 自身 `CI` 继续绿灯
- 重点观察 `Cloudflare Worker syntax and deploy dry-run` 是否不再出现“可通过设置 FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 解决”的那类提示
- 合并后继续观察下一次主线 `CI`，确认合并门禁不再依赖默认 Node 20 runtime
