### PR TITLE
fix: make profile username changes safe under D1 reference constraints

### DIFF
--- a/fabushi/web/src/handlers/profile.js
+++ b/fabushi/web/src/handlers/profile.js
@@ -97,13 +97,38 @@ async function safeRun(db, sql, ...params) {
 }
 
 async function updateUsernameReferences(db, oldUsername, newUsername) {
-  await safeRun(db, 'UPDATE email_username_mapping SET username = ? WHERE username = ?', newUsername, oldUsername);
-  await safeRun(db, 'UPDATE alipay_bindings SET username = ? WHERE username = ?', newUsername, oldUsername);
-  await safeRun(db, 'UPDATE purchase_history SET user_id = ? WHERE user_id = ?', newUsername, oldUsername);
-  await safeRun(db, 'UPDATE redeem_history SET username = ? WHERE username = ?', newUsername, oldUsername);
-  await safeRun(db, 'UPDATE meditation_records SET username = ? WHERE username = ?', newUsername, oldUsername);
-  await safeRun(db, 'UPDATE likes SET username = ? WHERE username = ?', newUsername, oldUsername);
-  await safeRun(db, 'UPDATE favorites SET username = ? WHERE username = ?', newUsername, oldUsername);
+  const updates = [
+    ['UPDATE email_username_mapping SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE alipay_bindings SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE orders SET user_id = ? WHERE user_id = ?', newUsername, oldUsername],
+    ['UPDATE orders SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE purchase_history SET user_id = ? WHERE user_id = ?', newUsername, oldUsername],
+    ['UPDATE purchase_history SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE redeem_history SET user_id = ? WHERE user_id = ?', newUsername, oldUsername],
+    ['UPDATE redeem_history SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE memberships SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE meditation_records SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE meditation_goals SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE meditation_settings SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE meditation_group_members SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE meditation_groups SET owner_username = ? WHERE owner_username = ?', newUsername, oldUsername],
+    ['UPDATE user_follows SET follower_username = ? WHERE follower_username = ?', newUsername, oldUsername],
+    ['UPDATE user_follows SET following_username = ? WHERE following_username = ?', newUsername, oldUsername],
+    ['UPDATE notifications SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE notifications SET related_username = ? WHERE related_username = ?', newUsername, oldUsername],
+    ['UPDATE sync_log SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE user_sync_state SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE comments SET user_id = ? WHERE user_id = ?', newUsername, oldUsername],
+    ['UPDATE comments SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE likes SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE favorites SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE content_likes SET username = ? WHERE username = ?', newUsername, oldUsername],
+    ['UPDATE content_favorites SET username = ? WHERE username = ?', newUsername, oldUsername]
+  ];
+
+  for (const [sql, ...params] of updates) {
+    await safeRun(db, sql, ...params);
+  }
 }
 
 async function applyEmailMapping(db, oldEmail, newEmail, username) {
@@ -160,6 +185,183 @@ async function uploadAvatarObject(request, env, username, imageBase64, fileName,
   return avatarUrlFor(request, key);
 }
 
+function migrationPlaceholderEmail(username) {
+  const normalized = String(username || 'user').replace(/[^a-zA-Z0-9._-]/g, '-');
+  return `${normalized}__rename__${Date.now()}@local.invalid`;
+}
+
+function getFinalProfileState(user, {
+  targetUsername,
+  newEmail,
+  newPhone,
+  finalAvatar,
+  passwordCreds,
+  practiceTitle,
+  practiceFilePath,
+  practiceSelectedAt,
+  updatedAt
+}) {
+  const email = newEmail !== undefined ? newEmail : normalizeOptionalString(user.email);
+  const phone = newPhone !== undefined ? newPhone : normalizeOptionalString(user.phone_number);
+  const practiceChanged = practiceTitle !== undefined;
+
+  return {
+    username: targetUsername,
+    email,
+    password_hash: passwordCreds?.passwordHash ?? user.password_hash ?? null,
+    salt: passwordCreds?.salt ?? user.salt ?? null,
+    iterations: passwordCreds?.iterations ?? user.iterations ?? null,
+    algo: passwordCreds?.algo ?? user.algo ?? null,
+    email_verified: newEmail !== undefined
+      ? (email ? 1 : 0)
+      : (user.email_verified ?? 0),
+    alipay_user_id: normalizeOptionalString(user.alipay_user_id),
+    alipay_nickname: normalizeOptionalString(user.alipay_nickname),
+    alipay_avatar: normalizeOptionalString(user.alipay_avatar),
+    alipay_bound_at: normalizeOptionalString(user.alipay_bound_at),
+    wechat_openid: normalizeOptionalString(user.wechat_openid),
+    wechat_nickname: normalizeOptionalString(user.wechat_nickname),
+    wechat_headimgurl: normalizeOptionalString(user.wechat_headimgurl),
+    wechat_bound_at: normalizeOptionalString(user.wechat_bound_at),
+    phone_number: phone,
+    firebase_uid: normalizeOptionalString(user.firebase_uid),
+    apple_user_id: normalizeOptionalString(user.apple_user_id),
+    nickname: targetUsername,
+    avatar: finalAvatar !== undefined ? finalAvatar : normalizeOptionalString(user.avatar),
+    bio: normalizeOptionalString(user.bio),
+    main_practice_title: practiceChanged
+      ? (practiceTitle ?? null)
+      : normalizeOptionalString(user.main_practice_title),
+    main_practice_file_path: practiceChanged
+      ? (practiceTitle ? practiceFilePath ?? null : null)
+      : normalizeOptionalString(user.main_practice_file_path),
+    main_practice_selected_at: practiceChanged
+      ? (practiceTitle ? practiceSelectedAt : null)
+      : normalizeOptionalString(user.main_practice_selected_at),
+    membership_type: user.membership_type || 'expired',
+    membership_expires_at: normalizeOptionalString(user.membership_expires_at),
+    free_trial_end_date: normalizeOptionalString(user.free_trial_end_date),
+    stripe_customer_id: normalizeOptionalString(user.stripe_customer_id),
+    subscription_id: normalizeOptionalString(user.subscription_id),
+    total_transferred_bytes: user.total_transferred_bytes ?? 0,
+    last_transfer_at: normalizeOptionalString(user.last_transfer_at),
+    sync_version: user.sync_version ?? 1,
+    extra_data: normalizeOptionalString(user.extra_data),
+    created_at: user.created_at,
+    updated_at: updatedAt
+  };
+}
+
+async function runInTransaction(db, action) {
+  await db.prepare('BEGIN TRANSACTION').run();
+  try {
+    const result = await action();
+    await db.prepare('COMMIT').run();
+    return result;
+  } catch (error) {
+    try {
+      await db.prepare('ROLLBACK').run();
+    } catch (rollbackError) {
+      console.warn('回滚资料更新事务失败:', rollbackError?.message || rollbackError);
+    }
+    throw error;
+  }
+}
+
+async function migrateUsernameChange(db, user, {
+  oldUsername,
+  targetUsername,
+  newEmail,
+  newPhone,
+  finalAvatar,
+  passwordCreds,
+  practiceTitle,
+  practiceFilePath,
+  practiceSelectedAt,
+  updatedAt
+}) {
+  const finalState = getFinalProfileState(user, {
+    targetUsername,
+    newEmail,
+    newPhone,
+    finalAvatar,
+    passwordCreds,
+    practiceTitle,
+    practiceFilePath,
+    practiceSelectedAt,
+    updatedAt
+  });
+
+  await runInTransaction(db, async () => {
+    await db.prepare(`
+      UPDATE users
+      SET email = ?, phone_number = NULL, firebase_uid = NULL, apple_user_id = NULL,
+          alipay_user_id = NULL, wechat_openid = NULL, updated_at = ?
+      WHERE username = ?
+    `).bind(
+      migrationPlaceholderEmail(oldUsername),
+      updatedAt,
+      oldUsername
+    ).run();
+
+    await db.prepare(`
+      INSERT INTO users (
+        username, email, password_hash, salt, iterations, algo, email_verified,
+        alipay_user_id, alipay_nickname, alipay_avatar, alipay_bound_at,
+        wechat_openid, wechat_nickname, wechat_headimgurl, wechat_bound_at,
+        phone_number, firebase_uid, apple_user_id,
+        nickname, avatar, bio,
+        main_practice_title, main_practice_file_path, main_practice_selected_at,
+        membership_type, membership_expires_at, free_trial_end_date,
+        stripe_customer_id, subscription_id,
+        total_transferred_bytes, last_transfer_at,
+        sync_version, extra_data,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      finalState.username,
+      finalState.email,
+      finalState.password_hash,
+      finalState.salt,
+      finalState.iterations,
+      finalState.algo,
+      finalState.email_verified,
+      finalState.alipay_user_id,
+      finalState.alipay_nickname,
+      finalState.alipay_avatar,
+      finalState.alipay_bound_at,
+      finalState.wechat_openid,
+      finalState.wechat_nickname,
+      finalState.wechat_headimgurl,
+      finalState.wechat_bound_at,
+      finalState.phone_number,
+      finalState.firebase_uid,
+      finalState.apple_user_id,
+      finalState.nickname,
+      finalState.avatar,
+      finalState.bio,
+      finalState.main_practice_title,
+      finalState.main_practice_file_path,
+      finalState.main_practice_selected_at,
+      finalState.membership_type,
+      finalState.membership_expires_at,
+      finalState.free_trial_end_date,
+      finalState.stripe_customer_id,
+      finalState.subscription_id,
+      finalState.total_transferred_bytes,
+      finalState.last_transfer_at,
+      finalState.sync_version,
+      finalState.extra_data,
+      finalState.created_at,
+      finalState.updated_at
+    ).run();
+
+    await updateUsernameReferences(db, oldUsername, targetUsername);
+    await applyEmailMapping(db, user.email, finalState.email, targetUsername);
+    await db.prepare('DELETE FROM users WHERE username = ?').bind(oldUsername).run();
+  });
+}
+
 export async function handleUploadAvatar(request, env, db) {
   try {
     const auth = await authenticate(request, env, db);
@@ -207,68 +409,49 @@ export async function handleUpdateProfile(request, env, db) {
 
     const oldUsername = auth.user.username;
     const targetUsername = newUsername || oldUsername;
+    const usernameChanged = targetUsername !== oldUsername;
     const updates = [];
     const values = [];
-    let usernameChanged = false;
+    const updatedAt = new Date().toISOString();
 
     if (newUsername !== undefined && newUsername !== oldUsername) {
       const existingUser = await db.getUser(newUsername);
       if (existingUser) {
         return jsonResponse({ error: '用户名已存在' }, 400);
       }
-      updates.push('username = ?');
-      values.push(newUsername);
-      updates.push('nickname = ?');
-      values.push(newUsername);
-      usernameChanged = true;
-    } else if (newUsername !== undefined) {
-      updates.push('nickname = ?');
-      values.push(newUsername);
     }
 
-    if (newEmail !== undefined) {
-      if (newEmail) {
-        const existingEmailUser = await db.getUserByEmail(newEmail);
-        if (existingEmailUser && existingEmailUser.username !== oldUsername) {
-          return jsonResponse({ error: '该邮箱已被其他账号使用' }, 400);
-        }
+    if (newEmail !== undefined && newEmail) {
+      const existingEmailUser = await db.getUserByEmail(newEmail);
+      if (existingEmailUser && existingEmailUser.username !== oldUsername) {
+        return jsonResponse({ error: '该邮箱已被其他账号使用' }, 400);
       }
-      updates.push('email = ?');
-      values.push(newEmail || '');
-      updates.push('email_verified = ?');
-      values.push(newEmail ? 1 : 0);
     }
 
-    if (newPhone !== undefined) {
-      if (newPhone) {
-        const existingPhoneUser = await db.getUserByPhone(newPhone);
-        if (existingPhoneUser && existingPhoneUser.username !== oldUsername) {
-          return jsonResponse({ error: '该手机号已被其他账号使用' }, 400);
-        }
+    if (newPhone !== undefined && newPhone) {
+      const existingPhoneUser = await db.getUserByPhone(newPhone);
+      if (existingPhoneUser && existingPhoneUser.username !== oldUsername) {
+        return jsonResponse({ error: '该手机号已被其他账号使用' }, 400);
       }
-      updates.push('phone_number = ?');
-      values.push(newPhone);
     }
 
+    let finalAvatar;
     if (body.avatar !== undefined) {
-      const avatar = normalizeOptionalString(body.avatar);
-      updates.push('avatar = ?');
-      values.push(avatar);
+      finalAvatar = normalizeOptionalString(body.avatar);
     }
 
     if (body.avatarData?.imageBase64) {
-      const avatarUrl = await uploadAvatarObject(
+      finalAvatar = await uploadAvatarObject(
         request,
         env,
-        oldUsername,
+        targetUsername,
         body.avatarData.imageBase64,
         body.avatarData.fileName,
         body.avatarData.contentType
       );
-      updates.push('avatar = ?');
-      values.push(avatarUrl);
     }
 
+    let passwordCreds;
     if (body.password !== undefined && String(body.password).length > 0) {
       const hasPassword = Boolean(auth.user.password_hash && auth.user.salt);
       if (hasPassword) {
@@ -278,15 +461,41 @@ export async function handleUpdateProfile(request, env, db) {
       if (password.length < 6 || password.length > 128) {
         return jsonResponse({ error: '密码长度需为 6-128 位' }, 400);
       }
-      const creds = await createPasswordHash(password);
-      updates.push('password_hash = ?', 'salt = ?', 'iterations = ?', 'algo = ?');
-      values.push(creds.passwordHash, creds.salt, creds.iterations, creds.algo);
+      passwordCreds = await createPasswordHash(password);
     }
 
     const mainPractice = body.mainPractice;
     const practiceTitle = mainPractice?.title ?? body.mainPracticeTitle;
     const practiceFilePath = mainPractice?.filePath ?? body.mainPracticeFilePath;
-    const practiceSelectedAt = mainPractice?.selectedAt ?? new Date().toISOString();
+    const practiceSelectedAt = mainPractice?.selectedAt ?? updatedAt;
+
+    if (!usernameChanged && newUsername !== undefined) {
+      updates.push('nickname = ?');
+      values.push(newUsername);
+    }
+
+    if (newEmail !== undefined) {
+      updates.push('email = ?');
+      values.push(newEmail || '');
+      updates.push('email_verified = ?');
+      values.push(newEmail ? 1 : 0);
+    }
+
+    if (newPhone !== undefined) {
+      updates.push('phone_number = ?');
+      values.push(newPhone);
+    }
+
+    if (finalAvatar !== undefined) {
+      updates.push('avatar = ?');
+      values.push(finalAvatar);
+    }
+
+    if (passwordCreds) {
+      updates.push('password_hash = ?', 'salt = ?', 'iterations = ?', 'algo = ?');
+      values.push(passwordCreds.passwordHash, passwordCreds.salt, passwordCreds.iterations, passwordCreds.algo);
+    }
+
     if (practiceTitle !== undefined) {
       updates.push('main_practice_title = ?');
       values.push(practiceTitle);
@@ -296,24 +505,33 @@ export async function handleUpdateProfile(request, env, db) {
       values.push(practiceTitle ? practiceSelectedAt : null);
     }
 
-    if (updates.length === 0) {
+    if (!usernameChanged && updates.length === 0) {
       return jsonResponse({ message: '没有需要更新的字段', user: serializeUser(auth.user) });
     }
 
-    updates.push('updated_at = ?');
-    values.push(new Date().toISOString());
-    values.push(oldUsername);
-
-    await db.prepare(`UPDATE users SET ${updates.join(', ')} WHERE username = ?`).bind(...values).run();
-
-    if (newEmail !== undefined) {
-      await applyEmailMapping(db, auth.user.email, newEmail, targetUsername);
-    } else if (usernameChanged && auth.user.email) {
-      await applyEmailMapping(db, auth.user.email, auth.user.email.toLowerCase(), targetUsername);
-    }
-
     if (usernameChanged) {
-      await updateUsernameReferences(db, oldUsername, targetUsername);
+      await migrateUsernameChange(db, auth.user, {
+        oldUsername,
+        targetUsername,
+        newEmail,
+        newPhone,
+        finalAvatar,
+        passwordCreds,
+        practiceTitle,
+        practiceFilePath,
+        practiceSelectedAt,
+        updatedAt
+      });
+    } else {
+      updates.push('updated_at = ?');
+      values.push(updatedAt);
+      values.push(oldUsername);
+
+      await db.prepare(`UPDATE users SET ${updates.join(', ')} WHERE username = ?`).bind(...values).run();
+
+      if (newEmail !== undefined) {
+        await applyEmailMapping(db, auth.user.email, newEmail, targetUsername);
+      }
     }
 
     const updatedUser = await db.getUser(targetUsername);

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { generateToken } from '../auth-utils.js';
+import { handleUpdateProfile } from '../src/handlers/profile.js';
+
+function createDbMock() {
+  const users = new Map();
+  const emailMapping = new Map();
+  const statements = [];
+
+  const db = {
+    users,
+    emailMapping,
+    statements,
+    async getUser(username) {
+      const user = users.get(username);
+      return user ? { ...user } : null;
+    },
+    async getUserByEmail(email) {
+      const username = emailMapping.get(email);
+      if (!username) return null;
+      const user = users.get(username);
+      return user ? { ...user } : null;
+    },
+    async getUserByPhone(phoneNumber) {
+      for (const user of users.values()) {
+        if (user.phone_number === phoneNumber) {
+          return { ...user };
+        }
+      }
+      return null;
+    },
+    prepare(sql) {
+      return {
+        bind(...params) {
+          return {
+            async run() {
+              statements.push({ sql, params });
+
+              if (/^BEGIN TRANSACTION/.test(sql) || /^COMMIT/.test(sql) || /^ROLLBACK/.test(sql)) {
+                return;
+              }
+
+              if (sql.startsWith('UPDATE users') && sql.includes('phone_number = NULL')) {
+                const [placeholderEmail, updatedAt, username] = params;
+                const user = users.get(username);
+                user.email = placeholderEmail;
+                user.phone_number = null;
+                user.firebase_uid = null;
+                user.apple_user_id = null;
+                user.alipay_user_id = null;
+                user.wechat_openid = null;
+                user.updated_at = updatedAt;
+                return;
+              }
+
+              if (sql.startsWith('INSERT INTO users')) {
+                const columnsSection = sql.slice(sql.indexOf('(') + 1, sql.indexOf(') VALUES'));
+                const columns = columnsSection.split(',').map((column) => column.trim());
+                const record = {};
+                columns.forEach((column, index) => {
+                  record[column] = params[index];
+                });
+                users.set(record.username, record);
+                return;
+              }
+
+              if (sql.startsWith('DELETE FROM users')) {
+                users.delete(params[0]);
+                return;
+              }
+
+              if (sql.startsWith('DELETE FROM email_username_mapping')) {
+                emailMapping.delete(params[0]);
+                return;
+              }
+
+              if (sql.startsWith('INSERT OR REPLACE INTO email_username_mapping')) {
+                emailMapping.set(params[0], params[1]);
+                return;
+              }
+            }
+          };
+        }
+      };
+    }
+  };
+
+  return db;
+}
+
+test('handleUpdateProfile migrates username changes without direct in-place username update', async () => {
+  const db = createDbMock();
+  db.users.set('oldname', {
+    username: 'oldname',
+    email: 'old@example.com',
+    password_hash: '',
+    salt: '',
+    iterations: 0,
+    algo: '',
+    email_verified: 1,
+    alipay_user_id: null,
+    alipay_nickname: null,
+    alipay_avatar: null,
+    alipay_bound_at: null,
+    wechat_openid: null,
+    wechat_nickname: null,
+    wechat_headimgurl: null,
+    wechat_bound_at: null,
+    phone_number: '+8613800138000',
+    firebase_uid: 'firebase-uid-1',
+    apple_user_id: null,
+    nickname: 'oldname',
+    avatar: 'https://example.com/avatar.png',
+    bio: null,
+    main_practice_title: '心经',
+    main_practice_file_path: '/sutras/xinjing.md',
+    main_practice_selected_at: '2026-05-01T00:00:00Z',
+    membership_type: 'trial',
+    membership_expires_at: null,
+    free_trial_end_date: '2026-05-31T00:00:00Z',
+    stripe_customer_id: null,
+    subscription_id: null,
+    total_transferred_bytes: 123,
+    last_transfer_at: '2026-05-04T00:00:00Z',
+    sync_version: 7,
+    extra_data: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-04T00:00:00Z'
+  });
+  db.emailMapping.set('old@example.com', 'oldname');
+
+  const env = { JWT_SECRET: 'test-secret' };
+  const token = await generateToken('oldname', env);
+  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      username: 'newname',
+      email: 'old@example.com',
+      phoneNumber: '+8613800138000'
+    })
+  });
+
+  const response = await handleUpdateProfile(request, env, db);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.user.username, 'newname');
+  assert.ok(payload.token);
+
+  assert.equal(db.users.has('oldname'), false);
+  assert.equal(db.users.has('newname'), true);
+  assert.equal(db.users.get('newname').email, 'old@example.com');
+  assert.equal(db.users.get('newname').phone_number, '+8613800138000');
+  assert.equal(db.users.get('newname').firebase_uid, 'firebase-uid-1');
+  assert.equal(db.emailMapping.get('old@example.com'), 'newname');
+
+  const directUsernameUpdate = db.statements.find(({ sql }) =>
+    sql.startsWith('UPDATE users SET') && sql.includes('username = ?')
+  );
+  assert.equal(directUsernameUpdate, undefined);
+});

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -32,54 +32,60 @@ function createDbMock() {
       return null;
     },
     prepare(sql) {
+      const execute = async (params = []) => {
+        statements.push({ sql, params });
+
+        if (/^BEGIN TRANSACTION/.test(sql) || /^COMMIT/.test(sql) || /^ROLLBACK/.test(sql)) {
+          return;
+        }
+
+        if (sql.startsWith('UPDATE users') && sql.includes('phone_number = NULL')) {
+          const [placeholderEmail, updatedAt, username] = params;
+          const user = users.get(username);
+          user.email = placeholderEmail;
+          user.phone_number = null;
+          user.firebase_uid = null;
+          user.apple_user_id = null;
+          user.alipay_user_id = null;
+          user.wechat_openid = null;
+          user.updated_at = updatedAt;
+          return;
+        }
+
+        if (sql.startsWith('INSERT INTO users')) {
+          const columnsSection = sql.slice(sql.indexOf('(') + 1, sql.indexOf(') VALUES'));
+          const columns = columnsSection.split(',').map((column) => column.trim());
+          const record = {};
+          columns.forEach((column, index) => {
+            record[column] = params[index];
+          });
+          users.set(record.username, record);
+          return;
+        }
+
+        if (sql.startsWith('DELETE FROM users')) {
+          users.delete(params[0]);
+          return;
+        }
+
+        if (sql.startsWith('DELETE FROM email_username_mapping')) {
+          emailMapping.delete(params[0]);
+          return;
+        }
+
+        if (sql.startsWith('INSERT OR REPLACE INTO email_username_mapping')) {
+          emailMapping.set(params[0], params[1]);
+        }
+      };
+
       return {
+        async run() {
+          return execute();
+        },
         bind(...params) {
           return {
             async run() {
-              statements.push({ sql, params });
-
-              if (/^BEGIN TRANSACTION/.test(sql) || /^COMMIT/.test(sql) || /^ROLLBACK/.test(sql)) {
-                return;
-              }
-
-              if (sql.startsWith('UPDATE users') && sql.includes('phone_number = NULL')) {
-                const [placeholderEmail, updatedAt, username] = params;
-                const user = users.get(username);
-                user.email = placeholderEmail;
-                user.phone_number = null;
-                user.firebase_uid = null;
-                user.apple_user_id = null;
-                user.alipay_user_id = null;
-                user.wechat_openid = null;
-                user.updated_at = updatedAt;
-                return;
-              }
-
-              if (sql.startsWith('INSERT INTO users')) {
-                const columnsSection = sql.slice(sql.indexOf('(') + 1, sql.indexOf(') VALUES'));
-                const columns = columnsSection.split(',').map((column) => column.trim());
-                const record = {};
-                columns.forEach((column, index) => {
-                  record[column] = params[index];
-                });
-                users.set(record.username, record);
-                return;
-              }
-
-              if (sql.startsWith('DELETE FROM users')) {
-                users.delete(params[0]);
-                return;
-              }
-
-              if (sql.startsWith('DELETE FROM email_username_mapping')) {
-                emailMapping.delete(params[0]);
-                return;
-              }
-
-              if (sql.startsWith('INSERT OR REPLACE INTO email_username_mapping')) {
-                emailMapping.set(params[0], params[1]);
-                return;
-              }
+              return execute(params);
             }
           };
         }

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -32,14 +32,16 @@ function createDbMock() {
       return null;
     },
     prepare(sql) {
+      const normalizedSql = sql.trimStart();
+
       const execute = async (params = []) => {
         statements.push({ sql, params });
 
-        if (/^BEGIN TRANSACTION/.test(sql) || /^COMMIT/.test(sql) || /^ROLLBACK/.test(sql)) {
+        if (/^BEGIN TRANSACTION/.test(normalizedSql) || /^COMMIT/.test(normalizedSql) || /^ROLLBACK/.test(normalizedSql)) {
           return;
         }
 
-        if (sql.startsWith('UPDATE users') && sql.includes('phone_number = NULL')) {
+        if (normalizedSql.startsWith('UPDATE users') && normalizedSql.includes('phone_number = NULL')) {
           const [placeholderEmail, updatedAt, username] = params;
           const user = users.get(username);
           user.email = placeholderEmail;
@@ -52,8 +54,8 @@ function createDbMock() {
           return;
         }
 
-        if (sql.startsWith('INSERT INTO users')) {
-          const columnsSection = sql.slice(sql.indexOf('(') + 1, sql.indexOf(') VALUES'));
+        if (normalizedSql.startsWith('INSERT INTO users')) {
+          const columnsSection = normalizedSql.slice(normalizedSql.indexOf('(') + 1, normalizedSql.indexOf(') VALUES'));
           const columns = columnsSection.split(',').map((column) => column.trim());
           const record = {};
           columns.forEach((column, index) => {
@@ -63,17 +65,17 @@ function createDbMock() {
           return;
         }
 
-        if (sql.startsWith('DELETE FROM users')) {
+        if (normalizedSql.startsWith('DELETE FROM users')) {
           users.delete(params[0]);
           return;
         }
 
-        if (sql.startsWith('DELETE FROM email_username_mapping')) {
+        if (normalizedSql.startsWith('DELETE FROM email_username_mapping')) {
           emailMapping.delete(params[0]);
           return;
         }
 
-        if (sql.startsWith('INSERT OR REPLACE INTO email_username_mapping')) {
+        if (normalizedSql.startsWith('INSERT OR REPLACE INTO email_username_mapping')) {
           emailMapping.set(params[0], params[1]);
         }
       };


### PR DESCRIPTION
## 概要
- 修复编辑资料时“更改名字报错”的主因：用户名改动不再原地更新 `users.username`
- 改为在 Worker 里执行可事务回滚的“新用户行插入 + 关联表迁移 + 旧用户行删除”迁移流程
- 补一条针对用户名迁移路径的 Worker 单测，防止后续再次退化为直接改主表

Fixes #103

## 根因
当前 `handleUpdateProfile` 在用户名变更时直接执行：
- `UPDATE users SET username = ? ... WHERE username = ?`
- 然后再尝试补更新其他映射和关联表

但仓库当前 D1 schema 已经广泛使用 `username -> users(username)` 作为外键或事实关联键，而且并没有统一的 `ON UPDATE CASCADE`。这样一来，线上一旦真的执行改名，就很容易在主表先改名这一步直接撞上引用约束，或者留下部分旧表名/旧列名没迁完的悬空状态。

另外，旧实现里用于“补更新引用”的表清单仍混有较早时期的命名：
- `likes` / `favorites`
- `purchase_history.user_id`

而当前 schema 已经演进出更多以 `username` 为主键关联的表，例如：
- `orders.username`
- `content_likes.username`
- `content_favorites.username`
- `user_follows.*`
- `notifications.*`
- `meditation_*`
- `sync_log` / `user_sync_state`

所以这个问题不是简单的前端输入报错，而是用户名迁移策略与当前数据模型已经不匹配。

## 修复思路
这次改为按引用完整性来做用户名迁移：
1. 先验证新用户名、邮箱、手机号唯一性
2. 如果用户名未变化，继续走原来的轻量字段更新路径
3. 如果用户名变化：
   - 在事务中先临时释放旧用户行上的唯一邮箱/手机号/第三方身份占位
   - 插入一条带新用户名的新用户记录，并保留原有会员、登录、统计与资料字段
   - 批量迁移已知关联表的 `username` 引用
   - 重建邮箱映射
   - 删除旧用户行
4. 最后重新签发新用户名 token

这让改名过程不再依赖数据库层必须支持 `ON UPDATE CASCADE`，而是由应用层显式完成可控迁移。

## 改动范围
- `fabushi/web/src/handlers/profile.js`
  - 新增用户名迁移事务逻辑
  - 扩展关联表更新清单
  - 保留未改名场景的轻量更新路径
- `fabushi/web/tests/profile.test.js`
  - 新增回归测试，验证改名成功且不会再发出 `UPDATE users SET username = ?` 这类原地重命名 SQL

## 风险与验证
- 风险集中在 Worker 资料更新链路，不改 Flutter 页面交互
- 这次是把高风险的“原地重命名”换成显式迁移，目的是和当前 D1 约束模型对齐
- 新增的 Worker 单测覆盖了这条最关键的回归路径
- 还需要依赖 PR CI 继续验证现有 Worker contract tests 和整条主线交付链路

## 合并后跟进
- 优先确认这条 PR 的 `CI` 绿灯
- 合并后继续确认 `main` 上的 CI/CD/Release 仍保持闭环
- 再回看 issue #103，确认线上“更改名字报错”已消失