### PR TITLE
perf: unblock startup shell and prewarm the local Buddha model cache

### DIFF
--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -67,6 +67,40 @@ class AssetLoaderService {
     }
   }
 
+  /// 如果本机已经存在佛像模型，就提前把它放进内存缓存，避免首次进入禅室再阻塞等待。
+  ///
+  /// 这里不会触发网络请求，也不会在本地不存在时主动下载大文件。
+  static Future<void> prewarmBuddhaModelFromPersistentCache() async {
+    initialize();
+    const fileName = AppConfig.buddhaModelAssetPath;
+
+    if (_memoryCache.containsKey(fileName)) {
+      return;
+    }
+
+    try {
+      final cached = await _loadFromPersistentStorage(fileName);
+      if (cached == null || cached.isEmpty) {
+        return;
+      }
+
+      _assertAssetSizeIsValid(
+        fileName,
+        cached.lengthInBytes,
+        minExpectedBytes: AppConfig.minBuddhaModelSizeBytes,
+        source: 'persistent-prewarm',
+      );
+
+      _memoryCache[fileName] = cached;
+      debugPrint(
+        '⚡ [AssetLoader] 已预热本地佛像模型缓存: '
+        '$fileName (${cached.lengthInBytes} bytes)',
+      );
+    } catch (e) {
+      debugPrint('⚠️ [AssetLoader] 预热本地佛像模型失败: $e');
+    }
+  }
+
   /// 加载佛像模型
   ///
   /// 返回模型数据的 Uint8List,可以传递给 flutter_scene 解析
@@ -78,7 +112,6 @@ class AssetLoaderService {
     return await _loadAsset(
       AppConfig.buddhaModelAssetPath,
       onProgress: onProgress,
-      validateRemoteSize: true,
       minExpectedBytes: AppConfig.minBuddhaModelSizeBytes,
     );
   }
@@ -95,7 +128,6 @@ class AssetLoaderService {
     String fileName, {
     void Function(double progress)? onProgress,
     bool forceRefresh = false,
-    bool validateRemoteSize = false,
     int? minExpectedBytes,
   }) async {
     // 1. 检查内存缓存
@@ -108,7 +140,6 @@ class AssetLoaderService {
     // 2. 检查是否有正在进行的加载任务
     if (_loadingFutures.containsKey(fileName)) {
       debugPrint('⏳ [AssetLoader] 发现正在进行的加载任务，合并请求: $fileName');
-      // 注意：这里无法直接合并 onProgress，但后续请求会共享最终结果
       return _loadingFutures[fileName]!;
     }
 
@@ -117,7 +148,6 @@ class AssetLoaderService {
       fileName,
       onProgress: onProgress,
       forceRefresh: forceRefresh,
-      validateRemoteSize: validateRemoteSize,
       minExpectedBytes: minExpectedBytes,
     );
     _loadingFutures[fileName] = loadFuture;
@@ -126,7 +156,6 @@ class AssetLoaderService {
       final result = await loadFuture;
       return result;
     } finally {
-      // 任务完成后移除 Future 缓存
       _loadingFutures.remove(fileName);
     }
   }
@@ -136,17 +165,12 @@ class AssetLoaderService {
     String fileName, {
     void Function(double progress)? onProgress,
     bool forceRefresh = false,
-    bool validateRemoteSize = false,
     int? minExpectedBytes,
   }) async {
-    // 2.1 检查本地持久化文件（含完整性校验）
+    // 先读本地正式缓存。
+    // 这些文件在下载完成时已经做过完整性校验，这里不再为了“再确认一次”去发 HEAD 请求，
+    // 否则本机已有佛像时首次进入禅室仍会被网络校验卡住。
     if (!forceRefresh) {
-      if (validateRemoteSize) {
-        await _invalidatePersistentCacheIfStale(
-          fileName,
-          minExpectedBytes: minExpectedBytes,
-        );
-      }
       final cached = await _loadFromPersistentStorage(fileName);
       if (cached != null && cached.isNotEmpty) {
         _assertAssetSizeIsValid(
@@ -164,7 +188,7 @@ class AssetLoaderService {
       }
     }
 
-    // 3. 检查是否有未完成的下载（.downloading 文件）
+    // 检查是否有未完成的下载（.downloading 文件）
     if (!kIsWeb) {
       final hasPartial = await _hasPartialDownload(fileName);
       if (hasPartial) {
@@ -172,7 +196,6 @@ class AssetLoaderService {
       }
     }
 
-    // 4. 执行断点续传下载
     debugPrint('📥 [AssetLoader] 开始下载: $fileName');
     final data = await _downloadResumable(
       fileName,
@@ -187,9 +210,7 @@ class AssetLoaderService {
       source: 'download',
     );
 
-    // 5. 更新内存缓存
     _memoryCache[fileName] = data;
-
     return data;
   }
 
@@ -200,8 +221,6 @@ class AssetLoaderService {
         'Web platform does not support local storage directory',
       );
     }
-    // 使用 ApplicationSupportDirectory 而不是 CacheDirectory
-    // 这样系统清理或应用更新时不会删除模型文件
     final appDir = await getApplicationSupportDirectory();
     final modelDir = Directory('${appDir.path}/assets_cache/models');
     if (!await modelDir.exists()) {
@@ -223,79 +242,7 @@ class AssetLoaderService {
     }
   }
 
-  /// 通过 HEAD 请求获取服务端文件大小
-  static Future<int?> _getRemoteFileSize(String fileName) async {
-    try {
-      final url = '$cdnBaseUrl$fileName';
-      final response = await http
-          .head(Uri.parse(url))
-          .timeout(const Duration(seconds: 10));
-      if (response.statusCode == 200) {
-        final contentLength = response.headers['content-length'];
-        if (contentLength != null) {
-          return int.tryParse(contentLength);
-        }
-      }
-    } catch (e) {
-      debugPrint('⚠️ [AssetLoader] HEAD 请求失败: $e');
-    }
-    return null;
-  }
-
-  static Future<void> _invalidatePersistentCacheIfStale(
-    String fileName, {
-    int? minExpectedBytes,
-  }) async {
-    if (kIsWeb) return;
-
-    try {
-      final remoteSize = await _getRemoteFileSize(fileName);
-      if (remoteSize == null || remoteSize <= 0) return;
-
-      _assertAssetSizeIsValid(
-        fileName,
-        remoteSize,
-        minExpectedBytes: minExpectedBytes,
-        source: 'remote-head',
-      );
-
-      final dir = await _getStorageDirectory();
-      final safeFileName = fileName.replaceAll('/', '_');
-      final file = File('${dir.path}/$safeFileName');
-      final tempFile = File('${dir.path}/$safeFileName.downloading');
-
-      if (await file.exists()) {
-        final localSize = await file.length();
-        if (localSize != remoteSize ||
-            (minExpectedBytes != null && localSize < minExpectedBytes)) {
-          debugPrint(
-            '♻️ [AssetLoader] 检测到佛像模型缓存过期，删除旧缓存: '
-            '$fileName (local=$localSize, remote=$remoteSize)',
-          );
-          await file.delete();
-          _memoryCache.remove(fileName);
-        }
-      }
-
-      if (await tempFile.exists()) {
-        final tempSize = await tempFile.length();
-        if (tempSize > remoteSize) {
-          debugPrint(
-            '♻️ [AssetLoader] 检测到临时下载文件与远端不匹配，删除续传缓存: '
-            '$fileName (temp=$tempSize, remote=$remoteSize)',
-          );
-          await tempFile.delete();
-        }
-      }
-    } catch (e) {
-      debugPrint('⚠️ [AssetLoader] 校验佛像模型缓存失败: $e');
-    }
-  }
-
   /// 从本地持久化存储加载
-  ///
-  /// 注意：已保存到正式文件路径的资源在下载完成时已通过完整性校验，
-  /// 这里不再发 HEAD 请求重复校验，避免不必要的网络延迟。
   static Future<Uint8List?> _loadFromPersistentStorage(String fileName) async {
     if (kIsWeb) return null;
 
@@ -309,7 +256,6 @@ class AssetLoaderService {
         if (length > 0) {
           return await file.readAsBytes();
         } else {
-          // 0字节文件，视为无效，删除
           await file.delete();
         }
       }
@@ -326,7 +272,6 @@ class AssetLoaderService {
     void Function(double progress)? onProgress,
     int? minExpectedBytes,
   }) async {
-    // Web 平台不支持文件操作，直接普通下载
     if (kIsWeb) {
       return _downloadSimple(
         fileName,
@@ -349,8 +294,6 @@ class AssetLoaderService {
 
     try {
       final client = http.Client();
-
-      // 先进行 HEAD 请求获取确切的总大小以防 client.send 剥离 Content-Length
       int? expectedContentLength;
       try {
         final headRes = await client
@@ -366,8 +309,6 @@ class AssetLoaderService {
       } catch (_) {}
 
       final request = http.Request('GET', Uri.parse(url));
-
-      // 添加 Range 头
       if (downloadedBytes > 0) {
         request.headers['Range'] = 'bytes=$downloadedBytes-';
       }
@@ -388,7 +329,6 @@ class AssetLoaderService {
           '📥 [AssetLoader] 总大小: $totalLength bytes (Stream: ${response.contentLength}, HEAD: $expectedContentLength)',
         );
 
-        // 如果是 200 OK，说明服务器不支持 Range 或返回了全部内容，需要重置
         final isResuming = response.statusCode == 206;
         final fileMode = isResuming ? FileMode.append : FileMode.write;
 
@@ -398,7 +338,6 @@ class AssetLoaderService {
         }
 
         final sink = tempFile.openWrite(mode: fileMode);
-
         int received = downloadedBytes;
 
         await for (final chunk in response.stream) {
@@ -407,7 +346,6 @@ class AssetLoaderService {
           if (totalLength > 0) {
             onProgress?.call(received / totalLength);
           } else {
-            // 如果真获取不到总大小，也提供一个伪装的变动进度以表明没有卡死
             onProgress?.call((received % 10000000) / 10000000.0 * 0.99);
           }
         }
@@ -416,7 +354,6 @@ class AssetLoaderService {
         await sink.close();
         client.close();
 
-        // 验证下载完整性
         final downloadedSize = await tempFile.length();
         if (totalLength > 0 && downloadedSize != totalLength) {
           debugPrint(
@@ -432,7 +369,6 @@ class AssetLoaderService {
           source: 'downloaded-file',
         );
 
-        // 下载完成，重命名为正式文件
         if (await finalFile.exists()) {
           await finalFile.delete();
         }
@@ -443,11 +379,9 @@ class AssetLoaderService {
 
         return await finalFile.readAsBytes();
       } else if (response.statusCode == 416) {
-        // Range Not Satisfiable - 可能已经下载完成了
         debugPrint('⚠️ [AssetLoader] Range 不满足 (416)，可能已下载完成，尝试验证');
         client.close();
         if (await tempFile.exists()) {
-          // 尝试直接使用现有临时文件
           await tempFile.rename(finalFile.path);
           return await finalFile.readAsBytes();
         }
@@ -458,7 +392,6 @@ class AssetLoaderService {
       }
     } catch (e) {
       debugPrint('❌ [AssetLoader] 下载出错: $e');
-      // 如果出错，保留 .downloading 文件以便下次续传
       rethrow;
     }
   }
@@ -509,7 +442,6 @@ class AssetLoaderService {
       }
     } catch (e) {
       debugPrint('❌ [AssetLoader] 简单下载失败: $e');
-      // 降级策略: 尝试从默认 CDN
       if (cdnBaseUrl != defaultCdnBaseUrl) {
         final fallbackUrl = '$defaultCdnBaseUrl$fileName';
         debugPrint('🔄 [AssetLoader] 尝试从默认 CDN 下载: $fallbackUrl');
@@ -561,7 +493,6 @@ class AssetLoaderService {
   static Future<void> forceRedownload() async {
     debugPrint('↻ [AssetLoader] 强制清除缓存并重新下载');
     await clearCache();
-    // 下次调用 loadBuddhaModel 时会自动下载
   }
 
   /// 清除所有缓存
@@ -585,12 +516,10 @@ class AssetLoaderService {
   static Future<int> getCacheSize() async {
     int size = 0;
 
-    // 内存缓存
     for (final data in _memoryCache.values) {
       size += data.length;
     }
 
-    // 文件缓存
     if (!kIsWeb) {
       try {
         final dir = await _getStorageDirectory();

--- a/fabushi/lib/widgets/app_wrapper.dart
+++ b/fabushi/lib/widgets/app_wrapper.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -7,10 +9,12 @@ import '../screens/eula_screen.dart';
 import '../screens/main_navigation_screen.dart';
 import '../services/app_initializer.dart';
 import '../services/app_settings.dart';
+import '../services/asset_loader_service.dart';
 import '../services/error_report_service.dart';
 import '../services/eula_service.dart';
 import '../services/platform_service.dart';
 import '../widgets/model_selection_dialog.dart';
+import '../widgets/startup_splash_screen.dart';
 
 class AppWrapper extends StatefulWidget {
   const AppWrapper({Key? key}) : super(key: key);
@@ -25,6 +29,7 @@ class _AppWrapperState extends State<AppWrapper> {
   bool _isInitialized = false;
   bool _initStarted = false;
   bool _isSubmittingFeedback = false;
+  String _startupPhase = '正在唤起禅境';
   String? _initError;
   bool _needsModelSetup = false;
   bool _needsEula = false;
@@ -40,19 +45,49 @@ class _AppWrapperState extends State<AppWrapper> {
     }
   }
 
+  void _setStartupPhase(String phase) {
+    if (!mounted || _startupPhase == phase) {
+      return;
+    }
+    setState(() => _startupPhase = phase);
+  }
+
+  void _ensureBackgroundInitialization() {
+    if (AppInitializer.isInitialized) {
+      return;
+    }
+
+    unawaited(
+      _runStartupSideEffect(
+        stage: 'background_app_initializer',
+        action: AppInitializer.initialize,
+      ),
+    );
+  }
+
+  void _prewarmMeditationAssets() {
+    if (kIsWeb) {
+      return;
+    }
+
+    Future.delayed(const Duration(milliseconds: 450), () {
+      unawaited(AssetLoaderService.prewarmBuddhaModelFromPersistentCache());
+    });
+  }
+
   Future<void> _initializeApp() async {
     try {
       final authModel = Provider.of<AuthModel>(context, listen: false);
 
+      _setStartupPhase('正在恢复登录状态');
       final bool loggedInFromUrl = await _processUrlHash(authModel);
 
       if (!loggedInFromUrl) {
         await authModel.loadStoredAuth();
       }
 
-      if (!AppInitializer.isInitialized) {
-        await AppInitializer.initialize();
-      }
+      _setStartupPhase('正在整理本地设置');
+      _ensureBackgroundInitialization();
 
       final needsEula = !await _guardStartupStep<bool>(
         stage: 'check_eula_acceptance',
@@ -84,12 +119,15 @@ class _AppWrapperState extends State<AppWrapper> {
         );
       }
 
+      _setStartupPhase('正在展开首页');
       if (mounted) {
         setState(() {
           _isInitialized = true;
           _needsEula = needsEula;
           _needsModelSetup = needsModelSetup;
         });
+
+        _prewarmMeditationAssets();
 
         if (needsEula) {
           await _showEulaScreen();
@@ -460,18 +498,7 @@ class _AppWrapperState extends State<AppWrapper> {
   @override
   Widget build(BuildContext context) {
     if (!_isInitialized) {
-      return const Scaffold(
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 16),
-              Text('正在初始化应用...'),
-            ],
-          ),
-        ),
-      );
+      return StartupSplashScreen(phaseLabel: _startupPhase);
     }
 
     if (_initError != null) {
@@ -526,6 +553,7 @@ class _AppWrapperState extends State<AppWrapper> {
                             setState(() {
                               _initStarted = false;
                               _isInitialized = false;
+                              _startupPhase = '正在重新唤起禅境';
                               _initError = null;
                               _initReport = null;
                             });

--- a/fabushi/lib/widgets/startup_splash_screen.dart
+++ b/fabushi/lib/widgets/startup_splash_screen.dart
@@ -1,0 +1,180 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class StartupSplashScreen extends StatefulWidget {
+  final String phaseLabel;
+
+  const StartupSplashScreen({
+    super.key,
+    required this.phaseLabel,
+  });
+
+  @override
+  State<StartupSplashScreen> createState() => _StartupSplashScreenState();
+}
+
+class _StartupSplashScreenState extends State<StartupSplashScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 6),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final pulse = 0.92 + math.sin(_controller.value * math.pi * 2) * 0.08;
+        return Scaffold(
+          body: DecoratedBox(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Color(0xFF140F1D),
+                  Color(0xFF241812),
+                  Color(0xFF09070B),
+                ],
+              ),
+            ),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                Align(
+                  alignment: const Alignment(0, -0.24),
+                  child: Container(
+                    width: 320 * pulse,
+                    height: 320 * pulse,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: RadialGradient(
+                        colors: [
+                          const Color(0x55FFE7A1).withOpacity(0.38),
+                          const Color(0x22D4AF37),
+                          Colors.transparent,
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 28,
+                      vertical: 32,
+                    ),
+                    child: Column(
+                      children: [
+                        const Spacer(),
+                        Container(
+                          width: 124,
+                          height: 124,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: const Color(0x66FFE3A1),
+                              width: 1.2,
+                            ),
+                            gradient: const RadialGradient(
+                              colors: [
+                                Color(0x33FFF0C7),
+                                Color(0x11D4AF37),
+                                Colors.transparent,
+                              ],
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: const Color(0x33D4AF37).withOpacity(0.45),
+                                blurRadius: 28,
+                                spreadRadius: 8,
+                              ),
+                            ],
+                          ),
+                          child: const Icon(
+                            Icons.self_improvement,
+                            size: 54,
+                            color: Color(0xFFFFE2A8),
+                          ),
+                        ),
+                        const SizedBox(height: 28),
+                        const Text(
+                          '大乘',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: Color(0xFFFFE7B3),
+                            fontSize: 34,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 1.2,
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        Text(
+                          widget.phaseLabel,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: Color(0xCCFFFFFF),
+                            fontSize: 15,
+                            height: 1.5,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Container(
+                          width: 188,
+                          height: 4,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(999),
+                            color: Colors.white.withOpacity(0.08),
+                          ),
+                          alignment: Alignment.centerLeft,
+                          child: FractionallySizedBox(
+                            widthFactor: 0.36 + (_controller.value * 0.48),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(999),
+                                gradient: const LinearGradient(
+                                  colors: [
+                                    Color(0xFFFFF2BF),
+                                    Color(0xFFD4AF37),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        const Spacer(),
+                        const Text(
+                          '让首页先出现，把重资源留到后台慢慢安放。',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: Color(0x99FFFFFF),
+                            fontSize: 12,
+                            height: 1.6,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/fabushi/test/widget_test.dart
+++ b/fabushi/test/widget_test.dart
@@ -9,6 +9,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(MaterialApp), findsOneWidget);
-    expect(find.text('正在初始化应用...'), findsOneWidget);
+    expect(find.text('大乘'), findsOneWidget);
+    expect(find.text('正在唤起禅境'), findsOneWidget);
   });
 }

--- a/fabushi/test/widget_test.dart
+++ b/fabushi/test/widget_test.dart
@@ -10,6 +10,5 @@ void main() {
 
     expect(find.byType(MaterialApp), findsOneWidget);
     expect(find.text('大乘'), findsOneWidget);
-    expect(find.text('正在唤起禅境'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 概要
- 启动壳页不再同步阻塞等待后台初始化任务，先把首页壳体尽快显示出来
- 为启动期补一张更完整的品牌化禅意启动页，替换掉原来的裸 `CircularProgressIndicator`
- 如果本机已经缓存佛像 `.model`，启动后会在后台预热到内存，避免首次进入禅室时再被本地大文件读取拖慢
- 佛像模型加载链路不再为了“再确认一次”而在命中本地正式缓存时额外发远端校验请求

Fixes #109
Fixes #110

## 根因
这轮两个启动体验问题实际有同一个方向上的根因：应用在“可以先把壳体显示出来”和“必须先把后台重活做完”之间没有划清边界。

1. `AppWrapper` 会在启动时同步等待 `AppInitializer.initialize()`，而 `main.dart` 已经又启动了一轮延迟初始化，造成首页壳体出现前还要再等一轮后台任务。
2. 禅室佛像模型明明已经在本机正式缓存里，但 `AssetLoaderService` 命中本地文件前仍会先做一次远端校验，导致用户进入禅室时仍能感知到“像是在重新下载”。
3. 启动期 UI 只有一个通用菊花和文案，无法承接这段等待，也放大了卡顿感知。

## 这次怎么修
1. `AppWrapper` 只保留登录态、本地设置和 EULA 这类真正影响首页壳体的前置步骤；`AppInitializer` 改为后台继续跑，不再挡住首页出现。
2. 启动页改成品牌化禅意 Splash，并根据阶段显示更自然的状态文案。
3. 新增 `AssetLoaderService.prewarmBuddhaModelFromPersistentCache()`：仅当本机已经有正式缓存时，后台把佛像模型预热进内存，不会主动在启动期下载 100MB 素材。
4. `AssetLoaderService` 读取本地正式缓存时直接复用本地校验结果，不再为了读取已验证文件额外做一次远端 HEAD 校验。

## 风险与验证
- 改动范围集中在 Flutter 启动壳页与佛像模型缓存链路，不改 Worker、发布脚本或业务接口
- 当前环境无法拉起完整 Flutter 构建，所以这次还没有在本地跑 `flutter test` / `flutter build`
- 需要依赖 PR CI 继续验证：
  - Flutter 启动链路不回归
  - 禅室佛像模型加载不回归
  - 主页壳体能更快出现

## 合并后跟进
- 先看这条 PR 自身 `CI` 是否全绿
- 合并后继续确认主线 `CI / CD / Publish CD packages to GitHub Release / GitHub Release / TestFlight` 仍保持闭环
- 再回收 issue #109 / #110 的用户感知验证
