### PR TITLE
fix: compress oversized avatars and persist fresh profile state

### DIFF
--- a/fabushi/lib/models/auth_model.dart
+++ b/fabushi/lib/models/auth_model.dart
@@ -86,7 +86,6 @@ class User {
 }
 
 class AuthModel extends ChangeNotifier {
-  // 服务实例
   final AuthService _authService = AuthService();
   final MembershipService _membershipService = MembershipService();
   final AlipayAuthService _alipayAuthService = AlipayAuthService();
@@ -108,6 +107,49 @@ class AuthModel extends ChangeNotifier {
     // Initialization is now handled by the UI layer (AppWrapper) to avoid race conditions.
   }
 
+  DateTime? _parseMembershipExpiry(dynamic expiresAt) {
+    if (expiresAt is! String || expiresAt.isEmpty) {
+      return null;
+    }
+    try {
+      return DateTime.parse(expiresAt);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  User _userFromServerPayload(
+    Map<String, dynamic> userJson, {
+    required bool isAdmin,
+    String? fallbackUsername,
+    String? fallbackEmail,
+    String? fallbackPhoneNumber,
+    String? fallbackFirebaseUid,
+    String? fallbackMembershipType,
+    DateTime? fallbackMembershipExpiry,
+  }) {
+    final membershipJson = userJson['membership'];
+    final membershipType = membershipJson is Map
+        ? membershipJson['type'] as String?
+        : fallbackMembershipType;
+    final membershipExpiry = membershipJson is Map
+        ? _parseMembershipExpiry(membershipJson['expiresAt']) ?? fallbackMembershipExpiry
+        : fallbackMembershipExpiry;
+
+    return User(
+      username: userJson['username'] ?? fallbackUsername ?? '',
+      email: userJson['email'] ?? fallbackEmail ?? '',
+      membershipType: membershipType,
+      membershipExpiry: membershipExpiry,
+      isAdmin: isAdmin,
+      alipayUserId: userJson['alipayUserId'] ?? userJson['alipay_user_id'],
+      nickname: userJson['nickname'],
+      avatar: userJson['avatar'],
+      phoneNumber: userJson['phoneNumber'] ?? userJson['phone_number'] ?? fallbackPhoneNumber,
+      firebaseUid: userJson['firebaseUid'] ?? userJson['firebase_uid'] ?? fallbackFirebaseUid,
+    );
+  }
+
   Future<void> _syncMeditationPracticeForCurrentUser() async {
     await MeditationSessionManager().switchUser(_currentUser?.username);
   }
@@ -123,7 +165,6 @@ class AuthModel extends ChangeNotifier {
         final userData = json.decode(userJsonString);
         _currentUser = User.fromJson(userData);
 
-        // 关键：设置 AuthService 的 token
         final basicUserModel = UserModel(
           username: _currentUser!.username,
           email: _currentUser!.email,
@@ -147,18 +188,14 @@ class AuthModel extends ChangeNotifier {
         await _syncMeditationPracticeForCurrentUser();
         unawaited(PracticeStatsService().flushPendingRecords());
 
-        // 初始化同步服务并拉取最新数据
         await SyncService().initialize();
-        SyncService().pullFromCloud(); // 后台异步同步
+        SyncService().pullFromCloud();
 
-        notifyListeners(); // 立即更新UI显示登录状态
-
-        // 后台异步刷新用户信息（不阻塞UI）
+        notifyListeners();
         refreshUserInfo();
       }
     } catch (e) {
       debugPrint('加载存储的认证信息失败: $e');
-      // 加载失败时清除状态
       _currentUser = null;
       _token = null;
       notifyListeners();
@@ -176,25 +213,27 @@ class AuthModel extends ChangeNotifier {
         _token = result['token'];
         final userJson = result['user'];
 
-        // 登录后，额外获取管理员状态
-        final adminStatusResult = await _membershipService.getAdminStats(
-          _token!,
-        );
+        final adminStatusResult = await _membershipService.getAdminStats(_token!);
         final bool isAdmin =
             adminStatusResult['success'] == true &&
             adminStatusResult['isAdmin'] == true;
 
-        final membershipJson = userJson['membership'] ?? {};
-        _currentUser = User(
-          username: userJson['username'] ?? '',
-          email: userJson['email'] ?? '',
-          membershipType: membershipJson['type'],
-          membershipExpiry: membershipJson['expiresAt'] != null
-              ? DateTime.parse(membershipJson['expiresAt'])
-              : null,
-          isAdmin: isAdmin,
-          alipayUserId: userJson['alipayUserId'],
-        );
+        if (userJson is Map<String, dynamic>) {
+          _currentUser = _userFromServerPayload(
+            userJson,
+            isAdmin: isAdmin,
+            fallbackUsername: username,
+            fallbackEmail: username.contains('@') ? username : '',
+          );
+        } else {
+          _currentUser = User(
+            username: username,
+            email: username.contains('@') ? username : '',
+            membershipType: null,
+            membershipExpiry: null,
+            isAdmin: isAdmin,
+          );
+        }
 
         await _storeAuth();
         PracticeStatsService().setAuthToken(_token);
@@ -202,14 +241,12 @@ class AuthModel extends ChangeNotifier {
         await _syncMeditationPracticeForCurrentUser();
         unawaited(PracticeStatsService().flushPendingRecords());
 
-        // 初始化同步服务并进行全量同步
         await SyncService().initialize();
-        SyncService().fullSync(); // 后台全量同步
+        SyncService().fullSync();
 
         _setLoading(false);
         notifyListeners();
 
-        // 后台异步刷新完整用户信息（包括会员信息）
         refreshUserInfo();
 
         return true;
@@ -243,7 +280,6 @@ class AuthModel extends ChangeNotifier {
       );
 
       if (result['success'] == true) {
-        // 注册成功后自动登录
         _setLoading(false);
         return await login(username, password);
       } else {
@@ -330,7 +366,6 @@ class AuthModel extends ChangeNotifier {
     try {
       debugPrint('🔄 开始刷新用户信息...');
 
-      // 先获取管理员状态
       final adminStatusResult = await _membershipService.getAdminStats(_token!);
       final bool isAdmin =
           adminStatusResult['success'] == true &&
@@ -338,7 +373,6 @@ class AuthModel extends ChangeNotifier {
 
       debugPrint('👤 管理员状态: $isAdmin');
 
-      // 再刷新用户信息
       await _authService.refreshUserInfo();
       final userModel = _authService.currentUser;
 
@@ -375,7 +409,6 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  // 支付宝登录相关方法
   Future<Map<String, dynamic>> getAlipayLoginUrl({String? platform}) async {
     try {
       return await _alipayAuthService.getAlipayLoginUrl(platform: platform);
@@ -397,7 +430,6 @@ class AuthModel extends ChangeNotifier {
         final username = result['username'] ?? '';
         final email = result['email'] ?? '';
 
-        // 先设置token到AuthService
         final basicUserModel = UserModel(
           username: username,
           email: email,
@@ -407,7 +439,6 @@ class AuthModel extends ChangeNotifier {
         );
         await _authService.setAuth(_token!, basicUserModel);
 
-        // 创建临时用户对象
         _currentUser = User(
           username: username,
           email: email,
@@ -423,7 +454,6 @@ class AuthModel extends ChangeNotifier {
         _setLoading(false);
         notifyListeners();
 
-        // 后台刷新完整用户信息（包括会员信息和管理员状态）
         refreshUserInfo();
         return true;
       } else {
@@ -438,7 +468,6 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  /// 支付宝一键注册（无需填写信息）- 从macOS回调参数直接注册
   Future<bool> alipayOneClickRegister(
     String alipayUserId,
     String? nickname,
@@ -450,7 +479,6 @@ class AuthModel extends ChangeNotifier {
     try {
       debugPrint('支付宝一键注册开始: alipayUserId=$alipayUserId');
 
-      // 直接调用一键注册API（授权码已在回调时使用）
       final result = await _alipayAuthService.alipayOneClickRegister(
         alipayUserId: alipayUserId,
         nickname: nickname,
@@ -462,12 +490,10 @@ class AuthModel extends ChangeNotifier {
       );
 
       if (result['success'] == true) {
-        // 注册成功后自动登录
         _token = result['token'];
         final username = result['username'];
         final email = result['email'];
 
-        // 创建基本用户模型
         final basicUserModel = UserModel(
           username: username,
           email: email ?? '',
@@ -476,10 +502,8 @@ class AuthModel extends ChangeNotifier {
           membership: MembershipInfo(type: 'trial', isActive: true),
         );
 
-        // 关键：先保存token到SharedPreferences，确保后续API调用能获取到token
         await _authService.setAuth(_token!, basicUserModel);
 
-        // 创建临时用户对象
         _currentUser = User(
           username: username,
           email: email ?? '',
@@ -488,14 +512,12 @@ class AuthModel extends ChangeNotifier {
           isAdmin: false,
         );
 
-        // 立即保存并通知UI
         await _storeAuth();
         await LikeService().initialize(userId: _currentUser!.username);
         await _syncMeditationPracticeForCurrentUser();
         _setLoading(false);
         notifyListeners();
 
-        // 后台异步刷新完整用户信息（包括会员信息和管理员状态）
         refreshUserInfo();
 
         return true;
@@ -511,7 +533,6 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  /// Apple登录 - 使用 Sign in with Apple
   Future<bool> appleLogin({
     required String identityToken,
     required String authorizationCode,
@@ -540,7 +561,6 @@ class AuthModel extends ChangeNotifier {
         final userJson = result['user'];
         final username = result['username'] ?? userJson?['username'] ?? '';
 
-        // 创建基本用户模型
         final basicUserModel = UserModel(
           username: username,
           email: userJson?['email'] ?? email ?? '',
@@ -554,16 +574,24 @@ class AuthModel extends ChangeNotifier {
 
         await _authService.setAuth(_token!, basicUserModel);
 
-        // 创建用户对象
-        _currentUser = User(
-          username: username,
-          email: userJson?['email'] ?? email ?? '',
-          membershipType: userJson?['membership']?['type'] ?? 'trial',
-          membershipExpiry: userJson?['membership']?['expiresAt'] != null
-              ? DateTime.parse(userJson['membership']['expiresAt'])
-              : DateTime.now().add(const Duration(days: 3)),
-          isAdmin: false,
-        );
+        if (userJson is Map<String, dynamic>) {
+          _currentUser = _userFromServerPayload(
+            userJson,
+            isAdmin: false,
+            fallbackUsername: username,
+            fallbackEmail: email ?? '',
+            fallbackMembershipType: 'trial',
+            fallbackMembershipExpiry: DateTime.now().add(const Duration(days: 3)),
+          );
+        } else {
+          _currentUser = User(
+            username: username,
+            email: email ?? '',
+            membershipType: 'trial',
+            membershipExpiry: DateTime.now().add(const Duration(days: 3)),
+            isAdmin: false,
+          );
+        }
 
         await _storeAuth();
         await LikeService().initialize(userId: _currentUser!.username);
@@ -571,10 +599,8 @@ class AuthModel extends ChangeNotifier {
         _setLoading(false);
         notifyListeners();
 
-        // 后台刷新完整用户信息
         refreshUserInfo();
 
-        // 初始化同步服务
         await SyncService().initialize();
         SyncService().fullSync();
 
@@ -593,7 +619,6 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  /// Firebase手机号登录 - 同步到D1后端
   Future<bool> firebasePhoneLogin({
     required String idToken,
     required String phoneNumber,
@@ -606,7 +631,6 @@ class AuthModel extends ChangeNotifier {
     try {
       debugPrint('📱 Firebase手机登录开始: phone=$phoneNumber, isNew=$isNewUser');
 
-      // 调用后端API同步Firebase用户到D1
       final result = await _authService.firebasePhoneLogin(
         idToken: idToken,
         phoneNumber: phoneNumber,
@@ -621,7 +645,6 @@ class AuthModel extends ChangeNotifier {
         final userJson = result['user'];
         final username = result['username'] ?? userJson?['username'] ?? '';
 
-        // 创建基本用户模型
         final basicUserModel = UserModel(
           username: username,
           email: userJson?['email'] ?? '',
@@ -631,22 +654,32 @@ class AuthModel extends ChangeNotifier {
             type: userJson?['membership']?['type'] ?? 'trial',
             isActive: true,
           ),
+          phoneNumber: phoneNumber,
         );
 
         await _authService.setAuth(_token!, basicUserModel);
 
-        // 创建用户对象
-        _currentUser = User(
-          username: username,
-          email: userJson?['email'] ?? '',
-          membershipType: userJson?['membership']?['type'] ?? 'trial',
-          membershipExpiry: userJson?['membership']?['expiresAt'] != null
-              ? DateTime.parse(userJson['membership']['expiresAt'])
-              : DateTime.now().add(const Duration(days: 3)),
-          isAdmin: false,
-          phoneNumber: phoneNumber,
-          firebaseUid: firebaseUid,
-        );
+        if (userJson is Map<String, dynamic>) {
+          _currentUser = _userFromServerPayload(
+            userJson,
+            isAdmin: false,
+            fallbackUsername: username,
+            fallbackPhoneNumber: phoneNumber,
+            fallbackFirebaseUid: firebaseUid,
+            fallbackMembershipType: 'trial',
+            fallbackMembershipExpiry: DateTime.now().add(const Duration(days: 3)),
+          );
+        } else {
+          _currentUser = User(
+            username: username,
+            email: userJson?['email'] ?? '',
+            membershipType: 'trial',
+            membershipExpiry: DateTime.now().add(const Duration(days: 3)),
+            isAdmin: false,
+            phoneNumber: phoneNumber,
+            firebaseUid: firebaseUid,
+          );
+        }
 
         await _storeAuth();
         await LikeService().initialize(userId: _currentUser!.username);
@@ -654,7 +687,6 @@ class AuthModel extends ChangeNotifier {
         _setLoading(false);
         notifyListeners();
 
-        // 后台刷新完整用户信息
         refreshUserInfo();
 
         debugPrint('✅ Firebase手机登录完成: $username');
@@ -685,35 +717,35 @@ class AuthModel extends ChangeNotifier {
         '支付宝注册开始: username=$username, email=$email, authCode=$authCode',
       );
 
-      // 首先尝试使用授权码直接登录（可能后端已经自动创建了用户）
       final loginResult = await _alipayAuthService.alipayLogin(authCode, null);
 
       debugPrint('支付宝登录结果: $loginResult');
 
       if (loginResult['success'] == true) {
-        // 如果登录成功，直接使用返回的用户信息
         _token = loginResult['token'];
         final userJson = loginResult['user'];
 
-        // 获取管理员状态
-        final adminStatusResult = await _membershipService.getAdminStats(
-          _token!,
-        );
+        final adminStatusResult = await _membershipService.getAdminStats(_token!);
         final bool isAdmin =
             adminStatusResult['success'] == true &&
             adminStatusResult['isAdmin'] == true;
 
-        final membershipJson = userJson['membership'] ?? {};
-        _currentUser = User(
-          username: userJson['username'] ?? '',
-          email: userJson['email'] ?? '',
-          membershipType: membershipJson['type'],
-          membershipExpiry: membershipJson['expiresAt'] != null
-              ? DateTime.parse(membershipJson['expiresAt'])
-              : null,
-          isAdmin: isAdmin,
-          alipayUserId: userJson['alipayUserId'],
-        );
+        if (userJson is Map<String, dynamic>) {
+          _currentUser = _userFromServerPayload(
+            userJson,
+            isAdmin: isAdmin,
+            fallbackUsername: userJson['username'] ?? username,
+            fallbackEmail: userJson['email'] ?? email,
+          );
+        } else {
+          _currentUser = User(
+            username: username,
+            email: email,
+            membershipType: 'trial',
+            membershipExpiry: DateTime.now().add(const Duration(days: 3)),
+            isAdmin: isAdmin,
+          );
+        }
 
         await _storeAuth();
         await LikeService().initialize(userId: _currentUser!.username);
@@ -723,12 +755,10 @@ class AuthModel extends ChangeNotifier {
         notifyListeners();
         return true;
       } else if (loginResult['needsRegistration'] == true) {
-        // 如果是新用户需要注册，使用支付宝用户信息自动注册
         final alipayUser = loginResult['alipayUser'];
 
         debugPrint('需要注册新用户，支付宝用户信息: $alipayUser');
 
-        // 生成默认的用户名和邮箱（如果未提供）
         final autoUsername = username.isNotEmpty
             ? username
             : (alipayUser?['nick_name'] ??
@@ -742,7 +772,7 @@ class AuthModel extends ChangeNotifier {
         final result = await _alipayAuthService.alipayRegister(
           alipayUserId: alipayUser?['user_id'] ?? authCode,
           username: autoUsername,
-          password: '', // 支付宝用户不需要密码
+          password: '',
           email: autoEmail,
           nickname: alipayUser?['nick_name'],
           avatar: alipayUser?['avatar'],
@@ -751,29 +781,32 @@ class AuthModel extends ChangeNotifier {
         debugPrint('支付宝注册结果: $result');
 
         if (result['success'] == true) {
-          // 注册成功后自动登录
           _token = result['token'];
           final userJson = result['user'];
 
-          // 获取管理员状态
-          final adminStatusResult = await _membershipService.getAdminStats(
-            _token!,
-          );
+          final adminStatusResult = await _membershipService.getAdminStats(_token!);
           final bool isAdmin =
               adminStatusResult['success'] == true &&
               adminStatusResult['isAdmin'] == true;
 
-          final membershipJson = userJson['membership'] ?? {};
-          _currentUser = User(
-            username: userJson['username'] ?? '',
-            email: userJson['email'] ?? '',
-            membershipType: membershipJson['type'],
-            membershipExpiry: membershipJson['expiresAt'] != null
-                ? DateTime.parse(membershipJson['expiresAt'])
-                : null,
-            isAdmin: isAdmin,
-            alipayUserId: userJson['alipayUserId'],
-          );
+          if (userJson is Map<String, dynamic>) {
+            _currentUser = _userFromServerPayload(
+              userJson,
+              isAdmin: isAdmin,
+              fallbackUsername: autoUsername,
+              fallbackEmail: autoEmail,
+              fallbackMembershipType: 'trial',
+              fallbackMembershipExpiry: DateTime.now().add(const Duration(days: 3)),
+            );
+          } else {
+            _currentUser = User(
+              username: autoUsername,
+              email: autoEmail,
+              membershipType: 'trial',
+              membershipExpiry: DateTime.now().add(const Duration(days: 3)),
+              isAdmin: isAdmin,
+            );
+          }
 
           await _storeAuth();
           await LikeService().initialize(userId: _currentUser!.username);
@@ -787,11 +820,9 @@ class AuthModel extends ChangeNotifier {
           return false;
         }
       } else {
-        // 登录失败 - 处理不同的错误类型
         String errorMessage = loginResult['error'] ?? '支付宝登录失败';
         String? errorCode = loginResult['code'];
 
-        // 根据错误代码提供更具体的错误信息
         if (errorCode == 'CODE_INVALID') {
           errorMessage = '支付宝授权码已过期或无效，请重新尝试登录';
         } else if (errorCode == 'CODE_REUSED') {
@@ -811,9 +842,7 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  // 直接从token设置认证状态（用于HTML页面登录同步）
   Future<void> setTokenDirectly(String token, String username) async {
-    // Create a basic user model for the service layer
     final basicUserModel = UserModel(
       username: username,
       email: '',
@@ -822,39 +851,30 @@ class AuthModel extends ChangeNotifier {
       membership: MembershipInfo(type: 'expired', isActive: false),
     );
 
-    // Update the AuthService singleton so subsequent API calls are authenticated.
     await _authService.setAuth(token, basicUserModel);
 
-    // Update this AuthModel's state to match.
     _token = token;
     _currentUser = User(
       username: username,
-      email: '', // Will be filled by refreshUserInfo
+      email: '',
       membershipType: null,
       membershipExpiry: null,
       isAdmin: false,
     );
 
-    // Store in AuthModel's storage (redundant but part of current design)
     await _storeAuth();
     await _syncMeditationPracticeForCurrentUser();
-
-    // Notify UI to show "logged in" state immediately.
     notifyListeners();
 
-    // In the background, fetch the full user details from the server.
     await refreshUserInfo();
   }
 
-  // 使用token直接登录（用于macOS支付宝登录）
   Future<void> loginWithToken(String token, String username) async {
     try {
       debugPrint('使用token登录: username=$username');
 
-      // 先设置 _token
       _token = token;
 
-      // 创建基本用户模型
       final basicUserModel = UserModel(
         username: username,
         email: '',
@@ -863,10 +883,8 @@ class AuthModel extends ChangeNotifier {
         membership: MembershipInfo(type: 'trial', isActive: true),
       );
 
-      // 关键：先设置token到AuthService（会保存到SharedPreferences）
       await _authService.setAuth(token, basicUserModel);
 
-      // 设置本地用户状态
       _currentUser = User(
         username: username,
         email: '',
@@ -875,16 +893,14 @@ class AuthModel extends ChangeNotifier {
         isAdmin: false,
       );
 
-      // 立即保存并通知UI
-      await _storeAuth();
-      await LikeService().initialize(userId: _currentUser!.username);
-      await _syncMeditationPracticeForCurrentUser();
-      notifyListeners();
+        await _storeAuth();
+        await LikeService().initialize(userId: _currentUser!.username);
+        await _syncMeditationPracticeForCurrentUser();
+        notifyListeners();
 
       debugPrint('✅ Token已设置，登录完成');
 
-      // 后台异步刷新完整用户信息
-      refreshUserInfo();
+      await refreshUserInfo();
     } catch (e) {
       debugPrint('使用token登录失败: $e');
     }
@@ -897,7 +913,6 @@ class AuthModel extends ChangeNotifier {
     try {
       final result = await _authService.deleteAccount();
       if (result['success'] == true) {
-        // 若云端注销成功，清除本地状态
         await logout();
         _setLoading(false);
         return {'success': true, 'message': '注销成功'};
@@ -925,10 +940,9 @@ class AuthModel extends ChangeNotifier {
       LikeService().setAuthToken(null);
       PracticeStatsService().setAuthToken(null);
       await LikeService().clearUserData();
-      await SyncService().clearSyncState(); // 清除同步状态
+      await SyncService().clearSyncState();
       await MeditationSessionManager().switchUser(null);
 
-      // 清除存储的认证信息
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove('auth_token');
       await prefs.remove('user_data');
@@ -959,7 +973,6 @@ class AuthModel extends ChangeNotifier {
     _error = null;
   }
 
-  // 检查用户是否有权限执行某个操作
   bool hasPermission(String permission) {
     if (_currentUser == null) return false;
 
@@ -969,13 +982,12 @@ class AuthModel extends ChangeNotifier {
       case 'premium':
         return _currentUser!.hasPremiumMembership || _currentUser!.isAdmin;
       case 'basic':
-        return true; // 所有登录用户都有基本权限
+        return true;
       default:
         return false;
     }
   }
 
-  // 获取用户会员状态描述
   String getMembershipStatusText() {
     if (_currentUser == null) return '未登录';
     if (_currentUser!.membershipType == null ||
@@ -987,7 +999,6 @@ class AuthModel extends ChangeNotifier {
     return _currentUser!.membershipType ?? '普通用户';
   }
 
-  // 获取会员到期时间描述
   String? getMembershipExpiryText() {
     if (_currentUser?.membershipExpiry == null) return null;
 
@@ -1006,7 +1017,6 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  // 获取会员剩余天数
   int? getMembershipDaysRemaining() {
     if (_currentUser?.membershipExpiry == null) return null;
 
@@ -1014,7 +1024,7 @@ class AuthModel extends ChangeNotifier {
     final now = DateTime.now();
     final difference = expiry.difference(now);
 
-    if (difference.isNegative) return -1; // 已过期
+    if (difference.isNegative) return -1;
 
     return difference.inDays;
   }

--- a/fabushi/lib/screens/edit_profile_screen.dart
+++ b/fabushi/lib/screens/edit_profile_screen.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:image/image.dart' as img;
 import 'package:provider/provider.dart';
 
 import '../core/config/app_config.dart';
@@ -9,6 +11,20 @@ import '../core/design_system/app_theme.dart';
 import '../models/auth_model.dart';
 import '../services/http_service.dart';
 import '../services/meditation_session_manager.dart';
+
+class _PreparedAvatarUpload {
+  final String base64;
+  final String fileName;
+  final String contentType;
+  final bool wasCompressed;
+
+  const _PreparedAvatarUpload({
+    required this.base64,
+    required this.fileName,
+    required this.contentType,
+    required this.wasCompressed,
+  });
+}
 
 /// 编辑资料页面
 class EditProfileScreen extends StatefulWidget {
@@ -19,6 +35,8 @@ class EditProfileScreen extends StatefulWidget {
 }
 
 class _EditProfileScreenState extends State<EditProfileScreen> {
+  static const int _maxAvatarBytes = 3 * 1024 * 1024;
+
   final _formKey = GlobalKey<FormState>();
   late TextEditingController _usernameController;
   late TextEditingController _emailController;
@@ -82,22 +100,103 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       withData: true,
     );
     final file = result?.files.single;
-    final bytes = file?.bytes;
-    if (file == null || bytes == null) return;
+    if (file == null || file.bytes == null) return;
 
-    if (bytes.length > 3 * 1024 * 1024) {
+    final prepared = _prepareAvatarUpload(file);
+    if (prepared == null) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('头像图片不能超过 3MB')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('头像图片处理失败，请换一张图片重试')),
+      );
       return;
     }
 
     setState(() {
-      _pendingAvatarBase64 = base64Encode(bytes);
-      _pendingAvatarFileName = file.name;
-      _pendingAvatarContentType = _contentTypeForName(file.name);
+      _pendingAvatarBase64 = prepared.base64;
+      _pendingAvatarFileName = prepared.fileName;
+      _pendingAvatarContentType = prepared.contentType;
     });
+
+    if (prepared.wasCompressed && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('头像图片过大，已自动压缩到可上传大小')),
+      );
+    }
+  }
+
+  _PreparedAvatarUpload? _prepareAvatarUpload(PlatformFile file) {
+    final bytes = file.bytes;
+    if (bytes == null || bytes.isEmpty) {
+      return null;
+    }
+
+    if (bytes.length <= _maxAvatarBytes) {
+      return _PreparedAvatarUpload(
+        base64: base64Encode(bytes),
+        fileName: file.name,
+        contentType: _contentTypeForName(file.name),
+        wasCompressed: false,
+      );
+    }
+
+    final decoded = img.decodeImage(bytes);
+    if (decoded == null) {
+      return null;
+    }
+
+    const qualities = [88, 80, 72, 64, 56, 48, 40, 32];
+    final originalMaxSide = decoded.width > decoded.height
+        ? decoded.width
+        : decoded.height;
+    var targetMaxSide = originalMaxSide > 1600 ? 1600 : originalMaxSide;
+    Uint8List? encodedBytes;
+
+    while (targetMaxSide >= 720) {
+      final resized = img.copyResize(
+        decoded,
+        width: decoded.width >= decoded.height ? targetMaxSide : null,
+        height: decoded.height > decoded.width ? targetMaxSide : null,
+        interpolation: img.Interpolation.average,
+      );
+
+      for (final quality in qualities) {
+        final candidate = Uint8List.fromList(
+          img.encodeJpg(resized, quality: quality),
+        );
+        if (candidate.length <= _maxAvatarBytes) {
+          encodedBytes = candidate;
+          break;
+        }
+      }
+
+      if (encodedBytes != null) {
+        break;
+      }
+
+      if (targetMaxSide == 720) {
+        break;
+      }
+      final nextSide = (targetMaxSide * 0.8).round();
+      targetMaxSide = nextSide < 720 ? 720 : nextSide;
+    }
+
+    if (encodedBytes == null) {
+      return null;
+    }
+
+    return _PreparedAvatarUpload(
+      base64: base64Encode(encodedBytes),
+      fileName: _compressedAvatarFileName(file.name),
+      contentType: 'image/jpeg',
+      wasCompressed: true,
+    );
+  }
+
+  String _compressedAvatarFileName(String originalName) {
+    final dotIndex = originalName.lastIndexOf('.');
+    final baseName = dotIndex > 0 ? originalName.substring(0, dotIndex) : originalName;
+    final safeBaseName = baseName.trim().isEmpty ? 'avatar' : baseName.trim();
+    return '${safeBaseName}_compressed.jpg';
   }
 
   String _contentTypeForName(String name) {
@@ -304,7 +403,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           ),
           const SizedBox(height: 12),
           const Text(
-            '点击从本地选择头像',
+            '点击从本地选择头像，过大的图片会自动压缩',
             style: TextStyle(color: Colors.white54, fontSize: 12),
           ),
         ],

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   path: ^1.8.3
   archive: ^4.0.7
   csv: ^6.0.0
+  image: ^4.5.4
 
   # UI组件
   flex_color_scheme: ^8.0.2


### PR DESCRIPTION
## 概要
- 编辑资料页支持对超出 3MB 的头像图片做本地压缩后再上传，而不是直接拦截失败
- 用户名改动重新签发 token 后，客户端会等待最新资料回读完成，避免头像/手机号/昵称等仍停留在旧状态
- 常规登录也直接保留服务端返回的头像、昵称和手机号，减少“重新登录后还是旧资料”的感知

Fixes #118

## 根因
这次用户反馈里的两个现象其实是一条链路上的两个断点：

1. 编辑资料页当前对头像文件大小是硬拦截，大于 3MB 直接报错，没有任何压缩降级路径。
2. 资料更新成功后，如果用户名发生变化，客户端虽然会收到新 token，但 `loginWithToken()` 只是先写一个临时本地用户再异步刷新；刷新没完成前，页面和本地缓存都可能短时间保留旧头像/旧资料。
3. 普通账号密码登录路径里，`AuthModel.login()` 也没有把服务端已经返回的头像、昵称、手机号带进本地用户状态，进一步放大了“重新登录后资料像没更新”的感知。

## 这次怎么修
1. 在 `EditProfileScreen` 里新增头像预处理：
   - 超过 3MB 时自动解码、缩放、降 JPEG 质量
   - 直到压到可上传范围内再提交
   - 如果仍无法压到目标大小，再明确提示失败
2. 编辑资料页保存成功后：
   - 对需要新 token 的改名场景，等待 `AuthModel.loginWithToken()` 完成最新资料回读
   - 确保本地缓存和 UI 尽快落到服务端最终状态
3. `AuthModel` 新增统一的服务端用户载荷映射逻辑，让账号密码登录、Apple 登录、Firebase 手机登录、支付宝注册回填这些路径都尽量直接保留头像、昵称、手机号等资料字段。

## 风险与范围
- Flutter 侧改动，范围集中在资料编辑页与认证状态持久化
- 不改 Worker 接口协议，不改 D1 schema，不动发布工作流
- 头像压缩新增了 `image` 依赖，用的是纯 Dart 本地图像处理

## 验证
- 当前环境无法拉起完整 Flutter checkout 与 `flutter test` / `flutter analyze`，所以本地还没有跑编译级验证
- 需要依赖 PR CI 继续确认：
  - Flutter 工程仍能通过 analyze / test / build
  - 资料编辑页的头像上传与改名后回读没有回归

## 合并后跟进
- 关注这条 PR 的 CI 结果
- 若合并后主线 CI / CD / package release / GitHub Release / TestFlight 继续保持闭环，再回收 issue #118 的用户侧验证
- issue #114 如果仍能复现，再继续沿资料页链路向下深挖服务端或前端剩余断点