### PR TITLE
fix: keep meditation group owners active during membership evaluation

### DIFF
--- a/fabushi/web/src/handlers/meditation.js
+++ b/fabushi/web/src/handlers/meditation.js
@@ -60,7 +60,70 @@ function daysBetween(startDate, endDate) {
     return Math.max(0, Math.floor((end - start) / 86400000) + 1);
 }
 
+async function ensureOwnerMembershipActive(db, groupId, ownerUsername = null) {
+    const resolvedOwnerUsername = ownerUsername || (await db.prepare(`
+      SELECT owner_username
+      FROM meditation_groups
+      WHERE id = ?
+    `).bind(groupId).first())?.owner_username;
+
+    if (!resolvedOwnerUsername) {
+        return null;
+    }
+
+    const now = new Date().toISOString();
+    const ownerMembership = await db.prepare(`
+      SELECT id, status, role
+      FROM meditation_group_members
+      WHERE group_id = ? AND username = ?
+    `).bind(groupId, resolvedOwnerUsername).first();
+
+    if (!ownerMembership) {
+        await db.prepare(`
+      INSERT INTO meditation_group_members (
+        group_id, username, role, status,
+        cumulative_missed_days, consecutive_missed_days,
+        warning_message, removal_reason, removed_at,
+        joined_at, updated_at
+      )
+      VALUES (?, ?, 'owner', 'active', 0, 0, NULL, NULL, NULL, ?, ?)
+    `).bind(groupId, resolvedOwnerUsername, now, now).run();
+        return resolvedOwnerUsername;
+    }
+
+    if (ownerMembership.role !== 'owner' || ownerMembership.status !== 'active') {
+        await db.prepare(`
+      UPDATE meditation_group_members
+      SET role = 'owner',
+          status = 'active',
+          cumulative_missed_days = 0,
+          consecutive_missed_days = 0,
+          warning_message = NULL,
+          removal_reason = NULL,
+          removed_at = NULL,
+          updated_at = ?
+      WHERE id = ?
+    `).bind(now, ownerMembership.id).run();
+    }
+
+    return resolvedOwnerUsername;
+}
+
+async function restoreOwnerMemberships(db, username) {
+    const ownedGroups = await db.prepare(`
+      SELECT id
+      FROM meditation_groups
+      WHERE owner_username = ?
+    `).bind(username).all();
+
+    for (const group of ownedGroups.results || []) {
+        await ensureOwnerMembershipActive(db, group.id, username);
+    }
+}
+
 async function refreshGroupsForUser(db, username) {
+    await restoreOwnerMemberships(db, username);
+
     const memberships = await db.prepare(`
       SELECT m.group_id
       FROM meditation_group_members m
@@ -75,7 +138,7 @@ async function refreshGroupsForUser(db, username) {
 
 async function evaluateGroupMembers(db, groupId, onlyUsername = null) {
     const group = await db.prepare(`
-      SELECT id, daily_goal_minutes, cumulative_miss_limit, consecutive_miss_limit
+      SELECT id, owner_username, daily_goal_minutes, cumulative_miss_limit, consecutive_miss_limit
       FROM meditation_groups
       WHERE id = ?
     `).bind(groupId).first();
@@ -84,12 +147,14 @@ async function evaluateGroupMembers(db, groupId, onlyUsername = null) {
         return;
     }
 
+    await ensureOwnerMembershipActive(db, groupId, group.owner_username);
+
     const today = formatDate(new Date());
     const yesterday = formatDate(addDays(new Date(), -1));
     let memberQuery = `
-      SELECT id, username, joined_at
+      SELECT id, username, joined_at, role
       FROM meditation_group_members
-      WHERE group_id = ? AND status = 'active'
+      WHERE group_id = ? AND status = 'active' AND role != 'owner'
     `;
     const memberParams = [groupId];
     if (onlyUsername) {
@@ -552,6 +617,7 @@ export async function handleGetMeditationGroupDetail(request, env, db) {
             return jsonResponse({ success: false, error: 'groupId required' }, 400);
         }
 
+        await restoreOwnerMemberships(db, auth.username);
         await evaluateGroupMembers(db, groupId);
 
         const today = formatDate(new Date());
@@ -610,7 +676,7 @@ export async function handleGetMeditationGroupDetail(request, env, db) {
       LIMIT 100
     `).bind(today, groupId).all();
 
-        const pendingResult = groupRow.my_role === 'owner'
+        const pendingResult = groupRow.owner_username === auth.username
             ? await db.prepare(`
         SELECT m.username, COALESCE(u.nickname, m.username) as displayName, COALESCE(u.avatar, u.alipay_avatar, u.wechat_headimgurl) as avatar, m.updated_at
         FROM meditation_group_members m
@@ -662,14 +728,19 @@ export async function handleReviewMeditationGroupJoin(request, env, db) {
             return jsonResponse({ success: false, error: '参数不完整' }, 400);
         }
 
-        const owner = await db.prepare(`
-      SELECT role
-      FROM meditation_group_members
-      WHERE group_id = ? AND username = ? AND status = 'active'
-    `).bind(groupId, auth.username).first();
-        if (!owner || owner.role !== 'owner') {
+        const group = await db.prepare(`
+      SELECT owner_username
+      FROM meditation_groups
+      WHERE id = ?
+    `).bind(groupId).first();
+        if (!group) {
+            return jsonResponse({ success: false, error: '小组不存在' }, 404);
+        }
+        if (group.owner_username !== auth.username) {
             return jsonResponse({ success: false, error: '只有小组创建者可以审核' }, 403);
         }
+
+        await ensureOwnerMembershipActive(db, groupId, auth.username);
 
         await db.prepare(`
       UPDATE meditation_group_members

--- a/fabushi/web/tests/meditation-groups.test.js
+++ b/fabushi/web/tests/meditation-groups.test.js
@@ -1,0 +1,314 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  handleGetMeditationGroupDetail,
+  handleReviewMeditationGroupJoin,
+} from '../src/handlers/meditation.js';
+
+function createDbMock() {
+  const groups = new Map();
+  const members = new Map();
+
+  const keyFor = (groupId, username) => `${groupId}:${username}`;
+
+  const db = {
+    groups,
+    members,
+    prepare(sql) {
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+
+      return {
+        bind(...params) {
+          return {
+            async first() {
+              if (normalizedSql.startsWith('SELECT owner_username FROM meditation_groups WHERE id = ?')) {
+                const group = groups.get(params[0]);
+                return group ? { owner_username: group.owner_username } : null;
+              }
+
+              if (normalizedSql.startsWith('SELECT id, owner_username, daily_goal_minutes, cumulative_miss_limit, consecutive_miss_limit FROM meditation_groups WHERE id = ?')) {
+                const group = groups.get(params[0]);
+                return group ? { ...group } : null;
+              }
+
+              if (normalizedSql.startsWith('SELECT id, status, role FROM meditation_group_members WHERE group_id = ? AND username = ?')) {
+                const member = members.get(keyFor(params[0], params[1]));
+                return member ? { id: member.id, status: member.status, role: member.role } : null;
+              }
+
+              if (normalizedSql.includes('LEFT JOIN meditation_group_members my ON my.group_id = g.id AND my.username = ? WHERE g.id = ?')) {
+                const [today, username, groupId] = params;
+                void today;
+                const group = groups.get(groupId);
+                if (!group) return null;
+                const member = members.get(keyFor(groupId, username));
+                return {
+                  ...group,
+                  owner_nickname: null,
+                  my_status: member?.status ?? null,
+                  my_role: member?.role ?? null,
+                  my_warning_message: member?.warning_message ?? null,
+                  member_count: Array.from(members.values()).filter(
+                    (entry) => entry.group_id === groupId && entry.status === 'active',
+                  ).length,
+                  total_duration: 0,
+                  today_duration: 0,
+                };
+              }
+
+              if (normalizedSql.startsWith('SELECT SUM(COALESCE(duration, 0)) as duration FROM meditation_records WHERE username = ? AND record_date = ?')) {
+                return { duration: 0 };
+              }
+
+              return null;
+            },
+            async all() {
+              if (normalizedSql.startsWith('SELECT id FROM meditation_groups WHERE owner_username = ?')) {
+                return {
+                  results: Array.from(groups.values())
+                    .filter((group) => group.owner_username === params[0])
+                    .map((group) => ({ id: group.id })),
+                };
+              }
+
+              if (normalizedSql.startsWith('SELECT m.group_id FROM meditation_group_members m JOIN meditation_groups g ON g.id = m.group_id WHERE m.username = ? AND m.status = \'active\'')) {
+                return {
+                  results: Array.from(members.values())
+                    .filter((member) => member.username === params[0] && member.status === 'active')
+                    .map((member) => ({ group_id: member.group_id })),
+                };
+              }
+
+              if (normalizedSql.startsWith('SELECT id, username, joined_at, role FROM meditation_group_members WHERE group_id = ? AND status = \'active\' AND role != \'owner\'')) {
+                const [groupId, onlyUsername] = params;
+                return {
+                  results: Array.from(members.values()).filter((member) => {
+                    if (member.group_id !== groupId || member.status !== 'active' || member.role === 'owner') {
+                      return false;
+                    }
+                    return onlyUsername ? member.username === onlyUsername : true;
+                  }),
+                };
+              }
+
+              if (normalizedSql.includes('FROM meditation_group_members m LEFT JOIN users u ON u.username = m.username LEFT JOIN meditation_records r ON r.username = m.username WHERE m.group_id = ? AND m.status = \'active\'')) {
+                return {
+                  results: Array.from(members.values())
+                    .filter((member) => member.group_id === params[1] && member.status === 'active')
+                    .map((member) => ({
+                      username: member.username,
+                      displayName: member.username,
+                      avatar: null,
+                      role: member.role,
+                      cumulative_missed_days: member.cumulative_missed_days ?? 0,
+                      consecutive_missed_days: member.consecutive_missed_days ?? 0,
+                      warning_message: member.warning_message ?? null,
+                      totalDuration: 0,
+                      todayDuration: 0,
+                      activeDays: 0,
+                    })),
+                };
+              }
+
+              if (normalizedSql.includes('FROM meditation_group_members m LEFT JOIN users u ON u.username = m.username WHERE m.group_id = ? AND m.status = \'pending\'')) {
+                return {
+                  results: Array.from(members.values())
+                    .filter((member) => member.group_id === params[0] && member.status === 'pending')
+                    .map((member) => ({
+                      username: member.username,
+                      displayName: member.username,
+                      avatar: null,
+                      updated_at: member.updated_at,
+                    })),
+                };
+              }
+
+              if (normalizedSql.startsWith('SELECT record_date, SUM(COALESCE(duration, 0)) as duration FROM meditation_records WHERE username = ? AND record_date >= ? AND record_date <= ? GROUP BY record_date')) {
+                return { results: [] };
+              }
+
+              return { results: [] };
+            },
+            async run() {
+              if (normalizedSql.startsWith('UPDATE meditation_group_members SET role = \'owner\', status = \'active\'')) {
+                const [updatedAt, id] = params;
+                const member = Array.from(members.values()).find((entry) => entry.id === id);
+                member.role = 'owner';
+                member.status = 'active';
+                member.cumulative_missed_days = 0;
+                member.consecutive_missed_days = 0;
+                member.warning_message = null;
+                member.removal_reason = null;
+                member.removed_at = null;
+                member.updated_at = updatedAt;
+                return;
+              }
+
+              if (normalizedSql.startsWith('INSERT INTO meditation_group_members ( group_id, username, role, status,')) {
+                const [groupId, username, joinedAt, updatedAt] = params;
+                members.set(keyFor(groupId, username), {
+                  id: members.size + 1,
+                  group_id: groupId,
+                  username,
+                  role: 'owner',
+                  status: 'active',
+                  cumulative_missed_days: 0,
+                  consecutive_missed_days: 0,
+                  warning_message: null,
+                  removal_reason: null,
+                  removed_at: null,
+                  joined_at: joinedAt,
+                  updated_at: updatedAt,
+                });
+                return;
+              }
+
+              if (normalizedSql.startsWith('UPDATE meditation_group_members SET status = ?, joined_at = CASE WHEN ? = \'active\' THEN ? ELSE joined_at END, updated_at = ? WHERE group_id = ? AND username = ? AND status = \'pending\'')) {
+                const [status, , joinedAt, updatedAt, groupId, username] = params;
+                const member = members.get(keyFor(groupId, username));
+                if (member && member.status === 'pending') {
+                  member.status = status;
+                  member.joined_at = status === 'active' ? joinedAt : member.joined_at;
+                  member.updated_at = updatedAt;
+                }
+                return;
+              }
+
+              if (normalizedSql.startsWith('UPDATE meditation_group_members SET cumulative_missed_days = ?,')) {
+                const [cumulativeMissed, consecutiveMissed, warningMessage, updatedAt, id] = params;
+                const member = Array.from(members.values()).find((entry) => entry.id === id);
+                member.cumulative_missed_days = cumulativeMissed;
+                member.consecutive_missed_days = consecutiveMissed;
+                member.warning_message = warningMessage;
+                member.updated_at = updatedAt;
+                return;
+              }
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { db, groups, members, keyFor };
+}
+
+function authHeader(username) {
+  const payload = Buffer.from(JSON.stringify({ username })).toString('base64url');
+  return `Bearer header.${payload}.signature`;
+}
+
+test('group detail restores removed owner membership and keeps pending requests visible', async () => {
+  const { db, groups, members, keyFor } = createDbMock();
+  groups.set(7, {
+    id: 7,
+    owner_username: 'owner1',
+    name: '晨课共修',
+    description: '',
+    require_approval: 1,
+    daily_goal_minutes: 30,
+    cumulative_miss_limit: 7,
+    consecutive_miss_limit: 3,
+    created_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(7, 'owner1'), {
+    id: 1,
+    group_id: 7,
+    username: 'owner1',
+    role: 'owner',
+    status: 'removed',
+    cumulative_missed_days: 4,
+    consecutive_missed_days: 3,
+    warning_message: '已接近清退',
+    removal_reason: '连续未达标 3 天',
+    removed_at: '2026-05-05T00:00:00Z',
+    joined_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(7, 'pending-user'), {
+    id: 2,
+    group_id: 7,
+    username: 'pending-user',
+    role: 'member',
+    status: 'pending',
+    joined_at: '2026-05-05T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+
+  const response = await handleGetMeditationGroupDetail(
+    new Request('https://flutter.ombhrum.com/api/meditation/groups/detail?groupId=7', {
+      headers: { Authorization: authHeader('owner1') },
+    }),
+    {},
+    db,
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.group.myStatus, 'active');
+  assert.equal(payload.data.group.myRole, 'owner');
+  assert.equal(payload.data.pendingMembers.length, 1);
+
+  const ownerMembership = members.get(keyFor(7, 'owner1'));
+  assert.equal(ownerMembership.status, 'active');
+  assert.equal(ownerMembership.warning_message, null);
+  assert.equal(ownerMembership.removal_reason, null);
+});
+
+test('group owner can still approve join requests after owner membership is restored', async () => {
+  const { db, groups, members, keyFor } = createDbMock();
+  groups.set(11, {
+    id: 11,
+    owner_username: 'owner2',
+    name: '晚课共修',
+    description: '',
+    require_approval: 1,
+    daily_goal_minutes: 45,
+    cumulative_miss_limit: 6,
+    consecutive_miss_limit: 2,
+    created_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(11, 'owner2'), {
+    id: 5,
+    group_id: 11,
+    username: 'owner2',
+    role: 'owner',
+    status: 'removed',
+    joined_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(11, 'applicant'), {
+    id: 6,
+    group_id: 11,
+    username: 'applicant',
+    role: 'member',
+    status: 'pending',
+    joined_at: '2026-05-05T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+
+  const response = await handleReviewMeditationGroupJoin(
+    new Request('https://flutter.ombhrum.com/api/meditation/groups/review', {
+      method: 'POST',
+      headers: {
+        Authorization: authHeader('owner2'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        groupId: 11,
+        username: 'applicant',
+        approve: true,
+      }),
+    }),
+    {},
+    db,
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(members.get(keyFor(11, 'owner2')).status, 'active');
+  assert.equal(members.get(keyFor(11, 'applicant')).status, 'active');
+});


### PR DESCRIPTION
## 概要
- 让共修小组组主不再被自动清退逻辑当成普通成员处理
- 组主一旦因为旧数据处于 `removed` 状态，会在读取小组列表/详情或审核申请前自动修复回 `owner + active`
- 补两条 Worker 回归测试，锁住“组主被清退后看不到或处理不了申请”这条复发链路

Fixes #116

## 根因
当前 `meditation.js` 的共修小组评估逻辑会把所有 `active` 成员一视同仁地套用未达标清退规则，没有把 `role = 'owner'` 视为特殊身份。这样一来：

1. 组主也可能被自动改成 `removed`
2. 一旦组主记录被清退，审核接口 `handleReviewMeditationGroupJoin` 又只认 `status = 'active'` 的 owner membership
3. 结果就是用户既会看到“自己创建的小组把自己清退了”，也会连带失去处理入组申请的能力

这不是单点 UI 问题，而是组主身份约束在后端没有被持续守住。

## 这次怎么修
1. 新增 `ensureOwnerMembershipActive(...)`
   - 如果组主 membership 丢失则补回
   - 如果组主被标成 `removed` / 非 `owner`，则自动修复成 `owner + active`
   - 同时清掉 warning / removal 状态，避免旧异常残留
2. 新增 `restoreOwnerMemberships(...)`
   - 用户刷新共修小组时，先把自己创建的小组 owner membership 全部修正回健康状态
3. `evaluateGroupMembers(...)`
   - 在真正做清退评估前先修复 owner membership
   - owner 不再进入普通成员的未达标清退计算
4. `handleGetMeditationGroupDetail(...)`
   - 详情页先做 owner 自愈
   - pending 成员可见性改为依据 `group.owner_username === auth.username`，不再依赖一条可能已经脏掉的 membership 状态
5. `handleReviewMeditationGroupJoin(...)`
   - 审核权限直接以 `meditation_groups.owner_username` 为准
   - 审核前顺手修复 owner membership，保证旧脏数据也能继续审批

## 风险与范围
- 只改 Worker 侧 `fabushi/web/src/handlers/meditation.js`
- 不改 Flutter UI，不改 D1 schema，不碰发布工作流
- 目标是把“owner 身份不可被清退”变成后端持续维持的约束，而不是一次性数据修补

## 验证
- 本地回归：`node --test fabushi/web/tests/meditation-groups.test.js`
- 覆盖点：
  - 组主已被标记为 `removed` 时，打开小组详情会自动恢复 owner membership，并继续看到 pending 申请
  - 组主已被标记为 `removed` 时，仍可审批新的入组申请
- 仍需依赖 PR CI 继续确认 Worker 现有测试与主线交付链路无回归