### PR TITLE
fix: close staging social privacy CD gate regressions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -155,6 +155,13 @@ jobs:
               print('Development D1 database id placeholder not present')
           PY2
 
+      - name: Apply development D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
+        run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote --yes
+
       - name: Deploy staging Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
@@ -178,6 +185,7 @@ jobs:
       STAGING_TEST_PASSWORD: ${{ secrets.STAGING_TEST_PASSWORD }}
       STAGING_TEST_EMAIL: ${{ vars.STAGING_TEST_EMAIL }}
       STAGING_TEST_PHONE: ${{ vars.STAGING_TEST_PHONE }}
+      STAGING_SOCIAL_TARGET_USERNAME: ${{ vars.STAGING_SOCIAL_TARGET_USERNAME }}
     steps:
       - name: Checkout E2E files
         uses: actions/checkout@v5
@@ -312,6 +320,13 @@ jobs:
 
           print('Verified production deploy artifact no longer mutates routes')
           PY2
+
+      - name: Apply production D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
+        run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote --yes
 
       - name: Deploy production Worker
         env:

--- a/fabushi/e2e/tests/staging_social_privacy.spec.ts
+++ b/fabushi/e2e/tests/staging_social_privacy.spec.ts
@@ -3,9 +3,11 @@ import { test, expect } from '@playwright/test';
 const baseUrl = process.env.STAGING_APP_URL;
 const testUser = process.env.STAGING_TEST_LOGIN;
 const testPassword = process.env.STAGING_TEST_PASSWORD;
+const configuredSocialTarget = process.env.STAGING_SOCIAL_TARGET_USERNAME?.trim() || null;
 
 test.describe('Staging Social and Privacy API', () => {
   let authToken: string;
+  let followTargetUsername: string | null = configuredSocialTarget;
 
   test.beforeAll(async ({ request }) => {
     const resp = await request.post(`${baseUrl}/api/auth/login`, {
@@ -14,16 +16,30 @@ test.describe('Staging Social and Privacy API', () => {
     expect(resp.ok()).toBeTruthy();
     const body = await resp.json();
     authToken = body.token;
+
+    if (!followTargetUsername) {
+      const leaderboardResp = await request.get(`${baseUrl}/api/leaderboard/practice`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+      expect(leaderboardResp.ok()).toBeTruthy();
+      const leaderboardBody = await leaderboardResp.json();
+      const entries = Array.isArray(leaderboardBody.leaderboard) ? leaderboardBody.leaderboard : [];
+      const candidate = entries.find((entry: any) => entry?.username && entry.username !== testUser);
+      followTargetUsername = candidate?.username || null;
+    }
   });
 
   test('toggle follow/unfollow', async ({ request }) => {
+    test.skip(!followTargetUsername, 'staging 环境暂无可关注的其他用户');
+
     const resp = await request.post(`${baseUrl}/api/social/follow/toggle`, {
-      data: { username: 'alice' },
+      data: { username: followTargetUsername },
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(resp.ok()).toBeTruthy();
     const body = await resp.json();
     expect(body).toHaveProperty('success', true);
+    expect(body).toHaveProperty('username', followTargetUsername);
   });
 
   test('fetch follow list', async ({ request }) => {
@@ -50,7 +66,8 @@ test.describe('Staging Social and Privacy API', () => {
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(getResp.ok()).toBeTruthy();
-    const privacy = await getResp.json();
+    const getBody = await getResp.json();
+    const privacy = getBody.privacy ?? getBody;
     expect(privacy).toHaveProperty('isPrivate');
 
     const postResp = await request.post(`${baseUrl}/api/social/practice-privacy`, {
@@ -63,8 +80,10 @@ test.describe('Staging Social and Privacy API', () => {
       },
     });
     expect(postResp.ok()).toBeTruthy();
-    const updated = await postResp.json();
-    expect(updated).toHaveProperty('success', true);
+    const postBody = await postResp.json();
+    expect(postBody).toHaveProperty('success', true);
+    const updated = postBody.privacy ?? postBody;
+    expect(updated).toHaveProperty('isPrivate', true);
   });
 
   test('leaderboard practice records respect privacy', async ({ request }) => {


### PR DESCRIPTION
## Summary
- apply D1 migrations in CD before both staging and production Worker deploys so schema-dependent APIs do not lag behind shipped code
- make the staging social/privacy Playwright gate deterministic by discovering a real follow target instead of hard-coding `alice`
- align the staging privacy assertions with the API response shape by accepting the nested `privacy` payload already returned by the backend

## Root cause
The failing CD run on source SHA `bac05606e33d2adc06b73a8596d0442c41a67925` was not a Playwright discovery problem anymore. The logs show the gate reached the real staging API and then failed on the follow and privacy endpoints.

Two separate regressions were sitting on that path:
1. The deployment workflow shipped new social/privacy handlers without applying the matching D1 migration first, so staging could serve code that expects `user_follows` and `user_practice_privacy` before those tables exist.
2. The E2E test depended on a hard-coded `alice` account and on a top-level privacy response shape, making the gate brittle even when the deployment itself is healthy.

## Why this fix
Applying migrations inside the deploy workflow closes the release-process gap at the source instead of relying on a separate manual database step. Making the E2E test discover a real target user from the staged leaderboard keeps the gate meaningful while removing environment-specific test data assumptions.

## Validation
- Reviewed the failing job log from Actions run `25373440498` and confirmed the first failures were real non-2xx responses from `/api/social/follow/toggle` and `/api/social/practice-privacy`.
- Verified the deployed workflow previously had no D1 migration step before staging or production deploy.
- Scoped the fix to the CD workflow and the staging Playwright spec only.

## Residual risk
- This PR relies on the repository's existing Cloudflare credentials already being sufficient for `wrangler deploy`; the same credentials should also be valid for `wrangler d1 migrations apply`.
- If the staging environment has no other leaderboard user at all, the follow-toggle test now skips instead of failing for unrelated seed-data reasons.

## Follow-up after merge
- Re-run or allow the existing CD pipeline to run on `main`, then confirm staging E2E, production deploy, production smoke, GitHub Release evidence, and TestFlight evidence are all green before starting the next iteration.