### PR TITLE
fix: unblock CD D1 migrations in deploy workflow

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -6,11 +6,12 @@ from pathlib import Path
 import re
 import sys
 
-workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
+publish_workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
+deploy_workflow = Path('.github/workflows/deploy-production.yml').read_text(encoding='utf-8')
 
 checkout_match = re.search(
     r"- name: Checkout source for version metadata\n(?P<body>.*?)\n\s*- name: Prepare release assets",
-    workflow,
+    publish_workflow,
     re.DOTALL,
 )
 if not checkout_match:
@@ -33,14 +34,26 @@ release_asset_requirements = (
     'ios_signing_not_configured',
 )
 for required in release_asset_requirements:
-    if required not in workflow:
+    if required not in publish_workflow:
         missing.append(required)
+
+migration_steps = re.findall(
+    r"run:\s*(npx --yes wrangler@latest d1 migrations apply DB --env (development|production) --remote(?:\s+\S+)*)",
+    deploy_workflow,
+)
+
+if len(migration_steps) != 2:
+    missing.append('development/production D1 migration steps')
+
+for command, environment in migration_steps:
+    if command.strip().endswith('--yes'):
+        missing.append(f'{environment} D1 migration command should not pass wrangler --yes')
 
 if missing:
     sys.stderr.write(
-        'publish-cd-release.yml is missing required release guardrails: ' + ', '.join(missing) + '\n'
+        'workflow guardrails are missing required protections: ' + ', '.join(missing) + '\n'
     )
     raise SystemExit(1)
 
-print('publish-cd-release checkout and TestFlight evidence guardrails are in place')
+print('publish release and deploy workflow guardrails are in place')
 PY

--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -37,17 +37,21 @@ for required in release_asset_requirements:
     if required not in publish_workflow:
         missing.append(required)
 
-migration_steps = re.findall(
-    r"run:\s*(npx --yes wrangler@latest d1 migrations apply DB --env (development|production) --remote(?:\s+\S+)*)",
-    deploy_workflow,
+expected_migration_commands = (
+    'run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote',
+    'run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote',
 )
+for required in expected_migration_commands:
+    if required not in deploy_workflow:
+        missing.append(required)
 
-if len(migration_steps) != 2:
-    missing.append('development/production D1 migration steps')
-
-for command, environment in migration_steps:
-    if command.strip().endswith('--yes'):
-        missing.append(f'{environment} D1 migration command should not pass wrangler --yes')
+invalid_migration_commands = (
+    'run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote --yes',
+    'run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote --yes',
+)
+for invalid in invalid_migration_commands:
+    if invalid in deploy_workflow:
+        missing.append(f'invalid command still present: {invalid}')
 
 if missing:
     sys.stderr.write(

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -160,7 +160,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
-        run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote --yes
+        run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote
 
       - name: Deploy staging Worker
         env:
@@ -326,7 +326,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
-        run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote --yes
+        run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote
 
       - name: Deploy production Worker
         env:


### PR DESCRIPTION
## 概要
- 去掉 `wrangler d1 migrations apply` 命令尾部不再支持的额外 `--yes`
- 保留 `npx --yes wrangler@latest ...` 这一层非交互安装能力，不改变实际迁移目标环境
- 扩展工作流守护脚本，让 CI 直接拦截 deploy workflow 里再次引入同类无效 migration 参数的回归

## 根因
主分支最新一次 CD 失败不是 D1 schema 本身有问题，而是 `fix: close staging social privacy CD gate regressions (#132)` 新增迁移步骤时，把 `npx --yes` 的确认参数又附加到了 `wrangler d1 migrations apply` 命令末尾。

最新失败日志已经明确显示：
- `Apply development D1 migrations`
- `Unknown argument: yes`

也就是说，流水线在真正执行任何迁移前就被 CLI 参数解析拦住了，所以 staging deploy、后续生产 deploy、GitHub Release 和 TestFlight 全部被连带阻塞。

## 这次怎么修
1. `deploy-production.yml`
   - development / production 两个 D1 migration step 都改为：
     - `npx --yes wrangler@latest d1 migrations apply DB --env <env> --remote`
   - 只保留 `npx` 这一层的 `--yes`
   - 去掉 `wrangler` 子命令尾部的无效 `--yes`
2. `check-publish-cd-release.sh`
   - 在原有 release / TestFlight 守护基础上，额外检查 `deploy-production.yml`
   - 要求 development / production 两个 migration step 都存在
   - 如果 migration command 末尾再次出现 `--yes`，CI 直接失败，防止同类回归再混进主线

## 验证
- 对照失败 job `74412260085` 的日志，根因与修复点一一对应
- 本地对 workflow 文本做了断言，确认两个 migration command 都已经移除尾部 `--yes`
- 本地守护脚本逻辑已更新，后续 PR CI 会继续验证 release 与 deploy workflow guardrails

## 发布链路影响
这条修复合并后，需要继续跟进：
- PR CI
- 合并后的 main 分支 CI
- 重新触发或等待 CD 重新跑通 staging deploy -> staging E2E -> production deploy -> production smoke
- 后续 GitHub Release 与 TestFlight 链路是否恢复闭环

Fixes #134