### PR TITLE
fix: avoid false network errors after successful Android login

### DIFF
--- a/fabushi/lib/services/auth_service.dart
+++ b/fabushi/lib/services/auth_service.dart
@@ -46,6 +46,61 @@ class AuthService {
     };
   }
 
+  static UserModel buildLoginUser(
+    Map<String, dynamic> data, {
+    required String requestedIdentifier,
+  }) {
+    final rawUser = data['user'];
+    final user = rawUser is Map ? Map<String, dynamic>.from(rawUser) : <String, dynamic>{};
+    final resolvedUsername =
+        (user['username'] ?? data['username'] ?? requestedIdentifier).toString();
+    final resolvedEmail =
+        (user['email'] as String?) ??
+        (resolvedUsername.contains('@') ? resolvedUsername : '');
+    final membershipJson = user['membership'];
+
+    return UserModel(
+      username: resolvedUsername,
+      email: resolvedEmail,
+      emailVerified:
+          user['emailVerified'] as bool? ?? user['email_verified'] == true,
+      createdAt:
+          (user['createdAt'] ?? user['created_at'] ?? DateTime.now().toIso8601String())
+              .toString(),
+      wechatOpenid: user['wechatOpenid'] as String?,
+      wechatNickname: user['wechatNickname'] as String?,
+      wechatHeadimgurl: user['wechatHeadimgurl'] as String?,
+      wechatBoundAt: user['wechatBoundAt'] as String?,
+      alipayUserId: user['alipayUserId'] as String?,
+      alipayNickname: user['alipayNickname'] as String?,
+      alipayAvatar: user['alipayAvatar'] as String?,
+      alipayBoundAt: user['alipayBoundAt'] as String?,
+      nickname: user['nickname'] as String?,
+      avatar: user['avatar'] as String?,
+      phoneNumber: (user['phoneNumber'] ?? user['phone_number']) as String?,
+      firebaseUid: (user['firebaseUid'] ?? user['firebase_uid']) as String?,
+      mainPractice: user['mainPractice'] is Map
+          ? Map<String, dynamic>.from(user['mainPractice'] as Map)
+          : null,
+      membership: membershipJson is Map
+          ? MembershipInfo.fromJson(Map<String, dynamic>.from(membershipJson))
+          : MembershipInfo(type: 'expired', isActive: false),
+    );
+  }
+
+  void _refreshUserInfoAfterLogin(String token) {
+    print('开始后台异步刷新用户信息...');
+    _fetchUserInfo()
+        .then((fullUserInfo) async {
+          print('后台刷新成功，更新用户信息: ${fullUserInfo.membership.type}');
+          _currentUser = fullUserInfo;
+          await _saveAuth(token, fullUserInfo);
+        })
+        .catchError((e) {
+          print('后台刷新用户信息失败: $e');
+        });
+  }
+
   Future<void> initialize() async {
     await _loadStoredAuth();
   }
@@ -120,46 +175,25 @@ class AuthService {
       );
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
         final token = data['token'] as String;
+        final userInfo = buildLoginUser(
+          data,
+          requestedIdentifier: username,
+        );
 
-        _currentToken = token;
-
-        UserModel userInfo;
         if (data.containsKey('user') && data['user'] != null) {
-          print('使用登录API返回的完整用户信息');
-          userInfo = UserModel.fromJson(data['user']);
+          print('使用登录API返回的用户信息，并允许后续资料刷新失败时继续登录');
         } else if (data.containsKey('username')) {
-          print('登录API返回基本信息，创建临时用户对象');
-          final usernameFromApi = data['username'] as String;
-          userInfo = UserModel(
-            username: usernameFromApi,
-            email: usernameFromApi.contains('@') ? usernameFromApi : '',
-            emailVerified: false,
-            createdAt: DateTime.now().toIso8601String(),
-            membership: MembershipInfo(type: 'expired', isActive: false),
-          );
-
-          await _saveAuth(token, userInfo);
-
-          print('开始后台异步刷新用户信息...');
-          _fetchUserInfo()
-              .then((fullUserInfo) async {
-                print('后台刷新成功，更新用户信息: ${fullUserInfo.membership.type}');
-                _currentUser = fullUserInfo;
-                await _saveAuth(token, fullUserInfo);
-              })
-              .catchError((e) {
-                print('后台刷新用户信息失败: $e');
-              });
-
-          return {'success': true, 'token': token, 'user': userInfo.toJson()};
+          print('登录API返回基本信息，先用最小用户资料完成登录');
         } else {
-          print('登录API未返回用户信息，同步请求用户详细信息');
-          userInfo = await _fetchUserInfo();
+          print('登录API未返回用户信息，回退到请求入参完成首屏登录');
         }
 
+        _currentToken = token;
+        _currentUser = userInfo;
         await _saveAuth(token, userInfo);
+        _refreshUserInfoAfterLogin(token);
 
         return {'success': true, 'token': token, 'user': userInfo.toJson()};
       }
@@ -167,6 +201,14 @@ class AuthService {
       return _failureFromResponse(response, '登录失败');
     } catch (e) {
       print('登录请求失败: $e');
+      if (_currentToken != null && _currentUser != null) {
+        print('登录接口已成功返回，保留当前会话并跳过附加资料刷新失败');
+        return {
+          'success': true,
+          'token': _currentToken,
+          'user': _currentUser!.toJson(),
+        };
+      }
       return {'success': false, 'error': '网络错误，请检查网络连接'};
     }
   }

--- a/fabushi/test/services/auth_service_test.dart
+++ b/fabushi/test/services/auth_service_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/models/user_model.dart';
+import 'package:global_dharma_sharing/services/auth_service.dart';
+
+void main() {
+  group('AuthService.buildLoginUser', () {
+    test('tolerates partial user payloads from a successful login response', () {
+      final user = AuthService.buildLoginUser(
+        {
+          'token': 'token-123',
+          'username': 'android_fallback',
+          'user': {
+            'username': 'android_user',
+            'nickname': '安卓用户',
+            'phone_number': '+8613800000000',
+            'membership': {
+              'type': 'trial',
+              'isActive': true,
+            },
+          },
+        },
+        requestedIdentifier: 'requested_name',
+      );
+
+      expect(user.username, 'android_user');
+      expect(user.nickname, '安卓用户');
+      expect(user.phoneNumber, '+8613800000000');
+      expect(user.membership.type, 'trial');
+      expect(user.membership.isActive, isTrue);
+      expect(user.createdAt, isNotEmpty);
+    });
+
+    test('falls back to the requested identifier when login payload is minimal', () {
+      final user = AuthService.buildLoginUser(
+        {
+          'token': 'token-456',
+        },
+        requestedIdentifier: 'fallback@example.com',
+      );
+
+      expect(user.username, 'fallback@example.com');
+      expect(user.email, 'fallback@example.com');
+      expect(user.membership, isA<MembershipInfo>());
+      expect(user.membership.type, 'expired');
+      expect(user.membership.isActive, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
- 让账号密码登录在后端已经成功返回 token 时，不再因为后续资料补全或本地持久化的附带异常被整体误报成“网络错误”
- 给登录返回的 `user` payload 增加容错解析，允许缺少 `createdAt` 等非首屏必需字段时先完成登录
- 补一条 Flutter 单测，锁住这条成功登录载荷的回退解析路径

## 根因
issue #128 的症状是：安卓端网络正常，但账号密码登录却提示网络错误，而苹果端同账号同密码正常。

从当前代码链路看，`AuthService.login()` 里有一个很容易把“登录已成功”误判成“网络错误”的路径：
1. 登录接口只要 `HTTP 200`，其实 token 已经拿到了
2. 但随后如果发生任一附带失败，例如：
   - 登录返回的 `user` payload 不是 `UserModel.fromJson(...)` 期望的完整结构
   - 后续首屏资料补全请求失败
   - 本地认证信息持久化失败
3. 这些异常会被同一个 `catch` 整体吞掉，然后统一改写成 `网络错误，请检查网络连接`

这会把“认证成功后的补充步骤失败”错误地暴露成“登录本身失败”，非常像用户在安卓端看到的现象。

## 这次怎么修
1. `fabushi/lib/services/auth_service.dart`
   - 新增 `buildLoginUser(...)`，把登录成功载荷解析成更稳健的 `UserModel`
   - 对缺少 `createdAt` / `membership` 等非首屏关键字段的 payload 做回退值处理
   - 登录 API 成功后，先把 token 和最小可用用户态落到内存与本地，再异步刷新完整资料
   - 如果失败点发生在成功拿到 token 之后，保留当前会话，不再误报成网络错误
2. `fabushi/test/services/auth_service_test.dart`
   - 验证部分 `user` payload 仍能成功构造登录用户对象
   - 验证最小 payload 也会回退到请求用户名完成登录态建立

## 为什么这样做
- 这次不去猜测某个安卓设备上的单一外围异常，而是直接修掉“成功登录也会被后续异常改写成网络错误”这条错误传播路径
- 即使后续资料补全暂时失败，用户也不该被卡死在登录页；先进入已登录态，再后台补全资料，更符合真实用户体验
- 单测把最脆弱的 payload 容错路径锁住，避免以后再把同类安卓问题重新带回去

## 验证
- 新增 Flutter 单测覆盖登录成功载荷的两种回退解析场景
- 后续继续以 GitHub Actions 的 Flutter / Android / CI 全链路结果作为最终验证

Fixes #128