### PR TITLE
fix: make co-practice group discovery and approval easier to find

### DIFF
--- a/fabushi/lib/models/co_practice_group_model.dart
+++ b/fabushi/lib/models/co_practice_group_model.dart
@@ -20,6 +20,7 @@ class CoPracticeGroup {
   final int cumulativeMissLimit;
   final int consecutiveMissLimit;
   final int memberCount;
+  final int pendingCount;
   final int totalDuration;
   final int todayDuration;
   final String? myStatus;
@@ -38,6 +39,7 @@ class CoPracticeGroup {
     required this.cumulativeMissLimit,
     required this.consecutiveMissLimit,
     required this.memberCount,
+    required this.pendingCount,
     required this.totalDuration,
     required this.todayDuration,
     this.myStatus,
@@ -66,6 +68,7 @@ class CoPracticeGroup {
         json['consecutiveMissLimit'] ?? json['consecutive_miss_limit'],
       ),
       memberCount: _asInt(json['memberCount'] ?? json['member_count']),
+      pendingCount: _asInt(json['pendingCount'] ?? json['pending_count']),
       totalDuration: _asInt(json['totalDuration'] ?? json['total_duration']),
       todayDuration: _asInt(json['todayDuration'] ?? json['today_duration']),
       myStatus: (json['myStatus'] ?? json['my_status'])?.toString(),

--- a/fabushi/lib/widgets/co_practice_group_panel.dart
+++ b/fabushi/lib/widgets/co_practice_group_panel.dart
@@ -70,6 +70,39 @@ class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFD4AF37).withValues(alpha: 0.10),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: const Color(0xFFD4AF37).withValues(alpha: 0.24),
+            ),
+          ),
+          child: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '共修小组入口',
+                style: TextStyle(
+                  color: Color(0xFFD4AF37),
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              SizedBox(height: 6),
+              Text(
+                '先搜索小组名、组主或群号，点开后即可申请加入；创建者点开自己的小组，就能在详情页里看到待审批成员。',
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 12,
+                  height: 1.45,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
         Row(
           children: [
             Expanded(
@@ -78,7 +111,7 @@ class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
                 onChanged: _onSearchChanged,
                 style: const TextStyle(color: Colors.white),
                 decoration: InputDecoration(
-                  hintText: '搜索共修小组',
+                  hintText: '搜索小组名、组主或群号 #123',
                   hintStyle: const TextStyle(color: Colors.white38),
                   prefixIcon: const Icon(Icons.search, color: Colors.white54),
                   suffixIcon: _searchController.text.isEmpty
@@ -214,6 +247,24 @@ class _CoPracticeGroupTile extends StatelessWidget {
                 spacing: 8,
                 runSpacing: 6,
                 children: [
+                  Text(
+                    '组主 ${group.ownerName}',
+                    style: const TextStyle(
+                      color: Colors.white54,
+                      fontSize: 12,
+                    ),
+                  ),
+                  _InfoPill(
+                    icon: Icons.tag_outlined,
+                    text: '群号 #${group.id}',
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                children: [
                   _InfoPill(
                     icon: Icons.timer_outlined,
                     text: '累计 ${_formatMinutes(group.totalDuration)}',
@@ -230,6 +281,20 @@ class _CoPracticeGroupTile extends StatelessWidget {
                     icon: Icons.group_outlined,
                     text: '${group.memberCount} 人',
                   ),
+                  if (group.myRole == 'owner')
+                    _InfoPill(
+                      icon: Icons.admin_panel_settings_outlined,
+                      text: group.pendingCount > 0
+                          ? '待审批 ${group.pendingCount}'
+                          : '组主管理',
+                    ),
+                  if (group.myStatus == null ||
+                      group.myStatus == 'removed' ||
+                      group.myStatus == 'rejected')
+                    _InfoPill(
+                      icon: Icons.travel_explore_outlined,
+                      text: group.requireApproval ? '点开申请加入' : '点开直接加入',
+                    ),
                 ],
               ),
               if (group.myWarningMessage?.isNotEmpty == true) ...[
@@ -466,6 +531,14 @@ class _CoPracticeGroupDetailSheetState
                     runSpacing: 8,
                     children: [
                       _InfoPill(
+                        icon: Icons.person_outline,
+                        text: '组主 ${group.ownerName}',
+                      ),
+                      _InfoPill(
+                        icon: Icons.tag_outlined,
+                        text: '群号 #${group.id}',
+                      ),
+                      _InfoPill(
                         icon: Icons.timer_outlined,
                         text: '累计 ${_formatMinutes(group.totalDuration)}',
                       ),
@@ -478,6 +551,13 @@ class _CoPracticeGroupDetailSheetState
                         text:
                             '累计 ${group.cumulativeMissLimit} / 连续 ${group.consecutiveMissLimit}',
                       ),
+                      if (group.myRole == 'owner')
+                        _InfoPill(
+                          icon: Icons.mark_email_unread_outlined,
+                          text: group.pendingCount > 0
+                              ? '待审批 ${group.pendingCount} 人'
+                              : '暂无待审批',
+                        ),
                     ],
                   ),
                   if (group.myWarningMessage?.isNotEmpty == true) ...[
@@ -499,6 +579,39 @@ class _CoPracticeGroupDetailSheetState
                         ),
                       ),
                     ),
+                  if (group.myStatus == 'pending') ...[
+                    const SizedBox(height: 12),
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.orange.withValues(alpha: 0.10),
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(
+                          color: Colors.orange.withValues(alpha: 0.28),
+                        ),
+                      ),
+                      child: const Row(
+                        children: [
+                          Icon(
+                            Icons.hourglass_top,
+                            color: Colors.orange,
+                            size: 18,
+                          ),
+                          SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              '申请已经发出，创建者点开这个小组详情页，就能在下方“待同意成员”里审批。',
+                              style: TextStyle(
+                                color: Colors.white70,
+                                fontSize: 12,
+                                height: 1.4,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                   if (detail.pendingMembers.isNotEmpty) ...[
                     const SizedBox(height: 18),
                     const Text(
@@ -515,6 +628,37 @@ class _CoPracticeGroupDetailSheetState
                         isWorking: _isWorking,
                         onApprove: () => _review(member.username, true),
                         onReject: () => _review(member.username, false),
+                      ),
+                    ),
+                  ],
+                  if (group.myRole == 'owner' && detail.pendingMembers.isEmpty) ...[
+                    const SizedBox(height: 18),
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.05),
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(color: Colors.white10),
+                      ),
+                      child: const Row(
+                        children: [
+                          Icon(
+                            Icons.admin_panel_settings_outlined,
+                            color: Color(0xFFD4AF37),
+                            size: 18,
+                          ),
+                          SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              '这里就是小组管理与审批入口。别人申请加入后，会直接出现在这里。',
+                              style: TextStyle(
+                                color: Colors.white60,
+                                fontSize: 12,
+                                height: 1.4,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ],

--- a/fabushi/lib/widgets/co_practice_group_panel.dart
+++ b/fabushi/lib/widgets/co_practice_group_panel.dart
@@ -249,15 +249,9 @@ class _CoPracticeGroupTile extends StatelessWidget {
                 children: [
                   Text(
                     '组主 ${group.ownerName}',
-                    style: const TextStyle(
-                      color: Colors.white54,
-                      fontSize: 12,
-                    ),
+                    style: const TextStyle(color: Colors.white54, fontSize: 12),
                   ),
-                  _InfoPill(
-                    icon: Icons.tag_outlined,
-                    text: '群号 #${group.id}',
-                  ),
+                  _InfoPill(icon: Icons.tag_outlined, text: '群号 #${group.id}'),
                 ],
               ),
               const SizedBox(height: 10),
@@ -631,7 +625,8 @@ class _CoPracticeGroupDetailSheetState
                       ),
                     ),
                   ],
-                  if (group.myRole == 'owner' && detail.pendingMembers.isEmpty) ...[
+                  if (group.myRole == 'owner' &&
+                      detail.pendingMembers.isEmpty) ...[
                     const SizedBox(height: 18),
                     Container(
                       padding: const EdgeInsets.all(12),

--- a/fabushi/web/src/handlers/meditation.js
+++ b/fabushi/web/src/handlers/meditation.js
@@ -262,12 +262,28 @@ function mapGroupRow(row) {
         cumulativeMissLimit: row.cumulative_miss_limit || 0,
         consecutiveMissLimit: row.consecutive_miss_limit || 0,
         memberCount: row.member_count || row.memberCount || 0,
+        pendingCount: row.pending_count || row.pendingCount || 0,
         totalDuration: row.total_duration || row.totalDuration || 0,
         todayDuration: row.today_duration || row.todayDuration || 0,
         myStatus: row.my_status || null,
         myRole: row.my_role || null,
         myWarningMessage: row.my_warning_message || null,
         createdAt: row.created_at || null
+    };
+}
+
+function parseGroupSearchQuery(query) {
+    const raw = (query || '').trim();
+    if (!raw) {
+        return { text: '', groupId: null };
+    }
+
+    const normalized = raw.startsWith('#') ? raw.slice(1).trim() : raw;
+    const numericId = /^\d+$/.test(normalized) ? asInt(normalized) : null;
+
+    return {
+        text: raw,
+        groupId: numericId && numericId > 0 ? numericId : null
     };
 }
 
@@ -440,16 +456,25 @@ export async function handleGetMeditationGroups(request, env, db) {
         await refreshGroupsForUser(db, auth.username);
 
         const url = new URL(request.url);
-        const query = (url.searchParams.get('query') || '').trim();
+        const search = parseGroupSearchQuery(url.searchParams.get('query') || '');
         const requestedLimit = parseInt(url.searchParams.get('limit') || '30');
         const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 50) : 30;
         const today = formatDate(new Date());
         const params = [today, auth.username];
         let whereClause = '';
 
-        if (query) {
-            whereClause = `WHERE g.name LIKE ? OR g.description LIKE ?`;
-            params.push(`%${query}%`, `%${query}%`);
+        if (search.text) {
+            whereClause = `
+        WHERE g.name LIKE ?
+           OR g.description LIKE ?
+           OR g.owner_username LIKE ?
+           OR COALESCE(owner.nickname, '') LIKE ?
+      `;
+            params.push(`%${search.text}%`, `%${search.text}%`, `%${search.text}%`, `%${search.text}%`);
+            if (search.groupId) {
+                whereClause += ` OR g.id = ?`;
+                params.push(search.groupId);
+            }
         }
 
         params.push(limit);
@@ -461,6 +486,11 @@ export async function handleGetMeditationGroups(request, env, db) {
         my.status as my_status,
         my.role as my_role,
         my.warning_message as my_warning_message,
+        (
+          SELECT COUNT(*)
+          FROM meditation_group_members m
+          WHERE m.group_id = g.id AND m.status = 'pending'
+        ) as pending_count,
         (
           SELECT COUNT(*)
           FROM meditation_group_members m

--- a/fabushi/web/tests/meditation-groups.test.js
+++ b/fabushi/web/tests/meditation-groups.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  handleGetMeditationGroups,
   handleGetMeditationGroupDetail,
   handleReviewMeditationGroupJoin,
 } from '../src/handlers/meditation.js';
@@ -49,6 +50,9 @@ function createDbMock() {
                   my_status: member?.status ?? null,
                   my_role: member?.role ?? null,
                   my_warning_message: member?.warning_message ?? null,
+                  pending_count: Array.from(members.values()).filter(
+                    (entry) => entry.group_id === groupId && entry.status === 'pending',
+                  ).length,
                   member_count: Array.from(members.values()).filter(
                     (entry) => entry.group_id === groupId && entry.status === 'active',
                   ).length,
@@ -64,6 +68,48 @@ function createDbMock() {
               return null;
             },
             async all() {
+              if (normalizedSql.includes('FROM meditation_groups g LEFT JOIN users owner ON owner.username = g.owner_username LEFT JOIN meditation_group_members my ON my.group_id = g.id AND my.username = ?')) {
+                const [today, username, ...rest] = params;
+                void today;
+                const limit = rest.at(-1);
+                const searchTerms = rest.slice(0, -1).filter((value) => typeof value === 'string');
+                const groupIdSearch = rest
+                  .slice(0, -1)
+                  .find((value) => typeof value === 'number');
+                const trimmedQuery = searchTerms[0]?.replaceAll('%', '').trim().toLowerCase() ?? '';
+                const rows = Array.from(groups.values()).filter((group) => {
+                  if (groupIdSearch && group.id === groupIdSearch) return true;
+                  if (!trimmedQuery) return true;
+                  return [
+                    group.name,
+                    group.description,
+                    group.owner_username,
+                    group.owner_nickname || '',
+                  ].some((field) => field.toLowerCase().includes(trimmedQuery));
+                }).slice(0, limit);
+
+                return {
+                  results: rows.map((group) => {
+                    const member = members.get(keyFor(group.id, username));
+                    return {
+                      ...group,
+                      owner_nickname: group.owner_nickname || null,
+                      my_status: member?.status ?? null,
+                      my_role: member?.role ?? null,
+                      my_warning_message: member?.warning_message ?? null,
+                      pending_count: Array.from(members.values()).filter(
+                        (entry) => entry.group_id === group.id && entry.status === 'pending',
+                      ).length,
+                      member_count: Array.from(members.values()).filter(
+                        (entry) => entry.group_id === group.id && entry.status === 'active',
+                      ).length,
+                      total_duration: 0,
+                      today_duration: 0,
+                    };
+                  }),
+                };
+              }
+
               if (normalizedSql.startsWith('SELECT id FROM meditation_groups WHERE owner_username = ?')) {
                 return {
                   results: Array.from(groups.values())
@@ -311,4 +357,103 @@ test('group owner can still approve join requests after owner membership is rest
   assert.equal(payload.success, true);
   assert.equal(members.get(keyFor(11, 'owner2')).status, 'active');
   assert.equal(members.get(keyFor(11, 'applicant')).status, 'active');
+});
+
+test('group list supports owner search and exposes pending approvals to the owner', async () => {
+  const { db, groups, members, keyFor } = createDbMock();
+  groups.set(21, {
+    id: 21,
+    owner_username: 'group-owner',
+    owner_nickname: '禅修发起人',
+    name: '晨光共修',
+    description: '每天一起完成早课',
+    require_approval: 1,
+    daily_goal_minutes: 20,
+    cumulative_miss_limit: 5,
+    consecutive_miss_limit: 2,
+    created_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(21, 'group-owner'), {
+    id: 9,
+    group_id: 21,
+    username: 'group-owner',
+    role: 'owner',
+    status: 'active',
+    joined_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(21, 'pending-a'), {
+    id: 10,
+    group_id: 21,
+    username: 'pending-a',
+    role: 'member',
+    status: 'pending',
+    joined_at: '2026-05-05T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(21, 'pending-b'), {
+    id: 11,
+    group_id: 21,
+    username: 'pending-b',
+    role: 'member',
+    status: 'pending',
+    joined_at: '2026-05-05T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+
+  const response = await handleGetMeditationGroups(
+    new Request('https://flutter.ombhrum.com/api/meditation/groups?query=%E7%A6%85%E4%BF%AE%E5%8F%91%E8%B5%B7%E4%BA%BA', {
+      headers: { Authorization: authHeader('group-owner') },
+    }),
+    {},
+    db,
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.groups.length, 1);
+  assert.equal(payload.data.groups[0].ownerName, '禅修发起人');
+  assert.equal(payload.data.groups[0].pendingCount, 2);
+  assert.equal(payload.data.groups[0].myRole, 'owner');
+});
+
+test('group list also supports searching by visible group id token', async () => {
+  const { db, groups, members, keyFor } = createDbMock();
+  groups.set(35, {
+    id: 35,
+    owner_username: 'owner-35',
+    owner_nickname: '晚课组织者',
+    name: '莲灯晚课',
+    description: '晚间共修',
+    require_approval: 1,
+    daily_goal_minutes: 25,
+    cumulative_miss_limit: 5,
+    consecutive_miss_limit: 2,
+    created_at: '2026-05-05T00:00:00Z',
+  });
+  members.set(keyFor(35, 'searcher'), {
+    id: 12,
+    group_id: 35,
+    username: 'searcher',
+    role: 'member',
+    status: 'removed',
+    joined_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-05T00:00:00Z',
+  });
+
+  const response = await handleGetMeditationGroups(
+    new Request('https://flutter.ombhrum.com/api/meditation/groups?query=%2335', {
+      headers: { Authorization: authHeader('searcher') },
+    }),
+    {},
+    db,
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.groups.length, 1);
+  assert.equal(payload.data.groups[0].id, 35);
+  assert.equal(payload.data.groups[0].name, '莲灯晚课');
 });


### PR DESCRIPTION
## 概要
- 支持按可见群号搜索共修小组，用户现在可以直接输入 `#123` 或纯数字群号来找组
- 在小组列表和详情里明确展示群号、加入入口，以及创建者的审批入口提示
- 补一条 Worker 回归测试，锁住群号搜索这条发现路径

## 根因
issue #135 里暴露出来的不是单一接口报错，而是“发现路径不清楚”：
1. 当前搜索主要依赖小组名或组主昵称，用户拿到一个群号时并不能直接搜到组
2. 小组管理与审批虽然已经存在于详情页，但入口提示太弱，用户不知道点开后在哪里审批
3. 结果就是用户 B 不知道如何找到组、如何申请加入，组主也不容易确认审批入口在哪里

## 这次怎么修
1. `fabushi/web/src/handlers/meditation.js`
   - 新增 `parseGroupSearchQuery(...)`
   - 当搜索词形如 `#35` 或 `35` 时，后端会把它识别为群号并精确匹配 `g.id`
   - 保留原有按小组名、简介、组主用户名/昵称的模糊搜索
2. `fabushi/lib/widgets/co_practice_group_panel.dart`
   - 面板顶部新增简短引导，直接告诉用户“先搜索，点开申请，组主在详情页审批”
   - 列表卡片和详情页都显式展示 `群号 #id`
   - 对未加入用户补充“点开申请加入 / 直接加入”提示
   - 对待审批和组主管理入口补充更明确的说明文案
3. `fabushi/web/tests/meditation-groups.test.js`
   - 新增 `#35` 搜索命中目标小组的回归用例

## 验证
- `node --test fabushi/web/tests/meditation-groups.test.js`

Fixes #135