### PR TITLE
fix: expose practice privacy controls and hide deleted users from practice leaderboard

### DIFF
--- a/fabushi/lib/screens/settings_screen.dart
+++ b/fabushi/lib/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'keep_alive_guide_screen.dart';
+import 'practice_privacy_screen.dart';
 import '../services/api_client.dart';
 import '../services/app_settings.dart';
 import '../services/llm_model_config.dart';
@@ -446,6 +447,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         );
                       }
                     },
+                  ),
+
+                  _buildSettingItem(
+                    context,
+                    icon: Icons.visibility_outlined,
+                    iconColor: Colors.purpleAccent,
+                    title: '修行隐私',
+                    subtitle: '控制修行排行榜与公开记录的展示范围',
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const PracticePrivacyScreen(),
+                      ),
+                    ),
                   ),
 
                   _buildSettingItem(

--- a/fabushi/test/unit/practice_privacy_settings_entry_test.dart
+++ b/fabushi/test/unit/practice_privacy_settings_entry_test.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('settings screen exposes a direct entry to practice privacy controls', () {
+    final source = File('lib/screens/settings_screen.dart').readAsStringSync();
+
+    expect(source, contains("import 'practice_privacy_screen.dart';"));
+    expect(source, contains("title: '修行隐私'"));
+    expect(source, contains("subtitle: '控制修行排行榜与公开记录的展示范围'"));
+    expect(source, contains('builder: (_) => const PracticePrivacyScreen()'));
+  });
+}

--- a/fabushi/web/src/handlers/auth.js
+++ b/fabushi/web/src/handlers/auth.js
@@ -32,6 +32,73 @@ function serializeUser(user) {
   };
 }
 
+async function safeRun(db, sql, ...params) {
+  try {
+    await db.prepare(sql).bind(...params).run();
+  } catch (error) {
+    console.warn('账户删除引用清理跳过:', error?.message || error);
+  }
+}
+
+async function runInTransaction(db, action) {
+  await db.prepare('BEGIN TRANSACTION').run();
+  try {
+    const result = await action();
+    await db.prepare('COMMIT').run();
+    return result;
+  } catch (error) {
+    try {
+      await db.prepare('ROLLBACK').run();
+    } catch (rollbackError) {
+      console.warn('账户删除事务回滚失败:', rollbackError?.message || rollbackError);
+    }
+    throw error;
+  }
+}
+
+async function deleteUserArtifacts(db, username, email) {
+  const normalizedEmail = String(email || '').trim().toLowerCase();
+  const deletions = [
+    ['DELETE FROM meditation_group_members WHERE group_id IN (SELECT id FROM meditation_groups WHERE owner_username = ?)', username],
+    ['DELETE FROM meditation_groups WHERE owner_username = ?', username],
+    ['DELETE FROM meditation_group_members WHERE username = ?', username],
+    ['DELETE FROM meditation_records WHERE username = ?', username],
+    ['DELETE FROM meditation_goals WHERE username = ?', username],
+    ['DELETE FROM meditation_settings WHERE username = ?', username],
+    ['DELETE FROM user_practice_privacy WHERE username = ?', username],
+    ['DELETE FROM user_follows WHERE follower_username = ? OR following_username = ?', username, username],
+    ['DELETE FROM notifications WHERE username = ? OR related_username = ?', username, username],
+    ['DELETE FROM sync_log WHERE username = ?', username],
+    ['DELETE FROM user_sync_state WHERE username = ?', username],
+    ['DELETE FROM comments WHERE user_id = ? OR username = ?', username, username],
+    ['DELETE FROM likes WHERE username = ?', username],
+    ['DELETE FROM favorites WHERE username = ?', username],
+    ['DELETE FROM content_likes WHERE user_id = ? OR username = ?', username, username],
+    ['DELETE FROM content_favorites WHERE username = ?', username],
+    ['DELETE FROM content_reports WHERE reporter_user_id = ?', username],
+    ['DELETE FROM user_blocks WHERE blocked_user_id = ?', username],
+    ['DELETE FROM email_username_mapping WHERE username = ?', username],
+  ];
+
+  if (normalizedEmail) {
+    deletions.push(['DELETE FROM email_username_mapping WHERE email = ?', normalizedEmail]);
+  }
+
+  for (const [sql, ...params] of deletions) {
+    await safeRun(db, sql, ...params);
+  }
+}
+
+async function clearLeaderboardCaches(env) {
+  await Promise.allSettled([
+    env.USERS_KV?.delete('leaderboard:cache'),
+    env.USERS_KV?.delete('leaderboard:cache:v2'),
+    env.USERS_KV?.delete('leaderboard:practice:v2'),
+    env.USERS_KV?.delete('leaderboard:practice:v3'),
+    env.USERS_KV?.delete('leaderboard:practice:v4')
+  ]);
+}
+
 // 注册
 export async function handleRegister(request, env, db) {
   const { username, email, password, verificationCode } = await request.json();
@@ -285,11 +352,17 @@ export async function handleDeleteAccount(request, env, db) {
       return jsonResponse({ error: '用户不存在' }, 404);
     }
 
-    if (db.deleteUser) {
-      await db.deleteUser(tokenData.username);
-    } else {
-      await db.prepare('DELETE FROM users WHERE username = ?').bind(tokenData.username).run();
-    }
+    await runInTransaction(db, async () => {
+      await deleteUserArtifacts(db, tokenData.username, user.email);
+
+      if (db.deleteUser) {
+        await db.deleteUser(tokenData.username);
+      } else {
+        await db.prepare('DELETE FROM users WHERE username = ?').bind(tokenData.username).run();
+      }
+    });
+
+    await clearLeaderboardCaches(env);
 
     return jsonResponse({ success: true, message: '账户已注销' }, 200);
   } catch (error) {

--- a/fabushi/web/src/handlers/leaderboard.js
+++ b/fabushi/web/src/handlers/leaderboard.js
@@ -193,7 +193,7 @@ export async function handleGetPracticeLeaderboard(request, env, db) {
           LIMIT 1
         ) as latestSutra
       FROM meditation_records mr
-      LEFT JOIN users u ON mr.username = u.username
+      JOIN users u ON mr.username = u.username
       LEFT JOIN user_practice_privacy pp ON pp.username = mr.username
       GROUP BY mr.username
       ORDER BY SUM(COALESCE(mr.duration, 0)) DESC, totalRecords DESC, latestPracticeAt DESC

--- a/fabushi/web/tests/account-deletion-and-practice-privacy.test.js
+++ b/fabushi/web/tests/account-deletion-and-practice-privacy.test.js
@@ -4,18 +4,9 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const webRoot = new URL('..', import.meta.url);
-const screensRoot = new URL('../../lib/screens/', import.meta.url);
 
 const authHandler = readFileSync(join(webRoot.pathname, 'src/handlers/auth.js'), 'utf8');
 const leaderboardHandler = readFileSync(join(webRoot.pathname, 'src/handlers/leaderboard.js'), 'utf8');
-const settingsScreen = readFileSync(join(screensRoot.pathname, 'settings_screen.dart'), 'utf8');
-
-test('settings screen exposes a direct entry to practice privacy controls', () => {
-  assert.match(settingsScreen, /import 'practice_privacy_screen\.dart';/);
-  assert.match(settingsScreen, /title: '修行隐私'/);
-  assert.match(settingsScreen, /subtitle: '控制修行排行榜与公开记录的展示范围'/);
-  assert.match(settingsScreen, /builder: \(_\) => const PracticePrivacyScreen\(\)/);
-});
 
 test('practice leaderboard filters out deleted users instead of keeping orphaned records visible', () => {
   assert.match(leaderboardHandler, /FROM meditation_records mr\s+JOIN users u ON mr\.username = u\.username/s);

--- a/fabushi/web/tests/account-deletion-and-practice-privacy.test.js
+++ b/fabushi/web/tests/account-deletion-and-practice-privacy.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const webRoot = new URL('..', import.meta.url);
+const screensRoot = new URL('../../lib/screens/', import.meta.url);
+
+const authHandler = readFileSync(join(webRoot.pathname, 'src/handlers/auth.js'), 'utf8');
+const leaderboardHandler = readFileSync(join(webRoot.pathname, 'src/handlers/leaderboard.js'), 'utf8');
+const settingsScreen = readFileSync(join(screensRoot.pathname, 'settings_screen.dart'), 'utf8');
+
+test('settings screen exposes a direct entry to practice privacy controls', () => {
+  assert.match(settingsScreen, /import 'practice_privacy_screen\.dart';/);
+  assert.match(settingsScreen, /title: '修行隐私'/);
+  assert.match(settingsScreen, /subtitle: '控制修行排行榜与公开记录的展示范围'/);
+  assert.match(settingsScreen, /builder: \(_\) => const PracticePrivacyScreen\(\)/);
+});
+
+test('practice leaderboard filters out deleted users instead of keeping orphaned records visible', () => {
+  assert.match(leaderboardHandler, /FROM meditation_records mr\s+JOIN users u ON mr\.username = u\.username/s);
+  assert.doesNotMatch(leaderboardHandler, /FROM meditation_records mr\s+LEFT JOIN users u ON mr\.username = u\.username/s);
+});
+
+test('account deletion purges meditation and social artifacts before removing the user', () => {
+  assert.match(authHandler, /async function deleteUserArtifacts\(db, username, email\)/);
+  assert.match(authHandler, /DELETE FROM meditation_records WHERE username = \?/);
+  assert.match(authHandler, /DELETE FROM meditation_goals WHERE username = \?/);
+  assert.match(authHandler, /DELETE FROM meditation_settings WHERE username = \?/);
+  assert.match(authHandler, /DELETE FROM user_practice_privacy WHERE username = \?/);
+  assert.match(authHandler, /DELETE FROM meditation_groups WHERE owner_username = \?/);
+  assert.match(authHandler, /DELETE FROM meditation_group_members WHERE group_id IN \(SELECT id FROM meditation_groups WHERE owner_username = \?\)/);
+  assert.match(authHandler, /DELETE FROM user_follows WHERE follower_username = \? OR following_username = \?/);
+  assert.match(authHandler, /await clearLeaderboardCaches\(env\);/);
+  assert.match(authHandler, /await runInTransaction\(db, async \(\) => \{/);
+});


### PR DESCRIPTION
## 概要
- 在设置页补出明确可见的“修行隐私”入口，用户现在可以直接进入并保存功课公开范围
- 修行排行榜改为只展示仍存在于 `users` 主表中的账号，避免已注销账户继续以历史记录形式残留在榜单里
- 注销账户时同步清理修行、社交和小组相关数据，并主动刷新排行榜缓存，避免同类幽灵账号再次出现
- 补一条回归测试，锁住“入口可见 + 榜单过滤 + 注销清理”这组三连防线

## 根因
issue #146 其实包含两层断点：
1. 修行隐私功能已经实现过，但设置页没有把入口接出来，用户无法自然找到它
2. 注销账户当前只删除 `users` 主表，没有同步清理 `meditation_records` 等从表，导致历史修行记录还能被排行榜聚合出来，形成“已注销账号还在禅室排行榜里”的幽灵数据

只修展示层不够，因为后续继续注销账号时还会重复留下脏数据；只修删除流程也不够，因为当前已存在的孤儿记录仍会继续被榜单展示。

## 这次怎么修
1. `fabushi/lib/screens/settings_screen.dart`
   - 新增“修行隐私”设置项
   - 直接导航到现有 `PracticePrivacyScreen`
2. `fabushi/web/src/handlers/leaderboard.js`
   - 修行排行榜从 `LEFT JOIN users` 改为 `JOIN users`
   - 榜单只统计仍有有效用户主档案的账号，立即隐藏现存孤儿记录
3. `fabushi/web/src/handlers/auth.js`
   - 为注销账户新增 `deleteUserArtifacts(...)`
   - 删除修行记录、修行目标、修行设置、修行隐私、关注关系、共修小组与成员关系等用户衍生数据
   - 注销完成后主动清理排行榜缓存
4. `fabushi/web/tests/account-deletion-and-practice-privacy.test.js`
   - 守住设置入口、榜单过滤和注销清理 SQL 三个关键点

## 为什么这样做
- 这次把“找不到入口”和“删号后残留”一起处理掉，避免用户刚能找到隐私设置，榜单却还在继续暴露已注销数据
- 榜单过滤负责立刻收敛现存脏数据的展示面
- 注销清理负责消除后续复发路径
- 缓存失效保证修复不会因为旧榜单缓存而延迟生效太久

## 验证
- 新增 Worker 回归测试覆盖：
  - 设置页存在修行隐私入口
  - 修行排行榜必须 `JOIN users`
  - 注销账户必须先清理修行 / 社交 / 小组衍生数据并刷新缓存
- 当前环境没有本地完整 checkout 与 Flutter / Worker 执行环境，最终仍以该 PR 的 GitHub Actions 为准继续推进

Fixes #146