### PR TITLE
fix: open profile details from donation leaderboard

### DIFF
--- a/fabushi/lib/screens/leaderboard_screen.dart
+++ b/fabushi/lib/screens/leaderboard_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../models/leaderboard_model.dart';
 import '../widgets/space_background.dart';
 import '../widgets/follow_button.dart';
+import '../widgets/leaderboard_user_detail_sheet.dart';
 import '../core/design_system/app_theme.dart';
 
 class LeaderboardScreen extends StatefulWidget {
@@ -117,6 +118,12 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
                         margin: const EdgeInsets.only(bottom: 8),
                         decoration: AppTheme.glassDecoration,
                         child: ListTile(
+                          onTap: () => LeaderboardUserDetailSheet.show(
+                            context,
+                            entry: entry,
+                            highlightLabel: '累计布施',
+                            highlightValue: _formatBytes(entry.totalBytes),
+                          ),
                           leading: _buildRankBadge(entry.rank),
                           title: Text(
                             entry.displayName.isNotEmpty

--- a/fabushi/lib/widgets/leaderboard_user_detail_sheet.dart
+++ b/fabushi/lib/widgets/leaderboard_user_detail_sheet.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+
+import '../models/leaderboard_model.dart';
+import '../services/leaderboard_service.dart';
+import 'follow_button.dart';
+
+typedef PublicPracticeRecordLoader =
+    Future<List<Map<String, dynamic>>> Function(String username);
+
+class LeaderboardUserDetailSheet extends StatelessWidget {
+  final LeaderboardEntry entry;
+  final String highlightLabel;
+  final String highlightValue;
+  final PublicPracticeRecordLoader? recordsLoader;
+
+  const LeaderboardUserDetailSheet({
+    super.key,
+    required this.entry,
+    required this.highlightLabel,
+    required this.highlightValue,
+    this.recordsLoader,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required LeaderboardEntry entry,
+    required String highlightLabel,
+    required String highlightValue,
+    PublicPracticeRecordLoader? recordsLoader,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: const Color(0xFF151515),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+      ),
+      builder: (_) => LeaderboardUserDetailSheet(
+        entry: entry,
+        highlightLabel: highlightLabel,
+        highlightValue: highlightValue,
+        recordsLoader: recordsLoader,
+      ),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _loadRecords() {
+    final loader = recordsLoader;
+    if (loader != null) {
+      return loader(entry.username);
+    }
+    return LeaderboardService().fetchPublicPracticeRecords(entry.username);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final displayName =
+        entry.displayName.isNotEmpty ? entry.displayName : entry.username;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(18, 16, 18, 24),
+        child: FutureBuilder<List<Map<String, dynamic>>>(
+          future: _loadRecords(),
+          builder: (context, snapshot) {
+            final records = snapshot.data ?? const <Map<String, dynamic>>[];
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildAvatar(displayName),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            displayName,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 17,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            '@${entry.username}',
+                            style: const TextStyle(
+                              color: Colors.white54,
+                              fontSize: 13,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            '${entry.followerCount} 粉丝 · 关注 ${entry.followingCount}',
+                            style: const TextStyle(
+                              color: Colors.white38,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    FollowButton(
+                      username: entry.username,
+                      initialIsFollowing: entry.isFollowing,
+                      isSelf: entry.isSelf,
+                      initialFollowerCount: entry.followerCount,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.white10,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: Colors.white12),
+                  ),
+                  child: Row(
+                    children: [
+                      Text(
+                        highlightLabel,
+                        style: const TextStyle(
+                          color: Colors.white60,
+                          fontSize: 13,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          highlightValue,
+                          textAlign: TextAlign.right,
+                          style: const TextStyle(
+                            color: Color(0xFFD4AF37),
+                            fontSize: 15,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (entry.isPracticePrivate) ...[
+                  const SizedBox(height: 12),
+                  const Text(
+                    '对方已将功课记录设为私密',
+                    style: TextStyle(color: Colors.white54, fontSize: 13),
+                  ),
+                ],
+                const SizedBox(height: 16),
+                const Text(
+                  '公开修行记录',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                if (snapshot.connectionState == ConnectionState.waiting)
+                  const Padding(
+                    padding: EdgeInsets.all(28),
+                    child: Center(
+                      child: CircularProgressIndicator(
+                        color: Color(0xFFD4AF37),
+                      ),
+                    ),
+                  )
+                else if (records.isEmpty)
+                  Container(
+                    padding: const EdgeInsets.symmetric(vertical: 28),
+                    decoration: BoxDecoration(
+                      color: Colors.white10,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Center(
+                      child: Text(
+                        '暂无公开记录',
+                        style: TextStyle(color: Colors.white54),
+                      ),
+                    ),
+                  )
+                else
+                  ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxHeight: MediaQuery.sizeOf(context).height * 0.46,
+                    ),
+                    child: ListView.separated(
+                      shrinkWrap: true,
+                      itemCount: records.length,
+                      separatorBuilder: (context, index) =>
+                          const Divider(color: Colors.white10, height: 1),
+                      itemBuilder: (context, index) {
+                        final record = records[index];
+                        final sutra =
+                            record['sutra_name']?.toString() ?? '修行功课';
+                        final date = record['record_date']?.toString() ?? '';
+                        final localTime =
+                            record['local_time']?.toString() ?? '';
+                        final count = record['chant_count'] == null
+                            ? null
+                            : _asInt(record['chant_count']);
+                        final duration = record['duration'] == null
+                            ? null
+                            : _asInt(record['duration']);
+
+                        return ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: const Icon(
+                            Icons.self_improvement,
+                            color: Color(0xFFD4AF37),
+                          ),
+                          title: Text(
+                            sutra,
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          subtitle: Text(
+                            [
+                              _formatDateTime(date, localTime),
+                              if (count != null) _formatPracticeCount(count),
+                              if (duration != null) _formatMinutes(duration),
+                            ].where((part) => part.isNotEmpty).join(' · '),
+                            style: const TextStyle(
+                              color: Colors.white54,
+                              fontSize: 12,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAvatar(String displayName) {
+    final initial = displayName.isNotEmpty ? displayName[0] : '?';
+    return CircleAvatar(
+      radius: 24,
+      backgroundColor: Colors.white10,
+      backgroundImage:
+          entry.avatar?.isNotEmpty == true ? NetworkImage(entry.avatar!) : null,
+      child: entry.avatar?.isNotEmpty == true
+          ? null
+          : Text(
+              initial,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+    );
+  }
+
+  int _asInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.round();
+    if (value is String) return int.tryParse(value) ?? 0;
+    return 0;
+  }
+
+  String _formatPracticeCount(int count) => '$count 遍';
+
+  String _formatDateTime(String date, String localTime) {
+    if (date.isEmpty) return localTime;
+    if (localTime.isEmpty) return date;
+    return '$date $localTime';
+  }
+
+  String _formatMinutes(int minutes) {
+    if (minutes <= 0) return '0 分钟';
+    if (minutes < 60) return '$minutes 分钟';
+    final hours = minutes ~/ 60;
+    final remain = minutes % 60;
+    return remain == 0 ? '$hours 小时' : '$hours 小时 $remain 分钟';
+  }
+}

--- a/fabushi/lib/widgets/practice_leaderboard_sheet.dart
+++ b/fabushi/lib/widgets/practice_leaderboard_sheet.dart
@@ -5,6 +5,7 @@ import '../models/leaderboard_model.dart';
 import '../services/leaderboard_service.dart';
 import 'co_practice_group_panel.dart';
 import 'follow_button.dart';
+import 'leaderboard_user_detail_sheet.dart';
 
 class PracticeLeaderboardSheet extends StatefulWidget {
   const PracticeLeaderboardSheet({super.key});
@@ -111,7 +112,10 @@ class _PracticeLeaderboardSheetState extends State<PracticeLeaderboardSheet> {
                 const SizedBox(height: 12),
                 Expanded(
                   child: TabBarView(
-                    children: [_buildGlobalLeaderboard(), const CoPracticeGroupPanel()],
+                    children: [
+                      _buildGlobalLeaderboard(),
+                      const CoPracticeGroupPanel(),
+                    ],
                   ),
                 ),
               ],
@@ -127,12 +131,19 @@ class _PracticeLeaderboardSheetState extends State<PracticeLeaderboardSheet> {
       future: _future,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator(color: Color(0xFFD4AF37)));
+          return const Center(
+            child: CircularProgressIndicator(color: Color(0xFFD4AF37)),
+          );
         }
 
         final entries = snapshot.data ?? [];
         if (entries.isEmpty) {
-          return const Center(child: Text('暂无修行排行数据', style: TextStyle(color: Colors.white54)));
+          return const Center(
+            child: Text(
+              '暂无修行排行数据',
+              style: TextStyle(color: Colors.white54),
+            ),
+          );
         }
 
         return ListView.separated(
@@ -142,7 +153,12 @@ class _PracticeLeaderboardSheetState extends State<PracticeLeaderboardSheet> {
             final entry = entries[index];
             return _PracticeLeaderboardTile(
               entry: entry,
-              onTap: () => _showRecords(context, entry),
+              onTap: () => LeaderboardUserDetailSheet.show(
+                context,
+                entry: entry,
+                highlightLabel: '修行时长',
+                highlightValue: _practiceMetric(entry),
+              ),
               onFollowChanged: _refresh,
             );
           },
@@ -151,151 +167,11 @@ class _PracticeLeaderboardSheetState extends State<PracticeLeaderboardSheet> {
     );
   }
 
-  void _showRecords(BuildContext context, LeaderboardEntry entry) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: const Color(0xFF151515),
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
-      ),
-      builder: (context) {
-        return FutureBuilder<List<Map<String, dynamic>>>(
-          future: LeaderboardService().fetchPublicPracticeRecords(entry.username),
-          builder: (context, snapshot) {
-            final records = snapshot.data ?? [];
-            return SafeArea(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            '${entry.displayName} 的公开修行记录',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
-                        FollowButton(
-                          username: entry.username,
-                          initialIsFollowing: entry.isFollowing,
-                          isSelf: entry.isSelf,
-                        ),
-                      ],
-                    ),
-                    if (entry.isPracticePrivate) ...[
-                      const SizedBox(height: 12),
-                      const Text('对方已将功课记录设为私密', style: TextStyle(color: Colors.white54, fontSize: 13)),
-                    ],
-                    const SizedBox(height: 12),
-                    if (snapshot.connectionState == ConnectionState.waiting)
-                      const Padding(
-                        padding: EdgeInsets.all(28),
-                        child: Center(child: CircularProgressIndicator(color: Color(0xFFD4AF37))),
-                      )
-                    else if (records.isEmpty)
-                      const Padding(
-                        padding: EdgeInsets.all(28),
-                        child: Center(child: Text('暂无公开记录', style: TextStyle(color: Colors.white54))),
-                      )
-                    else
-                      ConstrainedBox(
-                        constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.48),
-                        child: ListView.separated(
-                          shrinkWrap: true,
-                          itemCount: records.length,
-                          separatorBuilder: (context, index) => const Divider(color: Colors.white10, height: 1),
-                          itemBuilder: (context, index) {
-                            final record = records[index];
-                            final sutra = record['sutra_name']?.toString() ?? '修行功课';
-                            final date = record['record_date']?.toString() ?? '';
-                            final count = record['chant_count'] == null ? null : _asInt(record['chant_count']);
-                            final duration = record['duration'] == null ? null : _asInt(record['duration']);
-                            final localTime = record['local_time']?.toString() ?? '';
-                            return ListTile(
-                              contentPadding: EdgeInsets.zero,
-                              onTap: () => _showRecordDetail(context, record, publicOwner: entry.displayName),
-                              leading: const Icon(Icons.self_improvement, color: Color(0xFFD4AF37)),
-                              title: Text(sutra, style: const TextStyle(color: Colors.white)),
-                              subtitle: Text(
-                                [
-                                  _formatDateTime(date, localTime),
-                                  if (count != null) _formatPracticeCount(count),
-                                  if (duration != null) _formatMinutes(duration),
-                                ].where((part) => part.isNotEmpty).join(' · '),
-                                style: const TextStyle(color: Colors.white54, fontSize: 12),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            );
-          },
-        );
-      },
-    );
-  }
-
-  void _showRecordDetail(BuildContext context, Map<String, dynamic> record, {required String publicOwner}) {
-    final sutra = record['sutra_name']?.toString() ?? '修行功课';
-    final date = record['record_date']?.toString() ?? '';
-    final localTime = record['local_time']?.toString() ?? '';
-    final count = record['chant_count'] == null ? null : _asInt(record['chant_count']);
-    final duration = record['duration'] == null ? null : _asInt(record['duration']);
-    final source = _asInt(record['is_manual']) == 1 ? '补录' : '禅室';
-    final createdAt = record['created_at']?.toString() ?? '';
-
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: const Color(0xFF1E1E1E),
-      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(18))),
-      builder: (context) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(18, 16, 18, 24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Text('$publicOwner 的修行详情', style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.bold)),
-                const SizedBox(height: 14),
-                _DetailRow(label: '功课', value: sutra),
-                _DetailRow(label: '时间', value: _formatDateTime(date, localTime)),
-                _DetailRow(label: '修行时长', value: duration == null ? '未公开' : _formatMinutes(duration)),
-                _DetailRow(label: '念诵遍数', value: count == null ? '未公开' : _formatPracticeCount(count)),
-                _DetailRow(label: '来源', value: source),
-                if (createdAt.isNotEmpty) _DetailRow(label: '同步时间', value: createdAt),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  int _asInt(dynamic value) {
-    if (value is int) return value;
-    if (value is num) return value.round();
-    if (value is String) return int.tryParse(value) ?? 0;
-    return 0;
-  }
-
-  String _formatPracticeCount(int count) => '$count 遍';
-
-  String _formatDateTime(String date, String localTime) {
-    if (date.isEmpty) return localTime;
-    if (localTime.isEmpty) return date;
-    return '$date $localTime';
+  String _practiceMetric(LeaderboardEntry entry) {
+    if (entry.isPracticePrivate || entry.totalDuration == null) {
+      return '已私密';
+    }
+    return _formatMinutes(entry.totalDuration!);
   }
 
   String _formatMinutes(int minutes) {
@@ -307,33 +183,16 @@ class _PracticeLeaderboardSheetState extends State<PracticeLeaderboardSheet> {
   }
 }
 
-class _DetailRow extends StatelessWidget {
-  final String label;
-  final String value;
-
-  const _DetailRow({required this.label, required this.value});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(width: 76, child: Text(label, style: const TextStyle(color: Colors.white38, fontSize: 13))),
-          Expanded(child: Text(value.isEmpty ? '-' : value, style: const TextStyle(color: Colors.white, fontSize: 14))),
-        ],
-      ),
-    );
-  }
-}
-
 class _PracticeLeaderboardTile extends StatelessWidget {
   final LeaderboardEntry entry;
   final VoidCallback onTap;
   final VoidCallback onFollowChanged;
 
-  const _PracticeLeaderboardTile({required this.entry, required this.onTap, required this.onFollowChanged});
+  const _PracticeLeaderboardTile({
+    required this.entry,
+    required this.onTap,
+    required this.onFollowChanged,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -354,15 +213,34 @@ class _PracticeLeaderboardTile extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      entry.displayName.isNotEmpty ? entry.displayName : entry.username,
+                      entry.displayName.isNotEmpty
+                          ? entry.displayName
+                          : entry.username,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                     const SizedBox(height: 4),
-                    Text(_subtitle, maxLines: 1, overflow: TextOverflow.ellipsis, style: const TextStyle(color: Colors.white54, fontSize: 12)),
+                    Text(
+                      _subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Colors.white54,
+                        fontSize: 12,
+                      ),
+                    ),
                     const SizedBox(height: 3),
-                    Text('${entry.followerCount} 粉丝', style: const TextStyle(color: Colors.white38, fontSize: 11)),
+                    Text(
+                      '${entry.followerCount} 粉丝',
+                      style: const TextStyle(
+                        color: Colors.white38,
+                        fontSize: 11,
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -371,7 +249,13 @@ class _PracticeLeaderboardTile extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(_durationText, style: const TextStyle(color: Color(0xFFD4AF37), fontWeight: FontWeight.bold)),
+                  Text(
+                    _durationText,
+                    style: const TextStyle(
+                      color: Color(0xFFD4AF37),
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                   const SizedBox(height: 8),
                   FollowButton(
                     username: entry.username,
@@ -419,10 +303,17 @@ class _PracticeLeaderboardTile extends StatelessWidget {
         CircleAvatar(
           radius: 23,
           backgroundColor: Colors.white10,
-          backgroundImage: entry.avatar?.isNotEmpty == true ? NetworkImage(entry.avatar!) : null,
+          backgroundImage:
+              entry.avatar?.isNotEmpty == true ? NetworkImage(entry.avatar!) : null,
           child: entry.avatar?.isNotEmpty == true
               ? null
-              : Text(entry.rank.toString(), style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+              : Text(
+                  entry.rank.toString(),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
         ),
         Positioned(
           right: -5,
@@ -436,7 +327,14 @@ class _PracticeLeaderboardTile extends StatelessWidget {
               border: Border.all(color: const Color(0xFF111111), width: 2),
             ),
             alignment: Alignment.center,
-            child: Text('${entry.rank}', style: const TextStyle(color: Colors.white, fontSize: 10, fontWeight: FontWeight.bold)),
+            child: Text(
+              '${entry.rank}',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
           ),
         ),
       ],

--- a/fabushi/test/unit/leaderboard_social_privacy_test.dart
+++ b/fabushi/test/unit/leaderboard_social_privacy_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:global_dharma_sharing/models/leaderboard_model.dart';
 import 'package:global_dharma_sharing/widgets/follow_button.dart';
+import 'package:global_dharma_sharing/widgets/leaderboard_user_detail_sheet.dart';
 
 void main() {
   group('LeaderboardEntry social and privacy parsing', () {
@@ -91,6 +92,91 @@ void main() {
 
       expect(find.text('已关注'), findsOneWidget);
       expect(find.text('9 粉丝'), findsOneWidget);
+    });
+  });
+
+  group('LeaderboardUserDetailSheet', () {
+    testWidgets('renders summary and public records', (tester) async {
+      final entry = LeaderboardEntry.fromJson({
+        'username': 'alice',
+        'displayName': 'Alice',
+        'rank': 2,
+        'totalBytes': 2048,
+        'totalRecords': 3,
+        'totalCount': 9,
+        'totalDuration': 45,
+        'totalDays': 2,
+        'followerCount': 12,
+        'followingCount': 4,
+        'isFollowing': true,
+        'privacy': {'isPrivate': false},
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            backgroundColor: const Color(0xFF121212),
+            body: LeaderboardUserDetailSheet(
+              entry: entry,
+              highlightLabel: '累计布施',
+              highlightValue: '2.0 KB',
+              recordsLoader: (_) async => [
+                {
+                  'sutra_name': '心经',
+                  'record_date': '2026-05-06',
+                  'local_time': '08:00',
+                  'chant_count': 3,
+                  'duration': 15,
+                },
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('@alice'), findsOneWidget);
+      expect(find.text('累计布施'), findsOneWidget);
+      expect(find.text('2.0 KB'), findsOneWidget);
+      expect(find.text('12 粉丝 · 关注 4'), findsOneWidget);
+      expect(find.text('公开修行记录'), findsOneWidget);
+      expect(find.text('心经'), findsOneWidget);
+      expect(find.text('2026-05-06 08:00 · 3 遍 · 15 分钟'), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when no records are public', (tester) async {
+      final entry = LeaderboardEntry.fromJson({
+        'username': 'bob',
+        'displayName': 'Bob',
+        'rank': 1,
+        'totalBytes': 0,
+        'totalRecords': 0,
+        'totalDays': 0,
+        'followerCount': 0,
+        'followingCount': 0,
+        'privacy': {'isPrivate': true},
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            backgroundColor: const Color(0xFF121212),
+            body: LeaderboardUserDetailSheet(
+              entry: entry,
+              highlightLabel: '修行时长',
+              highlightValue: '已私密',
+              recordsLoader: (_) async => const [],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('对方已将功课记录设为私密'), findsOneWidget);
+      expect(find.text('暂无公开记录'), findsOneWidget);
     });
   });
 }

--- a/fabushi/test/unit/leaderboard_social_privacy_test.dart
+++ b/fabushi/test/unit/leaderboard_social_privacy_test.dart
@@ -167,7 +167,7 @@ void main() {
               entry: entry,
               highlightLabel: '修行时长',
               highlightValue: '已私密',
-              recordsLoader: (_) async => const [],
+              recordsLoader: (_) async => <Map<String, dynamic>>[],
             ),
           ),
         ),


### PR DESCRIPTION
## 概要
- 全球布施排行榜补上点击用户后查看个人详情的能力，不再只有修行榜可以进入详情
- 把榜单用户详情抽成一个可复用底部面板，统一展示头像、用户名、关注关系、关键指标和公开修行记录
- 修行排行榜同步复用同一套详情面板，避免两个榜单后续继续分叉
- 补一组轻量 widget / model 测试，锁住详情面板的基础展示和空态

## 根因
issue #147 暴露的是榜单交互能力不一致：
1. 修行排行榜已经有“点用户看详情”的路径
2. 全球布施排行榜只有静态列表和关注按钮，缺少进入用户详情的入口
3. 两个榜单长期各自实现，导致后续一个有详情、一个没有详情

如果只在布施榜里临时加一个单独弹窗，后面两个榜单还会继续各自演进，交互再次走散的概率很高。

## 这次怎么修
1. 新增 `fabushi/lib/widgets/leaderboard_user_detail_sheet.dart`
   - 统一承接榜单用户详情展示
   - 展示头像、用户名、粉丝/关注、关键指标和公开修行记录
   - 允许注入记录加载器，方便测试
2. 更新 `fabushi/lib/screens/leaderboard_screen.dart`
   - 全球布施排行榜 `ListTile` 增加点击入口
   - 点击后打开用户详情面板，并把“累计布施”作为高亮指标传入
3. 更新 `fabushi/lib/widgets/practice_leaderboard_sheet.dart`
   - 修行榜改为复用同一个详情面板
   - 把“修行时长 / 已私密”作为高亮指标传入
4. 更新 `fabushi/test/unit/leaderboard_social_privacy_test.dart`
   - 补详情面板的展示与空态测试

## 验证
- 新增 widget / model 测试覆盖：
  - 详情面板展示用户名、指标和公开记录
  - 私密或无公开记录时显示空态
- 当前环境无法直接运行 Flutter 测试命令，后续以该 PR 的 GitHub Actions 为准继续推进

Fixes #147