### PR TITLE
fix: let users edit and delete saved practice records

### DIFF
--- a/fabushi/lib/screens/practice_record_screen.dart
+++ b/fabushi/lib/screens/practice_record_screen.dart
@@ -68,12 +68,70 @@ class _PracticeRecordScreenState extends State<PracticeRecordScreen> {
     if (changed == true) await _loadData();
   }
 
+  Future<void> _showEditRecordDialog(PracticeRecord record) async {
+    final changed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AddPracticeRecordDialog(initialRecord: record),
+    );
+    if (changed == true) await _loadData();
+  }
+
   Future<void> _showGoalDialog() async {
     final changed = await showDialog<bool>(
       context: context,
       builder: (context) => SetGoalDialog(initialSutra: _defaultSutra),
     );
     if (changed == true) await _loadData();
+  }
+
+  Future<void> _confirmDeleteRecord(PracticeRecord record) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: const Color(0xFF1E1E1E),
+        title: const Text(
+          '删除记录',
+          style: TextStyle(color: Colors.white),
+        ),
+        content: Text(
+          '将删除 ${record.sutraName} 这条修行记录，相关统计会同步更新。',
+          style: const TextStyle(color: Colors.white70, height: 1.5),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消', style: TextStyle(color: Colors.white54)),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(backgroundColor: Colors.redAccent),
+            child: const Text('确认删除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    final deleted = await _service.deleteRecord(record.id);
+    if (!mounted) return;
+
+    if (deleted) {
+      await _loadData();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('修行记录已删除'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(_service.lastError ?? '删除失败，请检查网络后重试'),
+        ),
+      );
+    }
   }
 
   @override
@@ -419,7 +477,7 @@ class _PracticeRecordScreenState extends State<PracticeRecordScreen> {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
       ),
-      builder: (context) {
+      builder: (sheetContext) {
         return SafeArea(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(18, 16, 18, 24),
@@ -465,6 +523,44 @@ class _PracticeRecordScreenState extends State<PracticeRecordScreen> {
                     ),
                   ),
                 ],
+                const SizedBox(height: 18),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: () {
+                          Navigator.pop(sheetContext);
+                          _showEditRecordDialog(record);
+                        },
+                        icon: const Icon(Icons.edit_outlined),
+                        label: const Text('编辑记录'),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: Colors.white,
+                          side: BorderSide(
+                            color: Colors.white.withValues(alpha: 0.2),
+                          ),
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton.icon(
+                        onPressed: () {
+                          Navigator.pop(sheetContext);
+                          _confirmDeleteRecord(record);
+                        },
+                        icon: const Icon(Icons.delete_outline),
+                        label: const Text('删除记录'),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: Colors.redAccent,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ],
             ),
           ),

--- a/fabushi/lib/services/practice_stats_service.dart
+++ b/fabushi/lib/services/practice_stats_service.dart
@@ -442,6 +442,44 @@ class PracticeStatsService extends ChangeNotifier {
     ]);
   }
 
+  Future<bool> _sendRecordMutation({
+    required String method,
+    required int recordId,
+    Map<String, dynamic>? body,
+  }) async {
+    final url = await _baseUrl;
+    final uri = Uri.parse(
+      '$url/api/meditation/records',
+    ).replace(queryParameters: {'id': recordId.toString()});
+
+    late final http.Response response;
+    if (method == 'PUT') {
+      response = await http.put(
+        uri,
+        headers: _headers,
+        body: jsonEncode(body ?? const <String, dynamic>{}),
+      );
+    } else if (method == 'DELETE') {
+      response = await http.delete(uri, headers: _headers);
+    } else {
+      throw ArgumentError('Unsupported record mutation method: $method');
+    }
+
+    if (response.statusCode != 200) {
+      _lastError = '云端保存失败: HTTP ${response.statusCode}';
+      return false;
+    }
+
+    final data = jsonDecode(response.body);
+    if (data['success'] == true) {
+      _lastError = null;
+      return true;
+    }
+
+    _lastError = data['error']?.toString() ?? '云端保存失败';
+    return false;
+  }
+
   Future<bool> flushPendingRecords() async {
     if (_isFlushingPending) return _pendingSyncCount == 0;
     if (!await _ensureAuthToken()) return false;
@@ -714,6 +752,77 @@ class PracticeStatsService extends ChangeNotifier {
       localTime: localTime,
       notes: notes,
     );
+  }
+
+  Future<bool> updateRecord({
+    required int recordId,
+    required String sutra,
+    required int chantCount,
+    int duration = 0,
+    required bool isManual,
+    String sutraSource = 'custom',
+    String? recordDate,
+    String? localTime,
+    String? notes,
+    int? timezoneOffsetMinutes,
+    DateTime? startTime,
+    DateTime? endTime,
+  }) async {
+    _lastWriteQueued = false;
+    if (!await _ensureAuthToken()) return false;
+
+    try {
+      final updated = await _sendRecordMutation(
+        method: 'PUT',
+        recordId: recordId,
+        body: {
+          'sutra': sutra,
+          'sutraSource': sutraSource,
+          'chantCount': chantCount,
+          'duration': duration,
+          'isManual': isManual,
+          'recordDate': recordDate,
+          'localTime': localTime,
+          'notes': notes ?? '',
+          'timezoneOffsetMinutes':
+              timezoneOffsetMinutes ?? DateTime.now().timeZoneOffset.inMinutes,
+          if (startTime != null) 'startTime': startTime.toIso8601String(),
+          if (endTime != null) 'endTime': endTime.toIso8601String(),
+        },
+      );
+
+      if (updated) {
+        await _refreshAfterRecordMutation();
+        return true;
+      }
+    } catch (e) {
+      _lastError = '更新修行记录失败: $e';
+      debugPrint(_lastError);
+    }
+
+    return false;
+  }
+
+  Future<bool> deleteRecord(int recordId) async {
+    _lastWriteQueued = false;
+    if (!await _ensureAuthToken()) return false;
+
+    try {
+      final deleted = await _sendRecordMutation(
+        method: 'DELETE',
+        recordId: recordId,
+      );
+
+      if (deleted) {
+        await _refreshAfterRecordMutation();
+        return true;
+      }
+    } catch (e) {
+      _lastError = '删除修行记录失败: $e';
+      debugPrint(_lastError);
+    }
+
+    return false;
   }
 
   /// 同步禅室修行记录

--- a/fabushi/lib/widgets/practice_dialogs.dart
+++ b/fabushi/lib/widgets/practice_dialogs.dart
@@ -4,8 +4,13 @@ import '../services/practice_stats_service.dart';
 /// 补录功课对话框
 class AddPracticeRecordDialog extends StatefulWidget {
   final String? initialSutra;
+  final PracticeRecord? initialRecord;
 
-  const AddPracticeRecordDialog({super.key, this.initialSutra});
+  const AddPracticeRecordDialog({
+    super.key,
+    this.initialSutra,
+    this.initialRecord,
+  });
 
   @override
   State<AddPracticeRecordDialog> createState() =>
@@ -21,10 +26,31 @@ class _AddPracticeRecordDialogState extends State<AddPracticeRecordDialog> {
   TimeOfDay _selectedTime = TimeOfDay.now();
   bool _isLoading = false;
 
+  bool get _isEditing => widget.initialRecord != null;
+
   @override
   void initState() {
     super.initState();
-    if (widget.initialSutra != null) {
+    final initialRecord = widget.initialRecord;
+    if (initialRecord != null) {
+      _sutraController.text = initialRecord.sutraName;
+      _countController.text = initialRecord.chantCount.toString();
+      _durationController.text = initialRecord.duration.toString();
+      _notesController.text = initialRecord.notes ?? '';
+      final parsedDate = DateTime.tryParse(initialRecord.recordDate);
+      if (parsedDate != null) {
+        _selectedDate = parsedDate;
+      }
+      if (initialRecord.localTime?.isNotEmpty == true) {
+        final parts = initialRecord.localTime!.split(':');
+        if (parts.length == 2) {
+          _selectedTime = TimeOfDay(
+            hour: int.tryParse(parts[0]) ?? _selectedTime.hour,
+            minute: int.tryParse(parts[1]) ?? _selectedTime.minute,
+          );
+        }
+      }
+    } else if (widget.initialSutra != null) {
       _sutraController.text = widget.initialSutra!;
     }
   }
@@ -117,14 +143,30 @@ class _AddPracticeRecordDialogState extends State<AddPracticeRecordDialog> {
     final timeStr =
         '${_selectedTime.hour.toString().padLeft(2, '0')}:${_selectedTime.minute.toString().padLeft(2, '0')}';
 
-    final success = await service.addManualRecord(
-      sutra: sutra,
-      chantCount: count,
-      duration: duration,
-      recordDate: dateStr,
-      localTime: timeStr,
-      notes: notes.isEmpty ? null : notes,
-    );
+    final success = _isEditing
+        ? await service.updateRecord(
+            recordId: widget.initialRecord!.id,
+            sutra: sutra,
+            chantCount: count,
+            duration: duration,
+            recordDate: dateStr,
+            localTime: timeStr,
+            notes: notes.isEmpty ? null : notes,
+            isManual: widget.initialRecord!.isManual,
+            sutraSource: widget.initialRecord!.sutraSource,
+            timezoneOffsetMinutes:
+                widget.initialRecord!.timezoneOffsetMinutes,
+            startTime: widget.initialRecord!.startTime,
+            endTime: widget.initialRecord!.endTime,
+          )
+        : await service.addManualRecord(
+            sutra: sutra,
+            chantCount: count,
+            duration: duration,
+            recordDate: dateStr,
+            localTime: timeStr,
+            notes: notes.isEmpty ? null : notes,
+          );
 
     if (!mounted) return;
 
@@ -135,17 +177,25 @@ class _AddPracticeRecordDialogState extends State<AddPracticeRecordDialog> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            service.lastWriteQueued ? '网络暂不可用，补录已加入云端待同步' : '功课已补录到云端',
+            _isEditing
+                ? '修行记录已更新'
+                : service.lastWriteQueued
+                    ? '网络暂不可用，补录已加入云端待同步'
+                    : '功课已补录到云端',
           ),
-          backgroundColor: service.lastWriteQueued
-              ? Colors.orange
-              : Colors.green,
+          backgroundColor: _isEditing
+              ? Colors.green
+              : service.lastWriteQueued
+                  ? Colors.orange
+                  : Colors.green,
         ),
       );
     } else {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('补录失败，请先登录并检查网络')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(_isEditing ? '更新失败，请检查网络后重试' : '补录失败，请先登录并检查网络'),
+        ),
+      );
     }
   }
 
@@ -160,9 +210,9 @@ class _AddPracticeRecordDialogState extends State<AddPracticeRecordDialog> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const Text(
-              '补录功课',
-              style: TextStyle(
+            Text(
+              _isEditing ? '编辑记录' : '补录功课',
+              style: const TextStyle(
                 color: Colors.white,
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
@@ -336,7 +386,7 @@ class _AddPracticeRecordDialogState extends State<AddPracticeRecordDialog> {
                               color: Colors.white,
                             ),
                           )
-                        : const Text('确认补录'),
+                        : Text(_isEditing ? '保存修改' : '确认补录'),
                   ),
                 ),
               ],

--- a/fabushi/web/src/handlers/meditation.js
+++ b/fabushi/web/src/handlers/meditation.js
@@ -60,6 +60,56 @@ function daysBetween(startDate, endDate) {
     return Math.max(0, Math.floor((end - start) / 86400000) + 1);
 }
 
+async function getNextSyncVersion(db, username) {
+    const versionResult = await db.prepare(`
+      SELECT COALESCE(MAX(sync_version), 0) + 1 as next_version FROM (
+        SELECT MAX(sync_version) as sync_version FROM content_likes WHERE username = ?
+        UNION ALL
+        SELECT MAX(sync_version) as sync_version FROM comments WHERE username = ?
+        UNION ALL
+        SELECT MAX(sync_version) as sync_version FROM meditation_records WHERE username = ?
+        UNION ALL
+        SELECT MAX(sync_version) as sync_version FROM meditation_goals WHERE username = ?
+        UNION ALL
+        SELECT MAX(sync_version) as sync_version FROM user_follows WHERE follower_username = ?
+      )
+    `).bind(username, username, username, username, username).first();
+
+    return versionResult?.next_version || 1;
+}
+
+async function clearPracticeCaches(env) {
+    await Promise.allSettled([
+        env.USERS_KV?.delete('leaderboard:cache'),
+        env.USERS_KV?.delete('leaderboard:cache:v2'),
+        env.USERS_KV?.delete('leaderboard:practice:v2'),
+        env.USERS_KV?.delete('leaderboard:practice:v3'),
+        env.USERS_KV?.delete('leaderboard:practice:v4')
+    ]);
+}
+
+async function updateGoalProgress(db, username, sutraName, delta, syncVersion, now) {
+    if (!sutraName || !delta) {
+        return;
+    }
+
+    await db.prepare(`
+      UPDATE meditation_goals
+      SET current_count = CASE
+            WHEN current_count + ? < 0 THEN 0
+            ELSE current_count + ?
+          END,
+          updated_at = ?,
+          sync_version = ?
+      WHERE username = ? AND sutra_name = ? AND status = 'active'
+    `).bind(delta, delta, now, syncVersion, username, sutraName).run();
+}
+
+function resolveRecordId(request, body = null) {
+    const url = new URL(request.url);
+    return asInt(url.searchParams.get('id') || body?.id);
+}
+
 async function ensureOwnerMembershipActive(db, groupId, ownerUsername = null) {
     const resolvedOwnerUsername = ownerUsername || (await db.prepare(`
       SELECT owner_username
@@ -317,20 +367,7 @@ export async function handleSyncRecord(request, env, db) {
         const now = new Date().toISOString();
         const date = recordDate || now.split('T')[0];
         const localClock = parseLocalTime(localTime, new Date());
-        const versionResult = await db.prepare(`
-      SELECT COALESCE(MAX(sync_version), 0) + 1 as next_version FROM (
-        SELECT MAX(sync_version) as sync_version FROM content_likes WHERE username = ?
-        UNION ALL
-        SELECT MAX(sync_version) as sync_version FROM comments WHERE username = ?
-        UNION ALL
-        SELECT MAX(sync_version) as sync_version FROM meditation_records WHERE username = ?
-        UNION ALL
-        SELECT MAX(sync_version) as sync_version FROM meditation_goals WHERE username = ?
-        UNION ALL
-        SELECT MAX(sync_version) as sync_version FROM user_follows WHERE follower_username = ?
-      )
-    `).bind(auth.username, auth.username, auth.username, auth.username, auth.username).first();
-        const nextVersion = versionResult?.next_version || 1;
+        const nextVersion = await getNextSyncVersion(db, auth.username);
 
         const insertResult = await db.prepare(`
       INSERT INTO meditation_records (
@@ -365,12 +402,7 @@ export async function handleSyncRecord(request, env, db) {
       WHERE username = ? AND sutra_name = ? AND status = 'active'
     `).bind(chantCount, now, nextVersion + 1, auth.username, sutra).run();
 
-        await Promise.allSettled([
-            env.USERS_KV?.delete('leaderboard:cache'),
-            env.USERS_KV?.delete('leaderboard:practice:v2'),
-            env.USERS_KV?.delete('leaderboard:practice:v3')
-        ]);
-
+        await clearPracticeCaches(env);
         await refreshGroupsForUser(db, auth.username);
 
         return jsonResponse({
@@ -442,6 +474,175 @@ export async function handleGetRecords(request, env, db) {
     } catch (e) {
         console.error('获取修行记录失败:', e);
         return jsonResponse({ success: false, error: '获取记录失败' }, 500);
+    }
+}
+
+// 更新修行记录 PUT /api/meditation/records?id=123
+export async function handleUpdateRecord(request, env, db) {
+    const auth = await authenticateUser(request, db);
+    if (auth.error) {
+        return jsonResponse({ success: false, error: auth.error }, auth.status);
+    }
+
+    try {
+        const body = await request.json();
+        const recordId = resolveRecordId(request, body);
+        if (!recordId) {
+            return jsonResponse({ success: false, error: 'recordId required' }, 400);
+        }
+
+        const existing = await db.prepare(`
+      SELECT id, sutra_name, sutra_source, duration, chant_count, record_date,
+             local_time, timezone_offset_minutes, start_time, end_time,
+             is_manual, notes
+      FROM meditation_records
+      WHERE id = ? AND username = ?
+    `).bind(recordId, auth.username).first();
+
+        if (!existing) {
+            return jsonResponse({ success: false, error: '记录不存在' }, 404);
+        }
+
+        const now = new Date().toISOString();
+        const resolvedSutra = (body.sutra ?? existing.sutra_name ?? '').toString().trim();
+        if (!resolvedSutra) {
+            return jsonResponse({ success: false, error: '功课名称不能为空' }, 400);
+        }
+
+        const resolvedSutraSource = (body.sutraSource ?? existing.sutra_source ?? 'custom').toString();
+        const resolvedDuration = Math.max(0, asInt(body.duration, existing.duration || 0));
+        const resolvedChantCount = Math.max(0, asInt(body.chantCount, existing.chant_count || 0));
+        const resolvedRecordDate = (body.recordDate || existing.record_date || formatDate(new Date())).toString();
+        const resolvedLocalTime = parseLocalTime(body.localTime || existing.local_time, new Date());
+        const resolvedTimezoneOffsetMinutes = body.timezoneOffsetMinutes ?? existing.timezone_offset_minutes ?? null;
+        const resolvedStartTime = body.startTime ?? existing.start_time ?? null;
+        const resolvedEndTime = body.endTime ?? existing.end_time ?? null;
+        const resolvedIsManual = body.isManual === undefined
+            ? (existing.is_manual === 1 || existing.is_manual === true)
+            : body.isManual === true;
+        const resolvedNotes = (body.notes ?? existing.notes ?? '').toString();
+        const nextVersion = await getNextSyncVersion(db, auth.username);
+
+        await db.prepare(`
+      UPDATE meditation_records
+      SET sutra_name = ?,
+          sutra_source = ?,
+          duration = ?,
+          chant_count = ?,
+          record_date = ?,
+          local_time = ?,
+          timezone_offset_minutes = ?,
+          start_time = ?,
+          end_time = ?,
+          is_manual = ?,
+          notes = ?,
+          sync_version = ?
+      WHERE id = ? AND username = ?
+    `).bind(
+            resolvedSutra,
+            resolvedSutraSource,
+            resolvedDuration,
+            resolvedChantCount,
+            resolvedRecordDate,
+            resolvedLocalTime,
+            resolvedTimezoneOffsetMinutes,
+            resolvedStartTime,
+            resolvedEndTime,
+            resolvedIsManual ? 1 : 0,
+            resolvedNotes,
+            nextVersion,
+            recordId,
+            auth.username
+        ).run();
+
+        let goalVersion = nextVersion + 1;
+        if (existing.sutra_name === resolvedSutra) {
+            const delta = resolvedChantCount - (existing.chant_count || 0);
+            await updateGoalProgress(db, auth.username, resolvedSutra, delta, goalVersion, now);
+        } else {
+            await updateGoalProgress(db, auth.username, existing.sutra_name, -(existing.chant_count || 0), goalVersion, now);
+            goalVersion += 1;
+            await updateGoalProgress(db, auth.username, resolvedSutra, resolvedChantCount, goalVersion, now);
+        }
+
+        await clearPracticeCaches(env);
+        await refreshGroupsForUser(db, auth.username);
+
+        return jsonResponse({
+            success: true,
+            message: '修行记录已更新',
+            data: {
+                id: recordId,
+                sutra: resolvedSutra,
+                chantCount: resolvedChantCount,
+                duration: resolvedDuration,
+                recordDate: resolvedRecordDate,
+                localTime: resolvedLocalTime,
+                notes: resolvedNotes,
+            },
+        });
+    } catch (e) {
+        console.error('更新修行记录失败:', e);
+        return jsonResponse({ success: false, error: '更新记录失败: ' + e.message }, 500);
+    }
+}
+
+// 删除修行记录 DELETE /api/meditation/records?id=123
+export async function handleDeleteRecord(request, env, db) {
+    const auth = await authenticateUser(request, db);
+    if (auth.error) {
+        return jsonResponse({ success: false, error: auth.error }, auth.status);
+    }
+
+    try {
+        let body = null;
+        if (request.headers.get('Content-Type')?.includes('application/json')) {
+            try {
+                body = await request.json();
+            } catch (_) {
+                body = null;
+            }
+        }
+
+        const recordId = resolveRecordId(request, body);
+        if (!recordId) {
+            return jsonResponse({ success: false, error: 'recordId required' }, 400);
+        }
+
+        const existing = await db.prepare(`
+      SELECT id, sutra_name, chant_count
+      FROM meditation_records
+      WHERE id = ? AND username = ?
+    `).bind(recordId, auth.username).first();
+
+        if (!existing) {
+            return jsonResponse({ success: false, error: '记录不存在' }, 404);
+        }
+
+        const now = new Date().toISOString();
+        const nextVersion = await getNextSyncVersion(db, auth.username);
+
+        await db.prepare(`
+      DELETE FROM meditation_records
+      WHERE id = ? AND username = ?
+    `).bind(recordId, auth.username).run();
+
+        await updateGoalProgress(
+            db,
+            auth.username,
+            existing.sutra_name,
+            -(existing.chant_count || 0),
+            nextVersion + 1,
+            now,
+        );
+
+        await clearPracticeCaches(env);
+        await refreshGroupsForUser(db, auth.username);
+
+        return jsonResponse({ success: true, message: '修行记录已删除' });
+    } catch (e) {
+        console.error('删除修行记录失败:', e);
+        return jsonResponse({ success: false, error: '删除记录失败: ' + e.message }, 500);
     }
 }
 

--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -16,7 +16,7 @@ import { handleToggleLike, handleGetLikeCount, handleBatchGetLikeCounts, handleG
 import { handleToggleFavorite, handleGetMyFavorites, handleBatchCheckFavorites } from './handlers/favorites.js';
 import { handleBatchGetContentStats } from './handlers/content-stats.js';
 import { handleOnlineJoin, handleOnlineHeartbeat, handleOnlineLeave, handleOnlineCount } from './handlers/online.js';
-import { handleSyncRecord, handleGetRecords, handleGetStats, handleGetWeeklyStats, handleGetMonthlyStats, handleSetGoal, handleGetGoals, handleMeditationSettings, handleGetMeditationGroups, handleCreateMeditationGroup, handleJoinMeditationGroup, handleGetMeditationGroupDetail, handleReviewMeditationGroupJoin } from './handlers/meditation.js';
+import { handleSyncRecord, handleGetRecords, handleUpdateRecord, handleDeleteRecord, handleGetStats, handleGetWeeklyStats, handleGetMonthlyStats, handleSetGoal, handleGetGoals, handleMeditationSettings, handleGetMeditationGroups, handleCreateMeditationGroup, handleJoinMeditationGroup, handleGetMeditationGroupDetail, handleReviewMeditationGroupJoin } from './handlers/meditation.js';
 import { handleGetSyncData, handlePushSyncData, handleGetSyncState } from './handlers/sync.js';
 import { handleToggleFollow, handleGetFollowList, handleGetFollowSummary, handleGetPracticePrivacy, handleUpdatePracticePrivacy } from './handlers/social.js';
 import { handleBuiltinMigration, handleFullTextSearch, handleGetCategories as handleBuiltinCategories } from '../migrate-builtin-handler-fixed.js';
@@ -148,6 +148,8 @@ export async function route(request, env, db, ctx) {
   // 修行记录API
   if (pathname === '/api/meditation/record' && method === 'POST') return await handleSyncRecord(request, env, db);
   if (pathname === '/api/meditation/records' && method === 'GET') return await handleGetRecords(request, env, db);
+  if (pathname === '/api/meditation/records' && method === 'PUT') return await handleUpdateRecord(request, env, db);
+  if (pathname === '/api/meditation/records' && method === 'DELETE') return await handleDeleteRecord(request, env, db);
   if (pathname === '/api/meditation/stats' && method === 'GET') return await handleGetStats(request, env, db);
   if (pathname === '/api/meditation/weekly' && method === 'GET') return await handleGetWeeklyStats(request, env, db);
   if (pathname === '/api/meditation/monthly' && method === 'GET') return await handleGetMonthlyStats(request, env, db);

--- a/fabushi/web/tests/meditation-records.test.js
+++ b/fabushi/web/tests/meditation-records.test.js
@@ -1,0 +1,264 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  handleUpdateRecord,
+  handleDeleteRecord,
+} from '../src/handlers/meditation.js';
+
+function authHeader(username) {
+  const payload = Buffer.from(JSON.stringify({ username })).toString('base64url');
+  return `Bearer header.${payload}.signature`;
+}
+
+function createDbMock() {
+  const records = new Map();
+  const goals = new Map();
+
+  const db = {
+    prepare(sql) {
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+
+      return {
+        bind(...params) {
+          return {
+            async first() {
+              if (normalizedSql.startsWith('SELECT COALESCE(MAX(sync_version), 0) + 1 as next_version FROM (')) {
+                const username = params[0];
+                const recordVersions = Array.from(records.values())
+                    .filter((record) => record.username === username)
+                    .map((record) => record.sync_version || 0);
+                const goalVersions = Array.from(goals.values())
+                    .filter((goal) => goal.username === username)
+                    .map((goal) => goal.sync_version || 0);
+                const maxVersion = Math.max(0, ...recordVersions, ...goalVersions);
+                return { next_version: maxVersion + 1 };
+              }
+
+              if (normalizedSql.startsWith('SELECT id, sutra_name, sutra_source, duration, chant_count, record_date,')) {
+                const record = records.get(params[0]);
+                if (!record || record.username !== params[1]) return null;
+                return { ...record };
+              }
+
+              if (normalizedSql.startsWith('SELECT id, sutra_name, chant_count FROM meditation_records WHERE id = ? AND username = ?')) {
+                const record = records.get(params[0]);
+                if (!record || record.username !== params[1]) return null;
+                return {
+                  id: record.id,
+                  sutra_name: record.sutra_name,
+                  chant_count: record.chant_count,
+                };
+              }
+
+              return null;
+            },
+            async all() {
+              if (normalizedSql.startsWith('SELECT id FROM meditation_groups WHERE owner_username = ?')) {
+                return { results: [] };
+              }
+
+              if (normalizedSql.startsWith('SELECT m.group_id FROM meditation_group_members m JOIN meditation_groups g ON g.id = m.group_id WHERE m.username = ? AND m.status = \'active\'')) {
+                return { results: [] };
+              }
+
+              return { results: [] };
+            },
+            async run() {
+              if (normalizedSql.startsWith('UPDATE meditation_records SET sutra_name = ?,')) {
+                const [
+                  sutraName,
+                  sutraSource,
+                  duration,
+                  chantCount,
+                  recordDate,
+                  localTime,
+                  timezoneOffsetMinutes,
+                  startTime,
+                  endTime,
+                  isManual,
+                  notes,
+                  syncVersion,
+                  recordId,
+                  username,
+                ] = params;
+                const record = records.get(recordId);
+                if (!record || record.username !== username) return;
+                Object.assign(record, {
+                  sutra_name: sutraName,
+                  sutra_source: sutraSource,
+                  duration,
+                  chant_count: chantCount,
+                  record_date: recordDate,
+                  local_time: localTime,
+                  timezone_offset_minutes: timezoneOffsetMinutes,
+                  start_time: startTime,
+                  end_time: endTime,
+                  is_manual: isManual,
+                  notes,
+                  sync_version: syncVersion,
+                });
+                return;
+              }
+
+              if (normalizedSql.startsWith('UPDATE meditation_goals SET current_count = CASE')) {
+                const [delta, , updatedAt, syncVersion, username, sutraName] = params;
+                const key = `${username}:${sutraName}`;
+                const goal = goals.get(key);
+                if (!goal || goal.status !== 'active') return;
+                goal.current_count = Math.max(0, goal.current_count + delta);
+                goal.updated_at = updatedAt;
+                goal.sync_version = syncVersion;
+                return;
+              }
+
+              if (normalizedSql.startsWith('DELETE FROM meditation_records WHERE id = ? AND username = ?')) {
+                const [recordId, username] = params;
+                const record = records.get(recordId);
+                if (record && record.username === username) {
+                  records.delete(recordId);
+                }
+              }
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { db, records, goals };
+}
+
+function createEnv() {
+  const deletedKeys = [];
+  return {
+    deletedKeys,
+    USERS_KV: {
+      async delete(key) {
+        deletedKeys.push(key);
+      },
+    },
+  };
+}
+
+test('updating a record with a new sutra moves goal progress and clears caches', async () => {
+  const { db, records, goals } = createDbMock();
+  const env = createEnv();
+
+  records.set(7, {
+    id: 7,
+    username: 'bhrum108',
+    sutra_name: '心经',
+    sutra_source: 'custom',
+    duration: 30,
+    chant_count: 2,
+    record_date: '2026-05-06',
+    local_time: '08:00',
+    timezone_offset_minutes: 480,
+    start_time: null,
+    end_time: null,
+    is_manual: 1,
+    notes: '旧心得',
+    sync_version: 3,
+  });
+  goals.set('bhrum108:心经', {
+    username: 'bhrum108',
+    sutra_name: '心经',
+    current_count: 10,
+    status: 'active',
+    sync_version: 2,
+  });
+  goals.set('bhrum108:金刚经', {
+    username: 'bhrum108',
+    sutra_name: '金刚经',
+    current_count: 4,
+    status: 'active',
+    sync_version: 2,
+  });
+
+  const response = await handleUpdateRecord(
+    new Request('https://flutter.ombhrum.com/api/meditation/records?id=7', {
+      method: 'PUT',
+      headers: {
+        Authorization: authHeader('bhrum108'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        sutra: '金刚经',
+        sutraSource: 'custom',
+        chantCount: 5,
+        duration: 45,
+        recordDate: '2026-05-06',
+        localTime: '09:30',
+        notes: '补充后的心得',
+        isManual: true,
+      }),
+    }),
+    env,
+    db,
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(records.get(7)?.sutra_name, '金刚经');
+  assert.equal(records.get(7)?.chant_count, 5);
+  assert.equal(records.get(7)?.duration, 45);
+  assert.equal(records.get(7)?.notes, '补充后的心得');
+  assert.equal(goals.get('bhrum108:心经')?.current_count, 8);
+  assert.equal(goals.get('bhrum108:金刚经')?.current_count, 9);
+  assert.deepEqual(env.deletedKeys.sort(), [
+    'leaderboard:cache',
+    'leaderboard:cache:v2',
+    'leaderboard:practice:v2',
+    'leaderboard:practice:v3',
+    'leaderboard:practice:v4',
+  ]);
+});
+
+test('deleting a record removes it and rolls back goal progress', async () => {
+  const { db, records, goals } = createDbMock();
+  const env = createEnv();
+
+  records.set(9, {
+    id: 9,
+    username: 'bhrum108',
+    sutra_name: '药师经',
+    sutra_source: 'custom',
+    duration: 20,
+    chant_count: 3,
+    record_date: '2026-05-05',
+    local_time: '21:00',
+    timezone_offset_minutes: 480,
+    start_time: null,
+    end_time: null,
+    is_manual: 1,
+    notes: '',
+    sync_version: 6,
+  });
+  goals.set('bhrum108:药师经', {
+    username: 'bhrum108',
+    sutra_name: '药师经',
+    current_count: 3,
+    status: 'active',
+    sync_version: 5,
+  });
+
+  const response = await handleDeleteRecord(
+    new Request('https://flutter.ombhrum.com/api/meditation/records?id=9', {
+      method: 'DELETE',
+      headers: {
+        Authorization: authHeader('bhrum108'),
+      },
+    }),
+    env,
+    db,
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(records.has(9), false);
+  assert.equal(goals.get('bhrum108:药师经')?.current_count, 0);
+  assert.equal(env.deletedKeys.includes('leaderboard:practice:v4'), true);
+});


### PR DESCRIPTION
## 概要
- 给修行记录补上编辑和删除能力，用户现在可以直接修改既有功课名称、遍数、时长、时间和心得，也可以删除误记记录
- 后端在更新/删除记录时同步修正发愿目标进度、刷新排行榜缓存，并重新评估共修小组的修行统计，避免只改表面数据
- 复用现有补录弹窗作为编辑弹窗，把最近记录详情里的编辑/删除入口直接接出来，减少交互分叉
- 补一条 Worker 回归测试，锁住“改记录/删记录会同步修正目标进度与缓存”这条根因链

## 根因
issue #152 暴露的不是单一页面按钮缺失，而是整条记录维护链路只做了“新增 + 查询”，没有“更新 + 删除”：
1. Worker 只有 `POST /api/meditation/record` 和 `GET /api/meditation/records`
2. Flutter 记录页也只有补录入口，没有修改/删除入口
3. 因此用户回看旧记录时，即使只是想补写心得或修正时长，也只能重新新增一条，不能维护原记录

如果只临时加一个前端按钮而不处理后端统计联动，发愿目标进度、排行榜缓存和共修统计又会继续残留脏数据，所以这次把整条链一起补齐。

## 这次怎么修
1. `fabushi/web/src/handlers/meditation.js`
   - 新增修行记录更新/删除处理器
   - 记录变化时同步修正 `meditation_goals.current_count`
   - 统一清理修行相关排行榜缓存，并重新评估共修成员状态
2. `fabushi/web/src/router.js`
   - 为 `/api/meditation/records` 接上 `PUT` / `DELETE`
3. `fabushi/lib/services/practice_stats_service.dart`
   - 新增 `updateRecord(...)` / `deleteRecord(...)`
   - 继续复用记录变更后的整页刷新逻辑
4. `fabushi/lib/widgets/practice_dialogs.dart`
   - 复用现有补录弹窗作为编辑弹窗，支持预填原记录
5. `fabushi/lib/screens/practice_record_screen.dart`
   - 在修行详情底部新增编辑/删除操作
6. `fabushi/web/tests/meditation-records.test.js`
   - 覆盖改记录迁移目标进度、删记录回收目标进度和缓存清理

## 验证
- 新增 Worker 回归测试覆盖：
  - 改记录时旧目标扣回、新目标补进
  - 删记录时目标进度回收为正确值
  - 修行相关排行榜缓存会被清理
- 当前环境无法直接跑仓库 CI，后续继续以该 PR 的 GitHub Actions 为准推进

Fixes #152