### PR TITLE
fix: auto-report profile update failures and guard username rename flow

### DIFF
--- a/fabushi/e2e/tests/staging-profile-api.spec.js
+++ b/fabushi/e2e/tests/staging-profile-api.spec.js
@@ -25,7 +25,7 @@ function safeProjectName(testInfo) {
 test.describe('staging profile API flow', () => {
   test.describe.configure({ mode: 'serial' });
 
-  test('logs in with username, email, and phone, then updates profile fields without changing stable values', async ({ request }, testInfo) => {
+  test('logs in with username, email, and phone, then updates profile fields and exercises username rename rollback', async ({ request }, testInfo) => {
     for (const name of requiredEnv) env(name);
 
     const login = env('STAGING_TEST_LOGIN');
@@ -41,7 +41,6 @@ test.describe('staging profile API flow', () => {
       expect(response.status(), `login failed for ${identifier}: ${await response.text()}`).toBe(200);
       const body = await response.json();
       expect(body.token).toBeTruthy();
-      expect(body.username).toBe(login);
       expect(body.user, 'login response must include user after staging deployment').toBeTruthy();
       return { token: body.token, user: body.user };
     }
@@ -109,5 +108,69 @@ test.describe('staging profile API flow', () => {
     expect(after.email).toBe(email);
     expect(after.phoneNumber).toBe(phone);
     expect(after.avatar).toContain(marker);
+
+    const renameSuffix = projectMarker.slice(-10);
+    const trimmedLogin = login.slice(0, Math.max(2, 31 - renameSuffix.length));
+    const renamedUsername = `${trimmedLogin}-${renameSuffix}`;
+
+    const renameResponse = await request.post(apiUrl('/api/auth/update-profile'), {
+      headers: { Authorization: `Bearer ${tokenAfterUpdate}` },
+      data: {
+        username: renamedUsername,
+        email,
+        phoneNumber: phone,
+        avatar: `https://example.com/fabushi-e2e-avatar-rename-${projectMarker}.png`
+      }
+    });
+    expect(renameResponse.status(), await renameResponse.text()).toBe(200);
+    const renamed = await renameResponse.json();
+    expect(renamed.success).toBe(true);
+    expect(renamed.user?.username).toBe(renamedUsername);
+    expect(renamed.token, 'username change should rotate a fresh token').toBeTruthy();
+
+    const renamedToken = renamed.token;
+    const renamedInfo = await request.get(apiUrl('/api/auth/user-info'), {
+      headers: { Authorization: `Bearer ${renamedToken}` }
+    });
+    expect(renamedInfo.status(), await renamedInfo.text()).toBe(200);
+    const renamedPayload = await renamedInfo.json();
+    expect(renamedPayload.username).toBe(renamedUsername);
+    expect(renamedPayload.email).toBe(email);
+    expect(renamedPayload.phoneNumber).toBe(phone);
+
+    const renamedLogin = await passwordLogin(renamedUsername);
+    expect(renamedLogin.user?.username).toBe(renamedUsername);
+    await passwordLogin(email);
+    await passwordLogin(phone);
+
+    const rollbackResponse = await request.post(apiUrl('/api/auth/update-profile'), {
+      headers: { Authorization: `Bearer ${renamedToken}` },
+      data: {
+        username: login,
+        email,
+        phoneNumber: phone,
+        avatar: `https://example.com/fabushi-e2e-avatar-rollback-${projectMarker}.png`
+      }
+    });
+    expect(rollbackResponse.status(), await rollbackResponse.text()).toBe(200);
+    const rolledBack = await rollbackResponse.json();
+    expect(rolledBack.success).toBe(true);
+    expect(rolledBack.user?.username).toBe(login);
+    expect(rolledBack.token, 'rolling back username should also issue a fresh token').toBeTruthy();
+
+    const rollbackToken = rolledBack.token;
+    const rollbackInfo = await request.get(apiUrl('/api/auth/user-info'), {
+      headers: { Authorization: `Bearer ${rollbackToken}` }
+    });
+    expect(rollbackInfo.status(), await rollbackInfo.text()).toBe(200);
+    const rollbackPayload = await rollbackInfo.json();
+    expect(rollbackPayload.username).toBe(login);
+    expect(rollbackPayload.email).toBe(email);
+    expect(rollbackPayload.phoneNumber).toBe(phone);
+
+    const finalUsernameLogin = await passwordLogin(login);
+    expect(finalUsernameLogin.user?.username).toBe(login);
+    await passwordLogin(email);
+    await passwordLogin(phone);
   });
 });

--- a/fabushi/lib/screens/edit_profile_screen.dart
+++ b/fabushi/lib/screens/edit_profile_screen.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import '../core/config/app_config.dart';
 import '../core/design_system/app_theme.dart';
 import '../models/auth_model.dart';
+import '../services/error_report_service.dart';
 import '../services/http_service.dart';
 import '../services/meditation_session_manager.dart';
 
@@ -207,6 +208,88 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     return 'image/jpeg';
   }
 
+  String _maskEmail(String value) {
+    if (value.isEmpty || !value.contains('@')) return value;
+    final parts = value.split('@');
+    final local = parts.first;
+    final domain = parts.sublist(1).join('@');
+    if (local.length <= 2) return '${local[0]}*@${domain}';
+    return '${local.substring(0, 2)}***@${domain}';
+  }
+
+  String _maskPhone(String value) {
+    if (value.length < 7) return value;
+    return '${value.substring(0, 3)}****${value.substring(value.length - 4)}';
+  }
+
+  String _trimPreview(String value, {int maxLength = 600}) {
+    final normalized = value.trim();
+    if (normalized.length <= maxLength) return normalized;
+    return '${normalized.substring(0, maxLength)}...';
+  }
+
+  Map<String, dynamic> _buildProfileFailureDiagnostics({
+    int? statusCode,
+    String? serverError,
+    String? responseBodyPreview,
+  }) {
+    final currentUser = context.read<AuthModel>().currentUser;
+    return {
+      'attemptedUsername': _usernameController.text.trim(),
+      'attemptedEmail': _maskEmail(_emailController.text.trim()),
+      'attemptedPhone': _maskPhone(_phoneController.text.trim()),
+      'changedUsername': currentUser?.username != _usernameController.text.trim(),
+      'changedEmail': currentUser?.email != _emailController.text.trim(),
+      'changedPhone': currentUser?.phoneNumber != _phoneController.text.trim(),
+      'hasPendingAvatarUpload': _pendingAvatarBase64 != null,
+      'hasPasswordSetupAttempt': !_hasPassword && _passwordController.text.isNotEmpty,
+      if (statusCode != null) 'statusCode': statusCode,
+      if (serverError != null && serverError.isNotEmpty) 'serverError': serverError,
+      if (responseBodyPreview != null && responseBodyPreview.isNotEmpty)
+        'responseBodyPreview': _trimPreview(responseBodyPreview),
+    };
+  }
+
+  Future<String?> _autoReportProfileFailure({
+    required String source,
+    Object? error,
+    StackTrace? stackTrace,
+    int? statusCode,
+    String? serverError,
+    String? responseBodyPreview,
+  }) async {
+    try {
+      await ErrorReportService.instance.recordError(
+        error ?? serverError ?? '个人资料更新失败',
+        stackTrace: stackTrace,
+        stage: 'profile_update',
+        source: source,
+        fatal: false,
+        extra: _buildProfileFailureDiagnostics(
+          statusCode: statusCode,
+          serverError: serverError,
+          responseBodyPreview: responseBodyPreview,
+        ),
+      );
+
+      final result = await ErrorReportService.instance.submitLastReport(
+        title: '编辑资料失败自动报告',
+        userDescription: '用户在编辑资料页保存资料时失败，客户端已自动补充请求上下文与服务端返回。',
+        contact: '',
+        authToken: context.read<AuthModel>().authToken,
+        page: 'edit_profile_screen',
+        category: 'profile_update_failure',
+      );
+
+      if (result['success'] == true && result['issueNumber'] != null) {
+        return '#${result['issueNumber']}';
+      }
+    } catch (_) {
+      // 自动上报失败时不再打断用户原始错误提示。
+    }
+    return null;
+  }
+
   Future<void> _saveProfile() async {
     if (!_formKey.currentState!.validate()) return;
 
@@ -269,16 +352,34 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           Navigator.pop(context);
         }
       } else {
+        final serverError = (data['error'] ?? '更新失败').toString();
+        final reportRef = await _autoReportProfileFailure(
+          source: 'EditProfileScreen._saveProfile.response',
+          statusCode: response.statusCode,
+          serverError: serverError,
+          responseBodyPreview: response.body,
+        );
+        final message = reportRef == null
+            ? serverError
+            : '$serverError，已自动提交诊断 $reportRef';
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text(data['error'] ?? '更新失败')));
+        ).showSnackBar(SnackBar(content: Text(message)));
       }
-    } catch (e) {
+    } catch (e, stackTrace) {
       if (!mounted) return;
       setState(() => _isLoading = false);
+      final reportRef = await _autoReportProfileFailure(
+        source: 'EditProfileScreen._saveProfile.exception',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      final message = reportRef == null
+          ? '更新失败: $e'
+          : '更新失败: $e，已自动提交诊断 $reportRef';
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('更新失败: $e')));
+      ).showSnackBar(SnackBar(content: Text(message)));
     }
   }
 

--- a/fabushi/lib/services/error_report_service.dart
+++ b/fabushi/lib/services/error_report_service.dart
@@ -61,9 +61,12 @@ class AppErrorReport {
     };
   }
 
-  String buildFeedbackDescription(String userDescription) {
+  String buildFeedbackDescription(
+    String userDescription, {
+    String intro = '应用在运行过程中出现异常，以下信息由客户端自动采集。',
+  }) {
     final lines = <String>[
-      '应用在启动过程中出现异常，以下信息由客户端自动采集。',
+      intro,
       '',
       if (userDescription.trim().isNotEmpty) ...[
         '### 用户补充说明',
@@ -197,6 +200,10 @@ class ErrorReportService {
     required String userDescription,
     required String contact,
     String? authToken,
+    String page = 'startup_failure_dialog',
+    String category = 'startup_crash',
+    bool autoCollected = true,
+    String descriptionIntro = '应用在运行过程中出现异常，以下信息由客户端自动采集。',
   }) async {
     final report = _lastReport;
     if (report == null) {
@@ -210,13 +217,16 @@ class ErrorReportService {
       WorkerConfig.getEndpoint('submitFeedback'),
       body: {
         'title': title.trim().isEmpty ? report.suggestedTitle : title.trim(),
-        'description': report.buildFeedbackDescription(userDescription),
+        'description': report.buildFeedbackDescription(
+          userDescription,
+          intro: descriptionIntro,
+        ),
         if (contact.trim().isNotEmpty) 'contact': contact.trim(),
-        'page': 'startup_failure_dialog',
+        'page': page,
         'platform': report.platform,
         'appVersion': report.appVersion,
-        'category': 'startup_crash',
-        'autoCollected': true,
+        'category': category,
+        'autoCollected': autoCollected,
         'diagnostics': report.toDiagnosticsPayload(),
       },
       token: authToken,


### PR DESCRIPTION
## 概要
- 编辑资料页保存失败时，客户端会自动采集设备、字段变更、后端返回等诊断信息，并直接通过现有反馈通道创建 issue
- 把现有错误上报服务从“仅启动异常”扩成通用错误上报，可复用于资料更新这类非启动期失败
- staging 资料流 E2E 新增真实的“改用户名 -> 校验新用户名登录/查询 -> 改回原用户名”回归门禁，避免 issue #144 这类问题再次只靠人工截图暴露

## 根因
issue #144 暴露出两层缺口同时存在：
1. 用户改用户名失败时，当前页面只会给一个本地提示，缺少自动把设备、请求上下文和服务端错误带回仓库的问题通道
2. 现有 staging 资料流只覆盖“不改用户名的资料更新”，没有把用户名迁移这条最脆弱的链路纳入回归验证

## 这次怎么修
1. `fabushi/lib/services/error_report_service.dart`
   - 让错误报告提交支持自定义 `page` / `category` / 描述前言
   - 保留原有启动异常能力，同时开放给其他业务错误复用
2. `fabushi/lib/screens/edit_profile_screen.dart`
   - 在资料保存失败时自动记录错误
   - 自动附带用户名/邮箱/手机号变更状态、头像上传状态、HTTP 状态码和服务端返回摘要
   - 自动提交反馈 issue，并把 issue 编号回显给用户
3. `fabushi/e2e/tests/staging-profile-api.spec.js`
   - 补上 staging 用户名改名与改回链路
   - 校验改名后 token 轮换、`user-info` 可读、新用户名可登录、邮箱/手机号登录不受影响

## 验证
- 这次运行环境无法直接拉起仓库本地测试，所以验证主要通过新增的 staging Playwright 门禁来承接
- PR 合并前继续以 GitHub Actions / staging E2E 结果为准

Fixes #144