### PR TITLE
fix: prefer native D1 transactions for profile updates

### DIFF
--- a/fabushi/web/src/handlers/profile.js
+++ b/fabushi/web/src/handlers/profile.js
@@ -256,7 +256,23 @@ function getFinalProfileState(user, {
   };
 }
 
+function getNativeTransactionRunner(db) {
+  const storage = db?.state?.storage;
+  if (storage && typeof storage.transaction === 'function') {
+    return (action) => storage.transaction(action);
+  }
+  if (db && typeof db.transaction === 'function') {
+    return (action) => db.transaction(action);
+  }
+  return null;
+}
+
 async function runInTransaction(db, action) {
+  const nativeTransaction = getNativeTransactionRunner(db);
+  if (nativeTransaction) {
+    return nativeTransaction(action);
+  }
+
   await db.prepare('BEGIN TRANSACTION').run();
   try {
     const result = await action();

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -4,7 +4,8 @@ import assert from 'node:assert/strict';
 import { generateToken } from '../auth-utils.js';
 import { handleUpdateProfile } from '../src/handlers/profile.js';
 
-function createDbMock() {
+function createDbMock(options = {}) {
+  const { nativeTransaction = false } = options;
   const users = new Map();
   const emailMapping = new Map();
   const statements = [];
@@ -94,6 +95,17 @@ function createDbMock() {
       };
     }
   };
+
+  if (nativeTransaction) {
+    db.state = {
+      storage: {
+        async transaction(action) {
+          statements.push({ sql: '__native_transaction__', params: [] });
+          return action();
+        }
+      }
+    };
+  }
 
   return db;
 }
@@ -189,4 +201,77 @@ test('handleUpdateProfile migrates username changes without direct in-place user
       `missing migration statement: ${expectedSql}`
     );
   }
+});
+
+test('handleUpdateProfile prefers native storage transactions when available', async () => {
+  const db = createDbMock({ nativeTransaction: true });
+  db.users.set('nativeold', {
+    username: 'nativeold',
+    email: 'native@example.com',
+    password_hash: '',
+    salt: '',
+    iterations: 0,
+    algo: '',
+    email_verified: 1,
+    alipay_user_id: null,
+    alipay_nickname: null,
+    alipay_avatar: null,
+    alipay_bound_at: null,
+    wechat_openid: null,
+    wechat_nickname: null,
+    wechat_headimgurl: null,
+    wechat_bound_at: null,
+    phone_number: '+8613800138111',
+    firebase_uid: 'firebase-native-uid',
+    apple_user_id: null,
+    nickname: 'nativeold',
+    avatar: null,
+    bio: null,
+    main_practice_title: null,
+    main_practice_file_path: null,
+    main_practice_selected_at: null,
+    membership_type: 'trial',
+    membership_expires_at: null,
+    free_trial_end_date: '2026-05-31T00:00:00Z',
+    stripe_customer_id: null,
+    subscription_id: null,
+    total_transferred_bytes: 0,
+    last_transfer_at: null,
+    sync_version: 1,
+    extra_data: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-04T00:00:00Z'
+  });
+  db.emailMapping.set('native@example.com', 'nativeold');
+
+  const env = { JWT_SECRET: 'test-secret' };
+  const token = await generateToken('nativeold', env);
+  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      username: 'nativenew',
+      email: 'native@example.com',
+      phoneNumber: '+8613800138111'
+    })
+  });
+
+  const response = await handleUpdateProfile(request, env, db);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.user.username, 'nativenew');
+  assert.ok(payload.token);
+  assert.equal(db.users.has('nativeold'), false);
+  assert.equal(db.users.has('nativenew'), true);
+  assert.equal(db.emailMapping.get('native@example.com'), 'nativenew');
+  assert.ok(db.statements.some(({ sql }) => sql === '__native_transaction__'));
+  assert.equal(
+    db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
+    false
+  );
 });


### PR DESCRIPTION
## 为什么改

`issue #158` 和 `#159` 暴露出一个已经在线上触发的根因：资料更新里的用户名迁移仍然手写了 `BEGIN TRANSACTION / COMMIT / ROLLBACK`。Cloudflare 当前这条 D1 / Durable Object 路径已经不允许这样做，于是用户只要改用户名，就会直接在事务入口收到 `D1_ERROR`，前面的引用迁移逻辑根本来不及执行。

## 这次改了什么

- `fabushi/web/src/handlers/profile.js`
  - 给资料更新事务新增原生事务优先策略
  - 如果运行时提供 `state.storage.transaction(...)`，优先走 Cloudflare 支持的原生事务接口
  - 只有在没有原生事务能力的旧环境 / 测试桩里，才回退到现有的 SQL `BEGIN / COMMIT / ROLLBACK`
- `fabushi/web/tests/profile.test.js`
  - 补一条原生事务路径回归测试
  - 明确要求：当原生事务可用时，不再落回手写 SQL 事务语句
  - 保留现有用户名迁移覆盖，继续守住引用迁移完整性

## 根因结论

这次不是前端参数问题，也不是用户名引用表又漏迁了一张，而是资料更新链路在进入迁移逻辑前就被不再允许的手写事务语句拦住了。

## 验证

- 代码级验证：资料更新事务现在会优先探测并使用原生事务接口
- 测试级验证：新增回归测试覆盖“原生事务存在时不再执行 `BEGIN / COMMIT / ROLLBACK`”
- 当前环境没有仓库本地 checkout 和 GitHub Actions 运行能力，所以这轮仍以 PR checks 为最终准绳

Fixes #158
Fixes #159