### PR TITLE
feat: standardize co-practice public group codes

### DIFF
--- a/fabushi/lib/models/co_practice_group_model.dart
+++ b/fabushi/lib/models/co_practice_group_model.dart
@@ -9,6 +9,8 @@ bool _asBool(dynamic value) => value == true || value == 1 || value == '1';
 
 String _asString(dynamic value) => value?.toString() ?? '';
 
+String _formatGroupCode(int id) => id.toString().padLeft(6, '0');
+
 class CoPracticeGroup {
   final int id;
   final String name;
@@ -47,6 +49,8 @@ class CoPracticeGroup {
     this.myWarningMessage,
     this.createdAt,
   });
+
+  String get publicCode => _formatGroupCode(id);
 
   factory CoPracticeGroup.fromJson(Map<String, dynamic> json) {
     return CoPracticeGroup(

--- a/fabushi/lib/widgets/co_practice_group_panel.dart
+++ b/fabushi/lib/widgets/co_practice_group_panel.dart
@@ -92,7 +92,7 @@ class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
               ),
               SizedBox(height: 6),
               Text(
-                '先搜索小组名、组主或群号，点开后即可申请加入；创建者点开自己的小组，就能在详情页里看到待审批成员。',
+                '先搜索小组名、组主或标准群号，点开后即可申请加入；创建者点开自己的小组，就能在详情页里看到待审批成员。',
                 style: TextStyle(
                   color: Colors.white70,
                   fontSize: 12,
@@ -111,7 +111,7 @@ class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
                 onChanged: _onSearchChanged,
                 style: const TextStyle(color: Colors.white),
                 decoration: InputDecoration(
-                  hintText: '搜索小组名、组主或群号 #123',
+                  hintText: '搜索小组名、组主或群号 #000123',
                   hintStyle: const TextStyle(color: Colors.white38),
                   prefixIcon: const Icon(Icons.search, color: Colors.white54),
                   suffixIcon: _searchController.text.isEmpty
@@ -251,7 +251,10 @@ class _CoPracticeGroupTile extends StatelessWidget {
                     '组主 ${group.ownerName}',
                     style: const TextStyle(color: Colors.white54, fontSize: 12),
                   ),
-                  _InfoPill(icon: Icons.tag_outlined, text: '群号 #${group.id}'),
+                  _InfoPill(
+                    icon: Icons.tag_outlined,
+                    text: '群号 #${group.publicCode}',
+                  ),
                 ],
               ),
               const SizedBox(height: 10),
@@ -530,7 +533,7 @@ class _CoPracticeGroupDetailSheetState
                       ),
                       _InfoPill(
                         icon: Icons.tag_outlined,
-                        text: '群号 #${group.id}',
+                        text: '群号 #${group.publicCode}',
                       ),
                       _InfoPill(
                         icon: Icons.timer_outlined,

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -110,7 +110,7 @@ function createDbMock(options = {}) {
   return db;
 }
 
-test('handleUpdateProfile migrates username changes without direct in-place username update', async () => {
+test('handleUpdateProfile migrates username changes without direct in-place username update', { concurrency: false }, async () => {
   const db = createDbMock();
   db.users.set('oldname', {
     username: 'oldname',
@@ -203,7 +203,7 @@ test('handleUpdateProfile migrates username changes without direct in-place user
   }
 });
 
-test('handleUpdateProfile prefers native storage transactions when available', async () => {
+test('handleUpdateProfile prefers native storage transactions when available', { concurrency: false }, async () => {
   const db = createDbMock({ nativeTransaction: true });
   db.users.set('nativeold', {
     username: 'nativeold',

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -110,168 +110,170 @@ function createDbMock(options = {}) {
   return db;
 }
 
-test('handleUpdateProfile migrates username changes without direct in-place username update', { concurrency: false }, async () => {
-  const db = createDbMock();
-  db.users.set('oldname', {
-    username: 'oldname',
-    email: 'old@example.com',
-    password_hash: '',
-    salt: '',
-    iterations: 0,
-    algo: '',
-    email_verified: 1,
-    alipay_user_id: null,
-    alipay_nickname: null,
-    alipay_avatar: null,
-    alipay_bound_at: null,
-    wechat_openid: null,
-    wechat_nickname: null,
-    wechat_headimgurl: null,
-    wechat_bound_at: null,
-    phone_number: '+8613800138000',
-    firebase_uid: 'firebase-uid-1',
-    apple_user_id: null,
-    nickname: 'oldname',
-    avatar: 'https://example.com/avatar.png',
-    bio: null,
-    main_practice_title: '心经',
-    main_practice_file_path: '/sutras/xinjing.md',
-    main_practice_selected_at: '2026-05-01T00:00:00Z',
-    membership_type: 'trial',
-    membership_expires_at: null,
-    free_trial_end_date: '2026-05-31T00:00:00Z',
-    stripe_customer_id: null,
-    subscription_id: null,
-    total_transferred_bytes: 123,
-    last_transfer_at: '2026-05-04T00:00:00Z',
-    sync_version: 7,
-    extra_data: null,
-    created_at: '2026-05-01T00:00:00Z',
-    updated_at: '2026-05-04T00:00:00Z'
-  });
-  db.emailMapping.set('old@example.com', 'oldname');
-
-  const env = { JWT_SECRET: 'test-secret' };
-  const token = await generateToken('oldname', env);
-  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`
-    },
-    body: JSON.stringify({
-      username: 'newname',
+test.describe('handleUpdateProfile transaction regressions', { concurrency: false }, () => {
+  test('handleUpdateProfile migrates username changes without direct in-place username update', async () => {
+    const db = createDbMock();
+    db.users.set('oldname', {
+      username: 'oldname',
       email: 'old@example.com',
-      phoneNumber: '+8613800138000'
-    })
-  });
+      password_hash: '',
+      salt: '',
+      iterations: 0,
+      algo: '',
+      email_verified: 1,
+      alipay_user_id: null,
+      alipay_nickname: null,
+      alipay_avatar: null,
+      alipay_bound_at: null,
+      wechat_openid: null,
+      wechat_nickname: null,
+      wechat_headimgurl: null,
+      wechat_bound_at: null,
+      phone_number: '+8613800138000',
+      firebase_uid: 'firebase-uid-1',
+      apple_user_id: null,
+      nickname: 'oldname',
+      avatar: 'https://example.com/avatar.png',
+      bio: null,
+      main_practice_title: '心经',
+      main_practice_file_path: '/sutras/xinjing.md',
+      main_practice_selected_at: '2026-05-01T00:00:00Z',
+      membership_type: 'trial',
+      membership_expires_at: null,
+      free_trial_end_date: '2026-05-31T00:00:00Z',
+      stripe_customer_id: null,
+      subscription_id: null,
+      total_transferred_bytes: 123,
+      last_transfer_at: '2026-05-04T00:00:00Z',
+      sync_version: 7,
+      extra_data: null,
+      created_at: '2026-05-01T00:00:00Z',
+      updated_at: '2026-05-04T00:00:00Z'
+    });
+    db.emailMapping.set('old@example.com', 'oldname');
 
-  const response = await handleUpdateProfile(request, env, db);
-  assert.equal(response.status, 200);
+    const env = { JWT_SECRET: 'test-secret' };
+    const token = await generateToken('oldname', env);
+    const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        username: 'newname',
+        email: 'old@example.com',
+        phoneNumber: '+8613800138000'
+      })
+    });
 
-  const payload = await response.json();
-  assert.equal(payload.success, true);
-  assert.equal(payload.user.username, 'newname');
-  assert.equal(payload.user.nickname, 'newname');
-  assert.ok(payload.token);
+    const response = await handleUpdateProfile(request, env, db);
+    assert.equal(response.status, 200);
 
-  assert.equal(db.users.has('oldname'), false);
-  assert.equal(db.users.has('newname'), true);
-  assert.equal(db.users.get('newname').email, 'old@example.com');
-  assert.equal(db.users.get('newname').phone_number, '+8613800138000');
-  assert.equal(db.users.get('newname').firebase_uid, 'firebase-uid-1');
-  assert.equal(db.emailMapping.get('old@example.com'), 'newname');
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+    assert.equal(payload.user.username, 'newname');
+    assert.equal(payload.user.nickname, 'newname');
+    assert.ok(payload.token);
 
-  const directUsernameUpdate = db.statements.find(({ sql }) =>
-    sql.startsWith('UPDATE users SET') && sql.includes('username = ?')
-  );
-  assert.equal(directUsernameUpdate, undefined);
+    assert.equal(db.users.has('oldname'), false);
+    assert.equal(db.users.has('newname'), true);
+    assert.equal(db.users.get('newname').email, 'old@example.com');
+    assert.equal(db.users.get('newname').phone_number, '+8613800138000');
+    assert.equal(db.users.get('newname').firebase_uid, 'firebase-uid-1');
+    assert.equal(db.emailMapping.get('old@example.com'), 'newname');
 
-  const expectedReferenceUpdates = [
-    'UPDATE comments SET user_id = ? WHERE user_id = ?',
-    'UPDATE content_likes SET user_id = ? WHERE user_id = ?',
-    'UPDATE user_practice_privacy SET username = ? WHERE username = ?',
-    'UPDATE content_reports SET reporter_user_id = ? WHERE reporter_user_id = ?',
-    'UPDATE user_blocks SET blocked_user_id = ? WHERE blocked_user_id = ?'
-  ];
-
-  for (const expectedSql of expectedReferenceUpdates) {
-    assert.ok(
-      db.statements.some(({ sql }) => sql === expectedSql),
-      `missing migration statement: ${expectedSql}`
+    const directUsernameUpdate = db.statements.find(({ sql }) =>
+      sql.startsWith('UPDATE users SET') && sql.includes('username = ?')
     );
-  }
-});
+    assert.equal(directUsernameUpdate, undefined);
 
-test('handleUpdateProfile prefers native storage transactions when available', { concurrency: false }, async () => {
-  const db = createDbMock({ nativeTransaction: true });
-  db.users.set('nativeold', {
-    username: 'nativeold',
-    email: 'native@example.com',
-    password_hash: '',
-    salt: '',
-    iterations: 0,
-    algo: '',
-    email_verified: 1,
-    alipay_user_id: null,
-    alipay_nickname: null,
-    alipay_avatar: null,
-    alipay_bound_at: null,
-    wechat_openid: null,
-    wechat_nickname: null,
-    wechat_headimgurl: null,
-    wechat_bound_at: null,
-    phone_number: '+8613800138111',
-    firebase_uid: 'firebase-native-uid',
-    apple_user_id: null,
-    nickname: 'nativeold',
-    avatar: null,
-    bio: null,
-    main_practice_title: null,
-    main_practice_file_path: null,
-    main_practice_selected_at: null,
-    membership_type: 'trial',
-    membership_expires_at: null,
-    free_trial_end_date: '2026-05-31T00:00:00Z',
-    stripe_customer_id: null,
-    subscription_id: null,
-    total_transferred_bytes: 0,
-    last_transfer_at: null,
-    sync_version: 1,
-    extra_data: null,
-    created_at: '2026-05-01T00:00:00Z',
-    updated_at: '2026-05-04T00:00:00Z'
+    const expectedReferenceUpdates = [
+      'UPDATE comments SET user_id = ? WHERE user_id = ?',
+      'UPDATE content_likes SET user_id = ? WHERE user_id = ?',
+      'UPDATE user_practice_privacy SET username = ? WHERE username = ?',
+      'UPDATE content_reports SET reporter_user_id = ? WHERE reporter_user_id = ?',
+      'UPDATE user_blocks SET blocked_user_id = ? WHERE blocked_user_id = ?'
+    ];
+
+    for (const expectedSql of expectedReferenceUpdates) {
+      assert.ok(
+        db.statements.some(({ sql }) => sql === expectedSql),
+        `missing migration statement: ${expectedSql}`
+      );
+    }
   });
-  db.emailMapping.set('native@example.com', 'nativeold');
 
-  const env = { JWT_SECRET: 'test-secret' };
-  const token = await generateToken('nativeold', env);
-  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`
-    },
-    body: JSON.stringify({
-      username: 'nativenew',
+  test('handleUpdateProfile prefers native storage transactions when available', async () => {
+    const db = createDbMock({ nativeTransaction: true });
+    db.users.set('nativeold', {
+      username: 'nativeold',
       email: 'native@example.com',
-      phoneNumber: '+8613800138111'
-    })
+      password_hash: '',
+      salt: '',
+      iterations: 0,
+      algo: '',
+      email_verified: 1,
+      alipay_user_id: null,
+      alipay_nickname: null,
+      alipay_avatar: null,
+      alipay_bound_at: null,
+      wechat_openid: null,
+      wechat_nickname: null,
+      wechat_headimgurl: null,
+      wechat_bound_at: null,
+      phone_number: '+8613800138111',
+      firebase_uid: 'firebase-native-uid',
+      apple_user_id: null,
+      nickname: 'nativeold',
+      avatar: null,
+      bio: null,
+      main_practice_title: null,
+      main_practice_file_path: null,
+      main_practice_selected_at: null,
+      membership_type: 'trial',
+      membership_expires_at: null,
+      free_trial_end_date: '2026-05-31T00:00:00Z',
+      stripe_customer_id: null,
+      subscription_id: null,
+      total_transferred_bytes: 0,
+      last_transfer_at: null,
+      sync_version: 1,
+      extra_data: null,
+      created_at: '2026-05-01T00:00:00Z',
+      updated_at: '2026-05-04T00:00:00Z'
+    });
+    db.emailMapping.set('native@example.com', 'nativeold');
+
+    const env = { JWT_SECRET: 'test-secret' };
+    const token = await generateToken('nativeold', env);
+    const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        username: 'nativenew',
+        email: 'native@example.com',
+        phoneNumber: '+8613800138111'
+      })
+    });
+
+    const response = await handleUpdateProfile(request, env, db);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+    assert.equal(payload.user.username, 'nativenew');
+    assert.ok(payload.token);
+    assert.equal(db.users.has('nativeold'), false);
+    assert.equal(db.users.has('nativenew'), true);
+    assert.equal(db.emailMapping.get('native@example.com'), 'nativenew');
+    assert.ok(db.statements.some(({ sql }) => sql === '__native_transaction__'));
+    assert.equal(
+      db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
+      false
+    );
   });
-
-  const response = await handleUpdateProfile(request, env, db);
-  assert.equal(response.status, 200);
-
-  const payload = await response.json();
-  assert.equal(payload.success, true);
-  assert.equal(payload.user.username, 'nativenew');
-  assert.ok(payload.token);
-  assert.equal(db.users.has('nativeold'), false);
-  assert.equal(db.users.has('nativenew'), true);
-  assert.equal(db.emailMapping.get('native@example.com'), 'nativenew');
-  assert.ok(db.statements.some(({ sql }) => sql === '__native_transaction__'));
-  assert.equal(
-    db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
-    false
-  );
 });


### PR DESCRIPTION
## 为什么改

`issue #145` 里有一条很明确但还没真正落地的产品诉求：共修小组的群号应该更标准，最好像常见群号那样更容易口头传递、截图识别和手动输入。

现在主线虽然已经支持按群号搜索，但界面上仍然直接展示数据库自增 id，例如 `#21`、`#35`。这对用户来说不够稳定，也不够像一个正式的公开群号。

## 这次改了什么

- `fabushi/lib/models/co_practice_group_model.dart`
  - 为共修小组新增统一的 `publicCode` 视图值
  - 规则是把现有数字 id 统一格式化成 6 位群号，例如 `21 -> 000021`
- `fabushi/lib/widgets/co_practice_group_panel.dart`
  - 列表与详情页统一展示 `群号 #000021` 这种标准格式
  - 搜索提示文案同步改成标准群号示例 `#000123`
  - 引导文案改成“搜索小组名、组主或标准群号”，让用户知道该怎么找组

## 为什么这样做

- 不改数据库主键，也不引入新的迁移风险
- 先把用户真正看到和传播的群号标准化，立刻改善可读性与可分享性
- 现有后端按数字群号搜索的能力已经能兼容前导零，所以这次前端标准化不会破坏当前搜索路径

## 验证

- 结构级验证：群号展示入口只来自 `CoPracticeGroup.publicCode`，列表和详情页已统一
- 兼容性判断：当前后端群号搜索仍基于数字解析，`#000123` 会自然落回 `123`
- 当前环境没有本地 Flutter checkout / CI 运行能力，这轮继续以 PR checks 为最终准绳

Part of #145