### PR TITLE
chore: include build number in app error reports

### DIFF
--- a/fabushi/lib/core/constants/app_constants.dart
+++ b/fabushi/lib/core/constants/app_constants.dart
@@ -3,7 +3,7 @@ class AppConstants {
 
   // 应用信息
   static const String appName = '大乘';
-  static const String appVersion = '1.0.0';
+  static const String appVersion = '1.0.0+16';
 
   // 支持的国家代码
   static const List<String> supportedCountries = [


### PR DESCRIPTION
## 为什么改

`issue #163` 的最新补充很明确：自动上报里只有 `1.0.0` 还不够，排查时需要能直接区分到具体构建版本。

当前错误上报链路使用的是 `AppConstants.appVersion`，它仍然停在不带 build number 的 `1.0.0`。但仓库当前 `pubspec.yaml` 已经是 `1.0.0+16`，这会导致自动采集 issue 里写出的版本粒度偏粗，不利于把用户反馈和具体发版批次对上。

## 这次改了什么

- 把 `fabushi/lib/core/constants/app_constants.dart` 里的 `appVersion` 从 `1.0.0` 同步为 `1.0.0+16`
- 这样 `ErrorReportService` 自动提交到 GitHub issue 的 `App 版本` 与 diagnostics 里的 `appVersion` 都会直接带上当前构建号

## 为什么先这样做

- 这是一个小步、低风险、立刻提升排障质量的修正
- 不改反馈协议，不改服务端 issue 模板，不影响已有提交流程
- 先把当前版本粒度和仓库真实构建号对齐，避免继续产生模糊反馈数据

## 验证

- 代码路径确认：`ErrorReportService` 会直接把 `AppConstants.appVersion` 写入反馈请求体与诊断信息
- 仓库版本对齐确认：当前 `pubspec.yaml` 版本为 `1.0.0+16`
- 这轮环境没有本地 Flutter checkout / 运行能力，因此继续以 PR checks 为最终准绳

Part of #163