### PR TITLE
fix: roll co-practice D1 schema into managed migrations

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -8,6 +8,7 @@ import sys
 
 publish_workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
 deploy_workflow = Path('.github/workflows/deploy-production.yml').read_text(encoding='utf-8')
+co_practice_migration = Path('fabushi/web/migrations/20260506_co_practice_groups.sql')
 
 checkout_match = re.search(
     r"- name: Checkout source for version metadata\n(?P<body>.*?)\n\s*- name: Prepare release assets",
@@ -52,6 +53,18 @@ invalid_migration_commands = (
 for invalid in invalid_migration_commands:
     if invalid in deploy_workflow:
         missing.append(f'invalid command still present: {invalid}')
+
+if not co_practice_migration.exists():
+    missing.append('fabushi/web/migrations/20260506_co_practice_groups.sql')
+else:
+    migration_text = co_practice_migration.read_text(encoding='utf-8')
+    for required in (
+        'CREATE TABLE IF NOT EXISTS meditation_groups',
+        'CREATE TABLE IF NOT EXISTS meditation_group_members',
+        'ALTER TABLE meditation_records ADD COLUMN local_time TEXT;',
+    ):
+        if required not in migration_text:
+            missing.append(f'co-practice migration missing: {required}')
 
 if missing:
     sys.stderr.write(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
         run: |
           set -euo pipefail
           printf '{"type":"module"}\n' > package.json
-          node --test tests/*.test.js
+          node --test --test-concurrency=1 tests/*.test.js
 
       - name: Validate Worker bundle with Wrangler dry-run
         run: npx --yes wrangler@latest deploy --dry-run --outdir ../../worker-dry-run
@@ -328,6 +328,7 @@ jobs:
           sparse-checkout: |
             /.github/workflows/**
             /.github/scripts/**
+            /fabushi/web/migrations/**
 
       - name: Validate publish release workflow guardrail
         shell: bash

--- a/fabushi/web/migrations/20260506_co_practice_groups.sql
+++ b/fabushi/web/migrations/20260506_co_practice_groups.sql
@@ -1,0 +1,43 @@
+-- Managed D1 migration for co-practice groups.
+-- This keeps the production/staging deploy workflow in sync with the
+-- meditation group endpoints shipped in the Worker.
+
+ALTER TABLE meditation_records ADD COLUMN local_time TEXT;
+ALTER TABLE meditation_records ADD COLUMN timezone_offset_minutes INTEGER;
+ALTER TABLE meditation_records ADD COLUMN start_time TEXT;
+ALTER TABLE meditation_records ADD COLUMN end_time TEXT;
+
+CREATE TABLE IF NOT EXISTS meditation_groups (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  description TEXT,
+  owner_username TEXT NOT NULL,
+  require_approval INTEGER DEFAULT 0,
+  daily_goal_minutes INTEGER DEFAULT 30,
+  cumulative_miss_limit INTEGER DEFAULT 7,
+  consecutive_miss_limit INTEGER DEFAULT 3,
+  created_at TEXT NOT NULL,
+  updated_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS meditation_group_members (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  group_id INTEGER NOT NULL,
+  username TEXT NOT NULL,
+  role TEXT DEFAULT 'member',
+  status TEXT DEFAULT 'pending',
+  joined_at TEXT,
+  updated_at TEXT,
+  cumulative_missed_days INTEGER DEFAULT 0,
+  consecutive_missed_days INTEGER DEFAULT 0,
+  warning_message TEXT,
+  removed_at TEXT,
+  removal_reason TEXT,
+  UNIQUE(group_id, username)
+);
+
+CREATE INDEX IF NOT EXISTS idx_meditation_groups_owner ON meditation_groups(owner_username);
+CREATE INDEX IF NOT EXISTS idx_meditation_groups_name ON meditation_groups(name);
+CREATE INDEX IF NOT EXISTS idx_meditation_group_members_group ON meditation_group_members(group_id);
+CREATE INDEX IF NOT EXISTS idx_meditation_group_members_username ON meditation_group_members(username);
+CREATE INDEX IF NOT EXISTS idx_meditation_group_members_status ON meditation_group_members(status);


### PR DESCRIPTION
## 为什么改

`issue #145` 最新补充的两条现象已经不再像单纯的 UI 问题：

- 最新版本 46 里仍然看不到别的用户创建的小组
- 点击“创建小组”按钮会转圈后恢复原样，没有实际创建结果

继续下钻后，我确认这套共修小组接口代码和路由其实已经在主线里：
- `router.js` 已经挂了 `GET/POST /api/meditation/groups`
- `meditation.js` 已经实现了搜索、创建、详情、审批这些处理器

真正的断点更像是数据库层：仓库里虽然存在 `fabushi/web/migration_co_practice_groups.sql`，但主线 CD 自动执行的是 `wrangler d1 migrations apply ...`，它只会吃 `fabushi/web/migrations/` 目录下的正式迁移文件。当前该目录里并没有把共修小组表结构纳入受管迁移，这意味着主线发布可以带上接口代码，却没有把对应 D1 schema 稳定推到环境里。

这会直接导致：
- `/api/meditation/groups` 相关查询/创建在缺表环境中报错
- Flutter 端因为当前 service 对非 200 统一回落为空列表 / null，看起来就像“搜不到组”“创建按钮没反应”

## 这次改了什么

- 新增 `fabushi/web/migrations/20260506_co_practice_groups.sql`
  - 把共修小组需要的 D1 schema 正式纳入受管迁移目录
  - 包含 `meditation_groups`、`meditation_group_members` 以及记录本地时分字段补齐
- 补强 `.github/scripts/check-publish-cd-release.sh`
  - CI 会校验这份共修小组迁移文件确实存在于正式迁移目录
  - 同时校验 migration 文件里至少包含核心建表语句，避免以后再次出现“功能 SQL 躺在仓库里，但不在自动发布迁移链路里”的静默漏发

## 为什么这样做

- 这是对当前症状最贴近根因的修复，不是继续在前端加提示文案掩盖 500
- 不需要改现有接口协议，也不需要额外手工维护环境差异
- 修完后，主线 deploy workflow 在 development / production 都会通过正式 D1 migration 把这套 schema 带上

## 验证

- 结构级验证：
  - `deploy-production.yml` 已通过 `wrangler d1 migrations apply DB --env development|production --remote` 执行正式迁移目录
  - 新文件路径现在位于 `fabushi/web/migrations/`，会被主线 CD 自动拾取
- Guardrail 验证：
  - `Workflow guardrails` 会检查 `fabushi/web/migrations/20260506_co_practice_groups.sql` 是否存在且包含关键建表语句
- 交付闭环：
  - 仍需等这条 PR 的 CI、合并、mainline CD、GitHub Release 与 TestFlight 继续跑完

Part of #145