### PR TITLE
fix: unblock co-practice D1 migration on existing databases

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -61,10 +61,19 @@ else:
     for required in (
         'CREATE TABLE IF NOT EXISTS meditation_groups',
         'CREATE TABLE IF NOT EXISTS meditation_group_members',
-        'ALTER TABLE meditation_records ADD COLUMN local_time TEXT;',
+        'CREATE INDEX IF NOT EXISTS idx_meditation_group_members_status ON meditation_group_members(status);',
     ):
         if required not in migration_text:
             missing.append(f'co-practice migration missing: {required}')
+
+    for forbidden in (
+        'ALTER TABLE meditation_records ADD COLUMN local_time TEXT;',
+        'ALTER TABLE meditation_records ADD COLUMN timezone_offset_minutes INTEGER;',
+        'ALTER TABLE meditation_records ADD COLUMN start_time TEXT;',
+        'ALTER TABLE meditation_records ADD COLUMN end_time TEXT;',
+    ):
+        if forbidden in migration_text:
+            missing.append(f'co-practice migration should not re-add existing meditation_records columns: {forbidden}')
 
 if missing:
     sys.stderr.write(

--- a/fabushi/web/migrations/20260506_co_practice_groups.sql
+++ b/fabushi/web/migrations/20260506_co_practice_groups.sql
@@ -1,11 +1,8 @@
 -- Managed D1 migration for co-practice groups.
--- This keeps the production/staging deploy workflow in sync with the
--- meditation group endpoints shipped in the Worker.
-
-ALTER TABLE meditation_records ADD COLUMN local_time TEXT;
-ALTER TABLE meditation_records ADD COLUMN timezone_offset_minutes INTEGER;
-ALTER TABLE meditation_records ADD COLUMN start_time TEXT;
-ALTER TABLE meditation_records ADD COLUMN end_time TEXT;
+-- The meditation_records local-time columns already live in schema_v2.sql and
+-- the legacy one-off migration file. Keep the release-managed migration limited
+-- to table and index creation so CD can run safely on databases where those
+-- columns already exist.
 
 CREATE TABLE IF NOT EXISTS meditation_groups (
   id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## 为什么改

`main` 合入 `#166` 后，主线 `CD - Staging API gated production deploy #104` 在 `Apply development D1 migrations` 失败，第一处确定性红灯是：

```text
duplicate column name: local_time
```

这说明 `fabushi/web/migrations/20260506_co_practice_groups.sql` 里那 4 条给 `meditation_records` 加本地时区字段的 `ALTER TABLE`，对当前 development / production D1 来说已经不是“待迁移”，而是“重复加列”。结果是 staging migration 直接中断，后面的 staging E2E、production deploy、GitHub Release 和 TestFlight 全部被挡住。

## 这次改了什么

- 把 `fabushi/web/migrations/20260506_co_practice_groups.sql` 收敛为真正可重复执行的 managed migration
  - 去掉会在现网库上稳定失败的 4 条重复加列语句
  - 保留这次主线真正需要由 CI 兜底落库的共修小组表与索引创建
- 更新 `.github/scripts/check-publish-cd-release.sh`
  - 继续要求这条 migration 必须包含共修小组表/索引
  - 反向守卫：不再允许这条 managed migration 重新添加 `meditation_records` 的既有列，避免同类非幂等 SQL 再次进入主线

## 为什么这样做

- `meditation_records.local_time / timezone_offset_minutes / start_time / end_time` 已经存在于 `schema_v2.sql`，旧的一次性迁移文件里也带过这组字段
- 当前主线真正阻塞的是 release-managed migration 对“已存在列”的重复修改，而不是共修小组表本身缺失
- 先把 managed migration 收成对现有数据库安全的版本，才能恢复 `main -> CD -> Release -> TestFlight` 闭环

## 验证

- 根因证据：`CD #104` 日志已明确报 `duplicate column name: local_time`
- 结构验证：这次补丁后，managed migration 仅保留 `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` 语句
- 回归门禁：workflow guardrail 现在会直接拦截这条 migration 再次出现重复 `ALTER TABLE meditation_records ADD COLUMN ...`

Part of #170