### PR TITLE
fix: restore native profile transactions and stabilize worker regression tests

### DIFF
--- a/fabushi/web/src/services/database.js
+++ b/fabushi/web/src/services/database.js
@@ -2,6 +2,10 @@
 export class DatabaseService {
   constructor(db) {
     this.db = db;
+    this.state = db?.state;
+    if (typeof db?.transaction === 'function') {
+      this.transaction = db.transaction.bind(db);
+    }
   }
 
   // 直接暴露 prepare 方法，允许处理器直接调用 db.prepare()

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import { generateToken } from '../auth-utils.js';
 import { handleUpdateProfile } from '../src/handlers/profile.js';
+import { DatabaseService } from '../src/services/database.js';
 
 function createDbMock(options = {}) {
   const { nativeTransaction = false } = options;
@@ -91,6 +92,12 @@ function createDbMock(options = {}) {
               return execute(params);
             }
           };
+        },
+        first() {
+          return execute();
+        },
+        all() {
+          return { results: [] };
         }
       };
     }
@@ -110,11 +117,10 @@ function createDbMock(options = {}) {
   return db;
 }
 
-test('handleUpdateProfile migrates username changes without direct in-place username update', async () => {
-  const db = createDbMock();
-  db.users.set('oldname', {
-    username: 'oldname',
-    email: 'old@example.com',
+function seedUser(db, username, email, phoneNumber, extra = {}) {
+  db.users.set(username, {
+    username,
+    email,
     password_hash: '',
     salt: '',
     iterations: 0,
@@ -128,28 +134,42 @@ test('handleUpdateProfile migrates username changes without direct in-place user
     wechat_nickname: null,
     wechat_headimgurl: null,
     wechat_bound_at: null,
-    phone_number: '+8613800138000',
-    firebase_uid: 'firebase-uid-1',
+    phone_number: phoneNumber,
+    firebase_uid: extra.firebase_uid ?? null,
     apple_user_id: null,
-    nickname: 'oldname',
-    avatar: 'https://example.com/avatar.png',
+    nickname: username,
+    avatar: extra.avatar ?? null,
     bio: null,
-    main_practice_title: '心经',
-    main_practice_file_path: '/sutras/xinjing.md',
-    main_practice_selected_at: '2026-05-01T00:00:00Z',
+    main_practice_title: extra.main_practice_title ?? null,
+    main_practice_file_path: extra.main_practice_file_path ?? null,
+    main_practice_selected_at: extra.main_practice_selected_at ?? null,
     membership_type: 'trial',
     membership_expires_at: null,
     free_trial_end_date: '2026-05-31T00:00:00Z',
     stripe_customer_id: null,
     subscription_id: null,
-    total_transferred_bytes: 123,
-    last_transfer_at: '2026-05-04T00:00:00Z',
-    sync_version: 7,
+    total_transferred_bytes: extra.total_transferred_bytes ?? 0,
+    last_transfer_at: extra.last_transfer_at ?? null,
+    sync_version: extra.sync_version ?? 1,
     extra_data: null,
     created_at: '2026-05-01T00:00:00Z',
     updated_at: '2026-05-04T00:00:00Z'
   });
-  db.emailMapping.set('old@example.com', 'oldname');
+  db.emailMapping.set(email, username);
+}
+
+test('handleUpdateProfile migrates username changes without direct in-place username update', async () => {
+  const db = createDbMock();
+  seedUser(db, 'oldname', 'old@example.com', '+8613800138000', {
+    firebase_uid: 'firebase-uid-1',
+    avatar: 'https://example.com/avatar.png',
+    main_practice_title: '心经',
+    main_practice_file_path: '/sutras/xinjing.md',
+    main_practice_selected_at: '2026-05-01T00:00:00Z',
+    total_transferred_bytes: 123,
+    last_transfer_at: '2026-05-04T00:00:00Z',
+    sync_version: 7
+  });
 
   const env = { JWT_SECRET: 'test-secret' };
   const token = await generateToken('oldname', env);
@@ -205,44 +225,9 @@ test('handleUpdateProfile migrates username changes without direct in-place user
 
 test('handleUpdateProfile prefers native storage transactions when available', async () => {
   const db = createDbMock({ nativeTransaction: true });
-  db.users.set('nativeold', {
-    username: 'nativeold',
-    email: 'native@example.com',
-    password_hash: '',
-    salt: '',
-    iterations: 0,
-    algo: '',
-    email_verified: 1,
-    alipay_user_id: null,
-    alipay_nickname: null,
-    alipay_avatar: null,
-    alipay_bound_at: null,
-    wechat_openid: null,
-    wechat_nickname: null,
-    wechat_headimgurl: null,
-    wechat_bound_at: null,
-    phone_number: '+8613800138111',
-    firebase_uid: 'firebase-native-uid',
-    apple_user_id: null,
-    nickname: 'nativeold',
-    avatar: null,
-    bio: null,
-    main_practice_title: null,
-    main_practice_file_path: null,
-    main_practice_selected_at: null,
-    membership_type: 'trial',
-    membership_expires_at: null,
-    free_trial_end_date: '2026-05-31T00:00:00Z',
-    stripe_customer_id: null,
-    subscription_id: null,
-    total_transferred_bytes: 0,
-    last_transfer_at: null,
-    sync_version: 1,
-    extra_data: null,
-    created_at: '2026-05-01T00:00:00Z',
-    updated_at: '2026-05-04T00:00:00Z'
+  seedUser(db, 'nativeold', 'native@example.com', '+8613800138111', {
+    firebase_uid: 'firebase-native-uid'
   });
-  db.emailMapping.set('native@example.com', 'nativeold');
 
   const env = { JWT_SECRET: 'test-secret' };
   const token = await generateToken('nativeold', env);
@@ -272,6 +257,45 @@ test('handleUpdateProfile prefers native storage transactions when available', a
   assert.ok(db.statements.some(({ sql }) => sql === '__native_transaction__'));
   assert.equal(
     db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
+    false
+  );
+});
+
+test('DatabaseService preserves native transaction access for profile updates', async () => {
+  const rawDb = createDbMock({ nativeTransaction: true });
+  seedUser(rawDb, 'wrappedold', 'wrapped@example.com', '+8613800138222', {
+    firebase_uid: 'firebase-wrapped-uid'
+  });
+  const db = new DatabaseService(rawDb);
+
+  const env = { JWT_SECRET: 'test-secret' };
+  const token = await generateToken('wrappedold', env);
+  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      username: 'wrappednew',
+      email: 'wrapped@example.com',
+      phoneNumber: '+8613800138222'
+    })
+  });
+
+  const response = await handleUpdateProfile(request, env, db);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.user.username, 'wrappednew');
+  assert.ok(payload.token);
+  assert.equal(rawDb.users.has('wrappedold'), false);
+  assert.equal(rawDb.users.has('wrappednew'), true);
+  assert.equal(rawDb.emailMapping.get('wrapped@example.com'), 'wrappednew');
+  assert.ok(rawDb.statements.some(({ sql }) => sql === '__native_transaction__'));
+  assert.equal(
+    rawDb.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
     false
   );
 });

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -43,6 +43,25 @@ function createDbMock(options = {}) {
           return;
         }
 
+        if (normalizedSql.startsWith('SELECT * FROM users WHERE username = ?')) {
+          const user = users.get(params[0]);
+          return user ? { ...user } : null;
+        }
+
+        if (normalizedSql.startsWith('SELECT username FROM email_username_mapping WHERE email = ?')) {
+          const username = emailMapping.get(params[0]);
+          return username ? { username } : null;
+        }
+
+        if (normalizedSql.startsWith('SELECT * FROM users WHERE phone_number = ?')) {
+          for (const user of users.values()) {
+            if (user.phone_number === params[0]) {
+              return { ...user };
+            }
+          }
+          return null;
+        }
+
         if (normalizedSql.startsWith('UPDATE users') && normalizedSql.includes('phone_number = NULL')) {
           const [placeholderEmail, updatedAt, username] = params;
           const user = users.get(username);

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -90,6 +90,12 @@ function createDbMock(options = {}) {
           return {
             async run() {
               return execute(params);
+            },
+            async first() {
+              return execute(params);
+            },
+            async all() {
+              return { results: (await execute(params)) ?? [] };
             }
           };
         },

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -110,170 +110,168 @@ function createDbMock(options = {}) {
   return db;
 }
 
-test.describe('handleUpdateProfile transaction regressions', { concurrency: false }, () => {
-  test('handleUpdateProfile migrates username changes without direct in-place username update', async () => {
-    const db = createDbMock();
-    db.users.set('oldname', {
-      username: 'oldname',
+test('handleUpdateProfile migrates username changes without direct in-place username update', async () => {
+  const db = createDbMock();
+  db.users.set('oldname', {
+    username: 'oldname',
+    email: 'old@example.com',
+    password_hash: '',
+    salt: '',
+    iterations: 0,
+    algo: '',
+    email_verified: 1,
+    alipay_user_id: null,
+    alipay_nickname: null,
+    alipay_avatar: null,
+    alipay_bound_at: null,
+    wechat_openid: null,
+    wechat_nickname: null,
+    wechat_headimgurl: null,
+    wechat_bound_at: null,
+    phone_number: '+8613800138000',
+    firebase_uid: 'firebase-uid-1',
+    apple_user_id: null,
+    nickname: 'oldname',
+    avatar: 'https://example.com/avatar.png',
+    bio: null,
+    main_practice_title: '心经',
+    main_practice_file_path: '/sutras/xinjing.md',
+    main_practice_selected_at: '2026-05-01T00:00:00Z',
+    membership_type: 'trial',
+    membership_expires_at: null,
+    free_trial_end_date: '2026-05-31T00:00:00Z',
+    stripe_customer_id: null,
+    subscription_id: null,
+    total_transferred_bytes: 123,
+    last_transfer_at: '2026-05-04T00:00:00Z',
+    sync_version: 7,
+    extra_data: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-04T00:00:00Z'
+  });
+  db.emailMapping.set('old@example.com', 'oldname');
+
+  const env = { JWT_SECRET: 'test-secret' };
+  const token = await generateToken('oldname', env);
+  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      username: 'newname',
       email: 'old@example.com',
-      password_hash: '',
-      salt: '',
-      iterations: 0,
-      algo: '',
-      email_verified: 1,
-      alipay_user_id: null,
-      alipay_nickname: null,
-      alipay_avatar: null,
-      alipay_bound_at: null,
-      wechat_openid: null,
-      wechat_nickname: null,
-      wechat_headimgurl: null,
-      wechat_bound_at: null,
-      phone_number: '+8613800138000',
-      firebase_uid: 'firebase-uid-1',
-      apple_user_id: null,
-      nickname: 'oldname',
-      avatar: 'https://example.com/avatar.png',
-      bio: null,
-      main_practice_title: '心经',
-      main_practice_file_path: '/sutras/xinjing.md',
-      main_practice_selected_at: '2026-05-01T00:00:00Z',
-      membership_type: 'trial',
-      membership_expires_at: null,
-      free_trial_end_date: '2026-05-31T00:00:00Z',
-      stripe_customer_id: null,
-      subscription_id: null,
-      total_transferred_bytes: 123,
-      last_transfer_at: '2026-05-04T00:00:00Z',
-      sync_version: 7,
-      extra_data: null,
-      created_at: '2026-05-01T00:00:00Z',
-      updated_at: '2026-05-04T00:00:00Z'
-    });
-    db.emailMapping.set('old@example.com', 'oldname');
-
-    const env = { JWT_SECRET: 'test-secret' };
-    const token = await generateToken('oldname', env);
-    const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`
-      },
-      body: JSON.stringify({
-        username: 'newname',
-        email: 'old@example.com',
-        phoneNumber: '+8613800138000'
-      })
-    });
-
-    const response = await handleUpdateProfile(request, env, db);
-    assert.equal(response.status, 200);
-
-    const payload = await response.json();
-    assert.equal(payload.success, true);
-    assert.equal(payload.user.username, 'newname');
-    assert.equal(payload.user.nickname, 'newname');
-    assert.ok(payload.token);
-
-    assert.equal(db.users.has('oldname'), false);
-    assert.equal(db.users.has('newname'), true);
-    assert.equal(db.users.get('newname').email, 'old@example.com');
-    assert.equal(db.users.get('newname').phone_number, '+8613800138000');
-    assert.equal(db.users.get('newname').firebase_uid, 'firebase-uid-1');
-    assert.equal(db.emailMapping.get('old@example.com'), 'newname');
-
-    const directUsernameUpdate = db.statements.find(({ sql }) =>
-      sql.startsWith('UPDATE users SET') && sql.includes('username = ?')
-    );
-    assert.equal(directUsernameUpdate, undefined);
-
-    const expectedReferenceUpdates = [
-      'UPDATE comments SET user_id = ? WHERE user_id = ?',
-      'UPDATE content_likes SET user_id = ? WHERE user_id = ?',
-      'UPDATE user_practice_privacy SET username = ? WHERE username = ?',
-      'UPDATE content_reports SET reporter_user_id = ? WHERE reporter_user_id = ?',
-      'UPDATE user_blocks SET blocked_user_id = ? WHERE blocked_user_id = ?'
-    ];
-
-    for (const expectedSql of expectedReferenceUpdates) {
-      assert.ok(
-        db.statements.some(({ sql }) => sql === expectedSql),
-        `missing migration statement: ${expectedSql}`
-      );
-    }
+      phoneNumber: '+8613800138000'
+    })
   });
 
-  test('handleUpdateProfile prefers native storage transactions when available', async () => {
-    const db = createDbMock({ nativeTransaction: true });
-    db.users.set('nativeold', {
-      username: 'nativeold',
+  const response = await handleUpdateProfile(request, env, db);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.user.username, 'newname');
+  assert.equal(payload.user.nickname, 'newname');
+  assert.ok(payload.token);
+
+  assert.equal(db.users.has('oldname'), false);
+  assert.equal(db.users.has('newname'), true);
+  assert.equal(db.users.get('newname').email, 'old@example.com');
+  assert.equal(db.users.get('newname').phone_number, '+8613800138000');
+  assert.equal(db.users.get('newname').firebase_uid, 'firebase-uid-1');
+  assert.equal(db.emailMapping.get('old@example.com'), 'newname');
+
+  const directUsernameUpdate = db.statements.find(({ sql }) =>
+    sql.startsWith('UPDATE users SET') && sql.includes('username = ?')
+  );
+  assert.equal(directUsernameUpdate, undefined);
+
+  const expectedReferenceUpdates = [
+    'UPDATE comments SET user_id = ? WHERE user_id = ?',
+    'UPDATE content_likes SET user_id = ? WHERE user_id = ?',
+    'UPDATE user_practice_privacy SET username = ? WHERE username = ?',
+    'UPDATE content_reports SET reporter_user_id = ? WHERE reporter_user_id = ?',
+    'UPDATE user_blocks SET blocked_user_id = ? WHERE blocked_user_id = ?'
+  ];
+
+  for (const expectedSql of expectedReferenceUpdates) {
+    assert.ok(
+      db.statements.some(({ sql }) => sql === expectedSql),
+      `missing migration statement: ${expectedSql}`
+    );
+  }
+});
+
+test('handleUpdateProfile prefers native storage transactions when available', async () => {
+  const db = createDbMock({ nativeTransaction: true });
+  db.users.set('nativeold', {
+    username: 'nativeold',
+    email: 'native@example.com',
+    password_hash: '',
+    salt: '',
+    iterations: 0,
+    algo: '',
+    email_verified: 1,
+    alipay_user_id: null,
+    alipay_nickname: null,
+    alipay_avatar: null,
+    alipay_bound_at: null,
+    wechat_openid: null,
+    wechat_nickname: null,
+    wechat_headimgurl: null,
+    wechat_bound_at: null,
+    phone_number: '+8613800138111',
+    firebase_uid: 'firebase-native-uid',
+    apple_user_id: null,
+    nickname: 'nativeold',
+    avatar: null,
+    bio: null,
+    main_practice_title: null,
+    main_practice_file_path: null,
+    main_practice_selected_at: null,
+    membership_type: 'trial',
+    membership_expires_at: null,
+    free_trial_end_date: '2026-05-31T00:00:00Z',
+    stripe_customer_id: null,
+    subscription_id: null,
+    total_transferred_bytes: 0,
+    last_transfer_at: null,
+    sync_version: 1,
+    extra_data: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-04T00:00:00Z'
+  });
+  db.emailMapping.set('native@example.com', 'nativeold');
+
+  const env = { JWT_SECRET: 'test-secret' };
+  const token = await generateToken('nativeold', env);
+  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      username: 'nativenew',
       email: 'native@example.com',
-      password_hash: '',
-      salt: '',
-      iterations: 0,
-      algo: '',
-      email_verified: 1,
-      alipay_user_id: null,
-      alipay_nickname: null,
-      alipay_avatar: null,
-      alipay_bound_at: null,
-      wechat_openid: null,
-      wechat_nickname: null,
-      wechat_headimgurl: null,
-      wechat_bound_at: null,
-      phone_number: '+8613800138111',
-      firebase_uid: 'firebase-native-uid',
-      apple_user_id: null,
-      nickname: 'nativeold',
-      avatar: null,
-      bio: null,
-      main_practice_title: null,
-      main_practice_file_path: null,
-      main_practice_selected_at: null,
-      membership_type: 'trial',
-      membership_expires_at: null,
-      free_trial_end_date: '2026-05-31T00:00:00Z',
-      stripe_customer_id: null,
-      subscription_id: null,
-      total_transferred_bytes: 0,
-      last_transfer_at: null,
-      sync_version: 1,
-      extra_data: null,
-      created_at: '2026-05-01T00:00:00Z',
-      updated_at: '2026-05-04T00:00:00Z'
-    });
-    db.emailMapping.set('native@example.com', 'nativeold');
-
-    const env = { JWT_SECRET: 'test-secret' };
-    const token = await generateToken('nativeold', env);
-    const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`
-      },
-      body: JSON.stringify({
-        username: 'nativenew',
-        email: 'native@example.com',
-        phoneNumber: '+8613800138111'
-      })
-    });
-
-    const response = await handleUpdateProfile(request, env, db);
-    assert.equal(response.status, 200);
-
-    const payload = await response.json();
-    assert.equal(payload.success, true);
-    assert.equal(payload.user.username, 'nativenew');
-    assert.ok(payload.token);
-    assert.equal(db.users.has('nativeold'), false);
-    assert.equal(db.users.has('nativenew'), true);
-    assert.equal(db.emailMapping.get('native@example.com'), 'nativenew');
-    assert.ok(db.statements.some(({ sql }) => sql === '__native_transaction__'));
-    assert.equal(
-      db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
-      false
-    );
+      phoneNumber: '+8613800138111'
+    })
   });
+
+  const response = await handleUpdateProfile(request, env, db);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.user.username, 'nativenew');
+  assert.ok(payload.token);
+  assert.equal(db.users.has('nativeold'), false);
+  assert.equal(db.users.has('nativenew'), true);
+  assert.equal(db.emailMapping.get('native@example.com'), 'nativenew');
+  assert.ok(db.statements.some(({ sql }) => sql === '__native_transaction__'));
+  assert.equal(
+    db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
+    false
+  );
 });


### PR DESCRIPTION
## 为什么改

这一轮主控扫描里，`main` 同时暴露了两条其实属于同一资料更新链路的阻塞信号：

- `CI #353` 在 Worker contract tests 红掉，直接挡住了文档 PR `#172`
- 用户反馈 `#174` 仍然报 `D1_ERROR`，说明资料更新在真实运行时还有事务入口问题

进一步下钻后，根因分成两层：

1. `fabushi/web/tests/profile.test.js` 目前用了 `test.describe(..., { concurrency: false })` 包装，在 GitHub Actions 的 Node test runner 里会触发 `Unable to deserialize cloned data due to invalid or unsupported version.`，导致测试运行器自己崩掉。
2. `profile.js` 虽然已经优先探测 `state.storage.transaction(...)`，但 `DatabaseService` 包装层没有把底层 D1 对象的 `state` 透传出来，真实路由走 `new DatabaseService(env.DB)` 时，处理器仍然可能看不到原生事务能力，最后退回到 `BEGIN TRANSACTION`。

## 这次改了什么

- `fabushi/web/src/services/database.js`
  - 透传底层数据库对象的 `state`
  - 如果底层实现本身提供 `transaction(...)`，也一起透传给上层处理器
  - 让 `handleUpdateProfile` 在真实路由里也能拿到 Cloudflare 支持的原生事务入口
- `fabushi/web/tests/profile.test.js`
  - 去掉会把 Node runner 打崩的顶层 `test.describe(...)` 包装
  - 保留现有两条资料更新回归断言
  - 新增一条回归测试，明确要求 `DatabaseService` 包装后仍然不能丢失原生事务能力

## 根因结论

这次不是资料更新业务规则本身回退，而是：

- 测试层有一个 Node runner 兼容性问题，把 Worker lane 打红了
- 运行时包装层又把原生事务能力截断了，导致线上资料更新仍可能落回不被允许的 SQL 事务语句

## 验证

- 预期直接修复 `CI #353` 中 `Run Worker contract tests` 的唯一失败点
- 预期修复 `DatabaseService -> profile handler` 这条真实运行时链路上的原生事务透传问题
- 当前环境没有仓库本地 checkout，因此以 GitHub Actions 结果作为最终验证

Fixes #173
Refs #174