### PR TITLE
fix: tolerate immutable GitHub releases in official-site beta sync

### DIFF
--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -205,6 +205,7 @@ jobs:
           PY
 
       - name: Upload beta state asset to the release
+        id: upload_state
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -212,18 +213,46 @@ jobs:
           RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
         run: |
           set -euo pipefail
-          gh release upload "$RELEASE_TAG" OFFICIAL_SITE_RELEASE_STATE.json --repo "$RELEASE_REPO" --clobber
+          upload_log="$(mktemp)"
+          if gh release upload "$RELEASE_TAG" OFFICIAL_SITE_RELEASE_STATE.json --repo "$RELEASE_REPO" --clobber 2>"$upload_log"; then
+            echo "uploaded=true" >> "$GITHUB_OUTPUT"
+            echo "immutable_release=false" >> "$GITHUB_OUTPUT"
+            rm -f "$upload_log"
+            exit 0
+          fi
+
+          if grep -q 'Cannot upload assets to an immutable release' "$upload_log"; then
+            cat "$upload_log"
+            echo "uploaded=false" >> "$GITHUB_OUTPUT"
+            echo "immutable_release=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release $RELEASE_TAG is immutable, so OFFICIAL_SITE_RELEASE_STATE.json was not uploaded. The official site will keep using release metadata and TestFlight status fallbacks."
+            rm -f "$upload_log"
+            exit 0
+          fi
+
+          cat "$upload_log" >&2
+          rm -f "$upload_log"
+          exit 1
 
       - name: Write summary
         shell: bash
         env:
           RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
+          RELEASE_STATE_UPLOADED: ${{ steps.upload_state.outputs.uploaded }}
+          IMMUTABLE_RELEASE: ${{ steps.upload_state.outputs.immutable_release }}
         run: |
           {
             echo "## Official site beta state synced"
             echo ""
             echo "- Release tag: $RELEASE_TAG"
-            echo "- Asset: OFFICIAL_SITE_RELEASE_STATE.json"
+            if [ "$RELEASE_STATE_UPLOADED" = "true" ]; then
+              echo "- Asset: OFFICIAL_SITE_RELEASE_STATE.json uploaded to the GitHub Release"
+            elif [ "$IMMUTABLE_RELEASE" = "true" ]; then
+              echo "- Asset upload skipped because the GitHub Release is immutable"
+              echo "- Official site fallback remains available through release metadata and TESTFLIGHT_UPLOAD_STATUS.txt"
+            else
+              echo "- Asset: OFFICIAL_SITE_RELEASE_STATE.json was generated locally"
+            fi
             echo "- Android beta now points at the latest GitHub Release APK asset."
             echo "- iOS beta now points at the TestFlight public link when IOS_TESTFLIGHT_PUBLIC_URL is configured."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 为什么改

`issue #175` 对应的 `Sync official site beta download state #1` 不是在生成官网 beta 状态 JSON 时失败，而是在最后一步把 `OFFICIAL_SITE_RELEASE_STATE.json` 上传回 release 时被 GitHub 拒绝：

- 失败时间：2026-05-06 14:39 UTC
- 失败接口返回：`HTTP 422: Cannot upload assets to an immutable release.`

这说明当前 release 一旦进入 immutable 状态，workflow 再去 `gh release upload --clobber` 就会稳定打红，即使前面的 beta 元数据生成本身已经成功。

## 这次改了什么

- 保留现有的 beta 状态 JSON 生成逻辑
- 只收口上传步骤：
  - 正常可写 release 继续上传 `OFFICIAL_SITE_RELEASE_STATE.json`
  - 如果 GitHub 明确返回 immutable release，则把它视为一个已识别的外部约束，输出 notice 和 step outputs，并让 workflow 成功结束
- 更新 step summary，让它区分“已上传资产”和“因 immutable release 改走 fallback”两种结果

## 为什么这样做

- 这次根因不是官网 beta 数据算不出来，而是 GitHub release 生命周期限制了后续资产覆盖上传
- 仓库里的官网读取逻辑已经具备 fallback：拿不到 `OFFICIAL_SITE_RELEASE_STATE.json` 时，会回退到 GitHub Release 元数据和 `TESTFLIGHT_UPLOAD_STATUS.txt`
- 所以这里真正该修的是：不要把一个已知的外部只读状态继续当成 workflow 失败

## 验证

- 预期修复 `#175` 里 `Upload beta state asset to the release` 的 422 红灯
- 对可写 release，不改变现有上传路径
- 对 immutable release，workflow 应输出“skip upload, keep fallback”而不是失败

Fixes #175