### PR TITLE
fix: surface co-practice group creation errors in app

### DIFF
--- a/fabushi/lib/services/co_practice_service.dart
+++ b/fabushi/lib/services/co_practice_service.dart
@@ -7,14 +7,66 @@ import '../core/config/app_config.dart';
 import '../models/co_practice_group_model.dart';
 import 'app_settings.dart';
 
+class CoPracticeGroupCreationResult {
+  final int? groupId;
+  final String? errorMessage;
+  final int? statusCode;
+
+  const CoPracticeGroupCreationResult._({
+    this.groupId,
+    this.errorMessage,
+    this.statusCode,
+  });
+
+  const CoPracticeGroupCreationResult.success(int groupId)
+    : this._(groupId: groupId);
+
+  const CoPracticeGroupCreationResult.failure(
+    String errorMessage, {
+    int? statusCode,
+  }) : this._(errorMessage: errorMessage, statusCode: statusCode);
+
+  bool get isSuccess => groupId != null;
+}
+
 class CoPracticeService {
   static final CoPracticeService _instance = CoPracticeService._internal();
-  factory CoPracticeService() => _instance;
-  CoPracticeService._internal();
+  factory CoPracticeService({
+    http.Client? httpClient,
+    Future<String> Function()? baseUrlResolver,
+    Future<Map<String, String>> Function()? headersResolver,
+  }) {
+    if (httpClient != null ||
+        baseUrlResolver != null ||
+        headersResolver != null) {
+      return CoPracticeService._internal(
+        httpClient: httpClient,
+        baseUrlResolver: baseUrlResolver,
+        headersResolver: headersResolver,
+      );
+    }
+    return _instance;
+  }
 
-  Future<String> get _baseUrl async => await AppSettings.getBackendUrl();
+  CoPracticeService._internal({
+    http.Client? httpClient,
+    Future<String> Function()? baseUrlResolver,
+    Future<Map<String, String>> Function()? headersResolver,
+  }) : _httpClient = httpClient ?? http.Client(),
+       _baseUrlResolver = baseUrlResolver ?? AppSettings.getBackendUrl,
+       _headersResolver = headersResolver;
+
+  final http.Client _httpClient;
+  final Future<String> Function() _baseUrlResolver;
+  final Future<Map<String, String>> Function()? _headersResolver;
+
+  Future<String> get _baseUrl async => _baseUrlResolver();
 
   Future<Map<String, String>> _headers() async {
+    if (_headersResolver != null) {
+      return _headersResolver!();
+    }
+
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString(AppConfig.tokenStorageKey);
     return {
@@ -31,10 +83,10 @@ class CoPracticeService {
     final uri = Uri.parse(
       '$baseUrl/api/meditation/groups',
     ).replace(queryParameters: {'query': query, 'limit': limit.toString()});
-    final response = await http.get(uri, headers: await _headers());
+    final response = await _httpClient.get(uri, headers: await _headers());
     if (response.statusCode != 200) return [];
 
-    final data = jsonDecode(response.body);
+    final data = _decodeJsonMap(response.body);
     if (data['success'] != true) return [];
 
     final groups = data['data']?['groups'] as List<dynamic>? ?? [];
@@ -46,7 +98,7 @@ class CoPracticeService {
         .toList();
   }
 
-  Future<int?> createGroup({
+  Future<CoPracticeGroupCreationResult> createGroup({
     required String name,
     String description = '',
     required bool requireApproval,
@@ -54,38 +106,57 @@ class CoPracticeService {
     required int cumulativeMissLimit,
     required int consecutiveMissLimit,
   }) async {
-    final baseUrl = await _baseUrl;
-    final response = await http.post(
-      Uri.parse('$baseUrl/api/meditation/groups'),
-      headers: await _headers(),
-      body: jsonEncode({
-        'name': name,
-        'description': description,
-        'requireApproval': requireApproval,
-        'dailyGoalMinutes': dailyGoalMinutes,
-        'cumulativeMissLimit': cumulativeMissLimit,
-        'consecutiveMissLimit': consecutiveMissLimit,
-      }),
-    );
+    try {
+      final baseUrl = await _baseUrl;
+      final response = await _httpClient.post(
+        Uri.parse('$baseUrl/api/meditation/groups'),
+        headers: await _headers(),
+        body: jsonEncode({
+          'name': name,
+          'description': description,
+          'requireApproval': requireApproval,
+          'dailyGoalMinutes': dailyGoalMinutes,
+          'cumulativeMissLimit': cumulativeMissLimit,
+          'consecutiveMissLimit': consecutiveMissLimit,
+        }),
+      );
 
-    if (response.statusCode != 200) return null;
-    final data = jsonDecode(response.body);
-    if (data['success'] != true) return null;
-    final id = data['data']?['groupId'];
-    if (id is int) return id;
-    return int.tryParse(id?.toString() ?? '');
+      final data = _decodeJsonMap(response.body);
+      if (response.statusCode != 200 || data['success'] != true) {
+        return CoPracticeGroupCreationResult.failure(
+          _extractErrorMessage(data, fallback: '创建共修小组失败'),
+          statusCode: response.statusCode,
+        );
+      }
+
+      final id = data['data']?['groupId'];
+      if (id is int) {
+        return CoPracticeGroupCreationResult.success(id);
+      }
+
+      final parsedId = int.tryParse(id?.toString() ?? '');
+      if (parsedId != null) {
+        return CoPracticeGroupCreationResult.success(parsedId);
+      }
+
+      return const CoPracticeGroupCreationResult.failure('创建成功，但未返回小组编号');
+    } catch (_) {
+      return const CoPracticeGroupCreationResult.failure(
+        '创建共修小组失败，请检查网络后重试',
+      );
+    }
   }
 
   Future<String?> joinGroup(int groupId) async {
     final baseUrl = await _baseUrl;
-    final response = await http.post(
+    final response = await _httpClient.post(
       Uri.parse('$baseUrl/api/meditation/groups/join'),
       headers: await _headers(),
       body: jsonEncode({'groupId': groupId}),
     );
 
     if (response.statusCode != 200) return null;
-    final data = jsonDecode(response.body);
+    final data = _decodeJsonMap(response.body);
     if (data['success'] != true) return null;
     return data['data']?['message']?.toString() ?? '已提交';
   }
@@ -95,10 +166,10 @@ class CoPracticeService {
     final uri = Uri.parse(
       '$baseUrl/api/meditation/groups/detail',
     ).replace(queryParameters: {'groupId': groupId.toString()});
-    final response = await http.get(uri, headers: await _headers());
+    final response = await _httpClient.get(uri, headers: await _headers());
     if (response.statusCode != 200) return null;
 
-    final data = jsonDecode(response.body);
+    final data = _decodeJsonMap(response.body);
     if (data['success'] != true) return null;
     return CoPracticeGroupDetail.fromJson(
       Map<String, dynamic>.from(data['data'] as Map),
@@ -111,7 +182,7 @@ class CoPracticeService {
     required bool approve,
   }) async {
     final baseUrl = await _baseUrl;
-    final response = await http.post(
+    final response = await _httpClient.post(
       Uri.parse('$baseUrl/api/meditation/groups/review'),
       headers: await _headers(),
       body: jsonEncode({
@@ -122,7 +193,33 @@ class CoPracticeService {
     );
 
     if (response.statusCode != 200) return false;
-    final data = jsonDecode(response.body);
+    final data = _decodeJsonMap(response.body);
     return data['success'] == true;
+  }
+
+  Map<String, dynamic> _decodeJsonMap(String body) {
+    if (body.trim().isEmpty) {
+      return const <String, dynamic>{};
+    }
+
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    if (decoded is Map) {
+      return Map<String, dynamic>.from(decoded);
+    }
+    return const <String, dynamic>{};
+  }
+
+  String _extractErrorMessage(
+    Map<String, dynamic> data, {
+    required String fallback,
+  }) {
+    final message = data['error'] ?? data['message'];
+    if (message is String && message.trim().isNotEmpty) {
+      return message.trim();
+    }
+    return fallback;
   }
 }

--- a/fabushi/lib/widgets/co_practice_group_panel.dart
+++ b/fabushi/lib/widgets/co_practice_group_panel.dart
@@ -898,7 +898,7 @@ class _CreateCoPracticeGroupDialogState
     }
 
     setState(() => _isLoading = true);
-    final groupId = await CoPracticeService().createGroup(
+    final result = await CoPracticeService().createGroup(
       name: name,
       description: _descriptionController.text.trim(),
       requireApproval: _requireApproval,
@@ -910,11 +910,15 @@ class _CreateCoPracticeGroupDialogState
     setState(() => _isLoading = false);
 
     final messenger = ScaffoldMessenger.of(context);
-    if (groupId != null) {
+    if (result.groupId != null) {
       Navigator.of(context).pop(true);
       messenger.showSnackBar(const SnackBar(content: Text('共修小组已创建')));
     } else {
-      messenger.showSnackBar(const SnackBar(content: Text('创建失败，请先登录并检查网络')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(result.errorMessage ?? '创建失败，请先登录并检查网络'),
+        ),
+      );
     }
   }
 

--- a/fabushi/test/unit/services/co_practice_service_test.dart
+++ b/fabushi/test/unit/services/co_practice_service_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:global_dharma_sharing/services/co_practice_service.dart';
+
+void main() {
+  CoPracticeService createService(MockClient client) {
+    return CoPracticeService(
+      httpClient: client,
+      baseUrlResolver: () async => 'https://example.com',
+      headersResolver: () async => const {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer test-token',
+      },
+    );
+  }
+
+  test('createGroup returns group id on success', () async {
+    final service = createService(
+      MockClient((request) async {
+        expect(request.method, 'POST');
+        expect(request.url.path, '/api/meditation/groups');
+        expect(request.headers['Authorization'], 'Bearer test-token');
+        return http.Response(
+          '{"success":true,"data":{"groupId":42}}',
+          200,
+          headers: const {'content-type': 'application/json'},
+        );
+      }),
+    );
+
+    final result = await service.createGroup(
+      name: '晨课共修',
+      description: '每天一起完成早课',
+      requireApproval: true,
+      dailyGoalMinutes: 30,
+      cumulativeMissLimit: 7,
+      consecutiveMissLimit: 3,
+    );
+
+    expect(result.isSuccess, isTrue);
+    expect(result.groupId, 42);
+    expect(result.errorMessage, isNull);
+  });
+
+  test('createGroup surfaces backend error messages', () async {
+    final service = createService(
+      MockClient(
+        (_) async => http.Response(
+          '{"success":false,"error":"meditation_groups 表尚未完成迁移"}',
+          500,
+          headers: const {'content-type': 'application/json'},
+        ),
+      ),
+    );
+
+    final result = await service.createGroup(
+      name: '晨课共修',
+      requireApproval: true,
+      dailyGoalMinutes: 30,
+      cumulativeMissLimit: 7,
+      consecutiveMissLimit: 3,
+    );
+
+    expect(result.isSuccess, isFalse);
+    expect(result.groupId, isNull);
+    expect(result.statusCode, 500);
+    expect(result.errorMessage, 'meditation_groups 表尚未完成迁移');
+  });
+
+  test('createGroup falls back when response body has no message', () async {
+    final service = createService(
+      MockClient(
+        (_) async => http.Response(
+          '{"success":false}',
+          400,
+          headers: const {'content-type': 'application/json'},
+        ),
+      ),
+    );
+
+    final result = await service.createGroup(
+      name: '晨课共修',
+      requireApproval: true,
+      dailyGoalMinutes: 30,
+      cumulativeMissLimit: 7,
+      consecutiveMissLimit: 3,
+    );
+
+    expect(result.isSuccess, isFalse);
+    expect(result.errorMessage, '创建共修小组失败');
+    expect(result.statusCode, 400);
+  });
+}


### PR DESCRIPTION
## 为什么改

`#145` 里已经出现了一个很具体但仍然难定位的用户症状：点击“创建小组”后按钮会转一圈，再恢复原样，但界面没有给出足够明确的失败原因。

继续看当前客户端代码可以确认，现有 `CoPracticeService.createGroup(...)` 在以下几种情况下都会直接回 `null`：

- 后端返回 4xx / 5xx
- Worker 返回了 `success: false`
- 返回体里没有预期的小组编号

结果就是：前端最后只能统一弹一个很泛的“创建失败，请先登录并检查网络”，把真实的后端错误细节吞掉了。像 `meditation_groups` 缺迁移、鉴权失败、参数校验失败这类真正决定下一步排查方向的信息，用户和后续巡检都看不到。

## 这次改了什么

- 给 `CoPracticeService` 增加 `CoPracticeGroupCreationResult`
  - 成功时返回 `groupId`
  - 失败时保留 `errorMessage` 和 `statusCode`
- `createGroup(...)` 现在会优先把 Worker 返回的 `error` / `message` 透传出来，而不是一律吞成 `null`
- 创建小组弹窗改为直接使用这些错误信息展示 snackbar
  - 让用户至少能看到“到底是网络、鉴权、参数还是服务端迁移出了问题”
- 新增服务层测试，锁住：
  - 创建成功时返回小组编号
  - 后端报错时把真实错误文案透出来
  - 返回体缺少具体错误时，仍有稳定 fallback 提示

## 为什么现在做

发布链路当前还在等新的 GitHub Release / TestFlight 证据覆盖 `#169` / `#174`，这段等待窗口不应该空着。

这次补丁是一个低风险、小步、可回滚的诊断增强：

- 不改后端协议
- 不改数据库结构
- 不影响已有成功路径
- 但可以显著减少 `#145` 这类“按钮没反应却看不出根因”的排障盲区

## 验证

- 新增 `fabushi/test/unit/services/co_practice_service_test.dart`
- 覆盖成功返回、后端显式错误、以及无错误文案时的 fallback 三条路径

Part of #145