### PR TITLE
fix: restore Android Alipay callback scheme parity

### DIFF
--- a/fabushi/android/app/src/main/AndroidManifest.xml
+++ b/fabushi/android/app/src/main/AndroidManifest.xml
@@ -96,6 +96,14 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <!-- Tobias SDK 回调 scheme，需与 pubspec 中的 url_scheme 保持一致 -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="fabushi"/>
+            </intent-filter>
             
             <!-- 支付宝登录回调深度链接 -->
             <intent-filter>

--- a/fabushi/lib/screens/douyin_login_screen.dart
+++ b/fabushi/lib/screens/douyin_login_screen.dart
@@ -32,6 +32,7 @@ class AlipayInAppBrowser extends InAppBrowser {
     // 拦截自定义 URL Scheme 重定向
     if (url.startsWith('com.ombhrum.fabushi://') ||
         url.startsWith('globaldharma://') ||
+        url.startsWith('fabushi://') ||
         url.startsWith('alipays://')) {
       debugPrint('拦截到 App Scheme 重定向，关闭浏览器并处理回调');
       onDeepLinkCaptured(url);
@@ -433,7 +434,8 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
 
       String urlWithoutScheme = decodedUrl
           .replaceFirst('com.ombhrum.fabushi://', '')
-          .replaceFirst('globaldharma://', '');
+          .replaceFirst('globaldharma://', '')
+          .replaceFirst('fabushi://', '');
 
       final queryParams = urlWithoutScheme.split('&');
       for (final param in queryParams) {

--- a/fabushi/lib/services/platform_service.dart
+++ b/fabushi/lib/services/platform_service.dart
@@ -143,9 +143,10 @@ class NativePlatformService implements PlatformService {
   void _handleDeepLink(String url) {
     debugPrint('NativePlatformService: 处理深度链接URL: $url');
 
-    // 检查是否是支付宝回调
+    // Tobias SDK 在 Android 上回调到 pubspec 里声明的 url_scheme。
     if (url.startsWith('com.ombhrum.fabushi://') ||
-        url.startsWith('globaldharma://')) {
+        url.startsWith('globaldharma://') ||
+        url.startsWith('fabushi://')) {
       if (_messageHandler != null) {
         _messageHandler!(url);
       }


### PR DESCRIPTION
## 为什么改

`#130` 反馈是“安卓端支付宝登录失败，苹果端可正常登录”。这轮主控继续下钻支付登录链路后，定位到一个很像根因的 scheme 断裂点：

- Flutter `pubspec.yaml` 里的 Tobias SDK `url_scheme` 配置是 `fabushi`
- 但 Android `AndroidManifest.xml` 只声明了 `com.ombhrum.fabushi` 和 `globaldharma` 两个 deep link scheme
- Flutter 侧原生 deep-link 监听与登录回调解析，也只识别 `com.ombhrum.fabushi://` 和 `globaldharma://`

这意味着只要支付宝 SDK 在 Android 上按 Tobias 配置回到 `fabushi://...`，当前应用就可能出现两层接不住：

1. Android Activity 本身没有声明 `fabushi` intent filter
2. 就算链接被其他方式送到 Flutter，`PlatformService` 和登录页解析器也会把它当成非授权回调直接忽略

这组错位很能解释“苹果端正常、安卓端失败”：iOS 走的是另一套 URL scheme / SDK 配置，而 Android 这边的 Tobias 回调链路没有和仓库当前配置保持一致。

## 这次改了什么

- 在 `fabushi/android/app/src/main/AndroidManifest.xml` 补上 `fabushi` scheme 的 `VIEW` intent filter
- 在 `fabushi/lib/services/platform_service.dart` 让原生深链接监听接受 `fabushi://`
- 在 `fabushi/lib/screens/douyin_login_screen.dart` 让 WebView 拦截器和回调解析器都接受并解析 `fabushi://`

## 为什么现在做

- 当前没有打开的 PR 堵在主链上，发布链路也已重新拿到新的 public release / TestFlight 证据
- 这时最合适的等待窗口升级，就是把高价值、低侵入、易复核的用户登录阻塞继续往前推
- 这次修复不改后端授权协议、不改数据库，只补齐 Android 端 callback scheme 接收链路，风险收敛

## 验证

- 结构验证：Android 清单、原生深链监听、Flutter 登录回调解析三处现在都已覆盖 `fabushi://`
- 行为预期：若 Tobias SDK 在 Android 上按 `url_scheme: fabushi` 回调，应用不再因为 scheme 未注册/未识别而静默失败
- 当前执行环境没有本地 Flutter/Android 可运行检出，因此本轮以代码链路一致性审查作为提交前验证；后续请在 PR checks 与 Android 实机登录复测中继续确认

Fixes #130