### PR TITLE
fix: surface co-practice group discovery errors in app

### DIFF
--- a/fabushi/lib/services/co_practice_service.dart
+++ b/fabushi/lib/services/co_practice_service.dart
@@ -29,6 +29,33 @@ class CoPracticeGroupCreationResult {
   bool get isSuccess => groupId != null;
 }
 
+class CoPracticeGroupSearchResult {
+  final List<CoPracticeGroup> groups;
+  final String? errorMessage;
+  final int? statusCode;
+
+  const CoPracticeGroupSearchResult._({
+    required this.groups,
+    this.errorMessage,
+    this.statusCode,
+  });
+
+  const CoPracticeGroupSearchResult.success(List<CoPracticeGroup> groups)
+    : this._(groups: groups);
+
+  const CoPracticeGroupSearchResult.failure(
+    String errorMessage, {
+    int? statusCode,
+  }) : this._(
+         groups: const [],
+         errorMessage: errorMessage,
+         statusCode: statusCode,
+       );
+
+  bool get hasError =>
+      errorMessage != null && errorMessage!.trim().isNotEmpty;
+}
+
 class CoPracticeService {
   static final CoPracticeService _instance = CoPracticeService._internal();
   factory CoPracticeService({
@@ -79,23 +106,41 @@ class CoPracticeService {
     String query = '',
     int limit = 30,
   }) async {
-    final baseUrl = await _baseUrl;
-    final uri = Uri.parse(
-      '$baseUrl/api/meditation/groups',
-    ).replace(queryParameters: {'query': query, 'limit': limit.toString()});
-    final response = await _httpClient.get(uri, headers: await _headers());
-    if (response.statusCode != 200) return [];
+    final result = await searchGroupsWithStatus(query: query, limit: limit);
+    return result.groups;
+  }
 
-    final data = _decodeJsonMap(response.body);
-    if (data['success'] != true) return [];
+  Future<CoPracticeGroupSearchResult> searchGroupsWithStatus({
+    String query = '',
+    int limit = 30,
+  }) async {
+    try {
+      final baseUrl = await _baseUrl;
+      final uri = Uri.parse(
+        '$baseUrl/api/meditation/groups',
+      ).replace(queryParameters: {'query': query, 'limit': limit.toString()});
+      final response = await _httpClient.get(uri, headers: await _headers());
+      final data = _decodeJsonMap(response.body);
+      if (response.statusCode != 200 || data['success'] != true) {
+        return CoPracticeGroupSearchResult.failure(
+          _extractErrorMessage(data, fallback: '获取共修小组失败'),
+          statusCode: response.statusCode,
+        );
+      }
 
-    final groups = data['data']?['groups'] as List<dynamic>? ?? [];
-    return groups
-        .map(
-          (item) =>
-              CoPracticeGroup.fromJson(Map<String, dynamic>.from(item as Map)),
-        )
-        .toList();
+      final groups = (data['data']?['groups'] as List<dynamic>? ?? [])
+          .map(
+            (item) => CoPracticeGroup.fromJson(
+              Map<String, dynamic>.from(item as Map),
+            ),
+          )
+          .toList();
+      return CoPracticeGroupSearchResult.success(groups);
+    } catch (_) {
+      return const CoPracticeGroupSearchResult.failure(
+        '获取共修小组失败，请检查网络后重试',
+      );
+    }
   }
 
   Future<CoPracticeGroupCreationResult> createGroup({

--- a/fabushi/lib/widgets/co_practice_group_panel.dart
+++ b/fabushi/lib/widgets/co_practice_group_panel.dart
@@ -15,7 +15,7 @@ class CoPracticeGroupPanel extends StatefulWidget {
 class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
   final _service = CoPracticeService();
   final _searchController = TextEditingController();
-  late Future<List<CoPracticeGroup>> _future;
+  late Future<CoPracticeGroupSearchResult> _future;
   Timer? _debounce;
 
   @override
@@ -31,8 +31,8 @@ class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
     super.dispose();
   }
 
-  Future<List<CoPracticeGroup>> _load() {
-    return _service.searchGroups(query: _searchController.text.trim());
+  Future<CoPracticeGroupSearchResult> _load() {
+    return _service.searchGroupsWithStatus(query: _searchController.text.trim());
   }
 
   void _refresh() {
@@ -152,7 +152,7 @@ class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
         ),
         const SizedBox(height: 12),
         Expanded(
-          child: FutureBuilder<List<CoPracticeGroup>>(
+          child: FutureBuilder<CoPracticeGroupSearchResult>(
             future: _future,
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
@@ -161,7 +161,16 @@ class _CoPracticeGroupPanelState extends State<CoPracticeGroupPanel> {
                 );
               }
 
-              final groups = snapshot.data ?? [];
+              final result = snapshot.data;
+              final groups = result?.groups ?? [];
+              if (result?.hasError == true && groups.isEmpty) {
+                return _GroupLoadError(
+                  message: result!.errorMessage!,
+                  statusCode: result.statusCode,
+                  onRetry: _refresh,
+                );
+              }
+
               if (groups.isEmpty) {
                 return const Center(
                   child: Text(
@@ -398,6 +407,68 @@ class _WarningStrip extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _GroupLoadError extends StatelessWidget {
+  final String message;
+  final int? statusCode;
+  final VoidCallback onRetry;
+
+  const _GroupLoadError({
+    required this.message,
+    required this.statusCode,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final detail = statusCode == null ? message : 'HTTP $statusCode · $message';
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              color: Colors.orange,
+              size: 30,
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              '小组列表暂时加载失败',
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              detail,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white60,
+                fontSize: 12,
+                height: 1.45,
+              ),
+            ),
+            const SizedBox(height: 14),
+            OutlinedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh, color: Color(0xFFD4AF37)),
+              label: const Text(
+                '重新加载',
+                style: TextStyle(color: Color(0xFFD4AF37)),
+              ),
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: Color(0xFFD4AF37)),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/fabushi/test/unit/services/co_practice_service_test.dart
+++ b/fabushi/test/unit/services/co_practice_service_test.dart
@@ -16,6 +16,50 @@ void main() {
     );
   }
 
+  test('searchGroupsWithStatus returns groups on success', () async {
+    final service = createService(
+      MockClient((request) async {
+        expect(request.method, 'GET');
+        expect(request.url.path, '/api/meditation/groups');
+        expect(request.url.queryParameters['query'], '晨课');
+        expect(request.headers['Authorization'], 'Bearer test-token');
+        return http.Response(
+          '{"success":true,"data":{"groups":[{"id":21,"name":"晨课共修","description":"每天一起完成早课","ownerUsername":"owner1","ownerName":"发起人","requireApproval":true,"dailyGoalMinutes":30,"cumulativeMissLimit":7,"consecutiveMissLimit":3,"memberCount":5,"pendingCount":2,"totalDuration":180,"todayDuration":45}]}}',
+          200,
+          headers: const {'content-type': 'application/json'},
+        );
+      }),
+    );
+
+    final result = await service.searchGroupsWithStatus(query: '晨课');
+
+    expect(result.hasError, isFalse);
+    expect(result.statusCode, isNull);
+    expect(result.groups, hasLength(1));
+    expect(result.groups.single.name, '晨课共修');
+    expect(result.groups.single.ownerName, '发起人');
+    expect(result.groups.single.publicCode, '000021');
+  });
+
+  test('searchGroupsWithStatus surfaces backend error messages', () async {
+    final service = createService(
+      MockClient(
+        (_) async => http.Response(
+          '{"success":false,"error":"meditation_groups 表尚未完成迁移"}',
+          500,
+          headers: const {'content-type': 'application/json'},
+        ),
+      ),
+    );
+
+    final result = await service.searchGroupsWithStatus(query: '晨课');
+
+    expect(result.hasError, isTrue);
+    expect(result.groups, isEmpty);
+    expect(result.statusCode, 500);
+    expect(result.errorMessage, 'meditation_groups 表尚未完成迁移');
+  });
+
   test('createGroup returns group id on success', () async {
     final service = createService(
       MockClient((request) async {


### PR DESCRIPTION
## 为什么改

`#145` 这轮继续往下拆时，剩下一个很影响定位的现象：

- 非创建者进入“小组排行”时，页面可能直接是空白/空列表
- 但当前客户端把两种完全不同的状态都渲染成同一个结果：`暂无共修小组`
  - 真的没有小组
  - 搜索/列表接口其实已经报错

这会让后续复测很难区分：到底是数据确实为空，还是后端返回了迁移/鉴权/权限类错误但被前端吞掉了。

## 这次改了什么

- 给 `CoPracticeService` 新增 `CoPracticeGroupSearchResult`
  - 保留 `groups`
  - 同时保留 `errorMessage` 和 `statusCode`
- 保持现有 `searchGroups(...)` 兼容，同时新增 `searchGroupsWithStatus(...)`
- `CoPracticeGroupPanel` 现在会区分：
  - 接口成功但没有小组：继续显示 `暂无共修小组`
  - 接口失败且没有结果：显示明确的加载失败提示、HTTP 状态和重试按钮
- 新增单元测试，锁住：
  - 搜索成功时返回小组数据
  - 搜索失败时透出后端错误文案

## 为什么现在做

这一步不是宣称 `#145` 的排行榜可见性根因已经完全修掉，而是把“错误被伪装成空列表”的排障盲区先消掉。

这样下一次如果非创建者仍然看不到小组，界面至少会直接告诉我们是：

- 真没有数据
- 还是后端接口返回了明确错误

这会让后续继续追 `#145` 的真实根因更快、更准。

## 验证

- 新增 `fabushi/test/unit/services/co_practice_service_test.dart` 覆盖搜索成功和失败透传
- UI 行为验证：空列表与接口失败现在不再共用同一个空状态

Part of #145