### PR TITLE
ci: run JavaScript CI lanes on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Check Worker JavaScript syntax
         shell: bash
@@ -276,7 +276,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install E2E dependencies
         run: npm ci
@@ -302,7 +302,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## 为什么改

这一轮主控推进里，当前最直接挡住主链的是 `PR #185` 对应 merge queue 的 `CI #380`。失败日志已经收敛到同一个点：

- 失败 job：`Cloudflare Worker syntax and deploy dry-run`
- 失败步骤：`Run Worker contract tests`
- 运行时：`actions/setup-node@v6` 明确安装的是 `node: v22.22.2`
- 失败表现：`tests/profile.test.js` 在 GitHub Actions 的 Node 22 test runner 中抛出 `Unable to deserialize cloned data due to invalid or unsupported version.`

同时，这次 PR 自身改动只涉及 Flutter 端共修小组错误展示，和 Worker 代码并不重叠，说明 merge queue 当前踩到的是主线 CI JavaScript 运行时兼容性问题，而不是 `#185` 的业务回归。

## 这次改了什么

只改 `.github/workflows/ci.yml`，把 CI 里 3 条 JavaScript 工位统一从 Node 22 升到 Node 24：

- `worker`
- `e2e-contract`
- `frontend`

## 为什么这样修

- 当前 `ci.yml` 已经显式设置 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`，说明仓库已经在收口 GitHub Actions 的 Node 24 切换。
- 本地按 Worker contract tests 的最小复现链路在当前 Node 24 环境可以稳定通过，说明根因更接近 Node 22 runner 兼容性，而不是业务代码本身坏掉。
- `deploy-production.yml` / `publish-cd-release.yml` 也已经在 workflow 级启用了 Node 24 action runtime；这次把主线 `CI` 的 JavaScript 执行版本一起统一，能减少不同工位运行时漂移。

## 风险与范围

- 不改 Flutter、Worker、前端业务逻辑
- 不改测试断言
- 只调整 CI JavaScript 工位的 Node 主版本

## 验证

- 本地最小复现：`tests/profile.test.js` 在当前 Node 24 环境通过
- 以该 PR 的 GitHub Actions 结果作为仓库侧最终验证

Refs #186
Unblocks #185