### PR TITLE
feat: deploy official site to Cloudflare Worker

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -1,0 +1,83 @@
+name: Deploy official site to Cloudflare Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/**
+      - .github/workflows/deploy-official-site-cloudflare.yml
+  release:
+    types:
+      - published
+      - edited
+  workflow_run:
+    workflows:
+      - Sync official site beta download state
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: deploy-official-site-cloudflare
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: cloudflare-worker
+      url: https://fabushi.ombhrum.com
+    steps:
+      - name: Checkout official site source
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /frontend/**
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.9.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build official site
+        working-directory: frontend
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+          NEXT_PUBLIC_SITE_ORIGIN: ${{ vars.OFFICIAL_SITE_ORIGIN || 'https://fabushi.ombhrum.com' }}
+          NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_REPO: ${{ vars.OFFICIAL_SITE_RELEASE_REPO || github.repository }}
+          NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL: ${{ vars.IOS_TESTFLIGHT_PUBLIC_URL || '' }}
+        run: pnpm build:web
+
+      - name: Deploy official site to Cloudflare Worker
+        working-directory: frontend
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "Cloudflare credentials are not configured. Set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID." >&2
+            exit 1
+          fi
+
+          npx --yes wrangler@latest deploy \
+            --name fabushi-official-site \
+            --assets apps/web/out \
+            --compatibility-date 2026-05-06 \
+            --domain fabushi.ombhrum.com

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -1,4 +1,6 @@
-const RELEASES_API_URL = "https://api.github.com/repos/bhrumom/fabushi/releases?per_page=8";
+const officialSiteReleaseRepo = process.env.NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_REPO?.trim() || "bhrum/fabushi";
+const iosTestFlightPublicUrl = process.env.NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL?.trim() || "";
+const RELEASES_API_URL = `https://api.github.com/repos/${officialSiteReleaseRepo}/releases?per_page=8`;
 
 const DEFAULT_MIRROR_BASES = [
   {
@@ -280,17 +282,20 @@ async function buildFallbackBetaState(release: GitHubRelease): Promise<OfficialS
   const testFlightStatus = await loadTestFlightStatus(release);
   if (testFlightStatus) {
     const uploaded = testFlightStatus.status === "uploaded";
+    const primaryHref = uploaded && iosTestFlightPublicUrl ? iosTestFlightPublicUrl : release.html_url;
     channels.push({
       platform: "iOS",
       audience: "beta",
       status: uploaded ? "TestFlight 构建已上传" : "等待 TestFlight 可加入",
       title: "iOS TestFlight Beta",
       description:
-        uploaded
-          ? "iOS beta 已经上传到 TestFlight。下一次 beta 同步工作流完成后，这里会显示直接加入链接。"
+        uploaded && iosTestFlightPublicUrl
+          ? "iOS beta 已经上传到 TestFlight，点击即可打开公开加入页面。"
+          : uploaded
+            ? "iOS beta 已经上传到 TestFlight。配置公开加入链接后，这里会显示直接加入入口。"
           : "iOS beta 会在 TestFlight 上传成功后自动补到官网入口。",
-      primaryLabel: uploaded ? "查看 Beta 发布说明" : "等待 TestFlight 开放",
-      primaryHref: release.html_url,
+      primaryLabel: uploaded && iosTestFlightPublicUrl ? "加入 iOS TestFlight" : uploaded ? "查看 Beta 发布说明" : "等待 TestFlight 开放",
+      primaryHref,
       version: testFlightStatus.build_number || release.tag_name,
       publishedAt: testFlightStatus.uploaded_at || release.published_at || undefined,
       updateSummary: summary,
@@ -298,6 +303,8 @@ async function buildFallbackBetaState(release: GitHubRelease): Promise<OfficialS
       note:
         testFlightStatus.reason === "app_store_connect_credentials_not_configured"
           ? "当前仓库还没有配置 App Store Connect 上传凭据。"
+          : uploaded && iosTestFlightPublicUrl
+            ? "点击后会打开 Apple TestFlight 的公开加入页面。"
           : uploaded
             ? "一旦公开 TestFlight 加入链接被同步进发布资产，这里会自动切成可直接加入。"
             : "当前还没有可公开加入的 TestFlight 入口。",


### PR DESCRIPTION
## Summary
- add Cloudflare Worker deployment workflow for the official site
- trigger official site deployment after release publication and beta state sync
- let the download page use the configured public TestFlight URL when release assets are immutable

## Verification
- validated workflow YAML locally
- deployed and verified https://fabushi.ombhrum.com/download/ shows Android APK and iOS TestFlight join link