### PR TITLE
fix: read latest installed build number in app feedback

### DIFF
--- a/fabushi/lib/screens/settings_screen.dart
+++ b/fabushi/lib/screens/settings_screen.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'keep_alive_guide_screen.dart';
 import 'practice_privacy_screen.dart';
+import '../core/constants/app_constants.dart';
 import '../services/api_client.dart';
+import '../services/app_build_info_service.dart';
 import '../services/app_settings.dart';
 import '../services/llm_model_config.dart';
 import '../services/llm_model_manager.dart';
@@ -25,6 +27,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _defaultTtsMuted = true;
   bool _isLoading = true;
   bool _isSubmittingFeedback = false;
+  String _appVersionLabel = AppConstants.appVersion;
 
   // 读诵匹配阈值（百分比形式，0.0 ~ 1.0）
   double _fastMatchThreshold = 0.50;
@@ -96,6 +99,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final defaultMuted = await AppSettings.getDefaultTtsMuted();
     final fastMatchThreshold = await AppSettings.getFastMatchThreshold();
     final matchThreshold = await AppSettings.getMatchThreshold();
+    final appVersionLabel = await AppBuildInfoService.instance.getVersionLabel();
 
     // 加载 AI 模型相关设置
     final deviceInfo = await DeviceCapabilityService.instance
@@ -116,6 +120,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _defaultTtsMuted = defaultMuted;
         _fastMatchThreshold = fastMatchThreshold;
         _matchThreshold = matchThreshold;
+        _appVersionLabel = appVersionLabel;
         _deviceInfo = deviceInfo;
         _modelStatus = modelStatus;
         _selectedModel = selectedModel;
@@ -164,6 +169,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         if (contact.trim().isNotEmpty) 'contact': contact.trim(),
         'page': 'settings_screen',
         'platform': _feedbackPlatformLabel(),
+        'appVersion': _appVersionLabel,
       },
       token: authModel.authToken,
     );
@@ -242,6 +248,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       const Text(
                         '问题会自动同步到 GitHub Issue，方便后续跟进。',
                         style: TextStyle(color: Colors.white70, fontSize: 13),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '当前版本：$_appVersionLabel',
+                        style: const TextStyle(color: Colors.white54, fontSize: 12),
                       ),
                       const SizedBox(height: 16),
                       TextField(
@@ -477,11 +488,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     icon: Icons.info_outline,
                     iconColor: Colors.blue,
                     title: '关于',
-                    subtitle: '版本 1.0.0',
+                    subtitle: '版本 $_appVersionLabel',
                     onTap: () => showAboutDialog(
                       context: context,
-                      applicationName: '大乘',
-                      applicationVersion: '1.0.0',
+                      applicationName: AppConstants.appName,
+                      applicationVersion: _appVersionLabel,
                       children: [const Text('传播佛法，利益众生')],
                     ),
                   ),

--- a/fabushi/lib/services/app_build_info_service.dart
+++ b/fabushi/lib/services/app_build_info_service.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../core/constants/app_constants.dart';
+
+class AppBuildInfo {
+  const AppBuildInfo({
+    required this.appName,
+    required this.version,
+    required this.buildNumber,
+  });
+
+  final String appName;
+  final String version;
+  final String buildNumber;
+
+  String get versionLabel {
+    final normalizedVersion = version.trim();
+    final normalizedBuildNumber = buildNumber.trim();
+
+    if (normalizedVersion.isEmpty) {
+      return normalizedBuildNumber.isEmpty
+          ? AppConstants.appVersion
+          : normalizedBuildNumber;
+    }
+
+    if (normalizedBuildNumber.isEmpty ||
+        normalizedVersion.endsWith('+$normalizedBuildNumber')) {
+      return normalizedVersion;
+    }
+
+    return '$normalizedVersion+$normalizedBuildNumber';
+  }
+}
+
+class AppBuildInfoService {
+  AppBuildInfoService._();
+
+  static final AppBuildInfoService instance = AppBuildInfoService._();
+
+  AppBuildInfo? _cachedInfo;
+
+  Future<AppBuildInfo> getBuildInfo() async {
+    final cachedInfo = _cachedInfo;
+    if (cachedInfo != null) {
+      return cachedInfo;
+    }
+
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      final buildInfo = AppBuildInfo(
+        appName: packageInfo.appName.trim().isEmpty
+            ? AppConstants.appName
+            : packageInfo.appName.trim(),
+        version: packageInfo.version.trim(),
+        buildNumber: packageInfo.buildNumber.trim(),
+      );
+      _cachedInfo = buildInfo;
+      return buildInfo;
+    } catch (error) {
+      debugPrint('读取应用构建信息失败，回退到静态版本号: $error');
+      final fallbackInfo = _fallbackBuildInfo();
+      _cachedInfo = fallbackInfo;
+      return fallbackInfo;
+    }
+  }
+
+  Future<String> getVersionLabel() async {
+    return (await getBuildInfo()).versionLabel;
+  }
+
+  AppBuildInfo _fallbackBuildInfo() {
+    final rawVersion = AppConstants.appVersion.trim();
+    final separatorIndex = rawVersion.lastIndexOf('+');
+
+    if (separatorIndex <= 0 || separatorIndex == rawVersion.length - 1) {
+      return AppBuildInfo(
+        appName: AppConstants.appName,
+        version: rawVersion,
+        buildNumber: '',
+      );
+    }
+
+    return AppBuildInfo(
+      appName: AppConstants.appName,
+      version: rawVersion.substring(0, separatorIndex),
+      buildNumber: rawVersion.substring(separatorIndex + 1),
+    );
+  }
+}

--- a/fabushi/lib/services/error_report_service.dart
+++ b/fabushi/lib/services/error_report_service.dart
@@ -5,8 +5,8 @@ import 'dart:ui';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 
-import '../core/constants/app_constants.dart';
 import 'api_client.dart';
+import 'app_build_info_service.dart';
 import 'worker_config.dart';
 
 class AppErrorReport {
@@ -183,7 +183,7 @@ class ErrorReportService {
       stage: stage,
       source: source,
       platform: _platformLabel(),
-      appVersion: AppConstants.appVersion,
+      appVersion: await AppBuildInfoService.instance.getVersionLabel(),
       occurredAt: DateTime.now().toUtc(),
       fatal: fatal,
       deviceSummary: await _collectDeviceSummary(),

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   # 本地存储
   shared_preferences: ^2.2.2
   path_provider: ^2.0.15
+  package_info_plus: ^8.3.1
 
   # 文件处理
   file_picker: ^10.3.3


### PR DESCRIPTION
## 为什么改

app 内多个反馈入口仍在使用写死的版本号 `1.0.0+16`。这会让用户明明已经装了新的发布包，但 GitHub Issue 里仍然回传旧构建号，直接干扰线上问题归因、发布覆盖判断和 TestFlight / Release 对账。

## 这次改了什么

- 新增 `AppBuildInfoService`，统一通过运行时包信息读取当前安装版本与构建号
- 设置页普通反馈提交时，改为附带当前安装包的最新构建号
- 启动异常、资料编辑失败等自动反馈链路，改为复用同一套运行时构建号读取
- 设置页“关于”与反馈弹窗同步显示当前版本，避免界面继续显示旧值
- `pubspec.yaml` 补充 `package_info_plus` 依赖，用于跨平台读取包版本信息

## 为什么这样做

- 反馈里的 build number 应该反映用户手上正在运行的包，而不是仓库里某个过时常量
- 统一做成服务后，后续新增反馈入口也不会再各自写死版本号
- 对 iOS TestFlight、Android 包和 Web 版本信息都沿用现成平台能力，减少人为维护漂移

## 验证

- 分支对比确认只修改了 4 个相关文件：设置页、错误上报服务、版本信息服务、`pubspec.yaml`
- 普通反馈与自动诊断反馈现在都会携带运行时 `appVersion`
- 当前环境没有本地 Flutter / Dart 命令可用，无法在这里执行 `flutter pub get`、`dart format` 或 `flutter analyze`
- 依赖解析与平台构建请以 PR CI 为最终验证结果
