### PR TITLE
docs: clarify queue-only merge handling in release controller

### DIFF
--- a/docs/release-controller.md
+++ b/docs/release-controller.md
@@ -46,6 +46,29 @@
 - PR 描述里说明为什么改、改了什么、如何验证、如何防复发
 - PR 合并后仍需继续回追 mainline CI / CD / Release / TestFlight
 
+### Merge Queue 重叠改动处理规则
+
+当多个 open PR 同时修改同一组文件、同一条用户路径或同一个回归主题时，不要把它们当成彼此独立的绿灯直接一起送进 merge queue。
+
+默认处理方式：
+
+- 先判断谁是主阻塞修复，谁是非阻塞补强或体验优化
+- 如果后者可能覆盖前者的文件或行为，就先暂停后者的自动推进，再等待前者落主线
+- 前一个 PR 合入后，再让后一个 PR 基于最新 `main` 重新确认差异、checks 和合并顺序
+- 在 PR 线程或相关 issue 中明确记录这种顺序安排，避免后续巡检误把“都在排队”当成低风险状态
+
+### Queue-only 仓库合并推进规则
+
+当 direct merge 被仓库规则拒绝，并明确提示 `Changes must be made through the merge queue` 时，默认按“queue 是当前唯一剩余主线 gate”处理，而不是把 head checks 已绿误判成已经完成。
+
+默认处理方式：
+
+- 立即切换到 `auto-merge` 或等效 merge queue 路径，不让 PR 停在“绿了但没人继续推”的状态
+- 在 PR 线程或相关 issue 里明确记录：当前已无代码或评审阻塞，剩余 gate 是 merge queue 本身
+- 在 PR 真正 `merged` 之前，不关闭对应修复 issue，也不宣称问题已经进入主线
+- 等待 queue 外部结果期间，立即切去其他工位推进事项或新的小步升级；一旦 queue 出现 merge / fail 新信号，再立刻切回
+- PR 真正 merged 后，继续按 `main -> CI -> CD -> GitHub Release -> TestFlight` 顺序复核，而不是把 queue 放行为最终终点
+
 ### 3. Issue 治理工位
 
 负责：

--- a/docs/release-controller.md
+++ b/docs/release-controller.md
@@ -65,6 +65,7 @@
 
 - 立即切换到 `auto-merge` 或等效 merge queue 路径，不让 PR 停在“绿了但没人继续推”的状态
 - 在 PR 线程或相关 issue 里明确记录：当前已无代码或评审阻塞，剩余 gate 是 merge queue 本身
+- 对 queue 状态的判断优先以 PR 页面、merge queue 事件和后续 mainline 结果为准，不把“曾经 enable auto-merge”本身当成完成证据
 - 在 PR 真正 `merged` 之前，不关闭对应修复 issue，也不宣称问题已经进入主线
 - 等待 queue 外部结果期间，立即切去其他工位推进事项或新的小步升级；一旦 queue 出现 merge / fail 新信号，再立刻切回
 - PR 真正 merged 后，继续按 `main -> CI -> CD -> GitHub Release -> TestFlight` 顺序复核，而不是把 queue 放行为最终终点

--- a/docs/release-controller.md
+++ b/docs/release-controller.md
@@ -66,6 +66,7 @@
 - 立即切换到 `auto-merge` 或等效 merge queue 路径，不让 PR 停在“绿了但没人继续推”的状态
 - 在 PR 线程或相关 issue 里明确记录：当前已无代码或评审阻塞，剩余 gate 是 merge queue 本身
 - 对 queue 状态的判断优先以 PR 页面、merge queue 事件和后续 mainline 结果为准，不把“曾经 enable auto-merge”本身当成完成证据
+- 对“历史 head 曾经绿过”和“当前 head 已满足必需门禁”要分开判断，避免拿旧提交的绿灯误替代最新提交的 queue 准入条件
 - 在 PR 真正 `merged` 之前，不关闭对应修复 issue，也不宣称问题已经进入主线
 - 等待 queue 外部结果期间，立即切去其他工位推进事项或新的小步升级；一旦 queue 出现 merge / fail 新信号，再立刻切回
 - PR 真正 merged 后，继续按 `main -> CI -> CD -> GitHub Release -> TestFlight` 顺序复核，而不是把 queue 放行为最终终点


### PR DESCRIPTION
## 为什么改

这一轮主控推进里，`PR #191` 的代码与 checks 都已经到位，但仓库规则仍然拒绝 direct merge，并明确要求通过 merge queue。

这暴露出一个长期容易被误判的点：

- `head checks` 全绿，不等于修复已经进入主线
- `auto-merge` 已开启，也不等于发布链已经闭环
- 对 queue-only 仓库来说，merge queue 本身就是需要继续跟踪的独立 gate

如果这条规则不写回仓库，后续巡检很容易重复出现两类偏差：

- 看到 PR 绿了，就把问题过早当成已完成
- 在 queue 等外部结果时没有及时切去推进别的工位事项

## 这次改了什么

- 更新 `docs/release-controller.md`
- 在 PR 推进工位下新增 `Queue-only 仓库合并推进规则`
- 明确要求：
  - direct merge 被 queue 规则拒绝后，立即切换到 `auto-merge` / merge queue 路径
  - 在 PR 真正 merged 前，不关闭对应修复 issue，也不宣称问题已进入主线
  - queue 等待期间要切去其他工位继续推进，而不是空等
  - PR merged 后仍需继续追 `main -> CI -> CD -> GitHub Release -> TestFlight`

## 为什么现在做

这是这轮已经真实发生的主控调度场景，不是抽象规范补充。它属于长期有效、应被版本管理的主控运行规则，应该同步回仓库，而不是只停留在 Memory 或当前会话里。

## 验证

- 仅修改文档 `docs/release-controller.md`
- 规则内容直接对应这轮 `PR #191` 被 merge queue 规则挡下后的实际处理方式
- 无运行时代码改动，交由仓库现有文档 / guardrail checks 继续验证