### PR TITLE
fix: normalize meditation auth before legacy handlers

### DIFF
--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -22,7 +22,45 @@ import { handleToggleFollow, handleGetFollowList, handleGetFollowSummary, handle
 import { handleBuiltinMigration, handleFullTextSearch, handleGetCategories as handleBuiltinCategories } from '../migrate-builtin-handler-fixed.js';
 import { handleReport, handleBlockUser, handleGetReports, handleReviewReport, handleGetBlocks } from './handlers/moderation.js';
 import { handleSubmitFeedback } from './handlers/feedback.js';
+import { verifyToken } from '../auth-utils.js';
 import { jsonResponse } from './utils/response.js';
+
+function createLegacyMeditationToken(username) {
+  const payload = btoa(JSON.stringify({ username }));
+  return `legacy.${payload}.signature`;
+}
+
+async function normalizeMeditationAuthRequest(request, env, pathname) {
+  if (!pathname.startsWith('/api/meditation/')) {
+    return { request };
+  }
+
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return { request };
+  }
+
+  try {
+    const tokenData = await verifyToken(authHeader.substring(7), env);
+    const username = tokenData?.username || tokenData?.sub;
+    if (!username) {
+      return {
+        response: jsonResponse({ success: false, error: '认证失败，请重新登录' }, 401),
+      };
+    }
+
+    const headers = new Headers(request.headers);
+    headers.set('Authorization', `Bearer ${createLegacyMeditationToken(username)}`);
+    return {
+      request: new Request(request, { headers }),
+    };
+  } catch (error) {
+    console.warn('修行接口认证预处理失败:', error);
+    return {
+      response: jsonResponse({ success: false, error: '认证失败，请重新登录' }, 401),
+    };
+  }
+}
 
 export async function route(request, env, db, ctx) {
   const url = new URL(request.url);
@@ -37,6 +75,12 @@ export async function route(request, env, db, ctx) {
   if (pathname === '/health') {
     return jsonResponse({ status: 'ok', timestamp: new Date().toISOString() });
   }
+
+  const normalizedMeditationAuth = await normalizeMeditationAuthRequest(request, env, pathname);
+  if (normalizedMeditationAuth.response) {
+    return normalizedMeditationAuth.response;
+  }
+  request = normalizedMeditationAuth.request;
 
   // 短信验证码API (全平台支持)
   if (pathname === '/api/sms/send' && method === 'POST') return await handleSendSmsCode(request, env, db);

--- a/fabushi/web/tests/router-meditation-auth.test.js
+++ b/fabushi/web/tests/router-meditation-auth.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { generateToken } from '../auth-utils.js';
+import { route } from '../src/router.js';
+
+const TEST_ENV = { JWT_SECRET: 'test-secret' };
+
+function createDbMock() {
+  return {
+    prepare(sql) {
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+      return {
+        bind(...params) {
+          return {
+            async all() {
+              if (normalizedSql.startsWith('SELECT id, sutra_name, target_count, current_count, dedication, status, created_at, completed_at FROM meditation_goals WHERE username = ? AND status = ? ORDER BY created_at DESC')) {
+                assert.equal(params[0], 'meditator');
+                assert.equal(params[1], 'active');
+                return {
+                  results: [
+                    {
+                      id: 1,
+                      sutra_name: '心经',
+                      target_count: 108,
+                      current_count: 12,
+                      dedication: '回向众生',
+                      status: 'active',
+                      created_at: '2026-05-01T00:00:00Z',
+                      completed_at: null,
+                    },
+                  ],
+                };
+              }
+              return { results: [] };
+            },
+            async first() {
+              return null;
+            },
+            async run() {
+              return null;
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('router accepts signed JWTs on meditation endpoints by normalizing them for legacy handlers', async () => {
+  const token = await generateToken('meditator', TEST_ENV);
+  const response = await route(
+    new Request('https://flutter.ombhrum.com/api/meditation/goal?status=active', {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    TEST_ENV,
+    createDbMock(),
+    {},
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.goals.length, 1);
+  assert.equal(payload.data.goals[0].sutra_name, '心经');
+  assert.equal(payload.data.goals[0].progress, 11);
+});
+
+test('router rejects invalid signed JWTs before legacy meditation handlers can accept them', async () => {
+  const token = await generateToken('meditator', TEST_ENV);
+  const tampered = `${token.slice(0, -1)}${token.endsWith('a') ? 'b' : 'a'}`;
+  const response = await route(
+    new Request('https://flutter.ombhrum.com/api/meditation/goal?status=active', {
+      headers: { Authorization: `Bearer ${tampered}` },
+    }),
+    TEST_ENV,
+    createDbMock(),
+    {},
+  );
+
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assert.equal(payload.success, false);
+  assert.match(payload.error, /认证失败/);
+});


### PR DESCRIPTION
## 为什么改

用户新报的 `Issue #198` 提示“小组排行加载失败，401，token解析失败”，和更早的 `Issue #145` 中“非创建者看不到小组排行/搜索结果为空”的现象，已经收敛到同一条后端认证路径。

当前仓库里大多数接口都通过 `verifyToken` 校验签名后的 JWT，但 `meditation.js` 这组旧处理器仍在直接 `atob(parts[1])` 解析 payload：

- 对正常的 base64url JWT，这条旧路径会出现 `Token解析失败`
- 对被篡改但结构仍像 JWT 的 token，这条旧路径甚至可能误接收

这不是单一页面问题，而是整组修行 / 共修接口的认证实现漂移。

## 这次改了什么

- 在 `fabushi/web/src/router.js` 为 `/api/meditation/*` 增加统一认证预处理
- 先用仓库现有 `verifyToken` 校验签名 JWT
- 校验通过后，再把请求转换成旧处理器可识别的兼容 token，避免一次性大改整份 `meditation.js`
- 校验失败时直接在路由层返回 `401`，不再让旧处理器误接收篡改 token
- 新增 `fabushi/web/tests/router-meditation-auth.test.js` 覆盖：
  - 合法签名 token 可正常访问修行接口
  - 篡改 token 会被路由层拦截，而不是继续落到旧处理器

## 为什么这样做

这是一个高价值、小步、可回滚的等待窗口升级：

- 直接止住当前真实线上 401 故障
- 同时把 `Issue #145` 与 `Issue #198` 对应的认证根因统一治理
- 不需要在本轮把整份 `meditation.js` 全量重构，降低改动面
- 先把签名 JWT 和旧处理器之间的兼容层补上，再为后续彻底收口旧认证逻辑留出空间

## 验证

- 新增 `fabushi/web/tests/router-meditation-auth.test.js`
- 验证合法 JWT 能通过 `/api/meditation/goal`
- 验证篡改 JWT 会返回 `401`
- 其余修行接口仍通过原有 `meditation.js` 处理逻辑执行

## 关联

- Closes #198
- Related #145