### PR TITLE
docs: clarify no-head-check PR handling in release controller

### DIFF
--- a/docs/release-controller.md
+++ b/docs/release-controller.md
@@ -46,6 +46,17 @@
 - PR 描述里说明为什么改、改了什么、如何验证、如何防复发
 - PR 合并后仍需继续回追 mainline CI / CD / Release / TestFlight
 
+### 无 Head Checks PR 的推进规则
+
+对文档、运行手册、提示词映射或其他受路径过滤影响的 PR，可能会出现 `head SHA` 没有关联 workflow runs、combined status 为空的情况。
+
+默认处理方式：
+
+- 先区分这是“本来就不会触发检查”，还是“按仓库规则本应触发却没有触发”
+- 如果属于 docs-only / path-filter 场景，且仓库保护规则也没有要求额外 checks，就继续按 review / auto-merge / merge queue 路径推进
+- 这类 PR 在真正 `merged` 前，仍然属于等待中的 PR 事项，不能因为 checks 为空就误判成失败，也不能因为没有红灯就误判成已闭环
+- 如果按仓库规则本应触发检查却完全没有运行记录，就把它视为 workflow 覆盖缺口，回到根因修复模式，补齐触发条件、路径规则或门禁说明
+
 ### Merge Queue 重叠改动处理规则
 
 当多个 open PR 同时修改同一组文件、同一条用户路径或同一个回归主题时，不要把它们当成彼此独立的绿灯直接一起送进 merge queue。


### PR DESCRIPTION
## 为什么改

这轮主控推进里，`PR #196` 是一个只改 `docs/release-controller.md` 的文档类 PR。我在继续复核它的推进状态时，遇到了一个新的长期规则缺口：

- `head SHA` 没有关联 workflow runs
- combined status 也是空
- 这不自动等于失败
- 也不自动等于已经闭环

如果这条判断规则不写回仓库，后续 scheduled run 很容易重复出现两种误判：

- 看到 checks 为空，就把 docs-only PR 误判成异常
- 看到没有红灯，就把仍在等待 merge queue / auto-merge 的 PR 误判成已完成

## 这次改了什么

- 更新 `docs/release-controller.md`
- 在 PR 推进工位下新增 `无 Head Checks PR 的推进规则`
- 明确要求：
  - 先区分“本来就不会触发检查”和“本应触发却没有触发”
  - docs-only / path-filter 场景下，如果仓库保护规则也没有要求额外 checks，就继续按 review / auto-merge / merge queue 路径推进
  - 在真正 `merged` 前，不能因为 checks 为空就误判成失败，也不能误判成闭环
  - 如果按仓库规则本应触发检查却没有任何运行记录，要把它当成 workflow 覆盖缺口继续修

## 为什么现在做

这是这轮 `#196` 真实暴露出来的调度模式，不是抽象补充。它属于长期有效、应被版本管理的主控规则，应该同步回仓库。

## 顺序说明

- 这条 PR 与 `#196` 修改同一份文档
- 默认应先让 `#196` 落主线，再基于最新 `main` 收口这条补充规则
- 因此先保持 draft，避免和 `#196` 一起并行进入 merge queue

## 验证

- 仅修改文档 `docs/release-controller.md`
- 无运行时代码改动
- 规则内容直接对应这轮对 `PR #196` 的实际复核场景
