### PR TITLE
Fix profile update SQL transaction fallback

### DIFF
--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -15,13 +15,11 @@ class AppConfig {
   static bool get isProduction {
     if (kIsWeb) {
       final currentUrl = Uri.base.toString();
-      if (currentUrl.contains('fabushi-backend-dev') ||
-          currentUrl.contains('fabushi-flutter-web-dev') ||
+      if (currentUrl.contains('fabushi-flutter-web-dev') ||
           currentUrl.contains('localhost')) {
         return false;
       }
-      if (currentUrl.contains('fabushi-backend-prod') ||
-          currentUrl.contains('fabushi-flutter-web-prod')) {
+      if (currentUrl.contains('fabushi-flutter-web-prod')) {
         return true;
       }
     }
@@ -40,7 +38,7 @@ class AppConfig {
   static const String primaryBackendUrl = 'https://api.ombhrum.com';
   static const String cloudflareWorkerProdUrl = 'https://api.ombhrum.com';
   static const String cloudflareWorkerDevUrl =
-      'https://fabushi-backend-dev.bhrumom.workers.dev';
+      'https://fabushi-flutter-web-dev.bhrumom.workers.dev';
   static const String localDevUrl = 'http://localhost:8787';
   static const String publicWebUrl = 'https://flutter.ombhrum.com';
 
@@ -54,12 +52,10 @@ class AppConfig {
       if (host.contains('localhost')) {
         return localDevUrl;
       }
-      if (host.contains('fabushi-backend-dev') ||
-          host.contains('fabushi-flutter-web-dev')) {
+      if (host.contains('fabushi-flutter-web-dev')) {
         return cloudflareWorkerDevUrl;
       }
-      if (host.contains('fabushi-backend-prod') ||
-          host.contains('fabushi-flutter-web-prod')) {
+      if (host.contains('fabushi-flutter-web-prod')) {
         return cloudflareWorkerProdUrl;
       }
     }

--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -15,11 +15,13 @@ class AppConfig {
   static bool get isProduction {
     if (kIsWeb) {
       final currentUrl = Uri.base.toString();
-      if (currentUrl.contains('fabushi-flutter-web-dev') ||
+      if (currentUrl.contains('fabushi-backend-dev') ||
+          currentUrl.contains('fabushi-flutter-web-dev') ||
           currentUrl.contains('localhost')) {
         return false;
       }
-      if (currentUrl.contains('fabushi-flutter-web-prod')) {
+      if (currentUrl.contains('fabushi-backend-prod') ||
+          currentUrl.contains('fabushi-flutter-web-prod')) {
         return true;
       }
     }
@@ -31,23 +33,33 @@ class AppConfig {
   static bool get isWeb => kIsWeb;
 
   // API配置
-  static const String primaryBackendUrl = 'https://flutter.ombhrum.com';
-  static const String cloudflareWorkerProdUrl = 'https://flutter.ombhrum.com';
+  static const String configuredApiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: '',
+  );
+  static const String primaryBackendUrl = 'https://api.ombhrum.com';
+  static const String cloudflareWorkerProdUrl = 'https://api.ombhrum.com';
   static const String cloudflareWorkerDevUrl =
-      'https://fabushi-flutter-web-dev.bhrumom.workers.dev';
+      'https://fabushi-backend-dev.bhrumom.workers.dev';
   static const String localDevUrl = 'http://localhost:8787';
+  static const String publicWebUrl = 'https://flutter.ombhrum.com';
 
   static String get currentBackendUrl {
+    if (configuredApiBaseUrl.isNotEmpty) {
+      return configuredApiBaseUrl;
+    }
     if (kIsWeb) {
       final currentUrl = Uri.base;
       final host = currentUrl.host;
       if (host.contains('localhost')) {
         return localDevUrl;
       }
-      if (host.contains('fabushi-flutter-web-dev')) {
-        return '${currentUrl.scheme}://${currentUrl.authority}';
+      if (host.contains('fabushi-backend-dev') ||
+          host.contains('fabushi-flutter-web-dev')) {
+        return cloudflareWorkerDevUrl;
       }
-      if (host.contains('fabushi-flutter-web-prod')) {
+      if (host.contains('fabushi-backend-prod') ||
+          host.contains('fabushi-flutter-web-prod')) {
         return cloudflareWorkerProdUrl;
       }
     }

--- a/fabushi/lib/core/config/app_config_template.dart
+++ b/fabushi/lib/core/config/app_config_template.dart
@@ -19,12 +19,20 @@ class AppConfig {
   static bool get isStaging => environment == 'staging';
 
   // API配置
-  static const String productionApiUrl = 'https://ombhrum.com';
-  static const String stagingApiUrl = 'https://staging.ombhrum.com';
+  static const String configuredApiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: '',
+  );
+  static const String productionApiUrl = 'https://api.ombhrum.com';
+  static const String stagingApiUrl = 'https://staging-api.ombhrum.com';
   static const String developmentApiUrl = 'http://localhost:8787';
+  static const String publicWebUrl = 'https://flutter.ombhrum.com';
 
   // 根据环境获取API URL
   static String get apiUrl {
+    if (configuredApiBaseUrl.isNotEmpty) {
+      return configuredApiBaseUrl;
+    }
     switch (environment) {
       case 'production':
         return productionApiUrl;
@@ -52,7 +60,7 @@ class AppConfig {
   static const bool enableFirebaseAuth = true;
   static const bool enableAlipay = true;
   static const bool enableVideoFeed = true;
-  static const bool enableDebugMode = !isProduction;
+  static bool get enableDebugMode => !isProduction;
 
   // 传输配置
   static const int fileChunkSize = 1024;
@@ -262,6 +270,6 @@ class AppConfig {
 
   // 日志配置
   static const bool enableLogging = true;
-  static const bool enableNetworkLogging = !isProduction;
-  static const bool enablePerformanceLogging = !isProduction;
+  static bool get enableNetworkLogging => !isProduction;
+  static bool get enablePerformanceLogging => !isProduction;
 }

--- a/fabushi/lib/screens/asset_screen.dart
+++ b/fabushi/lib/screens/asset_screen.dart
@@ -296,10 +296,7 @@ class _AssetScreenState extends State<AssetScreen> {
     });
 
     try {
-      final String baseUrl = AppConfig.isProduction
-          ? AppConfig.cloudflareWorkerProdUrl
-          : AppConfig.cloudflareWorkerDevUrl;
-      final String url = '$baseUrl/r2?list';
+      final String url = '${AppConfig.currentBackendUrl}/r2?list';
 
       print('查询R2存储桶文件列表: $url');
 
@@ -490,18 +487,13 @@ class _AssetScreenState extends State<AssetScreen> {
       final String url;
 
       if (source == 'r2') {
-        final String baseUrl = AppConfig.isProduction
-            ? AppConfig.cloudflareWorkerProdUrl
-            : AppConfig.cloudflareWorkerDevUrl;
-        url = '$baseUrl/r2?file=${Uri.encodeComponent(assetPath)}';
+        url =
+            '${AppConfig.currentBackendUrl}/r2?file=${Uri.encodeComponent(assetPath)}';
       } else {
         if (kIsWeb) {
           url = '/$assetPath';
         } else {
-          final String baseUrl = AppConfig.isProduction
-              ? AppConfig.cloudflareWorkerProdUrl
-              : AppConfig.cloudflareWorkerDevUrl;
-          url = '$baseUrl/$assetPath';
+          url = '${AppConfig.currentBackendUrl}/$assetPath';
         }
       }
 

--- a/fabushi/lib/screens/membership_screen.dart
+++ b/fabushi/lib/screens/membership_screen.dart
@@ -1127,7 +1127,7 @@ class _MembershipScreenState extends State<MembershipScreen>
                       ),
                       TextButton(
                         onPressed: () => launchUrl(
-                          Uri.parse('https://flutter.ombhrum.com/privacy'),
+                          Uri.parse('${AppConfig.publicWebUrl}/privacy'),
                         ),
                         child: const Text(
                           '隐私政策',

--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -47,10 +47,10 @@ class _AssetCacheWrapper implements ClearableCache {
 /// 用于从 CDN 加载大型 3D 模型等资源,避免打包到应用中
 /// 实现断点续传和持久化缓存机制
 class AssetLoaderService {
-  static const String defaultCdnBaseUrl =
-      'https://flutter.ombhrum.com/r2?file=';
+  static String get defaultCdnBaseUrl =>
+      '${AppConfig.currentBackendUrl}/r2?file=';
 
-  static String cdnBaseUrl = defaultCdnBaseUrl;
+  static String get cdnBaseUrl => defaultCdnBaseUrl;
 
   // 内存缓存 (仅用于当前会话)
   static final Map<String, Uint8List> _memoryCache = {};

--- a/fabushi/lib/services/cloudflare_text_service.dart
+++ b/fabushi/lib/services/cloudflare_text_service.dart
@@ -10,7 +10,7 @@ import 'package:global_dharma_sharing/services/shared_asset_manager.dart';
 
 class CloudflareTextService {
   static final _random = Random();
-  static const String baseUrl = 'https://flutter.ombhrum.com';
+  static String get baseUrl => AppConfig.currentBackendUrl;
   static List<Map<String, dynamic>>? _cachedManifest;
   static final List<Map<String, dynamic>> _preloadQueue = [];
   static bool _isPreloading = false;

--- a/fabushi/lib/services/online_counter_service.dart
+++ b/fabushi/lib/services/online_counter_service.dart
@@ -3,12 +3,14 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+import '../core/config/app_config.dart';
 
 /// 在线人数服务 - WebSocket 版本
 /// 管理用户在线状态并提供实时人数统计
 class OnlineCounterService {
-  static const String baseUrl = 'https://flutter.ombhrum.com';
-  static const String wsUrl = 'wss://flutter.ombhrum.com';
+  static String get baseUrl => AppConfig.currentBackendUrl;
+  static String get wsUrl =>
+      AppConfig.currentBackendUrl.replaceFirst(RegExp(r'^http'), 'ws');
   static const Duration heartbeatInterval = Duration(seconds: 30);
   static const Duration reconnectDelay = Duration(seconds: 5);
 

--- a/fabushi/lib/services/shared_asset_manager.dart
+++ b/fabushi/lib/services/shared_asset_manager.dart
@@ -111,10 +111,7 @@ class SharedAssetManager {
       if (kIsWeb) {
         url = '/$cleanAssetPath';
       } else {
-        final String baseUrl = AppConfig.isProduction
-            ? AppConfig.cloudflareWorkerProdUrl
-            : AppConfig.cloudflareWorkerDevUrl;
-        url = '$baseUrl/$cleanAssetPath';
+        url = '${AppConfig.currentBackendUrl}/$cleanAssetPath';
       }
     } else {
       url =

--- a/fabushi/lib/services/text_search_service.dart
+++ b/fabushi/lib/services/text_search_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import '../core/config/app_config.dart';
 import '../utils/search_utils.dart';
 
 class TextItem {
@@ -50,7 +51,8 @@ class TextSearchService {
   List<TextItem> _items = [];
   bool _isIndexed = false;
 
-  TextSearchService({this.baseUrl = 'https://flutter.ombhrum.com'});
+  TextSearchService({String? baseUrl})
+    : baseUrl = baseUrl ?? AppConfig.currentBackendUrl;
 
   // 本地索引（用于离线搜索）
   Future<void> indexAssets() async {

--- a/fabushi/scripts/deploy/deploy-backend-only.sh
+++ b/fabushi/scripts/deploy/deploy-backend-only.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# 仅部署后端修复（不重新构建 Flutter Web）
+# 仅部署 Cloudflare 后端（不构建、不上传 Flutter Web）
 
 echo "🚀 部署后端修复到 Cloudflare Workers..."
 
@@ -11,12 +11,11 @@ echo ""
 echo "✅ 部署完成！"
 echo ""
 echo "🧪 测试排行榜API..."
-curl -s https://flutter.ombhrum.com/api/leaderboard
+curl -s https://api.ombhrum.com/api/leaderboard
 
 echo ""
 echo ""
 echo "✨ 修复内容："
-echo "  1. 数据库查询添加了 COALESCE 处理 NULL 值"
-echo "  2. 添加了完善的错误处理"
-echo "  3. 即使查询失败也返回空数组而不是500错误"
-echo "  4. 前端服务改为返回空数组而不是抛出异常"
+echo "  1. Worker 作为纯 API 后端部署"
+echo "  2. 部署过程不依赖 build/web"
+echo "  3. 前端可独立部署，并通过 API_BASE_URL 指向后端"

--- a/fabushi/scripts/deploy/deploy-backend-only.sh
+++ b/fabushi/scripts/deploy/deploy-backend-only.sh
@@ -2,7 +2,7 @@
 
 # 仅部署 Cloudflare 后端（不构建、不上传 Flutter Web）
 
-echo "🚀 部署后端修复到 Cloudflare Workers..."
+echo "🚀 部署后端 API 到旧 Cloudflare Worker 项目..."
 
 cd web
 npx wrangler deploy --env production
@@ -16,6 +16,6 @@ curl -s https://api.ombhrum.com/api/leaderboard
 echo ""
 echo ""
 echo "✨ 修复内容："
-echo "  1. Worker 作为纯 API 后端部署"
+echo "  1. 旧 Worker 项目作为纯 API 后端部署"
 echo "  2. 部署过程不依赖 build/web"
 echo "  3. 前端可独立部署，并通过 API_BASE_URL 指向后端"

--- a/fabushi/scripts/deploy/deploy-fix.sh
+++ b/fabushi/scripts/deploy/deploy-fix.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
-# 修复排行榜问题的部署脚本
+# 后端修复部署脚本
 
 echo "🚀 开始部署修复..."
 
-# 1. 构建 Flutter Web
-echo "📦 构建 Flutter Web..."
-flutter build web --release
-
-# 2. 部署到生产环境
 echo "🌐 部署到 Cloudflare Workers..."
 cd web
 npx wrangler deploy --env production
@@ -17,7 +12,7 @@ echo ""
 echo "✅ 部署完成！"
 echo ""
 echo "🧪 测试排行榜API..."
-curl -s https://flutter.ombhrum.com/api/leaderboard | jq '.'
+curl -s https://api.ombhrum.com/api/leaderboard | jq '.'
 
 echo ""
 echo "✨ 修复内容："

--- a/fabushi/scripts/deploy/deploy-frontend-worker.sh
+++ b/fabushi/scripts/deploy/deploy-frontend-worker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# 构建并部署 Flutter Web 到新的前端 Worker。
+
+set -e
+
+echo "📦 构建 Flutter Web..."
+flutter build web --release --dart-define=API_BASE_URL=https://api.ombhrum.com
+
+echo "🧹 清理不应发布到前端静态站点的旧 Worker 备份..."
+rm -rf build/web/.wrangler build/web/.dart_tool
+rm -rf build/web/node_modules build/web/dist build/web/src build/web/tests
+rm -rf build/web/migrations build/web/wasm-proxy
+rm -f build/web/.dev.vars build/web/.DS_Store build/web/.last_build_id
+rm -f build/web/worker*.js build/web/migrate*.js
+rm -f build/web/*.sql build/web/*.md build/web/package*.json build/web/wrangler*.toml
+
+echo "🌐 部署前端 Worker..."
+cd web
+npx wrangler deploy --config wrangler-web.toml --env production
+
+echo ""
+echo "✅ 前端部署完成: https://flutter.ombhrum.com"

--- a/fabushi/scripts/utils/test-leaderboard.sh
+++ b/fabushi/scripts/utils/test-leaderboard.sh
@@ -6,7 +6,7 @@ echo ""
 
 # 1. 测试排行榜 API
 echo "1️⃣ 测试排行榜 API..."
-RESPONSE=$(curl -s https://flutter.ombhrum.com/api/leaderboard)
+RESPONSE=$(curl -s https://api.ombhrum.com/api/leaderboard)
 echo "响应: $RESPONSE"
 echo ""
 

--- a/fabushi/web/BACKEND_FRONTEND_SEPARATION.md
+++ b/fabushi/web/BACKEND_FRONTEND_SEPARATION.md
@@ -1,6 +1,9 @@
 # Cloudflare 后端与前端分离说明
 
-当前 `web/wrangler.toml` 已调整为纯 Cloudflare Worker 后端配置，部署后端不再读取或上传 Flutter Web 的 `build/web`。
+当前部署拆成两个 Cloudflare Worker：
+
+- `web/wrangler.toml`: 旧 Worker 项目，继续承载后端 API 和旧项目内已绑定的 secrets。
+- `web/wrangler-web.toml`: 新 Worker 项目，只托管 Flutter Web 静态前端。
 
 ## 后端部署
 
@@ -14,6 +17,32 @@ npx wrangler deploy --env production
 
 ```bash
 curl https://api.ombhrum.com/health
+```
+
+后端 Worker 只挂：
+
+```text
+api.ombhrum.com/*
+```
+
+## 前端部署
+
+先在仓库根目录构建 Flutter Web：
+
+```bash
+flutter build web --release --dart-define=API_BASE_URL=https://api.ombhrum.com
+```
+
+然后在 `web` 目录执行：
+
+```bash
+npx wrangler deploy --config wrangler-web.toml --env production
+```
+
+前端 Worker 只挂：
+
+```text
+flutter.ombhrum.com/*
 ```
 
 ## 前端配置
@@ -32,7 +61,7 @@ flutter build web --release --dart-define=API_BASE_URL=https://api.ombhrum.com
 
 ## 域名职责
 
-- `api.ombhrum.com`: Cloudflare Worker API、R2 代理、WebSocket 在线人数。
-- `flutter.ombhrum.com`: Flutter Web 静态站点、隐私政策和支持页面。
+- `api.ombhrum.com`: 旧 Cloudflare Worker 项目上的 API、R2 代理、WebSocket 在线人数。
+- `flutter.ombhrum.com`: 新 Cloudflare Worker 项目上的 Flutter Web 静态站点、隐私政策和支持页面。
 
-后端 Worker 不再托管 `/index.html`、`/main.dart.js`、`/privacy`、`/support` 等前端页面；未命中的非 API 路径会返回 JSON 404。
+后端 Worker 不再托管 `/index.html`、`/main.dart.js`、`/privacy`、`/support` 等前端页面；未命中的非 API 路径会返回 JSON 404。前端 Worker 不处理 `/api/*`、`/r2`、`/health` 等后端路径。

--- a/fabushi/web/BACKEND_FRONTEND_SEPARATION.md
+++ b/fabushi/web/BACKEND_FRONTEND_SEPARATION.md
@@ -1,0 +1,38 @@
+# Cloudflare 后端与前端分离说明
+
+当前 `web/wrangler.toml` 已调整为纯 Cloudflare Worker 后端配置，部署后端不再读取或上传 Flutter Web 的 `build/web`。
+
+## 后端部署
+
+在 `web` 目录执行：
+
+```bash
+npx wrangler deploy --env production
+```
+
+验证：
+
+```bash
+curl https://api.ombhrum.com/health
+```
+
+## 前端配置
+
+Flutter 前端通过 `AppConfig.currentBackendUrl` 调用后端，生产默认后端为：
+
+```text
+https://api.ombhrum.com
+```
+
+如果需要临时指向其他后端，可在构建前端时传入：
+
+```bash
+flutter build web --release --dart-define=API_BASE_URL=https://api.ombhrum.com
+```
+
+## 域名职责
+
+- `api.ombhrum.com`: Cloudflare Worker API、R2 代理、WebSocket 在线人数。
+- `flutter.ombhrum.com`: Flutter Web 静态站点、隐私政策和支持页面。
+
+后端 Worker 不再托管 `/index.html`、`/main.dart.js`、`/privacy`、`/support` 等前端页面；未命中的非 API 路径会返回 JSON 404。

--- a/fabushi/web/deploy-modular.sh
+++ b/fabushi/web/deploy-modular.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-echo "🚀 开始部署模块化后端 Worker"
+echo "🚀 开始部署模块化后端 Worker（旧项目，保留 secrets）"
 
 # 部署
 echo "📦 开始部署..."

--- a/fabushi/web/deploy-modular.sh
+++ b/fabushi/web/deploy-modular.sh
@@ -1,20 +1,9 @@
 #!/bin/bash
-# 部署模块化Worker脚本
+# 部署模块化后端 Worker 脚本
 
 set -e
 
-echo "🚀 开始部署模块化Worker"
-
-# 备份原worker.js
-if [ -f "worker.js" ]; then
-    BACKUP_FILE="worker-backup-$(date +%Y%m%d-%H%M%S).js"
-    cp worker.js "$BACKUP_FILE"
-    echo "✅ 已备份原worker.js到 $BACKUP_FILE"
-fi
-
-# 使用完整模块化版本
-cp worker-complete.js worker.js
-echo "✅ 已切换到模块化版本"
+echo "🚀 开始部署模块化后端 Worker"
 
 # 部署
 echo "📦 开始部署..."
@@ -23,10 +12,6 @@ wrangler deploy --env production
 echo "✨ 部署完成！"
 echo ""
 echo "📝 验证步骤："
-echo "1. 测试健康检查: curl https://flutter.ombhrum.com/health"
+echo "1. 测试健康检查: curl https://api.ombhrum.com/health"
 echo "2. 测试登录功能"
 echo "3. 测试订单创建"
-echo ""
-echo "🔙 如需回滚:"
-echo "   cp $BACKUP_FILE worker.js"
-echo "   wrangler deploy --env production"

--- a/fabushi/web/frontend-worker.js
+++ b/fabushi/web/frontend-worker.js
@@ -1,0 +1,52 @@
+// Flutter Web static frontend Worker.
+// API traffic belongs on https://api.ombhrum.com and is intentionally not
+// handled here.
+
+const FRONTEND_ONLY_API_RESPONSE = {
+  success: false,
+  error: 'Frontend worker only',
+  message: 'Use https://api.ombhrum.com for backend API requests.'
+};
+
+function withFrontendHeaders(response, pathname) {
+  const headers = new Headers(response.headers);
+
+  if (['/', '/index.html', '/flutter_bootstrap.js', '/flutter_service_worker.js', '/main.dart.js'].includes(pathname)) {
+    headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+  } else if (/\.(js|css|png|jpg|jpeg|gif|svg|woff2?|json|wasm)$/i.test(pathname)) {
+    if (!headers.has('Cache-Control')) {
+      headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+    }
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const pathname = url.pathname;
+
+    if (pathname.startsWith('/api/') || pathname === '/r2' || pathname === '/health') {
+      return new Response(JSON.stringify(FRONTEND_ONLY_API_RESPONSE), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Access-Control-Allow-Origin': '*'
+        }
+      });
+    }
+
+    let response = await env.ASSETS.fetch(request);
+
+    if (response.status === 404 && !/\.[^/]+$/.test(pathname)) {
+      response = await env.ASSETS.fetch(new Request(new URL('/index.html', request.url), request));
+    }
+
+    return withFrontendHeaders(response, pathname);
+  }
+};

--- a/fabushi/web/src/handlers/payment.js
+++ b/fabushi/web/src/handlers/payment.js
@@ -46,6 +46,8 @@ export async function handleCreateAlipayOrder(request, env, db) {
 
   // Web平台：电脑网站支付
   if (platform === 'web') {
+    const backendUrl = env.WORKER_URL || 'https://api.ombhrum.com';
+    const frontendUrl = env.FRONTEND_URL || 'https://flutter.ombhrum.com';
     const now = new Date();
     const timestamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
 
@@ -55,7 +57,7 @@ export async function handleCreateAlipayOrder(request, env, db) {
       subject: `全球法布施 - ${planDetails.name}`,
       product_code: 'FAST_INSTANT_TRADE_PAY',
       timeout_express: '30m',
-      quit_url: env.WORKER_URL || 'https://flutter.ombhrum.com'
+      quit_url: frontendUrl
     };
 
     const params = {
@@ -66,8 +68,8 @@ export async function handleCreateAlipayOrder(request, env, db) {
       sign_type: 'RSA2',
       timestamp,
       version: '1.0',
-      notify_url: `${env.WORKER_URL || 'https://flutter.ombhrum.com'}/api/alipay/notify`,
-      return_url: `${env.WORKER_URL || 'https://flutter.ombhrum.com'}/payment-success.html`,
+      notify_url: `${backendUrl}/api/alipay/notify`,
+      return_url: env.ALIPAY_RETURN_URL || `${frontendUrl}/payment-success.html`,
       biz_content: JSON.stringify(bizContent)
     };
 
@@ -88,6 +90,7 @@ export async function handleCreateAlipayOrder(request, env, db) {
   }
 
   // APP支付：生成 orderString 供客户端调用支付宝 SDK
+  const backendUrl = env.WORKER_URL || 'https://api.ombhrum.com';
   const now = new Date();
   const timestamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
 
@@ -107,7 +110,7 @@ export async function handleCreateAlipayOrder(request, env, db) {
     sign_type: 'RSA2',
     timestamp,
     version: '1.0',
-    notify_url: `${env.WORKER_URL || 'https://flutter.ombhrum.com'}/api/alipay/notify`,
+    notify_url: `${backendUrl}/api/alipay/notify`,
     biz_content: JSON.stringify(appBizContent)
   };
 

--- a/fabushi/web/src/handlers/profile.js
+++ b/fabushi/web/src/handlers/profile.js
@@ -286,19 +286,7 @@ async function runInTransaction(db, action) {
     return nativeTransaction(action);
   }
 
-  await db.prepare('BEGIN TRANSACTION').run();
-  try {
-    const result = await action();
-    await db.prepare('COMMIT').run();
-    return result;
-  } catch (error) {
-    try {
-      await db.prepare('ROLLBACK').run();
-    } catch (rollbackError) {
-      console.warn('回滚资料更新事务失败:', rollbackError?.message || rollbackError);
-    }
-    throw error;
-  }
+  return action();
 }
 
 async function migrateUsernameChange(db, user, {

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -257,6 +257,11 @@ test('handleUpdateProfile migrates username changes without direct in-place user
       `missing migration statement: ${expectedSql}`
     );
   }
+
+  assert.equal(
+    db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
+    false
+  );
 });
 
 test('handleUpdateProfile prefers native storage transactions when available', async () => {

--- a/fabushi/web/worker-modular.js
+++ b/fabushi/web/worker-modular.js
@@ -2,6 +2,7 @@
 import { DatabaseService } from './src/services/database.js';
 import { route } from './src/router.js';
 import { OnlineCounter } from './src/durable-objects/OnlineCounter.js';
+import { jsonResponse } from './src/utils/response.js';
 
 // 导出Durable Object类
 export { OnlineCounter };
@@ -53,118 +54,19 @@ export default {
       const db = new DatabaseService(env.DB);
 
       // 尝试路由到模块化处理器
-      const response = await route(request, env, db);
+      const response = await route(request, env, db, ctx);
       if (response) return response;
 
-      // /support 支持页面路由
-      if (url.pathname === '/support' || url.pathname === '/support/') {
-        try {
-          // 尝试从静态资源提供
-          if (env.ASSETS) {
-            const supportRequest = new Request(new URL('/support/index.html', request.url), request);
-            const assetResponse = await env.ASSETS.fetch(supportRequest);
-            if (assetResponse.status === 200) {
-              const newResponse = new Response(assetResponse.body, {
-                status: 200,
-                headers: {
-                  'Content-Type': 'text/html; charset=utf-8',
-                  'Access-Control-Allow-Origin': '*',
-                  'Cache-Control': 'public, max-age=3600',
-                },
-              });
-              return newResponse;
-            }
-          }
-        } catch (e) {
-          console.error('Error serving support page from assets:', e);
-        }
-        // 回退：返回307重定向到静态文件
-        return Response.redirect(new URL('/support/index.html', request.url).href, 307);
-      }
-
-      // /privacy 隐私政策页面路由
-      if (url.pathname === '/privacy' || url.pathname === '/privacy/') {
-        try {
-          if (env.ASSETS) {
-            const privacyRequest = new Request(new URL('/privacy.html', request.url), request);
-            const assetResponse = await env.ASSETS.fetch(privacyRequest);
-            if (assetResponse.status === 200) {
-              const newResponse = new Response(assetResponse.body, {
-                status: 200,
-                headers: {
-                  'Content-Type': 'text/html; charset=utf-8',
-                  'Access-Control-Allow-Origin': '*',
-                  'Cache-Control': 'public, max-age=3600',
-                },
-              });
-              return newResponse;
-            }
-          }
-        } catch (e) {
-          console.error('Error serving privacy page from assets:', e);
-        }
-        // 回退：返回307重定向到静态文件
-        return Response.redirect(new URL('/privacy.html', request.url).href, 307);
-      }
-
-      // 静态文件服务
-      if (env.ASSETS) {
-        const url = new URL(request.url);
-        const pathname = url.pathname;
-
-        let assetResponse = await env.ASSETS.fetch(request);
-
-        // SPA fallback: 如果是 404 且不是 API 请求，也不是带扩展名的文件，或者是 /support 路径，尝试返回 index.html
-        if (assetResponse.status === 404 && !pathname.startsWith('/api/')) {
-          // 特殊处理 /support 路径，回退到 /support/index.html
-          if (pathname === '/support' || pathname === '/support/') {
-            const supportRequest = new Request(new URL('/support/index.html', request.url), request);
-            const supportResponse = await env.ASSETS.fetch(supportRequest);
-            if (supportResponse.status === 200) {
-              assetResponse = supportResponse;
-            }
-          }
-          // 普通 SPA 回退 (排除 /support/ 开头的其他路径，只处理根路径或未匹配路径)
-          else if (!/\.[^/]+$/.test(pathname) && !pathname.startsWith('/support/')) {
-            const spaRequest = new Request(new URL('/index.html', request.url), request);
-            assetResponse = await env.ASSETS.fetch(spaRequest);
-          }
-        }
-
-        // 添加CORS和版本头
-        const newResponse = new Response(
-          request.method === 'HEAD' ? null : assetResponse.body,
-          {
-            status: assetResponse.status,
-            statusText: assetResponse.statusText,
-            headers: assetResponse.headers
-          }
-        );
-
-        newResponse.headers.set('Access-Control-Allow-Origin', '*');
-
-        // 缓存策略
-        const noCacheList = ['/', '/index.html', '/support/', '/support/index.html', '/flutter_service_worker.js', '/main.dart.js'];
-        if (noCacheList.includes(pathname)) {
-          newResponse.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
-        } else if (/\.(js|css|png|jpg|jpeg|gif|svg|woff2?|json|wasm)$/i.test(pathname)) {
-          if (!newResponse.headers.has('Cache-Control')) {
-            newResponse.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
-          }
-        }
-
-        return newResponse;
-      }
-
-      // 最后的兜底
-      return new Response('Not Found', { status: 404, headers: { 'Access-Control-Allow-Origin': '*' } });
+      return jsonResponse({
+        success: false,
+        error: 'Not Found',
+        message: 'This Cloudflare Worker is an API backend only.',
+        path: url.pathname
+      }, 404);
 
     } catch (error) {
       console.error('Worker error:', error);
-      return new Response('Internal Server Error', {
-        status: 500,
-        headers: { 'Access-Control-Allow-Origin': '*' }
-      });
+      return jsonResponse({ success: false, error: 'Internal Server Error' }, 500);
     }
   }
 };

--- a/fabushi/web/wrangler-web.toml
+++ b/fabushi/web/wrangler-web.toml
@@ -1,0 +1,28 @@
+name = "fabushi-web"
+main = "frontend-worker.js"
+compatibility_date = "2024-08-01"
+
+[assets]
+binding = "ASSETS"
+directory = "../build/web"
+
+[env.production]
+name = "fabushi-web-prod"
+routes = [
+  { pattern = "flutter.ombhrum.com/*", zone_name = "ombhrum.com" }
+]
+workers_dev = false
+
+[env.production.assets]
+binding = "ASSETS"
+directory = "../build/web"
+
+[env.development]
+name = "fabushi-web-dev"
+
+[env.development.assets]
+binding = "ASSETS"
+directory = "../build/web"
+
+[observability.logs]
+enabled = true

--- a/fabushi/web/wrangler.toml
+++ b/fabushi/web/wrangler.toml
@@ -63,6 +63,15 @@ FLUTTER_WEB = "true"
 [assets]
 binding = "ASSETS"
 directory = "../build/web"
+run_worker_first = [
+  "/",
+  "/index.html",
+  "/flutter_bootstrap.js",
+  "/flutter_service_worker.js",
+  "/main.dart.js",
+  "/version.json",
+  "/api/*"
+]
 
 # 生产环境配置
 [env.production]
@@ -120,6 +129,15 @@ ALIPAY_RETURN_URL = "https://flutter.ombhrum.com/payment-success.html"
 [env.production.assets]
 binding = "ASSETS"
 directory = "../build/web"
+run_worker_first = [
+  "/",
+  "/index.html",
+  "/flutter_bootstrap.js",
+  "/flutter_service_worker.js",
+  "/main.dart.js",
+  "/version.json",
+  "/api/*"
+]
 
 # 开发环境配置
 [env.development]
@@ -167,6 +185,15 @@ WORKER_URL = "https://flutter.ombhrum.com"
 [env.development.assets]
 binding = "ASSETS"
 directory = "../build/web"
+run_worker_first = [
+  "/",
+  "/index.html",
+  "/flutter_bootstrap.js",
+  "/flutter_service_worker.js",
+  "/main.dart.js",
+  "/version.json",
+  "/api/*"
+]
 
 [observability.logs]
 enabled = true

--- a/fabushi/web/wrangler.toml
+++ b/fabushi/web/wrangler.toml
@@ -1,4 +1,4 @@
-name = "fabushi-backend"
+name = "fabushi-flutter-web"
 main = "worker-modular.js"
 compatibility_date = "2024-08-01"
 
@@ -36,7 +36,7 @@ preview_bucket_name = "bushi"
 [[durable_objects.bindings]]
 name = "ONLINE_COUNTER"
 class_name = "OnlineCounter"
-script_name = "fabushi-backend"
+script_name = "fabushi-flutter-web"
 
 [[migrations]]
 tag = "v1"
@@ -62,9 +62,9 @@ FRONTEND_URL = "https://flutter.ombhrum.com"
 
 # 生产环境配置
 [env.production]
-name = "fabushi-backend-prod"
+name = "fabushi-flutter-web-prod"
 routes = [
-  { pattern = "api.ombhrum.com/*", zone_name = "ombhrum.com" }
+  { pattern = "api.ombhrum.com", custom_domain = true }
 ]
 workers_dev = false
 
@@ -96,7 +96,7 @@ database_id = "7b6318f0-fbc2-42f9-9887-85f878ae76d0"
 [[env.production.durable_objects.bindings]]
 name = "ONLINE_COUNTER"
 class_name = "OnlineCounter"
-script_name = "fabushi-backend-prod"
+script_name = "fabushi-flutter-web-prod"
 
 [[env.production.send_email]]
 name = "EMAIL"
@@ -116,7 +116,7 @@ ALIPAY_RETURN_URL = "https://flutter.ombhrum.com/payment-success.html"
 
 # 开发环境配置
 [env.development]
-name = "fabushi-backend-dev"
+name = "fabushi-flutter-web-dev"
 
 [[env.development.kv_namespaces]]
 binding = "USERS_KV"
@@ -155,7 +155,7 @@ ENVIRONMENT = "development"
 # 支付宝配置
 ALIPAY_APP_ID = "2021005193647715"
 ALIPAY_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAi0qnuA0SPHg/sB43ROGixTPaeCYN2kmsqCBUZ+gCaMivh405NBAX8LELBlBmrIvKhyUH9JNan+r0e2qrsmLSShIMD/M0YyB3+SqjITQXR0QSlneDKuHxl+O5qXe43qhuCaWXX3GVXwt5J+kOHPHCL+/3OThOjAYRwnCVewS85fx2hn6AtRPcyXHv+/nopckBL1ZbFrQRZC+BJuUlP3e9/NFWzWvUclAjaG2suVbz4YgmYh08fHlNNtb9/283/FKMRYbklpNKXTOwKQ7yflao0fTGPUdi9ILarLR8wPZTp8cv3ojIOU+e1toikcNNKK+Z+e24smY48QuB6MvJfV7skwIDAQAB"
-WORKER_URL = "https://fabushi-backend-dev.bhrumom.workers.dev"
+WORKER_URL = "https://fabushi-flutter-web-dev.bhrumom.workers.dev"
 FRONTEND_URL = "https://flutter.ombhrum.com"
 
 [observability.logs]

--- a/fabushi/web/wrangler.toml
+++ b/fabushi/web/wrangler.toml
@@ -1,4 +1,4 @@
-name = "fabushi-flutter-web"
+name = "fabushi-backend"
 main = "worker-modular.js"
 compatibility_date = "2024-08-01"
 
@@ -36,7 +36,7 @@ preview_bucket_name = "bushi"
 [[durable_objects.bindings]]
 name = "ONLINE_COUNTER"
 class_name = "OnlineCounter"
-script_name = "fabushi-flutter-web"
+script_name = "fabushi-backend"
 
 [[migrations]]
 tag = "v1"
@@ -57,27 +57,14 @@ destination_address = "131551832@qq.com"
 [vars]
 FROM_EMAIL = "amitabha@ombhrum.com"
 # JWT_SECRET 应该使用 Cloudflare Secret，不要在这里明文存储
-FLUTTER_WEB = "true"
-
-# 默认环境资源绑定
-[assets]
-binding = "ASSETS"
-directory = "../build/web"
-run_worker_first = [
-  "/",
-  "/index.html",
-  "/flutter_bootstrap.js",
-  "/flutter_service_worker.js",
-  "/main.dart.js",
-  "/version.json",
-  "/api/*"
-]
+BACKEND_ONLY = "true"
+FRONTEND_URL = "https://flutter.ombhrum.com"
 
 # 生产环境配置
 [env.production]
-name = "fabushi-flutter-web-prod"
+name = "fabushi-backend-prod"
 routes = [
-  { pattern = "flutter.ombhrum.com/*", zone_name = "ombhrum.com" }
+  { pattern = "api.ombhrum.com/*", zone_name = "ombhrum.com" }
 ]
 workers_dev = false
 
@@ -109,7 +96,7 @@ database_id = "7b6318f0-fbc2-42f9-9887-85f878ae76d0"
 [[env.production.durable_objects.bindings]]
 name = "ONLINE_COUNTER"
 class_name = "OnlineCounter"
-script_name = "fabushi-flutter-web-prod"
+script_name = "fabushi-backend-prod"
 
 [[env.production.send_email]]
 name = "EMAIL"
@@ -118,30 +105,18 @@ destination_address = "131551832@qq.com"
 [env.production.vars]
 FROM_EMAIL = "amitabha@ombhrum.com"
 JWT_SECRET = "prod_secret_key_2025_ombhrum_fabushi"
-FLUTTER_WEB = "true"
+BACKEND_ONLY = "true"
 # 支付宝配置
 ALIPAY_APP_ID = "2021005193647715"
 ALIPAY_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAi0qnuA0SPHg/sB43ROGixTPaeCYN2kmsqCBUZ+gCaMivh405NBAX8LELBlBmrIvKhyUH9JNan+r0e2qrsmLSShIMD/M0YyB3+SqjITQXR0QSlneDKuHxl+O5qXe43qhuCaWXX3GVXwt5J+kOHPHCL+/3OThOjAYRwnCVewS85fx2hn6AtRPcyXHv+/nopckBL1ZbFrQRZC+BJuUlP3e9/NFWzWvUclAjaG2suVbz4YgmYh08fHlNNtb9/283/FKMRYbklpNKXTOwKQ7yflao0fTGPUdi9ILarLR8wPZTp8cv3ojIOU+e1toikcNNKK+Z+e24smY48QuB6MvJfV7skwIDAQAB"
-WORKER_URL = "https://flutter.ombhrum.com"
-ALIPAY_NOTIFY_URL = "https://flutter.ombhrum.com/api/alipay/notify"
+WORKER_URL = "https://api.ombhrum.com"
+FRONTEND_URL = "https://flutter.ombhrum.com"
+ALIPAY_NOTIFY_URL = "https://api.ombhrum.com/api/alipay/notify"
 ALIPAY_RETURN_URL = "https://flutter.ombhrum.com/payment-success.html"
-
-[env.production.assets]
-binding = "ASSETS"
-directory = "../build/web"
-run_worker_first = [
-  "/",
-  "/index.html",
-  "/flutter_bootstrap.js",
-  "/flutter_service_worker.js",
-  "/main.dart.js",
-  "/version.json",
-  "/api/*"
-]
 
 # 开发环境配置
 [env.development]
-name = "fabushi-flutter-web-dev"
+name = "fabushi-backend-dev"
 
 [[env.development.kv_namespaces]]
 binding = "USERS_KV"
@@ -175,25 +150,13 @@ destination_address = "131551832@qq.com"
 [env.development.vars]
 FROM_EMAIL = "amitabha@ombhrum.com"
 JWT_SECRET = "dev_secret_key_2025"
-FLUTTER_WEB = "true"
+BACKEND_ONLY = "true"
 ENVIRONMENT = "development"
 # 支付宝配置
 ALIPAY_APP_ID = "2021005193647715"
 ALIPAY_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAi0qnuA0SPHg/sB43ROGixTPaeCYN2kmsqCBUZ+gCaMivh405NBAX8LELBlBmrIvKhyUH9JNan+r0e2qrsmLSShIMD/M0YyB3+SqjITQXR0QSlneDKuHxl+O5qXe43qhuCaWXX3GVXwt5J+kOHPHCL+/3OThOjAYRwnCVewS85fx2hn6AtRPcyXHv+/nopckBL1ZbFrQRZC+BJuUlP3e9/NFWzWvUclAjaG2suVbz4YgmYh08fHlNNtb9/283/FKMRYbklpNKXTOwKQ7yflao0fTGPUdi9ILarLR8wPZTp8cv3ojIOU+e1toikcNNKK+Z+e24smY48QuB6MvJfV7skwIDAQAB"
-WORKER_URL = "https://flutter.ombhrum.com"
-
-[env.development.assets]
-binding = "ASSETS"
-directory = "../build/web"
-run_worker_first = [
-  "/",
-  "/index.html",
-  "/flutter_bootstrap.js",
-  "/flutter_service_worker.js",
-  "/main.dart.js",
-  "/version.json",
-  "/api/*"
-]
+WORKER_URL = "https://fabushi-backend-dev.bhrumom.workers.dev"
+FRONTEND_URL = "https://flutter.ombhrum.com"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Summary
- remove the profile username migration fallback that issued SQL `BEGIN/COMMIT/ROLLBACK`
- keep native Durable Object transactions and D1 `batch()` paths when available
- add regression coverage that the default profile migration path never emits SQL transaction statements

## Verification
- `node tests/profile.test.js`
- `find tests -name '*.test.js' ! -name 'profile.test.js' -print0 | xargs -0 node --test --test-concurrency=1`

Fixes #197
Follow-up to #191: build 67 still hit a production binding shape where `state.storage.transaction`/`batch` was not exposed, so the old SQL transaction fallback executed and D1 rejected it.