### PR TITLE
fix: guard profile migration against undefined D1 binds

### DIFF
--- a/fabushi/web/src/handlers/profile.js
+++ b/fabushi/web/src/handlers/profile.js
@@ -209,7 +209,7 @@ function getFinalProfileState(user, {
   const phone = newPhone !== undefined ? newPhone : normalizeOptionalString(user.phone_number);
   const practiceChanged = practiceTitle !== undefined;
 
-  return {
+  const finalState = {
     username: targetUsername,
     email,
     password_hash: passwordCreds?.passwordHash ?? user.password_hash ?? null,
@@ -251,9 +251,13 @@ function getFinalProfileState(user, {
     last_transfer_at: normalizeOptionalString(user.last_transfer_at),
     sync_version: user.sync_version ?? 1,
     extra_data: normalizeOptionalString(user.extra_data),
-    created_at: user.created_at,
+    created_at: user.created_at || updatedAt,
     updated_at: updatedAt
   };
+
+  return Object.fromEntries(
+    Object.entries(finalState).map(([key, value]) => [key, value === undefined ? null : value])
+  );
 }
 
 function getNativeTransactionRunner(db) {

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -39,6 +39,10 @@ function createDbMock(options = {}) {
       const execute = async (params = []) => {
         statements.push({ sql, params });
 
+        if (params.some((param) => param === undefined)) {
+          throw new TypeError("D1_TYPE_ERROR: Type 'undefined' not supported for value 'undefined'");
+        }
+
         if (/^BEGIN TRANSACTION/.test(normalizedSql) || /^COMMIT/.test(normalizedSql) || /^ROLLBACK/.test(normalizedSql)) {
           return;
         }
@@ -339,6 +343,51 @@ test('handleUpdateProfile uses D1 batch instead of SQL transactions when availab
     db.statements.some(({ sql }) => /^BEGIN TRANSACTION|^COMMIT|^ROLLBACK/.test(sql.trimStart())),
     false
   );
+});
+
+test('handleUpdateProfile coerces missing optional legacy fields to null during username migration', async () => {
+  const db = createDbMock({ batchTransaction: true });
+  seedUser(db, 'legacyold', 'legacy@example.com', '+8613800138555', {
+    firebase_uid: 'firebase-legacy-uid'
+  });
+
+  const legacyUser = db.users.get('legacyold');
+  delete legacyUser.alipay_bound_at;
+  delete legacyUser.wechat_bound_at;
+  delete legacyUser.bio;
+  delete legacyUser.membership_expires_at;
+  delete legacyUser.stripe_customer_id;
+  delete legacyUser.subscription_id;
+  delete legacyUser.extra_data;
+
+  const env = { JWT_SECRET: 'test-secret' };
+  const token = await generateToken('legacyold', env);
+  const request = new Request('https://flutter.ombhrum.com/api/auth/update-profile', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      username: 'legacynew',
+      email: 'legacy@example.com',
+      phoneNumber: ''
+    })
+  });
+
+  const response = await handleUpdateProfile(request, env, db);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.user.username, 'legacynew');
+  assert.equal(db.users.get('legacynew').alipay_bound_at, null);
+  assert.equal(db.users.get('legacynew').wechat_bound_at, null);
+  assert.equal(db.users.get('legacynew').bio, null);
+  assert.equal(db.users.get('legacynew').membership_expires_at, null);
+  assert.equal(db.users.get('legacynew').stripe_customer_id, null);
+  assert.equal(db.users.get('legacynew').subscription_id, null);
+  assert.equal(db.users.get('legacynew').extra_data, null);
 });
 
 test('DatabaseService preserves native transaction access for profile updates', async () => {


### PR DESCRIPTION
## 为什么改

前后端分离后的资料编辑链路继续推进时，`PR #202` 已经去掉了 SQL transaction fallback，但最新用户反馈 `issue #200` 又暴露出新的运行时根因：

- 报错时间：2026-05-07 04:41 UTC
- 错误签名：`D1_TYPE_ERROR: Type 'undefined' not supported for value 'undefined'`
- 触发条件：编辑资料时发生用户名迁移，旧用户记录里某些可空字段在运行时对象上是 `undefined`

当前 `migrateUsernameChange(...)` 会把旧用户对象重组后直接 bind 进 D1 `INSERT INTO users`。如果历史数据里某些可空字段没有值且被取成 `undefined`，D1 会直接拒绝 bind，导致资料保存仍然 500。

## 这次改了什么

- 在 `fabushi/web/src/handlers/profile.js` 里，对用户名迁移生成的最终用户快照做统一收口：
  - 旧记录里的缺失可空字段统一落成 `null`
  - `created_at` 缺失时兜底为本次 `updatedAt`
- 保持现有 native transaction / D1 batch 路径不变，只修正进入 D1 bind 前的数据形态
- 在 `fabushi/web/tests/profile.test.js` 增加两层回归保护：
  - mock D1 现在会像真实运行时一样直接拒绝 `undefined` bind
  - 新增 legacy 用户回归用例，覆盖缺失可空字段时的用户名迁移仍能成功

## 验证

- `node tests/profile.test.js`
- 其中新增断言会在出现 `undefined` bind 时直接失败，避免再次只在生产运行时暴露

Fixes #200
Follow-up to #202