### PR TITLE
fix: realign API smoke gates and meditation auth regression coverage

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -192,7 +192,7 @@ jobs:
       run:
         working-directory: fabushi/e2e
     env:
-      STAGING_APP_URL: https://fabushi-flutter-web-dev.bhrumom.workers.dev
+      STAGING_API_URL: https://fabushi-flutter-web-dev.bhrumom.workers.dev
       STAGING_TEST_LOGIN: ${{ secrets.STAGING_TEST_LOGIN }}
       STAGING_TEST_PASSWORD: ${{ secrets.STAGING_TEST_PASSWORD }}
       STAGING_TEST_EMAIL: ${{ vars.STAGING_TEST_EMAIL }}
@@ -212,7 +212,7 @@ jobs:
         run: |
           set -euo pipefail
           missing=0
-          for name in STAGING_APP_URL STAGING_TEST_LOGIN STAGING_TEST_PASSWORD STAGING_TEST_EMAIL STAGING_TEST_PHONE; do
+          for name in STAGING_API_URL STAGING_TEST_LOGIN STAGING_TEST_PASSWORD STAGING_TEST_EMAIL STAGING_TEST_PHONE; do
             if [ -z "${!name:-}" ]; then
               echo "$name is not configured."
               missing=1
@@ -235,9 +235,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsS "$STAGING_APP_URL" > /tmp/staging-index.html
-          test -s /tmp/staging-index.html
-          status=$(curl -sS -o /tmp/staging-auth.json -w '%{http_code}' "$STAGING_APP_URL/api/auth/user-info")
+          curl -fsS "$STAGING_API_URL/health" > /tmp/staging-health.json
+          test -s /tmp/staging-health.json
+          status=$(curl -sS -o /tmp/staging-auth.json -w '%{http_code}' "$STAGING_API_URL/api/auth/user-info")
           if [ "$status" != "401" ] && [ "$status" != "403" ]; then
             echo "Expected unauthenticated user-info to return 401 or 403, got $status"
             cat /tmp/staging-auth.json
@@ -269,7 +269,7 @@ jobs:
     timeout-minutes: 15
     environment:
       name: production
-      url: ${{ vars.PRODUCTION_APP_URL || 'https://flutter.ombhrum.com' }}
+      url: ${{ vars.PRODUCTION_API_URL || 'https://api.ombhrum.com' }}
     defaults:
       run:
         working-directory: release-artifact/fabushi/web
@@ -355,8 +355,8 @@ jobs:
             echo ""
             echo "- Source SHA: ${{ needs.build-artifact.outputs.source_sha }}"
             echo "- Artifact: fabushi-release-${{ needs.build-artifact.outputs.source_sha }}"
-            echo "- Gates: staging API E2E, staging smoke"
-            echo "- URL: ${{ vars.PRODUCTION_APP_URL || 'https://flutter.ombhrum.com' }}"
+            echo "- Gates: staging API E2E, staging API smoke"
+            echo "- URL: ${{ vars.PRODUCTION_API_URL || 'https://api.ombhrum.com' }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   production-smoke:
@@ -367,15 +367,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      PRODUCTION_APP_URL: ${{ vars.PRODUCTION_APP_URL || 'https://flutter.ombhrum.com' }}
+      PRODUCTION_API_URL: ${{ vars.PRODUCTION_API_URL || 'https://api.ombhrum.com' }}
     steps:
-      - name: Smoke test production site and API auth boundary
+      - name: Smoke test production API health and auth boundary
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsS "$PRODUCTION_APP_URL" > /tmp/production-index.html
-          test -s /tmp/production-index.html
-          status=$(curl -sS -o /tmp/production-auth.json -w '%{http_code}' "$PRODUCTION_APP_URL/api/auth/user-info")
+          curl -fsS "$PRODUCTION_API_URL/health" > /tmp/production-health.json
+          test -s /tmp/production-health.json
+          status=$(curl -sS -o /tmp/production-auth.json -w '%{http_code}' "$PRODUCTION_API_URL/api/auth/user-info")
           if [ "$status" != "401" ] && [ "$status" != "403" ]; then
             echo "Expected unauthenticated user-info to return 401 or 403, got $status"
             cat /tmp/production-auth.json
@@ -389,7 +389,7 @@ jobs:
             echo "## Production smoke test passed"
             echo ""
             echo "- Source SHA: ${{ needs.build-artifact.outputs.source_sha }}"
-            echo "- URL: $PRODUCTION_APP_URL"
+            echo "- URL: $PRODUCTION_API_URL"
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify-failure:
@@ -434,8 +434,8 @@ jobs:
                 '### Deployment gates',
                 '',
                 '- Staging API E2E',
-                '- Staging smoke test',
-                '- Production deploy and smoke test',
+                '- Staging API smoke test',
+                '- Production deploy and API smoke test',
                 '',
                 '### Rollback',
                 '',

--- a/fabushi/e2e/tests/staging_social_privacy.spec.ts
+++ b/fabushi/e2e/tests/staging_social_privacy.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const baseUrl = process.env.STAGING_APP_URL;
+const apiBaseUrl = process.env.STAGING_API_URL;
 const testUser = process.env.STAGING_TEST_LOGIN;
 const testPassword = process.env.STAGING_TEST_PASSWORD;
 const configuredSocialTarget = process.env.STAGING_SOCIAL_TARGET_USERNAME?.trim() || null;
@@ -10,7 +10,7 @@ test.describe('Staging Social and Privacy API', () => {
   let followTargetUsername: string | null = configuredSocialTarget;
 
   test.beforeAll(async ({ request }) => {
-    const resp = await request.post(`${baseUrl}/api/auth/login`, {
+    const resp = await request.post(`${apiBaseUrl}/api/auth/login`, {
       data: { username: testUser, password: testPassword },
     });
     expect(resp.ok()).toBeTruthy();
@@ -18,7 +18,7 @@ test.describe('Staging Social and Privacy API', () => {
     authToken = body.token;
 
     if (!followTargetUsername) {
-      const leaderboardResp = await request.get(`${baseUrl}/api/leaderboard/practice`, {
+      const leaderboardResp = await request.get(`${apiBaseUrl}/api/leaderboard/practice`, {
         headers: { Authorization: `Bearer ${authToken}` },
       });
       expect(leaderboardResp.ok()).toBeTruthy();
@@ -32,7 +32,7 @@ test.describe('Staging Social and Privacy API', () => {
   test('toggle follow/unfollow', async ({ request }) => {
     test.skip(!followTargetUsername, 'staging 环境暂无可关注的其他用户');
 
-    const resp = await request.post(`${baseUrl}/api/social/follow/toggle`, {
+    const resp = await request.post(`${apiBaseUrl}/api/social/follow/toggle`, {
       data: { username: followTargetUsername },
       headers: { Authorization: `Bearer ${authToken}` },
     });
@@ -43,7 +43,7 @@ test.describe('Staging Social and Privacy API', () => {
   });
 
   test('fetch follow list', async ({ request }) => {
-    const resp = await request.get(`${baseUrl}/api/social/follows?type=following&username=${testUser}`, {
+    const resp = await request.get(`${apiBaseUrl}/api/social/follows?type=following&username=${testUser}`, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(resp.ok()).toBeTruthy();
@@ -52,7 +52,7 @@ test.describe('Staging Social and Privacy API', () => {
   });
 
   test('fetch follow summary', async ({ request }) => {
-    const resp = await request.get(`${baseUrl}/api/social/follow-summary?username=${testUser}`, {
+    const resp = await request.get(`${apiBaseUrl}/api/social/follow-summary?username=${testUser}`, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(resp.ok()).toBeTruthy();
@@ -62,7 +62,7 @@ test.describe('Staging Social and Privacy API', () => {
   });
 
   test('practice privacy GET and UPDATE', async ({ request }) => {
-    const getResp = await request.get(`${baseUrl}/api/social/practice-privacy`, {
+    const getResp = await request.get(`${apiBaseUrl}/api/social/practice-privacy`, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(getResp.ok()).toBeTruthy();
@@ -70,7 +70,7 @@ test.describe('Staging Social and Privacy API', () => {
     const privacy = getBody.privacy ?? getBody;
     expect(privacy).toHaveProperty('isPrivate');
 
-    const postResp = await request.post(`${baseUrl}/api/social/practice-privacy`, {
+    const postResp = await request.post(`${apiBaseUrl}/api/social/practice-privacy`, {
       headers: { Authorization: `Bearer ${authToken}` },
       data: {
         isPrivate: true,
@@ -87,7 +87,7 @@ test.describe('Staging Social and Privacy API', () => {
   });
 
   test('leaderboard practice records respect privacy', async ({ request }) => {
-    const resp = await request.get(`${baseUrl}/api/leaderboard/practice`, {
+    const resp = await request.get(`${apiBaseUrl}/api/leaderboard/practice`, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(resp.ok()).toBeTruthy();
@@ -104,7 +104,7 @@ test.describe('Staging Social and Privacy API', () => {
   });
 
   test('leaderboard records endpoint hides notes/remarks', async ({ request }) => {
-    const practiceResp = await request.get(`${baseUrl}/api/leaderboard/practice`, {
+    const practiceResp = await request.get(`${apiBaseUrl}/api/leaderboard/practice`, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(practiceResp.ok()).toBeTruthy();
@@ -114,7 +114,7 @@ test.describe('Staging Social and Privacy API', () => {
 
     test.skip(!publicEntry, 'staging 环境暂无可用于公开记录校验的排行榜用户');
 
-    const resp = await request.get(`${baseUrl}/api/leaderboard/practice/records?username=${encodeURIComponent(publicEntry.username)}`, {
+    const resp = await request.get(`${apiBaseUrl}/api/leaderboard/practice/records?username=${encodeURIComponent(publicEntry.username)}`, {
       headers: { Authorization: `Bearer ${authToken}` },
     });
     expect(resp.ok()).toBeTruthy();

--- a/fabushi/web/tests/router-meditation-auth.test.js
+++ b/fabushi/web/tests/router-meditation-auth.test.js
@@ -68,7 +68,9 @@ test('router accepts signed JWTs on meditation endpoints by normalizing them for
 
 test('router rejects invalid signed JWTs before legacy meditation handlers can accept them', async () => {
   const token = await generateToken('meditator', TEST_ENV);
-  const tampered = `${token.slice(0, -1)}${token.endsWith('a') ? 'b' : 'a'}`;
+  const [header, payload, signature] = token.split('.');
+  const tamperedSignature = `${signature[0] === 'a' ? 'b' : 'a'}${signature.slice(1)}`;
+  const tampered = `${header}.${payload}.${tamperedSignature}`;
   const response = await route(
     new Request('https://flutter.ombhrum.com/api/meditation/goal?status=active', {
       headers: { Authorization: `Bearer ${tampered}` },
@@ -79,7 +81,7 @@ test('router rejects invalid signed JWTs before legacy meditation handlers can a
   );
 
   assert.equal(response.status, 401);
-  const payload = await response.json();
-  assert.equal(payload.success, false);
-  assert.match(payload.error, /认证失败/);
+  const body = await response.json();
+  assert.equal(body.success, false);
+  assert.match(body.error, /认证失败/);
 });


### PR DESCRIPTION
## 为什么改

这一轮主控推进里，主链同时出现了两条新的交付失败：

- `issue #205` / `CI #421`：Worker contract tests 红在 `router-meditation-auth.test.js`
- `issue #204` / `CD #122`：staging smoke gate 仍按前后端未拆分模型检查根路径，结果对当前 backend-only staging deploy 命中 404

这两条都挡在主交付链上，但性质不同：

1. Worker 红灯不是产品接口实际坏了，而是回归测试把 token 的最后一位替换成别的字符。对 base64url 编码来说，这种尾位改动不总能稳定改变签名字节，于是会出现“看似篡改、实际仍可验签”的假失败。
2. CD smoke gate 则是仓库真实部署模型已经变了：`deploy-production.yml` 现在部署的是独立 Cloudflare 后端 API，而 smoke gate 还在把它当成会返回前端首页的单体站点去探测。

## 这次改了什么

### 1. 修正 Worker JWT 回归测试的伪造方式
- 更新 `fabushi/web/tests/router-meditation-auth.test.js`
- 不再改签名尾位，而是稳定篡改签名首字符
- 这样能确保构造出来的 token 一定验签失败，避免再把编码细节误当成产品回归

### 2. 让 staging API E2E 明确指向后端 API 地址
- 更新 `fabushi/e2e/tests/staging_social_privacy.spec.ts`
- 用 `STAGING_API_URL` 代替含义已经漂移的 `STAGING_APP_URL`
- 让这组测试从变量命名开始就和“backend-only deploy”对齐

### 3. 把 CD smoke gate 改成检查真实部署目标
- 更新 `.github/workflows/deploy-production.yml`
- staging smoke 不再 `curl` 根路径首页，而是：
  - 检查 `$STAGING_API_URL/health`
  - 继续验证未登录访问 `/api/auth/user-info` 必须返回 `401/403`
- production smoke 同步切到 `PRODUCTION_API_URL`，不再把当前 workflow 没有部署的前端静态站点当成 smoke gate 目标
- deployment summary / failure note 里的 gate 描述也同步收口到 API 语义

## 为什么这样修

- 先把假红的测试修正成确定性断言，避免 CI 持续被无效信号绊住
- 再把 CD smoke gate 与现在的前后端拆分部署现实对齐，避免 workflow 自己用过时假设打自己
- 这两处一起收口后，主链判断会重新回到“真实产品回归”而不是“测试构造问题 + smoke 模型漂移”

## 验证

- Worker 侧：`router-meditation-auth.test.js` 现在只要签名被真实篡改，就应稳定返回 `401`
- CD 侧：staging / production smoke gate 现在检查健康接口和 auth boundary，不再要求 backend-only Worker 返回前端首页
- 当前环境无法本地克隆仓库或直接运行 GitHub Actions，最终以该 PR 的 CI / CD 结果继续闭环

Fixes #205
Fixes #204