### PR TITLE
ci: retry transient Cloudflare D1 migration failures

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -9,6 +9,7 @@ import sys
 publish_workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
 deploy_workflow = Path('.github/workflows/deploy-production.yml').read_text(encoding='utf-8')
 co_practice_migration = Path('fabushi/web/migrations/20260506_co_practice_groups.sql')
+d1_retry_helper = Path('.github/scripts/run-wrangler-d1-migrations.sh')
 
 checkout_match = re.search(
     r"- name: Checkout source for version metadata\n(?P<body>.*?)\n\s*- name: Prepare release assets",
@@ -38,21 +39,36 @@ for required in release_asset_requirements:
     if required not in publish_workflow:
         missing.append(required)
 
-expected_migration_commands = (
-    'run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote',
-    'run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote',
+expected_deploy_requirements = (
+    'cp -R .github/scripts ../release-artifact/.github/scripts',
+    'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB development',
+    'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB production',
 )
-for required in expected_migration_commands:
+for required in expected_deploy_requirements:
     if required not in deploy_workflow:
         missing.append(required)
 
 invalid_migration_commands = (
+    'run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote',
+    'run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote',
     'run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote --yes',
     'run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote --yes',
 )
 for invalid in invalid_migration_commands:
     if invalid in deploy_workflow:
         missing.append(f'invalid command still present: {invalid}')
+
+if not d1_retry_helper.exists():
+    missing.append('.github/scripts/run-wrangler-d1-migrations.sh')
+else:
+    helper_text = d1_retry_helper.read_text(encoding='utf-8')
+    for required in (
+        'Upstream service unavailable \\[code: 7009\\]',
+        'WRANGLER_D1_MAX_ATTEMPTS',
+        'npx --yes wrangler@latest d1 migrations apply',
+    ):
+        if required not in helper_text:
+            missing.append(f'd1 retry helper missing: {required}')
 
 if not co_practice_migration.exists():
     missing.append('fabushi/web/migrations/20260506_co_practice_groups.sql')

--- a/.github/scripts/run-wrangler-d1-migrations.sh
+++ b/.github/scripts/run-wrangler-d1-migrations.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <database-binding> <environment> [extra wrangler args...]" >&2
+  exit 64
+fi
+
+binding="$1"
+environment="$2"
+shift 2
+
+max_attempts="${WRANGLER_D1_MAX_ATTEMPTS:-4}"
+delay_seconds="${WRANGLER_D1_RETRY_DELAY_SECONDS:-15}"
+log_file="$(mktemp)"
+trap 'rm -f "$log_file"' EXIT
+
+is_transient_failure() {
+  local path="$1"
+  python3 - "$path" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding='utf-8', errors='ignore')
+patterns = (
+    r'Upstream service unavailable \[code: 7009\]',
+    r'\bECONNRESET\b',
+    r'\bETIMEDOUT\b',
+    r'network socket disconnected',
+    r'error sending request',
+)
+raise SystemExit(0 if any(re.search(pattern, text, re.IGNORECASE) for pattern in patterns) else 1)
+PY
+}
+
+attempt=1
+while true; do
+  echo "Running D1 migrations for binding '$binding' in env '$environment' (attempt $attempt/$max_attempts)"
+
+  set +e
+  npx --yes wrangler@latest d1 migrations apply "$binding" --env "$environment" --remote "$@" 2>&1 | tee "$log_file"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "D1 migrations applied successfully."
+    exit 0
+  fi
+
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "D1 migrations failed after $attempt attempts." >&2
+    exit "$status"
+  fi
+
+  if ! is_transient_failure "$log_file"; then
+    echo "D1 migrations failed with a non-retryable error; stopping after attempt $attempt." >&2
+    exit "$status"
+  fi
+
+  echo "Detected transient Cloudflare D1 failure. Retrying in ${delay_seconds}s..." >&2
+  sleep "$delay_seconds"
+  attempt=$((attempt + 1))
+  delay_seconds=$((delay_seconds * 2))
+done

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -99,8 +99,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ../release-artifact/fabushi/build
+          mkdir -p ../release-artifact/.github
           cp -R build/web ../release-artifact/fabushi/build/web
           cp -R web ../release-artifact/fabushi/web
+          cp -R .github/scripts ../release-artifact/.github/scripts
           find ../release-artifact/fabushi/web -path '*/assets/built_in/*' -prune -exec rm -rf {} + || true
           printf '%s\n' "${{ steps.source.outputs.source_sha }}" > ../release-artifact/SOURCE_SHA
 
@@ -172,7 +174,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
-        run: npx --yes wrangler@latest d1 migrations apply DB --env development --remote
+        run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB development
 
       - name: Deploy staging Worker
         env:
@@ -338,7 +340,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
-        run: npx --yes wrangler@latest d1 migrations apply DB --env production --remote
+        run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB production
 
       - name: Deploy production Worker
         env:

--- a/docs/release-controller.md
+++ b/docs/release-controller.md
@@ -156,6 +156,17 @@ Fabushi 当前主线发布依赖：
 - 新 migration 默认按对现有数据库安全的方式编写，避免在已存在列/表上重复失败
 - 如果某条 migration 是近期事故高发点，应同步给 guardrail 增加正向要求或反向拦截
 
+### Cloudflare D1 瞬时故障重试规则
+
+Fabushi 主线 deploy 里的 `wrangler d1 migrations apply` 会直接碰到 Cloudflare 远端 D1 API。像 `Upstream service unavailable [code: 7009]` 这类平台侧瞬时故障，不应被误判成 schema SQL 根因，但也不能用无限重试把真实配置错误掩盖掉。
+
+默认要求：
+
+- 只对已知瞬时平台故障做有限次数重试与退避，不把所有失败都吞掉
+- SQL 语法、绑定缺失、数据库 id 错误、权限错误等非瞬时失败，首轮就必须直接失败
+- 重试 helper 要作为仓库脚本和 workflow guardrail 一起版本管理，避免后续又漂回裸跑 `wrangler d1 migrations apply`
+- 如果有限重试后仍失败，就把事项继续记为发布闭环阻塞，并在 issue / runbook / 下一轮调度里明确标注为“外部平台或迁移门禁仍未恢复”
+
 ### GitHub Release 资产规则
 
 Fabushi 当前官网 beta 同步会读取 GitHub Release 资产，但 release 一旦进入 immutable 生命周期，就不能再靠 `gh release upload --clobber` 回写或覆盖资产。


### PR DESCRIPTION
## 为什么改

本轮主控巡检发现当前主线唯一确定性红灯是 `Issue #209` 对应的 `CD - Staging API gated production deploy` 失败：

- source SHA: `75c432858f3f7547bf51b7aa688a1a1fadb744c0`
- 失败 job: `Deploy production environment`
- 首个失败步骤: `Apply production D1 migrations`
- 失败日志明确信号：`Upstream service unavailable [code: 7009]`

这个信号更符合 Cloudflare D1 上游瞬时不可用，而不是 schema SQL、本地 migration 文件或凭证缺失导致的确定性配置错误。当前 workflow 直接裸跑 `wrangler d1 migrations apply`，一旦遇到这种平台侧短时故障就会把整条主线 CD 打红。

## 这次改了什么

- 新增 `.github/scripts/run-wrangler-d1-migrations.sh`
  - 只对已知瞬时故障做有限次数重试和退避
  - 对非瞬时错误继续 fail-fast，不吞掉真实问题
- 更新 `.github/workflows/deploy-production.yml`
  - 构建 release artifact 时一并携带 deploy helper scripts
  - development / production 的 D1 migration 步骤改为通过 retry helper 执行
- 更新 `.github/scripts/check-publish-cd-release.sh`
  - 把 retry helper wiring 纳入 guardrail，防止后续回退成裸跑命令
- 更新 `docs/release-controller.md`
  - 把 Cloudflare D1 瞬时故障的长期处理规则同步回仓库运行手册

## 如何验证

- 仓库内结构验证：
  - workflow 已改为调用 `bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB development`
  - workflow 已改为调用 `bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB production`
  - release artifact 会携带 `.github/scripts`
  - guardrail 会校验 helper、workflow wiring 和禁止旧的裸跑命令
- 运行期验证：
  - 这条 PR 合入后，继续回追 `main -> CI -> CD -> GitHub Release -> TestFlight`
  - 重点看 `CD - Staging API gated production deploy` 是否在同类 `7009` 短暂波动下自动恢复
  - 若 helper 用尽重试仍失败，则继续保留 `Issue #209` 作为外部平台或迁移门禁阻塞

## 影响范围

- 只改 deploy workflow、guardrail 和运行手册
- 不改业务逻辑和用户接口
- 属于发布闭环增强与回归防护
