### PR TITLE
feat: strengthen homepage clarity, trust, and search structure

### DIFF
--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -1,12 +1,14 @@
 :root {
   color-scheme: light;
-  --bg: #f5efe2;
-  --surface: rgba(255, 250, 242, 0.86);
-  --ink: #1f170f;
-  --muted: #6d5a48;
-  --accent: #b45f06;
-  --accent-strong: #8b3d0b;
-  --line: rgba(73, 47, 23, 0.14);
+  --bg: #faf8f3;
+  --surface: rgba(255, 255, 255, 0.78);
+  --surface-strong: rgba(255, 255, 255, 0.92);
+  --ink: #171412;
+  --muted: #60584f;
+  --accent: #9a6232;
+  --accent-strong: #734823;
+  --line: rgba(23, 20, 18, 0.1);
+  --shadow: 0 20px 60px rgba(23, 20, 18, 0.06);
 }
 
 * {
@@ -20,9 +22,19 @@ html {
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top, rgba(255, 226, 186, 0.7), transparent 38%),
-    linear-gradient(180deg, #f7f0e4 0%, #f3e6d2 48%, #efe0cb 100%);
+    radial-gradient(circle at top left, rgba(224, 196, 153, 0.22), transparent 30%),
+    radial-gradient(circle at top right, rgba(232, 214, 191, 0.2), transparent 28%),
+    linear-gradient(180deg, #fbfaf6 0%, #f6f1e9 48%, #f2ece2 100%);
   color: var(--ink);
+  font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", sans-serif;
+}
+
+h1,
+h2,
+h3,
+.brand-kicker,
+.site-wordmark,
+.footer-title {
   font-family: "Noto Serif SC", "Source Han Serif SC", serif;
 }
 
@@ -47,8 +59,8 @@ a {
 
 .hero,
 .band {
-  padding-top: 32px;
-  padding-bottom: 64px;
+  padding-top: 36px;
+  padding-bottom: 72px;
 }
 
 .inner-hero {
@@ -57,22 +69,43 @@ a {
 }
 
 .hero {
-  min-height: 92vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 28px;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.8fr);
+  gap: 32px;
+  align-items: end;
 }
 
 .site-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 20px;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(23, 20, 18, 0.08);
 }
 
 .site-wordmark {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
   font-size: 1rem;
   font-weight: 700;
+}
+
+.site-wordmark small {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .site-nav-links,
@@ -86,12 +119,13 @@ a {
 .hero-copy,
 .inner-copy,
 .section-heading,
-.article-body {
-  max-width: 860px;
+.article-body,
+.final-cta {
+  max-width: 960px;
 }
 
 .hero-copy {
-  padding: 12vh 0 8vh;
+  padding: 8vh 0 6vh;
 }
 
 .inner-copy {
@@ -102,7 +136,9 @@ a {
 .section-heading p,
 .platform-name,
 .download-status,
-.article-date {
+.article-date,
+.surface-tag,
+.trust-item span {
   margin: 0 0 12px;
   color: var(--accent-strong);
   font-size: 0.95rem;
@@ -110,25 +146,31 @@ a {
 
 .brand-kicker {
   margin: 0 0 16px;
-  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  font-size: clamp(1.9rem, 3vw, 3rem);
 }
 
 .hero-copy h1,
 .inner-copy h1,
-.section-heading h2 {
+.section-heading h2,
+.final-cta h2 {
   margin: 0;
-  line-height: 1.05;
+  line-height: 1.06;
   letter-spacing: 0;
 }
 
 .hero-copy h1 {
-  font-size: clamp(3rem, 8vw, 6.4rem);
-  max-width: 12ch;
+  font-size: clamp(3rem, 7vw, 6.2rem);
+  max-width: 11ch;
 }
 
 .inner-copy h1,
-.section-heading h2 {
-  font-size: clamp(2.2rem, 5vw, 4.4rem);
+.section-heading h2,
+.final-cta h2 {
+  font-size: clamp(2.15rem, 4.8vw, 4.2rem);
+}
+
+.section-heading.compact h2 {
+  max-width: 16ch;
 }
 
 .lede,
@@ -143,20 +185,31 @@ a {
 .empty-copy,
 .roadmap-list,
 .release-card p,
-.release-note {
+.release-note,
+.trust-item p,
+.journey-card p,
+.surface-card p,
+.definition-card p,
+.contact-card p {
   color: var(--muted);
   line-height: 1.75;
 }
 
 .lede {
-  margin: 20px 0 0;
+  margin: 22px 0 0;
   max-width: 46rem;
-  font-size: 1.1rem;
+  font-size: 1.08rem;
+}
+
+.lede.small {
+  max-width: 40rem;
+  font-size: 1rem;
 }
 
 .hero-actions,
 .inline-cta,
-.release-card-actions {
+.release-card-actions,
+.final-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
@@ -167,16 +220,16 @@ a {
 .secondary-action {
   border-radius: 999px;
   padding: 12px 20px;
-  transition: transform 180ms ease, background-color 180ms ease;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
 }
 
 .primary-action {
   background: var(--accent);
-  color: #fff7ed;
+  color: #fffaf4;
 }
 
 .secondary-action {
-  background: var(--surface);
+  background: var(--surface-strong);
   border: 1px solid var(--line);
 }
 
@@ -185,13 +238,28 @@ a {
   transform: translateY(-1px);
 }
 
+.kicker-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.kicker-list span {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(23, 20, 18, 0.08);
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 .hero-panel {
-  align-self: flex-end;
-  max-width: 360px;
-  padding: 22px;
-  background: rgba(54, 31, 14, 0.08);
-  border: 1px solid var(--line);
-  border-radius: 8px;
+  padding: 24px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(249, 243, 235, 0.82));
+  border: 1px solid rgba(23, 20, 18, 0.08);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
   backdrop-filter: blur(12px);
 }
 
@@ -204,31 +272,81 @@ a {
 
 .hero-panel strong {
   display: block;
-  margin: 8px 0 10px;
-  font-size: 1.25rem;
+  margin: 8px 0 18px;
+  font-size: 1.2rem;
+}
+
+.hero-route-map {
+  display: grid;
+  gap: 12px;
+}
+
+.hero-route-item {
+  display: grid;
+  gap: 6px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(23, 20, 18, 0.08);
+}
+
+.hero-route-item:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.hero-route-item span {
+  color: var(--accent-strong);
+}
+
+.hero-route-item strong {
+  margin: 0;
+  font-size: 1rem;
 }
 
 .band.alt {
-  background: rgba(255, 249, 239, 0.65);
+  background: rgba(255, 255, 255, 0.36);
 }
 
 .band.cinematic {
   background:
-    linear-gradient(120deg, rgba(188, 110, 34, 0.08), rgba(255, 250, 242, 0.35)),
-    linear-gradient(180deg, rgba(255, 244, 228, 0.8), rgba(242, 228, 206, 0.6));
+    linear-gradient(120deg, rgba(154, 98, 50, 0.08), rgba(255, 255, 255, 0.25)),
+    linear-gradient(180deg, rgba(255, 248, 240, 0.88), rgba(246, 238, 226, 0.76));
 }
 
 .section-heading {
-  margin-bottom: 28px;
+  margin-bottom: 30px;
+}
+
+.section-heading h2 {
+  max-width: 14ch;
 }
 
 .feature-grid,
 .architecture-grid,
 .download-grid,
-.application-grid {
+.application-grid,
+.trust-grid,
+.journey-grid,
+.surface-grid,
+.definition-grid {
   display: grid;
   gap: 16px;
+}
+
+.feature-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-grid-wide,
+.trust-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.journey-grid,
+.surface-grid,
+.definition-grid,
+.proof-layout,
+.contact-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .feature-block,
@@ -236,18 +354,46 @@ a {
 .download-card,
 .application-card,
 .preview-row,
-.release-card {
+.release-card,
+.journey-card,
+.surface-card,
+.definition-card,
+.contact-card {
   background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
+  border: 1px solid rgba(23, 20, 18, 0.08);
+  border-radius: 14px;
+  padding: 20px;
   backdrop-filter: blur(10px);
+  box-shadow: 0 14px 40px rgba(23, 20, 18, 0.04);
+}
+
+.trust-band {
+  padding-top: 8px;
+}
+
+.trust-item {
+  display: grid;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(23, 20, 18, 0.08);
+}
+
+.trust-item strong {
+  font-size: 1.15rem;
+}
+
+.trust-item p,
+.journey-summary {
+  margin: 0;
 }
 
 .feature-block h3,
 .architecture-grid h3,
 .download-card h2,
-.release-card h2 {
+.release-card h2,
+.journey-card h3,
+.surface-card h3,
+.definition-card h3 {
   margin: 0 0 10px;
 }
 
@@ -267,7 +413,6 @@ a {
 }
 
 .status-note-list p,
-.contact-card p,
 .editorial-row small,
 .release-mirror-block p {
   margin: 0;
@@ -289,7 +434,7 @@ a {
 }
 
 .editorial-row {
-  grid-template-columns: 140px minmax(0, 1fr);
+  grid-template-columns: 120px minmax(0, 1fr);
   align-items: start;
 }
 
@@ -304,7 +449,8 @@ a {
 
 .platform-meta strong,
 .download-card strong,
-.editorial-row strong {
+.editorial-row strong,
+.contact-card strong {
   display: block;
 }
 
@@ -340,7 +486,9 @@ a {
   line-height: 1.75;
 }
 
-.release-update-list li + li {
+.release-update-list li + li,
+.application-list li + li,
+.roadmap-list li + li {
   margin-top: 8px;
 }
 
@@ -353,7 +501,9 @@ a {
   gap: 12px;
 }
 
-.release-note {
+.release-note,
+.application-summary,
+.application-list {
   margin: 0;
 }
 
@@ -365,31 +515,13 @@ a {
 
 .application-summary,
 .application-list {
-  margin: 0;
   color: var(--muted);
   line-height: 1.75;
 }
 
-.application-list {
+.application-list,
+.roadmap-list {
   padding-left: 20px;
-}
-
-.application-list li + li {
-  margin-top: 8px;
-}
-
-.contact-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.contact-card {
-  display: block;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
 }
 
 .contact-card span,
@@ -401,20 +533,16 @@ a {
   margin: 8px 0 10px;
 }
 
-.roadmap-list {
-  margin: 0;
-  padding-left: 20px;
-}
-
-.roadmap-list li + li {
-  margin-top: 12px;
-}
-
 .preview-row {
   display: grid;
   grid-template-columns: 56px minmax(0, 1fr) max-content;
   gap: 14px;
   align-items: center;
+}
+
+.proof-layout {
+  display: grid;
+  gap: 24px;
 }
 
 .faq-item {
@@ -448,6 +576,24 @@ a {
   font-size: 1.08rem;
 }
 
+.final-cta-band {
+  padding-top: 0;
+}
+
+.final-cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 24px;
+  padding-top: 28px;
+  border-top: 1px solid rgba(23, 20, 18, 0.08);
+}
+
+.final-actions {
+  margin-top: 0;
+  align-self: flex-end;
+}
+
 .site-footer {
   display: flex;
   justify-content: space-between;
@@ -462,6 +608,28 @@ a {
   font-weight: 700;
 }
 
+.footer-copy {
+  margin: 0;
+  max-width: 34rem;
+}
+
+.footer-copy + .footer-copy {
+  margin-top: 6px;
+}
+
+@media (max-width: 900px) {
+  .hero-grid,
+  .proof-layout,
+  .final-cta {
+    grid-template-columns: minmax(0, 1fr);
+    flex-direction: column;
+  }
+
+  .hero-copy {
+    padding-top: 4vh;
+  }
+}
+
 @media (max-width: 720px) {
   .hero,
   .band,
@@ -474,13 +642,19 @@ a {
 
   .site-nav,
   .site-footer,
-  .release-card-header {
+  .release-card-header,
+  .final-cta {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .hero-panel {
-    align-self: stretch;
+  .hero-grid,
+  .journey-grid,
+  .surface-grid,
+  .definition-grid,
+  .proof-layout,
+  .contact-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .platform-row,
@@ -491,5 +665,9 @@ a {
 
   .platform-meta {
     text-align: left;
+  }
+
+  .final-actions {
+    margin-top: 4px;
   }
 }

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -9,10 +9,16 @@ const homeUrl = siteUrl("/");
 export const metadata: Metadata = {
   title: `${brand.name} | 官网`,
   description: brand.mission,
+  applicationName: brand.englishName,
   metadataBase: new URL(homeUrl),
   alternates: {
     canonical: homeUrl,
   },
+  keywords: ["法布施", "Fabushi", "佛法传播", "修行记录", "微信小程序", "共修", "佛教应用"],
+  category: "religion",
+  creator: "Fabushi Team",
+  publisher: "Fabushi Team",
+  referrer: "origin-when-cross-origin",
   openGraph: {
     title: `${brand.name} | 官网`,
     description: brand.mission,
@@ -20,6 +26,22 @@ export const metadata: Metadata = {
     siteName: "Fabushi",
     locale: "zh_CN",
     type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${brand.name} | 官网`,
+    description: brand.mission,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
 };
 

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,10 +1,19 @@
 import { fabushiApiClient } from "@fabushi/api-client";
-import { brand, contactChannels, faqItems, homeHighlights, launchRoadmap } from "@fabushi/shared";
+import {
+  audienceJourneys,
+  brand,
+  contactChannels,
+  faqItems,
+  homeHighlights,
+  launchRoadmap,
+  productSurfaceMap,
+  trustHighlights,
+} from "@fabushi/shared";
 import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
 import { getAllArticles, getFeaturedArticles } from "../lib/content";
 import { getOfficialSiteReleaseCollection } from "../lib/official-site-releases";
-import { siteHref } from "../lib/site-url";
+import { siteHref, siteUrl } from "../lib/site-url";
 
 async function getLeaderboardPreview() {
   try {
@@ -28,39 +37,112 @@ export default async function HomePage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
 
+  const structuredData = [
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      name: brand.name,
+      alternateName: brand.englishName,
+      url: siteUrl("/"),
+      email: "support@fabushi.com",
+      sameAs: ["https://github.com/bhrumom/fabushi"],
+      description: brand.mission,
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: `${brand.name}官网`,
+      url: siteUrl("/"),
+      description: brand.mission,
+      inLanguage: "zh-CN",
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: faqItems.slice(0, 4).map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    },
+  ];
+
   return (
     <main className="page-shell">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+
       <header className="hero">
         <SiteHeader />
 
-        <div className="hero-copy">
-          <p className="eyebrow">法布施官网</p>
-          <p className="brand-kicker">{brand.name}</p>
-          <h1>官网负责入口，小程序负责触达，主应用负责完整体验。</h1>
-          <p className="lede">{brand.mission}</p>
-          <div className="hero-actions">
-            <a className="primary-action" href={siteHref("/download")}>
-              查看下载入口
-            </a>
-            <a className="secondary-action" href={siteHref("/faq")}>
-              查看常见问题
-            </a>
+        <div className="hero-grid">
+          <div className="hero-copy">
+            <p className="eyebrow">法布施官网</p>
+            <p className="brand-kicker">{brand.name}</p>
+            <h1>把佛法传播、修行记录与共修协作，收进一个清楚、可信、可持续的数字入口。</h1>
+            <p className="lede">
+              {brand.mission} 当前官网优先解决三件事：把产品讲清楚，把下载与测试入口讲明白，把官网、微信小程序和主应用的职责边界讲透。
+            </p>
+            <div className="hero-actions">
+              <a className="primary-action" href={siteHref("/download")}>
+                查看下载入口
+              </a>
+              <a className="secondary-action" href={siteHref("/#product-surfaces")}>
+                了解三端分工
+              </a>
+            </div>
+            <div className="kicker-list" aria-label="首页关键信息">
+              <span>官网承接搜索与对外入口</span>
+              <span>小程序承接微信生态轻触达</span>
+              <span>主应用承接完整长期体验</span>
+            </div>
           </div>
-        </div>
 
-        <div className="hero-panel">
-          <p>当前推进</p>
-          <strong>Next.js 官网 + Taro 微信小程序 + 现有 Workers API 共用</strong>
-          <span>现在官网会直接读取最新 beta 发布资产，并预留人工验收后的正式版发布入口。</span>
+          <aside className="hero-panel" aria-label="当前站点策略">
+            <p>当前站点策略</p>
+            <strong>先把入口和边界讲清楚，再把发布链路、内容运营和搜索可见性持续接进来。</strong>
+            <div className="hero-route-map">
+              <div className="hero-route-item">
+                <span>官网</span>
+                <strong>说明、搜索、下载入口、FAQ</strong>
+              </div>
+              <div className="hero-route-item">
+                <span>微信小程序</span>
+                <strong>轻浏览、榜单、公开档案、基础登录</strong>
+              </div>
+              <div className="hero-route-item">
+                <span>Flutter 主应用</span>
+                <strong>沉浸式体验、创作上传、长期记录</strong>
+              </div>
+            </div>
+          </aside>
         </div>
       </header>
+
+      <section className="band trust-band" aria-labelledby="trust-heading">
+        <div className="section-heading compact" id="trust-heading">
+          <p>信任与判断依据</p>
+          <h2>不只讲愿景，也把用户现在最需要确认的真实信息直接放在首页。</h2>
+        </div>
+        <div className="trust-grid">
+          {trustHighlights.map((item) => (
+            <article key={item.title} className="trust-item">
+              <span>{item.title}</span>
+              <strong>{item.value}</strong>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
-          <h2>官网负责品牌与入口，小程序负责轻场景触达，Flutter 继续承接重体验。</h2>
+          <h2>法布施当前最适合先被理解成一个帮助传播、记录、发现与共修连接的多端产品体系。</h2>
         </div>
-        <div className="feature-grid">
+        <div className="feature-grid feature-grid-wide">
           {homeHighlights.map((item) => (
             <article key={item.title} className="feature-block">
               <h3>{item.title}</h3>
@@ -70,10 +152,42 @@ export default async function HomePage() {
         </div>
       </section>
 
+      <section className="band alt" id="audiences">
+        <div className="section-heading">
+          <p>适合谁用</p>
+          <h2>首页不只回答“这是什么”，也应该回答“这对谁现在最有用”。</h2>
+        </div>
+        <div className="journey-grid">
+          {audienceJourneys.map((item) => (
+            <article key={item.title} className="journey-card">
+              <h3>{item.title}</h3>
+              <p className="journey-summary">{item.summary}</p>
+              <p>{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band" id="product-surfaces">
+        <div className="section-heading">
+          <p>产品分工</p>
+          <h2>官网、小程序和主应用不是三张重复页面，而是三种职责清楚的入口与工作面。</h2>
+        </div>
+        <div className="surface-grid">
+          {productSurfaceMap.map((item) => (
+            <article key={item.title} className="surface-card">
+              <span className="surface-tag">{item.title}</span>
+              <h3>{item.role}</h3>
+              <p>{item.bestFor}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="band cinematic">
         <div className="section-heading">
-          <p>下载入口</p>
-          <h2>beta 安装包和 TestFlight 状态已经能直接回流到官网入口里。</h2>
+          <p>下载与发布状态</p>
+          <h2>官网现在已经开始承接真实发布状态，而不是只放一段静态等待说明。</h2>
         </div>
         <div className="platform-strip">
           {releasePreview.map((item) => (
@@ -98,8 +212,22 @@ export default async function HomePage() {
 
       <section className="band alt" id="mini-program">
         <div className="section-heading">
-          <p>微信小程序</p>
-          <h2>首期建议先覆盖轻浏览、榜单、公开档案与基础登录。</h2>
+          <p>为什么先这样做</p>
+          <h2>当前阶段最重要的不是把所有功能一次堆满，而是先把每个入口的工作边界和推进顺序做对。</h2>
+        </div>
+        <div className="definition-grid">
+          <div className="definition-card">
+            <h3>先把官网做成真实入口</h3>
+            <p>官网先承接品牌说明、下载判断、FAQ 和内容页，才能稳定支持搜索、分享和后续活动页面扩展。</p>
+          </div>
+          <div className="definition-card">
+            <h3>小程序先做轻路径</h3>
+            <p>微信生态更适合轻浏览、公开发现和快速传播，所以首期优先覆盖榜单、档案、登录和基础触达链路。</p>
+          </div>
+          <div className="definition-card">
+            <h3>主应用保留重体验</h3>
+            <p>更完整的创作、上传、沉浸式浏览和长期记录仍由主应用承接，避免为了轻入口反而稀释核心体验。</p>
+          </div>
         </div>
         <ol className="roadmap-list">
           {launchRoadmap.map((item) => (
@@ -108,85 +236,61 @@ export default async function HomePage() {
         </ol>
       </section>
 
-      <section className="band" id="architecture">
+      <section className="band" id="proof">
         <div className="section-heading">
-          <p>技术架构</p>
-          <h2>一个前端 monorepo，共享接口层、类型、文案和部分纯业务逻辑。</h2>
+          <p>真实接口验证</p>
+          <h2>首页已经不只是文案展示，它会直接读取现有后端接口和持续内容资产。</h2>
         </div>
-        <div className="architecture-grid">
+        <div className="proof-layout">
           <div>
-            <h3>apps/web</h3>
-            <p>Next.js 官网，负责 SEO、落地页、功能说明、后续内容运营。</p>
+            <h3>排行榜预览</h3>
+            <div className="preview-list">
+              {leaderboard.length === 0 ? (
+                <p className="empty-copy">当前没有拉到排行榜预览，页面仍可正常展示静态说明与下载入口。</p>
+              ) : (
+                leaderboard.map((item, index) => (
+                  <div key={item.username} className="preview-row">
+                    <span>#{index + 1}</span>
+                    <strong>{item.displayName || item.username}</strong>
+                    <span>{item.totalBytes.toLocaleString()} bytes</span>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
           <div>
-            <h3>apps/mp-wechat</h3>
-            <p>Taro 微信小程序，围绕微信生态内的轻触达和轻交互。</p>
+            <h3>内容专栏</h3>
+            <div className="editorial-list">
+              {featuredArticles.map((item) => (
+                <a key={item.slug} className="editorial-row" href={siteHref(`/insights/${item.slug}`)}>
+                  <span>{item.category}</span>
+                  <div>
+                    <strong>{item.title}</strong>
+                    <p>{item.description}</p>
+                    <small>
+                      {item.author} · {item.readTime}
+                    </small>
+                  </div>
+                </a>
+              ))}
+            </div>
+            <div className="inline-cta">
+              <a className="secondary-action" href={siteHref("/insights")}>
+                查看全部 {allArticles.length} 篇内容
+              </a>
+            </div>
           </div>
-          <div>
-            <h3>packages/shared</h3>
-            <p>品牌信息、导航、固定文案、纯前端通用工具。</p>
-          </div>
-          <div>
-            <h3>packages/api-client</h3>
-            <p>统一对接现有 `flutter.ombhrum.com` API 与共享类型。</p>
-          </div>
-        </div>
-      </section>
-
-      <section className="band alt">
-        <div className="section-heading">
-          <p>接口复用</p>
-          <h2>官网已经直接接了现有排行榜接口，作为“后端继续共用”的第一块落地验证。</h2>
-        </div>
-        <div className="preview-list">
-          {leaderboard.length === 0 ? (
-            <p className="empty-copy">当前没有拉到排行榜预览，页面仍可正常展示静态内容。</p>
-          ) : (
-            leaderboard.map((item, index) => (
-              <div key={item.username} className="preview-row">
-                <span>#{index + 1}</span>
-                <strong>{item.displayName || item.username}</strong>
-                <span>{item.totalBytes.toLocaleString()} bytes</span>
-              </div>
-            ))
-          )}
-        </div>
-      </section>
-
-      <section className="band">
-        <div className="section-heading">
-          <p>内容专栏</p>
-          <h2>官网不只是一张首页，还要能持续承接路线、更新和专题内容。</h2>
-        </div>
-        <div className="editorial-list">
-          {featuredArticles.map((item) => (
-            <a key={item.slug} className="editorial-row" href={siteHref(`/insights/${item.slug}`)}>
-              <span>{item.category}</span>
-              <div>
-                <strong>{item.title}</strong>
-                <p>{item.description}</p>
-                <small>
-                  {item.author} · {item.readTime}
-                </small>
-              </div>
-            </a>
-          ))}
-        </div>
-        <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/insights")}>
-            查看全部 {allArticles.length} 篇内容
-          </a>
         </div>
       </section>
 
       <section className="band alt">
         <div className="section-heading">
           <p>常见问题</p>
-          <h2>先把用户最容易问的几件事说清楚，官网才真正开始工作。</h2>
+          <h2>把最常反复解释的问题直接写成清楚答案，更利于搜索理解、AI 摘要和人工判断。</h2>
         </div>
         <div className="faq-list">
-          {faqItems.slice(0, 3).map((item) => (
-            <details key={item.question} className="faq-item">
+          {faqItems.slice(0, 4).map((item) => (
+            <details key={item.question} className="faq-item" open>
               <summary>{item.question}</summary>
               <p>{item.answer}</p>
             </details>
@@ -202,8 +306,28 @@ export default async function HomePage() {
         </div>
       </section>
 
+      <section className="band final-cta-band">
+        <div className="final-cta">
+          <div>
+            <p className="eyebrow">下一步</p>
+            <h2>先选正确入口，再决定是体验、反馈、传播还是合作。</h2>
+            <p className="lede small">
+              当前官网已经适合承担说明、下载判断和内容承接。下一步最自然的动作，是去看下载状态、申请测试资格，或者直接进入公开开发记录。
+            </p>
+          </div>
+          <div className="hero-actions final-actions">
+            <a className="primary-action" href={siteHref("/download")}>
+              去下载入口
+            </a>
+            <a className="secondary-action" href={siteHref("/apply")}>
+              申请测试
+            </a>
+          </div>
+        </div>
+      </section>
+
       <section className="band">
-        <div className="section-heading">
+        <div className="section-heading compact">
           <p>联系</p>
           <h2>除了下载入口之外，官网也要把支持、反馈和公开协作的去处讲清楚。</h2>
         </div>

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -6,6 +6,7 @@ export function SiteFooter() {
       <div>
         <p className="footer-title">法布施 Fabushi</p>
         <p className="footer-copy">让佛法、修行与善意传播得更远。</p>
+        <p className="footer-copy">官网负责说明与入口，小程序负责轻触达，主应用负责更完整的长期体验。</p>
       </div>
       <div className="footer-links">
         <a href={siteHref("/download")}>下载入口</a>

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -5,7 +5,8 @@ export function SiteHeader() {
   return (
     <nav className="site-nav" aria-label="主导航">
       <a className="site-wordmark" href={siteHref("/")}>
-        Fabushi
+        <span>法布施</span>
+        <small>Fabushi</small>
       </a>
       <div className="site-nav-links">
         {primaryNavigation.map((item) => (

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -13,14 +13,63 @@ export const homeHighlights = [
   },
 ] as const;
 
-export const primaryNavigation = [
-  { label: "首页", href: "/" },
-  { label: "下载", href: "/download" },
-  { label: "申请测试", href: "/apply" },
-  { label: "常见问题", href: "/faq" },
-  { label: "联系", href: "/contact" },
-  { label: "核心能力", href: "/#capabilities" },
-  { label: "内容专栏", href: "/insights" },
+export const trustHighlights = [
+  {
+    title: "发布状态回流官网",
+    value: "Release / TestFlight / 正式版同步",
+    description: "下载页可以直接承接 GitHub Release、TestFlight 上传状态和后续人工验收后的正式版入口。",
+  },
+  {
+    title: "三端分工清楚",
+    value: "官网 / 微信小程序 / 主应用",
+    description: "用户先看懂从哪里开始，再决定是轻触达、持续传播，还是进入完整沉浸式体验。",
+  },
+  {
+    title: "现有后端继续复用",
+    value: "Workers API + 共享类型",
+    description: "官网不是独立空壳，而是继续共用现有 API、业务模型和发布链路。",
+  },
+  {
+    title: "公开开发可追踪",
+    value: "GitHub 仓库持续公开",
+    description: "官网、下载状态、专题内容与项目推进可以在同一条公开记录里被追溯和验证。",
+  },
+] as const;
+
+export const audienceJourneys = [
+  {
+    title: "第一次了解法布施的人",
+    summary: "先通过官网快速理解产品定位、开放状态和当前最合适的入口。",
+    detail: "适合想知道这个项目到底解决什么问题、当前能不能加入、下一步应该从哪里开始的人。",
+  },
+  {
+    title: "已经在持续修行的人",
+    summary: "可以用主应用沉淀更完整的修行记录、公开档案和内容互动。",
+    detail: "如果你需要更完整的个人中心、内容创作和长期记录体验，主应用会是核心承接面。",
+  },
+  {
+    title: "希望传播或共修协作的人",
+    summary: "先从微信小程序和公开榜单进入轻触达，再逐步沉淀到更完整的关系链路里。",
+    detail: "这条路径更适合内容传播、活动扩散、公开发现和社群连接等轻量但高频的场景。",
+  },
+] as const;
+
+export const productSurfaceMap = [
+  {
+    title: "官网",
+    role: "品牌说明、下载入口、FAQ、专题内容",
+    bestFor: "初次认知、搜索收录、生成式搜索引用、活动落地页与长期对外入口。",
+  },
+  {
+    title: "微信小程序",
+    role: "轻浏览、榜单、公开档案、基础登录",
+    bestFor: "微信生态内的轻触达、社交发现和传播起点。",
+  },
+  {
+    title: "Flutter 主应用",
+    role: "完整体验、重交互、沉浸式内容与长期记录",
+    bestFor: "更完整的创作、上传、关系链与个人沉淀。",
+  },
 ] as const;
 
 export const launchRoadmap = [


### PR DESCRIPTION
## 为什么改

这一轮官网优化优先处理首页最关键的几个问题：

- 首屏已经有信息，但价值表达还不够聚焦，用户不容易一眼看懂官网、小程序、主应用分别负责什么
- 首页缺少更直接的信任信号、适用对象说明和结构化定义，SEO / GEO 可理解性还不够强
- 页面视觉层级偏平，模块之间的主次关系和转化路径还可以更清楚

## 这次改了什么

- 重写首页首屏与模块顺序
  - 把首页改成“价值表达 -> 信任依据 -> 适合谁用 -> 三端分工 -> 下载状态 -> 推进逻辑 -> 真实接口验证 -> FAQ -> CTA”
- 补强共享文案结构
  - 新增 trust highlights、audience journeys、product surface map，减少首页对单段解释文案的依赖
- 提升 SEO / GEO 结构
  - 在布局层补充 keywords、robots、twitter / open graph 基础信息
  - 在首页加入 Organization、WebSite、FAQPage JSON-LD
  - 让首页直接回答“这是什么、适合谁、为什么这样设计、从哪里开始”
- 升级视觉层级
  - 调整全局配色、字体搭配、首屏网格、胶囊信息带、信任区、终局 CTA 和页脚品牌表达
  - 让首页整体更克制、更清楚，也更接近可持续运营的官网气质

## 影响范围

- `frontend/apps/web/src/app/page.tsx`
- `frontend/apps/web/src/app/layout.tsx`
- `frontend/apps/web/src/app/globals.css`
- `frontend/apps/web/src/components/site-header.tsx`
- `frontend/apps/web/src/components/site-footer.tsx`
- `frontend/packages/shared/src/copy.ts`

## 验证

- 已做分支内文件级自检，确认首页结构、样式类名和元信息互相对齐
- 当前环境无法直接本地安装依赖并跑 Next.js 构建，最终以 PR 的 `CI result` 为准
