### PR TITLE
fix: package CD helper scripts from repo root

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -40,7 +40,7 @@ for required in release_asset_requirements:
         missing.append(required)
 
 expected_deploy_requirements = (
-    'cp -R .github/scripts ../release-artifact/.github/scripts',
+    'cp -R ../.github/scripts ../release-artifact/.github/scripts',
     'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB development',
     'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB production',
 )
@@ -57,6 +57,13 @@ invalid_migration_commands = (
 for invalid in invalid_migration_commands:
     if invalid in deploy_workflow:
         missing.append(f'invalid command still present: {invalid}')
+
+invalid_deploy_packaging = (
+    'cp -R .github/scripts ../release-artifact/.github/scripts',
+)
+for invalid in invalid_deploy_packaging:
+    if invalid in deploy_workflow:
+        missing.append(f'invalid helper packaging still present: {invalid}')
 
 if not d1_retry_helper.exists():
     missing.append('.github/scripts/run-wrangler-d1-migrations.sh')

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir -p ../release-artifact/.github
           cp -R build/web ../release-artifact/fabushi/build/web
           cp -R web ../release-artifact/fabushi/web
-          cp -R .github/scripts ../release-artifact/.github/scripts
+          cp -R ../.github/scripts ../release-artifact/.github/scripts
           find ../release-artifact/fabushi/web -path '*/assets/built_in/*' -prune -exec rm -rf {} + || true
           printf '%s\n' "${{ steps.source.outputs.source_sha }}" > ../release-artifact/SOURCE_SHA
 


### PR DESCRIPTION
## 为什么改

本轮主控继续推进发布闭环时，最新主线红灯已经从 `#209` 的 Cloudflare D1 瞬时故障切换成新的 `#214`：

- source SHA: `634d50179db27854eb206947aac7638995e1f1de`
- 失败 workflow: `CD - Staging API gated production deploy #127`
- 首个失败 job: `Build release artifact`
- 首个失败步骤: `Package release artifact`
- 失败日志明确信号：`cp: cannot stat '.github/scripts': No such file or directory`

这不是 Cloudflare 外部平台问题，而是 `#210` 自己引入的一条打包路径回归：

- `build-artifact` job 的默认工作目录是 `fabushi/`
- 但新加入的 helper 打包步骤仍按仓库根目录写成了 `cp -R .github/scripts ...`
- 结果 helper 脚本根本没有被装进 release artifact，后续 CD 还没走到 D1 retry 就先在打包阶段失败

## 这次改了什么

- 更新 `.github/workflows/deploy-production.yml`
  - 把 helper 打包路径改成相对于 `fabushi/` 工作目录正确可达的 `../.github/scripts`
- 更新 `.github/scripts/check-publish-cd-release.sh`
  - guardrail 现在要求正确的 `../.github/scripts` 路径
  - 同时显式拦截旧的错误路径，避免以后再把同类回归带回主线

## 为什么这样修

- 保留 `#210` 已经引入的 D1 瞬时故障有限重试能力
- 只修 helper 脚本装箱路径，不扩大改动面
- 把这类“workflow 默认工作目录与相对路径不一致”的问题收口成 guardrail，而不是靠下一次主线红灯才发现

## 如何验证

- `deploy-production.yml` 的 `Package release artifact` 现在会从 `fabushi/` 回到仓库根目录复制 `.github/scripts`
- guardrail 会要求正确路径，并拒绝旧错误路径
- PR 合入后继续回追：`main -> CI -> CD -> GitHub Release -> TestFlight`
- 重点观察：
  - `Build release artifact` 不再因缺失 `.github/scripts` 失败
  - `#210` 引入的 D1 retry helper 能真正进入 staging / production deploy 阶段生效

## 关联

- Fixes #214
- Follow-up to #210
- Keeps #209 on the intended repair path
