### PR TITLE
fix: ship CD helper scripts outside hidden artifact paths

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -40,9 +40,10 @@ for required in release_asset_requirements:
         missing.append(required)
 
 expected_deploy_requirements = (
-    'cp -R ../.github/scripts ../release-artifact/.github/scripts',
-    'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB development',
-    'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB production',
+    'mkdir -p ../release-artifact/github-scripts',
+    'cp -R ../.github/scripts/. ../release-artifact/github-scripts',
+    'run: bash ../../github-scripts/run-wrangler-d1-migrations.sh DB development',
+    'run: bash ../../github-scripts/run-wrangler-d1-migrations.sh DB production',
 )
 for required in expected_deploy_requirements:
     if required not in deploy_workflow:
@@ -60,10 +61,13 @@ for invalid in invalid_migration_commands:
 
 invalid_deploy_packaging = (
     'cp -R .github/scripts ../release-artifact/.github/scripts',
+    'cp -R ../.github/scripts ../release-artifact/.github/scripts',
+    'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB development',
+    'run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB production',
 )
 for invalid in invalid_deploy_packaging:
     if invalid in deploy_workflow:
-        missing.append(f'invalid helper packaging still present: {invalid}')
+        missing.append(f'invalid helper artifact path still present: {invalid}')
 
 if not d1_retry_helper.exists():
     missing.append('.github/scripts/run-wrangler-d1-migrations.sh')

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -99,10 +99,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ../release-artifact/fabushi/build
-          mkdir -p ../release-artifact/.github
+          mkdir -p ../release-artifact/github-scripts
           cp -R build/web ../release-artifact/fabushi/build/web
           cp -R web ../release-artifact/fabushi/web
-          cp -R ../.github/scripts ../release-artifact/.github/scripts
+          cp -R ../.github/scripts/. ../release-artifact/github-scripts
           find ../release-artifact/fabushi/web -path '*/assets/built_in/*' -prune -exec rm -rf {} + || true
           printf '%s\n' "${{ steps.source.outputs.source_sha }}" > ../release-artifact/SOURCE_SHA
 
@@ -174,7 +174,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
-        run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB development
+        run: bash ../../github-scripts/run-wrangler-d1-migrations.sh DB development
 
       - name: Deploy staging Worker
         env:
@@ -340,7 +340,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || secrets.CLOUDFLARE_API_KEY || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN || vars.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL || secrets.CF_EMAIL || vars.CF_EMAIL || vars.CLOUDFLARE_EMAIL }}
-        run: bash ../../.github/scripts/run-wrangler-d1-migrations.sh DB production
+        run: bash ../../github-scripts/run-wrangler-d1-migrations.sh DB production
 
       - name: Deploy production Worker
         env:


### PR DESCRIPTION
## 为什么改

`PR #216` 修掉了 build-artifact 阶段的相对路径，但 merge 后主线 `CD #128` 仍在 staging deploy 失败，新的 open issue 已切换成 `#220`。

这次失败的首个确定根因不是 Cloudflare D1 本身，而是 release artifact 的打包形态仍然不对：

- build job 里虽然已经把 helper 从仓库根目录复制进 artifact
- 但复制目标仍是隐藏目录 `release-artifact/.github/scripts`
- `actions/upload-artifact@v7` 默认不会把这类隐藏目录内容带进下载后的 artifact
- 结果 deploy job 在 `release-artifact/fabushi/web` 里执行 `bash ../../.github/scripts/run-wrangler-d1-migrations.sh ...` 时，下载后的 artifact 实际并没有这个路径，于是直接报 `No such file or directory`

所以这不是 `#209` 那种 Cloudflare `7009` 继续复发，而是 `#216` 之后暴露出来的下一层 artifact packaging 回归。

## 这次改了什么

- 把 D1 retry helper 从隐藏目录 artifact 路径改成显式的 `release-artifact/github-scripts`
- staging / production 两个 deploy job 都改为从 `../../github-scripts/run-wrangler-d1-migrations.sh` 调用 helper
- 更新 workflow guardrail：
  - 要求新的非隐藏 helper 打包路径存在
  - 拦截旧的 `.github/scripts` artifact 路径
  - 拦截两个 deploy job 继续引用旧隐藏路径

## 为什么这样修

- 避免依赖 artifact action 对隐藏目录的默认行为
- 保留 `#210` 引入的 D1 瞬时故障重试逻辑，不扩大改动面
- 把这类“本地路径对、artifact 下载后丢失”的问题沉淀成 guardrail，避免再靠主线红灯发现

## 如何验证

- PR CI 需继续验证 workflow guardrail 与整体 CI 通过
- 合入后继续跟进 `main -> CD`，重点看：
  - staging deploy 不再报 `../../.github/scripts/run-wrangler-d1-migrations.sh: No such file or directory`
  - deploy job 能真正执行 D1 retry helper
  - 若后续再失败，才回到 Cloudflare / D1 本身继续判定

## 关联

- Fixes #220
- Follow-up to #216
- Keeps #209 on the intended retry-helper validation path