### PR TITLE
docs: add deploy artifact path guardrails

### DIFF
--- a/docs/deploy-artifact-path-guardrails.md
+++ b/docs/deploy-artifact-path-guardrails.md
@@ -1,0 +1,61 @@
+# Deploy Artifact Path Guardrails
+
+本文档沉淀这轮主控在 `CD #128` / `issue #220` 里踩中的一条长期规则：**下游 deploy job 需要的 helper、脚本或配置，不能只放在 release artifact 的隐藏目录路径里。**
+
+## 事故信号
+
+这次主线失败发生在：
+
+- Workflow: `CD - Staging API gated production deploy #128`
+- Source SHA: `65dc9c7ebbb7465f3f456b512ba9e667fc201a77`
+- 首个失败步骤：`Deploy staging environment -> Apply development D1 migrations`
+- 直接报错：`bash: ../../.github/scripts/run-wrangler-d1-migrations.sh: No such file or directory`
+
+根因不是 Cloudflare D1 本身，而是 deploy 依赖的 helper 虽然在 build job 里被复制了，但落在了 artifact 内的隐藏目录 `.github/scripts`。下载后的 artifact 没有把这条路径稳定带到下游 job，导致 deploy 在真正执行迁移前就先失败。
+
+## 默认规则
+
+对任何需要跨 job 传递到 release artifact 的脚本、helper、配置或元数据，默认遵循以下规则：
+
+- 不依赖 artifact 内的隐藏目录路径，例如 `.github/`、`.something/`。
+- 下游 job 需要直接执行的脚本，优先放到显式非隐藏目录，例如 `github-scripts/`、`release-metadata/`、`deploy-assets/`。
+- build job 的复制路径和 deploy job 的运行路径要成对出现，并在同一轮改动里一起更新。
+- workflow guardrail 必须同时检查：
+  - 期望的非隐藏 artifact 路径存在
+  - deploy job 的实际调用路径与打包路径一致
+  - 旧隐藏路径没有继续残留在 workflow 中
+
+## 适用场景
+
+这条规则至少适用于：
+
+- D1 migration retry helpers
+- deploy 前后置 shell scripts
+- release note / TestFlight / summary 生成脚本
+- 任何不是由 checkout 重新取回，而是依赖 artifact 透传给后续 job 的仓库文件
+
+## Fabushi 当前仓库的落地方式
+
+当前仓库已按以下方式收口：
+
+- build job 把 helper 放到 `release-artifact/github-scripts`
+- deploy job 从 `../../github-scripts/run-wrangler-d1-migrations.sh` 调用 helper
+- `.github/scripts/check-publish-cd-release.sh` 明确要求新路径存在，并拦截旧的 `.github/scripts` artifact / runtime 路径
+
+## 何时复查
+
+当出现以下任一信号时，优先先查这条规则，而不是立刻把问题归因为 Cloudflare、D1 或业务代码：
+
+- deploy job 报 `No such file or directory`
+- build job 明明打包了脚本，但下游 job 看不到
+- workflow 新增 helper 后，build 阶段成功，deploy 却在 helper 启动前失败
+- 同一个脚本在仓库工作目录可见，但在下载后的 artifact 目录不可见
+
+## 主控处理要求
+
+主控在遇到这类问题时，默认按以下顺序处理：
+
+1. 先确认失败发生在脚本装箱/落盘路径，还是脚本执行本身。
+2. 如果是 artifact 路径问题，优先修正 build/deploy 路径配对，不把它误判成外部平台故障。
+3. 修复后把 guardrail 一起补上，避免同类问题再次靠主线红灯暴露。
+4. 只有在 helper 真正进入目标执行路径后，才继续判断下游的 D1、Cloudflare 或其他外部系统是否仍有阻塞。


### PR DESCRIPTION
## 为什么改

这轮主控继续追 `#209 -> #216 -> #220 -> #221` 这条发布闭环时，新的确定性根因已经从 Cloudflare D1 本身切换成了 **release artifact 装箱路径**：

- `CD #128` / `issue #220` 的首个失败点不是 D1 API，而是 deploy job 在真正执行迁移前就先报：`bash: ../../.github/scripts/run-wrangler-d1-migrations.sh: No such file or directory`
- 根因是 helper 虽然被复制进 artifact，但落在了隐藏目录 `.github/scripts`
- 下游 deploy job 对 artifact 内隐藏路径的依赖不稳定，结果主线先被脚本落盘路径挡住，根本还没进入 D1 retry helper 的真实验证阶段

这不是一次性的偶发描述问题，而是一条长期有效、应被版本管理的主控规则。

## 这次改了什么

- 新增 `docs/deploy-artifact-path-guardrails.md`
- 把以下长期规则同步回仓库：
  - 下游 deploy job 需要直接执行的 helper、脚本或配置，不应只放在 artifact 的隐藏目录里
  - build job 的复制路径与 deploy job 的运行路径必须成对收口
  - workflow guardrail 既要要求新路径存在，也要拦截旧隐藏路径残留
  - 在 helper 真正进入目标执行路径前，不要把后续 D1 / Cloudflare 失败判断提前混进来

## 为什么现在做

`PR #221` 已经修掉了这次具体回归，但如果这条规则只停留在当前上下文和 issue 评论里，后续 scheduled run 仍然会重复靠主线红灯才想起这类约束。

把它独立成仓库文档，有三个直接价值：

- 减少后续主控把 artifact 路径问题误判成外部平台故障
- 给 workflow / guardrail 修改提供一个明确的长期参照面
- 避免继续把同类规则堆进正在变化的总手册，保持这次同步小而可审阅

## 验证

- 仅新增文档 `docs/deploy-artifact-path-guardrails.md`
- 文档内容直接对应本轮 `CD #128` / `issue #220` / `PR #221` 的真实根因与收口方式
- 无运行时代码改动

## 关联

- Follow-up to #221
- Documents the root cause behind #220 while keeping #209 on the correct validation path