### PR TITLE
优化官网首页结构、视觉层级与 SEO/GEO 基础

### DIFF
--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -1,12 +1,17 @@
 :root {
-  color-scheme: light;
-  --bg: #f5efe2;
-  --surface: rgba(255, 250, 242, 0.86);
-  --ink: #1f170f;
-  --muted: #6d5a48;
-  --accent: #b45f06;
-  --accent-strong: #8b3d0b;
-  --line: rgba(73, 47, 23, 0.14);
+  color-scheme: dark;
+  --bg: #09090b;
+  --bg-elevated: #111216;
+  --surface: rgba(17, 18, 22, 0.82);
+  --surface-strong: rgba(255, 255, 255, 0.04);
+  --ink: #f4efe8;
+  --muted: #b1a69a;
+  --muted-strong: #d8cdbf;
+  --accent: #c98b4a;
+  --accent-strong: #f1bb78;
+  --line: rgba(255, 255, 255, 0.1);
+  --line-strong: rgba(255, 255, 255, 0.16);
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
 }
 
 * {
@@ -20,10 +25,11 @@ html {
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top, rgba(255, 226, 186, 0.7), transparent 38%),
-    linear-gradient(180deg, #f7f0e4 0%, #f3e6d2 48%, #efe0cb 100%);
+    radial-gradient(circle at top left, rgba(201, 139, 74, 0.22), transparent 30%),
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.06), transparent 28%),
+    linear-gradient(180deg, #0b0b0f 0%, #101114 48%, #09090b 100%);
   color: var(--ink);
-  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
 a {
@@ -47,55 +53,144 @@ a {
 
 .hero,
 .band {
-  padding-top: 32px;
-  padding-bottom: 64px;
+  padding-top: 36px;
+  padding-bottom: 88px;
 }
 
 .inner-hero {
-  padding-top: 32px;
-  padding-bottom: 48px;
+  padding-top: 28px;
+  padding-bottom: 56px;
 }
 
 .hero {
-  min-height: 92vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: 36px;
+  justify-content: flex-start;
 }
 
-.site-nav {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+.hero-grid,
+.split-layout,
+.dual-grid {
+  display: grid;
+  gap: 24px;
 }
 
-.site-wordmark {
-  font-size: 1rem;
-  font-weight: 700;
-}
-
-.site-nav-links,
-.footer-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
-  color: var(--muted);
+.hero-grid {
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.85fr);
+  align-items: end;
 }
 
 .hero-copy,
 .inner-copy,
 .section-heading,
 .article-body {
-  max-width: 860px;
+  max-width: 920px;
 }
 
 .hero-copy {
-  padding: 12vh 0 8vh;
+  padding: 12vh 0 6vh;
 }
 
 .inner-copy {
   padding-top: 10vh;
+}
+
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  background: rgba(9, 9, 11, 0.72);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+}
+
+.site-wordmark {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: fit-content;
+}
+
+.site-wordmark span,
+.site-wordmark small {
+  display: block;
+}
+
+.site-wordmark span {
+  font-size: 0.98rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-wordmark small {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.site-nav-cluster,
+.site-nav-links,
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.site-nav-links,
+.footer-links {
+  color: var(--muted);
+}
+
+.site-nav-links a:hover,
+.footer-links a:hover {
+  color: var(--ink);
+}
+
+.nav-action,
+.primary-action,
+.secondary-action,
+.tertiary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 11px 18px;
+  border-radius: 8px;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, color 180ms ease;
+}
+
+.nav-action,
+.primary-action {
+  background: var(--accent);
+  color: #1a1108;
+  font-weight: 600;
+}
+
+.secondary-action,
+.tertiary-action {
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--ink);
+}
+
+.tertiary-action {
+  color: var(--muted-strong);
+}
+
+.nav-action:hover,
+.primary-action:hover,
+.secondary-action:hover,
+.tertiary-action:hover {
+  transform: translateY(-1px);
 }
 
 .eyebrow,
@@ -103,37 +198,58 @@ a {
 .platform-name,
 .download-status,
 .article-date {
-  margin: 0 0 12px;
+  margin: 0 0 14px;
   color: var(--accent-strong);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .brand-kicker {
-  margin: 0 0 16px;
-  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  margin: 0 0 18px;
+  color: var(--muted-strong);
+  font-size: clamp(1.15rem, 2.3vw, 1.8rem);
+  font-weight: 500;
+}
+
+.brand-kicker span {
+  color: var(--muted);
 }
 
 .hero-copy h1,
 .inner-copy h1,
-.section-heading h2 {
+.section-heading h2,
+.feature-block h3,
+.proof-card h3,
+.audience-card h3,
+.architecture-grid h3,
+.download-card h2,
+.release-card h2 {
   margin: 0;
-  line-height: 1.05;
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  line-height: 1.08;
   letter-spacing: 0;
 }
 
 .hero-copy h1 {
-  font-size: clamp(3rem, 8vw, 6.4rem);
-  max-width: 12ch;
+  max-width: 11ch;
+  font-size: clamp(3.2rem, 7vw, 6.2rem);
 }
 
 .inner-copy h1,
 .section-heading h2 {
-  font-size: clamp(2.2rem, 5vw, 4.4rem);
+  font-size: clamp(2.3rem, 4.8vw, 4.4rem);
+}
+
+.section-heading.compact h2 {
+  font-size: clamp(1.8rem, 3.2vw, 2.8rem);
 }
 
 .lede,
 .article-body p,
 .feature-block p,
+.proof-card p,
+.audience-card p,
 .architecture-grid p,
 .download-card p,
 .platform-row p,
@@ -143,15 +259,23 @@ a {
 .empty-copy,
 .roadmap-list,
 .release-card p,
-.release-note {
+.release-note,
+.mini-stat span,
+.hero-panel p,
+.hero-panel span,
+.status-note-list p,
+.contact-card p,
+.editorial-row small,
+.release-mirror-block p,
+.preview-row span {
   color: var(--muted);
   line-height: 1.75;
 }
 
 .lede {
-  margin: 20px 0 0;
+  margin: 22px 0 0;
   max-width: 46rem;
-  font-size: 1.1rem;
+  font-size: 1.08rem;
 }
 
 .hero-actions,
@@ -159,96 +283,109 @@ a {
 .release-card-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  margin-top: 28px;
+  gap: 12px;
+  margin-top: 30px;
 }
 
-.primary-action,
-.secondary-action {
-  border-radius: 999px;
-  padding: 12px 20px;
-  transition: transform 180ms ease, background-color 180ms ease;
+.hero-rail {
+  display: grid;
+  gap: 16px;
 }
 
-.primary-action {
-  background: var(--accent);
-  color: #fff7ed;
-}
-
-.secondary-action {
+.hero-panel,
+.feature-block,
+.proof-card,
+.audience-card,
+.architecture-grid > div,
+.download-card,
+.application-card,
+.preview-row,
+.release-card,
+.contact-card,
+.stack-card {
+  border: 1px solid var(--line);
   background: var(--surface);
-  border: 1px solid var(--line);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow);
 }
 
-.primary-action:hover,
-.secondary-action:hover {
-  transform: translateY(-1px);
+.hero-panel,
+.feature-block,
+.proof-card,
+.audience-card,
+.architecture-grid > div,
+.download-card,
+.application-card,
+.preview-row,
+.release-card,
+.contact-card,
+.stack-card {
+  border-radius: 10px;
+  padding: 20px;
 }
 
-.hero-panel {
-  align-self: flex-end;
-  max-width: 360px;
-  padding: 22px;
-  background: rgba(54, 31, 14, 0.08);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  backdrop-filter: blur(12px);
-}
-
-.hero-panel p,
-.hero-panel span {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.6;
+.hero-panel strong,
+.mini-stat strong,
+.platform-meta strong,
+.download-card strong,
+.editorial-row strong,
+.contact-card strong {
+  display: block;
 }
 
 .hero-panel strong {
-  display: block;
   margin: 8px 0 10px;
-  font-size: 1.25rem;
+  font-size: 1.22rem;
+  line-height: 1.45;
 }
 
-.band.alt {
-  background: rgba(255, 249, 239, 0.65);
-}
-
-.band.cinematic {
-  background:
-    linear-gradient(120deg, rgba(188, 110, 34, 0.08), rgba(255, 250, 242, 0.35)),
-    linear-gradient(180deg, rgba(255, 244, 228, 0.8), rgba(242, 228, 206, 0.6));
-}
-
-.section-heading {
-  margin-bottom: 28px;
-}
-
+.hero-mini-grid,
+.proof-grid,
+.audience-grid,
 .feature-grid,
 .architecture-grid,
 .download-grid,
-.application-grid {
+.application-grid,
+.contact-grid {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.feature-block,
-.architecture-grid > div,
-.download-card,
-.application-card,
-.preview-row,
-.release-card {
-  background: var(--surface);
+.mini-stat {
+  padding: 16px 18px;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
-  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 10px;
 }
 
-.feature-block h3,
-.architecture-grid h3,
-.download-card h2,
-.release-card h2 {
-  margin: 0 0 10px;
+.mini-stat strong {
+  margin-top: 8px;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.band.alt {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.band.cinematic,
+.cta-band {
+  background:
+    linear-gradient(120deg, rgba(201, 139, 74, 0.1), rgba(255, 255, 255, 0.02)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
+}
+
+.proof-band {
+  padding-top: 0;
+}
+
+.section-heading {
+  margin-bottom: 30px;
+}
+
+.section-heading.narrow {
+  max-width: 760px;
 }
 
 .platform-strip,
@@ -260,26 +397,21 @@ a {
   gap: 12px;
 }
 
+.faq-list.full {
+  gap: 18px;
+}
+
 .status-note-list {
   display: grid;
   gap: 8px;
   margin-top: 18px;
 }
 
-.status-note-list p,
-.contact-card p,
-.editorial-row small,
-.release-mirror-block p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
 .platform-row,
 .editorial-row {
   display: grid;
   gap: 16px;
-  padding: 18px 0;
+  padding: 20px 0;
   border-top: 1px solid var(--line);
 }
 
@@ -300,16 +432,6 @@ a {
 
 .platform-meta {
   text-align: right;
-}
-
-.platform-meta strong,
-.download-card strong,
-.editorial-row strong {
-  display: block;
-}
-
-.download-card {
-  display: block;
 }
 
 .release-card {
@@ -333,14 +455,18 @@ a {
   font-size: 0.95rem;
 }
 
-.release-update-list {
+.release-update-list,
+.roadmap-list,
+.application-list {
   margin: 0;
   padding-left: 20px;
   color: var(--muted);
   line-height: 1.75;
 }
 
-.release-update-list li + li {
+.release-update-list li + li,
+.roadmap-list li + li,
+.application-list li + li {
   margin-top: 8px;
 }
 
@@ -348,48 +474,30 @@ a {
   margin-top: 0;
 }
 
-.release-mirror-block {
+.release-mirror-block,
+.application-card {
   display: grid;
   gap: 12px;
 }
 
-.release-note {
-  margin: 0;
+.split-layout,
+.dual-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.application-card {
+.stack-card.transparent {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.preview-row {
   display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) max-content;
   gap: 14px;
-  align-content: start;
-}
-
-.application-summary,
-.application-list {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.75;
-}
-
-.application-list {
-  padding-left: 20px;
-}
-
-.application-list li + li {
-  margin-top: 8px;
-}
-
-.contact-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.contact-card {
-  display: block;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
+  align-items: center;
 }
 
 .contact-card span,
@@ -399,22 +507,6 @@ a {
 
 .contact-card strong {
   margin: 8px 0 10px;
-}
-
-.roadmap-list {
-  margin: 0;
-  padding-left: 20px;
-}
-
-.roadmap-list li + li {
-  margin-top: 12px;
-}
-
-.preview-row {
-  display: grid;
-  grid-template-columns: 56px minmax(0, 1fr) max-content;
-  gap: 14px;
-  align-items: center;
 }
 
 .faq-item {
@@ -431,6 +523,7 @@ a {
   cursor: pointer;
   list-style: none;
   font-weight: 600;
+  color: var(--ink);
 }
 
 .faq-item p {
@@ -445,7 +538,7 @@ a {
 
 .article-body p {
   margin: 0 0 18px;
-  font-size: 1.08rem;
+  font-size: 1.05rem;
 }
 
 .site-footer {
@@ -462,6 +555,19 @@ a {
   font-weight: 700;
 }
 
+@media (max-width: 960px) {
+  .hero-grid,
+  .split-layout,
+  .dual-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .hero-copy {
+    padding-top: 8vh;
+    padding-bottom: 0;
+  }
+}
+
 @media (max-width: 720px) {
   .hero,
   .band,
@@ -473,14 +579,15 @@ a {
   }
 
   .site-nav,
+  .site-nav-cluster,
   .site-footer,
   .release-card-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .hero-panel {
-    align-self: stretch;
+  .site-nav {
+    position: static;
   }
 
   .platform-row,
@@ -491,5 +598,9 @@ a {
 
   .platform-meta {
     text-align: left;
+  }
+
+  .hero-copy h1 {
+    max-width: none;
   }
 }

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -5,21 +5,56 @@ import { siteUrl } from "../lib/site-url";
 import "./globals.css";
 
 const homeUrl = siteUrl("/");
+const siteTitle = `${brand.name} | 佛法传播、修行记录与共修连接平台`;
+const siteDescription =
+  "Fabushi 法布施官网，集中提供产品介绍、下载入口、测试申请、FAQ 与更新内容，帮助用户快速理解法布施平台如何承接佛法传播、修行记录与共修连接。";
 
 export const metadata: Metadata = {
-  title: `${brand.name} | 官网`,
-  description: brand.mission,
+  title: siteTitle,
+  description: siteDescription,
+  keywords: [
+    "法布施",
+    "Fabushi",
+    "佛法传播",
+    "修行记录",
+    "共修",
+    "佛教应用",
+    "佛法社区",
+    "下载入口",
+    "FAQ",
+  ],
+  applicationName: brand.englishName,
+  authors: [{ name: "Fabushi" }],
+  creator: "Fabushi",
+  publisher: "Fabushi",
   metadataBase: new URL(homeUrl),
   alternates: {
     canonical: homeUrl,
   },
+  category: "religion and spirituality",
   openGraph: {
-    title: `${brand.name} | 官网`,
-    description: brand.mission,
+    title: siteTitle,
+    description: siteDescription,
     url: homeUrl,
     siteName: "Fabushi",
     locale: "zh_CN",
     type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteTitle,
+    description: siteDescription,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
 };
 

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -4,7 +4,37 @@ import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
 import { getAllArticles, getFeaturedArticles } from "../lib/content";
 import { getOfficialSiteReleaseCollection } from "../lib/official-site-releases";
-import { siteHref } from "../lib/site-url";
+import { siteHref, siteUrl } from "../lib/site-url";
+
+const audienceGroups = [
+  {
+    title: "第一次接触法布施的人",
+    description: "先在官网看清产品定位、下载状态、FAQ 和首期开放范围，不必先进入应用才理解项目。",
+  },
+  {
+    title: "想参与内测与反馈的人",
+    description: "直接找到 Android Beta、iOS TestFlight、申请入口和支持邮箱，减少来回询问。",
+  },
+  {
+    title: "关注传播与共修的人",
+    description: "通过内容专栏、公开榜单、公开档案与后续专题页，理解平台如何承接佛法传播与同行连接。",
+  },
+] as const;
+
+const trustPillars = [
+  {
+    title: "官网不是一张静态海报",
+    description: "首页、下载入口、FAQ、内容专栏和联系信息都围绕真实用户问题来组织，降低首次理解成本。",
+  },
+  {
+    title: "发布状态会回流到官网",
+    description: "Android Beta、iOS TestFlight 与正式版信息会随着发布资产同步更新，避免入口失真或过期。",
+  },
+  {
+    title: "内容、入口与应用体验分工清晰",
+    description: "官网负责理解与转化，小程序负责轻触达，主应用负责完整体验，减少用户对渠道角色的困惑。",
+  },
+] as const;
 
 async function getLeaderboardPreview() {
   try {
@@ -28,37 +58,145 @@ export default async function HomePage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
 
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        name: `${brand.name} ${brand.englishName}`,
+        alternateName: [brand.name, brand.englishName],
+        url: siteUrl("/"),
+        description: brand.mission,
+        email: "support@fabushi.com",
+        sameAs: ["https://github.com/bhrumom/fabushi"],
+      },
+      {
+        "@type": "WebSite",
+        name: `${brand.name} 官网`,
+        url: siteUrl("/"),
+        inLanguage: "zh-CN",
+        description:
+          "Fabushi 法布施官网，集中提供产品介绍、下载入口、测试申请、FAQ 与更新内容，帮助用户快速理解平台定位与当前开放能力。",
+      },
+      {
+        "@type": "SoftwareApplication",
+        name: `${brand.name} ${brand.englishName}`,
+        applicationCategory: "LifestyleApplication",
+        operatingSystem: "iOS, Android, Web",
+        url: siteUrl("/download"),
+        description:
+          "围绕佛法传播、修行记录、公开档案、榜单与共修连接构建的产品体系，官网负责下载引导、信息说明与持续内容更新。",
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: faqItems.slice(0, 4).map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
+      },
+    ],
+  };
+
   return (
     <main className="page-shell">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
       <header className="hero">
         <SiteHeader />
 
-        <div className="hero-copy">
-          <p className="eyebrow">法布施官网</p>
-          <p className="brand-kicker">{brand.name}</p>
-          <h1>官网负责入口，小程序负责触达，主应用负责完整体验。</h1>
-          <p className="lede">{brand.mission}</p>
-          <div className="hero-actions">
-            <a className="primary-action" href={siteHref("/download")}>
-              查看下载入口
-            </a>
-            <a className="secondary-action" href={siteHref("/faq")}>
-              查看常见问题
-            </a>
+        <div className="hero-grid">
+          <div className="hero-copy">
+            <p className="eyebrow">佛法传播平台</p>
+            <p className="brand-kicker">
+              {brand.name} <span>Fabushi</span>
+            </p>
+            <h1>让佛法传播、修行记录与共修连接，在一个清晰可信的入口里开始。</h1>
+            <p className="lede">
+              Fabushi 官网集中承接产品介绍、下载入口、测试申请、FAQ 与更新内容，让第一次接触项目的人也能快速知道：
+              这是什么、适合谁、现在能做什么。
+            </p>
+            <div className="hero-actions">
+              <a className="primary-action" href={siteHref("/download")}>
+                查看下载入口
+              </a>
+              <a className="secondary-action" href={siteHref("/apply")}>
+                申请测试资格
+              </a>
+              <a className="tertiary-action" href={siteHref("/faq")}>
+                先看常见问题
+              </a>
+            </div>
           </div>
-        </div>
 
-        <div className="hero-panel">
-          <p>当前推进</p>
-          <strong>Next.js 官网 + Taro 微信小程序 + 现有 Workers API 共用</strong>
-          <span>现在官网会直接读取最新 beta 发布资产，并预留人工验收后的正式版发布入口。</span>
+          <aside className="hero-rail">
+            <div className="hero-panel">
+              <p>当前开放重点</p>
+              <strong>官网先负责理解、入口与转化，再把轻触达交给小程序，把完整体验交给主应用。</strong>
+              <span>
+                这意味着首页会优先说清定位、下载状态、首期范围、FAQ 与联系路径，而不是只展示一句抽象口号。
+              </span>
+            </div>
+
+            <div className="hero-mini-grid">
+              <div className="mini-stat">
+                <span>下载与发布</span>
+                <strong>{releasePreview.length > 0 ? `${releasePreview.length} 个入口已同步` : "入口持续更新中"}</strong>
+              </div>
+              <div className="mini-stat">
+                <span>内容专栏</span>
+                <strong>{allArticles.length} 篇公开内容已上线</strong>
+              </div>
+              <div className="mini-stat">
+                <span>信任与证明</span>
+                <strong>{leaderboard.length > 0 ? "排行榜预览可直接读取" : "静态页面也能先完整理解项目"}</strong>
+              </div>
+            </div>
+          </aside>
         </div>
       </header>
+
+      <section className="band proof-band" id="why-fabushi">
+        <div className="section-heading narrow">
+          <p>为什么官网值得先看</p>
+          <h2>先把“这是什么、现在开放到哪里、我下一步该点哪里”讲清楚，用户才会继续往下走。</h2>
+        </div>
+        <div className="proof-grid">
+          {trustPillars.map((item) => (
+            <article key={item.title} className="proof-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="for-whom">
+        <div className="section-heading">
+          <p>适合谁先进入</p>
+          <h2>如果你想理解法布施平台，而不是先下载再摸索，官网应该先把这三类人服务好。</h2>
+        </div>
+        <div className="audience-grid">
+          {audienceGroups.map((item) => (
+            <article key={item.title} className="audience-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
-          <h2>官网负责品牌与入口，小程序负责轻场景触达，Flutter 继续承接重体验。</h2>
+          <h2>官网要先把用户能感受到的价值说具体，再把渠道和技术分工解释清楚。</h2>
         </div>
         <div className="feature-grid">
           {homeHighlights.map((item) => (
@@ -70,10 +208,10 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band cinematic">
+      <section className="band cinematic" id="download">
         <div className="section-heading">
-          <p>下载入口</p>
-          <h2>beta 安装包和 TestFlight 状态已经能直接回流到官网入口里。</h2>
+          <p>下载与状态</p>
+          <h2>下载页会优先承接真实发布状态，而不是让用户进入一个只会让他继续等待的空入口。</h2>
         </div>
         <div className="platform-strip">
           {releasePreview.map((item) => (
@@ -94,118 +232,111 @@ export default async function HomePage() {
             <p key={item}>{item}</p>
           ))}
         </div>
-      </section>
-
-      <section className="band alt" id="mini-program">
-        <div className="section-heading">
-          <p>微信小程序</p>
-          <h2>首期建议先覆盖轻浏览、榜单、公开档案与基础登录。</h2>
-        </div>
-        <ol className="roadmap-list">
-          {launchRoadmap.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ol>
-      </section>
-
-      <section className="band" id="architecture">
-        <div className="section-heading">
-          <p>技术架构</p>
-          <h2>一个前端 monorepo，共享接口层、类型、文案和部分纯业务逻辑。</h2>
-        </div>
-        <div className="architecture-grid">
-          <div>
-            <h3>apps/web</h3>
-            <p>Next.js 官网，负责 SEO、落地页、功能说明、后续内容运营。</p>
-          </div>
-          <div>
-            <h3>apps/mp-wechat</h3>
-            <p>Taro 微信小程序，围绕微信生态内的轻触达和轻交互。</p>
-          </div>
-          <div>
-            <h3>packages/shared</h3>
-            <p>品牌信息、导航、固定文案、纯前端通用工具。</p>
-          </div>
-          <div>
-            <h3>packages/api-client</h3>
-            <p>统一对接现有 `flutter.ombhrum.com` API 与共享类型。</p>
-          </div>
-        </div>
-      </section>
-
-      <section className="band alt">
-        <div className="section-heading">
-          <p>接口复用</p>
-          <h2>官网已经直接接了现有排行榜接口，作为“后端继续共用”的第一块落地验证。</h2>
-        </div>
-        <div className="preview-list">
-          {leaderboard.length === 0 ? (
-            <p className="empty-copy">当前没有拉到排行榜预览，页面仍可正常展示静态内容。</p>
-          ) : (
-            leaderboard.map((item, index) => (
-              <div key={item.username} className="preview-row">
-                <span>#{index + 1}</span>
-                <strong>{item.displayName || item.username}</strong>
-                <span>{item.totalBytes.toLocaleString()} bytes</span>
-              </div>
-            ))
-          )}
-        </div>
-      </section>
-
-      <section className="band">
-        <div className="section-heading">
-          <p>内容专栏</p>
-          <h2>官网不只是一张首页，还要能持续承接路线、更新和专题内容。</h2>
-        </div>
-        <div className="editorial-list">
-          {featuredArticles.map((item) => (
-            <a key={item.slug} className="editorial-row" href={siteHref(`/insights/${item.slug}`)}>
-              <span>{item.category}</span>
-              <div>
-                <strong>{item.title}</strong>
-                <p>{item.description}</p>
-                <small>
-                  {item.author} · {item.readTime}
-                </small>
-              </div>
-            </a>
-          ))}
-        </div>
         <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/insights")}>
-            查看全部 {allArticles.length} 篇内容
-          </a>
-        </div>
-      </section>
-
-      <section className="band alt">
-        <div className="section-heading">
-          <p>常见问题</p>
-          <h2>先把用户最容易问的几件事说清楚，官网才真正开始工作。</h2>
-        </div>
-        <div className="faq-list">
-          {faqItems.slice(0, 3).map((item) => (
-            <details key={item.question} className="faq-item">
-              <summary>{item.question}</summary>
-              <p>{item.answer}</p>
-            </details>
-          ))}
-        </div>
-        <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/faq")}>
-            查看完整 FAQ
+          <a className="primary-action" href={siteHref("/download")}>
+            打开完整下载页
           </a>
           <a className="secondary-action" href={siteHref("/contact")}>
-            联系我们
+            联系支持
           </a>
         </div>
       </section>
 
-      <section className="band">
-        <div className="section-heading">
-          <p>联系</p>
-          <h2>除了下载入口之外，官网也要把支持、反馈和公开协作的去处讲清楚。</h2>
+      <section className="band alt" id="roadmap">
+        <div className="split-layout">
+          <div className="stack-card">
+            <div className="section-heading compact">
+              <p>首期范围</p>
+              <h2>先把高频入口和轻触达路径跑通，再逐步扩到更重的体验。</h2>
+            </div>
+            <ol className="roadmap-list">
+              {launchRoadmap.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ol>
+            <div className="inline-cta">
+              <a className="secondary-action" href={siteHref("/apply")}>
+                申请参与首期测试
+              </a>
+            </div>
+          </div>
+
+          <div className="stack-card">
+            <div className="section-heading compact">
+              <p>公开证明</p>
+              <h2>除了路线说明，官网也要给出能被快速验证的公开信息。</h2>
+            </div>
+            <div className="preview-list">
+              {leaderboard.length === 0 ? (
+                <p className="empty-copy">当前没有拉到排行榜预览，但下载、FAQ 与内容说明仍然可以完整承接首次访问。</p>
+              ) : (
+                leaderboard.map((item, index) => (
+                  <div key={item.username} className="preview-row">
+                    <span>#{index + 1}</span>
+                    <strong>{item.displayName || item.username}</strong>
+                    <span>{item.totalBytes.toLocaleString()} bytes</span>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="band" id="insights">
+        <div className="dual-grid">
+          <div className="stack-card transparent">
+            <div className="section-heading compact">
+              <p>内容专栏</p>
+              <h2>官网不仅负责下载和说明，也要持续承接路线、更新与专题解释。</h2>
+            </div>
+            <div className="editorial-list">
+              {featuredArticles.map((item) => (
+                <a key={item.slug} className="editorial-row" href={siteHref(`/insights/${item.slug}`)}>
+                  <span>{item.category}</span>
+                  <div>
+                    <strong>{item.title}</strong>
+                    <p>{item.description}</p>
+                    <small>
+                      {item.author} · {item.readTime}
+                    </small>
+                  </div>
+                </a>
+              ))}
+            </div>
+            <div className="inline-cta">
+              <a className="secondary-action" href={siteHref("/insights")}>
+                查看全部 {allArticles.length} 篇内容
+              </a>
+            </div>
+          </div>
+
+          <div className="stack-card transparent">
+            <div className="section-heading compact">
+              <p>常见问题</p>
+              <h2>把搜索里最容易出现的问题先答出来，SEO 和 GEO 才更容易真正生效。</h2>
+            </div>
+            <div className="faq-list">
+              {faqItems.slice(0, 4).map((item) => (
+                <details key={item.question} className="faq-item">
+                  <summary>{item.question}</summary>
+                  <p>{item.answer}</p>
+                </details>
+              ))}
+            </div>
+            <div className="inline-cta">
+              <a className="secondary-action" href={siteHref("/faq")}>
+                查看完整 FAQ
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="band cta-band" id="contact">
+        <div className="section-heading narrow">
+          <p>联系与下一步</p>
+          <h2>准备下载、申请测试、反馈问题或讨论合作时，官网应该把可执行的下一步摆在最前面。</h2>
         </div>
         <div className="contact-grid">
           {contactChannels.map((item) => (

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -5,10 +5,13 @@ export const dynamic = "force-static";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
     sitemap: siteUrl("/sitemap.xml"),
+    host: new URL(siteUrl("/")).origin,
   };
 }

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -4,16 +4,22 @@ import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
 
+const staticRoutes = ["/", "/download", "/apply", "/faq", "/contact", "/insights"] as const;
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const routes: MetadataRoute.Sitemap = ["/", "/download", "/apply", "/faq", "/contact", "/insights"].map((path) => ({
-    url: siteUrl(path),
-    lastModified: "2026-05-06",
+  const pages: MetadataRoute.Sitemap = staticRoutes.map((route) => ({
+    url: siteUrl(route),
+    lastModified: new Date(),
+    changeFrequency: route === "/" ? "weekly" : "monthly",
+    priority: route === "/" ? 1 : route === "/download" || route === "/faq" ? 0.9 : 0.7,
   }));
 
-  const articleRoutes = getAllArticles().map((article) => ({
+  const articlePages: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
     url: siteUrl(`/insights/${article.slug}`),
-    lastModified: article.publishedAt,
+    lastModified: new Date(article.publishedAt),
+    changeFrequency: "monthly",
+    priority: article.featured ? 0.8 : 0.6,
   }));
 
-  return [...routes, ...articleRoutes];
+  return [...pages, ...articlePages];
 }

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -5,7 +5,7 @@ export function SiteFooter() {
     <footer className="site-footer">
       <div>
         <p className="footer-title">法布施 Fabushi</p>
-        <p className="footer-copy">让佛法、修行与善意传播得更远。</p>
+        <p className="footer-copy">官网集中承接下载入口、测试申请、FAQ、内容更新与公开协作信息。</p>
       </div>
       <div className="footer-links">
         <a href={siteHref("/download")}>下载入口</a>

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -5,14 +5,20 @@ export function SiteHeader() {
   return (
     <nav className="site-nav" aria-label="主导航">
       <a className="site-wordmark" href={siteHref("/")}>
-        Fabushi
+        <span>Fabushi</span>
+        <small>法布施</small>
       </a>
-      <div className="site-nav-links">
-        {primaryNavigation.map((item) => (
-          <a key={item.href} href={siteHref(item.href)}>
-            {item.label}
-          </a>
-        ))}
+      <div className="site-nav-cluster">
+        <div className="site-nav-links">
+          {primaryNavigation.map((item) => (
+            <a key={item.href} href={siteHref(item.href)}>
+              {item.label}
+            </a>
+          ))}
+        </div>
+        <a className="nav-action" href={siteHref("/download")}>
+          下载入口
+        </a>
       </div>
     </nav>
   );


### PR DESCRIPTION
## 本轮优化

- 重写官网首页首屏文案与信息结构，先讲清产品定位、适合人群、下载状态与下一步动作
- 补充首页结构化数据，增强 FAQ、网站与应用层面的 GEO/SEO 可理解性
- 强化站点级 metadata、canonical、robots 与 sitemap 信号
- 重做官网视觉基线与导航层级，加入更明确的下载 CTA 和更克制的深色质感
- 收紧 footer 文案，让下载、FAQ、申请测试与内容入口更清晰

## 为什么这样改

- 当前官网最需要先解决“用户第一次来能不能快速看懂并继续行动”这个问题
- 首页需要同时承担品牌说明、下载引导、FAQ 入口和内容承接，不能只像一张静态介绍页
- 生成式搜索与传统搜索都更依赖明确的定义、FAQ 结构、页面语义和可索引路由信号

## 影响范围

- `frontend/apps/web/src/app/page.tsx`
- `frontend/apps/web/src/app/layout.tsx`
- `frontend/apps/web/src/app/globals.css`
- `frontend/apps/web/src/app/robots.ts`
- `frontend/apps/web/src/app/sitemap.ts`
- `frontend/apps/web/src/components/site-header.tsx`
- `frontend/apps/web/src/components/site-footer.tsx`

## 验证

- 已确认改动仅落在官网 Web 应用相关文件
- 当前环境无法直接运行仓库前端构建或截图验证，只完成了代码与改动范围校对
- 仓库主分支受规则保护，本次通过分支和草稿 PR 进入后续 CI / merge queue 流程