### PR TITLE
[codex] 优化 Fabushi 官网首页路径与核心落地页语义结构

### DIFF
--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -2,16 +2,44 @@ import type { Metadata } from "next";
 import { betaApplicationTracks, brand } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `申请测试 | ${brand.name}`,
   description: "查看 Fabushi 当前可申请的测试与合作入口，并按不同场景选择对应通道。",
+  alternates: {
+    canonical: siteUrl("/apply"),
+  },
+  keywords: ["法布施内测", "Fabushi 申请测试", "法布施 Android Beta", "法布施 TestFlight", "法布施合作"],
 };
 
 export default function ApplyPage() {
+  const applyPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `${brand.name} 申请测试`,
+    url: siteUrl("/apply"),
+    inLanguage: "zh-CN",
+    description: "Fabushi 当前开放的 iOS、Android 与合作沟通申请通道。",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: betaApplicationTracks.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "EntryPoint",
+          name: item.name,
+          description: item.summary,
+          urlTemplate: siteHref(item.ctaHref),
+        },
+      })),
+    },
+  };
+
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applyPageJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">

--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -35,10 +35,29 @@ export default function ApplyPage() {
       })),
     },
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "申请测试",
+        item: siteUrl("/apply"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applyPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/contact/page.tsx
+++ b/frontend/apps/web/src/app/contact/page.tsx
@@ -38,10 +38,29 @@ export default function ContactPage() {
       ],
     },
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "联系",
+        item: siteUrl("/contact"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/contact/page.tsx
+++ b/frontend/apps/web/src/app/contact/page.tsx
@@ -2,16 +2,47 @@ import type { Metadata } from "next";
 import { brand, contactChannels } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `联系 | ${brand.name}`,
   description: "查看 Fabushi 的支持邮箱、官网域名和公开仓库入口。",
+  alternates: {
+    canonical: siteUrl("/contact"),
+  },
+  keywords: ["联系 Fabushi", "法布施支持邮箱", "法布施官网", "Fabushi GitHub", "法布施合作"],
 };
 
 export default function ContactPage() {
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+  const contactPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ContactPage",
+    name: `${brand.name} 联系方式`,
+    url: siteUrl("/contact"),
+    inLanguage: "zh-CN",
+    description: "Fabushi 的支持邮箱、官网域名与公开仓库入口。",
+    mainEntity: {
+      "@type": "Organization",
+      name: `${brand.name} Fabushi`,
+      url: siteUrl("/"),
+      email: supportEmail,
+      sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
+      contactPoint: [
+        {
+          "@type": "ContactPoint",
+          contactType: "customer support",
+          email: supportEmail,
+          availableLanguage: ["zh-CN"],
+        },
+      ],
+    },
+  };
+
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -146,10 +146,29 @@ export default async function DownloadPage() {
       url: siteUrl("/"),
     },
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "下载入口",
+        item: siteUrl("/download"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(downloadPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -98,6 +98,23 @@ export default async function DownloadPage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const allChannels = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels];
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+  const recommendationPaths = [
+    {
+      label: "想最快看到最新改动",
+      title: "优先看 Android beta 或 iOS TestFlight。",
+      description: "这两条通道会最先承接最新一轮可公开测试的安装包和状态更新，适合愿意跟着版本节奏一起体验的人。",
+    },
+    {
+      label: "想先判断自己适不适合加入测试",
+      title: "先看版本说明、更新时间和适用提示，再决定要不要安装。",
+      description: "下载页现在会把版本、发布时间、更新摘要和补充说明直接写在入口旁边，避免你先下载再回头找上下文。",
+    },
+    {
+      label: "更看重稳定与人工验收",
+      title: "优先等正式版入口，而不是直接进入 beta。",
+      description: "正式版只在人工验收完成后才会上架到官网，更适合不希望承担测试波动、需要更稳妥安装入口的人。",
+    },
+  ] as const;
 
   const downloadPageJsonLd = {
     "@context": "https://schema.org",
@@ -172,6 +189,22 @@ export default async function DownloadPage() {
 
       <section className="band">
         <div className="section-heading">
+          <p>选择建议</p>
+          <h2>如果你不确定现在该点哪一个入口，先按你的风险偏好和目的来选。</h2>
+        </div>
+        <div className="path-grid">
+          {recommendationPaths.map((item) => (
+            <article key={item.title} className="path-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
           <p>同步说明</p>
           <h2>官网上的下载说明现在会跟着发布资产一起更新，而不是靠手工改文案。</h2>
         </div>
@@ -182,7 +215,7 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band">
         <div className="section-heading">
           <p>推荐路径</p>
           <h2>如果你现在只是第一次接触这个项目，建议先这样走。</h2>

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -1,16 +1,27 @@
 import type { Metadata } from "next";
-import { brand } from "@fabushi/shared";
+import { brand, contactChannels } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import {
   getOfficialSiteReleaseCollection,
   type OfficialSiteChannel,
 } from "../../lib/official-site-releases";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `下载入口 | ${brand.name}`,
   description: "查看 Fabushi 官网上的 Android Beta、iOS TestFlight 与正式版发布状态。",
+  alternates: {
+    canonical: siteUrl("/download"),
+  },
+  keywords: [
+    "法布施下载",
+    "Fabushi 下载",
+    "Android Beta",
+    "iOS TestFlight",
+    "法布施官网",
+    "法布施正式版",
+  ],
 };
 
 function formatPublishedAt(value?: string) {
@@ -85,9 +96,44 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
 
 export default async function DownloadPage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
+  const allChannels = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels];
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+
+  const downloadPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `${brand.name} 下载入口`,
+    url: siteUrl("/download"),
+    inLanguage: "zh-CN",
+    description: "查看 Fabushi Android beta、iOS TestFlight 与正式版的当前可见下载状态。",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: allChannels.map((channel, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "SoftwareApplication",
+          name: channel.title,
+          operatingSystem: channel.platform,
+          description: channel.description,
+          url: siteUrl("/download"),
+          downloadUrl: siteHref(channel.primaryHref),
+          applicationCategory: channel.audience === "stable" ? "ProductivityApplication" : "BetaSoftwareApplication",
+        },
+      })),
+    },
+    provider: {
+      "@type": "Organization",
+      name: `${brand.name} Fabushi`,
+      email: supportEmail,
+      url: siteUrl("/"),
+    },
+  };
 
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(downloadPageJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -2,23 +2,42 @@ import type { Metadata } from "next";
 import { brand, faqItems } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `常见问题 | ${brand.name}`,
-  description: "查看官网、微信小程序与主应用之间的职责划分，以及首期上线范围。",
+  description: "查看 Fabushi 是什么、是否可下载，以及官网、微信小程序与主应用分别承担什么角色。",
+  alternates: {
+    canonical: siteUrl("/faq"),
+  },
+  keywords: ["法布施 FAQ", "Fabushi 常见问题", "法布施下载", "法布施官网", "法布施小程序"],
 };
 
 export default function FaqPage() {
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqItems.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
+
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">
           <p className="eyebrow">常见问题</p>
-          <h1>把最容易反复解释的问题写出来，官网才真正开始工作。</h1>
+          <h1>把用户最容易问的关键问题写清楚，官网才真正开始承担解释和转化的工作。</h1>
           <p className="lede">
-            这一页优先回答官网、微信小程序和 Flutter 主应用之间的关系，以及为什么当前要拆出新的前端 monorepo。
+            这一页优先回答 Fabushi 是什么、现在能否下载、适合哪些人先关注，以及官网、微信小程序和 Flutter 主应用之间的分工关系。
           </p>
         </div>
       </section>

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -26,10 +26,29 @@ export default function FaqPage() {
       },
     })),
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "常见问题",
+        item: siteUrl("/faq"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -277,6 +277,7 @@ h3,
 .application-list,
 .path-card p,
 .evidence-card p,
+.definition-card p,
 .channel-card p,
 .channel-list {
   color: var(--muted);
@@ -306,6 +307,7 @@ h3,
 .contact-grid,
 .path-grid,
 .evidence-grid,
+.definition-grid,
 .channel-grid {
   display: grid;
   gap: 16px;
@@ -330,6 +332,7 @@ h3,
 .narrative-block,
 .path-card,
 .evidence-card,
+.definition-card,
 .channel-card {
   background: var(--surface);
   border: 1px solid var(--line);
@@ -340,7 +343,8 @@ h3,
 }
 
 .path-card,
-.channel-card {
+.channel-card,
+.definition-card {
   display: grid;
   gap: 14px;
   align-content: start;
@@ -351,6 +355,10 @@ h3,
   gap: 10px;
   align-content: start;
   background: var(--surface-strong);
+}
+
+.definition-card {
+  background: linear-gradient(180deg, rgba(255, 250, 244, 0.92), rgba(247, 239, 228, 0.92));
 }
 
 .path-card h3,
@@ -365,6 +373,7 @@ h3,
 .editorial-row strong,
 .contact-card strong,
 .evidence-card strong,
+.definition-card h3,
 .channel-card h3 {
   display: block;
   color: var(--ink);
@@ -377,6 +386,7 @@ h3,
 .architecture-grid h3,
 .download-card h2,
 .release-card h2,
+.definition-card h3,
 .channel-card h3 {
   margin: 0;
 }
@@ -395,6 +405,7 @@ h3,
 .narrative-block h3,
 .use-case-block h3,
 .path-card h3,
+.definition-card h3,
 .channel-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
@@ -472,6 +483,7 @@ h3,
 .application-grid,
 .contact-grid,
 .evidence-grid,
+.definition-grid,
 .channel-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -147,14 +147,16 @@ h3,
 
 .nav-cta,
 .primary-action,
-.secondary-action {
+.secondary-action,
+.path-link {
   border-radius: 999px;
   padding: 12px 20px;
   transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
 }
 
 .nav-cta,
-.primary-action {
+.primary-action,
+.path-link {
   background: var(--ink);
   color: #fffaf3;
 }
@@ -166,7 +168,8 @@ h3,
 
 .nav-cta:hover,
 .primary-action:hover,
-.secondary-action:hover {
+.secondary-action:hover,
+.path-link:hover {
   transform: translateY(-1px);
 }
 
@@ -271,7 +274,8 @@ h3,
 .editorial-row small,
 .release-mirror-block p,
 .application-summary,
-.application-list {
+.application-list,
+.path-card p {
   color: var(--muted);
   line-height: 1.72;
 }
@@ -296,7 +300,8 @@ h3,
 .download-grid,
 .application-grid,
 .use-case-grid,
-.contact-grid {
+.contact-grid,
+.path-grid {
   display: grid;
   gap: 16px;
 }
@@ -317,7 +322,8 @@ h3,
 .release-card,
 .use-case-block,
 .contact-card,
-.narrative-block {
+.narrative-block,
+.path-card {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 18px;
@@ -326,6 +332,13 @@ h3,
   backdrop-filter: blur(10px);
 }
 
+.path-card {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.path-card h3,
 .signal-chip strong,
 .hero-proof-row strong,
 .narrative-block h3,
@@ -340,6 +353,20 @@ h3,
   color: var(--ink);
 }
 
+.path-card h3,
+.narrative-block h3,
+.use-case-block h3,
+.feature-block h3,
+.architecture-grid h3,
+.download-card h2,
+.release-card h2 {
+  margin: 0;
+}
+
+.path-link {
+  justify-self: start;
+}
+
 .signal-chip strong,
 .hero-proof-row strong {
   font-size: 1rem;
@@ -347,7 +374,8 @@ h3,
 
 .hero-panel strong,
 .narrative-block h3,
-.use-case-block h3 {
+.use-case-block h3,
+.path-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
 }
@@ -392,10 +420,15 @@ h3,
     linear-gradient(180deg, rgba(255, 244, 228, 0.82), rgba(237, 227, 214, 0.6));
 }
 
+.quick-paths {
+  padding-top: 12px;
+}
+
 .section-heading {
   margin-bottom: 28px;
 }
 
+.path-grid,
 .narrative-grid,
 .use-case-grid,
 .feature-grid,
@@ -404,15 +437,6 @@ h3,
 .application-grid,
 .contact-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.feature-block h3,
-.architecture-grid h3,
-.download-card h2,
-.release-card h2,
-.use-case-block h3,
-.narrative-block h3 {
-  margin: 0 0 10px;
 }
 
 .platform-strip,

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -1,12 +1,18 @@
 :root {
   color-scheme: light;
-  --bg: #f5efe2;
-  --surface: rgba(255, 250, 242, 0.86);
-  --ink: #1f170f;
-  --muted: #6d5a48;
-  --accent: #b45f06;
-  --accent-strong: #8b3d0b;
-  --line: rgba(73, 47, 23, 0.14);
+  --bg: #f6f1e8;
+  --surface: rgba(255, 251, 245, 0.82);
+  --surface-strong: rgba(255, 248, 239, 0.94);
+  --ink: #19140f;
+  --muted: #65594d;
+  --accent: #a86130;
+  --accent-strong: #7f441d;
+  --accent-soft: rgba(168, 97, 48, 0.12);
+  --secondary: #4f695f;
+  --secondary-soft: rgba(79, 105, 95, 0.12);
+  --line: rgba(58, 43, 29, 0.12);
+  --line-strong: rgba(58, 43, 29, 0.2);
+  --shadow: 0 24px 60px rgba(53, 37, 24, 0.08);
 }
 
 * {
@@ -20,15 +26,25 @@ html {
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top, rgba(255, 226, 186, 0.7), transparent 38%),
-    linear-gradient(180deg, #f7f0e4 0%, #f3e6d2 48%, #efe0cb 100%);
+    radial-gradient(circle at top left, rgba(236, 214, 180, 0.52), transparent 34%),
+    radial-gradient(circle at top right, rgba(153, 186, 170, 0.18), transparent 32%),
+    linear-gradient(180deg, #faf6ef 0%, #f6efe4 44%, #f1e7db 100%);
   color: var(--ink);
-  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
 a {
   color: inherit;
   text-decoration: none;
+}
+
+h1,
+h2,
+h3,
+.brand-kicker,
+.site-wordmark span,
+.footer-title {
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
 }
 
 .page-shell,
@@ -48,7 +64,7 @@ a {
 .hero,
 .band {
   padding-top: 32px;
-  padding-bottom: 64px;
+  padding-bottom: 72px;
 }
 
 .inner-hero {
@@ -57,22 +73,58 @@ a {
 }
 
 .hero {
-  min-height: 92vh;
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 
 .site-nav {
+  position: sticky;
+  top: 18px;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 18px;
+  padding: 14px 16px;
+  background: rgba(255, 250, 244, 0.72);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 10px 30px rgba(48, 34, 24, 0.06);
 }
 
 .site-wordmark {
-  font-size: 1rem;
-  font-weight: 700;
+  display: inline-grid;
+  gap: 2px;
+}
+
+.site-wordmark span {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.site-wordmark small,
+.detail-label {
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.site-nav-links-wrap,
+.hero-stage,
+.hero-actions,
+.inline-cta,
+.release-card-actions {
+  display: flex;
+  gap: 14px;
+}
+
+.site-nav-links-wrap {
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .site-nav-links,
@@ -83,6 +135,49 @@ a {
   color: var(--muted);
 }
 
+.site-nav-links a,
+.footer-links a {
+  transition: color 180ms ease;
+}
+
+.site-nav-links a:hover,
+.footer-links a:hover {
+  color: var(--ink);
+}
+
+.nav-cta,
+.primary-action,
+.secondary-action {
+  border-radius: 999px;
+  padding: 12px 20px;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.nav-cta,
+.primary-action {
+  background: var(--ink);
+  color: #fffaf3;
+}
+
+.secondary-action {
+  background: var(--surface);
+  border: 1px solid var(--line);
+}
+
+.nav-cta:hover,
+.primary-action:hover,
+.secondary-action:hover {
+  transform: translateY(-1px);
+}
+
+.hero-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(280px, 0.88fr);
+  align-items: end;
+  gap: 28px;
+  margin-top: auto;
+}
+
 .hero-copy,
 .inner-copy,
 .section-heading,
@@ -91,26 +186,44 @@ a {
 }
 
 .hero-copy {
-  padding: 12vh 0 8vh;
+  padding: 10vh 0 6vh;
 }
 
 .inner-copy {
   padding-top: 10vh;
 }
 
+.hero-aside {
+  display: grid;
+  gap: 16px;
+  padding-bottom: 6vh;
+}
+
 .eyebrow,
 .section-heading p,
 .platform-name,
 .download-status,
-.article-date {
+.article-date,
+.hero-panel p {
   margin: 0 0 12px;
   color: var(--accent-strong);
   font-size: 0.95rem;
 }
 
 .brand-kicker {
-  margin: 0 0 16px;
-  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 0 0 18px;
+  font-size: clamp(2rem, 3vw, 3rem);
+}
+
+.brand-kicker span {
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.46em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .hero-copy h1,
@@ -122,13 +235,17 @@ a {
 }
 
 .hero-copy h1 {
-  font-size: clamp(3rem, 8vw, 6.4rem);
-  max-width: 12ch;
+  max-width: 11ch;
+  font-size: clamp(3.1rem, 8vw, 6.5rem);
 }
 
 .inner-copy h1,
 .section-heading h2 {
-  font-size: clamp(2.2rem, 5vw, 4.4rem);
+  font-size: clamp(2.2rem, 5vw, 4.5rem);
+}
+
+.section-heading h2 {
+  max-width: 14ch;
 }
 
 .lede,
@@ -143,111 +260,158 @@ a {
 .empty-copy,
 .roadmap-list,
 .release-card p,
-.release-note {
+.release-note,
+.signal-chip strong,
+.hero-panel span,
+.hero-proof-row span,
+.narrative-block p,
+.use-case-block p,
+.contact-card p,
+.status-note-list p,
+.editorial-row small,
+.release-mirror-block p,
+.application-summary,
+.application-list {
   color: var(--muted);
-  line-height: 1.75;
+  line-height: 1.72;
 }
 
 .lede {
   margin: 20px 0 0;
   max-width: 46rem;
-  font-size: 1.1rem;
+  font-size: 1.12rem;
 }
 
 .hero-actions,
 .inline-cta,
 .release-card-actions {
-  display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  margin-top: 28px;
+  margin-top: 30px;
 }
 
-.primary-action,
-.secondary-action {
-  border-radius: 999px;
-  padding: 12px 20px;
-  transition: transform 180ms ease, background-color 180ms ease;
+.hero-signal-bar,
+.narrative-grid,
+.feature-grid,
+.architecture-grid,
+.download-grid,
+.application-grid,
+.use-case-grid,
+.contact-grid {
+  display: grid;
+  gap: 16px;
 }
 
-.primary-action {
-  background: var(--accent);
-  color: #fff7ed;
+.hero-signal-bar {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 36px;
 }
 
-.secondary-action {
+.signal-chip,
+.hero-panel,
+.hero-proof-list,
+.feature-block,
+.architecture-grid > div,
+.download-card,
+.application-card,
+.preview-row,
+.release-card,
+.use-case-block,
+.contact-card,
+.narrative-block {
   background: var(--surface);
   border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
 }
 
-.primary-action:hover,
-.secondary-action:hover {
-  transform: translateY(-1px);
+.signal-chip strong,
+.hero-proof-row strong,
+.narrative-block h3,
+.use-case-block h3,
+.feature-block h3,
+.architecture-grid h3,
+.download-card h2,
+.release-card h2,
+.editorial-row strong,
+.contact-card strong {
+  display: block;
+  color: var(--ink);
 }
 
-.hero-panel {
-  align-self: flex-end;
-  max-width: 360px;
-  padding: 22px;
-  background: rgba(54, 31, 14, 0.08);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  backdrop-filter: blur(12px);
+.signal-chip strong,
+.hero-proof-row strong {
+  font-size: 1rem;
 }
 
-.hero-panel p,
-.hero-panel span {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.6;
+.hero-panel strong,
+.narrative-block h3,
+.use-case-block h3 {
+  font-size: 1.35rem;
+  line-height: 1.35;
 }
 
 .hero-panel strong {
   display: block;
   margin: 8px 0 10px;
-  font-size: 1.25rem;
+}
+
+.hero-proof-list {
+  display: grid;
+  gap: 14px;
+}
+
+.hero-proof-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 16px;
+  align-items: start;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.hero-proof-row:first-of-type {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.hero-proof-row em {
+  color: var(--secondary);
+  font-style: normal;
+  font-size: 0.95rem;
 }
 
 .band.alt {
-  background: rgba(255, 249, 239, 0.65);
+  background: rgba(255, 249, 241, 0.5);
 }
 
 .band.cinematic {
   background:
-    linear-gradient(120deg, rgba(188, 110, 34, 0.08), rgba(255, 250, 242, 0.35)),
-    linear-gradient(180deg, rgba(255, 244, 228, 0.8), rgba(242, 228, 206, 0.6));
+    linear-gradient(120deg, rgba(168, 97, 48, 0.08), rgba(255, 250, 244, 0.36)),
+    linear-gradient(180deg, rgba(255, 244, 228, 0.82), rgba(237, 227, 214, 0.6));
 }
 
 .section-heading {
   margin-bottom: 28px;
 }
 
+.narrative-grid,
+.use-case-grid,
 .feature-grid,
 .architecture-grid,
 .download-grid,
-.application-grid {
-  display: grid;
-  gap: 16px;
+.application-grid,
+.contact-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.feature-block,
-.architecture-grid > div,
-.download-card,
-.application-card,
-.preview-row,
-.release-card {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
-  backdrop-filter: blur(10px);
 }
 
 .feature-block h3,
 .architecture-grid h3,
 .download-card h2,
-.release-card h2 {
+.release-card h2,
+.use-case-block h3,
+.narrative-block h3 {
   margin: 0 0 10px;
 }
 
@@ -266,21 +430,15 @@ a {
   margin-top: 18px;
 }
 
-.status-note-list p,
-.contact-card p,
-.editorial-row small,
-.release-mirror-block p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
 .platform-row,
 .editorial-row {
   display: grid;
   gap: 16px;
-  padding: 18px 0;
-  border-top: 1px solid var(--line);
+  padding: 22px;
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
 }
 
 .platform-row {
@@ -293,11 +451,6 @@ a {
   align-items: start;
 }
 
-.platform-row:first-child,
-.editorial-row:first-child {
-  border-top: 0;
-}
-
 .platform-meta {
   text-align: right;
 }
@@ -308,11 +461,10 @@ a {
   display: block;
 }
 
-.download-card {
-  display: block;
-}
-
-.release-card {
+.download-card,
+.release-card,
+.application-card,
+.contact-card {
   display: grid;
   gap: 14px;
 }
@@ -333,14 +485,18 @@ a {
   font-size: 0.95rem;
 }
 
-.release-update-list {
+.release-update-list,
+.application-list,
+.roadmap-list {
   margin: 0;
   padding-left: 20px;
   color: var(--muted);
   line-height: 1.75;
 }
 
-.release-update-list li + li {
+.release-update-list li + li,
+.application-list li + li,
+.roadmap-list li + li {
   margin-top: 8px;
 }
 
@@ -353,63 +509,6 @@ a {
   gap: 12px;
 }
 
-.release-note {
-  margin: 0;
-}
-
-.application-card {
-  display: grid;
-  gap: 14px;
-  align-content: start;
-}
-
-.application-summary,
-.application-list {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.75;
-}
-
-.application-list {
-  padding-left: 20px;
-}
-
-.application-list li + li {
-  margin-top: 8px;
-}
-
-.contact-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.contact-card {
-  display: block;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
-}
-
-.contact-card span,
-.contact-card strong {
-  display: block;
-}
-
-.contact-card strong {
-  margin: 8px 0 10px;
-}
-
-.roadmap-list {
-  margin: 0;
-  padding-left: 20px;
-}
-
-.roadmap-list li + li {
-  margin-top: 12px;
-}
-
 .preview-row {
   display: grid;
   grid-template-columns: 56px minmax(0, 1fr) max-content;
@@ -418,13 +517,11 @@ a {
 }
 
 .faq-item {
-  border-top: 1px solid var(--line);
-  padding-top: 16px;
-}
-
-.faq-item:first-child {
-  border-top: 0;
-  padding-top: 0;
+  padding: 18px 20px;
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
 }
 
 .faq-item summary {
@@ -448,6 +545,11 @@ a {
   font-size: 1.08rem;
 }
 
+.contact-card span,
+.contact-card strong {
+  display: block;
+}
+
 .site-footer {
   display: flex;
   justify-content: space-between;
@@ -462,6 +564,21 @@ a {
   font-weight: 700;
 }
 
+@media (max-width: 960px) {
+  .hero-stage,
+  .hero-signal-bar,
+  .platform-row,
+  .editorial-row,
+  .preview-row,
+  .hero-proof-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .platform-meta {
+    text-align: left;
+  }
+}
+
 @media (max-width: 720px) {
   .hero,
   .band,
@@ -473,23 +590,29 @@ a {
   }
 
   .site-nav,
+  .site-nav-links-wrap,
   .site-footer,
   .release-card-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .hero-panel {
-    align-self: stretch;
+  .site-nav {
+    border-radius: 28px;
   }
 
-  .platform-row,
-  .editorial-row,
-  .preview-row {
-    grid-template-columns: minmax(0, 1fr);
+  .hero-copy {
+    padding-top: 8vh;
   }
 
-  .platform-meta {
-    text-align: left;
+  .hero-copy h1,
+  .section-heading h2 {
+    max-width: none;
+  }
+
+  .brand-kicker {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
   }
 }

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -275,7 +275,10 @@ h3,
 .release-mirror-block p,
 .application-summary,
 .application-list,
-.path-card p {
+.path-card p,
+.evidence-card p,
+.channel-card p,
+.channel-list {
   color: var(--muted);
   line-height: 1.72;
 }
@@ -301,7 +304,9 @@ h3,
 .application-grid,
 .use-case-grid,
 .contact-grid,
-.path-grid {
+.path-grid,
+.evidence-grid,
+.channel-grid {
   display: grid;
   gap: 16px;
 }
@@ -323,7 +328,9 @@ h3,
 .use-case-block,
 .contact-card,
 .narrative-block,
-.path-card {
+.path-card,
+.evidence-card,
+.channel-card {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 18px;
@@ -332,10 +339,18 @@ h3,
   backdrop-filter: blur(10px);
 }
 
-.path-card {
+.path-card,
+.channel-card {
   display: grid;
   gap: 14px;
   align-content: start;
+}
+
+.evidence-card {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  background: var(--surface-strong);
 }
 
 .path-card h3,
@@ -348,7 +363,9 @@ h3,
 .download-card h2,
 .release-card h2,
 .editorial-row strong,
-.contact-card strong {
+.contact-card strong,
+.evidence-card strong,
+.channel-card h3 {
   display: block;
   color: var(--ink);
 }
@@ -359,7 +376,8 @@ h3,
 .feature-block h3,
 .architecture-grid h3,
 .download-card h2,
-.release-card h2 {
+.release-card h2,
+.channel-card h3 {
   margin: 0;
 }
 
@@ -368,14 +386,16 @@ h3,
 }
 
 .signal-chip strong,
-.hero-proof-row strong {
+.hero-proof-row strong,
+.evidence-card strong {
   font-size: 1rem;
 }
 
 .hero-panel strong,
 .narrative-block h3,
 .use-case-block h3,
-.path-card h3 {
+.path-card h3,
+.channel-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
 }
@@ -410,6 +430,21 @@ h3,
   font-size: 0.95rem;
 }
 
+.channel-list,
+.release-update-list,
+.application-list,
+.roadmap-list {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.channel-list li + li,
+.release-update-list li + li,
+.application-list li + li,
+.roadmap-list li + li {
+  margin-top: 8px;
+}
+
 .band.alt {
   background: rgba(255, 249, 241, 0.5);
 }
@@ -435,7 +470,9 @@ h3,
 .architecture-grid,
 .download-grid,
 .application-grid,
-.contact-grid {
+.contact-grid,
+.evidence-grid,
+.channel-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
@@ -512,16 +549,8 @@ h3,
 .release-update-list,
 .application-list,
 .roadmap-list {
-  margin: 0;
-  padding-left: 20px;
   color: var(--muted);
   line-height: 1.75;
-}
-
-.release-update-list li + li,
-.application-list li + li,
-.roadmap-list li + li {
-  margin-top: 8px;
 }
 
 .release-card-actions {

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -5,21 +5,56 @@ import { siteUrl } from "../lib/site-url";
 import "./globals.css";
 
 const homeUrl = siteUrl("/");
+const siteTitle = `${brand.name} Fabushi | 佛法传播、修行记录与下载入口`;
+const siteDescription =
+  "Fabushi 法布施官网，统一承接佛法传播、修行记录、公开档案、排行榜、下载入口、测试申请与内容专栏。";
 
 export const metadata: Metadata = {
-  title: `${brand.name} | 官网`,
-  description: brand.mission,
+  title: siteTitle,
+  description: siteDescription,
   metadataBase: new URL(homeUrl),
+  applicationName: `${brand.name} Fabushi`,
   alternates: {
     canonical: homeUrl,
   },
+  keywords: [
+    "法布施",
+    "Fabushi",
+    "佛法传播",
+    "修行记录",
+    "佛教应用",
+    "下载入口",
+    "TestFlight",
+    "Android Beta",
+    "微信小程序",
+    "公开档案",
+    "排行榜",
+  ],
+  category: "community",
+  manifest: siteUrl("/manifest.webmanifest"),
   openGraph: {
-    title: `${brand.name} | 官网`,
-    description: brand.mission,
+    title: siteTitle,
+    description: siteDescription,
     url: homeUrl,
     siteName: "Fabushi",
     locale: "zh_CN",
     type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteTitle,
+    description: siteDescription,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
 };
 

--- a/frontend/apps/web/src/app/manifest.ts
+++ b/frontend/apps/web/src/app/manifest.ts
@@ -5,12 +5,12 @@ export const dynamic = "force-static";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "法布施官网",
+    name: "法布施 Fabushi 官网",
     short_name: "Fabushi",
-    description: "法布施官网与多端产品入口",
+    description: "Fabushi 官网，统一承接佛法传播、修行记录、下载入口、测试申请与内容专栏。",
     start_url: siteHref("/"),
     display: "standalone",
-    background_color: "#f7f0e4",
-    theme_color: "#b45f06",
+    background_color: "#f6f1e8",
+    theme_color: "#19140f",
   };
 }

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import {
   contactChannels,
   faqItems,
   homeActionPaths,
+  homeChannelRoles,
   homeHighlights,
   homeTrustSignals,
   homeUseCases,
@@ -38,6 +39,28 @@ export default async function HomePage() {
   const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
   const faqPreview = faqItems.slice(0, 4);
+  const siteEvidence = [
+    {
+      label: "可见下载状态",
+      value: releasePreview.length > 0 ? `${releasePreview.length} 个入口已同步` : "入口持续同步中",
+      detail: "首页和下载页会直接承接当前公开可见的 beta 与正式版状态。",
+    },
+    {
+      label: "公开内容积累",
+      value: `${allArticles.length} 篇内容已上线`,
+      detail: "路线说明、专题文章与更新内容会持续沉淀，而不是只靠一张首页解释项目。",
+    },
+    {
+      label: "问题预答复",
+      value: `${faqItems.length} 个 FAQ 已整理`,
+      detail: "把“这是什么、适合谁、是否能下载、各端怎么分工”提前写清楚。",
+    },
+    {
+      label: "稳定联系入口",
+      value: `${contactChannels.length} 条公开通道`,
+      detail: "测试申请、支持反馈与公开协作都有明确去处，不用靠猜测联系路径。",
+    },
+  ] as const;
 
   const organizationJsonLd = {
     "@context": "https://schema.org",
@@ -175,6 +198,22 @@ export default async function HomePage() {
         </div>
       </section>
 
+      <section className="band alt" id="evidence">
+        <div className="section-heading">
+          <p>公开事实</p>
+          <h2>如果官网想建立信任，就要先给出可验证、可引用、可复查的公开信息。</h2>
+        </div>
+        <div className="evidence-grid">
+          {siteEvidence.map((item) => (
+            <article key={item.label} className="evidence-card">
+              <span className="detail-label">{item.label}</span>
+              <strong>{item.value}</strong>
+              <p>{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="band" id="trust">
         <div className="section-heading">
           <p>为什么先做官网</p>
@@ -207,7 +246,31 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="capabilities">
+      <section className="band" id="channel-roles">
+        <div className="section-heading">
+          <p>入口分工</p>
+          <h2>不是每个人都该直接跳进同一个端里，官网要先告诉你该从哪里开始。</h2>
+        </div>
+        <div className="channel-grid">
+          {homeChannelRoles.map((item) => (
+            <article key={item.channel} className="channel-card">
+              <span className="detail-label">{item.channel}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <ul className="channel-list">
+                {item.bestFor.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
           <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,10 +1,18 @@
 import { fabushiApiClient } from "@fabushi/api-client";
-import { brand, contactChannels, faqItems, homeHighlights, launchRoadmap } from "@fabushi/shared";
+import {
+  brand,
+  contactChannels,
+  faqItems,
+  homeHighlights,
+  homeTrustSignals,
+  homeUseCases,
+  launchRoadmap,
+} from "@fabushi/shared";
 import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
 import { getAllArticles, getFeaturedArticles } from "../lib/content";
 import { getOfficialSiteReleaseCollection } from "../lib/official-site-releases";
-import { siteHref } from "../lib/site-url";
+import { siteHref, siteUrl } from "../lib/site-url";
 
 async function getLeaderboardPreview() {
   try {
@@ -27,38 +35,142 @@ export default async function HomePage() {
   const allArticles = getAllArticles();
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+  const faqPreview = faqItems.slice(0, 4);
+
+  const organizationJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: `${brand.name} Fabushi`,
+    url: siteUrl("/"),
+    email: supportEmail,
+    description: brand.mission,
+    sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
+  };
+
+  const websiteJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: `${brand.name} Fabushi`,
+    url: siteUrl("/"),
+    inLanguage: "zh-CN",
+    description: "Fabushi 官网，统一承接品牌说明、下载入口、测试申请、FAQ 和内容专栏。",
+  };
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqPreview.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
 
   return (
     <main className="page-shell">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+
       <header className="hero">
         <SiteHeader />
 
-        <div className="hero-copy">
-          <p className="eyebrow">法布施官网</p>
-          <p className="brand-kicker">{brand.name}</p>
-          <h1>官网负责入口，小程序负责触达，主应用负责完整体验。</h1>
-          <p className="lede">{brand.mission}</p>
-          <div className="hero-actions">
-            <a className="primary-action" href={siteHref("/download")}>
-              查看下载入口
-            </a>
-            <a className="secondary-action" href={siteHref("/faq")}>
-              查看常见问题
-            </a>
+        <div className="hero-stage">
+          <div className="hero-copy">
+            <p className="eyebrow">法布施官网 · 品牌入口 / 下载引导 / 内容专栏</p>
+            <p className="brand-kicker">
+              {brand.name}
+              <span>Fabushi</span>
+            </p>
+            <h1>把佛法传播、修行记录与同行连接，放进一个更清晰的数字入口。</h1>
+            <p className="lede">
+              官网先负责解释方向、建立信任、呈现下载状态与内容路线；微信小程序负责轻触达；主应用继续承接上传、互动与沉浸式体验。
+            </p>
+            <div className="hero-actions">
+              <a className="primary-action" href={siteHref("/download")}>
+                查看下载入口
+              </a>
+              <a className="secondary-action" href={siteHref("/apply")}>
+                申请测试资格
+              </a>
+              <a className="secondary-action" href={siteHref("/faq")}>
+                查看常见问题
+              </a>
+            </div>
+            <div className="hero-signal-bar">
+              {homeTrustSignals.map((item) => (
+                <article key={item.title} className="signal-chip">
+                  <span className="detail-label">{item.title}</span>
+                  <strong>{item.summary}</strong>
+                </article>
+              ))}
+            </div>
           </div>
-        </div>
 
-        <div className="hero-panel">
-          <p>当前推进</p>
-          <strong>Next.js 官网 + Taro 微信小程序 + 现有 Workers API 共用</strong>
-          <span>现在官网会直接读取最新 beta 发布资产，并预留人工验收后的正式版发布入口。</span>
+          <aside className="hero-aside">
+            <div className="hero-panel">
+              <p>一句话理解</p>
+              <strong>{brand.name} 是一个围绕佛法传播、修行记录与同行连接展开的数字产品体系。</strong>
+              <span>
+                官网负责说明与引导，小程序负责微信生态触达，Flutter 主应用承接更完整的浏览、上传、互动与个人使用流程。
+              </span>
+            </div>
+            <div className="hero-proof-list">
+              <p className="detail-label">当前公开入口</p>
+              {releasePreview.map((item) => (
+                <a key={`${item.audience}-${item.platform}`} className="hero-proof-row" href={siteHref(item.primaryHref)}>
+                  <div>
+                    <strong>{item.title}</strong>
+                    <span>{item.description}</span>
+                  </div>
+                  <em>{item.status}</em>
+                </a>
+              ))}
+            </div>
+          </aside>
         </div>
       </header>
+
+      <section className="band" id="trust">
+        <div className="section-heading">
+          <p>为什么先做官网</p>
+          <h2>先把入口、分工、状态和信任信息讲清楚，转化路径才不会在第一屏就断掉。</h2>
+        </div>
+        <div className="narrative-grid">
+          {homeTrustSignals.map((item) => (
+            <article key={item.title} className="narrative-block">
+              <span className="detail-label">{item.title}</span>
+              <h3>{item.summary}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="audience">
+        <div className="section-heading">
+          <p>适用场景</p>
+          <h2>Fabushi 官网应该同时服务首次到达、内测申请、合作判断和搜索理解这四种场景。</h2>
+        </div>
+        <div className="use-case-grid">
+          {homeUseCases.map((item) => (
+            <article key={item.audience} className="use-case-block">
+              <span className="detail-label">{item.audience}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
-          <h2>官网负责品牌与入口，小程序负责轻场景触达，Flutter 继续承接重体验。</h2>
+          <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>
         </div>
         <div className="feature-grid">
           {homeHighlights.map((item) => (
@@ -73,7 +185,7 @@ export default async function HomePage() {
       <section className="band cinematic">
         <div className="section-heading">
           <p>下载入口</p>
-          <h2>beta 安装包和 TestFlight 状态已经能直接回流到官网入口里。</h2>
+          <h2>官网已经开始把公开可见的发布状态直接拉回页面，减少“想下载却找不到入口”的摩擦。</h2>
         </div>
         <div className="platform-strip">
           {releasePreview.map((item) => (
@@ -99,7 +211,7 @@ export default async function HomePage() {
       <section className="band alt" id="mini-program">
         <div className="section-heading">
           <p>微信小程序</p>
-          <h2>首期建议先覆盖轻浏览、榜单、公开档案与基础登录。</h2>
+          <h2>首期优先覆盖轻浏览、榜单、公开档案与基础登录，把最容易传播的场景先跑通。</h2>
         </div>
         <ol className="roadmap-list">
           {launchRoadmap.map((item) => (
@@ -111,12 +223,12 @@ export default async function HomePage() {
       <section className="band" id="architecture">
         <div className="section-heading">
           <p>技术架构</p>
-          <h2>一个前端 monorepo，共享接口层、类型、文案和部分纯业务逻辑。</h2>
+          <h2>一个前端 monorepo，共享接口层、类型、文案和部分纯业务逻辑，让官网与小程序各自发挥但不分家。</h2>
         </div>
         <div className="architecture-grid">
           <div>
             <h3>apps/web</h3>
-            <p>Next.js 官网，负责 SEO、落地页、功能说明、后续内容运营。</p>
+            <p>Next.js 官网，负责 SEO、落地页、功能说明、下载引导和后续内容运营。</p>
           </div>
           <div>
             <h3>apps/mp-wechat</h3>
@@ -124,11 +236,11 @@ export default async function HomePage() {
           </div>
           <div>
             <h3>packages/shared</h3>
-            <p>品牌信息、导航、固定文案、纯前端通用工具。</p>
+            <p>品牌信息、导航、固定文案、内容结构与纯前端通用工具。</p>
           </div>
           <div>
             <h3>packages/api-client</h3>
-            <p>统一对接现有 `flutter.ombhrum.com` API 与共享类型。</p>
+            <p>统一对接现有 flutter.ombhrum.com API 与共享类型。</p>
           </div>
         </div>
       </section>
@@ -136,11 +248,11 @@ export default async function HomePage() {
       <section className="band alt">
         <div className="section-heading">
           <p>接口复用</p>
-          <h2>官网已经直接接了现有排行榜接口，作为“后端继续共用”的第一块落地验证。</h2>
+          <h2>官网已经直接接入现有排行榜接口，证明它不是孤立宣传页，而是会逐步承接真实产品数据的入口层。</h2>
         </div>
         <div className="preview-list">
           {leaderboard.length === 0 ? (
-            <p className="empty-copy">当前没有拉到排行榜预览，页面仍可正常展示静态内容。</p>
+            <p className="empty-copy">当前没有拉到排行榜预览，页面仍会稳定展示其余静态与内容型模块。</p>
           ) : (
             leaderboard.map((item, index) => (
               <div key={item.username} className="preview-row">
@@ -156,7 +268,7 @@ export default async function HomePage() {
       <section className="band">
         <div className="section-heading">
           <p>内容专栏</p>
-          <h2>官网不只是一张首页，还要能持续承接路线、更新和专题内容。</h2>
+          <h2>官网不只是一张首页，它还要持续承接路线、更新、专题内容和后续可引用的公开信息。</h2>
         </div>
         <div className="editorial-list">
           {featuredArticles.map((item) => (
@@ -182,10 +294,10 @@ export default async function HomePage() {
       <section className="band alt">
         <div className="section-heading">
           <p>常见问题</p>
-          <h2>先把用户最容易问的几件事说清楚，官网才真正开始工作。</h2>
+          <h2>把用户最容易问的关键问题提前说清楚，也是在补强搜索和生成式引用最爱抓取的结构化信息。</h2>
         </div>
         <div className="faq-list">
-          {faqItems.slice(0, 3).map((item) => (
+          {faqPreview.map((item) => (
             <details key={item.question} className="faq-item">
               <summary>{item.question}</summary>
               <p>{item.answer}</p>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -57,6 +57,25 @@ export default async function HomePage() {
     description: "Fabushi 官网，统一承接品牌说明、下载入口、测试申请、FAQ 和内容专栏。",
   };
 
+  const applicationJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: `${brand.name} Fabushi`,
+    applicationCategory: "LifestyleApplication",
+    operatingSystem: "iOS, Android, Web, WeChat Mini Program",
+    inLanguage: "zh-CN",
+    url: siteUrl("/"),
+    downloadUrl: siteUrl("/download"),
+    description:
+      "Fabushi 法布施是一个围绕佛法传播、修行记录、公开档案、榜单与同行连接组织起来的多端产品体系。",
+    featureList: [
+      "佛法传播与内容入口",
+      "修行记录与隐私边界",
+      "公开档案与榜单浏览",
+      "下载引导、测试申请与 FAQ",
+    ],
+  };
+
   const faqJsonLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
@@ -74,6 +93,7 @@ export default async function HomePage() {
     <main className="page-shell">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applicationJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
       <header className="hero">

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -61,6 +61,26 @@ export default async function HomePage() {
       detail: "测试申请、支持反馈与公开协作都有明确去处，不用靠猜测联系路径。",
     },
   ] as const;
+  const definitionBlocks = [
+    {
+      label: "Fabushi 是什么",
+      title: "一个围绕佛法传播、修行记录与同行连接组织起来的数字产品体系。",
+      description:
+        "官网不是主应用的替代品，而是统一承接理解、下载、测试申请、内容更新与公开协作的第一入口。",
+    },
+    {
+      label: "现在已经开放什么",
+      title: "官网、FAQ、下载状态、申请测试与内容专栏已经开始协同工作。",
+      description:
+        "第一次接触项目的人，已经可以先在这里完成理解、判断与下一步动作，而不必先进入应用再摸索。",
+    },
+    {
+      label: "还在逐步开放什么",
+      title: "微信小程序首期能力与更完整的主应用体验会继续按节奏释放。",
+      description:
+        "这让站点可以真实同步当前状态，而不是过度承诺尚未公开的功能或入口。",
+    },
+  ] as const;
 
   const organizationJsonLd = {
     "@context": "https://schema.org",
@@ -214,7 +234,31 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="trust">
+      <section className="band" id="definition">
+        <div className="section-heading">
+          <p>先定义清楚</p>
+          <h2>让用户和搜索系统都先搞清楚 Fabushi 是什么、已经开放什么、还在推进什么。</h2>
+        </div>
+        <div className="definition-grid">
+          {definitionBlocks.map((item) => (
+            <article key={item.label} className="definition-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+        <div className="inline-cta">
+          <a className="secondary-action" href={siteHref("/faq")}>
+            继续看完整 FAQ
+          </a>
+          <a className="secondary-action" href={siteHref("/download")}>
+            查看当前下载状态
+          </a>
+        </div>
+      </section>
+
+      <section className="band alt" id="trust">
         <div className="section-heading">
           <p>为什么先做官网</p>
           <h2>先把入口、分工、状态和信任信息讲清楚，转化路径才不会在第一屏就断掉。</h2>
@@ -230,7 +274,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band alt" id="audience">
+      <section className="band" id="audience">
         <div className="section-heading">
           <p>适用场景</p>
           <h2>Fabushi 官网应该同时服务首次到达、内测申请、合作判断和搜索理解这四种场景。</h2>
@@ -246,7 +290,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="channel-roles">
+      <section className="band alt" id="channel-roles">
         <div className="section-heading">
           <p>入口分工</p>
           <h2>不是每个人都该直接跳进同一个端里，官网要先告诉你该从哪里开始。</h2>
@@ -270,7 +314,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band alt" id="capabilities">
+      <section className="band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
           <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -3,6 +3,7 @@ import {
   brand,
   contactChannels,
   faqItems,
+  homeActionPaths,
   homeHighlights,
   homeTrustSignals,
   homeUseCases,
@@ -154,6 +155,25 @@ export default async function HomePage() {
           </aside>
         </div>
       </header>
+
+      <section className="band quick-paths" id="paths">
+        <div className="section-heading">
+          <p>快速路径</p>
+          <h2>第一次来到这里，通常只需要先完成这三件事里的其中一件。</h2>
+        </div>
+        <div className="path-grid">
+          {homeActionPaths.map((item) => (
+            <article key={item.title} className="path-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="band" id="trust">
         <div className="section-heading">

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -12,7 +12,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/api/"],
       },
     ],
-    host: siteUrl("/"),
+    host: new URL(siteUrl("/")).origin,
     sitemap: siteUrl("/sitemap.xml"),
   };
 }

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -5,10 +5,14 @@ export const dynamic = "force-static";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    host: siteUrl("/"),
     sitemap: siteUrl("/sitemap.xml"),
   };
 }

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -7,7 +7,7 @@ export const dynamic = "force-static";
 export default function sitemap(): MetadataRoute.Sitemap {
   const routes: MetadataRoute.Sitemap = ["/", "/download", "/apply", "/faq", "/contact", "/insights"].map((path) => ({
     url: siteUrl(path),
-    lastModified: "2026-05-06",
+    lastModified: "2026-05-07",
   }));
 
   const articleRoutes = getAllArticles().map((article) => ({

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -4,15 +4,21 @@ import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
 
+const staticRoutes = ["/", "/download", "/apply", "/faq", "/contact", "/insights"] as const;
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const routes: MetadataRoute.Sitemap = ["/", "/download", "/apply", "/faq", "/contact", "/insights"].map((path) => ({
+  const routes: MetadataRoute.Sitemap = staticRoutes.map((path) => ({
     url: siteUrl(path),
     lastModified: "2026-05-07",
+    changeFrequency: path === "/" ? "weekly" : path === "/download" || path === "/faq" ? "weekly" : "monthly",
+    priority: path === "/" ? 1 : path === "/download" || path === "/faq" ? 0.9 : path === "/apply" ? 0.85 : 0.75,
   }));
 
-  const articleRoutes = getAllArticles().map((article) => ({
+  const articleRoutes: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
     url: siteUrl(`/insights/${article.slug}`),
     lastModified: article.publishedAt,
+    changeFrequency: "monthly",
+    priority: article.featured ? 0.8 : 0.65,
   }));
 
   return [...routes, ...articleRoutes];

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -5,14 +5,20 @@ export function SiteHeader() {
   return (
     <nav className="site-nav" aria-label="主导航">
       <a className="site-wordmark" href={siteHref("/")}>
-        Fabushi
+        <span>Fabushi</span>
+        <small>法布施官网</small>
       </a>
-      <div className="site-nav-links">
-        {primaryNavigation.map((item) => (
-          <a key={item.href} href={siteHref(item.href)}>
-            {item.label}
-          </a>
-        ))}
+      <div className="site-nav-links-wrap">
+        <div className="site-nav-links">
+          {primaryNavigation.map((item) => (
+            <a key={item.href} href={siteHref(item.href)}>
+              {item.label}
+            </a>
+          ))}
+        </div>
+        <a className="nav-cta" href={siteHref("/download")}>
+          下载入口
+        </a>
       </div>
     </nav>
   );

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -57,6 +57,30 @@ export const homeUseCases = [
   },
 ] as const;
 
+export const homeActionPaths = [
+  {
+    label: "第一次了解",
+    title: "先快速看懂 Fabushi 是什么，以及官网为什么这样组织。",
+    description: "如果你是第一次来到这里，先看 FAQ 和首页结构说明，判断这是不是你要找的产品方向。",
+    href: "/faq",
+    ctaLabel: "先看常见问题",
+  },
+  {
+    label: "准备进入",
+    title: "先确认当前是否有可公开下载或可申请的测试入口。",
+    description: "下载页会持续承接 Android beta、iOS TestFlight 和正式版的公开状态，避免用户在错误页面里兜圈。",
+    href: "/download",
+    ctaLabel: "查看下载状态",
+  },
+  {
+    label: "准备沟通",
+    title: "想申请测试、反馈问题或讨论合作时，直接进入正确通道。",
+    description: "把申请测试、支持反馈和合作询问拆成明确入口，能减少很多没有上下文的来回邮件。",
+    href: "/apply",
+    ctaLabel: "进入申请通道",
+  },
+] as const;
+
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -81,6 +81,33 @@ export const homeActionPaths = [
   },
 ] as const;
 
+export const homeChannelRoles = [
+  {
+    channel: "官网",
+    title: "先负责解释方向、建立信任、给出下载与沟通入口。",
+    description: "适合第一次接触 Fabushi、想先判断项目定位、想看下载状态，或需要专题内容和 FAQ 的访问者。",
+    bestFor: ["首页与 FAQ 快速理解", "查看下载状态与发布说明", "进入申请测试或合作沟通"],
+    href: "/",
+    ctaLabel: "继续浏览官网",
+  },
+  {
+    channel: "微信小程序",
+    title: "优先承接微信生态里的轻触达、轻浏览与公开信息分发。",
+    description: "适合想在微信里快速查看榜单、公开档案与轻量内容入口的人，不强求先进入完整主应用。",
+    bestFor: ["微信内轻触达", "公开档案与榜单浏览", "低门槛内容传播入口"],
+    href: "/insights/wechat-mini-program-phase-one",
+    ctaLabel: "查看小程序路线",
+  },
+  {
+    channel: "主应用",
+    title: "继续承接更完整的修行记录、上传分享、互动与沉浸式体验。",
+    description: "适合已经确定要深入使用 Fabushi、愿意参与测试，或需要完整个人流程与重交互能力的用户。",
+    bestFor: ["更完整的个人使用流程", "上传与互动等重交互场景", "参与 iOS / Android 内测"],
+    href: "/download",
+    ctaLabel: "查看主应用入口",
+  },
+] as const;
+
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -1,15 +1,15 @@
 export const homeHighlights = [
   {
-    title: "全球法布施传播",
-    description: "围绕内容传播、上传分享、回向记录与可见榜单，建立持续增长的善意网络。",
+    title: "传播入口更清楚",
+    description: "把项目定位、下载状态、申请测试和内容入口收拢到同一官网里，减少用户第一次接触时的理解成本。",
   },
   {
-    title: "修行记录与隐私控制",
-    description: "保留公开展示与私密修行的边界，让个人节奏与社交互动能自然共存。",
+    title: "修行记录更有边界",
+    description: "同时照顾公开传播、个人修行记录与隐私控制，让分享、回向与安静练习可以并存。",
   },
   {
-    title: "轻社群与共修关系",
-    description: "通过关注、排行榜、共修小组和公开档案，帮助用户更容易找到同行者。",
+    title: "多端协作不再割裂",
+    description: "官网负责理解与转化，小程序负责轻触达，主应用负责完整体验，三者围绕同一套品牌与发布节奏协同工作。",
   },
 ] as const;
 
@@ -68,9 +68,9 @@ export const primaryNavigation = [
 ] as const;
 
 export const launchRoadmap = [
-  "先上线官网，承接品牌介绍、功能说明、下载指引和后续活动落地页。",
-  "同步建设微信小程序首期版本，优先覆盖轻浏览、榜单、公开档案和基础登录。",
-  "继续把更重的创作、上传和沉浸式体验保留在 Flutter 主应用里。",
+  "先把官网做成稳定的公开入口，集中承接项目介绍、下载状态、FAQ、内容更新和联系路径。",
+  "同步推进微信小程序首期版本，优先覆盖轻浏览、榜单、公开档案和基础登录等轻场景触达能力。",
+  "继续把更完整的上传、沉浸式浏览、个人中心和重交互流程保留在 Flutter 主应用里。",
 ] as const;
 
 export const downloadOptions = [
@@ -105,36 +105,41 @@ export const downloadOptions = [
 ] as const;
 
 export const downloadStatusNotes = [
-  "当前仓库里还没有可直接公开挂出的 App Store、TestFlight 或 APK 正式下载直链。",
-  "官网先把各平台状态、职责和等待名单入口讲清楚，避免用户点进来却落到空页面。",
-  "一旦正式下载链接可公开，优先替换 downloadOptions 中的对应入口即可，不需要重做页面结构。",
+  "官网现在会直接承接 Android beta、iOS TestFlight 和正式版发布状态，不再只是一个泛泛的等待名单页面。",
+  "当正式下载链接尚未公开时，页面会优先说明状态、适用人群和下一步动作，避免用户点进来却找不到判断依据。",
+  "一旦正式下载链接可公开，优先替换对应入口即可，不需要重新改整页结构。",
 ] as const;
 
 export const faqItems = [
   {
+    question: "法布施 Fabushi 是什么？",
+    answer:
+      "Fabushi 是一个围绕佛法传播、修行记录、善意分享与社群连接组织起来的多端产品入口。官网负责解释与引导，小程序负责轻触达，主应用负责完整体验。",
+  },
+  {
     question: "官网、微信小程序和 Flutter 主应用分别承担什么角色？",
     answer:
-      "官网负责品牌说明、下载入口、FAQ 和内容运营；微信小程序负责微信生态里的轻触达；Flutter 主应用继续承接完整的沉浸式体验和重交互流程。",
+      "官网负责品牌说明、下载入口、FAQ、发布说明和内容运营；微信小程序负责微信生态里的轻浏览与轻交互；Flutter 主应用继续承接更完整的沉浸式体验和重交互流程。",
+  },
+  {
+    question: "Fabushi 现在可以下载吗？",
+    answer:
+      "可以先通过官网查看 Android beta、iOS TestFlight 与正式版的当前状态。可公开下载时，官网会直接给出入口；暂未公开时，会明确说明申请测试或等待下一步发布的方式。",
   },
   {
     question: "为什么不直接用 Flutter Web 同时做官网和小程序？",
     answer:
-      "官网需要更好的 SEO、内容结构和首屏控制，小程序又有自己的运行规范。拆成 Next.js + Taro 可以减少后续返工，同时继续复用现有后端与业务层。",
+      "官网需要更清晰的 SEO、内容结构、首屏表达和发布信息管理，小程序也有自己的运行规范。拆成 Next.js 官网和 Taro 小程序，可以减少后续返工，同时继续复用现有后端与业务层。",
   },
   {
-    question: "官网和小程序会不会变成两套完全分裂的系统？",
+    question: "Fabushi 适合哪些人先关注？",
     answer:
-      "不会。新前端 monorepo 会持续共享 API client、类型、品牌文案和部分纯业务逻辑，差异主要保留在各自的页面表现层。",
-  },
-  {
-    question: "小程序首期最先会上什么？",
-    answer:
-      "优先是轻浏览、榜单、公开档案和基础登录，先把传播入口和社交发现路径打通，再逐步补更复杂的内容创作与上传流程。",
+      "适合正在做佛法内容传播、需要安静记录修行、希望与共修同行者建立连接，或者想参与传播合作与渠道联动的人。官网会优先帮助这些人快速判断自己该走哪条入口。",
   },
   {
     question: "为什么下载页现在不再只是等待名单入口？",
     answer:
-      "因为官网已经开始直接读取 GitHub Release 的 Android beta 安装包、TestFlight 上传状态，以及人工验收后发布的正式版信息。这样下载页会跟着发布链路一起更新，而不是靠手动改文案。",
+      "因为官网已经开始直接读取 GitHub Release 的 Android beta 安装包、TestFlight 上传状态，以及人工验收后发布的正式版信息。这样下载页会跟着发布链路一起更新，而不是只靠手工改文案。",
   },
 ] as const;
 
@@ -143,19 +148,19 @@ export const contactChannels = [
     label: "支持邮箱",
     value: "support@fabushi.com",
     href: "mailto:support@fabushi.com",
-    note: "下载申请、测试资格、问题反馈和合作沟通统一从这里进入。",
+    note: "测试申请、下载问题、反馈收集和合作沟通统一从这里进入，避免入口分散。",
   },
   {
     label: "官网域名",
     value: "fabushi.ombhrum.com",
     href: "https://fabushi.ombhrum.com",
-    note: "后续会作为官网、专题页和正式下载指引的统一入口。",
+    note: "长期对外入口会统一收拢到官网，便于承接下载、FAQ、专题内容和活动页面。",
   },
   {
     label: "GitHub 仓库",
     value: "bhrumom/fabushi",
     href: "https://github.com/bhrumom/fabushi",
-    note: "适合查看项目进展、提交 issue 和跟踪公开开发记录。",
+    note: "适合查看公开开发记录、发布资产、issue 反馈与持续迭代进展。",
   },
 ] as const;
 

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -13,6 +13,50 @@ export const homeHighlights = [
   },
 ] as const;
 
+export const homeTrustSignals = [
+  {
+    title: "平台分工清晰",
+    summary: "官网负责解释与引导，小程序负责轻触达，主应用负责完整体验。",
+    description:
+      "用户第一次进入时就能知道该从哪里了解产品、从哪里申请测试、从哪里进入更深度的使用流程，减少入口混乱和跳失。",
+  },
+  {
+    title: "发布状态可见",
+    summary: "下载页会直接承接 beta 安装包、TestFlight 状态和正式版发布说明。",
+    description:
+      "官网不再只是静态等待名单，而是开始连接真实发布链路，让用户、合作方和搜索引擎都能看到当前可获得的入口。",
+  },
+  {
+    title: "内容能够持续累积",
+    summary: "除了首页，官网还承接路线、专题内容、更新说明和 FAQ。",
+    description:
+      "这让站点既能做品牌入口，也能沉淀长期可搜索、可引用、可分享的内容资产，而不是一页式说明页。",
+  },
+] as const;
+
+export const homeUseCases = [
+  {
+    audience: "新用户",
+    title: "先理解产品，再决定从哪个入口进入。",
+    description: "官网优先解释 Fabushi 是什么、适合谁、当前能做什么，以及 iOS、Android、微信小程序分别是什么状态。",
+  },
+  {
+    audience: "内测申请者",
+    title: "快速找到申请路径、下载状态和反馈方式。",
+    description: "把等待名单、测试资格、安装包说明和反馈邮箱放在一条清晰路径里，减少用户往返询问。",
+  },
+  {
+    audience: "合作与渠道方",
+    title: "更快判断项目方向、公开能力和可合作的切入点。",
+    description: "官网把产品定位、公开协作方式、内容专栏和联系入口整理清楚，方便外部伙伴快速完成判断。",
+  },
+  {
+    audience: "生成式搜索与搜索引擎",
+    title: "更容易准确理解 Fabushi 的平台结构和价值主张。",
+    description: "定义、场景、FAQ、内容专栏和可见发布状态会一起组成更容易被引用和总结的站点语义结构。",
+  },
+] as const;
+
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },


### PR DESCRIPTION
## 这轮改了什么

- 将官网首页继续从“项目说明页”收紧为“品牌入口 + 下载引导 + 测试转化”的产品官网表达
- 新增首页快速路径、公开事实与“先定义清楚”区块，让用户和搜索系统都能先准确理解 Fabushi 是什么、现在开放什么、还在推进什么
- 继续优化首页文案与视觉节奏，强化首屏价值表达、信任信号、场景适配和入口分工说明
- 为 FAQ、下载、申请测试、联系页面补充 breadcrumb 结构化数据，增强页面层级的可理解性与生成式搜索引用友好度
- 保持下载、申请、联系页面的 canonical、关键词和 JSON-LD 协同一致，继续补强 SEO / GEO 基础

## 为什么这样改

- 当前官网最值钱的任务不是堆功能，而是先把用户第一次到达时最容易卡住的理解、判断和转化路径讲清楚
- “定义清晰度”是这轮最重要的增量：很多搜索流量和生成式引用会先问 Fabushi 是什么、现在能做什么，而不是先关心视觉细节
- 给关键落地页补上 breadcrumb 语义，能让站点结构更容易被搜索系统和 AI 引擎当成一组有层级的页面来理解，而不是互相孤立的单页

## 这轮重点文件

- `frontend/apps/web/src/app/page.tsx`
- `frontend/apps/web/src/app/globals.css`
- `frontend/apps/web/src/app/faq/page.tsx`
- `frontend/apps/web/src/app/download/page.tsx`
- `frontend/apps/web/src/app/apply/page.tsx`
- `frontend/apps/web/src/app/contact/page.tsx`

## 验证说明

- 已确认本轮改动已经写入现有官网优化分支与 PR
- 已复查首页新增的定义区块，以及 FAQ、下载、申请测试、联系页面的 breadcrumb 结构化数据均已落到文件内容中
- 当前环境无法运行本地 Next.js 构建或页面截图验证，因为仓库无法直接拉到本地工作区，只能通过 GitHub 连接器读取和更新文件

## 后续仍值得继续推进

- 下载页继续增加更明确的版本差异说明与适用人群对比
- 内容专栏继续补问题式专题，扩大 FAQ 和文章对搜索与生成式引用的覆盖
- 在不破坏现有克制风格的前提下，继续增强移动端首屏和导航的可用性