### PR TITLE
docs: add draft PR required-check recovery rule

### DIFF
--- a/docs/release-controller.md
+++ b/docs/release-controller.md
@@ -83,6 +83,18 @@
 - 只有在仓库规则确实允许该类 PR 无额外检查时，才可继续按 review / auto-merge / merge queue 路径推进
 - 这类 PR 在真正 `merged` 前，仍然属于等待中的 PR 事项，不能因为 checks 为空就误判成失败，也不能因为没有红灯就误判成已闭环
 
+### Draft PR 无检查收口规则
+
+当一条 draft PR 的当前 `head SHA` 既没有 workflow runs，也没有 combined status，而且工具链或接口又无法稳定把它转成 ready for review 时，不要把它当成普通等待位长期悬空。
+
+默认处理方式：
+
+- 先记录旧 draft 的 `head SHA`、缺失的必需检查名，以及“当前没有 runs / status”这个事实
+- 如果仓库规则要求 `CI result` 之类的必需门禁，而当前工具又无法直接把 draft 转正，就关闭旧 draft，并基于同一 `head branch` 立即重开一条 ready PR
+- 把这条新 ready PR 视为“重新挂载必需门禁”的动作，而不是重复开新需求；PR 描述或评论里要说明替代原因
+- 只有当新 ready PR 也继续没有 head checks 时，才进一步把问题升级为真实 workflow 触发缺口继续追
+- 旧 draft 与替代 ready PR 之间的关系要在评论、运行手册或主控记录里留痕，避免后续巡检误把旧 draft 继续当成活跃主线
+
 ### 3. Issue 治理工位
 
 负责：


### PR DESCRIPTION
## 为什么改

这轮主控继续推进官网线时，旧 draft `#225` 暴露出一个新的长期规则缺口：

- 当前 `head SHA` `4592d36f6fa142318bf58bcb32035a05be95ed1a` 没有关联 workflow runs，也没有 combined status
- 仓库规则又要求必需检查 `CI result`
- 连接器的 draft -> ready 接口当前仍报 schema 错误，不能稳定把旧 draft 转成 ready

如果这条处理方式只留在一次性评论里，后续 scheduled run 还会重复把这种状态误当成普通等待。

## 这次改了什么

- 更新 `docs/release-controller.md`
- 新增 `Draft PR 无检查收口规则`，明确：
  - 先记录旧 draft 的 head SHA 与缺失的必需检查
  - 工具无法转正时，关闭旧 draft，并基于同一 head branch 立即重开 ready PR
  - 新 ready PR 的作用是重新挂载必需门禁，而不是重复开新需求
  - 只有替代 ready PR 仍然没有 head checks 时，才继续升级为真实 workflow 触发缺口

## 为什么现在同步

这是一条已经在仓库真实推进里被验证过的调度规则，而且会直接影响后续主控是否空等、是否误判、是否继续推进同一条分支。

把它版本化有两个直接价值：

- 减少后续把“draft + 无检查 + 转不了 ready”误判成普通等待
- 让旧 draft 与替代 ready PR 的关系在仓库里有长期说明，而不是只存在于当轮上下文

## 验证

- 仅修改 `docs/release-controller.md`
- 无运行时代码改动
- 规则内容直接对应本轮 `#225 -> #226` 的真实推进动作