### PR TITLE
[codex] 优化下载页决策清晰度与 GEO 语义

### DIFF
--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -6,11 +6,85 @@ import {
   getOfficialSiteReleaseCollection,
   type OfficialSiteChannel,
 } from "../../lib/official-site-releases";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
+
+const downloadUrl = siteUrl("/download");
+const downloadTitle = `下载入口 | ${brand.name}`;
+const downloadDescription =
+  "查看 Fabushi 官网上的 Android Beta、iOS TestFlight 与正式版发布状态，并根据你的场景选择合适入口。";
+
+const decisionPaths = [
+  {
+    title: "想先体验最新进度",
+    recommendation: "优先看 Beta 渠道",
+    description: "适合愿意更早体验新版本、也能接受内测节奏和偶发问题的人。",
+    checkpoints: ["Android Beta 会跟随最新 GitHub Release 自动同步", "iOS Beta 会在 TestFlight 上传成功后补到官网", "如果你准备反馈问题，这条路径最合适"],
+  },
+  {
+    title: "想要更稳的安装体验",
+    recommendation: "等待正式版入口",
+    description: "适合第一次接触项目、暂时不想承担测试波动，或者准备推荐给更多人的用户。",
+    checkpoints: ["正式版只在人工验收通过后才会上线", "官网不会提前挂出未经确认的正式安装包", "入口一旦公开，会直接替换为正式版下载路径"],
+  },
+  {
+    title: "先判断自己该走哪条路",
+    recommendation: "先看推荐路径和 FAQ",
+    description: "适合还不确定自己是来下载、申请资格，还是先了解发布状态的人。",
+    checkpoints: ["先分清 Beta 与正式版的职责差异", "下载慢时优先尝试镜像链接", "还没有公开入口时，直接去申请测试或联系支持"],
+  },
+] as const;
+
+const releasePrinciples = [
+  {
+    title: "Beta 测试版",
+    summary: "更快同步、更适合早期反馈，也更可能跟着交付节奏持续变化。",
+    bullets: ["入口优先由自动同步链路更新", "适合主动体验新功能和报告问题的人", "下载说明会跟着 release 资产一起刷新"],
+  },
+  {
+    title: "正式版",
+    summary: "更强调稳定性和人工确认，不会因为有构建产物就立刻公开挂出。",
+    bullets: ["必须经过人工验收后才会发布", "更适合第一次安装或对稳定性更敏感的人", "官网只展示已经确认可公开分发的入口"],
+  },
+] as const;
+
+const downloadFaqs = [
+  {
+    question: "我应该优先下 Beta，还是等正式版？",
+    answer:
+      "如果你愿意更早体验最新进度，并能接受测试节奏，优先看 Beta。若你更在意稳定性、或者准备第一次接触项目，建议先等正式版入口。",
+  },
+  {
+    question: "为什么官网不把所有构建产物都直接挂出来？",
+    answer:
+      "因为下载页的职责不是展示所有产物，而是只给用户当前真正适合点击的入口。正式版尤其需要经过人工验收，避免用户拿到还不适合公开分发的安装包。",
+  },
+  {
+    question: "如果页面上还没有公开入口，我下一步该做什么？",
+    answer:
+      "先看当前 release 状态和推荐路径。如果是想参与体验，可以直接申请测试；如果是想确认发布时间或下载问题，优先联系支持邮箱。",
+  },
+] as const;
 
 export const metadata: Metadata = {
-  title: `下载入口 | ${brand.name}`,
-  description: "查看 Fabushi 官网上的 Android Beta、iOS TestFlight 与正式版发布状态。",
+  title: downloadTitle,
+  description: downloadDescription,
+  keywords: ["Fabushi 下载", "法布施下载", "Android Beta", "iOS TestFlight", "正式版发布"],
+  alternates: {
+    canonical: downloadUrl,
+  },
+  openGraph: {
+    title: downloadTitle,
+    description: downloadDescription,
+    url: downloadUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: downloadTitle,
+    description: downloadDescription,
+  },
 };
 
 function formatPublishedAt(value?: string) {
@@ -86,17 +160,95 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
 export default async function DownloadPage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
 
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "首页", item: siteUrl("/") },
+          { "@type": "ListItem", position: 2, name: "下载入口", item: downloadUrl },
+        ],
+      },
+      {
+        "@type": "CollectionPage",
+        name: `${brand.name} 下载入口`,
+        url: downloadUrl,
+        description: downloadDescription,
+        inLanguage: "zh-CN",
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: downloadFaqs.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
+      },
+    ],
+  };
+
   return (
     <main className="inner-page">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">
           <p className="eyebrow">下载入口</p>
-          <h1>官网现在直接承接测试版与正式版入口，不再只停留在等待名单。</h1>
+          <h1>把入口分清楚，比把所有包一股脑挂出来更重要。</h1>
           <p className="lede">
-            Android beta 会跟着最新 GitHub Release 自动更新，iOS beta 会在 TestFlight 上传成功后同步到官网。
-            正式版则通过人工验证后的手动发布动作上架，避免把未经确认的安装包直接挂出去。
+            这页的任务不是堆下载按钮，而是先帮你判断：现在该去 Beta、该等正式版，还是该先申请测试资格。
+            Android Beta、iOS TestFlight 与正式版发布状态都会在这里持续同步。
           </p>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
+          <p>先做判断</p>
+          <h2>如果你只想知道下一步该点哪里，先按场景选路径，而不是先猜平台状态。</h2>
+        </div>
+        <div className="decision-grid">
+          {decisionPaths.map((item) => (
+            <article key={item.title} className="decision-card">
+              <p className="eyebrow">{item.title}</p>
+              <h3>{item.recommendation}</h3>
+              <p>{item.description}</p>
+              <ul className="decision-list">
+                {item.checkpoints.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
+          <p>版本差异</p>
+          <h2>Beta 和正式版的区别，不只是“能不能下载”，而是入口更新方式和适合人群完全不同。</h2>
+        </div>
+        <div className="compare-grid">
+          {releasePrinciples.map((item) => (
+            <article key={item.title} className="compare-card">
+              <h3>{item.title}</h3>
+              <p>{item.summary}</p>
+              <ul className="compare-list">
+                {item.bullets.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
         </div>
       </section>
 
@@ -142,9 +294,9 @@ export default async function DownloadPage() {
           <h2>如果你现在只是第一次接触这个项目，建议先这样走。</h2>
         </div>
         <ol className="roadmap-list">
-          <li>先看官网，了解当前开放的是测试版还是已经过人工验收的正式版。</li>
-          <li>如果你在国内网络环境下下载较慢，优先尝试页面里的 GitHub 镜像入口。</li>
-          <li>如果 iOS TestFlight 还没有公开加入链接，先查看 release 状态或联系支持邮箱。</li>
+          <li>先看官网判断当前开放的是测试版，还是已经过人工验收的正式版。</li>
+          <li>如果你愿意更早体验新版本，再进入 Beta；如果更在意稳定性，就等正式版入口。</li>
+          <li>如果下载较慢，优先尝试页面里的镜像链接；如果还没有公开入口，直接申请测试或联系支持。</li>
         </ol>
         <div className="inline-cta">
           <a className="primary-action" href={siteHref("/apply")}>
@@ -153,6 +305,21 @@ export default async function DownloadPage() {
           <a className="secondary-action" href={siteHref("/contact")}>
             查看联系信息
           </a>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
+          <p>常见问题</p>
+          <h2>把下载前最容易犹豫的几个问题先回答出来，用户和搜索系统都更容易做出正确判断。</h2>
+        </div>
+        <div className="faq-list full">
+          {downloadFaqs.map((item) => (
+            <details key={item.question} className="faq-item">
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
+          ))}
         </div>
       </section>
 

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -224,7 +224,9 @@ a {
 .audience-card h3,
 .architecture-grid h3,
 .download-card h2,
-.release-card h2 {
+.release-card h2,
+.decision-card h3,
+.compare-card h3 {
   margin: 0;
   font-family: "Noto Serif SC", "Source Han Serif SC", serif;
   line-height: 1.08;
@@ -267,7 +269,11 @@ a {
 .contact-card p,
 .editorial-row small,
 .release-mirror-block p,
-.preview-row span {
+.preview-row span,
+.decision-card p,
+.compare-card p,
+.decision-list,
+.compare-list {
   color: var(--muted);
   line-height: 1.75;
 }
@@ -302,7 +308,9 @@ a {
 .preview-row,
 .release-card,
 .contact-card,
-.stack-card {
+.stack-card,
+.decision-card,
+.compare-card {
   border: 1px solid var(--line);
   background: var(--surface);
   backdrop-filter: blur(16px);
@@ -319,7 +327,9 @@ a {
 .preview-row,
 .release-card,
 .contact-card,
-.stack-card {
+.stack-card,
+.decision-card,
+.compare-card {
   border-radius: 10px;
   padding: 20px;
 }
@@ -346,7 +356,9 @@ a {
 .architecture-grid,
 .download-grid,
 .application-grid,
-.contact-grid {
+.contact-grid,
+.decision-grid,
+.compare-grid {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -434,9 +446,15 @@ a {
   text-align: right;
 }
 
-.release-card {
+.release-card,
+.decision-card,
+.compare-card {
   display: grid;
   gap: 14px;
+}
+
+.decision-card .eyebrow {
+  margin-bottom: 0;
 }
 
 .release-card-header {
@@ -457,7 +475,9 @@ a {
 
 .release-update-list,
 .roadmap-list,
-.application-list {
+.application-list,
+.decision-list,
+.compare-list {
   margin: 0;
   padding-left: 20px;
   color: var(--muted);
@@ -466,7 +486,9 @@ a {
 
 .release-update-list li + li,
 .roadmap-list li + li,
-.application-list li + li {
+.application-list li + li,
+.decision-list li + li,
+.compare-list li + li {
   margin-top: 8px;
 }
 


### PR DESCRIPTION
## 这轮改了什么

- 把下载页从“入口列表页”继续收紧成“下载决策页”，先帮助用户判断该走 Beta、正式版，还是先申请测试
- 新增 Beta / 正式版差异说明、推荐路径与下载前 FAQ，让第一次进入官网的人更容易快速做出正确动作
- 为下载页补充更完整的 metadata、canonical、open graph 和 JSON-LD，增强搜索与生成式搜索对页面语义的理解
- 补充下载页新增模块所需样式，保持现有官网的深色、克制基线不被打散

## 为什么这样改

- 目前首页已经能承担基础介绍，下载页下一步最值钱的提升是“减少犹豫”和“讲清入口差异”
- 用户真正卡住的常常不是找不到按钮，而是不确定自己该下哪个版本、现在该不该等正式版
- 这类问题如果直接写成页面结构和 FAQ，不仅提升转化路径，也更适合被搜索系统和 AI 引擎准确引用

## 影响文件

- `frontend/apps/web/src/app/download/page.tsx`
- `frontend/apps/web/src/app/globals.css`

## 验证说明

- 改动已落在最新 `main` 基础上的新分支中，相对主线仅修改下载页和相关样式
- 当前环境仍无法本地拉仓库运行 Next.js 构建，因此本轮只做了结构与差异校对，最终以仓库 CI 为准
- head `221419e743bc849a88ca040559a5aaeb98c0d69d` 已成功触发 `CI #455`

## 后续仍值得继续推进

- 首页和下载页之间继续增加更明确的跨页导流与状态同步提示
- FAQ 与内容专栏继续扩展问题式专题，覆盖“适合谁”“怎么下载”“何时上正式版”等搜索意图
- 在不破坏当前克制风格的前提下，继续提升移动端导航与下载路径的扫描效率

## 为什么这条 draft 要关闭重开

- 当前 connector 的 `draft -> ready for review` 接口仍报 schema 错误，不能直接转正
- 这条 draft 的 head 已经有真实成功的 `CI #455`
- 为了把同一 head branch 推进到可合并路径，这里按仓库 runbook 关闭 draft，并基于同一 head branch 立即重开 ready PR