### PR TITLE
[codex] 继续补强 Fabushi 官网信任信息与隐私入口

### DIFF
--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -4,13 +4,81 @@ import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
+const applyUrl = siteUrl("/apply");
+const applyTitle = `申请测试 | ${brand.name}`;
+const applyDescription = "查看 Fabushi 当前可申请的测试与合作入口，并按不同场景选择对应通道。";
+
+const applicationJourneys = [
+  {
+    title: "想先体验完整主应用流程",
+    description: "更适合先看 iOS TestFlight 入口，尤其是你想重点体验完整内容浏览、个人中心和重交互流程时。",
+    href: "mailto:support@fabushi.com?subject=Fabushi%20iOS%20Beta%20Application",
+    ctaLabel: "申请 iOS 内测",
+  },
+  {
+    title: "想尽快跟上最新交付进度",
+    description: "更适合先看 Android Beta，尤其是你愿意更早体验新版本并持续反馈问题时。",
+    href: "mailto:support@fabushi.com?subject=Fabushi%20Android%20Beta%20Application",
+    ctaLabel: "申请 Android 内测",
+  },
+  {
+    title: "想讨论传播合作或渠道联动",
+    description: "如果你更在意内容共建、活动承接或渠道资源，直接走合作入口会更准确。",
+    href: "mailto:support@fabushi.com?subject=Fabushi%20Partnership%20Inquiry",
+    ctaLabel: "发起合作沟通",
+  },
+] as const;
+
+const prepChecklist = [
+  {
+    title: "先说你的目标",
+    description: "说明你更关心传播、修行记录、榜单社交、设备测试，还是渠道合作。",
+  },
+  {
+    title: "把必要信息一次带全",
+    description: "包括常用邮箱、平台、机型、系统版本，或者合作方向与可回联方式。",
+  },
+  {
+    title: "最好提前说明反馈意愿",
+    description: "如果你愿意持续反馈体验问题，后续资格发放和沟通节奏通常会更顺。",
+  },
+] as const;
+
+const applicationSignals = [
+  {
+    title: "入口先分清楚",
+    description: "把 iOS、Android 和合作沟通拆成三条路径，本身就是在减少后续筛选成本。",
+  },
+  {
+    title: "申请页先服务真实决策",
+    description: "这页不是为了堆表单，而是帮你更快判断自己该走哪条通道。",
+  },
+  {
+    title: "下载与申请会互相配合",
+    description: "如果下载页暂时还没有适合你的公开入口，申请页就应该成为自然的下一步。",
+  },
+] as const;
+
 export const metadata: Metadata = {
-  title: `申请测试 | ${brand.name}`,
-  description: "查看 Fabushi 当前可申请的测试与合作入口，并按不同场景选择对应通道。",
+  title: applyTitle,
+  description: applyDescription,
   alternates: {
-    canonical: siteUrl("/apply"),
+    canonical: applyUrl,
   },
   keywords: ["法布施内测", "Fabushi 申请测试", "法布施 Android Beta", "法布施 TestFlight", "法布施合作"],
+  openGraph: {
+    title: applyTitle,
+    description: applyDescription,
+    url: applyUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: applyTitle,
+    description: applyDescription,
+  },
 };
 
 export default function ApplyPage() {
@@ -18,7 +86,7 @@ export default function ApplyPage() {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     name: `${brand.name} 申请测试`,
-    url: siteUrl("/apply"),
+    url: applyUrl,
     inLanguage: "zh-CN",
     description: "Fabushi 当前开放的 iOS、Android 与合作沟通申请通道。",
     mainEntity: {
@@ -49,15 +117,23 @@ export default function ApplyPage() {
         "@type": "ListItem",
         position: 2,
         name: "申请测试",
-        item: siteUrl("/apply"),
+        item: applyUrl,
       },
     ],
   };
 
   return (
     <main className="inner-page">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applyPageJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(applyPageJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
 
       <section className="inner-hero">
         <SiteHeader />
@@ -71,7 +147,40 @@ export default function ApplyPage() {
         </div>
       </section>
 
+      <section className="band alt">
+        <div className="section-heading">
+          <p>先判断你该走哪条路</p>
+          <h2>这一步先做对，后面的资格发放、设备确认和反馈沟通会简单很多。</h2>
+        </div>
+        <div className="path-grid">
+          {applicationJourneys.map((item) => (
+            <article key={item.title} className="path-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="band">
+        <div className="section-heading">
+          <p>申请前最好先准备</p>
+          <h2>把这些信息一次带上，往返确认和资格筛选通常会更高效。</h2>
+        </div>
+        <div className="definition-grid">
+          {prepChecklist.map((item) => (
+            <article key={item.title} className="definition-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
         <div className="section-heading">
           <p>申请通道</p>
           <h2>按你的目标选择入口，会比一股脑挤到同一个邮箱主题里更高效。</h2>
@@ -97,27 +206,22 @@ export default function ApplyPage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band">
         <div className="section-heading">
-          <p>收到申请后</p>
-          <h2>官网先把处理顺序讲清楚，能减少对方发出邮件后的不确定感。</h2>
+          <p>为什么这一页值得先看</p>
+          <h2>申请页不仅是一个入口集合，更是把下载、反馈和合作分流清楚的关键环节。</h2>
         </div>
-        <ol className="roadmap-list">
-          <li>团队会先按 iOS、Android 和合作沟通分流，不同入口不会混在同一条处理队列里。</li>
-          <li>信息完整的申请更容易直接进入后续资格确认、设备核对或合作往来，而不是先来回补上下文。</li>
-          <li>如果当前轮次暂未开放，官网会优先通过下载页、FAQ 和后续邮件说明下一步状态，而不是让申请停在黑箱里。</li>
-        </ol>
-        <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/download")}>
-            先看下载状态
-          </a>
-          <a className="secondary-action" href={siteHref("/privacy")}>
-            查看隐私说明
-          </a>
+        <div className="evidence-grid">
+          {applicationSignals.map((item) => (
+            <article key={item.title} className="evidence-card">
+              <strong>{item.title}</strong>
+              <p>{item.description}</p>
+            </article>
+          ))}
         </div>
       </section>
 
-      <section className="band">
+      <section className="band alt">
         <div className="section-heading">
           <p>申请建议</p>
           <h2>把基本信息一次带全，往返确认会少很多。</h2>
@@ -130,6 +234,9 @@ export default function ApplyPage() {
         <div className="inline-cta">
           <a className="secondary-action" href={siteHref("/download")}>
             回到下载入口
+          </a>
+          <a className="secondary-action" href={siteHref("/privacy")}>
+            查看隐私说明
           </a>
           <a className="secondary-action" href={siteHref("/contact")}>
             查看联系信息

--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -2,16 +2,44 @@ import type { Metadata } from "next";
 import { betaApplicationTracks, brand } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `申请测试 | ${brand.name}`,
   description: "查看 Fabushi 当前可申请的测试与合作入口，并按不同场景选择对应通道。",
+  alternates: {
+    canonical: siteUrl("/apply"),
+  },
+  keywords: ["法布施内测", "Fabushi 申请测试", "法布施 Android Beta", "法布施 TestFlight", "法布施合作"],
 };
 
 export default function ApplyPage() {
+  const applyPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `${brand.name} 申请测试`,
+    url: siteUrl("/apply"),
+    inLanguage: "zh-CN",
+    description: "Fabushi 当前开放的 iOS、Android 与合作沟通申请通道。",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: betaApplicationTracks.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "EntryPoint",
+          name: item.name,
+          description: item.summary,
+          urlTemplate: siteHref(item.ctaHref),
+        },
+      })),
+    },
+  };
+
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applyPageJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">

--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -99,6 +99,26 @@ export default function ApplyPage() {
 
       <section className="band alt">
         <div className="section-heading">
+          <p>收到申请后</p>
+          <h2>官网先把处理顺序讲清楚，能减少对方发出邮件后的不确定感。</h2>
+        </div>
+        <ol className="roadmap-list">
+          <li>团队会先按 iOS、Android 和合作沟通分流，不同入口不会混在同一条处理队列里。</li>
+          <li>信息完整的申请更容易直接进入后续资格确认、设备核对或合作往来，而不是先来回补上下文。</li>
+          <li>如果当前轮次暂未开放，官网会优先通过下载页、FAQ 和后续邮件说明下一步状态，而不是让申请停在黑箱里。</li>
+        </ol>
+        <div className="inline-cta">
+          <a className="secondary-action" href={siteHref("/download")}>
+            先看下载状态
+          </a>
+          <a className="secondary-action" href={siteHref("/privacy")}>
+            查看隐私说明
+          </a>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
           <p>申请建议</p>
           <h2>把基本信息一次带全，往返确认会少很多。</h2>
         </div>

--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -35,10 +35,29 @@ export default function ApplyPage() {
       })),
     },
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "申请测试",
+        item: siteUrl("/apply"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applyPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -44,6 +44,58 @@ const prepChecklist = [
   },
 ] as const;
 
+const applicationProcessSteps = [
+  {
+    title: "先确认你属于哪条入口",
+    description: "官网会先按 iOS、Android 和合作沟通三种目标来判断，不同目的不会混在同一个处理队列里。",
+  },
+  {
+    title: "再看当前开放阶段是否匹配",
+    description: "如果对应入口仍在准备、名额有限或发布状态还没公开，会先回复当前阶段和更合适的下一步，而不是假装已经开放。",
+  },
+  {
+    title: "通过邮件继续确认关键信息",
+    description: "设备、系统版本、关注模块和反馈意愿，通常都会决定后续该发哪个入口、什么时候发。",
+  },
+  {
+    title: "资格发放后继续进入反馈闭环",
+    description: "申请页不是终点，下载、体验、反馈和后续版本说明会继续回到官网、邮件或公开协作通道里。",
+  },
+] as const;
+
+const applicationReviewPrinciples = [
+  {
+    title: "会明确当前状态",
+    description: "如果入口还没准备好，官网和邮件都应该先告诉你目前处于什么阶段，而不是只让你等待。",
+  },
+  {
+    title: "会按场景分流处理",
+    description: "下载体验、资格申请、合作沟通和公开建议，本来就不该挤进同一套回复逻辑里。",
+  },
+  {
+    title: "不会承诺并不存在的自动化流程",
+    description: "当前申请与筛选仍以人工处理为主，因此更重要的是把路径、条件和下一步说清楚。",
+  },
+] as const;
+
+const applyFaqs = [
+  {
+    question: "提交申请后通常会发生什么？",
+    answer:
+      "通常会先确认你申请的是 iOS、Android 还是合作沟通，再结合当前开放阶段决定是直接继续、补充信息，还是先说明暂未开放的状态。",
+  },
+  {
+    question: "现在会承诺多快回复吗？",
+    answer:
+      "当前更适合承诺的是“会先说明当前阶段与下一步”，而不是给出一个并不稳定的自动回复时限。官网会优先把路径和所需信息写清楚，减少无效往返。",
+  },
+  {
+    question: "如果现在还没有公开入口，我还有必要申请吗？",
+    answer:
+      "有必要。如果你已经明确想参与测试或合作，申请页的价值就在于让你进入正确队列，并获得当前阶段与后续动作说明，而不是继续在下载页反复猜测。",
+  },
+] as const;
+
 const applicationSignals = [
   {
     title: "入口先分清楚",
@@ -82,42 +134,56 @@ export const metadata: Metadata = {
 };
 
 export default function ApplyPage() {
-  const applyPageJsonLd = {
+  const structuredData = {
     "@context": "https://schema.org",
-    "@type": "CollectionPage",
-    name: `${brand.name} 申请测试`,
-    url: applyUrl,
-    inLanguage: "zh-CN",
-    description: "Fabushi 当前开放的 iOS、Android 与合作沟通申请通道。",
-    mainEntity: {
-      "@type": "ItemList",
-      itemListElement: betaApplicationTracks.map((item, index) => ({
-        "@type": "ListItem",
-        position: index + 1,
-        item: {
-          "@type": "EntryPoint",
-          name: item.name,
-          description: item.summary,
-          urlTemplate: siteHref(item.ctaHref),
-        },
-      })),
-    },
-  };
-  const breadcrumbJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
+    "@graph": [
       {
-        "@type": "ListItem",
-        position: 1,
-        name: "首页",
-        item: siteUrl("/"),
+        "@type": "CollectionPage",
+        name: `${brand.name} 申请测试`,
+        url: applyUrl,
+        inLanguage: "zh-CN",
+        description: "Fabushi 当前开放的 iOS、Android 与合作沟通申请通道。",
+        mainEntity: {
+          "@type": "ItemList",
+          itemListElement: betaApplicationTracks.map((item, index) => ({
+            "@type": "ListItem",
+            position: index + 1,
+            item: {
+              "@type": "EntryPoint",
+              name: item.name,
+              description: item.summary,
+              urlTemplate: siteHref(item.ctaHref),
+            },
+          })),
+        },
       },
       {
-        "@type": "ListItem",
-        position: 2,
-        name: "申请测试",
-        item: applyUrl,
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "首页",
+            item: siteUrl("/"),
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "申请测试",
+            item: applyUrl,
+          },
+        ],
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: applyFaqs.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
       },
     ],
   };
@@ -127,12 +193,7 @@ export default function ApplyPage() {
       <script
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(applyPageJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
       <section className="inner-hero">
@@ -208,6 +269,36 @@ export default function ApplyPage() {
 
       <section className="band">
         <div className="section-heading">
+          <p>申请后通常会发生什么</p>
+          <h2>把处理节奏说清楚，比空泛承诺“很快回复”更能建立信任。</h2>
+        </div>
+        <div className="definition-grid">
+          {applicationProcessSteps.map((item) => (
+            <article key={item.title} className="definition-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
+          <p>处理原则</p>
+          <h2>官网应该先把会发生什么、不会假装什么写出来，让申请预期更加稳定。</h2>
+        </div>
+        <div className="compare-grid">
+          {applicationReviewPrinciples.map((item) => (
+            <article key={item.title} className="compare-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
           <p>为什么这一页值得先看</p>
           <h2>申请页不仅是一个入口集合，更是把下载、反馈和合作分流清楚的关键环节。</h2>
         </div>
@@ -223,14 +314,17 @@ export default function ApplyPage() {
 
       <section className="band alt">
         <div className="section-heading">
-          <p>申请建议</p>
-          <h2>把基本信息一次带全，往返确认会少很多。</h2>
+          <p>常见问题</p>
+          <h2>把申请后的预期、节奏和边界先回答出来，用户和生成式搜索都更容易理解这页的价值。</h2>
         </div>
-        <ol className="roadmap-list">
-          <li>说明你最关心的是传播、修行记录、榜单社交，还是渠道合作。</li>
-          <li>如果是设备测试，请把平台、机型或系统版本一并写清楚。</li>
-          <li>如果你愿意持续反馈问题，也建议在申请邮件里直接写明。</li>
-        </ol>
+        <div className="faq-list full">
+          {applyFaqs.map((item) => (
+            <details key={item.question} className="faq-item">
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
+          ))}
+        </div>
         <div className="inline-cta">
           <a className="secondary-action" href={siteHref("/download")}>
             回到下载入口

--- a/frontend/apps/web/src/app/contact/page.tsx
+++ b/frontend/apps/web/src/app/contact/page.tsx
@@ -87,6 +87,26 @@ export default function ContactPage() {
 
       <section className="band alt">
         <div className="section-heading">
+          <p>使用边界</p>
+          <h2>不同入口负责不同类型的沟通，提前说清楚会比事后转发更省力。</h2>
+        </div>
+        <ol className="roadmap-list">
+          <li>下载申请、测试资格、隐私边界和需要私下补充的信息，优先走支持邮箱。</li>
+          <li>公开开发进度、可复查的问题轨迹和发布资产，优先走 GitHub 仓库，不把私密申请混进公开线程。</li>
+          <li>官网域名继续负责统一承接品牌说明、FAQ、下载状态和对外内容入口，减少信息四散在不同平台里。</li>
+        </ol>
+        <div className="inline-cta">
+          <a className="secondary-action" href={siteHref("/privacy")}>
+            查看隐私说明
+          </a>
+          <a className="secondary-action" href={siteHref("/apply")}>
+            去申请测试
+          </a>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
           <p>建议用途</p>
           <h2>把沟通入口的职责区分清楚，能减少很多来回确认。</h2>
         </div>

--- a/frontend/apps/web/src/app/contact/page.tsx
+++ b/frontend/apps/web/src/app/contact/page.tsx
@@ -4,13 +4,66 @@ import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
+const contactUrl = siteUrl("/contact");
+const contactTitle = `联系 | ${brand.name}`;
+const contactDescription = "查看 Fabushi 的支持邮箱、官网域名和公开仓库入口。";
+
+const contactJourneys = [
+  {
+    title: "下载申请、测试资格、问题反馈",
+    description: "优先走支持邮箱，并在邮件里直接带上平台、机型、场景和你最想解决的问题。",
+    href: "mailto:support@fabushi.com",
+    ctaLabel: "发送支持邮件",
+  },
+  {
+    title: "想看公开进度、Issue 和协作记录",
+    description: "优先去 GitHub 仓库，这条路径更适合公开问题跟踪、版本记录和技术协作。",
+    href: "https://github.com/bhrumom/fabushi",
+    ctaLabel: "打开 GitHub 仓库",
+  },
+  {
+    title: "想转发官网或确认正式入口",
+    description: "优先使用官网域名，把首页、下载页、FAQ 和隐私说明作为统一对外入口来转发。",
+    href: "https://fabushi.ombhrum.com",
+    ctaLabel: "打开官网域名",
+  },
+] as const;
+
+const responseSignals = [
+  {
+    title: "先给出清楚的来意",
+    description: "说明你是想下载、申请测试、反馈问题，还是讨论合作，后续转接会更快。",
+  },
+  {
+    title: "设备与平台信息尽量一次带全",
+    description: "尤其是 Android 机型、iOS 邮箱、系统版本和触发问题的场景，能明显减少来回确认。",
+  },
+  {
+    title: "公开问题尽量沉淀到 GitHub",
+    description: "这样更适合后续复查、团队协作和外部理解，也能提升站点的公开可信度。",
+  },
+] as const;
+
 export const metadata: Metadata = {
-  title: `联系 | ${brand.name}`,
-  description: "查看 Fabushi 的支持邮箱、官网域名和公开仓库入口。",
+  title: contactTitle,
+  description: contactDescription,
   alternates: {
-    canonical: siteUrl("/contact"),
+    canonical: contactUrl,
   },
   keywords: ["联系 Fabushi", "法布施支持邮箱", "法布施官网", "Fabushi GitHub", "法布施合作"],
+  openGraph: {
+    title: contactTitle,
+    description: contactDescription,
+    url: contactUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: contactTitle,
+    description: contactDescription,
+  },
 };
 
 export default function ContactPage() {
@@ -19,7 +72,7 @@ export default function ContactPage() {
     "@context": "https://schema.org",
     "@type": "ContactPage",
     name: `${brand.name} 联系方式`,
-    url: siteUrl("/contact"),
+    url: contactUrl,
     inLanguage: "zh-CN",
     description: "Fabushi 的支持邮箱、官网域名与公开仓库入口。",
     mainEntity: {
@@ -52,15 +105,23 @@ export default function ContactPage() {
         "@type": "ListItem",
         position: 2,
         name: "联系",
-        item: siteUrl("/contact"),
+        item: contactUrl,
       },
     ],
   };
 
   return (
     <main className="inner-page">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
 
       <section className="inner-hero">
         <SiteHeader />
@@ -73,7 +134,29 @@ export default function ContactPage() {
         </div>
       </section>
 
+      <section className="band alt">
+        <div className="section-heading">
+          <p>先选路径</p>
+          <h2>不同问题去不同入口，沟通会比“先发一封没有上下文的邮件”顺畅得多。</h2>
+        </div>
+        <div className="path-grid">
+          {contactJourneys.map((item) => (
+            <article key={item.title} className="path-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="band">
+        <div className="section-heading">
+          <p>固定入口</p>
+          <h2>让下载、申请、合作和公开协作都有稳定入口，用户才会更愿意继续往下走。</h2>
+        </div>
         <div className="contact-grid">
           {contactChannels.map((item) => (
             <a key={item.label} className="contact-card" href={siteHref(item.href)}>
@@ -87,37 +170,23 @@ export default function ContactPage() {
 
       <section className="band alt">
         <div className="section-heading">
-          <p>使用边界</p>
-          <h2>不同入口负责不同类型的沟通，提前说清楚会比事后转发更省力。</h2>
+          <p>联系前最好准备什么</p>
+          <h2>把这些信息一次带全，往返确认通常会少很多。</h2>
         </div>
-        <ol className="roadmap-list">
-          <li>下载申请、测试资格、隐私边界和需要私下补充的信息，优先走支持邮箱。</li>
-          <li>公开开发进度、可复查的问题轨迹和发布资产，优先走 GitHub 仓库，不把私密申请混进公开线程。</li>
-          <li>官网域名继续负责统一承接品牌说明、FAQ、下载状态和对外内容入口，减少信息四散在不同平台里。</li>
-        </ol>
-        <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/privacy")}>
-            查看隐私说明
-          </a>
-          <a className="secondary-action" href={siteHref("/apply")}>
-            去申请测试
-          </a>
+        <div className="evidence-grid">
+          {responseSignals.map((item) => (
+            <article key={item.title} className="evidence-card">
+              <strong>{item.title}</strong>
+              <p>{item.description}</p>
+            </article>
+          ))}
         </div>
-      </section>
-
-      <section className="band">
-        <div className="section-heading">
-          <p>建议用途</p>
-          <h2>把沟通入口的职责区分清楚，能减少很多来回确认。</h2>
-        </div>
-        <ol className="roadmap-list">
-          <li>下载申请、测试资格和正式链接通知，优先走支持邮箱。</li>
-          <li>公开开发进度、问题跟踪和可复查记录，优先走 GitHub 仓库。</li>
-          <li>品牌介绍、专题内容和长期对外入口，统一落到官网域名。</li>
-        </ol>
         <div className="inline-cta">
           <a className="primary-action" href={siteHref("/apply")}>
             去申请测试
+          </a>
+          <a className="secondary-action" href={siteHref("/privacy")}>
+            查看隐私说明
           </a>
           <a className="secondary-action" href={siteHref("/download")}>
             回到下载页

--- a/frontend/apps/web/src/app/contact/page.tsx
+++ b/frontend/apps/web/src/app/contact/page.tsx
@@ -29,6 +29,21 @@ const contactJourneys = [
   },
 ] as const;
 
+const contactBoundaries = [
+  {
+    title: "涉及个人信息或资格判断",
+    description: "像邮箱、设备信息、测试资格、下载失败截图这类内容，更适合走支持邮箱，不适合直接公开到 issue 里。",
+  },
+  {
+    title: "涉及公开问题、版本记录或站点建议",
+    description: "只要内容适合公开复查、也对后续协作有帮助，优先沉淀到 GitHub 会更清楚。",
+  },
+  {
+    title: "只是想确认正式入口和项目定位",
+    description: "先用官网页做转发和说明，通常比把同样的问题反复发给支持邮箱更高效。",
+  },
+] as const;
+
 const responseSignals = [
   {
     title: "先给出清楚的来意",
@@ -41,6 +56,24 @@ const responseSignals = [
   {
     title: "公开问题尽量沉淀到 GitHub",
     description: "这样更适合后续复查、团队协作和外部理解，也能提升站点的公开可信度。",
+  },
+] as const;
+
+const contactFaqs = [
+  {
+    question: "什么情况应该优先发支持邮箱？",
+    answer:
+      "凡是涉及测试资格、下载问题、设备环境、个人邮箱、账号信息或不适合公开暴露的内容，都更适合先发支持邮箱。",
+  },
+  {
+    question: "什么情况更适合提 GitHub issue？",
+    answer:
+      "如果问题可以公开复现、对后续版本记录有帮助，或者属于官网结构、文案和公开体验建议，优先沉淀到 GitHub 会更清楚。",
+  },
+  {
+    question: "联系时最好一次带上哪些信息？",
+    answer:
+      "至少带上你的目标、所用平台、机型或系统版本、触发场景，以及你最希望解决的问题。这样通常能减少很多来回确认。",
   },
 ] as const;
 
@@ -68,44 +101,58 @@ export const metadata: Metadata = {
 
 export default function ContactPage() {
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
-  const contactPageJsonLd = {
+  const structuredData = {
     "@context": "https://schema.org",
-    "@type": "ContactPage",
-    name: `${brand.name} 联系方式`,
-    url: contactUrl,
-    inLanguage: "zh-CN",
-    description: "Fabushi 的支持邮箱、官网域名与公开仓库入口。",
-    mainEntity: {
-      "@type": "Organization",
-      name: `${brand.name} Fabushi`,
-      url: siteUrl("/"),
-      email: supportEmail,
-      sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
-      contactPoint: [
-        {
-          "@type": "ContactPoint",
-          contactType: "customer support",
-          email: supportEmail,
-          availableLanguage: ["zh-CN"],
-        },
-      ],
-    },
-  };
-  const breadcrumbJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
+    "@graph": [
       {
-        "@type": "ListItem",
-        position: 1,
-        name: "首页",
-        item: siteUrl("/"),
+        "@type": "ContactPage",
+        name: `${brand.name} 联系方式`,
+        url: contactUrl,
+        inLanguage: "zh-CN",
+        description: "Fabushi 的支持邮箱、官网域名与公开仓库入口。",
+        mainEntity: {
+          "@type": "Organization",
+          name: `${brand.name} Fabushi`,
+          url: siteUrl("/"),
+          email: supportEmail,
+          sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
+          contactPoint: [
+            {
+              "@type": "ContactPoint",
+              contactType: "customer support",
+              email: supportEmail,
+              availableLanguage: ["zh-CN"],
+            },
+          ],
+        },
       },
       {
-        "@type": "ListItem",
-        position: 2,
-        name: "联系",
-        item: contactUrl,
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "首页",
+            item: siteUrl("/"),
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "联系",
+            item: contactUrl,
+          },
+        ],
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: contactFaqs.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
       },
     ],
   };
@@ -115,12 +162,7 @@ export default function ContactPage() {
       <script
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
       <section className="inner-hero">
@@ -170,6 +212,21 @@ export default function ContactPage() {
 
       <section className="band alt">
         <div className="section-heading">
+          <p>公开与私密边界</p>
+          <h2>把什么适合公开、什么适合私下联系写清楚，本身就是信任信息的一部分。</h2>
+        </div>
+        <div className="definition-grid">
+          {contactBoundaries.map((item) => (
+            <article key={item.title} className="definition-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
           <p>联系前最好准备什么</p>
           <h2>把这些信息一次带全，往返确认通常会少很多。</h2>
         </div>
@@ -179,6 +236,21 @@ export default function ContactPage() {
               <strong>{item.title}</strong>
               <p>{item.description}</p>
             </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
+          <p>常见问题</p>
+          <h2>把联系边界和入口职责先写清楚，用户与搜索系统都更容易找到正确路径。</h2>
+        </div>
+        <div className="faq-list full">
+          {contactFaqs.map((item) => (
+            <details key={item.question} className="faq-item">
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
           ))}
         </div>
         <div className="inline-cta">

--- a/frontend/apps/web/src/app/contact/page.tsx
+++ b/frontend/apps/web/src/app/contact/page.tsx
@@ -38,10 +38,29 @@ export default function ContactPage() {
       ],
     },
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "联系",
+        item: siteUrl("/contact"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/contact/page.tsx
+++ b/frontend/apps/web/src/app/contact/page.tsx
@@ -2,16 +2,47 @@ import type { Metadata } from "next";
 import { brand, contactChannels } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `联系 | ${brand.name}`,
   description: "查看 Fabushi 的支持邮箱、官网域名和公开仓库入口。",
+  alternates: {
+    canonical: siteUrl("/contact"),
+  },
+  keywords: ["联系 Fabushi", "法布施支持邮箱", "法布施官网", "Fabushi GitHub", "法布施合作"],
 };
 
 export default function ContactPage() {
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+  const contactPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ContactPage",
+    name: `${brand.name} 联系方式`,
+    url: siteUrl("/contact"),
+    inLanguage: "zh-CN",
+    description: "Fabushi 的支持邮箱、官网域名与公开仓库入口。",
+    mainEntity: {
+      "@type": "Organization",
+      name: `${brand.name} Fabushi`,
+      url: siteUrl("/"),
+      email: supportEmail,
+      sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
+      contactPoint: [
+        {
+          "@type": "ContactPoint",
+          contactType: "customer support",
+          email: supportEmail,
+          availableLanguage: ["zh-CN"],
+        },
+      ],
+    },
+  };
+
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(contactPageJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -146,10 +146,29 @@ export default async function DownloadPage() {
       url: siteUrl("/"),
     },
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "下载入口",
+        item: siteUrl("/download"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(downloadPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -115,6 +115,11 @@ export default async function DownloadPage() {
       description: "正式版只在人工验收完成后才会上架到官网，更适合不希望承担测试波动、需要更稳妥安装入口的人。",
     },
   ] as const;
+  const preInstallChecklist = [
+    "你现在更想优先体验最新改动，还是更想降低安装后的波动与反复更新。",
+    "你是否已经看过对应入口旁边的版本、更新时间和更新摘要，而不是只看按钮名称。",
+    "如果你准备反馈问题或申请资格，是否已经知道该走下载、申请测试还是联系支持这三条不同路径。",
+  ] as const;
 
   const downloadPageJsonLd = {
     "@context": "https://schema.org",
@@ -224,6 +229,18 @@ export default async function DownloadPage() {
 
       <section className="band alt">
         <div className="section-heading">
+          <p>安装前确认</p>
+          <h2>真正点下载前，先确认这三件事，能少走很多回头路。</h2>
+        </div>
+        <ol className="roadmap-list">
+          {preInstallChecklist.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
           <p>同步说明</p>
           <h2>官网上的下载说明现在会跟着发布资产一起更新，而不是靠手工改文案。</h2>
         </div>
@@ -234,7 +251,7 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band">
+      <section className="band alt">
         <div className="section-heading">
           <p>推荐路径</p>
           <h2>如果你现在只是第一次接触这个项目，建议先这样走。</h2>

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -98,6 +98,23 @@ export default async function DownloadPage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const allChannels = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels];
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+  const recommendationPaths = [
+    {
+      label: "想最快看到最新改动",
+      title: "优先看 Android beta 或 iOS TestFlight。",
+      description: "这两条通道会最先承接最新一轮可公开测试的安装包和状态更新，适合愿意跟着版本节奏一起体验的人。",
+    },
+    {
+      label: "想先判断自己适不适合加入测试",
+      title: "先看版本说明、更新时间和适用提示，再决定要不要安装。",
+      description: "下载页现在会把版本、发布时间、更新摘要和补充说明直接写在入口旁边，避免你先下载再回头找上下文。",
+    },
+    {
+      label: "更看重稳定与人工验收",
+      title: "优先等正式版入口，而不是直接进入 beta。",
+      description: "正式版只在人工验收完成后才会上架到官网，更适合不希望承担测试波动、需要更稳妥安装入口的人。",
+    },
+  ] as const;
 
   const downloadPageJsonLd = {
     "@context": "https://schema.org",
@@ -172,6 +189,22 @@ export default async function DownloadPage() {
 
       <section className="band">
         <div className="section-heading">
+          <p>选择建议</p>
+          <h2>如果你不确定现在该点哪一个入口，先按你的风险偏好和目的来选。</h2>
+        </div>
+        <div className="path-grid">
+          {recommendationPaths.map((item) => (
+            <article key={item.title} className="path-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
           <p>同步说明</p>
           <h2>官网上的下载说明现在会跟着发布资产一起更新，而不是靠手工改文案。</h2>
         </div>
@@ -182,7 +215,7 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band">
         <div className="section-heading">
           <p>推荐路径</p>
           <h2>如果你现在只是第一次接触这个项目，建议先这样走。</h2>

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -115,6 +115,23 @@ export default async function DownloadPage() {
       description: "正式版只在人工验收完成后才会上架到官网，更适合不希望承担测试波动、需要更稳妥安装入口的人。",
     },
   ] as const;
+  const platformFitGuidance = [
+    {
+      title: "Android Beta",
+      bestFor: "想最快跟上最新版本、愿意更早反馈问题的人。",
+      description: "如果你更在意尽快体验最新公开交付，而不是等到人工验收全部完成，Android beta 通常会是最先更新的入口。",
+    },
+    {
+      title: "iOS TestFlight",
+      bestFor: "已经明确想参与 iOS 内测，并愿意接受名额、审核和链接状态波动的人。",
+      description: "它更适合已经确认要深入体验完整主应用流程的用户，而不是只想随手点开看看的首次访问者。",
+    },
+    {
+      title: "正式版入口",
+      bestFor: "更希望先看人工验收结果、尽量减少安装后波动的人。",
+      description: "如果你主要想确认现在有没有相对稳定、可转发、可复用的下载入口，先等正式版通常比直接进入 beta 更合适。",
+    },
+  ] as const;
   const preInstallChecklist = [
     "你现在更想优先体验最新改动，还是更想降低安装后的波动与反复更新。",
     "你是否已经看过对应入口旁边的版本、更新时间和更新摘要，而不是只看按钮名称。",
@@ -213,6 +230,22 @@ export default async function DownloadPage() {
 
       <section className="band">
         <div className="section-heading">
+          <p>平台适配</p>
+          <h2>如果你是在比较 Android beta、iOS TestFlight 和正式版，先按你的使用阶段来选。</h2>
+        </div>
+        <div className="definition-grid">
+          {platformFitGuidance.map((item) => (
+            <article key={item.title} className="definition-card">
+              <h3>{item.title}</h3>
+              <p><strong>更适合谁：</strong>{item.bestFor}</p>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
           <p>选择建议</p>
           <h2>如果你不确定现在该点哪一个入口，先按你的风险偏好和目的来选。</h2>
         </div>
@@ -227,7 +260,7 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band">
         <div className="section-heading">
           <p>安装前确认</p>
           <h2>真正点下载前，先确认这三件事，能少走很多回头路。</h2>
@@ -239,7 +272,7 @@ export default async function DownloadPage() {
         </ol>
       </section>
 
-      <section className="band">
+      <section className="band alt">
         <div className="section-heading">
           <p>同步说明</p>
           <h2>官网上的下载说明现在会跟着发布资产一起更新，而不是靠手工改文案。</h2>
@@ -251,7 +284,7 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band">
         <div className="section-heading">
           <p>推荐路径</p>
           <h2>如果你现在只是第一次接触这个项目，建议先这样走。</h2>

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -1,16 +1,27 @@
 import type { Metadata } from "next";
-import { brand } from "@fabushi/shared";
+import { brand, contactChannels } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import {
   getOfficialSiteReleaseCollection,
   type OfficialSiteChannel,
 } from "../../lib/official-site-releases";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `下载入口 | ${brand.name}`,
   description: "查看 Fabushi 官网上的 Android Beta、iOS TestFlight 与正式版发布状态。",
+  alternates: {
+    canonical: siteUrl("/download"),
+  },
+  keywords: [
+    "法布施下载",
+    "Fabushi 下载",
+    "Android Beta",
+    "iOS TestFlight",
+    "法布施官网",
+    "法布施正式版",
+  ],
 };
 
 function formatPublishedAt(value?: string) {
@@ -85,9 +96,44 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
 
 export default async function DownloadPage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
+  const allChannels = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels];
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+
+  const downloadPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `${brand.name} 下载入口`,
+    url: siteUrl("/download"),
+    inLanguage: "zh-CN",
+    description: "查看 Fabushi Android beta、iOS TestFlight 与正式版的当前可见下载状态。",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: allChannels.map((channel, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "SoftwareApplication",
+          name: channel.title,
+          operatingSystem: channel.platform,
+          description: channel.description,
+          url: siteUrl("/download"),
+          downloadUrl: siteHref(channel.primaryHref),
+          applicationCategory: channel.audience === "stable" ? "ProductivityApplication" : "BetaSoftwareApplication",
+        },
+      })),
+    },
+    provider: {
+      "@type": "Organization",
+      name: `${brand.name} Fabushi`,
+      email: supportEmail,
+      url: siteUrl("/"),
+    },
+  };
 
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(downloadPageJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -8,20 +8,107 @@ import {
 } from "../../lib/official-site-releases";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
-export const metadata: Metadata = {
-  title: `下载入口 | ${brand.name}`,
-  description: "查看 Fabushi 官网上的 Android Beta、iOS TestFlight 与正式版发布状态。",
-  alternates: {
-    canonical: siteUrl("/download"),
+const downloadUrl = siteUrl("/download");
+const downloadTitle = `下载入口 | ${brand.name}`;
+const downloadDescription =
+  "查看 Fabushi 官网上的 Android Beta、iOS TestFlight 与正式版发布状态，并根据你的场景选择合适入口。";
+
+const decisionPaths = [
+  {
+    title: "想先体验最新进度",
+    recommendation: "优先看 Beta 渠道",
+    description: "适合愿意更早体验新版本、也能接受内测节奏和偶发问题的人。",
+    checkpoints: ["Android Beta 会跟随最新 GitHub Release 自动同步", "iOS Beta 会在 TestFlight 上传成功后补到官网", "如果你准备反馈问题，这条路径最合适"],
   },
-  keywords: [
-    "法布施下载",
-    "Fabushi 下载",
-    "Android Beta",
-    "iOS TestFlight",
-    "法布施官网",
-    "法布施正式版",
-  ],
+  {
+    title: "想要更稳的安装体验",
+    recommendation: "等待正式版入口",
+    description: "适合第一次接触项目、暂时不想承担测试波动，或者准备推荐给更多人的用户。",
+    checkpoints: ["正式版只在人工验收通过后才会上线", "官网不会提前挂出未经确认的正式安装包", "入口一旦公开，会直接替换为正式版下载路径"],
+  },
+  {
+    title: "先判断自己该走哪条路",
+    recommendation: "先看推荐路径和 FAQ",
+    description: "适合还不确定自己是来下载、申请资格，还是先了解发布状态的人。",
+    checkpoints: ["先分清 Beta 与正式版的职责差异", "下载慢时优先尝试镜像链接", "还没有公开入口时，直接去申请测试或联系支持"],
+  },
+] as const;
+
+const releasePrinciples = [
+  {
+    title: "Beta 测试版",
+    summary: "更快同步、更适合早期反馈，也更可能跟着交付节奏持续变化。",
+    bullets: ["入口优先由自动同步链路更新", "适合主动体验新功能和报告问题的人", "下载说明会跟着 release 资产一起刷新"],
+  },
+  {
+    title: "正式版",
+    summary: "更强调稳定性和人工确认，不会因为有构建产物就立刻公开挂出。",
+    bullets: ["必须经过人工验收后才会发布", "更适合第一次安装或对稳定性更敏感的人", "官网只展示已经确认可公开分发的入口"],
+  },
+] as const;
+
+const platformFitGuidance = [
+  {
+    title: "Android Beta",
+    bestFor: "想最快跟上最新版本、愿意更早反馈问题的人。",
+    description: "如果你更在意尽快体验最新公开交付，而不是等到人工验收全部完成，Android beta 通常会是最先更新的入口。",
+  },
+  {
+    title: "iOS TestFlight",
+    bestFor: "已经明确想参与 iOS 内测，并愿意接受名额、审核和链接状态波动的人。",
+    description: "它更适合已经确认要深入体验完整主应用流程的用户，而不是只想随手点开看看的首次访问者。",
+  },
+  {
+    title: "正式版入口",
+    bestFor: "更希望先看人工验收结果、尽量减少安装后波动的人。",
+    description: "如果你主要想确认现在有没有相对稳定、可转发、可复用的下载入口，先等正式版通常比直接进入 beta 更合适。",
+  },
+] as const;
+
+const preInstallChecklist = [
+  "你现在更想优先体验最新改动，还是更想降低安装后的波动与反复更新。",
+  "你是否已经看过对应入口旁边的版本、更新时间和更新摘要，而不是只看按钮名称。",
+  "如果你准备反馈问题或申请资格，是否已经知道该走下载、申请测试还是联系支持这三条不同路径。",
+] as const;
+
+const downloadFaqs = [
+  {
+    question: "我应该优先下 Beta，还是等正式版？",
+    answer:
+      "如果你愿意更早体验最新进度，并能接受测试节奏，优先看 Beta。若你更在意稳定性、或者准备第一次接触项目，建议先等正式版入口。",
+  },
+  {
+    question: "为什么官网不把所有构建产物都直接挂出来？",
+    answer:
+      "因为下载页的职责不是展示所有产物，而是只给用户当前真正适合点击的入口。正式版尤其需要经过人工验收，避免用户拿到还不适合公开分发的安装包。",
+  },
+  {
+    question: "如果页面上还没有公开入口，我下一步该做什么？",
+    answer:
+      "先看当前 release 状态和推荐路径。如果是想参与体验，可以直接申请测试；如果是想确认发布时间或下载问题，优先联系支持邮箱。",
+  },
+] as const;
+
+export const metadata: Metadata = {
+  title: downloadTitle,
+  description: downloadDescription,
+  keywords: ["Fabushi 下载", "法布施下载", "Android Beta", "iOS TestFlight", "正式版发布"],
+  alternates: {
+    canonical: downloadUrl,
+  },
+  openGraph: {
+    title: downloadTitle,
+    description: downloadDescription,
+    url: downloadUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: downloadTitle,
+    description: downloadDescription,
+  },
 };
 
 function formatPublishedAt(value?: string) {
@@ -98,109 +185,118 @@ export default async function DownloadPage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const allChannels = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels];
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
-  const recommendationPaths = [
-    {
-      label: "想最快看到最新改动",
-      title: "优先看 Android beta 或 iOS TestFlight。",
-      description: "这两条通道会最先承接最新一轮可公开测试的安装包和状态更新，适合愿意跟着版本节奏一起体验的人。",
-    },
-    {
-      label: "想先判断自己适不适合加入测试",
-      title: "先看版本说明、更新时间和适用提示，再决定要不要安装。",
-      description: "下载页现在会把版本、发布时间、更新摘要和补充说明直接写在入口旁边，避免你先下载再回头找上下文。",
-    },
-    {
-      label: "更看重稳定与人工验收",
-      title: "优先等正式版入口，而不是直接进入 beta。",
-      description: "正式版只在人工验收完成后才会上架到官网，更适合不希望承担测试波动、需要更稳妥安装入口的人。",
-    },
-  ] as const;
-  const platformFitGuidance = [
-    {
-      title: "Android Beta",
-      bestFor: "想最快跟上最新版本、愿意更早反馈问题的人。",
-      description: "如果你更在意尽快体验最新公开交付，而不是等到人工验收全部完成，Android beta 通常会是最先更新的入口。",
-    },
-    {
-      title: "iOS TestFlight",
-      bestFor: "已经明确想参与 iOS 内测，并愿意接受名额、审核和链接状态波动的人。",
-      description: "它更适合已经确认要深入体验完整主应用流程的用户，而不是只想随手点开看看的首次访问者。",
-    },
-    {
-      title: "正式版入口",
-      bestFor: "更希望先看人工验收结果、尽量减少安装后波动的人。",
-      description: "如果你主要想确认现在有没有相对稳定、可转发、可复用的下载入口，先等正式版通常比直接进入 beta 更合适。",
-    },
-  ] as const;
-  const preInstallChecklist = [
-    "你现在更想优先体验最新改动，还是更想降低安装后的波动与反复更新。",
-    "你是否已经看过对应入口旁边的版本、更新时间和更新摘要，而不是只看按钮名称。",
-    "如果你准备反馈问题或申请资格，是否已经知道该走下载、申请测试还是联系支持这三条不同路径。",
-  ] as const;
 
-  const downloadPageJsonLd = {
+  const structuredData = {
     "@context": "https://schema.org",
-    "@type": "CollectionPage",
-    name: `${brand.name} 下载入口`,
-    url: siteUrl("/download"),
-    inLanguage: "zh-CN",
-    description: "查看 Fabushi Android beta、iOS TestFlight 与正式版的当前可见下载状态。",
-    mainEntity: {
-      "@type": "ItemList",
-      itemListElement: allChannels.map((channel, index) => ({
-        "@type": "ListItem",
-        position: index + 1,
-        item: {
-          "@type": "SoftwareApplication",
-          name: channel.title,
-          operatingSystem: channel.platform,
-          description: channel.description,
-          url: siteUrl("/download"),
-          downloadUrl: siteHref(channel.primaryHref),
-          applicationCategory: channel.audience === "stable" ? "ProductivityApplication" : "BetaSoftwareApplication",
-        },
-      })),
-    },
-    provider: {
-      "@type": "Organization",
-      name: `${brand.name} Fabushi`,
-      email: supportEmail,
-      url: siteUrl("/"),
-    },
-  };
-  const breadcrumbJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
+    "@graph": [
       {
-        "@type": "ListItem",
-        position: 1,
-        name: "首页",
-        item: siteUrl("/"),
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "首页", item: siteUrl("/") },
+          { "@type": "ListItem", position: 2, name: "下载入口", item: downloadUrl },
+        ],
       },
       {
-        "@type": "ListItem",
-        position: 2,
-        name: "下载入口",
-        item: siteUrl("/download"),
+        "@type": "CollectionPage",
+        name: `${brand.name} 下载入口`,
+        url: downloadUrl,
+        description: downloadDescription,
+        inLanguage: "zh-CN",
+        mainEntity: {
+          "@type": "ItemList",
+          itemListElement: allChannels.map((channel, index) => ({
+            "@type": "ListItem",
+            position: index + 1,
+            item: {
+              "@type": "SoftwareApplication",
+              name: channel.title,
+              operatingSystem: channel.platform,
+              description: channel.description,
+              url: downloadUrl,
+              downloadUrl: siteHref(channel.primaryHref),
+              applicationCategory: channel.audience === "stable" ? "ProductivityApplication" : "BetaSoftwareApplication",
+            },
+          })),
+        },
+      },
+      {
+        "@type": "Organization",
+        name: `${brand.name} Fabushi`,
+        url: siteUrl("/"),
+        email: supportEmail,
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: downloadFaqs.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
       },
     ],
   };
 
   return (
     <main className="inner-page">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(downloadPageJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
 
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">
           <p className="eyebrow">下载入口</p>
-          <h1>官网现在直接承接测试版与正式版入口，不再只停留在等待名单。</h1>
+          <h1>把入口分清楚，比把所有包一股脑挂出来更重要。</h1>
           <p className="lede">
-            Android beta 会跟着最新 GitHub Release 自动更新，iOS beta 会在 TestFlight 上传成功后同步到官网。
-            正式版则通过人工验证后的手动发布动作上架，避免把未经确认的安装包直接挂出去。
+            这页的任务不是堆下载按钮，而是先帮你判断：现在该去 Beta、该等正式版，还是该先申请测试资格。
+            Android Beta、iOS TestFlight 与正式版发布状态都会在这里持续同步。
           </p>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
+          <p>先做判断</p>
+          <h2>如果你只想知道下一步该点哪里，先按场景选路径，而不是先猜平台状态。</h2>
+        </div>
+        <div className="decision-grid">
+          {decisionPaths.map((item) => (
+            <article key={item.title} className="decision-card">
+              <p className="eyebrow">{item.title}</p>
+              <h3>{item.recommendation}</h3>
+              <p>{item.description}</p>
+              <ul className="decision-list">
+                {item.checkpoints.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
+          <p>版本差异</p>
+          <h2>Beta 和正式版的区别，不只是“能不能下载”，而是入口更新方式和适合人群完全不同。</h2>
+        </div>
+        <div className="compare-grid">
+          {releasePrinciples.map((item) => (
+            <article key={item.title} className="compare-card">
+              <h3>{item.title}</h3>
+              <p>{item.summary}</p>
+              <ul className="compare-list">
+                {item.bullets.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
         </div>
       </section>
 
@@ -231,7 +327,7 @@ export default async function DownloadPage() {
       <section className="band">
         <div className="section-heading">
           <p>平台适配</p>
-          <h2>如果你是在比较 Android beta、iOS TestFlight 和正式版，先按你的使用阶段来选。</h2>
+          <h2>如果你是在比较 Android Beta、iOS TestFlight 和正式版，先按你的使用阶段来选。</h2>
         </div>
         <div className="definition-grid">
           {platformFitGuidance.map((item) => (
@@ -246,22 +342,6 @@ export default async function DownloadPage() {
 
       <section className="band alt">
         <div className="section-heading">
-          <p>选择建议</p>
-          <h2>如果你不确定现在该点哪一个入口，先按你的风险偏好和目的来选。</h2>
-        </div>
-        <div className="path-grid">
-          {recommendationPaths.map((item) => (
-            <article key={item.title} className="path-card">
-              <span className="detail-label">{item.label}</span>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band">
-        <div className="section-heading">
           <p>安装前确认</p>
           <h2>真正点下载前，先确认这三件事，能少走很多回头路。</h2>
         </div>
@@ -272,7 +352,7 @@ export default async function DownloadPage() {
         </ol>
       </section>
 
-      <section className="band alt">
+      <section className="band">
         <div className="section-heading">
           <p>同步说明</p>
           <h2>官网上的下载说明现在会跟着发布资产一起更新，而不是靠手工改文案。</h2>
@@ -284,15 +364,15 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band">
+      <section className="band alt">
         <div className="section-heading">
           <p>推荐路径</p>
           <h2>如果你现在只是第一次接触这个项目，建议先这样走。</h2>
         </div>
         <ol className="roadmap-list">
-          <li>先看官网，了解当前开放的是测试版还是已经过人工验收的正式版。</li>
-          <li>如果你在国内网络环境下下载较慢，优先尝试页面里的 GitHub 镜像入口。</li>
-          <li>如果 iOS TestFlight 还没有公开加入链接，先查看 release 状态或联系支持邮箱。</li>
+          <li>先看官网判断当前开放的是测试版，还是已经过人工验收的正式版。</li>
+          <li>如果你愿意更早体验新版本，再进入 Beta；如果更在意稳定性，就等正式版入口。</li>
+          <li>如果下载较慢，优先尝试页面里的镜像链接；如果还没有公开入口，直接申请测试或联系支持。</li>
         </ol>
         <div className="inline-cta">
           <a className="primary-action" href={siteHref("/apply")}>
@@ -301,6 +381,21 @@ export default async function DownloadPage() {
           <a className="secondary-action" href={siteHref("/contact")}>
             查看联系信息
           </a>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
+          <p>常见问题</p>
+          <h2>把下载前最容易犹豫的几个问题先回答出来，用户和搜索系统都更容易做出正确判断。</h2>
+        </div>
+        <div className="faq-list full">
+          {downloadFaqs.map((item) => (
+            <details key={item.question} className="faq-item">
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
+          ))}
         </div>
       </section>
 

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -65,6 +65,35 @@ const platformFitGuidance = [
   },
 ] as const;
 
+const entryGuardrails = [
+  {
+    label: "可以直接进入测试版",
+    title: "你更适合先体验最新公开进度，而不是等到所有事情都变稳定。",
+    description:
+      "如果你符合这些条件，先进入 Beta 通常更有效，因为官网已经在帮你同步状态、版本和镜像说明。",
+    bullets: [
+      "你愿意更早体验版本更新，也愿意接受偶发波动和更频繁的变更。",
+      "你有明确的设备、平台和关注模块，准备在体验后给出反馈。",
+      "你更在意尽快参与当前进度，而不是把它当成一个马上就要推荐给更多人的稳定入口。",
+    ],
+    href: "/download#beta-channels",
+    ctaLabel: "直接看 Beta 入口",
+  },
+  {
+    label: "先别急着点测试版",
+    title: "你更适合先等正式版，或者先通过申请与 FAQ 把路径判断清楚。",
+    description:
+      "如果你更符合这些情况，先理解边界和阶段，会比直接进入测试版更省时间，也更不容易产生预期落差。",
+    bullets: [
+      "你现在只接受稳定、可复用、适合转发的正式下载入口。",
+      "你还没决定自己是来下载、申请资格、反馈问题，还是只想先了解项目。",
+      "你不打算承担 beta 节奏，也不希望遇到需要镜像、资格或后续沟通才能解决的安装问题。",
+    ],
+    href: "/apply",
+    ctaLabel: "先去申请或了解",
+  },
+] as const;
+
 const preInstallChecklist = [
   "你现在更想优先体验最新改动，还是更想降低安装后的波动与反复更新。",
   "你是否已经看过对应入口旁边的版本、更新时间和更新摘要，而不是只看按钮名称。",
@@ -300,7 +329,31 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band">
+      <section className="band" id="download-fit">
+        <div className="section-heading">
+          <p>适合谁先下</p>
+          <h2>下载页也应该先帮你排除不合适的路径，而不是默认每个人都该先点测试版。</h2>
+        </div>
+        <div className="compare-grid">
+          {entryGuardrails.map((item) => (
+            <article key={item.label} className="compare-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <ul className="compare-list">
+                {item.bullets.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band" id="beta-channels">
         <div className="section-heading">
           <p>Beta 渠道</p>
           <h2>安装包发布完成后，这里的测试入口会自动跟上最新一轮交付结果。</h2>
@@ -312,7 +365,7 @@ export default async function DownloadPage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band alt" id="stable-channels">
         <div className="section-heading">
           <p>正式版</p>
           <h2>正式版入口只在人工验收通过后，由手动 GitHub Action 发布到官网。</h2>

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -2,23 +2,42 @@ import type { Metadata } from "next";
 import { brand, faqItems } from "@fabushi/shared";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
-import { siteHref } from "../../lib/site-url";
+import { siteHref, siteUrl } from "../../lib/site-url";
 
 export const metadata: Metadata = {
   title: `常见问题 | ${brand.name}`,
-  description: "查看官网、微信小程序与主应用之间的职责划分，以及首期上线范围。",
+  description: "查看 Fabushi 是什么、是否可下载，以及官网、微信小程序与主应用分别承担什么角色。",
+  alternates: {
+    canonical: siteUrl("/faq"),
+  },
+  keywords: ["法布施 FAQ", "Fabushi 常见问题", "法布施下载", "法布施官网", "法布施小程序"],
 };
 
 export default function FaqPage() {
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqItems.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
+
   return (
     <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">
           <p className="eyebrow">常见问题</p>
-          <h1>把最容易反复解释的问题写出来，官网才真正开始工作。</h1>
+          <h1>把用户最容易问的关键问题写清楚，官网才真正开始承担解释和转化的工作。</h1>
           <p className="lede">
-            这一页优先回答官网、微信小程序和 Flutter 主应用之间的关系，以及为什么当前要拆出新的前端 monorepo。
+            这一页优先回答 Fabushi 是什么、现在能否下载、适合哪些人先关注，以及官网、微信小程序和 Flutter 主应用之间的分工关系。
           </p>
         </div>
       </section>

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -4,13 +4,67 @@ import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
+const faqUrl = siteUrl("/faq");
+const faqTitle = `常见问题 | ${brand.name}`;
+const faqDescription =
+  "查看 Fabushi 是什么、现在能否下载，以及官网、微信小程序与主应用分别承担什么角色。";
+
+const roleDefinitions = [
+  {
+    title: "官网负责先解释清楚",
+    description: "首页、下载入口、FAQ、隐私说明和联系路径先承担理解、信任建立与转化，不让第一次访问的人只能靠猜。",
+  },
+  {
+    title: "微信小程序负责轻触达",
+    description: "更适合承接轻浏览、榜单、公开档案和微信生态内的快速传播，不承担最重的沉浸式流程。",
+  },
+  {
+    title: "主应用负责完整体验",
+    description: "更完整的内容浏览、上传分享、个人中心和重交互流程，继续放在主应用里逐步打磨。",
+  },
+] as const;
+
+const faqJourneys = [
+  {
+    title: "想先判断现在能不能下载",
+    description: "优先去下载页看 Beta、正式版和镜像入口的当前状态，而不是先点击一个可能还没开放的按钮。",
+    href: "/download",
+    ctaLabel: "去下载入口",
+  },
+  {
+    title: "想参与内测或合作沟通",
+    description: "先按 iOS、Android 或合作方向拆分入口，后续资格发放和反馈沟通会更顺畅。",
+    href: "/apply",
+    ctaLabel: "去申请测试",
+  },
+  {
+    title: "想先确认边界和联系方式",
+    description: "如果你更在意隐私说明、支持邮箱和公开协作路径，可以先看隐私页与联系页。",
+    href: "/privacy",
+    ctaLabel: "查看隐私说明",
+  },
+] as const;
+
 export const metadata: Metadata = {
-  title: `常见问题 | ${brand.name}`,
-  description: "查看 Fabushi 是什么、是否可下载，以及官网、微信小程序与主应用分别承担什么角色。",
+  title: faqTitle,
+  description: faqDescription,
   alternates: {
-    canonical: siteUrl("/faq"),
+    canonical: faqUrl,
   },
   keywords: ["法布施 FAQ", "Fabushi 常见问题", "法布施下载", "法布施官网", "法布施小程序"],
+  openGraph: {
+    title: faqTitle,
+    description: faqDescription,
+    url: faqUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: faqTitle,
+    description: faqDescription,
+  },
 };
 
 export default function FaqPage() {
@@ -40,15 +94,23 @@ export default function FaqPage() {
         "@type": "ListItem",
         position: 2,
         name: "常见问题",
-        item: siteUrl("/faq"),
+        item: faqUrl,
       },
     ],
   };
 
   return (
     <main className="inner-page">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
 
       <section className="inner-hero">
         <SiteHeader />
@@ -61,7 +123,26 @@ export default function FaqPage() {
         </div>
       </section>
 
+      <section className="band alt">
+        <div className="section-heading">
+          <p>先讲角色</p>
+          <h2>把三个入口各自负责什么说清楚，后面的下载、申请和内容理解才不会混在一起。</h2>
+        </div>
+        <div className="definition-grid">
+          {roleDefinitions.map((item) => (
+            <article key={item.title} className="definition-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="band">
+        <div className="section-heading">
+          <p>常见问题本体</p>
+          <h2>这里优先回答首次访问最容易阻塞理解和决策的几个问题。</h2>
+        </div>
         <div className="faq-list full">
           {faqItems.map((item) => (
             <details key={item.question} className="faq-item" open>
@@ -70,10 +151,25 @@ export default function FaqPage() {
             </details>
           ))}
         </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
+          <p>下一步怎么走</p>
+          <h2>FAQ 的价值不只是回答问题，还要把人送到正确的下一页。</h2>
+        </div>
+        <div className="path-grid">
+          {faqJourneys.map((item) => (
+            <article key={item.title} className="path-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
         <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/download")}>
-            去下载入口
-          </a>
           <a className="secondary-action" href={siteHref("/contact")}>
             查看联系信息
           </a>

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -26,10 +26,29 @@ export default function FaqPage() {
       },
     })),
   };
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "常见问题",
+        item: siteUrl("/faq"),
+      },
+    ],
+  };
 
   return (
     <main className="inner-page">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="inner-hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -277,6 +277,7 @@ h3,
 .application-list,
 .path-card p,
 .evidence-card p,
+.definition-card p,
 .channel-card p,
 .channel-list {
   color: var(--muted);
@@ -306,6 +307,7 @@ h3,
 .contact-grid,
 .path-grid,
 .evidence-grid,
+.definition-grid,
 .channel-grid {
   display: grid;
   gap: 16px;
@@ -330,6 +332,7 @@ h3,
 .narrative-block,
 .path-card,
 .evidence-card,
+.definition-card,
 .channel-card {
   background: var(--surface);
   border: 1px solid var(--line);
@@ -340,7 +343,8 @@ h3,
 }
 
 .path-card,
-.channel-card {
+.channel-card,
+.definition-card {
   display: grid;
   gap: 14px;
   align-content: start;
@@ -351,6 +355,10 @@ h3,
   gap: 10px;
   align-content: start;
   background: var(--surface-strong);
+}
+
+.definition-card {
+  background: linear-gradient(180deg, rgba(255, 250, 244, 0.92), rgba(247, 239, 228, 0.92));
 }
 
 .path-card h3,
@@ -365,6 +373,7 @@ h3,
 .editorial-row strong,
 .contact-card strong,
 .evidence-card strong,
+.definition-card h3,
 .channel-card h3 {
   display: block;
   color: var(--ink);
@@ -377,6 +386,7 @@ h3,
 .architecture-grid h3,
 .download-card h2,
 .release-card h2,
+.definition-card h3,
 .channel-card h3 {
   margin: 0;
 }
@@ -395,6 +405,7 @@ h3,
 .narrative-block h3,
 .use-case-block h3,
 .path-card h3,
+.definition-card h3,
 .channel-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
@@ -472,6 +483,7 @@ h3,
 .application-grid,
 .contact-grid,
 .evidence-grid,
+.definition-grid,
 .channel-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -147,14 +147,16 @@ h3,
 
 .nav-cta,
 .primary-action,
-.secondary-action {
+.secondary-action,
+.path-link {
   border-radius: 999px;
   padding: 12px 20px;
   transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
 }
 
 .nav-cta,
-.primary-action {
+.primary-action,
+.path-link {
   background: var(--ink);
   color: #fffaf3;
 }
@@ -166,7 +168,8 @@ h3,
 
 .nav-cta:hover,
 .primary-action:hover,
-.secondary-action:hover {
+.secondary-action:hover,
+.path-link:hover {
   transform: translateY(-1px);
 }
 
@@ -271,7 +274,8 @@ h3,
 .editorial-row small,
 .release-mirror-block p,
 .application-summary,
-.application-list {
+.application-list,
+.path-card p {
   color: var(--muted);
   line-height: 1.72;
 }
@@ -296,7 +300,8 @@ h3,
 .download-grid,
 .application-grid,
 .use-case-grid,
-.contact-grid {
+.contact-grid,
+.path-grid {
   display: grid;
   gap: 16px;
 }
@@ -317,7 +322,8 @@ h3,
 .release-card,
 .use-case-block,
 .contact-card,
-.narrative-block {
+.narrative-block,
+.path-card {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 18px;
@@ -326,6 +332,13 @@ h3,
   backdrop-filter: blur(10px);
 }
 
+.path-card {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.path-card h3,
 .signal-chip strong,
 .hero-proof-row strong,
 .narrative-block h3,
@@ -340,6 +353,20 @@ h3,
   color: var(--ink);
 }
 
+.path-card h3,
+.narrative-block h3,
+.use-case-block h3,
+.feature-block h3,
+.architecture-grid h3,
+.download-card h2,
+.release-card h2 {
+  margin: 0;
+}
+
+.path-link {
+  justify-self: start;
+}
+
 .signal-chip strong,
 .hero-proof-row strong {
   font-size: 1rem;
@@ -347,7 +374,8 @@ h3,
 
 .hero-panel strong,
 .narrative-block h3,
-.use-case-block h3 {
+.use-case-block h3,
+.path-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
 }
@@ -392,10 +420,15 @@ h3,
     linear-gradient(180deg, rgba(255, 244, 228, 0.82), rgba(237, 227, 214, 0.6));
 }
 
+.quick-paths {
+  padding-top: 12px;
+}
+
 .section-heading {
   margin-bottom: 28px;
 }
 
+.path-grid,
 .narrative-grid,
 .use-case-grid,
 .feature-grid,
@@ -404,15 +437,6 @@ h3,
 .application-grid,
 .contact-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.feature-block h3,
-.architecture-grid h3,
-.download-card h2,
-.release-card h2,
-.use-case-block h3,
-.narrative-block h3 {
-  margin: 0 0 10px;
 }
 
 .platform-strip,

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -1,12 +1,18 @@
 :root {
   color-scheme: light;
-  --bg: #f5efe2;
-  --surface: rgba(255, 250, 242, 0.86);
-  --ink: #1f170f;
-  --muted: #6d5a48;
-  --accent: #b45f06;
-  --accent-strong: #8b3d0b;
-  --line: rgba(73, 47, 23, 0.14);
+  --bg: #f6f1e8;
+  --surface: rgba(255, 251, 245, 0.82);
+  --surface-strong: rgba(255, 248, 239, 0.94);
+  --ink: #19140f;
+  --muted: #65594d;
+  --accent: #a86130;
+  --accent-strong: #7f441d;
+  --accent-soft: rgba(168, 97, 48, 0.12);
+  --secondary: #4f695f;
+  --secondary-soft: rgba(79, 105, 95, 0.12);
+  --line: rgba(58, 43, 29, 0.12);
+  --line-strong: rgba(58, 43, 29, 0.2);
+  --shadow: 0 24px 60px rgba(53, 37, 24, 0.08);
 }
 
 * {
@@ -20,15 +26,25 @@ html {
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top, rgba(255, 226, 186, 0.7), transparent 38%),
-    linear-gradient(180deg, #f7f0e4 0%, #f3e6d2 48%, #efe0cb 100%);
+    radial-gradient(circle at top left, rgba(236, 214, 180, 0.52), transparent 34%),
+    radial-gradient(circle at top right, rgba(153, 186, 170, 0.18), transparent 32%),
+    linear-gradient(180deg, #faf6ef 0%, #f6efe4 44%, #f1e7db 100%);
   color: var(--ink);
-  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
 a {
   color: inherit;
   text-decoration: none;
+}
+
+h1,
+h2,
+h3,
+.brand-kicker,
+.site-wordmark span,
+.footer-title {
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
 }
 
 .page-shell,
@@ -48,7 +64,7 @@ a {
 .hero,
 .band {
   padding-top: 32px;
-  padding-bottom: 64px;
+  padding-bottom: 72px;
 }
 
 .inner-hero {
@@ -57,22 +73,58 @@ a {
 }
 
 .hero {
-  min-height: 92vh;
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 
 .site-nav {
+  position: sticky;
+  top: 18px;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 18px;
+  padding: 14px 16px;
+  background: rgba(255, 250, 244, 0.72);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 10px 30px rgba(48, 34, 24, 0.06);
 }
 
 .site-wordmark {
-  font-size: 1rem;
-  font-weight: 700;
+  display: inline-grid;
+  gap: 2px;
+}
+
+.site-wordmark span {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.site-wordmark small,
+.detail-label {
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.site-nav-links-wrap,
+.hero-stage,
+.hero-actions,
+.inline-cta,
+.release-card-actions {
+  display: flex;
+  gap: 14px;
+}
+
+.site-nav-links-wrap {
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .site-nav-links,
@@ -83,6 +135,49 @@ a {
   color: var(--muted);
 }
 
+.site-nav-links a,
+.footer-links a {
+  transition: color 180ms ease;
+}
+
+.site-nav-links a:hover,
+.footer-links a:hover {
+  color: var(--ink);
+}
+
+.nav-cta,
+.primary-action,
+.secondary-action {
+  border-radius: 999px;
+  padding: 12px 20px;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.nav-cta,
+.primary-action {
+  background: var(--ink);
+  color: #fffaf3;
+}
+
+.secondary-action {
+  background: var(--surface);
+  border: 1px solid var(--line);
+}
+
+.nav-cta:hover,
+.primary-action:hover,
+.secondary-action:hover {
+  transform: translateY(-1px);
+}
+
+.hero-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(280px, 0.88fr);
+  align-items: end;
+  gap: 28px;
+  margin-top: auto;
+}
+
 .hero-copy,
 .inner-copy,
 .section-heading,
@@ -91,26 +186,44 @@ a {
 }
 
 .hero-copy {
-  padding: 12vh 0 8vh;
+  padding: 10vh 0 6vh;
 }
 
 .inner-copy {
   padding-top: 10vh;
 }
 
+.hero-aside {
+  display: grid;
+  gap: 16px;
+  padding-bottom: 6vh;
+}
+
 .eyebrow,
 .section-heading p,
 .platform-name,
 .download-status,
-.article-date {
+.article-date,
+.hero-panel p {
   margin: 0 0 12px;
   color: var(--accent-strong);
   font-size: 0.95rem;
 }
 
 .brand-kicker {
-  margin: 0 0 16px;
-  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 0 0 18px;
+  font-size: clamp(2rem, 3vw, 3rem);
+}
+
+.brand-kicker span {
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.46em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .hero-copy h1,
@@ -122,13 +235,17 @@ a {
 }
 
 .hero-copy h1 {
-  font-size: clamp(3rem, 8vw, 6.4rem);
-  max-width: 12ch;
+  max-width: 11ch;
+  font-size: clamp(3.1rem, 8vw, 6.5rem);
 }
 
 .inner-copy h1,
 .section-heading h2 {
-  font-size: clamp(2.2rem, 5vw, 4.4rem);
+  font-size: clamp(2.2rem, 5vw, 4.5rem);
+}
+
+.section-heading h2 {
+  max-width: 14ch;
 }
 
 .lede,
@@ -143,111 +260,158 @@ a {
 .empty-copy,
 .roadmap-list,
 .release-card p,
-.release-note {
+.release-note,
+.signal-chip strong,
+.hero-panel span,
+.hero-proof-row span,
+.narrative-block p,
+.use-case-block p,
+.contact-card p,
+.status-note-list p,
+.editorial-row small,
+.release-mirror-block p,
+.application-summary,
+.application-list {
   color: var(--muted);
-  line-height: 1.75;
+  line-height: 1.72;
 }
 
 .lede {
   margin: 20px 0 0;
   max-width: 46rem;
-  font-size: 1.1rem;
+  font-size: 1.12rem;
 }
 
 .hero-actions,
 .inline-cta,
 .release-card-actions {
-  display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  margin-top: 28px;
+  margin-top: 30px;
 }
 
-.primary-action,
-.secondary-action {
-  border-radius: 999px;
-  padding: 12px 20px;
-  transition: transform 180ms ease, background-color 180ms ease;
+.hero-signal-bar,
+.narrative-grid,
+.feature-grid,
+.architecture-grid,
+.download-grid,
+.application-grid,
+.use-case-grid,
+.contact-grid {
+  display: grid;
+  gap: 16px;
 }
 
-.primary-action {
-  background: var(--accent);
-  color: #fff7ed;
+.hero-signal-bar {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 36px;
 }
 
-.secondary-action {
+.signal-chip,
+.hero-panel,
+.hero-proof-list,
+.feature-block,
+.architecture-grid > div,
+.download-card,
+.application-card,
+.preview-row,
+.release-card,
+.use-case-block,
+.contact-card,
+.narrative-block {
   background: var(--surface);
   border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
 }
 
-.primary-action:hover,
-.secondary-action:hover {
-  transform: translateY(-1px);
+.signal-chip strong,
+.hero-proof-row strong,
+.narrative-block h3,
+.use-case-block h3,
+.feature-block h3,
+.architecture-grid h3,
+.download-card h2,
+.release-card h2,
+.editorial-row strong,
+.contact-card strong {
+  display: block;
+  color: var(--ink);
 }
 
-.hero-panel {
-  align-self: flex-end;
-  max-width: 360px;
-  padding: 22px;
-  background: rgba(54, 31, 14, 0.08);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  backdrop-filter: blur(12px);
+.signal-chip strong,
+.hero-proof-row strong {
+  font-size: 1rem;
 }
 
-.hero-panel p,
-.hero-panel span {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.6;
+.hero-panel strong,
+.narrative-block h3,
+.use-case-block h3 {
+  font-size: 1.35rem;
+  line-height: 1.35;
 }
 
 .hero-panel strong {
   display: block;
   margin: 8px 0 10px;
-  font-size: 1.25rem;
+}
+
+.hero-proof-list {
+  display: grid;
+  gap: 14px;
+}
+
+.hero-proof-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 16px;
+  align-items: start;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.hero-proof-row:first-of-type {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.hero-proof-row em {
+  color: var(--secondary);
+  font-style: normal;
+  font-size: 0.95rem;
 }
 
 .band.alt {
-  background: rgba(255, 249, 239, 0.65);
+  background: rgba(255, 249, 241, 0.5);
 }
 
 .band.cinematic {
   background:
-    linear-gradient(120deg, rgba(188, 110, 34, 0.08), rgba(255, 250, 242, 0.35)),
-    linear-gradient(180deg, rgba(255, 244, 228, 0.8), rgba(242, 228, 206, 0.6));
+    linear-gradient(120deg, rgba(168, 97, 48, 0.08), rgba(255, 250, 244, 0.36)),
+    linear-gradient(180deg, rgba(255, 244, 228, 0.82), rgba(237, 227, 214, 0.6));
 }
 
 .section-heading {
   margin-bottom: 28px;
 }
 
+.narrative-grid,
+.use-case-grid,
 .feature-grid,
 .architecture-grid,
 .download-grid,
-.application-grid {
-  display: grid;
-  gap: 16px;
+.application-grid,
+.contact-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.feature-block,
-.architecture-grid > div,
-.download-card,
-.application-card,
-.preview-row,
-.release-card {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
-  backdrop-filter: blur(10px);
 }
 
 .feature-block h3,
 .architecture-grid h3,
 .download-card h2,
-.release-card h2 {
+.release-card h2,
+.use-case-block h3,
+.narrative-block h3 {
   margin: 0 0 10px;
 }
 
@@ -266,21 +430,15 @@ a {
   margin-top: 18px;
 }
 
-.status-note-list p,
-.contact-card p,
-.editorial-row small,
-.release-mirror-block p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
 .platform-row,
 .editorial-row {
   display: grid;
   gap: 16px;
-  padding: 18px 0;
-  border-top: 1px solid var(--line);
+  padding: 22px;
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
 }
 
 .platform-row {
@@ -293,11 +451,6 @@ a {
   align-items: start;
 }
 
-.platform-row:first-child,
-.editorial-row:first-child {
-  border-top: 0;
-}
-
 .platform-meta {
   text-align: right;
 }
@@ -308,11 +461,10 @@ a {
   display: block;
 }
 
-.download-card {
-  display: block;
-}
-
-.release-card {
+.download-card,
+.release-card,
+.application-card,
+.contact-card {
   display: grid;
   gap: 14px;
 }
@@ -333,14 +485,18 @@ a {
   font-size: 0.95rem;
 }
 
-.release-update-list {
+.release-update-list,
+.application-list,
+.roadmap-list {
   margin: 0;
   padding-left: 20px;
   color: var(--muted);
   line-height: 1.75;
 }
 
-.release-update-list li + li {
+.release-update-list li + li,
+.application-list li + li,
+.roadmap-list li + li {
   margin-top: 8px;
 }
 
@@ -353,63 +509,6 @@ a {
   gap: 12px;
 }
 
-.release-note {
-  margin: 0;
-}
-
-.application-card {
-  display: grid;
-  gap: 14px;
-  align-content: start;
-}
-
-.application-summary,
-.application-list {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.75;
-}
-
-.application-list {
-  padding-left: 20px;
-}
-
-.application-list li + li {
-  margin-top: 8px;
-}
-
-.contact-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.contact-card {
-  display: block;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 18px;
-}
-
-.contact-card span,
-.contact-card strong {
-  display: block;
-}
-
-.contact-card strong {
-  margin: 8px 0 10px;
-}
-
-.roadmap-list {
-  margin: 0;
-  padding-left: 20px;
-}
-
-.roadmap-list li + li {
-  margin-top: 12px;
-}
-
 .preview-row {
   display: grid;
   grid-template-columns: 56px minmax(0, 1fr) max-content;
@@ -418,13 +517,11 @@ a {
 }
 
 .faq-item {
-  border-top: 1px solid var(--line);
-  padding-top: 16px;
-}
-
-.faq-item:first-child {
-  border-top: 0;
-  padding-top: 0;
+  padding: 18px 20px;
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
 }
 
 .faq-item summary {
@@ -448,6 +545,11 @@ a {
   font-size: 1.08rem;
 }
 
+.contact-card span,
+.contact-card strong {
+  display: block;
+}
+
 .site-footer {
   display: flex;
   justify-content: space-between;
@@ -462,6 +564,21 @@ a {
   font-weight: 700;
 }
 
+@media (max-width: 960px) {
+  .hero-stage,
+  .hero-signal-bar,
+  .platform-row,
+  .editorial-row,
+  .preview-row,
+  .hero-proof-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .platform-meta {
+    text-align: left;
+  }
+}
+
 @media (max-width: 720px) {
   .hero,
   .band,
@@ -473,23 +590,29 @@ a {
   }
 
   .site-nav,
+  .site-nav-links-wrap,
   .site-footer,
   .release-card-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .hero-panel {
-    align-self: stretch;
+  .site-nav {
+    border-radius: 28px;
   }
 
-  .platform-row,
-  .editorial-row,
-  .preview-row {
-    grid-template-columns: minmax(0, 1fr);
+  .hero-copy {
+    padding-top: 8vh;
   }
 
-  .platform-meta {
-    text-align: left;
+  .hero-copy h1,
+  .section-heading h2 {
+    max-width: none;
+  }
+
+  .brand-kicker {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
   }
 }

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -114,6 +114,7 @@ h3,
 }
 
 .site-nav-links-wrap,
+.site-nav-cluster,
 .hero-stage,
 .hero-actions,
 .inline-cta,
@@ -122,7 +123,8 @@ h3,
   gap: 14px;
 }
 
-.site-nav-links-wrap {
+.site-nav-links-wrap,
+.site-nav-cluster {
   align-items: center;
   flex-wrap: wrap;
 }
@@ -146,30 +148,39 @@ h3,
 }
 
 .nav-cta,
+.nav-action,
 .primary-action,
 .secondary-action,
-.path-link {
+.path-link,
+.tertiary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 999px;
   padding: 12px 20px;
   transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
 }
 
 .nav-cta,
+.nav-action,
 .primary-action,
 .path-link {
   background: var(--ink);
   color: #fffaf3;
 }
 
-.secondary-action {
+.secondary-action,
+.tertiary-action {
   background: var(--surface);
   border: 1px solid var(--line);
 }
 
 .nav-cta:hover,
+.nav-action:hover,
 .primary-action:hover,
 .secondary-action:hover,
-.path-link:hover {
+.path-link:hover,
+.tertiary-action:hover {
   transform: translateY(-1px);
 }
 
@@ -196,7 +207,8 @@ h3,
   padding-top: 10vh;
 }
 
-.hero-aside {
+.hero-aside,
+.hero-rail {
   display: grid;
   gap: 16px;
   padding-bottom: 6vh;
@@ -231,7 +243,19 @@ h3,
 
 .hero-copy h1,
 .inner-copy h1,
-.section-heading h2 {
+.section-heading h2,
+.path-card h3,
+.narrative-block h3,
+.use-case-block h3,
+.feature-block h3,
+.architecture-grid h3,
+.download-card h2,
+.release-card h2,
+.definition-card h3,
+.channel-card h3,
+.governance-card h3,
+.decision-card h3,
+.compare-card h3 {
   margin: 0;
   line-height: 1.05;
   letter-spacing: 0;
@@ -280,7 +304,14 @@ h3,
 .definition-card p,
 .channel-card p,
 .channel-list,
-.governance-card p {
+.governance-card p,
+.decision-card p,
+.compare-card p,
+.decision-list,
+.compare-list,
+.mini-stat span,
+.proof-card p,
+.audience-card p {
   color: var(--muted);
   line-height: 1.72;
 }
@@ -310,7 +341,12 @@ h3,
 .evidence-grid,
 .definition-grid,
 .channel-grid,
-.governance-grid {
+.governance-grid,
+.decision-grid,
+.compare-grid,
+.proof-grid,
+.audience-grid,
+.hero-mini-grid {
   display: grid;
   gap: 16px;
 }
@@ -336,7 +372,13 @@ h3,
 .evidence-card,
 .definition-card,
 .channel-card,
-.governance-card {
+.governance-card,
+.decision-card,
+.compare-card,
+.proof-card,
+.audience-card,
+.mini-stat,
+.stack-card {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 18px;
@@ -348,7 +390,12 @@ h3,
 .path-card,
 .channel-card,
 .definition-card,
-.governance-card {
+.governance-card,
+.decision-card,
+.compare-card,
+.proof-card,
+.audience-card,
+.stack-card {
   display: grid;
   gap: 14px;
   align-content: start;
@@ -383,22 +430,14 @@ h3,
 .evidence-card strong,
 .definition-card h3,
 .channel-card h3,
-.governance-card h3 {
+.governance-card h3,
+.decision-card h3,
+.compare-card h3,
+.proof-card h3,
+.audience-card h3,
+.mini-stat strong {
   display: block;
   color: var(--ink);
-}
-
-.path-card h3,
-.narrative-block h3,
-.use-case-block h3,
-.feature-block h3,
-.architecture-grid h3,
-.download-card h2,
-.release-card h2,
-.definition-card h3,
-.channel-card h3,
-.governance-card h3 {
-  margin: 0;
 }
 
 .path-link {
@@ -407,7 +446,8 @@ h3,
 
 .signal-chip strong,
 .hero-proof-row strong,
-.evidence-card strong {
+.evidence-card strong,
+.mini-stat strong {
   font-size: 1rem;
 }
 
@@ -417,7 +457,11 @@ h3,
 .path-card h3,
 .definition-card h3,
 .channel-card h3,
-.governance-card h3 {
+.governance-card h3,
+.decision-card h3,
+.compare-card h3,
+.proof-card h3,
+.audience-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
 }
@@ -455,7 +499,9 @@ h3,
 .channel-list,
 .release-update-list,
 .application-list,
-.roadmap-list {
+.roadmap-list,
+.decision-list,
+.compare-list {
   margin: 0;
   padding-left: 20px;
 }
@@ -463,7 +509,9 @@ h3,
 .channel-list li + li,
 .release-update-list li + li,
 .application-list li + li,
-.roadmap-list li + li {
+.roadmap-list li + li,
+.decision-list li + li,
+.compare-list li + li {
   margin-top: 8px;
 }
 
@@ -471,13 +519,15 @@ h3,
   background: rgba(255, 249, 241, 0.5);
 }
 
-.band.cinematic {
+.band.cinematic,
+.cta-band {
   background:
     linear-gradient(120deg, rgba(168, 97, 48, 0.08), rgba(255, 250, 244, 0.36)),
     linear-gradient(180deg, rgba(255, 244, 228, 0.82), rgba(237, 227, 214, 0.6));
 }
 
-.quick-paths {
+.quick-paths,
+.proof-band {
   padding-top: 12px;
 }
 
@@ -496,7 +546,12 @@ h3,
 .evidence-grid,
 .definition-grid,
 .channel-grid,
-.governance-grid {
+.governance-grid,
+.decision-grid,
+.compare-grid,
+.proof-grid,
+.audience-grid,
+.hero-mini-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
@@ -507,6 +562,10 @@ h3,
 .release-section-stack {
   display: grid;
   gap: 12px;
+}
+
+.faq-list.full {
+  gap: 18px;
 }
 
 .status-note-list {
@@ -568,13 +627,6 @@ h3,
   gap: 14px;
   color: var(--muted);
   font-size: 0.95rem;
-}
-
-.release-update-list,
-.application-list,
-.roadmap-list {
-  color: var(--muted);
-  line-height: 1.75;
 }
 
 .release-card-actions {
@@ -641,6 +693,14 @@ h3,
   font-weight: 700;
 }
 
+.stack-card.transparent {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
 @media (max-width: 960px) {
   .hero-stage,
   .hero-signal-bar,
@@ -668,6 +728,7 @@ h3,
 
   .site-nav,
   .site-nav-links-wrap,
+  .site-nav-cluster,
   .site-footer,
   .release-card-header {
     flex-direction: column;

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -275,7 +275,10 @@ h3,
 .release-mirror-block p,
 .application-summary,
 .application-list,
-.path-card p {
+.path-card p,
+.evidence-card p,
+.channel-card p,
+.channel-list {
   color: var(--muted);
   line-height: 1.72;
 }
@@ -301,7 +304,9 @@ h3,
 .application-grid,
 .use-case-grid,
 .contact-grid,
-.path-grid {
+.path-grid,
+.evidence-grid,
+.channel-grid {
   display: grid;
   gap: 16px;
 }
@@ -323,7 +328,9 @@ h3,
 .use-case-block,
 .contact-card,
 .narrative-block,
-.path-card {
+.path-card,
+.evidence-card,
+.channel-card {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 18px;
@@ -332,10 +339,18 @@ h3,
   backdrop-filter: blur(10px);
 }
 
-.path-card {
+.path-card,
+.channel-card {
   display: grid;
   gap: 14px;
   align-content: start;
+}
+
+.evidence-card {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  background: var(--surface-strong);
 }
 
 .path-card h3,
@@ -348,7 +363,9 @@ h3,
 .download-card h2,
 .release-card h2,
 .editorial-row strong,
-.contact-card strong {
+.contact-card strong,
+.evidence-card strong,
+.channel-card h3 {
   display: block;
   color: var(--ink);
 }
@@ -359,7 +376,8 @@ h3,
 .feature-block h3,
 .architecture-grid h3,
 .download-card h2,
-.release-card h2 {
+.release-card h2,
+.channel-card h3 {
   margin: 0;
 }
 
@@ -368,14 +386,16 @@ h3,
 }
 
 .signal-chip strong,
-.hero-proof-row strong {
+.hero-proof-row strong,
+.evidence-card strong {
   font-size: 1rem;
 }
 
 .hero-panel strong,
 .narrative-block h3,
 .use-case-block h3,
-.path-card h3 {
+.path-card h3,
+.channel-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
 }
@@ -410,6 +430,21 @@ h3,
   font-size: 0.95rem;
 }
 
+.channel-list,
+.release-update-list,
+.application-list,
+.roadmap-list {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.channel-list li + li,
+.release-update-list li + li,
+.application-list li + li,
+.roadmap-list li + li {
+  margin-top: 8px;
+}
+
 .band.alt {
   background: rgba(255, 249, 241, 0.5);
 }
@@ -435,7 +470,9 @@ h3,
 .architecture-grid,
 .download-grid,
 .application-grid,
-.contact-grid {
+.contact-grid,
+.evidence-grid,
+.channel-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
@@ -512,16 +549,8 @@ h3,
 .release-update-list,
 .application-list,
 .roadmap-list {
-  margin: 0;
-  padding-left: 20px;
   color: var(--muted);
   line-height: 1.75;
-}
-
-.release-update-list li + li,
-.application-list li + li,
-.roadmap-list li + li {
-  margin-top: 8px;
 }
 
 .release-card-actions {

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -279,7 +279,8 @@ h3,
 .evidence-card p,
 .definition-card p,
 .channel-card p,
-.channel-list {
+.channel-list,
+.governance-card p {
   color: var(--muted);
   line-height: 1.72;
 }
@@ -308,13 +309,14 @@ h3,
 .path-grid,
 .evidence-grid,
 .definition-grid,
-.channel-grid {
+.channel-grid,
+.governance-grid {
   display: grid;
   gap: 16px;
 }
 
 .hero-signal-bar {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   margin-top: 36px;
 }
 
@@ -333,7 +335,8 @@ h3,
 .path-card,
 .evidence-card,
 .definition-card,
-.channel-card {
+.channel-card,
+.governance-card {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 18px;
@@ -344,7 +347,8 @@ h3,
 
 .path-card,
 .channel-card,
-.definition-card {
+.definition-card,
+.governance-card {
   display: grid;
   gap: 14px;
   align-content: start;
@@ -361,6 +365,10 @@ h3,
   background: linear-gradient(180deg, rgba(255, 250, 244, 0.92), rgba(247, 239, 228, 0.92));
 }
 
+.governance-card {
+  background: linear-gradient(180deg, rgba(255, 249, 241, 0.94), rgba(244, 235, 221, 0.9));
+}
+
 .path-card h3,
 .signal-chip strong,
 .hero-proof-row strong,
@@ -374,7 +382,8 @@ h3,
 .contact-card strong,
 .evidence-card strong,
 .definition-card h3,
-.channel-card h3 {
+.channel-card h3,
+.governance-card h3 {
   display: block;
   color: var(--ink);
 }
@@ -387,7 +396,8 @@ h3,
 .download-card h2,
 .release-card h2,
 .definition-card h3,
-.channel-card h3 {
+.channel-card h3,
+.governance-card h3 {
   margin: 0;
 }
 
@@ -406,7 +416,8 @@ h3,
 .use-case-block h3,
 .path-card h3,
 .definition-card h3,
-.channel-card h3 {
+.channel-card h3,
+.governance-card h3 {
   font-size: 1.35rem;
   line-height: 1.35;
 }
@@ -484,7 +495,8 @@ h3,
 .contact-grid,
 .evidence-grid,
 .definition-grid,
-.channel-grid {
+.channel-grid,
+.governance-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -5,21 +5,56 @@ import { siteUrl } from "../lib/site-url";
 import "./globals.css";
 
 const homeUrl = siteUrl("/");
+const siteTitle = `${brand.name} Fabushi | 佛法传播、修行记录与下载入口`;
+const siteDescription =
+  "Fabushi 法布施官网，统一承接佛法传播、修行记录、公开档案、排行榜、下载入口、测试申请与内容专栏。";
 
 export const metadata: Metadata = {
-  title: `${brand.name} | 官网`,
-  description: brand.mission,
+  title: siteTitle,
+  description: siteDescription,
   metadataBase: new URL(homeUrl),
+  applicationName: `${brand.name} Fabushi`,
   alternates: {
     canonical: homeUrl,
   },
+  keywords: [
+    "法布施",
+    "Fabushi",
+    "佛法传播",
+    "修行记录",
+    "佛教应用",
+    "下载入口",
+    "TestFlight",
+    "Android Beta",
+    "微信小程序",
+    "公开档案",
+    "排行榜",
+  ],
+  category: "community",
+  manifest: siteUrl("/manifest.webmanifest"),
   openGraph: {
-    title: `${brand.name} | 官网`,
-    description: brand.mission,
+    title: siteTitle,
+    description: siteDescription,
     url: homeUrl,
     siteName: "Fabushi",
     locale: "zh_CN",
     type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteTitle,
+    description: siteDescription,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
 };
 

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -5,32 +5,35 @@ import { siteUrl } from "../lib/site-url";
 import "./globals.css";
 
 const homeUrl = siteUrl("/");
-const siteTitle = `${brand.name} Fabushi | 佛法传播、修行记录与下载入口`;
+const siteTitle = `${brand.name} Fabushi | 佛法传播、修行记录与共修连接平台`;
 const siteDescription =
-  "Fabushi 法布施官网，统一承接佛法传播、修行记录、公开档案、排行榜、下载入口、测试申请与内容专栏。";
+  "Fabushi 法布施官网，统一承接佛法传播、修行记录、下载入口、测试申请、FAQ、隐私说明与内容专栏。";
 
 export const metadata: Metadata = {
   title: siteTitle,
   description: siteDescription,
-  metadataBase: new URL(homeUrl),
-  applicationName: `${brand.name} Fabushi`,
-  alternates: {
-    canonical: homeUrl,
-  },
   keywords: [
     "法布施",
     "Fabushi",
     "佛法传播",
     "修行记录",
+    "共修",
     "佛教应用",
+    "佛法社区",
     "下载入口",
-    "TestFlight",
     "Android Beta",
+    "TestFlight",
     "微信小程序",
-    "公开档案",
-    "排行榜",
   ],
-  category: "community",
+  applicationName: `${brand.name} Fabushi`,
+  authors: [{ name: "Fabushi" }],
+  creator: "Fabushi",
+  publisher: "Fabushi",
+  metadataBase: new URL(homeUrl),
+  alternates: {
+    canonical: homeUrl,
+  },
+  category: "religion and spirituality",
   manifest: siteUrl("/manifest.webmanifest"),
   openGraph: {
     title: siteTitle,

--- a/frontend/apps/web/src/app/manifest.ts
+++ b/frontend/apps/web/src/app/manifest.ts
@@ -5,12 +5,12 @@ export const dynamic = "force-static";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "法布施官网",
+    name: "法布施 Fabushi 官网",
     short_name: "Fabushi",
-    description: "法布施官网与多端产品入口",
+    description: "Fabushi 官网，统一承接佛法传播、修行记录、下载入口、测试申请与内容专栏。",
     start_url: siteHref("/"),
     display: "standalone",
-    background_color: "#f7f0e4",
-    theme_color: "#b45f06",
+    background_color: "#f6f1e8",
+    theme_color: "#19140f",
   };
 }

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -81,6 +81,32 @@ export default async function HomePage() {
         "这让站点可以真实同步当前状态，而不是过度承诺尚未公开的功能或入口。",
     },
   ] as const;
+  const governanceFacts = [
+    {
+      label: "隐私边界",
+      title: "先把收集范围、用途、支持邮箱和用户控制权说清楚。",
+      description:
+        "用户在下载、申请测试或进入更完整的产品流程前，应该先知道哪些信息会被处理，以及出现问题时该找谁。",
+      href: "/privacy",
+      ctaLabel: "查看隐私说明",
+    },
+    {
+      label: "反馈与治理",
+      title: "FAQ、申请测试、公开仓库和联系入口形成闭环。",
+      description:
+        "把常见问题、测试申请、支持邮箱和公开协作入口放在可复查的位置，能减少“我该联系谁、该去哪一步”的犹豫。",
+      href: "/contact",
+      ctaLabel: "查看联系入口",
+    },
+    {
+      label: "发布节奏",
+      title: "下载状态、测试资格和公开说明保持同步更新。",
+      description:
+        "官网先说清楚当前开放什么、还在准备什么，让每次转化动作都有现实状态对应，而不是靠模糊承诺推进。",
+      href: "/download",
+      ctaLabel: "查看下载状态",
+    },
+  ] as const;
 
   const organizationJsonLd = {
     "@context": "https://schema.org",
@@ -133,12 +159,26 @@ export default async function HomePage() {
     })),
   };
 
+  const governanceJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "Fabushi trust and governance",
+    itemListElement: governanceFacts.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.title,
+      description: item.description,
+      url: siteUrl(item.href),
+    })),
+  };
+
   return (
     <main className="page-shell">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applicationJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(governanceJsonLd) }} />
 
       <header className="hero">
         <SiteHeader />
@@ -274,7 +314,26 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="audience">
+      <section className="band" id="governance">
+        <div className="section-heading">
+          <p>信任与治理</p>
+          <h2>品牌感只能让人停一下，真正推动申请、下载和长期使用的，是状态、边界和反馈机制都讲清楚。</h2>
+        </div>
+        <div className="governance-grid">
+          {governanceFacts.map((item) => (
+            <article key={item.label} className="governance-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="audience">
         <div className="section-heading">
           <p>适用场景</p>
           <h2>Fabushi 官网应该同时服务首次到达、内测申请、合作判断和搜索理解这四种场景。</h2>
@@ -290,7 +349,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band alt" id="channel-roles">
+      <section className="band" id="channel-roles">
         <div className="section-heading">
           <p>入口分工</p>
           <h2>不是每个人都该直接跳进同一个端里，官网要先告诉你该从哪里开始。</h2>
@@ -314,7 +373,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="capabilities">
+      <section className="band alt" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
           <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>
@@ -454,6 +513,9 @@ export default async function HomePage() {
         <div className="inline-cta">
           <a className="secondary-action" href={siteHref("/faq")}>
             查看完整 FAQ
+          </a>
+          <a className="secondary-action" href={siteHref("/privacy")}>
+            查看隐私说明
           </a>
           <a className="secondary-action" href={siteHref("/contact")}>
             联系我们

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import {
   contactChannels,
   faqItems,
   homeActionPaths,
+  homeChannelRoles,
   homeHighlights,
   homeTrustSignals,
   homeUseCases,
@@ -38,6 +39,28 @@ export default async function HomePage() {
   const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
   const faqPreview = faqItems.slice(0, 4);
+  const siteEvidence = [
+    {
+      label: "可见下载状态",
+      value: releasePreview.length > 0 ? `${releasePreview.length} 个入口已同步` : "入口持续同步中",
+      detail: "首页和下载页会直接承接当前公开可见的 beta 与正式版状态。",
+    },
+    {
+      label: "公开内容积累",
+      value: `${allArticles.length} 篇内容已上线`,
+      detail: "路线说明、专题文章与更新内容会持续沉淀，而不是只靠一张首页解释项目。",
+    },
+    {
+      label: "问题预答复",
+      value: `${faqItems.length} 个 FAQ 已整理`,
+      detail: "把“这是什么、适合谁、是否能下载、各端怎么分工”提前写清楚。",
+    },
+    {
+      label: "稳定联系入口",
+      value: `${contactChannels.length} 条公开通道`,
+      detail: "测试申请、支持反馈与公开协作都有明确去处，不用靠猜测联系路径。",
+    },
+  ] as const;
 
   const organizationJsonLd = {
     "@context": "https://schema.org",
@@ -175,6 +198,22 @@ export default async function HomePage() {
         </div>
       </section>
 
+      <section className="band alt" id="evidence">
+        <div className="section-heading">
+          <p>公开事实</p>
+          <h2>如果官网想建立信任，就要先给出可验证、可引用、可复查的公开信息。</h2>
+        </div>
+        <div className="evidence-grid">
+          {siteEvidence.map((item) => (
+            <article key={item.label} className="evidence-card">
+              <span className="detail-label">{item.label}</span>
+              <strong>{item.value}</strong>
+              <p>{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="band" id="trust">
         <div className="section-heading">
           <p>为什么先做官网</p>
@@ -207,7 +246,31 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="capabilities">
+      <section className="band" id="channel-roles">
+        <div className="section-heading">
+          <p>入口分工</p>
+          <h2>不是每个人都该直接跳进同一个端里，官网要先告诉你该从哪里开始。</h2>
+        </div>
+        <div className="channel-grid">
+          {homeChannelRoles.map((item) => (
+            <article key={item.channel} className="channel-card">
+              <span className="detail-label">{item.channel}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <ul className="channel-list">
+                {item.bestFor.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
           <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,10 +1,18 @@
 import { fabushiApiClient } from "@fabushi/api-client";
-import { brand, contactChannels, faqItems, homeHighlights, launchRoadmap } from "@fabushi/shared";
+import {
+  brand,
+  contactChannels,
+  faqItems,
+  homeHighlights,
+  homeTrustSignals,
+  homeUseCases,
+  launchRoadmap,
+} from "@fabushi/shared";
 import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
 import { getAllArticles, getFeaturedArticles } from "../lib/content";
 import { getOfficialSiteReleaseCollection } from "../lib/official-site-releases";
-import { siteHref } from "../lib/site-url";
+import { siteHref, siteUrl } from "../lib/site-url";
 
 async function getLeaderboardPreview() {
   try {
@@ -27,38 +35,142 @@ export default async function HomePage() {
   const allArticles = getAllArticles();
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+  const faqPreview = faqItems.slice(0, 4);
+
+  const organizationJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: `${brand.name} Fabushi`,
+    url: siteUrl("/"),
+    email: supportEmail,
+    description: brand.mission,
+    sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
+  };
+
+  const websiteJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: `${brand.name} Fabushi`,
+    url: siteUrl("/"),
+    inLanguage: "zh-CN",
+    description: "Fabushi 官网，统一承接品牌说明、下载入口、测试申请、FAQ 和内容专栏。",
+  };
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqPreview.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
 
   return (
     <main className="page-shell">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+
       <header className="hero">
         <SiteHeader />
 
-        <div className="hero-copy">
-          <p className="eyebrow">法布施官网</p>
-          <p className="brand-kicker">{brand.name}</p>
-          <h1>官网负责入口，小程序负责触达，主应用负责完整体验。</h1>
-          <p className="lede">{brand.mission}</p>
-          <div className="hero-actions">
-            <a className="primary-action" href={siteHref("/download")}>
-              查看下载入口
-            </a>
-            <a className="secondary-action" href={siteHref("/faq")}>
-              查看常见问题
-            </a>
+        <div className="hero-stage">
+          <div className="hero-copy">
+            <p className="eyebrow">法布施官网 · 品牌入口 / 下载引导 / 内容专栏</p>
+            <p className="brand-kicker">
+              {brand.name}
+              <span>Fabushi</span>
+            </p>
+            <h1>把佛法传播、修行记录与同行连接，放进一个更清晰的数字入口。</h1>
+            <p className="lede">
+              官网先负责解释方向、建立信任、呈现下载状态与内容路线；微信小程序负责轻触达；主应用继续承接上传、互动与沉浸式体验。
+            </p>
+            <div className="hero-actions">
+              <a className="primary-action" href={siteHref("/download")}>
+                查看下载入口
+              </a>
+              <a className="secondary-action" href={siteHref("/apply")}>
+                申请测试资格
+              </a>
+              <a className="secondary-action" href={siteHref("/faq")}>
+                查看常见问题
+              </a>
+            </div>
+            <div className="hero-signal-bar">
+              {homeTrustSignals.map((item) => (
+                <article key={item.title} className="signal-chip">
+                  <span className="detail-label">{item.title}</span>
+                  <strong>{item.summary}</strong>
+                </article>
+              ))}
+            </div>
           </div>
-        </div>
 
-        <div className="hero-panel">
-          <p>当前推进</p>
-          <strong>Next.js 官网 + Taro 微信小程序 + 现有 Workers API 共用</strong>
-          <span>现在官网会直接读取最新 beta 发布资产，并预留人工验收后的正式版发布入口。</span>
+          <aside className="hero-aside">
+            <div className="hero-panel">
+              <p>一句话理解</p>
+              <strong>{brand.name} 是一个围绕佛法传播、修行记录与同行连接展开的数字产品体系。</strong>
+              <span>
+                官网负责说明与引导，小程序负责微信生态触达，Flutter 主应用承接更完整的浏览、上传、互动与个人使用流程。
+              </span>
+            </div>
+            <div className="hero-proof-list">
+              <p className="detail-label">当前公开入口</p>
+              {releasePreview.map((item) => (
+                <a key={`${item.audience}-${item.platform}`} className="hero-proof-row" href={siteHref(item.primaryHref)}>
+                  <div>
+                    <strong>{item.title}</strong>
+                    <span>{item.description}</span>
+                  </div>
+                  <em>{item.status}</em>
+                </a>
+              ))}
+            </div>
+          </aside>
         </div>
       </header>
+
+      <section className="band" id="trust">
+        <div className="section-heading">
+          <p>为什么先做官网</p>
+          <h2>先把入口、分工、状态和信任信息讲清楚，转化路径才不会在第一屏就断掉。</h2>
+        </div>
+        <div className="narrative-grid">
+          {homeTrustSignals.map((item) => (
+            <article key={item.title} className="narrative-block">
+              <span className="detail-label">{item.title}</span>
+              <h3>{item.summary}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="audience">
+        <div className="section-heading">
+          <p>适用场景</p>
+          <h2>Fabushi 官网应该同时服务首次到达、内测申请、合作判断和搜索理解这四种场景。</h2>
+        </div>
+        <div className="use-case-grid">
+          {homeUseCases.map((item) => (
+            <article key={item.audience} className="use-case-block">
+              <span className="detail-label">{item.audience}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
-          <h2>官网负责品牌与入口，小程序负责轻场景触达，Flutter 继续承接重体验。</h2>
+          <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>
         </div>
         <div className="feature-grid">
           {homeHighlights.map((item) => (
@@ -73,7 +185,7 @@ export default async function HomePage() {
       <section className="band cinematic">
         <div className="section-heading">
           <p>下载入口</p>
-          <h2>beta 安装包和 TestFlight 状态已经能直接回流到官网入口里。</h2>
+          <h2>官网已经开始把公开可见的发布状态直接拉回页面，减少“想下载却找不到入口”的摩擦。</h2>
         </div>
         <div className="platform-strip">
           {releasePreview.map((item) => (
@@ -99,7 +211,7 @@ export default async function HomePage() {
       <section className="band alt" id="mini-program">
         <div className="section-heading">
           <p>微信小程序</p>
-          <h2>首期建议先覆盖轻浏览、榜单、公开档案与基础登录。</h2>
+          <h2>首期优先覆盖轻浏览、榜单、公开档案与基础登录，把最容易传播的场景先跑通。</h2>
         </div>
         <ol className="roadmap-list">
           {launchRoadmap.map((item) => (
@@ -111,12 +223,12 @@ export default async function HomePage() {
       <section className="band" id="architecture">
         <div className="section-heading">
           <p>技术架构</p>
-          <h2>一个前端 monorepo，共享接口层、类型、文案和部分纯业务逻辑。</h2>
+          <h2>一个前端 monorepo，共享接口层、类型、文案和部分纯业务逻辑，让官网与小程序各自发挥但不分家。</h2>
         </div>
         <div className="architecture-grid">
           <div>
             <h3>apps/web</h3>
-            <p>Next.js 官网，负责 SEO、落地页、功能说明、后续内容运营。</p>
+            <p>Next.js 官网，负责 SEO、落地页、功能说明、下载引导和后续内容运营。</p>
           </div>
           <div>
             <h3>apps/mp-wechat</h3>
@@ -124,11 +236,11 @@ export default async function HomePage() {
           </div>
           <div>
             <h3>packages/shared</h3>
-            <p>品牌信息、导航、固定文案、纯前端通用工具。</p>
+            <p>品牌信息、导航、固定文案、内容结构与纯前端通用工具。</p>
           </div>
           <div>
             <h3>packages/api-client</h3>
-            <p>统一对接现有 `flutter.ombhrum.com` API 与共享类型。</p>
+            <p>统一对接现有 flutter.ombhrum.com API 与共享类型。</p>
           </div>
         </div>
       </section>
@@ -136,11 +248,11 @@ export default async function HomePage() {
       <section className="band alt">
         <div className="section-heading">
           <p>接口复用</p>
-          <h2>官网已经直接接了现有排行榜接口，作为“后端继续共用”的第一块落地验证。</h2>
+          <h2>官网已经直接接入现有排行榜接口，证明它不是孤立宣传页，而是会逐步承接真实产品数据的入口层。</h2>
         </div>
         <div className="preview-list">
           {leaderboard.length === 0 ? (
-            <p className="empty-copy">当前没有拉到排行榜预览，页面仍可正常展示静态内容。</p>
+            <p className="empty-copy">当前没有拉到排行榜预览，页面仍会稳定展示其余静态与内容型模块。</p>
           ) : (
             leaderboard.map((item, index) => (
               <div key={item.username} className="preview-row">
@@ -156,7 +268,7 @@ export default async function HomePage() {
       <section className="band">
         <div className="section-heading">
           <p>内容专栏</p>
-          <h2>官网不只是一张首页，还要能持续承接路线、更新和专题内容。</h2>
+          <h2>官网不只是一张首页，它还要持续承接路线、更新、专题内容和后续可引用的公开信息。</h2>
         </div>
         <div className="editorial-list">
           {featuredArticles.map((item) => (
@@ -182,10 +294,10 @@ export default async function HomePage() {
       <section className="band alt">
         <div className="section-heading">
           <p>常见问题</p>
-          <h2>先把用户最容易问的几件事说清楚，官网才真正开始工作。</h2>
+          <h2>把用户最容易问的关键问题提前说清楚，也是在补强搜索和生成式引用最爱抓取的结构化信息。</h2>
         </div>
         <div className="faq-list">
-          {faqItems.slice(0, 3).map((item) => (
+          {faqPreview.map((item) => (
             <details key={item.question} className="faq-item">
               <summary>{item.question}</summary>
               <p>{item.answer}</p>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -174,11 +174,11 @@ export default async function HomePage() {
 
   return (
     <main className="page-shell">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applicationJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(governanceJsonLd) }} />
+      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
+      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
+      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(applicationJsonLd) }} />
+      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(governanceJsonLd) }} />
 
       <header className="hero">
         <SiteHeader />

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -57,6 +57,25 @@ export default async function HomePage() {
     description: "Fabushi 官网，统一承接品牌说明、下载入口、测试申请、FAQ 和内容专栏。",
   };
 
+  const applicationJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: `${brand.name} Fabushi`,
+    applicationCategory: "LifestyleApplication",
+    operatingSystem: "iOS, Android, Web, WeChat Mini Program",
+    inLanguage: "zh-CN",
+    url: siteUrl("/"),
+    downloadUrl: siteUrl("/download"),
+    description:
+      "Fabushi 法布施是一个围绕佛法传播、修行记录、公开档案、榜单与同行连接组织起来的多端产品体系。",
+    featureList: [
+      "佛法传播与内容入口",
+      "修行记录与隐私边界",
+      "公开档案与榜单浏览",
+      "下载引导、测试申请与 FAQ",
+    ],
+  };
+
   const faqJsonLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
@@ -74,6 +93,7 @@ export default async function HomePage() {
     <main className="page-shell">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(applicationJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
       <header className="hero">

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -61,6 +61,26 @@ export default async function HomePage() {
       detail: "测试申请、支持反馈与公开协作都有明确去处，不用靠猜测联系路径。",
     },
   ] as const;
+  const definitionBlocks = [
+    {
+      label: "Fabushi 是什么",
+      title: "一个围绕佛法传播、修行记录与同行连接组织起来的数字产品体系。",
+      description:
+        "官网不是主应用的替代品，而是统一承接理解、下载、测试申请、内容更新与公开协作的第一入口。",
+    },
+    {
+      label: "现在已经开放什么",
+      title: "官网、FAQ、下载状态、申请测试与内容专栏已经开始协同工作。",
+      description:
+        "第一次接触项目的人，已经可以先在这里完成理解、判断与下一步动作，而不必先进入应用再摸索。",
+    },
+    {
+      label: "还在逐步开放什么",
+      title: "微信小程序首期能力与更完整的主应用体验会继续按节奏释放。",
+      description:
+        "这让站点可以真实同步当前状态，而不是过度承诺尚未公开的功能或入口。",
+    },
+  ] as const;
 
   const organizationJsonLd = {
     "@context": "https://schema.org",
@@ -214,7 +234,31 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="trust">
+      <section className="band" id="definition">
+        <div className="section-heading">
+          <p>先定义清楚</p>
+          <h2>让用户和搜索系统都先搞清楚 Fabushi 是什么、已经开放什么、还在推进什么。</h2>
+        </div>
+        <div className="definition-grid">
+          {definitionBlocks.map((item) => (
+            <article key={item.label} className="definition-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+        <div className="inline-cta">
+          <a className="secondary-action" href={siteHref("/faq")}>
+            继续看完整 FAQ
+          </a>
+          <a className="secondary-action" href={siteHref("/download")}>
+            查看当前下载状态
+          </a>
+        </div>
+      </section>
+
+      <section className="band alt" id="trust">
         <div className="section-heading">
           <p>为什么先做官网</p>
           <h2>先把入口、分工、状态和信任信息讲清楚，转化路径才不会在第一屏就断掉。</h2>
@@ -230,7 +274,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band alt" id="audience">
+      <section className="band" id="audience">
         <div className="section-heading">
           <p>适用场景</p>
           <h2>Fabushi 官网应该同时服务首次到达、内测申请、合作判断和搜索理解这四种场景。</h2>
@@ -246,7 +290,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="channel-roles">
+      <section className="band alt" id="channel-roles">
         <div className="section-heading">
           <p>入口分工</p>
           <h2>不是每个人都该直接跳进同一个端里，官网要先告诉你该从哪里开始。</h2>
@@ -270,7 +314,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band alt" id="capabilities">
+      <section className="band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
           <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -107,6 +107,34 @@ export default async function HomePage() {
       ctaLabel: "查看下载状态",
     },
   ] as const;
+  const entryReadiness = [
+    {
+      label: "现在适合继续往下走",
+      title: "你已经准备好进入下载、申请或联系路径。",
+      description:
+        "如果你符合这些情况，官网应该帮助你尽快做决定，而不是继续把你留在抽象介绍里。",
+      bullets: [
+        "你已经明确想判断当前有没有适合自己的下载或测试入口。",
+        "你愿意接受 beta 节奏，或者愿意先进入申请与反馈流程。",
+        "你需要先把官网、小程序和主应用的分工看清楚，再进入具体入口。",
+      ],
+      href: "/download",
+      ctaLabel: "去看下载状态",
+    },
+    {
+      label: "现在更适合先理解和观望",
+      title: "你不必因为看见入口就立刻下载或申请。",
+      description:
+        "如果你更符合这些情况，先看 FAQ、隐私说明和路径定义，反而更能减少误判、反复和落差。",
+      bullets: [
+        "你现在只接受稳定正式版，不希望承担测试波动或资格等待。",
+        "你还没判断清楚自己是来下载、申请测试、反馈问题，还是只想先了解项目。",
+        "你期待官网已经覆盖所有深度功能体验，而不是先承担说明、筛选和引导角色。",
+      ],
+      href: "/faq",
+      ctaLabel: "先看 FAQ",
+    },
+  ] as const;
 
   const organizationJsonLd = {
     "@context": "https://schema.org",
@@ -344,6 +372,30 @@ export default async function HomePage() {
               <span className="detail-label">{item.audience}</span>
               <h3>{item.title}</h3>
               <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band" id="readiness">
+        <div className="section-heading">
+          <p>进入判断</p>
+          <h2>官网不该默认每个访问者都应该立刻下载，它更应该先帮人判断“现在适不适合继续往下走”。</h2>
+        </div>
+        <div className="compare-grid">
+          {entryReadiness.map((item) => (
+            <article key={item.label} className="compare-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <ul className="compare-list">
+                {item.bullets.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
             </article>
           ))}
         </div>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -3,6 +3,7 @@ import {
   brand,
   contactChannels,
   faqItems,
+  homeActionPaths,
   homeHighlights,
   homeTrustSignals,
   homeUseCases,
@@ -154,6 +155,25 @@ export default async function HomePage() {
           </aside>
         </div>
       </header>
+
+      <section className="band quick-paths" id="paths">
+        <div className="section-heading">
+          <p>快速路径</p>
+          <h2>第一次来到这里，通常只需要先完成这三件事里的其中一件。</h2>
+        </div>
+        <div className="path-grid">
+          {homeActionPaths.map((item) => (
+            <article key={item.title} className="path-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <a className="path-link" href={siteHref(item.href)}>
+                {item.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="band" id="trust">
         <div className="section-heading">

--- a/frontend/apps/web/src/app/privacy/page.tsx
+++ b/frontend/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,195 @@
+import type { Metadata } from "next";
+import { brand, contactChannels } from "@fabushi/shared";
+import { SiteFooter } from "../../components/site-footer";
+import { SiteHeader } from "../../components/site-header";
+import { siteHref, siteUrl } from "../../lib/site-url";
+
+const privacySections = [
+  {
+    label: "账户与身份",
+    title: "只处理建立账户、维持登录和回应支持请求所必需的信息。",
+    description:
+      "当你申请测试、订阅发布通知或联系支持时，我们会优先收集完成这件事所需的最少信息，而不是为了营销而扩大范围。",
+    points: [
+      "常见信息包括邮箱地址、测试申请说明和你主动提供的设备信息。",
+      "如果后续开放更多登录方式，会先说明用途和对应的处理边界。",
+      "不会因为浏览官网而默认要求你先注册账户。",
+    ],
+  },
+  {
+    label: "设备与使用",
+    title: "只在改进可用性、排查问题和保持服务稳定时使用必要的技术信息。",
+    description:
+      "官网、下载页和申请测试页的核心目标是帮助你判断 Fabushi 是否适合自己，因此我们更重视可用性与公开状态说明，而不是追求过度追踪。",
+    points: [
+      "可能会记录基础的设备、浏览器和访问日志，用于错误排查与站点运维。",
+      "如果页面需要接入真实发布状态或公开数据，会优先说明其来源与展示目的。",
+      "不会把与你无关的技术信息包装成必须同意的前置条件。",
+    ],
+  },
+  {
+    label: "内容与互动",
+    title: "你主动提交的申请、反馈和问题说明，只会用于对应的沟通与处理流程。",
+    description:
+      "申请测试、反馈问题或讨论合作时，最重要的是把你的意图和后续去向讲清楚，让每一条信息都知道自己该落到哪里。",
+    points: [
+      "测试申请会用于资格筛选、下载通知和后续反馈联络。",
+      "问题反馈会用于排查 bug、改进体验和补充 FAQ。",
+      "合作沟通会用于判断是否需要进一步邮件或仓库协作。",
+    ],
+  },
+  {
+    label: "数据用途",
+    title: "收集信息的目的主要是解释产品、承接下载、安排测试和回应支持。",
+    description:
+      "Fabushi 当前官网的职责很明确：先帮助人理解产品、判断状态、找到入口，再进入更深的使用流程，因此数据用途也应保持克制和可解释。",
+    points: [
+      "用于发送下载状态、测试资格和必要的支持回复。",
+      "用于维护 FAQ、内容专栏和发布说明的准确性。",
+      "用于保障站点安全、降低滥用和处理公开反馈。",
+    ],
+  },
+  {
+    label: "你的控制权",
+    title: "你可以询问、更新或删除与自己相关的信息，并要求我们解释处理范围。",
+    description:
+      "无论你是第一次申请测试，还是已经在和团队沟通，都应该拥有清楚的退出和确认路径，而不是被迫留在一个不透明的流程里。",
+    points: [
+      "可以通过支持邮箱询问当前保留了哪些与你相关的申请或反馈信息。",
+      "可以要求更新错误信息，或在不影响必要合规与安全记录的前提下申请删除。",
+      "如果后续出现范围明显变化的处理方式，官网会先更新说明。",
+    ],
+  },
+  {
+    label: "更新与联系",
+    title: "隐私说明会随着官网、下载链路和支持流程的变化而更新。",
+    description:
+      "这页不是为了凑一个合规链接，而是为了让首次访问、测试申请和长期关注 Fabushi 的人，都能先看到边界、支持方式和更新节奏。",
+    points: [
+      "当官网新增关键入口、表单或数据展示方式时，会同步修订这页说明。",
+      "如果你对数据边界有疑问，优先通过公开支持邮箱联系。",
+      "与下载、FAQ 和联系页保持互相可跳转，减少来回查找。",
+    ],
+  },
+] as const;
+
+export const metadata: Metadata = {
+  title: `隐私说明 | ${brand.name}`,
+  description: "查看 Fabushi 对账户、设备、内容互动、支持通道和用户权利的公开隐私说明。",
+  alternates: {
+    canonical: siteUrl("/privacy"),
+  },
+  keywords: ["Fabushi 隐私说明", "法布施隐私政策", "法布施支持", "法布施测试申请", "Fabushi 数据边界"],
+};
+
+export default function PrivacyPage() {
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
+  const supportHref = contactChannels.find((item) => item.href.startsWith("mailto:"))?.href ?? "mailto:support@fabushi.com";
+
+  const privacyPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `${brand.name} 隐私说明`,
+    url: siteUrl("/privacy"),
+    inLanguage: "zh-CN",
+    description: "Fabushi 对账户、设备、内容互动、支持通道和用户权利的公开隐私说明。",
+    about: {
+      "@type": "Organization",
+      name: `${brand.name} Fabushi`,
+      url: siteUrl("/"),
+      email: supportEmail,
+    },
+  };
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "首页",
+        item: siteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "隐私说明",
+        item: siteUrl("/privacy"),
+      },
+    ],
+  };
+
+  return (
+    <main className="inner-page">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(privacyPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <section className="inner-hero">
+        <SiteHeader />
+        <div className="inner-copy">
+          <p className="eyebrow">隐私说明</p>
+          <h1>先把信息边界、支持路径和用户控制权讲清楚，再谈下载、申请和长期使用。</h1>
+          <p className="lede">
+            这页不是只给审核或法务看的补充链接，而是让第一次接触 Fabushi 的人，也能先判断这套产品在数据处理、支持响应和公开说明上是否足够可信。
+          </p>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading">
+          <p>我们怎么处理信息</p>
+          <h2>官网先服务理解、下载和测试申请，所以隐私边界也应该保持克制、清楚、可复查。</h2>
+        </div>
+        <div className="governance-grid">
+          {privacySections.map((item) => (
+            <article key={item.label} className="governance-card">
+              <span className="detail-label">{item.label}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+              <ul className="channel-list">
+                {item.points.map((point) => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading">
+          <p>联系与下一步</p>
+          <h2>如果你关心测试申请、账户边界或反馈处理方式，先走这些公开入口。</h2>
+        </div>
+        <div className="contact-grid">
+          <a className="contact-card" href={supportHref}>
+            <span>支持邮箱</span>
+            <strong>{supportEmail}</strong>
+            <p>适合询问测试申请、下载通知、数据边界和反馈处理方式。</p>
+          </a>
+          <a className="contact-card" href={siteHref("/contact")}>
+            <span>联系页</span>
+            <strong>查看公开通道</strong>
+            <p>统一查看官网域名、仓库入口和对外沟通方式。</p>
+          </a>
+          <a className="contact-card" href={siteHref("/download")}>
+            <span>下载状态</span>
+            <strong>回到下载页</strong>
+            <p>先确认当前开放什么、还在准备什么，再决定下一步动作。</p>
+          </a>
+        </div>
+        <div className="inline-cta">
+          <a className="primary-action" href={supportHref}>
+            联系支持
+          </a>
+          <a className="secondary-action" href={siteHref("/faq")}>
+            查看常见问题
+          </a>
+        </div>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -12,7 +12,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/api/"],
       },
     ],
-    host: new URL(siteUrl("/")).origin,
     sitemap: siteUrl("/sitemap.xml"),
+    host: new URL(siteUrl("/")).origin,
   };
 }

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -12,7 +12,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/api/"],
       },
     ],
-    host: siteUrl("/"),
+    host: new URL(siteUrl("/")).origin,
     sitemap: siteUrl("/sitemap.xml"),
   };
 }

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -5,10 +5,14 @@ export const dynamic = "force-static";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    host: siteUrl("/"),
     sitemap: siteUrl("/sitemap.xml"),
   };
 }

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -7,35 +7,28 @@ export const dynamic = "force-static";
 const staticRoutes = ["/", "/download", "/apply", "/faq", "/privacy", "/contact", "/insights"] as const;
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const routes: MetadataRoute.Sitemap = staticRoutes.map((path) => ({
-    url: siteUrl(path),
-    lastModified: "2026-05-08",
-    changeFrequency:
-      path === "/"
-        ? "weekly"
-        : path === "/download" || path === "/faq"
-          ? "weekly"
-          : path === "/privacy"
-            ? "monthly"
-            : "monthly",
+  const pages: MetadataRoute.Sitemap = staticRoutes.map((route) => ({
+    url: siteUrl(route),
+    lastModified: route === "/privacy" ? "2026-05-08" : new Date(),
+    changeFrequency: route === "/" ? "weekly" : route === "/download" || route === "/faq" ? "weekly" : "monthly",
     priority:
-      path === "/"
+      route === "/"
         ? 1
-        : path === "/download" || path === "/faq"
+        : route === "/download" || route === "/faq"
           ? 0.9
-          : path === "/apply"
+          : route === "/apply"
             ? 0.85
-            : path === "/privacy"
+            : route === "/privacy"
               ? 0.8
               : 0.75,
   }));
 
-  const articleRoutes: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
+  const articlePages: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
     url: siteUrl(`/insights/${article.slug}`),
-    lastModified: article.publishedAt,
+    lastModified: new Date(article.publishedAt),
     changeFrequency: "monthly",
     priority: article.featured ? 0.8 : 0.65,
   }));
 
-  return [...routes, ...articleRoutes];
+  return [...pages, ...articlePages];
 }

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -7,7 +7,7 @@ export const dynamic = "force-static";
 export default function sitemap(): MetadataRoute.Sitemap {
   const routes: MetadataRoute.Sitemap = ["/", "/download", "/apply", "/faq", "/contact", "/insights"].map((path) => ({
     url: siteUrl(path),
-    lastModified: "2026-05-06",
+    lastModified: "2026-05-07",
   }));
 
   const articleRoutes = getAllArticles().map((article) => ({

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -4,14 +4,30 @@ import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
 
-const staticRoutes = ["/", "/download", "/apply", "/faq", "/contact", "/insights"] as const;
+const staticRoutes = ["/", "/download", "/apply", "/faq", "/privacy", "/contact", "/insights"] as const;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const routes: MetadataRoute.Sitemap = staticRoutes.map((path) => ({
     url: siteUrl(path),
-    lastModified: "2026-05-07",
-    changeFrequency: path === "/" ? "weekly" : path === "/download" || path === "/faq" ? "weekly" : "monthly",
-    priority: path === "/" ? 1 : path === "/download" || path === "/faq" ? 0.9 : path === "/apply" ? 0.85 : 0.75,
+    lastModified: "2026-05-08",
+    changeFrequency:
+      path === "/"
+        ? "weekly"
+        : path === "/download" || path === "/faq"
+          ? "weekly"
+          : path === "/privacy"
+            ? "monthly"
+            : "monthly",
+    priority:
+      path === "/"
+        ? 1
+        : path === "/download" || path === "/faq"
+          ? 0.9
+          : path === "/apply"
+            ? 0.85
+            : path === "/privacy"
+              ? 0.8
+              : 0.75,
   }));
 
   const articleRoutes: MetadataRoute.Sitemap = getAllArticles().map((article) => ({

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -4,15 +4,21 @@ import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
 
+const staticRoutes = ["/", "/download", "/apply", "/faq", "/contact", "/insights"] as const;
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const routes: MetadataRoute.Sitemap = ["/", "/download", "/apply", "/faq", "/contact", "/insights"].map((path) => ({
+  const routes: MetadataRoute.Sitemap = staticRoutes.map((path) => ({
     url: siteUrl(path),
     lastModified: "2026-05-07",
+    changeFrequency: path === "/" ? "weekly" : path === "/download" || path === "/faq" ? "weekly" : "monthly",
+    priority: path === "/" ? 1 : path === "/download" || path === "/faq" ? 0.9 : path === "/apply" ? 0.85 : 0.75,
   }));
 
-  const articleRoutes = getAllArticles().map((article) => ({
+  const articleRoutes: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
     url: siteUrl(`/insights/${article.slug}`),
     lastModified: article.publishedAt,
+    changeFrequency: "monthly",
+    priority: article.featured ? 0.8 : 0.65,
   }));
 
   return [...routes, ...articleRoutes];

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -11,6 +11,7 @@ export function SiteFooter() {
         <a href={siteHref("/download")}>下载入口</a>
         <a href={siteHref("/apply")}>申请测试</a>
         <a href={siteHref("/faq")}>常见问题</a>
+        <a href={siteHref("/privacy")}>隐私说明</a>
         <a href={siteHref("/contact")}>联系</a>
         <a href={siteHref("/insights")}>内容专栏</a>
         <a href="mailto:support@fabushi.com">support@fabushi.com</a>

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -5,14 +5,20 @@ export function SiteHeader() {
   return (
     <nav className="site-nav" aria-label="主导航">
       <a className="site-wordmark" href={siteHref("/")}>
-        Fabushi
+        <span>Fabushi</span>
+        <small>法布施官网</small>
       </a>
-      <div className="site-nav-links">
-        {primaryNavigation.map((item) => (
-          <a key={item.href} href={siteHref(item.href)}>
-            {item.label}
-          </a>
-        ))}
+      <div className="site-nav-links-wrap">
+        <div className="site-nav-links">
+          {primaryNavigation.map((item) => (
+            <a key={item.href} href={siteHref(item.href)}>
+              {item.label}
+            </a>
+          ))}
+        </div>
+        <a className="nav-cta" href={siteHref("/download")}>
+          下载入口
+        </a>
       </div>
     </nav>
   );

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -57,6 +57,30 @@ export const homeUseCases = [
   },
 ] as const;
 
+export const homeActionPaths = [
+  {
+    label: "第一次了解",
+    title: "先快速看懂 Fabushi 是什么，以及官网为什么这样组织。",
+    description: "如果你是第一次来到这里，先看 FAQ 和首页结构说明，判断这是不是你要找的产品方向。",
+    href: "/faq",
+    ctaLabel: "先看常见问题",
+  },
+  {
+    label: "准备进入",
+    title: "先确认当前是否有可公开下载或可申请的测试入口。",
+    description: "下载页会持续承接 Android beta、iOS TestFlight 和正式版的公开状态，避免用户在错误页面里兜圈。",
+    href: "/download",
+    ctaLabel: "查看下载状态",
+  },
+  {
+    label: "准备沟通",
+    title: "想申请测试、反馈问题或讨论合作时，直接进入正确通道。",
+    description: "把申请测试、支持反馈和合作询问拆成明确入口，能减少很多没有上下文的来回邮件。",
+    href: "/apply",
+    ctaLabel: "进入申请通道",
+  },
+] as const;
+
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -81,6 +81,33 @@ export const homeActionPaths = [
   },
 ] as const;
 
+export const homeChannelRoles = [
+  {
+    channel: "官网",
+    title: "先负责解释方向、建立信任、给出下载与沟通入口。",
+    description: "适合第一次接触 Fabushi、想先判断项目定位、想看下载状态，或需要专题内容和 FAQ 的访问者。",
+    bestFor: ["首页与 FAQ 快速理解", "查看下载状态与发布说明", "进入申请测试或合作沟通"],
+    href: "/",
+    ctaLabel: "继续浏览官网",
+  },
+  {
+    channel: "微信小程序",
+    title: "优先承接微信生态里的轻触达、轻浏览与公开信息分发。",
+    description: "适合想在微信里快速查看榜单、公开档案与轻量内容入口的人，不强求先进入完整主应用。",
+    bestFor: ["微信内轻触达", "公开档案与榜单浏览", "低门槛内容传播入口"],
+    href: "/insights/wechat-mini-program-phase-one",
+    ctaLabel: "查看小程序路线",
+  },
+  {
+    channel: "主应用",
+    title: "继续承接更完整的修行记录、上传分享、互动与沉浸式体验。",
+    description: "适合已经确定要深入使用 Fabushi、愿意参与测试，或需要完整个人流程与重交互能力的用户。",
+    bestFor: ["更完整的个人使用流程", "上传与互动等重交互场景", "参与 iOS / Android 内测"],
+    href: "/download",
+    ctaLabel: "查看主应用入口",
+  },
+] as const;
+
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -1,15 +1,15 @@
 export const homeHighlights = [
   {
-    title: "全球法布施传播",
-    description: "围绕内容传播、上传分享、回向记录与可见榜单，建立持续增长的善意网络。",
+    title: "传播入口更清楚",
+    description: "把项目定位、下载状态、申请测试和内容入口收拢到同一官网里，减少用户第一次接触时的理解成本。",
   },
   {
-    title: "修行记录与隐私控制",
-    description: "保留公开展示与私密修行的边界，让个人节奏与社交互动能自然共存。",
+    title: "修行记录更有边界",
+    description: "同时照顾公开传播、个人修行记录与隐私控制，让分享、回向与安静练习可以并存。",
   },
   {
-    title: "轻社群与共修关系",
-    description: "通过关注、排行榜、共修小组和公开档案，帮助用户更容易找到同行者。",
+    title: "多端协作不再割裂",
+    description: "官网负责理解与转化，小程序负责轻触达，主应用负责完整体验，三者围绕同一套品牌与发布节奏协同工作。",
   },
 ] as const;
 
@@ -68,9 +68,9 @@ export const primaryNavigation = [
 ] as const;
 
 export const launchRoadmap = [
-  "先上线官网，承接品牌介绍、功能说明、下载指引和后续活动落地页。",
-  "同步建设微信小程序首期版本，优先覆盖轻浏览、榜单、公开档案和基础登录。",
-  "继续把更重的创作、上传和沉浸式体验保留在 Flutter 主应用里。",
+  "先把官网做成稳定的公开入口，集中承接项目介绍、下载状态、FAQ、内容更新和联系路径。",
+  "同步推进微信小程序首期版本，优先覆盖轻浏览、榜单、公开档案和基础登录等轻场景触达能力。",
+  "继续把更完整的上传、沉浸式浏览、个人中心和重交互流程保留在 Flutter 主应用里。",
 ] as const;
 
 export const downloadOptions = [
@@ -105,36 +105,41 @@ export const downloadOptions = [
 ] as const;
 
 export const downloadStatusNotes = [
-  "当前仓库里还没有可直接公开挂出的 App Store、TestFlight 或 APK 正式下载直链。",
-  "官网先把各平台状态、职责和等待名单入口讲清楚，避免用户点进来却落到空页面。",
-  "一旦正式下载链接可公开，优先替换 downloadOptions 中的对应入口即可，不需要重做页面结构。",
+  "官网现在会直接承接 Android beta、iOS TestFlight 和正式版发布状态，不再只是一个泛泛的等待名单页面。",
+  "当正式下载链接尚未公开时，页面会优先说明状态、适用人群和下一步动作，避免用户点进来却找不到判断依据。",
+  "一旦正式下载链接可公开，优先替换对应入口即可，不需要重新改整页结构。",
 ] as const;
 
 export const faqItems = [
   {
+    question: "法布施 Fabushi 是什么？",
+    answer:
+      "Fabushi 是一个围绕佛法传播、修行记录、善意分享与社群连接组织起来的多端产品入口。官网负责解释与引导，小程序负责轻触达，主应用负责完整体验。",
+  },
+  {
     question: "官网、微信小程序和 Flutter 主应用分别承担什么角色？",
     answer:
-      "官网负责品牌说明、下载入口、FAQ 和内容运营；微信小程序负责微信生态里的轻触达；Flutter 主应用继续承接完整的沉浸式体验和重交互流程。",
+      "官网负责品牌说明、下载入口、FAQ、发布说明和内容运营；微信小程序负责微信生态里的轻浏览与轻交互；Flutter 主应用继续承接更完整的沉浸式体验和重交互流程。",
+  },
+  {
+    question: "Fabushi 现在可以下载吗？",
+    answer:
+      "可以先通过官网查看 Android beta、iOS TestFlight 与正式版的当前状态。可公开下载时，官网会直接给出入口；暂未公开时，会明确说明申请测试或等待下一步发布的方式。",
   },
   {
     question: "为什么不直接用 Flutter Web 同时做官网和小程序？",
     answer:
-      "官网需要更好的 SEO、内容结构和首屏控制，小程序又有自己的运行规范。拆成 Next.js + Taro 可以减少后续返工，同时继续复用现有后端与业务层。",
+      "官网需要更清晰的 SEO、内容结构、首屏表达和发布信息管理，小程序也有自己的运行规范。拆成 Next.js 官网和 Taro 小程序，可以减少后续返工，同时继续复用现有后端与业务层。",
   },
   {
-    question: "官网和小程序会不会变成两套完全分裂的系统？",
+    question: "Fabushi 适合哪些人先关注？",
     answer:
-      "不会。新前端 monorepo 会持续共享 API client、类型、品牌文案和部分纯业务逻辑，差异主要保留在各自的页面表现层。",
-  },
-  {
-    question: "小程序首期最先会上什么？",
-    answer:
-      "优先是轻浏览、榜单、公开档案和基础登录，先把传播入口和社交发现路径打通，再逐步补更复杂的内容创作与上传流程。",
+      "适合正在做佛法内容传播、需要安静记录修行、希望与共修同行者建立连接，或者想参与传播合作与渠道联动的人。官网会优先帮助这些人快速判断自己该走哪条入口。",
   },
   {
     question: "为什么下载页现在不再只是等待名单入口？",
     answer:
-      "因为官网已经开始直接读取 GitHub Release 的 Android beta 安装包、TestFlight 上传状态，以及人工验收后发布的正式版信息。这样下载页会跟着发布链路一起更新，而不是靠手动改文案。",
+      "因为官网已经开始直接读取 GitHub Release 的 Android beta 安装包、TestFlight 上传状态，以及人工验收后发布的正式版信息。这样下载页会跟着发布链路一起更新，而不是只靠手工改文案。",
   },
 ] as const;
 
@@ -143,19 +148,19 @@ export const contactChannels = [
     label: "支持邮箱",
     value: "support@fabushi.com",
     href: "mailto:support@fabushi.com",
-    note: "下载申请、测试资格、问题反馈和合作沟通统一从这里进入。",
+    note: "测试申请、下载问题、反馈收集和合作沟通统一从这里进入，避免入口分散。",
   },
   {
     label: "官网域名",
     value: "fabushi.ombhrum.com",
     href: "https://fabushi.ombhrum.com",
-    note: "后续会作为官网、专题页和正式下载指引的统一入口。",
+    note: "长期对外入口会统一收拢到官网，便于承接下载、FAQ、专题内容和活动页面。",
   },
   {
     label: "GitHub 仓库",
     value: "bhrumom/fabushi",
     href: "https://github.com/bhrumom/fabushi",
-    note: "适合查看项目进展、提交 issue 和跟踪公开开发记录。",
+    note: "适合查看公开开发记录、发布资产、issue 反馈与持续迭代进展。",
   },
 ] as const;
 

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -13,6 +13,50 @@ export const homeHighlights = [
   },
 ] as const;
 
+export const homeTrustSignals = [
+  {
+    title: "平台分工清晰",
+    summary: "官网负责解释与引导，小程序负责轻触达，主应用负责完整体验。",
+    description:
+      "用户第一次进入时就能知道该从哪里了解产品、从哪里申请测试、从哪里进入更深度的使用流程，减少入口混乱和跳失。",
+  },
+  {
+    title: "发布状态可见",
+    summary: "下载页会直接承接 beta 安装包、TestFlight 状态和正式版发布说明。",
+    description:
+      "官网不再只是静态等待名单，而是开始连接真实发布链路，让用户、合作方和搜索引擎都能看到当前可获得的入口。",
+  },
+  {
+    title: "内容能够持续累积",
+    summary: "除了首页，官网还承接路线、专题内容、更新说明和 FAQ。",
+    description:
+      "这让站点既能做品牌入口，也能沉淀长期可搜索、可引用、可分享的内容资产，而不是一页式说明页。",
+  },
+] as const;
+
+export const homeUseCases = [
+  {
+    audience: "新用户",
+    title: "先理解产品，再决定从哪个入口进入。",
+    description: "官网优先解释 Fabushi 是什么、适合谁、当前能做什么，以及 iOS、Android、微信小程序分别是什么状态。",
+  },
+  {
+    audience: "内测申请者",
+    title: "快速找到申请路径、下载状态和反馈方式。",
+    description: "把等待名单、测试资格、安装包说明和反馈邮箱放在一条清晰路径里，减少用户往返询问。",
+  },
+  {
+    audience: "合作与渠道方",
+    title: "更快判断项目方向、公开能力和可合作的切入点。",
+    description: "官网把产品定位、公开协作方式、内容专栏和联系入口整理清楚，方便外部伙伴快速完成判断。",
+  },
+  {
+    audience: "生成式搜索与搜索引擎",
+    title: "更容易准确理解 Fabushi 的平台结构和价值主张。",
+    description: "定义、场景、FAQ、内容专栏和可见发布状态会一起组成更容易被引用和总结的站点语义结构。",
+  },
+] as const;
+
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },


### PR DESCRIPTION
## 这轮改了什么

- 在官网首页新增“信任与治理”区块，把隐私边界、反馈治理和发布节奏直接放进首屏之后的核心叙事
- 新增 `privacy` 页面，正式承接隐私说明、用户控制权、支持邮箱与跳转路径
- 将首页 FAQ 区块与页脚补上隐私入口，减少用户在测试申请、下载和反馈前的疑虑
- 将 `privacy` 纳入站点地图，强化搜索与生成式搜索对站点结构的理解
- 调整官网样式，让新增治理模块和隐私页保持与现有官网一致的高级、克制视觉节奏

## 为什么这样改

- 现有官网已经把“这是什么、如何下载、如何申请测试”讲得更清楚了，这一轮最值得补的是“是否可信、边界是否明确、出现问题该找谁”
- 对首次到达用户来说，隐私说明、反馈闭环和发布状态同步，是决定是否继续申请测试或留下联系方式的关键
- 对搜索引擎和 AI 引擎来说，独立隐私页、首页治理区块和更完整的结构化信息，会让 Fabushi 的站点语义更完整，更容易被准确引用

## 这轮重点文件

- `frontend/apps/web/src/app/page.tsx`
- `frontend/apps/web/src/app/globals.css`
- `frontend/apps/web/src/app/privacy/page.tsx`
- `frontend/apps/web/src/app/sitemap.ts`
- `frontend/apps/web/src/components/site-footer.tsx`

## 验证说明

- 已复查首页新增的治理区块、FAQ 新增隐私入口、新隐私页与 sitemap 更新内容都已写入分支
- 当前环境无法运行本地 Next.js 构建或截图验证，因为无法直接拉取仓库到本地工作区，只能通过 GitHub 连接器读取与更新文件

## 后续仍值得继续推进

- 下载页继续补“不同平台适合谁”的更清晰对比
- 联系页与申请测试页可继续增加更明确的响应预期与处理流程说明
- 内容专栏可以继续扩展围绕隐私边界、测试资格和产品分工的问题式文章

## 为什么这次直接开 ready PR

- 原 draft `#230` 的 head `99efc7efacb6f9987f93b940659179e4db9a89f1` 仍没有任何 workflow run / combined status
- connector 的 `draft -> ready for review` 接口继续不可靠，之前已在 `#228` 上复现过 schema 错误
- 为避免把这条官网升级线继续停在 draft 中间态，这里按仓库 runbook 直接基于同一 head branch 重开 ready PR，重新给必需门禁挂载机会