### PR TITLE
[codex] 修复 profile rename 的 free_trial_end_date 漏迁移

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -9,7 +9,12 @@ import sys
 publish_workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
 deploy_workflow = Path('.github/workflows/deploy-production.yml').read_text(encoding='utf-8')
 co_practice_migration = Path('fabushi/web/migrations/20260506_co_practice_groups.sql')
+free_trial_migration = Path('fabushi/web/migrations/20260508_users_free_trial_end_date.sql')
 d1_retry_helper = Path('.github/scripts/run-wrangler-d1-migrations.sh')
+schema_sql = Path('fabushi/web/schema.sql').read_text(encoding='utf-8')
+schema_v2_sql = Path('fabushi/web/schema_v2.sql').read_text(encoding='utf-8')
+profile_handler = Path('fabushi/web/src/handlers/profile.js').read_text(encoding='utf-8')
+profile_test = Path('fabushi/web/tests/profile.test.js').read_text(encoding='utf-8')
 
 checkout_match = re.search(
     r"- name: Checkout source for version metadata\n(?P<body>.*?)\n\s*- name: Prepare release assets",
@@ -101,6 +106,26 @@ else:
     ):
         if forbidden in migration_text:
             missing.append(f'co-practice migration should not re-add existing meditation_records columns: {forbidden}')
+
+if 'free_trial_end_date' not in schema_sql:
+    missing.append('schema.sql missing free_trial_end_date')
+if 'free_trial_end_date' not in schema_v2_sql:
+    missing.append('schema_v2.sql missing free_trial_end_date')
+if 'free_trial_end_date' not in profile_handler:
+    missing.append('profile.js missing free_trial_end_date usage')
+if 'free_trial_end_date' not in profile_test:
+    missing.append('profile.test.js missing free_trial_end_date fixture coverage')
+
+if not free_trial_migration.exists():
+    missing.append('fabushi/web/migrations/20260508_users_free_trial_end_date.sql')
+else:
+    migration_text = free_trial_migration.read_text(encoding='utf-8')
+    for required in (
+        'ALTER TABLE users ADD COLUMN free_trial_end_date TEXT;',
+        'profile username-rename flow',
+    ):
+        if required not in migration_text:
+            missing.append(f'free-trial migration missing: {required}')
 
 if missing:
     sys.stderr.write(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,10 @@ jobs:
             /.github/workflows/**
             /.github/scripts/**
             /fabushi/web/migrations/**
+            /fabushi/web/schema.sql
+            /fabushi/web/schema_v2.sql
+            /fabushi/web/src/handlers/profile.js
+            /fabushi/web/tests/profile.test.js
 
       - name: Validate publish release workflow guardrail
         shell: bash

--- a/fabushi/web/migrations/20260508_users_free_trial_end_date.sql
+++ b/fabushi/web/migrations/20260508_users_free_trial_end_date.sql
@@ -1,0 +1,6 @@
+-- Managed D1 migration for the profile username-rename flow.
+-- `free_trial_end_date` already exists in schema.sql/schema_v2.sql and is
+-- referenced by the live profile handler plus release-gate E2E tests, so the
+-- release-managed migration must add it for existing databases too.
+
+ALTER TABLE users ADD COLUMN free_trial_end_date TEXT;


### PR DESCRIPTION
## 根因

`main` 上最新几次 `CD - Staging API gated production deploy` 都在 `Staging API E2E and smoke gate` 失败，失败点一致落在 `tests/staging-profile-api.spec.js` 的用户名改名回滚路径。

最新失败 run `25535049071` 的日志已经给出确定性根因：

- `POST /api/auth/update-profile` 在用户名改名流里返回 `500`
- Worker 返回 `D1_ERROR: table users has no column named free_trial_end_date: SQLITE_ERROR`
- `profile.js`、`profile.test.js`、`schema.sql` 与 `schema_v2.sql` 都已经把 `free_trial_end_date` 视为现有字段
- 但 release-managed `fabushi/web/migrations/` 目录里缺少把这列补到已存在数据库的正式 migration

这不是测试波动，而是典型的 schema drift：代码与 schema 文件已依赖该列，但主线 deploy 对现有 D1 数据库并没有对应迁移。

## 这轮修复

1. 新增 `fabushi/web/migrations/20260508_users_free_trial_end_date.sql`
   - 把 `free_trial_end_date` 通过 release-managed D1 migration 补到现有 `users` 表
   - 让 staging / production 在后续 deploy 时都能通过同一条版本化路径拿到该列

2. 补强 `.github/scripts/check-publish-cd-release.sh`
   - 把 `schema.sql`、`schema_v2.sql`、`profile.js`、`profile.test.js` 与新的 migration 一起纳入 guardrail
   - 明确要求：既然发布链路与 profile rename 测试已依赖 `free_trial_end_date`，仓库中就必须存在对应 release-managed migration
   - 防止后续再出现“schema 文件与运行时代码已经前进，但 migrations 目录没有跟上”的同类回归

## 为什么这样修

- 当前主线失败发生在 staging E2E 命中的真实运行时数据库，而不是纯本地测试环境
- 只改测试或只改 schema 文件都不能修复现有 D1 数据库缺列的问题
- 把修复放进 `fabushi/web/migrations/` 才能真正进入 `main -> CD` 的正式闭环
- 同时补 guardrail，避免以后再靠线上 gate 才发现同类问题

## 验证

- 复核最新失败 job `74949329239`：错误签名稳定为 `table users has no column named free_trial_end_date`
- 复核仓库当前代码：`profile.js`、`profile.test.js`、`schema.sql`、`schema_v2.sql` 都已使用或声明该列
- 对新增 guardrail 脚本做了 `bash -n` 语法检查

## 预期闭环

- 这条 PR 合入后，后续 mainline CD 在 `Apply development D1 migrations` 阶段会把缺列补上
- `Staging API E2E and smoke gate` 应不再因为该列缺失而在 profile rename 路径返回 `500`
- 相关自动 failure issues 可在主线验证通过后再统一收口

关联 issue：#244 #242 #241 #237