### PR TITLE
[codex] 修复 CD profile rename 缺少支付列迁移

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -10,6 +10,7 @@ publish_workflow = Path('.github/workflows/publish-cd-release.yml').read_text(en
 deploy_workflow = Path('.github/workflows/deploy-production.yml').read_text(encoding='utf-8')
 co_practice_migration = Path('fabushi/web/migrations/20260506_co_practice_groups.sql')
 free_trial_migration = Path('fabushi/web/migrations/20260508_users_free_trial_end_date.sql')
+payment_columns_migration = Path('fabushi/web/migrations/20260508_users_payment_columns.sql')
 d1_retry_helper = Path('.github/scripts/run-wrangler-d1-migrations.sh')
 schema_sql = Path('fabushi/web/schema.sql').read_text(encoding='utf-8')
 schema_v2_sql = Path('fabushi/web/schema_v2.sql').read_text(encoding='utf-8')
@@ -126,6 +127,28 @@ else:
     ):
         if required not in migration_text:
             missing.append(f'free-trial migration missing: {required}')
+
+for payment_field in ('stripe_customer_id', 'subscription_id'):
+    if payment_field not in schema_sql:
+        missing.append(f'schema.sql missing {payment_field}')
+    if payment_field not in schema_v2_sql:
+        missing.append(f'schema_v2.sql missing {payment_field}')
+    if payment_field not in profile_handler:
+        missing.append(f'profile.js missing {payment_field} usage')
+    if payment_field not in profile_test:
+        missing.append(f'profile.test.js missing {payment_field} fixture coverage')
+
+if not payment_columns_migration.exists():
+    missing.append('fabushi/web/migrations/20260508_users_payment_columns.sql')
+else:
+    migration_text = payment_columns_migration.read_text(encoding='utf-8')
+    for required in (
+        'ALTER TABLE users ADD COLUMN stripe_customer_id TEXT;',
+        'ALTER TABLE users ADD COLUMN subscription_id TEXT;',
+        'profile username-rename flow',
+    ):
+        if required not in migration_text:
+            missing.append(f'payment columns migration missing: {required}')
 
 if missing:
     sys.stderr.write(

--- a/fabushi/web/migrations/20260508_users_payment_columns.sql
+++ b/fabushi/web/migrations/20260508_users_payment_columns.sql
@@ -1,0 +1,7 @@
+-- Managed D1 migration for the profile username-rename flow.
+-- `stripe_customer_id` and `subscription_id` already exist in schema.sql/schema_v2.sql
+-- and are referenced by the live profile handler plus release-gate E2E tests, so
+-- the release-managed migration must add them for existing databases too.
+
+ALTER TABLE users ADD COLUMN stripe_customer_id TEXT;
+ALTER TABLE users ADD COLUMN subscription_id TEXT;


### PR DESCRIPTION
## Summary

- Add a release-managed D1 migration for the `users` payment columns used by the profile username-rename flow.
- Cover both `stripe_customer_id` and `subscription_id` so existing staging/production D1 databases match `schema.sql` / `schema_v2.sql` before the E2E gate runs.
- Extend the publish/CD guardrail to require those columns to stay covered by schema, profile handler/test fixtures, and the managed migration.

## Root cause

Latest CD run `25537693408` failed in `Staging API E2E and smoke gate` because `tests/staging-profile-api.spec.js` hit the username rename path and the live API returned:

```text
D1_ERROR: table users has no column named stripe_customer_id: SQLITE_ERROR
```

The code and schema already reference `stripe_customer_id` / `subscription_id`, but existing D1 databases did not have a release-managed migration for those columns.

## Validation

- Inspected issue #249 and the failed job logs for CD run `25537693408`.
- Compared this branch against `main`: only the new D1 migration and guardrail update are changed.
- CI should validate the guardrail and the normal CD path after merge.