### PR TITLE
fix: rebuild legacy users table before user-id backfill

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -72,7 +72,7 @@ for required in (
 
 for required in (
     'CREATE TABLE users__id_migration',
-    'SELECT\n  rowid,',
+    'rowid,',
     'CREATE TABLE email_username_mapping__user_id_migration',
     'CREATE TABLE alipay_bindings__user_id_migration',
     'idx_email_username_mapping_user_id',

--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -71,8 +71,10 @@ for required in (
         missing.append(f'auth-user-id.test.js missing: {required}')
 
 for required in (
-    'ALTER TABLE email_username_mapping ADD COLUMN user_id INTEGER;',
-    'ALTER TABLE alipay_bindings ADD COLUMN user_id INTEGER;',
+    'CREATE TABLE users__id_migration',
+    'SELECT\n  rowid,',
+    'CREATE TABLE email_username_mapping__user_id_migration',
+    'CREATE TABLE alipay_bindings__user_id_migration',
     'idx_email_username_mapping_user_id',
     'idx_alipay_bindings_user_id',
 ):

--- a/fabushi/web/migrations/20260508_users_id_identity.sql
+++ b/fabushi/web/migrations/20260508_users_id_identity.sql
@@ -1,19 +1,178 @@
 -- Managed D1 migration for the user-id-first auth and mapping close-out.
--- Keep legacy username columns for compatibility, but backfill canonical user ids
--- so fresh tokens, profile writes, and third-party bindings can move to users.id.
+-- Some long-lived D1 databases still have a legacy users table without users.id.
+-- Rebuild those tables into the current id-backed shape before backfilling the
+-- email/alipay mapping tables, so profile writes and fresh tokens can rely on
+-- users.id without breaking old environments.
 
-ALTER TABLE email_username_mapping ADD COLUMN user_id INTEGER;
-UPDATE email_username_mapping
-SET user_id = (
-  SELECT id FROM users WHERE users.username = email_username_mapping.username
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE users__id_migration (
+  id INTEGER PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  salt TEXT NOT NULL,
+  iterations INTEGER NOT NULL,
+  algo TEXT NOT NULL,
+  email_verified INTEGER DEFAULT 0,
+  membership_type TEXT DEFAULT 'trial',
+  membership_expires_at TEXT,
+  free_trial_end_date TEXT,
+  stripe_customer_id TEXT,
+  subscription_id TEXT,
+  wechat_openid TEXT,
+  wechat_nickname TEXT,
+  wechat_headimgurl TEXT,
+  wechat_bound_at TEXT,
+  alipay_user_id TEXT,
+  alipay_nickname TEXT,
+  alipay_avatar TEXT,
+  alipay_bound_at TEXT,
+  phone_number TEXT,
+  firebase_uid TEXT,
+  apple_user_id TEXT,
+  nickname TEXT,
+  avatar TEXT,
+  bio TEXT,
+  main_practice_title TEXT,
+  main_practice_file_path TEXT,
+  main_practice_selected_at TEXT,
+  total_transferred_bytes INTEGER DEFAULT 0,
+  last_transfer_at TEXT,
+  sync_version INTEGER DEFAULT 1,
+  extra_data TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT
+);
+
+INSERT INTO users__id_migration (
+  id,
+  username,
+  email,
+  password_hash,
+  salt,
+  iterations,
+  algo,
+  email_verified,
+  membership_type,
+  membership_expires_at,
+  free_trial_end_date,
+  stripe_customer_id,
+  subscription_id,
+  wechat_openid,
+  wechat_nickname,
+  wechat_headimgurl,
+  wechat_bound_at,
+  alipay_user_id,
+  alipay_nickname,
+  alipay_avatar,
+  alipay_bound_at,
+  phone_number,
+  firebase_uid,
+  apple_user_id,
+  nickname,
+  avatar,
+  bio,
+  main_practice_title,
+  main_practice_file_path,
+  main_practice_selected_at,
+  total_transferred_bytes,
+  last_transfer_at,
+  sync_version,
+  extra_data,
+  created_at,
+  updated_at
 )
-WHERE user_id IS NULL;
+SELECT
+  rowid,
+  username,
+  email,
+  password_hash,
+  salt,
+  iterations,
+  algo,
+  email_verified,
+  membership_type,
+  membership_expires_at,
+  free_trial_end_date,
+  stripe_customer_id,
+  subscription_id,
+  wechat_openid,
+  wechat_nickname,
+  wechat_headimgurl,
+  wechat_bound_at,
+  alipay_user_id,
+  alipay_nickname,
+  alipay_avatar,
+  alipay_bound_at,
+  phone_number,
+  firebase_uid,
+  apple_user_id,
+  nickname,
+  avatar,
+  bio,
+  main_practice_title,
+  main_practice_file_path,
+  main_practice_selected_at,
+  total_transferred_bytes,
+  last_transfer_at,
+  sync_version,
+  extra_data,
+  created_at,
+  updated_at
+FROM users;
+
+DROP TABLE users;
+ALTER TABLE users__id_migration RENAME TO users;
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_users_wechat_openid ON users(wechat_openid);
+CREATE INDEX IF NOT EXISTS idx_users_alipay_user_id ON users(alipay_user_id);
+CREATE INDEX IF NOT EXISTS idx_users_phone_number ON users(phone_number);
+CREATE INDEX IF NOT EXISTS idx_users_firebase_uid ON users(firebase_uid);
+CREATE INDEX IF NOT EXISTS idx_users_apple_user_id ON users(apple_user_id);
+
+CREATE TABLE email_username_mapping__user_id_migration (
+  email TEXT PRIMARY KEY,
+  username TEXT NOT NULL,
+  user_id INTEGER,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+INSERT INTO email_username_mapping__user_id_migration (email, username, user_id)
+SELECT
+  map.email,
+  map.username,
+  users.id
+FROM email_username_mapping map
+LEFT JOIN users ON users.username = map.username;
+
+DROP TABLE email_username_mapping;
+ALTER TABLE email_username_mapping__user_id_migration RENAME TO email_username_mapping;
 CREATE INDEX IF NOT EXISTS idx_email_username_mapping_user_id ON email_username_mapping(user_id);
 
-ALTER TABLE alipay_bindings ADD COLUMN user_id INTEGER;
-UPDATE alipay_bindings
-SET user_id = (
-  SELECT id FROM users WHERE users.username = alipay_bindings.username
-)
-WHERE user_id IS NULL;
+CREATE TABLE alipay_bindings__user_id_migration (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  alipay_user_id TEXT UNIQUE NOT NULL,
+  username TEXT,
+  user_id INTEGER,
+  bound_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+INSERT INTO alipay_bindings__user_id_migration (id, alipay_user_id, username, user_id, bound_at)
+SELECT
+  binding.id,
+  binding.alipay_user_id,
+  binding.username,
+  users.id,
+  binding.bound_at
+FROM alipay_bindings binding
+LEFT JOIN users ON users.username = binding.username;
+
+DROP TABLE alipay_bindings;
+ALTER TABLE alipay_bindings__user_id_migration RENAME TO alipay_bindings;
 CREATE INDEX IF NOT EXISTS idx_alipay_bindings_user_id ON alipay_bindings(user_id);
+
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
## 为什么改

最新主线 CD `#263` 在 `2026-05-08 11:12 UTC` 的 development D1 migration 步骤稳定失败，报错是：

- workflow run: `CD - Staging API gated production deploy #143`
- failed step: `Apply development D1 migrations`
- concrete error: `no such column: id`

这说明 `20260508_users_id_identity.sql` 之前把远端数据库默认当成“`users.id` 已经存在，只差给映射表补 `user_id`”来处理，但真实的长寿命 D1 库仍然保留着没有 `users.id` 的旧 `users` 表。

结果就是：

- 新代码已经按 `users.id` / `token.userId` / `WHERE id = ?` 走
- 但发布链在真正进入 staging deploy 前，连 migration 都过不去
- 如果只继续重试，不会自己恢复

## 这次改了什么

- 把 `fabushi/web/migrations/20260508_users_id_identity.sql` 改成兼容旧库的版本：
  - 先重建 legacy `users` 表，使用旧表 `rowid` 回填稳定的 `users.id`
  - 再重建 `email_username_mapping`，按 `username -> users.id` 回填 `user_id`
  - 再重建 `alipay_bindings`，按 `username -> users.id` 回填 `user_id`
  - 同步补回这些表在当前 schema 中依赖的索引
- 更新 `.github/scripts/check-publish-cd-release.sh`
  - 不再只盯旧的 `ALTER TABLE ... ADD COLUMN user_id` 形状
  - 改为要求这条 migration 保留 legacy `users` rebuild + mapping table rebuild 的关键保护片段

## 为什么这样修

这次不是简单补一列就够，因为失败日志已经证明远端最早卡住的是 `users.id` 本身不存在。

如果继续让 migration 假设 `users.id` 已存在：

- staging / production D1 会一直在这一步稳定失败
- `#257` 合入后的 user-id-first 代码也拿不到对应的数据库闭环

先把旧 `users` 表收敛成带稳定 `id` 的版本，再去回填映射表，是当前最小且对症的修法。

## 验证

- 已直接核对失败 job 日志：`Apply development D1 migrations` 在执行 `20260508_users_id_identity.sql` 时因 `users.id` 缺失而失败
- 当前执行环境无法直接连 Cloudflare D1 复跑远端 migration；最终以这条 PR 的 `CI` 和合入后的下一次 mainline `CD` 为准
- guardrail 已同步更新，防止后续又把这条 migration 退回成只适用于“库里早已有 users.id”的版本

Fixes #263