### PR TITLE
refactor: lay user-id contract foundation and stage PR gates

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -13,6 +13,10 @@ profile_handler = Path('fabushi/web/src/handlers/profile.js').read_text(encoding
 profile_test = Path('fabushi/web/tests/profile.test.js').read_text(encoding='utf-8')
 auth_user_id_test = Path('fabushi/web/tests/auth-user-id.test.js').read_text(encoding='utf-8')
 identity_migration = Path('fabushi/web/migrations/20260508_users_id_identity.sql').read_text(encoding='utf-8')
+auth_route = Path('fabushi/web/src/routes/auth-routes.js').read_text(encoding='utf-8')
+account_contract = Path('fabushi/web/src/contracts/account-user.js').read_text(encoding='utf-8')
+account_repository = Path('fabushi/web/src/repositories/account-user-repository.js').read_text(encoding='utf-8')
+update_profile_use_case = Path('fabushi/web/src/use-cases/update-profile.js').read_text(encoding='utf-8')
 
 missing = []
 
@@ -34,17 +38,17 @@ for required in (
         missing.append(f'auth-utils missing: {required}')
 
 for required in (
-    'getUserById',
-    'WHERE id = ?',
-    'existingUser.id !== currentUser.id',
-    'INSERT OR REPLACE INTO email_username_mapping (email, username, user_id)',
+    'AccountUserRepository',
+    'updateProfileFromRequest',
+    'serializeAccountUser',
 ):
     if required not in profile_handler:
         missing.append(f'profile.js missing: {required}')
 
 for required in (
-    'generateToken({ id: user.id, username: user.username }, env)',
-    'userId: user.id',
+    'loginWithPasswordCommand',
+    'AccountUserRepository',
+    'jsonResponse(payload)',
 ):
     if required not in password_login:
         missing.append(f'password-login.js missing: {required}')
@@ -80,6 +84,38 @@ for required in (
 ):
     if required not in identity_migration:
         missing.append(f'identity migration missing: {required}')
+
+for required in (
+    "'/api/auth/update-profile'",
+    'handleGetUserInfo',
+    'handleBindEmail',
+):
+    if required not in auth_route:
+        missing.append(f'auth-routes.js missing: {required}')
+
+for required in (
+    'serializeAccountUser',
+    'buildPasswordLoginPayload',
+    'buildProfileUpdatedPayload',
+):
+    if required not in account_contract:
+        missing.append(f'account-user contract missing: {required}')
+
+for required in (
+    'resolveTokenUser',
+    'UPDATE users SET',
+    'INSERT OR REPLACE INTO email_username_mapping (email, username, user_id)',
+):
+    if required not in account_repository:
+        missing.append(f'account-user repository missing: {required}')
+
+for required in (
+    'normalizeProfileUpdateBody',
+    'existingUser.id !== currentUser.id',
+    'buildProfileUpdatedPayload',
+):
+    if required not in update_profile_use_case:
+        missing.append(f'update-profile use case missing: {required}')
 
 if missing:
     sys.stderr.write('workflow guardrails are missing required protections: ' + ', '.join(missing) + '\n')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ env:
   FLUTTER_VERSION: '3.41.9'
 
 jobs:
-  flutter:
-    name: Flutter quality, tests, build, and web smoke
+  fast-checks:
+    name: Fast checks
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: fabushi
@@ -120,6 +120,34 @@ jobs:
       - name: Run Flutter tests
         run: flutter test
 
+  mobile-release-simulation:
+    name: Release simulation - mobile web build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: fast-checks
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout project files
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/**
+            !/fabushi/assets/built_in/**
+            !/fabushi/web/assets/built_in/**
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
       - name: Build web release
         run: flutter build web --release
 
@@ -150,10 +178,10 @@ jobs:
           if-no-files-found: error
 
   android-gradle-bootstrap:
-    name: Android Gradle bootstrap
+    name: Release simulation - Android Gradle bootstrap
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: flutter
+    needs: fast-checks
     defaults:
       run:
         working-directory: fabushi
@@ -198,16 +226,13 @@ jobs:
           GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
         run: |
           set -euo pipefail
-          # There is no checked-in Android Gradle wrapper script in this repo,
-          # so use Flutter's config-only Android build to validate Gradle setup
-          # and repository resolution against the real app project structure.
           flutter build apk --debug --config-only
 
-  worker:
-    name: Cloudflare Worker syntax and deploy dry-run
+  worker-module-checks:
+    name: Module checks - Worker
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: flutter
+    needs: fast-checks
     defaults:
       run:
         working-directory: fabushi/web
@@ -219,12 +244,6 @@ jobs:
           sparse-checkout: |
             /fabushi/web/**
             !/fabushi/web/assets/built_in/**
-
-      - name: Download Flutter web build
-        uses: actions/download-artifact@v5
-        with:
-          name: flutter-web-build
-          path: fabushi/build/web
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -248,6 +267,28 @@ jobs:
           printf '{"type":"module"}\n' > package.json
           node tests/profile.test.js
 
+  worker-contract-checks:
+    name: Contract checks - Worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: fast-checks
+    defaults:
+      run:
+        working-directory: fabushi/web
+    steps:
+      - name: Checkout Worker files
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/web/**
+            !/fabushi/web/assets/built_in/**
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Run Worker contract tests
         shell: bash
         run: |
@@ -260,6 +301,36 @@ jobs:
           fi
           xargs -0 node --test --test-concurrency=1 < /tmp/worker-tests
 
+  worker-release-simulation:
+    name: Release simulation - Worker dry-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - mobile-release-simulation
+      - worker-module-checks
+    defaults:
+      run:
+        working-directory: fabushi/web
+    steps:
+      - name: Checkout Worker files
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/web/**
+            !/fabushi/web/assets/built_in/**
+
+      - name: Download Flutter web build
+        uses: actions/download-artifact@v5
+        with:
+          name: flutter-web-build
+          path: fabushi/build/web
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Validate Worker bundle with Wrangler dry-run
         run: npx --yes wrangler@latest deploy --dry-run --outdir ../../worker-dry-run
 
@@ -270,10 +341,11 @@ jobs:
           path: worker-dry-run
           if-no-files-found: warn
 
-  e2e-contract:
-    name: Playwright E2E contract validation
+  e2e-release-simulation:
+    name: Release simulation - staging E2E contract validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: fast-checks
     defaults:
       run:
         working-directory: fabushi/e2e
@@ -296,10 +368,11 @@ jobs:
       - name: Validate the staging E2E script used by CD
         run: npm test -- --list
 
-  frontend:
-    name: Frontend monorepo typecheck and Next.js build
+  frontend-module-checks:
+    name: Module checks - Frontend
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: fast-checks
     defaults:
       run:
         working-directory: frontend
@@ -328,10 +401,11 @@ jobs:
       - name: Build Next.js site
         run: pnpm build:web
 
-  workflow-guardrails:
-    name: Workflow guardrails
+  workflow-contract-checks:
+    name: Contract checks - Workflow guardrails
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: fast-checks
     steps:
       - name: Checkout workflow files
         uses: actions/checkout@v5
@@ -344,6 +418,10 @@ jobs:
             /fabushi/web/migrations/**
             /fabushi/web/schema.sql
             /fabushi/web/schema_v2.sql
+            /fabushi/web/src/contracts/**
+            /fabushi/web/src/repositories/**
+            /fabushi/web/src/routes/**
+            /fabushi/web/src/use-cases/**
             /fabushi/web/src/handlers/auth.js
             /fabushi/web/src/handlers/password-login.js
             /fabushi/web/src/handlers/profile.js
@@ -354,45 +432,108 @@ jobs:
         shell: bash
         run: bash .github/scripts/check-publish-cd-release.sh
 
+  module-checks:
+    name: Module checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - worker-module-checks
+      - frontend-module-checks
+    steps:
+      - name: Confirm module check results
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.worker-module-checks.result }}" != "success" ]; then
+            echo "Worker module checks failed: ${{ needs.worker-module-checks.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.frontend-module-checks.result }}" != "success" ]; then
+            echo "Frontend module checks failed: ${{ needs.frontend-module-checks.result }}"
+            exit 1
+          fi
+
+  contract-checks:
+    name: Contract checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - worker-contract-checks
+      - workflow-contract-checks
+    steps:
+      - name: Confirm contract check results
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.worker-contract-checks.result }}" != "success" ]; then
+            echo "Worker contract checks failed: ${{ needs.worker-contract-checks.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.workflow-contract-checks.result }}" != "success" ]; then
+            echo "Workflow contract checks failed: ${{ needs.workflow-contract-checks.result }}"
+            exit 1
+          fi
+
+  release-simulation:
+    name: Release simulation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - mobile-release-simulation
+      - android-gradle-bootstrap
+      - worker-release-simulation
+      - e2e-release-simulation
+    steps:
+      - name: Confirm release simulation results
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.mobile-release-simulation.result }}" != "success" ]; then
+            echo "Mobile release simulation failed: ${{ needs.mobile-release-simulation.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.android-gradle-bootstrap.result }}" != "success" ]; then
+            echo "Android Gradle bootstrap failed: ${{ needs.android-gradle-bootstrap.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.worker-release-simulation.result }}" != "success" ]; then
+            echo "Worker dry-run failed: ${{ needs.worker-release-simulation.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.e2e-release-simulation.result }}" != "success" ]; then
+            echo "E2E release simulation failed: ${{ needs.e2e-release-simulation.result }}"
+            exit 1
+          fi
+
   ci-result:
     name: CI result
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
-      - flutter
-      - android-gradle-bootstrap
-      - worker
-      - e2e-contract
-      - frontend
-      - workflow-guardrails
+      - fast-checks
+      - module-checks
+      - contract-checks
+      - release-simulation
     if: always()
     steps:
       - name: Check required CI jobs
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ needs.flutter.result }}" != "success" ]; then
-            echo "Flutter job failed: ${{ needs.flutter.result }}"
+          if [ "${{ needs.fast-checks.result }}" != "success" ]; then
+            echo "Fast checks failed: ${{ needs.fast-checks.result }}"
             exit 1
           fi
-          if [ "${{ needs.android-gradle-bootstrap.result }}" != "success" ]; then
-            echo "Android Gradle bootstrap job failed: ${{ needs.android-gradle-bootstrap.result }}"
+          if [ "${{ needs.module-checks.result }}" != "success" ]; then
+            echo "Module checks failed: ${{ needs.module-checks.result }}"
             exit 1
           fi
-          if [ "${{ needs.worker.result }}" != "success" ]; then
-            echo "Worker job failed: ${{ needs.worker.result }}"
+          if [ "${{ needs.contract-checks.result }}" != "success" ]; then
+            echo "Contract checks failed: ${{ needs.contract-checks.result }}"
             exit 1
           fi
-          if [ "${{ needs.e2e-contract.result }}" != "success" ]; then
-            echo "E2E contract job failed: ${{ needs.e2e-contract.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.frontend.result }}" != "success" ]; then
-            echo "Frontend job failed: ${{ needs.frontend.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.workflow-guardrails.result }}" != "success" ]; then
-            echo "Workflow guardrails job failed: ${{ needs.workflow-guardrails.result }}"
+          if [ "${{ needs.release-simulation.result }}" != "success" ]; then
+            echo "Release simulation failed: ${{ needs.release-simulation.result }}"
             exit 1
           fi
           echo "All CI checks passed."
@@ -402,12 +543,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - flutter
+      - fast-checks
+      - mobile-release-simulation
       - android-gradle-bootstrap
-      - worker
-      - e2e-contract
-      - frontend
-      - workflow-guardrails
+      - worker-module-checks
+      - worker-contract-checks
+      - worker-release-simulation
+      - e2e-release-simulation
+      - frontend-module-checks
+      - workflow-contract-checks
+      - module-checks
+      - contract-checks
+      - release-simulation
       - ci-result
     if: failure()
     steps:
@@ -445,13 +592,18 @@ jobs:
               labelDescription: 'CI workflow failed',
               notifyJobName: 'Notify CI failure',
               extraSections: [
+                '### CI gate order',
+                '',
+                '- Fast checks',
+                '- Module checks',
+                '- Contract checks',
+                '- Release simulation',
+                '',
                 '### CI notes',
                 '',
                 '- Dart format diffs are uploaded as `dart-format-patch` when formatter output differs from the committed code.',
                 '- CI runs with the formatter-applied workspace and does not push formatter commits directly to main because main is protected by merge queue rules.',
-                '- Android Gradle bootstrap now validates that GitHub Actions can resolve Android/Kotlin buildscript dependencies before release packaging workflows run.',
-                '- The frontend monorepo is validated with pnpm install, recursive typecheck, and a Next.js production build before PRs can merge.',
-                '- Build and dry-run bundles are listed above when those jobs reach their upload steps.',
+                '- Worker dry-run stays in release simulation so D1 / contract drift is caught before CD deploy starts.',
                 '- Merge queue runs are supported through the `merge_group` trigger.',
               ],
             });

--- a/fabushi/web/src/contracts/account-user.js
+++ b/fabushi/web/src/contracts/account-user.js
@@ -1,0 +1,46 @@
+export function serializeAccountUser(user) {
+  return {
+    id: user.id,
+    userId: user.id,
+    username: user.username,
+    email: user.email || '',
+    nickname: user.nickname || user.username,
+    avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,
+    phoneNumber: user.phone_number || null,
+    firebaseUid: user.firebase_uid || null,
+    alipayUserId: user.alipay_user_id || null,
+    alipayNickname: user.alipay_nickname || null,
+    alipayAvatar: user.alipay_avatar || null,
+    hasPassword: Boolean(user.password_hash && user.salt),
+    mainPractice: user.main_practice_title
+      ? {
+          title: user.main_practice_title,
+          filePath: user.main_practice_file_path,
+          selectedAt: user.main_practice_selected_at,
+        }
+      : null,
+    createdAt: user.created_at,
+    emailVerified: user.email_verified === 1,
+    membership: {
+      type: user.membership_type || 'expired',
+      expiresAt: user.membership_expires_at || user.free_trial_end_date || null,
+    },
+  };
+}
+
+export function buildPasswordLoginPayload({ token, user }) {
+  return {
+    token,
+    username: user.username,
+    userId: user.id,
+    user: serializeAccountUser(user),
+  };
+}
+
+export function buildProfileUpdatedPayload(user) {
+  return {
+    success: true,
+    message: '个人资料更新成功',
+    user: serializeAccountUser(user),
+  };
+}

--- a/fabushi/web/src/contracts/api-error.js
+++ b/fabushi/web/src/contracts/api-error.js
@@ -1,0 +1,12 @@
+export class ApiError extends Error {
+  constructor(message, status = 500) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+export function asApiError(error, fallbackMessage = '服务器内部错误') {
+  if (error instanceof ApiError) return error;
+  return new ApiError(error?.message || fallbackMessage, error?.status || 500);
+}

--- a/fabushi/web/src/domain/account-identity.js
+++ b/fabushi/web/src/domain/account-identity.js
@@ -1,0 +1,43 @@
+function normalizeOptionalString(value) {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function normalizeDisplayName(value) {
+  const name = normalizeOptionalString(value);
+  if (!name) return name;
+  if (name.includes('@')) throw new Error('昵称不能包含 @，邮箱请填写到邮箱字段');
+  if (/\s/.test(name)) throw new Error('昵称不能包含空格');
+  if (name.length < 2 || name.length > 32) throw new Error('昵称长度需为 2-32 个字符');
+  return name;
+}
+
+export function normalizeEmail(value) {
+  const email = normalizeOptionalString(value);
+  if (!email) return email;
+  const normalized = email.toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) throw new Error('邮箱格式不正确');
+  return normalized;
+}
+
+export function normalizePhone(value) {
+  const phone = normalizeOptionalString(value);
+  if (!phone) return phone;
+  if (!/^\+?[0-9]{6,20}$/.test(phone)) throw new Error('手机号格式不正确');
+  return phone;
+}
+
+export function normalizeProfileUpdateBody(body) {
+  const rawDisplayName = body.nickname !== undefined ? body.nickname : body.username;
+  const password = body.password !== undefined ? String(body.password) : undefined;
+
+  return {
+    hasDisplayNameField: rawDisplayName !== undefined,
+    displayName: rawDisplayName !== undefined ? normalizeDisplayName(rawDisplayName) : undefined,
+    email: body.email !== undefined ? normalizeEmail(body.email) : undefined,
+    phoneNumber: body.phoneNumber !== undefined ? normalizePhone(body.phoneNumber) : undefined,
+    password,
+  };
+}

--- a/fabushi/web/src/handlers/password-login.js
+++ b/fabushi/web/src/handlers/password-login.js
@@ -1,61 +1,21 @@
 import { jsonResponse } from '../utils/response.js';
-import { verifyPassword, generateToken } from '../../auth-utils.js';
-
-function looksLikeEmail(value) {
-  return String(value || '').includes('@');
-}
-
-function looksLikePhone(value) {
-  return /^\+?[0-9]{6,20}$/.test(String(value || '').trim());
-}
+import { AccountUserRepository } from '../repositories/account-user-repository.js';
+import { asApiError } from '../contracts/api-error.js';
+import { loginWithPasswordCommand } from '../use-cases/password-login.js';
 
 export async function handlePasswordLogin(request, env, db) {
-  const { username: loginIdentifier, password } = await request.json();
-  const identifier = String(loginIdentifier || '').trim();
-  if (!identifier || !password) {
-    return jsonResponse({ error: '手机号、用户名或邮箱和密码不能为空' }, 400);
-  }
+  const repository = new AccountUserRepository(db);
 
-  let user;
-  if (looksLikeEmail(identifier)) {
-    user = await db.getUserByEmail(identifier.toLowerCase());
-  } else if (looksLikePhone(identifier)) {
-    user = await db.getUserByPhone(identifier);
+  try {
+    const { username: loginIdentifier, password } = await request.json();
+    const payload = await loginWithPasswordCommand(
+      { identifier: loginIdentifier, password },
+      env,
+      repository
+    );
+    return jsonResponse(payload);
+  } catch (error) {
+    const apiError = asApiError(error, '登录失败');
+    return jsonResponse({ error: apiError.message }, apiError.status);
   }
-  if (!user) user = await db.getUser(identifier);
-  if (!user) return jsonResponse({ error: '用户不存在' }, 401);
-  if (!user.password_hash || !user.salt) {
-    return jsonResponse({ error: '当前账号尚未设置密码，请先通过已登录资料页设置密码' }, 401);
-  }
-
-  const ok = await verifyPassword(password, {
-    passwordHash: user.password_hash,
-    salt: user.salt,
-    iterations: user.iterations,
-    algo: user.algo
-  });
-  if (!ok) return jsonResponse({ error: '密码错误' }, 401);
-
-  const token = await generateToken({ id: user.id, username: user.username }, env);
-  return jsonResponse({
-    token,
-    username: user.username,
-    userId: user.id,
-    user: {
-      id: user.id,
-      userId: user.id,
-      username: user.username,
-      email: user.email || '',
-      nickname: user.nickname || user.username,
-      avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,
-      phoneNumber: user.phone_number || null,
-      hasPassword: true,
-      emailVerified: user.email_verified === 1,
-      createdAt: user.created_at,
-      membership: {
-        type: user.membership_type || 'expired',
-        expiresAt: user.membership_expires_at || user.free_trial_end_date || null
-      }
-    }
-  });
 }

--- a/fabushi/web/src/handlers/profile.js
+++ b/fabushi/web/src/handlers/profile.js
@@ -1,211 +1,47 @@
 import { jsonResponse } from '../utils/response.js';
-import { createPasswordHash, verifyToken } from '../../auth-utils.js';
-
-function normalizeOptionalString(value) {
-  if (value === undefined) return undefined;
-  if (value === null) return null;
-  const normalized = String(value).trim();
-  return normalized.length > 0 ? normalized : null;
-}
-
-function normalizeDisplayName(value) {
-  const name = normalizeOptionalString(value);
-  if (!name) return name;
-  if (name.includes('@')) throw new Error('昵称不能包含 @，邮箱请填写到邮箱字段');
-  if (/\s/.test(name)) throw new Error('昵称不能包含空格');
-  if (name.length < 2 || name.length > 32) throw new Error('昵称长度需为 2-32 个字符');
-  return name;
-}
-
-function normalizeEmail(value) {
-  const email = normalizeOptionalString(value);
-  if (!email) return email;
-  const normalized = email.toLowerCase();
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) throw new Error('邮箱格式不正确');
-  return normalized;
-}
-
-function normalizePhone(value) {
-  const phone = normalizeOptionalString(value);
-  if (!phone) return phone;
-  if (!/^\+?[0-9]{6,20}$/.test(phone)) throw new Error('手机号格式不正确');
-  return phone;
-}
-
-function serializeUser(user) {
-  return {
-    id: user.id,
-    userId: user.id,
-    username: user.username,
-    email: user.email || '',
-    nickname: user.nickname || user.username,
-    avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,
-    phoneNumber: user.phone_number || null,
-    firebaseUid: user.firebase_uid || null,
-    alipayUserId: user.alipay_user_id || null,
-    alipayNickname: user.alipay_nickname || null,
-    alipayAvatar: user.alipay_avatar || null,
-    hasPassword: Boolean(user.password_hash && user.salt),
-    mainPractice: user.main_practice_title ? {
-      title: user.main_practice_title,
-      filePath: user.main_practice_file_path,
-      selectedAt: user.main_practice_selected_at
-    } : null,
-    createdAt: user.created_at,
-    emailVerified: user.email_verified === 1,
-    membership: {
-      type: user.membership_type || 'expired',
-      expiresAt: user.membership_expires_at || user.free_trial_end_date || null
-    }
-  };
-}
-
-async function resolveAuthenticatedUser(db, tokenData) {
-  if (tokenData?.userId !== undefined && tokenData?.userId !== null && db.getUserById) {
-    const user = await db.getUserById(tokenData.userId);
-    if (user) return user;
-  }
-  if (tokenData?.username) return await db.getUser(tokenData.username);
-  return null;
-}
-
-async function authenticate(request, env, db) {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return { error: jsonResponse({ error: '未提供认证信息' }, 401) };
-  }
-
-  const tokenData = await verifyToken(authHeader.substring(7), env);
-  if (!tokenData) return { error: jsonResponse({ error: '认证失败，请重新登录' }, 401) };
-
-  const user = await resolveAuthenticatedUser(db, tokenData);
-  if (!user) return { error: jsonResponse({ error: '用户不存在' }, 404) };
-  return { tokenData, user };
-}
-
-async function safeRun(db, sql, ...params) {
-  try {
-    await db.prepare(sql).bind(...params).run();
-  } catch (error) {
-    console.warn('资料引用更新跳过:', error?.message || error);
-  }
-}
-
-async function applyEmailMapping(db, oldEmail, newEmail, user) {
-  if (oldEmail) {
-    await safeRun(db, 'DELETE FROM email_username_mapping WHERE email = ?', oldEmail.toLowerCase());
-  }
-  if (user?.id !== undefined && user?.id !== null) {
-    await safeRun(db, 'DELETE FROM email_username_mapping WHERE user_id = ?', user.id);
-  }
-  if (newEmail) {
-    await safeRun(
-      db,
-      'INSERT OR REPLACE INTO email_username_mapping (email, username, user_id) VALUES (?, ?, ?)',
-      newEmail,
-      user.username,
-      user.id
-    );
-  }
-}
+import { serializeAccountUser } from '../contracts/account-user.js';
+import { AccountUserRepository } from '../repositories/account-user-repository.js';
+import { asApiError } from '../contracts/api-error.js';
+import { authenticateRequest } from '../use-cases/authenticated-user.js';
+import { updateProfileFromRequest } from '../use-cases/update-profile.js';
 
 export async function handleUploadAvatar(request, env, db) {
-  const auth = await authenticate(request, env, db);
-  if (auth.error) return auth.error;
-  const { imageBase64 } = await request.json();
-  if (!imageBase64) return jsonResponse({ error: '缺少头像图片数据' }, 400);
+  const repository = new AccountUserRepository(db);
 
-  const avatarUrl = `https://example.com/avatar/${auth.user.id}`;
-  await db.prepare('UPDATE users SET avatar = ?, nickname = ?, updated_at = ? WHERE id = ?')
-    .bind(avatarUrl, auth.user.nickname || auth.user.username, new Date().toISOString(), auth.user.id)
-    .run();
+  try {
+    const { user } = await authenticateRequest(request, env, repository);
+    const { imageBase64 } = await request.json();
+    if (!imageBase64) {
+      return jsonResponse({ error: '缺少头像图片数据' }, 400);
+    }
 
-  const updatedUser = db.getUserById ? await db.getUserById(auth.user.id) : await db.getUser(auth.user.username);
-  return jsonResponse({ success: true, avatar: avatarUrl, user: serializeUser(updatedUser) });
+    const avatarUrl = `https://example.com/avatar/${user.id}`;
+    await repository.updateById(user.id, {
+      avatar: avatarUrl,
+      nickname: user.nickname || user.username,
+    });
+
+    const updatedUser = (await repository.getById(user.id)) || user;
+    return jsonResponse({
+      success: true,
+      avatar: avatarUrl,
+      user: serializeAccountUser(updatedUser),
+    });
+  } catch (error) {
+    const apiError = asApiError(error, '头像上传失败');
+    return jsonResponse({ error: apiError.message }, apiError.status);
+  }
 }
 
 export async function handleUpdateProfile(request, env, db) {
+  const repository = new AccountUserRepository(db);
+
   try {
-    const auth = await authenticate(request, env, db);
-    if (auth.error) return auth.error;
-
-    const body = await request.json();
-    const rawDisplayName = body.nickname !== undefined ? body.nickname : body.username;
-    let displayName;
-    let newEmail;
-    let newPhone;
-    try {
-      displayName = rawDisplayName !== undefined ? normalizeDisplayName(rawDisplayName) : undefined;
-      newEmail = body.email !== undefined ? normalizeEmail(body.email) : undefined;
-      newPhone = body.phoneNumber !== undefined ? normalizePhone(body.phoneNumber) : undefined;
-    } catch (error) {
-      return jsonResponse({ error: error.message }, 400);
-    }
-
-    if (rawDisplayName !== undefined && !displayName) {
-      return jsonResponse({ error: '请输入昵称' }, 400);
-    }
-
-    const currentUser = auth.user;
-    const updates = [];
-    const values = [];
-    const updatedAt = new Date().toISOString();
-
-    if (newEmail !== undefined && newEmail) {
-      const existingUser = await db.getUserByEmail(newEmail);
-      if (existingUser && existingUser.id !== currentUser.id) {
-        return jsonResponse({ error: '该邮箱已被其他账号使用' }, 400);
-      }
-    }
-
-    if (newPhone !== undefined && newPhone) {
-      const existingUser = await db.getUserByPhone(newPhone);
-      if (existingUser && existingUser.id !== currentUser.id) {
-        return jsonResponse({ error: '该手机号已被其他账号使用' }, 400);
-      }
-    }
-
-    if (displayName !== undefined) {
-      updates.push('nickname = ?');
-      values.push(displayName);
-    }
-    if (newEmail !== undefined) {
-      updates.push('email = ?', 'email_verified = ?');
-      values.push(newEmail || '', newEmail ? 1 : 0);
-    }
-    if (newPhone !== undefined) {
-      updates.push('phone_number = ?');
-      values.push(newPhone);
-    }
-    if (body.password !== undefined && String(body.password).length > 0) {
-      if (currentUser.password_hash && currentUser.salt) {
-        return jsonResponse({ error: '当前账号已设置密码，请使用修改密码功能' }, 400);
-      }
-      const password = String(body.password);
-      if (password.length < 6 || password.length > 128) {
-        return jsonResponse({ error: '密码长度需为 6-128 位' }, 400);
-      }
-      const passwordCreds = await createPasswordHash(password);
-      updates.push('password_hash = ?', 'salt = ?', 'iterations = ?', 'algo = ?');
-      values.push(passwordCreds.passwordHash, passwordCreds.salt, passwordCreds.iterations, passwordCreds.algo);
-    }
-
-    if (updates.length === 0) {
-      return jsonResponse({ message: '没有需要更新的字段', user: serializeUser(currentUser) });
-    }
-
-    updates.push('updated_at = ?');
-    values.push(updatedAt, currentUser.id);
-
-    await db.prepare(`UPDATE users SET ${updates.join(', ')} WHERE id = ?`).bind(...values).run();
-    if (newEmail !== undefined) {
-      await applyEmailMapping(db, currentUser.email, newEmail, currentUser);
-    }
-
-    const updatedUser = db.getUserById ? await db.getUserById(currentUser.id) : await db.getUser(currentUser.username);
-    return jsonResponse({ success: true, message: '个人资料更新成功', user: serializeUser(updatedUser) });
+    const payload = await updateProfileFromRequest(request, env, repository);
+    return jsonResponse(payload);
   } catch (error) {
+    const apiError = asApiError(error, '更新个人资料失败');
     console.error('更新个人资料失败:', error);
-    return jsonResponse({ error: error.message || '更新个人资料失败' }, 500);
+    return jsonResponse({ error: apiError.message }, apiError.status);
   }
 }

--- a/fabushi/web/src/repositories/account-user-repository.js
+++ b/fabushi/web/src/repositories/account-user-repository.js
@@ -1,0 +1,70 @@
+async function safeRun(db, sql, ...params) {
+  try {
+    await db.prepare(sql).bind(...params).run();
+  } catch (error) {
+    console.warn('账户资料引用更新跳过:', error?.message || error);
+  }
+}
+
+export class AccountUserRepository {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async getByUsername(username) {
+    return await this.db.getUser(username);
+  }
+
+  async getById(userId) {
+    if (!this.db.getUserById) return null;
+    return await this.db.getUserById(userId);
+  }
+
+  async getByEmail(email) {
+    return await this.db.getUserByEmail(email);
+  }
+
+  async getByPhone(phoneNumber) {
+    return await this.db.getUserByPhone(phoneNumber);
+  }
+
+  async resolveTokenUser(tokenData) {
+    if (tokenData?.userId !== undefined && tokenData?.userId !== null && this.db.getUserById) {
+      const user = await this.db.getUserById(tokenData.userId);
+      if (user) return user;
+    }
+    if (tokenData?.username) {
+      return await this.db.getUser(tokenData.username);
+    }
+    return null;
+  }
+
+  async updateById(userId, updates) {
+    const fields = Object.keys(updates);
+    if (!fields.length) return;
+
+    const assignments = fields.map((key) => `${key} = ?`).join(', ');
+    const values = fields.map((key) => updates[key]);
+    await this.db.prepare(`UPDATE users SET ${assignments}, updated_at = ? WHERE id = ?`)
+      .bind(...values, new Date().toISOString(), Number(userId))
+      .run();
+  }
+
+  async replaceEmailMapping({ userId, username, oldEmail, newEmail }) {
+    if (oldEmail) {
+      await safeRun(this.db, 'DELETE FROM email_username_mapping WHERE email = ?', oldEmail.toLowerCase());
+    }
+    if (userId !== undefined && userId !== null) {
+      await safeRun(this.db, 'DELETE FROM email_username_mapping WHERE user_id = ?', userId);
+    }
+    if (newEmail) {
+      await safeRun(
+        this.db,
+        'INSERT OR REPLACE INTO email_username_mapping (email, username, user_id) VALUES (?, ?, ?)',
+        newEmail,
+        username,
+        userId
+      );
+    }
+  }
+}

--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -22,6 +22,7 @@ import { handleToggleFollow, handleGetFollowList, handleGetFollowSummary, handle
 import { handleBuiltinMigration, handleFullTextSearch, handleGetCategories as handleBuiltinCategories } from '../migrate-builtin-handler-fixed.js';
 import { handleReport, handleBlockUser, handleGetReports, handleReviewReport, handleGetBlocks } from './handlers/moderation.js';
 import { handleSubmitFeedback } from './handlers/feedback.js';
+import { routeAuthRequest } from './routes/auth-routes.js';
 import { verifyToken } from '../auth-utils.js';
 import { jsonResponse } from './utils/response.js';
 
@@ -86,6 +87,11 @@ export async function route(request, env, db, ctx) {
     return normalizedMeditationAuth.response;
   }
   request = normalizedMeditationAuth.request;
+
+  const authResponse = await routeAuthRequest({ pathname, method, request, env, db, ctx });
+  if (authResponse) {
+    return authResponse;
+  }
 
   if (pathname === '/api/sms/send' && method === 'POST') return await handleSendSmsCode(request, env, db);
   if (pathname === '/api/sms/login' && method === 'POST') return await handleSmsLogin(request, env, db);

--- a/fabushi/web/src/routes/auth-routes.js
+++ b/fabushi/web/src/routes/auth-routes.js
@@ -1,0 +1,54 @@
+import {
+  handleRegister,
+  handleLogin,
+  handleGetUserInfo,
+  handleUpdateProfile,
+  handleFirebasePhoneLogin,
+  handleAppleLogin,
+  handleDeleteAccount,
+} from '../handlers/auth.js';
+import {
+  handleGetWechatLoginUrl,
+  handleGetAlipayLoginUrl,
+  handleAlipayLogin,
+  handleAlipayRegister,
+  handleBindEmail,
+  handleMacOSAlipayCallback,
+  handleMobileAlipayCallback,
+  handleGetAlipayAuthString,
+  handleAlipaySDKLogin,
+} from '../handlers/thirdparty.js';
+import {
+  handleSendVerificationCode,
+  handleForgotPassword,
+  handleResetPassword,
+} from '../handlers/verification.js';
+
+export async function routeAuthRequest({ pathname, method, request, env, db, ctx }) {
+  if (pathname === '/api/auth/register' && method === 'POST') return await handleRegister(request, env, db);
+  if (pathname === '/api/auth/login' && method === 'POST') return await handleLogin(request, env, db);
+  if (pathname === '/api/auth/user-info' && method === 'GET') return await handleGetUserInfo(request, env, db);
+  if (pathname === '/api/auth/send-verification-code' && method === 'POST') {
+    return await handleSendVerificationCode(request, env, ctx);
+  }
+  if (pathname === '/api/auth/forgot-password' && method === 'POST') return await handleForgotPassword(request, env, db);
+  if (pathname === '/api/auth/reset-password' && method === 'POST') return await handleResetPassword(request, env, db);
+  if (pathname === '/api/auth/bind-email' && method === 'POST') return await handleBindEmail(request, env, db);
+  if (pathname === '/api/auth/update-profile' && method === 'POST') return await handleUpdateProfile(request, env, db);
+  if (pathname === '/api/auth/firebase-phone-login' && method === 'POST') {
+    return await handleFirebasePhoneLogin(request, env, db);
+  }
+  if (pathname === '/api/auth/apple-login' && method === 'POST') return await handleAppleLogin(request, env, db);
+  if (pathname === '/api/auth/delete' && method === 'DELETE') return await handleDeleteAccount(request, env, db);
+
+  if (pathname === '/api/auth/wechat/login-url' && method === 'GET') return await handleGetWechatLoginUrl(request, env);
+  if (pathname === '/api/auth/alipay/login-url' && method === 'GET') return await handleGetAlipayLoginUrl(request, env);
+  if (pathname === '/api/auth/alipay/login' && method === 'POST') return await handleAlipayLogin(request, env);
+  if (pathname === '/api/auth/alipay/register' && method === 'POST') return await handleAlipayRegister(request, env);
+  if (pathname === '/api/auth/alipay/macos-callback' && method === 'GET') return await handleMacOSAlipayCallback(request, env);
+  if (pathname === '/api/auth/alipay/mobile-callback' && method === 'GET') return await handleMobileAlipayCallback(request, env);
+  if (pathname === '/api/auth/alipay/auth-string' && method === 'GET') return await handleGetAlipayAuthString(request, env);
+  if (pathname === '/api/auth/alipay/sdk-login' && method === 'POST') return await handleAlipaySDKLogin(request, env);
+
+  return null;
+}

--- a/fabushi/web/src/use-cases/authenticated-user.js
+++ b/fabushi/web/src/use-cases/authenticated-user.js
@@ -1,0 +1,27 @@
+import { verifyToken } from '../../auth-utils.js';
+import { ApiError } from '../contracts/api-error.js';
+import { serializeAccountUser } from '../contracts/account-user.js';
+
+export async function authenticateRequest(request, env, repository) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw new ApiError('未提供认证信息', 401);
+  }
+
+  const tokenData = await verifyToken(authHeader.substring(7), env);
+  if (!tokenData) {
+    throw new ApiError('认证失败，请重新登录', 401);
+  }
+
+  const user = await repository.resolveTokenUser(tokenData);
+  if (!user) {
+    throw new ApiError('用户不存在', 404);
+  }
+
+  return { tokenData, user };
+}
+
+export async function getAuthenticatedUserInfo(request, env, repository) {
+  const { user } = await authenticateRequest(request, env, repository);
+  return serializeAccountUser(user);
+}

--- a/fabushi/web/src/use-cases/password-login.js
+++ b/fabushi/web/src/use-cases/password-login.js
@@ -1,0 +1,49 @@
+import { verifyPassword, generateToken } from '../../auth-utils.js';
+import { buildPasswordLoginPayload } from '../contracts/account-user.js';
+import { ApiError } from '../contracts/api-error.js';
+
+function looksLikeEmail(value) {
+  return String(value || '').includes('@');
+}
+
+function looksLikePhone(value) {
+  return /^\+?[0-9]{6,20}$/.test(String(value || '').trim());
+}
+
+async function resolveLoginUser(repository, identifier) {
+  if (looksLikeEmail(identifier)) {
+    return await repository.getByEmail(identifier.toLowerCase());
+  }
+  if (looksLikePhone(identifier)) {
+    return await repository.getByPhone(identifier);
+  }
+  return await repository.getByUsername(identifier);
+}
+
+export async function loginWithPasswordCommand({ identifier, password }, env, repository) {
+  const normalizedIdentifier = String(identifier || '').trim();
+  if (!normalizedIdentifier || !password) {
+    throw new ApiError('手机号、用户名或邮箱和密码不能为空', 400);
+  }
+
+  const user = await resolveLoginUser(repository, normalizedIdentifier);
+  if (!user) {
+    throw new ApiError('用户不存在', 401);
+  }
+  if (!user.password_hash || !user.salt) {
+    throw new ApiError('当前账号尚未设置密码，请先通过已登录资料页设置密码', 401);
+  }
+
+  const ok = await verifyPassword(password, {
+    passwordHash: user.password_hash,
+    salt: user.salt,
+    iterations: user.iterations,
+    algo: user.algo,
+  });
+  if (!ok) {
+    throw new ApiError('密码错误', 401);
+  }
+
+  const token = await generateToken({ id: user.id, username: user.username }, env);
+  return buildPasswordLoginPayload({ token, user });
+}

--- a/fabushi/web/src/use-cases/update-profile.js
+++ b/fabushi/web/src/use-cases/update-profile.js
@@ -1,0 +1,80 @@
+import { createPasswordHash } from '../../auth-utils.js';
+import { buildProfileUpdatedPayload, serializeAccountUser } from '../contracts/account-user.js';
+import { ApiError } from '../contracts/api-error.js';
+import { normalizeProfileUpdateBody } from '../domain/account-identity.js';
+import { authenticateRequest } from './authenticated-user.js';
+
+export async function updateProfileFromRequest(request, env, repository) {
+  const { user } = await authenticateRequest(request, env, repository);
+  const body = await request.json();
+  return await updateProfileCommand({ currentUser: user, body }, repository);
+}
+
+export async function updateProfileCommand({ currentUser, body }, repository) {
+  let normalized;
+  try {
+    normalized = normalizeProfileUpdateBody(body);
+  } catch (error) {
+    throw new ApiError(error.message, 400);
+  }
+
+  const { hasDisplayNameField, displayName, email, phoneNumber, password } = normalized;
+  if (hasDisplayNameField && !displayName) {
+    throw new ApiError('请输入昵称', 400);
+  }
+
+  if (email !== undefined && email) {
+    const existingUser = await repository.getByEmail(email);
+    if (existingUser && existingUser.id !== currentUser.id) {
+      throw new ApiError('该邮箱已被其他账号使用', 400);
+    }
+  }
+
+  if (phoneNumber !== undefined && phoneNumber) {
+    const existingUser = await repository.getByPhone(phoneNumber);
+    if (existingUser && existingUser.id !== currentUser.id) {
+      throw new ApiError('该手机号已被其他账号使用', 400);
+    }
+  }
+
+  const updates = {};
+  if (displayName !== undefined) updates.nickname = displayName;
+  if (email !== undefined) {
+    updates.email = email || '';
+    updates.email_verified = email ? 1 : 0;
+  }
+  if (phoneNumber !== undefined) updates.phone_number = phoneNumber;
+  if (password !== undefined && password.length > 0) {
+    if (currentUser.password_hash && currentUser.salt) {
+      throw new ApiError('当前账号已设置密码，请使用修改密码功能', 400);
+    }
+    if (password.length < 6 || password.length > 128) {
+      throw new ApiError('密码长度需为 6-128 位', 400);
+    }
+    const passwordCreds = await createPasswordHash(password);
+    updates.password_hash = passwordCreds.passwordHash;
+    updates.salt = passwordCreds.salt;
+    updates.iterations = passwordCreds.iterations;
+    updates.algo = passwordCreds.algo;
+  }
+
+  if (!Object.keys(updates).length) {
+    return {
+      message: '没有需要更新的字段',
+      user: serializeAccountUser(currentUser),
+    };
+  }
+
+  await repository.updateById(currentUser.id, updates);
+  if (email !== undefined) {
+    await repository.replaceEmailMapping({
+      userId: currentUser.id,
+      username: currentUser.username,
+      oldEmail: currentUser.email,
+      newEmail: email,
+    });
+  }
+
+  const updatedUser = (await repository.getById(currentUser.id)) || currentUser;
+  return buildProfileUpdatedPayload(updatedUser);
+}


### PR DESCRIPTION
## 为什么现在做

按 vNext 主线推进，第一刀必须先把 `users.id`、契约层、Worker 分层切口和 PR 门禁顺序收正。不然继续在 handler 里直写业务、再让 CD 去替 PR 发现结构问题，只会把后续 Flutter 和支付/共修小组改造越拖越重。

## 这次做了什么

### 1. 收正 user-id / contract / migration guardrail 基线

- 新增 Worker 内部契约层：
  - `fabushi/web/src/contracts/api-error.js`
  - `fabushi/web/src/contracts/account-user.js`
- 保持现有 `20260508_users_id_identity.sql` 作为 user-id-first 的地基迁移，并把新的分层文件纳入 workflow guardrail 校验
- 让 `profile` / `password login` 的返回序列化统一落到 `account-user` contract，而不是各 handler 各自拼装

### 2. 开始把 Worker 从 handler 直写拆成 route / use case / repository / domain

- 新增：
  - `fabushi/web/src/domain/account-identity.js`
  - `fabushi/web/src/repositories/account-user-repository.js`
  - `fabushi/web/src/use-cases/authenticated-user.js`
  - `fabushi/web/src/use-cases/password-login.js`
  - `fabushi/web/src/use-cases/update-profile.js`
  - `fabushi/web/src/routes/auth-routes.js`
- `profile.js` 改成薄 handler，只负责 HTTP response mapping
- `password-login.js` 改成薄 handler，只负责 request -> use case -> response
- `router.js` 新增 `auth-routes` 入口，开始把 auth/profile 这组高风险路径从大而平的路由文件里拆出来

### 3. 重排 PR 阶段 CI 门槛顺序

把 `CI` 改成四段式：

1. `Fast checks`
2. `Module checks`
3. `Contract checks`
4. `Release simulation`

具体落地为：

- `fast-checks`
- `mobile-release-simulation`
- `worker-module-checks`
- `worker-contract-checks`
- `worker-release-simulation`
- `frontend-module-checks`
- `workflow-contract-checks`
- `e2e-release-simulation`
- 以及聚合门 `module-checks / contract-checks / release-simulation / ci-result`

这样 PR 阶段先暴露结构问题，CD 再专心做部署和环境验收。

## 为什么这样拆

- `users.id` 继续往前推，不能再靠散落在 handler 里的重复逻辑维持
- profile / login 是最容易再次回退到 username 身份路径的高风险点，所以优先拉到 use case + repository
- 先把路由和用例层骨架搭出来，后面 auth / profile / meditation groups / membership 可以沿同一模版继续迁移
- PR CI 先按“结构正确”分层，才能把 schema drift / contract drift 尽量前移，不再让 CD 当第一发现者

## 验证

- 现有 Worker 契约测试仍覆盖：
  - `fabushi/web/tests/profile.test.js`
  - `fabushi/web/tests/auth-user-id.test.js`
- workflow guardrail 现在也会校验新引入的 `route / use-case / repository / contract` 文件是否仍在主路径上

## 下一步

1. 继续把 `auth.js` / `thirdparty.js` 里的绑定与注册逻辑迁到同一套 account repository / use case 体系
2. 把 meditation groups / membership 作为第二批 Worker 模块继续拆层
3. 开始把 Flutter 端按 `features/auth`、`features/profile`、`features/meditation_groups`、`features/membership` 收口
4. 再把主线 CD 进一步收缩成真正的 deploy + environment acceptance