### PR TITLE
fix: make D1 user-id migration safe inside transaction

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -95,15 +95,26 @@ for required in (
         missing.append(f'auth-user-id.test.js missing: {required}')
 
 for required in (
-    'CREATE TABLE users__id_migration',
-    'rowid,',
-    'CREATE TABLE email_username_mapping__user_id_migration',
-    'CREATE TABLE alipay_bindings__user_id_migration',
+    'PRAGMA defer_foreign_keys = ON;',
+    'ALTER TABLE email_username_mapping RENAME TO email_username_mapping__legacy;',
+    'ALTER TABLE alipay_bindings RENAME TO alipay_bindings__legacy;',
+    'ALTER TABLE users RENAME TO users__legacy;',
+    'DROP TABLE users__legacy;',
+    'CREATE TABLE email_username_mapping (',
+    'CREATE TABLE alipay_bindings (',
     'idx_email_username_mapping_user_id',
     'idx_alipay_bindings_user_id',
 ):
     if required not in identity_migration:
         missing.append(f'identity migration missing: {required}')
+
+for forbidden in (
+    'PRAGMA foreign_keys = OFF;',
+    'DROP TABLE users;',
+    'ALTER TABLE users__id_migration RENAME TO users;',
+):
+    if forbidden in identity_migration:
+        missing.append(f'identity migration should not contain: {forbidden}')
 
 for required in (
     'ALTER TABLE users ADD COLUMN stripe_customer_id TEXT',

--- a/fabushi/web/migrations/20260508_users_id_identity.sql
+++ b/fabushi/web/migrations/20260508_users_id_identity.sql
@@ -1,12 +1,17 @@
 -- Managed D1 migration for the user-id-first auth and mapping close-out.
 -- Some long-lived D1 databases still have a legacy users table without users.id.
--- Rebuild those tables into the current id-backed shape before backfilling the
--- email/alipay mapping tables, so profile writes and fresh tokens can rely on
--- users.id without breaking old environments.
+-- D1 applies migrations inside a transaction, so we cannot rely on toggling
+-- foreign_keys off mid-flight. Rename the legacy tables first, rebuild the
+-- users table, repopulate the child tables, then drop the legacy copies while
+-- deferred foreign-key checks stay open until commit.
 
-PRAGMA foreign_keys = OFF;
+PRAGMA defer_foreign_keys = ON;
 
-CREATE TABLE users__id_migration (
+ALTER TABLE email_username_mapping RENAME TO email_username_mapping__legacy;
+ALTER TABLE alipay_bindings RENAME TO alipay_bindings__legacy;
+ALTER TABLE users RENAME TO users__legacy;
+
+CREATE TABLE users (
   id INTEGER PRIMARY KEY,
   username TEXT UNIQUE NOT NULL,
   email TEXT UNIQUE NOT NULL,
@@ -45,7 +50,7 @@ CREATE TABLE users__id_migration (
   updated_at TEXT
 );
 
-INSERT INTO users__id_migration (
+INSERT INTO users (
   id,
   username,
   email,
@@ -120,10 +125,7 @@ SELECT
   extra_data,
   created_at,
   updated_at
-FROM users;
-
-DROP TABLE users;
-ALTER TABLE users__id_migration RENAME TO users;
+FROM users__legacy;
 
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
@@ -133,26 +135,24 @@ CREATE INDEX IF NOT EXISTS idx_users_phone_number ON users(phone_number);
 CREATE INDEX IF NOT EXISTS idx_users_firebase_uid ON users(firebase_uid);
 CREATE INDEX IF NOT EXISTS idx_users_apple_user_id ON users(apple_user_id);
 
-CREATE TABLE email_username_mapping__user_id_migration (
+CREATE TABLE email_username_mapping (
   email TEXT PRIMARY KEY,
   username TEXT NOT NULL,
   user_id INTEGER,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-INSERT INTO email_username_mapping__user_id_migration (email, username, user_id)
+INSERT INTO email_username_mapping (email, username, user_id)
 SELECT
   map.email,
   map.username,
   users.id
-FROM email_username_mapping map
+FROM email_username_mapping__legacy map
 LEFT JOIN users ON users.username = map.username;
 
-DROP TABLE email_username_mapping;
-ALTER TABLE email_username_mapping__user_id_migration RENAME TO email_username_mapping;
 CREATE INDEX IF NOT EXISTS idx_email_username_mapping_user_id ON email_username_mapping(user_id);
 
-CREATE TABLE alipay_bindings__user_id_migration (
+CREATE TABLE alipay_bindings (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   alipay_user_id TEXT UNIQUE NOT NULL,
   username TEXT,
@@ -161,18 +161,18 @@ CREATE TABLE alipay_bindings__user_id_migration (
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-INSERT INTO alipay_bindings__user_id_migration (id, alipay_user_id, username, user_id, bound_at)
+INSERT INTO alipay_bindings (id, alipay_user_id, username, user_id, bound_at)
 SELECT
   binding.id,
   binding.alipay_user_id,
   binding.username,
   users.id,
   binding.bound_at
-FROM alipay_bindings binding
+FROM alipay_bindings__legacy binding
 LEFT JOIN users ON users.username = binding.username;
 
-DROP TABLE alipay_bindings;
-ALTER TABLE alipay_bindings__user_id_migration RENAME TO alipay_bindings;
 CREATE INDEX IF NOT EXISTS idx_alipay_bindings_user_id ON alipay_bindings(user_id);
 
-PRAGMA foreign_keys = ON;
+DROP TABLE email_username_mapping__legacy;
+DROP TABLE alipay_bindings__legacy;
+DROP TABLE users__legacy;


### PR DESCRIPTION
## Why

CD is still failing on `Apply development D1 migrations` after `#275`. The latest run for `main` commit `e58e88d2bac483924192e936cf52f1b15af455a6` shows only `20260508_users_id_identity.sql` pending, and it fails with `FOREIGN KEY constraint failed`.

The migration currently tries to flip `PRAGMA foreign_keys = OFF` while rebuilding `users`. That pattern does not hold inside D1's migration transaction, so the legacy child tables still block the parent-table swap.

## What changed

- Rework `20260508_users_id_identity.sql` to use `PRAGMA defer_foreign_keys = ON`.
- Rename the legacy `users`, `email_username_mapping`, and `alipay_bindings` tables first, rebuild the new `users` table, repopulate the child tables against the rebuilt ids, then drop the legacy tables in a transaction-safe order.
- Strengthen `.github/scripts/check-publish-cd-release.sh` so this migration keeps the deferred-foreign-key strategy and does not regress to the old `foreign_keys = OFF` / `DROP TABLE users` flow.

## Verification

- Local sqlite simulation of the legacy `users` / `email_username_mapping` / `alipay_bindings` schema with `PRAGMA foreign_keys = ON` and the migration executed inside an explicit transaction.
- Verified the migrated data keeps `users.id`, `stripe_customer_id`, `subscription_id`, and rebuilt `user_id` mappings for email/alipay rows.
