### PR TITLE
refactor: add user_no and group_no layering

### DIFF
--- a/fabushi/web/migrations/20260509_user_no_group_no_layering.sql
+++ b/fabushi/web/migrations/20260509_user_no_group_no_layering.sql
@@ -1,0 +1,37 @@
+-- Managed D1 migration for internal-id / external-number layering.
+-- users.id and meditation_groups.id remain the relational primary keys.
+-- user_no / group_no become the externally surfaced stable numbers.
+
+PRAGMA defer_foreign_keys = ON;
+
+ALTER TABLE users ADD COLUMN user_no INTEGER;
+UPDATE users
+SET user_no = id
+WHERE user_no IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_user_no ON users(user_no);
+
+CREATE TRIGGER IF NOT EXISTS trg_users_assign_user_no
+AFTER INSERT ON users
+FOR EACH ROW
+WHEN NEW.user_no IS NULL
+BEGIN
+  UPDATE users
+  SET user_no = NEW.id
+  WHERE id = NEW.id;
+END;
+
+ALTER TABLE meditation_groups ADD COLUMN group_no INTEGER;
+UPDATE meditation_groups
+SET group_no = id
+WHERE group_no IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_meditation_groups_group_no ON meditation_groups(group_no);
+
+CREATE TRIGGER IF NOT EXISTS trg_meditation_groups_assign_group_no
+AFTER INSERT ON meditation_groups
+FOR EACH ROW
+WHEN NEW.group_no IS NULL
+BEGIN
+  UPDATE meditation_groups
+  SET group_no = NEW.id
+  WHERE id = NEW.id;
+END;

--- a/fabushi/web/src/contracts/account-user.js
+++ b/fabushi/web/src/contracts/account-user.js
@@ -1,7 +1,10 @@
 export function serializeAccountUser(user) {
+  const userNo = user.user_no ?? user.id ?? null;
+
   return {
     id: user.id,
     userId: user.id,
+    userNo,
     username: user.username,
     email: user.email || '',
     nickname: user.nickname || user.username,
@@ -33,6 +36,7 @@ export function buildPasswordLoginPayload({ token, user }) {
     token,
     username: user.username,
     userId: user.id,
+    userNo: user.user_no ?? user.id ?? null,
     user: serializeAccountUser(user),
   };
 }

--- a/fabushi/web/src/handlers/auth.js
+++ b/fabushi/web/src/handlers/auth.js
@@ -12,9 +12,12 @@ import { deleteAccountCommand } from '../use-cases/delete-account.js';
 export { handleLogin, handleUpdateProfile, handleUploadAvatar };
 
 function serializeUser(user) {
+  const userNo = user.user_no ?? user.id ?? null;
+
   return {
     id: user.id,
     userId: user.id,
+    userNo,
     username: user.username,
     email: user.email || '',
     nickname: user.nickname || user.username,
@@ -108,6 +111,7 @@ export async function handleFirebasePhoneLogin(request, env, db) {
         token: await generateToken({ id: user.id, username: user.username }, env),
         username: user.username,
         userId: user.id,
+        userNo: user.user_no ?? user.id ?? null,
         isNewUser: false,
         user: serializeUser(user)
       });
@@ -132,6 +136,7 @@ export async function handleFirebasePhoneLogin(request, env, db) {
       : await db.getUser(username);
     const fallbackUser = createdUser || {
       id: null,
+      user_no: null,
       username,
       email,
       phone_number: phoneNumber,
@@ -146,6 +151,7 @@ export async function handleFirebasePhoneLogin(request, env, db) {
       token: await generateToken({ id: createdUser?.id, username }, env),
       username,
       userId: createdUser?.id,
+      userNo: createdUser?.user_no ?? createdUser?.id ?? null,
       isNewUser: isNewUser ?? true,
       user: serializeUser(fallbackUser)
     });
@@ -214,6 +220,7 @@ export async function handleAppleLogin(request, env, db) {
         token: await generateToken({ id: user.id, username: user.username }, env),
         username: user.username,
         userId: user.id,
+        userNo: user.user_no ?? user.id ?? null,
         isNewUser: false,
         user: serializeUser(user)
       });
@@ -238,6 +245,7 @@ export async function handleAppleLogin(request, env, db) {
         token: await generateToken({ id: updated.id, username: updated.username }, env),
         username: updated.username,
         userId: updated.id,
+        userNo: updated.user_no ?? updated.id ?? null,
         isNewUser: false,
         user: serializeUser(updated)
       });
@@ -259,6 +267,7 @@ export async function handleAppleLogin(request, env, db) {
       token: await generateToken({ id: createdUser?.id, username }, env),
       username,
       userId: createdUser?.id,
+      userNo: createdUser?.user_no ?? createdUser?.id ?? null,
       isNewUser: true,
       user: serializeUser(createdUser)
     });

--- a/fabushi/web/src/routes/meditation-routes.js
+++ b/fabushi/web/src/routes/meditation-routes.js
@@ -15,6 +15,137 @@ import {
   handleReviewMeditationGroupJoin,
   handleSyncRecord,
 } from '../handlers/meditation.js';
+import { jsonResponse } from '../utils/response.js';
+
+function asInt(value, fallback = 0) {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+async function resolveGroupIdFromGroupNo(db, groupNo) {
+  const normalizedGroupNo = asInt(groupNo);
+  if (!normalizedGroupNo) return null;
+  const result = await db.prepare(`
+    SELECT id
+    FROM meditation_groups
+    WHERE group_no = ?
+  `).bind(normalizedGroupNo).first();
+  return result?.id || null;
+}
+
+async function getGroupNoById(db, groupId) {
+  const normalizedGroupId = asInt(groupId);
+  if (!normalizedGroupId) return null;
+  const result = await db.prepare(`
+    SELECT group_no
+    FROM meditation_groups
+    WHERE id = ?
+  `).bind(normalizedGroupId).first();
+  return result?.group_no || null;
+}
+
+async function cloneRequestWithJsonBody(request, body) {
+  return new Request(request.url, {
+    method: request.method,
+    headers: request.headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function cloneRequestWithUrl(request, nextUrl) {
+  return new Request(nextUrl.toString(), {
+    method: request.method,
+    headers: request.headers,
+    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+  });
+}
+
+async function rewriteNumericGroupQueryToInternalId(request, db) {
+  const url = new URL(request.url);
+  const rawQuery = (url.searchParams.get('query') || '').trim();
+  const normalized = rawQuery.startsWith('#') ? rawQuery.slice(1).trim() : rawQuery;
+  if (!/^\d+$/.test(normalized)) {
+    return request;
+  }
+
+  const groupId = await resolveGroupIdFromGroupNo(db, normalized);
+  if (!groupId) {
+    return request;
+  }
+
+  url.searchParams.set('query', `#${groupId}`);
+  return cloneRequestWithUrl(request, url);
+}
+
+async function rewriteGroupDetailRequest(request, db) {
+  const url = new URL(request.url);
+  const groupNo = url.searchParams.get('groupNo');
+  if (!groupNo || url.searchParams.get('groupId')) {
+    return request;
+  }
+
+  const groupId = await resolveGroupIdFromGroupNo(db, groupNo);
+  if (!groupId) {
+    return request;
+  }
+
+  url.searchParams.set('groupId', String(groupId));
+  return cloneRequestWithUrl(request, url);
+}
+
+async function rewriteGroupBodyRequest(request, db) {
+  const body = await request.json();
+  if (body.groupId || !body.groupNo) {
+    return { request, body };
+  }
+
+  const groupId = await resolveGroupIdFromGroupNo(db, body.groupNo);
+  if (!groupId) {
+    return { request, body };
+  }
+
+  const nextBody = {
+    ...body,
+    groupId,
+  };
+
+  return {
+    request: await cloneRequestWithJsonBody(request, nextBody),
+    body: nextBody,
+  };
+}
+
+async function withVisibleGroupNumbers(response, db, options = {}) {
+  const payload = await response.json();
+  const nextPayload = structuredClone(payload);
+
+  const groups = nextPayload?.data?.groups;
+  if (Array.isArray(groups)) {
+    for (const group of groups) {
+      const groupNo = await getGroupNoById(db, group.id);
+      if (groupNo) {
+        group.groupNo = groupNo;
+      }
+    }
+  }
+
+  const group = nextPayload?.data?.group;
+  if (group?.id) {
+    const groupNo = await getGroupNoById(db, group.id);
+    if (groupNo) {
+      group.groupNo = groupNo;
+    }
+  }
+
+  if (options.includeCreatedGroupNo && nextPayload?.data?.groupId) {
+    const groupNo = await getGroupNoById(db, nextPayload.data.groupId);
+    if (groupNo) {
+      nextPayload.data.groupNo = groupNo;
+    }
+  }
+
+  return jsonResponse(nextPayload, response.status);
+}
 
 export async function routeMeditationRequest({ pathname, method, request, env, db }) {
   if (pathname === '/api/meditation/record' && method === 'POST') {
@@ -48,19 +179,26 @@ export async function routeMeditationRequest({ pathname, method, request, env, d
     return await handleMeditationSettings(request, env, db);
   }
   if (pathname === '/api/meditation/groups' && method === 'GET') {
-    return await handleGetMeditationGroups(request, env, db);
+    const nextRequest = await rewriteNumericGroupQueryToInternalId(request, db);
+    const response = await handleGetMeditationGroups(nextRequest, env, db);
+    return await withVisibleGroupNumbers(response, db);
   }
   if (pathname === '/api/meditation/groups' && method === 'POST') {
-    return await handleCreateMeditationGroup(request, env, db);
+    const response = await handleCreateMeditationGroup(request, env, db);
+    return await withVisibleGroupNumbers(response, db, { includeCreatedGroupNo: true });
   }
   if (pathname === '/api/meditation/groups/join' && method === 'POST') {
-    return await handleJoinMeditationGroup(request, env, db);
+    const { request: nextRequest } = await rewriteGroupBodyRequest(request, db);
+    return await handleJoinMeditationGroup(nextRequest, env, db);
   }
   if (pathname === '/api/meditation/groups/detail' && method === 'GET') {
-    return await handleGetMeditationGroupDetail(request, env, db);
+    const nextRequest = await rewriteGroupDetailRequest(request, db);
+    const response = await handleGetMeditationGroupDetail(nextRequest, env, db);
+    return await withVisibleGroupNumbers(response, db);
   }
   if (pathname === '/api/meditation/groups/review' && method === 'POST') {
-    return await handleReviewMeditationGroupJoin(request, env, db);
+    const { request: nextRequest } = await rewriteGroupBodyRequest(request, db);
+    return await handleReviewMeditationGroupJoin(nextRequest, env, db);
   }
 
   return null;

--- a/fabushi/web/src/services/database.js
+++ b/fabushi/web/src/services/database.js
@@ -92,6 +92,12 @@ export class DatabaseService {
     return await this.db.prepare('SELECT * FROM users WHERE id = ?').bind(normalizedId).first();
   }
 
+  async getUserByUserNo(userNo) {
+    const normalizedUserNo = Number(userNo);
+    if (!Number.isFinite(normalizedUserNo)) return null;
+    return await this.db.prepare('SELECT * FROM users WHERE user_no = ?').bind(normalizedUserNo).first();
+  }
+
   async getUserByAlipayId(alipayUserId) {
     const binding = await this.db.prepare(
       'SELECT user_id, username FROM alipay_bindings WHERE alipay_user_id = ?'
@@ -124,11 +130,13 @@ export class DatabaseService {
 
   async createUser(userData) {
     const userId = await this.generateUniqueUserId();
+    const userNo = await this.generateUniqueUserNo();
     await this.db.prepare(`
-      INSERT INTO users (id, username, email, password_hash, salt, iterations, algo, email_verified, membership_type, free_trial_end_date, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO users (id, user_no, username, email, password_hash, salt, iterations, algo, email_verified, membership_type, free_trial_end_date, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).bind(
       userId,
+      userNo,
       userData.username,
       userData.email,
       userData.passwordHash,
@@ -141,8 +149,8 @@ export class DatabaseService {
       userData.createdAt
     ).run();
 
-    const createdUser = await this.getUserById(userId);
-    if (!createdUser) throw new Error('创建用户后无法重新读取 users.id');
+    const createdUser = await this.getCreatedUser(userId, userNo);
+    if (!createdUser) throw new Error('创建用户后无法重新读取 users.id / users.user_no');
 
     await this.db.prepare(
       'INSERT INTO email_username_mapping (email, username, user_id) VALUES (?, ?, ?)'
@@ -177,11 +185,13 @@ export class DatabaseService {
 
   async createPhoneUser(userData) {
     const userId = await this.generateUniqueUserId();
+    const userNo = await this.generateUniqueUserNo();
     await this.db.prepare(`
-      INSERT INTO users (id, username, email, phone_number, firebase_uid, password_hash, salt, iterations, algo, email_verified, membership_type, free_trial_end_date, created_at)
-      VALUES (?, ?, ?, ?, ?, '', '', 0, '', 1, ?, ?, ?)
+      INSERT INTO users (id, user_no, username, email, phone_number, firebase_uid, password_hash, salt, iterations, algo, email_verified, membership_type, free_trial_end_date, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, '', '', 0, '', 1, ?, ?, ?)
     `).bind(
       userId,
+      userNo,
       userData.username,
       userData.email,
       userData.phoneNumber,
@@ -190,7 +200,7 @@ export class DatabaseService {
       userData.freeTrialEndDate,
       userData.createdAt
     ).run();
-    return await this.getUserById(userId);
+    return await this.getCreatedUser(userId, userNo);
   }
 
   async getUserByAppleId(appleUserId) {
@@ -199,11 +209,13 @@ export class DatabaseService {
 
   async createAppleUser(userData) {
     const userId = await this.generateUniqueUserId();
+    const userNo = await this.generateUniqueUserNo();
     await this.db.prepare(`
-      INSERT INTO users (id, username, email, apple_user_id, nickname, password_hash, salt, iterations, algo, email_verified, membership_type, membership_expires_at, created_at)
-      VALUES (?, ?, ?, ?, ?, '', '', 0, '', 1, ?, ?, ?)
+      INSERT INTO users (id, user_no, username, email, apple_user_id, nickname, password_hash, salt, iterations, algo, email_verified, membership_type, membership_expires_at, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, '', '', 0, '', 1, ?, ?, ?)
     `).bind(
       userId,
+      userNo,
       userData.username,
       userData.email,
       userData.appleUserId,
@@ -212,14 +224,20 @@ export class DatabaseService {
       userData.membershipExpiresAt,
       userData.createdAt
     ).run();
-    const createdUser = await this.getUserById(userId);
-    if (!createdUser) throw new Error('创建 Apple 用户后无法重新读取 users.id');
+    const createdUser = await this.getCreatedUser(userId, userNo);
+    if (!createdUser) throw new Error('创建 Apple 用户后无法重新读取 users.id / users.user_no');
     if (userData.email) {
       await this.db.prepare(
         'INSERT OR REPLACE INTO email_username_mapping (email, username, user_id) VALUES (?, ?, ?)'
       ).bind(userData.email, userData.username, createdUser.id).run();
     }
     return createdUser;
+  }
+
+  async getCreatedUser(userId, userNo) {
+    const userById = await this.getUserById(userId);
+    if (userById) return userById;
+    return await this.getUserByUserNo(userNo);
   }
 
   async generateUniqueUserId() {
@@ -230,4 +248,17 @@ export class DatabaseService {
     }
     throw new Error('无法生成可用的雪花式用户 ID');
   }
+
+  async generateUniqueUserNo() {
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const candidate = generateSixDigitNo();
+      const existing = await this.getUserByUserNo(candidate);
+      if (!existing) return candidate;
+    }
+    throw new Error('无法生成可用的 6 位用户号');
+  }
+}
+
+function generateSixDigitNo() {
+  return Math.floor(100000 + Math.random() * 900000);
 }

--- a/fabushi/web/tests/external-number-layering.test.js
+++ b/fabushi/web/tests/external-number-layering.test.js
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { serializeAccountUser, buildPasswordLoginPayload } from '../src/contracts/account-user.js';
+import { DatabaseService } from '../src/services/database.js';
+
+function createDbMock() {
+  const state = {
+    users: [],
+    emailMappings: [],
+  };
+
+  return {
+    prepare(sql) {
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+      return {
+        bind(...params) {
+          return {
+            async first() {
+              if (normalizedSql === 'SELECT * FROM users WHERE id = ?') {
+                return state.users.find((user) => user.id === Number(params[0])) || null;
+              }
+              if (normalizedSql === 'SELECT * FROM users WHERE user_no = ?') {
+                return state.users.find((user) => user.user_no === Number(params[0])) || null;
+              }
+              if (normalizedSql === 'SELECT * FROM users WHERE email = ?') {
+                return state.users.find((user) => user.email === params[0]) || null;
+              }
+              if (normalizedSql === 'SELECT user_id, username FROM email_username_mapping WHERE email = ?') {
+                return state.emailMappings.find((entry) => entry.email === params[0]) || null;
+              }
+              return null;
+            },
+            async run() {
+              if (normalizedSql.startsWith('INSERT INTO users (id, user_no, username, email, password_hash, salt, iterations, algo, email_verified, membership_type, free_trial_end_date, created_at)')) {
+                const [userId, userNo, username, email, passwordHash, salt, iterations, algo, emailVerified, membershipType, freeTrialEndDate, createdAt] = params;
+                const user = {
+                  id: Number(userId),
+                  user_no: Number(userNo),
+                  username,
+                  email,
+                  password_hash: passwordHash,
+                  salt,
+                  iterations,
+                  algo,
+                  email_verified: emailVerified,
+                  membership_type: membershipType,
+                  free_trial_end_date: freeTrialEndDate,
+                  created_at: createdAt,
+                };
+                state.users.push(user);
+                return { meta: { last_row_id: user.id } };
+              }
+              if (normalizedSql === 'INSERT INTO email_username_mapping (email, username, user_id) VALUES (?, ?, ?)') {
+                const [email, username, userId] = params;
+                state.emailMappings.push({ email, username, user_id: userId });
+                return { meta: {} };
+              }
+              throw new Error(`Unexpected SQL in test: ${normalizedSql}`);
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('serializeAccountUser and login payload expose userNo separately from internal id', () => {
+  const user = {
+    id: 12,
+    user_no: 618273,
+    username: 'mingyue',
+    email: 'mingyue@example.com',
+    nickname: '明月',
+    created_at: '2026-05-09T00:00:00Z',
+    email_verified: 1,
+    membership_type: 'trial',
+    free_trial_end_date: '2026-05-16T00:00:00Z',
+  };
+
+  const serialized = serializeAccountUser(user);
+  assert.equal(serialized.id, 12);
+  assert.equal(serialized.userId, 12);
+  assert.equal(serialized.userNo, 618273);
+
+  const payload = buildPasswordLoginPayload({ token: 'token', user });
+  assert.equal(payload.userId, 12);
+  assert.equal(payload.userNo, 618273);
+  assert.equal(payload.user.userNo, 618273);
+});
+
+test('DatabaseService createUser stores generated user_no while id stays snowflake internal id', async () => {
+  const db = createDbMock();
+  const service = new DatabaseService(db);
+
+  const created = await service.createUser({
+    username: 'liangchen',
+    email: 'liangchen@example.com',
+    passwordHash: 'hash',
+    salt: 'salt',
+    iterations: 1,
+    algo: 'pbkdf2',
+    emailVerified: true,
+    membershipType: 'trial',
+    freeTrialEndDate: '2026-05-16T00:00:00Z',
+    createdAt: '2026-05-09T00:00:00Z',
+  });
+
+  assert.equal(Number.isSafeInteger(created.id), true);
+  assert.match(String(created.user_no), /^\d{6}$/);
+  assert.notEqual(created.user_no, created.id);
+});


### PR DESCRIPTION
## Summary
- add `users.user_no` as the externally visible user number while preserving `users.id` as the internal snowflake primary key
- add the managed migration for `users.user_no` and `meditation_groups.group_no` backfill / insert-time fallbacks
- expose `userNo` in account/auth payloads and add groupNo compatibility around meditation group routes
- add focused regression coverage for account payload serialization and user creation layering

## Conflict Resolution
- rebuilt this PR branch on top of the latest `main` after #289
- kept the main-branch snowflake `users.id` implementation instead of reintroducing autoincrement internal IDs
- kept #289's profile username-rename token rotation contract while adding `userNo`
- dropped the stale schema-file conflict hunks that changed internal IDs to `AUTOINCREMENT`; the rollout now relies on the managed D1 migration

## Validation
- focused external-number regression test included
- GitHub CI is running on the rebuilt clean commit

## Notes
- the migration backfills existing rows with `user_no = id` and `group_no = id` so existing visible numbers remain stable during the transition
- `meditation_groups` gets the second-layer column through migration, and the route layer accepts/returns `groupNo` while preserving internal `groupId` behavior