### PR TITLE
fix: unblock legacy D1 identity migration in CD

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -112,6 +112,7 @@ for forbidden in (
     'PRAGMA foreign_keys = OFF;',
     'DROP TABLE users;',
     'ALTER TABLE users__id_migration RENAME TO users;',
+    'binding.id,',
 ):
     if forbidden in identity_migration:
         missing.append(f'identity migration should not contain: {forbidden}')

--- a/fabushi/web/migrations/20260508_users_id_identity.sql
+++ b/fabushi/web/migrations/20260508_users_id_identity.sql
@@ -161,9 +161,8 @@ CREATE TABLE alipay_bindings (
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-INSERT INTO alipay_bindings (id, alipay_user_id, username, user_id, bound_at)
+INSERT INTO alipay_bindings (alipay_user_id, username, user_id, bound_at)
 SELECT
-  binding.id,
   binding.alipay_user_id,
   binding.username,
   users.id,


### PR DESCRIPTION
## Summary
- stop the identity migration from assuming legacy `alipay_bindings` rows always have an `id` column
- let rebuilt `alipay_bindings` rows receive fresh autoincrement ids while preserving the important external fields and `user_id` linkage
- add a guardrail so the migration cannot drift back to the broken legacy-column assumption

## Why
`main` is currently blocked in CD on the `Apply development D1 migrations` step. The latest failure is concrete:

- workflow run: `CD #150`
- job: `Deploy staging environment`
- error: `no such column: binding.id`

That points to `fabushi/web/migrations/20260508_users_id_identity.sql` assuming every historical `alipay_bindings` table already had an `id` column. Older long-lived D1 databases do not guarantee that shape, so the migration fails before staging deploy can even start.

## What Changed
- changed the `alipay_bindings__legacy -> alipay_bindings` backfill to insert only `alipay_user_id`, `username`, `user_id`, and `bound_at`
- left the rebuilt table definition as `id INTEGER PRIMARY KEY AUTOINCREMENT`, so SQLite/D1 assigns fresh row ids during backfill instead of reading a legacy column that may not exist
- extended `.github/scripts/check-publish-cd-release.sh` to reject reintroducing `binding.id,` into the identity migration

## Validation
- reasoned directly from the failing CD log for run `25586013694` / job `75114737820`
- verified the failure lines point at `binding.id` in the `alipay_bindings` backfill query
- kept the fix scoped to the exact incompatible legacy-shape assumption so downstream auth/account work stays untouched

## Follow-up
- once this PR merges, re-check the next `main -> CD -> staging migrations` run before declaring issue `#278` closed
- if staging gets past migrations, continue the full `CD -> GitHub Release -> TestFlight` chain review