### PR TITLE
Refine official site homepage into a cleaner Codex-inspired landing page

### DIFF
--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -1,17 +1,21 @@
 :root {
   color-scheme: dark;
-  --bg: #09090b;
-  --bg-elevated: #111216;
-  --surface: rgba(17, 18, 22, 0.82);
+  --bg: #050608;
+  --bg-soft: #0b0d10;
+  --bg-elevated: #101317;
+  --surface: rgba(16, 19, 23, 0.72);
   --surface-strong: rgba(255, 255, 255, 0.04);
-  --ink: #f4efe8;
-  --muted: #b1a69a;
-  --muted-strong: #d8cdbf;
-  --accent: #c98b4a;
-  --accent-strong: #f1bb78;
+  --surface-glow: rgba(130, 161, 255, 0.08);
+  --ink: #f4f7fb;
+  --muted: #a5adb8;
+  --muted-strong: #d6dde7;
+  --accent: #f3f4f6;
+  --accent-ink: #050608;
   --line: rgba(255, 255, 255, 0.1);
-  --line-strong: rgba(255, 255, 255, 0.16);
-  --shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+  --line-strong: rgba(255, 255, 255, 0.18);
+  --brand: #7b8cff;
+  --brand-soft: rgba(123, 140, 255, 0.18);
+  --shadow: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 24px 80px rgba(0, 0, 0, 0.34);
 }
 
 * {
@@ -25,11 +29,11 @@ html {
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top left, rgba(201, 139, 74, 0.22), transparent 30%),
-    radial-gradient(circle at top right, rgba(255, 255, 255, 0.06), transparent 28%),
-    linear-gradient(180deg, #0b0b0f 0%, #101114 48%, #09090b 100%);
+    radial-gradient(circle at 18% 18%, rgba(123, 140, 255, 0.16), transparent 26%),
+    radial-gradient(circle at 82% 12%, rgba(255, 255, 255, 0.08), transparent 18%),
+    linear-gradient(180deg, #050608 0%, #0a0c0f 42%, #050608 100%);
   color: var(--ink);
-  font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  font-family: "Noto Sans SC", "PingFang SC", "Helvetica Neue", Arial, sans-serif;
 }
 
 a {
@@ -47,14 +51,14 @@ a {
 .inner-hero,
 .article-body,
 .site-footer {
-  padding-left: 24px;
-  padding-right: 24px;
+  padding-left: clamp(20px, 4vw, 48px);
+  padding-right: clamp(20px, 4vw, 48px);
 }
 
 .hero,
 .band {
-  padding-top: 36px;
-  padding-bottom: 88px;
+  padding-top: 32px;
+  padding-bottom: 96px;
 }
 
 .inner-hero {
@@ -67,14 +71,20 @@ a {
   display: flex;
   flex-direction: column;
   gap: 36px;
-  justify-content: flex-start;
 }
 
+.hero-stage,
 .hero-grid,
 .split-layout,
 .dual-grid {
   display: grid;
-  gap: 24px;
+  gap: 28px;
+}
+
+.hero-stage {
+  grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.95fr);
+  align-items: center;
+  flex: 1;
 }
 
 .hero-grid {
@@ -90,7 +100,7 @@ a {
 }
 
 .hero-copy {
-  padding: 12vh 0 6vh;
+  padding: 9vh 0 4vh;
 }
 
 .inner-copy {
@@ -99,15 +109,16 @@ a {
 
 .site-nav {
   position: sticky;
-  top: 0;
-  z-index: 10;
+  top: 18px;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 14px 18px;
+  padding: 14px 16px;
+  border-radius: 14px;
   border: 1px solid var(--line);
-  background: rgba(9, 9, 11, 0.72);
+  background: rgba(5, 6, 8, 0.72);
   backdrop-filter: blur(18px);
   box-shadow: var(--shadow);
 }
@@ -115,7 +126,7 @@ a {
 .site-wordmark {
   display: inline-flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   min-width: fit-content;
 }
 
@@ -125,7 +136,7 @@ a {
 }
 
 .site-wordmark span {
-  font-size: 0.98rem;
+  font-size: 0.95rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -133,12 +144,13 @@ a {
 
 .site-wordmark small {
   color: var(--muted);
-  font-size: 0.78rem;
+  font-size: 0.76rem;
 }
 
 .site-nav-cluster,
 .site-nav-links,
-.footer-links {
+.footer-links,
+.hero-signal-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -148,6 +160,11 @@ a {
 .site-nav-links,
 .footer-links {
   color: var(--muted);
+}
+
+.site-nav-links a,
+.footer-links a {
+  transition: color 180ms ease;
 }
 
 .site-nav-links a:hover,
@@ -164,21 +181,26 @@ a {
   justify-content: center;
   min-height: 42px;
   padding: 11px 18px;
-  border-radius: 8px;
-  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, color 180ms ease;
+  border-radius: 10px;
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    box-shadow 180ms ease;
 }
 
 .nav-action,
 .primary-action {
   background: var(--accent);
-  color: #1a1108;
+  color: var(--accent-ink);
   font-weight: 600;
 }
 
 .secondary-action,
 .tertiary-action {
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.02);
   color: var(--ink);
 }
 
@@ -197,23 +219,24 @@ a {
 .section-heading p,
 .platform-name,
 .download-status,
-.article-date {
+.article-date,
+.statement-card span {
   margin: 0 0 14px;
-  color: var(--accent-strong);
-  font-size: 0.92rem;
-  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .brand-kicker {
   margin: 0 0 18px;
   color: var(--muted-strong);
-  font-size: clamp(1.15rem, 2.3vw, 1.8rem);
+  font-size: clamp(1.05rem, 2vw, 1.3rem);
   font-weight: 500;
 }
 
 .brand-kicker span {
-  color: var(--muted);
+  color: var(--brand);
 }
 
 .hero-copy h1,
@@ -226,21 +249,26 @@ a {
 .download-card h2,
 .release-card h2,
 .decision-card h3,
-.compare-card h3 {
+.compare-card h3,
+.statement-card h3,
+.feature-column h3,
+.cta-panel h2 {
   margin: 0;
-  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
-  line-height: 1.08;
-  letter-spacing: 0;
+  line-height: 1.04;
+  letter-spacing: -0.04em;
 }
 
 .hero-copy h1 {
   max-width: 11ch;
-  font-size: clamp(3.2rem, 7vw, 6.2rem);
+  font-size: clamp(3.3rem, 8vw, 6.8rem);
+  font-weight: 600;
 }
 
 .inner-copy h1,
-.section-heading h2 {
-  font-size: clamp(2.3rem, 4.8vw, 4.4rem);
+.section-heading h2,
+.cta-panel h2 {
+  font-size: clamp(2.3rem, 5vw, 4.4rem);
+  font-weight: 600;
 }
 
 .section-heading.compact h2 {
@@ -273,15 +301,18 @@ a {
 .decision-card p,
 .compare-card p,
 .decision-list,
-.compare-list {
+.compare-list,
+.feature-column p,
+.statement-card a,
+.hero-console-line span {
   color: var(--muted);
-  line-height: 1.75;
+  line-height: 1.72;
 }
 
 .lede {
   margin: 22px 0 0;
-  max-width: 46rem;
-  font-size: 1.08rem;
+  max-width: 38rem;
+  font-size: 1.06rem;
 }
 
 .hero-actions,
@@ -293,9 +324,100 @@ a {
   margin-top: 30px;
 }
 
-.hero-rail {
+.hero-signal-row {
+  margin-top: 32px;
+  gap: 10px;
+}
+
+.hero-signal-row span {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--muted-strong);
+  font-size: 0.85rem;
+}
+
+.hero-visual {
+  position: relative;
+  min-height: 520px;
   display: grid;
+  place-items: center;
+}
+
+.hero-orbit {
+  position: absolute;
+  inset: auto;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  filter: blur(0.2px);
+}
+
+.hero-orbit-a {
+  width: min(46vw, 440px);
+  height: min(46vw, 440px);
+  background: radial-gradient(circle at 50% 50%, rgba(123, 140, 255, 0.18), transparent 62%);
+  animation: slowPulse 10s ease-in-out infinite;
+}
+
+.hero-orbit-b {
+  width: min(34vw, 320px);
+  height: min(34vw, 320px);
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.06), transparent 60%);
+  animation: slowPulse 10s ease-in-out infinite reverse;
+}
+
+.hero-console {
+  position: relative;
+  width: min(100%, 440px);
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
+    linear-gradient(180deg, rgba(9, 11, 14, 0.94), rgba(9, 11, 14, 0.82));
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.hero-console-head,
+.hero-console-line {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
   gap: 16px;
+}
+
+.hero-console-head {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted-strong);
+  font-size: 0.9rem;
+}
+
+.hero-console-head small {
+  color: var(--muted);
+  justify-self: end;
+}
+
+.hero-console-body {
+  padding: 18px 20px 22px;
+  display: grid;
+  gap: 18px;
+}
+
+.hero-console-line em,
+.feature-column small {
+  color: var(--brand);
+  font-style: normal;
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.hero-console-line strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 1.05rem;
+  color: var(--ink);
 }
 
 .hero-panel,
@@ -310,7 +432,9 @@ a {
 .contact-card,
 .stack-card,
 .decision-card,
-.compare-card {
+.compare-card,
+.statement-card,
+.cta-panel {
   border: 1px solid var(--line);
   background: var(--surface);
   backdrop-filter: blur(16px);
@@ -329,27 +453,22 @@ a {
 .contact-card,
 .stack-card,
 .decision-card,
-.compare-card {
-  border-radius: 10px;
-  padding: 20px;
+.compare-card,
+.statement-card,
+.cta-panel {
+  border-radius: 18px;
+  padding: 22px;
 }
 
-.hero-panel strong,
-.mini-stat strong,
-.platform-meta strong,
-.download-card strong,
-.editorial-row strong,
-.contact-card strong {
-  display: block;
+.compact-band {
+  padding-top: 24px;
 }
 
-.hero-panel strong {
-  margin: 8px 0 10px;
-  font-size: 1.22rem;
-  line-height: 1.45;
+.minimal-band {
+  background: rgba(255, 255, 255, 0.02);
 }
 
-.hero-mini-grid,
+.statement-grid,
 .proof-grid,
 .audience-grid,
 .feature-grid,
@@ -364,32 +483,52 @@ a {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.mini-stat {
-  padding: 16px 18px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.02);
-  border-radius: 10px;
+.statement-card {
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
-.mini-stat strong {
-  margin-top: 8px;
-  font-size: 1rem;
-  line-height: 1.5;
+.statement-card h3 {
+  max-width: 14ch;
+  font-size: clamp(1.4rem, 2vw, 2rem);
+  font-weight: 500;
+}
+
+.statement-card a {
+  color: var(--muted-strong);
+}
+
+.editorial-band {
+  padding-top: 24px;
+}
+
+.editorial-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 22px;
+  align-items: start;
+}
+
+.feature-column {
+  padding-top: 18px;
+  border-top: 1px solid var(--line-strong);
+}
+
+.feature-column h3 {
+  margin-top: 14px;
+  font-size: clamp(1.4rem, 2vw, 2rem);
+  font-weight: 500;
+}
+
+.feature-column p {
+  margin-top: 14px;
+  max-width: 24rem;
 }
 
 .band.alt {
-  background: rgba(255, 255, 255, 0.02);
-}
-
-.band.cinematic,
-.cta-band {
-  background:
-    linear-gradient(120deg, rgba(201, 139, 74, 0.1), rgba(255, 255, 255, 0.02)),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
-}
-
-.proof-band {
-  padding-top: 0;
+  background: rgba(255, 255, 255, 0.015);
 }
 
 .section-heading {
@@ -400,6 +539,7 @@ a {
   max-width: 760px;
 }
 
+.platform-list,
 .platform-strip,
 .editorial-list,
 .faq-list,
@@ -409,25 +549,22 @@ a {
   gap: 12px;
 }
 
-.faq-list.full {
-  gap: 18px;
-}
-
-.status-note-list {
+.faq-shell {
   display: grid;
-  gap: 8px;
-  margin-top: 18px;
+  grid-template-columns: minmax(0, 0.72fr) minmax(0, 1fr);
+  gap: 28px;
+  align-items: start;
 }
 
 .platform-row,
 .editorial-row {
   display: grid;
   gap: 16px;
-  padding: 20px 0;
+  padding: 22px 0;
   border-top: 1px solid var(--line);
 }
 
-.platform-row {
+.platform-row.refined {
   grid-template-columns: minmax(0, 1fr) max-content;
   align-items: end;
 }
@@ -444,6 +581,16 @@ a {
 
 .platform-meta {
   text-align: right;
+}
+
+.platform-meta strong,
+.contact-card strong {
+  display: block;
+}
+
+.platform-meta span {
+  color: var(--muted);
+  font-size: 0.92rem;
 }
 
 .release-card,
@@ -522,6 +669,14 @@ a {
   align-items: center;
 }
 
+.contact-grid.minimal {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.contact-card.minimal {
+  min-height: 180px;
+}
+
 .contact-card span,
 .contact-card strong {
   display: block;
@@ -533,7 +688,7 @@ a {
 
 .faq-item {
   border-top: 1px solid var(--line);
-  padding-top: 16px;
+  padding-top: 18px;
 }
 
 .faq-item:first-child {
@@ -549,8 +704,16 @@ a {
 }
 
 .faq-item p {
-  margin: 10px 0 0;
-  max-width: 60rem;
+  margin: 12px 0 0;
+  max-width: 58rem;
+}
+
+.cta-panel {
+  display: grid;
+  gap: 28px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02)),
+    linear-gradient(135deg, rgba(123, 140, 255, 0.08), rgba(255, 255, 255, 0.02));
 }
 
 .article-body {
@@ -577,7 +740,23 @@ a {
   font-weight: 700;
 }
 
-@media (max-width: 960px) {
+@keyframes slowPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.9;
+  }
+
+  50% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 1080px) {
+  .hero-stage,
+  .faq-shell,
+  .editorial-feature-grid,
   .hero-grid,
   .split-layout,
   .dual-grid {
@@ -587,6 +766,14 @@ a {
   .hero-copy {
     padding-top: 8vh;
     padding-bottom: 0;
+  }
+
+  .hero-copy h1 {
+    max-width: 12ch;
+  }
+
+  .hero-visual {
+    min-height: 420px;
   }
 }
 
@@ -612,9 +799,10 @@ a {
     position: static;
   }
 
-  .platform-row,
+  .platform-row.refined,
   .editorial-row,
-  .preview-row {
+  .preview-row,
+  .contact-grid.minimal {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -624,5 +812,11 @@ a {
 
   .hero-copy h1 {
     max-width: none;
+    font-size: clamp(2.9rem, 14vw, 4.4rem);
+  }
+
+  .statement-card,
+  .contact-card.minimal {
+    min-height: auto;
   }
 }

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,63 +1,42 @@
-import { fabushiApiClient } from "@fabushi/api-client";
-import { brand, contactChannels, faqItems, homeHighlights, launchRoadmap } from "@fabushi/shared";
+import { brand, contactChannels, downloadOptions, faqItems, homeHighlights } from "@fabushi/shared";
 import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
-import { getAllArticles, getFeaturedArticles } from "../lib/content";
-import { getOfficialSiteReleaseCollection } from "../lib/official-site-releases";
 import { siteHref, siteUrl } from "../lib/site-url";
 
-const audienceGroups = [
+const heroSignals = [
+  "产品定位",
+  "下载状态",
+  "测试申请",
+  "常见问题",
+] as const;
+
+const intentPaths = [
   {
-    title: "第一次接触法布施的人",
-    description: "先在官网看清产品定位、下载状态、FAQ 和首期开放范围，不必先进入应用才理解项目。",
+    title: "先理解",
+    description: "用最短路径看清法布施是什么、适合谁、现在开放到哪里。",
+    href: "/faq",
+    label: "查看常见问题",
   },
   {
-    title: "想参与内测与反馈的人",
-    description: "直接找到 Android Beta、iOS TestFlight、申请入口和支持邮箱，减少来回询问。",
+    title: "再进入",
+    description: "根据平台状态选择 Android、iOS 或小程序相关入口，不走空页面。",
+    href: "/download",
+    label: "打开下载入口",
   },
   {
-    title: "关注传播与共修的人",
-    description: "通过内容专栏、公开榜单、公开档案与后续专题页，理解平台如何承接佛法传播与同行连接。",
+    title: "然后参与",
+    description: "如果你愿意内测、反馈问题或讨论合作，直接进入明确的联系路径。",
+    href: "/apply",
+    label: "申请测试资格",
   },
 ] as const;
 
-const trustPillars = [
-  {
-    title: "官网不是一张静态海报",
-    description: "首页、下载入口、FAQ、内容专栏和联系信息都围绕真实用户问题来组织，降低首次理解成本。",
-  },
-  {
-    title: "发布状态会回流到官网",
-    description: "Android Beta、iOS TestFlight 与正式版信息会随着发布资产同步更新，避免入口失真或过期。",
-  },
-  {
-    title: "内容、入口与应用体验分工清晰",
-    description: "官网负责理解与转化，小程序负责轻触达，主应用负责完整体验，减少用户对渠道角色的困惑。",
-  },
-] as const;
+const conciseFaq = faqItems.slice(0, 3);
+const conciseHighlights = homeHighlights.slice(0, 3);
+const conciseDownloads = downloadOptions.slice(0, 3);
+const conciseContacts = contactChannels.slice(0, 2);
 
-async function getLeaderboardPreview() {
-  try {
-    const data = await fabushiApiClient.get<{
-      leaderboard: Array<{
-        username: string;
-        displayName: string;
-        totalBytes: number;
-      }>;
-    }>("/api/leaderboard?limit=3");
-    return data.leaderboard;
-  } catch {
-    return [];
-  }
-}
-
-export default async function HomePage() {
-  const leaderboard = await getLeaderboardPreview();
-  const featuredArticles = getFeaturedArticles();
-  const allArticles = getAllArticles();
-  const releaseCollection = await getOfficialSiteReleaseCollection();
-  const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
-
+export default function HomePage() {
   const structuredData = {
     "@context": "https://schema.org",
     "@graph": [
@@ -75,8 +54,7 @@ export default async function HomePage() {
         name: `${brand.name} 官网`,
         url: siteUrl("/"),
         inLanguage: "zh-CN",
-        description:
-          "Fabushi 法布施官网，集中提供产品介绍、下载入口、测试申请、FAQ 与更新内容，帮助用户快速理解平台定位与当前开放能力。",
+        description: "Fabushi 法布施官网，集中提供产品介绍、下载入口、测试申请与 FAQ。",
       },
       {
         "@type": "SoftwareApplication",
@@ -84,12 +62,11 @@ export default async function HomePage() {
         applicationCategory: "LifestyleApplication",
         operatingSystem: "iOS, Android, Web",
         url: siteUrl("/download"),
-        description:
-          "围绕佛法传播、修行记录、公开档案、榜单与共修连接构建的产品体系，官网负责下载引导、信息说明与持续内容更新。",
+        description: "围绕佛法传播、修行记录与共修连接构建的产品体系。",
       },
       {
         "@type": "FAQPage",
-        mainEntity: faqItems.slice(0, 4).map((item) => ({
+        mainEntity: conciseFaq.map((item) => ({
           "@type": "Question",
           name: item.question,
           acceptedAnswer: {
@@ -102,105 +79,99 @@ export default async function HomePage() {
   };
 
   return (
-    <main className="page-shell">
+    <main className="page-shell home-shell">
       <script
         type="application/ld+json"
         suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
-      <header className="hero">
+      <section className="hero">
         <SiteHeader />
 
-        <div className="hero-grid">
+        <div className="hero-stage">
           <div className="hero-copy">
             <p className="eyebrow">佛法传播平台</p>
             <p className="brand-kicker">
               {brand.name} <span>Fabushi</span>
             </p>
-            <h1>让佛法传播、修行记录与共修连接，在一个清晰可信的入口里开始。</h1>
+            <h1>一个更安静、更清晰的入口，让人先理解法布施，再决定是否进入。</h1>
             <p className="lede">
-              Fabushi 官网集中承接产品介绍、下载入口、测试申请、FAQ 与更新内容，让第一次接触项目的人也能快速知道：
-              这是什么、适合谁、现在能做什么。
+              官网不再试图一次讲完所有事情。它先把产品定位、下载状态、测试申请和常见问题整理清楚，让第一次到来的人几秒内知道下一步该去哪里。
             </p>
+
             <div className="hero-actions">
               <a className="primary-action" href={siteHref("/download")}>
                 查看下载入口
               </a>
-              <a className="secondary-action" href={siteHref("/apply")}>
-                申请测试资格
-              </a>
-              <a className="tertiary-action" href={siteHref("/faq")}>
+              <a className="secondary-action" href={siteHref("/faq")}>
                 先看常见问题
               </a>
             </div>
+
+            <div className="hero-signal-row" aria-label="首页重点信息">
+              {heroSignals.map((item) => (
+                <span key={item}>{item}</span>
+              ))}
+            </div>
           </div>
 
-          <aside className="hero-rail">
-            <div className="hero-panel">
-              <p>当前开放重点</p>
-              <strong>官网先负责理解、入口与转化，再把轻触达交给小程序，把完整体验交给主应用。</strong>
-              <span>
-                这意味着首页会优先说清定位、下载状态、首期范围、FAQ 与联系路径，而不是只展示一句抽象口号。
-              </span>
+          <div className="hero-visual" aria-hidden="true">
+            <div className="hero-orbit hero-orbit-a" />
+            <div className="hero-orbit hero-orbit-b" />
+            <div className="hero-console">
+              <div className="hero-console-head">
+                <span>Fabushi / Home</span>
+                <small>Live structure</small>
+              </div>
+              <div className="hero-console-body">
+                <div className="hero-console-line">
+                  <em>01</em>
+                  <strong>这是什么</strong>
+                  <span>佛法传播、修行记录、共修连接</span>
+                </div>
+                <div className="hero-console-line">
+                  <em>02</em>
+                  <strong>现在能做什么</strong>
+                  <span>看状态、找入口、申请测试、了解 FAQ</span>
+                </div>
+                <div className="hero-console-line">
+                  <em>03</em>
+                  <strong>下一步去哪里</strong>
+                  <span>下载页、申请页、联系页</span>
+                </div>
+              </div>
             </div>
-
-            <div className="hero-mini-grid">
-              <div className="mini-stat">
-                <span>下载与发布</span>
-                <strong>{releasePreview.length > 0 ? `${releasePreview.length} 个入口已同步` : "入口持续更新中"}</strong>
-              </div>
-              <div className="mini-stat">
-                <span>内容专栏</span>
-                <strong>{allArticles.length} 篇公开内容已上线</strong>
-              </div>
-              <div className="mini-stat">
-                <span>信任与证明</span>
-                <strong>{leaderboard.length > 0 ? "排行榜预览可直接读取" : "静态页面也能先完整理解项目"}</strong>
-              </div>
-            </div>
-          </aside>
+          </div>
         </div>
-      </header>
+      </section>
 
-      <section className="band proof-band" id="why-fabushi">
+      <section className="band compact-band" id="why-fabushi">
         <div className="section-heading narrow">
-          <p>为什么官网值得先看</p>
-          <h2>先把“这是什么、现在开放到哪里、我下一步该点哪里”讲清楚，用户才会继续往下走。</h2>
+          <p>首页原则</p>
+          <h2>少一点解释负担，多一点方向感。</h2>
         </div>
-        <div className="proof-grid">
-          {trustPillars.map((item) => (
-            <article key={item.title} className="proof-card">
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
+        <div className="statement-grid">
+          {intentPaths.map((item) => (
+            <article key={item.title} className="statement-card">
+              <span>{item.title}</span>
+              <h3>{item.description}</h3>
+              <a href={siteHref(item.href)}>{item.label}</a>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="band alt" id="for-whom">
-        <div className="section-heading">
-          <p>适合谁先进入</p>
-          <h2>如果你想理解法布施平台，而不是先下载再摸索，官网应该先把这三类人服务好。</h2>
-        </div>
-        <div className="audience-grid">
-          {audienceGroups.map((item) => (
-            <article key={item.title} className="audience-card">
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band" id="capabilities">
+      <section className="band editorial-band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
-          <h2>官网要先把用户能感受到的价值说具体，再把渠道和技术分工解释清楚。</h2>
+          <h2>法布施不是一个单点工具，而是一条从传播到连接的连续路径。</h2>
         </div>
-        <div className="feature-grid">
-          {homeHighlights.map((item) => (
-            <article key={item.title} className="feature-block">
+
+        <div className="editorial-feature-grid">
+          {conciseHighlights.map((item, index) => (
+            <article key={item.title} className="feature-column">
+              <small>{`0${index + 1}`}</small>
               <h3>{item.title}</h3>
               <p>{item.description}</p>
             </article>
@@ -208,144 +179,68 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band cinematic" id="download">
+      <section className="band alt minimal-band" id="download">
         <div className="section-heading">
-          <p>下载与状态</p>
-          <h2>下载页会优先承接真实发布状态，而不是让用户进入一个只会让他继续等待的空入口。</h2>
+          <p>当前入口</p>
+          <h2>把真实状态摆在前面，比堆很多承诺更有用。</h2>
         </div>
-        <div className="platform-strip">
-          {releasePreview.map((item) => (
-            <a key={`${item.audience}-${item.platform}`} className="platform-row" href={siteHref(item.primaryHref)}>
+
+        <div className="platform-list">
+          {conciseDownloads.map((item) => (
+            <a key={item.platform} className="platform-row refined" href={siteHref(item.ctaHref)}>
               <div>
-                <span className="platform-name">{item.title}</span>
+                <span className="platform-name">{item.platform}</span>
                 <p>{item.description}</p>
               </div>
               <div className="platform-meta">
                 <strong>{item.status}</strong>
-                <span>{item.primaryLabel}</span>
+                <span>{item.ctaLabel}</span>
               </div>
             </a>
           ))}
         </div>
-        <div className="status-note-list">
-          {releaseCollection.notes.map((item) => (
-            <p key={item}>{item}</p>
-          ))}
-        </div>
-        <div className="inline-cta">
-          <a className="primary-action" href={siteHref("/download")}>
-            打开完整下载页
-          </a>
-          <a className="secondary-action" href={siteHref("/contact")}>
-            联系支持
-          </a>
-        </div>
       </section>
 
-      <section className="band alt" id="roadmap">
-        <div className="split-layout">
-          <div className="stack-card">
-            <div className="section-heading compact">
-              <p>首期范围</p>
-              <h2>先把高频入口和轻触达路径跑通，再逐步扩到更重的体验。</h2>
-            </div>
-            <ol className="roadmap-list">
-              {launchRoadmap.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ol>
-            <div className="inline-cta">
-              <a className="secondary-action" href={siteHref("/apply")}>
-                申请参与首期测试
-              </a>
-            </div>
+      <section className="band faq-band" id="faq">
+        <div className="faq-shell">
+          <div className="section-heading compact">
+            <p>常见问题</p>
+            <h2>先回答最容易被搜索、也最容易卡住转化的问题。</h2>
           </div>
 
-          <div className="stack-card">
-            <div className="section-heading compact">
-              <p>公开证明</p>
-              <h2>除了路线说明，官网也要给出能被快速验证的公开信息。</h2>
-            </div>
-            <div className="preview-list">
-              {leaderboard.length === 0 ? (
-                <p className="empty-copy">当前没有拉到排行榜预览，但下载、FAQ 与内容说明仍然可以完整承接首次访问。</p>
-              ) : (
-                leaderboard.map((item, index) => (
-                  <div key={item.username} className="preview-row">
-                    <span>#{index + 1}</span>
-                    <strong>{item.displayName || item.username}</strong>
-                    <span>{item.totalBytes.toLocaleString()} bytes</span>
-                  </div>
-                ))
-              )}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="band" id="insights">
-        <div className="dual-grid">
-          <div className="stack-card transparent">
-            <div className="section-heading compact">
-              <p>内容专栏</p>
-              <h2>官网不仅负责下载和说明，也要持续承接路线、更新与专题解释。</h2>
-            </div>
-            <div className="editorial-list">
-              {featuredArticles.map((item) => (
-                <a key={item.slug} className="editorial-row" href={siteHref(`/insights/${item.slug}`)}>
-                  <span>{item.category}</span>
-                  <div>
-                    <strong>{item.title}</strong>
-                    <p>{item.description}</p>
-                    <small>
-                      {item.author} · {item.readTime}
-                    </small>
-                  </div>
-                </a>
-              ))}
-            </div>
-            <div className="inline-cta">
-              <a className="secondary-action" href={siteHref("/insights")}>
-                查看全部 {allArticles.length} 篇内容
-              </a>
-            </div>
+          <div className="faq-list">
+            {conciseFaq.map((item) => (
+              <details key={item.question} className="faq-item">
+                <summary>{item.question}</summary>
+                <p>{item.answer}</p>
+              </details>
+            ))}
           </div>
 
-          <div className="stack-card transparent">
-            <div className="section-heading compact">
-              <p>常见问题</p>
-              <h2>把搜索里最容易出现的问题先答出来，SEO 和 GEO 才更容易真正生效。</h2>
-            </div>
-            <div className="faq-list">
-              {faqItems.slice(0, 4).map((item) => (
-                <details key={item.question} className="faq-item">
-                  <summary>{item.question}</summary>
-                  <p>{item.answer}</p>
-                </details>
-              ))}
-            </div>
-            <div className="inline-cta">
-              <a className="secondary-action" href={siteHref("/faq")}>
-                查看完整 FAQ
-              </a>
-            </div>
+          <div className="inline-cta">
+            <a className="secondary-action" href={siteHref("/faq")}>
+              查看完整 FAQ
+            </a>
           </div>
         </div>
       </section>
 
       <section className="band cta-band" id="contact">
-        <div className="section-heading narrow">
-          <p>联系与下一步</p>
-          <h2>准备下载、申请测试、反馈问题或讨论合作时，官网应该把可执行的下一步摆在最前面。</h2>
-        </div>
-        <div className="contact-grid">
-          {contactChannels.map((item) => (
-            <a key={item.label} className="contact-card" href={siteHref(item.href)}>
-              <span>{item.label}</span>
-              <strong>{item.value}</strong>
-              <p>{item.note}</p>
-            </a>
-          ))}
+        <div className="cta-panel">
+          <div className="section-heading compact narrow">
+            <p>下一步</p>
+            <h2>准备下载、申请测试或直接联系时，官网只保留最清楚的入口。</h2>
+          </div>
+
+          <div className="contact-grid minimal">
+            {conciseContacts.map((item) => (
+              <a key={item.label} className="contact-card minimal" href={siteHref(item.href)}>
+                <span>{item.label}</span>
+                <strong>{item.value}</strong>
+                <p>{item.note}</p>
+              </a>
+            ))}
+          </div>
         </div>
       </section>
 

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -1,6 +1,10 @@
 import { primaryNavigation } from "@fabushi/shared";
 import { siteHref } from "../lib/site-url";
 
+const compactNavigation = primaryNavigation.filter((item) =>
+  ["/download", "/faq", "/contact", "/insights"].includes(item.href),
+);
+
 export function SiteHeader() {
   return (
     <nav className="site-nav" aria-label="主导航">
@@ -10,7 +14,7 @@ export function SiteHeader() {
       </a>
       <div className="site-nav-cluster">
         <div className="site-nav-links">
-          {primaryNavigation.map((item) => (
+          {compactNavigation.map((item) => (
             <a key={item.href} href={siteHref(item.href)}>
               {item.label}
             </a>


### PR DESCRIPTION
## Summary

- rebuild the homepage into a calmer, more focused landing page with a single dominant hero
- simplify the top navigation so the first screen points users toward download, FAQ, contact, and content
- replace the previous card-heavy visual system with a darker, more restrained homepage style inspired by Linear and Vercel

## What changed

- reduced homepage information density and removed several competing sections from the first pass
- added a Codex-style hero with a compact visual console, tighter messaging, and clearer CTA hierarchy
- reorganized the homepage into five clearer jobs: hero, intent paths, core capabilities, live entry points, and FAQ/contact
- kept structured data and FAQ coverage so SEO and GEO value remain intact while the page gets visually cleaner

## Notes

- main is protected by merge queue rules, so this change was pushed to a branch and opened as a draft PR
- this pass focused on the homepage and shared homepage navigation only

## Validation

- implementation reviewed for content structure and responsive layout logic
- full local Next.js runtime verification was not available in this workspace because the repository was not checked out locally
