### PR TITLE
fix: restore avatar persistence in profile updates

### DIFF
--- a/fabushi/web/src/domain/account-identity.js
+++ b/fabushi/web/src/domain/account-identity.js
@@ -38,6 +38,7 @@ export function normalizeProfileUpdateBody(body) {
     displayName: rawDisplayName !== undefined ? normalizeDisplayName(rawDisplayName) : undefined,
     email: body.email !== undefined ? normalizeEmail(body.email) : undefined,
     phoneNumber: body.phoneNumber !== undefined ? normalizePhone(body.phoneNumber) : undefined,
+    avatar: body.avatar !== undefined ? normalizeOptionalString(body.avatar) : undefined,
     password,
   };
 }

--- a/fabushi/web/src/use-cases/update-profile.js
+++ b/fabushi/web/src/use-cases/update-profile.js
@@ -18,7 +18,7 @@ export async function updateProfileCommand({ currentUser, body }, repository) {
     throw new ApiError(error.message, 400);
   }
 
-  const { hasDisplayNameField, displayName, email, phoneNumber, password } = normalized;
+  const { hasDisplayNameField, displayName, email, phoneNumber, avatar, password } = normalized;
   if (hasDisplayNameField && !displayName) {
     throw new ApiError('请输入昵称', 400);
   }
@@ -44,6 +44,7 @@ export async function updateProfileCommand({ currentUser, body }, repository) {
     updates.email_verified = email ? 1 : 0;
   }
   if (phoneNumber !== undefined) updates.phone_number = phoneNumber;
+  if (avatar !== undefined) updates.avatar = avatar;
   if (password !== undefined && password.length > 0) {
     if (currentUser.password_hash && currentUser.salt) {
       throw new ApiError('当前账号已设置密码，请使用修改密码功能', 400);

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -171,6 +171,30 @@ test('handleUpdateProfile uses token userId before mismatched username fallback'
   assert.equal(db.users.get('wrong_user').nickname, '错用户');
 });
 
+test('handleUpdateProfile persists avatar updates in the returned payload and stored user', async () => {
+  const db = createDbMock();
+  const user = db.seedUser('avatar_user', 'avatar@example.com', '+8613800138111', {
+    nickname: '旧头像昵称',
+    avatar: 'https://example.com/old-avatar.png'
+  });
+  const avatar = 'https://example.com/new-avatar.png';
+
+  const response = await updateProfile(db, { id: user.id, username: user.username }, {
+    nickname: '新头像昵称',
+    email: 'avatar@example.com',
+    phoneNumber: '+8613800138111',
+    avatar
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.equal(payload.user.userId, user.id);
+  assert.equal(payload.user.nickname, '新头像昵称');
+  assert.equal(payload.user.avatar, avatar);
+  assert.equal(db.users.get('avatar_user').avatar, avatar);
+});
+
 test('handleUpdateProfile rejects duplicate email by id, not by username', async () => {
   const db = createDbMock();
   const one = db.seedUser('one', 'one@example.com', '+8613800138222');


### PR DESCRIPTION
## 摘要
- 把 `avatar` 重新纳入 profile update 的规范化与写库链路
- 补一条后端回归测试，确保更新资料时返回体和持久化数据都会反映新头像

## 根因
`CD #151` 的 staging profile API E2E 失败并不是迁移问题，而是资料更新接口在分层改造后漏掉了 `avatar` 字段：

- 失败时间：2026-05-09 01:19 UTC
- workflow：`CD - Staging API gated production deploy #151`
- job：`Staging API E2E and smoke gate`
- 失败断言：`updated.user?.avatar` 仍然返回上一次 iOS 回滚时留下的旧头像 URL

对照当前代码可以确认：`normalizeProfileUpdateBody()` 没有解析 `avatar`，`updateProfileCommand()` 也没有把它写入 `updates`，因此接口虽然 200 成功，但返回用户对象仍是旧头像。

## 改动
- 在 `fabushi/web/src/domain/account-identity.js` 中补回 `avatar` 规范化
- 在 `fabushi/web/src/use-cases/update-profile.js` 中把 `avatar` 写入更新字段
- 在 `fabushi/web/tests/profile.test.js` 中新增 avatar 持久化回归测试

## 验证
- 复核了 `CD #151` / job `75119031842` 日志，失败稳定指向 `updated.user?.avatar`
- 在本地最小 Node 测试环境中执行了针对 `handleUpdateProfile` 的回归测试，结果通过

## 后续
- 这条 PR 合并后，继续观察新的 `main -> CD` 是否越过 `Staging API E2E and smoke gate`
- 若主线 CD 恢复，再继续追 `GitHub Release -> TestFlight`