### PR TITLE
fix: restore profile username rename release contract

### DIFF
--- a/fabushi/web/src/contracts/account-user.js
+++ b/fabushi/web/src/contracts/account-user.js
@@ -37,10 +37,12 @@ export function buildPasswordLoginPayload({ token, user }) {
   };
 }
 
-export function buildProfileUpdatedPayload(user) {
-  return {
+export function buildProfileUpdatedPayload(user, token) {
+  const payload = {
     success: true,
     message: '个人资料更新成功',
     user: serializeAccountUser(user),
   };
+  if (token) payload.token = token;
+  return payload;
 }

--- a/fabushi/web/src/domain/account-identity.js
+++ b/fabushi/web/src/domain/account-identity.js
@@ -29,13 +29,52 @@ export function normalizePhone(value) {
   return phone;
 }
 
-export function normalizeProfileUpdateBody(body) {
-  const rawDisplayName = body.nickname !== undefined ? body.nickname : body.username;
+export function normalizeUsername(value) {
+  const username = normalizeOptionalString(value);
+  if (!username) return username;
+  if (username.includes('@') || /\s/.test(username)) {
+    throw new Error('用户名不能包含 @ 或空格');
+  }
+  if (username.length < 2 || username.length > 32) {
+    throw new Error('用户名长度需为 2-32 个字符');
+  }
+  return username;
+}
+
+function looksLikeAccountUsername(value) {
+  return /^[A-Za-z0-9_-]{2,32}$/.test(value);
+}
+
+export function normalizeProfileUpdateBody(body, currentUsername = '') {
+  const rawNickname = body.nickname;
+  const rawUsername = body.username;
   const password = body.password !== undefined ? String(body.password) : undefined;
+  const normalizedCurrentUsername = String(currentUsername || '').trim();
+
+  let hasDisplayNameField = rawNickname !== undefined;
+  let displayName = rawNickname !== undefined ? normalizeDisplayName(rawNickname) : undefined;
+  let username;
+
+  if (rawUsername !== undefined) {
+    const normalizedUsername = normalizeOptionalString(rawUsername);
+    const wantsRename = Boolean(
+      normalizedUsername
+      && normalizedUsername !== normalizedCurrentUsername
+      && looksLikeAccountUsername(normalizedUsername)
+    );
+
+    if (wantsRename) {
+      username = normalizeUsername(normalizedUsername);
+    } else if (rawNickname === undefined) {
+      hasDisplayNameField = true;
+      displayName = normalizeDisplayName(rawUsername);
+    }
+  }
 
   return {
-    hasDisplayNameField: rawDisplayName !== undefined,
-    displayName: rawDisplayName !== undefined ? normalizeDisplayName(rawDisplayName) : undefined,
+    hasDisplayNameField,
+    displayName,
+    username,
     email: body.email !== undefined ? normalizeEmail(body.email) : undefined,
     phoneNumber: body.phoneNumber !== undefined ? normalizePhone(body.phoneNumber) : undefined,
     avatar: body.avatar !== undefined ? normalizeOptionalString(body.avatar) : undefined,

--- a/fabushi/web/src/repositories/account-user-repository.js
+++ b/fabushi/web/src/repositories/account-user-repository.js
@@ -67,4 +67,37 @@ export class AccountUserRepository {
       );
     }
   }
+
+  async renameUsernameReferences({ userId, oldUsername, newUsername }) {
+    if (!oldUsername || !newUsername || oldUsername === newUsername) return;
+
+    const updates = [
+      ['UPDATE email_username_mapping SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE alipay_bindings SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE orders SET username = ? WHERE account_user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE purchase_history SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE redeem_history SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE memberships SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE meditation_records SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE meditation_goals SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE meditation_settings SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE meditation_groups SET owner_username = ? WHERE owner_user_id = ? OR owner_username = ?', newUsername, userId, oldUsername],
+      ['UPDATE meditation_group_members SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE user_follows SET follower_username = ? WHERE follower_user_id = ? OR follower_username = ?', newUsername, userId, oldUsername],
+      ['UPDATE user_follows SET following_username = ? WHERE following_user_id = ? OR following_username = ?', newUsername, userId, oldUsername],
+      ['UPDATE notifications SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE notifications SET related_username = ? WHERE related_user_id = ? OR related_username = ?', newUsername, userId, oldUsername],
+      ['UPDATE sync_log SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE user_sync_state SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE comments SET username = ? WHERE account_user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE likes SET username = ? WHERE username = ?', newUsername, oldUsername],
+      ['UPDATE favorites SET username = ? WHERE username = ?', newUsername, oldUsername],
+      ['UPDATE content_likes SET username = ? WHERE account_user_id = ? OR username = ?', newUsername, userId, oldUsername],
+      ['UPDATE content_favorites SET username = ? WHERE user_id = ? OR username = ?', newUsername, userId, oldUsername],
+    ];
+
+    for (const [sql, ...params] of updates) {
+      await safeRun(this.db, sql, ...params);
+    }
+  }
 }

--- a/fabushi/web/src/use-cases/update-profile.js
+++ b/fabushi/web/src/use-cases/update-profile.js
@@ -1,4 +1,4 @@
-import { createPasswordHash } from '../../auth-utils.js';
+import { createPasswordHash, generateToken } from '../../auth-utils.js';
 import { buildProfileUpdatedPayload, serializeAccountUser } from '../contracts/account-user.js';
 import { ApiError } from '../contracts/api-error.js';
 import { normalizeProfileUpdateBody } from '../domain/account-identity.js';
@@ -7,20 +7,27 @@ import { authenticateRequest } from './authenticated-user.js';
 export async function updateProfileFromRequest(request, env, repository) {
   const { user } = await authenticateRequest(request, env, repository);
   const body = await request.json();
-  return await updateProfileCommand({ currentUser: user, body }, repository);
+  return await updateProfileCommand({ currentUser: user, body, env }, repository);
 }
 
-export async function updateProfileCommand({ currentUser, body }, repository) {
+export async function updateProfileCommand({ currentUser, body, env }, repository) {
   let normalized;
   try {
-    normalized = normalizeProfileUpdateBody(body);
+    normalized = normalizeProfileUpdateBody(body, currentUser.username);
   } catch (error) {
     throw new ApiError(error.message, 400);
   }
 
-  const { hasDisplayNameField, displayName, email, phoneNumber, avatar, password } = normalized;
+  const { hasDisplayNameField, displayName, username, email, phoneNumber, avatar, password } = normalized;
   if (hasDisplayNameField && !displayName) {
     throw new ApiError('请输入昵称', 400);
+  }
+
+  if (username !== undefined && username !== currentUser.username) {
+    const existingUser = await repository.getByUsername(username);
+    if (existingUser && existingUser.id !== currentUser.id) {
+      throw new ApiError('用户名已存在', 400);
+    }
   }
 
   if (email !== undefined && email) {
@@ -38,6 +45,7 @@ export async function updateProfileCommand({ currentUser, body }, repository) {
   }
 
   const updates = {};
+  if (username !== undefined && username !== currentUser.username) updates.username = username;
   if (displayName !== undefined) updates.nickname = displayName;
   if (email !== undefined) {
     updates.email = email || '';
@@ -67,15 +75,29 @@ export async function updateProfileCommand({ currentUser, body }, repository) {
   }
 
   await repository.updateById(currentUser.id, updates);
-  if (email !== undefined) {
-    await repository.replaceEmailMapping({
+  const updatedUser = (await repository.getById(currentUser.id)) || { ...currentUser, ...updates };
+
+  if (username !== undefined && username !== currentUser.username) {
+    await repository.renameUsernameReferences({
       userId: currentUser.id,
-      username: currentUser.username,
-      oldEmail: currentUser.email,
-      newEmail: email,
+      oldUsername: currentUser.username,
+      newUsername: updatedUser.username,
     });
   }
 
-  const updatedUser = (await repository.getById(currentUser.id)) || currentUser;
-  return buildProfileUpdatedPayload(updatedUser);
+  const resolvedEmail = email !== undefined ? email : currentUser.email;
+  if (resolvedEmail || email !== undefined) {
+    await repository.replaceEmailMapping({
+      userId: currentUser.id,
+      username: updatedUser.username,
+      oldEmail: currentUser.email,
+      newEmail: resolvedEmail,
+    });
+  }
+
+  const token = username !== undefined && username !== currentUser.username
+    ? await generateToken({ id: updatedUser.id, username: updatedUser.username }, env)
+    : undefined;
+
+  return buildProfileUpdatedPayload(updatedUser, token);
 }

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { generateToken } from '../auth-utils.js';
+import { generateToken, verifyToken } from '../auth-utils.js';
 import { handleUpdateProfile } from '../src/handlers/profile.js';
 
 function createDbMock() {
@@ -45,6 +45,7 @@ function createDbMock() {
           const key = params.at(-1);
           const user = whereById ? usersById.get(Number(key)) : users.get(key);
           if (!user) return;
+          const oldUsername = user.username;
           const assignments = normalizedSql
             .slice('UPDATE users SET'.length, normalizedSql.indexOf(whereById ? 'WHERE id = ?' : 'WHERE username = ?'))
             .split(',')
@@ -54,6 +55,9 @@ function createDbMock() {
             const match = assignment.match(/^([a-zA-Z0-9_]+)\s*=\s*\?$/);
             if (match) user[match[1]] = params[index];
           });
+          if (oldUsername !== user.username) {
+            users.delete(oldUsername);
+          }
           users.set(user.username, user);
           usersById.set(user.id, user);
           return;
@@ -209,4 +213,29 @@ test('handleUpdateProfile rejects duplicate email by id, not by username', async
   const payload = await response.json();
   assert.equal(response.status, 400);
   assert.equal(payload.error, '该邮箱已被其他账号使用');
+});
+
+test('handleUpdateProfile renames username, rotates token, and refreshes email mapping', async () => {
+  const db = createDbMock();
+  const user = db.seedUser('stable_1', 'stable@example.com', '+8613800138444', { nickname: '旧昵称' });
+
+  const response = await updateProfile(db, { id: user.id, username: user.username }, {
+    username: 'stable-renamed',
+    email: 'stable@example.com',
+    phoneNumber: '+8613800138444'
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.user.userId, user.id);
+  assert.equal(payload.user.username, 'stable-renamed');
+  assert.equal(payload.user.nickname, '旧昵称');
+  assert.ok(payload.token);
+  assert.equal(db.users.has('stable_1'), false);
+  assert.equal(db.users.get('stable-renamed').id, user.id);
+  assert.equal(db.emailMapping.get('stable@example.com').username, 'stable-renamed');
+
+  const tokenPayload = await verifyToken(payload.token, { JWT_SECRET: 'test-secret' });
+  assert.equal(tokenPayload.userId, user.id);
+  assert.equal(tokenPayload.username, 'stable-renamed');
 });


### PR DESCRIPTION
## Summary
- restore actual username rename handling in the profile update flow
- issue a fresh auth token after username changes and refresh email mapping to the new username
- keep legacy nickname-style `username` payloads working for non-account-style values
- add focused regression coverage for username rename token rotation and mapping refresh

## Why
The latest `main` CD run failed in the staging profile API E2E gate because `/api/auth/update-profile` returned the old username after a rename attempt and did not rotate a fresh token. That broke username rename + rollback coverage across desktop and mobile browsers.

## Validation
- ran a focused local `node --test tests/profile.test.js` regression covering:
  - legacy display-name compatibility
  - username rename response payload
  - token rotation after rename
  - email mapping refresh after rename

## Expected outcome
After merge, the staging profile API E2E step in CD should stop failing on the username rename / rollback flow and production deployment can proceed again.