### PR TITLE
harden external user and group numbers

### DIFF
--- a/fabushi/web/migrations/20260509_external_numbers_randomized.sql
+++ b/fabushi/web/migrations/20260509_external_numbers_randomized.sql
@@ -1,0 +1,28 @@
+-- Upgrade external display numbers to non-enumerable random short numbers.
+-- Internal relational ids remain separate and are not exposed as user_no/group_no.
+--
+-- Application code supplies CSPRNG values first. These triggers are only a
+-- database safety net for legacy/direct inserts that omit the external number.
+
+DROP TRIGGER IF EXISTS trg_users_assign_user_no;
+DROP TRIGGER IF EXISTS trg_meditation_groups_assign_group_no;
+
+CREATE TRIGGER IF NOT EXISTS trg_users_assign_user_no
+AFTER INSERT ON users
+FOR EACH ROW
+WHEN NEW.user_no IS NULL
+BEGIN
+  UPDATE users
+  SET user_no = 100000000 + ABS(RANDOM() % 900000000)
+  WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_meditation_groups_assign_group_no
+AFTER INSERT ON meditation_groups
+FOR EACH ROW
+WHEN NEW.group_no IS NULL
+BEGIN
+  UPDATE meditation_groups
+  SET group_no = 10000000 + ABS(RANDOM() % 90000000)
+  WHERE id = NEW.id;
+END;

--- a/fabushi/web/src/routes/meditation-routes.js
+++ b/fabushi/web/src/routes/meditation-routes.js
@@ -15,6 +15,7 @@ import {
   handleReviewMeditationGroupJoin,
   handleSyncRecord,
 } from '../handlers/meditation.js';
+import { generateGroupNo } from '../services/external-numbers.js';
 import { jsonResponse } from '../utils/response.js';
 
 function asInt(value, fallback = 0) {
@@ -42,6 +43,36 @@ async function getGroupNoById(db, groupId) {
     WHERE id = ?
   `).bind(normalizedGroupId).first();
   return result?.group_no || null;
+}
+
+async function generateUniqueGroupNo(db) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const candidate = generateGroupNo();
+    const existingGroupId = await resolveGroupIdFromGroupNo(db, candidate);
+    if (!existingGroupId) return candidate;
+  }
+
+  throw new Error('无法生成可用的 8 位群号');
+}
+
+async function ensureCreatedGroupNo(db, groupId) {
+  const normalizedGroupId = asInt(groupId);
+  if (!normalizedGroupId) return null;
+
+  const currentGroupNo = await getGroupNoById(db, normalizedGroupId);
+  if (currentGroupNo && currentGroupNo !== normalizedGroupId) {
+    return currentGroupNo;
+  }
+
+  const groupNo = await generateUniqueGroupNo(db);
+  await db.prepare(`
+    UPDATE meditation_groups
+    SET group_no = ?,
+        updated_at = COALESCE(updated_at, CURRENT_TIMESTAMP)
+    WHERE id = ?
+  `).bind(groupNo, normalizedGroupId).run();
+
+  return groupNo;
 }
 
 async function cloneRequestWithJsonBody(request, body) {
@@ -138,7 +169,9 @@ async function withVisibleGroupNumbers(response, db, options = {}) {
   }
 
   if (options.includeCreatedGroupNo && nextPayload?.data?.groupId) {
-    const groupNo = await getGroupNoById(db, nextPayload.data.groupId);
+    const groupNo = options.assignCreatedGroupNo
+      ? await ensureCreatedGroupNo(db, nextPayload.data.groupId)
+      : await getGroupNoById(db, nextPayload.data.groupId);
     if (groupNo) {
       nextPayload.data.groupNo = groupNo;
     }
@@ -185,7 +218,10 @@ export async function routeMeditationRequest({ pathname, method, request, env, d
   }
   if (pathname === '/api/meditation/groups' && method === 'POST') {
     const response = await handleCreateMeditationGroup(request, env, db);
-    return await withVisibleGroupNumbers(response, db, { includeCreatedGroupNo: true });
+    return await withVisibleGroupNumbers(response, db, {
+      includeCreatedGroupNo: true,
+      assignCreatedGroupNo: true,
+    });
   }
   if (pathname === '/api/meditation/groups/join' && method === 'POST') {
     const { request: nextRequest } = await rewriteGroupBodyRequest(request, db);

--- a/fabushi/web/src/services/database.js
+++ b/fabushi/web/src/services/database.js
@@ -1,3 +1,5 @@
+import { generateUserNo } from './external-numbers.js';
+
 export const USER_ID_CUSTOM_EPOCH_MS = Date.UTC(2025, 0, 1);
 const USER_ID_TIMESTAMP_BITS = 41;
 const USER_ID_WORKER_BITS = 5;
@@ -251,14 +253,10 @@ export class DatabaseService {
 
   async generateUniqueUserNo() {
     for (let attempt = 0; attempt < 200; attempt += 1) {
-      const candidate = generateSixDigitNo();
+      const candidate = generateUserNo();
       const existing = await this.getUserByUserNo(candidate);
       if (!existing) return candidate;
     }
-    throw new Error('无法生成可用的 6 位用户号');
+    throw new Error('无法生成可用的 9 位用户号');
   }
-}
-
-function generateSixDigitNo() {
-  return Math.floor(100000 + Math.random() * 900000);
 }

--- a/fabushi/web/src/services/external-numbers.js
+++ b/fabushi/web/src/services/external-numbers.js
@@ -1,0 +1,49 @@
+export const USER_NO_LENGTH = 9;
+export const GROUP_NO_LENGTH = 8;
+
+const UINT32_SIZE = 0x100000000;
+
+export function generateSecureInteger(min, max) {
+  const lower = Math.trunc(Number(min));
+  const upper = Math.trunc(Number(max));
+  if (!Number.isSafeInteger(lower) || !Number.isSafeInteger(upper) || upper < lower) {
+    throw new Error('secure random range is invalid');
+  }
+
+  const range = upper - lower + 1;
+  if (range <= 0 || range > UINT32_SIZE) {
+    throw new Error('secure random range exceeds uint32 support');
+  }
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error('crypto.getRandomValues is required');
+  }
+
+  const limit = Math.floor(UINT32_SIZE / range) * range;
+  const buffer = new Uint32Array(1);
+  let value;
+  do {
+    globalThis.crypto.getRandomValues(buffer);
+    value = buffer[0];
+  } while (value >= limit);
+
+  return lower + (value % range);
+}
+
+export function generateExternalNumericNo(length) {
+  const normalizedLength = Math.trunc(Number(length));
+  if (!Number.isSafeInteger(normalizedLength) || normalizedLength < 2 || normalizedLength > 9) {
+    throw new Error('external number length must be between 2 and 9 digits');
+  }
+
+  const min = 10 ** (normalizedLength - 1);
+  const max = (10 ** normalizedLength) - 1;
+  return generateSecureInteger(min, max);
+}
+
+export function generateUserNo() {
+  return generateExternalNumericNo(USER_NO_LENGTH);
+}
+
+export function generateGroupNo() {
+  return generateExternalNumericNo(GROUP_NO_LENGTH);
+}

--- a/fabushi/web/tests/external-number-layering.test.js
+++ b/fabushi/web/tests/external-number-layering.test.js
@@ -68,7 +68,7 @@ function createDbMock() {
 test('serializeAccountUser and login payload expose userNo separately from internal id', () => {
   const user = {
     id: 12,
-    user_no: 618273,
+    user_no: 618273941,
     username: 'mingyue',
     email: 'mingyue@example.com',
     nickname: '明月',
@@ -81,12 +81,12 @@ test('serializeAccountUser and login payload expose userNo separately from inter
   const serialized = serializeAccountUser(user);
   assert.equal(serialized.id, 12);
   assert.equal(serialized.userId, 12);
-  assert.equal(serialized.userNo, 618273);
+  assert.equal(serialized.userNo, 618273941);
 
   const payload = buildPasswordLoginPayload({ token: 'token', user });
   assert.equal(payload.userId, 12);
-  assert.equal(payload.userNo, 618273);
-  assert.equal(payload.user.userNo, 618273);
+  assert.equal(payload.userNo, 618273941);
+  assert.equal(payload.user.userNo, 618273941);
 });
 
 test('DatabaseService createUser stores generated user_no while id stays snowflake internal id', async () => {
@@ -107,6 +107,6 @@ test('DatabaseService createUser stores generated user_no while id stays snowfla
   });
 
   assert.equal(Number.isSafeInteger(created.id), true);
-  assert.match(String(created.user_no), /^\d{6}$/);
+  assert.match(String(created.user_no), /^\d{9}$/);
   assert.notEqual(created.user_no, created.id);
 });

--- a/fabushi/web/tests/external-numbers.test.js
+++ b/fabushi/web/tests/external-numbers.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GROUP_NO_LENGTH,
+  USER_NO_LENGTH,
+  generateExternalNumericNo,
+  generateGroupNo,
+  generateUserNo,
+} from '../src/services/external-numbers.js';
+
+test('external numeric numbers use fixed non-enumerable display lengths', () => {
+  const userNo = generateUserNo();
+  const groupNo = generateGroupNo();
+
+  assert.match(String(userNo), /^\d{9}$/);
+  assert.match(String(groupNo), /^\d{8}$/);
+  assert.equal(USER_NO_LENGTH, 9);
+  assert.equal(GROUP_NO_LENGTH, 8);
+});
+
+test('external numeric generator rejects unsafe display lengths', () => {
+  assert.throws(() => generateExternalNumericNo(1), /between 2 and 9/);
+  assert.throws(() => generateExternalNumericNo(10), /between 2 and 9/);
+});


### PR DESCRIPTION
## Summary
- keep internal `users.id` on the existing snowflake-style distributed ID path
- add a shared external-number generator backed by `crypto.getRandomValues`
- change new `userNo` generation from 6-digit `Math.random()` to 9-digit CSPRNG numbers
- change new `groupNo` assignment from `group_no = id` fallback to 8-digit CSPRNG numbers after group creation
- replace DB trigger fallback from `NEW.id` mirroring to random 9-digit user numbers and 8-digit group numbers
- add focused regression tests for external number lengths and user creation layering

## Design
- internal IDs are stable, non-public relational identifiers
- external numbers are short, stable, unique, and non-enumerable enough for user-facing lookup/support/invite flows
- UNIQUE indexes remain the final collision guard, while application code checks and retries before writes

## Validation
- added `external-numbers.test.js`
- updated `external-number-layering.test.js` to expect 9-digit `userNo`
- CI will run on this PR