### PR TITLE
use snowflake internal ids for meditation groups

### DIFF
--- a/fabushi/web/src/routes/meditation-routes.js
+++ b/fabushi/web/src/routes/meditation-routes.js
@@ -15,12 +15,48 @@ import {
   handleReviewMeditationGroupJoin,
   handleSyncRecord,
 } from '../handlers/meditation.js';
+import { generateSnowflakeUserId as generateSnowflakeGroupId } from '../services/database.js';
 import { generateGroupNo } from '../services/external-numbers.js';
 import { jsonResponse } from '../utils/response.js';
 
 function asInt(value, fallback = 0) {
   const parsed = parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+async function authenticateRouteUser(request) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { error: '未授权访问', status: 401 };
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return { error: 'Token格式无效', status: 401 };
+    }
+
+    const payload = JSON.parse(atob(parts[1]));
+    const username = payload.username || payload.sub;
+    if (!username) {
+      return { error: '无法获取用户信息', status: 401 };
+    }
+
+    return { username };
+  } catch (_) {
+    return { error: 'Token解瞐失败', status: 401 };
+  }
+}
+
+async function resolveGroupById(db, groupId) {
+  const normalizedGroupId = asInt(groupId);
+  if (!normalizedGroupId) return null;
+  return await db.prepare(`
+    SELECT id
+    FROM meditation_groups
+    WHERE id = ?
+  `).bind(normalizedGroupId).first();
 }
 
 async function resolveGroupIdFromGroupNo(db, groupNo) {
@@ -43,6 +79,16 @@ async function getGroupNoById(db, groupId) {
     WHERE id = ?
   `).bind(normalizedGroupId).first();
   return result?.group_no || null;
+}
+
+async function generateUniqueGroupId(db) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const candidate = generateSnowflakeGroupId();
+    const existingGroup = await resolveGroupById(db, candidate);
+    if (!existingGroup) return candidate;
+  }
+
+  throw new Error('无法生成可用的雪舱式羄绔 ID');
 }
 
 async function generateUniqueGroupNo(db) {
@@ -180,6 +226,58 @@ async function withVisibleGroupNumbers(response, db, options = {}) {
   return jsonResponse(nextPayload, response.status);
 }
 
+async function handleCreateMeditationGroupWithGeneratedIds(request, db) {
+  const auth = await authenticateRouteUser(request);
+  if (auth.error) {
+    return jsonResponse({ success: false, error: auth.error }, auth.status);
+  }
+
+  try {
+    const body = await request.json();
+    const name = (body.name || '').toString().trim();
+    if (!name) {
+      return jsonResponse({ success: false, error: '小绔對称不能为立' }, 400);
+    }
+
+    const now = new Date().toISOString();
+    const groupId = await generateUniqueGroupId(db);
+    const groupNo = await generateUniqueGroupNo(db);
+    const dailyGoalMinutes = Math.max(0, asInt(body.dailyGoalMinutes, 30));
+    const cumulativeMissLimit = Math.max(0, asInt(body.cumulativeMissLimit, 7));
+    const consecutiveMissLimit = Math.max(0, asInt(body.consecutiveMissLimit, 3));
+
+    await db.prepare(`
+      INSERT INTO meditation_groups (
+        id, group_no, name, description, owner_username, require_approval, daily_goal_minutes,
+        cumulative_miss_limit, consecutive_miss_limit, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      groupId,
+      groupNo,
+      name,
+      (body.description || '').toString().trim(),
+      auth.username,
+      body.requireApproval ? 1 : 0,
+      dailyGoalMinutes,
+      cumulativeMissLimit,
+      consecutiveMissLimit,
+      now,
+      now
+    ).run();
+
+    await db.prepare(`
+      INSERT INTO meditation_group_members (group_id, username, role, status, joined_at, updated_at)
+      VALUES (?, ?, 'owner', 'active', ?, ?)
+    `).bind(groupId, auth.username, now, now).run();
+
+    return jsonResponse({ success: true, data: { groupId, groupNo } });
+  } catch (e) {
+    console.error('创建共伮小绔失败', e);
+    return jsonResponse({ success: false, error: '创建共伮小绔失败' }, 500);
+  }
+}
+
 export async function routeMeditationRequest({ pathname, method, request, env, db }) {
   if (pathname === '/api/meditation/record' && method === 'POST') {
     return await handleSyncRecord(request, env, db);
@@ -217,11 +315,7 @@ export async function routeMeditationRequest({ pathname, method, request, env, d
     return await withVisibleGroupNumbers(response, db);
   }
   if (pathname === '/api/meditation/groups' && method === 'POST') {
-    const response = await handleCreateMeditationGroup(request, env, db);
-    return await withVisibleGroupNumbers(response, db, {
-      includeCreatedGroupNo: true,
-      assignCreatedGroupNo: true,
-    });
+    return await handleCreateMeditationGroupWithGeneratedIds(request, db);
   }
   if (pathname === '/api/meditation/groups/join' && method === 'POST') {
     const { request: nextRequest } = await rewriteGroupBodyRequest(request, db);

--- a/fabushi/web/tests/meditation-group-id-layering.test.js
+++ b/fabushi/web/tests/meditation-group-id-layering.test.js
@@ -96,7 +96,7 @@ test('creating meditation group uses snowflake internal id and random external g
     },
     body: JSON.stringify({
       name: '昨修小绔',
-      description: '日每共修,
+      description: '日每共修',
       dailyGoalMinutes: 30,
       cumulativeMissLimit: 7,
       consecutiveMissLimit: 3,

--- a/fabushi/web/tests/meditation-group-id-layering.test.js
+++ b/fabushi/web/tests/meditation-group-id-layering.test.js
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { routeMeditationRequest } from '../src/routes/meditation-routes.js';
+
+function makeToken(username) {
+  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({ username }));
+  return `${header}.${payload}.signature`;
+}
+
+function createGroupDbMock() {
+  const state = {
+    groups: [],
+    members: [],
+  };
+
+  return {
+    prepare(sql) {
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+      return {
+        bind(...params) {
+          return {
+            async first() {
+              if (normalizedSql === 'SELECT id FROM meditation_groups WHERE id = ?') {
+                return state.groups.find((group) => group.id === Number(params[0])) || null;
+              }
+              if (normalizedSql === 'SELECT id FROM meditation_groups WHERE group_no = ?') {
+                return state.groups.find((group) => group.group_no === Number(params[0])) || null;
+              }
+              if (normalizedSql === 'SELECT group_no FROM meditation_groups WHERE id = ?') {
+                const group = state.groups.find((entry) => entry.id === Number(params[0]));
+                return group ? { group_no: group.group_no } : null;
+              }
+              return null;
+            },
+            async run() {
+              if (normalizedSql.startsWith('INSERT INTO meditation_groups ( id, group_no, name, description, owner_username')) {
+                const [
+                  id,
+                  groupNo,
+                  name,
+                  description,
+                  ownerUsername,
+                  requireApproval,
+                  dailyGoalMinutes,
+                  cumulativeMissLimit,
+                  consecutiveMissLimit,
+                  createdAt,
+                  updatedAt,
+                ] = params;
+                state.groups.push({
+                  id: Number(id),
+                  group_no: Number(groupNo),
+                  name,
+                  description,
+                  owner_username: ownerUsername,
+                  require_approval: requireApproval,
+                  daily_goal_minutes: dailyGoalMinutes,
+                  cumulative_miss_limit: cumulativeMissLimit,
+                  consecutive_miss_limit: consecutiveMissLimit,
+                  created_at: createdAt,
+                  updated_at: updatedAt,
+                });
+                return { meta: { last_row_id: Number(id) } };
+              }
+              if (normalizedSql.startsWith('INSERT INTO meditation_group_members (group_id, username, role, status, joined_at, updated_at)')) {
+                const [groupId, username, joinedAt, updatedAt] = params;
+                state.members.push({
+                  group_id: Number(groupId),
+                  username,
+                  role: 'owner',
+                  status: 'active',
+                  joined_at: joinedAt,
+                  updated_at: updatedAt,
+                });
+                return { meta: {} };
+              }
+              throw new Error(`Unexpected SQL in test: ${normalizedSql}`);
+            },
+          };
+        },
+      };
+    },
+    state,
+  };
+}
+
+test('creating meditation group uses snowflake internal id and random external groupNo', async () => {
+  const db = createGroupDbMock();
+  const request = new Request('https://example.com/api/meditation/groups', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${makeToken('mingyue')}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: '昨修小绔',
+      description: '日每共修,
+      dailyGoalMinutes: 30,
+      cumulativeMissLimit: 7,
+      consecutiveMissLimit: 3,
+    }),
+  });
+
+  const response = await routeMeditationRequest({
+    pathname: '/api/meditation/groups',
+    method: 'POST',
+    request,
+    env: {},
+    db,
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+
+  assert.equal(payload.success, true);
+  assert.equal(Number.isSafeInteger(payload.data.groupId), true);
+  assert.match(String(payload.data.groupNo), /^\d{8}$/);
+  assert.notEqual(payload.data.groupId, payload.data.groupNo);
+  assert.equal(db.state.groups[0].id, payload.data.groupId);
+  assert.equal(db.state.groups[0].group_no, payload.data.groupNo);
+  assert.equal(db.state.members[0].group_id, payload.data.groupId);
+});


### PR DESCRIPTION
## Summary
- make `POST /api/meditation/groups` generate and insert a snowflake-style internal `groupId` instead of using D1 row autoincrement
- keep `groupNo` as the independent 8-digit external group number introduced in #290
- keep group membership rows referencing the generated internal snowflake `groupId`
- add a focused route-level regression test proving `groupId` is a safe integer, `groupNo` is 8 digits, and they are not equal

## Design
- `users.id` and `meditation_groups.id` are now both internal snowflake-style IDs
- `users.user_no` and `meditation_groups.group_no` remain separate external lookup/display numbers
- no data rewrite is needed for historical group rows; this is a forward-only creation-path upgrade

## Validation
- added `meditation-group-id-layering.test.js`
- CI will run on this PR