### PR TITLE
Fix account deletion D1 transaction error

### DIFF
--- a/fabushi/web/src/handlers/auth.js
+++ b/fabushi/web/src/handlers/auth.js
@@ -287,6 +287,7 @@ export async function handleDeleteAccount(request, env, db) {
   } catch (error) {
     const apiError = asApiError(error, '注销账户失败');
     console.error('注销账户失败:', error);
-    return jsonResponse({ error: apiError.message }, apiError.status);
+    const message = apiError.status >= 500 ? '注销账户失败，请稍后重试' : apiError.message;
+    return jsonResponse({ error: message }, apiError.status);
   }
 }

--- a/fabushi/web/src/repositories/account-user-command-repository.js
+++ b/fabushi/web/src/repositories/account-user-command-repository.js
@@ -43,7 +43,7 @@ export class AccountUserRepository extends BaseAccountUserRepository {
       return await storage.transaction(async () => await action());
     }
 
-    // Cloudflare D1 / Durable Object SQLite rejects explicit SQL BEGIN/COMMIT
+    // Cloudflare storage may reject explicit SQL transaction-control
     // statements. When a JavaScript transaction API is unavailable, keep the
     // deletion flow idempotent and run the cleanup directly instead of failing
     // before the first DELETE.

--- a/fabushi/web/src/repositories/account-user-command-repository.js
+++ b/fabushi/web/src/repositories/account-user-command-repository.js
@@ -8,6 +8,10 @@ async function safeRun(db, sql, ...params) {
   }
 }
 
+function resolveDurableObjectStorage(db) {
+  return db?.state?.storage || db?.db?.state?.storage || null;
+}
+
 export class AccountUserRepository extends BaseAccountUserRepository {
   async getByFirebaseUid(firebaseUid) {
     return await this.db.getUserByFirebaseUid(firebaseUid);
@@ -30,19 +34,20 @@ export class AccountUserRepository extends BaseAccountUserRepository {
   }
 
   async withTransaction(action) {
-    await this.db.prepare('BEGIN TRANSACTION').run();
-    try {
-      const result = await action();
-      await this.db.prepare('COMMIT').run();
-      return result;
-    } catch (error) {
-      try {
-        await this.db.prepare('ROLLBACK').run();
-      } catch (rollbackError) {
-        console.warn('账户事务回滚失败:', rollbackError?.message || rollbackError);
-      }
-      throw error;
+    if (typeof this.db.transaction === 'function') {
+      return await this.db.transaction(action);
     }
+
+    const storage = resolveDurableObjectStorage(this.db);
+    if (typeof storage?.transaction === 'function') {
+      return await storage.transaction(async () => await action());
+    }
+
+    // Cloudflare D1 / Durable Object SQLite rejects explicit SQL BEGIN/COMMIT
+    // statements. When a JavaScript transaction API is unavailable, keep the
+    // deletion flow idempotent and run the cleanup directly instead of failing
+    // before the first DELETE.
+    return await action();
   }
 
   async deleteAccountArtifacts({ userId, username, email }) {

--- a/fabushi/web/tests/account-deletion-and-practice-privacy.test.js
+++ b/fabushi/web/tests/account-deletion-and-practice-privacy.test.js
@@ -33,3 +33,14 @@ test('account deletion purges meditation and social artifacts before removing th
   assert.match(accountCommandRepository, /DELETE FROM meditation_group_members WHERE group_id IN \(SELECT id FROM meditation_groups WHERE owner_username = \?\)/);
   assert.match(accountCommandRepository, /DELETE FROM user_follows WHERE follower_username = \? OR following_username = \?/);
 });
+
+test('account deletion avoids unsupported SQL transactions on Cloudflare storage', () => {
+  assert.match(accountCommandRepository, /typeof this\.db\.transaction === 'function'/);
+  assert.match(accountCommandRepository, /storage\.transaction/);
+  assert.match(accountCommandRepository, /return await action\(\);/);
+  assert.doesNotMatch(accountCommandRepository, /BEGIN TRANSACTION|SAVEPOINT|COMMIT|ROLLBACK/);
+});
+
+test('account deletion hides backend SQL errors from users', () => {
+  assert.match(authHandler, /apiError\.status >= 500 \? '注销账户失败，请稍后重试' : apiError\.message/);
+});


### PR DESCRIPTION
## Summary
- Stop wrapping account deletion in explicit SQL transaction-control statements when no JavaScript transaction API is available.
- Prefer the repository/database transaction API, then Cloudflare Durable Object storage transaction API when present.
- Keep the deletion cleanup idempotent so Cloudflare storage does not fail before the first DELETE.
- Hide backend SQL/D1 implementation errors from the user-facing account deletion API response.
- Add regression coverage for the D1-safe account deletion path.

## Root cause
The account deletion command called `repository.withTransaction(...)`, and `withTransaction` used explicit SQL transaction-control statements. Cloudflare storage can reject those statements and throws the D1/Durable Object error shown in the app.

This is not primarily a user id problem. `user.id` is still passed into cleanup for tables that store user IDs, but the visible failure happened before cleanup because the transaction wrapper was rejected.

## Testing
- Not run locally: this environment cannot resolve github.com to clone/install the repo.
- Added source-level regression tests in `fabushi/web/tests/account-deletion-and-practice-privacy.test.js`.