### PR TITLE
Fix group join feedback and shorten group numbers

### DIFF
--- a/fabushi/lib/models/co_practice_group_model.dart
+++ b/fabushi/lib/models/co_practice_group_model.dart
@@ -9,10 +9,11 @@ bool _asBool(dynamic value) => value == true || value == 1 || value == '1';
 
 String _asString(dynamic value) => value?.toString() ?? '';
 
-String _formatGroupCode(int id) => id.toString().padLeft(6, '0');
+String _formatGroupCode(int id) => id.toString().padLeft(5, '0');
 
 class CoPracticeGroup {
   final int id;
+  final int groupNo;
   final String name;
   final String description;
   final String ownerUsername;
@@ -32,6 +33,7 @@ class CoPracticeGroup {
 
   const CoPracticeGroup({
     required this.id,
+    required this.groupNo,
     required this.name,
     required this.description,
     required this.ownerUsername,
@@ -50,11 +52,13 @@ class CoPracticeGroup {
     this.createdAt,
   });
 
-  String get publicCode => _formatGroupCode(id);
+  String get publicCode => _formatGroupCode(groupNo > 0 ? groupNo : id);
 
   factory CoPracticeGroup.fromJson(Map<String, dynamic> json) {
+    final id = _asInt(json['id']);
     return CoPracticeGroup(
-      id: _asInt(json['id']),
+      id: id,
+      groupNo: _asInt(json['groupNo'] ?? json['group_no']),
       name: _asString(json['name']),
       description: _asString(json['description']),
       ownerUsername: _asString(json['ownerUsername'] ?? json['owner_username']),

--- a/fabushi/lib/services/co_practice_service.dart
+++ b/fabushi/lib/services/co_practice_service.dart
@@ -56,6 +56,30 @@ class CoPracticeGroupSearchResult {
       errorMessage != null && errorMessage!.trim().isNotEmpty;
 }
 
+class CoPracticeGroupJoinResult {
+  final bool isSuccess;
+  final String message;
+  final String? status;
+  final int? statusCode;
+
+  const CoPracticeGroupJoinResult._({
+    required this.isSuccess,
+    required this.message,
+    this.status,
+    this.statusCode,
+  });
+
+  const CoPracticeGroupJoinResult.success({
+    required String message,
+    String? status,
+  }) : this._(isSuccess: true, message: message, status: status);
+
+  const CoPracticeGroupJoinResult.failure(
+    String message, {
+    int? statusCode,
+  }) : this._(isSuccess: false, message: message, statusCode: statusCode);
+}
+
 class CoPracticeService {
   static final CoPracticeService _instance = CoPracticeService._internal();
   factory CoPracticeService({
@@ -192,18 +216,39 @@ class CoPracticeService {
     }
   }
 
-  Future<String?> joinGroup(int groupId) async {
-    final baseUrl = await _baseUrl;
-    final response = await _httpClient.post(
-      Uri.parse('$baseUrl/api/meditation/groups/join'),
-      headers: await _headers(),
-      body: jsonEncode({'groupId': groupId}),
-    );
+  Future<CoPracticeGroupJoinResult> joinGroup(int groupId) async {
+    try {
+      final baseUrl = await _baseUrl;
+      final response = await _httpClient.post(
+        Uri.parse('$baseUrl/api/meditation/groups/join'),
+        headers: await _headers(),
+        body: jsonEncode({'groupId': groupId}),
+      );
 
-    if (response.statusCode != 200) return null;
-    final data = _decodeJsonMap(response.body);
-    if (data['success'] != true) return null;
-    return data['data']?['message']?.toString() ?? '已提交';
+      final data = _decodeJsonMap(response.body);
+      if (response.statusCode != 200 || data['success'] != true) {
+        return CoPracticeGroupJoinResult.failure(
+          _extractErrorMessage(
+            data,
+            fallback: _joinFailureFallback(response.statusCode),
+          ),
+          statusCode: response.statusCode,
+        );
+      }
+
+      final status = data['data']?['status']?.toString();
+      final message = data['data']?['message']?.toString().trim();
+      return CoPracticeGroupJoinResult.success(
+        status: status,
+        message: message?.isNotEmpty == true
+            ? message!
+            : _joinSuccessFallback(status),
+      );
+    } catch (_) {
+      return const CoPracticeGroupJoinResult.failure(
+        '申请加入失败，请检查网络后重试',
+      );
+    }
   }
 
   Future<CoPracticeGroupDetail?> fetchGroupDetail(int groupId) async {
@@ -266,5 +311,26 @@ class CoPracticeService {
       return message.trim();
     }
     return fallback;
+  }
+
+  String _joinFailureFallback(int statusCode) {
+    if (statusCode == 401 || statusCode == 403) {
+      return '请先登录后再申请加入';
+    }
+    if (statusCode == 404) {
+      return '小组不存在或已被删除';
+    }
+    if (statusCode >= 500) {
+      return '申请加入失败，服务器暂时不可用';
+    }
+    return '申请加入失败，请稍后再试';
+  }
+
+  String _joinSuccessFallback(String? status) {
+    return switch (status) {
+      'pending' => '申请已提交，等待群主审核',
+      'active' => '已加入共修小组',
+      _ => '申请已提交',
+    };
   }
 }

--- a/fabushi/lib/services/co_practice_service.dart
+++ b/fabushi/lib/services/co_practice_service.dart
@@ -56,30 +56,6 @@ class CoPracticeGroupSearchResult {
       errorMessage != null && errorMessage!.trim().isNotEmpty;
 }
 
-class CoPracticeGroupJoinResult {
-  final bool isSuccess;
-  final String message;
-  final String? status;
-  final int? statusCode;
-
-  const CoPracticeGroupJoinResult._({
-    required this.isSuccess,
-    required this.message,
-    this.status,
-    this.statusCode,
-  });
-
-  const CoPracticeGroupJoinResult.success({
-    required String message,
-    String? status,
-  }) : this._(isSuccess: true, message: message, status: status);
-
-  const CoPracticeGroupJoinResult.failure(
-    String message, {
-    int? statusCode,
-  }) : this._(isSuccess: false, message: message, statusCode: statusCode);
-}
-
 class CoPracticeService {
   static final CoPracticeService _instance = CoPracticeService._internal();
   factory CoPracticeService({
@@ -216,7 +192,7 @@ class CoPracticeService {
     }
   }
 
-  Future<CoPracticeGroupJoinResult> joinGroup(int groupId) async {
+  Future<String?> joinGroup(int groupId) async {
     try {
       final baseUrl = await _baseUrl;
       final response = await _httpClient.post(
@@ -227,27 +203,19 @@ class CoPracticeService {
 
       final data = _decodeJsonMap(response.body);
       if (response.statusCode != 200 || data['success'] != true) {
-        return CoPracticeGroupJoinResult.failure(
-          _extractErrorMessage(
-            data,
-            fallback: _joinFailureFallback(response.statusCode),
-          ),
-          statusCode: response.statusCode,
+        return _extractErrorMessage(
+          data,
+          fallback: _joinFailureFallback(response.statusCode),
         );
       }
 
       final status = data['data']?['status']?.toString();
       final message = data['data']?['message']?.toString().trim();
-      return CoPracticeGroupJoinResult.success(
-        status: status,
-        message: message?.isNotEmpty == true
-            ? message!
-            : _joinSuccessFallback(status),
-      );
+      return message?.isNotEmpty == true
+          ? message!
+          : _joinSuccessFallback(status);
     } catch (_) {
-      return const CoPracticeGroupJoinResult.failure(
-        '申请加入失败，请检查网络后重试',
-      );
+      return '申请加入失败，请检查网络后重试';
     }
   }
 

--- a/fabushi/test/unit/services/co_practice_service_test.dart
+++ b/fabushi/test/unit/services/co_practice_service_test.dart
@@ -24,7 +24,7 @@ void main() {
         expect(request.url.queryParameters['query'], '晨课');
         expect(request.headers['Authorization'], 'Bearer test-token');
         return http.Response(
-          '{"success":true,"data":{"groups":[{"id":21,"name":"晨课共修","description":"每天一起完成早课","ownerUsername":"owner1","ownerName":"发起人","requireApproval":true,"dailyGoalMinutes":30,"cumulativeMissLimit":7,"consecutiveMissLimit":3,"memberCount":5,"pendingCount":2,"totalDuration":180,"todayDuration":45}]}}',
+          '{"success":true,"data":{"groups":[{"id":21,"groupNo":12345,"name":"晨课共修","description":"每天一起完成早课","ownerUsername":"owner1","ownerName":"发起人","requireApproval":true,"dailyGoalMinutes":30,"cumulativeMissLimit":7,"consecutiveMissLimit":3,"memberCount":5,"pendingCount":2,"totalDuration":180,"todayDuration":45}]}}',
           200,
           headers: const {'content-type': 'application/json'},
         );
@@ -38,7 +38,7 @@ void main() {
     expect(result.groups, hasLength(1));
     expect(result.groups.single.name, '晨课共修');
     expect(result.groups.single.ownerName, '发起人');
-    expect(result.groups.single.publicCode, '000021');
+    expect(result.groups.single.publicCode, '12345');
   });
 
   test('searchGroupsWithStatus surfaces backend error messages', () async {
@@ -135,5 +135,56 @@ void main() {
     expect(result.isSuccess, isFalse);
     expect(result.errorMessage, '创建共修小组失败');
     expect(result.statusCode, 400);
+  });
+
+  test('joinGroup returns pending review message on success', () async {
+    final service = createService(
+      MockClient((request) async {
+        expect(request.method, 'POST');
+        expect(request.url.path, '/api/meditation/groups/join');
+        expect(request.headers['Authorization'], 'Bearer test-token');
+        return http.Response(
+          '{"success":true,"data":{"status":"pending","message":"已提交加入申请，等待同意"}}',
+          200,
+          headers: const {'content-type': 'application/json'},
+        );
+      }),
+    );
+
+    final message = await service.joinGroup(42);
+
+    expect(message, '已提交加入申请，等待同意');
+  });
+
+  test('joinGroup surfaces backend error messages', () async {
+    final service = createService(
+      MockClient(
+        (_) async => http.Response(
+          '{"success":false,"error":"请先登录后再申请加入"}',
+          401,
+          headers: const {'content-type': 'application/json'},
+        ),
+      ),
+    );
+
+    final message = await service.joinGroup(42);
+
+    expect(message, '请先登录后再申请加入');
+  });
+
+  test('joinGroup returns readable fallback for empty server errors', () async {
+    final service = createService(
+      MockClient(
+        (_) async => http.Response(
+          '{"success":false}',
+          500,
+          headers: const {'content-type': 'application/json'},
+        ),
+      ),
+    );
+
+    final message = await service.joinGroup(42);
+
+    expect(message, '申请加入失败，服务器暂时不可用');
   });
 }

--- a/fabushi/web/src/routes/meditation-routes.js
+++ b/fabushi/web/src/routes/meditation-routes.js
@@ -16,7 +16,11 @@ import {
   handleSyncRecord,
 } from '../handlers/meditation.js';
 import { generateSnowflakeUserId as generateSnowflakeGroupId } from '../services/database.js';
-import { generateGroupNo } from '../services/external-numbers.js';
+import {
+  GROUP_NO_MAX_LENGTH,
+  GROUP_NO_MIN_LENGTH,
+  generateGroupNo,
+} from '../services/external-numbers.js';
 import { jsonResponse } from '../utils/response.js';
 
 function asInt(value, fallback = 0) {
@@ -92,13 +96,15 @@ async function generateUniqueGroupId(db) {
 }
 
 async function generateUniqueGroupNo(db) {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
-    const candidate = generateGroupNo();
-    const existingGroupId = await resolveGroupIdFromGroupNo(db, candidate);
-    if (!existingGroupId) return candidate;
+  for (let length = GROUP_NO_MIN_LENGTH; length <= GROUP_NO_MAX_LENGTH; length += 1) {
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const candidate = generateGroupNo(length);
+      const existingGroupId = await resolveGroupIdFromGroupNo(db, candidate);
+      if (!existingGroupId) return candidate;
+    }
   }
 
-  throw new Error('无法生成可用的 8 位群号');
+  throw new Error(`无法生成可用的 ${GROUP_NO_MIN_LENGTH}-${GROUP_NO_MAX_LENGTH} 位群号`);
 }
 
 async function ensureCreatedGroupNo(db, groupId) {
@@ -172,19 +178,17 @@ async function rewriteGroupDetailRequest(request, db) {
 
 async function rewriteGroupBodyRequest(request, db) {
   const body = await request.json();
-  if (body.groupId || !body.groupNo) {
-    return { request, body };
-  }
+  let nextBody = body;
 
-  const groupId = await resolveGroupIdFromGroupNo(db, body.groupNo);
-  if (!groupId) {
-    return { request, body };
+  if (!body.groupId && body.groupNo) {
+    const groupId = await resolveGroupIdFromGroupNo(db, body.groupNo);
+    if (groupId) {
+      nextBody = {
+        ...body,
+        groupId,
+      };
+    }
   }
-
-  const nextBody = {
-    ...body,
-    groupId,
-  };
 
   return {
     request: await cloneRequestWithJsonBody(request, nextBody),

--- a/fabushi/web/src/services/external-numbers.js
+++ b/fabushi/web/src/services/external-numbers.js
@@ -1,5 +1,7 @@
 export const USER_NO_LENGTH = 9;
-export const GROUP_NO_LENGTH = 8;
+export const GROUP_NO_MIN_LENGTH = 5;
+export const GROUP_NO_MAX_LENGTH = 8;
+export const GROUP_NO_LENGTH = GROUP_NO_MIN_LENGTH;
 
 const UINT32_SIZE = 0x100000000;
 
@@ -44,6 +46,6 @@ export function generateUserNo() {
   return generateExternalNumericNo(USER_NO_LENGTH);
 }
 
-export function generateGroupNo() {
-  return generateExternalNumericNo(GROUP_NO_LENGTH);
+export function generateGroupNo(length = GROUP_NO_LENGTH) {
+  return generateExternalNumericNo(length);
 }

--- a/fabushi/web/tests/external-numbers.test.js
+++ b/fabushi/web/tests/external-numbers.test.js
@@ -3,20 +3,29 @@ import assert from 'node:assert/strict';
 
 import {
   GROUP_NO_LENGTH,
+  GROUP_NO_MAX_LENGTH,
+  GROUP_NO_MIN_LENGTH,
   USER_NO_LENGTH,
   generateExternalNumericNo,
   generateGroupNo,
   generateUserNo,
 } from '../src/services/external-numbers.js';
 
-test('external numeric numbers use fixed non-enumerable display lengths', () => {
+test('external numeric numbers use intended display lengths', () => {
   const userNo = generateUserNo();
   const groupNo = generateGroupNo();
 
   assert.match(String(userNo), /^\d{9}$/);
-  assert.match(String(groupNo), /^\d{8}$/);
+  assert.match(String(groupNo), /^\d{5}$/);
   assert.equal(USER_NO_LENGTH, 9);
-  assert.equal(GROUP_NO_LENGTH, 8);
+  assert.equal(GROUP_NO_LENGTH, 5);
+  assert.equal(GROUP_NO_MIN_LENGTH, 5);
+  assert.equal(GROUP_NO_MAX_LENGTH, 8);
+});
+
+test('group numeric generator supports longer pools when short pools are saturated', () => {
+  assert.match(String(generateGroupNo(6)), /^\d{6}$/);
+  assert.match(String(generateGroupNo(8)), /^\d{8}$/);
 });
 
 test('external numeric generator rejects unsafe display lengths', () => {

--- a/fabushi/web/tests/meditation-group-id-layering.test.js
+++ b/fabushi/web/tests/meditation-group-id-layering.test.js
@@ -86,7 +86,7 @@ function createGroupDbMock() {
   };
 }
 
-test('creating meditation group uses snowflake internal id and random external groupNo', async () => {
+test('creating meditation group uses snowflake internal id and short external groupNo', async () => {
   const db = createGroupDbMock();
   const request = new Request('https://example.com/api/meditation/groups', {
     method: 'POST',
@@ -116,7 +116,7 @@ test('creating meditation group uses snowflake internal id and random external g
 
   assert.equal(payload.success, true);
   assert.equal(Number.isSafeInteger(payload.data.groupId), true);
-  assert.match(String(payload.data.groupNo), /^\d{8}$/);
+  assert.match(String(payload.data.groupNo), /^\d{5}$/);
   assert.notEqual(payload.data.groupId, payload.data.groupNo);
   assert.equal(db.state.groups[0].id, payload.data.groupId);
   assert.equal(db.state.groups[0].group_no, payload.data.groupNo);

--- a/fabushi/web/tests/meditation-group-id-layering.test.js
+++ b/fabushi/web/tests/meditation-group-id-layering.test.js
@@ -26,11 +26,22 @@ function createGroupDbMock() {
                 return state.groups.find((group) => group.id === Number(params[0])) || null;
               }
               if (normalizedSql === 'SELECT id FROM meditation_groups WHERE group_no = ?') {
-                return state.groups.find((group) => group.group_no === Number(params[0])) || null;
+                const group = state.groups.find((entry) => entry.group_no === Number(params[0]));
+                return group ? { id: group.id } : null;
               }
               if (normalizedSql === 'SELECT group_no FROM meditation_groups WHERE id = ?') {
                 const group = state.groups.find((entry) => entry.id === Number(params[0]));
                 return group ? { group_no: group.group_no } : null;
+              }
+              if (normalizedSql === 'SELECT id, require_approval, owner_username FROM meditation_groups WHERE id = ?') {
+                const group = state.groups.find((entry) => entry.id === Number(params[0]));
+                return group
+                  ? {
+                      id: group.id,
+                      require_approval: group.require_approval,
+                      owner_username: group.owner_username,
+                    }
+                  : null;
               }
               return null;
             },
@@ -63,6 +74,27 @@ function createGroupDbMock() {
                   updated_at: updatedAt,
                 });
                 return { meta: { last_row_id: Number(id) } };
+              }
+              if (normalizedSql.startsWith('INSERT INTO meditation_group_members (group_id, username, role, status, joined_at, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT')) {
+                const [groupId, username, role, status, joinedAt, updatedAt] = params;
+                const existing = state.members.find(
+                  (member) => member.group_id === Number(groupId) && member.username === username,
+                );
+                if (existing) {
+                  existing.role = existing.role === 'owner' ? 'owner' : role;
+                  existing.status = status;
+                  existing.updated_at = updatedAt;
+                } else {
+                  state.members.push({
+                    group_id: Number(groupId),
+                    username,
+                    role,
+                    status,
+                    joined_at: joinedAt,
+                    updated_at: updatedAt,
+                  });
+                }
+                return { meta: {} };
               }
               if (normalizedSql.startsWith('INSERT INTO meditation_group_members (group_id, username, role, status, joined_at, updated_at)')) {
                 const [groupId, username, joinedAt, updatedAt] = params;
@@ -121,4 +153,41 @@ test('creating meditation group uses snowflake internal id and short external gr
   assert.equal(db.state.groups[0].id, payload.data.groupId);
   assert.equal(db.state.groups[0].group_no, payload.data.groupNo);
   assert.equal(db.state.members[0].group_id, payload.data.groupId);
+});
+
+test('joining meditation group keeps request body readable after route rewrite', async () => {
+  const db = createGroupDbMock();
+  db.state.groups.push({
+    id: 1793864023001,
+    group_no: 12345,
+    owner_username: 'owner',
+    require_approval: 1,
+  });
+
+  const request = new Request('https://example.com/api/meditation/groups/join', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${makeToken('applicant')}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ groupId: 1793864023001 }),
+  });
+
+  const response = await routeMeditationRequest({
+    pathname: '/api/meditation/groups/join',
+    method: 'POST',
+    request,
+    env: {},
+    db,
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.status, 'pending');
+  assert.equal(payload.data.message, '已提交加入申请，等待同意');
+  assert.equal(db.state.members[0].group_id, 1793864023001);
+  assert.equal(db.state.members[0].username, 'applicant');
+  assert.equal(db.state.members[0].status, 'pending');
 });


### PR DESCRIPTION
## Summary
- fix meditation group join request body rewrite so POST bodies are re-created after route-level groupNo/groupId mapping
- surface clear join feedback messages for pending/active/auth/server-error cases
- switch new group display numbers to start from a 5-digit pool and expand toward 8 digits only if shorter pools collide heavily
- display backend groupNo in Flutter instead of the internal groupId fallback
- update web and Flutter regression tests

## Tests
- Not run locally (container cannot resolve github.com to clone repo); updated existing unit/regression tests for changed behavior.

Fixes #294