### PR TITLE
优化官网首页文案与视觉层级

### DIFF
--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -740,6 +740,95 @@ a {
   font-weight: 700;
 }
 
+.home-shell .hero,
+.home-shell .band {
+  padding-bottom: clamp(64px, 9vw, 112px);
+}
+
+.home-shell .hero {
+  min-height: auto;
+  gap: 28px;
+}
+
+.home-shell .hero-stage,
+.home-shell .band > .section-heading,
+.home-shell .editorial-feature-grid,
+.home-shell .platform-list,
+.home-shell .faq-shell,
+.home-shell .cta-panel {
+  width: min(100%, 1160px);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.home-shell .hero-copy {
+  padding-top: clamp(64px, 9vw, 112px);
+  padding-bottom: clamp(32px, 6vw, 72px);
+}
+
+.home-shell .hero-copy h1 {
+  max-width: 8ch;
+  font-size: clamp(4rem, 10vw, 7.8rem);
+}
+
+.home-shell .lede {
+  max-width: 31rem;
+  color: var(--muted-strong);
+  font-size: clamp(1.08rem, 1.6vw, 1.24rem);
+}
+
+.home-shell .hero-actions {
+  margin-top: 28px;
+}
+
+.home-shell .primary-action,
+.home-shell .secondary-action,
+.home-shell .nav-action {
+  border-radius: 999px;
+}
+
+.home-shell .hero-visual {
+  min-height: 460px;
+}
+
+.home-shell .hero-console {
+  width: min(100%, 420px);
+  border-radius: 32px;
+}
+
+.home-shell .hero-console-line {
+  grid-template-columns: 48px minmax(0, 1fr);
+}
+
+.home-shell .section-heading {
+  margin-bottom: 24px;
+}
+
+.home-shell .section-heading h2,
+.home-shell .cta-panel h2 {
+  max-width: 12ch;
+}
+
+.home-shell .editorial-feature-grid {
+  gap: clamp(18px, 3vw, 36px);
+}
+
+.home-shell .feature-column p,
+.home-shell .platform-row p,
+.home-shell .contact-card p,
+.home-shell .faq-item p {
+  max-width: 34rem;
+}
+
+.home-shell .platform-row.refined {
+  padding: 26px 0;
+}
+
+.home-shell .cta-panel {
+  padding: clamp(28px, 5vw, 48px);
+  border-radius: 32px;
+}
+
 @keyframes slowPulse {
   0%,
   100% {
@@ -774,6 +863,10 @@ a {
 
   .hero-visual {
     min-height: 420px;
+  }
+
+  .home-shell .hero-copy h1 {
+    max-width: 10ch;
   }
 }
 
@@ -818,5 +911,18 @@ a {
   .statement-card,
   .contact-card.minimal {
     min-height: auto;
+  }
+
+  .home-shell .hero-copy {
+    padding-top: 42px;
+  }
+
+  .home-shell .hero-copy h1 {
+    max-width: none;
+    font-size: clamp(3.3rem, 16vw, 4.9rem);
+  }
+
+  .home-shell .hero-visual {
+    min-height: 360px;
   }
 }

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -3,33 +3,7 @@ import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
 import { siteHref, siteUrl } from "../lib/site-url";
 
-const heroSignals = [
-  "产品定位",
-  "下载状态",
-  "测试申请",
-  "常见问题",
-] as const;
-
-const intentPaths = [
-  {
-    title: "先理解",
-    description: "用最短路径看清法布施是什么、适合谁、现在开放到哪里。",
-    href: "/faq",
-    label: "查看常见问题",
-  },
-  {
-    title: "再进入",
-    description: "根据平台状态选择 Android、iOS 或小程序相关入口，不走空页面。",
-    href: "/download",
-    label: "打开下载入口",
-  },
-  {
-    title: "然后参与",
-    description: "如果你愿意内测、反馈问题或讨论合作，直接进入明确的联系路径。",
-    href: "/apply",
-    label: "申请测试资格",
-  },
-] as const;
+const heroSignals = ["佛法传播", "修行记录", "共修连接"] as const;
 
 const conciseFaq = faqItems.slice(0, 3);
 const conciseHighlights = homeHighlights.slice(0, 3);
@@ -54,7 +28,7 @@ export default function HomePage() {
         name: `${brand.name} 官网`,
         url: siteUrl("/"),
         inLanguage: "zh-CN",
-        description: "Fabushi 法布施官网，集中提供产品介绍、下载入口、测试申请与 FAQ。",
+        description: "Fabushi 法布施官网，提供产品介绍、下载入口、测试申请与 FAQ。",
       },
       {
         "@type": "SoftwareApplication",
@@ -62,7 +36,7 @@ export default function HomePage() {
         applicationCategory: "LifestyleApplication",
         operatingSystem: "iOS, Android, Web",
         url: siteUrl("/download"),
-        description: "围绕佛法传播、修行记录与共修连接构建的产品体系。",
+        description: "佛法传播、修行记录与共修连接平台。",
       },
       {
         "@type": "FAQPage",
@@ -91,21 +65,19 @@ export default function HomePage() {
 
         <div className="hero-stage">
           <div className="hero-copy">
-            <p className="eyebrow">佛法传播平台</p>
-            <p className="brand-kicker">
-              {brand.name} <span>Fabushi</span>
-            </p>
-            <h1>一个更安静、更清晰的入口，让人先理解法布施，再决定是否进入。</h1>
+            <p className="eyebrow">法布施 Fabushi</p>
+            <p className="brand-kicker">{brand.tagline}</p>
+            <h1>把佛法传播得更远。</h1>
             <p className="lede">
-              官网不再试图一次讲完所有事情。它先把产品定位、下载状态、测试申请和常见问题整理清楚，让第一次到来的人几秒内知道下一步该去哪里。
+              上传分享、记录修行、找到同行者。官网只保留下载、内测申请和常见问题入口。
             </p>
 
             <div className="hero-actions">
-              <a className="primary-action" href={siteHref("/download")}>
-                查看下载入口
+              <a className="primary-action" href={siteHref("/apply")}>
+                申请测试
               </a>
-              <a className="secondary-action" href={siteHref("/faq")}>
-                先看常见问题
+              <a className="secondary-action" href={siteHref("/download")}>
+                查看下载
               </a>
             </div>
 
@@ -121,24 +93,24 @@ export default function HomePage() {
             <div className="hero-orbit hero-orbit-b" />
             <div className="hero-console">
               <div className="hero-console-head">
-                <span>Fabushi / Home</span>
-                <small>Live structure</small>
+                <span>当前入口</span>
+                <small>Beta</small>
               </div>
               <div className="hero-console-body">
                 <div className="hero-console-line">
                   <em>01</em>
-                  <strong>这是什么</strong>
+                  <strong>产品</strong>
                   <span>佛法传播、修行记录、共修连接</span>
                 </div>
                 <div className="hero-console-line">
                   <em>02</em>
-                  <strong>现在能做什么</strong>
-                  <span>看状态、找入口、申请测试、了解 FAQ</span>
+                  <strong>下载</strong>
+                  <span>Android 封闭测试，iOS 准备中</span>
                 </div>
                 <div className="hero-console-line">
                   <em>03</em>
-                  <strong>下一步去哪里</strong>
-                  <span>下载页、申请页、联系页</span>
+                  <strong>参与</strong>
+                  <span>申请测试、反馈问题、合作沟通</span>
                 </div>
               </div>
             </div>
@@ -146,26 +118,10 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="band compact-band" id="why-fabushi">
-        <div className="section-heading narrow">
-          <p>首页原则</p>
-          <h2>少一点解释负担，多一点方向感。</h2>
-        </div>
-        <div className="statement-grid">
-          {intentPaths.map((item) => (
-            <article key={item.title} className="statement-card">
-              <span>{item.title}</span>
-              <h3>{item.description}</h3>
-              <a href={siteHref(item.href)}>{item.label}</a>
-            </article>
-          ))}
-        </div>
-      </section>
-
       <section className="band editorial-band" id="capabilities">
         <div className="section-heading">
           <p>核心能力</p>
-          <h2>法布施不是一个单点工具，而是一条从传播到连接的连续路径。</h2>
+          <h2>传播、记录、连接。</h2>
         </div>
 
         <div className="editorial-feature-grid">
@@ -181,8 +137,8 @@ export default function HomePage() {
 
       <section className="band alt minimal-band" id="download">
         <div className="section-heading">
-          <p>当前入口</p>
-          <h2>把真实状态摆在前面，比堆很多承诺更有用。</h2>
+          <p>下载</p>
+          <h2>选择可用入口。</h2>
         </div>
 
         <div className="platform-list">
@@ -204,8 +160,8 @@ export default function HomePage() {
       <section className="band faq-band" id="faq">
         <div className="faq-shell">
           <div className="section-heading compact">
-            <p>常见问题</p>
-            <h2>先回答最容易被搜索、也最容易卡住转化的问题。</h2>
+            <p>FAQ</p>
+            <h2>先回答关键问题。</h2>
           </div>
 
           <div className="faq-list">
@@ -228,8 +184,8 @@ export default function HomePage() {
       <section className="band cta-band" id="contact">
         <div className="cta-panel">
           <div className="section-heading compact narrow">
-            <p>下一步</p>
-            <h2>准备下载、申请测试或直接联系时，官网只保留最清楚的入口。</h2>
+            <p>联系</p>
+            <h2>申请测试或合作沟通。</h2>
           </div>
 
           <div className="contact-grid minimal">

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -5,14 +5,13 @@ export function SiteFooter() {
     <footer className="site-footer">
       <div>
         <p className="footer-title">法布施 Fabushi</p>
-        <p className="footer-copy">官网集中承接下载入口、测试申请、FAQ、内容更新与公开协作信息。</p>
+        <p className="footer-copy">佛法传播、修行记录与共修连接。</p>
       </div>
       <div className="footer-links">
-        <a href={siteHref("/download")}>下载入口</a>
+        <a href={siteHref("/download")}>下载</a>
         <a href={siteHref("/apply")}>申请测试</a>
-        <a href={siteHref("/faq")}>常见问题</a>
+        <a href={siteHref("/faq")}>FAQ</a>
         <a href={siteHref("/contact")}>联系</a>
-        <a href={siteHref("/insights")}>内容专栏</a>
         <a href="mailto:support@fabushi.com">support@fabushi.com</a>
       </div>
     </footer>

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -2,7 +2,7 @@ import { primaryNavigation } from "@fabushi/shared";
 import { siteHref } from "../lib/site-url";
 
 const compactNavigation = primaryNavigation.filter((item) =>
-  ["/download", "/faq", "/contact", "/insights"].includes(item.href),
+  ["/download", "/apply", "/faq", "/contact"].includes(item.href),
 );
 
 export function SiteHeader() {
@@ -20,8 +20,8 @@ export function SiteHeader() {
             </a>
           ))}
         </div>
-        <a className="nav-action" href={siteHref("/download")}>
-          下载入口
+        <a className="nav-action" href={siteHref("/apply")}>
+          申请测试
         </a>
       </div>
     </nav>

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -1,15 +1,15 @@
 export const homeHighlights = [
   {
-    title: "全球法布施传播",
-    description: "围绕内容传播、上传分享、回向记录与可见榜单，建立持续增长的善意网络。",
+    title: "传播佛法",
+    description: "上传、分享、回向，让善意被看见。",
   },
   {
-    title: "修行记录与隐私控制",
-    description: "保留公开展示与私密修行的边界，让个人节奏与社交互动能自然共存。",
+    title: "记录修行",
+    description: "公开或私密记录，保留自己的节奏。",
   },
   {
-    title: "轻社群与共修关系",
-    description: "通过关注、排行榜、共修小组和公开档案，帮助用户更容易找到同行者。",
+    title: "找到同行者",
+    description: "通过关注、榜单和共修关系连接彼此。",
   },
 ] as const;
 
@@ -17,80 +17,79 @@ export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },
   { label: "申请测试", href: "/apply" },
-  { label: "常见问题", href: "/faq" },
+  { label: "FAQ", href: "/faq" },
   { label: "联系", href: "/contact" },
   { label: "核心能力", href: "/#capabilities" },
-  { label: "内容专栏", href: "/insights" },
+  { label: "内容", href: "/insights" },
 ] as const;
 
 export const launchRoadmap = [
-  "先上线官网，承接品牌介绍、功能说明、下载指引和后续活动落地页。",
-  "同步建设微信小程序首期版本，优先覆盖轻浏览、榜单、公开档案和基础登录。",
-  "继续把更重的创作、上传和沉浸式体验保留在 Flutter 主应用里。",
+  "官网先承接介绍、下载、FAQ 和活动入口。",
+  "微信小程序优先做轻浏览、榜单和公开档案。",
+  "Flutter 主应用继续承接完整体验。",
 ] as const;
 
 export const downloadOptions = [
   {
     platform: "iOS",
     status: "内测准备中",
-    description: "保留沉浸式内容浏览、上传分享、完整个人中心和重交互流程。",
+    description: "完整主应用体验，开放后通过 TestFlight 参与。",
     ctaLabel: "加入 iOS 等待名单",
     ctaHref: "mailto:support@fabushi.com?subject=Fabushi%20iOS%20TestFlight",
   },
   {
     platform: "Android",
     status: "封闭测试中",
-    description: "优先承接传播、榜单、公开档案与上传相关的完整主应用体验。",
+    description: "优先体验传播、榜单、档案与上传流程。",
     ctaLabel: "加入 Android 等待名单",
     ctaHref: "mailto:support@fabushi.com?subject=Fabushi%20Android%20Beta",
   },
   {
     platform: "微信小程序",
-    status: "首期规划中",
-    description: "聚焦轻浏览、榜单、公开档案和微信生态内的便捷触达。",
+    status: "规划中",
+    description: "轻浏览、榜单和微信生态触达。",
     ctaLabel: "查看小程序路线",
     ctaHref: "/insights/wechat-mini-program-phase-one",
   },
   {
     platform: "Web 官网",
-    status: "本轮建设中",
-    description: "负责品牌说明、下载引导、FAQ、专题内容与活动落地页。",
+    status: "建设中",
+    description: "品牌说明、下载引导、FAQ 与专题内容。",
     ctaLabel: "浏览官网路线",
     ctaHref: "/insights/official-site-structure",
   },
 ] as const;
 
 export const downloadStatusNotes = [
-  "当前仓库里还没有可直接公开挂出的 App Store、TestFlight 或 APK 正式下载直链。",
-  "官网先把各平台状态、职责和等待名单入口讲清楚，避免用户点进来却落到空页面。",
-  "一旦正式下载链接可公开，优先替换 downloadOptions 中的对应入口即可，不需要重做页面结构。",
+  "当前还没有可公开挂出的 App Store、TestFlight 或 APK 正式直链。",
+  "官网先展示真实状态和等待名单入口。",
+  "正式链接可公开后，直接替换对应入口。",
 ] as const;
 
 export const faqItems = [
   {
-    question: "官网、微信小程序和 Flutter 主应用分别承担什么角色？",
+    question: "官网、微信小程序和主应用分别做什么？",
     answer:
-      "官网负责品牌说明、下载入口、FAQ 和内容运营；微信小程序负责微信生态里的轻触达；Flutter 主应用继续承接完整的沉浸式体验和重交互流程。",
+      "官网负责介绍、下载、FAQ 和内容；微信小程序负责轻触达；主应用承接完整体验。",
   },
   {
-    question: "为什么不直接用 Flutter Web 同时做官网和小程序？",
+    question: "为什么不直接用 Flutter Web 做官网？",
     answer:
-      "官网需要更好的 SEO、内容结构和首屏控制，小程序又有自己的运行规范。拆成 Next.js + Taro 可以减少后续返工，同时继续复用现有后端与业务层。",
+      "官网更需要 SEO、内容结构和首屏速度，所以使用 Next.js。",
   },
   {
-    question: "官网和小程序会不会变成两套完全分裂的系统？",
+    question: "官网和小程序会不会分裂？",
     answer:
-      "不会。新前端 monorepo 会持续共享 API client、类型、品牌文案和部分纯业务逻辑，差异主要保留在各自的页面表现层。",
+      "不会。前端会共享 API、类型、品牌文案和部分业务逻辑。",
   },
   {
-    question: "小程序首期最先会上什么？",
-    answer:
-      "优先是轻浏览、榜单、公开档案和基础登录，先把传播入口和社交发现路径打通，再逐步补更复杂的内容创作与上传流程。",
+    question: "小程序首期会上什么？",
+    answer: "轻浏览、榜单、公开档案和基础登录。",
   },
   {
-    question: "为什么下载页现在不再只是等待名单入口？",
+    question: "为什么下载页不只是等待名单？",
     answer:
-      "因为官网已经开始直接读取 GitHub Release 的 Android beta 安装包、TestFlight 上传状态，以及人工验收后发布的正式版信息。这样下载页会跟着发布链路一起更新，而不是靠手动改文案。",
+      "下载页会逐步接入 Android beta、TestFlight 状态和正式版信息。",
   },
 ] as const;
 
@@ -99,30 +98,30 @@ export const contactChannels = [
     label: "支持邮箱",
     value: "support@fabushi.com",
     href: "mailto:support@fabushi.com",
-    note: "下载申请、测试资格、问题反馈和合作沟通统一从这里进入。",
+    note: "测试申请、问题反馈、合作沟通。",
   },
   {
     label: "官网域名",
     value: "fabushi.ombhrum.com",
     href: "https://fabushi.ombhrum.com",
-    note: "后续会作为官网、专题页和正式下载指引的统一入口。",
+    note: "官网和正式下载入口。",
   },
   {
     label: "GitHub 仓库",
     value: "bhrumom/fabushi",
     href: "https://github.com/bhrumom/fabushi",
-    note: "适合查看项目进展、提交 issue 和跟踪公开开发记录。",
+    note: "查看进展、提交 issue。",
   },
 ] as const;
 
 export const betaApplicationTracks = [
   {
     name: "iOS TestFlight",
-    summary: "适合想优先体验完整主应用流程，并愿意接受内测节奏的用户。",
+    summary: "适合优先体验完整主应用流程的用户。",
     checklist: [
-      "附上你的常用邮箱",
-      "说明你更关注内容传播、修行记录还是社交发现",
-      "写明你是否愿意反馈 bug 和体验问题",
+      "留下常用邮箱",
+      "说明关注内容传播、修行记录还是社交发现",
+      "说明是否愿意反馈问题",
     ],
     ctaLabel: "申请 iOS 内测",
     ctaHref:
@@ -130,11 +129,11 @@ export const betaApplicationTracks = [
   },
   {
     name: "Android Beta",
-    summary: "适合想尽快体验传播、榜单、公开档案和上传相关完整主流程的用户。",
+    summary: "适合优先体验 Android 主流程的用户。",
     checklist: [
-      "附上你的常用邮箱",
-      "说明你的 Android 机型或系统版本",
-      "写明你最想优先体验哪个模块",
+      "留下常用邮箱",
+      "说明 Android 机型或系统版本",
+      "说明最想体验的模块",
     ],
     ctaLabel: "申请 Android 内测",
     ctaHref:
@@ -142,11 +141,11 @@ export const betaApplicationTracks = [
   },
   {
     name: "合作与渠道",
-    summary: "适合想讨论传播合作、内容共建、渠道联动或活动承接的人。",
+    summary: "适合讨论内容、渠道或活动合作。",
     checklist: [
-      "附上你的姓名或组织名称",
-      "说明合作方向或渠道资源",
-      "留下可回联的邮箱或微信说明",
+      "留下姓名或组织名称",
+      "说明合作方向",
+      "留下回联方式",
     ],
     ctaLabel: "发起合作沟通",
     ctaHref:


### PR DESCRIPTION
## Summary
- 精简官网首页文案，删除偏内部说明的“首页原则”等内容
- 将首屏改成更直接的产品定位、下载状态和测试申请入口
- 收紧导航、底部、FAQ、下载卡片和联系卡片文案
- 增加首页专属布局微调：内容最大宽度、首屏留白、圆角按钮、卡片间距和 CTA 面板视觉

## Notes
- 分支基于当前 `main` 最新提交，compare 显示 ahead 5 / behind 0
- 未在本地运行构建；改动集中在 TSX 文案结构和 CSS 样式层