### PR TITLE
Redesign official site homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ node_modules/
 .env
 .env.local
 
+# Next.js frontend build artifacts
+frontend/apps/web/.next/
+frontend/apps/web/out/
+
 # Flutter/Dart 相关
 .dart_tool/
 .packages

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -1,18 +1,18 @@
 :root {
-  color-scheme: light;
-  --bg: #f6f1e8;
-  --surface: rgba(255, 251, 245, 0.82);
-  --surface-strong: rgba(255, 248, 239, 0.94);
-  --ink: #19140f;
-  --muted: #65594d;
-  --accent: #a86130;
-  --accent-strong: #7f441d;
-  --accent-soft: rgba(168, 97, 48, 0.12);
-  --secondary: #4f695f;
-  --secondary-soft: rgba(79, 105, 95, 0.12);
-  --line: rgba(58, 43, 29, 0.12);
-  --line-strong: rgba(58, 43, 29, 0.2);
-  --shadow: 0 24px 60px rgba(53, 37, 24, 0.08);
+  color-scheme: dark;
+  --bg: #05060b;
+  --bg-soft: #0c1020;
+  --ink: #f7f8ff;
+  --muted: #aab1cc;
+  --muted-strong: #d8ddf3;
+  --surface: rgba(12, 15, 28, 0.78);
+  --surface-strong: rgba(17, 22, 43, 0.92);
+  --line: rgba(255, 255, 255, 0.13);
+  --line-strong: rgba(255, 255, 255, 0.22);
+  --accent: #8da2ff;
+  --accent-strong: #d7ddff;
+  --gold: #e2b35f;
+  --shadow: 0 26px 90px rgba(0, 0, 0, 0.36);
 }
 
 * {
@@ -25,10 +25,7 @@ html {
 
 body {
   margin: 0;
-  background:
-    radial-gradient(circle at top left, rgba(236, 214, 180, 0.52), transparent 34%),
-    radial-gradient(circle at top right, rgba(153, 186, 170, 0.18), transparent 32%),
-    linear-gradient(180deg, #faf6ef 0%, #f6efe4 44%, #f1e7db 100%);
+  background: var(--bg);
   color: var(--ink);
   font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
@@ -41,15 +38,21 @@ a {
 h1,
 h2,
 h3,
-.brand-kicker,
 .site-wordmark span,
 .footer-title {
-  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  margin: 0;
+  letter-spacing: 0;
 }
 
 .page-shell,
 .inner-page {
   min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 16%, rgba(241, 244, 255, 0.7), transparent 16rem),
+    radial-gradient(circle at 72% 18%, rgba(90, 108, 255, 0.62), transparent 24rem),
+    radial-gradient(circle at 84% 60%, rgba(151, 90, 255, 0.46), transparent 20rem),
+    linear-gradient(135deg, #dce8ff 0%, #5167ff 28%, #0b0f37 58%, #02030a 100%);
 }
 
 .hero,
@@ -57,94 +60,94 @@ h3,
 .inner-hero,
 .article-body,
 .site-footer {
-  padding-left: 24px;
-  padding-right: 24px;
-}
-
-.hero,
-.band {
-  padding-top: 32px;
-  padding-bottom: 72px;
-}
-
-.inner-hero {
-  padding-top: 32px;
-  padding-bottom: 48px;
+  padding-left: 28px;
+  padding-right: 28px;
 }
 
 .hero {
-  min-height: 100svh;
+  position: relative;
+  min-height: 82svh;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  padding-top: 16px;
+  padding-bottom: 42px;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(2, 3, 10, 0.52) 82%),
+    radial-gradient(ellipse at 18% 54%, rgba(255, 255, 255, 0.6), transparent 24rem);
+  pointer-events: none;
 }
 
 .site-nav {
   position: sticky;
-  top: 18px;
+  top: 16px;
   z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 18px;
-  padding: 14px 16px;
-  background: rgba(255, 250, 244, 0.72);
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  backdrop-filter: blur(16px);
-  box-shadow: 0 10px 30px rgba(48, 34, 24, 0.06);
+  width: 100%;
+  padding: 0;
+  color: #05060b;
 }
 
 .site-wordmark {
-  display: inline-grid;
-  gap: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: max-content;
+}
+
+.site-wordmark::before {
+  content: "法";
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(5, 6, 11, 0.2);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.22);
+  font-weight: 800;
 }
 
 .site-wordmark span {
-  font-size: 1.2rem;
-  line-height: 1;
+  display: block;
+  font-size: 1.18rem;
+  font-weight: 800;
 }
 
-.site-wordmark small,
-.detail-label {
-  color: var(--accent-strong);
-  font-size: 0.78rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+.site-wordmark small {
+  display: none;
 }
 
 .site-nav-links-wrap,
+.site-nav-links,
 .site-nav-cluster,
-.hero-stage,
 .hero-actions,
 .inline-cta,
 .release-card-actions {
   display: flex;
-  gap: 14px;
-}
-
-.site-nav-links-wrap,
-.site-nav-cluster {
   align-items: center;
   flex-wrap: wrap;
-}
-
-.site-nav-links,
-.footer-links {
-  display: flex;
-  flex-wrap: wrap;
   gap: 14px;
-  color: var(--muted);
 }
 
-.site-nav-links a,
-.footer-links a {
+.site-nav-links {
+  color: rgba(5, 6, 11, 0.64);
+  font-size: 0.95rem;
+}
+
+.site-nav-links a {
   transition: color 180ms ease;
 }
 
-.site-nav-links a:hover,
-.footer-links a:hover {
-  color: var(--ink);
+.site-nav-links a:hover {
+  color: #05060b;
 }
 
 .nav-cta,
@@ -156,8 +159,11 @@ h3,
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-height: 42px;
   border-radius: 999px;
-  padding: 12px 20px;
+  padding: 11px 19px;
+  border: 1px solid transparent;
+  font-weight: 700;
   transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
 }
 
@@ -165,14 +171,15 @@ h3,
 .nav-action,
 .primary-action,
 .path-link {
-  background: var(--ink);
-  color: #fffaf3;
+  background: #05060b;
+  color: #fff;
 }
 
 .secondary-action,
 .tertiary-action {
-  background: var(--surface);
-  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.22);
+  color: var(--ink);
 }
 
 .nav-cta:hover,
@@ -184,34 +191,40 @@ h3,
   transform: translateY(-1px);
 }
 
-.hero-stage {
+.hero-center {
+  position: relative;
+  z-index: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1.12fr) minmax(280px, 0.88fr);
-  align-items: end;
-  gap: 28px;
-  margin-top: auto;
+  justify-items: center;
+  text-align: center;
+  max-width: 960px;
+  margin: auto;
+  padding-top: 48px;
 }
 
-.hero-copy,
-.inner-copy,
-.section-heading,
-.article-body {
-  max-width: 860px;
-}
-
-.hero-copy {
-  padding: 10vh 0 6vh;
-}
-
-.inner-copy {
-  padding-top: 10vh;
-}
-
-.hero-aside,
-.hero-rail {
+.app-mark {
   display: grid;
-  gap: 16px;
-  padding-bottom: 6vh;
+  place-items: center;
+  width: 84px;
+  height: 84px;
+  margin-bottom: 22px;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 35% 28%, rgba(255, 255, 255, 0.9), transparent 1.6rem),
+    linear-gradient(145deg, #ffffff, #7d8eff 42%, #2837df);
+  box-shadow: 0 24px 60px rgba(25, 39, 164, 0.4);
+}
+
+.app-mark span {
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  color: #2630c9;
+  font-size: 1.85rem;
+  font-weight: 900;
 }
 
 .eyebrow,
@@ -219,67 +232,255 @@ h3,
 .platform-name,
 .download-status,
 .article-date,
-.hero-panel p {
+.hero-panel p,
+.detail-label {
   margin: 0 0 12px;
   color: var(--accent-strong);
-  font-size: 0.95rem;
-}
-
-.brand-kicker {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 12px;
-  margin: 0 0 18px;
-  font-size: clamp(2rem, 3vw, 3rem);
-}
-
-.brand-kicker span {
-  color: var(--muted);
-  font-family: inherit;
-  font-size: 0.46em;
+  font-size: 0.86rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.hero-copy h1,
-.inner-copy h1,
-.section-heading h2,
-.path-card h3,
-.narrative-block h3,
-.use-case-block h3,
-.feature-block h3,
-.architecture-grid h3,
-.download-card h2,
-.release-card h2,
-.definition-card h3,
-.channel-card h3,
-.governance-card h3,
-.decision-card h3,
-.compare-card h3 {
+.hero-center h1 {
+  color: #05060b;
+  font-size: clamp(4.4rem, 11vw, 8rem);
+  line-height: 0.9;
+  font-weight: 800;
+}
+
+.hero-subtitle {
+  margin: 24px 0 0;
+  color: #05060b;
+  font-size: clamp(1.25rem, 2.3vw, 2rem);
+  font-weight: 800;
+}
+
+.lede {
+  margin: 18px 0 0;
+  max-width: 760px;
+  color: rgba(5, 6, 11, 0.72);
+  font-size: 1.08rem;
+  line-height: 1.78;
+}
+
+.hero-actions {
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.trust-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(24px, 7vw, 92px);
+  margin-top: 44px;
+  color: rgba(5, 6, 11, 0.58);
+  font-weight: 800;
+}
+
+.showcase-band {
+  position: relative;
+  padding: 0 28px 110px;
+  background: linear-gradient(180deg, rgba(2, 3, 10, 0.42), #03040a 38%, #05060b 100%);
+}
+
+.product-frame {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  max-width: 1130px;
+  min-height: 620px;
+  margin: 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.8);
+  box-shadow: 0 30px 110px rgba(0, 0, 0, 0.62);
+}
+
+.frame-sidebar {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+  padding: 18px;
+  background: linear-gradient(180deg, rgba(74, 91, 157, 0.86), rgba(8, 16, 57, 0.86));
+  border-right: 1px solid var(--line);
+}
+
+.window-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 5px;
+  border-radius: 999px;
+}
+
+.window-dot.red {
+  background: #ff776e;
+}
+
+.window-dot.yellow {
+  background: #ffd36a;
+}
+
+.window-dot.green {
+  background: #68d989;
+}
+
+.frame-sidebar strong {
+  margin-top: 8px;
+  font-size: 1.05rem;
+}
+
+.frame-sidebar nav {
+  display: grid;
+  gap: 8px;
+  color: #dfe5ff;
+}
+
+.frame-sidebar nav span {
+  padding: 10px 12px;
+  border-radius: 8px;
+}
+
+.frame-sidebar nav .active {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.frame-main {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 28px;
+  padding: 28px;
+  background:
+    radial-gradient(circle at 80% 8%, rgba(119, 139, 255, 0.24), transparent 18rem),
+    #050507;
+}
+
+.frame-topbar,
+.contact-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.frame-topbar {
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+}
+
+.conversation {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+  max-width: 620px;
+}
+
+.conversation p,
+.conversation article {
   margin: 0;
+  border-radius: 22px;
+  padding: 18px 20px;
+}
+
+.conversation p {
+  justify-self: end;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.conversation article {
+  display: grid;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--line);
+}
+
+.conversation article span,
+.status-card span {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.status-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 14px;
+}
+
+.status-card {
+  display: grid;
+  gap: 8px;
+  min-height: 116px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.band,
+.inner-hero {
+  background: #05060b;
+  padding-top: 96px;
+  padding-bottom: 96px;
+}
+
+.inner-hero {
+  min-height: 54vh;
+}
+
+.inner-copy,
+.section-heading,
+.article-body {
+  max-width: 920px;
+}
+
+.inner-copy {
+  padding-top: 8vh;
+}
+
+.section-heading {
+  margin-bottom: 34px;
+}
+
+.section-heading h2,
+.inner-copy h1 {
+  max-width: 860px;
+  color: var(--ink);
+  font-size: clamp(2.4rem, 5vw, 5rem);
   line-height: 1.05;
-  letter-spacing: 0;
 }
 
-.hero-copy h1 {
-  max-width: 11ch;
-  font-size: clamp(3.1rem, 8vw, 6.5rem);
+.feature-story {
+  padding-top: 120px;
 }
 
-.inner-copy h1,
-.section-heading h2 {
-  font-size: clamp(2.2rem, 5vw, 4.5rem);
+.feature-rows {
+  display: grid;
+  gap: 18px;
+  max-width: 980px;
+  margin-left: auto;
 }
 
-.section-heading h2 {
-  max-width: 14ch;
+.feature-row {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  gap: 22px;
+  padding: 26px 0;
+  border-top: 1px solid var(--line);
 }
 
-.lede,
-.article-body p,
-.feature-block p,
-.architecture-grid p,
-.download-card p,
+.feature-row span {
+  color: var(--accent);
+  font-weight: 800;
+}
+
+.feature-row h3 {
+  font-size: clamp(1.45rem, 2.4vw, 2.35rem);
+}
+
+.feature-row p,
+.use-case-block p,
 .platform-row p,
 .editorial-row p,
 .faq-item p,
@@ -288,15 +489,8 @@ h3,
 .roadmap-list,
 .release-card p,
 .release-note,
-.signal-chip strong,
-.hero-panel span,
-.hero-proof-row span,
-.narrative-block p,
-.use-case-block p,
+.article-body p,
 .contact-card p,
-.status-note-list p,
-.editorial-row small,
-.release-mirror-block p,
 .application-summary,
 .application-list,
 .path-card p,
@@ -308,33 +502,45 @@ h3,
 .decision-card p,
 .compare-card p,
 .decision-list,
-.compare-list,
-.mini-stat span,
-.proof-card p,
-.audience-card p {
+.compare-list {
   color: var(--muted);
-  line-height: 1.72;
+  line-height: 1.76;
 }
 
-.lede {
-  margin: 20px 0 0;
-  max-width: 46rem;
-  font-size: 1.12rem;
+.dark-band,
+.content-band,
+.faq-band,
+.band.alt,
+.band.cinematic,
+.cta-band {
+  background:
+    radial-gradient(circle at 12% 20%, rgba(107, 126, 255, 0.16), transparent 22rem),
+    linear-gradient(180deg, #05060b, #080a12);
 }
 
-.hero-actions,
-.inline-cta,
-.release-card-actions {
-  flex-wrap: wrap;
-  margin-top: 30px;
-}
-
-.hero-signal-bar,
-.narrative-grid,
+.use-case-grid,
+.platform-strip,
+.editorial-list,
+.faq-list,
+.contact-grid,
+.path-grid,
+.evidence-grid,
+.definition-grid,
+.channel-grid,
+.governance-grid,
+.decision-grid,
+.compare-grid,
 .feature-grid,
 .architecture-grid,
 .download-grid,
 .application-grid,
+.proof-grid,
+.audience-grid,
+.hero-mini-grid {
+  display: grid;
+  gap: 14px;
+}
+
 .use-case-grid,
 .contact-grid,
 .path-grid,
@@ -344,29 +550,27 @@ h3,
 .governance-grid,
 .decision-grid,
 .compare-grid,
+.feature-grid,
+.architecture-grid,
+.download-grid,
+.application-grid,
 .proof-grid,
 .audience-grid,
 .hero-mini-grid {
-  display: grid;
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
 }
 
-.hero-signal-bar {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  margin-top: 36px;
-}
-
-.signal-chip,
-.hero-panel,
-.hero-proof-list,
+.use-case-block,
+.platform-row,
+.editorial-row,
+.faq-item,
+.contact-card,
 .feature-block,
 .architecture-grid > div,
 .download-card,
+.release-card,
 .application-card,
 .preview-row,
-.release-card,
-.use-case-block,
-.contact-card,
 .narrative-block,
 .path-card,
 .evidence-card,
@@ -379,54 +583,45 @@ h3,
 .audience-card,
 .mini-stat,
 .stack-card {
-  background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 18px;
-  padding: 20px;
+  border-radius: 8px;
+  background: var(--surface);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(12px);
 }
 
+.use-case-block,
+.contact-card,
+.feature-block,
+.architecture-grid > div,
+.download-card,
+.release-card,
+.application-card,
+.narrative-block,
 .path-card,
-.channel-card,
+.evidence-card,
 .definition-card,
+.channel-card,
 .governance-card,
 .decision-card,
 .compare-card,
 .proof-card,
 .audience-card,
+.mini-stat,
 .stack-card {
   display: grid;
+  align-content: start;
   gap: 14px;
-  align-content: start;
+  padding: 22px;
 }
 
-.evidence-card {
-  display: grid;
-  gap: 10px;
-  align-content: start;
-  background: var(--surface-strong);
-}
-
-.definition-card {
-  background: linear-gradient(180deg, rgba(255, 250, 244, 0.92), rgba(247, 239, 228, 0.92));
-}
-
-.governance-card {
-  background: linear-gradient(180deg, rgba(255, 249, 241, 0.94), rgba(244, 235, 221, 0.9));
-}
-
-.path-card h3,
-.signal-chip strong,
-.hero-proof-row strong,
-.narrative-block h3,
 .use-case-block h3,
 .feature-block h3,
 .architecture-grid h3,
 .download-card h2,
 .release-card h2,
-.editorial-row strong,
 .contact-card strong,
+.path-card h3,
 .evidence-card strong,
 .definition-card h3,
 .channel-card h3,
@@ -438,62 +633,93 @@ h3,
 .mini-stat strong {
   display: block;
   color: var(--ink);
+  font-size: 1.24rem;
+  line-height: 1.34;
 }
 
-.path-link {
-  justify-self: start;
-}
-
-.signal-chip strong,
-.hero-proof-row strong,
-.evidence-card strong,
-.mini-stat strong {
-  font-size: 1rem;
-}
-
-.hero-panel strong,
-.narrative-block h3,
-.use-case-block h3,
-.path-card h3,
-.definition-card h3,
-.channel-card h3,
-.governance-card h3,
-.decision-card h3,
-.compare-card h3,
-.proof-card h3,
-.audience-card h3 {
-  font-size: 1.35rem;
-  line-height: 1.35;
-}
-
-.hero-panel strong {
-  display: block;
-  margin: 8px 0 10px;
-}
-
-.hero-proof-list {
+.platform-row,
+.editorial-row {
   display: grid;
-  gap: 14px;
-}
-
-.hero-proof-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
   gap: 16px;
+  padding: 24px;
+}
+
+.platform-row {
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: end;
+  background: var(--surface-strong);
+}
+
+.platform-row.accent-row {
+  background:
+    radial-gradient(circle at 10% 30%, rgba(226, 179, 95, 0.2), transparent 15rem),
+    var(--surface-strong);
+}
+
+.platform-meta {
+  text-align: right;
+}
+
+.platform-meta strong {
+  display: block;
+}
+
+.editorial-row {
+  grid-template-columns: 140px minmax(0, 1fr);
   align-items: start;
-  padding-top: 14px;
-  border-top: 1px solid var(--line);
 }
 
-.hero-proof-row:first-of-type {
-  padding-top: 0;
-  border-top: 0;
+.editorial-row span,
+.editorial-row small,
+.platform-meta span {
+  color: var(--muted);
 }
 
-.hero-proof-row em {
-  color: var(--secondary);
-  font-style: normal;
-  font-size: 0.95rem;
+.editorial-row strong {
+  display: block;
+  color: var(--ink);
+}
+
+.inline-cta {
+  margin-top: 28px;
+}
+
+.faq-item {
+  padding: 20px 22px;
+}
+
+.faq-item summary {
+  cursor: pointer;
+  list-style: none;
+  font-weight: 800;
+}
+
+.faq-item p {
+  margin: 10px 0 0;
+  max-width: 64rem;
+}
+
+.contact-strip {
+  margin-top: 24px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.contact-strip strong {
+  display: block;
+  font-size: 1.35rem;
+}
+
+.article-body {
+  padding-top: 8px;
+  padding-bottom: 64px;
+}
+
+.article-body p {
+  margin: 0 0 18px;
+  font-size: 1.08rem;
 }
 
 .channel-list,
@@ -515,182 +741,34 @@ h3,
   margin-top: 8px;
 }
 
-.band.alt {
-  background: rgba(255, 249, 241, 0.5);
-}
-
-.band.cinematic,
-.cta-band {
-  background:
-    linear-gradient(120deg, rgba(168, 97, 48, 0.08), rgba(255, 250, 244, 0.36)),
-    linear-gradient(180deg, rgba(255, 244, 228, 0.82), rgba(237, 227, 214, 0.6));
-}
-
-.quick-paths,
-.proof-band {
-  padding-top: 12px;
-}
-
-.section-heading {
-  margin-bottom: 28px;
-}
-
-.path-grid,
-.narrative-grid,
-.use-case-grid,
-.feature-grid,
-.architecture-grid,
-.download-grid,
-.application-grid,
-.contact-grid,
-.evidence-grid,
-.definition-grid,
-.channel-grid,
-.governance-grid,
-.decision-grid,
-.compare-grid,
-.proof-grid,
-.audience-grid,
-.hero-mini-grid {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.platform-strip,
-.editorial-list,
-.faq-list,
-.preview-list,
-.release-section-stack {
-  display: grid;
-  gap: 12px;
-}
-
-.faq-list.full {
-  gap: 18px;
-}
-
-.status-note-list {
-  display: grid;
-  gap: 8px;
-  margin-top: 18px;
-}
-
-.platform-row,
-.editorial-row {
-  display: grid;
-  gap: 16px;
-  padding: 22px;
-  background: var(--surface-strong);
-  border: 1px solid var(--line);
-  border-radius: 18px;
-  box-shadow: var(--shadow);
-}
-
-.platform-row {
-  grid-template-columns: minmax(0, 1fr) max-content;
-  align-items: end;
-}
-
-.editorial-row {
-  grid-template-columns: 140px minmax(0, 1fr);
-  align-items: start;
-}
-
-.platform-meta {
-  text-align: right;
-}
-
-.platform-meta strong,
-.download-card strong,
-.editorial-row strong {
-  display: block;
-}
-
-.download-card,
-.release-card,
-.application-card,
-.contact-card {
-  display: grid;
-  gap: 14px;
-}
-
-.release-card-header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 14px;
-  align-items: flex-start;
-}
-
-.release-card-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.release-card-actions {
-  margin-top: 0;
-}
-
-.release-mirror-block {
-  display: grid;
-  gap: 12px;
-}
-
 .preview-row {
   display: grid;
   grid-template-columns: 56px minmax(0, 1fr) max-content;
   gap: 14px;
   align-items: center;
-}
-
-.faq-item {
-  padding: 18px 20px;
-  background: var(--surface-strong);
-  border: 1px solid var(--line);
-  border-radius: 18px;
-  box-shadow: var(--shadow);
-}
-
-.faq-item summary {
-  cursor: pointer;
-  list-style: none;
-  font-weight: 600;
-}
-
-.faq-item p {
-  margin: 10px 0 0;
-  max-width: 60rem;
-}
-
-.article-body {
-  padding-top: 8px;
-  padding-bottom: 56px;
-}
-
-.article-body p {
-  margin: 0 0 18px;
-  font-size: 1.08rem;
-}
-
-.contact-card span,
-.contact-card strong {
-  display: block;
+  padding: 18px;
 }
 
 .site-footer {
   display: flex;
   justify-content: space-between;
   gap: 24px;
-  padding-top: 28px;
+  padding-top: 30px;
   padding-bottom: 48px;
   border-top: 1px solid var(--line);
+  background: #05060b;
 }
 
 .footer-title {
   margin: 0 0 6px;
-  font-weight: 700;
+  font-weight: 800;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  color: var(--muted);
 }
 
 .stack-card.transparent {
@@ -702,13 +780,25 @@ h3,
 }
 
 @media (max-width: 960px) {
-  .hero-stage,
-  .hero-signal-bar,
+  .site-nav {
+    align-items: flex-start;
+  }
+
+  .site-nav-links-wrap {
+    justify-content: flex-end;
+  }
+
+  .product-frame,
   .platform-row,
   .editorial-row,
-  .preview-row,
-  .hero-proof-row {
+  .preview-row {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .frame-sidebar {
+    min-height: 180px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
   }
 
   .platform-meta {
@@ -721,36 +811,43 @@ h3,
   .band,
   .inner-hero,
   .article-body,
-  .site-footer {
+  .site-footer,
+  .showcase-band {
     padding-left: 18px;
     padding-right: 18px;
   }
 
   .site-nav,
   .site-nav-links-wrap,
-  .site-nav-cluster,
   .site-footer,
-  .release-card-header {
+  .contact-strip {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .site-nav {
-    border-radius: 28px;
+  .site-nav-links {
+    gap: 10px;
+    font-size: 0.88rem;
   }
 
-  .hero-copy {
-    padding-top: 8vh;
+  .nav-cta {
+    display: none;
   }
 
-  .hero-copy h1,
-  .section-heading h2 {
-    max-width: none;
+  .hero-center {
+    padding-top: 58px;
   }
 
-  .brand-kicker {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
+  .hero-center h1 {
+    font-size: clamp(4.2rem, 21vw, 6.5rem);
+  }
+
+  .trust-strip {
+    margin-top: 44px;
+    gap: 18px;
+  }
+
+  .feature-row {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from "next";
 import { brand } from "@fabushi/shared";
 import { siteUrl } from "../lib/site-url";
 import "./globals.css";
-import "./screenshot-hero.css";
 
 const homeUrl = siteUrl("/");
 const siteTitle = `${brand.name} Fabushi | 佛法传播、修行记录与共修连接平台`;

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,15 +1,5 @@
 import { fabushiApiClient } from "@fabushi/api-client";
-import {
-  brand,
-  contactChannels,
-  faqItems,
-  homeActionPaths,
-  homeChannelRoles,
-  homeHighlights,
-  homeTrustSignals,
-  homeUseCases,
-  launchRoadmap,
-} from "@fabushi/shared";
+import { brand, contactChannels, faqItems, homeHighlights, homeUseCases } from "@fabushi/shared";
 import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
 import { getAllArticles, getFeaturedArticles } from "../lib/content";
@@ -38,336 +28,157 @@ export default async function HomePage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
   const releasePreview = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@fabushi.com";
-  const faqPreview = faqItems.slice(0, 5);
-  const siteEvidence = [
-    {
-      label: "可见下载状态",
-      value: releasePreview.length > 0 ? `${releasePreview.length} 个入口已同步` : "入口持续同步中",
-      detail: "首页和下载页会直接承接当前公开可见的 beta 与正式版状态。",
-    },
-    {
-      label: "公开内容积累",
-      value: `${allArticles.length} 篇内容已上线`,
-      detail: "路线说明、专题文章与更新内容会持续沉淀，而不是只靠一张首页解释项目。",
-    },
-    {
-      label: "问题预答复",
-      value: `${faqItems.length} 个 FAQ 已整理`,
-      detail: "把“这是什么、适合谁、是否能下载、各端怎么分工”提前写清楚。",
-    },
-    {
-      label: "稳定联系入口",
-      value: `${contactChannels.length} 条公开通道`,
-      detail: "测试申请、支持反馈与公开协作都有明确去处，不用靠猜测联系路径。",
-    },
-  ] as const;
-  const definitionBlocks = [
-    {
-      label: "Fabushi 是什么",
-      title: "一个围绕佛法传播、修行记录与同行连接组织起来的数字产品体系。",
-      description:
-        "官网不是主应用的替代品，而是统一承接理解、下载、测试申请、内容更新与公开协作的第一入口。",
-    },
-    {
-      label: "现在已经开放什么",
-      title: "官网、FAQ、下载状态、申请测试与内容专栏已经开始协同工作。",
-      description:
-        "第一次接触项目的人，已经可以先在这里完成理解、判断与下一步动作，而不必先进入应用再摸索。",
-    },
-    {
-      label: "还在逐步开放什么",
-      title: "微信小程序首期能力与更完整的主应用体验会继续按节奏释放。",
-      description:
-        "这让站点可以真实同步当前状态，而不是过度承诺尚未公开的功能或入口。",
-    },
-  ] as const;
-  const governanceFacts = [
-    {
-      label: "隐私边界",
-      title: "先把收集范围、用途、支持邮箱和用户控制权说清楚。",
-      description:
-        "用户在下载、申请测试或进入更完整的产品流程前，应该先知道哪些信息会被处理，以及出现问题时该找谁。",
-      href: "/privacy",
-      ctaLabel: "查看隐私说明",
-    },
-    {
-      label: "反馈与治理",
-      title: "FAQ、申请测试、公开仓库和联系入口形成闭环。",
-      description:
-        "把常见问题、测试申请、支持邮箱和公开协作入口放在可复查的位置，能减少“我该联系谁、该去哪一步”的犹豫。",
-      href: "/contact",
-      ctaLabel: "查看联系入口",
-    },
-    {
-      label: "发布节奏",
-      title: "下载状态、测试资格和公开说明保持同步更新。",
-      description:
-        "官网先说清楚当前开放什么、还在准备什么，让每次转化动作都有现实状态对应，而不是靠模糊承诺推进。",
-      href: "/download",
-      ctaLabel: "查看下载状态",
-    },
-  ] as const;
-  const entryReadiness = [
-    {
-      label: "现在适合继续往下走",
-      title: "你已经准备好进入下载、申请或联系路径。",
-      description:
-        "如果你符合这些情况，官网应该帮助你尽快做决定，而不是继续把你留在抽象介绍里。",
-      bullets: [
-        "你已经明确想判断当前有没有适合自己的下载或测试入口。",
-        "你愿意接受 beta 节奏，或者愿意先进入申请与反馈流程。",
-        "你需要先把官网、小程序和主应用的分工看清楚，再进入具体入口。",
-      ],
-      href: "/download",
-      ctaLabel: "去看下载状态",
-    },
-    {
-      label: "现在更适合先理解和观望",
-      title: "你不必因为看见入口就立刻下载或申请。",
-      description:
-        "如果你更符合这些情况，先看 FAQ、隐私说明和路径定义，反而更能减少误判、反复和落差。",
-      bullets: [
-        "你现在只接受稳定正式版，不希望承担测试波动或资格等待。",
-        "你还没判断清楚自己是来下载、申请测试、反馈问题，还是只想先了解项目。",
-        "你期待官网已经覆盖所有深度功能体验，而不是先承担说明、筛选和引导角色。",
-      ],
-      href: "/faq",
-      ctaLabel: "先看 FAQ",
-    },
-  ] as const;
+  const faqPreview = faqItems.slice(0, 4);
 
-  const organizationJsonLd = {
+  const structuredData = {
     "@context": "https://schema.org",
-    "@type": "Organization",
-    name: `${brand.name} Fabushi`,
-    url: siteUrl("/"),
-    email: supportEmail,
-    description: brand.mission,
-    sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
-  };
-
-  const websiteJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    name: `${brand.name} Fabushi`,
-    url: siteUrl("/"),
-    inLanguage: "zh-CN",
-    description: "Fabushi 官网，统一承接品牌说明、下载入口、测试申请、FAQ 和内容专栏。",
-  };
-
-  const applicationJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
-    name: `${brand.name} Fabushi`,
-    applicationCategory: "LifestyleApplication",
-    operatingSystem: "iOS, Android, Web, WeChat Mini Program",
-    inLanguage: "zh-CN",
-    url: siteUrl("/"),
-    downloadUrl: siteUrl("/download"),
-    description:
-      "Fabushi 法布施是一个围绕佛法传播、修行记录、公开档案、榜单与同行连接组织起来的多端产品体系。",
-    featureList: [
-      "佛法传播与内容入口",
-      "修行记录与隐私边界",
-      "公开档案与榜单浏览",
-      "下载引导、测试申请与 FAQ",
-    ],
-  };
-
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqPreview.map((item) => ({
-      "@type": "Question",
-      name: item.question,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: item.answer,
+    "@graph": [
+      {
+        "@type": "Organization",
+        name: `${brand.name} Fabushi`,
+        url: siteUrl("/"),
+        email: supportEmail,
+        description: brand.mission,
+        sameAs: contactChannels.filter((item) => item.href.startsWith("https://")).map((item) => item.href),
       },
-    })),
-  };
-
-  const governanceJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: "Fabushi trust and governance",
-    itemListElement: governanceFacts.map((item, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: item.title,
-      description: item.description,
-      url: siteUrl(item.href),
-    })),
+      {
+        "@type": "WebSite",
+        name: `${brand.name} 官网`,
+        url: siteUrl("/"),
+        inLanguage: "zh-CN",
+        description: "Fabushi 官网，统一承接品牌说明、下载入口、测试申请、FAQ 与内容专栏。",
+      },
+      {
+        "@type": "SoftwareApplication",
+        name: `${brand.name} Fabushi`,
+        applicationCategory: "LifestyleApplication",
+        operatingSystem: "iOS, Android, Web, WeChat Mini Program",
+        url: siteUrl("/download"),
+        description:
+          "围绕佛法传播、修行记录、公开档案、榜单与同行连接构建的多端产品体系。",
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: faqPreview.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
+      },
+    ],
   };
 
   return (
     <main className="page-shell">
-      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
-      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
-      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(applicationJsonLd) }} />
-      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
-      <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(governanceJsonLd) }} />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
 
       <header className="hero">
         <SiteHeader />
 
-        <div className="hero-stage">
-          <div className="hero-copy">
-            <p className="eyebrow">法布施官网 · 品牌入口 / 下载引导 / 内容专栏</p>
-            <p className="brand-kicker">
-              {brand.name}
-              <span>Fabushi</span>
-            </p>
-            <h1>把佛法传播、修行记录与同行连接，放进一个更清晰的数字入口。</h1>
-            <p className="lede">
-              官网先负责解释方向、建立信任、呈现下载状态与内容路线；微信小程序负责轻触达；主应用继续承接上传、互动与沉浸式体验。
-            </p>
-            <div className="hero-actions">
-              <a className="primary-action" href={siteHref("/download")}>
-                查看下载入口
-              </a>
-              <a className="secondary-action" href={siteHref("/apply")}>
-                申请测试资格
-              </a>
-              <a className="secondary-action" href={siteHref("/faq")}>
-                查看常见问题
-              </a>
-            </div>
-            <div className="hero-signal-bar">
-              {homeTrustSignals.map((item) => (
-                <article key={item.title} className="signal-chip">
-                  <span className="detail-label">{item.title}</span>
-                  <strong>{item.summary}</strong>
-                </article>
-              ))}
-            </div>
+        <div className="hero-center">
+          <div className="app-mark" aria-hidden="true">
+            <span>法</span>
           </div>
-
-          <aside className="hero-aside">
-            <div className="hero-panel">
-              <p>一句话理解</p>
-              <strong>{brand.name} 是一个围绕佛法传播、修行记录与同行连接展开的数字产品体系。</strong>
-              <span>
-                官网负责说明与引导，小程序负责微信生态触达，Flutter 主应用承接更完整的浏览、上传、互动与个人使用流程。
-              </span>
-            </div>
-            <div className="hero-proof-list">
-              <p className="detail-label">当前公开入口</p>
-              {releasePreview.map((item) => (
-                <a key={`${item.audience}-${item.platform}`} className="hero-proof-row" href={siteHref(item.primaryHref)}>
-                  <div>
-                    <strong>{item.title}</strong>
-                    <span>{item.description}</span>
-                  </div>
-                  <em>{item.status}</em>
-                </a>
-              ))}
-            </div>
-          </aside>
+          <p className="eyebrow">Fabushi official site</p>
+          <h1>{brand.name}</h1>
+          <p className="hero-subtitle">{brand.tagline}</p>
+          <p className="lede">
+            一个面向佛法传播、修行记录与同行连接的数字入口。官网负责把项目定位、下载状态、测试申请和常见问题讲清楚，让第一次到达的人也能知道下一步该去哪里。
+          </p>
+          <div className="hero-actions">
+            <a className="primary-action" href={siteHref("/download")}>
+              查看下载入口
+            </a>
+            <a className="secondary-action" href={siteHref("/apply")}>
+              申请测试资格
+            </a>
+          </div>
+          <div className="trust-strip" aria-label="当前官网状态">
+            <span>官网</span>
+            <span>下载状态</span>
+            <span>测试申请</span>
+            <span>内容专栏</span>
+          </div>
         </div>
       </header>
 
-      <section className="band quick-paths" id="paths">
-        <div className="section-heading">
-          <p>快速路径</p>
-          <h2>第一次来到这里，通常只需要先完成这三件事里的其中一件。</h2>
+      <section className="showcase-band" id="experience">
+        <div className="product-frame" aria-label="Fabushi 官网体验预览">
+          <div className="frame-sidebar">
+            <span className="window-dot red" />
+            <span className="window-dot yellow" />
+            <span className="window-dot green" />
+            <strong>Fabushi</strong>
+            <nav>
+              <span className="active">下载状态</span>
+              <span>共修连接</span>
+              <span>内容专栏</span>
+              <span>FAQ</span>
+            </nav>
+          </div>
+          <div className="frame-main">
+            <div className="frame-topbar">
+              <span>今日入口</span>
+              <strong>{releasePreview.length > 0 ? `${releasePreview.length} 个发布入口` : "发布入口同步中"}</strong>
+            </div>
+            <div className="conversation">
+              <p>我第一次看到 Fabushi，应该先做什么？</p>
+              <article>
+                <strong>先确认当前状态。</strong>
+                <span>官网会把下载、内测、内容路线和支持入口放在同一处，减少来回寻找。</span>
+              </article>
+            </div>
+            <div className="status-board">
+              {releasePreview.length === 0 ? (
+                <div className="status-card">
+                  <span>发布</span>
+                  <strong>入口持续同步中</strong>
+                </div>
+              ) : (
+                releasePreview.map((item) => (
+                  <a key={`${item.audience}-${item.platform}`} className="status-card" href={siteHref(item.primaryHref)}>
+                    <span>{item.platform}</span>
+                    <strong>{item.status}</strong>
+                  </a>
+                ))
+              )}
+            </div>
+          </div>
         </div>
-        <div className="path-grid">
-          {homeActionPaths.map((item) => (
-            <article key={item.title} className="path-card">
-              <span className="detail-label">{item.label}</span>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-              <a className="path-link" href={siteHref(item.href)}>
-                {item.ctaLabel}
-              </a>
+      </section>
+
+      <section className="band feature-story" id="capabilities">
+        <div className="section-heading">
+          <p>核心能力</p>
+          <h2>把理解、触达和深度使用连成一条清晰路径。</h2>
+        </div>
+        <div className="feature-rows">
+          {homeHighlights.map((item, index) => (
+            <article key={item.title} className="feature-row">
+              <span>{String(index + 1).padStart(2, "0")}</span>
+              <div>
+                <h3>{item.title}</h3>
+                <p>{item.description}</p>
+              </div>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="band alt" id="evidence">
+      <section className="band dark-band" id="audience">
         <div className="section-heading">
-          <p>公开事实</p>
-          <h2>如果官网想建立信任，就要先给出可验证、可引用、可复查的公开信息。</h2>
-        </div>
-        <div className="evidence-grid">
-          {siteEvidence.map((item) => (
-            <article key={item.label} className="evidence-card">
-              <span className="detail-label">{item.label}</span>
-              <strong>{item.value}</strong>
-              <p>{item.detail}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band" id="definition">
-        <div className="section-heading">
-          <p>先定义清楚</p>
-          <h2>让用户和搜索系统都先搞清楚 Fabushi 是什么、已经开放什么、还在推进什么。</h2>
-        </div>
-        <div className="definition-grid">
-          {definitionBlocks.map((item) => (
-            <article key={item.label} className="definition-card">
-              <span className="detail-label">{item.label}</span>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-            </article>
-          ))}
-        </div>
-        <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/faq")}>
-            继续看完整 FAQ
-          </a>
-          <a className="secondary-action" href={siteHref("/download")}>
-            查看当前下载状态
-          </a>
-        </div>
-      </section>
-
-      <section className="band alt" id="trust">
-        <div className="section-heading">
-          <p>为什么先做官网</p>
-          <h2>先把入口、分工、状态和信任信息讲清楚，转化路径才不会在第一屏就断掉。</h2>
-        </div>
-        <div className="narrative-grid">
-          {homeTrustSignals.map((item) => (
-            <article key={item.title} className="narrative-block">
-              <span className="detail-label">{item.title}</span>
-              <h3>{item.summary}</h3>
-              <p>{item.description}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band" id="governance">
-        <div className="section-heading">
-          <p>信任与治理</p>
-          <h2>品牌感只能让人停一下，真正推动申请、下载和长期使用的，是状态、边界和反馈机制都讲清楚。</h2>
-        </div>
-        <div className="governance-grid">
-          {governanceFacts.map((item) => (
-            <article key={item.label} className="governance-card">
-              <span className="detail-label">{item.label}</span>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-              <a className="path-link" href={siteHref(item.href)}>
-                {item.ctaLabel}
-              </a>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band alt" id="audience">
-        <div className="section-heading">
-          <p>适用场景</p>
-          <h2>Fabushi 官网应该同时服务首次到达、内测申请、合作判断和搜索理解这四种场景。</h2>
+          <p>适合谁</p>
+          <h2>官网先服务真实到达场景，而不是堆满抽象介绍。</h2>
         </div>
         <div className="use-case-grid">
-          {homeUseCases.map((item) => (
+          {homeUseCases.slice(0, 4).map((item) => (
             <article key={item.audience} className="use-case-block">
               <span className="detail-label">{item.audience}</span>
               <h3>{item.title}</h3>
@@ -377,73 +188,10 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band" id="readiness">
+      <section className="band" id="download">
         <div className="section-heading">
-          <p>进入判断</p>
-          <h2>官网不该默认每个访问者都应该立刻下载，它更应该先帮人判断“现在适不适合继续往下走”。</h2>
-        </div>
-        <div className="compare-grid">
-          {entryReadiness.map((item) => (
-            <article key={item.label} className="compare-card">
-              <span className="detail-label">{item.label}</span>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-              <ul className="compare-list">
-                {item.bullets.map((entry) => (
-                  <li key={entry}>{entry}</li>
-                ))}
-              </ul>
-              <a className="path-link" href={siteHref(item.href)}>
-                {item.ctaLabel}
-              </a>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band" id="channel-roles">
-        <div className="section-heading">
-          <p>入口分工</p>
-          <h2>不是每个人都该直接跳进同一个端里，官网要先告诉你该从哪里开始。</h2>
-        </div>
-        <div className="channel-grid">
-          {homeChannelRoles.map((item) => (
-            <article key={item.channel} className="channel-card">
-              <span className="detail-label">{item.channel}</span>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-              <ul className="channel-list">
-                {item.bestFor.map((entry) => (
-                  <li key={entry}>{entry}</li>
-                ))}
-              </ul>
-              <a className="path-link" href={siteHref(item.href)}>
-                {item.ctaLabel}
-              </a>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band alt" id="capabilities">
-        <div className="section-heading">
-          <p>核心能力</p>
-          <h2>产品体系不是三套彼此割裂的站点，而是一条从发现、触达到深度使用的连续路径。</h2>
-        </div>
-        <div className="feature-grid">
-          {homeHighlights.map((item) => (
-            <article key={item.title} className="feature-block">
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band cinematic">
-        <div className="section-heading">
-          <p>下载入口</p>
-          <h2>官网已经开始把公开可见的发布状态直接拉回页面，减少“想下载却找不到入口”的摩擦。</h2>
+          <p>下载与申请</p>
+          <h2>当前能做什么，直接给出入口。</h2>
         </div>
         <div className="platform-strip">
           {releasePreview.map((item) => (
@@ -458,75 +206,23 @@ export default async function HomePage() {
               </div>
             </a>
           ))}
-        </div>
-        <div className="status-note-list">
-          {releaseCollection.notes.map((item) => (
-            <p key={item}>{item}</p>
-          ))}
-        </div>
-      </section>
-
-      <section className="band alt" id="mini-program">
-        <div className="section-heading">
-          <p>微信小程序</p>
-          <h2>首期优先覆盖轻浏览、榜单、公开档案与基础登录，把最容易传播的场景先跑通。</h2>
-        </div>
-        <ol className="roadmap-list">
-          {launchRoadmap.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ol>
-      </section>
-
-      <section className="band" id="architecture">
-        <div className="section-heading">
-          <p>技术架构</p>
-          <h2>一个前端 monorepo，共享接口层、类型、文案和部分纯业务逻辑，让官网与小程序各自发挥但不分家。</h2>
-        </div>
-        <div className="architecture-grid">
-          <div>
-            <h3>apps/web</h3>
-            <p>Next.js 官网，负责 SEO、落地页、功能说明、下载引导和后续内容运营。</p>
-          </div>
-          <div>
-            <h3>apps/mp-wechat</h3>
-            <p>Taro 微信小程序，围绕微信生态内的轻触达和轻交互。</p>
-          </div>
-          <div>
-            <h3>packages/shared</h3>
-            <p>品牌信息、导航、固定文案、内容结构与纯前端通用工具。</p>
-          </div>
-          <div>
-            <h3>packages/api-client</h3>
-            <p>统一对接现有 flutter.ombhrum.com API 与共享类型。</p>
-          </div>
+          <a className="platform-row accent-row" href={siteHref("/apply")}>
+            <div>
+              <span className="platform-name">测试与反馈</span>
+              <p>适合想参与 iOS、Android 或合作沟通的人，直接进入申请路径。</p>
+            </div>
+            <div className="platform-meta">
+              <strong>开放申请</strong>
+              <span>提交意向</span>
+            </div>
+          </a>
         </div>
       </section>
 
-      <section className="band alt">
-        <div className="section-heading">
-          <p>接口复用</p>
-          <h2>官网已经直接接入现有排行榜接口，证明它不是孤立宣传页，而是会逐步承接真实产品数据的入口层。</h2>
-        </div>
-        <div className="preview-list">
-          {leaderboard.length === 0 ? (
-            <p className="empty-copy">当前没有拉到排行榜预览，页面仍会稳定展示其余静态与内容型模块。</p>
-          ) : (
-            leaderboard.map((item, index) => (
-              <div key={item.username} className="preview-row">
-                <span>#{index + 1}</span>
-                <strong>{item.displayName || item.username}</strong>
-                <span>{item.totalBytes.toLocaleString()} bytes</span>
-              </div>
-            ))
-          )}
-        </div>
-      </section>
-
-      <section className="band">
+      <section className="band content-band" id="insights">
         <div className="section-heading">
           <p>内容专栏</p>
-          <h2>官网不只是一张首页，它还要持续承接路线、更新、专题内容和后续可引用的公开信息。</h2>
+          <h2>路线、更新和说明沉淀成可复查的公开内容。</h2>
         </div>
         <div className="editorial-list">
           {featuredArticles.map((item) => (
@@ -549,10 +245,10 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band faq-band" id="faq">
         <div className="section-heading">
           <p>常见问题</p>
-          <h2>把用户最容易问的关键问题提前说清楚，也是在补强搜索和生成式引用最爱抓取的结构化信息。</h2>
+          <h2>把用户最容易卡住的问题提前回答。</h2>
         </div>
         <div className="faq-list">
           {faqPreview.map((item) => (
@@ -562,32 +258,14 @@ export default async function HomePage() {
             </details>
           ))}
         </div>
-        <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/faq")}>
-            查看完整 FAQ
+        <div className="contact-strip">
+          <div>
+            <span className="detail-label">公开数据</span>
+            <strong>{leaderboard.length > 0 ? "排行榜预览已接入" : "静态信息可稳定访问"}</strong>
+          </div>
+          <a className="primary-action" href={`mailto:${supportEmail}`}>
+            联系支持
           </a>
-          <a className="secondary-action" href={siteHref("/privacy")}>
-            查看隐私说明
-          </a>
-          <a className="secondary-action" href={siteHref("/contact")}>
-            联系我们
-          </a>
-        </div>
-      </section>
-
-      <section className="band">
-        <div className="section-heading">
-          <p>联系</p>
-          <h2>除了下载入口之外，官网也要把支持、反馈和公开协作的去处讲清楚。</h2>
-        </div>
-        <div className="contact-grid">
-          {contactChannels.map((item) => (
-            <a key={item.label} className="contact-card" href={siteHref(item.href)}>
-              <span>{item.label}</span>
-              <strong>{item.value}</strong>
-              <p>{item.note}</p>
-            </a>
-          ))}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Redesign the official site homepage with a Codex-inspired immersive hero and product preview
- Focus homepage content on Fabushi downloads, beta application, capabilities, insights, FAQ, and support paths
- Remove the old screenshot-specific CSS override from the app layout
- Ignore Next.js generated build artifacts

## Verification
- `corepack pnpm --filter @fabushi/web typecheck`
- `corepack pnpm --filter @fabushi/web build`
- Browser preview checked on desktop and 390px mobile viewport