### PR TITLE
fix: sync third-party profile names and avatars

### DIFF
--- a/fabushi/lib/services/alipay_auth_service.dart
+++ b/fabushi/lib/services/alipay_auth_service.dart
@@ -11,6 +11,24 @@ class AlipayAuthService {
     return await AppSettings.getBackendUrl();
   }
 
+  Map<String, dynamic> _successAuthPayload(
+    Map<String, dynamic> data, {
+    bool defaultOneClick = false,
+  }) {
+    return {
+      'success': true,
+      'token': data['token'],
+      'username': data['username'] ?? data['user']?['username'],
+      'email': data['email'] ?? data['user']?['email'],
+      'user': data['user'],
+      'isNewUser': data['isNewUser'] ?? false,
+      'needsRegistration': data['needsRegistration'] ?? false,
+      'alipayUser': data['alipayUser'],
+      'message': data['message'],
+      'isOneClick': data['isOneClick'] ?? defaultOneClick,
+    };
+  }
+
   /// 获取支付宝登录授权URL
   Future<Map<String, dynamic>> getAlipayLoginUrl({String? platform}) async {
     try {
@@ -110,15 +128,8 @@ class AlipayAuthService {
       }
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        return {
-          'success': data['success'] ?? false,
-          'token': data['token'],
-          'username': data['username'],
-          'isNewUser': data['isNewUser'] ?? false,
-          'needsRegistration': data['needsRegistration'] ?? false,
-          'alipayUser': data['alipayUser'],
-        };
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return _successAuthPayload(data);
       } else {
         final data = jsonDecode(response.body);
         return {'success': false, 'message': data['error'] ?? 'SDK登录失败'};
@@ -151,16 +162,8 @@ class AlipayAuthService {
       }
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        return {
-          'success': true,
-          'token': data['token'],
-          'username': data['username'],
-          'email': data['email'],
-          'isNewUser': data['isNewUser'] ?? false,
-          'needsRegistration': data['needsRegistration'] ?? false,
-          'alipayUser': data['alipayUser'],
-        };
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return _successAuthPayload(data);
       } else if (response.statusCode == 202) {
         // 新用户需要注册
         final data = jsonDecode(response.body);
@@ -205,13 +208,8 @@ class AlipayAuthService {
       );
 
       if (response.statusCode == 201) {
-        final data = jsonDecode(response.body);
-        return {
-          'success': true,
-          'token': data['token'],
-          'username': data['username'],
-          'message': data['message'],
-        };
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return _successAuthPayload(data);
       } else {
         final data = jsonDecode(response.body);
         return {'success': false, 'message': data['error'] ?? '支付宝注册失败'};
@@ -242,15 +240,8 @@ class AlipayAuthService {
       );
 
       if (response.statusCode == 200 || response.statusCode == 201) {
-        final data = jsonDecode(response.body);
-        return {
-          'success': true,
-          'token': data['token'],
-          'username': data['username'],
-          'email': data['email'],
-          'message': data['message'] ?? '一键注册成功',
-          'isOneClick': data['isOneClick'] ?? true,
-        };
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return _successAuthPayload(data, defaultOneClick: true);
       } else {
         final data = jsonDecode(response.body);
         return {'success': false, 'message': data['error'] ?? '支付宝一键注册失败'};

--- a/fabushi/web/migrations/20260510_group_members_user_id.sql
+++ b/fabushi/web/migrations/20260510_group_members_user_id.sql
@@ -1,0 +1,28 @@
+-- Add stable user-id columns for co-practice groups.
+-- `username` remains for display and backward compatibility, but group identity
+-- should be resolved through users.id when available.
+
+ALTER TABLE meditation_groups ADD COLUMN owner_user_id INTEGER;
+ALTER TABLE meditation_group_members ADD COLUMN user_id INTEGER;
+
+UPDATE meditation_groups
+SET owner_user_id = (
+  SELECT id FROM users WHERE users.username = meditation_groups.owner_username
+)
+WHERE owner_user_id IS NULL AND owner_username IS NOT NULL;
+
+UPDATE meditation_group_members
+SET user_id = (
+  SELECT id FROM users WHERE users.username = meditation_group_members.username
+)
+WHERE user_id IS NULL AND username IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_meditation_groups_owner_user_id
+  ON meditation_groups(owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_meditation_group_members_user_id
+  ON meditation_group_members(user_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_meditation_group_members_group_user_id_unique
+  ON meditation_group_members(group_id, user_id)
+  WHERE user_id IS NOT NULL;

--- a/fabushi/web/src/handlers/auth.js
+++ b/fabushi/web/src/handlers/auth.js
@@ -170,6 +170,8 @@ export async function handleAppleLogin(request, env, db) {
       return jsonResponse({ error: '缺少必要参数 (identityToken, authorizationCode)' }, 400);
     }
 
+    const appleDisplayName = [givenName, familyName].filter(Boolean).join(' ').trim();
+
     let appleUserId;
     let appleEmail;
     try {
@@ -204,8 +206,7 @@ export async function handleAppleLogin(request, env, db) {
     if (user) {
       const updates = {};
       if (appleEmail && !user.email) updates.email = appleEmail;
-      const fullName = [givenName, familyName].filter(Boolean).join(' ');
-      if (fullName && !user.nickname) updates.nickname = user.username;
+      if (appleDisplayName && !user.nickname) updates.nickname = appleDisplayName;
       if (Object.keys(updates).length > 0) {
         if (db.updateUserById) {
           await db.updateUserById(user.id, updates);
@@ -233,7 +234,11 @@ export async function handleAppleLogin(request, env, db) {
     const existingEmailUser = await db.db.prepare('SELECT * FROM users WHERE email = ?').bind(userEmail).first();
     if (existingEmailUser) {
       const updates = { apple_user_id: appleUserId };
-      if (!existingEmailUser.nickname) updates.nickname = existingEmailUser.username;
+      if (appleDisplayName && !existingEmailUser.nickname) {
+        updates.nickname = appleDisplayName;
+      } else if (!existingEmailUser.nickname) {
+        updates.nickname = existingEmailUser.username;
+      }
       if (db.updateUserById) {
         await db.updateUserById(existingEmailUser.id, updates);
       } else {
@@ -255,7 +260,7 @@ export async function handleAppleLogin(request, env, db) {
       username,
       email: userEmail,
       appleUserId,
-      nickname: username,
+      nickname: appleDisplayName || username,
       membershipType: 'trial',
       membershipExpiresAt: trialEndDate.toISOString(),
       createdAt: new Date().toISOString()

--- a/fabushi/web/src/handlers/profile.js
+++ b/fabushi/web/src/handlers/profile.js
@@ -5,6 +5,45 @@ import { asApiError } from '../contracts/api-error.js';
 import { authenticateRequest } from '../use-cases/authenticated-user.js';
 import { updateProfileFromRequest } from '../use-cases/update-profile.js';
 
+const MAX_INLINE_AVATAR_BYTES = 512 * 1024;
+
+function estimateBase64Bytes(base64) {
+  return Math.floor((base64.length * 3) / 4);
+}
+
+function inferImageMimeType(base64) {
+  if (base64.startsWith('/9j/')) return 'image/jpeg';
+  if (base64.startsWith('R0lGOD')) return 'image/gif';
+  if (base64.startsWith('UklGR')) return 'image/webp';
+  return 'image/png';
+}
+
+function normalizeAvatarDataUrl(imageBase64) {
+  const raw = String(imageBase64 || '').trim();
+  if (!raw) return null;
+
+  if (raw.startsWith('data:image/')) {
+    const commaIndex = raw.indexOf(',');
+    if (commaIndex === -1) return null;
+
+    const base64Payload = raw.slice(commaIndex + 1).replace(/\s/g, '');
+    if (!base64Payload) return null;
+    if (estimateBase64Bytes(base64Payload) > MAX_INLINE_AVATAR_BYTES) {
+      return { error: '头像图片过大，请选择 512KB 以内的图片', status: 413 };
+    }
+
+    return raw.slice(0, commaIndex + 1) + base64Payload;
+  }
+
+  const normalizedBase64 = raw.replace(/\s/g, '');
+  if (!normalizedBase64) return null;
+  if (estimateBase64Bytes(normalizedBase64) > MAX_INLINE_AVATAR_BYTES) {
+    return { error: '头像图片过大，请选择 512KB 以内的图片', status: 413 };
+  }
+
+  return `data:${inferImageMimeType(normalizedBase64)};base64,${normalizedBase64}`;
+}
+
 export async function handleUploadAvatar(request, env, db) {
   const repository = new AccountUserRepository(db);
 
@@ -15,16 +54,23 @@ export async function handleUploadAvatar(request, env, db) {
       return jsonResponse({ error: '缺少头像图片数据' }, 400);
     }
 
-    const avatarUrl = `https://example.com/avatar/${user.id}`;
+    const avatarDataUrl = normalizeAvatarDataUrl(imageBase64);
+    if (!avatarDataUrl) {
+      return jsonResponse({ error: '头像图片数据格式无效' }, 400);
+    }
+    if (avatarDataUrl.error) {
+      return jsonResponse({ error: avatarDataUrl.error }, avatarDataUrl.status);
+    }
+
     await repository.updateById(user.id, {
-      avatar: avatarUrl,
+      avatar: avatarDataUrl,
       nickname: user.nickname || user.username,
     });
 
     const updatedUser = (await repository.getById(user.id)) || user;
     return jsonResponse({
       success: true,
-      avatar: avatarUrl,
+      avatar: avatarDataUrl,
       user: serializeAccountUser(updatedUser),
     });
   } catch (error) {

--- a/fabushi/web/src/handlers/thirdparty.js
+++ b/fabushi/web/src/handlers/thirdparty.js
@@ -3,6 +3,74 @@ import { AccountUserRepository } from '../repositories/account-user-repository.j
 import { asApiError } from '../contracts/api-error.js';
 import { bindEmailFromRequest } from '../use-cases/bind-email.js';
 
+function serializeAlipayAccountUser(user) {
+  if (!user) return null;
+
+  const userNo = user.user_no ?? user.id ?? null;
+  return {
+    id: user.id,
+    userId: user.id,
+    userNo,
+    username: user.username,
+    email: user.email || '',
+    nickname: user.nickname || user.alipay_nickname || user.username,
+    avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,
+    phoneNumber: user.phone_number || null,
+    firebaseUid: user.firebase_uid || null,
+    alipayUserId: user.alipay_user_id || null,
+    alipayNickname: user.alipay_nickname || null,
+    alipayAvatar: user.alipay_avatar || null,
+    createdAt: user.created_at || null,
+    emailVerified: user.email_verified === 1 || user.email_verified === true,
+    membership: {
+      type: user.membership_type || 'expired',
+      expiresAt: user.membership_expires_at || user.free_trial_end_date || null,
+    },
+  };
+}
+
+async function readUserForAuthResponse(env, payload) {
+  if (!env.DB || !payload) return null;
+
+  if (payload.userId !== undefined && payload.userId !== null) {
+    const byId = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(payload.userId).first();
+    if (byId) return byId;
+  }
+
+  if (payload.username) {
+    return await env.DB.prepare('SELECT * FROM users WHERE username = ?').bind(payload.username).first();
+  }
+
+  return null;
+}
+
+async function withFullUserResponse(response, env) {
+  if (!response || ![200, 201].includes(response.status)) {
+    return response;
+  }
+
+  let payload;
+  try {
+    payload = await response.clone().json();
+  } catch (_) {
+    return response;
+  }
+
+  if (!payload || payload.user) {
+    return response;
+  }
+
+  const user = await readUserForAuthResponse(env, payload);
+  if (!user) {
+    return response;
+  }
+
+  return jsonResponse({
+    ...payload,
+    user: serializeAlipayAccountUser(user),
+  }, response.status);
+}
+
 // 微信登录URL
 export async function handleGetWechatLoginUrl(request, env) {
   const state = crypto.randomUUID();
@@ -24,7 +92,8 @@ export async function handleGetAlipayLoginUrl(request, env) {
 // 支付宝登录
 export async function handleAlipayLogin(request, env) {
   const { handleAlipayLogin } = await import('../../alipay-login-functions.js');
-  return await handleAlipayLogin(request, env);
+  const response = await handleAlipayLogin(request, env);
+  return await withFullUserResponse(response, env);
 }
 
 // macOS支付宝回调
@@ -42,7 +111,8 @@ export async function handleMobileAlipayCallback(request, env) {
 // 支付宝注册
 export async function handleAlipayRegister(request, env) {
   const { registerAlipayUser } = await import('../../alipay-login-functions.js');
-  return await registerAlipayUser(request, env);
+  const response = await registerAlipayUser(request, env);
+  return await withFullUserResponse(response, env);
 }
 
 // 绑定邮箱
@@ -67,5 +137,6 @@ export async function handleGetAlipayAuthString(request, env) {
 // 支付宝SDK登录
 export async function handleAlipaySDKLogin(request, env) {
   const { handleAlipaySDKLogin } = await import('../../alipay-login-functions.js');
-  return await handleAlipaySDKLogin(request, env);
+  const response = await handleAlipaySDKLogin(request, env);
+  return await withFullUserResponse(response, env);
 }

--- a/fabushi/web/src/routes/meditation-routes.js
+++ b/fabushi/web/src/routes/meditation-routes.js
@@ -28,7 +28,21 @@ function asInt(value, fallback = 0) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
-async function authenticateRouteUser(request) {
+async function resolveUserIdByUsername(db, username) {
+  if (!username) return null;
+  try {
+    const row = await db.prepare(`
+      SELECT id
+      FROM users
+      WHERE username = ?
+    `).bind(username).first();
+    return row?.id ?? null;
+  } catch (_) {
+    return null;
+  }
+}
+
+async function authenticateRouteUser(request, db = null) {
   const authHeader = request.headers.get('Authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return { error: '未授权访问', status: 401 };
@@ -47,10 +61,20 @@ async function authenticateRouteUser(request) {
       return { error: '无法获取用户信息', status: 401 };
     }
 
-    return { username };
+    const tokenUserId = payload.userId ?? payload.id ?? null;
+    const userId = tokenUserId ?? (db ? await resolveUserIdByUsername(db, username) : null);
+    return { username, userId };
   } catch (_) {
-    return { error: 'Token解瞐失败', status: 401 };
+    return { error: 'Token解析失败', status: 401 };
   }
+}
+
+function isMissingUserIdColumnError(error) {
+  const message = String(error?.message || error || '').toLowerCase();
+  return message.includes('owner_user_id') ||
+    message.includes('user_id') ||
+    message.includes('no such column') ||
+    message.includes('has no column named');
 }
 
 async function resolveGroupById(db, groupId) {
@@ -92,7 +116,7 @@ async function generateUniqueGroupId(db) {
     if (!existingGroup) return candidate;
   }
 
-  throw new Error('无法生成可用的雪舱式羄绔 ID');
+  throw new Error('无法生成可用的雪花式小组 ID');
 }
 
 async function generateUniqueGroupNo(db) {
@@ -231,7 +255,7 @@ async function withVisibleGroupNumbers(response, db, options = {}) {
 }
 
 async function handleCreateMeditationGroupWithGeneratedIds(request, db) {
-  const auth = await authenticateRouteUser(request);
+  const auth = await authenticateRouteUser(request, db);
   if (auth.error) {
     return jsonResponse({ success: false, error: auth.error }, auth.status);
   }
@@ -240,7 +264,7 @@ async function handleCreateMeditationGroupWithGeneratedIds(request, db) {
     const body = await request.json();
     const name = (body.name || '').toString().trim();
     if (!name) {
-      return jsonResponse({ success: false, error: '小绔對称不能为立' }, 400);
+      return jsonResponse({ success: false, error: '小组名称不能为空' }, 400);
     }
 
     const now = new Date().toISOString();
@@ -250,35 +274,148 @@ async function handleCreateMeditationGroupWithGeneratedIds(request, db) {
     const cumulativeMissLimit = Math.max(0, asInt(body.cumulativeMissLimit, 7));
     const consecutiveMissLimit = Math.max(0, asInt(body.consecutiveMissLimit, 3));
 
-    await db.prepare(`
-      INSERT INTO meditation_groups (
-        id, group_no, name, description, owner_username, require_approval, daily_goal_minutes,
-        cumulative_miss_limit, consecutive_miss_limit, created_at, updated_at
-      )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).bind(
-      groupId,
-      groupNo,
-      name,
-      (body.description || '').toString().trim(),
-      auth.username,
-      body.requireApproval ? 1 : 0,
-      dailyGoalMinutes,
-      cumulativeMissLimit,
-      consecutiveMissLimit,
-      now,
-      now
-    ).run();
+    try {
+      await db.prepare(`
+        INSERT INTO meditation_groups (
+          id, group_no, name, description, owner_username, owner_user_id, require_approval, daily_goal_minutes,
+          cumulative_miss_limit, consecutive_miss_limit, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).bind(
+        groupId,
+        groupNo,
+        name,
+        (body.description || '').toString().trim(),
+        auth.username,
+        auth.userId,
+        body.requireApproval ? 1 : 0,
+        dailyGoalMinutes,
+        cumulativeMissLimit,
+        consecutiveMissLimit,
+        now,
+        now
+      ).run();
 
-    await db.prepare(`
-      INSERT INTO meditation_group_members (group_id, username, role, status, joined_at, updated_at)
-      VALUES (?, ?, 'owner', 'active', ?, ?)
-    `).bind(groupId, auth.username, now, now).run();
+      await db.prepare(`
+        INSERT INTO meditation_group_members (group_id, username, user_id, role, status, joined_at, updated_at)
+        VALUES (?, ?, ?, 'owner', 'active', ?, ?)
+      `).bind(groupId, auth.username, auth.userId, now, now).run();
+    } catch (error) {
+      if (!isMissingUserIdColumnError(error)) {
+        throw error;
+      }
+
+      await db.prepare(`
+        INSERT INTO meditation_groups (
+          id, group_no, name, description, owner_username, require_approval, daily_goal_minutes,
+          cumulative_miss_limit, consecutive_miss_limit, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).bind(
+        groupId,
+        groupNo,
+        name,
+        (body.description || '').toString().trim(),
+        auth.username,
+        body.requireApproval ? 1 : 0,
+        dailyGoalMinutes,
+        cumulativeMissLimit,
+        consecutiveMissLimit,
+        now,
+        now
+      ).run();
+
+      await db.prepare(`
+        INSERT INTO meditation_group_members (group_id, username, role, status, joined_at, updated_at)
+        VALUES (?, ?, 'owner', 'active', ?, ?)
+      `).bind(groupId, auth.username, now, now).run();
+    }
 
     return jsonResponse({ success: true, data: { groupId, groupNo } });
   } catch (e) {
-    console.error('创建共伮小绔失败', e);
-    return jsonResponse({ success: false, error: '创建共伮小绔失败' }, 500);
+    console.error('创建共修小组失败', e);
+    return jsonResponse({ success: false, error: '创建共修小组失败' }, 500);
+  }
+}
+
+async function handleJoinMeditationGroupWithStableUserId(request, env, db) {
+  const auth = await authenticateRouteUser(request, db);
+  if (auth.error) {
+    return jsonResponse({ success: false, error: auth.error }, auth.status);
+  }
+
+  try {
+    const body = await request.json();
+    const groupId = asInt(body.groupId);
+    if (!groupId) {
+      return jsonResponse({ success: false, error: 'groupId required' }, 400);
+    }
+
+    if (!auth.userId) {
+      return await handleJoinMeditationGroup(await cloneRequestWithJsonBody(request, body), env, db);
+    }
+
+    let group;
+    try {
+      group = await db.prepare(`
+        SELECT id, require_approval, owner_username, owner_user_id
+        FROM meditation_groups
+        WHERE id = ?
+      `).bind(groupId).first();
+    } catch (error) {
+      if (!isMissingUserIdColumnError(error)) {
+        throw error;
+      }
+      return await handleJoinMeditationGroup(await cloneRequestWithJsonBody(request, body), env, db);
+    }
+
+    if (!group) {
+      return jsonResponse({ success: false, error: '小组不存在' }, 404);
+    }
+
+    const now = new Date().toISOString();
+    const isOwner = group.owner_user_id === auth.userId || group.owner_username === auth.username;
+    const role = isOwner ? 'owner' : 'member';
+    const status = role === 'owner' || group.require_approval !== 1 ? 'active' : 'pending';
+
+    const existing = await db.prepare(`
+      SELECT id, role
+      FROM meditation_group_members
+      WHERE group_id = ? AND user_id = ?
+    `).bind(groupId, auth.userId).first();
+
+    if (existing) {
+      await db.prepare(`
+        UPDATE meditation_group_members
+        SET username = ?,
+            status = ?,
+            role = CASE WHEN role = 'owner' THEN 'owner' ELSE ? END,
+            warning_message = NULL,
+            removal_reason = NULL,
+            removed_at = NULL,
+            updated_at = ?
+        WHERE id = ?
+      `).bind(auth.username, status, role, now, existing.id).run();
+    } else {
+      await db.prepare(`
+        INSERT INTO meditation_group_members (group_id, username, user_id, role, status, joined_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).bind(groupId, auth.username, auth.userId, role, status, now, now).run();
+    }
+
+    return jsonResponse({
+      success: true,
+      data: {
+        status,
+        message: status === 'pending' ? '已提交加入申请，等待同意' : '已加入共修小组',
+      },
+    });
+  } catch (e) {
+    if (isMissingUserIdColumnError(e)) {
+      return await handleJoinMeditationGroup(request, env, db);
+    }
+    console.error('加入共修小组失败:', e);
+    return jsonResponse({ success: false, error: '加入共修小组失败' }, 500);
   }
 }
 
@@ -323,7 +460,7 @@ export async function routeMeditationRequest({ pathname, method, request, env, d
   }
   if (pathname === '/api/meditation/groups/join' && method === 'POST') {
     const { request: nextRequest } = await rewriteGroupBodyRequest(request, db);
-    return await handleJoinMeditationGroup(nextRequest, env, db);
+    return await handleJoinMeditationGroupWithStableUserId(nextRequest, env, db);
   }
   if (pathname === '/api/meditation/groups/detail' && method === 'GET') {
     const nextRequest = await rewriteGroupDetailRequest(request, db);


### PR DESCRIPTION
## Summary
- Fix Apple login nickname persistence so Apple full names are stored as display names instead of falling back to generated usernames.
- Replace placeholder avatar upload URLs with persisted inline image data URLs and size validation.
- Add full user payloads to Alipay login/register/SDK responses, including nickname and avatar fallbacks.
- Propagate Alipay `user` payloads through the Flutter Alipay auth service so profile refresh and cache paths can use complete identity data.
- Add a D1 migration that backfills `meditation_groups.owner_user_id` and `meditation_group_members.user_id`, plus indexes/unique constraint for `group_id + user_id`.
- Update routed co-practice group creation/join flows so new writes use stable `user_id` where available; usernames remain as display/compatibility fields.

## Notes
- The branch was cut from an earlier main commit and is currently behind `main`; please update/merge main before landing if required by branch protection.
- The stable user-id path now covers group creation and joining through `/api/meditation/groups` and `/api/meditation/groups/join`. Detail/list/review still route through the existing handler, which remains username-compatible; because username-change code already backfills group usernames by `user_id`, this should address the reported duplicate join request without a broad handler rewrite.
- If this migration has already been partially applied in an environment, D1 may reject duplicate `ADD COLUMN` statements. Apply only once or use the existing migration runner safeguards.

## Testing
- Not run in this environment.