### PR TITLE
fix: avoid long-path checkout in publish cd release detection

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 
 deploy_workflow = Path('.github/workflows/deploy-production.yml').read_text(encoding='utf-8')
+publish_release_workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
 auth_utils = Path('fabushi/web/auth-utils.js').read_text(encoding='utf-8')
 auth_handler = Path('fabushi/web/src/handlers/auth.js').read_text(encoding='utf-8')
 password_login = Path('fabushi/web/src/handlers/password-login.js').read_text(encoding='utf-8')
@@ -39,6 +40,20 @@ for required in (
 ):
     if required not in deploy_workflow:
         missing.append(f'deploy workflow missing: {required}')
+
+for required in (
+    'Checkout source for change detection',
+    'sparse-checkout-cone-mode: false',
+    'sparse-checkout: |\n            /.github/**',
+):
+    if required not in publish_release_workflow:
+        missing.append(f'publish release workflow missing: {required}')
+
+for forbidden in (
+    '      - name: Checkout source for change detection\n        uses: actions/checkout@v5\n        with:\n          ref: ${{ steps.source.outputs.source_sha }}\n          fetch-depth: 0\n\n      - name: Detect changed mobile package targets',
+):
+    if forbidden in publish_release_workflow:
+        missing.append(f'publish release workflow should not contain: {forbidden}')
 
 for required in (
     'env?.DB?.prepare',

--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -109,6 +109,9 @@ jobs:
         with:
           ref: ${{ steps.source.outputs.source_sha }}
           fetch-depth: 0
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.github/**
 
       - name: Detect changed mobile package targets
         id: mobile-changes


### PR DESCRIPTION
## 为什么改

当前主线 `Publish CD packages to GitHub Release` 已经出现连续失败，不是发布资产阶段本身坏了，而是前置 job `Resolve completed CD context and mobile changes` 在 `Checkout source for change detection` 就稳定挂掉。

最新失败 run / job 已经给出确定性根因：

- workflow run: `Publish CD packages to GitHub Release #113`
- job: `Resolve completed CD context and mobile changes`
- failed step: `Checkout source for change detection`
- concrete error: `File name too long`

日志里可以直接看到 checkout 在落工作区时碰到了仓库内超长内置资源路径，例如：

- `fabushi/assets/built_in/...mp3`
- `fabushi/web/assets/built_in/...mp3`

但这一步真正目的只是为了执行 `git diff --name-only`，判断 Android / iOS / shared mobile 文件是否有改动，并不需要把整仓库资源都 checkout 到 runner 工作区。

## 这次改了什么

1. 更新 `.github/workflows/publish-cd-release.yml`
   - 把 `Checkout source for change detection` 改成稀疏 checkout
   - 只取 `/.github/**` 这一小块安全路径建立 git 工作区
   - 保留 `fetch-depth: 0`，这样后续 `git diff` 仍然可以对 `SOURCE_SHA` 做完整提交比较

2. 更新 `.github/scripts/check-publish-cd-release.sh`
   - 把这条保护规则纳入 workflow guardrail
   - 明确要求 change-detection checkout 必须保留 sparse checkout
   - 同时拦截旧的“无 sparse checkout 的全量 checkout”形态，防止回退

## 为什么这样修

这次不去碰 release 资产组装、Android 构建、iOS 构建或 GitHub Release 发布逻辑，因为它们并不是当前第一失败点。

真正需要修的是：

- `resolve-cd-context` 必须能拿到 git 元数据
- 但不应该为此把整个含超长资源名的仓库完整展开到 runner 文件系统

用稀疏 checkout 建立最小 git 工作区，既保留了变更检测所需的提交历史，又绕开了 Linux runner 的路径长度问题，属于最小且对症的修法。

## 验证

- 对照失败日志确认当前首个红灯是 checkout 阶段的 `File name too long`
- 对照 workflow 逻辑确认该 job 后续只依赖 git 历史做 `diff`，不依赖这些超长资源文件本身
- 复核这次改动范围仅限：
  - `.github/workflows/publish-cd-release.yml`
  - `.github/scripts/check-publish-cd-release.sh`

## 预期闭环

- 这条 PR 合入后，下一次 `Publish CD packages to GitHub Release` 应先越过 `Resolve completed CD context and mobile changes`
- 若移动端改动存在，再继续进入 Android / iOS 构建与 GitHub Release 发布
- 若没有移动端改动，release workflow 也应能稳定给出“跳过 mobile package build”的正确结果，而不是在 checkout 阶段提前失败

关联 issue：#307 #305 #302 #301