### PR TITLE
ci: scope CI and CD jobs to touched code areas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,219 @@ env:
   FLUTTER_VERSION: '3.41.9'
 
 jobs:
+  detect-changes:
+    name: Detect changed code areas
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      app_changed: ${{ steps.classify.outputs.app_changed }}
+      android_changed: ${{ steps.classify.outputs.android_changed }}
+      worker_changed: ${{ steps.classify.outputs.worker_changed }}
+      frontend_changed: ${{ steps.classify.outputs.frontend_changed }}
+      workflow_guard_changed: ${{ steps.classify.outputs.workflow_guard_changed }}
+    steps:
+      - name: Checkout diff inputs
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.github/workflows/**
+            /.github/scripts/**
+            /fabushi/analysis_options.yaml
+            /fabushi/l10n.yaml
+            /fabushi/pubspec.yaml
+            /fabushi/pubspec.lock
+            /fabushi/lib/**
+            /fabushi/test/**
+            /fabushi/integration_test/**
+            /fabushi/assets/**
+            !/fabushi/assets/built_in/**
+            /fabushi/fonts/**
+            /fabushi/android/**
+            /fabushi/ios/**
+            /fabushi/web/**
+            !/fabushi/web/assets/built_in/**
+            /fabushi/e2e/**
+            /frontend/**
+
+      - name: Resolve diff range
+        id: range
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          base_sha=""
+          head_sha=""
+
+          case "$EVENT_NAME" in
+            pull_request)
+              base_sha="$PR_BASE_SHA"
+              head_sha="$PR_HEAD_SHA"
+              ;;
+            merge_group)
+              base_sha="$MG_BASE_SHA"
+              head_sha="$MG_HEAD_SHA"
+              ;;
+            push)
+              base_sha="$BEFORE_SHA"
+              head_sha="${AFTER_SHA:-$GITHUB_SHA_VALUE}"
+              if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+                base_sha=""
+              fi
+              ;;
+            workflow_dispatch)
+              head_sha="$(git rev-parse HEAD)"
+              base_sha="$(git rev-parse HEAD^ 2>/dev/null || true)"
+              ;;
+            *)
+              head_sha="$GITHUB_SHA_VALUE"
+              base_sha="$(git rev-parse HEAD^ 2>/dev/null || true)"
+              ;;
+          esac
+
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Classify changed code areas
+        id: classify
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.range.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.range.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="changed-files.txt"
+          if [ -n "$BASE_SHA" ] && git rev-parse "$BASE_SHA" >/dev/null 2>&1; then
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$changed_files"
+          else
+            git diff-tree --root --no-commit-id --name-only -r "$HEAD_SHA" > "$changed_files"
+          fi
+
+          app_changed=false
+          android_changed=false
+          worker_changed=false
+          frontend_changed=false
+          workflow_guard_changed=false
+
+          app_reasons=()
+          android_reasons=()
+          worker_reasons=()
+          frontend_reasons=()
+          guard_reasons=()
+
+          mark_app() {
+            app_changed=true
+            app_reasons+=("$1")
+          }
+
+          mark_android() {
+            android_changed=true
+            android_reasons+=("$1")
+          }
+
+          mark_worker() {
+            worker_changed=true
+            worker_reasons+=("$1")
+          }
+
+          mark_frontend() {
+            frontend_changed=true
+            frontend_reasons+=("$1")
+          }
+
+          mark_guard() {
+            workflow_guard_changed=true
+            guard_reasons+=("$1")
+          }
+
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            case "$path" in
+              fabushi/android/*)
+                mark_app "mobile platform input changed: $path"
+                mark_android "android build input changed: $path"
+                ;;
+              fabushi/ios/*)
+                mark_app "mobile platform input changed: $path"
+                ;;
+              fabushi/lib/*|fabushi/test/*|fabushi/integration_test/*|fabushi/assets/*|fabushi/fonts/*|fabushi/pubspec.yaml|fabushi/pubspec.lock|fabushi/analysis_options.yaml|fabushi/l10n.yaml)
+                mark_app "shared Flutter app input changed: $path"
+                mark_android "android build depends on shared Flutter app input: $path"
+                ;;
+              fabushi/web/*|fabushi/e2e/*)
+                mark_worker "worker or deploy gate input changed: $path"
+                mark_guard "workflow guardrails cover worker/deploy path: $path"
+                ;;
+              frontend/*)
+                mark_frontend "frontend workspace input changed: $path"
+                ;;
+              .github/workflows/*|.github/workflows/*/*|.github/scripts/*|.github/scripts/*/*)
+                mark_worker "deployment or package-release workflow input changed: $path"
+                mark_guard "workflow guardrail input changed: $path"
+                ;;
+            esac
+          done < "$changed_files"
+
+          {
+            echo "app_changed=$app_changed"
+            echo "android_changed=$android_changed"
+            echo "worker_changed=$worker_changed"
+            echo "frontend_changed=$frontend_changed"
+            echo "workflow_guard_changed=$workflow_guard_changed"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Changed code area detection"
+            echo ""
+            echo "- App changed: $app_changed"
+            echo "- Android build changed: $android_changed"
+            echo "- Worker or deploy runtime changed: $worker_changed"
+            echo "- Frontend changed: $frontend_changed"
+            echo "- Workflow guardrails changed: $workflow_guard_changed"
+            echo ""
+            echo "### Reasons"
+            echo ""
+            if [ "${#app_reasons[@]}" -gt 0 ]; then
+              printf '%s\n' "${app_reasons[@]}" | awk '!seen[$0]++ { printf "- App: `%s`\n", $0 }'
+            fi
+            if [ "${#android_reasons[@]}" -gt 0 ]; then
+              printf '%s\n' "${android_reasons[@]}" | awk '!seen[$0]++ { printf "- Android: `%s`\n", $0 }'
+            fi
+            if [ "${#worker_reasons[@]}" -gt 0 ]; then
+              printf '%s\n' "${worker_reasons[@]}" | awk '!seen[$0]++ { printf "- Worker/CD: `%s`\n", $0 }'
+            fi
+            if [ "${#frontend_reasons[@]}" -gt 0 ]; then
+              printf '%s\n' "${frontend_reasons[@]}" | awk '!seen[$0]++ { printf "- Frontend: `%s`\n", $0 }'
+            fi
+            if [ "${#guard_reasons[@]}" -gt 0 ]; then
+              printf '%s\n' "${guard_reasons[@]}" | awk '!seen[$0]++ { printf "- Guardrail: `%s`\n", $0 }'
+            fi
+            if [ ! -s "$changed_files" ]; then
+              echo "- No changed files were detected."
+            fi
+            echo ""
+            echo "### Changed files"
+            echo ""
+            sed 's/^/- `/' "$changed_files" | sed 's/$/`/' || true
+          } >> "$GITHUB_STEP_SUMMARY"
+
   fast-checks:
     name: Fast checks
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: detect-changes
+    if: needs.detect-changes.outputs.app_changed == 'true'
     defaults:
       run:
         working-directory: fabushi
@@ -52,9 +261,6 @@ jobs:
             /fabushi/assets/**
             !/fabushi/assets/built_in/**
             /fabushi/fonts/**
-            /fabushi/web/**
-            !/fabushi/web/assets/built_in/**
-            /fabushi/e2e/**
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -124,7 +330,8 @@ jobs:
     name: Release simulation - mobile web build
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: fast-checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.app_changed == 'true' || needs.detect-changes.outputs.worker_changed == 'true'
     defaults:
       run:
         working-directory: fabushi
@@ -181,7 +388,8 @@ jobs:
     name: Release simulation - Android Gradle bootstrap
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: fast-checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.android_changed == 'true'
     defaults:
       run:
         working-directory: fabushi
@@ -232,7 +440,8 @@ jobs:
     name: Module checks - Worker
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: fast-checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.worker_changed == 'true'
     defaults:
       run:
         working-directory: fabushi/web
@@ -271,7 +480,8 @@ jobs:
     name: Contract checks - Worker
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: fast-checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.worker_changed == 'true'
     defaults:
       run:
         working-directory: fabushi/web
@@ -306,8 +516,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:
+      - detect-changes
       - mobile-release-simulation
       - worker-module-checks
+    if: needs.detect-changes.outputs.worker_changed == 'true'
     defaults:
       run:
         working-directory: fabushi/web
@@ -345,7 +557,8 @@ jobs:
     name: Release simulation - staging E2E contract validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: fast-checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.worker_changed == 'true'
     defaults:
       run:
         working-directory: fabushi/e2e
@@ -372,7 +585,8 @@ jobs:
     name: Module checks - Frontend
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: fast-checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend_changed == 'true'
     defaults:
       run:
         working-directory: frontend
@@ -405,7 +619,8 @@ jobs:
     name: Contract checks - Workflow guardrails
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: fast-checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.workflow_guard_changed == 'true'
     steps:
       - name: Checkout workflow files
         uses: actions/checkout@v5
@@ -440,6 +655,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
+      - detect-changes
       - worker-module-checks
       - frontend-module-checks
     steps:
@@ -447,20 +663,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ needs.worker-module-checks.result }}" != "success" ]; then
-            echo "Worker module checks failed: ${{ needs.worker-module-checks.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.frontend-module-checks.result }}" != "success" ]; then
-            echo "Frontend module checks failed: ${{ needs.frontend-module-checks.result }}"
-            exit 1
-          fi
+          for pair in \
+            "Worker module checks:${{ needs.worker-module-checks.result }}" \
+            "Frontend module checks:${{ needs.frontend-module-checks.result }}"
+          do
+            name="${pair%%:*}"
+            result="${pair#*:}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "$name failed: $result"
+              exit 1
+            fi
+          done
 
   contract-checks:
     name: Contract checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
+      - detect-changes
       - worker-contract-checks
       - workflow-contract-checks
     steps:
@@ -468,20 +688,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ needs.worker-contract-checks.result }}" != "success" ]; then
-            echo "Worker contract checks failed: ${{ needs.worker-contract-checks.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.workflow-contract-checks.result }}" != "success" ]; then
-            echo "Workflow contract checks failed: ${{ needs.workflow-contract-checks.result }}"
-            exit 1
-          fi
+          for pair in \
+            "Worker contract checks:${{ needs.worker-contract-checks.result }}" \
+            "Workflow contract checks:${{ needs.workflow-contract-checks.result }}"
+          do
+            name="${pair%%:*}"
+            result="${pair#*:}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "$name failed: $result"
+              exit 1
+            fi
+          done
 
   release-simulation:
     name: Release simulation
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
+      - detect-changes
       - mobile-release-simulation
       - android-gradle-bootstrap
       - worker-release-simulation
@@ -491,28 +715,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ needs.mobile-release-simulation.result }}" != "success" ]; then
-            echo "Mobile release simulation failed: ${{ needs.mobile-release-simulation.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.android-gradle-bootstrap.result }}" != "success" ]; then
-            echo "Android Gradle bootstrap failed: ${{ needs.android-gradle-bootstrap.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.worker-release-simulation.result }}" != "success" ]; then
-            echo "Worker dry-run failed: ${{ needs.worker-release-simulation.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.e2e-release-simulation.result }}" != "success" ]; then
-            echo "E2E release simulation failed: ${{ needs.e2e-release-simulation.result }}"
-            exit 1
-          fi
+          for pair in \
+            "Mobile release simulation:${{ needs.mobile-release-simulation.result }}" \
+            "Android Gradle bootstrap:${{ needs.android-gradle-bootstrap.result }}" \
+            "Worker dry-run:${{ needs.worker-release-simulation.result }}" \
+            "E2E release simulation:${{ needs.e2e-release-simulation.result }}"
+          do
+            name="${pair%%:*}"
+            result="${pair#*:}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "$name failed: $result"
+              exit 1
+            fi
+          done
 
   ci-result:
     name: CI result
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
+      - detect-changes
       - fast-checks
       - module-checks
       - contract-checks
@@ -523,29 +745,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ needs.fast-checks.result }}" != "success" ]; then
-            echo "Fast checks failed: ${{ needs.fast-checks.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.module-checks.result }}" != "success" ]; then
-            echo "Module checks failed: ${{ needs.module-checks.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.contract-checks.result }}" != "success" ]; then
-            echo "Contract checks failed: ${{ needs.contract-checks.result }}"
-            exit 1
-          fi
-          if [ "${{ needs.release-simulation.result }}" != "success" ]; then
-            echo "Release simulation failed: ${{ needs.release-simulation.result }}"
-            exit 1
-          fi
-          echo "All CI checks passed."
+          for pair in \
+            "Fast checks:${{ needs.fast-checks.result }}" \
+            "Module checks:${{ needs.module-checks.result }}" \
+            "Contract checks:${{ needs.contract-checks.result }}" \
+            "Release simulation:${{ needs.release-simulation.result }}"
+          do
+            name="${pair%%:*}"
+            result="${pair#*:}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "$name failed: $result"
+              exit 1
+            fi
+          done
+          echo "Relevant CI checks passed or were intentionally skipped."
 
   notify-ci-failure:
     name: Notify CI failure
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
+      - detect-changes
       - fast-checks
       - mobile-release-simulation
       - android-gradle-bootstrap
@@ -597,16 +817,17 @@ jobs:
               extraSections: [
                 '### CI gate order',
                 '',
-                '- Fast checks',
-                '- Module checks',
-                '- Contract checks',
-                '- Release simulation',
+                '- Detect changed code areas',
+                '- Fast checks only for app-affecting changes',
+                '- Module checks only for touched worker/frontend areas',
+                '- Contract checks only for touched worker/workflow guardrail areas',
+                '- Release simulation only for touched deploy-relevant areas',
                 '',
                 '### CI notes',
                 '',
                 '- Dart format diffs are uploaded as `dart-format-patch` when formatter output differs from the committed code.',
                 '- CI runs with the formatter-applied workspace and does not push formatter commits directly to main because main is protected by merge queue rules.',
-                '- Worker dry-run stays in release simulation so D1 / contract drift is caught before CD deploy starts.',
+                '- Worker dry-run stays in release simulation so D1 / contract drift is caught before CD deploy starts when worker/deploy inputs change.',
                 '- Merge queue runs are supported through the `merge_group` trigger.',
               ],
             });

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,6 +41,7 @@ jobs:
         working-directory: fabushi
     outputs:
       source_sha: ${{ steps.source.outputs.source_sha }}
+      deploy_changed: ${{ steps.deploy-changes.outputs.deploy_changed }}
     steps:
       - name: Resolve source commit
         id: source
@@ -63,6 +64,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ steps.source.outputs.source_sha }}
+          fetch-depth: 0
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /fabushi/**
@@ -71,18 +73,89 @@ jobs:
             /.github/workflows/**
             /.github/scripts/**
 
+      - name: Detect deploy-relevant changes
+        id: deploy-changes
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="changed-files.txt"
+          if git rev-parse "$SOURCE_SHA^" >/dev/null 2>&1; then
+            git diff --name-only "$SOURCE_SHA^" "$SOURCE_SHA" > "$changed_files"
+          else
+            git diff-tree --root --no-commit-id --name-only -r "$SOURCE_SHA" > "$changed_files"
+          fi
+
+          deploy_changed=false
+          reasons=()
+
+          mark_deploy() {
+            deploy_changed=true
+            reasons+=("$1")
+          }
+
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            case "$path" in
+              fabushi/lib/*|fabushi/assets/*|fabushi/fonts/*|fabushi/pubspec.yaml|fabushi/pubspec.lock|fabushi/analysis_options.yaml|fabushi/l10n.yaml)
+                mark_deploy "shared Flutter deploy input changed: $path"
+                ;;
+              fabushi/android/*|fabushi/ios/*)
+                mark_deploy "mobile platform input changed and should keep deploy artifact honest: $path"
+                ;;
+              fabushi/web/*|fabushi/e2e/*)
+                mark_deploy "worker runtime or staging gate input changed: $path"
+                ;;
+              .github/workflows/deploy-production.yml|.github/scripts/*)
+                mark_deploy "deployment pipeline input changed: $path"
+                ;;
+            esac
+          done < "$changed_files"
+
+          echo "deploy_changed=$deploy_changed" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Deploy change detection"
+            echo ""
+            echo "- Source SHA: $SOURCE_SHA"
+            echo "- Deploy changed: $deploy_changed"
+            echo ""
+            echo "### Reasons"
+            echo ""
+            if [ "${#reasons[@]}" -gt 0 ]; then
+              printf '%s\n' "${reasons[@]}" | awk '!seen[$0]++ { printf "- `%s`\n", $0 }'
+            else
+              echo "- No deploy-relevant inputs changed. This CD run will stop before artifact build and environment deploy steps."
+            fi
+            echo ""
+            echo "### Changed files"
+            echo ""
+            sed 's/^/- `/' "$changed_files" | sed 's/$/`/' || true
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Skip deploy build when inputs are unchanged
+        if: steps.deploy-changes.outputs.deploy_changed != 'true'
+        shell: bash
+        run: |
+          echo "No deploy-relevant inputs changed; skipping release artifact build and downstream environment deploy jobs."
+
       - name: Set up Flutter
+        if: steps.deploy-changes.outputs.deploy_changed == 'true'
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
 
       - name: Set up Node.js
+        if: steps.deploy-changes.outputs.deploy_changed == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - name: Run profile update D1 transaction regression
+        if: steps.deploy-changes.outputs.deploy_changed == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -90,11 +163,13 @@ jobs:
           node web/tests/profile.test.js
 
       - name: Build Flutter web release
+        if: steps.deploy-changes.outputs.deploy_changed == 'true'
         run: |
           flutter pub get
           flutter build web --release
 
       - name: Package release artifact
+        if: steps.deploy-changes.outputs.deploy_changed == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -107,6 +182,7 @@ jobs:
           printf '%s\n' "${{ steps.source.outputs.source_sha }}" > ../release-artifact/SOURCE_SHA
 
       - name: Upload release artifact
+        if: steps.deploy-changes.outputs.deploy_changed == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: fabushi-release-${{ steps.source.outputs.source_sha }}
@@ -117,6 +193,7 @@ jobs:
   deploy-staging:
     name: Deploy staging environment
     needs: build-artifact
+    if: needs.build-artifact.outputs.deploy_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -188,6 +265,7 @@ jobs:
     needs:
       - build-artifact
       - deploy-staging
+    if: needs.build-artifact.outputs.deploy_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -195,9 +273,6 @@ jobs:
         working-directory: fabushi/e2e
     env:
       STAGING_API_URL: https://fabushi-flutter-web-dev.bhrumom.workers.dev
-      # Profile E2E currently calls staging API routes through an app-style base URL.
-      # Keep the default aligned with the API-only staging deployment until a
-      # separate staging frontend URL is provisioned, while still allowing an override.
       STAGING_APP_URL: ${{ vars.STAGING_APP_URL || 'https://fabushi-flutter-web-dev.bhrumom.workers.dev' }}
       STAGING_TEST_LOGIN: ${{ secrets.STAGING_TEST_LOGIN }}
       STAGING_TEST_PASSWORD: ${{ secrets.STAGING_TEST_PASSWORD }}
@@ -271,6 +346,7 @@ jobs:
     needs:
       - build-artifact
       - staging-e2e
+    if: needs.build-artifact.outputs.deploy_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -370,6 +446,7 @@ jobs:
     needs:
       - build-artifact
       - deploy-production
+    if: needs.build-artifact.outputs.deploy_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -439,6 +516,7 @@ jobs:
               extraSections: [
                 '### Deployment gates',
                 '',
+                '- Detect deploy-relevant changes before building artifacts',
                 '- Staging API E2E',
                 '- Staging API smoke test',
                 '- Production deploy and API smoke test',


### PR DESCRIPTION
## 为什么改

当前仓库的 `CI` 和 `CD - Staging API gated production deploy` 大多还是“只要有提交就整条链路都跑”，即使这次改动只碰了 `frontend/`、只碰了 Worker，或者只是调整了一小块 deploy 脚本，也会把不相关的 Flutter、Android、staging、production 等步骤一起拉起来。

这会带来几个直接问题：

- 不相关的 job 白跑，耗时和 runner 成本都上去
- 真正相关的红灯容易被一串无关 job 淹没
- 主线 merge 后，即使这次提交没有触碰 deploy 输入，CD 也会继续构建 artifact、跑 staging、再跑 production

这次改的是触发和调度方式，不改业务逻辑：让 CI/CD 先识别“这次到底改了哪块”，再只跑相关流水线。

## 这次改了什么

### 1. CI 先做一次轻量 change detection

在 `.github/workflows/ci.yml` 里新增 `Detect changed code areas`：

- 按事件类型解析 diff range（`pull_request` / `merge_group` / `push` / `workflow_dispatch`）
- 只做最小化 sparse checkout，避免把整仓库都展开
- 按改动路径输出几类布尔信号：
  - `app_changed`
  - `android_changed`
  - `worker_changed`
  - `frontend_changed`
  - `workflow_guard_changed`

### 2. CI 各 job 只在命中相关区域时运行

现在会变成：

- `Fast checks` 只在 Flutter app / mobile 平台相关代码改动时运行
- `Android Gradle bootstrap` 只在 Android 或 shared Flutter 输入改动时运行
- Worker 语法、contract、dry-run、E2E 列表校验，只在 Worker / deploy 相关输入改动时运行
- Frontend 的 typecheck / build，只在 `frontend/` 改动时运行
- Workflow guardrail，只在 `.github/*` 或它守护的 worker/deploy 输入改动时运行

### 3. CI 汇总 gate 改成接受“成功或有意跳过”

之前聚合 job 默认把所有上游都当成必须真的跑完。

现在 `module-checks` / `contract-checks` / `release-simulation` / `ci-result` 都显式接受：

- `success`
- `skipped`

这样路径未命中的 job 跳过时，CI 仍然能正常收口，而不是被“没跑”卡住。

### 4. CD 在主线部署前先判断这次提交是否真的影响 deploy

在 `.github/workflows/deploy-production.yml` 的 `build-artifact` job 里新增 deploy change detection：

- 先比较 `SOURCE_SHA^..SOURCE_SHA`
- 只要这次没有命中 deploy-relevant 输入，就直接停在摘要阶段
- 不再继续做：
  - Flutter web release build
  - artifact 打包
  - staging deploy
  - staging E2E
  - production deploy
  - production smoke

### 5. 只把真正影响 deploy 的输入继续送进 staging / production

当前判定为 deploy-relevant 的主要输入包括：

- `fabushi/lib/**`
- `fabushi/assets/**`
- `fabushi/fonts/**`
- `fabushi/pubspec.*`
- `fabushi/analysis_options.yaml`
- `fabushi/l10n.yaml`
- `fabushi/android/**`
- `fabushi/ios/**`
- `fabushi/web/**`
- `fabushi/e2e/**`
- `.github/workflows/deploy-production.yml`
- `.github/scripts/**`

这意味着像纯 `frontend/` 改动，或者未来其他与 deploy 无关的主线提交，不会再把整条 CD 拉起来。

## 预期效果

- 改 `frontend/`：只跑 frontend 相关 CI，不再顺带跑 Flutter / Worker / deploy 模拟
- 改 Worker / deploy 脚本：只跑 Worker / deploy 相关 CI，不再把不相关 frontend 拉进来
- 改 Android：只跑 app / Android 相关链路
- 主线 merge 后如果没碰 deploy 输入：CD 会快速结束，不再继续 staging / production

## 验证

- 这轮无法在本地直接运行 GitHub Actions，只能通过仓库内结构和条件关系做静态校对
- 已把改动范围控制在：
  - `.github/workflows/ci.yml`
  - `.github/workflows/deploy-production.yml`
- 后续以这条 PR 的 `CI` 和合入后的主线 `CD` 实际结果为准

## 后续观察点

1. 看这条 PR 上不同 job 是否按改动范围正确跳过或运行
2. 合入后观察下一次 `main` 上的 `CD` 是否在无 deploy 输入时快速结束
3. 若效果稳定，再考虑把 package release 的 change detector 与这套分类规则进一步统一