### PR TITLE
feat: limit username changes annually and show user number

### DIFF
--- a/fabushi/lib/models/auth_model.dart
+++ b/fabushi/lib/models/auth_model.dart
@@ -13,6 +13,7 @@ import 'user_model.dart';
 
 class User {
   final String username;
+  final int? userNo;
   final String email;
   final String? membershipType;
   final DateTime? membershipExpiry;
@@ -22,9 +23,11 @@ class User {
   final String? avatar;
   final String? phoneNumber;
   final String? firebaseUid;
+  final String? usernameChangedAt;
 
   User({
     required this.username,
+    this.userNo,
     required this.email,
     this.membershipType,
     this.membershipExpiry,
@@ -34,11 +37,20 @@ class User {
     this.avatar,
     this.phoneNumber,
     this.firebaseUid,
+    this.usernameChangedAt,
   });
+
+  static int? _parseOptionalInt(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value.toString());
+  }
 
   factory User.fromJson(Map<String, dynamic> json) {
     return User(
       username: json['username'] ?? '',
+      userNo: _parseOptionalInt(json['userNo'] ?? json['user_no'] ?? json['id']),
       email: json['email'] ?? '',
       membershipType: json['membershipType'],
       membershipExpiry: json['membershipExpiry'] != null
@@ -50,12 +62,14 @@ class User {
       avatar: json['avatar'],
       phoneNumber: json['phoneNumber'],
       firebaseUid: json['firebaseUid'],
+      usernameChangedAt: json['usernameChangedAt'] ?? json['username_changed_at'],
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
       'username': username,
+      'userNo': userNo,
       'email': email,
       'membershipType': membershipType,
       'membershipExpiry': membershipExpiry?.toIso8601String(),
@@ -65,6 +79,7 @@ class User {
       'avatar': avatar,
       'phoneNumber': phoneNumber,
       'firebaseUid': firebaseUid,
+      'usernameChangedAt': usernameChangedAt,
     };
   }
 
@@ -138,6 +153,7 @@ class AuthModel extends ChangeNotifier {
 
     return User(
       username: userJson['username'] ?? fallbackUsername ?? '',
+      userNo: User._parseOptionalInt(userJson['userNo'] ?? userJson['user_no'] ?? userJson['id']),
       email: userJson['email'] ?? fallbackEmail ?? '',
       membershipType: membershipType,
       membershipExpiry: membershipExpiry,
@@ -147,6 +163,7 @@ class AuthModel extends ChangeNotifier {
       avatar: userJson['avatar'],
       phoneNumber: userJson['phoneNumber'] ?? userJson['phone_number'] ?? fallbackPhoneNumber,
       firebaseUid: userJson['firebaseUid'] ?? userJson['firebase_uid'] ?? fallbackFirebaseUid,
+      usernameChangedAt: userJson['usernameChangedAt'] ?? userJson['username_changed_at'],
     );
   }
 
@@ -167,9 +184,11 @@ class AuthModel extends ChangeNotifier {
 
         final basicUserModel = UserModel(
           username: _currentUser!.username,
+          userNo: _currentUser!.userNo,
           email: _currentUser!.email,
           emailVerified: true,
           createdAt: DateTime.now().toIso8601String(),
+          usernameChangedAt: _currentUser!.usernameChangedAt,
           membership: MembershipInfo(
             type: _currentUser!.membershipType ?? 'expired',
             isActive: _currentUser!.hasPremiumMembership,
@@ -383,6 +402,7 @@ class AuthModel extends ChangeNotifier {
 
         _currentUser = User(
           username: userModel.username,
+          userNo: userModel.userNo,
           email: userModel.email ?? '',
           membershipType: userModel.membership.type,
           membershipExpiry: userModel.membership.expiresAt != null
@@ -394,6 +414,7 @@ class AuthModel extends ChangeNotifier {
           avatar: userModel.avatarUrl,
           phoneNumber: userModel.phoneNumber,
           firebaseUid: userModel.firebaseUid,
+          usernameChangedAt: userModel.usernameChangedAt,
         );
 
         await _storeAuth();

--- a/fabushi/lib/models/user_model.dart
+++ b/fabushi/lib/models/user_model.dart
@@ -1,11 +1,20 @@
 // 用户数据模型
 // 定义用户相关的数据结构
 
+int? _parseOptionalInt(dynamic value) {
+  if (value == null) return null;
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value.toString());
+}
+
 class UserModel {
   final String username;
+  final int? userNo;
   final String? email;
   final bool emailVerified;
   final String createdAt;
+  final String? usernameChangedAt;
   final String? wechatOpenid;
   final String? wechatNickname;
   final String? wechatHeadimgurl;
@@ -23,9 +32,11 @@ class UserModel {
 
   UserModel({
     required this.username,
+    this.userNo,
     this.email,
     required this.emailVerified,
     required this.createdAt,
+    this.usernameChangedAt,
     this.wechatOpenid,
     this.wechatNickname,
     this.wechatHeadimgurl,
@@ -46,9 +57,11 @@ class UserModel {
   factory UserModel.fromJson(Map<String, dynamic> json) {
     return UserModel(
       username: json['username'] as String,
+      userNo: _parseOptionalInt(json['userNo'] ?? json['user_no'] ?? json['id']),
       email: json['email'] as String?,
       emailVerified: json['emailVerified'] as bool? ?? false,
       createdAt: json['createdAt'] as String,
+      usernameChangedAt: json['usernameChangedAt'] as String? ?? json['username_changed_at'] as String?,
       wechatOpenid: json['wechatOpenid'] as String?,
       wechatNickname: json['wechatNickname'] as String?,
       wechatHeadimgurl: json['wechatHeadimgurl'] as String?,
@@ -72,9 +85,11 @@ class UserModel {
   Map<String, dynamic> toJson() {
     return {
       'username': username,
+      'userNo': userNo,
       'email': email,
       'emailVerified': emailVerified,
       'createdAt': createdAt,
+      'usernameChangedAt': usernameChangedAt,
       'wechatOpenid': wechatOpenid,
       'wechatNickname': wechatNickname,
       'wechatHeadimgurl': wechatHeadimgurl,
@@ -95,9 +110,11 @@ class UserModel {
   // 复制并修改部分字段
   UserModel copyWith({
     String? username,
+    int? userNo,
     String? email,
     bool? emailVerified,
     String? createdAt,
+    String? usernameChangedAt,
     String? wechatOpenid,
     String? wechatNickname,
     String? wechatHeadimgurl,
@@ -115,9 +132,11 @@ class UserModel {
   }) {
     return UserModel(
       username: username ?? this.username,
+      userNo: userNo ?? this.userNo,
       email: email ?? this.email,
       emailVerified: emailVerified ?? this.emailVerified,
       createdAt: createdAt ?? this.createdAt,
+      usernameChangedAt: usernameChangedAt ?? this.usernameChangedAt,
       wechatOpenid: wechatOpenid ?? this.wechatOpenid,
       wechatNickname: wechatNickname ?? this.wechatNickname,
       wechatHeadimgurl: wechatHeadimgurl ?? this.wechatHeadimgurl,

--- a/fabushi/lib/screens/edit_profile_screen.dart
+++ b/fabushi/lib/screens/edit_profile_screen.dart
@@ -39,6 +39,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   static const int _maxAvatarBytes = 3 * 1024 * 1024;
 
   final _formKey = GlobalKey<FormState>();
+  late TextEditingController _displayNameController;
   late TextEditingController _usernameController;
   late TextEditingController _emailController;
   late TextEditingController _phoneController;
@@ -57,6 +58,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   void initState() {
     super.initState();
     final user = context.read<AuthModel>().currentUser;
+    _displayNameController = TextEditingController(text: user?.nickname ?? '');
     _usernameController = TextEditingController(text: user?.username ?? '');
     _emailController = TextEditingController(text: user?.email ?? '');
     _phoneController = TextEditingController(text: user?.phoneNumber ?? '');
@@ -68,6 +70,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
   @override
   void dispose() {
+    _displayNameController.dispose();
     _usernameController.dispose();
     _emailController.dispose();
     _phoneController.dispose();
@@ -235,9 +238,11 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   }) {
     final currentUser = context.read<AuthModel>().currentUser;
     return {
+      'attemptedDisplayName': _displayNameController.text.trim(),
       'attemptedUsername': _usernameController.text.trim(),
       'attemptedEmail': _maskEmail(_emailController.text.trim()),
       'attemptedPhone': _maskPhone(_phoneController.text.trim()),
+      'changedDisplayName': currentUser?.nickname != _displayNameController.text.trim(),
       'changedUsername': currentUser?.username != _usernameController.text.trim(),
       'changedEmail': currentUser?.email != _emailController.text.trim(),
       'changedPhone': currentUser?.phoneNumber != _phoneController.text.trim(),
@@ -295,12 +300,19 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
     setState(() => _isLoading = true);
 
+    final authModel = context.read<AuthModel>();
+    final currentUser = authModel.currentUser;
+    final trimmedDisplayName = _displayNameController.text.trim();
     final body = <String, dynamic>{
       'username': _usernameController.text.trim(),
       'email': _emailController.text.trim(),
       'phoneNumber': _phoneController.text.trim(),
       'avatar': _avatarController.text.trim(),
     };
+
+    if (trimmedDisplayName.isNotEmpty || currentUser?.nickname?.isNotEmpty == true) {
+      body['displayName'] = trimmedDisplayName;
+    }
 
     if (!_hasPassword && _passwordController.text.isNotEmpty) {
       body['password'] = _passwordController.text;
@@ -335,7 +347,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                   _usernameController.text.trim())
             : _usernameController.text.trim();
 
-        final authModel = context.read<AuthModel>();
         if (token != null) {
           await authModel.loginWithToken(token, updatedUsername);
         } else {
@@ -441,6 +452,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   }
 
   Widget _buildAvatarSection(User? user) {
+    final fallbackName = user?.displayName ?? user?.username ?? '';
+
     return GestureDetector(
       onTap: _pickAvatar,
       child: Column(
@@ -467,9 +480,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                         _pendingAvatarBase64 == null)
                     ? Center(
                         child: Text(
-                          (user?.username.isNotEmpty == true
-                                  ? user!.username[0]
-                                  : '?')
+                          (fallbackName.isNotEmpty ? fallbackName[0] : '?')
                               .toUpperCase(),
                           style: const TextStyle(
                             color: Colors.white,
@@ -529,6 +540,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   }
 
   Widget _buildFormSection(User? user) {
+    final currentDisplayName = user?.displayName ?? user?.username ?? '未设置';
+
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       decoration: BoxDecoration(
@@ -537,6 +550,21 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       ),
       child: Column(
         children: [
+          _buildFormItem(
+            label: '显示名称',
+            child: TextFormField(
+              controller: _displayNameController,
+              style: const TextStyle(color: Colors.white, fontSize: 15),
+              decoration: InputDecoration(
+                border: InputBorder.none,
+                hintText: user?.nickname?.isNotEmpty == true
+                    ? '请输入对外显示的名称'
+                    : '当前对外显示: $currentDisplayName',
+                hintStyle: const TextStyle(color: Colors.white38),
+              ),
+            ),
+          ),
+          _divider(),
           _buildFormItem(
             label: '用户名',
             child: TextFormField(
@@ -559,6 +587,13 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 }
                 return null;
               },
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 0, 16, 12),
+            child: Text(
+              '个人主页默认优先显示“显示名称”，用户名用于登录和账号标识。',
+              style: TextStyle(color: Colors.white38, fontSize: 12),
             ),
           ),
           _divider(),

--- a/fabushi/lib/screens/edit_profile_screen.dart
+++ b/fabushi/lib/screens/edit_profile_screen.dart
@@ -592,9 +592,15 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           const Padding(
             padding: EdgeInsets.fromLTRB(16, 0, 16, 12),
             child: Text(
-              '个人主页默认优先显示“显示名称”，用户名用于登录和账号标识。',
+              '昵称用于主页展示；用户名用于登录和账号标识，并且一年只能修改一次。',
               style: TextStyle(color: Colors.white38, fontSize: 12),
             ),
+          ),
+          _divider(),
+          _buildInfoItem(
+            label: '学号',
+            value: user?.userNo?.toString() ?? '未生成',
+            showArrow: false,
           ),
           _divider(),
           _buildFormItem(

--- a/fabushi/lib/screens/my_profile_screen.dart
+++ b/fabushi/lib/screens/my_profile_screen.dart
@@ -223,6 +223,16 @@ class _MyProfileScreenState extends State<MyProfileScreen> {
                                     color: Colors.white,
                                   ),
                                 ),
+                                if (user.displayName != user.username) ...[
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    '@${user.username}',
+                                    style: const TextStyle(
+                                      color: Colors.white54,
+                                      fontSize: 13,
+                                    ),
+                                  ),
+                                ],
                                 const SizedBox(height: 6),
                                 Row(
                                   children: [

--- a/fabushi/lib/screens/my_profile_screen.dart
+++ b/fabushi/lib/screens/my_profile_screen.dart
@@ -233,6 +233,14 @@ class _MyProfileScreenState extends State<MyProfileScreen> {
                                     ),
                                   ),
                                 ],
+                                const SizedBox(height: 4),
+                                Text(
+                                  '学号 ${user.userNo?.toString() ?? '--'}',
+                                  style: const TextStyle(
+                                    color: Colors.white54,
+                                    fontSize: 13,
+                                  ),
+                                ),
                                 const SizedBox(height: 6),
                                 Row(
                                   children: [

--- a/fabushi/lib/services/auth_service.dart
+++ b/fabushi/lib/services/auth_service.dart
@@ -31,6 +31,13 @@ class AuthService {
     return '${token.substring(0, previewLength)}...';
   }
 
+  int? _parseOptionalInt(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value.toString());
+  }
+
   Map<String, dynamic> _failureFromResponse(
     dynamic response,
     String fallbackMessage,
@@ -61,12 +68,14 @@ class AuthService {
 
     return UserModel(
       username: resolvedUsername,
+      userNo: _instance._parseOptionalInt(user['userNo'] ?? user['user_no'] ?? user['id'] ?? data['userNo'] ?? data['userId']),
       email: resolvedEmail,
       emailVerified:
           user['emailVerified'] as bool? ?? user['email_verified'] == true,
       createdAt:
           (user['createdAt'] ?? user['created_at'] ?? DateTime.now().toIso8601String())
               .toString(),
+      usernameChangedAt: (user['usernameChangedAt'] ?? user['username_changed_at']) as String?,
       wechatOpenid: user['wechatOpenid'] as String?,
       wechatNickname: user['wechatNickname'] as String?,
       wechatHeadimgurl: user['wechatHeadimgurl'] as String?,
@@ -354,9 +363,11 @@ class AuthService {
 
         return UserModel(
           username: data['username'] ?? '',
+          userNo: _parseOptionalInt(data['userNo'] ?? data['user_no'] ?? data['id'] ?? data['userId']),
           email: data['email'] ?? '',
           emailVerified: true,
           createdAt: DateTime.now().toIso8601String(),
+          usernameChangedAt: data['usernameChangedAt'] ?? data['username_changed_at'],
           nickname: data['nickname'],
           avatar: data['avatar'],
           phoneNumber: data['phoneNumber'] ?? data['phone_number'],
@@ -544,9 +555,11 @@ class AuthService {
 
           final userInfo = UserModel(
             username: data['username'] ?? userJson?['username'] ?? '',
+            userNo: _parseOptionalInt(userJson?['userNo'] ?? userJson?['user_no'] ?? userJson?['id'] ?? data['userNo'] ?? data['userId']),
             email: userJson?['email'] ?? email ?? '',
             emailVerified: true,
             createdAt: DateTime.now().toIso8601String(),
+            usernameChangedAt: userJson?['usernameChangedAt'] ?? userJson?['username_changed_at'],
             membership: MembershipInfo(
               type: userJson?['membership']?['type'] ?? 'trial',
               isActive: true,
@@ -600,9 +613,11 @@ class AuthService {
 
           final userInfo = UserModel(
             username: data['username'] ?? userJson?['username'] ?? '',
+            userNo: _parseOptionalInt(userJson?['userNo'] ?? userJson?['user_no'] ?? userJson?['id'] ?? data['userNo'] ?? data['userId']),
             email: userJson?['email'] ?? '',
             emailVerified: true,
             createdAt: DateTime.now().toIso8601String(),
+            usernameChangedAt: userJson?['usernameChangedAt'] ?? userJson?['username_changed_at'],
             membership: MembershipInfo(
               type: userJson?['membership']?['type'] ?? 'trial',
               isActive: true,

--- a/fabushi/web/migrations/20260510_users_username_changed_at.sql
+++ b/fabushi/web/migrations/20260510_users_username_changed_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN username_changed_at TEXT;

--- a/fabushi/web/schema.sql
+++ b/fabushi/web/schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS users (
   last_transfer_at TEXT,
   sync_version INTEGER DEFAULT 1,
   extra_data TEXT,
+  username_changed_at TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT
 );

--- a/fabushi/web/schema_v2.sql
+++ b/fabushi/web/schema_v2.sql
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS users (
   last_transfer_at TEXT,
   sync_version INTEGER DEFAULT 1,
   extra_data TEXT,
+  username_changed_at TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT
 );

--- a/fabushi/web/src/contracts/account-user.js
+++ b/fabushi/web/src/contracts/account-user.js
@@ -6,6 +6,7 @@ export function serializeAccountUser(user) {
     userId: user.id,
     userNo,
     username: user.username,
+    usernameChangedAt: user.username_changed_at || null,
     email: user.email || '',
     nickname: user.nickname || user.username,
     avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,

--- a/fabushi/web/src/domain/account-identity.js
+++ b/fabushi/web/src/domain/account-identity.js
@@ -46,13 +46,13 @@ function looksLikeAccountUsername(value) {
 }
 
 export function normalizeProfileUpdateBody(body, currentUsername = '') {
-  const rawNickname = body.nickname;
+  const rawDisplayName = body.displayName !== undefined ? body.displayName : body.nickname;
   const rawUsername = body.username;
   const password = body.password !== undefined ? String(body.password) : undefined;
   const normalizedCurrentUsername = String(currentUsername || '').trim();
 
-  let hasDisplayNameField = rawNickname !== undefined;
-  let displayName = rawNickname !== undefined ? normalizeDisplayName(rawNickname) : undefined;
+  let hasDisplayNameField = rawDisplayName !== undefined;
+  let displayName = rawDisplayName !== undefined ? normalizeDisplayName(rawDisplayName) : undefined;
   let username;
 
   if (rawUsername !== undefined) {
@@ -65,7 +65,7 @@ export function normalizeProfileUpdateBody(body, currentUsername = '') {
 
     if (wantsRename) {
       username = normalizeUsername(normalizedUsername);
-    } else if (rawNickname === undefined) {
+    } else if (rawDisplayName === undefined) {
       hasDisplayNameField = true;
       displayName = normalizeDisplayName(rawUsername);
     }

--- a/fabushi/web/src/use-cases/update-profile.js
+++ b/fabushi/web/src/use-cases/update-profile.js
@@ -4,6 +4,19 @@ import { ApiError } from '../contracts/api-error.js';
 import { normalizeProfileUpdateBody } from '../domain/account-identity.js';
 import { authenticateRequest } from './authenticated-user.js';
 
+const USERNAME_CHANGE_WINDOW_MS = 365 * 24 * 60 * 60 * 1000;
+
+function parseIsoDate(value) {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return null;
+  return new Date(timestamp);
+}
+
+function formatDateOnly(date) {
+  return date.toISOString().slice(0, 10);
+}
+
 export async function updateProfileFromRequest(request, env, repository) {
   const { user } = await authenticateRequest(request, env, repository);
   const body = await request.json();
@@ -24,6 +37,14 @@ export async function updateProfileCommand({ currentUser, body, env }, repositor
   }
 
   if (username !== undefined && username !== currentUser.username) {
+    const lastChangedAt = parseIsoDate(currentUser.username_changed_at);
+    if (lastChangedAt) {
+      const nextAllowedAt = new Date(lastChangedAt.getTime() + USERNAME_CHANGE_WINDOW_MS);
+      if (nextAllowedAt.getTime() > Date.now()) {
+        throw new ApiError(`用户名一年只能修改一次，请在${formatDateOnly(nextAllowedAt)}后再试`, 400);
+      }
+    }
+
     const existingUser = await repository.getByUsername(username);
     if (existingUser && existingUser.id !== currentUser.id) {
       throw new ApiError('用户名已存在', 400);
@@ -45,7 +66,10 @@ export async function updateProfileCommand({ currentUser, body, env }, repositor
   }
 
   const updates = {};
-  if (username !== undefined && username !== currentUser.username) updates.username = username;
+  if (username !== undefined && username !== currentUser.username) {
+    updates.username = username;
+    updates.username_changed_at = new Date().toISOString();
+  }
   if (displayName !== undefined) updates.nickname = displayName;
   if (email !== undefined) {
     updates.email = email || '';

--- a/fabushi/web/tests/profile.test.js
+++ b/fabushi/web/tests/profile.test.js
@@ -88,8 +88,10 @@ function createDbMock() {
       };
     },
     seedUser(username, email, phoneNumber, extra = {}) {
+      const id = nextId++;
       const user = {
-        id: nextId++,
+        id,
+        user_no: extra.user_no ?? id,
         username,
         email,
         password_hash: '',
@@ -105,6 +107,7 @@ function createDbMock() {
         membership_type: 'trial',
         membership_expires_at: null,
         free_trial_end_date: '2026-05-31T00:00:00Z',
+        username_changed_at: extra.username_changed_at ?? null,
         created_at: '2026-05-01T00:00:00Z',
         updated_at: '2026-05-04T00:00:00Z'
       };
@@ -155,6 +158,24 @@ test('handleUpdateProfile treats legacy username payload as display name and kee
     db.statements.some(({ sql }) => sql.startsWith('INSERT INTO users') || sql.startsWith('DELETE FROM users')),
     false
   );
+});
+
+test('handleUpdateProfile accepts explicit displayName field and keeps username stable', async () => {
+  const db = createDbMock();
+  const user = db.seedUser('display_name_user', 'display@example.com', '+8613800138009', { nickname: '旧显示名' });
+
+  const response = await updateProfile(db, { id: user.id, username: user.username }, {
+    displayName: '新显示名',
+    email: 'display@example.com',
+    phoneNumber: '+8613800138009'
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.user.userId, user.id);
+  assert.equal(payload.user.username, 'display_name_user');
+  assert.equal(payload.user.nickname, '新显示名');
+  assert.equal(db.users.get('display_name_user').nickname, '新显示名');
 });
 
 test('handleUpdateProfile uses token userId before mismatched username fallback', async () => {
@@ -215,6 +236,30 @@ test('handleUpdateProfile rejects duplicate email by id, not by username', async
   assert.equal(payload.error, '该邮箱已被其他账号使用');
 });
 
+test('handleUpdateProfile blocks username rename within one year window', async () => {
+  const db = createDbMock();
+  const recentChangeAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const expectedNextDate = new Date(Date.parse(recentChangeAt) + 365 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const user = db.seedUser('rename_locked', 'locked@example.com', '+8613800138440', {
+    nickname: '改名受限',
+    username_changed_at: recentChangeAt,
+  });
+
+  const response = await updateProfile(db, { id: user.id, username: user.username }, {
+    username: 'rename_unlocked_later',
+    email: 'locked@example.com',
+    phoneNumber: '+8613800138440'
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.error, `用户名一年只能修改一次，请在${expectedNextDate}后再试`);
+  assert.equal(db.users.has('rename_locked'), true);
+  assert.equal(db.users.has('rename_unlocked_later'), false);
+});
+
 test('handleUpdateProfile renames username, rotates token, and refreshes email mapping', async () => {
   const db = createDbMock();
   const user = db.seedUser('stable_1', 'stable@example.com', '+8613800138444', { nickname: '旧昵称' });
@@ -231,8 +276,11 @@ test('handleUpdateProfile renames username, rotates token, and refreshes email m
   assert.equal(payload.user.username, 'stable-renamed');
   assert.equal(payload.user.nickname, '旧昵称');
   assert.ok(payload.token);
+  assert.ok(payload.user.userNo);
+  assert.ok(payload.user.usernameChangedAt);
   assert.equal(db.users.has('stable_1'), false);
   assert.equal(db.users.get('stable-renamed').id, user.id);
+  assert.ok(db.users.get('stable-renamed').username_changed_at);
   assert.equal(db.emailMapping.get('stable@example.com').username, 'stable-renamed');
 
   const tokenPayload = await verifyToken(payload.token, { JWT_SECRET: 'test-secret' });


### PR DESCRIPTION
## Summary
- split profile editing into `显示名称` and `用户名`, and wire the explicit `displayName` request field through the existing backend contract
- enforce a backend rename gate so `用户名` can only change once per 365 days, while `昵称/显示名称` remains editable
- surface `userNo` as `学号` in the profile UI and carry it through the frontend auth/user models
- add `username_changed_at` schema coverage plus a release migration for existing D1 databases

## Why
We had two different problems sitting together:
1. the outer profile page rendered `displayName` (`nickname ?? username`) while the edit page only showed `username`, which made users feel the edit page was stale
2. product now wants `昵称` to stay flexible, but `用户名` to behave more like a stable account identifier and only be changeable rarely

This PR closes both by making the UI semantics explicit and moving the once-per-year username rule into the backend update-profile use case so old clients cannot bypass it.

## Validation
- branch diff reviewed to confirm the change is scoped to profile UI, auth/user model parsing, the update-profile use case, schema files, and `profile.test.js`
- added regression coverage for explicit `displayName` updates and the annual username-change rejection path
- did not run local Flutter or Worker test commands in this environment because the repository workspace is not mounted locally here