### PR TITLE
feat: compact global leaderboard transfer units

### DIFF
--- a/fabushi/lib/screens/leaderboard_screen.dart
+++ b/fabushi/lib/screens/leaderboard_screen.dart
@@ -8,6 +8,25 @@ import '../widgets/follow_button.dart';
 import '../widgets/leaderboard_user_detail_sheet.dart';
 import '../core/design_system/app_theme.dart';
 
+String formatLeaderboardBytes(int bytes) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+
+  double value = bytes.toDouble();
+  var unitIndex = 0;
+
+  while (value >= 1000 && unitIndex < units.length - 1) {
+    value /= 1000;
+    unitIndex += 1;
+  }
+
+  var formatted = value >= 100 ? value.toStringAsFixed(0) : value.toStringAsFixed(1);
+  if (formatted.endsWith('.0')) {
+    formatted = formatted.substring(0, formatted.length - 2);
+  }
+
+  return '$formatted ${units[unitIndex]}';
+}
+
 class LeaderboardScreen extends StatefulWidget {
   const LeaderboardScreen({super.key});
 
@@ -122,7 +141,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
                             context,
                             entry: entry,
                             highlightLabel: '累计布施',
-                            highlightValue: _formatBytes(entry.totalBytes),
+                            highlightValue: formatLeaderboardBytes(entry.totalBytes),
                           ),
                           leading: _buildRankBadge(entry.rank),
                           title: Text(
@@ -146,7 +165,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
                             mainAxisSize: MainAxisSize.min,
                             children: [
                               Text(
-                                _formatBytes(entry.totalBytes),
+                                formatLeaderboardBytes(entry.totalBytes),
                                 style: const TextStyle(color: Colors.white70),
                               ),
                               const SizedBox(width: 10),
@@ -215,17 +234,6 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
         ),
       ),
     );
-  }
-
-  String _formatBytes(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) {
-      return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    }
-    if (bytes < 1024 * 1024 * 1024) {
-      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    }
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
   }
 
   String _formatUpdateTime(DateTime time) {

--- a/fabushi/test/unit/leaderboard_social_privacy_test.dart
+++ b/fabushi/test/unit/leaderboard_social_privacy_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:global_dharma_sharing/models/leaderboard_model.dart';
+import 'package:global_dharma_sharing/screens/leaderboard_screen.dart';
 import 'package:global_dharma_sharing/widgets/follow_button.dart';
 import 'package:global_dharma_sharing/widgets/leaderboard_user_detail_sheet.dart';
 
@@ -58,6 +59,15 @@ void main() {
       expect(entry.canShowPracticeName, isFalse);
       expect(entry.canShowDuration, isFalse);
       expect(entry.canShowChantCount, isFalse);
+    });
+  });
+
+  group('Leaderboard byte formatting', () {
+    test('compacts decimal transfer units for leaderboard display', () {
+      expect(formatLeaderboardBytes(999), '999 B');
+      expect(formatLeaderboardBytes(1530), '1.5 KB');
+      expect(formatLeaderboardBytes(2000 * 1000 * 1000), '2 GB');
+      expect(formatLeaderboardBytes(2000 * 1000 * 1000 * 1000), '2 TB');
     });
   });
 


### PR DESCRIPTION
## 为什么改
全球排行榜里的数据量现在按 `1024` 进制显示 `B/KB/MB/GB`，在大数值下会显得偏长，也不符合用户希望的“`2000g -> 2t`，依此类推”的直觉压缩展示。

## 改了什么
1. 把全球布施排行榜的数据量格式化提成可复用函数。
2. 展示逻辑改成 `1000` 进制压缩，支持从 `B` 一直到 `TB/PB`。
3. 自动去掉无意义的小数尾巴，比如 `2.0 TB` 会显示为 `2 TB`。
4. 补了一条单元测试，锁住 `2000 GB -> 2 TB` 这类展示结果。

## 如何验证
1. 打开全球布施排行榜，确认大额数据量会按更紧凑的单位显示。
2. 重点确认 `2000 * 1000^3 bytes` 对应展示为 `2 TB`。
3. 运行 Flutter 单测，确认 `leaderboard_social_privacy_test.dart` 通过。

## 预防复发
以后如果排行榜展示口径再调整，测试会先提示单位压缩规则发生了变化。