### PR TITLE
ci: exclude stale llama gitlink from native smoke checkout

### DIFF
--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -71,6 +71,8 @@ jobs:
             /fabushi/**
             !/fabushi/assets/built_in/**
             !/fabushi/web/assets/built_in/**
+            !/fabushi/native_libs/llama.cpp
+            !/fabushi/native_libs/llama.cpp/**
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -120,6 +122,8 @@ jobs:
             /fabushi/**
             !/fabushi/assets/built_in/**
             !/fabushi/web/assets/built_in/**
+            !/fabushi/native_libs/llama.cpp
+            !/fabushi/native_libs/llama.cpp/**
             /.github/scripts/**
 
       - name: Set up Java
@@ -188,6 +192,8 @@ jobs:
             /fabushi/**
             !/fabushi/assets/built_in/**
             !/fabushi/web/assets/built_in/**
+            !/fabushi/native_libs/llama.cpp
+            !/fabushi/native_libs/llama.cpp/**
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -62,6 +62,7 @@ jobs:
         working-directory: fabushi
     steps:
       - name: Checkout Android source
+        continue-on-error: true
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-source.outputs.source_sha }}
@@ -119,6 +120,7 @@ jobs:
         working-directory: fabushi
     steps:
       - name: Checkout Android source and native test helper
+        continue-on-error: true
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-source.outputs.source_sha }}
@@ -195,6 +197,7 @@ jobs:
         working-directory: fabushi
     steps:
       - name: Checkout iOS source
+        continue-on-error: true
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-source.outputs.source_sha }}

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -74,6 +74,12 @@ jobs:
             !/fabushi/native_libs/llama.cpp
             !/fabushi/native_libs/llama.cpp/**
 
+      - name: Seed stale llama gitlink metadata for checkout cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config --local submodule.fabushi/native_libs/llama.cpp.url https://github.com/ggerganov/llama.cpp.git
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
@@ -125,6 +131,12 @@ jobs:
             !/fabushi/native_libs/llama.cpp
             !/fabushi/native_libs/llama.cpp/**
             /.github/scripts/**
+
+      - name: Seed stale llama gitlink metadata for checkout cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config --local submodule.fabushi/native_libs/llama.cpp.url https://github.com/ggerganov/llama.cpp.git
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -194,6 +206,12 @@ jobs:
             !/fabushi/web/assets/built_in/**
             !/fabushi/native_libs/llama.cpp
             !/fabushi/native_libs/llama.cpp/**
+
+      - name: Seed stale llama gitlink metadata for checkout cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config --local submodule.fabushi/native_libs/llama.cpp.url https://github.com/ggerganov/llama.cpp.git
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Why
`Native smoke` 目前的主失败点不是 Android / iOS 原生构建本身，而是 `actions/checkout` 在 post-job cleanup 阶段把仓库里残留的 `fabushi/native_libs/llama.cpp` gitlink 当成子模块处理，随后因为仓库没有受管 `.gitmodules` 而报：

```text
fatal: No url found for submodule path 'fabushi/native_libs/llama.cpp' in .gitmodules
```

这会让 workflow 在真正进入 Flutter / Gradle / Xcode smoke 之前就被 cleanup 假红拦住。

## What changed
- 在 `native-smoke.yml` 的三个 checkout 场景里继续显式排除 `fabushi/native_libs/llama.cpp`
- 为这条陈旧 gitlink 注入本地 `submodule.*.url` 元数据，避免 checkout cleanup 因缺失 `.gitmodules` 直接崩掉
- 将相关 checkout 标成 `continue-on-error: true`，让 workflow 继续进入真实 native build；如果源码真的没拉下来，后续构建步骤会自然失败并暴露真实红灯

## Expected result
- `Native smoke` 不再被 `llama.cpp` cleanup 假红提前截断
- workflow 会继续执行 Android / iOS smoke，本次检查重新回到“看真实构建结果”而不是“卡在 checkout 清理”

## Notes
- 这条修复只处理 checkout/post-job cleanup 噪音，不改应用代码
- 若后续要正式把 `llama.cpp` 作为受管子模块恢复，仍应补齐 `.gitmodules` 与明确的拉取策略