### PR TITLE
docs: add failure snapshot closure governance

### DIFF
--- a/docs/release-evidence.md
+++ b/docs/release-evidence.md
@@ -73,10 +73,44 @@ Fabushi 当前对 issue 的完成标准不是“代码 merged 就算结束”，
 
 如果目标 release 没有 `TESTFLIGHT_UPLOAD_STATUS.txt` 资产，默认按“发布证据不完整”处理，而不是默认当作成功。
 
+## 自动 failure snapshot 收口规则
+
+自动生成的 `ci-failure`、`deployment-failure`、`release-failure` issue 默认应视为“某一时刻的失败快照”，而不是永久 backlog。主控巡检时要优先保留当前真正还在阻塞的最新样本，把已经被后续结果覆盖的旧快照及时收口。
+
+### 什么时候可以关闭旧快照
+
+满足以下任一组合时，可以把旧 failure snapshot 关闭：
+
+1. 对应修复 PR 已 merge，且后续更晚的主线运行已经明确进入新的失败阶段
+2. 后续主线运行已经越过该 issue 记录的失败步骤，说明这张旧快照不再代表当前阻塞点
+3. 同一失败家族已经有更新、更贴近当前主线状态的 open 跟踪位
+
+### 关闭前要补什么说明
+
+关闭这类旧快照前，默认要在 issue 里写清楚：
+
+- 它被哪条更晚的 mainline 结果或哪张更新 issue 覆盖
+- 当前真正保留的活跃跟踪位是哪一个
+- 为什么这里不再应该继续占用 open blocker 视图
+
+### 什么情况下不能提前关闭
+
+出现以下任一情况时，不应提前收口：
+
+- 还没有晚于修复 merge 时间的新外部运行证据
+- 最新主线结果仍卡在同一个失败步骤，没有出现“向前推进”的信号
+- 当前没有更新的 active issue 承接同一失败家族
+- 发布 / Release / TestFlight 主链仍未形成新的可验证结果
+
+### 为什么要单独写这条规则
+
+如果不把“失败快照”和“当前 blocker”分开管理，open issue 列表会长期混着历史噪音与真实阻塞，导致后续主控在等待窗口里重复花时间清单式复盘，而不是继续推进当前主线。
+
 ## 判定纪律
 
 - 不要只因为 PR merged 就关闭真实用户 issue
 - 不要只因为某条 workflow success 就跳过 release / TestFlight 证据
+- 不要把自动生成的 failure snapshot 全都长期留在 open 列表里；要持续把 blocker 视图收敛到当前真正活跃的少数事项
 - 不要使用“今天”“刚刚”“最新”这类相对时间代替 UTC 绝对时间
 - 如果记忆、issue 评论或运行上下文里的旧版本号和当前 latest release 不一致，先重新以公开 release 证据为准，再继续判断
 
@@ -89,4 +123,4 @@ Fabushi 当前对 issue 的完成标准不是“代码 merged 就算结束”，
 - `docs/release-controller.md`
 - GitHub Releases 页面及其资产
 
-这份文档是 `docs/release-controller.md` 的补充说明，重点不是重复发布流程本身，而是把“如何读取发布覆盖证据”这件事单独讲清楚，减少后续主控巡检继续误判入口。
+这份文档是 `docs/release-controller.md` 的补充说明，重点不是重复发布流程本身，而是把“如何读取发布覆盖证据”和“如何收口自动失败快照”这两件事单独讲清楚，减少后续主控巡检继续误判入口。


### PR DESCRIPTION
## Why
当前主控持续交付流程里，又坐实了一条长期有效的治理规则：自动生成的 `ci-failure`、`deployment-failure`、`release-failure` issue 本质上是 failure snapshot，而不是永久 backlog。如果不把“历史快照”和“当前 blocker”分开管理，open issue 列表会不断堆积旧告警，后续 scheduled run 会反复花时间清单式复盘，而不是继续推进真正还在阻塞的主线事项。

## What changed
- 更新 `docs/release-evidence.md`
- 补充“自动 failure snapshot 收口规则”章节
- 明确旧快照何时可以关闭、关闭前需要写清哪些覆盖关系、什么情况下不能提前关闭
- 把这条规则纳入发布证据与 issue 闭环判断的一部分

## Why now
- 本轮已经实际收口了一批被后续主线结果覆盖的旧 `deployment-failure` / `ci-failure` issue
- 如果这条规则只留在当前上下文和 memory 里，后续轮次还会重复误判、重复清理
- 把它写回仓库后，后续主控、人工巡检和 PR 审阅都可以使用同一套判断标准

## Validation
- 对照本轮已收口的旧 failure snapshot，确认文档里的“可关闭 / 不可关闭”条件与实际处理一致
- 只修改文档，不改生产代码和 workflow 行为