### PR TITLE
fix: verify meditation route JWTs before legacy handler handoff

### DIFF
--- a/fabushi/web/src/routes/meditation-routes.js
+++ b/fabushi/web/src/routes/meditation-routes.js
@@ -15,6 +15,7 @@ import {
   handleReviewMeditationGroupJoin,
   handleSyncRecord,
 } from '../handlers/meditation.js';
+import { verifyToken } from '../../auth-utils.js';
 import { generateSnowflakeUserId as generateSnowflakeGroupId } from '../services/database.js';
 import {
   GROUP_NO_MAX_LENGTH,
@@ -42,31 +43,66 @@ async function resolveUserIdByUsername(db, username) {
   }
 }
 
-async function authenticateRouteUser(request, db = null) {
+function buildLegacyMeditationToken({ username, userId }) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({
+    ...(userId !== undefined && userId !== null ? { userId } : {}),
+    username,
+  }));
+  return `${header}.${payload}.legacy`;
+}
+
+function cloneRequestWithAuthToken(request, token) {
+  const headers = new Headers(request.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+  });
+}
+
+async function authenticateRouteUser(request, env, db = null) {
   const authHeader = request.headers.get('Authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return { error: '未授权访问', status: 401 };
   }
 
   const token = authHeader.substring(7);
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) {
-      return { error: 'Token格式无效', status: 401 };
-    }
-
-    const payload = JSON.parse(atob(parts[1]));
-    const username = payload.username || payload.sub;
-    if (!username) {
-      return { error: '无法获取用户信息', status: 401 };
-    }
-
-    const tokenUserId = payload.userId ?? payload.id ?? null;
-    const userId = tokenUserId ?? (db ? await resolveUserIdByUsername(db, username) : null);
-    return { username, userId };
-  } catch (_) {
-    return { error: 'Token解析失败', status: 401 };
+  const payload = await verifyToken(token, env);
+  if (!payload) {
+    return { error: '认证失败', status: 401 };
   }
+
+  const username = payload.username || payload.sub;
+  if (!username) {
+    return { error: '无法获取用户信息', status: 401 };
+  }
+
+  const tokenUserId = payload.userId ?? payload.id ?? null;
+  const userId = tokenUserId ?? (db ? await resolveUserIdByUsername(db, username) : null);
+  return { username, userId };
+}
+
+async function prepareLegacyMeditationRequest(request, env, db) {
+  const auth = await authenticateRouteUser(request, env, db);
+  if (auth.error) {
+    return auth;
+  }
+
+  return {
+    auth,
+    request: cloneRequestWithAuthToken(request, buildLegacyMeditationToken(auth)),
+  };
+}
+
+async function routeWithVerifiedLegacyAuth(handler, request, env, db) {
+  const prepared = await prepareLegacyMeditationRequest(request, env, db);
+  if (prepared.error) {
+    return jsonResponse({ success: false, error: prepared.error }, prepared.status);
+  }
+
+  return await handler(prepared.request, env, db);
 }
 
 function isMissingUserIdColumnError(error) {
@@ -254,8 +290,8 @@ async function withVisibleGroupNumbers(response, db, options = {}) {
   return jsonResponse(nextPayload, response.status);
 }
 
-async function handleCreateMeditationGroupWithGeneratedIds(request, db) {
-  const auth = await authenticateRouteUser(request, db);
+async function handleCreateMeditationGroupWithGeneratedIds(request, env, db) {
+  const auth = await authenticateRouteUser(request, env, db);
   if (auth.error) {
     return jsonResponse({ success: false, error: auth.error }, auth.status);
   }
@@ -339,7 +375,7 @@ async function handleCreateMeditationGroupWithGeneratedIds(request, db) {
 }
 
 async function handleJoinMeditationGroupWithStableUserId(request, env, db) {
-  const auth = await authenticateRouteUser(request, db);
+  const auth = await authenticateRouteUser(request, env, db);
   if (auth.error) {
     return jsonResponse({ success: false, error: auth.error }, auth.status);
   }
@@ -352,7 +388,11 @@ async function handleJoinMeditationGroupWithStableUserId(request, env, db) {
     }
 
     if (!auth.userId) {
-      return await handleJoinMeditationGroup(await cloneRequestWithJsonBody(request, body), env, db);
+      const prepared = await prepareLegacyMeditationRequest(await cloneRequestWithJsonBody(request, body), env, db);
+      if (prepared.error) {
+        return jsonResponse({ success: false, error: prepared.error }, prepared.status);
+      }
+      return await handleJoinMeditationGroup(prepared.request, env, db);
     }
 
     let group;
@@ -366,7 +406,11 @@ async function handleJoinMeditationGroupWithStableUserId(request, env, db) {
       if (!isMissingUserIdColumnError(error)) {
         throw error;
       }
-      return await handleJoinMeditationGroup(await cloneRequestWithJsonBody(request, body), env, db);
+      const prepared = await prepareLegacyMeditationRequest(await cloneRequestWithJsonBody(request, body), env, db);
+      if (prepared.error) {
+        return jsonResponse({ success: false, error: prepared.error }, prepared.status);
+      }
+      return await handleJoinMeditationGroup(prepared.request, env, db);
     }
 
     if (!group) {
@@ -412,7 +456,11 @@ async function handleJoinMeditationGroupWithStableUserId(request, env, db) {
     });
   } catch (e) {
     if (isMissingUserIdColumnError(e)) {
-      return await handleJoinMeditationGroup(request, env, db);
+      const prepared = await prepareLegacyMeditationRequest(request, env, db);
+      if (prepared.error) {
+        return jsonResponse({ success: false, error: prepared.error }, prepared.status);
+      }
+      return await handleJoinMeditationGroup(prepared.request, env, db);
     }
     console.error('加入共修小组失败:', e);
     return jsonResponse({ success: false, error: '加入共修小组失败' }, 500);
@@ -421,42 +469,42 @@ async function handleJoinMeditationGroupWithStableUserId(request, env, db) {
 
 export async function routeMeditationRequest({ pathname, method, request, env, db }) {
   if (pathname === '/api/meditation/record' && method === 'POST') {
-    return await handleSyncRecord(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleSyncRecord, request, env, db);
   }
   if (pathname === '/api/meditation/records' && method === 'GET') {
-    return await handleGetRecords(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleGetRecords, request, env, db);
   }
   if (pathname === '/api/meditation/records' && method === 'PUT') {
-    return await handleUpdateRecord(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleUpdateRecord, request, env, db);
   }
   if (pathname === '/api/meditation/records' && method === 'DELETE') {
-    return await handleDeleteRecord(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleDeleteRecord, request, env, db);
   }
   if (pathname === '/api/meditation/stats' && method === 'GET') {
-    return await handleGetStats(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleGetStats, request, env, db);
   }
   if (pathname === '/api/meditation/weekly' && method === 'GET') {
-    return await handleGetWeeklyStats(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleGetWeeklyStats, request, env, db);
   }
   if (pathname === '/api/meditation/monthly' && method === 'GET') {
-    return await handleGetMonthlyStats(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleGetMonthlyStats, request, env, db);
   }
   if (pathname === '/api/meditation/goal' && method === 'POST') {
-    return await handleSetGoal(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleSetGoal, request, env, db);
   }
   if (pathname === '/api/meditation/goal' && method === 'GET') {
-    return await handleGetGoals(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleGetGoals, request, env, db);
   }
   if (pathname === '/api/meditation/settings' && (method === 'GET' || method === 'POST')) {
-    return await handleMeditationSettings(request, env, db);
+    return await routeWithVerifiedLegacyAuth(handleMeditationSettings, request, env, db);
   }
   if (pathname === '/api/meditation/groups' && method === 'GET') {
     const nextRequest = await rewriteNumericGroupQueryToInternalId(request, db);
-    const response = await handleGetMeditationGroups(nextRequest, env, db);
+    const response = await routeWithVerifiedLegacyAuth(handleGetMeditationGroups, nextRequest, env, db);
     return await withVisibleGroupNumbers(response, db);
   }
   if (pathname === '/api/meditation/groups' && method === 'POST') {
-    return await handleCreateMeditationGroupWithGeneratedIds(request, db);
+    return await handleCreateMeditationGroupWithGeneratedIds(request, env, db);
   }
   if (pathname === '/api/meditation/groups/join' && method === 'POST') {
     const { request: nextRequest } = await rewriteGroupBodyRequest(request, db);
@@ -464,12 +512,12 @@ export async function routeMeditationRequest({ pathname, method, request, env, d
   }
   if (pathname === '/api/meditation/groups/detail' && method === 'GET') {
     const nextRequest = await rewriteGroupDetailRequest(request, db);
-    const response = await handleGetMeditationGroupDetail(nextRequest, env, db);
+    const response = await routeWithVerifiedLegacyAuth(handleGetMeditationGroupDetail, nextRequest, env, db);
     return await withVisibleGroupNumbers(response, db);
   }
   if (pathname === '/api/meditation/groups/review' && method === 'POST') {
     const { request: nextRequest } = await rewriteGroupBodyRequest(request, db);
-    return await handleReviewMeditationGroupJoin(nextRequest, env, db);
+    return await routeWithVerifiedLegacyAuth(handleReviewMeditationGroupJoin, nextRequest, env, db);
   }
 
   return null;

--- a/fabushi/web/tests/meditation-route-auth.test.js
+++ b/fabushi/web/tests/meditation-route-auth.test.js
@@ -1,0 +1,156 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { generateToken } from '../auth-utils.js';
+import { routeMeditationRequest } from '../src/routes/meditation-routes.js';
+
+function createDbMock() {
+  const groups = new Map();
+  const members = new Map();
+
+  const keyFor = (groupId, username) => `${groupId}:${username}`;
+
+  const db = {
+    prepare(sql) {
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+
+      return {
+        bind(...params) {
+          return {
+            async first() {
+              if (normalizedSql.startsWith('SELECT id FROM users WHERE username = ?')) {
+                return params[0] === 'group_owner' ? { id: 21 } : null;
+              }
+
+              if (normalizedSql.startsWith('SELECT owner_username FROM meditation_groups WHERE id = ?')) {
+                const group = groups.get(params[0]);
+                return group ? { owner_username: group.owner_username } : null;
+              }
+
+              if (normalizedSql.startsWith('SELECT SUM(COALESCE(duration, 0)) as duration FROM meditation_records WHERE username = ? AND record_date = ?')) {
+                return { duration: 0 };
+              }
+
+              return null;
+            },
+            async all() {
+              if (normalizedSql.startsWith('SELECT id FROM meditation_groups WHERE owner_username = ?')) {
+                return { results: [] };
+              }
+
+              if (normalizedSql.startsWith('SELECT m.group_id FROM meditation_group_members m JOIN meditation_groups g ON g.id = m.group_id WHERE m.username = ? AND m.status = \'active\'')) {
+                return { results: [] };
+              }
+
+              if (normalizedSql.includes('FROM meditation_groups g LEFT JOIN users owner ON owner.username = g.owner_username LEFT JOIN meditation_group_members my ON my.group_id = g.id AND my.username = ?')) {
+                const [today, username, ...rest] = params;
+                void today;
+                const limit = rest.at(-1);
+                const searchTerms = rest.slice(0, -1).filter((value) => typeof value === 'string');
+                const trimmedQuery = searchTerms[0]?.replaceAll('%', '').trim().toLowerCase() ?? '';
+                const rows = Array.from(groups.values())
+                  .filter((group) => {
+                    if (!trimmedQuery) return true;
+                    return [group.name, group.description, group.owner_username, group.owner_nickname || '']
+                      .some((field) => field.toLowerCase().includes(trimmedQuery));
+                  })
+                  .slice(0, limit);
+
+                return {
+                  results: rows.map((group) => {
+                    const member = members.get(keyFor(group.id, username));
+                    return {
+                      ...group,
+                      owner_nickname: group.owner_nickname || null,
+                      my_status: member?.status ?? null,
+                      my_role: member?.role ?? null,
+                      my_warning_message: member?.warning_message ?? null,
+                      pending_count: 0,
+                      member_count: member ? 1 : 0,
+                      total_duration: 0,
+                      today_duration: 0,
+                    };
+                  }),
+                };
+              }
+
+              return { results: [] };
+            },
+            async run() {
+              return undefined;
+            },
+          };
+        },
+      };
+    },
+  };
+
+  groups.set(21, {
+    id: 21,
+    owner_username: 'group_owner',
+    owner_nickname: '禅修发起人',
+    name: '晨光共修',
+    description: '每天一起完成早课',
+    require_approval: 1,
+    daily_goal_minutes: 20,
+    cumulative_miss_limit: 5,
+    consecutive_miss_limit: 2,
+    created_at: '2026-05-05T00:00:00Z',
+  });
+
+  members.set(keyFor(21, 'group_owner'), {
+    id: 1,
+    group_id: 21,
+    username: 'group_owner',
+    role: 'owner',
+    status: 'active',
+    warning_message: null,
+  });
+
+  return db;
+}
+
+test('routeMeditationRequest accepts signed base64url JWTs on meditation group routes', async () => {
+  const env = { JWT_SECRET: 'test-secret' };
+  const db = createDbMock();
+  const token = await generateToken({ id: 21, username: 'group_owner' }, env);
+
+  const response = await routeMeditationRequest({
+    pathname: '/api/meditation/groups',
+    method: 'GET',
+    request: new Request('https://flutter.ombhrum.com/api/meditation/groups?query=%E7%A6%85%E4%BF%AE%E5%8F%91%E8%B5%B7%E4%BA%BA', {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    env,
+    db,
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.groups.length, 1);
+  assert.equal(payload.data.groups[0].ownerName, '禅修发起人');
+  assert.equal(payload.data.groups[0].name, '晨光共修');
+});
+
+test('routeMeditationRequest rejects tampered meditation JWTs before legacy handoff', async () => {
+  const env = { JWT_SECRET: 'test-secret' };
+  const db = createDbMock();
+  const validToken = await generateToken({ id: 21, username: 'group_owner' }, env);
+  const tamperedToken = `${validToken.slice(0, -1)}${validToken.endsWith('a') ? 'b' : 'a'}`;
+
+  const response = await routeMeditationRequest({
+    pathname: '/api/meditation/groups',
+    method: 'GET',
+    request: new Request('https://flutter.ombhrum.com/api/meditation/groups?query=%E6%99%A8%E5%85%89', {
+      headers: { Authorization: `Bearer ${tamperedToken}` },
+    }),
+    env,
+    db,
+  });
+
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assert.equal(payload.success, false);
+  assert.equal(payload.error, '认证失败');
+});


### PR DESCRIPTION
## Why
`#252` 里提到的小组排行榜 401 还没有真正退出主线：`meditation` 相关路由最终还是会落到旧 handler 的本地 JWT parser，遇到带标准签名、base64url payload 的 token 时，容易在 `Token解析失败` 这里直接挡住后续查询。

## What changed
- 在 `fabushi/web/src/routes/meditation-routes.js` 里统一先用 `verifyToken()` 验签和验过期
- 对仍未迁出的 legacy meditation handlers，增加一层受控 handoff，把已验证的身份改写成它们当前能读懂的内部 payload，再继续复用现有 handler 逻辑
- 让 groups、records、stats、goals、settings 等 meditation 路由都走同一条已验签入口，而不是继续各自依赖旧 parser
- 新增 `fabushi/web/tests/meditation-route-auth.test.js`，覆盖“真实签名 token 可以通过”以及“篡改 token 会在 legacy handoff 前被拒绝”两条回归场景

## Why this step
- 当前仓库里 `meditation.js` 仍然很大，直接在一个小修复里同时重写整套 handler 认证路径，风险和 diff 都偏大
- 先把生产入口的认证边界统一到 route 层，可以立刻修掉 `#252` 的用户路径，同时不给其他 meditation 能力引入新的无验证入口
- 后续若继续拆分 handler，本次 route 层 guardrail 仍然保留价值

## Validation
- 新增 route 级回归测试，使用 `generateToken()` 生成的真实签名 JWT 走 `/api/meditation/groups`
- 新增 tampered token 用例，确认会在进入 legacy handler 前返回 `401 认证失败`
- 改动范围仅限 meditation route auth handoff 与对应测试，没有改动业务 SQL 或 UI