### PR TITLE
[codex] Preserve user number after auth refresh

### DIFF
--- a/fabushi/lib/models/auth_model.dart
+++ b/fabushi/lib/models/auth_model.dart
@@ -500,7 +500,7 @@ class AuthModel extends ChangeNotifier {
 
         _currentUser = User(
           username: userModel.username,
-          userNo: userModel.userNo,
+          userNo: userModel.userNo ?? _currentUser?.userNo,
           email: userModel.email ?? '',
           membershipType: userModel.membership.type,
           membershipExpiry: userModel.membership.expiresAt != null

--- a/fabushi/lib/services/auth_service.dart
+++ b/fabushi/lib/services/auth_service.dart
@@ -58,9 +58,12 @@ class AuthService {
     required String requestedIdentifier,
   }) {
     final rawUser = data['user'];
-    final user = rawUser is Map ? Map<String, dynamic>.from(rawUser) : <String, dynamic>{};
+    final user = rawUser is Map
+        ? Map<String, dynamic>.from(rawUser)
+        : <String, dynamic>{};
     final resolvedUsername =
-        (user['username'] ?? data['username'] ?? requestedIdentifier).toString();
+        (user['username'] ?? data['username'] ?? requestedIdentifier)
+            .toString();
     final resolvedEmail =
         (user['email'] as String?) ??
         (resolvedUsername.contains('@') ? resolvedUsername : '');
@@ -68,14 +71,23 @@ class AuthService {
 
     return UserModel(
       username: resolvedUsername,
-      userNo: _instance._parseOptionalInt(user['userNo'] ?? user['user_no'] ?? user['id'] ?? data['userNo'] ?? data['userId']),
+      userNo: _instance._parseOptionalInt(
+        user['userNo'] ??
+            user['user_no'] ??
+            user['id'] ??
+            data['userNo'] ??
+            data['userId'],
+      ),
       email: resolvedEmail,
       emailVerified:
           user['emailVerified'] as bool? ?? user['email_verified'] == true,
       createdAt:
-          (user['createdAt'] ?? user['created_at'] ?? DateTime.now().toIso8601String())
+          (user['createdAt'] ??
+                  user['created_at'] ??
+                  DateTime.now().toIso8601String())
               .toString(),
-      usernameChangedAt: (user['usernameChangedAt'] ?? user['username_changed_at']) as String?,
+      usernameChangedAt:
+          (user['usernameChangedAt'] ?? user['username_changed_at']) as String?,
       wechatOpenid: user['wechatOpenid'] as String?,
       wechatNickname: user['wechatNickname'] as String?,
       wechatHeadimgurl: user['wechatHeadimgurl'] as String?,
@@ -94,6 +106,166 @@ class AuthService {
       membership: membershipJson is Map
           ? MembershipInfo.fromJson(Map<String, dynamic>.from(membershipJson))
           : MembershipInfo(type: 'expired', isActive: false),
+    );
+  }
+
+  static String? _optionalString(dynamic value) {
+    if (value == null) return null;
+    return value.toString();
+  }
+
+  static bool _parseBool(dynamic value, {required bool fallback}) {
+    if (value == null) return fallback;
+    if (value is bool) return value;
+    if (value is num) return value != 0;
+    final normalized = value.toString().trim().toLowerCase();
+    if (normalized == 'true' || normalized == '1') return true;
+    if (normalized == 'false' || normalized == '0') return false;
+    return fallback;
+  }
+
+  static bool _isMembershipActive(String type, String? expiresAt) {
+    if (type == 'expired' || expiresAt == null || expiresAt.isEmpty) {
+      return false;
+    }
+
+    try {
+      final expiryDate = DateTime.parse(expiresAt);
+      return expiryDate.isAfter(DateTime.now());
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static Map<String, dynamic>? _optionalMap(dynamic value) {
+    if (value is Map) {
+      return Map<String, dynamic>.from(value);
+    }
+    return null;
+  }
+
+  static MembershipInfo _buildMembershipInfo(
+    Map<String, dynamic> data, {
+    MembershipInfo? fallbackMembership,
+  }) {
+    final membershipJson = _optionalMap(data['membership']);
+    final membershipSource = membershipJson ?? data;
+    final type =
+        _optionalString(membershipSource['type'] ?? data['membershipType']) ??
+        fallbackMembership?.type ??
+        'expired';
+    final expiresAt =
+        _optionalString(
+          membershipSource['expiresAt'] ??
+              membershipSource['expires_at'] ??
+              data['membershipExpiresAt'] ??
+              data['membership_expires_at'],
+        ) ??
+        fallbackMembership?.expiresAt;
+    final explicitIsActive =
+        membershipSource['isActive'] ?? membershipSource['is_active'];
+    final computedIsActive = _isMembershipActive(type, expiresAt);
+
+    return MembershipInfo(
+      type: type,
+      isActive: _parseBool(explicitIsActive, fallback: computedIsActive),
+      expiresAt: expiresAt,
+      daysRemaining:
+          _instance._parseOptionalInt(
+            membershipSource['daysRemaining'] ??
+                membershipSource['days_remaining'],
+          ) ??
+          fallbackMembership?.daysRemaining,
+      subscriptionId:
+          _optionalString(
+            membershipSource['subscriptionId'] ??
+                membershipSource['subscription_id'],
+          ) ??
+          fallbackMembership?.subscriptionId,
+      paymentMethod:
+          _optionalString(
+            membershipSource['paymentMethod'] ??
+                membershipSource['payment_method'],
+          ) ??
+          fallbackMembership?.paymentMethod,
+    );
+  }
+
+  static UserModel buildRefreshedUser(
+    Map<String, dynamic> data, {
+    UserModel? fallbackUser,
+  }) {
+    final membership = _buildMembershipInfo(
+      data,
+      fallbackMembership: fallbackUser?.membership,
+    );
+
+    return UserModel(
+      username:
+          _optionalString(data['username']) ?? fallbackUser?.username ?? '',
+      userNo:
+          _instance._parseOptionalInt(
+            data['userNo'] ??
+                data['user_no'] ??
+                data['id'] ??
+                data['userId'] ??
+                data['user_id'],
+          ) ??
+          fallbackUser?.userNo,
+      email: _optionalString(data['email']) ?? fallbackUser?.email ?? '',
+      emailVerified: _parseBool(
+        data['emailVerified'] ?? data['email_verified'],
+        fallback: fallbackUser?.emailVerified ?? true,
+      ),
+      createdAt:
+          _optionalString(data['createdAt'] ?? data['created_at']) ??
+          fallbackUser?.createdAt ??
+          DateTime.now().toIso8601String(),
+      usernameChangedAt:
+          _optionalString(
+            data['usernameChangedAt'] ?? data['username_changed_at'],
+          ) ??
+          fallbackUser?.usernameChangedAt,
+      wechatOpenid:
+          _optionalString(data['wechatOpenid'] ?? data['wechat_openid']) ??
+          fallbackUser?.wechatOpenid,
+      wechatNickname:
+          _optionalString(data['wechatNickname'] ?? data['wechat_nickname']) ??
+          fallbackUser?.wechatNickname,
+      wechatHeadimgurl:
+          _optionalString(
+            data['wechatHeadimgurl'] ?? data['wechat_headimgurl'],
+          ) ??
+          fallbackUser?.wechatHeadimgurl,
+      wechatBoundAt:
+          _optionalString(data['wechatBoundAt'] ?? data['wechat_bound_at']) ??
+          fallbackUser?.wechatBoundAt,
+      alipayUserId:
+          _optionalString(data['alipayUserId'] ?? data['alipay_user_id']) ??
+          fallbackUser?.alipayUserId,
+      alipayNickname:
+          _optionalString(data['alipayNickname'] ?? data['alipay_nickname']) ??
+          fallbackUser?.alipayNickname,
+      alipayAvatar:
+          _optionalString(data['alipayAvatar'] ?? data['alipay_avatar']) ??
+          fallbackUser?.alipayAvatar,
+      alipayBoundAt:
+          _optionalString(data['alipayBoundAt'] ?? data['alipay_bound_at']) ??
+          fallbackUser?.alipayBoundAt,
+      nickname: _optionalString(data['nickname']) ?? fallbackUser?.nickname,
+      avatar:
+          _optionalString(data['avatar'] ?? data['avatarUrl']) ??
+          fallbackUser?.avatar,
+      phoneNumber:
+          _optionalString(data['phoneNumber'] ?? data['phone_number']) ??
+          fallbackUser?.phoneNumber,
+      firebaseUid:
+          _optionalString(data['firebaseUid'] ?? data['firebase_uid']) ??
+          fallbackUser?.firebaseUid,
+      mainPractice:
+          _optionalMap(data['mainPractice'] ?? data['main_practice']) ??
+          fallbackUser?.mainPractice,
+      membership: membership,
     );
   }
 
@@ -186,10 +358,7 @@ class AuthService {
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
         final token = data['token'] as String;
-        final userInfo = buildLoginUser(
-          data,
-          requestedIdentifier: username,
-        );
+        final userInfo = buildLoginUser(data, requestedIdentifier: username);
 
         if (data.containsKey('user') && data['user'] != null) {
           print('使用登录API返回的用户信息，并允许后续资料刷新失败时继续登录');
@@ -338,51 +507,29 @@ class AuthService {
     }
 
     try {
+      final fallbackUser = _currentUser;
       final response = await HttpService.get(
-        AppConfig.adminCheckStatusUrl,
+        AppConfig.userInfoUrl,
         useAuth: true,
       );
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
+        final decoded = jsonDecode(response.body);
+        if (decoded is! Map) {
+          throw Exception('用户信息响应格式不正确');
+        }
+        final data = Map<String, dynamic>.from(decoded);
         print('📥 获取到的用户数据: $data');
 
-        final membershipExpiresAt = data['membershipExpiresAt'];
-        final membershipType = data['membershipType'] ?? 'expired';
-
-        bool isActive = false;
-        if (membershipExpiresAt != null && membershipType != 'expired') {
-          try {
-            final expiryDate = DateTime.parse(membershipExpiresAt);
-            isActive = expiryDate.isAfter(DateTime.now());
-            print('📅 会员到期时间: $expiryDate, 是否激活: $isActive');
-          } catch (e) {
-            print('⚠️ 解析会员到期时间失败: $e');
-          }
+        final userInfo = buildRefreshedUser(data, fallbackUser: fallbackUser);
+        final membershipExpiresAt = userInfo.membership.expiresAt;
+        if (membershipExpiresAt != null) {
+          print(
+            '📅 会员到期时间: $membershipExpiresAt, 是否激活: ${userInfo.membership.isActive}',
+          );
         }
 
-        return UserModel(
-          username: data['username'] ?? '',
-          userNo: _parseOptionalInt(data['userNo'] ?? data['user_no'] ?? data['id'] ?? data['userId']),
-          email: data['email'] ?? '',
-          emailVerified: true,
-          createdAt: DateTime.now().toIso8601String(),
-          usernameChangedAt: data['usernameChangedAt'] ?? data['username_changed_at'],
-          nickname: data['nickname'],
-          avatar: data['avatar'],
-          phoneNumber: data['phoneNumber'] ?? data['phone_number'],
-          alipayUserId: data['alipayUserId'] ?? data['alipay_user_id'],
-          alipayNickname: data['alipayNickname'] ?? data['alipay_nickname'],
-          alipayAvatar: data['alipayAvatar'] ?? data['alipay_avatar'],
-          mainPractice: data['mainPractice'] is Map
-              ? Map<String, dynamic>.from(data['mainPractice'] as Map)
-              : null,
-          membership: MembershipInfo(
-            type: membershipType,
-            isActive: isActive,
-            expiresAt: membershipExpiresAt,
-          ),
-        );
+        return userInfo;
       } else {
         throw Exception(
           '获取用户信息失败: ${HttpService.getErrorMessage(response)} (HTTP ${response.statusCode})',

--- a/fabushi/test/services/auth_service_test.dart
+++ b/fabushi/test/services/auth_service_test.dart
@@ -4,45 +4,111 @@ import 'package:global_dharma_sharing/services/auth_service.dart';
 
 void main() {
   group('AuthService.buildLoginUser', () {
-    test('tolerates partial user payloads from a successful login response', () {
-      final user = AuthService.buildLoginUser(
-        {
+    test(
+      'tolerates partial user payloads from a successful login response',
+      () {
+        final user = AuthService.buildLoginUser({
           'token': 'token-123',
           'username': 'android_fallback',
           'user': {
             'username': 'android_user',
             'nickname': '安卓用户',
             'phone_number': '+8613800000000',
-            'membership': {
-              'type': 'trial',
-              'isActive': true,
-            },
+            'membership': {'type': 'trial', 'isActive': true},
           },
-        },
-        requestedIdentifier: 'requested_name',
-      );
+        }, requestedIdentifier: 'requested_name');
 
-      expect(user.username, 'android_user');
-      expect(user.nickname, '安卓用户');
-      expect(user.phoneNumber, '+8613800000000');
-      expect(user.membership.type, 'trial');
-      expect(user.membership.isActive, isTrue);
-      expect(user.createdAt, isNotEmpty);
+        expect(user.username, 'android_user');
+        expect(user.nickname, '安卓用户');
+        expect(user.phoneNumber, '+8613800000000');
+        expect(user.membership.type, 'trial');
+        expect(user.membership.isActive, isTrue);
+        expect(user.createdAt, isNotEmpty);
+      },
+    );
+
+    test('preserves user number from successful login response', () {
+      final user = AuthService.buildLoginUser({
+        'token': 'token-789',
+        'user': {
+          'username': 'student_user',
+          'userNo': 618273941,
+          'email': 'student@example.com',
+        },
+      }, requestedIdentifier: 'student_user');
+
+      expect(user.username, 'student_user');
+      expect(user.userNo, 618273941);
+      expect(user.email, 'student@example.com');
     });
 
-    test('falls back to the requested identifier when login payload is minimal', () {
-      final user = AuthService.buildLoginUser(
-        {
+    test(
+      'falls back to the requested identifier when login payload is minimal',
+      () {
+        final user = AuthService.buildLoginUser({
           'token': 'token-456',
-        },
-        requestedIdentifier: 'fallback@example.com',
+        }, requestedIdentifier: 'fallback@example.com');
+
+        expect(user.username, 'fallback@example.com');
+        expect(user.email, 'fallback@example.com');
+        expect(user.membership, isA<MembershipInfo>());
+        expect(user.membership.type, 'expired');
+        expect(user.membership.isActive, isFalse);
+      },
+    );
+  });
+
+  group('AuthService.buildRefreshedUser', () {
+    test('parses user-info payload with user number and nested membership', () {
+      final user = AuthService.buildRefreshedUser({
+        'username': 'profile_user',
+        'userNo': 987654321,
+        'email': 'profile@example.com',
+        'emailVerified': true,
+        'nickname': '资料用户',
+        'avatar': 'https://example.com/avatar.png',
+        'phoneNumber': '+8613800000000',
+        'firebaseUid': 'firebase-uid',
+        'alipayUserId': 'alipay-uid',
+        'membership': {'type': 'paid', 'expiresAt': '2099-01-01T00:00:00.000Z'},
+      });
+
+      expect(user.username, 'profile_user');
+      expect(user.userNo, 987654321);
+      expect(user.nickname, '资料用户');
+      expect(user.avatar, 'https://example.com/avatar.png');
+      expect(user.phoneNumber, '+8613800000000');
+      expect(user.firebaseUid, 'firebase-uid');
+      expect(user.alipayUserId, 'alipay-uid');
+      expect(user.membership.type, 'paid');
+      expect(user.membership.expiresAt, '2099-01-01T00:00:00.000Z');
+      expect(user.membership.isActive, isTrue);
+    });
+
+    test('keeps fallback user number when refresh payload omits it', () {
+      final fallbackUser = UserModel(
+        username: 'existing_user',
+        userNo: 123456789,
+        email: 'old@example.com',
+        emailVerified: true,
+        createdAt: '2026-05-01T00:00:00.000Z',
+        membership: MembershipInfo(
+          type: 'trial',
+          isActive: true,
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        ),
       );
 
-      expect(user.username, 'fallback@example.com');
-      expect(user.email, 'fallback@example.com');
-      expect(user.membership, isA<MembershipInfo>());
-      expect(user.membership.type, 'expired');
-      expect(user.membership.isActive, isFalse);
+      final user = AuthService.buildRefreshedUser({
+        'username': 'existing_user',
+        'email': 'new@example.com',
+        'membership': {'type': 'paid', 'expiresAt': '2099-02-01T00:00:00.000Z'},
+      }, fallbackUser: fallbackUser);
+
+      expect(user.userNo, 123456789);
+      expect(user.email, 'new@example.com');
+      expect(user.membership.type, 'paid');
+      expect(user.membership.expiresAt, '2099-02-01T00:00:00.000Z');
     });
   });
 }


### PR DESCRIPTION
## Summary
- Refresh auth user info from `/api/auth/user-info` instead of the admin status endpoint.
- Parse refreshed user payloads through a shared helper that supports `userNo`, snake_case variants, third-party profile fields, and nested membership data.
- Preserve the existing user number when a refresh payload omits it so the 学号 display no longer flashes away after login.

## Validation
- `/opt/homebrew/bin/flutter test test/services/auth_service_test.dart` passed (`5/5`).
- `/opt/homebrew/bin/flutter analyze lib/services/auth_service.dart lib/models/auth_model.dart` ran, but the repo has existing warnings/lints (`avoid_print`, `unnecessary_cast`, `use_null_aware_elements`) so it exits non-zero.