### PR TITLE
ci: fix missing GH_TOKEN in sync beta state workflow

### DIFF
--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -305,6 +305,7 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # The file was generated in the previous workspace, need to recreate or fetch it


### PR DESCRIPTION
## Summary
The previous fix added a `gh release download` command, but `gh` requires the `GH_TOKEN` environment variable to authenticate with the GitHub API. This PR adds the missing `GH_TOKEN: ${{ github.token }}` environment variable to the `Copy state to public API and commit` step.

Fixes the error:
`gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.`

## Test plan
- [x] Run workflow manually to ensure it authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)