### PR TITLE
[codex] fix official site release sync

### DIFF
--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -305,6 +305,7 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # The file was generated in the previous workspace, need to recreate or fetch it

--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -289,6 +289,12 @@ jobs:
           rm -f "$upload_log"
           exit 1
 
+      - name: Copy generated file to a safe location before checkout
+        shell: bash
+        run: |
+          mkdir -p $RUNNER_TEMP/sync-beta-state
+          cp OFFICIAL_SITE_RELEASE_STATE.json $RUNNER_TEMP/sync-beta-state/
+
       - name: Push beta state to official site repo
         id: push_state
         if: steps.upload_state.outcome == 'success'
@@ -308,9 +314,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # The file was generated in the previous workspace, need to recreate or fetch it
-          # Since checkout wipes the workspace, we should fetch it from the release
-          gh release download "$RELEASE_TAG" --pattern OFFICIAL_SITE_RELEASE_STATE.json --repo ${{ github.repository }} --dir . || true
+          # First try to restore the file from the safe location
+          if [ -f $RUNNER_TEMP/sync-beta-state/OFFICIAL_SITE_RELEASE_STATE.json ]; then
+            cp $RUNNER_TEMP/sync-beta-state/OFFICIAL_SITE_RELEASE_STATE.json OFFICIAL_SITE_RELEASE_STATE.json
+            echo "Restored generated file from RUNNER_TEMP"
+          else
+            # Fallback to fetching it from the release (will fail if release is immutable and wasn't uploaded)
+            gh release download "$RELEASE_TAG" --pattern OFFICIAL_SITE_RELEASE_STATE.json --repo ${{ github.repository }} --dir . || true
+          fi
 
           if [ -f OFFICIAL_SITE_RELEASE_STATE.json ]; then
             mkdir -p frontend/apps/web/public/api
@@ -325,7 +336,8 @@ jobs:
             git commit -m "chore: sync beta release state for $RELEASE_TAG"
             git push origin main
           else
-            echo "::warning::OFFICIAL_SITE_RELEASE_STATE.json not found, skipping commit to official site repo"
+            echo "::error::OFFICIAL_SITE_RELEASE_STATE.json could not be restored or downloaded."
+            exit 1
           fi
 
       - name: Write summary

--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -320,12 +320,31 @@ jobs:
             echo "Restored generated file from RUNNER_TEMP"
           else
             # Fallback to fetching it from the release (will fail if release is immutable and wasn't uploaded)
-            gh release download "$RELEASE_TAG" --pattern OFFICIAL_SITE_RELEASE_STATE.json --repo ${{ github.repository }} --dir . || true
+            gh release download "$RELEASE_TAG" --pattern OFFICIAL_SITE_RELEASE_STATE.json --repo ${{ github.repository }} --dir .
           fi
 
           if [ -f OFFICIAL_SITE_RELEASE_STATE.json ]; then
             mkdir -p frontend/apps/web/public/api
-            cp OFFICIAL_SITE_RELEASE_STATE.json frontend/apps/web/public/api/releases.json
+            python3 - <<'PY'
+            import json
+            from pathlib import Path
+
+            source_path = Path("OFFICIAL_SITE_RELEASE_STATE.json")
+            target_path = Path("frontend/apps/web/public/api/releases.json")
+            state = json.loads(source_path.read_text(encoding="utf-8"))
+            channels = state.get("channels", [])
+            api_state = {
+                "betaChannels": [channel for channel in channels if channel.get("audience") == "beta"],
+                "stableChannels": [channel for channel in channels if channel.get("audience") == "stable"],
+                "screenshots": state.get("screenshots", {}),
+                "releases": state.get("releases", []),
+                "notes": state.get("notes", []),
+            }
+            target_path.write_text(
+                json.dumps(api_state, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            PY
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add frontend/apps/web/public/api/releases.json

--- a/fabushi/integration_test/store_screenshots_test.dart
+++ b/fabushi/integration_test/store_screenshots_test.dart
@@ -77,9 +77,4 @@ Future<void> _capture(
   }
 
   await binding.takeScreenshot(name);
-
-  if (Platform.isAndroid) {
-    await binding.revertFlutterImage();
-    await tester.pump();
-  }
 }

--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -1,7 +1,126 @@
 {
-  "betaChannels": [],
+  "betaChannels": [
+    {
+      "platform": "Android",
+      "audience": "beta",
+      "status": "Beta 自动同步",
+      "title": "Android Beta",
+      "description": "官网直接读取最新发布版本的 APK 安装包，安装包发布后这里会自动更新。",
+      "primaryLabel": "下载 Android Beta",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-148-mobile.01aa4666d6e6/fabushi-android-arm64-01aa4666d6e6.apk",
+      "version": "v1.0.0-148-mobile.01aa4666d6e6",
+      "publishedAt": "2026-05-14T00:47:16Z",
+      "updateSummary": [
+        "PR #359: feat(web): comprehensive UI/UX overhaul to world-class Bento grid design",
+        "Redesigned color tokens in `globals.css` with a tech & zen dark theme",
+        "Refactored `page.tsx` into a modern Bento Box layout grid",
+        "Integrated `framer-motion` for scroll reveal and stagger entrance animations",
+        "Created new `<BentoCard>` component with interactive spotlight hover effect",
+        "Upgraded the Hero section with 3D stacked floating screenshots (parallax hover)"
+      ],
+      "mirrorLinks": [
+        {
+          "label": "国内镜像 1",
+          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-148-mobile.01aa4666d6e6/fabushi-android-arm64-01aa4666d6e6.apk"
+        },
+        {
+          "label": "国内镜像 2",
+          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-148-mobile.01aa4666d6e6/fabushi-android-arm64-01aa4666d6e6.apk"
+        }
+      ],
+      "note": "国内访问较慢时，可以优先尝试镜像下载入口。",
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6"
+    },
+    {
+      "platform": "iOS",
+      "audience": "beta",
+      "status": "TestFlight 已开放",
+      "title": "iOS TestFlight Beta",
+      "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
+      "primaryLabel": "查看 iOS 发布状态",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6",
+      "version": "148",
+      "publishedAt": "2026-05-14T00:23:54Z",
+      "updateSummary": [
+        "PR #359: feat(web): comprehensive UI/UX overhaul to world-class Bento grid design",
+        "Redesigned color tokens in `globals.css` with a tech & zen dark theme",
+        "Refactored `page.tsx` into a modern Bento Box layout grid",
+        "Integrated `framer-motion` for scroll reveal and stagger entrance animations",
+        "Created new `<BentoCard>` component with interactive spotlight hover effect",
+        "Upgraded the Hero section with 3D stacked floating screenshots (parallax hover)"
+      ],
+      "mirrorLinks": [],
+      "note": "已经上传到 TestFlight，但仓库变量 IOS_TESTFLIGHT_PUBLIC_URL 还没有配置公开加入链接。",
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6"
+    }
+  ],
   "stableChannels": [],
   "screenshots": {},
-  "releases": [],
-  "notes": []
+  "releases": [
+    {
+      "tag": "v1.0.0-148-mobile.01aa4666d6e6",
+      "title": "Fabushi mobile 1.0.0+148 (01aa4666d6e6)",
+      "publishedAt": "2026-05-14T00:47:16Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6",
+      "summary": [
+        "PR #359: feat(web): comprehensive UI/UX overhaul to world-class Bento grid design",
+        "Redesigned color tokens in `globals.css` with a tech & zen dark theme",
+        "Refactored `page.tsx` into a modern Bento Box layout grid",
+        "Integrated `framer-motion` for scroll reveal and stagger entrance animations",
+        "Created new `<BentoCard>` component with interactive spotlight hover effect",
+        "Upgraded the Hero section with 3D stacked floating screenshots (parallax hover)"
+      ]
+    },
+    {
+      "tag": "v1.0.0-147-mobile.bf69a3ea8679",
+      "title": "Fabushi mobile 1.0.0+147 (bf69a3ea8679)",
+      "publishedAt": "2026-05-13T23:56:48Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-147-mobile.bf69a3ea8679",
+      "summary": [
+        "PR #358: ci: fix missing GH_TOKEN in sync beta state workflow",
+        "[x] Run workflow manually to ensure it authenticates successfully"
+      ]
+    },
+    {
+      "tag": "v1.0.0-144-mobile.b6d5f08bef3d",
+      "title": "Fabushi mobile 1.0.0+144 (b6d5f08bef3d)",
+      "publishedAt": "2026-05-13T09:35:05Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-144-mobile.b6d5f08bef3d",
+      "summary": [
+        "PR #353: ci: fix official site sync not triggering automatically",
+        "Listen for `Publish CD packages to GitHub Release` workflow completion instead of `release` events, bypassing GITHUB_TOKEN recursive trigger limitations.",
+        "Fallback to fetching the latest GitHub release tag dynamically when no explicit tag is supplied by inputs or release context.",
+        "Update `Push beta state to official site repo` condition to execute even if attaching metadata to an immutable release is rejected (so the official site still receives updates).",
+        "Verify syntax and run the workflow dispatch to see if it correctly locates the latest release."
+      ]
+    },
+    {
+      "tag": "v1.0.0-142-mobile.4011ea22012e",
+      "title": "Fabushi mobile 1.0.0+142 (4011ea22012e)",
+      "publishedAt": "2026-05-13T05:58:32Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-142-mobile.4011ea22012e",
+      "summary": [
+        "PR #352: ci: keep release publish unblocked by screenshots"
+      ]
+    },
+    {
+      "tag": "v1.0.0-137-mobile.1ffba4b6640c",
+      "title": "Fabushi mobile 1.0.0+137 (1ffba4b6640c)",
+      "publishedAt": "2026-05-12T08:26:06Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-137-mobile.1ffba4b6640c",
+      "summary": [
+        "PR #336: fix: add missing .gitmodules for llama.cpp submodule mapping",
+        "Adds missing `.gitmodules` at repo root with `fabushi/native_libs/llama.cpp` submodule mapping to `https://github.com/ggml-org/llama.cpp`",
+        "The git index has this submodule (gitlink 160000) but `.gitmodules` was absent, causing every `actions/checkout` cleanup step to fail with `fatal: No url found for submodule path`",
+        "`Staging API E2E and smoke gate` — \"Checkout E2E files\" step failure",
+        "`Notify deployment failure` — \"Checkout failure notifier\" step failure → \"Create or update detailed CD failure issue\" was skipped",
+        "Any other job that checks out this repo without the workaround"
+      ]
+    }
+  ],
+  "notes": [
+    "Android beta 下载链接来自最新发布版本的 APK 资产。",
+    "iOS TestFlight 入口会在上传状态成功后和 Android beta 一起同步。",
+    "镜像链接面向国内网络环境准备，如镜像暂时不可用请使用原始下载地址。"
+  ]
 }

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -1,4 +1,4 @@
-const officialSiteReleaseRepo = process.env.NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_REPO?.trim() || "bhrum/fabushi";
+const officialSiteReleaseRepo = process.env.NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_REPO?.trim() || "bhrumom/fabushi";
 const iosTestFlightPublicUrl = process.env.NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL?.trim() || "";
 const RELEASES_API_URL = `https://api.github.com/repos/${officialSiteReleaseRepo}/releases?per_page=8`;
 
@@ -392,10 +392,25 @@ export async function getReleaseCollectionClient(): Promise<OfficialSiteReleaseC
   try {
     const res = await fetch("/api/releases.json");
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
+    const data = (await res.json()) as Record<string, unknown>;
+    const channels = Array.isArray(data.channels)
+      ? data.channels.map(normalizeChannel).filter((item): item is OfficialSiteChannel => item !== null)
+      : [];
+    const betaChannels =
+      Array.isArray(data.betaChannels) && data.betaChannels.length > 0
+        ? data.betaChannels
+            .map(normalizeChannel)
+            .filter((item): item is OfficialSiteChannel => item !== null)
+        : channels.filter((channel) => channel.audience === "beta");
+    const stableChannels =
+      Array.isArray(data.stableChannels) && data.stableChannels.length > 0
+        ? data.stableChannels
+            .map(normalizeChannel)
+            .filter((item): item is OfficialSiteChannel => item !== null)
+        : channels.filter((channel) => channel.audience === "stable");
     return {
-      betaChannels: (data.betaChannels ?? []).map(normalizeChannel).filter(Boolean) as OfficialSiteChannel[],
-      stableChannels: (data.stableChannels ?? []).map(normalizeChannel).filter(Boolean) as OfficialSiteChannel[],
+      betaChannels,
+      stableChannels,
       screenshots: normalizeScreenshots(data.screenshots) ?? {},
       releases: normalizeReleaseEntries(data.releases),
       notes: Array.isArray(data.notes) ? data.notes : [],


### PR DESCRIPTION
## Summary
- fail the official site beta sync when the release state file cannot be restored or downloaded
- write the generated release state into the static `/api/releases.json` schema the web app actually reads
- point the official site release fallback repo at `bhrumom/fabushi` and tolerate legacy `channels` payloads
- remove the obsolete Flutter screenshot test API that broke the release screenshot job

## Root cause
The beta sync workflow could report success while silently skipping the public API update, and the latest screenshot job failed during compilation because `IntegrationTestWidgetsFlutterBinding.revertFlutterImage()` is no longer available in the Flutter version used by CI.

## Validation
- `/opt/homebrew/bin/flutter analyze integration_test/store_screenshots_test.dart test_driver/store_screenshot_driver.dart`
- `corepack pnpm --filter @fabushi/web typecheck`
- `bash .github/scripts/check-publish-cd-release.sh`
