### PR TITLE
fix(profile): 修复头像更新后不生效与排行榜头像缺失

### DIFF
--- a/fabushi/lib/models/leaderboard_model.dart
+++ b/fabushi/lib/models/leaderboard_model.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'dart:convert';
+
 import '../services/leaderboard_service.dart';
 
 class LeaderboardEntry {
@@ -141,8 +143,20 @@ class LeaderboardModel extends ChangeNotifier {
   String? get error => _error;
   DateTime? get lastUpdateTime => _lastUpdateTime;
 
+  static Future<void> clearCache() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_cacheKey);
+    await prefs.remove(_timestampKey);
+  }
+
   Future<void> fetchLeaderboard({bool forceRefresh = false}) async {
-    // 首次加载缓存
+    if (forceRefresh) {
+      await clearCache();
+      _entries = [];
+      _lastUpdateTime = null;
+      _hasLoadedCache = true;
+    }
+
     if (!_hasLoadedCache) {
       await _loadCache();
       _hasLoadedCache = true;
@@ -151,21 +165,18 @@ class LeaderboardModel extends ChangeNotifier {
       }
     }
 
-    // 检查缓存（1天）
     if (!forceRefresh && _lastUpdateTime != null && _entries.isNotEmpty) {
       final diff = DateTime.now().difference(_lastUpdateTime!);
       if (diff.inDays < 1) {
-        return; // 使用缓存，不需要刷新
+        return;
       }
     }
 
-    // 检查刷新限制（1分钟）- 只在真正需要网络请求时才检查
     if (_lastRefreshTime != null) {
       final diff = DateTime.now().difference(_lastRefreshTime!);
       if (diff.inSeconds < 60) {
         _error = '刷新过于频繁，请${60 - diff.inSeconds}秒后再试';
         notifyListeners();
-        // 3秒后自动清除错误消息
         Future.delayed(const Duration(seconds: 3), () {
           if (_error?.contains('刷新过于频繁') == true) {
             _error = null;

--- a/fabushi/lib/screens/edit_profile_screen.dart
+++ b/fabushi/lib/screens/edit_profile_screen.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import '../core/config/app_config.dart';
 import '../core/design_system/app_theme.dart';
 import '../models/auth_model.dart';
+import '../models/leaderboard_model.dart';
 import '../services/error_report_service.dart';
 import '../services/http_service.dart';
 import '../services/meditation_session_manager.dart';
@@ -342,16 +343,22 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       if (response.statusCode == 200 && data['success'] == true) {
         final token = data['token'] as String?;
         final userJson = data['user'];
-        final updatedUsername = userJson is Map
-            ? (userJson['username'] as String? ??
-                  _usernameController.text.trim())
-            : _usernameController.text.trim();
+        final updatedUserJson = userJson is Map
+            ? Map<String, dynamic>.from(userJson)
+            : null;
+        final updatedUsername = updatedUserJson?['username'] as String? ??
+            _usernameController.text.trim();
 
         if (token != null) {
-          await authModel.loginWithToken(token, updatedUsername);
+          await authModel.loginWithToken(
+            token,
+            updatedUsername,
+            userJson: updatedUserJson,
+          );
         } else {
           await authModel.refreshUserInfo();
         }
+        await LeaderboardModel.clearCache();
 
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/fabushi/lib/screens/leaderboard_screen.dart
+++ b/fabushi/lib/screens/leaderboard_screen.dart
@@ -1,12 +1,12 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../core/design_system/app_theme.dart';
 import '../models/leaderboard_model.dart';
-import '../widgets/space_background.dart';
 import '../widgets/follow_button.dart';
 import '../widgets/leaderboard_user_detail_sheet.dart';
-import '../core/design_system/app_theme.dart';
+import '../widgets/space_background.dart';
 
 String formatLeaderboardBytes(int bytes) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
@@ -143,7 +143,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
                             highlightLabel: '累计布施',
                             highlightValue: formatLeaderboardBytes(entry.totalBytes),
                           ),
-                          leading: _buildRankBadge(entry.rank),
+                          leading: _buildAvatarRank(entry),
                           title: Text(
                             entry.displayName.isNotEmpty
                                 ? entry.displayName
@@ -212,28 +212,60 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
     );
   }
 
-  Widget _buildRankBadge(int rank) {
-    Color color;
-    if (rank == 1) {
-      color = Colors.amber;
-    } else if (rank == 2) {
-      color = Colors.grey;
-    } else if (rank == 3) {
-      color = Colors.brown;
-    } else {
-      color = Colors.blue;
-    }
+  Widget _buildAvatarRank(LeaderboardEntry entry) {
+    final hasAvatar = entry.avatar?.isNotEmpty == true;
+    final fallback = entry.displayName.isNotEmpty
+        ? entry.displayName[0].toUpperCase()
+        : (entry.username.isNotEmpty ? entry.username[0].toUpperCase() : '?');
 
-    return CircleAvatar(
-      backgroundColor: color,
-      child: Text(
-        '$rank',
-        style: const TextStyle(
-          color: Colors.white,
-          fontWeight: FontWeight.bold,
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        CircleAvatar(
+          radius: 23,
+          backgroundColor: Colors.white10,
+          backgroundImage: hasAvatar ? NetworkImage(entry.avatar!) : null,
+          child: hasAvatar
+              ? null
+              : Text(
+                  fallback,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
         ),
-      ),
+        Positioned(
+          right: -5,
+          bottom: -5,
+          child: Container(
+            width: 22,
+            height: 22,
+            decoration: BoxDecoration(
+              color: _rankColor(entry.rank),
+              shape: BoxShape.circle,
+              border: Border.all(color: const Color(0xFF111111), width: 2),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              '${entry.rank}',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
+  }
+
+  Color _rankColor(int rank) {
+    if (rank == 1) return Colors.amber;
+    if (rank == 2) return Colors.grey;
+    if (rank == 3) return Colors.brown;
+    return const Color(0xFF476A8E);
   }
 
   String _formatUpdateTime(DateTime time) {

--- a/fabushi/web/src/use-cases/account-registration.js
+++ b/fabushi/web/src/use-cases/account-registration.js
@@ -6,8 +6,14 @@ function normalizeRequiredString(value) {
   return String(value || '').trim();
 }
 
+function normalizeOptionalString(value) {
+  if (value === undefined || value === null) return null;
+  const normalized = String(value).trim();
+  return normalized.length === 0 ? null : normalized;
+}
+
 export async function registerAccountCommand(body, env, repository) {
-  const { username, email, password, verificationCode } = body;
+  const { username, email, password, verificationCode, nickname, avatar } = body;
 
   if (!username || !email || !password || !verificationCode) {
     throw new ApiError('缺少必要字段', 400);
@@ -15,6 +21,8 @@ export async function registerAccountCommand(body, env, repository) {
 
   const normalizedUsername = normalizeRequiredString(username);
   const normalizedEmail = normalizeRequiredString(email).toLowerCase();
+  const normalizedNickname = normalizeOptionalString(nickname) || normalizedUsername;
+  const normalizedAvatar = normalizeOptionalString(avatar);
 
   if (normalizedUsername.includes('@') || /\s/.test(normalizedUsername)) {
     throw new ApiError('用户名不能包含 @ 或空格', 400);
@@ -51,6 +59,8 @@ export async function registerAccountCommand(body, env, repository) {
     iterations: creds.iterations,
     algo: creds.algo,
     emailVerified: true,
+    nickname: normalizedNickname,
+    avatar: normalizedAvatar,
     membershipType: 'trial',
     freeTrialEndDate: trialEndDate.toISOString(),
     createdAt: new Date().toISOString(),

--- a/fabushi/web/src/use-cases/update-profile.js
+++ b/fabushi/web/src/use-cases/update-profile.js
@@ -5,6 +5,7 @@ import { normalizeProfileUpdateBody } from '../domain/account-identity.js';
 import { authenticateRequest } from './authenticated-user.js';
 
 const USERNAME_CHANGE_WINDOW_MS = 365 * 24 * 60 * 60 * 1000;
+const MAX_AVATAR_BYTES = 3 * 1024 * 1024;
 
 function parseIsoDate(value) {
   if (!value) return null;
@@ -17,13 +18,83 @@ function formatDateOnly(date) {
   return date.toISOString().slice(0, 10);
 }
 
+function sanitizeAvatarExtension(fileName, contentType) {
+  const fallbackExtension = String(contentType || 'image/jpeg')
+    .split('/')
+    .pop()
+    ?.replace('jpeg', 'jpg') || 'jpg';
+  const explicitExtension = String(fileName || '').split('.').pop()?.toLowerCase() || '';
+
+  if (/^[a-z0-9]{2,5}$/.test(explicitExtension)) {
+    return explicitExtension;
+  }
+
+  return fallbackExtension;
+}
+
+function decodeBase64Image(imageBase64) {
+  const raw = String(imageBase64 || '').trim();
+  if (!raw) {
+    throw new ApiError('头像图片为空', 400);
+  }
+
+  const payload = raw.replace(/^data:image\/[a-zA-Z0-9.+-]+;base64,/, '');
+  try {
+    const binary = atob(payload);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch (_) {
+    throw new ApiError('头像图片数据格式无效', 400);
+  }
+}
+
+function avatarUrlFor(request, key) {
+  const url = new URL(request.url);
+  return `${url.origin}/r2?file=${encodeURIComponent(key)}`;
+}
+
+async function uploadAvatarObject({ request, env, username, avatarData }) {
+  if (!avatarData?.imageBase64) {
+    return null;
+  }
+
+  if (!env.R2_BUCKET) {
+    throw new ApiError('R2存储桶未绑定，无法保存头像到云端', 500);
+  }
+
+  const bytes = decodeBase64Image(avatarData.imageBase64);
+  if (!bytes.length) {
+    throw new ApiError('头像图片为空', 400);
+  }
+  if (bytes.length > MAX_AVATAR_BYTES) {
+    throw new ApiError('头像图片不能超过 3MB', 413);
+  }
+
+  const rawContentType = String(avatarData.contentType || '').trim().toLowerCase();
+  const contentType = rawContentType.startsWith('image/')
+    ? rawContentType
+    : 'image/jpeg';
+  const extension = sanitizeAvatarExtension(avatarData.fileName, contentType);
+  const objectKey = `avatars/${encodeURIComponent(username)}/${Date.now()}-${crypto.randomUUID()}.${extension}`;
+
+  await env.R2_BUCKET.put(objectKey, bytes, {
+    httpMetadata: { contentType },
+    customMetadata: { username },
+  });
+
+  return avatarUrlFor(request, objectKey);
+}
+
 export async function updateProfileFromRequest(request, env, repository) {
   const { user } = await authenticateRequest(request, env, repository);
   const body = await request.json();
-  return await updateProfileCommand({ currentUser: user, body, env }, repository);
+  return await updateProfileCommand({ currentUser: user, body, env, request }, repository);
 }
 
-export async function updateProfileCommand({ currentUser, body, env }, repository) {
+export async function updateProfileCommand({ currentUser, body, env, request }, repository) {
   let normalized;
   try {
     normalized = normalizeProfileUpdateBody(body, currentUser.username);
@@ -31,7 +102,19 @@ export async function updateProfileCommand({ currentUser, body, env }, repositor
     throw new ApiError(error.message, 400);
   }
 
-  const { hasDisplayNameField, displayName, username, email, phoneNumber, avatar, password } = normalized;
+  const {
+    hasDisplayNameField,
+    displayName,
+    username,
+    email,
+    phoneNumber,
+    avatar,
+    password,
+  } = normalized;
+  const avatarData = body?.avatarData && typeof body.avatarData === 'object'
+    ? body.avatarData
+    : null;
+
   if (hasDisplayNameField && !displayName) {
     throw new ApiError('请输入昵称', 400);
   }
@@ -70,13 +153,25 @@ export async function updateProfileCommand({ currentUser, body, env }, repositor
     updates.username = username;
     updates.username_changed_at = new Date().toISOString();
   }
-  if (displayName !== undefined) updates.nickname = displayName;
+  if (hasDisplayNameField) updates.nickname = displayName;
   if (email !== undefined) {
     updates.email = email || '';
     updates.email_verified = email ? 1 : 0;
   }
   if (phoneNumber !== undefined) updates.phone_number = phoneNumber;
-  if (avatar !== undefined) updates.avatar = avatar;
+
+  if (avatarData?.imageBase64) {
+    const resolvedUsername = updates.username || currentUser.username;
+    updates.avatar = await uploadAvatarObject({
+      request,
+      env,
+      username: resolvedUsername,
+      avatarData,
+    });
+  } else if (avatar !== undefined) {
+    updates.avatar = avatar;
+  }
+
   if (password !== undefined && password.length > 0) {
     if (currentUser.password_hash && currentUser.salt) {
       throw new ApiError('当前账号已设置密码，请使用修改密码功能', 400);


### PR DESCRIPTION
## Summary
- restore avatar upload handling in the profile update use case so `avatarData` is uploaded to R2 and persisted back onto the user record
- show user avatars on the global leaderboard instead of only rendering the rank badge
- clear cached leaderboard data after profile updates so newly changed avatars are visible immediately
- preserve `nickname` and `avatar` when registration payloads include them

## Root cause
The profile-editing screen still sent `avatarData`, but the refactored `update-profile` use case no longer handled that field. This meant the app could show a success toast without actually persisting the new avatar. Separately, the global leaderboard UI never rendered `entry.avatar`, and cached leaderboard data could keep stale avatars around even after a successful profile save.

## Validation
- code inspection of the updated profile flow confirms `avatarData` is now decoded, uploaded through `R2_BUCKET`, and written back as the stored avatar URL
- code inspection of the leaderboard screen confirms avatar rendering now uses leaderboard payload avatar data with a rank overlay
- code inspection of registration flow confirms optional `nickname` and `avatar` are preserved when provided
- full Flutter / Worker runtime tests were not run in this environment