### PR TITLE
Fix homepage screenshot key typing

### DIFF
--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -10,7 +10,8 @@ import {
 import { siteHref, siteUrl } from "../lib/site-url";
 import { ZenOrbit } from "../components/zen-orbit";
 
-type ProductScreenshotKey = keyof typeof FALLBACK_SCREENSHOTS;
+const SCREENSHOT_KEYS = ["home", "meditation", "sutra", "video"] as const;
+type ProductScreenshotKey = (typeof SCREENSHOT_KEYS)[number];
 
 interface ProductMoment {
   title: string;


### PR DESCRIPTION
## Summary
- narrow the homepage screenshot key type to the four supported screenshot names
- keep `resolveScreenshot` type-safe when reading `OfficialSiteScreenshots`

## Why this PR still exists
The visual restore and beta sync workflow changes from the earlier follow-up are already in `main` through PR #368.
This PR now contains only the remaining type fix that was still needed on top of those merged changes.

## CI expectation
- frontend typecheck should stop failing on `frontend/apps/web/src/app/page.tsx`
- no runtime behavior change is expected; this is a compile-time typing fix only