### PR TITLE
feat(web): localize official site and surface synced release details

### DIFF
--- a/frontend/apps/web/src/app/apply/page.tsx
+++ b/frontend/apps/web/src/app/apply/page.tsx
@@ -1,14 +1,64 @@
 import type { Metadata } from "next";
-import { betaApplicationTracks, brand } from "@fabushi/shared";
+import { brand } from "@fabushi/shared";
+import { LocalizedText } from "../../components/localized-text";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
 const applyUrl = siteUrl("/apply");
-const applyTitle = `申请测试 | ${brand.name}`;
-const applyDescription = "选择 Fabushi iOS、Android 或合作申请入口。";
+const applyTitle = `Beta Apply | ${brand.name}`;
+const applyDescription = "Choose the Fabushi iOS, Android, or partner application path.";
 
-const applyTips = ["写明平台和设备", "留下常用邮箱", "说明最想体验的功能"] as const;
+const applicationTracks = [
+  {
+    nameZh: "iOS TestFlight",
+    nameEn: "iOS TestFlight",
+    summaryZh: "适合想提前体验 iPhone 或 iPad 新版本的人。",
+    summaryEn: "For people who want early access on iPhone or iPad.",
+    checklistZh: ["留下 Apple ID 邮箱", "写明设备型号", "告诉我们最想体验的功能"],
+    checklistEn: ["Share the Apple ID email", "Include the device model", "Tell us which feature you care about most"],
+    ctaHref: "/download",
+    ctaLabelZh: "先看 iOS 下载状态",
+    ctaLabelEn: "See iOS beta status",
+  },
+  {
+    nameZh: "Android Beta",
+    nameEn: "Android Beta",
+    summaryZh: "适合想直接安装 APK 并尽快反馈问题的人。",
+    summaryEn: "For people who want the APK quickly and can share feedback fast.",
+    checklistZh: ["写明手机品牌和系统版本", "说明是否能安装外部 APK", "留下常用邮箱"],
+    checklistEn: ["Include phone brand and Android version", "Tell us if side-loading APKs is available", "Leave a regular contact email"],
+    ctaHref: "/download",
+    ctaLabelZh: "先看 Android 下载状态",
+    ctaLabelEn: "See Android beta status",
+  },
+  {
+    nameZh: "合作沟通",
+    nameEn: "Partnership",
+    summaryZh: "适合机构、共修组织或内容合作方联系。",
+    summaryEn: "For organizations, practice groups, or content partnerships.",
+    checklistZh: ["说明你的组织或项目", "写明合作诉求", "留下稳定联系邮箱"],
+    checklistEn: ["Describe the organization or project", "Explain the kind of collaboration you want", "Leave a reliable contact email"],
+    ctaHref: "/contact",
+    ctaLabelZh: "前往联系页",
+    ctaLabelEn: "Open contact page",
+  },
+] as const;
+
+const applyTips = [
+  {
+    zh: "写明平台和设备",
+    en: "Mention the platform and device",
+  },
+  {
+    zh: "留下常用邮箱",
+    en: "Leave a reachable email",
+  },
+  {
+    zh: "说明最想体验的功能",
+    en: "Say which feature you want most",
+  },
+] as const;
 
 export const metadata: Metadata = {
   title: applyTitle,
@@ -16,13 +66,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: applyUrl,
   },
-  keywords: ["法布施内测", "Fabushi 申请测试", "Android Beta", "TestFlight"],
+  keywords: ["Fabushi beta apply", "Android Beta", "TestFlight"],
   openGraph: {
     title: applyTitle,
     description: applyDescription,
     url: applyUrl,
     siteName: "Fabushi",
-    locale: "zh_CN",
+    locale: "en_US",
     type: "website",
   },
   twitter: {
@@ -38,20 +88,20 @@ export default function ApplyPage() {
     "@graph": [
       {
         "@type": "CollectionPage",
-        name: `${brand.name} 申请测试`,
+        name: `${brand.name} Beta Apply`,
         url: applyUrl,
-        inLanguage: "zh-CN",
+        inLanguage: "en",
         description: applyDescription,
       },
       {
         "@type": "ItemList",
-        itemListElement: betaApplicationTracks.map((item, index) => ({
+        itemListElement: applicationTracks.map((item, index) => ({
           "@type": "ListItem",
           position: index + 1,
           item: {
             "@type": "EntryPoint",
-            name: item.name,
-            description: item.summary,
+            name: item.nameEn,
+            description: item.summaryEn,
             urlTemplate: siteHref(item.ctaHref),
           },
         })),
@@ -70,26 +120,40 @@ export default function ApplyPage() {
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">
-          <p className="eyebrow">申请测试</p>
-          <h1>选一个入口，直接发出申请。</h1>
-          <p className="lede">iOS TestFlight、Android Beta 和合作沟通分开处理。</p>
+          <p className="eyebrow">
+            <LocalizedText zh="申请测试" en="Apply" />
+          </p>
+          <h1>
+            <LocalizedText zh="选一个入口，直接发出申请。" en="Choose the right path and send the request directly." />
+          </h1>
+          <p className="lede">
+            <LocalizedText zh="iOS TestFlight、Android Beta 和合作沟通分开处理。" en="iOS TestFlight, Android beta, and partnership requests are handled separately." />
+          </p>
         </div>
       </section>
 
       <section className="band compact-band">
         <div className="application-grid">
-          {betaApplicationTracks.map((item) => (
-            <article key={item.name} className="application-card">
-              <p className="eyebrow">{item.name}</p>
-              <h2>{item.name}</h2>
-              <p>{item.summary}</p>
+          {applicationTracks.map((item) => (
+            <article key={item.nameEn} className="application-card">
+              <p className="eyebrow">
+                <LocalizedText zh={item.nameZh} en={item.nameEn} />
+              </p>
+              <h2>
+                <LocalizedText zh={item.nameZh} en={item.nameEn} />
+              </h2>
+              <p>
+                <LocalizedText zh={item.summaryZh} en={item.summaryEn} />
+              </p>
               <ol className="application-list">
-                {item.checklist.map((entry) => (
-                  <li key={entry}>{entry}</li>
+                {item.checklistZh.map((_, index) => (
+                  <li key={`${item.nameEn}-${index}`}>
+                    <LocalizedText zh={item.checklistZh[index]} en={item.checklistEn[index]} />
+                  </li>
                 ))}
               </ol>
               <a className="primary-action" href={siteHref(item.ctaHref)}>
-                {item.ctaLabel}
+                <LocalizedText zh={item.ctaLabelZh} en={item.ctaLabelEn} />
               </a>
             </article>
           ))}
@@ -98,20 +162,26 @@ export default function ApplyPage() {
 
       <section className="band alt">
         <div className="section-heading tight">
-          <p>准备</p>
-          <h2>三条信息足够开始。</h2>
+          <p>
+            <LocalizedText zh="准备" en="Prepare" />
+          </p>
+          <h2>
+            <LocalizedText zh="三条信息足够开始。" en="Three details are enough to get started." />
+          </h2>
         </div>
         <div className="note-grid">
           {applyTips.map((item) => (
-            <p key={item}>{item}</p>
+            <p key={item.en}>
+              <LocalizedText zh={item.zh} en={item.en} />
+            </p>
           ))}
         </div>
         <div className="inline-cta">
           <a className="secondary-action" href={siteHref("/download")}>
-            回到下载
+            <LocalizedText zh="回到下载" en="Back to downloads" />
           </a>
           <a className="secondary-action" href={siteHref("/privacy")}>
-            隐私说明
+            <LocalizedText zh="隐私说明" en="Privacy" />
           </a>
         </div>
       </section>

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -3,6 +3,7 @@ import { brand, contactChannels } from "@fabushi/shared";
 import { DownloadClient } from "../../components/download-client";
 import type { DownloadChannel } from "../../components/download-client";
 import { DownloadLink } from "../../components/download-link";
+import { LocalizedText } from "../../components/localized-text";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import { ZenOrbit } from "../../components/zen-orbit";
@@ -13,28 +14,34 @@ import {
 import { siteHref, siteUrl } from "../../lib/site-url";
 
 const downloadUrl = siteUrl("/download");
-const downloadTitle = `下载 | ${brand.name}`;
-const downloadDescription = "选择 Fabushi Android Beta、iOS TestFlight 或正式版入口。";
+const downloadTitle = `Download | ${brand.name}`;
+const downloadDescription = "Choose Android beta, iOS TestFlight, or stable download paths for Fabushi.";
 
 const downloadFaqs = [
   {
-    question: "我应该先点哪个入口？",
-    answer: "想尽快体验新版本，先看 Beta；想要更稳，等正式版；不确定时先申请测试。",
+    questionZh: "我应该先点哪个入口？",
+    questionEn: "Which button should I open first?",
+    answerZh: "想尽快体验新版本，先看测试版；更想要稳定，就等正式版。",
+    answerEn: "Pick beta for the newest release quickly. Wait for stable if you want the calmer path.",
   },
   {
-    question: "Android 下载慢怎么办？",
-    answer: "优先尝试卡片里的镜像链接；如果仍不可用，把平台和错误截图发到支持邮箱。",
+    questionZh: "Android 下载慢怎么办？",
+    questionEn: "What if Android downloads are slow?",
+    answerZh: "优先尝试卡片里的镜像链接；如果仍不可用，把平台和错误截图发到支持邮箱。",
+    answerEn: "Try the mirror links on the card first. If that still fails, send the platform and screenshot to support.",
   },
   {
-    question: "iOS 为什么可能跳到 TestFlight？",
-    answer: "iOS 内测通过 Apple TestFlight 分发。公开加入链接开放后，下载页会直接显示。",
+    questionZh: "iOS 为什么会跳到 TestFlight？",
+    questionEn: "Why does iOS open TestFlight?",
+    answerZh: "iOS 内测通过 Apple TestFlight 分发。公开加入链接开放后，下载页会直接显示。",
+    answerEn: "iOS beta is distributed through Apple TestFlight. Once public access is ready, the page links there directly.",
   },
 ] as const;
 
 export const metadata: Metadata = {
   title: downloadTitle,
   description: downloadDescription,
-  keywords: ["Fabushi 下载", "法布施下载", "Android Beta", "iOS TestFlight"],
+  keywords: ["Fabushi download", "Android Beta", "iOS TestFlight", "release notes"],
   alternates: {
     canonical: downloadUrl,
   },
@@ -43,7 +50,7 @@ export const metadata: Metadata = {
     description: downloadDescription,
     url: downloadUrl,
     siteName: "Fabushi",
-    locale: "zh_CN",
+    locale: "en_US",
     type: "website",
   },
   twitter: {
@@ -59,21 +66,42 @@ function formatPublishedAt(value?: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
 
-  return new Intl.DateTimeFormat("zh-CN", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  }).format(date);
+  return date.toISOString().slice(0, 10);
+}
+
+function getChannelActionCopy(channel: OfficialSiteChannel) {
+  if (channel.audience === "stable" && channel.primaryHref.startsWith("/contact")) {
+    return {
+      zh: "查看状态",
+      en: "View status",
+    };
+  }
+
+  if (channel.platform === "iOS") {
+    return {
+      zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
+      en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
+    };
+  }
+
+  return {
+    zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
+    en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
+  };
 }
 
 function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
   const publishedAt = formatPublishedAt(channel.publishedAt);
+  const summary = channel.updateSummary.slice(0, 3);
+  const actionCopy = getChannelActionCopy(channel);
 
   return (
     <article className="release-card">
       <div className="release-card-header">
         <div>
-          <p className="eyebrow">{channel.audience === "beta" ? "测试版" : "正式版"}</p>
+          <p className="eyebrow">
+            <LocalizedText zh={channel.audience === "beta" ? "测试版" : "正式版"} en={channel.audience === "beta" ? "Beta" : "Stable"} />
+          </p>
           <h2>{channel.title}</h2>
         </div>
         <span className="download-status">{channel.status}</span>
@@ -81,22 +109,29 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
       <p>{channel.description}</p>
       {(channel.version || publishedAt) && (
         <div className="release-card-meta">
-          {channel.version ? <span>版本 {channel.version}</span> : null}
-          {publishedAt ? <span>{publishedAt}</span> : null}
+          {channel.version ? <span><LocalizedText zh="版本" en="Version" /> v{channel.version}</span> : null}
+          {publishedAt ? <span><LocalizedText zh="发布时间" en="Published" /> {publishedAt}</span> : null}
         </div>
       )}
+      {summary.length > 0 ? (
+        <ul className="release-summary-list">
+          {summary.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      ) : null}
       <div className="release-card-actions">
         <DownloadLink className="primary-action" channel={channel}>
-          {channel.primaryLabel}
+          <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
         </DownloadLink>
         {channel.releasePageHref ? (
           <a className="secondary-action" href={siteHref(channel.releasePageHref)}>
-            Release
+            <LocalizedText zh="查看 Release" en="View release" />
           </a>
         ) : null}
       </div>
       {channel.mirrorLinks.length > 0 && (
-        <div className="mirror-links" aria-label={`${channel.title} 镜像下载`}>
+        <div className="mirror-links" aria-label={`${channel.title} mirror links`}>
           {channel.mirrorLinks.map((item) => (
             <a key={item.href} href={siteHref(item.href)}>
               {item.label}
@@ -122,10 +157,10 @@ export default async function DownloadPage() {
     "@graph": [
       {
         "@type": "CollectionPage",
-        name: `${brand.name} 下载`,
+        name: `${brand.name} Download`,
         url: downloadUrl,
         description: downloadDescription,
-        inLanguage: "zh-CN",
+        inLanguage: "en",
       },
       {
         "@type": "ItemList",
@@ -145,10 +180,10 @@ export default async function DownloadPage() {
         "@type": "FAQPage",
         mainEntity: downloadFaqs.map((item) => ({
           "@type": "Question",
-          name: item.question,
+          name: item.questionEn,
           acceptedAnswer: {
             "@type": "Answer",
-            text: item.answer,
+            text: item.answerEn,
           },
         })),
       },
@@ -167,16 +202,29 @@ export default async function DownloadPage() {
         <SiteHeader />
         <ZenOrbit />
         <div className="inner-copy">
-          <p className="eyebrow">下载</p>
-          <h1>选择你的入口。</h1>
-          <p className="lede">Android Beta、iOS TestFlight 和正式版状态会在这里同步。</p>
+          <p className="eyebrow">
+            <LocalizedText zh="下载" en="Download" />
+          </p>
+          <h1>
+            <LocalizedText zh="选一个入口，知道自己下的是哪个版本。" en="Pick a download path and know exactly which version you are getting." />
+          </h1>
+          <p className="lede">
+            <LocalizedText
+              zh="Android Beta、iOS TestFlight、发布时间和更新摘要会在这里一起同步。"
+              en="Android beta, iOS TestFlight, publish time, and update summaries are synced here together."
+            />
+          </p>
         </div>
       </section>
 
       <section className="band compact-band" id="beta-channels">
         <div className="section-heading tight">
-          <p>下载</p>
-          <h2>选择适合你的入口。</h2>
+          <p>
+            <LocalizedText zh="下载" en="Download" />
+          </p>
+          <h2>
+            <LocalizedText zh="先从最合适的平台入口开始。" en="Start with the path that matches your device." />
+          </h2>
         </div>
         {betaChannels.length > 0 ? (
           <DownloadClient channels={betaChannels as DownloadChannel[]} />
@@ -185,15 +233,26 @@ export default async function DownloadPage() {
             <article className="release-card">
               <div className="release-card-header">
                 <div>
-                  <p className="eyebrow">测试版</p>
-                  <h2>Beta 同步中</h2>
+                  <p className="eyebrow">
+                    <LocalizedText zh="测试版" en="Beta" />
+                  </p>
+                  <h2>
+                    <LocalizedText zh="Beta 同步中" en="Beta is syncing" />
+                  </h2>
                 </div>
-                <span className="download-status">暂未开放</span>
+                <span className="download-status">
+                  <LocalizedText zh="暂未开放" en="Not open yet" />
+                </span>
               </div>
-              <p>当前还没有可公开点击的 Beta 入口。可以先提交测试申请。</p>
+              <p>
+                <LocalizedText
+                  zh="当前还没有可公开点击的 Beta 入口。可以先提交测试申请。"
+                  en="There is no public beta button yet. You can still apply for access first."
+                />
+              </p>
               <div className="release-card-actions">
                 <a className="primary-action" href={siteHref("/apply")}>
-                  申请测试
+                  <LocalizedText zh="申请测试" en="Apply" />
                 </a>
               </div>
             </article>
@@ -203,8 +262,12 @@ export default async function DownloadPage() {
 
       <section className="band alt" id="stable-channels">
         <div className="section-heading tight">
-          <p>正式版</p>
-          <h2>适合想要更稳安装的人。</h2>
+          <p>
+            <LocalizedText zh="正式版" en="Stable" />
+          </p>
+          <h2>
+            <LocalizedText zh="适合想要更稳安装的人。" en="For people who would rather wait for a steadier install path." />
+          </h2>
         </div>
         <div className="download-grid">
           {stableChannels.map((channel) => (
@@ -215,27 +278,39 @@ export default async function DownloadPage() {
 
       <section className="band">
         <div className="section-heading tight">
-          <p>说明</p>
-          <h2>下载前只看这三条。</h2>
+          <p>
+            <LocalizedText zh="说明" en="Notes" />
+          </p>
+          <h2>
+            <LocalizedText zh="下载前只看这三条。" en="Three things worth checking before you download." />
+          </h2>
         </div>
         <div className="note-grid">
           {notes.map((item) => (
             <p key={item}>{item}</p>
           ))}
-          <p>遇到下载或安装问题，发邮件到 {supportEmail}。</p>
+          <p>
+            <LocalizedText zh={`遇到下载或安装问题，发邮件到 ${supportEmail}。`} en={`If download or install fails, email ${supportEmail}.`} />
+          </p>
         </div>
       </section>
 
       <section className="band alt">
         <div className="section-heading tight">
           <p>FAQ</p>
-          <h2>少一点犹豫。</h2>
+          <h2>
+            <LocalizedText zh="少一点犹豫。" en="Remove the last bit of hesitation." />
+          </h2>
         </div>
         <div className="faq-list full">
           {downloadFaqs.map((item) => (
-            <details key={item.question} className="faq-item">
-              <summary>{item.question}</summary>
-              <p>{item.answer}</p>
+            <details key={item.questionEn} className="faq-item">
+              <summary>
+                <LocalizedText zh={item.questionZh} en={item.questionEn} />
+              </summary>
+              <p>
+                <LocalizedText zh={item.answerZh} en={item.answerEn} />
+              </p>
             </details>
           ))}
         </div>
@@ -244,8 +319,12 @@ export default async function DownloadPage() {
       {releaseCollection.releases.length > 0 && (
         <section className="band" id="release-changelog">
           <div className="section-heading tight">
-            <p>更新日志</p>
-            <h2>最近更新了什么。</h2>
+            <p>
+              <LocalizedText zh="更新日志" en="Release log" />
+            </p>
+            <h2>
+              <LocalizedText zh="最近更新了什么。" en="What changed recently." />
+            </h2>
           </div>
           <div className="changelog-timeline">
             {releaseCollection.releases.map((entry) => (
@@ -256,14 +335,17 @@ export default async function DownloadPage() {
                       {entry.title}
                     </a>
                   </h3>
-                  <time dateTime={entry.publishedAt}>
-                    {formatPublishedAt(entry.publishedAt)}
-                  </time>
+                  <time dateTime={entry.publishedAt}>{formatPublishedAt(entry.publishedAt)}</time>
+                </div>
+                <div className="release-card-meta compact">
+                  <span>
+                    <LocalizedText zh="版本" en="Version" /> {entry.tag}
+                  </span>
                 </div>
                 {entry.summary.length > 0 && (
-                  <ul>
+                  <ul className="release-summary-list compact">
                     {entry.summary.map((line, i) => (
-                      <li key={i}>{line}</li>
+                      <li key={`${entry.tag}-${i}`}>{line}</li>
                     ))}
                   </ul>
                 )}
@@ -273,7 +355,7 @@ export default async function DownloadPage() {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  查看完整发布说明
+                  <LocalizedText zh="查看完整发布说明" en="View full release notes" />
                 </a>
               </article>
             ))}

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -1,12 +1,40 @@
 import type { Metadata } from "next";
-import { brand, faqItems } from "@fabushi/shared";
+import { brand } from "@fabushi/shared";
+import { LocalizedText } from "../../components/localized-text";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
 const faqUrl = siteUrl("/faq");
-const faqTitle = `常见问题 | ${brand.name}`;
-const faqDescription = "查看 Fabushi 下载、内测、平台入口和支持方式。";
+const faqTitle = `FAQ | ${brand.name}`;
+const faqDescription = "Fabushi download, beta access, and support questions.";
+
+const faqItems = [
+  {
+    questionZh: "我应该下载哪个版本？",
+    questionEn: "Which version should I download?",
+    answerZh: "想尽快体验新功能，先看测试版；更重视稳定性，就等正式版。",
+    answerEn: "Choose beta if you want new features quickly. Wait for stable if you prefer a steadier path.",
+  },
+  {
+    questionZh: "iOS 为什么会跳到 TestFlight？",
+    questionEn: "Why does iOS open TestFlight?",
+    answerZh: "iOS 内测通过 Apple TestFlight 分发，公开加入链接准备好后会直接显示。",
+    answerEn: "iOS beta is distributed through Apple TestFlight, and the public join link appears here once it is ready.",
+  },
+  {
+    questionZh: "Android 下载慢怎么办？",
+    questionEn: "What if Android downloads are slow?",
+    answerZh: "优先尝试下载页里的镜像链接；原始链接也会继续保留。",
+    answerEn: "Try the mirror links on the download page first. The original link stays available too.",
+  },
+  {
+    questionZh: "官网会显示版本更新信息吗？",
+    questionEn: "Will the site show release updates?",
+    answerZh: "会。首页和下载页都会同步 GitHub 发布版本、发布时间和更新摘要。",
+    answerEn: "Yes. The homepage and download page sync GitHub release versions, publish time, and update summaries.",
+  },
+] as const;
 
 export const metadata: Metadata = {
   title: faqTitle,
@@ -14,13 +42,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: faqUrl,
   },
-  keywords: ["法布施 FAQ", "Fabushi 常见问题", "法布施下载"],
+  keywords: ["Fabushi FAQ", "download help", "beta access"],
   openGraph: {
     title: faqTitle,
     description: faqDescription,
     url: faqUrl,
     siteName: "Fabushi",
-    locale: "zh_CN",
+    locale: "en_US",
     type: "website",
   },
   twitter: {
@@ -36,10 +64,10 @@ export default function FaqPage() {
     "@type": "FAQPage",
     mainEntity: faqItems.map((item) => ({
       "@type": "Question",
-      name: item.question,
+      name: item.questionEn,
       acceptedAnswer: {
         "@type": "Answer",
-        text: item.answer,
+        text: item.answerEn,
       },
     })),
   };
@@ -56,26 +84,34 @@ export default function FaqPage() {
         <SiteHeader />
         <div className="inner-copy">
           <p className="eyebrow">FAQ</p>
-          <h1>先解决下载前会卡住的问题。</h1>
-          <p className="lede">产品、下载、内测、支持方式都在这里。</p>
+          <h1>
+            <LocalizedText zh="先解决下载前会卡住的问题。" en="Solve the questions that usually block a download first." />
+          </h1>
+          <p className="lede">
+            <LocalizedText zh="产品、下载、内测和支持方式都在这里。" en="Product, download, beta access, and support answers all live here." />
+          </p>
         </div>
       </section>
 
       <section className="band compact-band">
         <div className="faq-list full">
           {faqItems.map((item) => (
-            <details key={item.question} className="faq-item">
-              <summary>{item.question}</summary>
-              <p>{item.answer}</p>
+            <details key={item.questionEn} className="faq-item">
+              <summary>
+                <LocalizedText zh={item.questionZh} en={item.questionEn} />
+              </summary>
+              <p>
+                <LocalizedText zh={item.answerZh} en={item.answerEn} />
+              </p>
             </details>
           ))}
         </div>
         <div className="inline-cta">
           <a className="primary-action" href={siteHref("/download")}>
-            去下载
+            <LocalizedText zh="去下载" en="Go to downloads" />
           </a>
           <a className="secondary-action" href={siteHref("/apply")}>
-            申请测试
+            <LocalizedText zh="申请测试" en="Apply for beta" />
           </a>
         </div>
       </section>

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -25,6 +25,22 @@ html {
   scroll-behavior: smooth;
 }
 
+html:not([data-site-locale="en"]) .locale-en {
+  display: none;
+}
+
+html:not([data-site-locale="en"]) .locale-zh {
+  display: inline;
+}
+
+html[data-site-locale="en"] .locale-zh {
+  display: none;
+}
+
+html[data-site-locale="en"] .locale-en {
+  display: inline;
+}
+
 body {
   margin: 0;
   background: var(--bg);
@@ -32,9 +48,17 @@ body {
   font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
+html[data-site-locale="en"] body {
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
 a {
   color: inherit;
   text-decoration: none;
+}
+
+button {
+  font: inherit;
 }
 
 img,
@@ -57,6 +81,10 @@ h3,
 .footer-title {
   margin: 0;
   letter-spacing: 0;
+}
+
+.localized-text {
+  display: inline;
 }
 
 .page-shell,
@@ -153,6 +181,32 @@ h3,
 
 .site-nav-links a:hover {
   color: var(--ink);
+}
+
+.language-switch {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.06);
+}
+
+.language-button {
+  min-width: 44px;
+  min-height: 34px;
+  padding: 6px 12px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted-strong);
+  cursor: pointer;
+  transition: background-color 180ms ease, color 180ms ease;
+}
+
+.language-button.active {
+  background: rgba(232, 189, 107, 0.18);
+  color: var(--gold-soft);
 }
 
 .nav-cta,
@@ -263,7 +317,9 @@ h3,
 }
 
 .release-pill {
-  min-height: 88px;
+  display: grid;
+  gap: 8px;
+  min-height: 108px;
   padding: 16px;
   border: 1px solid var(--line);
   border-radius: 8px;
@@ -289,6 +345,22 @@ h3,
   display: block;
   color: var(--ink);
   line-height: 1.35;
+}
+
+.release-pill small,
+.release-pill em,
+.platform-detail-line,
+.release-note,
+.recommended-tag {
+  color: var(--muted);
+  font-style: normal;
+  font-size: 0.88rem;
+}
+
+.release-pill small,
+.release-pill em {
+  display: block;
+  line-height: 1.4;
 }
 
 .hero-visual {
@@ -478,6 +550,10 @@ h3,
   padding: 20px;
 }
 
+.platform-row.detailed {
+  align-items: start;
+}
+
 .platform-row.accent-row {
   background:
     linear-gradient(135deg, rgba(232, 189, 107, 0.15), rgba(120, 214, 232, 0.06)),
@@ -501,7 +577,11 @@ h3,
 .path-card p,
 .evidence-card p,
 .compare-card p,
-.note-grid p {
+.note-grid p,
+.platform-summary-list li,
+.release-summary-list li,
+.changelog-entry li,
+.changelog-meta time {
   margin: 0;
   color: var(--muted);
   line-height: 1.72;
@@ -520,6 +600,24 @@ h3,
 .platform-meta span,
 .editorial-row small {
   color: var(--muted);
+}
+
+.platform-detail-line,
+.release-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.platform-summary-list,
+.release-summary-list {
+  margin: 12px 0 0;
+  padding-left: 18px;
+}
+
+.platform-summary-list.compact,
+.release-summary-list.compact {
+  margin-top: 8px;
 }
 
 .feature-card,
@@ -552,6 +650,10 @@ h3,
   color: var(--ink);
   font-size: 1.18rem;
   line-height: 1.34;
+}
+
+.homepage-release-card {
+  max-width: 820px;
 }
 
 .moment-card {
@@ -618,10 +720,8 @@ h3,
   font-size: 0.9rem;
 }
 
-.release-card-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+.release-card-meta.compact {
+  font-size: 0.82rem;
 }
 
 .mirror-links a {
@@ -663,6 +763,27 @@ h3,
 
 .inline-cta {
   margin-top: 26px;
+}
+
+.recommended-banner,
+.section-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 249, 235, 0.04);
+  color: var(--muted-strong);
+}
+
+.section-divider {
+  justify-content: center;
+}
+
+.recommended-tag {
+  margin-left: 6px;
+  color: var(--gold-soft);
 }
 
 .editorial-row {
@@ -772,6 +893,10 @@ h3,
     font-size: 0.9rem;
   }
 
+  .language-switch {
+    order: 2;
+  }
+
   .nav-cta {
     display: none;
   }
@@ -787,7 +912,7 @@ h3,
   }
 
   .release-pill {
-    min-height: 72px;
+    min-height: 88px;
   }
 
   .platform-meta {
@@ -820,19 +945,18 @@ h3,
   }
 }
 
-/* Changelog timeline */
 .changelog-timeline {
   display: flex;
   flex-direction: column;
   gap: 0;
-  max-width: 720px;
+  max-width: 820px;
   margin: 0 auto;
 }
 
 .changelog-entry {
   position: relative;
   padding: 28px 0 28px 32px;
-  border-left: 2px solid rgba(18, 18, 28, 0.08);
+  border-left: 2px solid rgba(255, 249, 235, 0.12);
 }
 
 .changelog-entry:last-child {
@@ -847,7 +971,7 @@ h3,
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: var(--screenshot-bg-c, #7b72ff);
+  background: var(--gold);
 }
 
 .changelog-meta {
@@ -862,6 +986,7 @@ h3,
   font-size: 1.1rem;
   font-weight: 680;
   margin: 0;
+  color: var(--ink);
 }
 
 .changelog-meta h3 a {
@@ -874,38 +999,13 @@ h3,
 }
 
 .changelog-meta time {
-  color: rgba(5, 5, 7, 0.42);
   font-size: 0.85rem;
-}
-
-.changelog-entry ul {
-  margin: 0 0 16px;
-  padding: 0;
-  list-style: none;
-}
-
-.changelog-entry li {
-  position: relative;
-  padding: 4px 0 4px 18px;
-  color: rgba(5, 5, 7, 0.7);
-  font-size: 0.94rem;
-  line-height: 1.55;
-}
-
-.changelog-entry li::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 12px;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: rgba(18, 18, 28, 0.16);
 }
 
 .changelog-entry .secondary-action {
   display: inline-block;
   font-size: 0.88rem;
+  margin-top: 8px;
 }
 
 @media (max-width: 720px) {

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -1,34 +1,31 @@
 import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import { brand } from "@fabushi/shared";
+import { LocaleProvider } from "../components/locale-provider";
 import { siteUrl } from "../lib/site-url";
 import "./globals.css";
 
 const homeUrl = siteUrl("/");
-const siteTitle = `${brand.name} 大乘 | 经文听诵、禅修与全球法布施`;
+const siteTitle = `${brand.name} | Dharma Sharing, Meditation, and Global Practice`;
 const siteDescription =
-  "大乘 法布施提供经文听诵、禅修冥想、法流视频、修行记录与 Android / iOS 下载入口。";
+  "Fabushi offers sutra listening, meditation, dharma videos, practice tracking, and Android / iOS beta downloads.";
 
 export const metadata: Metadata = {
   title: siteTitle,
   description: siteDescription,
   keywords: [
+    "Fabushi",
     "法布施",
-    "大乘",
-    "佛法传播",
-    "修行记录",
-    "共修",
-    "佛教应用",
-    "佛法社区",
-    "下载入口",
+    "meditation",
+    "sutra",
+    "practice tracker",
     "Android Beta",
-    "TestFlight",
-    "微信小程序",
+    "iOS TestFlight",
   ],
-  applicationName: `${brand.name} 大乘`,
-  authors: [{ name: "大乘" }],
-  creator: "大乘",
-  publisher: "大乘",
+  applicationName: `${brand.name} Fabushi`,
+  authors: [{ name: "Fabushi" }],
+  creator: "Fabushi",
+  publisher: "Fabushi",
   metadataBase: new URL(homeUrl),
   alternates: {
     canonical: homeUrl,
@@ -39,8 +36,8 @@ export const metadata: Metadata = {
     title: siteTitle,
     description: siteDescription,
     url: homeUrl,
-    siteName: "大乘",
-    locale: "zh_CN",
+    siteName: "Fabushi",
+    locale: "en_US",
     type: "website",
   },
   twitter: {
@@ -63,8 +60,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="zh-CN">
-      <body>{children}</body>
+    <html lang="zh-CN" suppressHydrationWarning>
+      <body>
+        <LocaleProvider>{children}</LocaleProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,10 +1,12 @@
-import { brand, contactChannels, faqItems, homeHighlights } from "@fabushi/shared";
+import { brand, contactChannels } from "@fabushi/shared";
 import { DownloadLink } from "../components/download-link";
+import { LocalizedText } from "../components/localized-text";
 import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
 import {
   FALLBACK_SCREENSHOTS,
   getOfficialSiteReleaseCollection,
+  type OfficialSiteChannel,
   type OfficialSiteScreenshots,
 } from "../lib/official-site-releases";
 import { siteHref, siteUrl } from "../lib/site-url";
@@ -18,13 +20,15 @@ const SCREENSHOT_KEYS = [
   "group-practice",
   "global-ranking",
   "global-donation",
-  "global-donation-leaderboard"
+  "global-donation-leaderboard",
 ] as const;
 type ProductScreenshotKey = (typeof SCREENSHOT_KEYS)[number];
 
 interface ProductMoment {
-  title: string;
-  description: string;
+  titleZh: string;
+  titleEn: string;
+  descriptionZh: string;
+  descriptionEn: string;
   screenshot: ProductScreenshotKey;
   alt: string;
 }
@@ -34,57 +38,168 @@ const HERO_SIDE_IMAGE_KEY: ProductScreenshotKey = "main-sutra";
 
 const PRODUCT_MOMENTS: ProductMoment[] = [
   {
-    title: "全球法布施",
-    description: "看见善意如何跨越地域，直接抵达世界各地。",
+    titleZh: "全球法布施",
+    titleEn: "Global Giving",
+    descriptionZh: "看见善意如何跨越地域，直接抵达世界各地。",
+    descriptionEn: "See compassion travel across regions and reach people around the world.",
     screenshot: "global-dharma",
-    alt: "大乘 全球法布施界面截图",
+    alt: "Fabushi global dharma screen",
   },
   {
-    title: "随时随地开始修行",
-    description: "打开就能进入禅修状态，把修行节奏留在日常里。",
+    titleZh: "随时随地开始修行",
+    titleEn: "Start Practicing Anytime",
+    descriptionZh: "打开就能进入禅修状态，把修行节奏留在日常里。",
+    descriptionEn: "Open the app and return to practice without friction.",
     screenshot: "start-meditation",
-    alt: "大乘 修行入口界面截图",
+    alt: "Fabushi meditation entry screen",
   },
   {
-    title: "沉浸式禅修体验",
-    description: "用更安静、更专注的界面承接每一次练习。",
+    titleZh: "沉浸式禅修体验",
+    titleEn: "Immersive Meditation",
+    descriptionZh: "用更安静、更专注的界面承接每一次练习。",
+    descriptionEn: "A calmer, more focused interface for each meditation session.",
     screenshot: "immersive-meditation",
-    alt: "大乘 沉浸式禅修体验界面截图",
+    alt: "Fabushi immersive meditation screen",
   },
   {
-    title: "锁定主修功课",
-    description: "先确定主线，再围绕自己的路径稳定推进。",
+    titleZh: "锁定主修功课",
+    titleEn: "Keep Your Main Practice Stable",
+    descriptionZh: "先确定主线，再围绕自己的路径稳定推进。",
+    descriptionEn: "Choose a main path first, then keep steady progress around it.",
     screenshot: "main-sutra",
-    alt: "大乘 主修功课界面截图",
+    alt: "Fabushi main practice screen",
   },
   {
-    title: "轻松加入共修小组",
-    description: "搜索、申请、加入和管理共修关系都放在同一条路径里。",
+    titleZh: "轻松加入共修小组",
+    titleEn: "Join Group Practice Easily",
+    descriptionZh: "搜索、申请、加入和管理共修关系都放在同一条路径里。",
+    descriptionEn: "Search, apply, join, and manage group practice from one flow.",
     screenshot: "group-practice",
-    alt: "大乘 共修小组界面截图",
+    alt: "Fabushi group practice screen",
   },
   {
-    title: "全球修行排行",
-    description: "修行进度和榜单变化一眼可见，方便持续跟进。",
+    titleZh: "全球修行排行",
+    titleEn: "Global Practice Rankings",
+    descriptionZh: "修行进度和榜单变化一眼可见，方便持续跟进。",
+    descriptionEn: "Track progress and ranking changes at a glance.",
     screenshot: "global-ranking",
-    alt: "大乘 全球修行排行界面截图",
+    alt: "Fabushi practice ranking screen",
   },
   {
-    title: "全球布施排行",
-    description: "实时查看全球布施动态，感受功德流动。",
+    titleZh: "全球布施排行",
+    titleEn: "Global Donation Activity",
+    descriptionZh: "实时查看全球布施动态，感受功德流动。",
+    descriptionEn: "Follow donation activity in real time and see merit in motion.",
     screenshot: "global-donation",
-    alt: "大乘 全球布施排行界面截图",
+    alt: "Fabushi donation activity screen",
   },
   {
-    title: "全球布施排行榜",
-    description: "用更直观的排行榜界面看见用户与善行的连接。",
+    titleZh: "全球布施排行榜",
+    titleEn: "Donation Leaderboard",
+    descriptionZh: "用更直观的排行榜界面看见用户与善行的连接。",
+    descriptionEn: "A clearer leaderboard view that connects people with generosity.",
     screenshot: "global-donation-leaderboard",
-    alt: "大乘 全球布施排行榜界面截图",
+    alt: "Fabushi donation leaderboard screen",
   },
 ];
 
+const FEATURE_HIGHLIGHTS = [
+  {
+    titleZh: "经文与禅修放在同一处",
+    titleEn: "Sutras and meditation in one place",
+    descriptionZh: "减少切换成本，让修行从打开应用开始就更顺。",
+    descriptionEn: "Reduce context switching so practice starts smoothly the moment the app opens.",
+  },
+  {
+    titleZh: "版本状态公开可见",
+    titleEn: "Visible release status",
+    descriptionZh: "官网直接同步 GitHub 发布版本、发布时间和更新摘要。",
+    descriptionEn: "The site now syncs GitHub release versions, publish time, and update summaries directly.",
+  },
+  {
+    titleZh: "下载入口按平台组织",
+    titleEn: "Platform-aware download entry",
+    descriptionZh: "Android、iOS 和镜像入口分开呈现，减少误点。",
+    descriptionEn: "Android, iOS, and mirror links are separated so the right path is easier to choose.",
+  },
+  {
+    titleZh: "全球善行有反馈",
+    titleEn: "Global feedback loop",
+    descriptionZh: "排行榜、布施动态和共修小组让持续修行更有回应。",
+    descriptionEn: "Rankings, donation activity, and group practice create a stronger feedback loop.",
+  },
+] as const;
+
+const FAQ_PREVIEW = [
+  {
+    questionZh: "我应该下载哪个版本？",
+    questionEn: "Which version should I download?",
+    answerZh: "想尽快体验新功能，先下测试版；更重视稳定性，就等正式版。",
+    answerEn: "Choose beta if you want the newest features quickly. Wait for stable if you prefer a calmer release.",
+  },
+  {
+    questionZh: "iOS 为什么会跳到 TestFlight？",
+    questionEn: "Why does iOS open TestFlight?",
+    answerZh: "iOS 内测通过 Apple TestFlight 分发，公开加入后官网会直接带你过去。",
+    answerEn: "iOS beta builds are distributed through Apple TestFlight, and the site takes you there when public access is ready.",
+  },
+  {
+    questionZh: "Android 下载慢怎么办？",
+    questionEn: "What if Android downloads are slow?",
+    answerZh: "国内网络环境下可以优先尝试镜像入口，原始链接仍会保留。",
+    answerEn: "If the original Android download is slow, try the mirror links first. The original link stays available too.",
+  },
+  {
+    questionZh: "官网会显示我下载的是哪个版本吗？",
+    questionEn: "Will the site show which version I am downloading?",
+    answerZh: "会。首页和下载页现在都会显示版本号、发布时间和最近更新摘要。",
+    answerEn: "Yes. The homepage and download page now show version, publish date, and a short update summary.",
+  },
+] as const;
+
 function resolveScreenshot(screenshots: OfficialSiteScreenshots, key: ProductScreenshotKey) {
   return screenshots[key] ?? FALLBACK_SCREENSHOTS[key];
+}
+
+function formatPublishedAt(value?: string) {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+function getChannelActionCopy(channel: OfficialSiteChannel) {
+  if (channel.platform === "iOS") {
+    return {
+      zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
+      en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
+    };
+  }
+
+  return {
+    zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
+    en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
+  };
+}
+
+function getChannelDisplayTitle(channel: OfficialSiteChannel) {
+  if (channel.platform === "iOS") {
+    return {
+      zh: channel.audience === "beta" ? "iOS 测试版" : "iOS 正式版",
+      en: channel.audience === "beta" ? "iOS Beta" : "iOS Stable",
+    };
+  }
+
+  return {
+    zh: channel.audience === "beta" ? "Android 测试版" : "Android 正式版",
+    en: channel.audience === "beta" ? "Android Beta" : "Android Stable",
+  };
 }
 
 export default async function HomePage() {
@@ -95,36 +210,36 @@ export default async function HomePage() {
   };
   const channels = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 3);
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
-  const directChannel = releaseCollection.betaChannels.find((item) => !item.primaryHref.startsWith("/contact"));
-  const primaryLabel = directChannel?.primaryLabel ?? "查看下载入口";
-  const faqPreview = faqItems.slice(0, 4);
+  const androidBetaChannel = releaseCollection.betaChannels.find((item) => item.platform === "Android");
+  const iosBetaChannel = releaseCollection.betaChannels.find((item) => item.platform === "iOS");
+  const latestRelease = releaseCollection.releases[0];
 
   const structuredData = {
     "@context": "https://schema.org",
     "@graph": [
       {
         "@type": "Organization",
-        name: `${brand.name} 大乘`,
+        name: `${brand.name} Fabushi`,
         url: siteUrl("/"),
         email: supportEmail,
-        description: brand.mission,
+        description: "Fabushi offers meditation, sutra listening, and global giving.",
       },
       {
         "@type": "SoftwareApplication",
-        name: `${brand.name} 大乘`,
+        name: `${brand.name} Fabushi`,
         applicationCategory: "LifestyleApplication",
         operatingSystem: "iOS, Android, Web",
         url: siteUrl("/download"),
-        description: brand.tagline,
+        description: "Meditation, sutra listening, and global dharma sharing.",
       },
       {
         "@type": "FAQPage",
-        mainEntity: faqPreview.map((item) => ({
+        mainEntity: FAQ_PREVIEW.map((item) => ({
           "@type": "Question",
-          name: item.question,
+          name: item.questionEn,
           acceptedAnswer: {
             "@type": "Answer",
-            text: item.answer,
+            text: item.answerEn,
           },
         })),
       },
@@ -145,59 +260,95 @@ export default async function HomePage() {
           <section className="hero-copy" aria-labelledby="home-title">
             <div className="brand-kicker">
               <img src={siteHref("/product/app-icon.png")} alt="" />
-              <span>大乘</span>
+              <span>
+                <LocalizedText zh="大乘" en="Fabushi" />
+              </span>
             </div>
-            <h1 id="home-title">法布施</h1>
-            <p className="hero-subtitle">{brand.tagline}</p>
+            <h1 id="home-title">
+              <LocalizedText zh="法布施" en="Dharma Sharing" />
+            </h1>
+            <p className="hero-subtitle">
+              <LocalizedText
+                zh="经文听诵、禅修、法流视频、修行记录与全球法布施。"
+                en="Sutra listening, meditation, dharma videos, practice tracking, and global giving in one place."
+              />
+            </p>
             <div className="hero-actions">
-              {directChannel ? (
-                <DownloadLink className="primary-action" channel={directChannel}>
-                  {primaryLabel}
+              {androidBetaChannel ? (
+                <DownloadLink className="primary-action" channel={androidBetaChannel}>
+                  <LocalizedText zh="下载 Android 测试版" en="Download Android Beta" />
                 </DownloadLink>
               ) : (
                 <a className="primary-action" href={siteHref("/download")}>
-                  {primaryLabel}
+                  <LocalizedText zh="查看下载入口" en="View downloads" />
                 </a>
               )}
-              <a className="secondary-action" href={siteHref("/apply")}>
-                申请测试
-              </a>
+              {iosBetaChannel ? (
+                <DownloadLink className="secondary-action" channel={iosBetaChannel}>
+                  <LocalizedText zh="下载 iOS 测试版" en="Download iOS Beta" />
+                </DownloadLink>
+              ) : (
+                <a className="secondary-action" href={siteHref("/apply")}>
+                  <LocalizedText zh="申请测试" en="Apply for beta" />
+                </a>
+              )}
             </div>
 
-            <div className="release-pill-grid" aria-label="当前下载状态">
+            <div className="release-pill-grid" aria-label="Current download status / 当前下载状态">
               {channels.length > 0 ? (
-                channels.map((item) => (
-                  <DownloadLink
-                    key={`${item.audience}-${item.platform}`}
-                    className="release-pill"
-                    channel={item}
-                  >
-                    <span>{item.title}</span>
-                    <strong>{item.status}</strong>
-                  </DownloadLink>
-                ))
+                channels.map((item) => {
+                  const titleCopy = getChannelDisplayTitle(item);
+                  const actionCopy = getChannelActionCopy(item);
+                  const publishedAt = formatPublishedAt(item.publishedAt);
+                  return (
+                    <DownloadLink
+                      key={`${item.audience}-${item.platform}`}
+                      className="release-pill"
+                      channel={item}
+                    >
+                      <span>
+                        <LocalizedText zh={titleCopy.zh} en={titleCopy.en} />
+                      </span>
+                      <strong>{item.status}</strong>
+                      {(item.version || publishedAt) && (
+                        <small>
+                          {item.version ? `v${item.version}` : ""}
+                          {item.version && publishedAt ? " · " : ""}
+                          {publishedAt ?? ""}
+                        </small>
+                      )}
+                      <em>
+                        <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
+                      </em>
+                    </DownloadLink>
+                  );
+                })
               ) : (
                 <a className="release-pill" href={siteHref("/download")}>
-                  <span>下载入口</span>
-                  <strong>同步中</strong>
+                  <span>
+                    <LocalizedText zh="下载入口" en="Downloads" />
+                  </span>
+                  <strong>
+                    <LocalizedText zh="同步中" en="Syncing" />
+                  </strong>
                 </a>
               )}
             </div>
           </section>
 
-          <section className="hero-visual" aria-label="大乘 产品预览">
+          <section className="hero-visual" aria-label="Fabushi product preview">
             <ZenOrbit />
             <div className="phone-stack">
               <div className="phone-frame main-phone poster-frame">
                 <img
                   src={siteHref(resolveScreenshot(screenshots, HERO_MAIN_IMAGE_KEY))}
-                  alt="大乘 首页精选界面截图"
+                  alt="Fabushi homepage screenshot"
                 />
               </div>
               <div className="phone-frame side-phone poster-frame">
                 <img
                   src={siteHref(resolveScreenshot(screenshots, HERO_SIDE_IMAGE_KEY))}
-                  alt="大乘 功能预览界面截图"
+                  alt="Fabushi feature preview screenshot"
                 />
               </div>
             </div>
@@ -207,49 +358,134 @@ export default async function HomePage() {
 
       <section className="band compact-band" id="download">
         <div className="section-heading tight">
-          <p>下载</p>
-          <h2>按你的平台进入。</h2>
+          <p>
+            <LocalizedText zh="下载" en="Download" />
+          </p>
+          <h2>
+            <LocalizedText zh="按你的平台进入。" en="Pick the path that matches your platform." />
+          </h2>
         </div>
         <div className="platform-strip">
-          {channels.map((item) => (
-            <DownloadLink
-              key={`${item.audience}-${item.platform}`}
-              className="platform-row"
-              channel={item}
-            >
-              <div>
-                <span className="platform-name">{item.title}</span>
-                <p>{item.description}</p>
-              </div>
-              <div className="platform-meta">
-                <strong>{item.status}</strong>
-                <span>{item.primaryLabel}</span>
-              </div>
-            </DownloadLink>
-          ))}
+          {channels.map((item) => {
+            const titleCopy = getChannelDisplayTitle(item);
+            const actionCopy = getChannelActionCopy(item);
+            const publishedAt = formatPublishedAt(item.publishedAt);
+            return (
+              <DownloadLink
+                key={`${item.audience}-${item.platform}`}
+                className="platform-row detailed"
+                channel={item}
+              >
+                <div>
+                  <span className="platform-name">
+                    <LocalizedText zh={titleCopy.zh} en={titleCopy.en} />
+                  </span>
+                  <p>{item.description}</p>
+                  {(item.version || publishedAt) && (
+                    <div className="platform-detail-line">
+                      {item.version ? <span>v{item.version}</span> : null}
+                      {publishedAt ? <span>{publishedAt}</span> : null}
+                    </div>
+                  )}
+                </div>
+                <div className="platform-meta">
+                  <strong>{item.status}</strong>
+                  <span>
+                    <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
+                  </span>
+                </div>
+              </DownloadLink>
+            );
+          })}
           <a className="platform-row accent-row" href={siteHref("/download")}>
             <div>
-              <span className="platform-name">全部入口</span>
-              <p>查看 Android、iOS、正式版和镜像说明。</p>
+              <span className="platform-name">
+                <LocalizedText zh="全部入口" en="All downloads" />
+              </span>
+              <p>
+                <LocalizedText
+                  zh="查看 Android、iOS、正式版、镜像和最近更新。"
+                  en="See Android, iOS, stable, mirror links, and recent updates in one place."
+                />
+              </p>
             </div>
             <div className="platform-meta">
-              <strong>下载页</strong>
-              <span>进入</span>
+              <strong>
+                <LocalizedText zh="下载页" en="Download page" />
+              </strong>
+              <span>
+                <LocalizedText zh="进入" en="Open" />
+              </span>
             </div>
           </a>
         </div>
       </section>
 
+      {latestRelease ? (
+        <section className="band alt" id="updates">
+          <div className="section-heading tight">
+            <p>
+              <LocalizedText zh="版本更新" en="Release update" />
+            </p>
+            <h2>
+              <LocalizedText zh="官网现在会同步 GitHub 发布信息。" en="The site now mirrors GitHub release information." />
+            </h2>
+          </div>
+          <article className="release-card homepage-release-card">
+            <div className="release-card-header">
+              <div>
+                <p className="eyebrow">
+                  <LocalizedText zh="最新版本" en="Latest release" />
+                </p>
+                <h2>{latestRelease.title}</h2>
+              </div>
+              {latestRelease.publishedAt ? <span className="download-status">{formatPublishedAt(latestRelease.publishedAt)}</span> : null}
+            </div>
+            <div className="release-card-meta">
+              <span>
+                <LocalizedText zh="版本" en="Version" /> {latestRelease.tag}
+              </span>
+              <span>
+                <LocalizedText zh="来源" en="Source" /> GitHub Releases
+              </span>
+            </div>
+            {latestRelease.summary.length > 0 ? (
+              <ul className="release-summary-list">
+                {latestRelease.summary.slice(0, 4).map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            ) : null}
+            <div className="release-card-actions">
+              <a className="primary-action" href={latestRelease.htmlUrl} target="_blank" rel="noopener noreferrer">
+                <LocalizedText zh="查看完整发布说明" en="View release notes" />
+              </a>
+              <a className="secondary-action" href={siteHref("/download")}>
+                <LocalizedText zh="查看全部下载入口" en="See all downloads" />
+              </a>
+            </div>
+          </article>
+        </section>
+      ) : null}
+
       <section className="band feature-band" id="features">
         <div className="section-heading tight">
-          <p>体验</p>
-          <h2>留下真正有用的信息。</h2>
+          <p>
+            <LocalizedText zh="体验" en="Experience" />
+          </p>
+          <h2>
+            <LocalizedText zh="留下真正有用的信息。" en="Show the details people actually need before downloading." />
+          </h2>
         </div>
         <div className="feature-grid">
-          {homeHighlights.map((item) => (
-            <article key={item.title} className="feature-card">
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
+          {FEATURE_HIGHLIGHTS.map((item) => (
+            <article key={item.titleEn} className="feature-card">
+              <h3>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </h3>
+              <p>
+                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+              </p>
             </article>
           ))}
         </div>
@@ -257,12 +493,16 @@ export default async function HomePage() {
 
       <section className="band product-band">
         <div className="section-heading tight">
-          <p>预览</p>
-          <h2>精选功能截图。</h2>
+          <p>
+            <LocalizedText zh="预览" en="Preview" />
+          </p>
+          <h2>
+            <LocalizedText zh="精选功能截图。" en="Key moments from the product." />
+          </h2>
         </div>
         <div className="moment-grid showcase-grid">
           {PRODUCT_MOMENTS.map((item) => (
-            <article key={item.title} className="moment-card">
+            <article key={item.titleEn} className="moment-card">
               <div className="moment-image">
                 <img
                   src={siteHref(resolveScreenshot(screenshots, item.screenshot))}
@@ -270,8 +510,12 @@ export default async function HomePage() {
                   loading="lazy"
                 />
               </div>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
+              <h3>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </h3>
+              <p>
+                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+              </p>
             </article>
           ))}
         </div>
@@ -280,22 +524,28 @@ export default async function HomePage() {
       <section className="band faq-band" id="faq">
         <div className="section-heading tight">
           <p>FAQ</p>
-          <h2>先回答最关键的。</h2>
+          <h2>
+            <LocalizedText zh="先回答最关键的。" en="Answer the questions that block people first." />
+          </h2>
         </div>
         <div className="faq-list">
-          {faqPreview.map((item) => (
-            <details key={item.question} className="faq-item">
-              <summary>{item.question}</summary>
-              <p>{item.answer}</p>
+          {FAQ_PREVIEW.map((item) => (
+            <details key={item.questionEn} className="faq-item">
+              <summary>
+                <LocalizedText zh={item.questionZh} en={item.questionEn} />
+              </summary>
+              <p>
+                <LocalizedText zh={item.answerZh} en={item.answerEn} />
+              </p>
             </details>
           ))}
         </div>
         <div className="inline-cta">
           <a className="secondary-action" href={siteHref("/faq")}>
-            查看全部常见问题
+            <LocalizedText zh="查看全部常见问题" en="View all FAQs" />
           </a>
           <a className="secondary-action" href={`mailto:${supportEmail}`}>
-            联系支持
+            <LocalizedText zh="联系支持" en="Contact support" />
           </a>
         </div>
       </section>

--- a/frontend/apps/web/src/components/download-client.tsx
+++ b/frontend/apps/web/src/components/download-client.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { DownloadLink } from "./download-link";
+import { LocalizedText } from "./localized-text";
+import { useSiteLocale } from "./locale-provider";
 
 export interface DownloadChannel {
   platform: "Android" | "iOS";
@@ -30,12 +32,12 @@ function detectPlatform(): DetectedPlatform {
   return "other";
 }
 
-function getRecommendedTitle(platform: DetectedPlatform): string {
+function getRecommendedTitle(platform: DetectedPlatform, locale: "zh" | "en"): string {
   switch (platform) {
     case "android":
-      return "推荐 Android Beta";
+      return locale === "zh" ? "推荐 Android 测试版" : "Recommended Android Beta";
     case "ios":
-      return "推荐 iOS TestFlight";
+      return locale === "zh" ? "推荐 iOS 测试版" : "Recommended iOS Beta";
     default:
       return "";
   }
@@ -47,7 +49,75 @@ function matchesPlatform(channel: DownloadChannel, platform: DetectedPlatform): 
   return false;
 }
 
+function formatPublishedAt(value?: string) {
+  if (!value) return null;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toISOString().slice(0, 10);
+}
+
+function getChannelActionCopy(channel: DownloadChannel) {
+  if (channel.audience === "stable" && channel.primaryHref.startsWith("/contact")) {
+    return {
+      zh: "查看状态",
+      en: "View status",
+    };
+  }
+
+  if (channel.platform === "iOS") {
+    return {
+      zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
+      en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
+    };
+  }
+
+  return {
+    zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
+    en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
+  };
+}
+
+function ChannelCard({ channel, recommended = false }: { channel: DownloadChannel; recommended?: boolean }) {
+  const publishedAt = formatPublishedAt(channel.publishedAt);
+  const actionCopy = getChannelActionCopy(channel);
+  const summary = channel.updateSummary.slice(0, 2);
+
+  return (
+    <DownloadLink className={recommended ? "platform-row recommended detailed" : "platform-row detailed"} channel={channel}>
+      <div>
+        <span className="platform-name">
+          {channel.title}
+          {recommended ? <sup className="recommended-tag"><LocalizedText zh="推荐" en="Top" /></sup> : null}
+        </span>
+        <p>{channel.description}</p>
+        {(channel.version || publishedAt) && (
+          <div className="platform-detail-line">
+            {channel.version ? <span>v{channel.version}</span> : null}
+            {publishedAt ? <span>{publishedAt}</span> : null}
+          </div>
+        )}
+        {summary.length > 0 && (
+          <ul className="platform-summary-list">
+            {summary.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="platform-meta">
+        <strong>{channel.status}</strong>
+        <span>
+          <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
+        </span>
+      </div>
+    </DownloadLink>
+  );
+}
+
 export function DownloadClient({ channels }: { channels: DownloadChannel[] }) {
+  const { locale } = useSiteLocale();
   const [platform, setPlatform] = useState<DetectedPlatform>("other");
   const [mounted, setMounted] = useState(false);
 
@@ -57,13 +127,9 @@ export function DownloadClient({ channels }: { channels: DownloadChannel[] }) {
   }, []);
 
   const recommended = platform !== "other" ? channels.filter((ch) => matchesPlatform(ch, platform)) : [];
-  const recommendedTitle = getRecommendedTitle(platform);
+  const recommendedTitle = getRecommendedTitle(platform, locale);
 
-  if (!mounted) {
-    return <div className="platform-strip">{renderAllChannels(channels)}</div>;
-  }
-
-  if (recommended.length === 0) {
+  if (!mounted || recommended.length === 0) {
     return <div className="platform-strip">{renderAllChannels(channels)}</div>;
   }
 
@@ -71,32 +137,20 @@ export function DownloadClient({ channels }: { channels: DownloadChannel[] }) {
     <>
       {recommendedTitle && (
         <div className="recommended-banner">
-          <span>为你推荐</span>
+          <span>
+            <LocalizedText zh="为你推荐" en="Recommended" />
+          </span>
           <span>{recommendedTitle}</span>
         </div>
       )}
       <div className="platform-strip recommended-first">
         {recommended.map((channel) => (
-          <DownloadLink
-            key={`${channel.audience}-${channel.platform}`}
-            className="platform-row recommended"
-            channel={channel}
-          >
-            <div>
-              <span className="platform-name">
-                {channel.title}
-                <sup className="recommended-tag">推荐</sup>
-              </span>
-              <p>{channel.description}</p>
-            </div>
-            <div className="platform-meta">
-              <strong>{channel.status}</strong>
-              <span>{channel.primaryLabel}</span>
-            </div>
-          </DownloadLink>
+          <ChannelCard key={`${channel.audience}-${channel.platform}-recommended`} channel={channel} recommended />
         ))}
         <div className="section-divider">
-          <span>全部下载入口</span>
+          <span>
+            <LocalizedText zh="全部下载入口" en="All download options" />
+          </span>
         </div>
         {renderAllChannels(channels)}
       </div>
@@ -106,19 +160,6 @@ export function DownloadClient({ channels }: { channels: DownloadChannel[] }) {
 
 function renderAllChannels(channels: DownloadChannel[]) {
   return channels.map((channel) => (
-    <DownloadLink
-      key={`${channel.audience}-${channel.platform}`}
-      className="platform-row"
-      channel={channel}
-    >
-      <div>
-        <span className="platform-name">{channel.title}</span>
-        <p>{channel.description}</p>
-      </div>
-      <div className="platform-meta">
-        <strong>{channel.status}</strong>
-        <span>{channel.primaryLabel}</span>
-      </div>
-    </DownloadLink>
+    <ChannelCard key={`${channel.audience}-${channel.platform}`} channel={channel} />
   ));
 }

--- a/frontend/apps/web/src/components/language-switch.tsx
+++ b/frontend/apps/web/src/components/language-switch.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useSiteLocale } from "./locale-provider";
+
+export function LanguageSwitch() {
+  const { locale, setLocale } = useSiteLocale();
+
+  return (
+    <div className="language-switch" aria-label="Language switch">
+      <button
+        type="button"
+        className={locale === "zh" ? "language-button active" : "language-button"}
+        onClick={() => setLocale("zh")}
+      >
+        中
+      </button>
+      <button
+        type="button"
+        className={locale === "en" ? "language-button active" : "language-button"}
+        onClick={() => setLocale("en")}
+      >
+        EN
+      </button>
+    </div>
+  );
+}

--- a/frontend/apps/web/src/components/locale-provider.tsx
+++ b/frontend/apps/web/src/components/locale-provider.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+export type SiteLocale = "zh" | "en";
+
+interface LocaleContextValue {
+  locale: SiteLocale;
+  setLocale: (nextLocale: SiteLocale) => void;
+}
+
+const STORAGE_KEY = "fabushi-site-locale";
+const DEFAULT_LOCALE: SiteLocale = "zh";
+const ZH_COUNTRY_CODES = new Set(["CN", "HK", "MO", "TW"]);
+
+const LocaleContext = createContext<LocaleContextValue>({
+  locale: DEFAULT_LOCALE,
+  setLocale: () => {},
+});
+
+function applyLocale(locale: SiteLocale) {
+  document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
+  document.documentElement.dataset.siteLocale = locale;
+}
+
+function normalizeLocale(value: string | null | undefined): SiteLocale | null {
+  if (value === "zh" || value === "en") {
+    return value;
+  }
+
+  return null;
+}
+
+function resolveLocaleFromLanguage(language: string | null | undefined): SiteLocale {
+  return language?.toLowerCase().startsWith("zh") ? "zh" : "en";
+}
+
+async function detectLocaleByIp(): Promise<SiteLocale | null> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), 1800);
+
+  try {
+    const response = await fetch("/cdn-cgi/trace", {
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const trace = await response.text();
+    const countryCode = trace
+      .split("\n")
+      .find((line) => line.startsWith("loc="))
+      ?.slice("loc=".length)
+      .trim()
+      .toUpperCase();
+
+    if (!countryCode) {
+      return null;
+    }
+
+    return ZH_COUNTRY_CODES.has(countryCode) ? "zh" : "en";
+  } catch {
+    return null;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<SiteLocale>(DEFAULT_LOCALE);
+
+  useEffect(() => {
+    let active = true;
+
+    const storedLocale = normalizeLocale(window.localStorage.getItem(STORAGE_KEY));
+    if (storedLocale) {
+      setLocaleState(storedLocale);
+      applyLocale(storedLocale);
+      return;
+    }
+
+    const browserLocale = resolveLocaleFromLanguage(window.navigator.language);
+    setLocaleState(browserLocale);
+    applyLocale(browserLocale);
+
+    detectLocaleByIp().then((detectedLocale) => {
+      if (!active || !detectedLocale) {
+        return;
+      }
+
+      setLocaleState(detectedLocale);
+      applyLocale(detectedLocale);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const setLocale = (nextLocale: SiteLocale) => {
+    setLocaleState(nextLocale);
+    applyLocale(nextLocale);
+    window.localStorage.setItem(STORAGE_KEY, nextLocale);
+  };
+
+  const value = useMemo(
+    () => ({ locale, setLocale }),
+    [locale],
+  );
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+}
+
+export function useSiteLocale() {
+  return useContext(LocaleContext);
+}

--- a/frontend/apps/web/src/components/localized-text.tsx
+++ b/frontend/apps/web/src/components/localized-text.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+interface LocalizedTextProps {
+  zh: ReactNode;
+  en: ReactNode;
+  className?: string;
+}
+
+export function LocalizedText({ zh, en, className }: LocalizedTextProps) {
+  return (
+    <span className={["localized-text", className].filter(Boolean).join(" ")}>
+      <span className="locale-zh">{zh}</span>
+      <span className="locale-en">{en}</span>
+    </span>
+  );
+}

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -1,19 +1,39 @@
+import { LocalizedText } from "./localized-text";
 import { siteHref } from "../lib/site-url";
 
 export function SiteFooter() {
   return (
     <footer className="site-footer">
       <div>
-        <p className="footer-title">法布施 大乘</p>
-        <p className="footer-copy">经文、禅修、法流与全球法布施。</p>
+        <p className="footer-title">
+          <LocalizedText zh="法布施 大乘" en="Fabushi" />
+        </p>
+        <p className="footer-copy">
+          <LocalizedText
+            zh="经文、禅修、法流与全球法布施。"
+            en="Sutras, meditation, dharma videos, and global giving."
+          />
+        </p>
       </div>
       <div className="footer-links">
-        <a href={siteHref("/download")}>下载入口</a>
-        <a href={siteHref("/apply")}>申请测试</a>
-        <a href={siteHref("/faq")}>常见问题</a>
-        <a href={siteHref("/privacy")}>隐私说明</a>
-        <a href={siteHref("/contact")}>联系</a>
-        <a href={siteHref("/insights")}>内容专栏</a>
+        <a href={siteHref("/download")}>
+          <LocalizedText zh="下载入口" en="Download" />
+        </a>
+        <a href={siteHref("/apply")}>
+          <LocalizedText zh="申请测试" en="Apply" />
+        </a>
+        <a href={siteHref("/faq")}>
+          <LocalizedText zh="常见问题" en="FAQ" />
+        </a>
+        <a href={siteHref("/privacy")}>
+          <LocalizedText zh="隐私说明" en="Privacy" />
+        </a>
+        <a href={siteHref("/contact")}>
+          <LocalizedText zh="联系" en="Contact" />
+        </a>
+        <a href={siteHref("/insights")}>
+          <LocalizedText zh="内容专栏" en="Insights" />
+        </a>
         <a href="mailto:support@ombhrum.com">support@ombhrum.com</a>
       </div>
     </footer>

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -1,23 +1,52 @@
-import { primaryNavigation } from "@fabushi/shared";
+import { LanguageSwitch } from "./language-switch";
+import { LocalizedText } from "./localized-text";
 import { siteHref } from "../lib/site-url";
+
+const NAV_ITEMS = [
+  {
+    href: "/#download",
+    zh: "下载",
+    en: "Download",
+  },
+  {
+    href: "/#features",
+    zh: "功能",
+    en: "Features",
+  },
+  {
+    href: "/faq",
+    zh: "常见问题",
+    en: "FAQ",
+  },
+  {
+    href: "/apply",
+    zh: "申请测试",
+    en: "Apply",
+  },
+] as const;
 
 export function SiteHeader() {
   return (
-    <nav className="site-nav" aria-label="主导航">
+    <nav className="site-nav" aria-label="Main navigation / 主导航">
       <a className="site-wordmark" href={siteHref("/")}>
-        <span>大乘</span>
-        <small>法布施</small>
+        <span>
+          <LocalizedText zh="大乘" en="Fabushi" />
+        </span>
+        <small>
+          <LocalizedText zh="法布施" en="Dharma Sharing" />
+        </small>
       </a>
       <div className="site-nav-links-wrap">
         <div className="site-nav-links">
-          {primaryNavigation.map((item) => (
+          {NAV_ITEMS.map((item) => (
             <a key={item.href} href={siteHref(item.href)}>
-              {item.label}
+              <LocalizedText zh={item.zh} en={item.en} />
             </a>
           ))}
         </div>
+        <LanguageSwitch />
         <a className="nav-cta" href={siteHref("/download")}>
-          下载入口
+          <LocalizedText zh="下载入口" en="Download" />
         </a>
       </div>
     </nav>

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -120,6 +120,9 @@ async function fetchJson<T>(url: string): Promise<T | null> {
       headers: {
         Accept: "application/vnd.github+json",
       },
+      next: {
+        revalidate: 600,
+      },
     });
 
     if (!response.ok) {
@@ -134,7 +137,11 @@ async function fetchJson<T>(url: string): Promise<T | null> {
 
 async function fetchText(url: string): Promise<string | null> {
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      next: {
+        revalidate: 600,
+      },
+    });
 
     if (!response.ok) {
       return null;
@@ -170,6 +177,20 @@ function buildMirrorLinks(primaryHref: string): OfficialSiteMirrorLink[] {
     label: item.label,
     href: `${item.prefix}${path}`,
   }));
+}
+
+function buildReleaseEntries(releases: GitHubRelease[]): OfficialSiteReleaseEntry[] {
+  return releases
+    .filter((release) => !release.draft)
+    .slice(0, 5)
+    .map((release) => ({
+      tag: release.tag_name,
+      title: release.name?.trim() || release.tag_name,
+      publishedAt: release.published_at ?? "",
+      htmlUrl: release.html_url,
+      summary: extractUpdateSummary(release.body, release.name ?? release.tag_name),
+    }))
+    .filter((entry) => entry.tag.length > 0);
 }
 
 function normalizeChannel(input: unknown): OfficialSiteChannel | null {
@@ -356,19 +377,20 @@ async function buildFallbackBetaState(release: GitHubRelease): Promise<OfficialS
   const testFlightStatus = await loadTestFlightStatus(release);
   if (testFlightStatus) {
     const uploaded = testFlightStatus.status === "uploaded";
-    const primaryHref = uploaded && iosTestFlightPublicUrl ? iosTestFlightPublicUrl : release.html_url;
+    const publicJoinHref = testFlightStatus.public_url || testFlightStatus.public_link || iosTestFlightPublicUrl;
+    const primaryHref = uploaded && publicJoinHref ? publicJoinHref : release.html_url;
     channels.push({
       platform: "iOS",
       audience: "beta",
-      status: uploaded ? "TestFlight 构建已上传" : "等待 TestFlight 可加入",
+      status: uploaded ? "TestFlight 已开放" : "等待 TestFlight 可加入",
       title: "iOS TestFlight Beta",
       description:
-        uploaded && iosTestFlightPublicUrl
+        uploaded && publicJoinHref
           ? "iOS beta 已经上传到 TestFlight，点击即可打开公开加入页面。"
           : uploaded
-            ? "iOS beta 已经上传到 TestFlight。公开加入链接开放后可直接加入。"
-          : "iOS beta 会在 TestFlight 上传成功后自动补到官网入口。",
-      primaryLabel: uploaded && iosTestFlightPublicUrl ? "加入 iOS TestFlight" : uploaded ? "查看 Beta 发布说明" : "等待 TestFlight 开放",
+            ? "iOS beta 已经上传到 TestFlight。公开加入链接同步后可直接加入。"
+            : "iOS beta 会在 TestFlight 上传成功后自动补到官网入口。",
+      primaryLabel: uploaded ? "下载 iOS 测试版" : "等待 iOS 测试版开放",
       primaryHref,
       version: testFlightStatus.build_number || release.tag_name,
       publishedAt: testFlightStatus.uploaded_at || release.published_at || undefined,
@@ -377,17 +399,18 @@ async function buildFallbackBetaState(release: GitHubRelease): Promise<OfficialS
       note:
         testFlightStatus.reason === "app_store_connect_credentials_not_configured"
           ? "当前仓库还没有配置 App Store Connect 上传凭据。"
-          : uploaded && iosTestFlightPublicUrl
+          : uploaded && publicJoinHref
             ? "点击后会打开 Apple TestFlight 的公开加入页面。"
-          : uploaded
-            ? "一旦公开 TestFlight 加入链接被同步进发布资产，这里会自动切成可直接加入。"
-            : "当前还没有可公开加入的 TestFlight 入口。",
+            : uploaded
+              ? "已经同步到发布记录，公开 TestFlight 加入链接配置后这里会自动切成直达入口。"
+              : "当前还没有可公开加入的 TestFlight 入口。",
       releasePageHref: release.html_url,
     });
   }
 
   return {
     channels,
+    releases: buildReleaseEntries([release]),
     notes: [
       "Android Beta 会优先显示最新 APK。",
       "iOS TestFlight 可加入时会显示直接入口。",
@@ -398,7 +421,11 @@ async function buildFallbackBetaState(release: GitHubRelease): Promise<OfficialS
 
 export async function getReleaseCollectionClient(): Promise<OfficialSiteReleaseCollection> {
   try {
-    const res = await fetch("/api/releases.json");
+    const res = await fetch("/api/releases.json", {
+      next: {
+        revalidate: 300,
+      },
+    });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = (await res.json()) as Record<string, unknown>;
     const channels = Array.isArray(data.channels)
@@ -421,7 +448,7 @@ export async function getReleaseCollectionClient(): Promise<OfficialSiteReleaseC
       stableChannels,
       screenshots: normalizeScreenshots(data.screenshots) ?? {},
       releases: normalizeReleaseEntries(data.releases),
-      notes: Array.isArray(data.notes) ? data.notes : [],
+      notes: Array.isArray(data.notes) ? data.notes.filter((item): item is string => typeof item === "string") : [],
     };
   } catch {
     return { betaChannels: [], stableChannels: [], screenshots: {}, releases: [], notes: [] };
@@ -431,6 +458,7 @@ export async function getReleaseCollectionClient(): Promise<OfficialSiteReleaseC
 export async function getOfficialSiteReleaseCollection(): Promise<OfficialSiteReleaseCollection> {
   const releases = (await fetchJson<GitHubRelease[]>(RELEASES_API_URL)) ?? [];
   const publishedReleases = releases.filter((release) => !release.draft);
+  const fallbackReleaseEntries = buildReleaseEntries(publishedReleases);
 
   const betaRelease = publishedReleases[0] ?? null;
   const syncedBetaState = betaRelease
@@ -454,7 +482,7 @@ export async function getOfficialSiteReleaseCollection(): Promise<OfficialSiteRe
     betaChannels: betaState?.channels ?? [],
     stableChannels: stableState?.channels?.length ? stableState.channels : DEFAULT_STABLE_CHANNELS,
     screenshots: betaState?.screenshots ?? {},
-    releases: betaState?.releases ?? [],
+    releases: betaState?.releases?.length ? betaState.releases : fallbackReleaseEntries,
     notes:
       betaState?.notes?.length
         ? betaState.notes

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -193,6 +193,43 @@ function buildReleaseEntries(releases: GitHubRelease[]): OfficialSiteReleaseEntr
     .filter((entry) => entry.tag.length > 0);
 }
 
+function isTestFlightJoinUrl(href: string): boolean {
+  return href.includes("testflight.apple.com");
+}
+
+function applyConfiguredIosTestFlightChannel(channel: OfficialSiteChannel): OfficialSiteChannel {
+  if (channel.platform !== "iOS" || channel.audience !== "beta" || !iosTestFlightPublicUrl) {
+    return channel;
+  }
+
+  if (isTestFlightJoinUrl(channel.primaryHref)) {
+    return channel;
+  }
+
+  const pointsToReleasePage =
+    !channel.primaryHref ||
+    channel.primaryHref.startsWith("https://github.com/") ||
+    channel.primaryHref.startsWith("/releases") ||
+    channel.primaryHref === channel.releasePageHref;
+
+  if (!pointsToReleasePage) {
+    return channel;
+  }
+
+  return {
+    ...channel,
+    status: channel.status.includes("TestFlight") ? channel.status : "TestFlight 已开放",
+    description: "iOS beta 已经配置为通过 Apple TestFlight 分发，点击即可打开公开加入页面。",
+    primaryLabel: "下载 iOS 测试版",
+    primaryHref: iosTestFlightPublicUrl,
+    note: "点击后会打开 Apple TestFlight 的公开加入页面。",
+  };
+}
+
+function applyConfiguredIosTestFlightChannels(channels: OfficialSiteChannel[]): OfficialSiteChannel[] {
+  return channels.map((channel) => applyConfiguredIosTestFlightChannel(channel));
+}
+
 function normalizeChannel(input: unknown): OfficialSiteChannel | null {
   if (!input || typeof input !== "object") {
     return null;
@@ -377,7 +414,7 @@ async function buildFallbackBetaState(release: GitHubRelease): Promise<OfficialS
   const testFlightStatus = await loadTestFlightStatus(release);
   if (testFlightStatus) {
     const uploaded = testFlightStatus.status === "uploaded";
-    const publicJoinHref = testFlightStatus.public_url || testFlightStatus.public_link || iosTestFlightPublicUrl;
+    const publicJoinHref = iosTestFlightPublicUrl || testFlightStatus.public_url || testFlightStatus.public_link;
     const primaryHref = uploaded && publicJoinHref ? publicJoinHref : release.html_url;
     channels.push({
       platform: "iOS",
@@ -444,7 +481,7 @@ export async function getReleaseCollectionClient(): Promise<OfficialSiteReleaseC
             .filter((item): item is OfficialSiteChannel => item !== null)
         : channels.filter((channel) => channel.audience === "stable");
     return {
-      betaChannels,
+      betaChannels: applyConfiguredIosTestFlightChannels(betaChannels),
       stableChannels,
       screenshots: normalizeScreenshots(data.screenshots) ?? {},
       releases: normalizeReleaseEntries(data.releases),
@@ -479,7 +516,7 @@ export async function getOfficialSiteReleaseCollection(): Promise<OfficialSiteRe
     : null;
 
   return {
-    betaChannels: betaState?.channels ?? [],
+    betaChannels: applyConfiguredIosTestFlightChannels(betaState?.channels ?? []),
     stableChannels: stableState?.channels?.length ? stableState.channels : DEFAULT_STABLE_CHANNELS,
     screenshots: betaState?.screenshots ?? {},
     releases: betaState?.releases?.length ? betaState.releases : fallbackReleaseEntries,


### PR DESCRIPTION
## Summary
- replace the homepage secondary CTA from test application to the iOS beta entry when an iOS beta channel exists
- add IP-based default locale detection with a manual Chinese/English toggle for the main official-site pages
- surface version, publish time, and update summaries on the homepage and download page
- fall back to GitHub Releases metadata when synced release state does not carry changelog entries

## Notes
- changes are scoped to the official-site experience under `frontend/apps/web`
- release data still prefers synced state assets, but now keeps showing release history even when the asset is incomplete
- iOS beta still opens the release page when a public TestFlight join URL is not configured

## Validation
- not run locally in this environment because the repository checkout is not available in the workspace
- reviewed the changed files and release data flow through the GitHub connector