### PR TITLE
修复官网语言切换、下载文案和重复截图

### DIFF
--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -11,6 +11,12 @@ import {
   getOfficialSiteReleaseCollection,
   type OfficialSiteChannel,
 } from "../../lib/official-site-releases";
+import {
+  getUserFacingDescription,
+  getUserFacingNote,
+  getUserFacingStatus,
+  getUserFacingSummary,
+} from "../../lib/channel-display";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
 const downloadUrl = siteUrl("/download");
@@ -35,6 +41,21 @@ const downloadFaqs = [
     questionEn: "Why does iOS open TestFlight?",
     answerZh: "iOS 内测通过 Apple TestFlight 分发。公开加入链接开放后，下载页会直接显示。",
     answerEn: "iOS beta is distributed through Apple TestFlight. Once public access is ready, the page links there directly.",
+  },
+] as const;
+
+const DOWNLOAD_NOTES = [
+  {
+    zh: "下载前先确认平台、版本号和发布时间，避免下错包。",
+    en: "Check the platform, version, and publish date before downloading so you get the right build.",
+  },
+  {
+    zh: "Android 下载较慢时，可以优先尝试镜像入口。",
+    en: "If Android downloads are slow, try the mirror links first.",
+  },
+  {
+    zh: "iOS 测试版通过 TestFlight 分发，入口开放后会直接跳转。",
+    en: "iOS beta is distributed through TestFlight, and the button will jump there once access opens.",
   },
 ] as const;
 
@@ -92,8 +113,11 @@ function getChannelActionCopy(channel: OfficialSiteChannel) {
 
 function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
   const publishedAt = formatPublishedAt(channel.publishedAt);
-  const summary = channel.updateSummary.slice(0, 3);
+  const summary = getUserFacingSummary(channel);
   const actionCopy = getChannelActionCopy(channel);
+  const statusCopy = getUserFacingStatus(channel);
+  const descriptionCopy = getUserFacingDescription(channel);
+  const noteCopy = getUserFacingNote(channel);
 
   return (
     <article className="release-card">
@@ -104,9 +128,13 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
           </p>
           <h2>{channel.title}</h2>
         </div>
-        <span className="download-status">{channel.status}</span>
+        <span className="download-status">
+          <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
+        </span>
       </div>
-      <p>{channel.description}</p>
+      <p>
+        <LocalizedText zh={descriptionCopy.zh} en={descriptionCopy.en} />
+      </p>
       {(channel.version || publishedAt) && (
         <div className="release-card-meta">
           {channel.version ? <span><LocalizedText zh="版本" en="Version" /> v{channel.version}</span> : null}
@@ -116,7 +144,9 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
       {summary.length > 0 ? (
         <ul className="release-summary-list">
           {summary.map((item) => (
-            <li key={item}>{item}</li>
+            <li key={item.en}>
+              <LocalizedText zh={item.zh} en={item.en} />
+            </li>
           ))}
         </ul>
       ) : null}
@@ -126,7 +156,7 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
         </DownloadLink>
         {channel.releasePageHref ? (
           <a className="secondary-action" href={siteHref(channel.releasePageHref)}>
-            <LocalizedText zh="查看 Release" en="View release" />
+            <LocalizedText zh="查看版本说明" en="View release notes" />
           </a>
         ) : null}
       </div>
@@ -139,7 +169,11 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
           ))}
         </div>
       )}
-      {channel.note ? <p className="release-note">{channel.note}</p> : null}
+      {noteCopy ? (
+        <p className="release-note">
+          <LocalizedText zh={noteCopy.zh} en={noteCopy.en} />
+        </p>
+      ) : null}
     </article>
   );
 }
@@ -150,7 +184,6 @@ export default async function DownloadPage() {
   const stableChannels = releaseCollection.stableChannels;
   const allChannels = [...betaChannels, ...stableChannels];
   const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
-  const notes = releaseCollection.notes.slice(0, 3);
 
   const structuredData = {
     "@context": "https://schema.org",
@@ -210,8 +243,8 @@ export default async function DownloadPage() {
           </h1>
           <p className="lede">
             <LocalizedText
-              zh="Android Beta、iOS TestFlight、发布时间和更新摘要会在这里一起同步。"
-              en="Android beta, iOS TestFlight, publish time, and update summaries are synced here together."
+              zh="这里会集中显示可下载版本、发布时间和最近更新。"
+              en="This page brings the available builds, publish date, and recent updates into one place."
             />
           </p>
         </div>
@@ -237,7 +270,7 @@ export default async function DownloadPage() {
                     <LocalizedText zh="测试版" en="Beta" />
                   </p>
                   <h2>
-                    <LocalizedText zh="Beta 同步中" en="Beta is syncing" />
+                    <LocalizedText zh="测试资格整理中" en="Beta access is being prepared" />
                   </h2>
                 </div>
                 <span className="download-status">
@@ -246,7 +279,7 @@ export default async function DownloadPage() {
               </div>
               <p>
                 <LocalizedText
-                  zh="当前还没有可公开点击的 Beta 入口。可以先提交测试申请。"
+                  zh="当前还没有公开可点的测试入口。可以先提交测试申请。"
                   en="There is no public beta button yet. You can still apply for access first."
                 />
               </p>
@@ -282,12 +315,14 @@ export default async function DownloadPage() {
             <LocalizedText zh="说明" en="Notes" />
           </p>
           <h2>
-            <LocalizedText zh="下载前只看这三条。" en="Three things worth checking before you download." />
+            <LocalizedText zh="下载前只看这几条。" en="A few things worth checking before you download." />
           </h2>
         </div>
         <div className="note-grid">
-          {notes.map((item) => (
-            <p key={item}>{item}</p>
+          {DOWNLOAD_NOTES.map((item) => (
+            <p key={item.en}>
+              <LocalizedText zh={item.zh} en={item.en} />
+            </p>
           ))}
           <p>
             <LocalizedText zh={`遇到下载或安装问题，发邮件到 ${supportEmail}。`} en={`If download or install fails, email ${supportEmail}.`} />

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -160,6 +160,7 @@ h3,
 
 .site-nav-links-wrap,
 .site-nav-links,
+.site-nav-actions,
 .hero-actions,
 .inline-cta,
 .release-card-actions,
@@ -168,6 +169,16 @@ h3,
   align-items: center;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+.site-nav-links-wrap {
+  flex: 1 1 auto;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.site-nav-actions {
+  margin-left: auto;
 }
 
 .site-nav-links {
@@ -184,28 +195,67 @@ h3,
 }
 
 .language-switch {
+  position: relative;
+}
+
+.language-toggle {
   display: inline-flex;
   align-items: center;
-  padding: 4px;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
   border: 1px solid var(--line);
   border-radius: 999px;
   background: rgba(255, 249, 235, 0.06);
+  color: var(--gold-soft);
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background-color 180ms ease;
 }
 
-.language-button {
-  min-width: 44px;
-  min-height: 34px;
-  padding: 6px 12px;
+.language-toggle:hover,
+.language-toggle[aria-expanded="true"] {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+  background: rgba(255, 249, 235, 0.1);
+}
+
+.language-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.language-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  min-width: 152px;
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(12, 17, 26, 0.96);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.language-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 40px;
+  padding: 10px 12px;
   border: 0;
-  border-radius: 999px;
+  border-radius: 10px;
   background: transparent;
   color: var(--muted-strong);
   cursor: pointer;
   transition: background-color 180ms ease, color 180ms ease;
 }
 
-.language-button.active {
-  background: rgba(232, 189, 107, 0.18);
+.language-option:hover,
+.language-option.active {
+  background: rgba(232, 189, 107, 0.16);
   color: var(--gold-soft);
 }
 
@@ -882,19 +932,25 @@ h3,
   }
 
   .site-nav,
-  .site-nav-links-wrap,
   .site-footer {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .site-nav-links {
-    gap: 10px;
-    font-size: 0.9rem;
+  .site-nav-links-wrap {
+    width: 100%;
+    align-items: flex-start;
+    gap: 14px;
   }
 
-  .language-switch {
-    order: 2;
+  .site-nav-actions {
+    margin-left: auto;
+  }
+
+  .site-nav-links {
+    width: 100%;
+    gap: 10px;
+    font-size: 0.9rem;
   }
 
   .nav-cta {

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -9,6 +9,10 @@ import {
   type OfficialSiteChannel,
   type OfficialSiteScreenshots,
 } from "../lib/official-site-releases";
+import {
+  getUserFacingDescription,
+  getUserFacingStatus,
+} from "../lib/channel-display";
 import { siteHref, siteUrl } from "../lib/site-url";
 import { ZenOrbit } from "../components/zen-orbit";
 
@@ -93,14 +97,6 @@ const PRODUCT_MOMENTS: ProductMoment[] = [
     screenshot: "global-donation",
     alt: "Fabushi donation activity screen",
   },
-  {
-    titleZh: "全球布施排行榜",
-    titleEn: "Donation Leaderboard",
-    descriptionZh: "用更直观的排行榜界面看见用户与善行的连接。",
-    descriptionEn: "A clearer leaderboard view that connects people with generosity.",
-    screenshot: "global-donation-leaderboard",
-    alt: "Fabushi donation leaderboard screen",
-  },
 ];
 
 const FEATURE_HIGHLIGHTS = [
@@ -111,10 +107,10 @@ const FEATURE_HIGHLIGHTS = [
     descriptionEn: "Reduce context switching so practice starts smoothly the moment the app opens.",
   },
   {
-    titleZh: "版本状态公开可见",
-    titleEn: "Visible release status",
-    descriptionZh: "官网直接同步 GitHub 发布版本、发布时间和更新摘要。",
-    descriptionEn: "The site now syncs GitHub release versions, publish time, and update summaries directly.",
+    titleZh: "下载前先看清版本",
+    titleEn: "See the version before you download",
+    descriptionZh: "首页直接告诉你平台、版本号、发布时间和最近更新。",
+    descriptionEn: "The homepage shows the platform, version, publish date, and latest updates before you tap download.",
   },
   {
     titleZh: "下载入口按平台组织",
@@ -152,8 +148,8 @@ const FAQ_PREVIEW = [
   {
     questionZh: "官网会显示我下载的是哪个版本吗？",
     questionEn: "Will the site show which version I am downloading?",
-    answerZh: "会。首页和下载页现在都会显示版本号、发布时间和最近更新摘要。",
-    answerEn: "Yes. The homepage and download page now show version, publish date, and a short update summary.",
+    answerZh: "会。首页和下载页都会显示版本号、发布时间和最近更新。",
+    answerEn: "Yes. The homepage and download page both show the version, publish date, and recent updates.",
   },
 ] as const;
 
@@ -185,20 +181,6 @@ function getChannelActionCopy(channel: OfficialSiteChannel) {
   return {
     zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
     en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
-  };
-}
-
-function getChannelDisplayTitle(channel: OfficialSiteChannel) {
-  if (channel.platform === "iOS") {
-    return {
-      zh: channel.audience === "beta" ? "iOS 测试版" : "iOS 正式版",
-      en: channel.audience === "beta" ? "iOS Beta" : "iOS Stable",
-    };
-  }
-
-  return {
-    zh: channel.audience === "beta" ? "Android 测试版" : "Android 正式版",
-    en: channel.audience === "beta" ? "Android Beta" : "Android Stable",
   };
 }
 
@@ -284,7 +266,7 @@ export default async function HomePage() {
                 </a>
               )}
               {iosBetaChannel ? (
-                <DownloadLink className="secondary-action" channel={iosBetaChannel}>
+                <DownloadLink className="primary-action" channel={iosBetaChannel}>
                   <LocalizedText zh="下载 iOS 测试版" en="Download iOS Beta" />
                 </DownloadLink>
               ) : (
@@ -297,8 +279,9 @@ export default async function HomePage() {
             <div className="release-pill-grid" aria-label="Current download status / 当前下载状态">
               {channels.length > 0 ? (
                 channels.map((item) => {
-                  const titleCopy = getChannelDisplayTitle(item);
+                  const titleCopy = item.title;
                   const actionCopy = getChannelActionCopy(item);
+                  const statusCopy = getUserFacingStatus(item);
                   const publishedAt = formatPublishedAt(item.publishedAt);
                   return (
                     <DownloadLink
@@ -306,10 +289,10 @@ export default async function HomePage() {
                       className="release-pill"
                       channel={item}
                     >
-                      <span>
-                        <LocalizedText zh={titleCopy.zh} en={titleCopy.en} />
-                      </span>
-                      <strong>{item.status}</strong>
+                      <span>{titleCopy}</span>
+                      <strong>
+                        <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
+                      </strong>
                       {(item.version || publishedAt) && (
                         <small>
                           {item.version ? `v${item.version}` : ""}
@@ -329,7 +312,7 @@ export default async function HomePage() {
                     <LocalizedText zh="下载入口" en="Downloads" />
                   </span>
                   <strong>
-                    <LocalizedText zh="同步中" en="Syncing" />
+                    <LocalizedText zh="入口整理中" en="Links coming soon" />
                   </strong>
                 </a>
               )}
@@ -367,8 +350,10 @@ export default async function HomePage() {
         </div>
         <div className="platform-strip">
           {channels.map((item) => {
-            const titleCopy = getChannelDisplayTitle(item);
+            const titleCopy = item.title;
             const actionCopy = getChannelActionCopy(item);
+            const descriptionCopy = getUserFacingDescription(item);
+            const statusCopy = getUserFacingStatus(item);
             const publishedAt = formatPublishedAt(item.publishedAt);
             return (
               <DownloadLink
@@ -377,10 +362,10 @@ export default async function HomePage() {
                 channel={item}
               >
                 <div>
-                  <span className="platform-name">
-                    <LocalizedText zh={titleCopy.zh} en={titleCopy.en} />
-                  </span>
-                  <p>{item.description}</p>
+                  <span className="platform-name">{titleCopy}</span>
+                  <p>
+                    <LocalizedText zh={descriptionCopy.zh} en={descriptionCopy.en} />
+                  </p>
                   {(item.version || publishedAt) && (
                     <div className="platform-detail-line">
                       {item.version ? <span>v{item.version}</span> : null}
@@ -389,7 +374,9 @@ export default async function HomePage() {
                   )}
                 </div>
                 <div className="platform-meta">
-                  <strong>{item.status}</strong>
+                  <strong>
+                    <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
+                  </strong>
                   <span>
                     <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
                   </span>
@@ -428,7 +415,7 @@ export default async function HomePage() {
               <LocalizedText zh="版本更新" en="Release update" />
             </p>
             <h2>
-              <LocalizedText zh="官网现在会同步 GitHub 发布信息。" en="The site now mirrors GitHub release information." />
+              <LocalizedText zh="下载前，先看最近版本和更新摘要。" en="Check the latest version and update summary before you download." />
             </h2>
           </div>
           <article className="release-card homepage-release-card">
@@ -446,7 +433,7 @@ export default async function HomePage() {
                 <LocalizedText zh="版本" en="Version" /> {latestRelease.tag}
               </span>
               <span>
-                <LocalizedText zh="来源" en="Source" /> GitHub Releases
+                <LocalizedText zh="类型" en="Type" /> <LocalizedText zh="官方更新" en="Official update" />
               </span>
             </div>
             {latestRelease.summary.length > 0 ? (
@@ -474,7 +461,7 @@ export default async function HomePage() {
             <LocalizedText zh="体验" en="Experience" />
           </p>
           <h2>
-            <LocalizedText zh="留下真正有用的信息。" en="Show the details people actually need before downloading." />
+            <LocalizedText zh="下载前就先知道真正有用的信息。" en="See the details that matter before you download." />
           </h2>
         </div>
         <div className="feature-grid">

--- a/frontend/apps/web/src/components/download-client.tsx
+++ b/frontend/apps/web/src/components/download-client.tsx
@@ -4,6 +4,11 @@ import { useEffect, useState } from "react";
 import { DownloadLink } from "./download-link";
 import { LocalizedText } from "./localized-text";
 import { useSiteLocale } from "./locale-provider";
+import {
+  getUserFacingDescription,
+  getUserFacingStatus,
+  getUserFacingSummary,
+} from "../lib/channel-display";
 
 export interface DownloadChannel {
   platform: "Android" | "iOS";
@@ -82,7 +87,9 @@ function getChannelActionCopy(channel: DownloadChannel) {
 function ChannelCard({ channel, recommended = false }: { channel: DownloadChannel; recommended?: boolean }) {
   const publishedAt = formatPublishedAt(channel.publishedAt);
   const actionCopy = getChannelActionCopy(channel);
-  const summary = channel.updateSummary.slice(0, 2);
+  const statusCopy = getUserFacingStatus(channel);
+  const descriptionCopy = getUserFacingDescription(channel);
+  const summary = getUserFacingSummary(channel);
 
   return (
     <DownloadLink className={recommended ? "platform-row recommended detailed" : "platform-row detailed"} channel={channel}>
@@ -91,7 +98,9 @@ function ChannelCard({ channel, recommended = false }: { channel: DownloadChanne
           {channel.title}
           {recommended ? <sup className="recommended-tag"><LocalizedText zh="推荐" en="Top" /></sup> : null}
         </span>
-        <p>{channel.description}</p>
+        <p>
+          <LocalizedText zh={descriptionCopy.zh} en={descriptionCopy.en} />
+        </p>
         {(channel.version || publishedAt) && (
           <div className="platform-detail-line">
             {channel.version ? <span>v{channel.version}</span> : null}
@@ -101,13 +110,17 @@ function ChannelCard({ channel, recommended = false }: { channel: DownloadChanne
         {summary.length > 0 && (
           <ul className="platform-summary-list">
             {summary.map((item) => (
-              <li key={item}>{item}</li>
+              <li key={item.en}>
+                <LocalizedText zh={item.zh} en={item.en} />
+              </li>
             ))}
           </ul>
         )}
       </div>
       <div className="platform-meta">
-        <strong>{channel.status}</strong>
+        <strong>
+          <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
+        </strong>
         <span>
           <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
         </span>

--- a/frontend/apps/web/src/components/language-switch.tsx
+++ b/frontend/apps/web/src/components/language-switch.tsx
@@ -1,26 +1,82 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { useSiteLocale } from "./locale-provider";
 
 export function LanguageSwitch() {
   const { locale, setLocale } = useSiteLocale();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, []);
+
+  function selectLocale(nextLocale: "zh" | "en") {
+    setLocale(nextLocale);
+    setOpen(false);
+  }
 
   return (
-    <div className="language-switch" aria-label="Language switch">
+    <div ref={rootRef} className="language-switch" aria-label="Language switch">
       <button
         type="button"
-        className={locale === "zh" ? "language-button active" : "language-button"}
-        onClick={() => setLocale("zh")}
+        className="language-toggle"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={locale === "zh" ? "切换语言" : "Change language"}
+        onClick={() => setOpen((current) => !current)}
       >
-        中
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M12 3h9M16.5 3c0 7-3.5 12-8.5 15M13 8H6m0 0h5m-5 0c0 3.5 1.8 6.7 4.8 8.9M5 21l4.2-10.5L13.4 21"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.7"
+          />
+        </svg>
       </button>
-      <button
-        type="button"
-        className={locale === "en" ? "language-button active" : "language-button"}
-        onClick={() => setLocale("en")}
-      >
-        EN
-      </button>
+      {open ? (
+        <div className="language-menu" role="menu">
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={locale === "zh"}
+            className={locale === "zh" ? "language-option active" : "language-option"}
+            onClick={() => selectLocale("zh")}
+          >
+            简体中文
+          </button>
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={locale === "en"}
+            className={locale === "en" ? "language-option active" : "language-option"}
+            onClick={() => selectLocale("en")}
+          >
+            English
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -44,10 +44,12 @@ export function SiteHeader() {
             </a>
           ))}
         </div>
-        <LanguageSwitch />
-        <a className="nav-cta" href={siteHref("/download")}>
-          <LocalizedText zh="下载入口" en="Download" />
-        </a>
+        <div className="site-nav-actions">
+          <LanguageSwitch />
+          <a className="nav-cta" href={siteHref("/download")}>
+            <LocalizedText zh="下载入口" en="Download" />
+          </a>
+        </div>
       </div>
     </nav>
   );

--- a/frontend/apps/web/src/lib/channel-display.ts
+++ b/frontend/apps/web/src/lib/channel-display.ts
@@ -1,0 +1,164 @@
+export interface DisplayChannel {
+  platform: "Android" | "iOS";
+  audience: "beta" | "stable";
+  status: string;
+  description: string;
+  primaryHref: string;
+  mirrorLinks: { label?: string; href: string }[];
+  updateSummary: string[];
+  note?: string;
+}
+
+interface LocalizedCopy {
+  zh: string;
+  en: string;
+}
+
+const TECHNICAL_COPY_PATTERN = /github|自动同步|仓库|app store connect|凭据|发布记录|release|同步|uploaded|upload|asset|api/i;
+
+function fallbackDescription(channel: DisplayChannel): LocalizedCopy {
+  if (channel.platform === "Android" && channel.audience === "beta") {
+    return {
+      zh: "适合希望第一时间体验新功能的用户。",
+      en: "Best for people who want the newest features first.",
+    };
+  }
+
+  if (channel.platform === "iOS" && channel.audience === "beta") {
+    return {
+      zh: "通过 TestFlight 安装，适合提前体验 iPhone 或 iPad 新版本。",
+      en: "Delivered through TestFlight for early access on iPhone or iPad.",
+    };
+  }
+
+  return {
+    zh: "适合更看重稳定安装和日常使用的用户。",
+    en: "Best for people who prefer a steadier install path.",
+  };
+}
+
+function fallbackSummary(channel: DisplayChannel): LocalizedCopy[] {
+  if (channel.platform === "Android" && channel.audience === "beta") {
+    return [
+      {
+        zh: "这里会优先显示最新可安装的 Android 测试版本。",
+        en: "This section highlights the latest Android beta you can install.",
+      },
+      {
+        zh: "下载较慢时，可以优先尝试镜像入口。",
+        en: "If the download is slow, try the mirror links first.",
+      },
+    ];
+  }
+
+  if (channel.platform === "iOS" && channel.audience === "beta") {
+    return [
+      {
+        zh: "iOS 测试版本通过 Apple TestFlight 分发。",
+        en: "iOS beta builds are distributed through Apple TestFlight.",
+      },
+      {
+        zh: "入口开放后，点击即可直接加入测试。",
+        en: "Once access is open, the button will take you straight into testing.",
+      },
+    ];
+  }
+
+  return [
+    {
+      zh: "正式版开放后，这里会提供更稳定的安装入口。",
+      en: "When stable is ready, this section will provide the steadier install path.",
+    },
+    {
+      zh: "下载前可以先确认版本号和更新时间。",
+      en: "You can confirm the version and publish date before downloading.",
+    },
+  ];
+}
+
+export function getUserFacingStatus(channel: DisplayChannel): LocalizedCopy {
+  if (channel.platform === "Android" && channel.audience === "beta") {
+    return {
+      zh: "最新测试版",
+      en: "Latest beta",
+    };
+  }
+
+  if (channel.platform === "iOS" && channel.audience === "beta") {
+    if (channel.primaryHref.includes("testflight.apple.com")) {
+      return {
+        zh: "TestFlight 可加入",
+        en: "Join on TestFlight",
+      };
+    }
+
+    return {
+      zh: "等待测试入口",
+      en: "Waiting for access",
+    };
+  }
+
+  if (channel.primaryHref.startsWith("/contact")) {
+    return {
+      zh: "正式版筹备中",
+      en: "Stable coming soon",
+    };
+  }
+
+  return {
+    zh: "正式版可用",
+    en: "Stable available",
+  };
+}
+
+export function getUserFacingDescription(channel: DisplayChannel): LocalizedCopy {
+  if (TECHNICAL_COPY_PATTERN.test(channel.description)) {
+    return fallbackDescription(channel);
+  }
+
+  return {
+    zh: channel.description,
+    en: channel.description,
+  };
+}
+
+export function getUserFacingSummary(channel: DisplayChannel): LocalizedCopy[] {
+  const summary = channel.updateSummary
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .filter((item) => !TECHNICAL_COPY_PATTERN.test(item))
+    .slice(0, 2)
+    .map((item) => ({ zh: item, en: item }));
+
+  return summary.length > 0 ? summary : fallbackSummary(channel);
+}
+
+export function getUserFacingNote(channel: DisplayChannel): LocalizedCopy | null {
+  if (channel.platform === "Android" && channel.mirrorLinks.length > 0) {
+    return {
+      zh: "下载较慢时，可优先尝试镜像入口。",
+      en: "If the download is slow, try the mirror links first.",
+    };
+  }
+
+  if (channel.platform === "iOS" && channel.audience === "beta") {
+    return channel.primaryHref.includes("testflight.apple.com")
+      ? {
+          zh: "点击后会打开 Apple TestFlight 页面。",
+          en: "This button opens the Apple TestFlight page.",
+        }
+      : {
+          zh: "测试资格开放后，这里会显示可加入入口。",
+          en: "A join button will appear here once testing access opens.",
+        };
+  }
+
+  if (channel.note && !TECHNICAL_COPY_PATTERN.test(channel.note)) {
+    return {
+      zh: channel.note,
+      en: channel.note,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 变更内容

- 将中英切换改为右上角单图标入口，点击后使用下拉菜单选择语言
- 将首页 iOS 测试版按钮调整为与 Android 一致的金色主按钮样式
- 清理官网中暴露给用户的开发者内部文案，例如自动同步、GitHub、仓库状态等表述，并替换为用户可理解的信息
- 首页和下载页的版本卡片统一做用户视角文案净化，避免内部状态直接展示
- 删除首页产品预览里重复出现的最后一张全球布施排行榜截图

## 说明

- 本次改动只聚焦 `frontend/apps/web` 官网前端，不触碰其他模块
- 新增了一个小型文案映射工具，用来统一处理下载渠道的用户可见描述

## 验证

- 已确认改动分支相对 `main` 只包含官网前端相关 7 个文件
- 当前环境无法直接运行该仓库的本地前端构建或视觉回归验证