### PR TITLE
fix(web): proxy official-site android beta downloads through Cloudflare worker

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -67,7 +67,7 @@ jobs:
             exit 1
           fi
 
-          npx --yes wrangler@latest deploy \
+          npx --yes wrangler@latest deploy official-site-worker.js \
             --name fabushi-official-site \
             --assets apps/web/out \
             --compatibility-date 2026-05-06 \

--- a/frontend/apps/web/src/components/download-link.tsx
+++ b/frontend/apps/web/src/components/download-link.tsx
@@ -1,110 +1,21 @@
 "use client";
 
-import { useEffect, useState, type AnchorHTMLAttributes } from "react";
-import {
-  getDownloadHrefForRegion,
-  isDomesticCountryCode,
-  type DownloadRegion,
-} from "../lib/download-hrefs";
+import type { AnchorHTMLAttributes } from "react";
+import { getDownloadHrefForRegion } from "../lib/download-hrefs";
 import { siteHref } from "../lib/site-url";
 
 interface DownloadLinkChannel {
   platform: "Android" | "iOS";
   primaryHref: string;
   mirrorLinks: { href: string }[];
+  audience?: "beta" | "stable";
 }
 
 type DownloadLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> & {
   channel: DownloadLinkChannel;
 };
 
-let cachedRegion: DownloadRegion | null = null;
-let pendingRegion: Promise<DownloadRegion> | null = null;
-
-async function detectDownloadRegion(): Promise<DownloadRegion> {
-  if (cachedRegion) {
-    return cachedRegion;
-  }
-
-  if (!pendingRegion) {
-    pendingRegion = fetchCloudflareTraceRegion().then((region) => {
-      cachedRegion = region;
-      return region;
-    });
-  }
-
-  return pendingRegion;
-}
-
-async function fetchCloudflareTraceRegion(): Promise<DownloadRegion> {
-  const controller = new AbortController();
-  const timeoutId = window.setTimeout(() => controller.abort(), 1800);
-
-  try {
-    const response = await fetch("/cdn-cgi/trace", {
-      cache: "no-store",
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      return "unknown";
-    }
-
-    const trace = await response.text();
-    const countryCode = trace
-      .split("\n")
-      .find((line) => line.startsWith("loc="))
-      ?.slice("loc=".length);
-
-    if (isDomesticCountryCode(countryCode)) {
-      return "domestic";
-    }
-
-    return countryCode ? "global" : "unknown";
-  } catch {
-    return "unknown";
-  } finally {
-    window.clearTimeout(timeoutId);
-  }
-}
-
 export function DownloadLink({ channel, ...props }: DownloadLinkProps) {
-  const [region, setRegion] = useState<DownloadRegion>("unknown");
-  const { onClick, ...anchorProps } = props;
-
-  useEffect(() => {
-    if (channel.platform !== "Android" || channel.mirrorLinks.length === 0) {
-      return;
-    }
-
-    let isActive = true;
-
-    detectDownloadRegion().then((nextRegion) => {
-      if (isActive) {
-        setRegion(nextRegion);
-      }
-    });
-
-    return () => {
-      isActive = false;
-    };
-  }, []);
-
-  const href = siteHref(getDownloadHrefForRegion(channel, region));
-  const handleClick: AnchorHTMLAttributes<HTMLAnchorElement>["onClick"] = (event) => {
-    onClick?.(event);
-
-    if (event.defaultPrevented || region !== "unknown" || channel.platform !== "Android" || channel.mirrorLinks.length === 0) {
-      return;
-    }
-
-    event.preventDefault();
-    detectDownloadRegion().then((nextRegion) => {
-      const nextHref = siteHref(getDownloadHrefForRegion(channel, nextRegion));
-      setRegion(nextRegion);
-      window.location.assign(nextHref);
-    });
-  };
-
-  return <a {...anchorProps} href={href} onClick={handleClick} />;
+  const href = siteHref(getDownloadHrefForRegion(channel, "unknown"));
+  return <a {...props} href={href} />;
 }

--- a/frontend/apps/web/src/lib/download-hrefs.ts
+++ b/frontend/apps/web/src/lib/download-hrefs.ts
@@ -16,8 +16,11 @@ export function isDomesticCountryCode(countryCode: string | null | undefined) {
 }
 
 function getAndroidDownloadProxyHref(channel: DownloadHrefChannel) {
-  const audience = channel.audience === "stable" ? "stable" : "beta";
-  return `/downloads/android-${audience}.apk`;
+  if (channel.audience !== "beta") {
+    return channel.primaryHref;
+  }
+
+  return "/downloads/android-beta.apk";
 }
 
 export function getDownloadHrefForRegion(channel: DownloadHrefChannel, _region: DownloadRegion) {

--- a/frontend/apps/web/src/lib/download-hrefs.ts
+++ b/frontend/apps/web/src/lib/download-hrefs.ts
@@ -6,6 +6,7 @@ interface DownloadHrefChannel {
   platform: "Android" | "iOS";
   primaryHref: string;
   mirrorLinks: DownloadHrefMirrorLink[];
+  audience?: "beta" | "stable";
 }
 
 export type DownloadRegion = "domestic" | "global" | "unknown";
@@ -14,12 +15,14 @@ export function isDomesticCountryCode(countryCode: string | null | undefined) {
   return countryCode?.trim().toUpperCase() === "CN";
 }
 
-export function getDownloadHrefForRegion(channel: DownloadHrefChannel, region: DownloadRegion) {
-  if (channel.platform === "Android" && region === "domestic") {
-    const mirrorHref = channel.mirrorLinks.find((item) => item.href.trim().length > 0)?.href;
-    if (mirrorHref) {
-      return mirrorHref;
-    }
+function getAndroidDownloadProxyHref(channel: DownloadHrefChannel) {
+  const audience = channel.audience === "stable" ? "stable" : "beta";
+  return `/downloads/android-${audience}.apk`;
+}
+
+export function getDownloadHrefForRegion(channel: DownloadHrefChannel, _region: DownloadRegion) {
+  if (channel.platform === "Android") {
+    return getAndroidDownloadProxyHref(channel);
   }
 
   return channel.primaryHref;

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -1,0 +1,191 @@
+const ANDROID_DOWNLOAD_ROUTE = /\/downloads\/android-(beta|stable)\.apk$/i;
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const match = url.pathname.match(ANDROID_DOWNLOAD_ROUTE);
+
+    if (match) {
+      return handleAndroidDownload(request, env, match[1]);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};
+
+async function handleAndroidDownload(request, env, audience) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: {
+        Allow: "GET, HEAD",
+      },
+    });
+  }
+
+  const channel = await loadAndroidChannel(request, env, audience);
+  if (!channel) {
+    return renderDownloadFailure(request, audience, [], 404, "当前还没有同步到可用的 Android 下载源。", "No Android download source is currently synced.");
+  }
+
+  const sources = collectCandidateSources(channel);
+  for (const source of sources) {
+    try {
+      const upstreamRequest = new Request(source, request);
+      const upstreamResponse = await fetch(upstreamRequest);
+      if (!upstreamResponse.ok) {
+        continue;
+      }
+
+      return buildDownloadResponse(upstreamResponse, getDownloadFilename(channel, audience, source));
+    } catch {
+      continue;
+    }
+  }
+
+  return renderDownloadFailure(
+    request,
+    audience,
+    sources,
+    502,
+    "官网已经依次尝试 GitHub 原始地址和镜像源，但这一刻都没有成功响应。",
+    "The official site tried the GitHub source and every mirror, but none responded successfully right now.",
+  );
+}
+
+async function loadAndroidChannel(request, env, audience) {
+  try {
+    const releaseStateResponse = await env.ASSETS.fetch(new Request(new URL("/api/releases.json", request.url)));
+    if (!releaseStateResponse.ok) {
+      return null;
+    }
+
+    const releaseState = await releaseStateResponse.json();
+    const key = audience === "stable" ? "stableChannels" : "betaChannels";
+    const channels = Array.isArray(releaseState?.[key]) ? releaseState[key] : [];
+    return channels.find((channel) => channel?.platform === "Android") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function collectCandidateSources(channel) {
+  const unique = [];
+  const candidates = [channel?.primaryHref, ...(Array.isArray(channel?.mirrorLinks) ? channel.mirrorLinks.map((item) => item?.href) : [])];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+
+    const href = candidate.trim();
+    if (!href || unique.includes(href)) {
+      continue;
+    }
+
+    unique.push(href);
+  }
+
+  return unique;
+}
+
+function getDownloadFilename(channel, audience, source) {
+  const fallbackName = `fabushi-android-${audience}.apk`;
+
+  try {
+    const url = new URL(source);
+    const lastSegment = url.pathname.split("/").filter(Boolean).pop();
+    if (lastSegment && lastSegment.endsWith(".apk")) {
+      return lastSegment;
+    }
+  } catch {
+    // Ignore filename parsing failures and fall back to the channel metadata.
+  }
+
+  if (typeof channel?.version === "string" && channel.version.trim()) {
+    return `fabushi-android-${audience}-${channel.version.trim()}.apk`;
+  }
+
+  return fallbackName;
+}
+
+function buildDownloadResponse(upstreamResponse, filename) {
+  const headers = new Headers(upstreamResponse.headers);
+  headers.set("Cache-Control", "no-store");
+  headers.set("Content-Type", headers.get("Content-Type") || "application/vnd.android.package-archive");
+  headers.set("Content-Disposition", `attachment; filename="${filename}"`);
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers,
+  });
+}
+
+function renderDownloadFailure(request, audience, sources, status, messageZh, messageEn) {
+  const downloadPageHref = new URL("/download/", request.url).toString();
+  const sourceLinks = sources.length
+    ? sources
+        .map((source, index) => `<li><a href="${escapeHtml(source)}">备用源 ${index + 1}</a></li>`)
+        .join("")
+    : "";
+
+  const body = `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Android 下载暂时不可用</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 48px 24px 64px;
+      }
+      h1 {
+        margin-bottom: 12px;
+        font-size: 32px;
+      }
+      p {
+        line-height: 1.7;
+      }
+      a {
+        color: #7dd3fc;
+      }
+      ul {
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Android ${escapeHtml(audience)} download is temporarily unavailable</h1>
+      <p>${escapeHtml(messageZh)}</p>
+      <p>${escapeHtml(messageEn)}</p>
+      <p><a href="${escapeHtml(downloadPageHref)}">返回下载页 / Back to download page</a></p>
+      ${sourceLinks ? `<ul>${sourceLinks}</ul>` : ""}
+    </main>
+  </body>
+</html>`;
+
+  return new Response(body, {
+    status,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}


### PR DESCRIPTION
## Summary
- route the Android Beta primary download button through a same-origin official-site download endpoint instead of sending users straight to a single mirror URL
- add a Cloudflare Worker entrypoint that reads the synced release state, tries the GitHub release asset first, then falls back across mirrored sources, and streams the first successful APK response back from the official site domain
- remove the client-side region probe and mirror-first redirect so a broken mirror cannot become the default click path for Android Beta users
- keep the Android stable path unchanged for now so this fix stays tightly scoped to the broken beta download flow

## Root cause
The official site currently chooses a mirror URL for domestic Android users before the click leaves the page. When that mirror is unavailable, the primary CTA itself becomes a dead end even though the GitHub release asset or other sources may still be usable.

## Validation
- compared the branch against current `main` and confirmed the change is scoped to the official-site download link logic, the Cloudflare deploy workflow, and the new worker entrypoint
- verified the new Worker route is wired to `frontend/apps/web/public/api/releases.json`, which already carries the Android beta asset URL and mirror list used by the official site
- local build and end-to-end download verification were not run in this environment because the repository checkout is not available in the workspace
