### PR TITLE
fix: avoid heredoc parsing failure in beta sync workflow

### DIFF
--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -316,26 +316,7 @@ jobs:
 
           if [ -f OFFICIAL_SITE_RELEASE_STATE.json ]; then
             mkdir -p frontend/apps/web/public/api
-            python3 - <<'PY'
-import json
-from pathlib import Path
-
-source_path = Path("OFFICIAL_SITE_RELEASE_STATE.json")
-target_path = Path("frontend/apps/web/public/api/releases.json")
-state = json.loads(source_path.read_text(encoding="utf-8"))
-channels = state.get("channels", [])
-api_state = {
-    "betaChannels": [channel for channel in channels if channel.get("audience") == "beta"],
-    "stableChannels": [channel for channel in channels if channel.get("audience") == "stable"],
-    "screenshots": state.get("screenshots", {}),
-    "releases": state.get("releases", []),
-    "notes": state.get("notes", []),
-}
-target_path.write_text(
-    json.dumps(api_state, ensure_ascii=False, indent=2) + "\n",
-    encoding="utf-8",
-)
-PY
+            python3 -c 'import json; from pathlib import Path; source_path = Path("OFFICIAL_SITE_RELEASE_STATE.json"); target_path = Path("frontend/apps/web/public/api/releases.json"); state = json.loads(source_path.read_text(encoding="utf-8")); channels = state.get("channels", []); api_state = {"betaChannels": [channel for channel in channels if channel.get("audience") == "beta"], "stableChannels": [channel for channel in channels if channel.get("audience") == "stable"], "screenshots": state.get("screenshots", {}), "releases": state.get("releases", []), "notes": state.get("notes", [])}; target_path.write_text(json.dumps(api_state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")'
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add frontend/apps/web/public/api/releases.json


### PR DESCRIPTION
## Summary
- Replace the failing Python heredoc in `sync-official-site-beta.yml` with a `python3 -c` invocation.
- Keep the official-site beta sync logic unchanged while avoiding Bash heredoc delimiter parsing issues caused by generated shell indentation.

## Context
Recent `Sync official site beta download state` runs failed in `Copy state to public API and commit` with:

```text
warning: here-document at line 13 delimited by end-of-file (wanted `PY')
syntax error: unexpected end of file
```

The release asset upload immutable-release notice is handled successfully and is not the failure root cause.

## Testing
- Not run locally; workflow-only change.
- Expected validation: GitHub Actions CI / merge queue checks on this PR.