### PR TITLE
ci: stop beta sync from failing on main push rules

### DIFF
--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -298,6 +298,7 @@ jobs:
             /frontend/apps/web/public/api/**
 
       - name: Copy state to public API and commit
+        id: commit_state
         if: steps.push_state.outcome == 'success'
         shell: bash
         env:
@@ -322,10 +323,29 @@ jobs:
             git add frontend/apps/web/public/api/releases.json
             if git diff --cached --quiet; then
               echo "No changes to commit."
+              echo "push_blocked_by_repo_rules=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             git commit -m "chore: sync beta release state for $RELEASE_TAG"
-            git push origin main
+
+            push_log="$(mktemp)"
+            if git push origin main 2>"$push_log"; then
+              echo "push_blocked_by_repo_rules=false" >> "$GITHUB_OUTPUT"
+              rm -f "$push_log"
+              exit 0
+            fi
+
+            if grep -q 'GH013: Repository rule violations found' "$push_log" && grep -q 'Changes must be made through the merge queue' "$push_log"; then
+              cat "$push_log"
+              echo "push_blocked_by_repo_rules=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping direct push to main because repository rules require the merge queue. The official site will keep using release metadata and TESTFLIGHT_UPLOAD_STATUS.txt fallbacks."
+              rm -f "$push_log"
+              exit 0
+            fi
+
+            cat "$push_log" >&2
+            rm -f "$push_log"
+            exit 1
           else
             echo "::error::OFFICIAL_SITE_RELEASE_STATE.json could not be restored or downloaded."
             exit 1
@@ -337,6 +357,7 @@ jobs:
           RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
           RELEASE_STATE_UPLOADED: ${{ steps.upload_state.outputs.uploaded }}
           IMMUTABLE_RELEASE: ${{ steps.upload_state.outputs.immutable_release }}
+          PUSH_BLOCKED_BY_REPO_RULES: ${{ steps.commit_state.outputs.push_blocked_by_repo_rules }}
         run: |
           {
             echo "## Official site beta state synced"
@@ -349,6 +370,10 @@ jobs:
               echo "- Official site fallback remains available through release metadata and TESTFLIGHT_UPLOAD_STATUS.txt"
             else
               echo "- Asset: OFFICIAL_SITE_RELEASE_STATE.json was generated locally"
+            fi
+            if [ "$PUSH_BLOCKED_BY_REPO_RULES" = "true" ]; then
+              echo "- Repository rules blocked the direct push to main, so /api/releases.json was not committed automatically"
+              echo "- The official site will keep falling back to release metadata and TESTFLIGHT_UPLOAD_STATUS.txt"
             fi
             echo "- Android beta now points at the latest GitHub Release APK asset."
             echo "- iOS beta now points at the TestFlight public link when IOS_TESTFLIGHT_PUBLIC_URL is configured."


### PR DESCRIPTION
## 问题

`Sync official site beta download state` 在生成 `OFFICIAL_SITE_RELEASE_STATE.json` 后，会尝试把 `frontend/apps/web/public/api/releases.json` 直接推到 `main`。当前仓库规则要求通过 merge queue，并要求 `CI result` 检查，因此这一步会被 GitHub 以 `GH013` 拒绝，导致整条工作流误报失败。

## 修复

- 给 `Copy state to public API and commit` 这一步加上 `id`，把推送结果暴露给后续 summary。
- 将 `git push origin main` 改为带日志捕获的分支保护识别逻辑。
- 当日志明确包含 `GH013` 和 `Changes must be made through the merge queue` 时，改为输出 notice 并成功结束步骤。
- 其他 push 失败仍然保持失败，避免掩盖真正的异常。
- 在 summary 中补充“仓库规则阻止直推 main，官网继续走 release metadata / TESTFLIGHT_UPLOAD_STATUS.txt 回退”的说明。

## 影响

- 这次修复会让该 workflow 在命中仓库规则时不再整条失败。
- 官网仍可继续依赖已有的 release metadata 和 `TESTFLIGHT_UPLOAD_STATUS.txt` 回退逻辑展示 beta 信息。
- 这不会绕过现有仓库规则；如果未来还需要把 `releases.json` 真正落到 `main`，仍然需要改成 PR / merge queue 流程。
