### PR TITLE
fix: refresh invalid android buddha model cache from r2

### DIFF
--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -551,7 +551,7 @@ class AssetLoaderService {
 
   static int? _parseTotalLengthFromContentRange(String? contentRange) {
     if (contentRange == null) return null;
-    final match = RegExp(r'/(\\d+)$').firstMatch(contentRange);
+    final match = RegExp(r'/(\d+)$').firstMatch(contentRange);
     if (match == null) return null;
     return int.tryParse(match.group(1)!);
   }

--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -109,11 +109,25 @@ class AssetLoaderService {
   }) async {
     // 确保已注册到 MemoryManager
     initialize();
-    return await _loadAsset(
-      AppConfig.buddhaModelAssetPath,
-      onProgress: onProgress,
-      minExpectedBytes: AppConfig.minBuddhaModelSizeBytes,
-    );
+
+    try {
+      return await _loadAsset(
+        AppConfig.buddhaModelAssetPath,
+        onProgress: onProgress,
+        minExpectedBytes: AppConfig.minBuddhaModelSizeBytes,
+      );
+    } catch (e) {
+      debugPrint(
+        '⚠️ [AssetLoader] 佛像模型首次加载失败，清理旧缓存后重试 R2: $e',
+      );
+      await evictBuddhaModelCache();
+      return _loadAsset(
+        AppConfig.buddhaModelAssetPath,
+        onProgress: onProgress,
+        forceRefresh: true,
+        minExpectedBytes: AppConfig.minBuddhaModelSizeBytes,
+      );
+    }
   }
 
   static Future<void> evictBuddhaModelCache() async {
@@ -185,18 +199,27 @@ class AssetLoaderService {
     if (!forceRefresh) {
       final cached = await _loadFromPersistentStorage(fileName);
       if (cached != null && cached.isNotEmpty) {
-        _assertAssetSizeIsValid(
-          fileName,
-          cached.lengthInBytes,
-          minExpectedBytes: minExpectedBytes,
-          source: 'persistent-cache',
-        );
-        debugPrint(
-          '✅ [AssetLoader] 从本地存储加载: $fileName (${cached.lengthInBytes} bytes)',
-        );
-        _memoryCache[fileName] = cached;
-        onProgress?.call(1.0);
-        return cached;
+        try {
+          _assertAssetSizeIsValid(
+            fileName,
+            cached.lengthInBytes,
+            minExpectedBytes: minExpectedBytes,
+            source: 'persistent-cache',
+          );
+          debugPrint(
+            '✅ [AssetLoader] 从本地存储加载: $fileName (${cached.lengthInBytes} bytes)',
+          );
+          _memoryCache[fileName] = cached;
+          onProgress?.call(1.0);
+          return cached;
+        } catch (e) {
+          debugPrint(
+            '⚠️ [AssetLoader] 本地佛像缓存无效，删除后回退到 R2 重新下载: '
+            '$fileName - $e',
+          );
+          _memoryCache.remove(fileName);
+          await _deletePersistentAsset(fileName, includePartial: true);
+        }
       }
     }
 
@@ -528,7 +551,7 @@ class AssetLoaderService {
 
   static int? _parseTotalLengthFromContentRange(String? contentRange) {
     if (contentRange == null) return null;
-    final match = RegExp(r'/(\d+)$').firstMatch(contentRange);
+    final match = RegExp(r'/(\\d+)$').firstMatch(contentRange);
     if (match == null) return null;
     return int.tryParse(match.group(1)!);
   }


### PR DESCRIPTION
## 背景
安卓端进入禅室时会直接走 R2 上的 `.model` 主链路，但如果设备本地残留了历史错误缓存、过小的旧文件，或中断后的残缺下载，当前实现会一直重复读取这些无效文件，导致即使 R2 上已经有正确模型也仍然报错。

## 这次改动
- 在 `AssetLoaderService.loadBuddhaModel()` 首次失败后，主动清理佛像模型的内存缓存、本地正式缓存和 `.downloading` 临时文件，再强制从 R2 重新拉取一次。
- 在读取本地持久化缓存时，如果发现文件大小不满足 `.model` 的最小阈值，立即删除无效缓存并回退到 R2 下载，而不是直接把错误抛给页面。
- 保持现有 `.model` 主链路，不再退回 legacy GLB WebView 兼容方案。

## 验证建议
- Android 安装旧包或保留旧缓存场景下进入禅室，确认会自动重新从 R2 拉取模型并恢复展示。
- 在下载中途杀进程后重进禅室，确认残缺缓存会被清理并重新下载。
- R2 模型本身异常时，页面仍会失败，但不会被本地脏缓存永久卡死。