### PR TITLE
fix(web): refresh official site after beta sync and version android downloads

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -7,6 +7,13 @@ on:
     paths:
       - frontend/**
       - .github/workflows/deploy-official-site-cloudflare.yml
+  workflow_run:
+    workflows:
+      - Sync official site beta download state
+    types:
+      - completed
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -28,6 +35,7 @@ jobs:
       - name: Checkout official site source
         uses: actions/checkout@v5
         with:
+          ref: main
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /frontend/**

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -89,9 +89,15 @@ function collectCandidateSources(channel) {
   return unique;
 }
 
-function getDownloadFilename(channel, audience, source) {
-  const fallbackName = `fabushi-android-${audience}.apk`;
+function sanitizeFilenamePart(value) {
+  return String(value ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
 
+function extractSourceFilename(source) {
   try {
     const url = new URL(source);
     const lastSegment = url.pathname.split("/").filter(Boolean).pop();
@@ -102,18 +108,54 @@ function getDownloadFilename(channel, audience, source) {
     // Ignore filename parsing failures and fall back to the channel metadata.
   }
 
-  if (typeof channel?.version === "string" && channel.version.trim()) {
-    return `fabushi-android-${audience}-${channel.version.trim()}.apk`;
+  return "";
+}
+
+function extractVariant(sourceFilename) {
+  if (!sourceFilename) {
+    return "";
   }
 
-  return fallbackName;
+  const normalized = sourceFilename.toLowerCase();
+  if (normalized.includes("arm64")) {
+    return "arm64";
+  }
+  if (normalized.includes("armv7")) {
+    return "armv7";
+  }
+  if (normalized.includes("universal")) {
+    return "universal";
+  }
+  if (normalized.includes("x86_64")) {
+    return "x86_64";
+  }
+
+  return "";
+}
+
+function getDownloadFilename(channel, audience, source) {
+  const fallbackName = `fabushi-android-${audience}.apk`;
+  const sourceFilename = extractSourceFilename(source);
+  const version = sanitizeFilenamePart(channel?.version);
+
+  if (version) {
+    const parts = ["fabushi", "android", sanitizeFilenamePart(audience)];
+    const variant = sanitizeFilenamePart(extractVariant(sourceFilename));
+    if (variant && variant !== audience) {
+      parts.push(variant);
+    }
+    parts.push(version);
+    return `${parts.join("-")}.apk`;
+  }
+
+  return sourceFilename || fallbackName;
 }
 
 function buildDownloadResponse(upstreamResponse, filename) {
   const headers = new Headers(upstreamResponse.headers);
   headers.set("Cache-Control", "no-store");
   headers.set("Content-Type", headers.get("Content-Type") || "application/vnd.android.package-archive");
-  headers.set("Content-Disposition", `attachment; filename="${filename}"`);
+  headers.set("Content-Disposition", `attachment; filename="${filename}"; filename*=UTF-8''${encodeURIComponent(filename)}`);
 
   return new Response(upstreamResponse.body, {
     status: upstreamResponse.status,


### PR DESCRIPTION
## 问题

官网版本号落后于 GitHub latest release，不是 release 没发出来，而是官网 Cloudflare Worker 站点只会在 `main` 上有 `frontend/**` push 或手动触发时重新构建。`Sync official site beta download state` 即使已经把最新 beta 信息同步好了，也不会自动触发官网重新部署，所以官网会停在上一次构建时读到的 release 快照。

同时，Android 官网下载走 `frontend/official-site-worker.js` 代理时，会优先直接沿用上游 APK 资产名。当前发布资产名主要是 `fabushi-android-arm64-<short_sha>.apk`，用户下载到本地后看不到版本号和渠道信息。

## 这次修复

- 给 `Deploy official site to Cloudflare Worker` 增加 `workflow_run` 触发，监听 `Sync official site beta download state` 成功完成后自动重建官网。
- 在官网部署工作流的 checkout 步骤显式固定 `ref: main`，避免 `workflow_run` 场景下取错构建基线。
- 调整 Android 下载代理的文件名生成逻辑：当 release channel 已经带有 `version` 时，优先返回 `fabushi-android-<audience>-<variant>-<version>.apk` 这种可读文件名，而不是继续把只有短 SHA 的上游文件名透传给用户。
- 给下载响应补充 `filename*`，提升浏览器对版本化文件名的兼容性。

## 影响

- 以后 release beta 状态同步完成后，官网会自动重新部署，首页和下载页显示的版本会更快追上 latest release。
- Android 用户从官网点击下载后，保存到本地的 APK 文件名会明确体现 beta/stable、架构和版本号。
- 改动范围仍然只在官网部署 workflow 和下载 worker，两处都不碰 App 本体逻辑。

## 验证

- 已对比分支相对最新 `main` 的 diff，确认只包含 2 个文件：官网部署 workflow 和 Android 下载 worker。
- 当前环境没有本地仓库 checkout 能力，未做本地构建；这次以 GitHub Actions workflow 校验和官网下载行为回归作为最终验证。