### PR TITLE
fix(web): keep download notes inside official site

### DIFF
--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -155,8 +155,8 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
           <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
         </DownloadLink>
         {channel.releasePageHref ? (
-          <a className="secondary-action" href={siteHref(channel.releasePageHref)}>
-            <LocalizedText zh="查看版本说明" en="View release notes" />
+          <a className="secondary-action" href={siteHref("/download#release-changelog")}>
+            <LocalizedText zh="查看下载内容说明" en="View download notes" />
           </a>
         ) : null}
       </div>
@@ -365,11 +365,7 @@ export default async function DownloadPage() {
             {releaseCollection.releases.map((entry) => (
               <article key={entry.tag} className="changelog-entry">
                 <div className="changelog-meta">
-                  <h3>
-                    <a href={entry.htmlUrl} target="_blank" rel="noopener noreferrer">
-                      {entry.title}
-                    </a>
-                  </h3>
+                  <h3>{entry.title}</h3>
                   <time dateTime={entry.publishedAt}>{formatPublishedAt(entry.publishedAt)}</time>
                 </div>
                 <div className="release-card-meta compact">
@@ -384,14 +380,6 @@ export default async function DownloadPage() {
                     ))}
                   </ul>
                 )}
-                <a
-                  className="secondary-action"
-                  href={entry.htmlUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <LocalizedText zh="查看完整发布说明" en="View full release notes" />
-                </a>
               </article>
             ))}
           </div>

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -444,8 +444,8 @@ export default async function HomePage() {
               </ul>
             ) : null}
             <div className="release-card-actions">
-              <a className="primary-action" href={latestRelease.htmlUrl} target="_blank" rel="noopener noreferrer">
-                <LocalizedText zh="查看完整发布说明" en="View release notes" />
+              <a className="primary-action" href={siteHref("/download#release-changelog")}>
+                <LocalizedText zh="查看完整下载内容说明" en="View full download notes" />
               </a>
               <a className="secondary-action" href={siteHref("/download")}>
                 <LocalizedText zh="查看全部下载入口" en="See all downloads" />


### PR DESCRIPTION
## Summary
- keep the homepage download-notes CTA inside the official site by linking it to the on-site release log section
- change download-page release-note actions to point to the on-site changelog instead of GitHub release pages
- remove the changelog title link-out so download note browsing stays within the official site

## Why
- users clicking the download note / release-note actions on the official site should stay in the official site flow instead of being sent to GitHub
- this keeps the download explanation experience more consistent and reduces unnecessary off-site jumps

## Testing
- verified the homepage CTA now targets `/download#release-changelog`
- verified the download page release-note actions now target `/download#release-changelog`
- verified changelog entry titles on the download page no longer link out to GitHub