### PR TITLE
fix(web): refresh official site after package publish and fall back to latest apk

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/deploy-official-site-cloudflare.yml
   workflow_run:
     workflows:
+      - Publish CD packages to GitHub Release
       - Sync official site beta download state
     types:
       - completed

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -10,6 +10,10 @@ const DEFAULT_MIRROR_BASES = [
     label: "国内镜像 2",
     prefix: "https://ghfast.top/https://github.com/",
   },
+  {
+    label: "国内镜像 3",
+    prefix: "https://gh-proxy.com/https://github.com/",
+  },
 ];
 
 export default {
@@ -37,19 +41,26 @@ async function handleAndroidDownload(request, env, audience) {
 
   const channel = await loadAndroidChannel(request, env, audience);
   if (!channel) {
-    return renderDownloadFailure(request, audience, [], 404, "当前还没有同步到可用的 Android 下载源。", "No Android download source is currently synced.");
+    return renderDownloadFailure(
+      request,
+      audience,
+      [],
+      404,
+      "当前还没有同步到可用的 Android 下载源。",
+      "No Android download source is currently synced.",
+    );
   }
 
   const sources = collectCandidateSources(channel);
   for (const source of sources) {
     try {
-      const upstreamRequest = new Request(source, request);
+      const upstreamRequest = new Request(source.href, request);
       const upstreamResponse = await fetch(upstreamRequest);
       if (!upstreamResponse.ok) {
         continue;
       }
 
-      return buildDownloadResponse(upstreamResponse, getDownloadFilename(channel, audience, source));
+      return buildDownloadResponse(upstreamResponse, getDownloadFilename(channel, audience, source.href));
     } catch {
       continue;
     }
@@ -137,7 +148,12 @@ async function loadLatestReleaseAndroidChannel(env) {
 }
 
 function isApkAsset(asset) {
-  return Boolean(asset && typeof asset.name === "string" && asset.name.endsWith(".apk") && typeof asset.browser_download_url === "string");
+  return Boolean(
+    asset &&
+      typeof asset.name === "string" &&
+      asset.name.endsWith(".apk") &&
+      typeof asset.browser_download_url === "string",
+  );
 }
 
 function getReleaseRepo(env) {
@@ -161,7 +177,8 @@ function buildMirrorLinks(primaryHref, env) {
 }
 
 function getMirrorBases(env) {
-  const rawMirrorBases = typeof env?.OFFICIAL_SITE_GITHUB_MIRROR_BASES === "string" ? env.OFFICIAL_SITE_GITHUB_MIRROR_BASES : "";
+  const rawMirrorBases =
+    typeof env?.OFFICIAL_SITE_GITHUB_MIRROR_BASES === "string" ? env.OFFICIAL_SITE_GITHUB_MIRROR_BASES : "";
   const configuredMirrors = rawMirrorBases
     .split("\n")
     .map((line) => line.trim())
@@ -184,19 +201,36 @@ function getMirrorBases(env) {
 
 function collectCandidateSources(channel) {
   const unique = [];
-  const candidates = [channel?.primaryHref, ...(Array.isArray(channel?.mirrorLinks) ? channel.mirrorLinks.map((item) => item?.href) : [])];
+  const candidates = [
+    {
+      label: "GitHub 原始下载",
+      href: channel?.primaryHref,
+      kind: "primary",
+    },
+    ...(Array.isArray(channel?.mirrorLinks)
+      ? channel.mirrorLinks.map((item, index) => ({
+          label: item?.label || `备用镜像 ${index + 1}`,
+          href: item?.href,
+          kind: "mirror",
+        }))
+      : []),
+  ];
 
   for (const candidate of candidates) {
-    if (typeof candidate !== "string") {
+    if (typeof candidate?.href !== "string") {
       continue;
     }
 
-    const href = candidate.trim();
-    if (!href || unique.includes(href)) {
+    const href = candidate.href.trim();
+    if (!href || unique.some((item) => item.href === href)) {
       continue;
     }
 
-    unique.push(href);
+    unique.push({
+      label: candidate.label,
+      href,
+      kind: candidate.kind,
+    });
   }
 
   return unique;
@@ -278,9 +312,17 @@ function buildDownloadResponse(upstreamResponse, filename) {
 
 function renderDownloadFailure(request, audience, sources, status, messageZh, messageEn) {
   const downloadPageHref = new URL("/download/", request.url).toString();
-  const sourceLinks = sources.length
-    ? sources
-        .map((source, index) => `<li><a href="${escapeHtml(source)}">备用源 ${index + 1}</a></li>`)
+  const primarySource = sources.find((item) => item.kind === "primary") ?? null;
+  const mirrorSources = sources.filter((item) => item.kind === "mirror");
+  const primaryAction = primarySource
+    ? `<a class="primary-download" href="${escapeHtml(primarySource.href)}">${escapeHtml(primarySource.label)} / Original download</a>`
+    : "";
+  const sourceLinks = mirrorSources.length
+    ? mirrorSources
+        .map(
+          (source) =>
+            `<a class="mirror-link" href="${escapeHtml(source.href)}">${escapeHtml(source.label)} / Mirror download</a>`,
+        )
         .join("")
     : "";
 
@@ -291,10 +333,13 @@ function renderDownloadFailure(request, audience, sources, status, messageZh, me
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Android 下载暂时不可用</title>
     <style>
+      :root {
+        color-scheme: dark;
+      }
       body {
         margin: 0;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background: #0f172a;
+        background: radial-gradient(circle at top, #1f2937 0%, #0f172a 58%, #020617 100%);
         color: #e2e8f0;
       }
       main {
@@ -309,11 +354,44 @@ function renderDownloadFailure(request, audience, sources, status, messageZh, me
       p {
         line-height: 1.7;
       }
-      a {
+      .actions,
+      .mirrors {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 20px;
+      }
+      .primary-download,
+      .mirror-link,
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 48px;
+        padding: 0 18px;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .primary-download {
+        background: linear-gradient(135deg, #f7d774 0%, #d4af37 100%);
+        color: #1f2937;
+        box-shadow: 0 10px 24px rgba(212, 175, 55, 0.28);
+      }
+      .mirror-link {
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        color: #f8fafc;
+      }
+      .back-link {
+        margin-top: 28px;
+        background: transparent;
+        border: 1px solid rgba(125, 211, 252, 0.35);
         color: #7dd3fc;
       }
-      ul {
-        padding-left: 20px;
+      .hint {
+        margin-top: 18px;
+        color: #cbd5e1;
       }
     </style>
   </head>
@@ -322,8 +400,10 @@ function renderDownloadFailure(request, audience, sources, status, messageZh, me
       <h1>Android ${escapeHtml(audience)} download is temporarily unavailable</h1>
       <p>${escapeHtml(messageZh)}</p>
       <p>${escapeHtml(messageEn)}</p>
-      <p><a href="${escapeHtml(downloadPageHref)}">返回下载页 / Back to download page</a></p>
-      ${sourceLinks ? `<ul>${sourceLinks}</ul>` : ""}
+      ${primaryAction ? `<div class="actions">${primaryAction}</div>` : ""}
+      ${sourceLinks ? `<div class="mirrors">${sourceLinks}</div>` : ""}
+      <p class="hint">如原始下载较慢，可改用备用镜像继续安装。 If the original download is slow, try one of the mirror links.</p>
+      <a class="back-link" href="${escapeHtml(downloadPageHref)}">返回下载页 / Back to download page</a>
     </main>
   </body>
 </html>`;

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -95,7 +95,7 @@ async function loadSyncedAndroidChannel(request, env, audience) {
 async function loadLatestReleaseAndroidChannel(env) {
   try {
     const releaseRepo = getReleaseRepo(env);
-    const response = await fetch(`${GITHUB_API_BASE}/repos/${releaseRepo}/releases?per_page=5`, {
+    const response = await fetch(`${GITHUB_API_BASE}/repos/${releaseRepo}/releases/latest`, {
       headers: {
         Accept: "application/vnd.github+json",
       },
@@ -105,13 +105,8 @@ async function loadLatestReleaseAndroidChannel(env) {
       return null;
     }
 
-    const releases = await response.json();
-    if (!Array.isArray(releases)) {
-      return null;
-    }
-
-    const release = releases.find((item) => !item?.draft && Array.isArray(item?.assets) && item.assets.some(isApkAsset));
-    if (!release) {
+    const release = await response.json();
+    if (!release || release.draft || !Array.isArray(release.assets)) {
       return null;
     }
 

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -1,4 +1,16 @@
 const ANDROID_DOWNLOAD_ROUTE = /\/downloads\/android-(beta|stable)\.apk$/i;
+const DEFAULT_RELEASE_REPO = "bhrumom/fabushi";
+const GITHUB_API_BASE = "https://api.github.com";
+const DEFAULT_MIRROR_BASES = [
+  {
+    label: "国内镜像 1",
+    prefix: "https://mirror.ghproxy.com/https://github.com/",
+  },
+  {
+    label: "国内镜像 2",
+    prefix: "https://ghfast.top/https://github.com/",
+  },
+];
 
 export default {
   async fetch(request, env) {
@@ -54,6 +66,17 @@ async function handleAndroidDownload(request, env, audience) {
 }
 
 async function loadAndroidChannel(request, env, audience) {
+  if (audience === "beta") {
+    const latestReleaseChannel = await loadLatestReleaseAndroidChannel(env);
+    if (latestReleaseChannel) {
+      return latestReleaseChannel;
+    }
+  }
+
+  return loadSyncedAndroidChannel(request, env, audience);
+}
+
+async function loadSyncedAndroidChannel(request, env, audience) {
   try {
     const releaseStateResponse = await env.ASSETS.fetch(new Request(new URL("/api/releases.json", request.url)));
     if (!releaseStateResponse.ok) {
@@ -67,6 +90,101 @@ async function loadAndroidChannel(request, env, audience) {
   } catch {
     return null;
   }
+}
+
+async function loadLatestReleaseAndroidChannel(env) {
+  try {
+    const releaseRepo = getReleaseRepo(env);
+    const response = await fetch(`${GITHUB_API_BASE}/repos/${releaseRepo}/releases?per_page=5`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const releases = await response.json();
+    if (!Array.isArray(releases)) {
+      return null;
+    }
+
+    const release = releases.find((item) => !item?.draft && Array.isArray(item?.assets) && item.assets.some(isApkAsset));
+    if (!release) {
+      return null;
+    }
+
+    const apkAssets = release.assets.filter(isApkAsset);
+    const apkAsset = apkAssets.find((asset) => asset.name.toLowerCase().includes("arm64")) ?? apkAssets[0];
+    if (!apkAsset?.browser_download_url) {
+      return null;
+    }
+
+    return {
+      platform: "Android",
+      audience: "beta",
+      status: "Beta 自动同步",
+      title: "Android Beta",
+      description: "官网会优先读取最新 GitHub Release 的 Android 安装包。",
+      primaryLabel: "下载 Android Beta",
+      primaryHref: apkAsset.browser_download_url,
+      version: typeof release.tag_name === "string" ? release.tag_name : undefined,
+      publishedAt: typeof release.published_at === "string" ? release.published_at : undefined,
+      updateSummary: [],
+      mirrorLinks: buildMirrorLinks(apkAsset.browser_download_url, env),
+      note: "如果同步快照还没刷新，官网会直接回退到最新 release 安装包。",
+      releasePageHref: typeof release.html_url === "string" ? release.html_url : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isApkAsset(asset) {
+  return Boolean(asset && typeof asset.name === "string" && asset.name.endsWith(".apk") && typeof asset.browser_download_url === "string");
+}
+
+function getReleaseRepo(env) {
+  if (typeof env?.OFFICIAL_SITE_RELEASE_REPO === "string" && env.OFFICIAL_SITE_RELEASE_REPO.trim()) {
+    return env.OFFICIAL_SITE_RELEASE_REPO.trim();
+  }
+
+  return DEFAULT_RELEASE_REPO;
+}
+
+function buildMirrorLinks(primaryHref, env) {
+  if (!primaryHref.startsWith("https://github.com/")) {
+    return [];
+  }
+
+  const path = primaryHref.slice("https://github.com/".length);
+  return getMirrorBases(env).map((item) => ({
+    label: item.label,
+    href: `${item.prefix}${path}`,
+  }));
+}
+
+function getMirrorBases(env) {
+  const rawMirrorBases = typeof env?.OFFICIAL_SITE_GITHUB_MIRROR_BASES === "string" ? env.OFFICIAL_SITE_GITHUB_MIRROR_BASES : "";
+  const configuredMirrors = rawMirrorBases
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [label, prefix] = line.split("|");
+      if (!label || !prefix) {
+        return null;
+      }
+
+      return {
+        label: label.trim(),
+        prefix: prefix.trim(),
+      };
+    })
+    .filter(Boolean);
+
+  return configuredMirrors.length > 0 ? configuredMirrors : DEFAULT_MIRROR_BASES;
 }
 
 function collectCandidateSources(channel) {


### PR DESCRIPTION
## 问题

官网最新安装包信息这次没有自动跟上，根因不是页面读取逻辑坏了，而是同步链路里有两个断点：

- `Sync official site beta download state` 即使生成了最新状态，也可能因为仓库规则无法直推 `main`，导致 `/api/releases.json` 继续停在旧快照。
- `Deploy official site to Cloudflare Worker` 之前只监听 beta sync 成功完成；一旦 beta sync 被仓库规则挡住，官网就不会因为新的 GitHub Release 自动重建。

这会让官网页面和 Android 下载代理都更容易继续指向旧的安装包信息。

## 这次修复

- 让 `Deploy official site to Cloudflare Worker` 同时监听 `Publish CD packages to GitHub Release` 和 `Sync official site beta download state` 成功完成。
- 保持官网构建固定基于 `main`，但不再把自动刷新绑定在 beta sync 单一路径上。
- 给 `frontend/official-site-worker.js` 增加兜底：Android beta 下载优先读取 GitHub latest release 的 APK 资产；只有拿不到 latest release 时，才回退到静态 `/api/releases.json`。
- 保留原始 GitHub 下载作为主入口，并在失败页补上多个备用镜像链接；金色主按钮仍指向原始下载地址。
- 允许通过 worker 环境变量覆盖镜像前缀，同时保留默认镜像兜底。

## 影响

- 新的移动端 release 发出来后，官网即使没有及时把 `releases.json` 落盘到仓库，也会自动重建到最新 release 信息。
- Android beta 下载代理不再被旧的静态 release 快照卡住，会直接优先命中最新 GitHub Release APK。
- 即使当前时刻代理拉取失败，用户也会在失败页看到原始下载按钮和多个镜像入口，而不是停在死页。
- 这次改动不绕过仓库规则，也不碰 App 本体打包逻辑，只补官网刷新和下载入口的兜底链路。

## 验证建议

- 发布一个新的 mobile GitHub Release，确认官网部署 workflow 会自动触发。
- 在 beta sync 仍无法直推 `main` 的情况下，确认官网首页/下载页显示的版本已追到 latest release。
- 点击官网 Android beta 下载，确认实际拿到的是 latest release 的 APK，而不是旧快照里的安装包。
- 人为让原始下载暂时不可达时，确认失败页会显示金色原始下载按钮和多个镜像链接。