### PR TITLE
fix(android): bundle Buddha model into APK and load it before remote fetch

### DIFF
--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -168,6 +168,9 @@ class AppConfig {
   // 3D 佛像模型配置
   // 如果 R2 上需要切换到新的对象键，优先改这里，便于强制绕开旧缓存。
   static const String buddhaModelAssetPath = 'models/buddha_model.model';
+  // 安卓主链路优先读取随包发布的 .model，避免核心佛像展示受远端对象或下载中断影响。
+  static const String bundledBuddhaModelAssetPath =
+      'assets/models/buddha_model.model';
   // 兼容旧链路：移动端在 .model 缺失时，可退回到仍在线上的 legacy GLB。
   static const String legacyBuddhaGlbAssetPath = 'models/佛像模型.glb';
   // 当前线上正确模型明显大于 48MB，小于该阈值视为误传/降质文件。

--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -1,9 +1,13 @@
-import 'package:flutter/foundation.dart';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, Uint8List, debugPrint, defaultTargetPlatform, kIsWeb;
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
-import 'dart:io';
-import 'memory_manager.dart';
+
 import '../core/config/app_config.dart';
+import 'memory_manager.dart';
 
 /// 3D 模型资源缓存包装器
 /// 实现 ClearableCache 接口以便 MemoryManager 在内存警告时清理
@@ -44,13 +48,15 @@ class _AssetCacheWrapper implements ClearableCache {
 
 /// 大型资源动态加载服务
 ///
-/// 用于从 CDN 加载大型 3D 模型等资源,避免打包到应用中
-/// 实现断点续传和持久化缓存机制
+/// 用于加载 3D 模型等大型资源，优先复用随包资源与本地缓存，必要时再回退到远端下载。
 class AssetLoaderService {
   static String get defaultCdnBaseUrl =>
       '${AppConfig.currentBackendUrl}/r2?file=';
 
   static String get cdnBaseUrl => defaultCdnBaseUrl;
+
+  static bool get _shouldPreferBundledBuddhaModel =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
 
   // 内存缓存 (仅用于当前会话)
   static final Map<String, Uint8List> _memoryCache = {};
@@ -76,6 +82,15 @@ class AssetLoaderService {
 
     if (_memoryCache.containsKey(fileName)) {
       return;
+    }
+
+    if (_shouldPreferBundledBuddhaModel) {
+      try {
+        await _loadBundledBuddhaModel();
+        return;
+      } catch (e) {
+        debugPrint('⚠️ [AssetLoader] 预热随包佛像模型失败，继续检查本地缓存: $e');
+      }
     }
 
     try {
@@ -110,6 +125,15 @@ class AssetLoaderService {
     // 确保已注册到 MemoryManager
     initialize();
 
+    if (_shouldPreferBundledBuddhaModel) {
+      try {
+        return await _loadBundledBuddhaModel(onProgress: onProgress);
+      } catch (e) {
+        debugPrint('⚠️ [AssetLoader] 随包佛像模型读取失败，回退到 R2: $e');
+        _memoryCache.remove(AppConfig.buddhaModelAssetPath);
+      }
+    }
+
     try {
       return await _loadAsset(
         AppConfig.buddhaModelAssetPath,
@@ -136,6 +160,37 @@ class AssetLoaderService {
       AppConfig.buddhaModelAssetPath,
       includePartial: true,
     );
+  }
+
+  static Future<Uint8List> _loadBundledBuddhaModel({
+    void Function(double progress)? onProgress,
+  }) async {
+    const cacheKey = AppConfig.buddhaModelAssetPath;
+
+    if (_memoryCache.containsKey(cacheKey)) {
+      onProgress?.call(1.0);
+      return _memoryCache[cacheKey]!;
+    }
+
+    final byteData = await rootBundle.load(AppConfig.bundledBuddhaModelAssetPath);
+    final data = byteData.buffer.asUint8List(
+      byteData.offsetInBytes,
+      byteData.lengthInBytes,
+    );
+
+    if (data.isEmpty) {
+      throw Exception(
+        '打包佛像模型为空: ${AppConfig.bundledBuddhaModelAssetPath}',
+      );
+    }
+
+    _memoryCache[cacheKey] = data;
+    onProgress?.call(1.0);
+    debugPrint(
+      '📦 [AssetLoader] 从随包佛像模型加载: '
+      '${AppConfig.bundledBuddhaModelAssetPath} (${data.lengthInBytes} bytes)',
+    );
+    return data;
   }
 
   // 正在进行的加载任务，防止并发下载同一资源

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -163,7 +163,8 @@ flutter:
     - assets/earth_texture.jpg
     - assets/ip_data/
     - assets/sherpa_models/streaming-paraformer-zh-en/
-    # 佛像模型优先从 R2 加载原始版本，不默认打包本地简化 .model
+    # 安卓佛像模型改为随包提供，禅室不再把首次展示依赖在远端下载上
+    - assets/models/buddha_model.model
   
   fonts:
     # 使用子集化后的字体（从80MB压缩至~4.5MB）


### PR DESCRIPTION
## 问题

安卓禅室佛像当前把 `.model` 主链路建立在远端 R2 下载之上：

- `AssetLoaderService.loadBuddhaModel()` 会优先走远端 `models/buddha_model.model`
- 仓库里其实已经有 `fabushi/assets/models/buddha_model.model`
- 但 `pubspec.yaml` 没有把这份模型打进 APK，所以 Android 首次展示仍然依赖网络、R2 对象状态、下载完整性和本地缓存健康度

这也是为什么此前即使补过缓存清理、R2 强制刷新、Impeller 和 WebView fallback，安卓侧仍然会反复遇到“加载模型出错”：核心资源本身没有被收回到应用包里，主链路仍然建立在外部依赖上。

## 这次修复

- 将 `assets/models/buddha_model.model` 正式加入 `pubspec.yaml`，随 Android 安装包一起发布
- 在 `AppConfig` 中显式声明随包佛像模型路径
- 在 `AssetLoaderService` 中让 Android 优先读取随包 `.model`，并把它放入内存缓存
- 保留现有 R2 下载链路作为回退，只有随包模型读取失败时才继续走远端下载
- `prewarmBuddhaModelFromPersistentCache()` 在 Android 上改为优先预热随包模型，避免首进禅室还要等远端链路

## 为什么这样修

这次修的是资源供给方式，而不是继续给远端链路打补丁。

只要佛像模型仍然不在 APK 里，Android 端首次进入禅室就会继续受以下外部因素影响：

- 远端对象是否存在或被误传
- R2 / Worker / 网络是否可达
- 下载是否中断
- 本地缓存是否残缺

把仓库里已经存在的 `.model` 直接纳入 APK 后，安卓禅室主链路就回到本地资源读取，才能从根上消除这类“模型本身拿不到”的问题。远端链路继续保留，只作为兜底，而不是主依赖。

## 风险与影响

- Android 安装包体积会随佛像 `.model` 增大，这是这次根因修复的代价
- iOS / Web 现有链路不变，这次只把 Android 改成优先走随包模型
- 现有 WebView legacy GLB fallback 仍保留，用于渲染层继续兜底，不影响这次主链路收口

## 验证建议

- `flutter pub get`
- `flutter build apk --debug`
- Android 真机安装后断网进入禅室，确认佛像仍可正常展示
- 清除应用数据后首次进入禅室，确认不再依赖远端下载进度
- 保留现有渲染回退验证：如果 `flutter_scene` / `Impeller` 层报错，页面仍按现有兼容路径处理

## 备注

当前环境没有本地仓库 checkout 和 Flutter toolchain 运行条件，这次未执行本地 Flutter 构建；实现与回读基于仓库主线文件和分支 diff 完成。