### PR TITLE
[codex] fix android remote buddha model loading

### DIFF
--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -168,8 +168,16 @@ class AppConfig {
   // 3D 佛像模型配置
   // 如果 R2 上需要切换到新的对象键，优先改这里，便于强制绕开旧缓存。
   static const String buddhaModelAssetPath = 'models/buddha_model.model';
-  // 兼容旧链路：移动端在 .model 缺失时，可退回到仍在线上的 legacy GLB。
+  // 兼容旧链路：移动端在 .model 无法渲染时，可退回到官网静态资源上的远端 GLB。
   static const String legacyBuddhaGlbAssetPath = 'models/佛像模型.glb';
+  static String get legacyBuddhaGlbUrl {
+    final encodedPath = legacyBuddhaGlbAssetPath
+        .split('/')
+        .map(Uri.encodeComponent)
+        .join('/');
+    return '$publicWebUrl/assets/$encodedPath';
+  }
+
   // 当前线上正确模型明显大于 48MB，小于该阈值视为误传/降质文件。
   static const int minBuddhaModelSizeBytes = 100 * 1024 * 1024;
 

--- a/fabushi/lib/screens/buddha_model_screen_native.dart
+++ b/fabushi/lib/screens/buddha_model_screen_native.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -161,8 +162,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   }
 
   String _buildLegacyBuddhaFallbackHtml() {
-    final glbUrl =
-        '${AppConfig.currentBackendUrl}/r2?file=${Uri.encodeComponent(AppConfig.legacyBuddhaGlbAssetPath)}';
+    final glbUrlJson = jsonEncode(AppConfig.legacyBuddhaGlbUrl);
 
     return '''
 <!DOCTYPE html>
@@ -210,9 +210,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     }
   </script>
   <script type="module">
-    import * as THREE from 'three';
-    import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    const glbUrl = $glbUrlJson;
 
     const notifyHost = (message) => {
       const bridge = window.$_legacyFallbackChannelName;
@@ -223,50 +221,6 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
 
     const container = document.getElementById('container');
     const status = document.getElementById('status');
-    const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 10000);
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setPixelRatio(window.devicePixelRatio || 1);
-    renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setClearColor(0x000000, 0);
-    container.appendChild(renderer.domElement);
-
-    camera.position.set(0, 120, 290);
-
-    const controls = new OrbitControls(camera, renderer.domElement);
-    controls.enableDamping = true;
-    controls.enablePan = false;
-    controls.autoRotate = true;
-    controls.autoRotateSpeed = 1.4;
-    controls.minDistance = 180;
-    controls.maxDistance = 360;
-    controls.target.set(0, 90, 0);
-
-    const ambientLight = new THREE.AmbientLight(0xffffff, 1.1);
-    scene.add(ambientLight);
-
-    const keyLight = new THREE.DirectionalLight(0xffd05b, 1.8);
-    keyLight.position.set(80, 200, 120);
-    scene.add(keyLight);
-
-    const fillLight = new THREE.PointLight(0xffe7aa, 1.1, 620);
-    fillLight.position.set(-120, 110, 90);
-    scene.add(fillLight);
-
-    const rimLight = new THREE.PointLight(0x8b5a16, 0.9, 520);
-    rimLight.position.set(0, 40, -180);
-    scene.add(rimLight);
-
-    const haloGeometry = new THREE.RingGeometry(70, 102, 64);
-    const haloMaterial = new THREE.MeshBasicMaterial({
-      color: 0xffd97b,
-      transparent: true,
-      opacity: 0.24,
-      side: THREE.DoubleSide,
-    });
-    const halo = new THREE.Mesh(haloGeometry, haloMaterial);
-    halo.position.set(0, 150, -32);
-    scene.add(halo);
 
     const fail = (reason) => {
       const errorMessage = reason || 'Legacy Buddha GLB load failed';
@@ -276,6 +230,39 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       }
       notifyHost('error:' + errorMessage);
     };
+
+    async function importThreeRuntime() {
+      const candidates = [
+        {
+          root: 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js',
+          loader: 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js',
+          controls: 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js',
+        },
+        {
+          root: 'https://esm.sh/three@0.160.0',
+          loader: 'https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js',
+          controls: 'https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js',
+        },
+      ];
+
+      let lastError;
+      for (const candidate of candidates) {
+        try {
+          const THREE = await import(candidate.root);
+          const loaderModule = await import(candidate.loader);
+          const controlsModule = await import(candidate.controls);
+          return {
+            THREE,
+            GLTFLoader: loaderModule.GLTFLoader,
+            OrbitControls: controlsModule.OrbitControls,
+          };
+        } catch (error) {
+          lastError = error;
+          console.warn('Three runtime import failed from', candidate.root, error);
+        }
+      }
+      throw lastError || new Error('Three runtime import failed');
+    }
 
     window.addEventListener('error', (event) => {
       const message = event && event.message ? event.message : 'Legacy Buddha runtime error';
@@ -287,66 +274,127 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       fail(reason);
     });
 
-    const loader = new GLTFLoader();
-    loader.load(
-      '$glbUrl',
-      (gltf) => {
-        const model = gltf.scene;
-        const box = new THREE.Box3().setFromObject(model);
-        const size = new THREE.Vector3();
-        const center = new THREE.Vector3();
-        box.getSize(size);
-        box.getCenter(center);
-        const maxDim = Math.max(size.x || 1, size.y || 1, size.z || 1);
-        const scale = 170 / maxDim;
-
-        model.scale.setScalar(scale);
-        model.position.sub(center.multiplyScalar(scale));
-        model.position.y += 18;
-        model.rotation.y = Math.PI;
-        model.rotation.x = 0.08;
-
-        model.traverse((child) => {
-          if (!child.isMesh) return;
-          child.castShadow = false;
-          child.receiveShadow = false;
-          if (child.material) {
-            child.material.metalness = 0.72;
-            child.material.roughness = 0.24;
-            child.material.color = new THREE.Color(0xffd46a);
-            child.material.needsUpdate = true;
-          }
-        });
-
-        scene.add(model);
-        if (status) {
-          status.style.display = 'none';
-        }
-        notifyHost('ready');
-      },
-      undefined,
-      (error) => {
-        const errorMessage = error && error.message
-          ? error.message
-          : 'Legacy Buddha GLB load failed';
-        fail(errorMessage);
+    importThreeRuntime().then(({ THREE, GLTFLoader, OrbitControls }) => {
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 10000);
+      const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+      renderer.setPixelRatio(window.devicePixelRatio || 1);
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      renderer.setClearColor(0x000000, 0);
+      if ('outputColorSpace' in renderer && 'SRGBColorSpace' in THREE) {
+        renderer.outputColorSpace = THREE.SRGBColorSpace;
       }
-    );
+      container.appendChild(renderer.domElement);
 
-    function animate() {
-      requestAnimationFrame(animate);
-      controls.update();
-      halo.rotation.z += 0.0018;
-      renderer.render(scene, camera);
-    }
+      camera.position.set(0, 120, 290);
 
-    window.addEventListener('resize', () => {
-      camera.aspect = window.innerWidth / window.innerHeight;
-      camera.updateProjectionMatrix();
-      renderer.setSize(window.innerWidth, window.innerHeight, false);
+      const controls = new OrbitControls(camera, renderer.domElement);
+      controls.enableDamping = true;
+      controls.enablePan = false;
+      controls.autoRotate = true;
+      controls.autoRotateSpeed = 1.4;
+      controls.minDistance = 180;
+      controls.maxDistance = 360;
+      controls.target.set(0, 90, 0);
+
+      const ambientLight = new THREE.AmbientLight(0xffffff, 1.1);
+      scene.add(ambientLight);
+
+      const keyLight = new THREE.DirectionalLight(0xffd05b, 1.8);
+      keyLight.position.set(80, 200, 120);
+      scene.add(keyLight);
+
+      const fillLight = new THREE.PointLight(0xffe7aa, 1.1, 620);
+      fillLight.position.set(-120, 110, 90);
+      scene.add(fillLight);
+
+      const rimLight = new THREE.PointLight(0x8b5a16, 0.9, 520);
+      rimLight.position.set(0, 40, -180);
+      scene.add(rimLight);
+
+      const haloGeometry = new THREE.RingGeometry(70, 102, 64);
+      const haloMaterial = new THREE.MeshBasicMaterial({
+        color: 0xffd97b,
+        transparent: true,
+        opacity: 0.24,
+        side: THREE.DoubleSide,
+      });
+      const halo = new THREE.Mesh(haloGeometry, haloMaterial);
+      halo.position.set(0, 150, -32);
+      scene.add(halo);
+
+      const loader = new GLTFLoader();
+      loader.load(
+        glbUrl,
+        (gltf) => {
+          const model = gltf.scene;
+          const box = new THREE.Box3().setFromObject(model);
+          const size = new THREE.Vector3();
+          const center = new THREE.Vector3();
+          box.getSize(size);
+          box.getCenter(center);
+          const maxDim = Math.max(size.x || 1, size.y || 1, size.z || 1);
+          const scale = 170 / maxDim;
+
+          model.scale.setScalar(scale);
+          model.position.sub(center.multiplyScalar(scale));
+          model.position.y += 18;
+          model.rotation.y = Math.PI;
+          model.rotation.x = 0.08;
+
+          model.traverse((child) => {
+            if (!child.isMesh) return;
+            child.castShadow = false;
+            child.receiveShadow = false;
+            if (child.material) {
+              child.material.metalness = 0.72;
+              child.material.roughness = 0.24;
+              child.material.color = new THREE.Color(0xffd46a);
+              child.material.needsUpdate = true;
+            }
+          });
+
+          scene.add(model);
+          if (status) {
+            status.style.display = 'none';
+          }
+          notifyHost('ready');
+        },
+        (progress) => {
+          if (!status || !progress.lengthComputable || progress.total <= 0) {
+            return;
+          }
+          const percent = Math.max(0, Math.min(99, Math.floor((progress.loaded / progress.total) * 100)));
+          status.textContent = '恭请佛像...' + percent + '%';
+        },
+        (error) => {
+          const errorMessage = error && error.message
+            ? error.message
+            : 'Legacy Buddha GLB load failed';
+          fail(errorMessage);
+        }
+      );
+
+      function animate() {
+        requestAnimationFrame(animate);
+        controls.update();
+        halo.rotation.z += 0.0018;
+        renderer.render(scene, camera);
+      }
+
+      window.addEventListener('resize', () => {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(window.innerWidth, window.innerHeight, false);
+      });
+
+      animate();
+    }).catch((error) => {
+      const message = error && error.message
+        ? error.message
+        : 'Three runtime import failed';
+      fail(message);
     });
-
-    animate();
   </script>
 </body>
 </html>
@@ -360,7 +408,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
 
   void _startLegacyFallbackTimeout() {
     _cancelLegacyFallbackTimeout();
-    _legacyFallbackTimeout = Timer(const Duration(seconds: 15), () {
+    _legacyFallbackTimeout = Timer(const Duration(seconds: 120), () {
       if (!mounted || _legacyWebViewReady || _loadFailed) {
         return;
       }
@@ -459,7 +507,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     try {
       await controller.loadHtmlString(
         _buildLegacyBuddhaFallbackHtml(),
-        baseUrl: AppConfig.currentBackendUrl,
+        baseUrl: AppConfig.publicWebUrl,
       );
     } catch (e) {
       debugPrint('❌ [BuddhaModel] 兼容 WebView 初始化失败: $e');
@@ -583,7 +631,8 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
 
     for (int i = 0; i < _particleCount; i++) {
       final p = _smokeParticles[i];
-      final sourceOffset = _incenseStickOffsets[i % _incenseStickOffsets.length];
+      final sourceOffset =
+          _incenseStickOffsets[i % _incenseStickOffsets.length];
       final tipPos = vector.Vector3(
         _incenseBaseX + sourceOffset,
         _incenseBaseY + currentHeight,
@@ -655,21 +704,21 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       });
     }
 
-    const maxRetries = 3;
+    const maxRetries = 2;
     for (int attempt = 1; attempt <= maxRetries; attempt++) {
-      var modelDataLoaded = false;
+      Uint8List? modelData;
       try {
-        final modelData = await AssetLoaderService.loadBuddhaModel(
+        modelData = await AssetLoaderService.loadBuddhaModel(
           onProgress: (progress) {
             if (mounted) {
               setState(() => _loadingProgress = progress);
             }
           },
         );
-        modelDataLoaded = true;
         if (!mounted) return;
 
         await _buildBuddhaNode(modelData);
+        AssetLoaderService.releaseBuddhaModelMemoryCache();
 
         if (mounted) {
           setState(() {
@@ -681,9 +730,26 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       } catch (e) {
         _lastLoadError = '$e';
         debugPrint('❌ 模型加载失败 (尝试 $attempt): $e');
-        if (modelDataLoaded) {
-          await AssetLoaderService.evictBuddhaModelCache();
+
+        if (modelData != null) {
+          AssetLoaderService.releaseBuddhaModelMemoryCache();
+          if (_canUseLegacyWebViewFallback) {
+            debugPrint(
+              '↪️ [BuddhaModel] 远端 .model 已下载但原生解包/渲染失败，'
+              '切换远端 GLB 兼容渲染: $_lastLoadError',
+            );
+            await _activateLegacyWebViewFallback();
+            return;
+          }
+          if (mounted) {
+            setState(() {
+              _isLoading = false;
+              _loadFailed = true;
+            });
+          }
+          return;
         }
+
         if (attempt < maxRetries) {
           await Future.delayed(Duration(seconds: 1 << attempt));
           continue;
@@ -708,10 +774,10 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   }
 
   Future<void> _buildBuddhaNode(Uint8List modelData) async {
-    final node = await Node.fromFlatbuffer(modelData.buffer.asByteData());
+    final bounds = ModelAutoFit.computeBoundsFromModelBytes(modelData);
+    final node = await Node.fromFlatbuffer(ByteData.sublistView(modelData));
     _retuneBuddhaMaterials(node);
 
-    final bounds = ModelAutoFit.computeBoundsFromModelBytes(modelData);
     final originalTransform = node.localTransform.clone();
     node.localTransform = ModelAutoFit.computeFitTransform(
       bounds,
@@ -888,7 +954,9 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
                             color: Colors.black.withValues(alpha: 0.48),
                             borderRadius: BorderRadius.circular(16),
                             border: Border.all(
-                              color: const Color(0xFFD4AF37).withValues(alpha: 0.36),
+                              color: const Color(
+                                0xFFD4AF37,
+                              ).withValues(alpha: 0.36),
                             ),
                           ),
                           child: const Column(
@@ -1317,11 +1385,11 @@ class ScenePainter extends CustomPainter {
     canvas.drawPath(
       flame,
       Paint()
-        ..shader = ui.Gradient.radial(
-          center.translate(0, -16),
-          20,
-          const [Color(0xFFFFF5B7), Color(0xFFFF8A24), Color(0x00FF8A24)],
-        ),
+        ..shader = ui.Gradient.radial(center.translate(0, -16), 20, const [
+          Color(0xFFFFF5B7),
+          Color(0xFFFF8A24),
+          Color(0x00FF8A24),
+        ]),
     );
     canvas.drawOval(
       Rect.fromCenter(center: center.translate(0, 2), width: 30, height: 12),

--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -52,6 +52,16 @@ class AssetLoaderService {
 
   static String get cdnBaseUrl => defaultCdnBaseUrl;
 
+  static const List<int> _flutterSceneModelFileIdentifier = [
+    0x49,
+    0x50,
+    0x53,
+    0x43,
+  ]; // IPSC
+
+  static bool get _canPrewarmLargeBuddhaModelBytes =>
+      kIsWeb || defaultTargetPlatform != TargetPlatform.android;
+
   // 内存缓存 (仅用于当前会话)
   static final Map<String, Uint8List> _memoryCache = {};
 
@@ -69,12 +79,18 @@ class AssetLoaderService {
 
   /// 如果本机已经存在佛像模型，就提前把它放进内存缓存，避免首次进入禅室再阻塞等待。
   ///
+  /// Android 上该模型太大，启动预热会显著抬高内存峰值，因此只在进入禅室时按需读取。
   /// 这里不会触发网络请求，也不会在本地不存在时主动下载大文件。
   static Future<void> prewarmBuddhaModelFromPersistentCache() async {
     initialize();
     const fileName = AppConfig.buddhaModelAssetPath;
 
     if (_memoryCache.containsKey(fileName)) {
+      return;
+    }
+
+    if (!_canPrewarmLargeBuddhaModelBytes) {
+      debugPrint('ℹ️ [AssetLoader] Android 跳过启动预热佛像大模型字节');
       return;
     }
 
@@ -88,6 +104,11 @@ class AssetLoaderService {
         fileName,
         cached.lengthInBytes,
         minExpectedBytes: AppConfig.minBuddhaModelSizeBytes,
+        source: 'persistent-prewarm',
+      );
+      _assertAssetSignatureIsValid(
+        fileName,
+        cached,
         source: 'persistent-prewarm',
       );
 
@@ -117,9 +138,7 @@ class AssetLoaderService {
         minExpectedBytes: AppConfig.minBuddhaModelSizeBytes,
       );
     } catch (e) {
-      debugPrint(
-        '⚠️ [AssetLoader] 佛像模型首次加载失败，清理旧缓存后重试 R2: $e',
-      );
+      debugPrint('⚠️ [AssetLoader] 佛像模型首次加载失败，清理旧缓存后重试 R2: $e');
       await evictBuddhaModelCache();
       return _loadAsset(
         AppConfig.buddhaModelAssetPath,
@@ -136,6 +155,10 @@ class AssetLoaderService {
       AppConfig.buddhaModelAssetPath,
       includePartial: true,
     );
+  }
+
+  static void releaseBuddhaModelMemoryCache() {
+    _memoryCache.remove(AppConfig.buddhaModelAssetPath);
   }
 
   // 正在进行的加载任务，防止并发下载同一资源
@@ -206,6 +229,11 @@ class AssetLoaderService {
             minExpectedBytes: minExpectedBytes,
             source: 'persistent-cache',
           );
+          _assertAssetSignatureIsValid(
+            fileName,
+            cached,
+            source: 'persistent-cache',
+          );
           debugPrint(
             '✅ [AssetLoader] 从本地存储加载: $fileName (${cached.lengthInBytes} bytes)',
           );
@@ -244,6 +272,7 @@ class AssetLoaderService {
       minExpectedBytes: minExpectedBytes,
       source: 'download',
     );
+    _assertAssetSignatureIsValid(fileName, data, source: 'download');
 
     _memoryCache[fileName] = data;
     return data;
@@ -392,9 +421,9 @@ class AssetLoaderService {
 
         final totalLength = isResuming
             ? _parseTotalLengthFromContentRange(
-                  response.headers['content-range'],
-                ) ??
-                ((response.contentLength ?? 0) + downloadedBytes)
+                    response.headers['content-range'],
+                  ) ??
+                  ((response.contentLength ?? 0) + downloadedBytes)
             : response.contentLength ?? expectedContentLength ?? 0;
         _assertAssetSizeIsValid(
           fileName,
@@ -422,7 +451,6 @@ class AssetLoaderService {
 
         await sink.flush();
         await sink.close();
-        client.close();
 
         final downloadedSize = await tempFile.length();
         if (totalLength > 0 && downloadedSize != totalLength) {
@@ -595,6 +623,30 @@ class AssetLoaderService {
         'R2 可能上传了错误文件。',
       );
     }
+  }
+
+  static void _assertAssetSignatureIsValid(
+    String fileName,
+    Uint8List data, {
+    required String source,
+  }) {
+    if (fileName != AppConfig.buddhaModelAssetPath) return;
+    if (isFlutterSceneModelData(data)) return;
+
+    throw Exception(
+      '资源格式异常($source): $fileName 不是有效的 flutter_scene .model 文件。',
+    );
+  }
+
+  @visibleForTesting
+  static bool isFlutterSceneModelData(Uint8List data) {
+    if (data.lengthInBytes < 8) return false;
+    for (var i = 0; i < _flutterSceneModelFileIdentifier.length; i++) {
+      if (data[4 + i] != _flutterSceneModelFileIdentifier[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   static String _formatBytes(int bytes) {

--- a/fabushi/lib/utils/model_auto_fit.dart
+++ b/fabushi/lib/utils/model_auto_fit.dart
@@ -1,5 +1,6 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'dart:math' as math;
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
@@ -70,8 +71,7 @@ class ModelAutoFit {
 
         if (rawBytes == null || vertexCount == 0) continue;
 
-        // 将 List<int> 转为 ByteData 以便读取 float32
-        final byteData = ByteData.sublistView(Uint8List.fromList(rawBytes));
+        final byteData = _asByteDataView(rawBytes);
 
         for (int i = 0; i < vertexCount; i++) {
           final offset = i * vertexStride;
@@ -112,6 +112,13 @@ class ModelAutoFit {
     );
   }
 
+  static ByteData _asByteDataView(List<int> bytes) {
+    if (bytes is Uint8List) {
+      return ByteData.sublistView(bytes);
+    }
+    return ByteData.sublistView(Uint8List.fromList(bytes));
+  }
+
   /// 根据边界框计算适配变换矩阵
   ///
   /// [bounds] 模型边界框
@@ -137,11 +144,12 @@ class ModelAutoFit {
       ..multiply(originalTransform ?? vector.Matrix4.identity())
       ..rotateY(facingCorrectionY)
       ..rotateX(tiltCorrectionX)
-      ..translate(
+      ..translateByDouble(
         -center.x * scale,
         -center.y * scale + yOffset,
         -center.z * scale,
+        1.0,
       )
-      ..scale(scale, scale, scale);
+      ..scaleByDouble(scale, scale, scale, 1.0);
   }
 }

--- a/fabushi/test/unit/core/app_config_buddha_model_test.dart
+++ b/fabushi/test/unit/core/app_config_buddha_model_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/core/config/app_config.dart';
+
+void main() {
+  group('Buddha model remote configuration', () {
+    test('keeps the native .model on the R2 remote path', () {
+      expect(AppConfig.buddhaModelAssetPath, 'models/buddha_model.model');
+    });
+
+    test('loads the compatibility GLB from the public remote static host', () {
+      expect(
+        AppConfig.legacyBuddhaGlbUrl,
+        'https://flutter.ombhrum.com/assets/models/'
+        '%E4%BD%9B%E5%83%8F%E6%A8%A1%E5%9E%8B.glb',
+      );
+      expect(AppConfig.legacyBuddhaGlbUrl, isNot(contains('/r2?file=')));
+    });
+  });
+}

--- a/fabushi/test/unit/services/asset_loader_service_test.dart
+++ b/fabushi/test/unit/services/asset_loader_service_test.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/services/asset_loader_service.dart';
+
+void main() {
+  group('AssetLoaderService Buddha model validation', () {
+    test('accepts flutter_scene .model data with IPSC file identifier', () {
+      final data = Uint8List.fromList([
+        0x14,
+        0x00,
+        0x00,
+        0x00,
+        0x49,
+        0x50,
+        0x53,
+        0x43,
+      ]);
+
+      expect(AssetLoaderService.isFlutterSceneModelData(data), isTrue);
+    });
+
+    test('rejects GLB or truncated data as .model bytes', () {
+      final glb = Uint8List.fromList([
+        0x67,
+        0x6C,
+        0x54,
+        0x46,
+        0x02,
+        0x00,
+        0x00,
+        0x00,
+      ]);
+
+      expect(AssetLoaderService.isFlutterSceneModelData(glb), isFalse);
+      expect(AssetLoaderService.isFlutterSceneModelData(Uint8List(4)), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Summary:
- Keep Buddha .model loading on the remote R2 path instead of bundling it in the APK.
- Fix Android/iOS GLB fallback to use the reachable public static GLB URL.
- Validate .model signatures and lower Android memory pressure around large model loading.

Root cause:
- Android could download the large remote .model but then fail during native flutter_scene/Impeller unpacking or GPU upload.
- The fallback GLB URL pointed at an R2 route that currently returns 404, so Android ended in the double-failure state shown in the screenshot.

Validation:
- /opt/homebrew/bin/flutter analyze --no-pub lib/core/config/app_config.dart lib/services/asset_loader_service.dart lib/screens/buddha_model_screen_native.dart lib/utils/model_auto_fit.dart test/unit/core/app_config_buddha_model_test.dart test/unit/services/asset_loader_service_test.dart
- /opt/homebrew/bin/flutter test --no-pub test/unit/core/app_config_buddha_model_test.dart test/unit/services/asset_loader_service_test.dart
- Verified remote .model and GLB HEAD responses.
- Verified the remote GLB parses with Three GLTFLoader in Chromium.