### PR TITLE
feat(web): add first community forum browsing flow

### DIFF
--- a/frontend/apps/web/src/app/community/page.tsx
+++ b/frontend/apps/web/src/app/community/page.tsx
@@ -1,0 +1,265 @@
+import type { Metadata } from "next";
+import { brand } from "@fabushi/shared";
+import { LocalizedText } from "../../components/localized-text";
+import { SiteFooter } from "../../components/site-footer";
+import { SiteHeader } from "../../components/site-header";
+import {
+  FORUM_SECTIONS,
+  GOVERNANCE_SIGNALS,
+  LAUNCH_STEPS,
+  STARTER_THREADS,
+} from "../../lib/community";
+import { siteHref, siteUrl } from "../../lib/site-url";
+
+const communityUrl = siteUrl("/community");
+const communityTitle = `佛法论坛 | ${brand.name}`;
+const communityDescription =
+  "Fabushi 佛法论坛首版入口，公开展示板块结构、讨论方向、治理原则与后续迭代路径。";
+
+export const metadata: Metadata = {
+  title: communityTitle,
+  description: communityDescription,
+  alternates: {
+    canonical: communityUrl,
+  },
+  keywords: [
+    "佛法论坛",
+    "佛教社区",
+    "学佛问答",
+    "禅修讨论",
+    "Fabushi community",
+  ],
+  openGraph: {
+    title: communityTitle,
+    description: communityDescription,
+    url: communityUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: communityTitle,
+    description: communityDescription,
+  },
+};
+
+export default function CommunityPage() {
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name: "Fabushi 佛法论坛",
+        url: communityUrl,
+        description: communityDescription,
+      },
+      {
+        "@type": "ItemList",
+        name: "Fabushi 佛法论坛板块",
+        itemListElement: FORUM_SECTIONS.map((item, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: item.titleZh,
+          description: item.summaryZh,
+        })),
+      },
+    ],
+  };
+
+  return (
+    <main className="inner-page">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="inner-hero">
+        <SiteHeader />
+        <div className="inner-copy">
+          <p className="eyebrow">
+            <LocalizedText zh="论坛首版" en="Community MVP" />
+          </p>
+          <h1>
+            <LocalizedText
+              zh="把佛法讨论做成能长期沉淀的社区。"
+              en="Build a dharma community that can compound over time."
+            />
+          </h1>
+          <p className="lede">
+            <LocalizedText
+              zh="这里先公开论坛的首版结构：板块怎么分、首批讨论从哪里开始、秩序怎么维持，以及后面会怎样一步步补上真实互动能力。"
+              en="This first version makes the community structure public: how the boards are organized, where early discussions begin, how order is maintained, and how real interaction will be added step by step."
+            />
+          </p>
+        </div>
+      </section>
+
+      <section className="band compact-band">
+        <div className="recommended-banner">
+          <LocalizedText
+            zh="当前阶段：论坛公开入口已经建立，首批示例帖子也已可浏览；下一步优先补发帖、回复、收藏、关注和新手引导。"
+            en="Current stage: the public forum entry is live, starter discussion pages are now browseable, and the next priority is posting, replies, bookmarks, follows, and newcomer guidance."
+          />
+        </div>
+        <div className="article-body">
+          <p>
+            <LocalizedText
+              zh="这不是一个追求热闹的泛讨论区。Fabushi 论坛会优先服务真实修学者和认真提问的新手，让高质量讨论慢慢沉淀成可复用的知识，而不是被时间线冲散。"
+              en="This is not meant to become a noisy general chat zone. The Fabushi forum is designed first for sincere newcomers and long-term practitioners, so good discussions can accumulate into reusable knowledge instead of disappearing in a feed."
+            />
+          </p>
+          <p>
+            <LocalizedText
+              zh="首版先把社区骨架搭清楚，再逐步接入账户、互动和治理能力。这样做的目标不是拖慢进度，而是确保论坛一开始就有方向、有边界，也有持续扩展的余地。"
+              en="The first release starts by making the community skeleton clear, then adds accounts, interaction, and governance in layers. The goal is not to move slowly, but to make sure the forum begins with direction, boundaries, and room to grow."
+            />
+          </p>
+          <div className="inline-cta">
+            <a className="primary-action" href={siteHref("/community/threads")}>
+              <LocalizedText zh="浏览首批示例帖子" en="Browse starter threads" />
+            </a>
+            <a className="secondary-action" href={siteHref("/contact")}>
+              <LocalizedText zh="联系团队反馈论坛需求" en="Contact the team with forum feedback" />
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="板块结构" en="Board Structure" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="先把讨论空间分清楚，后续内容才有沉淀的可能。"
+              en="Clear discussion spaces first, so later knowledge has somewhere to settle."
+            />
+          </h2>
+        </div>
+        <div className="definition-grid">
+          {FORUM_SECTIONS.map((item) => (
+            <article key={item.slug} className="definition-card">
+              <h3>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </h3>
+              <p>
+                <LocalizedText zh={item.summaryZh} en={item.summaryEn} />
+              </p>
+              <p>
+                <LocalizedText zh={item.guidanceZh} en={item.guidanceEn} />
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="首批讨论题" en="Starter Threads" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="论坛不是先空着等人来，而是先给出值得讨论的问题。"
+              en="The forum should not wait empty for people to arrive. It should begin with good questions."
+            />
+          </h2>
+        </div>
+        <div className="editorial-list">
+          {STARTER_THREADS.map((item) => (
+            <a
+              key={item.slug}
+              className="editorial-row"
+              href={siteHref(`/community/threads/${item.slug}`)}
+            >
+              <span>
+                <LocalizedText zh={item.sectionZh} en={item.sectionEn} />
+              </span>
+              <div>
+                <strong>
+                  <LocalizedText zh={item.titleZh} en={item.titleEn} />
+                </strong>
+                <p>
+                  <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+                </p>
+                <small>
+                  <LocalizedText zh="查看这条示例帖子" en="Open this starter thread" />
+                </small>
+              </div>
+            </a>
+          ))}
+        </div>
+        <div className="inline-cta">
+          <a className="secondary-action" href={siteHref("/community/threads")}>
+            <LocalizedText zh="进入帖子列表" en="Open thread index" />
+          </a>
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="治理原则" en="Governance" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="秩序不是靠压制建立的，而是靠清晰边界和稳定引导。"
+              en="Order is not built by force alone. It comes from clear boundaries and steady guidance."
+            />
+          </h2>
+        </div>
+        <div className="governance-grid">
+          {GOVERNANCE_SIGNALS.map((item) => (
+            <article key={item.titleEn} className="governance-card">
+              <h3>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </h3>
+              <p>
+                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="迭代路径" en="Launch Path" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="从公开入口开始，一步步走到真实可用的论坛。"
+              en="Start with a public entry, then move step by step toward a working forum."
+            />
+          </h2>
+        </div>
+        <div className="path-grid">
+          {LAUNCH_STEPS.map((item) => (
+            <article key={item.titleEn} className="path-card">
+              <h3>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </h3>
+              <p>
+                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+              </p>
+            </article>
+          ))}
+        </div>
+        <div className="inline-cta">
+          <a className="primary-action" href={siteHref("/community/threads")}>
+            <LocalizedText zh="先看论坛种子内容" en="See starter forum content" />
+          </a>
+          <a className="secondary-action" href={siteHref("/")}>
+            <LocalizedText zh="回到首页" en="Back to home" />
+          </a>
+        </div>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/frontend/apps/web/src/app/community/threads/[slug]/page.tsx
+++ b/frontend/apps/web/src/app/community/threads/[slug]/page.tsx
@@ -1,0 +1,271 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { brand } from "@fabushi/shared";
+import { LocalizedText } from "../../../../components/localized-text";
+import { SiteFooter } from "../../../../components/site-footer";
+import { SiteHeader } from "../../../../components/site-header";
+import {
+  FORUM_THREADS,
+  getForumSectionBySlug,
+  getForumThreadBySlug,
+} from "../../../../lib/community";
+import { siteHref, siteUrl } from "../../../../lib/site-url";
+
+interface ThreadPageProps {
+  params: {
+    slug: string;
+  };
+}
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return FORUM_THREADS.map((thread) => ({ slug: thread.slug }));
+}
+
+export function generateMetadata({ params }: ThreadPageProps): Metadata {
+  const thread = getForumThreadBySlug(params.slug);
+
+  if (!thread) {
+    return {
+      title: `论坛帖子 | ${brand.name}`,
+      description: "Fabushi 佛法论坛帖子详情。",
+    };
+  }
+
+  const section = getForumSectionBySlug(thread.sectionSlug);
+  const threadUrl = siteUrl(`/community/threads/${thread.slug}`);
+  const title = `${thread.titleZh} | ${brand.name}`;
+  const description = thread.summaryZh;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: threadUrl,
+    },
+    keywords: [thread.titleZh, section?.titleZh ?? "佛法论坛", ...thread.tagsZh],
+    openGraph: {
+      title,
+      description,
+      url: threadUrl,
+      siteName: "Fabushi",
+      locale: "zh_CN",
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default function CommunityThreadDetailPage({ params }: ThreadPageProps) {
+  const thread = getForumThreadBySlug(params.slug);
+
+  if (!thread) {
+    notFound();
+  }
+
+  const section = getForumSectionBySlug(thread.sectionSlug);
+  const threadUrl = siteUrl(`/community/threads/${thread.slug}`);
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "DiscussionForumPosting",
+        headline: thread.titleZh,
+        description: thread.summaryZh,
+        url: threadUrl,
+        articleSection: section?.titleZh ?? thread.sectionSlug,
+        author: {
+          "@type": "Person",
+          name: thread.authorZh,
+        },
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Fabushi 佛法论坛",
+            item: siteUrl("/community"),
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "论坛示例帖子",
+            item: siteUrl("/community/threads"),
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: thread.titleZh,
+            item: threadUrl,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <main className="inner-page">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="inner-hero">
+        <SiteHeader />
+        <div className="inner-copy">
+          <p className="eyebrow">
+            <LocalizedText
+              zh={section?.titleZh ?? thread.sectionSlug}
+              en={section?.titleEn ?? thread.sectionSlug}
+            />
+          </p>
+          <h1>
+            <LocalizedText zh={thread.titleZh} en={thread.titleEn} />
+          </h1>
+          <p className="lede">
+            <LocalizedText zh={thread.summaryZh} en={thread.summaryEn} />
+          </p>
+        </div>
+      </section>
+
+      <section className="band compact-band">
+        <div className="recommended-banner">
+          <LocalizedText
+            zh={`${thread.authorZh} · ${thread.roleZh} · ${thread.publishedLabelZh}`}
+            en={`${thread.authorEn} · ${thread.roleEn} · ${thread.publishedLabelEn}`}
+          />
+        </div>
+        <div className="definition-grid">
+          <article className="definition-card">
+            <h3>
+              <LocalizedText zh="最近动态" en="Latest activity" />
+            </h3>
+            <p>
+              <LocalizedText zh={thread.lastActivityZh} en={thread.lastActivityEn} />
+            </p>
+          </article>
+          <article className="definition-card">
+            <h3>
+              <LocalizedText zh="互动信号" en="Signals" />
+            </h3>
+            <p>
+              <LocalizedText
+                zh={`${thread.repliesCount} 条回复 · ${thread.followsCount} 人关注 · ${thread.bookmarksCount} 次收藏`}
+                en={`${thread.repliesCount} replies · ${thread.followsCount} follows · ${thread.bookmarksCount} bookmarks`}
+              />
+            </p>
+          </article>
+          <article className="definition-card">
+            <h3>
+              <LocalizedText zh="标签" en="Tags" />
+            </h3>
+            <p>
+              <LocalizedText zh={thread.tagsZh.join(" · ")} en={thread.tagsEn.join(" · ")} />
+            </p>
+          </article>
+          <article className="definition-card">
+            <h3>
+              <LocalizedText zh="为什么先做这条" en="Why this thread first" />
+            </h3>
+            <p>
+              <LocalizedText zh={thread.featuredReasonZh} en={thread.featuredReasonEn} />
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="发起帖正文" en="Opening post" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="先把问题说清楚，后面的讨论才会越来越好。"
+              en="A clear opening question gives the rest of the discussion somewhere solid to go."
+            />
+          </h2>
+        </div>
+        <div className="article-body">
+          {thread.openingPostZh.map((paragraph, index) => (
+            <p key={paragraph}>
+              <LocalizedText zh={paragraph} en={thread.openingPostEn[index]} />
+            </p>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="当前沉淀点" en="Archive points" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="这条帖子后续最值得沉淀成什么。"
+              en="What this thread is most likely to mature into later."
+            />
+          </h2>
+        </div>
+        <div className="governance-grid">
+          {thread.takeawaysZh.map((item, index) => (
+            <article key={item} className="governance-card">
+              <h3>
+                <LocalizedText zh={`重点 ${index + 1}`} en={`Point ${index + 1}`} />
+              </h3>
+              <p>
+                <LocalizedText zh={item} en={thread.takeawaysEn[index]} />
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="建议回帖方向" en="Suggested reply prompts" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="让回复更具体，也让后续整理更容易。"
+              en="Help replies become more concrete and easier to organize later."
+            />
+          </h2>
+        </div>
+        <div className="editorial-list">
+          {thread.replyPromptsZh.map((item, index) => (
+            <article key={item} className="editorial-row">
+              <span>
+                <LocalizedText zh={`提示 ${index + 1}`} en={`Prompt ${index + 1}`} />
+              </span>
+              <div>
+                <strong>
+                  <LocalizedText zh={item} en={thread.replyPromptsEn[index]} />
+                </strong>
+              </div>
+            </article>
+          ))}
+        </div>
+        <div className="inline-cta">
+          <a className="primary-action" href={siteHref("/community/threads")}>
+            <LocalizedText zh="回到帖子列表" en="Back to thread index" />
+          </a>
+          <a className="secondary-action" href={siteHref("/community")}>
+            <LocalizedText zh="回到论坛入口" en="Back to forum entry" />
+          </a>
+        </div>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/frontend/apps/web/src/app/community/threads/page.tsx
+++ b/frontend/apps/web/src/app/community/threads/page.tsx
@@ -1,0 +1,259 @@
+import type { Metadata } from "next";
+import { brand } from "@fabushi/shared";
+import { LocalizedText } from "../../../components/localized-text";
+import { SiteFooter } from "../../../components/site-footer";
+import { SiteHeader } from "../../../components/site-header";
+import {
+  FORUM_SECTIONS,
+  FORUM_THREADS,
+  getForumSectionBySlug,
+  getForumThreadsBySection,
+} from "../../../lib/community";
+import { siteHref, siteUrl } from "../../../lib/site-url";
+
+const threadsUrl = siteUrl("/community/threads");
+const threadsTitle = `论坛示例帖子 | ${brand.name}`;
+const threadsDescription =
+  "Fabushi 佛法论坛首批示例帖子列表，展示论坛将如何承载新手提问、经论研读、禅修问答与修学日志。";
+
+export const metadata: Metadata = {
+  title: threadsTitle,
+  description: threadsDescription,
+  alternates: {
+    canonical: threadsUrl,
+  },
+  keywords: ["佛法论坛帖子", "学佛讨论", "禅修问答", "经论研读", "Fabushi forum threads"],
+  openGraph: {
+    title: threadsTitle,
+    description: threadsDescription,
+    url: threadsUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: threadsTitle,
+    description: threadsDescription,
+  },
+};
+
+export default function CommunityThreadsPage() {
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name: "Fabushi 论坛示例帖子",
+        url: threadsUrl,
+        description: threadsDescription,
+      },
+      {
+        "@type": "ItemList",
+        name: "Fabushi 首批论坛帖子",
+        itemListElement: FORUM_THREADS.map((item, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          url: siteUrl(`/community/threads/${item.slug}`),
+          name: item.titleZh,
+          description: item.summaryZh,
+        })),
+      },
+    ],
+  };
+
+  return (
+    <main className="inner-page">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="inner-hero">
+        <SiteHeader />
+        <div className="inner-copy">
+          <p className="eyebrow">
+            <LocalizedText zh="论坛帖子索引" en="Thread Index" />
+          </p>
+          <h1>
+            <LocalizedText
+              zh="从种子帖子开始，把论坛真正走成可浏览的讨论空间。"
+              en="Start with seed threads and turn the forum into a space people can actually browse."
+            />
+          </h1>
+          <p className="lede">
+            <LocalizedText
+              zh="这里收拢了 Fabushi 佛法论坛首批示例帖子。它们还不是完整社区流量，但已经把论坛最核心的讨论方向、提问方式和沉淀逻辑公开出来。"
+              en="This page gathers the first Fabushi forum starter threads. It is not the full community yet, but it already exposes the discussion directions, question style, and archiving logic the forum will build on."
+            />
+          </p>
+        </div>
+      </section>
+
+      <section className="band compact-band">
+        <div className="recommended-banner">
+          <LocalizedText
+            zh="当前目标不是制造热闹，而是先让“新手起步、经论研读、禅修问答、修学日志”四类讨论路径有清晰落点。"
+            en="The immediate goal is not volume but clear landing zones for newcomer questions, sutra study, meditation practice, and practice journals."
+          />
+        </div>
+        <div className="article-body">
+          <p>
+            <LocalizedText
+              zh="论坛首轮内容会优先采用“种子帖子 + 后续沉淀”的方式推进。也就是说，先把值得长期讨论的问题摆出来，再逐步补回复、收藏、关注和精华归档。"
+              en="The first content pass uses a seed-thread model: publish questions worth discussing over time, then layer in replies, bookmarks, follows, and featured archiving."
+            />
+          </p>
+          <p>
+            <LocalizedText
+              zh="你现在看到的每一条帖子，既是示例内容，也是后续真实数据模型、板块结构和新手引导流程的原型。"
+              en="Each thread here is both sample content and a prototype for the future data model, board structure, and newcomer guidance flow."
+            />
+          </p>
+          <div className="inline-cta">
+            <a className="primary-action" href={siteHref("/community")}>
+              <LocalizedText zh="回看论坛入口" en="Back to forum entry" />
+            </a>
+            <a className="secondary-action" href={siteHref("/contact")}>
+              <LocalizedText zh="反馈你最想先参与的话题" en="Share which topic you want first" />
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="板块概览" en="Board Snapshot" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="先让每个板块都有第一条像样的讨论。"
+              en="Make sure each board begins with a discussion worth entering."
+            />
+          </h2>
+        </div>
+        <div className="definition-grid">
+          {FORUM_SECTIONS.map((section) => {
+            const count = getForumThreadsBySection(section.slug).length;
+            return (
+              <article key={section.slug} className="definition-card">
+                <h3>
+                  <LocalizedText zh={section.titleZh} en={section.titleEn} />
+                </h3>
+                <p>
+                  <LocalizedText zh={section.summaryZh} en={section.summaryEn} />
+                </p>
+                <p>
+                  <LocalizedText
+                    zh={`当前示例帖子 ${count} 条`}
+                    en={`${count} starter thread${count === 1 ? "" : "s"} so far`}
+                  />
+                </p>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="帖子列表" en="Threads" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="先浏览问题，再决定论坛后续要把哪些能力补齐。"
+              en="Browse the questions first, then decide which forum capabilities need to be added next."
+            />
+          </h2>
+        </div>
+        <div className="editorial-list">
+          {FORUM_THREADS.map((thread) => {
+            const section = getForumSectionBySlug(thread.sectionSlug);
+            return (
+              <a
+                key={thread.slug}
+                className="editorial-row"
+                href={siteHref(`/community/threads/${thread.slug}`)}
+              >
+                <span>
+                  <LocalizedText
+                    zh={section?.titleZh ?? thread.sectionSlug}
+                    en={section?.titleEn ?? thread.sectionSlug}
+                  />
+                </span>
+                <div>
+                  <strong>
+                    <LocalizedText zh={thread.titleZh} en={thread.titleEn} />
+                  </strong>
+                  <p>
+                    <LocalizedText zh={thread.summaryZh} en={thread.summaryEn} />
+                  </p>
+                  <small>
+                    <LocalizedText
+                      zh={`${thread.repliesCount} 条回复 · ${thread.followsCount} 人关注 · ${thread.bookmarksCount} 次收藏 · ${thread.lastActivityZh}`}
+                      en={`${thread.repliesCount} replies · ${thread.followsCount} follows · ${thread.bookmarksCount} bookmarks · ${thread.lastActivityEn}`}
+                    />
+                  </small>
+                </div>
+              </a>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="为什么先这样做" en="Why This First" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="论坛真正的骨架，不只是页面，而是被长期复用的问题结构。"
+              en="The real backbone of the forum is not just pages, but question structures that can be reused over time."
+            />
+          </h2>
+        </div>
+        <div className="governance-grid">
+          <article className="governance-card">
+            <h3>
+              <LocalizedText zh="先把提问方式做对" en="Start with good question framing" />
+            </h3>
+            <p>
+              <LocalizedText
+                zh="如果最早的讨论就能带出出处、上下文、适用对象和复盘方式，后续的数据层与治理逻辑会更容易接上。"
+                en="If the earliest threads already model sources, context, intended audience, and review patterns, later data and moderation layers can grow on steadier ground."
+              />
+            </p>
+          </article>
+          <article className="governance-card">
+            <h3>
+              <LocalizedText zh="先把沉淀点暴露出来" en="Expose archive points early" />
+            </h3>
+            <p>
+              <LocalizedText
+                zh="每条示例帖子都已经预留了“摘要、标签、回帖提示、后续可整理内容”的结构，方便后面接精华归档。"
+                en="Each thread already carries summary, tags, reply prompts, and archive-ready structure so featured knowledge pages can be added later."
+              />
+            </p>
+          </article>
+          <article className="governance-card">
+            <h3>
+              <LocalizedText zh="先看浏览闭环哪里最缺" en="Find the next missing piece" />
+            </h3>
+            <p>
+              <LocalizedText
+                zh="当列表和详情页都出现后，我们就能更准确判断接下来该优先做发帖、回复表单，还是审核和新手引导。"
+                en="Once both list and detail views exist, it becomes much easier to judge whether posting, reply forms, moderation, or onboarding should come next."
+              />
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllArticles } from "../lib/content";
+import { FORUM_THREADS } from "../lib/community";
 import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
@@ -9,6 +10,8 @@ const staticRoutes = [
   "/download",
   "/apply",
   "/faq",
+  "/community",
+  "/community/threads",
   "/privacy",
   "/contact",
   "/insights",
@@ -21,36 +24,30 @@ const staticRoutes = [
   "/beginner-sutra-recommendations",
 ] as const;
 
+const weeklyRoutes = new Set([
+  "/",
+  "/download",
+  "/faq",
+  "/community",
+  "/community/threads",
+  "/buddhadharma",
+  "/start-learning-buddhism",
+  "/meditation",
+  "/practice-guide",
+  "/daily-practice",
+  "/sutra-guide",
+  "/beginner-sutra-recommendations",
+]);
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const pages: MetadataRoute.Sitemap = staticRoutes.map((route) => ({
     url: siteUrl(route),
     lastModified: route === "/privacy" ? "2026-05-08" : new Date(),
-    changeFrequency:
-      route === "/"
-        ? "weekly"
-        : route === "/download" ||
-            route === "/faq" ||
-            route === "/buddhadharma" ||
-            route === "/start-learning-buddhism" ||
-            route === "/meditation" ||
-            route === "/practice-guide" ||
-            route === "/daily-practice" ||
-            route === "/sutra-guide" ||
-            route === "/beginner-sutra-recommendations"
-          ? "weekly"
-          : "monthly",
+    changeFrequency: weeklyRoutes.has(route) ? "weekly" : "monthly",
     priority:
       route === "/"
         ? 1
-        : route === "/download" ||
-            route === "/faq" ||
-            route === "/buddhadharma" ||
-            route === "/start-learning-buddhism" ||
-            route === "/meditation" ||
-            route === "/practice-guide" ||
-            route === "/daily-practice" ||
-            route === "/sutra-guide" ||
-            route === "/beginner-sutra-recommendations"
+        : weeklyRoutes.has(route)
           ? 0.9
           : route === "/apply"
             ? 0.85
@@ -66,5 +63,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: article.featured ? 0.8 : 0.65,
   }));
 
-  return [...pages, ...articlePages];
+  const forumThreadPages: MetadataRoute.Sitemap = FORUM_THREADS.map((thread) => ({
+    url: siteUrl(`/community/threads/${thread.slug}`),
+    lastModified: new Date(),
+    changeFrequency: "weekly",
+    priority: 0.8,
+  }));
+
+  return [...pages, ...articlePages, ...forumThreadPages];
 }

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -25,6 +25,9 @@ export function SiteFooter() {
         <a href={siteHref("/faq")}>
           <LocalizedText zh="常见问题" en="FAQ" />
         </a>
+        <a href={siteHref("/community")}>
+          <LocalizedText zh="佛法论坛" en="Community Forum" />
+        </a>
         <a href={siteHref("/buddhadharma")}>
           <LocalizedText zh="佛法入门" en="Dharma Basics" />
         </a>

--- a/frontend/apps/web/src/lib/community.ts
+++ b/frontend/apps/web/src/lib/community.ts
@@ -1,0 +1,415 @@
+export interface ForumSection {
+  slug: string;
+  titleZh: string;
+  titleEn: string;
+  summaryZh: string;
+  summaryEn: string;
+  guidanceZh: string;
+  guidanceEn: string;
+}
+
+export interface StarterThread {
+  slug: string;
+  titleZh: string;
+  titleEn: string;
+  sectionZh: string;
+  sectionEn: string;
+  descriptionZh: string;
+  descriptionEn: string;
+}
+
+export interface GovernanceSignal {
+  titleZh: string;
+  titleEn: string;
+  descriptionZh: string;
+  descriptionEn: string;
+}
+
+export interface LaunchStep {
+  titleZh: string;
+  titleEn: string;
+  descriptionZh: string;
+  descriptionEn: string;
+}
+
+export interface ForumThread {
+  slug: string;
+  sectionSlug: string;
+  titleZh: string;
+  titleEn: string;
+  summaryZh: string;
+  summaryEn: string;
+  authorZh: string;
+  authorEn: string;
+  roleZh: string;
+  roleEn: string;
+  publishedLabelZh: string;
+  publishedLabelEn: string;
+  lastActivityZh: string;
+  lastActivityEn: string;
+  repliesCount: number;
+  followsCount: number;
+  bookmarksCount: number;
+  tagsZh: string[];
+  tagsEn: string[];
+  featuredReasonZh: string;
+  featuredReasonEn: string;
+  openingPostZh: string[];
+  openingPostEn: string[];
+  takeawaysZh: string[];
+  takeawaysEn: string[];
+  replyPromptsZh: string[];
+  replyPromptsEn: string[];
+}
+
+export const FORUM_SECTIONS: ForumSection[] = [
+  {
+    slug: "newcomer-path",
+    titleZh: "新手起步",
+    titleEn: "Newcomer Path",
+    summaryZh: "给第一次接触佛法的人一个能放心提问、能被温和接住的入口。",
+    summaryEn: "A gentle place for first questions, where newcomers can ask openly and be guided with care.",
+    guidanceZh: "适合提出“先读什么、先练什么、先建立什么日常节奏”这一类起步问题。",
+    guidanceEn: "Best for questions about where to begin, what to read first, and how to build a first daily rhythm.",
+  },
+  {
+    slug: "sutra-study",
+    titleZh: "经论研读",
+    titleEn: "Sutra Study",
+    summaryZh: "围绕经典、次第、名相与出处做可追溯的讨论，不鼓励断章取义。",
+    summaryEn: "A traceable discussion area for sutras, commentaries, terminology, and references.",
+    guidanceZh: "鼓励贴出经论出处、上下文和不同理解路径，帮助长期沉淀。",
+    guidanceEn: "Members are encouraged to include sources, context, and interpretive paths so knowledge can accumulate.",
+  },
+  {
+    slug: "meditation-practice",
+    titleZh: "禅修问答",
+    titleEn: "Meditation Practice",
+    summaryZh: "聚焦坐禅、散乱、昏沉、节奏、陪练与复盘，把经验说清楚。",
+    summaryEn: "Focused on sitting practice, distraction, dullness, rhythm, group sessions, and thoughtful review.",
+    guidanceZh: "适合讨论练习感受，但避免把个人状态直接包装成权威结论。",
+    guidanceEn: "Personal experience is welcome, but it should not be presented as final authority.",
+  },
+  {
+    slug: "practice-journal",
+    titleZh: "修学日志",
+    titleEn: "Practice Journal",
+    summaryZh: "允许长期记录自己的愿心、障碍、调整与回看，形成真实修学轨迹。",
+    summaryEn: "A space for long-term logs of vows, obstacles, adjustments, and reflection.",
+    guidanceZh: "强调持续与诚实记录，而不是表演式打卡。",
+    guidanceEn: "The emphasis is on steady, honest reflection rather than performative check-ins.",
+  },
+  {
+    slug: "group-practice",
+    titleZh: "共修与地区",
+    titleEn: "Group Practice",
+    summaryZh: "连接线上共修、线下地区交流与时区组织，让关系真正沉下来。",
+    summaryEn: "Connect online groups, regional circles, and timezone-based practice rhythms.",
+    guidanceZh: "后续会逐步扩展成按地区、语言和主题组织的社区网络。",
+    guidanceEn: "This section can later expand into a community network organized by region, language, and theme.",
+  },
+  {
+    slug: "knowledge-archive",
+    titleZh: "资料整理",
+    titleEn: "Knowledge Archive",
+    summaryZh: "把高质量回答、精华串和专题索引整理成可反复引用的知识页。",
+    summaryEn: "Turn high-quality answers, curated threads, and topic indexes into reusable knowledge pages.",
+    guidanceZh: "这是论坛避免只剩时间线噪音的关键区域。",
+    guidanceEn: "This is how the forum avoids becoming a stream of noise.",
+  },
+];
+
+export const FORUM_THREADS: ForumThread[] = [
+  {
+    slug: "first-year-stability",
+    sectionSlug: "newcomer-path",
+    titleZh: "学佛第一年，先稳定什么最重要？",
+    titleEn: "In the first year, what is most important to stabilize?",
+    summaryZh: "与其一开始同时抓很多法门，不如先把愿心、作息、听闻和最基础的练习节奏稳下来。",
+    summaryEn: "Instead of trying too many practices at once, stabilize aspiration, daily rhythm, listening, and one basic practice first.",
+    authorZh: "净行",
+    authorEn: "Jing Xing",
+    roleZh: "论坛发起帖",
+    roleEn: "Forum seed thread",
+    publishedLabelZh: "首批引导话题",
+    publishedLabelEn: "Seed discussion",
+    lastActivityZh: "最近整理：起步节奏清单",
+    lastActivityEn: "Latest update: starter rhythm checklist",
+    repliesCount: 18,
+    followsCount: 42,
+    bookmarksCount: 27,
+    tagsZh: ["新手", "作息", "起步"],
+    tagsEn: ["newcomer", "daily rhythm", "beginning"],
+    featuredReasonZh: "适合作为新手欢迎区的第一条常驻讨论。",
+    featuredReasonEn: "A strong anchor thread for the newcomer welcome area.",
+    openingPostZh: [
+      "很多人学佛的第一年，最大的困难不是信息不够，而是同时抓太多，结果什么都不稳。今天想邀请大家一起讨论：如果只能先稳定三件事，你会选什么？为什么？",
+      "我自己的判断是，第一优先通常不是“立刻进入很多高强度练习”，而是先把愿心、作息、听闻和一个最基础的日常练习放稳。这样后面读经、持诵、禅修或参加共修时，才有真正能持续的土壤。",
+      "欢迎大家结合自己的路径来分享，但尽量说清楚适用对象：是面向完全零基础的新手，还是已经开始固定听经、诵经或禅修的人。",
+    ],
+    openingPostEn: [
+      "In the first year of practice, the biggest problem is often not a lack of information but trying too many things at once. If you could stabilize only three things first, what would they be, and why?",
+      "My own view is that the first priority is usually not intense practice volume, but a steady aspiration, daily rhythm, listening habit, and one basic repeatable practice. That creates soil for later sutra study, chanting, meditation, or group practice.",
+      "Please share from your own path, but note who your advice is for: someone completely new, or someone who has already begun a stable routine of listening, recitation, or meditation.",
+    ],
+    takeawaysZh: [
+      "先稳节奏，再谈扩展，不要让起步阶段变成堆任务。",
+      "建议回复时写明自己的起点，避免把个人路径说成唯一标准。",
+      "后续可以把高质量回复整理成“新手第一年节奏建议”。",
+    ],
+    takeawaysEn: [
+      "Stabilize rhythm before expansion so the first stage does not become a pile of tasks.",
+      "Replies should state the speaker's starting point instead of presenting one path as universal.",
+      "Strong responses can later become a newcomer first-year rhythm guide.",
+    ],
+    replyPromptsZh: [
+      "如果是完全零基础的人，你会建议先固定什么？",
+      "你走过弯路后，最希望早点稳定下来的是什么？",
+      "哪些建议看似积极，但其实容易让新手失去节奏？",
+    ],
+    replyPromptsEn: [
+      "For a complete beginner, what would you ask them to stabilize first?",
+      "Looking back, what do you wish you had made steady earlier?",
+      "Which well-meant suggestions actually make beginners lose their rhythm?",
+    ],
+  },
+  {
+    slug: "how-to-ask-while-reading-sutras",
+    sectionSlug: "sutra-study",
+    titleZh: "读经时遇到看不懂的名相，应该怎样提问？",
+    titleEn: "How should we ask about terms we do not understand in sutra reading?",
+    summaryZh: "好问题不是只贴一个词，而是把出处、上下文和自己的理解一起带出来，这样讨论才更能沉淀。",
+    summaryEn: "A good question brings the term, the source passage, surrounding context, and the reader's current understanding together.",
+    authorZh: "闻思",
+    authorEn: "Wen Si",
+    roleZh: "经论研读发起帖",
+    roleEn: "Sutra study seed thread",
+    publishedLabelZh: "首批引导话题",
+    publishedLabelEn: "Seed discussion",
+    lastActivityZh: "最近整理：提问模板已加入",
+    lastActivityEn: "Latest update: question template added",
+    repliesCount: 11,
+    followsCount: 31,
+    bookmarksCount: 36,
+    tagsZh: ["名相", "出处", "提问方式"],
+    tagsEn: ["terminology", "sources", "asking well"],
+    featuredReasonZh: "这类提问方式会直接影响论坛的长期知识质量。",
+    featuredReasonEn: "The way people ask here will shape the forum's long-term knowledge quality.",
+    openingPostZh: [
+      "经论研读区很容易出现一种情况：有人只贴一个名相，然后问“这是什么意思？”这样的提问当然真实，但如果没有出处和上下文，回答也很容易发散，甚至互相误解。",
+      "我想先做一个更适合论坛长期沉淀的提问范式：至少附上经论出处、前后文、自己目前的理解，以及你卡住的具体点。这样别人不只是来“给答案”，而是能一起帮助厘清语境。",
+      "欢迎大家补充：对于新手来说，怎样的提问模板既不会太重，又能明显提高讨论质量？",
+    ],
+    openingPostEn: [
+      "In sutra study, a common pattern is that someone posts a single term and asks, 'What does this mean?' The question is sincere, but without source and context, the replies often scatter or misunderstand each other.",
+      "I want to propose a forum-friendly question format: include the source text, nearby context, your current understanding, and the exact point where you got stuck. Then people can clarify the frame instead of only dropping answers.",
+      "Please add to this: what kind of question template stays light enough for beginners while still raising the quality of discussion?",
+    ],
+    takeawaysZh: [
+      "提问要尽量把出处、上下文和卡点一起带出来。",
+      "论坛后续可以把常见提问模板做成固定置顶说明。",
+      "好的提问本身就是知识沉淀的起点。",
+    ],
+    takeawaysEn: [
+      "Questions should carry source, context, and the exact point of confusion.",
+      "The forum can later turn common question formats into pinned guidance.",
+      "A well-formed question is already the start of knowledge archiving.",
+    ],
+    replyPromptsZh: [
+      "你见过最有帮助的一种读经提问方式是什么？",
+      "哪些补充信息最值得作为固定字段？",
+      "怎样避免把提问门槛抬得太高，让新手不敢开口？",
+    ],
+    replyPromptsEn: [
+      "What is the most helpful sutra-reading question format you have seen?",
+      "Which extra details deserve to become standard fields?",
+      "How do we keep the bar helpful without making beginners afraid to ask?",
+    ],
+  },
+  {
+    slug: "working-with-distraction-and-dullness",
+    sectionSlug: "meditation-practice",
+    titleZh: "禅修里最常见的散乱和昏沉，大家怎么处理？",
+    titleEn: "How do people work with distraction and dullness in meditation?",
+    summaryZh: "把散乱和昏沉说得具体一些：发生在什么时候、前后做了什么、如何复盘，比空泛谈体验更有帮助。",
+    summaryEn: "It helps more to describe when distraction or dullness appears, what came before it, and how you reviewed it than to speak vaguely about states.",
+    authorZh: "清照",
+    authorEn: "Qing Zhao",
+    roleZh: "禅修问答发起帖",
+    roleEn: "Meditation seed thread",
+    publishedLabelZh: "首批引导话题",
+    publishedLabelEn: "Seed discussion",
+    lastActivityZh: "最近整理：复盘提示已补充",
+    lastActivityEn: "Latest update: review prompts added",
+    repliesCount: 23,
+    followsCount: 38,
+    bookmarksCount: 33,
+    tagsZh: ["禅修", "散乱", "昏沉"],
+    tagsEn: ["meditation", "distraction", "dullness"],
+    featuredReasonZh: "这是最容易活跃、也最需要降噪的一类主题。",
+    featuredReasonEn: "This topic will likely become active quickly and needs grounded framing from the start.",
+    openingPostZh: [
+      "散乱和昏沉几乎是每个练习者都会遇到的，但论坛里如果只说“我今天状态不好”，其实很难互相帮助。真正有用的分享，往往会把练习前的状态、练习中的变化和结束后的复盘说清楚。",
+      "我建议这个串先聚焦在实践层面：你通常在什么情况下更容易散乱？昏沉来时，你会怎么调整坐姿、呼吸、时长或作息？哪些调整对你有效，哪些只是暂时掩盖问题？",
+      "也想提醒一点：欢迎谈经验，但尽量不要把短期体感包装成深层境界判断。这样论坛会更稳，也更适合真正互相帮助。",
+    ],
+    openingPostEn: [
+      "Almost every practitioner meets distraction and dullness, but a post that only says 'I had a bad session' gives others little to work with. The most helpful sharing usually explains the preconditions, what changed during the sit, and how the session was reviewed afterward.",
+      "I suggest keeping this thread practical first: when are you more likely to become distracted, what adjustments do you make in posture, breathing, duration, or routine, and which changes actually help?",
+      "One more note: personal experience is welcome, but please avoid framing short-term sensations as deep attainment claims. That keeps the forum steadier and more useful.",
+    ],
+    takeawaysZh: [
+      "把问题落到练习前、中、后的复盘细节里。",
+      "讨论应优先帮助调整节奏，而不是放大体验感。",
+      "后续可以把高质量回复沉淀成“散乱 / 昏沉处理索引”。",
+    ],
+    takeawaysEn: [
+      "Ground the conversation in before, during, and after-practice review details.",
+      "The goal is to help adjustment and rhythm, not dramatize experience.",
+      "Strong replies can later become an index for working with distraction and dullness.",
+    ],
+    replyPromptsZh: [
+      "你最常见的散乱触发点是什么？",
+      "哪些调整帮助你从昏沉里出来，而不是只是硬撑？",
+      "怎样描述自己的体验，才能更容易得到有效帮助？",
+    ],
+    replyPromptsEn: [
+      "What most often triggers distraction for you?",
+      "Which adjustments help you emerge from dullness instead of just enduring it?",
+      "How can someone describe a session so others can actually help?",
+    ],
+  },
+  {
+    slug: "honest-practice-journal",
+    sectionSlug: "practice-journal",
+    titleZh: "怎样写修学日志，既真实又不流于自我表演？",
+    titleEn: "How can a practice journal stay honest without turning into performance?",
+    summaryZh: "修学日志不只是记录“我做了什么”，更重要的是记下愿心、节奏、障碍和调整，这样回看才真的有用。",
+    summaryEn: "A practice journal becomes useful when it records aspiration, rhythm, obstacles, and adjustments, not just a list of completed actions.",
+    authorZh: "持灯",
+    authorEn: "Chi Deng",
+    roleZh: "修学日志发起帖",
+    roleEn: "Practice journal seed thread",
+    publishedLabelZh: "首批引导话题",
+    publishedLabelEn: "Seed discussion",
+    lastActivityZh: "最近整理：日志模板草案",
+    lastActivityEn: "Latest update: journal template draft",
+    repliesCount: 9,
+    followsCount: 26,
+    bookmarksCount: 41,
+    tagsZh: ["日志", "复盘", "长期记录"],
+    tagsEn: ["journal", "review", "long-term record"],
+    featuredReasonZh: "这会影响论坛能否形成长期可回看的修学轨迹。",
+    featuredReasonEn: "This determines whether the forum can support long-term, reviewable practice paths.",
+    openingPostZh: [
+      "修学日志区如果只剩“今天打卡了什么”，很快就会变成一种表演压力。可如果什么都不记，很多真正重要的变化又会在几周后完全想不起来。",
+      "我想邀请大家一起讨论：一条健康的修学日志，最少应该包含哪些部分？比如今天的发心、做了什么、遇到什么障碍、怎么调整，以及接下来准备观察什么。",
+      "如果你已经有稳定记录的经验，也欢迎分享你后来删掉了哪些“看起来很积极、实际没帮助”的记录习惯。",
+    ],
+    openingPostEn: [
+      "If the practice journal area becomes only a list of check-ins, it quickly creates performance pressure. But if nothing is recorded, many meaningful changes disappear from memory within weeks.",
+      "I want to ask: what is the minimum healthy structure of a practice journal? For example, today's aspiration, what was done, what obstacle appeared, how it was adjusted, and what to watch next.",
+      "If you already keep a stable journal, please share which habits looked diligent but later turned out not to help.",
+    ],
+    takeawaysZh: [
+      "日志要帮助回看和调整，而不是制造展示压力。",
+      "推荐围绕发心、节奏、障碍、调整四项来写。",
+      "后续可把优质模板沉淀成固定写作引导。",
+    ],
+    takeawaysEn: [
+      "A journal should support review and adjustment rather than performance pressure.",
+      "A useful base format centers on aspiration, rhythm, obstacles, and adjustment.",
+      "Strong templates can later become stable writing guidance for the forum.",
+    ],
+    replyPromptsZh: [
+      "你记录日志时，最想在几周后回看到什么？",
+      "哪些内容值得保留，哪些内容容易变成自我展示？",
+      "如果论坛给一个默认模板，你最希望它提醒你写哪一项？",
+    ],
+    replyPromptsEn: [
+      "When you review a journal weeks later, what do you most want to see?",
+      "Which kinds of notes are worth keeping, and which drift into self-display?",
+      "If the forum offered a default template, what would you most want it to prompt?",
+    ],
+  },
+];
+
+export const STARTER_THREADS: StarterThread[] = FORUM_THREADS.map((thread) => {
+  const section = FORUM_SECTIONS.find((item) => item.slug === thread.sectionSlug);
+
+  return {
+    slug: thread.slug,
+    titleZh: thread.titleZh,
+    titleEn: thread.titleEn,
+    sectionZh: section?.titleZh ?? thread.sectionSlug,
+    sectionEn: section?.titleEn ?? thread.sectionSlug,
+    descriptionZh: thread.summaryZh,
+    descriptionEn: thread.summaryEn,
+  };
+});
+
+export const GOVERNANCE_SIGNALS: GovernanceSignal[] = [
+  {
+    titleZh: "优先引导，不先争胜",
+    titleEn: "Guide before debating",
+    descriptionZh: "对新手问题先帮助厘清背景与语境，不鼓励靠压制感建立权威。",
+    descriptionEn: "Beginner questions should be met with context and guidance, not dominance.",
+  },
+  {
+    titleZh: "引用请尽量给出处",
+    titleEn: "Cite when possible",
+    descriptionZh: "涉及经典、祖师语录或关键佛法判断时，尽量附上经论出处，减少误传。",
+    descriptionEn: "When discussing key dharma claims or quotations, include sources whenever possible.",
+  },
+  {
+    titleZh: "错误信息要温和纠偏",
+    titleEn: "Correct gently",
+    descriptionZh: "论坛会建立纠偏机制，但处理方式应以澄清和帮助理解为主，而不是羞辱。",
+    descriptionEn: "The forum should correct harmful inaccuracies, but with clarity rather than humiliation.",
+  },
+  {
+    titleZh: "精华要能沉淀成知识",
+    titleEn: "Turn highlights into knowledge",
+    descriptionZh: "高质量讨论不应只留在时间线里，后续会进入专题索引和资料整理区。",
+    descriptionEn: "Strong discussions should not vanish in the feed; they should become part of the archive.",
+  },
+];
+
+export const LAUNCH_STEPS: LaunchStep[] = [
+  {
+    titleZh: "阶段一：论坛公开入口",
+    titleEn: "Phase 1: Public entry",
+    descriptionZh: "先把板块结构、讨论主题、治理原则和产品方向公开出来，建立清晰预期。",
+    descriptionEn: "Publish the forum structure, starter topics, governance principles, and product direction.",
+  },
+  {
+    titleZh: "阶段二：基础互动",
+    titleEn: "Phase 2: Core interaction",
+    descriptionZh: "补上发帖、回复、引用、收藏和关注，让社区开始形成最小讨论闭环。",
+    descriptionEn: "Add posting, replies, quotes, bookmarks, and follows to form the first discussion loop.",
+  },
+  {
+    titleZh: "阶段三：审核与新手引导",
+    titleEn: "Phase 3: Moderation and onboarding",
+    descriptionZh: "引入版规、纠偏、欢迎流程和板块引导，保护讨论质量与秩序。",
+    descriptionEn: "Introduce moderation, correction flows, welcoming steps, and clearer board guidance.",
+  },
+  {
+    titleZh: "阶段四：知识沉淀",
+    titleEn: "Phase 4: Knowledge archive",
+    descriptionZh: "将优质问答、精选串和长期专题沉淀成知识页，真正形成论坛资产。",
+    descriptionEn: "Convert great Q&A, curated threads, and long-term topics into durable knowledge pages.",
+  },
+];
+
+export function getForumSectionBySlug(slug: string) {
+  return FORUM_SECTIONS.find((item) => item.slug === slug) ?? null;
+}
+
+export function getForumThreadBySlug(slug: string) {
+  return FORUM_THREADS.find((item) => item.slug === slug) ?? null;
+}
+
+export function getForumThreadsBySection(sectionSlug: string) {
+  return FORUM_THREADS.filter((item) => item.sectionSlug === sectionSlug);
+}

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -39,6 +39,7 @@ export const homeUseCases = [
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },
+  { label: "佛法论坛", href: "/community" },
   { label: "申请测试", href: "/apply" },
   { label: "常见问题", href: "/faq" },
   { label: "联系", href: "/contact" },


### PR DESCRIPTION
## 问题

论坛项目上一轮已经把 `/community -> /community/threads -> /community/threads/[slug]` 这条浏览闭环做出来了，但原 PR #399 挂在一个已经落后于 `main` 的分支上，主站这期间又继续新增了佛法内容入口与 sitemap 链接，导致论坛改动没有办法顺畅继续推进到当前主线。

现在最优先的不是再分散做新想法，而是把这批论坛首版骨架重新对齐到最新仓库状态，让项目重新进入可审查、可合并、可继续迭代的轨道。

## 这次改动

- 新增论坛入口页：`/community`
- 新增论坛帖子列表页：`/community/threads`
- 新增首批示例帖子详情页：`/community/threads/[slug]`
- 新增论坛共享数据模块：
  - 板块结构
  - 首批示例帖子
  - 治理信号
  - 启动阶段路径
- 将论坛入口接入：
  - 顶部主导航
  - 页脚链接
  - `sitemap.ts`
- 在对齐最新 `main` 的同时，保留已经合入主站的内容入口：
  - `/daily-practice`
  - `/beginner-sutra-recommendations`

## 为什么现在做

- 论坛项目当前最关键的阶段仍然是把“可浏览的论坛骨架”稳定落到主站中，而不是继续停留在概念说明页。
- 这一步一旦进入主线，后续每小时推进就可以更聚焦到真实数据模型、发帖/回复流程、新手引导和审核接口，而不是反复处理分支漂移。
- 论坛入口、帖子列表、帖子详情、导航发现和 sitemap 暴露都已经成型，这是一批边界清晰、可检查、值得先合并的基础改动。

## 验证

- 已通过 compare 确认新分支相对当前 `main`：
  - `behind_by = 0`
  - 仅包含 7 个与论坛浏览骨架直接相关的改动文件
- 已回读关键文件，确认论坛入口、帖子列表、帖子详情、共享数据、导航、页脚与 sitemap 已全部落在新分支上
- 当前环境没有仓库本地工作副本，未直接运行 Next.js 构建；最终构建与检查仍依赖仓库 CI

## 备注

- 本 PR 实际上是把原先卡在旧基线上的论坛骨架重新对齐到当前主线，可视为对 PR #399 的可合并替代版本。
- 后续若本 PR 进入主线，下一优先级会转到论坛真实数据模型与最小发帖/回复流程。