### PR TITLE
fix(web): align community thread page props with Next 15

### DIFF
--- a/frontend/apps/web/src/app/community/threads/[slug]/page.tsx
+++ b/frontend/apps/web/src/app/community/threads/[slug]/page.tsx
@@ -11,10 +11,12 @@ import {
 } from "../../../../lib/community";
 import { siteHref, siteUrl } from "../../../../lib/site-url";
 
+type ThreadPageParams = {
+  slug: string;
+};
+
 interface ThreadPageProps {
-  params: {
-    slug: string;
-  };
+  params: Promise<ThreadPageParams>;
 }
 
 export const dynamicParams = false;
@@ -23,8 +25,9 @@ export function generateStaticParams() {
   return FORUM_THREADS.map((thread) => ({ slug: thread.slug }));
 }
 
-export function generateMetadata({ params }: ThreadPageProps): Metadata {
-  const thread = getForumThreadBySlug(params.slug);
+export async function generateMetadata({ params }: ThreadPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const thread = getForumThreadBySlug(slug);
 
   if (!thread) {
     return {
@@ -34,7 +37,7 @@ export function generateMetadata({ params }: ThreadPageProps): Metadata {
   }
 
   const section = getForumSectionBySlug(thread.sectionSlug);
-  const threadUrl = siteUrl(`/community/threads/${thread.slug}`);
+  const threadUrl = siteUrl(`/community/threads/${slug}`);
   const title = `${thread.titleZh} | ${brand.name}`;
   const description = thread.summaryZh;
 
@@ -61,15 +64,16 @@ export function generateMetadata({ params }: ThreadPageProps): Metadata {
   };
 }
 
-export default function CommunityThreadDetailPage({ params }: ThreadPageProps) {
-  const thread = getForumThreadBySlug(params.slug);
+export default async function CommunityThreadDetailPage({ params }: ThreadPageProps) {
+  const { slug } = await params;
+  const thread = getForumThreadBySlug(slug);
 
   if (!thread) {
     notFound();
   }
 
   const section = getForumSectionBySlug(thread.sectionSlug);
-  const threadUrl = siteUrl(`/community/threads/${thread.slug}`);
+  const threadUrl = siteUrl(`/community/threads/${slug}`);
   const structuredData = {
     "@context": "https://schema.org",
     "@graph": [


### PR DESCRIPTION
## 问题

`PR #406` 合入后，论坛帖子详情页 `frontend/apps/web/src/app/community/threads/[slug]/page.tsx` 在 Next.js 构建阶段报类型错误：

- `issue #407` 对应 `CI #819`
- `issue #408` 对应 `CI #821`
- 失败点一致：`Build Next.js site`
- 日志明确指出 `ThreadPageProps` 不满足当前 Next.js `PageProps` 约束，`params` 需要按 promise 形态处理

这说明问题已经不只是旧 PR 上的快照，而是已经进入 `main` 的真实主链路红灯。

## 这次修复

- 将论坛帖子详情页的 `params` 类型调整为 Next.js 15 当前要求的 promise 形态
- 将 `generateMetadata` 改为 `async`，并先 `await params`
- 将页面组件改为 `async`，统一在读取 slug 前解析 `params`
- 其余页面结构、SEO 输出和论坛内容数据不做行为改动

## 为什么这样修

当前失败不是业务数据问题，而是 App Router 页面签名和当前 Next.js 类型约束不一致。

最小修复就是把同一文件里的 metadata 与 page 入口统一成 promise-based params 读取方式，让构建器不再把该页面判为不兼容的 `PageProps`。

## 验证

- 对照 `issue #407` / `issue #408` 的失败日志，确认唯一首故障集中在 `src/app/community/threads/[slug]/page.tsx` 的 `ThreadPageProps`
- 这次只修改该文件的页面参数签名与读取方式，不扩散到论坛其他页面
- 当前环境没有仓库工作副本，无法本地执行 `pnpm build:web`；最终以仓库 CI 复跑结果为准