### PR TITLE
feat(web): expose seed forum thread APIs

### DIFF
--- a/frontend/apps/web/src/app/api/community/threads/[slug]/route.ts
+++ b/frontend/apps/web/src/app/api/community/threads/[slug]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getForumThreadResponse } from "../../../../../lib/community-api";
+
+const responseHeaders = {
+  "Cache-Control": "public, s-maxage=300, stale-while-revalidate=86400",
+};
+
+type RouteContext = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { slug } = await params;
+  const response = getForumThreadResponse(slug);
+
+  if (!response) {
+    return NextResponse.json(
+      {
+        error: "Forum thread not found",
+      },
+      {
+        status: 404,
+        headers: responseHeaders,
+      },
+    );
+  }
+
+  return NextResponse.json(response, {
+    headers: responseHeaders,
+  });
+}

--- a/frontend/apps/web/src/app/api/community/threads/route.ts
+++ b/frontend/apps/web/src/app/api/community/threads/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { getForumThreadsResponse } from "../../../../lib/community-api";
+
+const responseHeaders = {
+  "Cache-Control": "public, s-maxage=300, stale-while-revalidate=86400",
+};
+
+export function GET() {
+  return NextResponse.json(getForumThreadsResponse(), {
+    headers: responseHeaders,
+  });
+}

--- a/frontend/apps/web/src/lib/community-api.ts
+++ b/frontend/apps/web/src/lib/community-api.ts
@@ -1,0 +1,101 @@
+import type {
+  ForumSectionSummary,
+  ForumThreadDetail,
+  ForumThreadListItem,
+  ForumThreadResponse,
+  ForumThreadsResponse,
+} from "@fabushi/api-client";
+import {
+  FORUM_SECTIONS,
+  FORUM_THREADS,
+  getForumSectionBySlug,
+  getForumThreadBySlug,
+} from "./community";
+
+function mapForumSectionSummary(section: (typeof FORUM_SECTIONS)[number]): ForumSectionSummary {
+  return {
+    slug: section.slug,
+    titleZh: section.titleZh,
+    titleEn: section.titleEn,
+    summaryZh: section.summaryZh,
+    summaryEn: section.summaryEn,
+    guidanceZh: section.guidanceZh,
+    guidanceEn: section.guidanceEn,
+  };
+}
+
+function mapForumThreadListItem(thread: (typeof FORUM_THREADS)[number]): ForumThreadListItem {
+  const section = getForumSectionBySlug(thread.sectionSlug);
+
+  return {
+    slug: thread.slug,
+    sectionSlug: thread.sectionSlug,
+    sectionTitleZh: section?.titleZh ?? thread.sectionSlug,
+    sectionTitleEn: section?.titleEn ?? thread.sectionSlug,
+    titleZh: thread.titleZh,
+    titleEn: thread.titleEn,
+    summaryZh: thread.summaryZh,
+    summaryEn: thread.summaryEn,
+    authorZh: thread.authorZh,
+    authorEn: thread.authorEn,
+    roleZh: thread.roleZh,
+    roleEn: thread.roleEn,
+    publishedLabelZh: thread.publishedLabelZh,
+    publishedLabelEn: thread.publishedLabelEn,
+    lastActivityZh: thread.lastActivityZh,
+    lastActivityEn: thread.lastActivityEn,
+    repliesCount: thread.repliesCount,
+    followsCount: thread.followsCount,
+    bookmarksCount: thread.bookmarksCount,
+    tagsZh: thread.tagsZh,
+    tagsEn: thread.tagsEn,
+    featuredReasonZh: thread.featuredReasonZh,
+    featuredReasonEn: thread.featuredReasonEn,
+  };
+}
+
+function mapForumThreadDetail(thread: (typeof FORUM_THREADS)[number]): ForumThreadDetail {
+  return {
+    ...mapForumThreadListItem(thread),
+    openingPostZh: thread.openingPostZh,
+    openingPostEn: thread.openingPostEn,
+    takeawaysZh: thread.takeawaysZh,
+    takeawaysEn: thread.takeawaysEn,
+    replyPromptsZh: thread.replyPromptsZh,
+    replyPromptsEn: thread.replyPromptsEn,
+  };
+}
+
+export function getForumSectionSummaries(): ForumSectionSummary[] {
+  return FORUM_SECTIONS.map(mapForumSectionSummary);
+}
+
+export function getForumThreadListItems(): ForumThreadListItem[] {
+  return FORUM_THREADS.map(mapForumThreadListItem);
+}
+
+export function getForumThreadsResponse(): ForumThreadsResponse {
+  return {
+    source: "seed",
+    generatedAt: new Date().toISOString(),
+    sections: getForumSectionSummaries(),
+    threads: getForumThreadListItems(),
+  };
+}
+
+export function getForumThreadResponse(slug: string): ForumThreadResponse | null {
+  const thread = getForumThreadBySlug(slug);
+
+  if (!thread) {
+    return null;
+  }
+
+  const section = getForumSectionBySlug(thread.sectionSlug);
+
+  return {
+    source: "seed",
+    generatedAt: new Date().toISOString(),
+    section: section ? mapForumSectionSummary(section) : null,
+    thread: mapForumThreadDetail(thread),
+  };
+}

--- a/frontend/packages/api-client/src/endpoints.ts
+++ b/frontend/packages/api-client/src/endpoints.ts
@@ -8,4 +8,6 @@ export const endpoints = {
   register: "/api/auth/register",
   sendVerificationCode: "/api/auth/send-verification-code",
   userInfo: "/api/auth/user-info",
+  forumThreads: "/api/community/threads",
+  forumThread: (slug: string) => `/api/community/threads/${encodeURIComponent(slug)}`,
 } as const;

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -18,3 +18,62 @@ export interface VerificationCodePayload {
   email: string;
   type: "register" | "forgot";
 }
+
+export interface ForumSectionSummary {
+  slug: string;
+  titleZh: string;
+  titleEn: string;
+  summaryZh: string;
+  summaryEn: string;
+  guidanceZh: string;
+  guidanceEn: string;
+}
+
+export interface ForumThreadListItem {
+  slug: string;
+  sectionSlug: string;
+  sectionTitleZh: string;
+  sectionTitleEn: string;
+  titleZh: string;
+  titleEn: string;
+  summaryZh: string;
+  summaryEn: string;
+  authorZh: string;
+  authorEn: string;
+  roleZh: string;
+  roleEn: string;
+  publishedLabelZh: string;
+  publishedLabelEn: string;
+  lastActivityZh: string;
+  lastActivityEn: string;
+  repliesCount: number;
+  followsCount: number;
+  bookmarksCount: number;
+  tagsZh: string[];
+  tagsEn: string[];
+  featuredReasonZh: string;
+  featuredReasonEn: string;
+}
+
+export interface ForumThreadDetail extends ForumThreadListItem {
+  openingPostZh: string[];
+  openingPostEn: string[];
+  takeawaysZh: string[];
+  takeawaysEn: string[];
+  replyPromptsZh: string[];
+  replyPromptsEn: string[];
+}
+
+export interface ForumThreadsResponse {
+  source: "seed";
+  generatedAt: string;
+  sections: ForumSectionSummary[];
+  threads: ForumThreadListItem[];
+}
+
+export interface ForumThreadResponse {
+  source: "seed";
+  generatedAt: string;
+  section: ForumSectionSummary | null;
+  thread: ForumThreadDetail;
+}


### PR DESCRIPTION
## 问题

论坛当前已经有 `/community -> /community/threads -> /community/threads/[slug]` 的浏览闭环，但帖子数据还只存在于页面内部的静态内容模块里。这样虽然能继续展示页面，却还没有形成一个可复用、可检查、可逐步替换成真实数据层的论坛内容接口边界。

如果下一步直接接发帖、回复、收藏或审核，会先卡在两个问题上：

- 前端页面和未来数据层之间还没有稳定的论坛响应结构
- 论坛种子内容还没有一个对外可读的 JSON 路由，后续无法平滑接入真实服务或独立客户端消费

## 这次改动

- 在 `@fabushi/api-client` 中新增论坛接口地址：
  - `forumThreads`
  - `forumThread(slug)`
- 在 `@fabushi/api-client` 中新增论坛种子内容响应类型：
  - `ForumSectionSummary`
  - `ForumThreadListItem`
  - `ForumThreadDetail`
  - `ForumThreadsResponse`
  - `ForumThreadResponse`
- 在 `frontend/apps/web` 新增论坛种子内容映射层：
  - `src/lib/community-api.ts`
- 新增两个 Next.js JSON 路由：
  - `GET /api/community/threads`
  - `GET /api/community/threads/[slug]`
- 路由返回统一的 seed source 与 generatedAt 字段，并加上短期缓存头，方便后续替换成真实持久化实现

## 为什么现在做

当前论坛项目最值得优先推进的，不是再补一层展示页，而是把“论坛内容原型”推进成“论坛内容接口原型”。

这样做有几个直接收益：

- 后续接真实发帖、回复、收藏、关注时，不需要再从页面里倒拆数据结构
- 移动端、独立客户端或后续服务层可以开始复用同一份论坛响应契约
- 页面骨架仍保持稳定，但数据来源已经开始从静态展示模块向真实内容服务边界过渡

这是一项改动面小、但对论坛下一阶段最有承接力的基础工作。

## 验证

- 已确认分支相对 `main`：`behind_by = 0`
- 改动范围收敛为 5 个文件：2 个 API client 文件、1 个映射层、2 个 JSON 路由
- 当前环境仍然没有仓库本地 checkout，无法直接运行 `pnpm --dir frontend typecheck` 或 `pnpm --dir frontend build:web`
- 最终类型检查与构建验证依赖仓库 CI

## 合并条件

- Web 相关 CI 通过
- 新增论坛 JSON 路由无 Next.js 类型错误
- 确认后续可继续在这组接口上接真实发帖与回复流程
