### PR TITLE
feat(web): surface dharma content clusters in site header

### DIFF
--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -9,24 +9,24 @@ const NAV_ITEMS = [
     en: "Download",
   },
   {
-    href: "/#features",
-    zh: "功能",
-    en: "Features",
-  },
-  {
     href: "/buddhadharma",
     zh: "佛法入门",
     en: "Dharma Basics",
   },
   {
+    href: "/practice-guide",
+    zh: "修行方法",
+    en: "Practice Guide",
+  },
+  {
+    href: "/sutra-guide",
+    zh: "佛经导读",
+    en: "Sutra Guide",
+  },
+  {
     href: "/faq",
     zh: "常见问题",
     en: "FAQ",
-  },
-  {
-    href: "/apply",
-    zh: "申请测试",
-    en: "Apply",
   },
 ] as const;
 


### PR DESCRIPTION
## 问题

官网这几轮已经把佛法内容集群扩到：

- `/buddhadharma`
- `/start-learning-buddhism`
- `/practice-guide`
- `/daily-practice`
- `/meditation`
- `/sutra-guide`
- `/beginner-sutra-recommendations`

但最新主线上，`frontend/apps/web/src/components/site-header.tsx` 的顶部导航仍然停留在：

- 下载
- 功能
- 佛法入门
- 常见问题
- 申请测试

这会带来一个很具体的发现入口问题：

- 页脚和正文里虽然已经有更多佛法内容入口，但全站最稳定、最高频出现的顶部导航，还没有把“修行方法”和“佛经导读”两个已经成型的内容主集群露出来
- 对首页和内容页进入的用户来说，站点的第一层主题信号仍然偏向产品功能，而不是“产品入口 + 佛法内容学习路径”

## 这次改动

- 更新全站 `SiteHeader` 顶部导航
- 保留：
  - `下载`
  - `佛法入门`
  - `常见问题`
- 替换掉偏产品型的：
  - `功能`
  - `申请测试`
- 新增更高收益的内容集群入口：
  - `修行方法` -> `/practice-guide`
  - `佛经导读` -> `/sutra-guide`

## 为什么现在做

当前最值得推进的不是继续补页脚入口，而是把已经写出来的内容集群提到全站最高频的导航层。

这是一个改动面很小、但对发现入口和站点主题组织都更直接的修复：

- `practice-guide` 会更容易获得全站级固定内链
- `sutra-guide` 会更明确地进入第一层导航结构
- 首页和内容页都会更早暴露“佛法入门 / 修行方法 / 佛经导读”这组三条主路径

## 配图判断

- 本轮没有新增配图。
- 当前最高收益问题是全站导航入口层，而不是页面视觉层。
- 现有佛法内容页仍主要依赖长内容、FAQ、Breadcrumb 与 ItemList / FAQ schema 承接搜索意图；这一轮先把内容发现入口补强更划算。

## 预期改善

- 改善 `/practice-guide` 与 `/sutra-guide` 的站内发现条件和固定内链强度
- 让官网顶部第一层导航更准确地反映当前已经成型的佛法内容组织
- 增强首页与全站内容页对“佛法入门 / 修行方法 / 佛经导读”这组三类搜索意图的主题分发信号

## 验证

- 已确认分支相对 `main`：`behind_by = 0`
- 改动范围只收敛在 1 个文件：`frontend/apps/web/src/components/site-header.tsx`
- 当前环境没有仓库本地工作副本，无法直接运行前端构建；最终检查依赖仓库 CI
