### PR TITLE
fix(web): statically export forum seed API routes

### DIFF
--- a/frontend/apps/web/src/app/api/community/threads/[slug]/route.ts
+++ b/frontend/apps/web/src/app/api/community/threads/[slug]/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
+import { FORUM_THREADS } from "../../../../../lib/community";
 import { getForumThreadResponse } from "../../../../../lib/community-api";
+
+export const dynamic = "force-static";
+export const dynamicParams = false;
 
 const responseHeaders = {
   "Cache-Control": "public, s-maxage=300, stale-while-revalidate=86400",
@@ -10,6 +14,10 @@ type RouteContext = {
     slug: string;
   }>;
 };
+
+export function generateStaticParams() {
+  return FORUM_THREADS.map((thread) => ({ slug: thread.slug }));
+}
 
 export async function GET(_request: Request, { params }: RouteContext) {
   const { slug } = await params;

--- a/frontend/apps/web/src/app/api/community/threads/route.ts
+++ b/frontend/apps/web/src/app/api/community/threads/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { getForumThreadsResponse } from "../../../../lib/community-api";
 
+export const dynamic = "force-static";
+
 const responseHeaders = {
   "Cache-Control": "public, s-maxage=300, stale-while-revalidate=86400",
 };


### PR DESCRIPTION
## 问题

`PR #410` 合入后，主线 `CI #827` 与对应的 `issue #412` 不再红在旧的论坛详情页 `params` 类型问题上，而是进入了新的、更靠后的构建故障：

- `Build Next.js site` 已经能通过编译与类型检查
- 失败点切换为 `Collecting page data`
- 日志明确报错：`/api/community/threads/[slug]` 在 `output: export` 下没有配置静态导出兼容的 route segment 选项

这说明 `PR #409` 修掉的旧 blocker 已经被越过，当前真正挡住主链路的是新加的论坛 seed JSON 路由没有按静态导出模式声明。

## 这次修复

- 为 `/api/community/threads` 显式加上 `export const dynamic = "force-static"`
- 为 `/api/community/threads/[slug]` 显式加上 `export const dynamic = "force-static"`
- 为 `/api/community/threads/[slug]` 增加 `generateStaticParams()`，按现有 `FORUM_THREADS` 预生成所有 slug
- 为动态 seed API 路由加上 `dynamicParams = false`，与当前论坛静态种子内容模型保持一致

## 为什么这样修

当前 web 站点已经启用了 `output: "export"`。按照 Next.js 对 Route Handlers 的静态导出约束，动态 API 路由如果要参与静态构建，需要显式声明成静态并提供可预生成的 params。

这次改动保持最小范围：

- 不改论坛 seed 数据结构
- 不改页面展示逻辑
- 只让新增的 JSON 路由符合当前站点的静态导出约束

## 验证依据

- `issue #411` / `issue #412` 的失败日志都已明确指向同一错误：
  - `route "/api/community/threads/[slug]" with "output: export"`
- Next.js 官方文档明确说明：
  - Route Handlers 可配合 `generateStaticParams`
  - `GET` Route Handlers 需要通过 `dynamic = "force-static"` 进入静态缓存/导出路径
- 改动范围仅 2 个 route 文件

## 合并后预期

- `Module checks - Frontend` 应越过当前的 API route static export 构建错误
- `issue #412` 将获得新的 mainline 复跑证据
- 旧 failure snapshots `#408` / `#411` 可以继续按被后续更精确结果覆盖来收口