### PR TITLE
chore(forum): remove website forum entrypoints and start independent root

### DIFF
--- a/forum/README.md
+++ b/forum/README.md
@@ -1,0 +1,9 @@
+# Fabushi Forum
+
+This directory is the independent root for the forum project.
+
+Current ground rules:
+
+- Build the forum from this directory instead of extending the marketing website.
+- Keep forum product, data model, and deployment planning separate from `frontend/apps/web`.
+- Treat the existing `/community` pages in the website as legacy prototype surface, not the long-term forum home.

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
 import { getAllArticles } from "../lib/content";
-import { FORUM_THREADS } from "../lib/community";
 import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
@@ -10,8 +9,6 @@ const staticRoutes = [
   "/download",
   "/apply",
   "/faq",
-  "/community",
-  "/community/threads",
   "/privacy",
   "/contact",
   "/insights",
@@ -28,8 +25,6 @@ const weeklyRoutes = new Set([
   "/",
   "/download",
   "/faq",
-  "/community",
-  "/community/threads",
   "/buddhadharma",
   "/start-learning-buddhism",
   "/meditation",
@@ -63,12 +58,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: article.featured ? 0.8 : 0.65,
   }));
 
-  const forumThreadPages: MetadataRoute.Sitemap = FORUM_THREADS.map((thread) => ({
-    url: siteUrl(`/community/threads/${thread.slug}`),
-    lastModified: new Date(),
-    changeFrequency: "weekly",
-    priority: 0.8,
-  }));
-
-  return [...pages, ...articlePages, ...forumThreadPages];
+  return [...pages, ...articlePages];
 }

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -25,9 +25,6 @@ export function SiteFooter() {
         <a href={siteHref("/faq")}>
           <LocalizedText zh="常见问题" en="FAQ" />
         </a>
-        <a href={siteHref("/community")}>
-          <LocalizedText zh="佛法论坛" en="Community Forum" />
-        </a>
         <a href={siteHref("/buddhadharma")}>
           <LocalizedText zh="佛法入门" en="Dharma Basics" />
         </a>

--- a/frontend/packages/shared/src/copy.ts
+++ b/frontend/packages/shared/src/copy.ts
@@ -39,7 +39,6 @@ export const homeUseCases = [
 export const primaryNavigation = [
   { label: "首页", href: "/" },
   { label: "下载", href: "/download" },
-  { label: "佛法论坛", href: "/community" },
   { label: "申请测试", href: "/apply" },
   { label: "常见问题", href: "/faq" },
   { label: "联系", href: "/contact" },


### PR DESCRIPTION
## 问题

当前论坛方向已经不再适合继续挂在官网里推进，但仓库主线上仍保留了几类会把论坛继续暴露成官网一部分的入口：

- 页脚中的 `/community` 链接
- 共享导航文案里的“佛法论坛”项
- sitemap 中的 `/community`、`/community/threads` 与论坛帖子 URL

这会把论坛产品继续往“官网内嵌子模块”的方向推深，和现在明确的目标冲突：论坛要从仓库根目录的独立空白目录重新建立，而不是继续沿着官网结构迭代。

## 这次改动

- 从官网页脚移除论坛入口
- 从共享导航文案中移除论坛入口项
- 从 sitemap 中移除：
  - `/community`
  - `/community/threads`
  - `/community/threads/[slug]`
- 在仓库根目录创建独立 `forum/` 目录
- 新增 `forum/README.md`，明确论坛后续应从独立目录推进，而不是继续扩展 `frontend/apps/web`

## 为什么这样做

这次不是普通导航清理，而是一次结构纠偏：

- 官网继续保留论坛入口，会强化错误的产品边界
- 先把入口撤掉，才能让后续论坛建设聚焦在独立项目上
- 先建立根目录下的 `forum/` 起点，也能为后续技术选型、目录规划和部署边界提供明确落点

## 有意暂不处理

- 不删除现有 `/community` 页面与论坛 seed API 原型
- 不在这一轮直接搭建 `forum/` 的运行骨架
- 不改现有官网的其他佛法内容入口

现有 `/community` 相关代码暂时保留为历史原型参考，但不再作为长期论坛主路径。

## 验证

- 分支相对 `main`：`behind_by = 0`
- 改动范围收敛为 5 个文件
- 已核对官网侧不再通过本次修改的页脚、共享导航文案与 sitemap 暴露论坛入口
- 当前环境没有仓库本地 checkout，无法执行本地构建或测试；最终验证依赖仓库 CI

## 合并后预期

- 官网不再把论坛作为站内公开入口继续暴露
- 仓库内论坛建设的标准起点切换到根目录 `forum/`
- 下一阶段可以直接围绕独立论坛项目骨架继续推进