### PR TITLE
feat(forum): structure seed content and add reply-aware thread detail

### DIFF
--- a/forum/README.md
+++ b/forum/README.md
@@ -9,9 +9,10 @@ The forum is no longer being extended inside the marketing website. This directo
 Current scope:
 
 - independent app shell under `forum/src/app`
-- seed forum sections and threads under `forum/src/lib/forum-data.ts`
+- structured seed content under `forum/src/data/forum-content.json`
+- forum domain helpers under `forum/src/lib/forum-data.ts`
 - read-only routes for thread listing and thread detail
-- JSON routes for the same seed contract
+- JSON routes for the same seed contract, including reply data on thread detail
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 
 ## Current product boundary
@@ -22,16 +23,16 @@ Included:
 
 - landing page
 - thread list page
-- thread detail page
-- seed data contract
+- thread detail page with sample replies
+- structured seed content contract
 - read-only API boundary
+- moderation and knowledge-stage fields reserved in the content model
 
 Not included yet:
 
 - authentication
 - posting or replying
-- moderation actions
-- persistence layer
+- durable persistence layer
 - search, notifications, bookmarks, or follows as real user actions
 
 ## Local development
@@ -53,4 +54,4 @@ pnpm build
 
 ## Why this is the next step
 
-The highest-priority gap after creating `forum/` was that it still could not run. This skeleton turns the independent root into a real project boundary so the next iteration can plug in database models, auth, posting flows, and governance logic without going back through the website prototype.
+The highest-priority gap after creating `forum/` was that forum content still lived as hard-coded TypeScript arrays. This iteration moves the project onto a structured content store and reply-aware contract so the next pass can attach a real persistence layer, posting flow, and governance events without first untangling page-local seed data.

--- a/forum/src/app/api/thread/[slug]/route.ts
+++ b/forum/src/app/api/thread/[slug]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getSectionBySlug, getThreadBySlug } from "../../../../lib/forum-data";
+import { getThreadDetailBySlug } from "../../../../lib/forum-data";
 
 interface RouteContext {
   params: Promise<{ slug: string }>;
@@ -7,23 +7,15 @@ interface RouteContext {
 
 export async function GET(_request: Request, context: RouteContext) {
   const { slug } = await context.params;
-  const thread = getThreadBySlug(slug);
+  const detail = getThreadDetailBySlug(slug);
 
-  if (!thread) {
+  if (!detail) {
     return NextResponse.json({ error: "Thread not found" }, { status: 404 });
   }
 
-  return NextResponse.json(
-    {
-      thread,
-      section: getSectionBySlug(thread.sectionSlug),
-      source: "seed",
-      generatedAt: new Date().toISOString(),
+  return NextResponse.json(detail, {
+    headers: {
+      "cache-control": "public, max-age=300, s-maxage=300",
     },
-    {
-      headers: {
-        "cache-control": "public, max-age=300, s-maxage=300",
-      },
-    },
-  );
+  });
 }

--- a/forum/src/app/globals.css
+++ b/forum/src/app/globals.css
@@ -29,7 +29,7 @@ body {
   font-family: "Noto Serif SC", "Songti SC", "STSong", serif;
 }
 
- a {
+a {
   color: inherit;
   text-decoration: none;
 }

--- a/forum/src/app/globals.css
+++ b/forum/src/app/globals.css
@@ -29,7 +29,7 @@ body {
   font-family: "Noto Serif SC", "Songti SC", "STSong", serif;
 }
 
-a {
+ a {
   color: inherit;
   text-decoration: none;
 }
@@ -105,7 +105,8 @@ main {
 .hero-grid,
 .section-grid,
 .thread-grid,
-.metrics {
+.metrics,
+.reply-stack {
   display: grid;
   gap: 18px;
 }
@@ -153,7 +154,8 @@ main {
 }
 
 .thread-meta span,
-.thread-tags span {
+.thread-tags span,
+.reply-signal {
   padding: 6px 10px;
   border-radius: 999px;
   background: rgba(140, 90, 43, 0.08);
@@ -210,6 +212,40 @@ main {
   padding-left: 20px;
 }
 
+.reply-stack {
+  margin-top: 18px;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: end;
+}
+
+.section-heading p {
+  margin: 0;
+}
+
+.reply-card {
+  padding: 18px 20px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.reply-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: start;
+  margin-bottom: 12px;
+}
+
+.reply-card p + p {
+  margin-top: 12px;
+}
+
 .api-note {
   margin-top: 24px;
   padding: 18px 20px;
@@ -244,9 +280,16 @@ main {
   .hero-grid,
   .section-grid,
   .thread-grid,
-  .metrics {
+  .metrics,
+  .reply-stack {
     grid-template-columns: 1fr;
     display: grid;
+  }
+
+  .reply-top,
+  .section-heading {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .hero h1,

--- a/forum/src/app/threads/[slug]/page.tsx
+++ b/forum/src/app/threads/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getSectionBySlug, getThreadBySlug } from "../../../lib/forum-data";
+import { getThreadDetailBySlug } from "../../../lib/forum-data";
 
 interface ThreadPageProps {
   params: Promise<{ slug: string }>;
@@ -8,13 +8,13 @@ interface ThreadPageProps {
 
 export default async function ThreadDetailPage({ params }: ThreadPageProps) {
   const { slug } = await params;
-  const thread = getThreadBySlug(slug);
+  const detail = getThreadDetailBySlug(slug);
 
-  if (!thread) {
+  if (!detail) {
     notFound();
   }
 
-  const section = getSectionBySlug(thread.sectionSlug);
+  const { thread, section, replies } = detail;
 
   return (
     <main>
@@ -50,6 +50,8 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
           {thread.tags.map((tag) => (
             <span key={tag}>{tag}</span>
           ))}
+          <span>{thread.knowledgeStage === "candidate" ? "候选资料" : "讨论中"}</span>
+          <span>{thread.moderationState === "published" ? "已发布" : "需复核"}</span>
         </div>
 
         <section className="list-block">
@@ -59,6 +61,32 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
               <li key={paragraph}>{paragraph}</li>
             ))}
           </ul>
+        </section>
+
+        <section className="reply-stack">
+          <div className="section-heading">
+            <div>
+              <h2>首批回复样例</h2>
+              <p>这一层已经开始承接真实论坛会需要的回复、治理提示和后续沉淀信号。</p>
+            </div>
+          </div>
+
+          {replies.map((reply) => (
+            <article key={reply.id} className="reply-card">
+              <div className="reply-top">
+                <div className="thread-meta">
+                  <span>{reply.author}</span>
+                  <span>{reply.roleLabel}</span>
+                  <span>{reply.publishedAt}</span>
+                </div>
+                <span className="reply-signal">{reply.trustSignal}</span>
+              </div>
+
+              {reply.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </article>
+          ))}
         </section>
 
         <section className="list-block">
@@ -72,7 +100,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
 
         <section className="api-note">
           <h2>后续扩展位置</h2>
-          <p>这里下一轮可以直接接真实回复流、收藏操作、关注状态、新手引导提示和审核事件时间线。</p>
+          <p>下一轮可以直接把这里的结构接到真实持久化层、发帖表单、回复提交和审核事件时间线上。</p>
           <div className="footer-note">
             <span>作者：{thread.author}</span>
             <span>发布时间：{thread.publishedAt}</span>

--- a/forum/src/data/forum-content.json
+++ b/forum/src/data/forum-content.json
@@ -1,0 +1,266 @@
+{
+  "sections": [
+    {
+      "slug": "newcomer-path",
+      "name": "新手起步",
+      "description": "给第一次认真接触佛法的人一个可提问、可被接住、也能慢慢建立节奏的入口。",
+      "moderationFocus": "优先温和纠偏，避免把个人经验包装成唯一标准。",
+      "postingPrompt": "请尽量写清楚自己的起点、当前困惑和已经尝试过的方法。"
+    },
+    {
+      "slug": "sutra-study",
+      "name": "经论研读",
+      "description": "围绕经典出处、上下文和术语理解展开可追溯讨论，让内容能长期沉淀。",
+      "moderationFocus": "鼓励带出处和上下文，减少断章取义。",
+      "postingPrompt": "提问前请补充经论出处、前后文，以及你现在卡住的具体点。"
+    },
+    {
+      "slug": "meditation-practice",
+      "name": "禅修问答",
+      "description": "聚焦坐禅、散乱、昏沉、练习节奏和复盘，把经验说具体。",
+      "moderationFocus": "欢迎经验分享，但避免境界化表达和权威化断言。",
+      "postingPrompt": "分享体验时请尽量包含练习前状态、练习过程和结束后的复盘。"
+    },
+    {
+      "slug": "knowledge-archive",
+      "name": "资料整理",
+      "description": "把高质量回答、专题串和稳定共识沉淀成可重复引用的知识页。",
+      "moderationFocus": "优先整理长期价值高、引用清楚、适合再次访问的内容。",
+      "postingPrompt": "适合发布结构化总结、归档提案和可长期引用的整理帖。"
+    }
+  ],
+  "threads": [
+    {
+      "slug": "first-year-stability",
+      "sectionSlug": "newcomer-path",
+      "title": "学佛第一年，先稳定什么最重要？",
+      "summary": "先把愿心、作息、听闻和一个最基础的练习节奏稳下来，比一开始抓很多法门更关键。",
+      "author": "净行",
+      "publishedAt": "2026-05-16",
+      "lastActivity": "最近整理：起步节奏清单",
+      "replyCount": 3,
+      "followCount": 42,
+      "bookmarkCount": 27,
+      "tags": ["新手", "作息", "起步"],
+      "openingPost": [
+        "很多人学佛的第一年，不是信息太少，而是同时抓太多，结果什么都没有稳住。",
+        "如果只能先稳定三件事，我更倾向于愿心、作息和一个能长期重复的基础练习。这样后面接读经、持诵、禅修或共修时，脚下才有地。",
+        "欢迎大家结合自己的经历来讲，但尽量说清楚适用对象：是完全零基础的人，还是已经开始有固定日常的人。"
+      ],
+      "takeaways": [
+        "先稳节奏，再谈扩展。",
+        "建议回复时写明自己的起点，避免把个人路径说成唯一答案。",
+        "这类高质量回复后续适合沉淀为新手欢迎资料。"
+      ],
+      "moderationState": "published",
+      "knowledgeStage": "candidate"
+    },
+    {
+      "slug": "how-to-ask-while-reading-sutras",
+      "sectionSlug": "sutra-study",
+      "title": "读经时遇到看不懂的名相，应该怎样提问？",
+      "summary": "好问题不只是贴一个词，而是把出处、上下文和自己的理解一起带出来。",
+      "author": "闻思",
+      "publishedAt": "2026-05-16",
+      "lastActivity": "最近整理：读经提问模板",
+      "replyCount": 2,
+      "followCount": 31,
+      "bookmarkCount": 36,
+      "tags": ["名相", "出处", "提问方式"],
+      "openingPost": [
+        "经论研读区最怕只剩一句“这是什么意思？”，因为没有出处和上下文时，回答很容易发散。",
+        "我建议论坛从一开始就鼓励更好的提问格式：至少附上经论出处、前后文、自己目前的理解，以及卡住的具体点。",
+        "这样别人不是只来扔答案，而是能一起把语境理清楚。"
+      ],
+      "takeaways": [
+        "带出处、带上下文、带当前理解。",
+        "好的提问本身就是知识沉淀的起点。",
+        "后续可以把提问模板做成固定置顶说明。"
+      ],
+      "moderationState": "published",
+      "knowledgeStage": "candidate"
+    },
+    {
+      "slug": "working-with-distraction-and-dullness",
+      "sectionSlug": "meditation-practice",
+      "title": "禅修里最常见的散乱和昏沉，大家怎么处理？",
+      "summary": "把练习前状态、练习中的变化和结束后的复盘讲具体，比泛泛谈体验更有帮助。",
+      "author": "清照",
+      "publishedAt": "2026-05-16",
+      "lastActivity": "最近整理：复盘提示补充",
+      "replyCount": 3,
+      "followCount": 38,
+      "bookmarkCount": 33,
+      "tags": ["禅修", "散乱", "昏沉"],
+      "openingPost": [
+        "散乱和昏沉几乎人人都会遇到，但如果只说“我今天状态不好”，别人其实帮不上太多。",
+        "更有用的分享，往往会把练习前的身心状态、练习中的变化，以及结束后的复盘都讲清楚。",
+        "欢迎谈经验，但尽量不要把短期体感包装成深层境界判断。"
+      ],
+      "takeaways": [
+        "论坛需要具体经验，而不是空泛体验形容。",
+        "复盘维度可以包括作息、坐姿、时长和呼吸。",
+        "这类话题活跃度高，治理边界要从第一天就明确。"
+      ],
+      "moderationState": "published",
+      "knowledgeStage": "discussion"
+    },
+    {
+      "slug": "what-deserves-the-archive-first",
+      "sectionSlug": "knowledge-archive",
+      "title": "论坛早期最值得优先沉淀成资料页的内容是什么？",
+      "summary": "不是所有热门讨论都值得归档，真正优先的是可反复帮助新人的结构化内容。",
+      "author": "常住编辑",
+      "publishedAt": "2026-05-16",
+      "lastActivity": "最近整理：归档标准草案",
+      "replyCount": 2,
+      "followCount": 19,
+      "bookmarkCount": 22,
+      "tags": ["精华", "归档", "资料页"],
+      "openingPost": [
+        "如果论坛想长期有价值，就不能只靠时间线往前滚。",
+        "早期最值得沉淀的，往往不是最热闹的串，而是能反复帮助新人的结构化回答，比如起步路径、常见误区、读经提问模板和稳定练习建议。",
+        "这条讨论的目的，是先把“什么值得沉淀”这件事说清楚。"
+      ],
+      "takeaways": [
+        "可复用、可引用、可减少重复答疑的内容优先。",
+        "归档标准应同时考虑正确性、清晰度和长期访问价值。",
+        "后续适合接精华标记和资料页生成流程。"
+      ],
+      "moderationState": "published",
+      "knowledgeStage": "candidate"
+    }
+  ],
+  "replies": [
+    {
+      "id": "reply-stability-1",
+      "threadSlug": "first-year-stability",
+      "author": "明彻",
+      "roleLabel": "三年修学",
+      "publishedAt": "2026-05-16 09:10",
+      "moderationState": "published",
+      "trustSignal": "经验可复用，适合后续整理为新手资料。",
+      "body": [
+        "对完全零基础的人，我会先把起床和睡前各留出十分钟，先让接触佛法有一个固定落点。",
+        "如果一开始就安排太多项目，很容易变成今天很热，三周后完全停掉。先稳住最小节奏，后面再扩。"
+      ]
+    },
+    {
+      "id": "reply-stability-2",
+      "threadSlug": "first-year-stability",
+      "author": "寂光",
+      "roleLabel": "带新同修",
+      "publishedAt": "2026-05-16 10:24",
+      "moderationState": "published",
+      "trustSignal": "建议区分“发心很强”和“日常真能重复”这两个层面。",
+      "body": [
+        "我带新人的时候，会先看他是不是已经能稳定听闻和记录，而不是先问想学哪一套法门。",
+        "愿心很重要，但没有作息和复盘承接，热情很快就会变成焦虑。"
+      ]
+    },
+    {
+      "id": "reply-stability-3",
+      "threadSlug": "first-year-stability",
+      "author": "论坛引导员",
+      "roleLabel": "治理预留",
+      "publishedAt": "2026-05-16 11:02",
+      "moderationState": "published",
+      "trustSignal": "此类帖子适合固定置顶“新手起步模板”后继续沉淀。",
+      "body": [
+        "后续如果把这一类讨论做成固定模板，建议要求回复注明“适用对象”和“自己维持了多久”。",
+        "这样既能减少空泛回答，也方便把高质量经验逐步整理进资料区。"
+      ]
+    },
+    {
+      "id": "reply-sutra-1",
+      "threadSlug": "how-to-ask-while-reading-sutras",
+      "author": "了知",
+      "roleLabel": "经论学习",
+      "publishedAt": "2026-05-16 09:42",
+      "moderationState": "published",
+      "trustSignal": "提问格式清楚时，更容易形成可检索的长期内容。",
+      "body": [
+        "我最希望提问里至少有四样：出处、原句、自己的理解、到底卡在哪里。",
+        "只有名相没有上下文时，别人回答得越快，越容易偏离原文语境。"
+      ]
+    },
+    {
+      "id": "reply-sutra-2",
+      "threadSlug": "how-to-ask-while-reading-sutras",
+      "author": "法藏",
+      "roleLabel": "版块协作",
+      "publishedAt": "2026-05-16 10:55",
+      "moderationState": "published",
+      "trustSignal": "适合后续沉淀成固定发帖模板和版块说明。",
+      "body": [
+        "如果论坛后面允许发帖模板，我建议这个版块默认就带上“出处 / 前后文 / 当前理解 / 想确认什么”。",
+        "模板不是为了拘束，而是为了让后续回答更能被复用。"
+      ]
+    },
+    {
+      "id": "reply-meditation-1",
+      "threadSlug": "working-with-distraction-and-dullness",
+      "author": "澄怀",
+      "roleLabel": "长期练习",
+      "publishedAt": "2026-05-16 08:58",
+      "moderationState": "published",
+      "trustSignal": "把复盘维度讲具体，有助于减少神秘化表达。",
+      "body": [
+        "我现在会强迫自己每次都记下睡眠、饮食、坐姿和时长，再看散乱或昏沉是怎么出现的。",
+        "这样过几周回看时，能发现很多问题其实和生活节奏直接相关。"
+      ]
+    },
+    {
+      "id": "reply-meditation-2",
+      "threadSlug": "working-with-distraction-and-dullness",
+      "author": "观行",
+      "roleLabel": "同修反馈",
+      "publishedAt": "2026-05-16 10:08",
+      "moderationState": "published",
+      "trustSignal": "适合继续引导大家补“练习前状态”和“结束后复盘”。",
+      "body": [
+        "以前我只记“今天坐得好不好”，后来发现这种记录几乎没法帮助下次调整。",
+        "把前后状态补上后，连自己都更容易看见哪些做法真的稳。"
+      ]
+    },
+    {
+      "id": "reply-meditation-3",
+      "threadSlug": "working-with-distraction-and-dullness",
+      "author": "论坛引导员",
+      "roleLabel": "治理预留",
+      "publishedAt": "2026-05-16 11:20",
+      "moderationState": "published",
+      "trustSignal": "该类高活跃话题需要尽早明确不鼓励境界化断言。",
+      "body": [
+        "这个板块很容易滑向“我遇到了什么特殊境界”的叙事，所以建议尽早把治理边界写到版块说明里。",
+        "先保护讨论质量，后面再谈活跃度。"
+      ]
+    },
+    {
+      "id": "reply-archive-1",
+      "threadSlug": "what-deserves-the-archive-first",
+      "author": "常住编辑",
+      "roleLabel": "资料整理",
+      "publishedAt": "2026-05-16 09:35",
+      "moderationState": "published",
+      "trustSignal": "优先沉淀能减少重复答疑的结构化内容。",
+      "body": [
+        "我会优先看这条内容能不能在一个月后继续帮到新人，而不是今天有多少人点赞。",
+        "能减少重复提问的内容，往往最值得进入资料区。"
+      ]
+    },
+    {
+      "id": "reply-archive-2",
+      "threadSlug": "what-deserves-the-archive-first",
+      "author": "闻思",
+      "roleLabel": "内容协作",
+      "publishedAt": "2026-05-16 10:40",
+      "moderationState": "published",
+      "trustSignal": "归档标准最好从项目早期就明文化。",
+      "body": [
+        "如果归档标准等到帖子很多以后才补，会很难统一口径。",
+        "现在就把“可复用、可引用、可减少重复答疑”写清楚，后面很多争议会小很多。"
+      ]
+    }
+  ]
+}

--- a/forum/src/lib/forum-data.ts
+++ b/forum/src/lib/forum-data.ts
@@ -1,8 +1,14 @@
+import forumContent from "../data/forum-content.json";
+
+export type ForumModerationState = "published" | "needs-review" | "archived";
+export type ForumKnowledgeStage = "discussion" | "candidate" | "archived";
+
 export interface ForumSection {
   slug: string;
   name: string;
   description: string;
   moderationFocus: string;
+  postingPrompt: string;
 }
 
 export interface ForumThread {
@@ -19,129 +25,32 @@ export interface ForumThread {
   tags: string[];
   openingPost: string[];
   takeaways: string[];
+  moderationState: ForumModerationState;
+  knowledgeStage: ForumKnowledgeStage;
 }
 
-export const FORUM_SECTIONS: ForumSection[] = [
-  {
-    slug: "newcomer-path",
-    name: "新手起步",
-    description: "给第一次认真接触佛法的人一个可提问、可被接住、也能慢慢建立节奏的入口。",
-    moderationFocus: "优先温和纠偏，避免把个人经验包装成唯一标准。",
-  },
-  {
-    slug: "sutra-study",
-    name: "经论研读",
-    description: "围绕经典出处、上下文和术语理解展开可追溯讨论，让内容能长期沉淀。",
-    moderationFocus: "鼓励带出处和上下文，减少断章取义。",
-  },
-  {
-    slug: "meditation-practice",
-    name: "禅修问答",
-    description: "聚焦坐禅、散乱、昏沉、练习节奏和复盘，把经验说具体。",
-    moderationFocus: "欢迎经验分享，但避免境界化表达和权威化断言。",
-  },
-  {
-    slug: "knowledge-archive",
-    name: "资料整理",
-    description: "把高质量回答、专题串和稳定共识沉淀成可重复引用的知识页。",
-    moderationFocus: "优先整理长期价值高、引用清楚、适合再次访问的内容。",
-  },
-];
+export interface ForumReply {
+  id: string;
+  threadSlug: string;
+  author: string;
+  roleLabel: string;
+  publishedAt: string;
+  moderationState: ForumModerationState;
+  trustSignal: string;
+  body: string[];
+}
 
-export const FORUM_THREADS: ForumThread[] = [
-  {
-    slug: "first-year-stability",
-    sectionSlug: "newcomer-path",
-    title: "学佛第一年，先稳定什么最重要？",
-    summary: "先把愿心、作息、听闻和一个最基础的练习节奏稳下来，比一开始抓很多法门更关键。",
-    author: "净行",
-    publishedAt: "2026-05-16",
-    lastActivity: "最近整理：起步节奏清单",
-    replyCount: 18,
-    followCount: 42,
-    bookmarkCount: 27,
-    tags: ["新手", "作息", "起步"],
-    openingPost: [
-      "很多人学佛的第一年，不是信息太少，而是同时抓太多，结果什么都没有稳住。",
-      "如果只能先稳定三件事，我更倾向于愿心、作息和一个能长期重复的基础练习。这样后面接读经、持诵、禅修或共修时，脚下才有地。",
-      "欢迎大家结合自己的经历来讲，但尽量说清楚适用对象：是完全零基础的人，还是已经开始有固定日常的人。"
-    ],
-    takeaways: [
-      "先稳节奏，再谈扩展。",
-      "建议回复时写明自己的起点，避免把个人路径说成唯一答案。",
-      "这类高质量回复后续适合沉淀为新手欢迎资料。"
-    ],
-  },
-  {
-    slug: "how-to-ask-while-reading-sutras",
-    sectionSlug: "sutra-study",
-    title: "读经时遇到看不懂的名相，应该怎样提问？",
-    summary: "好问题不只是贴一个词，而是把出处、上下文和自己的理解一起带出来。",
-    author: "闻思",
-    publishedAt: "2026-05-16",
-    lastActivity: "最近整理：读经提问模板",
-    replyCount: 11,
-    followCount: 31,
-    bookmarkCount: 36,
-    tags: ["名相", "出处", "提问方式"],
-    openingPost: [
-      "经论研读区最怕只剩一句“这是什么意思？”，因为没有出处和上下文时，回答很容易发散。",
-      "我建议论坛从一开始就鼓励更好的提问格式：至少附上经论出处、前后文、自己目前的理解，以及卡住的具体点。",
-      "这样别人不是只来扔答案，而是能一起把语境理清楚。"
-    ],
-    takeaways: [
-      "带出处、带上下文、带当前理解。",
-      "好的提问本身就是知识沉淀的起点。",
-      "后续可以把提问模板做成固定置顶说明。"
-    ],
-  },
-  {
-    slug: "working-with-distraction-and-dullness",
-    sectionSlug: "meditation-practice",
-    title: "禅修里最常见的散乱和昏沉，大家怎么处理？",
-    summary: "把练习前状态、练习中的变化和结束后的复盘讲具体，比泛泛谈体验更有帮助。",
-    author: "清照",
-    publishedAt: "2026-05-16",
-    lastActivity: "最近整理：复盘提示补充",
-    replyCount: 23,
-    followCount: 38,
-    bookmarkCount: 33,
-    tags: ["禅修", "散乱", "昏沉"],
-    openingPost: [
-      "散乱和昏沉几乎人人都会遇到，但如果只说“我今天状态不好”，别人其实帮不上太多。",
-      "更有用的分享，往往会把练习前的身心状态、练习中的变化，以及结束后的复盘都讲清楚。",
-      "欢迎谈经验，但尽量不要把短期体感包装成深层境界判断。"
-    ],
-    takeaways: [
-      "论坛需要具体经验，而不是空泛体验形容。",
-      "复盘维度可以包括作息、坐姿、时长和呼吸。",
-      "这类话题活跃度高，治理边界要从第一天就明确。"
-    ],
-  },
-  {
-    slug: "what-deserves-the-archive-first",
-    sectionSlug: "knowledge-archive",
-    title: "论坛早期最值得优先沉淀成资料页的内容是什么？",
-    summary: "不是所有热门讨论都值得归档，真正优先的是可反复帮助新人的结构化内容。",
-    author: "常住编辑",
-    publishedAt: "2026-05-16",
-    lastActivity: "最近整理：归档标准草案",
-    replyCount: 7,
-    followCount: 19,
-    bookmarkCount: 22,
-    tags: ["精华", "归档", "资料页"],
-    openingPost: [
-      "如果论坛想长期有价值，就不能只靠时间线往前滚。",
-      "早期最值得沉淀的，往往不是最热闹的串，而是能反复帮助新人的结构化回答，比如起步路径、常见误区、读经提问模板和稳定练习建议。",
-      "这条讨论的目的，是先把“什么值得沉淀”这件事说清楚。"
-    ],
-    takeaways: [
-      "可复用、可引用、可减少重复答疑的内容优先。",
-      "归档标准应同时考虑正确性、清晰度和长期访问价值。",
-      "后续适合接精华标记和资料页生成流程。"
-    ],
-  },
-];
+interface ForumContentStore {
+  sections: ForumSection[];
+  threads: ForumThread[];
+  replies: ForumReply[];
+}
+
+const content = forumContent as ForumContentStore;
+
+export const FORUM_SECTIONS: ForumSection[] = content.sections;
+export const FORUM_THREADS: ForumThread[] = content.threads;
+export const FORUM_REPLIES: ForumReply[] = content.replies;
 
 export function getSectionBySlug(slug: string) {
   return FORUM_SECTIONS.find((section) => section.slug === slug);
@@ -155,14 +64,41 @@ export function getThreadsBySection(sectionSlug: string) {
   return FORUM_THREADS.filter((thread) => thread.sectionSlug === sectionSlug);
 }
 
+export function getRepliesByThreadSlug(threadSlug: string) {
+  return FORUM_REPLIES.filter((reply) => reply.threadSlug === threadSlug);
+}
+
+export function getThreadDetailBySlug(slug: string) {
+  const thread = getThreadBySlug(slug);
+
+  if (!thread) {
+    return undefined;
+  }
+
+  return {
+    thread,
+    section: getSectionBySlug(thread.sectionSlug),
+    replies: getRepliesByThreadSlug(thread.slug),
+    source: "seed-json",
+    generatedAt: new Date().toISOString(),
+  };
+}
+
 export function getForumSnapshot() {
   return {
-    sections: FORUM_SECTIONS.map((section) => ({
-      ...section,
-      threadCount: getThreadsBySection(section.slug).length,
-    })),
+    sections: FORUM_SECTIONS.map((section) => {
+      const threads = getThreadsBySection(section.slug);
+      const replyCount = threads.reduce((total, thread) => total + getRepliesByThreadSlug(thread.slug).length, 0);
+
+      return {
+        ...section,
+        threadCount: threads.length,
+        replyCount,
+      };
+    }),
     threads: FORUM_THREADS,
+    replies: FORUM_REPLIES,
     generatedAt: new Date().toISOString(),
-    source: "seed",
+    source: "seed-json",
   };
 }


### PR DESCRIPTION
## 问题

`PR #421` 已经让根目录 `forum/` 成为一个可运行、可检查的独立论坛骨架，但当前论坛内容仍主要停留在 `forum/src/lib/forum-data.ts` 里的硬编码 TypeScript 数组。

这会带来三个直接问题：

- 页面展示和内容结构仍然耦合在同一份文件里，下一步接真实持久化层前还得先拆一次数据模型
- 帖子详情虽然已经能打开，但还没有开始承接“回复”这一层真实论坛最关键的讨论结构
- 治理与资料沉淀只能停留在文字描述里，还没有进入论坛自己的内容契约

当前最高优先级不是马上接一套可能返工的数据库方案，而是先把论坛内容推进成可独立演进的结构化数据层入口，让下一轮的持久化、发帖和审核流有明确落点。

## 这次改动

- 新建 `forum/src/data/forum-content.json`
  - 把论坛板块、帖子和首批回复迁到结构化内容仓
  - 为板块补入 `postingPrompt`
  - 为帖子补入 `moderationState` 与 `knowledgeStage`
  - 为回复补入 `roleLabel`、`trustSignal` 与 `moderationState`
- 扩展 `forum/src/lib/forum-data.ts`
  - 从结构化内容仓读取 `sections + threads + replies`
  - 补出 `getRepliesByThreadSlug()`
  - 补出 `getThreadDetailBySlug()`
  - 统一输出 `seed-json` source
- 更新 `forum/src/app/threads/[slug]/page.tsx`
  - 帖子详情页开始展示首批回复样例
  - 把资料沉淀阶段与治理状态显式带到页面上
- 更新 `forum/src/app/api/thread/[slug]/route.ts`
  - 单帖 JSON 路由改为返回 `thread + section + replies + source + generatedAt`
- 更新 `forum/README.md`
  - 明确论坛当前已从“页面骨架 + 种子数组”进入“结构化内容仓 + 回复契约”阶段

## 为什么现在做

这一步是论坛从“能浏览”走向“能承接真实互动”的最小关键改动：

- 先把内容结构从页面代码里抽出来，后续接数据库时不会先返工页面数据模型
- 先让帖子详情承接回复结构，后续补最小发帖和首条回复流程才有真实落点
- 先把治理和资料沉淀信号落进内容契约，后续审核、新手引导和精华归档就不是从零开始

相比这一轮直接上完整后端，这个切片更小、更稳，也更能保证下一步持续推进不会被返工拖慢。

## 验证

- compare 已确认分支相对 `main`：`behind_by = 0`
- 改动范围收敛在 `forum/**` 内部，共 6 个文件，不涉及官网原型回流
- 已回读关键文件，确认：
  - 结构化内容仓已覆盖板块、帖子、回复三层
  - 帖子详情页已实际消费回复数据
  - 单帖 JSON 路由已返回回复结构
- 当前环境没有仓库本地 checkout，无法直接执行 `pnpm --dir forum typecheck` 或 `pnpm --dir forum build`
- 最终类型检查与构建验证依赖仓库现有 `Module checks - Forum` 工作流

## 下一步承接

- 确定论坛真实数据层边界，判断是复用仓库现有服务层还是给 `forum/` 配独立持久化入口
- 在当前结构化内容契约上接“新建主题 + 首条回复”流程
- 把治理状态和资料沉淀阶段从展示字段推进成真实持久化状态流