### PR TITLE
fix(android): harden CI release builds against flaky Maven mirrors

### DIFF
--- a/fabushi/android/app/build.gradle.kts
+++ b/fabushi/android/app/build.gradle.kts
@@ -20,7 +20,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "com.ombhrum.fabushi"
     compileSdk = 36
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/fabushi/android/build.gradle.kts
+++ b/fabushi/android/build.gradle.kts
@@ -5,14 +5,11 @@ buildscript {
         if (preferOfficialReposInCi) {
             google()
             mavenCentral()
-        }
-
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/central") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-
-        if (!preferOfficialReposInCi) {
+        } else {
+            maven { url = uri("https://maven.aliyun.com/repository/google") }
+            maven { url = uri("https://maven.aliyun.com/repository/central") }
+            maven { url = uri("https://maven.aliyun.com/repository/public") }
+            maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
             google()
             mavenCentral()
         }
@@ -27,14 +24,11 @@ allprojects {
             if (preferOfficialReposInCi) {
                 google()
                 mavenCentral()
-            }
-
-            maven { url = uri("https://maven.aliyun.com/repository/google") }
-            maven { url = uri("https://maven.aliyun.com/repository/central") }
-            maven { url = uri("https://maven.aliyun.com/repository/public") }
-            maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-
-            if (!preferOfficialReposInCi) {
+            } else {
+                maven { url = uri("https://maven.aliyun.com/repository/google") }
+                maven { url = uri("https://maven.aliyun.com/repository/central") }
+                maven { url = uri("https://maven.aliyun.com/repository/public") }
+                maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
                 google()
                 mavenCentral()
             }

--- a/fabushi/android/settings.gradle.kts
+++ b/fabushi/android/settings.gradle.kts
@@ -23,16 +23,13 @@ pluginManagement {
             google()
             mavenCentral()
             gradlePluginPortal()
-        }
-
-        // Keep local and regional builds mirror-first, but let GitHub-hosted CI try upstream first.
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/central") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-        maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
-
-        if (!preferOfficialReposInCi) {
+        } else {
+            // Keep local and regional builds mirror-first, but let CI avoid flaky mirror metadata.
+            maven { url = uri("https://maven.aliyun.com/repository/google") }
+            maven { url = uri("https://maven.aliyun.com/repository/central") }
+            maven { url = uri("https://maven.aliyun.com/repository/public") }
+            maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
+            maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
             google()
             mavenCentral()
             gradlePluginPortal()
@@ -51,15 +48,12 @@ dependencyResolutionManagement {
         if (preferOfficialReposInCi) {
             google()
             mavenCentral()
-        }
-
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/central") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
-        maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
-
-        if (!preferOfficialReposInCi) {
+        } else {
+            maven { url = uri("https://maven.aliyun.com/repository/google") }
+            maven { url = uri("https://maven.aliyun.com/repository/central") }
+            maven { url = uri("https://maven.aliyun.com/repository/public") }
+            maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
+            maven { url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/") }
             google()
             mavenCentral()
         }


### PR DESCRIPTION
## 问题

`issue #423` 这次不是红在 Google Play 提交，也不是签名配置，而是 Android release build 在解析 `integration_test` 运行时依赖时被镜像源打断了：

- 失败点：`Build Android install packages`
- 首个确定性错误：`Could not GET https://maven.aliyun.com/repository/public/androidx/test/rules/maven-metadata.xml` -> `502 Bad Gateway`
- 失败任务：`:integration_test:mapReleaseSourceSetPaths`

同一份日志里还出现了第二个已经暴露出来的构建风险：

- 当前 app 配置的 NDK 还是 `27.0.12077973`
- 但 `integration_test` 已明确要求 `28.2.13676358`

如果只把这次 502 当成偶发网络问题，后续 release workflow 仍然会继续碰到同样的镜像脆弱点；而且即便绕过镜像，这条线也已经暴露出 NDK 版本落后于当前依赖面。

## 这次改动

- 更新 `fabushi/android/settings.gradle.kts`
  - 在 GitHub Actions / CI 环境下，Android 依赖解析只使用 `google()`、`mavenCentral()` 与 `gradlePluginPortal()`
  - 保留本地与区域化构建的镜像优先策略，不改非 CI 环境的镜像选择
- 更新 `fabushi/android/build.gradle.kts`
  - 同样把 buildscript 仓库改成 CI 只走官方源
  - 避免 release build 继续在 CI 中触碰 `maven.aliyun.com` 的动态元数据
- 更新 `fabushi/android/app/build.gradle.kts`
  - 将 `ndkVersion` 从 `27.0.12077973` 提升到日志已明确要求的 `28.2.13676358`

## 为什么这样修

这次需要修的是 CI 构建输入的稳定性，而不是继续等镜像偶发恢复：

- GitHub-hosted runner 在海外，继续让 CI 解析 AndroidX 动态版本时命中阿里云镜像，只会把发布成功与否绑定到外部镜像健康度
- 本地开发仍可能需要镜像加速，所以不应该把所有镜像策略一刀切删掉
- NDK 升级是日志已经明确指出的兼容性要求，顺手一起收口能避免 rerun 后马上撞到下一层门槛

## 风险审查

- 改动只收敛在 3 个 Android 构建文件
- 没有改应用业务代码、签名逻辑、Google Play 上传逻辑或 release asset 发布逻辑
- 非 CI 环境仍保留原来的镜像优先策略，避免对本地开发体验造成无谓回退
- NDK 调整使用的是构建日志里已经点名的更高兼容版本，属于顺着现有依赖面补齐，而不是额外引入新链路

## 验证

- compare 已确认分支相对 `main`：`behind_by = 0`、只修改 3 个文件
- 已回读分支内容，确认：
  - CI 分支仓库配置不再包含阿里云 / 腾讯镜像
  - 非 CI 分支仍保留镜像优先 + 官方回退
  - app 的 `ndkVersion` 已提升到 `28.2.13676358`
- 当前环境无法直接拿到仓库本地 checkout 运行 `flutter build apk` / `flutter build appbundle`
- 最终验证依赖新的 GitHub Actions：
  - `CI`
  - `Publish CD packages to GitHub Release`

## 预期结果

- Android release build 不再因为 `maven.aliyun.com/repository/public` 的 502 失败
- rerun 后应越过这次 `androidx.test:rules` 元数据解析故障
- `issue #423` 可以在新的 package publish 成功证据出现后收口
