### PR TITLE
fix(web): prefer direct Android beta downloads before fallbacks

### DIFF
--- a/frontend/apps/web/src/components/download-client.tsx
+++ b/frontend/apps/web/src/components/download-client.tsx
@@ -9,6 +9,8 @@ import {
   getUserFacingStatus,
   getUserFacingSummary,
 } from "../lib/channel-display";
+import { getDownloadFallbackLinks } from "../lib/download-hrefs";
+import { siteHref } from "../lib/site-url";
 
 export interface DownloadChannel {
   platform: "Android" | "iOS";
@@ -90,6 +92,7 @@ function ChannelCard({ channel, recommended = false }: { channel: DownloadChanne
   const statusCopy = getUserFacingStatus(channel);
   const descriptionCopy = getUserFacingDescription(channel);
   const summary = getUserFacingSummary(channel);
+  const fallbackLinks = getDownloadFallbackLinks(channel);
 
   return (
     <DownloadLink className={recommended ? "platform-row recommended detailed" : "platform-row detailed"} channel={channel}>
@@ -115,6 +118,15 @@ function ChannelCard({ channel, recommended = false }: { channel: DownloadChanne
               </li>
             ))}
           </ul>
+        )}
+        {fallbackLinks.length > 0 && (
+          <div className="mirror-links" aria-label={`${channel.title} fallback links`}>
+            {fallbackLinks.map((item) => (
+              <a key={item.href} href={siteHref(item.href)}>
+                {item.label}
+              </a>
+            ))}
+          </div>
         )}
       </div>
       <div className="platform-meta">

--- a/frontend/apps/web/src/components/download-client.tsx
+++ b/frontend/apps/web/src/components/download-client.tsx
@@ -95,7 +95,7 @@ function ChannelCard({ channel, recommended = false }: { channel: DownloadChanne
   const fallbackLinks = getDownloadFallbackLinks(channel);
 
   return (
-    <DownloadLink className={recommended ? "platform-row recommended detailed" : "platform-row detailed"} channel={channel}>
+    <article className={recommended ? "platform-row recommended detailed" : "platform-row detailed"}>
       <div>
         <span className="platform-name">
           {channel.title}
@@ -133,11 +133,11 @@ function ChannelCard({ channel, recommended = false }: { channel: DownloadChanne
         <strong>
           <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
         </strong>
-        <span>
+        <DownloadLink className="primary-action" channel={channel}>
           <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
-        </span>
+        </DownloadLink>
       </div>
-    </DownloadLink>
+    </article>
   );
 }
 

--- a/frontend/apps/web/src/lib/download-hrefs.ts
+++ b/frontend/apps/web/src/lib/download-hrefs.ts
@@ -1,4 +1,5 @@
 interface DownloadHrefMirrorLink {
+  label?: string;
   href: string;
 }
 
@@ -9,24 +10,69 @@ interface DownloadHrefChannel {
   audience?: "beta" | "stable";
 }
 
+export interface DownloadFallbackLink {
+  label: string;
+  href: string;
+  kind: "mirror" | "worker";
+}
+
 export type DownloadRegion = "domestic" | "global" | "unknown";
+
+const ANDROID_BETA_WORKER_FALLBACK_HREF = "/downloads/android-beta.apk";
+const ANDROID_BETA_WORKER_FALLBACK_LABEL = "Worker 兜底 / Worker fallback";
 
 export function isDomesticCountryCode(countryCode: string | null | undefined) {
   return countryCode?.trim().toUpperCase() === "CN";
 }
 
-function getAndroidDownloadProxyHref(channel: DownloadHrefChannel) {
-  if (channel.audience !== "beta") {
-    return channel.primaryHref;
+function normalizeHref(href: string | null | undefined) {
+  return typeof href === "string" ? href.trim() : "";
+}
+
+function canUseAndroidWorkerFallback(channel: DownloadHrefChannel) {
+  return channel.platform === "Android" && channel.audience === "beta";
+}
+
+export function getAndroidWorkerFallbackHref(channel: DownloadHrefChannel) {
+  if (!canUseAndroidWorkerFallback(channel)) {
+    return "";
   }
 
-  return "/downloads/android-beta.apk";
+  return ANDROID_BETA_WORKER_FALLBACK_HREF;
+}
+
+export function getDownloadFallbackLinks(channel: DownloadHrefChannel): DownloadFallbackLink[] {
+  const links: DownloadFallbackLink[] = [];
+  const seen = new Set<string>();
+  const primaryHref = normalizeHref(channel.primaryHref);
+
+  const pushLink = (label: string, href: string, kind: DownloadFallbackLink["kind"]) => {
+    const normalizedHref = normalizeHref(href);
+    if (!normalizedHref || normalizedHref === primaryHref || seen.has(normalizedHref)) {
+      return;
+    }
+
+    seen.add(normalizedHref);
+    links.push({
+      label,
+      href: normalizedHref,
+      kind,
+    });
+  };
+
+  channel.mirrorLinks.forEach((item, index) => {
+    pushLink(item.label?.trim() || `备用镜像 ${index + 1}`, item.href, "mirror");
+  });
+
+  pushLink(ANDROID_BETA_WORKER_FALLBACK_LABEL, getAndroidWorkerFallbackHref(channel), "worker");
+
+  return links;
 }
 
 export function getDownloadHrefForRegion(channel: DownloadHrefChannel, _region: DownloadRegion) {
   if (channel.platform === "Android") {
-    return getAndroidDownloadProxyHref(channel);
+    return normalizeHref(channel.primaryHref) || getDownloadFallbackLinks(channel)[0]?.href || "";
   }
 
-  return channel.primaryHref;
+  return normalizeHref(channel.primaryHref);
 }


### PR DESCRIPTION
## 问题

官网下载页里的 Android beta 主按钮当前没有先走 release 资产原链接，而是统一跳到 `/downloads/android-beta.apk` worker 代理。这样一来，只要 worker 侧一时没拿到同步状态，用户点击“下载 Android 测试版”就会先看到下载失败页，即使 GitHub release 原始 APK 链接本身其实仍然可用。

用户期望的顺序应该是：

1. 先用 GitHub 原始下载链接
2. 原链接较慢或不可用时再试镜像
3. 最后才试 worker 兜底

## 这次改动

- 更新 `frontend/apps/web/src/lib/download-hrefs.ts`
  - Android 下载主入口改为优先返回 `primaryHref`
  - 新增统一的 fallback link 组装逻辑，按“镜像 -> worker”输出备用入口
  - 保留 Android beta 的 worker 兜底路径，但不再把它当成默认首跳
- 更新 `frontend/apps/web/src/components/download-client.tsx`
  - 下载卡片不再整块包成单个链接，避免在卡片里加入镜像 / worker 备用链接时出现嵌套 `<a>`
  - 主 CTA 继续保留在卡片右侧
  - 将镜像链接和 `Worker fallback` 作为并列备用入口展示在卡片内容区

## 为什么这样修

当前故障不是 release 资产不存在，而是入口顺序错了：

- 主按钮先走 worker，会把 worker 的同步延迟放大成用户面前的首屏错误
- 原始 release 链接本来就是最直接、最少中间层的下载路径，应该是第一优先级
- 镜像是网络层 fallback，不应抢在原链接前面
- worker 代理仍然有价值，但更适合作为最后一层兜底，而不是默认下载链路

## 验证

- 已复核当前分支相对 `main` 的 diff，只收敛在 2 个前端文件
- 已静态检查：
  - Android beta 主 CTA 现在会直接使用 channel 的 `primaryHref`
  - 镜像链接仍会显示
  - worker fallback 会作为最后一个备用入口显示
  - 避免了在下载卡片中嵌套锚点标签的结构问题
- 当前运行环境无法直接 checkout 仓库并执行前端构建，因为外部 git clone 被网络策略拒绝

## 预期结果

- 官网点击“下载 Android 测试版”时，优先直接打开 GitHub release 原始 APK 下载链接
- 若用户原始链接较慢，可继续点镜像
- 只有在需要时，才再尝试 worker 兜底入口
- 之前那种“一上来先看到 worker 报错页”的体验会被移除