### PR TITLE
feat(forum): add standalone container deployment baseline

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -1,0 +1,31 @@
+name: Container checks - Forum
+
+on:
+  pull_request:
+    paths:
+      - "forum/**"
+      - ".github/workflows/forum-container-checks.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "forum/**"
+      - ".github/workflows/forum-container-checks.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  forum-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout forum workspace only
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            forum
+          fetch-depth: 1
+
+      - name: Build forum container image
+        run: docker build -t fabushi-forum ./forum

--- a/forum/.dockerignore
+++ b/forum/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+coverage
+.git
+Dockerfile
+README.md

--- a/forum/Dockerfile
+++ b/forum/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-alpine AS builder
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package.json ./
+RUN pnpm install --no-frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+FROM node:22-alpine AS runner
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+ENV NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /app
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/forum/README.md
+++ b/forum/README.md
@@ -4,7 +4,7 @@ This directory is the independent root for the forum project.
 
 ## What exists now
 
-The forum is no longer being extended inside the marketing website. This directory now contains a standalone Next.js app skeleton so the project can move from an empty placeholder into something runnable and testable.
+The forum is no longer being extended inside the marketing website. This directory now contains a standalone Next.js app skeleton so the project can move from an empty placeholder into something runnable, testable, and deployable on its own.
 
 Current scope:
 
@@ -14,6 +14,7 @@ Current scope:
 - read-only routes for thread listing and thread detail
 - JSON routes for the same seed contract, including reply data on thread detail
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
+- a container deployment baseline built from Next.js standalone output
 
 ## Current product boundary
 
@@ -27,6 +28,7 @@ Included:
 - structured seed content contract
 - read-only API boundary
 - moderation and knowledge-stage fields reserved in the content model
+- standalone server artifact for container packaging
 
 Not included yet:
 
@@ -50,8 +52,28 @@ Useful checks:
 ```bash
 pnpm typecheck
 pnpm build
+pnpm start:standalone
 ```
+
+## Container deployment
+
+The app now builds with `output: "standalone"`, so deployment does not need the whole repository at runtime.
+
+Build and run locally with Docker:
+
+```bash
+docker build -t fabushi-forum ./forum
+docker run --rm -p 3000:3000 fabushi-forum
+```
+
+Runtime defaults:
+
+- `PORT=3000`
+- `HOSTNAME=0.0.0.0`
+- `NODE_ENV=production`
+
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes.
 
 ## Why this is the next step
 
-The highest-priority gap after creating `forum/` was that forum content still lived as hard-coded TypeScript arrays. This iteration moves the project onto a structured content store and reply-aware contract so the next pass can attach a real persistence layer, posting flow, and governance events without first untangling page-local seed data.
+After the structured seed content contract landed, the next highest-value blocker was deployment readiness for the independent forum app. This iteration keeps the current seed-backed product surface intact while adding a real container path, so the next pass can attach persistence, posting flow, and governance services without first inventing a deployment baseline.

--- a/forum/next.config.ts
+++ b/forum/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   reactStrictMode: true,
   typedRoutes: true,
 };

--- a/forum/package.json
+++ b/forum/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "start:standalone": "node .next/standalone/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## 问题

`forum/` 现在已经是独立 Next.js 论坛骨架，也有自己的检查工作流和只读 JSON 契约，但它还没有一个清晰、可复用、可检查的独立部署落点。

这会卡住论坛从“能跑”继续走向“能部署”：

- 论坛应用还没有自己的容器打包方式
- 运行时还没有脱离整仓开发环境的启动路径
- CI 也还没有验证论坛镜像是否能被实际构建出来

在真实数据库和发帖能力落地前，先补独立部署基线，比仓促选一套持久化方案更稳，也更接近首次可上线状态。

## 这次改动

- 更新 `forum/next.config.ts`
  - 开启 `output: "standalone"`
- 更新 `forum/package.json`
  - 新增 `start:standalone`
- 新增 `forum/Dockerfile`
  - 用 Next.js standalone 产物构建独立论坛镜像
- 新增 `forum/.dockerignore`
  - 收紧论坛镜像构建上下文
- 更新 `forum/README.md`
  - 补充论坛容器化运行方式与运行时默认环境
- 新增 `.github/workflows/forum-container-checks.yml`
  - 在 `forum/**` 变更时直接检查 Docker 镜像是否能构建

## 为什么现在做

当前论坛已经有页面骨架、结构化内容层和独立检查入口，下一层最缺的不是更多静态页面，而是一个真正脱离官网原型的部署起点。

这一步的收益很直接：

- 论坛从“本地 Next 应用”变成“可打包的独立服务”
- 后续接数据库、鉴权和发帖能力时，不需要先重新补部署基线
- CI 会开始直接验证论坛镜像构建，而不只是验证应用 build

## 验证

- compare 已确认分支相对 `main`：`behind_by = 0`
- 改动范围收敛为 6 个文件，只涉及 `forum/**` 与一条论坛专用 workflow
- 已回读关键文件，确认：
  - `forum/next.config.ts` 已启用 standalone 输出
  - `forum/Dockerfile` 以 standalone 产物作为运行时入口
  - `forum-container-checks.yml` 会直接执行 `docker build -t fabushi-forum ./forum`
- 当前环境没有仓库本地 checkout，无法在本地直接跑 `pnpm --dir forum build` 或 `docker build ./forum`
- 最终构建验证依赖仓库 Actions：
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 确定论坛持久化层边界，优先判断独立论坛服务如何接数据库
- 在当前结构化内容契约上接“新建主题 + 首条回复”流程
- 明确论坛独立部署入口是子域名、单独域名，还是反向代理路径