### PR TITLE
fix(web): preserve previous iOS beta entry when latest release is Android-only

### DIFF
--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -196,37 +196,38 @@ jobs:
               }
           ]
 
-          tf_status = testflight_status.get("status", "")
-          tf_uploaded_at = testflight_status.get("uploaded_at") or release.get("published_at")
-          tf_build_number = testflight_status.get("build_number") or release_tag
-          tf_uploaded = tf_status == "uploaded"
-          ios_primary_href = ios_testflight_public_url if tf_uploaded and ios_testflight_public_url else release_url
-          ios_primary_label = "加入 iOS TestFlight" if tf_uploaded and ios_testflight_public_url else "查看 iOS 发布状态"
-          ios_note = ""
-          if tf_uploaded and not ios_testflight_public_url:
-              ios_note = "已经上传到 TestFlight，但仓库变量 IOS_TESTFLIGHT_PUBLIC_URL 还没有配置公开加入链接。"
-          elif testflight_status.get("reason") == "app_store_connect_credentials_not_configured":
-              ios_note = "当前仓库还没有配置 App Store Connect 上传凭据。"
-          elif not tf_uploaded:
-              ios_note = "当前还没有拿到可公开加入的 TestFlight 入口。"
+          if testflight_status:
+              tf_status = testflight_status.get("status", "")
+              tf_uploaded_at = testflight_status.get("uploaded_at") or release.get("published_at")
+              tf_build_number = testflight_status.get("build_number") or release_tag
+              tf_uploaded = tf_status == "uploaded"
+              ios_primary_href = ios_testflight_public_url if tf_uploaded and ios_testflight_public_url else release_url
+              ios_primary_label = "加入 iOS TestFlight" if tf_uploaded and ios_testflight_public_url else "查看 iOS 发布状态"
+              ios_note = ""
+              if tf_uploaded and not ios_testflight_public_url:
+                  ios_note = "已经上传到 TestFlight，但仓库变量 IOS_TESTFLIGHT_PUBLIC_URL 还没有配置公开加入链接。"
+              elif testflight_status.get("reason") == "app_store_connect_credentials_not_configured":
+                  ios_note = "当前仓库还没有配置 App Store Connect 上传凭据。"
+              elif not tf_uploaded:
+                  ios_note = "当前还没有拿到可公开加入的 TestFlight 入口。"
 
-          channels.append(
-              {
-                  "platform": "iOS",
-                  "audience": "beta",
-                  "status": "TestFlight 已开放" if tf_uploaded else "等待 TestFlight 可加入",
-                  "title": "iOS TestFlight Beta",
-                  "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
-                  "primaryLabel": ios_primary_label,
-                  "primaryHref": ios_primary_href,
-                  "version": tf_build_number,
-                  "publishedAt": tf_uploaded_at,
-                  "updateSummary": summary,
-                  "mirrorLinks": [],
-                  "note": ios_note,
-                  "releasePageHref": release_url,
-              }
-          )
+              channels.append(
+                  {
+                      "platform": "iOS",
+                      "audience": "beta",
+                      "status": "TestFlight 已开放" if tf_uploaded else "等待 TestFlight 可加入",
+                      "title": "iOS TestFlight Beta",
+                      "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
+                      "primaryLabel": ios_primary_label,
+                      "primaryHref": ios_primary_href,
+                      "version": tf_build_number,
+                      "publishedAt": tf_uploaded_at,
+                      "updateSummary": summary,
+                      "mirrorLinks": [],
+                      "note": ios_note,
+                      "releasePageHref": release_url,
+                  }
+              )
 
           state = {
               "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -317,7 +318,60 @@ jobs:
 
           if [ -f OFFICIAL_SITE_RELEASE_STATE.json ]; then
             mkdir -p frontend/apps/web/public/api
-            python3 -c 'import json; from pathlib import Path; source_path = Path("OFFICIAL_SITE_RELEASE_STATE.json"); target_path = Path("frontend/apps/web/public/api/releases.json"); state = json.loads(source_path.read_text(encoding="utf-8")); channels = state.get("channels", []); api_state = {"betaChannels": [channel for channel in channels if channel.get("audience") == "beta"], "stableChannels": [channel for channel in channels if channel.get("audience") == "stable"], "screenshots": state.get("screenshots", {}), "releases": state.get("releases", []), "notes": state.get("notes", [])}; target_path.write_text(json.dumps(api_state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")'
+            python3 - <<'PY'
+            import json
+            from pathlib import Path
+
+            source_path = Path("OFFICIAL_SITE_RELEASE_STATE.json")
+            target_path = Path("frontend/apps/web/public/api/releases.json")
+
+            state = json.loads(source_path.read_text(encoding="utf-8"))
+            channels = state.get("channels", [])
+            incoming_beta = [channel for channel in channels if channel.get("audience") == "beta"]
+            incoming_stable = [channel for channel in channels if channel.get("audience") == "stable"]
+
+            existing = {}
+            if target_path.exists():
+                try:
+                    existing = json.loads(target_path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    existing = {}
+
+            def merge_channels(incoming, previous):
+                merged = {}
+                insertion_order = []
+                for channel in previous:
+                    if not isinstance(channel, dict):
+                        continue
+                    key = f"{channel.get('audience', '')}:{channel.get('platform', '')}"
+                    if key not in merged:
+                        insertion_order.append(key)
+                    merged[key] = channel
+                for channel in incoming:
+                    if not isinstance(channel, dict):
+                        continue
+                    key = f"{channel.get('audience', '')}:{channel.get('platform', '')}"
+                    if key not in merged:
+                        insertion_order.append(key)
+                    merged[key] = channel
+                preferred_order = ["beta:Android", "beta:iOS", "stable:Android", "stable:iOS"]
+                ordered_keys = [key for key in preferred_order if key in merged]
+                ordered_keys.extend(key for key in insertion_order if key not in ordered_keys)
+                return [merged[key] for key in ordered_keys]
+
+            previous_beta = existing.get("betaChannels", []) if isinstance(existing, dict) else []
+            previous_stable = existing.get("stableChannels", []) if isinstance(existing, dict) else []
+
+            api_state = {
+                "betaChannels": merge_channels(incoming_beta, previous_beta),
+                "stableChannels": merge_channels(incoming_stable, previous_stable),
+                "screenshots": state.get("screenshots") or (existing.get("screenshots") if isinstance(existing, dict) else {}) or {},
+                "releases": state.get("releases") or (existing.get("releases") if isinstance(existing, dict) else []) or [],
+                "notes": state.get("notes") or (existing.get("notes") if isinstance(existing, dict) else []) or [],
+            }
+
+            target_path.write_text(json.dumps(api_state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            PY
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add frontend/apps/web/public/api/releases.json

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -1,10 +1,10 @@
 import { readFile } from "node:fs/promises";
-import path from "node:path";
+import { join } from "node:path";
 
 const officialSiteReleaseRepo = process.env.NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_REPO?.trim() || "bhrumom/fabushi";
 const iosTestFlightPublicUrl = process.env.NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL?.trim() || "";
 const RELEASES_API_URL = `https://api.github.com/repos/${officialSiteReleaseRepo}/releases?per_page=8`;
-const PERSISTED_RELEASES_PATH = path.join(process.cwd(), "public", "api", "releases.json");
+const PERSISTED_RELEASES_PATH = join(process.cwd(), "public", "api", "releases.json");
 
 const DEFAULT_MIRROR_BASES = [
   {

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -1,6 +1,10 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
 const officialSiteReleaseRepo = process.env.NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_REPO?.trim() || "bhrumom/fabushi";
 const iosTestFlightPublicUrl = process.env.NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL?.trim() || "";
 const RELEASES_API_URL = `https://api.github.com/repos/${officialSiteReleaseRepo}/releases?per_page=8`;
+const PERSISTED_RELEASES_PATH = path.join(process.cwd(), "public", "api", "releases.json");
 
 const DEFAULT_MIRROR_BASES = [
   {
@@ -125,6 +129,13 @@ export const FALLBACK_SCREENSHOTS: Record<string, string> = {
   "global-donation": "/product/global-donation.png",
   "global-donation-leaderboard": "/product/global-donation-leaderboard.png",
 };
+
+const CHANNEL_ORDER: Array<Pick<OfficialSiteChannel, "audience" | "platform">> = [
+  { audience: "beta", platform: "Android" },
+  { audience: "beta", platform: "iOS" },
+  { audience: "stable", platform: "Android" },
+  { audience: "stable", platform: "iOS" },
+];
 
 const DEFAULT_STABLE_CHANNELS: OfficialSiteChannel[] = [
   {
@@ -333,6 +344,30 @@ function applyConfiguredIosTestFlightChannels(channels: OfficialSiteChannel[]): 
   return channels.map((channel) => applyConfiguredIosTestFlightChannel(channel));
 }
 
+function getChannelKey(channel: Pick<OfficialSiteChannel, "audience" | "platform">): string {
+  return `${channel.audience}:${channel.platform}`;
+}
+
+function mergeChannels(primary: OfficialSiteChannel[], fallback: OfficialSiteChannel[]): OfficialSiteChannel[] {
+  const merged = new Map<string, OfficialSiteChannel>();
+
+  for (const channel of fallback) {
+    merged.set(getChannelKey(channel), channel);
+  }
+
+  for (const channel of primary) {
+    merged.set(getChannelKey(channel), channel);
+  }
+
+  const orderedChannels = CHANNEL_ORDER.map((channel) => merged.get(getChannelKey(channel))).filter(
+    (channel): channel is OfficialSiteChannel => Boolean(channel),
+  );
+  const seenKeys = new Set(orderedChannels.map((channel) => getChannelKey(channel)));
+  const remainingChannels = Array.from(merged.values()).filter((channel) => !seenKeys.has(getChannelKey(channel)));
+
+  return [...orderedChannels, ...remainingChannels];
+}
+
 function normalizeChannel(input: unknown): OfficialSiteChannel | null {
   if (!input || typeof input !== "object") {
     return null;
@@ -453,6 +488,37 @@ function normalizeState(input: unknown): OfficialSiteReleaseAssetState | null {
   };
 }
 
+function normalizeReleaseCollectionRecord(data: Record<string, unknown>): OfficialSiteReleaseCollection {
+  const channels = Array.isArray(data.channels)
+    ? data.channels.map(normalizeChannel).filter((item): item is OfficialSiteChannel => item !== null)
+    : [];
+  const betaChannels =
+    Array.isArray(data.betaChannels) && data.betaChannels.length > 0
+      ? data.betaChannels.map(normalizeChannel).filter((item): item is OfficialSiteChannel => item !== null)
+      : channels.filter((channel) => channel.audience === "beta");
+  const stableChannels =
+    Array.isArray(data.stableChannels) && data.stableChannels.length > 0
+      ? data.stableChannels.map(normalizeChannel).filter((item): item is OfficialSiteChannel => item !== null)
+      : channels.filter((channel) => channel.audience === "stable");
+
+  return {
+    betaChannels,
+    stableChannels,
+    screenshots: normalizeScreenshots(data.screenshots) ?? {},
+    releases: normalizeReleaseEntries(data.releases),
+    notes: Array.isArray(data.notes) ? data.notes.filter((item): item is string => typeof item === "string") : [],
+  };
+}
+
+async function loadPersistedReleaseCollection(): Promise<OfficialSiteReleaseCollection | null> {
+  try {
+    const content = await readFile(PERSISTED_RELEASES_PATH, "utf-8");
+    return normalizeReleaseCollectionRecord(JSON.parse(content) as Record<string, unknown>);
+  } catch {
+    return null;
+  }
+}
+
 async function loadStateAsset(
   release: GitHubRelease,
   assetName: "OFFICIAL_SITE_RELEASE_STATE.json" | "OFFICIAL_SITE_STABLE_RELEASE_STATE.json",
@@ -571,27 +637,10 @@ export async function getReleaseCollectionClient(): Promise<OfficialSiteReleaseC
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = (await res.json()) as Record<string, unknown>;
-    const channels = Array.isArray(data.channels)
-      ? data.channels.map(normalizeChannel).filter((item): item is OfficialSiteChannel => item !== null)
-      : [];
-    const betaChannels =
-      Array.isArray(data.betaChannels) && data.betaChannels.length > 0
-        ? data.betaChannels
-            .map(normalizeChannel)
-            .filter((item): item is OfficialSiteChannel => item !== null)
-        : channels.filter((channel) => channel.audience === "beta");
-    const stableChannels =
-      Array.isArray(data.stableChannels) && data.stableChannels.length > 0
-        ? data.stableChannels
-            .map(normalizeChannel)
-            .filter((item): item is OfficialSiteChannel => item !== null)
-        : channels.filter((channel) => channel.audience === "stable");
+    const collection = normalizeReleaseCollectionRecord(data);
     return {
-      betaChannels: applyConfiguredIosTestFlightChannels(betaChannels),
-      stableChannels,
-      screenshots: normalizeScreenshots(data.screenshots) ?? {},
-      releases: normalizeReleaseEntries(data.releases),
-      notes: Array.isArray(data.notes) ? data.notes.filter((item): item is string => typeof item === "string") : [],
+      ...collection,
+      betaChannels: applyConfiguredIosTestFlightChannels(collection.betaChannels),
     };
   } catch {
     return { betaChannels: [], stableChannels: [], screenshots: {}, releases: [], notes: [] };
@@ -599,6 +648,7 @@ export async function getReleaseCollectionClient(): Promise<OfficialSiteReleaseC
 }
 
 export async function getOfficialSiteReleaseCollection(): Promise<OfficialSiteReleaseCollection> {
+  const persistedCollection = await loadPersistedReleaseCollection();
   const releases = (await fetchJson<GitHubRelease[]>(RELEASES_API_URL)) ?? [];
   const publishedReleases = releases.filter((release) => !release.draft);
   const fallbackReleaseEntries = buildReleaseEntries(publishedReleases);
@@ -622,16 +672,28 @@ export async function getOfficialSiteReleaseCollection(): Promise<OfficialSiteRe
     : null;
 
   return {
-    betaChannels: applyConfiguredIosTestFlightChannels(betaState?.channels ?? []),
-    stableChannels: stableState?.channels?.length ? stableState.channels : DEFAULT_STABLE_CHANNELS,
-    screenshots: betaState?.screenshots ?? {},
-    releases: betaState?.releases?.length ? betaState.releases : fallbackReleaseEntries,
+    betaChannels: applyConfiguredIosTestFlightChannels(
+      mergeChannels(betaState?.channels ?? [], persistedCollection?.betaChannels ?? []),
+    ),
+    stableChannels: mergeChannels(
+      stableState?.channels?.length ? stableState.channels : DEFAULT_STABLE_CHANNELS,
+      persistedCollection?.stableChannels ?? [],
+    ),
+    screenshots: betaState?.screenshots ?? persistedCollection?.screenshots ?? {},
+    releases:
+      betaState?.releases?.length
+        ? betaState.releases
+        : persistedCollection?.releases?.length
+          ? persistedCollection.releases
+          : fallbackReleaseEntries,
     notes:
       betaState?.notes?.length
         ? betaState.notes
-        : [
-            "当前 Beta 入口会先显示公开发布记录里的可用信息。",
-            "TestFlight 公共加入链接开放后会显示直接入口。",
-          ],
+        : persistedCollection?.notes?.length
+          ? persistedCollection.notes
+          : [
+              "当前 Beta 入口会先显示公开发布记录里的可用信息。",
+              "TestFlight 公共加入链接开放后会显示直接入口。",
+            ],
   };
 }


### PR DESCRIPTION
## Summary
- preserve the previous iOS beta channel on the website when the latest release only contains Android assets
- stop the beta sync workflow from generating a fresh empty iOS channel when no TestFlight status file exists
- merge newly generated beta channel data into the persisted `releases.json` file instead of replacing missing channels with blanks

## Why
When a release ships without an iOS build, the sync path was overwriting the previously published iOS install information with a newer empty placeholder. That made the website lose the last working iOS entry even though Android was the only thing that changed.

## What changed
- `frontend/apps/web/src/lib/official-site-releases.ts`
  - loads the persisted `public/api/releases.json` data on the server
  - merges persisted channels back in when the newest release state is partial
  - keeps existing release notes and screenshots as fallback data
- `.github/workflows/sync-official-site-beta.yml`
  - only emits a new iOS beta channel when `TESTFLIGHT_UPLOAD_STATUS.txt` is actually present
  - preserves missing channels from the existing `releases.json` during sync instead of clearing them

## Validation
- compared `main...codex/fix-ios-download-preserve-main` and confirmed only the workflow and release aggregation logic changed
- verified the new merge path preserves `beta:iOS` whenever the newest release state only carries Android
