### PR TITLE
feat(forum): add runtime status boundary and container smoke checks

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -29,3 +29,33 @@ jobs:
 
       - name: Build forum container image
         run: docker build -t fabushi-forum ./forum
+
+      - name: Start forum container
+        run: docker run -d --rm --name fabushi-forum-check -p 3000:3000 fabushi-forum
+
+      - name: Smoke test forum status endpoint
+        run: |
+          for attempt in 1 2 3 4 5; do
+            response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)" && break
+            sleep 3
+          done
+
+          if [ -z "${response:-}" ]; then
+            docker logs fabushi-forum-check
+            exit 1
+          fi
+
+          echo "$response"
+          FORUM_STATUS_RESPONSE="$response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_STATUS_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["dataSource"] == "seed-json", payload
+          assert payload["persistenceMode"] == "seed-only", payload
+          PY
+
+      - name: Stop forum container
+        if: always()
+        run: docker stop fabushi-forum-check

--- a/forum/.env.example
+++ b/forum/.env.example
@@ -1,0 +1,5 @@
+# Current supported value: seed-json
+FORUM_DATA_SOURCE=seed-json
+
+# Reserved for the first durable persistence pass.
+FORUM_DATABASE_URL=

--- a/forum/README.md
+++ b/forum/README.md
@@ -11,10 +11,12 @@ Current scope:
 - independent app shell under `forum/src/app`
 - structured seed content under `forum/src/data/forum-content.json`
 - forum domain helpers under `forum/src/lib/forum-data.ts`
-- read-only routes for thread listing and thread detail
+- a repository boundary that keeps page rendering and API routes behind one forum data source contract
+- read-only routes for thread listing, thread detail, and runtime status
 - JSON routes for the same seed contract, including reply data on thread detail
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
+- a container smoke check that starts the forum and hits `/api/status`
 
 ## Current product boundary
 
@@ -28,6 +30,7 @@ Included:
 - structured seed content contract
 - read-only API boundary
 - moderation and knowledge-stage fields reserved in the content model
+- a runtime status endpoint for deployment smoke checks
 - standalone server artifact for container packaging
 
 Not included yet:
@@ -38,6 +41,8 @@ Not included yet:
 - search, notifications, bookmarks, or follows as real user actions
 
 ## Local development
+
+Copy `.env.example` to `.env.local` if you want to make the runtime defaults explicit.
 
 ```bash
 cd forum
@@ -53,7 +58,23 @@ Useful checks:
 pnpm typecheck
 pnpm build
 pnpm start:standalone
+curl http://localhost:3000/api/status
 ```
+
+## Runtime contract
+
+The forum currently runs in `seed-json` mode, but the page layer and API routes no longer read the JSON file directly. They now go through a single repository boundary, so the first durable database pass can replace the data source without rewriting the route or page structure.
+
+Current runtime fields:
+
+- `FORUM_DATA_SOURCE=seed-json`
+- `FORUM_DATABASE_URL=` reserved for the first durable persistence pass
+
+Current JSON routes:
+
+- `GET /api/threads`
+- `GET /api/thread/[slug]`
+- `GET /api/status`
 
 ## Container deployment
 
@@ -64,6 +85,7 @@ Build and run locally with Docker:
 ```bash
 docker build -t fabushi-forum ./forum
 docker run --rm -p 3000:3000 fabushi-forum
+curl http://localhost:3000/api/status
 ```
 
 Runtime defaults:
@@ -72,8 +94,8 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, and then verifies the container actually serves the runtime status endpoint.
 
 ## Why this is the next step
 
-After the structured seed content contract landed, the next highest-value blocker was deployment readiness for the independent forum app. This iteration keeps the current seed-backed product surface intact while adding a real container path, so the next pass can attach persistence, posting flow, and governance services without first inventing a deployment baseline.
+After the structured seed content contract and standalone deployment baseline landed, the next highest-value gap was a clear runtime boundary for the forum's first persistent data source. This iteration keeps the current seed-backed product surface intact while making the data source explicit and adding a smoke-testable runtime endpoint, so the next pass can attach posting flow and durable storage without guessing where that boundary should live.

--- a/forum/src/app/api/status/route.ts
+++ b/forum/src/app/api/status/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getForumRuntimeStatus } from "../../../lib/forum-data";
+
+export async function GET() {
+  const status = getForumRuntimeStatus();
+
+  return NextResponse.json(status, {
+    headers: {
+      "cache-control": "no-store",
+      "x-forum-data-source": status.dataSource,
+    },
+  });
+}

--- a/forum/src/app/page.tsx
+++ b/forum/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { FORUM_SECTIONS, FORUM_THREADS, getForumSnapshot } from "../lib/forum-data";
+import { getForumSnapshot } from "../lib/forum-data";
 
 export default function HomePage() {
   const snapshot = getForumSnapshot();
@@ -35,7 +35,7 @@ export default function HomePage() {
       </section>
 
       <section className="thread-grid">
-        {FORUM_THREADS.slice(0, 4).map((thread) => (
+        {snapshot.threads.slice(0, 4).map((thread) => (
           <article key={thread.slug} className="thread-card">
             <div className="thread-meta">
               <span>{thread.author}</span>
@@ -58,7 +58,7 @@ export default function HomePage() {
       </section>
 
       <section className="section-grid">
-        {FORUM_SECTIONS.map((section) => (
+        {snapshot.sections.map((section) => (
           <article key={section.slug} className="panel">
             <h3>{section.name}</h3>
             <p>{section.description}</p>
@@ -72,6 +72,7 @@ export default function HomePage() {
         <p>种子数据已经通过独立应用自己的 JSON 路由暴露出来，后续可以在不重写页面结构的前提下切到真实数据层。</p>
         <p className="code">GET /api/threads</p>
         <p className="code">GET /api/thread/[slug]</p>
+        <p className="code">GET /api/status</p>
         <div className="footer-note">
           <span>sections: {snapshot.sections.length}</span>
           <span>threads: {snapshot.threads.length}</span>

--- a/forum/src/app/threads/page.tsx
+++ b/forum/src/app/threads/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
-import { FORUM_SECTIONS, FORUM_THREADS, getThreadsBySection } from "../../lib/forum-data";
+import { getForumSnapshot } from "../../lib/forum-data";
 
 export default function ThreadsPage() {
+  const snapshot = getForumSnapshot();
+
   return (
     <main>
       <section className="hero">
@@ -19,17 +21,17 @@ export default function ThreadsPage() {
       </section>
 
       <section className="section-grid">
-        {FORUM_SECTIONS.map((section) => (
+        {snapshot.sections.map((section) => (
           <article key={section.slug} className="panel">
             <h2>{section.name}</h2>
             <p>{section.description}</p>
-            <p>当前种子帖子 {getThreadsBySection(section.slug).length} 条</p>
+            <p>当前种子帖子 {section.threadCount} 条</p>
           </article>
         ))}
       </section>
 
       <section className="thread-grid">
-        {FORUM_THREADS.map((thread) => (
+        {snapshot.threads.map((thread) => (
           <article key={thread.slug} className="thread-card">
             <div className="thread-meta">
               <span>{thread.author}</span>

--- a/forum/src/lib/forum-data.ts
+++ b/forum/src/lib/forum-data.ts
@@ -1,5 +1,7 @@
-import forumContent from "../data/forum-content.json";
+import { createSeedForumRepository } from "./forum-seed-repository";
 
+export type ForumDataSource = "seed-json";
+export type ForumPersistenceMode = "seed-only";
 export type ForumModerationState = "published" | "needs-review" | "archived";
 export type ForumKnowledgeStage = "discussion" | "candidate" | "archived";
 
@@ -40,65 +42,84 @@ export interface ForumReply {
   body: string[];
 }
 
-interface ForumContentStore {
-  sections: ForumSection[];
-  threads: ForumThread[];
-  replies: ForumReply[];
+export interface ForumSectionSummary extends ForumSection {
+  threadCount: number;
+  replyCount: number;
 }
 
-const content = forumContent as ForumContentStore;
+export interface ForumThreadDetail {
+  thread: ForumThread;
+  section?: ForumSection;
+  replies: ForumReply[];
+  source: ForumDataSource;
+  generatedAt: string;
+}
 
-export const FORUM_SECTIONS: ForumSection[] = content.sections;
-export const FORUM_THREADS: ForumThread[] = content.threads;
-export const FORUM_REPLIES: ForumReply[] = content.replies;
+export interface ForumSnapshot {
+  sections: ForumSectionSummary[];
+  threads: ForumThread[];
+  replies: ForumReply[];
+  generatedAt: string;
+  source: ForumDataSource;
+}
+
+export interface ForumRuntimeStatus {
+  service: "forum";
+  dataSource: ForumDataSource;
+  persistenceMode: ForumPersistenceMode;
+  databaseConfigured: boolean;
+  counts: {
+    sections: number;
+    threads: number;
+    replies: number;
+  };
+  generatedAt: string;
+}
+
+export interface ForumRepository {
+  dataSource: ForumDataSource;
+  persistenceMode: ForumPersistenceMode;
+  getSections(): ForumSection[];
+  getThreads(): ForumThread[];
+  getReplies(): ForumReply[];
+  getSectionBySlug(slug: string): ForumSection | undefined;
+  getThreadBySlug(slug: string): ForumThread | undefined;
+  getThreadsBySection(sectionSlug: string): ForumThread[];
+  getRepliesByThreadSlug(threadSlug: string): ForumReply[];
+  getThreadDetailBySlug(slug: string): ForumThreadDetail | undefined;
+  getSnapshot(): ForumSnapshot;
+  getRuntimeStatus(): ForumRuntimeStatus;
+}
+
+const forumRepository = createSeedForumRepository();
+
+export const FORUM_DATA_SOURCE = forumRepository.dataSource;
+export const FORUM_PERSISTENCE_MODE = forumRepository.persistenceMode;
 
 export function getSectionBySlug(slug: string) {
-  return FORUM_SECTIONS.find((section) => section.slug === slug);
+  return forumRepository.getSectionBySlug(slug);
 }
 
 export function getThreadBySlug(slug: string) {
-  return FORUM_THREADS.find((thread) => thread.slug === slug);
+  return forumRepository.getThreadBySlug(slug);
 }
 
 export function getThreadsBySection(sectionSlug: string) {
-  return FORUM_THREADS.filter((thread) => thread.sectionSlug === sectionSlug);
+  return forumRepository.getThreadsBySection(sectionSlug);
 }
 
 export function getRepliesByThreadSlug(threadSlug: string) {
-  return FORUM_REPLIES.filter((reply) => reply.threadSlug === threadSlug);
+  return forumRepository.getRepliesByThreadSlug(threadSlug);
 }
 
 export function getThreadDetailBySlug(slug: string) {
-  const thread = getThreadBySlug(slug);
-
-  if (!thread) {
-    return undefined;
-  }
-
-  return {
-    thread,
-    section: getSectionBySlug(thread.sectionSlug),
-    replies: getRepliesByThreadSlug(thread.slug),
-    source: "seed-json",
-    generatedAt: new Date().toISOString(),
-  };
+  return forumRepository.getThreadDetailBySlug(slug);
 }
 
 export function getForumSnapshot() {
-  return {
-    sections: FORUM_SECTIONS.map((section) => {
-      const threads = getThreadsBySection(section.slug);
-      const replyCount = threads.reduce((total, thread) => total + getRepliesByThreadSlug(thread.slug).length, 0);
+  return forumRepository.getSnapshot();
+}
 
-      return {
-        ...section,
-        threadCount: threads.length,
-        replyCount,
-      };
-    }),
-    threads: FORUM_THREADS,
-    replies: FORUM_REPLIES,
-    generatedAt: new Date().toISOString(),
-    source: "seed-json",
-  };
+export function getForumRuntimeStatus() {
+  return forumRepository.getRuntimeStatus();
 }

--- a/forum/src/lib/forum-seed-repository.ts
+++ b/forum/src/lib/forum-seed-repository.ts
@@ -1,0 +1,90 @@
+import forumContent from "../data/forum-content.json";
+import type {
+  ForumReply,
+  ForumRepository,
+  ForumRuntimeStatus,
+  ForumSection,
+  ForumSnapshot,
+  ForumThread,
+  ForumThreadDetail,
+} from "./forum-data";
+
+interface ForumContentStore {
+  sections: ForumSection[];
+  threads: ForumThread[];
+  replies: ForumReply[];
+}
+
+const content = forumContent as ForumContentStore;
+
+export function createSeedForumRepository(): ForumRepository {
+  const sections = content.sections;
+  const threads = content.threads;
+  const replies = content.replies;
+
+  const getSectionBySlug = (slug: string) => sections.find((section) => section.slug === slug);
+  const getThreadBySlug = (slug: string) => threads.find((thread) => thread.slug === slug);
+  const getThreadsBySection = (sectionSlug: string) => threads.filter((thread) => thread.sectionSlug === sectionSlug);
+  const getRepliesByThreadSlug = (threadSlug: string) => replies.filter((reply) => reply.threadSlug === threadSlug);
+
+  const getThreadDetailBySlug = (slug: string): ForumThreadDetail | undefined => {
+    const thread = getThreadBySlug(slug);
+
+    if (!thread) {
+      return undefined;
+    }
+
+    return {
+      thread,
+      section: getSectionBySlug(thread.sectionSlug),
+      replies: getRepliesByThreadSlug(thread.slug),
+      source: "seed-json",
+      generatedAt: new Date().toISOString(),
+    };
+  };
+
+  const getSnapshot = (): ForumSnapshot => ({
+    sections: sections.map((section) => {
+      const sectionThreads = getThreadsBySection(section.slug);
+      const replyCount = sectionThreads.reduce((total, thread) => total + getRepliesByThreadSlug(thread.slug).length, 0);
+
+      return {
+        ...section,
+        threadCount: sectionThreads.length,
+        replyCount,
+      };
+    }),
+    threads,
+    replies,
+    generatedAt: new Date().toISOString(),
+    source: "seed-json",
+  });
+
+  const getRuntimeStatus = (): ForumRuntimeStatus => ({
+    service: "forum",
+    dataSource: "seed-json",
+    persistenceMode: "seed-only",
+    databaseConfigured: Boolean(process.env.FORUM_DATABASE_URL?.trim()),
+    counts: {
+      sections: sections.length,
+      threads: threads.length,
+      replies: replies.length,
+    },
+    generatedAt: new Date().toISOString(),
+  });
+
+  return {
+    dataSource: "seed-json",
+    persistenceMode: "seed-only",
+    getSections: () => sections,
+    getThreads: () => threads,
+    getReplies: () => replies,
+    getSectionBySlug,
+    getThreadBySlug,
+    getThreadsBySection,
+    getRepliesByThreadSlug,
+    getThreadDetailBySlug,
+    getSnapshot,
+    getRuntimeStatus,
+  };
+}


### PR DESCRIPTION
## 问题

`forum/` 现在已经有独立页面骨架、结构化 seed 内容和容器构建基线，但当前离“可持续接真实数据层、也能被部署流程可靠检查”还差一小步：

- 页面和 API 仍然直接依赖 seed 内容 helper，没有一个显式的论坛数据源边界
- 容器检查当前只验证 `docker build`，还没有确认论坛进程真的能启动并对外返回可用响应
- 后续接数据库、发帖和首条回复流程时，还缺一个稳定的运行时状态入口去帮助部署和 smoke check

这会让论坛项目继续推进时，数据层边界和部署检查都比较模糊。

## 这次改动

- 重构 `forum/src/lib/forum-data.ts`
  - 抽出 `ForumRepository`、`ForumSnapshot`、`ForumThreadDetail` 和 `ForumRuntimeStatus`
  - 让页面和路由改为通过统一的论坛仓储边界读取数据
- 新增 `forum/src/lib/forum-seed-repository.ts`
  - 把当前 `forum-content.json` 的 seed 读取实现收口成独立仓储实现
  - 在这里统一产出 `seed-json` 数据源、线程详情、统计快照和运行时状态
- 新增 `GET /api/status`
  - 返回论坛服务名、当前数据源、持久化模式、数据库配置存在性和基础计数
  - 作为容器和后续部署的 smoke-check 入口
- 新增 `forum/.env.example`
  - 把 `FORUM_DATA_SOURCE` 默认值和后续 `FORUM_DATABASE_URL` 预留位显式化
- 更新 `forum/src/app/page.tsx` 和 `forum/src/app/threads/page.tsx`
  - 改为从统一 snapshot 读取数据，而不是直接抓静态导出数组
- 更新 `forum/README.md`
  - 补齐运行时边界、状态路由和本地 smoke check 说明
- 更新 `.github/workflows/forum-container-checks.yml`
  - 在镜像构建后启动论坛容器
  - 直接请求 `/api/status`
  - 校验返回的 `service / dataSource / persistenceMode`

## 为什么现在做

当前论坛最需要的不是再多一页静态内容，而是把“当前这套 seed 内容是如何被应用消费的”和“容器上线后怎样确认它真的活着”这两件事收清楚。

这一步的价值比较直接：

- 后续把 `seed-json` 换成真实数据库时，不需要先返工页面和 API 的读取方式
- 论坛容器检查不再停留在“镜像能 build”，而是开始验证“服务能启动并返回预期状态”
- 独立部署、数据层接入和后续发帖流，都多了一个明确的运行时边界可承接

## 验证

- compare 已确认分支相对 `main`：`behind_by = 0`
- 改动范围收敛在 8 个文件，只涉及 `forum/**` 和论坛专用容器检查 workflow
- 已回读关键文件，确认：
  - `forum-data.ts` 已转为论坛仓储边界 facade
  - `forum-seed-repository.ts` 已独立承接当前 seed 数据实现
  - `GET /api/status` 已返回论坛运行时状态
  - `forum-container-checks.yml` 已在 build 后启动容器并校验状态接口
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build` 或本地 `docker run`；最终验证依赖仓库 Actions：
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 在当前 `ForumRepository` 边界上接入第一版 durable storage，实现线程与首条回复的真实写入路径
- 把 `FORUM_DATABASE_URL` 从预留配置推进到真实数据库连接和 schema 初始化
- 在 `GET /api/status` 基础上继续补最小健康检查和部署观测字段