### PR TITLE
feat(forum): bootstrap sqlite storage and thread creation path

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -30,10 +30,15 @@ jobs:
       - name: Build forum container image
         run: docker build -t fabushi-forum ./forum
 
-      - name: Start forum container
-        run: docker run -d --rm --name fabushi-forum-check -p 3000:3000 fabushi-forum
+      - name: Start forum container in sqlite mode
+        run: |
+          docker run -d --rm --name fabushi-forum-check \
+            -e FORUM_DATA_SOURCE=sqlite \
+            -e FORUM_DATABASE_URL=file:/tmp/forum.db \
+            -p 3000:3000 \
+            fabushi-forum
 
-      - name: Smoke test forum status endpoint
+      - name: Smoke test forum sqlite status endpoint
         run: |
           for attempt in 1 2 3 4 5; do
             response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)" && break
@@ -52,8 +57,57 @@ jobs:
 
           payload = json.loads(os.environ["FORUM_STATUS_RESPONSE"])
           assert payload["service"] == "forum", payload
-          assert payload["dataSource"] == "seed-json", payload
-          assert payload["persistenceMode"] == "seed-only", payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["writesEnabled"] is True, payload
+          assert payload["counts"]["threads"] >= 4, payload
+          PY
+
+      - name: Smoke test forum thread creation endpoint
+        run: |
+          response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/threads \
+            -H 'content-type: application/json' \
+            --data '{
+              "sectionSlug": "newcomer-path",
+              "title": "建立稳定作息时，先固定早课还是先固定睡前复盘？",
+              "author": "容器检查",
+              "summary": "想验证 sqlite 写入路径是否能承接真实线程创建。",
+              "tags": ["新手", "作息"],
+              "openingPost": ["这条帖子是容器检查创建的，用来确认论坛第一版 durable storage 已经可写。"]
+            }')"
+
+          echo "$response"
+          FORUM_CREATE_RESPONSE="$response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_CREATE_RESPONSE"])
+          assert payload["source"] == "sqlite", payload
+          assert payload["thread"]["sectionSlug"] == "newcomer-path", payload
+          assert payload["thread"]["title"].startswith("建立稳定作息时"), payload
+          assert payload["thread"]["openingPost"], payload
+          print(payload["thread"]["slug"])
+          PY
+
+          slug="$(FORUM_CREATE_RESPONSE="$response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_CREATE_RESPONSE"])
+          print(payload["thread"]["slug"])
+          PY
+          )"
+
+          detail="$(curl --fail --show-error --silent "http://127.0.0.1:3000/api/thread/${slug}")"
+          echo "$detail"
+          FORUM_DETAIL_RESPONSE="$detail" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_DETAIL_RESPONSE"])
+          assert payload["source"] == "sqlite", payload
+          assert payload["thread"]["slug"], payload
+          assert payload["thread"]["author"] == "容器检查", payload
           PY
 
       - name: Stop forum container

--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -112,4 +112,4 @@ jobs:
 
       - name: Stop forum container
         if: always()
-        run: docker stop fabushi-forum-check
+        run: docker stop fabushi-forum-check || true

--- a/forum/.env.example
+++ b/forum/.env.example
@@ -1,5 +1,5 @@
-# Current supported value: seed-json
+# Supported values: seed-json | sqlite
 FORUM_DATA_SOURCE=seed-json
 
-# Reserved for the first durable persistence pass.
-FORUM_DATABASE_URL=
+# Optional in seed-json mode. When sqlite is enabled, a file: URL is recommended.
+FORUM_DATABASE_URL=file:./data/forum.db

--- a/forum/README.md
+++ b/forum/README.md
@@ -13,10 +13,11 @@ Current scope:
 - forum domain helpers under `forum/src/lib/forum-data.ts`
 - a repository boundary that keeps page rendering and API routes behind one forum data source contract
 - read-only routes for thread listing, thread detail, and runtime status
-- JSON routes for the same seed contract, including reply data on thread detail
+- a sqlite-backed repository option that can bootstrap from the current seed content
+- a minimal thread-creation API when sqlite mode is enabled
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
-- a container smoke check that starts the forum and hits `/api/status`
+- a container smoke check that starts the forum, validates `/api/status`, and exercises sqlite thread creation
 
 ## Current product boundary
 
@@ -31,14 +32,15 @@ Included:
 - read-only API boundary
 - moderation and knowledge-stage fields reserved in the content model
 - a runtime status endpoint for deployment smoke checks
+- a first durable persistence path backed by sqlite file storage
 - standalone server artifact for container packaging
 
 Not included yet:
 
 - authentication
-- posting or replying
-- durable persistence layer
+- reply creation
 - search, notifications, bookmarks, or follows as real user actions
+- moderation workflows beyond reserved fields and write-state checks
 
 ## Local development
 
@@ -59,22 +61,36 @@ pnpm typecheck
 pnpm build
 pnpm start:standalone
 curl http://localhost:3000/api/status
+curl -X POST http://localhost:3000/api/threads \
+  -H 'content-type: application/json' \
+  -d '{
+    "sectionSlug": "newcomer-path",
+    "title": "想建立稳定作息，该从哪一步开始？",
+    "author": "测试用户",
+    "summary": "先把最小作息和听闻节奏稳定下来。",
+    "tags": ["新手", "作息"],
+    "openingPost": ["我目前还没有固定作息，想先把每天最小的修学节奏建立起来。"]
+  }'
 ```
 
 ## Runtime contract
 
-The forum currently runs in `seed-json` mode, but the page layer and API routes no longer read the JSON file directly. They now go through a single repository boundary, so the first durable database pass can replace the data source without rewriting the route or page structure.
+The forum still defaults to `seed-json` mode, but the page layer and API routes no longer read the JSON file directly. They now go through a single repository boundary, so durable storage can replace the seed source without rewriting the route or page structure.
 
-Current runtime fields:
+Supported runtime fields:
 
 - `FORUM_DATA_SOURCE=seed-json`
-- `FORUM_DATABASE_URL=` reserved for the first durable persistence pass
+- `FORUM_DATA_SOURCE=sqlite`
+- `FORUM_DATABASE_URL=file:./data/forum.db`
 
 Current JSON routes:
 
 - `GET /api/threads`
+- `POST /api/threads`
 - `GET /api/thread/[slug]`
 - `GET /api/status`
+
+`GET /api/status` now reports whether writes are enabled for the current data source. In `sqlite` mode, the repository initializes its schema automatically and seeds the database from `forum-content.json` the first time it starts.
 
 ## Container deployment
 
@@ -84,7 +100,10 @@ Build and run locally with Docker:
 
 ```bash
 docker build -t fabushi-forum ./forum
-docker run --rm -p 3000:3000 fabushi-forum
+docker run --rm -p 3000:3000 \
+  -e FORUM_DATA_SOURCE=sqlite \
+  -e FORUM_DATABASE_URL=file:/tmp/forum.db \
+  fabushi-forum
 curl http://localhost:3000/api/status
 ```
 
@@ -94,8 +113,8 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, and then verifies the container actually serves the runtime status endpoint.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, and creates a thread through the API to confirm the first durable storage path is working.
 
 ## Why this is the next step
 
-After the structured seed content contract and standalone deployment baseline landed, the next highest-value gap was a clear runtime boundary for the forum's first persistent data source. This iteration keeps the current seed-backed product surface intact while making the data source explicit and adding a smoke-testable runtime endpoint, so the next pass can attach posting flow and durable storage without guessing where that boundary should live.
+After the structured seed content contract, standalone deployment baseline, and runtime status boundary landed, the next highest-value gap was a durable storage path that the deploy flow could actually exercise. This iteration keeps the existing product surface intact while adding a real sqlite-backed repository, a first write endpoint, and a smoke-checkable persistence mode. That gives the next pass a stable place to add replies, moderation events, and database-backed user workflows.

--- a/forum/src/app/api/threads/route.ts
+++ b/forum/src/app/api/threads/route.ts
@@ -1,5 +1,82 @@
 import { NextResponse } from "next/server";
-import { getForumSnapshot } from "../../../lib/forum-data";
+import {
+  type CreateForumThreadInput,
+  ForumInputError,
+  ForumWriteUnavailableError,
+  createForumThread,
+  getForumSnapshot,
+} from "../../../lib/forum-data";
+
+interface CreateThreadPayload {
+  sectionSlug?: unknown;
+  title?: unknown;
+  summary?: unknown;
+  author?: unknown;
+  tags?: unknown;
+  openingPost?: unknown;
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new ForumInputError(`${fieldName} must be a string.`);
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    throw new ForumInputError(`${fieldName} is required.`);
+  }
+
+  return trimmed;
+}
+
+function normalizeStringArray(value: unknown, fieldName: string): string[] {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new ForumInputError(`${fieldName} must be a string or string array.`);
+  }
+
+  const normalized = value
+    .map((entry) => {
+      if (typeof entry !== "string") {
+        throw new ForumInputError(`${fieldName} entries must be strings.`);
+      }
+
+      return entry.trim();
+    })
+    .filter(Boolean);
+
+  return normalized;
+}
+
+function parseCreateThreadPayload(payload: CreateThreadPayload): CreateForumThreadInput {
+  const sectionSlug = requireString(payload.sectionSlug, "sectionSlug");
+  const title = requireString(payload.title, "title");
+  const author = requireString(payload.author, "author");
+  const openingPost = normalizeStringArray(payload.openingPost, "openingPost");
+
+  if (openingPost.length === 0) {
+    throw new ForumInputError("openingPost must contain at least one paragraph.");
+  }
+
+  const summary = typeof payload.summary === "string" && payload.summary.trim().length > 0
+    ? payload.summary.trim()
+    : openingPost[0].slice(0, 140);
+  const tags = payload.tags === undefined ? [] : normalizeStringArray(payload.tags, "tags");
+
+  return {
+    sectionSlug,
+    title,
+    summary,
+    author,
+    tags,
+    openingPost,
+  };
+}
 
 export async function GET() {
   return NextResponse.json(getForumSnapshot(), {
@@ -7,4 +84,38 @@ export async function GET() {
       "cache-control": "public, max-age=300, s-maxage=300",
     },
   });
+}
+
+export async function POST(request: Request) {
+  let payload: CreateThreadPayload;
+
+  try {
+    payload = (await request.json()) as CreateThreadPayload;
+  } catch {
+    return NextResponse.json({ error: "Request body must be valid JSON." }, { status: 400 });
+  }
+
+  try {
+    const createdThread = createForumThread(parseCreateThreadPayload(payload));
+
+    return NextResponse.json(createdThread, {
+      status: 201,
+      headers: {
+        "cache-control": "no-store",
+        location: `/api/thread/${createdThread.thread.slug}`,
+        "x-forum-data-source": createdThread.source,
+      },
+    });
+  } catch (error) {
+    if (error instanceof ForumInputError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    if (error instanceof ForumWriteUnavailableError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("Failed to create forum thread", error);
+    return NextResponse.json({ error: "Unable to create forum thread." }, { status: 500 });
+  }
 }

--- a/forum/src/lib/forum-data.ts
+++ b/forum/src/lib/forum-data.ts
@@ -1,7 +1,8 @@
 import { createSeedForumRepository } from "./forum-seed-repository";
+import { createSqliteForumRepository } from "./forum-sqlite-repository";
 
-export type ForumDataSource = "seed-json";
-export type ForumPersistenceMode = "seed-only";
+export type ForumDataSource = "seed-json" | "sqlite";
+export type ForumPersistenceMode = "seed-only" | "sqlite-file";
 export type ForumModerationState = "published" | "needs-review" | "archived";
 export type ForumKnowledgeStage = "discussion" | "candidate" | "archived";
 
@@ -63,17 +64,41 @@ export interface ForumSnapshot {
   source: ForumDataSource;
 }
 
+export interface CreateForumThreadInput {
+  sectionSlug: string;
+  title: string;
+  summary: string;
+  author: string;
+  tags: string[];
+  openingPost: string[];
+}
+
 export interface ForumRuntimeStatus {
   service: "forum";
   dataSource: ForumDataSource;
   persistenceMode: ForumPersistenceMode;
   databaseConfigured: boolean;
+  writesEnabled: boolean;
   counts: {
     sections: number;
     threads: number;
     replies: number;
   };
   generatedAt: string;
+}
+
+export class ForumWriteUnavailableError extends Error {
+  constructor(message = "Forum writes are not enabled for the current data source.") {
+    super(message);
+    this.name = "ForumWriteUnavailableError";
+  }
+}
+
+export class ForumInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ForumInputError";
+  }
 }
 
 export interface ForumRepository {
@@ -89,9 +114,34 @@ export interface ForumRepository {
   getThreadDetailBySlug(slug: string): ForumThreadDetail | undefined;
   getSnapshot(): ForumSnapshot;
   getRuntimeStatus(): ForumRuntimeStatus;
+  createThread(input: CreateForumThreadInput): ForumThreadDetail;
 }
 
-const forumRepository = createSeedForumRepository();
+function resolveForumDataSource(): ForumDataSource {
+  const configuredSource = process.env.FORUM_DATA_SOURCE?.trim();
+
+  if (!configuredSource || configuredSource === "seed-json") {
+    return "seed-json";
+  }
+
+  if (configuredSource === "sqlite") {
+    return "sqlite";
+  }
+
+  throw new Error(`Unsupported FORUM_DATA_SOURCE: ${configuredSource}`);
+}
+
+function createForumRepository(): ForumRepository {
+  const dataSource = resolveForumDataSource();
+
+  if (dataSource === "sqlite") {
+    return createSqliteForumRepository();
+  }
+
+  return createSeedForumRepository();
+}
+
+const forumRepository = createForumRepository();
 
 export const FORUM_DATA_SOURCE = forumRepository.dataSource;
 export const FORUM_PERSISTENCE_MODE = forumRepository.persistenceMode;
@@ -122,4 +172,8 @@ export function getForumSnapshot() {
 
 export function getForumRuntimeStatus() {
   return forumRepository.getRuntimeStatus();
+}
+
+export function createForumThread(input: CreateForumThreadInput) {
+  return forumRepository.createThread(input);
 }

--- a/forum/src/lib/forum-seed-repository.ts
+++ b/forum/src/lib/forum-seed-repository.ts
@@ -1,5 +1,6 @@
 import forumContent from "../data/forum-content.json";
 import type {
+  CreateForumThreadInput,
   ForumReply,
   ForumRepository,
   ForumRuntimeStatus,
@@ -8,6 +9,7 @@ import type {
   ForumThread,
   ForumThreadDetail,
 } from "./forum-data";
+import { ForumWriteUnavailableError } from "./forum-data";
 
 interface ForumContentStore {
   sections: ForumSection[];
@@ -65,6 +67,7 @@ export function createSeedForumRepository(): ForumRepository {
     dataSource: "seed-json",
     persistenceMode: "seed-only",
     databaseConfigured: Boolean(process.env.FORUM_DATABASE_URL?.trim()),
+    writesEnabled: false,
     counts: {
       sections: sections.length,
       threads: threads.length,
@@ -72,6 +75,10 @@ export function createSeedForumRepository(): ForumRepository {
     },
     generatedAt: new Date().toISOString(),
   });
+
+  const createThread = (_input: CreateForumThreadInput): ForumThreadDetail => {
+    throw new ForumWriteUnavailableError("Thread creation is only available when FORUM_DATA_SOURCE=sqlite.");
+  };
 
   return {
     dataSource: "seed-json",
@@ -86,5 +93,6 @@ export function createSeedForumRepository(): ForumRepository {
     getThreadDetailBySlug,
     getSnapshot,
     getRuntimeStatus,
+    createThread,
   };
 }

--- a/forum/src/lib/forum-sqlite-repository.ts
+++ b/forum/src/lib/forum-sqlite-repository.ts
@@ -1,0 +1,599 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import forumContent from "../data/forum-content.json";
+import type {
+  CreateForumThreadInput,
+  ForumReply,
+  ForumRepository,
+  ForumRuntimeStatus,
+  ForumSection,
+  ForumSnapshot,
+  ForumThread,
+  ForumThreadDetail,
+} from "./forum-data";
+import { ForumInputError } from "./forum-data";
+
+interface ForumContentStore {
+  sections: ForumSection[];
+  threads: ForumThread[];
+  replies: ForumReply[];
+}
+
+interface SqliteSectionRow {
+  slug: string;
+  name: string;
+  description: string;
+  moderation_focus: string;
+  posting_prompt: string;
+}
+
+interface SqliteThreadRow {
+  slug: string;
+  section_slug: string;
+  title: string;
+  summary: string;
+  author: string;
+  published_at: string;
+  last_activity: string;
+  reply_count: number;
+  follow_count: number;
+  bookmark_count: number;
+  tags_json: string;
+  opening_post_json: string;
+  takeaways_json: string;
+  moderation_state: ForumThread["moderationState"];
+  knowledge_stage: ForumThread["knowledgeStage"];
+}
+
+interface SqliteReplyRow {
+  id: string;
+  thread_slug: string;
+  author: string;
+  role_label: string;
+  published_at: string;
+  moderation_state: ForumReply["moderationState"];
+  trust_signal: string;
+  body_json: string;
+}
+
+const seedContent = forumContent as ForumContentStore;
+const DEFAULT_DATABASE_URL = "file:./data/forum.db";
+
+function parseJsonArray(value: string): string[] {
+  const parsed = JSON.parse(value) as unknown;
+  return Array.isArray(parsed) ? parsed.map((item) => String(item)) : [];
+}
+
+function mapSection(row: SqliteSectionRow): ForumSection {
+  return {
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    moderationFocus: row.moderation_focus,
+    postingPrompt: row.posting_prompt,
+  };
+}
+
+function mapThread(row: SqliteThreadRow): ForumThread {
+  return {
+    slug: row.slug,
+    sectionSlug: row.section_slug,
+    title: row.title,
+    summary: row.summary,
+    author: row.author,
+    publishedAt: row.published_at,
+    lastActivity: row.last_activity,
+    replyCount: Number(row.reply_count),
+    followCount: Number(row.follow_count),
+    bookmarkCount: Number(row.bookmark_count),
+    tags: parseJsonArray(row.tags_json),
+    openingPost: parseJsonArray(row.opening_post_json),
+    takeaways: parseJsonArray(row.takeaways_json),
+    moderationState: row.moderation_state,
+    knowledgeStage: row.knowledge_stage,
+  };
+}
+
+function mapReply(row: SqliteReplyRow): ForumReply {
+  return {
+    id: row.id,
+    threadSlug: row.thread_slug,
+    author: row.author,
+    roleLabel: row.role_label,
+    publishedAt: row.published_at,
+    moderationState: row.moderation_state,
+    trustSignal: row.trust_signal,
+    body: parseJsonArray(row.body_json),
+  };
+}
+
+function resolveSqliteDatabasePath(databaseUrl: string): string {
+  const trimmedUrl = databaseUrl.trim();
+
+  if (!trimmedUrl) {
+    throw new Error("FORUM_DATABASE_URL cannot be empty when FORUM_DATA_SOURCE=sqlite.");
+  }
+
+  const withoutPrefix = trimmedUrl.startsWith("file:") ? trimmedUrl.slice(5) : trimmedUrl;
+
+  if (!withoutPrefix || withoutPrefix === ":memory:") {
+    return withoutPrefix;
+  }
+
+  const normalizedPath = withoutPrefix.startsWith("//") ? withoutPrefix.slice(2) : withoutPrefix;
+
+  return path.isAbsolute(normalizedPath)
+    ? normalizedPath
+    : path.resolve(process.cwd(), normalizedPath);
+}
+
+function ensureDatabaseDirectory(databasePath: string) {
+  if (!databasePath || databasePath === ":memory:") {
+    return;
+  }
+
+  mkdirSync(path.dirname(databasePath), { recursive: true });
+}
+
+function slugifyTitle(title: string): string {
+  const normalized = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (normalized) {
+    return normalized;
+  }
+
+  return `thread-${Date.now().toString(36)}`;
+}
+
+function initializeSchema(database: DatabaseSync) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS forum_sections (
+      slug TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      moderation_focus TEXT NOT NULL,
+      posting_prompt TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS forum_threads (
+      slug TEXT PRIMARY KEY,
+      section_slug TEXT NOT NULL,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      author TEXT NOT NULL,
+      published_at TEXT NOT NULL,
+      last_activity TEXT NOT NULL,
+      reply_count INTEGER NOT NULL DEFAULT 0,
+      follow_count INTEGER NOT NULL DEFAULT 0,
+      bookmark_count INTEGER NOT NULL DEFAULT 0,
+      tags_json TEXT NOT NULL,
+      opening_post_json TEXT NOT NULL,
+      takeaways_json TEXT NOT NULL,
+      moderation_state TEXT NOT NULL,
+      knowledge_stage TEXT NOT NULL,
+      FOREIGN KEY (section_slug) REFERENCES forum_sections(slug)
+    );
+
+    CREATE TABLE IF NOT EXISTS forum_replies (
+      id TEXT PRIMARY KEY,
+      thread_slug TEXT NOT NULL,
+      author TEXT NOT NULL,
+      role_label TEXT NOT NULL,
+      published_at TEXT NOT NULL,
+      moderation_state TEXT NOT NULL,
+      trust_signal TEXT NOT NULL,
+      body_json TEXT NOT NULL,
+      FOREIGN KEY (thread_slug) REFERENCES forum_threads(slug)
+    );
+  `);
+}
+
+function seedDatabaseIfEmpty(database: DatabaseSync) {
+  const countRow = database.prepare("SELECT COUNT(*) AS count FROM forum_sections").get() as { count: number };
+
+  if (Number(countRow.count) > 0) {
+    return;
+  }
+
+  const insertSection = database.prepare(`
+    INSERT INTO forum_sections (slug, name, description, moderation_focus, posting_prompt)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+  const insertThread = database.prepare(`
+    INSERT INTO forum_threads (
+      slug,
+      section_slug,
+      title,
+      summary,
+      author,
+      published_at,
+      last_activity,
+      reply_count,
+      follow_count,
+      bookmark_count,
+      tags_json,
+      opening_post_json,
+      takeaways_json,
+      moderation_state,
+      knowledge_stage
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const insertReply = database.prepare(`
+    INSERT INTO forum_replies (
+      id,
+      thread_slug,
+      author,
+      role_label,
+      published_at,
+      moderation_state,
+      trust_signal,
+      body_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  database.exec("BEGIN");
+
+  try {
+    for (const section of seedContent.sections) {
+      insertSection.run(
+        section.slug,
+        section.name,
+        section.description,
+        section.moderationFocus,
+        section.postingPrompt,
+      );
+    }
+
+    for (const thread of seedContent.threads) {
+      insertThread.run(
+        thread.slug,
+        thread.sectionSlug,
+        thread.title,
+        thread.summary,
+        thread.author,
+        thread.publishedAt,
+        thread.lastActivity,
+        thread.replyCount,
+        thread.followCount,
+        thread.bookmarkCount,
+        JSON.stringify(thread.tags),
+        JSON.stringify(thread.openingPost),
+        JSON.stringify(thread.takeaways),
+        thread.moderationState,
+        thread.knowledgeStage,
+      );
+    }
+
+    for (const reply of seedContent.replies) {
+      insertReply.run(
+        reply.id,
+        reply.threadSlug,
+        reply.author,
+        reply.roleLabel,
+        reply.publishedAt,
+        reply.moderationState,
+        reply.trustSignal,
+        JSON.stringify(reply.body),
+      );
+    }
+
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function nextThreadSlug(database: DatabaseSync, title: string): string {
+  const baseSlug = slugifyTitle(title);
+  const existingThread = database.prepare("SELECT slug FROM forum_threads WHERE slug = ? LIMIT 1");
+
+  if (!existingThread.get(baseSlug)) {
+    return baseSlug;
+  }
+
+  let suffix = 2;
+
+  while (existingThread.get(`${baseSlug}-${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${baseSlug}-${suffix}`;
+}
+
+export function createSqliteForumRepository(): ForumRepository {
+  const databasePath = resolveSqliteDatabasePath(process.env.FORUM_DATABASE_URL?.trim() || DEFAULT_DATABASE_URL);
+  ensureDatabaseDirectory(databasePath);
+
+  const database = new DatabaseSync(databasePath);
+  database.exec("PRAGMA foreign_keys = ON");
+  initializeSchema(database);
+  seedDatabaseIfEmpty(database);
+
+  const getSections = (): ForumSection[] => {
+    const rows = database
+      .prepare("SELECT slug, name, description, moderation_focus, posting_prompt FROM forum_sections ORDER BY name ASC")
+      .all() as SqliteSectionRow[];
+
+    return rows.map(mapSection);
+  };
+
+  const getThreads = (): ForumThread[] => {
+    const rows = database
+      .prepare(`
+        SELECT
+          slug,
+          section_slug,
+          title,
+          summary,
+          author,
+          published_at,
+          last_activity,
+          reply_count,
+          follow_count,
+          bookmark_count,
+          tags_json,
+          opening_post_json,
+          takeaways_json,
+          moderation_state,
+          knowledge_stage
+        FROM forum_threads
+        ORDER BY published_at DESC, slug DESC
+      `)
+      .all() as SqliteThreadRow[];
+
+    return rows.map(mapThread);
+  };
+
+  const getReplies = (): ForumReply[] => {
+    const rows = database
+      .prepare(`
+        SELECT
+          id,
+          thread_slug,
+          author,
+          role_label,
+          published_at,
+          moderation_state,
+          trust_signal,
+          body_json
+        FROM forum_replies
+        ORDER BY published_at ASC, id ASC
+      `)
+      .all() as SqliteReplyRow[];
+
+    return rows.map(mapReply);
+  };
+
+  const getSectionBySlug = (slug: string): ForumSection | undefined => {
+    const row = database
+      .prepare("SELECT slug, name, description, moderation_focus, posting_prompt FROM forum_sections WHERE slug = ? LIMIT 1")
+      .get(slug) as SqliteSectionRow | undefined;
+
+    return row ? mapSection(row) : undefined;
+  };
+
+  const getThreadBySlug = (slug: string): ForumThread | undefined => {
+    const row = database
+      .prepare(`
+        SELECT
+          slug,
+          section_slug,
+          title,
+          summary,
+          author,
+          published_at,
+          last_activity,
+          reply_count,
+          follow_count,
+          bookmark_count,
+          tags_json,
+          opening_post_json,
+          takeaways_json,
+          moderation_state,
+          knowledge_stage
+        FROM forum_threads
+        WHERE slug = ?
+        LIMIT 1
+      `)
+      .get(slug) as SqliteThreadRow | undefined;
+
+    return row ? mapThread(row) : undefined;
+  };
+
+  const getThreadsBySection = (sectionSlug: string): ForumThread[] => {
+    const rows = database
+      .prepare(`
+        SELECT
+          slug,
+          section_slug,
+          title,
+          summary,
+          author,
+          published_at,
+          last_activity,
+          reply_count,
+          follow_count,
+          bookmark_count,
+          tags_json,
+          opening_post_json,
+          takeaways_json,
+          moderation_state,
+          knowledge_stage
+        FROM forum_threads
+        WHERE section_slug = ?
+        ORDER BY published_at DESC, slug DESC
+      `)
+      .all(sectionSlug) as SqliteThreadRow[];
+
+    return rows.map(mapThread);
+  };
+
+  const getRepliesByThreadSlug = (threadSlug: string): ForumReply[] => {
+    const rows = database
+      .prepare(`
+        SELECT
+          id,
+          thread_slug,
+          author,
+          role_label,
+          published_at,
+          moderation_state,
+          trust_signal,
+          body_json
+        FROM forum_replies
+        WHERE thread_slug = ?
+        ORDER BY published_at ASC, id ASC
+      `)
+      .all(threadSlug) as SqliteReplyRow[];
+
+    return rows.map(mapReply);
+  };
+
+  const getThreadDetailBySlug = (slug: string): ForumThreadDetail | undefined => {
+    const thread = getThreadBySlug(slug);
+
+    if (!thread) {
+      return undefined;
+    }
+
+    return {
+      thread,
+      section: getSectionBySlug(thread.sectionSlug),
+      replies: getRepliesByThreadSlug(thread.slug),
+      source: "sqlite",
+      generatedAt: new Date().toISOString(),
+    };
+  };
+
+  const getSnapshot = (): ForumSnapshot => {
+    const sections = getSections();
+    const threads = getThreads();
+    const replies = getReplies();
+
+    return {
+      sections: sections.map((section) => {
+        const sectionThreads = threads.filter((thread) => thread.sectionSlug === section.slug);
+        const replyCount = sectionThreads.reduce((total, thread) => total + replies.filter((reply) => reply.threadSlug === thread.slug).length, 0);
+
+        return {
+          ...section,
+          threadCount: sectionThreads.length,
+          replyCount,
+        };
+      }),
+      threads,
+      replies,
+      generatedAt: new Date().toISOString(),
+      source: "sqlite",
+    };
+  };
+
+  const getRuntimeStatus = (): ForumRuntimeStatus => {
+    const countsRow = database
+      .prepare(`
+        SELECT
+          (SELECT COUNT(*) FROM forum_sections) AS sections,
+          (SELECT COUNT(*) FROM forum_threads) AS threads,
+          (SELECT COUNT(*) FROM forum_replies) AS replies
+      `)
+      .get() as { sections: number; threads: number; replies: number };
+
+    return {
+      service: "forum",
+      dataSource: "sqlite",
+      persistenceMode: "sqlite-file",
+      databaseConfigured: true,
+      writesEnabled: true,
+      counts: {
+        sections: Number(countsRow.sections),
+        threads: Number(countsRow.threads),
+        replies: Number(countsRow.replies),
+      },
+      generatedAt: new Date().toISOString(),
+    };
+  };
+
+  const createThread = (input: CreateForumThreadInput): ForumThreadDetail => {
+    const section = getSectionBySlug(input.sectionSlug);
+
+    if (!section) {
+      throw new ForumInputError(`Forum section "${input.sectionSlug}" does not exist.`);
+    }
+
+    const slug = nextThreadSlug(database, input.title);
+    const createdAt = new Date().toISOString();
+    const openingPost = input.openingPost.filter((paragraph) => paragraph.trim().length > 0);
+
+    if (openingPost.length === 0) {
+      throw new ForumInputError("Thread openingPost must contain at least one non-empty paragraph.");
+    }
+
+    database.prepare(`
+      INSERT INTO forum_threads (
+        slug,
+        section_slug,
+        title,
+        summary,
+        author,
+        published_at,
+        last_activity,
+        reply_count,
+        follow_count,
+        bookmark_count,
+        tags_json,
+        opening_post_json,
+        takeaways_json,
+        moderation_state,
+        knowledge_stage
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      slug,
+      input.sectionSlug,
+      input.title,
+      input.summary,
+      input.author,
+      createdAt,
+      "刚刚创建",
+      0,
+      0,
+      0,
+      JSON.stringify(input.tags),
+      JSON.stringify(openingPost),
+      JSON.stringify([]),
+      "published",
+      "discussion",
+    );
+
+    const createdDetail = getThreadDetailBySlug(slug);
+
+    if (!createdDetail) {
+      throw new Error("Created thread could not be reloaded from sqlite storage.");
+    }
+
+    return createdDetail;
+  };
+
+  return {
+    dataSource: "sqlite",
+    persistenceMode: "sqlite-file",
+    getSections,
+    getThreads,
+    getReplies,
+    getSectionBySlug,
+    getThreadBySlug,
+    getThreadsBySection,
+    getRepliesByThreadSlug,
+    getThreadDetailBySlug,
+    getSnapshot,
+    getRuntimeStatus,
+    createThread,
+  };
+}

--- a/forum/src/lib/forum-sqlite-repository.ts
+++ b/forum/src/lib/forum-sqlite-repository.ts
@@ -323,7 +323,7 @@ export function createSqliteForumRepository(): ForumRepository {
   const getSections = (): ForumSection[] => {
     const rows = database
       .prepare("SELECT slug, name, description, moderation_focus, posting_prompt FROM forum_sections ORDER BY name ASC")
-      .all() as SqliteSectionRow[];
+      .all() as unknown as SqliteSectionRow[];
 
     return rows.map(mapSection);
   };
@@ -350,7 +350,7 @@ export function createSqliteForumRepository(): ForumRepository {
         FROM forum_threads
         ORDER BY published_at DESC, slug DESC
       `)
-      .all() as SqliteThreadRow[];
+      .all() as unknown as SqliteThreadRow[];
 
     return rows.map(mapThread);
   };
@@ -370,7 +370,7 @@ export function createSqliteForumRepository(): ForumRepository {
         FROM forum_replies
         ORDER BY published_at ASC, id ASC
       `)
-      .all() as SqliteReplyRow[];
+      .all() as unknown as SqliteReplyRow[];
 
     return rows.map(mapReply);
   };
@@ -434,7 +434,7 @@ export function createSqliteForumRepository(): ForumRepository {
         WHERE section_slug = ?
         ORDER BY published_at DESC, slug DESC
       `)
-      .all(sectionSlug) as SqliteThreadRow[];
+      .all(sectionSlug) as unknown as SqliteThreadRow[];
 
     return rows.map(mapThread);
   };
@@ -455,7 +455,7 @@ export function createSqliteForumRepository(): ForumRepository {
         WHERE thread_slug = ?
         ORDER BY published_at ASC, id ASC
       `)
-      .all(threadSlug) as SqliteReplyRow[];
+      .all(threadSlug) as unknown as SqliteReplyRow[];
 
     return rows.map(mapReply);
   };

--- a/forum/src/lib/forum-sqlite-repository.ts
+++ b/forum/src/lib/forum-sqlite-repository.ts
@@ -117,7 +117,11 @@ function resolveSqliteDatabasePath(databaseUrl: string): string {
 
   const withoutPrefix = trimmedUrl.startsWith("file:") ? trimmedUrl.slice(5) : trimmedUrl;
 
-  if (!withoutPrefix || withoutPrefix === ":memory:") {
+  if (!withoutPrefix) {
+    throw new Error("FORUM_DATABASE_URL must point to a sqlite file path.");
+  }
+
+  if (withoutPrefix === ":memory:") {
     return withoutPrefix;
   }
 


### PR DESCRIPTION
## 问题

`forum/` 已经有独立运行时边界、容器基线和 `ForumRepository` facade，但当前论坛仍停留在 `seed-json` 只读模式：

- `FORUM_DATABASE_URL` 还只是预留位，没有任何真实持久化实现
- 部署 smoke check 只能确认论坛能启动，不能确认第一版 durable storage 真正可用
- API 还没有最小写入入口，下一步发帖、首条回复和治理状态流没有稳定承接点

这意味着论坛虽然更像独立服务了，但还没有真正跨进“可持久化、可验证的真实论坛数据层”这一步。

## 这次改动

- 扩展 `forum/src/lib/forum-data.ts`
  - 支持 `seed-json | sqlite` 两种数据源
  - 新增 `ForumInputError`、`ForumWriteUnavailableError`
  - 给仓储边界补上 `createThread()` 最小写入契约
  - 在运行时状态里增加 `writesEnabled`
- 更新 `forum/src/lib/forum-seed-repository.ts`
  - 明确 seed 仓储保持只读
  - 在写入请求下返回显式错误，而不是静默失败
- 新增 `forum/src/lib/forum-sqlite-repository.ts`
  - 使用 Node 内建 `node:sqlite` 启动 sqlite 文件数据库
  - 自动初始化 `forum_sections / forum_threads / forum_replies` 三张表
  - 首次启动时把当前 `forum-content.json` 种子内容导入 sqlite
  - 提供第一页 durable storage 的读取与 `createThread()` 写入实现
- 更新 `forum/src/app/api/threads/route.ts`
  - 保留现有 `GET /api/threads`
  - 新增 `POST /api/threads`，允许在 `sqlite` 模式下创建新主题和开场帖
  - 为输入不合法、只读模式和内部错误返回明确状态码
- 更新 `forum/.env.example`
  - 把 `sqlite` 作为显式支持的数据源
  - 给出推荐的 sqlite 文件 URL
- 更新 `forum/README.md`
  - 文档化 sqlite 模式、首条写入接口和本地 / Docker 验证方式
- 更新 `.github/workflows/forum-container-checks.yml`
  - 让容器检查以 `FORUM_DATA_SOURCE=sqlite` 启动论坛
  - 校验 `/api/status` 返回 `sqlite-file` + `writesEnabled=true`
  - 直接通过 `POST /api/threads` 创建线程，再回读详情接口确认持久化写入成功

## 为什么现在做

当前论坛最值得推进的，不是一次性接完整账户、回复树和审核系统，而是先把 `ForumRepository` 后面的第一层 durable storage 真正落下来。

这一小步的收益很集中：

- 论坛第一次有了可持续保存内容的真实后端边界，而不只是 seed 读取
- 部署与容器检查第一次能验证“服务可写”，而不只是“服务能启动”
- 下一轮继续接首条回复、治理事件和发帖表单时，不需要再返工存储抽象

## 验证

- 已回读关键文件，确认：
  - `forum-data.ts` 已支持 sqlite 数据源与写入契约
  - `forum-sqlite-repository.ts` 已包含 schema 初始化、种子导入和线程创建写入
  - `POST /api/threads` 已接到新的仓储边界
  - `forum-container-checks.yml` 已开始真实验证 sqlite 写入路径
- 当前环境无法拉取仓库本地 checkout，因而没法在本地直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build` 或容器 smoke check
- 最终验证依赖仓库现有 Actions：
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 在 sqlite 仓储上补 `POST /api/thread/[slug]/replies`，把“新建主题 + 首条回复”补成完整最小互动闭环
- 把回复治理、精华沉淀和新手引导状态推进成可持久化事件流
- 再决定 sqlite 是否作为过渡持久化层继续保留，还是迁移到更适合生产的独立数据库服务