### PR TITLE
feat(forum): add sqlite reply write path for thread interactions

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -110,6 +110,31 @@ jobs:
           assert payload["thread"]["author"] == "容器检查", payload
           PY
 
+      - name: Smoke test forum reply creation endpoint
+        run: |
+          response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/thread/first-year-stability/replies \
+            -H 'content-type: application/json' \
+            --data '{
+              "author": "容器回复检查",
+              "roleLabel": "容器检查",
+              "trustSignal": "用于确认 sqlite 回复写入路径可用。",
+              "body": ["这条回复由容器检查写入，用来确认 forum_replies 与线程计数更新已经打通。"]
+            }')"
+
+          echo "$response"
+          FORUM_REPLY_RESPONSE="$response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_REPLY_RESPONSE"])
+          assert payload["source"] == "sqlite", payload
+          assert payload["thread"]["slug"] == "first-year-stability", payload
+          assert payload["thread"]["replyCount"] >= 4, payload
+          assert payload["thread"]["lastActivity"] == "刚刚回复", payload
+          assert payload["replies"][-1]["author"] == "容器回复检查", payload
+          assert payload["replies"][-1]["body"], payload
+          PY
+
       - name: Stop forum container
         if: always()
         run: docker stop fabushi-forum-check || true

--- a/forum/README.md
+++ b/forum/README.md
@@ -15,9 +15,10 @@ Current scope:
 - read-only routes for thread listing, thread detail, and runtime status
 - a sqlite-backed repository option that can bootstrap from the current seed content
 - a minimal thread-creation API when sqlite mode is enabled
+- a minimal reply-creation API for existing threads in sqlite mode
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
-- a container smoke check that starts the forum, validates `/api/status`, and exercises sqlite thread creation
+- a container smoke check that starts the forum, validates `/api/status`, and exercises sqlite thread and reply creation
 
 ## Current product boundary
 
@@ -33,12 +34,13 @@ Included:
 - moderation and knowledge-stage fields reserved in the content model
 - a runtime status endpoint for deployment smoke checks
 - a first durable persistence path backed by sqlite file storage
+- a first reply write path for existing threads
 - standalone server artifact for container packaging
 
 Not included yet:
 
 - authentication
-- reply creation
+- reply UI in the page layer
 - search, notifications, bookmarks, or follows as real user actions
 - moderation workflows beyond reserved fields and write-state checks
 
@@ -71,6 +73,14 @@ curl -X POST http://localhost:3000/api/threads \
     "tags": ["新手", "作息"],
     "openingPost": ["我目前还没有固定作息，想先把每天最小的修学节奏建立起来。"]
   }'
+curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
+  -H 'content-type: application/json' \
+  -d '{
+    "author": "测试回复",
+    "roleLabel": "新加入同修",
+    "trustSignal": "回复已按主题聚焦提交，等待更多互动后再决定是否沉淀。",
+    "body": ["我发现先把睡前十分钟固定下来，比一下子改整天作息更容易坚持。"]
+  }'
 ```
 
 ## Runtime contract
@@ -88,9 +98,10 @@ Current JSON routes:
 - `GET /api/threads`
 - `POST /api/threads`
 - `GET /api/thread/[slug]`
+- `POST /api/thread/[slug]/replies`
 - `GET /api/status`
 
-`GET /api/status` now reports whether writes are enabled for the current data source. In `sqlite` mode, the repository initializes its schema automatically and seeds the database from `forum-content.json` the first time it starts.
+`GET /api/status` now reports whether writes are enabled for the current data source. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, and lets existing threads accept the first persisted reply submissions.
 
 ## Container deployment
 
@@ -113,8 +124,8 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, and creates a thread through the API to confirm the first durable storage path is working.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, creates a thread through the API, and adds a reply to confirm the first interaction loop is working end to end.
 
 ## Why this is the next step
 
-After the structured seed content contract, standalone deployment baseline, and runtime status boundary landed, the next highest-value gap was a durable storage path that the deploy flow could actually exercise. This iteration keeps the existing product surface intact while adding a real sqlite-backed repository, a first write endpoint, and a smoke-checkable persistence mode. That gives the next pass a stable place to add replies, moderation events, and database-backed user workflows.
+After the structured seed content contract, standalone deployment baseline, runtime status boundary, and first durable thread creation path landed, the next highest-value gap was reply persistence on top of the same sqlite boundary. This iteration keeps the product surface narrow while adding a real reply write endpoint, thread-level activity updates, and a smoke-checkable interaction loop. That gives the next pass a stable place to add moderation events, page-level reply forms, and database-backed user workflows.

--- a/forum/src/app/api/thread/[slug]/replies/route.ts
+++ b/forum/src/app/api/thread/[slug]/replies/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import {
+  type CreateForumReplyInput,
+  ForumInputError,
+  ForumWriteUnavailableError,
+  createForumReply,
+  getThreadBySlug,
+} from "../../../../../lib/forum-data";
+
+interface RouteContext {
+  params: Promise<{ slug: string }>;
+}
+
+interface CreateReplyPayload {
+  author?: unknown;
+  roleLabel?: unknown;
+  trustSignal?: unknown;
+  body?: unknown;
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new ForumInputError(`${fieldName} must be a string.`);
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    throw new ForumInputError(`${fieldName} is required.`);
+  }
+
+  return trimmed;
+}
+
+function normalizeStringArray(value: unknown, fieldName: string): string[] {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new ForumInputError(`${fieldName} must be a string or string array.`);
+  }
+
+  const normalized = value
+    .map((entry) => {
+      if (typeof entry !== "string") {
+        throw new ForumInputError(`${fieldName} entries must be strings.`);
+      }
+
+      return entry.trim();
+    })
+    .filter(Boolean);
+
+  return normalized;
+}
+
+function parseCreateReplyPayload(threadSlug: string, payload: CreateReplyPayload): CreateForumReplyInput {
+  const author = requireString(payload.author, "author");
+  const body = normalizeStringArray(payload.body, "body");
+
+  if (body.length === 0) {
+    throw new ForumInputError("body must contain at least one paragraph.");
+  }
+
+  const roleLabel = typeof payload.roleLabel === "string" && payload.roleLabel.trim().length > 0
+    ? payload.roleLabel.trim()
+    : "论坛参与者";
+  const trustSignal = typeof payload.trustSignal === "string" && payload.trustSignal.trim().length > 0
+    ? payload.trustSignal.trim()
+    : "新提交回复，等待更多互动后再判断是否适合沉淀。";
+
+  return {
+    threadSlug,
+    author,
+    roleLabel,
+    trustSignal,
+    body,
+  };
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const { slug } = await context.params;
+
+  if (!getThreadBySlug(slug)) {
+    return NextResponse.json({ error: "Thread not found" }, { status: 404 });
+  }
+
+  let payload: CreateReplyPayload;
+
+  try {
+    payload = (await request.json()) as CreateReplyPayload;
+  } catch {
+    return NextResponse.json({ error: "Request body must be valid JSON." }, { status: 400 });
+  }
+
+  try {
+    const updatedThread = createForumReply(parseCreateReplyPayload(slug, payload));
+
+    return NextResponse.json(updatedThread, {
+      status: 201,
+      headers: {
+        "cache-control": "no-store",
+        location: `/api/thread/${updatedThread.thread.slug}`,
+        "x-forum-data-source": updatedThread.source,
+      },
+    });
+  } catch (error) {
+    if (error instanceof ForumInputError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    if (error instanceof ForumWriteUnavailableError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("Failed to create forum reply", error);
+    return NextResponse.json({ error: "Unable to create forum reply." }, { status: 500 });
+  }
+}

--- a/forum/src/lib/forum-data.ts
+++ b/forum/src/lib/forum-data.ts
@@ -73,6 +73,14 @@ export interface CreateForumThreadInput {
   openingPost: string[];
 }
 
+export interface CreateForumReplyInput {
+  threadSlug: string;
+  author: string;
+  roleLabel: string;
+  trustSignal: string;
+  body: string[];
+}
+
 export interface ForumRuntimeStatus {
   service: "forum";
   dataSource: ForumDataSource;
@@ -115,6 +123,7 @@ export interface ForumRepository {
   getSnapshot(): ForumSnapshot;
   getRuntimeStatus(): ForumRuntimeStatus;
   createThread(input: CreateForumThreadInput): ForumThreadDetail;
+  createReply(input: CreateForumReplyInput): ForumThreadDetail;
 }
 
 function resolveForumDataSource(): ForumDataSource {
@@ -176,4 +185,8 @@ export function getForumRuntimeStatus() {
 
 export function createForumThread(input: CreateForumThreadInput) {
   return forumRepository.createThread(input);
+}
+
+export function createForumReply(input: CreateForumReplyInput) {
+  return forumRepository.createReply(input);
 }

--- a/forum/src/lib/forum-seed-repository.ts
+++ b/forum/src/lib/forum-seed-repository.ts
@@ -1,5 +1,6 @@
 import forumContent from "../data/forum-content.json";
 import type {
+  CreateForumReplyInput,
   CreateForumThreadInput,
   ForumReply,
   ForumRepository,
@@ -80,6 +81,10 @@ export function createSeedForumRepository(): ForumRepository {
     throw new ForumWriteUnavailableError("Thread creation is only available when FORUM_DATA_SOURCE=sqlite.");
   };
 
+  const createReply = (_input: CreateForumReplyInput): ForumThreadDetail => {
+    throw new ForumWriteUnavailableError("Reply creation is only available when FORUM_DATA_SOURCE=sqlite.");
+  };
+
   return {
     dataSource: "seed-json",
     persistenceMode: "seed-only",
@@ -94,5 +99,6 @@ export function createSeedForumRepository(): ForumRepository {
     getSnapshot,
     getRuntimeStatus,
     createThread,
+    createReply,
   };
 }

--- a/forum/src/lib/forum-sqlite-repository.ts
+++ b/forum/src/lib/forum-sqlite-repository.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import forumContent from "../data/forum-content.json";
 import type {
+  CreateForumReplyInput,
   CreateForumThreadInput,
   ForumReply,
   ForumRepository,
@@ -311,6 +312,23 @@ function nextThreadSlug(database: DatabaseSync, title: string): string {
   return `${baseSlug}-${suffix}`;
 }
 
+function nextReplyId(database: DatabaseSync, threadSlug: string): string {
+  const baseId = `reply-${threadSlug}-${Date.now().toString(36)}`;
+  const existingReply = database.prepare("SELECT id FROM forum_replies WHERE id = ? LIMIT 1");
+
+  if (!existingReply.get(baseId)) {
+    return baseId;
+  }
+
+  let suffix = 2;
+
+  while (existingReply.get(`${baseId}-${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${baseId}-${suffix}`;
+}
+
 export function createSqliteForumRepository(): ForumRepository {
   const databasePath = resolveSqliteDatabasePath(process.env.FORUM_DATABASE_URL?.trim() || DEFAULT_DATABASE_URL);
   ensureDatabaseDirectory(databasePath);
@@ -585,6 +603,71 @@ export function createSqliteForumRepository(): ForumRepository {
     return createdDetail;
   };
 
+  const createReply = (input: CreateForumReplyInput): ForumThreadDetail => {
+    const thread = getThreadBySlug(input.threadSlug);
+
+    if (!thread) {
+      throw new ForumInputError(`Forum thread "${input.threadSlug}" does not exist.`);
+    }
+
+    const body = input.body.filter((paragraph) => paragraph.trim().length > 0);
+
+    if (body.length === 0) {
+      throw new ForumInputError("Reply body must contain at least one non-empty paragraph.");
+    }
+
+    const replyId = nextReplyId(database, input.threadSlug);
+    const createdAt = new Date().toISOString();
+
+    database.exec("BEGIN");
+
+    try {
+      database.prepare(`
+        INSERT INTO forum_replies (
+          id,
+          thread_slug,
+          author,
+          role_label,
+          published_at,
+          moderation_state,
+          trust_signal,
+          body_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        replyId,
+        input.threadSlug,
+        input.author,
+        input.roleLabel,
+        createdAt,
+        "published",
+        input.trustSignal,
+        JSON.stringify(body),
+      );
+
+      database.prepare(`
+        UPDATE forum_threads
+        SET
+          reply_count = reply_count + 1,
+          last_activity = ?
+        WHERE slug = ?
+      `).run("刚刚回复", input.threadSlug);
+
+      database.exec("COMMIT");
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
+
+    const updatedDetail = getThreadDetailBySlug(input.threadSlug);
+
+    if (!updatedDetail) {
+      throw new Error("Updated thread could not be reloaded from sqlite storage after reply creation.");
+    }
+
+    return updatedDetail;
+  };
+
   return {
     dataSource: "sqlite",
     persistenceMode: "sqlite-file",
@@ -599,5 +682,6 @@ export function createSqliteForumRepository(): ForumRepository {
     getSnapshot,
     getRuntimeStatus,
     createThread,
+    createReply,
   };
 }


### PR DESCRIPTION
## 问题

`forum/` 已经通过 `PR #435` 进入 sqlite durable storage，并有了 `POST /api/threads` 的最小主题创建能力，但当前互动链路还断在“回复”这一步：

- 现有 sqlite 仓储只能创建主题，不能为已存在线程写入回复
- `GET /api/thread/[slug]` 虽然能读回复，但回复数量和最近活动还没有真实写入路径驱动
- 容器 smoke check 目前只能证明“服务可写线程”，还不能证明最小线程互动闭环已经成立

这意味着论坛已经有了第一版持久化边界，但距离“可运行、可测试、可部署”的最小互动闭环还差最后一段。

## 这次改动

- 扩展 `forum/src/lib/forum-data.ts`
  - 新增 `CreateForumReplyInput`
  - 为 `ForumRepository` 增加 `createReply()` 契约
  - 暴露 `createForumReply()` 供路由层统一调用
- 更新 `forum/src/lib/forum-seed-repository.ts`
  - 明确 seed 数据源在回复写入上继续保持只读
  - 在非 sqlite 模式下返回显式的只读错误
- 更新 `forum/src/lib/forum-sqlite-repository.ts`
  - 新增 sqlite 回复 ID 生成逻辑
  - 新增 `createReply()`，写入 `forum_replies`
  - 回复成功后同步更新 `forum_threads.reply_count` 与 `last_activity`
  - 让线程详情接口可以回读最新持久化回复结果
- 新增 `forum/src/app/api/thread/[slug]/replies/route.ts`
  - 提供 `POST /api/thread/[slug]/replies`
  - 做输入校验、线程存在性校验、只读模式拦截和统一错误返回
  - 为角色标签与信任信号提供默认值，避免第一版接口负担过重
- 更新 `forum/README.md`
  - 文档化新回复接口与本地验证方式
  - 明确当前论坛已经具备 sqlite 下的最小线程互动写入链路
- 更新 `.github/workflows/forum-container-checks.yml`
  - 在现有 sqlite 线程创建 smoke check 之后，新增回复创建 smoke check
  - 断言回复写入后线程 `replyCount` 增长、`lastActivity` 更新，并能在详情响应里读到新回复

## 为什么现在做

论坛当前阶段最重要的，不是马上接账户系统或复杂审核面板，而是先把 sqlite 边界上的最小互动闭环补完整。

这一小步的收益很集中：

- 论坛第一次具备了“线程创建 + 回复写入 + 详情回读”的真实持久化互动链路
- 容器检查第一次能覆盖到回复写入，而不只是主题创建
- 下一轮继续接页面级回复表单、审核事件和角色状态时，不需要再返工仓储抽象

## 验证

- 已回读分支关键文件，确认：
  - `forum-data.ts` 已新增回复写入契约
  - `forum-seed-repository.ts` 已对回复写入显式只读
  - `forum-sqlite-repository.ts` 已支持回复持久化、计数回写和最近活动更新
  - `POST /api/thread/[slug]/replies` 已新增并接到统一仓储边界
  - `forum-container-checks.yml` 已覆盖 sqlite 回复写入 smoke check
- 当前环境无法直接克隆 GitHub 仓库到本地，`git clone https://github.com/bhrumom/fabushi.git` 返回 403，因此本轮没法在本地直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build` 或容器检查
- 最终验证依赖仓库现有 Actions：
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 在页面层接最小回复表单，让 sqlite 回复路径不只停留在 API
- 把回复治理信号、角色标签和新手引导状态继续推进成可持久化事件流
- 再决定 sqlite 是否继续作为过渡持久化层，还是迁移到更长期的数据库服务