### PR TITLE
feat(forum): add page-level reply composer on thread detail

### DIFF
--- a/forum/README.md
+++ b/forum/README.md
@@ -16,6 +16,7 @@ Current scope:
 - a sqlite-backed repository option that can bootstrap from the current seed content
 - a minimal thread-creation API when sqlite mode is enabled
 - a minimal reply-creation API for existing threads in sqlite mode
+- a page-level reply composer on thread detail when writes are enabled
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
 - a container smoke check that starts the forum, validates `/api/status`, and exercises sqlite thread and reply creation
@@ -29,6 +30,7 @@ Included:
 - landing page
 - thread list page
 - thread detail page with sample replies
+- page-level reply submission in writable mode
 - structured seed content contract
 - read-only API boundary
 - moderation and knowledge-stage fields reserved in the content model
@@ -40,7 +42,7 @@ Included:
 Not included yet:
 
 - authentication
-- reply UI in the page layer
+- thread creation UI in the page layer
 - search, notifications, bookmarks, or follows as real user actions
 - moderation workflows beyond reserved fields and write-state checks
 
@@ -82,6 +84,8 @@ curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
     "body": ["我发现先把睡前十分钟固定下来，比一下子改整天作息更容易坚持。"]
   }'
 ```
+
+When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/first-year-stability` and submit a reply through the page-level form. In `seed-json` mode, the same form stays visible but clearly reports that the runtime is still read-only.
 
 ## Runtime contract
 
@@ -128,4 +132,4 @@ A dedicated GitHub Actions workflow now checks that the forum container image ca
 
 ## Why this is the next step
 
-After the structured seed content contract, standalone deployment baseline, runtime status boundary, and first durable thread creation path landed, the next highest-value gap was reply persistence on top of the same sqlite boundary. This iteration keeps the product surface narrow while adding a real reply write endpoint, thread-level activity updates, and a smoke-checkable interaction loop. That gives the next pass a stable place to add moderation events, page-level reply forms, and database-backed user workflows.
+After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, and first reply write path landed, the next highest-value gap was page-level reply submission on top of the same sqlite boundary. This iteration keeps the product surface narrow while letting the thread detail page submit a real reply, surface read-only mode clearly, and re-read the latest thread state. That gives the next pass a stable place to add moderation events, page-level thread creation, and database-backed user workflows.

--- a/forum/src/app/globals.css
+++ b/forum/src/app/globals.css
@@ -155,7 +155,8 @@ main {
 
 .thread-meta span,
 .thread-tags span,
-.reply-signal {
+.reply-signal,
+.reply-runtime {
   padding: 6px 10px;
   border-radius: 999px;
   background: rgba(140, 90, 43, 0.08);
@@ -212,6 +213,14 @@ main {
   padding-left: 20px;
 }
 
+.reply-composer {
+  margin-top: 18px;
+  padding: 18px 20px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.68);
+}
+
 .reply-stack {
   margin-top: 18px;
 }
@@ -225,6 +234,98 @@ main {
 
 .section-heading p {
   margin: 0;
+}
+
+.reply-form {
+  display: grid;
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.reply-form-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
+  gap: 14px;
+}
+
+.reply-field {
+  display: grid;
+  gap: 8px;
+}
+
+.reply-field span {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.reply-input,
+.reply-textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: #fffdf8;
+  color: var(--text);
+  font: inherit;
+  padding: 12px 14px;
+}
+
+.reply-input {
+  min-height: 48px;
+}
+
+.reply-textarea {
+  min-height: 156px;
+  resize: vertical;
+}
+
+.reply-input:focus,
+.reply-textarea:focus {
+  outline: 2px solid rgba(140, 90, 43, 0.16);
+  border-color: rgba(140, 90, 43, 0.48);
+}
+
+.reply-form-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.reply-form-hint,
+.reply-form-message {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.reply-form-message[data-tone="success"] {
+  color: #44611d;
+}
+
+.reply-form-message[data-tone="error"] {
+  color: #8a3520;
+}
+
+.submit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fffdf8;
+  font: inherit;
+  cursor: pointer;
+}
+
+.reply-input:disabled,
+.reply-textarea:disabled,
+.submit-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .reply-card {
@@ -281,13 +382,15 @@ main {
   .section-grid,
   .thread-grid,
   .metrics,
-  .reply-stack {
+  .reply-stack,
+  .reply-form-grid {
     grid-template-columns: 1fr;
     display: grid;
   }
 
   .reply-top,
-  .section-heading {
+  .section-heading,
+  .reply-form-footer {
     flex-direction: column;
     align-items: stretch;
   }

--- a/forum/src/app/threads/[slug]/page.tsx
+++ b/forum/src/app/threads/[slug]/page.tsx
@@ -1,6 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getThreadDetailBySlug } from "../../../lib/forum-data";
+import { getForumRuntimeStatus, getThreadDetailBySlug } from "../../../lib/forum-data";
+import { ThreadReplyForm } from "./reply-form";
+
+export const dynamic = "force-dynamic";
 
 interface ThreadPageProps {
   params: Promise<{ slug: string }>;
@@ -14,6 +17,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
     notFound();
   }
 
+  const runtime = getForumRuntimeStatus();
   const { thread, section, replies } = detail;
 
   return (
@@ -63,11 +67,21 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
           </ul>
         </section>
 
+        <ThreadReplyForm
+          threadSlug={thread.slug}
+          writesEnabled={runtime.writesEnabled}
+          dataSource={runtime.dataSource}
+        />
+
         <section className="reply-stack">
           <div className="section-heading">
             <div>
-              <h2>首批回复样例</h2>
-              <p>这一层已经开始承接真实论坛会需要的回复、治理提示和后续沉淀信号。</p>
+              <h2>当前回复</h2>
+              <p>
+                {runtime.writesEnabled
+                  ? "新回复提交后会回写 sqlite，并在刷新后直接显示在这里。"
+                  : "当前环境先以样例回复展示结构，切到 sqlite 后这里会承接真实提交。"}
+              </p>
             </div>
           </div>
 
@@ -100,7 +114,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
 
         <section className="api-note">
           <h2>后续扩展位置</h2>
-          <p>下一轮可以直接把这里的结构接到真实持久化层、发帖表单、回复提交和审核事件时间线上。</p>
+          <p>下一轮可以继续把同一条链路扩到主题创建页、审核事件时间线和角色状态持久化。</p>
           <div className="footer-note">
             <span>作者：{thread.author}</span>
             <span>发布时间：{thread.publishedAt}</span>

--- a/forum/src/app/threads/[slug]/reply-form.tsx
+++ b/forum/src/app/threads/[slug]/reply-form.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useDeferredValue, useState, useTransition, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+interface ThreadReplyFormProps {
+  threadSlug: string;
+  writesEnabled: boolean;
+  dataSource: string;
+}
+
+type FormTone = "error" | "success";
+
+function getParagraphs(value: string) {
+  return value
+    .split(/\n+/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+}
+
+export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: ThreadReplyFormProps) {
+  const router = useRouter();
+  const [author, setAuthor] = useState("");
+  const [body, setBody] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [tone, setTone] = useState<FormTone | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const deferredBody = useDeferredValue(body);
+  const paragraphCount = getParagraphs(deferredBody).length;
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!writesEnabled) {
+      setTone("error");
+      setMessage(`当前 ${dataSource} 模式还是只读，切到 sqlite 后才能在页面里直接提交回复。`);
+      return;
+    }
+
+    const trimmedAuthor = author.trim();
+    const paragraphs = getParagraphs(body);
+
+    if (!trimmedAuthor || paragraphs.length === 0) {
+      setTone("error");
+      setMessage("请先填写称呼和回复内容。");
+      return;
+    }
+
+    startTransition(() => {
+      void (async () => {
+        try {
+          setTone(null);
+          setMessage(null);
+
+          const response = await fetch(`/api/thread/${threadSlug}/replies`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              author: trimmedAuthor,
+              body: paragraphs,
+            }),
+          });
+
+          const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+
+          if (!response.ok) {
+            throw new Error(payload?.error ?? "提交回复失败，请稍后再试。");
+          }
+
+          setAuthor("");
+          setBody("");
+          setTone("success");
+          setMessage("回复已写入当前线程，页面正在刷新。");
+          router.refresh();
+        } catch (error) {
+          setTone("error");
+          setMessage(error instanceof Error ? error.message : "提交回复失败，请稍后再试。");
+        }
+      })();
+    });
+  }
+
+  return (
+    <section className="reply-composer" aria-labelledby="reply-composer-heading">
+      <div className="section-heading">
+        <div>
+          <h2 id="reply-composer-heading">写一条最小回复</h2>
+          <p>先把页面层接到 sqlite 回复接口，确认真实互动不只停留在 API。</p>
+        </div>
+        <span className="reply-runtime">{writesEnabled ? `当前数据源：${dataSource} / 可写` : `当前数据源：${dataSource} / 只读`}</span>
+      </div>
+
+      {!writesEnabled ? (
+        <p className="reply-form-hint">
+          当前运行环境还在只读模式。把 `FORUM_DATA_SOURCE` 切到 `sqlite` 后，这里就能直接提交最小回复。
+        </p>
+      ) : null}
+
+      <form className="reply-form" onSubmit={handleSubmit}>
+        <div className="reply-form-grid">
+          <label className="reply-field">
+            <span>你的称呼</span>
+            <input
+              className="reply-input"
+              name="author"
+              value={author}
+              onChange={(event) => setAuthor(event.target.value)}
+              placeholder="例如：新加入同修"
+              disabled={!writesEnabled || isPending}
+              autoComplete="name"
+            />
+          </label>
+
+          <label className="reply-field">
+            <span>回复内容</span>
+            <textarea
+              className="reply-textarea"
+              name="body"
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              placeholder="可以直接写一段，也可以换行写成两三段。"
+              disabled={!writesEnabled || isPending}
+            />
+          </label>
+        </div>
+
+        <div className="reply-form-footer">
+          <p className="reply-form-hint">
+            {paragraphCount > 0
+              ? `当前会提交 ${paragraphCount} 段内容。接口会自动补默认角色标签和信任信号。`
+              : "回复支持按空行切成多段，先把最小交流闭环跑通。"}
+          </p>
+          <button className="submit-button" type="submit" disabled={!writesEnabled || isPending}>
+            {isPending ? "提交中..." : "提交回复"}
+          </button>
+        </div>
+
+        {message ? (
+          <p className="reply-form-message" data-tone={tone ?? undefined}>
+            {message}
+          </p>
+        ) : null}
+      </form>
+    </section>
+  );
+}


### PR DESCRIPTION
## 问题

`PR #439` 已经把 sqlite 回复写入路径接到了论坛 API，但当前互动还断在页面层：

- 帖子详情页仍然只能展示样例回复，不能直接提交最小回复
- 就算 API 已经可写，页面也没有把这条能力承接起来
- 线程详情页目前没有显式声明动态读取，提交后也缺少稳定的刷新路径

这意味着论坛已经有了最小回复后端，但离“页面可用、可测试、可继续扩展”的闭环还差最后一小步。

## 这次改动

- 新增 `forum/src/app/threads/[slug]/reply-form.tsx`
  - 提供页面层最小回复表单
  - 只收集称呼和回复内容，让当前接口继续自动补默认角色标签与信任信号
  - 在提交中、成功、失败和只读模式下给出明确反馈
- 更新 `forum/src/app/threads/[slug]/page.tsx`
  - 把线程详情页标为动态读取
  - 接入新的回复表单组件
  - 根据当前运行态区分“真实可写回复”与“只读样例展示”说明
- 更新 `forum/src/app/globals.css`
  - 为回复表单、运行态提示和提交按钮补齐样式与移动端适配
- 更新 `forum/README.md`
  - 文档化页面层回复提交流程
  - 说明 sqlite 模式下如何直接从线程页验证回复闭环

## 为什么现在做

这一步比继续扩鉴权、审核后台或更多页面更值得先做，因为它直接把上一轮已经合入的 sqlite 回复能力接到了真实用户入口。

收益很集中：

- 论坛第一次具备“打开帖子 -> 填写回复 -> 提交 -> 刷新后看到新回复”的页面级闭环
- 只读模式和可写模式的差异第一次在页面上被说清楚，不再只藏在 API 行为里
- 下一轮继续接主题创建页、审核事件和角色状态时，可以沿着同一条页面到仓储的链路往前推

## 验证

- compare 已确认本分支相对 `main`：`ahead_by = 4`、`behind_by = 0`
- 改动范围只收敛在 4 个论坛文件：
  - `forum/src/app/threads/[slug]/reply-form.tsx`
  - `forum/src/app/threads/[slug]/page.tsx`
  - `forum/src/app/globals.css`
  - `forum/README.md`
- 已回读分支文件，确认：
  - 线程详情页已接入页面层回复表单
  - 页面已显式 `force-dynamic`，避免回复后继续读旧内容
  - 只读模式会在表单层明确提示，而不是等接口报错才知道
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build` 或浏览器级手动提交流程
- 最终检查依赖仓库现有 Actions：
  - `Module checks - Forum`
  - `Container checks - Forum`
  - 整仓 `CI`

## 下一步承接

- 为论坛补页面层主题创建入口，让 sqlite 最小写入闭环从“已有线程可回复”扩到“新主题可发起”
- 把回复治理信号和角色状态推进成持久化事件，而不只停留在展示字段