### PR TITLE
feat(forum): add page-level thread creation flow

### DIFF
--- a/forum/README.md
+++ b/forum/README.md
@@ -15,6 +15,7 @@ Current scope:
 - read-only routes for thread listing, thread detail, and runtime status
 - a sqlite-backed repository option that can bootstrap from the current seed content
 - a minimal thread-creation API when sqlite mode is enabled
+- a page-level thread composer on top of the thread-creation API in writable mode
 - a minimal reply-creation API for existing threads in sqlite mode
 - a page-level reply composer on thread detail when writes are enabled
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
@@ -30,6 +31,7 @@ Included:
 - landing page
 - thread list page
 - thread detail page with sample replies
+- page-level thread creation in writable mode
 - page-level reply submission in writable mode
 - structured seed content contract
 - read-only API boundary
@@ -42,7 +44,6 @@ Included:
 Not included yet:
 
 - authentication
-- thread creation UI in the page layer
 - search, notifications, bookmarks, or follows as real user actions
 - moderation workflows beyond reserved fields and write-state checks
 
@@ -85,7 +86,7 @@ curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
   }'
 ```
 
-When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/first-year-stability` and submit a reply through the page-level form. In `seed-json` mode, the same form stays visible but clearly reports that the runtime is still read-only.
+When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/new` to create a new topic, and `http://localhost:3000/threads/first-year-stability` to submit a reply through the page-level form. In `seed-json` mode, both page-level forms stay visible but clearly report that the runtime is still read-only.
 
 ## Runtime contract
 
@@ -105,7 +106,7 @@ Current JSON routes:
 - `POST /api/thread/[slug]/replies`
 - `GET /api/status`
 
-`GET /api/status` now reports whether writes are enabled for the current data source. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, and lets existing threads accept the first persisted reply submissions.
+`GET /api/status` now reports whether writes are enabled for the current data source. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, lets the page-level thread composer create new topics, and lets existing threads accept the first persisted reply submissions.
 
 ## Container deployment
 
@@ -132,4 +133,4 @@ A dedicated GitHub Actions workflow now checks that the forum container image ca
 
 ## Why this is the next step
 
-After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, and first reply write path landed, the next highest-value gap was page-level reply submission on top of the same sqlite boundary. This iteration keeps the product surface narrow while letting the thread detail page submit a real reply, surface read-only mode clearly, and re-read the latest thread state. That gives the next pass a stable place to add moderation events, page-level thread creation, and database-backed user workflows.
+After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, first reply write path, and page-level reply submission landed, the next highest-value gap was page-level thread creation on top of the same sqlite boundary. This iteration keeps the product surface narrow while letting the thread list flow continue into a real composer page and then into a newly created thread detail page. That gives the next pass a stable place to add moderation events, validation rules, and database-backed user workflows.

--- a/forum/src/app/globals.css
+++ b/forum/src/app/globals.css
@@ -365,6 +365,96 @@ main {
   font-size: 14px;
 }
 
+.thread-action-bar {
+  margin-top: 22px;
+  padding: 18px 20px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.62);
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.thread-action-bar h2 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+}
+
+.thread-action-bar p {
+  margin: 0;
+}
+
+.composer-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  gap: 18px;
+  margin-top: 24px;
+}
+
+.composer-panel {
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.composer-panel h2 {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+}
+
+.composer-panel p {
+  color: var(--muted);
+  line-height: 1.75;
+  font-size: 16px;
+}
+
+.composer-section-list {
+  display: grid;
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.composer-section-card {
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.composer-section-card p {
+  margin: 12px 0 0;
+}
+
+.composer-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.composer-inline-note {
+  display: grid;
+  gap: 8px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(140, 90, 43, 0.06);
+}
+
+.composer-inline-note .reply-form-hint {
+  margin: 0;
+}
+
+.composer-select {
+  appearance: none;
+}
+
+.composer-textarea {
+  min-height: 220px;
+}
+
 @media (max-width: 820px) {
   main {
     width: min(100vw - 20px, 1120px);
@@ -390,9 +480,15 @@ main {
 
   .reply-top,
   .section-heading,
-  .reply-form-footer {
+  .reply-form-footer,
+  .thread-action-bar {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .composer-grid,
+  .composer-form-grid {
+    grid-template-columns: 1fr;
   }
 
   .hero h1,

--- a/forum/src/app/page.tsx
+++ b/forum/src/app/page.tsx
@@ -1,8 +1,11 @@
 import Link from "next/link";
-import { getForumSnapshot } from "../lib/forum-data";
+import { getForumRuntimeStatus, getForumSnapshot } from "../lib/forum-data";
+
+export const dynamic = "force-dynamic";
 
 export default function HomePage() {
   const snapshot = getForumSnapshot();
+  const runtime = getForumRuntimeStatus();
 
   return (
     <main>
@@ -12,24 +15,25 @@ export default function HomePage() {
           <nav className="nav">
             <Link href="/">首页</Link>
             <Link href="/threads">帖子列表</Link>
-            <a href="/api/threads">只读 API</a>
+            <Link href="/threads/new">发起主题</Link>
+            <a href="/api/threads">论坛 API</a>
           </nav>
         </div>
 
-        <h1>把论坛从占位目录推进成真正可启动的独立项目。</h1>
+        <h1>把论坛从占位目录推进成真正能承接互动的独立项目。</h1>
         <p>
-          这一版先不追求完整社区能力，而是先把独立运行骨架、种子数据、帖子列表、帖子详情和只读接口立住，
-          让下一轮可以直接接真实数据模型、发帖流程、鉴权和治理能力。
+          这一版先不追求完整社区能力，而是先把独立运行骨架、sqlite 最小写入、帖子详情回复和页面层主题创建入口接起来，
+          让下一轮可以直接接审核状态、鉴权和更完整的用户流程。
         </p>
 
         <div className="hero-grid">
           <article className="panel">
             <h2>当前阶段</h2>
-            <p>独立论坛应用初始化。目标是从空目录进入“能启动、能浏览、能继续扩展”的状态。</p>
+            <p>sqlite 最小互动闭环。目标是让论坛从“能启动、能浏览”进入“能发起主题、能回复、能继续扩展”的状态。</p>
           </article>
           <article className="panel">
             <h2>下一步承接点</h2>
-            <p>优先把种子数据替换成真实持久化模型，并补最小可用的发帖和首条回复流程。</p>
+            <p>优先把审核事件、角色状态和新手引导沿着同一条页面到仓储链路继续持久化，而不是回到静态占位页面。</p>
           </article>
         </div>
       </section>
@@ -68,15 +72,18 @@ export default function HomePage() {
       </section>
 
       <section className="api-note">
-        <h2>当前只读边界</h2>
-        <p>种子数据已经通过独立应用自己的 JSON 路由暴露出来，后续可以在不重写页面结构的前提下切到真实数据层。</p>
+        <h2>当前接口边界</h2>
+        <p>论坛页面已经不再直接读取种子文件，而是统一经过仓储边界。当前环境也会明确显示是否处于可写模式。</p>
         <p className="code">GET /api/threads</p>
+        <p className="code">POST /api/threads</p>
         <p className="code">GET /api/thread/[slug]</p>
+        <p className="code">POST /api/thread/[slug]/replies</p>
         <p className="code">GET /api/status</p>
         <div className="footer-note">
           <span>sections: {snapshot.sections.length}</span>
           <span>threads: {snapshot.threads.length}</span>
           <span>source: {snapshot.source}</span>
+          <span>{runtime.writesEnabled ? "writes enabled" : "read-only"}</span>
         </div>
       </section>
     </main>

--- a/forum/src/app/threads/new/page.tsx
+++ b/forum/src/app/threads/new/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { getForumRuntimeStatus, getForumSnapshot } from "../../lib/forum-data";
+import { ThreadComposer } from "./thread-composer";
+
+export const dynamic = "force-dynamic";
+
+export default function NewThreadPage() {
+  const snapshot = getForumSnapshot();
+  const runtime = getForumRuntimeStatus();
+
+  return (
+    <main>
+      <section className="thread-shell">
+        <div className="hero-top">
+          <span className="badge">发起主题 / Start Thread</span>
+          <nav className="nav">
+            <Link href="/">首页</Link>
+            <Link href="/threads">帖子列表</Link>
+            <a href="/api/threads">JSON</a>
+          </nav>
+        </div>
+
+        <h1>先把问题提清楚，再让讨论慢慢长出来。</h1>
+        <p>
+          这一页把页面层主题创建入口接到现有 sqlite 写路径，让论坛第一次同时具备“在页面里发起主题”和“在页面里回复主题”的最小互动承接。
+        </p>
+
+        <div className="composer-grid">
+          <section className="composer-panel">
+            <h2>版块与发帖提示</h2>
+            <p>
+              第一版先不追求复杂模板，而是把“选对版块、写清起点、保持问题聚焦”这些最影响讨论质量的前置动作放到页面里。
+            </p>
+
+            <div className="composer-section-list">
+              {snapshot.sections.map((section) => (
+                <article key={section.slug} className="composer-section-card">
+                  <div className="thread-meta">
+                    <span>{section.name}</span>
+                    <span>{section.threadCount} 条主题</span>
+                    <span>{section.replyCount} 条回复</span>
+                  </div>
+                  <p>{section.description}</p>
+                  <p>{section.postingPrompt}</p>
+                  <p>{section.moderationFocus}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <ThreadComposer
+            sections={snapshot.sections.map((section) => ({
+              slug: section.slug,
+              name: section.name,
+              postingPrompt: section.postingPrompt,
+              moderationFocus: section.moderationFocus,
+            }))}
+            writesEnabled={runtime.writesEnabled}
+            dataSource={runtime.dataSource}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/forum/src/app/threads/new/thread-composer.tsx
+++ b/forum/src/app/threads/new/thread-composer.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useDeferredValue, useState, useTransition, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+interface ComposerSection {
+  slug: string;
+  name: string;
+  postingPrompt: string;
+  moderationFocus: string;
+}
+
+interface ThreadComposerProps {
+  sections: ComposerSection[];
+  writesEnabled: boolean;
+  dataSource: string;
+}
+
+type FormTone = "error" | "success";
+
+function getParagraphs(value: string) {
+  return value
+    .split(/\n+/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+}
+
+function getTags(value: string) {
+  return value
+    .split(/[，,\n]+/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadComposerProps) {
+  const router = useRouter();
+  const [sectionSlug, setSectionSlug] = useState(sections[0]?.slug ?? "");
+  const [title, setTitle] = useState("");
+  const [author, setAuthor] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
+  const [openingPost, setOpeningPost] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [tone, setTone] = useState<FormTone | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const deferredOpeningPost = useDeferredValue(openingPost);
+  const deferredTags = useDeferredValue(tagsInput);
+  const paragraphCount = getParagraphs(deferredOpeningPost).length;
+  const tagCount = getTags(deferredTags).length;
+  const selectedSection = sections.find((section) => section.slug === sectionSlug) ?? sections[0];
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!writesEnabled) {
+      setTone("error");
+      setMessage(`当前 ${dataSource} 模式还是只读，切到 sqlite 后才能在页面里直接发布主题。`);
+      return;
+    }
+
+    if (!selectedSection) {
+      setTone("error");
+      setMessage("当前还没有可选版块，暂时无法发起主题。");
+      return;
+    }
+
+    const trimmedTitle = title.trim();
+    const trimmedAuthor = author.trim();
+    const paragraphs = getParagraphs(openingPost);
+    const tags = getTags(tagsInput);
+
+    if (!trimmedTitle || !trimmedAuthor || paragraphs.length === 0) {
+      setTone("error");
+      setMessage("请先选择版块，并填写标题、称呼和开场帖内容。");
+      return;
+    }
+
+    startTransition(() => {
+      void (async () => {
+        try {
+          setTone(null);
+          setMessage(null);
+
+          const response = await fetch("/api/threads", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              sectionSlug: selectedSection.slug,
+              title: trimmedTitle,
+              author: trimmedAuthor,
+              tags,
+              openingPost: paragraphs,
+            }),
+          });
+
+          const payload = (await response.json().catch(() => null)) as {
+            error?: string;
+            thread?: { slug?: string };
+          } | null;
+
+          if (!response.ok) {
+            throw new Error(payload?.error ?? "发布主题失败，请稍后再试。");
+          }
+
+          const createdSlug = payload?.thread?.slug;
+
+          if (!createdSlug) {
+            throw new Error("主题已创建，但没有返回详情地址。");
+          }
+
+          setTitle("");
+          setAuthor("");
+          setTagsInput("");
+          setOpeningPost("");
+          setTone("success");
+          setMessage("主题已创建，正在跳转到详情页。");
+          router.push(`/threads/${createdSlug}`);
+        } catch (error) {
+          setTone("error");
+          setMessage(error instanceof Error ? error.message : "发布主题失败，请稍后再试。");
+        }
+      })();
+    });
+  }
+
+  return (
+    <section className="composer-panel" aria-labelledby="thread-composer-heading">
+      <div className="section-heading">
+        <div>
+          <h2 id="thread-composer-heading">发起一条最小主题</h2>
+          <p>先把页面层接到已有的线程创建接口，确认“浏览列表 -> 发起主题 -> 进入详情页”的链路已经成立。</p>
+        </div>
+        <span className="reply-runtime">{writesEnabled ? `当前数据源：${dataSource} / 可写` : `当前数据源：${dataSource} / 只读`}</span>
+      </div>
+
+      {!writesEnabled ? (
+        <p className="reply-form-hint">
+          当前运行环境还在只读模式。把 `FORUM_DATA_SOURCE` 切到 `sqlite` 后，这里就能直接提交新主题。
+        </p>
+      ) : null}
+
+      <form className="reply-form" onSubmit={handleSubmit}>
+        <div className="composer-form-grid">
+          <label className="reply-field">
+            <span>选择版块</span>
+            <select
+              className="reply-input composer-select"
+              name="sectionSlug"
+              value={sectionSlug}
+              onChange={(event) => setSectionSlug(event.target.value)}
+              disabled={!writesEnabled || isPending || sections.length === 0}
+            >
+              {sections.map((section) => (
+                <option key={section.slug} value={section.slug}>
+                  {section.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="reply-field">
+            <span>主题标题</span>
+            <input
+              className="reply-input"
+              name="title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="例如：刚开始读经时，怎样记录自己真正看不懂的地方？"
+              disabled={!writesEnabled || isPending}
+            />
+          </label>
+
+          <label className="reply-field">
+            <span>你的称呼</span>
+            <input
+              className="reply-input"
+              name="author"
+              value={author}
+              onChange={(event) => setAuthor(event.target.value)}
+              placeholder="例如：新加入同修"
+              disabled={!writesEnabled || isPending}
+              autoComplete="name"
+            />
+          </label>
+
+          <label className="reply-field">
+            <span>标签</span>
+            <input
+              className="reply-input"
+              name="tags"
+              value={tagsInput}
+              onChange={(event) => setTagsInput(event.target.value)}
+              placeholder="用逗号分开，例如：新手，读经，提问"
+              disabled={!writesEnabled || isPending}
+            />
+          </label>
+        </div>
+
+        <label className="reply-field">
+          <span>开场帖</span>
+          <textarea
+            className="reply-textarea composer-textarea"
+            name="openingPost"
+            value={openingPost}
+            onChange={(event) => setOpeningPost(event.target.value)}
+            placeholder="先写清你的起点、当前困惑，以及你已经尝试过什么。"
+            disabled={!writesEnabled || isPending}
+          />
+        </label>
+
+        {selectedSection ? (
+          <div className="composer-inline-note">
+            <p className="reply-form-hint">当前版块：{selectedSection.name}</p>
+            <p className="reply-form-hint">发帖提示：{selectedSection.postingPrompt}</p>
+            <p className="reply-form-hint">治理重点：{selectedSection.moderationFocus}</p>
+          </div>
+        ) : null}
+
+        <div className="reply-form-footer">
+          <p className="reply-form-hint">
+            {paragraphCount > 0
+              ? `当前会提交 ${paragraphCount} 段开场帖${tagCount > 0 ? `，并附带 ${tagCount} 个标签` : ""}。接口会自动生成摘要。`
+              : "开场帖支持按空行分段；第一版先让标题、版块和开场帖稳定落库。"}
+          </p>
+          <button className="submit-button" type="submit" disabled={!writesEnabled || isPending || !selectedSection}>
+            {isPending ? "发布中..." : "发布主题"}
+          </button>
+        </div>
+
+        {message ? (
+          <p className="reply-form-message" data-tone={tone ?? undefined}>
+            {message}
+          </p>
+        ) : null}
+      </form>
+    </section>
+  );
+}

--- a/forum/src/app/threads/page.tsx
+++ b/forum/src/app/threads/page.tsx
@@ -1,8 +1,11 @@
 import Link from "next/link";
-import { getForumSnapshot } from "../../lib/forum-data";
+import { getForumRuntimeStatus, getForumSnapshot } from "../../lib/forum-data";
+
+export const dynamic = "force-dynamic";
 
 export default function ThreadsPage() {
   const snapshot = getForumSnapshot();
+  const runtime = getForumRuntimeStatus();
 
   return (
     <main>
@@ -11,13 +14,28 @@ export default function ThreadsPage() {
           <span className="badge">帖子列表 / Thread Index</span>
           <nav className="nav">
             <Link href="/">返回首页</Link>
+            <Link href="/threads/new">发起主题</Link>
             <a href="/api/threads">查看 API</a>
           </nav>
         </div>
         <h1>先把值得长期讨论的问题摆出来。</h1>
         <p>
-          当前列表使用种子内容驱动，但页面结构已经按真实论坛的浏览方式组织：板块、线程摘要、互动指标和详情入口都已具备独立承接点。
+          当前列表已经按真实论坛的浏览方式组织：板块、线程摘要、互动指标、详情入口和主题创建入口都开始沿着同一条独立论坛链路推进。
         </p>
+
+        <div className="thread-action-bar">
+          <div>
+            <h2>开始一条新主题</h2>
+            <p>
+              {runtime.writesEnabled
+                ? "当前运行环境已经允许页面层直接发起主题，下一轮可以继续沿着这条链路接审核事件和用户状态。"
+                : `当前 ${runtime.dataSource} 模式还是只读，但页面层发帖入口已经可以先承接结构和表单交互，切到 sqlite 后即可直接发布。`}
+            </p>
+          </div>
+          <Link className="primary-link" href="/threads/new">
+            发起主题
+          </Link>
+        </div>
       </section>
 
       <section className="section-grid">
@@ -25,6 +43,7 @@ export default function ThreadsPage() {
           <article key={section.slug} className="panel">
             <h2>{section.name}</h2>
             <p>{section.description}</p>
+            <p>{section.postingPrompt}</p>
             <p>当前种子帖子 {section.threadCount} 条</p>
           </article>
         ))}


### PR DESCRIPTION
## 问题

`forum/` 已经有了 sqlite 线程创建 API、sqlite 回复写入 API，以及帖子详情页的页面层回复表单，但当前互动链路还缺一块很关键的页面入口：

- 用户还不能在页面里直接发起一条新主题
- `POST /api/threads` 目前仍停留在 API 层，列表页和首页没有把这条能力承接起来
- 首页文案和论坛入口说明也还停在更早的“只读骨架”阶段，和当前 sqlite 最小互动闭环不完全一致

这意味着论坛虽然已经能写入，但距离“页面可用、可测试、可继续扩展”的最小发帖闭环还差最后一小步。

## 这次改动

- 新增 `forum/src/app/threads/new/page.tsx`
  - 增加独立的页面层发帖入口
  - 把版块说明、发帖提示和治理重点直接放进页面承接
- 新增 `forum/src/app/threads/new/thread-composer.tsx`
  - 提供页面层最小主题创建表单
  - 只收集版块、标题、称呼、标签和开场帖
  - 继续复用现有 `POST /api/threads`
  - 在只读 / 可写模式下给出明确反馈，并在创建成功后跳转到新主题详情页
- 更新 `forum/src/app/threads/page.tsx`
  - 把帖子列表页改成动态读取运行态
  - 新增“发起主题”入口和运行态说明
  - 让列表页不只承担浏览，也开始承接新主题发起动作
- 更新 `forum/src/app/page.tsx`
  - 把论坛首页的阶段说明、入口导航和接口说明对齐到当前 sqlite 最小互动闭环状态
- 更新 `forum/src/app/globals.css`
  - 为发帖入口区、发帖页双栏布局、主题表单和版块说明卡片补样式与移动端适配
- 更新 `forum/README.md`
  - 文档化页面层主题创建入口
  - 补充 `/threads/new` 的本地验证方式，并把当前产品边界说明更新到最新状态

## 为什么现在做

这一步比继续扩鉴权、审核后台或更多静态页面更值得先做，因为它直接把已经存在的 sqlite 主题创建能力接到了真实用户入口。

收益很集中：

- 论坛第一次具备“打开列表 -> 发起主题 -> 进入详情页”的页面级闭环
- 页面层现在同时承接“发起主题”和“回复主题”，最小互动流不再只停留在 API
- 下一轮继续接审核事件、角色状态和新手引导时，可以沿着同一条页面到仓储链路继续推进

## 验证

- compare 已确认本分支相对 `main`：`ahead_by = 6`、`behind_by = 0`
- 改动范围只收敛在 6 个论坛文件：
  - `forum/src/app/page.tsx`
  - `forum/src/app/threads/page.tsx`
  - `forum/src/app/threads/new/page.tsx`
  - `forum/src/app/threads/new/thread-composer.tsx`
  - `forum/src/app/globals.css`
  - `forum/README.md`
- 已回读分支关键文件，确认：
  - 发帖页已经接到 `POST /api/threads`
  - 列表页和首页都已经把当前发帖能力显式承接出来
  - 只读模式与 sqlite 可写模式都会在页面上给出明确提示
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build` 或浏览器级手动提交流程
- 最终检查依赖仓库现有 Actions：
  - `Module checks - Forum`
  - `Container checks - Forum`
  - 整仓 `CI`

## 下一步承接

- 把审核事件、角色状态和新手引导沿着同一条页面到仓储链路推进成可持久化状态流
- 在目标运行环境验证“发起主题 -> 回复主题 -> 回读详情”的页面级 smoke check
- 再决定 sqlite 是继续作为过渡持久化层，还是切到更长期的数据库服务