### PR TITLE
test(forum): verify page-level sqlite readback in container checks

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -63,17 +63,30 @@ jobs:
           assert payload["counts"]["threads"] >= 4, payload
           PY
 
+      - name: Smoke test forum writable page surfaces
+        run: |
+          new_thread_page="$(curl --fail --show-error --silent http://127.0.0.1:3000/threads/new)"
+          FORUM_NEW_THREAD_PAGE="$new_thread_page" python3 - <<'PY'
+          import os
+          from html import unescape
+
+          html = unescape(os.environ["FORUM_NEW_THREAD_PAGE"])
+          assert "发起一条最小主题" in html, html[:1000]
+          assert "当前数据源：sqlite / 可写" in html, html[:1000]
+          assert "版块与发帖提示" in html, html[:1000]
+          PY
+
       - name: Smoke test forum thread creation endpoint
         run: |
           response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/threads \
             -H 'content-type: application/json' \
             --data '{
               "sectionSlug": "newcomer-path",
-              "title": "建立稳定作息时，先固定早课还是先固定睡前复盘？",
-              "author": "容器检查",
-              "summary": "想验证 sqlite 写入路径是否能承接真实线程创建。",
-              "tags": ["新手", "作息"],
-              "openingPost": ["这条帖子是容器检查创建的，用来确认论坛第一版 durable storage 已经可写。"]
+              "title": "容器页面检查：新主题能否进入真实帖子页？",
+              "author": "页面检查用户",
+              "summary": "想确认 sqlite 新主题创建后，列表页和详情页都会回读到最新内容。",
+              "tags": ["页面检查", "sqlite"],
+              "openingPost": ["这条主题由容器页面检查创建，用来确认论坛页面层也能读到刚写入的新线程。"]
             }')"
 
           echo "$response"
@@ -84,7 +97,7 @@ jobs:
           payload = json.loads(os.environ["FORUM_CREATE_RESPONSE"])
           assert payload["source"] == "sqlite", payload
           assert payload["thread"]["sectionSlug"] == "newcomer-path", payload
-          assert payload["thread"]["title"].startswith("建立稳定作息时"), payload
+          assert payload["thread"]["title"].startswith("容器页面检查"), payload
           assert payload["thread"]["openingPost"], payload
           print(payload["thread"]["slug"])
           PY
@@ -107,18 +120,42 @@ jobs:
           payload = json.loads(os.environ["FORUM_DETAIL_RESPONSE"])
           assert payload["source"] == "sqlite", payload
           assert payload["thread"]["slug"], payload
-          assert payload["thread"]["author"] == "容器检查", payload
+          assert payload["thread"]["author"] == "页面检查用户", payload
           PY
+
+          thread_list_page="$(curl --fail --show-error --silent http://127.0.0.1:3000/threads)"
+          FORUM_THREAD_LIST_PAGE="$thread_list_page" python3 - <<'PY'
+          import os
+          from html import unescape
+
+          html = unescape(os.environ["FORUM_THREAD_LIST_PAGE"])
+          assert "发起主题" in html, html[:1000]
+          assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:2000]
+          assert "页面检查用户" in html, html[:2000]
+          PY
+
+          thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${slug}")"
+          FORUM_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY'
+          import os
+          from html import unescape
+
+          html = unescape(os.environ["FORUM_THREAD_DETAIL_PAGE"])
+          assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:2000]
+          assert "页面检查用户" in html, html[:2000]
+          assert "写一条最小回复" in html, html[:2000]
+          PY
+
+          echo "thread_slug=${slug}" >> "$GITHUB_ENV"
 
       - name: Smoke test forum reply creation endpoint
         run: |
-          response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/thread/first-year-stability/replies \
+          response="$(curl --fail --show-error --silent "http://127.0.0.1:3000/api/thread/${thread_slug}/replies" \
             -H 'content-type: application/json' \
             --data '{
-              "author": "容器回复检查",
-              "roleLabel": "容器检查",
-              "trustSignal": "用于确认 sqlite 回复写入路径可用。",
-              "body": ["这条回复由容器检查写入，用来确认 forum_replies 与线程计数更新已经打通。"]
+              "author": "页面回复检查",
+              "roleLabel": "页面回读验证",
+              "trustSignal": "用于确认 sqlite 回复写入后，线程详情页会显示新回复。",
+              "body": ["这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。"]
             }')"
 
           echo "$response"
@@ -128,11 +165,23 @@ jobs:
 
           payload = json.loads(os.environ["FORUM_REPLY_RESPONSE"])
           assert payload["source"] == "sqlite", payload
-          assert payload["thread"]["slug"] == "first-year-stability", payload
-          assert payload["thread"]["replyCount"] >= 4, payload
+          assert payload["thread"]["slug"] == os.environ["thread_slug"], payload
+          assert payload["thread"]["replyCount"] >= 1, payload
           assert payload["thread"]["lastActivity"] == "刚刚回复", payload
-          assert payload["replies"][-1]["author"] == "容器回复检查", payload
+          assert payload["replies"][-1]["author"] == "页面回复检查", payload
           assert payload["replies"][-1]["body"], payload
+          PY
+
+          thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${thread_slug}")"
+          FORUM_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY'
+          import os
+          from html import unescape
+
+          html = unescape(os.environ["FORUM_THREAD_DETAIL_PAGE"])
+          assert "当前回复" in html, html[:2000]
+          assert "页面回复检查" in html, html[:4000]
+          assert "页面回读验证" in html, html[:4000]
+          assert "这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。" in html, html[:4000]
           PY
 
       - name: Stop forum container

--- a/forum/README.md
+++ b/forum/README.md
@@ -20,7 +20,7 @@ Current scope:
 - a page-level reply composer on thread detail when writes are enabled
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
-- a container smoke check that starts the forum, validates `/api/status`, and exercises sqlite thread and reply creation
+- a container smoke check that starts the forum, validates `/api/status`, exercises sqlite thread and reply creation, and reads the updated thread back through real forum pages
 
 ## Current product boundary
 
@@ -84,6 +84,9 @@ curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
     "trustSignal": "回复已按主题聚焦提交，等待更多互动后再决定是否沉淀。",
     "body": ["我发现先把睡前十分钟固定下来，比一下子改整天作息更容易坚持。"]
   }'
+curl http://localhost:3000/threads/new
+curl http://localhost:3000/threads
+curl http://localhost:3000/threads/first-year-stability
 ```
 
 When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/new` to create a new topic, and `http://localhost:3000/threads/first-year-stability` to submit a reply through the page-level form. In `seed-json` mode, both page-level forms stay visible but clearly report that the runtime is still read-only.
@@ -129,8 +132,8 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, creates a thread through the API, and adds a reply to confirm the first interaction loop is working end to end.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, confirms `/threads/new` exposes the writable page-level composer, creates a thread through the API, reads that thread back through `/threads` and `/threads/[slug]`, and then adds a reply to verify the updated discussion is visible on the thread detail page.
 
 ## Why this is the next step
 
-After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, first reply write path, and page-level reply submission landed, the next highest-value gap was page-level thread creation on top of the same sqlite boundary. This iteration keeps the product surface narrow while letting the thread list flow continue into a real composer page and then into a newly created thread detail page. That gives the next pass a stable place to add moderation events, validation rules, and database-backed user workflows.
+After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, first reply write path, and page-level reply submission landed, the next highest-value gap was proving that the same sqlite interaction loop is visible through the real page layer, not just through JSON endpoints. This iteration keeps the product surface narrow while making deployment checks more trustworthy, so the next pass can focus on moderation events, role state, and more explicit newcomer guidance instead of rediscovering whether the current forum pages still reflect newly written content.


### PR DESCRIPTION
## 问题

论坛现在已经有了：

- sqlite 线程创建 API
- sqlite 回复写入 API
- 页面层 `threads/new` 发帖入口
- 页面层帖子详情回复表单

但当前容器检查仍主要停留在 JSON 路由层：

- 能证明 sqlite 可写
- 能证明 API 创建主题和回复后可以从 JSON 回读
- 还不能证明真实论坛页面也会把这些最新写入内容渲染出来

这会留下一个很关键的上线前盲点：部署检查即使通过，也还没有自动确认 `/threads/new`、`/threads` 和 `/threads/[slug]` 这些真实页面是否仍然承接住当前最小互动闭环。

## 这次改动

- 更新 `.github/workflows/forum-container-checks.yml`
  - 在 sqlite 模式容器启动后，新增 `/threads/new` 页面回读校验
  - 断言页面层发帖入口已经处于可写运行态
  - 在线程创建成功后，继续回读 `/threads` 与 `/threads/[slug]`
  - 断言新主题已经出现在真实帖子列表页和帖子详情页
  - 在回复写入成功后，再次回读帖子详情页
  - 断言新回复的作者、角色标签和正文已经显示在页面层
- 更新 `forum/README.md`
  - 把新的页面级 smoke check 范围补进文档
  - 明确当前容器检查已经不只验证 API，也验证真实页面回读链路

## 为什么现在做

当前阶段最值得补的，不是再开一个新功能点，而是把现有最小互动闭环的部署检查再推进半步。

原因很直接：

- 这一步最贴近“可运行、可测试、可部署状态”的提升
- 改动边界很小，只收敛在论坛工作流和文档
- 它能让下一轮继续补审核事件、角色状态和新手引导时，有更可靠的基线，不用反复担心页面层是不是已经和 sqlite 写入脱节

## 验证

- compare 已确认分支相对 `main`：`ahead_by = 2`、`behind_by = 0`
- 改动范围只在 2 个文件：
  - `.github/workflows/forum-container-checks.yml`
  - `forum/README.md`
- 已回读分支文件，确认当前工作流会按顺序验证：
  - `/api/status`
  - `/threads/new`
  - `POST /api/threads`
  - `/threads`
  - `/threads/[slug]`
  - `POST /api/thread/[slug]/replies`
  - 再次回读 `/threads/[slug]`
- 当前环境没有仓库本地 checkout，因此没有在本地直接跑 Docker 或 GitHub Actions；最终检查依赖仓库现有 Actions

## 下一步承接

- 把审核事件沿着当前页面到仓储链路推进成可持久化时间线
- 把主题作者/回复作者的角色状态和新手引导信号从展示字段推进到更明确的持久化数据边界
- 在论坛部署入口确认后，再决定 sqlite 之后的数据层演进路径