### PR TITLE
fix(android): prefer bundled Buddha fallback paths before remote GLB

### DIFF
--- a/fabushi/assets/buddha_fallback/index.html
+++ b/fabushi/assets/buddha_fallback/index.html
@@ -43,18 +43,49 @@
   <script>
     (function () {
       var channelName = 'FabushiBuddhaFallback';
-      var remoteGlbUrl = 'https://flutter.ombhrum.com/assets/models/%E4%BD%9B%E5%83%8F%E6%A8%A1%E5%9E%8B.glb';
-      var bundledGlbUrl = new URL(
-        '../../web/assets/models/%E4%BD%9B%E5%83%8F%E6%A8%A1%E5%9E%8B.glb',
-        window.location.href
-      ).href;
+      var encodedGlbName = '%E4%BD%9B%E5%83%8F%E6%A8%A1%E5%9E%8B.glb';
+      var currentUrl = window.location.href;
+      var origin = window.location.origin || '';
+      var remoteGlbUrl = 'https://flutter.ombhrum.com/assets/models/' + encodedGlbName;
+
+      var candidateSpecs = [
+        {
+          label: 'bundled-glb-relative-two-up',
+          url: new URL('../../web/assets/models/' + encodedGlbName, currentUrl).href,
+        },
+        {
+          label: 'bundled-glb-relative-one-up',
+          url: new URL('../web/assets/models/' + encodedGlbName, currentUrl).href,
+        },
+        origin
+          ? {
+              label: 'bundled-glb-origin-assets-root',
+              url: origin + '/assets/web/assets/models/' + encodedGlbName,
+            }
+          : null,
+        origin
+          ? {
+              label: 'bundled-glb-origin-web-root',
+              url: origin + '/web/assets/models/' + encodedGlbName,
+            }
+          : null,
+        { label: 'remote-static-glb', url: remoteGlbUrl },
+      ].filter(Boolean);
+
+      var dedupedCandidates = [];
+      var seenUrls = Object.create(null);
+      candidateSpecs.forEach(function (candidate) {
+        if (!candidate.url || seenUrls[candidate.url]) {
+          return;
+        }
+        seenUrls[candidate.url] = true;
+        dedupedCandidates.push(candidate);
+      });
 
       window.FABUSHI_BUDDHA_CONFIG = {
         channelName: channelName,
-        glbCandidates: [
-          { label: 'remote-static-glb', url: remoteGlbUrl },
-          { label: 'bundled-glb', url: bundledGlbUrl }
-        ]
+        pageUrl: currentUrl,
+        glbCandidates: dedupedCandidates,
       };
 
       window.fabushiNotifyBuddhaHost = function (message) {

--- a/fabushi/test/unit/core/app_config_buddha_model_test.dart
+++ b/fabushi/test/unit/core/app_config_buddha_model_test.dart
@@ -40,5 +40,21 @@ void main() {
       expect(html, isNot(contains('cdn.jsdelivr.net')));
       expect(html, isNot(contains('esm.sh')));
     });
+
+    test('prefers bundled GLB candidates before the remote static URL', () {
+      final html = File(AppConfig.bundledBuddhaFallbackHtmlAssetPath)
+          .readAsStringSync();
+
+      expect(html, contains('bundled-glb-relative-two-up'));
+      expect(html, contains('bundled-glb-relative-one-up'));
+      expect(html, contains('bundled-glb-origin-assets-root'));
+      expect(html, contains('bundled-glb-origin-web-root'));
+      expect(html.indexOf('bundled-glb-relative-two-up'), isNonNegative);
+      expect(html.indexOf('remote-static-glb'), isNonNegative);
+      expect(
+        html.indexOf('bundled-glb-relative-two-up'),
+        lessThan(html.indexOf('remote-static-glb')),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- make the Android Buddha WebView fallback try bundled GLB asset URLs before the remote static URL
- add multiple bundled asset path shapes so Android WebView can survive different `loadFlutterAsset` base URLs
- cover the new fallback ordering in the existing Buddha fallback configuration test

## Why
Android currently jumps straight into the WebView fallback path. When that fallback still prefers the remote GLB first and only guesses one bundled asset URL, the failure message is hard to interpret and the fallback can still break even though the GLB is already packaged in the app.

The most likely remaining problem is path resolution on Android WebView asset URLs. This change makes the fallback more robust by:
- preferring local packaged GLB candidates first
- trying several Android asset URL layouts before going to the network
- preserving the candidate labels so the existing error surface shows which exact path failed

## Validation
- Verified the branch diff only changes the Android Buddha fallback HTML and its unit coverage
- Added a test assertion that bundled GLB candidates appear before `remote-static-glb`
- I could not run Flutter tests or an Android build in this environment because the workspace does not have a local checkout or runnable Flutter toolchain

## Impact
- Android fallback is less dependent on network reachability
- Android failure details become more actionable because candidate labels now identify the exact bundled path form that failed
- iOS behavior is unchanged