### PR TITLE
fix(forum): restore new thread page buildability

### DIFF
--- a/forum/src/app/threads/new/page.tsx
+++ b/forum/src/app/threads/new/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getForumRuntimeStatus, getForumSnapshot } from "../../lib/forum-data";
+import { getForumRuntimeStatus, getForumSnapshot } from "../../../lib/forum-data";
 import { ThreadComposer } from "./thread-composer";
 
 export const dynamic = "force-dynamic";

--- a/forum/src/app/threads/new/thread-composer.tsx
+++ b/forum/src/app/threads/new/thread-composer.tsx
@@ -129,7 +129,7 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
       <div className="section-heading">
         <div>
           <h2 id="thread-composer-heading">发起一条最小主题</h2>
-          <p>先把页面层接到已有的线程创建接口，确认“浏览列表 -> 发起主题 -> 进入详情页”的链路已经成立。</p>
+          <p>先把页面层接到已有的线程创建接口，确认浏览列表、发起主题、进入详情页这条链路已经成立。</p>
         </div>
         <span className="reply-runtime">{writesEnabled ? `当前数据源：${dataSource} / 可写` : `当前数据源：${dataSource} / 只读`}</span>
       </div>


### PR DESCRIPTION
## Summary
- fix the `threads/new` page import so it resolves `forum-data` from the real `src/lib` path
- replace the raw `->` JSX text in the composer intro with plain prose so TypeScript and Next build can parse the page again
- unblock forum-specific CI for follow-up PRs such as `#448`

## Why
`#448` exposed that the current `main` forum tree is already failing before the new smoke assertions even run. The failing checks point to two pre-existing page build problems on `forum/src/app/threads/new`:
- `page.tsx` imports `../../lib/forum-data`, which resolves to `src/app/lib` instead of `src/lib`
- `thread-composer.tsx` contains raw `->` text inside JSX, which the parser rejects as unexpected `>` tokens

Because those failures live on the existing page layer, they should be repaired as a focused forum buildability fix rather than folded into `#448`'s workflow-scope test upgrade.

## Validation
- Root cause confirmed from the failing `#448` Actions logs:
  - `Module checks - Forum #20`
  - `Container checks - Forum #15`
- The reported failures both point at `forum/src/app/threads/new`
- This patch is intentionally limited to the two offending files so the next forum checks can prove the page compiles again

## Impact
- restores buildability of the forum new-thread page on `main`
- gives `#448` a clean base so its page-level smoke expansion can be judged on its own behavior
- keeps the fix separate from the workflow enhancement for easier review
