### PR TITLE
feat(web): connect emptiness with practice and daily routine pages

### DIFF
--- a/frontend/apps/web/src/app/daily-practice/page.tsx
+++ b/frontend/apps/web/src/app/daily-practice/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const pageUrl = siteUrl("/daily-practice");
 const pageTitle = `日常功课怎么安排 | ${brand.name}`;
 const pageDescription =
-  "面向初学者梳理日常功课怎么安排：晨起、白天与晚间可以怎样放进禅修、经文听诵、念佛、阅读与简短回顾，帮助学佛修行、六度与生活真正接在一起。";
+  "面向初学者梳理日常功课怎么安排：晨起、白天与晚间可以怎样放进禅修、经文听诵、念佛、阅读与简短回顾，帮助学佛修行、六度、空性理解与生活真正接在一起。";
 
 const routinePrinciples = [
   {
@@ -114,6 +114,15 @@ const relatedPaths = [
     descriptionEn: "This is the better next page if you want to see how generosity, discipline, patience, diligence, meditation, and wisdom slowly return to morning, daytime, and evening rhythm.",
   },
   {
+    href: "/what-is-emptiness",
+    labelZh: "空性怎么理解",
+    labelEn: "How to Understand Emptiness",
+    titleZh: "把“少一点抓得太死”慢慢接回晨起、白天和晚间。",
+    titleEn: "Return the loosening of rigid grasping to morning, daytime, and evening rhythm.",
+    descriptionZh: "如果你想知道空性为什么不只是离生活很远的名相，而会影响功课节奏、待人处事和每天的回观，这一页会更适合继续往下看。",
+    descriptionEn: "This is the better next page if you want to see why emptiness is not remote from life, but can reshape a routine, relationships, and daily reflection.",
+  },
+  {
     href: "/start-learning-buddhism",
     labelZh: "学佛从哪里开始",
     labelEn: "Where to Begin",
@@ -177,6 +186,12 @@ const faqItems = [
     answerEn: "No. What matters is not never breaking the rhythm, but being able to return after it breaks. When continuity stops, begin again with a smaller version instead of forcing the old plan.",
   },
   {
+    questionZh: "空性怎么理解，和日常功课有什么关系？",
+    questionEn: "How does understanding emptiness relate to a daily practice routine?",
+    answerZh: "如果把空性只当成很远的名相，功课很容易变成完成任务。更稳的方向，是在晨起、白天和晚间慢慢看见：很多情绪和判断并没有想象中那样固定。这样禅修、听诵、念佛和回顾，就会变成帮助自己少一点抓得太死、更多一点清醒和柔软的练习。",
+    answerEn: "If emptiness is treated as a remote term, a daily routine can shrink into task completion. A steadier direction is to notice across morning, daytime, and evening that many emotions and judgments are less fixed than they seemed. Then meditation, listening, recitation, and review become practices of loosening rigid grasping and growing in clarity and softness.",
+  },
+  {
     questionZh: "Fabushi 在日常功课里最适合扮演什么角色？",
     questionEn: "What role does Fabushi play in a daily practice routine?",
     answerZh: "它更适合作为经文听诵、禅修提醒、简短记录和帮助维持连续性的辅助工具，让功课更容易放进每天的生活，而不是只在偶尔想起时才做。",
@@ -196,6 +211,7 @@ export const metadata: Metadata = {
     "初学者功课安排",
     "居士日常修行",
     "六度分别是什么",
+    "空性怎么理解",
     "修行方法",
     "Fabushi",
   ],
@@ -229,7 +245,7 @@ export default function DailyPracticePage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["日常功课", "学佛修行", "初学者功课安排"],
+        about: ["日常功课", "学佛修行", "初学者功课安排", "空性理解"],
       },
       {
         "@type": "BreadcrumbList",
@@ -330,6 +346,12 @@ export default function DailyPracticePage() {
             <LocalizedText
               zh="比较稳妥的功课，不是看起来最完整的那一种，而是最能留下来的那一种。传统修学常重视闻、思、修能否慢慢接续起来。放到今天的生活里，日常功课更像是一条轻轻贯穿一天的线，而不是早晚各做一大段、白天完全断开。"
               en="The steadier routine is usually not the one that looks most complete, but the one that can truly stay alive. Traditional learning often values whether hearing, reflection, and practice can continue into one another. Inside modern life, a daily routine often works better as a light thread through the day than as two heavy blocks that leave the middle empty."
+            />
+          </p>
+          <p>
+            <LocalizedText
+              zh="日常功课的价值，也不只是把几个动作做完。随着晨起、白天和晚间慢慢出现回返点，人会开始看见：很多急躁、执着和判断，并没有想象中那样固定，这也是为什么六度和空性会和功课页放在同一条路上。功课越回到这里，练习就越不只是完成任务，而是在帮助自己多一点清醒和柔软。"
+              en="The value of a daily routine is not only finishing a few actions. As morning, daytime, and evening gain small points of return, people often begin to see that agitation, attachment, and judgment are less fixed than they seemed. This is why the six paramitas and emptiness belong on the same path as a routine page. The more practice returns here, the less it becomes task completion and the more it supports clarity and softness."
             />
           </p>
           <p>

--- a/frontend/apps/web/src/app/practice-guide/page.tsx
+++ b/frontend/apps/web/src/app/practice-guide/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const pageUrl = siteUrl("/practice-guide");
 const pageTitle = `修行方法总览 | ${brand.name}`;
 const pageDescription =
-  "面向初学者梳理学佛修行可以从哪些方法开始：禅修、经文听诵、阅读、念佛与日常记录如何配合，才能把修行、六度与日常生活接在一起。";
+  "面向初学者梳理学佛修行可以从哪些方法开始：禅修、经文听诵、阅读、念佛与日常记录如何配合，才能把修行、六度、空性理解与日常生活接在一起。";
 
 const practicePrinciples = [
   {
@@ -108,6 +108,15 @@ const relatedPaths = [
     descriptionEn: "This is the better next page if you want to see how generosity, discipline, patience, diligence, meditation, and wisdom return to actual practice methods and ordinary conduct.",
   },
   {
+    href: "/what-is-emptiness",
+    labelZh: "空性怎么理解",
+    labelEn: "How to Understand Emptiness",
+    titleZh: "把“少一点抓得太死”慢慢接回练习方式。",
+    titleEn: "Return the loosening of rigid grasping to actual practice methods.",
+    descriptionZh: "如果你想知道空性为什么不是离生活很远的概念，而会影响禅修、念佛、听诵和待人处事，这一页会更适合继续往下看。",
+    descriptionEn: "This is the better next page if you want to see why emptiness is not remote from life, but can reshape meditation, recitation, listening, and ordinary conduct.",
+  },
+  {
     href: "/buddhadharma",
     labelZh: "佛法入门",
     labelEn: "Dharma Basics",
@@ -171,6 +180,12 @@ const faqItems = [
     answerEn: "Yes, but it helps to give them different weights. Choose one main line and let the others support it. Many beginners use listening for familiarity, short meditation for steadiness, and a little reading or note-taking for understanding.",
   },
   {
+    questionZh: "空性怎么理解，和修行方法有什么关系？",
+    questionEn: "How does understanding emptiness relate to actual practice methods?",
+    answerZh: "如果把空性理解成离生活很远的高深义理，修行就容易只剩方法清单。更稳的方向，是先看见很多情绪、判断和习惯并没有想象中那样固定，这样禅修、听诵、念佛和记录就不只是为了完成任务，而是在帮助自己少一点抓得太死。",
+    answerEn: "If emptiness is treated as distant doctrine, practice can shrink into a checklist of methods. A steadier direction is to notice that many emotions, judgments, and habits are less fixed than they seem, so meditation, listening, recitation, and notes become ways of loosening rigid grasping instead of merely finishing tasks.",
+  },
+  {
     questionZh: "Fabushi 在修行方法总览里最适合扮演什么角色？",
     questionEn: "What role does Fabushi play in a beginner practice routine?",
     answerZh: "它更适合作为经文听诵、禅修提醒、修行记录和保持连续性的辅助工具，帮助你把练习接进生活，而不是只停留在偶尔想起时才做。",
@@ -191,6 +206,7 @@ export const metadata: Metadata = {
     "初学者怎么修行",
     "日常功课",
     "六度分别是什么",
+    "空性怎么理解",
     "念佛",
     "Fabushi",
   ],
@@ -224,7 +240,7 @@ export default function PracticeGuidePage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["修行方法", "学佛修行", "日常功课"],
+        about: ["修行方法", "学佛修行", "日常功课", "空性理解"],
       },
       {
         "@type": "BreadcrumbList",
@@ -325,6 +341,12 @@ export default function PracticeGuidePage() {
             <LocalizedText
               zh="比较稳妥的做法，是先让自己每天有一个最轻但真实的动作。可以是坐几分钟禅修，也可以是听一段经文、念一小段佛号，或读一点导读。传统学习里常说闻、思、修要相续，对初学者来说，这并不意味着一天里要把所有事情都做满，而是让接触、理解和实践慢慢连起来。"
               en="A steadier approach is to keep one light but real daily action. It can be a few minutes of meditation, one short scripture passage, a small round of recitation, or a little reading. Traditional learning often treats hearing, reflection, and practice as a sequence. For beginners, that does not mean filling the whole day, but letting contact, understanding, and lived practice connect gradually."
+            />
+          </p>
+          <p>
+            <LocalizedText
+              zh="修行方法最后不只是在练几种技能。随着节奏慢慢稳定，人也会开始看见：很多急躁、执着和判断，并没有想象中那样固定，这也是为什么六度和空性会和方法页放在同一条路上。方法越回到这里，练习就越不只是完成任务，而是在帮助自己少一点抓得太死。"
+              en="Practice methods are not only a set of techniques. As the rhythm steadies, people often begin to see that agitation, attachment, and judgment are less fixed than they seem. This is why the six paramitas and emptiness belong on the same path as method pages. The more practice returns here, the less it becomes task-completion and the more it helps loosen rigid grasping."
             />
           </p>
           <p>


### PR DESCRIPTION
## 问题

官网当前已经有：

- `/what-is-emptiness`
- `/what-are-the-six-paramitas`
- `/practice-guide`
- `/daily-practice`

其中“空性怎么理解”这张概念页，已经进入首页、页脚、站点地图和相关概念页，但它和两张实践页之间仍主要是单向关系：

- `/what-is-emptiness` 已经会把读者引到 `/practice-guide` 和 `/daily-practice`
- 但 `/practice-guide` 与 `/daily-practice` 本身还没有把“空性怎样回到修行方法 / 日常功课”说清楚
- 这会让站内在“概念理解 -> 练习方法 -> 日常节奏”这条路径上，少一层很关键的双向连接

当前更高收益的动作，不是再开新页，而是先把这条回路补完整。

## 这次改动

- 更新 `frontend/apps/web/src/app/practice-guide/page.tsx`
  - metadata description 与 keywords 补入“空性怎么理解”信号
  - JSON-LD `about` 补入 `空性理解`
  - 导读段落新增“修行方法为什么会和空性放在同一条路上”的解释
  - `继续阅读` 新增 `/what-is-emptiness` 入口
  - FAQ 新增“空性怎么理解，和修行方法有什么关系？”
- 更新 `frontend/apps/web/src/app/daily-practice/page.tsx`
  - metadata description 与 keywords 补入“空性怎么理解”信号
  - JSON-LD `about` 补入 `空性理解`
  - 导读段落新增“日常功课为什么会和空性放在同一条路上”的解释
  - `继续阅读` 新增 `/what-is-emptiness` 入口
  - FAQ 新增“空性怎么理解，和日常功课有什么关系？”

## 为什么现在做

这一步的收益很集中：

- 把“概念页 -> 实践页”的单向发现路径，补成更完整的双向互链
- 让 `/practice-guide` 与 `/daily-practice` 不只承接“怎么练”，也开始更自然承接“为什么练习会帮助人少一点抓得太死”这一层理解
- 用最小改动同时补到：正文解释、FAQ、关键词、结构化语义和继续阅读入口
- 不需要再引入新模板、新路由或新的视觉承载位

## 配图判断

- 本轮没有新增配图。
- 原因没有变化：当前佛法知识页线上稳定承载仍以长文本、FAQ、Breadcrumb / ItemList 为主，还没有已经验证过的佛法专题图承载位。
- 这次更高收益的动作，是先把“空性如何落回练习”这条站内路径补成闭环。

## 验证

- compare 已确认本分支官网改动只收敛在 2 个文件：
  - `frontend/apps/web/src/app/practice-guide/page.tsx`
  - `frontend/apps/web/src/app/daily-practice/page.tsx`
- compare 同时确认主线在执行期间继续前进，但新增文件只落在论坛相关路径，不与本次官网改动重叠
- 已回读分支文件，确认两张实践页都已补上：
  - 空性相关 metadata / keywords
  - FAQ 问答
  - `继续阅读` 内链
  - 解释“空性如何回到练习与日常”的正文段落
- 当前环境没有仓库本地 checkout，无法直接运行 Next.js 构建；最终检查依赖仓库 CI

## 预期改善

- `/practice-guide` 与 `/daily-practice` 会更明确承接“空性怎么理解”和实践类搜索 / 阅读意图之间的连接
- 站内会第一次把“空性 -> 修行方法 -> 日常功课”做成更完整的双向路径，而不只是概念页单向分发
- 读者从方法页和功课页继续往下读时，更容易进入概念理解，而不只停在方法清单层