### PR TITLE
feat(forum): persist moderation timeline alongside thread writes

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -61,6 +61,7 @@ jobs:
           assert payload["persistenceMode"] == "sqlite-file", payload
           assert payload["writesEnabled"] is True, payload
           assert payload["counts"]["threads"] >= 4, payload
+          assert payload["counts"]["moderationEvents"] >= 4, payload
           PY
 
       - name: Smoke test forum writable page surfaces
@@ -99,6 +100,8 @@ jobs:
           assert payload["thread"]["sectionSlug"] == "newcomer-path", payload
           assert payload["thread"]["title"].startswith("容器页面检查"), payload
           assert payload["thread"]["openingPost"], payload
+          assert payload["moderationEvents"][-1]["eventType"] == "thread-created", payload
+          assert "新主题已发布" in payload["moderationEvents"][-1]["summary"], payload
           print(payload["thread"]["slug"])
           PY
 
@@ -121,6 +124,7 @@ jobs:
           assert payload["source"] == "sqlite", payload
           assert payload["thread"]["slug"], payload
           assert payload["thread"]["author"] == "页面检查用户", payload
+          assert payload["moderationEvents"][-1]["eventType"] == "thread-created", payload
           PY
 
           thread_list_page="$(curl --fail --show-error --silent http://127.0.0.1:3000/threads)"
@@ -143,6 +147,8 @@ jobs:
           assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:2000]
           assert "页面检查用户" in html, html[:2000]
           assert "写一条最小回复" in html, html[:2000]
+          assert "审核时间线" in html, html[:3000]
+          assert "新主题已发布" in html, html[:4000]
           PY
 
           echo "thread_slug=${slug}" >> "$GITHUB_ENV"
@@ -170,6 +176,8 @@ jobs:
           assert payload["thread"]["lastActivity"] == "刚刚回复", payload
           assert payload["replies"][-1]["author"] == "页面回复检查", payload
           assert payload["replies"][-1]["body"], payload
+          assert payload["moderationEvents"][-1]["eventType"] == "reply-created", payload
+          assert "新回复已写入时间线" in payload["moderationEvents"][-1]["summary"], payload
           PY
 
           thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${thread_slug}")"
@@ -182,6 +190,7 @@ jobs:
           assert "页面回复检查" in html, html[:4000]
           assert "页面回读验证" in html, html[:4000]
           assert "这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。" in html, html[:4000]
+          assert "新回复已写入时间线" in html, html[:5000]
           PY
 
       - name: Stop forum container

--- a/forum/README.md
+++ b/forum/README.md
@@ -18,6 +18,7 @@ Current scope:
 - a page-level thread composer on top of the thread-creation API in writable mode
 - a minimal reply-creation API for existing threads in sqlite mode
 - a page-level reply composer on thread detail when writes are enabled
+- a first moderation-event timeline that can be read back from thread detail and runtime status
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
 - a container smoke check that starts the forum, validates `/api/status`, exercises sqlite thread and reply creation, and reads the updated thread back through real forum pages
@@ -36,6 +37,7 @@ Included:
 - structured seed content contract
 - read-only API boundary
 - moderation and knowledge-stage fields reserved in the content model
+- a first moderation-event timeline for thread publishing and new sqlite writes
 - a runtime status endpoint for deployment smoke checks
 - a first durable persistence path backed by sqlite file storage
 - a first reply write path for existing threads
@@ -45,7 +47,7 @@ Not included yet:
 
 - authentication
 - search, notifications, bookmarks, or follows as real user actions
-- moderation workflows beyond reserved fields and write-state checks
+- moderation workflows beyond the first persisted timeline and write-state checks
 
 ## Local development
 
@@ -84,12 +86,13 @@ curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
     "trustSignal": "回复已按主题聚焦提交，等待更多互动后再决定是否沉淀。",
     "body": ["我发现先把睡前十分钟固定下来，比一下子改整天作息更容易坚持。"]
   }'
+curl http://localhost:3000/api/thread/first-year-stability
 curl http://localhost:3000/threads/new
 curl http://localhost:3000/threads
 curl http://localhost:3000/threads/first-year-stability
 ```
 
-When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/new` to create a new topic, and `http://localhost:3000/threads/first-year-stability` to submit a reply through the page-level form. In `seed-json` mode, both page-level forms stay visible but clearly report that the runtime is still read-only.
+When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/new` to create a new topic, and `http://localhost:3000/threads/first-year-stability` to submit a reply through the page-level form. In `seed-json` mode, both page-level forms stay visible but clearly report that the runtime is still read-only. `GET /api/thread/[slug]` now includes `moderationEvents`, so thread detail can expose the first durable governance timeline instead of only content fields.
 
 ## Runtime contract
 
@@ -109,7 +112,7 @@ Current JSON routes:
 - `POST /api/thread/[slug]/replies`
 - `GET /api/status`
 
-`GET /api/status` now reports whether writes are enabled for the current data source. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, lets the page-level thread composer create new topics, and lets existing threads accept the first persisted reply submissions.
+`GET /api/status` now reports whether writes are enabled for the current data source and how many moderation events the current store already contains. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, writes the first moderation timeline events alongside newly created threads and replies, lets the page-level thread composer create new topics, and lets existing threads accept the first persisted reply submissions.
 
 ## Container deployment
 
@@ -132,8 +135,8 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, confirms `/threads/new` exposes the writable page-level composer, creates a thread through the API, reads that thread back through `/threads` and `/threads/[slug]`, and then adds a reply to verify the updated discussion is visible on the thread detail page.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, confirms `/threads/new` exposes the writable page-level composer, creates a thread through the API, reads that thread back through `/threads` and `/threads/[slug]`, and then adds a reply to verify both the updated discussion and the appended moderation timeline event are visible on the thread detail page.
 
 ## Why this is the next step
 
-After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, first reply write path, and page-level reply submission landed, the next highest-value gap was proving that the same sqlite interaction loop is visible through the real page layer, not just through JSON endpoints. This iteration keeps the product surface narrow while making deployment checks more trustworthy, so the next pass can focus on moderation events, role state, and more explicit newcomer guidance instead of rediscovering whether the current forum pages still reflect newly written content.
+After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, first reply write path, page-level reply submission, page-level thread creation, and page-level sqlite readback checks landed, the next highest-value gap was turning governance signals into durable data rather than leaving them in copy alone. This iteration keeps the product surface narrow while making moderation state inspectable through the same repository and page boundary, so the next pass can focus on role state and more explicit newcomer guidance instead of rediscovering whether governance events survive real writes.

--- a/forum/src/app/page.tsx
+++ b/forum/src/app/page.tsx
@@ -20,20 +20,20 @@ export default function HomePage() {
           </nav>
         </div>
 
-        <h1>把论坛从占位目录推进成真正能承接互动的独立项目。</h1>
+        <h1>把论坛从占位目录推进成真正能承接互动与治理的独立项目。</h1>
         <p>
-          这一版先不追求完整社区能力，而是先把独立运行骨架、sqlite 最小写入、帖子详情回复和页面层主题创建入口接起来，
-          让下一轮可以直接接审核状态、鉴权和更完整的用户流程。
+          这一版先不追求完整社区能力，而是先把独立运行骨架、sqlite 最小写入、帖子详情回复、页面层主题创建入口和首条审核时间线接起来，
+          让下一轮可以直接接角色状态、新手引导和更完整的用户流程。
         </p>
 
         <div className="hero-grid">
           <article className="panel">
             <h2>当前阶段</h2>
-            <p>sqlite 最小互动闭环。目标是让论坛从“能启动、能浏览”进入“能发起主题、能回复、能继续扩展”的状态。</p>
+            <p>sqlite 最小互动闭环加首条治理时间线。目标是让论坛从“能发起主题、能回复”进入“每次写入都会留下可回读的审核状态”。</p>
           </article>
           <article className="panel">
             <h2>下一步承接点</h2>
-            <p>优先把审核事件、角色状态和新手引导沿着同一条页面到仓储链路继续持久化，而不是回到静态占位页面。</p>
+            <p>优先把角色状态和新手引导沿着同一条页面到仓储链路继续持久化，而不是回到静态占位页面。</p>
           </article>
         </div>
       </section>
@@ -73,7 +73,7 @@ export default function HomePage() {
 
       <section className="api-note">
         <h2>当前接口边界</h2>
-        <p>论坛页面已经不再直接读取种子文件，而是统一经过仓储边界。当前环境也会明确显示是否处于可写模式。</p>
+        <p>论坛页面已经不再直接读取种子文件，而是统一经过仓储边界。当前环境也会明确显示是否处于可写模式，以及当前治理时间线已经累计了多少条事件。</p>
         <p className="code">GET /api/threads</p>
         <p className="code">POST /api/threads</p>
         <p className="code">GET /api/thread/[slug]</p>
@@ -82,6 +82,7 @@ export default function HomePage() {
         <div className="footer-note">
           <span>sections: {snapshot.sections.length}</span>
           <span>threads: {snapshot.threads.length}</span>
+          <span>moderation events: {snapshot.moderationEvents.length}</span>
           <span>source: {snapshot.source}</span>
           <span>{runtime.writesEnabled ? "writes enabled" : "read-only"}</span>
         </div>

--- a/forum/src/app/threads/[slug]/page.tsx
+++ b/forum/src/app/threads/[slug]/page.tsx
@@ -18,7 +18,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
   }
 
   const runtime = getForumRuntimeStatus();
-  const { thread, section, replies } = detail;
+  const { thread, section, replies, moderationEvents } = detail;
 
   return (
     <main>
@@ -104,6 +104,25 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
         </section>
 
         <section className="list-block">
+          <h2>审核时间线</h2>
+          {moderationEvents.length > 0 ? (
+            <ul>
+              {moderationEvents.map((event) => (
+                <li key={event.id}>
+                  <strong>{event.actorLabel}</strong>
+                  {" · "}
+                  {event.createdAt}
+                  {" · "}
+                  {event.summary}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>当前线程还没有新的审核事件，后续真实治理动作会继续沿着这条时间线落库。</p>
+          )}
+        </section>
+
+        <section className="list-block">
           <h2>当前值得沉淀的要点</h2>
           <ul>
             {thread.takeaways.map((item) => (
@@ -114,7 +133,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
 
         <section className="api-note">
           <h2>后续扩展位置</h2>
-          <p>下一轮可以继续把同一条链路扩到主题创建页、审核事件时间线和角色状态持久化。</p>
+          <p>下一轮可以继续把角色状态和新手引导沿着同一条页面到仓储链路持久化，而不是把治理能力留在展示文案里。</p>
           <div className="footer-note">
             <span>作者：{thread.author}</span>
             <span>发布时间：{thread.publishedAt}</span>

--- a/forum/src/lib/forum-data.ts
+++ b/forum/src/lib/forum-data.ts
@@ -5,6 +5,7 @@ export type ForumDataSource = "seed-json" | "sqlite";
 export type ForumPersistenceMode = "seed-only" | "sqlite-file";
 export type ForumModerationState = "published" | "needs-review" | "archived";
 export type ForumKnowledgeStage = "discussion" | "candidate" | "archived";
+export type ForumModerationEventType = "thread-published" | "thread-created" | "reply-created";
 
 export interface ForumSection {
   slug: string;
@@ -43,6 +44,16 @@ export interface ForumReply {
   body: string[];
 }
 
+export interface ForumModerationEvent {
+  id: string;
+  threadSlug: string;
+  replyId?: string;
+  eventType: ForumModerationEventType;
+  actorLabel: string;
+  summary: string;
+  createdAt: string;
+}
+
 export interface ForumSectionSummary extends ForumSection {
   threadCount: number;
   replyCount: number;
@@ -52,6 +63,7 @@ export interface ForumThreadDetail {
   thread: ForumThread;
   section?: ForumSection;
   replies: ForumReply[];
+  moderationEvents: ForumModerationEvent[];
   source: ForumDataSource;
   generatedAt: string;
 }
@@ -60,6 +72,7 @@ export interface ForumSnapshot {
   sections: ForumSectionSummary[];
   threads: ForumThread[];
   replies: ForumReply[];
+  moderationEvents: ForumModerationEvent[];
   generatedAt: string;
   source: ForumDataSource;
 }
@@ -91,6 +104,7 @@ export interface ForumRuntimeStatus {
     sections: number;
     threads: number;
     replies: number;
+    moderationEvents: number;
   };
   generatedAt: string;
 }
@@ -115,10 +129,12 @@ export interface ForumRepository {
   getSections(): ForumSection[];
   getThreads(): ForumThread[];
   getReplies(): ForumReply[];
+  getModerationEvents(): ForumModerationEvent[];
   getSectionBySlug(slug: string): ForumSection | undefined;
   getThreadBySlug(slug: string): ForumThread | undefined;
   getThreadsBySection(sectionSlug: string): ForumThread[];
   getRepliesByThreadSlug(threadSlug: string): ForumReply[];
+  getModerationEventsByThreadSlug(threadSlug: string): ForumModerationEvent[];
   getThreadDetailBySlug(slug: string): ForumThreadDetail | undefined;
   getSnapshot(): ForumSnapshot;
   getRuntimeStatus(): ForumRuntimeStatus;
@@ -169,6 +185,10 @@ export function getThreadsBySection(sectionSlug: string) {
 
 export function getRepliesByThreadSlug(threadSlug: string) {
   return forumRepository.getRepliesByThreadSlug(threadSlug);
+}
+
+export function getModerationEventsByThreadSlug(threadSlug: string) {
+  return forumRepository.getModerationEventsByThreadSlug(threadSlug);
 }
 
 export function getThreadDetailBySlug(slug: string) {

--- a/forum/src/lib/forum-seed-repository.ts
+++ b/forum/src/lib/forum-seed-repository.ts
@@ -2,6 +2,7 @@ import forumContent from "../data/forum-content.json";
 import type {
   CreateForumReplyInput,
   CreateForumThreadInput,
+  ForumModerationEvent,
   ForumReply,
   ForumRepository,
   ForumRuntimeStatus,
@@ -18,17 +19,39 @@ interface ForumContentStore {
   replies: ForumReply[];
 }
 
+function describeSeedModerationSummary(thread: ForumThread) {
+  if (thread.knowledgeStage === "candidate") {
+    return "种子主题已发布，并标记为候选资料，后续适合继续整理。";
+  }
+
+  return "种子主题已发布，当前仍处于讨论沉淀阶段。";
+}
+
+function buildSeedModerationEvents(threads: ForumThread[]): ForumModerationEvent[] {
+  return threads.map((thread) => ({
+    id: `seed-thread-published-${thread.slug}`,
+    threadSlug: thread.slug,
+    eventType: "thread-published",
+    actorLabel: "论坛种子内容",
+    summary: describeSeedModerationSummary(thread),
+    createdAt: thread.publishedAt,
+  }));
+}
+
 const content = forumContent as ForumContentStore;
 
 export function createSeedForumRepository(): ForumRepository {
   const sections = content.sections;
   const threads = content.threads;
   const replies = content.replies;
+  const moderationEvents = buildSeedModerationEvents(threads);
 
   const getSectionBySlug = (slug: string) => sections.find((section) => section.slug === slug);
   const getThreadBySlug = (slug: string) => threads.find((thread) => thread.slug === slug);
   const getThreadsBySection = (sectionSlug: string) => threads.filter((thread) => thread.sectionSlug === sectionSlug);
   const getRepliesByThreadSlug = (threadSlug: string) => replies.filter((reply) => reply.threadSlug === threadSlug);
+  const getModerationEventsByThreadSlug = (threadSlug: string) =>
+    moderationEvents.filter((event) => event.threadSlug === threadSlug);
 
   const getThreadDetailBySlug = (slug: string): ForumThreadDetail | undefined => {
     const thread = getThreadBySlug(slug);
@@ -41,6 +64,7 @@ export function createSeedForumRepository(): ForumRepository {
       thread,
       section: getSectionBySlug(thread.sectionSlug),
       replies: getRepliesByThreadSlug(thread.slug),
+      moderationEvents: getModerationEventsByThreadSlug(thread.slug),
       source: "seed-json",
       generatedAt: new Date().toISOString(),
     };
@@ -59,6 +83,7 @@ export function createSeedForumRepository(): ForumRepository {
     }),
     threads,
     replies,
+    moderationEvents,
     generatedAt: new Date().toISOString(),
     source: "seed-json",
   });
@@ -73,6 +98,7 @@ export function createSeedForumRepository(): ForumRepository {
       sections: sections.length,
       threads: threads.length,
       replies: replies.length,
+      moderationEvents: moderationEvents.length,
     },
     generatedAt: new Date().toISOString(),
   });
@@ -91,10 +117,12 @@ export function createSeedForumRepository(): ForumRepository {
     getSections: () => sections,
     getThreads: () => threads,
     getReplies: () => replies,
+    getModerationEvents: () => moderationEvents,
     getSectionBySlug,
     getThreadBySlug,
     getThreadsBySection,
     getRepliesByThreadSlug,
+    getModerationEventsByThreadSlug,
     getThreadDetailBySlug,
     getSnapshot,
     getRuntimeStatus,

--- a/forum/src/lib/forum-sqlite-repository.ts
+++ b/forum/src/lib/forum-sqlite-repository.ts
@@ -5,6 +5,7 @@ import forumContent from "../data/forum-content.json";
 import type {
   CreateForumReplyInput,
   CreateForumThreadInput,
+  ForumModerationEvent,
   ForumReply,
   ForumRepository,
   ForumRuntimeStatus,
@@ -58,12 +59,46 @@ interface SqliteReplyRow {
   body_json: string;
 }
 
+interface SqliteModerationEventRow {
+  id: string;
+  thread_slug: string;
+  reply_id: string | null;
+  event_type: ForumModerationEvent["eventType"];
+  actor_label: string;
+  summary: string;
+  created_at: string;
+}
+
 const seedContent = forumContent as ForumContentStore;
 const DEFAULT_DATABASE_URL = "file:./data/forum.db";
 
 function parseJsonArray(value: string): string[] {
   const parsed = JSON.parse(value) as unknown;
   return Array.isArray(parsed) ? parsed.map((item) => String(item)) : [];
+}
+
+function describeSeedModerationSummary(thread: ForumThread) {
+  if (thread.knowledgeStage === "candidate") {
+    return "种子主题已发布，并标记为候选资料，后续适合继续整理。";
+  }
+
+  return "种子主题已发布，当前仍处于讨论沉淀阶段。";
+}
+
+function describeThreadCreationSummary(sectionSlug: string) {
+  if (sectionSlug === "newcomer-path") {
+    return "新主题已发布，并进入新手起步引导队列，后续可继续补充适用对象与已尝试方法。";
+  }
+
+  return "新主题已发布，后续可根据互动质量继续补充治理判断和资料沉淀。";
+}
+
+function describeReplyCreationSummary(sectionSlug: string) {
+  if (sectionSlug === "newcomer-path") {
+    return "新回复已写入时间线，适合后续继续补充适用对象与已尝试方法。";
+  }
+
+  return "新回复已写入时间线，等待更多互动后再判断是否适合沉淀。";
 }
 
 function mapSection(row: SqliteSectionRow): ForumSection {
@@ -106,6 +141,18 @@ function mapReply(row: SqliteReplyRow): ForumReply {
     moderationState: row.moderation_state,
     trustSignal: row.trust_signal,
     body: parseJsonArray(row.body_json),
+  };
+}
+
+function mapModerationEvent(row: SqliteModerationEventRow): ForumModerationEvent {
+  return {
+    id: row.id,
+    threadSlug: row.thread_slug,
+    replyId: row.reply_id ?? undefined,
+    eventType: row.event_type,
+    actorLabel: row.actor_label,
+    summary: row.summary,
+    createdAt: row.created_at,
   };
 }
 
@@ -194,6 +241,18 @@ function initializeSchema(database: DatabaseSync) {
       body_json TEXT NOT NULL,
       FOREIGN KEY (thread_slug) REFERENCES forum_threads(slug)
     );
+
+    CREATE TABLE IF NOT EXISTS forum_moderation_events (
+      id TEXT PRIMARY KEY,
+      thread_slug TEXT NOT NULL,
+      reply_id TEXT,
+      event_type TEXT NOT NULL,
+      actor_label TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (thread_slug) REFERENCES forum_threads(slug),
+      FOREIGN KEY (reply_id) REFERENCES forum_replies(id)
+    );
   `);
 }
 
@@ -241,6 +300,18 @@ function seedDatabaseIfEmpty(database: DatabaseSync) {
     )
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `);
+  const insertModerationEvent = database.prepare(`
+    INSERT INTO forum_moderation_events (
+      id,
+      thread_slug,
+      reply_id,
+      event_type,
+      actor_label,
+      summary,
+      created_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
 
   database.exec("BEGIN");
 
@@ -272,6 +343,16 @@ function seedDatabaseIfEmpty(database: DatabaseSync) {
         JSON.stringify(thread.takeaways),
         thread.moderationState,
         thread.knowledgeStage,
+      );
+
+      insertModerationEvent.run(
+        `seed-thread-published-${thread.slug}`,
+        thread.slug,
+        null,
+        "thread-published",
+        "论坛种子内容",
+        describeSeedModerationSummary(thread),
+        thread.publishedAt,
       );
     }
 
@@ -323,6 +404,23 @@ function nextReplyId(database: DatabaseSync, threadSlug: string): string {
   let suffix = 2;
 
   while (existingReply.get(`${baseId}-${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${baseId}-${suffix}`;
+}
+
+function nextModerationEventId(database: DatabaseSync, threadSlug: string, eventType: ForumModerationEvent["eventType"]): string {
+  const baseId = `event-${eventType}-${threadSlug}-${Date.now().toString(36)}`;
+  const existingEvent = database.prepare("SELECT id FROM forum_moderation_events WHERE id = ? LIMIT 1");
+
+  if (!existingEvent.get(baseId)) {
+    return baseId;
+  }
+
+  let suffix = 2;
+
+  while (existingEvent.get(`${baseId}-${suffix}`)) {
     suffix += 1;
   }
 
@@ -391,6 +489,25 @@ export function createSqliteForumRepository(): ForumRepository {
       .all() as unknown as SqliteReplyRow[];
 
     return rows.map(mapReply);
+  };
+
+  const getModerationEvents = (): ForumModerationEvent[] => {
+    const rows = database
+      .prepare(`
+        SELECT
+          id,
+          thread_slug,
+          reply_id,
+          event_type,
+          actor_label,
+          summary,
+          created_at
+        FROM forum_moderation_events
+        ORDER BY created_at ASC, id ASC
+      `)
+      .all() as unknown as SqliteModerationEventRow[];
+
+    return rows.map(mapModerationEvent);
   };
 
   const getSectionBySlug = (slug: string): ForumSection | undefined => {
@@ -478,6 +595,26 @@ export function createSqliteForumRepository(): ForumRepository {
     return rows.map(mapReply);
   };
 
+  const getModerationEventsByThreadSlug = (threadSlug: string): ForumModerationEvent[] => {
+    const rows = database
+      .prepare(`
+        SELECT
+          id,
+          thread_slug,
+          reply_id,
+          event_type,
+          actor_label,
+          summary,
+          created_at
+        FROM forum_moderation_events
+        WHERE thread_slug = ?
+        ORDER BY created_at ASC, id ASC
+      `)
+      .all(threadSlug) as unknown as SqliteModerationEventRow[];
+
+    return rows.map(mapModerationEvent);
+  };
+
   const getThreadDetailBySlug = (slug: string): ForumThreadDetail | undefined => {
     const thread = getThreadBySlug(slug);
 
@@ -489,6 +626,7 @@ export function createSqliteForumRepository(): ForumRepository {
       thread,
       section: getSectionBySlug(thread.sectionSlug),
       replies: getRepliesByThreadSlug(thread.slug),
+      moderationEvents: getModerationEventsByThreadSlug(thread.slug),
       source: "sqlite",
       generatedAt: new Date().toISOString(),
     };
@@ -498,6 +636,7 @@ export function createSqliteForumRepository(): ForumRepository {
     const sections = getSections();
     const threads = getThreads();
     const replies = getReplies();
+    const moderationEvents = getModerationEvents();
 
     return {
       sections: sections.map((section) => {
@@ -512,6 +651,7 @@ export function createSqliteForumRepository(): ForumRepository {
       }),
       threads,
       replies,
+      moderationEvents,
       generatedAt: new Date().toISOString(),
       source: "sqlite",
     };
@@ -523,9 +663,10 @@ export function createSqliteForumRepository(): ForumRepository {
         SELECT
           (SELECT COUNT(*) FROM forum_sections) AS sections,
           (SELECT COUNT(*) FROM forum_threads) AS threads,
-          (SELECT COUNT(*) FROM forum_replies) AS replies
+          (SELECT COUNT(*) FROM forum_replies) AS replies,
+          (SELECT COUNT(*) FROM forum_moderation_events) AS moderation_events
       `)
-      .get() as { sections: number; threads: number; replies: number };
+      .get() as { sections: number; threads: number; replies: number; moderation_events: number };
 
     return {
       service: "forum",
@@ -537,6 +678,7 @@ export function createSqliteForumRepository(): ForumRepository {
         sections: Number(countsRow.sections),
         threads: Number(countsRow.threads),
         replies: Number(countsRow.replies),
+        moderationEvents: Number(countsRow.moderation_events),
       },
       generatedAt: new Date().toISOString(),
     };
@@ -557,42 +699,72 @@ export function createSqliteForumRepository(): ForumRepository {
       throw new ForumInputError("Thread openingPost must contain at least one non-empty paragraph.");
     }
 
-    database.prepare(`
-      INSERT INTO forum_threads (
+    database.exec("BEGIN");
+
+    try {
+      database.prepare(`
+        INSERT INTO forum_threads (
+          slug,
+          section_slug,
+          title,
+          summary,
+          author,
+          published_at,
+          last_activity,
+          reply_count,
+          follow_count,
+          bookmark_count,
+          tags_json,
+          opening_post_json,
+          takeaways_json,
+          moderation_state,
+          knowledge_stage
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
         slug,
-        section_slug,
-        title,
-        summary,
-        author,
-        published_at,
-        last_activity,
-        reply_count,
-        follow_count,
-        bookmark_count,
-        tags_json,
-        opening_post_json,
-        takeaways_json,
-        moderation_state,
-        knowledge_stage
-      )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      slug,
-      input.sectionSlug,
-      input.title,
-      input.summary,
-      input.author,
-      createdAt,
-      "刚刚创建",
-      0,
-      0,
-      0,
-      JSON.stringify(input.tags),
-      JSON.stringify(openingPost),
-      JSON.stringify([]),
-      "published",
-      "discussion",
-    );
+        input.sectionSlug,
+        input.title,
+        input.summary,
+        input.author,
+        createdAt,
+        "刚刚创建",
+        0,
+        0,
+        0,
+        JSON.stringify(input.tags),
+        JSON.stringify(openingPost),
+        JSON.stringify([]),
+        "published",
+        "discussion",
+      );
+
+      database.prepare(`
+        INSERT INTO forum_moderation_events (
+          id,
+          thread_slug,
+          reply_id,
+          event_type,
+          actor_label,
+          summary,
+          created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        nextModerationEventId(database, slug, "thread-created"),
+        slug,
+        null,
+        "thread-created",
+        "系统记录",
+        describeThreadCreationSummary(input.sectionSlug),
+        createdAt,
+      );
+
+      database.exec("COMMIT");
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
 
     const createdDetail = getThreadDetailBySlug(slug);
 
@@ -653,6 +825,27 @@ export function createSqliteForumRepository(): ForumRepository {
         WHERE slug = ?
       `).run("刚刚回复", input.threadSlug);
 
+      database.prepare(`
+        INSERT INTO forum_moderation_events (
+          id,
+          thread_slug,
+          reply_id,
+          event_type,
+          actor_label,
+          summary,
+          created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        nextModerationEventId(database, input.threadSlug, "reply-created"),
+        input.threadSlug,
+        replyId,
+        "reply-created",
+        "系统记录",
+        describeReplyCreationSummary(thread.sectionSlug),
+        createdAt,
+      );
+
       database.exec("COMMIT");
     } catch (error) {
       database.exec("ROLLBACK");
@@ -674,10 +867,12 @@ export function createSqliteForumRepository(): ForumRepository {
     getSections,
     getThreads,
     getReplies,
+    getModerationEvents,
     getSectionBySlug,
     getThreadBySlug,
     getThreadsBySection,
     getRepliesByThreadSlug,
+    getModerationEventsByThreadSlug,
     getThreadDetailBySlug,
     getSnapshot,
     getRuntimeStatus,


### PR DESCRIPTION
## 问题

论坛现在已经有了：

- sqlite 主题创建写入
- sqlite 回复写入
- 页面层 `threads/new` 发帖入口
- 页面层帖子详情回复表单
- 容器级页面回读 smoke check

但治理状态仍基本停留在展示字段和说明文案里：

- 主题和回复写入后，不会留下真实可回读的审核事件
- `GET /api/status` 还不能反映论坛当前已经累计了多少条治理事件
- 帖子详情页虽然已有治理语义，但还没有一条真实时间线来承接“这条内容经历了什么状态变化”

这会让论坛继续停在“能写内容”，但还没有迈进“写入后有最小治理状态可追踪”的阶段。

## 这次改动

- 更新 `forum/src/lib/forum-data.ts`
  - 新增 `ForumModerationEvent` 契约
  - 让 `ForumThreadDetail`、`ForumSnapshot` 和 `ForumRuntimeStatus` 一起承接治理事件数据
- 更新 `forum/src/lib/forum-seed-repository.ts`
  - 为现有种子主题生成首条 `thread-published` 治理事件
  - 让 `seed-json` 模式下的详情页结构也能直接承接审核时间线
- 更新 `forum/src/lib/forum-sqlite-repository.ts`
  - 新增 `forum_moderation_events` 表
  - 在种子导入时写入首条主题发布事件
  - 在新建主题时写入 `thread-created`
  - 在新建回复时写入 `reply-created`
  - 让运行时状态开始统计治理事件数量
- 更新 `forum/src/app/threads/[slug]/page.tsx`
  - 新增“审核时间线”区块
  - 直接展示当前线程的治理事件，避免治理能力继续停留在文案说明里
- 更新 `forum/src/app/page.tsx`
  - 把首页阶段说明和运行态摘要对齐到“首条治理事件已持久化”的状态
- 更新 `.github/workflows/forum-container-checks.yml`
  - 在 sqlite 容器检查中新增治理事件断言
  - 既验证新主题会追加 `thread-created`
  - 也验证新回复会追加 `reply-created`
- 更新 `forum/README.md`
  - 文档化治理时间线、状态计数和本地 / 容器验证方式

## 为什么现在做

在页面级最小互动闭环已经形成、页面级 readback 检查也已进入主线之后，当前最高收益切片不是再开一个新页面，而是把首条治理状态真正推进到持久化层。

这一步的收益很集中：

- 论坛第一次不只写入内容，也写入可回读的治理事件
- 页面层、API 和容器检查会一起承接这条时间线，不容易再次脱节
- 下一轮角色状态和新手引导可以直接沿着同一条仓储与页面边界继续扩展

## 验证

- compare 已确认本分支相对 `main`：`ahead_by = 7`、`behind_by = 0`
- 改动范围收敛在 7 个论坛相关文件：
  - `.github/workflows/forum-container-checks.yml`
  - `forum/README.md`
  - `forum/src/app/page.tsx`
  - `forum/src/app/threads/[slug]/page.tsx`
  - `forum/src/lib/forum-data.ts`
  - `forum/src/lib/forum-seed-repository.ts`
  - `forum/src/lib/forum-sqlite-repository.ts`
- 已通过 GitHub compare 回读确认：
  - sqlite 状态计数开始承接 `moderationEvents`
  - 新主题和新回复写入都会追加治理事件
  - 帖子详情页已经新增“审核时间线”区块
  - 容器 smoke check 已开始对治理事件进行断言
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build`、`docker build ./forum` 或浏览器级手动检查
- 最终检查依赖仓库现有 Actions：
  - `CI`
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 把主题作者/回复作者的角色状态与新手引导信号沿着现有页面表单、API 和 sqlite 仓储继续持久化
- 再把页面级 smoke check 扩到这些新字段，避免治理链路重新回退成只靠展示文案
