### PR TITLE
chore: sync beta release state for v1.0.0-208-mobile.56c0652a910d

### DIFF
--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -7,29 +7,29 @@
       "title": "Android Beta",
       "description": "官网直接读取最新发布版本的 APK 安装包，安装包发布后这里会自动更新。",
       "primaryLabel": "下载 Android Beta",
-      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-148-mobile.01aa4666d6e6/fabushi-android-arm64-01aa4666d6e6.apk",
-      "version": "v1.0.0-148-mobile.01aa4666d6e6",
-      "publishedAt": "2026-05-14T00:47:16Z",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-208-mobile.56c0652a910d/fabushi-android-arm64-56c0652a910d.apk",
+      "version": "v1.0.0-208-mobile.56c0652a910d",
+      "publishedAt": "2026-05-16T13:53:58Z",
       "updateSummary": [
-        "PR #359: feat(web): comprehensive UI/UX overhaul to world-class Bento grid design",
-        "Redesigned color tokens in `globals.css` with a tech & zen dark theme",
-        "Refactored `page.tsx` into a modern Bento Box layout grid",
-        "Integrated `framer-motion` for scroll reveal and stagger entrance animations",
-        "Created new `<BentoCard>` component with interactive spotlight hover effect",
-        "Upgraded the Hero section with 3D stacked floating screenshots (parallax hover)"
+        "PR #445: [codex] fix android buddha model fallback",
+        "Android 禅室不再先下载/解包远端 293MB `buddha_model.model`，直接走内置 WebView + GLB 兼容渲染，避免 `.model` 在 Android 上的下载和内存峰值。",
+        "新增打包进 App 的 fallback HTML/Three.js bundle，并优先加载官网 GLB，失败时再尝试 APK 内置 GLB。",
+        "失败页现在展示原生 `.model` 与兼容 GLB 的具体失败阶段；资源校验也会带上 HTTP URL 和首字节签名，方便判断是否拿到了 GLB、HTML 错误页或错误 R2 对象。",
+        "`flutter test --no-pub test/unit/core/app_config_buddha_model_test.dart test/unit/services/asset_loader_service_test.dart`",
+        "`flutter analyze --no-pub lib/screens/buddha_model_screen_native.dart lib/services/asset_loader_service.dart lib/core/config/app_config.dart test/unit/core/app_config_buddha_model_test.dart`"
       ],
       "mirrorLinks": [
         {
           "label": "国内镜像 1",
-          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-148-mobile.01aa4666d6e6/fabushi-android-arm64-01aa4666d6e6.apk"
+          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-208-mobile.56c0652a910d/fabushi-android-arm64-56c0652a910d.apk"
         },
         {
           "label": "国内镜像 2",
-          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-148-mobile.01aa4666d6e6/fabushi-android-arm64-01aa4666d6e6.apk"
+          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-208-mobile.56c0652a910d/fabushi-android-arm64-56c0652a910d.apk"
         }
       ],
       "note": "国内访问较慢时，可以优先尝试镜像下载入口。",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-208-mobile.56c0652a910d"
     },
     {
       "platform": "iOS",
@@ -37,90 +37,101 @@
       "status": "TestFlight 已开放",
       "title": "iOS TestFlight Beta",
       "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
-      "primaryLabel": "查看 iOS 发布状态",
-      "primaryHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6",
-      "version": "148",
-      "publishedAt": "2026-05-14T00:23:54Z",
+      "primaryLabel": "加入 iOS TestFlight",
+      "primaryHref": "https://testflight.apple.com/join/98KFgV2z",
+      "version": "208",
+      "publishedAt": "2026-05-16T13:53:12Z",
       "updateSummary": [
-        "PR #359: feat(web): comprehensive UI/UX overhaul to world-class Bento grid design",
-        "Redesigned color tokens in `globals.css` with a tech & zen dark theme",
-        "Refactored `page.tsx` into a modern Bento Box layout grid",
-        "Integrated `framer-motion` for scroll reveal and stagger entrance animations",
-        "Created new `<BentoCard>` component with interactive spotlight hover effect",
-        "Upgraded the Hero section with 3D stacked floating screenshots (parallax hover)"
+        "PR #445: [codex] fix android buddha model fallback",
+        "Android 禅室不再先下载/解包远端 293MB `buddha_model.model`，直接走内置 WebView + GLB 兼容渲染，避免 `.model` 在 Android 上的下载和内存峰值。",
+        "新增打包进 App 的 fallback HTML/Three.js bundle，并优先加载官网 GLB，失败时再尝试 APK 内置 GLB。",
+        "失败页现在展示原生 `.model` 与兼容 GLB 的具体失败阶段；资源校验也会带上 HTTP URL 和首字节签名，方便判断是否拿到了 GLB、HTML 错误页或错误 R2 对象。",
+        "`flutter test --no-pub test/unit/core/app_config_buddha_model_test.dart test/unit/services/asset_loader_service_test.dart`",
+        "`flutter analyze --no-pub lib/screens/buddha_model_screen_native.dart lib/services/asset_loader_service.dart lib/core/config/app_config.dart test/unit/core/app_config_buddha_model_test.dart`"
       ],
       "mirrorLinks": [],
-      "note": "已经上传到 TestFlight，但仓库变量 IOS_TESTFLIGHT_PUBLIC_URL 还没有配置公开加入链接。",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6"
+      "note": "",
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-208-mobile.56c0652a910d"
     }
   ],
   "stableChannels": [],
   "screenshots": {},
   "releases": [
     {
-      "tag": "v1.0.0-148-mobile.01aa4666d6e6",
-      "title": "Fabushi mobile 1.0.0+148 (01aa4666d6e6)",
-      "publishedAt": "2026-05-14T00:47:16Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-148-mobile.01aa4666d6e6",
+      "tag": "v1.0.0-208-mobile.56c0652a910d",
+      "title": "Fabushi mobile 1.0.0+208 (56c0652a910d)",
+      "publishedAt": "2026-05-16T13:53:58Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-208-mobile.56c0652a910d",
       "summary": [
-        "PR #359: feat(web): comprehensive UI/UX overhaul to world-class Bento grid design",
-        "Redesigned color tokens in `globals.css` with a tech & zen dark theme",
-        "Refactored `page.tsx` into a modern Bento Box layout grid",
-        "Integrated `framer-motion` for scroll reveal and stagger entrance animations",
-        "Created new `<BentoCard>` component with interactive spotlight hover effect",
-        "Upgraded the Hero section with 3D stacked floating screenshots (parallax hover)"
+        "PR #445: [codex] fix android buddha model fallback",
+        "Android 禅室不再先下载/解包远端 293MB `buddha_model.model`，直接走内置 WebView + GLB 兼容渲染，避免 `.model` 在 Android 上的下载和内存峰值。",
+        "新增打包进 App 的 fallback HTML/Three.js bundle，并优先加载官网 GLB，失败时再尝试 APK 内置 GLB。",
+        "失败页现在展示原生 `.model` 与兼容 GLB 的具体失败阶段；资源校验也会带上 HTTP URL 和首字节签名，方便判断是否拿到了 GLB、HTML 错误页或错误 R2 对象。",
+        "`flutter test --no-pub test/unit/core/app_config_buddha_model_test.dart test/unit/services/asset_loader_service_test.dart`",
+        "`flutter analyze --no-pub lib/screens/buddha_model_screen_native.dart lib/services/asset_loader_service.dart lib/core/config/app_config.dart test/unit/core/app_config_buddha_model_test.dart`"
       ]
     },
     {
-      "tag": "v1.0.0-147-mobile.bf69a3ea8679",
-      "title": "Fabushi mobile 1.0.0+147 (bf69a3ea8679)",
-      "publishedAt": "2026-05-13T23:56:48Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-147-mobile.bf69a3ea8679",
+      "tag": "v1.0.0-190-mobile.9c1e747f7d76",
+      "title": "Fabushi mobile 1.0.0+190 (9c1e747f7d76)",
+      "publishedAt": "2026-05-16T07:45:09Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-190-mobile.9c1e747f7d76",
       "summary": [
-        "PR #358: ci: fix missing GH_TOKEN in sync beta state workflow",
-        "[x] Run workflow manually to ensure it authenticates successfully"
+        "PR #425: fix(android): harden CI release builds against flaky Maven mirrors",
+        "失败点：`Build Android install packages`",
+        "首个确定性错误：`Could not GET https://maven.aliyun.com/repository/public/androidx/test/rules/maven-metadata.xml` -> `502 Bad Gateway`",
+        "失败任务：`:integration_test:mapReleaseSourceSetPaths`",
+        "当前 app 配置的 NDK 还是 `27.0.12077973`",
+        "但 `integration_test` 已明确要求 `28.2.13676358`"
       ]
     },
     {
-      "tag": "v1.0.0-144-mobile.b6d5f08bef3d",
-      "title": "Fabushi mobile 1.0.0+144 (b6d5f08bef3d)",
-      "publishedAt": "2026-05-13T09:35:05Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-144-mobile.b6d5f08bef3d",
+      "tag": "v1.0.0-173-mobile.8b1008e548ed",
+      "title": "Fabushi mobile 1.0.0+173 (8b1008e548ed)",
+      "publishedAt": "2026-05-16T00:46:01Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-173-mobile.8b1008e548ed",
       "summary": [
-        "PR #353: ci: fix official site sync not triggering automatically",
-        "Listen for `Publish CD packages to GitHub Release` workflow completion instead of `release` events, bypassing GITHUB_TOKEN recursive trigger limitations.",
-        "Fallback to fetching the latest GitHub release tag dynamically when no explicit tag is supplied by inputs or release context.",
-        "Update `Push beta state to official site repo` condition to execute even if attaching metadata to an immutable release is rejected (so the official site still receives updates).",
-        "Verify syntax and run the workflow dispatch to see if it correctly locates the latest release."
+        "PR #394: feat(web): surface dharma learning paths on homepage",
+        "首页对佛法内容集群的内部链接传递还不够强，学习型页面更多只能靠导航、页脚或站内深链被发现。",
+        "首页自己的主题信号仍偏产品下载站，无法把“学佛从哪里开始 / 佛法入门 / 禅修入门 / 佛经导读”这条学习路径清楚地展示给用户和搜索引擎。",
+        "为首页新增 `metadata`，把 title、description、keywords、canonical、open graph、twitter 明确对齐到佛法学习路径与产品实践入口。",
+        "在首页新增 `学佛路径` 区块，用更接近初学者真实问题的方式承接四条内容路径：",
+        "在首页结构化数据中新增 `ItemList`，把四条学习路径作为首页可理解的内容列表输出。"
       ]
     },
     {
-      "tag": "v1.0.0-142-mobile.4011ea22012e",
-      "title": "Fabushi mobile 1.0.0+142 (4011ea22012e)",
-      "publishedAt": "2026-05-13T05:58:32Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-142-mobile.4011ea22012e",
+      "tag": "v1.0.0-171-mobile.f4d465e91e15",
+      "title": "Fabushi mobile 1.0.0+171 (f4d465e91e15)",
+      "publishedAt": "2026-05-15T23:54:18Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-171-mobile.f4d465e91e15",
       "summary": [
-        "PR #352: ci: keep release publish unblocked by screenshots"
+        "PR #391: fix(web): refresh official site after package publish and fall back to latest apk",
+        "`Sync official site beta download state` 即使生成了最新状态，也可能因为仓库规则无法直推 `main`，导致 `/api/releases.json` 继续停在旧快照。",
+        "`Deploy official site to Cloudflare Worker` 之前只监听 beta sync 成功完成；一旦 beta sync 被仓库规则挡住，官网就不会因为新的 GitHub Release 自动重建。",
+        "让 `Deploy official site to Cloudflare Worker` 同时监听 `Publish CD packages to GitHub Release` 和 `Sync official site beta download state` 成功完成。",
+        "保持官网构建固定基于 `main`，但不再把自动刷新绑定在 beta sync 单一路径上。",
+        "给 `frontend/official-site-worker.js` 增加兜底：Android beta 下载优先读取 GitHub latest release 的 APK 资产；只有拿不到 latest release 时，才回退到静态 `/api/releases.json`。"
       ]
     },
     {
-      "tag": "v1.0.0-137-mobile.1ffba4b6640c",
-      "title": "Fabushi mobile 1.0.0+137 (1ffba4b6640c)",
-      "publishedAt": "2026-05-12T08:26:06Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-137-mobile.1ffba4b6640c",
+      "tag": "v1.0.0-166-mobile.ceafd2e4926b",
+      "title": "Fabushi mobile 1.0.0+166 (ceafd2e4926b)",
+      "publishedAt": "2026-05-15T12:25:37Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-166-mobile.ceafd2e4926b",
       "summary": [
-        "PR #336: fix: add missing .gitmodules for llama.cpp submodule mapping",
-        "Adds missing `.gitmodules` at repo root with `fabushi/native_libs/llama.cpp` submodule mapping to `https://github.com/ggml-org/llama.cpp`",
-        "The git index has this submodule (gitlink 160000) but `.gitmodules` was absent, causing every `actions/checkout` cleanup step to fail with `fatal: No url found for submodule path`",
-        "`Staging API E2E and smoke gate` — \"Checkout E2E files\" step failure",
-        "`Notify deployment failure` — \"Checkout failure notifier\" step failure → \"Create or update detailed CD failure issue\" was skipped",
-        "Any other job that checks out this repo without the workaround"
+        "PR #314: fix: restore android buddha rendering with legacy glb fallback",
+        "在 `AppConfig` 增加 `legacyBuddhaGlbAssetPath`，把旧 GLB 对象键收口成正式配置。",
+        "在原生禅室佛像页保留现有 `flutter_scene + .model` 主链路。",
+        "当移动端 `.model` 加载或渲染失败时，自动切到 WebView 兼容渲染，直接使用 legacy GLB 路径恢复佛像展示，而不是给用户报错页。",
+        "兼容模式下继续保留经书按钮和香炉/烟雾叠层，避免禅室交互退化成纯只读页面。",
+        "这轮无法在容器里直接执行 Flutter/Android 编译验证，因为运行环境无法完整拉取仓库代码进行本地构建。"
       ]
     }
   ],
   "notes": [
-    "Android beta 下载链接来自最新发布版本的 APK 资产。",
-    "iOS TestFlight 入口会在上传状态成功后和 Android beta 一起同步。",
-    "镜像链接面向国内网络环境准备，如镜像暂时不可用请使用原始下载地址。"
+    "Android beta 下载链接来自本次发布中的 APK 资产。",
+    "镜像链接面向国内网络环境准备，如镜像暂时不可用请使用原始下载地址。",
+    "iOS TestFlight 入口会在上传状态成功后同步到官网。",
+    "如果本次 GitHub Release 只带了一个平台，官网会继续保留另一个平台上一版可用信息。"
   ]
 }


### PR DESCRIPTION
## Summary
- update `frontend/apps/web/public/api/releases.json` with the latest generated beta state
- use a PR fallback because repository rules blocked the workflow from pushing straight to `main`

## Why
- `Sync official site beta download state` generated a fresh `OFFICIAL_SITE_RELEASE_STATE.json`
- direct push to `main` was blocked by repository rules that require the merge queue
- opening a PR keeps the website state reviewable and lets the sync still converge

## Validation
- generated by `.github/workflows/sync-official-site-beta.yml`
- release tag: v1.0.0-208-mobile.56c0652a910d
- compare and normal PR checks should validate the resulting `releases.json` change