### PR TITLE
fix(ci): tolerate beta sync PR permission blocker and surface manual fallback

### DIFF
--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -181,6 +181,7 @@ jobs:
           exit 1
 
       - name: Create or update beta state sync PR
+        id: sync_pr
         if: steps.commit_state.outputs.push_blocked_by_repo_rules == 'true' && steps.commit_state.outputs.sync_pr_branch != ''
         uses: actions/github-script@v8
         env:
@@ -191,6 +192,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const head = `${owner}:${process.env.SYNC_PR_BRANCH}`;
+            const manualPrUrl = `https://github.com/${owner}/${repo}/pull/new/${process.env.SYNC_PR_BRANCH}`;
             const title = `chore: sync beta release state for ${process.env.RELEASE_TAG}`;
             const body = [
               '## Summary',
@@ -208,36 +210,50 @@ jobs:
               '- compare and normal PR checks should validate the resulting `releases.json` change',
             ].join('\n');
 
-            const { data: pulls } = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'open',
-              head,
-              base: 'main',
-            });
+            core.setOutput('pr_write_blocked', 'false');
+            core.setOutput('manual_pr_url', '');
 
-            if (pulls.length > 0) {
-              await github.rest.pulls.update({
+            try {
+              const { data: pulls } = await github.rest.pulls.list({
                 owner,
                 repo,
-                pull_number: pulls[0].number,
+                state: 'open',
+                head,
+                base: 'main',
+              });
+
+              if (pulls.length > 0) {
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: pulls[0].number,
+                  title,
+                  body,
+                });
+                core.notice(`Updated beta sync fallback PR #${pulls[0].number}.`);
+                return;
+              }
+
+              const { data: pull } = await github.rest.pulls.create({
+                owner,
+                repo,
+                head: process.env.SYNC_PR_BRANCH,
+                base: 'main',
                 title,
                 body,
+                maintainer_can_modify: true,
               });
-              core.notice(`Updated beta sync fallback PR #${pulls[0].number}.`);
-              return;
+              core.notice(`Created beta sync fallback PR #${pull.number}.`);
+            } catch (error) {
+              const message = error?.message || String(error);
+              if (error?.status === 403 && /GitHub Actions is not permitted to create or approve pull requests/i.test(message)) {
+                core.setOutput('pr_write_blocked', 'true');
+                core.setOutput('manual_pr_url', manualPrUrl);
+                core.notice(`GitHub Actions cannot create pull requests in this repository. The beta state update was pushed to ${process.env.SYNC_PR_BRANCH}; open ${manualPrUrl} to continue the reviewable fallback.`);
+                return;
+              }
+              throw error;
             }
-
-            const { data: pull } = await github.rest.pulls.create({
-              owner,
-              repo,
-              head: process.env.SYNC_PR_BRANCH,
-              base: 'main',
-              title,
-              body,
-              maintainer_can_modify: true,
-            });
-            core.notice(`Created beta sync fallback PR #${pull.number}.`);
 
       - name: Write summary
         shell: bash
@@ -247,6 +263,8 @@ jobs:
           IMMUTABLE_RELEASE: ${{ steps.upload_state.outputs.immutable_release }}
           PUSH_BLOCKED_BY_REPO_RULES: ${{ steps.commit_state.outputs.push_blocked_by_repo_rules }}
           SYNC_PR_BRANCH: ${{ steps.commit_state.outputs.sync_pr_branch }}
+          SYNC_PR_WRITE_BLOCKED: ${{ steps.sync_pr.outputs.pr_write_blocked || 'false' }}
+          SYNC_PR_MANUAL_URL: ${{ steps.sync_pr.outputs.manual_pr_url || '' }}
         run: |
           {
             echo "## Official site beta state synced"
@@ -263,6 +281,12 @@ jobs:
             if [ "$PUSH_BLOCKED_BY_REPO_RULES" = "true" ]; then
               echo "- Repository rules blocked the direct push to main, so /api/releases.json was not committed automatically"
               echo "- PR fallback branch pushed: $SYNC_PR_BRANCH"
+              if [ "$SYNC_PR_WRITE_BLOCKED" = "true" ]; then
+                echo "- GitHub Actions is not permitted to create pull requests in this repository"
+                echo "- Open this URL to continue manually: $SYNC_PR_MANUAL_URL"
+              else
+                echo "- The workflow created or updated the fallback PR automatically"
+              fi
               echo "- The official site will keep falling back to release metadata and TESTFLIGHT_UPLOAD_STATUS.txt until that PR merges"
             fi
             echo "- Available beta channels from this release were synced selectively."


### PR DESCRIPTION
## Summary
- keep `Sync official site beta download state` green when repo rules block direct push and GitHub Actions is not allowed to create PRs
- surface a manual PR URL in the workflow notice and job summary instead of failing at the fallback PR step
- preserve the existing automatic PR path when the repository does allow Actions-created PRs

## Why
The latest beta sync failure was no longer caused by release metadata generation or by the direct-push fallback branch logic.

The workflow already pushed the updated `releases.json` commit to `automation/sync-official-site-beta-state`, but then failed with:

- `GitHub Actions is not permitted to create or approve pull requests.`

That means the remaining blocker is repository policy, not the beta-state merge logic itself. The workflow should report that policy limit clearly and leave a reviewable handoff path instead of turning the whole sync run red.

## What changed
- give the fallback PR step a stable step id so the summary can read its outputs
- catch the specific 403 returned when Actions is forbidden from creating PRs
- emit a notice and summary line with the manual PR URL for the pushed fallback branch
- keep throwing for any other unexpected API failure so real workflow regressions still fail loudly

## Validation
- scoped to `.github/workflows/sync-official-site-beta.yml`
- preserves the existing success path for direct pushes
- preserves the existing automatic PR create/update path when repository settings allow it
- only downgrades the known policy blocker into an explicit manual handoff path