### PR TITLE
feat(web): connect practice pages to bodhicitta intent

### DIFF
--- a/frontend/apps/web/src/app/daily-practice/page.tsx
+++ b/frontend/apps/web/src/app/daily-practice/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const pageUrl = siteUrl("/daily-practice");
 const pageTitle = `日常功课怎么安排 | ${brand.name}`;
 const pageDescription =
-  "面向初学者梳理日常功课怎么安排：晨起、白天与晚间可以怎样放进禅修、经文听诵、念佛、阅读与简短回顾，帮助学佛修行、六度、空性理解与生活真正接在一起。";
+  "面向初学者梳理日常功课怎么安排：晨起、白天与晚间可以怎样放进禅修、经文听诵、念佛、阅读与简短回顾，帮助菩提心、学佛修行、六度、空性理解与生活真正接在一起。";
 
 const routinePrinciples = [
   {
@@ -105,6 +105,15 @@ const relatedPaths = [
     descriptionEn: "Return to the overview first if you are still mapping how meditation, listening, recitation, reading, and notes fit together.",
   },
   {
+    href: "/what-is-bodhicitta",
+    labelZh: "菩提心是什么意思",
+    labelEn: "What Bodhicitta Means",
+    titleZh: "把“为什么做这份功课”先放清楚。",
+    titleEn: "Clarify why you keep this routine and what direction it is meant to serve.",
+    descriptionZh: "如果你想知道日常功课为什么不只是一张任务清单，而要和发心一起慢慢站稳，这一页会更适合继续往下看。",
+    descriptionEn: "This is the better next page if you want to see why a daily routine is more than a checklist and needs to become steady together with aspiration.",
+  },
+  {
     href: "/what-are-the-six-paramitas",
     labelZh: "六度分别是什么",
     labelEn: "Six Paramitas",
@@ -174,6 +183,12 @@ const faqItems = [
     answerEn: "It helps more to ask what you need most right now. If steadiness is the need, let short meditation lead. If you need an easier rhythm, recitation or listening can come first. If you need orientation, begin by placing guide reading into the routine.",
   },
   {
+    questionZh: "菩提心是什么意思，和日常功课有什么关系？",
+    questionEn: "What does bodhicitta have to do with a daily practice routine?",
+    answerZh: "如果没有发心，功课很容易只剩完成任务。更稳的方向，是让晨起、白天和晚间的这些小动作，慢慢回到“我为什么学、愿意把这条路带向哪里”这件事上。这样功课才不只是维持自己，而会开始长出更宽的方向和柔软。",
+    answerEn: "Without aspiration, a daily routine can shrink into task completion. A steadier direction is to let the small actions of morning, daytime, and evening return to the question of why you practice and what direction you want the path to grow toward. Then the routine becomes more than self-maintenance and begins to open into a wider intention and softness.",
+  },
+  {
     questionZh: "白天工作忙，还能有日常功课吗？",
     questionEn: "Can I still keep a daily routine when work is busy?",
     answerZh: "可以。日常功课不一定等于大块时间。很多人真正能留下来的，是晨起几分钟、白天一个短提醒点、晚间一点回顾。功课轻一点，反而更容易和现实生活接上。",
@@ -210,6 +225,7 @@ export const metadata: Metadata = {
     "学佛日常功课",
     "初学者功课安排",
     "居士日常修行",
+    "菩提心是什么意思",
     "六度分别是什么",
     "空性怎么理解",
     "修行方法",
@@ -245,7 +261,7 @@ export default function DailyPracticePage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["日常功课", "学佛修行", "初学者功课安排", "空性理解"],
+        about: ["日常功课", "菩提心", "学佛修行", "初学者功课安排", "空性理解"],
       },
       {
         "@type": "BreadcrumbList",
@@ -350,8 +366,8 @@ export default function DailyPracticePage() {
           </p>
           <p>
             <LocalizedText
-              zh="日常功课的价值，也不只是把几个动作做完。随着晨起、白天和晚间慢慢出现回返点，人会开始看见：很多急躁、执着和判断，并没有想象中那样固定，这也是为什么六度和空性会和功课页放在同一条路上。功课越回到这里，练习就越不只是完成任务，而是在帮助自己多一点清醒和柔软。"
-              en="The value of a daily routine is not only finishing a few actions. As morning, daytime, and evening gain small points of return, people often begin to see that agitation, attachment, and judgment are less fixed than they seemed. This is why the six paramitas and emptiness belong on the same path as a routine page. The more practice returns here, the less it becomes task completion and the more it supports clarity and softness."
+              zh="日常功课的价值，也不只是把几个动作做完。随着晨起、白天和晚间慢慢出现回返点，人会开始看见：很多急躁、执着和判断，并没有想象中那样固定，这也是为什么菩提心、六度和空性会和功课页放在同一条路上。功课越回到这里，练习就越不只是完成任务，而是在帮助自己多一点清醒和柔软。"
+              en="The value of a daily routine is not only finishing a few actions. As morning, daytime, and evening gain small points of return, people often begin to see that agitation, attachment, and judgment are less fixed than they seemed. This is why bodhicitta, the six paramitas, and emptiness belong on the same path as a routine page. The more practice returns here, the less it becomes task completion and the more it supports clarity and softness."
             />
           </p>
           <p>

--- a/frontend/apps/web/src/app/practice-guide/page.tsx
+++ b/frontend/apps/web/src/app/practice-guide/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const pageUrl = siteUrl("/practice-guide");
 const pageTitle = `修行方法总览 | ${brand.name}`;
 const pageDescription =
-  "面向初学者梳理学佛修行可以从哪些方法开始：禅修、经文听诵、阅读、念佛与日常记录如何配合，才能把修行、六度、空性理解与日常生活接在一起。";
+  "面向初学者梳理学佛修行可以从哪些方法开始：禅修、经文听诵、阅读、念佛与日常记录如何配合，才能把菩提心、修行、六度、空性理解与日常生活接在一起。";
 
 const practicePrinciples = [
   {
@@ -99,6 +99,15 @@ const relatedPaths = [
     descriptionEn: "If you already know you want to practice but feel stuck on arranging a routine that can last, this page is more concrete.",
   },
   {
+    href: "/what-is-bodhicitta",
+    labelZh: "菩提心是什么意思",
+    labelEn: "What Bodhicitta Means",
+    titleZh: "把“为什么修、愿意把这条路带向哪里”先放清楚。",
+    titleEn: "Clarify why you practice and what direction you want the path to grow toward.",
+    descriptionZh: "如果你想知道修行方法为什么不只是在练技巧，而要和发心一起长出来，这一页会更适合继续往下看。",
+    descriptionEn: "This is the better next page if you want to see why practice methods are more than technique and need to grow together with aspiration.",
+  },
+  {
     href: "/what-are-the-six-paramitas",
     labelZh: "六度分别是什么",
     labelEn: "Six Paramitas",
@@ -168,6 +177,12 @@ const faqItems = [
     answerEn: "The better question is what you need most right now. Meditation can come first if you need steadiness, recitation or listening can come first if you need an easier rhythm, and reading can come first if you need clearer direction.",
   },
   {
+    questionZh: "菩提心是什么意思，和修行方法有什么关系？",
+    questionEn: "What does bodhicitta have to do with actual practice methods?",
+    answerZh: "如果没有发心，修行方法很容易只剩技巧和任务。更稳的方向，是让禅修、听诵、阅读、念佛和记录，慢慢回到“我为什么学、愿意把这条路带向哪里”这件事上。这样方法才不只是让自己舒服一点，也会开始长出更宽的方向。",
+    answerEn: "Without aspiration, practice methods can shrink into technique and task. A steadier direction is to let meditation, listening, reading, recitation, and notes return to the question of why you practice and what direction you want the path to grow toward. Then methods become more than self-soothing and begin to open into a wider intention.",
+  },
+  {
     questionZh: "日常功课一定要安排很多吗？",
     questionEn: "Does a daily routine need to be heavy to count?",
     answerZh: "不需要。很多人真正能留下来的修行，反而是很轻的节奏，例如每天几分钟禅修、听一段经文、念几分钟佛号，再留下一点记录。轻一点，往往更容易真做下去。",
@@ -204,6 +219,7 @@ export const metadata: Metadata = {
     "学佛修行",
     "佛教修行方法",
     "初学者怎么修行",
+    "菩提心是什么意思",
     "日常功课",
     "六度分别是什么",
     "空性怎么理解",
@@ -240,7 +256,7 @@ export default function PracticeGuidePage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["修行方法", "学佛修行", "日常功课", "空性理解"],
+        about: ["修行方法", "学佛修行", "菩提心", "日常功课", "空性理解"],
       },
       {
         "@type": "BreadcrumbList",
@@ -345,8 +361,8 @@ export default function PracticeGuidePage() {
           </p>
           <p>
             <LocalizedText
-              zh="修行方法最后不只是在练几种技能。随着节奏慢慢稳定，人也会开始看见：很多急躁、执着和判断，并没有想象中那样固定，这也是为什么六度和空性会和方法页放在同一条路上。方法越回到这里，练习就越不只是完成任务，而是在帮助自己少一点抓得太死。"
-              en="Practice methods are not only a set of techniques. As the rhythm steadies, people often begin to see that agitation, attachment, and judgment are less fixed than they seem. This is why the six paramitas and emptiness belong on the same path as method pages. The more practice returns here, the less it becomes task-completion and the more it helps loosen rigid grasping."
+              zh="修行方法最后不只是在练几种技能。随着节奏慢慢稳定，人也会开始看见：很多急躁、执着和判断，并没有想象中那样固定，这也是为什么菩提心、六度和空性会和方法页放在同一条路上。方法越回到这里，练习就越不只是完成任务，而是在帮助自己少一点抓得太死。"
+              en="Practice methods are not only a set of techniques. As the rhythm steadies, people often begin to see that agitation, attachment, and judgment are less fixed than they seem. This is why bodhicitta, the six paramitas, and emptiness belong on the same path as method pages. The more practice returns here, the less it becomes task-completion and the more it helps loosen rigid grasping."
             />
           </p>
           <p>


### PR DESCRIPTION
## Summary
- tighten `/practice-guide` and `/daily-practice` around the missing `菩提心是什么意思` concept link
- add reciprocal internal links from both high-intent practice pages to `/what-is-bodhicitta`
- expand page descriptions, keywords, FAQ coverage, and structured-data `about` terms so practice intent is more clearly connected to aspiration

## Why
- the current discovery layer for the dharma cluster is already relatively complete on homepage, footer, sitemap, and hub pages
- the clearer gap is one level deeper: practice-method and daily-routine pages already connect to `六度` and `空性`, but they still under-express the upstream `菩提心` concept that gives those routines direction
- this is a small, low-risk content/SEO change that strengthens intent matching for readers moving from concept understanding into actual practice

## Validation
- scope checked against `main`: only `frontend/apps/web/src/app/practice-guide/page.tsx` and `frontend/apps/web/src/app/daily-practice/page.tsx` changed
- added bodhicitta-related metadata, FAQ, and internal links without changing shared templates or navigation structure
- no ranking guarantees implied; this improves topical coverage, internal-link continuity, and question coverage for practice-oriented pages