### PR TITLE
feat(forum): persist role and newcomer guidance state

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -74,7 +74,8 @@ jobs:
           html = unescape(os.environ["FORUM_NEW_THREAD_PAGE"])
           assert "发起一条最小主题" in html, html[:1000]
           assert "当前数据源：sqlite / 可写" in html, html[:1000]
-          assert "版块与发帖提示" in html, html[:1000]
+          assert "作者角色" in html, html[:1500]
+          assert "引导信号" in html, html[:1500]
           PY
 
       - name: Smoke test forum thread creation endpoint
@@ -85,6 +86,8 @@ jobs:
               "sectionSlug": "newcomer-path",
               "title": "容器页面检查：新主题能否进入真实帖子页？",
               "author": "页面检查用户",
+              "authorRoleLabel": "新手观察者",
+              "guidanceSignal": "请先补一条最容易开始的下一步建议。",
               "summary": "想确认 sqlite 新主题创建后，列表页和详情页都会回读到最新内容。",
               "tags": ["页面检查", "sqlite"],
               "openingPost": ["这条主题由容器页面检查创建，用来确认论坛页面层也能读到刚写入的新线程。"]
@@ -99,6 +102,8 @@ jobs:
           assert payload["source"] == "sqlite", payload
           assert payload["thread"]["sectionSlug"] == "newcomer-path", payload
           assert payload["thread"]["title"].startswith("容器页面检查"), payload
+          assert payload["thread"]["authorRoleLabel"] == "新手观察者", payload
+          assert payload["thread"]["guidanceSignal"] == "请先补一条最容易开始的下一步建议。", payload
           assert payload["thread"]["openingPost"], payload
           assert payload["moderationEvents"][-1]["eventType"] == "thread-created", payload
           assert "新主题已发布" in payload["moderationEvents"][-1]["summary"], payload
@@ -124,6 +129,8 @@ jobs:
           assert payload["source"] == "sqlite", payload
           assert payload["thread"]["slug"], payload
           assert payload["thread"]["author"] == "页面检查用户", payload
+          assert payload["thread"]["authorRoleLabel"] == "新手观察者", payload
+          assert payload["thread"]["guidanceSignal"] == "请先补一条最容易开始的下一步建议。", payload
           assert payload["moderationEvents"][-1]["eventType"] == "thread-created", payload
           PY
 
@@ -134,8 +141,10 @@ jobs:
 
           html = unescape(os.environ["FORUM_THREAD_LIST_PAGE"])
           assert "发起主题" in html, html[:1000]
-          assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:2000]
-          assert "页面检查用户" in html, html[:2000]
+          assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:3000]
+          assert "页面检查用户" in html, html[:3000]
+          assert "新手观察者" in html, html[:3000]
+          assert "请先补一条最容易开始的下一步建议。" in html, html[:4000]
           PY
 
           thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${slug}")"
@@ -144,11 +153,13 @@ jobs:
           from html import unescape
 
           html = unescape(os.environ["FORUM_THREAD_DETAIL_PAGE"])
-          assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:2000]
-          assert "页面检查用户" in html, html[:2000]
-          assert "写一条最小回复" in html, html[:2000]
-          assert "审核时间线" in html, html[:3000]
-          assert "新主题已发布" in html, html[:4000]
+          assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:2500]
+          assert "页面检查用户" in html, html[:2500]
+          assert "新手观察者" in html, html[:2500]
+          assert "请先补一条最容易开始的下一步建议。" in html, html[:3500]
+          assert "写一条最小回复" in html, html[:2500]
+          assert "审核时间线" in html, html[:3500]
+          assert "新主题已发布" in html, html[:4500]
           PY
 
           echo "thread_slug=${slug}" >> "$GITHUB_ENV"
@@ -160,6 +171,7 @@ jobs:
             --data '{
               "author": "页面回复检查",
               "roleLabel": "页面回读验证",
+              "guidanceSignal": "请优先补一条最容易执行的下一步建议。",
               "trustSignal": "用于确认 sqlite 回复写入后，线程详情页会显示新回复。",
               "body": ["这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。"]
             }')"
@@ -175,6 +187,8 @@ jobs:
           assert payload["thread"]["replyCount"] >= 1, payload
           assert payload["thread"]["lastActivity"] == "刚刚回复", payload
           assert payload["replies"][-1]["author"] == "页面回复检查", payload
+          assert payload["replies"][-1]["roleLabel"] == "页面回读验证", payload
+          assert payload["replies"][-1]["guidanceSignal"] == "请优先补一条最容易执行的下一步建议。", payload
           assert payload["replies"][-1]["body"], payload
           assert payload["moderationEvents"][-1]["eventType"] == "reply-created", payload
           assert "新回复已写入时间线" in payload["moderationEvents"][-1]["summary"], payload
@@ -187,10 +201,11 @@ jobs:
 
           html = unescape(os.environ["FORUM_THREAD_DETAIL_PAGE"])
           assert "当前回复" in html, html[:2000]
-          assert "页面回复检查" in html, html[:4000]
-          assert "页面回读验证" in html, html[:4000]
-          assert "这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。" in html, html[:4000]
-          assert "新回复已写入时间线" in html, html[:5000]
+          assert "页面回复检查" in html, html[:4500]
+          assert "页面回读验证" in html, html[:4500]
+          assert "请优先补一条最容易执行的下一步建议。" in html, html[:5000]
+          assert "这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。" in html, html[:5000]
+          assert "新回复已写入时间线" in html, html[:5500]
           PY
 
       - name: Stop forum container

--- a/forum/README.md
+++ b/forum/README.md
@@ -19,6 +19,7 @@ Current scope:
 - a minimal reply-creation API for existing threads in sqlite mode
 - a page-level reply composer on thread detail when writes are enabled
 - a first moderation-event timeline that can be read back from thread detail and runtime status
+- persisted author-role and newcomer-guidance signals for new threads and replies
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
 - a container smoke check that starts the forum, validates `/api/status`, exercises sqlite thread and reply creation, and reads the updated thread back through real forum pages
@@ -38,9 +39,9 @@ Included:
 - read-only API boundary
 - moderation and knowledge-stage fields reserved in the content model
 - a first moderation-event timeline for thread publishing and new sqlite writes
-- a runtime status endpoint for deployment smoke checks
 - a first durable persistence path backed by sqlite file storage
 - a first reply write path for existing threads
+- persisted role and guidance fields for new thread authors and reply authors
 - standalone server artifact for container packaging
 
 Not included yet:
@@ -74,6 +75,8 @@ curl -X POST http://localhost:3000/api/threads \
     "sectionSlug": "newcomer-path",
     "title": "想建立稳定作息，该从哪一步开始？",
     "author": "测试用户",
+    "authorRoleLabel": "新手提问者",
+    "guidanceSignal": "请先给我一条最容易坚持的一步。",
     "summary": "先把最小作息和听闻节奏稳定下来。",
     "tags": ["新手", "作息"],
     "openingPost": ["我目前还没有固定作息，想先把每天最小的修学节奏建立起来。"]
@@ -83,6 +86,7 @@ curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
   -d '{
     "author": "测试回复",
     "roleLabel": "新加入同修",
+    "guidanceSignal": "我想先补一条最容易执行的下一步建议。",
     "trustSignal": "回复已按主题聚焦提交，等待更多互动后再决定是否沉淀。",
     "body": ["我发现先把睡前十分钟固定下来，比一下子改整天作息更容易坚持。"]
   }'
@@ -92,7 +96,7 @@ curl http://localhost:3000/threads
 curl http://localhost:3000/threads/first-year-stability
 ```
 
-When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/new` to create a new topic, and `http://localhost:3000/threads/first-year-stability` to submit a reply through the page-level form. In `seed-json` mode, both page-level forms stay visible but clearly report that the runtime is still read-only. `GET /api/thread/[slug]` now includes `moderationEvents`, so thread detail can expose the first durable governance timeline instead of only content fields.
+When `FORUM_DATA_SOURCE=sqlite`, you can also open `http://localhost:3000/threads/new` to create a new topic, and `http://localhost:3000/threads/first-year-stability` to submit a reply through the page-level form. In `seed-json` mode, both page-level forms stay visible but clearly report that the runtime is still read-only. `GET /api/thread/[slug]` now includes `moderationEvents`, thread-level `authorRoleLabel`, thread-level `guidanceSignal`, and reply-level `guidanceSignal`, so thread detail can expose the first durable governance timeline alongside role and newcomer guidance context instead of only content fields.
 
 ## Runtime contract
 
@@ -112,7 +116,7 @@ Current JSON routes:
 - `POST /api/thread/[slug]/replies`
 - `GET /api/status`
 
-`GET /api/status` now reports whether writes are enabled for the current data source and how many moderation events the current store already contains. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, writes the first moderation timeline events alongside newly created threads and replies, lets the page-level thread composer create new topics, and lets existing threads accept the first persisted reply submissions.
+`GET /api/status` now reports whether writes are enabled for the current data source and how many moderation events the current store already contains. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, writes the first moderation timeline events alongside newly created threads and replies, persists author-role and guidance fields for both topic creation and reply creation, lets the page-level thread composer create new topics, and lets existing threads accept the first persisted reply submissions.
 
 ## Container deployment
 
@@ -135,8 +139,8 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, confirms `/threads/new` exposes the writable page-level composer, creates a thread through the API, reads that thread back through `/threads` and `/threads/[slug]`, and then adds a reply to verify both the updated discussion and the appended moderation timeline event are visible on the thread detail page.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates the sqlite runtime status, confirms `/threads/new` exposes the writable page-level composer, creates a thread through the API, reads that thread back through `/threads` and `/threads/[slug]`, and then adds a reply to verify the latest discussion, role labels, guidance signals, and appended moderation timeline event are all visible on the thread detail page.
 
 ## Why this is the next step
 
-After the structured seed content contract, standalone deployment baseline, runtime status boundary, first durable thread creation path, first reply write path, page-level reply submission, page-level thread creation, and page-level sqlite readback checks landed, the next highest-value gap was turning governance signals into durable data rather than leaving them in copy alone. This iteration keeps the product surface narrow while making moderation state inspectable through the same repository and page boundary, so the next pass can focus on role state and more explicit newcomer guidance instead of rediscovering whether governance events survive real writes.
+After moderation timeline persistence landed, the highest-value gap was still that author role and newcomer-guidance state mostly existed as defaults or copy rather than explicit durable fields. This iteration keeps the product surface narrow while moving those signals into the same repository, API, page, and container-check boundary, so the next pass can build on real persisted state instead of rediscovering it at render time.

--- a/forum/src/app/api/thread/[slug]/replies/route.ts
+++ b/forum/src/app/api/thread/[slug]/replies/route.ts
@@ -14,6 +14,7 @@ interface RouteContext {
 interface CreateReplyPayload {
   author?: unknown;
   roleLabel?: unknown;
+  guidanceSignal?: unknown;
   trustSignal?: unknown;
   body?: unknown;
 }
@@ -30,6 +31,18 @@ function requireString(value: unknown, fieldName: string): string {
   }
 
   return trimmed;
+}
+
+function optionalString(value: unknown, fieldName: string): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    throw new ForumInputError(`${fieldName} must be a string.`);
+  }
+
+  return value.trim();
 }
 
 function normalizeStringArray(value: unknown, fieldName: string): string[] {
@@ -63,17 +76,15 @@ function parseCreateReplyPayload(threadSlug: string, payload: CreateReplyPayload
     throw new ForumInputError("body must contain at least one paragraph.");
   }
 
-  const roleLabel = typeof payload.roleLabel === "string" && payload.roleLabel.trim().length > 0
-    ? payload.roleLabel.trim()
-    : "论坛参与者";
-  const trustSignal = typeof payload.trustSignal === "string" && payload.trustSignal.trim().length > 0
-    ? payload.trustSignal.trim()
-    : "新提交回复，等待更多互动后再判断是否适合沉淀。";
+  const roleLabel = optionalString(payload.roleLabel, "roleLabel");
+  const guidanceSignal = optionalString(payload.guidanceSignal, "guidanceSignal");
+  const trustSignal = optionalString(payload.trustSignal, "trustSignal");
 
   return {
     threadSlug,
     author,
     roleLabel,
+    guidanceSignal,
     trustSignal,
     body,
   };

--- a/forum/src/app/api/threads/route.ts
+++ b/forum/src/app/api/threads/route.ts
@@ -12,6 +12,8 @@ interface CreateThreadPayload {
   title?: unknown;
   summary?: unknown;
   author?: unknown;
+  authorRoleLabel?: unknown;
+  guidanceSignal?: unknown;
   tags?: unknown;
   openingPost?: unknown;
 }
@@ -28,6 +30,18 @@ function requireString(value: unknown, fieldName: string): string {
   }
 
   return trimmed;
+}
+
+function optionalString(value: unknown, fieldName: string): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    throw new ForumInputError(`${fieldName} must be a string.`);
+  }
+
+  return value.trim();
 }
 
 function normalizeStringArray(value: unknown, fieldName: string): string[] {
@@ -57,6 +71,8 @@ function parseCreateThreadPayload(payload: CreateThreadPayload): CreateForumThre
   const sectionSlug = requireString(payload.sectionSlug, "sectionSlug");
   const title = requireString(payload.title, "title");
   const author = requireString(payload.author, "author");
+  const authorRoleLabel = optionalString(payload.authorRoleLabel, "authorRoleLabel");
+  const guidanceSignal = optionalString(payload.guidanceSignal, "guidanceSignal");
   const openingPost = normalizeStringArray(payload.openingPost, "openingPost");
 
   if (openingPost.length === 0) {
@@ -73,6 +89,8 @@ function parseCreateThreadPayload(payload: CreateThreadPayload): CreateForumThre
     title,
     summary,
     author,
+    authorRoleLabel,
+    guidanceSignal,
     tags,
     openingPost,
   };

--- a/forum/src/app/page.tsx
+++ b/forum/src/app/page.tsx
@@ -22,18 +22,18 @@ export default function HomePage() {
 
         <h1>把论坛从占位目录推进成真正能承接互动与治理的独立项目。</h1>
         <p>
-          这一版先不追求完整社区能力，而是先把独立运行骨架、sqlite 最小写入、帖子详情回复、页面层主题创建入口和首条审核时间线接起来，
-          让下一轮可以直接接角色状态、新手引导和更完整的用户流程。
+          这一版先不追求完整社区能力，而是先把独立运行骨架、sqlite 最小写入、帖子详情回复、页面层主题创建入口、审核时间线，以及作者角色与新手引导信号接起来，
+          让下一轮可以直接接更明确的登录、审核和部署边界。
         </p>
 
         <div className="hero-grid">
           <article className="panel">
             <h2>当前阶段</h2>
-            <p>sqlite 最小互动闭环加首条治理时间线。目标是让论坛从“能发起主题、能回复”进入“每次写入都会留下可回读的审核状态”。</p>
+            <p>sqlite 最小互动闭环加治理时间线与角色引导持久化。目标是让论坛从“能写内容”继续推进到“写入后带着真实上下文回读”。</p>
           </article>
           <article className="panel">
             <h2>下一步承接点</h2>
-            <p>优先把角色状态和新手引导沿着同一条页面到仓储链路继续持久化，而不是回到静态占位页面。</p>
+            <p>优先明确论坛独立部署入口，以及登录态、权限态和审核流该落在哪一层服务边界上。</p>
           </article>
         </div>
       </section>
@@ -43,10 +43,12 @@ export default function HomePage() {
           <article key={thread.slug} className="thread-card">
             <div className="thread-meta">
               <span>{thread.author}</span>
+              <span>{thread.authorRoleLabel}</span>
               <span>{thread.lastActivity}</span>
             </div>
             <h2>{thread.title}</h2>
             <p>{thread.summary}</p>
+            <p className="reply-form-hint">当前引导信号：{thread.guidanceSignal}</p>
             <div className="thread-tags">
               {thread.tags.map((tag) => (
                 <span key={tag}>{tag}</span>

--- a/forum/src/app/threads/[slug]/page.tsx
+++ b/forum/src/app/threads/[slug]/page.tsx
@@ -34,6 +34,12 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
 
         <h1>{thread.title}</h1>
         <p>{thread.summary}</p>
+        <div className="thread-meta">
+          <span>{thread.author}</span>
+          <span>{thread.authorRoleLabel}</span>
+          <span>{thread.publishedAt}</span>
+        </div>
+        <p className="reply-form-hint">当前引导信号：{thread.guidanceSignal}</p>
 
         <div className="metrics">
           <article className="metric">
@@ -67,11 +73,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
           </ul>
         </section>
 
-        <ThreadReplyForm
-          threadSlug={thread.slug}
-          writesEnabled={runtime.writesEnabled}
-          dataSource={runtime.dataSource}
-        />
+        <ThreadReplyForm threadSlug={thread.slug} writesEnabled={runtime.writesEnabled} dataSource={runtime.dataSource} />
 
         <section className="reply-stack">
           <div className="section-heading">
@@ -79,7 +81,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
               <h2>当前回复</h2>
               <p>
                 {runtime.writesEnabled
-                  ? "新回复提交后会回写 sqlite，并在刷新后直接显示在这里。"
+                  ? "新回复提交后会把角色状态、引导信号和正文一起写入 sqlite，并在刷新后直接显示在这里。"
                   : "当前环境先以样例回复展示结构，切到 sqlite 后这里会承接真实提交。"}
               </p>
             </div>
@@ -95,6 +97,7 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
                 </div>
                 <span className="reply-signal">{reply.trustSignal}</span>
               </div>
+              <p className="reply-form-hint">引导信号：{reply.guidanceSignal}</p>
 
               {reply.body.map((paragraph) => (
                 <p key={paragraph}>{paragraph}</p>
@@ -133,10 +136,10 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
 
         <section className="api-note">
           <h2>后续扩展位置</h2>
-          <p>下一轮可以继续把角色状态和新手引导沿着同一条页面到仓储链路持久化，而不是把治理能力留在展示文案里。</p>
+          <p>下一轮可以在这条已持久化的角色与引导链路上继续接更明确的审核动作、登录态和新手承接流程。</p>
           <div className="footer-note">
             <span>作者：{thread.author}</span>
-            <span>发布时间：{thread.publishedAt}</span>
+            <span>作者角色：{thread.authorRoleLabel}</span>
             <span>最近活动：{thread.lastActivity}</span>
           </div>
         </section>

--- a/forum/src/app/threads/[slug]/reply-form.tsx
+++ b/forum/src/app/threads/[slug]/reply-form.tsx
@@ -11,6 +11,8 @@ interface ThreadReplyFormProps {
 
 type FormTone = "error" | "success";
 
+const ROLE_OPTIONS = ["新加入同修", "持续修学者", "带新同修", "资料整理协作"];
+
 function getParagraphs(value: string) {
   return value
     .split(/\n+/)
@@ -21,6 +23,8 @@ function getParagraphs(value: string) {
 export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: ThreadReplyFormProps) {
   const router = useRouter();
   const [author, setAuthor] = useState("");
+  const [roleLabel, setRoleLabel] = useState(ROLE_OPTIONS[0]);
+  const [guidanceSignal, setGuidanceSignal] = useState("");
   const [body, setBody] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [tone, setTone] = useState<FormTone | null>(null);
@@ -38,11 +42,12 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
     }
 
     const trimmedAuthor = author.trim();
+    const trimmedGuidanceSignal = guidanceSignal.trim();
     const paragraphs = getParagraphs(body);
 
-    if (!trimmedAuthor || paragraphs.length === 0) {
+    if (!trimmedAuthor || !trimmedGuidanceSignal || paragraphs.length === 0) {
       setTone("error");
-      setMessage("请先填写称呼和回复内容。");
+      setMessage("请先填写称呼、角色状态、引导信号和回复内容。");
       return;
     }
 
@@ -59,6 +64,8 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
             },
             body: JSON.stringify({
               author: trimmedAuthor,
+              roleLabel,
+              guidanceSignal: trimmedGuidanceSignal,
               body: paragraphs,
             }),
           });
@@ -70,6 +77,7 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
           }
 
           setAuthor("");
+          setGuidanceSignal("");
           setBody("");
           setTone("success");
           setMessage("回复已写入当前线程，页面正在刷新。");
@@ -87,7 +95,7 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
       <div className="section-heading">
         <div>
           <h2 id="reply-composer-heading">写一条最小回复</h2>
-          <p>先把页面层接到 sqlite 回复接口，确认真实互动不只停留在 API。</p>
+          <p>这一步会把回复者的角色状态和当前引导信号一起写入 sqlite，而不是继续依赖接口默认文案。</p>
         </div>
         <span className="reply-runtime">{writesEnabled ? `当前数据源：${dataSource} / 可写` : `当前数据源：${dataSource} / 只读`}</span>
       </div>
@@ -114,6 +122,35 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
           </label>
 
           <label className="reply-field">
+            <span>角色状态</span>
+            <select
+              className="reply-input composer-select"
+              name="roleLabel"
+              value={roleLabel}
+              onChange={(event) => setRoleLabel(event.target.value)}
+              disabled={!writesEnabled || isPending}
+            >
+              {ROLE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="reply-field">
+            <span>引导信号</span>
+            <input
+              className="reply-input"
+              name="guidanceSignal"
+              value={guidanceSignal}
+              onChange={(event) => setGuidanceSignal(event.target.value)}
+              placeholder="例如：我想先补一条最容易执行的下一步建议。"
+              disabled={!writesEnabled || isPending}
+            />
+          </label>
+
+          <label className="reply-field">
             <span>回复内容</span>
             <textarea
               className="reply-textarea"
@@ -129,8 +166,8 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
         <div className="reply-form-footer">
           <p className="reply-form-hint">
             {paragraphCount > 0
-              ? `当前会提交 ${paragraphCount} 段内容。接口会自动补默认角色标签和信任信号。`
-              : "回复支持按空行切成多段，先把最小交流闭环跑通。"}
+              ? `当前会提交 ${paragraphCount} 段内容，并把回复者角色和引导信号一起落库。`
+              : "回复支持按空行切成多段，第一版先把角色状态和引导信号稳定接进真实回复流。"}
           </p>
           <button className="submit-button" type="submit" disabled={!writesEnabled || isPending}>
             {isPending ? "提交中..." : "提交回复"}

--- a/forum/src/app/threads/new/thread-composer.tsx
+++ b/forum/src/app/threads/new/thread-composer.tsx
@@ -18,6 +18,8 @@ interface ThreadComposerProps {
 
 type FormTone = "error" | "success";
 
+const ROLE_OPTIONS = ["新手提问者", "持续修学者", "带新同修", "资料整理者"];
+
 function getParagraphs(value: string) {
   return value
     .split(/\n+/)
@@ -37,6 +39,8 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
   const [sectionSlug, setSectionSlug] = useState(sections[0]?.slug ?? "");
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
+  const [authorRoleLabel, setAuthorRoleLabel] = useState(ROLE_OPTIONS[0]);
+  const [guidanceSignal, setGuidanceSignal] = useState("");
   const [tagsInput, setTagsInput] = useState("");
   const [openingPost, setOpeningPost] = useState("");
   const [message, setMessage] = useState<string | null>(null);
@@ -65,12 +69,13 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
 
     const trimmedTitle = title.trim();
     const trimmedAuthor = author.trim();
+    const trimmedGuidanceSignal = guidanceSignal.trim();
     const paragraphs = getParagraphs(openingPost);
     const tags = getTags(tagsInput);
 
-    if (!trimmedTitle || !trimmedAuthor || paragraphs.length === 0) {
+    if (!trimmedTitle || !trimmedAuthor || !trimmedGuidanceSignal || paragraphs.length === 0) {
       setTone("error");
-      setMessage("请先选择版块，并填写标题、称呼和开场帖内容。");
+      setMessage("请先填写标题、称呼、作者角色、引导信号和开场帖内容。");
       return;
     }
 
@@ -89,6 +94,8 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
               sectionSlug: selectedSection.slug,
               title: trimmedTitle,
               author: trimmedAuthor,
+              authorRoleLabel,
+              guidanceSignal: trimmedGuidanceSignal,
               tags,
               openingPost: paragraphs,
             }),
@@ -111,6 +118,7 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
 
           setTitle("");
           setAuthor("");
+          setGuidanceSignal("");
           setTagsInput("");
           setOpeningPost("");
           setTone("success");
@@ -129,7 +137,7 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
       <div className="section-heading">
         <div>
           <h2 id="thread-composer-heading">发起一条最小主题</h2>
-          <p>先把页面层接到已有的线程创建接口，确认浏览列表、发起主题、进入详情页这条链路已经成立。</p>
+          <p>这一步除了创建主题本身，也把作者角色和新手引导信号一起写入持久化层，避免它们只停留在展示文案。</p>
         </div>
         <span className="reply-runtime">{writesEnabled ? `当前数据源：${dataSource} / 可写` : `当前数据源：${dataSource} / 只读`}</span>
       </div>
@@ -185,6 +193,35 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
           </label>
 
           <label className="reply-field">
+            <span>作者角色</span>
+            <select
+              className="reply-input composer-select"
+              name="authorRoleLabel"
+              value={authorRoleLabel}
+              onChange={(event) => setAuthorRoleLabel(event.target.value)}
+              disabled={!writesEnabled || isPending}
+            >
+              {ROLE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="reply-field">
+            <span>引导信号</span>
+            <input
+              className="reply-input"
+              name="guidanceSignal"
+              value={guidanceSignal}
+              onChange={(event) => setGuidanceSignal(event.target.value)}
+              placeholder="例如：请先给我一条最容易开始的下一步建议。"
+              disabled={!writesEnabled || isPending}
+            />
+          </label>
+
+          <label className="reply-field">
             <span>标签</span>
             <input
               className="reply-input"
@@ -220,8 +257,8 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
         <div className="reply-form-footer">
           <p className="reply-form-hint">
             {paragraphCount > 0
-              ? `当前会提交 ${paragraphCount} 段开场帖${tagCount > 0 ? `，并附带 ${tagCount} 个标签` : ""}。接口会自动生成摘要。`
-              : "开场帖支持按空行分段；第一版先让标题、版块和开场帖稳定落库。"}
+              ? `当前会提交 ${paragraphCount} 段开场帖${tagCount > 0 ? `，并附带 ${tagCount} 个标签` : ""}，同时把作者角色和引导信号一起落库。`
+              : "开场帖支持按空行分段；第一版先把标题、版块、角色状态和引导信号稳定落库。"}
           </p>
           <button className="submit-button" type="submit" disabled={!writesEnabled || isPending || !selectedSection}>
             {isPending ? "发布中..." : "发布主题"}

--- a/forum/src/app/threads/page.tsx
+++ b/forum/src/app/threads/page.tsx
@@ -28,7 +28,7 @@ export default function ThreadsPage() {
             <h2>开始一条新主题</h2>
             <p>
               {runtime.writesEnabled
-                ? "当前运行环境已经允许页面层直接发起主题，下一轮可以继续沿着这条链路接审核事件和用户状态。"
+                ? "当前运行环境已经允许页面层直接发起主题，作者角色和新手引导信号也会随主题一起落库。"
                 : `当前 ${runtime.dataSource} 模式还是只读，但页面层发帖入口已经可以先承接结构和表单交互，切到 sqlite 后即可直接发布。`}
             </p>
           </div>
@@ -54,11 +54,13 @@ export default function ThreadsPage() {
           <article key={thread.slug} className="thread-card">
             <div className="thread-meta">
               <span>{thread.author}</span>
+              <span>{thread.authorRoleLabel}</span>
               <span>{thread.publishedAt}</span>
               <span>{thread.lastActivity}</span>
             </div>
             <h2>{thread.title}</h2>
             <p>{thread.summary}</p>
+            <p className="reply-form-hint">当前引导信号：{thread.guidanceSignal}</p>
             <div className="thread-tags">
               {thread.tags.map((tag) => (
                 <span key={tag}>{tag}</span>

--- a/forum/src/lib/forum-data.ts
+++ b/forum/src/lib/forum-data.ts
@@ -21,6 +21,8 @@ export interface ForumThread {
   title: string;
   summary: string;
   author: string;
+  authorRoleLabel: string;
+  guidanceSignal: string;
   publishedAt: string;
   lastActivity: string;
   replyCount: number;
@@ -38,6 +40,7 @@ export interface ForumReply {
   threadSlug: string;
   author: string;
   roleLabel: string;
+  guidanceSignal: string;
   publishedAt: string;
   moderationState: ForumModerationState;
   trustSignal: string;
@@ -82,6 +85,8 @@ export interface CreateForumThreadInput {
   title: string;
   summary: string;
   author: string;
+  authorRoleLabel: string;
+  guidanceSignal: string;
   tags: string[];
   openingPost: string[];
 }
@@ -90,6 +95,7 @@ export interface CreateForumReplyInput {
   threadSlug: string;
   author: string;
   roleLabel: string;
+  guidanceSignal: string;
   trustSignal: string;
   body: string[];
 }

--- a/forum/src/lib/forum-seed-repository.ts
+++ b/forum/src/lib/forum-seed-repository.ts
@@ -19,6 +19,75 @@ interface ForumContentStore {
   replies: ForumReply[];
 }
 
+function getDefaultThreadRoleLabel(sectionSlug: string) {
+  switch (sectionSlug) {
+    case "newcomer-path":
+      return "新手提问者";
+    case "sutra-study":
+      return "经论研读者";
+    case "meditation-practice":
+      return "练习反馈者";
+    case "knowledge-archive":
+      return "资料整理者";
+    default:
+      return "论坛提问者";
+  }
+}
+
+function getDefaultThreadGuidanceSignal(sectionSlug: string) {
+  switch (sectionSlug) {
+    case "newcomer-path":
+      return "请优先结合当前节奏给一条最容易开始的下一步建议。";
+    case "sutra-study":
+      return "请优先补出处、上下文和当前理解，再继续讨论名相。";
+    case "meditation-practice":
+      return "请优先结合练习前状态与结束后复盘来回应。";
+    case "knowledge-archive":
+      return "请优先说明这条内容为什么值得长期沉淀和复用。";
+    default:
+      return "请继续结合提问者当前阶段给出具体、可执行的回应。";
+  }
+}
+
+function getDefaultReplyGuidanceSignal(sectionSlug?: string) {
+  switch (sectionSlug) {
+    case "newcomer-path":
+      return "请先接住楼主当前阶段，再补一条最容易执行的起步建议。";
+    case "sutra-study":
+      return "请尽量围绕出处、上下文和当前理解继续回应。";
+    case "meditation-practice":
+      return "请优先结合练习条件、变化和复盘给出反馈。";
+    case "knowledge-archive":
+      return "请优先说明这条补充是否适合整理进长期资料。";
+    default:
+      return "请继续结合楼主当前阶段给出具体回应。";
+  }
+}
+
+function normalizeThread(thread: ForumThread): ForumThread {
+  return {
+    ...thread,
+    authorRoleLabel:
+      typeof thread.authorRoleLabel === "string" && thread.authorRoleLabel.trim().length > 0
+        ? thread.authorRoleLabel.trim()
+        : getDefaultThreadRoleLabel(thread.sectionSlug),
+    guidanceSignal:
+      typeof thread.guidanceSignal === "string" && thread.guidanceSignal.trim().length > 0
+        ? thread.guidanceSignal.trim()
+        : getDefaultThreadGuidanceSignal(thread.sectionSlug),
+  };
+}
+
+function normalizeReply(reply: ForumReply, thread?: ForumThread): ForumReply {
+  return {
+    ...reply,
+    guidanceSignal:
+      typeof reply.guidanceSignal === "string" && reply.guidanceSignal.trim().length > 0
+        ? reply.guidanceSignal.trim()
+        : getDefaultReplyGuidanceSignal(thread?.sectionSlug),
+  };
+}
+
 function describeSeedModerationSummary(thread: ForumThread) {
   if (thread.knowledgeStage === "candidate") {
     return "种子主题已发布，并标记为候选资料，后续适合继续整理。";
@@ -42,8 +111,9 @@ const content = forumContent as ForumContentStore;
 
 export function createSeedForumRepository(): ForumRepository {
   const sections = content.sections;
-  const threads = content.threads;
-  const replies = content.replies;
+  const threads = content.threads.map(normalizeThread);
+  const threadBySlug = new Map(threads.map((thread) => [thread.slug, thread]));
+  const replies = content.replies.map((reply) => normalizeReply(reply, threadBySlug.get(reply.threadSlug)));
   const moderationEvents = buildSeedModerationEvents(threads);
 
   const getSectionBySlug = (slug: string) => sections.find((section) => section.slug === slug);

--- a/forum/src/lib/forum-sqlite-repository.ts
+++ b/forum/src/lib/forum-sqlite-repository.ts
@@ -125,6 +125,14 @@ function getDefaultReplyGuidanceSignal(sectionSlug?: string) {
   }
 }
 
+function getDefaultReplyRoleLabel() {
+  return "论坛参与者";
+}
+
+function getDefaultReplyTrustSignal() {
+  return "新提交回复，等待更多互动后再判断是否适合沉淀。";
+}
+
 function normalizeThread(thread: ForumThread): ForumThread {
   return {
     ...thread,
@@ -142,10 +150,18 @@ function normalizeThread(thread: ForumThread): ForumThread {
 function normalizeReply(reply: ForumReply, thread?: ForumThread): ForumReply {
   return {
     ...reply,
+    roleLabel:
+      typeof reply.roleLabel === "string" && reply.roleLabel.trim().length > 0
+        ? reply.roleLabel.trim()
+        : getDefaultReplyRoleLabel(),
     guidanceSignal:
       typeof reply.guidanceSignal === "string" && reply.guidanceSignal.trim().length > 0
         ? reply.guidanceSignal.trim()
         : getDefaultReplyGuidanceSignal(thread?.sectionSlug),
+    trustSignal:
+      typeof reply.trustSignal === "string" && reply.trustSignal.trim().length > 0
+        ? reply.trustSignal.trim()
+        : getDefaultReplyTrustSignal(),
   };
 }
 
@@ -216,14 +232,20 @@ function mapReply(row: SqliteReplyRow): ForumReply {
     id: row.id,
     threadSlug: row.thread_slug,
     author: row.author,
-    roleLabel: row.role_label,
+    roleLabel:
+      typeof row.role_label === "string" && row.role_label.trim().length > 0
+        ? row.role_label.trim()
+        : getDefaultReplyRoleLabel(),
     guidanceSignal:
       typeof row.guidance_signal === "string" && row.guidance_signal.trim().length > 0
         ? row.guidance_signal.trim()
         : getDefaultReplyGuidanceSignal(),
     publishedAt: row.published_at,
     moderationState: row.moderation_state,
-    trustSignal: row.trust_signal,
+    trustSignal:
+      typeof row.trust_signal === "string" && row.trust_signal.trim().length > 0
+        ? row.trust_signal.trim()
+        : getDefaultReplyTrustSignal(),
     body: parseJsonArray(row.body_json),
   };
 }
@@ -923,7 +945,9 @@ export function createSqliteForumRepository(): ForumRepository {
     }
 
     const body = input.body.filter((paragraph) => paragraph.trim().length > 0);
+    const roleLabel = input.roleLabel.trim() || getDefaultReplyRoleLabel();
     const guidanceSignal = input.guidanceSignal.trim() || getDefaultReplyGuidanceSignal(thread.sectionSlug);
+    const trustSignal = input.trustSignal.trim() || getDefaultReplyTrustSignal();
 
     if (body.length === 0) {
       throw new ForumInputError("Reply body must contain at least one non-empty paragraph.");
@@ -952,11 +976,11 @@ export function createSqliteForumRepository(): ForumRepository {
         replyId,
         input.threadSlug,
         input.author,
-        input.roleLabel,
+        roleLabel,
         guidanceSignal,
         createdAt,
         "published",
-        input.trustSignal,
+        trustSignal,
         JSON.stringify(body),
       );
 

--- a/forum/src/lib/forum-sqlite-repository.ts
+++ b/forum/src/lib/forum-sqlite-repository.ts
@@ -36,6 +36,8 @@ interface SqliteThreadRow {
   title: string;
   summary: string;
   author: string;
+  author_role_label?: string | null;
+  guidance_signal?: string | null;
   published_at: string;
   last_activity: string;
   reply_count: number;
@@ -53,6 +55,7 @@ interface SqliteReplyRow {
   thread_slug: string;
   author: string;
   role_label: string;
+  guidance_signal?: string | null;
   published_at: string;
   moderation_state: ForumReply["moderationState"];
   trust_signal: string;
@@ -75,6 +78,75 @@ const DEFAULT_DATABASE_URL = "file:./data/forum.db";
 function parseJsonArray(value: string): string[] {
   const parsed = JSON.parse(value) as unknown;
   return Array.isArray(parsed) ? parsed.map((item) => String(item)) : [];
+}
+
+function getDefaultThreadRoleLabel(sectionSlug: string) {
+  switch (sectionSlug) {
+    case "newcomer-path":
+      return "新手提问者";
+    case "sutra-study":
+      return "经论研读者";
+    case "meditation-practice":
+      return "练习反馈者";
+    case "knowledge-archive":
+      return "资料整理者";
+    default:
+      return "论坛提问者";
+  }
+}
+
+function getDefaultThreadGuidanceSignal(sectionSlug: string) {
+  switch (sectionSlug) {
+    case "newcomer-path":
+      return "请优先结合当前节奏给一条最容易开始的下一步建议。";
+    case "sutra-study":
+      return "请优先补出处、上下文和当前理解，再继续讨论名相。";
+    case "meditation-practice":
+      return "请优先结合练习前状态与结束后复盘来回应。";
+    case "knowledge-archive":
+      return "请优先说明这条内容为什么值得长期沉淀和复用。";
+    default:
+      return "请继续结合提问者当前阶段给出具体、可执行的回应。";
+  }
+}
+
+function getDefaultReplyGuidanceSignal(sectionSlug?: string) {
+  switch (sectionSlug) {
+    case "newcomer-path":
+      return "请先接住楼主当前阶段，再补一条最容易执行的起步建议。";
+    case "sutra-study":
+      return "请尽量围绕出处、上下文和当前理解继续回应。";
+    case "meditation-practice":
+      return "请优先结合练习条件、变化和复盘给出反馈。";
+    case "knowledge-archive":
+      return "请优先说明这条补充是否适合整理进长期资料。";
+    default:
+      return "请继续结合楼主当前阶段给出具体回应。";
+  }
+}
+
+function normalizeThread(thread: ForumThread): ForumThread {
+  return {
+    ...thread,
+    authorRoleLabel:
+      typeof thread.authorRoleLabel === "string" && thread.authorRoleLabel.trim().length > 0
+        ? thread.authorRoleLabel.trim()
+        : getDefaultThreadRoleLabel(thread.sectionSlug),
+    guidanceSignal:
+      typeof thread.guidanceSignal === "string" && thread.guidanceSignal.trim().length > 0
+        ? thread.guidanceSignal.trim()
+        : getDefaultThreadGuidanceSignal(thread.sectionSlug),
+  };
+}
+
+function normalizeReply(reply: ForumReply, thread?: ForumThread): ForumReply {
+  return {
+    ...reply,
+    guidanceSignal:
+      typeof reply.guidanceSignal === "string" && reply.guidanceSignal.trim().length > 0
+        ? reply.guidanceSignal.trim()
+        : getDefaultReplyGuidanceSignal(thread?.sectionSlug),
+  };
 }
 
 function describeSeedModerationSummary(thread: ForumThread) {
@@ -118,6 +190,14 @@ function mapThread(row: SqliteThreadRow): ForumThread {
     title: row.title,
     summary: row.summary,
     author: row.author,
+    authorRoleLabel:
+      typeof row.author_role_label === "string" && row.author_role_label.trim().length > 0
+        ? row.author_role_label.trim()
+        : getDefaultThreadRoleLabel(row.section_slug),
+    guidanceSignal:
+      typeof row.guidance_signal === "string" && row.guidance_signal.trim().length > 0
+        ? row.guidance_signal.trim()
+        : getDefaultThreadGuidanceSignal(row.section_slug),
     publishedAt: row.published_at,
     lastActivity: row.last_activity,
     replyCount: Number(row.reply_count),
@@ -137,6 +217,10 @@ function mapReply(row: SqliteReplyRow): ForumReply {
     threadSlug: row.thread_slug,
     author: row.author,
     roleLabel: row.role_label,
+    guidanceSignal:
+      typeof row.guidance_signal === "string" && row.guidance_signal.trim().length > 0
+        ? row.guidance_signal.trim()
+        : getDefaultReplyGuidanceSignal(),
     publishedAt: row.published_at,
     moderationState: row.moderation_state,
     trustSignal: row.trust_signal,
@@ -217,6 +301,8 @@ function initializeSchema(database: DatabaseSync) {
       title TEXT NOT NULL,
       summary TEXT NOT NULL,
       author TEXT NOT NULL,
+      author_role_label TEXT NOT NULL DEFAULT '论坛提问者',
+      guidance_signal TEXT NOT NULL DEFAULT '请继续结合提问者当前阶段给出具体、可执行的回应。',
       published_at TEXT NOT NULL,
       last_activity TEXT NOT NULL,
       reply_count INTEGER NOT NULL DEFAULT 0,
@@ -235,6 +321,7 @@ function initializeSchema(database: DatabaseSync) {
       thread_slug TEXT NOT NULL,
       author TEXT NOT NULL,
       role_label TEXT NOT NULL,
+      guidance_signal TEXT NOT NULL DEFAULT '请继续结合楼主当前阶段给出具体回应。',
       published_at TEXT NOT NULL,
       moderation_state TEXT NOT NULL,
       trust_signal TEXT NOT NULL,
@@ -256,12 +343,41 @@ function initializeSchema(database: DatabaseSync) {
   `);
 }
 
+function tableHasColumn(database: DatabaseSync, tableName: string, columnName: string) {
+  const rows = database.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === columnName);
+}
+
+function ensureSchemaCompatibility(database: DatabaseSync) {
+  if (!tableHasColumn(database, "forum_threads", "author_role_label")) {
+    database.exec(
+      "ALTER TABLE forum_threads ADD COLUMN author_role_label TEXT NOT NULL DEFAULT '论坛提问者'",
+    );
+  }
+
+  if (!tableHasColumn(database, "forum_threads", "guidance_signal")) {
+    database.exec(
+      "ALTER TABLE forum_threads ADD COLUMN guidance_signal TEXT NOT NULL DEFAULT '请继续结合提问者当前阶段给出具体、可执行的回应。'",
+    );
+  }
+
+  if (!tableHasColumn(database, "forum_replies", "guidance_signal")) {
+    database.exec(
+      "ALTER TABLE forum_replies ADD COLUMN guidance_signal TEXT NOT NULL DEFAULT '请继续结合楼主当前阶段给出具体回应。'",
+    );
+  }
+}
+
 function seedDatabaseIfEmpty(database: DatabaseSync) {
   const countRow = database.prepare("SELECT COUNT(*) AS count FROM forum_sections").get() as { count: number };
 
   if (Number(countRow.count) > 0) {
     return;
   }
+
+  const normalizedThreads = seedContent.threads.map(normalizeThread);
+  const threadBySlug = new Map(normalizedThreads.map((thread) => [thread.slug, thread]));
+  const normalizedReplies = seedContent.replies.map((reply) => normalizeReply(reply, threadBySlug.get(reply.threadSlug)));
 
   const insertSection = database.prepare(`
     INSERT INTO forum_sections (slug, name, description, moderation_focus, posting_prompt)
@@ -274,6 +390,8 @@ function seedDatabaseIfEmpty(database: DatabaseSync) {
       title,
       summary,
       author,
+      author_role_label,
+      guidance_signal,
       published_at,
       last_activity,
       reply_count,
@@ -285,7 +403,7 @@ function seedDatabaseIfEmpty(database: DatabaseSync) {
       moderation_state,
       knowledge_stage
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const insertReply = database.prepare(`
     INSERT INTO forum_replies (
@@ -293,12 +411,13 @@ function seedDatabaseIfEmpty(database: DatabaseSync) {
       thread_slug,
       author,
       role_label,
+      guidance_signal,
       published_at,
       moderation_state,
       trust_signal,
       body_json
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const insertModerationEvent = database.prepare(`
     INSERT INTO forum_moderation_events (
@@ -326,13 +445,15 @@ function seedDatabaseIfEmpty(database: DatabaseSync) {
       );
     }
 
-    for (const thread of seedContent.threads) {
+    for (const thread of normalizedThreads) {
       insertThread.run(
         thread.slug,
         thread.sectionSlug,
         thread.title,
         thread.summary,
         thread.author,
+        thread.authorRoleLabel,
+        thread.guidanceSignal,
         thread.publishedAt,
         thread.lastActivity,
         thread.replyCount,
@@ -356,12 +477,13 @@ function seedDatabaseIfEmpty(database: DatabaseSync) {
       );
     }
 
-    for (const reply of seedContent.replies) {
+    for (const reply of normalizedReplies) {
       insertReply.run(
         reply.id,
         reply.threadSlug,
         reply.author,
         reply.roleLabel,
+        reply.guidanceSignal,
         reply.publishedAt,
         reply.moderationState,
         reply.trustSignal,
@@ -434,6 +556,7 @@ export function createSqliteForumRepository(): ForumRepository {
   const database = new DatabaseSync(databasePath);
   database.exec("PRAGMA foreign_keys = ON");
   initializeSchema(database);
+  ensureSchemaCompatibility(database);
   seedDatabaseIfEmpty(database);
 
   const getSections = (): ForumSection[] => {
@@ -453,6 +576,8 @@ export function createSqliteForumRepository(): ForumRepository {
           title,
           summary,
           author,
+          author_role_label,
+          guidance_signal,
           published_at,
           last_activity,
           reply_count,
@@ -479,6 +604,7 @@ export function createSqliteForumRepository(): ForumRepository {
           thread_slug,
           author,
           role_label,
+          guidance_signal,
           published_at,
           moderation_state,
           trust_signal,
@@ -527,6 +653,8 @@ export function createSqliteForumRepository(): ForumRepository {
           title,
           summary,
           author,
+          author_role_label,
+          guidance_signal,
           published_at,
           last_activity,
           reply_count,
@@ -555,6 +683,8 @@ export function createSqliteForumRepository(): ForumRepository {
           title,
           summary,
           author,
+          author_role_label,
+          guidance_signal,
           published_at,
           last_activity,
           reply_count,
@@ -582,6 +712,7 @@ export function createSqliteForumRepository(): ForumRepository {
           thread_slug,
           author,
           role_label,
+          guidance_signal,
           published_at,
           moderation_state,
           trust_signal,
@@ -641,7 +772,10 @@ export function createSqliteForumRepository(): ForumRepository {
     return {
       sections: sections.map((section) => {
         const sectionThreads = threads.filter((thread) => thread.sectionSlug === section.slug);
-        const replyCount = sectionThreads.reduce((total, thread) => total + replies.filter((reply) => reply.threadSlug === thread.slug).length, 0);
+        const replyCount = sectionThreads.reduce(
+          (total, thread) => total + replies.filter((reply) => reply.threadSlug === thread.slug).length,
+          0,
+        );
 
         return {
           ...section,
@@ -694,6 +828,8 @@ export function createSqliteForumRepository(): ForumRepository {
     const slug = nextThreadSlug(database, input.title);
     const createdAt = new Date().toISOString();
     const openingPost = input.openingPost.filter((paragraph) => paragraph.trim().length > 0);
+    const authorRoleLabel = input.authorRoleLabel.trim() || getDefaultThreadRoleLabel(input.sectionSlug);
+    const guidanceSignal = input.guidanceSignal.trim() || getDefaultThreadGuidanceSignal(input.sectionSlug);
 
     if (openingPost.length === 0) {
       throw new ForumInputError("Thread openingPost must contain at least one non-empty paragraph.");
@@ -709,6 +845,8 @@ export function createSqliteForumRepository(): ForumRepository {
           title,
           summary,
           author,
+          author_role_label,
+          guidance_signal,
           published_at,
           last_activity,
           reply_count,
@@ -720,13 +858,15 @@ export function createSqliteForumRepository(): ForumRepository {
           moderation_state,
           knowledge_stage
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         slug,
         input.sectionSlug,
         input.title,
         input.summary,
         input.author,
+        authorRoleLabel,
+        guidanceSignal,
         createdAt,
         "刚刚创建",
         0,
@@ -783,6 +923,7 @@ export function createSqliteForumRepository(): ForumRepository {
     }
 
     const body = input.body.filter((paragraph) => paragraph.trim().length > 0);
+    const guidanceSignal = input.guidanceSignal.trim() || getDefaultReplyGuidanceSignal(thread.sectionSlug);
 
     if (body.length === 0) {
       throw new ForumInputError("Reply body must contain at least one non-empty paragraph.");
@@ -800,17 +941,19 @@ export function createSqliteForumRepository(): ForumRepository {
           thread_slug,
           author,
           role_label,
+          guidance_signal,
           published_at,
           moderation_state,
           trust_signal,
           body_json
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         replyId,
         input.threadSlug,
         input.author,
         input.roleLabel,
+        guidanceSignal,
         createdAt,
         "published",
         input.trustSignal,


### PR DESCRIPTION
## 问题

论坛现在已经有了：

- sqlite 主题创建与回复写入
- 页面层 `/threads/new` 发帖入口
- 页面层帖子详情回复表单
- 审核时间线与页面级 sqlite 回读检查

但作者角色和新手引导信号仍然不够真实：

- 主题作者的角色状态还没有进入真实持久化字段
- 回复里的角色标签虽然有展示位，但页面表单和接口仍主要依赖默认值
- 新手引导信号还没有沿着页面、API、sqlite 和页面回读检查形成一条完整链路

这会让论坛继续停在“能写内容”，但还没有把“这是谁写的、当前更适合怎样接住他”做成真实可回读状态。

## 这次改动

- 更新 `forum/src/lib/forum-data.ts`
  - 为主题新增 `authorRoleLabel` 与 `guidanceSignal`
  - 为回复新增 `guidanceSignal`
  - 扩展主题创建与回复创建契约
- 更新 `forum/src/lib/forum-seed-repository.ts`
  - 为种子主题和种子回复补默认角色 / 引导信号归一化
  - 让 `seed-json` 与 sqlite 两种模式下的数据结构保持一致
- 更新 `forum/src/lib/forum-sqlite-repository.ts`
  - 为 `forum_threads` 新增 `author_role_label` 与 `guidance_signal`
  - 为 `forum_replies` 新增 `guidance_signal`
  - 为已有 sqlite 表补兼容迁移，避免旧库直接失配
  - 在主题创建与回复创建时把角色 / 引导信号一起落库，并保留回复沉淀信号默认值
- 更新 `forum/src/app/api/threads/route.ts`
  - 解析并承接主题作者角色与引导信号
- 更新 `forum/src/app/api/thread/[slug]/replies/route.ts`
  - 解析并承接回复角色与引导信号
- 更新 `forum/src/app/threads/new/thread-composer.tsx`
  - 页面层主题创建表单新增作者角色与引导信号输入
- 更新 `forum/src/app/threads/[slug]/reply-form.tsx`
  - 页面层回复表单新增角色状态与引导信号输入
- 更新 `forum/src/app/threads/[slug]/page.tsx` 与 `forum/src/app/threads/page.tsx`
  - 把作者角色和引导信号直接显示到详情页 / 列表页
- 更新 `forum/src/app/page.tsx`
  - 把首页阶段说明对齐到“角色与引导持久化已完成”的状态
- 更新 `.github/workflows/forum-container-checks.yml`
  - 容器检查新增断言：
    - `/threads/new` 页面已出现角色 / 引导字段
    - 新主题创建后，API、列表页、详情页都能回读角色 / 引导信号
    - 新回复创建后，详情页能回读回复角色、引导信号和审核时间线
- 更新 `forum/README.md`
  - 文档化新的主题 / 回复字段与本地验证方式

## 为什么现在做

在审核时间线已经持久化之后，当前最高收益切片不是再开一个新页面，而是把“角色状态 + 新手引导”也推进成真实字段。

这一步的收益很集中：

- 论坛第一次不只知道“有一条新内容”，也知道“这条内容是谁在当前阶段写的、适合怎样被接住”
- 页面表单、API、sqlite 和容器 smoke check 一起承接同一批字段，不容易再次回退成展示文案
- 下一轮无论接登录态、权限态还是审核流，都可以沿着这条已落库的上下文链路继续扩展

## 验证

- compare 已确认改动只收敛在 12 个论坛相关文件
- 已通过分支回读确认：
  - 主题与回复契约已经承接角色 / 引导字段
  - sqlite schema 与兼容迁移已经补齐
  - 页面层主题 / 回复表单都已接入真实字段
  - 列表页与详情页开始显示新字段
  - 容器检查已扩到这些字段的 API 与页面回读断言
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build` 或 `docker build ./forum`
- 最终检查依赖仓库现有 Actions：
  - `CI`
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 明确论坛独立部署入口，以及登录态、权限态和审核流应落在哪层服务边界
- 在这条已持久化的角色 / 引导链路上继续补更明确的审核动作与新手承接流程