### PR TITLE
docs(ci): clarify TestFlight verification boundary in beta state notes

### DIFF
--- a/.github/scripts/generate-official-site-beta-state.py
+++ b/.github/scripts/generate-official-site-beta-state.py
@@ -159,6 +159,7 @@ if testflight_status:
         }
     )
     notes.append("iOS TestFlight 入口会在上传状态成功后同步到官网。")
+    notes.append("官网展示的 iOS TestFlight 入口来自本次发布携带的上传状态与公开加入链接；如需确认 App Store Connect 后台最终处理态，仍需额外核验。")
 
 if not notes:
     notes.append("本次 release 没有带新的 Android APK 或 iOS TestFlight 状态，官网会继续保留现有渠道信息。")


### PR DESCRIPTION
## Summary
- clarify in generated official-site beta notes that a public TestFlight entry is not the same thing as direct App Store Connect final-state verification
- keep the release-state sync logic unchanged while making the evidence boundary explicit for future triage

## Why
- this repo can now persist the public iOS TestFlight link and `TestFlight 已开放` state into `releases.json`
- that is strong evidence that the workflow captured upload metadata and a public join path
- but it is still not the same as directly reading App Store Connect's final internal processing state
- making that boundary explicit in the generated notes reduces future false-closure when scheduled triage reads persisted beta state

## What changed
- update `.github/scripts/generate-official-site-beta-state.py`
- when TestFlight status data is present, append one more note that says the website state comes from release-carried upload status plus public join-link evidence, and that App Store Connect final-state verification still needs a separate check

## Validation
- scoped to the beta-state generator script only
- no release-sync behavior, fallback branch logic, or website merge behavior changed
- current environment does not have a local checkout or runnable workflow harness, so validation remains code-review based for this tiny wording-only change

## Expected effect
- future operators and scheduled runs will be less likely to over-claim TestFlight closure from public-link evidence alone
- the remaining external blocker stays visible without regressing the current release sync path