### PR TITLE
feat(web): align homepage hero with dharma learning intent

### DIFF
--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -176,6 +176,29 @@ const FAQ_PREVIEW = [
   },
 ] as const;
 
+const HERO_GUIDE_LINKS = [
+  {
+    href: "/start-learning-buddhism",
+    zh: "学佛从哪里开始",
+    en: "Where to Begin",
+  },
+  {
+    href: "/practice-guide",
+    zh: "修行方法总览",
+    en: "Practice Guide",
+  },
+  {
+    href: "/sutra-guide",
+    zh: "佛经导读",
+    en: "Sutra Guide",
+  },
+  {
+    href: "/what-is-emptiness",
+    zh: "空性怎么理解",
+    en: "Emptiness",
+  },
+] as const;
+
 const DHARMA_PATHS = [
   {
     href: "/start-learning-buddhism",
@@ -430,12 +453,12 @@ export default async function HomePage() {
               </span>
             </div>
             <h1 id="home-title">
-              <LocalizedText zh="法布施" en="Dharma Sharing" />
+              <LocalizedText zh="学佛，从今天的一小步开始。" en="Begin buddhadharma with one small step." />
             </h1>
             <p className="hero-subtitle">
               <LocalizedText
-                zh="经文听诵、禅修、法流视频、修行记录与全球法布施。"
-                en="Sutra listening, meditation, dharma videos, practice tracking, and global giving in one place."
+                zh="从学佛入门、因果、菩提心、六度与空性，到经文听诵、禅修、日常功课与全球法布施，先把学习路径和练习工具放回同一个入口。"
+                en="From beginner dharma questions and core concepts to sutra listening, meditation, daily rhythm, and global giving, Fabushi keeps learning paths and practice tools inside one entry point."
               />
             </p>
             <div className="hero-actions">
@@ -457,6 +480,18 @@ export default async function HomePage() {
                   <LocalizedText zh="申请测试" en="Apply for beta" />
                 </a>
               )}
+            </div>
+            <div className="release-section-stack" aria-label="Dharma learning shortcuts / 学佛入口">
+              <p className="eyebrow">
+                <LocalizedText zh="先从这些入口开始" en="Start with these paths" />
+              </p>
+              <div className="site-nav-links">
+                {HERO_GUIDE_LINKS.map((item) => (
+                  <a key={item.href} href={siteHref(item.href)}>
+                    <LocalizedText zh={item.zh} en={item.en} />
+                  </a>
+                ))}
+              </div>
             </div>
 
             <div className="release-pill-grid" aria-label="Current download status / 当前下载状态">


### PR DESCRIPTION
## Summary
- realign the homepage hero so the first-screen signal matches the dharma-learning intent already expressed in homepage metadata
- replace the brand-only hero headline with a beginner-friendly learning-oriented headline and tighter supporting copy
- add above-the-fold shortcuts to `/start-learning-buddhism`, `/practice-guide`, `/sutra-guide`, and `/what-is-emptiness` without disturbing the existing download flow

## Why
The homepage metadata, FAQ, and dharma-path distribution section already speak clearly to `学佛从哪里开始`, core concepts, practice methods, and scripture guidance. But the hero still read primarily as a product-download surface, with a brand-only headline and no immediate content entry points.

That mismatch left the site's highest-weight page with a noticeable gap between:
- what search engines are being told the page is about
- what readers see first when they land

This PR closes that gap in the smallest high-yield way: keep downloads visible, but let the hero immediately signal that Fabushi is also a learning-path entry point for buddhadharma, practice, scripture, and core concepts.

## What changed
- update the homepage `h1` to a clearer learning-oriented headline
- rewrite the hero supporting copy so it names the existing dharma cluster more directly
- add a small above-the-fold learning shortcut row linking to:
  - `/start-learning-buddhism`
  - `/practice-guide`
  - `/sutra-guide`
  - `/what-is-emptiness`
- keep the current screenshot system and download status pills unchanged

## Expected effect
- improves first-screen intent match for readers arriving on the homepage from beginner buddhadharma and concept-related queries
- strengthens homepage-level internal discovery for the live dharma cluster before the user scrolls into the longer `学佛路径` section
- makes the homepage's visible headline/copy more consistent with its metadata, FAQ schema, and existing content distribution logic

## Image decision
- no new image was added in this pass
- the homepage already has a stable screenshot system, and the higher-yield issue this hour was semantic alignment and first-screen content discovery rather than adding a new visual layer

## Validation
- compare confirms the branch is `ahead_by = 1` and `behind_by = 0` relative to `main`
- scope is intentionally limited to one file: `frontend/apps/web/src/app/page.tsx`
- no local Next.js build was run in this environment; merge readiness should rely on the repository's normal CI checks
- no ranking guarantees implied; this change improves page clarity, visible intent match, and above-the-fold internal distribution