### PR TITLE
feat(forum): gate writable preview behind shared access code

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -60,6 +60,7 @@ jobs:
           assert payload["dataSource"] == "sqlite", payload
           assert payload["persistenceMode"] == "sqlite-file", payload
           assert payload["writesEnabled"] is False, payload
+          assert payload["requiresAccessCode"] is False, payload
           assert payload["counts"]["threads"] >= 4, payload
           assert payload["counts"]["moderationEvents"] >= 4, payload
           PY
@@ -107,11 +108,12 @@ jobs:
         if: always()
         run: docker stop fabushi-forum-check-readonly || true
 
-      - name: Start forum container in sqlite writable mode
+      - name: Start forum container in sqlite writable preview mode
         run: |
           docker run -d --rm --name fabushi-forum-check \
             -e FORUM_DATA_SOURCE=sqlite \
             -e FORUM_ENABLE_WRITES=true \
+            -e FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
             -e FORUM_DATABASE_URL=file:/tmp/forum.db \
             -p 3000:3000 \
             fabushi-forum
@@ -138,6 +140,7 @@ jobs:
           assert payload["dataSource"] == "sqlite", payload
           assert payload["persistenceMode"] == "sqlite-file", payload
           assert payload["writesEnabled"] is True, payload
+          assert payload["requiresAccessCode"] is True, payload
           assert payload["counts"]["threads"] >= 4, payload
           assert payload["counts"]["moderationEvents"] >= 4, payload
           PY
@@ -151,13 +154,39 @@ jobs:
 
           html = unescape(os.environ["FORUM_NEW_THREAD_PAGE"])
           assert "发起一条最小主题" in html, html[:1000]
-          assert "当前数据源：sqlite / 可写" in html, html[:1000]
-          assert "作者角色" in html, html[:1500]
-          assert "引导信号" in html, html[:1500]
+          assert "当前数据源：sqlite / 可写" in html, html[:1200]
+          assert "写入口令" in html, html[:2200]
+          assert "小范围内测" in html, html[:2600]
           PY
 
       - name: Smoke test forum thread creation endpoint
         run: |
+          denied_status="$(curl --silent --show-error --output /tmp/forum-write-denied.json --write-out '%{http_code}' http://127.0.0.1:3000/api/threads \
+            -H 'content-type: application/json' \
+            --data '{
+              "sectionSlug": "newcomer-path",
+              "title": "容器页面检查：缺少口令时不应写入",
+              "author": "页面检查用户",
+              "authorRoleLabel": "新手观察者",
+              "guidanceSignal": "先验证写入口令确实生效。",
+              "summary": "想确认内测写入口令缺失时，sqlite 不会直接接收新主题。",
+              "tags": ["页面检查", "sqlite"],
+              "openingPost": ["这条请求应该先被 preview gate 拒绝。"]
+            }')"
+
+          if [ "$denied_status" != "403" ]; then
+            cat /tmp/forum-write-denied.json
+            exit 1
+          fi
+
+          FORUM_CREATE_DENIED_BODY="$(cat /tmp/forum-write-denied.json)" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_CREATE_DENIED_BODY"])
+          assert "write access code" in payload["error"], payload
+          PY
+
           response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/threads \
             -H 'content-type: application/json' \
             --data '{
@@ -166,6 +195,7 @@ jobs:
               "author": "页面检查用户",
               "authorRoleLabel": "新手观察者",
               "guidanceSignal": "请先补一条最容易开始的下一步建议。",
+              "writeAccessCode": "forum-preview-2026",
               "summary": "想确认 sqlite 新主题创建后，列表页和详情页都会回读到最新内容。",
               "tags": ["页面检查", "sqlite"],
               "openingPost": ["这条主题由容器页面检查创建，用来确认论坛页面层也能读到刚写入的新线程。"]
@@ -236,7 +266,8 @@ jobs:
           assert "新手观察者" in html, html[:2500]
           assert "请先补一条最容易开始的下一步建议。" in html, html[:3500]
           assert "写一条最小回复" in html, html[:2500]
-          assert "审核时间线" in html, html[:3500]
+          assert "写入口令" in html, html[:3500]
+          assert "审核时间线" in html, html[:4000]
           assert "新主题已发布" in html, html[:4500]
           PY
 
@@ -250,6 +281,7 @@ jobs:
               "author": "页面回复检查",
               "roleLabel": "页面回读验证",
               "guidanceSignal": "请优先补一条最容易执行的下一步建议。",
+              "writeAccessCode": "forum-preview-2026",
               "trustSignal": "用于确认 sqlite 回复写入后，线程详情页会显示新回复。",
               "body": ["这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。"]
             }')"

--- a/forum/.env.example
+++ b/forum/.env.example
@@ -7,3 +7,7 @@ FORUM_ENABLE_WRITES=false
 
 # Optional in seed-json mode. When sqlite is enabled, a file: URL is recommended.
 FORUM_DATABASE_URL=file:./data/forum.db
+
+# Optional in writable sqlite mode. Set this to require a shared write-access
+# code before page-level forms and API calls can create threads or replies.
+FORUM_WRITE_ACCESS_CODE=

--- a/forum/README.md
+++ b/forum/README.md
@@ -15,6 +15,7 @@ Current scope:
 - read-only routes for thread listing, thread detail, and runtime status
 - a sqlite-backed repository option that can bootstrap from the current seed content
 - an explicit sqlite write gate so durable storage does not automatically imply public thread and reply creation
+- an optional write-access code gate so writable sqlite deployments can stay in a small preview cohort before full authentication lands
 - a minimal thread-creation API when sqlite mode is enabled and writes are explicitly opened
 - a page-level thread composer on top of the thread-creation API in writable mode
 - a minimal reply-creation API for existing threads when sqlite writes are enabled
@@ -42,6 +43,7 @@ Included:
 - a first moderation-event timeline for thread publishing and new sqlite writes
 - a first durable persistence path backed by sqlite file storage
 - an explicit runtime gate for public writes
+- an optional write-access code for pre-auth preview deployments
 - a first reply write path for existing threads
 - persisted role and guidance fields for new thread authors and reply authors
 - standalone server artifact for container packaging
@@ -50,7 +52,7 @@ Not included yet:
 
 - authentication
 - search, notifications, bookmarks, or follows as real user actions
-- moderation workflows beyond the first persisted timeline and write-state checks
+- moderation workflows beyond the first persisted timeline, write-state checks, and preview-code gate
 
 ## Local development
 
@@ -77,6 +79,12 @@ If you want to exercise thread and reply creation locally, explicitly open write
 FORUM_DATA_SOURCE=sqlite FORUM_ENABLE_WRITES=true pnpm dev
 ```
 
+If you want that writable runtime to stay inside a small preview cohort, add a shared write-access code:
+
+```bash
+FORUM_DATA_SOURCE=sqlite FORUM_ENABLE_WRITES=true FORUM_WRITE_ACCESS_CODE=forum-preview-2026 pnpm dev
+```
+
 Useful checks:
 
 ```bash
@@ -92,6 +100,7 @@ curl -X POST http://localhost:3000/api/threads \
     "author": "测试用户",
     "authorRoleLabel": "新手提问者",
     "guidanceSignal": "请先给我一条最容易坚持的一步。",
+    "writeAccessCode": "forum-preview-2026",
     "summary": "先把最小作息和听闻节奏稳定下来。",
     "tags": ["新手", "作息"],
     "openingPost": ["我目前还没有固定作息，想先把每天最小的修学节奏建立起来。"]
@@ -102,6 +111,7 @@ curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
     "author": "测试回复",
     "roleLabel": "新加入同修",
     "guidanceSignal": "我想先补一条最容易执行的下一步建议。",
+    "writeAccessCode": "forum-preview-2026",
     "trustSignal": "回复已按主题聚焦提交，等待更多互动后再决定是否沉淀。",
     "body": ["我发现先把睡前十分钟固定下来，比一下子改整天作息更容易坚持。"]
   }'
@@ -111,7 +121,7 @@ curl http://localhost:3000/threads
 curl http://localhost:3000/threads/first-year-stability
 ```
 
-When `FORUM_DATA_SOURCE=sqlite` but `FORUM_ENABLE_WRITES=false`, the page-level forms stay visible and clearly report that the runtime is still read-only. When `FORUM_ENABLE_WRITES=true`, `http://localhost:3000/threads/new` can create a new topic and `http://localhost:3000/threads/first-year-stability` can submit a reply through the page-level form. `GET /api/thread/[slug]` now includes `moderationEvents`, thread-level `authorRoleLabel`, thread-level `guidanceSignal`, and reply-level `guidanceSignal`, so thread detail can expose the first durable governance timeline alongside role and newcomer guidance context instead of only content fields.
+When `FORUM_DATA_SOURCE=sqlite` but `FORUM_ENABLE_WRITES=false`, the page-level forms stay visible and clearly report that the runtime is still read-only. When `FORUM_ENABLE_WRITES=true`, `http://localhost:3000/threads/new` can create a new topic and `http://localhost:3000/threads/first-year-stability` can submit a reply through the page-level form. If `FORUM_WRITE_ACCESS_CODE` is set, both the page-level forms and the POST routes require the same shared code before accepting writes. `GET /api/thread/[slug]` now includes `moderationEvents`, thread-level `authorRoleLabel`, thread-level `guidanceSignal`, and reply-level `guidanceSignal`, so thread detail can expose the first durable governance timeline alongside role and newcomer guidance context instead of only content fields.
 
 ## Runtime contract
 
@@ -123,6 +133,7 @@ Supported runtime fields:
 - `FORUM_DATA_SOURCE=sqlite`
 - `FORUM_ENABLE_WRITES=false`
 - `FORUM_DATABASE_URL=file:./data/forum.db`
+- `FORUM_WRITE_ACCESS_CODE=forum-preview-2026`
 
 Current JSON routes:
 
@@ -132,7 +143,7 @@ Current JSON routes:
 - `POST /api/thread/[slug]/replies`
 - `GET /api/status`
 
-`GET /api/status` now reports whether the current runtime is writable, even when the data source is already `sqlite`. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, and keeps the forum durably readable by default. Only when `FORUM_ENABLE_WRITES=true` does the same runtime start accepting new threads and replies, writing moderation timeline events, and persisting author-role and guidance fields for those new submissions.
+`GET /api/status` now reports both whether the current runtime is writable and whether that writable runtime still requires a shared write-access code. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, and keeps the forum durably readable by default. Only when `FORUM_ENABLE_WRITES=true` does the same runtime start accepting new threads and replies, writing moderation timeline events, and persisting author-role and guidance fields for those new submissions. If `FORUM_WRITE_ACCESS_CODE` is also configured, those writes stay behind a shared preview gate until a fuller account boundary is ready.
 
 ## Container deployment
 
@@ -165,14 +176,26 @@ docker run --rm -p 3000:3000 \
 curl http://localhost:3000/api/status
 ```
 
+Keep writable deployments in a small preview cohort when needed:
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e FORUM_DATA_SOURCE=sqlite \
+  -e FORUM_ENABLE_WRITES=true \
+  -e FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+  -e FORUM_DATABASE_URL=file:/tmp/forum.db \
+  fabushi-forum
+curl http://localhost:3000/api/status
+```
+
 Runtime defaults:
 
 - `PORT=3000`
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates that sqlite starts in read-only mode by default, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, and then reruns the container with `FORUM_ENABLE_WRITES=true` to exercise thread creation, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates that sqlite starts in read-only mode by default, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, and then reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events.
 
 ## Why this is the next step
 
-After moderation timeline persistence and role-guidance persistence landed, the highest-value gap was no longer another UI slice. The bigger launch-readiness risk was that switching to sqlite also opened anonymous writes by default. This iteration keeps the product surface narrow while making the deployment posture safer: the forum can now be durably readable in sqlite mode first, and public writes become an explicit runtime decision instead of an accidental side effect of persistence.
+After the explicit sqlite write gate landed, the highest-value gap was no longer another UI slice. The remaining launch-readiness risk was that once a deployment opened writes, it still became fully anonymous and globally writable. This iteration keeps the product surface narrow while making the deployment posture safer: the forum can now be durably readable in sqlite mode first, then move into a small shared-code preview before the fuller authentication and permission boundary lands.

--- a/forum/src/app/api/thread/[slug]/replies/route.ts
+++ b/forum/src/app/api/thread/[slug]/replies/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 import {
   type CreateForumReplyInput,
   ForumInputError,
+  ForumWriteAccessDeniedError,
   ForumWriteUnavailableError,
+  assertForumWriteAccessCode,
   createForumReply,
   getThreadBySlug,
 } from "../../../../../lib/forum-data";
@@ -17,6 +19,7 @@ interface CreateReplyPayload {
   guidanceSignal?: unknown;
   trustSignal?: unknown;
   body?: unknown;
+  writeAccessCode?: unknown;
 }
 
 function requireString(value: unknown, fieldName: string): string {
@@ -106,6 +109,7 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   try {
+    assertForumWriteAccessCode(payload.writeAccessCode);
     const updatedThread = createForumReply(parseCreateReplyPayload(slug, payload));
 
     return NextResponse.json(updatedThread, {
@@ -119,6 +123,10 @@ export async function POST(request: Request, context: RouteContext) {
   } catch (error) {
     if (error instanceof ForumInputError) {
       return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    if (error instanceof ForumWriteAccessDeniedError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
     }
 
     if (error instanceof ForumWriteUnavailableError) {

--- a/forum/src/app/api/threads/route.ts
+++ b/forum/src/app/api/threads/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 import {
   type CreateForumThreadInput,
   ForumInputError,
+  ForumWriteAccessDeniedError,
   ForumWriteUnavailableError,
+  assertForumWriteAccessCode,
   createForumThread,
   getForumSnapshot,
 } from "../../../lib/forum-data";
@@ -16,6 +18,7 @@ interface CreateThreadPayload {
   guidanceSignal?: unknown;
   tags?: unknown;
   openingPost?: unknown;
+  writeAccessCode?: unknown;
 }
 
 function requireString(value: unknown, fieldName: string): string {
@@ -114,6 +117,7 @@ export async function POST(request: Request) {
   }
 
   try {
+    assertForumWriteAccessCode(payload.writeAccessCode);
     const createdThread = createForumThread(parseCreateThreadPayload(payload));
 
     return NextResponse.json(createdThread, {
@@ -127,6 +131,10 @@ export async function POST(request: Request) {
   } catch (error) {
     if (error instanceof ForumInputError) {
       return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    if (error instanceof ForumWriteAccessDeniedError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
     }
 
     if (error instanceof ForumWriteUnavailableError) {

--- a/forum/src/app/threads/[slug]/page.tsx
+++ b/forum/src/app/threads/[slug]/page.tsx
@@ -73,7 +73,12 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
           </ul>
         </section>
 
-        <ThreadReplyForm threadSlug={thread.slug} writesEnabled={runtime.writesEnabled} dataSource={runtime.dataSource} />
+        <ThreadReplyForm
+          threadSlug={thread.slug}
+          writesEnabled={runtime.writesEnabled}
+          requiresAccessCode={runtime.requiresAccessCode}
+          dataSource={runtime.dataSource}
+        />
 
         <section className="reply-stack">
           <div className="section-heading">
@@ -81,7 +86,9 @@ export default async function ThreadDetailPage({ params }: ThreadPageProps) {
               <h2>当前回复</h2>
               <p>
                 {runtime.writesEnabled
-                  ? "新回复提交后会把角色状态、引导信号和正文一起写入 sqlite，并在刷新后直接显示在这里。"
+                  ? runtime.requiresAccessCode
+                    ? "当前环境已经开放 sqlite 写入，但仍要求有效写入口令；适合先做小范围内测和人工承接。"
+                    : "新回复提交后会把角色状态、引导信号和正文一起写入 sqlite，并在刷新后直接显示在这里。"
                   : "当前环境会继续回读已有帖子和回复，但不会默认开放新写入；等部署环境确认后再显式打开 FORUM_ENABLE_WRITES。"}
               </p>
             </div>

--- a/forum/src/app/threads/[slug]/reply-form.tsx
+++ b/forum/src/app/threads/[slug]/reply-form.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 interface ThreadReplyFormProps {
   threadSlug: string;
   writesEnabled: boolean;
+  requiresAccessCode: boolean;
   dataSource: string;
 }
 
@@ -20,11 +21,12 @@ function getParagraphs(value: string) {
     .filter(Boolean);
 }
 
-export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: ThreadReplyFormProps) {
+export function ThreadReplyForm({ threadSlug, writesEnabled, requiresAccessCode, dataSource }: ThreadReplyFormProps) {
   const router = useRouter();
   const [author, setAuthor] = useState("");
   const [roleLabel, setRoleLabel] = useState(ROLE_OPTIONS[0]);
   const [guidanceSignal, setGuidanceSignal] = useState("");
+  const [writeAccessCode, setWriteAccessCode] = useState("");
   const [body, setBody] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [tone, setTone] = useState<FormTone | null>(null);
@@ -45,11 +47,18 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
 
     const trimmedAuthor = author.trim();
     const trimmedGuidanceSignal = guidanceSignal.trim();
+    const trimmedWriteAccessCode = writeAccessCode.trim();
     const paragraphs = getParagraphs(body);
 
     if (!trimmedAuthor || !trimmedGuidanceSignal || paragraphs.length === 0) {
       setTone("error");
       setMessage("请先填写称呼、角色状态、引导信号和回复内容。");
+      return;
+    }
+
+    if (requiresAccessCode && !trimmedWriteAccessCode) {
+      setTone("error");
+      setMessage("当前写入环境还要求写入口令；请先填写正确口令后再提交回复。");
       return;
     }
 
@@ -68,6 +77,7 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
               author: trimmedAuthor,
               roleLabel,
               guidanceSignal: trimmedGuidanceSignal,
+              writeAccessCode: trimmedWriteAccessCode,
               body: paragraphs,
             }),
           });
@@ -80,6 +90,7 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
 
           setAuthor("");
           setGuidanceSignal("");
+          setWriteAccessCode("");
           setBody("");
           setTone("success");
           setMessage("回复已写入当前线程，页面正在刷新。");
@@ -97,7 +108,9 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
       <div className="section-heading">
         <div>
           <h2 id="reply-composer-heading">写一条最小回复</h2>
-          <p>这一步会在开放写入时把回复者的角色状态和当前引导信号一起写入 sqlite，而不是继续依赖接口默认文案。</p>
+          <p>
+            这一步会在开放写入时把回复者的角色状态和当前引导信号一起写入 sqlite；如果当前环境仍处于内测口令模式，也会在这里一起校验。
+          </p>
         </div>
         <span className="reply-runtime">{writesEnabled ? `当前数据源：${dataSource} / 可写` : `当前数据源：${dataSource} / 只读`}</span>
       </div>
@@ -106,6 +119,8 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
         <p className="reply-form-hint">
           当前运行环境还在只读模式。先把 `FORUM_DATA_SOURCE` 设为 `sqlite`，再显式打开 `FORUM_ENABLE_WRITES=true`，这里才会直接提交最小回复。
         </p>
+      ) : requiresAccessCode ? (
+        <p className="reply-form-hint">当前运行环境已经开放写入，但仍要求有效写入口令，适合先做小范围内测。</p>
       ) : null}
 
       <form className="reply-form" onSubmit={handleSubmit}>
@@ -152,6 +167,21 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
             />
           </label>
 
+          {requiresAccessCode ? (
+            <label className="reply-field">
+              <span>写入口令</span>
+              <input
+                className="reply-input"
+                name="writeAccessCode"
+                value={writeAccessCode}
+                onChange={(event) => setWriteAccessCode(event.target.value)}
+                placeholder="例如：forum-preview-2026"
+                disabled={!writesEnabled || isPending}
+                autoComplete="off"
+              />
+            </label>
+          ) : null}
+
           <label className="reply-field">
             <span>回复内容</span>
             <textarea
@@ -168,8 +198,8 @@ export function ThreadReplyForm({ threadSlug, writesEnabled, dataSource }: Threa
         <div className="reply-form-footer">
           <p className="reply-form-hint">
             {paragraphCount > 0
-              ? `当前会提交 ${paragraphCount} 段内容，并把回复者角色和引导信号一起落库。`
-              : "回复支持按空行切成多段，第一版先把角色状态和引导信号稳定接进真实回复流。"}
+              ? `当前会提交 ${paragraphCount} 段内容，并把回复者角色和引导信号一起落库${requiresAccessCode ? "，同时校验写入口令" : ""}。`
+              : `回复支持按空行切成多段，第一版先把角色状态和引导信号稳定接进真实回复流${requiresAccessCode ? "，再用写入口令收住内测写入边界" : ""}。`}
           </p>
           <button className="submit-button" type="submit" disabled={!writesEnabled || isPending}>
             {isPending ? "提交中..." : "提交回复"}

--- a/forum/src/app/threads/new/page.tsx
+++ b/forum/src/app/threads/new/page.tsx
@@ -22,7 +22,7 @@ export default function NewThreadPage() {
 
         <h1>先把问题提清楚，再让讨论慢慢长出来。</h1>
         <p>
-          这一页把页面层主题创建入口接到现有 sqlite 写路径，让论坛第一次同时具备“在页面里发起主题”和“在页面里回复主题”的最小互动承接。
+          这一页把页面层主题创建入口接到现有 sqlite 写路径，让论坛第一次同时具备“在页面里发起主题”和“在页面里回复主题”的最小互动承接；现在也支持在部署前用写入口令先收住内测写入边界。
         </p>
 
         <div className="composer-grid">
@@ -56,6 +56,7 @@ export default function NewThreadPage() {
               moderationFocus: section.moderationFocus,
             }))}
             writesEnabled={runtime.writesEnabled}
+            requiresAccessCode={runtime.requiresAccessCode}
             dataSource={runtime.dataSource}
           />
         </div>

--- a/forum/src/app/threads/new/thread-composer.tsx
+++ b/forum/src/app/threads/new/thread-composer.tsx
@@ -13,6 +13,7 @@ interface ComposerSection {
 interface ThreadComposerProps {
   sections: ComposerSection[];
   writesEnabled: boolean;
+  requiresAccessCode: boolean;
   dataSource: string;
 }
 
@@ -34,13 +35,14 @@ function getTags(value: string) {
     .filter(Boolean);
 }
 
-export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadComposerProps) {
+export function ThreadComposer({ sections, writesEnabled, requiresAccessCode, dataSource }: ThreadComposerProps) {
   const router = useRouter();
   const [sectionSlug, setSectionSlug] = useState(sections[0]?.slug ?? "");
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
   const [authorRoleLabel, setAuthorRoleLabel] = useState(ROLE_OPTIONS[0]);
   const [guidanceSignal, setGuidanceSignal] = useState("");
+  const [writeAccessCode, setWriteAccessCode] = useState("");
   const [tagsInput, setTagsInput] = useState("");
   const [openingPost, setOpeningPost] = useState("");
   const [message, setMessage] = useState<string | null>(null);
@@ -72,12 +74,19 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
     const trimmedTitle = title.trim();
     const trimmedAuthor = author.trim();
     const trimmedGuidanceSignal = guidanceSignal.trim();
+    const trimmedWriteAccessCode = writeAccessCode.trim();
     const paragraphs = getParagraphs(openingPost);
     const tags = getTags(tagsInput);
 
     if (!trimmedTitle || !trimmedAuthor || !trimmedGuidanceSignal || paragraphs.length === 0) {
       setTone("error");
       setMessage("请先填写标题、称呼、作者角色、引导信号和开场帖内容。");
+      return;
+    }
+
+    if (requiresAccessCode && !trimmedWriteAccessCode) {
+      setTone("error");
+      setMessage("当前写入环境还要求写入口令；请先填写正确口令后再发布主题。");
       return;
     }
 
@@ -98,6 +107,7 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
               author: trimmedAuthor,
               authorRoleLabel,
               guidanceSignal: trimmedGuidanceSignal,
+              writeAccessCode: trimmedWriteAccessCode,
               tags,
               openingPost: paragraphs,
             }),
@@ -121,6 +131,7 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
           setTitle("");
           setAuthor("");
           setGuidanceSignal("");
+          setWriteAccessCode("");
           setTagsInput("");
           setOpeningPost("");
           setTone("success");
@@ -139,7 +150,9 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
       <div className="section-heading">
         <div>
           <h2 id="thread-composer-heading">发起一条最小主题</h2>
-          <p>这一步会在开放写入时把作者角色和新手引导信号一起写入持久化层，而不是继续只停留在展示文案。</p>
+          <p>
+            这一步会在开放写入时把作者角色和新手引导信号一起写入持久化层；如果当前环境仍处于内测口令模式，也会在这里一起校验。
+          </p>
         </div>
         <span className="reply-runtime">{writesEnabled ? `当前数据源：${dataSource} / 可写` : `当前数据源：${dataSource} / 只读`}</span>
       </div>
@@ -148,6 +161,8 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
         <p className="reply-form-hint">
           当前运行环境还在只读模式。先把 `FORUM_DATA_SOURCE` 设为 `sqlite`，再显式打开 `FORUM_ENABLE_WRITES=true`，这里才会直接提交新主题。
         </p>
+      ) : requiresAccessCode ? (
+        <p className="reply-form-hint">当前运行环境已经开放写入，但仍要求有效写入口令，适合先做小范围内测。</p>
       ) : null}
 
       <form className="reply-form" onSubmit={handleSubmit}>
@@ -223,6 +238,21 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
             />
           </label>
 
+          {requiresAccessCode ? (
+            <label className="reply-field">
+              <span>写入口令</span>
+              <input
+                className="reply-input"
+                name="writeAccessCode"
+                value={writeAccessCode}
+                onChange={(event) => setWriteAccessCode(event.target.value)}
+                placeholder="例如：forum-preview-2026"
+                disabled={!writesEnabled || isPending}
+                autoComplete="off"
+              />
+            </label>
+          ) : null}
+
           <label className="reply-field">
             <span>标签</span>
             <input
@@ -259,8 +289,8 @@ export function ThreadComposer({ sections, writesEnabled, dataSource }: ThreadCo
         <div className="reply-form-footer">
           <p className="reply-form-hint">
             {paragraphCount > 0
-              ? `当前会提交 ${paragraphCount} 段开场帖${tagCount > 0 ? `，并附带 ${tagCount} 个标签` : ""}，同时把作者角色和引导信号一起落库。`
-              : "开场帖支持按空行分段；第一版先把标题、版块、角色状态和引导信号稳定落库。"}
+              ? `当前会提交 ${paragraphCount} 段开场帖${tagCount > 0 ? `，并附带 ${tagCount} 个标签` : ""}，同时把作者角色和引导信号一起落库${requiresAccessCode ? "，并校验写入口令" : ""}。`
+              : `开场帖支持按空行分段；第一版先把标题、版块、角色状态和引导信号稳定落库${requiresAccessCode ? "，再用写入口令收住内测写入边界" : ""}。`}
           </p>
           <button className="submit-button" type="submit" disabled={!writesEnabled || isPending || !selectedSection}>
             {isPending ? "发布中..." : "发布主题"}

--- a/forum/src/lib/forum-data.ts
+++ b/forum/src/lib/forum-data.ts
@@ -125,6 +125,13 @@ export class ForumWriteUnavailableError extends Error {
   }
 }
 
+export class ForumWriteAccessDeniedError extends Error {
+  constructor(message = "This runtime requires a valid write access code before accepting new threads or replies.") {
+    super(message);
+    this.name = "ForumWriteAccessDeniedError";
+  }
+}
+
 export class ForumInputError extends Error {
   constructor(message: string) {
     super(message);
@@ -187,6 +194,14 @@ function resolveForumWritesEnabled(dataSource: ForumDataSource): boolean {
   throw new Error(`Unsupported FORUM_ENABLE_WRITES: ${process.env.FORUM_ENABLE_WRITES}`);
 }
 
+function resolveForumWriteAccessCode(dataSource: ForumDataSource): string {
+  if (dataSource !== "sqlite") {
+    return "";
+  }
+
+  return process.env.FORUM_WRITE_ACCESS_CODE?.trim() ?? "";
+}
+
 function getWriteUnavailableMessage(dataSource: ForumDataSource) {
   if (dataSource === "sqlite") {
     return "Forum writes are disabled for the current sqlite runtime. Set FORUM_ENABLE_WRITES=true to allow thread and reply creation.";
@@ -240,11 +255,29 @@ export function getForumSnapshot() {
 
 export function getForumRuntimeStatus() {
   const runtimeStatus = forumRepository.getRuntimeStatus();
+  const writesEnabled = resolveForumWritesEnabled(runtimeStatus.dataSource);
 
   return {
     ...runtimeStatus,
-    writesEnabled: resolveForumWritesEnabled(runtimeStatus.dataSource),
+    writesEnabled,
+    requiresAccessCode: writesEnabled && Boolean(resolveForumWriteAccessCode(runtimeStatus.dataSource)),
   };
+}
+
+export function assertForumWriteAccessCode(value: unknown) {
+  if (!resolveForumWritesEnabled(forumRepository.dataSource)) {
+    return;
+  }
+
+  const configuredCode = resolveForumWriteAccessCode(forumRepository.dataSource);
+
+  if (!configuredCode) {
+    return;
+  }
+
+  if (typeof value !== "string" || value.trim() !== configuredCode) {
+    throw new ForumWriteAccessDeniedError();
+  }
 }
 
 export function createForumThread(input: CreateForumThreadInput) {


### PR DESCRIPTION
## 问题

论坛现在已经把 sqlite 写入从“默认可写”收成了显式开关，但一旦环境打开 `FORUM_ENABLE_WRITES=true`，仍然会立刻变成全站匿名可写：

- 对“准备内测、还没接完整账户体系”的部署环境来说，这个口子还是太大
- 当前页面层发帖 / 回复表单没有任何过渡性的准入边界
- 容器检查也还没有覆盖“写入已开启，但仍要求预览口令”的运行态

这会让论坛虽然更接近可部署，但在真正进入小范围试用前，仍缺少一层很轻但很实用的写入保护。

## 这次改动

- 更新 `forum/src/lib/forum-data.ts`
  - 新增 `ForumWriteAccessDeniedError`
  - 新增 `assertForumWriteAccessCode()`
  - 解析可选环境变量 `FORUM_WRITE_ACCESS_CODE`
  - 让 `getForumRuntimeStatus()` 同时返回 `requiresAccessCode`
- 更新 `forum/src/app/api/threads/route.ts`
  - 在创建主题前校验 `writeAccessCode`
  - 当预览口令缺失或不匹配时返回 `403`
- 更新 `forum/src/app/api/thread/[slug]/replies/route.ts`
  - 在创建回复前校验 `writeAccessCode`
  - 当预览口令缺失或不匹配时返回 `403`
- 更新 `forum/src/app/threads/new/thread-composer.tsx`
  - 在需要时展示“写入口令”字段
  - 页面层提交主题时一并带上该字段
  - 对缺口令场景给出更明确的用户提示
- 更新 `forum/src/app/threads/[slug]/reply-form.tsx`
  - 在需要时展示“写入口令”字段
  - 页面层提交回复时一并带上该字段
  - 对缺口令场景给出更明确的用户提示
- 更新 `forum/src/app/threads/new/page.tsx` 与 `forum/src/app/threads/[slug]/page.tsx`
  - 把新的运行态要求传到页面层
  - 让详情页说明能区分“公开可写”和“小范围内测可写”
- 更新 `forum/.env.example` 与 `forum/README.md`
  - 文档化 `FORUM_WRITE_ACCESS_CODE`
  - 补本地与 Docker 运行示例
- 更新 `.github/workflows/forum-container-checks.yml`
  - 新增 preview 模式容器启动
  - 断言 `/api/status` 会返回 `requiresAccessCode=true`
  - 断言页面层会显示“写入口令”字段
  - 先验证缺口令写入会被 `403` 拒绝，再验证带口令时主题 / 回复可以正常写入并回读

## 为什么现在做

在完整登录、权限和审核层还没接上之前，论坛最需要的不是再加一个页面，而是把“可写环境”变成一个更稳的过渡态。

这一小步的收益很集中：

- 论坛可以先进入“sqlite 可持久化 + 小范围预览写入”的部署状态
- 页面层和 API 层都沿着同一条运行时边界工作，不会一边收口一边漏口子
- 下一轮继续接登录态和更正式的权限规则时，不需要推翻当前的写入链路

## 验证

- compare 已确认改动收敛在 10 个论坛相关文件
- 已回读分支内容确认：
  - 运行时状态新增 `requiresAccessCode`
  - 主题 / 回复 API 已承接 `writeAccessCode` 校验
  - 页面层主题 / 回复表单已承接“写入口令”输入
  - 容器检查已覆盖“缺口令拒绝 / 带口令通过”的 preview 写入流程
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build` 或 `docker build ./forum`
- 最终验证依赖仓库现有 Actions：
  - `CI`
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 明确论坛独立部署入口与目标运行环境
- 在这条 preview gate 之后继续接更正式的登录态、权限态和审核流边界