### PR TITLE
test(forum): verify sqlite preview persistence across container restarts

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -108,13 +108,19 @@ jobs:
         if: always()
         run: docker stop fabushi-forum-check-readonly || true
 
+      - name: Prepare persistent sqlite workspace
+        run: |
+          rm -rf /tmp/fabushi-forum-data
+          mkdir -p /tmp/fabushi-forum-data
+
       - name: Start forum container in sqlite writable preview mode
         run: |
           docker run -d --rm --name fabushi-forum-check \
+            -v /tmp/fabushi-forum-data:/data \
             -e FORUM_DATA_SOURCE=sqlite \
             -e FORUM_ENABLE_WRITES=true \
             -e FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
-            -e FORUM_DATABASE_URL=file:/tmp/forum.db \
+            -e FORUM_DATABASE_URL=file:/data/forum.db \
             -p 3000:3000 \
             fabushi-forum
 
@@ -318,8 +324,79 @@ jobs:
           assert "新回复已写入时间线" in html, html[:5500]
           PY
 
+      - name: Restart forum container with same sqlite volume
+        run: |
+          docker stop fabushi-forum-check
+          docker run -d --rm --name fabushi-forum-check-restart \
+            -v /tmp/fabushi-forum-data:/data \
+            -e FORUM_DATA_SOURCE=sqlite \
+            -e FORUM_ENABLE_WRITES=true \
+            -e FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+            -e FORUM_DATABASE_URL=file:/data/forum.db \
+            -p 3000:3000 \
+            fabushi-forum
+
+      - name: Smoke test forum sqlite data survives container restart
+        run: |
+          for attempt in 1 2 3 4 5; do
+            response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)" && break
+            sleep 3
+          done
+
+          if [ -z "${response:-}" ]; then
+            docker logs fabushi-forum-check-restart
+            exit 1
+          fi
+
+          echo "$response"
+          FORUM_RESTART_STATUS_RESPONSE="$response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_RESTART_STATUS_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["writesEnabled"] is True, payload
+          assert payload["requiresAccessCode"] is True, payload
+          assert payload["counts"]["threads"] >= 5, payload
+          assert payload["counts"]["moderationEvents"] >= 6, payload
+          PY
+
+          detail="$(curl --fail --show-error --silent "http://127.0.0.1:3000/api/thread/${thread_slug}")"
+          echo "$detail"
+          FORUM_RESTART_DETAIL_RESPONSE="$detail" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_RESTART_DETAIL_RESPONSE"])
+          assert payload["source"] == "sqlite", payload
+          assert payload["thread"]["slug"] == os.environ["thread_slug"], payload
+          assert payload["thread"]["author"] == "页面检查用户", payload
+          assert payload["thread"]["authorRoleLabel"] == "新手观察者", payload
+          assert payload["thread"]["guidanceSignal"] == "请先补一条最容易开始的下一步建议。", payload
+          assert payload["replies"][-1]["author"] == "页面回复检查", payload
+          assert payload["replies"][-1]["roleLabel"] == "页面回读验证", payload
+          assert payload["replies"][-1]["guidanceSignal"] == "请优先补一条最容易执行的下一步建议。", payload
+          assert payload["moderationEvents"][-1]["eventType"] == "reply-created", payload
+          assert "新回复已写入时间线" in payload["moderationEvents"][-1]["summary"], payload
+          PY
+
+          thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${thread_slug}")"
+          FORUM_RESTART_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY'
+          import os
+          from html import unescape
+
+          html = unescape(os.environ["FORUM_RESTART_THREAD_DETAIL_PAGE"])
+          assert "容器页面检查：新主题能否进入真实帖子页？" in html, html[:2500]
+          assert "页面回复检查" in html, html[:5000]
+          assert "页面回读验证" in html, html[:5000]
+          assert "新回复已写入时间线" in html, html[:5500]
+          PY
+
       - name: Stop forum containers
         if: always()
         run: |
           docker stop fabushi-forum-check || true
           docker stop fabushi-forum-check-readonly || true
+          docker stop fabushi-forum-check-restart || true

--- a/forum/README.md
+++ b/forum/README.md
@@ -25,6 +25,7 @@ Current scope:
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
 - a container smoke check that validates both the default sqlite read-only runtime and the explicitly writable sqlite runtime
+- a preview compose example that keeps sqlite on a mounted volume so data survives container restarts
 
 ## Current product boundary
 
@@ -188,14 +189,26 @@ docker run --rm -p 3000:3000 \
 curl http://localhost:3000/api/status
 ```
 
+If you want sqlite data to survive container restarts, use the preview compose example in this directory:
+
+```bash
+cd forum
+FORUM_ENABLE_WRITES=true FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+  docker compose -f docker-compose.preview.yml up --build -d
+curl http://localhost:3000/api/status
+docker compose -f docker-compose.preview.yml down
+```
+
+`docker-compose.preview.yml` mounts a named volume at `/data` and keeps `FORUM_DATABASE_URL=file:/data/forum.db`, so newly created threads, replies, and moderation events survive container restarts instead of being lost with the container filesystem.
+
 Runtime defaults:
 
 - `PORT=3000`
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates that sqlite starts in read-only mode by default, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, and then reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates that sqlite starts in read-only mode by default, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events, and then restarts the same writable container against a mounted sqlite path to confirm those writes still exist after the process comes back up.
 
 ## Why this is the next step
 
-After the explicit sqlite write gate landed, the highest-value gap was no longer another UI slice. The remaining launch-readiness risk was that once a deployment opened writes, it still became fully anonymous and globally writable. This iteration keeps the product surface narrow while making the deployment posture safer: the forum can now be durably readable in sqlite mode first, then move into a small shared-code preview before the fuller authentication and permission boundary lands.
+After the preview write-access gate landed, the next launch-readiness gap was no longer another UI slice. The remaining deployment risk was that the forum could accept real preview writes in sqlite mode without proving those writes survive a container restart. This iteration closes that gap in the smallest useful way: it adds a repeatable compose entry for mounted sqlite storage and extends the container smoke check to verify that a created thread, a created reply, and their moderation timeline still exist after the container starts again.

--- a/forum/docker-compose.preview.yml
+++ b/forum/docker-compose.preview.yml
@@ -1,0 +1,17 @@
+services:
+  forum:
+    build:
+      context: .
+    ports:
+      - "${FORUM_PORT:-3000}:3000"
+    environment:
+      FORUM_DATA_SOURCE: sqlite
+      FORUM_ENABLE_WRITES: "${FORUM_ENABLE_WRITES:-false}"
+      FORUM_DATABASE_URL: file:/data/forum.db
+      FORUM_WRITE_ACCESS_CODE: "${FORUM_WRITE_ACCESS_CODE:-}"
+    volumes:
+      - forum-sqlite-data:/data
+    restart: unless-stopped
+
+volumes:
+  forum-sqlite-data:


### PR DESCRIPTION
## 问题

论坛现在已经具备：

- sqlite durable storage
- 默认只读 + 显式开写 + preview 写入口令
- 页面层主题 / 回复提交
- 容器级 thread / reply / moderation timeline smoke check

但还有一个很接近真实部署的空档没有被验证：

- 当前容器检查主要覆盖“容器启动后能写入并回读”
- 还没有自动验证“容器重启后，sqlite 里的真实写入是否仍然存在”
- 仓库里也还没有一个直接可复用的 preview compose 入口，把 sqlite 文件显式挂到持久卷上

这会让论坛虽然更接近可部署，但对真正的 preview 环境来说，仍缺少一层关键的持久化确认。

## 这次改动

- 新增 `forum/docker-compose.preview.yml`
  - 提供 preview 部署示例
  - 把 sqlite 文件挂到 `/data/forum.db`
  - 使用命名卷确保容器重启后数据不会跟着容器文件系统一起消失
- 更新 `forum/README.md`
  - 文档化 preview compose 用法
  - 明确说明为什么挂载卷对 sqlite 预览部署很重要
  - 把容器检查说明扩到“重启后仍能回读线程 / 回复 / 审核时间线”
- 更新 `.github/workflows/forum-container-checks.yml`
  - 为 writable preview 容器增加持久卷挂载
  - 在线程创建、回复写入和页面回读之后重启容器
  - 重启后再次验证 `/api/status`、帖子详情数据和页面层回读，确认主题、回复和治理事件仍然存在

## 为什么现在做

在 preview 写入口令已经进入主线后，当前最高收益切片不再是补一个新页面，而是把 sqlite preview 部署的真实风险再收紧一层。

这一小步的收益很集中：

- 论坛第一次开始自动验证“重启后数据仍在”，更接近真实部署风险
- preview 环境有了直接可复用的 compose 入口，不再只停留在一条 `docker run` 命令
- 下一轮继续推进部署入口、登录态和权限边界时，不需要先回头补 sqlite 卷挂载和持久性基线

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 3`、`behind_by = 0`
- 改动范围收敛在 3 个论坛相关文件：
  - `.github/workflows/forum-container-checks.yml`
  - `forum/README.md`
  - `forum/docker-compose.preview.yml`
- 已回读分支内容确认：
  - preview compose 文件会把 sqlite 写到挂载卷
  - README 已补 preview compose 用法与重启持久性说明
  - 容器检查已扩到“写入 -> 重启 -> 再回读”的 sqlite 持久性断言
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build`、`docker build ./forum` 或手动重启容器验证
- 最终检查依赖仓库现有 Actions：
  - `CI`
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 明确论坛独立部署入口是子域名、独立域名还是反向代理路径
- 在这条已可持久化、可重启验证的 sqlite preview 基线之上，继续接更正式的登录态、权限态和审核流边界