### PR TITLE
feat(forum): add deployment health probe for preview runtime

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -38,18 +38,46 @@ jobs:
             -p 3000:3000 \
             fabushi-forum
 
-      - name: Smoke test forum sqlite status endpoint defaults to read-only
+      - name: Wait for forum sqlite read-only container healthcheck
         run: |
-          for attempt in 1 2 3 4 5; do
-            response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)" && break
+          for attempt in 1 2 3 4 5 6; do
+            container_health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' fabushi-forum-check-readonly)"
+
+            if [ "$container_health" = "healthy" ]; then
+              break
+            fi
+
+            if [ "$container_health" = "unhealthy" ]; then
+              docker logs fabushi-forum-check-readonly
+              exit 1
+            fi
+
             sleep 3
           done
 
-          if [ -z "${response:-}" ]; then
+          if [ "${container_health:-}" != "healthy" ]; then
             docker logs fabushi-forum-check-readonly
             exit 1
           fi
 
+      - name: Smoke test forum sqlite health and status endpoints default to read-only
+        run: |
+          health_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/health)"
+          echo "$health_response"
+          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_HEALTH_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["ready"] is True, payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["writesEnabled"] is False, payload
+          assert payload["requiresAccessCode"] is False, payload
+          PY
+
+          response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)"
           echo "$response"
           FORUM_STATUS_RESPONSE="$response" python3 - <<'PY'
           import json
@@ -124,18 +152,46 @@ jobs:
             -p 3000:3000 \
             fabushi-forum
 
-      - name: Smoke test forum writable sqlite status endpoint
+      - name: Wait for forum sqlite writable preview container healthcheck
         run: |
-          for attempt in 1 2 3 4 5; do
-            response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)" && break
+          for attempt in 1 2 3 4 5 6; do
+            container_health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' fabushi-forum-check)"
+
+            if [ "$container_health" = "healthy" ]; then
+              break
+            fi
+
+            if [ "$container_health" = "unhealthy" ]; then
+              docker logs fabushi-forum-check
+              exit 1
+            fi
+
             sleep 3
           done
 
-          if [ -z "${response:-}" ]; then
+          if [ "${container_health:-}" != "healthy" ]; then
             docker logs fabushi-forum-check
             exit 1
           fi
 
+      - name: Smoke test forum writable sqlite health and status endpoints
+        run: |
+          health_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/health)"
+          echo "$health_response"
+          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_HEALTH_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["ready"] is True, payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["writesEnabled"] is True, payload
+          assert payload["requiresAccessCode"] is True, payload
+          PY
+
+          response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)"
           echo "$response"
           FORUM_STATUS_RESPONSE="$response" python3 - <<'PY'
           import json
@@ -336,18 +392,46 @@ jobs:
             -p 3000:3000 \
             fabushi-forum
 
-      - name: Smoke test forum sqlite data survives container restart
+      - name: Wait for forum restarted sqlite preview container healthcheck
         run: |
-          for attempt in 1 2 3 4 5; do
-            response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)" && break
+          for attempt in 1 2 3 4 5 6; do
+            container_health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' fabushi-forum-check-restart)"
+
+            if [ "$container_health" = "healthy" ]; then
+              break
+            fi
+
+            if [ "$container_health" = "unhealthy" ]; then
+              docker logs fabushi-forum-check-restart
+              exit 1
+            fi
+
             sleep 3
           done
 
-          if [ -z "${response:-}" ]; then
+          if [ "${container_health:-}" != "healthy" ]; then
             docker logs fabushi-forum-check-restart
             exit 1
           fi
 
+      - name: Smoke test forum sqlite data survives container restart
+        run: |
+          health_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/health)"
+          echo "$health_response"
+          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_HEALTH_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["ready"] is True, payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["writesEnabled"] is True, payload
+          assert payload["requiresAccessCode"] is True, payload
+          PY
+
+          response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)"
           echo "$response"
           FORUM_RESTART_STATUS_RESPONSE="$response" python3 - <<'PY'
           import json

--- a/forum/Dockerfile
+++ b/forum/Dockerfile
@@ -28,4 +28,6 @@ COPY --from=builder /app/.next/static ./.next/static
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=5 CMD ["node", "-e", "fetch('http://127.0.0.1:3000/api/health').then((response) => { process.exit(response.ok ? 0 : 1); }).catch(() => process.exit(1));"]
+
 CMD ["node", "server.js"]

--- a/forum/README.md
+++ b/forum/README.md
@@ -12,7 +12,7 @@ Current scope:
 - structured seed content under `forum/src/data/forum-content.json`
 - forum domain helpers under `forum/src/lib/forum-data.ts`
 - a repository boundary that keeps page rendering and API routes behind one forum data source contract
-- read-only routes for thread listing, thread detail, and runtime status
+- read-only routes for thread listing, thread detail, runtime status, and deployment health
 - a sqlite-backed repository option that can bootstrap from the current seed content
 - an explicit sqlite write gate so durable storage does not automatically imply public thread and reply creation
 - an optional write-access code gate so writable sqlite deployments can stay in a small preview cohort before full authentication lands
@@ -24,7 +24,7 @@ Current scope:
 - persisted author-role and newcomer-guidance signals for new threads and replies
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
-- a container smoke check that validates both the default sqlite read-only runtime and the explicitly writable sqlite runtime
+- a container healthcheck plus smoke checks that validate both the default sqlite read-only runtime and the explicitly writable sqlite runtime
 - a preview compose example that keeps sqlite on a mounted volume so data survives container restarts
 
 ## Current product boundary
@@ -48,6 +48,7 @@ Included:
 - a first reply write path for existing threads
 - persisted role and guidance fields for new thread authors and reply authors
 - standalone server artifact for container packaging
+- a no-store health endpoint for deployment readiness probes
 
 Not included yet:
 
@@ -92,6 +93,7 @@ Useful checks:
 pnpm typecheck
 pnpm build
 pnpm start:standalone
+curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 curl -X POST http://localhost:3000/api/threads \
   -H 'content-type: application/json' \
@@ -122,7 +124,7 @@ curl http://localhost:3000/threads
 curl http://localhost:3000/threads/first-year-stability
 ```
 
-When `FORUM_DATA_SOURCE=sqlite` but `FORUM_ENABLE_WRITES=false`, the page-level forms stay visible and clearly report that the runtime is still read-only. When `FORUM_ENABLE_WRITES=true`, `http://localhost:3000/threads/new` can create a new topic and `http://localhost:3000/threads/first-year-stability` can submit a reply through the page-level form. If `FORUM_WRITE_ACCESS_CODE` is set, both the page-level forms and the POST routes require the same shared code before accepting writes. `GET /api/thread/[slug]` now includes `moderationEvents`, thread-level `authorRoleLabel`, thread-level `guidanceSignal`, and reply-level `guidanceSignal`, so thread detail can expose the first durable governance timeline alongside role and newcomer guidance context instead of only content fields.
+When `FORUM_DATA_SOURCE=sqlite` but `FORUM_ENABLE_WRITES=false`, the page-level forms stay visible and clearly report that the runtime is still read-only. When `FORUM_ENABLE_WRITES=true`, `http://localhost:3000/threads/new` can create a new topic and `http://localhost:3000/threads/first-year-stability` can submit a reply through the page-level form. If `FORUM_WRITE_ACCESS_CODE` is set, both the page-level forms and the POST routes require the same shared code before accepting writes. `GET /api/thread/[slug]` now includes `moderationEvents`, thread-level `authorRoleLabel`, thread-level `guidanceSignal`, and reply-level `guidanceSignal`, so thread detail can expose the first durable governance timeline alongside role and newcomer guidance context instead of only content fields. `GET /api/health` is the smallest deployment probe: it stays no-store, returns the current runtime mode, and gives preview containers, compose stacks, or future reverse proxies one stable readiness URL before they depend on the fuller `/api/status` payload.
 
 ## Runtime contract
 
@@ -138,13 +140,14 @@ Supported runtime fields:
 
 Current JSON routes:
 
+- `GET /api/health`
 - `GET /api/threads`
 - `POST /api/threads`
 - `GET /api/thread/[slug]`
 - `POST /api/thread/[slug]/replies`
 - `GET /api/status`
 
-`GET /api/status` now reports both whether the current runtime is writable and whether that writable runtime still requires a shared write-access code. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, and keeps the forum durably readable by default. Only when `FORUM_ENABLE_WRITES=true` does the same runtime start accepting new threads and replies, writing moderation timeline events, and persisting author-role and guidance fields for those new submissions. If `FORUM_WRITE_ACCESS_CODE` is also configured, those writes stay behind a shared preview gate until a fuller account boundary is ready.
+`GET /api/status` now reports both whether the current runtime is writable and whether that writable runtime still requires a shared write-access code. `GET /api/health` is intentionally slimmer: it returns the current readiness state plus the same write-mode boundary flags, so deployment tooling can tell whether the standalone forum service is up before asking for counts and richer runtime detail. In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, and keeps the forum durably readable by default. Only when `FORUM_ENABLE_WRITES=true` does the same runtime start accepting new threads and replies, writing moderation timeline events, and persisting author-role and guidance fields for those new submissions. If `FORUM_WRITE_ACCESS_CODE` is also configured, those writes stay behind a shared preview gate until a fuller account boundary is ready.
 
 ## Container deployment
 
@@ -163,6 +166,7 @@ docker run --rm -p 3000:3000 \
   -e FORUM_DATA_SOURCE=sqlite \
   -e FORUM_DATABASE_URL=file:/tmp/forum.db \
   fabushi-forum
+curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 ```
 
@@ -174,6 +178,7 @@ docker run --rm -p 3000:3000 \
   -e FORUM_ENABLE_WRITES=true \
   -e FORUM_DATABASE_URL=file:/tmp/forum.db \
   fabushi-forum
+curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 ```
 
@@ -186,6 +191,7 @@ docker run --rm -p 3000:3000 \
   -e FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
   -e FORUM_DATABASE_URL=file:/tmp/forum.db \
   fabushi-forum
+curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 ```
 
@@ -195,11 +201,12 @@ If you want sqlite data to survive container restarts, use the preview compose e
 cd forum
 FORUM_ENABLE_WRITES=true FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
   docker compose -f docker-compose.preview.yml up --build -d
+curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 docker compose -f docker-compose.preview.yml down
 ```
 
-`docker-compose.preview.yml` mounts a named volume at `/data` and keeps `FORUM_DATABASE_URL=file:/data/forum.db`, so newly created threads, replies, and moderation events survive container restarts instead of being lost with the container filesystem.
+`docker-compose.preview.yml` mounts a named volume at `/data`, keeps `FORUM_DATABASE_URL=file:/data/forum.db`, and now declares the same `/api/health` probe that the container image exposes through `HEALTHCHECK`. That gives preview deployments one consistent readiness contract whether they are started with `docker run`, `docker compose`, or a later reverse-proxy/platform wrapper.
 
 Runtime defaults:
 
@@ -207,8 +214,8 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, validates that sqlite starts in read-only mode by default, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events, and then restarts the same writable container against a mounted sqlite path to confirm those writes still exist after the process comes back up.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, waits for the container healthcheck to report healthy, validates that sqlite starts in read-only mode by default, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events, and then restarts the same writable container against a mounted sqlite path to confirm those writes still exist after the process comes back up.
 
 ## Why this is the next step
 
-After the preview write-access gate landed, the next launch-readiness gap was no longer another UI slice. The remaining deployment risk was that the forum could accept real preview writes in sqlite mode without proving those writes survive a container restart. This iteration closes that gap in the smallest useful way: it adds a repeatable compose entry for mounted sqlite storage and extends the container smoke check to verify that a created thread, a created reply, and their moderation timeline still exist after the container starts again.
+After the preview write-access gate landed, the next launch-readiness gap was no longer another UI slice. The remaining deployment risk was that the forum still lacked a first-class readiness probe, even though preview deployments were already close to real use. This iteration closes that gap in the smallest useful way: it adds a stable `/api/health` endpoint, wires the same probe into Docker and preview compose, and extends the container smoke checks to wait on health before they verify read-only mode, writable preview mode, and sqlite persistence across restarts.

--- a/forum/docker-compose.preview.yml
+++ b/forum/docker-compose.preview.yml
@@ -11,6 +11,16 @@ services:
       FORUM_WRITE_ACCESS_CODE: "${FORUM_WRITE_ACCESS_CODE:-}"
     volumes:
       - forum-sqlite-data:/data
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:3000/api/health').then((response) => { process.exit(response.ok ? 0 : 1); }).catch(() => process.exit(1));"
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 5
     restart: unless-stopped
 
 volumes:

--- a/forum/src/app/api/health/route.ts
+++ b/forum/src/app/api/health/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getForumRuntimeStatus } from "../../../lib/forum-data";
+
+export async function GET() {
+  const status = getForumRuntimeStatus();
+
+  return NextResponse.json(
+    {
+      service: status.service,
+      ready: true,
+      dataSource: status.dataSource,
+      persistenceMode: status.persistenceMode,
+      writesEnabled: status.writesEnabled,
+      requiresAccessCode: status.requiresAccessCode,
+      generatedAt: status.generatedAt,
+    },
+    {
+      headers: {
+        "cache-control": "no-store",
+        "x-forum-data-source": status.dataSource,
+      },
+    },
+  );
+}


### PR DESCRIPTION
## 问题

论坛现在已经具备：

- sqlite durable storage
- 默认只读 + 显式开写 + preview 写入口令
- 页面层主题 / 回复提交
- 容器级 thread / reply / moderation timeline smoke check
- preview compose 的持久卷挂载

但离真实预览部署还差一层很实际的部署边界：

- 当前只有 `/api/status` 这条较重的运行时接口，没有专门给容器平台、compose、反向代理或后续部署环境使用的轻量健康探针
- `forum/Dockerfile` 还没有声明正式的 `HEALTHCHECK`
- `docker-compose.preview.yml` 也还没有把同一条探针接成 preview 运行态的健康检查
- `Container checks - Forum` 目前是直接轮询状态接口，还没有显式等待容器进入健康态

这会让论坛虽然已经非常接近可部署，但在真正进入 preview 运行环境前，仍缺一条统一、可复用、可自动检查的 readiness 边界。

## 这次改动

- 新增 `forum/src/app/api/health/route.ts`
  - 提供轻量、`no-store` 的部署健康探针
  - 返回 `service`、`ready`、`dataSource`、`persistenceMode`、`writesEnabled`、`requiresAccessCode` 与 `generatedAt`
- 更新 `forum/Dockerfile`
  - 为独立论坛容器新增 `HEALTHCHECK`
  - 直接使用 Node 内建 `fetch` 探测 `/api/health`
- 更新 `forum/docker-compose.preview.yml`
  - 为 preview compose 运行态补同一条健康检查配置
  - 让 `docker run`、`docker compose` 和后续平台部署共用同一条探针
- 更新 `.github/workflows/forum-container-checks.yml`
  - 在只读 sqlite、preview 可写 sqlite、以及重启后的 sqlite 容器三段流程里，都先等待容器健康检查变成 `healthy`
  - 再分别验证 `/api/health` 与 `/api/status`
  - 保持原有主题创建、回复写入、页面回读和重启持久化断言不变
- 更新 `forum/README.md`
  - 文档化 `/api/health`
  - 补本地、Docker、preview compose 下的健康探针用法
  - 明确为什么这条接口比直接依赖 `/api/status` 更适合作为部署 readiness 边界

## 为什么现在做

当前最高优先级已经不是再加一个页面，而是继续把论坛的预览部署姿态补稳。

这一小步的收益很集中：

- 论坛第一次有了独立、稳定、轻量的部署健康探针
- 容器镜像、preview compose 和 CI smoke check 会围绕同一条 readiness URL 对齐
- 下一轮去确认部署入口、反向代理、登录态和权限边界时，不需要先回头补健康检查和容器 readiness 基线

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 5`、`behind_by = 0`
- 改动范围收敛在 5 个论坛相关文件：
  - `.github/workflows/forum-container-checks.yml`
  - `forum/Dockerfile`
  - `forum/README.md`
  - `forum/docker-compose.preview.yml`
  - `forum/src/app/api/health/route.ts`
- 已回读分支内容确认：
  - `/api/health` 已返回轻量运行时 readiness 信息
  - 容器镜像已声明 `HEALTHCHECK`
  - preview compose 已复用同一条健康探针
  - 容器检查工作流已改成“先等 healthy，再做状态 / 页面 / 写入 / 重启断言”
- 当前环境没有仓库本地 checkout，无法直接运行 `pnpm --dir forum typecheck`、`pnpm --dir forum build`、`docker build ./forum` 或手动启动容器验证
- 最终检查依赖仓库现有 Actions：
  - `CI`
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 明确论坛独立部署入口是子域名、独立域名还是反向代理路径
- 在这条已具备健康探针的 preview 基线之上，继续接更正式的登录态、权限态和审核流边界