### PR TITLE
feat(web): surface buddhist concepts hub in site header

### DIFF
--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -4,14 +4,14 @@ import { siteHref } from "../lib/site-url";
 
 const NAV_ITEMS = [
   {
-    href: "/#download",
-    zh: "下载",
-    en: "Download",
-  },
-  {
     href: "/buddhadharma",
     zh: "佛法入门",
     en: "Dharma Basics",
+  },
+  {
+    href: "/buddhist-concepts",
+    zh: "佛学概念",
+    en: "Concepts",
   },
   {
     href: "/practice-guide",


### PR DESCRIPTION
## Summary
- update the global site header so the live `/buddhist-concepts` hub is promoted into the first navigation layer
- remove the duplicate top-level `下载` nav link because the dedicated download CTA already covers that action
- keep the top nav centered on the current dharma cluster: `佛法入门 -> 佛学概念 -> 修行方法 -> 佛经导读 -> 常见问题`

## Why
The repo now has a real concept-cluster hub at `/buddhist-concepts`, and that page is already wired into `sitemap.ts`, the footer, `/buddhadharma`, and `/start-learning-buddhism`.

But the highest-frequency fixed navigation still did not expose that hub. That left a clear discovery gap:
- concept coverage exists in the site structure
- yet the first navigation layer still surfaces `下载` twice and gives no top-level slot to the new concepts overview page

At this stage, the highest-yield action is not another new page. It is lifting the existing concept hub into the global discovery layer.

## What changed
- update `frontend/apps/web/src/components/site-header.tsx`
- remove the redundant top-level `下载` nav item
- add `佛学概念 -> /buddhist-concepts`
- keep the separate download CTA button untouched

## Expected effect
- strengthens internal discovery for broader concept-cluster intent such as `佛学基本概念` and `佛教概念入门`
- makes the global header better reflect the actual dharma cluster now live on the site
- reduces duplication in the top navigation while preserving the download path through the CTA button

## Image decision
- no new image was added in this pass
- the current highest-yield bottleneck is still navigation-layer content discovery rather than adding a visual asset
- the site still does not show a validated buddhadharma topic-image pattern that would clearly outperform this smaller structural fix

## Validation
- compare confirms the branch is `ahead_by = 1` and `behind_by = 0` relative to `main`
- scope is intentionally limited to one file: `frontend/apps/web/src/components/site-header.tsx`
- no local Next.js build was run in this environment because the repository is not checked out here
- merge readiness should rely on the repository's normal CI checks
- no ranking guarantees implied; this change improves internal-link prominence, topic discoverability, and navigation clarity