### PR TITLE
feat(forum): verify production indexing contract in container checks

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           health_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/health)"
           echo "$health_response"
-          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY'
+          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY2'
           import json
           import os
 
@@ -78,11 +78,11 @@ jobs:
           assert payload["publicBaseUrlConfigured"] is False, payload
           assert payload["writesEnabled"] is False, payload
           assert payload["requiresAccessCode"] is False, payload
-          PY
+          PY2
 
           response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)"
           echo "$response"
-          FORUM_STATUS_RESPONSE="$response" python3 - <<'PY'
+          FORUM_STATUS_RESPONSE="$response" python3 - <<'PY2'
           import json
           import os
 
@@ -96,12 +96,12 @@ jobs:
           assert payload["requiresAccessCode"] is False, payload
           assert payload["counts"]["threads"] >= 4, payload
           assert payload["counts"]["moderationEvents"] >= 4, payload
-          PY
+          PY2
 
       - name: Smoke test forum sqlite read-only page surfaces
         run: |
           new_thread_page="$(curl --fail --show-error --silent http://127.0.0.1:3000/threads/new)"
-          FORUM_NEW_THREAD_PAGE="$new_thread_page" python3 - <<'PY'
+          FORUM_NEW_THREAD_PAGE="$new_thread_page" python3 - <<'PY2'
           import os
           from html import unescape
 
@@ -109,7 +109,7 @@ jobs:
           assert "发起一条最小主题" in html, html[:1000]
           assert "当前数据源：sqlite / 只读" in html, html[:1500]
           assert "FORUM_ENABLE_WRITES=true" in html, html[:2500]
-          PY
+          PY2
 
           status_code="$(curl --silent --show-error --output /tmp/forum-readonly-create.json --write-out '%{http_code}' http://127.0.0.1:3000/api/threads \
             -H 'content-type: application/json' \
@@ -129,40 +129,150 @@ jobs:
             exit 1
           fi
 
-          FORUM_CREATE_ERROR_BODY="$(cat /tmp/forum-readonly-create.json)" python3 - <<'PY'
+          FORUM_CREATE_ERROR_BODY="$(cat /tmp/forum-readonly-create.json)" python3 - <<'PY2'
           import json
           import os
 
           payload = json.loads(os.environ["FORUM_CREATE_ERROR_BODY"])
           assert "FORUM_ENABLE_WRITES=true" in payload["error"], payload
-          PY
+          PY2
 
       - name: Smoke test forum preview deployment headers and robots contract
         run: |
           response_headers="$(curl --silent --show-error --dump-header - --output /dev/null http://127.0.0.1:3000/threads)"
           echo "$response_headers"
-          FORUM_HEADERS="$response_headers" python3 - <<'PY'
+          FORUM_HEADERS="$response_headers" python3 - <<'PY2'
           import os
 
           headers = os.environ["FORUM_HEADERS"].lower()
           assert "x-forum-deployment-stage: preview" in headers, headers
           assert "x-forum-indexing-enabled: false" in headers, headers
           assert "x-robots-tag: noindex, nofollow, noarchive" in headers, headers
-          PY
+          PY2
 
           robots_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/robots.txt)"
           echo "$robots_response"
-          FORUM_ROBOTS_RESPONSE="$robots_response" python3 - <<'PY'
+          FORUM_ROBOTS_RESPONSE="$robots_response" python3 - <<'PY2'
           import os
 
           payload = os.environ["FORUM_ROBOTS_RESPONSE"]
           assert "User-Agent: *" in payload, payload
           assert "Disallow: /" in payload, payload
-          PY
+          PY2
 
       - name: Stop forum sqlite read-only container
         if: always()
         run: docker stop fabushi-forum-check-readonly || true
+
+      - name: Start forum container in sqlite production indexing mode
+        run: |
+          docker run -d --rm --name fabushi-forum-check-production \
+            -e FORUM_DEPLOYMENT_STAGE=production \
+            -e FORUM_PUBLIC_BASE_URL=https://forum.fabushi.test \
+            -e FORUM_DATA_SOURCE=sqlite \
+            -e FORUM_DATABASE_URL=file:/tmp/forum-production.db \
+            -p 3000:3000 \
+            fabushi-forum
+
+      - name: Wait for forum sqlite production indexing container healthcheck
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            container_health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' fabushi-forum-check-production)"
+
+            if [ "$container_health" = "healthy" ]; then
+              break
+            fi
+
+            if [ "$container_health" = "unhealthy" ]; then
+              docker logs fabushi-forum-check-production
+              exit 1
+            fi
+
+            sleep 3
+          done
+
+          if [ "${container_health:-}" != "healthy" ]; then
+            docker logs fabushi-forum-check-production
+            exit 1
+          fi
+
+      - name: Smoke test forum production indexing contract
+        run: |
+          health_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/health)"
+          echo "$health_response"
+          FORUM_PRODUCTION_HEALTH_RESPONSE="$health_response" python3 - <<'PY2'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_PRODUCTION_HEALTH_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["ready"] is True, payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["deploymentStage"] == "production", payload
+          assert payload["indexingEnabled"] is True, payload
+          assert payload["publicBaseUrlConfigured"] is True, payload
+          assert payload["writesEnabled"] is False, payload
+          assert payload["requiresAccessCode"] is False, payload
+          PY2
+
+          response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)"
+          echo "$response"
+          FORUM_PRODUCTION_STATUS_RESPONSE="$response" python3 - <<'PY2'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_PRODUCTION_STATUS_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["deploymentStage"] == "production", payload
+          assert payload["indexingEnabled"] is True, payload
+          assert payload["publicBaseUrl"] == "https://forum.fabushi.test", payload
+          assert payload["writesEnabled"] is False, payload
+          assert payload["requiresAccessCode"] is False, payload
+          assert payload["counts"]["threads"] >= 4, payload
+          assert payload["counts"]["moderationEvents"] >= 4, payload
+          PY2
+
+          response_headers="$(curl --silent --show-error --dump-header - --output /dev/null http://127.0.0.1:3000/threads)"
+          echo "$response_headers"
+          FORUM_PRODUCTION_HEADERS="$response_headers" python3 - <<'PY2'
+          import os
+
+          headers = os.environ["FORUM_PRODUCTION_HEADERS"].lower()
+          assert "x-forum-deployment-stage: production" in headers, headers
+          assert "x-forum-indexing-enabled: true" in headers, headers
+          assert "x-forum-public-base-url: https://forum.fabushi.test" in headers, headers
+          assert "x-robots-tag:" not in headers, headers
+          PY2
+
+          robots_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/robots.txt)"
+          echo "$robots_response"
+          FORUM_PRODUCTION_ROBOTS_RESPONSE="$robots_response" python3 - <<'PY2'
+          import os
+
+          payload = os.environ["FORUM_PRODUCTION_ROBOTS_RESPONSE"]
+          assert "User-Agent: *" in payload, payload
+          assert "Allow: /" in payload, payload
+          assert "Host: https://forum.fabushi.test" in payload, payload
+          assert "Disallow: /" not in payload, payload
+          PY2
+
+          thread_list_page="$(curl --fail --show-error --silent http://127.0.0.1:3000/threads)"
+          FORUM_PRODUCTION_THREAD_LIST_PAGE="$thread_list_page" python3 - <<'PY2'
+          import os
+          from html import unescape
+
+          html = unescape(os.environ["FORUM_PRODUCTION_THREAD_LIST_PAGE"]).lower()
+          assert 'index, follow' in html, html[:4000]
+          assert 'https://forum.fabushi.test/' in html, html[:4000]
+          assert 'noindex' not in html, html[:5000]
+          PY2
+
+      - name: Stop forum sqlite production indexing container
+        if: always()
+        run: docker stop fabushi-forum-check-production || true
 
       - name: Prepare persistent sqlite workspace
         run: |
@@ -206,7 +316,7 @@ jobs:
         run: |
           health_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/health)"
           echo "$health_response"
-          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY'
+          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY2'
           import json
           import os
 
@@ -220,11 +330,11 @@ jobs:
           assert payload["publicBaseUrlConfigured"] is False, payload
           assert payload["writesEnabled"] is True, payload
           assert payload["requiresAccessCode"] is True, payload
-          PY
+          PY2
 
           response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)"
           echo "$response"
-          FORUM_STATUS_RESPONSE="$response" python3 - <<'PY'
+          FORUM_STATUS_RESPONSE="$response" python3 - <<'PY2'
           import json
           import os
 
@@ -238,12 +348,12 @@ jobs:
           assert payload["requiresAccessCode"] is True, payload
           assert payload["counts"]["threads"] >= 4, payload
           assert payload["counts"]["moderationEvents"] >= 4, payload
-          PY
+          PY2
 
       - name: Smoke test forum writable page surfaces
         run: |
           new_thread_page="$(curl --fail --show-error --silent http://127.0.0.1:3000/threads/new)"
-          FORUM_NEW_THREAD_PAGE="$new_thread_page" python3 - <<'PY'
+          FORUM_NEW_THREAD_PAGE="$new_thread_page" python3 - <<'PY2'
           import os
           from html import unescape
 
@@ -252,7 +362,7 @@ jobs:
           assert "当前数据源：sqlite / 可写" in html, html[:1200]
           assert "写入口令" in html, html[:2200]
           assert "小范围内测" in html, html[:2600]
-          PY
+          PY2
 
       - name: Smoke test forum thread creation endpoint
         run: |
@@ -274,13 +384,13 @@ jobs:
             exit 1
           fi
 
-          FORUM_CREATE_DENIED_BODY="$(cat /tmp/forum-write-denied.json)" python3 - <<'PY'
+          FORUM_CREATE_DENIED_BODY="$(cat /tmp/forum-write-denied.json)" python3 - <<'PY2'
           import json
           import os
 
           payload = json.loads(os.environ["FORUM_CREATE_DENIED_BODY"])
           assert "write access code" in payload["error"], payload
-          PY
+          PY2
 
           response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/threads \
             -H 'content-type: application/json' \
@@ -297,7 +407,7 @@ jobs:
             }')"
 
           echo "$response"
-          FORUM_CREATE_RESPONSE="$response" python3 - <<'PY'
+          FORUM_CREATE_RESPONSE="$response" python3 - <<'PY2'
           import json
           import os
 
@@ -311,20 +421,20 @@ jobs:
           assert payload["moderationEvents"][-1]["eventType"] == "thread-created", payload
           assert "新主题已发布" in payload["moderationEvents"][-1]["summary"], payload
           print(payload["thread"]["slug"])
-          PY
+          PY2
 
-          slug="$(FORUM_CREATE_RESPONSE="$response" python3 - <<'PY'
+          slug="$(FORUM_CREATE_RESPONSE="$response" python3 - <<'PY2'
           import json
           import os
 
           payload = json.loads(os.environ["FORUM_CREATE_RESPONSE"])
           print(payload["thread"]["slug"])
-          PY
+          PY2
           )"
 
           detail="$(curl --fail --show-error --silent "http://127.0.0.1:3000/api/thread/${slug}")"
           echo "$detail"
-          FORUM_DETAIL_RESPONSE="$detail" python3 - <<'PY'
+          FORUM_DETAIL_RESPONSE="$detail" python3 - <<'PY2'
           import json
           import os
 
@@ -335,10 +445,10 @@ jobs:
           assert payload["thread"]["authorRoleLabel"] == "新手观察者", payload
           assert payload["thread"]["guidanceSignal"] == "请先补一条最容易开始的下一步建议。", payload
           assert payload["moderationEvents"][-1]["eventType"] == "thread-created", payload
-          PY
+          PY2
 
           thread_list_page="$(curl --fail --show-error --silent http://127.0.0.1:3000/threads)"
-          FORUM_THREAD_LIST_PAGE="$thread_list_page" python3 - <<'PY'
+          FORUM_THREAD_LIST_PAGE="$thread_list_page" python3 - <<'PY2'
           import os
           from html import unescape
 
@@ -348,10 +458,10 @@ jobs:
           assert "页面检查用户" in html, html[:3000]
           assert "新手观察者" in html, html[:3000]
           assert "请先补一条最容易开始的下一步建议。" in html, html[:4000]
-          PY
+          PY2
 
           thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${slug}")"
-          FORUM_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY'
+          FORUM_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY2'
           import os
           from html import unescape
 
@@ -364,7 +474,7 @@ jobs:
           assert "写入口令" in html, html[:3500]
           assert "审核时间线" in html, html[:4000]
           assert "新主题已发布" in html, html[:4500]
-          PY
+          PY2
 
           echo "thread_slug=${slug}" >> "$GITHUB_ENV"
 
@@ -382,7 +492,7 @@ jobs:
             }')"
 
           echo "$response"
-          FORUM_REPLY_RESPONSE="$response" python3 - <<'PY'
+          FORUM_REPLY_RESPONSE="$response" python3 - <<'PY2'
           import json
           import os
 
@@ -397,10 +507,10 @@ jobs:
           assert payload["replies"][-1]["body"], payload
           assert payload["moderationEvents"][-1]["eventType"] == "reply-created", payload
           assert "新回复已写入时间线" in payload["moderationEvents"][-1]["summary"], payload
-          PY
+          PY2
 
           thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${thread_slug}")"
-          FORUM_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY'
+          FORUM_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY2'
           import os
           from html import unescape
 
@@ -411,7 +521,7 @@ jobs:
           assert "请优先补一条最容易执行的下一步建议。" in html, html[:5000]
           assert "这条回复由页面检查写入，用来确认 forum 页面详情已经能回读最新回复。" in html, html[:5000]
           assert "新回复已写入时间线" in html, html[:5500]
-          PY
+          PY2
 
       - name: Restart forum container with same sqlite volume
         run: |
@@ -451,7 +561,7 @@ jobs:
         run: |
           health_response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/health)"
           echo "$health_response"
-          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY'
+          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY2'
           import json
           import os
 
@@ -465,11 +575,11 @@ jobs:
           assert payload["publicBaseUrlConfigured"] is False, payload
           assert payload["writesEnabled"] is True, payload
           assert payload["requiresAccessCode"] is True, payload
-          PY
+          PY2
 
           response="$(curl --fail --show-error --silent http://127.0.0.1:3000/api/status)"
           echo "$response"
-          FORUM_RESTART_STATUS_RESPONSE="$response" python3 - <<'PY'
+          FORUM_RESTART_STATUS_RESPONSE="$response" python3 - <<'PY2'
           import json
           import os
 
@@ -483,11 +593,11 @@ jobs:
           assert payload["requiresAccessCode"] is True, payload
           assert payload["counts"]["threads"] >= 5, payload
           assert payload["counts"]["moderationEvents"] >= 6, payload
-          PY
+          PY2
 
           detail="$(curl --fail --show-error --silent "http://127.0.0.1:3000/api/thread/${thread_slug}")"
           echo "$detail"
-          FORUM_RESTART_DETAIL_RESPONSE="$detail" python3 - <<'PY'
+          FORUM_RESTART_DETAIL_RESPONSE="$detail" python3 - <<'PY2'
           import json
           import os
 
@@ -502,10 +612,10 @@ jobs:
           assert payload["replies"][-1]["guidanceSignal"] == "请优先补一条最容易执行的下一步建议。", payload
           assert payload["moderationEvents"][-1]["eventType"] == "reply-created", payload
           assert "新回复已写入时间线" in payload["moderationEvents"][-1]["summary"], payload
-          PY
+          PY2
 
           thread_detail_page="$(curl --fail --show-error --silent "http://127.0.0.1:3000/threads/${thread_slug}")"
-          FORUM_RESTART_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY'
+          FORUM_RESTART_THREAD_DETAIL_PAGE="$thread_detail_page" python3 - <<'PY2'
           import os
           from html import unescape
 
@@ -514,11 +624,12 @@ jobs:
           assert "页面回复检查" in html, html[:5000]
           assert "页面回读验证" in html, html[:5000]
           assert "新回复已写入时间线" in html, html[:5500]
-          PY
+          PY2
 
       - name: Stop forum containers
         if: always()
         run: |
           docker stop fabushi-forum-check || true
           docker stop fabushi-forum-check-readonly || true
+          docker stop fabushi-forum-check-production || true
           docker stop fabushi-forum-check-restart || true

--- a/forum/README.md
+++ b/forum/README.md
@@ -235,9 +235,18 @@ docker run --rm -p 3000:3000 \
   -e FORUM_ENABLE_WRITES=false \
   -e FORUM_DATABASE_URL=file:/tmp/forum.db \
   fabushi-forum
+curl http://localhost:3000/api/health
+curl http://localhost:3000/api/status
 curl http://localhost:3000/robots.txt
 curl -I http://localhost:3000/threads
 ```
+
+In that production-indexing runtime, verify the pair of signals together before exposing traffic:
+
+- `GET /api/health` and `GET /api/status` both report `deploymentStage=production` and `indexingEnabled=true`
+- response headers on page routes include `x-forum-deployment-stage: production` and `x-forum-indexing-enabled: true`, without the preview `x-robots-tag`
+- `GET /robots.txt` switches from `Disallow: /` to `Allow: /` and includes the configured `Host:`
+- page HTML begins emitting canonical and indexable metadata against `FORUM_PUBLIC_BASE_URL`
 
 If you want sqlite data to survive container restarts, use the preview compose example in this directory:
 
@@ -258,7 +267,7 @@ Runtime defaults:
 - `HOSTNAME=0.0.0.0`
 - `NODE_ENV=production`
 
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, waits for the container healthcheck to report healthy, validates that sqlite starts in read-only mode by default, confirms preview responses stay noindex through headers and `robots.txt`, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events, and then restarts the same writable container against a mounted sqlite path to confirm those writes still exist after the process comes back up.
+A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, waits for the container healthcheck to report healthy, validates that sqlite starts in read-only mode by default, confirms preview responses stay noindex through headers and `robots.txt`, verifies a production runtime with `FORUM_PUBLIC_BASE_URL` flips health, status, headers, robots, and page metadata into indexable mode, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events, and then restarts the same writable container against a mounted sqlite path to confirm those writes still exist after the process comes back up.
 
 ## Why this is the next step
 


### PR DESCRIPTION
## 问题

论坛现在已经具备：

- preview 默认 noindex 的部署契约
- `FORUM_DEPLOYMENT_STAGE` + `FORUM_PUBLIC_BASE_URL` 运行时边界
- `/api/health`、`/api/status`、`robots.txt` 与响应头的 preview smoke check

但当前自动检查仍只覆盖“preview 是否收口”，还没有覆盖“production + public base URL 是否真的按预期放开索引”。

这会留下一个很实际的上线盲区：

- 我们已经能确认 preview 不会误开放
- 但还不能自动确认正式公开时，health/status、响应头、robots 和页面 metadata 会不会一起切到可索引状态
- 一旦后续真实域名接入，如果其中某一层没切过来，就会出现“容器是 production，但论坛仍在 noindex”或“信号不一致”的发布问题

## 这次改动

- 更新 `.github/workflows/forum-container-checks.yml`
  - 新增 production indexing smoke check
  - 启动 `FORUM_DEPLOYMENT_STAGE=production` + `FORUM_PUBLIC_BASE_URL=https://forum.fabushi.test` 的 sqlite 只读容器
  - 断言 `/api/health` 与 `/api/status` 会一起返回 `deploymentStage=production`、`indexingEnabled=true`
  - 断言页面响应头会切到 `x-forum-deployment-stage: production`、`x-forum-indexing-enabled: true`，并且不再带 preview `x-robots-tag`
  - 断言 `robots.txt` 会从 `Disallow: /` 切到 `Allow: /`，并带出 `Host:`
  - 断言页面 HTML 不再带 `noindex`，并开始包含基于 `FORUM_PUBLIC_BASE_URL` 的索引元数据
- 更新 `forum/README.md`
  - 补齐 production + public base URL 的本地验证方式
  - 把“preview 收口 / production 放开”的部署信号整理成成对检查说明

## 为什么现在做

在 `PR #471` 已把部署阶段契约写进代码后，当前最高收益切片不再是继续加页面，而是把这层契约补成真正可回归的自动检查。

这一小步的收益很集中：

- CI 不再只知道 preview 没漏，还能知道 production 能正常开
- 后续真实论坛域名、子域名或反向代理入口一旦确定，部署验证只需要把 `FORUM_PUBLIC_BASE_URL` 对齐到真实入口即可
- 登录态、权限态和审核流还没落地之前，论坛至少先把“什么时候该公开、什么时候还不能公开”这组边界守稳

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 2`、`behind_by = 0`
- 改动范围收敛在 2 个论坛相关文件：
  - `.github/workflows/forum-container-checks.yml`
  - `forum/README.md`
- 已回读分支内容确认：
  - production indexing smoke check 已接入现有容器工作流
  - README 已补 production 索引放开验证说明
- 当前环境没有仓库本地 checkout，无法直接在本地运行容器工作流
- 最终验证依赖仓库现有 Actions：
  - `CI`
  - `Module checks - Forum`
  - `Container checks - Forum`

## 下一步承接

- 在目标运行环境把真实论坛入口对齐到 `FORUM_PUBLIC_BASE_URL`
- 验证完整链路：preview 默认 noindex -> production 可索引 -> sqlite 默认只读 -> 显式开写 -> preview 写入口令 -> 页面级发帖 / 回复 / 审核时间线回读
- 再继续推进登录态、权限态和审核流服务边界