### PR TITLE
feat(forum): add live deployment smoke checks

### DIFF
--- a/.github/workflows/forum-live-deployment-checks.yml
+++ b/.github/workflows/forum-live-deployment-checks.yml
@@ -1,0 +1,66 @@
+name: Live deployment checks - Forum
+
+on:
+  workflow_dispatch:
+    inputs:
+      forum_url:
+        description: Forum base URL to check, for example https://forum.example.com
+        required: true
+        type: string
+      deployment_stage:
+        description: Expected deployment stage returned by the live forum runtime
+        required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - production
+      public_base_url:
+        description: Expected FORUM_PUBLIC_BASE_URL. Leave empty for preview or other noindex runtimes.
+        required: false
+        type: string
+      writes_enabled:
+        description: Expected writesEnabled value reported by /api/health and /api/status
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      requires_access_code:
+        description: Expected requiresAccessCode value reported by /api/health and /api/status
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+
+jobs:
+  forum-live-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout forum workspace only
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            forum
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Smoke test live forum deployment contract
+        run: |
+          node forum/scripts/check-deployment-contract.mjs \
+            --url "${{ inputs.forum_url }}" \
+            --deployment-stage "${{ inputs.deployment_stage }}" \
+            --public-base-url "${{ inputs.public_base_url }}" \
+            --writes-enabled "${{ inputs.writes_enabled }}" \
+            --requires-access-code "${{ inputs.requires_access_code }}"

--- a/forum/README.md
+++ b/forum/README.md
@@ -17,6 +17,7 @@ Current scope:
 - an explicit sqlite write gate so durable storage does not automatically imply public thread and reply creation
 - an optional write-access code gate so writable sqlite deployments can stay in a small preview cohort before full authentication lands
 - a preview/production deployment contract that keeps preview responses noindex until the public forum origin is explicit
+- a reusable deployment smoke script plus a manual GitHub Actions workflow for checking real preview and production forum URLs against that contract
 - a minimal thread-creation API when sqlite mode is enabled and writes are explicitly opened
 - a page-level thread composer on top of the thread-creation API in writable mode
 - a minimal reply-creation API for existing threads when sqlite writes are enabled
@@ -51,6 +52,7 @@ Included:
 - standalone server artifact for container packaging
 - a no-store health endpoint for deployment readiness probes
 - a preview-safe indexing contract driven by deployment stage plus public forum origin
+- a reusable smoke check for real deployment URLs
 
 Not included yet:
 
@@ -105,7 +107,7 @@ pnpm start:standalone
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 curl http://localhost:3000/robots.txt
-curl -I http://localhost:3000/threads
+pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage preview --writes-enabled=false --requires-access-code=false
 curl -X POST http://localhost:3000/api/threads \
   -H 'content-type: application/json' \
   -d '{
@@ -175,6 +177,26 @@ That means preview deployments, local smoke checks, and half-finished runtime ex
 
 In `sqlite` mode, the repository initializes its schema automatically, seeds the database from `forum-content.json` the first time it starts, and keeps the forum durably readable by default. Only when `FORUM_ENABLE_WRITES=true` does the same runtime start accepting new threads and replies, writing moderation timeline events, and persisting author-role and guidance fields for those new submissions. If `FORUM_WRITE_ACCESS_CODE` is also configured, those writes stay behind a shared preview gate until a fuller account boundary is ready.
 
+## Live deployment checks
+
+When a real preview URL or production forum origin exists, you no longer need to manually inspect `/api/health`, `/api/status`, headers, `robots.txt`, and page metadata one by one.
+
+Run the reusable script locally against any reachable forum URL:
+
+```bash
+pnpm smoke:deployment -- --url https://forum-preview.example.com --deployment-stage preview --writes-enabled=true --requires-access-code=true
+pnpm smoke:deployment -- --url https://forum.example.com --deployment-stage production --public-base-url https://forum.example.com --writes-enabled=false --requires-access-code=false
+```
+
+The same check is also available as the manual GitHub Actions workflow `Live deployment checks - Forum`. Provide:
+
+- `forum_url` for the real forum entry you want to verify
+- `deployment_stage` as `preview` or `production`
+- `public_base_url` when the target should already be publicly indexable
+- `writes_enabled` and `requires_access_code` so the live runtime is checked against the current rollout posture
+
+This closes the gap between “container checks passed in CI” and “the actual preview or production forum URL is configured correctly”.
+
 ## Container deployment
 
 The app now builds with `output: "standalone"`, so deployment does not need the whole repository at runtime.
@@ -196,6 +218,7 @@ docker run --rm -p 3000:3000 \
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 curl http://localhost:3000/robots.txt
+pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage preview --writes-enabled=false --requires-access-code=false
 ```
 
 Open writes only when the environment is ready to accept preview submissions:
@@ -209,6 +232,7 @@ docker run --rm -p 3000:3000 \
   fabushi-forum
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
+pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage preview --writes-enabled=true --requires-access-code=false
 ```
 
 Keep writable deployments in a small preview cohort when needed:
@@ -223,6 +247,7 @@ docker run --rm -p 3000:3000 \
   fabushi-forum
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
+pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage preview --writes-enabled=true --requires-access-code=true
 ```
 
 When the forum is actually ready to advertise a public origin, switch both deployment fields together:
@@ -239,6 +264,7 @@ curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 curl http://localhost:3000/robots.txt
 curl -I http://localhost:3000/threads
+pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage production --public-base-url https://forum.fabushi.com --writes-enabled=false --requires-access-code=false
 ```
 
 In that production-indexing runtime, verify the pair of signals together before exposing traffic:
@@ -258,17 +284,3 @@ curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 docker compose -f docker-compose.preview.yml down
 ```
-
-`docker-compose.preview.yml` now pins `FORUM_DEPLOYMENT_STAGE=preview`, can accept an optional `FORUM_PUBLIC_BASE_URL`, mounts a named volume at `/data`, keeps `FORUM_DATABASE_URL=file:/data/forum.db`, and declares the same `/api/health` probe that the container image exposes through `HEALTHCHECK`. That gives preview deployments one consistent readiness contract whether they are started with `docker run`, `docker compose`, or a later reverse-proxy/platform wrapper.
-
-Runtime defaults:
-
-- `PORT=3000`
-- `HOSTNAME=0.0.0.0`
-- `NODE_ENV=production`
-
-A dedicated GitHub Actions workflow now checks that the forum container image can be built whenever `forum/**` changes, waits for the container healthcheck to report healthy, validates that sqlite starts in read-only mode by default, confirms preview responses stay noindex through headers and `robots.txt`, verifies a production runtime with `FORUM_PUBLIC_BASE_URL` flips health, status, headers, robots, and page metadata into indexable mode, confirms `/threads/new` exposes the disabled page-level composer until writes are explicitly enabled, reruns the container with `FORUM_ENABLE_WRITES=true` plus a preview write-access code to exercise thread creation, denied writes without the code, thread-detail readback, reply submission, role labels, guidance signals, and appended moderation timeline events, and then restarts the same writable container against a mounted sqlite path to confirm those writes still exist after the process comes back up.
-
-## Why this is the next step
-
-After the preview write-access gate and health probe landed, the next launch-readiness gap was no longer another UI slice. The remaining deployment risk was that the forum still had no explicit preview-versus-production publishing contract, even though preview deployments were already close to real use. This iteration closes that gap in the smallest useful way: it keeps preview noindex by default, makes the deployment stage visible through runtime responses and headers, and only enables crawlable metadata after a public forum origin is intentionally configured.

--- a/forum/package.json
+++ b/forum/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "start:standalone": "node .next/standalone/server.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "smoke:deployment": "node ./scripts/check-deployment-contract.mjs"
   },
   "dependencies": {
     "next": "^15.5.2",

--- a/forum/scripts/check-deployment-contract.mjs
+++ b/forum/scripts/check-deployment-contract.mjs
@@ -13,7 +13,7 @@ function parseArgs(argv) {
     const key = part.slice(2);
     const value = argv[index + 1];
 
-    if (!value || value.startsWith("--")) {
+    if (value === undefined || value.startsWith("--")) {
       throw new Error(`Missing value for --${key}`);
     }
 

--- a/forum/scripts/check-deployment-contract.mjs
+++ b/forum/scripts/check-deployment-contract.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const part = argv[index];
+
+    if (!part.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${part}`);
+    }
+
+    const key = part.slice(2);
+    const value = argv[index + 1];
+
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function normalizeUrl(value) {
+  return value.replace(/\/$/, "");
+}
+
+function parseBoolean(value, key) {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Expected --${key} to be true or false, received: ${value}`);
+}
+
+function expect(condition, message, details) {
+  if (!condition) {
+    if (details === undefined) {
+      throw new Error(message);
+    }
+
+    throw new Error(`${message}\n${JSON.stringify(details, null, 2)}`);
+  }
+}
+
+async function fetchJson(target) {
+  const response = await fetch(target, {
+    headers: {
+      accept: "application/json",
+    },
+    redirect: "follow",
+  });
+
+  const body = await response.text();
+  expect(response.ok, `Request failed for ${target}`, {
+    status: response.status,
+    body,
+  });
+
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    throw new Error(`Expected JSON from ${target}: ${error}`);
+  }
+}
+
+async function fetchText(target) {
+  const response = await fetch(target, {
+    redirect: "follow",
+  });
+  const body = await response.text();
+
+  expect(response.ok, `Request failed for ${target}`, {
+    status: response.status,
+    body,
+  });
+
+  return {
+    body,
+    headers: response.headers,
+  };
+}
+
+const args = parseArgs(process.argv.slice(2));
+const forumUrl = normalizeUrl(args.url ?? "");
+const deploymentStage = args["deployment-stage"];
+const publicBaseUrl = args["public-base-url"] ? normalizeUrl(args["public-base-url"]) : "";
+const expectedWritesEnabled = parseBoolean(args["writes-enabled"], "writes-enabled");
+const expectedRequiresAccessCode = parseBoolean(args["requires-access-code"], "requires-access-code");
+
+expect(Boolean(forumUrl), "--url is required");
+expect(
+  deploymentStage === "preview" || deploymentStage === "production",
+  "--deployment-stage must be preview or production",
+  { deploymentStage },
+);
+
+const expectedIndexingEnabled = deploymentStage === "production" && Boolean(publicBaseUrl);
+
+const health = await fetchJson(`${forumUrl}/api/health`);
+const status = await fetchJson(`${forumUrl}/api/status`);
+const robots = await fetchText(`${forumUrl}/robots.txt`);
+const threadList = await fetchText(`${forumUrl}/threads`);
+const threadListHtml = threadList.body.toLowerCase();
+const robotsText = robots.body;
+
+expect(health.service === "forum", "health service should be forum", health);
+expect(health.ready === true, "health ready should be true", health);
+expect(health.deploymentStage === deploymentStage, "health deployment stage mismatch", health);
+expect(health.indexingEnabled === expectedIndexingEnabled, "health indexingEnabled mismatch", {
+  expectedIndexingEnabled,
+  health,
+});
+expect(
+  health.publicBaseUrlConfigured === Boolean(publicBaseUrl),
+  "health publicBaseUrlConfigured mismatch",
+  {
+    expected: Boolean(publicBaseUrl),
+    health,
+  },
+);
+
+expect(status.service === "forum", "status service should be forum", status);
+expect(status.deploymentStage === deploymentStage, "status deployment stage mismatch", status);
+expect(status.indexingEnabled === expectedIndexingEnabled, "status indexingEnabled mismatch", {
+  expectedIndexingEnabled,
+  status,
+});
+
+if (publicBaseUrl) {
+  expect(status.publicBaseUrl === publicBaseUrl, "status publicBaseUrl mismatch", {
+    expected: publicBaseUrl,
+    status,
+  });
+} else {
+  expect(!status.publicBaseUrl, "status publicBaseUrl should be empty when no public base URL is expected", status);
+}
+
+if (expectedWritesEnabled !== undefined) {
+  expect(health.writesEnabled === expectedWritesEnabled, "health writesEnabled mismatch", {
+    expectedWritesEnabled,
+    health,
+  });
+  expect(status.writesEnabled === expectedWritesEnabled, "status writesEnabled mismatch", {
+    expectedWritesEnabled,
+    status,
+  });
+}
+
+if (expectedRequiresAccessCode !== undefined) {
+  expect(health.requiresAccessCode === expectedRequiresAccessCode, "health requiresAccessCode mismatch", {
+    expectedRequiresAccessCode,
+    health,
+  });
+  expect(status.requiresAccessCode === expectedRequiresAccessCode, "status requiresAccessCode mismatch", {
+    expectedRequiresAccessCode,
+    status,
+  });
+}
+
+const stageHeader = threadList.headers.get("x-forum-deployment-stage");
+const indexingHeader = threadList.headers.get("x-forum-indexing-enabled");
+const publicBaseUrlHeader = threadList.headers.get("x-forum-public-base-url");
+const robotsTagHeader = threadList.headers.get("x-robots-tag");
+
+expect(stageHeader === deploymentStage, "page deployment stage header mismatch", {
+  expected: deploymentStage,
+  actual: stageHeader,
+});
+expect(indexingHeader === String(expectedIndexingEnabled), "page indexing header mismatch", {
+  expected: String(expectedIndexingEnabled),
+  actual: indexingHeader,
+});
+
+if (publicBaseUrl) {
+  expect(publicBaseUrlHeader === publicBaseUrl, "page public base URL header mismatch", {
+    expected: publicBaseUrl,
+    actual: publicBaseUrlHeader,
+  });
+} else {
+  expect(!publicBaseUrlHeader, "page public base URL header should be empty", {
+    actual: publicBaseUrlHeader,
+  });
+}
+
+if (expectedIndexingEnabled) {
+  expect(!robotsTagHeader, "x-robots-tag should be absent when indexing is enabled", {
+    robotsTagHeader,
+  });
+  expect(robotsText.includes("Allow: /"), "robots.txt should allow crawling", {
+    robotsText,
+  });
+  expect(robotsText.includes(`Host: ${publicBaseUrl}`), "robots.txt Host should match expected public base URL", {
+    publicBaseUrl,
+    robotsText,
+  });
+  expect(!robotsText.includes("Disallow: /"), "robots.txt should not disallow crawling", {
+    robotsText,
+  });
+  expect(threadListHtml.includes("index, follow"), "thread list HTML should be indexable", {
+    snippet: threadList.body.slice(0, 4000),
+  });
+  expect(threadListHtml.includes(publicBaseUrl.toLowerCase()), "thread list HTML should include the configured public base URL", {
+    publicBaseUrl,
+    snippet: threadList.body.slice(0, 4000),
+  });
+  expect(!threadListHtml.includes("noindex"), "thread list HTML should not include noindex metadata", {
+    snippet: threadList.body.slice(0, 4000),
+  });
+} else {
+  expect(
+    robotsTagHeader?.toLowerCase().includes("noindex") ?? false,
+    "x-robots-tag should keep preview/noindex deployments private",
+    { robotsTagHeader },
+  );
+  expect(robotsText.includes("Disallow: /"), "robots.txt should disallow crawling", {
+    robotsText,
+  });
+  expect(threadListHtml.includes("noindex"), "thread list HTML should include noindex metadata", {
+    snippet: threadList.body.slice(0, 4000),
+  });
+}
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      forumUrl,
+      deploymentStage,
+      indexingEnabled: expectedIndexingEnabled,
+      publicBaseUrl: publicBaseUrl || null,
+      writesEnabled: expectedWritesEnabled ?? null,
+      requiresAccessCode: expectedRequiresAccessCode ?? null,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## 问题

论坛现在已经能在 CI 里验证容器内的 preview / production 部署契约，但离真实上线前还有一层空档：

- 现在只能确认仓库里的示例容器配置没跑偏
- 一旦论坛真正部署到 preview 地址或正式域名，还需要人工逐条回看 `/api/health`、`/api/status`、响应头、`robots.txt` 和页面 metadata
- 当前最高优先级正是把真实论坛入口对齐到 `FORUM_PUBLIC_BASE_URL`，以及验证目标环境会不会沿着既有契约正确切换 indexing

这意味着代码里的部署边界已经有了，但“真实 URL 是否按预期工作”还没有一条可重复执行的仓库内检查路径。

## 这次改动

- 新增 `forum/scripts/check-deployment-contract.mjs`
  - 对任意可访问论坛 URL 校验 `/api/health`、`/api/status`、页面响应头、`robots.txt` 与页面 HTML
  - 支持断言 `deploymentStage`、`publicBaseUrl`、`writesEnabled` 与 `requiresAccessCode`
  - 统一覆盖 preview noindex 与 production indexing 两种运行态
- 新增 `.github/workflows/forum-live-deployment-checks.yml`
  - 提供手动触发的 live deployment smoke check
  - 输入真实 `forum_url`
  - 可同时声明预期的 `deployment_stage`、`public_base_url`、`writes_enabled` 与 `requires_access_code`
- 更新 `forum/package.json`
  - 新增 `pnpm smoke:deployment`
- 更新 `forum/README.md`
  - 补本地与线上两种 live deployment smoke check 用法
  - 把 preview / production / 写入口令这几类部署姿态的校验命令一起整理进文档

## 为什么现在做

在 `PR #474` 已把容器内的 production indexing contract 自动化之后，当前最高收益切片不再是继续补同类容器断言，而是补一条能直接面对真实论坛入口的检查路径。

这一小步的价值很集中：

- 目标运行环境一旦有 preview URL 或正式域名，就能立刻验证是否真的对齐 `FORUM_PUBLIC_BASE_URL`
- 可以更快发现“CI 里的示例容器正常，但真实部署入口没切干净”的问题
- 下一步去验证完整页面级治理闭环时，也能把 `writesEnabled` / `requiresAccessCode` 一起纳入同一条 live check

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 5`、`behind_by = 0`
- 改动范围收敛在 4 个论坛相关文件：
  - `.github/workflows/forum-live-deployment-checks.yml`
  - `forum/README.md`
  - `forum/package.json`
  - `forum/scripts/check-deployment-contract.mjs`
- 已回读分支内容确认：
  - 手动工作流会调用同一条脚本校验真实论坛 URL
  - 脚本会统一检查 health/status、响应头、robots 和页面 metadata
  - README 与 `pnpm smoke:deployment` 已对齐新的运行方式
- 当前环境没有仓库本地 checkout，无法直接在本地运行 `pnpm --dir forum smoke:deployment` 或手动访问真实论坛 URL
- 最终验证仍需依赖：
  - 仓库现有 `CI`
  - `Module checks - Forum`
  - 真实部署地址可用后手动触发 `Live deployment checks - Forum`

## 下一步承接

- 拿到真实 preview URL 后，先跑一次 `Live deployment checks - Forum`，确认 noindex、只读与写入口令姿态都符合预期
- 正式入口确定后，把同一条检查切到 production + `FORUM_PUBLIC_BASE_URL`，再继续验证页面级发帖 / 回复 / 审核时间线闭环