### PR TITLE
feat(forum): verify live preview write flow against deployed forum

### DIFF
--- a/.github/workflows/forum-live-deployment-checks.yml
+++ b/.github/workflows/forum-live-deployment-checks.yml
@@ -35,6 +35,14 @@ on:
         options:
           - "false"
           - "true"
+      exercise_write_flow:
+        description: For preview runtimes only. When true, the live check will create a thread and reply against the deployed forum.
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 permissions:
   contents: read
@@ -42,6 +50,8 @@ permissions:
 jobs:
   forum-live-deployment:
     runs-on: ubuntu-latest
+    env:
+      FORUM_WRITE_ACCESS_CODE: ${{ secrets.FORUM_LIVE_WRITE_ACCESS_CODE }}
     steps:
       - name: Checkout forum workspace only
         uses: actions/checkout@v4
@@ -63,4 +73,5 @@ jobs:
             --deployment-stage "${{ inputs.deployment_stage }}" \
             --public-base-url "${{ inputs.public_base_url }}" \
             --writes-enabled "${{ inputs.writes_enabled }}" \
-            --requires-access-code "${{ inputs.requires_access_code }}"
+            --requires-access-code "${{ inputs.requires_access_code }}" \
+            --exercise-write-flow "${{ inputs.exercise_write_flow }}"

--- a/forum/README.md
+++ b/forum/README.md
@@ -18,6 +18,7 @@ Current scope:
 - an optional write-access code gate so writable sqlite deployments can stay in a small preview cohort before full authentication lands
 - a preview/production deployment contract that keeps preview responses noindex until the public forum origin is explicit
 - a reusable deployment smoke script plus a manual GitHub Actions workflow for checking real preview and production forum URLs against that contract
+- an optional live preview write smoke check that can create a thread and reply against a deployed runtime before broader rollout
 - a minimal thread-creation API when sqlite mode is enabled and writes are explicitly opened
 - a page-level thread composer on top of the thread-creation API in writable mode
 - a minimal reply-creation API for existing threads when sqlite writes are enabled
@@ -53,6 +54,7 @@ Included:
 - a no-store health endpoint for deployment readiness probes
 - a preview-safe indexing contract driven by deployment stage plus public forum origin
 - a reusable smoke check for real deployment URLs
+- an optional write-path smoke check for deployed preview runtimes
 
 Not included yet:
 
@@ -131,6 +133,8 @@ curl -X POST http://localhost:3000/api/thread/first-year-stability/replies \
     "trustSignal": "回复已按主题聚焦提交，等待更多互动后再决定是否沉淀。",
     "body": ["我发现先把睡前十分钟固定下来，比一下子改整天作息更容易坚持。"]
   }'
+FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+  pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage preview --writes-enabled=true --requires-access-code=true --exercise-write-flow true
 curl http://localhost:3000/api/thread/first-year-stability
 curl http://localhost:3000/threads/new
 curl http://localhost:3000/threads
@@ -188,12 +192,22 @@ pnpm smoke:deployment -- --url https://forum-preview.example.com --deployment-st
 pnpm smoke:deployment -- --url https://forum.example.com --deployment-stage production --public-base-url https://forum.example.com --writes-enabled=false --requires-access-code=false
 ```
 
-The same check is also available as the manual GitHub Actions workflow `Live deployment checks - Forum`. Provide:
+If you want the live check to also verify the preview write path, opt in explicitly and provide the shared preview code through an environment variable. This mode creates a real thread and a real reply on the deployed runtime, so it is intended for preview environments and other safe rollout targets, not public production forums.
+
+```bash
+FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+  pnpm smoke:deployment -- --url https://forum-preview.example.com --deployment-stage preview --writes-enabled=true --requires-access-code=true --exercise-write-flow true
+```
+
+The same checks are also available as the manual GitHub Actions workflow `Live deployment checks - Forum`. Provide:
 
 - `forum_url` for the real forum entry you want to verify
 - `deployment_stage` as `preview` or `production`
 - `public_base_url` when the target should already be publicly indexable
 - `writes_enabled` and `requires_access_code` so the live runtime is checked against the current rollout posture
+- `exercise_write_flow=true` only when you intentionally want the workflow to create a preview thread and reply during the run
+
+If the preview runtime still requires a shared write-access code, store it in the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE` before triggering the workflow. The workflow passes that secret into the live smoke script only when the write-path check is enabled.
 
 This closes the gap between “container checks passed in CI” and “the actual preview or production forum URL is configured correctly”.
 
@@ -248,6 +262,8 @@ docker run --rm -p 3000:3000 \
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage preview --writes-enabled=true --requires-access-code=true
+FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+  pnpm smoke:deployment -- --url http://localhost:3000 --deployment-stage preview --writes-enabled=true --requires-access-code=true --exercise-write-flow true
 ```
 
 When the forum is actually ready to advertise a public origin, switch both deployment fields together:

--- a/forum/scripts/check-deployment-contract.mjs
+++ b/forum/scripts/check-deployment-contract.mjs
@@ -54,41 +54,281 @@ function expect(condition, message, details) {
   }
 }
 
-async function fetchJson(target) {
-  const response = await fetch(target, {
-    headers: {
-      accept: "application/json",
-    },
-    redirect: "follow",
-  });
-
-  const body = await response.text();
-  expect(response.ok, `Request failed for ${target}`, {
-    status: response.status,
-    body,
-  });
-
-  try {
-    return JSON.parse(body);
-  } catch (error) {
-    throw new Error(`Expected JSON from ${target}: ${error}`);
-  }
-}
-
-async function fetchText(target) {
+async function request(target, init = {}, expectedStatus = 200) {
+  const allowedStatuses = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
   const response = await fetch(target, {
     redirect: "follow",
+    ...init,
   });
   const body = await response.text();
 
-  expect(response.ok, `Request failed for ${target}`, {
+  expect(allowedStatuses.includes(response.status), `Request failed for ${target}`, {
     status: response.status,
     body,
+    expectedStatus: allowedStatuses,
   });
 
   return {
     body,
     headers: response.headers,
+    status: response.status,
+  };
+}
+
+async function fetchJson(target, init = {}, expectedStatus = 200) {
+  const response = await request(
+    target,
+    {
+      headers: {
+        accept: "application/json",
+        ...(init.headers ?? {}),
+      },
+      ...init,
+    },
+    expectedStatus,
+  );
+
+  try {
+    return {
+      ...response,
+      json: JSON.parse(response.body),
+    };
+  } catch (error) {
+    throw new Error(`Expected JSON from ${target}: ${error}`);
+  }
+}
+
+function createThreadPayload(runId) {
+  return {
+    sectionSlug: "newcomer-path",
+    title: `Live deployment smoke ${runId}`,
+    author: "Live deployment check",
+    authorRoleLabel: "Preview cohort tester",
+    guidanceSignal: "Please confirm the smallest next step appears in live readback.",
+    summary: "This thread verifies the deployed forum write path before broader rollout.",
+    tags: ["live-smoke", "preview"],
+    openingPost: [
+      "This thread is created by the live deployment smoke check to verify thread creation, page readback, and moderation timeline persistence.",
+    ],
+  };
+}
+
+function createReplyPayload() {
+  return {
+    author: "Live reply check",
+    roleLabel: "Preview reply verifier",
+    guidanceSignal: "Please surface one concrete next step in the live thread detail.",
+    trustSignal: "Written by the live deployment smoke check to verify reply persistence.",
+    body: [
+      "This reply verifies that the deployed forum can persist and read back a new response.",
+    ],
+  };
+}
+
+async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, writeAccessCode }) {
+  const runId = new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14);
+  const threadPayload = createThreadPayload(runId);
+
+  if (expectedRequiresAccessCode) {
+    const deniedCreate = await fetchJson(
+      `${forumUrl}/api/threads`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(threadPayload),
+      },
+      403,
+    );
+
+    expect(
+      typeof deniedCreate.json.error === "string" && deniedCreate.json.error.toLowerCase().includes("write access code"),
+      "thread creation without a write access code should be rejected before live writes run",
+      deniedCreate.json,
+    );
+  }
+
+  const createPayload = {
+    ...threadPayload,
+    ...(writeAccessCode ? { writeAccessCode } : {}),
+  };
+  const createdThread = await fetchJson(
+    `${forumUrl}/api/threads`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(createPayload),
+    },
+    201,
+  );
+
+  expect(createdThread.json.source === "sqlite", "created thread should be backed by sqlite", createdThread.json);
+  expect(createdThread.json.thread.sectionSlug === threadPayload.sectionSlug, "thread section mismatch", createdThread.json);
+  expect(createdThread.json.thread.title === threadPayload.title, "thread title mismatch", createdThread.json);
+  expect(createdThread.json.thread.author === threadPayload.author, "thread author mismatch", createdThread.json);
+  expect(
+    createdThread.json.thread.authorRoleLabel === threadPayload.authorRoleLabel,
+    "thread authorRoleLabel mismatch",
+    createdThread.json,
+  );
+  expect(
+    createdThread.json.thread.guidanceSignal === threadPayload.guidanceSignal,
+    "thread guidanceSignal mismatch",
+    createdThread.json,
+  );
+  expect(
+    createdThread.json.moderationEvents.at(-1)?.eventType === "thread-created",
+    "thread creation should append a moderation event",
+    createdThread.json,
+  );
+
+  const threadSlug = createdThread.json.thread.slug;
+  expect(Boolean(threadSlug), "thread slug should be returned after live thread creation", createdThread.json);
+
+  const threadDetail = await fetchJson(`${forumUrl}/api/thread/${threadSlug}`);
+  expect(threadDetail.json.source === "sqlite", "thread detail should resolve from sqlite", threadDetail.json);
+  expect(threadDetail.json.thread.slug === threadSlug, "thread detail slug mismatch", threadDetail.json);
+  expect(threadDetail.json.thread.author === threadPayload.author, "thread detail author mismatch", threadDetail.json);
+  expect(
+    threadDetail.json.moderationEvents.at(-1)?.eventType === "thread-created",
+    "thread detail should expose the creation moderation event",
+    threadDetail.json,
+  );
+
+  const threadListPage = await request(`${forumUrl}/threads`);
+  expect(threadListPage.body.includes(threadPayload.title), "thread list HTML should include the created thread title", {
+    threadTitle: threadPayload.title,
+    snippet: threadListPage.body.slice(0, 6000),
+  });
+  expect(threadListPage.body.includes(threadPayload.author), "thread list HTML should include the created thread author", {
+    author: threadPayload.author,
+    snippet: threadListPage.body.slice(0, 6000),
+  });
+  expect(
+    threadListPage.body.includes(threadPayload.authorRoleLabel),
+    "thread list HTML should include the created thread role label",
+    {
+      roleLabel: threadPayload.authorRoleLabel,
+      snippet: threadListPage.body.slice(0, 6000),
+    },
+  );
+  expect(
+    threadListPage.body.includes(threadPayload.guidanceSignal),
+    "thread list HTML should include the created thread guidance signal",
+    {
+      guidanceSignal: threadPayload.guidanceSignal,
+      snippet: threadListPage.body.slice(0, 6000),
+    },
+  );
+
+  const threadDetailPageBeforeReply = await request(`${forumUrl}/threads/${threadSlug}`);
+  expect(
+    threadDetailPageBeforeReply.body.includes(threadPayload.title),
+    "thread detail HTML should include the created thread title",
+    {
+      threadTitle: threadPayload.title,
+      snippet: threadDetailPageBeforeReply.body.slice(0, 7000),
+    },
+  );
+  expect(
+    threadDetailPageBeforeReply.body.includes(threadPayload.guidanceSignal),
+    "thread detail HTML should include the thread guidance signal",
+    {
+      guidanceSignal: threadPayload.guidanceSignal,
+      snippet: threadDetailPageBeforeReply.body.slice(0, 7000),
+    },
+  );
+  expect(
+    threadDetailPageBeforeReply.body.includes("审核时间线"),
+    "thread detail HTML should expose the moderation timeline block",
+    {
+      snippet: threadDetailPageBeforeReply.body.slice(0, 7000),
+    },
+  );
+
+  const replyPayload = createReplyPayload();
+  const createdReply = await fetchJson(
+    `${forumUrl}/api/thread/${threadSlug}/replies`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        ...replyPayload,
+        ...(writeAccessCode ? { writeAccessCode } : {}),
+      }),
+    },
+    201,
+  );
+
+  expect(createdReply.json.source === "sqlite", "created reply should be backed by sqlite", createdReply.json);
+  expect(createdReply.json.thread.slug === threadSlug, "reply response slug mismatch", createdReply.json);
+  expect(createdReply.json.thread.replyCount >= 1, "reply count should increase after live reply creation", createdReply.json);
+  expect(createdReply.json.thread.lastActivity === "刚刚回复", "lastActivity should reflect a new reply", createdReply.json);
+  expect(createdReply.json.replies.at(-1)?.author === replyPayload.author, "reply author mismatch", createdReply.json);
+  expect(createdReply.json.replies.at(-1)?.roleLabel === replyPayload.roleLabel, "reply roleLabel mismatch", createdReply.json);
+  expect(
+    createdReply.json.replies.at(-1)?.guidanceSignal === replyPayload.guidanceSignal,
+    "reply guidanceSignal mismatch",
+    createdReply.json,
+  );
+  expect(
+    createdReply.json.replies.at(-1)?.trustSignal === replyPayload.trustSignal,
+    "reply trustSignal mismatch",
+    createdReply.json,
+  );
+  expect(
+    createdReply.json.moderationEvents.at(-1)?.eventType === "reply-created",
+    "reply creation should append a moderation event",
+    createdReply.json,
+  );
+
+  const threadDetailAfterReply = await fetchJson(`${forumUrl}/api/thread/${threadSlug}`);
+  expect(
+    threadDetailAfterReply.json.replies.at(-1)?.author === replyPayload.author,
+    "thread detail should include the live reply author",
+    threadDetailAfterReply.json,
+  );
+  expect(
+    threadDetailAfterReply.json.moderationEvents.at(-1)?.eventType === "reply-created",
+    "thread detail should expose the reply moderation event",
+    threadDetailAfterReply.json,
+  );
+
+  const threadDetailPageAfterReply = await request(`${forumUrl}/threads/${threadSlug}`);
+  expect(
+    threadDetailPageAfterReply.body.includes(replyPayload.author),
+    "thread detail HTML should include the live reply author",
+    {
+      author: replyPayload.author,
+      snippet: threadDetailPageAfterReply.body.slice(0, 9000),
+    },
+  );
+  expect(
+    threadDetailPageAfterReply.body.includes(replyPayload.roleLabel),
+    "thread detail HTML should include the live reply role label",
+    {
+      roleLabel: replyPayload.roleLabel,
+      snippet: threadDetailPageAfterReply.body.slice(0, 9000),
+    },
+  );
+  expect(
+    threadDetailPageAfterReply.body.includes(replyPayload.guidanceSignal),
+    "thread detail HTML should include the live reply guidance signal",
+    {
+      guidanceSignal: replyPayload.guidanceSignal,
+      snippet: threadDetailPageAfterReply.body.slice(0, 9000),
+    },
+  );
+
+  return {
+    threadSlug,
+    threadTitle: threadPayload.title,
+    replyAuthor: replyPayload.author,
   };
 }
 
@@ -98,6 +338,8 @@ const deploymentStage = args["deployment-stage"];
 const publicBaseUrl = args["public-base-url"] ? normalizeUrl(args["public-base-url"]) : "";
 const expectedWritesEnabled = parseBoolean(args["writes-enabled"], "writes-enabled");
 const expectedRequiresAccessCode = parseBoolean(args["requires-access-code"], "requires-access-code");
+const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise-write-flow") ?? false;
+const writeAccessCode = args["write-access-code"]?.trim() || process.env.FORUM_WRITE_ACCESS_CODE?.trim() || "";
 
 expect(Boolean(forumUrl), "--url is required");
 expect(
@@ -110,62 +352,62 @@ const expectedIndexingEnabled = deploymentStage === "production" && Boolean(publ
 
 const health = await fetchJson(`${forumUrl}/api/health`);
 const status = await fetchJson(`${forumUrl}/api/status`);
-const robots = await fetchText(`${forumUrl}/robots.txt`);
-const threadList = await fetchText(`${forumUrl}/threads`);
+const robots = await request(`${forumUrl}/robots.txt`);
+const threadList = await request(`${forumUrl}/threads`);
 const threadListHtml = threadList.body.toLowerCase();
 const robotsText = robots.body;
 
-expect(health.service === "forum", "health service should be forum", health);
-expect(health.ready === true, "health ready should be true", health);
-expect(health.deploymentStage === deploymentStage, "health deployment stage mismatch", health);
-expect(health.indexingEnabled === expectedIndexingEnabled, "health indexingEnabled mismatch", {
+expect(health.json.service === "forum", "health service should be forum", health.json);
+expect(health.json.ready === true, "health ready should be true", health.json);
+expect(health.json.deploymentStage === deploymentStage, "health deployment stage mismatch", health.json);
+expect(health.json.indexingEnabled === expectedIndexingEnabled, "health indexingEnabled mismatch", {
   expectedIndexingEnabled,
-  health,
+  health: health.json,
 });
 expect(
-  health.publicBaseUrlConfigured === Boolean(publicBaseUrl),
+  health.json.publicBaseUrlConfigured === Boolean(publicBaseUrl),
   "health publicBaseUrlConfigured mismatch",
   {
     expected: Boolean(publicBaseUrl),
-    health,
+    health: health.json,
   },
 );
 
-expect(status.service === "forum", "status service should be forum", status);
-expect(status.deploymentStage === deploymentStage, "status deployment stage mismatch", status);
-expect(status.indexingEnabled === expectedIndexingEnabled, "status indexingEnabled mismatch", {
+expect(status.json.service === "forum", "status service should be forum", status.json);
+expect(status.json.deploymentStage === deploymentStage, "status deployment stage mismatch", status.json);
+expect(status.json.indexingEnabled === expectedIndexingEnabled, "status indexingEnabled mismatch", {
   expectedIndexingEnabled,
-  status,
+  status: status.json,
 });
 
 if (publicBaseUrl) {
-  expect(status.publicBaseUrl === publicBaseUrl, "status publicBaseUrl mismatch", {
+  expect(status.json.publicBaseUrl === publicBaseUrl, "status publicBaseUrl mismatch", {
     expected: publicBaseUrl,
-    status,
+    status: status.json,
   });
 } else {
-  expect(!status.publicBaseUrl, "status publicBaseUrl should be empty when no public base URL is expected", status);
+  expect(!status.json.publicBaseUrl, "status publicBaseUrl should be empty when no public base URL is expected", status.json);
 }
 
 if (expectedWritesEnabled !== undefined) {
-  expect(health.writesEnabled === expectedWritesEnabled, "health writesEnabled mismatch", {
+  expect(health.json.writesEnabled === expectedWritesEnabled, "health writesEnabled mismatch", {
     expectedWritesEnabled,
-    health,
+    health: health.json,
   });
-  expect(status.writesEnabled === expectedWritesEnabled, "status writesEnabled mismatch", {
+  expect(status.json.writesEnabled === expectedWritesEnabled, "status writesEnabled mismatch", {
     expectedWritesEnabled,
-    status,
+    status: status.json,
   });
 }
 
 if (expectedRequiresAccessCode !== undefined) {
-  expect(health.requiresAccessCode === expectedRequiresAccessCode, "health requiresAccessCode mismatch", {
+  expect(health.json.requiresAccessCode === expectedRequiresAccessCode, "health requiresAccessCode mismatch", {
     expectedRequiresAccessCode,
-    health,
+    health: health.json,
   });
-  expect(status.requiresAccessCode === expectedRequiresAccessCode, "status requiresAccessCode mismatch", {
+  expect(status.json.requiresAccessCode === expectedRequiresAccessCode, "status requiresAccessCode mismatch", {
     expectedRequiresAccessCode,
-    status,
+    status: status.json,
   });
 }
 
@@ -232,6 +474,27 @@ if (expectedIndexingEnabled) {
   });
 }
 
+let liveWriteVerification = null;
+
+if (exerciseWriteFlow) {
+  expect(deploymentStage === "preview", "--exercise-write-flow is only supported for preview runtimes.", {
+    deploymentStage,
+  });
+  expect(expectedWritesEnabled === true, "--exercise-write-flow requires --writes-enabled=true.", {
+    expectedWritesEnabled,
+  });
+
+  if (expectedRequiresAccessCode) {
+    expect(Boolean(writeAccessCode), "A write access code is required to exercise the live preview write flow. Pass --write-access-code or set FORUM_WRITE_ACCESS_CODE.");
+  }
+
+  liveWriteVerification = await verifyPreviewWriteFlow({
+    forumUrl,
+    expectedRequiresAccessCode: expectedRequiresAccessCode === true,
+    writeAccessCode,
+  });
+}
+
 console.log(
   JSON.stringify(
     {
@@ -242,6 +505,8 @@ console.log(
       publicBaseUrl: publicBaseUrl || null,
       writesEnabled: expectedWritesEnabled ?? null,
       requiresAccessCode: expectedRequiresAccessCode ?? null,
+      exerciseWriteFlow,
+      liveWriteVerification,
     },
     null,
     2,


### PR DESCRIPTION
## 问题

论坛现在已经能用 `Live deployment checks - Forum` 验证真实 URL 的部署契约，但它还只能回答：

- `/api/health`、`/api/status`、响应头、`robots.txt` 和页面 metadata 对不对
- preview 是否仍然保持 noindex
- production + `FORUM_PUBLIC_BASE_URL` 是否已经切到可索引状态

这还缺了真实上线前最关键的一层：

- 拿到真实 preview 地址以后，我们仍然要手动验证发帖、详情页回读、回复写入和治理时间线是否都正常
- 如果 preview 还启用了共享写入口令，目前也没有一条仓库内路径能在不暴露口令的前提下回归验证这条 gate
- 这会让论坛虽然已经很接近可部署，但在真正进入 preview 试用前，仍然缺少一条可重复执行的“真实互动闭环”检查

## 这次改动

- 更新 `forum/scripts/check-deployment-contract.mjs`
  - 保留现有 `/api/health`、`/api/status`、响应头、`robots.txt` 和页面 metadata 契约校验
  - 新增可选参数 `--exercise-write-flow true`
  - 仅在 `preview + writesEnabled=true` 时允许执行真实写入 smoke check
  - 当 `requiresAccessCode=true` 时，先验证缺口令创建会返回 `403`
  - 再创建真实主题，回读 `/api/thread/[slug]`、`/threads` 与 `/threads/[slug]`
  - 再提交真实回复，并确认回复数据与治理时间线已经追加 `reply-created`
- 更新 `.github/workflows/forum-live-deployment-checks.yml`
  - 新增手动输入 `exercise_write_flow`
  - 通过仓库 secret `FORUM_LIVE_WRITE_ACCESS_CODE` 承接 preview 写入口令，而不是把口令放进 workflow input
- 更新 `forum/README.md`
  - 补本地与 GitHub Actions 下的 live preview 写入 smoke check 用法
  - 明确说明这条检查会向真实 preview 运行态写入一条主题和一条回复，因此只适合 preview 或其他安全环境

## 为什么现在做

在 `PR #476` 已把真实 URL 的部署契约检查补齐后，当前最高收益切片不再是继续补类似的只读状态断言，而是把“真实 preview 地址上的最小互动闭环”也纳入同一条可重复执行的仓库检查路径。

这一小步的收益很集中：

- 真实 preview 地址一旦可用，就能直接验证“只读 -> 口令 gate -> 发帖 -> 页面回读 -> 回复 -> 治理事件”是否一起成立
- preview 仍需共享写入口令时，也不必把口令明文塞进手动工作流输入里
- 后续正式域名走 production indexing 检查时，仍可保持只读契约；而 preview 试用阶段则多了一条更贴近真实使用的回归路径

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 3`、`behind_by = 0`
- 改动范围收敛在 3 个论坛相关文件：
  - `.github/workflows/forum-live-deployment-checks.yml`
  - `forum/README.md`
  - `forum/scripts/check-deployment-contract.mjs`
- 已回读分支内容确认：
  - `exercise_write_flow` 只允许在 preview 运行态下开启
  - 需要写入口令时，脚本会先验证缺口令 `403`，再使用 `FORUM_WRITE_ACCESS_CODE` 完成真实写入闭环
  - README 与手动工作流说明已对齐新的 secret 和真实写入行为
- 当前环境没有仓库本地 checkout，无法直接在本地运行 `pnpm --dir forum smoke:deployment -- --exercise-write-flow true` 或访问真实 preview 地址
- 最终检查仍依赖仓库现有 Actions，以及后续拿到真实 preview URL 后手动触发 `Live deployment checks - Forum`

## 下一步承接

- 拿到真实 preview URL 后，先跑一次只读契约检查，再在安全环境中开启 `exercise_write_flow=true`
- 正式入口明确后，继续用同一条 workflow 验证 production + `FORUM_PUBLIC_BASE_URL` 的 indexing 契约
- 真实 preview 闭环稳定后，再继续推进登录态、权限态和审核流服务边界