### PR TITLE
feat(web): connect practice guide to concept hub

### DIFF
--- a/frontend/apps/web/src/app/practice-guide/page.tsx
+++ b/frontend/apps/web/src/app/practice-guide/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const pageUrl = siteUrl("/practice-guide");
 const pageTitle = `修行方法总览 | ${brand.name}`;
 const pageDescription =
-  "面向初学者梳理学佛修行可以从哪些方法开始：禅修、经文听诵、阅读、念佛与日常记录如何配合，才能把菩提心、修行、六度、空性理解与日常生活接在一起。";
+  "面向初学者梳理学佛修行可以从哪些方法开始：禅修、经文听诵、阅读、念佛与日常记录如何配合，才能把因果、菩提心、六度、空性与佛学基本概念理解一起接回日常生活。";
 
 const practicePrinciples = [
   {
@@ -79,6 +79,27 @@ const weeklyRhythm = [
   },
 ] as const;
 
+const conceptBridgeSteps = [
+  {
+    titleZh: "因果：为什么修行方法一断再断，常常会回到习惯和结果这层问题",
+    titleEn: "Karma: why broken rhythm often returns to habit and result",
+    descriptionZh: "很多人练着练着会发现，真正卡住的不是不知道做什么，而是同样的急躁、拖延和起伏总在重复。这时回到因果，会更容易看见方法为什么需要相续，而不是只靠一时热情。",
+    descriptionEn: "Many people discover that the real obstacle is not knowing what to do, but watching the same impatience, delay, and fluctuation repeat. Returning to karma helps explain why methods need continuity instead of depending on temporary enthusiasm.",
+  },
+  {
+    titleZh: "菩提心与六度：为什么方法不只是技巧，而会慢慢长成待人处事的方向",
+    titleEn: "Bodhicitta and the six paramitas: why methods become more than technique",
+    descriptionZh: "如果修行方法只是让自己舒服一点，它很容易变成任务清单。回到菩提心和六度，会更容易看见禅修、听诵、念佛和记录，怎样慢慢长成更宽的发心、忍耐与待人处事。",
+    descriptionEn: "If methods are only about feeling better, they can quickly shrink into tasks. Returning to bodhicitta and the six paramitas helps show how meditation, listening, recitation, and notes can widen into aspiration, patience, and conduct.",
+  },
+  {
+    titleZh: "空性与概念总览：为什么练习越往前走，越需要一张更完整的理解地图",
+    titleEn: "Emptiness and the concepts hub: why practice needs a wider map as it matures",
+    descriptionZh: "练习一段时间以后，很多人会开始卡在“我是不是又把功课抓得太死”或“这些概念彼此到底怎么连起来”。这时先回到佛学基本概念总览，再决定是继续看空性、因果还是六度，通常比在方法页里硬撑更稳。",
+    descriptionEn: "After some time, many people start asking whether they are gripping the routine too tightly or how the concepts actually connect. Returning to the concepts hub first, then moving into emptiness, karma, or the six paramitas, is often steadier than forcing the answer to stay inside a methods page alone.",
+  },
+] as const;
+
 const relatedPaths = [
   {
     href: "/start-learning-buddhism",
@@ -97,6 +118,24 @@ const relatedPaths = [
     titleEn: "Connect a lighter routine across morning, daytime, and evening.",
     descriptionZh: "如果你已经确定要开始练习，但卡在功课怎么安排、怎么做得更稳，这一页会更具体。",
     descriptionEn: "If you already know you want to practice but feel stuck on arranging a routine that can last, this page is more concrete.",
+  },
+  {
+    href: "/buddhist-concepts",
+    labelZh: "佛学基本概念",
+    labelEn: "Buddhist Concepts",
+    titleZh: "先回到一张更完整的概念地图，再决定自己卡在哪个概念上。",
+    titleEn: "Return to a wider concepts map before choosing which concept needs attention now.",
+    descriptionZh: "如果你已经发现自己不是缺方法，而是总被因果、菩提心、六度、空性这些词反复卡住，这一页会更适合先打开。",
+    descriptionEn: "Open this first if you have started to see that the problem is not a lack of methods, but repeated friction around karma, bodhicitta, the six paramitas, or emptiness.",
+  },
+  {
+    href: "/what-is-karma",
+    labelZh: "因果是什么意思",
+    labelEn: "What Karma Means",
+    titleZh: "把习惯、选择和结果怎样慢慢形成先放清楚。",
+    titleEn: "Clarify how habit, choice, and result gradually take shape together.",
+    descriptionZh: "如果你已经发现自己最常卡在“为什么知道应该修，却总是留不住节奏”，这一页会更适合继续往下看。",
+    descriptionEn: "This is the better next page if your main friction has become why you know you should practice but still cannot keep the rhythm alive.",
   },
   {
     href: "/what-is-bodhicitta",
@@ -177,6 +216,12 @@ const faqItems = [
     answerEn: "The better question is what you need most right now. Meditation can come first if you need steadiness, recitation or listening can come first if you need an easier rhythm, and reading can come first if you need clearer direction.",
   },
   {
+    questionZh: "因果是什么意思，和修行方法有什么关系？",
+    questionEn: "What does karma have to do with actual practice methods?",
+    answerZh: "如果不知道因果怎样和习惯、选择、结果连在一起，修行方法很容易只剩下一阵一阵的热情。回到因果，会更容易看见：今天怎么说话、怎么安排时间、断掉以后有没有回来，这些看起来很小的动作，正是在慢慢形成后面的结果。",
+    answerEn: "When karma is separated from habit, choice, and result, practice methods can shrink into bursts of enthusiasm. Returning to karma helps show how speech, time, and whether you come back after a break are already shaping later results.",
+  },
+  {
     questionZh: "菩提心是什么意思，和修行方法有什么关系？",
     questionEn: "What does bodhicitta have to do with actual practice methods?",
     answerZh: "如果没有发心，修行方法很容易只剩技巧和任务。更稳的方向，是让禅修、听诵、阅读、念佛和记录，慢慢回到“我为什么学、愿意把这条路带向哪里”这件事上。这样方法才不只是让自己舒服一点，也会开始长出更宽的方向。",
@@ -219,6 +264,8 @@ export const metadata: Metadata = {
     "学佛修行",
     "佛教修行方法",
     "初学者怎么修行",
+    "佛学基本概念",
+    "因果是什么意思",
     "菩提心是什么意思",
     "日常功课",
     "六度分别是什么",
@@ -256,7 +303,7 @@ export default function PracticeGuidePage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["修行方法", "学佛修行", "菩提心", "日常功课", "空性理解"],
+        about: ["修行方法", "学佛修行", "因果", "佛学基本概念", "菩提心", "日常功课", "空性理解"],
       },
       {
         "@type": "BreadcrumbList",
@@ -285,6 +332,16 @@ export default function PracticeGuidePage() {
         "@type": "ItemList",
         name: "初学者常见修行方法",
         itemListElement: practiceMethods.map((item, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: item.titleZh,
+          description: item.descriptionZh,
+        })),
+      },
+      {
+        "@type": "ItemList",
+        name: "修行方法和概念之间的桥接路径",
+        itemListElement: conceptBridgeSteps.map((item, index) => ({
           "@type": "ListItem",
           position: index + 1,
           name: item.titleZh,
@@ -363,6 +420,12 @@ export default function PracticeGuidePage() {
             <LocalizedText
               zh="修行方法最后不只是在练几种技能。随着节奏慢慢稳定，人也会开始看见：很多急躁、执着和判断，并没有想象中那样固定，这也是为什么菩提心、六度和空性会和方法页放在同一条路上。方法越回到这里，练习就越不只是完成任务，而是在帮助自己少一点抓得太死。"
               en="Practice methods are not only a set of techniques. As the rhythm steadies, people often begin to see that agitation, attachment, and judgment are less fixed than they seem. This is why bodhicitta, the six paramitas, and emptiness belong on the same path as method pages. The more practice returns here, the less it becomes task-completion and the more it helps loosen rigid grasping."
+            />
+          </p>
+          <p>
+            <LocalizedText
+              zh="很多人练到这里以后，还会开始问：为什么我明明知道要修，节奏却总是断？为什么方法一多就又只剩任务感？为什么做着做着又会回到因果、菩提心、六度、空性这些概念？这通常不是跑题，而是说明方法页已经开始把人带到更深一点的理解层了。先回到佛学基本概念总览，再决定自己更该继续看哪一张概念页，往往会比只在方法页里硬撑更稳。"
+              en="At this point many people begin to ask why the rhythm keeps breaking even when they know they should practice, why methods turn back into tasks when they multiply, or why the path keeps returning to karma, bodhicitta, the six paramitas, and emptiness. This is usually not a distraction. It often means the methods page has already carried the reader into a deeper layer of understanding. Returning to the concepts hub first, then choosing the concept page that matches the friction, is often steadier than forcing everything to remain inside a methods page alone."
             />
           </p>
           <p>
@@ -452,6 +515,32 @@ export default function PracticeGuidePage() {
         </div>
       </section>
 
+      <section className="band feature-band">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="回到概念" en="Return to Concepts" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="练着练着又回到因果、菩提心、六度和空性，往往不是岔开，而是路径开始变深。"
+              en="When practice keeps returning to karma, bodhicitta, the six paramitas, and emptiness, the path is often deepening rather than drifting."
+            />
+          </h2>
+        </div>
+        <div className="feature-grid">
+          {conceptBridgeSteps.map((item) => (
+            <article key={item.titleEn} className="feature-card">
+              <h3>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </h3>
+              <p>
+                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="band">
         <div className="section-heading tight">
           <p>
@@ -509,8 +598,8 @@ export default function PracticeGuidePage() {
           <a className="primary-action" href={siteHref("/download")}>
             <LocalizedText zh="下载法布施" en="Download Fabushi" />
           </a>
-          <a className="secondary-action" href={siteHref("/start-learning-buddhism")}>
-            <LocalizedText zh="回到学佛从哪里开始" en="Back to Where to Begin" />
+          <a className="secondary-action" href={siteHref("/buddhist-concepts")}>
+            <LocalizedText zh="继续看佛学基本概念" en="Continue to Buddhist Concepts" />
           </a>
         </div>
       </section>


### PR DESCRIPTION
## 问题

官网当前的佛法内容结构已经不缺“修行方法页”本身：

- `/practice-guide`
- `/daily-practice`
- `/meditation`
- 以及已经成形的概念层：
  - `/buddhist-concepts`
  - `/what-is-karma`
  - `/what-is-bodhicitta`
  - `/what-are-the-six-paramitas`
  - `/what-is-emptiness`

但当前最高收益缺口，不再是继续新开一张泛实践页，而是让 `/practice-guide` 这张实践总览页更自然地把读者送回概念总览层。

在本次修改前，`/practice-guide` 虽然已经提到菩提心、六度、空性，也有若干概念叶子页链接，但还有两个结构性问题：

- 它没有把 `/buddhist-concepts` 这张概念总览页作为一个明确的下一步入口露出来
- 它也没有单独说明：为什么读者练着练着，会从“怎么修”重新回到“因果、菩提心、六度、空性是什么意思”这类概念问题

这会让这张页更像“方法清单总览”，而不是“方法页也能把人继续送进概念理解层”的桥接页。

## 这次改动

- 仅更新 `frontend/apps/web/src/app/practice-guide/page.tsx`
- 扩写 page description 与 keywords：
  - 显式补入 `因果`
  - 显式补入 `佛学基本概念`
- 在导读正文新增一段：
  - 明确说明练习进入一段时间后，读者常会从“怎么修”回到“为什么总断、为什么只剩任务感、为什么会回到概念问题”
  - 把这类回流解释成自然的下一层理解，而不是跑题
- 新增 `conceptBridgeSteps` 与整段 `回到概念` 区块：
  - `因果 -> 为什么方法要相续`
  - `菩提心 / 六度 -> 为什么方法不只是技巧`
  - `空性 / 概念总览 -> 为什么练习越往前走越需要更完整的理解地图`
- 扩充 `relatedPaths`：
  - 新增 `/buddhist-concepts`
  - 新增 `/what-is-karma`
- 扩充 JSON-LD：
  - `about` 补入 `因果 / 佛学基本概念`
  - 新增一个 `ItemList`，专门表达“修行方法和概念之间的桥接路径”
- 扩充 FAQ：
  - 新增 `因果是什么意思，和修行方法有什么关系？`
- 调整页尾 CTA：
  - 二级 CTA 从回到起步页，改成继续进入 `/buddhist-concepts`

## 为什么现在做

这一步的收益很集中：

- 不用再开新页，就能让实践总览页从“方法总览”升级为“方法页 -> 概念总览”的桥接页
- 同时补到：
  - 页面主题语义
  - 概念型问题覆盖
  - 固定内链深度
  - JSON-LD 结构化语义
  - 实践页与概念页之间的连续阅读路径
- 改动只收敛在一个文件里，风险和实施成本都低，但对现有实践流量的分发价值很直接

## 配图判断

- 本轮没有新增配图。
- 原因没有变化：当前佛法内容页线上稳定承载仍以长文本、FAQ、Breadcrumb / ItemList 为主，还没有已经验证过的佛法专题图承载位。
- 这小时更高收益的动作，是先把 `/practice-guide` 的语义桥接层和下一步分发层补完整，而不是先强行引入视觉元素。

## 验证

- compare 已确认分支相对 `main`：`ahead_by = 1`、`behind_by = 0`
- 改动范围只在 1 个文件：
  - `frontend/apps/web/src/app/practice-guide/page.tsx`
- 分支回读已确认页面现在包含：
  - 新的 `conceptBridgeSteps`
  - 新增的 `回到概念` 区块
  - 新增的 `/buddhist-concepts` 与 `/what-is-karma` 相关路径
  - 扩充后的 metadata / JSON-LD / FAQ / CTA
- 当前环境没有仓库本地 checkout，无法直接运行 Next.js 构建；最终检查仍依赖仓库现有 CI
- 不对排名结果作保证；这次改动的确定性收益在于加强实践总览页对概念型后续问题的覆盖、内部发现能力与内容连续性

## 下一步承接

- 如果这一页合并后继续沿实践集群推进，下一步最值得补的不是再开新的泛方法页，而是继续把 `/daily-practice` 也同步补成“功课安排 -> 因果 / 菩提心 / 空性”更明确的桥接页。