### PR TITLE
test(forum): align production public base URL assertion

### DIFF
--- a/.github/workflows/forum-container-checks.yml
+++ b/.github/workflows/forum-container-checks.yml
@@ -266,7 +266,7 @@ jobs:
 
           html = unescape(os.environ["FORUM_PRODUCTION_THREAD_LIST_PAGE"]).lower()
           assert 'index, follow' in html, html[:4000]
-          assert 'https://forum.fabushi.test/' in html, html[:4000]
+          assert 'https://forum.fabushi.test' in html, html[:4000]
           assert 'noindex' not in html, html[:5000]
           PY2
 


### PR DESCRIPTION
## 问题

当前 `PR #478` 的 `Container checks - Forum` 失败，并不是新加的 live preview write smoke check 本身炸了，而是旧的 production indexing 断言仍把 public base URL 硬编码成带尾斜杠的字符串匹配：

- 当前 production 线程列表页面已经正确输出：
  - `x-forum-deployment-stage: production`
  - `x-forum-indexing-enabled: true`
  - `x-forum-public-base-url: https://forum.fabushi.test`
  - `robots` 为 `Allow: /` 且带 `Host:`
  - 页面 `meta robots` 为 `index, follow`
- 但 workflow 仍要求 HTML 必须包含 `https://forum.fabushi.test/`
- 运行时 `resolveForumPublicBaseUrl()` 会主动去掉尾斜杠，因此现在页面里出现的是 `https://forum.fabushi.test`

这会把 production indexing contract 误判成失败，进而卡住与此无关的新 PR 合并。

## 这次改动

- 仅更新 `.github/workflows/forum-container-checks.yml`
- 把 production thread list HTML 断言从必须包含 `https://forum.fabushi.test/` 调整为确认包含 `https://forum.fabushi.test`
- 保持其他关键 contract 不变：
  - `index, follow`
  - 不含 `noindex`
  - response headers 中的 production/indexing/public-base-url 信号
  - `robots.txt` 中的 `Allow: /` 与 `Host:`

## 风险审查

- 这不是放松核心发布边界，只是去掉一个与当前运行时规范不一致的尾斜杠误杀
- production 是否可索引、是否暴露 public base URL、是否移除了 preview noindex，仍然都被继续校验
- 改动范围只在 1 个 workflow 文件，不触及论坛应用代码、部署逻辑或 live preview write smoke check 实现

## 验证

- 失败日志已确认：production 容器输出的 HTML 中存在 `https://forum.fabushi.test`，但没有 `https://forum.fabushi.test/`
- 同一份失败日志也确认其他 production 契约都已经满足：
  - `/api/health` 与 `/api/status` 为 `deploymentStage=production`
  - `indexingEnabled=true`
  - `x-forum-public-base-url: https://forum.fabushi.test`
  - `robots.txt` 为 `Allow: /` 且包含 `Host: https://forum.fabushi.test`
- 当前环境没有仓库本地 checkout，无法本地重跑 Actions；最终结果依赖仓库现有 `Container checks - Forum`

## 为什么现在做

这是一条主链路阻塞修复：

- 不先去掉这条尾斜杠误杀，`PR #478` 会继续被与自身无关的旧断言卡住
- 先把这条 contract check 调整到与当前 runtime 一致，才能继续判断 `#478` 本身是否稳定可合并