### PR TITLE
feat(forum): publish deployable forum image on main

### DIFF
--- a/.github/workflows/forum-publish-image.yml
+++ b/.github/workflows/forum-publish-image.yml
@@ -1,0 +1,68 @@
+name: Publish forum container image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "forum/**"
+      - ".github/workflows/forum-publish-image.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: forum-publish-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-forum-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout forum workspace only
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            forum
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive forum image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/bhrumom/fabushi-forum
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=main,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push forum container image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./forum
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Summarize published forum image tags
+        run: |
+          {
+            echo "## Published forum image"
+            echo
+            echo '```'
+            echo '${{ steps.meta.outputs.tags }}' | tr ',' '\n'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/forum/README.md
+++ b/forum/README.md
@@ -27,6 +27,7 @@ Current scope:
 - persisted author-role and newcomer-guidance signals for new threads and replies
 - a dedicated GitHub Actions workflow that checks the forum app when `forum/**` changes
 - a container deployment baseline built from Next.js standalone output
+- a GitHub Actions workflow that publishes versioned forum container images to GHCR whenever `main` accepts forum changes
 - a container healthcheck plus smoke checks that validate both the default sqlite read-only runtime and the explicitly writable sqlite runtime
 - a preview compose example that keeps sqlite on a mounted volume so data survives container restarts
 
@@ -211,15 +212,35 @@ If the preview runtime still requires a shared write-access code, store it in th
 
 This closes the gap between “container checks passed in CI” and “the actual preview or production forum URL is configured correctly”.
 
+## Published container image
+
+The forum no longer stops at a local `docker build`. The GitHub Actions workflow `Publish forum container image` now publishes a reusable GHCR image whenever `main` accepts changes under `forum/**`.
+
+Published tags:
+
+- `ghcr.io/bhrumom/fabushi-forum:sha-<commit>`
+- `ghcr.io/bhrumom/fabushi-forum:main`
+- `ghcr.io/bhrumom/fabushi-forum:latest`
+
+Use `workflow_dispatch` when you need to republish the current `main` image without waiting for another forum merge.
+
 ## Container deployment
 
-The app now builds with `output: "standalone"`, so deployment does not need the whole repository at runtime.
+The app now builds with `output: "standalone"`, so deployment does not need the whole repository at runtime. Mainline forum changes can now be consumed either from a local build or from the published GHCR image.
 
 Build and run locally with Docker:
 
 ```bash
 docker build -t fabushi-forum ./forum
 ```
+
+Or pull the current mainline image directly:
+
+```bash
+docker pull ghcr.io/bhrumom/fabushi-forum:main
+```
+
+In the examples below, replace `fabushi-forum` with `ghcr.io/bhrumom/fabushi-forum:main` if you want to run the published image instead of a local build.
 
 Run sqlite in durable read-only preview mode first:
 


### PR DESCRIPTION
## 问题

论坛现在已经具备：

- 独立 `forum/` 应用
- standalone 容器构建基线
- 容器 healthcheck 与 sqlite smoke checks
- 真实 preview / production URL 的 live deployment smoke check

但当前还缺少一条很关键的发布基线：

- 论坛镜像虽然能在 CI 里临时 build，却不会在主线稳定产出一个可复用的部署镜像
- 这意味着后续 preview / production 环境仍需要手工从仓库再 build，而不是直接拉取已验证的主线工件
- 当前最高收益缺口不再是继续补更多局部检查，而是把论坛推进到“主线自动产出可部署镜像”的状态

## 这次改动

- 新增 `.github/workflows/forum-publish-image.yml`
  - 在 `main` 接收 `forum/**` 相关变更时自动执行
  - 也支持手动 `workflow_dispatch`
  - 继续采用 sparse checkout，只拉 `.github` 与 `forum`
  - 登录 GHCR，并发布 `ghcr.io/bhrumom/fabushi-forum`
  - 输出 3 类标签：
    - `sha-<commit>`
    - `main`
    - `latest`
- 更新 `forum/README.md`
  - 明确论坛现在会自动产出 GHCR 镜像
  - 补 `docker pull ghcr.io/bhrumom/fabushi-forum:main`
  - 说明后续部署示例里可以直接用已发布镜像，而不必每次重新本地 build

## 为什么现在做

在容器检查、健康探针、preview gate、production indexing contract 和 live deployment smoke check 都已进入主线后，当前最高收益切片不再是再补一条局部断言，而是把论坛从“可构建”推进到“可直接拉取部署”。

这一步的收益很集中：

- 后续 preview / production 环境可以直接消费主线镜像
- live deployment smoke check 可以更自然地对齐到同一份已发布工件
- 论坛部署链条第一次真正具备“代码合入主线 -> 自动产出可部署镜像”的闭环雏形

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 2`、`behind_by = 0`
- 改动范围收敛在 2 个论坛相关文件：
  - `.github/workflows/forum-publish-image.yml`
  - `forum/README.md`
- 已回读分支内容确认：
  - 新工作流具备 `packages: write`
  - 只在 `main` 的论坛相关变更或手动触发时发布镜像
  - README 已补齐 GHCR 镜像拉取与使用说明
- 当前环境没有仓库本地 checkout，无法在本地直接运行 Actions；最终验证依赖仓库现有 GitHub Actions

## 下一步承接

- 待镜像发布工作流进入主线后，用该镜像在真实 preview 环境落一次可读部署
- 拿到真实 preview URL 后，先跑一次只读 live deployment checks，再在安全环境里选择性开启 `exercise_write_flow=true`
- 再继续收紧 preview / production 的实际部署入口与环境变量对齐