### PR TITLE
refactor(web): keep homepage download area focused

### DIFF
--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -182,29 +182,6 @@ const FAQ_PREVIEW = [
   },
 ] as const;
 
-const HERO_GUIDE_LINKS = [
-  {
-    href: "/start-learning-buddhism",
-    zh: "学佛从哪里开始",
-    en: "Where to Begin",
-  },
-  {
-    href: "/buddhist-concepts",
-    zh: "佛学基本概念",
-    en: "Buddhist Concepts",
-  },
-  {
-    href: "/practice-guide",
-    zh: "修行方法总览",
-    en: "Practice Guide",
-  },
-  {
-    href: "/sutra-guide",
-    zh: "佛经导读",
-    en: "Sutra Guide",
-  },
-] as const;
-
 const DHARMA_PATHS = [
   {
     href: "/start-learning-buddhism",
@@ -470,13 +447,10 @@ export default async function HomePage() {
               </span>
             </div>
             <h1 id="home-title">
-              <LocalizedText zh="学佛，从今天的一小步开始。" en="Begin buddhadharma with one small step." />
+              <LocalizedText zh="全球法布施" en="Global Dharma Sharing" />
             </h1>
             <p className="hero-subtitle">
-              <LocalizedText
-                zh="从学佛入门、佛学基本概念、因果、菩提心、六度与空性，到经文听诵、禅修、日常功课与全球法布施，先把学习路径和练习工具放回同一个入口。"
-                en="From beginner dharma questions and a clearer concepts hub to sutra listening, meditation, daily rhythm, and global giving, Fabushi keeps learning paths and practice tools inside one entry point."
-              />
+              <LocalizedText zh="让善意跨越地域，流向世界各地。" en="Let compassion travel across regions and reach the world." />
             </p>
             <div className="hero-actions">
               {androidBetaChannel ? (
@@ -498,19 +472,6 @@ export default async function HomePage() {
                 </a>
               )}
             </div>
-            <div className="release-section-stack" aria-label="Dharma learning shortcuts / 学佛入口">
-              <p className="eyebrow">
-                <LocalizedText zh="先从这些入口开始" en="Start with these paths" />
-              </p>
-              <div className="site-nav-links">
-                {HERO_GUIDE_LINKS.map((item) => (
-                  <a key={item.href} href={siteHref(item.href)}>
-                    <LocalizedText zh={item.zh} en={item.en} />
-                  </a>
-                ))}
-              </div>
-            </div>
-
             <div className="release-pill-grid" aria-label="Current download status / 当前下载状态">
               {channels.length > 0 ? (
                 channels.map((item) => {


### PR DESCRIPTION
## 问题

官网首页首屏下载链路附近同时混入了学佛内容入口，导致下载相关信息周围出现不相干的分流。

同时，首屏主文案仍停留在“学佛，从今天的一小步开始”，不符合这次希望强调的“全球法布施”表达，下面的说明句也偏长。

## 这次改动

- 仅更新 `frontend/apps/web/src/app/page.tsx`
- 移除首屏下载按钮与下载状态区附近的 `学佛入口` 快捷链
- 将首屏主标题改为 `全球法布施`
- 将标题下方说明精简为一句更短的文案：`让善意跨越地域，流向世界各地。`
- 保留现有下载按钮、下载状态卡片、下载区块与后续学佛路径内容，不做额外结构扩散

## 预期效果

- 下载相关内容周围只保留下载链路本身，首页首屏更聚焦
- 主视觉表达从“学佛第一步”切换为“全球法布施”，与当前想强调的产品感受对齐
- 副文案更短，阅读负担更轻

## 验证

- 改动范围收敛在 1 个文件
- 当前环境没有仓库本地 checkout，无法直接跑前端构建；最终以仓库 CI 为准
