### PR TITLE
feat(forum): add deploy compose for published forum image

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -1,0 +1,116 @@
+name: Deploy compose checks - Forum
+
+on:
+  pull_request:
+    paths:
+      - "forum/docker-compose.deploy.yml"
+      - "forum/.env.deploy.example"
+      - "forum/DEPLOY.md"
+      - ".github/workflows/forum-deploy-compose-checks.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "forum/docker-compose.deploy.yml"
+      - "forum/.env.deploy.example"
+      - "forum/DEPLOY.md"
+      - ".github/workflows/forum-deploy-compose-checks.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  forum-deploy-compose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout forum workspace only
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            forum
+          fetch-depth: 1
+
+      - name: Build forum container image
+        run: docker build -t fabushi-forum ./forum
+
+      - name: Prepare deploy compose sqlite workspace
+        run: |
+          rm -rf /tmp/fabushi-forum-deploy-compose-data
+          mkdir -p /tmp/fabushi-forum-deploy-compose-data
+
+      - name: Start forum deploy compose with local image override
+        run: |
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          FORUM_PORT=3001 \
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
+          docker compose -f forum/docker-compose.deploy.yml up -d
+
+      - name: Wait for forum deploy compose health endpoint
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if curl --fail --show-error --silent http://127.0.0.1:3001/api/health >/tmp/forum-deploy-health.json; then
+              break
+            fi
+
+            sleep 3
+          done
+
+          cat /tmp/forum-deploy-health.json
+
+      - name: Smoke test forum deploy compose preview runtime
+        run: |
+          health_response="$(cat /tmp/forum-deploy-health.json)"
+          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY2'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_HEALTH_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["ready"] is True, payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["deploymentStage"] == "preview", payload
+          assert payload["indexingEnabled"] is False, payload
+          assert payload["publicBaseUrlConfigured"] is False, payload
+          assert payload["writesEnabled"] is False, payload
+          assert payload["requiresAccessCode"] is False, payload
+          PY2
+
+          status_response="$(curl --fail --show-error --silent http://127.0.0.1:3001/api/status)"
+          echo "$status_response"
+          FORUM_STATUS_RESPONSE="$status_response" python3 - <<'PY2'
+          import json
+          import os
+
+          payload = json.loads(os.environ["FORUM_STATUS_RESPONSE"])
+          assert payload["service"] == "forum", payload
+          assert payload["dataSource"] == "sqlite", payload
+          assert payload["persistenceMode"] == "sqlite-file", payload
+          assert payload["deploymentStage"] == "preview", payload
+          assert payload["indexingEnabled"] is False, payload
+          assert payload["writesEnabled"] is False, payload
+          assert payload["requiresAccessCode"] is False, payload
+          assert payload["counts"]["threads"] >= 4, payload
+          assert payload["counts"]["moderationEvents"] >= 4, payload
+          PY2
+
+          robots_response="$(curl --fail --show-error --silent http://127.0.0.1:3001/robots.txt)"
+          echo "$robots_response"
+          FORUM_ROBOTS_RESPONSE="$robots_response" python3 - <<'PY2'
+          import os
+
+          payload = os.environ["FORUM_ROBOTS_RESPONSE"]
+          assert "User-Agent: *" in payload, payload
+          assert "Disallow: /" in payload, payload
+          PY2
+
+      - name: Stop forum deploy compose
+        if: always()
+        run: |
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          FORUM_PORT=3001 \
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
+          docker compose -f forum/docker-compose.deploy.yml down -v || true

--- a/forum/.env.deploy.example
+++ b/forum/.env.deploy.example
@@ -1,0 +1,20 @@
+# Published forum image tag or digest to deploy.
+FORUM_IMAGE=ghcr.io/bhrumom/fabushi-forum:main
+
+# Host port that should expose the forum container.
+FORUM_PORT=3000
+
+# Local host path that should keep sqlite durable across restarts.
+FORUM_DATA_DIR=./data
+
+# preview keeps the forum noindex. Switch to production only together with
+# FORUM_PUBLIC_BASE_URL when the public origin is ready to be indexed.
+FORUM_DEPLOYMENT_STAGE=preview
+FORUM_PUBLIC_BASE_URL=
+
+# The forum currently deploys around sqlite durable storage by default.
+FORUM_DATA_SOURCE=sqlite
+FORUM_ENABLE_WRITES=false
+
+# Optional shared write gate for writable preview cohorts.
+FORUM_WRITE_ACCESS_CODE=

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -1,0 +1,101 @@
+# Deploy Fabushi Forum From The Published Image
+
+This guide turns the forum's published GHCR image into a repeatable preview or production runtime without rebuilding the repository on the target host.
+
+## Files involved
+
+- `docker-compose.deploy.yml`
+- `.env.deploy.example`
+
+Copy the example environment file first:
+
+```bash
+cd forum
+cp .env.deploy.example .env.deploy
+```
+
+Then edit `.env.deploy` for the target runtime.
+
+## Preview baseline
+
+Keep the safe default first:
+
+```dotenv
+FORUM_IMAGE=ghcr.io/bhrumom/fabushi-forum:main
+FORUM_PORT=3000
+FORUM_DATA_DIR=./data
+FORUM_DEPLOYMENT_STAGE=preview
+FORUM_PUBLIC_BASE_URL=
+FORUM_DATA_SOURCE=sqlite
+FORUM_ENABLE_WRITES=false
+FORUM_WRITE_ACCESS_CODE=
+```
+
+Start the forum:
+
+```bash
+docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
+curl http://localhost:3000/api/health
+curl http://localhost:3000/api/status
+curl http://localhost:3000/robots.txt
+```
+
+Expected preview signals:
+
+- `/api/health` returns `ready: true`
+- `/api/status` reports `deploymentStage=preview`
+- `robots.txt` contains `Disallow: /`
+- sqlite stays durable but read-only until writes are explicitly opened
+
+## Writable preview cohort
+
+Only open writes when the preview runtime is ready to accept real submissions.
+
+```dotenv
+FORUM_ENABLE_WRITES=true
+FORUM_WRITE_ACCESS_CODE=forum-preview-2026
+```
+
+After restarting the compose stack, the runtime stays preview-only and still requires the shared code before thread or reply creation succeeds.
+
+## Production indexing runtime
+
+Switch the deployment boundary only when the public origin is ready:
+
+```dotenv
+FORUM_DEPLOYMENT_STAGE=production
+FORUM_PUBLIC_BASE_URL=https://forum.fabushi.com
+FORUM_ENABLE_WRITES=false
+```
+
+Bring the stack back up and verify:
+
+```bash
+docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
+curl http://localhost:3000/api/health
+curl http://localhost:3000/api/status
+curl http://localhost:3000/robots.txt
+curl -I http://localhost:3000/threads
+```
+
+Expected production signals:
+
+- `/api/health` and `/api/status` both report `deploymentStage=production`
+- indexing becomes enabled only after `FORUM_PUBLIC_BASE_URL` is also set
+- `robots.txt` switches to `Allow: /` and includes the configured `Host:`
+- page responses stop emitting the preview `x-robots-tag`
+
+## Rolling to a newer forum image
+
+Update only the image tag in `.env.deploy`, then refresh the stack:
+
+```dotenv
+FORUM_IMAGE=ghcr.io/bhrumom/fabushi-forum:sha-<commit>
+```
+
+```bash
+docker compose --env-file .env.deploy -f docker-compose.deploy.yml pull
+docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
+```
+
+This keeps the deploy path aligned with the already published forum artifact instead of rebuilding from source on the server.

--- a/forum/docker-compose.deploy.yml
+++ b/forum/docker-compose.deploy.yml
@@ -1,0 +1,25 @@
+services:
+  forum:
+    image: "${FORUM_IMAGE:-ghcr.io/bhrumom/fabushi-forum:main}"
+    ports:
+      - "${FORUM_PORT:-3000}:3000"
+    environment:
+      FORUM_DEPLOYMENT_STAGE: "${FORUM_DEPLOYMENT_STAGE:-preview}"
+      FORUM_PUBLIC_BASE_URL: "${FORUM_PUBLIC_BASE_URL:-}"
+      FORUM_DATA_SOURCE: "${FORUM_DATA_SOURCE:-sqlite}"
+      FORUM_ENABLE_WRITES: "${FORUM_ENABLE_WRITES:-false}"
+      FORUM_DATABASE_URL: file:/data/forum.db
+      FORUM_WRITE_ACCESS_CODE: "${FORUM_WRITE_ACCESS_CODE:-}"
+    volumes:
+      - "${FORUM_DATA_DIR:-./data}:/data"
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:3000/api/health').then((response) => { process.exit(response.ok ? 0 : 1); }).catch(() => process.exit(1));"
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 5
+    restart: unless-stopped


### PR DESCRIPTION
## 问题

论坛现在已经具备：

- 独立 `forum/` 应用
- GHCR 主线镜像发布
- sqlite / preview gate / indexing contract / live smoke checks

但仓库里还缺一块很实际的部署闭环：

- 已发布镜像可以被拉取，却没有一份现成的运行配置把它直接变成 preview 或 production 运行态
- 这意味着后续部署仍然要在服务器上重新拼环境变量、卷挂载和健康检查，而不是直接复用仓库里的成型配置
- 当前最高收益缺口不再是继续补更多局部断言，而是把“已发布镜像如何真正跑起来”收成最小可复用基线

## 这次改动

- 新增 `forum/docker-compose.deploy.yml`
  - 默认消费 `ghcr.io/bhrumom/fabushi-forum:main`
  - 用显式环境变量承接 preview / production 部署契约、sqlite 持久化和可选写入口令
  - 保留和容器主线一致的 `/api/health` 健康检查与 `restart: unless-stopped`
- 新增 `forum/.env.deploy.example`
  - 把镜像标签、端口、数据目录、deployment stage、public base URL、sqlite 默认只读和 preview 口令 gate 一起收成部署样例
- 新增 `forum/DEPLOY.md`
  - 补“发布镜像 -> preview 基线 -> 可写 preview -> production indexing -> 镜像滚动更新”的直接运行说明
- 新增 `.github/workflows/forum-deploy-compose-checks.yml`
  - 用本地构建的论坛镜像覆盖 `FORUM_IMAGE`
  - 启动新的 deploy compose
  - 自动校验 `/api/health`、`/api/status` 和 `robots.txt` 是否仍对齐 preview + sqlite 只读基线

## 为什么现在做

在论坛已经有镜像发布与真实 URL smoke check 之后，当前最小关键改动不是再加一条说明文档，而是把“可部署工件”真正收成服务器可以直接复用的运行配置。

这一步的收益很集中：

- preview 或 production 服务器可以直接用仓库现成 compose 起论坛，而不是重新手写运行参数
- 已发布镜像、部署契约和健康检查终于落到同一条实际运行路径上
- 新的 deploy compose 也开始有自己的自动检查，不会只停留在文档层

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 4`、`behind_by = 0`
- 改动范围收敛在 4 个文件：
  - `.github/workflows/forum-deploy-compose-checks.yml`
  - `forum/.env.deploy.example`
  - `forum/DEPLOY.md`
  - `forum/docker-compose.deploy.yml`
- 新 workflow 会自动验证 deploy compose 启动后的 preview 只读运行态是否仍返回正确的 `/api/health`、`/api/status` 与 `robots.txt` 信号
- 当前环境无法本地 checkout 仓库，也无法在这里直接运行 GitHub Actions；最终检查仍依赖仓库 Actions

## 下一步承接

- 等这条 deploy compose 基线进入主线后，优先在真实 preview 主机上按 `.env.deploy` 方式拉起论坛
- 拿到真实 preview URL 后，先跑 `Live deployment checks - Forum` 的只读契约检查
- 确认环境安全后，再选择性开启 `exercise_write_flow=true` 验证真实 preview 写入闭环