### PR TITLE
test(forum): verify deploy compose runtime matrix

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -6,6 +6,7 @@ on:
       - "forum/docker-compose.deploy.yml"
       - "forum/.env.deploy.example"
       - "forum/DEPLOY.md"
+      - "forum/scripts/check-deployment-contract.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
   push:
     branches:
@@ -14,6 +15,7 @@ on:
       - "forum/docker-compose.deploy.yml"
       - "forum/.env.deploy.example"
       - "forum/DEPLOY.md"
+      - "forum/scripts/check-deployment-contract.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
 
 permissions:
@@ -39,7 +41,7 @@ jobs:
           rm -rf /tmp/fabushi-forum-deploy-compose-data
           mkdir -p /tmp/fabushi-forum-deploy-compose-data
 
-      - name: Start forum deploy compose with local image override
+      - name: Start forum deploy compose in sqlite read-only preview mode
         run: |
           COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
           FORUM_IMAGE=fabushi-forum \
@@ -47,8 +49,10 @@ jobs:
           FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
           docker compose -f forum/docker-compose.deploy.yml up -d
 
-      - name: Wait for forum deploy compose health endpoint
+      - name: Wait for forum deploy compose read-only preview health endpoint
         run: |
+          rm -f /tmp/forum-deploy-health.json
+
           for attempt in 1 2 3 4 5 6; do
             if curl --fail --show-error --silent http://127.0.0.1:3001/api/health >/tmp/forum-deploy-health.json; then
               break
@@ -59,52 +63,108 @@ jobs:
 
           cat /tmp/forum-deploy-health.json
 
-      - name: Smoke test forum deploy compose preview runtime
+      - name: Smoke test forum deploy compose read-only preview contract
         run: |
-          health_response="$(cat /tmp/forum-deploy-health.json)"
-          FORUM_HEALTH_RESPONSE="$health_response" python3 - <<'PY2'
-          import json
-          import os
+          node forum/scripts/check-deployment-contract.mjs \
+            --url http://127.0.0.1:3001 \
+            --deployment-stage preview \
+            --writes-enabled false \
+            --requires-access-code false
 
-          payload = json.loads(os.environ["FORUM_HEALTH_RESPONSE"])
-          assert payload["service"] == "forum", payload
-          assert payload["ready"] is True, payload
-          assert payload["dataSource"] == "sqlite", payload
-          assert payload["persistenceMode"] == "sqlite-file", payload
-          assert payload["deploymentStage"] == "preview", payload
-          assert payload["indexingEnabled"] is False, payload
-          assert payload["publicBaseUrlConfigured"] is False, payload
-          assert payload["writesEnabled"] is False, payload
-          assert payload["requiresAccessCode"] is False, payload
-          PY2
+      - name: Stop forum deploy compose read-only preview runtime
+        run: |
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          FORUM_PORT=3001 \
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
+          docker compose -f forum/docker-compose.deploy.yml down -v
 
-          status_response="$(curl --fail --show-error --silent http://127.0.0.1:3001/api/status)"
-          echo "$status_response"
-          FORUM_STATUS_RESPONSE="$status_response" python3 - <<'PY2'
-          import json
-          import os
+      - name: Reset deploy compose sqlite workspace before writable preview
+        run: |
+          rm -rf /tmp/fabushi-forum-deploy-compose-data
+          mkdir -p /tmp/fabushi-forum-deploy-compose-data
 
-          payload = json.loads(os.environ["FORUM_STATUS_RESPONSE"])
-          assert payload["service"] == "forum", payload
-          assert payload["dataSource"] == "sqlite", payload
-          assert payload["persistenceMode"] == "sqlite-file", payload
-          assert payload["deploymentStage"] == "preview", payload
-          assert payload["indexingEnabled"] is False, payload
-          assert payload["writesEnabled"] is False, payload
-          assert payload["requiresAccessCode"] is False, payload
-          assert payload["counts"]["threads"] >= 4, payload
-          assert payload["counts"]["moderationEvents"] >= 4, payload
-          PY2
+      - name: Start forum deploy compose in sqlite writable preview mode
+        run: |
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          FORUM_PORT=3001 \
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
+          FORUM_ENABLE_WRITES=true \
+          FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+          docker compose -f forum/docker-compose.deploy.yml up -d
 
-          robots_response="$(curl --fail --show-error --silent http://127.0.0.1:3001/robots.txt)"
-          echo "$robots_response"
-          FORUM_ROBOTS_RESPONSE="$robots_response" python3 - <<'PY2'
-          import os
+      - name: Wait for forum deploy compose writable preview health endpoint
+        run: |
+          rm -f /tmp/forum-deploy-health.json
 
-          payload = os.environ["FORUM_ROBOTS_RESPONSE"]
-          assert "User-Agent: *" in payload, payload
-          assert "Disallow: /" in payload, payload
-          PY2
+          for attempt in 1 2 3 4 5 6; do
+            if curl --fail --show-error --silent http://127.0.0.1:3001/api/health >/tmp/forum-deploy-health.json; then
+              break
+            fi
+
+            sleep 3
+          done
+
+          cat /tmp/forum-deploy-health.json
+
+      - name: Smoke test forum deploy compose writable preview contract
+        run: |
+          FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+          node forum/scripts/check-deployment-contract.mjs \
+            --url http://127.0.0.1:3001 \
+            --deployment-stage preview \
+            --writes-enabled true \
+            --requires-access-code true \
+            --exercise-write-flow true
+
+      - name: Stop forum deploy compose writable preview runtime
+        run: |
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          FORUM_PORT=3001 \
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
+          FORUM_ENABLE_WRITES=true \
+          FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
+          docker compose -f forum/docker-compose.deploy.yml down -v
+
+      - name: Reset deploy compose sqlite workspace before production runtime
+        run: |
+          rm -rf /tmp/fabushi-forum-deploy-compose-data
+          mkdir -p /tmp/fabushi-forum-deploy-compose-data
+
+      - name: Start forum deploy compose in sqlite production indexing mode
+        run: |
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          FORUM_PORT=3001 \
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
+          FORUM_DEPLOYMENT_STAGE=production \
+          FORUM_PUBLIC_BASE_URL=https://forum.fabushi.test \
+          docker compose -f forum/docker-compose.deploy.yml up -d
+
+      - name: Wait for forum deploy compose production health endpoint
+        run: |
+          rm -f /tmp/forum-deploy-health.json
+
+          for attempt in 1 2 3 4 5 6; do
+            if curl --fail --show-error --silent http://127.0.0.1:3001/api/health >/tmp/forum-deploy-health.json; then
+              break
+            fi
+
+            sleep 3
+          done
+
+          cat /tmp/forum-deploy-health.json
+
+      - name: Smoke test forum deploy compose production indexing contract
+        run: |
+          node forum/scripts/check-deployment-contract.mjs \
+            --url http://127.0.0.1:3001 \
+            --deployment-stage production \
+            --public-base-url https://forum.fabushi.test \
+            --writes-enabled false \
+            --requires-access-code false
 
       - name: Stop forum deploy compose
         if: always()

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -7,6 +7,12 @@ This guide turns the forum's published GHCR image into a repeatable preview or p
 - `docker-compose.deploy.yml`
 - `.env.deploy.example`
 
+The repository workflow `Deploy compose checks - Forum` now boots this same compose path in three deployment postures so the server-facing runtime stays covered in CI:
+
+- sqlite read-only preview
+- sqlite writable preview with a shared write-access code
+- sqlite production indexing with an explicit public base URL
+
 Copy the example environment file first:
 
 ```bash


### PR DESCRIPTION
## 问题

论坛现在已经有一条面向真实主机的 deploy compose 路径：

- `forum/docker-compose.deploy.yml`
- `forum/.env.deploy.example`
- `forum/DEPLOY.md`
- `Deploy compose checks - Forum`

但这条路径在仓库里还只验证了最保守的一种姿态：`preview + sqlite 只读`。

这意味着后续真正部署时，另外两段同样关键的运行边界仍然没有被同一条 server-facing 路径自动守住：

- `preview + FORUM_ENABLE_WRITES=true + FORUM_WRITE_ACCESS_CODE`
- `production + FORUM_PUBLIC_BASE_URL`

当前最高收益缺口不是再补一份部署说明，而是让这条真正会被服务器复用的 compose 路径，也能对齐论坛现在已有的三段 rollout contract。

## 这次改动

- 更新 `.github/workflows/forum-deploy-compose-checks.yml`
  - 把触发范围补到 `forum/scripts/check-deployment-contract.mjs`，避免 deploy compose workflow 和 deployment smoke script 漂移
  - 保留 sqlite 只读 preview compose 检查
  - 新增带共享写入口令的 writable preview compose 检查
  - 新增 `production + FORUM_PUBLIC_BASE_URL` 的 production indexing compose 检查
  - 三段检查都开始直接复用 `forum/scripts/check-deployment-contract.mjs`
- 更新 `forum/DEPLOY.md`
  - 明确仓库现在会自动验证三种 deploy compose 运行姿态：
    - sqlite read-only preview
    - sqlite writable preview with shared write-access code
    - sqlite production indexing with explicit public base URL

## 为什么现在做

论坛当前已经具备：

- GHCR 主线镜像发布
- deploy compose 基线
- live deployment smoke check
- writable preview gate
- production indexing contract

所以当前最小关键改动，不再是继续补局部断言，而是让 `deploy compose` 这条真正面向服务器的运行路径也和现有 rollout contract 对齐。

这样做的直接收益是：

- 服务器实际会走的 compose 路径，不再只验证“能启动”
- preview 从只读到小范围可写，再到 production 可索引，这三段边界都开始被同一条 deploy path 自动守住
- deploy compose workflow 与 live deployment smoke script 复用同一套 contract 检查逻辑，后续维护更稳

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 2`、`behind_by = 0`
- 改动范围收敛在 2 个文件：
  - `.github/workflows/forum-deploy-compose-checks.yml`
  - `forum/DEPLOY.md`
- 分支回读已确认：
  - deploy compose workflow 已覆盖 read-only preview / writable preview / production indexing 三段运行态
  - writable preview 检查会带 `FORUM_WRITE_ACCESS_CODE=forum-preview-2026` 并执行最小真实主题 / 回复闭环
  - production compose 检查会校验 `FORUM_PUBLIC_BASE_URL=https://forum.fabushi.test` 的 indexing contract
  - `forum/DEPLOY.md` 已明确说明这三种姿态已纳入仓库 CI
- 当前环境没有仓库本地 checkout，无法在这里直接运行 GitHub Actions；最终验证仍依赖仓库现有 CI

## 下一步承接

- 等这条三段式 deploy compose 检查进入主线后，最高优先级就更明确收敛到真实 preview 地址：
  1. 在真实主机按 `.env.deploy` + `docker-compose.deploy.yml` 拉起论坛
  2. 先跑只读 `Live deployment checks - Forum`
  3. 再在安全环境里开启 `exercise_write_flow=true` 验证真实 preview 写入闭环