### PR TITLE
feat(forum): schedule hourly live deployment smoke checks

### DIFF
--- a/.github/workflows/forum-live-deployment-checks.yml
+++ b/.github/workflows/forum-live-deployment-checks.yml
@@ -1,6 +1,8 @@
 name: Live deployment checks - Forum
 
 on:
+  schedule:
+    - cron: "17 * * * *"
   workflow_dispatch:
     inputs:
       forum_url:
@@ -47,6 +49,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: forum-live-deployment-checks
+  cancel-in-progress: false
+
 jobs:
   forum-live-deployment:
     runs-on: ubuntu-latest
@@ -66,12 +72,58 @@ jobs:
         with:
           node-version: 24
 
+      - name: Resolve live forum target
+        id: resolve
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            forum_url="${{ inputs.forum_url }}"
+            deployment_stage="${{ inputs.deployment_stage }}"
+            public_base_url="${{ inputs.public_base_url }}"
+            writes_enabled="${{ inputs.writes_enabled }}"
+            requires_access_code="${{ inputs.requires_access_code }}"
+            exercise_write_flow="${{ inputs.exercise_write_flow }}"
+          else
+            forum_url="${{ vars.FORUM_LIVE_URL }}"
+            deployment_stage="${{ vars.FORUM_LIVE_DEPLOYMENT_STAGE }}"
+            public_base_url="${{ vars.FORUM_LIVE_PUBLIC_BASE_URL }}"
+            writes_enabled="${{ vars.FORUM_LIVE_WRITES_ENABLED }}"
+            requires_access_code="${{ vars.FORUM_LIVE_REQUIRES_ACCESS_CODE }}"
+            exercise_write_flow="${{ vars.FORUM_LIVE_EXERCISE_WRITE_FLOW }}"
+          fi
+
+          if [[ -z "$forum_url" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=No forum URL configured for scheduled live deployment checks." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          deployment_stage="${deployment_stage:-preview}"
+          writes_enabled="${writes_enabled:-false}"
+          requires_access_code="${requires_access_code:-false}"
+          exercise_write_flow="${exercise_write_flow:-false}"
+
+          {
+            echo "skip=false"
+            echo "forum_url=$forum_url"
+            echo "deployment_stage=$deployment_stage"
+            echo "public_base_url=$public_base_url"
+            echo "writes_enabled=$writes_enabled"
+            echo "requires_access_code=$requires_access_code"
+            echo "exercise_write_flow=$exercise_write_flow"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip scheduled check when live target is not configured
+        if: steps.resolve.outputs.skip == 'true'
+        run: echo "${{ steps.resolve.outputs.reason }}"
+
       - name: Smoke test live forum deployment contract
+        if: steps.resolve.outputs.skip != 'true'
         run: |
           node forum/scripts/check-deployment-contract.mjs \
-            --url "${{ inputs.forum_url }}" \
-            --deployment-stage "${{ inputs.deployment_stage }}" \
-            --public-base-url "${{ inputs.public_base_url }}" \
-            --writes-enabled "${{ inputs.writes_enabled }}" \
-            --requires-access-code "${{ inputs.requires_access_code }}" \
-            --exercise-write-flow "${{ inputs.exercise_write_flow }}"
+            --url "${{ steps.resolve.outputs.forum_url }}" \
+            --deployment-stage "${{ steps.resolve.outputs.deployment_stage }}" \
+            --public-base-url "${{ steps.resolve.outputs.public_base_url }}" \
+            --writes-enabled "${{ steps.resolve.outputs.writes_enabled }}" \
+            --requires-access-code "${{ steps.resolve.outputs.requires_access_code }}" \
+            --exercise-write-flow "${{ steps.resolve.outputs.exercise_write_flow }}"

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -22,6 +22,42 @@ cp .env.deploy.example .env.deploy
 
 Then edit `.env.deploy` for the target runtime.
 
+## Hourly live deployment checks
+
+The repository workflow `Live deployment checks - Forum` can now run every hour against one configured live forum target. This turns the current highest-priority deployment question from a manual reminder into a standing smoke check.
+
+Scheduled runs read these repository variables:
+
+- `FORUM_LIVE_URL`
+- `FORUM_LIVE_DEPLOYMENT_STAGE`
+- `FORUM_LIVE_PUBLIC_BASE_URL`
+- `FORUM_LIVE_WRITES_ENABLED`
+- `FORUM_LIVE_REQUIRES_ACCESS_CODE`
+- `FORUM_LIVE_EXERCISE_WRITE_FLOW`
+
+If the live target still requires the shared preview code, also store it in the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE`.
+
+Recommended preview baseline:
+
+```text
+FORUM_LIVE_URL=https://forum-preview.example.com
+FORUM_LIVE_DEPLOYMENT_STAGE=preview
+FORUM_LIVE_PUBLIC_BASE_URL=
+FORUM_LIVE_WRITES_ENABLED=false
+FORUM_LIVE_REQUIRES_ACCESS_CODE=false
+FORUM_LIVE_EXERCISE_WRITE_FLOW=false
+```
+
+When preview writes are intentionally open behind the shared code, switch only the runtime flags you actually expect:
+
+```text
+FORUM_LIVE_WRITES_ENABLED=true
+FORUM_LIVE_REQUIRES_ACCESS_CODE=true
+FORUM_LIVE_EXERCISE_WRITE_FLOW=true
+```
+
+If `FORUM_LIVE_URL` is still empty, the hourly workflow exits cleanly without failing. Manual `workflow_dispatch` runs keep working with the explicit inputs.
+
 ## Preview baseline
 
 Keep the safe default first:


### PR DESCRIPTION
## 问题

论坛已经有 `Live deployment checks - Forum`，但它还停留在手动触发层：

- 真实 preview 地址拿到以后，仓库不会自己持续验证部署契约
- 当前最高优先级已经收敛到“真实地址验证”，但还缺少一条按小时重复执行的仓库内路径
- 如果还没有配置真实 live target，我们又不希望为了这件事把仓库周期性打红

## 这次改动

- 更新 `.github/workflows/forum-live-deployment-checks.yml`
  - 新增每小时一次的 `schedule` 触发
  - 保留原有 `workflow_dispatch` 手动输入路径
  - 为定时运行新增 live target 解析步骤，改为从仓库变量读取：
    - `FORUM_LIVE_URL`
    - `FORUM_LIVE_DEPLOYMENT_STAGE`
    - `FORUM_LIVE_PUBLIC_BASE_URL`
    - `FORUM_LIVE_WRITES_ENABLED`
    - `FORUM_LIVE_REQUIRES_ACCESS_CODE`
    - `FORUM_LIVE_EXERCISE_WRITE_FLOW`
  - 继续通过仓库 secret `FORUM_LIVE_WRITE_ACCESS_CODE` 承接 preview 写入口令
  - 若尚未配置 `FORUM_LIVE_URL`，工作流会安全跳过，而不是失败
- 更新 `forum/DEPLOY.md`
  - 补齐 hourly live deployment checks 的变量约定
  - 补齐 preview 推荐基线
  - 说明何时打开 preview 写入闭环检查

## 为什么现在做

在 deploy compose 三段自动验证和 live preview write-flow 手动检查都已经进入主线后，当前最缺的不是再补一个本地示例，而是把“真实地址验证”从记忆里的待办推进成仓库自己的持续机制。

这一步的收益很集中：

- 一旦真实 preview 地址可用，只需要填入仓库变量，小时级 smoke check 就会开始接管持续验证
- 真实目标尚未配置时，仓库不会因此产生无意义失败
- 手动触发路径仍保留，production indexing 和有意开启的 preview 写入闭环都还能沿用同一条 workflow

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 2`、`behind_by = 0`
- 改动范围收敛在 2 个论坛部署相关文件：
  - `.github/workflows/forum-live-deployment-checks.yml`
  - `forum/DEPLOY.md`
- 已回读分支内容确认：
  - 定时运行在 `FORUM_LIVE_URL` 缺失时会安全跳过
  - 手动输入路径仍保留
  - deploy 文档已对齐新的仓库变量与 secret 约定
- 当前环境没有仓库本地 checkout，无法在这里直接运行 GitHub Actions
- 最终检查仍依赖仓库 CI，以及后续把真实 preview 地址与期望运行态变量填入仓库配置

## 下一步承接

- 在仓库里配置真实 preview URL 和对应的 live runtime 变量
- 先让 hourly workflow 跑通只读 preview 契约
- preview 可写且安全时，再把 `FORUM_LIVE_EXERCISE_WRITE_FLOW=true` 打开，让小时级检查开始覆盖真实发帖 / 回复闭环