### PR TITLE
feat(web): connect emptiness page to concepts and practice cluster

### DIFF
--- a/frontend/apps/web/src/app/what-is-emptiness/page.tsx
+++ b/frontend/apps/web/src/app/what-is-emptiness/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const pageUrl = siteUrl("/what-is-emptiness");
 const pageTitle = `空性怎么理解 | ${brand.name}`;
 const pageDescription =
-  "面向初学者梳理空性怎么理解：空性不是什么都没有，也不是把世界否定掉，而是帮助人看见一切法因缘和合、没有固定不变的自性，让执着、烦恼和判断慢慢松开。";
+  "面向初学者梳理空性怎么理解：空性不是什么都没有，也不是把世界否定掉，而是帮助人看见一切法因缘和合、没有固定不变的自性，并把《心经》里常遇到的“空”接回六度、菩提心、佛学基本概念与日常练习。";
 
 const emptinessFoundations = [
   {
@@ -73,6 +73,36 @@ const conceptBlocks = [
   },
 ] as const;
 
+const scriptureBridgeSteps = [
+  {
+    href: "/beginner-sutra-recommendations",
+    labelZh: "从《心经》接到空性",
+    labelEn: "Heart Sutra to Emptiness",
+    titleZh: "如果你是先在《心经》里反复碰到“空”这个字，下一步先把它从熟悉的经句接回更可用的理解。",
+    titleEn: "If the Heart Sutra is where the word emptiness first keeps returning, the next step is to bring it from familiar lines into more usable understanding.",
+    descriptionZh: "很多人第一次真正碰到空性，不是在概念页里，而是在《心经》或般若类经典的语言里。把这一步说清楚，经典阅读才不容易只停在声音熟悉，却始终不敢继续往前。",
+    descriptionEn: "Many people first truly meet emptiness not on a concept page, but in the language of the Heart Sutra or other wisdom texts. Clarifying that bridge helps scripture study move beyond familiar sound into real continuation.",
+  },
+  {
+    href: "/what-are-the-six-paramitas",
+    labelZh: "从空性接到六度",
+    labelEn: "Emptiness to Six Paramitas",
+    titleZh: "如果你已经知道空性不是“什么都没有”，下一步更值得看它怎样回到般若、六度和做人做事里。",
+    titleEn: "If emptiness is no longer just mistaken for nothingness, the next useful step is to see how it returns to wisdom, the six paramitas, and ordinary conduct.",
+    descriptionZh: "很多人会在这里继续追问：为什么空性不会只停在观念里，而会慢慢回到布施、持戒、忍辱、精进、禅定这些更具体的练习方向？这正是六度最自然接进来的地方。",
+    descriptionEn: "Many readers continue by asking why emptiness does not stay as an idea, but gradually returns to generosity, discipline, patience, diligence, and meditation. This is exactly where the six paramitas enter most naturally.",
+  },
+  {
+    href: "/daily-practice",
+    labelZh: "从“少一点抓得太死”接回日常功课",
+    labelEn: "Loosening Grasping to Daily Practice",
+    titleZh: "如果你最关心的是怎样让“少一点僵硬”不只停在理解里，下一步先把它接回晨起、白天和晚间的小练习。",
+    titleEn: "If your main concern is how loosening rigid grasping can live beyond explanation, the next step is to return it to small practices across morning, daytime, and evening.",
+    descriptionZh: "空性的理解真正留得住，往往不是靠一次想明白，而是靠很轻但持续的功课，让自己在一天里一次次少一点抓死、多一点回观。",
+    descriptionEn: "Understanding emptiness usually stays alive not through one decisive insight, but through a light and continuous routine that slowly weakens rigid grasping across the day.",
+  },
+] as const;
+
 const commonMistakes = [
   {
     titleZh: "把空性理解成“反正什么都没有，所以怎样都无所谓”",
@@ -112,6 +142,15 @@ const relatedPaths = [
     titleEn: "Make the beginner question lighter and clearer first.",
     descriptionZh: "如果你现在还在找最适合自己的第一步，可以先回到起步页。",
     descriptionEn: "Return here first if you are still looking for the doorway that fits your present question best.",
+  },
+  {
+    href: "/buddhist-concepts",
+    labelZh: "佛学基本概念",
+    labelEn: "Buddhist Concepts",
+    titleZh: "先回到一张更完整的概念地图，再决定自己现在更该继续看哪一个词。",
+    titleEn: "Return to a wider concepts map before deciding which concept deserves attention next.",
+    descriptionZh: "如果你已经发现自己的问题不只停在空性一个词上，而是开始和因果、菩提心、六度连在一起，这一页会更适合先打开。",
+    descriptionEn: "Open this first if your question is no longer only about emptiness and is beginning to connect with karma, bodhicitta, and the six paramitas as well.",
   },
   {
     href: "/what-is-karma",
@@ -195,6 +234,12 @@ const faqItems = [
     answerEn: "Usually not. A steadier understanding is that all phenomena arise through conditions and do not possess an eternal self-existing essence. Emptiness does not cancel life, but helps loosen the tendency to treat things as too solid and absolute.",
   },
   {
+    questionZh: "《心经》和空性有什么关系？",
+    questionEn: "What does the Heart Sutra have to do with emptiness?",
+    answerZh: "很多人第一次真正碰到空性，不是在抽象定义里，而是在《心经》反复听到“色即是空、空即是色”这些句子的时候。问题通常不在于先把每一句都解释完整，而在于先知道：这些句子不是在说“什么都没有”，而是在帮人松开把经验抓得太实、太绝对的习惯。把这一步理清，再回头读《心经》，往往更容易读进去。",
+    answerEn: "Many readers first truly meet emptiness through lines in the Heart Sutra rather than abstract definitions. The key is not to explain every phrase immediately, but to understand that these lines are not saying nothing exists. They help loosen rigid grasping so returning to the sutra becomes easier.",
+  },
+  {
     questionZh: "空性会不会让人变冷漠，觉得什么都无所谓？",
     questionEn: "Will emptiness make a person cold or indifferent, as if nothing matters?",
     answerZh: "如果理解偏了，可能会这样说，但那通常不是佛法要表达的方向。更稳的理解，反而会让人少一点站在自我中心的执着里，更容易看见别人和自己都在因缘里受苦，因此更容易生起耐心和慈悲。",
@@ -211,6 +256,12 @@ const faqItems = [
     questionEn: "Do emptiness and karma contradict each other?",
     answerZh: "通常不需要这样理解。正因为一切都在因缘条件中成立，行为、习惯和结果才会彼此影响。空性不是取消因果，反而能帮助人少一点用僵硬的方式理解因果。",
     answerEn: "Usually not. Precisely because things arise through conditions, actions, habits, and results influence one another. Emptiness does not cancel karma, but can help us understand karma with less rigidity.",
+  },
+  {
+    questionZh: "空性和六度是什么关系？",
+    questionEn: "How are emptiness and the six paramitas related?",
+    answerZh: "可以把空性看成帮助心少一点执著的般若方向，把六度看成这种方向慢慢长成布施、持戒、忍辱、精进、禅定和般若的练习路径。没有空性的照见，六度容易只剩条目；没有六度，空性的理解也容易只停在观念里。",
+    answerEn: "You can think of emptiness as the wisdom direction that loosens grasping, and the six paramitas as the way that direction becomes generosity, discipline, patience, diligence, meditation, and wisdom in practice. Without emptiness, the paramitas can shrink into a list. Without the paramitas, emptiness can remain only an idea.",
   },
   {
     questionZh: "Fabushi 在理解空性这件事上最适合帮助什么？",
@@ -231,8 +282,10 @@ export const metadata: Metadata = {
     "空性",
     "什么是空性",
     "心经 空性",
-    "般若",
+    "佛学基本概念",
     "六度分别是什么",
+    "菩提心是什么意思",
+    "般若",
     "佛法入门",
     "Fabushi",
   ],
@@ -266,7 +319,7 @@ export default function WhatIsEmptinessPage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["空性", "般若", "因缘和合", "佛法入门"],
+        about: ["空性", "般若", "因缘和合", "心经", "六度", "佛学基本概念入门"],
       },
       {
         "@type": "BreadcrumbList",
@@ -286,6 +339,12 @@ export default function WhatIsEmptinessPage() {
           {
             "@type": "ListItem",
             position: 3,
+            name: "佛学基本概念入门",
+            item: siteUrl("/buddhist-concepts"),
+          },
+          {
+            "@type": "ListItem",
+            position: 4,
             name: "空性怎么理解",
             item: pageUrl,
           },
@@ -298,6 +357,17 @@ export default function WhatIsEmptinessPage() {
           "@type": "ListItem",
           position: index + 1,
           name: item.titleZh,
+          description: item.descriptionZh,
+        })),
+      },
+      {
+        "@type": "ItemList",
+        name: "空性的经典与实践桥接路径",
+        itemListElement: scriptureBridgeSteps.map((item, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: item.labelZh,
+          url: siteUrl(item.href),
           description: item.descriptionZh,
         })),
       },
@@ -367,6 +437,12 @@ export default function WhatIsEmptinessPage() {
             <LocalizedText
               zh="所以，空性并不是把生活否定掉，也不是叫人逃开关系、责任和因果。恰好相反，正因为一切都在因缘条件里成立，所以今天怎么说话、怎么起心动念、怎么回应别人，才会一点一点形成结果。看见这一点，常常会让人少一点僵硬，多一点宽度，也更愿意回到修行。"
               en="Emptiness therefore does not cancel life, nor does it invite us to escape relationship, responsibility, or karma. On the contrary, because everything arises through conditions, the way we speak, intend, and respond matters deeply and gradually forms results. Seeing this often softens rigidity, widens the mind, and makes it easier to return to practice."
+            />
+          </p>
+          <p>
+            <LocalizedText
+              zh="很多人第一次真正碰到空性，并不是在概念词条里，而是在《心经》或般若类经典的语言里，先反复听到“色即是空、空即是色”这一类句子。可如果这一步没有被接回更清楚的概念和练习，熟悉的经句很容易只停在声音里，下一步该往哪里走却还是不清楚。把《心经》、六度和日常功课重新接回同一条路上，空性才更容易从一时触动慢慢长成可用的理解。"
+              en="Many people first truly meet emptiness not through a glossary page, but in the language of the Heart Sutra and other wisdom texts. Without a clearer bridge into concept and practice, familiar lines can remain only familiar sounds while the next step still feels unclear. Returning the Heart Sutra, the six paramitas, and daily practice to one continuous path helps emptiness grow from a passing impression into usable understanding."
             />
           </p>
           <p>
@@ -456,6 +532,37 @@ export default function WhatIsEmptinessPage() {
         </div>
       </section>
 
+      <section className="band feature-band">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="下一步接哪里" en="Where to Go Next" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="把《心经》里的般若语言、六度里的做法和日常功课里的小动作，重新接回同一条理解路径。"
+              en="Return the wisdom language of scripture, the conduct of the paramitas, and the small actions of daily practice to one continuous path of understanding."
+            />
+          </h2>
+        </div>
+        <div className="editorial-list">
+          {scriptureBridgeSteps.map((item) => (
+            <a key={item.href} className="editorial-row" href={siteHref(item.href)}>
+              <span>
+                <LocalizedText zh={item.labelZh} en={item.labelEn} />
+              </span>
+              <div>
+                <strong>
+                  <LocalizedText zh={item.titleZh} en={item.titleEn} />
+                </strong>
+                <p>
+                  <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+                </p>
+              </div>
+            </a>
+          ))}
+        </div>
+      </section>
+
       <section className="band">
         <div className="section-heading tight">
           <p>
@@ -539,8 +646,8 @@ export default function WhatIsEmptinessPage() {
           <a className="primary-action" href={siteHref("/download")}>
             <LocalizedText zh="下载法布施" en="Download Fabushi" />
           </a>
-          <a className="secondary-action" href={siteHref("/buddhadharma")}>
-            <LocalizedText zh="返回佛法入门" en="Back to Dharma Basics" />
+          <a className="secondary-action" href={siteHref("/buddhist-concepts")}>
+            <LocalizedText zh="继续看佛学基本概念" en="Continue to Buddhist Concepts" />
           </a>
         </div>
       </section>


### PR DESCRIPTION
## 问题

官网当前的核心概念簇里，`/what-is-emptiness` 仍停在较早一版写法：

- breadcrumb 还停在 `首页 -> 佛法入门 -> 空性怎么理解`
- 页面还没有像 `/what-is-bodhicitta` 那样，把经典入口、概念中心页和实践页之间的桥接层单独说清楚
- 《心经》读到空性以后下一步去哪、空性怎样接回六度和日常功课，这些高相关后续问题还主要散在段落里，没有被收成更强的结构和结构化数据
- 页尾 CTA 也还停在返回 `佛法入门`，没有把读者送回 `佛学基本概念` 中心页

这会让它更像一张独立概念页，而不是概念簇、经典簇和实践簇之间的连续节点。

## 这次改动

- 仅更新 `frontend/apps/web/src/app/what-is-emptiness/page.tsx`
- 扩写 page description 与 keywords：
  - 补入 `《心经》`
  - 补入 `佛学基本概念`
  - 补入 `六度分别是什么`
  - 补入 `菩提心是什么意思`
- 在正文导读新增一段：
  - 说明很多人第一次真正碰到空性，其实是在《心经》或般若类经典的语言里
  - 把《心经》、六度与日常功课重新接回同一条理解路径
- 新增 `scriptureBridgeSteps` 与整段 `下一步接哪里` 区块：
  - `《心经》 -> /beginner-sutra-recommendations`
  - `空性 -> /what-are-the-six-paramitas`
  - `少一点抓得太死 -> /daily-practice`
- 扩充 `relatedPaths`：
  - 新增 `/buddhist-concepts`
- 扩充 JSON-LD：
  - `about` 补入 `心经 / 六度 / 佛学基本概念入门`
  - 新增一个 `ItemList`，表达“空性的经典与实践桥接路径”
- 修正 breadcrumb schema：
  - 从 `首页 -> 佛法入门 -> 空性怎么理解`
  - 调整为 `首页 -> 佛法入门 -> 佛学基本概念入门 -> 空性怎么理解`
- 扩充 FAQ：
  - `《心经》和空性有什么关系？`
  - `空性和六度是什么关系？`
- 调整页尾 CTA：
  - 二级 CTA 从返回佛法入门，改成继续进入 `/buddhist-concepts`

## 为什么现在做

这一步的收益很集中：

- 不用再开新页，就能把现有高相关概念页从“解释页”升级成“概念 -> 经典 -> 实践”的桥接页
- 同时补到：
  - 页面主题语义
  - 经典侧问题覆盖
  - 概念中心页回挂
  - breadcrumb 层级清晰度
  - JSON-LD 结构化语义
  - 空性页对六度与日常功课的继续分发能力

## 配图判断

- 本轮没有新增配图。
- 原因没有变化：当前佛法内容页线上稳定承载仍以长文本、FAQ、Breadcrumb / ItemList 为主，还没有已经验证过的佛法专题图承载位。
- 这小时更高收益的动作，是先把 `/what-is-emptiness` 的语义桥接层和站内层级补完整，而不是先强行引入视觉元素。

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 1`、`behind_by = 0`
- 改动范围只在 1 个文件：
  - `frontend/apps/web/src/app/what-is-emptiness/page.tsx`
- 分支回读已确认页面现在包含：
  - 新的 `scriptureBridgeSteps`
  - 新增的 `下一步接哪里` 区块
  - 新增的 `/buddhist-concepts` 回链
  - 调整后的 breadcrumb schema
  - 扩充后的 metadata / JSON-LD / FAQ / CTA
- 当前环境没有仓库本地 checkout，无法直接运行 Next.js 构建；最终检查仍依赖仓库现有 CI
- 不对排名结果作保证；这次改动的确定性收益在于加强空性页对经典入口、概念层级和实践后续问题的覆盖与连续阅读能力

## 下一步承接

- 如果这一页顺利合并，下一步最值得继续推进的不是立刻再开新词条，而是继续增强 `buddhist-concepts` 与 `beginner-sutra-recommendations` 之间的双向桥接，尤其是把《心经 / 空性》《普门品 / 菩提心》《金刚经 / 六度》这组三条入口在概念总览页里表达得更显性。