### PR TITLE
feat(forum): harden hourly live deployment smoke checks

### DIFF
--- a/.github/workflows/forum-live-deployment-checks.yml
+++ b/.github/workflows/forum-live-deployment-checks.yml
@@ -56,6 +56,7 @@ concurrency:
 jobs:
   forum-live-deployment:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       FORUM_WRITE_ACCESS_CODE: ${{ secrets.FORUM_LIVE_WRITE_ACCESS_CODE }}
     steps:
@@ -113,6 +114,29 @@ jobs:
             echo "exercise_write_flow=$exercise_write_flow"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Write live deployment target summary
+        shell: bash
+        run: |
+          {
+            echo "## Live forum target"
+            echo ""
+
+            if [[ "${{ steps.resolve.outputs.skip }}" == "true" ]]; then
+              echo "- status: skipped"
+              echo "- reason: ${{ steps.resolve.outputs.reason }}"
+              echo "- next config: set FORUM_LIVE_URL and the related FORUM_LIVE_* repository variables before expecting hourly checks to hit a real target"
+            else
+              echo "- status: ready to check"
+              echo "- forum_url: ${{ steps.resolve.outputs.forum_url }}"
+              echo "- deployment_stage: ${{ steps.resolve.outputs.deployment_stage }}"
+              echo "- public_base_url: ${{ steps.resolve.outputs.public_base_url || '(empty)' }}"
+              echo "- writes_enabled: ${{ steps.resolve.outputs.writes_enabled }}"
+              echo "- requires_access_code: ${{ steps.resolve.outputs.requires_access_code }}"
+              echo "- exercise_write_flow: ${{ steps.resolve.outputs.exercise_write_flow }}"
+              echo "- request_timeout_ms: 15000"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Skip scheduled check when live target is not configured
         if: steps.resolve.outputs.skip == 'true'
         run: echo "${{ steps.resolve.outputs.reason }}"
@@ -126,4 +150,24 @@ jobs:
             --public-base-url "${{ steps.resolve.outputs.public_base_url }}" \
             --writes-enabled "${{ steps.resolve.outputs.writes_enabled }}" \
             --requires-access-code "${{ steps.resolve.outputs.requires_access_code }}" \
-            --exercise-write-flow "${{ steps.resolve.outputs.exercise_write_flow }}"
+            --exercise-write-flow "${{ steps.resolve.outputs.exercise_write_flow }}" \
+            --request-timeout-ms 15000 \
+            --report-path /tmp/forum-live-deployment-report.json
+
+      - name: Append live smoke check report to job summary
+        if: always() && steps.resolve.outputs.skip != 'true'
+        shell: bash
+        run: |
+          {
+            echo ""
+            echo "## Live smoke check report"
+            echo ""
+
+            if [[ -f /tmp/forum-live-deployment-report.json ]]; then
+              echo '```json'
+              cat /tmp/forum-live-deployment-report.json
+              echo '```'
+            else
+              echo "Report file was not created. Inspect the smoke-check step logs for details."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -58,6 +58,10 @@ FORUM_LIVE_EXERCISE_WRITE_FLOW=true
 
 If `FORUM_LIVE_URL` is still empty, the hourly workflow exits cleanly without failing. Manual `workflow_dispatch` runs keep working with the explicit inputs.
 
+The hourly workflow now also writes a job summary for both skip and check paths, so the run itself tells you which target posture it resolved and whether the repository variables are still incomplete.
+
+Live HTTP requests now time out after 15 seconds per call. That keeps an unreachable preview or production target from leaving the hourly workflow hanging for too long before it reports the failure.
+
 ## Preview baseline
 
 Keep the safe default first:

--- a/forum/scripts/check-deployment-contract.mjs
+++ b/forum/scripts/check-deployment-contract.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { writeFile } from "node:fs/promises";
+
 function parseArgs(argv) {
   const parsed = {};
 
@@ -44,6 +46,20 @@ function parseBoolean(value, key) {
   throw new Error(`Expected --${key} to be true or false, received: ${value}`);
 }
 
+function parseInteger(value, key) {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Expected --${key} to be a positive integer, received: ${value}`);
+  }
+
+  return parsed;
+}
+
 function expect(condition, message, details) {
   if (!condition) {
     if (details === undefined) {
@@ -54,15 +70,29 @@ function expect(condition, message, details) {
   }
 }
 
-async function request(target, init = {}, expectedStatus = 200) {
+async function request(target, init = {}, expectedStatus = 200, timeoutMs = 15000) {
   const allowedStatuses = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
-  const response = await fetch(target, {
-    redirect: "follow",
-    ...init,
-  });
+  const method = init.method ?? "GET";
+
+  let response;
+
+  try {
+    response = await fetch(target, {
+      redirect: "follow",
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    if (error?.name === "TimeoutError") {
+      throw new Error(`Request timed out after ${timeoutMs}ms for ${method} ${target}`);
+    }
+
+    throw new Error(`Request failed for ${method} ${target}: ${error}`);
+  }
+
   const body = await response.text();
 
-  expect(allowedStatuses.includes(response.status), `Request failed for ${target}`, {
+  expect(allowedStatuses.includes(response.status), `Request failed for ${method} ${target}`, {
     status: response.status,
     body,
     expectedStatus: allowedStatuses,
@@ -75,7 +105,7 @@ async function request(target, init = {}, expectedStatus = 200) {
   };
 }
 
-async function fetchJson(target, init = {}, expectedStatus = 200) {
+async function fetchJson(target, init = {}, expectedStatus = 200, timeoutMs = 15000) {
   const response = await request(
     target,
     {
@@ -86,6 +116,7 @@ async function fetchJson(target, init = {}, expectedStatus = 200) {
       ...init,
     },
     expectedStatus,
+    timeoutMs,
   );
 
   try {
@@ -125,7 +156,7 @@ function createReplyPayload() {
   };
 }
 
-async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, writeAccessCode }) {
+async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, writeAccessCode, requestTimeoutMs }) {
   const runId = new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14);
   const threadPayload = createThreadPayload(runId);
 
@@ -140,6 +171,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
         body: JSON.stringify(threadPayload),
       },
       403,
+      requestTimeoutMs,
     );
 
     expect(
@@ -163,6 +195,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
       body: JSON.stringify(createPayload),
     },
     201,
+    requestTimeoutMs,
   );
 
   expect(createdThread.json.source === "sqlite", "created thread should be backed by sqlite", createdThread.json);
@@ -188,7 +221,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
   const threadSlug = createdThread.json.thread.slug;
   expect(Boolean(threadSlug), "thread slug should be returned after live thread creation", createdThread.json);
 
-  const threadDetail = await fetchJson(`${forumUrl}/api/thread/${threadSlug}`);
+  const threadDetail = await fetchJson(`${forumUrl}/api/thread/${threadSlug}`, {}, 200, requestTimeoutMs);
   expect(threadDetail.json.source === "sqlite", "thread detail should resolve from sqlite", threadDetail.json);
   expect(threadDetail.json.thread.slug === threadSlug, "thread detail slug mismatch", threadDetail.json);
   expect(threadDetail.json.thread.author === threadPayload.author, "thread detail author mismatch", threadDetail.json);
@@ -198,7 +231,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
     threadDetail.json,
   );
 
-  const threadListPage = await request(`${forumUrl}/threads`);
+  const threadListPage = await request(`${forumUrl}/threads`, {}, 200, requestTimeoutMs);
   expect(threadListPage.body.includes(threadPayload.title), "thread list HTML should include the created thread title", {
     threadTitle: threadPayload.title,
     snippet: threadListPage.body.slice(0, 6000),
@@ -224,7 +257,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
     },
   );
 
-  const threadDetailPageBeforeReply = await request(`${forumUrl}/threads/${threadSlug}`);
+  const threadDetailPageBeforeReply = await request(`${forumUrl}/threads/${threadSlug}`, {}, 200, requestTimeoutMs);
   expect(
     threadDetailPageBeforeReply.body.includes(threadPayload.title),
     "thread detail HTML should include the created thread title",
@@ -263,6 +296,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
       }),
     },
     201,
+    requestTimeoutMs,
   );
 
   expect(createdReply.json.source === "sqlite", "created reply should be backed by sqlite", createdReply.json);
@@ -287,7 +321,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
     createdReply.json,
   );
 
-  const threadDetailAfterReply = await fetchJson(`${forumUrl}/api/thread/${threadSlug}`);
+  const threadDetailAfterReply = await fetchJson(`${forumUrl}/api/thread/${threadSlug}`, {}, 200, requestTimeoutMs);
   expect(
     threadDetailAfterReply.json.replies.at(-1)?.author === replyPayload.author,
     "thread detail should include the live reply author",
@@ -299,7 +333,7 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
     threadDetailAfterReply.json,
   );
 
-  const threadDetailPageAfterReply = await request(`${forumUrl}/threads/${threadSlug}`);
+  const threadDetailPageAfterReply = await request(`${forumUrl}/threads/${threadSlug}`, {}, 200, requestTimeoutMs);
   expect(
     threadDetailPageAfterReply.body.includes(replyPayload.author),
     "thread detail HTML should include the live reply author",
@@ -332,6 +366,14 @@ async function verifyPreviewWriteFlow({ forumUrl, expectedRequiresAccessCode, wr
   };
 }
 
+async function writeReport(reportPath, payload) {
+  if (!reportPath) {
+    return;
+  }
+
+  await writeFile(reportPath, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+}
+
 const args = parseArgs(process.argv.slice(2));
 const forumUrl = normalizeUrl(args.url ?? "");
 const deploymentStage = args["deployment-stage"];
@@ -340,175 +382,200 @@ const expectedWritesEnabled = parseBoolean(args["writes-enabled"], "writes-enabl
 const expectedRequiresAccessCode = parseBoolean(args["requires-access-code"], "requires-access-code");
 const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise-write-flow") ?? false;
 const writeAccessCode = args["write-access-code"]?.trim() || process.env.FORUM_WRITE_ACCESS_CODE?.trim() || "";
+const requestTimeoutMs = parseInteger(args["request-timeout-ms"], "request-timeout-ms") ?? 15000;
+const reportPath = args["report-path"]?.trim() || "";
+const startedAt = new Date().toISOString();
 
-expect(Boolean(forumUrl), "--url is required");
-expect(
-  deploymentStage === "preview" || deploymentStage === "production",
-  "--deployment-stage must be preview or production",
-  { deploymentStage },
-);
-
-const expectedIndexingEnabled = deploymentStage === "production" && Boolean(publicBaseUrl);
-
-const health = await fetchJson(`${forumUrl}/api/health`);
-const status = await fetchJson(`${forumUrl}/api/status`);
-const robots = await request(`${forumUrl}/robots.txt`);
-const threadList = await request(`${forumUrl}/threads`);
-const threadListHtml = threadList.body.toLowerCase();
-const robotsText = robots.body;
-
-expect(health.json.service === "forum", "health service should be forum", health.json);
-expect(health.json.ready === true, "health ready should be true", health.json);
-expect(health.json.deploymentStage === deploymentStage, "health deployment stage mismatch", health.json);
-expect(health.json.indexingEnabled === expectedIndexingEnabled, "health indexingEnabled mismatch", {
-  expectedIndexingEnabled,
-  health: health.json,
-});
-expect(
-  health.json.publicBaseUrlConfigured === Boolean(publicBaseUrl),
-  "health publicBaseUrlConfigured mismatch",
-  {
-    expected: Boolean(publicBaseUrl),
-    health: health.json,
-  },
-);
-
-expect(status.json.service === "forum", "status service should be forum", status.json);
-expect(status.json.deploymentStage === deploymentStage, "status deployment stage mismatch", status.json);
-expect(status.json.indexingEnabled === expectedIndexingEnabled, "status indexingEnabled mismatch", {
-  expectedIndexingEnabled,
-  status: status.json,
-});
-
-if (publicBaseUrl) {
-  expect(status.json.publicBaseUrl === publicBaseUrl, "status publicBaseUrl mismatch", {
-    expected: publicBaseUrl,
-    status: status.json,
-  });
-} else {
-  expect(!status.json.publicBaseUrl, "status publicBaseUrl should be empty when no public base URL is expected", status.json);
-}
-
-if (expectedWritesEnabled !== undefined) {
-  expect(health.json.writesEnabled === expectedWritesEnabled, "health writesEnabled mismatch", {
-    expectedWritesEnabled,
-    health: health.json,
-  });
-  expect(status.json.writesEnabled === expectedWritesEnabled, "status writesEnabled mismatch", {
-    expectedWritesEnabled,
-    status: status.json,
-  });
-}
-
-if (expectedRequiresAccessCode !== undefined) {
-  expect(health.json.requiresAccessCode === expectedRequiresAccessCode, "health requiresAccessCode mismatch", {
-    expectedRequiresAccessCode,
-    health: health.json,
-  });
-  expect(status.json.requiresAccessCode === expectedRequiresAccessCode, "status requiresAccessCode mismatch", {
-    expectedRequiresAccessCode,
-    status: status.json,
-  });
-}
-
-const stageHeader = threadList.headers.get("x-forum-deployment-stage");
-const indexingHeader = threadList.headers.get("x-forum-indexing-enabled");
-const publicBaseUrlHeader = threadList.headers.get("x-forum-public-base-url");
-const robotsTagHeader = threadList.headers.get("x-robots-tag");
-
-expect(stageHeader === deploymentStage, "page deployment stage header mismatch", {
-  expected: deploymentStage,
-  actual: stageHeader,
-});
-expect(indexingHeader === String(expectedIndexingEnabled), "page indexing header mismatch", {
-  expected: String(expectedIndexingEnabled),
-  actual: indexingHeader,
-});
-
-if (publicBaseUrl) {
-  expect(publicBaseUrlHeader === publicBaseUrl, "page public base URL header mismatch", {
-    expected: publicBaseUrl,
-    actual: publicBaseUrlHeader,
-  });
-} else {
-  expect(!publicBaseUrlHeader, "page public base URL header should be empty", {
-    actual: publicBaseUrlHeader,
-  });
-}
-
-if (expectedIndexingEnabled) {
-  expect(!robotsTagHeader, "x-robots-tag should be absent when indexing is enabled", {
-    robotsTagHeader,
-  });
-  expect(robotsText.includes("Allow: /"), "robots.txt should allow crawling", {
-    robotsText,
-  });
-  expect(robotsText.includes(`Host: ${publicBaseUrl}`), "robots.txt Host should match expected public base URL", {
-    publicBaseUrl,
-    robotsText,
-  });
-  expect(!robotsText.includes("Disallow: /"), "robots.txt should not disallow crawling", {
-    robotsText,
-  });
-  expect(threadListHtml.includes("index, follow"), "thread list HTML should be indexable", {
-    snippet: threadList.body.slice(0, 4000),
-  });
-  expect(threadListHtml.includes(publicBaseUrl.toLowerCase()), "thread list HTML should include the configured public base URL", {
-    publicBaseUrl,
-    snippet: threadList.body.slice(0, 4000),
-  });
-  expect(!threadListHtml.includes("noindex"), "thread list HTML should not include noindex metadata", {
-    snippet: threadList.body.slice(0, 4000),
-  });
-} else {
+async function main() {
+  expect(Boolean(forumUrl), "--url is required");
   expect(
-    robotsTagHeader?.toLowerCase().includes("noindex") ?? false,
-    "x-robots-tag should keep preview/noindex deployments private",
-    { robotsTagHeader },
+    deploymentStage === "preview" || deploymentStage === "production",
+    "--deployment-stage must be preview or production",
+    { deploymentStage },
   );
-  expect(robotsText.includes("Disallow: /"), "robots.txt should disallow crawling", {
-    robotsText,
-  });
-  expect(threadListHtml.includes("noindex"), "thread list HTML should include noindex metadata", {
-    snippet: threadList.body.slice(0, 4000),
-  });
-}
 
-let liveWriteVerification = null;
+  const expectedIndexingEnabled = deploymentStage === "production" && Boolean(publicBaseUrl);
 
-if (exerciseWriteFlow) {
-  expect(deploymentStage === "preview", "--exercise-write-flow is only supported for preview runtimes.", {
-    deploymentStage,
+  const health = await fetchJson(`${forumUrl}/api/health`, {}, 200, requestTimeoutMs);
+  const status = await fetchJson(`${forumUrl}/api/status`, {}, 200, requestTimeoutMs);
+  const robots = await request(`${forumUrl}/robots.txt`, {}, 200, requestTimeoutMs);
+  const threadList = await request(`${forumUrl}/threads`, {}, 200, requestTimeoutMs);
+  const threadListHtml = threadList.body.toLowerCase();
+  const robotsText = robots.body;
+
+  expect(health.json.service === "forum", "health service should be forum", health.json);
+  expect(health.json.ready === true, "health ready should be true", health.json);
+  expect(health.json.deploymentStage === deploymentStage, "health deployment stage mismatch", health.json);
+  expect(health.json.indexingEnabled === expectedIndexingEnabled, "health indexingEnabled mismatch", {
+    expectedIndexingEnabled,
+    health: health.json,
   });
-  expect(expectedWritesEnabled === true, "--exercise-write-flow requires --writes-enabled=true.", {
-    expectedWritesEnabled,
+  expect(
+    health.json.publicBaseUrlConfigured === Boolean(publicBaseUrl),
+    "health publicBaseUrlConfigured mismatch",
+    {
+      expected: Boolean(publicBaseUrl),
+      health: health.json,
+    },
+  );
+
+  expect(status.json.service === "forum", "status service should be forum", status.json);
+  expect(status.json.deploymentStage === deploymentStage, "status deployment stage mismatch", status.json);
+  expect(status.json.indexingEnabled === expectedIndexingEnabled, "status indexingEnabled mismatch", {
+    expectedIndexingEnabled,
+    status: status.json,
   });
 
-  if (expectedRequiresAccessCode) {
-    expect(Boolean(writeAccessCode), "A write access code is required to exercise the live preview write flow. Pass --write-access-code or set FORUM_WRITE_ACCESS_CODE.");
+  if (publicBaseUrl) {
+    expect(status.json.publicBaseUrl === publicBaseUrl, "status publicBaseUrl mismatch", {
+      expected: publicBaseUrl,
+      status: status.json,
+    });
+  } else {
+    expect(!status.json.publicBaseUrl, "status publicBaseUrl should be empty when no public base URL is expected", status.json);
   }
 
-  liveWriteVerification = await verifyPreviewWriteFlow({
-    forumUrl,
-    expectedRequiresAccessCode: expectedRequiresAccessCode === true,
-    writeAccessCode,
+  if (expectedWritesEnabled !== undefined) {
+    expect(health.json.writesEnabled === expectedWritesEnabled, "health writesEnabled mismatch", {
+      expectedWritesEnabled,
+      health: health.json,
+    });
+    expect(status.json.writesEnabled === expectedWritesEnabled, "status writesEnabled mismatch", {
+      expectedWritesEnabled,
+      status: status.json,
+    });
+  }
+
+  if (expectedRequiresAccessCode !== undefined) {
+    expect(health.json.requiresAccessCode === expectedRequiresAccessCode, "health requiresAccessCode mismatch", {
+      expectedRequiresAccessCode,
+      health: health.json,
+    });
+    expect(status.json.requiresAccessCode === expectedRequiresAccessCode, "status requiresAccessCode mismatch", {
+      expectedRequiresAccessCode,
+      status: status.json,
+    });
+  }
+
+  const stageHeader = threadList.headers.get("x-forum-deployment-stage");
+  const indexingHeader = threadList.headers.get("x-forum-indexing-enabled");
+  const publicBaseUrlHeader = threadList.headers.get("x-forum-public-base-url");
+  const robotsTagHeader = threadList.headers.get("x-robots-tag");
+
+  expect(stageHeader === deploymentStage, "page deployment stage header mismatch", {
+    expected: deploymentStage,
+    actual: stageHeader,
   });
+  expect(indexingHeader === String(expectedIndexingEnabled), "page indexing header mismatch", {
+    expected: String(expectedIndexingEnabled),
+    actual: indexingHeader,
+  });
+
+  if (publicBaseUrl) {
+    expect(publicBaseUrlHeader === publicBaseUrl, "page public base URL header mismatch", {
+      expected: publicBaseUrl,
+      actual: publicBaseUrlHeader,
+    });
+  } else {
+    expect(!publicBaseUrlHeader, "page public base URL header should be empty", {
+      actual: publicBaseUrlHeader,
+    });
+  }
+
+  if (expectedIndexingEnabled) {
+    expect(!robotsTagHeader, "x-robots-tag should be absent when indexing is enabled", {
+      robotsTagHeader,
+    });
+    expect(robotsText.includes("Allow: /"), "robots.txt should allow crawling", {
+      robotsText,
+    });
+    expect(robotsText.includes(`Host: ${publicBaseUrl}`), "robots.txt Host should match expected public base URL", {
+      publicBaseUrl,
+      robotsText,
+    });
+    expect(!robotsText.includes("Disallow: /"), "robots.txt should not disallow crawling", {
+      robotsText,
+    });
+    expect(threadListHtml.includes("index, follow"), "thread list HTML should be indexable", {
+      snippet: threadList.body.slice(0, 4000),
+    });
+    expect(threadListHtml.includes(publicBaseUrl.toLowerCase()), "thread list HTML should include the configured public base URL", {
+      publicBaseUrl,
+      snippet: threadList.body.slice(0, 4000),
+    });
+    expect(!threadListHtml.includes("noindex"), "thread list HTML should not include noindex metadata", {
+      snippet: threadList.body.slice(0, 4000),
+    });
+  } else {
+    expect(
+      robotsTagHeader?.toLowerCase().includes("noindex") ?? false,
+      "x-robots-tag should keep preview/noindex deployments private",
+      { robotsTagHeader },
+    );
+    expect(robotsText.includes("Disallow: /"), "robots.txt should disallow crawling", {
+      robotsText,
+    });
+    expect(threadListHtml.includes("noindex"), "thread list HTML should include noindex metadata", {
+      snippet: threadList.body.slice(0, 4000),
+    });
+  }
+
+  let liveWriteVerification = null;
+
+  if (exerciseWriteFlow) {
+    expect(deploymentStage === "preview", "--exercise-write-flow is only supported for preview runtimes.", {
+      deploymentStage,
+    });
+    expect(expectedWritesEnabled === true, "--exercise-write-flow requires --writes-enabled=true.", {
+      expectedWritesEnabled,
+    });
+
+    if (expectedRequiresAccessCode) {
+      expect(Boolean(writeAccessCode), "A write access code is required to exercise the live preview write flow. Pass --write-access-code or set FORUM_WRITE_ACCESS_CODE.");
+    }
+
+    liveWriteVerification = await verifyPreviewWriteFlow({
+      forumUrl,
+      expectedRequiresAccessCode: expectedRequiresAccessCode === true,
+      writeAccessCode,
+      requestTimeoutMs,
+    });
+  }
+
+  const report = {
+    ok: true,
+    forumUrl,
+    deploymentStage,
+    indexingEnabled: expectedIndexingEnabled,
+    publicBaseUrl: publicBaseUrl || null,
+    writesEnabled: expectedWritesEnabled ?? null,
+    requiresAccessCode: expectedRequiresAccessCode ?? null,
+    exerciseWriteFlow,
+    requestTimeoutMs,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    liveWriteVerification,
+  };
+
+  await writeReport(reportPath, report);
+  console.log(JSON.stringify(report, null, 2));
 }
 
-console.log(
-  JSON.stringify(
-    {
-      ok: true,
-      forumUrl,
-      deploymentStage,
-      indexingEnabled: expectedIndexingEnabled,
-      publicBaseUrl: publicBaseUrl || null,
-      writesEnabled: expectedWritesEnabled ?? null,
-      requiresAccessCode: expectedRequiresAccessCode ?? null,
-      exerciseWriteFlow,
-      liveWriteVerification,
-    },
-    null,
-    2,
-  ),
-);
+main().catch(async (error) => {
+  await writeReport(reportPath, {
+    ok: false,
+    forumUrl: forumUrl || null,
+    deploymentStage: deploymentStage || null,
+    publicBaseUrl: publicBaseUrl || null,
+    writesEnabled: expectedWritesEnabled ?? null,
+    requiresAccessCode: expectedRequiresAccessCode ?? null,
+    exerciseWriteFlow,
+    requestTimeoutMs,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    error: error instanceof Error ? error.message : String(error),
+  });
+
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 问题

论坛已经把真实 URL 的 smoke check 推进到每小时自动运行，但在真正开始接 live target 之前，这条路径还缺两类很现实的运行保障：

- 如果 preview 或 production 目标卡住，当前 workflow 缺少明确的超时边界，小时级任务可能长时间悬挂
- 定时运行与手动运行虽然都能执行，但工作流本身还不会把“本次到底解析到了什么运行态”“为什么跳过”“实际校验结果是什么”直接收成运行摘要

这会让下一步最关键的“真实地址验证”在第一次接入时，虽然有机制，但排障反馈还不够快、也不够聚焦。

## 这次改动

- 更新 `.github/workflows/forum-live-deployment-checks.yml`
  - 为 `forum-live-deployment` job 新增 `timeout-minutes: 10`
  - 在解析 live target 之后新增 job summary 输出：
    - 若未配置 `FORUM_LIVE_URL`，明确写出 skip 原因和下一步需要补的仓库变量
    - 若已配置目标，明确写出本次解析得到的 URL、deployment stage、public base URL、writes 状态、access code 状态和请求超时值
  - 运行 smoke check 时显式传入 `--request-timeout-ms 15000`
  - 让 script 把结果写到 `/tmp/forum-live-deployment-report.json`
  - 新增一个始终执行的 summary 收尾步骤，把本次 smoke check 的 JSON 报告直接附到 job summary
- 更新 `forum/scripts/check-deployment-contract.mjs`
  - 新增 `--request-timeout-ms` 参数，默认每个 HTTP 请求 15 秒超时
  - 请求失败时补上更具体的方法、目标地址和超时信息
  - 所有健康检查、页面检查、preview 写入闭环检查统一承接同一超时配置
  - 新增 `--report-path` 参数，成功和失败两种结果都会落一份结构化 JSON 报告
  - 报告中补入 `startedAt`、`finishedAt`、`requestTimeoutMs` 和最终错误信息，方便直接从 workflow summary 回看
- 更新 `forum/DEPLOY.md`
  - 补齐 hourly workflow 现在会写 job summary 的说明
  - 补齐每次 live HTTP 请求 15 秒超时的说明，明确这条机制是为了让不可达目标更快失败并暴露问题

## 为什么现在做

当前论坛主线的最高优先级仍然是把 hourly live deployment checks 真正接到真实 preview 地址上。

在这一步之前，继续堆更多部署姿态或本地示例的收益已经不高；更值得补的是让现有 live smoke check 在面对真实目标时更稳、更快暴露问题：

- 真实目标不可达时，不会让每小时任务挂太久
- 即使是 skip，也能直接在运行摘要里看出缺哪项配置
- 一旦目标接通，成功或失败都能直接从 summary 回看结构化结果，而不是只翻日志

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 3`、`behind_by = 0`
- 改动范围收敛在 3 个论坛部署相关文件：
  - `.github/workflows/forum-live-deployment-checks.yml`
  - `forum/scripts/check-deployment-contract.mjs`
  - `forum/DEPLOY.md`
- 已回读分支内容确认：
  - live workflow 现在有 job 级超时
  - smoke script 已支持 `--request-timeout-ms` 与 `--report-path`
  - 成功与失败路径都会生成结构化报告
  - deploy 文档已对齐新的 summary 与超时行为
- 当前环境没有仓库本地 checkout，无法在这里直接运行 GitHub Actions
- 最终检查仍依赖仓库 CI，以及后续把真实 preview URL 与对应 runtime 变量填入仓库配置

## 下一步承接

- 在仓库里配置 `FORUM_LIVE_URL` 和对应的 `FORUM_LIVE_*` 变量
- 先让 hourly workflow 跑通只读 preview 契约
- 若 preview 后续显式开放写入，再把 `FORUM_LIVE_EXERCISE_WRITE_FLOW=true` 打开，让同一条 hourly check 覆盖真实主题 / 回复闭环