### PR TITLE
feat(forum): validate live deployment target config

### DIFF
--- a/.github/workflows/forum-live-deployment-checks.yml
+++ b/.github/workflows/forum-live-deployment-checks.yml
@@ -58,7 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      FORUM_WRITE_ACCESS_CODE: ${{ secrets.FORUM_LIVE_WRITE_ACCESS_CODE }}
+      FORUM_LIVE_REQUEST_TIMEOUT_MS: "15000"
+      FORUM_LIVE_TARGET_PATH: /tmp/forum-live-target.json
+      FORUM_LIVE_WRITE_ACCESS_CODE: ${{ secrets.FORUM_LIVE_WRITE_ACCESS_CODE }}
     steps:
       - name: Checkout forum workspace only
         uses: actions/checkout@v4
@@ -73,69 +75,45 @@ jobs:
         with:
           node-version: 24
 
-      - name: Resolve live forum target
+      - name: Resolve and validate live forum target
+        env:
+          FORUM_LIVE_SOURCE: ${{ github.event_name }}
+          FORUM_LIVE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.forum_url || vars.FORUM_LIVE_URL }}
+          FORUM_LIVE_DEPLOYMENT_STAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_stage || vars.FORUM_LIVE_DEPLOYMENT_STAGE }}
+          FORUM_LIVE_PUBLIC_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.public_base_url || vars.FORUM_LIVE_PUBLIC_BASE_URL }}
+          FORUM_LIVE_WRITES_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.writes_enabled || vars.FORUM_LIVE_WRITES_ENABLED }}
+          FORUM_LIVE_REQUIRES_ACCESS_CODE: ${{ github.event_name == 'workflow_dispatch' && inputs.requires_access_code || vars.FORUM_LIVE_REQUIRES_ACCESS_CODE }}
+          FORUM_LIVE_EXERCISE_WRITE_FLOW: ${{ github.event_name == 'workflow_dispatch' && inputs.exercise_write_flow || vars.FORUM_LIVE_EXERCISE_WRITE_FLOW }}
+        shell: bash
+        run: |
+          node forum/scripts/resolve-live-deployment-target.mjs
+
+      - name: Load resolved live forum target
         id: resolve
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            forum_url="${{ inputs.forum_url }}"
-            deployment_stage="${{ inputs.deployment_stage }}"
-            public_base_url="${{ inputs.public_base_url }}"
-            writes_enabled="${{ inputs.writes_enabled }}"
-            requires_access_code="${{ inputs.requires_access_code }}"
-            exercise_write_flow="${{ inputs.exercise_write_flow }}"
-          else
-            forum_url="${{ vars.FORUM_LIVE_URL }}"
-            deployment_stage="${{ vars.FORUM_LIVE_DEPLOYMENT_STAGE }}"
-            public_base_url="${{ vars.FORUM_LIVE_PUBLIC_BASE_URL }}"
-            writes_enabled="${{ vars.FORUM_LIVE_WRITES_ENABLED }}"
-            requires_access_code="${{ vars.FORUM_LIVE_REQUIRES_ACCESS_CODE }}"
-            exercise_write_flow="${{ vars.FORUM_LIVE_EXERCISE_WRITE_FLOW }}"
+          if [[ ! -f "$FORUM_LIVE_TARGET_PATH" ]]; then
+            echo "Resolved live target file was not created." >&2
+            exit 1
           fi
 
-          if [[ -z "$forum_url" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "reason=No forum URL configured for scheduled live deployment checks." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          node -e '
+            const fs = require("node:fs");
+            const target = JSON.parse(fs.readFileSync(process.env.FORUM_LIVE_TARGET_PATH, "utf8"));
+            const lines = [
+              `skip=${target.skip ? "true" : "false"}`,
+              `reason=${target.reason ?? ""}`,
+              `forum_url=${target.forumUrl ?? ""}`,
+              `deployment_stage=${target.deploymentStage ?? ""}`,
+              `public_base_url=${target.publicBaseUrl ?? ""}`,
+              `writes_enabled=${target.writesEnabled === undefined ? "" : String(target.writesEnabled)}`,
+              `requires_access_code=${target.requiresAccessCode === undefined ? "" : String(target.requiresAccessCode)}`,
+              `exercise_write_flow=${target.exerciseWriteFlow === undefined ? "" : String(target.exerciseWriteFlow)}`,
+              `request_timeout_ms=${target.requestTimeoutMs ?? ""}`,
+            ];
 
-          deployment_stage="${deployment_stage:-preview}"
-          writes_enabled="${writes_enabled:-false}"
-          requires_access_code="${requires_access_code:-false}"
-          exercise_write_flow="${exercise_write_flow:-false}"
-
-          {
-            echo "skip=false"
-            echo "forum_url=$forum_url"
-            echo "deployment_stage=$deployment_stage"
-            echo "public_base_url=$public_base_url"
-            echo "writes_enabled=$writes_enabled"
-            echo "requires_access_code=$requires_access_code"
-            echo "exercise_write_flow=$exercise_write_flow"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Write live deployment target summary
-        shell: bash
-        run: |
-          {
-            echo "## Live forum target"
-            echo ""
-
-            if [[ "${{ steps.resolve.outputs.skip }}" == "true" ]]; then
-              echo "- status: skipped"
-              echo "- reason: ${{ steps.resolve.outputs.reason }}"
-              echo "- next config: set FORUM_LIVE_URL and the related FORUM_LIVE_* repository variables before expecting hourly checks to hit a real target"
-            else
-              echo "- status: ready to check"
-              echo "- forum_url: ${{ steps.resolve.outputs.forum_url }}"
-              echo "- deployment_stage: ${{ steps.resolve.outputs.deployment_stage }}"
-              echo "- public_base_url: ${{ steps.resolve.outputs.public_base_url || '(empty)' }}"
-              echo "- writes_enabled: ${{ steps.resolve.outputs.writes_enabled }}"
-              echo "- requires_access_code: ${{ steps.resolve.outputs.requires_access_code }}"
-              echo "- exercise_write_flow: ${{ steps.resolve.outputs.exercise_write_flow }}"
-              echo "- request_timeout_ms: 15000"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`);
+          '
 
       - name: Skip scheduled check when live target is not configured
         if: steps.resolve.outputs.skip == 'true'
@@ -151,7 +129,7 @@ jobs:
             --writes-enabled "${{ steps.resolve.outputs.writes_enabled }}" \
             --requires-access-code "${{ steps.resolve.outputs.requires_access_code }}" \
             --exercise-write-flow "${{ steps.resolve.outputs.exercise_write_flow }}" \
-            --request-timeout-ms 15000 \
+            --request-timeout-ms "${{ steps.resolve.outputs.request_timeout_ms }}" \
             --report-path /tmp/forum-live-deployment-report.json
 
       - name: Append live smoke check report to job summary

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -56,9 +56,16 @@ FORUM_LIVE_REQUIRES_ACCESS_CODE=true
 FORUM_LIVE_EXERCISE_WRITE_FLOW=true
 ```
 
+The hourly workflow now validates that live-target settings describe a coherent runtime before it makes any HTTP requests. It will fail fast when the repository variables disagree with each other, including these cases:
+
+- `FORUM_LIVE_REQUIRES_ACCESS_CODE=true` while `FORUM_LIVE_WRITES_ENABLED=false`
+- `FORUM_LIVE_EXERCISE_WRITE_FLOW=true` outside preview mode
+- `FORUM_LIVE_EXERCISE_WRITE_FLOW=true` while writes are still disabled
+- `FORUM_LIVE_EXERCISE_WRITE_FLOW=true` and `FORUM_LIVE_REQUIRES_ACCESS_CODE=true` without the secret `FORUM_LIVE_WRITE_ACCESS_CODE`
+
 If `FORUM_LIVE_URL` is still empty, the hourly workflow exits cleanly without failing. Manual `workflow_dispatch` runs keep working with the explicit inputs.
 
-The hourly workflow now also writes a job summary for both skip and check paths, so the run itself tells you which target posture it resolved and whether the repository variables are still incomplete.
+The hourly workflow now also writes a job summary for both skip and check paths, so the run itself tells you which target posture it resolved and whether the repository variables are still incomplete. When preview checks carry a public base URL, or production checks still omit one, the summary also surfaces that mismatch as a warning instead of leaving it buried in the smoke-check logs.
 
 Live HTTP requests now time out after 15 seconds per call. That keeps an unreachable preview or production target from leaving the hourly workflow hanging for too long before it reports the failure.
 

--- a/forum/scripts/resolve-live-deployment-target.mjs
+++ b/forum/scripts/resolve-live-deployment-target.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { writeFile } from "node:fs/promises";
+
+function parseBoolean(value, key) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Expected ${key} to be true or false, received: ${value}`);
+}
+
+function normalizeUrl(value) {
+  return value ? value.replace(/\/$/, "") : "";
+}
+
+function createPayload(target) {
+  return JSON.stringify(target, null, 2);
+}
+
+function buildSummaryLines(target) {
+  if (target.skip) {
+    return [
+      "## Live forum target",
+      "",
+      "- status: skipped",
+      `- reason: ${target.reason}`,
+      "- next config: set FORUM_LIVE_URL and the related FORUM_LIVE_* repository variables before expecting hourly checks to hit a real target",
+    ];
+  }
+
+  return [
+    "## Live forum target",
+    "",
+    "- status: ready to check",
+    `- forum_url: ${target.forumUrl}`,
+    `- deployment_stage: ${target.deploymentStage}`,
+    `- public_base_url: ${target.publicBaseUrl || "(empty)"}`,
+    `- writes_enabled: ${String(target.writesEnabled)}`,
+    `- requires_access_code: ${String(target.requiresAccessCode)}`,
+    `- exercise_write_flow: ${String(target.exerciseWriteFlow)}`,
+    `- request_timeout_ms: ${target.requestTimeoutMs}`,
+    ...target.warnings.map((warning) => `- warning: ${warning}`),
+  ];
+}
+
+async function main() {
+  const source = process.env.FORUM_LIVE_SOURCE || "scheduled";
+  const forumUrl = normalizeUrl(process.env.FORUM_LIVE_URL?.trim() || "");
+
+  if (!forumUrl) {
+    const skippedTarget = {
+      source,
+      skip: true,
+      reason: "No forum URL configured for scheduled live deployment checks.",
+    };
+
+    if (process.env.FORUM_LIVE_TARGET_PATH) {
+      await writeFile(process.env.FORUM_LIVE_TARGET_PATH, `${createPayload(skippedTarget)}\n`, "utf-8");
+    }
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      await writeFile(process.env.GITHUB_STEP_SUMMARY, `${buildSummaryLines(skippedTarget).join("\n")}\n`, {
+        encoding: "utf-8",
+        flag: "a",
+      });
+    }
+
+    return;
+  }
+
+  const deploymentStage = process.env.FORUM_LIVE_DEPLOYMENT_STAGE?.trim() || "preview";
+  if (deploymentStage !== "preview" && deploymentStage !== "production") {
+    throw new Error(`Expected FORUM_LIVE_DEPLOYMENT_STAGE to be preview or production, received: ${deploymentStage}`);
+  }
+
+  const writesEnabled = parseBoolean(process.env.FORUM_LIVE_WRITES_ENABLED ?? "false", "FORUM_LIVE_WRITES_ENABLED") ?? false;
+  const requiresAccessCode =
+    parseBoolean(process.env.FORUM_LIVE_REQUIRES_ACCESS_CODE ?? "false", "FORUM_LIVE_REQUIRES_ACCESS_CODE") ?? false;
+  const exerciseWriteFlow =
+    parseBoolean(process.env.FORUM_LIVE_EXERCISE_WRITE_FLOW ?? "false", "FORUM_LIVE_EXERCISE_WRITE_FLOW") ?? false;
+
+  const publicBaseUrl = normalizeUrl(process.env.FORUM_LIVE_PUBLIC_BASE_URL?.trim() || "");
+  const writeAccessCode = process.env.FORUM_LIVE_WRITE_ACCESS_CODE?.trim() || "";
+  const requestTimeoutMs = Number.parseInt(process.env.FORUM_LIVE_REQUEST_TIMEOUT_MS || "15000", 10);
+
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new Error(
+      `Expected FORUM_LIVE_REQUEST_TIMEOUT_MS to be a positive integer, received: ${process.env.FORUM_LIVE_REQUEST_TIMEOUT_MS}`,
+    );
+  }
+
+  if (requiresAccessCode && !writesEnabled) {
+    throw new Error("FORUM_LIVE_REQUIRES_ACCESS_CODE=true requires FORUM_LIVE_WRITES_ENABLED=true.");
+  }
+
+  if (exerciseWriteFlow && deploymentStage !== "preview") {
+    throw new Error("FORUM_LIVE_EXERCISE_WRITE_FLOW=true is only supported for preview runtimes.");
+  }
+
+  if (exerciseWriteFlow && !writesEnabled) {
+    throw new Error("FORUM_LIVE_EXERCISE_WRITE_FLOW=true requires FORUM_LIVE_WRITES_ENABLED=true.");
+  }
+
+  if (exerciseWriteFlow && requiresAccessCode && !writeAccessCode) {
+    throw new Error(
+      "FORUM_LIVE_EXERCISE_WRITE_FLOW=true with FORUM_LIVE_REQUIRES_ACCESS_CODE=true requires secret FORUM_LIVE_WRITE_ACCESS_CODE.",
+    );
+  }
+
+  const warnings = [];
+
+  if (deploymentStage === "preview" && publicBaseUrl) {
+    warnings.push("preview checks received FORUM_LIVE_PUBLIC_BASE_URL; indexing still stays off until production mode.");
+  }
+
+  if (deploymentStage === "production" && !publicBaseUrl) {
+    warnings.push("production checks are running without FORUM_LIVE_PUBLIC_BASE_URL, so the live forum is expected to stay noindex.");
+  }
+
+  const resolvedTarget = {
+    source,
+    skip: false,
+    forumUrl,
+    deploymentStage,
+    publicBaseUrl,
+    writesEnabled,
+    requiresAccessCode,
+    exerciseWriteFlow,
+    requestTimeoutMs,
+    warnings,
+  };
+
+  if (process.env.FORUM_LIVE_TARGET_PATH) {
+    await writeFile(process.env.FORUM_LIVE_TARGET_PATH, `${createPayload(resolvedTarget)}\n`, "utf-8");
+  }
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await writeFile(process.env.GITHUB_STEP_SUMMARY, `${buildSummaryLines(resolvedTarget).join("\n")}\n`, {
+      encoding: "utf-8",
+      flag: "a",
+    });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a dedicated live-target resolver for the hourly forum deployment check
- fail fast when repository variables describe an impossible preview or production posture
- document the new preflight rules in the forum deployment guide

## Testing
- local node run with no `FORUM_LIVE_URL` configured
- local node run with a writable preview target plus shared access code
- local node run confirming invalid `requires_access_code=true` + `writes_enabled=false` fails fast

## Why now
The current highest-priority forum gap is no longer another page or API surface. It is getting the real preview or production target wired into the hourly live smoke check without silent misconfiguration. This change makes that handoff clearer and safer before the repository variables point at a real deployed forum.