### PR TITLE
fix(web): restore homepage global dharma hero title

### DIFF
--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -470,12 +470,12 @@ export default async function HomePage() {
               </span>
             </div>
             <h1 id="home-title">
-              <LocalizedText zh="学佛，从今天的一小步开始。" en="Begin buddhadharma with one small step." />
+              <LocalizedText zh="全球法布施" en="Global Dharma Giving" />
             </h1>
             <p className="hero-subtitle">
               <LocalizedText
-                zh="从学佛入门、佛学基本概念、因果、菩提心、六度与空性，到经文听诵、禅修、日常功课与全球法布施，先把学习路径和练习工具放回同一个入口。"
-                en="From beginner dharma questions and a clearer concepts hub to sutra listening, meditation, daily rhythm, and global giving, Fabushi keeps learning paths and practice tools inside one entry point."
+                zh="从学佛入门、佛学基本概念到经文听诵、禅修与日常功课，把修行路径和练习工具放回同一个入口。"
+                en="From beginner dharma questions and core concepts to sutra listening, meditation, and daily rhythm, Fabushi keeps learning paths and practice tools inside one entry point."
               />
             </p>
             <div className="hero-actions">


### PR DESCRIPTION
## 问题

最新 `main` 复核后发现：首页首屏虽然已经承接了完整的学佛路径分发、FAQ 和结构化数据，但 hero 本身仍有一个更基础的错位：

- 首页主标题当前不是项目约束要求的 `全球法布施`
- 首屏小字虽然只保留了一句，但它和主标题的关系已经被改成“学习入口页”式表达
- 这让首页在品牌首页、下载入口和内容分发页之间的角色边界变得不够稳定

当前最值得先修的，不是继续往首页堆更多 SEO 词面或再加一组入口，而是先把首页首屏语义收回到项目已经明确的首页约束里，再让现有的学习路径分发、FAQ、metadata 和结构化数据继续承担内容覆盖。

## 这次改动

- 仅更新 `frontend/apps/web/src/app/page.tsx`
- 把首页 hero `h1` 恢复为 `全球法布施`
- 把 hero supporting copy 收紧为一句话：
  - 保留学佛入门、佛学基本概念、经文听诵、禅修与日常功课这些已存在的路径信号
  - 但不再让首页首屏变成另一种替代 H1 的长标题
- 保留现有：
  - 首页 metadata
  - `学佛路径` 分发区块
  - 首页 FAQ 预览与 FAQ schema
  - 首页 `ItemList` 结构化数据
  - 下载按钮、截图体系与下载状态卡片

## 为什么现在做

这一步的收益很集中：

- 先把首页恢复到更稳定的一致性约束上
- 不牺牲现有已经铺好的内容分发层
- 避免为了首页 SEO 继续挤压首页本来更重要的品牌与下载入口角色
- 让后续内容增长继续更多落在主题页、概念页、佛经页和实践页，而不是反复改首页主标题

## 配图判断

- 本轮没有新增配图。
- 原因很明确：首页已经有稳定的产品截图体系；这次最值钱的是修正首屏 H1 与一句话说明的角色，不是再往首屏追加新的视觉元素。

## 验证

- compare 已确认当前分支相对 `main`：`ahead_by = 1`、`behind_by = 0`
- 改动范围只在 1 个文件：
  - `frontend/apps/web/src/app/page.tsx`
- 分支回读已确认首页 hero 现在包含：
  - `全球法布施` 作为首页主标题
  - 一句精简的小字说明
  - 原有学习路径快捷入口仍保留在折叠区上方
- 当前环境没有仓库本地 checkout，无法在这里直接运行 Next.js 构建；最终检查仍依赖仓库现有 CI
- 不对排名结果作保证；这次改动的确定性收益在于修正首页首屏语义与项目约束之间的冲突，同时保留既有内容分发层

## 下一步承接

- 下一步最值得继续推进的，不是再改首页主标题，而是继续审视 `practice-guide`、`daily-practice` 与佛经问题页之间的双向桥接，尤其是把“先从哪部经进入”怎样更自然地接回日常练习节奏表达得更清楚。