### PR TITLE
feat(forum): derive live target vars from deploy env

### DIFF
--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -37,6 +37,33 @@ Scheduled runs read these repository variables:
 
 If the live target still requires the shared preview code, also store it in the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE`.
 
+Once the target host has a working `forum/.env.deploy`, generate the matching hourly-check variables from that same file instead of retyping them by hand:
+
+```bash
+cd forum
+node scripts/prepare-live-deployment-vars.mjs \
+  --forum-url https://forum-preview.example.com \
+  --deploy-env-path .env.deploy
+```
+
+That command prints the exact `FORUM_LIVE_*` block expected by the hourly workflow. When you want copy-pasteable GitHub CLI commands instead, use:
+
+```bash
+cd forum
+node scripts/prepare-live-deployment-vars.mjs \
+  --forum-url https://forum-preview.example.com \
+  --deploy-env-path .env.deploy \
+  --format github-cli
+```
+
+If the preview runtime is intentionally writable and you want the hourly workflow to exercise the live thread-and-reply flow, add:
+
+```bash
+--exercise-write-flow true
+```
+
+When `.env.deploy` includes `FORUM_WRITE_ACCESS_CODE`, the `github-cli` output also prints the matching `gh secret set FORUM_LIVE_WRITE_ACCESS_CODE` command so the shared preview gate stays aligned with the live smoke check.
+
 Recommended preview baseline:
 
 ```text

--- a/forum/package.json
+++ b/forum/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "start:standalone": "node .next/standalone/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "smoke:deployment": "node ./scripts/check-deployment-contract.mjs"
+    "smoke:deployment": "node ./scripts/check-deployment-contract.mjs",
+    "prepare:live-target": "node ./scripts/prepare-live-deployment-vars.mjs"
   },
   "dependencies": {
     "next": "^15.5.2",

--- a/forum/scripts/prepare-live-deployment-vars.mjs
+++ b/forum/scripts/prepare-live-deployment-vars.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+function parseArgs(argv) {
+  const parsed = {
+    "deploy-env-path": ".env.deploy",
+    "exercise-write-flow": "false",
+    format: "env",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const part = argv[index];
+
+    if (!part.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${part}`);
+    }
+
+    const key = part.slice(2);
+    const value = argv[index + 1];
+
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value, key) {
+  if (value === undefined || value === null || value === "") {
+    return false;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Expected ${key} to be true or false, received: ${value}`);
+}
+
+function normalizeUrl(value) {
+  return value ? value.replace(/\/$/, "") : "";
+}
+
+function parseDotEnv(content) {
+  const values = {};
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex === -1) {
+      throw new Error(`Expected KEY=VALUE line in deploy env file, received: ${rawLine}`);
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    values[key] = value;
+  }
+
+  return values;
+}
+
+function buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow }) {
+  const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
+  if (deploymentStage !== "preview" && deploymentStage !== "production") {
+    throw new Error(
+      `Expected FORUM_DEPLOYMENT_STAGE in deploy env to be preview or production, received: ${deploymentStage}`,
+    );
+  }
+
+  const writesEnabled = parseBoolean(deployEnv.FORUM_ENABLE_WRITES ?? "false", "FORUM_ENABLE_WRITES");
+  const requiresAccessCode = writesEnabled && Boolean((deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim());
+  const publicBaseUrl = normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
+
+  if (exerciseWriteFlow && deploymentStage !== "preview") {
+    throw new Error("exercise_write_flow can only be enabled for preview deployments.");
+  }
+
+  if (exerciseWriteFlow && !writesEnabled) {
+    throw new Error("exercise_write_flow=true requires FORUM_ENABLE_WRITES=true in the deploy env file.");
+  }
+
+  return {
+    FORUM_LIVE_URL: normalizeUrl(forumUrl),
+    FORUM_LIVE_DEPLOYMENT_STAGE: deploymentStage,
+    FORUM_LIVE_PUBLIC_BASE_URL: publicBaseUrl,
+    FORUM_LIVE_WRITES_ENABLED: String(writesEnabled),
+    FORUM_LIVE_REQUIRES_ACCESS_CODE: String(requiresAccessCode),
+    FORUM_LIVE_EXERCISE_WRITE_FLOW: String(exerciseWriteFlow),
+  };
+}
+
+function renderEnvFormat(liveTarget) {
+  return Object.entries(liveTarget)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+}
+
+function renderGithubCliFormat(liveTarget, deployEnv) {
+  const lines = Object.entries(liveTarget).map(
+    ([key, value]) => `gh variable set ${key} --body '${value.replace(/'/g, "'\"'\"'")}'`,
+  );
+
+  if (liveTarget.FORUM_LIVE_REQUIRES_ACCESS_CODE === "true") {
+    const accessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
+
+    lines.push("");
+    lines.push("# Run this once if the preview write gate is enabled for the live target.");
+    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${accessCode.replace(/'/g, "'\"'\"'")}'`);
+  }
+
+  return lines.join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
+
+  if (!forumUrl) {
+    throw new Error("Missing required --forum-url.");
+  }
+
+  const format = args.format?.trim() || "env";
+  if (format !== "env" && format !== "github-cli") {
+    throw new Error(`Expected --format to be env or github-cli, received: ${format}`);
+  }
+
+  const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
+
+  const deployEnvContent = await readFile(args["deploy-env-path"], "utf-8");
+  const deployEnv = parseDotEnv(deployEnvContent);
+  const liveTarget = buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow });
+
+  if (format === "github-cli") {
+    console.log(renderGithubCliFormat(liveTarget, deployEnv));
+    return;
+  }
+
+  console.log(renderEnvFormat(liveTarget));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a forum helper script that derives `FORUM_LIVE_*` hourly-check variables from `forum/.env.deploy`
- add `pnpm prepare:live-target` as the stable entrypoint for that mapping step
- document the real-host handoff in `forum/DEPLOY.md`, including optional GitHub CLI commands and preview write-flow handling

## Why now
The current highest-priority forum blocker is no longer another page, API route, or workflow guard. The repository is already ready to check a real preview or production forum every hour, but the first live handoff still depends on manually translating `.env.deploy` into the repository-level `FORUM_LIVE_*` variables.

This change keeps the work narrowly focused on that gap:
- once a preview host is up from `forum/.env.deploy`
- we can derive the matching hourly live-check posture directly
- and reduce the risk of the host runtime drifting from the repository smoke-check configuration

## What changed
- `forum/scripts/prepare-live-deployment-vars.mjs`
  - requires `--forum-url`
  - reads `--deploy-env-path` (default `.env.deploy`)
  - derives:
    - `FORUM_LIVE_URL`
    - `FORUM_LIVE_DEPLOYMENT_STAGE`
    - `FORUM_LIVE_PUBLIC_BASE_URL`
    - `FORUM_LIVE_WRITES_ENABLED`
    - `FORUM_LIVE_REQUIRES_ACCESS_CODE`
    - `FORUM_LIVE_EXERCISE_WRITE_FLOW`
  - refuses impossible postures such as `--exercise-write-flow true` on production or while writes are still disabled
  - supports:
    - default env-block output
    - `--format github-cli` for `gh variable set ...` / `gh secret set ...`
- `forum/package.json`
  - adds `pnpm prepare:live-target`
- `forum/DEPLOY.md`
  - adds the concrete host-to-repository handoff step for hourly live deployment checks

## Verification
- local Node run with `.env.deploy` in read-only preview posture produced the expected `FORUM_LIVE_*` env block
- local Node run with writable preview plus `FORUM_WRITE_ACCESS_CODE` produced the expected `gh variable set ...` and `gh secret set ...` commands
- local Node run confirmed `--exercise-write-flow true` fails fast for production posture

## Remaining blocker after this PR
- the repository still needs a real `FORUM_LIVE_URL` and matching live target values before hourly checks can hit an actual deployed forum
- this PR narrows that blocker to real infrastructure values rather than more repo-side translation work