### PR TITLE
feat(forum): preflight deploy env postures before host rollout

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -6,7 +6,9 @@ on:
       - "forum/docker-compose.deploy.yml"
       - "forum/.env.deploy.example"
       - "forum/DEPLOY.md"
+      - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
+      - "forum/scripts/validate-deploy-env.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
   push:
     branches:
@@ -15,7 +17,9 @@ on:
       - "forum/docker-compose.deploy.yml"
       - "forum/.env.deploy.example"
       - "forum/DEPLOY.md"
+      - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
+      - "forum/scripts/validate-deploy-env.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
 
 permissions:
@@ -32,6 +36,47 @@ jobs:
             .github
             forum
           fetch-depth: 1
+
+      - name: Validate read-only preview deploy env baseline
+        run: |
+          node forum/scripts/validate-deploy-env.mjs \
+            --deploy-env-path forum/.env.deploy.example
+
+      - name: Prepare writable preview deploy env sample
+        run: |
+          cat <<'EOF' >/tmp/forum-deploy-writable-preview.env
+          FORUM_IMAGE=fabushi-forum
+          FORUM_PORT=3001
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data
+          FORUM_DEPLOYMENT_STAGE=preview
+          FORUM_PUBLIC_BASE_URL=
+          FORUM_DATA_SOURCE=sqlite
+          FORUM_ENABLE_WRITES=true
+          FORUM_WRITE_ACCESS_CODE=forum-preview-2026
+          EOF
+
+      - name: Validate writable preview deploy env posture
+        run: |
+          node forum/scripts/validate-deploy-env.mjs \
+            --deploy-env-path /tmp/forum-deploy-writable-preview.env
+
+      - name: Prepare production deploy env sample
+        run: |
+          cat <<'EOF' >/tmp/forum-deploy-production.env
+          FORUM_IMAGE=fabushi-forum
+          FORUM_PORT=3001
+          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data
+          FORUM_DEPLOYMENT_STAGE=production
+          FORUM_PUBLIC_BASE_URL=https://forum.fabushi.test
+          FORUM_DATA_SOURCE=sqlite
+          FORUM_ENABLE_WRITES=false
+          FORUM_WRITE_ACCESS_CODE=
+          EOF
+
+      - name: Validate production deploy env posture
+        run: |
+          node forum/scripts/validate-deploy-env.mjs \
+            --deploy-env-path /tmp/forum-deploy-production.env
 
       - name: Build forum container image
         run: docker build -t fabushi-forum ./forum

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -22,6 +22,20 @@ cp .env.deploy.example .env.deploy
 
 Then edit `.env.deploy` for the target runtime.
 
+Before you start the compose stack, validate the deploy posture from the same file:
+
+```bash
+cd forum
+pnpm check:deploy-env -- --deploy-env-path .env.deploy
+```
+
+That preflight step surfaces the effective deployment stage, write posture, access-code posture, and any mismatches that would otherwise only show up later during deploy or smoke-check time. It currently warns about cases like:
+
+- preview runtime carrying a public base URL
+- production runtime still missing a public base URL
+- write access code present while writes are still disabled
+- production runtime left writable before governance posture is ready
+
 ## Hourly live deployment checks
 
 The repository workflow `Live deployment checks - Forum` can now run every hour against one configured live forum target. This turns the current highest-priority deployment question from a manual reminder into a standing smoke check.

--- a/forum/package.json
+++ b/forum/package.json
@@ -10,7 +10,8 @@
     "start:standalone": "node .next/standalone/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke:deployment": "node ./scripts/check-deployment-contract.mjs",
-    "prepare:live-target": "node ./scripts/prepare-live-deployment-vars.mjs"
+    "prepare:live-target": "node ./scripts/prepare-live-deployment-vars.mjs",
+    "check:deploy-env": "node ./scripts/validate-deploy-env.mjs"
   },
   "dependencies": {
     "next": "^15.5.2",

--- a/forum/scripts/validate-deploy-env.mjs
+++ b/forum/scripts/validate-deploy-env.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+function parseArgs(argv) {
+  const parsed = {
+    "deploy-env-path": ".env.deploy",
+    format: "summary",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const part = argv[index];
+
+    if (!part.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${part}`);
+    }
+
+    const key = part.slice(2);
+    const value = argv[index + 1];
+
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value, key) {
+  if (value === undefined || value === null || value === "") {
+    return false;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Expected ${key} to be true or false, received: ${value}`);
+}
+
+function normalizeUrl(value) {
+  return value ? value.replace(/\/$/, "") : "";
+}
+
+function parseDotEnv(content) {
+  const values = {};
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex === -1) {
+      throw new Error(`Expected KEY=VALUE line in deploy env file, received: ${rawLine}`);
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    values[key] = value;
+  }
+
+  return values;
+}
+
+function buildDeployPosture({ deployEnvPath, deployEnv }) {
+  const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
+  if (deploymentStage !== "preview" && deploymentStage !== "production") {
+    throw new Error(
+      `Expected FORUM_DEPLOYMENT_STAGE in deploy env to be preview or production, received: ${deploymentStage}`,
+    );
+  }
+
+  const dataSource = deployEnv.FORUM_DATA_SOURCE?.trim() || "sqlite";
+  if (dataSource !== "sqlite" && dataSource !== "seed-json") {
+    throw new Error(`Expected FORUM_DATA_SOURCE in deploy env to be sqlite or seed-json, received: ${dataSource}`);
+  }
+
+  const image = deployEnv.FORUM_IMAGE?.trim() || "ghcr.io/bhrumom/fabushi-forum:main";
+  const port = deployEnv.FORUM_PORT?.trim() || "3000";
+  const dataDir = deployEnv.FORUM_DATA_DIR?.trim() || "./data";
+  const publicBaseUrl = normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
+  const writesEnabled = parseBoolean(deployEnv.FORUM_ENABLE_WRITES ?? "false", "FORUM_ENABLE_WRITES");
+  const writeAccessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
+  const requiresAccessCode = writesEnabled && Boolean(writeAccessCode);
+
+  const warnings = [];
+
+  if (deploymentStage === "preview" && publicBaseUrl) {
+    warnings.push("preview deploy env sets FORUM_PUBLIC_BASE_URL; the runtime will still stay noindex until production mode.");
+  }
+
+  if (deploymentStage === "production" && !publicBaseUrl) {
+    warnings.push("production deploy env omits FORUM_PUBLIC_BASE_URL, so the runtime will still behave as noindex.");
+  }
+
+  if (!writesEnabled && writeAccessCode) {
+    warnings.push(
+      "FORUM_WRITE_ACCESS_CODE is set while writes are disabled; the shared preview gate will stay inactive until FORUM_ENABLE_WRITES=true.",
+    );
+  }
+
+  if (deploymentStage === "production" && writesEnabled) {
+    warnings.push(
+      "production deploy env keeps writes enabled; confirm moderation and access posture before exposing a public indexed runtime.",
+    );
+  }
+
+  if (dataSource !== "sqlite") {
+    warnings.push("deploy compose currently defaults to sqlite durable storage; confirm this alternative data source is intentional.");
+  }
+
+  return {
+    status: "ready",
+    deployEnvPath,
+    image,
+    port,
+    dataDir,
+    dataSource,
+    deploymentStage,
+    publicBaseUrl,
+    writesEnabled,
+    requiresAccessCode,
+    warnings,
+  };
+}
+
+function renderSummary(posture) {
+  return [
+    "## Deploy env posture",
+    "",
+    "- status: ready to deploy",
+    `- deploy_env_path: ${posture.deployEnvPath}`,
+    `- image: ${posture.image}`,
+    `- port: ${posture.port}`,
+    `- data_dir: ${posture.dataDir}`,
+    `- data_source: ${posture.dataSource}`,
+    `- deployment_stage: ${posture.deploymentStage}`,
+    `- public_base_url: ${posture.publicBaseUrl || "(empty)"}`,
+    `- writes_enabled: ${String(posture.writesEnabled)}`,
+    `- requires_access_code: ${String(posture.requiresAccessCode)}`,
+    ...posture.warnings.map((warning) => `- warning: ${warning}`),
+  ].join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const format = args.format?.trim() || "summary";
+
+  if (format !== "summary" && format !== "json") {
+    throw new Error(`Expected --format to be summary or json, received: ${format}`);
+  }
+
+  const deployEnvPath = args["deploy-env-path"];
+  const deployEnvContent = await readFile(deployEnvPath, "utf-8");
+  const deployEnv = parseDotEnv(deployEnvContent);
+  const posture = buildDeployPosture({ deployEnvPath, deployEnv });
+
+  if (format === "json") {
+    console.log(`${JSON.stringify(posture, null, 2)}`);
+    return;
+  }
+
+  console.log(renderSummary(posture));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a deploy-env preflight script for `forum/.env.deploy`
- expose it as `pnpm check:deploy-env` and document the host-side usage in `forum/DEPLOY.md`
- run the preflight across preview, writable preview, and production sample postures before the existing deploy compose smoke checks

## Why now
The forum's current highest-priority blocker is no longer another page or workflow branch. It is the first real host handoff: editing `forum/.env.deploy`, bringing up `docker-compose.deploy.yml`, and then wiring the resulting runtime into the hourly live smoke checks.

`PR #502` already removed the manual `.env.deploy -> FORUM_LIVE_*` translation step, but there was still no explicit repo-side tool to catch a miswritten deploy env before the host even starts.

This PR keeps the scope narrow and directly aligned with that blocker:
- validate the deploy env first
- then start compose
- then derive the hourly live-target variables from the same file

## What changed
- `forum/scripts/validate-deploy-env.mjs`
  - reads a `.env.deploy`-style file
  - prints the effective deployment posture
  - validates `FORUM_DEPLOYMENT_STAGE` and `FORUM_DATA_SOURCE`
  - reports warnings for:
    - preview carrying `FORUM_PUBLIC_BASE_URL`
    - production missing `FORUM_PUBLIC_BASE_URL`
    - `FORUM_WRITE_ACCESS_CODE` present while writes stay disabled
    - production left writable
- `forum/package.json`
  - adds `pnpm check:deploy-env`
- `forum/DEPLOY.md`
  - adds the preflight step before `docker compose up`
- `.github/workflows/forum-deploy-compose-checks.yml`
  - includes the new script and `forum/package.json` in its path filters
  - validates read-only preview, writable preview, and production sample env files before running the existing compose contract checks

## Why this is the right smallest next move
The repository is already close to the point where the next meaningful progress has to happen on a real preview host. The best repo-side leverage now is not more live-check plumbing, but reducing the chance that the first host rollout fails because `.env.deploy` itself drifted into an unintended posture.

This makes the deployment handoff more reliable without expanding scope into unrelated forum features.

## Verification
- compared the branch against `main` and confirmed the diff stays within 4 deployment-focused files
- re-read the branch versions of the new preflight script, deploy workflow, and deploy guide to confirm they line up around the same host rollout path
- current environment still does not have a mounted repo checkout or a real preview target, so final runtime verification remains with the repository CI and the later real-host rollout