### PR TITLE
feat(web): align faq intent and strengthen six paramitas bridges

### DIFF
--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -6,33 +6,58 @@ import { SiteHeader } from "../../components/site-header";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
 const faqUrl = siteUrl("/faq");
-const faqTitle = `FAQ | ${brand.name}`;
-const faqDescription = "Fabushi download, beta access, and support questions.";
+const faqTitle = `学佛常见问题 | ${brand.name}`;
+const faqDescription =
+  "面向初学者整理学佛常见问题：学佛从哪里开始、先读经还是先禅修、佛学基本概念先看哪些、因果是什么意思、菩提心是什么意思、六度分别是什么、空性怎么理解，以及 Fabushi 在日常练习里最适合帮助什么。";
 
 const faqItems = [
   {
-    questionZh: "我应该下载哪个版本？",
-    questionEn: "Which version should I download?",
-    answerZh: "想尽快体验新功能，先看测试版；更重视稳定性，就等正式版。",
-    answerEn: "Choose beta if you want new features quickly. Wait for stable if you prefer a steadier path.",
+    questionZh: "学佛从哪里开始，才不会一开始就太重？",
+    questionEn: "How can I begin buddhadharma without making it too heavy immediately?",
+    answerZh: "更稳的起点通常不是一下子学很多，而是先看清自己当下最需要的入口。可以先从“学佛从哪里开始”理清方向，再决定先走佛法入门、佛学基本概念、修行方法，还是佛经导读。",
+    answerEn: "A steadier beginning is usually not to learn everything at once, but to clarify the doorway that matches your present question. Start by seeing where to begin, then choose whether dharma basics, core concepts, practice methods, or sutra study should come first.",
   },
   {
-    questionZh: "iOS 为什么会跳到 TestFlight？",
-    questionEn: "Why does iOS open TestFlight?",
-    answerZh: "iOS 内测通过 Apple TestFlight 分发，公开加入链接准备好后会直接显示。",
-    answerEn: "iOS beta is distributed through Apple TestFlight, and the public join link appears here once it is ready.",
+    questionZh: "先读经、先禅修，还是先把日常功课排出来？",
+    questionEn: "Should I begin with sutras, meditation, or a daily routine?",
+    answerZh: "更重要的是看你当下最需要什么。如果需要方向感，可以先看佛法入门；如果常常卡在因果、菩提心、六度、空性这些词，就先看佛学基本概念入门；如果需要把练习留在生活里，再继续看修行方法总览和日常功课安排。",
+    answerEn: "The better question is what you need most right now. If you need orientation, begin with dharma basics. If core terms such as karma, bodhicitta, the six paramitas, or emptiness keep stopping you, begin with the concepts hub. If you need practice to stay inside daily life, continue into the practice guide and daily routine page.",
   },
   {
-    questionZh: "Android 下载慢怎么办？",
-    questionEn: "What if Android downloads are slow?",
-    answerZh: "优先尝试下载页里的镜像链接；原始链接也会继续保留。",
-    answerEn: "Try the mirror links on the download page first. The original link stays available too.",
+    questionZh: "佛学基本概念应该先看哪几个？",
+    questionEn: "Which buddhist concepts should a beginner clarify first?",
+    answerZh: "对很多初学者来说，先把因果、菩提心、六度和空性放进同一张地图里，往往比零散地碰到一个算一个更稳。先看概念总览页，再决定自己现在更该先读哪一张概念页，会更容易继续往下走。",
+    answerEn: "For many beginners, it is steadier to place karma, bodhicitta, the six paramitas, and emptiness onto one map before treating them as isolated terms. Start with the concepts hub, then decide which concept page best matches the question you are living with now.",
   },
   {
-    questionZh: "官网会显示版本更新信息吗？",
-    questionEn: "Will the site show release updates?",
-    answerZh: "会。首页和下载页都会同步 GitHub 发布版本、发布时间和更新摘要。",
-    answerEn: "Yes. The homepage and download page sync GitHub release versions, publish time, and update summaries.",
+    questionZh: "因果是不是就是做好事得好报、做坏事受惩罚？",
+    questionEn: "Is karma just reward for good deeds and punishment for bad ones?",
+    answerZh: "更稳妥的理解不是这样简单。因果更像是起心动念、说话做事和长期习惯怎样慢慢形成结果，中间还会受到很多因缘影响，所以不适合被理解成一句立刻兑现的判断。",
+    answerEn: "A steadier understanding is not that simple. Karma is closer to the way intention, speech, action, and repeated habits gradually shape results together with many conditions, rather than an instant verdict.",
+  },
+  {
+    questionZh: "菩提心是不是只要对人好一点就够了？",
+    questionEn: "Is bodhicitta simply a matter of being a little nicer to people?",
+    answerZh: "不完全是。善意当然重要，但菩提心更深一层，它牵涉愿意把觉悟之路和众生利益一起放进修行方向里，而不是只让学习围着自己的得失打转。",
+    answerEn: "Not exactly. Kindness matters, but bodhicitta points more deeply toward placing awakening and the welfare of others inside the direction of practice instead of circling only around personal gain and loss.",
+  },
+  {
+    questionZh: "六度是不是一定要等懂很多教理以后，才谈得到？",
+    questionEn: "Do the six paramitas only matter after I understand a lot of doctrine?",
+    answerZh: "不一定。对初学者来说，六度可以先从很小的地方开始，例如今天多一点耐心、少一点急躁、练习断掉以后再回来一次。它不是离生活很远的清单，而是把发心慢慢接回日常的六个方向。",
+    answerEn: "Not necessarily. For beginners, the six paramitas can begin in very small ways, such as a little more patience today, a little less reactivity, or returning once more after the rhythm breaks. They are not distant doctrine, but six directions that slowly bring aspiration back into daily life.",
+  },
+  {
+    questionZh: "空性是不是就是“什么都没有”？",
+    questionEn: "Does emptiness mean that nothing exists at all?",
+    answerZh: "通常不是这样理解。更稳妥的方向，是说一切法都依赖因缘条件而成立，没有一个永远固定、不依赖任何条件的自性。它不是把生活否定掉，而是帮助人少一点把事情抓得太实、太绝对。",
+    answerEn: "Usually not. A steadier understanding is that all phenomena arise through conditions and do not possess an eternal self-existing essence. Emptiness does not cancel life, but helps loosen the tendency to treat things as too solid and absolute.",
+  },
+  {
+    questionZh: "Fabushi 在学佛入门阶段最适合帮助什么？",
+    questionEn: "What is Fabushi most useful for at the beginner stage?",
+    answerZh: "它更适合作为经文听诵、禅修提醒、简单记录和维持连续性的辅助工具，帮助你把修行节奏留在日常里。系统学习仍然要回到经典、老师和长期实践。",
+    answerEn: "It works best as a support tool for scripture listening, meditation reminders, simple notes, and continuity so practice can stay inside daily life. Deeper learning still depends on texts, teachers, and sustained practice.",
   },
 ] as const;
 
@@ -42,13 +67,25 @@ export const metadata: Metadata = {
   alternates: {
     canonical: faqUrl,
   },
-  keywords: ["Fabushi FAQ", "download help", "beta access"],
+  keywords: [
+    "学佛常见问题",
+    "学佛从哪里开始",
+    "佛法入门",
+    "佛学基本概念",
+    "因果是什么意思",
+    "菩提心是什么意思",
+    "六度分别是什么",
+    "空性怎么理解",
+    "初学者佛经推荐",
+    "修行方法",
+    "Fabushi",
+  ],
   openGraph: {
     title: faqTitle,
     description: faqDescription,
     url: faqUrl,
     siteName: "Fabushi",
-    locale: "en_US",
+    locale: "zh_CN",
     type: "website",
   },
   twitter: {
@@ -59,17 +96,60 @@ export const metadata: Metadata = {
 };
 
 export default function FaqPage() {
-  const faqJsonLd = {
+  const structuredData = {
     "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map((item) => ({
-      "@type": "Question",
-      name: item.questionEn,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: item.answerEn,
+    "@graph": [
+      {
+        "@type": "WebPage",
+        name: "学佛常见问题",
+        url: faqUrl,
+        description: faqDescription,
+        inLanguage: "zh-CN",
+        isPartOf: {
+          "@type": "WebSite",
+          name: `${brand.name} Fabushi`,
+          url: siteUrl("/"),
+        },
+        about: [
+          "学佛常见问题",
+          "学佛从哪里开始",
+          "佛法入门",
+          "佛学基本概念",
+          "因果",
+          "菩提心",
+          "六度",
+          "空性",
+        ],
       },
-    })),
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "首页",
+            item: siteUrl("/"),
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "学佛常见问题",
+            item: faqUrl,
+          },
+        ],
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: faqItems.map((item) => ({
+          "@type": "Question",
+          name: item.questionZh,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answerZh,
+          },
+        })),
+      },
+    ],
   };
 
   return (
@@ -77,18 +157,20 @@ export default function FaqPage() {
       <script
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
       <section className="inner-hero">
         <SiteHeader />
         <div className="inner-copy">
-          <p className="eyebrow">FAQ</p>
+          <p className="eyebrow">
+            <LocalizedText zh="学佛常见问题" en="Beginner FAQ" />
+          </p>
           <h1>
-            <LocalizedText zh="先解决下载前会卡住的问题。" en="Solve the questions that usually block a download first." />
+            <LocalizedText zh="先把学佛入门最常卡住的几个问题放清楚。" en="Clarify the beginner questions that most often block the next step." />
           </h1>
           <p className="lede">
-            <LocalizedText zh="产品、下载、内测和支持方式都在这里。" en="Product, download, beta access, and support answers all live here." />
+            <LocalizedText zh="从学佛从哪里开始，到因果、菩提心、六度、空性，再到佛经、禅修和日常功课，这一页先把最常见的问题收在一起。" en="From where to begin, to karma, bodhicitta, the six paramitas, emptiness, sutras, meditation, and daily rhythm, this page gathers the questions beginners ask most often." />
           </p>
         </div>
       </section>
@@ -107,11 +189,11 @@ export default function FaqPage() {
           ))}
         </div>
         <div className="inline-cta">
-          <a className="primary-action" href={siteHref("/download")}>
-            <LocalizedText zh="去下载" en="Go to downloads" />
+          <a className="primary-action" href={siteHref("/start-learning-buddhism")}>
+            <LocalizedText zh="先看学佛从哪里开始" en="Start with Where to Begin" />
           </a>
-          <a className="secondary-action" href={siteHref("/apply")}>
-            <LocalizedText zh="申请测试" en="Apply for beta" />
+          <a className="secondary-action" href={siteHref("/download")}>
+            <LocalizedText zh="再看下载入口" en="Then View Downloads" />
           </a>
         </div>
       </section>

--- a/frontend/apps/web/src/app/what-are-the-six-paramitas/page.tsx
+++ b/frontend/apps/web/src/app/what-are-the-six-paramitas/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const pageUrl = siteUrl("/what-are-the-six-paramitas");
 const pageTitle = `六度分别是什么 | ${brand.name}`;
 const pageDescription =
-  "面向初学者梳理六度分别是什么：布施、持戒、忍辱、精进、禅定、般若不是孤立清单，而是把菩提心、修行方法与日常功课接回生活的六个方向。";
+  "面向初学者梳理六度分别是什么：布施、持戒、忍辱、精进、禅定、般若不是孤立清单，而是把菩提心、《金刚经》里的般若问题、佛学基本概念、修行方法与日常功课接回生活的六个方向。";
 
 const sixParamitaFoundations = [
   {
@@ -91,6 +91,36 @@ const practiceSequence = [
   },
 ] as const;
 
+const scriptureBridgeSteps = [
+  {
+    href: "/beginner-sutra-recommendations",
+    labelZh: "从《金刚经》接到六度",
+    labelEn: "Diamond Sutra to Six Paramitas",
+    titleZh: "如果你是先在《金刚经》里被般若、无住和松动固着的语言打动，下一步先把这种感受接回更清楚的六度路径。",
+    titleEn: "If the Diamond Sutra first moved you through wisdom, non-abiding, and the loosening of rigid views, the next step is to return that experience to a clearer six-paramitas path.",
+    descriptionZh: "很多人第一次真正想继续理解六度，不是在概念清单里，而是在《金刚经》的语言里开始追问：这些义理为什么不会只停在观念里，而会回到做人做事与修行方法？把这一步说清楚，经典阅读才不容易只停在震动感上。",
+    descriptionEn: "Many readers first want to understand the six paramitas more deeply not through a concept list, but through the Diamond Sutra's language. The question becomes why these teachings do not stay in ideas alone, but return to conduct and actual practice. Clarifying that bridge helps scripture study continue beyond the initial impact.",
+  },
+  {
+    href: "/buddhist-concepts",
+    labelZh: "从六度接回佛学基本概念",
+    labelEn: "Six Paramitas to Concepts Hub",
+    titleZh: "如果你已经发现六度不只是六个名词，下一步可以回到更完整的概念地图，看它和因果、菩提心、空性怎样连成一条路。",
+    titleEn: "If the six paramitas are no longer just six terms, the next step is to return to the wider concepts hub and see how they join karma, bodhicitta, and emptiness on one path.",
+    descriptionZh: "很多人练着练着会发现，问题不会只停在“六度是什么意思”，而会继续连到因果为什么让方法要相续、菩提心为什么让发心变宽、空性为什么让般若不那么僵硬。先回到概念总览，会比在单页里硬撑更稳。",
+    descriptionEn: "Many readers eventually discover that the question does not stop at what the six paramitas mean. It keeps connecting to karma, bodhicitta, and emptiness. Returning to the concepts hub is often steadier than forcing every connection to remain on a single leaf page.",
+  },
+  {
+    href: "/daily-practice",
+    labelZh: "从六度接回日常功课",
+    labelEn: "Six Paramitas to Daily Practice",
+    titleZh: "如果你最关心的是怎样让六度不要只停在理解里，下一步先把它接回晨起、白天和晚间的小动作。",
+    titleEn: "If your main concern is how the six paramitas can live beyond explanation, the next step is to return them to small practices across morning, daytime, and evening.",
+    descriptionZh: "六度真正留得住，往往不是靠一次想明白，而是靠很轻但持续的功课，让自己在一天里一次次更愿意回来、更谨慎地说话、更能忍一点、少一点只围着自己打转。",
+    descriptionEn: "The six paramitas usually stay alive not through one decisive insight, but through a light and continuous routine that slowly builds return, care in speech, patience, and less self-enclosure across the day.",
+  },
+] as const;
+
 const commonMistakes = [
   {
     titleZh: "把六度当成一张背诵清单，却没有回到日常处境",
@@ -121,6 +151,33 @@ const relatedPaths = [
     titleEn: "Return to the intention that gives the six paramitas their direction.",
     descriptionZh: "如果你想先看清六度为什么会和大乘修学连在一起，可以先回到菩提心这一页。",
     descriptionEn: "Return here first if you want to see why the six paramitas belong so naturally to Mahayana aspiration.",
+  },
+  {
+    href: "/buddhist-concepts",
+    labelZh: "佛学基本概念",
+    labelEn: "Buddhist Concepts",
+    titleZh: "先回到一张更完整的概念地图，再决定自己现在更该继续看哪一个词。",
+    titleEn: "Return to a wider concepts map before deciding which concept deserves attention next.",
+    descriptionZh: "如果你已经发现自己的问题不只停在六度一个词上，而是开始和因果、菩提心、空性与修行方法连在一起，这一页会更适合先打开。",
+    descriptionEn: "Open this first if your question is no longer only about the six paramitas and is beginning to connect with karma, bodhicitta, emptiness, and actual practice.",
+  },
+  {
+    href: "/beginner-sutra-recommendations",
+    labelZh: "初学者佛经推荐",
+    labelEn: "Beginner Sutra Picks",
+    titleZh: "把《金刚经》为什么常会把人带到六度，放回更具体的经典入口里。",
+    titleEn: "Return the bridge from the Diamond Sutra to the six paramitas to a more specific beginner scripture entry point.",
+    descriptionZh: "如果你已经发现自己的问题更贴近《金刚经》、般若和松动固着看法，而不是抽象概念本身，这一页会更适合继续往下看。",
+    descriptionEn: "This page is more specific if your question is already closer to the Diamond Sutra, wisdom, and loosening rigid views than to abstract concept language alone.",
+  },
+  {
+    href: "/sutra-guide",
+    labelZh: "佛经导读",
+    labelEn: "Sutra Guide",
+    titleZh: "把经典阅读、般若问题和修行方向重新放回同一条路上。",
+    titleEn: "Return scripture study, wisdom questions, and the direction of practice to the same path.",
+    descriptionZh: "如果你已经发现自己常常是从《金刚经》、听诵或经典语言里先被打动，这一页会更适合继续往下走。",
+    descriptionEn: "This page is the better next step if you often find yourself moved first through the Diamond Sutra, listening, or the language of scripture itself.",
   },
   {
     href: "/what-is-emptiness",
@@ -192,10 +249,22 @@ const faqItems = [
     answerEn: "No. The six paramitas can become very deep, but they can also begin in very small ways. Giving a little more space, speaking a little more carefully, or returning after the rhythm breaks already belongs to this training.",
   },
   {
+    questionZh: "《金刚经》为什么常会把问题带到六度？",
+    questionEn: "Why does the Diamond Sutra so often lead people into the six paramitas?",
+    answerZh: "很多人被《金刚经》吸引，是因为它能松动固着看法；但继续往前时，更需要知道这种般若为什么不会只停在观念里，而会回到布施、持戒、忍辱、精进、禅定这些更具体的练习方向。六度正好能把这一步接起来。",
+    answerEn: "Many readers are drawn to the Diamond Sutra because it loosens rigid views, but the next need is often seeing why that wisdom does not remain only an idea and instead returns to generosity, discipline, patience, diligence, and meditation. The six paramitas are the natural bridge for that step.",
+  },
+  {
     questionZh: "般若是不是一定要懂很深的空性，才能算开始？",
     questionEn: "Does wisdom mean I need a deep understanding of emptiness before I can begin?",
     answerZh: "不一定。对初学者来说，般若可以先从更朴素的地方开始，例如慢慢看清哪些执着、判断和习惯正在让自己更苦。真正更深的义理会随着阅读、思惟和修行再慢慢展开，不必第一天就讲得很高。",
     answerEn: "Not necessarily. For beginners, wisdom can start more simply by seeing which attachments, judgments, and habits are deepening confusion. Deeper doctrine unfolds through reading, reflection, and practice over time and does not need to become lofty on day one.",
+  },
+  {
+    questionZh: "六度和佛学基本概念是什么关系？",
+    questionEn: "How do the six paramitas connect with the wider beginner concept map?",
+    answerZh: "六度不会孤立存在。它会继续连到菩提心为什么让方向变宽、因果为什么让方法要相续、空性为什么让般若不那么僵硬。把六度放回佛学基本概念总览里看，通常更容易明白它不是一张单独清单，而是整条修学路径中的一层。",
+    answerEn: "The six paramitas do not stand alone. They keep connecting back to how bodhicitta widens direction, how karma explains continuity, and how emptiness keeps wisdom from becoming rigid. Returning the six paramitas to the wider concepts hub usually makes it easier to see that they are not a separate checklist but one layer inside a larger path.",
   },
   {
     questionZh: "六度和日常功课有什么关系？",
@@ -222,7 +291,9 @@ export const metadata: Metadata = {
     "六度",
     "六度波罗蜜",
     "布施持戒忍辱精进禅定般若",
+    "金刚经 六度",
     "空性怎么理解",
+    "佛学基本概念",
     "菩提心",
     "大乘修行",
     "Fabushi",
@@ -257,7 +328,7 @@ export default function WhatAreTheSixParamitasPage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["六度", "六度波罗蜜", "菩提心", "大乘修行"],
+        about: ["六度", "六度波罗蜜", "菩提心", "大乘修行", "金刚经", "佛学基本概念入门", "空性"],
       },
       {
         "@type": "BreadcrumbList",
@@ -277,6 +348,12 @@ export default function WhatAreTheSixParamitasPage() {
           {
             "@type": "ListItem",
             position: 3,
+            name: "佛学基本概念入门",
+            item: siteUrl("/buddhist-concepts"),
+          },
+          {
+            "@type": "ListItem",
+            position: 4,
             name: "六度分别是什么",
             item: pageUrl,
           },
@@ -289,6 +366,17 @@ export default function WhatAreTheSixParamitasPage() {
           "@type": "ListItem",
           position: index + 1,
           name: item.titleZh,
+          description: item.descriptionZh,
+        })),
+      },
+      {
+        "@type": "ItemList",
+        name: "六度的经典与实践桥接路径",
+        itemListElement: scriptureBridgeSteps.map((item, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: item.labelZh,
+          url: siteUrl(item.href),
           description: item.descriptionZh,
         })),
       },
@@ -358,6 +446,12 @@ export default function WhatAreTheSixParamitasPage() {
             <LocalizedText
               zh="所以，六度不是和生活分开的另一套课程。它更像是在提醒人：修行不只是在安静的时候坐一坐，也会反映在今天怎么说话、怎么回应不顺、怎么把节奏接回来、怎么少一点只围着自己打转。对初学者来说，六度最有帮助的地方，不是一次把六个方向都做满，而是先找到自己现在最容易卡住的那一度。"
               en="The six paramitas are therefore not a separate course outside of life. They remind us that practice does not only happen in quiet formal moments, but also in how we speak today, respond to difficulty, return to rhythm, and loosen a path that circles too tightly around the self. For beginners, their real value is not filling out all six at once, but seeing which one feels most difficult right now."
+            />
+          </p>
+          <p>
+            <LocalizedText
+              zh="很多人第一次真正想继续理解六度，不是在概念清单里，而是在《金刚经》或般若类经典的语言里。问题常常不是“六度到底是哪六个”，而是“这些义理为什么不会只停在观念里，为什么会继续回到布施、持戒、忍辱、精进、禅定，乃至每天怎样做人做事”。把《金刚经》的入口、六度的概念页和后面的功课路径收回同一条线上，阅读才不容易断在最初的震动感上。"
+              en="Many readers first want to understand the six paramitas more deeply not through a concept list, but through the language of the Diamond Sutra and other wisdom texts. The question is often not only which six they are, but why these teachings do not stay as ideas and instead return to generosity, discipline, patience, diligence, meditation, and the way life is actually lived. Bringing the Diamond Sutra doorway, the six-paramitas page, and the later routine pages back onto one line helps reading continue beyond the first impact."
             />
           </p>
           <p>
@@ -455,6 +549,35 @@ export default function WhatAreTheSixParamitasPage() {
       <section className="band">
         <div className="section-heading tight">
           <p>
+            <LocalizedText zh="下一步接哪里" en="Where to Continue" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="把《金刚经》、六度、概念总览和日常练习重新接成同一条继续阅读路径。"
+              en="Reconnect the Diamond Sutra, the six paramitas, the concepts hub, and daily practice into one onward path."
+            />
+          </h2>
+        </div>
+        <div className="path-grid">
+          {scriptureBridgeSteps.map((item) => (
+            <a key={item.href} className="path-card" href={siteHref(item.href)}>
+              <h3>
+                <LocalizedText zh={item.labelZh} en={item.labelEn} />
+              </h3>
+              <strong>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </strong>
+              <p>
+                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+              </p>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>
             <LocalizedText zh="常见误区" en="Common Mistakes" />
           </p>
           <h2>
@@ -478,15 +601,15 @@ export default function WhatAreTheSixParamitasPage() {
         </div>
       </section>
 
-      <section className="band alt">
+      <section className="band">
         <div className="section-heading tight">
           <p>
             <LocalizedText zh="继续阅读" en="Keep Going" />
           </p>
           <h2>
             <LocalizedText
-              zh="把这张概念页接回更完整的入门、发心、方法和日常路径。"
-              en="Use this concept page as a bridge back into the wider beginner, aspiration, practice, and daily-life paths."
+              zh="把这张概念页接回更完整的入门、发心、经典、方法和日常路径。"
+              en="Use this concept page as a bridge back into the wider beginner, aspiration, scripture, practice, and daily-life paths."
             />
           </h2>
         </div>
@@ -509,7 +632,7 @@ export default function WhatAreTheSixParamitasPage() {
         </div>
       </section>
 
-      <section className="band faq-band">
+      <section className="band alt faq-band">
         <div className="section-heading tight">
           <p>FAQ</p>
           <h2>
@@ -535,8 +658,8 @@ export default function WhatAreTheSixParamitasPage() {
           <a className="primary-action" href={siteHref("/download")}>
             <LocalizedText zh="下载法布施" en="Download Fabushi" />
           </a>
-          <a className="secondary-action" href={siteHref("/what-is-bodhicitta")}>
-            <LocalizedText zh="返回菩提心是什么意思" en="Back to What Bodhicitta Means" />
+          <a className="secondary-action" href={siteHref("/buddhist-concepts")}>
+            <LocalizedText zh="返回佛学基本概念入门" en="Back to Buddhist Concepts" />
           </a>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- realign `/faq` from an old download-support page into a beginner buddhadharma FAQ page that matches the site's current learning-path structure
- strengthen `/what-are-the-six-paramitas` so it no longer reads like a mostly isolated concept leaf and instead bridges back into scripture, the concepts hub, and daily practice
- keep the scope intentionally tight to two high-leverage web files

## Why now
The latest `main` already has a much fuller buddhadharma cluster across homepage, beginner entry, concepts, practice, and sutra pages. The higher-yield gaps are now in two high-exposure places that still lag behind that structure:

1. `frontend/apps/web/src/app/faq/page.tsx`
- it is still written as an old product-support page
- but `/faq` is in the top navigation and `sitemap.ts`, so it is repeatedly emphasized as a high-visibility fixed entry point
- leaving it on `download / beta / support` wording makes it structurally out of sync with the rest of the live buddhadharma learning architecture

2. `frontend/apps/web/src/app/what-are-the-six-paramitas/page.tsx`
- it still lagged behind `what-is-bodhicitta` and `what-is-emptiness`
- it did not yet surface the natural `Diamond Sutra -> six paramitas` bridge clearly enough
- it also lacked a return path into `/buddhist-concepts`, so it behaved more like an isolated explainer than a node inside the concept cluster

## What changed
### `frontend/apps/web/src/app/faq/page.tsx`
- rewrote the page title, description, keywords, Open Graph, and Twitter metadata around beginner buddhadharma questions
- replaced the old product-support FAQ items with Chinese dharma-entry questions covering:
  - where to begin
  - sutras vs meditation vs daily routine
  - which core concepts to clarify first
  - karma
  - bodhicitta
  - the six paramitas
  - emptiness
  - Fabushi's role in beginner continuity
- changed FAQ structured data from English download-support answers to Chinese buddhadharma answers
- added `WebPage` and `BreadcrumbList` JSON-LD
- retargeted the primary CTA toward `/start-learning-buddhism`, keeping downloads as the secondary path

### `frontend/apps/web/src/app/what-are-the-six-paramitas/page.tsx`
- expanded the page description and keywords to include `金刚经 六度` and `佛学基本概念`
- added a new guide paragraph explaining that many readers first need this page after meeting wisdom language inside the `Diamond Sutra`
- added `scriptureBridgeSteps` plus a new `六度的经典与实践桥接路径` `ItemList` schema
- updated breadcrumb schema to:
  - `首页 -> 佛法入门 -> 佛学基本概念入门 -> 六度分别是什么`
- added stronger onward links into:
  - `/buddhist-concepts`
  - `/beginner-sutra-recommendations`
  - `/sutra-guide`
  - `/daily-practice`
- expanded FAQ coverage with:
  - `《金刚经》为什么常会把问题带到六度？`
  - `六度和佛学基本概念是什么关系？`
- changed the secondary CTA from the bodhicitta leaf page back to the concepts hub

## Image decision
- no new image was added in this hour
- `/faq` is a tool-like answer page where the primary issue was semantic mismatch, not visual attraction
- `/what-are-the-six-paramitas` still gets the highest return from clearer bridges, FAQ coverage, and structured data before introducing an unverified buddhadharma image pattern

## Verification
- branch readback confirms the PR stays scoped to 2 files:
  - `frontend/apps/web/src/app/faq/page.tsx`
  - `frontend/apps/web/src/app/what-are-the-six-paramitas/page.tsx`
- verified the branch versions now include:
  - the rewritten buddhadharma FAQ metadata, content, CTA, and schema
  - the new six-paramitas bridge section, breadcrumb path, related links, metadata terms, and FAQ additions
- this environment still does not have a mounted local repo checkout for running a Next.js build, so final runtime verification remains with repository CI
- no ranking guarantees implied; this change improves query-intent alignment, internal-link continuity, and high-visibility page consistency