### PR TITLE
feat(forum): bundle live deployment target config

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -8,8 +8,11 @@ on:
       - "forum/DEPLOY.md"
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
+      - "forum/scripts/prepare-live-deployment-vars.mjs"
+      - "forum/scripts/resolve-live-deployment-target.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
+      - ".github/workflows/forum-live-deployment-checks.yml"
   push:
     branches:
       - main
@@ -19,8 +22,11 @@ on:
       - "forum/DEPLOY.md"
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
+      - "forum/scripts/prepare-live-deployment-vars.mjs"
+      - "forum/scripts/resolve-live-deployment-target.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
+      - ".github/workflows/forum-live-deployment-checks.yml"
 
 permissions:
   contents: read
@@ -59,6 +65,34 @@ jobs:
         run: |
           node forum/scripts/validate-deploy-env.mjs \
             --deploy-env-path /tmp/forum-deploy-writable-preview.env
+
+      - name: Prepare bundled live target sample
+        run: |
+          node forum/scripts/prepare-live-deployment-vars.mjs \
+            --forum-url https://forum-preview.fabushi.test \
+            --deploy-env-path /tmp/forum-deploy-writable-preview.env \
+            --exercise-write-flow true \
+            --format json >/tmp/forum-live-target.json
+
+      - name: Validate bundled live target sample
+        run: |
+          export FORUM_LIVE_TARGET="$(cat /tmp/forum-live-target.json)"
+          export FORUM_LIVE_WRITE_ACCESS_CODE=forum-preview-2026
+          export FORUM_LIVE_TARGET_PATH=/tmp/forum-live-target-resolved.json
+
+          node forum/scripts/resolve-live-deployment-target.mjs
+          cat /tmp/forum-live-target-resolved.json
+
+      - name: Validate bundled live target GitHub CLI output
+        run: |
+          node forum/scripts/prepare-live-deployment-vars.mjs \
+            --forum-url https://forum-preview.fabushi.test \
+            --deploy-env-path /tmp/forum-deploy-writable-preview.env \
+            --exercise-write-flow true \
+            --format github-cli-bundled >/tmp/forum-live-target-cli.txt
+
+          grep "gh variable set FORUM_LIVE_TARGET" /tmp/forum-live-target-cli.txt
+          grep "gh secret set FORUM_LIVE_WRITE_ACCESS_CODE" /tmp/forum-live-target-cli.txt
 
       - name: Prepare production deploy env sample
         run: |

--- a/.github/workflows/forum-live-deployment-checks.yml
+++ b/.github/workflows/forum-live-deployment-checks.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Resolve and validate live forum target
         env:
           FORUM_LIVE_SOURCE: ${{ github.event_name }}
+          FORUM_LIVE_TARGET: ${{ vars.FORUM_LIVE_TARGET }}
         shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -40,14 +40,18 @@ That preflight step surfaces the effective deployment stage, write posture, acce
 
 The repository workflow `Live deployment checks - Forum` can now run every hour against one configured live forum target. This turns the current highest-priority deployment question from a manual reminder into a standing smoke check.
 
-Scheduled runs read these repository variables:
+Scheduled runs read either:
 
-- `FORUM_LIVE_URL`
-- `FORUM_LIVE_DEPLOYMENT_STAGE`
-- `FORUM_LIVE_PUBLIC_BASE_URL`
-- `FORUM_LIVE_WRITES_ENABLED`
-- `FORUM_LIVE_REQUIRES_ACCESS_CODE`
-- `FORUM_LIVE_EXERCISE_WRITE_FLOW`
+- a single repository variable `FORUM_LIVE_TARGET`
+- or the existing split repository variables:
+  - `FORUM_LIVE_URL`
+  - `FORUM_LIVE_DEPLOYMENT_STAGE`
+  - `FORUM_LIVE_PUBLIC_BASE_URL`
+  - `FORUM_LIVE_WRITES_ENABLED`
+  - `FORUM_LIVE_REQUIRES_ACCESS_CODE`
+  - `FORUM_LIVE_EXERCISE_WRITE_FLOW`
+
+If both are present, `FORUM_LIVE_TARGET` wins. This keeps the hourly workflow backward-compatible while letting the first real live target be stored as one cohesive bundle instead of six separate values.
 
 If the live target still requires the shared preview code, also store it in the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE`.
 
@@ -60,7 +64,27 @@ node scripts/prepare-live-deployment-vars.mjs \
   --deploy-env-path .env.deploy
 ```
 
-That command prints the exact `FORUM_LIVE_*` block expected by the hourly workflow. When you want copy-pasteable GitHub CLI commands instead, use:
+That command prints the existing split `FORUM_LIVE_*` block. If you want one bundled JSON payload for the repository variable `FORUM_LIVE_TARGET`, use:
+
+```bash
+cd forum
+node scripts/prepare-live-deployment-vars.mjs \
+  --forum-url https://forum-preview.example.com \
+  --deploy-env-path .env.deploy \
+  --format json
+```
+
+If you want copy-pasteable GitHub CLI commands for the single bundled variable instead, use:
+
+```bash
+cd forum
+node scripts/prepare-live-deployment-vars.mjs \
+  --forum-url https://forum-preview.example.com \
+  --deploy-env-path .env.deploy \
+  --format github-cli-bundled
+```
+
+The original split-variable CLI output is still available too:
 
 ```bash
 cd forum
@@ -76,7 +100,7 @@ If the preview runtime is intentionally writable and you want the hourly workflo
 --exercise-write-flow true
 ```
 
-When `.env.deploy` includes `FORUM_WRITE_ACCESS_CODE`, the `github-cli` output also prints the matching `gh secret set FORUM_LIVE_WRITE_ACCESS_CODE` command so the shared preview gate stays aligned with the live smoke check.
+When `.env.deploy` includes `FORUM_WRITE_ACCESS_CODE`, both `github-cli` formats also print the matching `gh secret set FORUM_LIVE_WRITE_ACCESS_CODE` command so the shared preview gate stays aligned with the live smoke check.
 
 Recommended preview baseline:
 
@@ -87,6 +111,19 @@ FORUM_LIVE_PUBLIC_BASE_URL=
 FORUM_LIVE_WRITES_ENABLED=false
 FORUM_LIVE_REQUIRES_ACCESS_CODE=false
 FORUM_LIVE_EXERCISE_WRITE_FLOW=false
+```
+
+Equivalent bundled target:
+
+```json
+{
+  "forumUrl": "https://forum-preview.example.com",
+  "deploymentStage": "preview",
+  "publicBaseUrl": "",
+  "writesEnabled": false,
+  "requiresAccessCode": false,
+  "exerciseWriteFlow": false
+}
 ```
 
 When preview writes are intentionally open behind the shared code, switch only the runtime flags you actually expect:
@@ -104,7 +141,7 @@ The hourly workflow now validates that live-target settings describe a coherent 
 - `FORUM_LIVE_EXERCISE_WRITE_FLOW=true` while writes are still disabled
 - `FORUM_LIVE_EXERCISE_WRITE_FLOW=true` and `FORUM_LIVE_REQUIRES_ACCESS_CODE=true` without the secret `FORUM_LIVE_WRITE_ACCESS_CODE`
 
-If `FORUM_LIVE_URL` is still empty, the hourly workflow exits cleanly without failing. Manual `workflow_dispatch` runs keep working with the explicit inputs.
+If `FORUM_LIVE_URL` and `FORUM_LIVE_TARGET` are both empty, the hourly workflow exits cleanly without failing. Manual `workflow_dispatch` runs keep working with the explicit inputs.
 
 The hourly workflow now also writes a job summary for both skip and check paths, so the run itself tells you which target posture it resolved and whether the repository variables are still incomplete. When preview checks carry a public base URL, or production checks still omit one, the summary also surfaces that mismatch as a warning instead of leaving it buried in the smoke-check logs.
 

--- a/forum/scripts/prepare-live-deployment-vars.mjs
+++ b/forum/scripts/prepare-live-deployment-vars.mjs
@@ -103,15 +103,34 @@ function buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow }) {
   };
 }
 
+function buildBundledLiveTarget(liveTarget) {
+  return {
+    forumUrl: liveTarget.FORUM_LIVE_URL,
+    deploymentStage: liveTarget.FORUM_LIVE_DEPLOYMENT_STAGE,
+    publicBaseUrl: liveTarget.FORUM_LIVE_PUBLIC_BASE_URL,
+    writesEnabled: liveTarget.FORUM_LIVE_WRITES_ENABLED === "true",
+    requiresAccessCode: liveTarget.FORUM_LIVE_REQUIRES_ACCESS_CODE === "true",
+    exerciseWriteFlow: liveTarget.FORUM_LIVE_EXERCISE_WRITE_FLOW === "true",
+  };
+}
+
+function quoteForSingleQuotedShell(value) {
+  return value.replace(/'/g, "'\"'\"'");
+}
+
 function renderEnvFormat(liveTarget) {
   return Object.entries(liveTarget)
     .map(([key, value]) => `${key}=${value}`)
     .join("\n");
 }
 
+function renderJsonFormat(liveTarget) {
+  return JSON.stringify(buildBundledLiveTarget(liveTarget), null, 2);
+}
+
 function renderGithubCliFormat(liveTarget, deployEnv) {
   const lines = Object.entries(liveTarget).map(
-    ([key, value]) => `gh variable set ${key} --body '${value.replace(/'/g, "'\"'\"'")}'`,
+    ([key, value]) => `gh variable set ${key} --body '${quoteForSingleQuotedShell(value)}'`,
   );
 
   if (liveTarget.FORUM_LIVE_REQUIRES_ACCESS_CODE === "true") {
@@ -119,7 +138,22 @@ function renderGithubCliFormat(liveTarget, deployEnv) {
 
     lines.push("");
     lines.push("# Run this once if the preview write gate is enabled for the live target.");
-    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${accessCode.replace(/'/g, "'\"'\"'")}'`);
+    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${quoteForSingleQuotedShell(accessCode)}'`);
+  }
+
+  return lines.join("\n");
+}
+
+function renderGithubCliBundledFormat(liveTarget, deployEnv) {
+  const bundledTargetJson = JSON.stringify(buildBundledLiveTarget(liveTarget));
+  const lines = [`gh variable set FORUM_LIVE_TARGET --body '${quoteForSingleQuotedShell(bundledTargetJson)}'`];
+
+  if (liveTarget.FORUM_LIVE_REQUIRES_ACCESS_CODE === "true") {
+    const accessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
+
+    lines.push("");
+    lines.push("# Run this once if the preview write gate is enabled for the live target.");
+    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${quoteForSingleQuotedShell(accessCode)}'`);
   }
 
   return lines.join("\n");
@@ -134,8 +168,8 @@ async function main() {
   }
 
   const format = args.format?.trim() || "env";
-  if (format !== "env" && format !== "github-cli") {
-    throw new Error(`Expected --format to be env or github-cli, received: ${format}`);
+  if (!["env", "json", "github-cli", "github-cli-bundled"].includes(format)) {
+    throw new Error(`Expected --format to be env, json, github-cli, or github-cli-bundled, received: ${format}`);
   }
 
   const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
@@ -146,6 +180,16 @@ async function main() {
 
   if (format === "github-cli") {
     console.log(renderGithubCliFormat(liveTarget, deployEnv));
+    return;
+  }
+
+  if (format === "github-cli-bundled") {
+    console.log(renderGithubCliBundledFormat(liveTarget, deployEnv));
+    return;
+  }
+
+  if (format === "json") {
+    console.log(renderJsonFormat(liveTarget));
     return;
   }
 

--- a/forum/scripts/resolve-live-deployment-target.mjs
+++ b/forum/scripts/resolve-live-deployment-target.mjs
@@ -15,6 +15,10 @@ function parseBoolean(value, key) {
     return false;
   }
 
+  if (value === true || value === false) {
+    return value;
+  }
+
   throw new Error(`Expected ${key} to be true or false, received: ${value}`);
 }
 
@@ -33,7 +37,7 @@ function buildSummaryLines(target) {
       "",
       "- status: skipped",
       `- reason: ${target.reason}`,
-      "- next config: set FORUM_LIVE_URL and the related FORUM_LIVE_* repository variables before expecting hourly checks to hit a real target",
+      "- next config: set FORUM_LIVE_URL or FORUM_LIVE_TARGET before expecting hourly checks to hit a real target",
     ];
   }
 
@@ -52,9 +56,68 @@ function buildSummaryLines(target) {
   ];
 }
 
+function parseBundledTarget(rawValue) {
+  if (!rawValue?.trim()) {
+    return {};
+  }
+
+  let parsed;
+
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch (error) {
+    throw new Error(`FORUM_LIVE_TARGET must be valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("FORUM_LIVE_TARGET must decode to a JSON object.");
+  }
+
+  return {
+    forumUrl: typeof parsed.forumUrl === "string" ? parsed.forumUrl : parsed.FORUM_LIVE_URL,
+    deploymentStage:
+      typeof parsed.deploymentStage === "string" ? parsed.deploymentStage : parsed.FORUM_LIVE_DEPLOYMENT_STAGE,
+    publicBaseUrl:
+      typeof parsed.publicBaseUrl === "string" ? parsed.publicBaseUrl : parsed.FORUM_LIVE_PUBLIC_BASE_URL,
+    writesEnabled:
+      typeof parsed.writesEnabled === "boolean"
+        ? parsed.writesEnabled
+        : parseBoolean(parsed.FORUM_LIVE_WRITES_ENABLED, "FORUM_LIVE_TARGET.FORUM_LIVE_WRITES_ENABLED"),
+    requiresAccessCode:
+      typeof parsed.requiresAccessCode === "boolean"
+        ? parsed.requiresAccessCode
+        : parseBoolean(
+            parsed.FORUM_LIVE_REQUIRES_ACCESS_CODE,
+            "FORUM_LIVE_TARGET.FORUM_LIVE_REQUIRES_ACCESS_CODE",
+          ),
+    exerciseWriteFlow:
+      typeof parsed.exerciseWriteFlow === "boolean"
+        ? parsed.exerciseWriteFlow
+        : parseBoolean(
+            parsed.FORUM_LIVE_EXERCISE_WRITE_FLOW,
+            "FORUM_LIVE_TARGET.FORUM_LIVE_EXERCISE_WRITE_FLOW",
+          ),
+  };
+}
+
+function resolveConfigValue({ bundledValue, envValue, normalize = (value) => value }) {
+  if (bundledValue !== undefined) {
+    return normalize(bundledValue);
+  }
+
+  return normalize(envValue);
+}
+
 async function main() {
   const source = process.env.FORUM_LIVE_SOURCE || "scheduled";
-  const forumUrl = normalizeUrl(process.env.FORUM_LIVE_URL?.trim() || "");
+  const bundledTarget = parseBundledTarget(process.env.FORUM_LIVE_TARGET || "");
+  const forumUrl = normalizeUrl(
+    resolveConfigValue({
+      bundledValue: bundledTarget.forumUrl,
+      envValue: process.env.FORUM_LIVE_URL?.trim() || "",
+      normalize: (value) => (typeof value === "string" ? normalizeUrl(value.trim()) : ""),
+    }),
+  );
 
   if (!forumUrl) {
     const skippedTarget = {
@@ -77,18 +140,42 @@ async function main() {
     return;
   }
 
-  const deploymentStage = process.env.FORUM_LIVE_DEPLOYMENT_STAGE?.trim() || "preview";
+  const deploymentStage = resolveConfigValue({
+    bundledValue: bundledTarget.deploymentStage,
+    envValue: process.env.FORUM_LIVE_DEPLOYMENT_STAGE?.trim() || "preview",
+    normalize: (value) => (typeof value === "string" ? value.trim() || "preview" : "preview"),
+  });
   if (deploymentStage !== "preview" && deploymentStage !== "production") {
     throw new Error(`Expected FORUM_LIVE_DEPLOYMENT_STAGE to be preview or production, received: ${deploymentStage}`);
   }
 
-  const writesEnabled = parseBoolean(process.env.FORUM_LIVE_WRITES_ENABLED ?? "false", "FORUM_LIVE_WRITES_ENABLED") ?? false;
+  const writesEnabled =
+    resolveConfigValue({
+      bundledValue: bundledTarget.writesEnabled,
+      envValue: parseBoolean(process.env.FORUM_LIVE_WRITES_ENABLED ?? "false", "FORUM_LIVE_WRITES_ENABLED") ?? false,
+    }) ?? false;
   const requiresAccessCode =
-    parseBoolean(process.env.FORUM_LIVE_REQUIRES_ACCESS_CODE ?? "false", "FORUM_LIVE_REQUIRES_ACCESS_CODE") ?? false;
+    resolveConfigValue({
+      bundledValue: bundledTarget.requiresAccessCode,
+      envValue:
+        parseBoolean(process.env.FORUM_LIVE_REQUIRES_ACCESS_CODE ?? "false", "FORUM_LIVE_REQUIRES_ACCESS_CODE") ??
+        false,
+    }) ?? false;
   const exerciseWriteFlow =
-    parseBoolean(process.env.FORUM_LIVE_EXERCISE_WRITE_FLOW ?? "false", "FORUM_LIVE_EXERCISE_WRITE_FLOW") ?? false;
+    resolveConfigValue({
+      bundledValue: bundledTarget.exerciseWriteFlow,
+      envValue:
+        parseBoolean(process.env.FORUM_LIVE_EXERCISE_WRITE_FLOW ?? "false", "FORUM_LIVE_EXERCISE_WRITE_FLOW") ??
+        false,
+    }) ?? false;
 
-  const publicBaseUrl = normalizeUrl(process.env.FORUM_LIVE_PUBLIC_BASE_URL?.trim() || "");
+  const publicBaseUrl = normalizeUrl(
+    resolveConfigValue({
+      bundledValue: bundledTarget.publicBaseUrl,
+      envValue: process.env.FORUM_LIVE_PUBLIC_BASE_URL?.trim() || "",
+      normalize: (value) => (typeof value === "string" ? normalizeUrl(value.trim()) : ""),
+    }),
+  );
   const writeAccessCode = process.env.FORUM_LIVE_WRITE_ACCESS_CODE?.trim() || "";
   const requestTimeoutMs = Number.parseInt(process.env.FORUM_LIVE_REQUEST_TIMEOUT_MS || "15000", 10);
 
@@ -117,6 +204,10 @@ async function main() {
   }
 
   const warnings = [];
+
+  if (process.env.FORUM_LIVE_TARGET?.trim()) {
+    warnings.push("live checks are reading the bundled FORUM_LIVE_TARGET variable; keep it aligned with the deploy env.");
+  }
 
   if (deploymentStage === "preview" && publicBaseUrl) {
     warnings.push("preview checks received FORUM_LIVE_PUBLIC_BASE_URL; indexing still stays off until production mode.");


### PR DESCRIPTION
## Summary
- let `prepare-live-deployment-vars.mjs` emit a bundled `FORUM_LIVE_TARGET` config alongside the existing split `FORUM_LIVE_*` output
- teach the hourly live deployment resolver and workflow to consume that bundled variable while staying backward-compatible with split variables
- cover the new bundled path in deploy-compose CI and document the shorter host-to-hourly handoff in `forum/DEPLOY.md`

## Why now
The forum's current highest-priority blocker is no longer another page, API route, or container contract. The remaining friction is the first real preview handoff: taking a working `forum/.env.deploy`, turning it into hourly live-check config, and wiring that config into the repository without mis-copying one of several related variables.

The repository already had:
- deploy env preflight
- deploy env to live variable derivation
- hourly live smoke checks

But it still expected the real target posture to be maintained as a split set of repository variables. This PR keeps the scope tight and pushes directly on that blocker by shrinking the handoff to one bundled variable plus the optional preview access-code secret.

## What changed
- `forum/scripts/prepare-live-deployment-vars.mjs`
  - keeps the original split `FORUM_LIVE_*` output
  - adds `--format json` for a bundled `FORUM_LIVE_TARGET` payload
  - adds `--format github-cli-bundled` for a single `gh variable set FORUM_LIVE_TARGET ...` command plus the optional write-access-code secret command
- `forum/scripts/resolve-live-deployment-target.mjs`
  - can now read `FORUM_LIVE_TARGET`
  - still supports the existing split `FORUM_LIVE_*` environment variables
  - bundled config wins when both are present
  - accepts both the new camelCase JSON fields and the legacy uppercase keys for compatibility
- `.github/workflows/forum-live-deployment-checks.yml`
  - passes `vars.FORUM_LIVE_TARGET` into the resolver for scheduled runs
  - keeps manual dispatch on explicit inputs and keeps the older split-variable fallback intact
- `.github/workflows/forum-deploy-compose-checks.yml`
  - now reruns when the bundled live-target scripts or live-check workflow change
  - validates generating bundled JSON from a writable preview deploy env
  - validates resolving that bundled JSON
  - validates that the bundled GitHub CLI output contains `FORUM_LIVE_TARGET` and the optional preview access-code secret command
- `forum/DEPLOY.md`
  - documents the bundled variable path and recommends it for the first real live-target handoff

## Verification
- locally ran `prepare-live-deployment-vars.mjs` in split output mode
- locally ran `prepare-live-deployment-vars.mjs --format json`
- locally ran `prepare-live-deployment-vars.mjs --format github-cli-bundled`
- locally ran `resolve-live-deployment-target.mjs` against:
  - bundled camelCase JSON
  - bundled legacy uppercase JSON
  - split `FORUM_LIVE_*` environment variables

## Current blocker after this PR
The repo-side wiring is now shorter and covered by CI, but the remaining blocker is still external configuration: a real preview/live URL and the actual target host `.env.deploy` values are still needed before the hourly workflow can hit a real forum runtime.