### PR TITLE
feat(forum): smoke deployed runtime from deploy env

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -10,6 +10,7 @@ on:
       - "forum/scripts/check-deployment-contract.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
+      - "forum/scripts/smoke-deployment-from-env.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
       - ".github/workflows/forum-live-deployment-checks.yml"
@@ -24,6 +25,7 @@ on:
       - "forum/scripts/check-deployment-contract.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
+      - "forum/scripts/smoke-deployment-from-env.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
       - ".github/workflows/forum-deploy-compose-checks.yml"
       - ".github/workflows/forum-live-deployment-checks.yml"
@@ -142,13 +144,11 @@ jobs:
 
           cat /tmp/forum-deploy-health.json
 
-      - name: Smoke test forum deploy compose read-only preview contract
+      - name: Smoke test forum deploy compose read-only preview contract from deploy env
         run: |
-          node forum/scripts/check-deployment-contract.mjs \
-            --url http://127.0.0.1:3001 \
-            --deployment-stage preview \
-            --writes-enabled false \
-            --requires-access-code false
+          node forum/scripts/smoke-deployment-from-env.mjs \
+            --forum-url http://127.0.0.1:3001 \
+            --deploy-env-path forum/.env.deploy.example
 
       - name: Stop forum deploy compose read-only preview runtime
         run: |
@@ -187,14 +187,11 @@ jobs:
 
           cat /tmp/forum-deploy-health.json
 
-      - name: Smoke test forum deploy compose writable preview contract
+      - name: Smoke test forum deploy compose writable preview contract from deploy env
         run: |
-          FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
-          node forum/scripts/check-deployment-contract.mjs \
-            --url http://127.0.0.1:3001 \
-            --deployment-stage preview \
-            --writes-enabled true \
-            --requires-access-code true \
+          node forum/scripts/smoke-deployment-from-env.mjs \
+            --forum-url http://127.0.0.1:3001 \
+            --deploy-env-path /tmp/forum-deploy-writable-preview.env \
             --exercise-write-flow true
 
       - name: Stop forum deploy compose writable preview runtime
@@ -236,14 +233,11 @@ jobs:
 
           cat /tmp/forum-deploy-health.json
 
-      - name: Smoke test forum deploy compose production indexing contract
+      - name: Smoke test forum deploy compose production contract from deploy env
         run: |
-          node forum/scripts/check-deployment-contract.mjs \
-            --url http://127.0.0.1:3001 \
-            --deployment-stage production \
-            --public-base-url https://forum.fabushi.test \
-            --writes-enabled false \
-            --requires-access-code false
+          node forum/scripts/smoke-deployment-from-env.mjs \
+            --forum-url http://127.0.0.1:3001 \
+            --deploy-env-path /tmp/forum-deploy-production.env
 
       - name: Stop forum deploy compose
         if: always()

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -166,10 +166,15 @@ Start the forum:
 
 ```bash
 docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
+pnpm smoke:deploy-env -- \
+  --forum-url http://127.0.0.1:3000 \
+  --deploy-env-path .env.deploy
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 curl http://localhost:3000/robots.txt
 ```
+
+The smoke command derives the expected runtime directly from `.env.deploy` and verifies the deployed forum's health endpoint, runtime status, headers, `robots.txt`, and page metadata against that same file.
 
 Expected preview signals:
 
@@ -189,6 +194,15 @@ FORUM_WRITE_ACCESS_CODE=forum-preview-2026
 
 After restarting the compose stack, the runtime stays preview-only and still requires the shared code before thread or reply creation succeeds.
 
+To validate the writable preview against the same deploy env and also exercise the live thread-and-reply path, run:
+
+```bash
+pnpm smoke:deploy-env -- \
+  --forum-url http://127.0.0.1:3000 \
+  --deploy-env-path .env.deploy \
+  --exercise-write-flow true
+```
+
 ## Production indexing runtime
 
 Switch the deployment boundary only when the public origin is ready:
@@ -203,6 +217,9 @@ Bring the stack back up and verify:
 
 ```bash
 docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
+pnpm smoke:deploy-env -- \
+  --forum-url https://forum.fabushi.com \
+  --deploy-env-path .env.deploy
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 curl http://localhost:3000/robots.txt

--- a/forum/package.json
+++ b/forum/package.json
@@ -10,6 +10,7 @@
     "start:standalone": "node .next/standalone/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke:deployment": "node ./scripts/check-deployment-contract.mjs",
+    "smoke:deploy-env": "node ./scripts/smoke-deployment-from-env.mjs",
     "prepare:live-target": "node ./scripts/prepare-live-deployment-vars.mjs",
     "check:deploy-env": "node ./scripts/validate-deploy-env.mjs"
   },

--- a/forum/scripts/smoke-deployment-from-env.mjs
+++ b/forum/scripts/smoke-deployment-from-env.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function parseArgs(argv) {
+  const parsed = {
+    "deploy-env-path": ".env.deploy",
+    "exercise-write-flow": "false",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const part = argv[index];
+
+    if (!part.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${part}`);
+    }
+
+    const key = part.slice(2);
+    const value = argv[index + 1];
+
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value, key) {
+  if (value === undefined || value === null || value === "") {
+    return false;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Expected ${key} to be true or false, received: ${value}`);
+}
+
+function normalizeUrl(value) {
+  return value ? value.replace(/\/$/, "") : "";
+}
+
+function parseDotEnv(content) {
+  const values = {};
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex === -1) {
+      throw new Error(`Expected KEY=VALUE line in deploy env file, received: ${rawLine}`);
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    values[key] = value;
+  }
+
+  return values;
+}
+
+function buildExpectedRuntime({ forumUrl, deployEnv, exerciseWriteFlow }) {
+  const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
+  if (deploymentStage !== "preview" && deploymentStage !== "production") {
+    throw new Error(
+      `Expected FORUM_DEPLOYMENT_STAGE in deploy env to be preview or production, received: ${deploymentStage}`,
+    );
+  }
+
+  const writesEnabled = parseBoolean(deployEnv.FORUM_ENABLE_WRITES ?? "false", "FORUM_ENABLE_WRITES");
+  const writeAccessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
+  const requiresAccessCode = writesEnabled && Boolean(writeAccessCode);
+  const publicBaseUrl = normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
+
+  if (exerciseWriteFlow && deploymentStage !== "preview") {
+    throw new Error("exercise_write_flow can only be enabled for preview deployments.");
+  }
+
+  if (exerciseWriteFlow && !writesEnabled) {
+    throw new Error("exercise_write_flow=true requires FORUM_ENABLE_WRITES=true in the deploy env file.");
+  }
+
+  return {
+    forumUrl: normalizeUrl(forumUrl),
+    deploymentStage,
+    publicBaseUrl,
+    writesEnabled,
+    requiresAccessCode,
+    exerciseWriteFlow,
+    writeAccessCode,
+  };
+}
+
+function runCheckScript(expectedRuntime, args) {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const checkScriptPath = join(scriptDir, "check-deployment-contract.mjs");
+  const commandArgs = [
+    checkScriptPath,
+    "--url",
+    expectedRuntime.forumUrl,
+    "--deployment-stage",
+    expectedRuntime.deploymentStage,
+    "--public-base-url",
+    expectedRuntime.publicBaseUrl,
+    "--writes-enabled",
+    String(expectedRuntime.writesEnabled),
+    "--requires-access-code",
+    String(expectedRuntime.requiresAccessCode),
+    "--exercise-write-flow",
+    String(expectedRuntime.exerciseWriteFlow),
+  ];
+
+  if (args["request-timeout-ms"]) {
+    commandArgs.push("--request-timeout-ms", args["request-timeout-ms"]);
+  }
+
+  if (args["report-path"]) {
+    commandArgs.push("--report-path", args["report-path"]);
+  }
+
+  if (expectedRuntime.exerciseWriteFlow && expectedRuntime.requiresAccessCode) {
+    commandArgs.push("--write-access-code", expectedRuntime.writeAccessCode);
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, commandArgs, {
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Deployment smoke check exited via signal: ${signal}`));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(new Error(`Deployment smoke check exited with code ${code}.`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
+
+  if (!forumUrl) {
+    throw new Error("Missing required --forum-url.");
+  }
+
+  const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
+  const deployEnvContent = await readFile(args["deploy-env-path"], "utf-8");
+  const deployEnv = parseDotEnv(deployEnvContent);
+  const expectedRuntime = buildExpectedRuntime({ forumUrl, deployEnv, exerciseWriteFlow });
+
+  await runCheckScript(expectedRuntime, args);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `forum/scripts/smoke-deployment-from-env.mjs` to derive the expected runtime contract from `forum/.env.deploy` and then run the existing deployment smoke check against a real forum URL
- expose it as `pnpm smoke:deploy-env` so the target host can verify the live runtime from the same file it was deployed with
- swap the deploy compose workflow over to this wrapper so the new host-facing command stays covered across read-only preview, writable preview, and production indexing postures

## Why now
The forum's current highest-priority blocker is no longer another page, API route, or container contract. The remaining friction is the first real host rollout: after `.env.deploy` is edited and `docker-compose.deploy.yml` is up, there was still no single repo-side command that said whether the live runtime actually matches that exact deploy env.

The repository already had:
- deploy env preflight before startup
- deploy env to hourly live-target derivation
- hourly smoke checks once repo variables are configured

But the host handoff still jumped from "compose is up" to manual curl checks and then straight into wiring hourly variables. This PR keeps the scope tight and closes that gap with one command that reuses the existing smoke checker instead of inventing a second contract.

## What changed
- `forum/scripts/smoke-deployment-from-env.mjs`
  - reads a `.env.deploy`-style file
  - derives expected deployment stage, public base URL, write posture, and access-code posture from that file
  - forwards those expectations into `check-deployment-contract.mjs`
  - supports optional `--exercise-write-flow true` for writable preview checks
  - passes through `--request-timeout-ms` and `--report-path` when needed
- `forum/package.json`
  - adds `pnpm smoke:deploy-env`
- `forum/DEPLOY.md`
  - documents the new command in preview, writable preview, and production rollout steps
  - makes the host-side sequence explicit: preflight `.env.deploy` -> bring up compose -> smoke the live runtime from that same file -> derive hourly live-target config
- `.github/workflows/forum-deploy-compose-checks.yml`
  - now reruns when the new wrapper changes
  - uses the wrapper itself for read-only preview, writable preview, and production deploy-compose checks so the host-facing command stays exercised in CI

## Verification
- ran `node --check` against the new `smoke-deployment-from-env.mjs` wrapper
- validated the new wrapper argument translation locally with a stubbed `check-deployment-contract.mjs` for:
  - writable preview + shared access code + `--exercise-write-flow true`
  - production + public base URL + read-only posture
- re-read the branch diff to confirm the change stays within 4 deploy-focused files

## Current blocker after this PR
The remaining blocker is still external configuration: a real preview host, a real forum URL, and the actual `.env.deploy` values are still needed before the first host rollout and hourly live checks can point at a real deployment.