### PR TITLE
docs(android): document flutter_gl release wiring invariants

### DIFF
--- a/fabushi/android/settings.gradle.kts
+++ b/fabushi/android/settings.gradle.kts
@@ -43,6 +43,7 @@ dependencyResolutionManagement {
         val preferOfficialReposInCi = System.getenv("GITHUB_ACTIONS") == "true" || System.getenv("CI") == "true"
         val flutterGlLocalMavenRepo = File(rootDir, "../lib/packages/flutter_gl/android/libs/maven")
 
+        // Keep the vendored threeegl coordinate visible from settings because app builds prefer settings repositories.
         maven { url = flutterGlLocalMavenRepo.toURI() }
         maven { url = uri("https://storage.flutter-io.cn/download.flutter.io") }
         maven { url = uri("https://jitpack.io") }

--- a/fabushi/lib/packages/flutter_gl/android/build.gradle
+++ b/fabushi/lib/packages/flutter_gl/android/build.gradle
@@ -60,7 +60,9 @@ dependencies {
 
     implementation 'androidx.annotation:annotation:1.9.1'
 
+    // threeegl resources depend on Material Components during release resource linking.
     implementation 'com.google.android.material:material:1.12.0'
 
+    // Resolve the vendored renderer through the repo-local Maven coordinate instead of direct AAR wiring.
     implementation 'com.futouapp.threeegl:threeegl:1.0.0'
 }


### PR DESCRIPTION
## Summary
- document why `fabushi/android/settings.gradle.kts` must expose the vendored `flutter_gl` Maven repo from settings
- document why `fabushi/lib/packages/flutter_gl/android/build.gradle` must keep both Material Components and the `threeegl` Maven coordinate together for Android release packaging
- keep the change behavior-free while still re-exercising the real mobile package release path on `main` once merged

## Why now
`Issue #494` is no longer blocked by an unknown Android root cause. The root-cause code fix already landed in `PR #492`, but the repository still lacks a fresh mobile package release success snapshot after that fix.

The current tool surface here cannot directly trigger the workflow's `workflow_dispatch`, so the safest repository-native way to stop waiting is:
- make one tiny mobile-input change
- keep it behavior-free
- use that merge to force the mobile package release workflow to run again on current `main`

This PR also leaves behind useful guardrail context next to the exact lines that previously broke release packaging.

## What changed
### `fabushi/android/settings.gradle.kts`
- added a short comment explaining that `RepositoriesMode.PREFER_SETTINGS` means the vendored `threeegl` Maven repo has to stay visible from settings for app builds

### `fabushi/lib/packages/flutter_gl/android/build.gradle`
- added a short comment explaining why `com.google.android.material:material:1.12.0` is required during release resource linking
- added a short comment explaining why `threeegl` should stay resolved through the repo-local Maven coordinate instead of direct AAR wiring

## Risk review
- no runtime behavior changed
- no dependency version changed
- no build logic changed
- diff is limited to comments in 2 existing Android build files
- relative to `main`, this branch is `ahead_by = 2` and `behind_by = 0`

## Expected effect after merge
- `main` gets a fresh mobile-input commit
- `Publish CD packages to GitHub Release` should stop skipping Android/iOS packaging for this merge and produce a new, current release-validation signal
- if package publishing fails again, the new failure will point at current `main` instead of the stale `1e24c83` snapshot behind `#494`

## Verification
- branch compare confirms the diff stays scoped to:
  - `fabushi/android/settings.gradle.kts`
  - `fabushi/lib/packages/flutter_gl/android/build.gradle`
- content readback confirms both changes are comments only
- no local Android build was available in this environment; final validation is intentionally delegated to repository CI and the downstream package-release workflow