### PR TITLE
feat(forum): combine live target handoff into one command

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -8,6 +8,7 @@ on:
       - "forum/DEPLOY.md"
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
+      - "forum/scripts/handoff-live-deployment-target.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
@@ -23,6 +24,7 @@ on:
       - "forum/DEPLOY.md"
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
+      - "forum/scripts/handoff-live-deployment-target.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
@@ -187,12 +189,17 @@ jobs:
 
           cat /tmp/forum-deploy-health.json
 
-      - name: Smoke test forum deploy compose writable preview contract from deploy env
+      - name: Handoff writable preview live target from deploy env
         run: |
-          node forum/scripts/smoke-deployment-from-env.mjs \
+          node forum/scripts/handoff-live-deployment-target.mjs \
             --forum-url http://127.0.0.1:3001 \
             --deploy-env-path /tmp/forum-deploy-writable-preview.env \
-            --exercise-write-flow true
+            --exercise-write-flow true \
+            --format github-cli-bundled >/tmp/forum-live-target-handoff.txt
+
+          cat /tmp/forum-live-target-handoff.txt
+          grep "gh variable set FORUM_LIVE_TARGET" /tmp/forum-live-target-handoff.txt
+          grep "gh secret set FORUM_LIVE_WRITE_ACCESS_CODE" /tmp/forum-live-target-handoff.txt
 
       - name: Stop forum deploy compose writable preview runtime
         run: |

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -55,7 +55,28 @@ If both are present, `FORUM_LIVE_TARGET` wins. This keeps the hourly workflow ba
 
 If the live target still requires the shared preview code, also store it in the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE`.
 
-Once the target host has a working `forum/.env.deploy`, generate the matching hourly-check variables from that same file instead of retyping them by hand:
+Once the target host has a working `forum/.env.deploy`, the shortest recommended handoff is now one command:
+
+```bash
+cd forum
+pnpm handoff:live-target -- \
+  --forum-url https://forum-preview.example.com \
+  --deploy-env-path .env.deploy
+```
+
+That single entrypoint will:
+
+- re-run the deploy env posture summary
+- smoke the live runtime against that same `.env.deploy`
+- print the bundled `gh variable set FORUM_LIVE_TARGET ...` command that matches the verified runtime
+
+If the preview runtime is intentionally writable and you want the handoff itself to prove the real thread-and-reply flow before printing the hourly config, add:
+
+```bash
+--exercise-write-flow true
+```
+
+If you want the underlying translation outputs directly instead of the full handoff command, the lower-level helper is still available:
 
 ```bash
 cd forum
@@ -92,12 +113,6 @@ node scripts/prepare-live-deployment-vars.mjs \
   --forum-url https://forum-preview.example.com \
   --deploy-env-path .env.deploy \
   --format github-cli
-```
-
-If the preview runtime is intentionally writable and you want the hourly workflow to exercise the live thread-and-reply flow, add:
-
-```bash
---exercise-write-flow true
 ```
 
 When `.env.deploy` includes `FORUM_WRITE_ACCESS_CODE`, both `github-cli` formats also print the matching `gh secret set FORUM_LIVE_WRITE_ACCESS_CODE` command so the shared preview gate stays aligned with the live smoke check.
@@ -176,6 +191,14 @@ curl http://localhost:3000/robots.txt
 
 The smoke command derives the expected runtime directly from `.env.deploy` and verifies the deployed forum's health endpoint, runtime status, headers, `robots.txt`, and page metadata against that same file.
 
+Once this local or server-side preview is reachable at its real target URL, run the one-command handoff so the hourly repository variable stays aligned with the verified runtime:
+
+```bash
+pnpm handoff:live-target -- \
+  --forum-url https://forum-preview.example.com \
+  --deploy-env-path .env.deploy
+```
+
 Expected preview signals:
 
 - `/api/health` returns `ready: true`
@@ -197,7 +220,7 @@ After restarting the compose stack, the runtime stays preview-only and still req
 To validate the writable preview against the same deploy env and also exercise the live thread-and-reply path, run:
 
 ```bash
-pnpm smoke:deploy-env -- \
+pnpm handoff:live-target -- \
   --forum-url http://127.0.0.1:3000 \
   --deploy-env-path .env.deploy \
   --exercise-write-flow true

--- a/forum/package.json
+++ b/forum/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke:deployment": "node ./scripts/check-deployment-contract.mjs",
     "smoke:deploy-env": "node ./scripts/smoke-deployment-from-env.mjs",
+    "handoff:live-target": "node ./scripts/handoff-live-deployment-target.mjs",
     "prepare:live-target": "node ./scripts/prepare-live-deployment-vars.mjs",
     "check:deploy-env": "node ./scripts/validate-deploy-env.mjs"
   },

--- a/forum/scripts/handoff-live-deployment-target.mjs
+++ b/forum/scripts/handoff-live-deployment-target.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function parseArgs(argv) {
+  const parsed = {
+    "deploy-env-path": ".env.deploy",
+    "exercise-write-flow": "false",
+    format: "github-cli-bundled",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const part = argv[index];
+
+    if (!part.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${part}`);
+    }
+
+    const key = part.slice(2);
+    const value = argv[index + 1];
+
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value, key) {
+  if (value === undefined || value === null || value === "") {
+    return false;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Expected ${key} to be true or false, received: ${value}`);
+}
+
+function normalizeUrl(value) {
+  return value ? value.replace(/\/$/, "") : "";
+}
+
+function runNodeScript(scriptName, scriptArgs, options = {}) {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const scriptPath = join(scriptDir, scriptName);
+  const captureStdout = options.captureStdout === true;
+  const stdio = captureStdout ? ["inherit", "pipe", "inherit"] : "inherit";
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...scriptArgs], {
+      stdio,
+      env: process.env,
+    });
+
+    let stdout = "";
+
+    if (captureStdout && child.stdout) {
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+      });
+    }
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`${scriptName} exited via signal: ${signal}`));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(new Error(`${scriptName} exited with code ${code}.`));
+        return;
+      }
+
+      resolve(stdout);
+    });
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
+
+  if (!forumUrl) {
+    throw new Error("Missing required --forum-url.");
+  }
+
+  const format = args.format?.trim() || "github-cli-bundled";
+  if (!["env", "json", "github-cli", "github-cli-bundled"].includes(format)) {
+    throw new Error(`Expected --format to be env, json, github-cli, or github-cli-bundled, received: ${format}`);
+  }
+
+  const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
+  const sharedArgs = ["--deploy-env-path", args["deploy-env-path"]];
+  const smokeArgs = [
+    "--forum-url",
+    forumUrl,
+    ...sharedArgs,
+    "--exercise-write-flow",
+    String(exerciseWriteFlow),
+  ];
+  const prepareArgs = [
+    "--forum-url",
+    forumUrl,
+    ...sharedArgs,
+    "--exercise-write-flow",
+    String(exerciseWriteFlow),
+    "--format",
+    format,
+  ];
+
+  if (args["request-timeout-ms"]) {
+    smokeArgs.push("--request-timeout-ms", args["request-timeout-ms"]);
+  }
+
+  if (args["report-path"]) {
+    smokeArgs.push("--report-path", args["report-path"]);
+  }
+
+  console.log("== Deploy env preflight ==");
+  await runNodeScript("validate-deploy-env.mjs", sharedArgs);
+
+  console.log("\n== Deployed runtime smoke check ==");
+  await runNodeScript("smoke-deployment-from-env.mjs", smokeArgs);
+
+  console.log("\n== Hourly live target handoff ==");
+  const preparedOutput = await runNodeScript("prepare-live-deployment-vars.mjs", prepareArgs, {
+    captureStdout: true,
+  });
+  process.stdout.write(preparedOutput.endsWith("\n") ? preparedOutput : `${preparedOutput}\n`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `forum/scripts/handoff-live-deployment-target.mjs` to run deploy-env preflight, live runtime smoke checks, and live-target config generation as one host-side handoff
- expose it as `pnpm handoff:live-target` and document it as the shortest recommended path after the real preview or production host is up
- exercise that new entrypoint inside `Deploy compose checks - Forum` so the host-facing wrapper stays covered in CI

## Why now
The forum's current highest-priority blocker is still the first real host rollout, not another page or API route. The repository already had the necessary pieces:
- `pnpm check:deploy-env`
- `pnpm smoke:deploy-env`
- `pnpm prepare:live-target`

But an operator still had to remember the right sequence and keep the forum URL, deploy env path, and optional preview write-flow flag aligned across multiple commands. That left the final host-to-hourly handoff more manual than it needed to be.

This PR keeps scope tight and pushes directly on that friction by turning the host-side sequence into one stable wrapper that reuses the existing scripts instead of creating a second contract.

## What changed
- `forum/scripts/handoff-live-deployment-target.mjs`
  - requires `--forum-url`
  - defaults to `.env.deploy`
  - reruns deploy-env posture validation
  - reruns the deployed-runtime smoke check from the same file
  - prints the final live-target handoff output in `env`, `json`, `github-cli`, or `github-cli-bundled` formats
  - defaults to `github-cli-bundled` so the first real handoff naturally emits one `FORUM_LIVE_TARGET` command plus the optional preview access-code secret command
- `forum/package.json`
  - adds `pnpm handoff:live-target`
- `forum/DEPLOY.md`
  - recommends the new wrapper as the shortest path once `docker-compose.deploy.yml` is already up
  - keeps the lower-level `prepare-live-deployment-vars.mjs` usage documented for direct format-specific needs
  - updates the writable preview flow to use the new wrapper when also exercising the real write path
- `.github/workflows/forum-deploy-compose-checks.yml`
  - reruns when the new wrapper changes
  - uses the new wrapper against the writable preview deploy-compose runtime
  - verifies the wrapper still emits the bundled `FORUM_LIVE_TARGET` and optional preview access-code secret commands

## Verification
- branch compare confirms the diff stays within four deploy-focused files
- the new wrapper only orchestrates existing forum deploy helpers instead of introducing a separate contract path
- `Deploy compose checks - Forum` now exercises the wrapper itself on the writable preview posture, alongside the existing read-only preview and production smoke checks
- this environment still does not have a local repository checkout or direct network access to clone the repo, so final runtime validation remains with repository CI

## Remaining blocker after this PR
The repository-side handoff is now shorter, but the external blocker remains the same: a real preview or production forum URL and its real `.env.deploy` values are still needed before hourly live checks can point at an actual deployment.