### PR TITLE
chore: sync beta release state for v1.0.0-264-mobile.9343bf8a0543

### DIFF
--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -7,29 +7,29 @@
       "title": "Android Beta",
       "description": "官网直接读取最新发布版本的 APK 安装包，安装包发布后这里会自动更新。",
       "primaryLabel": "下载 Android Beta",
-      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-229-mobile.d723b0a32d1d/fabushi-android-arm64-d723b0a32d1d.apk",
-      "version": "v1.0.0-229-mobile.d723b0a32d1d",
-      "publishedAt": "2026-05-16T21:22:02Z",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-264-mobile.9343bf8a0543/fabushi-android-arm64-9343bf8a0543.apk",
+      "version": "v1.0.0-264-mobile.9343bf8a0543",
+      "publishedAt": "2026-05-17T11:51:40Z",
       "updateSummary": [
-        "PR #470: Android 佛像优先使用 Three，失败后回退 flutter_scene",
-        "Android 端佛像展示优先走 Three WebView 兼容渲染",
-        "Three 链路失败时，自动回退到 `flutter_scene` 备用渲染",
-        "补齐 Android Three 页面初始化、脚本报错、Promise 异常、资源异常、候选地址为空、加载超时等错误回传",
-        "在 Flutter 侧区分并汇总 `Android Three` 和 `flutter_scene` 两条链路的错误，失败页可直接看到具体原因",
-        "Android 佛像加载路径变更为 Three 优先"
+        "PR #509: docs(android): document flutter_gl release wiring invariants",
+        "document why `fabushi/android/settings.gradle.kts` must expose the vendored `flutter_gl` Maven repo from settings",
+        "document why `fabushi/lib/packages/flutter_gl/android/build.gradle` must keep both Material Components and the `threeegl` Maven coordinate together for Android release packaging",
+        "keep the change behavior-free while still re-exercising the real mobile package release path on `main` once merged",
+        "make one tiny mobile-input change",
+        "keep it behavior-free"
       ],
       "mirrorLinks": [
         {
           "label": "国内镜像 1",
-          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-229-mobile.d723b0a32d1d/fabushi-android-arm64-d723b0a32d1d.apk"
+          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-264-mobile.9343bf8a0543/fabushi-android-arm64-9343bf8a0543.apk"
         },
         {
           "label": "国内镜像 2",
-          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-229-mobile.d723b0a32d1d/fabushi-android-arm64-d723b0a32d1d.apk"
+          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-264-mobile.9343bf8a0543/fabushi-android-arm64-9343bf8a0543.apk"
         }
       ],
       "note": "国内访问较慢时，可以优先尝试镜像下载入口。",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-229-mobile.d723b0a32d1d"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-264-mobile.9343bf8a0543"
     },
     {
       "platform": "iOS",
@@ -39,24 +39,38 @@
       "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
       "primaryLabel": "加入 iOS TestFlight",
       "primaryHref": "https://testflight.apple.com/join/98KFgV2z",
-      "version": "229",
-      "publishedAt": "2026-05-16T21:21:26Z",
+      "version": "264",
+      "publishedAt": "2026-05-17T11:49:53Z",
       "updateSummary": [
-        "PR #470: Android 佛像优先使用 Three，失败后回退 flutter_scene",
-        "Android 端佛像展示优先走 Three WebView 兼容渲染",
-        "Three 链路失败时，自动回退到 `flutter_scene` 备用渲染",
-        "补齐 Android Three 页面初始化、脚本报错、Promise 异常、资源异常、候选地址为空、加载超时等错误回传",
-        "在 Flutter 侧区分并汇总 `Android Three` 和 `flutter_scene` 两条链路的错误，失败页可直接看到具体原因",
-        "Android 佛像加载路径变更为 Three 优先"
+        "PR #509: docs(android): document flutter_gl release wiring invariants",
+        "document why `fabushi/android/settings.gradle.kts` must expose the vendored `flutter_gl` Maven repo from settings",
+        "document why `fabushi/lib/packages/flutter_gl/android/build.gradle` must keep both Material Components and the `threeegl` Maven coordinate together for Android release packaging",
+        "keep the change behavior-free while still re-exercising the real mobile package release path on `main` once merged",
+        "make one tiny mobile-input change",
+        "keep it behavior-free"
       ],
       "mirrorLinks": [],
       "note": "",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-229-mobile.d723b0a32d1d"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-264-mobile.9343bf8a0543"
     }
   ],
   "stableChannels": [],
   "screenshots": {},
   "releases": [
+    {
+      "tag": "v1.0.0-264-mobile.9343bf8a0543",
+      "title": "Fabushi mobile 1.0.0+264 (9343bf8a0543)",
+      "publishedAt": "2026-05-17T11:51:40Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-264-mobile.9343bf8a0543",
+      "summary": [
+        "PR #509: docs(android): document flutter_gl release wiring invariants",
+        "document why `fabushi/android/settings.gradle.kts` must expose the vendored `flutter_gl` Maven repo from settings",
+        "document why `fabushi/lib/packages/flutter_gl/android/build.gradle` must keep both Material Components and the `threeegl` Maven coordinate together for Android release packaging",
+        "keep the change behavior-free while still re-exercising the real mobile package release path on `main` once merged",
+        "make one tiny mobile-input change",
+        "keep it behavior-free"
+      ]
+    },
     {
       "tag": "v1.0.0-229-mobile.d723b0a32d1d",
       "title": "Fabushi mobile 1.0.0+229 (d723b0a32d1d)",
@@ -111,20 +125,6 @@
         "为首页新增 `metadata`，把 title、description、keywords、canonical、open graph、twitter 明确对齐到佛法学习路径与产品实践入口。",
         "在首页新增 `学佛路径` 区块，用更接近初学者真实问题的方式承接四条内容路径：",
         "在首页结构化数据中新增 `ItemList`，把四条学习路径作为首页可理解的内容列表输出。"
-      ]
-    },
-    {
-      "tag": "v1.0.0-171-mobile.f4d465e91e15",
-      "title": "Fabushi mobile 1.0.0+171 (f4d465e91e15)",
-      "publishedAt": "2026-05-15T23:54:18Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-171-mobile.f4d465e91e15",
-      "summary": [
-        "PR #391: fix(web): refresh official site after package publish and fall back to latest apk",
-        "`Sync official site beta download state` 即使生成了最新状态，也可能因为仓库规则无法直推 `main`，导致 `/api/releases.json` 继续停在旧快照。",
-        "`Deploy official site to Cloudflare Worker` 之前只监听 beta sync 成功完成；一旦 beta sync 被仓库规则挡住，官网就不会因为新的 GitHub Release 自动重建。",
-        "让 `Deploy official site to Cloudflare Worker` 同时监听 `Publish CD packages to GitHub Release` 和 `Sync official site beta download state` 成功完成。",
-        "保持官网构建固定基于 `main`，但不再把自动刷新绑定在 beta sync 单一路径上。",
-        "给 `frontend/official-site-worker.js` 增加兜底：Android beta 下载优先读取 GitHub latest release 的 APK 资产；只有拿不到 latest release 时，才回退到静态 `/api/releases.json`。"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- update `frontend/apps/web/public/api/releases.json` from the existing `automation/sync-official-site-beta-state` branch
- carry the newly generated official-site beta state for mobile release `v1.0.0-264-mobile.9343bf8a0543`
- refresh the persisted Android beta and iOS TestFlight public metadata to the latest successful mobile package release evidence

## Why
- `PR #509` already forced a fresh mobile-input publish path on current `main`
- the automation branch is now `ahead_by = 1` and `behind_by = 0` relative to `main`
- the only changed file is `frontend/apps/web/public/api/releases.json`
- leaving this branch unmerged would keep the website beta/download surface behind the latest GitHub Release and TestFlight public entry state

## What changed
- refresh Android beta download URL, version, publish time, and release page to `v1.0.0-264-mobile.9343bf8a0543`
- refresh iOS TestFlight public version/publish time to `264`
- prepend the latest release entry for `v1.0.0-264-mobile.9343bf8a0543`
- preserve the existing note that public TestFlight evidence is not the same as direct App Store Connect final-state verification

## Risk review
- compare shows `ahead_by = 1` and `behind_by = 0`, so there is no base drift to resolve
- scope is limited to one generated website-state file
- no application code, workflow logic, release asset generation, or TestFlight upload behavior changes in this PR
- this PR only advances the persisted public website state to match the newer release evidence already present on the automation branch

## Validation
- compare against `main` confirms the branch only changes `frontend/apps/web/public/api/releases.json`
- current branch state points Android beta and iOS TestFlight public metadata to release `v1.0.0-264-mobile.9343bf8a0543`
- merge readiness should rely on the repository's normal PR checks