### PR TITLE
feat(forum): sync verified live target directly to GitHub

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Prepare writable preview deploy env sample
         run: |
-          cat <<'EOF' >/tmp/forum-deploy-writable-preview.env
+          cat <<'ENVEOF' >/tmp/forum-deploy-writable-preview.env
           FORUM_IMAGE=fabushi-forum
           FORUM_PORT=3001
           FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data
@@ -63,7 +63,7 @@ jobs:
           FORUM_DATA_SOURCE=sqlite
           FORUM_ENABLE_WRITES=true
           FORUM_WRITE_ACCESS_CODE=forum-preview-2026
-          EOF
+          ENVEOF
 
       - name: Validate writable preview deploy env posture
         run: |
@@ -93,14 +93,16 @@ jobs:
             --forum-url https://forum-preview.fabushi.test \
             --deploy-env-path /tmp/forum-deploy-writable-preview.env \
             --exercise-write-flow true \
-            --format github-cli-bundled >/tmp/forum-live-target-cli.txt
+            --format github-cli-bundled \
+            --github-repo bhrumom/fabushi >/tmp/forum-live-target-cli.txt
 
           grep "gh variable set FORUM_LIVE_TARGET" /tmp/forum-live-target-cli.txt
           grep "gh secret set FORUM_LIVE_WRITE_ACCESS_CODE" /tmp/forum-live-target-cli.txt
+          grep "--repo 'bhrumom/fabushi'" /tmp/forum-live-target-cli.txt
 
       - name: Prepare production deploy env sample
         run: |
-          cat <<'EOF' >/tmp/forum-deploy-production.env
+          cat <<'ENVEOF' >/tmp/forum-deploy-production.env
           FORUM_IMAGE=fabushi-forum
           FORUM_PORT=3001
           FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data
@@ -109,7 +111,7 @@ jobs:
           FORUM_DATA_SOURCE=sqlite
           FORUM_ENABLE_WRITES=false
           FORUM_WRITE_ACCESS_CODE=
-          EOF
+          ENVEOF
 
       - name: Validate production deploy env posture
         run: |
@@ -189,17 +191,30 @@ jobs:
 
           cat /tmp/forum-deploy-health.json
 
-      - name: Handoff writable preview live target from deploy env
+      - name: Apply writable preview live target to GitHub via mocked gh
         run: |
+          mkdir -p /tmp/forum-mock-gh-bin
+          cat <<'GHEOF' >/tmp/forum-mock-gh-bin/gh
+          #!/usr/bin/env bash
+          printf '%s\n' "$*" >> /tmp/forum-gh-invocations.txt
+          GHEOF
+          chmod +x /tmp/forum-mock-gh-bin/gh
+          : >/tmp/forum-gh-invocations.txt
+
+          PATH="/tmp/forum-mock-gh-bin:$PATH" \
           node forum/scripts/handoff-live-deployment-target.mjs \
             --forum-url http://127.0.0.1:3001 \
             --deploy-env-path /tmp/forum-deploy-writable-preview.env \
             --exercise-write-flow true \
-            --format github-cli-bundled >/tmp/forum-live-target-handoff.txt
+            --apply-github-live-target true >/tmp/forum-live-target-handoff.txt
 
           cat /tmp/forum-live-target-handoff.txt
+          cat /tmp/forum-gh-invocations.txt
           grep "gh variable set FORUM_LIVE_TARGET" /tmp/forum-live-target-handoff.txt
-          grep "gh secret set FORUM_LIVE_WRITE_ACCESS_CODE" /tmp/forum-live-target-handoff.txt
+          grep "Applied FORUM_LIVE_TARGET to GitHub repo bhrumom/fabushi." /tmp/forum-live-target-handoff.txt
+          grep "variable set FORUM_LIVE_TARGET --body" /tmp/forum-gh-invocations.txt
+          grep "secret set FORUM_LIVE_WRITE_ACCESS_CODE --body" /tmp/forum-gh-invocations.txt
+          grep -- "--repo bhrumom/fabushi" /tmp/forum-gh-invocations.txt
 
       - name: Stop forum deploy compose writable preview runtime
         run: |

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -68,9 +68,21 @@ That single entrypoint will:
 
 - re-run the deploy env posture summary
 - smoke the live runtime against that same `.env.deploy`
-- print the bundled `gh variable set FORUM_LIVE_TARGET ...` command that matches the verified runtime
+- print the bundled `gh variable set FORUM_LIVE_TARGET ... --repo bhrumom/fabushi` command that matches the verified runtime
 
-If the preview runtime is intentionally writable and you want the handoff itself to prove the real thread-and-reply flow before printing the hourly config, add:
+The command defaults to `bhrumom/fabushi` as the target repository. If you need a different target, add:
+
+```bash
+--github-repo owner/name
+```
+
+If the host already has `gh` authenticated and you want to push the verified hourly target into GitHub immediately instead of running the printed commands yourself, add:
+
+```bash
+--apply-github-live-target true
+```
+
+If the preview runtime is intentionally writable and you want the handoff itself to prove the real thread-and-reply flow before printing or syncing the hourly config, add:
 
 ```bash
 --exercise-write-flow true
@@ -102,7 +114,8 @@ cd forum
 node scripts/prepare-live-deployment-vars.mjs \
   --forum-url https://forum-preview.example.com \
   --deploy-env-path .env.deploy \
-  --format github-cli-bundled
+  --format github-cli-bundled \
+  --github-repo bhrumom/fabushi
 ```
 
 The original split-variable CLI output is still available too:
@@ -112,7 +125,8 @@ cd forum
 node scripts/prepare-live-deployment-vars.mjs \
   --forum-url https://forum-preview.example.com \
   --deploy-env-path .env.deploy \
-  --format github-cli
+  --format github-cli \
+  --github-repo bhrumom/fabushi
 ```
 
 When `.env.deploy` includes `FORUM_WRITE_ACCESS_CODE`, both `github-cli` formats also print the matching `gh secret set FORUM_LIVE_WRITE_ACCESS_CODE` command so the shared preview gate stays aligned with the live smoke check.
@@ -225,6 +239,8 @@ pnpm handoff:live-target -- \
   --deploy-env-path .env.deploy \
   --exercise-write-flow true
 ```
+
+Add `--apply-github-live-target true` when you want the verified bundled live target and preview access-code secret written to GitHub immediately.
 
 ## Production indexing runtime
 

--- a/forum/scripts/handoff-live-deployment-target.mjs
+++ b/forum/scripts/handoff-live-deployment-target.mjs
@@ -9,6 +9,8 @@ function parseArgs(argv) {
     "deploy-env-path": ".env.deploy",
     "exercise-write-flow": "false",
     format: "github-cli-bundled",
+    "apply-github-live-target": "false",
+    "github-repo": "bhrumom/fabushi",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -90,6 +92,42 @@ function runNodeScript(scriptName, scriptArgs, options = {}) {
   });
 }
 
+function runShellCommand(command) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("sh", ["-lc", command], {
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Shell command exited via signal: ${signal}`));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(new Error(`Shell command exited with code ${code}: ${command}`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function runCommandBlock(commandBlock) {
+  for (const rawLine of commandBlock.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    await runShellCommand(line);
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const forumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
@@ -104,6 +142,13 @@ async function main() {
   }
 
   const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
+  const applyGithubLiveTarget = parseBoolean(args["apply-github-live-target"], "apply_github_live_target");
+  const githubRepo = args["github-repo"]?.trim() || "";
+
+  if (applyGithubLiveTarget && !githubRepo) {
+    throw new Error("--apply-github-live-target true requires --github-repo.");
+  }
+
   const sharedArgs = ["--deploy-env-path", args["deploy-env-path"]];
   const smokeArgs = [
     "--forum-url",
@@ -111,15 +156,6 @@ async function main() {
     ...sharedArgs,
     "--exercise-write-flow",
     String(exerciseWriteFlow),
-  ];
-  const prepareArgs = [
-    "--forum-url",
-    forumUrl,
-    ...sharedArgs,
-    "--exercise-write-flow",
-    String(exerciseWriteFlow),
-    "--format",
-    format,
   ];
 
   if (args["request-timeout-ms"]) {
@@ -130,6 +166,30 @@ async function main() {
     smokeArgs.push("--report-path", args["report-path"]);
   }
 
+  const preparedOutputs = new Map();
+  async function getPreparedOutput(outputFormat) {
+    if (preparedOutputs.has(outputFormat)) {
+      return preparedOutputs.get(outputFormat);
+    }
+
+    const prepareArgs = [
+      "--forum-url",
+      forumUrl,
+      ...sharedArgs,
+      "--exercise-write-flow",
+      String(exerciseWriteFlow),
+      "--format",
+      outputFormat,
+      "--github-repo",
+      githubRepo,
+    ];
+    const output = await runNodeScript("prepare-live-deployment-vars.mjs", prepareArgs, {
+      captureStdout: true,
+    });
+    preparedOutputs.set(outputFormat, output);
+    return output;
+  }
+
   console.log("== Deploy env preflight ==");
   await runNodeScript("validate-deploy-env.mjs", sharedArgs);
 
@@ -137,10 +197,21 @@ async function main() {
   await runNodeScript("smoke-deployment-from-env.mjs", smokeArgs);
 
   console.log("\n== Hourly live target handoff ==");
-  const preparedOutput = await runNodeScript("prepare-live-deployment-vars.mjs", prepareArgs, {
-    captureStdout: true,
-  });
+  const preparedOutput = await getPreparedOutput(format);
   process.stdout.write(preparedOutput.endsWith("\n") ? preparedOutput : `${preparedOutput}\n`);
+
+  if (!applyGithubLiveTarget) {
+    return;
+  }
+
+  console.log("\n== GitHub live target sync ==");
+  const applyCommandBlock = format === "github-cli-bundled" ? preparedOutput : await getPreparedOutput("github-cli-bundled");
+  if (format !== "github-cli-bundled") {
+    process.stdout.write(applyCommandBlock.endsWith("\n") ? applyCommandBlock : `${applyCommandBlock}\n`);
+  }
+
+  await runCommandBlock(applyCommandBlock);
+  console.log(`Applied FORUM_LIVE_TARGET to GitHub repo ${githubRepo}.`);
 }
 
 main().catch((error) => {

--- a/forum/scripts/prepare-live-deployment-vars.mjs
+++ b/forum/scripts/prepare-live-deployment-vars.mjs
@@ -7,6 +7,7 @@ function parseArgs(argv) {
     "deploy-env-path": ".env.deploy",
     "exercise-write-flow": "false",
     format: "env",
+    "github-repo": "",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -118,6 +119,14 @@ function quoteForSingleQuotedShell(value) {
   return value.replace(/'/g, "'\"'\"'");
 }
 
+function buildGithubRepoArg(githubRepo) {
+  if (!githubRepo) {
+    return "";
+  }
+
+  return ` --repo '${quoteForSingleQuotedShell(githubRepo)}'`;
+}
+
 function renderEnvFormat(liveTarget) {
   return Object.entries(liveTarget)
     .map(([key, value]) => `${key}=${value}`)
@@ -128,9 +137,10 @@ function renderJsonFormat(liveTarget) {
   return JSON.stringify(buildBundledLiveTarget(liveTarget), null, 2);
 }
 
-function renderGithubCliFormat(liveTarget, deployEnv) {
+function renderGithubCliFormat(liveTarget, deployEnv, githubRepo) {
+  const repoArg = buildGithubRepoArg(githubRepo);
   const lines = Object.entries(liveTarget).map(
-    ([key, value]) => `gh variable set ${key} --body '${quoteForSingleQuotedShell(value)}'`,
+    ([key, value]) => `gh variable set ${key} --body '${quoteForSingleQuotedShell(value)}'${repoArg}`,
   );
 
   if (liveTarget.FORUM_LIVE_REQUIRES_ACCESS_CODE === "true") {
@@ -138,22 +148,25 @@ function renderGithubCliFormat(liveTarget, deployEnv) {
 
     lines.push("");
     lines.push("# Run this once if the preview write gate is enabled for the live target.");
-    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${quoteForSingleQuotedShell(accessCode)}'`);
+    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${quoteForSingleQuotedShell(accessCode)}'${repoArg}`);
   }
 
   return lines.join("\n");
 }
 
-function renderGithubCliBundledFormat(liveTarget, deployEnv) {
+function renderGithubCliBundledFormat(liveTarget, deployEnv, githubRepo) {
+  const repoArg = buildGithubRepoArg(githubRepo);
   const bundledTargetJson = JSON.stringify(buildBundledLiveTarget(liveTarget));
-  const lines = [`gh variable set FORUM_LIVE_TARGET --body '${quoteForSingleQuotedShell(bundledTargetJson)}'`];
+  const lines = [
+    `gh variable set FORUM_LIVE_TARGET --body '${quoteForSingleQuotedShell(bundledTargetJson)}'${repoArg}`,
+  ];
 
   if (liveTarget.FORUM_LIVE_REQUIRES_ACCESS_CODE === "true") {
     const accessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
 
     lines.push("");
     lines.push("# Run this once if the preview write gate is enabled for the live target.");
-    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${quoteForSingleQuotedShell(accessCode)}'`);
+    lines.push(`gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body '${quoteForSingleQuotedShell(accessCode)}'${repoArg}`);
   }
 
   return lines.join("\n");
@@ -173,18 +186,19 @@ async function main() {
   }
 
   const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
+  const githubRepo = args["github-repo"]?.trim() || "";
 
   const deployEnvContent = await readFile(args["deploy-env-path"], "utf-8");
   const deployEnv = parseDotEnv(deployEnvContent);
   const liveTarget = buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow });
 
   if (format === "github-cli") {
-    console.log(renderGithubCliFormat(liveTarget, deployEnv));
+    console.log(renderGithubCliFormat(liveTarget, deployEnv, githubRepo));
     return;
   }
 
   if (format === "github-cli-bundled") {
-    console.log(renderGithubCliBundledFormat(liveTarget, deployEnv));
+    console.log(renderGithubCliBundledFormat(liveTarget, deployEnv, githubRepo));
     return;
   }
 


### PR DESCRIPTION
## Summary
- make `prepare-live-deployment-vars.mjs` repo-aware for GitHub CLI output so live-target commands can be run from any host, not only from inside a checkout
- extend `handoff-live-deployment-target.mjs` with an optional `--apply-github-live-target true` path that reuses the verified handoff output to update the live target variable and optional preview write-access secret directly through `gh`
- cover that new sync path in `Deploy compose checks - Forum` with a mocked `gh`, and document the new host-side flow in `forum/DEPLOY.md`

## Why now
The forum's current highest-priority blocker is still the first real preview rollout and hourly live-check handoff. Main already had:
- deploy env preflight
- deployed-runtime smoke checks
- one-command live-target handoff

But the last step still depended on manually re-running the printed `gh variable set ...` and `gh secret set ...` commands, and those commands assumed the operator was standing inside the right repository context.

This PR keeps scope tight and pushes directly on that last bit of deployment friction:
- GitHub CLI output now carries the target repo explicitly
- the same verified handoff command can optionally apply the repo variable and secret immediately
- CI now exercises that sync path without mutating the real repository state

## What changed
### `forum/scripts/prepare-live-deployment-vars.mjs`
- adds optional `--github-repo owner/name`
- appends `--repo owner/name` to both split and bundled GitHub CLI output modes when provided
- keeps `env` and `json` output behavior unchanged

### `forum/scripts/handoff-live-deployment-target.mjs`
- adds `--github-repo`, defaulting to `bhrumom/fabushi`
- adds `--apply-github-live-target true|false`, defaulting to `false`
- when apply mode is enabled:
  - still reruns deploy-env preflight and deployed-runtime smoke checks first
  - reuses the existing bundled GitHub CLI handoff output
  - executes only the real `gh ...` command lines from that output
  - leaves a final confirmation line after the variable and optional secret are applied

### `.github/workflows/forum-deploy-compose-checks.yml`
- validates repo-aware bundled GitHub CLI output
- replaces the writable preview handoff assertion with a mocked-`gh` sync run
- confirms the sync path issues both:
  - `gh variable set FORUM_LIVE_TARGET ... --repo bhrumom/fabushi`
  - `gh secret set FORUM_LIVE_WRITE_ACCESS_CODE ... --repo bhrumom/fabushi`

### `forum/DEPLOY.md`
- documents the repo-aware GitHub CLI output
- documents the optional direct sync flag for hosts that already have authenticated `gh`
- keeps the lower-level helper commands documented for operators who still want manual output only

## Verification
- `node --check` passes for the updated `prepare-live-deployment-vars.mjs` and `handoff-live-deployment-target.mjs`
- the sync path is covered in repository CI through a mocked `gh` binary inside `Deploy compose checks - Forum`
- this environment still cannot clone the repository locally or hit a real preview host URL directly, so final runtime validation remains with repository CI and the eventual real preview rollout

## Remaining blocker after this PR
The repository-side handoff is now shorter again, but the external blocker remains the same:
- a real preview or production forum URL is still needed
- a real `forum/.env.deploy` still needs to exist on the target host
- the first live target still has to be pointed at an actual running deployment before hourly checks can stop skipping