### PR TITLE
fix(forum): align deploy helpers with compose env parsing

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -9,6 +9,7 @@ on:
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
       - "forum/scripts/handoff-live-deployment-target.mjs"
+      - "forum/scripts/parse-deploy-env.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
@@ -25,6 +26,7 @@ on:
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
       - "forum/scripts/handoff-live-deployment-target.mjs"
+      - "forum/scripts/parse-deploy-env.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
@@ -70,6 +72,24 @@ jobs:
           node forum/scripts/validate-deploy-env.mjs \
             --deploy-env-path /tmp/forum-deploy-writable-preview.env
 
+      - name: Prepare quoted writable preview deploy env sample
+        run: |
+          cat <<'ENVEOF' >/tmp/forum-deploy-writable-preview-quoted.env
+          FORUM_IMAGE="fabushi-forum"
+          FORUM_PORT="3001"
+          FORUM_DATA_DIR="/tmp/fabushi-forum-deploy-compose-data" # quoted path should still parse cleanly
+          FORUM_DEPLOYMENT_STAGE="preview"
+          FORUM_PUBLIC_BASE_URL="" # preview should stay noindex
+          FORUM_DATA_SOURCE='sqlite'
+          FORUM_ENABLE_WRITES=true # leave this unquoted so the parser still reads the boolean string
+          FORUM_WRITE_ACCESS_CODE="forum-preview-2026" # quoted shared gate should stay aligned with docker compose parsing
+          ENVEOF
+
+      - name: Validate quoted writable preview deploy env posture
+        run: |
+          node forum/scripts/validate-deploy-env.mjs \
+            --deploy-env-path /tmp/forum-deploy-writable-preview-quoted.env
+
       - name: Prepare bundled live target sample
         run: |
           node forum/scripts/prepare-live-deployment-vars.mjs \
@@ -77,6 +97,18 @@ jobs:
             --deploy-env-path /tmp/forum-deploy-writable-preview.env \
             --exercise-write-flow true \
             --format json >/tmp/forum-live-target.json
+
+      - name: Prepare bundled live target sample from quoted deploy env
+        run: |
+          node forum/scripts/prepare-live-deployment-vars.mjs \
+            --forum-url "https://forum-preview.fabushi.test/" \
+            --deploy-env-path /tmp/forum-deploy-writable-preview-quoted.env \
+            --exercise-write-flow true \
+            --format github-cli-bundled \
+            --github-repo bhrumom/fabushi >/tmp/forum-live-target-quoted-cli.txt
+
+          grep --fixed-strings "gh variable set FORUM_LIVE_TARGET --body '{\"forumUrl\":\"https://forum-preview.fabushi.test\",\"deploymentStage\":\"preview\",\"publicBaseUrl\":\"\",\"writesEnabled\":true,\"requiresAccessCode\":true,\"exerciseWriteFlow\":true}' --repo 'bhrumom/fabushi'" /tmp/forum-live-target-quoted-cli.txt
+          grep --fixed-strings "gh secret set FORUM_LIVE_WRITE_ACCESS_CODE --body 'forum-preview-2026' --repo 'bhrumom/fabushi'" /tmp/forum-live-target-quoted-cli.txt
 
       - name: Validate bundled live target sample
         run: |

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -22,6 +22,12 @@ cp .env.deploy.example .env.deploy
 
 Then edit `.env.deploy` for the target runtime.
 
+`forum/.env.deploy` follows Docker Compose env-file syntax. That means the deploy helpers now accept the same common forms that Compose itself accepts, including:
+
+- quoted values such as `FORUM_IMAGE="ghcr.io/bhrumom/fabushi-forum:main"`
+- empty quoted values such as `FORUM_PUBLIC_BASE_URL=""`
+- inline comments after a value such as `FORUM_ENABLE_WRITES=true # preview cohort only`
+
 Before you start the compose stack, validate the deploy posture from the same file:
 
 ```bash
@@ -259,30 +265,15 @@ docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
 pnpm smoke:deploy-env -- \
   --forum-url https://forum.fabushi.com \
   --deploy-env-path .env.deploy
-curl http://localhost:3000/api/health
-curl http://localhost:3000/api/status
-curl http://localhost:3000/robots.txt
-curl -I http://localhost:3000/threads
+curl https://forum.fabushi.com/api/health
+curl https://forum.fabushi.com/api/status
+curl https://forum.fabushi.com/robots.txt
 ```
 
 Expected production signals:
 
-- `/api/health` and `/api/status` both report `deploymentStage=production`
-- indexing becomes enabled only after `FORUM_PUBLIC_BASE_URL` is also set
-- `robots.txt` switches to `Allow: /` and includes the configured `Host:`
-- page responses stop emitting the preview `x-robots-tag`
-
-## Rolling to a newer forum image
-
-Update only the image tag in `.env.deploy`, then refresh the stack:
-
-```dotenv
-FORUM_IMAGE=ghcr.io/bhrumom/fabushi-forum:sha-<commit>
-```
-
-```bash
-docker compose --env-file .env.deploy -f docker-compose.deploy.yml pull
-docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
-```
-
-This keeps the deploy path aligned with the already published forum artifact instead of rebuilding from source on the server.
+- `/api/health` returns `ready: true`
+- `/api/status` reports `deploymentStage=production`
+- `robots.txt` allows crawling
+- page metadata resolves canonical URLs against `FORUM_PUBLIC_BASE_URL`
+- headers stop advertising the preview noindex posture

--- a/forum/scripts/parse-deploy-env.mjs
+++ b/forum/scripts/parse-deploy-env.mjs
@@ -1,0 +1,138 @@
+export function decodeDoubleQuotedValue(value) {
+  let decoded = "";
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+
+    if (character !== "\\") {
+      decoded += character;
+      continue;
+    }
+
+    const nextCharacter = value[index + 1];
+    if (nextCharacter === undefined) {
+      decoded += "\\";
+      continue;
+    }
+
+    const escapeMap = {
+      "\\": "\\",
+      '"': '"',
+      "'": "'",
+      n: "\n",
+      r: "\r",
+      t: "\t",
+    };
+
+    decoded += escapeMap[nextCharacter] ?? nextCharacter;
+    index += 1;
+  }
+
+  return decoded;
+}
+
+export function decodeSingleQuotedValue(value) {
+  let decoded = "";
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+
+    if (character !== "\\") {
+      decoded += character;
+      continue;
+    }
+
+    const nextCharacter = value[index + 1];
+    if (nextCharacter === undefined) {
+      decoded += "\\";
+      continue;
+    }
+
+    if (nextCharacter === "'" || nextCharacter === "\\") {
+      decoded += nextCharacter;
+      index += 1;
+      continue;
+    }
+
+    decoded += character;
+  }
+
+  return decoded;
+}
+
+export function stripInlineComment(rawValue) {
+  let quoteCharacter = null;
+  let escaped = false;
+
+  for (let index = 0; index < rawValue.length; index += 1) {
+    const character = rawValue[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (quoteCharacter) {
+      if (character === "\\") {
+        escaped = true;
+        continue;
+      }
+
+      if (character === quoteCharacter) {
+        quoteCharacter = null;
+      }
+
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quoteCharacter = character;
+      continue;
+    }
+
+    if (character === "#" && (index === 0 || /\s/.test(rawValue[index - 1]))) {
+      return rawValue.slice(0, index).trimEnd();
+    }
+  }
+
+  return rawValue.trimEnd();
+}
+
+export function parseComposeEnvValue(rawValue) {
+  const valueWithoutComment = stripInlineComment(rawValue.trim());
+
+  if (valueWithoutComment.length < 2) {
+    return valueWithoutComment;
+  }
+
+  const quoteCharacter = valueWithoutComment[0];
+  if ((quoteCharacter !== '"' && quoteCharacter !== "'") || valueWithoutComment.at(-1) !== quoteCharacter) {
+    return valueWithoutComment;
+  }
+
+  const innerValue = valueWithoutComment.slice(1, -1);
+  return quoteCharacter === '"' ? decodeDoubleQuotedValue(innerValue) : decodeSingleQuotedValue(innerValue);
+}
+
+export function parseDotEnv(content) {
+  const values = {};
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = rawLine.search(/[=:]/);
+    if (separatorIndex === -1) {
+      throw new Error(`Expected KEY=VALUE line in deploy env file, received: ${rawLine}`);
+    }
+
+    const key = rawLine.slice(0, separatorIndex).trim();
+    const value = rawLine.slice(separatorIndex + 1);
+    values[key] = parseComposeEnvValue(value);
+  }
+
+  return values;
+}

--- a/forum/scripts/prepare-live-deployment-vars.mjs
+++ b/forum/scripts/prepare-live-deployment-vars.mjs
@@ -2,6 +2,8 @@
 
 import { readFile } from "node:fs/promises";
 
+import { parseDotEnv } from "./parse-deploy-env.mjs";
+
 function parseArgs(argv) {
   const parsed = {
     "deploy-env-path": ".env.deploy",
@@ -49,29 +51,6 @@ function parseBoolean(value, key) {
 
 function normalizeUrl(value) {
   return value ? value.replace(/\/$/, "") : "";
-}
-
-function parseDotEnv(content) {
-  const values = {};
-
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
-
-    if (!line || line.startsWith("#")) {
-      continue;
-    }
-
-    const separatorIndex = line.indexOf("=");
-    if (separatorIndex === -1) {
-      throw new Error(`Expected KEY=VALUE line in deploy env file, received: ${rawLine}`);
-    }
-
-    const key = line.slice(0, separatorIndex).trim();
-    const value = line.slice(separatorIndex + 1).trim();
-    values[key] = value;
-  }
-
-  return values;
 }
 
 function buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow }) {

--- a/forum/scripts/smoke-deployment-from-env.mjs
+++ b/forum/scripts/smoke-deployment-from-env.mjs
@@ -5,6 +5,8 @@ import { spawn } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseDotEnv } from "./parse-deploy-env.mjs";
+
 function parseArgs(argv) {
   const parsed = {
     "deploy-env-path": ".env.deploy",
@@ -50,29 +52,6 @@ function parseBoolean(value, key) {
 
 function normalizeUrl(value) {
   return value ? value.replace(/\/$/, "") : "";
-}
-
-function parseDotEnv(content) {
-  const values = {};
-
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
-
-    if (!line || line.startsWith("#")) {
-      continue;
-    }
-
-    const separatorIndex = line.indexOf("=");
-    if (separatorIndex === -1) {
-      throw new Error(`Expected KEY=VALUE line in deploy env file, received: ${rawLine}`);
-    }
-
-    const key = line.slice(0, separatorIndex).trim();
-    const value = line.slice(separatorIndex + 1).trim();
-    values[key] = value;
-  }
-
-  return values;
 }
 
 function buildExpectedRuntime({ forumUrl, deployEnv, exerciseWriteFlow }) {

--- a/forum/scripts/validate-deploy-env.mjs
+++ b/forum/scripts/validate-deploy-env.mjs
@@ -2,6 +2,8 @@
 
 import { readFile } from "node:fs/promises";
 
+import { parseDotEnv } from "./parse-deploy-env.mjs";
+
 function parseArgs(argv) {
   const parsed = {
     "deploy-env-path": ".env.deploy",
@@ -47,29 +49,6 @@ function parseBoolean(value, key) {
 
 function normalizeUrl(value) {
   return value ? value.replace(/\/$/, "") : "";
-}
-
-function parseDotEnv(content) {
-  const values = {};
-
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
-
-    if (!line || line.startsWith("#")) {
-      continue;
-    }
-
-    const separatorIndex = line.indexOf("=");
-    if (separatorIndex === -1) {
-      throw new Error(`Expected KEY=VALUE line in deploy env file, received: ${rawLine}`);
-    }
-
-    const key = line.slice(0, separatorIndex).trim();
-    const value = line.slice(separatorIndex + 1).trim();
-    values[key] = value;
-  }
-
-  return values;
 }
 
 function buildDeployPosture({ deployEnvPath, deployEnv }) {


### PR DESCRIPTION
## Summary
- add a shared `forum/scripts/parse-deploy-env.mjs` helper so deploy-side forum scripts parse `.env.deploy` the same way Docker Compose parses env files
- switch `validate-deploy-env.mjs`, `prepare-live-deployment-vars.mjs`, and `smoke-deployment-from-env.mjs` over to that shared parser
- extend `Deploy compose checks - Forum` with a quoted `.env.deploy` sample and document the supported env-file forms in `forum/DEPLOY.md`

## Why now
The forum's current highest-priority blocker is still the first real preview/live rollout, not another page or API route. Main already has the core deployment handoff pieces:
- deploy env preflight
- deploy compose smoke checks
- one-command live-target handoff
- optional direct GitHub live-target sync

That means the next smallest high-value improvement is to remove hidden friction from the first real host edit of `forum/.env.deploy`.

Before this PR, the helper scripts used a much simpler parser than Docker Compose itself. That left room for subtle mismatches when an operator used common Compose-native forms such as:
- quoted values
- empty quoted values
- inline comments after values

In that posture, Compose could accept a `.env.deploy` file while the repo-side validation or live-target helper misread the same file. This PR keeps scope tight and closes that gap.

## What changed
### `forum/scripts/parse-deploy-env.mjs`
- adds shared env-file parsing for forum deploy helpers
- handles quoted values, quoted empty strings, inline comments, and common escape sequences in a Compose-style way

### `forum/scripts/validate-deploy-env.mjs`
- now reuses the shared parser
- keeps the existing deploy-posture summary and warnings unchanged

### `forum/scripts/prepare-live-deployment-vars.mjs`
- now reuses the shared parser
- keeps split, bundled JSON, and GitHub CLI outputs aligned with the same `.env.deploy` semantics Compose uses

### `forum/scripts/smoke-deployment-from-env.mjs`
- now reuses the shared parser
- keeps host-side smoke expectations aligned with the same deploy env that launched the runtime

### `.github/workflows/forum-deploy-compose-checks.yml`
- adds `forum/scripts/parse-deploy-env.mjs` to path triggers
- adds a quoted writable-preview deploy env sample
- asserts that quoted values and inline comments still produce:
  - the expected bundled `FORUM_LIVE_TARGET` payload
  - the expected unquoted `FORUM_LIVE_WRITE_ACCESS_CODE` GitHub secret command

### `forum/DEPLOY.md`
- documents that `forum/.env.deploy` now accepts the same common env-file forms the helper scripts and Docker Compose both understand

## Validation
- branch compare confirms the diff stays scoped to forum deploy helper scripts, deploy CI, and deploy docs
- the new workflow coverage explicitly exercises quoted `.env.deploy` values and inline comments before the existing deploy-compose runtime checks run
- this environment still does not have a local checkout of the full repository, so final confirmation remains with repository CI on this PR

## Remaining blocker after this PR
This reduces host-side config friction again, but the external blocker is still the same:
- a real preview or production forum URL is still needed
- a real target-host `forum/.env.deploy` still needs to exist
- the hourly live deployment checks still need their first real target