### PR TITLE
feat(web): strengthen shared content navigation for nianfo cluster

### DIFF
--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -10,17 +10,17 @@ export function SiteFooter() {
         </p>
         <p className="footer-copy">
           <LocalizedText
-            zh="经文、禅修、法流与全球法布施。"
-            en="Sutras, meditation, dharma videos, and global giving."
+            zh="佛法导览、禅修、念佛、佛经与全球法布施。"
+            en="Dharma guides, meditation, nianfo, sutras, and global giving."
           />
         </p>
       </div>
       <div className="footer-links">
         <a href={siteHref("/download")}>
-          <LocalizedText zh="下载入口" en="Download" />
+          <LocalizedText zh="下载 App" en="Download App" />
         </a>
-        <a href={siteHref("/apply")}>
-          <LocalizedText zh="申请测试" en="Apply" />
+        <a href={siteHref("/insights")}>
+          <LocalizedText zh="官网资讯" en="Site News" />
         </a>
         <a href={siteHref("/faq")}>
           <LocalizedText zh="常见问题" en="FAQ" />
@@ -46,11 +46,11 @@ export function SiteFooter() {
         <a href={siteHref("/what-is-emptiness")}>
           <LocalizedText zh="空性怎么理解" en="How to Understand Emptiness" />
         </a>
-        <a href={siteHref("/meditation")}>
-          <LocalizedText zh="禅修入门" en="Meditation Guide" />
-        </a>
         <a href={siteHref("/practice-guide")}>
           <LocalizedText zh="修行方法总览" en="Practice Guide" />
+        </a>
+        <a href={siteHref("/meditation")}>
+          <LocalizedText zh="禅修入门" en="Meditation Guide" />
         </a>
         <a href={siteHref("/daily-practice")}>
           <LocalizedText zh="日常功课怎么安排" en="Daily Practice" />
@@ -72,9 +72,6 @@ export function SiteFooter() {
         </a>
         <a href={siteHref("/contact")}>
           <LocalizedText zh="联系" en="Contact" />
-        </a>
-        <a href={siteHref("/insights")}>
-          <LocalizedText zh="内容专栏" en="Insights" />
         </a>
         <a href="mailto:support@ombhrum.com">support@ombhrum.com</a>
       </div>

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -29,6 +29,11 @@ const NAV_ITEMS = [
     en: "Practice Guide",
   },
   {
+    href: "/nianfo-guide",
+    zh: "念佛入门",
+    en: "Nianfo Guide",
+  },
+  {
     href: "/sutra-guide",
     zh: "佛经导读",
     en: "Sutra Guide",


### PR DESCRIPTION
## Summary
- add `/nianfo-guide` to the shared top navigation so the new practice leaf is reachable from the highest-frequency internal-link layer
- remove the stale `/apply` footer link and reorder footer entries around content-first discovery instead of test-flow leftovers
- tighten footer copy and labels so the shared layout speaks more clearly in terms of dharma guides, practice, nianfo, sutras, and site news

## Why this hour
After re-reading the latest `main`, the biggest immediate gap was no longer page creation. The repo already has a richer practice/content cluster, including `/nianfo-guide`, but that new page still was not surfaced from the shared header. At the same time, the footer still carried a product-era `申请测试` entry that no longer fits the homepage's content-first information architecture.

That makes the smallest high-confidence move this hour a shared internal-link cleanup:
- raise the nianfo page into the top-level navigation
- keep download as the service CTA
- remove an outdated product/test distraction from the footer

## SEO and IA effect
- strengthens discovery for `/nianfo-guide` from every page using `SiteHeader`
- aligns shared navigation more closely with the current homepage role as an information hub rather than a download-first landing page
- reduces mixed signals from legacy product/test links in the footer
- reinforces content themes in persistent layout copy without introducing flip interactions or hiding正文 behind UI state

## Notes
- no local automated checks were run in this connector-only workflow
- this PR intentionally stays small and layout-scoped
- the next best follow-up remains the older `/daily-practice` flip-card implementation, which still deserves a dedicated SEO-first static-card review in a separate pass
