### PR TITLE
fix(release): sanitize official site beta summaries

### DIFF
--- a/.github/scripts/generate-official-site-beta-state.py
+++ b/.github/scripts/generate-official-site-beta-state.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 import urllib.request
 from datetime import datetime, timezone
@@ -18,6 +19,46 @@ if not mirror_lines:
         "国内镜像 2|https://ghfast.top/https://github.com/",
     ]
 
+TECHNICAL_RELEASE_LINE_PATTERN = re.compile(
+    r"(^pr\s*#\d+)|"
+    r"\b(ci|workflow|checkout|token|sha|commit|submodule|api|github|dispatch|"
+    r"globals\.css|page\.tsx|framer-motion|bentocard|settings\.gradle|build\.gradle|"
+    r"flutter_gl|threeegl|maven|material)\b|"
+    r"(^\[(x| )\])|"
+    r"(behavior-free|mobile-input|document why)",
+    re.IGNORECASE,
+)
+
+RELEASE_SUMMARY_RULES = [
+    (
+        re.compile(
+            r"ui/ux|bento|design|layout|hero section|spotlight hover|scroll reveal|floating screenshots|dark theme",
+            re.IGNORECASE,
+        ),
+        "改进官网界面与浏览体验。",
+    ),
+    (
+        re.compile(r"cache|stale|refresh", re.IGNORECASE),
+        "减少更新后仍显示旧内容的情况。",
+    ),
+    (
+        re.compile(r"android|apk|mirror", re.IGNORECASE),
+        "改进 Android 测试版下载与安装稳定性。",
+    ),
+    (
+        re.compile(r"ios|testflight", re.IGNORECASE),
+        "改进 iOS TestFlight 测试入口与发布准备。",
+    ),
+    (
+        re.compile(r"sync|release publish|release state|latest release|immutable release|published", re.IGNORECASE),
+        "提升版本同步与发布状态更新的可靠性。",
+    ),
+    (
+        re.compile(r"screenshot|preview", re.IGNORECASE),
+        "更新产品预览与发布信息展示。",
+    ),
+]
+
 release = json.loads(
     subprocess.check_output(
         ["gh", "api", f"repos/{release_repo}/releases/tags/{release_tag}"],
@@ -27,6 +68,81 @@ release = json.loads(
 
 assets = release.get("assets", [])
 screenshots = {}
+
+
+def normalize_summary_line(line):
+    normalized = re.sub(r"`", "", line or "")
+    normalized = re.sub(r"^pr\s*#\d+:\s*", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"^\[(x| )\]\s*", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip()
+
+
+def build_fallback_release_summary(title):
+    normalized_title = (title or "").lower()
+
+    if "ios" in normalized_title or "testflight" in normalized_title:
+        return [
+            "改进 iOS TestFlight 测试入口与发布准备。",
+            "优化最新版本信息的展示方式。",
+        ]
+
+    if "android" in normalized_title or "apk" in normalized_title:
+        return [
+            "改进 Android 测试版下载与安装稳定性。",
+            "优化最新版本信息的展示方式。",
+        ]
+
+    return [
+        "改进下载体验与版本信息展示。",
+        "优化整体稳定性与页面呈现。",
+    ]
+
+
+def map_release_line_to_user_facing(line):
+    normalized = normalize_summary_line(line)
+    if not normalized:
+        return None
+
+    for pattern, text in RELEASE_SUMMARY_RULES:
+        if pattern.search(normalized):
+            return text
+
+    if TECHNICAL_RELEASE_LINE_PATTERN.search(normalized):
+        return None
+
+    return normalized
+
+
+def sanitize_release_summaries(lines, fallback):
+    seen = set()
+    summary = []
+
+    for line in lines:
+        user_facing_line = map_release_line_to_user_facing(line)
+        if not user_facing_line:
+            continue
+
+        key = user_facing_line.lower()
+        if key in seen:
+            continue
+
+        seen.add(key)
+        summary.append(user_facing_line)
+        if len(summary) == 6:
+            return summary
+
+    if summary:
+        return summary
+
+    for fallback_line in build_fallback_release_summary(fallback):
+        key = fallback_line.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        summary.append(fallback_line)
+
+    return summary or [fallback]
 
 
 def extract_summary(body, fallback):
@@ -44,7 +160,7 @@ def extract_summary(body, fallback):
             cleaned = line[2:].strip()
             if cleaned:
                 lines.append(cleaned)
-    return lines[:6] if lines else [fallback]
+    return sanitize_release_summaries(lines, fallback)
 
 
 releases_list = []


### PR DESCRIPTION
## Summary
- sanitize release-body bullets before writing `OFFICIAL_SITE_RELEASE_STATE.json`
- map clearly technical or workflow-only lines into short user-facing release summaries
- keep fallback summaries when a release body does not contain any safe public-facing bullets

## Why
- the current official-site beta sync script writes `updateSummary` directly from release-body bullets
- that bypasses the user-facing summary cleanup already present in `frontend/apps/web/src/lib/official-site-releases.ts`
- as a result, the public `releases.json` can expose phrases like `PR #509`, `document why ...`, and `make one tiny mobile-input change`

## What changed
- add technical-line filtering and small topic-based summary mapping in `.github/scripts/generate-official-site-beta-state.py`
- keep summaries deduplicated and capped so the generated beta state stays compact
- add human-readable fallback summaries for Android, iOS/TestFlight, and generic release titles

## Validation
- `python3 -m py_compile /workspace/tmp/generate-official-site-beta-state.py`
- local runtime verification of `gh api` calls was not possible in this environment because the `gh` CLI is unavailable here
- the workflow itself already runs in a GitHub Actions environment where `gh` is present, so repository CI / next sync run remains the real end-to-end check

## Risk review
- scope is limited to one beta-sync helper script
- no app runtime, mobile build, forum deploy, or release-publish logic changes
- if the new sanitizer misses a line, the worst case is a conservative fallback summary rather than a release-chain regression