### PR TITLE
feat(forum): reuse deploy check URL across host handoff helpers

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -61,10 +61,12 @@ jobs:
           node forum/scripts/scaffold-deploy-env.mjs \
             --deploy-env-path /tmp/forum-deploy-preview-scaffold.env \
             --forum-port 3001 \
-            --forum-data-dir /tmp/fabushi-forum-deploy-compose-data
+            --forum-data-dir /tmp/fabushi-forum-deploy-compose-data \
+            --deploy-check-url http://127.0.0.1:3001
 
           grep "FORUM_DEPLOYMENT_STAGE=preview" /tmp/forum-deploy-preview-scaffold.env
           grep "FORUM_ENABLE_WRITES=false" /tmp/forum-deploy-preview-scaffold.env
+          grep "FORUM_DEPLOY_CHECK_URL=http://127.0.0.1:3001" /tmp/forum-deploy-preview-scaffold.env
 
       - name: Reject writable preview scaffold without access code
         shell: bash
@@ -84,11 +86,13 @@ jobs:
             --forum-image fabushi-forum \
             --forum-port 3001 \
             --forum-data-dir "/tmp/fabushi forum deploy compose data" \
+            --deploy-check-url http://127.0.0.1:3001 \
             --write-access-code forum-preview-2026
 
           grep 'FORUM_DATA_DIR="/tmp/fabushi forum deploy compose data"' /tmp/forum-deploy-writable-preview.env
           grep "FORUM_ENABLE_WRITES=true" /tmp/forum-deploy-writable-preview.env
           grep "FORUM_WRITE_ACCESS_CODE=forum-preview-2026" /tmp/forum-deploy-writable-preview.env
+          grep "FORUM_DEPLOY_CHECK_URL=http://127.0.0.1:3001" /tmp/forum-deploy-writable-preview.env
 
       - name: Prepare quoted writable preview deploy env sample
         run: |
@@ -96,6 +100,7 @@ jobs:
           FORUM_IMAGE="fabushi-forum"
           FORUM_PORT="3001"
           FORUM_DATA_DIR="/tmp/fabushi-forum-deploy-compose-data" # quoted path should still parse cleanly
+          FORUM_DEPLOY_CHECK_URL="https://forum-preview.fabushi.test/" # handoff helpers should normalize this
           FORUM_DEPLOYMENT_STAGE="preview"
           FORUM_PUBLIC_BASE_URL="" # preview should stay noindex
           FORUM_DATA_SOURCE='sqlite'
@@ -116,10 +121,9 @@ jobs:
             --exercise-write-flow true \
             --format json >/tmp/forum-live-target.json
 
-      - name: Prepare bundled live target sample from quoted deploy env
+      - name: Prepare bundled live target sample from deploy env check URL
         run: |
           node forum/scripts/prepare-live-deployment-vars.mjs \
-            --forum-url "https://forum-preview.fabushi.test/" \
             --deploy-env-path /tmp/forum-deploy-writable-preview-quoted.env \
             --exercise-write-flow true \
             --format github-cli-bundled \
@@ -173,6 +177,7 @@ jobs:
           grep "FORUM_DEPLOYMENT_STAGE=production" /tmp/forum-deploy-production.env
           grep "FORUM_PUBLIC_BASE_URL=https://forum.fabushi.test" /tmp/forum-deploy-production.env
           grep "FORUM_ENABLE_WRITES=false" /tmp/forum-deploy-production.env
+          grep "FORUM_DEPLOY_CHECK_URL=https://forum.fabushi.test" /tmp/forum-deploy-production.env
 
       - name: Build forum container image
         run: docker build -t fabushi-forum ./forum

--- a/forum/.env.deploy.example
+++ b/forum/.env.deploy.example
@@ -7,6 +7,10 @@ FORUM_PORT=3000
 # Local host path that should keep sqlite durable across restarts.
 FORUM_DATA_DIR=./data
 
+# Optional shared smoke-check and live-handoff URL. Leave empty until the real
+# preview or production address exists.
+FORUM_DEPLOY_CHECK_URL=
+
 # preview keeps the forum noindex. Switch to production only together with
 # FORUM_PUBLIC_BASE_URL when the public origin is ready to be indexed.
 FORUM_DEPLOYMENT_STAGE=preview

--- a/forum/scripts/handoff-live-deployment-target.mjs
+++ b/forum/scripts/handoff-live-deployment-target.mjs
@@ -131,11 +131,6 @@ async function runCommandBlock(commandBlock) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const forumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
-
-  if (!forumUrl) {
-    throw new Error("Missing required --forum-url.");
-  }
-
   const format = args.format?.trim() || "github-cli-bundled";
   if (!["env", "json", "github-cli", "github-cli-bundled"].includes(format)) {
     throw new Error(`Expected --format to be env, json, github-cli, or github-cli-bundled, received: ${format}`);
@@ -150,13 +145,11 @@ async function main() {
   }
 
   const sharedArgs = ["--deploy-env-path", args["deploy-env-path"]];
-  const smokeArgs = [
-    "--forum-url",
-    forumUrl,
-    ...sharedArgs,
-    "--exercise-write-flow",
-    String(exerciseWriteFlow),
-  ];
+  const smokeArgs = [...sharedArgs, "--exercise-write-flow", String(exerciseWriteFlow)];
+  if (forumUrl) {
+    smokeArgs.unshift(forumUrl);
+    smokeArgs.unshift("--forum-url");
+  }
 
   if (args["request-timeout-ms"]) {
     smokeArgs.push("--request-timeout-ms", args["request-timeout-ms"]);
@@ -172,17 +165,12 @@ async function main() {
       return preparedOutputs.get(outputFormat);
     }
 
-    const prepareArgs = [
-      "--forum-url",
-      forumUrl,
-      ...sharedArgs,
-      "--exercise-write-flow",
-      String(exerciseWriteFlow),
-      "--format",
-      outputFormat,
-      "--github-repo",
-      githubRepo,
-    ];
+    const prepareArgs = [...sharedArgs, "--exercise-write-flow", String(exerciseWriteFlow), "--format", outputFormat, "--github-repo", githubRepo];
+    if (forumUrl) {
+      prepareArgs.unshift(forumUrl);
+      prepareArgs.unshift("--forum-url");
+    }
+
     const output = await runNodeScript("prepare-live-deployment-vars.mjs", prepareArgs, {
       captureStdout: true,
     });

--- a/forum/scripts/prepare-live-deployment-vars.mjs
+++ b/forum/scripts/prepare-live-deployment-vars.mjs
@@ -153,12 +153,6 @@ function renderGithubCliBundledFormat(liveTarget, deployEnv, githubRepo) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
-
-  if (!forumUrl) {
-    throw new Error("Missing required --forum-url.");
-  }
-
   const format = args.format?.trim() || "env";
   if (!["env", "json", "github-cli", "github-cli-bundled"].includes(format)) {
     throw new Error(`Expected --format to be env, json, github-cli, or github-cli-bundled, received: ${format}`);
@@ -169,6 +163,12 @@ async function main() {
 
   const deployEnvContent = await readFile(args["deploy-env-path"], "utf-8");
   const deployEnv = parseDotEnv(deployEnvContent);
+  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
+
+  if (!forumUrl) {
+    throw new Error("Missing required --forum-url and deploy env FORUM_DEPLOY_CHECK_URL.");
+  }
+
   const liveTarget = buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow });
 
   if (format === "github-cli") {

--- a/forum/scripts/scaffold-deploy-env.mjs
+++ b/forum/scripts/scaffold-deploy-env.mjs
@@ -13,6 +13,7 @@ function parseArgs(argv) {
     "forum-image": "ghcr.io/bhrumom/fabushi-forum:main",
     "forum-port": "3000",
     "forum-data-dir": "./data",
+    "deploy-check-url": "",
     "data-source": "sqlite",
     "writes-enabled": "",
     "write-access-code": "",
@@ -85,6 +86,7 @@ function buildConfig(args) {
   const deploymentStageOverride = args["deployment-stage"]?.trim() || "";
   const writesEnabledOverride = parseBoolean(args["writes-enabled"], "writes_enabled");
   const publicBaseUrlOverride = normalizeUrl(args["public-base-url"]?.trim() || "");
+  const deployCheckUrlOverride = normalizeUrl(args["deploy-check-url"]?.trim() || "");
   const writeAccessCode = args["write-access-code"] ?? "";
   const dataSource = args["data-source"]?.trim() || "sqlite";
 
@@ -137,12 +139,15 @@ function buildConfig(args) {
     throw new Error("Refusing to scaffold a writable production deploy env. Use preview for write validation first.");
   }
 
+  const deployCheckUrl = deployCheckUrlOverride || (deploymentStage === "production" ? publicBaseUrl : "");
+
   return {
     preset,
     deployEnvPath: args["deploy-env-path"],
     forumImage: args["forum-image"]?.trim() || "ghcr.io/bhrumom/fabushi-forum:main",
     forumPort: args["forum-port"]?.trim() || "3000",
     forumDataDir: args["forum-data-dir"]?.trim() || "./data",
+    deployCheckUrl,
     dataSource,
     deploymentStage,
     publicBaseUrl,
@@ -159,6 +164,7 @@ function renderDeployEnv(config) {
     `FORUM_IMAGE=${quoteEnvValue(config.forumImage)}`,
     `FORUM_PORT=${quoteEnvValue(config.forumPort)}`,
     `FORUM_DATA_DIR=${quoteEnvValue(config.forumDataDir)}`,
+    `FORUM_DEPLOY_CHECK_URL=${quoteEnvValue(config.deployCheckUrl)}`,
     `FORUM_DEPLOYMENT_STAGE=${config.deploymentStage}`,
     `FORUM_PUBLIC_BASE_URL=${quoteEnvValue(config.publicBaseUrl)}`,
     `FORUM_DATA_SOURCE=${config.dataSource}`,
@@ -223,18 +229,21 @@ async function main() {
   await runValidateScript(config.deployEnvPath);
 
   const deployEnvPath = config.deployEnvPath;
-  const forumUrlHint =
-    config.deploymentStage === "production" && config.publicBaseUrl
-      ? config.publicBaseUrl
-      : "https://forum-preview.example.com";
+  const forumUrlHint = config.deployCheckUrl || "https://forum-preview.example.com";
+  const smokeCommand = config.deployCheckUrl
+    ? `- pnpm smoke:deploy-env -- --deploy-env-path ${deployEnvPath}`
+    : `- pnpm smoke:deploy-env -- --forum-url ${forumUrlHint} --deploy-env-path ${deployEnvPath}`;
+  const handoffCommand = config.deployCheckUrl
+    ? `- pnpm handoff:live-target -- --deploy-env-path ${deployEnvPath}`
+    : `- pnpm handoff:live-target -- --forum-url ${forumUrlHint} --deploy-env-path ${deployEnvPath}`;
 
   console.log("");
   console.log("## Next steps");
   console.log("");
   console.log(`- Review ${deployEnvPath} and adjust any host-specific values if needed.`);
   console.log(`- docker compose --env-file ${deployEnvPath} -f docker-compose.deploy.yml up -d`);
-  console.log(`- pnpm smoke:deploy-env -- --forum-url ${forumUrlHint} --deploy-env-path ${deployEnvPath}`);
-  console.log(`- pnpm handoff:live-target -- --forum-url ${forumUrlHint} --deploy-env-path ${deployEnvPath}`);
+  console.log(smokeCommand);
+  console.log(handoffCommand);
 }
 
 main().catch((error) => {

--- a/forum/scripts/smoke-deployment-from-env.mjs
+++ b/forum/scripts/smoke-deployment-from-env.mjs
@@ -142,15 +142,15 @@ function runCheckScript(expectedRuntime, args) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
-
-  if (!forumUrl) {
-    throw new Error("Missing required --forum-url.");
-  }
-
   const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
   const deployEnvContent = await readFile(args["deploy-env-path"], "utf-8");
   const deployEnv = parseDotEnv(deployEnvContent);
+  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
+
+  if (!forumUrl) {
+    throw new Error("Missing required --forum-url and deploy env FORUM_DEPLOY_CHECK_URL.");
+  }
+
   const expectedRuntime = buildExpectedRuntime({ forumUrl, deployEnv, exerciseWriteFlow });
 
   await runCheckScript(expectedRuntime, args);

--- a/forum/scripts/validate-deploy-env.mjs
+++ b/forum/scripts/validate-deploy-env.mjs
@@ -67,12 +67,17 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
   const image = deployEnv.FORUM_IMAGE?.trim() || "ghcr.io/bhrumom/fabushi-forum:main";
   const port = deployEnv.FORUM_PORT?.trim() || "3000";
   const dataDir = deployEnv.FORUM_DATA_DIR?.trim() || "./data";
+  const deployCheckUrl = normalizeUrl(deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
   const publicBaseUrl = normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
   const writesEnabled = parseBoolean(deployEnv.FORUM_ENABLE_WRITES ?? "false", "FORUM_ENABLE_WRITES");
   const writeAccessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
   const requiresAccessCode = writesEnabled && Boolean(writeAccessCode);
 
   const warnings = [];
+
+  if (!deployCheckUrl) {
+    warnings.push("FORUM_DEPLOY_CHECK_URL is empty, so smoke and handoff helpers still require an explicit --forum-url.");
+  }
 
   if (deploymentStage === "preview" && publicBaseUrl) {
     warnings.push("preview deploy env sets FORUM_PUBLIC_BASE_URL; the runtime will still stay noindex until production mode.");
@@ -104,6 +109,7 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
     image,
     port,
     dataDir,
+    deployCheckUrl,
     dataSource,
     deploymentStage,
     publicBaseUrl,
@@ -122,6 +128,7 @@ function renderSummary(posture) {
     `- image: ${posture.image}`,
     `- port: ${posture.port}`,
     `- data_dir: ${posture.dataDir}`,
+    `- deploy_check_url: ${posture.deployCheckUrl || "(empty)"}`,
     `- data_source: ${posture.dataSource}`,
     `- deployment_stage: ${posture.deploymentStage}`,
     `- public_base_url: ${posture.publicBaseUrl || "(empty)"}`,


### PR DESCRIPTION
## Summary
- add optional `FORUM_DEPLOY_CHECK_URL` to the deploy env surface so forum deploy helpers can share one checked target URL instead of repeating it across commands
- let `validate-deploy-env.mjs`, `smoke-deployment-from-env.mjs`, `prepare-live-deployment-vars.mjs`, and `handoff-live-deployment-target.mjs` all understand that shared value
- extend `scaffold-deploy-env.mjs`, `.env.deploy.example`, and `Deploy compose checks - Forum` so the new URL path is documented in config and covered in CI

## Why now
The forum's current highest-priority blocker is still the first real preview/live rollout on a host outside the repository. Main already had:
- deploy env scaffolding
- deploy env posture validation
- deployed runtime smoke checks
- one-command live-target handoff
- optional direct GitHub live-target sync

At that point, the next smallest high-value friction was practical rather than architectural: once an operator finally had a real forum URL, they still had to retype the same value across smoke, prepare, and handoff commands. This PR keeps scope tight and shortens exactly that seam.

## What changed
### `forum/.env.deploy.example`
- adds optional `FORUM_DEPLOY_CHECK_URL=`
- keeps preview default empty so the example does not pretend a real live target already exists

### `forum/scripts/validate-deploy-env.mjs`
- includes `deploy_check_url` in the posture summary
- warns when it is still empty, so operators know helper commands still need explicit `--forum-url`

### `forum/scripts/smoke-deployment-from-env.mjs`
- falls back to `FORUM_DEPLOY_CHECK_URL` when `--forum-url` is omitted

### `forum/scripts/prepare-live-deployment-vars.mjs`
- uses the same fallback so live-target generation can reuse the deploy env URL too

### `forum/scripts/handoff-live-deployment-target.mjs`
- no longer insists on `--forum-url` at the entrypoint when the deploy env already carries `FORUM_DEPLOY_CHECK_URL`
- still passes explicit `--forum-url` through when provided

### `forum/scripts/scaffold-deploy-env.mjs`
- adds optional `--deploy-check-url`
- production scaffolds now default `FORUM_DEPLOY_CHECK_URL` to the provided `FORUM_PUBLIC_BASE_URL`
- next-step output now drops explicit `--forum-url` only when the generated deploy env already has a shared check URL

### `.github/workflows/forum-deploy-compose-checks.yml`
- covers scaffolded preview envs with explicit `FORUM_DEPLOY_CHECK_URL`
- adds a quoted deploy-env sample that proves `prepare-live-deployment-vars.mjs` can derive the bundled live target directly from the env value
- asserts production scaffolds auto-populate `FORUM_DEPLOY_CHECK_URL` from `FORUM_PUBLIC_BASE_URL`

## Verification
- local scratch validation passed:
  - `node --check` for the updated deploy helper scripts
  - production scaffold emits `FORUM_DEPLOY_CHECK_URL=https://forum.fabushi.com`
  - live-target preparation succeeds without `--forum-url` when the deploy env carries that URL
- this environment still cannot clone the repository itself or hit a real preview host URL directly, so final end-to-end confirmation remains with repository CI and the eventual real preview rollout

## Remaining blocker after this PR
This tightens the repository-side handoff again, but the external blocker still stays the same:
- a real preview or production forum URL is still needed
- a real target-host `forum/.env.deploy` still needs to exist
- hourly live deployment checks still need that first verified live target before they can stop skipping