### PR TITLE
feat(forum): default deploy smoke checks to local host port

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -317,6 +317,7 @@ jobs:
       - name: Smoke test forum deploy compose production contract from deploy env
         run: |
           node forum/scripts/smoke-deployment-from-env.mjs \
+            --forum-url http://127.0.0.1:3001 \
             --deploy-env-path /tmp/forum-deploy-production.env
 
       - name: Stop forum deploy compose

--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -3,9 +3,11 @@ name: Deploy compose checks - Forum
 on:
   pull_request:
     paths:
-      - "forum/docker-compose.deploy.yml"
+      - ".github/workflows/forum-deploy-compose-checks.yml"
+      - ".github/workflows/forum-live-deployment-checks.yml"
       - "forum/.env.deploy.example"
       - "forum/DEPLOY.md"
+      - "forum/docker-compose.deploy.yml"
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
       - "forum/scripts/handoff-live-deployment-target.mjs"
@@ -15,15 +17,15 @@ on:
       - "forum/scripts/scaffold-deploy-env.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
-      - ".github/workflows/forum-deploy-compose-checks.yml"
-      - ".github/workflows/forum-live-deployment-checks.yml"
   push:
     branches:
       - main
     paths:
-      - "forum/docker-compose.deploy.yml"
+      - ".github/workflows/forum-deploy-compose-checks.yml"
+      - ".github/workflows/forum-live-deployment-checks.yml"
       - "forum/.env.deploy.example"
       - "forum/DEPLOY.md"
+      - "forum/docker-compose.deploy.yml"
       - "forum/package.json"
       - "forum/scripts/check-deployment-contract.mjs"
       - "forum/scripts/handoff-live-deployment-target.mjs"
@@ -33,8 +35,6 @@ on:
       - "forum/scripts/scaffold-deploy-env.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
-      - ".github/workflows/forum-deploy-compose-checks.yml"
-      - ".github/workflows/forum-live-deployment-checks.yml"
 
 permissions:
   contents: read
@@ -151,7 +151,7 @@ jobs:
 
           grep "gh variable set FORUM_LIVE_TARGET" /tmp/forum-live-target-cli.txt
           grep "gh secret set FORUM_LIVE_WRITE_ACCESS_CODE" /tmp/forum-live-target-cli.txt
-          grep "--repo 'bhrumom/fabushi'" /tmp/forum-live-target-cli.txt
+          grep --fixed-strings -- "--repo 'bhrumom/fabushi'" /tmp/forum-live-target-cli.txt
 
       - name: Reject production scaffold without public base URL
         shell: bash

--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -61,12 +61,11 @@ jobs:
           node forum/scripts/scaffold-deploy-env.mjs \
             --deploy-env-path /tmp/forum-deploy-preview-scaffold.env \
             --forum-port 3001 \
-            --forum-data-dir /tmp/fabushi-forum-deploy-compose-data \
-            --deploy-check-url http://127.0.0.1:3001
+            --forum-data-dir /tmp/fabushi-forum-deploy-compose-data
 
           grep "FORUM_DEPLOYMENT_STAGE=preview" /tmp/forum-deploy-preview-scaffold.env
           grep "FORUM_ENABLE_WRITES=false" /tmp/forum-deploy-preview-scaffold.env
-          grep "FORUM_DEPLOY_CHECK_URL=http://127.0.0.1:3001" /tmp/forum-deploy-preview-scaffold.env
+          grep '^FORUM_DEPLOY_CHECK_URL=$' /tmp/forum-deploy-preview-scaffold.env
 
       - name: Reject writable preview scaffold without access code
         shell: bash
@@ -212,8 +211,7 @@ jobs:
       - name: Smoke test forum deploy compose read-only preview contract from deploy env
         run: |
           node forum/scripts/smoke-deployment-from-env.mjs \
-            --forum-url http://127.0.0.1:3001 \
-            --deploy-env-path forum/.env.deploy.example
+            --deploy-env-path /tmp/forum-deploy-preview-scaffold.env
 
       - name: Stop forum deploy compose read-only preview runtime
         run: |
@@ -319,7 +317,6 @@ jobs:
       - name: Smoke test forum deploy compose production contract from deploy env
         run: |
           node forum/scripts/smoke-deployment-from-env.mjs \
-            --forum-url http://127.0.0.1:3001 \
             --deploy-env-path /tmp/forum-deploy-production.env
 
       - name: Stop forum deploy compose

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -67,6 +67,8 @@ That preflight step surfaces the effective deployment stage, write posture, acce
 - write access code present while writes are still disabled
 - production runtime left writable before governance posture is ready
 
+When `FORUM_DEPLOY_CHECK_URL` is still empty, `pnpm smoke:deploy-env` now falls back to `http://127.0.0.1:${FORUM_PORT}` on the same host. That lets the first compose rollout verify itself before a real preview or production URL exists. `pnpm handoff:live-target` still needs the real external URL unless `FORUM_DEPLOY_CHECK_URL` is already filled in.
+
 ## Hourly live deployment checks
 
 The repository workflow `Live deployment checks - Forum` can now run every hour against one configured live forum target. This turns the current highest-priority deployment question from a manual reminder into a standing smoke check.
@@ -86,7 +88,7 @@ If both are present, `FORUM_LIVE_TARGET` wins. This keeps the hourly workflow ba
 
 If the live target still requires the shared preview code, also store it in the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE`.
 
-Once the target host has a working `forum/.env.deploy`, the shortest recommended handoff is now one command:
+Once the target host has a working `forum/.env.deploy` and the runtime is reachable at its real preview or production URL, the shortest recommended handoff is now one command:
 
 ```bash
 cd forum
@@ -221,6 +223,7 @@ Equivalent deploy env:
 FORUM_IMAGE=ghcr.io/bhrumom/fabushi-forum:main
 FORUM_PORT=3000
 FORUM_DATA_DIR=./data
+FORUM_DEPLOY_CHECK_URL=
 FORUM_DEPLOYMENT_STAGE=preview
 FORUM_PUBLIC_BASE_URL=
 FORUM_DATA_SOURCE=sqlite
@@ -232,9 +235,7 @@ Start the forum:
 
 ```bash
 docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
-pnpm smoke:deploy-env -- \
-  --forum-url http://127.0.0.1:3000 \
-  --deploy-env-path .env.deploy
+pnpm smoke:deploy-env -- --deploy-env-path .env.deploy
 curl http://localhost:3000/api/health
 curl http://localhost:3000/api/status
 curl http://localhost:3000/robots.txt
@@ -317,9 +318,7 @@ Bring the stack back up and verify:
 
 ```bash
 docker compose --env-file .env.deploy -f docker-compose.deploy.yml up -d
-pnpm smoke:deploy-env -- \
-  --forum-url https://forum.fabushi.com \
-  --deploy-env-path .env.deploy
+pnpm smoke:deploy-env -- --deploy-env-path .env.deploy
 curl https://forum.fabushi.com/api/health
 curl https://forum.fabushi.com/api/status
 curl https://forum.fabushi.com/robots.txt

--- a/forum/scripts/scaffold-deploy-env.mjs
+++ b/forum/scripts/scaffold-deploy-env.mjs
@@ -230,9 +230,7 @@ async function main() {
 
   const deployEnvPath = config.deployEnvPath;
   const forumUrlHint = config.deployCheckUrl || "https://forum-preview.example.com";
-  const smokeCommand = config.deployCheckUrl
-    ? `- pnpm smoke:deploy-env -- --deploy-env-path ${deployEnvPath}`
-    : `- pnpm smoke:deploy-env -- --forum-url ${forumUrlHint} --deploy-env-path ${deployEnvPath}`;
+  const smokeCommand = `- pnpm smoke:deploy-env -- --deploy-env-path ${deployEnvPath}`;
   const handoffCommand = config.deployCheckUrl
     ? `- pnpm handoff:live-target -- --deploy-env-path ${deployEnvPath}`
     : `- pnpm handoff:live-target -- --forum-url ${forumUrlHint} --deploy-env-path ${deployEnvPath}`;

--- a/forum/scripts/smoke-deployment-from-env.mjs
+++ b/forum/scripts/smoke-deployment-from-env.mjs
@@ -54,6 +54,11 @@ function normalizeUrl(value) {
   return value ? value.replace(/\/$/, "") : "";
 }
 
+function buildLocalForumUrl(deployEnv) {
+  const port = deployEnv.FORUM_PORT?.trim() || "3000";
+  return normalizeUrl(`http://127.0.0.1:${port}`);
+}
+
 function buildExpectedRuntime({ forumUrl, deployEnv, exerciseWriteFlow }) {
   const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
   if (deploymentStage !== "preview" && deploymentStage !== "production") {
@@ -145,11 +150,9 @@ async function main() {
   const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
   const deployEnvContent = await readFile(args["deploy-env-path"], "utf-8");
   const deployEnv = parseDotEnv(deployEnvContent);
-  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
-
-  if (!forumUrl) {
-    throw new Error("Missing required --forum-url and deploy env FORUM_DEPLOY_CHECK_URL.");
-  }
+  const forumUrl = normalizeUrl(
+    args["forum-url"]?.trim() || deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || buildLocalForumUrl(deployEnv),
+  );
 
   const expectedRuntime = buildExpectedRuntime({ forumUrl, deployEnv, exerciseWriteFlow });
 

--- a/forum/scripts/validate-deploy-env.mjs
+++ b/forum/scripts/validate-deploy-env.mjs
@@ -51,6 +51,10 @@ function normalizeUrl(value) {
   return value ? value.replace(/\/$/, "") : "";
 }
 
+function buildLocalSmokeUrl(port) {
+  return normalizeUrl(`http://127.0.0.1:${port}`);
+}
+
 function buildDeployPosture({ deployEnvPath, deployEnv }) {
   const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
   if (deploymentStage !== "preview" && deploymentStage !== "production") {
@@ -68,6 +72,7 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
   const port = deployEnv.FORUM_PORT?.trim() || "3000";
   const dataDir = deployEnv.FORUM_DATA_DIR?.trim() || "./data";
   const deployCheckUrl = normalizeUrl(deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
+  const defaultSmokeUrl = deployCheckUrl || buildLocalSmokeUrl(port);
   const publicBaseUrl = normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
   const writesEnabled = parseBoolean(deployEnv.FORUM_ENABLE_WRITES ?? "false", "FORUM_ENABLE_WRITES");
   const writeAccessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
@@ -76,7 +81,9 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
   const warnings = [];
 
   if (!deployCheckUrl) {
-    warnings.push("FORUM_DEPLOY_CHECK_URL is empty, so smoke and handoff helpers still require an explicit --forum-url.");
+    warnings.push(
+      `FORUM_DEPLOY_CHECK_URL is empty, so handoff helpers still require an explicit --forum-url. smoke:deploy-env will fall back to ${defaultSmokeUrl} on the target host.`,
+    );
   }
 
   if (deploymentStage === "preview" && publicBaseUrl) {
@@ -110,6 +117,7 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
     port,
     dataDir,
     deployCheckUrl,
+    defaultSmokeUrl,
     dataSource,
     deploymentStage,
     publicBaseUrl,
@@ -129,6 +137,7 @@ function renderSummary(posture) {
     `- port: ${posture.port}`,
     `- data_dir: ${posture.dataDir}`,
     `- deploy_check_url: ${posture.deployCheckUrl || "(empty)"}`,
+    `- default_smoke_url: ${posture.defaultSmokeUrl}`,
     `- data_source: ${posture.dataSource}`,
     `- deployment_stage: ${posture.deploymentStage}`,
     `- public_base_url: ${posture.publicBaseUrl || "(empty)"}`,


### PR DESCRIPTION
## Summary
- let `forum/scripts/smoke-deployment-from-env.mjs` fall back to `http://127.0.0.1:${FORUM_PORT}` when neither `--forum-url` nor `FORUM_DEPLOY_CHECK_URL` is set
- extend `validate-deploy-env.mjs`, `scaffold-deploy-env.mjs`, and `forum/DEPLOY.md` so the new local-smoke default is visible in posture summaries, scaffold next steps, and host rollout docs
- update `Deploy compose checks - Forum` to cover the empty-`FORUM_DEPLOY_CHECK_URL` path and prove read-only preview smoke checks still pass without an explicit URL

## Why now
The forum's current highest-priority blocker is still the first real preview/live rollout on a target host. Main already has:
- deploy env scaffolding
- deploy env preflight
- deployed runtime smoke checks
- one-command live-target handoff
- optional direct GitHub live-target sync

At this point, the smallest high-value friction left inside the repository was the first smoke check immediately after `docker compose up`. In the common read-only preview posture, operators could still end up retyping `http://127.0.0.1:<port>` even before a real external URL existed. This PR keeps scope tight and removes exactly that extra step.

## What changed
### `forum/scripts/smoke-deployment-from-env.mjs`
- adds a final fallback to `http://127.0.0.1:${FORUM_PORT}`
- keeps explicit `--forum-url` and shared `FORUM_DEPLOY_CHECK_URL` higher priority when they exist

### `forum/scripts/validate-deploy-env.mjs`
- adds `default_smoke_url` to the posture summary
- updates the empty-`FORUM_DEPLOY_CHECK_URL` warning to explain that local smoke checks can still proceed, while live-target handoff still needs a real external URL

### `forum/scripts/scaffold-deploy-env.mjs`
- stops printing an unnecessary `--forum-url` for the standard local smoke step
- keeps the handoff command explicit when no shared check URL exists yet

### `forum/DEPLOY.md`
- documents the local-host fallback behavior for `pnpm smoke:deploy-env`
- updates preview and production host examples so the first post-compose smoke command can run straight from `.env.deploy`

### `.github/workflows/forum-deploy-compose-checks.yml`
- changes the read-only preview scaffold sample to leave `FORUM_DEPLOY_CHECK_URL` empty
- proves the runtime smoke check now succeeds against that sample without passing `--forum-url`
- keeps writable preview and production coverage intact

## Verification
- branch compare confirms the diff stays scoped to forum deploy helpers, forum deploy docs, and the deploy compose workflow
- `Deploy compose checks - Forum` now exercises the new empty-`FORUM_DEPLOY_CHECK_URL` path directly on the PR branch
- this environment still cannot clone the full repository or hit a real target host URL directly, so final end-to-end confirmation remains with repository CI and the eventual real host rollout

## Remaining blocker after this PR
This shortens the first host-side validation step again, but the external blockers still remain:
- a real preview or production forum URL is still needed for hourly live checks
- a real target-host `forum/.env.deploy` still needs to exist
- live-target handoff still needs that first verified external URL before scheduled checks can stop skipping