### PR TITLE
feat(forum): combine host-side deploy rollout into one helper

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -14,6 +14,7 @@ on:
       - "forum/scripts/parse-deploy-env.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
+      - "forum/scripts/rollout-deploy-env.mjs"
       - "forum/scripts/scaffold-deploy-env.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
@@ -32,6 +33,7 @@ on:
       - "forum/scripts/parse-deploy-env.mjs"
       - "forum/scripts/prepare-live-deployment-vars.mjs"
       - "forum/scripts/resolve-live-deployment-target.mjs"
+      - "forum/scripts/rollout-deploy-env.mjs"
       - "forum/scripts/scaffold-deploy-env.mjs"
       - "forum/scripts/smoke-deployment-from-env.mjs"
       - "forum/scripts/validate-deploy-env.mjs"
@@ -186,32 +188,17 @@ jobs:
           rm -rf /tmp/fabushi-forum-deploy-compose-data
           mkdir -p /tmp/fabushi-forum-deploy-compose-data
 
-      - name: Start forum deploy compose in sqlite read-only preview mode
+      - name: Roll out forum deploy compose read-only preview runtime through combined helper
         run: |
           COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
           FORUM_IMAGE=fabushi-forum \
-          FORUM_PORT=3001 \
-          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
-          docker compose -f forum/docker-compose.deploy.yml up -d
+          node forum/scripts/rollout-deploy-env.mjs \
+            --deploy-env-path /tmp/forum-deploy-preview-scaffold.env \
+            --compose-file forum/docker-compose.deploy.yml \
+            --compose-project-name fabushi-forum-deploy-check | tee /tmp/forum-rollout-preview.txt
 
-      - name: Wait for forum deploy compose read-only preview health endpoint
-        run: |
-          rm -f /tmp/forum-deploy-health.json
-
-          for attempt in 1 2 3 4 5 6; do
-            if curl --fail --show-error --silent http://127.0.0.1:3001/api/health >/tmp/forum-deploy-health.json; then
-              break
-            fi
-
-            sleep 3
-          done
-
-          cat /tmp/forum-deploy-health.json
-
-      - name: Smoke test forum deploy compose read-only preview contract from deploy env
-        run: |
-          node forum/scripts/smoke-deployment-from-env.mjs \
-            --deploy-env-path /tmp/forum-deploy-preview-scaffold.env
+          grep "Health probe ready at http://127.0.0.1:3001/api/health" /tmp/forum-rollout-preview.txt
+          grep "Skipping handoff because neither --forum-url nor FORUM_DEPLOY_CHECK_URL is available yet." /tmp/forum-rollout-preview.txt
 
       - name: Stop forum deploy compose read-only preview runtime
         run: |
@@ -226,31 +213,7 @@ jobs:
           rm -rf /tmp/fabushi-forum-deploy-compose-data
           mkdir -p /tmp/fabushi-forum-deploy-compose-data
 
-      - name: Start forum deploy compose in sqlite writable preview mode
-        run: |
-          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
-          FORUM_IMAGE=fabushi-forum \
-          FORUM_PORT=3001 \
-          FORUM_DATA_DIR=/tmp/fabushi-forum-deploy-compose-data \
-          FORUM_ENABLE_WRITES=true \
-          FORUM_WRITE_ACCESS_CODE=forum-preview-2026 \
-          docker compose -f forum/docker-compose.deploy.yml up -d
-
-      - name: Wait for forum deploy compose writable preview health endpoint
-        run: |
-          rm -f /tmp/forum-deploy-health.json
-
-          for attempt in 1 2 3 4 5 6; do
-            if curl --fail --show-error --silent http://127.0.0.1:3001/api/health >/tmp/forum-deploy-health.json; then
-              break
-            fi
-
-            sleep 3
-          done
-
-          cat /tmp/forum-deploy-health.json
-
-      - name: Apply writable preview live target to GitHub via mocked gh
+      - name: Roll out forum deploy compose writable preview runtime through combined helper
         run: |
           mkdir -p /tmp/forum-mock-gh-bin
           cat <<'GHEOF' >/tmp/forum-mock-gh-bin/gh
@@ -261,16 +224,19 @@ jobs:
           : >/tmp/forum-gh-invocations.txt
 
           PATH="/tmp/forum-mock-gh-bin:$PATH" \
-          node forum/scripts/handoff-live-deployment-target.mjs \
-            --forum-url http://127.0.0.1:3001 \
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          node forum/scripts/rollout-deploy-env.mjs \
             --deploy-env-path /tmp/forum-deploy-writable-preview.env \
+            --compose-file forum/docker-compose.deploy.yml \
+            --compose-project-name fabushi-forum-deploy-check \
             --exercise-write-flow true \
-            --apply-github-live-target true >/tmp/forum-live-target-handoff.txt
+            --apply-github-live-target true | tee /tmp/forum-live-target-handoff.txt
 
-          cat /tmp/forum-live-target-handoff.txt
           cat /tmp/forum-gh-invocations.txt
           grep "gh variable set FORUM_LIVE_TARGET" /tmp/forum-live-target-handoff.txt
           grep "Applied FORUM_LIVE_TARGET to GitHub repo bhrumom/fabushi." /tmp/forum-live-target-handoff.txt
+          grep "Health probe ready at http://127.0.0.1:3001/api/health" /tmp/forum-live-target-handoff.txt
           grep "variable set FORUM_LIVE_TARGET --body" /tmp/forum-gh-invocations.txt
           grep "secret set FORUM_LIVE_WRITE_ACCESS_CODE --body" /tmp/forum-gh-invocations.txt
           grep -- "--repo bhrumom/fabushi" /tmp/forum-gh-invocations.txt

--- a/forum/package.json
+++ b/forum/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke:deployment": "node ./scripts/check-deployment-contract.mjs",
     "smoke:deploy-env": "node ./scripts/smoke-deployment-from-env.mjs",
+    "rollout:deploy-env": "node ./scripts/rollout-deploy-env.mjs",
     "handoff:live-target": "node ./scripts/handoff-live-deployment-target.mjs",
     "prepare:live-target": "node ./scripts/prepare-live-deployment-vars.mjs",
     "scaffold:deploy-env": "node ./scripts/scaffold-deploy-env.mjs",

--- a/forum/scripts/rollout-deploy-env.mjs
+++ b/forum/scripts/rollout-deploy-env.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseDotEnv } from "./parse-deploy-env.mjs";
+
+function parseArgs(argv) {
+  const parsed = {
+    "deploy-env-path": ".env.deploy",
+    "compose-file": "docker-compose.deploy.yml",
+    detach: "true",
+    "handoff-live-target": "auto",
+    "exercise-write-flow": "false",
+    "apply-github-live-target": "false",
+    "github-repo": "bhrumom/fabushi",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const part = argv[index];
+
+    if (!part.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${part}`);
+    }
+
+    const key = part.slice(2);
+    const value = argv[index + 1];
+
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value, key) {
+  if (value === undefined || value === null || value === "") {
+    return false;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Expected ${key} to be true or false, received: ${value}`);
+}
+
+function parseInteger(value, key) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Expected ${key} to be a positive integer, received: ${value}`);
+  }
+
+  return parsed;
+}
+
+function normalizeUrl(value) {
+  return value ? value.replace(/\/$/, "") : "";
+}
+
+function validateHandoffMode(value) {
+  if (value === "auto" || value === "true" || value === "false") {
+    return value;
+  }
+
+  throw new Error(`Expected --handoff-live-target to be auto, true, or false, received: ${value}`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function runNodeScript(scriptName, scriptArgs) {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const scriptPath = join(scriptDir, scriptName);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...scriptArgs], {
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`${scriptName} exited via signal: ${signal}`));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(new Error(`${scriptName} exited with code ${code}.`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function runDockerComposeUp({ deployEnvPath, composeFile, detach, composeProjectName }) {
+  const args = ["compose", "--env-file", deployEnvPath, "-f", composeFile, "up"];
+  if (detach) {
+    args.push("-d");
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("docker", args, {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        ...(composeProjectName ? { COMPOSE_PROJECT_NAME: composeProjectName } : {}),
+      },
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`docker compose up exited via signal: ${signal}`));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(new Error(`docker compose up exited with code ${code}.`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function loadDeployEnv(deployEnvPath) {
+  const deployEnvContent = await readFile(deployEnvPath, "utf-8");
+  return parseDotEnv(deployEnvContent);
+}
+
+async function waitForLocalHealth(deployEnv, requestTimeoutMs) {
+  const port = deployEnv.FORUM_PORT?.trim() || "3000";
+  const healthUrl = `http://127.0.0.1:${port}/api/health`;
+  const timeoutMs = requestTimeoutMs ?? 5000;
+
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= 10; attempt += 1) {
+    try {
+      const response = await fetch(healthUrl, {
+        redirect: "follow",
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (response.ok) {
+        console.log(`Health probe ready at ${healthUrl} after attempt ${attempt}.`);
+        return;
+      }
+
+      const body = await response.text();
+      lastError = new Error(`Health probe returned ${response.status}: ${body}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(3000);
+  }
+
+  throw new Error(
+    `Timed out waiting for local health probe ${healthUrl}: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const deployEnvPath = args["deploy-env-path"];
+  const composeFile = args["compose-file"];
+  const detach = parseBoolean(args.detach, "detach");
+  const handoffMode = validateHandoffMode(args["handoff-live-target"]?.trim() || "auto");
+  const exerciseWriteFlow = parseBoolean(args["exercise-write-flow"], "exercise_write_flow");
+  const applyGithubLiveTarget = parseBoolean(args["apply-github-live-target"], "apply_github_live_target");
+  const githubRepo = args["github-repo"]?.trim() || "";
+  const composeProjectName = args["compose-project-name"]?.trim() || "";
+  const explicitForumUrl = normalizeUrl(args["forum-url"]?.trim() || "");
+  const requestTimeoutMs = parseInteger(args["request-timeout-ms"], "request_timeout_ms");
+
+  if (handoffMode === "false" && applyGithubLiveTarget) {
+    throw new Error("--apply-github-live-target true requires handoff-live-target to stay enabled.");
+  }
+
+  if (applyGithubLiveTarget && !githubRepo) {
+    throw new Error("--apply-github-live-target true requires --github-repo.");
+  }
+
+  const deployEnv = await loadDeployEnv(deployEnvPath);
+  const deployCheckUrl = normalizeUrl(deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
+  const handoffUrl = explicitForumUrl || deployCheckUrl;
+
+  const sharedArgs = ["--deploy-env-path", deployEnvPath];
+
+  console.log("== Deploy env preflight ==");
+  await runNodeScript("validate-deploy-env.mjs", sharedArgs);
+
+  console.log("\n== Deploy compose up ==");
+  await runDockerComposeUp({ deployEnvPath, composeFile, detach, composeProjectName });
+
+  console.log("\n== Wait for local health probe ==");
+  await waitForLocalHealth(deployEnv, requestTimeoutMs);
+
+  console.log("\n== Deployed runtime smoke check ==");
+  const smokeArgs = [...sharedArgs, "--exercise-write-flow", String(exerciseWriteFlow)];
+  if (explicitForumUrl) {
+    smokeArgs.push("--forum-url", explicitForumUrl);
+  }
+  if (requestTimeoutMs) {
+    smokeArgs.push("--request-timeout-ms", String(requestTimeoutMs));
+  }
+  if (args["report-path"]) {
+    smokeArgs.push("--report-path", args["report-path"]);
+  }
+  await runNodeScript("smoke-deployment-from-env.mjs", smokeArgs);
+
+  if (handoffMode === "false") {
+    return;
+  }
+
+  if (!handoffUrl) {
+    if (handoffMode === "true") {
+      throw new Error(
+        "Handoff requires either --forum-url or FORUM_DEPLOY_CHECK_URL in the deploy env file.",
+      );
+    }
+
+    console.log("\n== Hourly live target handoff ==");
+    console.log(
+      "Skipping handoff because neither --forum-url nor FORUM_DEPLOY_CHECK_URL is available yet. Re-run with the real preview or production URL once it exists.",
+    );
+    return;
+  }
+
+  console.log("\n== Hourly live target handoff ==");
+  const handoffArgs = [...sharedArgs, "--exercise-write-flow", String(exerciseWriteFlow)];
+  if (explicitForumUrl) {
+    handoffArgs.push("--forum-url", explicitForumUrl);
+  }
+  if (requestTimeoutMs) {
+    handoffArgs.push("--request-timeout-ms", String(requestTimeoutMs));
+  }
+  if (args["report-path"]) {
+    handoffArgs.push("--report-path", args["report-path"]);
+  }
+  if (args.format) {
+    handoffArgs.push("--format", args.format);
+  }
+  if (applyGithubLiveTarget) {
+    handoffArgs.push("--apply-github-live-target", "true");
+  }
+  if (githubRepo) {
+    handoffArgs.push("--github-repo", githubRepo);
+  }
+
+  await runNodeScript("handoff-live-deployment-target.mjs", handoffArgs);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `forum/scripts/rollout-deploy-env.mjs` to combine deploy-env preflight, `docker compose up`, local health waiting, runtime smoke checks, and optional live-target handoff
- expose the helper as `pnpm rollout:deploy-env`
- extend `Deploy compose checks - Forum` so CI exercises both the helper's skip-handoff path and its writable-preview + mocked-`gh` apply path

## Why now
The forum's current highest-priority blocker is still the first real preview rollout on a target host. Main already had the individual pieces:
- deploy env scaffolding
- deploy env preflight
- deployed-runtime smoke checks
- live-target handoff

But an operator still had to stitch those pieces together manually during the first real host bring-up. This PR keeps scope tight and reduces that friction at the point where deployment work is now concentrated.

## Verification
- local script-level validation with mocked `docker compose` and stub child scripts for:
  - read-only preview skip-handoff flow
  - writable preview apply-to-GitHub flow
- local temporary HTTP server validation to confirm the helper waits for `/api/health` before advancing into smoke checks
- repository CI updated to cover the combined helper in deploy-compose checks