### PR TITLE
feat(forum): let rollout bootstrap a missing deploy env

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -190,13 +190,20 @@ jobs:
 
       - name: Roll out forum deploy compose read-only preview runtime through combined helper
         run: |
+          rm -f /tmp/forum-rollout-preview-bootstrap.env
+
           COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
           FORUM_IMAGE=fabushi-forum \
           node forum/scripts/rollout-deploy-env.mjs \
-            --deploy-env-path /tmp/forum-deploy-preview-scaffold.env \
+            --deploy-env-path /tmp/forum-rollout-preview-bootstrap.env \
             --compose-file forum/docker-compose.deploy.yml \
-            --compose-project-name fabushi-forum-deploy-check | tee /tmp/forum-rollout-preview.txt
+            --compose-project-name fabushi-forum-deploy-check \
+            --scaffold-if-missing true \
+            --forum-image fabushi-forum \
+            --forum-port 3001 \
+            --forum-data-dir /tmp/fabushi-forum-deploy-compose-data | tee /tmp/forum-rollout-preview.txt
 
+          grep "== Scaffold deploy env ==" /tmp/forum-rollout-preview.txt
           grep "Health probe ready at http://127.0.0.1:3001/api/health" /tmp/forum-rollout-preview.txt
           grep "Skipping handoff because neither --forum-url nor FORUM_DEPLOY_CHECK_URL is available yet." /tmp/forum-rollout-preview.txt
 


### PR DESCRIPTION
## Summary
- let `forum/scripts/rollout-deploy-env.mjs` optionally scaffold `.env.deploy` before it starts the existing preflight -> compose -> health -> smoke -> handoff chain
- keep the new path narrowly opt-in behind `--scaffold-if-missing true`, with pass-through scaffold posture args such as preset, port, data dir, write access code, and public base URL
- extend `Deploy compose checks - Forum` so CI proves the read-only preview rollout helper can now start from a missing deploy env file instead of assuming one already exists

## Why now
The forum deployment path on `main` already has the bigger pieces in place:
- deploy env scaffolding
- deploy env preflight
- combined host-side rollout helper
- live target handoff and optional GitHub sync

At this point the next smallest host-side friction is the very first run on a fresh machine. Operators still need to remember to create `.env.deploy` before they can use the combined rollout helper. This PR keeps scope tight and removes exactly that extra step.

## What changed
### `forum/scripts/rollout-deploy-env.mjs`
- adds `--scaffold-if-missing true|false`, defaulting to `false`
- adds pass-through scaffold inputs:
  - `--scaffold-preset`
  - `--forum-image`
  - `--forum-port`
  - `--forum-data-dir`
  - `--deploy-check-url`
  - `--data-source`
  - `--writes-enabled`
  - `--write-access-code`
  - `--deployment-stage`
  - `--public-base-url`
- when the target deploy env file is absent and bootstrap mode is enabled, the helper now runs `scaffold-deploy-env.mjs` first and then continues with the existing rollout flow unchanged
- existing behavior is preserved when the file already exists or bootstrap mode is left off

### `.github/workflows/forum-deploy-compose-checks.yml`
- switches the read-only preview rollout helper assertion to start from a missing `/tmp/forum-rollout-preview-bootstrap.env`
- verifies the helper prints the scaffold phase and still reaches health + skip-handoff successfully
- keeps writable preview and production coverage intact

## Verification
- local `node --check` passed for the updated rollout helper and related scratch copies used during validation
- local script-level validation with:
  - mocked `docker compose`
  - stub child scripts for smoke and handoff
  - a temporary HTTP server returning `/api/health`
- the validation confirmed the helper can:
  - scaffold a missing writable preview deploy env
  - continue into compose startup
  - wait for the health endpoint
  - advance into the smoke stage without breaking the existing flow

## Remaining blocker after this PR
This removes one more piece of first-host friction, but the external blocker still stays the same:
- a real preview or production forum URL is still needed
- a real target-host rollout still needs to happen
- hourly live deployment checks still need that first verified live target before they can stop skipping