### PR TITLE
feat(web): turn homepage preview band into topic card gateways

### DIFF
--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -37,6 +37,9 @@ interface ProductMoment {
   descriptionEn: string;
   screenshot: ProductScreenshotKey;
   alt: string;
+  href: string;
+  ctaZh: string;
+  ctaEn: string;
 }
 
 interface BulletinItem {
@@ -58,54 +61,50 @@ const homeDescription =
 
 const PRODUCT_MOMENTS: ProductMoment[] = [
   {
-    titleZh: "全球法布施",
-    titleEn: "Global Giving",
-    descriptionZh: "看见善意如何跨越地域，直接抵达世界各地。",
-    descriptionEn: "See compassion travel across regions and reach people around the world.",
+    titleZh: "佛学基本概念",
+    titleEn: "Buddhist Concepts",
+    descriptionZh: "把因果、菩提心、六度和空性先放回同一张概念地图里，再决定自己现在该先看哪一张。",
+    descriptionEn: "Place karma, bodhicitta, the six paramitas, and emptiness back on one map before deciding which concept page should come next.",
     screenshot: "global-dharma",
-    alt: "Fabushi global dharma screen",
+    alt: "Buddhist concepts topic entry",
+    href: "/buddhist-concepts",
+    ctaZh: "进入概念专题",
+    ctaEn: "Open concepts hub",
   },
   {
-    titleZh: "随时随地开始修行",
-    titleEn: "Start Practicing Anytime",
-    descriptionZh: "打开就能进入禅修状态，把修行节奏留在日常里。",
-    descriptionEn: "Open the app and return to practice without friction.",
+    titleZh: "修行方法总览",
+    titleEn: "Practice Guide",
+    descriptionZh: "把禅修、念佛、听诵、阅读和记录放回同一张练习地图里，先看自己最需要哪一种起步方式。",
+    descriptionEn: "Return meditation, nianfo, listening, reading, and note-taking to one practice map, then choose the entry that fits best.",
     screenshot: "start-meditation",
-    alt: "Fabushi meditation entry screen",
+    alt: "Practice guide topic entry",
+    href: "/practice-guide",
+    ctaZh: "进入修行方法",
+    ctaEn: "Open practice guide",
   },
   {
-    titleZh: "沉浸式禅修体验",
-    titleEn: "Immersive Meditation",
-    descriptionZh: "用更安静、更专注的界面承接每一次练习。",
-    descriptionEn: "A calmer, more focused interface for each meditation session.",
-    screenshot: "immersive-meditation",
-    alt: "Fabushi immersive meditation screen",
-  },
-  {
-    titleZh: "锁定主修功课",
-    titleEn: "Keep Your Main Practice Stable",
-    descriptionZh: "先确定主线，再围绕自己的路径稳定推进。",
-    descriptionEn: "Choose a main path first, then keep steady progress around it.",
-    screenshot: "main-sutra",
-    alt: "Fabushi main practice screen",
-  },
-  {
-    titleZh: "轻松加入共修小组",
-    titleEn: "Join Group Practice Easily",
-    descriptionZh: "搜索、申请、加入和管理共修关系都放在同一条路径里。",
-    descriptionEn: "Search, apply, join, and manage group practice from one flow.",
+    titleZh: "念佛入门",
+    titleEn: "Nianfo Guide",
+    descriptionZh: "把一句佛号、白天的回返点和轻量功课慢慢接起来，让练习更容易真正留在生活里。",
+    descriptionEn: "Let one recited phrase, one daytime return point, and a lighter routine begin to stay inside ordinary life.",
     screenshot: "group-practice",
-    alt: "Fabushi group practice screen",
+    alt: "Nianfo guide topic entry",
+    href: "/nianfo-guide",
+    ctaZh: "进入念佛入门",
+    ctaEn: "Open nianfo guide",
   },
   {
-    titleZh: "全球修行排行",
-    titleEn: "Global Practice Rankings",
-    descriptionZh: "修行进度和榜单变化一眼可见，方便持续跟进。",
-    descriptionEn: "Track progress and ranking changes at a glance.",
-    screenshot: "global-ranking",
-    alt: "Fabushi practice ranking screen",
+    titleZh: "听诵和读经怎么配合",
+    titleEn: "Listening and Reading",
+    descriptionZh: "把通勤里的听诵、安静时的阅读和一句短记录接回同一条线上，不让经典只停在背景声音里。",
+    descriptionEn: "Reconnect commute listening, quiet reading, and one short note so scripture does not remain only in the background.",
+    screenshot: "main-sutra",
+    alt: "Listening and reading topic entry",
+    href: "/sutra-listening",
+    ctaZh: "进入听诵导读",
+    ctaEn: "Open listening guide",
   },
-];
+] as const;
 
 const FAQ_PREVIEW = [
   {
@@ -621,18 +620,18 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="band alt product-band" id="feature-preview">
+      <section className="band alt product-band" id="featured-guides">
         <div className="section-heading tight">
           <p>
-            <LocalizedText zh="专题与产品预览" en="Preview" />
+            <LocalizedText zh="专题导流" en="Featured Guides" />
           </p>
           <h2>
-            <LocalizedText zh="保留克制的配图卡片，但只作为摘要入口，不让视觉盖过正文导览。" en="Keep restrained image cards as summary entry points without letting visuals overpower the homepage guidance." />
+            <LocalizedText zh="保留克制的静态图片卡片，但只让它们承担专题入口，不再承担产品展示叙事。" en="Keep restrained static image cards, but use them as topic gateways instead of product-showcase storytelling." />
           </h2>
         </div>
         <div className="moment-grid showcase-grid">
           {PRODUCT_MOMENTS.map((item) => (
-            <article key={item.titleEn} className="moment-card">
+            <a key={item.href} className="moment-card guide-card" href={siteHref(item.href)}>
               <div className="moment-image">
                 <img
                   src={siteHref(resolveScreenshot(screenshots, item.screenshot))}
@@ -646,7 +645,10 @@ export default async function HomePage() {
               <p>
                 <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
               </p>
-            </article>
+              <span className="eyebrow">
+                <LocalizedText zh={item.ctaZh} en={item.ctaEn} />
+              </span>
+            </a>
           ))}
         </div>
       </section>


### PR DESCRIPTION
## Primary finding
- 最新 `main` 已经把首页重新定位成 `资讯首页 + 学佛路径总入口`，但首页中段仍保留了一整块偏产品展示的 `专题与产品预览` 区。
- 这一区块虽然有视觉完成度，却仍在强化“产品功能展示”而不是“内容专题导流”，与当前首页信息架构还有一点错位。
- 现有佛法内容集群已经足够丰富，因此本小时最高收益动作不是继续新开页面，而是把首页这块旧叙事收回到内容分发上。

## Chosen action
- 只改一个文件：`frontend/apps/web/src/app/page.tsx`
- 保留现有静态截图承载与首页整体节奏
- 不使用翻转卡片，不新增隐藏内容，不扩模板复杂度
- 直接把原来的产品预览卡片改成 SEO 安全的静态专题入口卡片

## What changed
- 扩展首页预览卡片数据结构，让卡片带有明确跳转目标和 CTA
- 将原 `专题与产品预览` 区改写为 `专题导流 / Featured Guides`
- 用现有视觉资源承接 4 条更高意图的内容入口：
  - `/buddhist-concepts`
  - `/practice-guide`
  - `/nianfo-guide`
  - `/sutra-listening`
- 卡片仍保持首屏可见、正文可抓取、静态可读，不引入翻转或背面隐藏内容
- 保留下载页入口在服务区，不再让中段图片卡片继续承担产品展示叙事

## Why this is the best move this hour
- 当前仓库最高频问题已经不再是“缺一张新页”，而是首页局部仍保留旧的下载/产品展示惯性
- 这次改动直接作用在最高权重页面，而且只动一个文件，收益和确定性都高
- 不需要等待新内容生产，就能立刻改善首页的内容导流一致性与内部链接语义

## SEO and IA effect
- 让首页从上到下的叙事更一致：资讯入口 -> 学佛路径 -> 专题导流 -> FAQ -> 服务入口
- 把原本偏展示型的图片卡片，收成更明确的主题集群入口
- 继续坚持卡片化但不翻转：卡片承担摘要和跳转，正文仍保持稳定可见
- 强化现有概念页、实践页、念佛页与听诵页从首页主体获得的静态内链

## Verification
- compare 确认当前分支相对 `main`：`ahead_by = 1`、`behind_by = 0`
- 改动范围仅 1 个文件：`frontend/apps/web/src/app/page.tsx`
- 本环境是 connector-only 工作流，没有运行本地 Next.js 构建；最终检查仍依赖仓库 CI
