### PR TITLE
feat(web): surface refreshed insight timestamps

### DIFF
--- a/frontend/apps/web/src/app/insights/[slug]/page.tsx
+++ b/frontend/apps/web/src/app/insights/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { SiteFooter } from "../../../components/site-footer";
 import { SiteHeader } from "../../../components/site-header";
 import { getAllArticles, getArticleBySlug } from "../../../lib/content";
 import { siteHref, siteUrl } from "../../../lib/site-url";
+import type { InsightArticle } from "../../../content/articles";
 
 type ArticlePageParams = Promise<{ slug: string }>;
 
@@ -77,6 +78,41 @@ const ARTICLE_FAQS = [
     answerEn: "If your goal is simply to download the app, the dedicated download page is clearer. Article pages can still mention related updates, but they do not act as the download conversion page.",
   },
 ] as const;
+
+function ArticleMeta({ article }: { article: InsightArticle }) {
+  return (
+    <span className="article-date">
+      {article.updatedAt ? (
+        <>
+          <LocalizedText zh={`更新 ${article.updatedAt}`} en={`Updated ${article.updatedAt}`} /> ·{" "}
+          <LocalizedText zh={`首发 ${article.publishedAt}`} en={`Published ${article.publishedAt}`} />
+        </>
+      ) : (
+        <LocalizedText zh={`发布 ${article.publishedAt}`} en={`Published ${article.publishedAt}`} />
+      )}
+      {" · "}
+      {article.author} · {article.readTime}
+    </span>
+  );
+}
+
+function ArticleListMeta({ article }: { article: InsightArticle }) {
+  const label = article.updatedAt
+    ? {
+        zh: `更新 ${article.updatedAt}`,
+        en: `Updated ${article.updatedAt}`,
+      }
+    : {
+        zh: `发布 ${article.publishedAt}`,
+        en: `Published ${article.publishedAt}`,
+      };
+
+  return (
+    <small>
+      <LocalizedText zh={label.zh} en={label.en} /> · {article.author} · {article.readTime}
+    </small>
+  );
+}
 
 export function generateStaticParams() {
   return getAllArticles().map((article) => ({ slug: article.slug }));
@@ -219,9 +255,7 @@ export default async function InsightArticlePage({ params }: { params: ArticlePa
           <p className="eyebrow">{article.category}</p>
           <h1>{article.title}</h1>
           <p className="lede">{article.description}</p>
-          <span className="article-date">
-            {article.publishedAt} · {article.author} · {article.readTime}
-          </span>
+          <ArticleMeta article={article} />
         </div>
       </section>
 
@@ -279,9 +313,7 @@ export default async function InsightArticlePage({ params }: { params: ArticlePa
                 <div>
                   <strong>{item.title}</strong>
                   <p>{item.description}</p>
-                  <small>
-                    {item.author} · {item.readTime}
-                  </small>
+                  <ArticleListMeta article={item} />
                 </div>
               </a>
             ))}

--- a/frontend/apps/web/src/app/insights/page.tsx
+++ b/frontend/apps/web/src/app/insights/page.tsx
@@ -5,6 +5,7 @@ import { SiteFooter } from "../../components/site-footer";
 import { SiteHeader } from "../../components/site-header";
 import { getAllArticles } from "../../lib/content";
 import { siteHref, siteUrl } from "../../lib/site-url";
+import type { InsightArticle } from "../../content/articles";
 
 const insightsUrl = siteUrl("/insights");
 const insightsTitle = `官网资讯与内容建设 | ${brand.name}`;
@@ -71,6 +72,24 @@ const INSIGHT_FAQS = [
   },
 ] as const;
 
+function ArticleMeta({ article }: { article: InsightArticle }) {
+  const label = article.updatedAt
+    ? {
+        zh: `更新 ${article.updatedAt}`,
+        en: `Updated ${article.updatedAt}`,
+      }
+    : {
+        zh: `发布 ${article.publishedAt}`,
+        en: `Published ${article.publishedAt}`,
+      };
+
+  return (
+    <small>
+      <LocalizedText zh={label.zh} en={label.en} /> · {article.author} · {article.readTime}
+    </small>
+  );
+}
+
 export const metadata: Metadata = {
   title: insightsTitle,
   description: insightsDescription,
@@ -120,6 +139,8 @@ export default function InsightsIndexPage() {
           headline: item.title,
           description: item.description,
           url: siteUrl(`/insights/${item.slug}`),
+          datePublished: item.publishedAt,
+          dateModified: item.updatedAt ?? item.publishedAt,
         })),
       },
       {
@@ -195,9 +216,7 @@ export default function InsightsIndexPage() {
               <div>
                 <strong>{item.title}</strong>
                 <p>{item.description}</p>
-                <small>
-                  {item.author} · {item.readTime}
-                </small>
+                <ArticleMeta article={item} />
               </div>
             </a>
           ))}

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -67,7 +67,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const articlePages: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
     url: siteUrl(`/insights/${article.slug}`),
-    lastModified: new Date(article.publishedAt),
+    lastModified: new Date(article.updatedAt ?? article.publishedAt),
     changeFrequency: "monthly",
     priority: article.featured ? 0.8 : 0.65,
   }));

--- a/frontend/apps/web/src/content/articles/index.ts
+++ b/frontend/apps/web/src/content/articles/index.ts
@@ -1,13 +1,18 @@
+import type { InsightArticle } from "./types";
 import { downloadWaitlistFlowArticle } from "./download-waitlist-flow";
 import { officialSiteStructureArticle } from "./official-site-structure";
 import { productRoadmapArticle } from "./product-roadmap";
 import { wechatMiniProgramPhaseOneArticle } from "./wechat-mini-program-phase-one";
+
+function getInsightArticleSortDate(article: InsightArticle) {
+  return article.updatedAt ?? article.publishedAt;
+}
 
 export const insightArticles = [
   productRoadmapArticle,
   wechatMiniProgramPhaseOneArticle,
   officialSiteStructureArticle,
   downloadWaitlistFlowArticle,
-].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+].sort((a, b) => getInsightArticleSortDate(b).localeCompare(getInsightArticleSortDate(a)));
 
 export type { InsightArticle } from "./types";


### PR DESCRIPTION
## Primary finding
- 最新 `main` 已经把 `/insights` 列表页、文章页和 4 篇既有资讯正文都刷新到了当前官网的信息架构。
- 但资讯层还有一个明显滞后点：文章虽然在 `2026-05-17` 刷新过，列表页、文章页可见日期和 sitemap 文章 `lastModified` 仍主要停在旧的 `publishedAt` 口径。
- 这会让“官网资讯 / 最新更新”这层看起来比实际更旧，也会让站点地图的 freshness 信号落后于真实内容状态。

## Chosen action
- 不新开页面，不改首页主结构。
- 直接修正现有资讯层的 freshness 信号，让已刷新的内容在列表页、详情页和 sitemap 上一起对齐。
- 保持现有 SEO 安全结构：静态正文、静态专题入口、FAQ 不变，不引入翻转交互。

## What changed
### `frontend/apps/web/src/content/articles/index.ts`
- 资讯内容默认按 `updatedAt ?? publishedAt` 排序，而不是只按旧发布日期排序。

### `frontend/apps/web/src/app/sitemap.ts`
- `/insights/[slug]` 的 `lastModified` 改为使用 `updatedAt ?? publishedAt`，让站点地图能反映最近一次内容刷新时间。

### `frontend/apps/web/src/app/insights/page.tsx`
- 列表页每篇资讯都显式显示“更新 YYYY-MM-DD”或“发布 YYYY-MM-DD”。
- `CollectionPage` 里的文章项新增 `datePublished` 和 `dateModified`。

### `frontend/apps/web/src/app/insights/[slug]/page.tsx`
- 单篇文章页显式显示“更新日期 + 首发日期”，不再只显示旧发布日期。
- 相关文章列表同步显示“更新 / 发布”时间口径。

## Why no card flip
- 这一轮处理的是资讯层 freshness 信号，不是专题分发层重构。
- `/insights` 列表页和文章页的第一职责仍然是完整阅读、稳定抓取和清楚分发。
- 因此继续保持静态列表和正文，不把时间信息藏进交互后态。

## Expected effect
- 让已刷新过的 4 篇既有资讯，不再在页面表层和 sitemap 里看起来像旧内容。
- 改善 `/insights` 作为“官网资讯与内容建设”栏目的可信度与时效性表达。
- 让搜索引擎和读者都更容易读到一致的发布时间 / 更新时间信号。

## Verification
- compare against `main` shows the branch is `ahead_by = 4` and `behind_by = 0`
- diff scope is limited to 4 files:
  - `frontend/apps/web/src/content/articles/index.ts`
  - `frontend/apps/web/src/app/sitemap.ts`
  - `frontend/apps/web/src/app/insights/page.tsx`
  - `frontend/apps/web/src/app/insights/[slug]/page.tsx`
- this connector workflow cannot run a local Next.js build here, so final verification remains with repository CI