### PR TITLE
fix(web): stop overstating sitemap freshness for static routes

### DIFF
--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -48,10 +48,31 @@ const weeklyRoutes = new Set([
   "/beginner-sutra-recommendations",
 ]);
 
+const routeLastModified: Partial<Record<(typeof staticRoutes)[number], string>> = {
+  "/": "2026-05-17",
+  "/faq": "2026-05-17",
+  "/privacy": "2026-05-08",
+  "/insights": "2026-05-17",
+  "/buddhadharma": "2026-05-15",
+  "/start-learning-buddhism": "2026-05-17",
+  "/buddhist-concepts": "2026-05-17",
+  "/what-is-karma": "2026-05-16",
+  "/what-is-bodhicitta": "2026-05-16",
+  "/what-are-the-six-paramitas": "2026-05-17",
+  "/what-is-emptiness": "2026-05-16",
+  "/meditation": "2026-05-15",
+  "/practice-guide": "2026-05-16",
+  "/daily-practice": "2026-05-16",
+  "/nianfo-guide": "2026-05-17",
+  "/sutra-guide": "2026-05-17",
+  "/sutra-listening": "2026-05-16",
+  "/beginner-sutra-recommendations": "2026-05-16",
+};
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const pages: MetadataRoute.Sitemap = staticRoutes.map((route) => ({
     url: siteUrl(route),
-    lastModified: route === "/privacy" ? "2026-05-08" : new Date(),
+    ...(routeLastModified[route] ? { lastModified: routeLastModified[route] } : {}),
     changeFrequency: weeklyRoutes.has(route) ? "weekly" : "monthly",
     priority:
       route === "/"


### PR DESCRIPTION
## Primary finding
- `frontend/apps/web/src/app/sitemap.ts` was still stamping almost every static route with `new Date()` on each build.
- That means the sitemap kept telling search engines that homepage, topic hubs, and concept pages were all freshly updated at deploy time even when their content had not changed.
- At this stage, that freshness inflation is a cleaner SEO issue to fix than opening another new page.

## Chosen action
- Keep scope to one file: `frontend/apps/web/src/app/sitemap.ts`.
- Replace deploy-time freshness with stable route-level `lastModified` dates only where recent content work is already evidenced.
- Leave article URLs on their existing `updatedAt ?? publishedAt` logic.

## What changed
- added a `routeLastModified` map for the key homepage, hub, concept, practice, and scripture routes that were actually updated during the 2026-05-15 to 2026-05-17 content expansion work
- removed the old `new Date()` behavior from static route sitemap entries
- keep `changeFrequency` and `priority` rules unchanged
- keep article sitemap entries unchanged so refreshed insight articles still use their own content dates

## Why this is the highest-yield move now
- the current sitemap behavior was making freshness signals less trustworthy across the site's most important static pages
- this is a repo-proven issue in a high-visibility SEO file, with a small and low-risk fix
- it improves technical accuracy without waiting for new content production or broader template changes

## Expected effect
- homepage and static dharma pages stop appearing artificially fresh on every deployment
- sitemap freshness signals become closer to actual content history
- search engines get a cleaner separation between truly refreshed article pages and stable static topic pages

## Verification
- compare against `main` shows the branch is `ahead_by = 1` and `behind_by = 0`
- diff scope is limited to one file:
  - `frontend/apps/web/src/app/sitemap.ts`
- branch readback confirms static routes now use explicit route dates when known and no longer default to deploy-time timestamps
- this connector workflow cannot run a local Next.js build here, so final verification remains with repository CI