### PR TITLE
feat(web): add howto schema to sutra listening question page

### DIFF
--- a/frontend/apps/web/src/app/sutra-listening/page.tsx
+++ b/frontend/apps/web/src/app/sutra-listening/page.tsx
@@ -52,6 +52,27 @@ const practiceRhythm = [
   },
 ] as const;
 
+const howToSteps = [
+  {
+    nameZh: "先听一遍，让经典先熟起来",
+    nameEn: "Listen once so scripture becomes familiar first",
+    textZh: "如果今天很难完整坐下来读，可以先听一遍经文，让语气、节奏和关键句先进入耳根。先建立熟悉感，通常比一开始就逼自己读很多更稳。",
+    textEn: "If it is hard to sit down and read fully today, begin by listening once so the tone, rhythm, and key lines settle first. Building familiarity is usually steadier than forcing a long reading session immediately.",
+  },
+  {
+    nameZh: "再读一小段，只抓住一两句真正读进去的话",
+    nameEn: "Read a short section and hold onto one or two lines",
+    textZh: "听完以后，再回到原文或导读里读一小段，先抓住一两句自己真正能读进去的话。看不懂全部很常见，不代表你不适合从经典开始。",
+    textEn: "After listening, return to the text or a guide and read only a short section. Hold onto one or two lines that truly land. Partial understanding is common and does not mean scripture is the wrong doorway for you.",
+  },
+  {
+    nameZh: "最后留一句记录，把今天听到的内容接回生活",
+    nameEn: "Leave one note that brings today’s listening back into life",
+    textZh: "不需要写很重的笔记。只要记下今天哪一句最让你安静下来、最像在回答眼前的处境，佛经学习就更容易从纸面回到现实生活。",
+    textEn: "You do not need heavy notes. Just record which line calmed you or seemed to answer your present situation so sutra study can return from the page into ordinary living.",
+  },
+] as const;
+
 const conceptBlocks = [
   {
     titleZh: "熏习",
@@ -261,6 +282,35 @@ export default function SutraListeningPage() {
         })),
       },
       {
+        "@type": "HowTo",
+        name: "经文听诵接回阅读的三步安排",
+        description: "先用听诵建立熟悉感，再读一小段原文或导读，最后留一句记录，把经典慢慢接回生活。",
+        totalTime: "P1D",
+        supply: [
+          {
+            "@type": "HowToSupply",
+            name: "一小段经文听诵或原文",
+          },
+          {
+            "@type": "HowToSupply",
+            name: "一句简短记录",
+          },
+        ],
+        tool: [
+          {
+            "@type": "HowToTool",
+            name: "Fabushi 听诵与提醒功能",
+          },
+        ],
+        step: howToSteps.map((item, index) => ({
+          "@type": "HowToStep",
+          position: index + 1,
+          name: item.nameZh,
+          text: item.textZh,
+          url: `${pageUrl}#listening-rhythm`,
+        })),
+      },
+      {
         "@type": "FAQPage",
         mainEntity: faqItems.map((item) => ({
           "@type": "Question",
@@ -363,7 +413,7 @@ export default function SutraListeningPage() {
         </div>
       </section>
 
-      <section className="band">
+      <section className="band" id="listening-rhythm">
         <div className="section-heading tight">
           <p>
             <LocalizedText zh="三步节奏" en="Three-Step Rhythm" />


### PR DESCRIPTION
## Primary finding
- 最新 `main` 的首页、导航、页脚和 sitemap 主线已经和最新首页规则对齐，这一小时不需要再继续回头修首页主体。
- 当前更高收益的缺口落在高意图问题页的结构化数据层。
- `frontend/apps/web/src/app/sutra-listening/page.tsx` 已经有非常清楚的“三步节奏”正文，直接承接：
  - `经文听诵能不能代替读经`
  - `听经和读经有什么区别`
  - `听诵和读经怎么配合`
- 但这张页在改动前还只有 `WebPage + BreadcrumbList + ItemList + FAQPage`，没有把这条可执行路径显式标成 `HowTo`。

## Chosen action
- 不开新页，不动首页，不扩导航。
- 只更新 `frontend/apps/web/src/app/sutra-listening/page.tsx`。
- 把现有已经写好的步骤型正文，正式补成结构化的 `HowTo` 表达。

## What changed
- 新增 `howToSteps` 常量，收拢页面里已经存在的三步节奏：
  - 先听一遍，让经典先熟起来
  - 再读一小段，只抓住一两句真正读进去的话
  - 最后留一句记录，把今天听到的内容接回生活
- 在页面 JSON-LD 中新增 `HowTo`：
  - 名称：`经文听诵接回阅读的三步安排`
  - description
  - `step`
  - `supply`
  - `tool`
- 为正文里的“三步节奏”区块补入稳定锚点 `#listening-rhythm`，让 `HowTo` 的 URL 指向页面内真实步骤位置。

## Why this is the best move this hour
- 这是已经被正文证据支持、范围最小、风险最低的一项增强。
- 它不依赖再生产新内容，也不需要再改首页信息架构。
- 直接作用在一张高意图问题页上，让搜索引擎更明确读到“这不是只有解释的页面，也是有步骤的页面”。

## Expected effect
- `sutra-listening` 会从“正文已经清楚的问题页”，进一步变成“正文清楚、步骤信号也显式结构化”的问题型页面。
- 对用户与搜索引擎来说，这页关于“听诵如何接回阅读”的路径表达会更直接。
- 这属于结构化数据与页面表达层的增强，不等同于已产生可验证排名提升。

## Verification
- compare against `main` shows the branch is `ahead_by = 1` and `behind_by = 0`
- diff scope is limited to one file:
  - `frontend/apps/web/src/app/sutra-listening/page.tsx`
- 当前连接器工作流无法本地运行 Next.js 构建，最终验证仍依赖仓库 CI