### PR TITLE
feat(android): add Buddha loading diagnostics and CI workflow

### DIFF
--- a/.github/workflows/android-buddha-loading-diagnostics.yml
+++ b/.github/workflows/android-buddha-loading-diagnostics.yml
@@ -1,0 +1,84 @@
+name: Android Buddha Loading Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      api-level:
+        description: Android emulator API level
+        required: false
+        default: '35'
+      profile:
+        description: Android emulator profile
+        required: false
+        default: pixel_7
+
+jobs:
+  android-buddha-diagnostics:
+    name: Android Buddha diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Run Android Buddha diagnostics
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ inputs.api-level }}
+          arch: x86_64
+          profile: ${{ inputs.profile }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          working-directory: fabushi
+          script: |
+            set +e
+            adb wait-for-device
+            adb logcat -c
+            flutter test integration_test/buddha_loading_android_diagnostics_test.dart -d emulator-5554 --reporter expanded | tee "$GITHUB_WORKSPACE/buddha_flutter_test.log"
+            test_exit=${PIPESTATUS[0]}
+            adb logcat -d > "$GITHUB_WORKSPACE/buddha_logcat_full.log"
+            grep -E 'BuddhaDiag|BuddhaModel|three_dart|AssetLoader' "$GITHUB_WORKSPACE/buddha_logcat_full.log" > "$GITHUB_WORKSPACE/buddha_logcat_filtered.log" || true
+            exit "$test_exit"
+
+      - name: Write diagnostics summary
+        if: always()
+        run: |
+          {
+            echo '## Android Buddha diagnostics'
+            echo
+            echo '### Filtered log tail'
+            echo
+            echo '```text'
+            tail -n 120 "$GITHUB_WORKSPACE/buddha_logcat_filtered.log" 2>/dev/null || echo 'No filtered diagnostics captured.'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload diagnostics artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-buddha-diagnostics
+          path: |
+            buddha_flutter_test.log
+            buddha_logcat_full.log
+            buddha_logcat_filtered.log
+          if-no-files-found: warn

--- a/.github/workflows/android-buddha-loading-diagnostics.yml
+++ b/.github/workflows/android-buddha-loading-diagnostics.yml
@@ -3,7 +3,7 @@ name: Android Buddha Loading Diagnostics
 on:
   workflow_dispatch:
     inputs:
-      api-level:
+      api_level:
         description: Android emulator API level
         required: false
         default: '35'
@@ -44,13 +44,13 @@ jobs:
       - name: Run Android Buddha diagnostics
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${{ inputs.api-level }}
+          api-level: ${{ inputs.api_level }}
           arch: x86_64
           profile: ${{ inputs.profile }}
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          working-directory: fabushi
           script: |
             set +e
+            cd fabushi
             adb wait-for-device
             adb logcat -c
             flutter test integration_test/buddha_loading_android_diagnostics_test.dart -d emulator-5554 --reporter expanded | tee "$GITHUB_WORKSPACE/buddha_flutter_test.log"

--- a/fabushi/integration_test/buddha_loading_android_diagnostics_test.dart
+++ b/fabushi/integration_test/buddha_loading_android_diagnostics_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:global_dharma_sharing/screens/buddha_model_screen.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Android Buddha loading reaches a visible ready state', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(
+            child: BuddhaModelScreen(isVisible: true),
+          ),
+        ),
+      ),
+    );
+
+    const readyBanner = '安卓佛像使用 three_dart 原生渲染';
+    const failureTitle = '禅境展现遇到阻碍';
+    final deadline = DateTime.now().add(const Duration(seconds: 150));
+
+    while (DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(seconds: 1));
+      if (find.text(readyBanner).evaluate().isNotEmpty ||
+          find.text(failureTitle).evaluate().isNotEmpty) {
+        break;
+      }
+    }
+
+    expect(
+      find.text(failureTitle),
+      findsNothing,
+      reason: '佛像加载进入失败态，请结合 [BuddhaDiag] 日志判断卡住阶段。',
+    );
+    expect(
+      find.text(readyBanner),
+      findsOneWidget,
+      reason: '佛像加载在超时前没有进入可见的 ready 状态。',
+    );
+  });
+}

--- a/fabushi/lib/screens/buddha_model_screen_android_three.dart
+++ b/fabushi/lib/screens/buddha_model_screen_android_three.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -16,6 +17,7 @@ class AndroidThreeBuddhaView extends StatefulWidget {
   final ValueChanged<double>? onProgress;
   final VoidCallback? onReady;
   final ValueChanged<String>? onError;
+  final ValueChanged<String>? onStatus;
 
   const AndroidThreeBuddhaView({
     super.key,
@@ -24,6 +26,7 @@ class AndroidThreeBuddhaView extends StatefulWidget {
     this.onProgress,
     this.onReady,
     this.onError,
+    this.onStatus,
   });
 
   @override
@@ -33,6 +36,8 @@ class AndroidThreeBuddhaView extends StatefulWidget {
 class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
   static const Duration _initDelay = Duration(milliseconds: 100);
   static const Duration _modelLoadTimeout = Duration(seconds: 90);
+
+  final Stopwatch _diagnosticStopwatch = Stopwatch();
 
   FlutterGlPlugin? _glPlugin;
   three.WebGLRenderer? _renderer;
@@ -46,6 +51,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
   bool _ready = false;
   bool _failed = false;
   bool _disposed = false;
+  bool _firstFrameLogged = false;
 
   @override
   Widget build(BuildContext context) {
@@ -88,6 +94,18 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
   Future<void> _initialize(Size size, double dpr) async {
     final plugin = FlutterGlPlugin();
+    _diagnosticStopwatch
+      ..reset()
+      ..start();
+    _emitStatus(
+      'initialize_start',
+      '开始初始化 Android Three 渲染上下文',
+      extra: {
+        'size': '${size.width.round()}x${size.height.round()}',
+        'dpr': dpr.toStringAsFixed(2),
+      },
+    );
+
     try {
       await plugin.initialize(
         options: {
@@ -98,6 +116,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
           'dpr': dpr,
         },
       );
+      _emitStatus('gl_plugin_ready', 'Flutter GL 插件初始化完成');
 
       if (!mounted || _disposed) {
         plugin.dispose();
@@ -110,6 +129,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
       await Future<void>.delayed(_initDelay);
       await plugin.prepareContext();
+      _emitStatus('gl_context_ready', 'OpenGL 上下文准备完成');
 
       if (!mounted || _disposed) {
         plugin.dispose();
@@ -118,6 +138,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
       _initRenderer(plugin, size, dpr);
       _initScene(size);
+      _emitStatus('scene_ready', 'Three 场景和灯光准备完成');
       widget.onProgress?.call(0.24);
 
       final model = await _loadBuddhaModel();
@@ -125,11 +146,13 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
       _fitAndRetuneModel(model);
       _scene!.add(model);
+      _emitStatus('model_attached', '佛像模型已挂载到 Three 场景');
       _updateCamera();
 
       _ready = true;
       _initializing = false;
       widget.onProgress?.call(1.0);
+      _emitStatus('ready', 'Android Three 渲染完成，可以展示佛像');
       widget.onReady?.call();
 
       if (mounted) {
@@ -211,21 +234,43 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
   }
 
   Future<three.Object3D> _loadBuddhaModel() async {
+    _emitStatus('bundled_glb_start', '开始读取打包 GLB');
     try {
       final bytes = await _loadBundledGlbBytes();
       widget.onProgress?.call(0.58);
-      return _parseGlbBytes(bytes);
+      _emitStatus(
+        'bundled_glb_ready',
+        '打包 GLB 校验通过，开始解析',
+        extra: {
+          'bytes': bytes.lengthInBytes,
+          'header': _formatHeader(bytes),
+        },
+      );
+      final model = await _parseGlbBytes(bytes);
+      _emitStatus('bundled_glb_parsed', '打包 GLB 解析完成');
+      return model;
     } catch (error) {
+      _emitStatus(
+        'bundled_glb_failed',
+        '打包 GLB 加载失败，切换远端 GLB',
+        extra: {'error': error},
+      );
       debugPrint(
         '⚠️ [BuddhaModel][three_dart] bundled GLB 加载失败，尝试远端 GLB: $error',
       );
     }
 
     widget.onProgress?.call(0.32);
+    _emitStatus(
+      'remote_glb_start',
+      '开始读取远端 GLB',
+      extra: {'url': AppConfig.legacyBuddhaGlbUrl},
+    );
     final loader = three_jsm.GLTFLoader();
     final result = await loader
         .loadAsync(AppConfig.legacyBuddhaGlbUrl)
         .timeout(_modelLoadTimeout);
+    _emitStatus('remote_glb_ready', '远端 GLB 下载和解析完成');
     return _extractScene(result);
   }
 
@@ -347,6 +392,10 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
       if (!kIsWeb && _sourceTexture != null) {
         unawaited(plugin.updateTexture(_sourceTexture));
       }
+      if (!_firstFrameLogged) {
+        _firstFrameLogged = true;
+        _emitStatus('first_frame', 'Android Three 首帧已经提交到纹理');
+      }
     } catch (error) {
       _fail('Android three_dart 渲染失败: $error');
     }
@@ -356,9 +405,34 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     if (_failed || _disposed) return;
     _failed = true;
     _ready = false;
+    _emitStatus('error', message, extra: {'failed': true});
     debugPrint('❌ [BuddhaModel][three_dart] $message');
     widget.onError?.call(message);
     if (mounted) setState(() {});
+  }
+
+  void _emitStatus(
+    String stage,
+    String message, {
+    Map<String, Object?> extra = const {},
+  }) {
+    final payload = <String, Object?>{
+      'stage': stage,
+      'elapsed_ms': _diagnosticStopwatch.elapsedMilliseconds,
+      ...extra,
+    };
+    final fields = payload.entries
+        .where((entry) => entry.value != null)
+        .map(
+          (entry) =>
+              '${entry.key}=${_normalizeDiagnosticValue(entry.value)}',
+        )
+        .join(' ');
+    debugPrint(
+      '[BuddhaDiag][android_three] $fields '
+      'message=${_normalizeDiagnosticValue(message)}',
+    );
+    widget.onStatus?.call(message);
   }
 
   static bool _isGlb(Uint8List bytes) {
@@ -375,6 +449,10 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
         .take(math.min(12, bytes.lengthInBytes))
         .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
         .join(' ');
+  }
+
+  static String _normalizeDiagnosticValue(Object? value) {
+    return value.toString().replaceAll(RegExp(r'\s+'), '_');
   }
 
   @override
@@ -394,6 +472,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     _renderTarget?.dispose();
     _scene = null;
     _camera = null;
+    _diagnosticStopwatch.stop();
     super.dispose();
   }
 }

--- a/fabushi/lib/screens/buddha_model_screen_native.dart
+++ b/fabushi/lib/screens/buddha_model_screen_native.dart
@@ -44,6 +44,8 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     with AutomaticKeepAliveClientMixin, SingleTickerProviderStateMixin {
   late final Ticker _ticker;
 
+  final List<String> _diagnosticTrail = <String>[];
+
   Scene? _scene;
   PerspectiveCamera? _camera;
   double _lastTime = 0.0;
@@ -95,6 +97,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     required String loadingLabel,
     _BuddhaRendererPath? activePath,
   }) {
+    _diagnosticTrail.clear();
     _lastLoadError = null;
     _renderFailed = false;
     _loadFailed = false;
@@ -108,6 +111,21 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     }
   }
 
+  void _pushDiagnostic(String message, {bool updateLoadingLabel = false}) {
+    final normalized = message.trim();
+    if (normalized.isEmpty) {
+      return;
+    }
+    _diagnosticTrail.removeWhere((item) => item == normalized);
+    _diagnosticTrail.add(normalized);
+    if (_diagnosticTrail.length > 6) {
+      _diagnosticTrail.removeRange(0, _diagnosticTrail.length - 6);
+    }
+    if (updateLoadingLabel) {
+      _loadingLabel = normalized;
+    }
+  }
+
   Future<void> _startAndroidThreePrimary() async {
     if (!mounted) return;
     setState(() {
@@ -117,6 +135,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
         loadingLabel: '安卓佛像加载中...',
         activePath: _BuddhaRendererPath.androidThreePrimary,
       );
+      _pushDiagnostic('安卓佛像加载中...', updateLoadingLabel: true);
     });
   }
 
@@ -129,6 +148,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
         loadingLabel: '恭请佛像...',
         activePath: _BuddhaRendererPath.flutterScenePrimary,
       );
+      _pushDiagnostic('flutter_scene 渲染准备中...', updateLoadingLabel: true);
     });
     await _loadFlutterSceneModel(
       asFallback: false,
@@ -153,9 +173,10 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       try {
         if (mounted) {
           setState(() {
-            _loadingLabel = attempt == 1
+            final status = attempt == 1
                 ? reasonLabel
                 : '$reasonLabel（重试 $attempt/$maxRetries）';
+            _pushDiagnostic(status, updateLoadingLabel: true);
           });
         }
 
@@ -169,6 +190,9 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
         );
 
         if (!mounted) return;
+        setState(() {
+          _pushDiagnostic('flutter_scene 已拿到模型字节，开始解析', updateLoadingLabel: true);
+        });
         await _buildBuddhaNode(modelData);
         AssetLoaderService.releaseBuddhaModelMemoryCache();
 
@@ -178,14 +202,23 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
           _renderFailed = false;
           _flutterSceneError = null;
           _loadingProgress = 1.0;
-          if (asFallback) {
-            _loadingLabel = '已切换 flutter_scene 备用展示';
-          }
+          _pushDiagnostic(
+            asFallback ? '已切换 flutter_scene 备用展示' : 'flutter_scene 渲染完成',
+            updateLoadingLabel: asFallback,
+          );
         });
         return;
       } catch (error) {
         _flutterSceneError = 'flutter_scene 解析失败: $error';
         _lastLoadError = _flutterSceneError;
+        if (mounted) {
+          setState(() {
+            _pushDiagnostic(
+              'flutter_scene 解析失败: ${_cleanLoadError(_flutterSceneError!)}',
+              updateLoadingLabel: true,
+            );
+          });
+        }
         AssetLoaderService.releaseBuddhaModelMemoryCache();
         if (attempt < maxRetries) {
           await Future.delayed(Duration(seconds: 1 << attempt));
@@ -301,6 +334,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   void _markAndroidThreeReady() {
     if (!mounted) return;
     setState(() {
+      _pushDiagnostic('Android Three 渲染完成，可以展示佛像');
       _isLoading = false;
       _loadFailed = false;
       _renderFailed = false;
@@ -311,6 +345,14 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   void _handleAndroidThreeFailure(String details) {
     _androidThreeError = details;
     _lastLoadError = details;
+    if (mounted) {
+      setState(() {
+        _pushDiagnostic(
+          'Android Three 失败: ${_cleanLoadError(details)}',
+          updateLoadingLabel: true,
+        );
+      });
+    }
     debugPrint('❌ [BuddhaModel] Android three_dart 失败: $details');
     _markLoadFailed(details);
   }
@@ -318,6 +360,14 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   void _markFlutterSceneFailed(String details) {
     _flutterSceneError = details;
     _lastLoadError = details;
+    if (mounted) {
+      setState(() {
+        _pushDiagnostic(
+          'flutter_scene 失败: ${_cleanLoadError(details)}',
+          updateLoadingLabel: true,
+        );
+      });
+    }
     debugPrint('❌ [BuddhaModel] flutter_scene 失败: $details');
     _markLoadFailed(details);
   }
@@ -357,6 +407,11 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
         _lastLoadError != null &&
         _lastLoadError!.isNotEmpty) {
       details.add(_cleanLoadError(_lastLoadError!));
+    }
+    if (_diagnosticTrail.isNotEmpty) {
+      details.add(
+        '最近进度：${_diagnosticTrail.map(_cleanLoadError).join(' -> ')}',
+      );
     }
     if (details.isEmpty) {
       return '未收到具体错误，请重试后查看设备日志。';
@@ -514,6 +569,15 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
                         _loadingProgress = progress;
                       });
                     },
+                    onStatus: (message) {
+                      if (!mounted) return;
+                      setState(() {
+                        _pushDiagnostic(
+                          message,
+                          updateLoadingLabel: _isLoading,
+                        );
+                      });
+                    },
                     onReady: _markAndroidThreeReady,
                     onError: _handleAndroidThreeFailure,
                   ),
@@ -607,6 +671,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
                           const SizedBox(height: 16),
                           Text(
                             _loadingLabel,
+                            textAlign: TextAlign.center,
                             style: const TextStyle(
                               color: Color(0xFFFFD700),
                               fontSize: 14,
@@ -621,6 +686,23 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
                                 style: const TextStyle(
                                   color: Colors.white70,
                                   fontSize: 12,
+                                ),
+                              ),
+                            ),
+                          if (_diagnosticTrail.isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 10),
+                              child: ConstrainedBox(
+                                constraints:
+                                    const BoxConstraints(maxWidth: 320),
+                                child: Text(
+                                  _diagnosticTrail.last,
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(
+                                    color: Colors.white60,
+                                    fontSize: 11,
+                                    height: 1.35,
+                                  ),
                                 ),
                               ),
                             ),


### PR DESCRIPTION
## Summary
- add structured `[BuddhaDiag]` status logs to the Android `three_dart` Buddha loading path
- surface recent loading-stage feedback in the native Buddha loading UI and failure details
- add an Android integration test plus a manual GitHub Action to capture emulator logs for Buddha loading diagnostics

## Why
Android is still getting stuck on "佛像加载中", and the current error signal is too coarse to tell whether the problem is:
- Flutter GL / OpenGL context setup
- bundled GLB validation or parse
- remote GLB fallback download
- first-frame texture submission

This change makes that path observable both in-app and in CI.

## What changed
- `fabushi/lib/screens/buddha_model_screen_android_three.dart`
  - emit structured `[BuddhaDiag][android_three]` logs for init, context, bundled GLB, remote GLB, model attach, ready, first frame, and error stages
  - pass human-readable status updates back to the parent widget during loading
- `fabushi/lib/screens/buddha_model_screen_native.dart`
  - keep a short diagnostics trail during loading
  - show the latest stage while loading
  - include recent stage history in the failure panel so Android errors are easier to localize
- `fabushi/integration_test/buddha_loading_android_diagnostics_test.dart`
  - boot the Buddha screen directly on Android and fail if it never reaches a visible ready state
- `.github/workflows/android-buddha-loading-diagnostics.yml`
  - add a manual workflow that runs the Android integration test on an emulator
  - always collect full and filtered logs as artifacts
  - publish the filtered diagnostics tail into the workflow summary

## Notes
- I could not run Flutter or emulator validation from this environment, so runtime verification still needs the new workflow to be triggered on GitHub.
- The diagnostics branch is currently behind `main`, but the diff is scoped to these four files only.