### PR TITLE
fix(forum): make skipped live checks point to the handoff path

### DIFF
--- a/forum/scripts/resolve-live-deployment-target.mjs
+++ b/forum/scripts/resolve-live-deployment-target.mjs
@@ -30,6 +30,28 @@ function createPayload(target) {
   return JSON.stringify(target, null, 2);
 }
 
+function buildSkipNextStepLines(target) {
+  return [
+    "### How to unblock",
+    "",
+    "Use a real preview or production forum URL from the host rollout, then hand it back to the hourly checks:",
+    "",
+    "```bash",
+    "cd forum",
+    "pnpm handoff:live-target -- \\",
+    "  --forum-url https://forum-preview.example.com \\",
+    "  --deploy-env-path .env.deploy \\",
+    "  --apply-github-live-target true",
+    "```",
+    "",
+    "That command re-validates `.env.deploy`, smoke-checks the live runtime, and syncs `FORUM_LIVE_TARGET` back to `bhrumom/fabushi`.",
+    "If the preview write gate stays enabled, it also syncs `FORUM_LIVE_WRITE_ACCESS_CODE`.",
+    "",
+    "If you want a one-off verification before saving hourly config, run this workflow manually with the same forum URL and posture inputs.",
+    `Guide: ${target.nextStepGuidePath}`,
+  ];
+}
+
 function buildSummaryLines(target) {
   if (target.skip) {
     return [
@@ -37,7 +59,10 @@ function buildSummaryLines(target) {
       "",
       "- status: skipped",
       `- reason: ${target.reason}`,
-      "- next config: set FORUM_LIVE_URL or FORUM_LIVE_TARGET before expecting hourly checks to hit a real target",
+      `- missing config: ${target.missingConfig.join(", ")}`,
+      `- guide: ${target.nextStepGuidePath}`,
+      "",
+      ...buildSkipNextStepLines(target),
     ];
   }
 
@@ -124,6 +149,17 @@ async function main() {
       source,
       skip: true,
       reason: "No forum URL configured for scheduled live deployment checks.",
+      missingConfig: ["FORUM_LIVE_TARGET or FORUM_LIVE_URL"],
+      nextStepGuidePath: "forum/DEPLOY.md",
+      recommendedHandoffCommand: [
+        "cd forum",
+        "pnpm handoff:live-target -- \\",
+        "  --forum-url https://forum-preview.example.com \\",
+        "  --deploy-env-path .env.deploy \\",
+        "  --apply-github-live-target true",
+      ].join("\n"),
+      repositoryConfigTargets: ["FORUM_LIVE_TARGET"],
+      optionalSecretTargets: ["FORUM_LIVE_WRITE_ACCESS_CODE"],
     };
 
     if (process.env.FORUM_LIVE_TARGET_PATH) {


### PR DESCRIPTION
## Summary
- make `forum/scripts/resolve-live-deployment-target.mjs` write an actionable skip summary when hourly live checks do not yet have a real forum target
- include the shortest host-side handoff command, the deployment guide path, and the repository variable / secret that the handoff will sync
- keep the change tightly scoped to the skip path so the current live-check contract stays unchanged once a real target is configured

## Why now
`PR #537` has already landed, so the old bootstrap rollout helper blocker is no longer the highest-priority forum deployment gap.

The remaining blocker is now more operational than structural:
- the repository can already validate live forum targets hourly
- it can already derive and sync `FORUM_LIVE_TARGET`
- but when no real preview or production forum URL has been wired yet, the scheduled workflow still mostly says "skipped" instead of clearly pushing the operator through the next real handoff step

This change keeps scope small and makes the current blocker more actionable without opening another deployment helper thread.

## What changed
### `forum/scripts/resolve-live-deployment-target.mjs`
- when `FORUM_LIVE_TARGET` and `FORUM_LIVE_URL` are both missing, the generated job summary now includes:
  - the missing config signal
  - the guide path `forum/DEPLOY.md`
  - a concrete `pnpm handoff:live-target -- --forum-url ... --deploy-env-path .env.deploy --apply-github-live-target true` command
  - a note that this handoff syncs `FORUM_LIVE_TARGET`
  - a note that writable preview can also sync `FORUM_LIVE_WRITE_ACCESS_CODE`
  - a reminder that a one-off manual workflow run is still available before saving hourly config
- the skipped target JSON payload now also carries the same next-step metadata for future automation or debugging

## Why this is the highest-value next step
The repo-side deployment chain is already deep enough that the main remaining drag is first live-target handoff clarity, not another missing helper. Improving the skip path does two useful things:
- it turns hourly skips into a clearer operator checklist
- it keeps future scheduled runs from re-surfacing the same "what exactly do I do next" question

## Verification
- branch compare against `main` is scoped to one file:
  - `forum/scripts/resolve-live-deployment-target.mjs`
- branch state is `ahead_by = 1` and `behind_by = 0`
- this connector environment still cannot clone the repository or run the GitHub Actions workflow locally, so final validation remains with repository CI on the PR

## Remaining blocker after this PR
This improves the handoff guidance, but it does not remove the external prerequisites:
- a real preview or production forum URL is still needed
- a target host still needs to run `forum/.env.deploy`
- one successful `pnpm handoff:live-target` is still needed before hourly checks can stop skipping