### PR TITLE
Android 佛像优先使用 flutter_scene 加载

### DIFF
--- a/fabushi/android/gradle.properties
+++ b/fabushi/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx2G -Dhttps.protocols=TLSv1.2,TLSv1.3 -Dsun.security.ssl.allowUnsafeRenegotiation=true -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx6G -Dhttps.protocols=TLSv1.2,TLSv1.3 -Dsun.security.ssl.allowUnsafeRenegotiation=true -XX:MaxMetaspaceSize=1G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true

--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -168,7 +168,7 @@ class AppConfig {
   // 3D 佛像模型配置
   // 如果 R2 上需要切换到新的对象键，优先改这里，便于强制绕开旧缓存。
   static const String buddhaModelAssetPath = 'models/buddha_model.model';
-  // Android 使用 three_dart 直接渲染 GLB；iOS 继续使用 flutter_scene .model。
+  // Android/iOS 优先使用 R2 上的 flutter_scene .model；Android 失败时再回退到 three_dart GLB。
   static const String legacyBuddhaGlbAssetPath = 'models/佛像模型.glb';
   static const String androidThreeBuddhaGlbAssetPath =
       'web/assets/models/佛像模型.glb';

--- a/fabushi/lib/screens/buddha_model_screen_android_three.dart
+++ b/fabushi/lib/screens/buddha_model_screen_android_three.dart
@@ -158,9 +158,9 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     renderer.setPixelRatio(dpr);
     renderer.setSize(size.width, size.height, false);
     renderer.shadowMap.enabled = false;
-    renderer.outputEncoding = three.sRGBEncoding;
-    renderer.toneMapping = three.ACESFilmicToneMapping;
-    renderer.toneMappingExposure = 1.1;
+    renderer.outputEncoding = three.LinearEncoding;
+    renderer.toneMapping = three.NoToneMapping;
+    renderer.toneMappingExposure = 1.0;
     renderer.setClearColor(three.Color(0x000000), 0.0);
 
     final renderTargetOptions = three.WebGLRenderTargetOptions({
@@ -292,32 +292,25 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
       if (child is! three.Mesh) return;
       child.castShadow = false;
       child.receiveShadow = false;
-      _retuneMaterial(child.material);
+      child.material = _createBuddhaMaterial(child.material);
     });
   }
 
-  void _retuneMaterial(dynamic material) {
+  dynamic _createBuddhaMaterial(dynamic material) {
     if (material is Iterable) {
-      for (final item in material) {
-        _retuneMaterial(item);
-      }
-      return;
+      return material.map(_createBuddhaMaterial).toList();
     }
 
-    if (material is three.MeshStandardMaterial) {
-      material.color = three.Color.fromHex(0xffcc4a);
-      material.metalness = 0.72;
-      material.roughness = 0.24;
-      material.emissive = three.Color.fromHex(0x1a1203);
-      material.emissiveIntensity = 0.42;
-      material.needsUpdate = true;
-      return;
+    final simpleMaterial = three.MeshBasicMaterial({
+      'color': three.Color.fromHex(0xffcc4a),
+      'fog': false,
+      'toneMapped': false,
+    });
+    if (material is three.Material && material.transparent == true) {
+      simpleMaterial.transparent = true;
+      simpleMaterial.opacity = material.opacity;
     }
-
-    if (material is three.Material) {
-      material.color = three.Color.fromHex(0xffcc4a);
-      material.needsUpdate = true;
-    }
+    return simpleMaterial;
   }
 
   void _updateCamera() {

--- a/fabushi/lib/screens/buddha_model_screen_native.dart
+++ b/fabushi/lib/screens/buddha_model_screen_native.dart
@@ -14,7 +14,7 @@ import '../services/asset_loader_service.dart';
 import '../utils/model_auto_fit.dart';
 import 'buddha_model_screen_android_three.dart';
 
-enum _BuddhaRendererPath { androidThreePrimary, flutterScenePrimary }
+enum _BuddhaRendererPath { flutterScenePrimary, androidThreeFallback }
 
 class BuddhaModelScreen extends StatefulWidget {
   final bool autoRotate;
@@ -68,7 +68,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   String? _flutterSceneError;
   String _loadingLabel = '恭请佛像...';
 
-  bool get _shouldUseAndroidThreePrimary =>
+  bool get _canUseAndroidThreeFallback =>
       !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
 
   @override
@@ -84,10 +84,6 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   }
 
   Future<void> _bootstrapRenderer() async {
-    if (_shouldUseAndroidThreePrimary) {
-      await _startAndroidThreePrimary();
-      return;
-    }
     await _startFlutterScenePrimary();
   }
 
@@ -108,14 +104,13 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     }
   }
 
-  Future<void> _startAndroidThreePrimary() async {
+  Future<void> _startAndroidThreeFallback() async {
     if (!mounted) return;
     setState(() {
-      _flutterSceneError = null;
       _androidThreeError = null;
       _resetForFreshLoad(
-        loadingLabel: '安卓佛像加载中...',
-        activePath: _BuddhaRendererPath.androidThreePrimary,
+        loadingLabel: '正在切换备用佛像渲染...',
+        activePath: _BuddhaRendererPath.androidThreeFallback,
       );
     });
   }
@@ -143,9 +138,11 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     try {
       await _ensureFlutterSceneEnvironment();
     } catch (error) {
-      _markFlutterSceneFailed('flutter_scene 初始化失败: $error');
+      await _handleFlutterSceneFailure('flutter_scene 初始化失败: $error');
       return;
     }
+
+    _scene?.removeAll();
 
     const maxRetries = 2;
     for (int attempt = 1; attempt <= maxRetries; attempt++) {
@@ -170,6 +167,10 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
 
         if (!mounted) return;
         await _buildBuddhaNode(modelData);
+        debugPrint(
+          '✅ [BuddhaModel] flutter_scene 模型已加载: '
+          '${modelData.lengthInBytes} bytes',
+        );
         AssetLoaderService.releaseBuddhaModelMemoryCache();
 
         setState(() {
@@ -194,7 +195,9 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       }
     }
 
-    _markFlutterSceneFailed(_flutterSceneError ?? 'flutter_scene 备用渲染失败');
+    await _handleFlutterSceneFailure(
+      _flutterSceneError ?? 'flutter_scene 渲染失败',
+    );
   }
 
   Future<void> _ensureFlutterSceneEnvironment() async {
@@ -315,10 +318,16 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     _markLoadFailed(details);
   }
 
-  void _markFlutterSceneFailed(String details) {
+  Future<void> _handleFlutterSceneFailure(String details) async {
     _flutterSceneError = details;
     _lastLoadError = details;
     debugPrint('❌ [BuddhaModel] flutter_scene 失败: $details');
+
+    if (_canUseAndroidThreeFallback) {
+      await _startAndroidThreeFallback();
+      return;
+    }
+
     _markLoadFailed(details);
   }
 
@@ -405,7 +414,11 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     if (_renderFailed || !mounted) {
       return;
     }
-    _markFlutterSceneFailed('flutter_scene 渲染失败: $error');
+    _renderFailed = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_handleFlutterSceneFailure('flutter_scene 渲染失败: $error'));
+    });
   }
 
   @override
@@ -448,10 +461,10 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   }
 
   String get _compatibilityBanner {
-    if (_activeRendererPath == _BuddhaRendererPath.androidThreePrimary) {
-      return '安卓佛像使用 three_dart 原生渲染';
+    if (_activeRendererPath == _BuddhaRendererPath.androidThreeFallback) {
+      return '已切换到 three_dart 备用渲染';
     }
-    return '佛像已切换为兼容展示';
+    return '佛像使用 flutter_scene 渲染';
   }
 
   @override
@@ -500,7 +513,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
               ),
               if (!_loadFailed &&
                   _activeRendererPath ==
-                      _BuddhaRendererPath.androidThreePrimary)
+                      _BuddhaRendererPath.androidThreeFallback)
                 Positioned.fill(
                   child: AndroidThreeBuddhaView(
                     key: ValueKey(
@@ -672,11 +685,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
                               side: const BorderSide(color: Color(0xFFFFD700)),
                             ),
                             onPressed: () {
-                              if (_shouldUseAndroidThreePrimary) {
-                                unawaited(_startAndroidThreePrimary());
-                              } else {
-                                unawaited(_startFlutterScenePrimary());
-                              }
+                              unawaited(_startFlutterScenePrimary());
                             },
                             child: const Text('静心重试'),
                           ),
@@ -816,6 +825,7 @@ class _IncensePainter extends CustomPainter {
           base.translate(-46, 12),
           base.translate(46, 34),
           const [Color(0xFFFFD36A), Color(0xFF7A4314), Color(0xFFD4AF37)],
+          const [0.0, 0.55, 1.0],
         ),
     );
 

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -178,7 +178,7 @@ flutter:
     - assets/ip_data/
     - assets/sherpa_models/streaming-paraformer-zh-en/
     - web/assets/models/佛像模型.glb
-    # iOS 使用 R2 上的 .model；Android 使用 three_dart 渲染打包 GLB，失败时再读远端 GLB
+    # Android/iOS 优先使用 R2 上的 .model；Android 仅在 flutter_scene 失败时回退到打包 GLB
   
   fonts:
     # 使用子集化后的字体（从80MB压缩至~4.5MB）


### PR DESCRIPTION
## Summary
- Make flutter_scene the primary Buddha renderer on Android, matching the iOS path and using the R2 `.model` asset first.
- Keep three_dart as the Android fallback when flutter_scene init/load/render fails.
- Preserve/retune the three_dart fallback material path and fix a flutter_scene incense gradient runtime error.

## Verification
- `dart analyze lib/screens/buddha_model_screen_native.dart lib/core/config/app_config.dart`
- `flutter build apk --debug -d AXYP6R4530001510`
- Installed on Android device `AXYP6R4530001510`, entered 禅室 via adb, cleared model cache, confirmed R2 download of `models/buddha_model.model` to `files/assets_cache/models/models_buddha_model.model` with size `308204772` bytes.
- Verified Buddha renders in the zen room with flutter_scene without entering the three_dart fallback path.