### PR TITLE
fix(forum): infer production live handoff target from public base url

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -199,6 +199,30 @@ jobs:
           grep "FORUM_ENABLE_WRITES=false" /tmp/forum-deploy-production.env
           grep "FORUM_DEPLOY_CHECK_URL=https://forum.fabushi.test" /tmp/forum-deploy-production.env
 
+      - name: Prepare production deploy env sample without deploy check URL
+        run: |
+          cp /tmp/forum-deploy-production.env /tmp/forum-deploy-production-no-check-url.env
+          sed -i 's#^FORUM_DEPLOY_CHECK_URL=.*#FORUM_DEPLOY_CHECK_URL=#' /tmp/forum-deploy-production-no-check-url.env
+          grep '^FORUM_DEPLOY_CHECK_URL=$' /tmp/forum-deploy-production-no-check-url.env
+
+      - name: Validate production handoff inference from public base URL
+        run: |
+          node forum/scripts/validate-deploy-env.mjs \
+            --deploy-env-path /tmp/forum-deploy-production-no-check-url.env >/tmp/forum-deploy-production-no-check-url-summary.txt
+
+          grep --fixed-strings "handoff_forum_url: https://forum.fabushi.test" /tmp/forum-deploy-production-no-check-url-summary.txt
+          grep --fixed-strings "FORUM_DEPLOY_CHECK_URL is empty, but production handoff helpers can reuse FORUM_PUBLIC_BASE_URL=https://forum.fabushi.test." /tmp/forum-deploy-production-no-check-url-summary.txt
+
+      - name: Prepare production live target sample from public base URL
+        run: |
+          node forum/scripts/prepare-live-deployment-vars.mjs \
+            --deploy-env-path /tmp/forum-deploy-production-no-check-url.env \
+            --format json >/tmp/forum-production-live-target.json
+
+          grep --fixed-strings '"forumUrl": "https://forum.fabushi.test"' /tmp/forum-production-live-target.json
+          grep --fixed-strings '"deploymentStage": "production"' /tmp/forum-production-live-target.json
+          grep --fixed-strings '"publicBaseUrl": "https://forum.fabushi.test"' /tmp/forum-production-live-target.json
+
       - name: Build forum container image
         run: docker build -t fabushi-forum ./forum
 
@@ -354,6 +378,27 @@ jobs:
           node forum/scripts/smoke-deployment-from-env.mjs \
             --deploy-env-path /tmp/forum-deploy-production.env \
             --forum-url http://127.0.0.1:3001
+
+      - name: Handoff production live target from public base URL
+        run: |
+          rm -f /tmp/forum-production-gh-invocations.txt
+          mkdir -p /tmp/forum-mock-gh-bin-production
+          cat <<'GHEOF' >/tmp/forum-mock-gh-bin-production/gh
+          #!/usr/bin/env bash
+          printf '%s\n' "$*" >> /tmp/forum-production-gh-invocations.txt
+          GHEOF
+          chmod +x /tmp/forum-mock-gh-bin-production/gh
+          : >/tmp/forum-production-gh-invocations.txt
+
+          PATH="/tmp/forum-mock-gh-bin-production:$PATH" \
+          node forum/scripts/handoff-live-deployment-target.mjs \
+            --deploy-env-path /tmp/forum-deploy-production-no-check-url.env \
+            --apply-github-live-target true \
+            2>&1 | tee /tmp/forum-production-live-target-handoff.txt
+
+          grep --fixed-strings "gh variable set FORUM_LIVE_TARGET --body '{\"forumUrl\":\"https://forum.fabushi.test\",\"deploymentStage\":\"production\",\"publicBaseUrl\":\"https://forum.fabushi.test\",\"writesEnabled\":false,\"requiresAccessCode\":false,\"exerciseWriteFlow\":false}' --repo 'bhrumom/fabushi'" /tmp/forum-production-live-target-handoff.txt
+          grep "Applied FORUM_LIVE_TARGET to GitHub repo bhrumom/fabushi." /tmp/forum-production-live-target-handoff.txt
+          grep --fixed-strings "variable set FORUM_LIVE_TARGET --body {\"forumUrl\":\"https://forum.fabushi.test\",\"deploymentStage\":\"production\",\"publicBaseUrl\":\"https://forum.fabushi.test\",\"writesEnabled\":false,\"requiresAccessCode\":false,\"exerciseWriteFlow\":false} --repo bhrumom/fabushi" /tmp/forum-production-gh-invocations.txt
 
       - name: Stop forum deploy compose
         if: always()

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -67,7 +67,7 @@ That preflight step surfaces the effective deployment stage, write posture, acce
 - write access code present while writes are still disabled
 - production runtime left writable before governance posture is ready
 
-When `FORUM_DEPLOY_CHECK_URL` is still empty, `pnpm smoke:deploy-env` now falls back to `http://127.0.0.1:${FORUM_PORT}` on the same host. That lets the first compose rollout verify itself before a real preview or production URL exists. `pnpm handoff:live-target` still needs the real external URL unless `FORUM_DEPLOY_CHECK_URL` is already filled in.
+When `FORUM_DEPLOY_CHECK_URL` is still empty, `pnpm smoke:deploy-env` now falls back to `http://127.0.0.1:${FORUM_PORT}` on the same host. That lets the first compose rollout verify itself before a real preview or production URL exists. `pnpm handoff:live-target` still needs the real external URL unless the deploy env already includes `FORUM_DEPLOY_CHECK_URL`; for production, it can also reuse `FORUM_PUBLIC_BASE_URL` when that public origin is already final.
 
 ## Hourly live deployment checks
 
@@ -96,6 +96,8 @@ pnpm handoff:live-target -- \
   --forum-url https://forum-preview.example.com \
   --deploy-env-path .env.deploy
 ```
+
+If `.env.deploy` already carries `FORUM_DEPLOY_CHECK_URL`, you can omit `--forum-url`. Production runtimes can also omit it when `.env.deploy` already declares the final `FORUM_PUBLIC_BASE_URL`.
 
 That single entrypoint will:
 
@@ -322,6 +324,14 @@ pnpm smoke:deploy-env -- --deploy-env-path .env.deploy
 curl https://forum.fabushi.com/api/health
 curl https://forum.fabushi.com/api/status
 curl https://forum.fabushi.com/robots.txt
+```
+
+Once the production origin is correct, the handoff can now stay fully deploy-env driven even if `FORUM_DEPLOY_CHECK_URL` is blank:
+
+```bash
+pnpm handoff:live-target -- \
+  --deploy-env-path .env.deploy \
+  --apply-github-live-target true
 ```
 
 Expected production signals:

--- a/forum/scripts/prepare-live-deployment-vars.mjs
+++ b/forum/scripts/prepare-live-deployment-vars.mjs
@@ -53,6 +53,20 @@ function normalizeUrl(value) {
   return value ? value.replace(/\/$/, "") : "";
 }
 
+function resolveForumUrl({ explicitForumUrl, deployEnv }) {
+  const forumUrl = normalizeUrl(explicitForumUrl?.trim() || deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
+  if (forumUrl) {
+    return forumUrl;
+  }
+
+  const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
+  if (deploymentStage === "production") {
+    return normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
+  }
+
+  return "";
+}
+
 function buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow }) {
   const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
   if (deploymentStage !== "preview" && deploymentStage !== "production") {
@@ -163,10 +177,15 @@ async function main() {
 
   const deployEnvContent = await readFile(args["deploy-env-path"], "utf-8");
   const deployEnv = parseDotEnv(deployEnvContent);
-  const forumUrl = normalizeUrl(args["forum-url"]?.trim() || deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
+  const forumUrl = resolveForumUrl({
+    explicitForumUrl: args["forum-url"],
+    deployEnv,
+  });
 
   if (!forumUrl) {
-    throw new Error("Missing required --forum-url and deploy env FORUM_DEPLOY_CHECK_URL.");
+    throw new Error(
+      "Missing required --forum-url and deploy env FORUM_DEPLOY_CHECK_URL. Production deploy envs may also infer from FORUM_PUBLIC_BASE_URL.",
+    );
   }
 
   const liveTarget = buildLiveTarget({ forumUrl, deployEnv, exerciseWriteFlow });

--- a/forum/scripts/validate-deploy-env.mjs
+++ b/forum/scripts/validate-deploy-env.mjs
@@ -74,6 +74,7 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
   const deployCheckUrl = normalizeUrl(deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
   const defaultSmokeUrl = deployCheckUrl || buildLocalSmokeUrl(port);
   const publicBaseUrl = normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
+  const handoffForumUrl = deployCheckUrl || (deploymentStage === "production" ? publicBaseUrl : "");
   const writesEnabled = parseBoolean(deployEnv.FORUM_ENABLE_WRITES ?? "false", "FORUM_ENABLE_WRITES");
   const writeAccessCode = (deployEnv.FORUM_WRITE_ACCESS_CODE || "").trim();
   const requiresAccessCode = writesEnabled && Boolean(writeAccessCode);
@@ -81,9 +82,15 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
   const warnings = [];
 
   if (!deployCheckUrl) {
-    warnings.push(
-      `FORUM_DEPLOY_CHECK_URL is empty, so handoff helpers still require an explicit --forum-url. smoke:deploy-env will fall back to ${defaultSmokeUrl} on the target host.`,
-    );
+    if (handoffForumUrl) {
+      warnings.push(
+        `FORUM_DEPLOY_CHECK_URL is empty, but production handoff helpers can reuse FORUM_PUBLIC_BASE_URL=${handoffForumUrl}. smoke:deploy-env will still fall back to ${defaultSmokeUrl} on the target host.`,
+      );
+    } else {
+      warnings.push(
+        `FORUM_DEPLOY_CHECK_URL is empty, so handoff helpers still require an explicit --forum-url. smoke:deploy-env will fall back to ${defaultSmokeUrl} on the target host.`,
+      );
+    }
   }
 
   if (deploymentStage === "preview" && publicBaseUrl) {
@@ -118,6 +125,7 @@ function buildDeployPosture({ deployEnvPath, deployEnv }) {
     dataDir,
     deployCheckUrl,
     defaultSmokeUrl,
+    handoffForumUrl,
     dataSource,
     deploymentStage,
     publicBaseUrl,
@@ -138,6 +146,7 @@ function renderSummary(posture) {
     `- data_dir: ${posture.dataDir}`,
     `- deploy_check_url: ${posture.deployCheckUrl || "(empty)"}`,
     `- default_smoke_url: ${posture.defaultSmokeUrl}`,
+    `- handoff_forum_url: ${posture.handoffForumUrl || "(requires --forum-url)"}`,
     `- data_source: ${posture.dataSource}`,
     `- deployment_stage: ${posture.deploymentStage}`,
     `- public_base_url: ${posture.publicBaseUrl || "(empty)"}`,


### PR DESCRIPTION
## Summary
- let `prepare-live-deployment-vars.mjs` derive the live forum URL from `FORUM_PUBLIC_BASE_URL` when a production deploy env has no `FORUM_DEPLOY_CHECK_URL`
- surface that inferred handoff target explicitly in `validate-deploy-env.mjs` so operators can see whether handoff is fully deploy-env driven or still needs `--forum-url`
- extend `Deploy compose checks - Forum` and `forum/DEPLOY.md` to cover and document the production no-check-url handoff path

## Why now
`PR #552` closed the repo-side skip-guidance thread, so the remaining highest-value follow-up is to shave one more manual step off the first real production handoff.

Today the production scaffold already declares `FORUM_PUBLIC_BASE_URL`, and `smoke:deploy-env` can already validate the runtime locally even when `FORUM_DEPLOY_CHECK_URL` is blank. The gap was that the live-target preparation step still needed another explicit URL unless the deploy-check URL was duplicated into the env file.

This PR keeps scope tight and makes the production handoff closer to a true one-command path.

## What changed
### `forum/scripts/prepare-live-deployment-vars.mjs`
- add `resolveForumUrl()`
- keep preferring explicit `--forum-url`
- keep using `FORUM_DEPLOY_CHECK_URL` when present
- for `production`, fall back to `FORUM_PUBLIC_BASE_URL` when `FORUM_DEPLOY_CHECK_URL` is empty
- update the missing-URL error to mention that production deploy envs can infer from `FORUM_PUBLIC_BASE_URL`

### `forum/scripts/validate-deploy-env.mjs`
- add `handoffForumUrl` to the computed posture
- include `handoff_forum_url` in the summary output
- distinguish between:
  - deploy envs that still require an explicit `--forum-url`
  - production deploy envs whose handoff can already reuse `FORUM_PUBLIC_BASE_URL`

### `.github/workflows/forum-deploy-compose-checks.yml`
- create a production deploy env sample with `FORUM_DEPLOY_CHECK_URL` deliberately cleared
- assert that `validate-deploy-env.mjs` surfaces the inferred `handoff_forum_url`
- assert that `prepare-live-deployment-vars.mjs` emits a production live target from `FORUM_PUBLIC_BASE_URL`
- run `handoff-live-deployment-target.mjs --apply-github-live-target true` against the production sample without `--forum-url`
- confirm the generated GitHub CLI sync command carries the expected production bundled target

### `forum/DEPLOY.md`
- document that production handoff can omit `--forum-url` when `.env.deploy` already carries the final `FORUM_PUBLIC_BASE_URL`
- document that `pnpm handoff:live-target -- --deploy-env-path .env.deploy --apply-github-live-target true` is now a valid production handoff shape even when `FORUM_DEPLOY_CHECK_URL` is blank

## Verification
- local syntax checks:
  - `node --check /workspace/scratchforum/forum/scripts/prepare-live-deployment-vars.mjs`
  - `node --check /workspace/scratchforum/forum/scripts/validate-deploy-env.mjs`
  - `node --check /workspace/scratchforum/forum/scripts/handoff-live-deployment-target.mjs`
- local behavior checks with a production deploy env sample whose `FORUM_DEPLOY_CHECK_URL` is blank:
  - `node /workspace/scratchforum/forum/scripts/validate-deploy-env.mjs --deploy-env-path /tmp/forum-deploy-production-no-check-url.env`
  - `node /workspace/scratchforum/forum/scripts/prepare-live-deployment-vars.mjs --deploy-env-path /tmp/forum-deploy-production-no-check-url.env --format json`
- final end-to-end verification remains with repository CI on this PR

## Expected outcome after merge
- the first real production live-target handoff no longer needs the operator to retype the public forum URL when `.env.deploy` already declares it
- deploy posture summaries become more actionable because they now say which forum URL handoff will use
- the production no-check-url path is no longer just documented; it is covered by repo CI