### PR TITLE
fix(forum): let production rollout infer live handoff target

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -155,9 +155,9 @@ jobs:
           cat /tmp/forum-live-target-skip-summary.md
 
           node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync("/tmp/forum-live-target-skip.json", "utf8")); if (!(data.skip === true && typeof data.recommendedRolloutCommand === "string" && data.recommendedRolloutCommand.includes("pnpm rollout:deploy-env") && data.recommendedRolloutCommand.includes("--scaffold-if-missing true") && typeof data.recommendedHandoffCommand === "string" && data.recommendedHandoffCommand.includes("pnpm handoff:live-target") && Array.isArray(data.repositoryConfigTargets) && data.repositoryConfigTargets.includes("FORUM_LIVE_TARGET") && Array.isArray(data.optionalSecretTargets) && data.optionalSecretTargets.includes("FORUM_LIVE_WRITE_ACCESS_CODE"))) { console.error(JSON.stringify(data, null, 2)); process.exit(1); }'
-          grep --fixed-strings "pnpm rollout:deploy-env -- \\\" /tmp/forum-live-target-skip-summary.md
+          grep --fixed-strings "pnpm rollout:deploy-env --" /tmp/forum-live-target-skip-summary.md
           grep --fixed-strings -- "--scaffold-if-missing true" /tmp/forum-live-target-skip-summary.md
-          grep --fixed-strings "pnpm handoff:live-target -- \\\" /tmp/forum-live-target-skip-summary.md
+          grep --fixed-strings "pnpm handoff:live-target --" /tmp/forum-live-target-skip-summary.md
           grep --fixed-strings -- "--apply-github-live-target true" /tmp/forum-live-target-skip-summary.md
           grep --fixed-strings "Guide: forum/DEPLOY.md" /tmp/forum-live-target-skip-summary.md
 

--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -155,9 +155,9 @@ jobs:
           cat /tmp/forum-live-target-skip-summary.md
 
           node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync("/tmp/forum-live-target-skip.json", "utf8")); if (!(data.skip === true && typeof data.recommendedRolloutCommand === "string" && data.recommendedRolloutCommand.includes("pnpm rollout:deploy-env") && data.recommendedRolloutCommand.includes("--scaffold-if-missing true") && typeof data.recommendedHandoffCommand === "string" && data.recommendedHandoffCommand.includes("pnpm handoff:live-target") && Array.isArray(data.repositoryConfigTargets) && data.repositoryConfigTargets.includes("FORUM_LIVE_TARGET") && Array.isArray(data.optionalSecretTargets) && data.optionalSecretTargets.includes("FORUM_LIVE_WRITE_ACCESS_CODE"))) { console.error(JSON.stringify(data, null, 2)); process.exit(1); }'
-          grep --fixed-strings "pnpm rollout:deploy-env -- \\" /tmp/forum-live-target-skip-summary.md
+          grep --fixed-strings "pnpm rollout:deploy-env -- \\\" /tmp/forum-live-target-skip-summary.md
           grep --fixed-strings -- "--scaffold-if-missing true" /tmp/forum-live-target-skip-summary.md
-          grep --fixed-strings "pnpm handoff:live-target -- \\" /tmp/forum-live-target-skip-summary.md
+          grep --fixed-strings "pnpm handoff:live-target -- \\\" /tmp/forum-live-target-skip-summary.md
           grep --fixed-strings -- "--apply-github-live-target true" /tmp/forum-live-target-skip-summary.md
           grep --fixed-strings "Guide: forum/DEPLOY.md" /tmp/forum-live-target-skip-summary.md
 
@@ -399,6 +399,33 @@ jobs:
           grep --fixed-strings "gh variable set FORUM_LIVE_TARGET --body '{\"forumUrl\":\"https://forum.fabushi.test\",\"deploymentStage\":\"production\",\"publicBaseUrl\":\"https://forum.fabushi.test\",\"writesEnabled\":false,\"requiresAccessCode\":false,\"exerciseWriteFlow\":false}' --repo 'bhrumom/fabushi'" /tmp/forum-production-live-target-handoff.txt
           grep "Applied FORUM_LIVE_TARGET to GitHub repo bhrumom/fabushi." /tmp/forum-production-live-target-handoff.txt
           grep --fixed-strings "variable set FORUM_LIVE_TARGET --body {\"forumUrl\":\"https://forum.fabushi.test\",\"deploymentStage\":\"production\",\"publicBaseUrl\":\"https://forum.fabushi.test\",\"writesEnabled\":false,\"requiresAccessCode\":false,\"exerciseWriteFlow\":false} --repo bhrumom/fabushi" /tmp/forum-production-gh-invocations.txt
+
+      - name: Roll out production runtime and auto-handoff from public base URL
+        run: |
+          rm -f /tmp/forum-production-rollout-gh-invocations.txt
+          mkdir -p /tmp/forum-mock-gh-bin-production-rollout
+          cat <<'GHEOF' >/tmp/forum-mock-gh-bin-production-rollout/gh
+          #!/usr/bin/env bash
+          printf '%s\n' "$*" >> /tmp/forum-production-rollout-gh-invocations.txt
+          GHEOF
+          chmod +x /tmp/forum-mock-gh-bin-production-rollout/gh
+          : >/tmp/forum-production-rollout-gh-invocations.txt
+
+          PATH="/tmp/forum-mock-gh-bin-production-rollout:$PATH" \
+          COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \
+          FORUM_IMAGE=fabushi-forum \
+          node forum/scripts/rollout-deploy-env.mjs \
+            --deploy-env-path /tmp/forum-deploy-production-no-check-url.env \
+            --compose-file forum/docker-compose.deploy.yml \
+            --compose-project-name fabushi-forum-deploy-check \
+            --handoff-live-target true \
+            --apply-github-live-target true \
+            2>&1 | tee /tmp/forum-production-rollout-handoff.txt
+
+          grep --fixed-strings "== Hourly live target handoff ==" /tmp/forum-production-rollout-handoff.txt
+          grep --fixed-strings "gh variable set FORUM_LIVE_TARGET --body '{\"forumUrl\":\"https://forum.fabushi.test\",\"deploymentStage\":\"production\",\"publicBaseUrl\":\"https://forum.fabushi.test\",\"writesEnabled\":false,\"requiresAccessCode\":false,\"exerciseWriteFlow\":false}' --repo 'bhrumom/fabushi'" /tmp/forum-production-rollout-handoff.txt
+          grep "Applied FORUM_LIVE_TARGET to GitHub repo bhrumom/fabushi." /tmp/forum-production-rollout-handoff.txt
+          grep --fixed-strings "variable set FORUM_LIVE_TARGET --body {\"forumUrl\":\"https://forum.fabushi.test\",\"deploymentStage\":\"production\",\"publicBaseUrl\":\"https://forum.fabushi.test\",\"writesEnabled\":false,\"requiresAccessCode\":false,\"exerciseWriteFlow\":false} --repo bhrumom/fabushi" /tmp/forum-production-rollout-gh-invocations.txt
 
       - name: Stop forum deploy compose
         if: always()

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -334,6 +334,16 @@ pnpm handoff:live-target -- \
   --apply-github-live-target true
 ```
 
+If you want the same production host run to boot the compose stack, verify the local runtime, and sync the hourly target in one pass, the combined rollout helper now follows the same `FORUM_PUBLIC_BASE_URL` fallback:
+
+```bash
+pnpm rollout:deploy-env -- \
+  --deploy-env-path .env.deploy \
+  --apply-github-live-target true
+```
+
+That combined helper still smokes the local runtime through `http://127.0.0.1:${FORUM_PORT}` when `FORUM_DEPLOY_CHECK_URL` is blank, then hands the verified hourly target off using `FORUM_PUBLIC_BASE_URL`.
+
 Expected production signals:
 
 - `/api/health` returns `ready: true`

--- a/forum/scripts/rollout-deploy-env.mjs
+++ b/forum/scripts/rollout-deploy-env.mjs
@@ -83,6 +83,20 @@ function validateHandoffMode(value) {
   throw new Error(`Expected --handoff-live-target to be auto, true, or false, received: ${value}`);
 }
 
+function resolveHandoffUrl({ explicitForumUrl, deployEnv }) {
+  const forumUrl = normalizeUrl(explicitForumUrl?.trim() || deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
+  if (forumUrl) {
+    return forumUrl;
+  }
+
+  const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
+  if (deploymentStage === "production") {
+    return normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL?.trim() || "");
+  }
+
+  return "";
+}
+
 function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -377,8 +391,10 @@ async function main() {
   }
 
   const deployEnv = await loadDeployEnv(deployEnvPath);
-  const deployCheckUrl = normalizeUrl(deployEnv.FORUM_DEPLOY_CHECK_URL?.trim() || "");
-  const handoffUrl = explicitForumUrl || deployCheckUrl;
+  const handoffUrl = resolveHandoffUrl({
+    explicitForumUrl,
+    deployEnv,
+  });
 
   const sharedArgs = ["--deploy-env-path", deployEnvPath];
 
@@ -418,13 +434,13 @@ async function main() {
   if (!handoffUrl) {
     if (handoffMode === "true") {
       throw new Error(
-        "Handoff requires either --forum-url or FORUM_DEPLOY_CHECK_URL in the deploy env file.",
+        "Handoff requires either --forum-url, FORUM_DEPLOY_CHECK_URL, or production FORUM_PUBLIC_BASE_URL in the deploy env file.",
       );
     }
 
     console.log("\n== Hourly live target handoff ==");
     console.log(
-      "Skipping handoff because neither --forum-url nor FORUM_DEPLOY_CHECK_URL is available yet. Re-run with the real preview or production URL once it exists.",
+      "Skipping handoff because neither --forum-url, FORUM_DEPLOY_CHECK_URL, nor a production FORUM_PUBLIC_BASE_URL is available yet. Re-run with the real preview or production URL once it exists.",
     );
     return;
   }


### PR DESCRIPTION
## Summary
- let `forum/scripts/rollout-deploy-env.mjs` reuse `FORUM_PUBLIC_BASE_URL` for production handoff when `FORUM_DEPLOY_CHECK_URL` is blank
- add deploy-compose CI coverage for the production rollout path so the combined helper proves it can boot, smoke, and sync `FORUM_LIVE_TARGET` in one pass
- document that the production combined rollout helper now follows the same deploy-env-driven fallback as `pnpm handoff:live-target`

## Why now
`PR #553` already taught the direct handoff helpers how to infer the production live target from `FORUM_PUBLIC_BASE_URL`, but the higher-level host entrypoint `pnpm rollout:deploy-env` still stopped short of that same fallback.

That left a small but real gap in the current highest-priority deployment thread:
- production `.env.deploy` could already be fully self-describing
- `pnpm smoke:deploy-env` could already validate the runtime locally without a deploy check URL
- `pnpm handoff:live-target` could already sync the hourly target from `FORUM_PUBLIC_BASE_URL`
- but `pnpm rollout:deploy-env` would still skip or error unless the operator repeated the URL manually

This PR keeps scope tight and makes the first real production host-side rollout more consistent with the rest of the deploy chain.

## What changed
### `forum/scripts/rollout-deploy-env.mjs`
- add `resolveHandoffUrl()`
- keep preferring explicit `--forum-url`
- keep using `FORUM_DEPLOY_CHECK_URL` when present
- for production, fall back to `FORUM_PUBLIC_BASE_URL` when `FORUM_DEPLOY_CHECK_URL` is empty
- update the forced-handoff error and auto-skip message so they reflect the same production fallback contract

### `.github/workflows/forum-deploy-compose-checks.yml`
- keep the existing direct `handoff-live-deployment-target.mjs` production coverage
- add a second production check that runs `rollout-deploy-env.mjs` with:
  - `--deploy-env-path /tmp/forum-deploy-production-no-check-url.env`
  - `--handoff-live-target true`
  - `--apply-github-live-target true`
- assert that the combined helper now reaches the handoff phase and applies the same bundled `FORUM_LIVE_TARGET` to the mocked GitHub CLI path

### `forum/DEPLOY.md`
- document that the production combined rollout helper can now stay fully deploy-env driven even when `FORUM_DEPLOY_CHECK_URL` is blank
- show the one-command production host path:
  - `pnpm rollout:deploy-env -- --deploy-env-path .env.deploy --apply-github-live-target true`

## Verification
- local syntax check on the updated helper:
  - `node --check /workspace/scratchforum/forum/scripts/rollout-deploy-env.mjs`
- compare against `main` is scoped to 3 files:
  - `.github/workflows/forum-deploy-compose-checks.yml`
  - `forum/DEPLOY.md`
  - `forum/scripts/rollout-deploy-env.mjs`
- final runtime verification remains with repository CI on this PR

## Expected outcome after merge
- production hosts no longer need to repeat the public forum URL when `pnpm rollout:deploy-env` is already working from a production `.env.deploy`
- the combined rollout helper becomes consistent with the direct handoff helper and the deploy posture summary
- the repository keeps covering this path in CI so the next production handoff does not drift back into a manual-only step