### PR TITLE
Fix Android zen room overlays and Buddha rendering

### DIFF
--- a/fabushi/lib/screens/buddha_model_screen_android_three.dart
+++ b/fabushi/lib/screens/buddha_model_screen_android_three.dart
@@ -158,9 +158,9 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     renderer.setPixelRatio(dpr);
     renderer.setSize(size.width, size.height, false);
     renderer.shadowMap.enabled = false;
-    renderer.outputEncoding = three.LinearEncoding;
+    renderer.outputEncoding = three.sRGBEncoding;
     renderer.toneMapping = three.NoToneMapping;
-    renderer.toneMappingExposure = 1.0;
+    renderer.toneMappingExposure = 1.25;
     renderer.setClearColor(three.Color(0x000000), 0.0);
 
     final renderTargetOptions = three.WebGLRenderTargetOptions({
@@ -191,18 +191,18 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     );
     camera.position.set(0, 120, 290);
 
-    final ambientLight = three.AmbientLight(0xffffff, 1.1);
+    final ambientLight = three.AmbientLight(0xffffff, 1.55);
     scene.add(ambientLight);
 
-    final keyLight = three.DirectionalLight(0xffd05b, 1.8);
+    final keyLight = three.DirectionalLight(0xffd05b, 2.35);
     keyLight.position.set(80, 200, 120);
     scene.add(keyLight);
 
-    final fillLight = three.PointLight(0xffe7aa, 1.1, 620);
+    final fillLight = three.PointLight(0xffe7aa, 1.45, 620);
     fillLight.position.set(-120, 110, 90);
     scene.add(fillLight);
 
-    final rimLight = three.PointLight(0x8b5a16, 0.9, 520);
+    final rimLight = three.PointLight(0x8b5a16, 1.1, 520);
     rimLight.position.set(0, 40, -180);
     scene.add(rimLight);
 
@@ -285,7 +285,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     }
 
     model.position.y += 18;
-    model.rotation.y = math.pi;
+    model.rotation.y = 0.0;
     model.rotation.x = 0.08;
 
     model.traverse((child) {
@@ -302,7 +302,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     }
 
     final simpleMaterial = three.MeshBasicMaterial({
-      'color': three.Color.fromHex(0xffcc4a),
+      'color': three.Color.fromHex(0xffdf75),
       'fog': false,
       'toneMapped': false,
     });

--- a/fabushi/lib/screens/buddha_model_screen_native.dart
+++ b/fabushi/lib/screens/buddha_model_screen_native.dart
@@ -53,7 +53,6 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   bool _renderFailed = false;
   double _loadingProgress = 0.0;
   double _rotationY = 0.0;
-  double _currentIncenseProgress = 0.0;
   final double _cameraDistance = 250.0;
 
   bool _isUserDragging = false;
@@ -75,7 +74,6 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
   void initState() {
     super.initState();
     _isAutoRotating = widget.autoRotate;
-    _currentIncenseProgress = widget.incenseProgress;
     _ticker = createTicker(_onTick);
     if (widget.isVisible) {
       _ticker.start();
@@ -109,7 +107,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     setState(() {
       _androidThreeError = null;
       _resetForFreshLoad(
-        loadingLabel: '正在切换备用佛像渲染...',
+        loadingLabel: '正在安奉佛像...',
         activePath: _BuddhaRendererPath.androidThreeFallback,
       );
     });
@@ -125,10 +123,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
         activePath: _BuddhaRendererPath.flutterScenePrimary,
       );
     });
-    await _loadFlutterSceneModel(
-      asFallback: false,
-      reasonLabel: 'flutter_scene 渲染准备中...',
-    );
+    await _loadFlutterSceneModel(asFallback: false, reasonLabel: '正在安奉佛像...');
   }
 
   Future<void> _loadFlutterSceneModel({
@@ -150,9 +145,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       try {
         if (mounted) {
           setState(() {
-            _loadingLabel = attempt == 1
-                ? reasonLabel
-                : '$reasonLabel（重试 $attempt/$maxRetries）';
+            _loadingLabel = reasonLabel;
           });
         }
 
@@ -180,7 +173,7 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
           _flutterSceneError = null;
           _loadingProgress = 1.0;
           if (asFallback) {
-            _loadingLabel = '已切换 flutter_scene 备用展示';
+            _loadingLabel = '佛像已安奉';
           }
         });
         return;
@@ -224,11 +217,11 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
         irradianceImage: goldEnvImage,
       );
       scene.environment.environmentMap = envMap;
-      scene.environment.intensity = 2.0;
-      scene.environment.exposure = 1.12;
+      scene.environment.intensity = 2.85;
+      scene.environment.exposure = 1.32;
     } catch (_) {
-      scene.environment.intensity = 1.75;
-      scene.environment.exposure = 1.05;
+      scene.environment.intensity = 2.35;
+      scene.environment.exposure = 1.22;
     }
   }
 
@@ -257,10 +250,10 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
       for (final MeshPrimitive primitive in mesh.primitives) {
         final material = primitive.material;
         if (material is PhysicallyBasedMaterial) {
-          material.baseColorFactor = vector.Vector4(1.0, 0.86, 0.08, 1.0);
-          material.metallicFactor = 0.68;
-          material.roughnessFactor = 0.18;
-          material.emissiveFactor = vector.Vector4(0.10, 0.07, 0.012, 1.0);
+          material.baseColorFactor = vector.Vector4(1.0, 0.92, 0.22, 1.0);
+          material.metallicFactor = 0.6;
+          material.roughnessFactor = 0.16;
+          material.emissiveFactor = vector.Vector4(0.18, 0.12, 0.03, 1.0);
           material.vertexColorWeight = 0.0;
         }
       }
@@ -430,9 +423,6 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     if (oldWidget.isVisible != widget.isVisible) {
       _updateVisibilityState(widget.isVisible);
     }
-    if (oldWidget.incenseProgress != widget.incenseProgress) {
-      _currentIncenseProgress = widget.incenseProgress;
-    }
   }
 
   void _updateVisibilityState(bool isVisible) {
@@ -446,25 +436,13 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
     }
   }
 
-  void updateIncenseProgress(double progress) {
-    _currentIncenseProgress = progress;
-    if (mounted) {
-      setState(() {});
-    }
-  }
+  void updateIncenseProgress(double _) {}
 
   void setAutoRotate(bool enabled) {
     _isAutoRotating = enabled;
     if (!enabled) {
       _isReturningToStart = true;
     }
-  }
-
-  String get _compatibilityBanner {
-    if (_activeRendererPath == _BuddhaRendererPath.androidThreeFallback) {
-      return '已切换到 three_dart 备用渲染';
-    }
-    return '佛像使用 flutter_scene 渲染';
   }
 
   @override
@@ -543,67 +521,6 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
                       camera: camera,
                       onRenderError: _handleRenderFailure,
                     ),
-                  ),
-                ),
-              if (!_isLoading && !_loadFailed)
-                Positioned.fill(
-                  child: IgnorePointer(
-                    child: CustomPaint(
-                      size: size,
-                      painter: _IncensePainter(
-                        incenseProgress: _currentIncenseProgress,
-                        isBurning: widget.isBurning,
-                      ),
-                    ),
-                  ),
-                ),
-              if (!_isLoading &&
-                  !_loadFailed &&
-                  _activeRendererPath !=
-                      _BuddhaRendererPath.flutterScenePrimary)
-                Positioned(
-                  top: 18,
-                  left: 20,
-                  right: 20,
-                  child: IgnorePointer(
-                    child: Center(
-                      child: Container(
-                        constraints: const BoxConstraints(maxWidth: 360),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 14,
-                          vertical: 10,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.black.withValues(alpha: 0.48),
-                          borderRadius: BorderRadius.circular(16),
-                          border: Border.all(
-                            color: const Color(
-                              0xFFD4AF37,
-                            ).withValues(alpha: 0.36),
-                          ),
-                        ),
-                        child: Text(
-                          _compatibilityBanner,
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            color: Color(0xFFFFD700),
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              if (widget.showBook && widget.bookTitle != null && !_isLoading)
-                Positioned(
-                  left: (size.width - 184) / 2,
-                  top: (size.height * 0.58)
-                      .clamp(0.0, size.height - 180)
-                      .toDouble(),
-                  child: _SutraBookButton(
-                    title: widget.bookTitle!,
-                    onTap: widget.onBookTap,
                   ),
                 ),
               if (_isLoading)
@@ -729,7 +646,12 @@ class _ScenePainter extends CustomPainter {
     }
 
     try {
-      scene.render(camera, canvas, viewport: Offset.zero & size);
+      canvas.save();
+      try {
+        scene.render(camera, canvas, viewport: Offset.zero & size);
+      } finally {
+        canvas.restore();
+      }
     } catch (error) {
       onRenderError?.call(error);
     }
@@ -737,157 +659,4 @@ class _ScenePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _ScenePainter oldDelegate) => true;
-}
-
-class _SutraBookButton extends StatelessWidget {
-  final String title;
-  final VoidCallback? onTap;
-
-  const _SutraBookButton({required this.title, this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: title,
-      child: SizedBox(
-        width: 184,
-        child: FilledButton(
-          onPressed: onTap,
-          style: FilledButton.styleFrom(
-            backgroundColor: const Color(0xAA5E0707),
-            foregroundColor: const Color(0xFFFFE6A3),
-            side: const BorderSide(color: Color(0xFFD4AF37)),
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(14),
-            ),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                title,
-                textAlign: TextAlign.center,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 6),
-              const Text(
-                '经卷',
-                style: TextStyle(fontSize: 11, color: Color(0xCCFFF4C2)),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _IncensePainter extends CustomPainter {
-  final double incenseProgress;
-  final bool isBurning;
-
-  const _IncensePainter({
-    required this.incenseProgress,
-    required this.isBurning,
-  });
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    if (size.isEmpty || !size.width.isFinite || !size.height.isFinite) {
-      return;
-    }
-
-    final base = Offset(size.width / 2, size.height * 0.82);
-    final remaining = (1.0 - incenseProgress).clamp(0.16, 1.0).toDouble();
-    final stickHeight = 74.0 * remaining;
-
-    canvas.drawOval(
-      Rect.fromCenter(center: base.translate(0, 36), width: 108, height: 20),
-      Paint()
-        ..color = const Color(0x55000000)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 8),
-    );
-
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(
-        Rect.fromCenter(center: base.translate(0, 22), width: 92, height: 22),
-        const Radius.circular(10),
-      ),
-      Paint()
-        ..shader = ui.Gradient.linear(
-          base.translate(-46, 12),
-          base.translate(46, 34),
-          const [Color(0xFFFFD36A), Color(0xFF7A4314), Color(0xFFD4AF37)],
-          const [0.0, 0.55, 1.0],
-        ),
-    );
-
-    for (final offset in const [-14.0, 0.0, 14.0]) {
-      final stickBase = base.translate(offset, 6);
-      final stickTip = stickBase.translate(0, -stickHeight - 14);
-      canvas.drawLine(
-        stickBase,
-        stickTip,
-        Paint()
-          ..shader = ui.Gradient.linear(
-            stickBase,
-            stickTip,
-            const [Color(0xFF5A2E16), Color(0xFFB07136), Color(0xFF2B1509)],
-            const [0.0, 0.5, 1.0],
-          )
-          ..strokeWidth = 3.3
-          ..strokeCap = StrokeCap.round,
-      );
-
-      if (!isBurning) {
-        continue;
-      }
-
-      canvas.drawCircle(
-        stickTip,
-        6,
-        Paint()
-          ..shader = ui.Gradient.radial(
-            stickTip,
-            8,
-            const [Color(0xFFFFF1A3), Color(0xFFFF6B1A), Color(0x00FF6B1A)],
-            const [0.0, 0.5, 1.0],
-          ),
-      );
-
-      for (var i = 0; i < 9; i++) {
-        final t =
-            ((DateTime.now().millisecondsSinceEpoch / 1000) * 0.2 +
-                i / 9 +
-                offset * 0.006) %
-            1.0;
-        final smokeCenter = Offset(
-          stickTip.dx + math.sin(t * math.pi * 2.0 + offset) * (7 + t * 24),
-          stickTip.dy - t * 118 - i * 3.0,
-        );
-        canvas.drawCircle(
-          smokeCenter,
-          2.4 + t * 9.0,
-          Paint()
-            ..color = Color.fromRGBO(
-              235,
-              229,
-              214,
-              ((1 - t) * 0.45 + 0.05).clamp(0.0, 0.5),
-            )
-            ..maskFilter = MaskFilter.blur(BlurStyle.normal, 2 + t * 5),
-        );
-      }
-    }
-  }
-
-  @override
-  bool shouldRepaint(covariant _IncensePainter oldDelegate) => true;
 }

--- a/fabushi/lib/screens/meditation_room_screen.dart
+++ b/fabushi/lib/screens/meditation_room_screen.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_volume_controller/flutter_volume_controller.dart';
 import '../models/auth_model.dart';
+import '../models/meditation_practice_model.dart';
 import '../models/sutra_model.dart';
 import '../services/practice_stats_service.dart';
 import '../services/meditation_session_manager.dart';
@@ -16,6 +18,7 @@ import '../widgets/online_counter_widget.dart';
 import '../widgets/practice_selection_sheet.dart';
 import '../widgets/practice_leaderboard_sheet.dart';
 import '../widgets/reflection_dialog.dart';
+import '../widgets/zen_room_2d_elements.dart';
 
 /// 禅室修行界面 - 零摩擦版本
 ///
@@ -25,7 +28,7 @@ import '../widgets/reflection_dialog.dart';
 /// - 灵活时长：随时可停，无最低要求
 /// - 即时反馈：成就系统实时激励
 class MeditationRoomScreen extends StatefulWidget {
-  const MeditationRoomScreen({Key? key}) : super(key: key);
+  const MeditationRoomScreen({super.key});
 
   @override
   State<MeditationRoomScreen> createState() => MeditationRoomScreenState();
@@ -444,7 +447,10 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(label, style: TextStyle(color: Colors.white.withOpacity(0.7))),
+          Text(
+            label,
+            style: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
+          ),
           Text(
             value,
             style: const TextStyle(
@@ -522,7 +528,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                         height: 40,
                         decoration: BoxDecoration(
                           color: isSelected
-                              ? const Color(0xFFD4AF37).withOpacity(0.2)
+                              ? const Color(0xFFD4AF37).withValues(alpha: 0.2)
                               : const Color(0xFF2A2A2A),
                           borderRadius: BorderRadius.circular(8),
                         ),
@@ -631,9 +637,11 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: Colors.green.withOpacity(0.1),
+                  color: Colors.green.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.green.withOpacity(0.3)),
+                  border: Border.all(
+                    color: Colors.green.withValues(alpha: 0.3),
+                  ),
                 ),
                 child: const Row(
                   children: [
@@ -766,20 +774,23 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                   autoRotate: _isCircumambulating,
                   isBurning: _sessionManager.isInSession,
                   incenseProgress: _incenseController.value,
-                  showBook: true,
-                  bookTitle: practice?.title ?? '选择功课',
-                  onBookTap:
-                      practice == null ||
-                          practice.filePath.startsWith('manual:')
-                      ? _showPracticeSelection
-                      : _openSutraReader,
+                  showBook: kIsWeb,
+                  bookTitle: kIsWeb ? practice?.title ?? '选择功课' : null,
+                  onBookTap: kIsWeb
+                      ? practice == null ||
+                                practice.filePath.startsWith('manual:')
+                            ? _showPracticeSelection
+                            : _openSutraReader
+                      : null,
                 ),
               ),
             ),
 
+            if (!kIsWeb) _buildNativeZenOfferings(practice),
+
             // 沉浸式遮罩
             if (_sessionManager.isInSession)
-              Container(color: Colors.black.withOpacity(0.15)),
+              Container(color: Colors.black.withValues(alpha: 0.15)),
 
             // UI 覆盖层
             Positioned.fill(
@@ -818,6 +829,66 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
     );
   }
 
+  Widget _buildNativeZenOfferings(MeditationPractice? practice) {
+    return Positioned.fill(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final size = Size(constraints.maxWidth, constraints.maxHeight);
+          final title = practice?.title ?? '选择功课';
+          final opensSelection =
+              practice == null || practice.filePath.startsWith('manual:');
+          final incenseWidth = (size.width * 0.30)
+              .clamp(180.0, 230.0)
+              .toDouble();
+          final incenseHeight = incenseWidth * 1.12;
+          final offeringTop = (size.height * 0.58)
+              .clamp(0.0, size.height - 300)
+              .toDouble();
+          final incenseLeft = (size.width * 0.18 - incenseWidth / 2)
+              .clamp(16.0, size.width - incenseWidth - 16)
+              .toDouble();
+          final bookRight = (size.width * 0.10).clamp(16.0, 120.0).toDouble();
+
+          return Stack(
+            children: [
+              Positioned(
+                left: incenseLeft,
+                top: offeringTop,
+                width: incenseWidth,
+                height: incenseHeight,
+                child: IgnorePointer(
+                  child: RepaintBoundary(
+                    child: AnimatedBuilder(
+                      animation: _incenseController,
+                      builder: (context, _) {
+                        return IncenseOffering(
+                          incenseProgress: _incenseController.value,
+                          isBurning: _sessionManager.isInSession,
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                right: bookRight,
+                top: offeringTop + 16,
+                child: RepaintBoundary(
+                  child: SutraBookButton(
+                    title: title,
+                    onTap: opensSelection
+                        ? _showPracticeSelection
+                        : _openSutraReader,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
   Widget _buildTopBar() {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -828,16 +899,16 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             decoration: BoxDecoration(
-              color: Colors.black.withOpacity(0.36),
+              color: Colors.black.withValues(alpha: 0.36),
               borderRadius: BorderRadius.circular(16),
               border: Border.all(
-                color: const Color(0xFFD4AF37).withOpacity(0.22),
+                color: const Color(0xFFD4AF37).withValues(alpha: 0.22),
               ),
             ),
             child: CompactOnlineCounterWidget(
               countStream: _onlineCounterService.onlineCountStream,
               initialCount: _onlineCounterService.currentCount,
-              icon: Icons.self_improvement,
+              icon: Icons.people_alt_rounded,
               color: const Color(0xFFD4AF37),
             ),
           ),
@@ -861,7 +932,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                   vertical: 6,
                 ),
                 decoration: BoxDecoration(
-                  color: Colors.black.withOpacity(0.4),
+                  color: Colors.black.withValues(alpha: 0.4),
                   borderRadius: BorderRadius.circular(16),
                   border: Border.all(
                     color: isActive
@@ -878,7 +949,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                           BoxShadow(
                             color: const Color(
                               0xFFD4AF37,
-                            ).withOpacity(0.2 * _pulseController.value),
+                            ).withValues(alpha: 0.2 * _pulseController.value),
                             blurRadius: 8,
                           ),
                         ]
@@ -930,7 +1001,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
           width: 42,
           height: 42,
           decoration: BoxDecoration(
-            color: Colors.black.withOpacity(0.36),
+            color: Colors.black.withValues(alpha: 0.36),
             shape: BoxShape.circle,
             border: Border.all(color: Colors.white24, width: 0.5),
           ),
@@ -966,10 +1037,10 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 20),
               decoration: BoxDecoration(
-                color: Colors.black.withOpacity(0.3),
+                color: Colors.black.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(30),
                 border: Border.all(
-                  color: const Color(0xFFD4AF37).withOpacity(0.3),
+                  color: const Color(0xFFD4AF37).withValues(alpha: 0.3),
                 ),
               ),
               child: Column(
@@ -1047,7 +1118,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                               (_sessionManager.isInSession
                                       ? Colors.red
                                       : const Color(0xFFD4AF37))
-                                  .withOpacity(0.3),
+                                  .withValues(alpha: 0.3),
                           blurRadius: 12,
                           offset: const Offset(0, 4),
                         ),
@@ -1106,8 +1177,8 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
         height: 56,
         decoration: BoxDecoration(
           color: isActive
-              ? const Color(0xFFD4AF37).withOpacity(0.2)
-              : Colors.black.withOpacity(0.4),
+              ? const Color(0xFFD4AF37).withValues(alpha: 0.2)
+              : Colors.black.withValues(alpha: 0.4),
           shape: BoxShape.circle,
           border: Border.all(
             color: isActive ? const Color(0xFFD4AF37) : Colors.white24,
@@ -1125,7 +1196,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
 
   Widget _buildLoadingOverlay() {
     return Container(
-      color: Colors.black.withOpacity(0.7),
+      color: Colors.black.withValues(alpha: 0.7),
       child: const Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/fabushi/lib/widgets/zen_room_2d_elements.dart
+++ b/fabushi/lib/widgets/zen_room_2d_elements.dart
@@ -15,9 +15,20 @@ class IncensePainter extends CustomPainter {
   }
 
   void _drawFixedIncense(Canvas canvas, Size size) {
-    final base = Offset(size.width / 2, size.height * 0.82);
+    final base = Offset(size.width / 2, size.height * 0.70);
     final remaining = (1.0 - incenseProgress).clamp(0.16, 1.0).toDouble();
-    final stickHeight = 74.0 * remaining;
+    final stickHeight = 88.0 * remaining;
+    final haloRect = Rect.fromCenter(
+      center: base.translate(0, -24),
+      width: 170,
+      height: 178,
+    );
+    canvas.drawOval(
+      haloRect,
+      Paint()
+        ..color = const Color(0x66000000)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 18),
+    );
     _drawIncenseBurner(canvas, base, stickHeight);
 
     for (final offset in const [-14.0, 0.0, 14.0]) {
@@ -27,12 +38,21 @@ class IncensePainter extends CustomPainter {
         stickBase,
         stickTip,
         Paint()
+          ..color = const Color(0xAA1A0904)
+          ..strokeWidth = 7
+          ..strokeCap = StrokeCap.round
+          ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2),
+      );
+      canvas.drawLine(
+        stickBase,
+        stickTip,
+        Paint()
           ..shader = ui.Gradient.linear(stickBase, stickTip, const [
             Color(0xFF5A2E16),
-            Color(0xFFB07136),
+            Color(0xFFE7B45F),
             Color(0xFF2B1509),
           ])
-          ..strokeWidth = 3.3
+          ..strokeWidth = 4.0
           ..strokeCap = StrokeCap.round,
       );
 
@@ -96,7 +116,7 @@ class IncensePainter extends CustomPainter {
   }
 
   void _drawIncenseBurner(Canvas canvas, Offset center, double stickHeight) {
-    final width = (stickHeight * 1.22).clamp(48.0, 88.0).toDouble();
+    final width = (stickHeight * 1.24).clamp(58.0, 112.0).toDouble();
     final topHeight = (stickHeight * 0.22).clamp(10.0, 16.0).toDouble();
     final bodyHeight = (stickHeight * 0.45).clamp(20.0, 34.0).toDouble();
     final topCenter = center.translate(0, 8);
@@ -183,12 +203,168 @@ class IncensePainter extends CustomPainter {
   }
 }
 
+class IncenseOffering extends StatelessWidget {
+  final double incenseProgress;
+  final bool isBurning;
+
+  const IncenseOffering({
+    super.key,
+    required this.incenseProgress,
+    required this.isBurning,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final remaining = (1.0 - incenseProgress).clamp(0.16, 1.0).toDouble();
+    final stickHeight = 88.0 * remaining;
+    const centerX = 85.0;
+    final flameBottom = 58.0 + stickHeight - 6.0;
+
+    return SizedBox.expand(
+      child: Center(
+        child: SizedBox(
+          width: 170,
+          height: 196,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            clipBehavior: Clip.none,
+            children: [
+              Positioned(
+                bottom: 4,
+                child: Container(
+                  width: 124,
+                  height: 22,
+                  decoration: const BoxDecoration(
+                    color: Color(0x66000000),
+                    borderRadius: BorderRadius.all(Radius.elliptical(62, 11)),
+                    boxShadow: [
+                      BoxShadow(color: Color(0x99000000), blurRadius: 14),
+                    ],
+                  ),
+                ),
+              ),
+              for (final dx in const [-18.0, 0.0, 18.0]) ...[
+                Positioned(
+                  left: centerX + dx - 3,
+                  bottom: 58,
+                  child: Container(
+                    width: 6,
+                    height: stickHeight,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(3),
+                      gradient: const LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [
+                          Color(0xFF2B1509),
+                          Color(0xFFE7B45F),
+                          Color(0xFF5A2E16),
+                        ],
+                      ),
+                      boxShadow: const [
+                        BoxShadow(color: Color(0xAA000000), blurRadius: 5),
+                      ],
+                    ),
+                  ),
+                ),
+                if (isBurning) ...[
+                  Positioned(
+                    left: centerX + dx - 9,
+                    bottom: flameBottom,
+                    child: Container(
+                      width: 18,
+                      height: 18,
+                      decoration: const BoxDecoration(
+                        shape: BoxShape.circle,
+                        gradient: RadialGradient(
+                          colors: [
+                            Color(0xFFFFF1A3),
+                            Color(0xFFFF6B1A),
+                            Color(0x00FF6B1A),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  for (var i = 0; i < 3; i++)
+                    Positioned(
+                      left: centerX + dx - 7 + (i.isEven ? -8 : 8),
+                      bottom: flameBottom + 22 + i * 24,
+                      child: Container(
+                        width: 14.0 + i * 6,
+                        height: 14.0 + i * 6,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: Color.fromRGBO(235, 229, 214, 0.16 - i * 0.03),
+                          boxShadow: const [
+                            BoxShadow(color: Color(0x66EDE5D8), blurRadius: 12),
+                          ],
+                        ),
+                      ),
+                    ),
+                ],
+              ],
+              Positioned(
+                bottom: 18,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 112,
+                      height: 20,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(20),
+                        gradient: const LinearGradient(
+                          colors: [
+                            Color(0xFFD4AF37),
+                            Color(0xFF6F3514),
+                            Color(0xFFFFD36A),
+                          ],
+                        ),
+                        border: Border.all(color: const Color(0x99D4AF37)),
+                      ),
+                    ),
+                    Transform.translate(
+                      offset: const Offset(0, -4),
+                      child: Container(
+                        width: 94,
+                        height: 34,
+                        decoration: const BoxDecoration(
+                          borderRadius: BorderRadius.vertical(
+                            bottom: Radius.circular(38),
+                            top: Radius.circular(8),
+                          ),
+                          gradient: LinearGradient(
+                            begin: Alignment.topLeft,
+                            end: Alignment.bottomRight,
+                            colors: [
+                              Color(0xFF9A5A24),
+                              Color(0xFF4A2111),
+                              Color(0xFF2A1208),
+                            ],
+                          ),
+                          boxShadow: [
+                            BoxShadow(color: Color(0x99000000), blurRadius: 8),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class SutraBookButton extends StatelessWidget {
   final String title;
   final VoidCallback? onTap;
 
-  const SutraBookButton({Key? key, required this.title, this.onTap})
-    : super(key: key);
+  const SutraBookButton({super.key, required this.title, this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -200,7 +376,38 @@ class SutraBookButton extends StatelessWidget {
         child: SizedBox(
           width: 184,
           height: 128,
-          child: CustomPaint(painter: _SutraBookPainter(title)),
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Positioned.fill(
+                child: CustomPaint(painter: _SutraBookPainter(title)),
+              ),
+              Container(
+                width: 74,
+                height: 74,
+                decoration: BoxDecoration(
+                  color: const Color(0xAA2A0202),
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: const Color(0xFFD4AF37),
+                    width: 1.4,
+                  ),
+                  boxShadow: const [
+                    BoxShadow(
+                      color: Color(0x99000000),
+                      blurRadius: 14,
+                      offset: Offset(0, 5),
+                    ),
+                  ],
+                ),
+                child: const Icon(
+                  Icons.auto_stories_rounded,
+                  color: Color(0xFFFFE6A3),
+                  size: 40,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Render native zen offerings above the Android/iOS Buddha scene so incense, burner, and sutra entry stay visible
- Move the online count affordance out of the Buddha area and use a people icon
- Brighten native/flutter_scene and Android three_dart Buddha renderers; re-exported and replaced the R2 .model from the R2 GLB

## Verification
- flutter analyze --no-pub lib\\screens\\meditation_room_screen.dart lib\\screens\\buddha_model_screen_native.dart lib\\screens\\buddha_model_screen_android_three.dart lib\\widgets\\zen_room_2d_elements.dart
- flutter test --no-pub test\\unit\\core\\app_config_buddha_model_test.dart test\\unit\\services\\asset_loader_service_test.dart
- flutter build apk --debug --no-pub
- Installed on Android device AXYP6R4530001510 via adb and verified the Zen Room screenshot shows Buddha, incense/burner, sutra entry, and top online count