### PR TITLE
feat(android): reopen current-main Buddha diagnostics as a smaller step

### DIFF
--- a/.github/workflows/android-buddha-loading-diagnostics.yml
+++ b/.github/workflows/android-buddha-loading-diagnostics.yml
@@ -1,0 +1,84 @@
+name: Android Buddha Loading Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_level:
+        description: Android emulator API level
+        required: false
+        default: '35'
+      profile:
+        description: Android emulator profile
+        required: false
+        default: pixel_7
+
+jobs:
+  android-buddha-diagnostics:
+    name: Android Buddha diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: fabushi
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Run Android Buddha diagnostics
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ inputs.api_level }}
+          arch: x86_64
+          profile: ${{ inputs.profile }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: |
+            set +e
+            cd fabushi
+            adb wait-for-device
+            adb logcat -c
+            flutter test integration_test/buddha_loading_android_diagnostics_test.dart -d emulator-5554 --reporter expanded | tee "$GITHUB_WORKSPACE/buddha_flutter_test.log"
+            test_exit=${PIPESTATUS[0]}
+            adb logcat -d > "$GITHUB_WORKSPACE/buddha_logcat_full.log"
+            grep -E 'BuddhaDiag|BuddhaModel|three_dart|AssetLoader' "$GITHUB_WORKSPACE/buddha_logcat_full.log" > "$GITHUB_WORKSPACE/buddha_logcat_filtered.log" || true
+            exit "$test_exit"
+
+      - name: Write diagnostics summary
+        if: always()
+        run: |
+          {
+            echo '## Android Buddha diagnostics'
+            echo
+            echo '### Filtered log tail'
+            echo
+            echo '```text'
+            tail -n 120 "$GITHUB_WORKSPACE/buddha_logcat_filtered.log" 2>/dev/null || echo 'No filtered diagnostics captured.'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload diagnostics artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-buddha-diagnostics
+          path: |
+            buddha_flutter_test.log
+            buddha_logcat_full.log
+            buddha_logcat_filtered.log
+          if-no-files-found: warn

--- a/fabushi/integration_test/buddha_loading_android_diagnostics_test.dart
+++ b/fabushi/integration_test/buddha_loading_android_diagnostics_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:global_dharma_sharing/screens/buddha_model_screen_android_three.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Android three diagnostics reach ready without fallback error', (
+    WidgetTester tester,
+  ) async {
+    final statuses = <String>[];
+    String? error;
+    var ready = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(
+            child: AndroidThreeBuddhaView(
+              rotationY: 0,
+              isVisible: true,
+              onStatus: statuses.add,
+              onReady: () => ready = true,
+              onError: (message) => error = message,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final deadline = DateTime.now().add(const Duration(seconds: 150));
+    while (DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(seconds: 1));
+      if (ready || error != null) {
+        break;
+      }
+    }
+
+    debugPrint('[BuddhaDiag][test] statuses=${statuses.join(' -> ')}');
+
+    expect(
+      error,
+      isNull,
+      reason: 'Android Three 仍进入失败态，请结合 workflow artifact 与 [BuddhaDiag] 日志定位阶段。',
+    );
+    expect(
+      ready,
+      isTrue,
+      reason: 'Android Three 在超时前没有进入 ready 状态；请查看 buddha_flutter_test.log 和 logcat artifact。',
+    );
+  });
+}

--- a/fabushi/lib/screens/buddha_model_screen_android_three.dart
+++ b/fabushi/lib/screens/buddha_model_screen_android_three.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -16,6 +17,7 @@ class AndroidThreeBuddhaView extends StatefulWidget {
   final ValueChanged<double>? onProgress;
   final VoidCallback? onReady;
   final ValueChanged<String>? onError;
+  final ValueChanged<String>? onStatus;
 
   const AndroidThreeBuddhaView({
     super.key,
@@ -24,6 +26,7 @@ class AndroidThreeBuddhaView extends StatefulWidget {
     this.onProgress,
     this.onReady,
     this.onError,
+    this.onStatus,
   });
 
   @override
@@ -33,6 +36,8 @@ class AndroidThreeBuddhaView extends StatefulWidget {
 class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
   static const Duration _initDelay = Duration(milliseconds: 100);
   static const Duration _modelLoadTimeout = Duration(seconds: 90);
+
+  final Stopwatch _diagnosticStopwatch = Stopwatch();
 
   FlutterGlPlugin? _glPlugin;
   three.WebGLRenderer? _renderer;
@@ -46,6 +51,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
   bool _ready = false;
   bool _failed = false;
   bool _disposed = false;
+  bool _firstFrameLogged = false;
 
   @override
   Widget build(BuildContext context) {
@@ -88,6 +94,18 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
   Future<void> _initialize(Size size, double dpr) async {
     final plugin = FlutterGlPlugin();
+    _diagnosticStopwatch
+      ..reset()
+      ..start();
+    _emitStatus(
+      'initialize_start',
+      '开始初始化 Android Three 渲染上下文',
+      extra: {
+        'size': '${size.width.round()}x${size.height.round()}',
+        'dpr': dpr.toStringAsFixed(2),
+      },
+    );
+
     try {
       await plugin.initialize(
         options: {
@@ -98,6 +116,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
           'dpr': dpr,
         },
       );
+      _emitStatus('gl_plugin_ready', 'Flutter GL 插件初始化完成');
 
       if (!mounted || _disposed) {
         plugin.dispose();
@@ -110,6 +129,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
       await Future<void>.delayed(_initDelay);
       await plugin.prepareContext();
+      _emitStatus('gl_context_ready', 'OpenGL 上下文准备完成');
 
       if (!mounted || _disposed) {
         plugin.dispose();
@@ -118,6 +138,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
       _initRenderer(plugin, size, dpr);
       _initScene(size);
+      _emitStatus('scene_ready', 'Three 场景和灯光准备完成');
       widget.onProgress?.call(0.24);
 
       final model = await _loadBuddhaModel();
@@ -125,11 +146,13 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
 
       _fitAndRetuneModel(model);
       _scene!.add(model);
+      _emitStatus('model_attached', '佛像模型已挂载到 Three 场景');
       _updateCamera();
 
       _ready = true;
       _initializing = false;
       widget.onProgress?.call(1.0);
+      _emitStatus('ready', 'Android Three 渲染完成，可以展示佛像');
       widget.onReady?.call();
 
       if (mounted) {
@@ -211,21 +234,43 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
   }
 
   Future<three.Object3D> _loadBuddhaModel() async {
+    _emitStatus('bundled_glb_start', '开始读取打包 GLB');
     try {
       final bytes = await _loadBundledGlbBytes();
       widget.onProgress?.call(0.58);
-      return _parseGlbBytes(bytes);
+      _emitStatus(
+        'bundled_glb_ready',
+        '打包 GLB 校验通过，开始解析',
+        extra: {
+          'bytes': bytes.lengthInBytes,
+          'header': _formatHeader(bytes),
+        },
+      );
+      final model = await _parseGlbBytes(bytes);
+      _emitStatus('bundled_glb_parsed', '打包 GLB 解析完成');
+      return model;
     } catch (error) {
+      _emitStatus(
+        'bundled_glb_failed',
+        '打包 GLB 加载失败，切换远端 GLB',
+        extra: {'error': error},
+      );
       debugPrint(
         '⚠️ [BuddhaModel][three_dart] bundled GLB 加载失败，尝试远端 GLB: $error',
       );
     }
 
     widget.onProgress?.call(0.32);
+    _emitStatus(
+      'remote_glb_start',
+      '开始读取远端 GLB',
+      extra: {'url': AppConfig.legacyBuddhaGlbUrl},
+    );
     final loader = three_jsm.GLTFLoader();
     final result = await loader
         .loadAsync(AppConfig.legacyBuddhaGlbUrl)
         .timeout(_modelLoadTimeout);
+    _emitStatus('remote_glb_ready', '远端 GLB 下载和解析完成');
     return _extractScene(result);
   }
 
@@ -340,6 +385,10 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
       if (!kIsWeb && _sourceTexture != null) {
         unawaited(plugin.updateTexture(_sourceTexture));
       }
+      if (!_firstFrameLogged) {
+        _firstFrameLogged = true;
+        _emitStatus('first_frame', 'Android Three 首帧已经提交到纹理');
+      }
     } catch (error) {
       _fail('Android three_dart 渲染失败: $error');
     }
@@ -349,9 +398,34 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     if (_failed || _disposed) return;
     _failed = true;
     _ready = false;
+    _emitStatus('error', message, extra: {'failed': true});
     debugPrint('❌ [BuddhaModel][three_dart] $message');
     widget.onError?.call(message);
     if (mounted) setState(() {});
+  }
+
+  void _emitStatus(
+    String stage,
+    String message, {
+    Map<String, Object?> extra = const {},
+  }) {
+    final payload = <String, Object?>{
+      'stage': stage,
+      'elapsed_ms': _diagnosticStopwatch.elapsedMilliseconds,
+      ...extra,
+    };
+    final fields = payload.entries
+        .where((entry) => entry.value != null)
+        .map(
+          (entry) =>
+              '${entry.key}=${_normalizeDiagnosticValue(entry.value)}',
+        )
+        .join(' ');
+    debugPrint(
+      '[BuddhaDiag][android_three] $fields '
+      'message=${_normalizeDiagnosticValue(message)}',
+    );
+    widget.onStatus?.call(message);
   }
 
   static bool _isGlb(Uint8List bytes) {
@@ -368,6 +442,10 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
         .take(math.min(12, bytes.lengthInBytes))
         .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
         .join(' ');
+  }
+
+  static String _normalizeDiagnosticValue(Object? value) {
+    return value.toString().replaceAll(RegExp(r'\s+'), '_');
   }
 
   @override
@@ -387,6 +465,7 @@ class _AndroidThreeBuddhaViewState extends State<AndroidThreeBuddhaView> {
     _renderTarget?.dispose();
     _scene = null;
     _camera = null;
+    _diagnosticStopwatch.stop();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- reopen `#554` from the latest `main` with a smaller Android diagnostics slice instead of reviving the closed, diverged `#547`
- add a manual emulator workflow that captures Flutter test output plus full and filtered `logcat` artifacts for the AndroidThree Buddha path
- add staged `BuddhaDiag` status emission inside `AndroidThreeBuddhaView` so the workflow artifacts show where the fallback renderer stopped or succeeded
- add an integration test that exercises `AndroidThreeBuddhaView` directly on the emulator, keeping this step focused on runtime diagnostics rather than changing the app's primary Android render path

## Why this shape
`#554` explicitly tightened the next move to:
1. start again from the latest `main`
2. prioritize readable emulator logs and artifacts first
3. avoid mechanically reviving the older Android split or reintroducing a broader render-path switch

This PR keeps that boundary:
- only 3 files are touched
- no direct change to the app's current Android primary/fallback routing in `buddha_model_screen_native.dart`
- the new workflow is `workflow_dispatch` only, so it does not add noise to the regular PR path

## Risk review
- `#547` was not safe to continue directly because it had already diverged and bundled diagnostics with a broader Android render-path change
- this PR intentionally does **not** carry forward the old `buddha_model_screen_native.dart` behavior flip
- the only runtime code change is inside the existing AndroidThree fallback widget, where we now emit staged diagnostics without changing the mainline screen-routing contract
- the manual workflow and focused integration test are additive and isolated to the Android diagnostics lane

## Verification
- compare against `main` is scoped to:
  - `.github/workflows/android-buddha-loading-diagnostics.yml`
  - `fabushi/integration_test/buddha_loading_android_diagnostics_test.dart`
  - `fabushi/lib/screens/buddha_model_screen_android_three.dart`
- branch state before PR creation:
  - `ahead_by = 3`
  - `behind_by = 0`
- this environment still cannot dispatch GitHub Actions workflows directly, so the new manual diagnostics workflow has not been executed yet from here

## Expected follow-up after merge or review
- run `Android Buddha Loading Diagnostics` once on the branch or PR head
- inspect `buddha_flutter_test.log`, `buddha_logcat_full.log`, and `buddha_logcat_filtered.log`
- use the staged `BuddhaDiag` markers to decide whether the next Android step should stay in diagnostics, move to a UI hint follow-up, or address a concrete renderer failure

Closes #554