### PR TITLE
fix(forum): show verified live target bundle in summary

### DIFF
--- a/forum/scripts/resolve-live-deployment-target.mjs
+++ b/forum/scripts/resolve-live-deployment-target.mjs
@@ -30,6 +30,17 @@ function createPayload(target) {
   return JSON.stringify(target, null, 2);
 }
 
+function buildBundledLiveTarget(target) {
+  return {
+    forumUrl: target.forumUrl,
+    deploymentStage: target.deploymentStage,
+    publicBaseUrl: target.publicBaseUrl,
+    writesEnabled: target.writesEnabled,
+    requiresAccessCode: target.requiresAccessCode,
+    exerciseWriteFlow: target.exerciseWriteFlow,
+  };
+}
+
 function buildSkipNextStepLines(target) {
   return [
     "### How to unblock",
@@ -68,6 +79,22 @@ function buildSkipNextStepLines(target) {
   ];
 }
 
+function buildReadySaveLines(target) {
+  return [
+    "",
+    "### Save for hourly checks",
+    "",
+    "If this verified runtime should become the standing hourly target, save the bundled payload below into the repository variable `FORUM_LIVE_TARGET`:",
+    "",
+    "```json",
+    JSON.stringify(target.bundledTarget, null, 2),
+    "```",
+    target.requiresAccessCode
+      ? "Keep the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE` aligned with the preview write gate too."
+      : "No `FORUM_LIVE_WRITE_ACCESS_CODE` secret update is required for this posture.",
+  ];
+}
+
 function buildSummaryLines(target) {
   if (target.skip) {
     return [
@@ -94,6 +121,7 @@ function buildSummaryLines(target) {
     `- exercise_write_flow: ${String(target.exerciseWriteFlow)}`,
     `- request_timeout_ms: ${target.requestTimeoutMs}`,
     ...target.warnings.map((warning) => `- warning: ${warning}`),
+    ...buildReadySaveLines(target),
   ];
 }
 
@@ -298,6 +326,16 @@ async function main() {
     exerciseWriteFlow,
     requestTimeoutMs,
     warnings,
+    bundledTarget: buildBundledLiveTarget({
+      forumUrl,
+      deploymentStage,
+      publicBaseUrl,
+      writesEnabled,
+      requiresAccessCode,
+      exerciseWriteFlow,
+    }),
+    repositoryConfigTargets: ["FORUM_LIVE_TARGET"],
+    optionalSecretTargets: requiresAccessCode ? ["FORUM_LIVE_WRITE_ACCESS_CODE"] : [],
   };
 
   if (process.env.FORUM_LIVE_TARGET_PATH) {


### PR DESCRIPTION
## Summary
- extend `forum/scripts/resolve-live-deployment-target.mjs` so successful live-target resolution also emits the bundled hourly target payload directly into the workflow summary
- include the repository config targets in the resolved JSON payload so follow-up automation and operators can see that `FORUM_LIVE_TARGET` is the value to persist
- when preview writes still require the shared gate, remind the operator to keep `FORUM_LIVE_WRITE_ACCESS_CODE` aligned too

## Why now
The current deployment helper thread has already landed the repo-side skip guidance and production shortcuts. The remaining friction is now smaller and happens after a manual or scheduled live check has already resolved a real runtime posture:
- the job summary says the target is valid
- but it does not immediately surface the exact bundled payload that should become the standing hourly target
- so the first real preview or production handoff still leaves one avoidable lookup step before the operator can save `FORUM_LIVE_TARGET`

This keeps scope tight while making the first successful live check more actionable.

## Verification
- local equivalent run against the updated script shape with:
  - bundled preview target JSON
  - `FORUM_LIVE_WRITE_ACCESS_CODE`
  - `FORUM_LIVE_TARGET_PATH`
  - `GITHUB_STEP_SUMMARY`
- confirmed the resolved payload now includes:
  - `bundledTarget`
  - `repositoryConfigTargets`
  - `optionalSecretTargets`
- confirmed the generated summary now includes:
  - `### Save for hourly checks`
  - the exact bundled JSON for `FORUM_LIVE_TARGET`
  - the preview write-gate secret reminder when access-code mode is enabled

## Expected outcome after merge
- the next successful manual or scheduled live check will directly show the bundle that should be saved for hourly reuse
- first-time live-target handoff becomes easier to close out without bouncing back to helper docs or reconstructing the payload by hand