### PR TITLE
chore(web): sync official site beta state to mobile 303

### DIFF
--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -7,26 +7,25 @@
       "title": "Android Beta",
       "description": "官网直接读取最新发布版本的 APK 安装包，安装包发布后这里会自动更新。",
       "primaryLabel": "下载 Android Beta",
-      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-296-mobile.33e5d5f9d6f2/fabushi-android-arm64-33e5d5f9d6f2.apk",
-      "version": "v1.0.0-296-mobile.33e5d5f9d6f2",
-      "publishedAt": "2026-05-18T07:04:21Z",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-303-mobile.2605074f8f6d/fabushi-android-arm64-2605074f8f6d.apk",
+      "version": "v1.0.0-303-mobile.2605074f8f6d",
+      "publishedAt": "2026-05-18T11:55:54Z",
       "updateSummary": [
         "改进 Android 测试版下载与安装稳定性。",
-        "dart analyze lib/screens/buddha_model_screen_native.dart lib/core/config/app_config.dart",
-        "减少更新后仍显示旧内容的情况。"
+        "only 3 files are touched"
       ],
       "mirrorLinks": [
         {
           "label": "国内镜像 1",
-          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-296-mobile.33e5d5f9d6f2/fabushi-android-arm64-33e5d5f9d6f2.apk"
+          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-303-mobile.2605074f8f6d/fabushi-android-arm64-2605074f8f6d.apk"
         },
         {
           "label": "国内镜像 2",
-          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-296-mobile.33e5d5f9d6f2/fabushi-android-arm64-33e5d5f9d6f2.apk"
+          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-303-mobile.2605074f8f6d/fabushi-android-arm64-2605074f8f6d.apk"
         }
       ],
       "note": "国内访问较慢时，可以优先尝试镜像下载入口。",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-296-mobile.33e5d5f9d6f2"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-303-mobile.2605074f8f6d"
     },
     {
       "platform": "iOS",
@@ -36,21 +35,41 @@
       "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
       "primaryLabel": "加入 iOS TestFlight",
       "primaryHref": "https://testflight.apple.com/join/98KFgV2z",
-      "version": "296",
-      "publishedAt": "2026-05-18T07:02:23Z",
+      "version": "303",
+      "publishedAt": "2026-05-18T11:55:26Z",
       "updateSummary": [
         "改进 Android 测试版下载与安装稳定性。",
-        "dart analyze lib/screens/buddha_model_screen_native.dart lib/core/config/app_config.dart",
-        "减少更新后仍显示旧内容的情况。"
+        "only 3 files are touched"
       ],
       "mirrorLinks": [],
       "note": "",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-296-mobile.33e5d5f9d6f2"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-303-mobile.2605074f8f6d"
     }
   ],
   "stableChannels": [],
   "screenshots": {},
   "releases": [
+    {
+      "tag": "v1.0.0-303-mobile.2605074f8f6d",
+      "title": "Fabushi mobile 1.0.0+303 (2605074f8f6d)",
+      "publishedAt": "2026-05-18T11:55:54Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-303-mobile.2605074f8f6d",
+      "summary": [
+        "改进 Android 测试版下载与安装稳定性。",
+        "only 3 files are touched"
+      ]
+    },
+    {
+      "tag": "v1.0.0-301-mobile.fe630b9fc1f1",
+      "title": "Fabushi mobile 1.0.0+301 (fe630b9fc1f1)",
+      "publishedAt": "2026-05-18T11:08:37Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-301-mobile.fe630b9fc1f1",
+      "summary": [
+        "改进 Android 测试版下载与安装稳定性。",
+        "Move the online count affordance out of the Buddha area and use a people icon",
+        "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
+      ]
+    },
     {
       "tag": "v1.0.0-296-mobile.33e5d5f9d6f2",
       "title": "Fabushi mobile 1.0.0+296 (33e5d5f9d6f2)",
@@ -79,31 +98,6 @@
       "summary": [
         "改进 Android 测试版下载与安装稳定性。",
         "Three 链路失败时，自动回退到 flutter_scene 备用渲染"
-      ]
-    },
-    {
-      "tag": "v1.0.0-208-mobile.56c0652a910d",
-      "title": "Fabushi mobile 1.0.0+208 (56c0652a910d)",
-      "publishedAt": "2026-05-16T13:53:58Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-208-mobile.56c0652a910d",
-      "summary": [
-        "改进 Android 测试版下载与安装稳定性。",
-        "失败页现在展示原生 .model 与兼容 GLB 的具体失败阶段；资源校验也会带上 HTTP URL 和首字节签名，方便判断是否拿到了 GLB、HTML 错误页或错误 R2 对象。",
-        "flutter test --no-pub test/unit/core/app_config_buddha_model_test.dart test/unit/services/asset_loader_service_test.dart",
-        "flutter analyze --no-pub lib/screens/buddha_model_screen_native.dart lib/services/asset_loader_service.dart lib/core/config/app_config.dart test/unit/core/app_config_buddha_model_test.dart",
-        "node --check fabushi/assets/buddha_fallback/buddha_fallback.js"
-      ]
-    },
-    {
-      "tag": "v1.0.0-190-mobile.9c1e747f7d76",
-      "title": "Fabushi mobile 1.0.0+190 (9c1e747f7d76)",
-      "publishedAt": "2026-05-16T07:45:09Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-190-mobile.9c1e747f7d76",
-      "summary": [
-        "改进 Android 测试版下载与安装稳定性。",
-        "失败任务：:integration_test:mapReleaseSourceSetPaths",
-        "当前 app 配置的 NDK 还是 27.0.12077973",
-        "但 integration_test 已明确要求 28.2.13676358"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- sync `frontend/apps/web/public/api/releases.json` from `automation/sync-official-site-beta-state` back onto `main`
- update the public Android beta download entry from `v1.0.0-296-mobile.33e5d5f9d6f2` to `v1.0.0-303-mobile.2605074f8f6d`
- update the public iOS TestFlight beta status from version `296` to `303`

## Why now
The repository currently has an actionable release-state drift:
- `main` still serves the older public beta snapshot (`296`)
- `automation/sync-official-site-beta-state` is `ahead_by = 1` and `behind_by = 0`
- there is no open PR carrying that state back to `main`

This PR closes that gap without reopening any broader release-automation design thread.

## Scope
- only `frontend/apps/web/public/api/releases.json`
- no runtime code changes
- no workflow logic changes

## Current evidence
- `main` currently publishes:
  - Android beta `v1.0.0-296-mobile.33e5d5f9d6f2`
  - Android `publishedAt = 2026-05-18T07:04:21Z`
  - iOS TestFlight public `version = 296`
  - iOS `publishedAt = 2026-05-18T07:02:23Z`
- automation branch already carries the newer public state:
  - Android beta `v1.0.0-303-mobile.2605074f8f6d`
  - Android `publishedAt = 2026-05-18T11:55:54Z`
  - iOS TestFlight public `version = 303`
  - iOS `publishedAt = 2026-05-18T11:55:26Z`

## Risk review
- branch compare is clean: `ahead_by = 1`, `behind_by = 0`
- diff scope is limited to the generated public release-state JSON
- no merge conflict risk is visible from the current compare snapshot

## Expected outcome after merge
- the official site beta state on `main` will catch up to the already-published mobile `303` release
- Android APK and iOS TestFlight public status will stop lagging behind the latest release metadata