### PR TITLE
test(forum): cover ready live-target summary in deploy checks

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -135,12 +135,24 @@ jobs:
 
       - name: Validate bundled live target sample
         run: |
+          rm -f /tmp/forum-live-target-resolved.json /tmp/forum-live-target-ready-summary.md
+
           export FORUM_LIVE_TARGET="$(cat /tmp/forum-live-target.json)"
           export FORUM_LIVE_WRITE_ACCESS_CODE=forum-preview-2026
           export FORUM_LIVE_TARGET_PATH=/tmp/forum-live-target-resolved.json
+          export GITHUB_STEP_SUMMARY=/tmp/forum-live-target-ready-summary.md
 
           node forum/scripts/resolve-live-deployment-target.mjs
           cat /tmp/forum-live-target-resolved.json
+          cat /tmp/forum-live-target-ready-summary.md
+
+          node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync("/tmp/forum-live-target-resolved.json", "utf8")); const expected = JSON.parse(fs.readFileSync("/tmp/forum-live-target.json", "utf8")); if (!(data.skip === false && data.forumUrl === "https://forum-preview.fabushi.test" && data.deploymentStage === "preview" && data.writesEnabled === true && data.requiresAccessCode === true && data.exerciseWriteFlow === true && JSON.stringify(data.bundledTarget) === JSON.stringify(expected) && Array.isArray(data.repositoryConfigTargets) && data.repositoryConfigTargets.includes("FORUM_LIVE_TARGET") && Array.isArray(data.optionalSecretTargets) && data.optionalSecretTargets.includes("FORUM_LIVE_WRITE_ACCESS_CODE"))) { console.error(JSON.stringify(data, null, 2)); process.exit(1); }'
+          grep --fixed-strings "### Save for hourly checks" /tmp/forum-live-target-ready-summary.md
+          grep --fixed-strings "FORUM_LIVE_TARGET" /tmp/forum-live-target-ready-summary.md
+          grep --fixed-strings '"forumUrl": "https://forum-preview.fabushi.test"' /tmp/forum-live-target-ready-summary.md
+          grep --fixed-strings '"deploymentStage": "preview"' /tmp/forum-live-target-ready-summary.md
+          grep --fixed-strings '"requiresAccessCode": true' /tmp/forum-live-target-ready-summary.md
+          grep --fixed-strings 'Keep the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE` aligned with the preview write gate too.' /tmp/forum-live-target-ready-summary.md
 
       - name: Validate skipped live target guidance
         run: |


### PR DESCRIPTION
## Summary
- extend `Deploy compose checks - Forum` so the bundled live-target validation also exercises the ready-path job summary written by `resolve-live-deployment-target.mjs`
- assert the resolved JSON keeps exposing the bundled target plus the repository variable / secret targets introduced by the latest handoff guidance work
- assert the generated summary still includes `Save for hourly checks`, the bundled `FORUM_LIVE_TARGET` payload, and the preview write-gate secret reminder

## Why now
`PR #561` already landed the operator-facing ready summary for successful live-target resolution. That closed the user-facing friction, but the repo-side coverage was still asymmetric:
- skipped guidance already had explicit CI assertions
- ready-path JSON and summary output were only being printed, not checked
- so the new hourly handoff guidance could drift silently in future helper edits

This keeps scope tight and protects the most recent deployment-guidance improvement without reopening the broader live-target helper thread.

## What changed
- update the existing `Validate bundled live target sample` step in `.github/workflows/forum-deploy-compose-checks.yml`
- capture `GITHUB_STEP_SUMMARY` into a temp file during the ready-path sample run
- assert the resolved payload still includes:
  - `bundledTarget`
  - `repositoryConfigTargets`
  - `optionalSecretTargets`
- assert the summary still includes:
  - `### Save for hourly checks`
  - `FORUM_LIVE_TARGET`
  - the expected bundled preview payload fields
  - the `FORUM_LIVE_WRITE_ACCESS_CODE` reminder for writable preview posture

## Verification
- branch scope is limited to one workflow file:
  - `.github/workflows/forum-deploy-compose-checks.yml`
- no runtime forum code changed
- final validation is delegated to repository CI on this PR because this environment does not have a live checkout of `bhrumom/fabushi`

## Expected outcome after merge
- the newest ready-path live-target guidance will be protected the same way the skipped-path guidance already is
- future changes to `resolve-live-deployment-target.mjs` are more likely to fail fast in CI if they break the hourly handoff summary contract
