### PR TITLE
test(forum): cover split live-target fallback in deploy checks

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -154,6 +154,30 @@ jobs:
           grep --fixed-strings '"requiresAccessCode": true' /tmp/forum-live-target-ready-summary.md
           grep --fixed-strings 'Keep the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE` aligned with the preview write gate too.' /tmp/forum-live-target-ready-summary.md
 
+      - name: Validate split live target fallback sample
+        run: |
+          rm -f /tmp/forum-live-target-split.json /tmp/forum-live-target-split-summary.md
+
+          export FORUM_LIVE_URL=https://forum.fabushi.test
+          export FORUM_LIVE_DEPLOYMENT_STAGE=production
+          export FORUM_LIVE_PUBLIC_BASE_URL=https://forum.fabushi.test
+          export FORUM_LIVE_WRITES_ENABLED=false
+          export FORUM_LIVE_REQUIRES_ACCESS_CODE=false
+          export FORUM_LIVE_EXERCISE_WRITE_FLOW=false
+          export FORUM_LIVE_TARGET_PATH=/tmp/forum-live-target-split.json
+          export GITHUB_STEP_SUMMARY=/tmp/forum-live-target-split-summary.md
+
+          node forum/scripts/resolve-live-deployment-target.mjs
+          cat /tmp/forum-live-target-split.json
+          cat /tmp/forum-live-target-split-summary.md
+
+          node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync("/tmp/forum-live-target-split.json", "utf8")); const expected = { forumUrl: "https://forum.fabushi.test", deploymentStage: "production", publicBaseUrl: "https://forum.fabushi.test", writesEnabled: false, requiresAccessCode: false, exerciseWriteFlow: false }; if (!(data.skip === false && data.forumUrl === expected.forumUrl && data.deploymentStage === expected.deploymentStage && data.publicBaseUrl === expected.publicBaseUrl && data.writesEnabled === expected.writesEnabled && data.requiresAccessCode === expected.requiresAccessCode && data.exerciseWriteFlow === expected.exerciseWriteFlow && JSON.stringify(data.bundledTarget) === JSON.stringify(expected) && Array.isArray(data.repositoryConfigTargets) && data.repositoryConfigTargets.includes("FORUM_LIVE_TARGET") && Array.isArray(data.optionalSecretTargets) && data.optionalSecretTargets.length === 0)) { console.error(JSON.stringify(data, null, 2)); process.exit(1); }'
+          grep --fixed-strings "### Save for hourly checks" /tmp/forum-live-target-split-summary.md
+          grep --fixed-strings "FORUM_LIVE_TARGET" /tmp/forum-live-target-split-summary.md
+          grep --fixed-strings '"deploymentStage": "production"' /tmp/forum-live-target-split-summary.md
+          grep --fixed-strings '"requiresAccessCode": false' /tmp/forum-live-target-split-summary.md
+          grep --fixed-strings 'No `FORUM_LIVE_WRITE_ACCESS_CODE` secret update is required for this posture.' /tmp/forum-live-target-split-summary.md
+
       - name: Validate skipped live target guidance
         run: |
           rm -f /tmp/forum-live-target-skip.json /tmp/forum-live-target-skip-summary.md


### PR DESCRIPTION
## Summary
- extend `Deploy compose checks - Forum` with a split-variable live-target sample that exercises the ready path without `FORUM_LIVE_TARGET`
- assert `resolve-live-deployment-target.mjs` still rebuilds the bundled payload, repository target list, and no-secret-ready summary from the legacy `FORUM_LIVE_*` variables
- keep the scope to one workflow file so this stays a CI contract follow-up, not a new helper thread

## Why now
The current deployment handoff work has already moved the repo toward the bundled `FORUM_LIVE_TARGET` path, and CI now covers:
- skipped guidance
- bundled ready-path summary output

But the repository still documents and supports the older split variable path for backward compatibility, and the scheduled workflow still exports those inputs when no bundled target exists.

That means there is still one small but real repo-side gap:
- if future helper edits break split-variable fallback, the hourly workflow could drift even though the bundled path still passes
- the first real handoff may still start from split variables before a standing bundled target has been saved

This PR closes that compatibility gap with the smallest possible check.

## What changed
- add `Validate split live target fallback sample` to `.github/workflows/forum-deploy-compose-checks.yml`
- resolve a production posture from split `FORUM_LIVE_*` variables only
- assert the resolved JSON still includes:
  - `bundledTarget`
  - `repositoryConfigTargets`
  - an empty `optionalSecretTargets` array for the no-access-code posture
- assert the generated summary still includes:
  - `### Save for hourly checks`
  - `FORUM_LIVE_TARGET`
  - the expected production bundled payload fields
  - the no-secret reminder for postures that do not need `FORUM_LIVE_WRITE_ACCESS_CODE`

## Verification
- compare against `main` is scoped to one file only:
  - `.github/workflows/forum-deploy-compose-checks.yml`
- final verification is delegated to repository CI on this PR because this environment does not have a live checkout of `bhrumom/fabushi`

## Expected outcome after merge
- the repo will keep covering both supported live-target entry shapes instead of only the newer bundled path
- future changes to `resolve-live-deployment-target.mjs` are more likely to fail fast if they silently break the compatibility path that still matters before the first real bundled handoff is saved