### PR TITLE
test(forum): cover preview direct handoff in deploy checks

### DIFF
--- a/.github/workflows/forum-deploy-compose-checks.yml
+++ b/.github/workflows/forum-deploy-compose-checks.yml
@@ -371,6 +371,33 @@ jobs:
           grep "secret set FORUM_LIVE_WRITE_ACCESS_CODE --body" /tmp/forum-gh-invocations.txt
           grep -- "--repo bhrumom/fabushi" /tmp/forum-gh-invocations.txt
 
+      - name: Handoff writable preview live target directly from deploy env check URL
+        run: |
+          rm -f /tmp/forum-preview-direct-handoff-gh-invocations.txt /tmp/forum-preview-direct-handoff-report.json
+          mkdir -p /tmp/forum-mock-gh-bin-preview-direct
+          cat <<'GHEOF' >/tmp/forum-mock-gh-bin-preview-direct/gh
+          #!/usr/bin/env bash
+          printf '%s\n' "$*" >> /tmp/forum-preview-direct-handoff-gh-invocations.txt
+          GHEOF
+          chmod +x /tmp/forum-mock-gh-bin-preview-direct/gh
+          : >/tmp/forum-preview-direct-handoff-gh-invocations.txt
+
+          PATH="/tmp/forum-mock-gh-bin-preview-direct:$PATH" \
+          node forum/scripts/handoff-live-deployment-target.mjs \
+            --deploy-env-path /tmp/forum-deploy-writable-preview.env \
+            --exercise-write-flow true \
+            --apply-github-live-target true \
+            --report-path /tmp/forum-preview-direct-handoff-report.json \
+            2>&1 | tee /tmp/forum-preview-direct-handoff.txt
+
+          grep --fixed-strings "gh variable set FORUM_LIVE_TARGET --body '{\"forumUrl\":\"http://127.0.0.1:3001\",\"deploymentStage\":\"preview\",\"publicBaseUrl\":\"\",\"writesEnabled\":true,\"requiresAccessCode\":true,\"exerciseWriteFlow\":true}' --repo 'bhrumom/fabushi'" /tmp/forum-preview-direct-handoff.txt
+          grep "Applied FORUM_LIVE_TARGET to GitHub repo bhrumom/fabushi." /tmp/forum-preview-direct-handoff.txt
+          test -f /tmp/forum-preview-direct-handoff-report.json
+          cat /tmp/forum-preview-direct-handoff-report.json
+          node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync("/tmp/forum-preview-direct-handoff-report.json", "utf8")); if (!(data.ok === true && data.forumUrl === "http://127.0.0.1:3001" && data.deploymentStage === "preview" && data.indexingEnabled === false && data.writesEnabled === true && data.requiresAccessCode === true && data.exerciseWriteFlow === true && data.liveWriteVerification && data.liveWriteVerification.threadSlug)) { console.error(JSON.stringify(data, null, 2)); process.exit(1); }'
+          grep --fixed-strings "variable set FORUM_LIVE_TARGET --body {\"forumUrl\":\"http://127.0.0.1:3001\",\"deploymentStage\":\"preview\",\"publicBaseUrl\":\"\",\"writesEnabled\":true,\"requiresAccessCode\":true,\"exerciseWriteFlow\":true} --repo bhrumom/fabushi" /tmp/forum-preview-direct-handoff-gh-invocations.txt
+          grep --fixed-strings "secret set FORUM_LIVE_WRITE_ACCESS_CODE --body forum-preview-2026 --repo bhrumom/fabushi" /tmp/forum-preview-direct-handoff-gh-invocations.txt
+
       - name: Stop forum deploy compose writable preview runtime
         run: |
           COMPOSE_PROJECT_NAME=fabushi-forum-deploy-check \


### PR DESCRIPTION
## Summary
- extend `Deploy compose checks - Forum` with one more writable-preview contract check that exercises `handoff-live-deployment-target.mjs` directly from `.env.deploy`
- prove the documented preview path still works without an explicit `--forum-url` when `FORUM_DEPLOY_CHECK_URL` is already present
- keep the scope to one workflow file so this stays a deployment-contract follow-up instead of reopening helper design

## Why now
`forum/DEPLOY.md` now documents a shorter preview host flow:
- once `.env.deploy` already carries `FORUM_DEPLOY_CHECK_URL`
- `pnpm handoff:live-target -- --deploy-env-path .env.deploy`
- should be enough to re-smoke the live runtime and sync the verified hourly target

The repo already covers nearby paths:
- `prepare-live-deployment-vars.mjs` infers preview targets from `FORUM_DEPLOY_CHECK_URL`
- `rollout-deploy-env.mjs` can boot writable preview and auto-handoff the live target
- production direct handoff from `FORUM_PUBLIC_BASE_URL` is explicitly covered too

But the direct preview `handoff-live-deployment-target.mjs` entrypoint itself was still uncovered. That meant the first real host-side hourly sync path described in the docs could still drift silently even though adjacent helpers passed.

## What changed
- update `.github/workflows/forum-deploy-compose-checks.yml`
- keep the existing writable preview runtime running after the combined rollout check
- add `Handoff writable preview live target directly from deploy env check URL`
- run `handoff-live-deployment-target.mjs` with:
  - `--deploy-env-path /tmp/forum-deploy-writable-preview.env`
  - `--exercise-write-flow true`
  - `--apply-github-live-target true`
  - no explicit `--forum-url`
- assert the step still:
  - smokes the writable preview runtime successfully
  - emits the expected bundled `FORUM_LIVE_TARGET` payload for `http://127.0.0.1:3001`
  - syncs the preview write-gate secret command
  - records a report with live thread-and-reply verification

## Verification
- compare against `main` is scoped to one file only:
  - `.github/workflows/forum-deploy-compose-checks.yml`
- branch compare before PR creation:
  - `ahead_by = 1`
  - `behind_by = 0`
- final validation is delegated to repository CI on this PR because this environment does not have a local checkout of `bhrumom/fabushi`

## Expected outcome after merge
- the repo will explicitly protect the documented preview direct-handoff path, not just the lower-level prepare helper and the higher-level rollout wrapper
- the first real preview host-side handoff should be less likely to surprise us with an uncovered compatibility gap
- if a future helper edit breaks preview handoff inference from `FORUM_DEPLOY_CHECK_URL`, CI should fail fast in the deploy-contract lane
