### PR TITLE
fix(forum): make rollout skip point to live handoff

### DIFF
--- a/forum/scripts/rollout-deploy-env.mjs
+++ b/forum/scripts/rollout-deploy-env.mjs
@@ -98,7 +98,7 @@ function resolveHandoffUrl({ explicitForumUrl, deployEnv }) {
 }
 
 function renderCommandBlock(command, args) {
-  const continuation = " \\\";
+  const continuation = ` ${String.fromCharCode(92)}`;
   const lines = ["cd forum", `${command} --${continuation}`];
 
   args.forEach((arg, index) => {

--- a/forum/scripts/rollout-deploy-env.mjs
+++ b/forum/scripts/rollout-deploy-env.mjs
@@ -98,10 +98,11 @@ function resolveHandoffUrl({ explicitForumUrl, deployEnv }) {
 }
 
 function renderCommandBlock(command, args) {
-  const lines = ["cd forum", `${command} -- \\`];
+  const continuation = " \\\";
+  const lines = ["cd forum", `${command} --${continuation}`];
 
   args.forEach((arg, index) => {
-    const suffix = index === args.length - 1 ? "" : " \\\";
+    const suffix = index === args.length - 1 ? "" : continuation;
     lines.push(`  ${arg}${suffix}`);
   });
 

--- a/forum/scripts/rollout-deploy-env.mjs
+++ b/forum/scripts/rollout-deploy-env.mjs
@@ -97,6 +97,63 @@ function resolveHandoffUrl({ explicitForumUrl, deployEnv }) {
   return "";
 }
 
+function renderCommandBlock(command, args) {
+  const lines = ["cd forum", `${command} -- \\`];
+
+  args.forEach((arg, index) => {
+    const suffix = index === args.length - 1 ? "" : " \\\";
+    lines.push(`  ${arg}${suffix}`);
+  });
+
+  return lines.join("\n");
+}
+
+function buildSkippedHandoffCommand({ deployEnvPath, exerciseWriteFlow, applyGithubLiveTarget }) {
+  const args = [
+    "--forum-url https://forum-preview.example.com",
+    `--deploy-env-path ${deployEnvPath}`,
+  ];
+
+  if (exerciseWriteFlow) {
+    args.push("--exercise-write-flow true");
+  }
+
+  if (applyGithubLiveTarget) {
+    args.push("--apply-github-live-target true");
+  }
+
+  return renderCommandBlock("pnpm handoff:live-target", args);
+}
+
+function logSkippedHandoffGuidance({ deployEnvPath, deployEnv, exerciseWriteFlow, applyGithubLiveTarget }) {
+  const deploymentStage = deployEnv.FORUM_DEPLOYMENT_STAGE?.trim() || "preview";
+
+  console.log(
+    "Skipping handoff because neither --forum-url, FORUM_DEPLOY_CHECK_URL, nor a production FORUM_PUBLIC_BASE_URL is available yet. Re-run with the real preview or production URL once it exists.",
+  );
+  console.log("");
+  console.log(
+    "The local rollout already completed and passed the host-side smoke check. The remaining step is only to bind that verified runtime to a real external URL for hourly checks.",
+  );
+  console.log("");
+  console.log("Once the runtime is reachable at its real preview or production URL, run:");
+  console.log("");
+  console.log(buildSkippedHandoffCommand({ deployEnvPath, exerciseWriteFlow, applyGithubLiveTarget }));
+  console.log("");
+
+  if (deploymentStage === "production") {
+    console.log(
+      "If this is intended to become the final production origin, save that URL as FORUM_PUBLIC_BASE_URL in .env.deploy so future handoffs can stay fully deploy-env driven.",
+    );
+  } else {
+    console.log(
+      "If this preview host will keep the same external URL, save it as FORUM_DEPLOY_CHECK_URL in .env.deploy so future handoffs can omit --forum-url.",
+    );
+  }
+
+  console.log("Guide: forum/DEPLOY.md");
+}
+
 function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -439,9 +496,12 @@ async function main() {
     }
 
     console.log("\n== Hourly live target handoff ==");
-    console.log(
-      "Skipping handoff because neither --forum-url, FORUM_DEPLOY_CHECK_URL, nor a production FORUM_PUBLIC_BASE_URL is available yet. Re-run with the real preview or production URL once it exists.",
-    );
+    logSkippedHandoffGuidance({
+      deployEnvPath,
+      deployEnv,
+      exerciseWriteFlow,
+      applyGithubLiveTarget: true,
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary
- make `forum/scripts/rollout-deploy-env.mjs` print an actionable handoff command when a fresh host rollout succeeds locally but still cannot sync `FORUM_LIVE_TARGET`
- explain the remaining gap in plain language: the runtime is healthy locally, but the first real external URL handoff is still missing
- point preview and production operators back to the right deploy-env field so future handoffs can stay more automatic

## Why now
`PR #569` closed the last repo-side coverage gap around direct preview handoff from `.env.deploy`. That means the main remaining friction inside the repository is no longer helper correctness deeper in the stack; it is the moment right after a successful first host-side rollout when no real preview or production URL has been wired yet.

Today that path still does the important technical work:
- scaffold when needed
- boot compose
- wait for health
- smoke-check the local runtime

But when handoff cannot continue, it only says that it was skipped. The operator still has to reconstruct the exact next command from memory or from `forum/DEPLOY.md`. This PR keeps scope tight and makes that first post-rollout moment more executable.

## What changed
- update `forum/scripts/rollout-deploy-env.mjs`
- add a small command renderer for multi-line follow-up commands
- when auto handoff is skipped because neither `--forum-url`, `FORUM_DEPLOY_CHECK_URL`, nor production `FORUM_PUBLIC_BASE_URL` is available yet:
  - print a concrete `pnpm handoff:live-target -- ...` follow-up command
  - keep `--exercise-write-flow true` in the suggested command when the rollout was validating writable preview
  - recommend saving the eventual external URL back into:
    - `FORUM_DEPLOY_CHECK_URL` for preview
    - `FORUM_PUBLIC_BASE_URL` for production
  - point back to `forum/DEPLOY.md`

## Verification
- local syntax check on the updated helper shape:
  - `node --check /tmp/rollout-deploy-env.mjs`
- compare against `main` is scoped to one file only:
  - `forum/scripts/rollout-deploy-env.mjs`
- final end-to-end verification remains with repository CI on this PR because this environment does not have a live checkout of `bhrumom/fabushi`

## Expected outcome after merge
- the first fresh preview host rollout will end with the next real handoff command already printed, instead of a generic skip line
- operators should be less likely to stall between “the runtime booted locally” and “the hourly live target is now wired”
- this keeps the deployment thread moving toward the real external preview/production handoff instead of reopening broader helper redesign
