### PR TITLE
fix(forum): add gh sync command to live target summary

### DIFF
--- a/.github/workflows/forum-live-deployment-checks.yml
+++ b/.github/workflows/forum-live-deployment-checks.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
+      FORUM_LIVE_GITHUB_REPO: ${{ github.repository }}
       FORUM_LIVE_REQUEST_TIMEOUT_MS: "15000"
       FORUM_LIVE_TARGET_PATH: /tmp/forum-live-target.json
       FORUM_LIVE_WRITE_ACCESS_CODE: ${{ secrets.FORUM_LIVE_WRITE_ACCESS_CODE }}

--- a/forum/scripts/resolve-live-deployment-target.mjs
+++ b/forum/scripts/resolve-live-deployment-target.mjs
@@ -93,7 +93,7 @@ function buildSkipNextStepLines(target) {
     "```",
     "",
     "That generic rollout command can scaffold `.env.deploy`, validate the deploy posture, bring the compose stack up, wait for health, and smoke-check the runtime.",
-    `That generic handoff command re-validates .env.deploy, smoke-checks the live runtime, and syncs \`FORUM_LIVE_TARGET\` back to \`${target.githubRepo}\`.`,
+    `That generic handoff command re-validates .env.deploy, smoke-checks the live runtime, and syncs FORUM_LIVE_TARGET back to ${target.githubRepo}.`,
     "For preview, the shorter handoff command above can stay deploy-env driven once `.env.deploy` already declares `FORUM_DEPLOY_CHECK_URL`.",
     "For production, the shorter commands above can stay fully deploy-env driven once `.env.deploy` already declares the final `FORUM_PUBLIC_BASE_URL`.",
     "With `--apply-github-live-target true`, writable preview can also sync `FORUM_LIVE_WRITE_ACCESS_CODE`.",

--- a/forum/scripts/resolve-live-deployment-target.mjs
+++ b/forum/scripts/resolve-live-deployment-target.mjs
@@ -41,6 +41,23 @@ function buildBundledLiveTarget(target) {
   };
 }
 
+function quoteForSingleQuotedShell(value) {
+  return value.replace(/'/g, "'\"'\"'");
+}
+
+function buildGithubRepoArg(githubRepo) {
+  if (!githubRepo) {
+    return "";
+  }
+
+  return ` --repo '${quoteForSingleQuotedShell(githubRepo)}'`;
+}
+
+function buildBundledTargetGithubVariableCommand(target) {
+  const bundledTargetJson = JSON.stringify(target.bundledTarget);
+  return `gh variable set FORUM_LIVE_TARGET --body '${quoteForSingleQuotedShell(bundledTargetJson)}'${buildGithubRepoArg(target.githubRepo)}`;
+}
+
 function buildSkipNextStepLines(target) {
   return [
     "### How to unblock",
@@ -76,7 +93,7 @@ function buildSkipNextStepLines(target) {
     "```",
     "",
     "That generic rollout command can scaffold `.env.deploy`, validate the deploy posture, bring the compose stack up, wait for health, and smoke-check the runtime.",
-    "That generic handoff command re-validates `.env.deploy`, smoke-checks the live runtime, and syncs `FORUM_LIVE_TARGET` back to `bhrumom/fabushi`.",
+    `That generic handoff command re-validates .env.deploy, smoke-checks the live runtime, and syncs \`FORUM_LIVE_TARGET\` back to \`${target.githubRepo}\`.`,
     "For preview, the shorter handoff command above can stay deploy-env driven once `.env.deploy` already declares `FORUM_DEPLOY_CHECK_URL`.",
     "For production, the shorter commands above can stay fully deploy-env driven once `.env.deploy` already declares the final `FORUM_PUBLIC_BASE_URL`.",
     "With `--apply-github-live-target true`, writable preview can also sync `FORUM_LIVE_WRITE_ACCESS_CODE`.",
@@ -96,8 +113,14 @@ function buildReadySaveLines(target) {
     "```json",
     JSON.stringify(target.bundledTarget, null, 2),
     "```",
+    "",
+    "If `gh` is already authenticated on a trusted shell, you can sync the same verified bundle directly with:",
+    "",
+    "```bash",
+    target.recommendedRepositoryCommand,
+    "```",
     target.requiresAccessCode
-      ? "Keep the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE` aligned with the preview write gate too."
+      ? "Keep the repository secret `FORUM_LIVE_WRITE_ACCESS_CODE` aligned with the preview write gate too. This summary intentionally does not print the secret value."
       : "No `FORUM_LIVE_WRITE_ACCESS_CODE` secret update is required for this posture.",
   ];
 }
@@ -186,6 +209,7 @@ function resolveConfigValue({ bundledValue, envValue, normalize = (value) => val
 
 async function main() {
   const source = process.env.FORUM_LIVE_SOURCE || "scheduled";
+  const githubRepo = process.env.FORUM_LIVE_GITHUB_REPO?.trim() || "bhrumom/fabushi";
   const bundledTarget = parseBundledTarget(process.env.FORUM_LIVE_TARGET || "");
   const forumUrl = normalizeUrl(
     resolveConfigValue({
@@ -198,6 +222,7 @@ async function main() {
   if (!forumUrl) {
     const skippedTarget = {
       source,
+      githubRepo,
       skip: true,
       reason: "No forum URL configured for scheduled live deployment checks.",
       missingConfig: ["FORUM_LIVE_TARGET or FORUM_LIVE_URL"],
@@ -328,8 +353,18 @@ async function main() {
     warnings.push("production checks are running without FORUM_LIVE_PUBLIC_BASE_URL, so the live forum is expected to stay noindex.");
   }
 
+  const bundledTargetPayload = buildBundledLiveTarget({
+    forumUrl,
+    deploymentStage,
+    publicBaseUrl,
+    writesEnabled,
+    requiresAccessCode,
+    exerciseWriteFlow,
+  });
+
   const resolvedTarget = {
     source,
+    githubRepo,
     skip: false,
     forumUrl,
     deploymentStage,
@@ -339,13 +374,10 @@ async function main() {
     exerciseWriteFlow,
     requestTimeoutMs,
     warnings,
-    bundledTarget: buildBundledLiveTarget({
-      forumUrl,
-      deploymentStage,
-      publicBaseUrl,
-      writesEnabled,
-      requiresAccessCode,
-      exerciseWriteFlow,
+    bundledTarget: bundledTargetPayload,
+    recommendedRepositoryCommand: buildBundledTargetGithubVariableCommand({
+      bundledTarget: bundledTargetPayload,
+      githubRepo,
     }),
     repositoryConfigTargets: ["FORUM_LIVE_TARGET"],
     optionalSecretTargets: requiresAccessCode ? ["FORUM_LIVE_WRITE_ACCESS_CODE"] : [],


### PR DESCRIPTION
## Summary
- make the live-target ready summary print the exact `gh variable set FORUM_LIVE_TARGET ...` command that matches the verified runtime
- keep preview write-gate guidance in the summary without ever printing the secret value itself
- pass the current repository name into the hourly workflow so the printed sync command always points at the active repo

## Why now
The deployment thread has already closed the bigger helper and coverage gaps around rollout, handoff, bundled targets, and split fallback. The next smallest repo-side friction is now the moment right after a successful live verification: the workflow summary shows the bundled JSON, but the operator still has to reconstruct the next `gh variable set FORUM_LIVE_TARGET ...` command from memory or from helper docs.

That means the runtime can already be proven healthy while the final repository sync step still carries unnecessary manual friction. This PR keeps scope tight and makes that first success state more executable.

## What changed
- update `forum/scripts/resolve-live-deployment-target.mjs`
- add a bundled-target GitHub CLI renderer for the ready summary
- include `recommendedRepositoryCommand` in the resolved payload for ready targets
- keep the existing preview write-gate reminder, but explicitly avoid printing the secret value into the workflow summary
- update `.github/workflows/forum-live-deployment-checks.yml` to pass `FORUM_LIVE_GITHUB_REPO=${{ github.repository }}` so the summary command always targets the current repository

## Verification
- compare against `main` is scoped to 2 files only:
  - `.github/workflows/forum-live-deployment-checks.yml`
  - `forum/scripts/resolve-live-deployment-target.mjs`
- no local checkout of `bhrumom/fabushi` is available in this environment, so final validation is delegated to repository CI on this PR

## Expected outcome after merge
- the first successful live verification run will end with both the bundled payload and the exact `gh variable set FORUM_LIVE_TARGET ...` command already printed
- operators should be less likely to stall between “the runtime verified successfully” and “the hourly target is now synced”
- preview write-gate runs still remind operators to keep `FORUM_LIVE_WRITE_ACCESS_CODE` aligned, without leaking the secret into the summary
