### PR TITLE
fix(web): bootstrap legacy tables before owned-data backfill migration

### DIFF
--- a/fabushi/web/migrations/20260519_owned_data_user_id.sql
+++ b/fabushi/web/migrations/20260519_owned_data_user_id.sql
@@ -1,6 +1,69 @@
 -- Backfill stable users.id ownership columns for mutable-username data.
 -- This migration is for D1 databases that already ran the earlier username-key
 -- social/sync/content migrations before users.id became the durable account key.
+--
+-- Some long-lived environments still predate a subset of the later legacy table
+-- rollouts. Bootstrap those table shells first so this backfill can keep moving
+-- instead of stopping at the first missing table.
+
+CREATE TABLE IF NOT EXISTS content_favorites (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  content_id TEXT NOT NULL,
+  content_type TEXT NOT NULL DEFAULT 'text',
+  username TEXT,
+  title TEXT,
+  file_path TEXT,
+  description TEXT,
+  created_at TEXT NOT NULL,
+  sync_version INTEGER DEFAULT 1,
+  UNIQUE(content_id, username)
+);
+
+CREATE TABLE IF NOT EXISTS user_follows (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  follower_username TEXT NOT NULL,
+  following_username TEXT NOT NULL,
+  sync_version INTEGER DEFAULT 1,
+  created_at TEXT NOT NULL,
+  UNIQUE(follower_username, following_username)
+);
+
+CREATE TABLE IF NOT EXISTS user_practice_privacy (
+  username TEXT PRIMARY KEY,
+  is_private INTEGER DEFAULT 0 NOT NULL,
+  show_practice_name INTEGER DEFAULT 1 NOT NULL,
+  show_duration INTEGER DEFAULT 1 NOT NULL,
+  show_chant_count INTEGER DEFAULT 1 NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL,
+  type TEXT NOT NULL,
+  content TEXT NOT NULL,
+  related_content_id TEXT,
+  related_username TEXT,
+  is_read INTEGER DEFAULT 0,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sync_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL,
+  table_name TEXT NOT NULL,
+  record_id INTEGER NOT NULL,
+  action TEXT NOT NULL,
+  sync_version INTEGER NOT NULL,
+  data_snapshot TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_sync_state (
+  username TEXT PRIMARY KEY,
+  last_sync_version INTEGER DEFAULT 0,
+  last_sync_at TEXT
+);
 
 ALTER TABLE content_likes ADD COLUMN account_user_id INTEGER;
 ALTER TABLE content_favorites ADD COLUMN user_id INTEGER;


### PR DESCRIPTION
## Summary
- bootstrap legacy D1 table shells that may be absent in long-lived environments before `20260519_owned_data_user_id.sql` starts altering them
- keep the change scoped to the already-failing migration file so the user-id ownership rollout can continue without reopening worker logic
- cover the specific `content_favorites` miss from `issue #582` while also preempting the same class of failure for nearby legacy social/sync tables

## Why now
`issue #582` is the current mainline delivery blocker. The latest CD run failed in `Apply development D1 migrations` with:
- `Migration 20260519_owned_data_user_id.sql failed`
- `no such table: content_favorites`

That tells us the code path is fine enough to build and reach staging deploy, but the D1 evolution chain still assumes every environment already has every late-added legacy table shell. At least the development database does not.

## Risk review
- one file only: `fabushi/web/migrations/20260519_owned_data_user_id.sql`
- no handler/runtime/business logic changes
- no new ownership semantics beyond what `#576` already introduced
- the new `CREATE TABLE IF NOT EXISTS ...` statements define only the pre-user-id legacy shells, then the existing `ALTER TABLE ... ADD COLUMN` and backfill logic continues as designed
- this is safer than teaching CD to special-case one environment, and it avoids leaving `main` blocked on a missing historical table

## Expected outcome
- the current owned-data backfill migration stops failing immediately on `content_favorites` being absent
- nearby long-lived environments that also missed `user_follows`, `user_practice_privacy`, `notifications`, `sync_log`, or `user_sync_state` table creation should no longer trip the same migration at the next statement
- once merged, `issue #582` can be re-evaluated by rerunning the failed CD path

## Verification
- compare against `main` is scoped to one file only:
  - `fabushi/web/migrations/20260519_owned_data_user_id.sql`
- root-cause evidence comes from `CD - Staging API gated production deploy #369` on `a076c1e`, where `Apply development D1 migrations` failed with `no such table: content_favorites`
- this environment does not have direct access to the repository checkout or Cloudflare D1 target, so the final proof remains the rerun of repository CI/CD after merge