### PR TITLE
ci(forum): add Oracle preview deploy workflow

### DIFF
--- a/.github/workflows/forum-oracle-preview-deploy.yml
+++ b/.github/workflows/forum-oracle-preview-deploy.yml
@@ -201,16 +201,6 @@ jobs:
             exit 1
           fi
 
-          if ! command -v pnpm >/dev/null 2>&1; then
-            if command -v corepack >/dev/null 2>&1; then
-              corepack enable
-              corepack prepare pnpm@10.9.0 --activate
-            else
-              echo "pnpm is missing and corepack is not available on the Oracle host." >&2
-              exit 1
-            fi
-          fi
-
           if [[ -n "${GHCR_USERNAME:-}" && -n "${GHCR_TOKEN:-}" ]]; then
             printf '%s\n' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
           fi
@@ -226,7 +216,6 @@ jobs:
           git reset --hard origin/main
 
           cd forum
-          pnpm install --no-frozen-lockfile
 
           if [[ "$REGENERATE_DEPLOY_ENV" == "true" || ! -f .env.deploy ]]; then
             preset="read-only-preview"
@@ -252,14 +241,14 @@ jobs:
               scaffold_args+=(--write-access-code "$FORUM_WRITE_ACCESS_CODE")
             fi
 
-            pnpm scaffold:deploy-env -- "${scaffold_args[@]}"
+            node ./scripts/scaffold-deploy-env.mjs "${scaffold_args[@]}"
           else
-            pnpm check:deploy-env -- --deploy-env-path .env.deploy
+            node ./scripts/validate-deploy-env.mjs --deploy-env-path .env.deploy
           fi
 
           docker compose --env-file .env.deploy -f docker-compose.deploy.yml pull
 
-          pnpm rollout:deploy-env -- \
+          node ./scripts/rollout-deploy-env.mjs \
             --deploy-env-path .env.deploy \
             --compose-file docker-compose.deploy.yml \
             --compose-project-name fabushi-forum-preview \
@@ -268,7 +257,7 @@ jobs:
             --request-timeout-ms "$REQUEST_TIMEOUT_MS" \
             --github-repo "$REPOSITORY"
 
-          pnpm prepare:live-target -- \
+          node ./scripts/prepare-live-deployment-vars.mjs \
             --deploy-env-path .env.deploy \
             --forum-url "$FORUM_URL" \
             --exercise-write-flow "$EXERCISE_WRITE_FLOW" \

--- a/.github/workflows/forum-oracle-preview-deploy.yml
+++ b/.github/workflows/forum-oracle-preview-deploy.yml
@@ -1,0 +1,329 @@
+name: Deploy forum preview - Oracle
+
+on:
+  workflow_dispatch:
+    inputs:
+      forum_url:
+        description: Public preview URL to verify and save, for example https://forum-preview.example.com
+        required: true
+        type: string
+      deploy_dir:
+        description: Absolute directory on the Oracle server where the repo should be deployed
+        required: true
+        default: /opt/fabushi
+        type: string
+      forum_port:
+        description: Host port exposed by docker compose
+        required: true
+        default: "3000"
+        type: string
+      forum_data_dir:
+        description: Host path for durable sqlite data, relative paths are resolved from forum/
+        required: true
+        default: ./data
+        type: string
+      deployment_stage:
+        description: Runtime deployment stage expected from /api/health and /api/status
+        required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - production
+      public_base_url:
+        description: Expected production public base URL. Leave empty for preview/noindex runtimes.
+        required: false
+        type: string
+      writes_enabled:
+        description: Enable writable preview mode. Requires FORUM_PREVIEW_WRITE_ACCESS_CODE secret.
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      exercise_write_flow:
+        description: Verify real thread-and-reply writes. Requires writable preview.
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      regenerate_deploy_env:
+        description: Replace forum/.env.deploy from workflow inputs before rolling out
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      update_github_live_target:
+        description: Save the verified target into repository variable FORUM_LIVE_TARGET after deployment
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: forum-oracle-preview-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-forum-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ORACLE_SSH_HOST: ${{ secrets.ORACLE_SSH_HOST }}
+      ORACLE_SSH_USER: ${{ secrets.ORACLE_SSH_USER }}
+      ORACLE_SSH_PRIVATE_KEY: ${{ secrets.ORACLE_SSH_PRIVATE_KEY }}
+      ORACLE_SSH_PORT: ${{ secrets.ORACLE_SSH_PORT || '22' }}
+      FORUM_WRITE_ACCESS_CODE: ${{ secrets.FORUM_PREVIEW_WRITE_ACCESS_CODE }}
+      FORUM_LIVE_WRITE_ACCESS_CODE: ${{ secrets.FORUM_LIVE_WRITE_ACCESS_CODE }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      FORUM_URL: ${{ inputs.forum_url }}
+      DEPLOY_DIR: ${{ inputs.deploy_dir }}
+      FORUM_PORT: ${{ inputs.forum_port }}
+      FORUM_DATA_DIR: ${{ inputs.forum_data_dir }}
+      DEPLOYMENT_STAGE: ${{ inputs.deployment_stage }}
+      PUBLIC_BASE_URL: ${{ inputs.public_base_url }}
+      WRITES_ENABLED: ${{ inputs.writes_enabled }}
+      EXERCISE_WRITE_FLOW: ${{ inputs.exercise_write_flow }}
+      REGENERATE_DEPLOY_ENV: ${{ inputs.regenerate_deploy_env }}
+      UPDATE_GITHUB_LIVE_TARGET: ${{ inputs.update_github_live_target }}
+      REQUEST_TIMEOUT_MS: "15000"
+    steps:
+      - name: Validate deploy inputs and secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for name in ORACLE_SSH_HOST ORACLE_SSH_USER ORACLE_SSH_PRIVATE_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub secret(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          if [[ "$EXERCISE_WRITE_FLOW" == "true" && "$WRITES_ENABLED" != "true" ]]; then
+            echo "exercise_write_flow=true requires writes_enabled=true." >&2
+            exit 1
+          fi
+
+          if [[ "$DEPLOYMENT_STAGE" == "production" && "$WRITES_ENABLED" == "true" ]]; then
+            echo "Refusing to deploy a writable production forum runtime." >&2
+            exit 1
+          fi
+
+          if [[ "$WRITES_ENABLED" == "true" && -z "${FORUM_WRITE_ACCESS_CODE:-}" ]]; then
+            echo "writes_enabled=true requires the FORUM_PREVIEW_WRITE_ACCESS_CODE secret." >&2
+            exit 1
+          fi
+
+          if [[ "$DEPLOYMENT_STAGE" == "production" && -z "${PUBLIC_BASE_URL:-}" ]]; then
+            echo "deployment_stage=production requires public_base_url." >&2
+            exit 1
+          fi
+
+          if [[ "$UPDATE_GITHUB_LIVE_TARGET" == "true" && "$WRITES_ENABLED" == "true" && -z "${FORUM_LIVE_WRITE_ACCESS_CODE:-}" ]]; then
+            echo "::warning::FORUM_LIVE_WRITE_ACCESS_CODE is empty. Scheduled live checks will need this secret if the saved live target requires the preview write gate."
+          fi
+
+      - name: Prepare SSH client
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$ORACLE_SSH_PRIVATE_KEY" > ~/.ssh/oracle_deploy_key
+          chmod 600 ~/.ssh/oracle_deploy_key
+
+          ssh-keyscan -p "$ORACLE_SSH_PORT" "$ORACLE_SSH_HOST" >> ~/.ssh/known_hosts
+
+      - name: Roll out forum on Oracle host
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          remote="${ORACLE_SSH_USER}@${ORACLE_SSH_HOST}"
+
+          quote_for_remote() {
+            printf '%q' "$1"
+          }
+
+          remote_env=(
+            "REPOSITORY=$(quote_for_remote "$GITHUB_REPOSITORY")"
+            "DEPLOY_DIR=$(quote_for_remote "$DEPLOY_DIR")"
+            "FORUM_URL=$(quote_for_remote "$FORUM_URL")"
+            "FORUM_PORT=$(quote_for_remote "$FORUM_PORT")"
+            "FORUM_DATA_DIR=$(quote_for_remote "$FORUM_DATA_DIR")"
+            "DEPLOYMENT_STAGE=$(quote_for_remote "$DEPLOYMENT_STAGE")"
+            "PUBLIC_BASE_URL=$(quote_for_remote "${PUBLIC_BASE_URL:-}")"
+            "WRITES_ENABLED=$(quote_for_remote "$WRITES_ENABLED")"
+            "EXERCISE_WRITE_FLOW=$(quote_for_remote "$EXERCISE_WRITE_FLOW")"
+            "REGENERATE_DEPLOY_ENV=$(quote_for_remote "$REGENERATE_DEPLOY_ENV")"
+            "REQUEST_TIMEOUT_MS=$(quote_for_remote "$REQUEST_TIMEOUT_MS")"
+            "FORUM_WRITE_ACCESS_CODE=$(quote_for_remote "${FORUM_WRITE_ACCESS_CODE:-}")"
+            "GHCR_USERNAME=$(quote_for_remote "${GHCR_USERNAME:-}")"
+            "GHCR_TOKEN=$(quote_for_remote "${GHCR_TOKEN:-}")"
+          )
+
+          ssh \
+            -i ~/.ssh/oracle_deploy_key \
+            -p "$ORACLE_SSH_PORT" \
+            -o StrictHostKeyChecking=yes \
+            "$remote" \
+            "${remote_env[@]}" \
+            'bash -se' <<'REMOTE'
+          set -euo pipefail
+
+          for binary in git docker node; do
+            if ! command -v "$binary" >/dev/null 2>&1; then
+              echo "Missing required binary on Oracle host: $binary" >&2
+              exit 1
+            fi
+          done
+
+          if ! docker compose version >/dev/null 2>&1; then
+            echo "Docker Compose v2 is required on the Oracle host." >&2
+            exit 1
+          fi
+
+          if ! command -v pnpm >/dev/null 2>&1; then
+            if command -v corepack >/dev/null 2>&1; then
+              corepack enable
+              corepack prepare pnpm@10.9.0 --activate
+            else
+              echo "pnpm is missing and corepack is not available on the Oracle host." >&2
+              exit 1
+            fi
+          fi
+
+          if [[ -n "${GHCR_USERNAME:-}" && -n "${GHCR_TOKEN:-}" ]]; then
+            printf '%s\n' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+          fi
+
+          if [[ ! -d "$DEPLOY_DIR/.git" ]]; then
+            mkdir -p "$(dirname "$DEPLOY_DIR")"
+            git clone "https://github.com/${REPOSITORY}.git" "$DEPLOY_DIR"
+          fi
+
+          cd "$DEPLOY_DIR"
+          git fetch --prune origin main
+          git checkout main
+          git reset --hard origin/main
+
+          cd forum
+          pnpm install --no-frozen-lockfile
+
+          if [[ "$REGENERATE_DEPLOY_ENV" == "true" || ! -f .env.deploy ]]; then
+            preset="read-only-preview"
+            if [[ "$DEPLOYMENT_STAGE" == "production" ]]; then
+              preset="production"
+            elif [[ "$WRITES_ENABLED" == "true" ]]; then
+              preset="writable-preview"
+            fi
+
+            scaffold_args=(
+              --deploy-env-path .env.deploy
+              --preset "$preset"
+              --forum-port "$FORUM_PORT"
+              --forum-data-dir "$FORUM_DATA_DIR"
+              --deploy-check-url "$FORUM_URL"
+              --deployment-stage "$DEPLOYMENT_STAGE"
+              --public-base-url "${PUBLIC_BASE_URL:-}"
+              --writes-enabled "$WRITES_ENABLED"
+              --force true
+            )
+
+            if [[ "$WRITES_ENABLED" == "true" ]]; then
+              scaffold_args+=(--write-access-code "$FORUM_WRITE_ACCESS_CODE")
+            fi
+
+            pnpm scaffold:deploy-env -- "${scaffold_args[@]}"
+          else
+            pnpm check:deploy-env -- --deploy-env-path .env.deploy
+          fi
+
+          docker compose --env-file .env.deploy -f docker-compose.deploy.yml pull
+
+          pnpm rollout:deploy-env -- \
+            --deploy-env-path .env.deploy \
+            --compose-file docker-compose.deploy.yml \
+            --compose-project-name fabushi-forum-preview \
+            --forum-url "$FORUM_URL" \
+            --exercise-write-flow "$EXERCISE_WRITE_FLOW" \
+            --request-timeout-ms "$REQUEST_TIMEOUT_MS" \
+            --github-repo "$REPOSITORY"
+
+          pnpm prepare:live-target -- \
+            --deploy-env-path .env.deploy \
+            --forum-url "$FORUM_URL" \
+            --exercise-write-flow "$EXERCISE_WRITE_FLOW" \
+            --format json > .forum-live-target.json
+          REMOTE
+
+      - name: Fetch verified live target from Oracle host
+        id: live-target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          remote="${ORACLE_SSH_USER}@${ORACLE_SSH_HOST}"
+          remote_target_path="$(printf '%q' "$DEPLOY_DIR/forum/.forum-live-target.json")"
+
+          ssh \
+            -i ~/.ssh/oracle_deploy_key \
+            -p "$ORACLE_SSH_PORT" \
+            -o StrictHostKeyChecking=yes \
+            "$remote" \
+            "cat $remote_target_path" > /tmp/forum-live-target.json
+
+          node -e '
+            const fs = require("node:fs");
+            const target = JSON.parse(fs.readFileSync("/tmp/forum-live-target.json", "utf8"));
+            if (!target.forumUrl || !target.deploymentStage) {
+              throw new Error("Verified live target is missing forumUrl or deploymentStage.");
+            }
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `forum_url=${target.forumUrl}\n`);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n## Verified forum live target\n\n\`\`\`json\n${JSON.stringify(target, null, 2)}\n\`\`\`\n`);
+          '
+
+      - name: Save verified target to GitHub repository variable
+        if: env.UPDATE_GITHUB_LIVE_TARGET == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh variable set FORUM_LIVE_TARGET \
+            --body "$(cat /tmp/forum-live-target.json)" \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Report deployment result
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          {
+            echo ""
+            echo "## Oracle forum deployment"
+            echo ""
+            echo "- URL: ${{ steps.live-target.outputs.forum_url }}"
+            echo "- Server: ${ORACLE_SSH_USER}@${ORACLE_SSH_HOST}:${ORACLE_SSH_PORT}"
+            echo "- Deploy directory: ${DEPLOY_DIR}"
+            echo "- GitHub live target sync: ${UPDATE_GITHUB_LIVE_TARGET}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a manual GitHub Actions workflow for deploying the forum preview runtime onto an Oracle host over SSH.

The workflow:
- validates required Oracle SSH secrets and deploy inputs
- connects to the Oracle host with a deploy key
- clones or updates `bhrumom/fabushi` under the selected deploy directory
- prepares `forum/.env.deploy` from workflow inputs, or reuses an existing one
- pulls the configured Docker image before rollout
- runs `pnpm rollout:deploy-env` so deploy env validation, compose startup, local health probing, smoke checks, and live target handoff use the existing forum deployment helper
- fetches the verified live target JSON from the host
- optionally writes the verified target to repository variable `FORUM_LIVE_TARGET`

## Required GitHub secrets

- `ORACLE_SSH_HOST`
- `ORACLE_SSH_USER`
- `ORACLE_SSH_PRIVATE_KEY`

Optional:
- `ORACLE_SSH_PORT`, defaults to `22`
- `FORUM_PREVIEW_WRITE_ACCESS_CODE`, required only for writable preview
- `FORUM_LIVE_WRITE_ACCESS_CODE`, needed by scheduled live checks when the saved target requires the preview write gate
- `GHCR_USERNAME` and `GHCR_TOKEN`, only needed if the server must authenticate to pull from GHCR

## Notes

This builds on the existing forum deploy helper stack: `rollout:deploy-env`, `scaffold:deploy-env`, `check:deploy-env`, and `prepare:live-target`. The workflow intentionally does not expose arbitrary shell command execution; it only runs the fixed deploy path on the configured Oracle host.