### PR TITLE
fix(forum): let Oracle deploy bootstrap before live-target handoff

### DIFF
--- a/.github/workflows/forum-oracle-preview-deploy.yml
+++ b/.github/workflows/forum-oracle-preview-deploy.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       forum_url:
-        description: Public preview URL to verify and save, for example https://forum-preview.example.com
-        required: true
+        description: Optional public preview URL to verify and save. Leave empty on the first rollout if the host still has no stable external URL.
+        required: false
         type: string
       deploy_dir:
         description: Absolute directory on the Oracle server where the repo should be deployed
@@ -137,6 +137,10 @@ jobs:
             exit 1
           fi
 
+          if [[ "$UPDATE_GITHUB_LIVE_TARGET" == "true" && "$DEPLOYMENT_STAGE" == "preview" && "$REGENERATE_DEPLOY_ENV" == "true" && -z "${FORUM_URL:-}" ]]; then
+            echo "::warning::forum_url is empty. This run can still bootstrap the preview host and pass local smoke checks, but live-target sync will stay skipped until the real preview URL is known."
+          fi
+
           if [[ "$UPDATE_GITHUB_LIVE_TARGET" == "true" && "$WRITES_ENABLED" == "true" && -z "${FORUM_LIVE_WRITE_ACCESS_CODE:-}" ]]; then
             echo "::warning::FORUM_LIVE_WRITE_ACCESS_CODE is empty. Scheduled live checks will need this secret if the saved live target requires the preview write gate."
           fi
@@ -257,11 +261,57 @@ jobs:
             --request-timeout-ms "$REQUEST_TIMEOUT_MS" \
             --github-repo "$REPOSITORY"
 
-          node ./scripts/prepare-live-deployment-vars.mjs \
-            --deploy-env-path .env.deploy \
-            --forum-url "$FORUM_URL" \
-            --exercise-write-flow "$EXERCISE_WRITE_FLOW" \
-            --format json > .forum-live-target.json
+          resolved_live_target="$(
+            node -e '
+              const fs = require("node:fs");
+              const text = fs.readFileSync(".env.deploy", "utf8");
+              const deployEnv = {};
+              for (const rawLine of text.split(/\r?\n/)) {
+                const line = rawLine.trim();
+                if (!line || line.startsWith("#")) {
+                  continue;
+                }
+
+                const trimmed = rawLine.trimStart();
+                const separatorIndex = trimmed.indexOf("=");
+                if (separatorIndex <= 0) {
+                  continue;
+                }
+
+                const key = trimmed.slice(0, separatorIndex).trim();
+                let value = trimmed.slice(separatorIndex + 1).trim();
+                if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("\x27") && value.endsWith("\x27"))) {
+                  value = value.slice(1, -1);
+                } else {
+                  const commentIndex = value.search(/\s+#/);
+                  if (commentIndex >= 0) {
+                    value = value.slice(0, commentIndex).trimEnd();
+                  }
+                }
+                deployEnv[key] = value;
+              }
+
+              const normalizeUrl = (value) => (value ? value.replace(/\/$/, "") : "");
+              const explicitForumUrl = normalizeUrl(process.env.FORUM_URL || "");
+              const deployCheckUrl = normalizeUrl(deployEnv.FORUM_DEPLOY_CHECK_URL || "");
+              const deploymentStage = (deployEnv.FORUM_DEPLOYMENT_STAGE || "preview").trim();
+              const publicBaseUrl = normalizeUrl(deployEnv.FORUM_PUBLIC_BASE_URL || "");
+              const resolved = explicitForumUrl || deployCheckUrl || (deploymentStage === "production" ? publicBaseUrl : "");
+              process.stdout.write(resolved);
+            '
+          )"
+
+          if [[ -n "$resolved_live_target" ]]; then
+            rm -f .forum-live-target.skip.txt
+            node ./scripts/prepare-live-deployment-vars.mjs \
+              --deploy-env-path .env.deploy \
+              --forum-url "$FORUM_URL" \
+              --exercise-write-flow "$EXERCISE_WRITE_FLOW" \
+              --format json > .forum-live-target.json
+          else
+            rm -f .forum-live-target.json
+            printf '%s\n' "No external forum URL was available yet, so this run stopped after host rollout and local smoke verification." > .forum-live-target.skip.txt
+          fi
           REMOTE
 
       - name: Fetch verified live target from Oracle host
@@ -272,26 +322,51 @@ jobs:
 
           remote="${ORACLE_SSH_USER}@${ORACLE_SSH_HOST}"
           remote_target_path="$(printf '%q' "$DEPLOY_DIR/forum/.forum-live-target.json")"
+          remote_skip_path="$(printf '%q' "$DEPLOY_DIR/forum/.forum-live-target.skip.txt")"
+
+          if ssh \
+            -i ~/.ssh/oracle_deploy_key \
+            -p "$ORACLE_SSH_PORT" \
+            -o StrictHostKeyChecking=yes \
+            "$remote" \
+            "test -f $remote_target_path"; then
+            ssh \
+              -i ~/.ssh/oracle_deploy_key \
+              -p "$ORACLE_SSH_PORT" \
+              -o StrictHostKeyChecking=yes \
+              "$remote" \
+              "cat $remote_target_path" > /tmp/forum-live-target.json
+
+            node -e '
+              const fs = require("node:fs");
+              const target = JSON.parse(fs.readFileSync("/tmp/forum-live-target.json", "utf8"));
+              if (!target.forumUrl || !target.deploymentStage) {
+                throw new Error("Verified live target is missing forumUrl or deploymentStage.");
+              }
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `skipped=false\n`);
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `forum_url=${target.forumUrl}\n`);
+              fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n## Verified forum live target\n\n\`\`\`json\n${JSON.stringify(target, null, 2)}\n\`\`\`\n`);
+            '
+            exit 0
+          fi
 
           ssh \
             -i ~/.ssh/oracle_deploy_key \
             -p "$ORACLE_SSH_PORT" \
             -o StrictHostKeyChecking=yes \
             "$remote" \
-            "cat $remote_target_path" > /tmp/forum-live-target.json
+            "cat $remote_skip_path" > /tmp/forum-live-target-skip.txt
 
           node -e '
             const fs = require("node:fs");
-            const target = JSON.parse(fs.readFileSync("/tmp/forum-live-target.json", "utf8"));
-            if (!target.forumUrl || !target.deploymentStage) {
-              throw new Error("Verified live target is missing forumUrl or deploymentStage.");
-            }
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `forum_url=${target.forumUrl}\n`);
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n## Verified forum live target\n\n\`\`\`json\n${JSON.stringify(target, null, 2)}\n\`\`\`\n`);
+            const reason = fs.readFileSync("/tmp/forum-live-target-skip.txt", "utf8").trim();
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `skipped=true\n`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `skip_reason=${reason}\n`);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n## Live target handoff skipped\n\n- ${reason}\n`);
           '
 
       - name: Save verified target to GitHub repository variable
-        if: env.UPDATE_GITHUB_LIVE_TARGET == 'true'
+        if: env.UPDATE_GITHUB_LIVE_TARGET == 'true' && steps.live-target.outputs.skipped != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -311,8 +386,15 @@ jobs:
             echo ""
             echo "## Oracle forum deployment"
             echo ""
-            echo "- URL: ${{ steps.live-target.outputs.forum_url }}"
+            if [[ "${{ steps.live-target.outputs.skipped }}" == "true" ]]; then
+              echo "- URL: (not saved yet)"
+              echo "- Live target sync: skipped until a real external URL is available"
+              echo "- Why: ${{ steps.live-target.outputs.skip_reason }}"
+              echo "- Next step: rerun this workflow with forum_url set, or keep forum/.env.deploy updated with FORUM_DEPLOY_CHECK_URL / FORUM_PUBLIC_BASE_URL before rerunning live-target handoff."
+            else
+              echo "- URL: ${{ steps.live-target.outputs.forum_url }}"
+              echo "- Live target sync: ${UPDATE_GITHUB_LIVE_TARGET}"
+            fi
             echo "- Server: ${ORACLE_SSH_USER}@${ORACLE_SSH_HOST}:${ORACLE_SSH_PORT}"
             echo "- Deploy directory: ${DEPLOY_DIR}"
-            echo "- GitHub live target sync: ${UPDATE_GITHUB_LIVE_TARGET}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/forum/DEPLOY.md
+++ b/forum/DEPLOY.md
@@ -117,6 +117,12 @@ If the host already has `gh` authenticated and you want to push the verified hou
 --apply-github-live-target true
 ```
 
+If you prefer to drive the same path from GitHub Actions on an Oracle host, use the manual workflow `Deploy forum preview - Oracle`:
+
+- On the first rollout, `forum_url` can stay empty. The workflow will still clone or refresh the repo, scaffold or validate `forum/.env.deploy`, pull the published image, run `rollout:deploy-env`, and verify the local host runtime.
+- In that no-URL first-pass mode, the workflow now reports that live-target sync was intentionally skipped instead of failing late while trying to save `FORUM_LIVE_TARGET`.
+- Once the preview has a stable external URL, rerun the same workflow with `forum_url` filled in, or keep `FORUM_DEPLOY_CHECK_URL` or `FORUM_PUBLIC_BASE_URL` inside `forum/.env.deploy`, and the workflow will complete the verified live-target handoff.
+
 If the preview runtime is intentionally writable and you want the handoff itself to prove the real thread-and-reply flow before printing or syncing the hourly config, add:
 
 ```bash


### PR DESCRIPTION
## Summary
- let `Deploy forum preview - Oracle` run without a `forum_url` on the first host bootstrap
- keep the rollout, local health verification, and compose smoke path intact even when no stable external preview URL exists yet
- surface an explicit "live target handoff skipped" result instead of failing late while trying to save `FORUM_LIVE_TARGET`
- document the new two-pass Oracle flow in `forum/DEPLOY.md`

## Why now
`PR #585` put the Oracle preview deploy workflow onto `main`, which was the right next move for deployment readiness. After that merge, the smallest remaining repo-side friction became clearer:

- the workflow still required `forum_url` up front
- that blocked the new workflow from being the true first rollout entrypoint on a fresh host
- the underlying forum deploy helpers already support a useful split:
  - first bring the runtime up and smoke it locally
  - then bind the verified runtime to a real external URL once one exists

This change makes the Oracle workflow match the helper stack the repository already trusts.

## What changed
- `.github/workflows/forum-oracle-preview-deploy.yml`
  - `forum_url` is now optional for manual runs
  - preview bootstrap without a stable external URL now warns early instead of pretending live-target sync can complete
  - after rollout, the workflow detects whether a real handoff target can be resolved from the explicit input or deploy env
  - if a target exists, it prepares and fetches the verified live-target JSON exactly as before
  - if no target exists yet, it records a clear skip reason and reports the next action in the job summary instead of failing late
- `forum/DEPLOY.md`
  - explains the new two-pass Oracle flow: bootstrap first, rerun with the real URL for verified live-target handoff

## Why this scope
This stays tightly on the current highest-priority deployment thread:
- it does not reopen broader forum feature work
- it does not invent a new deployment mechanism
- it only removes the last unnecessary workflow-level blocker between "host can run the forum" and "host has a stable public URL"

## Verification
- branch diff is limited to:
  - `.github/workflows/forum-oracle-preview-deploy.yml`
  - `forum/DEPLOY.md`
- logic review confirms the workflow now has two explicit outcomes:
  - verified live target fetched and optionally synced
  - rollout succeeded but live-target handoff skipped pending a real external URL
- final proof should come from GitHub Actions on this PR and then from a real workflow_dispatch run against the Oracle host

## Follow-up
Once merged, the next highest-priority step is no longer another repo-side deploy helper tweak. It becomes the real Oracle workflow run itself:
- first bootstrap if the host still lacks a stable public URL
- then rerun with the final preview URL to save `FORUM_LIVE_TARGET` and remove `issue #570` as an external blocker