### PR TITLE
chore(web): sync official site beta state to mobile 316

### DIFF
--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -7,28 +7,27 @@
       "title": "Android Beta",
       "description": "官网直接读取最新发布版本的 APK 安装包，安装包发布后这里会自动更新。",
       "primaryLabel": "下载 Android Beta",
-      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-307-mobile.fde8b7853fc8/fabushi-android-arm64-fde8b7853fc8.apk",
-      "version": "v1.0.0-307-mobile.fde8b7853fc8",
-      "publishedAt": "2026-05-18T13:03:57Z",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-316-mobile.792e8f00c9cd/fabushi-android-arm64-792e8f00c9cd.apk",
+      "version": "v1.0.0-316-mobile.792e8f00c9cd",
+      "publishedAt": "2026-05-19T00:07:03Z",
       "updateSummary": [
         "改进 Android 测试版下载与安装稳定性。",
-        "Lower the book into the offering area above the centered incense burner",
-        "Keep the book-style red/gold visual and main-practice title on the cover",
+        "keep the incense burner centered beneath the model",
         "flutter analyze --no-pub lib\\\\screens\\\\meditation_room_screen.dart lib\\\\widgets\\\\zen_room_2d_elements.dart",
         "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
       ],
       "mirrorLinks": [
         {
           "label": "国内镜像 1",
-          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-307-mobile.fde8b7853fc8/fabushi-android-arm64-fde8b7853fc8.apk"
+          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-316-mobile.792e8f00c9cd/fabushi-android-arm64-792e8f00c9cd.apk"
         },
         {
           "label": "国内镜像 2",
-          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-307-mobile.fde8b7853fc8/fabushi-android-arm64-fde8b7853fc8.apk"
+          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-316-mobile.792e8f00c9cd/fabushi-android-arm64-792e8f00c9cd.apk"
         }
       ],
       "note": "国内访问较慢时，可以优先尝试镜像下载入口。",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-307-mobile.fde8b7853fc8"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-316-mobile.792e8f00c9cd"
     },
     {
       "platform": "iOS",
@@ -38,23 +37,34 @@
       "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
       "primaryLabel": "加入 iOS TestFlight",
       "primaryHref": "https://testflight.apple.com/join/98KFgV2z",
-      "version": "307",
-      "publishedAt": "2026-05-18T13:03:20Z",
+      "version": "316",
+      "publishedAt": "2026-05-19T00:04:46Z",
       "updateSummary": [
         "改进 Android 测试版下载与安装稳定性。",
-        "Lower the book into the offering area above the centered incense burner",
-        "Keep the book-style red/gold visual and main-practice title on the cover",
+        "keep the incense burner centered beneath the model",
         "flutter analyze --no-pub lib\\\\screens\\\\meditation_room_screen.dart lib\\\\widgets\\\\zen_room_2d_elements.dart",
         "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
       ],
       "mirrorLinks": [],
       "note": "",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-307-mobile.fde8b7853fc8"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-316-mobile.792e8f00c9cd"
     }
   ],
   "stableChannels": [],
   "screenshots": {},
   "releases": [
+    {
+      "tag": "v1.0.0-316-mobile.792e8f00c9cd",
+      "title": "Fabushi mobile 1.0.0+316 (792e8f00c9cd)",
+      "publishedAt": "2026-05-19T00:07:03Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-316-mobile.792e8f00c9cd",
+      "summary": [
+        "改进 Android 测试版下载与安装稳定性。",
+        "keep the incense burner centered beneath the model",
+        "flutter analyze --no-pub lib\\\\screens\\\\meditation_room_screen.dart lib\\\\widgets\\\\zen_room_2d_elements.dart",
+        "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
+      ]
+    },
     {
       "tag": "v1.0.0-307-mobile.fde8b7853fc8",
       "title": "Fabushi mobile 1.0.0+307 (fde8b7853fc8)",
@@ -101,17 +111,6 @@
         "改进 Android 测试版下载与安装稳定性。",
         "Move the online count affordance out of the Buddha area and use a people icon",
         "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
-      ]
-    },
-    {
-      "tag": "v1.0.0-296-mobile.33e5d5f9d6f2",
-      "title": "Fabushi mobile 1.0.0+296 (33e5d5f9d6f2)",
-      "publishedAt": "2026-05-18T07:04:21Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-296-mobile.33e5d5f9d6f2",
-      "summary": [
-        "改进 Android 测试版下载与安装稳定性。",
-        "dart analyze lib/screens/buddha_model_screen_native.dart lib/core/config/app_config.dart",
-        "减少更新后仍显示旧内容的情况。"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- sync `frontend/apps/web/public/api/releases.json` from `automation/sync-official-site-beta-state` back onto `main`
- update the public Android beta download entry from `v1.0.0-307-mobile.fde8b7853fc8` to `v1.0.0-316-mobile.792e8f00c9cd`
- update the public iOS TestFlight beta status from version `307` to `316`
- keep the persisted public release history aligned with the latest published mobile beta snapshot already present on the automation branch

## Why now
The repository has a fresh release-state drift again:
- `main` still serves the older public beta snapshot (`307`)
- `automation/sync-official-site-beta-state` is currently `ahead_by = 1` and `behind_by = 0`
- the compare is limited to a single generated file: `frontend/apps/web/public/api/releases.json`
- there is no open PR currently carrying that generated state back to `main`

This PR closes that gap without reopening broader release-automation design work.

## Current evidence
- `main` currently publishes:
  - Android beta `v1.0.0-307-mobile.fde8b7853fc8`
  - Android `publishedAt = 2026-05-18T13:03:57Z`
  - iOS TestFlight public `version = 307`
  - iOS `publishedAt = 2026-05-18T13:03:20Z`
- automation branch already carries the newer public state:
  - Android beta `v1.0.0-316-mobile.792e8f00c9cd`
  - Android `publishedAt = 2026-05-19T00:07:03Z`
  - iOS TestFlight public `version = 316`
  - iOS `publishedAt = 2026-05-19T00:04:46Z`

## Risk review
- branch compare is clean: `ahead_by = 1`, `behind_by = 0`
- diff scope is limited to the generated public release-state JSON
- no runtime code or workflow logic changes are included
- no merge conflict risk is visible from the current compare snapshot

## Expected outcome after merge
- the official site beta state on `main` will catch up to the already-published mobile `316` release
- Android APK and iOS TestFlight public status will stop lagging behind the latest release metadata on the persistent site state
- the waiting-window release-state drift is closed with a single low-risk PR