### PR TITLE
feat(web): add CBETA-powered Faloo page to official site

### DIFF
--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import { brand } from "@fabushi/shared";
+import { LocalizedText } from "../../components/localized-text";
+import { SiteFooter } from "../../components/site-footer";
+import { SiteHeader } from "../../components/site-header";
+import { FaliuShell } from "../../components/faliu-shell";
+import { siteUrl } from "../../lib/site-url";
+
+const pageUrl = siteUrl("/faliu");
+const pageTitle = `法流 | CBETA 佛典流式浏览 | ${brand.name}`;
+const pageDescription =
+  "法流页使用 CBETA API 提供佛典题名、卷次与正文浏览，并接入法布施 App 后端的互动统计与评论数据。";
+
+export const metadata: Metadata = {
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: pageUrl,
+  },
+  keywords: [
+    "法流",
+    "CBETA API",
+    "佛典浏览",
+    "佛经搜索",
+    "大藏经阅读",
+    "Fabushi 法流",
+  ],
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: pageUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: pageTitle,
+    description: pageDescription,
+  },
+};
+
+export default function FaliuPage() {
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name: "法流",
+        url: pageUrl,
+        description: pageDescription,
+        inLanguage: "zh-CN",
+        isPartOf: {
+          "@type": "WebSite",
+          name: `${brand.name} Fabushi`,
+          url: siteUrl("/"),
+        },
+      },
+      {
+        "@type": "SearchResultsPage",
+        name: "CBETA 佛典流式浏览",
+        url: pageUrl,
+        description: "浏览精选佛典、切换专题分类，并查看卷次正文与互动数据。",
+      },
+    ],
+  };
+
+  return (
+    <main className="inner-page">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="inner-hero">
+        <SiteHeader />
+        <div className="inner-copy">
+          <p className="eyebrow">
+            <LocalizedText zh="法流" en="Faloo" />
+          </p>
+          <h1>
+            <LocalizedText
+              zh="把佛典浏览做成更顺手的流式入口。"
+              en="Turn scripture browsing into a calmer flowing surface."
+            />
+          </h1>
+          <p className="lede">
+            <LocalizedText
+              zh="这里用 CBETA API 提供正文与经目信息，同时接入 App 后端里的点赞、评论等互动统计。"
+              en="This surface uses the CBETA API for text and catalog data, while pulling engagement stats from the app backend."
+            />
+          </p>
+        </div>
+      </section>
+
+      <FaliuShell />
+      <SiteFooter />
+    </main>
+  );
+}

--- a/frontend/apps/web/src/components/faliu-shell.module.css
+++ b/frontend/apps/web/src/components/faliu-shell.module.css
@@ -1,0 +1,510 @@
+.band {
+  padding-top: 36px;
+}
+
+.shell {
+  width: min(1320px, 100%);
+  margin: 0 auto;
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.searchWrap {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.searchBox {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: min(100%, 820px);
+  min-height: 64px;
+  padding: 0 20px;
+  border: 1px solid rgba(255, 249, 235, 0.1);
+  border-radius: 18px;
+  background: rgba(8, 12, 18, 0.82);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.22);
+}
+
+.searchBox input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ink);
+  font-size: 1.05rem;
+}
+
+.searchBox input::placeholder {
+  color: rgba(255, 249, 235, 0.38);
+}
+
+.searchIcon {
+  color: var(--gold-soft);
+  font-size: 1.35rem;
+}
+
+.searchHint {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.downloadLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--gold), #ffe2a5);
+  color: var(--ink-dark);
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.tabRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 6px;
+  margin-bottom: 20px;
+}
+
+.tab,
+.activeTab {
+  min-height: 44px;
+  padding: 0 18px;
+  border: 1px solid rgba(255, 249, 235, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.05);
+  color: rgba(255, 249, 235, 0.72);
+  font-size: 0.96rem;
+  cursor: pointer;
+}
+
+.activeTab {
+  border-color: rgba(232, 189, 107, 0.34);
+  background: rgba(232, 189, 107, 0.14);
+  color: var(--ink);
+}
+
+.introRow {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 22px;
+}
+
+.sectionTitle {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(1.8rem, 3vw, 2.7rem);
+  line-height: 1;
+}
+
+.sectionHint {
+  margin: 10px 0 0;
+  max-width: 640px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.metaNote {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.metaNote span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.04);
+  color: var(--muted-strong);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.feedGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.feedCard {
+  min-width: 0;
+}
+
+.cardButton {
+  width: 100%;
+  min-height: 280px;
+  padding: 22px;
+  border: 1px solid rgba(255, 249, 235, 0.08);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(120, 214, 232, 0.05), transparent 35%),
+    linear-gradient(180deg, rgba(255, 249, 235, 0.06), rgba(8, 12, 18, 0.98));
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.cardButton:hover {
+  transform: translateY(-2px);
+  border-color: rgba(232, 189, 107, 0.24);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.cardTag,
+.cardCanon,
+.modalEyebrow {
+  color: var(--gold-soft);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cardButton h3,
+.modalHeader h3 {
+  margin: 18px 0 0;
+  color: var(--ink);
+  font-size: 1.52rem;
+  line-height: 1.24;
+}
+
+.byline,
+.modalByline {
+  margin: 12px 0 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.cardFacts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 22px 0 0;
+}
+
+.cardFacts div {
+  min-width: 0;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 249, 235, 0.05);
+}
+
+.cardFacts dt {
+  color: rgba(255, 249, 235, 0.44);
+  font-size: 0.8rem;
+}
+
+.cardFacts dd {
+  margin: 8px 0 0;
+  color: var(--ink);
+  font-size: 1.08rem;
+  font-weight: 700;
+}
+
+.cardMeta,
+.loadingLine,
+.mutedText {
+  margin: 18px 0 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.stateBox,
+.errorBox,
+.readerState {
+  display: grid;
+  place-items: center;
+  min-height: 180px;
+  border: 1px solid rgba(255, 249, 235, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 249, 235, 0.04);
+  color: var(--muted-strong);
+}
+
+.errorBox {
+  min-height: auto;
+  padding: 16px 18px;
+  margin-bottom: 18px;
+  place-items: start;
+  color: #ffd8bc;
+}
+
+.loadingLine {
+  text-align: center;
+}
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(5, 7, 13, 0.78);
+  backdrop-filter: blur(8px);
+  display: grid;
+  place-items: center;
+  padding: 18px;
+}
+
+.modal {
+  width: min(1440px, 100%);
+  max-height: calc(100svh - 36px);
+  overflow: hidden;
+  border: 1px solid rgba(255, 249, 235, 0.1);
+  border-radius: 22px;
+  background: #081018;
+  box-shadow: 0 36px 90px rgba(0, 0, 0, 0.4);
+}
+
+.modalHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 26px 28px 18px;
+}
+
+.closeButton {
+  width: 44px;
+  height: 44px;
+  border: 1px solid rgba(255, 249, 235, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.04);
+  color: var(--ink);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.modalMeta,
+.modalTabs {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 0 28px 16px;
+}
+
+.modalMeta span,
+.juanButton,
+.activeJuanButton {
+  min-height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.05);
+  color: var(--muted-strong);
+}
+
+.juanButton,
+.activeJuanButton {
+  border: 1px solid rgba(255, 249, 235, 0.08);
+  cursor: pointer;
+}
+
+.activeJuanButton {
+  border-color: rgba(232, 189, 107, 0.34);
+  background: rgba(232, 189, 107, 0.14);
+  color: var(--ink);
+}
+
+.modalBody {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.72fr);
+  min-height: 0;
+  max-height: calc(100svh - 230px);
+}
+
+.readerPanel,
+.sidePanel {
+  min-height: 0;
+}
+
+.readerPanel {
+  overflow: auto;
+  padding: 0 28px 28px;
+  border-right: 1px solid rgba(255, 249, 235, 0.08);
+}
+
+.readerHtml {
+  padding: 28px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 249, 235, 0.05), rgba(255, 249, 235, 0.02));
+  color: var(--muted-strong);
+  line-height: 1.85;
+  font-size: 1.04rem;
+}
+
+.readerHtml :global(.lb),
+.readerHtml :global(.noteAnchor),
+.readerHtml :global(.gaijiInfo),
+.readerHtml :global(#cbeta-copyright) {
+  display: none;
+}
+
+.readerHtml :global(p),
+.readerHtml :global(div),
+.readerHtml :global(li) {
+  margin: 0 0 14px;
+}
+
+.readerHtml :global(.head) {
+  margin: 24px 0 14px;
+  color: var(--ink);
+  font-size: 1.12rem;
+  font-weight: 700;
+}
+
+.readerHtml :global(.juan),
+.readerHtml :global(.byline) {
+  color: var(--gold-soft);
+}
+
+.readerHtml :global(.t),
+.readerHtml :global(.pc),
+.readerHtml :global(.cbeta) {
+  color: inherit;
+}
+
+.sidePanel {
+  overflow: auto;
+  padding: 0 24px 24px;
+}
+
+.infoPanel {
+  padding: 20px;
+  border: 1px solid rgba(255, 249, 235, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 249, 235, 0.03);
+}
+
+.infoPanel + .infoPanel {
+  margin-top: 16px;
+}
+
+.infoPanel h4 {
+  margin: 0 0 14px;
+  color: var(--ink);
+  font-size: 1rem;
+}
+
+.tocList,
+.commentList {
+  display: grid;
+  gap: 12px;
+}
+
+.tocItem,
+.commentItem {
+  padding: 14px;
+  border-radius: 12px;
+  background: rgba(255, 249, 235, 0.05);
+}
+
+.tocItem strong,
+.commentMeta strong {
+  display: block;
+  color: var(--ink);
+  line-height: 1.5;
+}
+
+.tocItem span,
+.commentMeta span,
+.commentItem small {
+  display: block;
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.commentMeta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.commentItem p {
+  margin: 10px 0 0;
+  color: var(--muted-strong);
+  line-height: 1.72;
+}
+
+@media (max-width: 1120px) {
+  .feedGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .modalBody {
+    grid-template-columns: minmax(0, 1fr);
+    max-height: calc(100svh - 200px);
+  }
+
+  .readerPanel {
+    border-right: 0;
+    border-bottom: 1px solid rgba(255, 249, 235, 0.08);
+  }
+}
+
+@media (max-width: 760px) {
+  .topbar,
+  .introRow,
+  .modalHeader {
+    flex-direction: column;
+  }
+
+  .feedGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cardFacts {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .modalBackdrop {
+    padding: 0;
+  }
+
+  .modal {
+    max-height: 100svh;
+    border-radius: 0;
+  }
+
+  .modalBody {
+    max-height: calc(100svh - 250px);
+  }
+
+  .readerPanel,
+  .sidePanel,
+  .modalHeader,
+  .modalMeta,
+  .modalTabs {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .readerHtml {
+    padding: 20px;
+  }
+}

--- a/frontend/apps/web/src/components/faliu-shell.tsx
+++ b/frontend/apps/web/src/components/faliu-shell.tsx
@@ -1,0 +1,601 @@
+"use client";
+
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { LocalizedText } from "./localized-text";
+import { siteHref } from "../lib/site-url";
+import {
+  buildCbetaContentId,
+  fetchAllWorks,
+  fetchBatchStats,
+  fetchComments,
+  fetchJuanDetail,
+  fetchWorkInfo,
+  searchWorksByTitle,
+  type AppComment,
+  type CbetaJuanDetail,
+  type CbetaWorkIndexItem,
+  type CbetaWorkInfo,
+  type ContentStats,
+} from "../lib/faliu-api";
+import styles from "./faliu-shell.module.css";
+
+type TabKey = "featured" | "prajna" | "pureland" | "lotus" | "huayan" | "zen";
+
+interface WorkCardItem {
+  work: string;
+  title: string;
+  juans: string[];
+  info?: CbetaWorkInfo | null;
+}
+
+const TAB_CONFIG: Array<{
+  key: TabKey;
+  labelZh: string;
+  labelEn: string;
+  hintZh: string;
+  hintEn: string;
+  featured: string[];
+  tokens: string[];
+}> = [
+  {
+    key: "featured",
+    labelZh: "精选",
+    labelEn: "Featured",
+    hintZh: "先看适合直接进入阅读的几部常见佛典。",
+    hintEn: "Start with a few approachable works that open quickly into reading.",
+    featured: ["T0365", "T0251", "T0262", "T0279", "T0261", "T0278", "T0235", "T0236", "T0270"],
+    tokens: [],
+  },
+  {
+    key: "prajna",
+    labelZh: "般若",
+    labelEn: "Prajna",
+    hintZh: "围绕般若、金刚、心经等主题聚合。",
+    hintEn: "Grouped around Prajna, Diamond, and Heart Sutra themes.",
+    featured: [],
+    tokens: ["般若", "金剛", "金刚", "心經", "心经"],
+  },
+  {
+    key: "pureland",
+    labelZh: "净土",
+    labelEn: "Pure Land",
+    hintZh: "以无量寿、阿弥陀、观经相关佛典为主。",
+    hintEn: "Centered on Amitabha, Infinite Life, and Visualization Sutra works.",
+    featured: [],
+    tokens: ["無量壽", "无量寿", "阿彌陀", "阿弥陀", "觀無量壽", "观无量寿"],
+  },
+  {
+    key: "lotus",
+    labelZh: "法华",
+    labelEn: "Lotus",
+    hintZh: "聚焦法华系统与相关注疏。",
+    hintEn: "Focused on the Lotus Sutra tradition and related commentaries.",
+    featured: [],
+    tokens: ["法華", "法华", "妙法蓮華", "妙法莲华"],
+  },
+  {
+    key: "huayan",
+    labelZh: "华严",
+    labelEn: "Huayan",
+    hintZh: "适合想直接切入华严体系的人。",
+    hintEn: "A direct entry into the Huayan corpus.",
+    featured: [],
+    tokens: ["華嚴", "华严"],
+  },
+  {
+    key: "zen",
+    labelZh: "禅门",
+    labelEn: "Zen",
+    hintZh: "偏向坛经、公案与禅宗相关文本。",
+    hintEn: "More oriented toward Chan texts, platform teachings, and koan material.",
+    featured: [],
+    tokens: ["壇經", "坛经", "禪", "禅", "祖師", "祖师"],
+  },
+];
+
+const CARD_LIMIT = 12;
+
+function dedupeWorks(items: CbetaWorkIndexItem[]) {
+  const seen = new Set<string>();
+  const next: CbetaWorkIndexItem[] = [];
+
+  for (const item of items) {
+    if (seen.has(item.work)) {
+      continue;
+    }
+
+    seen.add(item.work);
+    next.push(item);
+  }
+
+  return next;
+}
+
+function normalizeWorkCard(item: CbetaWorkIndexItem, info?: CbetaWorkInfo | null): WorkCardItem {
+  return {
+    work: item.work,
+    title: info?.title ?? item.title,
+    juans: item.juans,
+    info,
+  };
+}
+
+function flattenVisibleJuans(items: WorkCardItem[]) {
+  return items.map((item) => ({
+    contentId: buildCbetaContentId(item.work, item.juans[0] ?? "1"),
+    work: item.work,
+    juan: item.juans[0] ?? "1",
+  }));
+}
+
+function stripTags(value: string) {
+  return value.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function formatStats(value: number) {
+  if (value >= 10000) {
+    return `${(value / 10000).toFixed(1)}万`;
+  }
+
+  return `${value}`;
+}
+
+function formatCommentDate(value: string) {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+export function FaliuShell() {
+  const [activeTab, setActiveTab] = useState<TabKey>("featured");
+  const [works, setWorks] = useState<CbetaWorkIndexItem[]>([]);
+  const [workInfoMap, setWorkInfoMap] = useState<Record<string, CbetaWorkInfo | null>>({});
+  const [statsMap, setStatsMap] = useState<Record<string, ContentStats>>({});
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<WorkCardItem | null>(null);
+  const [selectedDetail, setSelectedDetail] = useState<CbetaJuanDetail | null>(null);
+  const [selectedComments, setSelectedComments] = useState<AppComment[]>([]);
+  const [selectedJuan, setSelectedJuan] = useState("1");
+  const [isBootLoading, setIsBootLoading] = useState(true);
+  const [isSearchLoading, setIsSearchLoading] = useState(false);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deferredQuery = useDeferredValue(query.trim());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function bootstrap() {
+      try {
+        setIsBootLoading(true);
+        const allWorks = await fetchAllWorks();
+
+        if (cancelled) {
+          return;
+        }
+
+        setWorks(allWorks);
+        setError(null);
+      } catch (cause) {
+        if (cancelled) {
+          return;
+        }
+
+        const message = cause instanceof Error ? cause.message : "法流数据加载失败";
+        setError(message);
+      } finally {
+        if (!cancelled) {
+          setIsBootLoading(false);
+        }
+      }
+    }
+
+    void bootstrap();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const activeTabConfig = TAB_CONFIG.find((item) => item.key === activeTab) ?? TAB_CONFIG[0];
+
+  const filteredWorks = useMemo(() => {
+    if (works.length === 0) {
+      return [];
+    }
+
+    if (deferredQuery.length >= 2) {
+      const lowered = deferredQuery.toLowerCase();
+      return works
+        .filter((item) => item.title.toLowerCase().includes(lowered) || item.work.toLowerCase().includes(lowered))
+        .slice(0, CARD_LIMIT);
+    }
+
+    if (activeTabConfig.featured.length > 0) {
+      const set = new Set(activeTabConfig.featured);
+      return works.filter((item) => set.has(item.work)).slice(0, CARD_LIMIT);
+    }
+
+    const matched = works.filter((item) =>
+      activeTabConfig.tokens.some((token) => item.title.includes(token)),
+    );
+
+    return matched.slice(0, CARD_LIMIT);
+  }, [activeTabConfig, deferredQuery, works]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function hydrateCards() {
+      if (filteredWorks.length === 0) {
+        return;
+      }
+
+      const missing = filteredWorks.filter((item) => !(item.work in workInfoMap));
+      const visibleJuans = flattenVisibleJuans(filteredWorks);
+      const missingContentIds = visibleJuans.filter((item) => !(item.contentId in statsMap));
+
+      if (missing.length === 0 && missingContentIds.length === 0) {
+        return;
+      }
+
+      try {
+        const [infos, stats] = await Promise.all([
+          missing.length > 0 ? Promise.all(missing.map((item) => fetchWorkInfo(item.work))) : Promise.resolve([]),
+          missingContentIds.length > 0
+            ? fetchBatchStats(missingContentIds.map((item) => item.contentId))
+            : Promise.resolve({}),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (infos.length > 0) {
+          setWorkInfoMap((current) => {
+            const next = { ...current };
+            for (let index = 0; index < missing.length; index += 1) {
+              next[missing[index].work] = infos[index];
+            }
+            return next;
+          });
+        }
+
+        if (Object.keys(stats).length > 0) {
+          setStatsMap((current) => ({ ...current, ...stats }));
+        }
+      } catch {
+        if (!cancelled) {
+          setError("部分法流数据暂时没能补齐，请稍后再试。");
+        }
+      }
+    }
+
+    void hydrateCards();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filteredWorks, statsMap, workInfoMap]);
+
+  useEffect(() => {
+    if (deferredQuery.length < 3) {
+      setIsSearchLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function runRemoteSearch() {
+      try {
+        setIsSearchLoading(true);
+        const results = await searchWorksByTitle(deferredQuery, 0, CARD_LIMIT);
+
+        if (cancelled) {
+          return;
+        }
+
+        const normalized = dedupeWorks(
+          results.map((item) => ({
+            work: item.work,
+            title: item.title,
+            juans: [String(item.juan ?? 1)],
+          })),
+        );
+
+        setWorks((current) => {
+          const merged = [...normalized, ...current];
+          return dedupeWorks(merged);
+        });
+
+        setWorkInfoMap((current) => {
+          const next = { ...current };
+          for (const item of results) {
+            next[item.work] = item;
+          }
+          return next;
+        });
+      } catch {
+        if (!cancelled) {
+          setError("搜索暂时失败，请稍后再试。");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsSearchLoading(false);
+        }
+      }
+    }
+
+    void runRemoteSearch();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [deferredQuery]);
+
+  const visibleCards = useMemo(
+    () => filteredWorks.map((item) => normalizeWorkCard(item, workInfoMap[item.work])),
+    [filteredWorks, workInfoMap],
+  );
+
+  async function openDetail(item: WorkCardItem, juan: string) {
+    setSelected(item);
+    setSelectedJuan(juan);
+    setIsDetailLoading(true);
+    setSelectedDetail(null);
+    setSelectedComments([]);
+
+    try {
+      const [detail, comments, stats] = await Promise.all([
+        fetchJuanDetail(item.work, juan),
+        fetchComments(buildCbetaContentId(item.work, juan)),
+        fetchBatchStats([buildCbetaContentId(item.work, juan)]),
+      ]);
+
+      setSelectedDetail(detail);
+      setSelectedComments(comments);
+      setStatsMap((current) => ({ ...current, ...stats }));
+      setError(null);
+    } catch {
+      setSelectedDetail(null);
+      setError("正文载入失败，请稍后重试。");
+    } finally {
+      setIsDetailLoading(false);
+    }
+  }
+
+  const selectedStats = selected
+    ? statsMap[buildCbetaContentId(selected.work, selectedJuan)] ?? { likeCount: 0, commentCount: 0 }
+    : { likeCount: 0, commentCount: 0 };
+
+  return (
+    <section className={`band ${styles.band}`}>
+      <div className={styles.shell}>
+        <div className={styles.topbar}>
+          <div className={styles.searchWrap}>
+            <label className={styles.searchBox}>
+              <span className={styles.searchIcon} aria-hidden="true">
+                Search
+              </span>
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="搜索经名、经号或关键词"
+                aria-label="搜索佛典"
+              />
+            </label>
+            <p className={styles.searchHint}>
+              <LocalizedText
+                zh="输入 3 个字以上会直接调用 CBETA 题名搜索。"
+                en="Queries with 3 or more characters call the CBETA title search directly."
+              />
+            </p>
+          </div>
+          <a className={styles.downloadLink} href={siteHref("/download")}>
+            <LocalizedText zh="下载 App" en="Download App" />
+          </a>
+        </div>
+
+        <div className={styles.tabRow} role="tablist" aria-label="法流分类">
+          {TAB_CONFIG.map((item) => {
+            const isActive = item.key === activeTab;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={isActive ? styles.activeTab : styles.tab}
+                onClick={() => {
+                  setActiveTab(item.key);
+                  setQuery("");
+                }}
+              >
+                <LocalizedText zh={item.labelZh} en={item.labelEn} />
+              </button>
+            );
+          })}
+        </div>
+
+        <div className={styles.introRow}>
+          <div>
+            <h2 className={styles.sectionTitle}>
+              <LocalizedText zh={activeTabConfig.labelZh} en={activeTabConfig.labelEn} />
+            </h2>
+            <p className={styles.sectionHint}>
+              <LocalizedText zh={activeTabConfig.hintZh} en={activeTabConfig.hintEn} />
+            </p>
+          </div>
+          <div className={styles.metaNote}>
+            <span>CBETA API</span>
+            <span>App Stats</span>
+            <span>Read Flow</span>
+          </div>
+        </div>
+
+        {error ? <p className={styles.errorBox}>{error}</p> : null}
+
+        {isBootLoading ? (
+          <div className={styles.stateBox}>
+            <LocalizedText zh="正在接入法流数据…" en="Loading the Faloo data surface..." />
+          </div>
+        ) : null}
+
+        {!isBootLoading && visibleCards.length === 0 ? (
+          <div className={styles.stateBox}>
+            <LocalizedText zh="这一组暂时没有可展示的佛典。" en="No matching works are available in this slice yet." />
+          </div>
+        ) : null}
+
+        <div className={styles.feedGrid}>
+          {visibleCards.map((item) => {
+            const firstJuan = item.juans[0] ?? "1";
+            const stats = statsMap[buildCbetaContentId(item.work, firstJuan)] ?? { likeCount: 0, commentCount: 0 };
+            const info = item.info;
+            return (
+              <article key={item.work} className={styles.feedCard}>
+                <button type="button" className={styles.cardButton} onClick={() => void openDetail(item, firstJuan)}>
+                  <div className={styles.cardHeader}>
+                    <span className={styles.cardTag}>{info?.category ?? item.work}</span>
+                    <span className={styles.cardCanon}>{item.work}</span>
+                  </div>
+                  <h3>{item.title}</h3>
+                  <p className={styles.byline}>{info?.byline ?? "CBETA 佛典"}</p>
+                  <dl className={styles.cardFacts}>
+                    <div>
+                      <dt>卷次</dt>
+                      <dd>{item.juans.length}</dd>
+                    </div>
+                    <div>
+                      <dt>点赞</dt>
+                      <dd>{formatStats(stats.likeCount)}</dd>
+                    </div>
+                    <div>
+                      <dt>评论</dt>
+                      <dd>{formatStats(stats.commentCount)}</dd>
+                    </div>
+                  </dl>
+                  <p className={styles.cardMeta}>
+                    {info?.time_dynasty ? `${info.time_dynasty} · ` : ""}
+                    {item.juans.length > 1 ? `共 ${item.juans.length} 卷` : `第 ${firstJuan} 卷`}
+                  </p>
+                </button>
+              </article>
+            );
+          })}
+        </div>
+
+        {isSearchLoading ? (
+          <p className={styles.loadingLine}>
+            <LocalizedText zh="正在补充题名搜索结果…" en="Pulling more title search results..." />
+          </p>
+        ) : null}
+      </div>
+
+      {selected ? (
+        <div className={styles.modalBackdrop} role="presentation" onClick={() => setSelected(null)}>
+          <div className={styles.modal} role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <div>
+                <p className={styles.modalEyebrow}>{selected.work}</p>
+                <h3>{selected.title}</h3>
+                <p className={styles.modalByline}>{selected.info?.byline ?? "CBETA 佛典"}</p>
+              </div>
+              <button type="button" className={styles.closeButton} onClick={() => setSelected(null)} aria-label="关闭">
+                X
+              </button>
+            </div>
+
+            <div className={styles.modalMeta}>
+              <span>Like {formatStats(selectedStats.likeCount)}</span>
+              <span>Comments {formatStats(selectedStats.commentCount)}</span>
+              <span>卷次 {selectedJuan}</span>
+            </div>
+
+            <div className={styles.modalTabs}>
+              {selected.juans.slice(0, 12).map((juan) => (
+                <button
+                  key={juan}
+                  type="button"
+                  className={juan === selectedJuan ? styles.activeJuanButton : styles.juanButton}
+                  onClick={() => void openDetail(selected, juan)}
+                >
+                  第 {juan} 卷
+                </button>
+              ))}
+            </div>
+
+            <div className={styles.modalBody}>
+              <section className={styles.readerPanel}>
+                {isDetailLoading ? (
+                  <div className={styles.readerState}>
+                    <LocalizedText zh="正文载入中…" en="Loading the text..." />
+                  </div>
+                ) : null}
+
+                {!isDetailLoading && selectedDetail ? (
+                  <div
+                    className={styles.readerHtml}
+                    dangerouslySetInnerHTML={{ __html: selectedDetail.html }}
+                  />
+                ) : null}
+
+                {!isDetailLoading && !selectedDetail ? (
+                  <div className={styles.readerState}>
+                    <LocalizedText zh="暂时没有拿到这一卷正文。" en="This juan is not available right now." />
+                  </div>
+                ) : null}
+              </section>
+
+              <aside className={styles.sidePanel}>
+                <section className={styles.infoPanel}>
+                  <h4>目录</h4>
+                  {selectedDetail?.toc && selectedDetail.toc.length > 0 ? (
+                    <div className={styles.tocList}>
+                      {selectedDetail.toc.slice(0, 18).map((node, index) => (
+                        <div key={`${node.lb ?? node.title ?? index}`} className={styles.tocItem}>
+                          <strong>{node.title ?? "未命名节点"}</strong>
+                          {node.lb ? <span>{node.lb}</span> : null}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className={styles.mutedText}>这一卷暂未返回目录结构。</p>
+                  )}
+                </section>
+
+                <section className={styles.infoPanel}>
+                  <h4>评论</h4>
+                  {selectedComments.length > 0 ? (
+                    <div className={styles.commentList}>
+                      {selectedComments.map((comment) => (
+                        <article key={comment.id} className={styles.commentItem}>
+                          <div className={styles.commentMeta}>
+                            <strong>{comment.nickname || comment.username || "法布施用户"}</strong>
+                            <span>{formatCommentDate(comment.createdAt)}</span>
+                          </div>
+                          <p>{stripTags(comment.content)}</p>
+                          {comment.mainPractice ? <small>主修功课：{comment.mainPractice}</small> : null}
+                        </article>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className={styles.mutedText}>这条佛典内容还没有同步到可展示的评论。</p>
+                  )}
+                </section>
+              </aside>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -4,6 +4,11 @@ import { siteHref } from "../lib/site-url";
 
 const NAV_ITEMS = [
   {
+    href: "/faliu",
+    zh: "法流",
+    en: "Faloo",
+  },
+  {
     href: "/faq",
     zh: "下载 FAQ",
     en: "Download FAQ",

--- a/frontend/apps/web/src/lib/faliu-api.ts
+++ b/frontend/apps/web/src/lib/faliu-api.ts
@@ -1,0 +1,226 @@
+export interface CbetaWorkIndexItem {
+  work: string;
+  title: string;
+  juans: string[];
+}
+
+export interface CbetaWorkInfo {
+  work: string;
+  category?: string;
+  orig_category?: string;
+  title: string;
+  byline?: string;
+  creators?: string;
+  time_dynasty?: string;
+  time_from?: number | null;
+  time_to?: number | null;
+  juan?: number;
+  juan_start?: number;
+  juan_end?: number;
+}
+
+export interface CbetaTocNode {
+  title?: string;
+  juan?: string | number;
+  lb?: string;
+  file?: string;
+  type?: string;
+  n?: string | number;
+  isFolder?: boolean;
+  children?: CbetaTocNode[];
+}
+
+export interface CbetaJuanDetail {
+  work: string;
+  juan: string;
+  html: string;
+  title: string;
+  byline?: string;
+  category?: string;
+  toc: CbetaTocNode[];
+  totalJuans: string[];
+}
+
+export interface ContentStats {
+  likeCount: number;
+  commentCount: number;
+}
+
+export interface AppComment {
+  id: number;
+  contentId: string;
+  content: string;
+  createdAt: string;
+  parentId?: number | null;
+  likeCount: number;
+  username?: string | null;
+  nickname?: string | null;
+  avatar?: string | null;
+  mainPractice?: string | null;
+}
+
+const CBETA_API_ROOT = "https://cbdata.dila.edu.tw/stable";
+const APP_API_ROOT = "https://api.ombhrum.com";
+
+function buildUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
+  const url = new URL(path, `${base}/`);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === "") {
+        continue;
+      }
+
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export function buildCbetaContentId(work: string, juan: string) {
+  return `cbeta:${work}:${juan}`;
+}
+
+export async function fetchAllWorks(): Promise<CbetaWorkIndexItem[]> {
+  return fetchJson<CbetaWorkIndexItem[]>(buildUrl(CBETA_API_ROOT, "download/all-works.json"));
+}
+
+export async function searchWorksByTitle(query: string, start = 0, rows = 24): Promise<CbetaWorkInfo[]> {
+  const data = await fetchJson<{
+    results?: Array<{
+      work?: string;
+      content?: string;
+      byline?: string;
+      juan?: number;
+      time_dynasty?: string;
+    }>;
+  }>(buildUrl(CBETA_API_ROOT, "search/title", { q: query, start, rows }));
+
+  return (data.results ?? []).flatMap((item) => {
+    if (!item.work || !item.content) {
+      return [];
+    }
+
+    return [
+      {
+        work: item.work,
+        title: item.content,
+        byline: item.byline,
+        juan: item.juan,
+        time_dynasty: item.time_dynasty,
+      },
+    ];
+  });
+}
+
+export async function fetchWorkInfo(work: string): Promise<CbetaWorkInfo | null> {
+  const data = await fetchJson<{ results?: CbetaWorkInfo[] }>(buildUrl(CBETA_API_ROOT, "works", { work }));
+  return data.results?.[0] ?? null;
+}
+
+export async function fetchJuanDetail(work: string, juan: string): Promise<CbetaJuanDetail | null> {
+  const data = await fetchJson<{
+    results?: Array<{ html?: string; juan?: string | number }>;
+    work_info?: CbetaWorkInfo;
+    toc?: { mulu?: CbetaTocNode[]; juan?: CbetaTocNode[] };
+  }>(buildUrl(CBETA_API_ROOT, "juans", { work, juan, work_info: 1, toc: 1 }));
+
+  const html = data.results?.[0]?.html;
+  const workInfo = data.work_info;
+
+  if (!html || !workInfo) {
+    return null;
+  }
+
+  return {
+    work,
+    juan,
+    html,
+    title: workInfo.title,
+    byline: workInfo.byline,
+    category: workInfo.category,
+    toc: [...(data.toc?.juan ?? []), ...(data.toc?.mulu ?? [])],
+    totalJuans: [],
+  };
+}
+
+export async function fetchBatchStats(contentIds: string[]): Promise<Record<string, ContentStats>> {
+  if (contentIds.length === 0) {
+    return {};
+  }
+
+  const response = await fetch(buildUrl(APP_API_ROOT, "api/content/batch-stats"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ contentIds }),
+  });
+
+  if (!response.ok) {
+    return {};
+  }
+
+  const data = (await response.json()) as {
+    stats?: Record<string, { likeCount?: number; commentCount?: number }>;
+  };
+
+  const entries = Object.entries(data.stats ?? {});
+  const mapped: Record<string, ContentStats> = {};
+
+  for (const [contentId, value] of entries) {
+    mapped[contentId] = {
+      likeCount: value.likeCount ?? 0,
+      commentCount: value.commentCount ?? 0,
+    };
+  }
+
+  return mapped;
+}
+
+export async function fetchComments(contentId: string): Promise<AppComment[]> {
+  const data = await fetchJson<{
+    comments?: Array<{
+      id: number;
+      content_id?: string;
+      video_id?: string;
+      content?: string;
+      created_at?: string;
+      parent_id?: number | null;
+      like_count?: number;
+      username?: string | null;
+      nickname?: string | null;
+      avatar?: string | null;
+      main_practice?: string | null;
+    }>;
+  }>(buildUrl(APP_API_ROOT, "api/comments", { contentId, page: 1, pageSize: 30 }));
+
+  return (data.comments ?? []).map((item) => ({
+    id: item.id,
+    contentId: item.content_id ?? item.video_id ?? contentId,
+    content: item.content ?? "",
+    createdAt: item.created_at ?? "",
+    parentId: item.parent_id,
+    likeCount: item.like_count ?? 0,
+    username: item.username,
+    nickname: item.nickname,
+    avatar: item.avatar,
+    mainPractice: item.main_practice,
+  }));
+}


### PR DESCRIPTION
## Summary
- add a new `/faliu` page on the official site and expose it in the top navigation
- build a client-side Faloo surface backed by the CBETA API for works, search, and juan HTML
- reuse app backend endpoints for likes, comment counts, and comment lists on CBETA content ids
- style the page as a feed-style browsing surface based on the provided reference

## Data wiring
- CBETA API: `download/all-works.json`, `search/title`, `works`, `juans`
- App backend: `/api/content/batch-stats`, `/api/comments`
- content id convention for web-side CBETA entries: `cbeta:<work>:<juan>`

## Notes
- this implementation is read-only for engagement data; it surfaces counts and comments but does not post comments or toggle likes
- I could not run live network verification from the workspace because outbound requests to the external APIs are blocked in this environment, so browser-side validation of CORS and exact payload behavior is still needed
