### PR TITLE
[codex] Polish CBETA Faloo feed UI

### DIFF
--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from "next";
 import { brand } from "@fabushi/shared";
-import { LocalizedText } from "../../components/localized-text";
-import { SiteFooter } from "../../components/site-footer";
-import { SiteHeader } from "../../components/site-header";
 import { FaliuShell } from "../../components/faliu-shell";
+import { FALIU_FEATURED_WORKS } from "../../lib/faliu-config";
+import {
+  buildCbetaContentId,
+  fetchAllWorks,
+  fetchBatchStats,
+  fetchWorkInfo,
+  type CbetaWorkInfo,
+  type ContentStats,
+  type CbetaWorkIndexItem,
+} from "../../lib/faliu-api";
 import { siteUrl } from "../../lib/site-url";
 
 const pageUrl = siteUrl("/faliu");
@@ -40,7 +47,42 @@ export const metadata: Metadata = {
   },
 };
 
-export default function FaliuPage() {
+async function loadInitialFaliuData() {
+  try {
+    const allWorks = await fetchAllWorks();
+    const featuredSet = new Set(FALIU_FEATURED_WORKS);
+    const featuredWorks = allWorks
+      .filter((item) => featuredSet.has(item.work))
+      .sort((left, right) => FALIU_FEATURED_WORKS.indexOf(left.work) - FALIU_FEATURED_WORKS.indexOf(right.work))
+      .slice(0, 12);
+    const fallbackWorks = featuredWorks.length > 0 ? featuredWorks : allWorks.slice(0, 12);
+    const infoEntries = await Promise.all(
+      fallbackWorks.map(async (item) => {
+        const info = await fetchWorkInfo(item.work).catch(() => null);
+        return [item.work, info] as const;
+      }),
+    );
+    const initialWorkInfo: Record<string, CbetaWorkInfo | null> = Object.fromEntries(infoEntries);
+    const initialStats: Record<string, ContentStats> = await fetchBatchStats(
+      fallbackWorks.map((item) => buildCbetaContentId(item.work, item.juans[0] ?? "1")),
+    ).catch(() => ({}));
+
+    return {
+      initialWorks: fallbackWorks,
+      initialWorkInfo,
+      initialStats,
+    };
+  } catch {
+    return {
+      initialWorks: [] as CbetaWorkIndexItem[],
+      initialWorkInfo: {},
+      initialStats: {},
+    };
+  }
+}
+
+export default async function FaliuPage() {
+  const initialData = await loadInitialFaliuData();
   const structuredData = {
     "@context": "https://schema.org",
     "@graph": [
@@ -66,36 +108,14 @@ export default function FaliuPage() {
   };
 
   return (
-    <main className="inner-page">
+    <main>
       <script
         type="application/ld+json"
         suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
-      <section className="inner-hero">
-        <SiteHeader />
-        <div className="inner-copy">
-          <p className="eyebrow">
-            <LocalizedText zh="法流" en="Faloo" />
-          </p>
-          <h1>
-            <LocalizedText
-              zh="把佛典浏览做成更顺手的流式入口。"
-              en="Turn scripture browsing into a calmer flowing surface."
-            />
-          </h1>
-          <p className="lede">
-            <LocalizedText
-              zh="这里用 CBETA API 提供正文与经目信息，同时接入 App 后端里的点赞、评论等互动统计。"
-              en="This surface uses the CBETA API for text and catalog data, while pulling engagement stats from the app backend."
-            />
-          </p>
-        </div>
-      </section>
-
-      <FaliuShell />
-      <SiteFooter />
+      <FaliuShell {...initialData} />
     </main>
   );
 }

--- a/frontend/apps/web/src/components/faliu-shell.module.css
+++ b/frontend/apps/web/src/components/faliu-shell.module.css
@@ -1,237 +1,429 @@
-.band {
-  padding-top: 36px;
+.appShell {
+  position: relative;
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr);
+  min-height: 100svh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 180px),
+    #0b0d16;
+  color: var(--ink);
+  overflow: hidden;
 }
 
-.shell {
-  width: min(1320px, 100%);
-  margin: 0 auto;
-}
-
-.topbar {
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100svh;
+  min-width: 0;
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 18px;
+  flex-direction: column;
+  gap: 24px;
+  padding: 28px 18px 24px 22px;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(13, 16, 28, 0.98), rgba(9, 11, 20, 0.98));
 }
 
-.searchWrap {
-  flex: 1 1 auto;
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   min-width: 0;
 }
 
-.searchBox {
+.brandMark,
+.installMark {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  background: #19e4dc;
+  color: #071015;
+  font-size: 1.3rem;
+  font-weight: 900;
+  box-shadow: 0 0 0 3px rgba(25, 228, 220, 0.12);
+}
+
+.brand strong,
+.installPanel strong {
+  display: block;
+  color: #ffffff;
+  font-size: 1.03rem;
+  line-height: 1.15;
+}
+
+.brand small,
+.installPanel small {
+  display: block;
+  margin-top: 4px;
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.sideNav {
+  display: grid;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.sideItem,
+.activeSideItem {
   display: flex;
   align-items: center;
+  gap: 14px;
+  min-height: 52px;
+  padding: 0 14px;
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.68);
+  font-weight: 720;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.sideItem:hover,
+.activeSideItem {
+  background: rgba(255, 255, 255, 0.11);
+  color: #ffffff;
+}
+
+.sideItem > span:first-child,
+.activeSideItem > span:first-child {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  color: currentColor;
+  font-size: 0.95rem;
+  font-weight: 900;
+}
+
+.installPanel {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
   gap: 12px;
-  width: min(100%, 820px);
-  min-height: 64px;
-  padding: 0 20px;
-  border: 1px solid rgba(255, 249, 235, 0.1);
-  border-radius: 18px;
-  background: rgba(8, 12, 18, 0.82);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.22);
+  align-items: center;
+  margin-top: auto;
+  padding: 14px;
+  border: 1px solid rgba(25, 228, 220, 0.26);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(25, 228, 220, 0.12), rgba(255, 255, 255, 0.035));
+}
+
+.mainPane {
+  min-width: 0;
+  height: 100svh;
+  overflow: auto;
+  padding: 26px clamp(18px, 3vw, 42px) 48px;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  min-height: 70px;
+  margin: -26px calc(clamp(18px, 3vw, 42px) * -1) 14px;
+  padding: 14px clamp(18px, 3vw, 42px);
+  background: rgba(11, 13, 22, 0.88);
+  backdrop-filter: blur(16px);
+}
+
+.searchBox {
+  flex: 0 1 660px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 56px;
+  padding: 0 12px 0 18px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.11);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.22);
+}
+
+.searchGlyph {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  border: 3px solid rgba(255, 255, 255, 0.78);
+  border-radius: 999px;
+}
+
+.searchGlyph::after {
+  content: "";
+  position: absolute;
+  right: -7px;
+  bottom: -5px;
+  width: 8px;
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  transform: rotate(45deg);
 }
 
 .searchBox input {
+  min-width: 0;
   width: 100%;
   border: 0;
   outline: 0;
   background: transparent;
-  color: var(--ink);
-  font-size: 1.05rem;
+  color: #ffffff;
+  font-size: 1rem;
 }
 
 .searchBox input::placeholder {
-  color: rgba(255, 249, 235, 0.38);
+  color: rgba(255, 255, 255, 0.46);
 }
 
-.searchIcon {
-  color: var(--gold-soft);
-  font-size: 1.35rem;
+.searchBox button {
+  min-height: 38px;
+  padding: 0 18px;
+  border: 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.16);
+  background: transparent;
+  color: #ffffff;
+  font-weight: 820;
+  cursor: pointer;
 }
 
-.searchHint {
-  margin: 10px 0 0;
-  color: var(--muted);
-  font-size: 0.92rem;
-}
-
-.downloadLink {
-  display: inline-flex;
+.actionRow {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  min-height: 48px;
-  padding: 0 20px;
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--gold), #ffe2a5);
-  color: var(--ink-dark);
-  font-weight: 800;
-  white-space: nowrap;
+  gap: 14px;
+}
+
+.actionButton {
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+  min-width: 46px;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 0.75rem;
+}
+
+.actionButton span {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  font-weight: 900;
+}
+
+.actionButton small {
+  font-size: 0.72rem;
 }
 
 .tabRow {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: clamp(18px, 2.3vw, 34px);
+  min-width: 0;
   overflow-x: auto;
-  padding-bottom: 6px;
-  margin-bottom: 20px;
+  padding: 0 0 14px;
+  margin-bottom: 14px;
+  scrollbar-width: none;
+}
+
+.tabRow::-webkit-scrollbar {
+  display: none;
 }
 
 .tab,
 .activeTab {
-  min-height: 44px;
-  padding: 0 18px;
-  border: 1px solid rgba(255, 249, 235, 0.08);
-  border-radius: 999px;
-  background: rgba(255, 249, 235, 0.05);
-  color: rgba(255, 249, 235, 0.72);
-  font-size: 0.96rem;
+  position: relative;
+  flex: 0 0 auto;
+  min-height: 40px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 1rem;
+  font-weight: 720;
   cursor: pointer;
 }
 
 .activeTab {
-  border-color: rgba(232, 189, 107, 0.34);
-  background: rgba(232, 189, 107, 0.14);
-  color: var(--ink);
+  color: #ffffff;
 }
 
-.introRow {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 22px;
-}
-
-.sectionTitle {
-  margin: 0;
-  color: var(--ink);
-  font-size: clamp(1.8rem, 3vw, 2.7rem);
-  line-height: 1;
-}
-
-.sectionHint {
-  margin: 10px 0 0;
-  max-width: 640px;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
-.metaNote {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.metaNote span {
-  display: inline-flex;
-  align-items: center;
-  min-height: 34px;
-  padding: 0 12px;
+.activeTab::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 28px;
+  height: 4px;
   border-radius: 999px;
-  background: rgba(255, 249, 235, 0.04);
-  color: var(--muted-strong);
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  background: #ff2e6d;
+  transform: translateX(-50%);
 }
 
 .feedGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
+  gap: 28px 22px;
+  align-items: start;
 }
 
 .feedCard {
   min-width: 0;
 }
 
-.cardButton {
+.coverButton,
+.titleButton {
   width: 100%;
-  min-height: 280px;
-  padding: 22px;
-  border: 1px solid rgba(255, 249, 235, 0.08);
-  border-radius: 16px;
-  background:
-    linear-gradient(180deg, rgba(120, 214, 232, 0.05), transparent 35%),
-    linear-gradient(180deg, rgba(255, 249, 235, 0.06), rgba(8, 12, 18, 0.98));
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: inherit;
   text-align: left;
   cursor: pointer;
-  transition: transform 180ms ease, border-color 180ms ease;
 }
 
-.cardButton:hover {
+.cover {
+  position: relative;
+  min-width: 0;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 8px;
+  background:
+    linear-gradient(var(--cover-angle), color-mix(in srgb, var(--cover-b) 78%, #000 22%), transparent 42%),
+    linear-gradient(180deg, color-mix(in srgb, var(--cover-a) 88%, #fff 12%), var(--cover-a));
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.3);
+  transition: transform 180ms ease, filter 180ms ease;
+}
+
+.coverButton:hover .cover {
   transform: translateY(-2px);
-  border-color: rgba(232, 189, 107, 0.24);
+  filter: saturate(1.08);
 }
 
-.cardHeader {
+.coverTexture {
+  position: absolute;
+  inset: 0;
+  opacity: 0.34;
+  background:
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.12) 0 1px, transparent 1px 36px),
+    repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.16) 0 2px, transparent 2px 22px);
+  mix-blend-mode: overlay;
+}
+
+.cover::before {
+  content: "";
+  position: absolute;
+  inset: 14px;
+  border: 1px solid color-mix(in srgb, var(--cover-c) 58%, transparent);
+  border-radius: 8px;
+}
+
+.coverTopline,
+.coverBottom {
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-}
-
-.cardTag,
-.cardCanon,
-.modalEyebrow {
-  color: var(--gold-soft);
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.cardButton h3,
-.modalHeader h3 {
-  margin: 18px 0 0;
-  color: var(--ink);
-  font-size: 1.52rem;
-  line-height: 1.24;
-}
-
-.byline,
-.modalByline {
-  margin: 12px 0 0;
-  color: var(--muted);
-  line-height: 1.65;
-}
-
-.cardFacts {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-  margin: 22px 0 0;
-}
-
-.cardFacts div {
-  min-width: 0;
-  padding: 12px;
-  border-radius: 12px;
-  background: rgba(255, 249, 235, 0.05);
-}
-
-.cardFacts dt {
-  color: rgba(255, 249, 235, 0.44);
+  color: color-mix(in srgb, var(--cover-ink) 84%, transparent);
   font-size: 0.8rem;
+  font-weight: 760;
 }
 
-.cardFacts dd {
+.coverTopline {
+  top: 16px;
+}
+
+.coverTopline span,
+.coverBottom span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coverBottom {
+  bottom: 16px;
+}
+
+.coverCenter {
+  position: absolute;
+  inset: 44px 24px 44px;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 9px;
+  text-align: center;
+}
+
+.coverCenter span {
+  color: color-mix(in srgb, var(--cover-c) 88%, #ffffff 12%);
+  font-weight: 900;
+  font-size: 0.86rem;
+}
+
+.coverCenter h2 {
+  display: -webkit-box;
+  margin: 0;
+  max-width: 94%;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: var(--cover-ink);
+  font-family: "Noto Serif SC", "Songti SC", serif;
+  font-size: clamp(1.35rem, 2.15vw, 2.28rem);
+  line-height: 1.12;
+  text-wrap: balance;
+}
+
+.coverCenter p {
+  display: -webkit-box;
+  margin: 0;
+  max-width: min(420px, 88%);
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  color: color-mix(in srgb, var(--cover-ink) 78%, transparent);
+  font-size: 0.88rem;
+  line-height: 1.35;
+}
+
+.titleButton {
+  display: -webkit-box;
+  margin-top: 12px;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: rgba(255, 255, 255, 0.94);
+  font-size: 1.03rem;
+  font-weight: 780;
+  line-height: 1.42;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   margin: 8px 0 0;
-  color: var(--ink);
-  font-size: 1.08rem;
-  font-weight: 700;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.92rem;
+  line-height: 1.4;
 }
 
-.cardMeta,
-.loadingLine,
-.mutedText {
-  margin: 18px 0 0;
-  color: var(--muted);
-  line-height: 1.65;
+.cardMeta span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .stateBox,
@@ -240,41 +432,70 @@
   display: grid;
   place-items: center;
   min-height: 180px;
-  border: 1px solid rgba(255, 249, 235, 0.08);
-  border-radius: 16px;
-  background: rgba(255, 249, 235, 0.04);
-  color: var(--muted-strong);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .errorBox {
   min-height: auto;
-  padding: 16px 18px;
-  margin-bottom: 18px;
+  padding: 14px 16px;
+  margin: 0 0 18px;
   place-items: start;
-  color: #ffd8bc;
+  color: #ffd4c4;
+}
+
+.loadingLine,
+.mutedText {
+  margin: 18px 0 0;
+  color: rgba(255, 255, 255, 0.58);
+  line-height: 1.65;
 }
 
 .loadingLine {
   text-align: center;
 }
 
+.floatRail {
+  position: fixed;
+  right: 18px;
+  top: 38%;
+  z-index: 20;
+  display: grid;
+  gap: 12px;
+}
+
+.floatRail span {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.76);
+  font-weight: 860;
+  backdrop-filter: blur(12px);
+}
+
 .modalBackdrop {
   position: fixed;
   inset: 0;
   z-index: 100;
-  background: rgba(5, 7, 13, 0.78);
-  backdrop-filter: blur(8px);
   display: grid;
   place-items: center;
   padding: 18px;
+  background: rgba(5, 7, 13, 0.78);
+  backdrop-filter: blur(8px);
 }
 
 .modal {
   width: min(1440px, 100%);
   max-height: calc(100svh - 36px);
   overflow: hidden;
-  border: 1px solid rgba(255, 249, 235, 0.1);
-  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
   background: #081018;
   box-shadow: 0 36px 90px rgba(0, 0, 0, 0.4);
 }
@@ -284,17 +505,37 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 18px;
-  padding: 26px 28px 18px;
+  padding: 24px 28px 16px;
+}
+
+.modalEyebrow {
+  margin: 0 0 8px;
+  color: var(--gold-soft);
+  font-size: 0.84rem;
+}
+
+.modalHeader h3 {
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(1.5rem, 2.7vw, 2.4rem);
+  line-height: 1.18;
+}
+
+.modalByline {
+  margin: 10px 0 0;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 1.6;
 }
 
 .closeButton {
+  flex: 0 0 auto;
   width: 44px;
   height: 44px;
-  border: 1px solid rgba(255, 249, 235, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 999px;
-  background: rgba(255, 249, 235, 0.04);
-  color: var(--ink);
-  font-size: 1.5rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: #ffffff;
+  font-size: 1.15rem;
   cursor: pointer;
 }
 
@@ -311,29 +552,30 @@
 .juanButton,
 .activeJuanButton {
   min-height: 36px;
-  padding: 0 12px;
+  padding: 8px 12px;
   border-radius: 999px;
-  background: rgba(255, 249, 235, 0.05);
-  color: var(--muted-strong);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.2;
 }
 
 .juanButton,
 .activeJuanButton {
-  border: 1px solid rgba(255, 249, 235, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   cursor: pointer;
 }
 
 .activeJuanButton {
   border-color: rgba(232, 189, 107, 0.34);
   background: rgba(232, 189, 107, 0.14);
-  color: var(--ink);
+  color: #ffffff;
 }
 
 .modalBody {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.72fr);
+  grid-template-columns: minmax(0, 1.42fr) minmax(320px, 0.7fr);
   min-height: 0;
-  max-height: calc(100svh - 230px);
+  max-height: calc(100svh - 226px);
 }
 
 .readerPanel,
@@ -344,14 +586,14 @@
 .readerPanel {
   overflow: auto;
   padding: 0 28px 28px;
-  border-right: 1px solid rgba(255, 249, 235, 0.08);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .readerHtml {
   padding: 28px;
-  border-radius: 18px;
-  background: linear-gradient(180deg, rgba(255, 249, 235, 0.05), rgba(255, 249, 235, 0.02));
-  color: var(--muted-strong);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.055);
+  color: rgba(255, 255, 255, 0.78);
   line-height: 1.85;
   font-size: 1.04rem;
 }
@@ -371,9 +613,9 @@
 
 .readerHtml :global(.head) {
   margin: 24px 0 14px;
-  color: var(--ink);
+  color: #ffffff;
   font-size: 1.12rem;
-  font-weight: 700;
+  font-weight: 760;
 }
 
 .readerHtml :global(.juan),
@@ -393,10 +635,10 @@
 }
 
 .infoPanel {
-  padding: 20px;
-  border: 1px solid rgba(255, 249, 235, 0.08);
-  border-radius: 16px;
-  background: rgba(255, 249, 235, 0.03);
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .infoPanel + .infoPanel {
@@ -405,7 +647,7 @@
 
 .infoPanel h4 {
   margin: 0 0 14px;
-  color: var(--ink);
+  color: #ffffff;
   font-size: 1rem;
 }
 
@@ -418,14 +660,14 @@
 .tocItem,
 .commentItem {
   padding: 14px;
-  border-radius: 12px;
-  background: rgba(255, 249, 235, 0.05);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.055);
 }
 
 .tocItem strong,
 .commentMeta strong {
   display: block;
-  color: var(--ink);
+  color: #ffffff;
   line-height: 1.5;
 }
 
@@ -434,7 +676,7 @@
 .commentItem small {
   display: block;
   margin-top: 6px;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.55);
   font-size: 0.86rem;
 }
 
@@ -447,11 +689,39 @@
 
 .commentItem p {
   margin: 10px 0 0;
-  color: var(--muted-strong);
+  color: rgba(255, 255, 255, 0.76);
   line-height: 1.72;
 }
 
-@media (max-width: 1120px) {
+@media (max-width: 1180px) {
+  .appShell {
+    grid-template-columns: 86px minmax(0, 1fr);
+  }
+
+  .sidebar {
+    padding: 22px 12px;
+    align-items: center;
+  }
+
+  .brand > span:not(.brandMark),
+  .sideItem :global(.localized-text),
+  .activeSideItem :global(.localized-text),
+  .installPanel > span:not(.installMark) {
+    display: none;
+  }
+
+  .sideItem,
+  .activeSideItem {
+    justify-content: center;
+    width: 54px;
+    padding: 0;
+  }
+
+  .installPanel {
+    display: flex;
+    padding: 10px;
+  }
+
   .feedGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -463,23 +733,79 @@
 
   .readerPanel {
     border-right: 0;
-    border-bottom: 1px solid rgba(255, 249, 235, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 }
 
 @media (max-width: 760px) {
-  .topbar,
-  .introRow,
-  .modalHeader {
+  .appShell {
+    display: block;
+    overflow: auto;
+  }
+
+  .sidebar {
+    position: relative;
+    height: auto;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 14px;
+    border-right: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .brand > span:not(.brandMark) {
+    display: block;
+  }
+
+  .sideNav {
+    display: none;
+  }
+
+  .installPanel {
+    margin: 0;
+  }
+
+  .mainPane {
+    height: auto;
+    min-height: calc(100svh - 64px);
+    overflow: visible;
+    padding: 12px 14px 34px;
+  }
+
+  .topbar {
+    position: relative;
     flex-direction: column;
+    align-items: stretch;
+    min-height: auto;
+    margin: 0 0 12px;
+    padding: 0;
+    background: transparent;
+    backdrop-filter: none;
+  }
+
+  .searchBox {
+    flex: 0 0 auto;
+    width: 100%;
+    grid-template-columns: 22px minmax(0, 1fr) auto;
+    min-height: 50px;
+  }
+
+  .actionRow {
+    justify-content: space-between;
+  }
+
+  .tabRow {
+    gap: 22px;
   }
 
   .feedGrid {
     grid-template-columns: minmax(0, 1fr);
+    gap: 22px;
   }
 
-  .cardFacts {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .floatRail {
+    display: none;
   }
 
   .modalBackdrop {
@@ -502,6 +828,10 @@
   .modalTabs {
     padding-left: 18px;
     padding-right: 18px;
+  }
+
+  .modalHeader {
+    flex-direction: column;
   }
 
   .readerHtml {

--- a/frontend/apps/web/src/components/faliu-shell.tsx
+++ b/frontend/apps/web/src/components/faliu-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { LocalizedText } from "./localized-text";
 import { siteHref } from "../lib/site-url";
+import { CARD_LIMIT, FALIU_TABS, type FaliuTabKey } from "../lib/faliu-config";
 import {
   buildCbetaContentId,
   fetchAllWorks,
@@ -19,7 +21,11 @@ import {
 } from "../lib/faliu-api";
 import styles from "./faliu-shell.module.css";
 
-type TabKey = "featured" | "prajna" | "pureland" | "lotus" | "huayan" | "zen";
+export interface FaliuInitialData {
+  initialWorks?: CbetaWorkIndexItem[];
+  initialWorkInfo?: Record<string, CbetaWorkInfo | null>;
+  initialStats?: Record<string, ContentStats>;
+}
 
 interface WorkCardItem {
   work: string;
@@ -28,72 +34,29 @@ interface WorkCardItem {
   info?: CbetaWorkInfo | null;
 }
 
-const TAB_CONFIG: Array<{
-  key: TabKey;
-  labelZh: string;
-  labelEn: string;
-  hintZh: string;
-  hintEn: string;
-  featured: string[];
-  tokens: string[];
-}> = [
-  {
-    key: "featured",
-    labelZh: "精选",
-    labelEn: "Featured",
-    hintZh: "先看适合直接进入阅读的几部常见佛典。",
-    hintEn: "Start with a few approachable works that open quickly into reading.",
-    featured: ["T0365", "T0251", "T0262", "T0279", "T0261", "T0278", "T0235", "T0236", "T0270"],
-    tokens: [],
-  },
-  {
-    key: "prajna",
-    labelZh: "般若",
-    labelEn: "Prajna",
-    hintZh: "围绕般若、金刚、心经等主题聚合。",
-    hintEn: "Grouped around Prajna, Diamond, and Heart Sutra themes.",
-    featured: [],
-    tokens: ["般若", "金剛", "金刚", "心經", "心经"],
-  },
-  {
-    key: "pureland",
-    labelZh: "净土",
-    labelEn: "Pure Land",
-    hintZh: "以无量寿、阿弥陀、观经相关佛典为主。",
-    hintEn: "Centered on Amitabha, Infinite Life, and Visualization Sutra works.",
-    featured: [],
-    tokens: ["無量壽", "无量寿", "阿彌陀", "阿弥陀", "觀無量壽", "观无量寿"],
-  },
-  {
-    key: "lotus",
-    labelZh: "法华",
-    labelEn: "Lotus",
-    hintZh: "聚焦法华系统与相关注疏。",
-    hintEn: "Focused on the Lotus Sutra tradition and related commentaries.",
-    featured: [],
-    tokens: ["法華", "法华", "妙法蓮華", "妙法莲华"],
-  },
-  {
-    key: "huayan",
-    labelZh: "华严",
-    labelEn: "Huayan",
-    hintZh: "适合想直接切入华严体系的人。",
-    hintEn: "A direct entry into the Huayan corpus.",
-    featured: [],
-    tokens: ["華嚴", "华严"],
-  },
-  {
-    key: "zen",
-    labelZh: "禅门",
-    labelEn: "Zen",
-    hintZh: "偏向坛经、公案与禅宗相关文本。",
-    hintEn: "More oriented toward Chan texts, platform teachings, and koan material.",
-    featured: [],
-    tokens: ["壇經", "坛经", "禪", "禅", "祖師", "祖师"],
-  },
-];
+const SIDE_NAV_ITEMS = [
+  { href: "/faliu", labelZh: "精选", labelEn: "Featured", mark: "法", active: true },
+  { href: "/sutra-guide", labelZh: "推荐", labelEn: "Guide", mark: "荐" },
+  { href: "/sutra-listening", labelZh: "听经", labelEn: "Listen", mark: "听" },
+  { href: "/daily-practice", labelZh: "修行", labelEn: "Practice", mark: "修" },
+  { href: "/community", labelZh: "社区", labelEn: "Community", mark: "众" },
+  { href: "/download", labelZh: "下载", labelEn: "Download", mark: "下" },
+] as const;
 
-const CARD_LIMIT = 12;
+const TOP_ACTIONS = [
+  { href: "/download", labelZh: "客户端", labelEn: "App", mark: "下" },
+  { href: "/faq", labelZh: "说明", labelEn: "FAQ", mark: "问" },
+  { href: "/contact", labelZh: "联系", labelEn: "Contact", mark: "信" },
+] as const;
+
+const COVER_PALETTES = [
+  { a: "#13251f", b: "#d4a64a", c: "#f4efe1", ink: "#fff8e7" },
+  { a: "#182236", b: "#3fb7a4", c: "#f1c15d", ink: "#f8fbff" },
+  { a: "#2a1817", b: "#c45844", c: "#f7d17a", ink: "#fff4e8" },
+  { a: "#142735", b: "#77c0d8", c: "#e8bd6b", ink: "#f5fbff" },
+  { a: "#261c2b", b: "#9bc27f", c: "#f0d36c", ink: "#fff7ee" },
+  { a: "#1e2419", b: "#d78b56", c: "#b8d9ce", ink: "#fff9ed" },
+];
 
 function dedupeWorks(items: CbetaWorkIndexItem[]) {
   const seen = new Set<string>();
@@ -114,13 +77,13 @@ function dedupeWorks(items: CbetaWorkIndexItem[]) {
 function normalizeWorkCard(item: CbetaWorkIndexItem, info?: CbetaWorkInfo | null): WorkCardItem {
   return {
     work: item.work,
-    title: info?.title ?? item.title,
+    title: stripTags(info?.title ?? item.title),
     juans: item.juans,
     info,
   };
 }
 
-function flattenVisibleJuans(items: WorkCardItem[]) {
+function flattenVisibleJuans(items: CbetaWorkIndexItem[]) {
   return items.map((item) => ({
     contentId: buildCbetaContentId(item.work, item.juans[0] ?? "1"),
     work: item.work,
@@ -153,17 +116,65 @@ function formatCommentDate(value: string) {
   return date.toISOString().slice(0, 10);
 }
 
-export function FaliuShell() {
-  const [activeTab, setActiveTab] = useState<TabKey>("featured");
-  const [works, setWorks] = useState<CbetaWorkIndexItem[]>([]);
-  const [workInfoMap, setWorkInfoMap] = useState<Record<string, CbetaWorkInfo | null>>({});
-  const [statsMap, setStatsMap] = useState<Record<string, ContentStats>>({});
+function getHash(value: string) {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash;
+}
+
+function getByline(info?: CbetaWorkInfo | null) {
+  return stripTags(info?.byline ?? info?.creators ?? "CBETA 佛典") || "CBETA 佛典";
+}
+
+function getTranslator(info?: CbetaWorkInfo | null) {
+  const creators = stripTags(info?.creators ?? "");
+
+  if (creators) {
+    return creators.endsWith("譯") || creators.endsWith("译") ? creators : `${creators} 譯`;
+  }
+
+  const byline = stripTags(info?.byline ?? "");
+  return byline || "譯者見 CBETA";
+}
+
+function getCoverStyle(item: WorkCardItem): CSSProperties {
+  const seed = getHash(`${item.title}:${getTranslator(item.info)}:${item.work}`);
+  const palette = COVER_PALETTES[seed % COVER_PALETTES.length];
+  const angle = 128 + (seed % 42);
+
+  return {
+    "--cover-a": palette.a,
+    "--cover-b": palette.b,
+    "--cover-c": palette.c,
+    "--cover-ink": palette.ink,
+    "--cover-angle": `${angle}deg`,
+  } as CSSProperties;
+}
+
+function getCategoryLabel(info?: CbetaWorkInfo | null, fallback?: string) {
+  const category = stripTags(info?.category ?? info?.orig_category ?? "");
+  return category ? category.split(/[，,]/)[0] : fallback ?? "CBETA";
+}
+
+export function FaliuShell({
+  initialWorks = [],
+  initialWorkInfo = {},
+  initialStats = {},
+}: FaliuInitialData) {
+  const [activeTab, setActiveTab] = useState<FaliuTabKey>("all");
+  const [works, setWorks] = useState<CbetaWorkIndexItem[]>(initialWorks);
+  const [workInfoMap, setWorkInfoMap] = useState<Record<string, CbetaWorkInfo | null>>(initialWorkInfo);
+  const [statsMap, setStatsMap] = useState<Record<string, ContentStats>>(initialStats);
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<WorkCardItem | null>(null);
   const [selectedDetail, setSelectedDetail] = useState<CbetaJuanDetail | null>(null);
   const [selectedComments, setSelectedComments] = useState<AppComment[]>([]);
   const [selectedJuan, setSelectedJuan] = useState("1");
-  const [isBootLoading, setIsBootLoading] = useState(true);
+  const [isBootLoading, setIsBootLoading] = useState(initialWorks.length === 0);
   const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -175,17 +186,20 @@ export function FaliuShell() {
 
     async function bootstrap() {
       try {
-        setIsBootLoading(true);
+        if (works.length === 0) {
+          setIsBootLoading(true);
+        }
+
         const allWorks = await fetchAllWorks();
 
         if (cancelled) {
           return;
         }
 
-        setWorks(allWorks);
+        setWorks((current) => dedupeWorks([...current, ...allWorks]));
         setError(null);
       } catch (cause) {
-        if (cancelled) {
+        if (cancelled || works.length > 0) {
           return;
         }
 
@@ -205,7 +219,7 @@ export function FaliuShell() {
     };
   }, []);
 
-  const activeTabConfig = TAB_CONFIG.find((item) => item.key === activeTab) ?? TAB_CONFIG[0];
+  const activeTabConfig = FALIU_TABS.find((item) => item.key === activeTab) ?? FALIU_TABS[0];
 
   const filteredWorks = useMemo(() => {
     if (works.length === 0) {
@@ -224,10 +238,7 @@ export function FaliuShell() {
       return works.filter((item) => set.has(item.work)).slice(0, CARD_LIMIT);
     }
 
-    const matched = works.filter((item) =>
-      activeTabConfig.tokens.some((token) => item.title.includes(token)),
-    );
-
+    const matched = works.filter((item) => activeTabConfig.tokens.some((token) => item.title.includes(token)));
     return matched.slice(0, CARD_LIMIT);
   }, [activeTabConfig, deferredQuery, works]);
 
@@ -306,16 +317,12 @@ export function FaliuShell() {
         const normalized = dedupeWorks(
           results.map((item) => ({
             work: item.work,
-            title: item.title,
+            title: stripTags(item.title),
             juans: [String(item.juan ?? 1)],
           })),
         );
 
-        setWorks((current) => {
-          const merged = [...normalized, ...current];
-          return dedupeWorks(merged);
-        });
-
+        setWorks((current) => dedupeWorks([...normalized, ...current]));
         setWorkInfoMap((current) => {
           const next = { ...current };
           for (const item of results) {
@@ -354,10 +361,11 @@ export function FaliuShell() {
     setSelectedComments([]);
 
     try {
+      const contentId = buildCbetaContentId(item.work, juan);
       const [detail, comments, stats] = await Promise.all([
         fetchJuanDetail(item.work, juan),
-        fetchComments(buildCbetaContentId(item.work, juan)),
-        fetchBatchStats([buildCbetaContentId(item.work, juan)]),
+        fetchComments(contentId),
+        fetchBatchStats([contentId]),
       ]);
 
       setSelectedDetail(detail);
@@ -377,35 +385,75 @@ export function FaliuShell() {
     : { likeCount: 0, commentCount: 0 };
 
   return (
-    <section className={`band ${styles.band}`}>
-      <div className={styles.shell}>
-        <div className={styles.topbar}>
-          <div className={styles.searchWrap}>
-            <label className={styles.searchBox}>
-              <span className={styles.searchIcon} aria-hidden="true">
-                Search
-              </span>
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="搜索经名、经号或关键词"
-                aria-label="搜索佛典"
-              />
-            </label>
-            <p className={styles.searchHint}>
-              <LocalizedText
-                zh="输入 3 个字以上会直接调用 CBETA 题名搜索。"
-                en="Queries with 3 or more characters call the CBETA title search directly."
-              />
-            </p>
+    <section className={styles.appShell} aria-label="法流">
+      <aside className={styles.sidebar}>
+        <a className={styles.brand} href={siteHref("/")}>
+          <span className={styles.brandMark}>法</span>
+          <span>
+            <strong>
+              <LocalizedText zh="法布施" en="Fabushi" />
+            </strong>
+            <small>
+              <LocalizedText zh="CBETA 法流" en="CBETA Faloo" />
+            </small>
+          </span>
+        </a>
+
+        <nav className={styles.sideNav} aria-label="法流导航">
+          {SIDE_NAV_ITEMS.map((item) => (
+            <a
+              key={item.href}
+              className={"active" in item && item.active ? styles.activeSideItem : styles.sideItem}
+              href={siteHref(item.href)}
+            >
+              <span aria-hidden="true">{item.mark}</span>
+              <LocalizedText zh={item.labelZh} en={item.labelEn} />
+            </a>
+          ))}
+        </nav>
+
+        <a className={styles.installPanel} href={siteHref("/download")}>
+          <span className={styles.installMark}>法</span>
+          <span>
+            <strong>
+              <LocalizedText zh="下载 APP" en="Download App" />
+            </strong>
+            <small>
+              <LocalizedText zh="手机随时看更方便" en="Read anywhere" />
+            </small>
+          </span>
+        </a>
+      </aside>
+
+      <div className={styles.mainPane}>
+        <header className={styles.topbar}>
+          <form className={styles.searchBox} onSubmit={(event) => event.preventDefault()}>
+            <span className={styles.searchGlyph} aria-hidden="true" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="搜索你感兴趣的经名"
+              aria-label="搜索佛典"
+            />
+            <button type="submit">
+              <LocalizedText zh="搜索" en="Search" />
+            </button>
+          </form>
+
+          <div className={styles.actionRow}>
+            {TOP_ACTIONS.map((item) => (
+              <a key={item.href} className={styles.actionButton} href={siteHref(item.href)}>
+                <span aria-hidden="true">{item.mark}</span>
+                <small>
+                  <LocalizedText zh={item.labelZh} en={item.labelEn} />
+                </small>
+              </a>
+            ))}
           </div>
-          <a className={styles.downloadLink} href={siteHref("/download")}>
-            <LocalizedText zh="下载 App" en="Download App" />
-          </a>
-        </div>
+        </header>
 
         <div className={styles.tabRow} role="tablist" aria-label="法流分类">
-          {TAB_CONFIG.map((item) => {
+          {FALIU_TABS.map((item) => {
             const isActive = item.key === activeTab;
             return (
               <button
@@ -425,33 +473,17 @@ export function FaliuShell() {
           })}
         </div>
 
-        <div className={styles.introRow}>
-          <div>
-            <h2 className={styles.sectionTitle}>
-              <LocalizedText zh={activeTabConfig.labelZh} en={activeTabConfig.labelEn} />
-            </h2>
-            <p className={styles.sectionHint}>
-              <LocalizedText zh={activeTabConfig.hintZh} en={activeTabConfig.hintEn} />
-            </p>
-          </div>
-          <div className={styles.metaNote}>
-            <span>CBETA API</span>
-            <span>App Stats</span>
-            <span>Read Flow</span>
-          </div>
-        </div>
-
         {error ? <p className={styles.errorBox}>{error}</p> : null}
 
         {isBootLoading ? (
           <div className={styles.stateBox}>
-            <LocalizedText zh="正在接入法流数据…" en="Loading the Faloo data surface..." />
+            <LocalizedText zh="正在接入法流数据..." en="Loading Faloo..." />
           </div>
         ) : null}
 
         {!isBootLoading && visibleCards.length === 0 ? (
           <div className={styles.stateBox}>
-            <LocalizedText zh="这一组暂时没有可展示的佛典。" en="No matching works are available in this slice yet." />
+            <LocalizedText zh="这一组暂时没有可展示的佛典。" en="No matching works are available yet." />
           </div>
         ) : null}
 
@@ -459,35 +491,34 @@ export function FaliuShell() {
           {visibleCards.map((item) => {
             const firstJuan = item.juans[0] ?? "1";
             const stats = statsMap[buildCbetaContentId(item.work, firstJuan)] ?? { likeCount: 0, commentCount: 0 };
-            const info = item.info;
+            const byline = getByline(item.info);
             return (
               <article key={item.work} className={styles.feedCard}>
-                <button type="button" className={styles.cardButton} onClick={() => void openDetail(item, firstJuan)}>
-                  <div className={styles.cardHeader}>
-                    <span className={styles.cardTag}>{info?.category ?? item.work}</span>
-                    <span className={styles.cardCanon}>{item.work}</span>
+                <button type="button" className={styles.coverButton} onClick={() => void openDetail(item, firstJuan)}>
+                  <div className={styles.cover} style={getCoverStyle(item)}>
+                    <div className={styles.coverTexture} aria-hidden="true" />
+                    <div className={styles.coverTopline}>
+                      <span>{getCategoryLabel(item.info, item.work)}</span>
+                      <span>{item.work}</span>
+                    </div>
+                    <div className={styles.coverCenter}>
+                      <span>{item.work}</span>
+                      <h2>{item.title}</h2>
+                      <p>{getTranslator(item.info)}</p>
+                    </div>
+                    <div className={styles.coverBottom}>
+                      <span>赞 {formatStats(stats.likeCount)}</span>
+                      <span>{item.juans.length > 1 ? `${item.juans.length} 卷` : `第 ${firstJuan} 卷`}</span>
+                    </div>
                   </div>
-                  <h3>{item.title}</h3>
-                  <p className={styles.byline}>{info?.byline ?? "CBETA 佛典"}</p>
-                  <dl className={styles.cardFacts}>
-                    <div>
-                      <dt>卷次</dt>
-                      <dd>{item.juans.length}</dd>
-                    </div>
-                    <div>
-                      <dt>点赞</dt>
-                      <dd>{formatStats(stats.likeCount)}</dd>
-                    </div>
-                    <div>
-                      <dt>评论</dt>
-                      <dd>{formatStats(stats.commentCount)}</dd>
-                    </div>
-                  </dl>
-                  <p className={styles.cardMeta}>
-                    {info?.time_dynasty ? `${info.time_dynasty} · ` : ""}
-                    {item.juans.length > 1 ? `共 ${item.juans.length} 卷` : `第 ${firstJuan} 卷`}
-                  </p>
                 </button>
+                <button type="button" className={styles.titleButton} onClick={() => void openDetail(item, firstJuan)}>
+                  {item.title}
+                </button>
+                <p className={styles.cardMeta}>
+                  <span>@ CBETA</span>
+                  <span>{item.info?.time_dynasty ? `${item.info.time_dynasty} · ${byline}` : byline}</span>
+                </p>
               </article>
             );
           })}
@@ -495,9 +526,15 @@ export function FaliuShell() {
 
         {isSearchLoading ? (
           <p className={styles.loadingLine}>
-            <LocalizedText zh="正在补充题名搜索结果…" en="Pulling more title search results..." />
+            <LocalizedText zh="正在补充题名搜索结果..." en="Pulling more title results..." />
           </p>
         ) : null}
+      </div>
+
+      <div className={styles.floatRail} aria-hidden="true">
+        <span>目</span>
+        <span>文</span>
+        <span>评</span>
       </div>
 
       {selected ? (
@@ -507,7 +544,7 @@ export function FaliuShell() {
               <div>
                 <p className={styles.modalEyebrow}>{selected.work}</p>
                 <h3>{selected.title}</h3>
-                <p className={styles.modalByline}>{selected.info?.byline ?? "CBETA 佛典"}</p>
+                <p className={styles.modalByline}>{getByline(selected.info)}</p>
               </div>
               <button type="button" className={styles.closeButton} onClick={() => setSelected(null)} aria-label="关闭">
                 X
@@ -515,8 +552,8 @@ export function FaliuShell() {
             </div>
 
             <div className={styles.modalMeta}>
-              <span>Like {formatStats(selectedStats.likeCount)}</span>
-              <span>Comments {formatStats(selectedStats.commentCount)}</span>
+              <span>赞 {formatStats(selectedStats.likeCount)}</span>
+              <span>评论 {formatStats(selectedStats.commentCount)}</span>
               <span>卷次 {selectedJuan}</span>
             </div>
 
@@ -537,15 +574,12 @@ export function FaliuShell() {
               <section className={styles.readerPanel}>
                 {isDetailLoading ? (
                   <div className={styles.readerState}>
-                    <LocalizedText zh="正文载入中…" en="Loading the text..." />
+                    <LocalizedText zh="正文载入中..." en="Loading the text..." />
                   </div>
                 ) : null}
 
                 {!isDetailLoading && selectedDetail ? (
-                  <div
-                    className={styles.readerHtml}
-                    dangerouslySetInnerHTML={{ __html: selectedDetail.html }}
-                  />
+                  <div className={styles.readerHtml} dangerouslySetInnerHTML={{ __html: selectedDetail.html }} />
                 ) : null}
 
                 {!isDetailLoading && !selectedDetail ? (

--- a/frontend/apps/web/src/lib/faliu-api.ts
+++ b/frontend/apps/web/src/lib/faliu-api.ts
@@ -60,7 +60,9 @@ export interface AppComment {
 }
 
 const CBETA_API_ROOT = "https://cbdata.dila.edu.tw/stable";
-const APP_API_ROOT = "https://api.ombhrum.com";
+const APP_API_ROOT = "https://api.ombhrum.com/api";
+const CBETA_PROXY_ROOT = "/api/cbeta";
+const APP_PROXY_ROOT = "/api/app";
 
 function buildUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
   const url = new URL(path, `${base}/`);
@@ -78,18 +80,110 @@ function buildUrl(base: string, path: string, params?: Record<string, string | n
   return url.toString();
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-    },
-  });
+function buildRelativeUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
+  const normalizedBase = base.replace(/\/+$/g, "");
+  const normalizedPath = path.replace(/^\/+/g, "");
+  const query = new URLSearchParams();
 
-  if (!response.ok) {
-    throw new Error(`Request failed: ${response.status}`);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === "") {
+        continue;
+      }
+
+      query.set(key, String(value));
+    }
   }
 
-  return (await response.json()) as T;
+  const suffix = query.toString();
+  return `${normalizedBase}/${normalizedPath}${suffix ? `?${suffix}` : ""}`;
+}
+
+function isBrowserRuntime() {
+  return typeof window !== "undefined";
+}
+
+function cbetaUrls(path: string, params?: Record<string, string | number | undefined>) {
+  const directUrl = buildUrl(CBETA_API_ROOT, path, params);
+
+  if (!isBrowserRuntime()) {
+    return [directUrl];
+  }
+
+  return [buildRelativeUrl(CBETA_PROXY_ROOT, path, params), directUrl];
+}
+
+function appUrls(path: string, params?: Record<string, string | number | undefined>) {
+  const directUrl = buildUrl(APP_API_ROOT, path, params);
+
+  if (!isBrowserRuntime()) {
+    return [directUrl];
+  }
+
+  return [buildRelativeUrl(APP_PROXY_ROOT, path, params), directUrl];
+}
+
+async function fetchJson<T>(urls: string | string[]): Promise<T> {
+  const candidates = Array.isArray(urls) ? urls : [urls];
+  let lastError: unknown = null;
+
+  for (const url of candidates) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        lastError = new Error(`Request failed: ${response.status}`);
+        continue;
+      }
+
+      return (await response.json()) as T;
+    } catch (cause) {
+      lastError = cause;
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error("Request failed");
+}
+
+async function postJson<T>(urls: string | string[], body: unknown): Promise<T> {
+  const candidates = Array.isArray(urls) ? urls : [urls];
+  let lastError: unknown = null;
+
+  for (const url of candidates) {
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        lastError = new Error(`Request failed: ${response.status}`);
+        continue;
+      }
+
+      return (await response.json()) as T;
+    } catch (cause) {
+      lastError = cause;
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error("Request failed");
 }
 
 export function buildCbetaContentId(work: string, juan: string) {
@@ -97,7 +191,7 @@ export function buildCbetaContentId(work: string, juan: string) {
 }
 
 export async function fetchAllWorks(): Promise<CbetaWorkIndexItem[]> {
-  return fetchJson<CbetaWorkIndexItem[]>(buildUrl(CBETA_API_ROOT, "download/all-works.json"));
+  return fetchJson<CbetaWorkIndexItem[]>(cbetaUrls("download/all-works.json"));
 }
 
 export async function searchWorksByTitle(query: string, start = 0, rows = 24): Promise<CbetaWorkInfo[]> {
@@ -109,7 +203,7 @@ export async function searchWorksByTitle(query: string, start = 0, rows = 24): P
       juan?: number;
       time_dynasty?: string;
     }>;
-  }>(buildUrl(CBETA_API_ROOT, "search/title", { q: query, start, rows }));
+  }>(cbetaUrls("search/title", { q: query, start, rows }));
 
   return (data.results ?? []).flatMap((item) => {
     if (!item.work || !item.content) {
@@ -129,18 +223,19 @@ export async function searchWorksByTitle(query: string, start = 0, rows = 24): P
 }
 
 export async function fetchWorkInfo(work: string): Promise<CbetaWorkInfo | null> {
-  const data = await fetchJson<{ results?: CbetaWorkInfo[] }>(buildUrl(CBETA_API_ROOT, "works", { work }));
+  const data = await fetchJson<{ results?: CbetaWorkInfo[] }>(cbetaUrls("works", { work }));
   return data.results?.[0] ?? null;
 }
 
 export async function fetchJuanDetail(work: string, juan: string): Promise<CbetaJuanDetail | null> {
   const data = await fetchJson<{
-    results?: Array<{ html?: string; juan?: string | number }>;
+    results?: Array<string | { html?: string; juan?: string | number }>;
     work_info?: CbetaWorkInfo;
     toc?: { mulu?: CbetaTocNode[]; juan?: CbetaTocNode[] };
-  }>(buildUrl(CBETA_API_ROOT, "juans", { work, juan, work_info: 1, toc: 1 }));
+  }>(cbetaUrls("juans", { work, juan, work_info: 1, toc: 1 }));
 
-  const html = data.results?.[0]?.html;
+  const firstResult = data.results?.[0];
+  const html = typeof firstResult === "string" ? firstResult : firstResult?.html;
   const workInfo = data.work_info;
 
   if (!html || !workInfo) {
@@ -164,22 +259,9 @@ export async function fetchBatchStats(contentIds: string[]): Promise<Record<stri
     return {};
   }
 
-  const response = await fetch(buildUrl(APP_API_ROOT, "api/content/batch-stats"), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ contentIds }),
-  });
-
-  if (!response.ok) {
-    return {};
-  }
-
-  const data = (await response.json()) as {
+  const data = await postJson<{
     stats?: Record<string, { likeCount?: number; commentCount?: number }>;
-  };
+  }>(appUrls("content/batch-stats"), { contentIds });
 
   const entries = Object.entries(data.stats ?? {});
   const mapped: Record<string, ContentStats> = {};
@@ -209,7 +291,7 @@ export async function fetchComments(contentId: string): Promise<AppComment[]> {
       avatar?: string | null;
       main_practice?: string | null;
     }>;
-  }>(buildUrl(APP_API_ROOT, "api/comments", { contentId, page: 1, pageSize: 30 }));
+  }>(appUrls("comments", { contentId, page: 1, pageSize: 30 }));
 
   return (data.comments ?? []).map((item) => ({
     id: item.id,

--- a/frontend/apps/web/src/lib/faliu-config.ts
+++ b/frontend/apps/web/src/lib/faliu-config.ts
@@ -1,0 +1,117 @@
+export type FaliuTabKey =
+  | "all"
+  | "buddha"
+  | "prajna"
+  | "pureland"
+  | "lotus"
+  | "huayan"
+  | "agama"
+  | "zen"
+  | "mantra"
+  | "vinaya"
+  | "abhidharma";
+
+export interface FaliuTabConfig {
+  key: FaliuTabKey;
+  labelZh: string;
+  labelEn: string;
+  featured: string[];
+  tokens: string[];
+}
+
+export const CARD_LIMIT = 12;
+
+export const FALIU_TABS: FaliuTabConfig[] = [
+  {
+    key: "all",
+    labelZh: "全部",
+    labelEn: "All",
+    featured: [
+      "T0365",
+      "T0251",
+      "T0235",
+      "T0262",
+      "T0279",
+      "T0366",
+      "T0001",
+      "T0099",
+      "T0220",
+      "T0374",
+      "T0261",
+      "T0278",
+    ],
+    tokens: [],
+  },
+  {
+    key: "buddha",
+    labelZh: "佛说",
+    labelEn: "Buddha",
+    featured: [],
+    tokens: ["佛說", "佛说"],
+  },
+  {
+    key: "prajna",
+    labelZh: "般若",
+    labelEn: "Prajna",
+    featured: [],
+    tokens: ["般若", "金剛", "金刚", "心經", "心经"],
+  },
+  {
+    key: "pureland",
+    labelZh: "净土",
+    labelEn: "Pure Land",
+    featured: [],
+    tokens: ["無量壽", "无量寿", "阿彌陀", "阿弥陀", "觀無量壽", "观无量寿", "淨土", "净土"],
+  },
+  {
+    key: "lotus",
+    labelZh: "法华",
+    labelEn: "Lotus",
+    featured: [],
+    tokens: ["法華", "法华", "妙法蓮華", "妙法莲华"],
+  },
+  {
+    key: "huayan",
+    labelZh: "华严",
+    labelEn: "Huayan",
+    featured: [],
+    tokens: ["華嚴", "华严", "大方廣佛", "大方广佛"],
+  },
+  {
+    key: "agama",
+    labelZh: "阿含",
+    labelEn: "Agama",
+    featured: [],
+    tokens: ["阿含", "長阿含", "长阿含", "雜阿含", "杂阿含", "中阿含", "增壹阿含"],
+  },
+  {
+    key: "zen",
+    labelZh: "禅门",
+    labelEn: "Zen",
+    featured: [],
+    tokens: ["壇經", "坛经", "禪", "禅", "祖師", "祖师", "公案"],
+  },
+  {
+    key: "mantra",
+    labelZh: "密教",
+    labelEn: "Mantra",
+    featured: [],
+    tokens: ["陀羅尼", "陀罗尼", "真言", "密", "咒"],
+  },
+  {
+    key: "vinaya",
+    labelZh: "律藏",
+    labelEn: "Vinaya",
+    featured: [],
+    tokens: ["律", "毘尼", "戒"],
+  },
+  {
+    key: "abhidharma",
+    labelZh: "论藏",
+    labelEn: "Abhidharma",
+    featured: [],
+    tokens: ["論", "论", "俱舍", "毘婆沙", "阿毘達磨", "阿毗达磨"],
+  },
+];
+
+export const FALIU_FEATURED_WORKS = FALIU_TABS[0].featured;

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -1,4 +1,8 @@
 const ANDROID_DOWNLOAD_ROUTE = /\/downloads\/android-(beta|stable)\.apk$/i;
+const CBETA_PROXY_ROUTE = /^\/api\/cbeta\/(.+)$/;
+const APP_PROXY_ROUTE = /^\/api\/app\/(.+)$/;
+const CBETA_API_BASE = "https://cbdata.dila.edu.tw/stable";
+const APP_API_BASE = "https://api.ombhrum.com/api";
 const DEFAULT_RELEASE_REPO = "bhrumom/fabushi";
 const GITHUB_API_BASE = "https://api.github.com";
 const DEFAULT_MIRROR_BASES = [
@@ -20,14 +24,76 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     const match = url.pathname.match(ANDROID_DOWNLOAD_ROUTE);
+    const cbetaMatch = url.pathname.match(CBETA_PROXY_ROUTE);
+    const appMatch = url.pathname.match(APP_PROXY_ROUTE);
 
     if (match) {
       return handleAndroidDownload(request, env, match[1]);
     }
 
+    if (cbetaMatch) {
+      return proxyApiRequest(request, CBETA_API_BASE, cbetaMatch[1], ["GET", "HEAD", "OPTIONS"]);
+    }
+
+    if (appMatch) {
+      return proxyApiRequest(request, APP_API_BASE, appMatch[1], ["GET", "POST", "HEAD", "OPTIONS"]);
+    }
+
     return env.ASSETS.fetch(request);
   },
 };
+
+async function proxyApiRequest(request, upstreamBase, upstreamPath, allowedMethods) {
+  if (!allowedMethods.includes(request.method)) {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: {
+        Allow: allowedMethods.filter((method) => method !== "OPTIONS").join(", "),
+      },
+    });
+  }
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        Allow: allowedMethods.filter((method) => method !== "OPTIONS").join(", "),
+      },
+    });
+  }
+
+  const requestUrl = new URL(request.url);
+  const upstreamUrl = new URL(upstreamPath.replace(/^\/+/g, ""), `${upstreamBase}/`);
+  upstreamUrl.search = requestUrl.search;
+
+  const headers = new Headers(request.headers);
+  headers.set("Accept", request.headers.get("Accept") || "application/json");
+  headers.delete("Host");
+  headers.delete("Cookie");
+
+  const upstreamResponse = await fetch(upstreamUrl.toString(), {
+    method: request.method,
+    headers,
+    body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
+    redirect: "follow",
+  });
+  const responseHeaders = new Headers(upstreamResponse.headers);
+
+  responseHeaders.delete("Content-Encoding");
+  responseHeaders.delete("Content-Length");
+  responseHeaders.delete("Set-Cookie");
+  responseHeaders.set("X-Fabushi-Proxy", "official-site");
+
+  if (upstreamBase === APP_API_BASE) {
+    responseHeaders.set("Cache-Control", "no-store");
+  }
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  });
+}
 
 async function handleAndroidDownload(request, env, audience) {
   if (request.method !== "GET" && request.method !== "HEAD") {


### PR DESCRIPTION
## Summary
- Rebuild the official-site /faliu page as a dark Douyin-style content feed with sidebar nav, top search, channel tabs, and three-column scripture cards.
- Use CBETA catalog/title/juan APIs for scripture content and the app backend database for stats and comments.
- Generate deterministic scripture covers from title, translator/byline, and work id, plus add official-site Worker API proxies for CBETA/app endpoints.

## Validation
- corepack pnpm --filter @fabushi/web typecheck
- corepack pnpm --filter @fabushi/web build
- Browser preview: desktop grid, mobile layout, and CBETA reader modal through a local proxy matching the Worker routes.