### PR TITLE
fix(web): sanitize official site public release summaries

### DIFF
--- a/.github/scripts/generate-official-site-beta-state.py
+++ b/.github/scripts/generate-official-site-beta-state.py
@@ -32,7 +32,7 @@ TECHNICAL_RELEASE_LINE_PATTERN = re.compile(
 RELEASE_SUMMARY_RULES = [
     (
         re.compile(
-            r"ui/ux|bento|design|layout|hero section|spotlight hover|scroll reveal|floating screenshots|dark theme",
+            r"ui/ux|bento|design|layout|hero section|spotlight hover|scroll reveal|floating screenshots|dark theme|smoke bubbles|wisps|diffusion",
             re.IGNORECASE,
         ),
         "改进官网界面与浏览体验。",
@@ -78,6 +78,10 @@ def normalize_summary_line(line):
     return normalized.strip()
 
 
+def contains_cjk(text):
+    return bool(re.search(r"[\u4e00-\u9fff]", text or ""))
+
+
 def build_fallback_release_summary(title):
     normalized_title = (title or "").lower()
 
@@ -109,6 +113,9 @@ def map_release_line_to_user_facing(line):
             return text
 
     if TECHNICAL_RELEASE_LINE_PATTERN.search(normalized):
+        return None
+
+    if re.search(r"[A-Za-z]", normalized) and not contains_cjk(normalized):
         return None
 
     return normalized

--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -12,7 +12,7 @@
       "publishedAt": "2026-05-19T06:40:38Z",
       "updateSummary": [
         "改进官网界面与浏览体验。",
-        "replace the visible smoke bubbles with layered translucent wisps and softer diffusion"
+        "优化整体稳定性与页面呈现。"
       ],
       "mirrorLinks": [
         {
@@ -39,7 +39,7 @@
       "publishedAt": "2026-05-19T06:38:04Z",
       "updateSummary": [
         "改进官网界面与浏览体验。",
-        "replace the visible smoke bubbles with layered translucent wisps and softer diffusion"
+        "优化整体稳定性与页面呈现。"
       ],
       "mirrorLinks": [],
       "note": "",
@@ -56,7 +56,7 @@
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-325-mobile.d5059671747a",
       "summary": [
         "改进官网界面与浏览体验。",
-        "replace the visible smoke bubbles with layered translucent wisps and softer diffusion"
+        "优化整体稳定性与页面呈现。"
       ]
     },
     {
@@ -66,9 +66,7 @@
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-316-mobile.792e8f00c9cd",
       "summary": [
         "改进 Android 测试版下载与安装稳定性。",
-        "keep the incense burner centered beneath the model",
-        "flutter analyze --no-pub lib\\\\screens\\\\meditation_room_screen.dart lib\\\\widgets\\\\zen_room_2d_elements.dart",
-        "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
+        "优化最新版本信息的展示方式。"
       ]
     },
     {
@@ -78,10 +76,7 @@
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-307-mobile.fde8b7853fc8",
       "summary": [
         "改进 Android 测试版下载与安装稳定性。",
-        "Lower the book into the offering area above the centered incense burner",
-        "Keep the book-style red/gold visual and main-practice title on the cover",
-        "flutter analyze --no-pub lib\\\\screens\\\\meditation_room_screen.dart lib\\\\widgets\\\\zen_room_2d_elements.dart",
-        "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
+        "优化最新版本信息的展示方式。"
       ]
     },
     {
@@ -91,11 +86,7 @@
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-304-mobile.e392e9946a1a",
       "summary": [
         "改进官网界面与浏览体验。",
-        "改进 Android 测试版下载与安装稳定性。",
-        "Restore the sutra entry as a red/gold book instead of a circular icon",
-        "Show the current main practice title on the book face",
-        "flutter analyze --no-pub lib\\\\screens\\\\meditation_room_screen.dart lib\\\\widgets\\\\zen_room_2d_elements.dart",
-        "flutter test --no-pub test\\\\unit\\\\core\\\\app_config_buddha_model_test.dart test\\\\unit\\\\services\\\\asset_loader_service_test.dart"
+        "改进 Android 测试版下载与安装稳定性。"
       ]
     },
     {
@@ -105,7 +96,7 @@
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-303-mobile.2605074f8f6d",
       "summary": [
         "改进 Android 测试版下载与安装稳定性。",
-        "only 3 files are touched"
+        "优化最新版本信息的展示方式。"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- sanitize the official-site beta summary generator so unmapped English and developer-facing release lines stop leaking into public `releases.json`
- map smoke/wisp UI wording back into the existing user-facing website summary bucket
- refresh the current persisted `frontend/apps/web/public/api/releases.json` so the public site immediately stops showing technical release-note fragments for recent versions

## Why now
The main delivery surface is currently clean on merge and release status, but the public website still exposes a few developer-facing release-note lines such as:
- `replace the visible smoke bubbles with layered translucent wisps and softer diffusion`
- `flutter analyze --no-pub ...`
- `only 3 files are touched`

That is low-risk to fix, user-facing, and a good waiting-window step while the remaining forum blockers stay outside the repository.

## Scope / Risk
- 2 files only:
  - `.github/scripts/generate-official-site-beta-state.py`
  - `frontend/apps/web/public/api/releases.json`
- no runtime app behavior changes
- no release pipeline control-flow changes
- the script change is limited to summary sanitization rules and an extra guard that drops unmapped English-only lines from the public surface

## Validation
- branch is `ahead_by = 2`, `behind_by = 0`
- compare against `main` stays limited to 2 files
- current public `releases.json` on `main` already contains the leaked English / technical summary lines, so the file refresh is intentional and immediately user-visible

## Expected outcome
- the next official-site beta sync will keep generating user-facing Chinese summaries instead of leaking developer wording
- the current public download/release surface on `main` will stop showing technical fragments for the latest synced versions