### PR TITLE
fix(web): remove homepage search box

### DIFF
--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { brand, contactChannels } from "@fabushi/shared";
 import { DownloadLink } from "../components/download-link";
-import { HomeFaliuSearch } from "../components/home-faliu-search";
 import { LocalizedText } from "../components/localized-text";
 import { SiteFooter } from "../components/site-footer";
 import { SiteHeader } from "../components/site-header";
@@ -300,7 +299,6 @@ export default async function HomePage() {
                 en="Bring meditation, listening, daily practice, and global giving into one app, then decide to download after seeing the interface clearly."
               />
             </p>
-            <HomeFaliuSearch />
             <div className="hero-actions">
               <a className="primary-action" href={siteHref("/download")}>
                 <LocalizedText zh="下载 App" en="Download App" />


### PR DESCRIPTION
## Summary
- remove the homepage `HomeFaliuSearch` render block from the hero section
- remove the unused `HomeFaliuSearch` import from the homepage entry file
- keep the rest of the homepage download flow and content unchanged

## Scope
- one file changed: `frontend/apps/web/src/app/page.tsx`
- no download links, screenshots, FAQ, or release cards were changed

## Verification
- confirmed the homepage search box was rendered directly inside `frontend/apps/web/src/app/page.tsx`
- this change removes only that render point and its import