### PR TITLE
feat(web): add Faliu suggestions and content fallback search

### DIFF
--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { brand } from "@fabushi/shared";
+import { FaliuContentSearchEnhancer } from "../../components/faliu-content-search-enhancer";
 import { FaliuShell } from "../../components/faliu-shell";
 import { FaliuSynonymEnhancer } from "../../components/faliu-synonym-enhancer";
 import { FALIU_FEATURED_WORKS } from "../../lib/faliu-config";
@@ -118,6 +119,7 @@ export default async function FaliuPage() {
 
       <FaliuShell {...initialData} />
       <FaliuSynonymEnhancer />
+      <FaliuContentSearchEnhancer />
     </main>
   );
 }

--- a/frontend/apps/web/src/components/faliu-content-search-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-content-search-enhancer.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { searchWorksByContent, type CbetaContentSearchResult } from "../lib/faliu-content-search";
+
+const MIN_QUERY_LENGTH = 2;
+const CONTENT_ROWS = 12;
+
+function getSearchInput() {
+  return document.querySelector<HTMLInputElement>('section[aria-label="法流"] input[aria-label="搜索佛典"]');
+}
+
+function getMainPane() {
+  return document.querySelector<HTMLElement>('section[aria-label="法流"] > div');
+}
+
+function getFeedGrid() {
+  return document.querySelector<HTMLElement>('section[aria-label="法流"] div[class*="feedGrid"]');
+}
+
+function getCurrentQuery(fallback = "") {
+  const input = getSearchInput();
+
+  if (input?.value.trim()) {
+    return input.value.trim();
+  }
+
+  return new URLSearchParams(window.location.search).get("q")?.trim() ?? fallback;
+}
+
+function hasVisibleTitleCards() {
+  return (getFeedGrid()?.querySelectorAll("article").length ?? 0) > 0;
+}
+
+export function FaliuContentSearchEnhancer() {
+  const [query, setQuery] = useState("");
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  const [results, setResults] = useState<CbetaContentSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [shouldShowFallback, setShouldShowFallback] = useState(false);
+
+  useEffect(() => {
+    const mainPane = getMainPane();
+    const input = getSearchInput();
+
+    if (!mainPane || !input) {
+      return;
+    }
+
+    const syncState = () => {
+      setHost(mainPane);
+      setQuery(getCurrentQuery());
+      window.setTimeout(() => setShouldShowFallback(!hasVisibleTitleCards()), 340);
+    };
+
+    const observer = new MutationObserver(() => {
+      window.setTimeout(() => setShouldShowFallback(!hasVisibleTitleCards()), 60);
+    });
+
+    observer.observe(mainPane, { childList: true, subtree: true });
+    input.addEventListener("input", syncState);
+    input.form?.addEventListener("submit", syncState);
+    window.addEventListener("popstate", syncState);
+    syncState();
+
+    return () => {
+      observer.disconnect();
+      input.removeEventListener("input", syncState);
+      input.form?.removeEventListener("submit", syncState);
+      window.removeEventListener("popstate", syncState);
+    };
+  }, []);
+
+  useEffect(() => {
+    const nextQuery = query.trim();
+
+    if (nextQuery.length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const timeout = window.setTimeout(() => {
+      setIsLoading(true);
+      searchWorksByContent(nextQuery, 0, CONTENT_ROWS)
+        .then((items) => {
+          if (!cancelled) {
+            setResults(items);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setResults([]);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setIsLoading(false);
+          }
+        });
+    }, 420);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
+  }, [query]);
+
+  const visibleResults = useMemo(() => results.slice(0, CONTENT_ROWS), [results]);
+
+  if (!host || query.trim().length < MIN_QUERY_LENGTH || (!shouldShowFallback && !isLoading)) {
+    return null;
+  }
+
+  return createPortal(
+    <section
+      aria-label="正文搜索结果"
+      style={{
+        margin: "0 0 24px",
+        padding: "18px",
+        border: "1px solid rgba(255, 255, 255, 0.1)",
+        borderRadius: 14,
+        background: "rgba(255, 255, 255, 0.045)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 12,
+          marginBottom: 16,
+        }}
+      >
+        <div>
+          <strong style={{ color: "#ffffff", fontSize: "1rem" }}>标题未命中，正在搜索正文</strong>
+          <p style={{ margin: "6px 0 0", color: "rgba(255, 255, 255, 0.58)", lineHeight: 1.5 }}>
+            下面显示的是正文命中的片段，片段放在卡片图片下方，方便确认搜到了什么内容。
+          </p>
+        </div>
+        <span style={{ color: "rgba(255, 255, 255, 0.54)", fontSize: "0.86rem" }}>
+          {isLoading ? "搜索中..." : `${visibleResults.length} 条`}
+        </span>
+      </div>
+
+      {visibleResults.length > 0 ? (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: "22px 18px",
+          }}
+        >
+          {visibleResults.map((item) => (
+            <article key={`${item.work}:${item.juan}:${item.matchSnippet}`} style={{ minWidth: 0 }}>
+              <div
+                style={{
+                  position: "relative",
+                  display: "grid",
+                  placeItems: "center",
+                  aspectRatio: "16 / 9",
+                  overflow: "hidden",
+                  borderRadius: 8,
+                  background:
+                    "linear-gradient(135deg, rgba(25, 228, 220, 0.26), transparent 48%), linear-gradient(180deg, #142735, #0d1622)",
+                  boxShadow: "0 18px 42px rgba(0, 0, 0, 0.3)",
+                  color: "#f5fbff",
+                  textAlign: "center",
+                  padding: 18,
+                }}
+              >
+                <div style={{ display: "grid", gap: 8 }}>
+                  <span style={{ color: "#e8bd6b", fontWeight: 900, fontSize: "0.86rem" }}>{item.work}</span>
+                  <h2
+                    style={{
+                      display: "-webkit-box",
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: "vertical",
+                      margin: 0,
+                      overflow: "hidden",
+                      fontFamily: '"Noto Serif SC", "Songti SC", serif',
+                      fontSize: "clamp(1.25rem, 2vw, 1.9rem)",
+                      lineHeight: 1.16,
+                    }}
+                  >
+                    {item.title}
+                  </h2>
+                  <span style={{ color: "rgba(255, 255, 255, 0.7)", fontSize: "0.86rem" }}>第 {item.juan ?? 1} 卷</span>
+                </div>
+              </div>
+
+              <p style={{ margin: "12px 0 0", color: "rgba(255, 255, 255, 0.94)", fontWeight: 780, lineHeight: 1.42 }}>
+                {item.title}
+              </p>
+              <p style={{ margin: "8px 0 0", color: "rgba(255, 255, 255, 0.56)", fontSize: "0.9rem", lineHeight: 1.6 }}>
+                正文命中：{item.matchSnippet}
+              </p>
+            </article>
+          ))}
+        </div>
+      ) : !isLoading ? (
+        <p style={{ margin: 0, color: "rgba(255, 255, 255, 0.58)", lineHeight: 1.65 }}>
+          正文也暂时没有找到匹配片段。
+        </p>
+      ) : null}
+    </section>,
+    host,
+  );
+}

--- a/frontend/apps/web/src/components/faliu-synonym-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-synonym-enhancer.tsx
@@ -6,11 +6,23 @@ import { normalizeCbetaQuery } from "../lib/faliu-api";
 
 const CBETA_API_ROOT = "https://api.cbetaonline.cn";
 const CBETA_PROXY_ROOT = "/api/cbeta";
-const MAX_SYNONYM_SUGGESTIONS = 8;
+const MAX_SUGGESTIONS_PER_GROUP = 8;
 const MIN_QUERY_LENGTH = 2;
 
 type CbetaSynonymResponse = {
   results?: string[];
+};
+
+type CbetaVariantResponse = {
+  results?: Array<{
+    q?: string;
+    hits?: number;
+  }>;
+};
+
+type VariantSuggestion = {
+  value: string;
+  hits: number;
 };
 
 function buildUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
@@ -48,9 +60,8 @@ function buildRelativeUrl(base: string, path: string, params?: Record<string, st
   return `${normalizedBase}/${normalizedPath}${suffix ? `?${suffix}` : ""}`;
 }
 
-function cbetaSynonymUrls(query: string) {
-  const params = { q: query };
-  return [buildRelativeUrl(CBETA_PROXY_ROOT, "search/synonym", params), buildUrl(CBETA_API_ROOT, "search/synonym", params)];
+function cbetaUrls(path: string, params: Record<string, string | number | undefined>) {
+  return [buildRelativeUrl(CBETA_PROXY_ROOT, path, params), buildUrl(CBETA_API_ROOT, path, params)];
 }
 
 async function fetchJson<T>(urls: string[]): Promise<T> {
@@ -82,11 +93,19 @@ async function fetchJson<T>(urls: string[]): Promise<T> {
   throw new Error("Request failed");
 }
 
+function getQueryTerms(query: string) {
+  return Array.from(new Set([query.trim(), normalizeCbetaQuery(query)].filter(Boolean)));
+}
+
+function getBlockedTerms(terms: string[]) {
+  return new Set(terms.map((term) => normalizeCbetaQuery(term).toLowerCase()));
+}
+
 async function fetchCbetaSynonyms(query: string) {
-  const terms = Array.from(new Set([query.trim(), normalizeCbetaQuery(query)].filter(Boolean)));
-  const blockedTerms = new Set(terms.map((term) => normalizeCbetaQuery(term).toLowerCase()));
+  const terms = getQueryTerms(query);
+  const blockedTerms = getBlockedTerms(terms);
   const responses = await Promise.allSettled(
-    terms.map((term) => fetchJson<CbetaSynonymResponse>(cbetaSynonymUrls(term))),
+    terms.map((term) => fetchJson<CbetaSynonymResponse>(cbetaUrls("search/synonym", { q: term }))),
   );
   const seen = new Set<string>();
   const suggestions: string[] = [];
@@ -107,13 +126,47 @@ async function fetchCbetaSynonyms(query: string) {
       seen.add(normalized);
       suggestions.push(synonym);
 
-      if (suggestions.length >= MAX_SYNONYM_SUGGESTIONS) {
+      if (suggestions.length >= MAX_SUGGESTIONS_PER_GROUP) {
         return suggestions;
       }
     }
   }
 
   return suggestions;
+}
+
+async function fetchCbetaVariants(query: string) {
+  const terms = getQueryTerms(query);
+  const blockedTerms = getBlockedTerms(terms);
+  const responses = await Promise.allSettled(
+    terms.map((term) => fetchJson<CbetaVariantResponse>(cbetaUrls("search/variants", { q: term, scope: "title" }))),
+  );
+  const seen = new Set<string>();
+  const suggestions: VariantSuggestion[] = [];
+
+  for (const response of responses) {
+    if (response.status !== "fulfilled") {
+      continue;
+    }
+
+    for (const item of response.value.results ?? []) {
+      const variant = item.q?.trim() ?? "";
+      const normalized = normalizeCbetaQuery(variant).toLowerCase();
+
+      if (!variant || blockedTerms.has(normalized) || seen.has(normalized)) {
+        continue;
+      }
+
+      seen.add(normalized);
+      suggestions.push({ value: variant, hits: item.hits ?? 0 });
+
+      if (suggestions.length >= MAX_SUGGESTIONS_PER_GROUP) {
+        return suggestions;
+      }
+    }
+  }
+
+  return suggestions.sort((left, right) => right.hits - left.hits);
 }
 
 function setNativeInputValue(input: HTMLInputElement, value: string) {
@@ -130,7 +183,8 @@ export function FaliuSynonymEnhancer() {
   const [host, setHost] = useState<HTMLFormElement | null>(null);
   const [input, setInput] = useState<HTMLInputElement | null>(null);
   const [query, setQuery] = useState("");
-  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [synonymSuggestions, setSynonymSuggestions] = useState<string[]>([]);
+  const [variantSuggestions, setVariantSuggestions] = useState<VariantSuggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -163,7 +217,8 @@ export function FaliuSynonymEnhancer() {
     const nextQuery = query.trim();
 
     if (nextQuery.length < MIN_QUERY_LENGTH) {
-      setSuggestions([]);
+      setSynonymSuggestions([]);
+      setVariantSuggestions([]);
       setIsLoading(false);
       return;
     }
@@ -171,15 +226,17 @@ export function FaliuSynonymEnhancer() {
     let cancelled = false;
     const timeout = window.setTimeout(() => {
       setIsLoading(true);
-      fetchCbetaSynonyms(nextQuery)
-        .then((items) => {
+      Promise.all([fetchCbetaVariants(nextQuery), fetchCbetaSynonyms(nextQuery)])
+        .then(([variants, synonyms]) => {
           if (!cancelled) {
-            setSuggestions(items);
+            setVariantSuggestions(variants);
+            setSynonymSuggestions(synonyms);
           }
         })
         .catch(() => {
           if (!cancelled) {
-            setSuggestions([]);
+            setVariantSuggestions([]);
+            setSynonymSuggestions([]);
           }
         })
         .finally(() => {
@@ -195,14 +252,15 @@ export function FaliuSynonymEnhancer() {
     };
   }, [query]);
 
-  function searchWithSynonym(synonym: string) {
+  function searchWithSuggestion(value: string) {
     if (!input || !host) {
       return;
     }
 
-    setSuggestions([]);
-    setQuery(synonym);
-    setNativeInputValue(input, synonym);
+    setSynonymSuggestions([]);
+    setVariantSuggestions([]);
+    setQuery(value);
+    setNativeInputValue(input, value);
     input.dispatchEvent(new Event("input", { bubbles: true }));
     input.dispatchEvent(new Event("change", { bubbles: true }));
 
@@ -215,14 +273,16 @@ export function FaliuSynonymEnhancer() {
     }, 0);
   }
 
-  if (!host || (!isLoading && suggestions.length === 0)) {
+  const hasSuggestions = synonymSuggestions.length > 0 || variantSuggestions.length > 0;
+
+  if (!host || (!isLoading && !hasSuggestions)) {
     return null;
   }
 
   return createPortal(
     <div
       role="listbox"
-      aria-label="近义词建议"
+      aria-label="CBETA 搜索建议"
       style={{
         position: "absolute",
         top: "calc(100% + 8px)",
@@ -230,7 +290,7 @@ export function FaliuSynonymEnhancer() {
         right: 0,
         zIndex: 30,
         display: "grid",
-        gap: 10,
+        gap: 12,
         padding: "12px 14px",
         border: "1px solid rgba(255, 255, 255, 0.14)",
         borderRadius: 14,
@@ -250,34 +310,67 @@ export function FaliuSynonymEnhancer() {
           lineHeight: 1.4,
         }}
       >
-        <span>近义词建议</span>
+        <span>CBETA 搜索建议</span>
         <span>{isLoading ? "正在查找..." : "点击后自动搜索"}</span>
       </div>
 
-      {suggestions.length > 0 ? (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-          {suggestions.map((item) => (
-            <button
-              key={item}
-              type="button"
-              role="option"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => searchWithSynonym(item)}
-              style={{
-                minHeight: 34,
-                padding: "0 12px",
-                border: "1px solid rgba(232, 189, 107, 0.28)",
-                borderRadius: 999,
-                background: "rgba(232, 189, 107, 0.12)",
-                color: "#fff7e3",
-                fontWeight: 760,
-                cursor: "pointer",
-              }}
-            >
-              {item}
-            </button>
-          ))}
-        </div>
+      {variantSuggestions.length > 0 ? (
+        <section style={{ display: "grid", gap: 8 }}>
+          <strong style={{ color: "rgba(255, 255, 255, 0.78)", fontSize: "0.86rem" }}>异体字建议</strong>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {variantSuggestions.map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                role="option"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => searchWithSuggestion(item.value)}
+                style={{
+                  minHeight: 34,
+                  padding: "0 12px",
+                  border: "1px solid rgba(25, 228, 220, 0.28)",
+                  borderRadius: 999,
+                  background: "rgba(25, 228, 220, 0.12)",
+                  color: "#e3fffd",
+                  fontWeight: 760,
+                  cursor: "pointer",
+                }}
+              >
+                {item.value}
+                {item.hits > 0 ? ` · ${item.hits}` : ""}
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {synonymSuggestions.length > 0 ? (
+        <section style={{ display: "grid", gap: 8 }}>
+          <strong style={{ color: "rgba(255, 255, 255, 0.78)", fontSize: "0.86rem" }}>近义词建议</strong>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {synonymSuggestions.map((item) => (
+              <button
+                key={item}
+                type="button"
+                role="option"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => searchWithSuggestion(item)}
+                style={{
+                  minHeight: 34,
+                  padding: "0 12px",
+                  border: "1px solid rgba(232, 189, 107, 0.28)",
+                  borderRadius: 999,
+                  background: "rgba(232, 189, 107, 0.12)",
+                  color: "#fff7e3",
+                  fontWeight: 760,
+                  cursor: "pointer",
+                }}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+        </section>
       ) : null}
     </div>,
     host,

--- a/frontend/apps/web/src/components/faliu-synonym-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-synonym-enhancer.tsx
@@ -9,6 +9,403 @@ const CBETA_PROXY_ROOT = "/api/cbeta";
 const MAX_SUGGESTIONS_PER_GROUP = 8;
 const MIN_QUERY_LENGTH = 2;
 
+const TRADITIONAL_TO_SIMPLIFIED: Record<string, string> = {
+  萬: "万",
+  與: "与",
+  叢: "丛",
+  嚴: "严",
+  義: "义",
+  樂: "乐",
+  書: "书",
+  習: "习",
+  鄉: "乡",
+  亂: "乱",
+  爭: "争",
+  雲: "云",
+  亞: "亚",
+  產: "产",
+  眾: "众",
+  優: "优",
+  會: "会",
+  傳: "传",
+  體: "体",
+  餘: "余",
+  側: "侧",
+  僑: "侨",
+  儼: "俨",
+  債: "债",
+  傾: "倾",
+  償: "偿",
+  關: "关",
+  興: "兴",
+  養: "养",
+  軍: "军",
+  淨: "净",
+  涼: "凉",
+  幾: "几",
+  擊: "击",
+  劉: "刘",
+  則: "则",
+  剛: "刚",
+  創: "创",
+  別: "别",
+  劍: "剑",
+  劇: "剧",
+  勸: "劝",
+  辦: "办",
+  務: "务",
+  動: "动",
+  勢: "势",
+  華: "华",
+  協: "协",
+  單: "单",
+  盧: "卢",
+  衛: "卫",
+  卻: "却",
+  歷: "历",
+  厲: "厉",
+  厭: "厌",
+  縣: "县",
+  參: "参",
+  雙: "双",
+  發: "发",
+  變: "变",
+  疊: "叠",
+  葉: "叶",
+  號: "号",
+  後: "后",
+  聽: "听",
+  吳: "吴",
+  啟: "启",
+  員: "员",
+  詠: "咏",
+  響: "响",
+  喚: "唤",
+  園: "园",
+  國: "国",
+  圖: "图",
+  圓: "圆",
+  聖: "圣",
+  場: "场",
+  堅: "坚",
+  壇: "坛",
+  壞: "坏",
+  壘: "垒",
+  墮: "堕",
+  壯: "壮",
+  聲: "声",
+  處: "处",
+  備: "备",
+  復: "复",
+  頭: "头",
+  夾: "夹",
+  奪: "夺",
+  奮: "奋",
+  妝: "妆",
+  婁: "娄",
+  嬰: "婴",
+  學: "学",
+  寧: "宁",
+  寶: "宝",
+  實: "实",
+  審: "审",
+  寬: "宽",
+  壽: "寿",
+  將: "将",
+  對: "对",
+  導: "导",
+  塵: "尘",
+  盡: "尽",
+  層: "层",
+  屬: "属",
+  歲: "岁",
+  島: "岛",
+  嶺: "岭",
+  峽: "峡",
+  巔: "巅",
+  師: "师",
+  帳: "帐",
+  帶: "带",
+  幫: "帮",
+  廣: "广",
+  莊: "庄",
+  慶: "庆",
+  廬: "庐",
+  庫: "库",
+  應: "应",
+  廟: "庙",
+  開: "开",
+  異: "异",
+  彌: "弥",
+  張: "张",
+  強: "强",
+  歸: "归",
+  當: "当",
+  錄: "录",
+  徑: "径",
+  徠: "徕",
+  憶: "忆",
+  懺: "忏",
+  憂: "忧",
+  懷: "怀",
+  態: "态",
+  總: "总",
+  惡: "恶",
+  惱: "恼",
+  驚: "惊",
+  懼: "惧",
+  懲: "惩",
+  戲: "戏",
+  戶: "户",
+  執: "执",
+  擴: "扩",
+  掃: "扫",
+  揚: "扬",
+  護: "护",
+  報: "报",
+  擔: "担",
+  擁: "拥",
+  擇: "择",
+  揮: "挥",
+  換: "换",
+  損: "损",
+  據: "据",
+  攝: "摄",
+  搖: "摇",
+  斂: "敛",
+  數: "数",
+  齋: "斋",
+  斷: "断",
+  舊: "旧",
+  時: "时",
+  顯: "显",
+  晉: "晋",
+  曉: "晓",
+  暫: "暂",
+  術: "术",
+  機: "机",
+  雜: "杂",
+  權: "权",
+  殺: "杀",
+  來: "来",
+  極: "极",
+  構: "构",
+  標: "标",
+  樹: "树",
+  棲: "栖",
+  樣: "样",
+  橋: "桥",
+  夢: "梦",
+  檢: "检",
+  樓: "楼",
+  歡: "欢",
+  歐: "欧",
+  淺: "浅",
+  濁: "浊",
+  測: "测",
+  濟: "济",
+  渾: "浑",
+  澀: "涩",
+  漸: "渐",
+  淵: "渊",
+  溫: "温",
+  濕: "湿",
+  滿: "满",
+  滯: "滞",
+  滅: "灭",
+  燈: "灯",
+  靈: "灵",
+  災: "灾",
+  爐: "炉",
+  點: "点",
+  煩: "烦",
+  燒: "烧",
+  熱: "热",
+  愛: "爱",
+  牽: "牵",
+  猶: "犹",
+  獨: "独",
+  獻: "献",
+  現: "现",
+  瓊: "琼",
+  瑤: "瑶",
+  瓔: "璎",
+  畫: "画",
+  暢: "畅",
+  療: "疗",
+  癡: "痴",
+  皺: "皱",
+  監: "监",
+  蓋: "盖",
+  盤: "盘",
+  礙: "碍",
+  禮: "礼",
+  禪: "禅",
+  離: "离",
+  種: "种",
+  稱: "称",
+  積: "积",
+  穩: "稳",
+  窮: "穷",
+  竅: "窍",
+  競: "竞",
+  筆: "笔",
+  篤: "笃",
+  篩: "筛",
+  築: "筑",
+  簽: "签",
+  簡: "简",
+  類: "类",
+  糧: "粮",
+  紀: "纪",
+  約: "约",
+  紅: "红",
+  級: "级",
+  純: "纯",
+  經: "经",
+  緒: "绪",
+  續: "续",
+  緣: "缘",
+  網: "网",
+  羅: "罗",
+  罰: "罚",
+  羈: "羁",
+  翹: "翘",
+  聯: "联",
+  肅: "肃",
+  勝: "胜",
+  腦: "脑",
+  脫: "脱",
+  臘: "腊",
+  輿: "舆",
+  艦: "舰",
+  藝: "艺",
+  節: "节",
+  範: "范",
+  薦: "荐",
+  藥: "药",
+  蓮: "莲",
+  獲: "获",
+  薩: "萨",
+  虛: "虚",
+  蟲: "虫",
+  蠻: "蛮",
+  補: "补",
+  觀: "观",
+  規: "规",
+  覺: "觉",
+  覽: "览",
+  見: "见",
+  視: "视",
+  觸: "触",
+  計: "计",
+  訂: "订",
+  記: "记",
+  訖: "讫",
+  講: "讲",
+  諷: "讽",
+  設: "设",
+  證: "证",
+  評: "评",
+  識: "识",
+  譯: "译",
+  誦: "诵",
+  誠: "诚",
+  話: "话",
+  說: "说",
+  請: "请",
+  諸: "诸",
+  讀: "读",
+  課: "课",
+  調: "调",
+  論: "论",
+  諦: "谛",
+  賢: "贤",
+  敗: "败",
+  貢: "贡",
+  財: "财",
+  責: "责",
+  質: "质",
+  讚: "赞",
+  贈: "赠",
+  趙: "赵",
+  趕: "赶",
+  踐: "践",
+  蹤: "踪",
+  車: "车",
+  軌: "轨",
+  轉: "转",
+  輪: "轮",
+  輕: "轻",
+  載: "载",
+  輝: "辉",
+  輯: "辑",
+  輸: "输",
+  邊: "边",
+  達: "达",
+  過: "过",
+  運: "运",
+  還: "还",
+  進: "进",
+  遠: "远",
+  連: "连",
+  適: "适",
+  選: "选",
+  遺: "遗",
+  遙: "遥",
+  鄧: "邓",
+  鄰: "邻",
+  釋: "释",
+  裡: "里",
+  鐘: "钟",
+  缽: "钵",
+  銀: "银",
+  鎖: "锁",
+  錯: "错",
+  錦: "锦",
+  長: "长",
+  門: "门",
+  閉: "闭",
+  問: "问",
+  聞: "闻",
+  閱: "阅",
+  陰: "阴",
+  階: "阶",
+  際: "际",
+  隨: "随",
+  隱: "隐",
+  難: "难",
+  霧: "雾",
+  霽: "霁",
+  靜: "静",
+  須: "须",
+  頓: "顿",
+  頌: "颂",
+  領: "领",
+  頻: "频",
+  題: "题",
+  顏: "颜",
+  風: "风",
+  飛: "飞",
+  飯: "饭",
+  館: "馆",
+  馬: "马",
+  馱: "驮",
+  驅: "驱",
+  驗: "验",
+  魯: "鲁",
+  鮮: "鲜",
+  鳩: "鸠",
+  鳴: "鸣",
+  鵝: "鹅",
+  鵬: "鹏",
+  麥: "麦",
+  黃: "黄",
+  龍: "龙",
+  無: "无",
+  頂: "顶",
+};
+
 type CbetaSynonymResponse = {
   results?: string[];
 };
@@ -101,6 +498,44 @@ function getBlockedTerms(terms: string[]) {
   return new Set(terms.map((term) => normalizeCbetaQuery(term).toLowerCase()));
 }
 
+function simplifyCbetaQuery(value: string) {
+  return value
+    .split("")
+    .map((character) => TRADITIONAL_TO_SIMPLIFIED[character] ?? character)
+    .join("")
+    .trim();
+}
+
+function collectSimplifiedSuggestions(query: string, variants: VariantSuggestion[], synonyms: string[]) {
+  const sourceValues = [query, ...variants.map((item) => item.value), ...synonyms].map((item) => item.trim()).filter(Boolean);
+  const blockedValues = new Set(sourceValues);
+  const seen = new Set<string>();
+  const suggestions: string[] = [];
+
+  for (const value of sourceValues) {
+    const simplified = simplifyCbetaQuery(value);
+
+    if (
+      !simplified ||
+      simplified.length < MIN_QUERY_LENGTH ||
+      simplified === value ||
+      blockedValues.has(simplified) ||
+      seen.has(simplified)
+    ) {
+      continue;
+    }
+
+    seen.add(simplified);
+    suggestions.push(simplified);
+
+    if (suggestions.length >= MAX_SUGGESTIONS_PER_GROUP) {
+      return suggestions;
+    }
+  }
+
+  return suggestions;
+}
+
 async function fetchCbetaSynonyms(query: string) {
   const terms = getQueryTerms(query);
   const blockedTerms = getBlockedTerms(terms);
@@ -183,6 +618,7 @@ export function FaliuSynonymEnhancer() {
   const [host, setHost] = useState<HTMLFormElement | null>(null);
   const [input, setInput] = useState<HTMLInputElement | null>(null);
   const [query, setQuery] = useState("");
+  const [simplifiedSuggestions, setSimplifiedSuggestions] = useState<string[]>([]);
   const [synonymSuggestions, setSynonymSuggestions] = useState<string[]>([]);
   const [variantSuggestions, setVariantSuggestions] = useState<VariantSuggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -217,6 +653,7 @@ export function FaliuSynonymEnhancer() {
     const nextQuery = query.trim();
 
     if (nextQuery.length < MIN_QUERY_LENGTH) {
+      setSimplifiedSuggestions([]);
       setSynonymSuggestions([]);
       setVariantSuggestions([]);
       setIsLoading(false);
@@ -231,10 +668,12 @@ export function FaliuSynonymEnhancer() {
           if (!cancelled) {
             setVariantSuggestions(variants);
             setSynonymSuggestions(synonyms);
+            setSimplifiedSuggestions(collectSimplifiedSuggestions(nextQuery, variants, synonyms));
           }
         })
         .catch(() => {
           if (!cancelled) {
+            setSimplifiedSuggestions([]);
             setVariantSuggestions([]);
             setSynonymSuggestions([]);
           }
@@ -257,6 +696,7 @@ export function FaliuSynonymEnhancer() {
       return;
     }
 
+    setSimplifiedSuggestions([]);
     setSynonymSuggestions([]);
     setVariantSuggestions([]);
     setQuery(value);
@@ -273,7 +713,8 @@ export function FaliuSynonymEnhancer() {
     }, 0);
   }
 
-  const hasSuggestions = synonymSuggestions.length > 0 || variantSuggestions.length > 0;
+  const hasSuggestions =
+    simplifiedSuggestions.length > 0 || synonymSuggestions.length > 0 || variantSuggestions.length > 0;
 
   if (!host || (!isLoading && !hasSuggestions)) {
     return null;
@@ -313,6 +754,35 @@ export function FaliuSynonymEnhancer() {
         <span>CBETA 搜索建议</span>
         <span>{isLoading ? "正在查找..." : "点击后自动搜索"}</span>
       </div>
+
+      {simplifiedSuggestions.length > 0 ? (
+        <section style={{ display: "grid", gap: 8 }}>
+          <strong style={{ color: "rgba(255, 255, 255, 0.78)", fontSize: "0.86rem" }}>简体字建议</strong>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {simplifiedSuggestions.map((item) => (
+              <button
+                key={item}
+                type="button"
+                role="option"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => searchWithSuggestion(item)}
+                style={{
+                  minHeight: 34,
+                  padding: "0 12px",
+                  border: "1px solid rgba(255, 255, 255, 0.24)",
+                  borderRadius: 999,
+                  background: "rgba(255, 255, 255, 0.11)",
+                  color: "#ffffff",
+                  fontWeight: 760,
+                  cursor: "pointer",
+                }}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {variantSuggestions.length > 0 ? (
         <section style={{ display: "grid", gap: 8 }}>

--- a/frontend/apps/web/src/lib/faliu-content-search.ts
+++ b/frontend/apps/web/src/lib/faliu-content-search.ts
@@ -179,6 +179,17 @@ function pickFirstString(item: RawContentResult, keys: string[]) {
   return "";
 }
 
+function pickFirstNumber(item: RawContentResult, keys: string[]) {
+  for (const key of keys) {
+    const numberValue = getNumber(item[key]);
+    if (numberValue !== undefined) {
+      return numberValue;
+    }
+  }
+
+  return undefined;
+}
+
 function normalizeContentResult(item: RawContentResult): CbetaContentSearchResult | null {
   const work = pickFirstString(item, ["work", "work_id", "workId", "sutra", "id"]);
   const snippet = trimSnippet(
@@ -190,7 +201,7 @@ function normalizeContentResult(item: RawContentResult): CbetaContentSearchResul
   }
 
   const title = pickFirstString(item, ["title", "work_title", "workTitle", "sutra_name", "book", "name"]) || work;
-  const juan = getNumber(item.juan) ?? getNumber(item.juan_num) ?? getNumber(item.juanNum) ?? getNumber(item卷) ?? 1;
+  const juan = pickFirstNumber(item, ["juan", "juan_num", "juanNum", "卷"]) ?? 1;
 
   return {
     work,

--- a/frontend/apps/web/src/lib/faliu-content-search.ts
+++ b/frontend/apps/web/src/lib/faliu-content-search.ts
@@ -1,0 +1,245 @@
+import { normalizeCbetaQuery, type CbetaWorkInfo } from "./faliu-api";
+
+const CBETA_API_ROOT = "https://api.cbetaonline.cn";
+const CBETA_PROXY_ROOT = "/api/cbeta";
+const CONTENT_SEARCH_ENDPOINTS = ["search/fulltext", "search/content", "search/all_in_one"] as const;
+
+export interface CbetaContentSearchResult extends CbetaWorkInfo {
+  matchSnippet: string;
+  matchSource: "content";
+}
+
+type RawContentResult = Record<string, unknown>;
+
+function buildUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
+  const url = new URL(path, `${base}/`);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === "") {
+        continue;
+      }
+
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+function buildRelativeUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
+  const normalizedBase = base.replace(/\/+$/g, "");
+  const normalizedPath = path.replace(/^\/+/g, "");
+  const query = new URLSearchParams();
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === "") {
+        continue;
+      }
+
+      query.set(key, String(value));
+    }
+  }
+
+  const suffix = query.toString();
+  return `${normalizedBase}/${normalizedPath}${suffix ? `?${suffix}` : ""}`;
+}
+
+function isBrowserRuntime() {
+  return typeof window !== "undefined";
+}
+
+function cbetaUrls(path: string, params?: Record<string, string | number | undefined>) {
+  const directUrl = buildUrl(CBETA_API_ROOT, path, params);
+
+  if (!isBrowserRuntime()) {
+    return [directUrl];
+  }
+
+  return [buildRelativeUrl(CBETA_PROXY_ROOT, path, params), directUrl];
+}
+
+async function fetchJson<T>(urls: string[]): Promise<T> {
+  let lastError: unknown = null;
+
+  for (const url of urls) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        lastError = new Error(`Request failed: ${response.status}`);
+        continue;
+      }
+
+      return (await response.json()) as T;
+    } catch (cause) {
+      lastError = cause;
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error("Request failed");
+}
+
+function getString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function getNumber(value: unknown) {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function stripSearchHtml(value: string) {
+  return value
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function trimSnippet(value: string) {
+  const normalized = stripSearchHtml(value);
+
+  if (normalized.length <= 90) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, 90)}...`;
+}
+
+function collectResults(data: unknown): RawContentResult[] {
+  const value = data as Record<string, unknown> | null;
+
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  const directResults = value.results;
+  if (Array.isArray(directResults)) {
+    return directResults.filter((item): item is RawContentResult => Boolean(item) && typeof item === "object");
+  }
+
+  const nestedResults = directResults as Record<string, unknown> | null;
+  if (nestedResults && Array.isArray(nestedResults.docs)) {
+    return nestedResults.docs.filter((item): item is RawContentResult => Boolean(item) && typeof item === "object");
+  }
+
+  const response = value.response as Record<string, unknown> | null;
+  if (response && Array.isArray(response.docs)) {
+    return response.docs.filter((item): item is RawContentResult => Boolean(item) && typeof item === "object");
+  }
+
+  const docs = value.docs;
+  if (Array.isArray(docs)) {
+    return docs.filter((item): item is RawContentResult => Boolean(item) && typeof item === "object");
+  }
+
+  return [];
+}
+
+function pickFirstString(item: RawContentResult, keys: string[]) {
+  for (const key of keys) {
+    const value = item[key];
+
+    if (Array.isArray(value)) {
+      const first = value.map(getString).find(Boolean);
+      if (first) {
+        return first;
+      }
+    }
+
+    const stringValue = getString(value);
+    if (stringValue) {
+      return stringValue;
+    }
+  }
+
+  return "";
+}
+
+function normalizeContentResult(item: RawContentResult): CbetaContentSearchResult | null {
+  const work = pickFirstString(item, ["work", "work_id", "workId", "sutra", "id"]);
+  const snippet = trimSnippet(
+    pickFirstString(item, ["kwic", "highlight", "snippet", "content", "text", "body", "p", "linehead"]),
+  );
+
+  if (!work || !snippet) {
+    return null;
+  }
+
+  const title = pickFirstString(item, ["title", "work_title", "workTitle", "sutra_name", "book", "name"]) || work;
+  const juan = getNumber(item.juan) ?? getNumber(item.juan_num) ?? getNumber(item.juanNum) ?? getNumber(item卷) ?? 1;
+
+  return {
+    work,
+    title,
+    byline: pickFirstString(item, ["byline", "creators", "creator"]),
+    creators: pickFirstString(item, ["creators", "creator"]),
+    time_dynasty: pickFirstString(item, ["time_dynasty", "dynasty"]),
+    juan,
+    matchSnippet: snippet,
+    matchSource: "content",
+  };
+}
+
+export async function searchWorksByContent(query: string, start = 0, rows = 24): Promise<CbetaContentSearchResult[]> {
+  const terms = Array.from(new Set([query.trim(), normalizeCbetaQuery(query)].filter(Boolean)));
+  const requests = terms.flatMap((term) =>
+    CONTENT_SEARCH_ENDPOINTS.map((endpoint) =>
+      fetchJson<unknown>(cbetaUrls(endpoint, { q: term, start, rows, field: "content" })),
+    ),
+  );
+  const responses = await Promise.allSettled(requests);
+  const seen = new Set<string>();
+  const results: CbetaContentSearchResult[] = [];
+
+  for (const response of responses) {
+    if (response.status !== "fulfilled") {
+      continue;
+    }
+
+    for (const item of collectResults(response.value)) {
+      const normalized = normalizeContentResult(item);
+
+      if (!normalized) {
+        continue;
+      }
+
+      const key = `${normalized.work}:${normalized.juan ?? 1}:${normalized.matchSnippet}`;
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      results.push(normalized);
+
+      if (results.length >= rows) {
+        return results;
+      }
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- Extend the Faliu search suggestion enhancer to include “简体字建议”, “异体字建议”, and “近义词建议”.
- Keep CBETA `search/variants` for variant suggestions and CBETA `search/synonym` for synonym suggestions.
- Add a CBETA content-search helper and a Faliu content-search fallback panel.
- When the title search has no visible cards, the page searches正文内容 and shows matching snippets under card-style covers so users can see exactly what matched.

## Notes
- Simplified suggestions are generated with a local traditional-to-simplified mapping so users can pick inputs like `大佛顶首楞严经` even when CBETA returns traditional/variant forms.
- Variant suggestions call `search/variants` with `scope=title` and display CBETA hit counts when returned.
- Content fallback currently tries `search/fulltext`, `search/content`, and `search/all_in_one` through `/api/cbeta` first, with direct CBETA API fallback.
- Search suggestions are de-duplicated after simplified-to-traditional normalization.

## Testing
- Not run locally in this environment.