### PR TITLE
chore(web): sync official site beta state to mobile 334

### DIFF
--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -7,25 +7,24 @@
       "title": "Android Beta",
       "description": "官网直接读取最新发布版本的 APK 安装包，安装包发布后这里会自动更新。",
       "primaryLabel": "下载 Android Beta",
-      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-325-mobile.d5059671747a/fabushi-android-arm64-d5059671747a.apk",
-      "version": "v1.0.0-325-mobile.d5059671747a",
-      "publishedAt": "2026-05-19T06:40:38Z",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/v1.0.0-334-mobile.d2f85bce106e/fabushi-android-arm64-d2f85bce106e.apk",
+      "version": "v1.0.0-334-mobile.d2f85bce106e",
+      "publishedAt": "2026-05-19T12:16:46Z",
       "updateSummary": [
-        "改进官网界面与浏览体验。",
-        "优化整体稳定性与页面呈现。"
+        "改进 Android 测试版下载与安装稳定性。"
       ],
       "mirrorLinks": [
         {
           "label": "国内镜像 1",
-          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-325-mobile.d5059671747a/fabushi-android-arm64-d5059671747a.apk"
+          "href": "https://mirror.ghproxy.com/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-334-mobile.d2f85bce106e/fabushi-android-arm64-d2f85bce106e.apk"
         },
         {
           "label": "国内镜像 2",
-          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-325-mobile.d5059671747a/fabushi-android-arm64-d5059671747a.apk"
+          "href": "https://ghfast.top/https://github.com/bhrumom/fabushi/releases/download/v1.0.0-334-mobile.d2f85bce106e/fabushi-android-arm64-d2f85bce106e.apk"
         }
       ],
       "note": "国内访问较慢时，可以优先尝试镜像下载入口。",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-325-mobile.d5059671747a"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-334-mobile.d2f85bce106e"
     },
     {
       "platform": "iOS",
@@ -35,28 +34,35 @@
       "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
       "primaryLabel": "加入 iOS TestFlight",
       "primaryHref": "https://testflight.apple.com/join/98KFgV2z",
-      "version": "325",
-      "publishedAt": "2026-05-19T06:38:04Z",
+      "version": "334",
+      "publishedAt": "2026-05-19T12:13:55Z",
       "updateSummary": [
-        "改进官网界面与浏览体验。",
-        "优化整体稳定性与页面呈现。"
+        "改进 Android 测试版下载与安装稳定性。"
       ],
       "mirrorLinks": [],
       "note": "",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-325-mobile.d5059671747a"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-334-mobile.d2f85bce106e"
     }
   ],
   "stableChannels": [],
   "screenshots": {},
   "releases": [
     {
+      "tag": "v1.0.0-334-mobile.d2f85bce106e",
+      "title": "Fabushi mobile 1.0.0+334 (d2f85bce106e)",
+      "publishedAt": "2026-05-19T12:16:46Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-334-mobile.d2f85bce106e",
+      "summary": [
+        "改进 Android 测试版下载与安装稳定性。"
+      ]
+    },
+    {
       "tag": "v1.0.0-325-mobile.d5059671747a",
       "title": "Fabushi mobile 1.0.0+325 (d5059671747a)",
       "publishedAt": "2026-05-19T06:40:38Z",
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-325-mobile.d5059671747a",
       "summary": [
-        "改进官网界面与浏览体验。",
-        "优化整体稳定性与页面呈现。"
+        "改进官网界面与浏览体验。"
       ]
     },
     {
@@ -65,8 +71,7 @@
       "publishedAt": "2026-05-19T00:07:03Z",
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-316-mobile.792e8f00c9cd",
       "summary": [
-        "改进 Android 测试版下载与安装稳定性。",
-        "优化最新版本信息的展示方式。"
+        "改进 Android 测试版下载与安装稳定性。"
       ]
     },
     {
@@ -75,8 +80,7 @@
       "publishedAt": "2026-05-18T13:03:57Z",
       "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-307-mobile.fde8b7853fc8",
       "summary": [
-        "改进 Android 测试版下载与安装稳定性。",
-        "优化最新版本信息的展示方式。"
+        "改进 Android 测试版下载与安装稳定性。"
       ]
     },
     {
@@ -87,16 +91,6 @@
       "summary": [
         "改进官网界面与浏览体验。",
         "改进 Android 测试版下载与安装稳定性。"
-      ]
-    },
-    {
-      "tag": "v1.0.0-303-mobile.2605074f8f6d",
-      "title": "Fabushi mobile 1.0.0+303 (2605074f8f6d)",
-      "publishedAt": "2026-05-18T11:55:54Z",
-      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-303-mobile.2605074f8f6d",
-      "summary": [
-        "改进 Android 测试版下载与安装稳定性。",
-        "优化最新版本信息的展示方式。"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- sync `frontend/apps/web/public/api/releases.json` from `automation/sync-official-site-beta-state` back onto `main`
- update the public Android beta download entry from `v1.0.0-325-mobile.d5059671747a` to `v1.0.0-334-mobile.d2f85bce106e`
- update the public iOS TestFlight beta status from version `325` to `334`
- keep the persisted public release history aligned with the latest published mobile beta snapshot already present on the automation branch

## Why now
The repository has a fresh release-state drift again:
- `main` still serves the older public beta snapshot (`325`)
- `automation/sync-official-site-beta-state` is currently `ahead_by = 1` and `behind_by = 0`
- the compare is limited to a single generated file: `frontend/apps/web/public/api/releases.json`
- there is no open PR currently carrying that generated state back to `main`

This PR closes that gap without reopening broader release-automation design work.

## Current evidence
- `main` currently publishes:
  - Android beta `v1.0.0-325-mobile.d5059671747a`
  - Android `publishedAt = 2026-05-19T06:40:38Z`
  - iOS TestFlight public `version = 325`
  - iOS `publishedAt = 2026-05-19T06:38:04Z`
- automation branch already carries the newer public state:
  - Android beta `v1.0.0-334-mobile.d2f85bce106e`
  - Android `publishedAt = 2026-05-19T12:16:46Z`
  - iOS TestFlight public `version = 334`
  - iOS `publishedAt = 2026-05-19T12:13:55Z`

## Risk review
- branch compare is clean: `ahead_by = 1`, `behind_by = 0`
- diff scope is limited to the generated public release-state JSON
- no runtime code or workflow logic changes are included
- no merge conflict risk is visible from the current compare snapshot

## Expected outcome after merge
- the official site beta state on `main` will catch up to the already-published mobile `334` release
- Android APK and iOS TestFlight public status will stop lagging behind the latest release metadata on the persistent site state
- the waiting-window release-state drift is closed with a single low-risk PR