### PR TITLE
fix: keep Android zen offerings visible

### DIFF
--- a/fabushi/lib/screens/meditation_room_screen.dart
+++ b/fabushi/lib/screens/meditation_room_screen.dart
@@ -837,24 +837,31 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
           final title = practice?.title ?? '选择功课';
           final opensSelection =
               practice == null || practice.filePath.startsWith('manual:');
-          final incenseWidth = (size.width * 0.22)
-              .clamp(128.0, 168.0)
+          final incenseWidth = (size.width * 0.30)
+              .clamp(180.0, 230.0)
               .toDouble();
-          final incenseHeight = incenseWidth * 1.24;
-          const smokeRise = 142.0;
-          final offeringTop = (size.height * 0.60)
-              .clamp(0.0, size.height - incenseHeight - 180)
+          final incenseHeight = incenseWidth * 1.12;
+          const smokeRise = 156.0;
+          final bottomClearance = 116.0 + MediaQuery.of(context).padding.bottom;
+          final offeringTop = (size.height * 0.58)
+              .clamp(0.0, size.height - 300)
               .toDouble();
-          final bookWidth = (size.width * 0.13).clamp(68.0, 88.0).toDouble();
+          final isCompactPortrait =
+              size.width < 430 && size.height > size.width;
+          final bookWidth = (size.width * (isCompactPortrait ? 0.145 : 0.16))
+              .clamp(isCompactPortrait ? 76.0 : 88.0, 108.0)
+              .toDouble();
           final bookHeight = bookWidth * SutraBookButton.aspectRatioHeight;
           final incenseLeft = (size.width - incenseWidth) / 2;
-          final bookCenterX = (size.width * 0.50)
-              .clamp(bookWidth / 2 + 12, size.width - bookWidth / 2 - 12)
-              .toDouble();
+          final bookCenterX =
+              (incenseLeft + incenseWidth * 0.88 + bookWidth * 0.48)
+                  .clamp(bookWidth / 2 + 12, size.width - bookWidth / 2 - 12)
+                  .toDouble();
           final bookLeft = bookCenterX - bookWidth / 2;
-          final bookTop = (offeringTop - bookHeight - 8)
-              .clamp(0.0, size.height - bookHeight)
-              .toDouble();
+          final bookTop =
+              (offeringTop + incenseHeight * (isCompactPortrait ? 0.42 : 0.34))
+                  .clamp(0.0, size.height - bookHeight - bottomClearance)
+                  .toDouble();
 
           return Stack(
             children: [

--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -285,7 +285,15 @@ class AssetLoaderService {
         'Web platform does not support local storage directory',
       );
     }
-    final appDir = await getApplicationSupportDirectory();
+    Directory appDir;
+    try {
+      appDir = await getApplicationSupportDirectory();
+    } catch (error) {
+      debugPrint(
+        '[AssetLoader] path_provider unavailable, using system temp cache: $error',
+      );
+      appDir = Directory('${Directory.systemTemp.path}/fabushi_support');
+    }
     final modelDir = Directory('${appDir.path}/assets_cache/models');
     if (!await modelDir.exists()) {
       await modelDir.create(recursive: true);


### PR DESCRIPTION
## Summary
- fall back to a Dart system temp cache when Android path_provider channel is unavailable during Buddha model loading
- resize/reposition the native zen incense and sutra book so the book no longer covers the incense sticks

## Verification
- flutter analyze lib/services/asset_loader_service.dart lib/screens/meditation_room_screen.dart

Note: intentionally did not build locally; release APK verification should use the cloud CD package.