### PR TITLE
fix: show full idle incense sticks

### DIFF
--- a/fabushi/lib/widgets/zen_room_2d_elements.dart
+++ b/fabushi/lib/widgets/zen_room_2d_elements.dart
@@ -359,7 +359,8 @@ class IncenseOfferingPainter extends CustomPainter {
     final bowlTop = size.height - 52 * scale;
     final bowlBottom = size.height - 8 * scale;
     final rimCenter = Offset(centerX, bowlTop);
-    final remaining = (1.0 - incenseProgress).clamp(0.18, 1.0).toDouble();
+    final visualProgress = isBurning ? incenseProgress : 0.0;
+    final remaining = (1.0 - visualProgress).clamp(0.34, 1.0).toDouble();
     final stickHeight = 78.0 * scale * remaining;
 
     _drawBowlShadow(canvas, centerX, bowlBottom, scale);
@@ -469,6 +470,15 @@ class IncenseOfferingPainter extends CustomPainter {
   }
 
   void _drawStick(Canvas canvas, Offset base, Offset tip, double scale) {
+    canvas.drawLine(
+      base,
+      tip,
+      Paint()
+        ..color = const Color(0xAA050200)
+        ..strokeWidth = 8.6 * scale
+        ..strokeCap = StrokeCap.round
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, 1.6 * scale),
+    );
     canvas.drawLine(
       base,
       tip,


### PR DESCRIPTION
## Summary
- show full incense sticks while the user is not actively burning incense
- keep a stronger dark under-stroke behind the sticks so they remain visible over the golden Buddha model

## Verification
- `dart format lib/widgets/zen_room_2d_elements.dart`
- `flutter analyze lib/widgets/zen_room_2d_elements.dart`

No local APK build was run; final validation will use the cloud release APK.