### PR TITLE
Update official site hero and root domain redirect

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -80,4 +80,5 @@ jobs:
             --name fabushi-official-site \
             --assets apps/web/out \
             --compatibility-date 2026-05-06 \
-            --domain fabushi.ombhrum.com
+            --domain fabushi.ombhrum.com \
+            --domain ombhrum.com

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -346,6 +346,10 @@ h3,
   font-weight: 900;
 }
 
+.hero-title-line {
+  display: block;
+}
+
 .hero-subtitle,
 .lede {
   margin: 0;

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -291,12 +291,20 @@ export default async function HomePage() {
               </span>
             </div>
             <h1 id="home-title">
-              <LocalizedText zh="全球法布施" en="Global Dharma Sharing" />
+              <LocalizedText
+                zh={
+                  <>
+                    <span className="hero-title-line">全球</span>
+                    <span className="hero-title-line">法布施</span>
+                  </>
+                }
+                en="Global Dharma Sharing"
+              />
             </h1>
             <p className="hero-subtitle">
               <LocalizedText
-                zh="把禅修、听诵、日常功课与全球法布施放进同一个 App，先看清界面，再决定下载。"
-                en="Bring meditation, listening, daily practice, and global giving into one app, then decide to download after seeing the interface clearly."
+                zh="用一个 App 连接经文听诵、禅修记录、法流学习与全球法布施。"
+                en="One app for sutra listening, meditation records, Dharma learning, and global giving."
               />
             </p>
             <div className="hero-actions">

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -5,6 +5,8 @@ const CBETA_API_BASE = "https://api.cbetaonline.cn";
 const APP_API_BASE = "https://api.ombhrum.com/api";
 const DEFAULT_RELEASE_REPO = "bhrumom/fabushi";
 const GITHUB_API_BASE = "https://api.github.com";
+const OFFICIAL_SITE_HOST = "fabushi.ombhrum.com";
+const ROOT_DOMAIN_REDIRECT_HOSTS = new Set(["ombhrum.com"]);
 const DEFAULT_MIRROR_BASES = [
   {
     label: "国内镜像 1",
@@ -23,6 +25,10 @@ const DEFAULT_MIRROR_BASES = [
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
+    if (ROOT_DOMAIN_REDIRECT_HOSTS.has(url.hostname.toLowerCase())) {
+      return redirectToOfficialSite(url);
+    }
+
     const match = url.pathname.match(ANDROID_DOWNLOAD_ROUTE);
     const cbetaMatch = url.pathname.match(CBETA_PROXY_ROUTE);
     const appMatch = url.pathname.match(APP_PROXY_ROUTE);
@@ -42,6 +48,13 @@ export default {
     return env.ASSETS.fetch(request);
   },
 };
+
+function redirectToOfficialSite(url) {
+  const redirectUrl = new URL(url.toString());
+  redirectUrl.protocol = "https:";
+  redirectUrl.host = OFFICIAL_SITE_HOST;
+  return Response.redirect(redirectUrl.toString(), 308);
+}
 
 async function proxyApiRequest(request, upstreamBase, upstreamPath, allowedMethods) {
   if (!allowedMethods.includes(request.method)) {


### PR DESCRIPTION
## Summary
- Bind ombhrum.com during official site Worker deploys
- Redirect ombhrum.com to fabushi.ombhrum.com while preserving path and query
- Split the Chinese hero title into two lines and replace the subtitle with a clearer one-line summary

## Tests
- node --check official-site-worker.js
- Worker redirect smoke test: ombhrum.com -> fabushi.ombhrum.com
- wrangler deploy --dry-run with both domains
- corepack pnpm --filter @fabushi/web typecheck
- corepack pnpm --filter @fabushi/web build