### PR TITLE
Fix official site root domain deployment route

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -81,4 +81,4 @@ jobs:
             --assets apps/web/out \
             --compatibility-date 2026-05-06 \
             --domain fabushi.ombhrum.com \
-            --domain ombhrum.com
+            --route ombhrum.com/*


### PR DESCRIPTION
## Summary
- Replace the ombhrum.com Custom Domain binding with a Workers route
- Keep fabushi.ombhrum.com as the Worker Custom Domain
- Avoid Cloudflare error 100117 when the apex domain already has DNS records

## Tests
- npx wrangler deploy --dry-run with --domain fabushi.ombhrum.com and --route ombhrum.com/*
- Worker redirect smoke test: ombhrum.com -> fabushi.ombhrum.com