### PR TITLE
Restore official site Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -80,5 +80,4 @@ jobs:
             --name fabushi-official-site \
             --assets apps/web/out \
             --compatibility-date 2026-05-06 \
-            --domain fabushi.ombhrum.com \
-            --route ombhrum.com/*
+            --domain fabushi.ombhrum.com


### PR DESCRIPTION
## Summary
- remove the attempted ombhrum.com route mutation from the official site Cloudflare deploy
- keep deployment scoped to the existing fabushi.ombhrum.com custom domain

## Why
The main deployment is failing because Cloudflare reports ombhrum.com/* is already assigned to another Worker named fabushi. The official site deploy should not try to take over that occupied route from CI.

## Validation
- node --check frontend/official-site-worker.js
- npx --yes wrangler@latest deploy official-site-worker.js --name fabushi-official-site --assets apps/web/out --compatibility-date 2026-05-06 --domain fabushi.ombhrum.com --dry-run
- Worker redirect smoke test: https://ombhrum.com/download/?a=1 -> 308 https://fabushi.ombhrum.com/download/?a=1