### PR TITLE
Serve Android downloads through official Worker R2

### DIFF
--- a/.github/scripts/generate-official-site-beta-state.py
+++ b/.github/scripts/generate-official-site-beta-state.py
@@ -224,7 +224,7 @@ if apk_asset and android_apk_public_href:
     )
     notes.append("Android beta APK 已同步到 R2，官网按钮会直接下载 R2 中的最新安装包。")
 elif apk_asset:
-    notes.append("本次 release 带有 Android APK，但没有拿到 R2 公网地址，官网会继续保留上一版 Android 入口。")
+    notes.append("本次 release 带有 Android APK，但没有拿到官网域名下载地址，官网会继续保留上一版 Android 入口。")
 
 if testflight_status:
     tf_status = testflight_status.get("status", "")

--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -70,6 +70,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID || secrets.CF_ZONE_ID || vars.CLOUDFLARE_ZONE_ID || vars.CF_ZONE_ID }}
+          OFFICIAL_SITE_R2_BUCKET: ${{ vars.OFFICIAL_SITE_R2_BUCKET || 'bushi' }}
         run: |
           set -euo pipefail
           if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
@@ -77,10 +78,21 @@ jobs:
             exit 1
           fi
 
-          npx --yes wrangler@latest deploy official-site-worker.js \
-            --name fabushi-official-site \
-            --assets apps/web/out \
-            --compatibility-date 2026-05-06 \
+          official_site_r2_bucket="${OFFICIAL_SITE_R2_BUCKET:-bushi}"
+          cat > wrangler.official-site.toml <<EOF
+          name = "fabushi-official-site"
+          main = "official-site-worker.js"
+          compatibility_date = "2026-05-06"
+
+          [assets]
+          directory = "apps/web/out"
+
+          [[r2_buckets]]
+          binding = "OFFICIAL_SITE_R2"
+          bucket_name = "${official_site_r2_bucket}"
+          EOF
+
+          npx --yes wrangler@latest deploy --config wrangler.official-site.toml \
             --domain fabushi.ombhrum.com
 
           api_base="https://api.cloudflare.com/client/v4"

--- a/.github/workflows/publish-official-site-stable.yml
+++ b/.github/workflows/publish-official-site-stable.yml
@@ -43,7 +43,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           OFFICIAL_SITE_R2_BUCKET: ${{ vars.OFFICIAL_SITE_R2_BUCKET || 'bushi' }}
           OFFICIAL_SITE_ANDROID_STABLE_R2_OBJECT_KEY: ${{ vars.OFFICIAL_SITE_ANDROID_STABLE_R2_OBJECT_KEY || 'downloads/android/fabushi-android-stable.apk' }}
-          OFFICIAL_SITE_R2_PUBLIC_BASE_URL: ${{ vars.OFFICIAL_SITE_R2_PUBLIC_BASE_URL || '' }}
+          OFFICIAL_SITE_ORIGIN: ${{ vars.OFFICIAL_SITE_ORIGIN || 'https://fabushi.ombhrum.com' }}
         run: |
           set -euo pipefail
           apk_dir="$RUNNER_TEMP/android-stable-r2"
@@ -78,7 +78,7 @@ jobs:
 
           bucket="${OFFICIAL_SITE_R2_BUCKET:-bushi}"
           object_key="${OFFICIAL_SITE_ANDROID_STABLE_R2_OBJECT_KEY:-downloads/android/fabushi-android-stable.apk}"
-          public_base="${OFFICIAL_SITE_R2_PUBLIC_BASE_URL:-}"
+          official_site_origin="${OFFICIAL_SITE_ORIGIN:-https://fabushi.ombhrum.com}"
 
           npx --yes wrangler@latest r2 object put "$bucket/$object_key" \
             --file "$apk_path" \
@@ -87,17 +87,7 @@ jobs:
             --force \
             --remote
 
-          if [ -z "$public_base" ]; then
-            dev_url_output="$(npx --yes wrangler@latest r2 bucket dev-url get "$bucket" 2>&1 || true)"
-            public_base="$(printf '%s\n' "$dev_url_output" | sed -nE "s/.*'(https:\/\/[^']+)'.*/\1/p" | tail -n 1)"
-          fi
-
-          if [ -z "$public_base" ]; then
-            echo "Could not resolve an R2 public URL for bucket $bucket. Set OFFICIAL_SITE_R2_PUBLIC_BASE_URL." >&2
-            exit 1
-          fi
-
-          android_r2_href="${public_base%/}/${object_key}"
+          android_r2_href="${official_site_origin%/}/${object_key}"
           echo "android_r2_href=$android_r2_href" >> "$GITHUB_OUTPUT"
 
       - name: Generate stable state asset for the official site
@@ -272,6 +262,6 @@ jobs:
                 `- Release tag: ${process.env.RELEASE_TAG || 'unknown'}`,
                 `- Requested Android asset: ${process.env.ANDROID_ASSET_NAME || 'auto-select first APK'}`,
                 '- Check whether the target release contains the intended APK asset and whether the manual inputs match the release assets.',
-                '- If metadata generation fails, also verify OFFICIAL_SITE_R2_PUBLIC_BASE_URL formatting.',
+                '- If metadata generation fails, also verify OFFICIAL_SITE_ORIGIN formatting.',
               ],
             });

--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -80,7 +80,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           OFFICIAL_SITE_R2_BUCKET: ${{ vars.OFFICIAL_SITE_R2_BUCKET || 'bushi' }}
           OFFICIAL_SITE_ANDROID_R2_OBJECT_KEY: ${{ vars.OFFICIAL_SITE_ANDROID_R2_OBJECT_KEY || 'downloads/android/fabushi-android-beta.apk' }}
-          OFFICIAL_SITE_R2_PUBLIC_BASE_URL: ${{ vars.OFFICIAL_SITE_R2_PUBLIC_BASE_URL || '' }}
+          OFFICIAL_SITE_ORIGIN: ${{ vars.OFFICIAL_SITE_ORIGIN || 'https://fabushi.ombhrum.com' }}
         run: |
           set -euo pipefail
           apk_dir="$RUNNER_TEMP/android-r2"
@@ -117,7 +117,7 @@ jobs:
 
           bucket="${OFFICIAL_SITE_R2_BUCKET:-bushi}"
           object_key="${OFFICIAL_SITE_ANDROID_R2_OBJECT_KEY:-downloads/android/fabushi-android-beta.apk}"
-          public_base="${OFFICIAL_SITE_R2_PUBLIC_BASE_URL:-}"
+          official_site_origin="${OFFICIAL_SITE_ORIGIN:-https://fabushi.ombhrum.com}"
 
           npx --yes wrangler@latest r2 object put "$bucket/$object_key" \
             --file "$apk_path" \
@@ -126,17 +126,7 @@ jobs:
             --force \
             --remote
 
-          if [ -z "$public_base" ]; then
-            dev_url_output="$(npx --yes wrangler@latest r2 bucket dev-url get "$bucket" 2>&1 || true)"
-            public_base="$(printf '%s\n' "$dev_url_output" | sed -nE "s/.*'(https:\/\/[^']+)'.*/\1/p" | tail -n 1)"
-          fi
-
-          if [ -z "$public_base" ]; then
-            echo "Could not resolve an R2 public URL for bucket $bucket. Set OFFICIAL_SITE_R2_PUBLIC_BASE_URL." >&2
-            exit 1
-          fi
-
-          android_r2_href="${public_base%/}/${object_key}"
+          android_r2_href="${official_site_origin%/}/${object_key}"
           echo "android_r2_href=$android_r2_href" >> "$GITHUB_OUTPUT"
           {
             echo "## Android APK synced to R2"
@@ -144,7 +134,7 @@ jobs:
             echo "- Release tag: $RELEASE_TAG"
             echo "- Bucket: $bucket"
             echo "- Object key: $object_key"
-            echo "- Public href: $android_r2_href"
+            echo "- Official Worker href: $android_r2_href"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate beta state asset for the official site
@@ -407,7 +397,7 @@ jobs:
             fi
             echo "- Available beta channels from this release were synced selectively."
             if [ -n "${{ steps.sync_android_r2.outputs.android_r2_href }}" ]; then
-              echo "- Android APK was copied to R2 and the official site state now points to that R2 object."
+              echo "- Android APK was copied to R2 and the official site state now points to the Worker-served domain URL."
             fi
             echo "- If a release only contains one platform, the official site keeps the previous entry for the other platform."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -458,6 +448,6 @@ jobs:
                 '',
                 `- Release tag: ${process.env.RELEASE_TAG || 'unknown'}`,
                 '- Check whether the selected release contains an APK asset and TESTFLIGHT_UPLOAD_STATUS.txt when iOS beta should be updated.',
-                '- Check whether IOS_TESTFLIGHT_PUBLIC_URL or OFFICIAL_SITE_R2_PUBLIC_BASE_URL variables are malformed when the sync script fails during metadata generation.',
+                '- Check whether IOS_TESTFLIGHT_PUBLIC_URL or OFFICIAL_SITE_ORIGIN variables are malformed when the sync script fails during metadata generation.',
               ],
             });

--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -7,7 +7,7 @@
       "title": "Android Beta",
       "description": "官网按钮会直接下载已经同步到 R2 的最新 Android APK 安装包。",
       "primaryLabel": "下载 Android Beta",
-      "primaryHref": "https://pub-1687c02b123649f2813adcb31f346698.r2.dev/downloads/android/fabushi-android-beta.apk",
+      "primaryHref": "https://fabushi.ombhrum.com/downloads/android/fabushi-android-beta.apk",
       "version": "v1.0.0-354-mobile.60549067903a",
       "publishedAt": "2026-05-21T02:10:48Z",
       "updateSummary": [

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -4,6 +4,22 @@ const CBETA_API_BASE = "https://api.cbetaonline.cn";
 const APP_API_BASE = "https://api.ombhrum.com/api";
 const OFFICIAL_SITE_HOST = "fabushi.ombhrum.com";
 const ROOT_DOMAIN_REDIRECT_HOSTS = new Set(["ombhrum.com"]);
+const ANDROID_R2_DOWNLOADS = new Map([
+  [
+    "/downloads/android/fabushi-android-beta.apk",
+    {
+      key: "downloads/android/fabushi-android-beta.apk",
+      filename: "fabushi-android-beta.apk",
+    },
+  ],
+  [
+    "/downloads/android/fabushi-android-stable.apk",
+    {
+      key: "downloads/android/fabushi-android-stable.apk",
+      filename: "fabushi-android-stable.apk",
+    },
+  ],
+]);
 
 export default {
   async fetch(request, env) {
@@ -12,8 +28,13 @@ export default {
       return redirectToOfficialSite(url);
     }
 
+    const androidDownload = ANDROID_R2_DOWNLOADS.get(url.pathname);
     const cbetaMatch = url.pathname.match(CBETA_PROXY_ROUTE);
     const appMatch = url.pathname.match(APP_PROXY_ROUTE);
+
+    if (androidDownload) {
+      return serveAndroidR2Download(request, env, androidDownload);
+    }
 
     if (cbetaMatch) {
       return proxyApiRequest(request, CBETA_API_BASE, cbetaMatch[1], ["GET", "HEAD", "OPTIONS"]);
@@ -32,6 +53,68 @@ function redirectToOfficialSite(url) {
   redirectUrl.protocol = "https:";
   redirectUrl.host = OFFICIAL_SITE_HOST;
   return Response.redirect(redirectUrl.toString(), 308);
+}
+
+async function serveAndroidR2Download(request, env, download) {
+  const allowedMethods = ["GET", "HEAD", "OPTIONS"];
+  if (!allowedMethods.includes(request.method)) {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: {
+        Allow: "GET, HEAD",
+      },
+    });
+  }
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        Allow: "GET, HEAD",
+      },
+    });
+  }
+
+  const bucket = env?.OFFICIAL_SITE_R2;
+  if (!bucket || typeof bucket.get !== "function" || typeof bucket.head !== "function") {
+    return new Response("Download storage is not configured.", {
+      status: 503,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  const object = request.method === "HEAD" ? await bucket.head(download.key) : await bucket.get(download.key);
+  if (!object) {
+    return new Response("Android package not found.", {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  const headers = new Headers();
+  object.writeHttpMetadata?.(headers);
+  headers.set("Content-Type", headers.get("Content-Type") || "application/vnd.android.package-archive");
+  headers.set(
+    "Content-Disposition",
+    `attachment; filename="${download.filename}"; filename*=UTF-8''${encodeURIComponent(download.filename)}`,
+  );
+  headers.set("Cache-Control", "no-store");
+  headers.set("Content-Length", String(object.size));
+  headers.set("X-Fabushi-R2-Download", "official-site");
+
+  const etag = object.httpEtag || (object.etag ? `"${object.etag}"` : "");
+  if (etag) {
+    headers.set("ETag", etag);
+  }
+
+  return new Response(request.method === "HEAD" ? null : object.body, {
+    status: 200,
+    headers,
+  });
 }
 
 async function proxyApiRequest(request, upstreamBase, upstreamPath, allowedMethods) {


### PR DESCRIPTION
## Summary
- serve Android APK download paths through the official-site Worker using the R2 binding
- bind the official-site deployment to the configured R2 bucket
- update beta/stable sync workflows to publish official domain download URLs instead of public r2.dev URLs
- keep Android mirror links empty and point the current release metadata at the Worker-served APK

## Verification
- node --check frontend/official-site-worker.js
- python -m py_compile .github/scripts/generate-official-site-beta-state.py
- git diff --check
- JSON parse frontend/apps/web/public/api/releases.json
- pnpm typecheck/build verified before commit