### PR TITLE
Fix mobile login and online counters

### DIFF
--- a/fabushi/android/app/src/main/AndroidManifest.xml
+++ b/fabushi/android/app/src/main/AndroidManifest.xml
@@ -142,6 +142,16 @@
 
          In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
     <queries>
+        <!-- Android 11+ package visibility for Alipay SDK install checks and app schemes. -->
+        <package android:name="com.eg.android.AlipayGphone"/>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="alipays"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="alipay"/>
+        </intent>
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>

--- a/fabushi/android/app/src/main/kotlin/com/ombhrum/fabushi/MainActivity.kt
+++ b/fabushi/android/app/src/main/kotlin/com/ombhrum/fabushi/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugins.GeneratedPluginRegistrant
 
 // 使用 FlutterFragmentActivity 以支持 audio_service 插件
 class MainActivity : FlutterFragmentActivity() {
@@ -41,7 +42,7 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-        super.configureFlutterEngine(flutterEngine)
+        GeneratedPluginRegistrant.registerWith(flutterEngine)
         
         // 热点相关 Method Channel
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->

--- a/fabushi/lib/screens/alipay_web_login_screen.dart
+++ b/fabushi/lib/screens/alipay_web_login_screen.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class AlipayWebLoginScreen extends StatefulWidget {
+  const AlipayWebLoginScreen({super.key, required this.loginUrl});
+
+  final String loginUrl;
+
+  @override
+  State<AlipayWebLoginScreen> createState() => _AlipayWebLoginScreenState();
+}
+
+class _AlipayWebLoginScreenState extends State<AlipayWebLoginScreen> {
+  static const _desktopUserAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+      'AppleWebKit/537.36 (KHTML, like Gecko) '
+      'Chrome/120.0.0.0 Safari/537.36';
+
+  late final WebViewController _controller;
+  int _progress = 0;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(const Color(0xFF0F0F0F))
+      ..setUserAgent(_desktopUserAgent)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onProgress: (progress) {
+            if (mounted) {
+              setState(() => _progress = progress);
+            }
+          },
+          onNavigationRequest: _handleNavigationRequest,
+          onWebResourceError: (error) {
+            if (!mounted || _isIgnoredWebViewError(error)) return;
+            setState(() => _errorMessage = error.description);
+          },
+        ),
+      )
+      ..loadRequest(Uri.parse(widget.loginUrl));
+  }
+
+  NavigationDecision _handleNavigationRequest(NavigationRequest request) {
+    final url = request.url;
+    final uri = Uri.tryParse(url);
+
+    if (_isAppCallbackUrl(url)) {
+      Navigator.of(context).pop(url);
+      return NavigationDecision.prevent;
+    }
+
+    if (uri != null && _isExternalAlipayUrl(uri)) {
+      _openExternalAlipay(uri);
+      return NavigationDecision.prevent;
+    }
+
+    if (uri != null && !_isWebUrl(uri)) {
+      return NavigationDecision.prevent;
+    }
+
+    if (_errorMessage != null) {
+      setState(() => _errorMessage = null);
+    }
+    return NavigationDecision.navigate;
+  }
+
+  bool _isAppCallbackUrl(String url) {
+    return url.startsWith('com.ombhrum.fabushi://') ||
+        url.startsWith('globaldharma://') ||
+        url.startsWith('fabushi://');
+  }
+
+  bool _isExternalAlipayUrl(Uri uri) {
+    final scheme = uri.scheme.toLowerCase();
+    return scheme == 'alipays' || scheme == 'alipay' || scheme == 'intent';
+  }
+
+  bool _isWebUrl(Uri uri) {
+    final scheme = uri.scheme.toLowerCase();
+    return scheme == 'http' || scheme == 'https' || scheme == 'about';
+  }
+
+  bool _isIgnoredWebViewError(WebResourceError error) {
+    final description = error.description.toLowerCase();
+    return description.contains('net::err_unknown_url_scheme') ||
+        description.contains('net::err_aborted');
+  }
+
+  Future<void> _openExternalAlipay(Uri uri) async {
+    try {
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } else if (mounted) {
+        setState(() => _errorMessage = '无法打开支付宝，请继续使用网页登录');
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _errorMessage = '无法打开支付宝，请继续使用网页登录');
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF0F0F0F),
+      appBar: AppBar(
+        title: const Text('支付宝登录'),
+        backgroundColor: const Color(0xFF0F0F0F),
+        foregroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          SizedBox(
+            height: 2,
+            child: _progress < 100
+                ? LinearProgressIndicator(
+                    value: _progress / 100,
+                    minHeight: 2,
+                    color: theme.colorScheme.primary,
+                    backgroundColor: Colors.white10,
+                  )
+                : const SizedBox.shrink(),
+          ),
+          if (_errorMessage != null)
+            Material(
+              color: Colors.red.withValues(alpha: 0.14),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      color: Colors.redAccent,
+                      size: 18,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        _errorMessage!,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Colors.redAccent,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          Expanded(child: WebViewWidget(controller: _controller)),
+        ],
+      ),
+    );
+  }
+}

--- a/fabushi/lib/screens/douyin_login_screen.dart
+++ b/fabushi/lib/screens/douyin_login_screen.dart
@@ -3,11 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart' hide IconAlignment;
-import 'package:sign_in_with_apple/sign_in_with_apple.dart'
-    as apple_pkg
-    show IconAlignment;
 import 'dart:async';
 import 'dart:io' show Platform;
 import '../models/auth_model.dart';
@@ -15,34 +11,7 @@ import '../services/platform_service.dart';
 import '../services/alipay_service.dart';
 import '../services/alipay_auth_service.dart';
 import '../core/design_system/app_theme.dart';
-
-/// 自定义 InAppBrowser，用于拦截支付宝登录后的 URL Scheme 重定向
-class AlipayInAppBrowser extends InAppBrowser {
-  final void Function(String url) onDeepLinkCaptured;
-
-  AlipayInAppBrowser({required this.onDeepLinkCaptured});
-
-  @override
-  Future<NavigationActionPolicy?> shouldOverrideUrlLoading(
-    NavigationAction navigationAction,
-  ) async {
-    final url = navigationAction.request.url?.toString() ?? '';
-    debugPrint('InAppBrowser 导航请求: $url');
-
-    // 拦截自定义 URL Scheme 重定向
-    if (url.startsWith('com.ombhrum.fabushi://') ||
-        url.startsWith('globaldharma://') ||
-        url.startsWith('fabushi://') ||
-        url.startsWith('alipays://')) {
-      debugPrint('拦截到 App Scheme 重定向，关闭浏览器并处理回调');
-      onDeepLinkCaptured(url);
-      close();
-      return NavigationActionPolicy.CANCEL;
-    }
-
-    return NavigationActionPolicy.ALLOW;
-  }
-}
+import 'alipay_web_login_screen.dart';
 
 /// 统一登录页面 - 支持手机号验证码登录和账号密码登录
 class DouyinLoginScreen extends StatefulWidget {
@@ -69,15 +38,7 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
   // 支付宝回调相关
   StreamSubscription? _urlSubscription;
   final PlatformService _platformService = PlatformServiceFactory.create();
-  InAppBrowser? _alipayBrowser;
-
-  // 检测是否为桌面平台
-  bool get _isDesktop {
-    return !kIsWeb &&
-        (defaultTargetPlatform == TargetPlatform.macOS ||
-            defaultTargetPlatform == TargetPlatform.windows ||
-            defaultTargetPlatform == TargetPlatform.linux);
-  }
+  bool _isAlipayWebLoginOpen = false;
 
   @override
   void initState() {
@@ -336,29 +297,23 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
       final loginUrl = result['loginUrl'] as String;
 
       if (_isMobile) {
-        debugPrint('使用伪装桌面端 User-Agent 打开 Alipay WebView');
-        _alipayBrowser = AlipayInAppBrowser(
-          onDeepLinkCaptured: (url) {
-            debugPrint('InAppBrowser 捕获到 deep link: $url');
-            _handleDeepLinkAlipayCallback(url);
-          },
-        );
-        await _alipayBrowser!.openUrlRequest(
-          urlRequest: URLRequest(url: WebUri(loginUrl)),
-          settings: InAppBrowserClassSettings(
-            browserSettings: InAppBrowserSettings(
-              hideUrlBar: false,
-              hideToolbarTop: false,
-            ),
-            webViewSettings: InAppWebViewSettings(
-              // 伪装成 macOS 桌面端浏览器，强制支付宝显示网页登录（账号密码/扫码），避免它强制尝试唤起支付宝 App
-              userAgent:
-                  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-              javaScriptEnabled: true,
-              useShouldOverrideUrlLoading: true,
-            ),
+        debugPrint('使用内置 WebView 打开支付宝网页授权');
+        _isAlipayWebLoginOpen = true;
+        final callbackUrl = await Navigator.of(context).push<String>(
+          MaterialPageRoute(
+            builder: (_) => AlipayWebLoginScreen(loginUrl: loginUrl),
+            fullscreenDialog: true,
           ),
         );
+        _isAlipayWebLoginOpen = false;
+
+        if (!mounted) return;
+        if (callbackUrl != null && callbackUrl.isNotEmpty) {
+          debugPrint('内置 WebView 捕获到 deep link: $callbackUrl');
+          await _handleDeepLinkAlipayCallback(callbackUrl);
+        } else {
+          setState(() => _isLoading = false);
+        }
       } else {
         final uri = Uri.parse(loginUrl);
         if (await canLaunchUrl(uri)) {
@@ -414,17 +369,11 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
   Future<void> _handleDeepLinkAlipayCallback(String url) async {
     debugPrint('收到深度链接支付宝回调: $url');
 
-    // 如果是移动端打开了内嵌网页登录，收到回调后尝试关闭内嵌网页
-    if (_isMobile) {
-      try {
-        _alipayBrowser?.close();
-      } catch (e) {
-        debugPrint('关闭 InAppBrowser 失败: $e');
-      }
-      try {
-        closeInAppWebView(); // 保留作为后备
-      } catch (e) {
-        debugPrint('关闭内嵌浏览器失败: $e');
+    if (_isMobile && _isAlipayWebLoginOpen && mounted) {
+      _isAlipayWebLoginOpen = false;
+      if (Navigator.of(context).canPop()) {
+        Navigator.of(context).pop();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
       }
     }
 

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -45,6 +45,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     WidgetsBinding.instance.addObserver(this);
     _loadGlobe();
     _fetchInitialCount();
+    _onlineCounterService.startCountPolling('global_sending');
   }
 
   Future<void> _fetchInitialCount() async {
@@ -830,7 +831,11 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   void _startSending(FileTransferModel model) async {
     // Android 平台：首次使用时显示自启动设置引导
     if (Platform.isAndroid && mounted) {
-      await AutoStartGuideDialog.showIfNeeded(context);
+      try {
+        await AutoStartGuideDialog.showIfNeeded(context);
+      } catch (e) {
+        debugPrint('Auto-start guide failed, continuing send: $e');
+      }
     }
 
     final assetCount = await model.prepareDefaultNonR2AssetsForSending();

--- a/fabushi/lib/screens/meditation_room_screen.dart
+++ b/fabushi/lib/screens/meditation_room_screen.dart
@@ -100,6 +100,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
 
     // 获取在线人数
     _fetchInitialCount();
+    _onlineCounterService.startCountPolling('zen_room');
 
     // 监听成就事件
     _achievementSubscription = _achievementSystem.achievementStream.listen((

--- a/fabushi/lib/services/online_counter_service.dart
+++ b/fabushi/lib/services/online_counter_service.dart
@@ -18,9 +18,12 @@ class OnlineCounterService {
   String? _sessionId;
   String? _currentActivity;
   Timer? _heartbeatTimer;
+  Timer? _countPollingTimer;
   WebSocketChannel? _channel;
   bool _isConnected = false;
   bool _shouldReconnect = false;
+  bool _isCountFetchInFlight = false;
+  String? _pollingActivity;
 
   // 在线人数流控制器
   final _onlineCountController = StreamController<int>.broadcast();
@@ -254,6 +257,8 @@ class OnlineCounterService {
 
   /// 获取指定活动类型的在线人数（不加入活动）
   Future<void> fetchCountForActivity(String activityType) async {
+    if (_isCountFetchInFlight) return;
+    _isCountFetchInFlight = true;
     try {
       final response = await http.get(
         Uri.parse('$baseUrl/api/online/count?activityType=$activityType'),
@@ -265,7 +270,32 @@ class OnlineCounterService {
       }
     } catch (e) {
       print('获取在线人数错误: $e');
+    } finally {
+      _isCountFetchInFlight = false;
     }
+  }
+
+  /// 启动在线人数轮询
+  void startCountPolling(
+    String activityType, {
+    Duration interval = const Duration(seconds: 5),
+  }) {
+    _pollingActivity = activityType;
+    _countPollingTimer?.cancel();
+
+    fetchCountForActivity(activityType);
+    _countPollingTimer = Timer.periodic(interval, (_) {
+      final activity = _pollingActivity;
+      if (activity != null) {
+        fetchCountForActivity(activity);
+      }
+    });
+  }
+
+  void stopCountPolling() {
+    _countPollingTimer?.cancel();
+    _countPollingTimer = null;
+    _pollingActivity = null;
   }
 
   /// 启动心跳定时器
@@ -369,6 +399,7 @@ class OnlineCounterService {
   /// 清理资源
   void dispose() {
     _shouldReconnect = false;
+    stopCountPolling();
     _stopHeartbeat();
     _channel?.sink.close();
     _channel = null;

--- a/fabushi/lib/services/workmanager_keep_alive.dart
+++ b/fabushi/lib/services/workmanager_keep_alive.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:workmanager/workmanager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'keep_alive_service.dart';
 
 /// WorkManager 保活服务
 ///
@@ -200,6 +201,7 @@ class SendingStateSnapshot {
 @pragma('vm:entry-point')
 void callbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
+    DartPluginRegistrant.ensureInitialized();
     debugPrint('📋 WorkManager 任务执行: $task');
 
     try {

--- a/fabushi/web/alipay-login-functions.js
+++ b/fabushi/web/alipay-login-functions.js
@@ -58,13 +58,18 @@ async function generateAlipayLoginUrl(env, platform) {
       redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/macos-callback`);
       console.log('macOS应用专用回调地址:', redirectUri);
     } else if (isMobileApp) {
-      // 移动端应用（iOS/Android）使用专用的回调地址，会重定向回App
-      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/mobile-callback`);
-      console.log('移动端应用专用回调地址:', redirectUri);
+      // 支付宝开放平台白名单按 redirect_uri 校验。移动端网页登录也先使用标准
+      // OAuth 回调，再由 state.type=mobile 分流到 App Scheme。
+      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
+      console.log('移动端应用使用标准OAuth回调地址:', redirectUri);
     } else {
       // Web应用使用标准回调地址
       redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
       console.log('Web应用标准回调地址:', redirectUri);
+    }
+
+    if (!redirectUri) {
+      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
     }
 
     const authUrl = `https://openauth.alipay.com/oauth2/publicAppAuthorize.htm?app_id=${appId}&scope=auth_user&redirect_uri=${redirectUri}&state=${state}`;
@@ -672,6 +677,21 @@ async function handleAlipayCallback(request, env) {
         redirectUrl.hash = 'error=invalid_state&error_message=登录状态无效，请重新登录';
         return Response.redirect(redirectUrl.toString(), 302);
       }
+
+      try {
+        const stateData = JSON.parse(storedState.state_data);
+        if (stateData.type === 'mobile') {
+          console.log('标准OAuth回调检测到移动端state，转入移动端回调处理');
+          return await handleMobileAlipayCallback(request, env);
+        }
+        if (stateData.type === 'macos') {
+          console.log('标准OAuth回调检测到macOS state，转入macOS回调处理');
+          return await handleMacOSAlipayCallback(request, env);
+        }
+      } catch (parseError) {
+        console.warn('解析state数据失败，继续按Web回调处理:', parseError);
+      }
+
       await env.DB.prepare('DELETE FROM alipay_states WHERE state = ?').bind(state).run();
     }
 

--- a/fabushi/web/src/handlers/thirdparty.js
+++ b/fabushi/web/src/handlers/thirdparty.js
@@ -96,6 +96,12 @@ export async function handleAlipayLogin(request, env) {
   return await withFullUserResponse(response, env);
 }
 
+// 支付宝 OAuth 回调（Web/移动端网页登录共用入口）
+export async function handleAlipayCallback(request, env) {
+  const { handleAlipayCallback } = await import('../../alipay-login-functions.js');
+  return await handleAlipayCallback(request, env);
+}
+
 // macOS支付宝回调
 export async function handleMacOSAlipayCallback(request, env) {
   const { handleMacOSAlipayCallback } = await import('../../alipay-login-functions.js');

--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -2,7 +2,7 @@ import { handleRegister, handleLogin, handleGetUserInfo, handleUpdateProfile, ha
 import { handleSendSmsCode, handleSmsLogin } from './handlers/sms.js';
 import { handleGetComments, handlePostComment, handleDeleteComment, handleGetTaggedPosts, handleGetHotFeed, handleGetPostDetail, handleBatchGetCommentCounts } from './handlers/comments.js';
 import { handleSendVerificationCode, handleForgotPassword, handleResetPassword } from './handlers/verification.js';
-import { handleGetWechatLoginUrl, handleGetAlipayLoginUrl, handleAlipayLogin, handleAlipayRegister, handleBindEmail, handleMacOSAlipayCallback, handleMobileAlipayCallback, handleGetAlipayAuthString, handleAlipaySDKLogin } from './handlers/thirdparty.js';
+import { handleGetWechatLoginUrl, handleGetAlipayLoginUrl, handleAlipayLogin, handleAlipayCallback, handleAlipayRegister, handleBindEmail, handleMacOSAlipayCallback, handleMobileAlipayCallback, handleGetAlipayAuthString, handleAlipaySDKLogin } from './handlers/thirdparty.js';
 import { handleCreateAlipayOrder, handleQueryAlipayOrder, handleAlipayNotify } from './handlers/payment.js';
 import { handleVerifyAppleReceipt } from './handlers/apple-iap.js';
 import { handleCreateRedeemCode, handleUseRedeemCode, handleGetPurchaseHistory, handleGetRedeemHistory } from './handlers/redeem.js';
@@ -134,6 +134,7 @@ export async function route(request, env, db, ctx) {
   if (pathname === '/api/auth/wechat/login-url' && method === 'GET') return await handleGetWechatLoginUrl(request, env);
   if (pathname === '/api/auth/alipay/login-url' && method === 'GET') return await handleGetAlipayLoginUrl(request, env);
   if (pathname === '/api/auth/alipay/login' && method === 'POST') return await handleAlipayLogin(request, env);
+  if (pathname === '/api/auth/alipay/callback' && method === 'GET') return await handleAlipayCallback(request, env);
   if (pathname === '/api/auth/alipay/register' && method === 'POST') return await handleAlipayRegister(request, env);
   if (pathname === '/api/auth/alipay/macos-callback' && method === 'GET') return await handleMacOSAlipayCallback(request, env);
   if (pathname === '/api/auth/alipay/mobile-callback' && method === 'GET') return await handleMobileAlipayCallback(request, env);

--- a/fabushi/web/src/routes/auth-routes.js
+++ b/fabushi/web/src/routes/auth-routes.js
@@ -11,6 +11,7 @@ import {
   handleGetWechatLoginUrl,
   handleGetAlipayLoginUrl,
   handleAlipayLogin,
+  handleAlipayCallback,
   handleAlipayRegister,
   handleBindEmail,
   handleMacOSAlipayCallback,
@@ -44,6 +45,7 @@ export async function routeAuthRequest({ pathname, method, request, env, db, ctx
   if (pathname === '/api/auth/wechat/login-url' && method === 'GET') return await handleGetWechatLoginUrl(request, env);
   if (pathname === '/api/auth/alipay/login-url' && method === 'GET') return await handleGetAlipayLoginUrl(request, env);
   if (pathname === '/api/auth/alipay/login' && method === 'POST') return await handleAlipayLogin(request, env);
+  if (pathname === '/api/auth/alipay/callback' && method === 'GET') return await handleAlipayCallback(request, env);
   if (pathname === '/api/auth/alipay/register' && method === 'POST') return await handleAlipayRegister(request, env);
   if (pathname === '/api/auth/alipay/macos-callback' && method === 'GET') return await handleMacOSAlipayCallback(request, env);
   if (pathname === '/api/auth/alipay/mobile-callback' && method === 'GET') return await handleMobileAlipayCallback(request, env);


### PR DESCRIPTION
## Summary
- Replace the mobile Alipay web fallback with the existing `webview_flutter` stack and intercept app callback schemes directly, removing the Android `flutter_inappbrowser` dependency path that was throwing `MissingPluginException`.
- Route mobile Alipay web OAuth through the standard `/api/auth/alipay/callback` endpoint, then dispatch by `state.type=mobile` back to the app scheme so the redirect URI can match the Alipay whitelist.
- Explicitly register Android Flutter plugins and WorkManager background-isolate plugins to address missing `shared_preferences_android` channels.
- Add polling for global sending and zen-room online counters so Android sees counts started from iOS, and let Android global send continue if the auto-start guide storage read fails.

## Verification
- `dart format lib\screens\douyin_login_screen.dart lib\screens\alipay_web_login_screen.dart lib\screens\globe_home_screen.dart lib\screens\meditation_room_screen.dart lib\services\online_counter_service.dart lib\services\workmanager_keep_alive.dart`
- `node --check web\alipay-login-functions.js`
- `node --check web\src\handlers\thirdparty.js`
- `node --check web\src\routes\auth-routes.js`
- `node --check web\src\router.js`
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib\screens\douyin_login_screen.dart lib\screens\alipay_web_login_screen.dart lib\screens\globe_home_screen.dart lib\screens\meditation_room_screen.dart lib\services\online_counter_service.dart lib\services\workmanager_keep_alive.dart`

## Build note
- `flutter build apk --debug` could not start Gradle in this Windows environment because Gradle failed before compilation with `Could not extract native JNI library`; the same failure reproduced with a fresh local `GRADLE_USER_HOME` and with `org.gradle.vfs.watch=false` / `org.gradle.native=false`.