### PR TITLE
Fix Android startup crash from FFmpegKit

### DIFF
--- a/fabushi/android/app/src/main/kotlin/com/ombhrum/fabushi/MainActivity.kt
+++ b/fabushi/android/app/src/main/kotlin/com/ombhrum/fabushi/MainActivity.kt
@@ -12,8 +12,8 @@ import android.util.Log
 import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugins.GeneratedPluginRegistrant
 
 // 使用 FlutterFragmentActivity 以支持 audio_service 插件
 class MainActivity : FlutterFragmentActivity() {
@@ -42,7 +42,7 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine)
+        registerFlutterPlugins(flutterEngine)
         
         // 热点相关 Method Channel
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
@@ -96,6 +96,56 @@ class MainActivity : FlutterFragmentActivity() {
         
         // 内存管理 Method Channel
         memoryChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, MEMORY_CHANNEL)
+    }
+
+    private fun registerFlutterPlugins(flutterEngine: FlutterEngine) {
+        // Skip ffmpeg_kit_flutter_new_audio on Android startup. Its native library can
+        // fail JNI loading on some Android 14 / arm64 devices and crash the app before
+        // Flutter renders the first frame.
+        registerPlugin(flutterEngine, "app_links") { com.llfbandit.app_links.AppLinksPlugin() }
+        registerPlugin(flutterEngine, "audio_service") { com.ryanheise.audioservice.AudioServicePlugin() }
+        registerPlugin(flutterEngine, "audio_session") { com.ryanheise.audio_session.AudioSessionPlugin() }
+        registerPlugin(flutterEngine, "cloud_firestore") { io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin() }
+        registerPlugin(flutterEngine, "connectivity_plus") { dev.fluttercommunity.plus.connectivity.ConnectivityPlugin() }
+        registerPlugin(flutterEngine, "device_info_plus") { dev.fluttercommunity.plus.device_info.DeviceInfoPlusPlugin() }
+        registerPlugin(flutterEngine, "file_picker") { com.mr.flutter.plugin.filepicker.FilePickerPlugin() }
+        registerPlugin(flutterEngine, "firebase_auth") { io.flutter.plugins.firebase.auth.FlutterFirebaseAuthPlugin() }
+        registerPlugin(flutterEngine, "firebase_core") { io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin() }
+        registerPlugin(flutterEngine, "flutter_inappwebview_android") { com.pichillilorenzo.flutter_inappwebview_android.InAppWebViewFlutterPlugin() }
+        registerPlugin(flutterEngine, "flutter_local_notifications") { com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin() }
+        registerPlugin(flutterEngine, "flutter_plugin_android_lifecycle") { io.flutter.plugins.flutter_plugin_android_lifecycle.FlutterAndroidLifecyclePlugin() }
+        registerPlugin(flutterEngine, "flutter_sound") { xyz.canardoux.fluttersound.FlutterSound() }
+        registerPlugin(flutterEngine, "flutter_tts") { com.eyedeadevelopment.fluttertts.FlutterTtsPlugin() }
+        registerPlugin(flutterEngine, "flutter_volume_controller") { com.yosemiteyss.flutter_volume_controller.FlutterVolumeControllerPlugin() }
+        registerPlugin(flutterEngine, "geolocator_android") { com.baseflow.geolocator.GeolocatorPlugin() }
+        registerPlugin(flutterEngine, "google_sign_in_android") { io.flutter.plugins.googlesignin.GoogleSignInPlugin() }
+        registerPlugin(flutterEngine, "in_app_purchase_android") { io.flutter.plugins.inapppurchase.InAppPurchasePlugin() }
+        registerPlugin(flutterEngine, "just_audio") { com.ryanheise.just_audio.JustAudioPlugin() }
+        registerPlugin(flutterEngine, "network_info_plus") { dev.fluttercommunity.plus.network_info.NetworkInfoPlusPlugin() }
+        registerPlugin(flutterEngine, "package_info_plus") { dev.fluttercommunity.plus.packageinfo.PackageInfoPlugin() }
+        registerPlugin(flutterEngine, "path_provider_android") { io.flutter.plugins.pathprovider.PathProviderPlugin() }
+        registerPlugin(flutterEngine, "permission_handler_android") { com.baseflow.permissionhandler.PermissionHandlerPlugin() }
+        registerPlugin(flutterEngine, "record_android") { com.llfbandit.record.RecordPlugin() }
+        registerPlugin(flutterEngine, "shared_preferences_android") { io.flutter.plugins.sharedpreferences.SharedPreferencesPlugin() }
+        registerPlugin(flutterEngine, "sign_in_with_apple") { com.aboutyou.dart_packages.sign_in_with_apple.SignInWithApplePlugin() }
+        registerPlugin(flutterEngine, "sqflite_android") { com.tekartik.sqflite.SqflitePlugin() }
+        registerPlugin(flutterEngine, "tobias") { com.jarvan.tobias.TobiasPlugin() }
+        registerPlugin(flutterEngine, "url_launcher_android") { io.flutter.plugins.urllauncher.UrlLauncherPlugin() }
+        registerPlugin(flutterEngine, "video_player_android") { io.flutter.plugins.videoplayer.VideoPlayerPlugin() }
+        registerPlugin(flutterEngine, "webview_flutter_android") { io.flutter.plugins.webviewflutter.WebViewFlutterPlugin() }
+        registerPlugin(flutterEngine, "workmanager") { dev.fluttercommunity.workmanager.WorkmanagerPlugin() }
+    }
+
+    private fun registerPlugin(
+        flutterEngine: FlutterEngine,
+        name: String,
+        pluginFactory: () -> FlutterPlugin
+    ) {
+        try {
+            flutterEngine.plugins.add(pluginFactory())
+        } catch (t: Throwable) {
+            Log.e(TAG, "Error registering plugin $name", t)
+        }
     }
     
     /**

--- a/fabushi/lib/services/audio_merger_service.dart
+++ b/fabushi/lib/services/audio_merger_service.dart
@@ -46,6 +46,10 @@ class AudioMergerService {
   /// 是否是 macOS 平台
   bool get _isMacOS => !kIsWeb && Platform.isMacOS;
 
+  /// Android disables FFmpegKit because its native library can fail during
+  /// plugin startup on some Android 14 / arm64 devices.
+  bool get _isAndroid => !kIsWeb && Platform.isAndroid;
+
   /// 合并 PCM 文件并嵌入字幕轨道，输出 M4A
   Future<String?> mergeWithSubtitle({
     required List<String> pcmPaths,
@@ -87,8 +91,12 @@ class AudioMergerService {
         }
 
         await _cleanupTempFiles([wavPath]);
+      } else if (_isAndroid) {
+        audioPath = '${tempDir.path}/audio_$timestamp.wav';
+        await _pcmToWav(mergedPcmPath, audioPath);
+        debugPrint('[AudioMerger] Android FFmpeg disabled, returning WAV');
       } else {
-        // iOS/Android: 使用 FFmpeg
+        // iOS: 使用 FFmpeg
         audioPath = '${tempDir.path}/audio_$timestamp.m4a';
         final success = await _pcmToAacFFmpeg(mergedPcmPath, audioPath);
         if (!success) {
@@ -101,7 +109,7 @@ class AudioMergerService {
       final outputPath = '${tempDir.path}/reading_$timestamp.m4a';
       bool embedSuccess = false;
 
-      if (!_isMacOS) {
+      if (!_isMacOS && !_isAndroid) {
         embedSuccess = await _embedSubtitleFFmpeg(
           audioPath,
           srtPath,


### PR DESCRIPTION
## Summary
- skip ffmpeg_kit_flutter_new_audio registration during Android activity startup to avoid JNI_OnLoad crashes on Android 14 / arm64 devices
- keep all other Android plugins registered manually, including shared_preferences, in-app webview, Tobias/Alipay, WorkManager, audio plugins, and URL/webview plugins
- use a pure Dart WAV fallback for Android reading-game audio merge so runtime paths do not call FFmpegKit

## Verification
- collected crash log from connected HONOR ALP-AN00: FFmpegKit failed to start / Bad JNI version returned from JNI_OnLoad
- dart analyze lib/services/audio_merger_service.dart
- flutter analyze --no-fatal-infos --no-fatal-warnings still fails on existing Drift dependency issues outside this change
- flutter build apk --debug is blocked locally by Gradle native JNI extraction before project compilation