### PR TITLE
Add Alipay open_id D1 migration

### DIFF
--- a/fabushi/web/migrations/20260522_users_alipay_open_id.sql
+++ b/fabushi/web/migrations/20260522_users_alipay_open_id.sql
@@ -1,0 +1,7 @@
+-- Add the Alipay OAuth open_id column used by the mobile login callback.
+-- Long-lived D1 databases already have alipay_user_id but were missing this
+-- companion identifier, causing Alipay one-click registration to fail at INSERT.
+
+ALTER TABLE users ADD COLUMN alipay_open_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_users_alipay_open_id ON users(alipay_open_id);

--- a/fabushi/web/schema.sql
+++ b/fabushi/web/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS users (
   wechat_headimgurl TEXT,
   wechat_bound_at TEXT,
   alipay_user_id TEXT,
+  alipay_open_id TEXT,
   alipay_nickname TEXT,
   alipay_avatar TEXT,
   alipay_bound_at TEXT,
@@ -45,6 +46,7 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
 CREATE INDEX IF NOT EXISTS idx_users_wechat_openid ON users(wechat_openid);
 CREATE INDEX IF NOT EXISTS idx_users_alipay_user_id ON users(alipay_user_id);
+CREATE INDEX IF NOT EXISTS idx_users_alipay_open_id ON users(alipay_open_id);
 CREATE INDEX IF NOT EXISTS idx_users_phone_number ON users(phone_number);
 CREATE INDEX IF NOT EXISTS idx_users_firebase_uid ON users(firebase_uid);
 CREATE INDEX IF NOT EXISTS idx_users_apple_user_id ON users(apple_user_id);

--- a/fabushi/web/schema_v2.sql
+++ b/fabushi/web/schema_v2.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS users (
   algo TEXT,
   email_verified INTEGER DEFAULT 0,
   alipay_user_id TEXT UNIQUE,
+  alipay_open_id TEXT,
   alipay_nickname TEXT,
   alipay_avatar TEXT,
   alipay_bound_at TEXT,
@@ -56,6 +57,7 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_alipay_user_id ON users(alipay_user_id);
+CREATE INDEX IF NOT EXISTS idx_users_alipay_open_id ON users(alipay_open_id);
 CREATE INDEX IF NOT EXISTS idx_users_wechat_openid ON users(wechat_openid);
 CREATE INDEX IF NOT EXISTS idx_users_phone_number ON users(phone_number);
 CREATE INDEX IF NOT EXISTS idx_users_firebase_uid ON users(firebase_uid);


### PR DESCRIPTION
## Summary
- add users.alipay_open_id to schema.sql and schema_v2.sql
- add a managed D1 migration for long-lived databases that already have alipay_user_id but not alipay_open_id
- index alipay_open_id for OAuth identity lookups

## Verification
- observed Android v366 login screen error from production API: D1_ERROR table users has no column named alipay_open_id
- git diff --check