### PR TITLE
Fix Alipay web login redirect errors

### DIFF
--- a/fabushi/lib/screens/alipay_web_login_screen.dart
+++ b/fabushi/lib/screens/alipay_web_login_screen.dart
@@ -39,6 +39,7 @@ class _AlipayWebLoginScreenState extends State<AlipayWebLoginScreen> {
           onNavigationRequest: _handleNavigationRequest,
           onWebResourceError: (error) {
             if (!mounted || _isIgnoredWebViewError(error)) return;
+            if (error.isForMainFrame == false) return;
             setState(() => _errorMessage = error.description);
           },
         ),
@@ -89,7 +90,9 @@ class _AlipayWebLoginScreenState extends State<AlipayWebLoginScreen> {
   bool _isIgnoredWebViewError(WebResourceError error) {
     final description = error.description.toLowerCase();
     return description.contains('net::err_unknown_url_scheme') ||
-        description.contains('net::err_aborted');
+        description.contains('net::err_aborted') ||
+        description.contains('net::err_blocked_by_orb') ||
+        description.contains('net::err_blocked_by_response');
   }
 
   Future<void> _openExternalAlipay(Uri uri) async {

--- a/fabushi/web/dist/worker-modular.js
+++ b/fabushi/web/dist/worker-modular.js
@@ -392,8 +392,8 @@ async function generateAlipayLoginUrl(env, platform) {
       redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/macos-callback`);
       console.log("macOS\u5E94\u7528\u4E13\u7528\u56DE\u8C03\u5730\u5740:", redirectUri);
     } else if (isMobileApp) {
-      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/mobile-callback`);
-      console.log("\u79FB\u52A8\u7AEF\u5E94\u7528\u4E13\u7528\u56DE\u8C03\u5730\u5740:", redirectUri);
+      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
+      console.log("\u79FB\u52A8\u7AEF\u5E94\u7528\u4F7F\u7528\u6807\u51C6OAuth\u56DE\u8C03\u5730\u5740:", redirectUri);
     } else {
       redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
       console.log("Web\u5E94\u7528\u6807\u51C6\u56DE\u8C03\u5730\u5740:", redirectUri);

--- a/fabushi/web/tests/alipay-user-id.test.js
+++ b/fabushi/web/tests/alipay-user-id.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { registerAlipayUser, sendRegistrationCaptcha } from '../alipay-login-functions.js';
+import { generateAlipayLoginUrl, registerAlipayUser, sendRegistrationCaptcha } from '../alipay-login-functions.js';
 import { verifyToken } from '../auth-utils.js';
 
 function createDbEnv() {
@@ -88,6 +88,25 @@ test('one-click Alipay registration stores user_id in mappings and token', async
   assert.equal(state.alipayBindings[0].userId, 100);
   assert.equal(tokenPayload.userId, 100);
   assert.equal(tokenPayload.username, payload.username);
+});
+
+test('mobile Alipay OAuth URL uses the standard whitelisted callback', async () => {
+  for (const platform of ['android', 'ios']) {
+    const { env } = createDbEnv();
+    env.ALIPAY_APP_ID = 'test-app-id';
+    env.WORKER_URL = 'https://api.ombhrum.com';
+
+    const response = await generateAlipayLoginUrl(env, platform);
+    const payload = await response.json();
+    const authUrl = new URL(payload.authUrl);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.platform, 'mobile');
+    assert.equal(
+      authUrl.searchParams.get('redirect_uri'),
+      'https://api.ombhrum.com/api/auth/alipay/callback',
+    );
+  }
 });
 
 test('manual Alipay registration stores user_id in mappings and token', async () => {


### PR DESCRIPTION
## Summary
- hide non-main-frame Alipay WebView resource errors such as Android ORB blocks
- keep mobile OAuth redirect_uri on the standard /api/auth/alipay/callback path in the bundled Worker
- add a regression test for Android/iOS Alipay login-url generation

## Verification
- node --test web/tests/alipay-user-id.test.js
- flutter analyze lib/screens/alipay_web_login_screen.dart
- verified production login-url for platform=android returns /api/auth/alipay/callback