### PR TITLE
fix: send homepage scriptures from CBETA

### DIFF
--- a/fabushi/lib/models/file_transfer_model.dart
+++ b/fabushi/lib/models/file_transfer_model.dart
@@ -1,29 +1,25 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:file_picker/file_picker.dart';
-import 'package:path_provider/path_provider.dart';
 import 'dart:io';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:async';
-import 'package:http/http.dart' as http;
 
 import '../screens/asset_screen.dart';
-import '../core/config/app_config.dart';
 import '../services/shared_asset_manager.dart';
 import '../services/download_manager.dart' show DownloadStatus;
 import '../services/real_global_send_service.dart';
 import '../services/platform_global_send_service.dart';
 import '../services/ip_location_service.dart';
 import '../services/leaderboard_service.dart';
+import '../services/cbeta_send_text_service.dart';
 // Android 和 iOS 统一使用 audio_service MediaSession
 import '../services/wifi_field_broadcast_service.dart';
 import '../services/hotspot_manager_service.dart';
 import '../services/keep_alive_service.dart';
 import '../widgets/download_progress_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:universal_html/html.dart' as html;
 import '../core/startup/deferred_loader.dart';
 import '../services/local_loopback_service.dart';
 
@@ -65,6 +61,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   final SharedAssetManager _sharedAssetManager = SharedAssetManager();
   final IPLocationService _ipLocationService = IPLocationService();
+  final CbetaSendTextService _cbetaSendTextService = CbetaSendTextService();
 
   // 场能广播服务
   WiFiFieldBroadcastService? _fieldBroadcastService;
@@ -310,40 +307,47 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   Future<int> prepareDefaultNonR2AssetsForSending() async {
-    final manifestString = await rootBundle.loadString(
-      'assets/data/asset-manifest.json',
-    );
-    final List<dynamic> files = json.decode(manifestString);
+    updateLog('📚 正在从 CBETA API 下载首页默认经文...');
 
-    final assetPaths =
-        files
-            .whereType<Map<String, dynamic>>()
-            .where((fileInfo) {
-              final key = (fileInfo['key'] ?? '').toString();
-              final source = (fileInfo['source'] ?? '').toString();
+    try {
+      final result = await _cbetaSendTextService.fetchDefaultSendTexts();
+      _selectedFiles = result.items.map((text) {
+        final content = [
+          '来源: CBETA',
+          '经名: ${text.title}',
+          '编号: ${text.work} 第 ${text.juan} 卷',
+          if (text.byline.isNotEmpty) '译者/作者: ${text.byline}',
+          if (text.category.isNotEmpty) '分类: ${text.category}',
+          if (text.sourceUrl.isNotEmpty) 'CBETA API: ${text.sourceUrl}',
+          '',
+          text.content,
+        ].join('\n');
+        final bytes = Uint8List.fromList(utf8.encode(content));
+        return PlatformFile(
+          name: text.fileName.isNotEmpty ? text.fileName : '${text.work}.txt',
+          size: bytes.length,
+          bytes: bytes,
+        );
+      }).toList();
 
-              return source != 'r2' &&
-                  key.isNotEmpty &&
-                  key.toLowerCase().endsWith('.txt') &&
-                  !key.contains('/.DS_Store') &&
-                  !key.startsWith('.');
-            })
-            .map((fileInfo) => (fileInfo['key'] ?? '').toString())
-            .toList()
-          ..sort();
-
-    _selectedFiles = assetPaths.map((assetPath) {
-      final fileName = assetPath.split('/').last;
-      final bytes = Uint8List.fromList(
-        utf8.encode('全球法布施素材\n$fileName\n$assetPath'),
+      _isLooping = true;
+      final titles = result.items.map((item) => '《${item.title}》').join('、');
+      final warning = result.errors.isEmpty
+          ? ''
+          : '；部分经文下载失败: ${jsonEncode(result.errors)}';
+      updateLog(
+        '📚 已从 CBETA 下载 ${_selectedFiles.length} 部经文，准备发送 $titles$warning',
       );
-      return PlatformFile(name: fileName, size: bytes.length, bytes: bytes);
-    }).toList();
-
-    _isLooping = true;
-    debugPrint('📚 已准备默认非 R2 经文素材: ${_selectedFiles.length} 个，循环发送已开启');
-    notifyListeners();
-    return _selectedFiles.length;
+      debugPrint('📚 已从 CBETA 下载 ${_selectedFiles.length} 部经文，循环发送已开启');
+      notifyListeners();
+      return _selectedFiles.length;
+    } catch (error) {
+      _selectedFiles = [];
+      updateLog('❌ CBETA 经文下载失败: $error');
+      debugPrint('❌ CBETA 经文下载失败: $error');
+      notifyListeners();
+      return 0;
+    }
   }
 
   Future<void> _downloadSelectedAssets(

--- a/fabushi/lib/screens/global_dharma_screen.dart
+++ b/fabushi/lib/screens/global_dharma_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/file_transfer_model.dart';
-import '../services/real_global_send_service.dart';
 import '../core/constants/country_servers.dart';
 import 'search_screen.dart';
 
@@ -60,9 +59,10 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
     final assetCount = await model.prepareDefaultNonR2AssetsForSending();
     if (assetCount == 0) {
       if (!mounted) return;
+      final detail = model.currentLog.isNotEmpty ? '\n${model.currentLog}' : '';
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('未找到可发送的非 R2 经文素材')));
+      ).showSnackBar(SnackBar(content: Text('未下载到可发送的 CBETA 经文$detail')));
       return;
     }
 

--- a/fabushi/lib/services/cbeta_send_text_service.dart
+++ b/fabushi/lib/services/cbeta_send_text_service.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../core/config/app_config.dart';
+
+class CbetaSendText {
+  final String work;
+  final int juan;
+  final String title;
+  final String byline;
+  final String category;
+  final String fileName;
+  final String content;
+  final String sourceUrl;
+
+  const CbetaSendText({
+    required this.work,
+    required this.juan,
+    required this.title,
+    required this.byline,
+    required this.category,
+    required this.fileName,
+    required this.content,
+    required this.sourceUrl,
+  });
+
+  factory CbetaSendText.fromJson(Map<String, dynamic> json) {
+    return CbetaSendText(
+      work: (json['work'] ?? '').toString(),
+      juan: _parseInt(json['juan']),
+      title: (json['title'] ?? '').toString(),
+      byline: (json['byline'] ?? '').toString(),
+      category: (json['category'] ?? '').toString(),
+      fileName: (json['fileName'] ?? '').toString(),
+      content: (json['content'] ?? '').toString(),
+      sourceUrl: (json['sourceUrl'] ?? '').toString(),
+    );
+  }
+
+  static int _parseInt(dynamic value) {
+    if (value is int) return value;
+    return int.tryParse((value ?? '').toString()) ?? 1;
+  }
+}
+
+class CbetaSendTextResult {
+  final List<CbetaSendText> items;
+  final List<dynamic> errors;
+  final String api;
+
+  const CbetaSendTextResult({
+    required this.items,
+    required this.errors,
+    required this.api,
+  });
+}
+
+class CbetaSendTextException implements Exception {
+  final String message;
+  final List<Map<String, dynamic>> attempts;
+
+  const CbetaSendTextException(this.message, this.attempts);
+
+  @override
+  String toString() {
+    final details = attempts.isEmpty ? '' : ' ${jsonEncode(attempts)}';
+    return '$message$details';
+  }
+}
+
+class CbetaSendTextService {
+  static const int _maxRetries = 3;
+  static const Duration _timeout = Duration(seconds: 15);
+
+  Future<CbetaSendTextResult> fetchDefaultSendTexts({int limit = 12}) async {
+    final baseUrl = AppConfig.currentBackendUrl.replaceFirst(
+      RegExp(r'/+$'),
+      '',
+    );
+    final uri = Uri.parse(
+      '$baseUrl/api/cbeta/send-texts',
+    ).replace(queryParameters: {'limit': limit.toString()});
+    final attempts = <Map<String, dynamic>>[];
+
+    for (int attempt = 1; attempt <= _maxRetries; attempt++) {
+      final startedAt = DateTime.now();
+      try {
+        final response = await http
+            .get(uri, headers: {'Accept': 'application/json'})
+            .timeout(_timeout);
+        final body = utf8.decode(response.bodyBytes);
+        final durationMs = DateTime.now().difference(startedAt).inMilliseconds;
+        final attemptInfo = <String, dynamic>{
+          'attempt': attempt,
+          'url': uri.toString(),
+          'statusCode': response.statusCode,
+          'durationMs': durationMs,
+          'body': _summarizeBody(body),
+        };
+
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          attempts.add(attemptInfo);
+          await _delayBeforeRetry(attempt);
+          continue;
+        }
+
+        final decoded = json.decode(body);
+        if (decoded is! Map<String, dynamic>) {
+          attempts.add({...attemptInfo, 'error': '响应不是 JSON 对象'});
+          await _delayBeforeRetry(attempt);
+          continue;
+        }
+
+        final rawItems = decoded['items'];
+        final items = rawItems is List
+            ? rawItems
+                  .whereType<Map<String, dynamic>>()
+                  .map(CbetaSendText.fromJson)
+                  .where((item) => item.content.trim().isNotEmpty)
+                  .toList()
+            : <CbetaSendText>[];
+        final serverErrors = decoded['errors'] is List
+            ? decoded['errors'] as List<dynamic>
+            : <dynamic>[];
+
+        if (items.isEmpty) {
+          attempts.add({
+            ...attemptInfo,
+            'error': '后端没有返回可发送的经文',
+            'serverErrors': serverErrors,
+          });
+          await _delayBeforeRetry(attempt);
+          continue;
+        }
+
+        return CbetaSendTextResult(
+          items: items,
+          errors: serverErrors,
+          api: (decoded['api'] ?? '').toString(),
+        );
+      } on TimeoutException catch (error) {
+        attempts.add({
+          'attempt': attempt,
+          'url': uri.toString(),
+          'error': '请求超时: ${error.message ?? _timeout.toString()}',
+        });
+        await _delayBeforeRetry(attempt);
+      } catch (error) {
+        attempts.add({
+          'attempt': attempt,
+          'url': uri.toString(),
+          'error': error.toString(),
+        });
+        await _delayBeforeRetry(attempt);
+      }
+    }
+
+    throw CbetaSendTextException('CBETA 经文下载失败，已重试 $_maxRetries 次。', attempts);
+  }
+
+  static Future<void> _delayBeforeRetry(int attempt) async {
+    if (attempt >= _maxRetries) return;
+    await Future.delayed(Duration(milliseconds: 300 * attempt));
+  }
+
+  static String _summarizeBody(String body) {
+    if (body.length <= 800) return body;
+    return '${body.substring(0, 800)}...';
+  }
+}

--- a/fabushi/lib/services/ip_location_service.dart
+++ b/fabushi/lib/services/ip_location_service.dart
@@ -21,10 +21,11 @@ class IPLocation {
   });
 
   factory IPLocation.fromJson(Map<String, dynamic> json) {
+    final countryCode = (json['countryCode'] ?? '').toString();
     return IPLocation(
       ip: json['query'] ?? json['ip'] ?? '',
-      country: json['country'] ?? '',
-      countryCode: json['countryCode'] ?? '',
+      country: _normalizeCountryName(json['country'], countryCode),
+      countryCode: countryCode,
       region: json['regionName'] ?? json['region'] ?? '',
       city: json['city'] ?? '',
       latitude: _parseDouble(json['lat']),
@@ -40,6 +41,14 @@ class IPLocation {
       return double.tryParse(value) ?? 0.0;
     }
     return 0.0;
+  }
+
+  static String _normalizeCountryName(dynamic value, String countryCode) {
+    final country = (value ?? '').toString();
+    if (countryCode.toUpperCase() == 'CN' || country.toLowerCase() == 'china') {
+      return '中国';
+    }
+    return country;
   }
 }
 
@@ -106,7 +115,7 @@ class IPLocationService {
         if (locParts.length == 2) {
           return IPLocation(
             ip: data['ip'] ?? '',
-            country: data['country'] ?? '',
+            country: data['country'] == 'CN' ? '中国' : (data['country'] ?? ''),
             countryCode: data['country'] ?? '',
             region: data['region'] ?? '',
             city: data['city'] ?? '',

--- a/fabushi/lib/services/udp_global_send_service.dart
+++ b/fabushi/lib/services/udp_global_send_service.dart
@@ -7,6 +7,16 @@ import 'geoip_data_service.dart';
 import 'country_coordinates_service.dart';
 import '../core/constants/country_servers.dart' as country_names;
 
+class _UdpSendResult {
+  final bool success;
+  final int bytesSent;
+  final String? error;
+
+  const _UdpSendResult.success(this.bytesSent) : success = true, error = null;
+
+  const _UdpSendResult.failure(this.error) : success = false, bytesSent = 0;
+}
+
 /// UDP 全球发送服务
 /// 使用 GeoLite2 IP 数据向全球每个国家发送 UDP 数据包
 /// 仅用于非 Web 平台（iOS/Android/macOS）
@@ -45,6 +55,7 @@ class UDPGlobalSendService {
 
   // 每个数据包的最大大小（UDP 推荐不超过 1472 字节以避免分片）
   static const int _maxPacketSize = 1400;
+  static const int _maxSendRetries = 3;
 
   UDPGlobalSendService({
     required this.onProgress,
@@ -207,9 +218,10 @@ class UDPGlobalSendService {
     List<String> countryCodes,
   ) async {
     int successCount = 0;
+    final scriptureTitle = _displayScriptureName(fileName);
 
     onLog(
-      '📤 准备发送文件: $fileName, ${fileBytes.length} 字节到 ${countryCodes.length} 个国家',
+      '📤 准备发送《$scriptureTitle》: $fileName, ${fileBytes.length} 字节到 ${countryCodes.length} 个国家',
     );
 
     for (int i = 0; i < countryCodes.length; i++) {
@@ -238,17 +250,25 @@ class UDPGlobalSendService {
       bool countrySuccess = false;
       int ipIndex = 0;
       int sendCount = 0;
+      int retryCount = 0;
+      String? lastSuccessIp;
+      final errors = <String>[];
 
       while (!countrySuccess ||
           DateTime.now().difference(sendStartTime) < minSendDuration) {
         if (!_isRunning) break;
+        if (ipIndex >= 20) break;
 
         // 循环使用该国家的所有 IP
         final ip = ips[ipIndex % ips.length];
         ipIndex++;
 
-        try {
-          final success = await _sendUDPPacketWithBytes(
+        onLog('📤 正在发送到 $countryName ($countryCode)：《$scriptureTitle》 -> $ip');
+
+        for (int attempt = 1; attempt <= _maxSendRetries; attempt++) {
+          if (!_isRunning) break;
+
+          final result = await _sendUDPPacketWithBytes(
             socket,
             fileName,
             fileBytes,
@@ -257,32 +277,46 @@ class UDPGlobalSendService {
             countryCode,
             countryName,
           );
-          if (success) {
+          if (result.success) {
             countrySuccess = true;
             sendCount++;
+            lastSuccessIp = ip;
+            break;
           }
-        } catch (e) {
-          // UDP 发送失败，继续尝试下一个 IP
+
+          final detail =
+              '$ip 第 $attempt/$_maxSendRetries 次: ${result.error ?? "未知错误"}';
+          errors.add(detail);
+          onLog(
+            '⚠️ UDP 发送到 $countryName ($countryCode) 失败：《$scriptureTitle》 -> $detail',
+          );
+
+          if (attempt < _maxSendRetries) {
+            retryCount++;
+            await Future.delayed(Duration(milliseconds: 150 * attempt));
+          }
         }
 
         // 短暂延迟，避免发送过快
         await Future.delayed(const Duration(milliseconds: 100));
-
-        // 最多发送 20 次，防止无限循环
-        if (ipIndex >= 20) break;
       }
 
       if (countrySuccess) {
         successCount++;
         _sentCount++; // 实时更新国家计数
         onProgress(_sentCount); // 实时通知进度更新
-        onLog('✅ UDP 发送到 $countryName ($countryCode) 成功 ($sendCount 次)');
+        onLog(
+          '✅ UDP 发送到 $countryName ($countryCode) 成功：《$scriptureTitle》 -> ${lastSuccessIp ?? "未知 IP"}，发送 $sendCount 次，重试 $retryCount 次',
+        );
 
         if (onCountrySent != null) {
           onCountrySent!(fileSize * sendCount);
         }
       } else {
-        onLog('❌ UDP 发送到 $countryName ($countryCode) 失败');
+        final errorText = errors.isEmpty ? '没有可用的发送结果' : errors.join(' | ');
+        onLog(
+          '❌ UDP 发送到 $countryName ($countryCode) 失败：《$scriptureTitle》，已重试 $retryCount 次，错误: $errorText',
+        );
       }
     }
 
@@ -509,7 +543,7 @@ class UDPGlobalSendService {
     }
   }
 
-  Future<bool> _sendUDPPacketWithBytes(
+  Future<_UdpSendResult> _sendUDPPacketWithBytes(
     RawDatagramSocket socket,
     String fileName,
     Uint8List fileBytes,
@@ -540,8 +574,9 @@ class UDPGlobalSendService {
 
       // 如果发送返回 0，可能是网络不可达，尝试下一个 IP
       if (headerSent <= 0) {
-        debugPrint('⚠️ UDP 头部发送失败 (0字节)，IP 可能不可达: $targetIP');
-        return false;
+        final error = 'UDP 头部发送 0 字节，IP 可能不可达: $targetIP:$_udpPort';
+        debugPrint('⚠️ $error');
+        return _UdpSendResult.failure(error);
       }
 
       // 分片发送文件数据
@@ -557,6 +592,11 @@ class UDPGlobalSendService {
         final packet = _buildDataPacket(packetIndex, chunk, countryCode);
 
         final sent = socket.send(packet, address, _udpPort);
+        if (sent <= 0) {
+          return _UdpSendResult.failure(
+            'UDP 数据包 $packetIndex 发送 0 字节: $targetIP:$_udpPort',
+          );
+        }
         totalBytesSent += sent;
 
         offset = end;
@@ -571,10 +611,10 @@ class UDPGlobalSendService {
       debugPrint(
         '✅ UDP 发送完成: $countryName - $packetIndex 个包, $totalBytesSent 字节',
       );
-      return true;
+      return _UdpSendResult.success(totalBytesSent);
     } catch (e) {
       debugPrint('❌ UDP 发送到 $targetIP 失败: $e');
-      return false;
+      return _UdpSendResult.failure('$targetIP:$_udpPort $e');
     }
   }
 
@@ -609,6 +649,16 @@ class UDPGlobalSendService {
       sum = (sum + byte) & 0xFFFFFFFF;
     }
     return sum.toRadixString(16);
+  }
+
+  String _displayScriptureName(String fileName) {
+    final withoutExtension = fileName.replaceFirst(RegExp(r'\.[^.]+$'), '');
+    final withoutCbetaPrefix = withoutExtension.replaceFirst(
+      RegExp(r'^[A-Z][A-Z0-9]?\d{4}[A-Z]?_\d+_'),
+      '',
+    );
+    final normalized = withoutCbetaPrefix.replaceAll('_', ' ').trim();
+    return normalized.isEmpty ? withoutExtension : normalized;
   }
 
   void _triggerBeamAnimation(String countryCode, String countryName) {

--- a/fabushi/web/src/handlers/cbeta.js
+++ b/fabushi/web/src/handlers/cbeta.js
@@ -1,0 +1,285 @@
+import { CORS_HEADERS } from '../config/constants.js';
+import { jsonResponse } from '../utils/response.js';
+
+const CBETA_API_ROOT = 'https://api.cbetaonline.cn';
+const DEFAULT_SEND_WORKS = [
+  'T0365',
+  'T0251',
+  'T0235',
+  'T0262',
+  'T0279',
+  'T0366',
+  'T0001',
+  'T0099',
+  'T0220',
+  'T0374',
+  'T0261',
+  'T0278',
+];
+const DEFAULT_RETRY_COUNT = 3;
+const DEFAULT_TIMEOUT_MS = 10000;
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function buildCbetaUrl(path, params = {}) {
+  const url = new URL(path.replace(/^\/+/, ''), `${CBETA_API_ROOT}/`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && `${value}` !== '') {
+      url.searchParams.set(key, `${value}`);
+    }
+  }
+  return url;
+}
+
+function summarizeBody(body) {
+  if (!body) return '';
+  return body.length > 600 ? `${body.slice(0, 600)}...` : body;
+}
+
+async function fetchJsonWithRetry(path, params = {}, options = {}) {
+  const retries = options.retries ?? DEFAULT_RETRY_COUNT;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const url = buildCbetaUrl(path, params);
+  const attempts = [];
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const startedAt = Date.now();
+
+    try {
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+        },
+        signal: controller.signal,
+      });
+      const bodyText = await response.text();
+      const detail = {
+        attempt,
+        url: url.toString(),
+        status: response.status,
+        statusText: response.statusText,
+        durationMs: Date.now() - startedAt,
+      };
+
+      if (!response.ok) {
+        attempts.push({
+          ...detail,
+          body: summarizeBody(bodyText),
+        });
+        if (attempt < retries) await sleep(250 * attempt);
+        continue;
+      }
+
+      try {
+        return {
+          data: JSON.parse(bodyText),
+          attempts: [...attempts, detail],
+        };
+      } catch (error) {
+        attempts.push({
+          ...detail,
+          error: `JSON parse failed: ${error.message}`,
+          body: summarizeBody(bodyText),
+        });
+        if (attempt < retries) await sleep(250 * attempt);
+      }
+    } catch (error) {
+      attempts.push({
+        attempt,
+        url: url.toString(),
+        durationMs: Date.now() - startedAt,
+        error: error?.name === 'AbortError'
+          ? `Request timed out after ${timeoutMs}ms`
+          : error?.message || String(error),
+      });
+      if (attempt < retries) await sleep(250 * attempt);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  const error = new Error(`CBETA request failed after ${retries} attempts`);
+  error.details = attempts;
+  throw error;
+}
+
+function decodeHtmlEntities(value) {
+  const namedEntities = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+  };
+
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (entity, code) => {
+    if (code[0] === '#') {
+      const radix = code[1]?.toLowerCase() === 'x' ? 16 : 10;
+      const raw = code[1]?.toLowerCase() === 'x' ? code.slice(2) : code.slice(1);
+      const parsed = parseInt(raw, radix);
+      return Number.isFinite(parsed) ? String.fromCodePoint(parsed) : entity;
+    }
+    return namedEntities[code] ?? entity;
+  });
+}
+
+function htmlToText(html) {
+  if (!html) return '';
+
+  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  const source = bodyMatch ? bodyMatch[1] : html;
+  const withoutBackMatter = source
+    .replace(/<div[^>]+id=['"]back['"][\s\S]*?<\/div>\s*<div[^>]+id=['"]cbeta-copyright['"]/i, '<div id="cbeta-copyright"')
+    .replace(/<div[^>]+id=['"]cbeta-copyright['"][\s\S]*?<\/div>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<span[^>]+class=['"][^'"]*\blb\b[^'"]*['"][^>]*>[\s\S]*?<\/span>/gi, '')
+    .replace(/<span[^>]+class=['"][^'"]*\blineInfo\b[^'"]*['"][^>]*>[\s\S]*?<\/span>/gi, '')
+    .replace(/<a[^>]+class=['"][^'"]*\bnoteAnchor\b[^'"]*['"][^>]*>[\s\S]*?<\/a>/gi, '')
+    .replace(/<a[^>]+class=['"][^'"]*\bfacsimile\b[^'"]*['"][^>]*>[\s\S]*?<\/a>/gi, '')
+    .replace(/<(p|div|br|h[1-6])\b[^>]*>/gi, '\n')
+    .replace(/<\/(p|div|h[1-6])>/gi, '\n')
+    .replace(/<[^>]+>/g, '');
+
+  return decodeHtmlEntities(withoutBackMatter)
+    .replace(/\r/g, '')
+    .replace(/[ \t\f\v]+/g, ' ')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function safeFileName(value) {
+  return value
+    .replace(/[\\/:*?"<>|]+/g, '_')
+    .replace(/\s+/g, '')
+    .slice(0, 80);
+}
+
+function extractTitleFromHtml(html) {
+  const match = html?.match(/<title>([\s\S]*?)<\/title>/i);
+  return match ? decodeHtmlEntities(match[1].replace(/<[^>]+>/g, '')).trim() : '';
+}
+
+function parseWorksParam(value) {
+  if (!value) return DEFAULT_SEND_WORKS;
+
+  const works = value
+    .split(',')
+    .map(item => item.trim().toUpperCase())
+    .filter(item => /^[A-Z][A-Z0-9]?\d{4}[A-Z]?$/.test(item));
+
+  return works.length > 0 ? works : DEFAULT_SEND_WORKS;
+}
+
+function parseLimit(value, fallback) {
+  const parsed = Number.parseInt(value || '', 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(parsed, 1), 24);
+}
+
+function toCbetaItem(work, juan, payload, attempts) {
+  const html = Array.isArray(payload?.results) ? payload.results[0] : '';
+  const workInfo = payload?.work_info || {};
+  const title = workInfo.title || extractTitleFromHtml(html) || work;
+  const content = htmlToText(html);
+
+  if (!content) {
+    throw new Error(`CBETA returned empty content for ${work} juan ${juan}`);
+  }
+
+  return {
+    work: workInfo.work || work,
+    juan,
+    title,
+    byline: workInfo.byline || '',
+    category: workInfo.category || workInfo.orig_category || '',
+    fileName: `${workInfo.work || work}_${juan}_${safeFileName(title)}.txt`,
+    content,
+    contentLength: content.length,
+    source: 'CBETA',
+    sourceApi: CBETA_API_ROOT,
+    sourceUrl: buildCbetaUrl('juans', {
+      work: workInfo.work || work,
+      juan,
+      work_info: 1,
+      toc: 1,
+    }).toString(),
+    fetchAttempts: attempts,
+  };
+}
+
+function normalizeError(work, juan, error) {
+  return {
+    work,
+    juan,
+    message: error?.message || String(error),
+    attempts: error?.details || [],
+    stack: error?.stack || '',
+  };
+}
+
+export async function handleGetCbetaSendTexts(request) {
+  const url = new URL(request.url);
+  const works = parseWorksParam(url.searchParams.get('works'));
+  const limit = parseLimit(url.searchParams.get('limit'), DEFAULT_SEND_WORKS.length);
+  const juan = parseLimit(url.searchParams.get('juan'), 1);
+  const selectedWorks = works.slice(0, limit);
+  const items = [];
+  const errors = [];
+
+  for (const work of selectedWorks) {
+    try {
+      const { data, attempts } = await fetchJsonWithRetry('juans', {
+        work,
+        juan,
+        work_info: 1,
+        toc: 1,
+      });
+      items.push(toCbetaItem(work, juan, data, attempts));
+    } catch (error) {
+      errors.push(normalizeError(work, juan, error));
+    }
+  }
+
+  const payload = {
+    success: items.length > 0,
+    source: 'CBETA',
+    api: CBETA_API_ROOT,
+    requested: selectedWorks.length,
+    count: items.length,
+    items,
+    errors,
+  };
+
+  return jsonResponse(payload, items.length > 0 ? 200 : 502);
+}
+
+export async function handleProxyCbetaRequest(request) {
+  const sourceUrl = new URL(request.url);
+  const cbetaPath = sourceUrl.pathname.replace(/^\/api\/cbeta\/?/, '');
+  const targetUrl = buildCbetaUrl(cbetaPath || '/', Object.fromEntries(sourceUrl.searchParams));
+  const response = await fetch(targetUrl.toString(), {
+    method: request.method,
+    headers: {
+      Accept: request.headers.get('Accept') || 'application/json',
+    },
+  });
+
+  const headers = new Headers(CORS_HEADERS);
+  const contentType = response.headers.get('Content-Type');
+  if (contentType) headers.set('Content-Type', contentType);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -11,6 +11,7 @@ import { handleMigrateKvToD1 } from './handlers/migration.js';
 import { handleCheckAdminStatus, handleListRedeemCodes, handleDeleteRedeemCode, handleGetAdminPrice } from './handlers/admin.js';
 import { handleGetAssetsList, handleR2List, handleR2Proxy } from './handlers/assets.js';
 import { handleSearch, handleGetTextContent, handleGetCategories } from './handlers/search.js';
+import { handleGetCbetaSendTexts, handleProxyCbetaRequest } from './handlers/cbeta.js';
 import { handleGetLeaderboard, handleGetLeaderboardRecords, handleGetPracticeLeaderboard, handleUpdateTransferData } from './handlers/leaderboard.js';
 import { handleToggleLike, handleGetLikeCount, handleBatchGetLikeCounts, handleGetMyLikes, handleGetReceivedLikeCount } from './handlers/likes.js';
 import { handleToggleFavorite, handleGetMyFavorites, handleBatchCheckFavorites } from './handlers/favorites.js';
@@ -167,6 +168,8 @@ export async function route(request, env, db, ctx) {
   if (pathname === '/api/search' && method === 'GET') return await handleSearch(request, env, db);
   if (pathname === '/api/search/content' && method === 'GET') return await handleGetTextContent(request, env, db);
   if (pathname === '/api/search/categories' && method === 'GET') return await handleGetCategories(request, env, db);
+  if (pathname === '/api/cbeta/send-texts' && method === 'GET') return await handleGetCbetaSendTexts(request, env);
+  if (pathname.startsWith('/api/cbeta/') && (method === 'GET' || method === 'HEAD')) return await handleProxyCbetaRequest(request, env);
 
   if (pathname === '/api/leaderboard' && method === 'GET') return await handleGetLeaderboard(request, env, db);
   if (pathname === '/api/leaderboard/practice' && method === 'GET') return await handleGetPracticeLeaderboard(request, env, db);

--- a/fabushi/web/tests/cbeta-send-texts.test.js
+++ b/fabushi/web/tests/cbeta-send-texts.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { handleGetCbetaSendTexts } from '../src/handlers/cbeta.js';
+
+const sampleHtml = `
+  <html><head><title>般若波羅蜜多心經</title></head><body>
+    <div id="body">
+      <span class="lb">T08n0251_p0848c06</span>
+      <p class="juan"><span class="t">般若波羅蜜多心經</span></p>
+      <p><span class="lineInfo"></span><span class="t">觀自在菩薩行深般若波羅蜜多時</span></p>
+      <p><span class="t">照見五蘊皆空，度一切苦厄。</span></p>
+    </div>
+    <div id="back"><div class="footnote">footnote</div></div>
+    <div id="cbeta-copyright"><p>copyright</p></div>
+  </body></html>
+`;
+
+function installFetchMock(handler) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = handler;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+test('CBETA send texts returns real stripped scripture content and detailed partial errors', async () => {
+  let failAttempts = 0;
+  const restoreFetch = installFetchMock(async url => {
+    const parsed = new URL(url);
+    const work = parsed.searchParams.get('work');
+    if (work === 'T0251') {
+      return new Response(JSON.stringify({
+        results: [sampleHtml],
+        work_info: {
+          work: 'T0251',
+          title: '般若波羅蜜多心經',
+          byline: '唐 玄奘譯',
+          category: '般若部類',
+        },
+      }), { status: 200 });
+    }
+
+    failAttempts++;
+    return new Response('upstream unavailable', {
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+  });
+
+  try {
+    const response = await handleGetCbetaSendTexts(
+      new Request('https://api.ombhrum.com/api/cbeta/send-texts?works=T0251,T9999&limit=2'),
+    );
+    assert.equal(response.status, 200);
+
+    const body = await response.json();
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.errors.length, 1);
+    assert.equal(body.errors[0].attempts.length, 3);
+    assert.equal(failAttempts, 3);
+
+    const item = body.items[0];
+    assert.equal(item.work, 'T0251');
+    assert.match(item.fileName, /^T0251_1_/);
+    assert.match(item.content, /觀自在菩薩/);
+    assert.doesNotMatch(item.content, /T08n0251/);
+    assert.doesNotMatch(item.content, /copyright/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test('CBETA send texts reports full upstream errors when no scripture can be fetched', async () => {
+  const restoreFetch = installFetchMock(async url => {
+    return new Response(JSON.stringify({ message: 'bad gateway', url }), {
+      status: 502,
+      statusText: 'Bad Gateway',
+    });
+  });
+
+  try {
+    const response = await handleGetCbetaSendTexts(
+      new Request('https://api.ombhrum.com/api/cbeta/send-texts?works=T0251&limit=1'),
+    );
+    assert.equal(response.status, 502);
+
+    const body = await response.json();
+    assert.equal(body.success, false);
+    assert.equal(body.count, 0);
+    assert.equal(body.errors.length, 1);
+    assert.match(body.errors[0].message, /failed after 3 attempts/);
+    assert.equal(body.errors[0].attempts[0].status, 502);
+    assert.match(body.errors[0].attempts[0].body, /bad gateway/);
+  } finally {
+    restoreFetch();
+  }
+});


### PR DESCRIPTION
## Summary
- add backend CBETA proxy/send-texts endpoint using the same api.cbetaonline.cn source as the official 法流 site
- download real CBETA scripture text for homepage sending instead of placeholder asset paths
- show scripture title, country, IP, retry count, and full UDP/CBETA error details; normalize IP country China to 中国

## Tests
- node --test web/tests/cbeta-send-texts.test.js web/tests/router-meditation-auth.test.js
- live route smoke: /api/cbeta/send-texts?limit=12 returned 12 scriptures from CBETA
- flutter build apk --debug

Note: flutter analyze still exits non-zero on existing project warnings/errors unrelated to this change, including missing Drift imports under lib/database and historical lint warnings.