### PR TITLE
Fix Android online counter polling

### DIFF
--- a/fabushi/lib/services/online_counter_service.dart
+++ b/fabushi/lib/services/online_counter_service.dart
@@ -257,6 +257,12 @@ class OnlineCounterService {
 
   /// 获取指定活动类型的在线人数（不加入活动）
   Future<void> fetchCountForActivity(String activityType) async {
+    if (_isConnected &&
+        _channel != null &&
+        _currentActivity == activityType) {
+      return;
+    }
+
     if (_isCountFetchInFlight) return;
     _isCountFetchInFlight = true;
     try {

--- a/fabushi/web/src/durable-objects/OnlineCounter.js
+++ b/fabushi/web/src/durable-objects/OnlineCounter.js
@@ -231,6 +231,7 @@ export class OnlineCounter {
         await this.ensureAlarm();
 
         console.log(`Session ${sessionId} joined via HTTP. Total: ${this.sessions.size}`);
+        this.broadcastCount();
 
         return this.jsonResponse({
             success: true,
@@ -278,6 +279,7 @@ export class OnlineCounter {
         const existed = this.sessions.delete(sessionId);
 
         console.log(`Session ${sessionId} left via HTTP. Total: ${this.sessions.size}`);
+        this.broadcastCount();
 
         return this.jsonResponse({
             success: true,

--- a/fabushi/web/tests/online-counter.test.js
+++ b/fabushi/web/tests/online-counter.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { OnlineCounter } from '../src/durable-objects/OnlineCounter.js';
+
+function createCounter() {
+  const storage = {
+    alarm: null,
+    async getAlarm() {
+      return this.alarm;
+    },
+    async setAlarm(value) {
+      this.alarm = value;
+    },
+  };
+
+  return new OnlineCounter({ storage }, {});
+}
+
+function jsonRequest(body) {
+  return new Request('https://example.com/api/online', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+test('HTTP online joins and leaves broadcast counts to WebSocket clients', async () => {
+  const counter = createCounter();
+  const sentMessages = [];
+  const ws = {
+    send(message) {
+      sentMessages.push(JSON.parse(message));
+    },
+  };
+
+  counter.sessions.set('ws-session', {
+    lastHeartbeat: Date.now(),
+    ws,
+  });
+  counter.webSockets.set(ws, 'ws-session');
+
+  const joinResponse = await counter.handleJoin(
+    jsonRequest({ sessionId: 'http-session' }),
+  );
+  const joinPayload = await joinResponse.json();
+
+  assert.equal(joinResponse.status, 200);
+  assert.equal(joinPayload.count, 2);
+  assert.equal(sentMessages[0].type, 'count_update');
+  assert.equal(sentMessages[0].count, 2);
+
+  const leaveResponse = await counter.handleLeave(
+    jsonRequest({ sessionId: 'http-session' }),
+  );
+  const leavePayload = await leaveResponse.json();
+
+  assert.equal(leaveResponse.status, 200);
+  assert.equal(leavePayload.count, 1);
+  assert.equal(sentMessages[1].type, 'count_update');
+  assert.equal(sentMessages[1].count, 1);
+});


### PR DESCRIPTION
## Summary
- prevent HTTP count polling from overwriting an active WebSocket online count on Android/iOS
- broadcast Durable Object count updates when HTTP fallback clients join or leave
- add a Node test for HTTP fallback broadcasts

## Tests
- node --test web\\tests\\alipay-user-id.test.js web\\tests\\online-counter.test.js
- flutter analyze --no-fatal-infos lib\\services\\online_counter_service.dart lib\\screens\\alipay_web_login_screen.dart
- git diff --check -- lib\\services\\online_counter_service.dart web\\src\\durable-objects\\OnlineCounter.js web\\tests\\online-counter.test.js