### PR TITLE
Show scripture send preparation status

### DIFF
--- a/fabushi/lib/models/file_transfer_model.dart
+++ b/fabushi/lib/models/file_transfer_model.dart
@@ -47,6 +47,8 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   // 传输状态
   bool _isTransferring = false;
+  bool _isPreparingSend = false;
+  String _preparingSendMessage = '';
   TransferStatus _status = TransferStatus.idle;
 
   // 统计数据
@@ -58,6 +60,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   PlatformGlobalSendService? _platformGlobalSendService;
   List<CountrySendStatus> _countryStatuses = [];
   String _currentLog = '';
+  String _currentSendingScripture = '';
 
   final SharedAssetManager _sharedAssetManager = SharedAssetManager();
   final IPLocationService _ipLocationService = IPLocationService();
@@ -146,12 +149,15 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   List<PlatformFile> get selectedFiles => _selectedFiles;
   List<String> get countryList => _countryList;
   bool get isTransferring => _isTransferring;
+  bool get isPreparingSend => _isPreparingSend;
+  String get preparingSendMessage => _preparingSendMessage;
   TransferStatus get status => _status;
   bool get hasFiles => _selectedFiles.isNotEmpty;
   int get globalSentCount => _globalSentCount;
   double get globalDataSentMB => _globalDataSentMB;
   List<CountrySendStatus> get countryStatuses => _countryStatuses;
   String get currentLog => _currentLog;
+  String get currentSendingScripture => _currentSendingScripture;
 
   /// 性能优化：批量通知更新（防抖）
   void _scheduleNotify() {
@@ -259,6 +265,19 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     notifyListeners();
   }
 
+  void beginPreparingSend(String message) {
+    if (_isDisposed) return;
+    _isPreparingSend = true;
+    _preparingSendMessage = message;
+    _currentLog = message;
+    notifyListeners();
+  }
+
+  void _finishPreparingSend() {
+    _isPreparingSend = false;
+    _preparingSendMessage = '';
+  }
+
   Future<void> selectFiles() async {
     try {
       // 内存优化：不使用 withData: true，避免大文件加载到内存
@@ -307,7 +326,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   Future<int> prepareDefaultNonR2AssetsForSending() async {
-    updateLog('📚 正在从 CBETA API 下载首页默认经文...');
+    beginPreparingSend('📚 正在下载默认经文，下载完成后会自动开始发送...');
 
     try {
       final result = await _cbetaSendTextService.fetchDefaultSendTexts();
@@ -331,10 +350,14 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       }).toList();
 
       _isLooping = true;
+      _currentSendingScripture = result.items.isNotEmpty
+          ? result.items.first.title
+          : '';
       final titles = result.items.map((item) => '《${item.title}》').join('、');
       final warning = result.errors.isEmpty
           ? ''
           : '；部分经文下载失败: ${jsonEncode(result.errors)}';
+      _preparingSendMessage = '📚 已下载 ${_selectedFiles.length} 部经文，正在启动发送...';
       updateLog(
         '📚 已从 CBETA 下载 ${_selectedFiles.length} 部经文，准备发送 $titles$warning',
       );
@@ -343,6 +366,8 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       return _selectedFiles.length;
     } catch (error) {
       _selectedFiles = [];
+      _currentSendingScripture = '';
+      _finishPreparingSend();
       updateLog('❌ CBETA 经文下载失败: $error');
       debugPrint('❌ CBETA 经文下载失败: $error');
       notifyListeners();
@@ -619,9 +644,19 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   Future<void> startGlobalTransfer({bool isLoopContinuation = false}) async {
     // 如果不是循环继续，检查是否已在传输中
     if (!isLoopContinuation && _isTransferring) return;
-    if (_selectedFiles.isEmpty) return;
+    if (_selectedFiles.isEmpty) {
+      _finishPreparingSend();
+      _scheduleNotify();
+      return;
+    }
 
     _isTransferring = true;
+    _finishPreparingSend();
+    if (_currentSendingScripture.isEmpty && _selectedFiles.isNotEmpty) {
+      _currentSendingScripture = _displayScriptureName(
+        _selectedFiles.first.name,
+      );
+    }
     _status = TransferStatus.transferring;
 
     // 初始化或增加循环计数
@@ -676,10 +711,13 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       await _stopBackgroundService();
       _isTransferring = false;
       _status = TransferStatus.completed;
+      _currentSendingScripture = '';
     } catch (e) {
       debugPrint('❌ 传输失败: $e');
       _status = TransferStatus.error;
       _isTransferring = false;
+      _finishPreparingSend();
+      _currentSendingScripture = '';
       _stopFieldEnergyBroadcast();
       await _stopBackgroundService();
       _schedulePersist(_persistTransferState);
@@ -773,6 +811,9 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
               sentCount: _globalSentCount,
               totalCount: _totalCountriesCount,
               currentCountry: currentCountry,
+              audioName: _currentSendingScripture.isNotEmpty
+                  ? _currentSendingScripture
+                  : null,
               loopCount: _loopCount,
               isLoopbackActive: true,
               loopbackCount: _loopbackCount,
@@ -811,10 +852,12 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   void stopTransfer() {
-    if (!_isTransferring) return;
+    if (!_isTransferring && !_isPreparingSend) return;
 
     _isTransferring = false;
+    _finishPreparingSend();
     _status = TransferStatus.idle;
+    _currentSendingScripture = '';
 
     _platformGlobalSendService?.stopSending();
 
@@ -839,7 +882,9 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   void _onTransferCompleted() {
     _isTransferring = false;
+    _finishPreparingSend();
     _status = TransferStatus.completed;
+    _currentSendingScripture = '';
     _schedulePersist(_persistTransferState);
     _scheduleNotify();
   }
@@ -848,7 +893,9 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   Future<void> _startBackgroundService() async {
     try {
       final fileName = _selectedFiles.isNotEmpty
-          ? _selectedFiles.first.name
+          ? (_currentSendingScripture.isNotEmpty
+                ? _currentSendingScripture
+                : _displayScriptureName(_selectedFiles.first.name))
           : '未知文件';
 
       // 1. 启动 KeepAliveService (audio_service)
@@ -885,6 +932,9 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       sentCount: sent,
       totalCount: total,
       currentCountry: country,
+      audioName: _currentSendingScripture.isNotEmpty
+          ? _currentSendingScripture
+          : null,
       loopCount: _loopCount,
       isLoopbackActive: _localLoopbackService?.isRunning ?? false,
       loopbackCount: _loopbackCount,
@@ -1169,11 +1219,32 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   void updateLog(String log) {
     _currentLog = log;
+    _updateCurrentSendingScriptureFromLog(log);
     // 关键修复：日志更新不需要频繁持久化，只在重要日志时持久化
     if (log.contains('成功') || log.contains('失败') || log.contains('完成')) {
       _schedulePersist(_persistTransferState);
     }
     _scheduleNotify();
+  }
+
+  void _updateCurrentSendingScriptureFromLog(String log) {
+    final match = RegExp(
+      r'(?:正在发送到|准备发送|UDP 发送到|发送到)[^《]*《([^》]+)》',
+    ).firstMatch(log);
+    final scripture = match?.group(1)?.trim();
+    if (scripture != null && scripture.isNotEmpty) {
+      _currentSendingScripture = scripture;
+    }
+  }
+
+  String _displayScriptureName(String fileName) {
+    final withoutExtension = fileName.replaceFirst(RegExp(r'\.[^.]+$'), '');
+    final withoutCbetaPrefix = withoutExtension.replaceFirst(
+      RegExp(r'^[A-Z][A-Z0-9]?\d{4}[A-Z]?_\d+_'),
+      '',
+    );
+    final normalized = withoutCbetaPrefix.replaceAll('_', ' ').trim();
+    return normalized.isEmpty ? withoutExtension : normalized;
   }
 
   int getSuccessCount() {

--- a/fabushi/lib/screens/global_dharma_screen.dart
+++ b/fabushi/lib/screens/global_dharma_screen.dart
@@ -101,9 +101,21 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
             ),
             tooltip: '搜索经文',
           ),
-          Selector<FileTransferModel, bool>(
-            selector: (_, m) => m.isTransferring,
-            builder: (_, isTransferring, __) => isTransferring
+          Consumer<FileTransferModel>(
+            builder: (context, model, child) => model.isPreparingSend
+                ? IconButton(
+                    icon: const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    ),
+                    onPressed: null,
+                    tooltip: '正在下载经文',
+                  )
+                : model.isTransferring
                 ? IconButton(
                     icon: const Icon(Icons.stop),
                     onPressed: _stopGlobalDharma,
@@ -128,7 +140,7 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
               m.globalDataSentMB,
               m.isLooping,
             ],
-            builder: (_, data, __) => _buildStatsCard(
+            builder: (context, data, child) => _buildStatsCard(
               data[0] as int,
               data[1] as int,
               data[2] as int,
@@ -140,7 +152,7 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
           // 当前日志
           Selector<FileTransferModel, String>(
             selector: (_, m) => m.currentLog,
-            builder: (_, log, __) => log.isNotEmpty
+            builder: (context, log, child) => log.isNotEmpty
                 ? Container(
                     padding: const EdgeInsets.all(16),
                     color: Colors.grey[100],
@@ -162,17 +174,62 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
                 : const SizedBox.shrink(),
           ),
 
+          Selector<FileTransferModel, String>(
+            selector: (_, m) => m.currentSendingScripture,
+            builder: (context, scripture, child) => scripture.isNotEmpty
+                ? Container(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                    alignment: Alignment.centerLeft,
+                    child: Row(
+                      children: [
+                        const Icon(Icons.menu_book, color: Color(0xFF667eea)),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            '当前经文：《$scripture》',
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+
           // 国家列表
           Expanded(child: _buildCountryList()),
         ],
       ),
-      floatingActionButton: Selector<FileTransferModel, bool>(
-        selector: (_, m) => m.isTransferring,
-        builder: (_, isTransferring, __) => FloatingActionButton.extended(
-          onPressed: isTransferring ? _stopGlobalDharma : _startGlobalDharma,
-          icon: Icon(isTransferring ? Icons.stop : Icons.play_arrow),
-          label: Text(isTransferring ? '停止发送' : '开始法布施'),
-          backgroundColor: isTransferring
+      floatingActionButton: Consumer<FileTransferModel>(
+        builder: (context, model, child) => FloatingActionButton.extended(
+          onPressed: model.isPreparingSend
+              ? null
+              : model.isTransferring
+              ? _stopGlobalDharma
+              : _startGlobalDharma,
+          icon: model.isPreparingSend
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : Icon(model.isTransferring ? Icons.stop : Icons.play_arrow),
+          label: Text(
+            model.isPreparingSend
+                ? '下载经文中'
+                : model.isTransferring
+                ? '停止发送'
+                : '开始法布施',
+          ),
+          backgroundColor: model.isTransferring
               ? Colors.red
               : const Color(0xFF667eea),
           foregroundColor: Colors.white,
@@ -259,7 +316,7 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
 
   Widget _buildCountryList() {
     return Consumer<FileTransferModel>(
-      builder: (_, model, __) {
+      builder: (context, model, child) {
         final statuses = model.countryStatuses;
         return Column(
           children: [

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -332,6 +332,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
               if (!model.isTransferring || _currentSendingCountry.isEmpty) {
                 return const SizedBox.shrink();
               }
+              final scripture = model.currentSendingScripture;
               return Positioned(
                 top: 70,
                 left: 20,
@@ -358,12 +359,33 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                           ),
                         ),
                         const SizedBox(width: 10),
-                        Text(
-                          '正在发送到 $_currentSendingCountry',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
+                        Flexible(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                scripture.isEmpty
+                                    ? '正在发送经文'
+                                    : '正在发送《$scripture》',
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              Text(
+                                '目标: $_currentSendingCountry',
+                                style: TextStyle(
+                                  color: Colors.white.withOpacity(0.78),
+                                  fontSize: 12,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
                           ),
                         ),
                       ],
@@ -396,7 +418,44 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
               mainAxisSize: MainAxisSize.min,
               children: [
                 // 发送进度显示（发送中时显示在顶部）
-                if (model.isTransferring) ...[
+                if (model.isPreparingSend) ...[
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.amber.withOpacity(0.16),
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: Colors.amber.withOpacity(0.35)),
+                    ),
+                    child: Row(
+                      children: [
+                        const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.amber,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Text(
+                            model.preparingSendMessage.isEmpty
+                                ? '正在准备发送...'
+                                : model.preparingSendMessage,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w500,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                ] else if (model.isTransferring) ...[
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
@@ -408,6 +467,30 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     ),
                     child: Column(
                       children: [
+                        Row(
+                          children: [
+                            const Icon(
+                              Icons.menu_book,
+                              color: Colors.white,
+                              size: 16,
+                            ),
+                            const SizedBox(width: 6),
+                            Expanded(
+                              child: Text(
+                                model.currentSendingScripture.isEmpty
+                                    ? '正在发送经文'
+                                    : '正在发送：《${model.currentSendingScripture}》',
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
                         // 动态杨升激活次数显示
                         if (model.loopbackCount > 0) ...[
                           const SizedBox(height: 8),
@@ -650,7 +733,27 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   children: [
                     // 开始/停止按钮
                     Expanded(
-                      child: model.isTransferring
+                      child: model.isPreparingSend
+                          ? ElevatedButton.icon(
+                              onPressed: null,
+                              icon: const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              ),
+                              label: const Text(
+                                '下载经文中',
+                                style: TextStyle(fontSize: 13),
+                              ),
+                              style: ElevatedButton.styleFrom(
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 10,
+                                ),
+                              ),
+                            )
+                          : model.isTransferring
                           ? ElevatedButton.icon(
                               onPressed: () => _stopSending(model),
                               icon: const Icon(Icons.stop, size: 18),
@@ -829,6 +932,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   }
 
   void _startSending(FileTransferModel model) async {
+    if (model.isPreparingSend || model.isTransferring) return;
+    model.beginPreparingSend('正在准备发送...');
+
     // Android 平台：首次使用时显示自启动设置引导
     if (Platform.isAndroid && mounted) {
       try {

--- a/fabushi/lib/services/keep_alive_service.dart
+++ b/fabushi/lib/services/keep_alive_service.dart
@@ -237,7 +237,7 @@ class KeepAliveAudioHandler extends BaseAudioHandler with SeekHandler {
     mediaItem.add(
       MediaItem(
         id: 'keep_alive_dharani',
-        title: '大乘',
+        title: _mediaTitle(),
         artist: _audioName,
         album: '后台保活中',
         duration: Duration.zero,
@@ -381,12 +381,16 @@ class KeepAliveAudioHandler extends BaseAudioHandler with SeekHandler {
     mediaItem.add(
       MediaItem(
         id: 'keep_alive_dharani',
-        title: '大乘',
+        title: _mediaTitle(),
         artist: subtitle,
-        album: _audioName,
+        album: '大乘',
         duration: _audioPlayer.duration ?? Duration.zero,
       ),
     );
+  }
+
+  String _mediaTitle() {
+    return _audioName.isEmpty ? '大乘' : '正在发送《$_audioName》';
   }
 
   /// 更新发送进度
@@ -394,6 +398,7 @@ class KeepAliveAudioHandler extends BaseAudioHandler with SeekHandler {
     required int sentCount,
     required int totalCount,
     required String currentCountry,
+    String? audioName,
     int? loopCount,
     bool isLoopbackActive = false,
     int loopbackCount = 0,
@@ -401,6 +406,9 @@ class KeepAliveAudioHandler extends BaseAudioHandler with SeekHandler {
     _sentCount = sentCount;
     _totalCount = totalCount;
     _currentCountry = currentCountry;
+    if (audioName != null && audioName.isNotEmpty) {
+      _audioName = audioName;
+    }
     if (loopCount != null) {
       _loopCount = loopCount;
     }
@@ -838,8 +846,10 @@ class KeepAliveService {
     // 降级模式：显示备用通知
     if (_isDegradedMode) {
       await _showFallbackNotification(
-        title: '大乘',
-        body: '${audioName ?? "准备中"} · 发送到 $totalCountries 个国家',
+        title: audioName == null || audioName.isEmpty
+            ? '大乘'
+            : '正在发送《$audioName》',
+        body: '发送到 $totalCountries 个国家',
       );
       debugPrint('📢 已显示备用通知（降级模式）');
     }
@@ -860,6 +870,7 @@ class KeepAliveService {
     required int sentCount,
     required int totalCount,
     required String currentCountry,
+    String? audioName,
     int? loopCount,
     bool isLoopbackActive = false,
     int loopbackCount = 0,
@@ -868,6 +879,7 @@ class KeepAliveService {
       sentCount: sentCount,
       totalCount: totalCount,
       currentCountry: currentCountry,
+      audioName: audioName,
       loopCount: loopCount,
       isLoopbackActive: isLoopbackActive,
       loopbackCount: loopbackCount,
@@ -883,7 +895,12 @@ class KeepAliveService {
         subtitle += ' | 🟢 杨升: $loopbackCount次';
       }
 
-      _showFallbackNotification(title: '大乘', body: subtitle);
+      _showFallbackNotification(
+        title: audioName == null || audioName.isEmpty
+            ? '大乘'
+            : '正在发送《$audioName》',
+        body: subtitle,
+      );
     }
   }
 

--- a/fabushi/lib/services/real_global_send_service.dart
+++ b/fabushi/lib/services/real_global_send_service.dart
@@ -146,7 +146,8 @@ class RealGlobalSendService {
   }
 
   Future<int> _sendFileToAllCountries(PlatformFile file) async {
-    onLog('📤 发送文件到全球: ${file.name}');
+    final scriptureTitle = _displayScriptureName(file.name);
+    onLog('📤 准备发送《$scriptureTitle》: ${file.name}');
 
     final countryCodes = globalCountryServers.keys.toList();
     int successCount = 0;
@@ -159,7 +160,9 @@ class RealGlobalSendService {
       final countryName = _getCountryName(countryCode);
       final servers = globalCountryServers[countryCode]!;
 
-      onLog('🌍 发送到 $countryName ($countryCode) - 使用 ${servers.length} 个服务器');
+      onLog(
+        '📤 正在发送到 $countryName ($countryCode)：《$scriptureTitle》 - 使用 ${servers.length} 个服务器',
+      );
 
       // 性能优化：在触发轨迹动画前让出主线程
       await Future.delayed(Duration.zero);
@@ -220,7 +223,13 @@ class RealGlobalSendService {
       bool countrySuccess = false;
       for (final serverUrl in servers) {
         try {
-          await _sendToServer(file, serverUrl, countryCode, countryName);
+          await _sendToServer(
+            file,
+            serverUrl,
+            countryCode,
+            countryName,
+            scriptureTitle,
+          );
           successCount++;
           countrySuccess = true;
 
@@ -246,7 +255,7 @@ class RealGlobalSendService {
         onProgress(_sentCount); // 实时通知进度更新
       } else {
         failCount++;
-        onLog('❌ $countryName ($countryCode) 所有服务器发送失败');
+        onLog('❌ 发送到 $countryName ($countryCode) 失败：《$scriptureTitle》');
       }
 
       _currentCountryIndex++;
@@ -260,7 +269,7 @@ class RealGlobalSendService {
       }
     }
 
-    onLog('✅ 文件 ${file.name} 发送完成 - 成功: $successCount, 失败: $failCount');
+    onLog('✅ 文件《$scriptureTitle》发送完成 - 成功: $successCount, 失败: $failCount');
     return successCount; // 返回成功发送的国家数
   }
 
@@ -274,6 +283,7 @@ class RealGlobalSendService {
     String serverUrl,
     String countryCode,
     String countryName,
+    String scriptureTitle,
   ) async {
     try {
       // 关键修复：在网络请求前让出主线程控制权
@@ -299,10 +309,22 @@ class RealGlobalSendService {
         await _sendSmallFile(requestData, serverUrl, countryCode, countryName);
       }
 
-      onLog('✅ 成功发送到 $countryName ($countryCode) - $serverUrl');
+      onLog(
+        '✅ 发送到 $countryName ($countryCode) 成功：《$scriptureTitle》 - $serverUrl',
+      );
     } catch (e) {
       throw Exception('发送失败: $e');
     }
+  }
+
+  String _displayScriptureName(String fileName) {
+    final withoutExtension = fileName.replaceFirst(RegExp(r'\.[^.]+$'), '');
+    final withoutCbetaPrefix = withoutExtension.replaceFirst(
+      RegExp(r'^[A-Z][A-Z0-9]?\d{4}[A-Z]?_\d+_'),
+      '',
+    );
+    final normalized = withoutCbetaPrefix.replaceAll('_', ' ').trim();
+    return normalized.isEmpty ? withoutExtension : normalized;
   }
 
   /// 流式发送大文件（分块读取，分块上传）


### PR DESCRIPTION
## Summary
- show an immediate preparing/downloading state after tapping start send
- surface the current scripture name in the home send overlay, control panel, global dharma screen, and keep-alive notification
- include scripture names in HTTP send logs so UI state updates across send modes

## Verification
- dart format fabushi/lib/models/file_transfer_model.dart fabushi/lib/screens/globe_home_screen.dart fabushi/lib/screens/global_dharma_screen.dart fabushi/lib/services/real_global_send_service.dart fabushi/lib/services/keep_alive_service.dart
- dart analyze lib/models/file_transfer_model.dart lib/screens/globe_home_screen.dart lib/screens/global_dharma_screen.dart lib/services/real_global_send_service.dart lib/services/keep_alive_service.dart (no errors; existing warnings/info remain)