### PR TITLE
Use backend Alipay OAuth callback

### DIFF
--- a/fabushi/web/alipay-login-functions.js
+++ b/fabushi/web/alipay-login-functions.js
@@ -4,6 +4,37 @@ import { generateToken, verifyToken, jsonResponse, verifyPassword, createPasswor
 import { importPrivateKey, importPublicKey, generateSign, verifySign } from './alipay-utils.js';
 import { calculateTrialEndDate } from './stripe-config.js';
 
+const DEFAULT_WORKER_URL = 'https://api.ombhrum.com';
+
+function trimTrailingSlash(value) {
+  return String(value || '').replace(/\/+$/, '');
+}
+
+function buildUrl(baseUrl, path) {
+  return `${trimTrailingSlash(baseUrl)}${path}`;
+}
+
+function getWorkerUrl(env) {
+  return trimTrailingSlash(env.WORKER_URL || DEFAULT_WORKER_URL);
+}
+
+function getAlipayOAuthRedirectUrl(env, callbackType) {
+  if (callbackType === 'mobile') {
+    return env.ALIPAY_MOBILE_AUTH_REDIRECT_URL ||
+      env.ALIPAY_AUTH_REDIRECT_URL ||
+      buildUrl(getWorkerUrl(env), '/api/auth/alipay/callback');
+  }
+
+  if (callbackType === 'macos') {
+    return env.ALIPAY_MACOS_AUTH_REDIRECT_URL ||
+      buildUrl(getWorkerUrl(env), '/api/auth/alipay/macos-callback');
+  }
+
+  return env.ALIPAY_WEB_AUTH_REDIRECT_URL ||
+    env.ALIPAY_AUTH_REDIRECT_URL ||
+    buildUrl(getWorkerUrl(env), '/api/auth/alipay/callback');
+}
+
 // 生成支付宝登录URL
 async function generateAlipayLoginUrl(env, platform) {
   try {
@@ -48,29 +79,12 @@ async function generateAlipayLoginUrl(env, platform) {
       return jsonResponse({ error: '支付宝应用ID未配置' }, 500);
     }
 
-    const workerUrl = env.WORKER_URL || 'https://your-worker-url.workers.dev';
+    const workerUrl = getWorkerUrl(env);
     console.log('使用worker URL:', workerUrl);
 
-    // 根据平台类型选择不同的回调地址
-    let redirectUri;
-    if (isMacOSApp) {
-      // macOS应用使用专用的回调地址
-      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/macos-callback`);
-      console.log('macOS应用专用回调地址:', redirectUri);
-    } else if (isMobileApp) {
-      // 支付宝开放平台白名单按 redirect_uri 校验。移动端网页登录也先使用标准
-      // OAuth 回调，再由 state.type=mobile 分流到 App Scheme。
-      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
-      console.log('移动端应用使用标准OAuth回调地址:', redirectUri);
-    } else {
-      // Web应用使用标准回调地址
-      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
-      console.log('Web应用标准回调地址:', redirectUri);
-    }
-
-    if (!redirectUri) {
-      redirectUri = encodeURIComponent(`${workerUrl}/api/auth/alipay/callback`);
-    }
+    const alipayRedirectUrl = getAlipayOAuthRedirectUrl(env, callbackType);
+    const redirectUri = encodeURIComponent(alipayRedirectUrl);
+    console.log('OAuth redirect_uri:', alipayRedirectUrl);
 
     const authUrl = `https://openauth.alipay.com/oauth2/publicAppAuthorize.htm?app_id=${appId}&scope=auth_user&redirect_uri=${redirectUri}&state=${state}`;
 

--- a/fabushi/web/frontend-worker.js
+++ b/fabushi/web/frontend-worker.js
@@ -2,6 +2,18 @@
 // API traffic belongs on https://api.ombhrum.com and is intentionally not
 // handled here.
 
+const PRIVATE_ASSET_PATTERNS = [
+  /^\/(?:src|tests|migrations|dist)\//,
+  /^\/(?:agent|docs)\//,
+  /^\/\.(?:wranglerignore|last_build_id)$/i,
+  /^\/(?:package(?:-lock)?\.json|wrangler(?:-web)?\.toml)$/i,
+  /^\/(?:schema(?:[_-].*)?\.sql|migration.*\.sql)$/i,
+  /^\/(?:worker|frontend-worker|migrate|retry|deploy|find-and-retry).*\.js$/i,
+  /^\/(?:retry|deploy|migrate).*\.(?:sh|bash)$/i,
+  /^\/(?:auth-utils|alipay-config|alipay-login-functions|alipay-utils|assets-json)\.js$/i,
+  /^\/.*\.md$/i,
+];
+
 const FRONTEND_ONLY_API_RESPONSE = {
   success: false,
   error: 'Frontend worker only',
@@ -31,6 +43,15 @@ export default {
     const url = new URL(request.url);
     const pathname = url.pathname;
 
+    if (isPrivateAssetPath(pathname)) {
+      return new Response('Not Found', {
+        status: 404,
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      });
+    }
+
     if (pathname.startsWith('/api/') || pathname === '/r2' || pathname === '/health') {
       return new Response(JSON.stringify(FRONTEND_ONLY_API_RESPONSE), {
         status: 404,
@@ -50,3 +71,7 @@ export default {
     return withFrontendHeaders(response, pathname);
   }
 };
+
+function isPrivateAssetPath(pathname) {
+  return PRIVATE_ASSET_PATTERNS.some((pattern) => pattern.test(pathname));
+}

--- a/fabushi/web/tests/alipay-user-id.test.js
+++ b/fabushi/web/tests/alipay-user-id.test.js
@@ -90,7 +90,7 @@ test('one-click Alipay registration stores user_id in mappings and token', async
   assert.equal(tokenPayload.username, payload.username);
 });
 
-test('mobile Alipay OAuth URL uses the standard whitelisted callback', async () => {
+test('mobile Alipay OAuth URL uses the backend callback directly', async () => {
   for (const platform of ['android', 'ios']) {
     const { env } = createDbEnv();
     env.ALIPAY_APP_ID = 'test-app-id';
@@ -107,6 +107,20 @@ test('mobile Alipay OAuth URL uses the standard whitelisted callback', async () 
       'https://api.ombhrum.com/api/auth/alipay/callback',
     );
   }
+});
+
+test('mobile Alipay OAuth URL honors explicit redirect override', async () => {
+  const { env } = createDbEnv();
+  env.ALIPAY_APP_ID = 'test-app-id';
+  env.WORKER_URL = 'https://api.ombhrum.com';
+  env.ALIPAY_MOBILE_AUTH_REDIRECT_URL = 'https://example.com/alipay-callback';
+
+  const response = await generateAlipayLoginUrl(env, 'android');
+  const payload = await response.json();
+  const authUrl = new URL(payload.authUrl);
+
+  assert.equal(response.status, 200);
+  assert.equal(authUrl.searchParams.get('redirect_uri'), 'https://example.com/alipay-callback');
 });
 
 test('manual Alipay registration stores user_id in mappings and token', async () => {

--- a/fabushi/web/tests/frontend-worker.test.js
+++ b/fabushi/web/tests/frontend-worker.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import worker from '../frontend-worker.js';
+
+const ASSETS = {
+  async fetch() {
+    return new Response('asset', { status: 200 });
+  },
+};
+
+test('frontend rejects API traffic instead of proxying it', async () => {
+  const response = await worker.fetch(
+    new Request('https://flutter.ombhrum.com/api/auth/login'),
+    { ASSETS },
+  );
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.equal(payload.error, 'Frontend worker only');
+});
+
+test('frontend does not expose bundled worker source assets', async () => {
+  for (const path of ['/wrangler.toml', '/src/router.js', '/tests/frontend-worker.test.js']) {
+    const response = await worker.fetch(
+      new Request(`https://flutter.ombhrum.com${path}`),
+      { ASSETS },
+    );
+
+    assert.equal(response.status, 404);
+  }
+});

--- a/fabushi/web/wrangler-web.toml
+++ b/fabushi/web/wrangler-web.toml
@@ -5,6 +5,7 @@ compatibility_date = "2024-08-01"
 [assets]
 binding = "ASSETS"
 directory = "../build/web"
+run_worker_first = true
 
 [env.production]
 name = "fabushi-web-prod"
@@ -16,6 +17,7 @@ workers_dev = false
 [env.production.assets]
 binding = "ASSETS"
 directory = "../build/web"
+run_worker_first = true
 
 [env.development]
 name = "fabushi-web-dev"
@@ -23,6 +25,7 @@ name = "fabushi-web-dev"
 [env.development.assets]
 binding = "ASSETS"
 directory = "../build/web"
+run_worker_first = true
 
 [observability.logs]
 enabled = true

--- a/fabushi/web/wrangler.toml
+++ b/fabushi/web/wrangler.toml
@@ -111,6 +111,7 @@ ALIPAY_APP_ID = "2021005193647715"
 ALIPAY_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAi0qnuA0SPHg/sB43ROGixTPaeCYN2kmsqCBUZ+gCaMivh405NBAX8LELBlBmrIvKhyUH9JNan+r0e2qrsmLSShIMD/M0YyB3+SqjITQXR0QSlneDKuHxl+O5qXe43qhuCaWXX3GVXwt5J+kOHPHCL+/3OThOjAYRwnCVewS85fx2hn6AtRPcyXHv+/nopckBL1ZbFrQRZC+BJuUlP3e9/NFWzWvUclAjaG2suVbz4YgmYh08fHlNNtb9/283/FKMRYbklpNKXTOwKQ7yflao0fTGPUdi9ILarLR8wPZTp8cv3ojIOU+e1toikcNNKK+Z+e24smY48QuB6MvJfV7skwIDAQAB"
 WORKER_URL = "https://api.ombhrum.com"
 FRONTEND_URL = "https://flutter.ombhrum.com"
+ALIPAY_MOBILE_AUTH_REDIRECT_URL = "https://api.ombhrum.com/api/auth/alipay/callback"
 ALIPAY_NOTIFY_URL = "https://api.ombhrum.com/api/alipay/notify"
 ALIPAY_RETURN_URL = "https://flutter.ombhrum.com/payment-success.html"
 
@@ -157,6 +158,7 @@ ALIPAY_APP_ID = "2021005193647715"
 ALIPAY_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAi0qnuA0SPHg/sB43ROGixTPaeCYN2kmsqCBUZ+gCaMivh405NBAX8LELBlBmrIvKhyUH9JNan+r0e2qrsmLSShIMD/M0YyB3+SqjITQXR0QSlneDKuHxl+O5qXe43qhuCaWXX3GVXwt5J+kOHPHCL+/3OThOjAYRwnCVewS85fx2hn6AtRPcyXHv+/nopckBL1ZbFrQRZC+BJuUlP3e9/NFWzWvUclAjaG2suVbz4YgmYh08fHlNNtb9/283/FKMRYbklpNKXTOwKQ7yflao0fTGPUdi9ILarLR8wPZTp8cv3ojIOU+e1toikcNNKK+Z+e24smY48QuB6MvJfV7skwIDAQAB"
 WORKER_URL = "https://fabushi-flutter-web-dev.bhrumom.workers.dev"
 FRONTEND_URL = "https://flutter.ombhrum.com"
+ALIPAY_MOBILE_AUTH_REDIRECT_URL = "https://fabushi-flutter-web-dev.bhrumom.workers.dev/api/auth/alipay/callback"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Summary
- route mobile Alipay OAuth directly to the API callback after whitelist update
- keep frontend Worker source/config assets private while rejecting API traffic
- update Alipay and frontend Worker tests

## Tests
- node --test fabushi\web\tests\alipay-user-id.test.js
- node --test fabushi\web\tests\frontend-worker.test.js

## Deployment
- API Worker deployed to production
- frontend Worker deployed to production