### PR TITLE
feat: self-host CBETA API on Cloudflare mirror

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: "1"
           NEXT_PUBLIC_SITE_ORIGIN: ${{ vars.OFFICIAL_SITE_ORIGIN || 'https://fabushi.ombhrum.com' }}
+          NEXT_PUBLIC_CBETA_API_ROOT: ${{ vars.CBETA_API_ROOT || 'https://fabushi.ombhrum.com/api/cbeta' }}
           NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_REPO: ${{ vars.OFFICIAL_SITE_RELEASE_REPO || github.repository }}
           NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL: ${{ vars.IOS_TESTFLIGHT_PUBLIC_URL || '' }}
         run: pnpm build:web
@@ -71,6 +72,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID || secrets.CF_ZONE_ID || vars.CLOUDFLARE_ZONE_ID || vars.CF_ZONE_ID }}
           OFFICIAL_SITE_R2_BUCKET: ${{ vars.OFFICIAL_SITE_R2_BUCKET || 'bushi' }}
+          CBETA_MIRROR_R2_BUCKET: ${{ vars.CBETA_MIRROR_R2_BUCKET || 'cbeta-api-mirror' }}
+          CBETA_UPSTREAM_BASE: ${{ vars.CBETA_UPSTREAM_BASE || 'https://api.cbetaonline.cn' }}
         run: |
           set -euo pipefail
           if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
@@ -79,10 +82,14 @@ jobs:
           fi
 
           official_site_r2_bucket="${OFFICIAL_SITE_R2_BUCKET:-bushi}"
-          cat > wrangler.official-site.toml <<EOF
+          cbeta_mirror_r2_bucket="${CBETA_MIRROR_R2_BUCKET:-cbeta-api-mirror}"
+          cat > wrangler.official-site.toml <<EOF2
           name = "fabushi-official-site"
           main = "official-site-worker.js"
-          compatibility_date = "2026-05-06"
+          compatibility_date = "2026-05-22"
+
+          [vars]
+          CBETA_UPSTREAM_BASE = "${CBETA_UPSTREAM_BASE}"
 
           [assets]
           directory = "apps/web/out"
@@ -90,7 +97,11 @@ jobs:
           [[r2_buckets]]
           binding = "OFFICIAL_SITE_R2"
           bucket_name = "${official_site_r2_bucket}"
-          EOF
+
+          [[r2_buckets]]
+          binding = "CBETA_MIRROR"
+          bucket_name = "${cbeta_mirror_r2_bucket}"
+          EOF2
 
           npx --yes wrangler@latest deploy --config wrangler.official-site.toml \
             --domain fabushi.ombhrum.com

--- a/.github/workflows/warm-cbeta-mirror.yml
+++ b/.github/workflows/warm-cbeta-mirror.yml
@@ -1,0 +1,106 @@
+name: Warm CBETA mirror
+
+on:
+  workflow_dispatch:
+    inputs:
+      work_limit:
+        description: Number of works to prewarm; 0 means all works
+        required: false
+        default: "0"
+      juan_limit:
+        description: Max juans per work to prewarm; 0 means all juans
+        required: false
+        default: "0"
+  schedule:
+    - cron: "20 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-cbeta-mirror
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Prewarm CBETA mirror through official site worker
+        env:
+          FABUSHI_CBETA_API_ROOT: ${{ vars.CBETA_API_ROOT || 'https://fabushi.ombhrum.com/api/cbeta' }}
+          WORK_LIMIT: ${{ github.event.inputs.work_limit || '0' }}
+          JUAN_LIMIT: ${{ github.event.inputs.juan_limit || '0' }}
+        run: |
+          node <<'EOF2'
+          const root = (process.env.FABUSHI_CBETA_API_ROOT || 'https://fabushi.ombhrum.com/api/cbeta').replace(/\/+$/g, '');
+          const workLimit = Number.parseInt(process.env.WORK_LIMIT || '0', 10) || 0;
+          const juanLimit = Number.parseInt(process.env.JUAN_LIMIT || '0', 10) || 0;
+          const concurrency = 6;
+          const retries = 3;
+
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          async function request(path, attempt = 1) {
+            const url = `${root}/${path.replace(/^\/+/, '')}`;
+            const response = await fetch(url, {
+              headers: {
+                Accept: 'application/json',
+                Referer: 'https://fabushi.ombhrum.com/',
+              },
+            });
+
+            if (!response.ok) {
+              const body = await response.text().catch(() => '');
+              if (attempt < retries) {
+                await sleep(400 * attempt);
+                return request(path, attempt + 1);
+              }
+              throw new Error(`${response.status} ${response.statusText} ${url} ${body.slice(0, 300)}`);
+            }
+
+            return response.json();
+          }
+
+          async function runQueue(items, worker) {
+            const queue = [...items];
+            const runners = Array.from({ length: Math.min(concurrency, queue.length || 1) }, async () => {
+              while (queue.length > 0) {
+                const item = queue.shift();
+                if (!item) {
+                  return;
+                }
+                await worker(item);
+              }
+            });
+            await Promise.all(runners);
+          }
+
+          const allWorks = await request('download/all-works.json');
+          const works = Array.isArray(allWorks) ? allWorks : [];
+          const selectedWorks = workLimit > 0 ? works.slice(0, workLimit) : works;
+
+          console.log(`Loaded ${works.length} works, prewarming ${selectedWorks.length}.`);
+
+          await runQueue(selectedWorks, async (item) => {
+            const work = item?.work;
+            const juans = Array.isArray(item?.juans) ? item.juans : [];
+            if (!work) {
+              return;
+            }
+
+            await request(`works?work=${encodeURIComponent(work)}`);
+            const selectedJuans = juanLimit > 0 ? juans.slice(0, juanLimit) : juans;
+            await runQueue(selectedJuans, async (juan) => {
+              await request(
+                `juans?work=${encodeURIComponent(work)}&juan=${encodeURIComponent(String(juan))}&work_info=1&toc=1`,
+              );
+            });
+            console.log(`Prewarmed ${work} (${selectedJuans.length} juans).`);
+          });
+          EOF2

--- a/fabushi/web/src/handlers/cbeta.js
+++ b/fabushi/web/src/handlers/cbeta.js
@@ -1,7 +1,7 @@
 import { CORS_HEADERS } from '../config/constants.js';
 import { jsonResponse } from '../utils/response.js';
 
-const CBETA_API_ROOT = 'https://api.cbetaonline.cn';
+const DEFAULT_CBETA_PUBLIC_API_ROOT = 'https://fabushi.ombhrum.com/api/cbeta';
 const DEFAULT_SEND_WORKS = [
   'T0365',
   'T0251',
@@ -23,8 +23,13 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function buildCbetaUrl(path, params = {}) {
-  const url = new URL(path.replace(/^\/+/, ''), `${CBETA_API_ROOT}/`);
+function getCbetaApiRoot(env) {
+  const configured = env?.CBETA_PUBLIC_API_ROOT;
+  return `${configured || DEFAULT_CBETA_PUBLIC_API_ROOT}`.trim().replace(/\/+$/g, '');
+}
+
+function buildCbetaUrl(env, path, params = {}) {
+  const url = new URL(path.replace(/^\/+/, ''), `${getCbetaApiRoot(env)}/`);
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value !== null && `${value}` !== '') {
       url.searchParams.set(key, `${value}`);
@@ -38,10 +43,10 @@ function summarizeBody(body) {
   return body.length > 600 ? `${body.slice(0, 600)}...` : body;
 }
 
-async function fetchJsonWithRetry(path, params = {}, options = {}) {
+async function fetchJsonWithRetry(env, path, params = {}, options = {}) {
   const retries = options.retries ?? DEFAULT_RETRY_COUNT;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const url = buildCbetaUrl(path, params);
+  const url = buildCbetaUrl(env, path, params);
   const attempts = [];
 
   for (let attempt = 1; attempt <= retries; attempt++) {
@@ -185,7 +190,7 @@ function parseLimit(value, fallback) {
   return Math.min(Math.max(parsed, 1), 24);
 }
 
-function toCbetaItem(work, juan, payload, attempts) {
+function toCbetaItem(env, work, juan, payload, attempts) {
   const html = Array.isArray(payload?.results) ? payload.results[0] : '';
   const workInfo = payload?.work_info || {};
   const title = workInfo.title || extractTitleFromHtml(html) || work;
@@ -205,8 +210,8 @@ function toCbetaItem(work, juan, payload, attempts) {
     content,
     contentLength: content.length,
     source: 'CBETA',
-    sourceApi: CBETA_API_ROOT,
-    sourceUrl: buildCbetaUrl('juans', {
+    sourceApi: getCbetaApiRoot(env),
+    sourceUrl: buildCbetaUrl(env, 'juans', {
       work: workInfo.work || work,
       juan,
       work_info: 1,
@@ -226,7 +231,7 @@ function normalizeError(work, juan, error) {
   };
 }
 
-export async function handleGetCbetaSendTexts(request) {
+export async function handleGetCbetaSendTexts(request, env) {
   const url = new URL(request.url);
   const works = parseWorksParam(url.searchParams.get('works'));
   const limit = parseLimit(url.searchParams.get('limit'), DEFAULT_SEND_WORKS.length);
@@ -237,13 +242,13 @@ export async function handleGetCbetaSendTexts(request) {
 
   for (const work of selectedWorks) {
     try {
-      const { data, attempts } = await fetchJsonWithRetry('juans', {
+      const { data, attempts } = await fetchJsonWithRetry(env, 'juans', {
         work,
         juan,
         work_info: 1,
         toc: 1,
       });
-      items.push(toCbetaItem(work, juan, data, attempts));
+      items.push(toCbetaItem(env, work, juan, data, attempts));
     } catch (error) {
       errors.push(normalizeError(work, juan, error));
     }
@@ -252,7 +257,7 @@ export async function handleGetCbetaSendTexts(request) {
   const payload = {
     success: items.length > 0,
     source: 'CBETA',
-    api: CBETA_API_ROOT,
+    api: getCbetaApiRoot(env),
     requested: selectedWorks.length,
     count: items.length,
     items,
@@ -262,10 +267,10 @@ export async function handleGetCbetaSendTexts(request) {
   return jsonResponse(payload, items.length > 0 ? 200 : 502);
 }
 
-export async function handleProxyCbetaRequest(request) {
+export async function handleProxyCbetaRequest(request, env) {
   const sourceUrl = new URL(request.url);
   const cbetaPath = sourceUrl.pathname.replace(/^\/api\/cbeta\/?/, '');
-  const targetUrl = buildCbetaUrl(cbetaPath || '/', Object.fromEntries(sourceUrl.searchParams));
+  const targetUrl = buildCbetaUrl(env, cbetaPath || '/', Object.fromEntries(sourceUrl.searchParams));
   const response = await fetch(targetUrl.toString(), {
     method: request.method,
     headers: {
@@ -276,6 +281,7 @@ export async function handleProxyCbetaRequest(request) {
   const headers = new Headers(CORS_HEADERS);
   const contentType = response.headers.get('Content-Type');
   if (contentType) headers.set('Content-Type', contentType);
+  headers.set('X-Fabushi-Cbeta-Proxy', 'app-backend');
 
   return new Response(response.body, {
     status: response.status,

--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -4,22 +4,12 @@ import { FaliuContentSearchEnhancer } from "../../components/faliu-content-searc
 import { FaliuMeritBenefitEnhancer } from "../../components/faliu-merit-benefit-enhancer";
 import { FaliuShell } from "../../components/faliu-shell";
 import { FaliuSynonymEnhancer } from "../../components/faliu-synonym-enhancer";
-import { FALIU_FEATURED_WORKS } from "../../lib/faliu-config";
-import {
-  buildCbetaContentId,
-  fetchAllWorks,
-  fetchBatchStats,
-  fetchWorkInfo,
-  type CbetaWorkInfo,
-  type ContentStats,
-  type CbetaWorkIndexItem,
-} from "../../lib/faliu-api";
 import { siteUrl } from "../../lib/site-url";
 
 const pageUrl = siteUrl("/faliu");
 const pageTitle = `法流 | CBETA 佛典流式浏览 | ${brand.name}`;
 const pageDescription =
-  "法流页使用 CBETA API 提供佛典题名、卷次与正文浏览，并接入法布施 App 后端的互动统计与评论数据。";
+  "法流页使用 Fabushi 自托管的 CBETA API 提供佛典题名、卷次与正文浏览，并接入法布施 App 后端的互动统计与评论数据。";
 
 export const metadata: Metadata = {
   title: pageTitle,
@@ -50,42 +40,7 @@ export const metadata: Metadata = {
   },
 };
 
-async function loadInitialFaliuData() {
-  try {
-    const allWorks = await fetchAllWorks();
-    const featuredSet = new Set(FALIU_FEATURED_WORKS);
-    const featuredWorks = allWorks
-      .filter((item) => featuredSet.has(item.work))
-      .sort((left, right) => FALIU_FEATURED_WORKS.indexOf(left.work) - FALIU_FEATURED_WORKS.indexOf(right.work))
-      .slice(0, 12);
-    const fallbackWorks = featuredWorks.length > 0 ? featuredWorks : allWorks.slice(0, 12);
-    const infoEntries = await Promise.all(
-      fallbackWorks.map(async (item) => {
-        const info = await fetchWorkInfo(item.work).catch(() => null);
-        return [item.work, info] as const;
-      }),
-    );
-    const initialWorkInfo: Record<string, CbetaWorkInfo | null> = Object.fromEntries(infoEntries);
-    const initialStats: Record<string, ContentStats> = await fetchBatchStats(
-      fallbackWorks.map((item) => buildCbetaContentId(item.work, item.juans[0] ?? "1")),
-    ).catch(() => ({}));
-
-    return {
-      initialWorks: fallbackWorks,
-      initialWorkInfo,
-      initialStats,
-    };
-  } catch {
-    return {
-      initialWorks: [] as CbetaWorkIndexItem[],
-      initialWorkInfo: {},
-      initialStats: {},
-    };
-  }
-}
-
-export default async function FaliuPage() {
-  const initialData = await loadInitialFaliuData();
+export default function FaliuPage() {
   const structuredData = {
     "@context": "https://schema.org",
     "@graph": [
@@ -118,7 +73,7 @@ export default async function FaliuPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
-      <FaliuShell {...initialData} />
+      <FaliuShell />
       <FaliuSynonymEnhancer />
       <FaliuContentSearchEnhancer />
       <FaliuMeritBenefitEnhancer />

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -1,9 +1,10 @@
-const CBETA_PROXY_ROUTE = /^\/api\/cbeta\/(.+)$/;
+const CBETA_PROXY_ROUTE = /^\/api\/cbeta(?:\/(.*))?$/;
 const APP_PROXY_ROUTE = /^\/api\/app\/(.+)$/;
-const CBETA_API_BASE = "https://api.cbetaonline.cn";
+const DEFAULT_CBETA_UPSTREAM_BASE = "https://api.cbetaonline.cn";
 const APP_API_BASE = "https://api.ombhrum.com/api";
 const OFFICIAL_SITE_HOST = "fabushi.ombhrum.com";
 const ROOT_DOMAIN_REDIRECT_HOSTS = new Set(["ombhrum.com"]);
+const CBETA_MIRROR_PREFIX = "cbeta-api";
 const ANDROID_R2_DOWNLOADS = new Map([
   [
     "/downloads/android/fabushi-android-beta.apk",
@@ -22,7 +23,7 @@ const ANDROID_R2_DOWNLOADS = new Map([
 ]);
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
     if (ROOT_DOMAIN_REDIRECT_HOSTS.has(url.hostname.toLowerCase())) {
       return redirectToOfficialSite(url);
@@ -37,7 +38,7 @@ export default {
     }
 
     if (cbetaMatch) {
-      return proxyApiRequest(request, CBETA_API_BASE, cbetaMatch[1], ["GET", "HEAD", "OPTIONS"]);
+      return proxyCbetaApiRequest(request, env, ctx, cbetaMatch[1] ?? "");
     }
 
     if (appMatch) {
@@ -117,6 +118,177 @@ async function serveAndroidR2Download(request, env, download) {
   });
 }
 
+function normalizeBaseUrl(value, fallback) {
+  const candidate = `${value || fallback}`.trim() || fallback;
+  return candidate.replace(/\/+$/g, "");
+}
+
+function buildCanonicalQuery(searchParams) {
+  return Array.from(searchParams.entries())
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+      if (leftKey === rightKey) {
+        return leftValue.localeCompare(rightValue);
+      }
+      return leftKey.localeCompare(rightKey);
+    })
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&");
+}
+
+function buildCbetaMirrorKey(pathname, searchParams) {
+  const normalizedPath = pathname.replace(/^\/+|\/+$/g, "") || "index";
+  const canonicalQuery = buildCanonicalQuery(searchParams);
+  return canonicalQuery
+    ? `${CBETA_MIRROR_PREFIX}/${normalizedPath}?${canonicalQuery}`
+    : `${CBETA_MIRROR_PREFIX}/${normalizedPath}`;
+}
+
+function buildCbetaUpstreamUrl(base, pathname, searchParams) {
+  const upstreamUrl = new URL(pathname.replace(/^\/+/, ""), `${base}/`);
+  const canonicalQuery = buildCanonicalQuery(searchParams);
+  upstreamUrl.search = canonicalQuery;
+  return upstreamUrl;
+}
+
+function applySanitizedProxyHeaders(sourceHeaders, extras = {}) {
+  const headers = new Headers(sourceHeaders);
+  headers.delete("Content-Encoding");
+  headers.delete("Content-Length");
+  headers.delete("Set-Cookie");
+
+  for (const [key, value] of Object.entries(extras)) {
+    if (!value) {
+      continue;
+    }
+    headers.set(key, value);
+  }
+
+  return headers;
+}
+
+async function readMirrorObject(bucket, key, method) {
+  if (!bucket) {
+    return null;
+  }
+
+  if (method === "HEAD" && typeof bucket.head === "function") {
+    return bucket.head(key);
+  }
+
+  if (typeof bucket.get === "function") {
+    return bucket.get(key);
+  }
+
+  return null;
+}
+
+async function writeMirrorObject(bucket, key, response) {
+  if (!bucket || response.status !== 200 || response.bodyUsed || typeof bucket.put !== "function") {
+    return;
+  }
+
+  const contentType = response.headers.get("Content-Type") || "application/json; charset=utf-8";
+  const cacheControl = response.headers.get("Cache-Control") || "public, max-age=86400";
+  const body = await response.arrayBuffer();
+
+  await bucket.put(key, body, {
+    httpMetadata: {
+      contentType,
+      cacheControl,
+    },
+    customMetadata: {
+      source: "upstream-fill",
+      mirroredAt: new Date().toISOString(),
+    },
+  });
+}
+
+function buildMirrorResponse(object, method) {
+  const headers = new Headers();
+  object.writeHttpMetadata?.(headers);
+  headers.set("Cache-Control", headers.get("Cache-Control") || "public, max-age=86400");
+  headers.set("Content-Length", String(object.size));
+  headers.set("X-Fabushi-Cbeta-Source", "r2-mirror");
+
+  const etag = object.httpEtag || (object.etag ? `"${object.etag}"` : "");
+  if (etag) {
+    headers.set("ETag", etag);
+  }
+
+  return new Response(method === "HEAD" ? null : object.body, {
+    status: 200,
+    headers,
+  });
+}
+
+async function proxyCbetaApiRequest(request, env, ctx, upstreamPath) {
+  const allowedMethods = ["GET", "HEAD", "OPTIONS"];
+  if (!allowedMethods.includes(request.method)) {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: {
+        Allow: "GET, HEAD",
+      },
+    });
+  }
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        Allow: "GET, HEAD",
+      },
+    });
+  }
+
+  const requestUrl = new URL(request.url);
+  const mirrorKey = buildCbetaMirrorKey(upstreamPath, requestUrl.searchParams);
+  const mirrorBucket = env?.CBETA_MIRROR;
+  const mirroredObject = await readMirrorObject(mirrorBucket, mirrorKey, request.method);
+
+  if (mirroredObject) {
+    return buildMirrorResponse(mirroredObject, request.method);
+  }
+
+  const upstreamBase = normalizeBaseUrl(env?.CBETA_UPSTREAM_BASE, DEFAULT_CBETA_UPSTREAM_BASE);
+  if (!upstreamBase) {
+    return new Response("CBETA mirror is not populated yet.", {
+      status: 503,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  const upstreamUrl = buildCbetaUpstreamUrl(upstreamBase, upstreamPath, requestUrl.searchParams);
+  const headers = new Headers(request.headers);
+  headers.set("Accept", request.headers.get("Accept") || "application/json");
+  headers.delete("Host");
+  headers.delete("Cookie");
+
+  const upstreamResponse = await fetch(upstreamUrl.toString(), {
+    method: request.method,
+    headers,
+    redirect: "follow",
+  });
+
+  const responseHeaders = applySanitizedProxyHeaders(upstreamResponse.headers, {
+    "X-Fabushi-Cbeta-Source": "upstream-fill",
+    "X-Fabushi-Cbeta-Key": mirrorKey,
+  });
+  const response = new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  });
+
+  if (request.method === "GET" && upstreamResponse.ok && mirrorBucket) {
+    ctx?.waitUntil?.(writeMirrorObject(mirrorBucket, mirrorKey, response.clone()));
+  }
+
+  return response;
+}
+
 async function proxyApiRequest(request, upstreamBase, upstreamPath, allowedMethods) {
   if (!allowedMethods.includes(request.method)) {
     return new Response("Method Not Allowed", {
@@ -137,7 +309,7 @@ async function proxyApiRequest(request, upstreamBase, upstreamPath, allowedMetho
   }
 
   const requestUrl = new URL(request.url);
-  const upstreamUrl = new URL(upstreamPath.replace(/^\/+/g, ""), `${upstreamBase}/`);
+  const upstreamUrl = new URL(upstreamPath.replace(/^\/+/, ""), `${upstreamBase}/`);
   upstreamUrl.search = requestUrl.search;
 
   const headers = new Headers(request.headers);


### PR DESCRIPTION
## Summary
- add an R2-backed CBETA mirror layer to the official site worker
- point the app backend CBETA send-text flow at the self-hosted CBETA API
- stop the faliu page from doing server-side direct CBETA fetches
- add Cloudflare deploy config and a scheduled prewarm workflow for the mirror

## Testing
- not run locally in this workspace because the repository code was not available as a local checkout and GitHub network clone was blocked
- validated the changed-file set through GitHub compare results

## Deploy Notes
- configure `CBETA_MIRROR_R2_BUCKET` in the official site deploy environment
- optionally keep `CBETA_UPSTREAM_BASE=https://api.cbetaonline.cn` during warm-up, then clear it after the mirror is fully populated if you want hard mirror-only behavior
- run the new `Warm CBETA mirror` workflow once after deploy to prefill works and juans into R2