### PR TITLE
Use host domain for Oracle CBETA upstream

### DIFF
--- a/fabushi/web/src/handlers/cbeta.js
+++ b/fabushi/web/src/handlers/cbeta.js
@@ -2,7 +2,7 @@ import { CORS_HEADERS } from '../config/constants.js';
 import { jsonResponse } from '../utils/response.js';
 
 const CBETA_PUBLIC_API_ROOT = 'https://api.ombhrum.com/api/cbeta';
-const CBETA_ORACLE_API_ROOT = 'http://144.24.17.21:3000';
+const CBETA_ORACLE_API_ROOT = 'http://144.24.17.21.sslip.io:3000';
 const CBETA_FALLBACK_API_ROOT = 'https://api.cbetaonline.cn';
 const CBETA_API_ROOTS = [CBETA_ORACLE_API_ROOT, CBETA_FALLBACK_API_ROOT];
 const DEFAULT_SEND_WORKS = [

--- a/fabushi/web/tests/cbeta-send-texts.test.js
+++ b/fabushi/web/tests/cbeta-send-texts.test.js
@@ -105,7 +105,7 @@ test('CBETA send texts falls back when Oracle returns empty juan content', async
     const parsed = new URL(url);
     attemptedHosts.push(parsed.host);
 
-    if (parsed.host === '144.24.17.21:3000') {
+    if (parsed.host === '144.24.17.21.sslip.io:3000') {
       return new Response(JSON.stringify({ num_found: 0, results: [] }), { status: 200 });
     }
 
@@ -131,9 +131,9 @@ test('CBETA send texts falls back when Oracle returns empty juan content', async
     assert.equal(body.items[0].sourceApi, 'https://api.cbetaonline.cn');
     assert.match(body.items[0].content, /觀自在菩薩/);
     assert.deepEqual(attemptedHosts, [
-      '144.24.17.21:3000',
-      '144.24.17.21:3000',
-      '144.24.17.21:3000',
+      '144.24.17.21.sslip.io:3000',
+      '144.24.17.21.sslip.io:3000',
+      '144.24.17.21.sslip.io:3000',
       'api.cbetaonline.cn',
     ]);
   } finally {


### PR DESCRIPTION
## Summary
- switch the Worker CBETA Oracle upstream from the bare VPS IP to `144.24.17.21.sslip.io:3000`
- keep official CBETA as fallback
- align tests with the host-domain upstream

## Validation
- verified `http://144.24.17.21.sslip.io:3000/health` returns 200 after allowing the host in Rails
- verified `http://144.24.17.21.sslip.io:3000/juans?work=T0251&juan=1&work_info=1&toc=1` returns 《般若波羅蜜多心經》正文
- `node --check fabushi/web/src/handlers/cbeta.js`
- `node --experimental-default-type=module --test --test-concurrency=1 fabushi/web/tests/cbeta-send-texts.test.js`