### PR TITLE
feat: upgrade app version checking to a backend-driven policy

### DIFF
--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -105,8 +105,9 @@ class AppConfig {
 
   // 应用信息
   static const String appName = '大乘';
+  // 保持与 pubspec.yaml 中的 version 同步，供 Web 回退和服务端比对使用。
   static const String appVersion = '1.0.0';
-  static const int appBuildNumber = 1;
+  static const int appBuildNumber = 16;
 
   // 功能开关
   static const bool enableFirebaseAuth = true;
@@ -165,6 +166,8 @@ class AppConfig {
       buildBackendUrl('/api/auth/reset-password');
   static String get userInfoUrl => buildBackendUrl('/api/auth/user-info');
   static String get bindEmailUrl => buildBackendUrl('/api/auth/bind-email');
+  static String get appVersionPolicyUrl =>
+      buildBackendUrl('/api/app/version-policy');
 
   static String get alipayCreateOrderUrl =>
       buildBackendUrl('/api/alipay/create-order');

--- a/fabushi/lib/services/app_update_service.dart
+++ b/fabushi/lib/services/app_update_service.dart
@@ -1,0 +1,359 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:uuid/uuid.dart';
+
+import '../core/config/app_config.dart';
+import 'http_service.dart';
+
+enum AppUpdateMode { optional, force }
+
+class AppVersionPolicy {
+  AppVersionPolicy({
+    required this.enabled,
+    required this.platform,
+    required this.channel,
+    required this.latestVersion,
+    required this.latestBuildNumber,
+    required this.minSupportedBuildNumber,
+    required this.forceUpdate,
+    required this.allowSkip,
+    required this.rolloutPercentage,
+    required this.promptIntervalHours,
+    required this.title,
+    required this.message,
+    required this.downloadUrl,
+    required this.releaseNotes,
+    required this.updateAvailable,
+    required this.strategy,
+    this.publishedAt,
+  });
+
+  final bool enabled;
+  final String platform;
+  final String channel;
+  final String latestVersion;
+  final int latestBuildNumber;
+  final int minSupportedBuildNumber;
+  final bool forceUpdate;
+  final bool allowSkip;
+  final int rolloutPercentage;
+  final int promptIntervalHours;
+  final String title;
+  final String message;
+  final String downloadUrl;
+  final List<String> releaseNotes;
+  final bool updateAvailable;
+  final String strategy;
+  final DateTime? publishedAt;
+
+  factory AppVersionPolicy.fromJson(Map<String, dynamic> json) {
+    final releaseNotesRaw = json['releaseNotes'];
+    final releaseNotes = releaseNotesRaw is List
+        ? releaseNotesRaw
+              .map((item) => item?.toString().trim() ?? '')
+              .where((item) => item.isNotEmpty)
+              .toList()
+        : <String>[];
+
+    return AppVersionPolicy(
+      enabled: json['enabled'] != false,
+      platform: (json['platform'] ?? 'unknown').toString(),
+      channel: (json['channel'] ?? 'stable').toString(),
+      latestVersion: (json['latestVersion'] ?? AppConfig.appVersion).toString(),
+      latestBuildNumber: _parseInt(
+        json['latestBuildNumber'],
+        AppConfig.appBuildNumber,
+      ),
+      minSupportedBuildNumber: _parseInt(
+        json['minSupportedBuildNumber'],
+        AppConfig.appBuildNumber,
+      ),
+      forceUpdate: json['forceUpdate'] == true,
+      allowSkip: json['allowSkip'] != false,
+      rolloutPercentage: _parseInt(json['rolloutPercentage'], 100)
+          .clamp(0, 100)
+          .toInt(),
+      promptIntervalHours: _parseInt(json['promptIntervalHours'], 24),
+      title: (json['title'] ?? '发现新版本').toString(),
+      message: (json['message'] ?? '新版本已发布，建议尽快更新。').toString(),
+      downloadUrl: (json['downloadUrl'] ?? '').toString(),
+      releaseNotes: releaseNotes,
+      updateAvailable: json['updateAvailable'] == true,
+      strategy: (json['strategy'] ?? 'none').toString(),
+      publishedAt: DateTime.tryParse((json['publishedAt'] ?? '').toString()),
+    );
+  }
+
+  static int _parseInt(dynamic value, int fallbackValue) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value?.toString() ?? '') ?? fallbackValue;
+  }
+}
+
+class AppUpdateDecision {
+  AppUpdateDecision({
+    required this.mode,
+    required this.currentVersion,
+    required this.currentBuildNumber,
+    required this.policy,
+  });
+
+  final AppUpdateMode mode;
+  final String currentVersion;
+  final int currentBuildNumber;
+  final AppVersionPolicy policy;
+
+  bool get isForce => mode == AppUpdateMode.force;
+  bool get canSkip => !isForce && policy.allowSkip;
+  String get latestVersionLabel =>
+      '${policy.latestVersion} (${policy.latestBuildNumber})';
+}
+
+class _AppInstallationInfo {
+  _AppInstallationInfo({
+    required this.version,
+    required this.buildNumber,
+    required this.platform,
+    required this.channel,
+  });
+
+  final String version;
+  final int buildNumber;
+  final String platform;
+  final String channel;
+}
+
+class AppUpdateService {
+  AppUpdateService._();
+
+  static final AppUpdateService instance = AppUpdateService._();
+  static const String _installIdKey = 'app_update_install_id';
+  static const String _skippedBuildNumberKey = 'app_update_skipped_build_number';
+  static const String _lastPromptAtKey = 'app_update_last_prompt_at';
+  static final Uuid _uuid = Uuid();
+
+  Future<AppUpdateDecision?> checkForUpdate({
+    bool ignoreLocalGuards = false,
+  }) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final installId = await _getOrCreateInstallId(prefs);
+      final info = await _getInstallationInfo();
+
+      final response = await HttpService.get(
+        AppConfig.appVersionPolicyUrl,
+        queryParams: {
+          'platform': info.platform,
+          'channel': info.channel,
+          'version': info.version,
+          'buildNumber': info.buildNumber.toString(),
+          'installId': installId,
+        },
+      );
+
+      if (!HttpService.isSuccessResponse(response)) {
+        return null;
+      }
+
+      final payload = jsonDecode(response.body);
+      if (payload is! Map<String, dynamic>) {
+        return null;
+      }
+
+      final policy = AppVersionPolicy.fromJson(payload);
+      if (!policy.enabled || !policy.updateAvailable) {
+        return null;
+      }
+
+      if (!_isRolloutEligible(installId, policy.rolloutPercentage)) {
+        return null;
+      }
+
+      final hasNewerBuild = info.buildNumber < policy.latestBuildNumber;
+      final hasNewerVersion =
+          _compareVersions(info.version, policy.latestVersion) < 0;
+      if (!hasNewerBuild && !hasNewerVersion) {
+        return null;
+      }
+
+      final isForce = policy.forceUpdate ||
+          info.buildNumber < policy.minSupportedBuildNumber;
+      final decision = AppUpdateDecision(
+        mode: isForce ? AppUpdateMode.force : AppUpdateMode.optional,
+        currentVersion: info.version,
+        currentBuildNumber: info.buildNumber,
+        policy: policy,
+      );
+
+      if (isForce) {
+        await clearSkippedVersion();
+        return decision;
+      }
+
+      if (!ignoreLocalGuards) {
+        final skippedBuildNumber = prefs.getInt(_skippedBuildNumberKey);
+        if (skippedBuildNumber == policy.latestBuildNumber) {
+          return null;
+        }
+
+        final lastPromptAtMillis = prefs.getInt(_lastPromptAtKey);
+        if (lastPromptAtMillis != null) {
+          final lastPromptAt = DateTime.fromMillisecondsSinceEpoch(
+            lastPromptAtMillis,
+          );
+          final nextPromptAt = lastPromptAt.add(
+            Duration(hours: policy.promptIntervalHours),
+          );
+          if (DateTime.now().isBefore(nextPromptAt)) {
+            return null;
+          }
+        }
+      }
+
+      return decision;
+    } catch (error) {
+      debugPrint('版本策略检查失败: $error');
+      return null;
+    }
+  }
+
+  Future<void> markPromptShown() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_lastPromptAtKey, DateTime.now().millisecondsSinceEpoch);
+  }
+
+  Future<void> markSkippedVersion(AppUpdateDecision decision) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+      _skippedBuildNumberKey,
+      decision.policy.latestBuildNumber,
+    );
+  }
+
+  Future<void> clearSkippedVersion() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_skippedBuildNumberKey);
+  }
+
+  Future<bool> openUpdatePage(AppUpdateDecision decision) async {
+    final updateUrl = decision.policy.downloadUrl.trim();
+    if (updateUrl.isEmpty) {
+      return false;
+    }
+    final uri = Uri.tryParse(updateUrl);
+    if (uri == null) {
+      return false;
+    }
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<_AppInstallationInfo> _getInstallationInfo() async {
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      final buildNumber = int.tryParse(packageInfo.buildNumber) ??
+          AppConfig.appBuildNumber;
+      final version = packageInfo.version.isNotEmpty
+          ? packageInfo.version
+          : AppConfig.appVersion;
+      return _AppInstallationInfo(
+        version: version,
+        buildNumber: buildNumber,
+        platform: _resolvePlatform(),
+        channel: _resolveChannel(),
+      );
+    } catch (_) {
+      return _AppInstallationInfo(
+        version: AppConfig.appVersion,
+        buildNumber: AppConfig.appBuildNumber,
+        platform: _resolvePlatform(),
+        channel: _resolveChannel(),
+      );
+    }
+  }
+
+  Future<String> _getOrCreateInstallId(SharedPreferences prefs) async {
+    final existing = prefs.getString(_installIdKey);
+    if (existing != null && existing.isNotEmpty) {
+      return existing;
+    }
+    final created = _uuid.v4();
+    await prefs.setString(_installIdKey, created);
+    return created;
+  }
+
+  String _resolvePlatform() {
+    if (kIsWeb) {
+      return 'web';
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return 'android';
+      case TargetPlatform.iOS:
+        return 'ios';
+      case TargetPlatform.macOS:
+        return 'macos';
+      case TargetPlatform.windows:
+        return 'windows';
+      case TargetPlatform.linux:
+        return 'linux';
+      case TargetPlatform.fuchsia:
+        return 'unknown';
+    }
+  }
+
+  String _resolveChannel() {
+    if (AppConfig.isProduction) {
+      return 'stable';
+    }
+    if (AppConfig.isStaging) {
+      return 'staging';
+    }
+    return 'development';
+  }
+
+  bool _isRolloutEligible(String installId, int rolloutPercentage) {
+    if (rolloutPercentage >= 100) {
+      return true;
+    }
+    if (rolloutPercentage <= 0) {
+      return false;
+    }
+
+    var hash = 0;
+    for (final codeUnit in installId.codeUnits) {
+      hash = (hash * 31 + codeUnit) % 100;
+    }
+    return hash < rolloutPercentage;
+  }
+
+  int _compareVersions(String left, String right) {
+    final leftParts = left
+        .split('.')
+        .map((item) => int.tryParse(item) ?? 0)
+        .toList(growable: false);
+    final rightParts = right
+        .split('.')
+        .map((item) => int.tryParse(item) ?? 0)
+        .toList(growable: false);
+    final length = leftParts.length > rightParts.length
+        ? leftParts.length
+        : rightParts.length;
+
+    for (var index = 0; index < length; index += 1) {
+      final leftValue = index < leftParts.length ? leftParts[index] : 0;
+      final rightValue = index < rightParts.length ? rightParts[index] : 0;
+      if (leftValue > rightValue) {
+        return 1;
+      }
+      if (leftValue < rightValue) {
+        return -1;
+      }
+    }
+    return 0;
+  }
+}

--- a/fabushi/lib/widgets/app_update_dialog.dart
+++ b/fabushi/lib/widgets/app_update_dialog.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_update_service.dart';
+
+class AppUpdateDialog extends StatelessWidget {
+  const AppUpdateDialog({
+    super.key,
+    required this.decision,
+    required this.onUpdatePressed,
+    this.onLaterPressed,
+    this.onSkipPressed,
+  });
+
+  final AppUpdateDecision decision;
+  final Future<void> Function() onUpdatePressed;
+  final VoidCallback? onLaterPressed;
+  final VoidCallback? onSkipPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final releaseNotes = decision.policy.releaseNotes;
+
+    return PopScope(
+      canPop: !decision.isForce,
+      child: AlertDialog(
+        backgroundColor: const Color(0xFF111827),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        titlePadding: const EdgeInsets.fromLTRB(24, 20, 24, 8),
+        contentPadding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+        actionsPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              decoration: BoxDecoration(
+                color: decision.isForce
+                    ? const Color(0x33EF4444)
+                    : const Color(0x3322C55E),
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: Text(
+                decision.isForce ? '必须更新' : '建议更新',
+                style: TextStyle(
+                  color: decision.isForce
+                      ? const Color(0xFFFCA5A5)
+                      : const Color(0xFF86EFAC),
+                  fontWeight: FontWeight.w700,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              decision.policy.title,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '当前 ${decision.currentVersion} (${decision.currentBuildNumber})  →  最新 ${decision.latestVersionLabel}',
+              style: const TextStyle(color: Colors.white60, fontSize: 13),
+            ),
+          ],
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              decision.policy.message,
+              style: const TextStyle(color: Colors.white70, height: 1.45),
+            ),
+            if (releaseNotes.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              const Text(
+                '本次更新',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.05),
+                  borderRadius: BorderRadius.circular(14),
+                  border: Border.all(color: Colors.white10),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: releaseNotes
+                      .map(
+                        (item) => Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: Text(
+                            '• $item',
+                            style: const TextStyle(
+                              color: Colors.white70,
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      )
+                      .toList(growable: false),
+                ),
+              ),
+            ],
+            if (decision.isForce) ...[
+              const SizedBox(height: 16),
+              const Text(
+                '当前版本已不再受支持，请完成更新后继续使用。',
+                style: TextStyle(
+                  color: Color(0xFFFCA5A5),
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ],
+        ),
+        actions: [
+          if (!decision.isForce && onLaterPressed != null)
+            TextButton(
+              onPressed: onLaterPressed,
+              child: const Text('稍后再说'),
+            ),
+          if (decision.canSkip && onSkipPressed != null)
+            TextButton(
+              onPressed: onSkipPressed,
+              child: const Text('跳过此版本'),
+            ),
+          FilledButton(
+            onPressed: () => onUpdatePressed(),
+            style: FilledButton.styleFrom(
+              backgroundColor:
+                  decision.isForce ? const Color(0xFFEF4444) : const Color(0xFF22C55E),
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            child: Text(decision.isForce ? '立即更新并继续' : '立即更新'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/fabushi/lib/widgets/app_wrapper.dart
+++ b/fabushi/lib/widgets/app_wrapper.dart
@@ -9,10 +9,12 @@ import '../screens/eula_screen.dart';
 import '../screens/main_navigation_screen.dart';
 import '../services/app_initializer.dart';
 import '../services/app_settings.dart';
+import '../services/app_update_service.dart';
 import '../services/asset_loader_service.dart';
 import '../services/error_report_service.dart';
 import '../services/eula_service.dart';
 import '../services/platform_service.dart';
+import '../widgets/app_update_dialog.dart';
 import '../widgets/model_selection_dialog.dart';
 import '../widgets/startup_splash_screen.dart';
 
@@ -29,6 +31,7 @@ class _AppWrapperState extends State<AppWrapper> {
   bool _isInitialized = false;
   bool _initStarted = false;
   bool _isSubmittingFeedback = false;
+  bool _versionCheckScheduled = false;
   String _startupPhase = '正在唤起禅境';
   String? _initError;
   bool _needsModelSetup = false;
@@ -134,8 +137,10 @@ class _AppWrapperState extends State<AppWrapper> {
         }
 
         if (needsModelSetup && mounted) {
-          _showModelSetupDialog();
+          await _showModelSetupDialog();
         }
+
+        _scheduleAppVersionCheck();
       }
     } catch (error, stackTrace) {
       debugPrint('Error during app initialization: $error');
@@ -188,6 +193,82 @@ class _AppWrapperState extends State<AppWrapper> {
         source: 'AppWrapper.startupSideEffect',
       );
     }
+  }
+
+  void _scheduleAppVersionCheck() {
+    if (_versionCheckScheduled) {
+      return;
+    }
+    _versionCheckScheduled = true;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Future<void>.delayed(const Duration(milliseconds: 600), () async {
+        if (!mounted) {
+          return;
+        }
+        await _showAppUpdateDialogIfNeeded();
+      });
+    });
+  }
+
+  Future<void> _showAppUpdateDialogIfNeeded() async {
+    final decision = await AppUpdateService.instance.checkForUpdate();
+    if (!mounted || decision == null) {
+      return;
+    }
+
+    await AppUpdateService.instance.markPromptShown();
+    if (!mounted) {
+      return;
+    }
+
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: !decision.isForce,
+      builder: (dialogContext) {
+        return AppUpdateDialog(
+          decision: decision,
+          onLaterPressed: decision.isForce
+              ? null
+              : () => Navigator.of(dialogContext).pop(),
+          onSkipPressed: decision.canSkip
+              ? () async {
+                  await AppUpdateService.instance.markSkippedVersion(decision);
+                  if (dialogContext.mounted) {
+                    Navigator.of(dialogContext).pop();
+                  }
+                }
+              : null,
+          onUpdatePressed: () async {
+            final launched =
+                await AppUpdateService.instance.openUpdatePage(decision);
+            if (!mounted) {
+              return;
+            }
+
+            if (!launched) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('暂时无法打开更新入口，请稍后重试')),
+              );
+              return;
+            }
+
+            if (decision.isForce) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('已打开更新入口，更新完成后请重新打开应用'),
+                ),
+              );
+              return;
+            }
+
+            if (dialogContext.mounted) {
+              Navigator.of(dialogContext).pop();
+            }
+          },
+        );
+      },
+    );
   }
 
   Future<void> _showEulaScreen() async {
@@ -556,6 +637,7 @@ class _AppWrapperState extends State<AppWrapper> {
                               _startupPhase = '正在重新唤起禅境';
                               _initError = null;
                               _initReport = null;
+                              _versionCheckScheduled = false;
                             });
                           },
                           style: ElevatedButton.styleFrom(

--- a/fabushi/web/src/handlers/app-version.js
+++ b/fabushi/web/src/handlers/app-version.js
@@ -1,0 +1,209 @@
+import { jsonResponse } from '../utils/response.js';
+
+const DEFAULT_RELEASE_NOTES = [
+  '优化启动体验与稳定性',
+  '修复已知问题并改进细节表现'
+];
+
+function pickFirst(...values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null && String(value).trim() !== '') {
+      return String(value).trim();
+    }
+  }
+  return '';
+}
+
+function parseInteger(value, fallbackValue) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? parsed : fallbackValue;
+}
+
+function parseBoolean(value, fallbackValue = false) {
+  if (value === undefined || value === null || value === '') {
+    return fallbackValue;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  return fallbackValue;
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normalizePlatform(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return 'unknown';
+  if (['android', 'ios', 'web', 'macos', 'windows', 'linux'].includes(normalized)) {
+    return normalized;
+  }
+  return 'unknown';
+}
+
+function normalizeChannel(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized || 'stable';
+}
+
+function normalizeReleaseNotes(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => String(item || '').trim())
+      .filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/\r?\n/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return [...DEFAULT_RELEASE_NOTES];
+}
+
+function compareVersions(left, right) {
+  const leftParts = String(left || '0')
+    .split('.')
+    .map((item) => Number.parseInt(item, 10) || 0);
+  const rightParts = String(right || '0')
+    .split('.')
+    .map((item) => Number.parseInt(item, 10) || 0);
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = leftParts[index] || 0;
+    const rightValue = rightParts[index] || 0;
+    if (leftValue > rightValue) return 1;
+    if (leftValue < rightValue) return -1;
+  }
+
+  return 0;
+}
+
+function shouldUpdate(clientVersion, clientBuildNumber, policy) {
+  if (clientBuildNumber >= 0 && clientBuildNumber < policy.latestBuildNumber) {
+    return true;
+  }
+  return compareVersions(clientVersion, policy.latestVersion) < 0;
+}
+
+function resolveDownloadUrl(platform, env) {
+  const platformKey = platform.toUpperCase();
+  return pickFirst(
+    env[`APP_VERSION_DOWNLOAD_URL_${platformKey}`],
+    env.APP_VERSION_DOWNLOAD_URL,
+    platform === 'web' ? env.FRONTEND_URL : '',
+    env.FRONTEND_URL,
+    env.WORKER_URL,
+    'https://flutter.ombhrum.com'
+  );
+}
+
+function buildPolicy(platform, channel, env) {
+  const platformKey = platform.toUpperCase();
+  const channelKey = channel.toUpperCase();
+  const latestVersion = pickFirst(
+    env[`APP_VERSION_LATEST_VERSION_${platformKey}_${channelKey}`],
+    env[`APP_VERSION_LATEST_VERSION_${platformKey}`],
+    env[`APP_VERSION_LATEST_VERSION_${channelKey}`],
+    env.APP_VERSION_LATEST_VERSION,
+    '1.0.0'
+  );
+  const latestBuildNumber = parseInteger(
+    pickFirst(
+      env[`APP_VERSION_LATEST_BUILD_${platformKey}_${channelKey}`],
+      env[`APP_VERSION_LATEST_BUILD_${platformKey}`],
+      env[`APP_VERSION_LATEST_BUILD_${channelKey}`],
+      env.APP_VERSION_LATEST_BUILD,
+      '16'
+    ),
+    16
+  );
+  const minSupportedBuildNumber = parseInteger(
+    pickFirst(
+      env[`APP_VERSION_MIN_SUPPORTED_BUILD_${platformKey}_${channelKey}`],
+      env[`APP_VERSION_MIN_SUPPORTED_BUILD_${platformKey}`],
+      env[`APP_VERSION_MIN_SUPPORTED_BUILD_${channelKey}`],
+      env.APP_VERSION_MIN_SUPPORTED_BUILD,
+      String(latestBuildNumber)
+    ),
+    latestBuildNumber
+  );
+  const rolloutPercentage = clamp(
+    parseInteger(
+      pickFirst(
+        env[`APP_VERSION_ROLLOUT_PERCENTAGE_${platformKey}_${channelKey}`],
+        env[`APP_VERSION_ROLLOUT_PERCENTAGE_${platformKey}`],
+        env[`APP_VERSION_ROLLOUT_PERCENTAGE_${channelKey}`],
+        env.APP_VERSION_ROLLOUT_PERCENTAGE,
+        '100'
+      ),
+      100
+    ),
+    0,
+    100
+  );
+  const promptIntervalHours = Math.max(
+    1,
+    parseInteger(env.APP_VERSION_PROMPT_INTERVAL_HOURS, 24)
+  );
+  const releaseNotes = normalizeReleaseNotes(
+    pickFirst(env.APP_VERSION_RELEASE_NOTES, DEFAULT_RELEASE_NOTES.join('\n'))
+  );
+  const forceUpdate = parseBoolean(env.APP_VERSION_FORCE_UPDATE, false);
+  const allowSkip = parseBoolean(env.APP_VERSION_ALLOW_SKIP, true) && !forceUpdate;
+
+  return {
+    enabled: parseBoolean(env.APP_VERSION_CHECK_ENABLED, true),
+    channel,
+    platform,
+    latestVersion,
+    latestBuildNumber,
+    minSupportedBuildNumber,
+    forceUpdate,
+    allowSkip,
+    rolloutPercentage,
+    promptIntervalHours,
+    publishedAt: pickFirst(env.APP_VERSION_PUBLISHED_AT, new Date().toISOString()),
+    title: pickFirst(env.APP_VERSION_TITLE, '发现新版本'),
+    message: pickFirst(
+      env.APP_VERSION_MESSAGE,
+      '新版本已发布，建议尽快更新以获得更稳定的体验。'
+    ),
+    releaseNotes,
+    downloadUrl: resolveDownloadUrl(platform, env)
+  };
+}
+
+export async function handleAppVersionPolicy(request, env) {
+  const url = new URL(request.url);
+  const platform = normalizePlatform(url.searchParams.get('platform'));
+  const channel = normalizeChannel(url.searchParams.get('channel'));
+  const clientVersion = String(url.searchParams.get('version') || '0.0.0').trim();
+  const clientBuildNumber = parseInteger(url.searchParams.get('buildNumber'), -1);
+
+  const policy = buildPolicy(platform, channel, env);
+  const updateAvailable = policy.enabled
+    ? shouldUpdate(clientVersion, clientBuildNumber, policy)
+    : false;
+  const hardBlockedByMinVersion =
+    clientBuildNumber >= 0 && clientBuildNumber < policy.minSupportedBuildNumber;
+  const forceUpdate = updateAvailable && (policy.forceUpdate || hardBlockedByMinVersion);
+
+  return jsonResponse({
+    ...policy,
+    updateAvailable,
+    forceUpdate,
+    strategy: !updateAvailable ? 'none' : forceUpdate ? 'force' : 'optional',
+    serverTime: new Date().toISOString(),
+    client: {
+      version: clientVersion,
+      buildNumber: clientBuildNumber
+    }
+  });
+}

--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -23,6 +23,7 @@ import { handleToggleFollow, handleGetFollowList, handleGetFollowSummary, handle
 import { handleBuiltinMigration, handleFullTextSearch, handleGetCategories as handleBuiltinCategories } from '../migrate-builtin-handler-fixed.js';
 import { handleReport, handleBlockUser, handleGetReports, handleReviewReport, handleGetBlocks } from './handlers/moderation.js';
 import { handleSubmitFeedback } from './handlers/feedback.js';
+import { handleAppVersionPolicy } from './handlers/app-version.js';
 import { routeAuthRequest } from './routes/auth-routes.js';
 import { routeMembershipRequest } from './routes/membership-routes.js';
 import { routeMeditationRequest } from './routes/meditation-routes.js';
@@ -84,6 +85,10 @@ export async function route(request, env, db, ctx) {
 
   if (pathname === '/health') {
     return jsonResponse({ status: 'ok', timestamp: new Date().toISOString() });
+  }
+
+  if (pathname === '/api/app/version-policy' && method === 'GET') {
+    return await handleAppVersionPolicy(request, env);
   }
 
   const normalizedMeditationAuth = await normalizeMeditationAuthRequest(request, env, pathname);


### PR DESCRIPTION
## Summary
- add a backend-driven app version policy endpoint for latest version, min supported build, rollout, skip, and prompt cadence
- add a Flutter app update service and startup dialog with force-update and optional-update flows
- wire startup flow to check update policy after initialization without blocking first paint

## Testing
- not run locally in this environment

## Follow-up
- configure production env vars such as `APP_VERSION_LATEST_BUILD`, `APP_VERSION_MIN_SUPPORTED_BUILD`, and platform-specific download URLs before enabling force update