### PR TITLE
ci: sparse-checkout version policy sync workflow

### DIFF
--- a/.github/workflows/sync-app-version-policy.yml
+++ b/.github/workflows/sync-app-version-policy.yml
@@ -1,5 +1,8 @@
 name: Sync App Version Policy
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   workflow_dispatch:
     inputs:
@@ -50,7 +53,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.target_commitish || github.sha }}
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.github/scripts/sync-app-version-policy.mjs
+            /fabushi/pubspec.yaml
 
       - name: Set release metadata env
         shell: bash


### PR DESCRIPTION
## Summary
- switch the version-policy sync workflow to sparse checkout only the sync script and `fabushi/pubspec.yaml`
- bump checkout to `actions/checkout@v5` and opt into Node 24 actions for this workflow
- avoid the `File name too long` failure that blocked the first production sync run

## Why
- the first `Sync App Version Policy` run on `main` failed on May 24, 2026 during checkout because the full repository contains very long asset paths
- this workflow only needs two files, so full checkout is unnecessary and brittle

## Testing
- not run locally
- intended validation is rerunning the workflow after merge