### PR TITLE
fix: derive version policy build number from GitHub release metadata

### DIFF
--- a/.github/scripts/sync-app-version-policy.mjs
+++ b/.github/scripts/sync-app-version-policy.mjs
@@ -31,6 +31,51 @@ function readPubspecVersion(pubspecPath) {
   };
 }
 
+function parseReleaseVersion(value) {
+  if (!value) return null;
+
+  const normalizedValue = String(value).trim();
+  if (!normalizedValue) return null;
+
+  const tagMatch = normalizedValue.match(/v?(\d+\.\d+\.\d+)-(\d+)-mobile(?:[.-].*)?$/i);
+  if (tagMatch) {
+    return {
+      version: tagMatch[1],
+      buildNumber: Number.parseInt(tagMatch[2], 10),
+    };
+  }
+
+  const titleMatch = normalizedValue.match(/(\d+\.\d+\.\d+)\+(\d+)/);
+  if (titleMatch) {
+    return {
+      version: titleMatch[1],
+      buildNumber: Number.parseInt(titleMatch[2], 10),
+    };
+  }
+
+  return null;
+}
+
+function resolveVersionMetadata({ pubspecPath, args }) {
+  const releaseCandidates = [
+    args.releaseTag,
+    process.env.GITHUB_RELEASE_TAG,
+    args.title,
+    process.env.VERSION_TITLE,
+    process.env.GITHUB_RELEASE_TITLE,
+    process.env.GITHUB_RELEASE_BODY,
+  ];
+
+  for (const candidate of releaseCandidates) {
+    const parsed = parseReleaseVersion(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  return readPubspecVersion(pubspecPath);
+}
+
 function normalizeBoolean(value, fallbackValue) {
   if (value === undefined || value === null || value === '') {
     return fallbackValue;
@@ -89,7 +134,7 @@ async function main() {
   const args = parseArgs(process.argv);
   const repoRoot = process.cwd();
   const pubspecPath = path.join(repoRoot, 'fabushi', 'pubspec.yaml');
-  const { version, buildNumber } = readPubspecVersion(pubspecPath);
+  const { version, buildNumber } = resolveVersionMetadata({ pubspecPath, args });
 
   const endpoint =
     args.endpoint ||

--- a/.github/workflows/sync-app-version-policy.yml
+++ b/.github/workflows/sync-app-version-policy.yml
@@ -23,8 +23,14 @@ on:
       message:
         description: Update dialog message
         required: false
+      release_tag:
+        description: Optional GitHub release tag used to parse app version and build number
+        required: false
       release_notes:
         description: Multi-line release notes
+        required: false
+      published_at:
+        description: Optional ISO published-at timestamp
         required: false
       force_update:
         description: Force update users on this rollout
@@ -70,6 +76,7 @@ jobs:
               echo 'GITHUB_RELEASE_TITLE<<EOF'
               echo "${{ github.event.release.name || github.event.release.tag_name }}"
               echo 'EOF'
+              echo 'GITHUB_RELEASE_TAG=${{ github.event.release.tag_name }}'
               echo 'GITHUB_RELEASE_BODY<<EOF'
               echo "${{ github.event.release.body }}"
               echo 'EOF'
@@ -80,9 +87,11 @@ jobs:
               echo 'GITHUB_RELEASE_TITLE<<EOF'
               echo "${{ inputs.title }}"
               echo 'EOF'
+              echo 'GITHUB_RELEASE_TAG=${{ inputs.release_tag }}'
               echo 'GITHUB_RELEASE_BODY<<EOF'
               echo "${{ inputs.release_notes }}"
               echo 'EOF'
+              echo "VERSION_PUBLISHED_AT=${{ inputs.published_at }}"
             } >> "$GITHUB_ENV"
           fi
 


### PR DESCRIPTION
## Summary
- derive app version policy version/build metadata from GitHub release tag or title before falling back to `fabushi/pubspec.yaml`
- add workflow dispatch inputs for release tag and published timestamp so historical releases can be resynced correctly
- keep the existing pubspec fallback for manual sync cases that do not provide release metadata

## Why
The current sync script always reads `fabushi/pubspec.yaml`, which is still `1.0.0+16`, so D1 is getting `latestBuildNumber: 16` even though the latest mobile GitHub release is `1.0.0+377`.

## Validation
- workflow dispatch on this branch to resync the latest release metadata into D1
- verify `/api/site/releases` and app version policy endpoints reflect build number `377`
