### PR TITLE
[codex] Add offline recitation practice books

### DIFF
--- a/fabushi/lib/models/practice_book_model.dart
+++ b/fabushi/lib/models/practice_book_model.dart
@@ -1,0 +1,247 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+enum PracticeBookSourceType { file, url, manual, cloud }
+
+enum PracticeBookSyncStatus { localOnly, pendingUpload, synced, syncFailed }
+
+PracticeBookSourceType practiceBookSourceTypeFromString(String? value) {
+  return PracticeBookSourceType.values.firstWhere(
+    (item) => item.name == value,
+    orElse: () => PracticeBookSourceType.manual,
+  );
+}
+
+PracticeBookSyncStatus practiceBookSyncStatusFromString(String? value) {
+  return PracticeBookSyncStatus.values.firstWhere(
+    (item) => item.name == value,
+    orElse: () => PracticeBookSyncStatus.localOnly,
+  );
+}
+
+class PracticeBook {
+  final String id;
+  final String practiceTitle;
+  final String title;
+  final PracticeBookSourceType sourceType;
+  final String? sourceUrl;
+  final String? sourceFileName;
+  final String contentHash;
+  final String plainText;
+  final String normalizedText;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final PracticeBookSyncStatus syncStatus;
+  final String? remoteObjectKey;
+  final bool isActive;
+
+  const PracticeBook({
+    required this.id,
+    required this.practiceTitle,
+    required this.title,
+    required this.sourceType,
+    this.sourceUrl,
+    this.sourceFileName,
+    required this.contentHash,
+    required this.plainText,
+    required this.normalizedText,
+    required this.createdAt,
+    required this.updatedAt,
+    this.syncStatus = PracticeBookSyncStatus.localOnly,
+    this.remoteObjectKey,
+    this.isActive = true,
+  });
+
+  factory PracticeBook.create({
+    required String id,
+    required String practiceTitle,
+    required String title,
+    required PracticeBookSourceType sourceType,
+    String? sourceUrl,
+    String? sourceFileName,
+    required String plainText,
+    String? remoteObjectKey,
+    PracticeBookSyncStatus syncStatus = PracticeBookSyncStatus.pendingUpload,
+  }) {
+    final normalizedText = PracticeBookText.normalizeForMatching(plainText);
+    final now = DateTime.now();
+    return PracticeBook(
+      id: id,
+      practiceTitle: practiceTitle,
+      title: title,
+      sourceType: sourceType,
+      sourceUrl: sourceUrl,
+      sourceFileName: sourceFileName,
+      contentHash: PracticeBookText.sha256Of(plainText),
+      plainText: plainText,
+      normalizedText: normalizedText,
+      createdAt: now,
+      updatedAt: now,
+      syncStatus: syncStatus,
+      remoteObjectKey: remoteObjectKey,
+      isActive: true,
+    );
+  }
+
+  factory PracticeBook.fromMap(Map<String, dynamic> map) {
+    return PracticeBook(
+      id: map['id'].toString(),
+      practiceTitle: (map['practice_title'] ?? map['practiceTitle'] ?? '')
+          .toString(),
+      title: (map['title'] ?? '').toString(),
+      sourceType: practiceBookSourceTypeFromString(
+        (map['source_type'] ?? map['sourceType'])?.toString(),
+      ),
+      sourceUrl: _emptyToNull(map['source_url'] ?? map['sourceUrl']),
+      sourceFileName: _emptyToNull(
+        map['source_file_name'] ?? map['sourceFileName'],
+      ),
+      contentHash: (map['content_hash'] ?? map['contentHash'] ?? '').toString(),
+      plainText: (map['plain_text'] ?? map['plainText'] ?? '').toString(),
+      normalizedText:
+          (map['normalized_text'] ??
+                  map['normalizedText'] ??
+                  PracticeBookText.normalizeForMatching(
+                    (map['plain_text'] ?? map['plainText'] ?? '').toString(),
+                  ))
+              .toString(),
+      createdAt:
+          DateTime.tryParse(
+            (map['created_at'] ?? map['createdAt'] ?? '').toString(),
+          ) ??
+          DateTime.now(),
+      updatedAt:
+          DateTime.tryParse(
+            (map['updated_at'] ?? map['updatedAt'] ?? '').toString(),
+          ) ??
+          DateTime.now(),
+      syncStatus: practiceBookSyncStatusFromString(
+        (map['sync_status'] ?? map['syncStatus'])?.toString(),
+      ),
+      remoteObjectKey: _emptyToNull(
+        map['remote_object_key'] ?? map['remoteObjectKey'],
+      ),
+      isActive:
+          map['is_active'] == true ||
+          map['is_active'] == 1 ||
+          map['isActive'] == true ||
+          map['isActive'] == 1,
+    );
+  }
+
+  factory PracticeBook.fromJson(Map<String, dynamic> json) {
+    return PracticeBook.fromMap(json);
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'practice_title': practiceTitle,
+      'title': title,
+      'source_type': sourceType.name,
+      'source_url': sourceUrl,
+      'source_file_name': sourceFileName,
+      'content_hash': contentHash,
+      'plain_text': plainText,
+      'normalized_text': normalizedText,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+      'sync_status': syncStatus.name,
+      'remote_object_key': remoteObjectKey,
+      'is_active': isActive ? 1 : 0,
+    };
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'practiceTitle': practiceTitle,
+    'title': title,
+    'sourceType': sourceType.name,
+    'sourceUrl': sourceUrl,
+    'sourceFileName': sourceFileName,
+    'contentHash': contentHash,
+    'plainText': plainText,
+    'normalizedText': normalizedText,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'syncStatus': syncStatus.name,
+    'remoteObjectKey': remoteObjectKey,
+    'isActive': isActive,
+  };
+
+  PracticeBook copyWith({
+    String? id,
+    String? practiceTitle,
+    String? title,
+    PracticeBookSourceType? sourceType,
+    String? sourceUrl,
+    String? sourceFileName,
+    String? contentHash,
+    String? plainText,
+    String? normalizedText,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    PracticeBookSyncStatus? syncStatus,
+    String? remoteObjectKey,
+    bool? isActive,
+  }) {
+    return PracticeBook(
+      id: id ?? this.id,
+      practiceTitle: practiceTitle ?? this.practiceTitle,
+      title: title ?? this.title,
+      sourceType: sourceType ?? this.sourceType,
+      sourceUrl: sourceUrl ?? this.sourceUrl,
+      sourceFileName: sourceFileName ?? this.sourceFileName,
+      contentHash: contentHash ?? this.contentHash,
+      plainText: plainText ?? this.plainText,
+      normalizedText: normalizedText ?? this.normalizedText,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      syncStatus: syncStatus ?? this.syncStatus,
+      remoteObjectKey: remoteObjectKey ?? this.remoteObjectKey,
+      isActive: isActive ?? this.isActive,
+    );
+  }
+
+  static String? _emptyToNull(dynamic value) {
+    final text = value?.toString();
+    if (text == null || text.trim().isEmpty) return null;
+    return text;
+  }
+}
+
+class PracticeBookText {
+  static String normalizeForMatching(String text) {
+    return text
+        .replaceAll(RegExp(r'<[^>]+>'), ' ')
+        .replaceAll(RegExp(r'[\u0000-\u001f]'), ' ')
+        .replaceAll(RegExp(r'\s+'), '')
+        .trim();
+  }
+
+  static String normalizePlainText(String text) {
+    return text
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\r', '\n')
+        .replaceAll(RegExp(r'[ \t]+\n'), '\n')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+  }
+
+  static String sha256Of(String text) {
+    return sha256.convert(utf8.encode(text)).toString();
+  }
+
+  static String titleFromText(String text, {String fallback = '功课本'}) {
+    final lines = text
+        .split('\n')
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .toList();
+    if (lines.isEmpty) return fallback;
+    final first = lines.first.replaceAll(RegExp(r'^[#>\s]+'), '').trim();
+    if (first.isEmpty) return fallback;
+    return first.length > 32 ? first.substring(0, 32) : first;
+  }
+}

--- a/fabushi/lib/screens/meditation_room_screen.dart
+++ b/fabushi/lib/screens/meditation_room_screen.dart
@@ -6,18 +6,23 @@ import 'package:provider/provider.dart';
 import 'package:flutter_volume_controller/flutter_volume_controller.dart';
 import '../models/auth_model.dart';
 import '../models/meditation_practice_model.dart';
+import '../models/practice_book_model.dart';
 import '../models/sutra_model.dart';
 import '../services/practice_stats_service.dart';
 import '../services/meditation_session_manager.dart';
 import '../services/achievement_system.dart';
+import '../services/practice_book_service.dart';
+import '../services/zen_recitation_counter_service.dart';
 import 'buddha_model_screen.dart';
 import 'sutra_reader_screen.dart';
+import '../features/video_feed/presentation/view/widgets/video_feed_view_full_text_reader.dart';
 import '../services/online_counter_service.dart';
 import '../widgets/achievement_popup.dart';
 import '../widgets/online_counter_widget.dart';
 import '../widgets/practice_selection_sheet.dart';
 import '../widgets/practice_leaderboard_sheet.dart';
 import '../widgets/reflection_dialog.dart';
+import '../widgets/practice_book_sheet.dart';
 import '../widgets/zen_room_2d_elements.dart';
 
 /// 禅室修行界面 - 零摩擦版本
@@ -45,11 +50,14 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
   final _sessionManager = MeditationSessionManager();
   final _achievementSystem = AchievementSystem();
   final _onlineCounterService = OnlineCounterService();
+  final _practiceBookService = PracticeBookService.instance;
+  final _recitationCounter = ZenRecitationCounterService();
 
   // ========== 状态变量 ==========
   bool _isCircumambulating = false;
   bool _isInitialized = false;
   bool _isPageVisible = false; // 追踪页面是否可见
+  PracticeBook? _activePracticeBook;
 
   // ========== 动画控制器 ==========
   late AnimationController _incenseController;
@@ -83,6 +91,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
     );
 
     _incenseController.addListener(_onIncenseProgressChanged);
+    _recitationCounter.addListener(_onRecitationCounterChanged);
 
     // 初始化
     _initialize();
@@ -94,6 +103,8 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
       _sessionManager.loadPreferences(),
       _achievementSystem.loadData(),
     ]);
+    await _loadActivePracticeBook();
+    await _recitationCounter.prepare(_activePracticeBook);
 
     // 初始化音量监听（用于念诵计数）
     _initVolumeListener();
@@ -116,9 +127,37 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
     // 启动时不主动弹出功课输入，等用户点击开始修行或功课按钮再提示。
   }
 
+  void _onRecitationCounterChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _loadActivePracticeBook() async {
+    final practice = _sessionManager.lockedPractice;
+    if (practice == null) {
+      _activePracticeBook = null;
+      return;
+    }
+    _activePracticeBook = await _practiceBookService.getActiveBook(
+      practice.title,
+    );
+  }
+
   /// 打开经文阅读界面
   void _openSutraReader() {
     final practice = _sessionManager.lockedPractice;
+    final book = _activePracticeBook;
+    if (book != null && book.plainText.isNotEmpty) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => VideoFeedViewFullTextReader(
+            bookTitle: book.title,
+            fullText: book.plainText,
+          ),
+        ),
+      );
+      return;
+    }
     if (practice != null && !practice.filePath.startsWith('manual:')) {
       openSutraReader(
         context,
@@ -140,9 +179,11 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
     if (!visible && _sessionManager.isInSession) {
       // 离开禅室页面时暂停计时（但不结束）
       _sessionManager.pauseSession();
+      _recitationCounter.stop();
     } else if (visible && _sessionManager.isInSession) {
       // 重新进入禅室页面时恢复计时
       _sessionManager.resumeSession();
+      _startOfflineRecitationCounter();
     }
   }
 
@@ -188,8 +229,10 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
         );
         showPracticeSelectionSheet(
           context,
-          onSelected: () {
+          onSelected: () async {
             // 功课选择完成后刷新界面
+            await _loadActivePracticeBook();
+            await _recitationCounter.prepare(_activePracticeBook);
             if (mounted) setState(() {});
           },
         );
@@ -209,9 +252,11 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
     if (!mounted || !_isPageVisible) return;
 
     // 使用锁定的功课开始
+    await _loadActivePracticeBook();
     await _sessionManager.instantStart(
       sutra: _sessionManager.lockedPractice?.title,
     );
+    await _startOfflineRecitationCounter();
 
     // 触发开始成就
     await _achievementSystem.onSessionStart();
@@ -226,6 +271,15 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
     _onlineCounterService.joinActivity('zen_room');
 
     if (mounted) setState(() {});
+  }
+
+  Future<void> _startOfflineRecitationCounter() async {
+    if (!_sessionManager.isInSession) return;
+    await _recitationCounter.start(
+      book: _activePracticeBook,
+      onCount: () => _sessionManager.incrementChant(),
+      onUndoCount: () => _sessionManager.decrementChant(),
+    );
   }
 
   bool _ensureCloudRecordingReady() {
@@ -294,6 +348,8 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _achievementSubscription?.cancel();
+    _recitationCounter.removeListener(_onRecitationCounterChanged);
+    _recitationCounter.stop();
     _incenseController.removeListener(_onIncenseProgressChanged);
     _incenseController.dispose();
     _pulseController.dispose();
@@ -305,6 +361,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
 
   /// 结束修行并同步数据
   Future<void> _endMeditation() async {
+    await _recitationCounter.stop();
     final result = await _sessionManager.endSession();
     _incenseController.stop();
     _incenseController.reset();
@@ -681,6 +738,16 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                   style: TextStyle(color: Colors.black),
                 ),
               ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context);
+                _showPracticeBookSheet();
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFD4AF37),
+              ),
+              child: const Text('功课本', style: TextStyle(color: Colors.black)),
+            ),
           ],
         ),
       );
@@ -689,11 +756,33 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
       showPracticeSelectionSheet(
         context,
         required: true, // 不可取消
-        onSelected: () {
+        onSelected: () async {
+          await _loadActivePracticeBook();
+          await _recitationCounter.prepare(_activePracticeBook);
           if (mounted) setState(() {});
         },
       );
     }
+  }
+
+  Future<void> _showPracticeBookSheet() async {
+    final practice = _sessionManager.lockedPractice;
+    if (practice == null) {
+      _showPracticeSelection();
+      return;
+    }
+    await PracticeBookSheet.show(
+      context,
+      practiceTitle: practice.title,
+      onChanged: (book) {
+        _activePracticeBook = book;
+        unawaited(_recitationCounter.prepare(book));
+        if (mounted) setState(() {});
+      },
+    );
+    await _loadActivePracticeBook();
+    await _recitationCounter.prepare(_activePracticeBook);
+    if (mounted) setState(() {});
   }
 
   void _showManualInput() {
@@ -781,7 +870,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                       ? practice == null ||
                                 practice.filePath.startsWith('manual:')
                             ? _showPracticeSelection
-                            : _openSutraReader
+                            : _showPracticeBookSheet
                       : null,
                 ),
               ),
@@ -910,7 +999,7 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                     height: bookHeight,
                     onTap: opensSelection
                         ? _showPracticeSelection
-                        : _openSutraReader,
+                        : _showPracticeBookSheet,
                   ),
                 ),
               ),
@@ -1139,9 +1228,175 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
               ),
             ),
           ),
+          const SizedBox(height: 14),
+          _buildRecitationStatus(),
         ],
       ),
     );
+  }
+
+  Widget _buildRecitationStatus() {
+    final status = _recitationCounter.status;
+    final progress = _recitationCounter.matchProgress.clamp(0.0, 1.0);
+    final showProgress =
+        status == ZenRecitationStatus.listening ||
+        status == ZenRecitationStatus.ready ||
+        status == ZenRecitationStatus.starting;
+    final recognizedText = _recitationCounter.recognizedText;
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 320),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.32),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: Colors.white12),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  _recitationStatusIcon(status),
+                  color: _recitationStatusColor(status),
+                  size: 18,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    _recitationCounter.statusMessage,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(color: Colors.white70, fontSize: 12),
+                  ),
+                ),
+                Switch.adaptive(
+                  value: _recitationCounter.autoEnabled,
+                  activeThumbColor: const Color(0xFFD4AF37),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  onChanged: (value) async {
+                    _recitationCounter.setAutoEnabled(value);
+                    if (value && _sessionManager.isInSession) {
+                      await _startOfflineRecitationCounter();
+                    }
+                    if (mounted) setState(() {});
+                  },
+                ),
+              ],
+            ),
+            if (showProgress) ...[
+              const SizedBox(height: 8),
+              LinearProgressIndicator(
+                value: progress <= 0 ? null : progress,
+                minHeight: 4,
+                color: const Color(0xFFD4AF37),
+                backgroundColor: Colors.white12,
+              ),
+            ],
+            if (recognizedText.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  recognizedText,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(color: Colors.white38, fontSize: 11),
+                ),
+              ),
+            ],
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                Expanded(
+                  child: _buildCounterAction(
+                    icon: Icons.add,
+                    label: '+1',
+                    onTap: _onTapCount,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _buildCounterAction(
+                    icon: Icons.undo,
+                    label: '撤销',
+                    enabled: _recitationCounter.canUndo,
+                    onTap: () {
+                      _recitationCounter.undoLastAutoCount();
+                      if (mounted) setState(() {});
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCounterAction({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+    bool enabled = true,
+  }) {
+    return Tooltip(
+      message: label,
+      child: GestureDetector(
+        onTap: enabled ? onTap : null,
+        child: Opacity(
+          opacity: enabled ? 1 : 0.42,
+          child: Container(
+            height: 38,
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.10),
+              borderRadius: BorderRadius.circular(19),
+              border: Border.all(color: Colors.white12),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon, color: Colors.white70, size: 17),
+                const SizedBox(width: 6),
+                Text(
+                  label,
+                  style: const TextStyle(color: Colors.white70, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _recitationStatusIcon(ZenRecitationStatus status) {
+    return switch (status) {
+      ZenRecitationStatus.listening => Icons.graphic_eq,
+      ZenRecitationStatus.ready => Icons.offline_bolt,
+      ZenRecitationStatus.starting => Icons.mic,
+      ZenRecitationStatus.missingBook => Icons.menu_book_outlined,
+      ZenRecitationStatus.missingModel => Icons.download,
+      ZenRecitationStatus.disabled => Icons.mic_off,
+      ZenRecitationStatus.error => Icons.error_outline,
+      ZenRecitationStatus.stopped => Icons.pause_circle_outline,
+    };
+  }
+
+  Color _recitationStatusColor(ZenRecitationStatus status) {
+    return switch (status) {
+      ZenRecitationStatus.listening ||
+      ZenRecitationStatus.ready ||
+      ZenRecitationStatus.starting => const Color(0xFFD4AF37),
+      ZenRecitationStatus.error => Colors.redAccent,
+      ZenRecitationStatus.missingBook ||
+      ZenRecitationStatus.missingModel => Colors.orangeAccent,
+      ZenRecitationStatus.disabled ||
+      ZenRecitationStatus.stopped => Colors.white54,
+    };
   }
 
   Widget _buildBottomControls() {

--- a/fabushi/lib/services/meditation_session_manager.dart
+++ b/fabushi/lib/services/meditation_session_manager.dart
@@ -287,7 +287,15 @@ class MeditationSessionManager extends ChangeNotifier {
 
   /// 增加念诵计数
   void incrementChant({int count = 1}) {
-    _chantCount += count;
+    final next = _chantCount + count;
+    _chantCount = next < 0 ? 0 : next;
+    notifyListeners();
+  }
+
+  /// 撤销最近一次念诵计数
+  void decrementChant({int count = 1}) {
+    final next = _chantCount - count;
+    _chantCount = next < 0 ? 0 : next;
     notifyListeners();
   }
 

--- a/fabushi/lib/services/offline_asr_model_service.dart
+++ b/fabushi/lib/services/offline_asr_model_service.dart
@@ -1,0 +1,2 @@
+export 'offline_asr_model_service_native.dart'
+    if (dart.library.html) 'offline_asr_model_service_stub.dart';

--- a/fabushi/lib/services/offline_asr_model_service_native.dart
+++ b/fabushi/lib/services/offline_asr_model_service_native.dart
@@ -1,0 +1,277 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+import '../core/config/app_config.dart';
+
+enum OfflineAsrModelStatus {
+  unknown,
+  notInstalled,
+  downloading,
+  installed,
+  error,
+}
+
+class OfflineAsrModelFile {
+  final String name;
+  final String url;
+  final String? sha256;
+  final int minBytes;
+
+  const OfflineAsrModelFile({
+    required this.name,
+    required this.url,
+    this.sha256,
+    this.minBytes = 1024,
+  });
+
+  factory OfflineAsrModelFile.fromJson(Map<String, dynamic> json) {
+    return OfflineAsrModelFile(
+      name: json['name'].toString(),
+      url: json['url'].toString(),
+      sha256: json['sha256']?.toString(),
+      minBytes: json['minBytes'] is int ? json['minBytes'] as int : 1024,
+    );
+  }
+}
+
+class OfflineAsrModelManifest {
+  final String id;
+  final String version;
+  final List<OfflineAsrModelFile> files;
+
+  const OfflineAsrModelManifest({
+    required this.id,
+    required this.version,
+    required this.files,
+  });
+
+  factory OfflineAsrModelManifest.fromJson(Map<String, dynamic> json) {
+    final files = (json['files'] as List<dynamic>? ?? [])
+        .map(
+          (item) => OfflineAsrModelFile.fromJson(
+            Map<String, dynamic>.from(item as Map),
+          ),
+        )
+        .toList();
+    return OfflineAsrModelManifest(
+      id: json['id']?.toString() ?? 'streaming-paraformer-zh-en',
+      version: json['version']?.toString() ?? '1',
+      files: files,
+    );
+  }
+}
+
+class OfflineAsrModelService extends ChangeNotifier {
+  static OfflineAsrModelService? _instance;
+  static OfflineAsrModelService get instance =>
+      _instance ??= OfflineAsrModelService._();
+  OfflineAsrModelService._();
+
+  OfflineAsrModelStatus _status = OfflineAsrModelStatus.unknown;
+  double _progress = 0;
+  String _statusMessage = '尚未检查离线语音模型';
+
+  OfflineAsrModelStatus get status => _status;
+  double get progress => _progress;
+  String get statusMessage => _statusMessage;
+
+  static const _modelId = 'streaming-paraformer-zh-en';
+  static const _requiredFiles = [
+    'encoder.int8.onnx',
+    'decoder.int8.onnx',
+    'tokens.txt',
+  ];
+
+  Future<Directory> _modelDirectory() async {
+    final appDir = await getApplicationDocumentsDirectory();
+    return Directory('${appDir.path}/sherpa-onnx-models/$_modelId');
+  }
+
+  Future<bool> refreshStatus() async {
+    final dir = await _modelDirectory();
+    final installed = await _isInstalled(dir);
+    _status = installed
+        ? OfflineAsrModelStatus.installed
+        : OfflineAsrModelStatus.notInstalled;
+    _progress = installed ? 1 : 0;
+    _statusMessage = installed ? '离线语音模型已就绪' : '请先下载离线语音模型';
+    notifyListeners();
+    return installed;
+  }
+
+  Future<String?> getInstalledModelDir() async {
+    final dir = await _modelDirectory();
+    if (await _isInstalled(dir)) return dir.path;
+    await refreshStatus();
+    return null;
+  }
+
+  Future<String?> downloadModel() async {
+    final manifest = await _loadManifest();
+    final dir = await _modelDirectory();
+    await dir.create(recursive: true);
+
+    _status = OfflineAsrModelStatus.downloading;
+    _progress = 0;
+    _statusMessage = '正在下载离线语音模型...';
+    notifyListeners();
+
+    try {
+      for (var i = 0; i < manifest.files.length; i++) {
+        final file = manifest.files[i];
+        final target = File('${dir.path}/${file.name}');
+        await _downloadFile(file, target);
+        final baseProgress = (i + 1) / manifest.files.length;
+        _progress = baseProgress.clamp(0, 1);
+        _statusMessage = '离线语音模型下载中 ${(_progress * 100).round()}%';
+        notifyListeners();
+      }
+
+      if (!await _isInstalled(dir)) {
+        throw StateError('模型文件不完整');
+      }
+
+      _status = OfflineAsrModelStatus.installed;
+      _progress = 1;
+      _statusMessage = '离线语音模型已就绪';
+      notifyListeners();
+      return dir.path;
+    } catch (e) {
+      _status = OfflineAsrModelStatus.error;
+      _statusMessage = '离线语音模型下载失败: $e';
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<void> clearModel() async {
+    final dir = await _modelDirectory();
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+    await refreshStatus();
+  }
+
+  Future<OfflineAsrModelManifest> _loadManifest() async {
+    final manifestUri = AppConfig.buildBackendUri(
+      '/api/meditation/asr-model-manifest',
+    );
+
+    try {
+      final response = await http
+          .get(manifestUri)
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode == 200) {
+        return OfflineAsrModelManifest.fromJson(
+          Map<String, dynamic>.from(jsonDecode(response.body) as Map),
+        );
+      }
+    } catch (e) {
+      debugPrint('[OfflineAsrModel] 使用默认 manifest: $e');
+    }
+
+    return _fallbackManifest();
+  }
+
+  OfflineAsrModelManifest _fallbackManifest() {
+    String r2Url(String fileName) {
+      final key = 'asr-models/$_modelId/$fileName';
+      return AppConfig.buildBackendUrl('/r2', queryParameters: {'file': key});
+    }
+
+    return OfflineAsrModelManifest(
+      id: _modelId,
+      version: 'fallback',
+      files: [
+        OfflineAsrModelFile(
+          name: 'encoder.int8.onnx',
+          url: r2Url('encoder.int8.onnx'),
+          minBytes: 1024 * 1024,
+        ),
+        OfflineAsrModelFile(
+          name: 'decoder.int8.onnx',
+          url: r2Url('decoder.int8.onnx'),
+          minBytes: 1024 * 512,
+        ),
+        OfflineAsrModelFile(
+          name: 'tokens.txt',
+          url: r2Url('tokens.txt'),
+          minBytes: 1024,
+        ),
+      ],
+    );
+  }
+
+  Future<void> _downloadFile(OfflineAsrModelFile modelFile, File target) async {
+    final request = http.Request('GET', Uri.parse(modelFile.url));
+    final response = await request.send().timeout(const Duration(minutes: 5));
+    if (response.statusCode != 200) {
+      throw HttpException('HTTP ${response.statusCode}: ${modelFile.name}');
+    }
+
+    final temp = File('${target.path}.downloading');
+    final sink = temp.openWrite();
+    final digestSink = AccumulatorSink<Digest>();
+    final byteSink = sha256.startChunkedConversion(digestSink);
+    var received = 0;
+
+    try {
+      await for (final chunk in response.stream) {
+        received += chunk.length;
+        sink.add(chunk);
+        byteSink.add(chunk);
+      }
+    } finally {
+      await sink.close();
+      byteSink.close();
+    }
+
+    if (received < modelFile.minBytes) {
+      if (await temp.exists()) {
+        await temp.delete();
+      }
+      throw StateError('${modelFile.name} 文件过小');
+    }
+
+    final expectedSha = modelFile.sha256;
+    if (expectedSha != null && expectedSha.isNotEmpty) {
+      final actualSha = digestSink.events.single.toString();
+      if (actualSha.toLowerCase() != expectedSha.toLowerCase()) {
+        if (await temp.exists()) {
+          await temp.delete();
+        }
+        throw StateError('${modelFile.name} 校验失败');
+      }
+    }
+
+    if (await target.exists()) {
+      await target.delete();
+    }
+    await temp.rename(target.path);
+  }
+
+  Future<bool> _isInstalled(Directory dir) async {
+    for (final fileName in _requiredFiles) {
+      final file = File('${dir.path}/$fileName');
+      if (!await file.exists()) return false;
+      final minSize = fileName.endsWith('.onnx') ? 1024 * 512 : 1024;
+      if (await file.length() < minSize) return false;
+    }
+    return true;
+  }
+}
+
+class AccumulatorSink<T> implements Sink<T> {
+  final List<T> events = [];
+
+  @override
+  void add(T data) => events.add(data);
+
+  @override
+  void close() {}
+}

--- a/fabushi/lib/services/offline_asr_model_service_stub.dart
+++ b/fabushi/lib/services/offline_asr_model_service_stub.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+
+enum OfflineAsrModelStatus {
+  unknown,
+  notInstalled,
+  downloading,
+  installed,
+  error,
+}
+
+class OfflineAsrModelService extends ChangeNotifier {
+  static OfflineAsrModelService? _instance;
+  static OfflineAsrModelService get instance =>
+      _instance ??= OfflineAsrModelService._();
+  OfflineAsrModelService._();
+
+  OfflineAsrModelStatus get status => OfflineAsrModelStatus.notInstalled;
+  double get progress => 0;
+  String get statusMessage => 'Web 暂不支持离线语音模型';
+
+  Future<bool> refreshStatus() async => false;
+  Future<String?> getInstalledModelDir() async => null;
+  Future<String?> downloadModel() async => null;
+  Future<void> clearModel() async {}
+}

--- a/fabushi/lib/services/practice_book_service.dart
+++ b/fabushi/lib/services/practice_book_service.dart
@@ -1,0 +1,2 @@
+export 'practice_book_service_native.dart'
+    if (dart.library.html) 'practice_book_service_stub.dart';

--- a/fabushi/lib/services/practice_book_service_native.dart
+++ b/fabushi/lib/services/practice_book_service_native.dart
@@ -1,0 +1,383 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:gbk_codec/gbk_codec.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:uuid/uuid.dart';
+
+import '../core/config/app_config.dart';
+import '../models/practice_book_model.dart';
+import 'app_settings.dart';
+
+class PracticeBookImportResult {
+  final PracticeBook? book;
+  final String? error;
+  final bool needsWebViewFallback;
+
+  const PracticeBookImportResult.success(this.book)
+    : error = null,
+      needsWebViewFallback = false;
+
+  const PracticeBookImportResult.failure(
+    this.error, {
+    this.needsWebViewFallback = false,
+  }) : book = null;
+
+  bool get isSuccess => book != null;
+}
+
+class PracticeBookService {
+  static PracticeBookService? _instance;
+  static PracticeBookService get instance =>
+      _instance ??= PracticeBookService._();
+  PracticeBookService._();
+
+  Database? _database;
+
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+    final dbPath = await getDatabasesPath();
+    final dbFile = path.join(dbPath, 'practice_books.db');
+    _database = await openDatabase(
+      dbFile,
+      version: 1,
+      onCreate: (db, _) async {
+        await db.execute('''
+          CREATE TABLE practice_books (
+            id TEXT PRIMARY KEY,
+            practice_title TEXT NOT NULL,
+            title TEXT NOT NULL,
+            source_type TEXT NOT NULL,
+            source_url TEXT,
+            source_file_name TEXT,
+            content_hash TEXT NOT NULL,
+            plain_text TEXT NOT NULL,
+            normalized_text TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            sync_status TEXT NOT NULL,
+            remote_object_key TEXT,
+            is_active INTEGER NOT NULL DEFAULT 1
+          )
+        ''');
+        await db.execute(
+          'CREATE INDEX idx_practice_books_practice_title ON practice_books(practice_title)',
+        );
+      },
+    );
+    return _database!;
+  }
+
+  Future<List<PracticeBook>> listBooks({String? practiceTitle}) async {
+    final db = await database;
+    final maps = await db.query(
+      'practice_books',
+      where: practiceTitle == null ? null : 'practice_title = ?',
+      whereArgs: practiceTitle == null ? null : [practiceTitle],
+      orderBy: 'updated_at DESC',
+    );
+    return maps.map(PracticeBook.fromMap).toList();
+  }
+
+  Future<PracticeBook?> getActiveBook(String practiceTitle) async {
+    final db = await database;
+    final maps = await db.query(
+      'practice_books',
+      where: 'practice_title = ? AND is_active = 1',
+      whereArgs: [practiceTitle],
+      orderBy: 'updated_at DESC',
+      limit: 1,
+    );
+    if (maps.isEmpty) return null;
+    return PracticeBook.fromMap(maps.first);
+  }
+
+  Future<PracticeBook> saveBook(
+    PracticeBook book, {
+    bool syncCloud = true,
+  }) async {
+    final db = await database;
+    await db.update(
+      'practice_books',
+      {'is_active': 0},
+      where: 'practice_title = ?',
+      whereArgs: [book.practiceTitle],
+    );
+    await db.insert(
+      'practice_books',
+      book.copyWith(isActive: true).toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
+    if (syncCloud) {
+      return await _uploadBookToCloud(book.copyWith(isActive: true));
+    }
+    return book.copyWith(isActive: true);
+  }
+
+  Future<void> deleteBook(String id, {bool syncCloud = true}) async {
+    final db = await database;
+    await db.delete('practice_books', where: 'id = ?', whereArgs: [id]);
+
+    if (!syncCloud) return;
+    final headers = await _authHeaders();
+    if (headers == null) return;
+    try {
+      final baseUrl = await AppSettings.getBackendUrl();
+      await http.delete(
+        Uri.parse(
+          '$baseUrl/api/meditation/practice-books',
+        ).replace(queryParameters: {'id': id}),
+        headers: headers,
+      );
+    } catch (e) {
+      debugPrint('[PracticeBook] 云端删除失败: $e');
+    }
+  }
+
+  Future<PracticeBookImportResult> importFile({
+    required PlatformFile file,
+    required String practiceTitle,
+  }) async {
+    try {
+      final bytes = await _readPlatformFile(file);
+      final extension = path.extension(file.name).toLowerCase();
+      final plainText = switch (extension) {
+        '.txt' || '.md' => _decodeTextBytes(bytes),
+        '.docx' => _extractDocxText(bytes),
+        '.pdf' => _extractPdfText(bytes),
+        _ => throw UnsupportedError('暂不支持 $extension 文件'),
+      };
+      final normalizedPlainText = PracticeBookText.normalizePlainText(
+        plainText,
+      );
+      if (normalizedPlainText.length < 2) {
+        return const PracticeBookImportResult.failure('未能提取到可用正文');
+      }
+
+      final title = PracticeBookText.titleFromText(
+        normalizedPlainText,
+        fallback: path.basenameWithoutExtension(file.name),
+      );
+      final book = PracticeBook.create(
+        id: const Uuid().v4(),
+        practiceTitle: practiceTitle,
+        title: title,
+        sourceType: PracticeBookSourceType.file,
+        sourceFileName: file.name,
+        plainText: normalizedPlainText,
+      );
+      return PracticeBookImportResult.success(await saveBook(book));
+    } catch (e) {
+      return PracticeBookImportResult.failure('导入文件失败: $e');
+    }
+  }
+
+  Future<PracticeBookImportResult> importUrl({
+    required String url,
+    required String practiceTitle,
+  }) async {
+    final normalizedUrl = url.trim();
+    if (!normalizedUrl.startsWith('http://') &&
+        !normalizedUrl.startsWith('https://')) {
+      return const PracticeBookImportResult.failure('请输入 http/https 链接');
+    }
+
+    final headers = await _authHeaders();
+    if (headers == null) {
+      return const PracticeBookImportResult.failure('请先登录后再同步链接功课本');
+    }
+
+    try {
+      final baseUrl = await AppSettings.getBackendUrl();
+      final response = await http.post(
+        Uri.parse('$baseUrl/api/meditation/practice-books/import-url'),
+        headers: headers,
+        body: jsonEncode({
+          'url': normalizedUrl,
+          'practiceTitle': practiceTitle,
+        }),
+      );
+
+      final data = jsonDecode(response.body);
+      if (response.statusCode != 200 || data['success'] != true) {
+        final needsFallback =
+            data['needsWebViewFallback'] == true ||
+            normalizedUrl.contains('mp.weixin.qq.com');
+        return PracticeBookImportResult.failure(
+          data['error']?.toString() ?? '链接解析失败',
+          needsWebViewFallback: needsFallback,
+        );
+      }
+
+      final book = PracticeBook.fromJson(
+        Map<String, dynamic>.from(data['data']['book'] as Map),
+      ).copyWith(syncStatus: PracticeBookSyncStatus.synced, isActive: true);
+      await saveBook(book, syncCloud: false);
+      return PracticeBookImportResult.success(book);
+    } catch (e) {
+      return PracticeBookImportResult.failure(
+        '链接解析失败: $e',
+        needsWebViewFallback: normalizedUrl.contains('mp.weixin.qq.com'),
+      );
+    }
+  }
+
+  Future<PracticeBook> saveExtractedWebText({
+    required String practiceTitle,
+    required String sourceUrl,
+    required String title,
+    required String plainText,
+  }) async {
+    final normalizedPlainText = PracticeBookText.normalizePlainText(plainText);
+    final book = PracticeBook.create(
+      id: const Uuid().v4(),
+      practiceTitle: practiceTitle,
+      title: title.trim().isEmpty
+          ? PracticeBookText.titleFromText(normalizedPlainText)
+          : title.trim(),
+      sourceType: PracticeBookSourceType.url,
+      sourceUrl: sourceUrl,
+      plainText: normalizedPlainText,
+    );
+    return await saveBook(book);
+  }
+
+  Future<void> syncFromCloud() async {
+    final headers = await _authHeaders();
+    if (headers == null) return;
+    try {
+      final baseUrl = await AppSettings.getBackendUrl();
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/meditation/practice-books'),
+        headers: headers,
+      );
+      if (response.statusCode != 200) return;
+      final data = jsonDecode(response.body);
+      if (data['success'] != true) return;
+      final books = (data['data']?['books'] as List<dynamic>? ?? [])
+          .map(
+            (item) =>
+                PracticeBook.fromJson(Map<String, dynamic>.from(item as Map)),
+          )
+          .toList();
+      for (final book in books) {
+        await saveBook(
+          book.copyWith(syncStatus: PracticeBookSyncStatus.synced),
+          syncCloud: false,
+        );
+      }
+    } catch (e) {
+      debugPrint('[PracticeBook] 云端同步失败: $e');
+    }
+  }
+
+  Future<PracticeBook> _uploadBookToCloud(PracticeBook book) async {
+    final headers = await _authHeaders();
+    if (headers == null) {
+      final pending = book.copyWith(
+        syncStatus: PracticeBookSyncStatus.pendingUpload,
+      );
+      await _saveLocalOnly(pending);
+      return pending;
+    }
+
+    try {
+      final baseUrl = await AppSettings.getBackendUrl();
+      final response = await http.post(
+        Uri.parse('$baseUrl/api/meditation/practice-books'),
+        headers: headers,
+        body: jsonEncode(book.toJson()),
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data['success'] == true && data['data']?['book'] is Map) {
+          final synced = PracticeBook.fromJson(
+            Map<String, dynamic>.from(data['data']['book'] as Map),
+          ).copyWith(syncStatus: PracticeBookSyncStatus.synced);
+          await _saveLocalOnly(synced);
+          return synced;
+        }
+      }
+    } catch (e) {
+      debugPrint('[PracticeBook] 云端上传失败: $e');
+    }
+
+    final failed = book.copyWith(syncStatus: PracticeBookSyncStatus.syncFailed);
+    await _saveLocalOnly(failed);
+    return failed;
+  }
+
+  Future<void> _saveLocalOnly(PracticeBook book) async {
+    final db = await database;
+    await db.insert(
+      'practice_books',
+      book.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<Map<String, String>?> _authHeaders() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString(AppConfig.tokenStorageKey);
+    if (token == null || token.isEmpty) return null;
+    return {
+      'Authorization': 'Bearer $token',
+      'Content-Type': 'application/json',
+    };
+  }
+
+  Future<List<int>> _readPlatformFile(PlatformFile file) async {
+    if (file.bytes != null) return file.bytes!;
+    final filePath = file.path;
+    if (filePath == null || filePath.isEmpty) {
+      throw StateError('无法读取文件内容');
+    }
+    return await File(filePath).readAsBytes();
+  }
+
+  String _decodeTextBytes(List<int> bytes) {
+    final utf8Text = utf8.decode(bytes, allowMalformed: true);
+    final replacementCount = '�'.allMatches(utf8Text).length;
+    if (replacementCount < 4) return utf8Text;
+    return gbk.decode(bytes);
+  }
+
+  String _extractDocxText(List<int> bytes) {
+    final archive = ZipDecoder().decodeBytes(bytes);
+    final document = archive.findFile('word/document.xml');
+    if (document == null) {
+      throw StateError('DOCX 缺少正文');
+    }
+    final xml = utf8.decode(
+      document.content as List<int>,
+      allowMalformed: true,
+    );
+    return xml
+        .replaceAll(RegExp(r'</w:p>'), '\n')
+        .replaceAll(RegExp(r'<[^>]+>'), '')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&amp;', '&');
+  }
+
+  String _extractPdfText(List<int> bytes) {
+    final raw = latin1.decode(bytes);
+    final matches = RegExp(r'\(([^()]{2,})\)\s*Tj').allMatches(raw);
+    final text = matches
+        .map((match) => match.group(1) ?? '')
+        .join('\n')
+        .replaceAll(r'\(', '(')
+        .replaceAll(r'\)', ')');
+    if (text.trim().isNotEmpty) return text;
+
+    final fallback = utf8.decode(bytes, allowMalformed: true);
+    return fallback.replaceAll(RegExp(r'[^一-龥A-Za-z0-9，。！？；：、\n ]'), ' ');
+  }
+}

--- a/fabushi/lib/services/practice_book_service_stub.dart
+++ b/fabushi/lib/services/practice_book_service_stub.dart
@@ -1,0 +1,53 @@
+import 'package:file_picker/file_picker.dart';
+
+import '../models/practice_book_model.dart';
+
+class PracticeBookImportResult {
+  final PracticeBook? book;
+  final String? error;
+  final bool needsWebViewFallback;
+
+  const PracticeBookImportResult.success(this.book)
+    : error = null,
+      needsWebViewFallback = false;
+
+  const PracticeBookImportResult.failure(
+    this.error, {
+    this.needsWebViewFallback = false,
+  }) : book = null;
+
+  bool get isSuccess => book != null;
+}
+
+class PracticeBookService {
+  static PracticeBookService? _instance;
+  static PracticeBookService get instance =>
+      _instance ??= PracticeBookService._();
+  PracticeBookService._();
+
+  Future<List<PracticeBook>> listBooks({String? practiceTitle}) async => [];
+  Future<PracticeBook?> getActiveBook(String practiceTitle) async => null;
+  Future<PracticeBook> saveBook(
+    PracticeBook book, {
+    bool syncCloud = true,
+  }) async => book;
+  Future<void> deleteBook(String id, {bool syncCloud = true}) async {}
+  Future<PracticeBookImportResult> importFile({
+    required PlatformFile file,
+    required String practiceTitle,
+  }) async => const PracticeBookImportResult.failure('Web 暂不支持功课本文件导入');
+  Future<PracticeBookImportResult> importUrl({
+    required String url,
+    required String practiceTitle,
+  }) async => const PracticeBookImportResult.failure('Web 暂不支持功课本链接导入');
+  Future<PracticeBook> saveExtractedWebText({
+    required String practiceTitle,
+    required String sourceUrl,
+    required String title,
+    required String plainText,
+  }) async {
+    throw UnsupportedError('Web 暂不支持功课本保存');
+  }
+
+  Future<void> syncFromCloud() async {}
+}

--- a/fabushi/lib/services/recitation_progress_matcher.dart
+++ b/fabushi/lib/services/recitation_progress_matcher.dart
@@ -1,0 +1,242 @@
+import 'package:lpinyin/lpinyin.dart';
+
+class RecitationMatchEvent {
+  final int countDelta;
+  final double progress;
+  final String hint;
+
+  const RecitationMatchEvent({
+    required this.countDelta,
+    required this.progress,
+    required this.hint,
+  });
+}
+
+class RecitationProgressMatcher {
+  RecitationProgressMatcher(
+    String targetText, {
+    DateTime Function()? now,
+    this.shortTokenLimit = 120,
+    this.longCompletionThreshold = 0.92,
+    this.shortCompletionThreshold = 0.78,
+    this.cooldown = const Duration(milliseconds: 1200),
+  }) : _now = now ?? DateTime.now {
+    _targetTokens = _toPinyinTokens(targetText);
+  }
+
+  final DateTime Function() _now;
+  final int shortTokenLimit;
+  final double longCompletionThreshold;
+  final double shortCompletionThreshold;
+  final Duration cooldown;
+
+  late final List<String> _targetTokens;
+  int _cursor = 0;
+  DateTime? _lastCountAt;
+  String _lastText = '';
+
+  bool get isReady => _targetTokens.isNotEmpty;
+  bool get isShortPractice => _targetTokens.length <= shortTokenLimit;
+  double get progress =>
+      _targetTokens.isEmpty ? 0 : (_cursor / _targetTokens.length).clamp(0, 1);
+
+  void reset() {
+    _cursor = 0;
+    _lastCountAt = null;
+    _lastText = '';
+  }
+
+  RecitationMatchEvent accept(
+    String recognizedText, {
+    bool isEndpoint = false,
+  }) {
+    if (_targetTokens.isEmpty) {
+      return const RecitationMatchEvent(
+        countDelta: 0,
+        progress: 0,
+        hint: '尚未加载功课本',
+      );
+    }
+
+    final incoming = _dedupeIncrement(recognizedText);
+    final tokens = _toPinyinTokens(
+      incoming.isEmpty ? recognizedText : incoming,
+    );
+    if (tokens.isEmpty) {
+      return RecitationMatchEvent(
+        countDelta: 0,
+        progress: progress,
+        hint: '等待识别正文',
+      );
+    }
+
+    if (isShortPractice) {
+      return _acceptShortPractice(tokens, isEndpoint: isEndpoint);
+    }
+
+    final match = _bestWindowMatch(tokens);
+    if (match.score >= 0.42) {
+      _cursor = _cursor > match.nextCursor ? _cursor : match.nextCursor;
+    }
+
+    if (progress >= longCompletionThreshold && _canCount()) {
+      _lastCountAt = _now();
+      _cursor = 0;
+      return const RecitationMatchEvent(
+        countDelta: 1,
+        progress: 1,
+        hint: '已识别完成一遍',
+      );
+    }
+
+    return RecitationMatchEvent(
+      countDelta: 0,
+      progress: progress,
+      hint: match.score >= 0.42 ? '正在跟随功课本' : '继续念诵',
+    );
+  }
+
+  RecitationMatchEvent _acceptShortPractice(
+    List<String> tokens, {
+    required bool isEndpoint,
+  }) {
+    final lcs = _longestCommonSubsequenceLength(tokens, _targetTokens);
+    final score = lcs / _targetTokens.length;
+    final shouldCount =
+        score >= shortCompletionThreshold &&
+        (isEndpoint || score >= 0.92) &&
+        _canCount();
+
+    if (shouldCount) {
+      _lastCountAt = _now();
+      return const RecitationMatchEvent(
+        countDelta: 1,
+        progress: 1,
+        hint: '已识别一遍',
+      );
+    }
+
+    return RecitationMatchEvent(
+      countDelta: 0,
+      progress: score.clamp(0, 1),
+      hint: score >= 0.5 ? '即将完成一遍' : '正在识别',
+    );
+  }
+
+  _WindowMatch _bestWindowMatch(List<String> tokens) {
+    final start = (_cursor - 30).clamp(0, _targetTokens.length);
+    final end = (_cursor + tokens.length + 180).clamp(0, _targetTokens.length);
+    var best = _WindowMatch(score: 0, nextCursor: 0, startCursor: _cursor);
+
+    for (var i = start; i < end; i++) {
+      final sliceEnd = (i + tokens.length + 12).clamp(0, _targetTokens.length);
+      if (sliceEnd <= i) continue;
+      final window = _targetTokens.sublist(i, sliceEnd);
+      final lcs = _longestCommonSubsequenceLength(tokens, window);
+      final score = lcs / tokens.length;
+      final nextCursor = i + lcs;
+      final isBetterScore = score > best.score + 0.000001;
+      final distance = (i - _cursor).abs();
+      final bestDistance = (best.startCursor - _cursor).abs();
+      final isForwardTie =
+          (score - best.score).abs() <= 0.000001 &&
+          (distance < bestDistance ||
+              (distance == bestDistance && nextCursor > best.nextCursor));
+      if (isBetterScore || isForwardTie) {
+        best = _WindowMatch(
+          score: score,
+          nextCursor: nextCursor,
+          startCursor: i,
+        );
+      }
+    }
+
+    return best;
+  }
+
+  bool _canCount() {
+    final last = _lastCountAt;
+    if (last == null) return true;
+    return _now().difference(last) >= cooldown;
+  }
+
+  String _dedupeIncrement(String text) {
+    final current = _normalizeChineseAndAlpha(text);
+    if (current.isEmpty) return '';
+    final previous = _lastText;
+    _lastText = current;
+
+    if (previous.isEmpty) return current;
+    if (current.startsWith(previous)) {
+      return current.substring(previous.length);
+    }
+    if (previous.startsWith(current)) return '';
+    return current;
+  }
+
+  static List<String> _toPinyinTokens(String text) {
+    final normalized = _normalizeChineseAndAlpha(text);
+    final tokens = <String>[];
+    for (final codePoint in normalized.runes) {
+      final char = String.fromCharCode(codePoint);
+      if (_isChinese(codePoint)) {
+        final pinyin = PinyinHelper.getPinyinE(
+          char,
+          defPinyin: '',
+        ).replaceAll(RegExp(r'\s+'), '').toLowerCase();
+        if (pinyin.isNotEmpty) tokens.add(pinyin);
+      } else {
+        tokens.add(char.toLowerCase());
+      }
+    }
+    return tokens;
+  }
+
+  static String _normalizeChineseAndAlpha(String text) {
+    final buffer = StringBuffer();
+    for (final codePoint in text.runes) {
+      final isAsciiAlphaNum =
+          (codePoint >= 0x30 && codePoint <= 0x39) ||
+          (codePoint >= 0x41 && codePoint <= 0x5a) ||
+          (codePoint >= 0x61 && codePoint <= 0x7a);
+      if (_isChinese(codePoint) || isAsciiAlphaNum) {
+        buffer.writeCharCode(codePoint);
+      }
+    }
+    return buffer.toString();
+  }
+
+  static bool _isChinese(int codePoint) {
+    return codePoint >= 0x4e00 && codePoint <= 0x9fff;
+  }
+
+  static int _longestCommonSubsequenceLength(List<String> a, List<String> b) {
+    if (a.isEmpty || b.isEmpty) return 0;
+    final dp = List<int>.filled(b.length + 1, 0);
+    for (var i = 1; i <= a.length; i++) {
+      var prev = 0;
+      for (var j = 1; j <= b.length; j++) {
+        final temp = dp[j];
+        if (a[i - 1] == b[j - 1]) {
+          dp[j] = prev + 1;
+        } else if (dp[j - 1] > dp[j]) {
+          dp[j] = dp[j - 1];
+        }
+        prev = temp;
+      }
+    }
+    return dp[b.length];
+  }
+}
+
+class _WindowMatch {
+  final double score;
+  final int nextCursor;
+  final int startCursor;
+
+  const _WindowMatch({
+    required this.score,
+    required this.nextCursor,
+    required this.startCursor,
+  });
+}

--- a/fabushi/lib/services/sherpa_stt_service_native.dart
+++ b/fabushi/lib/services/sherpa_stt_service_native.dart
@@ -3,10 +3,10 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:path_provider/path_provider.dart';
 
 // sherpa_onnx 仅在非 Web 平台使用
 import 'package:sherpa_onnx/sherpa_onnx.dart' as sherpa;
+import 'offline_asr_model_service.dart';
 
 /// 语音识别服务
 ///
@@ -131,10 +131,11 @@ class SherpaSTTService {
 
       onProgress?.call('正在准备语音识别引擎...');
 
-      // 获取模型目录
-      _modelDir = await _prepareModel();
+      // 获取已安装的本地模型目录。模型包由 OfflineAsrModelService 下载和校验，
+      // 避免把大模型直接打进安装包，也避免 assets 缺文件时初始化崩溃。
+      _modelDir = await OfflineAsrModelService.instance.getInstalledModelDir();
       if (_modelDir == null) {
-        onError?.call('无法加载语音识别模型');
+        onError?.call('请先下载离线语音模型');
         return false;
       }
 
@@ -165,68 +166,6 @@ class SherpaSTTService {
       debugPrint('[SherpaSTT] Sherpa-ONNX 初始化失败: $e');
       onError?.call('Sherpa-ONNX 初始化失败: $e');
       return false;
-    }
-  }
-
-  /// 准备模型文件
-  Future<String?> _prepareModel() async {
-    try {
-      final appDir = await getApplicationDocumentsDirectory();
-      final modelDir = Directory(
-        '${appDir.path}/sherpa-onnx-models/streaming-paraformer-zh-en',
-      );
-
-      // 检查模型是否已存在且完整
-      if (await modelDir.exists()) {
-        final encoderFile = File('${modelDir.path}/encoder.int8.onnx');
-        if (await encoderFile.exists()) {
-          final fileSize = await encoderFile.length();
-          if (fileSize > 1024 * 1024) {
-            debugPrint('[SherpaSTT] 使用已存在的模型: ${modelDir.path}');
-            return modelDir.path;
-          } else {
-            debugPrint('[SherpaSTT] 检测到损坏的模型缓存，正在删除...');
-            await modelDir.delete(recursive: true);
-          }
-        }
-      }
-
-      // 模型不存在，从 assets 复制
-      onProgress?.call('首次使用，正在解压内置语音模型...');
-      await modelDir.create(recursive: true);
-
-      return await _copyAssetsToLocal(modelDir.path);
-    } catch (e) {
-      debugPrint('[SherpaSTT] 准备模型失败: $e');
-      return null;
-    }
-  }
-
-  /// 从 Assets 复制模型到本地
-  Future<String?> _copyAssetsToLocal(String modelDir) async {
-    try {
-      const assetPrefix = 'assets/sherpa_models/streaming-paraformer-zh-en';
-      final files = ['encoder.int8.onnx', 'decoder.int8.onnx', 'tokens.txt'];
-
-      for (int i = 0; i < files.length; i++) {
-        final fileName = files[i];
-        debugPrint('[SherpaSTT] 复制 $fileName...');
-
-        final byteData = await rootBundle.load('$assetPrefix/$fileName');
-        final file = File('$modelDir/$fileName');
-        await file.writeAsBytes(
-          byteData.buffer.asUint8List(
-            byteData.offsetInBytes,
-            byteData.lengthInBytes,
-          ),
-        );
-      }
-
-      debugPrint('[SherpaSTT] 模型复制完成: $modelDir');
-      return modelDir;
-    } catch (e) {
-      debugPrint('[SherpaSTT] 复制模型失败: $e');
-      return null;
     }
   }
 

--- a/fabushi/lib/services/zen_recitation_counter_service.dart
+++ b/fabushi/lib/services/zen_recitation_counter_service.dart
@@ -1,0 +1,2 @@
+export 'zen_recitation_counter_service_native.dart'
+    if (dart.library.html) 'zen_recitation_counter_service_stub.dart';

--- a/fabushi/lib/services/zen_recitation_counter_service_native.dart
+++ b/fabushi/lib/services/zen_recitation_counter_service_native.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/practice_book_model.dart';
+import 'audio_stream_service.dart';
+import 'offline_asr_model_service.dart';
+import 'recitation_progress_matcher.dart';
+import 'sherpa_stt_service.dart';
+
+enum ZenRecitationStatus {
+  disabled,
+  missingBook,
+  missingModel,
+  ready,
+  starting,
+  listening,
+  stopped,
+  error,
+}
+
+class ZenRecitationCounterService extends ChangeNotifier {
+  final AudioStreamService _audioService = AudioStreamService.instance;
+  final SherpaSTTService _sttService = SherpaSTTService.instance;
+  RecitationProgressMatcher? _matcher;
+  StreamSubscription<Uint8List>? _audioSubscription;
+  VoidCallback? _onCount;
+  VoidCallback? _onUndoCount;
+
+  ZenRecitationStatus _status = ZenRecitationStatus.stopped;
+  String _statusMessage = '自动识别未启动';
+  String _recognizedText = '';
+  double _matchProgress = 0;
+  bool _autoEnabled = true;
+  int _autoCountStack = 0;
+
+  ZenRecitationStatus get status => _status;
+  String get statusMessage => _statusMessage;
+  String get recognizedText => _recognizedText;
+  double get matchProgress => _matchProgress;
+  bool get autoEnabled => _autoEnabled;
+  bool get canUndo => _autoCountStack > 0;
+
+  void setAutoEnabled(bool value) {
+    if (_autoEnabled == value) return;
+    _autoEnabled = value;
+    if (!value) {
+      stop();
+      _status = ZenRecitationStatus.disabled;
+      _statusMessage = '自动识别已关闭';
+    } else {
+      _status = ZenRecitationStatus.stopped;
+      _statusMessage = '自动识别待启动';
+    }
+    notifyListeners();
+  }
+
+  Future<void> prepare(PracticeBook? book) async {
+    if (!_autoEnabled) {
+      _status = ZenRecitationStatus.disabled;
+      _statusMessage = '自动识别已关闭';
+      notifyListeners();
+      return;
+    }
+    if (book == null || book.normalizedText.isEmpty) {
+      _status = ZenRecitationStatus.missingBook;
+      _statusMessage = '请先添加功课本';
+      notifyListeners();
+      return;
+    }
+    final modelReady = await OfflineAsrModelService.instance.refreshStatus();
+    _status = modelReady
+        ? ZenRecitationStatus.ready
+        : ZenRecitationStatus.missingModel;
+    _statusMessage = modelReady ? '离线识别已就绪' : '请先下载离线语音模型';
+    notifyListeners();
+  }
+
+  Future<void> start({
+    required PracticeBook? book,
+    required VoidCallback onCount,
+    required VoidCallback onUndoCount,
+  }) async {
+    _onCount = onCount;
+    _onUndoCount = onUndoCount;
+    _autoCountStack = 0;
+    _recognizedText = '';
+    _matchProgress = 0;
+
+    if (!_autoEnabled) {
+      _status = ZenRecitationStatus.disabled;
+      _statusMessage = '自动识别已关闭';
+      notifyListeners();
+      return;
+    }
+    if (book == null || book.normalizedText.isEmpty) {
+      _status = ZenRecitationStatus.missingBook;
+      _statusMessage = '未找到功课本，已保留手动计数';
+      notifyListeners();
+      return;
+    }
+    final modelDir = await OfflineAsrModelService.instance
+        .getInstalledModelDir();
+    if (modelDir == null) {
+      _status = ZenRecitationStatus.missingModel;
+      _statusMessage = '未安装离线语音模型，已保留手动计数';
+      notifyListeners();
+      return;
+    }
+
+    _status = ZenRecitationStatus.starting;
+    _statusMessage = '正在预热离线识别...';
+    notifyListeners();
+
+    try {
+      _matcher = RecitationProgressMatcher(book.normalizedText);
+      _sttService.onResult = _handleSpeechResult;
+      _sttService.onError = (error) {
+        _status = ZenRecitationStatus.error;
+        _statusMessage = error;
+        notifyListeners();
+      };
+      _sttService.onProgress = (message) {
+        _statusMessage = message;
+        notifyListeners();
+      };
+
+      final sttReady = await _sttService.initialize();
+      if (!sttReady) {
+        _status = ZenRecitationStatus.missingModel;
+        _statusMessage = '离线语音模型不可用，已保留手动计数';
+        notifyListeners();
+        return;
+      }
+
+      await _sttService.startRecognizing();
+      final stream = await _audioService.startRecording(saveToFile: false);
+      if (stream == null) {
+        _status = ZenRecitationStatus.error;
+        _statusMessage = '麦克风启动失败，已保留手动计数';
+        notifyListeners();
+        return;
+      }
+
+      _audioSubscription = stream.listen(_sttService.processAudio);
+      _status = ZenRecitationStatus.listening;
+      _statusMessage = '离线识别中';
+      notifyListeners();
+    } catch (e) {
+      _status = ZenRecitationStatus.error;
+      _statusMessage = '自动识别启动失败: $e';
+      notifyListeners();
+      await stop();
+    }
+  }
+
+  Future<void> stop() async {
+    await _audioSubscription?.cancel();
+    _audioSubscription = null;
+    if (_sttService.isRecognizing) {
+      await _sttService.stopRecognizing();
+    }
+    if (_audioService.isRecording) {
+      await _audioService.stopRecording();
+    }
+    if (_status == ZenRecitationStatus.listening ||
+        _status == ZenRecitationStatus.starting) {
+      _status = ZenRecitationStatus.stopped;
+      _statusMessage = '自动识别已停止';
+    }
+    notifyListeners();
+  }
+
+  void undoLastAutoCount() {
+    if (_autoCountStack <= 0) return;
+    _autoCountStack -= 1;
+    _onUndoCount?.call();
+    _statusMessage = '已撤销一次自动计数';
+    notifyListeners();
+  }
+
+  void _handleSpeechResult(String text, bool isFinal) {
+    final matcher = _matcher;
+    if (matcher == null || _status != ZenRecitationStatus.listening) return;
+
+    _recognizedText = text;
+    final event = matcher.accept(text, isEndpoint: isFinal);
+    _matchProgress = event.progress;
+    _statusMessage = event.hint;
+
+    if (event.countDelta > 0) {
+      for (var i = 0; i < event.countDelta; i++) {
+        _onCount?.call();
+        _autoCountStack += 1;
+      }
+    }
+    notifyListeners();
+  }
+}

--- a/fabushi/lib/services/zen_recitation_counter_service_stub.dart
+++ b/fabushi/lib/services/zen_recitation_counter_service_stub.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/practice_book_model.dart';
+
+enum ZenRecitationStatus {
+  disabled,
+  missingBook,
+  missingModel,
+  ready,
+  starting,
+  listening,
+  stopped,
+  error,
+}
+
+class ZenRecitationCounterService extends ChangeNotifier {
+  ZenRecitationStatus get status => ZenRecitationStatus.disabled;
+  String get statusMessage => 'Web 暂不支持离线语音识别';
+  String get recognizedText => '';
+  double get matchProgress => 0;
+  bool get autoEnabled => false;
+  bool get canUndo => false;
+
+  void setAutoEnabled(bool value) {}
+  Future<void> prepare(PracticeBook? book) async {}
+  Future<void> start({
+    required PracticeBook? book,
+    required VoidCallback onCount,
+    required VoidCallback onUndoCount,
+  }) async {}
+  Future<void> stop() async {}
+  void undoLastAutoCount() {}
+}

--- a/fabushi/lib/widgets/practice_book_sheet.dart
+++ b/fabushi/lib/widgets/practice_book_sheet.dart
@@ -1,0 +1,521 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import '../models/practice_book_model.dart';
+import '../services/offline_asr_model_service.dart';
+import '../services/practice_book_service.dart';
+
+class PracticeBookSheet extends StatefulWidget {
+  final String practiceTitle;
+  final void Function(PracticeBook? book)? onChanged;
+
+  const PracticeBookSheet({
+    super.key,
+    required this.practiceTitle,
+    this.onChanged,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required String practiceTitle,
+    void Function(PracticeBook? book)? onChanged,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: const Color(0xFF151515),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) =>
+          PracticeBookSheet(practiceTitle: practiceTitle, onChanged: onChanged),
+    );
+  }
+
+  @override
+  State<PracticeBookSheet> createState() => _PracticeBookSheetState();
+}
+
+class _PracticeBookSheetState extends State<PracticeBookSheet> {
+  final _service = PracticeBookService.instance;
+  final _modelService = OfflineAsrModelService.instance;
+  PracticeBook? _book;
+  bool _loading = true;
+  bool _busy = false;
+  String? _message;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+    _modelService.addListener(_onModelChanged);
+  }
+
+  @override
+  void dispose() {
+    _modelService.removeListener(_onModelChanged);
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    final book = await _service.getActiveBook(widget.practiceTitle);
+    await _modelService.refreshStatus();
+    if (!mounted) return;
+    setState(() {
+      _book = book;
+      _loading = false;
+    });
+  }
+
+  void _onModelChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _pickFile() async {
+    setState(() {
+      _busy = true;
+      _message = null;
+    });
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        allowMultiple: false,
+        withData: true,
+        type: FileType.custom,
+        allowedExtensions: ['txt', 'md', 'docx', 'pdf'],
+      );
+      final files = result?.files ?? const <PlatformFile>[];
+      if (files.isEmpty) return;
+      final file = files.first;
+      final importResult = await _service.importFile(
+        file: file,
+        practiceTitle: widget.practiceTitle,
+      );
+      await _handleImportResult(importResult);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _inputUrl() async {
+    final controller = TextEditingController();
+    final url = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: const Color(0xFF1E1E1E),
+        title: const Text('导入链接', style: TextStyle(color: Colors.white)),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          keyboardType: TextInputType.url,
+          style: const TextStyle(color: Colors.white),
+          decoration: const InputDecoration(
+            hintText: '粘贴微信公众号或网页链接',
+            hintStyle: TextStyle(color: Colors.white38),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('取消'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('导入'),
+          ),
+        ],
+      ),
+    );
+    if (url == null || url.isEmpty) return;
+
+    setState(() {
+      _busy = true;
+      _message = null;
+    });
+    try {
+      final result = await _service.importUrl(
+        url: url,
+        practiceTitle: widget.practiceTitle,
+      );
+      if (!result.isSuccess && result.needsWebViewFallback && mounted) {
+        final book = await Navigator.push<PracticeBook>(
+          context,
+          MaterialPageRoute(
+            builder: (_) => PracticeBookWebImportScreen(
+              practiceTitle: widget.practiceTitle,
+              sourceUrl: url,
+            ),
+          ),
+        );
+        if (book != null) {
+          await _setBook(book, '已从页面提取功课本');
+          return;
+        }
+      }
+      await _handleImportResult(result);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _handleImportResult(PracticeBookImportResult result) async {
+    if (result.book != null) {
+      await _setBook(result.book!, '功课本已保存');
+    } else if (mounted) {
+      setState(() => _message = result.error ?? '导入失败');
+    }
+  }
+
+  Future<void> _setBook(PracticeBook book, String message) async {
+    if (!mounted) return;
+    setState(() {
+      _book = book;
+      _message = message;
+    });
+    widget.onChanged?.call(book);
+  }
+
+  Future<void> _downloadModel() async {
+    setState(() {
+      _busy = true;
+      _message = null;
+    });
+    try {
+      final path = await _modelService.downloadModel();
+      if (!mounted) return;
+      setState(() {
+        _message = path == null ? _modelService.statusMessage : '离线语音模型已就绪';
+      });
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _deleteBook() async {
+    final book = _book;
+    if (book == null) return;
+    setState(() => _busy = true);
+    try {
+      await _service.deleteBook(book.id);
+      if (!mounted) return;
+      setState(() {
+        _book = null;
+        _message = '功课本已删除';
+      });
+      widget.onChanged?.call(null);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final modelReady = _modelService.status == OfflineAsrModelStatus.installed;
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 20,
+          right: 20,
+          top: 12,
+          bottom: 20 + MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: _loading
+            ? const SizedBox(
+                height: 220,
+                child: Center(
+                  child: CircularProgressIndicator(color: Color(0xFFD4AF37)),
+                ),
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: Colors.white24,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Text(
+                    widget.practiceTitle,
+                    style: const TextStyle(
+                      color: Color(0xFFD4AF37),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                  _buildCurrentBook(),
+                  const SizedBox(height: 14),
+                  _buildModelStatus(modelReady),
+                  if (_message != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _message!,
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ],
+                  const SizedBox(height: 18),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _ActionButton(
+                          icon: Icons.upload_file,
+                          label: '文件',
+                          enabled: !_busy,
+                          onTap: _pickFile,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: _ActionButton(
+                          icon: Icons.link,
+                          label: '链接',
+                          enabled: !_busy,
+                          onTap: _inputUrl,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: _ActionButton(
+                          icon: modelReady ? Icons.check_circle : Icons.mic,
+                          label: modelReady ? '已就绪' : '模型',
+                          enabled: !_busy && !modelReady,
+                          onTap: _downloadModel,
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (_book != null) ...[
+                    const SizedBox(height: 10),
+                    TextButton.icon(
+                      onPressed: _busy ? null : _deleteBook,
+                      icon: const Icon(Icons.delete_outline),
+                      label: const Text('删除当前功课本'),
+                    ),
+                  ],
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _buildCurrentBook() {
+    final book = _book;
+    if (book == null) {
+      return const Text(
+        '尚未添加功课本。添加后，禅室会用本地语音识别自动判断念诵遍数。',
+        style: TextStyle(color: Colors.white70, height: 1.5),
+      );
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            book.title,
+            style: const TextStyle(color: Colors.white, fontSize: 16),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '${book.normalizedText.length} 字 · ${_syncLabel(book.syncStatus)}',
+            style: const TextStyle(color: Colors.white54, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildModelStatus(bool modelReady) {
+    final progress = _modelService.progress;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: modelReady
+            ? Colors.green.withValues(alpha: 0.10)
+            : Colors.orange.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: modelReady
+              ? Colors.green.withValues(alpha: 0.35)
+              : Colors.orange.withValues(alpha: 0.35),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                modelReady ? Icons.offline_bolt : Icons.download,
+                color: modelReady ? Colors.greenAccent : Colors.orangeAccent,
+                size: 18,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  _modelService.statusMessage,
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ),
+            ],
+          ),
+          if (_modelService.status == OfflineAsrModelStatus.downloading) ...[
+            const SizedBox(height: 10),
+            LinearProgressIndicator(
+              value: progress <= 0 ? null : progress,
+              color: const Color(0xFFD4AF37),
+              backgroundColor: Colors.white12,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _syncLabel(PracticeBookSyncStatus status) {
+    return switch (status) {
+      PracticeBookSyncStatus.synced => '已云端同步',
+      PracticeBookSyncStatus.pendingUpload => '待云端同步',
+      PracticeBookSyncStatus.syncFailed => '云端同步失败',
+      PracticeBookSyncStatus.localOnly => '仅本地',
+    };
+  }
+}
+
+class PracticeBookWebImportScreen extends StatefulWidget {
+  final String practiceTitle;
+  final String sourceUrl;
+
+  const PracticeBookWebImportScreen({
+    super.key,
+    required this.practiceTitle,
+    required this.sourceUrl,
+  });
+
+  @override
+  State<PracticeBookWebImportScreen> createState() =>
+      _PracticeBookWebImportScreenState();
+}
+
+class _PracticeBookWebImportScreenState
+    extends State<PracticeBookWebImportScreen> {
+  InAppWebViewController? _controller;
+  bool _busy = false;
+
+  Future<void> _extract() async {
+    final controller = _controller;
+    if (controller == null) return;
+    setState(() => _busy = true);
+    try {
+      final title = await controller.evaluateJavascript(
+        source: 'document.title || ""',
+      );
+      final text = await controller.evaluateJavascript(
+        source:
+            'document.querySelector("#js_content")?.innerText || document.body.innerText || ""',
+      );
+      final plainText = text?.toString() ?? '';
+      if (plainText.trim().length < 20) {
+        if (mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('未能从当前页面提取到足够正文')));
+        }
+        return;
+      }
+      final book = await PracticeBookService.instance.saveExtractedWebText(
+        practiceTitle: widget.practiceTitle,
+        sourceUrl: widget.sourceUrl,
+        title: title?.toString() ?? '',
+        plainText: plainText,
+      );
+      if (mounted) Navigator.pop(context, book);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('提取功课本'),
+        actions: [
+          TextButton.icon(
+            onPressed: _busy ? null : _extract,
+            icon: const Icon(Icons.save_alt),
+            label: const Text('提取'),
+          ),
+        ],
+      ),
+      body: InAppWebView(
+        initialUrlRequest: URLRequest(url: WebUri(widget.sourceUrl)),
+        initialSettings: InAppWebViewSettings(
+          javaScriptEnabled: true,
+          mediaPlaybackRequiresUserGesture: false,
+        ),
+        onWebViewCreated: (controller) => _controller = controller,
+      ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.enabled,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: enabled ? onTap : null,
+      child: Opacity(
+        opacity: enabled ? 1 : 0.45,
+        child: Container(
+          height: 52,
+          decoration: BoxDecoration(
+            color: const Color(0xFFD4AF37),
+            borderRadius: BorderRadius.circular(26),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.black, size: 19),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.black,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fabushi/pubspec.lock
+++ b/fabushi/pubspec.lock
@@ -1781,7 +1781,7 @@ packages:
     source: hosted
     version: "1.10.2"
   sqflite:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sqflite
       sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   shared_preferences: ^2.2.2
   path_provider: ^2.0.15
   package_info_plus: ^8.3.1
+  sqflite: ^2.4.2
 
   # 文件处理
   file_picker: ^10.3.3

--- a/fabushi/test/unit/services/recitation_progress_matcher_test.dart
+++ b/fabushi/test/unit/services/recitation_progress_matcher_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/services/recitation_progress_matcher.dart';
+
+void main() {
+  group('RecitationProgressMatcher', () {
+    test('counts repeated short mantra with cooldown protection', () {
+      var now = DateTime(2026, 5, 24, 8);
+      final matcher = RecitationProgressMatcher('南无阿弥陀佛', now: () => now);
+
+      final first = matcher.accept('南无阿弥陀佛', isEndpoint: true);
+      expect(first.countDelta, 1);
+      expect(first.progress, 1);
+
+      final duplicate = matcher.accept('南无阿弥陀佛', isEndpoint: true);
+      expect(duplicate.countDelta, 0);
+
+      now = now.add(const Duration(milliseconds: 1300));
+      final second = matcher.accept('南无阿弥陀佛', isEndpoint: true);
+      expect(second.countDelta, 1);
+    });
+
+    test('tracks long text progress and counts after completion', () {
+      final sutra = List.filled(16, '观自在菩萨行深般若波罗蜜多时').join('，');
+      final matcher = RecitationProgressMatcher(sutra);
+
+      final firstHalf = matcher.accept(
+        List.filled(8, '观自在菩萨行深般若波罗蜜多时').join('，'),
+      );
+      expect(firstHalf.countDelta, 0);
+      expect(firstHalf.progress, greaterThan(0.40));
+      expect(firstHalf.progress, lessThan(0.70));
+
+      final secondHalf = matcher.accept(
+        List.filled(8, '观自在菩萨行深般若波罗蜜多时').join('，'),
+        isEndpoint: true,
+      );
+      expect(secondHalf.countDelta, 1);
+      expect(secondHalf.progress, 1);
+    });
+
+    test('tolerates small recognition omissions through pinyin matching', () {
+      final matcher = RecitationProgressMatcher('唵嘛呢叭咪吽');
+
+      final event = matcher.accept('唵嘛呢巴咪吽', isEndpoint: true);
+      expect(event.countDelta, 1);
+      expect(event.progress, 1);
+    });
+  });
+}

--- a/fabushi/web/migrations/20260524_practice_books.sql
+++ b/fabushi/web/migrations/20260524_practice_books.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS practice_books (
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL,
+  user_id INTEGER,
+  practice_title TEXT NOT NULL,
+  title TEXT NOT NULL,
+  source_type TEXT NOT NULL,
+  source_url TEXT,
+  source_file_name TEXT,
+  content_hash TEXT NOT NULL,
+  normalized_text TEXT NOT NULL,
+  remote_object_key TEXT NOT NULL,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  sync_version INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_practice_books_owner_updated
+  ON practice_books(user_id, username, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_practice_books_practice_active
+  ON practice_books(user_id, username, practice_title, is_active);
+
+CREATE INDEX IF NOT EXISTS idx_practice_books_username
+  ON practice_books(username);

--- a/fabushi/web/src/handlers/meditation.js
+++ b/fabushi/web/src/handlers/meditation.js
@@ -451,6 +451,492 @@ function parseGroupSearchQuery(query) {
     };
 }
 
+function normalizePlainText(text) {
+    return String(text || '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .replace(/[ \t]+\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+function normalizeForMatching(text) {
+    return String(text || '')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/[\u0000-\u001f]/g, ' ')
+        .replace(/\s+/g, '')
+        .trim();
+}
+
+function firstTextLine(text, fallback = '功课本') {
+    const line = normalizePlainText(text)
+        .split('\n')
+        .map((item) => item.trim())
+        .find((item) => item.length > 0);
+    if (!line) return fallback;
+    const cleaned = line.replace(/^[#>\s]+/, '').trim();
+    if (!cleaned) return fallback;
+    return cleaned.length > 32 ? cleaned.slice(0, 32) : cleaned;
+}
+
+async function sha256Hex(text) {
+    const bytes = new TextEncoder().encode(String(text || ''));
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return [...new Uint8Array(digest)]
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+function ownerObjectSegment(auth) {
+    const value = hasStableUserId(auth) ? `u-${auth.userId}` : `name-${auth.username}`;
+    return String(value).replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+function parseIsoOrNow(value, fallback = new Date()) {
+    const parsed = value ? new Date(value) : null;
+    return parsed && !Number.isNaN(parsed.getTime())
+        ? parsed.toISOString()
+        : fallback.toISOString();
+}
+
+function toPracticeBookRow(row, content = {}) {
+    return {
+        id: row.id,
+        practiceTitle: row.practice_title,
+        title: row.title,
+        sourceType: row.source_type,
+        sourceUrl: row.source_url || null,
+        sourceFileName: row.source_file_name || null,
+        contentHash: row.content_hash,
+        plainText: content.plainText || '',
+        normalizedText: content.normalizedText || row.normalized_text || '',
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+        syncStatus: 'synced',
+        remoteObjectKey: row.remote_object_key || null,
+        isActive: row.is_active === 1 || row.is_active === true
+    };
+}
+
+async function readPracticeBookContent(env, objectKey) {
+    if (!env.R2_BUCKET || !objectKey) return {};
+    const object = await env.R2_BUCKET.get(objectKey);
+    if (!object) return {};
+    try {
+        return JSON.parse(await object.text());
+    } catch (_) {
+        return {};
+    }
+}
+
+async function buildPracticeBookFromBody(body, auth, fallback = {}) {
+    const now = new Date();
+    const id = String(body.id || fallback.id || crypto.randomUUID());
+    const practiceTitle = String(body.practiceTitle || body.practice_title || fallback.practiceTitle || '').trim();
+    const plainText = normalizePlainText(body.plainText || body.plain_text || fallback.plainText || '');
+    const title = String(body.title || fallback.title || firstTextLine(plainText)).trim();
+    const sourceType = String(body.sourceType || body.source_type || fallback.sourceType || 'manual');
+    const normalizedText = normalizeForMatching(body.normalizedText || body.normalized_text || plainText);
+    const contentHash = String(body.contentHash || body.content_hash || await sha256Hex(plainText));
+    const remoteObjectKey = String(
+        body.remoteObjectKey ||
+        body.remote_object_key ||
+        `practice-books/${ownerObjectSegment(auth)}/${id}.json`
+    );
+
+    if (!practiceTitle) {
+        throw new Error('practiceTitle required');
+    }
+    if (!title) {
+        throw new Error('title required');
+    }
+    if (plainText.length < 2 || normalizedText.length < 2) {
+        throw new Error('plainText required');
+    }
+
+    return {
+        id,
+        practiceTitle,
+        title,
+        sourceType,
+        sourceUrl: body.sourceUrl || body.source_url || fallback.sourceUrl || null,
+        sourceFileName: body.sourceFileName || body.source_file_name || fallback.sourceFileName || null,
+        contentHash,
+        plainText,
+        normalizedText,
+        createdAt: parseIsoOrNow(body.createdAt || body.created_at || fallback.createdAt, now),
+        updatedAt: now.toISOString(),
+        remoteObjectKey,
+        isActive: body.isActive !== false && body.is_active !== 0
+    };
+}
+
+async function savePracticeBookForAuth(db, env, auth, book) {
+    if (!env.R2_BUCKET) {
+        throw new Error('R2_BUCKET not configured');
+    }
+
+    const objectPayload = {
+        id: book.id,
+        practiceTitle: book.practiceTitle,
+        title: book.title,
+        sourceType: book.sourceType,
+        sourceUrl: book.sourceUrl,
+        sourceFileName: book.sourceFileName,
+        contentHash: book.contentHash,
+        plainText: book.plainText,
+        normalizedText: book.normalizedText,
+        createdAt: book.createdAt,
+        updatedAt: book.updatedAt
+    };
+
+    await env.R2_BUCKET.put(book.remoteObjectKey, JSON.stringify(objectPayload), {
+        httpMetadata: { contentType: 'application/json; charset=utf-8' }
+    });
+
+    const scope = userScope(auth);
+    await db.prepare(`
+      UPDATE practice_books
+      SET is_active = 0,
+          updated_at = ?
+      WHERE ${scope.where} AND practice_title = ?
+    `).bind(book.updatedAt, ...scope.params, book.practiceTitle).run();
+
+    const nextVersion = await getNextSyncVersion(db, auth.username);
+    await db.prepare(`
+      INSERT INTO practice_books (
+        id, username, user_id, practice_title, title, source_type,
+        source_url, source_file_name, content_hash, normalized_text,
+        remote_object_key, is_active, created_at, updated_at, sync_version
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        username = excluded.username,
+        user_id = excluded.user_id,
+        practice_title = excluded.practice_title,
+        title = excluded.title,
+        source_type = excluded.source_type,
+        source_url = excluded.source_url,
+        source_file_name = excluded.source_file_name,
+        content_hash = excluded.content_hash,
+        normalized_text = excluded.normalized_text,
+        remote_object_key = excluded.remote_object_key,
+        is_active = excluded.is_active,
+        updated_at = excluded.updated_at,
+        sync_version = excluded.sync_version
+    `).bind(
+        book.id,
+        auth.username,
+        auth.userId,
+        book.practiceTitle,
+        book.title,
+        book.sourceType,
+        book.sourceUrl,
+        book.sourceFileName,
+        book.contentHash,
+        book.normalizedText,
+        book.remoteObjectKey,
+        book.isActive ? 1 : 0,
+        book.createdAt,
+        book.updatedAt,
+        nextVersion
+    ).run();
+
+    return { ...book, syncStatus: 'synced' };
+}
+
+function decodeHtmlEntities(text) {
+    const named = {
+        amp: '&',
+        lt: '<',
+        gt: '>',
+        quot: '"',
+        apos: "'",
+        nbsp: ' '
+    };
+    return String(text || '').replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (_, entity) => {
+        if (entity.startsWith('#x') || entity.startsWith('#X')) {
+            return String.fromCodePoint(parseInt(entity.slice(2), 16));
+        }
+        if (entity.startsWith('#')) {
+            return String.fromCodePoint(parseInt(entity.slice(1), 10));
+        }
+        return named[entity] || ' ';
+    });
+}
+
+function htmlToText(html) {
+    return normalizePlainText(
+        decodeHtmlEntities(
+            String(html || '')
+                .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+                .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+                .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
+                .replace(/<br\s*\/?>/gi, '\n')
+                .replace(/<\/(p|div|section|article|h[1-6]|li)>/gi, '\n')
+                .replace(/<[^>]+>/g, ' ')
+        ).replace(/[ \t]{2,}/g, ' ')
+    );
+}
+
+function extractElementById(html, id) {
+    const startPattern = new RegExp(`<([a-zA-Z0-9]+)[^>]*id=["']${id}["'][^>]*>`, 'i');
+    const start = startPattern.exec(html);
+    if (!start) return null;
+
+    const tag = start[1];
+    const contentStart = start.index + start[0].length;
+    const tagPattern = new RegExp(`</?${tag}\\b[^>]*>`, 'ig');
+    tagPattern.lastIndex = contentStart;
+    let depth = 1;
+    let match;
+    while ((match = tagPattern.exec(html)) !== null) {
+        if (match[0][1] === '/') {
+            depth -= 1;
+            if (depth === 0) {
+                return html.slice(contentStart, match.index);
+            }
+        } else {
+            depth += 1;
+        }
+    }
+    return html.slice(contentStart);
+}
+
+function extractHtmlTitle(html) {
+    const candidates = [
+        /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+        /<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:title["'][^>]*>/i,
+        /var\s+msg_title\s*=\s*["']([^"']+)["']/i,
+        /<title[^>]*>([\s\S]*?)<\/title>/i
+    ];
+    for (const pattern of candidates) {
+        const match = pattern.exec(html);
+        if (match?.[1]) {
+            return htmlToText(match[1]).slice(0, 80);
+        }
+    }
+    return '功课本';
+}
+
+function extractArticleText(html, url) {
+    const host = new URL(url).hostname;
+    const candidates = [];
+
+    if (host.includes('mp.weixin.qq.com')) {
+        const wechatContent = extractElementById(html, 'js_content');
+        if (wechatContent) candidates.push(wechatContent);
+    }
+
+    const richMedia = extractElementById(html, 'img-content') ||
+        extractElementById(html, 'js_article') ||
+        extractElementById(html, 'article-content');
+    if (richMedia) candidates.push(richMedia);
+
+    const articleMatch = /<article[^>]*>([\s\S]*?)<\/article>/i.exec(html);
+    if (articleMatch?.[1]) candidates.push(articleMatch[1]);
+
+    const bodyMatch = /<body[^>]*>([\s\S]*?)<\/body>/i.exec(html);
+    if (bodyMatch?.[1]) candidates.push(bodyMatch[1]);
+
+    return candidates
+        .map(htmlToText)
+        .sort((a, b) => b.length - a.length)[0] || '';
+}
+
+// 功课本列表 GET /api/meditation/practice-books
+export async function handleGetPracticeBooks(request, env, db) {
+    const auth = await authenticateUser(request, db);
+    if (auth.error) {
+        return jsonResponse({ success: false, error: auth.error }, auth.status);
+    }
+
+    try {
+        const url = new URL(request.url);
+        const practiceTitle = url.searchParams.get('practiceTitle');
+        const result = await withUserScope(db, auth, (scope) => {
+            let sql = `
+      SELECT id, username, user_id, practice_title, title, source_type,
+             source_url, source_file_name, content_hash, normalized_text,
+             remote_object_key, is_active, created_at, updated_at
+      FROM practice_books
+      WHERE ${scope.where}
+    `;
+            const params = [...scope.params];
+            if (practiceTitle) {
+                sql += ' AND practice_title = ?';
+                params.push(practiceTitle);
+            }
+            sql += ' ORDER BY updated_at DESC';
+            return { sql, params };
+        });
+
+        const books = [];
+        for (const row of result.results || []) {
+            const content = await readPracticeBookContent(env, row.remote_object_key);
+            books.push(toPracticeBookRow(row, content));
+        }
+
+        return jsonResponse({ success: true, data: { books } });
+    } catch (e) {
+        console.error('获取功课本失败:', e);
+        return jsonResponse({ success: false, error: '获取功课本失败' }, 500);
+    }
+}
+
+// 保存功课本 POST /api/meditation/practice-books
+export async function handleSavePracticeBook(request, env, db) {
+    const auth = await authenticateUser(request, db);
+    if (auth.error) {
+        return jsonResponse({ success: false, error: auth.error }, auth.status);
+    }
+
+    try {
+        const body = await request.json();
+        const book = await buildPracticeBookFromBody(body, auth);
+        const saved = await savePracticeBookForAuth(db, env, auth, book);
+        return jsonResponse({ success: true, data: { book: saved } });
+    } catch (e) {
+        console.error('保存功课本失败:', e);
+        return jsonResponse({ success: false, error: '保存功课本失败: ' + e.message }, 500);
+    }
+}
+
+// 删除功课本 DELETE /api/meditation/practice-books?id=...
+export async function handleDeletePracticeBook(request, env, db) {
+    const auth = await authenticateUser(request, db);
+    if (auth.error) {
+        return jsonResponse({ success: false, error: auth.error }, auth.status);
+    }
+
+    try {
+        const url = new URL(request.url);
+        const id = url.searchParams.get('id');
+        if (!id) {
+            return jsonResponse({ success: false, error: 'id required' }, 400);
+        }
+
+        const row = await withUserScope(db, auth, (scope) => ({
+            sql: `
+      SELECT id, remote_object_key
+      FROM practice_books
+      WHERE id = ? AND ${scope.where}
+    `,
+            params: [id, ...scope.params]
+        }), 'first');
+
+        if (!row) {
+            return jsonResponse({ success: false, error: '功课本不存在' }, 404);
+        }
+
+        await db.prepare('DELETE FROM practice_books WHERE id = ?').bind(id).run();
+        if (env.R2_BUCKET && row.remote_object_key) {
+            await env.R2_BUCKET.delete(row.remote_object_key);
+        }
+
+        return jsonResponse({ success: true });
+    } catch (e) {
+        console.error('删除功课本失败:', e);
+        return jsonResponse({ success: false, error: '删除功课本失败' }, 500);
+    }
+}
+
+// 导入链接 POST /api/meditation/practice-books/import-url
+export async function handleImportPracticeBookUrl(request, env, db) {
+    const auth = await authenticateUser(request, db);
+    if (auth.error) {
+        return jsonResponse({ success: false, error: auth.error }, auth.status);
+    }
+
+    try {
+        const body = await request.json();
+        const sourceUrl = String(body.url || body.sourceUrl || '').trim();
+        const practiceTitle = String(body.practiceTitle || '').trim();
+        if (!/^https?:\/\//i.test(sourceUrl)) {
+            return jsonResponse({ success: false, error: '请输入 http/https 链接' }, 400);
+        }
+
+        const remote = await fetch(sourceUrl, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 MicroMessenger/8.0 FabushiPracticeBookImporter',
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+            }
+        });
+        if (!remote.ok) {
+            return jsonResponse({
+                success: false,
+                error: `链接抓取失败: HTTP ${remote.status}`,
+                needsWebViewFallback: true
+            }, 422);
+        }
+
+        const html = await remote.text();
+        const plainText = extractArticleText(html, sourceUrl);
+        if (plainText.length < 40) {
+            return jsonResponse({
+                success: false,
+                error: '云端未能提取正文，可改用 App 内页面提取',
+                needsWebViewFallback: true
+            }, 422);
+        }
+
+        const book = await buildPracticeBookFromBody({
+            practiceTitle,
+            title: extractHtmlTitle(html) || firstTextLine(plainText),
+            sourceType: 'url',
+            sourceUrl,
+            plainText
+        }, auth);
+        const saved = await savePracticeBookForAuth(db, env, auth, book);
+        return jsonResponse({ success: true, data: { book: saved } });
+    } catch (e) {
+        console.error('链接导入功课本失败:', e);
+        return jsonResponse({
+            success: false,
+            error: '链接解析失败',
+            needsWebViewFallback: true
+        }, 422);
+    }
+}
+
+// 离线 ASR 模型包 manifest GET /api/meditation/asr-model-manifest
+export async function handleAsrModelManifest(request, env) {
+    const modelId = 'streaming-paraformer-zh-en';
+    const makeR2Url = (fileName) => {
+        const url = new URL('/r2', request.url);
+        url.searchParams.set('file', `asr-models/${modelId}/${fileName}`);
+        return url.toString();
+    };
+
+    return jsonResponse({
+        success: true,
+        id: modelId,
+        version: '2026-05-24-paraformer-int8',
+        provider: 'sherpa_onnx_paraformer',
+        offline: true,
+        files: [
+            {
+                name: 'encoder.int8.onnx',
+                url: makeR2Url('encoder.int8.onnx'),
+                minBytes: 1048576,
+                sha256: env.ASR_PARA_FORMER_ENCODER_SHA256 || null
+            },
+            {
+                name: 'decoder.int8.onnx',
+                url: makeR2Url('decoder.int8.onnx'),
+                minBytes: 524288,
+                sha256: env.ASR_PARA_FORMER_DECODER_SHA256 || null
+            },
+            {
+                name: 'tokens.txt',
+                url: makeR2Url('tokens.txt'),
+                minBytes: 1024,
+                sha256: env.ASR_PARA_FORMER_TOKENS_SHA256 || null
+            }
+        ]
+    });
+}
+
 // 同步修行记录 POST /api/meditation/record
 export async function handleSyncRecord(request, env, db) {
     const auth = await authenticateUser(request, db);

--- a/fabushi/web/src/routes/meditation-routes.js
+++ b/fabushi/web/src/routes/meditation-routes.js
@@ -14,6 +14,11 @@ import {
   handleGetMeditationGroupDetail,
   handleReviewMeditationGroupJoin,
   handleSyncRecord,
+  handleGetPracticeBooks,
+  handleSavePracticeBook,
+  handleDeletePracticeBook,
+  handleImportPracticeBookUrl,
+  handleAsrModelManifest,
 } from '../handlers/meditation.js';
 import { generateSnowflakeUserId as generateSnowflakeGroupId } from '../services/database.js';
 import {
@@ -420,6 +425,21 @@ async function handleJoinMeditationGroupWithStableUserId(request, env, db) {
 }
 
 export async function routeMeditationRequest({ pathname, method, request, env, db }) {
+  if (pathname === '/api/meditation/asr-model-manifest' && method === 'GET') {
+    return await handleAsrModelManifest(request, env);
+  }
+  if (pathname === '/api/meditation/practice-books' && method === 'GET') {
+    return await handleGetPracticeBooks(request, env, db);
+  }
+  if (pathname === '/api/meditation/practice-books' && method === 'POST') {
+    return await handleSavePracticeBook(request, env, db);
+  }
+  if (pathname === '/api/meditation/practice-books' && method === 'DELETE') {
+    return await handleDeletePracticeBook(request, env, db);
+  }
+  if (pathname === '/api/meditation/practice-books/import-url' && method === 'POST') {
+    return await handleImportPracticeBookUrl(request, env, db);
+  }
   if (pathname === '/api/meditation/record' && method === 'POST') {
     return await handleSyncRecord(request, env, db);
   }

--- a/fabushi/web/tests/practice-books.test.js
+++ b/fabushi/web/tests/practice-books.test.js
@@ -1,0 +1,274 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  handleAsrModelManifest,
+  handleDeletePracticeBook,
+  handleGetPracticeBooks,
+  handleImportPracticeBookUrl,
+  handleSavePracticeBook,
+} from '../src/handlers/meditation.js';
+
+function authHeader(username, userId = 101) {
+  const payload = Buffer.from(JSON.stringify({ username, userId })).toString(
+    'base64url',
+  );
+  return `Bearer header.${payload}.signature`;
+}
+
+function createR2Mock() {
+  const objects = new Map();
+  return {
+    objects,
+    bucket: {
+      async put(key, value) {
+        objects.set(key, value);
+      },
+      async get(key) {
+        if (!objects.has(key)) return null;
+        return {
+          async text() {
+            return objects.get(key);
+          },
+        };
+      },
+      async delete(key) {
+        objects.delete(key);
+      },
+    },
+  };
+}
+
+function createDbMock() {
+  const practiceBooks = new Map();
+
+  const inOwnerScope = (row, userId, username) =>
+    row.user_id === userId || (row.user_id == null && row.username === username);
+
+  const db = {
+    prepare(sql) {
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+      return {
+        bind(...params) {
+          return {
+            async first() {
+              if (normalizedSql.startsWith('SELECT id FROM users WHERE username = ?')) {
+                return { id: 101 };
+              }
+
+              if (normalizedSql.startsWith('SELECT COALESCE(MAX(sync_version), 0) + 1 as next_version FROM (')) {
+                return { next_version: 1 };
+              }
+
+              if (normalizedSql.startsWith('SELECT id, remote_object_key FROM practice_books WHERE id = ? AND')) {
+                const [id, userId, username] = params;
+                const row = practiceBooks.get(id);
+                return row && inOwnerScope(row, userId, username)
+                  ? { id: row.id, remote_object_key: row.remote_object_key }
+                  : null;
+              }
+
+              return null;
+            },
+            async all() {
+              if (normalizedSql.startsWith('SELECT id, username, user_id, practice_title, title, source_type,')) {
+                const [userId, username, practiceTitle] = params;
+                const rows = Array.from(practiceBooks.values())
+                  .filter((row) => inOwnerScope(row, userId, username))
+                  .filter((row) => !practiceTitle || row.practice_title === practiceTitle)
+                  .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+                return { results: rows };
+              }
+
+              return { results: [] };
+            },
+            async run() {
+              if (normalizedSql.startsWith('UPDATE meditation_records') ||
+                  normalizedSql.startsWith('UPDATE meditation_goals') ||
+                  normalizedSql.startsWith('UPDATE meditation_settings')) {
+                return {};
+              }
+
+              if (normalizedSql.startsWith('UPDATE practice_books SET is_active = 0,')) {
+                const [updatedAt, userId, username, practiceTitle] = params;
+                for (const row of practiceBooks.values()) {
+                  if (inOwnerScope(row, userId, username) && row.practice_title === practiceTitle) {
+                    row.is_active = 0;
+                    row.updated_at = updatedAt;
+                  }
+                }
+                return {};
+              }
+
+              if (normalizedSql.startsWith('INSERT INTO practice_books')) {
+                const [
+                  id,
+                  username,
+                  userId,
+                  practiceTitle,
+                  title,
+                  sourceType,
+                  sourceUrl,
+                  sourceFileName,
+                  contentHash,
+                  normalizedText,
+                  remoteObjectKey,
+                  isActive,
+                  createdAt,
+                  updatedAt,
+                  syncVersion,
+                ] = params;
+                practiceBooks.set(id, {
+                  id,
+                  username,
+                  user_id: userId,
+                  practice_title: practiceTitle,
+                  title,
+                  source_type: sourceType,
+                  source_url: sourceUrl,
+                  source_file_name: sourceFileName,
+                  content_hash: contentHash,
+                  normalized_text: normalizedText,
+                  remote_object_key: remoteObjectKey,
+                  is_active: isActive,
+                  created_at: createdAt,
+                  updated_at: updatedAt,
+                  sync_version: syncVersion,
+                });
+                return {};
+              }
+
+              if (normalizedSql.startsWith('DELETE FROM practice_books WHERE id = ?')) {
+                practiceBooks.delete(params[0]);
+                return {};
+              }
+
+              return {};
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { db, practiceBooks };
+}
+
+function jsonRequest(url, body, method = 'POST') {
+  return new Request(url, {
+    method,
+    headers: {
+      Authorization: authHeader('bhrum108'),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+test('practice book save, list, and delete are scoped to the authenticated owner', async () => {
+  const { db, practiceBooks } = createDbMock();
+  const r2 = createR2Mock();
+  const env = { R2_BUCKET: r2.bucket };
+
+  const saveResponse = await handleSavePracticeBook(
+    jsonRequest('https://api.example.com/api/meditation/practice-books', {
+      id: 'book-1',
+      practiceTitle: '心经',
+      title: '般若波罗蜜多心经',
+      sourceType: 'file',
+      sourceFileName: 'heart.txt',
+      plainText: '观自在菩萨，行深般若波罗蜜多时。',
+    }),
+    env,
+    db,
+  );
+
+  assert.equal(saveResponse.status, 200);
+  assert.equal((await saveResponse.json()).data.book.syncStatus, 'synced');
+  assert.equal(practiceBooks.get('book-1')?.username, 'bhrum108');
+  assert.equal(r2.objects.has('practice-books/u-101/book-1.json'), true);
+
+  const listResponse = await handleGetPracticeBooks(
+    new Request('https://api.example.com/api/meditation/practice-books?practiceTitle=%E5%BF%83%E7%BB%8F', {
+      headers: { Authorization: authHeader('bhrum108') },
+    }),
+    env,
+    db,
+  );
+  const listPayload = await listResponse.json();
+  assert.equal(listResponse.status, 200);
+  assert.equal(listPayload.data.books.length, 1);
+  assert.equal(listPayload.data.books[0].plainText, '观自在菩萨，行深般若波罗蜜多时。');
+
+  const deleteResponse = await handleDeletePracticeBook(
+    new Request('https://api.example.com/api/meditation/practice-books?id=book-1', {
+      method: 'DELETE',
+      headers: { Authorization: authHeader('bhrum108') },
+    }),
+    env,
+    db,
+  );
+  assert.equal(deleteResponse.status, 200);
+  assert.equal(practiceBooks.has('book-1'), false);
+  assert.equal(r2.objects.has('practice-books/u-101/book-1.json'), false);
+});
+
+test('wechat article import extracts visible article content into R2', async () => {
+  const { db } = createDbMock();
+  const r2 = createR2Mock();
+  const env = { R2_BUCKET: r2.bucket };
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () =>
+    new Response(`
+      <html>
+        <head><meta property="og:title" content="每日功课"/></head>
+        <body>
+          <div id="js_content">
+            <p>南无本师释迦牟尼佛。</p>
+            <p>愿以此功德，庄严佛净土，上报四重恩，下济三途苦。</p>
+            <p>若有见闻者，悉发菩提心，尽此一报身，同生极乐国。</p>
+          </div>
+        </body>
+      </html>
+    `, { status: 200, headers: { 'Content-Type': 'text/html' } });
+
+  try {
+    const response = await handleImportPracticeBookUrl(
+      jsonRequest('https://api.example.com/api/meditation/practice-books/import-url', {
+        url: 'https://mp.weixin.qq.com/s/example',
+        practiceTitle: '每日功课',
+      }),
+      env,
+      db,
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.book.title, '每日功课');
+    assert.equal(payload.data.book.sourceType, 'url');
+    assert.match(payload.data.book.plainText, /愿以此功德/);
+    assert.equal(r2.objects.size, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('asr manifest exposes R2-backed paraformer model files', async () => {
+  const response = await handleAsrModelManifest(
+    new Request('https://api.example.com/api/meditation/asr-model-manifest'),
+    {
+      ASR_PARA_FORMER_ENCODER_SHA256: 'encoder-sha',
+      ASR_PARA_FORMER_DECODER_SHA256: 'decoder-sha',
+      ASR_PARA_FORMER_TOKENS_SHA256: 'tokens-sha',
+    },
+  );
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.id, 'streaming-paraformer-zh-en');
+  assert.equal(payload.offline, true);
+  assert.equal(payload.files.length, 3);
+  assert.match(payload.files[0].url, /\/r2\?file=asr-models%2Fstreaming-paraformer-zh-en%2Fencoder\.int8\.onnx/);
+  assert.equal(payload.files[0].sha256, 'encoder-sha');
+});


### PR DESCRIPTION
## What changed

- Adds local practice-book storage/import for the meditation room, including txt/md/docx/pdf parsing and URL import with WeChat article fallback extraction.
- Adds offline ASR model package management for `sherpa_onnx` Paraformer models, downloaded from R2/CDN and SHA-256 checked when hashes are configured.
- Wires the meditation room to start local audio recognition after a locked main practice begins, match recognized text against the active practice book, auto-increment recitation counts, and allow manual +1 / undo / disabling auto recognition.
- Adds backend practice-book CRUD, URL import, R2 body storage, a D1 migration, and an ASR model manifest endpoint.
- Adds focused Dart matcher tests and Node tests for practice-book CRUD/R2/WeChat extraction/model manifest.

## Why

Users need a pure-offline voice counting experience during practice. Speech and counting stay on device; cloud is only used for optional practice-book sync and URL extraction.

## Release / package tracking

This touches shared Flutter app code and should produce fresh Android install packages after merge. The repository release workflow `publish-cd-release.yml` recognizes mobile package inputs, and the PR should be labeled with `build-mobile-package` (or equivalent existing label) so package generation is explicit.

Deployment prerequisites before enabling this in production:

- Run D1 migration `fabushi/web/migrations/20260524_practice_books.sql`.
- Upload Paraformer files to R2 under `asr-models/streaming-paraformer-zh-en/`:
  - `encoder.int8.onnx`
  - `decoder.int8.onnx`
  - `tokens.txt`
- Configure optional SHA vars for stronger model verification:
  - `ASR_PARA_FORMER_ENCODER_SHA256`
  - `ASR_PARA_FORMER_DECODER_SHA256`
  - `ASR_PARA_FORMER_TOKENS_SHA256`

## Validation

- `/opt/homebrew/bin/flutter test test/unit/services/recitation_progress_matcher_test.dart`
- `/opt/homebrew/bin/flutter analyze lib/models/practice_book_model.dart lib/services/recitation_progress_matcher.dart lib/services/offline_asr_model_service_native.dart lib/services/practice_book_service_native.dart lib/services/zen_recitation_counter_service_native.dart lib/widgets/practice_book_sheet.dart lib/screens/meditation_room_screen.dart`
- `node --check web/src/handlers/meditation.js`
- `node --check web/src/routes/meditation-routes.js`
- `node --check web/tests/practice-books.test.js`
- `node --test web/tests/practice-books.test.js`