### PR TITLE
fix(android): guard Alipay membership flow when app is not installed

### DIFF
--- a/fabushi/lib/services/alipay_service.dart
+++ b/fabushi/lib/services/alipay_service.dart
@@ -138,6 +138,14 @@ class AlipayService {
         return {'success': false, 'message': '支付宝APP支付不支持Web平台'};
       }
 
+      final isInstalled = await isAlipayInstalled();
+      if (!isInstalled) {
+        return {
+          'success': false,
+          'message': '未安装支付宝APP，请先安装支付宝或改用网页支付',
+        };
+      }
+
       // 验证支付参数
       if (!validatePayParameters(orderString)) {
         return {'success': false, 'message': '支付参数验证失败'};


### PR DESCRIPTION
## 背景
安卓会员订阅页在没有安装支付宝 APP 的设备上，仍可能继续调用 Tobias 原生支付。这样会把用户带进异常路径，表现为点击订阅后直接报错。

## 根因
`MembershipScreen` 会先尝试 `initAlipay()` 判断支付宝是否可用，但真正发起支付的 `AlipayService.payWithAlipay()` 没有再次做安装检查。只要前面的分流失效、用户从兜底选择里点了支付宝，或者设备安装状态判断前后不一致，就会直接打到原生 SDK。

## 修改
- 在 `AlipayService.payWithAlipay()` 里增加安装检查。
- 未安装支付宝时，不再调用 Tobias SDK，而是返回明确错误信息给前端提示。

## 验证
- VPS 上已核对订阅页与支付宝登录页逻辑，确认两处行为不一致。
- 当前 VPS 磁盘仅剩约 2.5GB，且未安装 Flutter，无法在该环境完成完整 Android 构建或真机运行。