### PR TITLE
Fix Android membership payment fallback

### DIFF
--- a/fabushi/lib/screens/membership_screen.dart
+++ b/fabushi/lib/screens/membership_screen.dart
@@ -268,9 +268,9 @@ class _MembershipScreenState extends State<MembershipScreen>
             );
           }
         }
-      } else if (paymentMethod == 'alipay') {
+      } else if (paymentMethod == 'alipay' || paymentMethod == 'alipay_web') {
         // 根据平台类型选择支付宝支付方式
-        if (kIsWeb || _isDesktopPlatform()) {
+        if (paymentMethod == 'alipay_web' || kIsWeb || _isDesktopPlatform()) {
           // Web和桌面端使用电脑网站支付
           result = await _membershipService.createAlipayWebOrder(
             authModel.authToken!,
@@ -341,8 +341,8 @@ class _MembershipScreenState extends State<MembershipScreen>
                 Icons.account_balance_wallet,
                 color: Colors.green,
               ),
-              title: const Text('支付宝'),
-              onTap: () => Navigator.of(context).pop('alipay'),
+              title: const Text('支付宝网页支付'),
+              onTap: () => Navigator.of(context).pop('alipay_web'),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- route Android fallback selection to web Alipay instead of retrying app-only Alipay
- relabel the fallback option so users can clearly choose web checkout

## Testing
- flutter analyze lib/screens/membership_screen.dart
- flutter test test/unit/services/membership_service_test.dart (currently blocked by missing impellerc artifact in flutter_scene native asset build on this VPS)
