### PR TITLE
ci: unify official site release sync through api.ombhrum.com

### DIFF
--- a/.github/scripts/sync-app-version-policy.mjs
+++ b/.github/scripts/sync-app-version-policy.mjs
@@ -99,9 +99,42 @@ function normalizeInteger(value) {
 
 function maybeSplitLines(value) {
   if (!value) return undefined;
-  return String(value)
+
+  const text = String(value).trim();
+  if (!text) return undefined;
+
+  if (text.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((item) => String(item || '').trim())
+          .filter(Boolean);
+      }
+    } catch (_) {
+      // fall through to plain text parsing
+    }
+  }
+
+  const includedChangesMatch = text.match(/## Included changes([\s\S]*?)(?:\n## |$)/i);
+  const source = includedChangesMatch?.[1] ?? text;
+  const lines = source
     .split(/\r?\n/)
     .map((item) => item.trim())
+    .filter(Boolean);
+
+  const bulletLines = lines
+    .filter((item) => /^[-*]\s+/.test(item))
+    .map((item) => item.replace(/^[-*]\s+/, '').trim())
+    .filter(Boolean);
+
+  if (bulletLines.length > 0) {
+    return bulletLines;
+  }
+
+  return lines
+    .filter((item) => !/^#{1,6}\s+/.test(item))
+    .map((item) => item.replace(/^[-*]\s+/, '').trim())
     .filter(Boolean);
 }
 

--- a/.github/workflows/publish-official-site-stable.yml
+++ b/.github/workflows/publish-official-site-stable.yml
@@ -26,10 +26,40 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout workflow helper scripts
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.github/scripts/sync-app-version-policy.mjs
+            /fabushi/pubspec.yaml
+
       - name: Set up Node.js for Wrangler
         uses: actions/setup-node@v6
         with:
           node-version: 22
+
+      - name: Load release metadata for version policy sync
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          release_json="$(gh api repos/$RELEASE_REPO/releases/tags/$RELEASE_TAG)"
+          {
+            echo 'GITHUB_RELEASE_TITLE<<EOF'
+            jq -r '.name // .tag_name // ""' <<< "$release_json"
+            echo 'EOF'
+            echo 'GITHUB_RELEASE_BODY<<EOF'
+            jq -r '.body // ""' <<< "$release_json"
+            echo 'EOF'
+            echo "GITHUB_RELEASE_TAG=$RELEASE_TAG"
+            echo "VERSION_PUBLISHED_AT=$(jq -r '.published_at // ""' <<< "$release_json")"
+          } >> "$GITHUB_ENV"
 
       - name: Sync stable Android APK to R2
         id: sync_android_r2
@@ -90,129 +120,34 @@ jobs:
           android_r2_href="${official_site_origin%/}/${object_key}"
           echo "android_r2_href=$android_r2_href" >> "$GITHUB_OUTPUT"
 
-      - name: Generate stable state asset for the official site
+      - name: Sync stable metadata into app version policy
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          ANDROID_ASSET_NAME: ${{ inputs.android_asset_name }}
-          SUMMARY_OVERRIDE: ${{ inputs.summary_override }}
-          ANDROID_APK_PUBLIC_HREF: ${{ steps.sync_android_r2.outputs.android_r2_href }}
+          VERSION_POLICY_ENDPOINT: ${{ vars.VERSION_POLICY_ENDPOINT }}
+          VERSION_POLICY_AUTOMATION_TOKEN: ${{ secrets.VERSION_POLICY_AUTOMATION_TOKEN }}
+          VERSION_POLICY_CHANNELS: stable
+          VERSION_POLICY_PLATFORMS: android
+          APP_DOWNLOAD_URL_ANDROID: ${{ steps.sync_android_r2.outputs.android_r2_href }}
+          VERSION_MESSAGE: ${{ inputs.summary_override }}
+          VERSION_SYNC_SOURCE: github-actions-official-site-stable
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import os
-          import subprocess
-          from datetime import datetime, timezone
-
-          release_repo = os.environ["RELEASE_REPO"]
-          release_tag = os.environ["RELEASE_TAG"]
-          requested_asset_name = os.environ.get("ANDROID_ASSET_NAME", "").strip()
-          summary_override = os.environ.get("SUMMARY_OVERRIDE", "").strip()
-          android_apk_public_href = os.environ.get("ANDROID_APK_PUBLIC_HREF", "").strip()
-          if not android_apk_public_href:
-              raise SystemExit("ANDROID_APK_PUBLIC_HREF is required after syncing the stable APK to R2.")
-
-          release = json.loads(
-              subprocess.check_output(
-                  ["gh", "api", f"repos/{release_repo}/releases/tags/{release_tag}"],
-                  text=True,
-              )
-          )
-          assets = release.get("assets", [])
-
-          apk_assets = [asset for asset in assets if asset.get("name", "").endswith(".apk")]
-          if not apk_assets:
-              raise SystemExit("No APK asset was found in the selected release.")
-
-          if requested_asset_name:
-              apk_asset = next(
-                  (asset for asset in apk_assets if asset.get("name") == requested_asset_name),
-                  None,
-              )
-              if apk_asset is None:
-                  raise SystemExit(f"APK asset '{requested_asset_name}' was not found in the selected release.")
-          else:
-              apk_asset = next((asset for asset in apk_assets if "arm64" in asset.get("name", "")), apk_assets[0])
-
-          def extract_summary(body: str | None, fallback: str) -> list[str]:
-              text = body or ""
-              marker = "## Included changes"
-              if marker in text:
-                  tail = text.split(marker, 1)[1]
-                  section = tail.split("\n## ", 1)[0]
-              else:
-                  section = text
-              lines = []
-              for raw_line in section.splitlines():
-                  line = raw_line.strip()
-                  if line.startswith("- "):
-                      cleaned = line[2:].strip()
-                      if cleaned:
-                          lines.append(cleaned)
-              return lines[:6] if lines else [fallback]
-
-          summary = extract_summary(release.get("body"), release.get("name") or release_tag)
-          if summary_override:
-              summary = [summary_override, *summary]
-
-          state = {
-              "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-              "release": {
-                  "tag": release_tag,
-                  "title": release.get("name") or release_tag,
-                  "publishedAt": release.get("published_at"),
-              },
-              "channels": [
-                  {
-                      "platform": "Android",
-                      "audience": "stable",
-                      "status": "人工验证通过",
-                      "title": "Android 正式版",
-                      "description": "这个入口由人工验证后手动发布到官网，并直接下载 R2 中的正式版 APK。",
-                      "primaryLabel": "下载 Android 正式版",
-                      "primaryHref": android_apk_public_href,
-                      "version": release_tag,
-                      "publishedAt": release.get("published_at"),
-                      "updateSummary": summary,
-                      "mirrorLinks": [],
-                      "note": "每次发布新的正式版 Android APK 后，R2 中的安装包会被覆盖为最新版本。",
-                  }
-              ],
-              "notes": [
-                  "正式版入口只会在人工验收通过后手动发布到官网，并指向 R2 中的 APK。",
-                  "如果后续需要切换到新的正式版，只需要再次运行这个 workflow 并指定新的 release_tag。",
-              ],
-          }
-
-          with open("OFFICIAL_SITE_STABLE_RELEASE_STATE.json", "w", encoding="utf-8") as handle:
-              json.dump(state, handle, ensure_ascii=False, indent=2)
-              handle.write("\n")
-          PY
-
-      - name: Upload stable state asset to the release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          set -euo pipefail
-          gh release upload "$RELEASE_TAG" OFFICIAL_SITE_STABLE_RELEASE_STATE.json --repo "$RELEASE_REPO" --clobber
+          node .github/scripts/sync-app-version-policy.mjs --releaseTag "$GITHUB_RELEASE_TAG"
 
       - name: Write summary
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
+          VERSION_POLICY_ENDPOINT: ${{ vars.VERSION_POLICY_ENDPOINT }}
+          ANDROID_R2_HREF: ${{ steps.sync_android_r2.outputs.android_r2_href }}
         run: |
           {
             echo "## Official site stable state published"
             echo ""
             echo "- Release tag: $RELEASE_TAG"
-            echo "- Asset: OFFICIAL_SITE_STABLE_RELEASE_STATE.json"
-            echo "- This release is now eligible to appear as the stable download on the official site."
+            echo "- Android stable APK synced to R2: $ANDROID_R2_HREF"
+            echo "- Runtime data source synced through api.ombhrum.com: $VERSION_POLICY_ENDPOINT"
+            echo "- The official site stable channel now reads from api.ombhrum.com/api/site/releases."
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify-stable-publish-failure:
@@ -256,12 +191,13 @@ jobs:
                 '',
                 '- 官网正式版下载入口不会切到这次人工验收通过的安装包。',
                 '- 正式版更新说明和 Android R2 下载入口也不会随这次手动发布刷新。',
+                '- api.ombhrum.com/api/site/releases 也不会更新到这次正式版。',
                 '',
                 '### Release context',
                 '',
                 `- Release tag: ${process.env.RELEASE_TAG || 'unknown'}`,
                 `- Requested Android asset: ${process.env.ANDROID_ASSET_NAME || 'auto-select first APK'}`,
                 '- Check whether the target release contains the intended APK asset and whether the manual inputs match the release assets.',
-                '- If metadata generation fails, also verify OFFICIAL_SITE_ORIGIN formatting.',
+                '- Check VERSION_POLICY_ENDPOINT and VERSION_POLICY_AUTOMATION_TOKEN when the D1 sync step fails.',
               ],
             });

--- a/.github/workflows/sync-official-site-beta.yml
+++ b/.github/workflows/sync-official-site-beta.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   actions: read
   issues: write
 
@@ -56,12 +56,36 @@ jobs:
           fi
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
+      - name: Load release metadata for version policy sync
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          release_json="$(gh api repos/$RELEASE_REPO/releases/tags/$RELEASE_TAG)"
+          {
+            echo 'GITHUB_RELEASE_TITLE<<EOF'
+            jq -r '.name // .tag_name // ""' <<< "$release_json"
+            echo 'EOF'
+            echo 'GITHUB_RELEASE_BODY<<EOF'
+            jq -r '.body // ""' <<< "$release_json"
+            echo 'EOF'
+            echo "GITHUB_RELEASE_TAG=$RELEASE_TAG"
+            echo "VERSION_PUBLISHED_AT=$(jq -r '.published_at // ""' <<< "$release_json")"
+          } >> "$GITHUB_ENV"
+
       - name: Checkout workflow helper scripts
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.release.target_commitish || github.sha }}
+          persist-credentials: false
           sparse-checkout-cone-mode: false
           sparse-checkout: |
-            /.github/scripts/**
+            /.github/scripts/generate-official-site-beta-state.py
+            /.github/scripts/sync-app-version-policy.mjs
+            /fabushi/pubspec.yaml
 
       - name: Set up Node.js for Wrangler
         uses: actions/setup-node@v6
@@ -167,7 +191,7 @@ jobs:
             cat "$upload_log"
             echo "uploaded=false" >> "$GITHUB_OUTPUT"
             echo "immutable_release=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Release $RELEASE_TAG is immutable, so OFFICIAL_SITE_RELEASE_STATE.json was not uploaded. The official site will keep using release metadata and TestFlight status fallbacks."
+            echo "::notice::Release $RELEASE_TAG is immutable, so OFFICIAL_SITE_RELEASE_STATE.json was not uploaded."
             rm -f "$upload_log"
             exit 0
           fi
@@ -176,72 +200,45 @@ jobs:
           rm -f "$upload_log"
           exit 1
 
-      - name: Download current official site releases JSON
+      - name: Resolve beta platform sync targets
+        id: policy_targets
         shell: bash
         env:
-          OFFICIAL_SITE_ORIGIN: ${{ vars.OFFICIAL_SITE_ORIGIN || 'https://fabushi.ombhrum.com' }}
+          ANDROID_R2_HREF: ${{ steps.sync_android_r2.outputs.android_r2_href }}
+          IOS_TESTFLIGHT_PUBLIC_URL: ${{ vars.IOS_TESTFLIGHT_PUBLIC_URL || '' }}
         run: |
           set -euo pipefail
-          work_dir="$RUNNER_TEMP/sync-beta-state"
-          mkdir -p "$work_dir"
-          current_json="$work_dir/current-releases.json"
-          if curl -fsSLo "$current_json" "${OFFICIAL_SITE_ORIGIN%/}/api/releases.json"; then
-            echo "Fetched current official site releases JSON from ${OFFICIAL_SITE_ORIGIN%/}/api/releases.json"
-          else
-            echo "{}" > "$current_json"
-            echo "::notice::Current official site releases JSON is not available yet; starting from an empty state."
+          platforms=()
+          if [ -n "${ANDROID_R2_HREF:-}" ]; then
+            platforms+=(android)
+          fi
+          if [ -n "${IOS_TESTFLIGHT_PUBLIC_URL:-}" ]; then
+            platforms+=(ios)
           fi
 
-      - name: Merge generated beta state into official site releases JSON
-        shell: bash
-        env:
-          OFFICIAL_SITE_RELEASE_STATE_PATH: OFFICIAL_SITE_RELEASE_STATE.json
-          OFFICIAL_SITE_RELEASES_EXISTING_PATH: ${{ runner.temp }}/sync-beta-state/current-releases.json
-          OFFICIAL_SITE_RELEASES_OUTPUT_PATH: ${{ runner.temp }}/sync-beta-state/releases.json
-        run: python3 .github/scripts/merge-official-site-beta-state.py
+          if [ "${#platforms[@]}" -eq 0 ]; then
+            echo "platforms=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No beta platform has a public download URL, so api.ombhrum.com sync will be skipped."
+            exit 0
+          fi
 
-      - name: Upload merged official site releases JSON to R2
-        id: sync_releases_json_r2
+          joined="$(IFS=,; echo "${platforms[*]}")"
+          echo "platforms=$joined" >> "$GITHUB_OUTPUT"
+
+      - name: Sync beta metadata into app version policy
+        if: steps.policy_targets.outputs.platforms != ''
         shell: bash
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
-          OFFICIAL_SITE_R2_BUCKET: ${{ vars.OFFICIAL_SITE_R2_BUCKET || 'bushi' }}
-          OFFICIAL_SITE_RELEASES_R2_OBJECT_KEY: ${{ vars.OFFICIAL_SITE_RELEASES_R2_OBJECT_KEY || 'api/releases.json' }}
-          OFFICIAL_SITE_ORIGIN: ${{ vars.OFFICIAL_SITE_ORIGIN || 'https://fabushi.ombhrum.com' }}
+          VERSION_POLICY_ENDPOINT: ${{ vars.VERSION_POLICY_ENDPOINT }}
+          VERSION_POLICY_AUTOMATION_TOKEN: ${{ secrets.VERSION_POLICY_AUTOMATION_TOKEN }}
+          VERSION_POLICY_CHANNELS: beta
+          VERSION_POLICY_PLATFORMS: ${{ steps.policy_targets.outputs.platforms }}
+          APP_DOWNLOAD_URL_ANDROID: ${{ steps.sync_android_r2.outputs.android_r2_href }}
+          APP_DOWNLOAD_URL_IOS: ${{ vars.IOS_TESTFLIGHT_PUBLIC_URL || '' }}
+          VERSION_SYNC_SOURCE: github-actions-official-site-beta
         run: |
           set -euo pipefail
-          merged_json="$RUNNER_TEMP/sync-beta-state/releases.json"
-          if [ ! -f "$merged_json" ]; then
-            echo "Merged releases JSON was not generated." >&2
-            exit 1
-          fi
-
-          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
-            echo "Cloudflare credentials are required to sync the official site releases JSON to R2." >&2
-            exit 1
-          fi
-
-          bucket="${OFFICIAL_SITE_R2_BUCKET:-bushi}"
-          object_key="${OFFICIAL_SITE_RELEASES_R2_OBJECT_KEY:-api/releases.json}"
-          official_site_origin="${OFFICIAL_SITE_ORIGIN:-https://fabushi.ombhrum.com}"
-
-          npx --yes wrangler@latest r2 object put "$bucket/$object_key" \
-            --file "$merged_json" \
-            --content-type application/json \
-            --cache-control no-store \
-            --force \
-            --remote
-
-          releases_json_href="${official_site_origin%/}/${object_key}"
-          echo "releases_json_href=$releases_json_href" >> "$GITHUB_OUTPUT"
-          {
-            echo "## Official site releases JSON synced to R2"
-            echo ""
-            echo "- Bucket: $bucket"
-            echo "- Object key: $object_key"
-            echo "- Official Worker href: $releases_json_href"
-          } >> "$GITHUB_STEP_SUMMARY"
+          node .github/scripts/sync-app-version-policy.mjs --releaseTag "$GITHUB_RELEASE_TAG"
 
       - name: Write summary
         shell: bash
@@ -250,7 +247,8 @@ jobs:
           RELEASE_STATE_UPLOADED: ${{ steps.upload_state.outputs.uploaded }}
           IMMUTABLE_RELEASE: ${{ steps.upload_state.outputs.immutable_release }}
           ANDROID_R2_HREF: ${{ steps.sync_android_r2.outputs.android_r2_href }}
-          RELEASES_JSON_R2_HREF: ${{ steps.sync_releases_json_r2.outputs.releases_json_href }}
+          BETA_POLICY_PLATFORMS: ${{ steps.policy_targets.outputs.platforms }}
+          VERSION_POLICY_ENDPOINT: ${{ vars.VERSION_POLICY_ENDPOINT }}
         run: |
           {
             echo "## Official site beta state synced"
@@ -260,18 +258,19 @@ jobs:
               echo "- Asset: OFFICIAL_SITE_RELEASE_STATE.json uploaded to the GitHub Release"
             elif [ "$IMMUTABLE_RELEASE" = "true" ]; then
               echo "- Asset upload skipped because the GitHub Release is immutable"
-              echo "- Official site fallback remains available through release metadata and TESTFLIGHT_UPLOAD_STATUS.txt"
             else
               echo "- Asset: OFFICIAL_SITE_RELEASE_STATE.json was generated locally"
             fi
             if [ -n "$ANDROID_R2_HREF" ]; then
               echo "- Android APK was copied to R2: $ANDROID_R2_HREF"
             fi
-            if [ -n "$RELEASES_JSON_R2_HREF" ]; then
-              echo "- Official site releases JSON was merged and copied to R2: $RELEASES_JSON_R2_HREF"
+            if [ -n "$BETA_POLICY_PLATFORMS" ]; then
+              echo "- Runtime data source synced through api.ombhrum.com: $VERSION_POLICY_ENDPOINT"
+              echo "- Synced beta platforms: $BETA_POLICY_PLATFORMS"
+            else
+              echo "- Runtime data source sync skipped because no public beta platform URL was available"
             fi
-            echo "- No Git commit or sync PR is needed for /api/releases.json anymore."
-            echo "- If a release only contains one platform, the official site keeps the previous entry for the other platform."
+            echo "- The official site now reads beta runtime metadata from api.ombhrum.com/api/site/releases."
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify-beta-sync-failure:
@@ -315,11 +314,12 @@ jobs:
                 '- Android beta 下载入口不会自动切到最新发布版本 APK。',
                 '- iOS TestFlight 状态不会自动同步到官网。',
                 '- 官网“这次更新了什么”和 Android R2 下载入口也不会随本次 release 刷新。',
+                '- api.ombhrum.com/api/site/releases 也不会更新到这次 beta 版本。',
                 '',
                 '### Release context',
                 '',
                 `- Release tag: ${process.env.RELEASE_TAG || 'unknown'}`,
-                '- Check whether the selected release contains an APK asset and TESTFLIGHT_UPLOAD_STATUS.txt when iOS beta should be updated.',
-                '- Check whether IOS_TESTFLIGHT_PUBLIC_URL or OFFICIAL_SITE_ORIGIN variables are malformed when the sync script fails during metadata generation.',
+                '- Check whether the selected release contains an APK asset and whether IOS_TESTFLIGHT_PUBLIC_URL is configured when iOS beta should be public.',
+                '- Check VERSION_POLICY_ENDPOINT and VERSION_POLICY_AUTOMATION_TOKEN when the D1 sync step fails.',
               ],
             });


### PR DESCRIPTION
## Summary
- route official-site beta sync through the D1-backed version policy API instead of the legacy `/api/releases.json` path
- route stable publish updates through the same `api.ombhrum.com/api/site/releases` data source
- normalize synced release notes before storing them so the official site shows cleaner update lines

## Why
The official site frontend already reads `api.ombhrum.com/api/site/releases`, but the release sync workflow was still maintaining `fabushi.ombhrum.com/api/releases.json`. That split allowed GitHub releases and the official site to drift out of sync.

## Notes
- beta sync now only updates platforms that have a public download URL, so an incomplete release does not wipe the previous visible channel
- the legacy release asset upload is kept for traceability, but the runtime source of truth becomes `api.ombhrum.com/api/site/releases`
