### PR TITLE
Fix incense gradient paint errors

### DIFF
--- a/fabushi/lib/screens/buddha_model_screen_native.dart
+++ b/fabushi/lib/screens/buddha_model_screen_native.dart
@@ -700,6 +700,7 @@ class _IncensePainter extends CustomPainter {
           base.translate(-46, 12),
           base.translate(46, 34),
           const [Color(0xFFFFD36A), Color(0xFF7A4314), Color(0xFFD4AF37)],
+          const [0.0, 0.55, 1.0],
         ),
     );
 


### PR DESCRIPTION
## Summary
- add explicit color stops for the native Buddha incense base gradient
- prevents release builds from throwing repeated Gradient colorStops errors on the Zen room

## Tests
- flutter analyze lib/screens/buddha_model_screen_native.dart