### PR TITLE
Make CBETA and practice sends local-first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,7 @@ jobs:
           sparse-checkout: |
             /scripts/check_home_send_flow.py
             /fabushi/lib/screens/globe_home_screen.dart
+            /fabushi/lib/screens/global_dharma_screen.dart
             /fabushi/lib/models/file_transfer_model.dart
 
       - name: Validate homepage send flow

--- a/fabushi/integration_test/home_send_real_device_test.dart
+++ b/fabushi/integration_test/home_send_real_device_test.dart
@@ -14,9 +14,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('real device homepage starts scripture sending', (tester) async {
+  testWidgets('real device homepage starts selected content sending', (
+    tester,
+  ) async {
     SharedPreferences.setMockInitialValues({'auto_start_guide_shown': true});
     final model = FileTransferModel();
+    await model.addTextContentForSending(
+      title: 'real-device-smoke',
+      text: '南无阿弥陀佛',
+    );
 
     await tester.pumpWidget(
       MultiProvider(
@@ -43,20 +49,16 @@ void main() {
     final deadline = DateTime.now().add(const Duration(seconds: 90));
     while (DateTime.now().isBefore(deadline) &&
         model.currentSendingScripture.isEmpty &&
-        !model.currentLog.contains('已将') &&
-        !model.currentLog.contains('开始逐国发送') &&
+        !model.currentLog.contains('real-device-smoke') &&
         model.globalSentCount == 0 &&
-        !model.currentLog.contains('失败') &&
-        !model.currentLog.contains('未下载')) {
+        !model.currentLog.contains('失败')) {
       await tester.pump(const Duration(milliseconds: 500));
     }
 
     expect(model.currentLog.contains('失败'), isFalse, reason: model.currentLog);
-    expect(model.currentLog.contains('未下载'), isFalse, reason: model.currentLog);
     expect(
       model.currentSendingScripture.isNotEmpty ||
-          model.currentLog.contains('已将') ||
-          model.currentLog.contains('开始逐国发送') ||
+          model.currentLog.contains('real-device-smoke') ||
           model.globalSentCount > 0,
       isTrue,
       reason:

--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -150,8 +150,6 @@ class AppConfig {
   static const String testModeStorageKey = 'test_mode';
 
   // API端点
-  static const String cbetaSendTextsEndpoint = '/api/cbeta/send-texts';
-
   static String get loginUrl => buildBackendUrl('/api/auth/login');
   static String get registerUrl => buildBackendUrl('/api/auth/register');
   static String get verifyUrl => buildBackendUrl('/api/auth/verify');

--- a/fabushi/lib/models/file_transfer_model.dart
+++ b/fabushi/lib/models/file_transfer_model.dart
@@ -1,20 +1,21 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:http/http.dart' as http;
 import 'dart:io';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:async';
 
-import '../core/constants/country_servers.dart';
+import '../core/config/app_config.dart';
 import '../screens/asset_screen.dart';
+import '../services/asset_loader_service.dart';
 import '../services/shared_asset_manager.dart';
 import '../services/download_manager.dart' show DownloadStatus;
 import '../services/real_global_send_service.dart';
 import '../services/platform_global_send_service.dart';
 import '../services/ip_location_service.dart';
 import '../services/leaderboard_service.dart';
-import '../services/cbeta_send_text_service.dart';
 import '../services/wifi_field_broadcast_service.dart';
 import '../services/hotspot_manager_service.dart';
 import '../services/keep_alive_service.dart';
@@ -54,7 +55,6 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   final SharedAssetManager _sharedAssetManager = SharedAssetManager();
   final IPLocationService _ipLocationService = IPLocationService();
-  final CbetaSendTextService _cbetaSendTextService = CbetaSendTextService();
   final Map<String, Uint8List> _downloadedScriptureMemory = {};
 
   WiFiFieldBroadcastService? _fieldBroadcastService;
@@ -67,8 +67,6 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   LocalLoopbackService? _localLoopbackService;
 
   bool _isDisposed = false;
-  bool _stopRequested = false;
-
   PlatformFile? get selectedFile =>
       _selectedFiles.isNotEmpty ? _selectedFiles.first : null;
   double _progress = 0.0;
@@ -243,12 +241,6 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     _preparingSendMessage = '';
   }
 
-  void _cacheScriptureFile(PlatformFile file) {
-    if (file.bytes != null) {
-      _downloadedScriptureMemory[file.name] = file.bytes!;
-    }
-  }
-
   void _releaseCachedScriptures({bool clearSelection = true}) {
     _downloadedScriptureMemory.clear();
     if (clearSelection) {
@@ -256,178 +248,28 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     }
   }
 
-  PlatformFile _buildPlatformFileFromText(CbetaSendText text) {
-    final content = [
-      '来源: CBETA',
-      '经名: ${text.title}',
-      '编号: ${text.work} 第 ${text.juan} 卷',
-      if (text.byline.isNotEmpty) '译者/作者: ${text.byline}',
-      if (text.category.isNotEmpty) '分类: ${text.category}',
-      if (text.sourceUrl.isNotEmpty) 'CBETA API: ${text.sourceUrl}',
-      '',
-      text.content,
-    ].join('\n');
-    final bytes = Uint8List.fromList(utf8.encode(content));
-    final file = PlatformFile(
-      name: text.fileName.isNotEmpty ? text.fileName : '${text.work}.txt',
-      size: bytes.length,
-      bytes: bytes,
-    );
-    _cacheScriptureFile(file);
-    return file;
-  }
-
   Future<int> startDefaultScriptureSendSequence() async {
     if (_isPreparingSend || _isTransferring) return 0;
 
-    _stopRequested = false;
-    _isLooping = false;
-    _status = TransferStatus.idle;
-    _globalSentCount = 0;
-    _globalDataSentMB = 0;
-    _releaseCachedScriptures();
-    beginPreparingSend('📚 正在逐部下载经文，下载一部发送一部...');
-
-    final seenScriptures = <String>{};
-    int sentScriptureCount = 0;
-    int offset = 0;
-    String? cursor;
-    bool foundAny = false;
-
-    try {
-      while (!_stopRequested) {
-        final result = await _cbetaSendTextService.fetchSendTextsPage(
-          limit: 1,
-          offset: offset,
-          cursor: cursor,
-        );
-
-        if (result.items.isEmpty) {
-          break;
-        }
-
-        foundAny = true;
-        bool pageHadNewItem = false;
-
-        for (final text in result.items) {
-          if (_stopRequested) break;
-
-          final scriptureKey =
-              '${text.work}_${text.juan}_${text.fileName}_${text.title}';
-          if (!seenScriptures.add(scriptureKey)) {
-            continue;
-          }
-          pageHadNewItem = true;
-
-          final file = _buildPlatformFileFromText(text);
-          _selectedFiles = [file];
-          _currentSendingScripture = text.title;
-          _preparingSendMessage = '📚 已下载《${text.title}》，准备发送到全部国家...';
-          _currentLog = '📚 已将《${text.title}》下载到内存，开始逐国发送';
-          initializeCountryStatuses(GLOBAL_COUNTRY_SERVERS, COUNTRY_NAMES);
-          notifyListeners();
-
-          await startGlobalTransfer(forceSingleRound: true);
-
-          if (_stopRequested) {
-            break;
-          }
-
-          if (_status == TransferStatus.error) {
-            _finishPreparingSend();
-            notifyListeners();
-            return sentScriptureCount;
-          }
-
-          sentScriptureCount++;
-          _releaseCachedScriptures();
-          _currentSendingScripture = '';
-          _currentLog = '✅ 已完成《${text.title}》全球发送，准备下一部经文...';
-          if (!_stopRequested) {
-            beginPreparingSend('📚 《${text.title}》已发送完成，继续下载下一部...');
-          }
-        }
-
-        if (_stopRequested) {
-          break;
-        }
-
-        if (!pageHadNewItem) {
-          break;
-        }
-
-        final nextCursor = result.nextCursor?.trim();
-        if (nextCursor != null &&
-            nextCursor.isNotEmpty &&
-            nextCursor != cursor) {
-          cursor = nextCursor;
-        } else if (result.hasMore) {
-          offset += result.items.length;
-        } else {
-          break;
-        }
-      }
-
-      if (!foundAny) {
-        _currentLog = '未下载到可发送的 CBETA 经文';
-        _finishPreparingSend();
-        notifyListeners();
-        return 0;
-      }
-
-      if (_stopRequested) {
-        _currentLog = '🛑 已停止逐部发送';
-      } else {
-        _currentLog = '✨ 已完成全部经文逐部下载与发送，共 $sentScriptureCount 部';
-        _status = TransferStatus.completed;
-      }
-      _finishPreparingSend();
-      notifyListeners();
-      return sentScriptureCount;
-    } catch (error) {
-      _selectedFiles = [];
-      _releaseCachedScriptures();
-      _currentSendingScripture = '';
-      _finishPreparingSend();
-      _status = TransferStatus.error;
-      updateLog('❌ CBETA 经文逐部下载失败: $error');
-      notifyListeners();
-      return sentScriptureCount;
+    if (!hasFiles) {
+      updateLog('请先选择链接、文本、本机文件或禅室佛像素材后再发送。');
+      return 0;
     }
+
+    await startGlobalTransfer(forceSingleRound: true);
+    return _globalSentCount;
   }
 
   Future<int> prepareDefaultNonR2AssetsForSending() async {
-    beginPreparingSend('📚 正在下载默认经文，下载完成后会自动开始发送...');
-
-    try {
-      final result = await _cbetaSendTextService.fetchDefaultSendTexts();
-      _selectedFiles = result.items.map(_buildPlatformFileFromText).toList();
-
-      _isLooping = true;
-      _currentSendingScripture = result.items.isNotEmpty
-          ? result.items.first.title
-          : '';
-      final titles = result.items.map((item) => '《${item.title}》').join('、');
-      final warning = result.errors.isEmpty
-          ? ''
-          : '；部分经文下载失败: ${jsonEncode(result.errors)}';
-      _preparingSendMessage = '📚 已下载 ${_selectedFiles.length} 部经文，正在启动发送...';
-      updateLog(
-        '📚 已从 CBETA 下载 ${_selectedFiles.length} 部经文，准备发送 $titles$warning',
-      );
-      debugPrint('📚 已从 CBETA 下载 ${_selectedFiles.length} 部经文，循环发送已开启');
-      notifyListeners();
-      return _selectedFiles.length;
-    } catch (error) {
-      _selectedFiles = [];
-      _releaseCachedScriptures();
-      _currentSendingScripture = '';
-      _finishPreparingSend();
-      updateLog('❌ CBETA 经文下载失败: $error');
-      debugPrint('❌ CBETA 经文下载失败: $error');
-      notifyListeners();
+    if (!hasFiles) {
+      updateLog('请先选择链接、文本、本机文件或禅室佛像素材后再发送。');
       return 0;
     }
+
+    _isLooping = true;
+    updateLog('已使用当前选择的内容准备发送。');
+    notifyListeners();
+    return _selectedFiles.length;
   }
 
   Future<void> selectFiles() async {
@@ -642,6 +484,112 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       '📁 添加文件: ${files.map((f) => f.name).join(', ')}，当前总数: ${_selectedFiles.length}',
     );
     notifyListeners();
+  }
+
+  Future<void> addTextContentForSending({
+    required String title,
+    required String text,
+    bool replaceExisting = true,
+  }) async {
+    final normalizedText = text.trim();
+    if (normalizedText.isEmpty) {
+      throw ArgumentError('请输入要发送的文本内容');
+    }
+
+    final fileName = '${_safeFileName(title.isEmpty ? 'text' : title)}.txt';
+    final bytes = Uint8List.fromList(utf8.encode(normalizedText));
+    final file = PlatformFile(name: fileName, size: bytes.length, bytes: bytes);
+
+    if (replaceExisting) {
+      _selectedFiles = [file];
+      _downloadedScriptureMemory
+        ..clear()
+        ..[file.name] = bytes;
+    } else {
+      addFiles([file]);
+      _downloadedScriptureMemory[file.name] = bytes;
+      return;
+    }
+
+    _currentSendingScripture = _displayScriptureName(file.name);
+    _currentLog = '已选择文本内容: ${file.name}';
+    notifyListeners();
+  }
+
+  Future<void> addUrlContentForSending(String url) async {
+    final uri = Uri.tryParse(url.trim());
+    if (uri == null || !(uri.scheme == 'http' || uri.scheme == 'https')) {
+      throw ArgumentError('请输入 http/https 链接');
+    }
+
+    beginPreparingSend('正在读取链接内容...');
+    try {
+      final response = await http
+          .get(
+            uri,
+            headers: const {
+              'Accept': 'text/html,text/plain,application/xhtml+xml,*/*',
+            },
+          )
+          .timeout(const Duration(seconds: 20));
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw StateError('链接读取失败: HTTP ${response.statusCode}');
+      }
+
+      final raw = utf8.decode(response.bodyBytes, allowMalformed: true);
+      final contentType = response.headers['content-type'] ?? '';
+      final isHtml =
+          contentType.toLowerCase().contains('html') ||
+          RegExp(r'<html|<body|<p[>\s]', caseSensitive: false).hasMatch(raw);
+      final extractedTitle = isHtml ? _extractHtmlTitle(raw) : null;
+      final bodyText = isHtml ? _htmlToReadableText(raw) : raw.trim();
+      final title = extractedTitle?.trim().isNotEmpty == true
+          ? extractedTitle!.trim()
+          : _titleFromUri(uri);
+      final sendText = [
+        '来源链接: ${uri.toString()}',
+        '',
+        bodyText.isEmpty ? uri.toString() : bodyText,
+      ].join('\n');
+
+      await addTextContentForSending(title: title, text: sendText);
+      _currentLog = '已读取链接内容: $title';
+    } finally {
+      _finishPreparingSend();
+      notifyListeners();
+    }
+  }
+
+  Future<void> addZenBuddhaAssetForSending() async {
+    beginPreparingSend('正在准备禅室佛像素材...');
+    try {
+      final file = await AssetLoaderService.getPersistentAssetFile(
+        AppConfig.buddhaModelAssetPath,
+        ensureLoaded: true,
+        onProgress: (progress) {
+          _preparingSendMessage =
+              '正在准备禅室佛像素材 ${(progress * 100).clamp(0, 100).toStringAsFixed(0)}%';
+          notifyListeners();
+        },
+      );
+      if (file == null || !await file.exists()) {
+        throw StateError('未找到禅室佛像素材');
+      }
+
+      final size = await file.length();
+      final platformFile = PlatformFile(
+        name: _pathBasename(AppConfig.buddhaModelAssetPath),
+        size: size,
+        path: file.path,
+      );
+      _selectedFiles = [platformFile];
+      _downloadedScriptureMemory.clear();
+      _currentSendingScripture = '禅室佛像素材';
+      _currentLog = '已选择禅室佛像素材: ${platformFile.name}';
+    } finally {
+      _finishPreparingSend();
+      notifyListeners();
+    }
   }
 
   void removeFile(PlatformFile file) {
@@ -915,7 +863,6 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   void stopTransfer() {
-    _stopRequested = true;
     if (!_isTransferring && !_isPreparingSend) return;
 
     _isTransferring = false;
@@ -966,6 +913,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     }
   }
 
+  // ignore: unused_element
   void _onToggleAudioMute() async {
     debugPrint('🔇 收到静音切换请求');
     await _keepAliveService.toggleMute();
@@ -1056,6 +1004,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     debugPrint('📋 平台全球发送服务初始化完成 - 模式: $mode');
   }
 
+  // ignore: unused_element
   Future<void> _initializeRealGlobalSendService() async {
     double? userLat;
     double? userLng;
@@ -1280,6 +1229,91 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     );
     final normalized = withoutCbetaPrefix.replaceAll('_', ' ').trim();
     return normalized.isEmpty ? withoutExtension : normalized;
+  }
+
+  String _safeFileName(String value) {
+    final safe = value
+        .replaceAll(RegExp(r'[\\/:*?"<>|]+'), '_')
+        .replaceAll(RegExp(r'\s+'), '_')
+        .trim();
+    if (safe.isEmpty) return 'content';
+    return safe.length > 80 ? safe.substring(0, 80) : safe;
+  }
+
+  String _pathBasename(String value) {
+    final parts = value.split(RegExp(r'[\\/]'));
+    return parts.isEmpty || parts.last.isEmpty ? value : parts.last;
+  }
+
+  String _titleFromUri(Uri uri) {
+    if (uri.pathSegments.isNotEmpty && uri.pathSegments.last.isNotEmpty) {
+      return Uri.decodeComponent(
+        uri.pathSegments.last.replaceAll(RegExp(r'\.[^.]+$'), ''),
+      );
+    }
+    return uri.host.isEmpty ? 'link' : uri.host;
+  }
+
+  String? _extractHtmlTitle(String html) {
+    final title = RegExp(
+      r'<title>([\s\S]*?)</title>',
+      caseSensitive: false,
+    ).firstMatch(html)?.group(1);
+    if (title == null) return null;
+    return _decodeHtmlEntities(title.replaceAll(RegExp(r'<[^>]+>'), '')).trim();
+  }
+
+  String _htmlToReadableText(String html) {
+    final bodyMatch = RegExp(
+      r'<body[^>]*>([\s\S]*?)</body>',
+      caseSensitive: false,
+    ).firstMatch(html);
+    var source = bodyMatch?.group(1) ?? html;
+    source = source
+        .replaceAll(
+          RegExp(r'<script[\s\S]*?</script>', caseSensitive: false),
+          '',
+        )
+        .replaceAll(RegExp(r'<style[\s\S]*?</style>', caseSensitive: false), '')
+        .replaceAll(
+          RegExp(r'<(p|div|br|h[1-6]|li)\b[^>]*>', caseSensitive: false),
+          '\n',
+        )
+        .replaceAll(RegExp(r'</(p|div|h[1-6]|li)>', caseSensitive: false), '\n')
+        .replaceAll(RegExp(r'<[^>]+>'), '');
+
+    return _decodeHtmlEntities(source)
+        .replaceAll('\r', '')
+        .replaceAll(RegExp(r'[ \t\f\v]+'), ' ')
+        .replaceAll(RegExp(r'\n[ \t]+'), '\n')
+        .replaceAll(RegExp(r'[ \t]+\n'), '\n')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+  }
+
+  String _decodeHtmlEntities(String value) {
+    const named = {
+      'amp': '&',
+      'lt': '<',
+      'gt': '>',
+      'quot': '"',
+      'apos': "'",
+      'nbsp': ' ',
+    };
+    return value.replaceAllMapped(RegExp(r'&(#x?[0-9a-fA-F]+|[a-zA-Z]+);'), (
+      match,
+    ) {
+      final code = match.group(1) ?? '';
+      if (code.startsWith('#x') || code.startsWith('#X')) {
+        final parsed = int.tryParse(code.substring(2), radix: 16);
+        return parsed == null ? match.group(0)! : String.fromCharCode(parsed);
+      }
+      if (code.startsWith('#')) {
+        final parsed = int.tryParse(code.substring(1));
+        return parsed == null ? match.group(0)! : String.fromCharCode(parsed);
+      }
+      return named[code] ?? match.group(0)!;
+    });
   }
 
   int getSuccessCount() {

--- a/fabushi/lib/models/practice_book_model.dart
+++ b/fabushi/lib/models/practice_book_model.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 
-enum PracticeBookSourceType { file, url, manual, cloud }
+enum PracticeBookSourceType { file, url, manual, image, cloud }
 
 enum PracticeBookSyncStatus { localOnly, pendingUpload, synced, syncFailed }
 
@@ -27,6 +27,7 @@ class PracticeBook {
   final PracticeBookSourceType sourceType;
   final String? sourceUrl;
   final String? sourceFileName;
+  final String? sourceFilePath;
   final String contentHash;
   final String plainText;
   final String normalizedText;
@@ -43,6 +44,7 @@ class PracticeBook {
     required this.sourceType,
     this.sourceUrl,
     this.sourceFileName,
+    this.sourceFilePath,
     required this.contentHash,
     required this.plainText,
     required this.normalizedText,
@@ -60,6 +62,7 @@ class PracticeBook {
     required PracticeBookSourceType sourceType,
     String? sourceUrl,
     String? sourceFileName,
+    String? sourceFilePath,
     required String plainText,
     String? remoteObjectKey,
     PracticeBookSyncStatus syncStatus = PracticeBookSyncStatus.pendingUpload,
@@ -73,6 +76,7 @@ class PracticeBook {
       sourceType: sourceType,
       sourceUrl: sourceUrl,
       sourceFileName: sourceFileName,
+      sourceFilePath: sourceFilePath,
       contentHash: PracticeBookText.sha256Of(plainText),
       plainText: plainText,
       normalizedText: normalizedText,
@@ -96,6 +100,9 @@ class PracticeBook {
       sourceUrl: _emptyToNull(map['source_url'] ?? map['sourceUrl']),
       sourceFileName: _emptyToNull(
         map['source_file_name'] ?? map['sourceFileName'],
+      ),
+      sourceFilePath: _emptyToNull(
+        map['source_file_path'] ?? map['sourceFilePath'],
       ),
       contentHash: (map['content_hash'] ?? map['contentHash'] ?? '').toString(),
       plainText: (map['plain_text'] ?? map['plainText'] ?? '').toString(),
@@ -142,6 +149,7 @@ class PracticeBook {
       'source_type': sourceType.name,
       'source_url': sourceUrl,
       'source_file_name': sourceFileName,
+      'source_file_path': sourceFilePath,
       'content_hash': contentHash,
       'plain_text': plainText,
       'normalized_text': normalizedText,
@@ -160,6 +168,7 @@ class PracticeBook {
     'sourceType': sourceType.name,
     'sourceUrl': sourceUrl,
     'sourceFileName': sourceFileName,
+    'sourceFilePath': sourceFilePath,
     'contentHash': contentHash,
     'plainText': plainText,
     'normalizedText': normalizedText,
@@ -177,6 +186,7 @@ class PracticeBook {
     PracticeBookSourceType? sourceType,
     String? sourceUrl,
     String? sourceFileName,
+    String? sourceFilePath,
     String? contentHash,
     String? plainText,
     String? normalizedText,
@@ -193,6 +203,7 @@ class PracticeBook {
       sourceType: sourceType ?? this.sourceType,
       sourceUrl: sourceUrl ?? this.sourceUrl,
       sourceFileName: sourceFileName ?? this.sourceFileName,
+      sourceFilePath: sourceFilePath ?? this.sourceFilePath,
       contentHash: contentHash ?? this.contentHash,
       plainText: plainText ?? this.plainText,
       normalizedText: normalizedText ?? this.normalizedText,

--- a/fabushi/lib/screens/global_dharma_screen.dart
+++ b/fabushi/lib/screens/global_dharma_screen.dart
@@ -25,13 +25,20 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
 
   Future<void> _startGlobalDharma() async {
     final model = context.read<FileTransferModel>();
-    final sentCount = await model.startDefaultScriptureSendSequence();
+    if (!model.hasFiles) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('请先在首页选择链接、文本、本机文件或禅室佛像素材。')),
+      );
+      return;
+    }
+
+    await model.startGlobalTransfer();
 
     if (!mounted || model.isTransferring || model.isPreparingSend) {
       return;
     }
 
-    if (sentCount == 0 && model.currentLog.contains('未下载到可发送')) {
+    if (model.globalSentCount == 0 && model.currentLog.isNotEmpty) {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(model.currentLog)));
@@ -175,7 +182,7 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
               : Icon(model.isTransferring ? Icons.stop : Icons.play_arrow),
           label: Text(
             model.isPreparingSend
-                ? '逐部下载中'
+                ? '准备发送中'
                 : model.isTransferring
                 ? '停止发送'
                 : '开始法布施',

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -595,7 +595,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                             ),
                             const SizedBox(width: 8),
                             const Text(
-                              '逐部发送',
+                              '内容发送',
                               style: TextStyle(
                                 color: AppTheme.primaryColor,
                                 fontSize: 13,
@@ -711,7 +711,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                                 ),
                               ),
                               label: const Text(
-                                '逐部下载中',
+                                '准备发送中',
                                 style: TextStyle(fontSize: 13),
                               ),
                               style: ElevatedButton.styleFrom(
@@ -895,8 +895,183 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     );
   }
 
+  Future<bool> _showSendContentSheet(FileTransferModel model) async {
+    final result = await showModalBottomSheet<bool>(
+      context: context,
+      backgroundColor: const Color(0xFF171717),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+      ),
+      builder: (sheetContext) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '选择要全球发送的内容',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 14),
+              _SendSourceTile(
+                icon: Icons.link,
+                title: '输入链接',
+                subtitle: '读取链接正文并发送',
+                onTap: () async {
+                  Navigator.pop(sheetContext, await _inputSendLink(model));
+                },
+              ),
+              _SendSourceTile(
+                icon: Icons.edit_note,
+                title: '输入文本',
+                subtitle: '发送手输或粘贴的文本',
+                onTap: () async {
+                  Navigator.pop(sheetContext, await _inputSendText(model));
+                },
+              ),
+              _SendSourceTile(
+                icon: Icons.folder_open,
+                title: '选择本机文件',
+                subtitle: '发送手机本机文件',
+                onTap: () async {
+                  final before = model.selectedFiles.length;
+                  await model.selectFiles();
+                  Navigator.pop(
+                    sheetContext,
+                    model.selectedFiles.length > before,
+                  );
+                },
+              ),
+              _SendSourceTile(
+                icon: Icons.self_improvement,
+                title: '禅室佛像素材',
+                subtitle: '发送禅室当前佛像模型素材',
+                onTap: () async {
+                  Navigator.pop(sheetContext, await _selectBuddhaAsset(model));
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    return result == true;
+  }
+
+  Future<bool> _inputSendText(FileTransferModel model) async {
+    final titleController = TextEditingController();
+    final textController = TextEditingController();
+    final result = await showDialog<Map<String, String>>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('输入发送文本'),
+        content: SizedBox(
+          width: 420,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: titleController,
+                decoration: const InputDecoration(labelText: '标题'),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: textController,
+                minLines: 6,
+                maxLines: 10,
+                decoration: const InputDecoration(
+                  hintText: '输入或粘贴要发送的内容',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('取消'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, {
+              'title': titleController.text.trim(),
+              'text': textController.text.trim(),
+            }),
+            child: const Text('确定'),
+          ),
+        ],
+      ),
+    );
+    if (result == null || (result['text'] ?? '').trim().isEmpty) return false;
+    await model.addTextContentForSending(
+      title: result['title'] ?? '',
+      text: result['text'] ?? '',
+    );
+    return true;
+  }
+
+  Future<bool> _inputSendLink(FileTransferModel model) async {
+    final controller = TextEditingController();
+    final url = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('输入链接'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          keyboardType: TextInputType.url,
+          decoration: const InputDecoration(hintText: 'https://...'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('取消'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('读取'),
+          ),
+        ],
+      ),
+    );
+    if (url == null || url.isEmpty) return false;
+    try {
+      await model.addUrlContentForSending(url);
+      return true;
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('链接读取失败: $e'), backgroundColor: Colors.red),
+        );
+      }
+      return false;
+    }
+  }
+
+  Future<bool> _selectBuddhaAsset(FileTransferModel model) async {
+    try {
+      await model.addZenBuddhaAssetForSending();
+      return true;
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('佛像素材准备失败: $e'), backgroundColor: Colors.red),
+        );
+      }
+      return false;
+    }
+  }
+
   void _startSending(FileTransferModel model) async {
     if (model.isPreparingSend || model.isTransferring) return;
+
+    final prepared = await _showSendContentSheet(model);
+    if (!prepared || !mounted || !model.hasFiles) return;
 
     if (Platform.isAndroid && mounted) {
       try {
@@ -912,14 +1087,15 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('🌍 开始逐部下载经文，并在每部下载完成后发送到全部国家...'),
+          content: Text('🌍 开始把所选内容发送到全部国家...'),
           duration: Duration(seconds: 2),
           backgroundColor: Colors.black87,
         ),
       );
     }
 
-    final sentCount = await model.startDefaultScriptureSendSequence();
+    await model.startGlobalTransfer();
+    final sentCount = model.globalSentCount;
 
     await _onlineCounterService.leaveActivity();
     _globeKey.currentState?.clearBeams();
@@ -934,7 +1110,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     if (model.status == TransferStatus.completed && sentCount > 0) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('✨ 经文已逐部发送完成，共完成 $sentCount 部！'),
+          content: Text('✨ 所选内容已发送完成，共完成 $sentCount 个国家！'),
           backgroundColor: Colors.green,
           duration: const Duration(seconds: 3),
         ),
@@ -968,5 +1144,35 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         ),
       );
     }
+  }
+}
+
+class _SendSourceTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final Future<void> Function() onTap;
+
+  const _SendSourceTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        backgroundColor: const Color(0xFFD4AF37).withValues(alpha: 0.16),
+        foregroundColor: const Color(0xFFD4AF37),
+        child: Icon(icon),
+      ),
+      title: Text(title, style: const TextStyle(color: Colors.white)),
+      subtitle: Text(subtitle, style: const TextStyle(color: Colors.white60)),
+      trailing: const Icon(Icons.chevron_right, color: Colors.white54),
+      onTap: onTap,
+    );
   }
 }

--- a/fabushi/lib/services/asset_loader_service.dart
+++ b/fabushi/lib/services/asset_loader_service.dart
@@ -181,6 +181,26 @@ class AssetLoaderService {
   }
 
   // 正在进行的加载任务，防止并发下载同一资源
+  static Future<File?> getPersistentAssetFile(
+    String fileName, {
+    bool ensureLoaded = false,
+    void Function(double progress)? onProgress,
+  }) async {
+    if (kIsWeb) return null;
+
+    if (ensureLoaded) {
+      await _loadAsset(fileName, onProgress: onProgress);
+    }
+
+    final dir = await _getStorageDirectory();
+    final safeFileName = fileName.replaceAll('/', '_');
+    final file = File('${dir.path}/$safeFileName');
+    if (await file.exists() && await file.length() > 0) {
+      return file;
+    }
+    return null;
+  }
+
   static final Map<String, Future<Uint8List>> _loadingFutures = {};
 
   /// 通用资源加载方法

--- a/fabushi/lib/services/cbeta_send_text_service.dart
+++ b/fabushi/lib/services/cbeta_send_text_service.dart
@@ -3,8 +3,6 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
-import '../core/config/app_config.dart';
-
 class CbetaSendText {
   final String work;
   final int juan;
@@ -25,24 +23,6 @@ class CbetaSendText {
     required this.content,
     required this.sourceUrl,
   });
-
-  factory CbetaSendText.fromJson(Map<String, dynamic> json) {
-    return CbetaSendText(
-      work: (json['work'] ?? '').toString(),
-      juan: _parseInt(json['juan']),
-      title: (json['title'] ?? '').toString(),
-      byline: (json['byline'] ?? '').toString(),
-      category: (json['category'] ?? '').toString(),
-      fileName: (json['fileName'] ?? '').toString(),
-      content: (json['content'] ?? '').toString(),
-      sourceUrl: (json['sourceUrl'] ?? '').toString(),
-    );
-  }
-
-  static int _parseInt(dynamic value) {
-    if (value is int) return value;
-    return int.tryParse((value ?? '').toString()) ?? 1;
-  }
 }
 
 class CbetaSendTextResult {
@@ -74,9 +54,41 @@ class CbetaSendTextException implements Exception {
   }
 }
 
+class _CbetaJsonResult {
+  final Map<String, dynamic> data;
+  final String apiRoot;
+  final Uri url;
+  final List<Map<String, dynamic>> attempts;
+
+  const _CbetaJsonResult({
+    required this.data,
+    required this.apiRoot,
+    required this.url,
+    required this.attempts,
+  });
+}
+
 class CbetaSendTextService {
   static const int _maxRetries = 3;
   static const Duration _timeout = Duration(seconds: 15);
+  static const String _officialApiRoot = 'https://api.cbetaonline.cn';
+  static const String _oracleApiRoot = 'http://144.24.17.21.sslip.io:3000';
+  static const List<String> _apiRoots = [_officialApiRoot, _oracleApiRoot];
+
+  static const List<String> _defaultSendWorks = [
+    'T0365',
+    'T0251',
+    'T0235',
+    'T0262',
+    'T0279',
+    'T0366',
+    'T0001',
+    'T0099',
+    'T0220',
+    'T0374',
+    'T0261',
+    'T0278',
+  ];
 
   Future<CbetaSendTextResult> fetchDefaultSendTexts({int limit = 12}) {
     return fetchSendTextsPage(limit: limit);
@@ -87,105 +99,323 @@ class CbetaSendTextService {
     int offset = 0,
     String? cursor,
   }) async {
-    final queryParameters = <String, String>{'limit': limit.toString()};
-    if (offset > 0) {
-      queryParameters['offset'] = offset.toString();
-    }
-    if (cursor != null && cursor.trim().isNotEmpty) {
-      queryParameters['cursor'] = cursor.trim();
-    }
+    final pageLimit = limit.clamp(1, 24).toInt();
+    final startIndex =
+        _parseCursor(cursor) ??
+        offset.clamp(0, _defaultSendWorks.length).toInt();
+    final items = <CbetaSendText>[];
+    final errors = <Map<String, dynamic>>[];
+    var index = startIndex;
 
-    final uri = AppConfig.buildBackendUri(
-      AppConfig.cbetaSendTextsEndpoint,
-      queryParameters: queryParameters,
-    );
-    final attempts = <Map<String, dynamic>>[];
+    while (index < _defaultSendWorks.length && items.length < pageLimit) {
+      final work = _defaultSendWorks[index];
+      index++;
 
-    for (int attempt = 1; attempt <= _maxRetries; attempt++) {
-      final startedAt = DateTime.now();
       try {
-        final response = await http
-            .get(uri, headers: {'Accept': 'application/json'})
-            .timeout(_timeout);
-        final body = utf8.decode(response.bodyBytes);
-        final durationMs = DateTime.now().difference(startedAt).inMilliseconds;
-        final attemptInfo = <String, dynamic>{
-          'attempt': attempt,
-          'url': uri.toString(),
-          'statusCode': response.statusCode,
-          'durationMs': durationMs,
-          'body': _summarizeBody(body),
-        };
-
-        if (response.statusCode < 200 || response.statusCode >= 300) {
-          attempts.add(attemptInfo);
-          await _delayBeforeRetry(attempt);
-          continue;
-        }
-
-        final decoded = json.decode(body);
-        if (decoded is! Map<String, dynamic>) {
-          attempts.add({...attemptInfo, 'error': '响应不是 JSON 对象'});
-          await _delayBeforeRetry(attempt);
-          continue;
-        }
-
-        final rawItems = decoded['items'];
-        final items = rawItems is List
-            ? rawItems
-                  .whereType<Map<String, dynamic>>()
-                  .map(CbetaSendText.fromJson)
-                  .where((item) => item.content.trim().isNotEmpty)
-                  .toList()
-            : <CbetaSendText>[];
-        final serverErrors = decoded['errors'] is List
-            ? decoded['errors'] as List<dynamic>
-            : <dynamic>[];
-
-        if (items.isEmpty) {
-          attempts.add({
-            ...attemptInfo,
-            'error': '后端没有返回可发送的经文',
-            'serverErrors': serverErrors,
-          });
-          await _delayBeforeRetry(attempt);
-          continue;
-        }
-
-        final nextCursor = (decoded['nextCursor'] ?? decoded['cursor'] ?? '')
-            .toString()
-            .trim();
-        final hasMore =
-            decoded['hasMore'] == true ||
-            decoded['has_next'] == true ||
-            (nextCursor.isNotEmpty && nextCursor != (cursor ?? '').trim()) ||
-            (items.length == limit && limit > 0);
-
-        return CbetaSendTextResult(
-          items: items,
-          errors: serverErrors,
-          api: (decoded['api'] ?? '').toString(),
-          hasMore: hasMore,
-          nextCursor: nextCursor.isEmpty ? null : nextCursor,
-        );
-      } on TimeoutException catch (error) {
-        attempts.add({
-          'attempt': attempt,
-          'url': uri.toString(),
-          'error': '请求超时: ${error.message ?? _timeout.toString()}',
+        final result = await _fetchJsonWithRetry('juans', {
+          'work': work,
+          'juan': '1',
+          'work_info': '1',
+          'toc': '1',
         });
-        await _delayBeforeRetry(attempt);
+        items.add(_toCbetaItem(work, 1, result));
       } catch (error) {
-        attempts.add({
-          'attempt': attempt,
-          'url': uri.toString(),
-          'error': error.toString(),
-        });
-        await _delayBeforeRetry(attempt);
+        errors.add(_normalizeError(work, 1, error));
       }
     }
 
-    throw CbetaSendTextException('CBETA 经文下载失败，已重试 $_maxRetries 次。', attempts);
+    if (items.isEmpty) {
+      throw CbetaSendTextException(
+        'CBETA direct API returned no sendable scripture.',
+        errors,
+      );
+    }
+
+    final hasMore = index < _defaultSendWorks.length;
+    return CbetaSendTextResult(
+      items: items,
+      errors: errors,
+      api: _officialApiRoot,
+      hasMore: hasMore,
+      nextCursor: hasMore ? index.toString() : null,
+    );
+  }
+
+  Future<_CbetaJsonResult> _fetchJsonWithRetry(
+    String path,
+    Map<String, String> params,
+  ) async {
+    final attempts = <Map<String, dynamic>>[];
+
+    for (final apiRoot in _apiRoots) {
+      final uri = _buildCbetaUri(apiRoot, path, params);
+
+      for (var attempt = 1; attempt <= _maxRetries; attempt++) {
+        final startedAt = DateTime.now();
+        try {
+          final response = await http
+              .get(uri, headers: {'Accept': 'application/json'})
+              .timeout(_timeout);
+          final body = utf8.decode(response.bodyBytes, allowMalformed: true);
+          final detail = <String, dynamic>{
+            'attempt': attempt,
+            'apiRoot': apiRoot,
+            'url': uri.toString(),
+            'statusCode': response.statusCode,
+            'durationMs': DateTime.now().difference(startedAt).inMilliseconds,
+          };
+
+          if (response.statusCode < 200 || response.statusCode >= 300) {
+            attempts.add({...detail, 'body': _summarizeBody(body)});
+            await _delayBeforeRetry(attempt);
+            continue;
+          }
+
+          final decoded = json.decode(body);
+          if (decoded is! Map<String, dynamic>) {
+            attempts.add({...detail, 'error': 'Response is not a JSON object'});
+            await _delayBeforeRetry(attempt);
+            continue;
+          }
+
+          if (!_hasUsableCbetaPayload(path, decoded)) {
+            attempts.add({
+              ...detail,
+              'error': _describeUnusablePayload(path, decoded),
+              'body': _summarizeBody(body),
+            });
+            await _delayBeforeRetry(attempt);
+            continue;
+          }
+
+          return _CbetaJsonResult(
+            data: decoded,
+            apiRoot: apiRoot,
+            url: uri,
+            attempts: [...attempts, detail],
+          );
+        } on TimeoutException catch (error) {
+          attempts.add({
+            'attempt': attempt,
+            'apiRoot': apiRoot,
+            'url': uri.toString(),
+            'durationMs': DateTime.now().difference(startedAt).inMilliseconds,
+            'error': 'Request timed out: ${error.message ?? _timeout}',
+          });
+          await _delayBeforeRetry(attempt);
+        } catch (error) {
+          attempts.add({
+            'attempt': attempt,
+            'apiRoot': apiRoot,
+            'url': uri.toString(),
+            'durationMs': DateTime.now().difference(startedAt).inMilliseconds,
+            'error': error.toString(),
+          });
+          await _delayBeforeRetry(attempt);
+        }
+      }
+    }
+
+    throw CbetaSendTextException('CBETA direct API request failed.', attempts);
+  }
+
+  CbetaSendText _toCbetaItem(
+    String requestedWork,
+    int requestedJuan,
+    _CbetaJsonResult result,
+  ) {
+    final data = result.data;
+    final workInfo = data['work_info'] is Map
+        ? Map<String, dynamic>.from(data['work_info'] as Map)
+        : <String, dynamic>{};
+    final html = _extractFirstHtml(data);
+    final title =
+        (workInfo['title'] ?? _extractTitleFromHtml(html) ?? requestedWork)
+            .toString();
+    final work = (workInfo['work'] ?? requestedWork).toString();
+    final content = _htmlToText(html);
+
+    if (content.trim().isEmpty) {
+      throw CbetaSendTextException(
+        'CBETA returned empty content.',
+        result.attempts,
+      );
+    }
+
+    return CbetaSendText(
+      work: work,
+      juan: requestedJuan,
+      title: title,
+      byline: (workInfo['byline'] ?? '').toString(),
+      category: (workInfo['category'] ?? workInfo['orig_category'] ?? '')
+          .toString(),
+      fileName: '${work}_${requestedJuan}_${_safeFileName(title)}.txt',
+      content: content,
+      sourceUrl: result.url.toString(),
+    );
+  }
+
+  static Uri _buildCbetaUri(
+    String apiRoot,
+    String path,
+    Map<String, String> params,
+  ) {
+    final root = apiRoot.replaceFirst(RegExp(r'/+$'), '');
+    final cleanPath = path.replaceFirst(RegExp(r'^/+'), '');
+    return Uri.parse('$root/$cleanPath').replace(queryParameters: params);
+  }
+
+  static bool _hasUsableCbetaPayload(String path, Map<String, dynamic> data) {
+    if (data['error'] != null) return false;
+    final normalizedPath = path.replaceFirst(RegExp(r'^/+'), '');
+    if (!normalizedPath.startsWith('juans')) return true;
+    return _extractFirstHtml(data).trim().isNotEmpty;
+  }
+
+  static String _describeUnusablePayload(
+    String path,
+    Map<String, dynamic> data,
+  ) {
+    if (data['error'] != null) return 'CBETA payload error: ${data['error']}';
+    if (path.replaceFirst(RegExp(r'^/+'), '').startsWith('juans')) {
+      return 'CBETA returned empty juan content';
+    }
+    return 'CBETA returned unusable payload';
+  }
+
+  static String _extractFirstHtml(Map<String, dynamic> data) {
+    final results = data['results'];
+    if (results is! List || results.isEmpty) return '';
+    final first = results.first;
+    if (first is String) return first;
+    if (first is Map && first['html'] is String) return first['html'] as String;
+    return '';
+  }
+
+  static String _htmlToText(String html) {
+    if (html.trim().isEmpty) return '';
+
+    final bodyMatch = RegExp(
+      r'<body[^>]*>([\s\S]*?)</body>',
+      caseSensitive: false,
+    ).firstMatch(html);
+    var source = bodyMatch?.group(1) ?? html;
+    source = source
+        .replaceAll(
+          RegExp(r'''<div[^>]+id=['"]back['"][\s\S]*$''', caseSensitive: false),
+          '',
+        )
+        .replaceAll(
+          RegExp(r'<script[\s\S]*?</script>', caseSensitive: false),
+          '',
+        )
+        .replaceAll(RegExp(r'<style[\s\S]*?</style>', caseSensitive: false), '')
+        .replaceAll(
+          RegExp(
+            r'''<span[^>]+class=['"][^'"]*\blb\b[^'"]*['"][^>]*>[\s\S]*?</span>''',
+            caseSensitive: false,
+          ),
+          '',
+        )
+        .replaceAll(
+          RegExp(
+            r'''<span[^>]+class=['"][^'"]*\blineInfo\b[^'"]*['"][^>]*>[\s\S]*?</span>''',
+            caseSensitive: false,
+          ),
+          '',
+        )
+        .replaceAll(
+          RegExp(
+            r'''<a[^>]+class=['"][^'"]*\bnoteAnchor\b[^'"]*['"][^>]*>[\s\S]*?</a>''',
+            caseSensitive: false,
+          ),
+          '',
+        )
+        .replaceAll(
+          RegExp(
+            r'''<a[^>]+class=['"][^'"]*\bfacsimile\b[^'"]*['"][^>]*>[\s\S]*?</a>''',
+            caseSensitive: false,
+          ),
+          '',
+        )
+        .replaceAll(
+          RegExp(r'<(p|div|br|h[1-6])\b[^>]*>', caseSensitive: false),
+          '\n',
+        )
+        .replaceAll(RegExp(r'</(p|div|h[1-6])>', caseSensitive: false), '\n')
+        .replaceAll(RegExp(r'<[^>]+>'), '');
+
+    return _decodeHtmlEntities(source)
+        .replaceAll('\r', '')
+        .replaceAll(RegExp(r'[ \t\f\v]+'), ' ')
+        .replaceAll(RegExp(r'\n[ \t]+'), '\n')
+        .replaceAll(RegExp(r'[ \t]+\n'), '\n')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+  }
+
+  static String _decodeHtmlEntities(String value) {
+    const named = {
+      'amp': '&',
+      'lt': '<',
+      'gt': '>',
+      'quot': '"',
+      'apos': "'",
+      'nbsp': ' ',
+    };
+
+    return value.replaceAllMapped(RegExp(r'&(#x?[0-9a-fA-F]+|[a-zA-Z]+);'), (
+      match,
+    ) {
+      final code = match.group(1) ?? '';
+      if (code.startsWith('#x') || code.startsWith('#X')) {
+        final parsed = int.tryParse(code.substring(2), radix: 16);
+        return parsed == null ? match.group(0)! : String.fromCharCode(parsed);
+      }
+      if (code.startsWith('#')) {
+        final parsed = int.tryParse(code.substring(1));
+        return parsed == null ? match.group(0)! : String.fromCharCode(parsed);
+      }
+      return named[code] ?? match.group(0)!;
+    });
+  }
+
+  static String? _extractTitleFromHtml(String html) {
+    final match = RegExp(
+      r'<title>([\s\S]*?)</title>',
+      caseSensitive: false,
+    ).firstMatch(html);
+    final title = match?.group(1);
+    if (title == null) return null;
+    return _decodeHtmlEntities(title.replaceAll(RegExp(r'<[^>]+>'), '')).trim();
+  }
+
+  static String _safeFileName(String value) {
+    final safe = value
+        .replaceAll(RegExp(r'[\\/:*?"<>|]+'), '_')
+        .replaceAll(RegExp(r'\s+'), '');
+    return safe.length > 80 ? safe.substring(0, 80) : safe;
+  }
+
+  static int? _parseCursor(String? value) {
+    final text = value?.trim();
+    if (text == null || text.isEmpty) return null;
+    final parsed = int.tryParse(text);
+    if (parsed == null) return null;
+    return parsed.clamp(0, _defaultSendWorks.length).toInt();
+  }
+
+  static Map<String, dynamic> _normalizeError(
+    String work,
+    int juan,
+    Object error,
+  ) {
+    return {
+      'work': work,
+      'juan': juan,
+      'message': error.toString(),
+      if (error is CbetaSendTextException) 'attempts': error.attempts,
+    };
   }
 
   static Future<void> _delayBeforeRetry(int attempt) async {

--- a/fabushi/lib/services/practice_book_service_native.dart
+++ b/fabushi/lib/services/practice_book_service_native.dart
@@ -5,15 +5,12 @@ import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:gbk_codec/gbk_codec.dart';
-import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
 
-import '../core/config/app_config.dart';
 import '../models/practice_book_model.dart';
-import 'app_settings.dart';
 
 class PracticeBookImportResult {
   final PracticeBook? book;
@@ -46,7 +43,7 @@ class PracticeBookService {
     final dbFile = path.join(dbPath, 'practice_books.db');
     _database = await openDatabase(
       dbFile,
-      version: 1,
+      version: 2,
       onCreate: (db, _) async {
         await db.execute('''
           CREATE TABLE practice_books (
@@ -56,6 +53,7 @@ class PracticeBookService {
             source_type TEXT NOT NULL,
             source_url TEXT,
             source_file_name TEXT,
+            source_file_path TEXT,
             content_hash TEXT NOT NULL,
             plain_text TEXT NOT NULL,
             normalized_text TEXT NOT NULL,
@@ -69,6 +67,13 @@ class PracticeBookService {
         await db.execute(
           'CREATE INDEX idx_practice_books_practice_title ON practice_books(practice_title)',
         );
+      },
+      onUpgrade: (db, oldVersion, _) async {
+        if (oldVersion < 2) {
+          await db.execute(
+            'ALTER TABLE practice_books ADD COLUMN source_file_path TEXT',
+          );
+        }
       },
     );
     return _database!;
@@ -100,45 +105,31 @@ class PracticeBookService {
 
   Future<PracticeBook> saveBook(
     PracticeBook book, {
-    bool syncCloud = true,
+    bool syncCloud = false,
   }) async {
     final db = await database;
+    final localBook = book.copyWith(
+      isActive: true,
+      syncStatus: PracticeBookSyncStatus.localOnly,
+      remoteObjectKey: null,
+    );
     await db.update(
       'practice_books',
       {'is_active': 0},
       where: 'practice_title = ?',
-      whereArgs: [book.practiceTitle],
+      whereArgs: [localBook.practiceTitle],
     );
     await db.insert(
       'practice_books',
-      book.copyWith(isActive: true).toMap(),
+      localBook.toMap(),
       conflictAlgorithm: ConflictAlgorithm.replace,
     );
-
-    if (syncCloud) {
-      return await _uploadBookToCloud(book.copyWith(isActive: true));
-    }
-    return book.copyWith(isActive: true);
+    return localBook;
   }
 
-  Future<void> deleteBook(String id, {bool syncCloud = true}) async {
+  Future<void> deleteBook(String id, {bool syncCloud = false}) async {
     final db = await database;
     await db.delete('practice_books', where: 'id = ?', whereArgs: [id]);
-
-    if (!syncCloud) return;
-    final headers = await _authHeaders();
-    if (headers == null) return;
-    try {
-      final baseUrl = await AppSettings.getBackendUrl();
-      await http.delete(
-        Uri.parse(
-          '$baseUrl/api/meditation/practice-books',
-        ).replace(queryParameters: {'id': id}),
-        headers: headers,
-      );
-    } catch (e) {
-      debugPrint('[PracticeBook] 云端删除失败: $e');
-    }
   }
 
   Future<PracticeBookImportResult> importFile({
@@ -146,8 +137,16 @@ class PracticeBookService {
     required String practiceTitle,
   }) async {
     try {
-      final bytes = await _readPlatformFile(file);
       final extension = path.extension(file.name).toLowerCase();
+      if (_isImageExtension(extension)) {
+        final book = await _importImage(
+          file: file,
+          practiceTitle: practiceTitle,
+        );
+        return PracticeBookImportResult.success(book);
+      }
+
+      final bytes = await _readPlatformFile(file);
       final plainText = switch (extension) {
         '.txt' || '.md' => _decodeTextBytes(bytes),
         '.docx' => _extractDocxText(bytes),
@@ -172,6 +171,7 @@ class PracticeBookService {
         sourceType: PracticeBookSourceType.file,
         sourceFileName: file.name,
         plainText: normalizedPlainText,
+        syncStatus: PracticeBookSyncStatus.localOnly,
       );
       return PracticeBookImportResult.success(await saveBook(book));
     } catch (e) {
@@ -184,49 +184,43 @@ class PracticeBookService {
     required String practiceTitle,
   }) async {
     final normalizedUrl = url.trim();
-    if (!normalizedUrl.startsWith('http://') &&
-        !normalizedUrl.startsWith('https://')) {
+    final uri = Uri.tryParse(normalizedUrl);
+    if (uri == null || !(uri.scheme == 'http' || uri.scheme == 'https')) {
       return const PracticeBookImportResult.failure('请输入 http/https 链接');
     }
 
-    final headers = await _authHeaders();
-    if (headers == null) {
-      return const PracticeBookImportResult.failure('请先登录后再同步链接功课本');
+    final book = PracticeBook.create(
+      id: const Uuid().v4(),
+      practiceTitle: practiceTitle,
+      title: _titleFromUrl(uri),
+      sourceType: PracticeBookSourceType.url,
+      sourceUrl: normalizedUrl,
+      plainText: normalizedUrl,
+      syncStatus: PracticeBookSyncStatus.localOnly,
+    );
+    return PracticeBookImportResult.success(await saveBook(book));
+  }
+
+  Future<PracticeBook> saveManualText({
+    required String practiceTitle,
+    required String title,
+    required String plainText,
+  }) async {
+    final normalizedPlainText = PracticeBookText.normalizePlainText(plainText);
+    if (normalizedPlainText.length < 2) {
+      throw ArgumentError('请输入功课文本内容');
     }
-
-    try {
-      final baseUrl = await AppSettings.getBackendUrl();
-      final response = await http.post(
-        Uri.parse('$baseUrl/api/meditation/practice-books/import-url'),
-        headers: headers,
-        body: jsonEncode({
-          'url': normalizedUrl,
-          'practiceTitle': practiceTitle,
-        }),
-      );
-
-      final data = jsonDecode(response.body);
-      if (response.statusCode != 200 || data['success'] != true) {
-        final needsFallback =
-            data['needsWebViewFallback'] == true ||
-            normalizedUrl.contains('mp.weixin.qq.com');
-        return PracticeBookImportResult.failure(
-          data['error']?.toString() ?? '链接解析失败',
-          needsWebViewFallback: needsFallback,
-        );
-      }
-
-      final book = PracticeBook.fromJson(
-        Map<String, dynamic>.from(data['data']['book'] as Map),
-      ).copyWith(syncStatus: PracticeBookSyncStatus.synced, isActive: true);
-      await saveBook(book, syncCloud: false);
-      return PracticeBookImportResult.success(book);
-    } catch (e) {
-      return PracticeBookImportResult.failure(
-        '链接解析失败: $e',
-        needsWebViewFallback: normalizedUrl.contains('mp.weixin.qq.com'),
-      );
-    }
+    final book = PracticeBook.create(
+      id: const Uuid().v4(),
+      practiceTitle: practiceTitle,
+      title: title.trim().isEmpty
+          ? PracticeBookText.titleFromText(normalizedPlainText)
+          : title.trim(),
+      sourceType: PracticeBookSourceType.manual,
+      plainText: normalizedPlainText,
+      syncStatus: PracticeBookSyncStatus.localOnly,
+    );
+    return saveBook(book);
   }
 
   Future<PracticeBook> saveExtractedWebText({
@@ -245,92 +239,52 @@ class PracticeBookService {
       sourceType: PracticeBookSourceType.url,
       sourceUrl: sourceUrl,
       plainText: normalizedPlainText,
+      syncStatus: PracticeBookSyncStatus.localOnly,
     );
-    return await saveBook(book);
+    return saveBook(book);
   }
 
   Future<void> syncFromCloud() async {
-    final headers = await _authHeaders();
-    if (headers == null) return;
-    try {
-      final baseUrl = await AppSettings.getBackendUrl();
-      final response = await http.get(
-        Uri.parse('$baseUrl/api/meditation/practice-books'),
-        headers: headers,
-      );
-      if (response.statusCode != 200) return;
-      final data = jsonDecode(response.body);
-      if (data['success'] != true) return;
-      final books = (data['data']?['books'] as List<dynamic>? ?? [])
-          .map(
-            (item) =>
-                PracticeBook.fromJson(Map<String, dynamic>.from(item as Map)),
-          )
-          .toList();
-      for (final book in books) {
-        await saveBook(
-          book.copyWith(syncStatus: PracticeBookSyncStatus.synced),
-          syncCloud: false,
-        );
-      }
-    } catch (e) {
-      debugPrint('[PracticeBook] 云端同步失败: $e');
-    }
+    debugPrint('[PracticeBook] Cloud sync disabled; books stay local only.');
   }
 
-  Future<PracticeBook> _uploadBookToCloud(PracticeBook book) async {
-    final headers = await _authHeaders();
-    if (headers == null) {
-      final pending = book.copyWith(
-        syncStatus: PracticeBookSyncStatus.pendingUpload,
-      );
-      await _saveLocalOnly(pending);
-      return pending;
-    }
-
-    try {
-      final baseUrl = await AppSettings.getBackendUrl();
-      final response = await http.post(
-        Uri.parse('$baseUrl/api/meditation/practice-books'),
-        headers: headers,
-        body: jsonEncode(book.toJson()),
-      );
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        if (data['success'] == true && data['data']?['book'] is Map) {
-          final synced = PracticeBook.fromJson(
-            Map<String, dynamic>.from(data['data']['book'] as Map),
-          ).copyWith(syncStatus: PracticeBookSyncStatus.synced);
-          await _saveLocalOnly(synced);
-          return synced;
-        }
-      }
-    } catch (e) {
-      debugPrint('[PracticeBook] 云端上传失败: $e');
-    }
-
-    final failed = book.copyWith(syncStatus: PracticeBookSyncStatus.syncFailed);
-    await _saveLocalOnly(failed);
-    return failed;
-  }
-
-  Future<void> _saveLocalOnly(PracticeBook book) async {
-    final db = await database;
-    await db.insert(
-      'practice_books',
-      book.toMap(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
+  Future<PracticeBook> _importImage({
+    required PlatformFile file,
+    required String practiceTitle,
+  }) async {
+    final bytes = await _readPlatformFile(file);
+    final id = const Uuid().v4();
+    final imageFile = await _copyImageToLocalStore(id, file.name, bytes);
+    final title = path.basenameWithoutExtension(file.name).trim().isEmpty
+        ? '图片功课本'
+        : path.basenameWithoutExtension(file.name).trim();
+    final book = PracticeBook.create(
+      id: id,
+      practiceTitle: practiceTitle,
+      title: title,
+      sourceType: PracticeBookSourceType.image,
+      sourceFileName: file.name,
+      sourceFilePath: imageFile.path,
+      plainText: title,
+      syncStatus: PracticeBookSyncStatus.localOnly,
     );
+    return saveBook(book);
   }
 
-  Future<Map<String, String>?> _authHeaders() async {
-    final prefs = await SharedPreferences.getInstance();
-    final token = prefs.getString(AppConfig.tokenStorageKey);
-    if (token == null || token.isEmpty) return null;
-    return {
-      'Authorization': 'Bearer $token',
-      'Content-Type': 'application/json',
-    };
+  Future<File> _copyImageToLocalStore(
+    String id,
+    String originalName,
+    List<int> bytes,
+  ) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final imageDir = Directory(path.join(dir.path, 'practice_books', 'images'));
+    if (!await imageDir.exists()) {
+      await imageDir.create(recursive: true);
+    }
+    final extension = path.extension(originalName).toLowerCase();
+    final file = File(path.join(imageDir.path, '$id$extension'));
+    await file.writeAsBytes(bytes, flush: true);
+    return file;
   }
 
   Future<List<int>> _readPlatformFile(PlatformFile file) async {
@@ -378,6 +332,25 @@ class PracticeBookService {
     if (text.trim().isNotEmpty) return text;
 
     final fallback = utf8.decode(bytes, allowMalformed: true);
-    return fallback.replaceAll(RegExp(r'[^一-龥A-Za-z0-9，。！？；：、\n ]'), ' ');
+    return fallback.replaceAll(
+      RegExp(r'[^\u4e00-\u9fffA-Za-z0-9，。！？；：、\n ]'),
+      ' ',
+    );
+  }
+
+  bool _isImageExtension(String extension) {
+    return const {'.jpg', '.jpeg', '.png', '.webp', '.gif'}.contains(extension);
+  }
+
+  String _titleFromUrl(Uri uri) {
+    final lastSegment = uri.pathSegments.isNotEmpty
+        ? uri.pathSegments.last.trim()
+        : '';
+    if (lastSegment.isNotEmpty) {
+      return Uri.decodeComponent(
+        lastSegment,
+      ).replaceAll(RegExp(r'\.[^.]+$'), '');
+    }
+    return uri.host.isEmpty ? '链接功课本' : uri.host;
   }
 }

--- a/fabushi/lib/services/practice_book_service_stub.dart
+++ b/fabushi/lib/services/practice_book_service_stub.dart
@@ -29,17 +29,29 @@ class PracticeBookService {
   Future<PracticeBook?> getActiveBook(String practiceTitle) async => null;
   Future<PracticeBook> saveBook(
     PracticeBook book, {
-    bool syncCloud = true,
-  }) async => book;
-  Future<void> deleteBook(String id, {bool syncCloud = true}) async {}
+    bool syncCloud = false,
+  }) async => book.copyWith(syncStatus: PracticeBookSyncStatus.localOnly);
+
+  Future<void> deleteBook(String id, {bool syncCloud = false}) async {}
+
   Future<PracticeBookImportResult> importFile({
     required PlatformFile file,
     required String practiceTitle,
   }) async => const PracticeBookImportResult.failure('Web 暂不支持功课本文件导入');
+
   Future<PracticeBookImportResult> importUrl({
     required String url,
     required String practiceTitle,
   }) async => const PracticeBookImportResult.failure('Web 暂不支持功课本链接导入');
+
+  Future<PracticeBook> saveManualText({
+    required String practiceTitle,
+    required String title,
+    required String plainText,
+  }) async {
+    throw UnsupportedError('Web 暂不支持功课本保存');
+  }
+
   Future<PracticeBook> saveExtractedWebText({
     required String practiceTitle,
     required String sourceUrl,

--- a/fabushi/lib/widgets/practice_book_sheet.dart
+++ b/fabushi/lib/widgets/practice_book_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -82,13 +84,22 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
         allowMultiple: false,
         withData: true,
         type: FileType.custom,
-        allowedExtensions: ['txt', 'md', 'docx', 'pdf'],
+        allowedExtensions: [
+          'txt',
+          'md',
+          'docx',
+          'pdf',
+          'jpg',
+          'jpeg',
+          'png',
+          'webp',
+          'gif',
+        ],
       );
       final files = result?.files ?? const <PlatformFile>[];
       if (files.isEmpty) return;
-      final file = files.first;
       final importResult = await _service.importFile(
-        file: file,
+        file: files.first,
         practiceTitle: widget.practiceTitle,
       );
       await _handleImportResult(importResult);
@@ -103,14 +114,14 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
       context: context,
       builder: (context) => AlertDialog(
         backgroundColor: const Color(0xFF1E1E1E),
-        title: const Text('导入链接', style: TextStyle(color: Colors.white)),
+        title: const Text('保存功课链接', style: TextStyle(color: Colors.white)),
         content: TextField(
           controller: controller,
           autofocus: true,
           keyboardType: TextInputType.url,
           style: const TextStyle(color: Colors.white),
           decoration: const InputDecoration(
-            hintText: '粘贴微信公众号或网页链接',
+            hintText: '粘贴网页或文章链接',
             hintStyle: TextStyle(color: Colors.white38),
           ),
         ),
@@ -121,7 +132,7 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
           ),
           ElevatedButton(
             onPressed: () => Navigator.pop(context, controller.text.trim()),
-            child: const Text('导入'),
+            child: const Text('保存'),
           ),
         ],
       ),
@@ -137,22 +148,78 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
         url: url,
         practiceTitle: widget.practiceTitle,
       );
-      if (!result.isSuccess && result.needsWebViewFallback && mounted) {
-        final book = await Navigator.push<PracticeBook>(
-          context,
-          MaterialPageRoute(
-            builder: (_) => PracticeBookWebImportScreen(
-              practiceTitle: widget.practiceTitle,
-              sourceUrl: url,
-            ),
-          ),
-        );
-        if (book != null) {
-          await _setBook(book, '已从页面提取功课本');
-          return;
-        }
-      }
       await _handleImportResult(result);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _inputText() async {
+    final titleController = TextEditingController();
+    final textController = TextEditingController();
+    final result = await showDialog<Map<String, String>>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: const Color(0xFF1E1E1E),
+        title: const Text('输入功课文本', style: TextStyle(color: Colors.white)),
+        content: SizedBox(
+          width: 420,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: titleController,
+                style: const TextStyle(color: Colors.white),
+                decoration: const InputDecoration(
+                  labelText: '标题',
+                  labelStyle: TextStyle(color: Colors.white70),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: textController,
+                minLines: 6,
+                maxLines: 10,
+                style: const TextStyle(color: Colors.white),
+                decoration: const InputDecoration(
+                  hintText: '粘贴或输入要对着念的功课内容',
+                  hintStyle: TextStyle(color: Colors.white38),
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('取消'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, {
+              'title': titleController.text.trim(),
+              'text': textController.text.trim(),
+            }),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    if (result == null || (result['text'] ?? '').trim().isEmpty) return;
+
+    setState(() {
+      _busy = true;
+      _message = null;
+    });
+    try {
+      final book = await _service.saveManualText(
+        practiceTitle: widget.practiceTitle,
+        title: result['title'] ?? '',
+        plainText: result['text'] ?? '',
+      );
+      await _setBook(book, '功课本已保存到本机');
+    } catch (e) {
+      if (mounted) setState(() => _message = '保存失败: $e');
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -160,7 +227,7 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
 
   Future<void> _handleImportResult(PracticeBookImportResult result) async {
     if (result.book != null) {
-      await _setBook(result.book!, '功课本已保存');
+      await _setBook(result.book!, '功课本已保存到本机');
     } else if (mounted) {
       setState(() => _message = result.error ?? '导入失败');
     }
@@ -181,10 +248,12 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
       _message = null;
     });
     try {
-      final path = await _modelService.downloadModel();
+      final modelPath = await _modelService.downloadModel();
       if (!mounted) return;
       setState(() {
-        _message = path == null ? _modelService.statusMessage : '离线语音模型已就绪';
+        _message = modelPath == null
+            ? _modelService.statusMessage
+            : '离线语音模型已就绪';
       });
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -200,12 +269,21 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
       if (!mounted) return;
       setState(() {
         _book = null;
-        _message = '功课本已删除';
+        _message = '功课本已从本机删除';
       });
       widget.onChanged?.call(null);
     } finally {
       if (mounted) setState(() => _busy = false);
     }
+  }
+
+  void _openReader() {
+    final book = _book;
+    if (book == null) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => PracticeBookReaderScreen(book: book)),
+    );
   }
 
   @override
@@ -261,42 +339,54 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
                     ),
                   ],
                   const SizedBox(height: 18),
-                  Row(
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 10,
                     children: [
-                      Expanded(
-                        child: _ActionButton(
-                          icon: Icons.upload_file,
-                          label: '文件',
-                          enabled: !_busy,
-                          onTap: _pickFile,
-                        ),
+                      _ActionButton(
+                        icon: Icons.upload_file,
+                        label: '文件/图片',
+                        enabled: !_busy,
+                        onTap: _pickFile,
                       ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: _ActionButton(
-                          icon: Icons.link,
-                          label: '链接',
-                          enabled: !_busy,
-                          onTap: _inputUrl,
-                        ),
+                      _ActionButton(
+                        icon: Icons.link,
+                        label: '链接',
+                        enabled: !_busy,
+                        onTap: _inputUrl,
                       ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: _ActionButton(
-                          icon: modelReady ? Icons.check_circle : Icons.mic,
-                          label: modelReady ? '已就绪' : '模型',
-                          enabled: !_busy && !modelReady,
-                          onTap: _downloadModel,
-                        ),
+                      _ActionButton(
+                        icon: Icons.edit_note,
+                        label: '文本',
+                        enabled: !_busy,
+                        onTap: _inputText,
+                      ),
+                      _ActionButton(
+                        icon: modelReady ? Icons.check_circle : Icons.mic,
+                        label: modelReady ? '模型就绪' : '语音模型',
+                        enabled: !_busy && !modelReady,
+                        onTap: _downloadModel,
                       ),
                     ],
                   ),
                   if (_book != null) ...[
-                    const SizedBox(height: 10),
-                    TextButton.icon(
-                      onPressed: _busy ? null : _deleteBook,
-                      icon: const Icon(Icons.delete_outline),
-                      label: const Text('删除当前功课本'),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: _busy ? null : _openReader,
+                            icon: const Icon(Icons.menu_book),
+                            label: const Text('打开对着念'),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        TextButton.icon(
+                          onPressed: _busy ? null : _deleteBook,
+                          icon: const Icon(Icons.delete_outline),
+                          label: const Text('删除'),
+                        ),
+                      ],
                     ),
                   ],
                 ],
@@ -309,7 +399,7 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
     final book = _book;
     if (book == null) {
       return const Text(
-        '尚未添加功课本。添加后，禅室会用本地语音识别自动判断念诵遍数。',
+        '尚未添加功课本。可保存链接、输入文本，或选择本机文件/图片；内容只保存在本机。',
         style: TextStyle(color: Colors.white70, height: 1.5),
       );
     }
@@ -331,7 +421,7 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
           ),
           const SizedBox(height: 8),
           Text(
-            '${book.normalizedText.length} 字 · ${_syncLabel(book.syncStatus)}',
+            '${_sourceLabel(book.sourceType)} · ${_syncLabel(book.syncStatus)}',
             style: const TextStyle(color: Colors.white54, fontSize: 12),
           ),
         ],
@@ -387,13 +477,85 @@ class _PracticeBookSheetState extends State<PracticeBookSheet> {
     );
   }
 
+  String _sourceLabel(PracticeBookSourceType type) {
+    return switch (type) {
+      PracticeBookSourceType.file => '本机文件',
+      PracticeBookSourceType.url => '链接',
+      PracticeBookSourceType.manual => '手输文本',
+      PracticeBookSourceType.image => '图片',
+      PracticeBookSourceType.cloud => '云端记录',
+    };
+  }
+
   String _syncLabel(PracticeBookSyncStatus status) {
     return switch (status) {
-      PracticeBookSyncStatus.synced => '已云端同步',
-      PracticeBookSyncStatus.pendingUpload => '待云端同步',
-      PracticeBookSyncStatus.syncFailed => '云端同步失败',
-      PracticeBookSyncStatus.localOnly => '仅本地',
+      PracticeBookSyncStatus.synced => '仅本机',
+      PracticeBookSyncStatus.pendingUpload => '仅本机',
+      PracticeBookSyncStatus.syncFailed => '仅本机',
+      PracticeBookSyncStatus.localOnly => '仅本机',
     };
+  }
+}
+
+class PracticeBookReaderScreen extends StatelessWidget {
+  final PracticeBook book;
+
+  const PracticeBookReaderScreen({super.key, required this.book});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF101010),
+      appBar: AppBar(
+        title: Text(book.title),
+        backgroundColor: const Color(0xFF151515),
+      ),
+      body: SafeArea(child: _buildBody()),
+    );
+  }
+
+  Widget _buildBody() {
+    if (book.sourceType == PracticeBookSourceType.url &&
+        (book.sourceUrl ?? '').isNotEmpty) {
+      return InAppWebView(
+        initialUrlRequest: URLRequest(url: WebUri(book.sourceUrl!)),
+        initialSettings: InAppWebViewSettings(
+          javaScriptEnabled: true,
+          mediaPlaybackRequiresUserGesture: false,
+        ),
+      );
+    }
+
+    if (book.sourceType == PracticeBookSourceType.image &&
+        (book.sourceFilePath ?? '').isNotEmpty) {
+      return InteractiveViewer(
+        minScale: 0.6,
+        maxScale: 5,
+        child: Center(
+          child: Image.file(
+            File(book.sourceFilePath!),
+            fit: BoxFit.contain,
+            errorBuilder: (context, error, stackTrace) =>
+                const Text('图片文件不存在', style: TextStyle(color: Colors.white70)),
+          ),
+        ),
+      );
+    }
+
+    return Scrollbar(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(22, 22, 22, 40),
+        child: SelectableText(
+          book.plainText,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 20,
+            height: 1.75,
+            fontFamily: 'NotoSerifSC',
+          ),
+        ),
+      ),
+    );
   }
 }
 
@@ -490,30 +652,17 @@ class _ActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: enabled ? onTap : null,
-      child: Opacity(
-        opacity: enabled ? 1 : 0.45,
-        child: Container(
-          height: 52,
-          decoration: BoxDecoration(
-            color: const Color(0xFFD4AF37),
-            borderRadius: BorderRadius.circular(26),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(icon, color: Colors.black, size: 19),
-              const SizedBox(width: 6),
-              Text(
-                label,
-                style: const TextStyle(
-                  color: Colors.black,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ],
-          ),
+    return SizedBox(
+      width: 104,
+      height: 50,
+      child: FilledButton.icon(
+        onPressed: enabled ? onTap : null,
+        icon: Icon(icon, size: 18),
+        label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+        style: FilledButton.styleFrom(
+          backgroundColor: const Color(0xFFD4AF37),
+          foregroundColor: Colors.black,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
         ),
       ),
     );

--- a/frontend/apps/web/src/components/faliu-synonym-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-synonym-enhancer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { CBETA_API_ROOT, CBETA_PROXY_ROOT } from "../lib/cbeta-config";
+import { CBETA_API_ROOT } from "../lib/cbeta-config";
 import { normalizeCbetaQuery } from "../lib/faliu-api";
 
 const MAX_SUGGESTIONS_PER_GROUP = 8;
@@ -437,27 +437,8 @@ function buildUrl(base: string, path: string, params?: Record<string, string | n
   return url.toString();
 }
 
-function buildRelativeUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
-  const normalizedBase = base.replace(/\/+$/g, "");
-  const normalizedPath = path.replace(/^\/+/g, "");
-  const query = new URLSearchParams();
-
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      if (value === undefined || value === null || value === "") {
-        continue;
-      }
-
-      query.set(key, String(value));
-    }
-  }
-
-  const suffix = query.toString();
-  return `${normalizedBase}/${normalizedPath}${suffix ? `?${suffix}` : ""}`;
-}
-
 function cbetaUrls(path: string, params: Record<string, string | number | undefined>) {
-  return [buildRelativeUrl(CBETA_PROXY_ROOT, path, params), buildUrl(CBETA_API_ROOT, path, params)];
+  return [buildUrl(CBETA_API_ROOT, path, params)];
 }
 
 async function fetchJson<T>(urls: string[]): Promise<T> {

--- a/frontend/apps/web/src/lib/cbeta-config.ts
+++ b/frontend/apps/web/src/lib/cbeta-config.ts
@@ -1,2 +1,1 @@
-export const CBETA_API_ROOT = "https://api.ombhrum.com/api/cbeta";
-export const CBETA_PROXY_ROOT = "/api/cbeta";
+export const CBETA_API_ROOT = "https://api.cbetaonline.cn";

--- a/frontend/apps/web/src/lib/faliu-api.ts
+++ b/frontend/apps/web/src/lib/faliu-api.ts
@@ -1,4 +1,4 @@
-import { CBETA_API_ROOT, CBETA_PROXY_ROOT } from "./cbeta-config";
+import { CBETA_API_ROOT } from "./cbeta-config";
 
 export interface CbetaWorkIndexItem {
   work: string;
@@ -629,12 +629,7 @@ function isBrowserRuntime() {
 
 function cbetaUrls(path: string, params?: Record<string, string | number | undefined>) {
   const directUrl = buildUrl(CBETA_API_ROOT, path, params);
-
-  if (!isBrowserRuntime()) {
-    return [directUrl];
-  }
-
-  return [buildRelativeUrl(CBETA_PROXY_ROOT, path, params), directUrl];
+  return [directUrl];
 }
 
 function appUrls(path: string, params?: Record<string, string | number | undefined>) {

--- a/frontend/apps/web/src/lib/faliu-content-search.ts
+++ b/frontend/apps/web/src/lib/faliu-content-search.ts
@@ -1,4 +1,4 @@
-import { CBETA_API_ROOT, CBETA_PROXY_ROOT } from "./cbeta-config";
+import { CBETA_API_ROOT } from "./cbeta-config";
 import { normalizeCbetaQuery, type CbetaWorkInfo } from "./faliu-api";
 
 const CONTENT_SEARCH_ENDPOINTS = ["search/fulltext", "search/content", "search/all_in_one"] as const;
@@ -26,37 +26,9 @@ function buildUrl(base: string, path: string, params?: Record<string, string | n
   return url.toString();
 }
 
-function buildRelativeUrl(base: string, path: string, params?: Record<string, string | number | undefined>) {
-  const normalizedBase = base.replace(/\/+$/g, "");
-  const normalizedPath = path.replace(/^\/+/g, "");
-  const query = new URLSearchParams();
-
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      if (value === undefined || value === null || value === "") {
-        continue;
-      }
-
-      query.set(key, String(value));
-    }
-  }
-
-  const suffix = query.toString();
-  return `${normalizedBase}/${normalizedPath}${suffix ? `?${suffix}` : ""}`;
-}
-
-function isBrowserRuntime() {
-  return typeof window !== "undefined";
-}
-
 function cbetaUrls(path: string, params?: Record<string, string | number | undefined>) {
   const directUrl = buildUrl(CBETA_API_ROOT, path, params);
-
-  if (!isBrowserRuntime()) {
-    return [directUrl];
-  }
-
-  return [buildRelativeUrl(CBETA_PROXY_ROOT, path, params), directUrl];
+  return [directUrl];
 }
 
 async function fetchJson<T>(urls: string[]): Promise<T> {

--- a/scripts/check_home_send_flow.py
+++ b/scripts/check_home_send_flow.py
@@ -5,40 +5,66 @@ import sys
 
 root = Path(__file__).resolve().parents[1]
 home = root / 'fabushi/lib/screens/globe_home_screen.dart'
+global_dharma = root / 'fabushi/lib/screens/global_dharma_screen.dart'
 model = root / 'fabushi/lib/models/file_transfer_model.dart'
 home_text = home.read_text(encoding='utf-8')
+global_dharma_text = global_dharma.read_text(encoding='utf-8')
 model_text = model.read_text(encoding='utf-8')
 
-method_match = re.search(r"void _startSending\(FileTransferModel model\) async \{(?P<body>.*?)\n  \}", home_text, re.S)
+method_match = re.search(
+    r"void _startSending\(FileTransferModel model\) async \{(?P<body>.*?)\n  \}",
+    home_text,
+    re.S,
+)
 if not method_match:
     print('FAIL: GlobeHomeScreen._startSending was not found')
     sys.exit(1)
+
 body = method_match.group('body')
-call = 'model.startDefaultScriptureSendSequence()'
-call_index = body.find(call)
-if call_index == -1:
-    print(f'FAIL: _startSending does not call {call}')
+if 'model.startDefaultScriptureSendSequence()' in body:
+    print('FAIL: homepage send must not default-download CBETA scriptures')
     sys.exit(1)
 
-pre_call_body = body[:call_index]
-if 'beginPreparingSend(' in pre_call_body:
-    print('FAIL: _startSending calls beginPreparingSend before startDefaultScriptureSendSequence')
-    print('This reintroduces the bug where isPreparingSend is set before the model guard runs.')
+if 'startDefaultScriptureSendSequence()' in global_dharma_text:
+    print('FAIL: global dharma send must not default-download CBETA scriptures')
     sys.exit(1)
 
-if 'if (model.isPreparingSend || model.isTransferring) return;' not in body:
-    print('FAIL: _startSending no longer guards duplicate send taps')
-    sys.exit(1)
-sequence_match = re.search(r"Future<int> startDefaultScriptureSendSequence\(\) async \{(?P<body>.*?)\n  \}", model_text, re.S)
-if not sequence_match:
-    print('FAIL: FileTransferModel.startDefaultScriptureSendSequence was not found')
-    sys.exit(1)
-sequence_body = sequence_match.group('body')
-if 'if (_isPreparingSend || _isTransferring) return 0;' not in sequence_body:
-    print('FAIL: startDefaultScriptureSendSequence guard changed; update this regression test intentionally')
-    sys.exit(1)
-if 'beginPreparingSend(' not in sequence_body:
-    print('FAIL: startDefaultScriptureSendSequence should own the preparing state')
+for method_name in (
+    'startDefaultScriptureSendSequence',
+    'prepareDefaultNonR2AssetsForSending',
+):
+    method_match = re.search(
+        rf"Future<int> {method_name}\(\) async \{{(?P<body>.*?)\n  \}}",
+        model_text,
+        re.S,
+    )
+    if not method_match:
+        print(f'FAIL: FileTransferModel.{method_name} was not found')
+        sys.exit(1)
+    method_body = method_match.group('body')
+    if 'fetchSendTextsPage' in method_body or 'fetchDefaultSendTexts' in method_body:
+        print(f'FAIL: {method_name} must not download default CBETA content')
+        sys.exit(1)
+
+if '_showSendContentSheet(model)' not in body:
+    print('FAIL: homepage send should ask for user-selected content when empty')
     sys.exit(1)
 
-print('PASS: homepage send flow calls startDefaultScriptureSendSequence without pre-setting preparing state')
+pre_sheet_body = body.split('_showSendContentSheet(model)', 1)[0]
+if 'model.hasFiles' in pre_sheet_body:
+    print('FAIL: homepage send should always ask for content before sending')
+    sys.exit(1)
+
+if 'await model.startGlobalTransfer()' not in body:
+    print('FAIL: homepage send should send the selected files/text/link content')
+    sys.exit(1)
+
+if 'Future<void> addUrlContentForSending' not in model_text:
+    print('FAIL: FileTransferModel should support link content sending')
+    sys.exit(1)
+
+if 'Future<void> addTextContentForSending' not in model_text:
+    print('FAIL: FileTransferModel should support manual text sending')
+    sys.exit(1)
+
+print('PASS: homepage send uses user-selected content and does not default-download CBETA')


### PR DESCRIPTION
## Summary
- call CBETA upstream APIs directly instead of the Worker-backed endpoint
- keep practice book content local-only, with manual text, links, files/images, and open-to-read support
- require homepage global send to choose link/text/local file/Zen Buddha asset before sending

## Tests
- python scripts/check_home_send_flow.py
- node --test tests/cbeta-send-texts.test.js tests/practice-books.test.js tests/frontend-worker.test.js
- corepack pnpm --filter @fabushi/web typecheck
- flutter test test/unit/services/recitation_progress_matcher_test.dart --reporter expanded
- dart analyze --no-fatal-warnings on changed Dart files (info-level existing lints only)
- Android real device AXYP6R4530001510: installed local versionCode 393 test APK, verified homepage source picker, manual text global send, practice book local text save, and open-to-read