### PR TITLE
[codex] Fix send content selection and large material transfer

### DIFF
--- a/fabushi/lib/models/file_transfer_model.dart
+++ b/fabushi/lib/models/file_transfer_model.dart
@@ -27,7 +27,44 @@ import '../services/workmanager_keep_alive.dart';
 
 enum TransferStatus { idle, transferring, completed, error }
 
+class LinkSendHistoryEntry {
+  final String url;
+  final String title;
+  final String preview;
+  final DateTime savedAt;
+
+  const LinkSendHistoryEntry({
+    required this.url,
+    required this.title,
+    required this.preview,
+    required this.savedAt,
+  });
+
+  factory LinkSendHistoryEntry.fromJson(Map<String, dynamic> json) {
+    return LinkSendHistoryEntry(
+      url: json['url'] as String? ?? '',
+      title: json['title'] as String? ?? '',
+      preview: json['preview'] as String? ?? '',
+      savedAt:
+          DateTime.tryParse(json['savedAt'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'url': url,
+    'title': title,
+    'preview': preview,
+    'savedAt': savedAt.toIso8601String(),
+  };
+}
+
 class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
+  static const String _linkHistoryPrefsKey = 'send_link_history_v1';
+  static const int _maxLinkHistoryEntries = 20;
+  static const int _linkHistoryPreviewLimit = 600;
+  static const int _largePayloadThresholdBytes = 1024 * 1024;
+
   bool _isGlobalSendEnabled = true;
   bool _isLooping = false;
   bool _isFieldEnergyMode = false;
@@ -52,6 +89,12 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   List<CountrySendStatus> _countryStatuses = [];
   String _currentLog = '';
   String _currentSendingScripture = '';
+  String _selectedContentKind = '';
+  String _selectedContentTitle = '';
+  String _selectedContentSubtitle = '';
+  String? _selectedContentPreviewText;
+  String? _selectedContentSourceUrl;
+  List<LinkSendHistoryEntry> _linkHistory = [];
 
   final SharedAssetManager _sharedAssetManager = SharedAssetManager();
   final IPLocationService _ipLocationService = IPLocationService();
@@ -125,6 +168,14 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   List<CountrySendStatus> get countryStatuses => _countryStatuses;
   String get currentLog => _currentLog;
   String get currentSendingScripture => _currentSendingScripture;
+  String get selectedContentKind => _selectedContentKind;
+  String get selectedContentTitle => _selectedContentTitle;
+  String get selectedContentSubtitle => _selectedContentSubtitle;
+  String? get selectedContentPreviewText => _selectedContentPreviewText;
+  String? get selectedContentSourceUrl => _selectedContentSourceUrl;
+  bool get hasSelectedContentPreview =>
+      (_selectedContentPreviewText?.trim().isNotEmpty ?? false);
+  List<LinkSendHistoryEntry> get linkHistory => List.unmodifiable(_linkHistory);
 
   void clearHotspotGuide() {
     _needsHotspotGuide = false;
@@ -245,7 +296,54 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     _downloadedScriptureMemory.clear();
     if (clearSelection) {
       _selectedFiles = [];
+      _clearSelectedContentSummary();
     }
+  }
+
+  void _setSelectedContentSummary({
+    required String kind,
+    required String title,
+    required String subtitle,
+    String? previewText,
+    String? sourceUrl,
+  }) {
+    _selectedContentKind = kind;
+    _selectedContentTitle = title.trim().isEmpty ? kind : title.trim();
+    _selectedContentSubtitle = subtitle.trim();
+    _selectedContentPreviewText = previewText;
+    _selectedContentSourceUrl = sourceUrl;
+  }
+
+  void _clearSelectedContentSummary() {
+    _selectedContentKind = '';
+    _selectedContentTitle = '';
+    _selectedContentSubtitle = '';
+    _selectedContentPreviewText = null;
+    _selectedContentSourceUrl = null;
+  }
+
+  void _updateFileSelectionSummary({String kind = '文件'}) {
+    if (_selectedFiles.isEmpty) {
+      _clearSelectedContentSummary();
+      return;
+    }
+
+    final totalBytes = _selectedFiles.fold<int>(
+      0,
+      (sum, file) => sum + file.size,
+    );
+    final first = _selectedFiles.first;
+    final title = _selectedFiles.length == 1
+        ? first.name
+        : '${first.name} 等 ${_selectedFiles.length} 个文件';
+    _setSelectedContentSummary(
+      kind: kind,
+      title: title,
+      subtitle: '${getFileSizeString(totalBytes)} · 点此重新选择发送内容',
+      previewText: _selectedFiles.length == 1
+          ? '文件名: ${first.name}\n大小: ${getFileSizeString(first.size)}'
+          : '已选择 ${_selectedFiles.length} 个文件\n总大小: ${getFileSizeString(totalBytes)}',
+    );
   }
 
   Future<int> startDefaultScriptureSendSequence() async {
@@ -283,6 +381,8 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
       if (result != null) {
         _selectedFiles.addAll(result.files);
+        _downloadedScriptureMemory.clear();
+        _updateFileSelectionSummary(kind: '本机文件');
         notifyListeners();
 
         for (final file in result.files) {
@@ -480,6 +580,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   void addFiles(List<PlatformFile> files) {
     _selectedFiles.addAll(files);
+    _updateFileSelectionSummary(kind: '素材文件');
     debugPrint(
       '📁 添加文件: ${files.map((f) => f.name).join(', ')}，当前总数: ${_selectedFiles.length}',
     );
@@ -490,6 +591,9 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     required String title,
     required String text,
     bool replaceExisting = true,
+    String sourceKind = '文本',
+    String? sourceUrl,
+    String? previewText,
   }) async {
     final normalizedText = text.trim();
     if (normalizedText.isEmpty) {
@@ -508,11 +612,29 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     } else {
       addFiles([file]);
       _downloadedScriptureMemory[file.name] = bytes;
+      _setSelectedContentSummary(
+        kind: sourceKind,
+        title: title.isEmpty ? file.name : title,
+        subtitle:
+            '${normalizedText.length} 字 · ${getFileSizeString(bytes.length)}',
+        previewText: previewText ?? normalizedText,
+        sourceUrl: sourceUrl,
+      );
       return;
     }
 
     _currentSendingScripture = _displayScriptureName(file.name);
-    _currentLog = '已选择文本内容: ${file.name}';
+    _setSelectedContentSummary(
+      kind: sourceKind,
+      title: title.isEmpty ? _currentSendingScripture : title,
+      subtitle:
+          '${normalizedText.length} 字 · ${getFileSizeString(bytes.length)}',
+      previewText: previewText ?? normalizedText,
+      sourceUrl: sourceUrl,
+    );
+    _currentLog = sourceKind == '链接'
+        ? '已选择链接内容: ${title.isEmpty ? file.name : title}'
+        : '已选择文本内容: ${file.name}';
     notifyListeners();
   }
 
@@ -552,12 +674,59 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
         bodyText.isEmpty ? uri.toString() : bodyText,
       ].join('\n');
 
-      await addTextContentForSending(title: title, text: sendText);
-      _currentLog = '已读取链接内容: $title';
+      await addTextContentForSending(
+        title: title,
+        text: sendText,
+        sourceKind: '链接',
+        sourceUrl: uri.toString(),
+        previewText: bodyText.isEmpty ? uri.toString() : bodyText,
+      );
+      await _rememberLinkHistory(
+        url: uri.toString(),
+        title: title,
+        preview: bodyText.isEmpty ? uri.toString() : bodyText,
+      );
+      _currentLog = bodyText.isEmpty
+          ? '链接未返回正文，已保存链接: $title'
+          : '已读取链接正文: $title（${bodyText.length} 字）';
     } finally {
       _finishPreparingSend();
       notifyListeners();
     }
+  }
+
+  Future<void> _rememberLinkHistory({
+    required String url,
+    required String title,
+    required String preview,
+  }) async {
+    final normalizedUrl = url.trim();
+    if (normalizedUrl.isEmpty) return;
+
+    final normalizedPreview = _compactPreview(preview);
+    _linkHistory = [
+      LinkSendHistoryEntry(
+        url: normalizedUrl,
+        title: title.trim().isEmpty ? normalizedUrl : title.trim(),
+        preview: normalizedPreview,
+        savedAt: DateTime.now(),
+      ),
+      ..._linkHistory.where((entry) => entry.url != normalizedUrl),
+    ].take(_maxLinkHistoryEntries).toList();
+
+    _schedulePersist(_persistLinkHistory);
+  }
+
+  String _compactPreview(String value) {
+    final normalized = value
+        .replaceAll('\r', '')
+        .replaceAll(RegExp(r'[ \t\f\v]+'), ' ')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+    if (normalized.length <= _linkHistoryPreviewLimit) {
+      return normalized;
+    }
+    return '${normalized.substring(0, _linkHistoryPreviewLimit)}...';
   }
 
   Future<void> addZenBuddhaAssetForSending() async {
@@ -586,6 +755,13 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _downloadedScriptureMemory.clear();
       _currentSendingScripture = '禅室佛像素材';
       _currentLog = '已选择禅室佛像素材: ${platformFile.name}';
+      _setSelectedContentSummary(
+        kind: '禅室佛像素材',
+        title: platformFile.name,
+        subtitle: '${getFileSizeString(size)} · 点此重新选择发送内容',
+        previewText:
+            '禅室佛像素材\n文件名: ${platformFile.name}\n大小: ${getFileSizeString(size)}',
+      );
     } finally {
       _finishPreparingSend();
       notifyListeners();
@@ -595,6 +771,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   void removeFile(PlatformFile file) {
     _selectedFiles.remove(file);
     _downloadedScriptureMemory.remove(file.name);
+    _updateFileSelectionSummary();
     debugPrint('🗑️ 移除文件: ${file.name}，当前总数: ${_selectedFiles.length}');
     notifyListeners();
   }
@@ -602,6 +779,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   void clearFiles() {
     _selectedFiles.clear();
     _downloadedScriptureMemory.clear();
+    _clearSelectedContentSummary();
     debugPrint('🧹 清空所有文件');
     notifyListeners();
   }
@@ -773,16 +951,27 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
       final file = _selectedFiles.first;
       Uint8List? fileBytes = file.bytes;
+      final originalSize = file.size;
 
       if (fileBytes == null && file.path != null) {
         final fileObj = File(file.path!);
-        fileBytes = await fileObj.readAsBytes();
+        if (await fileObj.exists()) {
+          final length = await fileObj.length();
+          final sampleLength = length > 1400 ? 1400 : length;
+          final randomAccessFile = await fileObj.open();
+          try {
+            fileBytes = await randomAccessFile.read(sampleLength);
+          } finally {
+            await randomAccessFile.close();
+          }
+        }
       }
 
       if (fileBytes != null) {
         await _fieldBroadcastService!.startBroadcast(
           data: fileBytes,
           fileName: file.name,
+          originalSize: originalSize,
         );
         debugPrint('🌟 场能广播已启动: ${file.name}');
       }
@@ -845,10 +1034,15 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       );
 
       final file = _selectedFiles.first;
+      final isLargePayload = file.size >= _largePayloadThresholdBytes;
       await _localLoopbackService!.start(
         data: file.bytes,
         filePath: file.path,
         fileName: file.name,
+        mode: LoopbackRunMode.isolate,
+        speedLevel: isLargePayload
+            ? LoopbackSpeedLevel.normal
+            : LoopbackSpeedLevel.high,
       );
     } catch (e) {
       debugPrint('⚠️ 启动本地回环失败: $e');
@@ -1331,6 +1525,19 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _globalDataSentMB = prefs.getDouble('global_data_sent_mb') ?? 0.0;
       _currentLog = prefs.getString('current_log') ?? '';
 
+      final linkHistoryJson = prefs.getString(_linkHistoryPrefsKey);
+      if (linkHistoryJson != null && linkHistoryJson.isNotEmpty) {
+        final decoded = json.decode(linkHistoryJson);
+        if (decoded is List) {
+          _linkHistory = decoded
+              .whereType<Map<String, dynamic>>()
+              .map(LinkSendHistoryEntry.fromJson)
+              .where((entry) => entry.url.isNotEmpty)
+              .take(_maxLinkHistoryEntries)
+              .toList();
+        }
+      }
+
       final statusesJson = prefs.getString('country_statuses');
       if (statusesJson != null) {
         final List<dynamic> decoded = json.decode(statusesJson);
@@ -1385,6 +1592,18 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     }
   }
 
+  Future<void> _persistLinkHistory() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final encoded = json.encode(
+        _linkHistory.map((entry) => entry.toJson()).toList(),
+      );
+      await prefs.setString(_linkHistoryPrefsKey, encoded);
+    } catch (e) {
+      debugPrint('持久化链接历史失败: $e');
+    }
+  }
+
   Future<void> clearPersistedState() async {
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -1393,6 +1612,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       await prefs.remove('global_data_sent_mb');
       await prefs.remove('current_log');
       await prefs.remove('country_statuses');
+      await prefs.remove(_linkHistoryPrefsKey);
     } catch (e) {
       debugPrint('清除持久化状态失败: $e');
     }

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../models/file_transfer_model.dart';
 import '../widgets/earth_globe_widget.dart';
@@ -348,7 +349,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                             children: [
                               Text(
                                 scripture.isEmpty
-                                    ? '正在发送经文'
+                                    ? '正在发送内容'
                                     : '正在发送《$scripture》',
                                 style: const TextStyle(
                                   color: Colors.white,
@@ -458,7 +459,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                             Expanded(
                               child: Text(
                                 model.currentSendingScripture.isEmpty
-                                    ? '正在发送经文'
+                                    ? '正在发送内容'
                                     : '正在发送：《${model.currentSendingScripture}》',
                                 style: const TextStyle(
                                   color: Colors.white,
@@ -574,44 +575,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: 12),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.1),
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Row(
-                          children: [
-                            Icon(
-                              Icons.library_books,
-                              color: AppTheme.primaryColor,
-                              size: 18,
-                            ),
-                            const SizedBox(width: 8),
-                            const Text(
-                              '内容发送',
-                              style: TextStyle(
-                                color: AppTheme.primaryColor,
-                                fontSize: 13,
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                          ],
-                        ),
-                        const Icon(
-                          Icons.check_circle,
-                          color: AppTheme.primaryColor,
-                          size: 20,
-                        ),
-                      ],
-                    ),
-                  ),
+                  _buildSelectedContentTile(model),
                   const SizedBox(height: 8),
                   Container(
                     padding: const EdgeInsets.symmetric(
@@ -760,6 +724,104 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     );
   }
 
+  Widget _buildSelectedContentTile(FileTransferModel model) {
+    final hasContent = model.hasFiles;
+    final title = hasContent ? model.selectedContentTitle : '选择发送内容';
+    final subtitle = hasContent
+        ? (model.selectedContentSubtitle.isEmpty
+              ? '点此重新选择链接、文本、文件或佛像素材'
+              : model.selectedContentSubtitle)
+        : '链接、文本、本机文件或禅室佛像素材';
+    final icon = _contentIcon(model.selectedContentKind);
+
+    return Material(
+      color: Colors.white.withOpacity(0.1),
+      borderRadius: BorderRadius.circular(10),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(10),
+        onTap: model.isPreparingSend
+            ? null
+            : () => _showSendContentSheet(model),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              Icon(icon, color: AppTheme.primaryColor, size: 20),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        if (hasContent && model.selectedContentKind.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(right: 6),
+                            child: Text(
+                              model.selectedContentKind,
+                              style: TextStyle(
+                                color: AppTheme.primaryColor.withOpacity(0.9),
+                                fontSize: 11,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        Expanded(
+                          child: Text(
+                            title,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: const TextStyle(
+                        color: Colors.white60,
+                        fontSize: 11,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              if (model.hasSelectedContentPreview) ...[
+                const SizedBox(width: 4),
+                IconButton(
+                  visualDensity: VisualDensity.compact,
+                  tooltip: '查看已读取内容',
+                  icon: const Icon(Icons.visibility, color: Colors.white70),
+                  onPressed: () => _showSelectedContentPreview(model),
+                ),
+              ],
+              const Icon(Icons.chevron_right, color: Colors.white54),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _contentIcon(String kind) {
+    return switch (kind) {
+      '链接' => Icons.link,
+      '文本' => Icons.edit_note,
+      '本机文件' => Icons.folder_open,
+      '素材文件' => Icons.inventory_2,
+      '禅室佛像素材' => Icons.self_improvement,
+      _ => Icons.library_books,
+    };
+  }
+
   void _showHotspotGuideDialog(BuildContext context) {
     String title;
     List<String> steps;
@@ -899,63 +961,106 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     final result = await showModalBottomSheet<bool>(
       context: context,
       backgroundColor: const Color(0xFF171717),
+      isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
       ),
       builder: (sheetContext) => SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text(
-                '选择要全球发送的内容',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w700,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(sheetContext).size.height * 0.84,
+          ),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '选择要全球发送的内容',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 14),
-              _SendSourceTile(
-                icon: Icons.link,
-                title: '输入链接',
-                subtitle: '读取链接正文并发送',
-                onTap: () async {
-                  Navigator.pop(sheetContext, await _inputSendLink(model));
-                },
-              ),
-              _SendSourceTile(
-                icon: Icons.edit_note,
-                title: '输入文本',
-                subtitle: '发送手输或粘贴的文本',
-                onTap: () async {
-                  Navigator.pop(sheetContext, await _inputSendText(model));
-                },
-              ),
-              _SendSourceTile(
-                icon: Icons.folder_open,
-                title: '选择本机文件',
-                subtitle: '发送手机本机文件',
-                onTap: () async {
-                  final before = model.selectedFiles.length;
-                  await model.selectFiles();
-                  Navigator.pop(
-                    sheetContext,
-                    model.selectedFiles.length > before,
-                  );
-                },
-              ),
-              _SendSourceTile(
-                icon: Icons.self_improvement,
-                title: '禅室佛像素材',
-                subtitle: '发送禅室当前佛像模型素材',
-                onTap: () async {
-                  Navigator.pop(sheetContext, await _selectBuddhaAsset(model));
-                },
-              ),
-            ],
+                const SizedBox(height: 14),
+                _SendSourceTile(
+                  icon: Icons.link,
+                  title: '输入链接',
+                  subtitle: '读取链接正文，读取后可点开查看',
+                  onTap: () async {
+                    final navigator = Navigator.of(sheetContext);
+                    final selected = await _inputSendLink(model);
+                    if (navigator.mounted) navigator.pop(selected);
+                  },
+                ),
+                _SendSourceTile(
+                  icon: Icons.edit_note,
+                  title: '输入文本',
+                  subtitle: '发送手输或粘贴的文本',
+                  onTap: () async {
+                    final navigator = Navigator.of(sheetContext);
+                    final selected = await _inputSendText(model);
+                    if (navigator.mounted) navigator.pop(selected);
+                  },
+                ),
+                _SendSourceTile(
+                  icon: Icons.folder_open,
+                  title: '选择本机文件',
+                  subtitle: '发送手机本机文件',
+                  onTap: () async {
+                    final navigator = Navigator.of(sheetContext);
+                    final before = model.selectedFiles.length;
+                    await model.selectFiles();
+                    if (navigator.mounted) {
+                      navigator.pop(model.selectedFiles.length > before);
+                    }
+                  },
+                ),
+                _SendSourceTile(
+                  icon: Icons.self_improvement,
+                  title: '禅室佛像素材',
+                  subtitle: '发送禅室当前佛像模型素材',
+                  onTap: () async {
+                    final navigator = Navigator.of(sheetContext);
+                    final selected = await _selectBuddhaAsset(model);
+                    if (navigator.mounted) navigator.pop(selected);
+                  },
+                ),
+                if (model.linkHistory.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Text(
+                    '链接历史',
+                    style: TextStyle(
+                      color: Colors.white70,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  ...model.linkHistory
+                      .take(8)
+                      .map(
+                        (entry) => _SendSourceTile(
+                          icon: Icons.history,
+                          title: entry.title.isEmpty ? entry.url : entry.title,
+                          subtitle: entry.preview.isEmpty
+                              ? entry.url
+                              : entry.preview,
+                          onTap: () async {
+                            final navigator = Navigator.of(sheetContext);
+                            final selected = await _selectLinkHistory(
+                              model,
+                              entry,
+                            );
+                            if (navigator.mounted) navigator.pop(selected);
+                          },
+                        ),
+                      ),
+                ],
+              ],
+            ),
           ),
         ),
       ),
@@ -1053,6 +1158,65 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     }
   }
 
+  Future<bool> _selectLinkHistory(
+    FileTransferModel model,
+    LinkSendHistoryEntry entry,
+  ) async {
+    try {
+      await model.addUrlContentForSending(entry.url);
+      return true;
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('历史链接读取失败: $e'), backgroundColor: Colors.red),
+        );
+      }
+      return false;
+    }
+  }
+
+  Future<void> _showSelectedContentPreview(FileTransferModel model) async {
+    final text = model.selectedContentPreviewText?.trim();
+    if (text == null || text.isEmpty) return;
+
+    final title = model.selectedContentTitle.isEmpty
+        ? '已读取内容'
+        : model.selectedContentTitle;
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(title, maxLines: 2, overflow: TextOverflow.ellipsis),
+        content: SizedBox(
+          width: 420,
+          child: SingleChildScrollView(
+            child: SelectableText(
+              model.selectedContentSourceUrl == null
+                  ? text
+                  : '来源链接: ${model.selectedContentSourceUrl}\n\n$text',
+            ),
+          ),
+        ),
+        actions: [
+          TextButton.icon(
+            onPressed: () async {
+              await Clipboard.setData(ClipboardData(text: text));
+              if (!dialogContext.mounted) return;
+              ScaffoldMessenger.of(
+                dialogContext,
+              ).showSnackBar(const SnackBar(content: Text('内容已复制')));
+            },
+            icon: const Icon(Icons.copy),
+            label: const Text('复制'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('关闭'),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<bool> _selectBuddhaAsset(FileTransferModel model) async {
     try {
       await model.addZenBuddhaAssetForSending();
@@ -1070,8 +1234,18 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   void _startSending(FileTransferModel model) async {
     if (model.isPreparingSend || model.isTransferring) return;
 
-    final prepared = await _showSendContentSheet(model);
-    if (!prepared || !mounted || !model.hasFiles) return;
+    if (!model.hasFiles) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('请先点“选择发送内容”选择链接、文本、本机文件或禅室佛像素材。'),
+            duration: Duration(seconds: 2),
+            backgroundColor: Colors.black87,
+          ),
+        );
+      }
+      return;
+    }
 
     if (Platform.isAndroid && mounted) {
       try {

--- a/fabushi/lib/services/local_loopback_service.dart
+++ b/fabushi/lib/services/local_loopback_service.dart
@@ -42,6 +42,8 @@ class LocalLoopbackService {
 
   /// 批量发送次数 - 每轮发送多个完整文件循环
   static const int _batchCount = 10;
+  static const int _largePayloadThreshold = 1024 * 1024;
+  static const int _largePayloadSampleBytes = 64 * 1024;
 
   bool _isRunning = false;
   int _loopCount = 0;
@@ -61,6 +63,8 @@ class LocalLoopbackService {
   String? _cachedFilePath;
   String? _cachedFileName;
   Uint8List? _cachedHeaderPacket;
+  int _cachedPayloadSize = 0;
+  int _effectiveBatchCount = _batchCount;
 
   // 极致优化：预构建的数据包缓存
   List<Uint8List>? _prebuiltPackets;
@@ -90,17 +94,28 @@ class LocalLoopbackService {
     Uint8List? data,
     String? filePath,
     required String fileName,
-    LoopbackRunMode mode = LoopbackRunMode.mainThread,
+    LoopbackRunMode mode = LoopbackRunMode.isolate,
     LoopbackSpeedLevel speedLevel = LoopbackSpeedLevel.extreme,
   }) async {
     if (_isRunning) return;
+
+    final fileSize = data?.length ?? await _safeFileLength(filePath);
+    final isLargePayload = fileSize >= _largePayloadThreshold;
 
     // 缓存参数
     _cachedData = data;
     _cachedFilePath = filePath;
     _cachedFileName = fileName;
-    _cachedHeaderPacket = _buildHeader(fileName);
-    _speedLevel = speedLevel;
+    _cachedPayloadSize = fileSize;
+    _cachedHeaderPacket = _buildHeader(
+      fileName,
+      originalSize: fileSize,
+      payloadMode: isLargePayload ? 'sample' : 'full',
+    );
+    _speedLevel = isLargePayload && speedLevel == LoopbackSpeedLevel.extreme
+        ? LoopbackSpeedLevel.normal
+        : speedLevel;
+    _effectiveBatchCount = isLargePayload ? 1 : _batchCount;
 
     // 极致优化：预构建数据包
     await _prebuildPackets();
@@ -125,30 +140,50 @@ class LocalLoopbackService {
     if (_cachedData != null) {
       // 内存数据预构建
       final data = _cachedData!;
+      final payload = data.length > _largePayloadThreshold
+          ? Uint8List.sublistView(
+              data,
+              0,
+              data.length < _largePayloadSampleBytes
+                  ? data.length
+                  : _largePayloadSampleBytes,
+            )
+          : data;
       int offset = 0;
 
-      while (offset < data.length) {
-        final end = (offset + _maxChunkSize < data.length)
+      while (offset < payload.length) {
+        final end = (offset + _maxChunkSize < payload.length)
             ? offset + _maxChunkSize
-            : data.length;
+            : payload.length;
         final packetSize = header.length + (end - offset);
         final packet = Uint8List(packetSize);
 
         // 零拷贝：直接写入目标buffer
         packet.setRange(0, header.length, header);
-        packet.setRange(header.length, packetSize, data, offset);
+        packet.setRange(header.length, packetSize, payload, offset);
 
         packets.add(packet);
         offset = end;
       }
 
-      _log('📦 预构建 ${packets.length} 个数据包 (每包最大 $_maxChunkSize 字节)');
+      _log(
+        '📦 预构建 ${packets.length} 个数据包 (原始 ${_formatBytes(_cachedPayloadSize)}, 发送样本 ${_formatBytes(payload.length)})',
+      );
     } else if (_cachedFilePath != null) {
-      // 文件数据：读入内存并预构建
+      // 文件数据：小文件完整预构建，大文件只读取轻量样本，避免卡住 UI。
       final file = File(_cachedFilePath!);
       if (await file.exists()) {
-        final fileData = await file.readAsBytes();
-        _cachedData = fileData; // 缓存到内存
+        final length = await file.length();
+        _cachedPayloadSize = length;
+        final sampleLength = length > _largePayloadThreshold
+            ? (length < _largePayloadSampleBytes
+                  ? length
+                  : _largePayloadSampleBytes)
+            : length;
+        final fileData = length > _largePayloadThreshold
+            ? await _readFileSample(file, sampleLength)
+            : await file.readAsBytes();
+        _cachedData = fileData;
 
         int offset = 0;
         while (offset < fileData.length) {
@@ -165,7 +200,7 @@ class LocalLoopbackService {
           offset = end;
         }
 
-        _log('📦 文件 ${file.lengthSync()} 字节 -> ${packets.length} 个预构建包');
+        _log('📦 文件 ${_formatBytes(length)} -> ${packets.length} 个回环样本包');
       }
     }
 
@@ -240,7 +275,7 @@ class LocalLoopbackService {
           port: _loopbackPort,
           initialLoopCount: _loopCount,
           speedLevel: _speedLevel,
-          batchCount: _batchCount,
+          batchCount: _effectiveBatchCount,
         ),
       );
     } catch (e) {
@@ -297,7 +332,7 @@ class LocalLoopbackService {
 
         try {
           // 批量发送
-          for (int batch = 0; batch < _batchCount; batch++) {
+          for (int batch = 0; batch < _effectiveBatchCount; batch++) {
             _loopCount++;
 
             // 使用预构建包发送
@@ -429,6 +464,8 @@ class LocalLoopbackService {
     _cachedFilePath = null;
     _cachedFileName = null;
     _cachedHeaderPacket = null;
+    _cachedPayloadSize = 0;
+    _effectiveBatchCount = _batchCount;
     _prebuiltPackets = null;
 
     _log('🛑 本地回环已停止');
@@ -439,12 +476,42 @@ class LocalLoopbackService {
     stop();
   }
 
-  Uint8List _buildHeader(String fileName) {
+  Future<int> _safeFileLength(String? filePath) async {
+    if (filePath == null) return 0;
+    try {
+      final file = File(filePath);
+      return await file.exists() ? await file.length() : 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  Future<Uint8List> _readFileSample(File file, int sampleLength) async {
+    final randomAccessFile = await file.open();
+    try {
+      return await randomAccessFile.read(sampleLength);
+    } finally {
+      await randomAccessFile.close();
+    }
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+
+  Uint8List _buildHeader(
+    String fileName, {
+    required int originalSize,
+    required String payloadMode,
+  }) {
     final header = {
       'type': 'dharma_local_loop',
       'fileName': fileName,
+      'fileSize': originalSize,
       'timestamp': DateTime.now().toIso8601String(),
-      'mode': 'extreme_speed',
+      'mode': 'loopback_$payloadMode',
     };
 
     final headerBytes = utf8.encode(jsonEncode(header));

--- a/fabushi/lib/services/udp_global_send_service.dart
+++ b/fabushi/lib/services/udp_global_send_service.dart
@@ -142,7 +142,7 @@ class UDPGlobalSendService {
           Uint8List? fileBytes = file.bytes;
 
           // 内存优化：大文件不加载全部内容
-          const int largeFileThreshold = 10 * 1024 * 1024; // 10MB
+          const int largeFileThreshold = 1024 * 1024; // 1MB
 
           if (file.size >= largeFileThreshold) {
             // 大文件：只发送元数据，不加载完整内容
@@ -435,6 +435,7 @@ class UDPGlobalSendService {
       final stream = file.openRead();
       int chunkIndex = 0;
       int totalBytesSent = headerBytes.length;
+      int packetIndex = 0;
 
       await for (var chunk in stream) {
         if (!_isRunning) break;
@@ -452,6 +453,11 @@ class UDPGlobalSendService {
           final sent = socket.send(packet, address, _udpPort);
           totalBytesSent += sent;
           offset = end;
+          packetIndex++;
+
+          if (packetIndex % 32 == 0) {
+            await Future.delayed(Duration.zero);
+          }
         }
 
         chunkIndex++;
@@ -512,6 +518,7 @@ class UDPGlobalSendService {
   static const int _streamChunkSize = 1024 * 1024;
 
   /// 发送元数据 UDP 包（不包含文件内容）- 保留作为备用
+  // ignore: unused_element
   Future<bool> _sendMetadataPacket(
     RawDatagramSocket socket,
     String fileName,

--- a/fabushi/lib/services/wifi_field_broadcast_service.dart
+++ b/fabushi/lib/services/wifi_field_broadcast_service.dart
@@ -70,6 +70,7 @@ class WiFiFieldBroadcastService {
   Future<void> startBroadcast({
     required Uint8List data,
     required String fileName,
+    int? originalSize,
   }) async {
     if (_isRunning) return;
     if (_socket == null) {
@@ -82,7 +83,7 @@ class WiFiFieldBroadcastService {
     _log('🌟 开始场能广播: $fileName');
 
     // 构建广播数据包
-    final packet = _buildBroadcastPacket(data, fileName);
+    final packet = _buildBroadcastPacket(data, fileName, originalSize);
 
     // 获取所有可用的网络接口地址
     final broadcastAddresses = await _getBroadcastAddresses();
@@ -152,12 +153,17 @@ class WiFiFieldBroadcastService {
   }
 
   /// 构建广播数据包
-  Uint8List _buildBroadcastPacket(Uint8List data, String fileName) {
+  Uint8List _buildBroadcastPacket(
+    Uint8List data,
+    String fileName,
+    int? originalSize,
+  ) {
     final header = {
       'type': 'dharma_field_energy',
       'fileName': fileName,
       'timestamp': DateTime.now().toIso8601String(),
-      'size': data.length,
+      'size': originalSize ?? data.length,
+      'sampleSize': data.length,
       'checksum': _calculateChecksum(data),
     };
 

--- a/fabushi/test/unit/models/file_transfer_model_send_content_test.dart
+++ b/fabushi/test/unit/models/file_transfer_model_send_content_test.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/models/file_transfer_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('text selection exposes a preview before sending', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final model = FileTransferModel();
+    addTearDown(model.dispose);
+    await tester.pump(const Duration(milliseconds: 350));
+
+    await model.addTextContentForSending(
+      title: '心经片段',
+      text: '观自在菩萨，行深般若波罗蜜多时。',
+    );
+
+    expect(model.hasFiles, isTrue);
+    expect(model.selectedContentKind, '文本');
+    expect(model.selectedContentTitle, '心经片段');
+    expect(model.hasSelectedContentPreview, isTrue);
+    expect(model.selectedContentPreviewText, contains('观自在菩萨'));
+  });
+
+  testWidgets('link history restores from persisted state', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'send_link_history_v1': jsonEncode([
+        {
+          'url': 'https://example.com/sutra',
+          'title': '示例经文',
+          'preview': '已读取的正文片段',
+          'savedAt': '2026-05-29T08:00:00.000',
+        },
+      ]),
+    });
+
+    final model = FileTransferModel();
+    addTearDown(model.dispose);
+
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(model.linkHistory, hasLength(1));
+    expect(model.linkHistory.first.url, 'https://example.com/sutra');
+    expect(model.linkHistory.first.preview, contains('正文片段'));
+  });
+}

--- a/scripts/check_home_send_flow.py
+++ b/scripts/check_home_send_flow.py
@@ -46,13 +46,25 @@ for method_name in (
         print(f'FAIL: {method_name} must not download default CBETA content')
         sys.exit(1)
 
-if '_showSendContentSheet(model)' not in body:
-    print('FAIL: homepage send should ask for user-selected content when empty')
+if '_buildSelectedContentTile(model)' not in home_text:
+    print('FAIL: homepage should expose a send-content selection tile')
     sys.exit(1)
 
-pre_sheet_body = body.split('_showSendContentSheet(model)', 1)[0]
-if 'model.hasFiles' in pre_sheet_body:
-    print('FAIL: homepage send should always ask for content before sending')
+if '() => _showSendContentSheet(model)' not in home_text:
+    print('FAIL: homepage content tile should open the send-content picker')
+    sys.exit(1)
+
+if '_showSendContentSheet(model)' in body:
+    print('FAIL: start button should not open the content picker')
+    sys.exit(1)
+
+pre_send_body = body.split('await model.startGlobalTransfer()', 1)[0]
+if '!model.hasFiles' not in pre_send_body:
+    print('FAIL: start button should require pre-selected content before sending')
+    sys.exit(1)
+
+if '请先点' not in pre_send_body:
+    print('FAIL: empty start should tell the user to choose send content first')
     sys.exit(1)
 
 if 'await model.startGlobalTransfer()' not in body:


### PR DESCRIPTION
## Summary
- Move send-content choice to the homepage tile so Start only sends already selected content.
- Add URL body extraction previews plus persisted link history for repeat selection.
- Reduce UI stalls for large audio/model assets by sampling large loopback/broadcast payloads, running loopback in an isolate, and yielding during large UDP streams.

## Validation
- `flutter test test\unit\models\file_transfer_model_send_content_test.dart`
- `flutter analyze --no-fatal-infos lib\models\file_transfer_model.dart lib\screens\globe_home_screen.dart lib\services\local_loopback_service.dart lib\services\wifi_field_broadcast_service.dart lib\services\udp_global_send_service.dart test\unit\models\file_transfer_model_send_content_test.dart`
- `android/gradlew.bat assembleDebug --no-daemon --max-workers=4 "-Dorg.gradle.jvmargs=-Xmx3G"`
- Installed debug APK on connected Android device `AXYP6R4530001510` and verified link preview/history, text send, and 293.9 MB Buddha material send/stop without ANR or Flutter fatal logs.