### PR TITLE
Direct CBETA to self-hosted API and keep practice books local

### DIFF
--- a/fabushi/lib/models/practice_book_model.dart
+++ b/fabushi/lib/models/practice_book_model.dart
@@ -6,6 +6,8 @@ enum PracticeBookSourceType { file, url, manual, image, cloud }
 
 enum PracticeBookSyncStatus { localOnly, pendingUpload, synced, syncFailed }
 
+const Object _copyWithUnset = Object();
+
 PracticeBookSourceType practiceBookSourceTypeFromString(String? value) {
   return PracticeBookSourceType.values.firstWhere(
     (item) => item.name == value,
@@ -65,7 +67,7 @@ class PracticeBook {
     String? sourceFilePath,
     required String plainText,
     String? remoteObjectKey,
-    PracticeBookSyncStatus syncStatus = PracticeBookSyncStatus.pendingUpload,
+    PracticeBookSyncStatus syncStatus = PracticeBookSyncStatus.localOnly,
   }) {
     final normalizedText = PracticeBookText.normalizeForMatching(plainText);
     final now = DateTime.now();
@@ -193,7 +195,7 @@ class PracticeBook {
     DateTime? createdAt,
     DateTime? updatedAt,
     PracticeBookSyncStatus? syncStatus,
-    String? remoteObjectKey,
+    Object? remoteObjectKey = _copyWithUnset,
     bool? isActive,
   }) {
     return PracticeBook(
@@ -210,7 +212,9 @@ class PracticeBook {
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       syncStatus: syncStatus ?? this.syncStatus,
-      remoteObjectKey: remoteObjectKey ?? this.remoteObjectKey,
+      remoteObjectKey: identical(remoteObjectKey, _copyWithUnset)
+          ? this.remoteObjectKey
+          : remoteObjectKey as String?,
       isActive: isActive ?? this.isActive,
     );
   }

--- a/fabushi/lib/screens/global_dharma_screen.dart
+++ b/fabushi/lib/screens/global_dharma_screen.dart
@@ -77,7 +77,7 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
                       ),
                     ),
                     onPressed: null,
-                    tooltip: '正在下载经文',
+                    tooltip: '正在准备发送',
                   )
                 : model.isTransferring
                 ? IconButton(
@@ -146,7 +146,7 @@ class _GlobalDharmaScreenState extends State<GlobalDharmaScreen> {
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
-                            '当前经文：《$scripture》',
+                            '当前内容：$scripture',
                             style: const TextStyle(
                               fontSize: 14,
                               fontWeight: FontWeight.w600,

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -1234,16 +1234,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   void _startSending(FileTransferModel model) async {
     if (model.isPreparingSend || model.isTransferring) return;
 
-    if (!model.hasFiles) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('请先点“选择发送内容”选择链接、文本、本机文件或禅室佛像素材。'),
-            duration: Duration(seconds: 2),
-            backgroundColor: Colors.black87,
-          ),
-        );
-      }
+    final prepared = await _showSendContentSheet(model);
+    if (!prepared || !mounted || !model.hasFiles) {
       return;
     }
 

--- a/fabushi/lib/services/cbeta_send_text_service.dart
+++ b/fabushi/lib/services/cbeta_send_text_service.dart
@@ -71,9 +71,8 @@ class _CbetaJsonResult {
 class CbetaSendTextService {
   static const int _maxRetries = 3;
   static const Duration _timeout = Duration(seconds: 15);
-  static const String _officialApiRoot = 'https://api.cbetaonline.cn';
-  static const String _oracleApiRoot = 'http://144.24.17.21.sslip.io:3000';
-  static const List<String> _apiRoots = [_officialApiRoot, _oracleApiRoot];
+  static const String _selfHostedApiRoot = 'http://144.24.17.21.sslip.io:3000';
+  static const List<String> _apiRoots = [_selfHostedApiRoot];
 
   static const List<String> _defaultSendWorks = [
     'T0365',
@@ -135,7 +134,7 @@ class CbetaSendTextService {
     return CbetaSendTextResult(
       items: items,
       errors: errors,
-      api: _officialApiRoot,
+      api: _selfHostedApiRoot,
       hasMore: hasMore,
       nextCursor: hasMore ? index.toString() : null,
     );

--- a/fabushi/lib/services/ios_background_audio_handler.dart
+++ b/fabushi/lib/services/ios_background_audio_handler.dart
@@ -50,7 +50,7 @@ class IOSBackgroundAudioHandler extends BaseAudioHandler {
       mediaItem.add(
         MediaItem(
           id: 'dharma_sending',
-          title: '正在发送经文',
+          title: '正在发送内容',
           artist: fileName,
           artUri: null,
           duration: Duration.zero, // 未知时长
@@ -92,7 +92,7 @@ class IOSBackgroundAudioHandler extends BaseAudioHandler {
         _loopCount = loopCount;
       }
 
-      String title = '正在发送经文';
+      String title = '正在发送内容';
       if (_loopCount > 0) {
         title = '循环发送中 (第 $_loopCount 轮)';
       }

--- a/fabushi/lib/services/practice_book_service_stub.dart
+++ b/fabushi/lib/services/practice_book_service_stub.dart
@@ -30,7 +30,10 @@ class PracticeBookService {
   Future<PracticeBook> saveBook(
     PracticeBook book, {
     bool syncCloud = false,
-  }) async => book.copyWith(syncStatus: PracticeBookSyncStatus.localOnly);
+  }) async => book.copyWith(
+    syncStatus: PracticeBookSyncStatus.localOnly,
+    remoteObjectKey: null,
+  );
 
   Future<void> deleteBook(String id, {bool syncCloud = false}) async {}
 

--- a/fabushi/test/unit/models/practice_book_model_test.dart
+++ b/fabushi/test/unit/models/practice_book_model_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/models/practice_book_model.dart';
+
+void main() {
+  group('PracticeBook', () {
+    test('defaults to local only storage', () {
+      final book = PracticeBook.create(
+        id: 'book-1',
+        practiceTitle: 'Daily practice',
+        title: 'Manual chanting text',
+        sourceType: PracticeBookSourceType.manual,
+        plainText: 'Namo Amitabha',
+      );
+
+      expect(book.syncStatus, PracticeBookSyncStatus.localOnly);
+      expect(book.remoteObjectKey, isNull);
+    });
+
+    test('can clear stale remote object references', () {
+      final book = PracticeBook.create(
+        id: 'book-2',
+        practiceTitle: 'Heart Sutra',
+        title: 'Heart Sutra practice',
+        sourceType: PracticeBookSourceType.url,
+        sourceUrl: 'https://example.com/heart-sutra',
+        plainText: 'https://example.com/heart-sutra',
+        remoteObjectKey: 'practice-books/book-2.txt',
+        syncStatus: PracticeBookSyncStatus.synced,
+      );
+
+      final localBook = book.copyWith(
+        syncStatus: PracticeBookSyncStatus.localOnly,
+        remoteObjectKey: null,
+      );
+
+      expect(localBook.syncStatus, PracticeBookSyncStatus.localOnly);
+      expect(localBook.remoteObjectKey, isNull);
+      expect(localBook.sourceUrl, 'https://example.com/heart-sutra');
+    });
+  });
+}

--- a/fabushi/web/src/handlers/cbeta.js
+++ b/fabushi/web/src/handlers/cbeta.js
@@ -2,9 +2,8 @@ import { CORS_HEADERS } from '../config/constants.js';
 import { jsonResponse } from '../utils/response.js';
 
 const CBETA_PUBLIC_API_ROOT = 'https://api.ombhrum.com/api/cbeta';
-const CBETA_ORACLE_API_ROOT = 'http://144.24.17.21.sslip.io:3000';
-const CBETA_FALLBACK_API_ROOT = 'https://api.cbetaonline.cn';
-const CBETA_API_ROOTS = [CBETA_ORACLE_API_ROOT, CBETA_FALLBACK_API_ROOT];
+const CBETA_SELF_HOSTED_API_ROOT = 'http://144.24.17.21.sslip.io:3000';
+const CBETA_API_ROOTS = [CBETA_SELF_HOSTED_API_ROOT];
 const DEFAULT_SEND_WORKS = [
   'T0365',
   'T0251',
@@ -26,7 +25,7 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function buildCbetaUrl(path, params = {}, apiRoot = CBETA_ORACLE_API_ROOT) {
+function buildCbetaUrl(path, params = {}, apiRoot = CBETA_SELF_HOSTED_API_ROOT) {
   const url = new URL(path.replace(/^\/+/, ''), `${apiRoot}/`);
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value !== null && `${value}` !== '') {
@@ -299,8 +298,8 @@ export async function handleGetCbetaSendTexts(request) {
     success: items.length > 0,
     source: 'CBETA',
     api: CBETA_PUBLIC_API_ROOT,
-    primaryApi: CBETA_ORACLE_API_ROOT,
-    fallbackApi: CBETA_FALLBACK_API_ROOT,
+    primaryApi: CBETA_SELF_HOSTED_API_ROOT,
+    fallbackApi: null,
     requested: selectedWorks.length,
     count: items.length,
     items,

--- a/fabushi/web/tests/cbeta-send-texts.test.js
+++ b/fabushi/web/tests/cbeta-send-texts.test.js
@@ -3,13 +3,15 @@ import assert from 'node:assert/strict';
 
 import { handleGetCbetaSendTexts } from '../src/handlers/cbeta.js';
 
+const SELF_HOSTED_API = 'http://144.24.17.21.sslip.io:3000';
+
 const sampleHtml = `
-  <html><head><title>般若波羅蜜多心經</title></head><body>
+  <html><head><title>Heart Sutra</title></head><body>
     <div id="body">
       <span class="lb">T08n0251_p0848c06</span>
-      <p class="juan"><span class="t">般若波羅蜜多心經</span></p>
-      <p><span class="lineInfo"></span><span class="t">觀自在菩薩行深般若波羅蜜多時</span></p>
-      <p><span class="t">照見五蘊皆空，度一切苦厄。</span></p>
+      <p class="juan"><span class="t">Heart Sutra</span></p>
+      <p><span class="lineInfo">line</span><span class="t">Avalokitesvara deeply practiced prajna.</span></p>
+      <p><span class="t">He saw the five aggregates are empty.</span></p>
     </div>
     <div id="back"><div class="footnote">footnote</div></div>
     <div id="cbeta-copyright"><p>copyright</p></div>
@@ -34,9 +36,9 @@ test('CBETA send texts returns real stripped scripture content and detailed part
         results: [sampleHtml],
         work_info: {
           work: 'T0251',
-          title: '般若波羅蜜多心經',
-          byline: '唐 玄奘譯',
-          category: '般若部類',
+          title: 'Heart Sutra',
+          byline: 'Xuanzang',
+          category: 'Prajna',
         },
       }), { status: 200 });
     }
@@ -57,14 +59,17 @@ test('CBETA send texts returns real stripped scripture content and detailed part
     const body = await response.json();
     assert.equal(body.success, true);
     assert.equal(body.count, 1);
+    assert.equal(body.primaryApi, SELF_HOSTED_API);
+    assert.equal(body.fallbackApi, null);
     assert.equal(body.errors.length, 1);
-    assert.equal(body.errors[0].attempts.length, 6);
-    assert.equal(failAttempts, 6);
+    assert.equal(body.errors[0].attempts.length, 3);
+    assert.equal(failAttempts, 3);
 
     const item = body.items[0];
     assert.equal(item.work, 'T0251');
+    assert.equal(item.sourceApi, SELF_HOSTED_API);
     assert.match(item.fileName, /^T0251_1_/);
-    assert.match(item.content, /觀自在菩薩/);
+    assert.match(item.content, /Avalokitesvara deeply practiced prajna/);
     assert.doesNotMatch(item.content, /T08n0251/);
     assert.doesNotMatch(item.content, /copyright/);
   } finally {
@@ -89,9 +94,10 @@ test('CBETA send texts reports full upstream errors when no scripture can be fet
     const body = await response.json();
     assert.equal(body.success, false);
     assert.equal(body.count, 0);
+    assert.equal(body.fallbackApi, null);
     assert.equal(body.errors.length, 1);
-    assert.match(body.errors[0].message, /failed after 6 attempts/);
-    assert.equal(body.errors[0].attempts.length, 6);
+    assert.match(body.errors[0].message, /failed after 3 attempts/);
+    assert.equal(body.errors[0].attempts.length, 3);
     assert.equal(body.errors[0].attempts[0].status, 502);
     assert.match(body.errors[0].attempts[0].body, /bad gateway/);
   } finally {
@@ -99,42 +105,28 @@ test('CBETA send texts reports full upstream errors when no scripture can be fet
   }
 });
 
-test('CBETA send texts falls back when Oracle returns empty juan content', async () => {
+test('CBETA send texts never falls back to official API when self-hosted returns empty content', async () => {
   const attemptedHosts = [];
   const restoreFetch = installFetchMock(async url => {
     const parsed = new URL(url);
     attemptedHosts.push(parsed.host);
-
-    if (parsed.host === '144.24.17.21.sslip.io:3000') {
-      return new Response(JSON.stringify({ num_found: 0, results: [] }), { status: 200 });
-    }
-
-    return new Response(JSON.stringify({
-      results: [sampleHtml],
-      work_info: {
-        work: 'T0251',
-        title: '般若波羅蜜多心經',
-        byline: '唐 玄奘譯',
-        category: '般若部類',
-      },
-    }), { status: 200 });
+    return new Response(JSON.stringify({ num_found: 0, results: [] }), { status: 200 });
   });
 
   try {
     const response = await handleGetCbetaSendTexts(
       new Request('https://api.ombhrum.com/api/cbeta/send-texts?works=T0251&limit=1'),
     );
-    assert.equal(response.status, 200);
+    assert.equal(response.status, 502);
 
     const body = await response.json();
-    assert.equal(body.count, 1);
-    assert.equal(body.items[0].sourceApi, 'https://api.cbetaonline.cn');
-    assert.match(body.items[0].content, /觀自在菩薩/);
+    assert.equal(body.count, 0);
+    assert.equal(body.fallbackApi, null);
+    assert.equal(body.errors.length, 1);
     assert.deepEqual(attemptedHosts, [
       '144.24.17.21.sslip.io:3000',
       '144.24.17.21.sslip.io:3000',
       '144.24.17.21.sslip.io:3000',
-      'api.cbetaonline.cn',
     ]);
   } finally {
     restoreFetch();

--- a/frontend/apps/web/src/lib/cbeta-config.ts
+++ b/frontend/apps/web/src/lib/cbeta-config.ts
@@ -1,1 +1,1 @@
-export const CBETA_API_ROOT = "https://api.cbetaonline.cn";
+export const CBETA_API_ROOT = "http://144.24.17.21.sslip.io:3000";

--- a/frontend/official-site-worker.js
+++ b/frontend/official-site-worker.js
@@ -1,6 +1,6 @@
 const CBETA_PROXY_ROUTE = /^\/api\/cbeta\/(.+)$/;
 const APP_PROXY_ROUTE = /^\/api\/app\/(.+)$/;
-const CBETA_API_BASE = "https://api.cbetaonline.cn";
+const CBETA_API_BASE = "http://144.24.17.21.sslip.io:3000";
 const APP_API_BASE = "https://api.ombhrum.com/api";
 const OFFICIAL_SITE_HOST = "fabushi.ombhrum.com";
 const ROOT_DOMAIN_REDIRECT_HOSTS = new Set(["ombhrum.com"]);

--- a/scripts/check_home_send_flow.py
+++ b/scripts/check_home_send_flow.py
@@ -54,17 +54,13 @@ if '() => _showSendContentSheet(model)' not in home_text:
     print('FAIL: homepage content tile should open the send-content picker')
     sys.exit(1)
 
-if '_showSendContentSheet(model)' in body:
-    print('FAIL: start button should not open the content picker')
+if 'final prepared = await _showSendContentSheet(model);' not in body:
+    print('FAIL: start button should open the content picker before sending')
     sys.exit(1)
 
 pre_send_body = body.split('await model.startGlobalTransfer()', 1)[0]
-if '!model.hasFiles' not in pre_send_body:
-    print('FAIL: start button should require pre-selected content before sending')
-    sys.exit(1)
-
-if '请先点' not in pre_send_body:
-    print('FAIL: empty start should tell the user to choose send content first')
+if '!prepared || !mounted || !model.hasFiles' not in pre_send_body:
+    print('FAIL: start button should require picker confirmation and selected content before sending')
     sys.exit(1)
 
 if 'await model.startGlobalTransfer()' not in body:


### PR DESCRIPTION
## Summary
- route mobile, web handler, and official site CBETA calls directly to the self-hosted API only
- keep practice book records local-only and clear stale cloud object keys
- make homepage global send open the content picker before sending selected link/text/file/Buddha material

## Tests
- node --test tests/cbeta-send-texts.test.js tests/frontend-worker.test.js
- flutter test test/unit/models/practice_book_model_test.dart
- python scripts/check_home_send_flow.py
- corepack pnpm --filter @fabushi/web typecheck
- dart analyze --no-fatal-warnings lib/models/practice_book_model.dart lib/services/practice_book_service_stub.dart lib/services/cbeta_send_text_service.dart lib/screens/global_dharma_screen.dart lib/screens/globe_home_screen.dart lib/services/ios_background_audio_handler.dart
- git diff --check
- Android debug APK build-number 397 installed and smoke-tested on AXYP6R4530001510 via adb