### PR TITLE
[codex] Fix selected material sending flow

### DIFF
--- a/fabushi/lib/models/file_transfer_model.dart
+++ b/fabushi/lib/models/file_transfer_model.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:http/http.dart' as http;
-import 'dart:io';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:async';
@@ -83,6 +82,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   int _globalSentCount = 0;
   double _globalDataSentMB = 0.0;
+  double? _currentCountryProgress;
 
   RealGlobalSendService? _realGlobalSendService;
   PlatformGlobalSendService? _platformGlobalSendService;
@@ -165,9 +165,15 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   bool get hasFiles => _selectedFiles.isNotEmpty;
   int get globalSentCount => _globalSentCount;
   double get globalDataSentMB => _globalDataSentMB;
+  double? get currentCountryProgress => _currentCountryProgress;
   List<CountrySendStatus> get countryStatuses => _countryStatuses;
   String get currentLog => _currentLog;
   String get currentSendingScripture => _currentSendingScripture;
+  bool get isCurrentMaterialCompleted =>
+      (_currentLog.contains('文件《') && _currentLog.contains('发送完成')) ||
+      (_currentLog.contains('UDP 发送到') && _currentLog.contains('成功')) ||
+      _currentLog.contains('已完整发送') ||
+      _currentLog.contains('流式发送完成');
   String get selectedContentKind => _selectedContentKind;
   String get selectedContentTitle => _selectedContentTitle;
   String get selectedContentSubtitle => _selectedContentSubtitle;
@@ -370,7 +376,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     return _selectedFiles.length;
   }
 
-  Future<void> selectFiles() async {
+  Future<bool> selectFiles({bool replaceExisting = true}) async {
     try {
       FilePickerResult? result = await FilePicker.platform.pickFiles(
         allowMultiple: true,
@@ -380,7 +386,11 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       );
 
       if (result != null) {
-        _selectedFiles.addAll(result.files);
+        if (replaceExisting) {
+          _selectedFiles = result.files;
+        } else {
+          _selectedFiles.addAll(result.files);
+        }
         _downloadedScriptureMemory.clear();
         _updateFileSelectionSummary(kind: '本机文件');
         notifyListeners();
@@ -391,10 +401,12 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
           );
         }
         debugPrint('已选择 ${result.files.length} 个文件');
+        return result.files.isNotEmpty;
       }
     } catch (e) {
       debugPrint('选择文件失败: $e');
     }
+    return false;
   }
 
   Future<void> selectBuiltInAssets(BuildContext context) async {
@@ -406,6 +418,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     if (selectedAssets != null &&
         selectedAssets is List &&
         selectedAssets.isNotEmpty) {
+      if (!context.mounted) return;
       final List<String> assetPaths = selectedAssets
           .map((asset) => asset.toString())
           .toList();
@@ -419,6 +432,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   ) async {
     try {
       await _sharedAssetManager.initialize();
+      if (!context.mounted) return;
 
       final List<String> needDownloadAssets = [];
       final List<String> alreadyDownloadedAssets = [];
@@ -447,7 +461,6 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
       if (alreadyDownloadedAssets.isNotEmpty) {
         final failedAssets = await _reuseDownloadedAssets(
-          context,
           alreadyDownloadedAssets,
         );
         if (failedAssets.isNotEmpty) {
@@ -458,24 +471,24 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
       if (needDownloadAssets.isNotEmpty) {
         for (String assetPath in needDownloadAssets) {
+          if (!context.mounted) return;
           await _downloadSingleAsset(context, assetPath);
         }
       }
 
+      if (!context.mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('所有素材处理完成')));
     } catch (e) {
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('处理失败: $e'), backgroundColor: Colors.red),
       );
     }
   }
 
-  Future<List<String>> _reuseDownloadedAssets(
-    BuildContext context,
-    List<String> assetPaths,
-  ) async {
+  Future<List<String>> _reuseDownloadedAssets(List<String> assetPaths) async {
     final List<String> failedAssets = [];
     try {
       for (String assetPath in assetPaths) {
@@ -503,6 +516,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     try {
       final taskId = await _sharedAssetManager.downloadAsset(assetPath);
       final fileName = assetPath.split('/').last;
+      if (!context.mounted) return;
       await _showDownloadProgressDialog(context, taskId, fileName, assetPath);
       debugPrint('✅ 素材下载完成并关闭对话框: $fileName');
     } catch (e) {
@@ -646,19 +660,15 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
     beginPreparingSend('正在读取链接内容...');
     try {
-      final response = await http
-          .get(
-            uri,
-            headers: const {
-              'Accept': 'text/html,text/plain,application/xhtml+xml,*/*',
-            },
-          )
-          .timeout(const Duration(seconds: 20));
+      final response = await _fetchReadableLink(uri);
       if (response.statusCode < 200 || response.statusCode >= 300) {
         throw StateError('链接读取失败: HTTP ${response.statusCode}');
       }
 
       final raw = utf8.decode(response.bodyBytes, allowMalformed: true);
+      if (_looksLikeWeChatVerificationPage(raw)) {
+        throw StateError('微信链接返回了环境验证页，请稍后重试或重新复制文章链接。');
+      }
       final contentType = response.headers['content-type'] ?? '';
       final isHtml =
           contentType.toLowerCase().contains('html') ||
@@ -693,6 +703,65 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _finishPreparingSend();
       notifyListeners();
     }
+  }
+
+  Future<http.Response> _fetchReadableLink(Uri uri) async {
+    final candidates = <Uri>[
+      if (_isWeChatArticleUri(uri)) _withWeChatArticleFlags(uri),
+      uri,
+    ];
+
+    http.Response? lastResponse;
+    Object? lastError;
+    for (final candidate in candidates) {
+      try {
+        final response = await http
+            .get(candidate, headers: _linkRequestHeaders(candidate))
+            .timeout(const Duration(seconds: 25));
+        lastResponse = response;
+        final raw = utf8.decode(response.bodyBytes, allowMalformed: true);
+        if (response.statusCode >= 200 &&
+            response.statusCode < 300 &&
+            !_looksLikeWeChatVerificationPage(raw)) {
+          return response;
+        }
+      } catch (e) {
+        lastError = e;
+      }
+    }
+
+    if (lastResponse != null) return lastResponse;
+    throw StateError('链接读取失败: $lastError');
+  }
+
+  Map<String, String> _linkRequestHeaders(Uri uri) {
+    final isWeChat = _isWeChatArticleUri(uri);
+    return {
+      'Accept':
+          'text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.7',
+      'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+      'Cache-Control': 'no-cache',
+      'User-Agent': isWeChat
+          ? 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/8.0.49'
+          : 'Mozilla/5.0 (Linux; Android 13; Mobile) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+      if (isWeChat) 'Referer': 'https://mp.weixin.qq.com/',
+    };
+  }
+
+  bool _isWeChatArticleUri(Uri uri) =>
+      uri.host.toLowerCase() == 'mp.weixin.qq.com' &&
+      (uri.path == '/s' || uri.path.startsWith('/s/'));
+
+  Uri _withWeChatArticleFlags(Uri uri) {
+    final query = Map<String, String>.from(uri.queryParameters);
+    query.putIfAbsent('nwr_flag', () => '1');
+    return uri.replace(queryParameters: query);
+  }
+
+  bool _looksLikeWeChatVerificationPage(String html) {
+    return html.contains('当前环境异常') &&
+        html.contains('完成验证后即可继续访问') &&
+        html.contains('环境异常');
   }
 
   Future<void> _rememberLinkHistory({
@@ -880,6 +949,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
     _globalSentCount = 0;
     _loopbackCount = 0;
+    _currentCountryProgress = null;
 
     _schedulePersist(_persistTransferState);
     _scheduleNotify();
@@ -915,12 +985,14 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _isTransferring = false;
       _status = TransferStatus.completed;
       _currentSendingScripture = '';
+      _currentCountryProgress = null;
     } catch (e) {
       debugPrint('❌ 传输失败: $e');
       _status = TransferStatus.error;
       _isTransferring = false;
       _finishPreparingSend();
       _currentSendingScripture = '';
+      _currentCountryProgress = null;
       _stopFieldEnergyBroadcast();
       await _stopBackgroundService();
       _schedulePersist(_persistTransferState);
@@ -953,23 +1025,10 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       Uint8List? fileBytes = file.bytes;
       final originalSize = file.size;
 
-      if (fileBytes == null && file.path != null) {
-        final fileObj = File(file.path!);
-        if (await fileObj.exists()) {
-          final length = await fileObj.length();
-          final sampleLength = length > 1400 ? 1400 : length;
-          final randomAccessFile = await fileObj.open();
-          try {
-            fileBytes = await randomAccessFile.read(sampleLength);
-          } finally {
-            await randomAccessFile.close();
-          }
-        }
-      }
-
-      if (fileBytes != null) {
+      if (fileBytes != null || file.path != null) {
         await _fieldBroadcastService!.startBroadcast(
           data: fileBytes,
+          filePath: file.path,
           fileName: file.name,
           originalSize: originalSize,
         );
@@ -1044,6 +1103,8 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
             ? LoopbackSpeedLevel.normal
             : LoopbackSpeedLevel.high,
       );
+      _loopbackCount = 1;
+      _scheduleNotify();
     } catch (e) {
       debugPrint('⚠️ 启动本地回环失败: $e');
     }
@@ -1063,6 +1124,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     _finishPreparingSend();
     _status = TransferStatus.idle;
     _currentSendingScripture = '';
+    _currentCountryProgress = null;
 
     _platformGlobalSendService?.stopSending();
     _stopFieldEnergyBroadcast();
@@ -1084,6 +1146,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     _finishPreparingSend();
     _status = TransferStatus.completed;
     _currentSendingScripture = '';
+    _currentCountryProgress = null;
     _schedulePersist(_persistTransferState);
     _scheduleNotify();
   }
@@ -1159,6 +1222,10 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       },
       onDataSent: (dataMB) {
         updateDataSent(dataMB);
+      },
+      onCountryProgress: (progress) {
+        _currentCountryProgress = progress.clamp(0.0, 1.0);
+        _scheduleNotify();
       },
       onStopped: () {
         _onTransferCompleted();
@@ -1294,6 +1361,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   void updateProgress(int count) {
     _globalSentCount = count;
+    _currentCountryProgress = null;
 
     String currentCountry = '全球';
     if (_countryStatuses.isNotEmpty &&
@@ -1399,6 +1467,9 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   void updateLog(String log) {
     _currentLog = log;
     _updateCurrentSendingScriptureFromLog(log);
+    if (isCurrentMaterialCompleted) {
+      _currentCountryProgress = 1.0;
+    }
     if (log.contains('成功') || log.contains('失败') || log.contains('完成')) {
       _schedulePersist(_persistTransferState);
     }
@@ -1449,6 +1520,26 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   String? _extractHtmlTitle(String html) {
+    final metaTitle = RegExp(
+      r'<meta[^>]+property=["'
+      ']og:title["'
+      '][^>]+content=["'
+      ']([^"'
+      ']+)["'
+      '][^>]*>',
+      caseSensitive: false,
+    ).firstMatch(html)?.group(1);
+    if (metaTitle != null && metaTitle.trim().isNotEmpty) {
+      return _decodeHtmlEntities(metaTitle).trim();
+    }
+
+    final activityName = _extractHtmlSectionById(html, 'activity-name');
+    if (activityName != null && activityName.trim().isNotEmpty) {
+      return _decodeHtmlEntities(
+        activityName.replaceAll(RegExp(r'<[^>]+>'), ''),
+      ).trim();
+    }
+
     final title = RegExp(
       r'<title>([\s\S]*?)</title>',
       caseSensitive: false,
@@ -1462,18 +1553,31 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       r'<body[^>]*>([\s\S]*?)</body>',
       caseSensitive: false,
     ).firstMatch(html);
-    var source = bodyMatch?.group(1) ?? html;
+    var source =
+        _extractHtmlSectionById(html, 'js_content') ??
+        _extractHtmlSectionById(html, 'js_content_container') ??
+        bodyMatch?.group(1) ??
+        html;
     source = source
         .replaceAll(
           RegExp(r'<script[\s\S]*?</script>', caseSensitive: false),
           '',
         )
         .replaceAll(RegExp(r'<style[\s\S]*?</style>', caseSensitive: false), '')
+        .replaceAll(RegExp(r'<rt[\s\S]*?</rt>', caseSensitive: false), '')
+        .replaceAll(RegExp(r'<rp[\s\S]*?</rp>', caseSensitive: false), '')
+        .replaceAll(RegExp(r'<!--[\s\S]*?-->', caseSensitive: false), '')
         .replaceAll(
-          RegExp(r'<(p|div|br|h[1-6]|li)\b[^>]*>', caseSensitive: false),
+          RegExp(
+            r'<(p|div|section|br|h[1-6]|li|tr)\b[^>]*>',
+            caseSensitive: false,
+          ),
           '\n',
         )
-        .replaceAll(RegExp(r'</(p|div|h[1-6]|li)>', caseSensitive: false), '\n')
+        .replaceAll(
+          RegExp(r'</(p|div|section|h[1-6]|li|tr)>', caseSensitive: false),
+          '\n',
+        )
         .replaceAll(RegExp(r'<[^>]+>'), '');
 
     return _decodeHtmlEntities(source)
@@ -1483,6 +1587,35 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
         .replaceAll(RegExp(r'[ \t]+\n'), '\n')
         .replaceAll(RegExp(r'\n{3,}'), '\n\n')
         .trim();
+  }
+
+  String? _extractHtmlSectionById(String html, String id) {
+    final startMatch = RegExp(
+      '<([a-zA-Z0-9]+)[^>]*\\bid=["\\\']${RegExp.escape(id)}["\\\'][^>]*>',
+      caseSensitive: false,
+    ).firstMatch(html);
+    if (startMatch == null) return null;
+
+    final tag = startMatch.group(1);
+    if (tag == null || tag.isEmpty) return null;
+
+    final tagRegex = RegExp('</?$tag\\b[^>]*>', caseSensitive: false);
+    var depth = 1;
+    for (final match in tagRegex.allMatches(html, startMatch.end)) {
+      final token = match.group(0) ?? '';
+      final isClosing = token.startsWith('</');
+      final isSelfClosing = token.endsWith('/>');
+      if (isClosing) {
+        depth--;
+        if (depth == 0) {
+          return html.substring(startMatch.end, match.start);
+        }
+      } else if (!isSelfClosing) {
+        depth++;
+      }
+    }
+
+    return null;
   }
 
   String _decodeHtmlEntities(String value) {

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -305,7 +305,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
               icon: const Icon(Icons.leaderboard, color: Colors.white),
               style: IconButton.styleFrom(
                 backgroundColor: AppTheme.glassDecoration.color,
-                highlightColor: AppTheme.primaryColor.withOpacity(0.3),
+                highlightColor: AppTheme.primaryColor.withValues(alpha: 0.3),
               ),
               tooltip: '排行榜',
             ),
@@ -316,6 +316,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                 return const SizedBox.shrink();
               }
               final scripture = model.currentSendingScripture;
+              final materialCompleted = model.isCurrentMaterialCompleted;
+              final countryProgress = model.currentCountryProgress;
               return Positioned(
                 top: 70,
                 left: 20,
@@ -327,21 +329,12 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                       vertical: 10,
                     ),
                     decoration: AppTheme.glassDecoration.copyWith(
-                      color: Colors.black.withOpacity(0.6),
+                      color: Colors.black.withValues(alpha: 0.6),
                       borderRadius: BorderRadius.circular(20),
                     ),
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Colors.cyan,
-                          ),
-                        ),
-                        const SizedBox(width: 10),
                         Flexible(
                           child: Column(
                             mainAxisSize: MainAxisSize.min,
@@ -350,6 +343,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                               Text(
                                 scripture.isEmpty
                                     ? '正在发送内容'
+                                    : materialCompleted
+                                    ? '已完成《$scripture》'
                                     : '正在发送《$scripture》',
                                 style: const TextStyle(
                                   color: Colors.white,
@@ -360,9 +355,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                                 overflow: TextOverflow.ellipsis,
                               ),
                               Text(
-                                '目标: $_currentSendingCountry',
+                                '发送到 $_currentSendingCountry',
                                 style: TextStyle(
-                                  color: Colors.white.withOpacity(0.78),
+                                  color: Colors.white.withValues(alpha: 0.78),
                                   fontSize: 12,
                                 ),
                                 maxLines: 1,
@@ -371,6 +366,27 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                             ],
                           ),
                         ),
+                        const SizedBox(width: 10),
+                        materialCompleted
+                            ? const Icon(
+                                Icons.check_circle,
+                                color: Colors.greenAccent,
+                                size: 18,
+                              )
+                            : SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  value:
+                                      countryProgress != null &&
+                                          countryProgress > 0 &&
+                                          countryProgress < 1
+                                      ? countryProgress
+                                      : null,
+                                  strokeWidth: 2,
+                                  color: Colors.cyan,
+                                ),
+                              ),
                       ],
                     ),
                   ),
@@ -403,9 +419,11 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: Colors.amber.withOpacity(0.16),
+                      color: Colors.amber.withValues(alpha: 0.16),
                       borderRadius: BorderRadius.circular(10),
-                      border: Border.all(color: Colors.amber.withOpacity(0.35)),
+                      border: Border.all(
+                        color: Colors.amber.withValues(alpha: 0.35),
+                      ),
                     ),
                     child: Row(
                       children: [
@@ -440,10 +458,10 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: AppTheme.primaryColor.withOpacity(0.15),
+                      color: AppTheme.primaryColor.withValues(alpha: 0.15),
                       borderRadius: BorderRadius.circular(10),
                       border: Border.all(
-                        color: AppTheme.primaryColor.withOpacity(0.3),
+                        color: AppTheme.primaryColor.withValues(alpha: 0.3),
                       ),
                     ),
                     child: Column(
@@ -476,16 +494,21 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                           const SizedBox(height: 8),
                           Row(
                             children: [
-                              Icon(
-                                Icons.sync,
-                                color: Colors.cyanAccent,
-                                size: 16,
+                              const SizedBox(
+                                width: 14,
+                                height: 14,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.cyanAccent,
+                                ),
                               ),
                               const SizedBox(width: 6),
                               Text(
-                                '动态杨升激活: ${model.loopbackCount} 次',
+                                '动态杨升高速转轮中',
                                 style: TextStyle(
-                                  color: Colors.cyanAccent.withOpacity(0.9),
+                                  color: Colors.cyanAccent.withValues(
+                                    alpha: 0.9,
+                                  ),
                                   fontSize: 12,
                                   fontWeight: FontWeight.w500,
                                 ),
@@ -499,7 +522,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                                   shape: BoxShape.circle,
                                   boxShadow: [
                                     BoxShadow(
-                                      color: Colors.cyanAccent.withOpacity(0.5),
+                                      color: Colors.cyanAccent.withValues(
+                                        alpha: 0.5,
+                                      ),
                                       blurRadius: 4,
                                       spreadRadius: 1,
                                     ),
@@ -537,7 +562,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                                   shape: BoxShape.circle,
                                   boxShadow: [
                                     BoxShadow(
-                                      color: Colors.purple.withOpacity(0.5),
+                                      color: Colors.purple.withValues(
+                                        alpha: 0.5,
+                                      ),
                                       blurRadius: 4,
                                       spreadRadius: 1,
                                     ),
@@ -551,7 +578,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                         ClipRRect(
                           borderRadius: BorderRadius.circular(4),
                           child: LinearProgressIndicator(
-                            backgroundColor: Colors.white.withOpacity(0.2),
+                            backgroundColor: Colors.white.withValues(
+                              alpha: 0.2,
+                            ),
                             valueColor: AlwaysStoppedAnimation<Color>(
                               AppTheme.primaryColor,
                             ),
@@ -584,11 +613,13 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     ),
                     decoration: BoxDecoration(
                       color: model.isFieldEnergyMode
-                          ? Colors.purple.withOpacity(0.2)
-                          : Colors.white.withOpacity(0.1),
+                          ? Colors.purple.withValues(alpha: 0.2)
+                          : Colors.white.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(10),
                       border: model.isFieldEnergyMode
-                          ? Border.all(color: Colors.purple.withOpacity(0.5))
+                          ? Border.all(
+                              color: Colors.purple.withValues(alpha: 0.5),
+                            )
                           : null,
                     ),
                     child: Row(
@@ -628,7 +659,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                                           : '自动开启热点向周围广播',
                                       style: TextStyle(
                                         color: model.isFieldEnergyMode
-                                            ? Colors.purple.withOpacity(0.7)
+                                            ? Colors.purple.withValues(
+                                                alpha: 0.7,
+                                              )
                                             : Colors.white54,
                                         fontSize: 10,
                                       ),
@@ -653,7 +686,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                                 model.clearHotspotGuide();
                               }
                             },
-                            activeColor: Colors.purple,
+                            activeThumbColor: Colors.purple,
                           ),
                         ),
                       ],
@@ -735,7 +768,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     final icon = _contentIcon(model.selectedContentKind);
 
     return Material(
-      color: Colors.white.withOpacity(0.1),
+      color: Colors.white.withValues(alpha: 0.1),
       borderRadius: BorderRadius.circular(10),
       child: InkWell(
         borderRadius: BorderRadius.circular(10),
@@ -761,7 +794,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                             child: Text(
                               model.selectedContentKind,
                               style: TextStyle(
-                                color: AppTheme.primaryColor.withOpacity(0.9),
+                                color: AppTheme.primaryColor.withValues(
+                                  alpha: 0.9,
+                                ),
                                 fontSize: 11,
                                 fontWeight: FontWeight.w700,
                               ),
@@ -908,9 +943,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: Colors.purple.withOpacity(0.2),
+                color: Colors.purple.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.purple.withOpacity(0.3)),
+                border: Border.all(color: Colors.purple.withValues(alpha: 0.3)),
               ),
               child: Row(
                 children: [
@@ -1011,10 +1046,11 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   subtitle: '发送手机本机文件',
                   onTap: () async {
                     final navigator = Navigator.of(sheetContext);
-                    final before = model.selectedFiles.length;
-                    await model.selectFiles();
+                    final selected = await model.selectFiles(
+                      replaceExisting: true,
+                    );
                     if (navigator.mounted) {
-                      navigator.pop(model.selectedFiles.length > before);
+                      navigator.pop(selected);
                     }
                   },
                 ),
@@ -1234,7 +1270,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   void _startSending(FileTransferModel model) async {
     if (model.isPreparingSend || model.isTransferring) return;
 
-    final prepared = await _showSendContentSheet(model);
+    final prepared = model.hasFiles || await _showSendContentSheet(model);
     if (!prepared || !mounted || !model.hasFiles) {
       return;
     }

--- a/fabushi/lib/services/local_loopback_service.dart
+++ b/fabushi/lib/services/local_loopback_service.dart
@@ -43,7 +43,6 @@ class LocalLoopbackService {
   /// 批量发送次数 - 每轮发送多个完整文件循环
   static const int _batchCount = 10;
   static const int _largePayloadThreshold = 1024 * 1024;
-  static const int _largePayloadSampleBytes = 64 * 1024;
 
   bool _isRunning = false;
   int _loopCount = 0;
@@ -63,8 +62,8 @@ class LocalLoopbackService {
   String? _cachedFilePath;
   String? _cachedFileName;
   Uint8List? _cachedHeaderPacket;
-  int _cachedPayloadSize = 0;
   int _effectiveBatchCount = _batchCount;
+  bool _streamFileFromPath = false;
 
   // 极致优化：预构建的数据包缓存
   List<Uint8List>? _prebuiltPackets;
@@ -106,11 +105,15 @@ class LocalLoopbackService {
     _cachedData = data;
     _cachedFilePath = filePath;
     _cachedFileName = fileName;
-    _cachedPayloadSize = fileSize;
+    _streamFileFromPath =
+        isLargePayload &&
+        data == null &&
+        filePath != null &&
+        filePath.isNotEmpty;
     _cachedHeaderPacket = _buildHeader(
       fileName,
       originalSize: fileSize,
-      payloadMode: isLargePayload ? 'sample' : 'full',
+      payloadMode: _streamFileFromPath ? 'stream' : 'full',
     );
     _speedLevel = isLargePayload && speedLevel == LoopbackSpeedLevel.extreme
         ? LoopbackSpeedLevel.normal
@@ -140,15 +143,7 @@ class LocalLoopbackService {
     if (_cachedData != null) {
       // 内存数据预构建
       final data = _cachedData!;
-      final payload = data.length > _largePayloadThreshold
-          ? Uint8List.sublistView(
-              data,
-              0,
-              data.length < _largePayloadSampleBytes
-                  ? data.length
-                  : _largePayloadSampleBytes,
-            )
-          : data;
+      final payload = data;
       int offset = 0;
 
       while (offset < payload.length) {
@@ -167,22 +162,20 @@ class LocalLoopbackService {
       }
 
       _log(
-        '📦 预构建 ${packets.length} 个数据包 (原始 ${_formatBytes(_cachedPayloadSize)}, 发送样本 ${_formatBytes(payload.length)})',
+        '📦 预构建 ${packets.length} 个数据包 (完整内容 ${_formatBytes(payload.length)})',
       );
     } else if (_cachedFilePath != null) {
-      // 文件数据：小文件完整预构建，大文件只读取轻量样本，避免卡住 UI。
+      // 文件数据：小文件完整预构建，大文件从磁盘流式读取完整文件，避免样本包。
       final file = File(_cachedFilePath!);
       if (await file.exists()) {
         final length = await file.length();
-        _cachedPayloadSize = length;
-        final sampleLength = length > _largePayloadThreshold
-            ? (length < _largePayloadSampleBytes
-                  ? length
-                  : _largePayloadSampleBytes)
-            : length;
-        final fileData = length > _largePayloadThreshold
-            ? await _readFileSample(file, sampleLength)
-            : await file.readAsBytes();
+        if (_streamFileFromPath) {
+          _log('📦 文件 ${_formatBytes(length)} 将以完整流式回环发送');
+          _prebuiltPackets = const [];
+          return;
+        }
+
+        final fileData = await file.readAsBytes();
         _cachedData = fileData;
 
         int offset = 0;
@@ -200,7 +193,7 @@ class LocalLoopbackService {
           offset = end;
         }
 
-        _log('📦 文件 ${_formatBytes(length)} -> ${packets.length} 个回环样本包');
+        _log('📦 文件 ${_formatBytes(length)} -> ${packets.length} 个完整回环包');
       }
     }
 
@@ -271,6 +264,7 @@ class LocalLoopbackService {
           sendPort: _receivePort!.sendPort,
           headerPacket: _cachedHeaderPacket!,
           prebuiltPackets: _prebuiltPackets,
+          streamFilePath: _streamFileFromPath ? _cachedFilePath : null,
           address: _loopbackAddress,
           port: _loopbackPort,
           initialLoopCount: _loopCount,
@@ -311,6 +305,11 @@ class LocalLoopbackService {
       _log('✨ [MainThread] 数据发送引擎初始化完成');
 
       final address = InternetAddress(_loopbackAddress);
+      if (_streamFileFromPath && _cachedFilePath != null) {
+        unawaited(_runMainThreadStreamLoop(address));
+        return;
+      }
+
       DateTime lastHeartbeat = DateTime.now();
       const heartbeatInterval = Duration(seconds: 2);
 
@@ -373,6 +372,7 @@ class LocalLoopbackService {
     final port = params.port;
     final prebuiltPackets = params.prebuiltPackets;
     final batchCount = params.batchCount;
+    final streamFilePath = params.streamFilePath;
 
     // Heartbeat tracking - 从传入的初始值开始
     int loopCount = params.initialLoopCount;
@@ -395,6 +395,37 @@ class LocalLoopbackService {
       // socket.setOption(SocketOption(O_SO_SNDBUF), 1024 * 1024); // 1MB发送缓冲区
 
       sendPort.send('✨ [Worker] 极速发送引擎初始化完成 (速度级别: ${params.speedLevel})');
+
+      if (streamFilePath != null && streamFilePath.isNotEmpty) {
+        sendPort.send('🔥 [Worker] 开始完整文件流式回环: $streamFilePath');
+        while (true) {
+          await _sendStreamFileOnce(
+            socket: socket,
+            address: address,
+            port: port,
+            headerPacket: params.headerPacket,
+            filePath: streamFilePath,
+            maxChunkSize: _maxChunkSize,
+          );
+          loopCount++;
+
+          final now = DateTime.now();
+          if (now.difference(lastHeartbeat) >= heartbeatInterval) {
+            sendPort.send({
+              'type': 'heartbeat',
+              'loopCount': loopCount < 1 ? 1 : loopCount,
+              'timestamp': now.toIso8601String(),
+            });
+            lastHeartbeat = now;
+          }
+
+          if (delayMicroseconds > 0) {
+            await Future.delayed(Duration(microseconds: delayMicroseconds));
+          } else {
+            await Future.delayed(Duration.zero);
+          }
+        }
+      }
 
       // 检查是否有预构建包
       if (prebuiltPackets == null || prebuiltPackets.isEmpty) {
@@ -464,8 +495,8 @@ class LocalLoopbackService {
     _cachedFilePath = null;
     _cachedFileName = null;
     _cachedHeaderPacket = null;
-    _cachedPayloadSize = 0;
     _effectiveBatchCount = _batchCount;
+    _streamFileFromPath = false;
     _prebuiltPackets = null;
 
     _log('🛑 本地回环已停止');
@@ -483,15 +514,6 @@ class LocalLoopbackService {
       return await file.exists() ? await file.length() : 0;
     } catch (_) {
       return 0;
-    }
-  }
-
-  Future<Uint8List> _readFileSample(File file, int sampleLength) async {
-    final randomAccessFile = await file.open();
-    try {
-      return await randomAccessFile.read(sampleLength);
-    } finally {
-      await randomAccessFile.close();
     }
   }
 
@@ -533,12 +555,72 @@ class LocalLoopbackService {
   }
 
   bool get isRunning => _isRunning;
+
+  Future<void> _runMainThreadStreamLoop(InternetAddress address) async {
+    final filePath = _cachedFilePath;
+    final header = _cachedHeaderPacket;
+    final socket = _mainThreadSocket;
+    if (filePath == null || header == null || socket == null) return;
+
+    DateTime lastHeartbeat = DateTime.now();
+    const heartbeatInterval = Duration(seconds: 2);
+    _log('🔥 [MainThread] 开始完整文件流式回环: $filePath');
+
+    while (_isRunning && _currentMode == LoopbackRunMode.mainThread) {
+      await _sendStreamFileOnce(
+        socket: socket,
+        address: address,
+        port: _loopbackPort,
+        headerPacket: header,
+        filePath: filePath,
+        maxChunkSize: _maxChunkSize,
+      );
+      _loopCount++;
+
+      final now = DateTime.now();
+      if (now.difference(lastHeartbeat) >= heartbeatInterval) {
+        onHeartbeat?.call(_loopCount < 1 ? 1 : _loopCount);
+        lastHeartbeat = now;
+      }
+
+      await Future.delayed(Duration.zero);
+    }
+  }
+
+  static Future<void> _sendStreamFileOnce({
+    required RawDatagramSocket socket,
+    required InternetAddress address,
+    required int port,
+    required Uint8List headerPacket,
+    required String filePath,
+    required int maxChunkSize,
+  }) async {
+    final file = File(filePath);
+    if (!await file.exists()) return;
+
+    await for (final chunk in file.openRead()) {
+      var offset = 0;
+      while (offset < chunk.length) {
+        final end = (offset + maxChunkSize < chunk.length)
+            ? offset + maxChunkSize
+            : chunk.length;
+        final packetSize = headerPacket.length + (end - offset);
+        final packet = Uint8List(packetSize);
+        packet.setRange(0, headerPacket.length, headerPacket);
+        packet.setRange(headerPacket.length, packetSize, chunk, offset);
+        socket.send(packet, address, port);
+        offset = end;
+      }
+      await Future.delayed(Duration.zero);
+    }
+  }
 }
 
 class _IsolateParams {
   final SendPort sendPort;
   final Uint8List headerPacket;
   final List<Uint8List>? prebuiltPackets;
+  final String? streamFilePath;
   final String address;
   final int port;
   final int initialLoopCount;
@@ -549,6 +631,7 @@ class _IsolateParams {
     required this.sendPort,
     required this.headerPacket,
     this.prebuiltPackets,
+    this.streamFilePath,
     required this.address,
     required this.port,
     this.initialLoopCount = 0,

--- a/fabushi/lib/services/platform_global_send_service.dart
+++ b/fabushi/lib/services/platform_global_send_service.dart
@@ -10,6 +10,7 @@ import 'udp_global_send_service.dart';
 class PlatformGlobalSendService {
   final ValueChanged<int> onProgress;
   final ValueChanged<double> onDataSent;
+  final ValueChanged<double>? onCountryProgress;
   final VoidCallback onStopped;
   final void Function(String) onLog;
   final Function(
@@ -37,6 +38,7 @@ class PlatformGlobalSendService {
   PlatformGlobalSendService({
     required this.onProgress,
     required this.onDataSent,
+    this.onCountryProgress,
     required this.onStopped,
     required this.onLog,
     this.onTransferBeam,
@@ -63,6 +65,7 @@ class PlatformGlobalSendService {
         _httpService = RealGlobalSendService(
           onProgress: onProgress,
           onDataSent: onDataSent,
+          onCountryProgress: onCountryProgress,
           onStopped: onStopped,
           onLog: onLog,
           onTransferBeam: onTransferBeam,
@@ -80,6 +83,7 @@ class PlatformGlobalSendService {
         _udpService = UDPGlobalSendService(
           onProgress: onProgress,
           onDataSent: onDataSent,
+          onCountryProgress: onCountryProgress,
           onStopped: onStopped,
           onLog: onLog,
           onTransferBeam: onTransferBeam,

--- a/fabushi/lib/services/real_global_send_service.dart
+++ b/fabushi/lib/services/real_global_send_service.dart
@@ -1,22 +1,19 @@
 import 'dart:convert';
 import 'dart:typed_data';
-import 'dart:isolate';
 import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:crypto/crypto.dart' as crypto;
-import 'global_server_config_loader.dart';
 import 'global_country_servers.dart';
 import 'country_coordinates_service.dart';
 import '../core/constants/country_servers.dart' as country_names;
-import 'dart:math' as math;
 
 /// 真实的全球发送服务
 /// 直接发送到249个国家的服务器地址，不使用代理
 class RealGlobalSendService {
   final ValueChanged<int> onProgress;
   final ValueChanged<double> onDataSent;
+  final ValueChanged<double>? onCountryProgress;
   final VoidCallback onStopped;
   final void Function(String) onLog;
   final Function(
@@ -35,14 +32,12 @@ class RealGlobalSendService {
   int _sentCount = 0;
   double _dataSentInMB = 0.0;
   int _totalCountries = 0;
-  int _currentCountryIndex = 0;
   int _loopCount = 0; // 当前轮次
 
   // 全球249个国家的服务器配置（将动态加载）
   Map<String, List<String>> globalCountryServers = {};
 
   final CountryCoordinatesService _coordService = CountryCoordinatesService();
-  final math.Random _random = math.Random();
 
   // 用户位置（固定起点）
   double? _userLatitude;
@@ -51,6 +46,7 @@ class RealGlobalSendService {
   RealGlobalSendService({
     required this.onProgress,
     required this.onDataSent,
+    this.onCountryProgress,
     required this.onStopped,
     required this.onLog,
     this.onTransferBeam,
@@ -67,7 +63,7 @@ class RealGlobalSendService {
   Future<bool> initialize() async {
     // 直接使用内置的全球服务器配置
     try {
-      print('🌍 开始加载全球服务器配置...');
+      debugPrint('🌍 开始加载全球服务器配置...');
       globalCountryServers = GLOBAL_COUNTRY_SERVERS;
       _totalCountries = globalCountryServers.length;
       onLog('✅ 成功加载全球服务器配置，共$_totalCountries个国家');
@@ -82,11 +78,6 @@ class RealGlobalSendService {
     }
   }
 
-  // 内置备用配置
-  Map<String, List<String>> _getBuiltInConfig() {
-    return globalCountryServers;
-  }
-
   // 每次成功发送的回调
   final Function(int)? onCountrySent;
 
@@ -99,7 +90,6 @@ class RealGlobalSendService {
     _isRunning = true;
     _sentCount = 0; // 这里改为国家计数
     _dataSentInMB = 0.0;
-    _currentCountryIndex = 0;
 
     try {
       onLog('🚀 开始真实全球发送 - 文件数量: ${files.length}, 目标国家: $_totalCountries 个');
@@ -257,8 +247,6 @@ class RealGlobalSendService {
         failCount++;
         onLog('❌ 发送到 $countryName ($countryCode) 失败：《$scriptureTitle》');
       }
-
-      _currentCountryIndex++;
 
       // 关键修复：让出主线程控制权，避免阻塞UI
       await Future.delayed(Duration.zero);
@@ -499,51 +487,6 @@ class RealGlobalSendService {
       if (response.statusCode != 201) {
         throw Exception('HTTP ${response.statusCode}');
       }
-    }
-  }
-
-  /// 计算文件哈希（流式读取，不占用大量内存）
-  Future<String> _calculateFileHash(PlatformFile file) async {
-    try {
-      if (file.path != null) {
-        // 有文件路径：流式读取计算哈希
-        final fileObj = File(file.path!);
-        final stream = fileObj.openRead();
-
-        // 使用简单的分块哈希计算，避免依赖 AccumulatorSink
-        var hash = crypto.sha256.convert([]);
-        final chunks = <int>[];
-
-        await for (var chunk in stream) {
-          chunks.addAll(chunk);
-          // 每累积 1MB 计算一次中间哈希，防止内存过大
-          if (chunks.length > 1024 * 1024) {
-            hash = crypto.sha256.convert(chunks);
-            chunks.clear();
-            chunks.addAll(hash.bytes);
-          }
-        }
-
-        // 计算最终哈希
-        return crypto.sha256.convert(chunks).toString();
-      } else if (file.bytes != null && file.bytes!.length < 10 * 1024 * 1024) {
-        // 有内存数据且不太大
-        return crypto.sha256.convert(file.bytes!).toString();
-      } else {
-        // 无法计算，返回基于文件名和大小的伪哈希
-        return crypto.sha256
-            .convert(
-              utf8.encode(
-                '${file.name}-${file.size}-${DateTime.now().millisecondsSinceEpoch}',
-              ),
-            )
-            .toString();
-      }
-    } catch (e) {
-      // 哈希计算失败，返回伪哈希
-      return crypto.sha256
-          .convert(utf8.encode('${file.name}-${file.size}'))
-          .toString();
     }
   }
 

--- a/fabushi/lib/services/udp_global_send_service.dart
+++ b/fabushi/lib/services/udp_global_send_service.dart
@@ -23,6 +23,7 @@ class _UdpSendResult {
 class UDPGlobalSendService {
   final ValueChanged<int> onProgress;
   final ValueChanged<double> onDataSent;
+  final ValueChanged<double>? onCountryProgress;
   final VoidCallback onStopped;
   final void Function(String) onLog;
   final Function(
@@ -60,6 +61,7 @@ class UDPGlobalSendService {
   UDPGlobalSendService({
     required this.onProgress,
     required this.onDataSent,
+    this.onCountryProgress,
     required this.onStopped,
     required this.onLog,
     this.onTransferBeam,
@@ -198,7 +200,7 @@ class UDPGlobalSendService {
             '📊 UDP 文件 ${file.name}: ${fileSizeMB.toStringAsFixed(2)} MB × $countriesSent 国 成功',
           );
 
-          await Future.delayed(const Duration(milliseconds: 100));
+          await Future.delayed(const Duration(milliseconds: 800));
         }
       } while (isLoop && _isRunning);
     } catch (e) {
@@ -234,6 +236,7 @@ class UDPGlobalSendService {
 
       // 触发地球轨迹动画
       _triggerBeamAnimation(countryCode, countryName);
+      onCountryProgress?.call(0);
 
       // 获取该国家的 IP 地址
       final ips = _geoIPService.getIPsForCountry(countryCode);
@@ -304,10 +307,12 @@ class UDPGlobalSendService {
       if (countrySuccess) {
         successCount++;
         _sentCount++; // 实时更新国家计数
+        onCountryProgress?.call(1);
         onProgress(_sentCount); // 实时通知进度更新
         onLog(
           '✅ UDP 发送到 $countryName ($countryCode) 成功：《$scriptureTitle》 -> ${lastSuccessIp ?? "未知 IP"}，发送 $sendCount 次，重试 $retryCount 次',
         );
+        await Future.delayed(const Duration(milliseconds: 600));
 
         if (onCountrySent != null) {
           onCountrySent!(fileSize * sendCount);
@@ -336,6 +341,7 @@ class UDPGlobalSendService {
   ) async {
     int successCount = 0;
 
+    final scriptureTitle = _displayScriptureName(file.name);
     final fileSizeMB = (file.size / 1024 / 1024).toStringAsFixed(1);
     onLog(
       '📤 大文件流式发送: ${file.name}, ${fileSizeMB}MB 到 ${countryCodes.length} 个国家',
@@ -370,6 +376,11 @@ class UDPGlobalSendService {
         continue;
       }
 
+      onCountryProgress?.call(0);
+      onLog(
+        '📤 正在发送到 $countryName ($countryCode)：《$scriptureTitle》 - 大文件 ${fileSizeMB}MB',
+      );
+
       // 流式发送文件到该国家
       final success = await _streamSendFileToCountry(
         socket,
@@ -384,7 +395,12 @@ class UDPGlobalSendService {
       if (success) {
         successCount++;
         _sentCount++;
+        onCountryProgress?.call(1);
         onProgress(_sentCount);
+        onLog(
+          '✅ UDP 发送到 $countryName ($countryCode) 成功：《$scriptureTitle》 - 已完整发送 ${file.name}',
+        );
+        await Future.delayed(const Duration(milliseconds: 600));
 
         if (onCountrySent != null) {
           onCountrySent!(file.size);
@@ -436,6 +452,8 @@ class UDPGlobalSendService {
       int chunkIndex = 0;
       int totalBytesSent = headerBytes.length;
       int packetIndex = 0;
+      var payloadBytesSent = 0;
+      var nextProgressReport = 0.02;
 
       await for (var chunk in stream) {
         if (!_isRunning) break;
@@ -452,6 +470,7 @@ class UDPGlobalSendService {
 
           final sent = socket.send(packet, address, _udpPort);
           totalBytesSent += sent;
+          payloadBytesSent += end - offset;
           offset = end;
           packetIndex++;
 
@@ -470,6 +489,14 @@ class UDPGlobalSendService {
         // 每发送 100 个块后稍作延迟，控制发送速率
         if (chunkIndex % 100 == 0) {
           await Future.delayed(const Duration(milliseconds: 10));
+        }
+
+        if (fileSize > 0) {
+          final progress = (payloadBytesSent / fileSize).clamp(0.0, 1.0);
+          if (progress >= nextProgressReport || progress >= 1.0) {
+            onCountryProgress?.call(progress);
+            nextProgressReport += 0.02;
+          }
         }
       }
 

--- a/fabushi/lib/services/wifi_field_broadcast_service.dart
+++ b/fabushi/lib/services/wifi_field_broadcast_service.dart
@@ -22,6 +22,7 @@ class WiFiFieldBroadcastService {
   static const int _broadcastPort = 8888;
   static const int _multicastPort = 8889;
   static const String _multicastGroup = '239.255.255.250'; // 标准多播地址
+  static const int _broadcastChunkSize = 1024;
 
   // 常用热点网段
   static const List<String> _hotspotBroadcasts = [
@@ -34,6 +35,13 @@ class WiFiFieldBroadcastService {
   RawDatagramSocket? _socket;
   bool _isRunning = false;
   Timer? _broadcastTimer;
+  RandomAccessFile? _sourceFileHandle;
+  Uint8List? _sourceData;
+  String _fileName = '';
+  int _originalSize = 0;
+  int _offset = 0;
+  int _chunkIndex = 0;
+  bool _isReadingChunk = false;
 
   final void Function(String)? onLog;
   final void Function(int)? onBroadcastCount;
@@ -68,7 +76,8 @@ class WiFiFieldBroadcastService {
   /// [data] 要广播的数据（经文内容）
   /// [fileName] 文件名
   Future<void> startBroadcast({
-    required Uint8List data,
+    Uint8List? data,
+    String? filePath,
     required String fileName,
     int? originalSize,
   }) async {
@@ -79,11 +88,32 @@ class WiFiFieldBroadcastService {
 
     _isRunning = true;
     _broadcastCount = 0;
+    _fileName = fileName;
+    _offset = 0;
+    _chunkIndex = 0;
+    _sourceData = data;
 
     _log('🌟 开始场能广播: $fileName');
 
-    // 构建广播数据包
-    final packet = _buildBroadcastPacket(data, fileName, originalSize);
+    if (_sourceData == null && filePath != null) {
+      final file = File(filePath);
+      if (await file.exists()) {
+        _sourceFileHandle = await file.open();
+        _originalSize = await file.length();
+      }
+    } else {
+      _originalSize = originalSize ?? data?.length ?? 0;
+    }
+
+    if (_sourceData == null && _sourceFileHandle == null) {
+      _log('⚠️ 场能广播没有可用素材数据');
+      _isRunning = false;
+      return;
+    }
+
+    if (_originalSize <= 0) {
+      _originalSize = originalSize ?? _sourceData?.length ?? 0;
+    }
 
     // 获取所有可用的网络接口地址
     final broadcastAddresses = await _getBroadcastAddresses();
@@ -92,12 +122,71 @@ class WiFiFieldBroadcastService {
 
     // 定时广播
     _broadcastTimer = Timer.periodic(
-      const Duration(milliseconds: 500),
-      (_) => _sendBroadcast(packet, broadcastAddresses),
+      const Duration(milliseconds: 150),
+      (_) => _broadcastNextChunk(broadcastAddresses),
     );
 
     // 立即发送一次
-    _sendBroadcast(packet, broadcastAddresses);
+    await _broadcastNextChunk(broadcastAddresses);
+  }
+
+  Future<void> _broadcastNextChunk(List<InternetAddress> addresses) async {
+    if (!_isRunning || _socket == null || _isReadingChunk) return;
+
+    _isReadingChunk = true;
+    try {
+      final chunk = await _readNextChunk();
+      if (chunk == null || chunk.isEmpty) return;
+      final packet = _buildBroadcastPacket(
+        chunk,
+        _fileName,
+        _originalSize,
+        chunkIndex: _chunkIndex,
+        offset: _offset - chunk.length,
+      );
+      _sendBroadcast(packet, addresses);
+      _chunkIndex++;
+    } finally {
+      _isReadingChunk = false;
+    }
+  }
+
+  Future<Uint8List?> _readNextChunk() async {
+    if (_sourceData != null) {
+      final data = _sourceData!;
+      if (data.isEmpty) return null;
+      if (_offset >= data.length) {
+        _offset = 0;
+        _chunkIndex = 0;
+      }
+      final end = (_offset + _broadcastChunkSize < data.length)
+          ? _offset + _broadcastChunkSize
+          : data.length;
+      final chunk = Uint8List.sublistView(data, _offset, end);
+      _offset = end;
+      return chunk;
+    }
+
+    final handle = _sourceFileHandle;
+    if (handle == null) return null;
+    if (_originalSize > 0 && _offset >= _originalSize) {
+      await handle.setPosition(0);
+      _offset = 0;
+      _chunkIndex = 0;
+    }
+
+    final chunk = await handle.read(_broadcastChunkSize);
+    if (chunk.isEmpty) {
+      await handle.setPosition(0);
+      _offset = 0;
+      _chunkIndex = 0;
+      final restarted = await handle.read(_broadcastChunkSize);
+      _offset = restarted.length;
+      return restarted;
+    }
+
+    _offset += chunk.length;
+    return chunk;
   }
 
   /// 发送单次广播
@@ -142,6 +231,11 @@ class WiFiFieldBroadcastService {
     _isRunning = false;
     _broadcastTimer?.cancel();
     _broadcastTimer = null;
+    _sourceFileHandle?.close();
+    _sourceFileHandle = null;
+    _sourceData = null;
+    _offset = 0;
+    _chunkIndex = 0;
     _log('🛑 场能广播已停止，共广播 $_broadcastCount 次');
   }
 
@@ -156,14 +250,21 @@ class WiFiFieldBroadcastService {
   Uint8List _buildBroadcastPacket(
     Uint8List data,
     String fileName,
-    int? originalSize,
-  ) {
+    int? originalSize, {
+    required int chunkIndex,
+    required int offset,
+  }) {
     final header = {
       'type': 'dharma_field_energy',
       'fileName': fileName,
       'timestamp': DateTime.now().toIso8601String(),
       'size': originalSize ?? data.length,
-      'sampleSize': data.length,
+      'chunkIndex': chunkIndex,
+      'chunkOffset': offset,
+      'chunkSize': data.length,
+      'totalChunks': originalSize == null || originalSize <= 0
+          ? 1
+          : (originalSize / _broadcastChunkSize).ceil(),
       'checksum': _calculateChecksum(data),
     };
 
@@ -179,12 +280,8 @@ class WiFiFieldBroadcastService {
     // 头部
     packet.add(headerBytes);
 
-    // 数据（如果太大则截取前1400字节）
-    if (data.length > 1400) {
-      packet.add(data.sublist(0, 1400));
-    } else {
-      packet.add(data);
-    }
+    // 数据块固定小于 UDP 广播安全大小，来自选中素材本体而不是样本包。
+    packet.add(data);
 
     return packet.toBytes();
   }

--- a/scripts/check_home_send_flow.py
+++ b/scripts/check_home_send_flow.py
@@ -54,8 +54,8 @@ if '() => _showSendContentSheet(model)' not in home_text:
     print('FAIL: homepage content tile should open the send-content picker')
     sys.exit(1)
 
-if 'final prepared = await _showSendContentSheet(model);' not in body:
-    print('FAIL: start button should open the content picker before sending')
+if 'final prepared = model.hasFiles || await _showSendContentSheet(model);' not in body:
+    print('FAIL: start button should only open the content picker when nothing is selected')
     sys.exit(1)
 
 pre_send_body = body.split('await model.startGlobalTransfer()', 1)[0]


### PR DESCRIPTION
## Summary
- send immediately when the home screen already has selected content instead of reopening the content picker
- read WeChat article links with mobile WeChat-compatible headers and strip article chrome from parsed content
- stream selected material through UDP, local loopback, and field-energy broadcast instead of using truncated samples; expose country progress and completion state in the sending UI

## Validation
- python scripts/check_home_send_flow.py
- flutter test --reporter expanded test\unit\models\file_transfer_model_send_content_test.dart
- flutter analyze --no-pub lib\models\file_transfer_model.dart lib\screens\globe_home_screen.dart lib\services\local_loopback_service.dart lib\services\platform_global_send_service.dart lib\services\real_global_send_service.dart lib\services\udp_global_send_service.dart lib\services\wifi_field_broadcast_service.dart
- flutter build apk --debug --no-pub --build-number=399
- ADB installed debug 399 on AXYP6R4530001510 and verified WeChat link read, direct start without picker, country progress/spinner, completion delay, local loopback spinner text, and field-energy broadcast using selected content