### PR TITLE
Fix Faloo CBETA API loading

### DIFF
--- a/frontend/apps/web/src/lib/cbeta-config.ts
+++ b/frontend/apps/web/src/lib/cbeta-config.ts
@@ -1,1 +1,1 @@
-export const CBETA_API_ROOT = "https://cbdata.dila.edu.tw/stable";
+export const CBETA_API_ROOT = "https://api.ombhrum.com/api/cbeta";

--- a/frontend/apps/web/src/lib/cbeta-config.ts
+++ b/frontend/apps/web/src/lib/cbeta-config.ts
@@ -1,1 +1,1 @@
-export const CBETA_API_ROOT = "http://144.24.17.21.sslip.io:3000";
+export const CBETA_API_ROOT = "https://cbdata.dila.edu.tw/stable";


### PR DESCRIPTION
## Summary
- Point the official site Faloo client at the existing HTTPS `api.ombhrum.com/api/cbeta` API instead of the old plain-HTTP CBETA host.
- Keeps scripture loading as a live API request path with CORS support, avoiding browser mixed-content/CORS failures on the HTTPS site.

## VPS verification
- Verified from bhrum2 that `https://api.ombhrum.com/api/cbeta/works?work=T0251` returns 200 with `Access-Control-Allow-Origin: *`.
- Verified from bhrum2 that `https://api.ombhrum.com/api/cbeta/juans?work=T0251&juan=1&work_info=1&toc=1` returns 200 and includes the Heart Sutra HTML body.

## Follow-up noted
- The Worker upstream still uses the old self-hosted CBETA API for some proxy paths; the client-side scripture detail loading is fixed by routing through the HTTPS API proxy, but Worker upstream should be switched to CBETA stable in a separate backend deploy if full index/search parity is required.