### PR TITLE
Add iOS App Store release to official site

### DIFF
--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -36,7 +36,25 @@
       "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-377-mobile.3dd4e4dc806f"
     }
   ],
-  "stableChannels": [],
+  "stableChannels": [
+    {
+      "platform": "iOS",
+      "audience": "stable",
+      "status": "App Store 已上架",
+      "title": "iOS 正式版",
+      "description": "已在 App Store 上架，适合 iPhone 和 iPad 用户直接安装。",
+      "primaryLabel": "在 App Store 下载",
+      "primaryHref": "https://apps.apple.com/cn/app/%E5%A4%A7%E4%B9%98/id6758606957",
+      "version": "1.0",
+      "publishedAt": "2026-06-01",
+      "updateSummary": [
+        "iOS 1.0 正式版已在 App Store 发布。",
+        "中国大陆可售状态已完成备案信息同步。"
+      ],
+      "mirrorLinks": [],
+      "note": "点击后会打开 Apple App Store 页面。"
+    }
+  ],
   "screenshots": {},
   "releases": [
     {
@@ -90,6 +108,7 @@
   ],
   "notes": [
     "Android beta APK 已同步到 R2，官网按钮会直接下载 R2 中的最新安装包。",
+    "iOS 正式版已上架 App Store，官网正式版入口会直接打开 App Store。",
     "iOS TestFlight 入口会在上传状态成功后同步到官网。",
     "官网展示的 iOS TestFlight 入口来自本次发布携带的上传状态与公开加入链接；如需确认 App Store Connect 后台最终处理态，仍需额外核验。",
     "如果本次 GitHub Release 只带了一个平台，官网会继续保留另一个平台上一版可用信息。"

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -38,10 +38,10 @@ const downloadFaqs = [
     answerEn: "Use the main download button on the current card again, then confirm that you downloaded the matching platform and version. If it still fails, send the device model, OS version, and an error screenshot to support.",
   },
   {
-    questionZh: "iOS 为什么会打开 TestFlight？",
-    questionEn: "Why does iOS open TestFlight?",
-    answerZh: "iOS 测试版通过 Apple TestFlight 分发。入口开放后，下载按钮会直接跳转到对应测试页，这是正常流程。",
-    answerEn: "iOS beta is distributed through Apple TestFlight. Once access is open, the download button will jump there directly, which is the expected flow.",
+    questionZh: "iOS 会打开 TestFlight 还是 App Store？",
+    questionEn: "Will iOS open TestFlight or the App Store?",
+    answerZh: "iOS 测试版通过 Apple TestFlight 分发；iOS 正式版通过 App Store 安装。下载页会把两个入口分开显示，按你想要的版本选择即可。",
+    answerEn: "iOS beta builds are distributed through Apple TestFlight; the stable iOS release installs through the App Store. The download page separates both paths so you can choose the version you want.",
   },
 ] as const;
 
@@ -55,8 +55,8 @@ const installSteps = [
   {
     titleZh: "进入对应下载入口并完成安装",
     titleEn: "Open the matching download path and install",
-    descriptionZh: "Android 使用主下载入口直接获取 R2 中的最新安装包；iOS 测试版会通过 TestFlight 打开。",
-    descriptionEn: "Use the main Android button to get the latest APK from R2. iOS beta opens through TestFlight.",
+    descriptionZh: "Android 使用主下载入口直接获取 R2 中的最新安装包；iOS 测试版会打开 TestFlight，正式版会打开 App Store。",
+    descriptionEn: "Use the main Android button to get the latest APK from R2. iOS beta opens TestFlight, while the stable release opens the App Store.",
   },
   {
     titleZh: "安装失败时先看 FAQ，再联系支持",
@@ -76,8 +76,8 @@ const DOWNLOAD_NOTES = [
     en: "Android downloads are served from R2, and each update replaces the APK at the same link.",
   },
   {
-    zh: "iOS 测试版通过 TestFlight 分发，入口开放后会直接跳转。",
-    en: "iOS beta is distributed through TestFlight, and the button will jump there once access opens.",
+    zh: "iOS 测试版通过 TestFlight 分发，正式版通过 App Store 安装。",
+    en: "iOS beta is distributed through TestFlight, while the stable release installs through the App Store.",
   },
 ] as const;
 

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -8,7 +8,7 @@ import { siteHref, siteUrl } from "../../lib/site-url";
 const faqUrl = siteUrl("/faq");
 const faqTitle = `App 下载常见问题 | Android、iOS、安装与版本说明 | ${brand.name}`;
 const faqDescription =
-  "集中说明法布施大乘 App 的下载问题：正式版和测试版怎么选、Android 下载慢怎么办、iOS 为什么跳到 TestFlight、安装失败怎么排查，以及联系支持前需要准备什么。";
+  "集中说明法布施大乘 App 的下载问题：正式版和测试版怎么选、Android 下载慢怎么办、iOS 如何选择 TestFlight 或 App Store、安装失败怎么排查，以及联系支持前需要准备什么。";
 
 const faqItems = [
   {
@@ -24,16 +24,16 @@ const faqItems = [
     answerEn: "Use the main download button on the current release card again, then confirm that you downloaded the matching platform and version. If it still fails, send the device model, OS version, and an error screenshot to support.",
   },
   {
-    questionZh: "iOS 为什么会跳到 TestFlight？",
-    questionEn: "Why does the iOS download button open TestFlight?",
-    answerZh: "iOS 测试版通过 Apple TestFlight 分发。入口开放后，下载按钮会直接跳到对应测试页，这是正常流程。",
-    answerEn: "The iOS beta build is distributed through Apple TestFlight. Once access is open, the download button jumps there directly, which is the expected flow.",
+    questionZh: "iOS 应该选 TestFlight 还是 App Store？",
+    questionEn: "Should I choose TestFlight or the App Store on iOS?",
+    answerZh: "想体验测试版就选择 TestFlight；想直接安装正式版就选择 App Store。现在 iOS 正式版已经上架，普通用户优先选择 App Store 会更稳。",
+    answerEn: "Choose TestFlight if you want the beta build. Choose the App Store if you want the stable release. The iOS stable release is now live, so most users should start with the App Store.",
   },
   {
     questionZh: "下载前我最少要确认哪些信息？",
     questionEn: "What should I confirm before downloading?",
-    answerZh: "至少先确认设备平台、版本偏好、发布时间，以及是否需要 TestFlight。这样能明显减少下错包或装不上去的概率。",
-    answerEn: "At minimum, confirm the device platform, version preference, publish date, and whether you need TestFlight. That reduces the chance of downloading the wrong build or hitting an avoidable install failure.",
+    answerZh: "至少先确认设备平台、版本偏好、发布时间，以及 iOS 是否要走 App Store 或 TestFlight。这样能明显减少下错包或装不上去的概率。",
+    answerEn: "At minimum, confirm the device platform, version preference, publish date, and whether iOS should use the App Store or TestFlight. That reduces the chance of downloading the wrong build or hitting an avoidable install failure.",
   },
   {
     questionZh: "联系支持前最好准备什么？",

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -1,4 +1,5 @@
 const iosTestFlightPublicUrl = process.env.NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL?.trim() || "";
+const iosAppStoreUrl = "https://apps.apple.com/cn/app/%E5%A4%A7%E4%B9%98/id6758606957";
 const configuredReleaseApiBaseUrl =
   process.env.NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_API_BASE_URL?.trim() ||
   process.env.NEXT_PUBLIC_FABUSHI_API_BASE_URL?.trim() ||
@@ -72,6 +73,24 @@ const CHANNEL_ORDER: Array<Pick<OfficialSiteChannel, "audience" | "platform">> =
   { audience: "stable", platform: "iOS" },
 ];
 
+const IOS_STABLE_CHANNEL: OfficialSiteChannel = {
+  platform: "iOS",
+  audience: "stable",
+  status: "App Store 已上架",
+  title: "iOS 正式版",
+  description: "已在 App Store 上架，适合 iPhone 和 iPad 用户直接安装。",
+  primaryLabel: "在 App Store 下载",
+  primaryHref: iosAppStoreUrl,
+  version: "1.0",
+  publishedAt: "2026-06-01",
+  updateSummary: [
+    "iOS 1.0 正式版已在 App Store 发布。",
+    "中国大陆可售状态已完成备案信息同步。",
+  ],
+  mirrorLinks: [],
+  note: "点击后会打开 Apple App Store 页面。",
+};
+
 const DEFAULT_STABLE_CHANNELS: OfficialSiteChannel[] = [
   {
     platform: "Android",
@@ -88,6 +107,7 @@ const DEFAULT_STABLE_CHANNELS: OfficialSiteChannel[] = [
     mirrorLinks: [],
     note: "正式版上线后，这里会显示已经同步到 Cloudflare 的下载地址。",
   },
+  IOS_STABLE_CHANNEL,
 ];
 
 function trimTrailingSlash(value: string) {
@@ -274,6 +294,23 @@ function applyConfiguredIosTestFlightChannels(channels: OfficialSiteChannel[]): 
   return channels.map((channel) => applyConfiguredIosTestFlightChannel(channel));
 }
 
+function applyIosStableAppStoreChannel(channel: OfficialSiteChannel): OfficialSiteChannel {
+  if (channel.platform !== "iOS" || channel.audience !== "stable") {
+    return channel;
+  }
+
+  return {
+    ...channel,
+    ...IOS_STABLE_CHANNEL,
+    mirrorLinks: channel.mirrorLinks.length > 0 ? channel.mirrorLinks : IOS_STABLE_CHANNEL.mirrorLinks,
+    releasePageHref: channel.releasePageHref,
+  };
+}
+
+function applyIosStableAppStoreChannels(channels: OfficialSiteChannel[]): OfficialSiteChannel[] {
+  return channels.map((channel) => applyIosStableAppStoreChannel(channel));
+}
+
 async function fetchOfficialSiteReleaseCollectionFromCloudflare(isClient: boolean): Promise<OfficialSiteReleaseCollection | null> {
   const url = buildReleaseApiUrl();
 
@@ -323,7 +360,7 @@ function buildFallbackCollection(): OfficialSiteReleaseCollection {
 function finalizeCollection(collection: OfficialSiteReleaseCollection): OfficialSiteReleaseCollection {
   return {
     betaChannels: applyConfiguredIosTestFlightChannels(collection.betaChannels),
-    stableChannels: mergeChannels(collection.stableChannels, DEFAULT_STABLE_CHANNELS),
+    stableChannels: applyIosStableAppStoreChannels(mergeChannels(collection.stableChannels, DEFAULT_STABLE_CHANNELS)),
     screenshots: collection.screenshots,
     releases: collection.releases,
     notes: collection.notes,


### PR DESCRIPTION
## Summary
- Add the iOS App Store stable channel for 大乘 / Fabushi on the official site.
- Force stale iOS stable runtime metadata to resolve to the App Store URL.
- Update download and FAQ copy to distinguish TestFlight beta from App Store stable.

## Verification
- `corepack pnpm --filter @fabushi/web build`
- `curl` local static export for `/download/` and `/api/releases.json` to confirm the App Store URL appears.