### PR TITLE
ci: align homepage send regression check

### DIFF
--- a/scripts/check_home_send_flow.py
+++ b/scripts/check_home_send_flow.py
@@ -46,21 +46,21 @@ for method_name in (
         print(f'FAIL: {method_name} must not download default CBETA content')
         sys.exit(1)
 
-if '_buildSelectedContentTile(model)' not in home_text:
-    print('FAIL: homepage should expose a send-content selection tile')
+if '_buildChatComposer(context, model)' not in home_text:
+    print('FAIL: homepage should expose the chat-style send composer')
     sys.exit(1)
 
-if '() => _showSendContentSheet(model)' not in home_text:
-    print('FAIL: homepage content tile should open the send-content picker')
+if '() => _openSendContentMenu(buttonContext, model)' not in home_text:
+    print('FAIL: homepage + button should open the send-content menu')
     sys.exit(1)
 
-if 'final prepared = model.hasFiles || await _showSendContentSheet(model);' not in body:
-    print('FAIL: start button should only open the content picker when nothing is selected')
+if "if (!model.hasFiles)" not in body:
+    print('FAIL: start button should require selected content before sending')
     sys.exit(1)
 
 pre_send_body = body.split('await model.startGlobalTransfer()', 1)[0]
-if '!prepared || !mounted || !model.hasFiles' not in pre_send_body:
-    print('FAIL: start button should require picker confirmation and selected content before sending')
+if '请先点击 + 选择链接、文本、文件或素材。' not in pre_send_body:
+    print('FAIL: start button should guide users to pick content from the + menu')
     sys.exit(1)
 
 if 'await model.startGlobalTransfer()' not in body:


### PR DESCRIPTION
## Summary
- update the homepage send regression guard to match the current chat-style composer
- keep the no-default-CBETA and selected-content-before-send checks in place

## Test
- python3 scripts/check_home_send_flow.py
- git diff --check