### PR TITLE
[codex] Refine home composer dharma flow

### DIFF
--- a/fabushi/lib/models/file_transfer_model.dart
+++ b/fabushi/lib/models/file_transfer_model.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'dart:async';
 
 import '../core/config/app_config.dart';
+import '../core/constants/country_servers.dart' as country_catalog;
 import '../screens/asset_screen.dart';
 import '../services/asset_loader_service.dart';
 import '../services/shared_asset_manager.dart';
@@ -60,6 +61,7 @@ class LinkSendHistoryEntry {
 
 class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   static const String _linkHistoryPrefsKey = 'send_link_history_v1';
+  static const String _sendCountryListPrefsKey = 'send_country_list_v1';
   static const int _maxLinkHistoryEntries = 20;
   static const int _linkHistoryPreviewLimit = 600;
   static const int _largePayloadThresholdBytes = 1024 * 1024;
@@ -248,11 +250,13 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   void setGlobalSendEnabled(bool enabled) {
     _isGlobalSendEnabled = enabled;
+    _schedulePersist(_persistSendPreferences);
     notifyListeners();
   }
 
   void setLooping(bool looping) {
     _isLooping = looping;
+    _schedulePersist(_persistSendPreferences);
     notifyListeners();
   }
 
@@ -263,6 +267,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _loopbackCount = 0;
       _stopLocalLoopback();
     }
+    _schedulePersist(_persistSendPreferences);
     notifyListeners();
   }
 
@@ -270,6 +275,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     _isFieldEnergyMode = enabled;
     _hotspotMessage = '';
     _needsHotspotGuide = false;
+    _schedulePersist(_persistSendPreferences);
     notifyListeners();
     debugPrint('🌟 无网场能模式: ${enabled ? "开启" : "关闭"}');
 
@@ -293,8 +299,35 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   void setCountryList(List<String> countries) {
-    _countryList = countries;
+    _countryList = countries.isEmpty ? <String>[] : countries.toSet().toList();
+    _schedulePersist(_persistSendPreferences);
     notifyListeners();
+  }
+
+  List<String>? get _selectedGlobalCountryCodes {
+    if (!_isGlobalSendEnabled || _countryList.isEmpty) {
+      return const [];
+    }
+    if (_countryList.contains('ALL')) {
+      return null;
+    }
+    return _countryList
+        .where(
+          (code) => country_catalog.GLOBAL_COUNTRY_SERVERS.containsKey(code),
+        )
+        .toSet()
+        .toList();
+  }
+
+  void _prepareCountryStatusesForTargets(List<String>? countryCodes) {
+    final servers = countryCodes == null
+        ? country_catalog.GLOBAL_COUNTRY_SERVERS
+        : {
+            for (final code in countryCodes)
+              if (country_catalog.GLOBAL_COUNTRY_SERVERS.containsKey(code))
+                code: country_catalog.GLOBAL_COUNTRY_SERVERS[code]!,
+          };
+    initializeCountryStatuses(servers, country_catalog.COUNTRY_NAMES);
   }
 
   void beginPreparingSend(String message) {
@@ -943,6 +976,19 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     }
 
     final shouldLoop = !forceSingleRound && _isLooping;
+    final targetCountryCodes = _selectedGlobalCountryCodes;
+    final shouldSendGlobal =
+        _isGlobalSendEnabled &&
+        (targetCountryCodes == null || targetCountryCodes.isNotEmpty);
+    final shouldRunLocal =
+        _isFieldEnergyMode || (_isLocalLoopbackEnabled && !kIsWeb);
+
+    if (!shouldSendGlobal && !shouldRunLocal) {
+      updateLog('请先在地区中选择全球、国家、本地场能或本地转经轮。');
+      _finishPreparingSend();
+      _scheduleNotify();
+      return;
+    }
 
     _isTransferring = true;
     _finishPreparingSend();
@@ -959,6 +1005,12 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _loopCount++;
     }
 
+    if (shouldSendGlobal) {
+      _prepareCountryStatusesForTargets(targetCountryCodes);
+    } else {
+      _countryStatuses = [];
+    }
+
     _globalSentCount = 0;
     _loopbackCount = 0;
     _currentCountryProgress = null;
@@ -968,7 +1020,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
     try {
       debugPrint(
-        '🚀 开始全球传输 - 文件数量: ${_selectedFiles.length}, 循环: $shouldLoop, 轮次: $_loopCount, 场能模式: $_isFieldEnergyMode, 本地回环: $_isLocalLoopbackEnabled',
+        '🚀 开始传输 - 文件数量: ${_selectedFiles.length}, 全球发送: $shouldSendGlobal, 循环: $shouldLoop, 轮次: $_loopCount, 场能模式: $_isFieldEnergyMode, 本地回环: $_isLocalLoopbackEnabled',
       );
 
       if (!isLoopContinuation) {
@@ -982,12 +1034,20 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
         await _startLocalLoopback();
       }
 
+      if (!shouldSendGlobal) {
+        updateLog('本地模块运行中，可点击停止结束。');
+        _schedulePersist(_persistTransferState);
+        _scheduleNotify();
+        return;
+      }
+
       debugPrint('🔧 准备初始化平台全球发送服务...');
       await _initializePlatformGlobalSendService();
       debugPrint('🔧 平台服务初始化完成，准备开始发送...');
       await _platformGlobalSendService?.startSending(
         files: _selectedFiles,
         isLoop: shouldLoop,
+        countryCodes: targetCountryCodes,
       );
       debugPrint('🔧 发送方法执行完毕，准备上传数据...');
       await _uploadPendingData();
@@ -995,6 +1055,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       debugPrint('✅ 传输完成，循环模式: $shouldLoop, 轮次: $_loopCount');
 
       _stopFieldEnergyBroadcast();
+      _stopLocalLoopback();
       await _stopBackgroundService();
       _isTransferring = false;
       _status = TransferStatus.completed;
@@ -1008,6 +1069,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _currentSendingScripture = '';
       _currentCountryProgress = null;
       _stopFieldEnergyBroadcast();
+      _stopLocalLoopback();
       await _stopBackgroundService();
       _schedulePersist(_persistTransferState);
       _scheduleNotify();
@@ -1671,6 +1733,29 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       _globalSentCount = prefs.getInt('global_sent_count') ?? 0;
       _globalDataSentMB = prefs.getDouble('global_data_sent_mb') ?? 0.0;
       _currentLog = prefs.getString('current_log') ?? '';
+      _isGlobalSendEnabled = prefs.getBool('send_global_enabled') ?? true;
+      _isLooping = prefs.getBool('send_looping') ?? false;
+      _isFieldEnergyMode = prefs.getBool('send_field_energy') ?? false;
+      _isLocalLoopbackEnabled = prefs.getBool('send_local_loopback') ?? false;
+
+      final countryListJson = prefs.getString(_sendCountryListPrefsKey);
+      if (countryListJson != null && countryListJson.isNotEmpty) {
+        final decoded = json.decode(countryListJson);
+        if (decoded is List) {
+          _countryList = decoded
+              .whereType<String>()
+              .where(
+                (code) =>
+                    code == 'ALL' ||
+                    country_catalog.GLOBAL_COUNTRY_SERVERS.containsKey(code),
+              )
+              .toSet()
+              .toList();
+        }
+      }
+      if (_countryList.isEmpty && _isGlobalSendEnabled) {
+        _countryList = ['ALL'];
+      }
 
       final linkHistoryJson = prefs.getString(_linkHistoryPrefsKey);
       if (linkHistoryJson != null && linkHistoryJson.isNotEmpty) {
@@ -1715,6 +1800,22 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
       await prefs.setString('current_log', _currentLog);
     } catch (e) {
       debugPrint('持久化传输状态失败: $e');
+    }
+  }
+
+  Future<void> _persistSendPreferences() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool('send_global_enabled', _isGlobalSendEnabled);
+      await prefs.setBool('send_looping', _isLooping);
+      await prefs.setBool('send_field_energy', _isFieldEnergyMode);
+      await prefs.setBool('send_local_loopback', _isLocalLoopbackEnabled);
+      await prefs.setString(
+        _sendCountryListPrefsKey,
+        json.encode(_countryList),
+      );
+    } catch (e) {
+      debugPrint('持久化发送偏好失败: $e');
     }
   }
 

--- a/fabushi/lib/models/file_transfer_model.dart
+++ b/fabushi/lib/models/file_transfer_model.dart
@@ -66,6 +66,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   bool _isGlobalSendEnabled = true;
   bool _isLooping = false;
+  bool _isLocalLoopbackEnabled = false;
   bool _isFieldEnergyMode = false;
   double _sendRateMB = 1.0;
   int _loopCount = 0;
@@ -149,6 +150,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   bool get isGlobalSendEnabled => _isGlobalSendEnabled;
   bool get isLooping => _isLooping;
+  bool get isLocalLoopbackEnabled => _isLocalLoopbackEnabled;
   bool get isFieldEnergyMode => _isFieldEnergyMode;
   int get loopCount => _loopCount;
   int get loopbackCount => _loopbackCount;
@@ -251,6 +253,16 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
   void setLooping(bool looping) {
     _isLooping = looping;
+    notifyListeners();
+  }
+
+  void setLocalLoopbackEnabled(bool enabled) {
+    if (_isLocalLoopbackEnabled == enabled) return;
+    _isLocalLoopbackEnabled = enabled;
+    if (!enabled) {
+      _loopbackCount = 0;
+      _stopLocalLoopback();
+    }
     notifyListeners();
   }
 
@@ -956,7 +968,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
 
     try {
       debugPrint(
-        '🚀 开始全球传输 - 文件数量: ${_selectedFiles.length}, 循环: $shouldLoop, 轮次: $_loopCount, 场能模式: $_isFieldEnergyMode',
+        '🚀 开始全球传输 - 文件数量: ${_selectedFiles.length}, 循环: $shouldLoop, 轮次: $_loopCount, 场能模式: $_isFieldEnergyMode, 本地回环: $_isLocalLoopbackEnabled',
       );
 
       if (!isLoopContinuation) {
@@ -966,7 +978,9 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
         }
       }
 
-      await _startLocalLoopback();
+      if (_isLocalLoopbackEnabled) {
+        await _startLocalLoopback();
+      }
 
       debugPrint('🔧 准备初始化平台全球发送服务...');
       await _initializePlatformGlobalSendService();
@@ -1004,7 +1018,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     if (kIsWeb) return;
     if (_selectedFiles.isEmpty) return;
 
-    if (!_isTransferring) {
+    if (!_isTransferring && _isLocalLoopbackEnabled) {
       await _startLocalLoopback();
     }
 
@@ -1044,7 +1058,7 @@ class FileTransferModel extends ChangeNotifier with WidgetsBindingObserver {
     _fieldBroadcastService?.dispose();
     _fieldBroadcastService = null;
 
-    if (!_isTransferring) {
+    if (!_isTransferring && _isLocalLoopbackEnabled) {
       _stopLocalLoopback();
     }
     debugPrint('🛑 场能广播已停止');

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -18,6 +18,7 @@ import '../services/membership_service.dart';
 import '../services/online_counter_service.dart';
 import '../widgets/online_counter_widget.dart';
 import '../widgets/auto_start_guide_dialog.dart';
+import 'membership_screen.dart';
 
 class GlobeHomeScreen extends StatefulWidget {
   const GlobeHomeScreen({super.key});
@@ -710,151 +711,10 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   const SizedBox(height: 10),
                   _buildRenderModeSegment(),
                   const SizedBox(height: 12),
-                  _buildSelectedContentTile(model),
-                  const SizedBox(height: 8),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: model.isFieldEnergyMode
-                          ? Colors.purple.withValues(alpha: 0.2)
-                          : Colors.white.withValues(alpha: 0.1),
-                      borderRadius: BorderRadius.circular(10),
-                      border: model.isFieldEnergyMode
-                          ? Border.all(
-                              color: Colors.purple.withValues(alpha: 0.5),
-                            )
-                          : null,
-                    ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Expanded(
-                          child: Row(
-                            children: [
-                              Icon(
-                                model.isFieldEnergyMode
-                                    ? Icons.wifi_tethering
-                                    : Icons.wifi_tethering_off,
-                                color: model.isFieldEnergyMode
-                                    ? Colors.purple
-                                    : Colors.white70,
-                                size: 18,
-                              ),
-                              const SizedBox(width: 8),
-                              Flexible(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      '无网场能模式',
-                                      style: TextStyle(
-                                        color: model.isFieldEnergyMode
-                                            ? Colors.purple
-                                            : Colors.white70,
-                                        fontSize: 13,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                    Text(
-                                      model.isFieldEnergyMode &&
-                                              model.hotspotMessage.isNotEmpty
-                                          ? model.hotspotMessage
-                                          : '自动开启热点向周围广播',
-                                      style: TextStyle(
-                                        color: model.isFieldEnergyMode
-                                            ? Colors.purple.withValues(
-                                                alpha: 0.7,
-                                              )
-                                            : Colors.white54,
-                                        fontSize: 10,
-                                      ),
-                                      maxLines: 2,
-                                      overflow: TextOverflow.ellipsis,
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        SizedBox(
-                          height: 28,
-                          child: Switch(
-                            value: model.isFieldEnergyMode,
-                            onChanged: (value) async {
-                              await model.setFieldEnergyMode(value);
-                              if (!context.mounted) return;
-                              if (model.needsHotspotGuide) {
-                                _showHotspotGuideDialog(context);
-                                model.clearHotspotGuide();
-                              }
-                            },
-                            activeThumbColor: Colors.purple,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
+                  _buildSendModuleControls(context, model),
                   const SizedBox(height: 12),
                 ],
-                Row(
-                  children: [
-                    Expanded(
-                      child: model.isPreparingSend
-                          ? ElevatedButton.icon(
-                              onPressed: null,
-                              icon: const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              ),
-                              label: const Text(
-                                '准备发送中',
-                                style: TextStyle(fontSize: 13),
-                              ),
-                              style: ElevatedButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 10,
-                                ),
-                              ),
-                            )
-                          : model.isTransferring
-                          ? ElevatedButton.icon(
-                              onPressed: () => _stopSending(model),
-                              icon: const Icon(Icons.stop, size: 18),
-                              label: const Text(
-                                '停止发送',
-                                style: TextStyle(fontSize: 13),
-                              ),
-                              style: ElevatedButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 10,
-                                ),
-                                backgroundColor: Colors.red.shade600,
-                              ),
-                            )
-                          : ElevatedButton.icon(
-                              onPressed: () => _startSending(model),
-                              icon: const Icon(Icons.send, size: 18),
-                              label: const Text(
-                                '开始发送',
-                                style: TextStyle(fontSize: 13),
-                              ),
-                              style: ElevatedButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 10,
-                                ),
-                                backgroundColor: AppTheme.primaryColor,
-                              ),
-                            ),
-                    ),
-                  ],
-                ),
+                _buildChatComposer(context, model),
               ],
             ),
           ),
@@ -938,31 +798,131 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     );
   }
 
-  Widget _buildSelectedContentTile(FileTransferModel model) {
+  Widget _buildSendModuleControls(
+    BuildContext context,
+    FileTransferModel model,
+  ) {
+    final isBusy = model.isPreparingSend || model.isTransferring;
+    final authModel = Provider.of<AuthModel?>(context);
+    final hasPremiumAccess = authModel?.hasPermission('premium') ?? false;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final loopTile = _ModuleSwitchTile(
+          icon: Icons.loop,
+          title: '循环发送',
+          subtitle: model.isLooping ? '完成后自动进入下一轮' : '当前只发送一轮',
+          value: model.isLooping,
+          enabled: !isBusy,
+          onChanged: model.setLooping,
+        );
+        final loopbackTile = _ModuleSwitchTile(
+          icon: Icons.sync_alt,
+          title: '本地回环',
+          subtitle: model.isLocalLoopbackEnabled
+              ? model.loopbackCount > 0
+                    ? '已回环 ${model.loopbackCount} 轮'
+                    : '会员模块已开启'
+              : '会员可开启独立回环',
+          value: model.isLocalLoopbackEnabled,
+          enabled: !isBusy,
+          locked: !hasPremiumAccess,
+          onChanged: (value) => _setLocalLoopbackEnabled(model, value),
+        );
+
+        return Column(
+          children: [
+            if (constraints.maxWidth < 360) ...[
+              loopTile,
+              const SizedBox(height: 8),
+              loopbackTile,
+            ] else
+              Row(
+                children: [
+                  Expanded(child: loopTile),
+                  const SizedBox(width: 8),
+                  Expanded(child: loopbackTile),
+                ],
+              ),
+            const SizedBox(height: 8),
+            _ModuleSwitchTile(
+              icon: model.isFieldEnergyMode
+                  ? Icons.wifi_tethering
+                  : Icons.wifi_tethering_off,
+              title: '无网场能模式',
+              subtitle:
+                  model.isFieldEnergyMode && model.hotspotMessage.isNotEmpty
+                  ? model.hotspotMessage
+                  : '开启热点向周围广播',
+              value: model.isFieldEnergyMode,
+              enabled: !isBusy,
+              activeColor: Colors.purple,
+              onChanged: (value) async {
+                await model.setFieldEnergyMode(value);
+                if (!context.mounted) return;
+                if (model.needsHotspotGuide) {
+                  _showHotspotGuideDialog(context);
+                  model.clearHotspotGuide();
+                }
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildChatComposer(BuildContext context, FileTransferModel model) {
     final hasContent = model.hasFiles;
     final title = hasContent ? model.selectedContentTitle : '选择发送内容';
     final subtitle = hasContent
         ? (model.selectedContentSubtitle.isEmpty
-              ? '点此重新选择链接、文本、文件或佛像素材'
+              ? '点 + 可重新选择链接、文本、文件或佛像素材'
               : model.selectedContentSubtitle)
         : '链接、文本、本机文件或禅室佛像素材';
     final icon = _contentIcon(model.selectedContentKind);
+    final isBusy = model.isPreparingSend || model.isTransferring;
 
-    return Material(
-      color: Colors.white.withValues(alpha: 0.1),
-      borderRadius: BorderRadius.circular(10),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(10),
-        onTap: model.isPreparingSend
-            ? null
-            : () => _showSendContentSheet(model),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            children: [
-              Icon(icon, color: AppTheme.primaryColor, size: 20),
-              const SizedBox(width: 10),
-              Expanded(
+    return Container(
+      padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
+      decoration: BoxDecoration(
+        color: const Color(0xFF242424).withValues(alpha: 0.96),
+        borderRadius: BorderRadius.circular(26),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.09)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.25),
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Builder(
+            builder: (buttonContext) => IconButton(
+              visualDensity: VisualDensity.compact,
+              tooltip: '添加发送内容',
+              icon: const Icon(Icons.add, color: Colors.white, size: 24),
+              onPressed: isBusy
+                  ? null
+                  : () => _openSendContentMenu(buttonContext, model),
+              style: IconButton.styleFrom(
+                backgroundColor: Colors.white.withValues(alpha: 0.08),
+                disabledBackgroundColor: Colors.white.withValues(alpha: 0.04),
+                fixedSize: const Size(40, 40),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Icon(icon, color: AppTheme.primaryColor, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: InkWell(
+              borderRadius: BorderRadius.circular(14),
+              onTap: null,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 5),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
@@ -970,26 +930,32 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     Row(
                       children: [
                         if (hasContent && model.selectedContentKind.isNotEmpty)
-                          Padding(
-                            padding: const EdgeInsets.only(right: 6),
-                            child: Text(
-                              model.selectedContentKind,
-                              style: TextStyle(
-                                color: AppTheme.primaryColor.withValues(
-                                  alpha: 0.9,
+                          Flexible(
+                            child: Padding(
+                              padding: const EdgeInsets.only(right: 6),
+                              child: Text(
+                                model.selectedContentKind,
+                                style: TextStyle(
+                                  color: AppTheme.primaryColor.withValues(
+                                    alpha: 0.95,
+                                  ),
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w700,
                                 ),
-                                fontSize: 11,
-                                fontWeight: FontWeight.w700,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
                               ),
                             ),
                           ),
                         Expanded(
                           child: Text(
                             title,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
+                            style: TextStyle(
+                              color: hasContent ? Colors.white : Colors.white60,
+                              fontSize: 14,
+                              fontWeight: hasContent
+                                  ? FontWeight.w600
+                                  : FontWeight.w500,
                             ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
@@ -1001,7 +967,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     Text(
                       subtitle,
                       style: const TextStyle(
-                        color: Colors.white60,
+                        color: Colors.white54,
                         fontSize: 11,
                       ),
                       maxLines: 1,
@@ -1010,18 +976,210 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   ],
                 ),
               ),
-              if (model.hasSelectedContentPreview) ...[
-                const SizedBox(width: 4),
-                IconButton(
-                  visualDensity: VisualDensity.compact,
-                  tooltip: '查看已读取内容',
-                  icon: const Icon(Icons.visibility, color: Colors.white70),
-                  onPressed: () => _showSelectedContentPreview(model),
-                ),
-              ],
-              const Icon(Icons.chevron_right, color: Colors.white54),
-            ],
+            ),
           ),
+          if (model.hasSelectedContentPreview)
+            IconButton(
+              visualDensity: VisualDensity.compact,
+              tooltip: '查看已读取内容',
+              icon: const Icon(Icons.visibility, color: Colors.white70),
+              onPressed: () => _showSelectedContentPreview(model),
+            ),
+          const SizedBox(width: 4),
+          _buildComposerActionButton(model),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildComposerActionButton(FileTransferModel model) {
+    if (model.isPreparingSend) {
+      return Container(
+        width: 42,
+        height: 42,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.1),
+          shape: BoxShape.circle,
+        ),
+        child: const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+
+    if (model.isTransferring) {
+      return IconButton(
+        tooltip: '停止发送',
+        icon: const Icon(Icons.stop, color: Colors.white, size: 21),
+        onPressed: () => _stopSending(model),
+        style: IconButton.styleFrom(
+          backgroundColor: Colors.red.shade600,
+          fixedSize: const Size(42, 42),
+        ),
+      );
+    }
+
+    return IconButton(
+      tooltip: '开始发送',
+      icon: const Icon(Icons.arrow_upward, color: Colors.black, size: 22),
+      onPressed: () => _startSending(model),
+      style: IconButton.styleFrom(
+        backgroundColor: Colors.white,
+        fixedSize: const Size(42, 42),
+      ),
+    );
+  }
+
+  Future<bool> _openSendContentMenu(
+    BuildContext anchorContext,
+    FileTransferModel model,
+  ) async {
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    final anchor = anchorContext.findRenderObject() as RenderBox?;
+    if (overlay == null || anchor == null) return false;
+
+    final anchorTopLeft = anchor.localToGlobal(Offset.zero, ancestor: overlay);
+    final anchorBottomRight = anchor.localToGlobal(
+      anchor.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    );
+    final position = RelativeRect.fromRect(
+      Rect.fromPoints(anchorTopLeft, anchorBottomRight),
+      Offset.zero & overlay.size,
+    );
+
+    final action = await showMenu<String>(
+      context: context,
+      position: position,
+      color: const Color(0xFF333333),
+      surfaceTintColor: Colors.transparent,
+      constraints: const BoxConstraints(minWidth: 260, maxWidth: 320),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      items: [
+        _sendMenuItem('files', Icons.attach_file, '添加照片和文件', '选择手机或电脑中的本机文件'),
+        _sendMenuItem('assets', Icons.inventory_2, '内置素材', '从素材库选择要发送的内容'),
+        _sendMenuItem('link', Icons.link, '输入链接', '读取链接正文后发送'),
+        _sendMenuItem('text', Icons.edit_note, '输入文本', '发送手输或粘贴的文本'),
+        _sendMenuItem(
+          'buddha',
+          Icons.self_improvement,
+          '禅室佛像素材',
+          '发送禅室当前佛像模型素材',
+        ),
+        if (model.linkHistory.isNotEmpty) ...[
+          const PopupMenuDivider(),
+          const PopupMenuItem<String>(
+            enabled: false,
+            height: 28,
+            child: Text(
+              '最近链接',
+              style: TextStyle(
+                color: Colors.white54,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          ...model.linkHistory.take(5).toList().asMap().entries.map((entry) {
+            final history = entry.value;
+            return _sendMenuItem(
+              'history:${entry.key}',
+              Icons.history,
+              history.title.isEmpty ? history.url : history.title,
+              history.preview.isEmpty ? history.url : history.preview,
+            );
+          }),
+        ],
+      ],
+    );
+
+    if (action == null) return false;
+    return _handleSendMenuAction(model, action);
+  }
+
+  PopupMenuItem<String> _sendMenuItem(
+    String value,
+    IconData icon,
+    String title,
+    String subtitle,
+  ) {
+    return PopupMenuItem<String>(
+      value: value,
+      height: 54,
+      child: _SendMenuRow(icon: icon, title: title, subtitle: subtitle),
+    );
+  }
+
+  Future<bool> _handleSendMenuAction(
+    FileTransferModel model,
+    String action,
+  ) async {
+    if (action == 'files') {
+      return await model.selectFiles(replaceExisting: true);
+    }
+    if (action == 'assets') {
+      await model.selectBuiltInAssets(context);
+      return model.hasFiles;
+    }
+    if (action == 'link') {
+      return await _inputSendLink(model);
+    }
+    if (action == 'text') {
+      return await _inputSendText(model);
+    }
+    if (action == 'buddha') {
+      return await _selectBuddhaAsset(model);
+    }
+    if (action.startsWith('history:')) {
+      final index = int.tryParse(action.substring('history:'.length));
+      if (index == null || index >= model.linkHistory.length) return false;
+      return await _selectLinkHistory(model, model.linkHistory[index]);
+    }
+    return false;
+  }
+
+  Future<void> _setLocalLoopbackEnabled(
+    FileTransferModel model,
+    bool enabled,
+  ) async {
+    if (!enabled) {
+      model.setLocalLoopbackEnabled(false);
+      return;
+    }
+
+    final authModel = Provider.of<AuthModel?>(context, listen: false);
+    final hasPremiumAccess = authModel?.hasPermission('premium') ?? false;
+    if (!hasPremiumAccess) {
+      model.setLocalLoopbackEnabled(false);
+      _showLoopbackMembershipPrompt();
+      return;
+    }
+
+    model.setLocalLoopbackEnabled(true);
+  }
+
+  void _showLoopbackMembershipPrompt() {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: const Text('本地回环是会员功能，开通会员后即可开启。'),
+        backgroundColor: Colors.black87,
+        action: SnackBarAction(
+          label: '去开通',
+          textColor: AppTheme.primaryColor,
+          onPressed: () {
+            if (!mounted) return;
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const MembershipScreen()),
+            );
+          },
         ),
       ),
     );
@@ -1171,118 +1329,6 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         ],
       ),
     );
-  }
-
-  Future<bool> _showSendContentSheet(FileTransferModel model) async {
-    final result = await showModalBottomSheet<bool>(
-      context: context,
-      backgroundColor: const Color(0xFF171717),
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
-      ),
-      builder: (sheetContext) => SafeArea(
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            maxHeight: MediaQuery.of(sheetContext).size.height * 0.84,
-          ),
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  '选择要全球发送的内容',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 18,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: 14),
-                _SendSourceTile(
-                  icon: Icons.link,
-                  title: '输入链接',
-                  subtitle: '读取链接正文，读取后可点开查看',
-                  onTap: () async {
-                    final navigator = Navigator.of(sheetContext);
-                    final selected = await _inputSendLink(model);
-                    if (navigator.mounted) navigator.pop(selected);
-                  },
-                ),
-                _SendSourceTile(
-                  icon: Icons.edit_note,
-                  title: '输入文本',
-                  subtitle: '发送手输或粘贴的文本',
-                  onTap: () async {
-                    final navigator = Navigator.of(sheetContext);
-                    final selected = await _inputSendText(model);
-                    if (navigator.mounted) navigator.pop(selected);
-                  },
-                ),
-                _SendSourceTile(
-                  icon: Icons.folder_open,
-                  title: '选择本机文件',
-                  subtitle: '发送手机本机文件',
-                  onTap: () async {
-                    final navigator = Navigator.of(sheetContext);
-                    final selected = await model.selectFiles(
-                      replaceExisting: true,
-                    );
-                    if (navigator.mounted) {
-                      navigator.pop(selected);
-                    }
-                  },
-                ),
-                _SendSourceTile(
-                  icon: Icons.self_improvement,
-                  title: '禅室佛像素材',
-                  subtitle: '发送禅室当前佛像模型素材',
-                  onTap: () async {
-                    final navigator = Navigator.of(sheetContext);
-                    final selected = await _selectBuddhaAsset(model);
-                    if (navigator.mounted) navigator.pop(selected);
-                  },
-                ),
-                if (model.linkHistory.isNotEmpty) ...[
-                  const SizedBox(height: 16),
-                  const Text(
-                    '链接历史',
-                    style: TextStyle(
-                      color: Colors.white70,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  ...model.linkHistory
-                      .take(8)
-                      .map(
-                        (entry) => _SendSourceTile(
-                          icon: Icons.history,
-                          title: entry.title.isEmpty ? entry.url : entry.title,
-                          subtitle: entry.preview.isEmpty
-                              ? entry.url
-                              : entry.preview,
-                          onTap: () async {
-                            final navigator = Navigator.of(sheetContext);
-                            final selected = await _selectLinkHistory(
-                              model,
-                              entry,
-                            );
-                            if (navigator.mounted) navigator.pop(selected);
-                          },
-                        ),
-                      ),
-                ],
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-    return result == true;
   }
 
   Future<bool> _inputSendText(FileTransferModel model) async {
@@ -1718,8 +1764,15 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       }
     }
 
-    final prepared = model.hasFiles || await _showSendContentSheet(model);
-    if (!prepared || !mounted || !model.hasFiles) {
+    if (!mounted) return;
+
+    if (!model.hasFiles) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('请先点击 + 选择链接、文本、文件或素材。'),
+          backgroundColor: Colors.black87,
+        ),
+      );
       return;
     }
 
@@ -1797,32 +1850,134 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   }
 }
 
-class _SendSourceTile extends StatelessWidget {
+class _ModuleSwitchTile extends StatelessWidget {
   final IconData icon;
   final String title;
   final String subtitle;
-  final Future<void> Function() onTap;
+  final bool value;
+  final bool enabled;
+  final bool locked;
+  final Color? activeColor;
+  final ValueChanged<bool> onChanged;
 
-  const _SendSourceTile({
+  const _ModuleSwitchTile({
     required this.icon,
     required this.title,
     required this.subtitle,
-    required this.onTap,
+    required this.value,
+    required this.onChanged,
+    this.enabled = true,
+    this.locked = false,
+    this.activeColor,
   });
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      leading: CircleAvatar(
-        backgroundColor: const Color(0xFFD4AF37).withValues(alpha: 0.16),
-        foregroundColor: const Color(0xFFD4AF37),
-        child: Icon(icon),
+    final effectiveColor = activeColor ?? AppTheme.primaryColor;
+    final isActive = value && enabled;
+    final foreground = isActive ? effectiveColor : Colors.white70;
+
+    return Container(
+      constraints: const BoxConstraints(minHeight: 58),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: isActive
+            ? effectiveColor.withValues(alpha: 0.16)
+            : Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: isActive
+              ? effectiveColor.withValues(alpha: 0.42)
+              : Colors.white.withValues(alpha: 0.08),
+        ),
       ),
-      title: Text(title, style: const TextStyle(color: Colors.white)),
-      subtitle: Text(subtitle, style: const TextStyle(color: Colors.white60)),
-      trailing: const Icon(Icons.chevron_right, color: Colors.white54),
-      onTap: onTap,
+      child: Row(
+        children: [
+          Icon(locked ? Icons.lock_outline : icon, color: foreground, size: 20),
+          const SizedBox(width: 9),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: foreground,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: const TextStyle(color: Colors.white54, fontSize: 10),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          Transform.scale(
+            scale: 0.78,
+            child: Switch(
+              value: value,
+              onChanged: enabled ? onChanged : null,
+              activeThumbColor: effectiveColor,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SendMenuRow extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  const _SendMenuRow({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, color: Colors.white, size: 22),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                subtitle,
+                style: const TextStyle(color: Colors.white60, fontSize: 11),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -5,8 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../core/config/app_config.dart';
+import '../core/constants/country_servers.dart' as country_catalog;
 import '../features/auth/application/auth_model.dart';
 import '../models/file_transfer_model.dart';
+import '../services/app_settings.dart';
 import '../widgets/earth_globe_widget.dart';
 import '../widgets/home_world_2d_widget.dart';
 import '../widgets/scene_render_mode.dart';
@@ -14,6 +16,9 @@ import 'leaderboard_screen.dart';
 import '../core/design_system/app_theme.dart';
 import '../services/alipay_service.dart';
 import '../services/apple_iap_service.dart';
+import '../services/llm_inference_service.dart';
+import '../services/llm_model_config.dart';
+import '../services/llm_model_manager.dart';
 import '../services/membership_service.dart';
 import '../services/online_counter_service.dart';
 import '../widgets/online_counter_widget.dart';
@@ -36,7 +41,16 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   bool _isGlobeLoaded = false;
   bool _isCallbackSetup = false;
   bool _isVisible = true;
+  bool _isDharmaComposerMode = false;
+  bool _isAiGenerating = false;
+  String _streamingAiText = '';
   SceneRenderMode _renderMode = SceneRenderMode.twoD;
+  final TextEditingController _chatInputController = TextEditingController();
+  final ScrollController _homeChatScrollController = ScrollController();
+  final List<_HomeChatMessage> _homeChatMessages = [];
+  StreamSubscription<String>? _aiStreamSubscription;
+  List<LLMModelType> _availableChatModels = [];
+  LLMModelType? _selectedChatModel;
   final _onlineCounterService = OnlineCounterService();
   final _membershipService = MembershipService();
   final _alipayService = AlipayService();
@@ -141,8 +155,47 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _loadGlobe();
+    _loadAvailableChatModel();
     _fetchInitialCount();
     _onlineCounterService.startCountPolling('global_sending');
+  }
+
+  Future<void> _loadAvailableChatModel() async {
+    if (kIsWeb) return;
+    try {
+      final downloadedModels = await LLMModelManager.instance
+          .getDownloadedModels();
+      final isMobile = Platform.isAndroid || Platform.isIOS;
+      final platformModels = LLMModelConfig.getChatModelsForPlatform(
+        isMobile: isMobile,
+      );
+      final supportedTypes = platformModels
+          .map((config) => config.type)
+          .toSet();
+      final chatModels = downloadedModels
+          .where((type) => supportedTypes.contains(type))
+          .toList();
+
+      LLMModelType? savedModel;
+      final savedModelName = await AppSettings.getSelectedModelName();
+      if (savedModelName != null) {
+        try {
+          savedModel = LLMModelType.values.firstWhere(
+            (type) => type.name == savedModelName,
+          );
+          if (!chatModels.contains(savedModel)) savedModel = null;
+        } catch (_) {}
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _availableChatModels = chatModels;
+        _selectedChatModel =
+            savedModel ?? (chatModels.isNotEmpty ? chatModels.first : null);
+      });
+    } catch (e) {
+      debugPrint('首页 AI 模型加载失败: $e');
+    }
   }
 
   Future<void> _fetchInitialCount() async {
@@ -203,6 +256,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       ).setTransferBeamCallback(null);
     } catch (_) {}
     _onlineCounterService.dispose();
+    _aiStreamSubscription?.cancel();
+    _chatInputController.dispose();
+    _homeChatScrollController.dispose();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -711,8 +767,11 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   const SizedBox(height: 10),
                   _buildRenderModeSegment(),
                   const SizedBox(height: 12),
-                  _buildSendModuleControls(context, model),
-                  const SizedBox(height: 12),
+                  if (!_isDharmaComposerMode &&
+                      _homeChatMessages.isNotEmpty) ...[
+                    _buildHomeChatThread(),
+                    const SizedBox(height: 12),
+                  ],
                 ],
                 _buildChatComposer(context, model),
               ],
@@ -798,96 +857,80 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     );
   }
 
-  Widget _buildSendModuleControls(
-    BuildContext context,
-    FileTransferModel model,
-  ) {
-    final isBusy = model.isPreparingSend || model.isTransferring;
-    final authModel = Provider.of<AuthModel?>(context);
-    final hasPremiumAccess = authModel?.hasPermission('premium') ?? false;
+  Widget _buildHomeChatThread() {
+    final messages = [
+      ..._homeChatMessages,
+      if (_isAiGenerating && _streamingAiText.isNotEmpty)
+        _HomeChatMessage(text: _streamingAiText, isUser: false),
+    ];
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final loopTile = _ModuleSwitchTile(
-          icon: Icons.loop,
-          title: '循环发送',
-          subtitle: model.isLooping ? '完成后自动进入下一轮' : '当前只发送一轮',
-          value: model.isLooping,
-          enabled: !isBusy,
-          onChanged: model.setLooping,
-        );
-        final loopbackTile = _ModuleSwitchTile(
-          icon: Icons.sync_alt,
-          title: '本地回环',
-          subtitle: model.isLocalLoopbackEnabled
-              ? model.loopbackCount > 0
-                    ? '已回环 ${model.loopbackCount} 轮'
-                    : '会员模块已开启'
-              : '会员可开启独立回环',
-          value: model.isLocalLoopbackEnabled,
-          enabled: !isBusy,
-          locked: !hasPremiumAccess,
-          onChanged: (value) => _setLocalLoopbackEnabled(model, value),
-        );
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 220),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.18),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+        ),
+        child: ListView.separated(
+          controller: _homeChatScrollController,
+          padding: const EdgeInsets.all(12),
+          shrinkWrap: true,
+          itemCount: messages.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 8),
+          itemBuilder: (context, index) {
+            final message = messages[index];
+            final alignment = message.isUser
+                ? CrossAxisAlignment.end
+                : CrossAxisAlignment.start;
+            final bubbleColor = message.isUser
+                ? AppTheme.primaryColor.withValues(alpha: 0.22)
+                : message.isError
+                ? Colors.red.withValues(alpha: 0.18)
+                : Colors.white.withValues(alpha: 0.08);
 
-        return Column(
-          children: [
-            if (constraints.maxWidth < 360) ...[
-              loopTile,
-              const SizedBox(height: 8),
-              loopbackTile,
-            ] else
-              Row(
-                children: [
-                  Expanded(child: loopTile),
-                  const SizedBox(width: 8),
-                  Expanded(child: loopbackTile),
-                ],
-              ),
-            const SizedBox(height: 8),
-            _ModuleSwitchTile(
-              icon: model.isFieldEnergyMode
-                  ? Icons.wifi_tethering
-                  : Icons.wifi_tethering_off,
-              title: '无网场能模式',
-              subtitle:
-                  model.isFieldEnergyMode && model.hotspotMessage.isNotEmpty
-                  ? model.hotspotMessage
-                  : '开启热点向周围广播',
-              value: model.isFieldEnergyMode,
-              enabled: !isBusy,
-              activeColor: Colors.purple,
-              onChanged: (value) async {
-                await model.setFieldEnergyMode(value);
-                if (!context.mounted) return;
-                if (model.needsHotspotGuide) {
-                  _showHotspotGuideDialog(context);
-                  model.clearHotspotGuide();
-                }
-              },
-            ),
-          ],
-        );
-      },
+            return Column(
+              crossAxisAlignment: alignment,
+              children: [
+                Container(
+                  constraints: const BoxConstraints(maxWidth: 420),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 9,
+                  ),
+                  decoration: BoxDecoration(
+                    color: bubbleColor,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Text(
+                    message.text,
+                    style: TextStyle(
+                      color: message.isError ? Colors.red[100] : Colors.white,
+                      fontSize: 13,
+                      height: 1.45,
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
     );
   }
 
   Widget _buildChatComposer(BuildContext context, FileTransferModel model) {
-    final hasContent = model.hasFiles;
-    final title = hasContent ? model.selectedContentTitle : '选择发送内容';
-    final subtitle = hasContent
-        ? (model.selectedContentSubtitle.isEmpty
-              ? '点 + 可重新选择链接、文本、文件或佛像素材'
-              : model.selectedContentSubtitle)
-        : '链接、文本、本机文件或禅室佛像素材';
-    final icon = _contentIcon(model.selectedContentKind);
     final isBusy = model.isPreparingSend || model.isTransferring;
+    final inputText = _chatInputController.text.trim();
+    final canSubmit = _isDharmaComposerMode
+        ? (inputText.isNotEmpty || model.hasFiles)
+        : inputText.isNotEmpty;
 
     return Container(
-      padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
+      padding: const EdgeInsets.fromLTRB(8, 8, 7, 8),
       decoration: BoxDecoration(
         color: const Color(0xFF242424).withValues(alpha: 0.96),
-        borderRadius: BorderRadius.circular(26),
+        borderRadius: BorderRadius.circular(_isDharmaComposerMode ? 24 : 26),
         border: Border.all(color: Colors.white.withValues(alpha: 0.09)),
         boxShadow: [
           BoxShadow(
@@ -897,102 +940,128 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           ),
         ],
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Builder(
-            builder: (buttonContext) => IconButton(
-              visualDensity: VisualDensity.compact,
-              tooltip: '添加发送内容',
-              icon: const Icon(Icons.add, color: Colors.white, size: 24),
-              onPressed: isBusy
-                  ? null
-                  : () => _openSendContentMenu(buttonContext, model),
-              style: IconButton.styleFrom(
-                backgroundColor: Colors.white.withValues(alpha: 0.08),
-                disabledBackgroundColor: Colors.white.withValues(alpha: 0.04),
-                fixedSize: const Size(40, 40),
+          if (_isDharmaComposerMode) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(5, 1, 6, 8),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  _ComposerChip(
+                    icon: Icons.self_improvement,
+                    label: '法布施',
+                    active: true,
+                    onRemove: () => _clearDharmaMode(model),
+                  ),
+                  _ComposerChip(
+                    icon: Icons.public,
+                    label: '地区 ${_regionSummary(model)}',
+                    active:
+                        model.isGlobalSendEnabled ||
+                        model.isFieldEnergyMode ||
+                        model.isLocalLoopbackEnabled,
+                    onTap: isBusy ? null : () => _showRegionSelector(model),
+                  ),
+                  _ComposerChip(
+                    icon: Icons.loop,
+                    label: model.isLooping ? '循环' : '单轮',
+                    active: model.isLooping,
+                    onTap: isBusy
+                        ? null
+                        : () {
+                            model.setLooping(!model.isLooping);
+                            setState(() {});
+                          },
+                  ),
+                  if (model.hasFiles)
+                    _ComposerChip(
+                      icon: _contentIcon(model.selectedContentKind),
+                      label: model.selectedContentTitle.isEmpty
+                          ? '图片'
+                          : model.selectedContentTitle,
+                      active: true,
+                      onTap: model.hasSelectedContentPreview
+                          ? () => _showSelectedContentPreview(model)
+                          : null,
+                      onRemove: isBusy
+                          ? null
+                          : () {
+                              model.clearFiles();
+                              setState(() {});
+                            },
+                    ),
+                ],
               ),
             ),
-          ),
-          const SizedBox(width: 8),
-          Icon(icon, color: AppTheme.primaryColor, size: 18),
-          const SizedBox(width: 8),
-          Expanded(
-            child: InkWell(
-              borderRadius: BorderRadius.circular(14),
-              onTap: null,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 5),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Row(
-                      children: [
-                        if (hasContent && model.selectedContentKind.isNotEmpty)
-                          Flexible(
-                            child: Padding(
-                              padding: const EdgeInsets.only(right: 6),
-                              child: Text(
-                                model.selectedContentKind,
-                                style: TextStyle(
-                                  color: AppTheme.primaryColor.withValues(
-                                    alpha: 0.95,
-                                  ),
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.w700,
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ),
-                        Expanded(
-                          child: Text(
-                            title,
-                            style: TextStyle(
-                              color: hasContent ? Colors.white : Colors.white60,
-                              fontSize: 14,
-                              fontWeight: hasContent
-                                  ? FontWeight.w600
-                                  : FontWeight.w500,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
+          ],
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Builder(
+                builder: (buttonContext) => IconButton(
+                  visualDensity: VisualDensity.compact,
+                  tooltip: '更多入口',
+                  icon: const Icon(Icons.add, color: Colors.white, size: 24),
+                  onPressed: isBusy
+                      ? null
+                      : () => _openSendContentMenu(buttonContext, model),
+                  style: IconButton.styleFrom(
+                    backgroundColor: Colors.white.withValues(alpha: 0.08),
+                    disabledBackgroundColor: Colors.white.withValues(
+                      alpha: 0.04,
                     ),
-                    const SizedBox(height: 2),
-                    Text(
-                      subtitle,
-                      style: const TextStyle(
-                        color: Colors.white54,
-                        fontSize: 11,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
+                    fixedSize: const Size(40, 40),
+                  ),
                 ),
               ),
-            ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextField(
+                  controller: _chatInputController,
+                  enabled: !model.isPreparingSend && !model.isTransferring,
+                  minLines: 1,
+                  maxLines: 4,
+                  textInputAction: TextInputAction.send,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                    height: 1.35,
+                  ),
+                  cursorColor: AppTheme.primaryColor,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    border: InputBorder.none,
+                    hintText: _isDharmaComposerMode
+                        ? (model.hasFiles ? '可继续输入法布施文字或链接' : '输入文字或链接')
+                        : '问问 AI',
+                    hintStyle: const TextStyle(
+                      color: Colors.white54,
+                      fontSize: 15,
+                    ),
+                  ),
+                  onChanged: (_) => setState(() {}),
+                  onSubmitted: (_) {
+                    if (canSubmit) _submitComposer(model);
+                  },
+                ),
+              ),
+              const SizedBox(width: 6),
+              _buildComposerActionButton(model, canSubmit: canSubmit),
+            ],
           ),
-          if (model.hasSelectedContentPreview)
-            IconButton(
-              visualDensity: VisualDensity.compact,
-              tooltip: '查看已读取内容',
-              icon: const Icon(Icons.visibility, color: Colors.white70),
-              onPressed: () => _showSelectedContentPreview(model),
-            ),
-          const SizedBox(width: 4),
-          _buildComposerActionButton(model),
         ],
       ),
     );
   }
 
-  Widget _buildComposerActionButton(FileTransferModel model) {
+  Widget _buildComposerActionButton(
+    FileTransferModel model, {
+    required bool canSubmit,
+  }) {
     if (model.isPreparingSend) {
       return Container(
         width: 42,
@@ -1010,6 +1079,18 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       );
     }
 
+    if (_isAiGenerating) {
+      return IconButton(
+        tooltip: '停止生成',
+        icon: const Icon(Icons.stop, color: Colors.white, size: 21),
+        onPressed: _stopAiGeneration,
+        style: IconButton.styleFrom(
+          backgroundColor: Colors.red.shade600,
+          fixedSize: const Size(42, 42),
+        ),
+      );
+    }
+
     if (model.isTransferring) {
       return IconButton(
         tooltip: '停止发送',
@@ -1023,11 +1104,18 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     }
 
     return IconButton(
-      tooltip: '开始发送',
-      icon: const Icon(Icons.arrow_upward, color: Colors.black, size: 22),
-      onPressed: () => _startSending(model),
+      tooltip: _isDharmaComposerMode ? '开始法布施' : '发送消息',
+      icon: Icon(
+        Icons.arrow_upward,
+        color: canSubmit ? Colors.black : Colors.white54,
+        size: 22,
+      ),
+      onPressed: canSubmit ? () => _submitComposer(model) : null,
       style: IconButton.styleFrom(
-        backgroundColor: Colors.white,
+        backgroundColor: canSubmit
+            ? Colors.white
+            : Colors.white.withValues(alpha: 0.1),
+        disabledBackgroundColor: Colors.white.withValues(alpha: 0.1),
         fixedSize: const Size(42, 42),
       ),
     );
@@ -1060,40 +1148,18 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       constraints: const BoxConstraints(minWidth: 260, maxWidth: 320),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
       items: [
-        _sendMenuItem('files', Icons.attach_file, '添加照片和文件', '选择手机或电脑中的本机文件'),
-        _sendMenuItem('assets', Icons.inventory_2, '内置素材', '从素材库选择要发送的内容'),
-        _sendMenuItem('link', Icons.link, '输入链接', '读取链接正文后发送'),
-        _sendMenuItem('text', Icons.edit_note, '输入文本', '发送手输或粘贴的文本'),
         _sendMenuItem(
-          'buddha',
+          'dharma',
           Icons.self_improvement,
-          '禅室佛像素材',
-          '发送禅室当前佛像模型素材',
+          '全球法布施',
+          _isDharmaComposerMode ? '已选择，可在输入框上方调整' : '默认全球发送',
         ),
-        if (model.linkHistory.isNotEmpty) ...[
-          const PopupMenuDivider(),
-          const PopupMenuItem<String>(
-            enabled: false,
-            height: 28,
-            child: Text(
-              '最近链接',
-              style: TextStyle(
-                color: Colors.white54,
-                fontSize: 12,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-          ),
-          ...model.linkHistory.take(5).toList().asMap().entries.map((entry) {
-            final history = entry.value;
-            return _sendMenuItem(
-              'history:${entry.key}',
-              Icons.history,
-              history.title.isEmpty ? history.url : history.title,
-              history.preview.isEmpty ? history.url : history.preview,
-            );
-          }),
-        ],
+        _sendMenuItem(
+          'files',
+          Icons.add_photo_alternate,
+          '添加图片和文件',
+          '选择本机图片或文件',
+        ),
       ],
     );
 
@@ -1118,28 +1184,423 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     FileTransferModel model,
     String action,
   ) async {
+    if (action == 'dharma') {
+      _activateDharmaMode(model);
+      return true;
+    }
     if (action == 'files') {
-      return await model.selectFiles(replaceExisting: true);
-    }
-    if (action == 'assets') {
-      await model.selectBuiltInAssets(context);
-      return model.hasFiles;
-    }
-    if (action == 'link') {
-      return await _inputSendLink(model);
-    }
-    if (action == 'text') {
-      return await _inputSendText(model);
-    }
-    if (action == 'buddha') {
-      return await _selectBuddhaAsset(model);
-    }
-    if (action.startsWith('history:')) {
-      final index = int.tryParse(action.substring('history:'.length));
-      if (index == null || index >= model.linkHistory.length) return false;
-      return await _selectLinkHistory(model, model.linkHistory[index]);
+      _activateDharmaMode(model);
+      final selected = await model.selectFiles(replaceExisting: true);
+      if (selected && mounted) setState(() {});
+      return selected;
     }
     return false;
+  }
+
+  void _submitComposer(FileTransferModel model) {
+    if (_isDharmaComposerMode) {
+      _startSending(model);
+    } else {
+      _sendAiChatFromComposer();
+    }
+  }
+
+  void _activateDharmaMode(FileTransferModel model) {
+    if (model.countryList.isEmpty) {
+      model.setCountryList(['ALL']);
+    }
+    if (!model.isGlobalSendEnabled &&
+        !model.isFieldEnergyMode &&
+        !model.isLocalLoopbackEnabled) {
+      model.setGlobalSendEnabled(true);
+      model.setCountryList(['ALL']);
+    }
+    setState(() {
+      _isDharmaComposerMode = true;
+    });
+  }
+
+  void _clearDharmaMode(FileTransferModel model) {
+    _chatInputController.clear();
+    model.clearFiles();
+    setState(() {
+      _isDharmaComposerMode = false;
+    });
+  }
+
+  String _regionSummary(FileTransferModel model) {
+    final labels = <String>[];
+
+    if (model.isGlobalSendEnabled && model.countryList.isNotEmpty) {
+      if (model.countryList.contains('ALL')) {
+        labels.add('全球');
+      } else {
+        final countryNames = model.countryList
+            .where(country_catalog.GLOBAL_COUNTRY_SERVERS.containsKey)
+            .map(_countryName)
+            .toList();
+        if (countryNames.length <= 2) {
+          labels.add(countryNames.join('、'));
+        } else if (countryNames.isNotEmpty) {
+          labels.add('${countryNames.length} 个国家');
+        }
+      }
+    }
+
+    if (model.isFieldEnergyMode) labels.add('本地场能');
+    if (model.isLocalLoopbackEnabled) labels.add('本地转经轮');
+
+    return labels.isEmpty ? '未选择' : labels.join('、');
+  }
+
+  String _countryName(String code) {
+    return country_catalog.COUNTRY_NAMES[code] ?? code;
+  }
+
+  List<MapEntry<String, String>> get _countryOptions {
+    final entries = country_catalog.GLOBAL_COUNTRY_SERVERS.keys
+        .map((code) => MapEntry(code, _countryName(code)))
+        .toList();
+    entries.sort((a, b) => a.value.compareTo(b.value));
+    return entries;
+  }
+
+  Future<void> _showRegionSelector(FileTransferModel model) async {
+    final authModel = Provider.of<AuthModel?>(context, listen: false);
+    final hasPremiumAccess = authModel?.hasPermission('premium') ?? false;
+    final selectedCodes = model.countryList.toSet();
+    var localField = model.isFieldEnergyMode;
+    var localLoopback = hasPremiumAccess && model.isLocalLoopbackEnabled;
+    var query = '';
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (sheetContext, setSheetState) {
+            final normalizedQuery = query.trim().toLowerCase();
+            final countries = _countryOptions.where((entry) {
+              if (normalizedQuery.isEmpty) return true;
+              return entry.key.toLowerCase().contains(normalizedQuery) ||
+                  entry.value.toLowerCase().contains(normalizedQuery);
+            }).toList();
+            final canApply =
+                selectedCodes.isNotEmpty || localField || localLoopback;
+
+            return SafeArea(
+              top: false,
+              child: Container(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(sheetContext).size.height * 0.82,
+                ),
+                padding: const EdgeInsets.fromLTRB(18, 10, 18, 18),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF202020),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 42,
+                      height: 4,
+                      margin: const EdgeInsets.only(bottom: 14),
+                      decoration: BoxDecoration(
+                        color: Colors.white24,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                    ),
+                    Row(
+                      children: [
+                        const Expanded(
+                          child: Text(
+                            '地区',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 20,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(sheetContext),
+                          child: const Text('取消'),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      onChanged: (value) {
+                        setSheetState(() => query = value);
+                      },
+                      style: const TextStyle(color: Colors.white),
+                      cursorColor: AppTheme.primaryColor,
+                      decoration: InputDecoration(
+                        isDense: true,
+                        prefixIcon: const Icon(
+                          Icons.search,
+                          color: Colors.white54,
+                        ),
+                        hintText: '搜索国家或代码',
+                        hintStyle: const TextStyle(color: Colors.white38),
+                        filled: true,
+                        fillColor: Colors.white.withValues(alpha: 0.08),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(14),
+                          borderSide: BorderSide.none,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Expanded(
+                      child: ListView(
+                        children: [
+                          _RegionCheckTile(
+                            icon: Icons.public,
+                            title: '全球',
+                            subtitle: '全部国家发送',
+                            selected: selectedCodes.contains('ALL'),
+                            onChanged: (selected) {
+                              setSheetState(() {
+                                if (selected) {
+                                  selectedCodes
+                                    ..clear()
+                                    ..add('ALL');
+                                } else {
+                                  selectedCodes.remove('ALL');
+                                }
+                              });
+                            },
+                          ),
+                          _RegionCheckTile(
+                            icon: Icons.wifi_tethering,
+                            title: '本地场能',
+                            subtitle: '通过本机热点向周围广播',
+                            selected: localField,
+                            onChanged: (selected) {
+                              setSheetState(() => localField = selected);
+                            },
+                          ),
+                          _RegionCheckTile(
+                            icon: hasPremiumAccess
+                                ? Icons.sync_alt
+                                : Icons.lock_outline,
+                            title: '本地转经轮',
+                            subtitle: hasPremiumAccess
+                                ? '本地回环独立运行'
+                                : '会员可开启本地回环',
+                            selected: localLoopback,
+                            onChanged: (selected) {
+                              if (selected && !hasPremiumAccess) {
+                                _showLoopbackMembershipPrompt();
+                                return;
+                              }
+                              setSheetState(() => localLoopback = selected);
+                            },
+                          ),
+                          const Divider(color: Colors.white12, height: 18),
+                          ...countries.map(
+                            (entry) => _RegionCheckTile(
+                              title: '${entry.value} ${entry.key}',
+                              subtitle: '国家发送节点',
+                              selected: selectedCodes.contains(entry.key),
+                              onChanged: (selected) {
+                                setSheetState(() {
+                                  selectedCodes.remove('ALL');
+                                  if (selected) {
+                                    selectedCodes.add(entry.key);
+                                  } else {
+                                    selectedCodes.remove(entry.key);
+                                  }
+                                });
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: canApply
+                            ? () async {
+                                final finalCodes = selectedCodes.toList();
+                                model.setCountryList(finalCodes);
+                                model.setGlobalSendEnabled(
+                                  finalCodes.isNotEmpty,
+                                );
+                                await model.setFieldEnergyMode(localField);
+                                await _setLocalLoopbackEnabled(
+                                  model,
+                                  localLoopback,
+                                );
+                                if (!sheetContext.mounted) return;
+                                Navigator.pop(sheetContext);
+
+                                if (!mounted) return;
+                                if (model.needsHotspotGuide) {
+                                  _showHotspotGuideDialog(context);
+                                  model.clearHotspotGuide();
+                                }
+                                setState(() {});
+                              }
+                            : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppTheme.primaryColor,
+                          foregroundColor: Colors.black,
+                          disabledBackgroundColor: Colors.white12,
+                          minimumSize: const Size.fromHeight(46),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(14),
+                          ),
+                        ),
+                        child: const Text('完成'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _sendAiChatFromComposer() async {
+    final text = _chatInputController.text.trim();
+    if (text.isEmpty || _isAiGenerating) return;
+
+    HapticFeedback.lightImpact();
+    await _aiStreamSubscription?.cancel();
+    _aiStreamSubscription = null;
+    _chatInputController.clear();
+    setState(() {
+      _homeChatMessages.add(_HomeChatMessage(text: text, isUser: true));
+      _isAiGenerating = true;
+      _streamingAiText = '';
+    });
+    _scrollHomeChatToBottom();
+
+    try {
+      if (kIsWeb) {
+        throw UnsupportedError('Web 平台暂不支持本地 AI 对话');
+      }
+      final selectedModel = _selectedChatModel;
+      if (selectedModel == null ||
+          !_availableChatModels.contains(selectedModel)) {
+        throw StateError('请先在 AI 页面下载并选择一个本地模型');
+      }
+
+      final inferenceService = LLMInferenceService.instance;
+      final modelPath = await LLMModelManager.instance.getModelPath(
+        selectedModel,
+      );
+      if (!inferenceService.isInitialized ||
+          inferenceService.modelPath != modelPath) {
+        await inferenceService.initialize(modelPath);
+      }
+
+      final stream = inferenceService.generateStream(_buildHomeAiPrompt(text));
+      _aiStreamSubscription = stream.listen(
+        (token) {
+          if (!mounted) return;
+          setState(() {
+            _streamingAiText += token;
+          });
+          _scrollHomeChatToBottom();
+        },
+        onDone: () {
+          if (!mounted) return;
+          setState(() {
+            if (_streamingAiText.trim().isNotEmpty) {
+              _homeChatMessages.add(
+                _HomeChatMessage(text: _streamingAiText, isUser: false),
+              );
+            }
+            _streamingAiText = '';
+            _isAiGenerating = false;
+          });
+          _scrollHomeChatToBottom();
+        },
+        onError: (error) {
+          if (!mounted) return;
+          setState(() {
+            _homeChatMessages.add(
+              _HomeChatMessage(
+                text: '生成失败: $error',
+                isUser: false,
+                isError: true,
+              ),
+            );
+            _streamingAiText = '';
+            _isAiGenerating = false;
+          });
+          _scrollHomeChatToBottom();
+        },
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _homeChatMessages.add(
+          _HomeChatMessage(text: '生成失败: $e', isUser: false, isError: true),
+        );
+        _streamingAiText = '';
+        _isAiGenerating = false;
+      });
+      _scrollHomeChatToBottom();
+    }
+  }
+
+  String _buildHomeAiPrompt(String question) {
+    final previousMessages = _homeChatMessages.length > 1
+        ? _homeChatMessages.take(_homeChatMessages.length - 1)
+        : const Iterable<_HomeChatMessage>.empty();
+    final recent = previousMessages
+        .toList()
+        .reversed
+        .take(6)
+        .toList()
+        .reversed
+        .map((message) => '${message.isUser ? "用户" : "AI"}: ${message.text}')
+        .join('\n');
+
+    return [
+      '你是法布施应用首页里的 AI 助手。回答要简洁、直接、友善。',
+      if (recent.isNotEmpty) '最近对话:\n$recent',
+      '用户: $question',
+      'AI:',
+    ].join('\n\n');
+  }
+
+  void _stopAiGeneration() {
+    _aiStreamSubscription?.cancel();
+    _aiStreamSubscription = null;
+    unawaited(LLMInferenceService.instance.stopGeneration());
+    if (!mounted) return;
+    setState(() {
+      if (_streamingAiText.trim().isNotEmpty) {
+        _homeChatMessages.add(
+          _HomeChatMessage(text: _streamingAiText, isUser: false),
+        );
+      }
+      _streamingAiText = '';
+      _isAiGenerating = false;
+    });
+  }
+
+  void _scrollHomeChatToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_homeChatScrollController.hasClients) return;
+      _homeChatScrollController.animateTo(
+        _homeChatScrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOut,
+      );
+    });
   }
 
   Future<void> _setLocalLoopbackEnabled(
@@ -1329,113 +1790,6 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         ],
       ),
     );
-  }
-
-  Future<bool> _inputSendText(FileTransferModel model) async {
-    final titleController = TextEditingController();
-    final textController = TextEditingController();
-    final result = await showDialog<Map<String, String>>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('输入发送文本'),
-        content: SizedBox(
-          width: 420,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: titleController,
-                decoration: const InputDecoration(labelText: '标题'),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: textController,
-                minLines: 6,
-                maxLines: 10,
-                decoration: const InputDecoration(
-                  hintText: '输入或粘贴要发送的内容',
-                  border: OutlineInputBorder(),
-                ),
-              ),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('取消'),
-          ),
-          ElevatedButton(
-            onPressed: () => Navigator.pop(context, {
-              'title': titleController.text.trim(),
-              'text': textController.text.trim(),
-            }),
-            child: const Text('确定'),
-          ),
-        ],
-      ),
-    );
-    if (result == null || (result['text'] ?? '').trim().isEmpty) return false;
-    await model.addTextContentForSending(
-      title: result['title'] ?? '',
-      text: result['text'] ?? '',
-    );
-    return true;
-  }
-
-  Future<bool> _inputSendLink(FileTransferModel model) async {
-    final controller = TextEditingController();
-    final url = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('输入链接'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          keyboardType: TextInputType.url,
-          decoration: const InputDecoration(hintText: 'https://...'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('取消'),
-          ),
-          ElevatedButton(
-            onPressed: () => Navigator.pop(context, controller.text.trim()),
-            child: const Text('读取'),
-          ),
-        ],
-      ),
-    );
-    if (url == null || url.isEmpty) return false;
-    try {
-      await model.addUrlContentForSending(url);
-      return true;
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('链接读取失败: $e'), backgroundColor: Colors.red),
-        );
-      }
-      return false;
-    }
-  }
-
-  Future<bool> _selectLinkHistory(
-    FileTransferModel model,
-    LinkSendHistoryEntry entry,
-  ) async {
-    try {
-      await model.addUrlContentForSending(entry.url);
-      return true;
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('历史链接读取失败: $e'), backgroundColor: Colors.red),
-        );
-      }
-      return false;
-    }
   }
 
   Future<void> _showSelectedContentPreview(FileTransferModel model) async {
@@ -1736,25 +2090,48 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         model.currentSendingScripture == AppConfig.zenBuddhaAssetDisplayName;
   }
 
-  Future<bool> _selectBuddhaAsset(FileTransferModel model) async {
-    try {
-      final unlocked = await _ensureBuddhaAssetUnlocked();
-      if (!unlocked) return false;
-
-      await model.addZenBuddhaAssetForSending();
-      return true;
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('佛像素材准备失败: $e'), backgroundColor: Colors.red),
-        );
-      }
-      return false;
-    }
+  bool _looksLikeHttpUrl(String text) {
+    final uri = Uri.tryParse(text.trim());
+    return uri != null && (uri.scheme == 'http' || uri.scheme == 'https');
   }
 
   void _startSending(FileTransferModel model) async {
     if (model.isPreparingSend || model.isTransferring) return;
+
+    final composerText = _chatInputController.text.trim();
+    if (composerText.isNotEmpty) {
+      try {
+        if (_looksLikeHttpUrl(composerText)) {
+          await model.addUrlContentForSending(composerText);
+        } else {
+          await model.addTextContentForSending(
+            title: '法布施',
+            text: composerText,
+            sourceKind: '文本',
+          );
+        }
+        _chatInputController.clear();
+        if (mounted) setState(() {});
+      } catch (e) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('内容准备失败: $e'), backgroundColor: Colors.red),
+        );
+        return;
+      }
+    }
+
+    if (!mounted) return;
+
+    if (model.isLocalLoopbackEnabled) {
+      final authModel = Provider.of<AuthModel?>(context, listen: false);
+      final hasPremiumAccess = authModel?.hasPermission('premium') ?? false;
+      if (!hasPremiumAccess) {
+        model.setLocalLoopbackEnabled(false);
+        _showLoopbackMembershipPrompt();
+        return;
+      }
+    }
 
     if (model.hasFiles && _isBuddhaAssetSelected(model)) {
       final unlocked = await _ensureBuddhaAssetUnlocked();
@@ -1769,7 +2146,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     if (!model.hasFiles) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('请先点击 + 选择链接、文本、文件或素材。'),
+          content: Text('请输入要法布施的文字或链接，或点 + 添加图片。'),
           backgroundColor: Colors.black87,
         ),
       );
@@ -1789,9 +2166,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('🌍 开始把所选内容发送到全部国家...'),
-          duration: Duration(seconds: 2),
+        SnackBar(
+          content: Text('🌍 开始法布施到${_regionSummary(model)}...'),
+          duration: const Duration(seconds: 2),
           backgroundColor: Colors.black87,
         ),
       );
@@ -1826,6 +2203,14 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           duration: Duration(seconds: 2),
         ),
       );
+    } else if (model.isTransferring) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('本地模块运行中，可点击停止结束。'),
+          backgroundColor: Colors.black87,
+          duration: Duration(seconds: 2),
+        ),
+      );
     }
   }
 
@@ -1850,89 +2235,178 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   }
 }
 
-class _ModuleSwitchTile extends StatelessWidget {
+class _ComposerChip extends StatelessWidget {
   final IconData icon;
-  final String title;
-  final String subtitle;
-  final bool value;
-  final bool enabled;
-  final bool locked;
-  final Color? activeColor;
-  final ValueChanged<bool> onChanged;
+  final String label;
+  final bool active;
+  final VoidCallback? onTap;
+  final VoidCallback? onRemove;
 
-  const _ModuleSwitchTile({
+  const _ComposerChip({
     required this.icon,
-    required this.title,
-    required this.subtitle,
-    required this.value,
-    required this.onChanged,
-    this.enabled = true,
-    this.locked = false,
-    this.activeColor,
+    required this.label,
+    this.active = false,
+    this.onTap,
+    this.onRemove,
   });
 
   @override
   Widget build(BuildContext context) {
-    final effectiveColor = activeColor ?? AppTheme.primaryColor;
-    final isActive = value && enabled;
-    final foreground = isActive ? effectiveColor : Colors.white70;
+    final foreground = active ? AppTheme.primaryColor : Colors.white70;
 
-    return Container(
-      constraints: const BoxConstraints(minHeight: 58),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: isActive
-            ? effectiveColor.withValues(alpha: 0.16)
-            : Colors.white.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-          color: isActive
-              ? effectiveColor.withValues(alpha: 0.42)
-              : Colors.white.withValues(alpha: 0.08),
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 230, minHeight: 34),
+        padding: EdgeInsets.only(
+          left: 10,
+          right: onRemove == null ? 12 : 8,
+          top: 6,
+          bottom: 6,
         ),
-      ),
-      child: Row(
-        children: [
-          Icon(locked ? Icons.lock_outline : icon, color: foreground, size: 20),
-          const SizedBox(width: 9),
-          Expanded(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: TextStyle(
-                    color: foreground,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w700,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  subtitle,
-                  style: const TextStyle(color: Colors.white54, fontSize: 10),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
+        decoration: BoxDecoration(
+          color: active
+              ? AppTheme.primaryColor.withValues(alpha: 0.14)
+              : Colors.white.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: active
+                ? AppTheme.primaryColor.withValues(alpha: 0.38)
+                : Colors.white.withValues(alpha: 0.1),
           ),
-          Transform.scale(
-            scale: 0.78,
-            child: Switch(
-              value: value,
-              onChanged: enabled ? onChanged : null,
-              activeThumbColor: effectiveColor,
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: foreground, size: 18),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                label,
+                style: TextStyle(
+                  color: foreground,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
-          ),
-        ],
+            if (onRemove != null) ...[
+              const SizedBox(width: 4),
+              GestureDetector(
+                onTap: onRemove,
+                behavior: HitTestBehavior.opaque,
+                child: Icon(Icons.close, color: foreground, size: 17),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }
+}
+
+class _RegionCheckTile extends StatelessWidget {
+  final IconData? icon;
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final ValueChanged<bool> onChanged;
+
+  const _RegionCheckTile({
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.onChanged,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: () => onChanged(!selected),
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 58),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: selected
+                ? AppTheme.primaryColor.withValues(alpha: 0.14)
+                : Colors.white.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: selected
+                  ? AppTheme.primaryColor.withValues(alpha: 0.38)
+                  : Colors.white.withValues(alpha: 0.08),
+            ),
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(
+                  icon,
+                  color: selected ? AppTheme.primaryColor : Colors.white70,
+                  size: 21,
+                ),
+                const SizedBox(width: 10),
+              ],
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: const TextStyle(
+                        color: Colors.white54,
+                        fontSize: 11,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              Checkbox(
+                value: selected,
+                onChanged: (value) => onChanged(value ?? false),
+                activeColor: AppTheme.primaryColor,
+                checkColor: Colors.black,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeChatMessage {
+  final String text;
+  final bool isUser;
+  final bool isError;
+
+  const _HomeChatMessage({
+    required this.text,
+    required this.isUser,
+    this.isError = false,
+  });
 }
 
 class _SendMenuRow extends StatelessWidget {

--- a/fabushi/lib/services/platform_global_send_service.dart
+++ b/fabushi/lib/services/platform_global_send_service.dart
@@ -106,6 +106,7 @@ class PlatformGlobalSendService {
   Future<void> startSending({
     required List<PlatformFile> files,
     required bool isLoop,
+    List<String>? countryCodes,
   }) async {
     if (!_isInitialized) {
       onLog('⚠️ 服务未初始化，正在初始化...');
@@ -113,9 +114,17 @@ class PlatformGlobalSendService {
     }
 
     if (kIsWeb) {
-      await _httpService?.startSending(files: files, isLoop: isLoop);
+      await _httpService?.startSending(
+        files: files,
+        isLoop: isLoop,
+        countryCodes: countryCodes,
+      );
     } else {
-      await _udpService?.startSending(files: files, isLoop: isLoop);
+      await _udpService?.startSending(
+        files: files,
+        isLoop: isLoop,
+        countryCodes: countryCodes,
+      );
     }
   }
 

--- a/fabushi/lib/services/real_global_send_service.dart
+++ b/fabushi/lib/services/real_global_send_service.dart
@@ -84,6 +84,7 @@ class RealGlobalSendService {
   Future<void> startSending({
     required List<PlatformFile> files,
     required bool isLoop,
+    List<String>? countryCodes,
   }) async {
     if (_isRunning) return;
 
@@ -92,6 +93,8 @@ class RealGlobalSendService {
     _dataSentInMB = 0.0;
 
     try {
+      final targetCountryCodes = _resolveTargetCountryCodes(countryCodes);
+      _totalCountries = targetCountryCodes.length;
       onLog('🚀 开始真实全球发送 - 文件数量: ${files.length}, 目标国家: $_totalCountries 个');
 
       _loopCount = 0; // 重置轮次计数
@@ -114,7 +117,10 @@ class RealGlobalSendService {
           // 关键修复：在处理每个文件前让出主线程控制权
           await Future.delayed(Duration.zero);
 
-          final countriesSent = await _sendFileToAllCountries(file);
+          final countriesSent = await _sendFileToAllCountries(
+            file,
+            targetCountryCodes,
+          );
 
           final fileSizeMB = file.size / (1024 * 1024);
           _dataSentInMB += fileSizeMB * countriesSent;
@@ -135,11 +141,13 @@ class RealGlobalSendService {
     }
   }
 
-  Future<int> _sendFileToAllCountries(PlatformFile file) async {
+  Future<int> _sendFileToAllCountries(
+    PlatformFile file,
+    List<String> countryCodes,
+  ) async {
     final scriptureTitle = _displayScriptureName(file.name);
     onLog('📤 准备发送《$scriptureTitle》: ${file.name}');
 
-    final countryCodes = globalCountryServers.keys.toList();
     int successCount = 0;
     int failCount = 0;
 
@@ -259,6 +267,20 @@ class RealGlobalSendService {
 
     onLog('✅ 文件《$scriptureTitle》发送完成 - 成功: $successCount, 失败: $failCount');
     return successCount; // 返回成功发送的国家数
+  }
+
+  List<String> _resolveTargetCountryCodes(List<String>? requestedCodes) {
+    if (requestedCodes == null ||
+        requestedCodes.isEmpty ||
+        requestedCodes.contains('ALL')) {
+      return globalCountryServers.keys.toList();
+    }
+
+    final available = globalCountryServers.keys.toSet();
+    return requestedCodes
+        .where((code) => available.contains(code))
+        .toSet()
+        .toList();
   }
 
   /// 发送文件到服务器

--- a/fabushi/lib/services/udp_global_send_service.dart
+++ b/fabushi/lib/services/udp_global_send_service.dart
@@ -102,6 +102,7 @@ class UDPGlobalSendService {
   Future<void> startSending({
     required List<PlatformFile> files,
     required bool isLoop,
+    List<String>? countryCodes,
   }) async {
     if (_isRunning) return;
 
@@ -116,9 +117,9 @@ class UDPGlobalSendService {
       socket = await RawDatagramSocket.bind(InternetAddress.anyIPv4, 0);
       onLog('🚀 UDP Socket 已创建，本地端口: ${socket.port}');
 
-      final countryCodes = _geoIPService.getAllCountryCodes();
+      final targetCountryCodes = _resolveTargetCountryCodes(countryCodes);
       onLog(
-        '📤 开始 UDP 全球发送 - 文件数: ${files.length}, 目标国家: ${countryCodes.length}',
+        '📤 开始 UDP 全球发送 - 文件数: ${files.length}, 目标国家: ${targetCountryCodes.length}',
       );
 
       _loopCount = 0; // 重置轮次计数
@@ -156,7 +157,7 @@ class UDPGlobalSendService {
             final countriesSent = await _sendLargeFileToAllCountries(
               socket,
               file,
-              countryCodes,
+              targetCountryCodes,
             );
 
             final fileSizeMB = file.size / (1024 * 1024);
@@ -188,7 +189,7 @@ class UDPGlobalSendService {
             file.name,
             fileBytes,
             file.size,
-            countryCodes,
+            targetCountryCodes,
           );
 
           final fileSizeMB = file.size / (1024 * 1024);
@@ -210,6 +211,21 @@ class UDPGlobalSendService {
       _isRunning = false;
       onStopped();
     }
+  }
+
+  List<String> _resolveTargetCountryCodes(List<String>? requestedCodes) {
+    final allCountryCodes = _geoIPService.getAllCountryCodes();
+    if (requestedCodes == null ||
+        requestedCodes.isEmpty ||
+        requestedCodes.contains('ALL')) {
+      return allCountryCodes;
+    }
+
+    final available = allCountryCodes.toSet();
+    return requestedCodes
+        .where((code) => available.contains(code))
+        .toSet()
+        .toList();
   }
 
   Future<int> _sendFileToAllCountriesWithBytes(


### PR DESCRIPTION
## Summary
- Reworked the home composer so the `+` menu only exposes Global Dharma mode and image/file selection.
- Shows removable Dharma, region, loop, and selected image/file chips above the input after Dharma mode is selected.
- Sends chat input as the source of truth: http/https input is read as link content, plain text is sent as text, and selected images/files are sent when the input is empty.
- Added remembered region/loop/local module preferences and wired selected country lists through HTTP/UDP global sending.

## Validation
- `dart format fabushi/lib/screens/globe_home_screen.dart fabushi/lib/models/file_transfer_model.dart fabushi/lib/services/platform_global_send_service.dart fabushi/lib/services/real_global_send_service.dart fabushi/lib/services/udp_global_send_service.dart`
- `flutter analyze lib/screens/globe_home_screen.dart lib/models/file_transfer_model.dart lib/services/platform_global_send_service.dart lib/services/real_global_send_service.dart lib/services/udp_global_send_service.dart`
- `git diff --check`