### PR TITLE
fix: keep 3D Buddha download progress visible

### DIFF
--- a/fabushi/lib/screens/buddha_model_screen_native.dart
+++ b/fabushi/lib/screens/buddha_model_screen_native.dart
@@ -10,6 +10,7 @@ import 'package:vector_math/vector_math.dart' as vector;
 
 import '../services/asset_loader_service.dart';
 import '../utils/model_auto_fit.dart';
+import '../widgets/buddha_model_loading_overlay.dart';
 
 enum _BuddhaRendererPath { flutterScenePrimary }
 
@@ -483,90 +484,16 @@ class BuddhaModelScreenState extends State<BuddhaModelScreen>
                 ),
               if (_isLoading)
                 Positioned.fill(
-                  child: Container(
-                    color: const Color(0xCC0B0E14),
-                    child: Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const CircularProgressIndicator(
-                            color: Color(0xFFFFD700),
-                          ),
-                          const SizedBox(height: 16),
-                          Text(
-                            _loadingLabel,
-                            style: const TextStyle(
-                              color: Color(0xFFFFD700),
-                              fontSize: 14,
-                              letterSpacing: 1.0,
-                            ),
-                          ),
-                          if (_loadingProgress > 0)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 8),
-                              child: Text(
-                                '${(_loadingProgress * 100).toInt()}%',
-                                style: const TextStyle(
-                                  color: Colors.white70,
-                                  fontSize: 12,
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
+                  child: BuddhaModelLoadingOverlay.loading(
+                    progress: _loadingProgress,
+                    label: _loadingLabel,
                   ),
                 ),
               if (_loadFailed && !_isLoading)
                 Positioned.fill(
-                  child: Container(
-                    color: const Color(0xD90B0E14),
-                    child: Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(
-                            Icons.error_outline,
-                            color: Colors.white54,
-                            size: 48,
-                          ),
-                          const SizedBox(height: 16),
-                          const Text(
-                            '禅境展现遇到阻碍',
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              color: Colors.white70,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 340),
-                            child: Text(
-                              _loadFailureDetails,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                color: Colors.white54,
-                                fontSize: 12,
-                                height: 1.35,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(height: 24),
-                          OutlinedButton(
-                            style: OutlinedButton.styleFrom(
-                              foregroundColor: const Color(0xFFFFD700),
-                              side: const BorderSide(color: Color(0xFFFFD700)),
-                            ),
-                            onPressed: () {
-                              unawaited(_startFlutterScenePrimary());
-                            },
-                            child: const Text('静心重试'),
-                          ),
-                        ],
-                      ),
-                    ),
+                  child: BuddhaModelLoadingOverlay.failed(
+                    failureDetails: _loadFailureDetails,
+                    onRetry: () => unawaited(_startFlutterScenePrimary()),
                   ),
                 ),
             ],

--- a/fabushi/lib/widgets/buddha_model_loading_overlay.dart
+++ b/fabushi/lib/widgets/buddha_model_loading_overlay.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+
+class BuddhaModelLoadingOverlay extends StatelessWidget {
+  final bool isLoading;
+  final double progress;
+  final String label;
+  final String? failureDetails;
+  final VoidCallback? onRetry;
+
+  const BuddhaModelLoadingOverlay.loading({
+    super.key,
+    required this.progress,
+    required this.label,
+  }) : isLoading = true,
+       failureDetails = null,
+       onRetry = null;
+
+  const BuddhaModelLoadingOverlay.failed({
+    super.key,
+    required this.failureDetails,
+    required this.onRetry,
+  }) : isLoading = false,
+       progress = 0.0,
+       label = '3D佛像下载失败';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: const Color(0xE60B0E14),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 360),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: const Color(0xD91A1620),
+                border: Border.all(color: const Color(0x99D4AF37)),
+                borderRadius: BorderRadius.circular(20),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Color(0x99000000),
+                    blurRadius: 24,
+                    offset: Offset(0, 12),
+                  ),
+                ],
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: isLoading ? _buildLoading() : _buildFailed(context),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoading() {
+    final normalizedProgress = progress.clamp(0.0, 1.0).toDouble();
+    final hasProgress = normalizedProgress > 0;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(
+          width: 40,
+          height: 40,
+          child: CircularProgressIndicator(
+            color: Color(0xFFFFD700),
+            strokeWidth: 3,
+          ),
+        ),
+        const SizedBox(height: 18),
+        Text(
+          label,
+          textAlign: TextAlign.center,
+          style: const TextStyle(
+            color: Color(0xFFFFD700),
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        LinearProgressIndicator(
+          value: hasProgress ? normalizedProgress : null,
+          minHeight: 8,
+          backgroundColor: const Color(0x44FFFFFF),
+          valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFFFFD700)),
+        ),
+        const SizedBox(height: 10),
+        Text(
+          hasProgress
+              ? '下载进度 ${(normalizedProgress * 100).toStringAsFixed(0)}%'
+              : '正在连接下载源...',
+          textAlign: TextAlign.center,
+          style: const TextStyle(color: Colors.white70, fontSize: 13),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFailed(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.error_outline, color: Colors.white70, size: 48),
+        const SizedBox(height: 16),
+        const Text(
+          '3D佛像下载失败',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 17,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Text(
+          failureDetails ?? '网络或模型文件校验失败，请稍后重试。',
+          textAlign: TextAlign.center,
+          style: const TextStyle(
+            color: Colors.white60,
+            fontSize: 12,
+            height: 1.4,
+          ),
+        ),
+        const SizedBox(height: 22),
+        FilledButton.icon(
+          onPressed: onRetry,
+          icon: const Icon(Icons.refresh),
+          label: const Text('重试'),
+          style: FilledButton.styleFrom(
+            backgroundColor: const Color(0xFFD4AF37),
+            foregroundColor: Colors.black,
+            padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 12),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/fabushi/lib/widgets/meditation_room_3d_widget.dart
+++ b/fabushi/lib/widgets/meditation_room_3d_widget.dart
@@ -175,10 +175,6 @@ class _MeditationRoom3DWidgetState extends State<MeditationRoom3DWidget>
       ),
       child: Stack(
         children: [
-          if (kIsWeb)
-            Center(
-              child: SizedBox(width: 400, height: 500, child: Buddha3DWidget()),
-            ),
           GestureDetector(
             onTapUp: (details) {
               final size = MediaQuery.of(context).size;
@@ -215,6 +211,10 @@ class _MeditationRoom3DWidgetState extends State<MeditationRoom3DWidget>
               },
             ),
           ),
+          if (kIsWeb)
+            const Center(
+              child: SizedBox(width: 400, height: 500, child: Buddha3DWidget()),
+            ),
           Positioned(
             top: 20,
             left: 0,

--- a/fabushi/test/unit/widgets/buddha_model_loading_overlay_test.dart
+++ b/fabushi/test/unit/widgets/buddha_model_loading_overlay_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/widgets/buddha_model_loading_overlay.dart';
+
+void main() {
+  group('BuddhaModelLoadingOverlay', () {
+    testWidgets('shows model download progress', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: BuddhaModelLoadingOverlay.loading(
+            progress: 0.42,
+            label: '正在安奉佛像...',
+          ),
+        ),
+      );
+
+      expect(find.text('正在安奉佛像...'), findsOneWidget);
+      expect(find.text('下载进度 42%'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('keeps retry action visible and tappable on failure', (
+      tester,
+    ) async {
+      var retryCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BuddhaModelLoadingOverlay.failed(
+            failureDetails: '网络连接失败',
+            onRetry: () => retryCount++,
+          ),
+        ),
+      );
+
+      expect(find.text('3D佛像下载失败'), findsOneWidget);
+      expect(find.text('网络连接失败'), findsOneWidget);
+      expect(find.text('重试'), findsOneWidget);
+
+      await tester.tap(find.text('重试'));
+      expect(retryCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated 3D Buddha loading overlay with a visible progress bar and retry button
- use the overlay for native Buddha model loading and failure states
- move the legacy 3D meditation Buddha layer above the scripture painting layer so loading feedback is not covered

## Tests
- `/opt/homebrew/Caskroom/flutter/3.32.8/flutter/bin/flutter test test/unit/widgets/buddha_model_loading_overlay_test.dart test/unit/widgets/scene_render_mode_test.dart`
- `/opt/homebrew/Caskroom/flutter/3.32.8/flutter/bin/dart analyze lib/screens/buddha_model_screen_native.dart lib/widgets/buddha_model_loading_overlay.dart lib/widgets/meditation_room_3d_widget.dart test/unit/widgets/buddha_model_loading_overlay_test.dart` (passes with existing info-level lints in legacy `meditation_room_3d_widget.dart`)

## Notes
- Full `flutter analyze` still fails on pre-existing repository issues such as missing `drift` imports and the checked-in `temp_video_feed` sources; this PR does not touch those files.