### PR TITLE
ci: raise real device e2e gradle heap

### DIFF
--- a/.github/workflows/android-real-device-e2e.yml
+++ b/.github/workflows/android-real-device-e2e.yml
@@ -117,6 +117,15 @@ jobs:
       - name: Get Flutter dependencies
         run: flutter pub get
 
+      - name: Increase Gradle heap for hosted runners
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat >> android/gradle.properties <<'EOF'
+          org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8
+          kotlin.daemon.jvm.options=-Xmx3g
+          EOF
+
       - name: Build Android app and instrumentation test APKs
         shell: bash
         env:


### PR DESCRIPTION
## Summary
- Raise the Android Real Device E2E Gradle daemon heap on hosted runners to match the native/release package workflows.
- Add Kotlin daemon heap configuration before building instrumentation APKs.

## Root cause
The failed Firebase Test Lab PR check did not reach Firebase Test Lab. It failed while building debug/instrumentation APKs because Jetifier hit `Java heap space` transforming Flutter debug dependencies. The workflow set `GRADLE_OPTS=-Xmx6g`, but the checked-in `android/gradle.properties` still constrained the Gradle daemon to `org.gradle.jvmargs=-Xmx3G`.

## Verification
- `git diff --check`

## Release tracking
The merged Rive change is already on `main` at `e852f38d`; publish run `26809203701` is being monitored until install packages are uploaded.