### PR TITLE
ci: align AndroidX test dependencies for FTL

### DIFF
--- a/.github/workflows/android-real-device-e2e.yml
+++ b/.github/workflows/android-real-device-e2e.yml
@@ -71,6 +71,7 @@ concurrency:
 env:
   FLUTTER_VERSION: '3.41.9'
   REAL_DEVICE_TEST_TARGET: integration_test/home_send_real_device_test.dart
+  REAL_DEVICE_TARGET_PLATFORM: android-arm64
 
 jobs:
   android-real-device-e2e:
@@ -132,9 +133,11 @@ jobs:
           GRADLE_OPTS: -Xmx6g -Dfile.encoding=UTF-8
         run: |
           set -euo pipefail
-          flutter build apk --debug --config-only
+          flutter build apk --debug --config-only --target-platform "$REAL_DEVICE_TARGET_PLATFORM"
           pushd android
-          ./gradlew app:assembleDebug app:assembleAndroidTest -Ptarget="$GITHUB_WORKSPACE/fabushi/${REAL_DEVICE_TEST_TARGET}"
+          ./gradlew app:assembleDebug app:assembleAndroidTest \
+            -Ptarget="$GITHUB_WORKSPACE/fabushi/${REAL_DEVICE_TEST_TARGET}" \
+            -Ptarget-platform="$REAL_DEVICE_TARGET_PLATFORM"
           popd
           test -f build/app/outputs/apk/debug/app-debug.apk
           test -f build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk

--- a/.github/workflows/android-real-device-e2e.yml
+++ b/.github/workflows/android-real-device-e2e.yml
@@ -19,7 +19,7 @@ on:
       device_model:
         description: Firebase Test Lab physical device model
         required: false
-        default: Pixel2
+        default: redfin
       device_version:
         description: Android API level for the physical device
         required: false
@@ -37,7 +37,7 @@ on:
       device_model:
         type: string
         required: false
-        default: Pixel2
+        default: redfin
       device_version:
         type: string
         required: false
@@ -158,7 +158,7 @@ jobs:
         env:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           FIREBASE_TEST_RESULTS_BUCKET: ${{ secrets.FIREBASE_TEST_RESULTS_BUCKET }}
-          DEVICE_MODEL: ${{ inputs.device_model || github.event.inputs.device_model || 'Pixel2' }}
+          DEVICE_MODEL: ${{ inputs.device_model || github.event.inputs.device_model || 'redfin' }}
           DEVICE_VERSION: ${{ inputs.device_version || github.event.inputs.device_version || '30' }}
           DEVICE_LOCALE: ${{ inputs.device_locale || github.event.inputs.device_locale || 'zh_CN' }}
           DEVICE_ORIENTATION: ${{ inputs.device_orientation || github.event.inputs.device_orientation || 'portrait' }}

--- a/fabushi/android/app/build.gradle.kts
+++ b/fabushi/android/app/build.gradle.kts
@@ -92,11 +92,21 @@ android {
 }
 
 dependencies {
+    val androidxTestRunnerVersion = "1.6.2"
+    val androidxTestRulesVersion = "1.6.1"
+    val espressoCoreVersion = "3.6.1"
+
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test:rules:1.6.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+
+    // Keep debug and androidTest classpaths aligned because AGP applies
+    // consistent dependency resolution between those configurations.
+    debugImplementation("androidx.test:runner:$androidxTestRunnerVersion")
+    debugImplementation("androidx.test:rules:$androidxTestRulesVersion")
+    debugImplementation("androidx.test.espresso:espresso-core:$espressoCoreVersion")
+    androidTestImplementation("androidx.test:runner:$androidxTestRunnerVersion")
+    androidTestImplementation("androidx.test:rules:$androidxTestRulesVersion")
+    androidTestImplementation("androidx.test.espresso:espresso-core:$espressoCoreVersion")
 }
 
 flutter {


### PR DESCRIPTION
## Summary
- Align AndroidX Test dependencies across debug and androidTest classpaths so AGP consistent dependency resolution no longer pins androidTest to the older Flutter integration_test transitive versions.
- Build Firebase Test Lab physical-device APKs for `android-arm64` only, avoiding unnecessary x86/x86_64 native Rive builds for a physical Pixel target.

## Root cause
After the Gradle heap fix in #707, the Android Real Device E2E build progressed past Jetifier/Rive native compilation and failed at `:app:checkDebugAndroidTestAarMetadata`. AGP consistent dependency resolution constrained `androidx.test:runner`/`rules`/`espresso-core` to the older debug runtime versions (`1.2.0`/`3.2.0`) while `androidTestImplementation` requested newer versions.

## Verification
- `git diff --check`
- CI will verify the Java 17 Android build path; local Gradle insight is blocked by this machine only having Java 24.

## Release tracking
Release `v1.0.1-413-mobile.e852f38db385` has already published APK, AAB, IPA, SHA256SUMS, and TestFlight status assets.