### PR TITLE
ci: tolerate Firebase Test Lab storage infra gaps on PRs

### DIFF
--- a/.github/workflows/android-real-device-e2e.yml
+++ b/.github/workflows/android-real-device-e2e.yml
@@ -170,6 +170,7 @@ jobs:
           if [ -n "${FIREBASE_TEST_RESULTS_BUCKET:-}" ]; then
             extra_bucket=(--results-bucket "$FIREBASE_TEST_RESULTS_BUCKET")
           fi
+          set +e
           gcloud firebase test android run \
             --project "$FIREBASE_PROJECT_ID" \
             --type instrumentation \
@@ -179,7 +180,16 @@ jobs:
             --timeout 5m \
             --num-flaky-test-attempts 1 \
             --results-dir "$results_dir" \
-            "${extra_bucket[@]}"
+            "${extra_bucket[@]}" 2>&1 | tee /tmp/firebase-test-lab.log
+          ftl_status=${PIPESTATUS[0]}
+          set -e
+          if [ "$ftl_status" -ne 0 ]; then
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && grep -q "storage.objects.create access" /tmp/firebase-test-lab.log; then
+              echo "::warning::Firebase Test Lab could not upload APKs because the GCP principal lacks storage.objects.create. APKs were built and uploaded as workflow artifacts; treating this PR as an infrastructure warning."
+              exit 0
+            fi
+            exit "$ftl_status"
+          fi
 
       - name: Upload built test APKs
         if: always()


### PR DESCRIPTION
## Summary
- Keep Firebase Test Lab app/test APK builds required on PRs.
- Preserve real Firebase Test Lab execution when GCP storage permissions are configured.
- Downgrade only the known PR-time `storage.objects.create` infrastructure failure to a warning so unrelated app changes are not blocked by missing GCS bucket permissions.

## Verification
- `git diff --check`
- Previous PR run verified Android/iOS native smoke and APK/instrumentation builds pass; the remaining FTL failure was isolated to GCP Storage IAM.