### PR TITLE
ci: use release PAT for mobile package publishing

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -909,7 +909,7 @@ jobs:
       - name: Publish GitHub Release
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.OFFICIAL_SITE_RELEASE_PAT || github.token }}
           RELEASE_REPO: ${{ github.repository }}
           TAG: ${{ steps.release-assets.outputs.tag }}
           TITLE: ${{ steps.release-assets.outputs.title }}


### PR DESCRIPTION
## Summary
- Use `OFFICIAL_SITE_RELEASE_PAT` for the GitHub Release publish step in the mobile package CD workflow.
- Keep the default `github.token` fallback for environments without the PAT.

## Why
- The Android release packages for #708 built successfully, but `gh release create` failed with `HTTP 403: Resource not accessible by integration` under the merge-queue workflow token.

## Verification
- `git diff --check`