### PR TITLE
Use hostname for Dacheng AI worker upstream

### DIFF
--- a/fabushi/web/src/handlers/dacheng-ai.js
+++ b/fabushi/web/src/handlers/dacheng-ai.js
@@ -1,7 +1,7 @@
 import { CORS_HEADERS } from '../config/constants.js';
 import { jsonResponse } from '../utils/response.js';
 
-const DEFAULT_DACHENG_AI_BACKEND_URL = 'http://141.148.140.39';
+const DEFAULT_DACHENG_AI_BACKEND_URL = 'http://141.148.140.39.sslip.io';
 
 export function isDachengAiPath(pathname) {
   return (


### PR DESCRIPTION
## Summary
- Change the Dacheng AI Worker proxy default upstream from the bare VPS IP to `141.148.140.39.sslip.io`.
- This avoids Cloudflare Worker direct-IP subrequest handling while keeping the backend on the same 141.148.140.39 VPS.

## Validation
- `node --check web/src/handlers/dacheng-ai.js`
- `npx --yes wrangler@latest deploy --env production --dry-run --outdir /tmp/fabushi-worker-hostname-dry-run`

## Note
The VPS backend is healthy locally, but Oracle cloud ingress for 80/8788 still needs to allow external traffic; otherwise hostname access cannot reach the instance.