### PR TITLE
[codex] Fix faliu vps2 pagination

### DIFF
--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -7,9 +7,10 @@ import { FaliuSynonymEnhancer } from "../../components/faliu-synonym-enhancer";
 import { FALIU_FEATURED_WORKS } from "../../lib/faliu-config";
 import {
   buildCbetaContentId,
-  fetchAllWorks,
   fetchBatchStats,
+  fetchWorksPage,
   fetchWorkInfo,
+  workInfoToIndexItem,
   type CbetaWorkInfo,
   type ContentStats,
   type CbetaWorkIndexItem,
@@ -72,32 +73,57 @@ function sortFeaturedWorks(items: CbetaWorkIndexItem[]) {
     .sort((left, right) => FALIU_FEATURED_WORKS.indexOf(left.work) - FALIU_FEATURED_WORKS.indexOf(right.work));
 }
 
+function dedupeWorks(items: CbetaWorkIndexItem[]) {
+  const seen = new Set<string>();
+  const next: CbetaWorkIndexItem[] = [];
+
+  for (const item of items) {
+    if (seen.has(item.work)) {
+      continue;
+    }
+
+    seen.add(item.work);
+    next.push(item);
+  }
+
+  return next;
+}
+
 async function loadInitialFaliuData() {
   try {
-    const allWorks = await fetchAllWorks().catch(() => FALLBACK_FEATURED_WORKS);
-    const featuredWorks = sortFeaturedWorks(allWorks).slice(0, 12);
-    const fallbackWorks = featuredWorks.length > 0 ? featuredWorks : FALLBACK_FEATURED_WORKS;
-    const infoEntries = await Promise.all(
-      fallbackWorks.map(async (item) => {
-        const info = await fetchWorkInfo(item.work).catch(() => null);
-        return [item.work, info] as const;
-      }),
+    const [catalogPage, featuredInfoEntries] = await Promise.all([
+      fetchWorksPage(0).catch(() => null),
+      Promise.all(
+        FALIU_FEATURED_WORKS.map(async (work) => {
+          const info = await fetchWorkInfo(work).catch(() => null);
+          return [work, info] as const;
+        }),
+      ),
+    ]);
+    const featuredWorks = featuredInfoEntries.flatMap(([work, info]) =>
+      info ? [workInfoToIndexItem(info)] : FALLBACK_FEATURED_WORKS.filter((item) => item.work === work),
     );
+    const initialWorks = dedupeWorks([...sortFeaturedWorks(featuredWorks), ...FALLBACK_FEATURED_WORKS, ...(catalogPage?.works ?? [])]);
+    const infoEntries = featuredInfoEntries.filter((entry): entry is readonly [string, CbetaWorkInfo] => entry[1] !== null);
     const initialWorkInfo: Record<string, CbetaWorkInfo | null> = Object.fromEntries(infoEntries);
     const initialStats: Record<string, ContentStats> = await fetchBatchStats(
-      fallbackWorks.map((item) => buildCbetaContentId(item.work, item.juans[0] ?? "1")),
+      initialWorks.slice(0, 12).map((item) => buildCbetaContentId(item.work, item.juans[0] ?? "1")),
     ).catch(() => ({}));
 
     return {
-      initialWorks: fallbackWorks,
+      initialWorks,
       initialWorkInfo,
       initialStats,
+      initialNextWorksPage: catalogPage?.nextPage ?? 0,
+      initialHasMoreWorks: catalogPage?.hasMore ?? true,
     };
   } catch {
     return {
       initialWorks: FALLBACK_FEATURED_WORKS,
       initialWorkInfo: {},
       initialStats: {},
+      initialNextWorksPage: 0,
+      initialHasMoreWorks: true,
     };
   }
 }

--- a/frontend/apps/web/src/components/faliu-shell.tsx
+++ b/frontend/apps/web/src/components/faliu-shell.tsx
@@ -6,11 +6,12 @@ import { LocalizedText } from "./localized-text";
 import { siteHref } from "../lib/site-url";
 import { CARD_LIMIT, FALIU_TABS, type FaliuTabKey } from "../lib/faliu-config";
 import {
+  CBETA_WORKS_PAGE_SIZE,
   buildCbetaContentId,
-  fetchAllWorks,
   fetchBatchStats,
   fetchComments,
   fetchJuanDetail,
+  fetchWorksPage,
   fetchWorkInfo,
   normalizeCbetaQuery,
   searchWorksByTitle,
@@ -27,6 +28,8 @@ export interface FaliuInitialData {
   initialWorkInfo?: Record<string, CbetaWorkInfo | null>;
   initialStats?: Record<string, ContentStats>;
   initialQuery?: string;
+  initialNextWorksPage?: number;
+  initialHasMoreWorks?: boolean;
 }
 
 interface WorkCardItem {
@@ -175,6 +178,8 @@ export function FaliuShell({
   initialWorkInfo = {},
   initialStats = {},
   initialQuery = "",
+  initialNextWorksPage = 0,
+  initialHasMoreWorks = true,
 }: FaliuInitialData) {
   const [activeTab, setActiveTab] = useState<FaliuTabKey>("all");
   const [works, setWorks] = useState<CbetaWorkIndexItem[]>(initialWorks);
@@ -182,12 +187,15 @@ export function FaliuShell({
   const [statsMap, setStatsMap] = useState<Record<string, ContentStats>>(initialStats);
   const [query, setQuery] = useState(initialQuery);
   const [visibleLimit, setVisibleLimit] = useState(CARD_LIMIT);
+  const [nextWorksPage, setNextWorksPage] = useState(initialNextWorksPage);
+  const [hasMoreCatalogWorks, setHasMoreCatalogWorks] = useState(initialHasMoreWorks);
   const [searchRevision, setSearchRevision] = useState(0);
   const [selected, setSelected] = useState<WorkCardItem | null>(null);
   const [selectedDetail, setSelectedDetail] = useState<CbetaJuanDetail | null>(null);
   const [selectedComments, setSelectedComments] = useState<AppComment[]>([]);
   const [selectedJuan, setSelectedJuan] = useState("1");
   const [isBootLoading, setIsBootLoading] = useState(initialWorks.length === 0);
+  const [isCatalogLoading, setIsCatalogLoading] = useState(false);
   const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -207,42 +215,40 @@ export function FaliuShell({
     }
   }, [initialQuery]);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadCatalogPage = useCallback(
+    async (page = nextWorksPage) => {
+      if (isCatalogLoading || !hasMoreCatalogWorks) {
+        return false;
+      }
 
-    async function bootstrap() {
       try {
-        if (works.length === 0) {
-          setIsBootLoading(true);
-        }
+        setIsCatalogLoading(true);
+        const result = await fetchWorksPage(page, CBETA_WORKS_PAGE_SIZE);
 
-        const allWorks = await fetchAllWorks();
-
-        if (cancelled) {
-          return;
-        }
-
-        setWorks((current) => dedupeWorks([...current, ...allWorks]));
+        setWorks((current) => dedupeWorks([...current, ...result.works]));
+        setNextWorksPage(result.nextPage);
+        setHasMoreCatalogWorks(result.hasMore);
         setError(null);
+        return result.works.length > 0;
       } catch (cause) {
-        if (cancelled || works.length > 0) {
-          return;
-        }
-
         const message = cause instanceof Error ? cause.message : "法流数据加载失败";
         setError(message);
+        return false;
       } finally {
-        if (!cancelled) {
-          setIsBootLoading(false);
-        }
+        setIsCatalogLoading(false);
+        setIsBootLoading(false);
       }
+    },
+    [hasMoreCatalogWorks, isCatalogLoading, nextWorksPage],
+  );
+
+  useEffect(() => {
+    if (works.length > 0) {
+      setIsBootLoading(false);
+      return;
     }
 
-    void bootstrap();
-
-    return () => {
-      cancelled = true;
-    };
+    void loadCatalogPage(0);
   }, []);
 
   const activeTabConfig = FALIU_TABS.find((item) => item.key === activeTab) ?? FALIU_TABS[0];
@@ -285,11 +291,23 @@ export function FaliuShell({
   }, [activeTab, activeTabConfig, deferredQuery, normalizedDeferredQuery, works]);
 
   const visibleWorks = useMemo(() => filteredWorks.slice(0, visibleLimit), [filteredWorks, visibleLimit]);
-  const hasMoreWorks = visibleLimit < filteredWorks.length;
+  const canLoadMoreCatalogWorks = hasMoreCatalogWorks && normalizedDeferredQuery.length < 2;
+  const hasMoreWorks = visibleLimit < filteredWorks.length || canLoadMoreCatalogWorks;
 
   const loadMoreWorks = useCallback(() => {
-    setVisibleLimit((current) => Math.min(current + CARD_LIMIT, filteredWorks.length));
-  }, [filteredWorks.length]);
+    if (visibleLimit < filteredWorks.length) {
+      setVisibleLimit((current) => Math.min(current + CARD_LIMIT, filteredWorks.length));
+      return;
+    }
+
+    if (canLoadMoreCatalogWorks) {
+      void loadCatalogPage().then((loaded) => {
+        if (loaded) {
+          setVisibleLimit((current) => current + CARD_LIMIT);
+        }
+      });
+    }
+  }, [canLoadMoreCatalogWorks, filteredWorks.length, loadCatalogPage, visibleLimit]);
 
   useEffect(() => {
     setVisibleLimit(CARD_LIMIT);
@@ -582,9 +600,15 @@ export function FaliuShell({
           </div>
         ) : null}
 
-        {!isBootLoading && visibleCards.length === 0 ? (
+        {!isBootLoading && visibleCards.length === 0 && !canLoadMoreCatalogWorks ? (
           <div className={styles.stateBox}>
             <LocalizedText zh="这一组暂时没有可展示的佛典。" en="No matching works are available yet." />
+          </div>
+        ) : null}
+
+        {!isBootLoading && visibleCards.length === 0 && canLoadMoreCatalogWorks ? (
+          <div className={styles.stateBox}>
+            <LocalizedText zh="正在继续接入这一组佛典..." en="Loading more works for this stream..." />
           </div>
         ) : null}
 
@@ -631,11 +655,17 @@ export function FaliuShell({
           </p>
         ) : null}
 
-        {visibleCards.length > 0 ? (
+        {isCatalogLoading ? (
+          <p className={styles.loadingLine}>
+            <LocalizedText zh="正在加载更多经文..." en="Loading more sutra works..." />
+          </p>
+        ) : null}
+
+        {visibleCards.length > 0 || hasMoreWorks ? (
           <div ref={loadMoreRef} className={styles.loadMoreRow}>
             {hasMoreWorks ? (
               <button type="button" onClick={loadMoreWorks}>
-                <LocalizedText zh="继续加载" en="Load more" />
+                <LocalizedText zh={visibleLimit < filteredWorks.length ? "继续加载" : "加载更多经文"} en="Load more" />
               </button>
             ) : (
               <span>

--- a/frontend/apps/web/src/lib/faliu-api.ts
+++ b/frontend/apps/web/src/lib/faliu-api.ts
@@ -8,6 +8,7 @@ export interface CbetaWorkIndexItem {
 
 export interface CbetaWorkInfo {
   work: string;
+  canon?: string;
   category?: string;
   orig_category?: string;
   title: string;
@@ -17,8 +18,18 @@ export interface CbetaWorkInfo {
   time_from?: number | null;
   time_to?: number | null;
   juan?: number;
+  juan_list?: string;
   juan_start?: number;
   juan_end?: number;
+  vol?: string;
+}
+
+export interface CbetaWorksPage {
+  works: CbetaWorkIndexItem[];
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+  nextPage: number;
 }
 
 export interface CbetaTocNode {
@@ -63,6 +74,9 @@ export interface AppComment {
 
 const APP_API_ROOT = "https://api.ombhrum.com/api";
 const APP_PROXY_ROOT = "/api/app";
+export const CBETA_WORKS_PAGE_SIZE = 120;
+const CBETA_WORKS_DEFAULT_CANON = "T";
+const CBETA_WORKS_DEFAULT_CANON_END = 3000;
 const SIMPLIFIED_TO_TRADITIONAL: Record<string, string> = {
   万: "萬",
   与: "與",
@@ -709,8 +723,65 @@ export function buildCbetaContentId(work: string, juan: string) {
   return `cbeta:${work}:${juan}`;
 }
 
+function parseJuanList(value?: string) {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function buildJuanRange(start?: number | null, end?: number | null, fallback?: number | null) {
+  if (start && end && end >= start) {
+    return Array.from({ length: end - start + 1 }, (_, index) => String(start + index));
+  }
+
+  if (fallback && fallback > 0) {
+    return Array.from({ length: fallback }, (_, index) => String(index + 1));
+  }
+
+  return ["1"];
+}
+
+export function workInfoToIndexItem(info: CbetaWorkInfo): CbetaWorkIndexItem {
+  const juans = parseJuanList(info.juan_list);
+
+  return {
+    work: info.work,
+    title: info.title,
+    juans: juans.length > 0 ? juans : buildJuanRange(info.juan_start, info.juan_end, info.juan),
+  };
+}
+
 export async function fetchAllWorks(): Promise<CbetaWorkIndexItem[]> {
-  return fetchJson<CbetaWorkIndexItem[]>(cbetaUrls("download/all-works.json"));
+  try {
+    return fetchJson<CbetaWorkIndexItem[]>(cbetaUrls("download/all-works.json"));
+  } catch {
+    const page = await fetchWorksPage(0);
+    return page.works;
+  }
+}
+
+export async function fetchWorksPage(
+  page = 0,
+  pageSize = CBETA_WORKS_PAGE_SIZE,
+  canon = CBETA_WORKS_DEFAULT_CANON,
+): Promise<CbetaWorksPage> {
+  const safePage = Math.max(0, Math.floor(page));
+  const safePageSize = Math.max(1, Math.floor(pageSize));
+  const workStart = safePage * safePageSize + 1;
+  const workEnd = Math.min(workStart + safePageSize - 1, CBETA_WORKS_DEFAULT_CANON_END);
+  const data = await fetchJson<{ num_found?: number; results?: CbetaWorkInfo[] }>(
+    cbetaUrls("works", { canon, work_start: workStart, work_end: workEnd }),
+  );
+  const works = (data.results ?? []).filter((item) => item.work && item.title).map(workInfoToIndexItem);
+
+  return {
+    works,
+    page: safePage,
+    pageSize: safePageSize,
+    hasMore: workEnd < CBETA_WORKS_DEFAULT_CANON_END,
+    nextPage: safePage + 1,
+  };
 }
 
 export async function searchWorksByTitle(query: string, start = 0, rows = 24): Promise<CbetaWorkInfo[]> {


### PR DESCRIPTION
## Summary
- Load the Faloo catalog from the vps2 self-hosted CBETA `works` range API when `/download/all-works.json` is unavailable.
- Seed the first viewport with featured sutras plus the first catalog page, then fetch additional vps2 pages as users continue scrolling.
- Keep all scripture title/detail/content calls on the existing vps2 API root.

## Root Cause
The page depended on `/download/all-works.json`, but vps2 currently returns 404 for that file. The UI therefore fell back to the hardcoded featured list and scrolling had no larger catalog to reveal.

## Validation
- `corepack pnpm --filter @fabushi/web typecheck`
- `corepack pnpm --filter @fabushi/web build`
- Headless Chrome: `/faliu` started with 12 cards, clicked Load more until the second vps2 page loaded, observed 142 cards and T0121+ content after `works?canon=T&work_start=121&work_end=240` returned 200.