### PR TITLE
Add LibreChat AI domain integration

### DIFF
--- a/ai-backend/deploy/librechat/Caddyfile
+++ b/ai-backend/deploy/librechat/Caddyfile
@@ -1,0 +1,18 @@
+ai.ombhrum.com {
+	encode zstd gzip
+
+	@ai_bridge path /api/ai* /api/resources* /codex-deepseek* /health
+	reverse_proxy @ai_bridge 127.0.0.1:8788 {
+		flush_interval -1
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+	}
+
+	reverse_proxy 127.0.0.1:3080 {
+		flush_interval -1
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+	}
+}

--- a/ai-backend/deploy/librechat/Caddyfile.tunnel
+++ b/ai-backend/deploy/librechat/Caddyfile.tunnel
@@ -1,0 +1,20 @@
+:8090 {
+	encode zstd gzip
+
+	@ai_bridge path /api/ai* /api/resources* /codex-deepseek* /health
+	reverse_proxy @ai_bridge 127.0.0.1:8788 {
+		flush_interval -1
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-Proto https
+		header_up X-Forwarded-Host {host}
+	}
+
+	reverse_proxy 127.0.0.1:3080 {
+		flush_interval -1
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-Proto https
+		header_up X-Forwarded-Host {host}
+	}
+}

--- a/ai-backend/deploy/librechat/README.md
+++ b/ai-backend/deploy/librechat/README.md
@@ -45,10 +45,11 @@ This still uses Cloudflare DNS/Tunnel only; no Worker is created.
 
 ### Runtime configuration
 
-The installer generates missing `CREDS_IV`, `CREDS_KEY`, `JWT_SECRET`, and
-`JWT_REFRESH_SECRET` values in `/opt/librechat/current/.env`. If the existing
-Dacheng AI bridge has `DEEPSEEK_API_KEY`, the installer copies it locally into
-LibreChat's `.env` without printing it.
+The installer generates missing `CREDS_IV`, `CREDS_KEY`, `JWT_SECRET`,
+`JWT_REFRESH_SECRET`, and `MEILI_MASTER_KEY` values in
+`/opt/librechat/current/.env`. If the existing Dacheng AI bridge has
+`DEEPSEEK_API_KEY`, the installer copies it locally into LibreChat's `.env`
+without printing it.
 
 Keep `DOMAIN_CLIENT=https://ai.ombhrum.com`, `DOMAIN_SERVER=https://ai.ombhrum.com`,
 and `TRUST_PROXY=1`. Do not commit runtime secrets.

--- a/ai-backend/deploy/librechat/README.md
+++ b/ai-backend/deploy/librechat/README.md
@@ -1,7 +1,7 @@
 # LibreChat on ai.ombhrum.com
 
-This deployment keeps Cloudflare in DNS/proxy mode only. Do not create or attach a
-Cloudflare Worker for `ai.ombhrum.com`.
+This deployment keeps Cloudflare in DNS/proxy/tunnel mode only. Do not create,
+attach, or route a Cloudflare Worker for `ai.ombhrum.com`.
 
 ## Topology
 
@@ -10,11 +10,13 @@ Cloudflare Worker for `ai.ombhrum.com`.
 - `https://ai.ombhrum.com/api/resources/*` -> Dacheng AI bridge resource tools
 - `https://ai.ombhrum.com/health` -> Dacheng AI bridge health endpoint
 
-Cloudflare may keep the record proxied. If SSE streaming or WebSocket upgrades
-misbehave, switch only this DNS record to DNS-only and keep the same origin
-configuration.
+Cloudflare may keep the record proxied when using a direct DNS record. If SSE
+streaming or WebSocket upgrades misbehave, switch only this DNS record to
+DNS-only and keep the same origin configuration.
 
 ## Deploy
+
+### Direct DNS/proxy mode
 
 1. Point Cloudflare DNS at the VPS:
 
@@ -28,20 +30,37 @@ configuration.
    sudo DOMAIN=ai.ombhrum.com ./install-on-bhrum1.sh
    ```
 
-3. Configure LibreChat secrets in `/opt/librechat/current/.env`.
+### Cloudflare Tunnel mode
 
-   Keep `DOMAIN_CLIENT=https://ai.ombhrum.com`, `DOMAIN_SERVER=https://ai.ombhrum.com`,
-   and `TRUST_PROXY=1`. Generate fresh `CREDS_IV`, `CREDS_KEY`, `JWT_SECRET`,
-   and `JWT_REFRESH_SECRET`; do not commit them.
+If `bhrum1` already runs a named Cloudflare Tunnel, route the hostname to the
+same VPS and let local Caddy handle path routing:
 
-4. Restart services:
+```bash
+cloudflared tunnel route dns --overwrite-dns <tunnel-id> ai.ombhrum.com
+sudo DOMAIN=ai.ombhrum.com CADDY_MODE=tunnel CADDY_TUNNEL_PORT=8090 ./install-on-bhrum1.sh
+sudo DOMAIN=ai.ombhrum.com CADDY_TUNNEL_PORT=8090 ./configure-cloudflare-tunnel.sh
+```
 
-   ```bash
-   sudo systemctl restart dacheng-ai-backend
-   sudo systemctl reload caddy
-   cd /opt/librechat/current
-   sudo docker compose up -d
-   ```
+This still uses Cloudflare DNS/Tunnel only; no Worker is created.
+
+### Runtime configuration
+
+The installer generates missing `CREDS_IV`, `CREDS_KEY`, `JWT_SECRET`, and
+`JWT_REFRESH_SECRET` values in `/opt/librechat/current/.env`. If the existing
+Dacheng AI bridge has `DEEPSEEK_API_KEY`, the installer copies it locally into
+LibreChat's `.env` without printing it.
+
+Keep `DOMAIN_CLIENT=https://ai.ombhrum.com`, `DOMAIN_SERVER=https://ai.ombhrum.com`,
+and `TRUST_PROXY=1`. Do not commit runtime secrets.
+
+After any config edit, restart services:
+
+```bash
+sudo systemctl restart dacheng-ai-backend
+sudo systemctl reload caddy
+cd /opt/librechat/current
+sudo docker compose up -d
+```
 
 ## Verification
 

--- a/ai-backend/deploy/librechat/README.md
+++ b/ai-backend/deploy/librechat/README.md
@@ -1,0 +1,57 @@
+# LibreChat on ai.ombhrum.com
+
+This deployment keeps Cloudflare in DNS/proxy mode only. Do not create or attach a
+Cloudflare Worker for `ai.ombhrum.com`.
+
+## Topology
+
+- `https://ai.ombhrum.com/` -> LibreChat Web on `127.0.0.1:3080`
+- `https://ai.ombhrum.com/api/ai/*` -> Dacheng AI bridge on `127.0.0.1:8788`
+- `https://ai.ombhrum.com/api/resources/*` -> Dacheng AI bridge resource tools
+- `https://ai.ombhrum.com/health` -> Dacheng AI bridge health endpoint
+
+Cloudflare may keep the record proxied. If SSE streaming or WebSocket upgrades
+misbehave, switch only this DNS record to DNS-only and keep the same origin
+configuration.
+
+## Deploy
+
+1. Point Cloudflare DNS at the VPS:
+
+   ```bash
+   CF_API_TOKEN=... CF_ZONE_ID=... AI_ORIGIN_IP=... ./upsert-cloudflare-dns.sh
+   ```
+
+2. Copy this directory to `bhrum1`, then run:
+
+   ```bash
+   sudo DOMAIN=ai.ombhrum.com ./install-on-bhrum1.sh
+   ```
+
+3. Configure LibreChat secrets in `/opt/librechat/current/.env`.
+
+   Keep `DOMAIN_CLIENT=https://ai.ombhrum.com`, `DOMAIN_SERVER=https://ai.ombhrum.com`,
+   and `TRUST_PROXY=1`. Generate fresh `CREDS_IV`, `CREDS_KEY`, `JWT_SECRET`,
+   and `JWT_REFRESH_SECRET`; do not commit them.
+
+4. Restart services:
+
+   ```bash
+   sudo systemctl restart dacheng-ai-backend
+   sudo systemctl reload caddy
+   cd /opt/librechat/current
+   sudo docker compose up -d
+   ```
+
+## Verification
+
+```bash
+curl -I https://ai.ombhrum.com
+curl -s https://ai.ombhrum.com/health
+curl -N https://ai.ombhrum.com/api/ai/chat/stream \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"请用一句话介绍大乘 AI","clientMembershipHint":true}'
+```
+
+The last command should stream server-sent events from the same bridge contract
+the Flutter app already consumes.

--- a/ai-backend/deploy/librechat/configure-cloudflare-tunnel.sh
+++ b/ai-backend/deploy/librechat/configure-cloudflare-tunnel.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-ai.ombhrum.com}"
+MCP_DOMAIN="${MCP_DOMAIN:-vps-mcp.ombhrum.com}"
+TUNNEL_CONFIG="${TUNNEL_CONFIG:-/home/ubuntu/.cloudflared/config.yml}"
+CADDY_TUNNEL_PORT="${CADDY_TUNNEL_PORT:-8090}"
+
+if [[ ! -f "$TUNNEL_CONFIG" ]]; then
+  echo "Tunnel config not found: $TUNNEL_CONFIG" >&2
+  exit 1
+fi
+
+tunnel_line="$(grep -E '^tunnel:' "$TUNNEL_CONFIG" | head -n 1)"
+credentials_line="$(grep -E '^credentials-file:' "$TUNNEL_CONFIG" | head -n 1)"
+
+if [[ -z "$tunnel_line" || -z "$credentials_line" ]]; then
+  echo "Tunnel config must contain tunnel and credentials-file entries." >&2
+  exit 1
+fi
+
+sudo cp "$TUNNEL_CONFIG" "${TUNNEL_CONFIG}.backup.$(date +%Y%m%d%H%M%S)"
+sudo tee "$TUNNEL_CONFIG" >/dev/null <<EOF
+$tunnel_line
+$credentials_line
+
+ingress:
+  - hostname: ${DOMAIN}
+    service: http://localhost:${CADDY_TUNNEL_PORT}
+  - hostname: ${MCP_DOMAIN}
+    service: http://localhost:8787
+  - service: http_status:404
+EOF
+
+sudo systemctl restart chatgpt-vps-tunnel.service
+echo "Cloudflare Tunnel ingress configured for https://${DOMAIN} without Workers."

--- a/ai-backend/deploy/librechat/install-on-bhrum1.sh
+++ b/ai-backend/deploy/librechat/install-on-bhrum1.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-ai.ombhrum.com}"
+LIBRECHAT_DIR="${LIBRECHAT_DIR:-/opt/librechat/current}"
+LIBRECHAT_REPO="${LIBRECHAT_REPO:-https://github.com/danny-avila/LibreChat.git}"
+LIBRECHAT_REF="${LIBRECHAT_REF:-main}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run as root or with sudo." >&2
+  exit 1
+fi
+
+apt-get update
+apt-get install -y ca-certificates curl git gnupg lsb-release
+
+if ! command -v docker >/dev/null 2>&1; then
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+  . /etc/os-release
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+
+if ! command -v caddy >/dev/null 2>&1; then
+  apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+  curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt \
+    > /etc/apt/sources.list.d/caddy-stable.list
+  apt-get update
+  apt-get install -y caddy
+fi
+
+install -d -m 0755 "$(dirname "$LIBRECHAT_DIR")"
+if [[ ! -d "$LIBRECHAT_DIR/.git" ]]; then
+  git clone "$LIBRECHAT_REPO" "$LIBRECHAT_DIR"
+fi
+
+cd "$LIBRECHAT_DIR"
+git fetch --tags origin
+git checkout "$LIBRECHAT_REF"
+git pull --ff-only origin "$LIBRECHAT_REF" || true
+
+if [[ ! -f .env ]]; then
+  cp .env.example .env
+fi
+
+cp "$SCRIPT_DIR/librechat.yaml" "$LIBRECHAT_DIR/librechat.yaml"
+cat > "$LIBRECHAT_DIR/docker-compose.override.yml" <<'EOF'
+services:
+  api:
+    ports:
+      - "127.0.0.1:3080:3080"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: ./librechat.yaml
+        target: /app/librechat.yaml
+EOF
+
+if ! grep -q '^DOMAIN_CLIENT=' .env; then
+  cat >> .env <<EOF
+
+DOMAIN_CLIENT=https://${DOMAIN}
+DOMAIN_SERVER=https://${DOMAIN}
+TRUST_PROXY=1
+EOF
+fi
+
+docker compose pull
+docker compose up -d
+
+install -d -m 0755 /etc/caddy/conf.d
+sed "s/ai\\.ombhrum\\.com/${DOMAIN}/g" "$SCRIPT_DIR/Caddyfile" \
+  > /etc/caddy/conf.d/ai.ombhrum.com.caddy
+
+if ! grep -q 'import /etc/caddy/conf.d/\*.caddy' /etc/caddy/Caddyfile; then
+  cp /etc/caddy/Caddyfile "/etc/caddy/Caddyfile.backup.$(date +%Y%m%d%H%M%S)"
+  printf '\nimport /etc/caddy/conf.d/*.caddy\n' >> /etc/caddy/Caddyfile
+fi
+
+systemctl enable --now docker
+systemctl enable --now caddy
+caddy validate --config /etc/caddy/Caddyfile
+systemctl reload caddy
+
+echo "LibreChat domain deployment prepared for https://${DOMAIN}"

--- a/ai-backend/deploy/librechat/install-on-bhrum1.sh
+++ b/ai-backend/deploy/librechat/install-on-bhrum1.sh
@@ -130,7 +130,16 @@ else
     > /etc/caddy/conf.d/ai.ombhrum.com.caddy
 fi
 
-if ! grep -q 'import /etc/caddy/conf.d/\*.caddy' /etc/caddy/Caddyfile; then
+if [[ "$CADDY_MODE" == "tunnel" ]]; then
+  cp /etc/caddy/Caddyfile "/etc/caddy/Caddyfile.backup.$(date +%Y%m%d%H%M%S)"
+  cat > /etc/caddy/Caddyfile <<'EOF'
+{
+	auto_https off
+}
+
+import /etc/caddy/conf.d/*.caddy
+EOF
+elif ! grep -q 'import /etc/caddy/conf.d/\*.caddy' /etc/caddy/Caddyfile; then
   cp /etc/caddy/Caddyfile "/etc/caddy/Caddyfile.backup.$(date +%Y%m%d%H%M%S)"
   printf '\nimport /etc/caddy/conf.d/*.caddy\n' >> /etc/caddy/Caddyfile
 fi

--- a/ai-backend/deploy/librechat/install-on-bhrum1.sh
+++ b/ai-backend/deploy/librechat/install-on-bhrum1.sh
@@ -80,8 +80,10 @@ ensure_hex_secret() {
   local key="$1"
   local bytes="$2"
   local current
+  local example
   current="$(grep -E "^${key}=" .env | tail -n 1 | cut -d= -f2- || true)"
-  if [[ -z "$current" || "$current" == "changeme" || "$current" == *"your"* || "$current" == *"replace"* ]]; then
+  example="$(grep -E "^${key}=" .env.example | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -z "$current" || "$current" == "$example" || "$current" == "changeme" || "$current" == *"your"* || "$current" == *"replace"* ]]; then
     set_env "$key" "$(openssl rand -hex "$bytes")"
   fi
 }

--- a/ai-backend/deploy/librechat/install-on-bhrum1.sh
+++ b/ai-backend/deploy/librechat/install-on-bhrum1.sh
@@ -92,7 +92,7 @@ services:
   api:
     environment:
       - CONFIG_PATH=/app/librechat.yaml
-    ports:
+    ports: !override
       - "127.0.0.1:3080:3080"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/ai-backend/deploy/librechat/install-on-bhrum1.sh
+++ b/ai-backend/deploy/librechat/install-on-bhrum1.sh
@@ -5,6 +5,8 @@ DOMAIN="${DOMAIN:-ai.ombhrum.com}"
 LIBRECHAT_DIR="${LIBRECHAT_DIR:-/opt/librechat/current}"
 LIBRECHAT_REPO="${LIBRECHAT_REPO:-https://github.com/danny-avila/LibreChat.git}"
 LIBRECHAT_REF="${LIBRECHAT_REF:-main}"
+CADDY_MODE="${CADDY_MODE:-direct}"
+CADDY_TUNNEL_PORT="${CADDY_TUNNEL_PORT:-8090}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ "$(id -u)" -ne 0 ]]; then
@@ -51,10 +53,45 @@ if [[ ! -f .env ]]; then
   cp .env.example .env
 fi
 
+set_env() {
+  local key="$1"
+  local value="$2"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v key="$key" -v value="$value" '
+    BEGIN { done = 0 }
+    $0 ~ "^" key "=" && done == 0 {
+      print key "=" value
+      done = 1
+      next
+    }
+    { print }
+    END {
+      if (done == 0) {
+        print key "=" value
+      }
+    }
+  ' .env > "$tmp"
+  cat "$tmp" > .env
+  rm -f "$tmp"
+}
+
+ensure_hex_secret() {
+  local key="$1"
+  local bytes="$2"
+  local current
+  current="$(grep -E "^${key}=" .env | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -z "$current" || "$current" == "changeme" || "$current" == *"your"* || "$current" == *"replace"* ]]; then
+    set_env "$key" "$(openssl rand -hex "$bytes")"
+  fi
+}
+
 cp "$SCRIPT_DIR/librechat.yaml" "$LIBRECHAT_DIR/librechat.yaml"
 cat > "$LIBRECHAT_DIR/docker-compose.override.yml" <<'EOF'
 services:
   api:
+    environment:
+      - CONFIG_PATH=/app/librechat.yaml
     ports:
       - "127.0.0.1:3080:3080"
     extra_hosts:
@@ -65,21 +102,30 @@ services:
         target: /app/librechat.yaml
 EOF
 
-if ! grep -q '^DOMAIN_CLIENT=' .env; then
-  cat >> .env <<EOF
+set_env "DOMAIN_CLIENT" "https://${DOMAIN}"
+set_env "DOMAIN_SERVER" "https://${DOMAIN}"
+set_env "TRUST_PROXY" "1"
+ensure_hex_secret "CREDS_KEY" 32
+ensure_hex_secret "CREDS_IV" 16
+ensure_hex_secret "JWT_SECRET" 32
+ensure_hex_secret "JWT_REFRESH_SECRET" 32
 
-DOMAIN_CLIENT=https://${DOMAIN}
-DOMAIN_SERVER=https://${DOMAIN}
-TRUST_PROXY=1
-EOF
+if [[ -f /opt/dacheng-ai/.env ]] && grep -q '^DEEPSEEK_API_KEY=' /opt/dacheng-ai/.env && ! grep -q '^DEEPSEEK_API_KEY=' .env; then
+  deepseek_key="$(grep '^DEEPSEEK_API_KEY=' /opt/dacheng-ai/.env | tail -n 1 | cut -d= -f2-)"
+  set_env "DEEPSEEK_API_KEY" "$deepseek_key"
 fi
 
 docker compose pull
 docker compose up -d
 
 install -d -m 0755 /etc/caddy/conf.d
-sed "s/ai\\.ombhrum\\.com/${DOMAIN}/g" "$SCRIPT_DIR/Caddyfile" \
-  > /etc/caddy/conf.d/ai.ombhrum.com.caddy
+if [[ "$CADDY_MODE" == "tunnel" ]]; then
+  sed "s/:8090/:${CADDY_TUNNEL_PORT}/g" "$SCRIPT_DIR/Caddyfile.tunnel" \
+    > /etc/caddy/conf.d/ai.ombhrum.com.caddy
+else
+  sed "s/ai\\.ombhrum\\.com/${DOMAIN}/g" "$SCRIPT_DIR/Caddyfile" \
+    > /etc/caddy/conf.d/ai.ombhrum.com.caddy
+fi
 
 if ! grep -q 'import /etc/caddy/conf.d/\*.caddy' /etc/caddy/Caddyfile; then
   cp /etc/caddy/Caddyfile "/etc/caddy/Caddyfile.backup.$(date +%Y%m%d%H%M%S)"

--- a/ai-backend/deploy/librechat/install-on-bhrum1.sh
+++ b/ai-backend/deploy/librechat/install-on-bhrum1.sh
@@ -109,6 +109,7 @@ ensure_hex_secret "CREDS_KEY" 32
 ensure_hex_secret "CREDS_IV" 16
 ensure_hex_secret "JWT_SECRET" 32
 ensure_hex_secret "JWT_REFRESH_SECRET" 32
+ensure_hex_secret "MEILI_MASTER_KEY" 32
 
 if [[ -f /opt/dacheng-ai/.env ]] && grep -q '^DEEPSEEK_API_KEY=' /opt/dacheng-ai/.env && ! grep -q '^DEEPSEEK_API_KEY=' .env; then
   deepseek_key="$(grep '^DEEPSEEK_API_KEY=' /opt/dacheng-ai/.env | tail -n 1 | cut -d= -f2-)"

--- a/ai-backend/deploy/librechat/librechat.yaml
+++ b/ai-backend/deploy/librechat/librechat.yaml
@@ -1,0 +1,50 @@
+version: 1.2.1
+
+cache: true
+
+interface:
+  remoteAgents:
+    use: true
+    create: true
+  agents: true
+  fileSearch: true
+  webSearch: true
+  mcpServers: true
+
+endpoints:
+  custom:
+    - name: "DeepSeek"
+      apiKey: "${DEEPSEEK_API_KEY}"
+      baseURL: "https://api.deepseek.com/v1"
+      models:
+        default:
+          - "deepseek-chat"
+          - "deepseek-reasoner"
+      titleConvo: true
+      titleModel: "deepseek-chat"
+      summarize: false
+      forcePrompt: false
+      modelDisplayLabel: "DeepSeek"
+  agents:
+    disableBuilder: false
+    capabilities:
+      - "file_search"
+      - "web_search"
+      - "artifacts"
+      - "context"
+      - "tools"
+      - "actions"
+      - "skills"
+      - "subagents"
+
+mcpSettings:
+  allowedAddresses:
+    - "127.0.0.1:8788"
+    - "host.docker.internal:8788"
+
+mcpServers:
+  dacheng-ai:
+    type: streamable-http
+    url: "http://host.docker.internal:8788/mcp"
+    timeout: 120000
+    chatMenu: false

--- a/ai-backend/deploy/librechat/librechat.yaml
+++ b/ai-backend/deploy/librechat/librechat.yaml
@@ -1,4 +1,4 @@
-version: 1.3.5
+version: 1.3.12
 
 cache: true
 

--- a/ai-backend/deploy/librechat/librechat.yaml
+++ b/ai-backend/deploy/librechat/librechat.yaml
@@ -9,7 +9,11 @@ interface:
   agents: true
   fileSearch: true
   webSearch: true
-  mcpServers: true
+  mcpServers:
+    use: true
+    create: true
+    share: false
+    public: false
 
 endpoints:
   custom:

--- a/ai-backend/deploy/librechat/librechat.yaml
+++ b/ai-backend/deploy/librechat/librechat.yaml
@@ -1,4 +1,4 @@
-version: 1.2.1
+version: 1.3.5
 
 cache: true
 

--- a/ai-backend/deploy/librechat/upsert-cloudflare-dns.sh
+++ b/ai-backend/deploy/librechat/upsert-cloudflare-dns.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-ai.ombhrum.com}"
+PROXIED="${PROXIED:-true}"
+
+if [[ -z "${CF_API_TOKEN:-}" || -z "${CF_ZONE_ID:-}" || -z "${AI_ORIGIN_IP:-}" ]]; then
+  echo "Set CF_API_TOKEN, CF_ZONE_ID, and AI_ORIGIN_IP." >&2
+  exit 1
+fi
+
+api="https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records"
+auth_headers=(-H "Authorization: Bearer ${CF_API_TOKEN}" -H "Content-Type: application/json")
+
+record_json="$(curl -fsS "${auth_headers[@]}" "${api}?type=A&name=${DOMAIN}")"
+record_id="$(node -e 'const data=JSON.parse(process.argv[1]); console.log(data.result?.[0]?.id || "")' "$record_json")"
+payload="$(node -e 'console.log(JSON.stringify({type:"A",name:process.argv[1],content:process.argv[2],ttl:1,proxied:process.argv[3] === "true"}))' "$DOMAIN" "$AI_ORIGIN_IP" "$PROXIED")"
+
+if [[ -n "$record_id" ]]; then
+  curl -fsS -X PUT "${auth_headers[@]}" -d "$payload" "${api}/${record_id}"
+else
+  curl -fsS -X POST "${auth_headers[@]}" -d "$payload" "$api"
+fi
+
+echo
+echo "Upserted ${DOMAIN} -> ${AI_ORIGIN_IP} proxied=${PROXIED}; no Worker route was created."

--- a/ai-backend/package-lock.json
+++ b/ai-backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@fabushi/dacheng-ai-backend",
       "version": "0.1.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.20.2",
         "@openai/codex-sdk": "^0.136.0",
         "better-sqlite3": "^12.10.0",
         "cors": "^2.8.5",
@@ -15,10 +16,63 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
-        "pino": "^10.1.0"
+        "pino": "^10.1.0",
+        "zod": "^3.25.76"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmmirror.com/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@openai/codex": {
@@ -172,6 +226,39 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/atomic-sleep": {
@@ -386,6 +473,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
@@ -540,6 +641,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmmirror.com/expand-template/-/expand-template-2.0.3.tgz",
@@ -609,6 +731,28 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -761,6 +905,15 @@
         "url": "https://github.com/sponsors/EvanHahn"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/http-errors/-/http-errors-2.0.1.tgz",
@@ -852,6 +1005,33 @@
       "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmmirror.com/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmmirror.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1028,6 +1208,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -1074,6 +1263,15 @@
       "resolved": "https://registry.npmmirror.com/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.2",
@@ -1223,6 +1421,15 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmmirror.com/router/-/router-2.2.0.tgz",
@@ -1336,6 +1543,27 @@
       "resolved": "https://registry.npmmirror.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1621,11 +1849,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/ai-backend/package.json
+++ b/ai-backend/package.json
@@ -13,6 +13,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.20.2",
     "@openai/codex-sdk": "^0.136.0",
     "better-sqlite3": "^12.10.0",
     "cors": "^2.8.5",
@@ -20,6 +21,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
-    "pino": "^10.1.0"
+    "pino": "^10.1.0",
+    "zod": "^3.25.76"
   }
 }

--- a/ai-backend/src/server.js
+++ b/ai-backend/src/server.js
@@ -4,6 +4,8 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import Database from 'better-sqlite3';
 import cors from 'cors';
 import dotenv from 'dotenv';
@@ -11,6 +13,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
 import pino from 'pino';
+import { z } from 'zod';
 
 dotenv.config();
 
@@ -195,6 +198,13 @@ function monthKey(date = new Date()) {
 
 function jsonResponse(res, status, payload) {
   res.status(status).json(payload);
+}
+
+function textToolResult(text, structuredContent = {}) {
+  return {
+    structuredContent,
+    content: [{ type: 'text', text }],
+  };
 }
 
 function sseHeaders(res) {
@@ -1845,6 +1855,200 @@ function persistDownloadedResource(user, content) {
   });
   return { id, fileName, filePath };
 }
+
+function createLibreChatMcpServer() {
+  const server = new McpServer({
+    name: 'dacheng-ai-tools',
+    version: '0.1.0',
+  });
+
+  server.registerTool(
+    'search_dharma_resources',
+    {
+      title: 'Search dharma resources',
+      description:
+        'Search for legally shareable Buddhist scripture, text, web, or audio resources that can be prepared for Fabushi sharing.',
+      inputSchema: {
+        query: z.string().min(2).max(200),
+        limit: z.number().int().min(1).max(12).optional(),
+      },
+      outputSchema: {
+        query: z.string(),
+        items: z.array(
+          z.object({
+            id: z.string(),
+            title: z.string(),
+            sourceName: z.string(),
+            url: z.string(),
+            snippet: z.string(),
+            resourceType: z.string(),
+            work: z.string().optional(),
+            juan: z.number().optional(),
+          }),
+        ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ query, limit }) => {
+      const items = await findResourceCandidates(query, limit ?? 8);
+      return textToolResult(`Found ${items.length} candidate resources for "${query}".`, {
+        query,
+        items,
+      });
+    },
+  );
+
+  server.registerTool(
+    'download_dharma_resource',
+    {
+      title: 'Download dharma resource',
+      description:
+        'Download and extract a selected resource. Use the url/work/juan returned by search_dharma_resources whenever possible.',
+      inputSchema: {
+        url: z.string().min(1).max(1000),
+        title: z.string().max(300).optional(),
+        sourceName: z.string().max(120).optional(),
+        work: z.string().max(40).optional(),
+        juan: z.number().int().min(1).optional(),
+        identifier: z.string().max(300).optional(),
+      },
+      outputSchema: {
+        title: z.string(),
+        sourceName: z.string(),
+        url: z.string(),
+        fileName: z.string(),
+        downloadId: z.string(),
+        contentText: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      const user = { userId: 'librechat:mcp' };
+      const cbeta = parseCbetaResource(input);
+      const internetArchive = parseInternetArchiveResource(input);
+      const content = cbeta
+        ? await downloadCbetaResource({ ...input, ...cbeta })
+        : internetArchive
+          ? await downloadInternetArchiveAudio({ ...input, ...internetArchive })
+          : await downloadWebResource(input);
+      const persisted = persistDownloadedResource(user, content);
+      const { binaryContent: _binaryContent, ...publicContent } = content;
+      return textToolResult(`Downloaded ${publicContent.title} as ${publicContent.fileName}.`, {
+        ...publicContent,
+        downloadId: persisted.id,
+      });
+    },
+  );
+
+  server.registerTool(
+    'prepare_dharma_share_text',
+    {
+      title: 'Prepare dharma sharing text',
+      description:
+        'Prepare a text payload for the Fabushi app to confirm and add to global dharma sharing. This returns a clientAction; it does not start sending.',
+      inputSchema: {
+        title: z.string().min(1).max(120),
+        text: z.string().min(1).max(20000),
+      },
+      outputSchema: {
+        clientAction: z.object({
+          type: z.literal('prepare_dharma_share_text'),
+          title: z.string(),
+          text: z.string(),
+        }),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    },
+    async ({ title, text }) =>
+      textToolResult(`Prepared "${title}" for user confirmation in the Fabushi app.`, {
+        clientAction: {
+          type: 'prepare_dharma_share_text',
+          title: safeUserText(title).slice(0, 120),
+          text: String(text || '').trim().slice(0, 20000),
+        },
+      }),
+  );
+
+  server.registerTool(
+    'prepare_practice_book_item',
+    {
+      title: 'Prepare practice book item',
+      description:
+        'Prepare a scripture, chant, or practice item for the Fabushi app practice book. This returns a clientAction; it does not mutate the app by itself.',
+      inputSchema: {
+        title: z.string().min(1).max(120),
+        sourceName: z.string().max(120).optional(),
+        text: z.string().min(1).max(20000),
+      },
+      outputSchema: {
+        clientAction: z.object({
+          type: z.literal('prepare_practice_book_item'),
+          title: z.string(),
+          sourceName: z.string(),
+          text: z.string(),
+        }),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    },
+    async ({ title, sourceName, text }) =>
+      textToolResult(`Prepared "${title}" for the Fabushi practice book confirmation flow.`, {
+        clientAction: {
+          type: 'prepare_practice_book_item',
+          title: safeUserText(title).slice(0, 120),
+          sourceName: safeUserText(sourceName || '大乘 AI').slice(0, 120),
+          text: String(text || '').trim().slice(0, 20000),
+        },
+      }),
+  );
+
+  return server;
+}
+
+async function handleMcpRequest(req, res) {
+  const server = createLibreChatMcpServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+
+  res.on('close', () => {
+    transport.close();
+    server.close();
+  });
+
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+}
+
+app.all('/mcp', async (req, res) => {
+  try {
+    await handleMcpRequest(req, res);
+  } catch (error) {
+    logger.error({ error: error.stack || String(error) }, 'MCP request failed');
+    if (!res.headersSent) {
+      res.status(500).json({
+        error: 'MCP request failed',
+        message: publicAiErrorMessage(error),
+      });
+    }
+  }
+});
 
 app.post(
   '/api/resources/download',

--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -45,7 +45,7 @@ class AppConfig {
     'AI_BACKEND_URL',
     defaultValue: '',
   );
-  static const String vpsAiBackendUrl = 'http://141.148.140.39';
+  static const String vpsAiBackendUrl = 'https://ai.ombhrum.com';
 
   static String get currentBackendUrl {
     if (configuredApiBaseUrl.isNotEmpty) {

--- a/fabushi/test/unit/core/app_config_buddha_model_test.dart
+++ b/fabushi/test/unit/core/app_config_buddha_model_test.dart
@@ -4,6 +4,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:global_dharma_sharing/core/config/app_config.dart';
 
 void main() {
+  group('AI backend configuration', () {
+    test('uses the Cloudflare DNS domain instead of the raw VPS IP', () {
+      expect(AppConfig.currentAiBackendUrl, 'https://ai.ombhrum.com');
+    });
+  });
+
   group('Buddha model remote configuration', () {
     test('keeps the native .model on the R2 remote path', () {
       expect(AppConfig.buddhaModelAssetPath, 'models/buddha_model.model');

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -14,6 +14,11 @@ const NAV_ITEMS = [
     en: "Download FAQ",
   },
   {
+    href: "https://ai.ombhrum.com",
+    zh: "大乘 AI",
+    en: "AI",
+  },
+  {
     href: "/contact",
     zh: "联系支持",
     en: "Contact Support",


### PR DESCRIPTION
## Summary

- Point the Flutter AI backend default to `https://ai.ombhrum.com` while preserving the existing `/api/ai/chat/stream` app contract.
- Add the official site “大乘 AI / AI” navigation entry to LibreChat native web.
- Expose the existing Dacheng AI bridge as a Streamable HTTP MCP server for LibreChat tools.
- Add LibreChat deployment assets for `ai.ombhrum.com` with Cloudflare DNS/Tunnel/Caddy routing and no Worker.

## Deployment completed

- `bhrum1` now runs LibreChat via Docker Compose on `127.0.0.1:3080`.
- Caddy listens locally on `:8090` and routes `/` to LibreChat and `/api/ai/*` to the App bridge on `127.0.0.1:8788`.
- Cloudflare Tunnel ingress routes `ai.ombhrum.com` to the local Caddy listener; no Cloudflare Worker was created.

## Verification

- `npm run check` in `ai-backend`.
- `node --check ai-backend/src/server.js`.
- Flutter unit test: `flutter test test/unit/core/app_config_buddha_model_test.dart`.
- Web typecheck/build: `pnpm --filter @fabushi/web typecheck` and `pnpm --filter @fabushi/web build`.
- VPS bridge `/health` and `/mcp tools/list` verified.
- LibreChat container logs show `dacheng-ai` MCP initialized with 4 tools.
- Public Cloudflare route verified with `curl --resolve` for LibreChat Web, `/health`, and streaming `/api/ai/chat/stream`.
