### PR TITLE
feat: route app chat through LibreChat agent

### DIFF
--- a/ai-backend/.env.example
+++ b/ai-backend/.env.example
@@ -6,6 +6,12 @@ DEEPSEEK_API_KEY=REPLACE_WITH_DEEPSEEK_API_KEY
 DEEPSEEK_BASE_URL=https://api.deepseek.com
 DEEPSEEK_MODEL=deepseek-chat
 
+# Prefer LibreChat Agents API as the app chat backend when these are configured.
+ENABLE_LIBRECHAT_AGENT_CHAT=false
+LIBRECHAT_AGENTS_BASE_URL=http://127.0.0.1:3080/api/agents/v1
+LIBRECHAT_AGENT_API_KEY=REPLACE_WITH_LIBRECHAT_AGENT_API_KEY
+LIBRECHAT_AGENT_ID=agent_xxx
+
 FABUSHI_API_BASE_URL=http://141.148.140.39
 CBETA_API_ROOT=https://144.24.17.21.sslip.io
 MEMBER_MONTHLY_TOKEN_LIMIT=1000000
@@ -16,4 +22,5 @@ RATE_LIMIT_PER_MINUTE=90
 TRUST_PROXY_HOPS=1
 LOG_LEVEL=info
 ENABLE_CODEX_SDK=false
+# Enables Codex SDK chat orchestration over the DeepSeek-compatible Responses adapter.
 ENABLE_CODEX_SDK_CHAT=true

--- a/ai-backend/src/server.js
+++ b/ai-backend/src/server.js
@@ -173,6 +173,12 @@ const fabushiApiBaseUrl = (process.env.FABUSHI_API_BASE_URL || 'http://141.148.1
 const memberMonthlyLimit = Number(process.env.MEMBER_MONTHLY_TOKEN_LIMIT || 1_000_000);
 const freeMonthlyLimit = Number(process.env.FREE_MONTHLY_TOKEN_LIMIT || 50_000);
 const maxResourceTextChars = Number(process.env.MAX_RESOURCE_TEXT_CHARS || 80_000);
+const enableLibreChatAgentChat = process.env.ENABLE_LIBRECHAT_AGENT_CHAT === 'true';
+const libreChatAgentsBaseUrl = (
+  process.env.LIBRECHAT_AGENTS_BASE_URL || 'http://127.0.0.1:3080/api/agents/v1'
+).replace(/\/+$/, '');
+const libreChatAgentApiKey = process.env.LIBRECHAT_AGENT_API_KEY || '';
+const libreChatAgentId = process.env.LIBRECHAT_AGENT_ID || '';
 const enableCodexSdkChat = process.env.ENABLE_CODEX_SDK_CHAT === 'true';
 const codexDeepSeekProviderId = 'deepseek-chat-completions';
 const codexResponsesBaseUrl = (
@@ -612,6 +618,170 @@ function responseUsage(usage = {}) {
   };
 }
 
+function createLibreChatAgentRuntime() {
+  if (!enableLibreChatAgentChat || !libreChatAgentApiKey || !libreChatAgentId) {
+    return {
+      enabled: false,
+      provider: 'librechat-agent',
+      reason: !enableLibreChatAgentChat
+        ? 'ENABLE_LIBRECHAT_AGENT_CHAT is not true'
+        : !libreChatAgentApiKey
+          ? 'LIBRECHAT_AGENT_API_KEY is not configured'
+          : 'LIBRECHAT_AGENT_ID is not configured',
+    };
+  }
+
+  return {
+    enabled: true,
+    provider: 'librechat-agent',
+    model: libreChatAgentId,
+    chatCompletionsUrl: `${libreChatAgentsBaseUrl}/chat/completions`,
+  };
+}
+
+function libreChatUsage(usage = {}) {
+  return {
+    promptTokens: Number(usage.prompt_tokens || usage.input_tokens || usage.promptTokens || 0),
+    completionTokens: Number(usage.completion_tokens || usage.output_tokens || usage.completionTokens || 0),
+    totalTokens: Number(usage.total_tokens || usage.totalTokens || 0),
+  };
+}
+
+async function callLibreChatAgent(messages) {
+  const runtime = createLibreChatAgentRuntime();
+  if (!runtime.enabled) {
+    const error = new Error(runtime.reason || 'LibreChat Agent chat is not enabled');
+    error.statusCode = 503;
+    throw error;
+  }
+
+  const response = await fetch(runtime.chatCompletionsUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${libreChatAgentApiKey}`,
+    },
+    body: JSON.stringify({
+      model: runtime.model,
+      messages,
+      temperature: 0.4,
+      stream: false,
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+
+  const bodyText = await response.text();
+  let payload;
+  try {
+    payload = bodyText ? JSON.parse(bodyText) : {};
+  } catch {
+    payload = { error: bodyText };
+  }
+
+  if (!response.ok) {
+    const upstreamMessage = payload?.error?.message || payload?.message || bodyText || '';
+    const error = new Error(upstreamMessage || `LibreChat Agent request failed: ${response.status}`);
+    error.statusCode = response.status;
+    throw error;
+  }
+
+  const message = payload?.choices?.[0]?.message?.content?.trim();
+  if (!message) {
+    const error = new Error('LibreChat Agent returned an empty response');
+    error.statusCode = 502;
+    throw error;
+  }
+
+  return {
+    message,
+    usage: libreChatUsage(payload?.usage),
+  };
+}
+
+async function callLibreChatAgentStream(messages, callbacks = {}) {
+  const runtime = createLibreChatAgentRuntime();
+  if (!runtime.enabled) {
+    const error = new Error(runtime.reason || 'LibreChat Agent chat is not enabled');
+    error.statusCode = 503;
+    throw error;
+  }
+
+  const response = await fetch(runtime.chatCompletionsUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'text/event-stream',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${libreChatAgentApiKey}`,
+    },
+    body: JSON.stringify({
+      model: runtime.model,
+      messages,
+      temperature: 0.4,
+      stream: true,
+    }),
+    signal: callbacks.signal || AbortSignal.timeout(180_000),
+  });
+
+  if (!response.ok) {
+    const bodyText = await response.text();
+    let payload;
+    try {
+      payload = bodyText ? JSON.parse(bodyText) : {};
+    } catch {
+      payload = { error: bodyText };
+    }
+    const upstreamMessage = payload?.error?.message || payload?.message || bodyText || '';
+    const error = new Error(upstreamMessage || `LibreChat Agent request failed: ${response.status}`);
+    error.statusCode = response.status;
+    throw error;
+  }
+
+  let buffer = '';
+  let message = '';
+  let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  const decoder = new TextDecoder();
+
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() || '';
+
+    for (const rawLine of lines) {
+      const line = rawLine.trim();
+      if (!line.startsWith('data:')) continue;
+      const data = line.slice('data:'.length).trim();
+      if (!data || data === '[DONE]') continue;
+
+      let payload;
+      try {
+        payload = JSON.parse(data);
+      } catch {
+        continue;
+      }
+
+      const delta = payload?.choices?.[0]?.delta?.content || '';
+      if (delta) {
+        message += delta;
+        callbacks.onToken?.(delta);
+      }
+
+      if (payload?.usage) {
+        usage = libreChatUsage(payload.usage);
+      }
+    }
+  }
+
+  message = message.trim();
+  if (!message) {
+    const error = new Error('LibreChat Agent returned an empty response');
+    error.statusCode = 502;
+    throw error;
+  }
+
+  return { message, usage };
+}
+
 function isDeepSeekQuotaError(error) {
   const message = String(error?.message || error || '');
   return /额度|insufficient\s+balance|balance/i.test(message);
@@ -892,11 +1062,15 @@ app.post(
 
 app.get('/health', (_req, res) => {
   const codexRuntime = createCodexDeepSeekRuntime();
+  const libreChatRuntime = createLibreChatAgentRuntime();
   jsonResponse(res, 200, {
     status: 'ok',
     service: 'dacheng-ai-backend',
-    provider: 'deepseek',
-    model: deepseekModel,
+    provider: libreChatRuntime.enabled ? libreChatRuntime.provider : 'deepseek',
+    model: libreChatRuntime.enabled ? libreChatRuntime.model : deepseekModel,
+    libreChatAgentChatEnabled: libreChatRuntime.enabled,
+    libreChatAgentProvider: libreChatRuntime.provider,
+    libreChatAgentReason: libreChatRuntime.enabled ? undefined : libreChatRuntime.reason,
     codexSdkAvailable: true,
     codexSdkChatEnabled: codexRuntime.enabled,
     codexSdkProvider: codexRuntime.provider,
@@ -949,6 +1123,7 @@ app.post(
       createdAt,
     });
 
+    const libreChatRuntime = createLibreChatAgentRuntime();
     const skillResult = await runResourceFinderSkill({ message, user });
     const skillContext = resourceContextMessage(skillResult);
     const historyRows = statements.listMessages.all(conversationId).slice(-14);
@@ -959,20 +1134,41 @@ app.post(
     ];
 
     const codexRuntime = createCodexDeepSeekRuntime();
-    let provider = 'deepseek';
+    let provider = libreChatRuntime.enabled ? libreChatRuntime.provider : 'deepseek';
+    let responseModel = libreChatRuntime.enabled ? libreChatRuntime.model : deepseekModel;
     let aiResult;
     try {
-      if (codexRuntime.enabled) {
+      if (libreChatRuntime.enabled) {
+        aiResult = await callLibreChatAgent(modelMessages);
+      } else if (codexRuntime.enabled) {
         provider = codexRuntime.provider;
         aiResult = await callCodexSdkDeepSeek(modelMessages);
       } else {
         aiResult = await callDeepSeek(modelMessages);
       }
     } catch (error) {
-      if (!codexRuntime.enabled || isDeepSeekQuotaError(error)) throw error;
-      logger.warn({ error: String(error) }, 'Codex SDK chat failed, falling back to DeepSeek direct');
-      provider = 'deepseek';
-      aiResult = await callDeepSeek(modelMessages);
+      if (libreChatRuntime.enabled) {
+        logger.warn({ error: String(error) }, 'LibreChat Agent chat failed, falling back to Codex SDK or DeepSeek direct');
+        provider = codexRuntime.enabled ? codexRuntime.provider : 'deepseek';
+        responseModel = deepseekModel;
+        if (codexRuntime.enabled) {
+          try {
+            aiResult = await callCodexSdkDeepSeek(modelMessages);
+          } catch (codexError) {
+            if (isDeepSeekQuotaError(codexError)) throw codexError;
+            logger.warn({ error: String(codexError) }, 'Codex SDK chat failed, falling back to DeepSeek direct');
+            provider = 'deepseek';
+            aiResult = await callDeepSeek(modelMessages);
+          }
+        } else {
+          aiResult = await callDeepSeek(modelMessages);
+        }
+      } else {
+        if (!codexRuntime.enabled || isDeepSeekQuotaError(error)) throw error;
+        logger.warn({ error: String(error) }, 'Codex SDK chat failed, falling back to DeepSeek direct');
+        provider = 'deepseek';
+        aiResult = await callDeepSeek(modelMessages);
+      }
     }
     const usage = {
       promptTokens: aiResult.usage.promptTokens || estimateTokens(JSON.stringify(modelMessages)),
@@ -1007,7 +1203,7 @@ app.post(
       success: true,
       conversationId,
       provider,
-      model: deepseekModel,
+      model: responseModel,
       message: aiResult.message,
       usage: {
         ...usage,
@@ -1066,17 +1262,18 @@ app.post('/api/ai/chat/stream', async (req, res) => {
     });
 
     const codexRuntime = createCodexDeepSeekRuntime();
-    let provider = codexRuntime.enabled ? codexRuntime.provider : 'deepseek';
+    const libreChatRuntime = createLibreChatAgentRuntime();
+    let provider = libreChatRuntime.enabled
+      ? libreChatRuntime.provider
+      : codexRuntime.enabled
+        ? codexRuntime.provider
+        : 'deepseek';
+    let responseModel = libreChatRuntime.enabled ? libreChatRuntime.model : deepseekModel;
     writeSse(res, 'meta', {
       conversationId,
       provider,
-      model: deepseekModel,
+      model: responseModel,
     });
-    writeSse(res, 'step', {
-      title: '连接后端 AI',
-      message: '大乘后端已直连 VPS，并使用 DeepSeek OpenAI-compatible API。',
-    });
-
     const skillResult = await runResourceFinderSkill({
       message,
       user,
@@ -1092,7 +1289,11 @@ app.post('/api/ai/chat/stream', async (req, res) => {
 
     let aiResult;
     try {
-      if (codexRuntime.enabled) {
+      if (libreChatRuntime.enabled) {
+        aiResult = await callLibreChatAgentStream(modelMessages, {
+          onToken: (token) => writeSse(res, 'delta', { text: token }),
+        });
+      } else if (codexRuntime.enabled) {
         aiResult = await callCodexSdkDeepSeek(modelMessages, {
           onToken: (token) => writeSse(res, 'delta', { text: token }),
           onStep: (step) => writeSse(res, 'step', step),
@@ -1103,16 +1304,54 @@ app.post('/api/ai/chat/stream', async (req, res) => {
         });
       }
     } catch (error) {
-      if (!codexRuntime.enabled || isDeepSeekQuotaError(error)) throw error;
-      logger.warn({ error: String(error) }, 'Codex SDK streaming chat failed, falling back to DeepSeek direct');
-      provider = 'deepseek';
-      writeSse(res, 'step', {
-        title: 'Codex SDK 暂不可用',
-        message: '已自动回退为 DeepSeek 直连流式返回。',
-      });
-      aiResult = await callDeepSeekStream(modelMessages, {
-        onToken: (token) => writeSse(res, 'delta', { text: token }),
-      });
+      if (libreChatRuntime.enabled) {
+        logger.warn({ error: String(error) }, 'LibreChat Agent streaming chat failed, falling back to Codex SDK or DeepSeek direct');
+        provider = codexRuntime.enabled ? codexRuntime.provider : 'deepseek';
+        responseModel = deepseekModel;
+        writeSse(res, 'meta', {
+          conversationId,
+          provider,
+          model: responseModel,
+        });
+        if (codexRuntime.enabled) {
+          try {
+            aiResult = await callCodexSdkDeepSeek(modelMessages, {
+              onToken: (token) => writeSse(res, 'delta', { text: token }),
+              onStep: (step) => writeSse(res, 'step', step),
+            });
+          } catch (codexError) {
+            if (isDeepSeekQuotaError(codexError)) throw codexError;
+            logger.warn({ error: String(codexError) }, 'Codex SDK streaming chat failed, falling back to DeepSeek direct');
+            provider = 'deepseek';
+            responseModel = deepseekModel;
+            writeSse(res, 'meta', {
+              conversationId,
+              provider,
+              model: responseModel,
+            });
+            aiResult = await callDeepSeekStream(modelMessages, {
+              onToken: (token) => writeSse(res, 'delta', { text: token }),
+            });
+          }
+        } else {
+          aiResult = await callDeepSeekStream(modelMessages, {
+            onToken: (token) => writeSse(res, 'delta', { text: token }),
+          });
+        }
+      } else {
+        if (!codexRuntime.enabled || isDeepSeekQuotaError(error)) throw error;
+        logger.warn({ error: String(error) }, 'Codex SDK streaming chat failed, falling back to DeepSeek direct');
+        provider = 'deepseek';
+        responseModel = deepseekModel;
+        writeSse(res, 'meta', {
+          conversationId,
+          provider,
+          model: responseModel,
+        });
+        aiResult = await callDeepSeekStream(modelMessages, {
+          onToken: (token) => writeSse(res, 'delta', { text: token }),
+        });
+      }
     }
 
     const usage = {
@@ -1147,7 +1386,7 @@ app.post('/api/ai/chat/stream', async (req, res) => {
     writeSse(res, 'done', {
       conversationId,
       provider,
-      model: deepseekModel,
+      model: responseModel,
       message: aiResult.message,
       usage: {
         ...usage,
@@ -1576,6 +1815,8 @@ function extractResourceQuery(message) {
 function resourceContextMessage(skillResult) {
   if (!skillResult) return '';
   const lines = [
+    '本轮资源检索/下载已经由大乘 App 后端完成。',
+    '不要再次调用 search_dharma_resources、download_dharma_resource 或其他资源 MCP 工具；请直接基于以下结果回答用户。',
     `后端已调用 skill: ${skillResult.skillName}`,
     `执行目标: ${skillResult.query}`,
   ];

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../core/config/app_config.dart';
@@ -44,6 +45,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   bool _isGlobalSendTimelineVisible = false;
   bool _isAiGenerating = false;
   String _streamingAiText = '';
+  String _aiActivityText = '';
   SceneRenderMode _renderMode = SceneRenderMode.twoD;
   final TextEditingController _chatInputController = TextEditingController();
   final ScrollController _homeChatScrollController = ScrollController();
@@ -810,12 +812,25 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         ],
         if (_isAiGenerating)
           _streamingAiText.trim().isEmpty
-              ? const Align(
+              ? Align(
                   alignment: Alignment.centerLeft,
-                  child: _ThinkingDots(label: '正在思考'),
+                  child: _ThinkingDots(
+                    label: _aiActivityText.trim().isEmpty
+                        ? '正在思考'
+                        : _aiActivityText.trim(),
+                  ),
                 )
-              : _buildChatBubble(
-                  _HomeChatMessage(text: _streamingAiText, isUser: false),
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (_aiActivityText.trim().isNotEmpty) ...[
+                      _AiActivityLabel(_aiActivityText.trim()),
+                      const SizedBox(height: 8),
+                    ],
+                    _buildChatBubble(
+                      _HomeChatMessage(text: _streamingAiText, isUser: false),
+                    ),
+                  ],
                 ),
         if (_isAiGenerating) const SizedBox(height: 18),
         if (hasSendingProcess) _buildGlobalSendingProcess(model),
@@ -845,15 +860,17 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         constraints: const BoxConstraints(maxWidth: 430),
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
         decoration: BoxDecoration(color: bubbleColor, borderRadius: radius),
-        child: Text(
-          message.text,
-          style: TextStyle(
-            color: message.isError ? Colors.red[100] : Colors.white,
-            fontSize: 17,
-            height: 1.42,
-            fontWeight: message.isUser ? FontWeight.w700 : FontWeight.w500,
-          ),
-        ),
+        child: message.isUser || message.isError
+            ? Text(
+                message.text,
+                style: TextStyle(
+                  color: message.isError ? Colors.red[100] : Colors.white,
+                  fontSize: 17,
+                  height: 1.42,
+                  fontWeight: message.isUser ? FontWeight.w700 : FontWeight.w500,
+                ),
+              )
+            : _MarkdownChatText(message.text),
       ),
     );
   }
@@ -1066,6 +1083,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       _activeConversationId = null;
       _homeChatMessages.clear();
       _streamingAiText = '';
+      _aiActivityText = '';
       _isDharmaComposerMode = false;
       _showMaterialGallery = false;
       _isGlobalSendTimelineVisible = false;
@@ -1119,6 +1137,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         ..clear()
         ..addAll(messages);
       _streamingAiText = '';
+      _aiActivityText = '';
       _isDharmaComposerMode = false;
       _showMaterialGallery = false;
       _isGlobalSendTimelineVisible = conversation.isGlobalSendRunning;
@@ -1748,6 +1767,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       _homeChatMessages.add(_HomeChatMessage(text: text, isUser: true));
       _isAiGenerating = true;
       _streamingAiText = '';
+      _aiActivityText = '正在思考';
     });
     _scrollHomeChatToBottom(force: true);
 
@@ -1770,15 +1790,12 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         }
 
         if (event.isStep) {
-          final title = (event.raw['title'] ?? '').toString().trim();
-          final message = (event.raw['message'] ?? event.text)
-              .toString()
-              .trim();
-          final line = [
-            if (title.isNotEmpty) title,
-            if (message.isNotEmpty) message,
-          ].join('：');
-          if (line.isNotEmpty) stepLines.add('· $line');
+          final visibleStep = _visibleAiStepLabel(event);
+          if (visibleStep != null) {
+            stepLines
+              ..clear()
+              ..add(visibleStep);
+          }
         } else if (event.isDelta) {
           finalText += event.text;
         } else if (event.isDone) {
@@ -1790,10 +1807,10 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
 
         setState(() {
           _activeConversationId = latestConversationId;
-          _streamingAiText = [
-            if (stepLines.isNotEmpty) stepLines.join('\n'),
-            if (finalText.trim().isNotEmpty) finalText,
-          ].join('\n\n');
+          _aiActivityText = stepLines.isNotEmpty
+              ? stepLines.last
+              : (finalText.trim().isEmpty ? '正在思考' : '正在生成');
+          _streamingAiText = finalText;
         });
         _scrollHomeChatToBottom();
       }
@@ -1807,6 +1824,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           );
         }
         _streamingAiText = '';
+        _aiActivityText = '';
         _isAiGenerating = false;
       });
       _scrollHomeChatToBottom(force: true);
@@ -1822,6 +1840,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           ),
         );
         _streamingAiText = '';
+        _aiActivityText = '';
         _isAiGenerating = false;
       });
       _scrollHomeChatToBottom(force: true);
@@ -1840,8 +1859,23 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         );
       }
       _streamingAiText = '';
+      _aiActivityText = '';
       _isAiGenerating = false;
     });
+  }
+
+  String? _visibleAiStepLabel(DachengAiStreamEvent event) {
+    final title = (event.raw['title'] ?? '').toString().trim();
+    final message = (event.raw['message'] ?? event.text).toString().trim();
+    final combined = [title, message].where((part) => part.isNotEmpty).join(' ');
+    if (combined.isEmpty) return null;
+    if (RegExp(r'VPS|后端|DeepSeek|OpenAI-compatible|直连|连接').hasMatch(combined)) {
+      return null;
+    }
+    if (RegExp(r'执行命令|调用工具|搜索|下载|资源|整理|计划|文件|MCP|工具').hasMatch(combined)) {
+      return title.isNotEmpty ? title : message;
+    }
+    return null;
   }
 
   void _scrollHomeChatToBottom({bool force = false}) {
@@ -2714,6 +2748,116 @@ class _RegionCheckTile extends StatelessWidget {
                 materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AiActivityLabel extends StatelessWidget {
+  final String label;
+
+  const _AiActivityLabel(this.label);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(
+              strokeWidth: 1.8,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                AppTheme.primaryColor.withValues(alpha: 0.82),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Colors.white70,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MarkdownChatText extends StatelessWidget {
+  final String data;
+
+  const _MarkdownChatText(this.data);
+
+  @override
+  Widget build(BuildContext context) {
+    const baseStyle = TextStyle(
+      color: Colors.white,
+      fontSize: 17,
+      height: 1.46,
+      fontWeight: FontWeight.w500,
+    );
+
+    return MarkdownBody(
+      data: data,
+      selectable: true,
+      softLineBreak: true,
+      styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+        p: baseStyle,
+        strong: baseStyle.copyWith(fontWeight: FontWeight.w800),
+        em: baseStyle.copyWith(fontStyle: FontStyle.italic),
+        h1: baseStyle.copyWith(fontSize: 22, fontWeight: FontWeight.w800),
+        h2: baseStyle.copyWith(fontSize: 20, fontWeight: FontWeight.w800),
+        h3: baseStyle.copyWith(fontSize: 18, fontWeight: FontWeight.w800),
+        blockquote: baseStyle.copyWith(color: Colors.white70),
+        blockquoteDecoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(8),
+          border: Border(
+            left: BorderSide(
+              color: AppTheme.primaryColor.withValues(alpha: 0.72),
+              width: 3,
+            ),
+          ),
+        ),
+        code: baseStyle.copyWith(
+          color: const Color(0xFFE9F4FF),
+          fontFamily: 'monospace',
+          fontSize: 15,
+        ),
+        codeblockDecoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.24),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+        ),
+        listBullet: baseStyle,
+        a: baseStyle.copyWith(
+          color: AppTheme.primaryColor,
+          decoration: TextDecoration.underline,
+          decorationColor: AppTheme.primaryColor.withValues(alpha: 0.7),
+        ),
+        tableBody: baseStyle.copyWith(fontSize: 14),
+        tableHead: baseStyle.copyWith(fontSize: 14, fontWeight: FontWeight.w800),
+        horizontalRuleDecoration: BoxDecoration(
+          border: Border(
+            top: BorderSide(color: Colors.white.withValues(alpha: 0.14)),
           ),
         ),
       ),

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   lucide_icons_flutter: ^3.1.5
   rive: ^0.13.20
   searchfield: ^1.3.5
+  flutter_markdown: ^0.7.7+1
 
   # 地图和地理位置
   flutter_map: ^8.2.1


### PR DESCRIPTION
## Summary
- route app AI chat through the LibreChat Agents API when configured
- provision stream/non-stream fallback handling and health metadata
- render assistant Markdown in the app chat UI while separating execution status from final text
- keep resource search/download execution stable by passing backend-prepared context into the LibreChat Agent

## Validation
- npm run check (ai-backend)
- deployed dacheng-ai-backend on VPS and verified /health reports librechat-agent
- verified streaming resource query completes without LibreChat graph recursion
- Flutter/Dart are not installed on the VPS, so Flutter analysis is left to CI