### PR TITLE
Fix Linux desktop installer build

### DIFF
--- a/fabushi/linux/CMakeLists.txt
+++ b/fabushi/linux/CMakeLists.txt
@@ -42,6 +42,9 @@ endif()
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  # Some third-party Flutter Linux plugins vendor C sources that are warning-clean
+  # on older toolchains but trip unused-variable under newer GitHub runner clang.
+  target_compile_options(${TARGET} PRIVATE -Wno-error=unused-variable)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
## Summary
- Keep Linux desktop builds on -Wall -Werror.
- Allow unused-variable warnings from vendored native Flutter plugin C sources to avoid Ubuntu 24.04 clang failures in the desktop installer workflow.

## Verification
- git diff --check origin/main..HEAD
- Follow-up to #727 after the Linux installer matrix hit rive_common SBParagraph.c -Werror,-Wunused-variable.