### PR TITLE
Broaden Linux desktop unused warning allowance

### DIFF
--- a/fabushi/linux/CMakeLists.txt
+++ b/fabushi/linux/CMakeLists.txt
@@ -43,8 +43,8 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
   # Some third-party Flutter Linux plugins vendor C sources that are warning-clean
-  # on older toolchains but trip unused-variable under newer GitHub runner clang.
-  target_compile_options(${TARGET} PRIVATE -Wno-error=unused-variable)
+  # on older toolchains but trip unused diagnostics under newer runner clang.
+  target_compile_options(${TARGET} PRIVATE -Wno-error=unused)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
## Summary
- Keep Linux desktop builds on -Wall -Werror.
- Convert the unused warning group from error back to warning for vendored native Flutter plugin C sources.
- This follows #728, where unused-variable was fixed but Ubuntu 24.04 clang next failed on unused-function in rive_common.

## Verification
- git diff --check origin/main..HEAD
- Desktop installers workflow will be watched before enabling auto-merge.