### PR TITLE
Fix desktop release publishing without checkout

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -467,6 +467,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.resolve-release-context.outputs.release_tag }}
           SOURCE_SHA: ${{ needs.resolve-release-context.outputs.source_sha }}
           APP_VERSION: ${{ needs.resolve-release-context.outputs.app_version }}


### PR DESCRIPTION
## Summary
- Set GH_REPO for the desktop installer GitHub Release publishing step.
- Fixes gh release commands in the publish job, which runs without checkout and therefore has no .git directory.

## Verification
- ruby YAML parse for .github/workflows/desktop-installers.yml
- git diff --check
- Final publish run failure showed gh could not infer the repository without .git.