### PR TITLE
Add macOS App Store desktop upload

### DIFF
--- a/.github/scripts/upload-macos-app-store.sh
+++ b/.github/scripts/upload-macos-app-store.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status_dir="${MACOS_APP_STORE_STATUS_DIR:-$PWD/../macos-app-store-assets}"
+mkdir -p "$status_dir"
+status_file="$status_dir/MACOS_APP_STORE_UPLOAD_STATUS.txt"
+
+write_status() {
+  local status="$1"
+  local reason="$2"
+  {
+    echo "status=$status"
+    echo "reason=$reason"
+    echo "source_sha=${SOURCE_SHA:-}"
+    echo "app_version=${APP_VERSION:-}"
+    echo "build_number=${RELEASE_BUILD_NUMBER:-}"
+    echo "uploaded_at=${3:-}"
+  } > "$status_file"
+}
+
+require_config() {
+  local missing=()
+  for name in "$@"; do
+    if [ -z "${!name:-}" ]; then
+      missing+=("$name")
+    fi
+  done
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  {
+    echo "macOS App Store Connect upload is not configured."
+    echo ""
+    echo "Missing configuration:"
+    printf -- "- %s\n" "${missing[@]}"
+  } > "$status_dir/MACOS_APP_STORE_NOT_CONFIGURED.txt"
+
+  write_status "skipped" "macos_app_store_connect_not_configured"
+  if [ "${MACOS_APP_STORE_UPLOAD_REQUIRED:-false}" = "true" ]; then
+    cat "$status_dir/MACOS_APP_STORE_NOT_CONFIGURED.txt" >&2
+    exit 1
+  fi
+
+  cat "$status_dir/MACOS_APP_STORE_NOT_CONFIGURED.txt"
+  exit 0
+}
+
+case "${MACOS_APP_STORE_UPLOAD_ENABLED:-true}" in
+  true|TRUE|True|1|yes|YES) ;;
+  *)
+    write_status "skipped" "macos_app_store_upload_disabled"
+    echo "macOS App Store Connect upload is disabled."
+    exit 0
+    ;;
+esac
+
+require_config \
+  APP_STORE_CONNECT_API_KEY_ID \
+  APP_STORE_CONNECT_API_ISSUER_ID \
+  APP_STORE_CONNECT_API_KEY_BASE64 \
+  MACOS_APP_STORE_TEAM_ID \
+  MACOS_APP_STORE_BUNDLE_ID
+
+version_name="${APP_VERSION%%+*}"
+build_number="${RELEASE_BUILD_NUMBER:-${APP_VERSION##*+}}"
+if [ -z "$version_name" ] || [ "$version_name" = "$APP_VERSION" ] || [ -z "$build_number" ]; then
+  echo "APP_VERSION must use Flutter's x.y.z+build format; got '$APP_VERSION'." >&2
+  exit 1
+fi
+
+api_key_dir="$RUNNER_TEMP/appstoreconnect/private_keys"
+altool_api_key_dir="$HOME/.appstoreconnect/private_keys"
+api_key_path="$api_key_dir/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+altool_api_key_path="$altool_api_key_dir/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+mkdir -p "$api_key_dir" "$altool_api_key_dir"
+printf '%s' "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$api_key_path"
+cp "$api_key_path" "$altool_api_key_path"
+chmod 600 "$api_key_path" "$altool_api_key_path"
+
+auth_args=(
+  -authenticationKeyPath "$api_key_path"
+  -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID"
+  -authenticationKeyIssuerID "$APP_STORE_CONNECT_API_ISSUER_ID"
+)
+
+manual_signing=false
+if [ -n "${MACOS_APP_STORE_CERTIFICATE_P12_BASE64:-}" ] ||
+   [ -n "${MACOS_APP_STORE_CERTIFICATE_PASSWORD:-}" ] ||
+   [ -n "${MACOS_APP_STORE_INSTALLER_CERTIFICATE_P12_BASE64:-}" ] ||
+   [ -n "${MACOS_APP_STORE_INSTALLER_CERTIFICATE_PASSWORD:-}" ] ||
+   [ -n "${MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64:-}" ]; then
+  for name in \
+    MACOS_APP_STORE_CERTIFICATE_P12_BASE64 \
+    MACOS_APP_STORE_CERTIFICATE_PASSWORD \
+    MACOS_APP_STORE_INSTALLER_CERTIFICATE_P12_BASE64 \
+    MACOS_APP_STORE_INSTALLER_CERTIFICATE_PASSWORD \
+    MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64; do
+    if [ -z "${!name:-}" ]; then
+      echo "$name is required when any manual macOS App Store signing secret is configured." >&2
+      exit 1
+    fi
+  done
+  manual_signing=true
+fi
+
+profile_name=""
+if [ "$manual_signing" = "true" ]; then
+  cert_path="$RUNNER_TEMP/macos_app_store_distribution.p12"
+  installer_cert_path="$RUNNER_TEMP/macos_installer_distribution.p12"
+  profile_path="$RUNNER_TEMP/fabushi-macos.provisionprofile"
+  profile_plist="$RUNNER_TEMP/fabushi-macos-profile.plist"
+  keychain_password="${KEYCHAIN_PASSWORD:-${GITHUB_RUN_ID:-macos-app-store}-${GITHUB_RUN_ATTEMPT:-1}}"
+  keychain_path="$RUNNER_TEMP/macos-app-store-signing.keychain-db"
+
+  printf '%s' "$MACOS_APP_STORE_CERTIFICATE_P12_BASE64" | base64 --decode > "$cert_path"
+  printf '%s' "$MACOS_APP_STORE_INSTALLER_CERTIFICATE_P12_BASE64" | base64 --decode > "$installer_cert_path"
+  printf '%s' "$MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile_path"
+
+  security create-keychain -p "$keychain_password" "$keychain_path"
+  security set-keychain-settings -lut 21600 "$keychain_path"
+  security unlock-keychain -p "$keychain_password" "$keychain_path"
+  security import "$cert_path" -P "$MACOS_APP_STORE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
+  security import "$installer_cert_path" -P "$MACOS_APP_STORE_INSTALLER_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
+  security list-keychains -d user -s "$keychain_path" login.keychain-db
+  security default-keychain -s "$keychain_path"
+  security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain_path"
+
+  mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+  security cms -D -i "$profile_path" > "$profile_plist"
+  profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$profile_plist")"
+  profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
+  profile_team_id="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$profile_plist")"
+  profile_app_identifier="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$profile_plist" 2>/dev/null || true)"
+  cp "$profile_path" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.provisionprofile"
+
+  if [ "$profile_team_id" != "$MACOS_APP_STORE_TEAM_ID" ]; then
+    echo "Provisioning profile team '$profile_team_id' does not match MACOS_APP_STORE_TEAM_ID '$MACOS_APP_STORE_TEAM_ID'." >&2
+    exit 1
+  fi
+  expected_profile_app_identifier="${MACOS_APP_STORE_TEAM_ID}.${MACOS_APP_STORE_BUNDLE_ID}"
+  if [ -n "$profile_app_identifier" ] && [ "$profile_app_identifier" != "$expected_profile_app_identifier" ]; then
+    echo "Provisioning profile app identifier '$profile_app_identifier' does not match '$expected_profile_app_identifier'." >&2
+    exit 1
+  fi
+fi
+
+archive_path="$PWD/build/macos/AppStore/global_dharma_sharing.xcarchive"
+export_path="$PWD/build/macos/AppStore/export"
+export_options="$RUNNER_TEMP/macos-app-store-export-options.plist"
+rm -rf "$archive_path" "$export_path"
+mkdir -p "$(dirname "$archive_path")" "$export_path"
+
+flutter build macos \
+  --release \
+  --no-pub \
+  --config-only \
+  --build-name "$version_name" \
+  --build-number "$build_number"
+
+archive_args=(
+  -workspace macos/Runner.xcworkspace
+  -scheme Runner
+  -configuration Release
+  -destination "generic/platform=macOS"
+  -archivePath "$archive_path"
+  MARKETING_VERSION="$version_name"
+  CURRENT_PROJECT_VERSION="$build_number"
+  PRODUCT_BUNDLE_IDENTIFIER="$MACOS_APP_STORE_BUNDLE_ID"
+  DEVELOPMENT_TEAM="$MACOS_APP_STORE_TEAM_ID"
+)
+
+if [ "$manual_signing" = "true" ]; then
+  archive_args+=(
+    CODE_SIGN_STYLE=Manual
+    CODE_SIGN_IDENTITY="${MACOS_APP_STORE_SIGNING_CERTIFICATE:-Mac App Distribution}"
+    PROVISIONING_PROFILE_SPECIFIER="$profile_name"
+  )
+else
+  archive_args+=(
+    CODE_SIGN_STYLE=Automatic
+  )
+fi
+
+xcodebuild \
+  "${archive_args[@]}" \
+  "${auth_args[@]}" \
+  -allowProvisioningUpdates \
+  clean archive
+
+internal_only=false
+case "${MACOS_APP_STORE_INTERNAL_TESTING_ONLY:-false}" in
+  true|TRUE|True|1|yes|YES) internal_only=true ;;
+esac
+
+{
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>destination</key>
+  <string>export</string>
+  <key>method</key>
+  <string>app-store-connect</string>
+  <key>signingStyle</key>
+  <string>$([ "$manual_signing" = "true" ] && echo manual || echo automatic)</string>
+  <key>teamID</key>
+  <string>${MACOS_APP_STORE_TEAM_ID}</string>
+  <key>manageAppVersionAndBuildNumber</key>
+  <false/>
+  <key>stripSwiftSymbols</key>
+  <true/>
+  <key>uploadSymbols</key>
+  <true/>
+  <key>testFlightInternalTestingOnly</key>
+EOF
+  if [ "$internal_only" = "true" ]; then
+    echo "  <true/>"
+  else
+    echo "  <false/>"
+  fi
+  if [ "$manual_signing" = "true" ]; then
+    cat <<EOF
+  <key>signingCertificate</key>
+  <string>${MACOS_APP_STORE_SIGNING_CERTIFICATE:-Mac App Distribution}</string>
+  <key>installerSigningCertificate</key>
+  <string>${MACOS_APP_STORE_INSTALLER_SIGNING_CERTIFICATE:-Mac Installer Distribution}</string>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>${MACOS_APP_STORE_BUNDLE_ID}</key>
+    <string>${profile_name}</string>
+  </dict>
+EOF
+  fi
+  cat <<EOF
+</dict>
+</plist>
+EOF
+} > "$export_options"
+
+xcodebuild \
+  -exportArchive \
+  -archivePath "$archive_path" \
+  -exportOptionsPlist "$export_options" \
+  -exportPath "$export_path" \
+  "${auth_args[@]}" \
+  -allowProvisioningUpdates
+
+pkg_path="$(find "$export_path" -maxdepth 2 -name '*.pkg' -type f | sort | head -n 1)"
+if [ -z "$pkg_path" ]; then
+  echo "xcodebuild export completed but no macOS App Store .pkg was produced under $export_path." >&2
+  find "$export_path" -maxdepth 3 -type f -print >&2 || true
+  exit 1
+fi
+
+short_sha="${SOURCE_SHA:-${GITHUB_SHA:-unknown}}"
+short_sha="${short_sha:0:12}"
+pkg_name="global_dharma_sharing-${version_name}-${build_number}-macos-app-store-${short_sha}.pkg"
+cp "$pkg_path" "$status_dir/$pkg_name"
+
+xcrun altool --validate-app \
+  --type macos \
+  --file "$pkg_path" \
+  --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+  --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+xcrun altool --upload-app \
+  --type macos \
+  --file "$pkg_path" \
+  --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+  --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+write_status "uploaded" "accepted_by_app_store_connect" "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - fabushi/**
       - .github/scripts/package-desktop-*
+      - .github/scripts/upload-macos-app-store.sh
       - .github/workflows/desktop-installers.yml
   push:
     branches:
@@ -14,6 +15,7 @@ on:
     paths:
       - fabushi/**
       - .github/scripts/package-desktop-*
+      - .github/scripts/upload-macos-app-store.sh
       - .github/workflows/desktop-installers.yml
   workflow_dispatch:
     inputs:
@@ -27,6 +29,11 @@ on:
         type: string
       publish_release:
         description: Publish packages to a GitHub Release after successful builds.
+        required: false
+        default: true
+        type: boolean
+      upload_macos_app_store:
+        description: Upload the macOS App Store package to App Store Connect for TestFlight/App Store processing.
         required: false
         default: true
         type: boolean
@@ -60,8 +67,10 @@ jobs:
       source_sha: ${{ steps.context.outputs.source_sha }}
       app_version: ${{ steps.context.outputs.app_version }}
       version_slug: ${{ steps.context.outputs.version_slug }}
+      release_build_number: ${{ steps.context.outputs.release_build_number }}
       release_tag: ${{ steps.context.outputs.release_tag }}
       publish_release: ${{ steps.context.outputs.publish_release }}
+      upload_macos_app_store: ${{ steps.context.outputs.upload_macos_app_store }}
     steps:
       - name: Checkout release metadata
         uses: actions/checkout@v5
@@ -81,6 +90,7 @@ jobs:
           INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           INPUT_PUBLISH_RELEASE: ${{ inputs.publish_release }}
+          INPUT_UPLOAD_MACOS_APP_STORE: ${{ inputs.upload_macos_app_store }}
         run: |
           set -euo pipefail
 
@@ -92,22 +102,33 @@ jobs:
           fi
 
           version_slug="${app_version//+/-}"
+          release_build_number="${app_version##*+}"
+          if [ "$release_build_number" = "$app_version" ] || [ -z "$release_build_number" ]; then
+            release_build_number="$GITHUB_RUN_NUMBER"
+          fi
           short_sha="$(git rev-parse --short=12 HEAD)"
           release_tag="${INPUT_RELEASE_TAG:-desktop-v${version_slug}-${GITHUB_RUN_NUMBER}-${short_sha}}"
 
           publish_release=false
+          upload_macos_app_store=false
           case "$EVENT_NAME" in
             pull_request)
               publish_release=false
+              upload_macos_app_store=false
               ;;
             workflow_dispatch)
               case "${INPUT_PUBLISH_RELEASE:-true}" in
                 true|TRUE|True|1|yes|YES) publish_release=true ;;
                 *) publish_release=false ;;
               esac
+              case "${INPUT_UPLOAD_MACOS_APP_STORE:-true}" in
+                true|TRUE|True|1|yes|YES) upload_macos_app_store=true ;;
+                *) upload_macos_app_store=false ;;
+              esac
               ;;
             push)
               publish_release=true
+              upload_macos_app_store=true
               ;;
           esac
 
@@ -115,8 +136,10 @@ jobs:
             echo "source_sha=$source_sha"
             echo "app_version=$app_version"
             echo "version_slug=$version_slug"
+            echo "release_build_number=$release_build_number"
             echo "release_tag=$release_tag"
             echo "publish_release=$publish_release"
+            echo "upload_macos_app_store=$upload_macos_app_store"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -124,8 +147,10 @@ jobs:
             echo ""
             echo "- Source SHA: \`$source_sha\`"
             echo "- App version: \`$app_version\`"
+            echo "- Release build number: \`$release_build_number\`"
             echo "- Release tag: \`$release_tag\`"
             echo "- Publish release: \`$publish_release\`"
+            echo "- Upload macOS App Store Connect build: \`$upload_macos_app_store\`"
             echo "- OpenClaw version: \`${OPENCLAW_VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -162,6 +187,9 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
     steps:
       - name: Checkout desktop source
         uses: actions/checkout@v5
@@ -320,7 +348,7 @@ jobs:
           security set-keychain-settings -lut 21600 "$keychain_path"
           security unlock-keychain -p "$RUNNER_TEMP" "$keychain_path"
           security import "$certificate_path" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
-          security list-keychain -d user -s "$keychain_path"
+          security list-keychains -d user -s "$keychain_path" login.keychain-db
           security set-key-partition-list -S apple-tool:,apple: -s -k "$RUNNER_TEMP" "$keychain_path"
 
       - name: Code sign macOS app
@@ -354,10 +382,7 @@ jobs:
         if: >-
           matrix.target == 'macos' &&
           github.event_name != 'pull_request' &&
-          env.MACOS_CERTIFICATE_P12_BASE64 != '' &&
-          env.APPLE_ID != '' &&
-          env.APPLE_TEAM_ID != '' &&
-          env.APPLE_APP_SPECIFIC_PASSWORD != ''
+          env.MACOS_CERTIFICATE_P12_BASE64 != ''
         shell: bash
         run: |
           set -euo pipefail
@@ -367,11 +392,27 @@ jobs:
             identity="$(security find-identity -v -p codesigning | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
           fi
           codesign --force --timestamp --sign "$identity" "$dmg_path"
-          xcrun notarytool submit "$dmg_path" \
-            --apple-id "$APPLE_ID" \
-            --team-id "$APPLE_TEAM_ID" \
-            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
-            --wait
+          if [ -n "$APPLE_ID" ] && [ -n "$APPLE_TEAM_ID" ] && [ -n "$APPLE_APP_SPECIFIC_PASSWORD" ]; then
+            xcrun notarytool submit "$dmg_path" \
+              --apple-id "$APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+              --wait
+          elif [ -n "$APP_STORE_CONNECT_API_KEY_ID" ] && [ -n "$APP_STORE_CONNECT_API_ISSUER_ID" ] && [ -n "$APP_STORE_CONNECT_API_KEY_BASE64" ]; then
+            key_dir="$RUNNER_TEMP/notarytool/private_keys"
+            key_path="$key_dir/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+            mkdir -p "$key_dir"
+            printf '%s' "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$key_path"
+            chmod 600 "$key_path"
+            xcrun notarytool submit "$dmg_path" \
+              --key "$key_path" \
+              --key-id "$APP_STORE_CONNECT_API_KEY_ID" \
+              --issuer "$APP_STORE_CONNECT_API_ISSUER_ID" \
+              --wait
+          else
+            echo "Skipping notarization because neither Apple ID credentials nor App Store Connect API credentials are configured."
+            exit 0
+          fi
           xcrun stapler staple "$dmg_path"
 
       - name: Build Linux release app
@@ -400,6 +441,141 @@ jobs:
           name: desktop-${{ matrix.target }}-${{ steps.openclaw.outputs.arch }}
           path: desktop-artifacts/*
           if-no-files-found: error
+          retention-days: 30
+
+  upload-macos-app-store:
+    name: Upload macOS build to App Store Connect
+    needs:
+      - resolve-release-context
+    if: needs.resolve-release-context.outputs.upload_macos_app_store == 'true'
+    runs-on: macos-15
+    timeout-minutes: 150
+    permissions:
+      contents: read
+      actions: read
+    defaults:
+      run:
+        working-directory: fabushi
+    env:
+      APP_VERSION: ${{ needs.resolve-release-context.outputs.app_version }}
+      RELEASE_BUILD_NUMBER: ${{ needs.resolve-release-context.outputs.release_build_number }}
+      SOURCE_SHA: ${{ needs.resolve-release-context.outputs.source_sha }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+      MACOS_APP_STORE_UPLOAD_ENABLED: ${{ needs.resolve-release-context.outputs.upload_macos_app_store }}
+      MACOS_APP_STORE_UPLOAD_REQUIRED: ${{ needs.resolve-release-context.outputs.upload_macos_app_store }}
+      MACOS_APP_STORE_TEAM_ID: ${{ vars.MACOS_APP_STORE_TEAM_ID || vars.APPLE_TEAM_ID || 'M4Q99K4UR4' }}
+      MACOS_APP_STORE_BUNDLE_ID: ${{ vars.MACOS_APP_STORE_BUNDLE_ID || 'com.ombhrum.fabushi' }}
+      MACOS_APP_STORE_INTERNAL_TESTING_ONLY: ${{ vars.MACOS_APP_STORE_INTERNAL_TESTING_ONLY || 'false' }}
+      MACOS_APP_STORE_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_APP_STORE_CERTIFICATE_P12_BASE64 }}
+      MACOS_APP_STORE_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_APP_STORE_CERTIFICATE_PASSWORD }}
+      MACOS_APP_STORE_INSTALLER_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_APP_STORE_INSTALLER_CERTIFICATE_P12_BASE64 }}
+      MACOS_APP_STORE_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_APP_STORE_INSTALLER_CERTIFICATE_PASSWORD }}
+      MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64 }}
+      MACOS_APP_STORE_SIGNING_CERTIFICATE: ${{ vars.MACOS_APP_STORE_SIGNING_CERTIFICATE || 'Mac App Distribution' }}
+      MACOS_APP_STORE_INSTALLER_SIGNING_CERTIFICATE: ${{ vars.MACOS_APP_STORE_INSTALLER_SIGNING_CERTIFICATE || 'Mac Installer Distribution' }}
+      MACOS_APP_STORE_STATUS_DIR: ${{ github.workspace }}/macos-app-store-assets
+    steps:
+      - name: Checkout desktop source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve-release-context.outputs.source_sha }}
+          lfs: true
+          fetch-depth: 1
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /*
+            !/fabushi/assets/built_in/**
+            !/fabushi/web/assets/built_in/**
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Set up Node.js for OpenClaw vendoring
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Flutter macOS desktop target
+        run: flutter config --enable-macos-desktop
+
+      - name: Resolve Flutter dependencies
+        run: flutter pub get
+
+      - name: Stabilize macOS native asset toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          developer_dir="$(xcode-select -p)"
+          if [ ! -x "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" ]; then
+            developer_app="$(
+              find /Applications -maxdepth 1 -type d -name 'Xcode*.app' -print |
+                while IFS= read -r app; do
+                  if [ -x "$app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" ]; then
+                    echo "$app"
+                  fi
+                done |
+                sort |
+                tail -n 1
+            )"
+            if [ -z "$developer_app" ]; then
+              echo "Unable to find a usable Xcode installation." >&2
+              exit 1
+            fi
+            sudo xcode-select -s "$developer_app/Contents/Developer"
+            developer_dir="$(xcode-select -p)"
+          fi
+
+          cc="$(xcrun --find clang)"
+          cxx="$(xcrun --find clang++)"
+          {
+            echo "DEVELOPER_DIR=$developer_dir"
+            echo "CC=$cc"
+            echo "CXX=$cxx"
+          } >> "$GITHUB_ENV"
+
+          for package_dir in "$PUB_CACHE"/hosted/pub.dev/flutter_scene_importer-*; do
+            [ -d "$package_dir" ] || continue
+            find "$package_dir" -name CMakeCache.txt -delete
+            find "$package_dir" -type d \( -name CMakeFiles -o -name 'cmake-build-*' -o -name build \) -prune -exec rm -rf {} +
+          done
+
+          xcodebuild -version
+          "$cc" --version
+
+      - name: Stabilize generated desktop plugin bindings
+        shell: bash
+        run: scripts/fix_desktop_generated_plugins.sh
+
+      - name: Vendor embedded OpenClaw runtime
+        shell: bash
+        env:
+          OPENCLAW_VERSION: ${{ env.OPENCLAW_VERSION }}
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            arm64) platform="macos-arm64" ;;
+            *) platform="macos-x64" ;;
+          esac
+          scripts/build_openclaw_desktop_bundle.sh "$platform"
+
+      - name: Archive, export, and upload macOS App Store package
+        shell: bash
+        run: ../.github/scripts/upload-macos-app-store.sh
+
+      - name: Upload macOS App Store package status
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-app-store-status
+          path: macos-app-store-assets
+          if-no-files-found: warn
           retention-days: 30
 
   publish-github-release:

--- a/fabushi/docs/DESKTOP_INSTALLER_CICD.md
+++ b/fabushi/docs/DESKTOP_INSTALLER_CICD.md
@@ -5,26 +5,56 @@
 ## 触发方式
 
 - Pull Request：构建 macOS / Linux / Windows 安装包并上传 workflow artifacts，不创建 GitHub Release。
-- Push main：构建三平台安装包，成功后创建 GitHub Release 并上传产物和 `SHA256SUMS.txt`。
-- workflow_dispatch：可指定 `source_sha`、`release_tag`、`openclaw_version`，也可关闭发布仅做构建验证。
+- Push main：构建三平台安装包，成功后创建 GitHub Release 并上传产物和 `SHA256SUMS.txt`；同时上传 macOS App Store 包到 App Store Connect。
+- workflow_dispatch：可指定 `source_sha`、`release_tag`、`openclaw_version`，也可关闭 GitHub Release 发布或 macOS App Store 上传，仅做构建验证。
 
 ## 产物
 
 - macOS：`.dmg` 和 `.zip`
 - Linux：`.deb` 和 `.tar.gz`
 - Windows：NSIS `.exe` 安装器和 `.zip`
+- Mac App Store Connect：用于 TestFlight/App Store 处理的 `.pkg`，同时保留上传状态 artifact
 
 所有平台在打包前都会运行 `scripts/build_openclaw_desktop_bundle.sh`，把 Node.js 与 OpenClaw runtime vendoring 到 `assets/openclaw/<platform>/`，最终用户无需安装 Node、npm 或 OpenClaw。默认 OpenClaw npm 版本固定为 `2026.6.1`，手动 workflow dispatch 可覆盖。
 
-## 可选签名与公证
+## macOS Developer ID 签名与公证
 
-macOS 发布支持以下 secrets。未配置时产物仍会构建并发布，但不会签名/公证。
+GitHub Release 里的 macOS DMG 面向 App Store 外分发，使用 Developer ID Application 证书签名，并通过 Apple 公证服务检查恶意软件、签发 notarization ticket，再 stapler 到 DMG 上。未配置时产物仍会构建并发布，但不会签名/公证。
 
 - `MACOS_CERTIFICATE_P12_BASE64`
 - `MACOS_CERTIFICATE_PASSWORD`
 - `MACOS_CODESIGN_IDENTITY`
-- `APPLE_ID`
-- `APPLE_TEAM_ID`
-- `APPLE_APP_SPECIFIC_PASSWORD`
+
+公证凭据可二选一：
+
+- App Store Connect API key：`APP_STORE_CONNECT_API_KEY_ID`、`APP_STORE_CONNECT_API_ISSUER_ID`、`APP_STORE_CONNECT_API_KEY_BASE64`
+- Apple ID app-specific password：`APPLE_ID`、`APPLE_TEAM_ID`、`APPLE_APP_SPECIFIC_PASSWORD`
+
+## macOS App Store Connect / TestFlight
+
+macOS App Store 上传使用 `.github/scripts/upload-macos-app-store.sh`，在 main push 或手动 dispatch 开启 `upload_macos_app_store` 时运行。它会 archive/export macOS App Store `.pkg`，用 App Store Connect API key 校验并上传。上传成功后，构建会进入 App Store Connect 的处理流程，可用于 TestFlight 内测或后续提交审核；workflow 不会自动点“提交审核”。
+
+必需 secrets：
+
+- `APP_STORE_CONNECT_API_KEY_ID`
+- `APP_STORE_CONNECT_API_ISSUER_ID`
+- `APP_STORE_CONNECT_API_KEY_BASE64`
+- `MACOS_APP_STORE_CERTIFICATE_P12_BASE64`
+- `MACOS_APP_STORE_CERTIFICATE_PASSWORD`
+- `MACOS_APP_STORE_INSTALLER_CERTIFICATE_P12_BASE64`
+- `MACOS_APP_STORE_INSTALLER_CERTIFICATE_PASSWORD`
+- `MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64`
+
+推荐 variables：
+
+- `MACOS_APP_STORE_TEAM_ID`
+- `MACOS_APP_STORE_BUNDLE_ID`
+- `MACOS_APP_STORE_SIGNING_CERTIFICATE`
+- `MACOS_APP_STORE_INSTALLER_SIGNING_CERTIFICATE`
+- `MACOS_APP_STORE_INTERNAL_TESTING_ONLY`
+
+## 与移动端 CD 的关系
+
+iOS / Android 原来的发布 CD 不被桌面 workflow 替代：Android 继续使用 Google Play service account 和 keystore secrets，iOS 继续使用现有 App Store Connect API key、iOS p12、iOS provisioning profile。新增的 macOS secrets/variables 只服务桌面安装包签名、公证和 Mac App Store/TestFlight 上传。
 
 Windows 代码签名证书暂未接入；当前 workflow 产出可安装 NSIS 包和校验和。


### PR DESCRIPTION
## Summary
- add a macOS App Store Connect upload job for desktop release builds
- support manual Mac App Distribution / Installer signing profile secrets and App Store Connect API upload
- extend Developer ID notarization to use existing App Store Connect API credentials
- document macOS Developer ID, notarization, and Mac App Store/TestFlight CD configuration

## Verification
- ruby YAML parse for `.github/workflows/desktop-installers.yml`
- `bash -n .github/scripts/upload-macos-app-store.sh`
- `git diff --check`

## Configured outside code
- created Apple Developer certificates for Developer ID Application, Mac App Distribution, and Mac Installer Distribution
- created macOS App Store provisioning profile for `M4Q99K4UR4.com.ombhrum.fabushi`
- configured GitHub macOS signing/upload secrets and variables