### PR TITLE
Fix macOS App Store package metadata

### DIFF
--- a/.github/scripts/upload-macos-app-store.sh
+++ b/.github/scripts/upload-macos-app-store.sh
@@ -327,7 +327,10 @@ fi
 short_sha="${SOURCE_SHA:-${GITHUB_SHA:-unknown}}"
 short_sha="${short_sha:0:12}"
 pkg_name="global_dharma_sharing-${version_name}-${build_number}-macos-app-store-${short_sha}.pkg"
-cp "$pkg_path" "$status_dir/$pkg_name"
+{
+  echo "package_name=$pkg_name"
+  echo "package_path=$pkg_path"
+} > "$status_dir/MACOS_APP_STORE_PACKAGE.txt"
 
 xcrun altool --validate-app \
   --type macos \

--- a/fabushi/macos/Runner/Info.plist
+++ b/fabushi/macos/Runner/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.education</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
## Summary
- Add the required macOS App Store LSApplicationCategoryType to Runner Info.plist
- Keep the macOS App Store upload status artifact text-only instead of copying the exported .pkg into it

## Validation
- /usr/bin/plutil -lint fabushi/macos/Runner/Info.plist
- /usr/libexec/PlistBuddy -c 'Print :LSApplicationCategoryType' fabushi/macos/Runner/Info.plist
- bash -n .github/scripts/upload-macos-app-store.sh
- git diff --check