### PR TITLE
feat: add inbound link dharma publishing flow

### DIFF
--- a/fabushi/android/app/src/main/AndroidManifest.xml
+++ b/fabushi/android/app/src/main/AndroidManifest.xml
@@ -99,6 +99,19 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="globaldharma"/>
             </intent-filter>
+
+            <!-- 接收来自豆包、浏览器、笔记应用等外部 App 的文字/链接分享 -->
+            <intent-filter android:label="法布施">
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/*"/>
+            </intent-filter>
+
+            <intent-filter android:label="法布施">
+                <action android:name="android.intent.action.SEND_MULTIPLE"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/*"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
@@ -129,6 +142,20 @@
         <intent>
             <action android:name="android.intent.action.VIEW"/>
             <data android:scheme="alipay"/>
+        </intent>
+
+        <!-- 自媒体平台发布/分享目标可见性声明 -->
+        <package android:name="com.tencent.mm"/>
+        <package android:name="com.xingin.xhs"/>
+        <package android:name="com.ss.android.ugc.aweme"/>
+        <package android:name="com.sina.weibo"/>
+        <package android:name="com.ss.android.article.news"/>
+        <package android:name="tv.danmaku.bili"/>
+        <package android:name="com.smile.gifmaker"/>
+        <package android:name="com.zhihu.android"/>
+        <intent>
+            <action android:name="android.intent.action.SEND"/>
+            <data android:mimeType="text/plain"/>
         </intent>
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>

--- a/fabushi/android/app/src/main/kotlin/com/ombhrum/fabushi/MainActivity.kt
+++ b/fabushi/android/app/src/main/kotlin/com/ombhrum/fabushi/MainActivity.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.net.Uri
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
 import androidx.annotation.NonNull
@@ -20,8 +21,12 @@ class MainActivity : FlutterFragmentActivity() {
     private val CHANNEL = "com.fabushi.app/hotspot"
     private val DEVICE_INFO_CHANNEL = "com.ombhrum.fabushi/device_info"
     private val MEMORY_CHANNEL = "com.ombhrum.fabushi/memory"
+    private val INBOUND_SHARE_CHANNEL = "com.ombhrum.fabushi/inbound_share"
+    private val PLATFORM_PUBLISH_CHANNEL = "com.ombhrum.fabushi/platform_publish"
     
     private var memoryChannel: MethodChannel? = null
+    private var inboundShareChannel: MethodChannel? = null
+    private var pendingSharePayload: Map<String, Any?>? = null
     
     companion object {
         private const val TAG = "MainActivity"
@@ -37,6 +42,25 @@ class MainActivity : FlutterFragmentActivity() {
                 Log.i(TAG, "Native libraries loaded successfully")
             } catch (e: Throwable) {
                 Log.e(TAG, "Failed to load native libraries: ${e.message}")
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pendingSharePayload = extractSharePayload(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        val payload = extractSharePayload(intent)
+        if (payload != null) {
+            pendingSharePayload = payload
+            try {
+                inboundShareChannel?.invokeMethod("onIncomingShare", payload)
+            } catch (e: Exception) {
+                Log.w(TAG, "Notify Flutter incoming share failed: ${e.message}")
             }
         }
     }
@@ -96,7 +120,136 @@ class MainActivity : FlutterFragmentActivity() {
         
         // 内存管理 Method Channel
         memoryChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, MEMORY_CHANNEL)
+
+        // 外部分享入口：接收来自豆包、浏览器等应用的链接或文本
+        inboundShareChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, INBOUND_SHARE_CHANNEL)
+        inboundShareChannel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getInitialShare" -> result.success(pendingSharePayload ?: emptyMap<String, Any?>())
+                "clearInitialShare" -> {
+                    pendingSharePayload = null
+                    result.success(true)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // 平台发布入口：把准备好的草稿交给 Android 分享/发布目标
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, PLATFORM_PUBLISH_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "shareToPlatform" -> {
+                    val args = call.arguments as? Map<*, *> ?: emptyMap<String, Any?>()
+                    val response = shareToPlatform(
+                        packageName = args["packageName"]?.toString(),
+                        platformName = args["platformName"]?.toString() ?: "目标平台",
+                        title = args["title"]?.toString() ?: "",
+                        text = args["text"]?.toString() ?: "",
+                        url = args["url"]?.toString() ?: ""
+                    )
+                    result.success(response)
+                }
+                else -> result.notImplemented()
+            }
+        }
     }
+
+
+    private fun extractSharePayload(intent: Intent?): Map<String, Any?>? {
+        if (intent == null) return null
+        val action = intent.action ?: return null
+        if (action != Intent.ACTION_SEND &&
+            action != Intent.ACTION_SEND_MULTIPLE &&
+            action != Intent.ACTION_VIEW
+        ) {
+            return null
+        }
+
+        val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT)
+            ?: intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
+            ?: intent.getStringExtra(Intent.EXTRA_HTML_TEXT)
+            ?: ""
+        val dataText = intent.data?.toString() ?: ""
+        val subject = intent.getStringExtra(Intent.EXTRA_SUBJECT) ?: ""
+        val combinedText = listOf(sharedText, dataText)
+            .filter { it.isNotBlank() }
+            .joinToString("\n")
+            .trim()
+        val firstUrl = firstHttpUrl(combinedText)
+            ?: dataText.takeIf { it.startsWith("http://") || it.startsWith("https://") }
+            ?: ""
+
+        if (combinedText.isBlank() && firstUrl.isBlank()) return null
+
+        return mapOf(
+            "text" to combinedText,
+            "url" to firstUrl,
+            "title" to subject,
+            "mimeType" to (intent.type ?: ""),
+            "sourcePackage" to (callingPackage ?: intent.getStringExtra(Intent.EXTRA_REFERRER_NAME) ?: ""),
+            "receivedAt" to System.currentTimeMillis().toString()
+        )
+    }
+
+    private fun firstHttpUrl(value: String): String? {
+        val match = Regex("https?://[^\\s]+", RegexOption.IGNORE_CASE).find(value) ?: return null
+        return match.value.trimEnd('，', '。', '、', ',', '.', ')', '）', ']', '】', '>', '》')
+    }
+
+    private fun shareToPlatform(
+        packageName: String?,
+        platformName: String,
+        title: String,
+        text: String,
+        url: String
+    ): Map<String, Any> {
+        if (text.isBlank() && url.isBlank()) {
+            return mapOf(
+                "success" to false,
+                "message" to "草稿内容为空，未拉起 $platformName"
+            )
+        }
+
+        val shareText = if (text.isBlank()) url else text
+        val targeted = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, title)
+            putExtra(Intent.EXTRA_TEXT, shareText)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            if (!packageName.isNullOrBlank()) setPackage(packageName)
+        }
+
+        val pm = packageManager
+        val canOpenTarget = targeted.resolveActivity(pm) != null
+        return try {
+            if (canOpenTarget) {
+                startActivity(targeted)
+                mapOf(
+                    "success" to true,
+                    "message" to "已拉起 $platformName，草稿内容已注入系统分享入口"
+                )
+            } else {
+                val fallback = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_SUBJECT, title)
+                    putExtra(Intent.EXTRA_TEXT, shareText)
+                }
+                val chooser = Intent.createChooser(fallback, "选择发布到 $platformName")
+                chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(chooser)
+                mapOf(
+                    "success" to true,
+                    "message" to "未找到 $platformName 专用入口，已打开系统分享面板"
+                )
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Share to platform failed", e)
+            mapOf(
+                "success" to false,
+                "message" to "拉起 $platformName 失败：${e.message ?: "未知错误"}"
+            )
+        }
+    }
+
 
     private fun registerFlutterPlugins(flutterEngine: FlutterEngine) {
         // Skip ffmpeg_kit_flutter_new_audio on Android startup. Its native library can

--- a/fabushi/lib/screens/dharma_publish_browser_screen.dart
+++ b/fabushi/lib/screens/dharma_publish_browser_screen.dart
@@ -1,0 +1,395 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import '../core/design_system/app_theme.dart';
+import '../services/dharma_publish_service.dart';
+
+class DharmaPublishBrowserScreen extends StatefulWidget {
+  final DharmaPublishDraft draft;
+  final List<DharmaPublishPlatform> platforms;
+
+  const DharmaPublishBrowserScreen({
+    super.key,
+    required this.draft,
+    required this.platforms,
+  });
+
+  @override
+  State<DharmaPublishBrowserScreen> createState() =>
+      _DharmaPublishBrowserScreenState();
+}
+
+class _DharmaPublishBrowserScreenState
+    extends State<DharmaPublishBrowserScreen> {
+  InAppWebViewController? _controller;
+  int _currentIndex = 0;
+  bool _loading = true;
+  bool _runningScript = false;
+  final Map<DharmaPublishPlatform, List<String>> _steps = {};
+  final Set<DharmaPublishPlatform> _completed = {};
+
+  DharmaPublishPlatform get _currentPlatform => widget.platforms[_currentIndex];
+
+  @override
+  void initState() {
+    super.initState();
+    for (final platform in widget.platforms) {
+      _steps[platform] = <String>[
+        '已创建发布任务：${platform.info.label}',
+      ];
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _copyDraftToClipboard();
+    });
+  }
+
+  Future<void> _copyDraftToClipboard() async {
+    await Clipboard.setData(ClipboardData(text: widget.draft.fullText));
+    _addStep(_currentPlatform, '已把完整草稿复制到剪贴板，可随时粘贴。');
+  }
+
+  void _addStep(DharmaPublishPlatform platform, String message) {
+    if (!mounted) return;
+    setState(() {
+      _steps.putIfAbsent(platform, () => <String>[]).add(message);
+    });
+  }
+
+  Future<void> _runAutofill() async {
+    final controller = _controller;
+    if (controller == null || _runningScript) return;
+    setState(() => _runningScript = true);
+    final platform = _currentPlatform;
+    try {
+      await _copyDraftToClipboard();
+      final payload = jsonEncode({
+        'title': widget.draft.title,
+        'body': widget.draft.body,
+        'sourceUrl': widget.draft.sourceUrl,
+        'tags': widget.draft.tags.map((tag) => '#$tag').join(' '),
+        'fullText': widget.draft.fullText,
+      });
+      final result = await controller.evaluateJavascript(
+        source: _autofillScript(payload),
+      );
+      final text = result?.toString() ?? '';
+      _addStep(
+        platform,
+        text.isEmpty ? '已执行页面自动填充脚本。' : '页面自动填充结果：$text',
+      );
+      _addStep(platform, '请在页面中检查标题、正文和附件，再点击平台自己的发布/保存按钮。');
+    } catch (e) {
+      _addStep(platform, '自动填充脚本执行失败：$e');
+    } finally {
+      if (mounted) setState(() => _runningScript = false);
+    }
+  }
+
+  String _autofillScript(String payloadJson) {
+    return '''
+(() => {
+  const payload = $payloadJson;
+  const visible = (el) => {
+    const style = window.getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    return style && style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+  };
+  const textInputs = Array.from(document.querySelectorAll('input, textarea, [contenteditable="true"], [role="textbox"]'))
+    .filter(visible);
+  const fire = (el) => {
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
+  };
+  const labelOf = (el) => [
+    el.getAttribute('placeholder') || '',
+    el.getAttribute('aria-label') || '',
+    el.getAttribute('name') || '',
+    el.id || '',
+    el.className || '',
+    el.parentElement?.innerText?.slice(0, 60) || ''
+  ].join(' ').toLowerCase();
+  const setValue = (el, value) => {
+    if (!el || !value) return false;
+    el.focus();
+    if (el.isContentEditable || el.getAttribute('contenteditable') === 'true' || el.getAttribute('role') === 'textbox') {
+      el.innerText = value;
+    } else {
+      el.value = value;
+    }
+    fire(el);
+    return true;
+  };
+  const titleInput = textInputs.find((el) => /title|标题|题目|headline|subject/.test(labelOf(el))) || textInputs.find((el) => el.tagName === 'INPUT');
+  const bodyInput = textInputs.find((el) => /content|正文|内容|描述|介绍|article|editor|文本/.test(labelOf(el)))
+    || textInputs.filter((el) => el !== titleInput).sort((a, b) => (b.getBoundingClientRect().height || 0) - (a.getBoundingClientRect().height || 0))[0]
+    || textInputs.find((el) => el !== titleInput);
+  const titleOk = setValue(titleInput, payload.title);
+  const bodyText = [payload.body, payload.sourceUrl ? '来源链接：' + payload.sourceUrl : '', payload.tags].filter(Boolean).join('\n\n');
+  const bodyOk = setValue(bodyInput, bodyText || payload.fullText);
+  return JSON.stringify({ titleFilled: titleOk, bodyFilled: bodyOk, editableCount: textInputs.length, pageTitle: document.title });
+})();
+''';
+  }
+
+  List<DharmaPublishResult> _buildResults({required bool finished}) {
+    return widget.platforms.map((platform) {
+      final steps = List<String>.from(_steps[platform] ?? const <String>[]);
+      final success = finished || _completed.contains(platform);
+      return DharmaPublishResult(
+        platform: platform,
+        success: success,
+        message: success
+            ? '已在内置浏览器打开 ${platform.info.label} 并准备草稿'
+            : '已记录 ${platform.info.label} 的浏览器步骤，尚未标记完成',
+        steps: steps,
+      );
+    }).toList();
+  }
+
+  Future<void> _markCurrentDone() async {
+    final platform = _currentPlatform;
+    _addStep(platform, '用户已确认此平台页面处理完成。');
+    setState(() => _completed.add(platform));
+    if (_currentIndex < widget.platforms.length - 1) {
+      setState(() {
+        _currentIndex += 1;
+        _loading = true;
+      });
+      await _controller?.loadUrl(
+        urlRequest: URLRequest(
+          url: WebUri(widget.platforms[_currentIndex].info.desktopUrl),
+        ),
+      );
+      await _copyDraftToClipboard();
+    } else if (mounted) {
+      Navigator.pop(context, _buildResults(finished: true));
+    }
+  }
+
+  Future<void> _finishAll() async {
+    if (!mounted) return;
+    Navigator.pop(context, _buildResults(finished: true));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final platform = _currentPlatform;
+    final steps = _steps[platform] ?? const <String>[];
+    return Scaffold(
+      backgroundColor: const Color(0xFF101010),
+      appBar: AppBar(
+        title: Text('法布施到平台：${platform.info.label}'),
+        backgroundColor: const Color(0xFF151515),
+        actions: [
+          TextButton.icon(
+            onPressed: _runningScript ? null : _runAutofill,
+            icon: const Icon(Icons.auto_fix_high),
+            label: Text(_runningScript ? '填充中' : '填充草稿'),
+          ),
+          TextButton.icon(
+            onPressed: _markCurrentDone,
+            icon: const Icon(Icons.done),
+            label: Text(_currentIndex < widget.platforms.length - 1 ? '下一平台' : '完成'),
+          ),
+        ],
+      ),
+      body: Row(
+        children: [
+          SizedBox(
+            width: 330,
+            child: Container(
+              color: const Color(0xFF181818),
+              child: SafeArea(
+                top: false,
+                child: ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    Text(
+                      '发布草稿',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w800,
+                          ),
+                    ),
+                    const SizedBox(height: 10),
+                    SelectableText(
+                      widget.draft.fullText,
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 13,
+                        height: 1.42,
+                      ),
+                    ),
+                    const SizedBox(height: 18),
+                    Text(
+                      '平台进度',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w800,
+                          ),
+                    ),
+                    const SizedBox(height: 8),
+                    for (var i = 0; i < widget.platforms.length; i++)
+                      _BrowserPlatformTile(
+                        platform: widget.platforms[i],
+                        selected: i == _currentIndex,
+                        done: _completed.contains(widget.platforms[i]),
+                        onTap: () async {
+                          setState(() {
+                            _currentIndex = i;
+                            _loading = true;
+                          });
+                          await _controller?.loadUrl(
+                            urlRequest: URLRequest(
+                              url: WebUri(widget.platforms[i].info.desktopUrl),
+                            ),
+                          );
+                        },
+                      ),
+                    const SizedBox(height: 18),
+                    ExpansionTile(
+                      initiallyExpanded: true,
+                      collapsedIconColor: Colors.white70,
+                      iconColor: AppTheme.primaryColor,
+                      title: const Text(
+                        '当前步骤',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      children: [
+                        for (final step in steps)
+                          ListTile(
+                            dense: true,
+                            leading: const Icon(
+                              Icons.check_circle_outline,
+                              color: Colors.white54,
+                              size: 18,
+                            ),
+                            title: Text(
+                              step,
+                              style: const TextStyle(
+                                color: Colors.white70,
+                                fontSize: 12,
+                                height: 1.3,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    FilledButton.icon(
+                      onPressed: _finishAll,
+                      icon: const Icon(Icons.fact_check_outlined),
+                      label: const Text('汇总返回对话'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Stack(
+              children: [
+                InAppWebView(
+                  initialUrlRequest: URLRequest(
+                    url: WebUri(platform.info.desktopUrl),
+                  ),
+                  initialSettings: InAppWebViewSettings(
+                    javaScriptEnabled: true,
+                    mediaPlaybackRequiresUserGesture: false,
+                  ),
+                  onWebViewCreated: (controller) {
+                    _controller = controller;
+                  },
+                  onLoadStart: (controller, url) {
+                    setState(() => _loading = true);
+                    _addStep(platform, '打开页面：${url?.toString() ?? platform.info.desktopUrl}');
+                  },
+                  onLoadStop: (controller, url) async {
+                    setState(() => _loading = false);
+                    _addStep(platform, '页面加载完成：${url?.toString() ?? ''}');
+                    await _runAutofill();
+                  },
+                  onReceivedError: (controller, request, error) {
+                    _addStep(platform, '页面加载错误：${error.description}');
+                  },
+                ),
+                if (_loading)
+                  const Positioned.fill(
+                    child: ColoredBox(
+                      color: Color(0x33000000),
+                      child: Center(child: CircularProgressIndicator()),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BrowserPlatformTile extends StatelessWidget {
+  final DharmaPublishPlatform platform;
+  final bool selected;
+  final bool done;
+  final VoidCallback onTap;
+
+  const _BrowserPlatformTile({
+    required this.platform,
+    required this.selected,
+    required this.done,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: selected
+                ? AppTheme.primaryColor.withValues(alpha: 0.15)
+                : Colors.white.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: selected
+                  ? AppTheme.primaryColor.withValues(alpha: 0.5)
+                  : Colors.white.withValues(alpha: 0.08),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                done ? Icons.check_circle : Icons.radio_button_unchecked,
+                color: done ? AppTheme.primaryColor : Colors.white54,
+                size: 19,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  platform.info.label,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -12,6 +12,9 @@ import '../features/auth/application/auth_model.dart';
 import '../models/file_transfer_model.dart';
 import '../services/ai_backend_policy.dart';
 import '../services/dacheng_ai_service.dart';
+import '../services/dharma_publish_service.dart';
+import '../services/inbound_share_service.dart';
+import 'dharma_publish_browser_screen.dart';
 import '../widgets/earth_globe_widget.dart';
 import '../widgets/home_world_2d_widget.dart';
 import '../widgets/scene_render_mode.dart';
@@ -42,9 +45,14 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   bool _isCallbackSetup = false;
   bool _isVisible = true;
   bool _isDharmaComposerMode = false;
+  DharmaComposerTarget _dharmaComposerTarget = DharmaComposerTarget.global;
+  final Set<DharmaPublishPlatform> _selectedPublishPlatforms = {
+    DharmaPublishPlatform.xiaohongshu,
+  };
   bool _showMaterialGallery = false;
   bool _isGlobalSendTimelineVisible = false;
   bool _isAiGenerating = false;
+  bool _isPublishingDraft = false;
   String _streamingAiText = '';
   String _aiActivityText = '';
   SceneRenderMode _renderMode = SceneRenderMode.twoD;
@@ -54,6 +62,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   final List<_HomeConversation> _conversationHistory = [];
   StreamSubscription<DachengAiStreamEvent>? _aiStreamSubscription;
   final DachengAiService _dachengAiService = DachengAiService();
+  final DharmaPublishService _dharmaPublishService = DharmaPublishService();
+  StreamSubscription<IncomingSharePayload>? _incomingShareSubscription;
+  String? _lastIncomingShareFingerprint;
   String? _activeConversationId;
   int _aiRequestSerial = 0;
   final _onlineCounterService = OnlineCounterService();
@@ -161,10 +172,14 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     WidgetsBinding.instance.addObserver(this);
     _loadGlobe();
     _fetchInitialCount();
+    InboundShareService.instance.start();
+    _incomingShareSubscription = InboundShareService.instance.incomingShares
+        .listen((payload) => unawaited(_handleIncomingShare(payload)));
     _onlineCounterService.startCountPolling('global_sending');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       unawaited(_loadRemoteConversations());
       unawaited(_refreshBuddhaAssetEntitlement());
+      unawaited(_consumeInitialShare());
     });
   }
 
@@ -242,6 +257,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         _isCallbackSetup = false;
         _setupTransferBeamCallback();
       }
+      unawaited(_consumeInitialShare());
     }
   }
 
@@ -263,6 +279,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       ).setTransferBeamCallback(null);
     } catch (_) {}
     _onlineCounterService.dispose();
+    _incomingShareSubscription?.cancel();
     _aiStreamSubscription?.cancel();
     _chatInputController.dispose();
     _homeChatScrollController.dispose();
@@ -1234,10 +1251,14 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   Widget _buildChatComposer(BuildContext context, FileTransferModel model) {
     final isBusy =
         model.isPreparingSend ||
+        _isPublishingDraft ||
         (_isDharmaComposerMode && model.isTransferring);
     final inputText = _chatInputController.text.trim();
     final canSubmit = _isDharmaComposerMode
-        ? (inputText.isNotEmpty || model.hasFiles)
+        ? _dharmaComposerTarget == DharmaComposerTarget.platform
+              ? (inputText.isNotEmpty || model.hasFiles) &&
+                    _selectedPublishPlatforms.isNotEmpty
+              : (inputText.isNotEmpty || model.hasFiles)
         : inputText.isNotEmpty;
 
     return Container(
@@ -1271,26 +1292,35 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     active: true,
                     onRemove: () => _clearDharmaMode(model),
                   ),
-                  _ComposerChip(
-                    icon: Icons.public,
-                    label: '地区 ${_regionSummary(model)}',
-                    active:
-                        model.isGlobalSendEnabled ||
-                        model.isFieldEnergyMode ||
-                        model.isLocalLoopbackEnabled,
-                    onTap: isBusy ? null : () => _showRegionSelector(model),
-                  ),
-                  _ComposerChip(
-                    icon: Icons.loop,
-                    label: model.isLooping ? '循环' : '单轮',
-                    active: model.isLooping,
-                    onTap: isBusy
-                        ? null
-                        : () {
-                            model.setLooping(!model.isLooping);
-                            setState(() {});
-                          },
-                  ),
+                  if (_dharmaComposerTarget == DharmaComposerTarget.platform)
+                    _ComposerChip(
+                      icon: Icons.campaign_outlined,
+                      label: '平台 ${_platformSummary()}',
+                      active: _selectedPublishPlatforms.isNotEmpty,
+                      onTap: isBusy ? null : () => _showPublishPlatformSelector(),
+                    )
+                  else ...[
+                    _ComposerChip(
+                      icon: Icons.public,
+                      label: '地区 ${_regionSummary(model)}',
+                      active:
+                          model.isGlobalSendEnabled ||
+                          model.isFieldEnergyMode ||
+                          model.isLocalLoopbackEnabled,
+                      onTap: isBusy ? null : () => _showRegionSelector(model),
+                    ),
+                    _ComposerChip(
+                      icon: Icons.loop,
+                      label: model.isLooping ? '循环' : '单轮',
+                      active: model.isLooping,
+                      onTap: isBusy
+                          ? null
+                          : () {
+                              model.setLooping(!model.isLooping);
+                              setState(() {});
+                            },
+                    ),
+                  ],
                   if (model.hasFiles)
                     _ComposerChip(
                       icon: _contentIcon(model.selectedContentKind),
@@ -1352,7 +1382,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     isDense: true,
                     border: InputBorder.none,
                     hintText: _isDharmaComposerMode
-                        ? (model.hasFiles ? '可继续输入法布施文字或链接' : '输入文字或链接')
+                        ? _dharmaComposerTarget == DharmaComposerTarget.platform
+                              ? (model.hasFiles ? '可继续输入发布说明' : '粘贴要发布的链接或正文')
+                              : (model.hasFiles ? '可继续输入法布施文字或链接' : '输入文字或链接')
                         : '问问 AI',
                     hintStyle: const TextStyle(
                       color: Colors.white54,
@@ -1378,6 +1410,23 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     FileTransferModel model, {
     required bool canSubmit,
   }) {
+    if (_isPublishingDraft) {
+      return Container(
+        width: 42,
+        height: 42,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.1),
+          shape: BoxShape.circle,
+        ),
+        child: const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+
     if (model.isPreparingSend) {
       return Container(
         width: 42,
@@ -1420,7 +1469,11 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     }
 
     return IconButton(
-      tooltip: _isDharmaComposerMode ? '开始法布施' : '发送消息',
+      tooltip: _isDharmaComposerMode
+          ? _dharmaComposerTarget == DharmaComposerTarget.platform
+                ? '预览并发布'
+                : '开始法布施'
+          : '发送消息',
       icon: Icon(
         Icons.arrow_upward,
         color: canSubmit ? Colors.black : Colors.white54,
@@ -1468,7 +1521,16 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           'dharma',
           Icons.self_improvement,
           '全球法布施',
-          _isDharmaComposerMode ? '已选择，可在输入框上方调整' : '默认全球发送',
+          _isDharmaComposerMode &&
+                  _dharmaComposerTarget == DharmaComposerTarget.global
+              ? '已选择，可在输入框上方调整'
+              : '默认全球发送',
+        ),
+        _sendMenuItem(
+          'platform_publish',
+          Icons.campaign_outlined,
+          '法布施到平台',
+          '公众号、小红书、抖音、微博等多选',
         ),
         _sendMenuItem(
           'files',
@@ -1501,11 +1563,20 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     String action,
   ) async {
     if (action == 'dharma') {
-      _activateDharmaMode(model, showMaterials: true);
+      _activateDharmaMode(
+        model,
+        showMaterials: true,
+        target: DharmaComposerTarget.global,
+      );
       return true;
     }
+    if (action == 'platform_publish') {
+      _activateDharmaMode(model, target: DharmaComposerTarget.platform);
+      await _showPublishPlatformSelector();
+      return _selectedPublishPlatforms.isNotEmpty;
+    }
     if (action == 'files') {
-      _activateDharmaMode(model);
+      _activateDharmaMode(model, target: _dharmaComposerTarget);
       final selected = await model.selectFiles(replaceExisting: true);
       if (selected && mounted) setState(() {});
       return selected;
@@ -1515,7 +1586,11 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
 
   void _submitComposer(FileTransferModel model) {
     if (_isDharmaComposerMode) {
-      _startSending(model);
+      if (_dharmaComposerTarget == DharmaComposerTarget.platform) {
+        unawaited(_startPlatformPublish(model));
+      } else {
+        _startSending(model);
+      }
     } else {
       _sendAiChatFromComposer();
     }
@@ -1524,19 +1599,23 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   void _activateDharmaMode(
     FileTransferModel model, {
     bool showMaterials = false,
+    DharmaComposerTarget target = DharmaComposerTarget.global,
   }) {
-    if (model.countryList.isEmpty) {
-      model.setCountryList(['ALL']);
-    }
-    if (!model.isGlobalSendEnabled &&
-        !model.isFieldEnergyMode &&
-        !model.isLocalLoopbackEnabled) {
-      model.setGlobalSendEnabled(true);
-      model.setCountryList(['ALL']);
+    if (target == DharmaComposerTarget.global) {
+      if (model.countryList.isEmpty) {
+        model.setCountryList(['ALL']);
+      }
+      if (!model.isGlobalSendEnabled &&
+          !model.isFieldEnergyMode &&
+          !model.isLocalLoopbackEnabled) {
+        model.setGlobalSendEnabled(true);
+        model.setCountryList(['ALL']);
+      }
     }
     setState(() {
       _isDharmaComposerMode = true;
-      _showMaterialGallery = showMaterials;
+      _dharmaComposerTarget = target;
+      _showMaterialGallery = showMaterials && target == DharmaComposerTarget.global;
     });
   }
 
@@ -1545,6 +1624,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     model.clearFiles();
     setState(() {
       _isDharmaComposerMode = false;
+      _dharmaComposerTarget = DharmaComposerTarget.global;
       _showMaterialGallery = false;
     });
   }
@@ -1584,6 +1664,773 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         .toList();
     entries.sort((a, b) => a.value.compareTo(b.value));
     return entries;
+  }
+
+  String _platformSummary() {
+    if (_selectedPublishPlatforms.isEmpty) return '未选择';
+    final labels = _selectedPublishPlatforms
+        .map((platform) => platform.info.shortLabel)
+        .toList();
+    if (labels.length <= 2) return labels.join('、');
+    return '${labels.take(2).join('、')} 等 ${labels.length} 个';
+  }
+
+  Future<void> _showPublishPlatformSelector() async {
+    final selected = Set<DharmaPublishPlatform>.from(_selectedPublishPlatforms);
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (sheetContext, setSheetState) {
+            return SafeArea(
+              top: false,
+              child: Container(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(sheetContext).size.height * 0.76,
+                ),
+                padding: const EdgeInsets.fromLTRB(18, 10, 18, 18),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF202020),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: Container(
+                        width: 42,
+                        height: 4,
+                        margin: const EdgeInsets.only(bottom: 14),
+                        decoration: BoxDecoration(
+                          color: Colors.white24,
+                          borderRadius: BorderRadius.circular(999),
+                        ),
+                      ),
+                    ),
+                    Row(
+                      children: [
+                        const Expanded(
+                          child: Text(
+                            '选择法布施平台',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 20,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        TextButton(
+                          onPressed: () => setSheetState(() {
+                            selected
+                              ..clear()
+                              ..addAll(DharmaPublishService.allPlatforms);
+                          }),
+                          child: const Text('全选'),
+                        ),
+                        TextButton(
+                          onPressed: () => setSheetState(selected.clear),
+                          child: const Text('清空'),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    const Text(
+                      '发布前会先下载/整理链接内容，缺少标题或正文时会在对话里补全并预览。',
+                      style: TextStyle(color: Colors.white60, fontSize: 13),
+                    ),
+                    const SizedBox(height: 14),
+                    Expanded(
+                      child: ListView(
+                        children: [
+                          for (final platform in DharmaPublishService.allPlatforms)
+                            _PlatformCheckTile(
+                              platform: platform,
+                              selected: selected.contains(platform),
+                              onChanged: (checked) {
+                                setSheetState(() {
+                                  if (checked) {
+                                    selected.add(platform);
+                                  } else {
+                                    selected.remove(platform);
+                                  }
+                                });
+                              },
+                            ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton(
+                            onPressed: () => Navigator.pop(sheetContext),
+                            child: const Text('取消'),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: FilledButton(
+                            onPressed: selected.isEmpty
+                                ? null
+                                : () {
+                                    setState(() {
+                                      _selectedPublishPlatforms
+                                        ..clear()
+                                        ..addAll(selected);
+                                    });
+                                    Navigator.pop(sheetContext);
+                                  },
+                            child: const Text('完成'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _consumeInitialShare() async {
+    final payload = await InboundShareService.instance.takeInitialShare();
+    if (payload == null || payload.isEmpty || !mounted) return;
+    await _handleIncomingShare(payload);
+    await InboundShareService.instance.clearInitialShare();
+  }
+
+  Future<void> _handleIncomingShare(IncomingSharePayload payload) async {
+    if (!mounted || payload.isEmpty) return;
+    final fingerprint = '${payload.bestText}|${payload.title}|${payload.sourcePackage}';
+    if (_lastIncomingShareFingerprint == fingerprint) return;
+    _lastIncomingShareFingerprint = fingerprint;
+
+    final model = Provider.of<FileTransferModel>(context, listen: false);
+    final sharedText = _normalizeIncomingShareText(payload);
+    final candidateUrl = payload.url.trim().isNotEmpty
+        ? payload.url.trim()
+        : _firstHttpUrl(sharedText);
+    final composerText = candidateUrl ?? sharedText;
+    if (composerText.trim().isEmpty) return;
+
+    if (mounted) {
+      _chatInputController.text = composerText.trim();
+      _chatInputController.selection = TextSelection.collapsed(
+        offset: _chatInputController.text.length,
+      );
+      setState(() {});
+    }
+
+    final target = await _showIncomingShareTargetSheet(payload, composerText);
+    if (target == null || !mounted) return;
+
+    _activateDharmaMode(model, target: target);
+    if (target == DharmaComposerTarget.platform) {
+      await _showPublishPlatformSelector();
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _homeChatMessages.add(
+        _HomeChatMessage(
+          text: [
+            '已接收外部分享。',
+            '',
+            '来源：${payload.displaySource}',
+            '模式：${target == DharmaComposerTarget.global ? "全球法布施" : "法布施到平台"}',
+            if (candidateUrl != null) '链接：$candidateUrl',
+          ].join('\n'),
+          isUser: false,
+        ),
+      );
+    });
+    _scrollHomeChatToBottom();
+  }
+
+  Future<DharmaComposerTarget?> _showIncomingShareTargetSheet(
+    IncomingSharePayload payload,
+    String text,
+  ) {
+    final preview = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    return showModalBottomSheet<DharmaComposerTarget>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return SafeArea(
+          top: false,
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(18, 10, 18, 18),
+            decoration: const BoxDecoration(
+              color: Color(0xFF202020),
+              borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 42,
+                    height: 4,
+                    margin: const EdgeInsets.only(bottom: 14),
+                    decoration: BoxDecoration(
+                      color: Colors.white24,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                ),
+                const Text(
+                  '收到外部分享',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  preview.length > 120 ? '${preview.substring(0, 120)}...' : preview,
+                  style: const TextStyle(color: Colors.white60, height: 1.35),
+                ),
+                const SizedBox(height: 16),
+                _ShareTargetTile(
+                  icon: Icons.public,
+                  title: '全球法布施',
+                  subtitle: '把链接放入输入框，点击发送后下载内容并进行全球法布施。',
+                  onTap: () => Navigator.pop(
+                    sheetContext,
+                    DharmaComposerTarget.global,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                _ShareTargetTile(
+                  icon: Icons.campaign_outlined,
+                  title: '法布施到平台',
+                  subtitle: '选择公众号、小红书、抖音、微博等平台，补齐标题正文后预览发布。',
+                  onTap: () => Navigator.pop(
+                    sheetContext,
+                    DharmaComposerTarget.platform,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: () => Navigator.pop(sheetContext),
+                    child: const Text('先放到输入框'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _normalizeIncomingShareText(IncomingSharePayload payload) {
+    final parts = <String>[
+      if (payload.title.trim().isNotEmpty) payload.title.trim(),
+      if (payload.text.trim().isNotEmpty) payload.text.trim(),
+      if (payload.url.trim().isNotEmpty && !payload.text.contains(payload.url))
+        payload.url.trim(),
+    ];
+    return parts.join('\n').trim();
+  }
+
+  String? _firstHttpUrl(String text) {
+    final match = RegExp(
+      r'https?://[^\s]+',
+      caseSensitive: false,
+    ).firstMatch(text.trim());
+    if (match == null) return null;
+    return match
+        .group(0)!
+        .replaceAll(RegExp(r'[，。、,.)）\]】>》]+$'), '')
+        .trim();
+  }
+
+  Future<bool> _prepareComposerContentForModel(
+    FileTransferModel model,
+    String composerText,
+  ) async {
+    final text = composerText.trim();
+    if (text.isEmpty) return model.hasFiles;
+
+    final link = _firstHttpUrl(text);
+    if (link != null) {
+      await model.addUrlContentForSending(link);
+    } else {
+      await model.addTextContentForSending(
+        title: '法布施',
+        text: text,
+        sourceKind: '文本',
+        replaceExisting: !model.hasFiles,
+      );
+    }
+
+    _chatInputController.clear();
+    if (mounted) setState(() {});
+    return true;
+  }
+
+  Future<void> _startPlatformPublish(FileTransferModel model) async {
+    if (model.isPreparingSend || _isPublishingDraft) return;
+    if (_selectedPublishPlatforms.isEmpty) {
+      await _showPublishPlatformSelector();
+      if (_selectedPublishPlatforms.isEmpty) return;
+    }
+
+    final composerText = _chatInputController.text.trim();
+    if (composerText.isEmpty && !model.hasFiles) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('请先粘贴链接或输入要发布的正文。'),
+          backgroundColor: Colors.black87,
+        ),
+      );
+      return;
+    }
+
+    setState(() => _isPublishingDraft = true);
+    DharmaPublishDraft draft;
+    try {
+      final prepared = await _prepareComposerContentForModel(model, composerText);
+      if (!prepared || !model.hasFiles) {
+        throw StateError('没有可发布的内容');
+      }
+      draft = _dharmaPublishService.buildDraftFromModel(
+        model,
+        fallbackText: composerText,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isPublishingDraft = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('内容准备失败: $e'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _isPublishingDraft = false);
+
+    final completedDraft = await _ensurePublishDraftComplete(
+      draft,
+      _selectedPublishPlatforms,
+    );
+    if (completedDraft == null || !mounted) return;
+
+    final reviewedDraft = await _reviewPublishDraft(
+      completedDraft,
+      _selectedPublishPlatforms,
+    );
+    if (reviewedDraft == null || !mounted) return;
+
+    setState(() => _isPublishingDraft = true);
+    try {
+      setState(() {
+        _homeChatMessages.add(
+          _HomeChatMessage(
+            text: _dharmaPublishService.buildPreviewMarkdown(
+              reviewedDraft,
+              _selectedPublishPlatforms,
+            ),
+            isUser: true,
+          ),
+        );
+      });
+      _scrollHomeChatToBottom();
+
+      final results = await _publishDraftWithBestPlatformExperience(
+        reviewedDraft,
+      );
+      if (!mounted) return;
+      setState(() {
+        _homeChatMessages.add(
+          _HomeChatMessage(
+            text: _publishResultsMarkdown(reviewedDraft, results),
+            isUser: false,
+          ),
+        );
+        _isDharmaComposerMode = false;
+        _dharmaComposerTarget = DharmaComposerTarget.global;
+      });
+      _scrollHomeChatToBottom();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _homeChatMessages.add(
+          _HomeChatMessage(
+            text: '发布流程遇到问题：$e',
+            isUser: false,
+            isError: true,
+          ),
+        );
+      });
+      _scrollHomeChatToBottom();
+    } finally {
+      if (mounted) setState(() => _isPublishingDraft = false);
+    }
+  }
+
+  Future<List<DharmaPublishResult>> _publishDraftWithBestPlatformExperience(
+    DharmaPublishDraft draft,
+  ) async {
+    if (!kIsWeb &&
+        (Platform.isMacOS || Platform.isWindows)) {
+      final results = await Navigator.push<List<DharmaPublishResult>>(
+        context,
+        MaterialPageRoute(
+          builder: (_) => DharmaPublishBrowserScreen(
+            draft: draft,
+            platforms: _selectedPublishPlatforms.toList(),
+          ),
+        ),
+      );
+      return results ??
+          _selectedPublishPlatforms
+              .map(
+                (platform) => DharmaPublishResult(
+                  platform: platform,
+                  success: false,
+                  message: '用户关闭了内置浏览器发布工作台',
+                  steps: const ['发布流程已取消或未完成。'],
+                ),
+              )
+              .toList();
+    }
+
+    return _dharmaPublishService.publishDraft(
+      draft: draft,
+      platforms: _selectedPublishPlatforms,
+    );
+  }
+
+  Future<DharmaPublishDraft?> _ensurePublishDraftComplete(
+    DharmaPublishDraft draft,
+    Set<DharmaPublishPlatform> platforms,
+  ) async {
+    if (_dharmaPublishService.missingFields(draft, platforms).isEmpty) {
+      return draft;
+    }
+    return _showEditDraftDialog(
+      draft,
+      title: '补全发布信息',
+      helperText: '检测到标题或正文不完整。可以自己输入，也可以使用 AI 生成/润色。',
+    );
+  }
+
+  Future<DharmaPublishDraft?> _reviewPublishDraft(
+    DharmaPublishDraft draft,
+    Set<DharmaPublishPlatform> platforms,
+  ) async {
+    var current = draft;
+    while (mounted) {
+      final action = await showDialog<String>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('发布预览'),
+          content: SizedBox(
+            width: 520,
+            child: SingleChildScrollView(
+              child: MarkdownBody(
+                data: _dharmaPublishService.buildPreviewMarkdown(
+                  current,
+                  platforms,
+                ),
+                selectable: true,
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, 'cancel'),
+              child: const Text('取消'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, 'edit'),
+              child: const Text('自己修改'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, 'ai'),
+              child: const Text('AI 修改'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(dialogContext, 'publish'),
+              child: const Text('发布'),
+            ),
+          ],
+        ),
+      );
+
+      if (action == 'publish') return current;
+      if (action == 'edit') {
+        final edited = await _showEditDraftDialog(current);
+        if (edited != null) current = edited;
+        continue;
+      }
+      if (action == 'ai') {
+        final requirement = await _askDraftRevisionRequirement();
+        if (requirement == null) continue;
+        final body = await _generateRevisedBody(current, requirement);
+        current = current.copyWith(
+          title: current.title.trim().isEmpty
+              ? await _generateTitleForDraft(current)
+              : current.title,
+          body: body,
+        );
+        continue;
+      }
+      return null;
+    }
+    return null;
+  }
+
+  Future<DharmaPublishDraft?> _showEditDraftDialog(
+    DharmaPublishDraft draft, {
+    String title = '修改发布草稿',
+    String helperText = '请确认标题、正文、标签和来源链接。',
+  }) async {
+    final titleController = TextEditingController(text: draft.title);
+    final bodyController = TextEditingController(text: draft.body);
+    final tagController = TextEditingController(text: draft.tags.join(' '));
+    final sourceController = TextEditingController(text: draft.sourceUrl);
+    bool generating = false;
+
+    final result = await showDialog<DharmaPublishDraft>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            Future<void> generateTitle() async {
+              setDialogState(() => generating = true);
+              final generated = await _generateTitleForDraft(
+                draft.copyWith(body: bodyController.text),
+              );
+              titleController.text = generated;
+              setDialogState(() => generating = false);
+            }
+
+            Future<void> polishBody() async {
+              setDialogState(() => generating = true);
+              final revised = await _generateRevisedBody(
+                draft.copyWith(
+                  title: titleController.text,
+                  body: bodyController.text,
+                ),
+                '润色为适合自媒体发布的温和、清晰、尊重平台规则的文案',
+              );
+              bodyController.text = revised;
+              setDialogState(() => generating = false);
+            }
+
+            return AlertDialog(
+              title: Text(title),
+              content: SizedBox(
+                width: 520,
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(helperText),
+                      const SizedBox(height: 14),
+                      TextField(
+                        controller: titleController,
+                        decoration: InputDecoration(
+                          labelText: '标题',
+                          suffixIcon: IconButton(
+                            tooltip: 'AI 生成标题',
+                            onPressed: generating ? null : generateTitle,
+                            icon: const Icon(Icons.auto_awesome),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: bodyController,
+                        minLines: 6,
+                        maxLines: 12,
+                        decoration: InputDecoration(
+                          labelText: '正文',
+                          alignLabelWithHint: true,
+                          suffixIcon: IconButton(
+                            tooltip: 'AI 润色正文',
+                            onPressed: generating ? null : polishBody,
+                            icon: const Icon(Icons.auto_fix_high),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: tagController,
+                        decoration: const InputDecoration(
+                          labelText: '标签（空格分隔）',
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: sourceController,
+                        decoration: const InputDecoration(labelText: '来源链接'),
+                      ),
+                      if (generating) ...[
+                        const SizedBox(height: 12),
+                        const LinearProgressIndicator(),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: generating
+                      ? null
+                      : () => Navigator.pop(dialogContext),
+                  child: const Text('取消'),
+                ),
+                FilledButton(
+                  onPressed: generating
+                      ? null
+                      : () {
+                          Navigator.pop(
+                            dialogContext,
+                            draft.copyWith(
+                              title: titleController.text.trim(),
+                              body: bodyController.text.trim(),
+                              sourceUrl: sourceController.text.trim(),
+                              tags: tagController.text
+                                  .split(RegExp(r'[\s,，#]+'))
+                                  .map((tag) => tag.trim())
+                                  .where((tag) => tag.isNotEmpty)
+                                  .toSet()
+                                  .toList(),
+                            ),
+                          );
+                        },
+                  child: const Text('继续'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    titleController.dispose();
+    bodyController.dispose();
+    tagController.dispose();
+    sourceController.dispose();
+    return result;
+  }
+
+  Future<String?> _askDraftRevisionRequirement() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('输入 AI 修改要求'),
+        content: TextField(
+          controller: controller,
+          minLines: 3,
+          maxLines: 5,
+          decoration: const InputDecoration(
+            hintText: '例如：更适合小红书，语气更温和，保留来源链接，控制在 500 字以内。',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, controller.text.trim()),
+            child: const Text('生成'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    return result;
+  }
+
+  Future<String> _generateTitleForDraft(DharmaPublishDraft draft) async {
+    final prompt = [
+      '请为下面法布施/公益分享内容生成一个适合自媒体发布的中文标题。',
+      '要求：只返回标题，不超过 28 个字，不夸大，不制造焦虑。',
+      '',
+      draft.bodyPreview,
+    ].join('\n');
+    final ai = await _askDachengAi(prompt);
+    final title = ai?.split('\n').first.trim();
+    if (title != null && title.isNotEmpty) return title;
+    return _dharmaPublishService.suggestTitle(draft);
+  }
+
+  Future<String> _generateRevisedBody(
+    DharmaPublishDraft draft,
+    String requirement,
+  ) async {
+    final prompt = [
+      '请根据要求修改下面的发布草稿。',
+      '要求：$requirement',
+      '请直接返回可发布正文，不要解释。',
+      '',
+      '标题：${draft.title}',
+      '正文：',
+      draft.body,
+      if (draft.sourceUrl.trim().isNotEmpty) '来源链接：${draft.sourceUrl}',
+    ].join('\n');
+    final ai = await _askDachengAi(prompt);
+    if (ai != null && ai.trim().isNotEmpty) return ai.trim();
+    return _dharmaPublishService.polishBody(draft);
+  }
+
+  Future<String?> _askDachengAi(String prompt) async {
+    try {
+      final authModel = Provider.of<AuthModel?>(context, listen: false);
+      final result = await _dachengAiService.sendChat(
+        message: prompt,
+        token: authModel?.authToken,
+        username: authModel?.currentUser?.username,
+        isMember: authModel?.hasPermission('premium') ?? false,
+      );
+      final message = result.message.trim();
+      return message.isEmpty ? null : message;
+    } catch (e) {
+      debugPrint('发布草稿 AI 生成失败，使用本地规则兜底: $e');
+      return null;
+    }
+  }
+
+  String _publishResultsMarkdown(
+    DharmaPublishDraft draft,
+    List<DharmaPublishResult> results,
+  ) {
+    final success = results.where((result) => result.success).length;
+    final lines = <String>[
+      '### 发布流程完成',
+      '',
+      '标题：${draft.title.trim().isEmpty ? "未命名" : draft.title.trim()}',
+      '平台：$success / ${results.length} 个入口已拉起',
+      '',
+      for (final result in results) ...[
+        result.success
+            ? '- ✅ ${result.platform.info.label}：${result.message}'
+            : '- ⚠️ ${result.platform.info.label}：${result.message}',
+        for (final step in result.steps) '  - $step',
+      ],
+      '',
+      '草稿内容已复制到剪贴板；若平台要求登录、验证码或最终发布确认，请在打开的页面/App 中完成。',
+    ];
+    return lines.join('\n');
   }
 
   Future<void> _showRegionSelector(FileTransferModel model) async {
@@ -2522,8 +3369,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     final composerText = _chatInputController.text.trim();
     if (composerText.isNotEmpty) {
       try {
-        if (_looksLikeHttpUrl(composerText)) {
-          await model.addUrlContentForSending(composerText);
+        final sharedLink = _firstHttpUrl(composerText);
+        if (_looksLikeHttpUrl(composerText) || sharedLink != null) {
+          await model.addUrlContentForSending(sharedLink ?? composerText);
         } else {
           await model.addTextContentForSending(
             title: '法布施',
@@ -2795,6 +3643,153 @@ class _RegionCheckTile extends StatelessWidget {
     );
   }
 }
+
+
+class _PlatformCheckTile extends StatelessWidget {
+  final DharmaPublishPlatform platform;
+  final bool selected;
+  final ValueChanged<bool> onChanged;
+
+  const _PlatformCheckTile({
+    required this.platform,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final info = platform.info;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: () => onChanged(!selected),
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 64),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+          decoration: BoxDecoration(
+            color: selected
+                ? AppTheme.primaryColor.withValues(alpha: 0.14)
+                : Colors.white.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: selected
+                  ? AppTheme.primaryColor.withValues(alpha: 0.38)
+                  : Colors.white.withValues(alpha: 0.08),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                Icons.campaign_outlined,
+                color: selected ? AppTheme.primaryColor : Colors.white70,
+                size: 22,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      info.label,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      info.description,
+                      style: const TextStyle(
+                        color: Colors.white54,
+                        fontSize: 11,
+                        height: 1.25,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              Checkbox(
+                value: selected,
+                onChanged: (value) => onChanged(value ?? false),
+                activeColor: AppTheme.primaryColor,
+                checkColor: Colors.black,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ShareTargetTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  const _ShareTargetTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.07),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.09)),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: AppTheme.primaryColor, size: 24),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    subtitle,
+                    style: const TextStyle(
+                      color: Colors.white60,
+                      fontSize: 12,
+                      height: 1.35,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: Colors.white38),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 
 class _AiActivityLabel extends StatelessWidget {
   final String label;

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -1563,11 +1563,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     String action,
   ) async {
     if (action == 'dharma') {
-      _activateDharmaMode(
-        model,
-        showMaterials: true,
-        target: DharmaComposerTarget.global,
-      );
+      _activateDharmaMode(model);
+      setState(() => _showMaterialGallery = true);
       return true;
     }
     if (action == 'platform_publish') {
@@ -3370,8 +3367,10 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     if (composerText.isNotEmpty) {
       try {
         final sharedLink = _firstHttpUrl(composerText);
-        if (_looksLikeHttpUrl(composerText) || sharedLink != null) {
-          await model.addUrlContentForSending(sharedLink ?? composerText);
+        if (_looksLikeHttpUrl(composerText)) {
+          await model.addUrlContentForSending(composerText);
+        } else if (sharedLink != null) {
+          await model.addUrlContentForSending(sharedLink);
         } else {
           await model.addTextContentForSending(
             title: '法布施',

--- a/fabushi/lib/services/dharma_publish_service.dart
+++ b/fabushi/lib/services/dharma_publish_service.dart
@@ -1,0 +1,391 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../models/file_transfer_model.dart';
+
+enum DharmaComposerTarget { global, platform }
+
+enum DharmaPublishPlatform {
+  wechatOfficial,
+  xiaohongshu,
+  douyin,
+  weibo,
+  toutiao,
+  bilibili,
+  kuaishou,
+  zhihu,
+}
+
+class DharmaPublishPlatformInfo {
+  final DharmaPublishPlatform platform;
+  final String label;
+  final String shortLabel;
+  final String description;
+  final String desktopUrl;
+  final String? androidPackage;
+  final bool titleRequired;
+  final bool bodyRequired;
+
+  const DharmaPublishPlatformInfo({
+    required this.platform,
+    required this.label,
+    required this.shortLabel,
+    required this.description,
+    required this.desktopUrl,
+    required this.androidPackage,
+    this.titleRequired = true,
+    this.bodyRequired = true,
+  });
+}
+
+extension DharmaPublishPlatformX on DharmaPublishPlatform {
+  DharmaPublishPlatformInfo get info {
+    switch (this) {
+      case DharmaPublishPlatform.wechatOfficial:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.wechatOfficial,
+          label: '微信公众号',
+          shortLabel: '公众号',
+          description: '打开公众号平台草稿入口，正文会复制到剪贴板。',
+          desktopUrl: 'https://mp.weixin.qq.com/',
+          androidPackage: 'com.tencent.mm',
+        );
+      case DharmaPublishPlatform.xiaohongshu:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.xiaohongshu,
+          label: '小红书',
+          shortLabel: '小红书',
+          description: '移动端优先拉起小红书分享入口，桌面打开创作平台。',
+          desktopUrl: 'https://creator.xiaohongshu.com/',
+          androidPackage: 'com.xingin.xhs',
+        );
+      case DharmaPublishPlatform.douyin:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.douyin,
+          label: '抖音',
+          shortLabel: '抖音',
+          description: '移动端优先拉起抖音分享入口，桌面打开抖音创作者服务平台。',
+          desktopUrl: 'https://creator.douyin.com/',
+          androidPackage: 'com.ss.android.ugc.aweme',
+        );
+      case DharmaPublishPlatform.weibo:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.weibo,
+          label: '微博',
+          shortLabel: '微博',
+          description: '移动端优先拉起微博分享入口，桌面打开微博首页。',
+          desktopUrl: 'https://weibo.com/',
+          androidPackage: 'com.sina.weibo',
+        );
+      case DharmaPublishPlatform.toutiao:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.toutiao,
+          label: '今日头条',
+          shortLabel: '头条',
+          description: '打开头条号后台，正文会复制到剪贴板。',
+          desktopUrl: 'https://mp.toutiao.com/',
+          androidPackage: 'com.ss.android.article.news',
+        );
+      case DharmaPublishPlatform.bilibili:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.bilibili,
+          label: '哔哩哔哩',
+          shortLabel: 'B站',
+          description: '打开 B 站创作中心，正文会复制到剪贴板。',
+          desktopUrl: 'https://member.bilibili.com/platform/home',
+          androidPackage: 'tv.danmaku.bili',
+        );
+      case DharmaPublishPlatform.kuaishou:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.kuaishou,
+          label: '快手',
+          shortLabel: '快手',
+          description: '移动端优先拉起快手分享入口，桌面打开快手创作者中心。',
+          desktopUrl: 'https://cp.kuaishou.com/',
+          androidPackage: 'com.smile.gifmaker',
+        );
+      case DharmaPublishPlatform.zhihu:
+        return const DharmaPublishPlatformInfo(
+          platform: DharmaPublishPlatform.zhihu,
+          label: '知乎',
+          shortLabel: '知乎',
+          description: '打开知乎写作入口，正文会复制到剪贴板。',
+          desktopUrl: 'https://www.zhihu.com/',
+          androidPackage: 'com.zhihu.android',
+        );
+    }
+  }
+}
+
+class DharmaPublishDraft {
+  final String title;
+  final String body;
+  final String sourceUrl;
+  final List<String> tags;
+  final DateTime createdAt;
+
+  const DharmaPublishDraft({
+    required this.title,
+    required this.body,
+    required this.sourceUrl,
+    required this.tags,
+    required this.createdAt,
+  });
+
+  DharmaPublishDraft copyWith({
+    String? title,
+    String? body,
+    String? sourceUrl,
+    List<String>? tags,
+    DateTime? createdAt,
+  }) {
+    return DharmaPublishDraft(
+      title: title ?? this.title,
+      body: body ?? this.body,
+      sourceUrl: sourceUrl ?? this.sourceUrl,
+      tags: tags ?? this.tags,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  String get fullText {
+    final parts = <String>[
+      if (title.trim().isNotEmpty) title.trim(),
+      if (body.trim().isNotEmpty) body.trim(),
+      if (sourceUrl.trim().isNotEmpty) '来源链接：${sourceUrl.trim()}',
+      if (tags.isNotEmpty) tags.map((tag) => '#$tag').join(' '),
+    ];
+    return parts.join('\n\n');
+  }
+
+  String get bodyPreview {
+    final normalized = body.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (normalized.length <= 160) return normalized;
+    return '${normalized.substring(0, 160)}...';
+  }
+}
+
+class DharmaPublishResult {
+  final DharmaPublishPlatform platform;
+  final bool success;
+  final String message;
+  final List<String> steps;
+
+  const DharmaPublishResult({
+    required this.platform,
+    required this.success,
+    required this.message,
+    this.steps = const [],
+  });
+}
+
+class DharmaPublishService {
+  static const MethodChannel _platformChannel = MethodChannel(
+    'com.ombhrum.fabushi/platform_publish',
+  );
+
+  static const List<DharmaPublishPlatform> allPlatforms = [
+    DharmaPublishPlatform.wechatOfficial,
+    DharmaPublishPlatform.xiaohongshu,
+    DharmaPublishPlatform.douyin,
+    DharmaPublishPlatform.weibo,
+    DharmaPublishPlatform.toutiao,
+    DharmaPublishPlatform.bilibili,
+    DharmaPublishPlatform.kuaishou,
+    DharmaPublishPlatform.zhihu,
+  ];
+
+  DharmaPublishDraft buildDraftFromModel(
+    FileTransferModel model, {
+    String fallbackText = '',
+  }) {
+    final sourceUrl = model.selectedContentSourceUrl?.trim() ?? '';
+    final preview = model.selectedContentPreviewText?.trim() ?? '';
+    final title = model.selectedContentTitle.trim();
+    final text = preview.isNotEmpty ? preview : fallbackText.trim();
+
+    return DharmaPublishDraft(
+      title: _cleanTitle(title),
+      body: _cleanBody(text),
+      sourceUrl: sourceUrl,
+      tags: _defaultTagsFor(text),
+      createdAt: DateTime.now(),
+    );
+  }
+
+  List<String> missingFields(
+    DharmaPublishDraft draft,
+    Iterable<DharmaPublishPlatform> platforms,
+  ) {
+    final requiresTitle = platforms.any((platform) => platform.info.titleRequired);
+    final requiresBody = platforms.any((platform) => platform.info.bodyRequired);
+    final missing = <String>[];
+
+    if (requiresTitle && _needsTitleReview(draft)) missing.add('title');
+    if (requiresBody && draft.body.trim().length < 12) missing.add('body');
+    return missing;
+  }
+
+  String suggestTitle(DharmaPublishDraft draft) {
+    final body = draft.body.trim();
+    if (body.isEmpty) return '法布施分享';
+    final sentences = body
+        .split(RegExp(r'[。！？!?\n]'))
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty)
+        .toList();
+    if (sentences.isNotEmpty) {
+      final first = sentences.first.replaceAll(RegExp(r'^[\s#：:，,]+'), '');
+      if (first.length >= 8) {
+        return first.length > 28 ? first.substring(0, 28) : first;
+      }
+    }
+    final compact = body.replaceAll(RegExp(r'\s+'), '');
+    if (compact.length <= 28) return compact;
+    return compact.substring(0, 28);
+  }
+
+  String polishBody(DharmaPublishDraft draft) {
+    final body = draft.body.trim();
+    if (body.isEmpty) return body;
+    final title = draft.title.trim().isEmpty ? suggestTitle(draft) : draft.title.trim();
+    final tags = draft.tags.isEmpty ? ['法布施', '大乘'] : draft.tags;
+    return [
+      title,
+      '',
+      body,
+      '',
+      '愿以此功德，普及于一切。',
+      tags.map((tag) => '#$tag').join(' '),
+    ].join('\n');
+  }
+
+  String buildPreviewMarkdown(
+    DharmaPublishDraft draft,
+    Iterable<DharmaPublishPlatform> platforms,
+  ) {
+    final platformLabels = platforms.map((p) => p.info.label).join('、');
+    return [
+      '### 发布预览',
+      '',
+      '**平台**：$platformLabels',
+      '**标题**：${draft.title.trim().isEmpty ? "待补充" : draft.title.trim()}',
+      if (draft.sourceUrl.trim().isNotEmpty) '**来源**：${draft.sourceUrl.trim()}',
+      '',
+      draft.body.trim().isEmpty ? '_正文待补充_' : draft.body.trim(),
+      if (draft.tags.isNotEmpty) '',
+      if (draft.tags.isNotEmpty) draft.tags.map((tag) => '#$tag').join(' '),
+    ].join('\n');
+  }
+
+  Future<List<DharmaPublishResult>> publishDraft({
+    required DharmaPublishDraft draft,
+    required Iterable<DharmaPublishPlatform> platforms,
+  }) async {
+    final results = <DharmaPublishResult>[];
+    await Clipboard.setData(ClipboardData(text: draft.fullText));
+
+    for (final platform in platforms) {
+      results.add(await _publishOne(draft, platform));
+    }
+
+    return results;
+  }
+
+  Future<DharmaPublishResult> _publishOne(
+    DharmaPublishDraft draft,
+    DharmaPublishPlatform platform,
+  ) async {
+    final info = platform.info;
+    final steps = <String>[
+      '已生成 ${info.label} 发布草稿',
+      '已复制标题、正文、来源链接和标签到剪贴板',
+    ];
+
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      try {
+        final response = await _platformChannel.invokeMethod<dynamic>(
+          'shareToPlatform',
+          {
+            'packageName': info.androidPackage,
+            'platformName': info.label,
+            'title': draft.title,
+            'text': draft.fullText,
+            'url': draft.sourceUrl,
+          },
+        );
+        final map = response is Map ? response : const <dynamic, dynamic>{};
+        final success = map['success'] == true;
+        final message = (map['message'] ?? '').toString();
+        steps.add(message.isEmpty ? '已尝试拉起 ${info.label}' : message);
+        return DharmaPublishResult(
+          platform: platform,
+          success: success,
+          message: message.isEmpty ? '已拉起 ${info.label} 分享/发布入口' : message,
+          steps: steps,
+        );
+      } on MissingPluginException {
+        steps.add('当前构建未启用 Android 平台发布通道，改为打开网页入口');
+      } on PlatformException catch (error) {
+        steps.add('拉起 ${info.label} App 失败：${error.message ?? error.code}');
+      }
+    }
+
+    final uri = Uri.tryParse(info.desktopUrl);
+    if (uri == null) {
+      steps.add('平台入口地址无效');
+      return DharmaPublishResult(
+        platform: platform,
+        success: false,
+        message: '${info.label} 平台入口地址无效',
+        steps: steps,
+      );
+    }
+
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    steps.add(
+      launched
+          ? '已打开 ${info.label} 网页发布入口，登录态由系统浏览器/平台侧保存'
+          : '未能自动打开 ${info.label} 网页入口，请手动访问 ${info.desktopUrl}',
+    );
+    return DharmaPublishResult(
+      platform: platform,
+      success: launched,
+      message: launched
+          ? '已打开 ${info.label} 发布入口，草稿内容已复制，可粘贴后确认发布'
+          : '未能打开 ${info.label} 发布入口，草稿内容已复制',
+      steps: steps,
+    );
+  }
+
+  bool _needsTitleReview(DharmaPublishDraft draft) {
+    final title = draft.title.trim();
+    if (title.length < 4) return true;
+    if (title.startsWith('http://') || title.startsWith('https://')) return true;
+    if (draft.sourceUrl.trim().isEmpty) return false;
+    final uri = Uri.tryParse(draft.sourceUrl.trim());
+    if (uri == null) return false;
+    return title == uri.host || title == 'link';
+  }
+
+  String _cleanTitle(String title) {
+    final normalized = title.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (normalized.length <= 60) return normalized;
+    return normalized.substring(0, 60);
+  }
+
+  String _cleanBody(String text) {
+    return text
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .replaceAll(RegExp(r'[ \t]{2,}'), ' ')
+        .trim();
+  }
+
+  List<String> _defaultTagsFor(String text) {
+    final tags = <String>['法布施', '大乘'];
+    if (text.contains('佛') || text.contains('菩萨')) tags.add('佛法');
+    if (text.contains('禅') || text.contains('修行')) tags.add('修行');
+    return tags.toSet().toList();
+  }
+}

--- a/fabushi/lib/services/inbound_share_service.dart
+++ b/fabushi/lib/services/inbound_share_service.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+class IncomingSharePayload {
+  final String text;
+  final String url;
+  final String title;
+  final String mimeType;
+  final String sourcePackage;
+  final DateTime receivedAt;
+
+  const IncomingSharePayload({
+    required this.text,
+    required this.url,
+    required this.title,
+    required this.mimeType,
+    required this.sourcePackage,
+    required this.receivedAt,
+  });
+
+  factory IncomingSharePayload.fromMap(Map<dynamic, dynamic> map) {
+    return IncomingSharePayload(
+      text: (map['text'] ?? '').toString(),
+      url: (map['url'] ?? '').toString(),
+      title: (map['title'] ?? '').toString(),
+      mimeType: (map['mimeType'] ?? '').toString(),
+      sourcePackage: (map['sourcePackage'] ?? '').toString(),
+      receivedAt: _parseReceivedAt(map['receivedAt']),
+    );
+  }
+
+  static DateTime _parseReceivedAt(dynamic value) {
+    final raw = (value ?? '').toString();
+    final parsedIso = DateTime.tryParse(raw);
+    if (parsedIso != null) return parsedIso;
+    final millis = int.tryParse(raw);
+    if (millis != null && millis > 0) {
+      return DateTime.fromMillisecondsSinceEpoch(millis);
+    }
+    return DateTime.now();
+  }
+
+  String get bestText {
+    if (url.trim().isNotEmpty) return url.trim();
+    return text.trim();
+  }
+
+  bool get isEmpty => bestText.isEmpty;
+
+  String get displaySource {
+    if (sourcePackage.trim().isNotEmpty) return sourcePackage.trim();
+    if (mimeType.trim().isNotEmpty) return mimeType.trim();
+    return '外部应用';
+  }
+}
+
+class InboundShareService {
+  InboundShareService._();
+
+  static final InboundShareService instance = InboundShareService._();
+
+  static const MethodChannel _channel = MethodChannel(
+    'com.ombhrum.fabushi/inbound_share',
+  );
+
+  final StreamController<IncomingSharePayload> _incomingController =
+      StreamController<IncomingSharePayload>.broadcast();
+
+  bool _started = false;
+
+  Stream<IncomingSharePayload> get incomingShares =>
+      _incomingController.stream;
+
+  void start() {
+    if (_started) return;
+    _started = true;
+    _channel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  Future<IncomingSharePayload?> takeInitialShare() async {
+    start();
+    try {
+      final payload = await _channel.invokeMethod<dynamic>('getInitialShare');
+      if (payload is Map && payload.isNotEmpty) {
+        return IncomingSharePayload.fromMap(payload);
+      }
+    } on MissingPluginException {
+      return null;
+    } on PlatformException {
+      return null;
+    }
+    return null;
+  }
+
+  Future<void> clearInitialShare() async {
+    try {
+      await _channel.invokeMethod<void>('clearInitialShare');
+    } on MissingPluginException {
+      return;
+    } on PlatformException {
+      return;
+    }
+  }
+
+  Future<void> _handleMethodCall(MethodCall call) async {
+    if (call.method != 'onIncomingShare') return;
+    final args = call.arguments;
+    if (args is Map && args.isNotEmpty) {
+      final payload = IncomingSharePayload.fromMap(args);
+      if (!payload.isEmpty) _incomingController.add(payload);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add Android inbound share handling so external apps can share text/links into Fabushi and choose Global Dharma vs platform publishing.
- Add Dharma platform composer flow with multi-select platforms, draft preparation from downloaded link content, missing title/body completion, AI title/body helper, preview, and publish confirmation.
- Add Android platform share handoff plus macOS/Windows in-app publishing workbench using the existing in-app WebView stack, clipboard draft handoff, page autofill script, and collapsible step logs.

## Notes
- Android receives ACTION_SEND / ACTION_SEND_MULTIPLE text links directly; iOS still needs a native Share Extension target for full share-sheet ingress.
- Third-party platforms may require login, captcha, attachments, or final publish confirmation in their own UI. The implementation prepares and injects/copies text where possible but keeps the user in control of final platform-side publish actions.

## Validation
- git diff --cached --check
- Static review of Android manifest, MainActivity share/publish channel, Flutter composer flow, and WebView publishing workbench.
- CI/native smoke will run on this PR.