### PR TITLE
feat: add iOS share extension and browser screenshots

### DIFF
--- a/fabushi/ios/Runner.xcodeproj/project.pbxproj
+++ b/fabushi/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F0FF00000000000000000003 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FF0000000000000000000B /* ShareViewController.swift */; };
+		F0FF00000000000000000014 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F0FF00000000000000000009 /* MainInterface.storyboard */; };
+		F0FF0000000000000000000E /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F0FF00000000000000000010 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
@@ -29,6 +32,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		F0FF00000000000000000012 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F0FF0000000000000000000C;
+			remoteInfo = ShareExtension;
+		};
 		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
@@ -49,9 +59,25 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F0FF0000000000000000000F /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				F0FF0000000000000000000E /* ShareExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F0FF0000000000000000000B /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		F0FF00000000000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F0FF00000000000000000009 /* MainInterface.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
+		F0FF00000000000000000007 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
+		F0FF00000000000000000010 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
@@ -87,6 +113,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		F0FF00000000000000000013 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4A94A3D1C1D93EA54684993D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -115,6 +148,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F0FF00000000000000000006 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				F0FF0000000000000000000B /* ShareViewController.swift */,
+				F0FF00000000000000000001 /* Info.plist */,
+				F0FF00000000000000000009 /* MainInterface.storyboard */,
+				F0FF00000000000000000007 /* ShareExtension.entitlements */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -176,6 +220,7 @@
 			children = (
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
+				F0FF00000000000000000006 /* ShareExtension */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				53EC2BB7395A9C0134835EE6 /* Pods */,
@@ -189,6 +234,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+				F0FF00000000000000000010 /* ShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -241,6 +287,7 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				F0FF0000000000000000000F /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				F9B8F18E6D2083C7ED002E6D /* [CP] Embed Pods Frameworks */,
 				D9FE6BB2B814CE531314BB0B /* [CP] Copy Pods Resources */,
@@ -248,11 +295,29 @@
 			buildRules = (
 			);
 			dependencies = (
+				F0FF00000000000000000002 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
+		};
+		F0FF0000000000000000000C /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F0FF0000000000000000000D /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				F0FF00000000000000000008 /* Sources */,
+				F0FF00000000000000000013 /* Frameworks */,
+				F0FF00000000000000000004 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShareExtension;
+			productName = ShareExtension;
+			productReference = F0FF00000000000000000010 /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -267,6 +332,9 @@
 					331C8080294A63A400263BE5 = {
 						CreatedOnToolsVersion = 14.0;
 						TestTargetID = 97C146ED1CF9000F007C117D;
+					};
+					F0FF0000000000000000000C = {
+						CreatedOnToolsVersion = 15.0;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -289,11 +357,20 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
+				F0FF0000000000000000000C /* ShareExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		F0FF00000000000000000004 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F0FF00000000000000000014 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		331C807F294A63A400263BE5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -406,6 +483,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		F0FF00000000000000000008 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F0FF00000000000000000003 /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		331C807D294A63A400263BE5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -426,6 +511,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		F0FF00000000000000000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F0FF0000000000000000000C /* ShareExtension */;
+			targetProxy = F0FF00000000000000000012 /* PBXContainerItemProxy */;
+		};
 		331C8086294A63A400263BE5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
@@ -769,6 +859,65 @@
 			};
 			name = Release;
 		};
+		F0FF00000000000000000011 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = M4Q99K4UR4;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.ombhrum.fabushi.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		F0FF0000000000000000000A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = M4Q99K4UR4;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.ombhrum.fabushi.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		F0FF00000000000000000005 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = M4Q99K4UR4;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.ombhrum.fabushi.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Profile;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -798,6 +947,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F0FF0000000000000000000D /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F0FF00000000000000000011 /* Debug */,
+				F0FF0000000000000000000A /* Release */,
+				F0FF00000000000000000005 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/fabushi/ios/Runner/AppDelegate.swift
+++ b/fabushi/ios/Runner/AppDelegate.swift
@@ -6,43 +6,101 @@ import BackgroundTasks
 @objc class AppDelegate: FlutterAppDelegate {
     // 内存警告 MethodChannel
     private var memoryChannel: FlutterMethodChannel?
-    
+    private var inboundShareChannel: FlutterMethodChannel?
+    private let inboundShareAppGroup = "group.com.ombhrum.fabushi.share"
+    private let inboundSharePayloadKey = "inboundSharePayload"
+    private var pendingSharePayload: [String: Any]?
+
     // 后台任务标识符
     private static let keepAliveTaskIdentifier = "com.ombhrum.fabushi.keepalive"
-    
+
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
-        
-        // 设置内存警告 MethodChannel
+
+        // 设置 MethodChannel
         if let controller = window?.rootViewController as? FlutterViewController {
             memoryChannel = FlutterMethodChannel(
                 name: "com.ombhrum.fabushi/memory",
                 binaryMessenger: controller.binaryMessenger
             )
+            configureInboundShareChannel(controller: controller)
         }
-        
+        pendingSharePayload = readSharedInboundPayload()
+
         // 注册后台任务 (iOS 13+)
         if #available(iOS 13.0, *) {
             registerBackgroundTasks()
         }
-        
+
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
-    
+
+    // MARK: - iOS Share Extension inbound payload
+
+    private func configureInboundShareChannel(controller: FlutterViewController) {
+        inboundShareChannel = FlutterMethodChannel(
+            name: "com.ombhrum.fabushi/inbound_share",
+            binaryMessenger: controller.binaryMessenger
+        )
+        inboundShareChannel?.setMethodCallHandler { [weak self] call, result in
+            guard let self = self else { return }
+            switch call.method {
+            case "getInitialShare":
+                if let payload = self.pendingSharePayload ?? self.readSharedInboundPayload() {
+                    self.pendingSharePayload = payload
+                    result(payload)
+                } else {
+                    result([String: Any]())
+                }
+            case "clearInitialShare":
+                self.pendingSharePayload = nil
+                UserDefaults(suiteName: self.inboundShareAppGroup)?.removeObject(forKey: self.inboundSharePayloadKey)
+                result(true)
+            default:
+                result(FlutterMethodNotImplemented)
+            }
+        }
+    }
+
+    private func readSharedInboundPayload() -> [String: Any]? {
+        guard let defaults = UserDefaults(suiteName: inboundShareAppGroup),
+              let payload = defaults.dictionary(forKey: inboundSharePayloadKey) else {
+            return nil
+        }
+        let text = (payload["text"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let url = (payload["url"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return (text.isEmpty && url.isEmpty) ? nil : payload
+    }
+
+    override func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+    ) -> Bool {
+        if url.scheme == "fabushi" {
+            if let payload = readSharedInboundPayload() {
+                pendingSharePayload = payload
+                inboundShareChannel?.invokeMethod("onIncomingShare", arguments: payload)
+            }
+            return true
+        }
+        return super.application(app, open: url, options: options)
+    }
+
     // MARK: - 内存警告处理
-    
+
     override func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
         NSLog("⚠️ iOS 收到内存警告")
-        
+
         // 通知 Flutter 层释放内存
         memoryChannel?.invokeMethod("warning", arguments: nil)
     }
-    
+
     // MARK: - 后台任务处理 (iOS 13+)
-    
+
     @available(iOS 13.0, *)
     private func registerBackgroundTasks() {
         BGTaskScheduler.shared.register(
@@ -51,43 +109,43 @@ import BackgroundTasks
         ) { task in
             self.handleKeepAliveTask(task as! BGProcessingTask)
         }
-        
+
         NSLog("✅ BGTaskScheduler 已注册")
     }
-    
+
     @available(iOS 13.0, *)
     private func handleKeepAliveTask(_ task: BGProcessingTask) {
         NSLog("📋 执行后台保活任务")
-        
+
         // 设置过期处理
         task.expirationHandler = {
             NSLog("⏰ 后台任务即将过期")
             task.setTaskCompleted(success: false)
         }
-        
+
         // 检查是否有需要恢复的任务
         let userDefaults = UserDefaults.standard
         let isActive = userDefaults.bool(forKey: "flutter.sending_is_active")
-        
+
         if isActive {
             NSLog("🔄 检测到需要恢复的发送任务")
             // 这里只能记录状态，让应用下次启动时恢复
             // iOS 后台任务无法直接启动 UI
         }
-        
+
         task.setTaskCompleted(success: true)
-        
+
         // 安排下一次任务
         scheduleKeepAliveTask()
     }
-    
+
     @available(iOS 13.0, *)
     func scheduleKeepAliveTask() {
         let request = BGProcessingTaskRequest(identifier: AppDelegate.keepAliveTaskIdentifier)
         request.requiresNetworkConnectivity = false
         request.requiresExternalPower = false
         request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60) // 15 分钟后
-        
+
         do {
             try BGTaskScheduler.shared.submit(request)
             NSLog("✅ 后台任务已调度")
@@ -95,12 +153,12 @@ import BackgroundTasks
             NSLog("❌ 调度后台任务失败: \(error)")
         }
     }
-    
+
     // MARK: - 应用进入后台时调度任务
-    
+
     override func applicationDidEnterBackground(_ application: UIApplication) {
         super.applicationDidEnterBackground(application)
-        
+
         if #available(iOS 13.0, *) {
             scheduleKeepAliveTask()
         }

--- a/fabushi/ios/Runner/Info.plist
+++ b/fabushi/ios/Runner/Info.plist
@@ -47,8 +47,6 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
-	
-	<!-- 支付宝 URL Scheme - 用于支付宝授权/支付回调 -->
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -61,57 +59,47 @@
 				<string>alipay2021005193647715</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>fabushi-share</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>fabushi</string>
+			</array>
+		</dict>
 	</array>
-	
-	<!-- 应用查询 schemes（检测其他应用是否安装）-->
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>alipay</string>
 		<string>alipays</string>
 		<string>alipayshare</string>
 	</array>
-	
-	<!-- 后台模式 - 音频、后台获取、后台处理 -->
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
 		<string>fetch</string>
 		<string>processing</string>
 	</array>
-	
-	<!-- BGTaskScheduler 任务标识符 (iOS 13+) -->
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.ombhrum.fabushi.keepalive</string>
 	</array>
-	
-	<!-- 通知权限说明 -->
 	<key>NSUserNotificationsUsageDescription</key>
 	<string>需要通知权限以显示发送进度和状态</string>
-	
-	<!-- 媒体库权限说明 -->
 	<key>NSAppleMusicUsageDescription</key>
 	<string>应用需要音频播放功能以保持后台运行</string>
-	
-	<!-- 麦克风权限说明 - 读诵录音功能 -->
 	<key>NSMicrophoneUsageDescription</key>
 	<string>需要麦克风权限以录制您的读诵音频</string>
-	
-	<!-- 语音识别权限说明 - 智能检测读诵进度 -->
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>需要语音识别权限以智能检测您的读诵进度</string>
-	
-	<!-- 位置权限说明 - 某些第三方库可能需要 -->
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>应用可能需要访问您的位置以提供本地化服务</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>应用可能需要访问您的位置以提供本地化服务</string>
-	
-	<!-- 相册权限说明 - 用于保存或选择图片 -->
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>应用需要访问您的相册以保存或选择图片</string>
-	
-	<!-- Firebase 配置 - 禁用 Method Swizzling 以避免 AppDelegate 代理冲突 -->
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
 </dict>

--- a/fabushi/ios/ShareExtension/Info.plist
+++ b/fabushi/ios/ShareExtension/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>法布施</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ShareExtension</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/fabushi/ios/ShareExtension/MainInterface.storyboard
+++ b/fabushi/ios/ShareExtension/MainInterface.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ShareVC">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="Scene">
+            <objects>
+                <viewController id="ShareVC" customClass="ShareViewController" customModule="ShareExtension" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="view">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="safe"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="firstResponder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor"><color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/></systemColor>
+    </resources>
+</document>

--- a/fabushi/ios/ShareExtension/ShareExtension.entitlements
+++ b/fabushi/ios/ShareExtension/ShareExtension.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.ombhrum.fabushi.share</string>

--- a/fabushi/ios/ShareExtension/ShareViewController.swift
+++ b/fabushi/ios/ShareExtension/ShareViewController.swift
@@ -1,0 +1,131 @@
+import Social
+import UIKit
+import UniformTypeIdentifiers
+
+final class ShareViewController: SLComposeServiceViewController {
+    private let appGroupIdentifier = "group.com.ombhrum.fabushi.share"
+    private let sharedPayloadKey = "inboundSharePayload"
+    private let hostAppURLScheme = "fabushi"
+
+    override func isContentValid() -> Bool {
+        return true
+    }
+
+    override func didSelectPost() {
+        Task { @MainActor in
+            let payload = await buildPayload()
+            savePayload(payload)
+            openHostApp()
+            extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+        }
+    }
+
+    override func configurationItems() -> [Any]! {
+        return []
+    }
+
+    private func buildPayload() async -> [String: Any] {
+        var textParts: [String] = []
+        var url = ""
+        var title = ""
+        var mimeType = ""
+
+        if let contentText = contentText?.trimmingCharacters(in: .whitespacesAndNewlines), !contentText.isEmpty {
+            textParts.append(contentText)
+            if title.isEmpty { title = contentText.components(separatedBy: .newlines).first ?? "" }
+        }
+
+        let extensionItems = extensionContext?.inputItems as? [NSExtensionItem] ?? []
+        for item in extensionItems {
+            if let attributedTitle = item.attributedTitle?.string.trimmingCharacters(in: .whitespacesAndNewlines), !attributedTitle.isEmpty {
+                title = attributedTitle
+            }
+            if let attributedContent = item.attributedContentText?.string.trimmingCharacters(in: .whitespacesAndNewlines), !attributedContent.isEmpty {
+                textParts.append(attributedContent)
+            }
+            for provider in item.attachments ?? [] {
+                if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+                    if let loaded = try? await provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil), let resolved = urlString(from: loaded) {
+                        if url.isEmpty { url = resolved }
+                        textParts.append(resolved)
+                        mimeType = UTType.url.identifier
+                    }
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+                    if let loaded = try? await provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil), let resolved = textString(from: loaded) {
+                        textParts.append(resolved)
+                        if mimeType.isEmpty { mimeType = UTType.plainText.identifier }
+                    }
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.text.identifier) {
+                    if let loaded = try? await provider.loadItem(forTypeIdentifier: UTType.text.identifier, options: nil), let resolved = textString(from: loaded) {
+                        textParts.append(resolved)
+                        if mimeType.isEmpty { mimeType = UTType.text.identifier }
+                    }
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                    if let loaded = try? await provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil), let resolved = urlString(from: loaded) {
+                        textParts.append(resolved)
+                        if mimeType.isEmpty { mimeType = UTType.fileURL.identifier }
+                    }
+                }
+            }
+        }
+
+        let combinedText = unique(textParts).joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        if url.isEmpty, let first = firstHttpURL(in: combinedText) {
+            url = first
+        }
+        if title.isEmpty {
+            title = url.isEmpty ? "外部分享" : url
+        }
+
+        return [
+            "text": combinedText,
+            "url": url,
+            "title": title,
+            "mimeType": mimeType,
+            "sourcePackage": "iOS 分享面板",
+            "receivedAt": String(Int(Date().timeIntervalSince1970 * 1000))
+        ]
+    }
+
+    private func savePayload(_ payload: [String: Any]) {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
+        defaults.set(payload, forKey: sharedPayloadKey)
+        defaults.synchronize()
+    }
+
+    private func openHostApp() {
+        guard let url = URL(string: "\(hostAppURLScheme)://share-extension") else { return }
+        extensionContext?.open(url, completionHandler: nil)
+    }
+
+    private func urlString(from value: NSSecureCoding?) -> String? {
+        if let url = value as? URL { return url.absoluteString }
+        if let string = value as? String { return string.trimmingCharacters(in: .whitespacesAndNewlines) }
+        return nil
+    }
+
+    private func textString(from value: NSSecureCoding?) -> String? {
+        if let string = value as? String { return string.trimmingCharacters(in: .whitespacesAndNewlines) }
+        if let attributed = value as? NSAttributedString { return attributed.string.trimmingCharacters(in: .whitespacesAndNewlines) }
+        if let url = value as? URL { return url.absoluteString }
+        return nil
+    }
+
+    private func unique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.compactMap { raw in
+            let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty, !seen.contains(value) else { return nil }
+            seen.insert(value)
+            return value
+        }
+    }
+
+    private func firstHttpURL(in value: String) -> String? {
+        let pattern = #"https?://[^\s]+"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
+        let nsRange = NSRange(value.startIndex..<value.endIndex, in: value)
+        guard let match = regex.firstMatch(in: value, options: [], range: nsRange), let range = Range(match.range, in: value) else { return nil }
+        return String(value[range]).trimmingCharacters(in: CharacterSet(charactersIn: "，。、,.))）]】>》"))
+    }
+}

--- a/fabushi/lib/screens/dharma_publish_browser_screen.dart
+++ b/fabushi/lib/screens/dharma_publish_browser_screen.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import '../core/design_system/app_theme.dart';
+import '../services/dharma_publish_screenshot_store.dart';
 import '../services/dharma_publish_service.dart';
 
 class DharmaPublishBrowserScreen extends StatefulWidget {
@@ -29,6 +31,7 @@ class _DharmaPublishBrowserScreenState
   bool _loading = true;
   bool _runningScript = false;
   final Map<DharmaPublishPlatform, List<String>> _steps = {};
+  final Map<DharmaPublishPlatform, List<String>> _screenshots = {};
   final Set<DharmaPublishPlatform> _completed = {};
 
   DharmaPublishPlatform get _currentPlatform => widget.platforms[_currentIndex];
@@ -40,6 +43,7 @@ class _DharmaPublishBrowserScreenState
       _steps[platform] = <String>[
         '已创建发布任务：${platform.info.label}',
       ];
+      _screenshots[platform] = <String>[];
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _copyDraftToClipboard();
@@ -56,6 +60,30 @@ class _DharmaPublishBrowserScreenState
     setState(() {
       _steps.putIfAbsent(platform, () => <String>[]).add(message);
     });
+  }
+
+  Future<void> _captureStepScreenshot(
+    DharmaPublishPlatform platform,
+    String label,
+  ) async {
+    final controller = _controller;
+    if (controller == null) return;
+    try {
+      final Uint8List? bytes = await controller.takeScreenshot();
+      if (bytes == null || bytes.isEmpty) return;
+      final path = await saveDharmaPublishScreenshot(
+        platformName: platform.name,
+        label: label,
+        bytes: bytes,
+      );
+      if (path == null || path.isEmpty || !mounted) return;
+      setState(() {
+        _screenshots.putIfAbsent(platform, () => <String>[]).add(path);
+      });
+      _addStep(platform, '已保存步骤截图：$path');
+    } catch (e) {
+      _addStep(platform, '步骤截图保存失败：$e');
+    }
   }
 
   Future<void> _runAutofill() async {
@@ -80,6 +108,7 @@ class _DharmaPublishBrowserScreenState
         platform,
         text.isEmpty ? '已执行页面自动填充脚本。' : '页面自动填充结果：$text',
       );
+      await _captureStepScreenshot(platform, 'autofill');
       _addStep(platform, '请在页面中检查标题、正文和附件，再点击平台自己的发布/保存按钮。');
     } catch (e) {
       _addStep(platform, '自动填充脚本执行失败：$e');
@@ -146,6 +175,9 @@ class _DharmaPublishBrowserScreenState
             ? '已在内置浏览器打开 ${platform.info.label} 并准备草稿'
             : '已记录 ${platform.info.label} 的浏览器步骤，尚未标记完成',
         steps: steps,
+        screenshotPaths: List<String>.from(
+          _screenshots[platform] ?? const <String>[],
+        ),
       );
     }).toList();
   }
@@ -153,6 +185,7 @@ class _DharmaPublishBrowserScreenState
   Future<void> _markCurrentDone() async {
     final platform = _currentPlatform;
     _addStep(platform, '用户已确认此平台页面处理完成。');
+    await _captureStepScreenshot(platform, 'confirmed');
     setState(() => _completed.add(platform));
     if (_currentIndex < widget.platforms.length - 1) {
       setState(() {
@@ -314,6 +347,7 @@ class _DharmaPublishBrowserScreenState
                   onLoadStop: (controller, url) async {
                     setState(() => _loading = false);
                     _addStep(platform, '页面加载完成：${url?.toString() ?? ''}');
+                    await _captureStepScreenshot(platform, 'load_stop');
                     await _runAutofill();
                   },
                   onReceivedError: (controller, request, error) {

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -2423,6 +2423,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
             ? '- ✅ ${result.platform.info.label}：${result.message}'
             : '- ⚠️ ${result.platform.info.label}：${result.message}',
         for (final step in result.steps) '  - $step',
+        if (result.screenshotPaths.isNotEmpty) '  - 浏览器截图（折叠展示）',
+        for (var i = 0; i < result.screenshotPaths.length; i++)
+          '    - 截图 ${i + 1}: ${result.screenshotPaths[i]}',
       ],
       '',
       '草稿内容已复制到剪贴板；若平台要求登录、验证码或最终发布确认，请在打开的页面/App 中完成。',

--- a/fabushi/lib/services/dharma_publish_screenshot_store.dart
+++ b/fabushi/lib/services/dharma_publish_screenshot_store.dart
@@ -1,0 +1,2 @@
+export 'dharma_publish_screenshot_store_stub.dart'
+    if (dart.library.io) 'dharma_publish_screenshot_store_io.dart';

--- a/fabushi/lib/services/dharma_publish_screenshot_store_io.dart
+++ b/fabushi/lib/services/dharma_publish_screenshot_store_io.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+
+Future<String?> saveDharmaPublishScreenshot({
+  required String platformName,
+  required String label,
+  required Uint8List bytes,
+}) async {
+  if (bytes.isEmpty) return null;
+  final dir = await getApplicationDocumentsDirectory();
+  final screenshotsDir = Directory('${dir.path}/dharma_publish_screenshots');
+  if (!await screenshotsDir.exists()) {
+    await screenshotsDir.create(recursive: true);
+  }
+  final safeLabel = label
+      .replaceAll(RegExp(r'[^a-zA-Z0-9_\-]+'), '_')
+      .replaceAll(RegExp(r'_+'), '_')
+      .toLowerCase();
+  final safePlatform = platformName
+      .replaceAll(RegExp(r'[^a-zA-Z0-9_\-]+'), '_')
+      .replaceAll(RegExp(r'_+'), '_')
+      .toLowerCase();
+  final file = File(
+    '${screenshotsDir.path}/${safePlatform}_${DateTime.now().millisecondsSinceEpoch}_$safeLabel.png',
+  );
+  await file.writeAsBytes(bytes, flush: true);
+  return file.path;
+}

--- a/fabushi/lib/services/dharma_publish_screenshot_store_stub.dart
+++ b/fabushi/lib/services/dharma_publish_screenshot_store_stub.dart
@@ -1,0 +1,9 @@
+import 'dart:typed_data';
+
+Future<String?> saveDharmaPublishScreenshot({
+  required String platformName,
+  required String label,
+  required Uint8List bytes,
+}) async {
+  return null;
+}

--- a/fabushi/lib/services/dharma_publish_service.dart
+++ b/fabushi/lib/services/dharma_publish_service.dart
@@ -171,12 +171,14 @@ class DharmaPublishResult {
   final bool success;
   final String message;
   final List<String> steps;
+  final List<String> screenshotPaths;
 
   const DharmaPublishResult({
     required this.platform,
     required this.success,
     required this.message,
     this.steps = const [],
+    this.screenshotPaths = const [],
   });
 }
 


### PR DESCRIPTION
## Summary
- add native iOS Share Extension target for receiving external links/text from the system share sheet
- persist Share Extension payloads through App Group storage and expose them through the existing inbound_share MethodChannel
- capture desktop WebView publish-workbench screenshots at page-load/autofill/confirmation steps and return screenshot paths in the chat result

## Validation
- plist parsing passed for Runner and ShareExtension plists/entitlements
- Xcode project inserted target IDs validated for duplicate declarations
- git diff --check passed

Note: this VPS does not have dart/flutter/xcode installed, so CI must run Dart formatting/analyze and iOS build validation.