### PR TITLE
ci: unblock iOS release without unsigned share extension

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -513,6 +513,7 @@ jobs:
       IOS_CERTIFICATE_P12_BASE64: ${{ secrets.IOS_CERTIFICATE_P12_BASE64 }}
       IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
       IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+      IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64 }}
       IOS_EXPORT_METHOD: ${{ vars.IOS_EXPORT_METHOD || 'app-store' }}
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
       APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -646,6 +647,31 @@ jobs:
           sed -i '' 's/CODE_SIGN_IDENTITY = "Apple Development";/CODE_SIGN_IDENTITY = "Apple Distribution";/g' ios/Runner.xcodeproj/project.pbxproj
           sed -i '' 's/"CODE_SIGN_IDENTITY\[sdk=iphoneos\*\]" = "iPhone Developer";/"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";/g' ios/Runner.xcodeproj/project.pbxproj
           sed -i '' "s/PROVISIONING_PROFILE_SPECIFIER = \"\";/PROVISIONING_PROFILE_SPECIFIER = \"${profile_name}\";/g" ios/Runner.xcodeproj/project.pbxproj
+
+      - name: Disable unsigned iOS Share Extension for release IPA
+        if: steps.ios-signing.outputs.configured == 'true' && env.IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64 == ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64 is not configured; building release IPA without the ShareExtension target."
+          /usr/libexec/PlistBuddy -c 'Delete :com.apple.security.application-groups' ios/Runner/Runner.entitlements 2>/dev/null || true
+          python3 - <<'PY'
+          from pathlib import Path
+
+          project_path = Path('ios/Runner.xcodeproj/project.pbxproj')
+          lines = project_path.read_text().splitlines()
+          remove_fragments = (
+              'F0FF0000000000000000000F /* Embed App Extensions */',
+              'F0FF00000000000000000002 /* PBXTargetDependency */',
+              'F0FF0000000000000000000C /* ShareExtension */',
+              'F0FF00000000000000000010 /* ShareExtension.appex */',
+          )
+          kept = [
+              line for line in lines
+              if not any(fragment in line for fragment in remove_fragments)
+          ]
+          project_path.write_text('\n'.join(kept) + '\n')
+          PY
 
       - name: Build signed iOS IPA
         if: steps.ios-signing.outputs.configured == 'true'


### PR DESCRIPTION
## Summary
- keep the iOS Share Extension source and Xcode target intact
- add optional IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64 secret wiring
- when that secret is not configured, remove the ShareExtension target/embed references and App Group entitlement from the temporary release workspace before building the signed iOS IPA, so existing main app signing can continue to publish packages

## Why
PR #745 added the native Share Extension, but the existing App Store provisioning profile does not yet include App Groups or a separate extension profile. The release workflow failed with: Provisioning profile fabushi_app_store does not support group.com.ombhrum.fabushi.share.

## Validation
- git diff --check passed
- failure log from Publish CD packages run 27058180841 identified the iOS signing/provisioning mismatch