### PR TITLE
ci: sign iOS Share Extension profile

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -587,10 +587,15 @@ jobs:
           cert_path="$RUNNER_TEMP/ios_distribution.p12"
           profile_path="$RUNNER_TEMP/fabushi.mobileprovision"
           profile_plist="$RUNNER_TEMP/fabushi-profile.plist"
+          share_profile_path="$RUNNER_TEMP/fabushi-share-extension.mobileprovision"
+          share_profile_plist="$RUNNER_TEMP/fabushi-share-extension-profile.plist"
           keychain_path="$RUNNER_TEMP/app-signing.keychain-db"
 
           printf '%s' "$IOS_CERTIFICATE_P12_BASE64" | base64 --decode > "$cert_path"
           printf '%s' "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile_path"
+          if [ -n "${IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64:-}" ]; then
+            printf '%s' "$IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$share_profile_path"
+          fi
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"
           security set-keychain-settings -lut 21600 "$keychain_path"
@@ -605,12 +610,70 @@ jobs:
           profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$profile_plist")"
           team_id="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$profile_plist")"
           profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
+          profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$profile_plist")"
           cp "$profile_path" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
 
-          bundle_id="$(grep -m 1 'PRODUCT_BUNDLE_IDENTIFIER = ' ios/Runner.xcodeproj/project.pbxproj | sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\1/' | tr -d ' ')"
+          bundle_id="$(awk -F' = |;' '/PRODUCT_BUNDLE_IDENTIFIER = / { gsub(/[[:space:]]/, "", $2); if ($2 !~ /\.RunnerTests$/ && $2 !~ /\.ShareExtension$/) { print $2; exit } }' ios/Runner.xcodeproj/project.pbxproj)"
           if [ -z "$bundle_id" ]; then
             echo "Could not detect PRODUCT_BUNDLE_IDENTIFIER from ios/Runner.xcodeproj/project.pbxproj" >&2
             exit 1
+          fi
+          if [ "${profile_app_id#${team_id}.}" != "$bundle_id" ]; then
+            echo "Main provisioning profile application id '$profile_app_id' does not match bundle id '$bundle_id'." >&2
+            exit 1
+          fi
+
+          share_profile_name=""
+          share_bundle_id="$(awk -F' = |;' '/PRODUCT_BUNDLE_IDENTIFIER = / { gsub(/[[:space:]]/, "", $2); if ($2 ~ /\.ShareExtension$/) { print $2; exit } }' ios/Runner.xcodeproj/project.pbxproj)"
+          if [ -n "${IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64:-}" ]; then
+            if [ -z "$share_bundle_id" ]; then
+              echo "Share extension provisioning profile is configured, but no ShareExtension bundle id was found." >&2
+              exit 1
+            fi
+
+            security cms -D -i "$share_profile_path" > "$share_profile_plist"
+            share_profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$share_profile_plist")"
+            share_team_id="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$share_profile_plist")"
+            share_profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$share_profile_plist")"
+            share_profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$share_profile_plist")"
+            cp "$share_profile_path" "$HOME/Library/MobileDevice/Provisioning Profiles/$share_profile_uuid.mobileprovision"
+
+            if [ "$share_team_id" != "$team_id" ]; then
+              echo "Share extension provisioning profile team '$share_team_id' does not match main app team '$team_id'." >&2
+              exit 1
+            fi
+            if [ "${share_profile_app_id#${team_id}.}" != "$share_bundle_id" ]; then
+              echo "Share extension provisioning profile application id '$share_profile_app_id' does not match bundle id '$share_bundle_id'." >&2
+              exit 1
+            fi
+
+            required_app_group="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.application-groups:0' ios/Runner/Runner.entitlements 2>/dev/null || true)"
+            if [ -n "$required_app_group" ]; then
+              if ! /usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.security.application-groups' "$profile_plist" 2>/dev/null | grep -Fq "$required_app_group"; then
+                echo "Main provisioning profile does not include required App Group '$required_app_group'." >&2
+                exit 1
+              fi
+              if ! /usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.security.application-groups' "$share_profile_plist" 2>/dev/null | grep -Fq "$required_app_group"; then
+                echo "Share extension provisioning profile does not include required App Group '$required_app_group'." >&2
+                exit 1
+              fi
+            fi
+          fi
+
+          provisioning_profile_entries="$(
+            cat <<EOF
+              <key>${bundle_id}</key>
+              <string>${profile_name}</string>
+          EOF
+          )"
+          if [ -n "$share_profile_name" ]; then
+            provisioning_profile_entries="$(
+              cat <<EOF
+          ${provisioning_profile_entries}
+              <key>${share_bundle_id}</key>
+              <string>${share_profile_name}</string>
+          EOF
+            )"
           fi
 
           cat > ios/ExportOptions.plist <<EOF
@@ -628,8 +691,7 @@ jobs:
             <string>${team_id}</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>${bundle_id}</key>
-              <string>${profile_name}</string>
+          ${provisioning_profile_entries}
             </dict>
             <key>stripSwiftSymbols</key>
             <true/>
@@ -643,10 +705,76 @@ jobs:
           PROVISIONING_PROFILE_SPECIFIER=${profile_name}
           EOF
 
-          sed -i '' 's/CODE_SIGN_STYLE = Automatic;/CODE_SIGN_STYLE = Manual;/g' ios/Runner.xcodeproj/project.pbxproj
-          sed -i '' 's/CODE_SIGN_IDENTITY = "Apple Development";/CODE_SIGN_IDENTITY = "Apple Distribution";/g' ios/Runner.xcodeproj/project.pbxproj
-          sed -i '' 's/"CODE_SIGN_IDENTITY\[sdk=iphoneos\*\]" = "iPhone Developer";/"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";/g' ios/Runner.xcodeproj/project.pbxproj
-          sed -i '' "s/PROVISIONING_PROFILE_SPECIFIER = \"\";/PROVISIONING_PROFILE_SPECIFIER = \"${profile_name}\";/g" ios/Runner.xcodeproj/project.pbxproj
+          python3 - "$team_id" "$bundle_id" "$profile_name" "$share_bundle_id" "$share_profile_name" <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          team_id, main_bundle_id, main_profile_name, share_bundle_id, share_profile_name = sys.argv[1:]
+          profile_by_bundle = {main_bundle_id: main_profile_name}
+          if share_bundle_id and share_profile_name:
+              profile_by_bundle[share_bundle_id] = share_profile_name
+
+          project_path = Path('ios/Runner.xcodeproj/project.pbxproj')
+          project_text = project_path.read_text().replace(
+              '"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";',
+              '"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";',
+          )
+          lines = project_text.splitlines()
+          output = []
+          i = 0
+          while i < len(lines):
+              line = lines[i]
+              if 'buildSettings = {' not in line:
+                  output.append(line)
+                  i += 1
+                  continue
+
+              block = [line]
+              i += 1
+              while i < len(lines):
+                  block.append(lines[i])
+                  if lines[i].strip() == '};':
+                      i += 1
+                      break
+                  i += 1
+
+              block_text = '\n'.join(block)
+              match = re.search(r'PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);', block_text)
+              bundle_id = match.group(1).strip() if match else ''
+              profile_name = profile_by_bundle.get(bundle_id)
+              if not profile_name:
+                  output.extend(block)
+                  continue
+
+              updated = []
+              saw_profile_specifier = False
+              for block_line in block:
+                  stripped = block_line.strip()
+                  if stripped.startswith('CODE_SIGN_IDENTITY = '):
+                      block_line = re.sub(r'CODE_SIGN_IDENTITY = .*;', 'CODE_SIGN_IDENTITY = "Apple Distribution";', block_line)
+                  elif stripped.startswith('CODE_SIGN_STYLE = '):
+                      block_line = re.sub(r'CODE_SIGN_STYLE = .*;', 'CODE_SIGN_STYLE = Manual;', block_line)
+                  elif stripped.startswith('DEVELOPMENT_TEAM = '):
+                      block_line = re.sub(r'DEVELOPMENT_TEAM = .*;', f'DEVELOPMENT_TEAM = {team_id};', block_line)
+                  elif stripped.startswith('PROVISIONING_PROFILE_SPECIFIER = '):
+                      block_line = re.sub(r'PROVISIONING_PROFILE_SPECIFIER = .*;', f'PROVISIONING_PROFILE_SPECIFIER = "{profile_name}";', block_line)
+                      saw_profile_specifier = True
+
+                  updated.append(block_line)
+
+              if not saw_profile_specifier:
+                  insert_at = next(
+                      (index + 1 for index, updated_line in enumerate(updated)
+                       if updated_line.strip().startswith('PRODUCT_BUNDLE_IDENTIFIER = ')),
+                      len(updated) - 1,
+                  )
+                  updated.insert(insert_at, f'\t\t\t\tPROVISIONING_PROFILE_SPECIFIER = "{profile_name}";')
+
+              output.extend(updated)
+
+          project_path.write_text('\n'.join(output) + '\n')
+          PY
 
       - name: Disable unsigned iOS Share Extension for release IPA
         if: steps.ios-signing.outputs.configured == 'true' && env.IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64 == ''


### PR DESCRIPTION
## Summary\n- Install the Share Extension provisioning profile when IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64 is configured.\n- Add both app and ShareExtension provisioning profiles to ExportOptions.plist.\n- Validate bundle id and App Group entitlements before signing.\n\n## Validation\n- Parsed workflow YAML locally.\n- Simulated project signing rewrite against the iOS pbxproj.