### PR TITLE
Fix release versioning and macOS installer packaging

### DIFF
--- a/.github/scripts/fix-macos-bundled-dylibs.sh
+++ b/.github/scripts/fix-macos-bundled-dylibs.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_path="${1:-}"
+if [ -z "$app_path" ]; then
+  echo "Usage: $0 path/to/App.app" >&2
+  exit 2
+fi
+if [ ! -d "$app_path" ]; then
+  echo "macOS app bundle not found: $app_path" >&2
+  exit 1
+fi
+
+frameworks_dir="$app_path/Contents/Frameworks"
+mkdir -p "$frameworks_dir"
+
+declare -A homebrew_deps=()
+collect_homebrew_deps() {
+  local binary="$1"
+  otool -L "$binary" 2>/dev/null |
+    awk 'NR > 1 { print $1 }' |
+    while IFS= read -r dep; do
+      case "$dep" in
+        /opt/homebrew/*|/usr/local/opt/*|/usr/local/Cellar/*)
+          printf '%s\n' "$dep"
+          ;;
+      esac
+    done
+}
+
+while IFS= read -r -d '' file; do
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    homebrew_deps["$dep"]=1
+  done < <(collect_homebrew_deps "$file")
+done < <(find "$app_path/Contents" -type f \( -perm -111 -o -name '*.dylib' -o -path '*.framework/Versions/*/*' \) -print0)
+
+if [ "${#homebrew_deps[@]}" -eq 0 ]; then
+  echo "No Homebrew dynamic library references found in $app_path."
+  exit 0
+fi
+
+for dep in "${!homebrew_deps[@]}"; do
+  dep_path="$dep"
+  if [ ! -f "$dep_path" ]; then
+    dep_name="$(basename "$dep")"
+    for candidate in \
+      "/opt/homebrew/lib/$dep_name" \
+      "/opt/homebrew/opt/$(basename "${dep%/lib/*}")/lib/$dep_name" \
+      "/usr/local/lib/$dep_name"; do
+      if [ -f "$candidate" ]; then
+        dep_path="$candidate"
+        break
+      fi
+    done
+  fi
+
+  if [ ! -f "$dep_path" ]; then
+    echo "Unable to locate Homebrew dependency referenced by bundle: $dep" >&2
+    exit 1
+  fi
+
+  dep_name="$(basename "$dep")"
+  bundled_path="$frameworks_dir/$dep_name"
+  cp -f "$dep_path" "$bundled_path"
+  chmod u+w "$bundled_path"
+  install_name_tool -id "@rpath/$dep_name" "$bundled_path"
+  echo "Bundled $dep as @rpath/$dep_name"
+done
+
+while IFS= read -r -d '' file; do
+  changed=false
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    dep_name="$(basename "$dep")"
+    install_name_tool -change "$dep" "@rpath/$dep_name" "$file"
+    changed=true
+  done < <(collect_homebrew_deps "$file")
+  if [ "$changed" = "true" ]; then
+    echo "Rewrote Homebrew references in $file"
+  fi
+done < <(find "$app_path/Contents" -type f \( -perm -111 -o -name '*.dylib' -o -path '*.framework/Versions/*/*' \) -print0)
+
+remaining_refs="$(
+  while IFS= read -r -d '' file; do
+    otool -L "$file" 2>/dev/null | awk 'NR > 1 { print $1 }'
+  done < <(find "$app_path/Contents" -type f \( -perm -111 -o -name '*.dylib' -o -path '*.framework/Versions/*/*' \) -print0) |
+    grep -E '^(/opt/homebrew|/usr/local/(opt|Cellar))/' || true
+)"
+if [ -n "$remaining_refs" ]; then
+  echo "Bundle still contains external Homebrew dynamic library references:" >&2
+  echo "$remaining_refs" >&2
+  exit 1
+fi

--- a/.github/scripts/package-desktop-macos.sh
+++ b/.github/scripts/package-desktop-macos.sh
@@ -18,14 +18,63 @@ mkdir -p "$OUT_DIR"
 
 DMG_PATH="$OUT_DIR/$APP_NAME-$VERSION_SLUG-macos-$ARCH.dmg"
 ZIP_PATH="$OUT_DIR/$APP_NAME-$VERSION_SLUG-macos-$ARCH.zip"
+RW_DMG_PATH="$OUT_DIR/$APP_NAME-$VERSION_SLUG-macos-$ARCH-rw.dmg"
+TEMP_ROOT="${RUNNER_TEMP:-/tmp}"
+DMG_MOUNT_POINT="$TEMP_ROOT/${APP_NAME}-dmg-mount"
 
-rm -f "$DMG_PATH" "$ZIP_PATH"
+rm -f "$DMG_PATH" "$ZIP_PATH" "$RW_DMG_PATH"
+rm -rf "$DMG_MOUNT_POINT"
+mkdir -p "$DMG_MOUNT_POINT"
+
+app_size_kb="$(du -sk "$APP_PATH" | awk '{ print $1 }')"
+dmg_size_mb=$((app_size_kb / 1024 + 256))
+if [ "$dmg_size_mb" -lt 512 ]; then
+  dmg_size_mb=512
+fi
+
 hdiutil create \
   -volname "$DISPLAY_NAME" \
-  -srcfolder "$APP_PATH" \
+  -fs HFS+ \
+  -size "${dmg_size_mb}m" \
   -ov \
-  -format UDZO \
-  "$DMG_PATH"
+  -format UDRW \
+  "$RW_DMG_PATH"
+
+hdiutil attach "$RW_DMG_PATH" -nobrowse -mountpoint "$DMG_MOUNT_POINT"
+cleanup_mount() {
+  hdiutil detach "$DMG_MOUNT_POINT" -quiet >/dev/null 2>&1 || true
+}
+trap cleanup_mount EXIT
+
+ditto "$APP_PATH" "$DMG_MOUNT_POINT/$APP_NAME.app"
+ln -s /Applications "$DMG_MOUNT_POINT/Applications"
+
+# Give Finder enough metadata to show the expected drag-to-Applications install view.
+osascript <<APPLESCRIPT || true
+tell application "Finder"
+  tell disk "$DISPLAY_NAME"
+    open
+    set current view of container window to icon view
+    set toolbar visible of container window to false
+    set statusbar visible of container window to false
+    set bounds of container window to {100, 100, 640, 420}
+    set theViewOptions to the icon view options of container window
+    set arrangement of theViewOptions to not arranged
+    set icon size of theViewOptions to 96
+    set position of item "$APP_NAME.app" of container window to {160, 150}
+    set position of item "Applications" of container window to {420, 150}
+    close
+  end tell
+end tell
+APPLESCRIPT
+
+sync
+hdiutil detach "$DMG_MOUNT_POINT"
+trap - EXIT
+rm -rf "$DMG_MOUNT_POINT"
+
+hdiutil convert "$RW_DMG_PATH" -format UDZO -o "$DMG_PATH"
+rm -f "$RW_DMG_PATH"
 
 ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
 

--- a/.github/scripts/upload-macos-app-store.sh
+++ b/.github/scripts/upload-macos-app-store.sh
@@ -325,6 +325,12 @@ while true; do
   exit "$archive_exit_code"
 done
 
+archived_app_path="$archive_path/Products/Applications/global_dharma_sharing.app"
+fix_bundled_dylibs_script="$PWD/../.github/scripts/fix-macos-bundled-dylibs.sh"
+if [ -x "$fix_bundled_dylibs_script" ]; then
+  "$fix_bundled_dylibs_script" "$archived_app_path"
+fi
+
 internal_only=false
 case "${MACOS_APP_STORE_INTERNAL_TESTING_ONLY:-false}" in
   true|TRUE|True|1|yes|YES) internal_only=true ;;

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -8,6 +8,7 @@ on:
       - fabushi/**
       - .github/scripts/package-desktop-*
       - .github/scripts/notarize-macos-dmg.sh
+      - .github/scripts/fix-macos-bundled-dylibs.sh
       - .github/scripts/upload-macos-app-store.sh
       - .github/workflows/desktop-installers.yml
   push:
@@ -17,6 +18,7 @@ on:
       - fabushi/**
       - .github/scripts/package-desktop-*
       - .github/scripts/notarize-macos-dmg.sh
+      - .github/scripts/fix-macos-bundled-dylibs.sh
       - .github/scripts/upload-macos-app-store.sh
       - .github/workflows/desktop-installers.yml
   workflow_dispatch:
@@ -363,6 +365,11 @@ jobs:
           security import "$certificate_path" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
           security list-keychains -d user -s "$keychain_path" login.keychain-db
           security set-key-partition-list -S apple-tool:,apple: -s -k "$RUNNER_TEMP" "$keychain_path"
+
+      - name: Fix bundled macOS dynamic library references
+        if: matrix.target == 'macos'
+        shell: bash
+        run: ../.github/scripts/fix-macos-bundled-dylibs.sh build/macos/Build/Products/Release/global_dharma_sharing.app
 
       - name: Code sign macOS app
         if: >-

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -97,17 +97,28 @@ jobs:
           set -euo pipefail
 
           source_sha="${PR_HEAD_SHA:-${INPUT_SOURCE_SHA:-${GITHUB_SHA}}}"
-          app_version="$(awk '/^version:/ { print $2; exit }' fabushi/pubspec.yaml)"
-          if [ -z "$app_version" ]; then
+          pubspec_version="$(awk '/^version:/ { print $2; exit }' fabushi/pubspec.yaml)"
+          if [ -z "$pubspec_version" ]; then
             echo "Unable to read app version from fabushi/pubspec.yaml" >&2
             exit 1
           fi
 
-          version_slug="${app_version//+/-}"
-          release_build_number="${app_version##*+}"
-          if [ "$release_build_number" = "$app_version" ] || [ -z "$release_build_number" ]; then
-            release_build_number="$GITHUB_RUN_NUMBER"
+          version_name="${pubspec_version%%+*}"
+          pubspec_build_number="${pubspec_version##*+}"
+          if [ "$pubspec_build_number" = "$pubspec_version" ] || ! [[ "$pubspec_build_number" =~ ^[0-9]+$ ]]; then
+            pubspec_build_number=0
           fi
+
+          release_build_number="${GITHUB_RUN_NUMBER:-0}"
+          if ! [[ "$release_build_number" =~ ^[0-9]+$ ]]; then
+            release_build_number=0
+          fi
+          if [ "$release_build_number" -le "$pubspec_build_number" ]; then
+            release_build_number=$((pubspec_build_number + 1))
+          fi
+
+          app_version="${version_name}+${release_build_number}"
+          version_slug="${app_version//+/-}"
           short_sha="$(git rev-parse --short=12 HEAD)"
           release_tag="${INPUT_RELEASE_TAG:-desktop-v${version_slug}-${GITHUB_RUN_NUMBER}-${short_sha}}"
 

--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -423,8 +423,9 @@ jobs:
               changes_not_sent_for_review=""
               ;;
             true|TRUE|True|1|yes|YES)
-              use_changes_not_sent_for_review=true
-              changes_not_sent_for_review=true
+              echo "GOOGLE_PLAY_CHANGES_NOT_SENT_FOR_REVIEW=true is no longer supported for this app because Google Play sends changes for review automatically; omitting changesNotSentForReview."
+              use_changes_not_sent_for_review=false
+              changes_not_sent_for_review=""
               ;;
             false|FALSE|False|0|no|NO)
               use_changes_not_sent_for_review=true


### PR DESCRIPTION
## Summary
- keep desktop/mobile release build numbers monotonic for automated release packaging
- bundle Homebrew dylib references inside the macOS app before signing to prevent launch crashes like /opt/homebrew/libz.1.dylib Team ID mismatches
- generate a standard macOS DMG with the app plus an Applications symlink and Finder drag-install layout

## Verification
- bash -n on macOS packaging, dylib fix, App Store upload, and notarization scripts
- parsed desktop-installers.yml and publish-cd-release.yml with PyYAML