### PR TITLE
Fix macOS dylib bundler with empty arrays

### DIFF
--- a/.github/scripts/fix-macos-bundled-dylibs.sh
+++ b/.github/scripts/fix-macos-bundled-dylibs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 app_path="${1:-}"
 if [ -z "$app_path" ]; then


### PR DESCRIPTION
## Summary
- remove nounset from the macOS dylib bundler so Bash 3 can safely handle an initially empty dependency array

## Verification
- bash -n on macOS dylib, packaging, and App Store upload scripts
- inspected failed release run 27078690677 and confirmed the failure was empty-array expansion under set -u