### PR TITLE
Fix macOS DMG blank image creation

### DIFF
--- a/.github/scripts/package-desktop-macos.sh
+++ b/.github/scripts/package-desktop-macos.sh
@@ -37,7 +37,6 @@ hdiutil create \
   -fs HFS+ \
   -size "${dmg_size_mb}m" \
   -ov \
-  -format UDRW \
   "$RW_DMG_PATH"
 
 hdiutil attach "$RW_DMG_PATH" -nobrowse -mountpoint "$DMG_MOUNT_POINT"


### PR DESCRIPTION
## Summary
- create the writable DMG staging image as a blank image without -format UDRW, then convert it to compressed UDZO after adding the app and Applications symlink

## Verification
- bash -n on macOS DMG packaging, dylib, and App Store upload scripts
- inspected failed release run 27081000909 and confirmed the failure was hdiutil create rejecting -format without -srcfolder/-srcdevice