### PR TITLE
Support chapter filters in Faliu merit benefit panel

### DIFF
--- a/frontend/apps/web/src/components/faliu-merit-benefit-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-merit-benefit-enhancer.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { getFaliuMeritBenefits, type FaliuMeritBenefit } from "../lib/faliu-merit-benefits";
 
 const PANEL_TITLE = "功德利益";
+const ALL_SECTIONS_KEY = "__all_sections__";
 const READER_SELECTOR = 'section[aria-label="法流"] [class*="readerHtml"]';
 const MODAL_SELECTOR = 'section[aria-label="法流"] [role="dialog"][aria-modal="true"]';
 const HOST_SELECTOR = '[data-faliu-merit-benefit-host="true"]';
@@ -20,6 +21,12 @@ interface IndexedCharacter {
 interface TextMatch {
   range: Range;
   element: HTMLElement;
+}
+
+interface BenefitSection {
+  key: string;
+  title: string;
+  benefits: FaliuMeritBenefit[];
 }
 
 function normalizeText(value: string) {
@@ -277,6 +284,39 @@ function groupBenefits(benefits: FaliuMeritBenefit[]) {
   }, {});
 }
 
+function getSectionTitle(benefit: FaliuMeritBenefit) {
+  return benefit.sectionTitle?.trim() ?? "";
+}
+
+function getBenefitSections(benefits: FaliuMeritBenefit[]) {
+  const sections: BenefitSection[] = [];
+  const indexByTitle = new Map<string, number>();
+
+  for (const benefit of benefits) {
+    const title = getSectionTitle(benefit);
+
+    if (!title) {
+      continue;
+    }
+
+    const existingIndex = indexByTitle.get(title);
+
+    if (existingIndex !== undefined) {
+      sections[existingIndex].benefits.push(benefit);
+      continue;
+    }
+
+    indexByTitle.set(title, sections.length);
+    sections.push({
+      key: `section-${sections.length}`,
+      title,
+      benefits: [benefit],
+    });
+  }
+
+  return sections;
+}
+
 function ensurePortalHost(panel: HTMLElement) {
   const existingHost = panel.querySelector<HTMLElement>(HOST_SELECTOR);
 
@@ -322,7 +362,23 @@ function restorePanelChildren(panel: HTMLElement, host: HTMLElement) {
 }
 
 function MeritBenefitPanel({ benefits }: { benefits: FaliuMeritBenefit[] }) {
-  const groups = useMemo(() => groupBenefits(benefits), [benefits]);
+  const sections = useMemo(() => getBenefitSections(benefits), [benefits]);
+  const hasSectionFilter = sections.length > 1;
+  const [activeSectionKey, setActiveSectionKey] = useState<string | null>(null);
+  const activeSection = sections.find((section) => section.key === activeSectionKey) ?? sections[0] ?? null;
+  const visibleBenefits = hasSectionFilter && activeSectionKey !== ALL_SECTIONS_KEY && activeSection ? activeSection.benefits : benefits;
+  const groups = useMemo(() => groupBenefits(visibleBenefits), [visibleBenefits]);
+
+  useEffect(() => {
+    if (!hasSectionFilter) {
+      setActiveSectionKey(null);
+      return;
+    }
+
+    if (!activeSectionKey || (activeSectionKey !== ALL_SECTIONS_KEY && !sections.some((section) => section.key === activeSectionKey))) {
+      setActiveSectionKey(sections[0]?.key ?? ALL_SECTIONS_KEY);
+    }
+  }, [activeSectionKey, hasSectionFilter, sections]);
 
   return (
     <div data-faliu-merit-benefits="true" style={{ display: "grid", gap: 16 }}>
@@ -332,6 +388,62 @@ function MeritBenefitPanel({ benefits }: { benefits: FaliuMeritBenefit[] }) {
           共 {benefits.length} 句。点击句子可跳到经文对应位置。
         </p>
       </div>
+
+      {hasSectionFilter ? (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }} role="tablist" aria-label="按品查看功德利益">
+          {sections.map((section) => {
+            const isActive = section.key === activeSectionKey;
+            return (
+              <button
+                key={section.key}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setActiveSectionKey(section.key)}
+                style={{
+                  minHeight: 34,
+                  maxWidth: "100%",
+                  border: `1px solid ${isActive ? "rgba(232, 189, 107, 0.48)" : "rgba(255, 255, 255, 0.12)"}`,
+                  borderRadius: 8,
+                  padding: "7px 10px",
+                  background: isActive ? "rgba(232, 189, 107, 0.16)" : "rgba(255, 255, 255, 0.055)",
+                  color: isActive ? "#ffffff" : "rgba(255, 255, 255, 0.68)",
+                  cursor: "pointer",
+                  fontSize: "0.82rem",
+                  fontWeight: 760,
+                  lineHeight: 1.25,
+                }}
+              >
+                {section.title} · {section.benefits.length}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeSectionKey === ALL_SECTIONS_KEY}
+            onClick={() => setActiveSectionKey(ALL_SECTIONS_KEY)}
+            style={{
+              minHeight: 34,
+              border: `1px solid ${activeSectionKey === ALL_SECTIONS_KEY ? "rgba(232, 189, 107, 0.48)" : "rgba(255, 255, 255, 0.12)"}`,
+              borderRadius: 8,
+              padding: "7px 10px",
+              background: activeSectionKey === ALL_SECTIONS_KEY ? "rgba(232, 189, 107, 0.16)" : "rgba(255, 255, 255, 0.055)",
+              color: activeSectionKey === ALL_SECTIONS_KEY ? "#ffffff" : "rgba(255, 255, 255, 0.68)",
+              cursor: "pointer",
+              fontSize: "0.82rem",
+              fontWeight: 760,
+              lineHeight: 1.25,
+            }}
+          >
+            全部 · {benefits.length}
+          </button>
+        </div>
+      ) : sections[0] ? (
+        <div style={{ color: "rgba(255, 255, 255, 0.52)", fontSize: "0.82rem", lineHeight: 1.5 }}>
+          {sections[0].title}
+        </div>
+      ) : null}
 
       {Object.entries(groups).map(([category, items]) => (
         <section key={category} style={{ display: "grid", gap: 10 }}>

--- a/frontend/apps/web/src/lib/faliu-merit-benefits-t0262.ts
+++ b/frontend/apps/web/src/lib/faliu-merit-benefits-t0262.ts
@@ -1,9 +1,12 @@
 import type { FaliuMeritBenefit } from "./faliu-merit-benefits";
 
+const PUMEN_SECTION_TITLE = "觀世音菩薩普門品第二十五";
+
 export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-001",
     category: "稱名解脫",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "若有無量百千萬億眾生受諸苦惱，聞是觀世音菩薩，一心稱名，觀世音菩薩即時觀其音聲，皆得解脫。",
     anchorText: "若有無量百千萬億眾生受諸苦惱",
     note: "经文直接说明受诸苦恼者闻观世音菩萨、一心称名，即得解脱。",
@@ -11,6 +14,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-002",
     category: "怖畏得脫",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "汝等應當一心稱觀世音菩薩名號。是菩薩能以無畏施於眾生。汝等若稱名者，於此怨賊當得解脫。",
     anchorText: "汝等應當一心稱觀世音菩薩名號",
     note: "商主劝众人一心称名，明说观世音菩萨能以无畏施于众生。",
@@ -18,6 +22,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-003",
     category: "離三毒",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "若有眾生多於婬欲，常念恭敬觀世音菩薩，便得離欲。若多瞋恚，常念恭敬觀世音菩薩，便得離瞋。若多愚癡，常念恭敬觀世音菩薩，便得離癡。",
     anchorText: "若有眾生多於婬欲，常念恭敬觀世音菩薩",
     note: "本段把常念恭敬观世音菩萨与离欲、离瞋、离痴相连。",
@@ -25,6 +30,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-004",
     category: "常應心念",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "觀世音菩薩有如是等大威神力，多所饒益。是故眾生常應心念。",
     anchorText: "觀世音菩薩有如是等大威神力，多所饒益",
     note: "经文总括观世音菩萨大威神力、多所饶益，并劝众生常应心念。",
@@ -32,6 +38,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-005",
     category: "求子善願",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "若有女人，設欲求男，禮拜供養觀世音菩薩，便生福德智慧之男；設欲求女，便生端正有相之女。宿殖德本，眾人愛敬。",
     anchorText: "若有女人，設欲求男，禮拜供養觀世音菩薩",
     note: "经文明说礼拜供养观世音菩萨，求男、求女各有相应善果。",
@@ -39,6 +46,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-006",
     category: "福不唐捐",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "若有眾生恭敬禮拜觀世音菩薩，福不唐捐。是故眾生皆應受持觀世音菩薩名號。",
     anchorText: "若有眾生恭敬禮拜觀世音菩薩，福不唐捐",
     note: "经文以“福不唐捐”劝众生受持观世音菩萨名号。",
@@ -46,6 +54,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-007",
     category: "福德無邊",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "若復有人受持觀世音菩薩名號，乃至一時禮拜、供養。是二人福，正等無異，於百千萬億劫不可窮盡。無盡意！受持觀世音菩薩名號，得如是無量無邊福德之利。",
     anchorText: "若復有人受持觀世音菩薩名號",
     note: "受持观世音菩萨名号，乃至一时礼拜供养，经中赞为无量无边福德之利。",
@@ -53,6 +62,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-008",
     category: "普門示現",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "是觀世音菩薩成就如是功德，以種種形，遊諸國土，度脫眾生。",
     anchorText: "是觀世音菩薩成就如是功德",
     note: "这一句总摄普门示现：以种种形游诸国土、度脱众生。",
@@ -60,6 +70,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-009",
     category: "施無畏者",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "是觀世音菩薩摩訶薩於怖畏急難之中能施無畏，是故此娑婆世界皆號之為施無畏者。",
     anchorText: "於怖畏急難之中能施無畏",
     note: "经文直接说明观世音菩萨于怖畏急难中能施无畏。",
@@ -67,6 +78,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-010",
     category: "滅諸有苦",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "聞名及見身，心念不空過，能滅諸有苦。",
     anchorText: "聞名及見身，心念不空過",
     note: "偈颂以极简句说明闻名、见身、心念皆不空过，能灭诸有苦。",
@@ -74,6 +86,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-011",
     category: "救世間苦",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "眾生被困厄，無量苦逼身，觀音妙智力，能救世間苦。",
     anchorText: "眾生被困厄，無量苦逼身",
     note: "偈颂概括观音妙智力能救众生困厄与世间苦。",
@@ -81,6 +94,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-012",
     category: "漸滅諸苦",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "種種諸惡趣，地獄鬼畜生，生老病死苦，以漸悉令滅。",
     anchorText: "種種諸惡趣，地獄鬼畜生",
     note: "偈颂说明种种恶趣及生老病死苦，以渐悉令灭。",
@@ -88,6 +102,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-013",
     category: "甘露法雨",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "悲體戒雷震，慈意妙大雲，澍甘露法雨，滅除煩惱焰。",
     anchorText: "悲體戒雷震，慈意妙大雲",
     note: "经文以甘露法雨比喻慈悲说法能灭除烦恼焰。",
@@ -95,6 +110,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-014",
     category: "常念勿疑",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "妙音觀世音，梵音海潮音，勝彼世間音，是故須常念，念念勿生疑。",
     anchorText: "妙音觀世音，梵音海潮音",
     note: "偈颂劝人常念、念念勿生疑。",
@@ -102,6 +118,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-015",
     category: "聞品功德",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "若有眾生聞是觀世音菩薩品自在之業、普門示現神通力者，當知是人功德不少。",
     anchorText: "若有眾生聞是觀世音菩薩品自在之業",
     note: "本品结尾直接说明，闻此品自在之业、普门示现神通力者，功德不少。",
@@ -109,6 +126,7 @@ export const T0262_JUAN_7_MERIT_BENEFITS: FaliuMeritBenefit[] = [
   {
     id: "t0262-007-016",
     category: "聞法發心",
+    sectionTitle: PUMEN_SECTION_TITLE,
     text: "佛說是普門品時，眾中八萬四千眾生，皆發無等等阿耨多羅三藐三菩提心。",
     anchorText: "佛說是普門品時，眾中八萬四千眾生",
     note: "经文以大众闻品发无上菩提心作为结尾。",

--- a/frontend/apps/web/src/lib/faliu-merit-benefits.ts
+++ b/frontend/apps/web/src/lib/faliu-merit-benefits.ts
@@ -6,6 +6,7 @@ import { T1153_JUAN_1_MERIT_BENEFITS, T1153_JUAN_2_MERIT_BENEFITS } from "./fali
 export interface FaliuMeritBenefit {
   id: string;
   category: string;
+  sectionTitle?: string;
   text: string;
   anchorText: string;
   note?: string;


### PR DESCRIPTION
## Summary
- add optional `sectionTitle` metadata to Faliu merit-benefit entries
- show section/chapter filter buttons in the merit-benefit side panel when one juan contains entries from multiple chapters
- keep single-section scriptures simple by showing the section title without extra filter controls
- mark existing `T0262` juan 7 entries as `觀世音菩薩普門品第二十五`

## Behavior
- Multiple `sectionTitle` values in one juan produce selectable tabs plus an `全部` option.
- Existing entries without `sectionTitle` keep the current category-only grouping behavior.
- Click-to-source highlighting still uses each entry's existing `anchorText` and `occurrence`.

## Testing
- Reviewed branch diff to confirm changes are scoped to the Faliu merit-benefit panel and data metadata.
- Not run locally; this environment does not have a checked-out app workspace for the full web build.