### PR TITLE
feat: land knowledge flashcard memorization flow

### DIFF
--- a/fabushi/lib/features/flashcards/application/content_pipeline.dart
+++ b/fabushi/lib/features/flashcards/application/content_pipeline.dart
@@ -1,0 +1,319 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+
+import '../data/flashcard_repository.dart';
+import '../domain/flashcard_models.dart';
+
+class ContentInput {
+  final String text;
+  final String? url;
+  final String title;
+  final String sourceApp;
+  final String mimeType;
+  final String sourceType;
+
+  const ContentInput({
+    this.text = '',
+    this.url,
+    this.title = '',
+    this.sourceApp = '',
+    this.mimeType = '',
+    this.sourceType = 'composer_text',
+  });
+}
+
+class ContentPipeline {
+  ContentPipeline({
+    required FlashcardRepository repository,
+    http.Client? httpClient,
+    this.textLongThresholdChars = 1200,
+    this.linkLongThresholdChars = 1800,
+  }) : _repository = repository,
+       _httpClient = httpClient ?? http.Client();
+
+  final FlashcardRepository _repository;
+  final http.Client _httpClient;
+  final int textLongThresholdChars;
+  final int linkLongThresholdChars;
+
+  Future<PreparedContent> prepare(ContentInput input) async {
+    final normalizedUrl = _normalizeUrl(input.url) ?? _firstHttpUrl(input.text);
+    final text = input.text.trim();
+
+    if (normalizedUrl != null && text.length < linkLongThresholdChars) {
+      try {
+        return await _prepareUrl(input, normalizedUrl);
+      } catch (e) {
+        if (text.length >= 20) {
+          return _prepareText(
+            input,
+            text,
+            title: input.title.trim().isEmpty ? '链接摘录' : input.title.trim(),
+            sourceUrl: normalizedUrl,
+            errorMessage: '链接正文提取失败，已改用分享文本：$e',
+          );
+        }
+        return _failedContent(input, normalizedUrl, e.toString());
+      }
+    }
+
+    if (text.trim().isEmpty) {
+      return _failedContent(input, normalizedUrl, '请输入链接或至少 20 个字的正文。');
+    }
+    return _prepareText(input, text, sourceUrl: normalizedUrl);
+  }
+
+  Future<PreparedContent> _prepareUrl(ContentInput input, String url) async {
+    final uri = Uri.parse(url);
+    final response = await _httpClient
+        .get(
+          uri,
+          headers: const {
+            'Accept': 'text/html,text/plain,application/xhtml+xml',
+            'User-Agent': 'FabushiApp/FlashcardContentPipeline',
+          },
+        )
+        .timeout(const Duration(seconds: 12));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError('HTTP ${response.statusCode}');
+    }
+
+    final body = _decodeBody(response);
+    final title = _extractTitle(body).trim().isNotEmpty
+        ? _extractTitle(body).trim()
+        : (input.title.trim().isEmpty ? uri.host : input.title.trim());
+    final readable = _extractReadableText(body);
+    if (readable.length < 20) {
+      throw StateError('正文过短或网页暂不可读');
+    }
+    return _prepareText(
+      input,
+      readable,
+      title: title,
+      sourceUrl: url,
+      sourceType: 'composer_url',
+    );
+  }
+
+  PreparedContent _prepareText(
+    ContentInput input,
+    String text, {
+    String? title,
+    String? sourceUrl,
+    String? sourceType,
+    String? errorMessage,
+  }) {
+    final cleaned = _cleanText(text);
+    if (cleaned.length < 20) {
+      return _failedContent(input, sourceUrl, '内容过短，请至少输入 20 个字或 2 句话。');
+    }
+
+    final effectiveTitle = _normalizeTitle(
+      title ?? input.title,
+      fallback: sourceUrl != null ? '链接内容' : '背诵内容',
+    );
+    final source = ContentSource(
+      id: flashcardId('source'),
+      sourceType: sourceType ?? input.sourceType,
+      rawText: cleaned,
+      url: sourceUrl,
+      title: effectiveTitle,
+      sourceApp: input.sourceApp.trim(),
+      mimeType: input.mimeType.trim(),
+      receivedAt: DateTime.now(),
+      rawTextHash: sha1.convert(utf8.encode(cleaned)).toString(),
+    );
+    final isLong =
+        cleaned.length >=
+        (sourceUrl == null ? textLongThresholdChars : linkLongThresholdChars);
+    final summary = summarizeText(cleaned, maxLength: isLong ? 160 : 120);
+    final previewText = summarizeText(cleaned, maxLength: isLong ? 220 : 480);
+
+    ContentDocument? document;
+    if (isLong) {
+      document = ContentDocument(
+        id: flashcardId('doc'),
+        sourceId: source.id,
+        title: effectiveTitle,
+        summary: summary,
+        fullText: cleaned,
+        charCount: cleaned.runes.length,
+        tokenCount: estimateTokenCount(cleaned),
+        language: _looksChinese(cleaned) ? 'zh' : 'mixed',
+        extractedAt: DateTime.now(),
+        sourceUrl: sourceUrl,
+      );
+      unawaited(_repository.saveDocument(document));
+    }
+
+    return PreparedContent(
+      source: source,
+      document: document,
+      title: effectiveTitle,
+      text: cleaned,
+      summary: summary,
+      previewText: previewText,
+      isLong: isLong,
+      errorMessage: errorMessage,
+    );
+  }
+
+  PreparedContent _failedContent(
+    ContentInput input,
+    String? sourceUrl,
+    String errorMessage,
+  ) {
+    final source = ContentSource(
+      id: flashcardId('source_failed'),
+      sourceType: input.sourceType,
+      rawText: input.text.trim(),
+      url: sourceUrl,
+      title: _normalizeTitle(input.title, fallback: '待处理内容'),
+      sourceApp: input.sourceApp,
+      mimeType: input.mimeType,
+      receivedAt: DateTime.now(),
+      rawTextHash: sha1.convert(utf8.encode(input.text.trim())).toString(),
+    );
+    return PreparedContent(
+      source: source,
+      title: source.title,
+      text: input.text.trim(),
+      summary: '内容提取失败',
+      previewText: errorMessage,
+      isLong: false,
+      isFailed: true,
+      errorMessage: errorMessage,
+    );
+  }
+
+  static String summarizeText(String text, {int maxLength = 160}) {
+    final cleaned = _cleanText(text);
+    if (cleaned.length <= maxLength) return cleaned;
+    return '${cleaned.substring(0, maxLength).trim()}...';
+  }
+
+  static int estimateTokenCount(String text) {
+    final chineseCount = RegExp(r'[\u4e00-\u9fa5]').allMatches(text).length;
+    final latinWords = RegExp(r'[A-Za-z0-9_]+').allMatches(text).length;
+    return chineseCount + latinWords;
+  }
+
+  static String? firstHttpUrl(String text) => _firstHttpUrl(text);
+
+  static String _decodeBody(http.Response response) {
+    final contentType = response.headers['content-type'] ?? '';
+    if (contentType.toLowerCase().contains('charset=utf-8')) {
+      return utf8.decode(response.bodyBytes, allowMalformed: true);
+    }
+    try {
+      return utf8.decode(response.bodyBytes, allowMalformed: true);
+    } catch (_) {
+      return response.body;
+    }
+  }
+
+  static String _extractTitle(String html) {
+    final match = RegExp(
+      r'<title[^>]*>(.*?)</title>',
+      caseSensitive: false,
+      dotAll: true,
+    ).firstMatch(html);
+    if (match == null) return '';
+    return _decodeHtmlEntities(_stripTags(match.group(1) ?? '')).trim();
+  }
+
+  static String _extractReadableText(String html) {
+    var text = html
+        .replaceAll(
+          RegExp(
+            r'<script[^>]*>.*?</script>',
+            caseSensitive: false,
+            dotAll: true,
+          ),
+          ' ',
+        )
+        .replaceAll(
+          RegExp(
+            r'<style[^>]*>.*?</style>',
+            caseSensitive: false,
+            dotAll: true,
+          ),
+          ' ',
+        )
+        .replaceAll(
+          RegExp(
+            r'<noscript[^>]*>.*?</noscript>',
+            caseSensitive: false,
+            dotAll: true,
+          ),
+          ' ',
+        )
+        .replaceAll(
+          RegExp(
+            r'</(?:p|div|section|article|br|li|h\d)>',
+            caseSensitive: false,
+          ),
+          '\n',
+        )
+        .replaceAll(RegExp(r'<[^>]+>'), ' ');
+    text = _decodeHtmlEntities(text);
+    return _cleanText(text);
+  }
+
+  static String _stripTags(String html) =>
+      html.replaceAll(RegExp(r'<[^>]+>'), ' ');
+
+  static String _decodeHtmlEntities(String text) {
+    return text
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#39;', "'")
+        .replaceAllMapped(RegExp(r'&#(\d+);'), (match) {
+          final code = int.tryParse(match.group(1) ?? '');
+          if (code == null) return match.group(0) ?? '';
+          return String.fromCharCode(code);
+        });
+  }
+
+  static String _cleanText(String text) {
+    return text
+        .replaceAll(RegExp(r'\r\n?'), '\n')
+        .replaceAll(RegExp(r'[\t\f\v ]+'), ' ')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+  }
+
+  static String? _firstHttpUrl(String text) {
+    final match = RegExp(
+      r'https?://[^\s，。、《》【】<>]+',
+      caseSensitive: false,
+    ).firstMatch(text.trim());
+    return match?.group(0)?.replaceAll(RegExp(r'[，。、,.)）\]】>》]+$'), '').trim();
+  }
+
+  static String? _normalizeUrl(String? value) {
+    final raw = value?.trim() ?? '';
+    if (raw.isEmpty) return null;
+    final uri = Uri.tryParse(raw);
+    if (uri == null || !(uri.scheme == 'http' || uri.scheme == 'https'))
+      return null;
+    return uri.toString();
+  }
+
+  static String _normalizeTitle(String raw, {required String fallback}) {
+    final title = raw.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (title.isEmpty) return fallback;
+    if (title.length <= 40) return title;
+    return title.substring(0, 40).trim();
+  }
+
+  static bool _looksChinese(String text) {
+    return RegExp(r'[\u4e00-\u9fa5]').hasMatch(text);
+  }
+}

--- a/fabushi/lib/features/flashcards/application/flashcard_service.dart
+++ b/fabushi/lib/features/flashcards/application/flashcard_service.dart
@@ -1,0 +1,502 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import '../../../services/dacheng_ai_service.dart';
+import '../data/flashcard_repository.dart';
+import '../domain/flashcard_models.dart';
+
+class FlashcardInput {
+  final String title;
+  final String text;
+  final String? documentId;
+  final String? sourceUrl;
+  final String requirement;
+  final int maxCards;
+
+  const FlashcardInput({
+    required this.title,
+    required this.text,
+    this.documentId,
+    this.sourceUrl,
+    this.requirement = '',
+    this.maxCards = 80,
+  });
+}
+
+enum FlashcardGenerationEventType { progress, cardDelta, done, error, stopped }
+
+class FlashcardGenerationEvent {
+  final FlashcardGenerationEventType type;
+  final String message;
+  final int progress;
+  final Flashcard? card;
+  final FlashcardDeck? deck;
+
+  const FlashcardGenerationEvent({
+    required this.type,
+    required this.message,
+    this.progress = 0,
+    this.card,
+    this.deck,
+  });
+
+  bool get isDone => type == FlashcardGenerationEventType.done;
+  bool get isError => type == FlashcardGenerationEventType.error;
+}
+
+class FlashcardService {
+  FlashcardService({
+    FlashcardRepository? repository,
+    DachengAiService? aiService,
+  }) : _repository = repository ?? FlashcardRepository(),
+       _aiService = aiService ?? DachengAiService();
+
+  static const int defaultMaxCards = 80;
+  static const int randomBlankMinGap = 3;
+
+  final FlashcardRepository _repository;
+  final DachengAiService _aiService;
+
+  Future<FlashcardDeck> generateRandomCloze(FlashcardInput input) async {
+    final now = DateTime.now();
+    final deckId = flashcardId('deck');
+    final sentences = splitSentences(input.text);
+    final cards = <Flashcard>[];
+    var sentenceIndex = 0;
+
+    for (final sentence in sentences) {
+      for (final part in splitLongSentence(sentence)) {
+        if (cards.length >= min(input.maxCards, defaultMaxCards)) break;
+        final card = _buildClozeCard(
+          deckId: deckId,
+          sentence: part,
+          sentenceIndex: sentenceIndex,
+          orderIndex: cards.length,
+        );
+        if (card != null) cards.add(card);
+      }
+      sentenceIndex++;
+      if (cards.length >= min(input.maxCards, defaultMaxCards)) break;
+    }
+
+    if (cards.isEmpty) {
+      throw StateError('CONTENT_TOO_SHORT: 内容过短，请至少输入 20 个字或 2 句话。');
+    }
+
+    final deck = FlashcardDeck(
+      id: deckId,
+      title: normalizeTitle(input.title),
+      sourceDocumentId: input.documentId,
+      mode: FlashcardCreationMode.randomCloze,
+      requirement: input.requirement,
+      status: FlashcardDeckStatus.ready,
+      cards: cards,
+      generationLog: const ['清洗文本', '按句切分', '随机挖空', '校验答案'],
+      createdAt: now,
+      updatedAt: now,
+    );
+    return _repository.saveDeck(deck);
+  }
+
+  Stream<FlashcardGenerationEvent> generateRandomClozeStream(
+    FlashcardInput input,
+  ) async* {
+    yield const FlashcardGenerationEvent(
+      type: FlashcardGenerationEventType.progress,
+      message: '正在提取正文并清洗多余空白...',
+      progress: 15,
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    yield const FlashcardGenerationEvent(
+      type: FlashcardGenerationEventType.progress,
+      message: '正在按标点切分句子...',
+      progress: 35,
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    yield const FlashcardGenerationEvent(
+      type: FlashcardGenerationEventType.progress,
+      message: '正在生成随机挖空卡片...',
+      progress: 70,
+    );
+    try {
+      final deck = await generateRandomCloze(input);
+      for (final card in deck.cards.take(3)) {
+        yield FlashcardGenerationEvent(
+          type: FlashcardGenerationEventType.cardDelta,
+          message: '已生成：${card.answer}',
+          progress: 86,
+          card: card,
+        );
+      }
+      yield FlashcardGenerationEvent(
+        type: FlashcardGenerationEventType.done,
+        message: '随机挖空完成，共 ${deck.cardCount} 张卡片。',
+        progress: 100,
+        deck: deck,
+      );
+    } catch (e) {
+      yield FlashcardGenerationEvent(
+        type: FlashcardGenerationEventType.error,
+        message: e.toString(),
+      );
+    }
+  }
+
+  Stream<FlashcardGenerationEvent> generateAiCardsStream(
+    FlashcardInput input, {
+    String? conversationId,
+    String? token,
+    String? username,
+    bool isMember = false,
+  }) async* {
+    final prompt = buildAiPrompt(input);
+    var finalText = '';
+    final generatedCards = <Flashcard>[];
+
+    yield const FlashcardGenerationEvent(
+      type: FlashcardGenerationEventType.progress,
+      message: '正在理解内容与制卡要求...',
+      progress: 8,
+    );
+
+    try {
+      await for (final event in _aiService.sendChatStream(
+        message: prompt,
+        conversationId: conversationId,
+        token: token,
+        username: username,
+        isMember: isMember,
+      )) {
+        if (event.isStep) {
+          final text = _visibleStep(event);
+          if (text.isNotEmpty) {
+            yield FlashcardGenerationEvent(
+              type: FlashcardGenerationEventType.progress,
+              message: text,
+              progress: min(92, 18 + generatedCards.length * 5),
+            );
+          }
+        } else if (event.isDelta) {
+          finalText += event.text;
+          final parsedDelta = _tryParseDeck(
+            rawText: finalText,
+            input: input,
+            fallbackMode: FlashcardCreationMode.aiCards,
+            persist: false,
+          );
+          if (parsedDelta != null &&
+              parsedDelta.cards.length > generatedCards.length) {
+            final newCards = parsedDelta.cards
+                .skip(generatedCards.length)
+                .take(3);
+            generatedCards.addAll(newCards);
+            for (final card in newCards) {
+              yield FlashcardGenerationEvent(
+                type: FlashcardGenerationEventType.cardDelta,
+                message: '已生成卡片：${card.front}',
+                progress: min(92, 22 + generatedCards.length * 6),
+                card: card,
+              );
+            }
+          }
+        } else if (event.isDone) {
+          finalText = (event.raw['message'] ?? finalText).toString();
+        } else if (event.isError) {
+          throw StateError(event.text.isEmpty ? 'AI 制卡失败' : event.text);
+        }
+      }
+
+      final deck = await _parseAndSaveAiDeck(finalText, input);
+      yield FlashcardGenerationEvent(
+        type: FlashcardGenerationEventType.done,
+        message: 'AI 制卡完成，共 ${deck.cardCount} 张卡片。',
+        progress: 100,
+        deck: deck,
+      );
+    } catch (e) {
+      yield FlashcardGenerationEvent(
+        type: FlashcardGenerationEventType.progress,
+        message: 'AI 制卡失败，正在回退为本地随机挖空。原因：$e',
+        progress: 88,
+      );
+      try {
+        final deck = await generateRandomCloze(input);
+        yield FlashcardGenerationEvent(
+          type: FlashcardGenerationEventType.done,
+          message: '已回退为随机挖空，共 ${deck.cardCount} 张卡片。',
+          progress: 100,
+          deck: deck,
+        );
+      } catch (fallbackError) {
+        yield FlashcardGenerationEvent(
+          type: FlashcardGenerationEventType.error,
+          message: fallbackError.toString(),
+        );
+      }
+    }
+  }
+
+  Future<FlashcardDeck> saveDeck(FlashcardDeck deck) {
+    return _repository.saveDeck(deck);
+  }
+
+  Future<List<FlashcardDeck>> listDecks() => _repository.listDecks();
+
+  static String buildAiPrompt(FlashcardInput input) {
+    final requirement = input.requirement.trim().isEmpty
+        ? '请提取核心概念，生成问答卡和挖空卡。'
+        : input.requirement.trim();
+    final content = input.text.length > 12000
+        ? '${input.text.substring(0, 12000)}\n（内容已截断，请基于以上内容制卡）'
+        : input.text;
+    return '''你是法布施 App 的知识背诵闪卡生成器。
+请根据正文和用户要求生成可背诵闪卡，只输出 JSON，不要输出 Markdown。
+
+输出格式：
+{
+  "title": "卡组标题",
+  "cards": [
+    {
+      "type": "qa 或 cloze",
+      "front": "正面题目",
+      "back": "背面解释或完整答案",
+      "clozeText": "挖空文本，可为空",
+      "answer": "答案",
+      "sourceQuote": "对应原文短句",
+      "tags": ["主题"]
+    }
+  ]
+}
+
+要求：$requirement
+最多 ${min(input.maxCards, defaultMaxCards)} 张，答案必须能在原文中找到依据。
+标题：${input.title}
+正文：
+$content''';
+  }
+
+  Future<FlashcardDeck> _parseAndSaveAiDeck(
+    String rawText,
+    FlashcardInput input,
+  ) async {
+    final parsed = _tryParseDeck(
+      rawText: rawText,
+      input: input,
+      fallbackMode: FlashcardCreationMode.aiCards,
+      persist: false,
+    );
+    if (parsed == null || parsed.cards.isEmpty) {
+      throw StateError('AI 输出缺少可用卡片');
+    }
+    return _repository.saveDeck(parsed);
+  }
+
+  FlashcardDeck? _tryParseDeck({
+    required String rawText,
+    required FlashcardInput input,
+    required FlashcardCreationMode fallbackMode,
+    required bool persist,
+  }) {
+    final jsonText = _extractJson(rawText);
+    if (jsonText == null) return null;
+    try {
+      final decoded = jsonDecode(jsonText);
+      final map = decoded is List<dynamic>
+          ? <String, dynamic>{'cards': decoded}
+          : decoded as Map<String, dynamic>;
+      final cardsJson = map['cards'] as List<dynamic>? ?? const [];
+      if (cardsJson.isEmpty) return null;
+      final now = DateTime.now();
+      final deckId = flashcardId('deck_ai');
+      final cards = <Flashcard>[];
+      for (final item in cardsJson.take(input.maxCards)) {
+        if (item is! Map) continue;
+        final itemMap = item.map(
+          (key, value) => MapEntry(key.toString(), value),
+        );
+        final front = (itemMap['front'] ?? itemMap['question'] ?? '')
+            .toString()
+            .trim();
+        final back =
+            (itemMap['back'] ??
+                    itemMap['explanation'] ??
+                    itemMap['answer'] ??
+                    '')
+                .toString()
+                .trim();
+        final answer = (itemMap['answer'] ?? back).toString().trim();
+        if (front.isEmpty || answer.isEmpty) continue;
+        final cloze = (itemMap['clozeText'] ?? itemMap['cloze'] ?? '')
+            .toString()
+            .trim();
+        final quote = (itemMap['sourceQuote'] ?? itemMap['sourceExcerpt'] ?? '')
+            .toString()
+            .trim();
+        final type = cloze.isNotEmpty
+            ? FlashcardType.cloze
+            : FlashcardTypeX.fromStorage(
+                (itemMap['type'] ?? itemMap['cardType'] ?? 'qa').toString(),
+              );
+        cards.add(
+          Flashcard(
+            id: flashcardId('card_ai'),
+            deckId: deckId,
+            orderIndex: cards.length,
+            cardType: type,
+            front: front,
+            back: back.isEmpty ? answer : back,
+            clozeText: cloze,
+            answer: answer,
+            sourceQuote: quote.isEmpty ? front : quote,
+            sourceSentenceIndex: cards.length,
+            tags: (itemMap['tags'] as List<dynamic>? ?? const [])
+                .map((tag) => tag.toString())
+                .where((tag) => tag.trim().isNotEmpty)
+                .toList(),
+            ttsText: [front, answer].where((part) => part.isNotEmpty).join('。'),
+            metadata: {'ai': true},
+          ),
+        );
+      }
+      if (cards.isEmpty) return null;
+      return FlashcardDeck(
+        id: deckId,
+        title: normalizeTitle((map['title'] ?? input.title).toString()),
+        sourceDocumentId: input.documentId,
+        mode: fallbackMode,
+        requirement: input.requirement,
+        status: FlashcardDeckStatus.ready,
+        cards: cards,
+        generationLog: const ['AI 分析内容', '提取知识点', '生成卡片', '校验答案'],
+        createdAt: now,
+        updatedAt: now,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static List<String> splitSentences(String text) {
+    final cleaned = text
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .replaceAll(RegExp(r'https?://\S+'), ' ')
+        .trim();
+    final matches = RegExp(r'[^。！？；.!?;\n]+[。！？；.!?;]?')
+        .allMatches(cleaned)
+        .map((match) => match.group(0)?.trim() ?? '')
+        .where((sentence) => sentence.runes.length >= 8)
+        .where(
+          (sentence) => RegExp(r'[\u4e00-\u9fa5A-Za-z]').hasMatch(sentence),
+        )
+        .toList();
+    return matches;
+  }
+
+  static List<String> splitLongSentence(String sentence) {
+    if (sentence.runes.length <= 72) return [sentence];
+    final parts = <String>[];
+    final runes = sentence.runes.toList();
+    for (var i = 0; i < runes.length; i += 56) {
+      final part = String.fromCharCodes(runes.skip(i).take(64)).trim();
+      if (part.runes.length >= 8) parts.add(part);
+    }
+    return parts;
+  }
+
+  Flashcard? _buildClozeCard({
+    required String deckId,
+    required String sentence,
+    required int sentenceIndex,
+    required int orderIndex,
+  }) {
+    final runes = sentence.runes.toList();
+    final candidates = <int>[];
+    for (var i = 0; i < runes.length; i++) {
+      final char = String.fromCharCode(runes[i]);
+      if (RegExp(r'[\u4e00-\u9fa5A-Za-z]').hasMatch(char)) {
+        candidates.add(i);
+      }
+    }
+    if (candidates.length < 5) return null;
+
+    final blankCount = switch (candidates.length) {
+      < 16 => 1,
+      < 32 => 2,
+      < 56 => 3,
+      _ => 4,
+    };
+    final gap = max(
+      randomBlankMinGap,
+      (candidates.length / (blankCount + 1)).floor(),
+    );
+    final blankIndexes = <int>[];
+    for (var i = 1; i <= blankCount; i++) {
+      final target = min(candidates.length - 1, i * gap);
+      blankIndexes.add(candidates[target]);
+      if (blankCount >= 3 &&
+          target + 1 < candidates.length &&
+          i == blankCount) {
+        blankIndexes.add(candidates[target + 1]);
+      }
+    }
+    final blankSet = blankIndexes.toSet();
+    final answer = blankIndexes
+        .map((index) => String.fromCharCode(runes[index]))
+        .join('');
+    final clozeText = List<String>.generate(runes.length, (index) {
+      if (blankSet.contains(index)) return '＿';
+      return String.fromCharCode(runes[index]);
+    }).join();
+
+    return Flashcard(
+      id: flashcardId('card'),
+      deckId: deckId,
+      orderIndex: orderIndex,
+      cardType: FlashcardType.cloze,
+      front: clozeText,
+      back: sentence,
+      clozeText: clozeText,
+      answer: answer,
+      sourceQuote: sentence,
+      sourceSentenceIndex: sentenceIndex,
+      tags: const ['随机挖空'],
+      ttsText: sentence,
+      metadata: {
+        'blankIndexes': blankIndexes,
+        'blankCount': blankIndexes.length,
+      },
+    );
+  }
+
+  static String normalizeTitle(String title) {
+    final normalized = title.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (normalized.isEmpty) return '背诵闪卡';
+    return normalized.length <= 32 ? normalized : normalized.substring(0, 32);
+  }
+
+  static String _visibleStep(DachengAiStreamEvent event) {
+    final title = (event.raw['title'] ?? '').toString().trim();
+    final message = (event.raw['message'] ?? event.text).toString().trim();
+    return title.isNotEmpty ? title : message;
+  }
+
+  static String? _extractJson(String rawText) {
+    final fence = RegExp(
+      r'```(?:json)?\s*([\s\S]*?)```',
+      caseSensitive: false,
+    ).firstMatch(rawText);
+    final text = fence?.group(1) ?? rawText;
+    final objectStart = text.indexOf('{');
+    final arrayStart = text.indexOf('[');
+    if (objectStart < 0 && arrayStart < 0) return null;
+    if (arrayStart >= 0 && (objectStart < 0 || arrayStart < objectStart)) {
+      final end = text.lastIndexOf(']');
+      if (end <= arrayStart) return null;
+      return text.substring(arrayStart, end + 1);
+    }
+    final end = text.lastIndexOf('}');
+    if (end <= objectStart) return null;
+    return text.substring(objectStart, end + 1);
+  }
+}

--- a/fabushi/lib/features/flashcards/data/flashcard_repository.dart
+++ b/fabushi/lib/features/flashcards/data/flashcard_repository.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../domain/flashcard_models.dart';
+
+/// 首版本地优先持久化。
+///
+/// 当前仓库没有统一 SQLite 层，因此先用 SharedPreferences 保存文档、Deck 和学习进度。
+/// 模型字段和 key 都按后续迁移预留，不影响旧版本启动。
+class FlashcardRepository {
+  static const String _documentsKey = 'flashcard_content_documents_v1';
+  static const String _decksKey = 'flashcard_decks_v1';
+  static const String _progressKey = 'flashcard_study_progress_v1';
+  static const int _maxDecks = 80;
+  static const int _maxDocuments = 80;
+
+  Future<ContentDocument> saveDocument(ContentDocument document) async {
+    final prefs = await SharedPreferences.getInstance();
+    final documents = await listDocuments();
+    final next = <ContentDocument>[
+      document,
+      ...documents.where((item) => item.id != document.id),
+    ].take(_maxDocuments).toList();
+    await prefs.setString(
+      _documentsKey,
+      jsonEncode(next.map((item) => item.toJson()).toList()),
+    );
+    return document;
+  }
+
+  Future<List<ContentDocument>> listDocuments() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_documentsKey);
+    if (raw == null || raw.trim().isEmpty) return const [];
+    try {
+      final list = jsonDecode(raw) as List<dynamic>;
+      return list
+          .whereType<Map<String, dynamic>>()
+          .map(ContentDocument.fromJson)
+          .toList();
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  Future<ContentDocument?> getDocument(String id) async {
+    final documents = await listDocuments();
+    for (final document in documents) {
+      if (document.id == id) return document;
+    }
+    return null;
+  }
+
+  Future<FlashcardDeck> saveDeck(FlashcardDeck deck) async {
+    final prefs = await SharedPreferences.getInstance();
+    final decks = await listDecks();
+    final normalized = deck.copyWith(updatedAt: DateTime.now());
+    final next = <FlashcardDeck>[
+      normalized,
+      ...decks.where((item) => item.id != normalized.id),
+    ].take(_maxDecks).toList();
+    await prefs.setString(
+      _decksKey,
+      jsonEncode(next.map((item) => item.toJson()).toList()),
+    );
+    return normalized;
+  }
+
+  Future<List<FlashcardDeck>> listDecks() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_decksKey);
+    if (raw == null || raw.trim().isEmpty) return const [];
+    try {
+      final list = jsonDecode(raw) as List<dynamic>;
+      final decks = list
+          .whereType<Map<String, dynamic>>()
+          .map(FlashcardDeck.fromJson)
+          .toList();
+      decks.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      return decks;
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  Future<FlashcardDeck?> getDeck(String id) async {
+    final decks = await listDecks();
+    for (final deck in decks) {
+      if (deck.id == id) return deck;
+    }
+    return null;
+  }
+
+  Future<void> saveStudyProgress(FlashcardStudyProgress progress) async {
+    final prefs = await SharedPreferences.getInstance();
+    final all = await _loadProgressMap();
+    all[progress.deckId] = progress.copyWith(updatedAt: DateTime.now());
+    await prefs.setString(
+      _progressKey,
+      jsonEncode(all.map((key, value) => MapEntry(key, value.toJson()))),
+    );
+  }
+
+  Future<FlashcardStudyProgress> getStudyProgress(String deckId) async {
+    final all = await _loadProgressMap();
+    return all[deckId] ?? FlashcardStudyProgress.empty(deckId);
+  }
+
+  Future<Map<String, FlashcardStudyProgress>> _loadProgressMap() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_progressKey);
+    if (raw == null || raw.trim().isEmpty)
+      return <String, FlashcardStudyProgress>{};
+    try {
+      final map = jsonDecode(raw) as Map<String, dynamic>;
+      return map.map((key, value) {
+        if (value is Map<String, dynamic>) {
+          return MapEntry(key, FlashcardStudyProgress.fromJson(value));
+        }
+        return MapEntry(key, FlashcardStudyProgress.empty(key));
+      });
+    } catch (_) {
+      return <String, FlashcardStudyProgress>{};
+    }
+  }
+}

--- a/fabushi/lib/features/flashcards/domain/flashcard_models.dart
+++ b/fabushi/lib/features/flashcards/domain/flashcard_models.dart
@@ -1,0 +1,563 @@
+import 'dart:convert';
+
+/// 背诵闪卡首版本地模型。
+///
+/// 字段按上传的数据库设计文档预留 documentId、status、metadata 等扩展点，
+/// 便于后续迁移到 SQLite/云同步时保持向后兼容。
+enum FlashcardCreationMode { randomCloze, aiCards }
+
+enum FlashcardDeckStatus { draft, generating, ready, failed, archived }
+
+enum FlashcardType { cloze, basic, qa }
+
+extension FlashcardCreationModeX on FlashcardCreationMode {
+  String get storageValue => switch (this) {
+    FlashcardCreationMode.randomCloze => 'random_cloze',
+    FlashcardCreationMode.aiCards => 'ai_cards',
+  };
+
+  String get label => switch (this) {
+    FlashcardCreationMode.randomCloze => '随机挖空',
+    FlashcardCreationMode.aiCards => 'AI 制卡',
+  };
+
+  static FlashcardCreationMode fromStorage(String value) {
+    return switch (value) {
+      'ai_cards' => FlashcardCreationMode.aiCards,
+      _ => FlashcardCreationMode.randomCloze,
+    };
+  }
+}
+
+extension FlashcardDeckStatusX on FlashcardDeckStatus {
+  String get storageValue => switch (this) {
+    FlashcardDeckStatus.draft => 'draft',
+    FlashcardDeckStatus.generating => 'generating',
+    FlashcardDeckStatus.ready => 'ready',
+    FlashcardDeckStatus.failed => 'failed',
+    FlashcardDeckStatus.archived => 'archived',
+  };
+
+  static FlashcardDeckStatus fromStorage(String value) {
+    return switch (value) {
+      'draft' => FlashcardDeckStatus.draft,
+      'generating' => FlashcardDeckStatus.generating,
+      'failed' => FlashcardDeckStatus.failed,
+      'archived' => FlashcardDeckStatus.archived,
+      _ => FlashcardDeckStatus.ready,
+    };
+  }
+}
+
+extension FlashcardTypeX on FlashcardType {
+  String get storageValue => switch (this) {
+    FlashcardType.basic => 'basic',
+    FlashcardType.qa => 'qa',
+    FlashcardType.cloze => 'cloze',
+  };
+
+  String get label => switch (this) {
+    FlashcardType.basic => '记忆',
+    FlashcardType.qa => '问答',
+    FlashcardType.cloze => '挖空',
+  };
+
+  static FlashcardType fromStorage(String value) {
+    return switch (value) {
+      'basic' => FlashcardType.basic,
+      'qa' => FlashcardType.qa,
+      _ => FlashcardType.cloze,
+    };
+  }
+}
+
+class ContentSource {
+  final String id;
+  final String sourceType;
+  final String rawText;
+  final String? url;
+  final String title;
+  final String sourceApp;
+  final String mimeType;
+  final DateTime receivedAt;
+  final String rawTextHash;
+
+  const ContentSource({
+    required this.id,
+    required this.sourceType,
+    required this.rawText,
+    this.url,
+    required this.title,
+    required this.sourceApp,
+    required this.mimeType,
+    required this.receivedAt,
+    required this.rawTextHash,
+  });
+
+  ContentSource copyWith({
+    String? id,
+    String? sourceType,
+    String? rawText,
+    String? url,
+    String? title,
+    String? sourceApp,
+    String? mimeType,
+    DateTime? receivedAt,
+    String? rawTextHash,
+  }) {
+    return ContentSource(
+      id: id ?? this.id,
+      sourceType: sourceType ?? this.sourceType,
+      rawText: rawText ?? this.rawText,
+      url: url ?? this.url,
+      title: title ?? this.title,
+      sourceApp: sourceApp ?? this.sourceApp,
+      mimeType: mimeType ?? this.mimeType,
+      receivedAt: receivedAt ?? this.receivedAt,
+      rawTextHash: rawTextHash ?? this.rawTextHash,
+    );
+  }
+
+  factory ContentSource.fromJson(Map<String, dynamic> json) {
+    return ContentSource(
+      id: (json['id'] ?? '').toString(),
+      sourceType: (json['sourceType'] ?? 'composer_text').toString(),
+      rawText: (json['rawText'] ?? '').toString(),
+      url: _emptyToNull(json['url']?.toString()),
+      title: (json['title'] ?? '未命名内容').toString(),
+      sourceApp: (json['sourceApp'] ?? '').toString(),
+      mimeType: (json['mimeType'] ?? '').toString(),
+      receivedAt:
+          DateTime.tryParse((json['receivedAt'] ?? '').toString()) ??
+          DateTime.now(),
+      rawTextHash: (json['rawTextHash'] ?? '').toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'sourceType': sourceType,
+    'rawText': rawText,
+    'url': url,
+    'title': title,
+    'sourceApp': sourceApp,
+    'mimeType': mimeType,
+    'receivedAt': receivedAt.toIso8601String(),
+    'rawTextHash': rawTextHash,
+  };
+}
+
+class ContentDocument {
+  final String id;
+  final String sourceId;
+  final String title;
+  final String summary;
+  final String fullText;
+  final int charCount;
+  final int tokenCount;
+  final String language;
+  final DateTime extractedAt;
+  final String? sourceUrl;
+
+  const ContentDocument({
+    required this.id,
+    required this.sourceId,
+    required this.title,
+    required this.summary,
+    required this.fullText,
+    required this.charCount,
+    required this.tokenCount,
+    required this.language,
+    required this.extractedAt,
+    this.sourceUrl,
+  });
+
+  factory ContentDocument.fromJson(Map<String, dynamic> json) {
+    return ContentDocument(
+      id: (json['id'] ?? '').toString(),
+      sourceId: (json['sourceId'] ?? '').toString(),
+      title: (json['title'] ?? '未命名文档').toString(),
+      summary: (json['summary'] ?? '').toString(),
+      fullText: (json['fullText'] ?? '').toString(),
+      charCount: _readInt(json['charCount']),
+      tokenCount: _readInt(json['tokenCount']),
+      language: (json['language'] ?? 'zh').toString(),
+      extractedAt:
+          DateTime.tryParse((json['extractedAt'] ?? '').toString()) ??
+          DateTime.now(),
+      sourceUrl: _emptyToNull(json['sourceUrl']?.toString()),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'sourceId': sourceId,
+    'title': title,
+    'summary': summary,
+    'fullText': fullText,
+    'charCount': charCount,
+    'tokenCount': tokenCount,
+    'language': language,
+    'extractedAt': extractedAt.toIso8601String(),
+    'sourceUrl': sourceUrl,
+  };
+}
+
+class PreparedContent {
+  final ContentSource source;
+  final ContentDocument? document;
+  final String title;
+  final String text;
+  final String summary;
+  final String previewText;
+  final bool isLong;
+  final bool isFailed;
+  final String? errorMessage;
+
+  const PreparedContent({
+    required this.source,
+    this.document,
+    required this.title,
+    required this.text,
+    required this.summary,
+    required this.previewText,
+    required this.isLong,
+    this.isFailed = false,
+    this.errorMessage,
+  });
+
+  String? get sourceUrl => source.url;
+  String get displaySource => source.sourceApp.isNotEmpty
+      ? source.sourceApp
+      : (source.url != null ? '链接' : '文本');
+  int get charCount => text.charactersCount;
+  bool get hasDocument => document != null;
+
+  PreparedContent copyWith({
+    ContentSource? source,
+    ContentDocument? document,
+    String? title,
+    String? text,
+    String? summary,
+    String? previewText,
+    bool? isLong,
+    bool? isFailed,
+    String? errorMessage,
+  }) {
+    return PreparedContent(
+      source: source ?? this.source,
+      document: document ?? this.document,
+      title: title ?? this.title,
+      text: text ?? this.text,
+      summary: summary ?? this.summary,
+      previewText: previewText ?? this.previewText,
+      isLong: isLong ?? this.isLong,
+      isFailed: isFailed ?? this.isFailed,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}
+
+class Flashcard {
+  final String id;
+  final String deckId;
+  final int orderIndex;
+  final FlashcardType cardType;
+  final String front;
+  final String back;
+  final String clozeText;
+  final String answer;
+  final String sourceQuote;
+  final int sourceSentenceIndex;
+  final List<String> tags;
+  final String ttsText;
+  final Map<String, dynamic> metadata;
+
+  const Flashcard({
+    required this.id,
+    required this.deckId,
+    required this.orderIndex,
+    required this.cardType,
+    required this.front,
+    required this.back,
+    required this.clozeText,
+    required this.answer,
+    required this.sourceQuote,
+    required this.sourceSentenceIndex,
+    this.tags = const [],
+    required this.ttsText,
+    this.metadata = const {},
+  });
+
+  Flashcard copyWith({
+    String? id,
+    String? deckId,
+    int? orderIndex,
+    FlashcardType? cardType,
+    String? front,
+    String? back,
+    String? clozeText,
+    String? answer,
+    String? sourceQuote,
+    int? sourceSentenceIndex,
+    List<String>? tags,
+    String? ttsText,
+    Map<String, dynamic>? metadata,
+  }) {
+    return Flashcard(
+      id: id ?? this.id,
+      deckId: deckId ?? this.deckId,
+      orderIndex: orderIndex ?? this.orderIndex,
+      cardType: cardType ?? this.cardType,
+      front: front ?? this.front,
+      back: back ?? this.back,
+      clozeText: clozeText ?? this.clozeText,
+      answer: answer ?? this.answer,
+      sourceQuote: sourceQuote ?? this.sourceQuote,
+      sourceSentenceIndex: sourceSentenceIndex ?? this.sourceSentenceIndex,
+      tags: tags ?? this.tags,
+      ttsText: ttsText ?? this.ttsText,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+
+  factory Flashcard.fromJson(Map<String, dynamic> json) {
+    return Flashcard(
+      id: (json['id'] ?? '').toString(),
+      deckId: (json['deckId'] ?? '').toString(),
+      orderIndex: _readInt(json['orderIndex']),
+      cardType: FlashcardTypeX.fromStorage((json['cardType'] ?? '').toString()),
+      front: (json['front'] ?? '').toString(),
+      back: (json['back'] ?? '').toString(),
+      clozeText: (json['clozeText'] ?? '').toString(),
+      answer: (json['answer'] ?? '').toString(),
+      sourceQuote: (json['sourceQuote'] ?? '').toString(),
+      sourceSentenceIndex: _readInt(json['sourceSentenceIndex']),
+      tags: (json['tags'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .where((item) => item.trim().isNotEmpty)
+          .toList(),
+      ttsText: (json['ttsText'] ?? '').toString(),
+      metadata: _readMap(json['metadata']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'deckId': deckId,
+    'orderIndex': orderIndex,
+    'cardType': cardType.storageValue,
+    'front': front,
+    'back': back,
+    'clozeText': clozeText,
+    'answer': answer,
+    'sourceQuote': sourceQuote,
+    'sourceSentenceIndex': sourceSentenceIndex,
+    'tags': tags,
+    'ttsText': ttsText,
+    'metadata': metadata,
+  };
+}
+
+class FlashcardDeck {
+  final String id;
+  final String title;
+  final String? sourceDocumentId;
+  final FlashcardCreationMode mode;
+  final String requirement;
+  final FlashcardDeckStatus status;
+  final List<Flashcard> cards;
+  final List<String> generationLog;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? lastStudiedAt;
+  final int lastStudiedIndex;
+
+  const FlashcardDeck({
+    required this.id,
+    required this.title,
+    this.sourceDocumentId,
+    required this.mode,
+    this.requirement = '',
+    this.status = FlashcardDeckStatus.ready,
+    this.cards = const [],
+    this.generationLog = const [],
+    required this.createdAt,
+    required this.updatedAt,
+    this.lastStudiedAt,
+    this.lastStudiedIndex = 0,
+  });
+
+  int get cardCount => cards.length;
+  bool get isReady => status == FlashcardDeckStatus.ready && cards.isNotEmpty;
+
+  FlashcardDeck copyWith({
+    String? id,
+    String? title,
+    String? sourceDocumentId,
+    FlashcardCreationMode? mode,
+    String? requirement,
+    FlashcardDeckStatus? status,
+    List<Flashcard>? cards,
+    List<String>? generationLog,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    DateTime? lastStudiedAt,
+    int? lastStudiedIndex,
+  }) {
+    return FlashcardDeck(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      sourceDocumentId: sourceDocumentId ?? this.sourceDocumentId,
+      mode: mode ?? this.mode,
+      requirement: requirement ?? this.requirement,
+      status: status ?? this.status,
+      cards: cards ?? this.cards,
+      generationLog: generationLog ?? this.generationLog,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lastStudiedAt: lastStudiedAt ?? this.lastStudiedAt,
+      lastStudiedIndex: lastStudiedIndex ?? this.lastStudiedIndex,
+    );
+  }
+
+  factory FlashcardDeck.fromJson(Map<String, dynamic> json) {
+    return FlashcardDeck(
+      id: (json['id'] ?? '').toString(),
+      title: (json['title'] ?? '背诵闪卡').toString(),
+      sourceDocumentId: _emptyToNull(json['sourceDocumentId']?.toString()),
+      mode: FlashcardCreationModeX.fromStorage((json['mode'] ?? '').toString()),
+      requirement: (json['requirement'] ?? '').toString(),
+      status: FlashcardDeckStatusX.fromStorage(
+        (json['status'] ?? '').toString(),
+      ),
+      cards: (json['cards'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(Flashcard.fromJson)
+          .toList(),
+      generationLog: (json['generationLog'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .where((item) => item.trim().isNotEmpty)
+          .toList(),
+      createdAt:
+          DateTime.tryParse((json['createdAt'] ?? '').toString()) ??
+          DateTime.now(),
+      updatedAt:
+          DateTime.tryParse((json['updatedAt'] ?? '').toString()) ??
+          DateTime.now(),
+      lastStudiedAt: DateTime.tryParse(
+        (json['lastStudiedAt'] ?? '').toString(),
+      ),
+      lastStudiedIndex: _readInt(json['lastStudiedIndex']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'sourceDocumentId': sourceDocumentId,
+    'mode': mode.storageValue,
+    'requirement': requirement,
+    'status': status.storageValue,
+    'cardCount': cardCount,
+    'cards': cards.map((card) => card.toJson()).toList(),
+    'generationLog': generationLog,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'lastStudiedAt': lastStudiedAt?.toIso8601String(),
+    'lastStudiedIndex': lastStudiedIndex,
+  };
+}
+
+class FlashcardStudyProgress {
+  final String deckId;
+  final int currentIndex;
+  final Set<String> masteredCardIds;
+  final Set<String> favoriteCardIds;
+  final DateTime updatedAt;
+
+  const FlashcardStudyProgress({
+    required this.deckId,
+    required this.currentIndex,
+    this.masteredCardIds = const {},
+    this.favoriteCardIds = const {},
+    required this.updatedAt,
+  });
+
+  factory FlashcardStudyProgress.empty(String deckId) {
+    return FlashcardStudyProgress(
+      deckId: deckId,
+      currentIndex: 0,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  FlashcardStudyProgress copyWith({
+    int? currentIndex,
+    Set<String>? masteredCardIds,
+    Set<String>? favoriteCardIds,
+    DateTime? updatedAt,
+  }) {
+    return FlashcardStudyProgress(
+      deckId: deckId,
+      currentIndex: currentIndex ?? this.currentIndex,
+      masteredCardIds: masteredCardIds ?? this.masteredCardIds,
+      favoriteCardIds: favoriteCardIds ?? this.favoriteCardIds,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  factory FlashcardStudyProgress.fromJson(Map<String, dynamic> json) {
+    return FlashcardStudyProgress(
+      deckId: (json['deckId'] ?? '').toString(),
+      currentIndex: _readInt(json['currentIndex']),
+      masteredCardIds: (json['masteredCardIds'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .toSet(),
+      favoriteCardIds: (json['favoriteCardIds'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .toSet(),
+      updatedAt:
+          DateTime.tryParse((json['updatedAt'] ?? '').toString()) ??
+          DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'deckId': deckId,
+    'currentIndex': currentIndex,
+    'masteredCardIds': masteredCardIds.toList(),
+    'favoriteCardIds': favoriteCardIds.toList(),
+    'updatedAt': updatedAt.toIso8601String(),
+  };
+}
+
+String flashcardId(String prefix) {
+  final micros = DateTime.now().microsecondsSinceEpoch;
+  return '${prefix}_${micros}_${micros.remainder(9973)}';
+}
+
+String encodeFlashcardJson(Object? object) => jsonEncode(object);
+
+Map<String, dynamic> _readMap(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return value.map((key, item) => MapEntry(key.toString(), item));
+  }
+  return <String, dynamic>{};
+}
+
+int _readInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse((value ?? '').toString()) ?? 0;
+}
+
+String? _emptyToNull(String? value) {
+  final trimmed = value?.trim() ?? '';
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+extension _FlashcardStringLength on String {
+  int get charactersCount => runes.length;
+}

--- a/fabushi/lib/features/flashcards/presentation/flashcard_study_screen.dart
+++ b/fabushi/lib/features/flashcards/presentation/flashcard_study_screen.dart
@@ -53,7 +53,9 @@ class _FlashcardStudyScreenState extends State<FlashcardStudyScreen> {
   Future<void> _loadProgress() async {
     final progress = await _repository.getStudyProgress(widget.deck.id);
     if (!mounted) return;
-    final index = progress.currentIndex.clamp(0, max(0, _cards.length - 1));
+    final index = progress.currentIndex
+        .clamp(0, max(0, _cards.length - 1))
+        .toInt();
     setState(() {
       _progress = progress;
       _currentIndex = index;

--- a/fabushi/lib/features/flashcards/presentation/flashcard_study_screen.dart
+++ b/fabushi/lib/features/flashcards/presentation/flashcard_study_screen.dart
@@ -1,0 +1,548 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+import '../../../core/design_system/app_theme.dart';
+import '../data/flashcard_repository.dart';
+import '../domain/flashcard_models.dart';
+
+class FlashcardStudyScreen extends StatefulWidget {
+  final FlashcardDeck deck;
+  final FlashcardRepository? repository;
+
+  const FlashcardStudyScreen({super.key, required this.deck, this.repository});
+
+  @override
+  State<FlashcardStudyScreen> createState() => _FlashcardStudyScreenState();
+}
+
+class _FlashcardStudyScreenState extends State<FlashcardStudyScreen> {
+  late final FlashcardRepository _repository;
+  late final PageController _pageController;
+  final FlutterTts _tts = FlutterTts();
+
+  FlashcardStudyProgress? _progress;
+  bool _showAnswer = false;
+  bool _shuffleCards = false;
+  bool _ttsEnabled = true;
+  bool _autoPlay = false;
+  bool _frontToBack = true;
+  bool _isSpeaking = false;
+  int _currentIndex = 0;
+  late List<Flashcard> _cards;
+
+  @override
+  void initState() {
+    super.initState();
+    _repository = widget.repository ?? FlashcardRepository();
+    _cards = List<Flashcard>.from(widget.deck.cards);
+    _pageController = PageController(initialPage: _currentIndex);
+    unawaited(_loadProgress());
+    unawaited(_initTts());
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    unawaited(_tts.stop());
+    super.dispose();
+  }
+
+  Future<void> _loadProgress() async {
+    final progress = await _repository.getStudyProgress(widget.deck.id);
+    if (!mounted) return;
+    final index = progress.currentIndex.clamp(0, max(0, _cards.length - 1));
+    setState(() {
+      _progress = progress;
+      _currentIndex = index;
+    });
+    if (_pageController.hasClients) {
+      _pageController.jumpToPage(index);
+    }
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('zh-CN');
+      await _tts.setSpeechRate(0.42);
+      await _tts.setPitch(1.0);
+      _tts.setStartHandler(() {
+        if (mounted) setState(() => _isSpeaking = true);
+      });
+      _tts.setCompletionHandler(() {
+        if (!mounted) return;
+        setState(() => _isSpeaking = false);
+        if (_autoPlay) _goNext(speak: true);
+      });
+      _tts.setCancelHandler(() {
+        if (mounted) setState(() => _isSpeaking = false);
+      });
+    } catch (_) {
+      if (mounted) setState(() => _ttsEnabled = false);
+    }
+  }
+
+  Future<void> _saveProgress() async {
+    final old = _progress ?? FlashcardStudyProgress.empty(widget.deck.id);
+    final next = old.copyWith(
+      currentIndex: _currentIndex,
+      updatedAt: DateTime.now(),
+    );
+    _progress = next;
+    await _repository.saveStudyProgress(next);
+  }
+
+  Future<void> _speakCurrent({bool includeAnswer = false}) async {
+    if (!_ttsEnabled || _cards.isEmpty) return;
+    final card = _cards[_currentIndex];
+    final text = includeAnswer
+        ? [
+            card.front,
+            card.answer,
+            card.back,
+          ].where((part) => part.trim().isNotEmpty).join('。')
+        : (_frontToBack ? card.front : card.back);
+    await _tts.stop();
+    if (text.trim().isNotEmpty) await _tts.speak(text);
+  }
+
+  void _toggleFavorite() {
+    final card = _cards[_currentIndex];
+    final old = _progress ?? FlashcardStudyProgress.empty(widget.deck.id);
+    final favorites = Set<String>.from(old.favoriteCardIds);
+    if (favorites.contains(card.id)) {
+      favorites.remove(card.id);
+    } else {
+      favorites.add(card.id);
+    }
+    setState(() {
+      _progress = old.copyWith(
+        favoriteCardIds: favorites,
+        updatedAt: DateTime.now(),
+      );
+    });
+    unawaited(_repository.saveStudyProgress(_progress!));
+  }
+
+  void _markMastered() {
+    final card = _cards[_currentIndex];
+    final old = _progress ?? FlashcardStudyProgress.empty(widget.deck.id);
+    final mastered = Set<String>.from(old.masteredCardIds)..add(card.id);
+    setState(() {
+      _progress = old.copyWith(
+        masteredCardIds: mastered,
+        updatedAt: DateTime.now(),
+      );
+    });
+    unawaited(_repository.saveStudyProgress(_progress!));
+    _goNext();
+  }
+
+  void _restart() {
+    setState(() {
+      _currentIndex = 0;
+      _showAnswer = false;
+    });
+    _pageController.animateToPage(
+      0,
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOut,
+    );
+    unawaited(_saveProgress());
+  }
+
+  void _goPrevious() {
+    if (_currentIndex <= 0) return;
+    _pageController.previousPage(
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOut,
+    );
+  }
+
+  void _goNext({bool speak = false}) {
+    if (_currentIndex >= _cards.length - 1) return;
+    _pageController.nextPage(
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOut,
+    );
+    if (speak) {
+      Future<void>.delayed(const Duration(milliseconds: 320), _speakCurrent);
+    }
+  }
+
+  void _openSettings() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            Widget switchTile({
+              required String title,
+              required String subtitle,
+              required bool value,
+              required ValueChanged<bool> onChanged,
+            }) {
+              return SwitchListTile(
+                value: value,
+                onChanged: (next) {
+                  onChanged(next);
+                  setSheetState(() {});
+                  setState(() {});
+                },
+                title: Text(
+                  title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                subtitle: Text(
+                  subtitle,
+                  style: const TextStyle(color: Colors.white60),
+                ),
+                activeThumbColor: AppTheme.primaryColor,
+              );
+            }
+
+            return SafeArea(
+              top: false,
+              child: Container(
+                padding: const EdgeInsets.fromLTRB(18, 10, 18, 18),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF202020),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(26)),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 42,
+                      height: 4,
+                      margin: const EdgeInsets.only(bottom: 14),
+                      decoration: BoxDecoration(
+                        color: Colors.white24,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                    ),
+                    const Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        '背诵设置',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 21,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    switchTile(
+                      title: '混合卡片',
+                      subtitle: '打乱当前卡组顺序，适合复习。',
+                      value: _shuffleCards,
+                      onChanged: (next) {
+                        _shuffleCards = next;
+                        if (next) {
+                          _cards = List<Flashcard>.from(widget.deck.cards)
+                            ..shuffle();
+                        } else {
+                          _cards = List<Flashcard>.from(widget.deck.cards);
+                        }
+                        _currentIndex = 0;
+                        _pageController.jumpToPage(0);
+                      },
+                    ),
+                    switchTile(
+                      title: '文字转语音',
+                      subtitle: '播放当前卡片文本。',
+                      value: _ttsEnabled,
+                      onChanged: (next) => _ttsEnabled = next,
+                    ),
+                    switchTile(
+                      title: '分类播放',
+                      subtitle: '自动播放完成后进入下一张。',
+                      value: _autoPlay,
+                      onChanged: (next) => _autoPlay = next,
+                    ),
+                    switchTile(
+                      title: '词语方向',
+                      subtitle: _frontToBack ? '当前：正面 -> 答案' : '当前：答案 -> 正面',
+                      value: _frontToBack,
+                      onChanged: (next) => _frontToBack = next,
+                    ),
+                    const SizedBox(height: 10),
+                    FilledButton.icon(
+                      onPressed: () {
+                        Navigator.pop(context);
+                        _restart();
+                      },
+                      icon: const Icon(Icons.restart_alt),
+                      label: const Text('重新启动单词卡'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mastered = _progress?.masteredCardIds.length ?? 0;
+    final favorites = _progress?.favoriteCardIds ?? const <String>{};
+    final card = _cards.isEmpty ? null : _cards[_currentIndex];
+    final favorite = card != null && favorites.contains(card.id);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F6F0),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFF8F6F0),
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.close, color: Colors.black87),
+          onPressed: () => Navigator.maybePop(context),
+        ),
+        title: Text(
+          '${_cards.isEmpty ? 0 : _currentIndex + 1} / ${_cards.length}',
+          style: const TextStyle(
+            color: Colors.black87,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            tooltip: '收藏',
+            onPressed: _cards.isEmpty ? null : _toggleFavorite,
+            icon: Icon(
+              favorite ? Icons.star : Icons.star_border,
+              color: favorite ? Colors.orange : Colors.black87,
+            ),
+          ),
+          IconButton(
+            tooltip: '设置',
+            onPressed: _openSettings,
+            icon: const Icon(Icons.settings_outlined, color: Colors.black87),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(22, 8, 22, 12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: LinearProgressIndicator(
+                      value: _cards.isEmpty
+                          ? 0
+                          : (_currentIndex + 1) / _cards.length,
+                      minHeight: 7,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    '已掌握 $mastered',
+                    style: const TextStyle(
+                      color: Colors.black54,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: _cards.isEmpty
+                  ? const Center(child: Text('暂无卡片'))
+                  : PageView.builder(
+                      controller: _pageController,
+                      onPageChanged: (index) {
+                        setState(() {
+                          _currentIndex = index;
+                          _showAnswer = false;
+                        });
+                        unawaited(_saveProgress());
+                      },
+                      itemCount: _cards.length,
+                      itemBuilder: (context, index) {
+                        return Padding(
+                          padding: const EdgeInsets.fromLTRB(22, 8, 22, 18),
+                          child: _StudyCard(
+                            card: _cards[index],
+                            showAnswer: _showAnswer,
+                            onTap: () =>
+                                setState(() => _showAnswer = !_showAnswer),
+                          ),
+                        );
+                      },
+                    ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 8, 18, 18),
+              child: Row(
+                children: [
+                  IconButton.filledTonal(
+                    onPressed: _goPrevious,
+                    icon: const Icon(Icons.chevron_left),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: _cards.isEmpty
+                          ? null
+                          : () => setState(() => _showAnswer = !_showAnswer),
+                      icon: Icon(
+                        _showAnswer
+                            ? Icons.visibility_off_outlined
+                            : Icons.visibility_outlined,
+                      ),
+                      label: Text(_showAnswer ? '隐藏答案' : '查看答案'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton.filledTonal(
+                    onPressed: _cards.isEmpty
+                        ? null
+                        : () => _speakCurrent(includeAnswer: _showAnswer),
+                    icon: Icon(
+                      _isSpeaking ? Icons.pause : Icons.volume_up_outlined,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton.filledTonal(
+                    onPressed: _goNext,
+                    icon: const Icon(Icons.chevron_right),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 0, 18, 18),
+              child: SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: _cards.isEmpty ? null : _markMastered,
+                  icon: const Icon(Icons.check_circle_outline),
+                  label: const Text('标记已掌握并下一张'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StudyCard extends StatelessWidget {
+  final Flashcard card;
+  final bool showAnswer;
+  final VoidCallback onTap;
+
+  const _StudyCard({
+    required this.card,
+    required this.showAnswer,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        padding: const EdgeInsets.all(26),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(28),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.08),
+              blurRadius: 24,
+              offset: const Offset(0, 12),
+            ),
+          ],
+          border: Border.all(color: const Color(0xFFE7DEC9)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFF3D2),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    card.cardType.label,
+                    style: const TextStyle(
+                      color: Color(0xFF8A5C00),
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                const Text(
+                  '点击翻面',
+                  style: TextStyle(
+                    color: Colors.black38,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 30),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Text(
+                  showAnswer
+                      ? (card.back.isEmpty ? card.answer : card.back)
+                      : card.front,
+                  style: const TextStyle(
+                    color: Colors.black87,
+                    fontSize: 25,
+                    height: 1.55,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+            ),
+            if (showAnswer) ...[
+              const SizedBox(height: 18),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFFFF8E8),
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: Text(
+                  '答案：${card.answer}\n原文：${card.sourceQuote}',
+                  style: const TextStyle(
+                    color: Colors.black54,
+                    height: 1.45,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -9,6 +9,11 @@ import 'package:provider/provider.dart';
 import '../core/config/app_config.dart';
 import '../core/constants/country_servers.dart' as country_catalog;
 import '../features/auth/application/auth_model.dart';
+import '../features/flashcards/application/content_pipeline.dart';
+import '../features/flashcards/application/flashcard_service.dart';
+import '../features/flashcards/data/flashcard_repository.dart';
+import '../features/flashcards/domain/flashcard_models.dart';
+import '../features/flashcards/presentation/flashcard_study_screen.dart';
 import '../models/file_transfer_model.dart';
 import '../services/ai_backend_policy.dart';
 import '../services/dacheng_ai_service.dart';
@@ -53,6 +58,12 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   bool _isGlobalSendTimelineVisible = false;
   bool _isAiGenerating = false;
   bool _isPublishingDraft = false;
+  bool _isFlashcardComposerMode = false;
+  bool _isPreparingFlashcardContent = false;
+  bool _isFlashcardGenerating = false;
+  FlashcardCreationMode _flashcardMode = FlashcardCreationMode.randomCloze;
+  PreparedContent? _activeFlashcardContent;
+  String? _flashcardGenerationMessageId;
   String _streamingAiText = '';
   String _aiActivityText = '';
   SceneRenderMode _renderMode = SceneRenderMode.twoD;
@@ -61,12 +72,18 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   final List<_HomeChatMessage> _homeChatMessages = [];
   final List<_HomeConversation> _conversationHistory = [];
   StreamSubscription<DachengAiStreamEvent>? _aiStreamSubscription;
+  StreamSubscription<FlashcardGenerationEvent>?
+  _flashcardGenerationSubscription;
   final DachengAiService _dachengAiService = DachengAiService();
   final DharmaPublishService _dharmaPublishService = DharmaPublishService();
+  late final FlashcardRepository _flashcardRepository;
+  late final ContentPipeline _contentPipeline;
+  late final FlashcardService _flashcardService;
   StreamSubscription<IncomingSharePayload>? _incomingShareSubscription;
   String? _lastIncomingShareFingerprint;
   String? _activeConversationId;
   int _aiRequestSerial = 0;
+  int _flashcardRequestSerial = 0;
   final _onlineCounterService = OnlineCounterService();
   final _membershipService = MembershipService();
   final _alipayService = AlipayService();
@@ -169,6 +186,12 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   @override
   void initState() {
     super.initState();
+    _flashcardRepository = FlashcardRepository();
+    _contentPipeline = ContentPipeline(repository: _flashcardRepository);
+    _flashcardService = FlashcardService(
+      repository: _flashcardRepository,
+      aiService: _dachengAiService,
+    );
     WidgetsBinding.instance.addObserver(this);
     _loadGlobe();
     _fetchInitialCount();
@@ -281,6 +304,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     _onlineCounterService.dispose();
     _incomingShareSubscription?.cancel();
     _aiStreamSubscription?.cancel();
+    _flashcardGenerationSubscription?.cancel();
     _chatInputController.dispose();
     _homeChatScrollController.dispose();
     WidgetsBinding.instance.removeObserver(this);
@@ -913,21 +937,661 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         constraints: const BoxConstraints(maxWidth: 430),
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
         decoration: BoxDecoration(color: bubbleColor, borderRadius: radius),
-        child: message.isUser || message.isError
-            ? Text(
-                message.text,
-                style: TextStyle(
-                  color: message.isError ? Colors.red[100] : Colors.white,
-                  fontSize: 17,
-                  height: 1.42,
-                  fontWeight: message.isUser
-                      ? FontWeight.w700
-                      : FontWeight.w500,
-                ),
-              )
-            : _MarkdownChatText(message.text),
+        child: _buildChatBubbleBody(message),
       ),
     );
+  }
+
+  Widget _buildChatBubbleBody(_HomeChatMessage message) {
+    switch (message.messageType) {
+      case _HomeChatMessageType.contentPreview:
+        final content = message.content;
+        if (content == null) return _MarkdownChatText(message.text);
+        return _buildContentPreviewMessage(content);
+      case _HomeChatMessageType.choice:
+        return _buildInlineChoiceMessage(message);
+      case _HomeChatMessageType.flashcardPreview:
+        final deck = message.deck;
+        if (deck == null) return _MarkdownChatText(message.text);
+        return _buildFlashcardDeckPreview(deck);
+      case _HomeChatMessageType.text:
+        if (message.isUser || message.isError) {
+          return Text(
+            message.text,
+            style: TextStyle(
+              color: message.isError ? Colors.red[100] : Colors.white,
+              fontSize: 17,
+              height: 1.42,
+              fontWeight: message.isUser ? FontWeight.w700 : FontWeight.w500,
+            ),
+          );
+        }
+        return _MarkdownChatText(message.text);
+    }
+  }
+
+  Widget _buildContentPreviewMessage(PreparedContent content) {
+    final isDocument = content.document != null;
+    final isFailed = content.isFailed;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Icon(
+              isFailed
+                  ? Icons.error_outline
+                  : isDocument
+                  ? Icons.description_outlined
+                  : Icons.article_outlined,
+              color: isFailed ? Colors.red[100] : AppTheme.primaryColor,
+              size: 20,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                isDocument ? '内容已整理为文档' : '内容预览卡',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 17,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Text(
+          content.title,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 16,
+            height: 1.35,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: [
+            _MiniInfoPill(content.displaySource),
+            _MiniInfoPill('${content.text.runes.length} 字'),
+            if (isDocument) const _MiniInfoPill('长文档'),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Text(
+          isFailed
+              ? (content.errorMessage ?? content.previewText)
+              : content.previewText,
+          maxLines: isDocument ? 4 : 7,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: isFailed ? Colors.red[100] : Colors.white70,
+            fontSize: 15,
+            height: 1.48,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        if (!isFailed && content.text.trim().isNotEmpty) ...[
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: () => _showPreparedContentDocument(content),
+            icon: const Icon(Icons.open_in_full, size: 16),
+            label: Text(isDocument ? '打开完整文档' : '展开全文'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: Colors.white,
+              side: BorderSide(color: Colors.white.withValues(alpha: 0.18)),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildInlineChoiceMessage(_HomeChatMessage message) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          message.text,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 17,
+            height: 1.35,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        const SizedBox(height: 12),
+        for (final option in message.choices) ...[
+          _InlineChoiceButton(
+            icon: option.icon,
+            title: option.title,
+            subtitle: option.subtitle,
+            selected: message.selectedValue == option.value,
+            disabled:
+                message.selectedValue != null &&
+                message.selectedValue != option.value,
+            onTap: message.selectedValue == null
+                ? () => unawaited(_selectInlineChoice(message, option))
+                : null,
+          ),
+          const SizedBox(height: 8),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildFlashcardDeckPreview(FlashcardDeck deck) {
+    final sampleCards = deck.cards.take(3).toList();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            const Icon(
+              Icons.style_outlined,
+              color: AppTheme.primaryColor,
+              size: 22,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                '已生成 ${deck.cardCount} 张背诵闪卡',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Text(
+          deck.title,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 16,
+            height: 1.35,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: [
+            _MiniInfoPill(deck.mode.label),
+            _MiniInfoPill(deck.status.storageValue),
+          ],
+        ),
+        const SizedBox(height: 12),
+        for (final card in sampleCards)
+          Container(
+            width: double.infinity,
+            margin: const EdgeInsets.only(bottom: 8),
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.06),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+            ),
+            child: Text(
+              card.front,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Colors.white70,
+                height: 1.35,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        const SizedBox(height: 6),
+        FilledButton.icon(
+          onPressed: () => _openFlashcardDeck(deck),
+          icon: const Icon(Icons.play_arrow),
+          label: const Text('开始背诵'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _selectInlineChoice(
+    _HomeChatMessage message,
+    _HomeChoiceOption option,
+  ) async {
+    if (message.selectedValue != null) return;
+    HapticFeedback.lightImpact();
+    setState(() => message.selectedValue = option.value);
+    try {
+      final callback = option.onSelected;
+      if (callback != null) await Future<void>.sync(callback);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _homeChatMessages.add(
+          _HomeChatMessage(text: '处理选择失败：$e', isUser: false, isError: true),
+        );
+      });
+    }
+    _scrollHomeChatToBottom(force: true);
+  }
+
+  Future<void> _showPreparedContentDocument(PreparedContent content) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return DraggableScrollableSheet(
+          initialChildSize: 0.78,
+          minChildSize: 0.45,
+          maxChildSize: 0.94,
+          builder: (context, controller) {
+            return Container(
+              padding: const EdgeInsets.fromLTRB(20, 14, 20, 20),
+              decoration: const BoxDecoration(
+                color: Color(0xFF202020),
+                borderRadius: BorderRadius.vertical(top: Radius.circular(26)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 42,
+                      height: 4,
+                      margin: const EdgeInsets.only(bottom: 14),
+                      decoration: BoxDecoration(
+                        color: Colors.white24,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                    ),
+                  ),
+                  Text(
+                    content.title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 21,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '${content.text.runes.length} 字 · ${content.displaySource}',
+                    style: const TextStyle(
+                      color: Colors.white54,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      controller: controller,
+                      child: Text(
+                        content.text,
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 16,
+                          height: 1.65,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  void _openFlashcardDeck(FlashcardDeck deck) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) =>
+            FlashcardStudyScreen(deck: deck, repository: _flashcardRepository),
+      ),
+    );
+  }
+
+  void _activateFlashcardMode({
+    FlashcardCreationMode? mode,
+    PreparedContent? content,
+  }) {
+    setState(() {
+      _isFlashcardComposerMode = true;
+      _isDharmaComposerMode = false;
+      _showMaterialGallery = false;
+      _flashcardMode = mode ?? _flashcardMode;
+      _activeFlashcardContent = content ?? _activeFlashcardContent;
+    });
+  }
+
+  void _clearFlashcardMode() {
+    _stopFlashcardGeneration(silent: true);
+    setState(() {
+      _isFlashcardComposerMode = false;
+      _activeFlashcardContent = null;
+      _flashcardMode = FlashcardCreationMode.randomCloze;
+    });
+  }
+
+  void _appendFlashcardModeChoiceMessage() {
+    setState(() {
+      _homeChatMessages.add(
+        _HomeChatMessage.choice(
+          text: '请选择背诵闪卡制作模式',
+          choices: [
+            _HomeChoiceOption(
+              value: FlashcardCreationMode.randomCloze.storageValue,
+              icon: Icons.auto_fix_high,
+              title: '随机挖空',
+              subtitle: '本地快速生成，无需 AI，适合立即背诵。',
+              onSelected: () {
+                _activateFlashcardMode(mode: FlashcardCreationMode.randomCloze);
+              },
+            ),
+            _HomeChoiceOption(
+              value: FlashcardCreationMode.aiCards.storageValue,
+              icon: Icons.auto_awesome,
+              title: 'AI 制卡',
+              subtitle: '按你的要求生成问答/挖空卡，失败自动回退。',
+              onSelected: () {
+                _activateFlashcardMode(mode: FlashcardCreationMode.aiCards);
+              },
+            ),
+          ],
+        ),
+      );
+    });
+    _scrollHomeChatToBottom(force: true);
+  }
+
+  Future<PreparedContent?> _prepareFlashcardContent(
+    String composerText,
+    FileTransferModel model,
+  ) async {
+    final text = composerText.trim();
+    if (_activeFlashcardContent != null) {
+      return _activeFlashcardContent;
+    }
+
+    if (text.isEmpty && model.hasSelectedContentPreview) {
+      final preview = model.selectedContentPreviewText?.trim() ?? '';
+      if (preview.isNotEmpty) {
+        return _contentPipeline.prepare(
+          ContentInput(
+            text: preview,
+            title: model.selectedContentTitle,
+            url: model.selectedContentSourceUrl,
+            sourceApp: '法布施内容',
+            sourceType: 'existing_dharma_content',
+          ),
+        );
+      }
+    }
+
+    if (text.isEmpty) {
+      throw StateError('请输入链接或至少 20 个字的正文。');
+    }
+
+    final url = ContentPipeline.firstHttpUrl(text);
+    return _contentPipeline.prepare(
+      ContentInput(
+        text: text,
+        url: url,
+        title: url != null ? '链接内容' : '背诵内容',
+        sourceType: url != null ? 'composer_url' : 'composer_text',
+      ),
+    );
+  }
+
+  Future<void> _startFlashcardGeneration(FileTransferModel model) async {
+    if (_isPreparingFlashcardContent || _isFlashcardGenerating) return;
+
+    final composerText = _chatInputController.text.trim();
+    final requirement = _activeFlashcardContent == null ? '' : composerText;
+    final requestSerial = ++_flashcardRequestSerial;
+
+    setState(() => _isPreparingFlashcardContent = true);
+    PreparedContent content;
+    try {
+      content =
+          await _prepareFlashcardContent(composerText, model) ??
+          (throw StateError('没有可制卡的内容'));
+      if (content.isFailed) {
+        throw StateError(content.errorMessage ?? '内容提取失败');
+      }
+    } catch (e) {
+      if (!mounted || requestSerial != _flashcardRequestSerial) return;
+      setState(() {
+        _isPreparingFlashcardContent = false;
+        _homeChatMessages.add(
+          _HomeChatMessage.contentPreview(
+            content: PreparedContent(
+              source: ContentSource(
+                id: flashcardId('source_failed'),
+                sourceType: 'composer_text',
+                rawText: composerText,
+                title: '内容准备失败',
+                sourceApp: '',
+                mimeType: '',
+                receivedAt: DateTime.now(),
+                rawTextHash: '',
+              ),
+              title: '内容准备失败',
+              text: composerText,
+              summary: '内容准备失败',
+              previewText: e.toString(),
+              isLong: false,
+              isFailed: true,
+              errorMessage: e.toString(),
+            ),
+          ),
+        );
+      });
+      _scrollHomeChatToBottom(force: true);
+      return;
+    }
+
+    if (!mounted || requestSerial != _flashcardRequestSerial) return;
+    final inputTextForMessage = _activeFlashcardContent == null
+        ? composerText
+        : requirement;
+    _chatInputController.clear();
+    final generationMessage = _HomeChatMessage(
+      text: '正在准备内容...',
+      isUser: false,
+    );
+
+    setState(() {
+      if (inputTextForMessage.isNotEmpty) {
+        _homeChatMessages.add(
+          _HomeChatMessage(text: inputTextForMessage, isUser: true),
+        );
+      }
+      _activeFlashcardContent = content;
+      _homeChatMessages.add(_HomeChatMessage.contentPreview(content: content));
+      _homeChatMessages.add(generationMessage);
+      _flashcardGenerationMessageId = generationMessage.id;
+      _isPreparingFlashcardContent = false;
+      _isFlashcardGenerating = true;
+    });
+    _scrollHomeChatToBottom(force: true);
+
+    final authModel = Provider.of<AuthModel?>(context, listen: false);
+    final input = FlashcardInput(
+      title: content.title,
+      text: content.text,
+      documentId: content.document?.id,
+      sourceUrl: content.sourceUrl,
+      requirement: requirement,
+    );
+    final startedAt = DateTime.now();
+    final eventStream = _flashcardMode == FlashcardCreationMode.aiCards
+        ? _flashcardService.generateAiCardsStream(
+            input,
+            conversationId: _activeConversationId,
+            token: authModel?.authToken,
+            username: authModel?.currentUser?.username,
+            isMember: authModel?.hasPermission('premium') ?? false,
+          )
+        : _flashcardService.generateRandomClozeStream(input);
+
+    await _flashcardGenerationSubscription?.cancel();
+    _flashcardGenerationSubscription = eventStream.listen(
+      (event) {
+        if (!mounted || requestSerial != _flashcardRequestSerial) return;
+        if (event.type == FlashcardGenerationEventType.done &&
+            event.deck != null) {
+          final elapsed = DateTime.now().difference(startedAt).inMilliseconds;
+          setState(() {
+            _replaceFlashcardGenerationMessage(
+              '制卡完成：${event.deck!.cardCount} 张 · ${elapsed}ms。',
+            );
+            _homeChatMessages.add(
+              _HomeChatMessage.flashcardPreview(deck: event.deck!),
+            );
+            _isFlashcardGenerating = false;
+            _flashcardGenerationSubscription = null;
+            _flashcardGenerationMessageId = null;
+          });
+          _scrollHomeChatToBottom(force: true);
+          return;
+        }
+        if (event.type == FlashcardGenerationEventType.error) {
+          setState(() {
+            _replaceFlashcardGenerationMessage('制卡失败：${event.message}');
+            _isFlashcardGenerating = false;
+            _flashcardGenerationSubscription = null;
+            _flashcardGenerationMessageId = null;
+          });
+          _scrollHomeChatToBottom(force: true);
+          return;
+        }
+        final progress = event.progress > 0 ? ' (${event.progress}%)' : '';
+        final cardText = event.card == null ? '' : '\n- ${event.card!.front}';
+        setState(() {
+          _replaceFlashcardGenerationMessage(
+            '${event.message}$progress$cardText',
+          );
+        });
+        _scrollHomeChatToBottom();
+      },
+      onError: (Object error) {
+        if (!mounted || requestSerial != _flashcardRequestSerial) return;
+        setState(() {
+          _replaceFlashcardGenerationMessage('制卡失败：$error');
+          _isFlashcardGenerating = false;
+          _flashcardGenerationSubscription = null;
+          _flashcardGenerationMessageId = null;
+        });
+      },
+      onDone: () {
+        if (!mounted || requestSerial != _flashcardRequestSerial) return;
+        if (_isFlashcardGenerating) {
+          setState(() => _isFlashcardGenerating = false);
+        }
+      },
+    );
+  }
+
+  void _replaceFlashcardGenerationMessage(String text) {
+    final id = _flashcardGenerationMessageId;
+    if (id == null) return;
+    final index = _homeChatMessages.indexWhere((message) => message.id == id);
+    if (index < 0) return;
+    _homeChatMessages[index].text = text;
+  }
+
+  void _stopFlashcardGeneration({bool silent = false}) {
+    _flashcardRequestSerial++;
+    _flashcardGenerationSubscription?.cancel();
+    _flashcardGenerationSubscription = null;
+    if (!mounted) return;
+    setState(() {
+      if (!silent) {
+        _replaceFlashcardGenerationMessage('制卡已停止。可切换模式或补充正文后重新发送。');
+      }
+      _isPreparingFlashcardContent = false;
+      _isFlashcardGenerating = false;
+      _flashcardGenerationMessageId = null;
+    });
+  }
+
+  void _appendIncomingShareChoiceMessage(
+    IncomingSharePayload payload,
+    PreparedContent content,
+    FileTransferModel model,
+  ) {
+    setState(() {
+      _homeChatMessages.add(
+        _HomeChatMessage.choice(
+          text: '请选择处理方式\n来源：${payload.displaySource}',
+          choices: [
+            _HomeChoiceOption(
+              value: 'global_dharma',
+              icon: Icons.public,
+              title: '全球法布施',
+              subtitle: '把整理后的内容发送到全球节点。',
+              onSelected: () async {
+                await _usePreparedContentForDharma(model, content);
+                _activateDharmaMode(model, target: DharmaComposerTarget.global);
+              },
+            ),
+            _HomeChoiceOption(
+              value: 'platform_publish',
+              icon: Icons.campaign_outlined,
+              title: '法布施到平台',
+              subtitle: '生成平台发布草稿并预览。',
+              onSelected: () async {
+                await _usePreparedContentForDharma(model, content);
+                _activateDharmaMode(
+                  model,
+                  target: DharmaComposerTarget.platform,
+                );
+                await _showPublishPlatformSelector();
+              },
+            ),
+            _HomeChoiceOption(
+              value: 'flashcards',
+              icon: Icons.style_outlined,
+              title: '制作背诵闪卡',
+              subtitle: '随机挖空或 AI 制卡，进入背诵页。',
+              onSelected: () {
+                _activateFlashcardMode(content: content);
+              },
+            ),
+          ],
+        ),
+      );
+    });
+  }
+
+  Future<void> _usePreparedContentForDharma(
+    FileTransferModel model,
+    PreparedContent content,
+  ) async {
+    await model.addTextContentForSending(
+      title: content.title,
+      text: content.text,
+      sourceKind: content.sourceUrl == null ? '文本' : '链接',
+      sourceUrl: content.sourceUrl,
+      previewText: content.previewText,
+      replaceExisting: true,
+    );
+    if (mounted) setState(() {});
   }
 
   bool _shouldShowGlobalSendProcess(FileTransferModel model) {
@@ -1252,9 +1916,17 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     final isBusy =
         model.isPreparingSend ||
         _isPublishingDraft ||
+        _isPreparingFlashcardContent ||
+        _isFlashcardGenerating ||
         (_isDharmaComposerMode && model.isTransferring);
     final inputText = _chatInputController.text.trim();
-    final canSubmit = _isDharmaComposerMode
+    final hasFlashcardContext =
+        (_activeFlashcardContent?.text.trim().isNotEmpty ?? false);
+    final canSubmit = _isFlashcardComposerMode
+        ? !_isPreparingFlashcardContent &&
+              !_isFlashcardGenerating &&
+              (inputText.isNotEmpty || hasFlashcardContext)
+        : _isDharmaComposerMode
         ? _dharmaComposerTarget == DharmaComposerTarget.platform
               ? (inputText.isNotEmpty || model.hasFiles) &&
                     _selectedPublishPlatforms.isNotEmpty
@@ -1265,7 +1937,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       padding: const EdgeInsets.fromLTRB(8, 8, 7, 8),
       decoration: BoxDecoration(
         color: const Color(0xFF242424).withValues(alpha: 0.96),
-        borderRadius: BorderRadius.circular(_isDharmaComposerMode ? 24 : 26),
+        borderRadius: BorderRadius.circular(
+          (_isDharmaComposerMode || _isFlashcardComposerMode) ? 24 : 26,
+        ),
         border: Border.all(color: Colors.white.withValues(alpha: 0.09)),
         boxShadow: [
           BoxShadow(
@@ -1279,7 +1953,50 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (_isDharmaComposerMode) ...[
+          if (_isFlashcardComposerMode) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(5, 1, 6, 8),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  _ComposerChip(
+                    icon: Icons.style_outlined,
+                    label: '背诵闪卡',
+                    active: true,
+                    onRemove: _isFlashcardGenerating
+                        ? null
+                        : _clearFlashcardMode,
+                  ),
+                  _ComposerChip(
+                    icon: _flashcardMode == FlashcardCreationMode.aiCards
+                        ? Icons.auto_awesome
+                        : Icons.auto_fix_high,
+                    label: '模式 ${_flashcardMode.label}',
+                    active: true,
+                    onTap: isBusy ? null : _appendFlashcardModeChoiceMessage,
+                  ),
+                  if (_activeFlashcardContent != null)
+                    _ComposerChip(
+                      icon: _activeFlashcardContent!.hasDocument
+                          ? Icons.description_outlined
+                          : Icons.article_outlined,
+                      label: _activeFlashcardContent!.hasDocument
+                          ? '文档 ${_activeFlashcardContent!.title}'
+                          : '内容 ${_activeFlashcardContent!.title}',
+                      active: true,
+                      onTap: () => _showPreparedContentDocument(
+                        _activeFlashcardContent!,
+                      ),
+                      onRemove: isBusy
+                          ? null
+                          : () =>
+                                setState(() => _activeFlashcardContent = null),
+                    ),
+                ],
+              ),
+            ),
+          ] else if (_isDharmaComposerMode) ...[
             Padding(
               padding: const EdgeInsets.fromLTRB(5, 1, 6, 8),
               child: Wrap(
@@ -1297,7 +2014,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                       icon: Icons.campaign_outlined,
                       label: '平台 ${_platformSummary()}',
                       active: _selectedPublishPlatforms.isNotEmpty,
-                      onTap: isBusy ? null : () => _showPublishPlatformSelector(),
+                      onTap: isBusy
+                          ? null
+                          : () => _showPublishPlatformSelector(),
                     )
                   else ...[
                     _ComposerChip(
@@ -1368,6 +2087,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   controller: _chatInputController,
                   enabled:
                       !model.isPreparingSend &&
+                      !_isPreparingFlashcardContent &&
+                      !_isFlashcardGenerating &&
                       (!model.isTransferring || !_isDharmaComposerMode),
                   minLines: 1,
                   maxLines: 4,
@@ -1381,7 +2102,13 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   decoration: InputDecoration(
                     isDense: true,
                     border: InputBorder.none,
-                    hintText: _isDharmaComposerMode
+                    hintText: _isFlashcardComposerMode
+                        ? _flashcardMode == FlashcardCreationMode.aiCards
+                              ? (_activeFlashcardContent == null
+                                    ? '粘贴链接或正文，发送后 AI 制卡'
+                                    : '输入制卡要求，例如：按重点概念出题')
+                              : '输入链接或正文，发送后自动挖空'
+                        : _isDharmaComposerMode
                         ? _dharmaComposerTarget == DharmaComposerTarget.platform
                               ? (model.hasFiles ? '可继续输入发布说明' : '粘贴要发布的链接或正文')
                               : (model.hasFiles ? '可继续输入法布施文字或链接' : '输入文字或链接')
@@ -1410,6 +2137,35 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     FileTransferModel model, {
     required bool canSubmit,
   }) {
+    if (_isPreparingFlashcardContent) {
+      return Container(
+        width: 42,
+        height: 42,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.1),
+          shape: BoxShape.circle,
+        ),
+        child: const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+
+    if (_isFlashcardGenerating) {
+      return IconButton(
+        tooltip: '停止制卡',
+        icon: const Icon(Icons.stop, color: Colors.white, size: 21),
+        onPressed: _stopFlashcardGeneration,
+        style: IconButton.styleFrom(
+          backgroundColor: Colors.red.shade600,
+          fixedSize: const Size(42, 42),
+        ),
+      );
+    }
+
     if (_isPublishingDraft) {
       return Container(
         width: 42,
@@ -1469,7 +2225,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     }
 
     return IconButton(
-      tooltip: _isDharmaComposerMode
+      tooltip: _isFlashcardComposerMode
+          ? '开始制卡'
+          : _isDharmaComposerMode
           ? _dharmaComposerTarget == DharmaComposerTarget.platform
                 ? '预览并发布'
                 : '开始法布施'
@@ -1533,6 +2291,12 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           '公众号、小红书、抖音、微博等多选',
         ),
         _sendMenuItem(
+          'flashcards',
+          Icons.style_outlined,
+          '背诵闪卡',
+          '把链接或正文制作成可背诵卡片',
+        ),
+        _sendMenuItem(
           'files',
           Icons.add_photo_alternate,
           '添加图片和文件',
@@ -1572,6 +2336,11 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       await _showPublishPlatformSelector();
       return _selectedPublishPlatforms.isNotEmpty;
     }
+    if (action == 'flashcards') {
+      _activateFlashcardMode();
+      _appendFlashcardModeChoiceMessage();
+      return true;
+    }
     if (action == 'files') {
       _activateDharmaMode(model, target: _dharmaComposerTarget);
       final selected = await model.selectFiles(replaceExisting: true);
@@ -1582,6 +2351,10 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   }
 
   void _submitComposer(FileTransferModel model) {
+    if (_isFlashcardComposerMode) {
+      unawaited(_startFlashcardGeneration(model));
+      return;
+    }
     if (_isDharmaComposerMode) {
       if (_dharmaComposerTarget == DharmaComposerTarget.platform) {
         unawaited(_startPlatformPublish(model));
@@ -1611,8 +2384,10 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     }
     setState(() {
       _isDharmaComposerMode = true;
+      _isFlashcardComposerMode = false;
       _dharmaComposerTarget = target;
-      _showMaterialGallery = showMaterials && target == DharmaComposerTarget.global;
+      _showMaterialGallery =
+          showMaterials && target == DharmaComposerTarget.global;
     });
   }
 
@@ -1621,6 +2396,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     model.clearFiles();
     setState(() {
       _isDharmaComposerMode = false;
+      _isFlashcardComposerMode = false;
+      _activeFlashcardContent = null;
       _dharmaComposerTarget = DharmaComposerTarget.global;
       _showMaterialGallery = false;
     });
@@ -1743,7 +2520,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     Expanded(
                       child: ListView(
                         children: [
-                          for (final platform in DharmaPublishService.allPlatforms)
+                          for (final platform
+                              in DharmaPublishService.allPlatforms)
                             _PlatformCheckTile(
                               platform: platform,
                               selected: selected.contains(platform),
@@ -1806,7 +2584,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
 
   Future<void> _handleIncomingShare(IncomingSharePayload payload) async {
     if (!mounted || payload.isEmpty) return;
-    final fingerprint = '${payload.bestText}|${payload.title}|${payload.sourcePackage}';
+    final fingerprint =
+        '${payload.bestText}|${payload.title}|${payload.sourcePackage}';
     if (_lastIncomingShareFingerprint == fingerprint) return;
     _lastIncomingShareFingerprint = fingerprint;
 
@@ -1818,40 +2597,85 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     final composerText = candidateUrl ?? sharedText;
     if (composerText.trim().isEmpty) return;
 
-    if (mounted) {
-      _chatInputController.text = composerText.trim();
-      _chatInputController.selection = TextSelection.collapsed(
-        offset: _chatInputController.text.length,
-      );
-      setState(() {});
-    }
-
-    final target = await _showIncomingShareTargetSheet(payload, composerText);
-    if (target == null || !mounted) return;
-
-    _activateDharmaMode(model, target: target);
-    if (target == DharmaComposerTarget.platform) {
-      await _showPublishPlatformSelector();
-    }
-
-    if (!mounted) return;
     setState(() {
       _homeChatMessages.add(
         _HomeChatMessage(
           text: [
             '已接收外部分享。',
-            '',
             '来源：${payload.displaySource}',
-            '模式：${target == DharmaComposerTarget.global ? "全球法布施" : "法布施到平台"}',
+            if (payload.title.trim().isNotEmpty) '标题：${payload.title.trim()}',
             if (candidateUrl != null) '链接：$candidateUrl',
           ].join('\n'),
           isUser: false,
         ),
       );
+      _isPreparingFlashcardContent = true;
     });
-    _scrollHomeChatToBottom();
+    _scrollHomeChatToBottom(force: true);
+
+    PreparedContent content;
+    try {
+      content = await _contentPipeline.prepare(
+        ContentInput(
+          text: sharedText.isEmpty ? composerText : sharedText,
+          url: candidateUrl,
+          title: payload.title.trim().isEmpty ? '外部分享' : payload.title.trim(),
+          sourceApp: payload.displaySource,
+          mimeType: payload.mimeType,
+          sourceType: 'external_share',
+        ),
+      );
+    } catch (e) {
+      content = PreparedContent(
+        source: ContentSource(
+          id: flashcardId('share_failed'),
+          sourceType: 'external_share',
+          rawText: composerText,
+          url: candidateUrl,
+          title: payload.title.trim().isEmpty ? '外部分享' : payload.title.trim(),
+          sourceApp: payload.displaySource,
+          mimeType: payload.mimeType,
+          receivedAt: payload.receivedAt,
+          rawTextHash: '',
+        ),
+        title: payload.title.trim().isEmpty ? '外部分享' : payload.title.trim(),
+        text: composerText,
+        summary: '外部分享内容提取失败',
+        previewText: e.toString(),
+        isLong: false,
+        isFailed: true,
+        errorMessage: e.toString(),
+      );
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _isPreparingFlashcardContent = false;
+      _activeFlashcardContent = content.isFailed ? null : content;
+      _chatInputController.clear();
+      _homeChatMessages.add(_HomeChatMessage.contentPreview(content: content));
+    });
+    if (content.isFailed) {
+      _chatInputController.text = composerText.trim();
+      _chatInputController.selection = TextSelection.collapsed(
+        offset: _chatInputController.text.length,
+      );
+      setState(() {
+        _homeChatMessages.add(
+          _HomeChatMessage(
+            text: '链接或分享内容暂时无法自动提取。你可以在输入框里改为粘贴正文后，再选择法布施或背诵闪卡。',
+            isUser: false,
+            isError: true,
+          ),
+        );
+      });
+    } else {
+      _appendIncomingShareChoiceMessage(payload, content, model);
+    }
+    _scrollHomeChatToBottom(force: true);
   }
 
+  // ignore: unused_element
   Future<DharmaComposerTarget?> _showIncomingShareTargetSheet(
     IncomingSharePayload payload,
     String text,
@@ -1894,7 +2718,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  preview.length > 120 ? '${preview.substring(0, 120)}...' : preview,
+                  preview.length > 120
+                      ? '${preview.substring(0, 120)}...'
+                      : preview,
                   style: const TextStyle(color: Colors.white60, height: 1.35),
                 ),
                 const SizedBox(height: 16),
@@ -1902,10 +2728,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                   icon: Icons.public,
                   title: '全球法布施',
                   subtitle: '把链接放入输入框，点击发送后下载内容并进行全球法布施。',
-                  onTap: () => Navigator.pop(
-                    sheetContext,
-                    DharmaComposerTarget.global,
-                  ),
+                  onTap: () =>
+                      Navigator.pop(sheetContext, DharmaComposerTarget.global),
                 ),
                 const SizedBox(height: 10),
                 _ShareTargetTile(
@@ -1949,10 +2773,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       caseSensitive: false,
     ).firstMatch(text.trim());
     if (match == null) return null;
-    return match
-        .group(0)!
-        .replaceAll(RegExp(r'[，。、,.)）\]】>》]+$'), '')
-        .trim();
+    return match.group(0)!.replaceAll(RegExp(r'[，。、,.)）\]】>》]+$'), '').trim();
   }
 
   Future<bool> _prepareComposerContentForModel(
@@ -1963,19 +2784,36 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     if (text.isEmpty) return model.hasFiles;
 
     final link = _firstHttpUrl(text);
-    if (link != null) {
-      await model.addUrlContentForSending(link);
-    } else {
-      await model.addTextContentForSending(
-        title: '法布施',
+    final content = await _contentPipeline.prepare(
+      ContentInput(
         text: text,
-        sourceKind: '文本',
-        replaceExisting: !model.hasFiles,
-      );
+        url: link,
+        title: link == null ? '法布施' : '链接内容',
+        sourceType: link == null ? 'composer_text' : 'composer_url',
+      ),
+    );
+    if (content.isFailed) {
+      throw StateError(content.errorMessage ?? '内容准备失败');
     }
 
+    await model.addTextContentForSending(
+      title: content.title,
+      text: content.text,
+      sourceKind: content.sourceUrl == null ? '文本' : '链接',
+      sourceUrl: content.sourceUrl,
+      previewText: content.previewText,
+      replaceExisting: !model.hasFiles,
+    );
+
     _chatInputController.clear();
-    if (mounted) setState(() {});
+    if (mounted) {
+      setState(() {
+        _homeChatMessages.add(
+          _HomeChatMessage.contentPreview(content: content),
+        );
+      });
+      _scrollHomeChatToBottom();
+    }
     return true;
   }
 
@@ -2000,7 +2838,10 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     setState(() => _isPublishingDraft = true);
     DharmaPublishDraft draft;
     try {
-      final prepared = await _prepareComposerContentForModel(model, composerText);
+      final prepared = await _prepareComposerContentForModel(
+        model,
+        composerText,
+      );
       if (!prepared || !model.hasFiles) {
         throw StateError('没有可发布的内容');
       }
@@ -2065,11 +2906,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       if (!mounted) return;
       setState(() {
         _homeChatMessages.add(
-          _HomeChatMessage(
-            text: '发布流程遇到问题：$e',
-            isUser: false,
-            isError: true,
-          ),
+          _HomeChatMessage(text: '发布流程遇到问题：$e', isUser: false, isError: true),
         );
       });
       _scrollHomeChatToBottom();
@@ -2081,8 +2918,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   Future<List<DharmaPublishResult>> _publishDraftWithBestPlatformExperience(
     DharmaPublishDraft draft,
   ) async {
-    if (!kIsWeb &&
-        (Platform.isMacOS || Platform.isWindows)) {
+    if (!kIsWeb && (Platform.isMacOS || Platform.isWindows)) {
       final results = await Navigator.push<List<DharmaPublishResult>>(
         context,
         MaterialPageRoute(
@@ -2348,7 +3184,8 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
             child: const Text('取消'),
           ),
           FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, controller.text.trim()),
+            onPressed: () =>
+                Navigator.pop(dialogContext, controller.text.trim()),
             child: const Text('生成'),
           ),
         ],
@@ -3646,7 +4483,6 @@ class _RegionCheckTile extends StatelessWidget {
   }
 }
 
-
 class _PlatformCheckTile extends StatelessWidget {
   final DharmaPublishPlatform platform;
   final bool selected;
@@ -3792,7 +4628,6 @@ class _ShareTargetTile extends StatelessWidget {
   }
 }
 
-
 class _AiActivityLabel extends StatelessWidget {
   final String label;
 
@@ -3906,16 +4741,188 @@ class _MarkdownChatText extends StatelessWidget {
   }
 }
 
+enum _HomeChatMessageType { text, contentPreview, choice, flashcardPreview }
+
 class _HomeChatMessage {
-  final String text;
+  final String id;
+  String text;
   final bool isUser;
   final bool isError;
+  final _HomeChatMessageType messageType;
+  final PreparedContent? content;
+  final FlashcardDeck? deck;
+  final List<_HomeChoiceOption> choices;
+  String? selectedValue;
 
-  const _HomeChatMessage({
+  _HomeChatMessage({
+    String? id,
     required this.text,
     required this.isUser,
     this.isError = false,
+    this.messageType = _HomeChatMessageType.text,
+    this.content,
+    this.deck,
+    this.choices = const [],
+    this.selectedValue,
+  }) : id = id ?? flashcardId('home_msg');
+
+  factory _HomeChatMessage.contentPreview({required PreparedContent content}) {
+    return _HomeChatMessage(
+      text: content.summary,
+      isUser: false,
+      isError: content.isFailed,
+      messageType: _HomeChatMessageType.contentPreview,
+      content: content,
+    );
+  }
+
+  factory _HomeChatMessage.choice({
+    required String text,
+    required List<_HomeChoiceOption> choices,
+  }) {
+    return _HomeChatMessage(
+      text: text,
+      isUser: false,
+      messageType: _HomeChatMessageType.choice,
+      choices: choices,
+    );
+  }
+
+  factory _HomeChatMessage.flashcardPreview({required FlashcardDeck deck}) {
+    return _HomeChatMessage(
+      text: deck.title,
+      isUser: false,
+      messageType: _HomeChatMessageType.flashcardPreview,
+      deck: deck,
+    );
+  }
+}
+
+class _HomeChoiceOption {
+  final String value;
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final FutureOr<void> Function()? onSelected;
+
+  const _HomeChoiceOption({
+    required this.value,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    this.onSelected,
   });
+}
+
+class _MiniInfoPill extends StatelessWidget {
+  final String label;
+
+  const _MiniInfoPill(this.label);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          color: Colors.white60,
+          fontSize: 12,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineChoiceButton extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final bool disabled;
+  final VoidCallback? onTap;
+
+  const _InlineChoiceButton({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    this.selected = false,
+    this.disabled = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = selected ? AppTheme.primaryColor : Colors.white;
+    return InkWell(
+      onTap: disabled ? null : onTap,
+      borderRadius: BorderRadius.circular(14),
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 160),
+        opacity: disabled ? 0.48 : 1,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: selected
+                ? AppTheme.primaryColor.withValues(alpha: 0.14)
+                : Colors.white.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: selected
+                  ? AppTheme.primaryColor.withValues(alpha: 0.6)
+                  : Colors.white.withValues(alpha: 0.08),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(icon, color: foreground, size: 22),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        color: foreground,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      subtitle,
+                      style: const TextStyle(
+                        color: Colors.white60,
+                        fontSize: 12,
+                        height: 1.3,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (selected)
+                const Icon(
+                  Icons.check_circle,
+                  color: AppTheme.primaryColor,
+                  size: 20,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _HomeConversation {

--- a/fabushi/test/features/flashcards/content_pipeline_test.dart
+++ b/fabushi/test/features/flashcards/content_pipeline_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:global_dharma_sharing/features/flashcards/application/content_pipeline.dart';
+import 'package:global_dharma_sharing/features/flashcards/data/flashcard_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('prepare returns preview content for short text', () async {
+    final pipeline = ContentPipeline(repository: FlashcardRepository());
+
+    final content = await pipeline.prepare(
+      const ContentInput(
+        title: '短正文',
+        text: '愿以此功德，普及于一切。我等与众生，皆共成佛道。',
+        sourceType: 'composer_text',
+      ),
+    );
+
+    expect(content.isFailed, isFalse);
+    expect(content.document, isNull);
+    expect(content.title, '短正文');
+    expect(content.previewText, contains('愿以此功德'));
+  });
+
+  test('prepare documentizes long text with configured threshold', () async {
+    final pipeline = ContentPipeline(
+      repository: FlashcardRepository(),
+      textLongThresholdChars: 80,
+    );
+    final text = List.filled(8, '菩萨应如是降伏其心，离一切相，修一切善法，令众生得安稳。').join('');
+
+    final content = await pipeline.prepare(
+      ContentInput(title: '长正文', text: text, sourceType: 'composer_text'),
+    );
+
+    expect(content.isFailed, isFalse);
+    expect(content.isLong, isTrue);
+    expect(content.document, isNotNull);
+    expect(content.document!.charCount, text.runes.length);
+    expect(content.previewText.length, lessThan(text.length));
+  });
+
+  test('firstHttpUrl extracts the first usable link', () {
+    final url = ContentPipeline.firstHttpUrl(
+      '请看 https://example.com/articles/1，后面是说明',
+    );
+    expect(url, 'https://example.com/articles/1');
+  });
+}

--- a/fabushi/test/features/flashcards/flashcard_service_test.dart
+++ b/fabushi/test/features/flashcards/flashcard_service_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:global_dharma_sharing/features/flashcards/application/flashcard_service.dart';
+import 'package:global_dharma_sharing/features/flashcards/data/flashcard_repository.dart';
+import 'package:global_dharma_sharing/features/flashcards/domain/flashcard_models.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('random cloze generation creates persisted cloze cards', () async {
+    final repository = FlashcardRepository();
+    final service = FlashcardService(repository: repository);
+
+    final deck = await service.generateRandomCloze(
+      const FlashcardInput(
+        title: '金刚经第五品',
+        text:
+            '如是我闻，一时，佛在舍卫国祇树给孤独园。与大比丘众千二百五十人俱。'
+            '尔时，世尊食时，著衣持钵，入舍卫大城乞食。于其城中，次第乞已，还至本处。',
+        maxCards: 10,
+      ),
+    );
+
+    expect(deck.mode, FlashcardCreationMode.randomCloze);
+    expect(deck.cards, isNotEmpty);
+    expect(deck.cards.length, lessThanOrEqualTo(10));
+    for (final card in deck.cards) {
+      expect(card.cardType, FlashcardType.cloze);
+      expect(card.clozeText, contains('＿'));
+      expect(card.answer.trim(), isNotEmpty);
+      expect(card.sourceQuote.trim(), isNotEmpty);
+    }
+
+    final savedDeck = await repository.getDeck(deck.id);
+    expect(savedDeck, isNotNull);
+    expect(savedDeck!.cards.length, deck.cards.length);
+  });
+
+  test('splitSentences filters short fragments and keeps useful sentences', () {
+    final sentences = FlashcardService.splitSentences(
+      '短。第一段包含足够多的文字用于生成背诵卡片。Second useful sentence works too!',
+    );
+
+    expect(sentences.length, 2);
+    expect(sentences.first, contains('第一段'));
+    expect(sentences.last, contains('Second'));
+  });
+}


### PR DESCRIPTION
## Summary
- Land the knowledge memorization flashcard flow in the existing GlobeHomeScreen conversation and composer UX.
- Add ContentPipeline, FlashcardService, FlashcardRepository, deck/card/document domain models, and FlashcardStudyScreen.
- Integrate external share -> content preview -> inline choice -> global dharma/platform publish/flashcard routing.
- Add + menu flashcard entry, mode chips, random cloze generation, AI card generation stream with fallback, stop handling, deck preview, TTS study settings, favorites, mastery, and saved progress.
- Add focused flashcard unit tests for content preparation, documentization, URL extraction, random cloze generation, and persistence.

## Verification
- `git diff --check`
- `flutter analyze lib/main.dart test/features/flashcards`
- `flutter test test/features/flashcards --no-pub`

## Notes
- The VPS is Linux arm64; targeted Flutter tests needed a local Flutter engine artifact symlink for impellerc lookup. No generated desktop registrant or lockfile changes are included in this PR.
