### PR TITLE
fix: sync macOS OpenClaw assets before desktop verification

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -361,6 +361,11 @@ jobs:
         if: matrix.target == 'macos'
         run: flutter build macos --release --no-pub
 
+      - name: Sync macOS OpenClaw assets into release app
+        if: matrix.target == 'macos'
+        shell: bash
+        run: ../.github/scripts/sync-openclaw-build-assets-v2.sh "${{ steps.openclaw.outputs.platform }}" build/macos/Build/Products/Release/global_dharma_sharing.app/Contents/Frameworks/App.framework/Resources/flutter_assets
+
       - name: Build macOS package CLI
         if: matrix.target == 'macos'
         shell: bash


### PR DESCRIPTION
## Summary
- sync vendored OpenClaw assets into the macOS release app before bundle verification
- keep macOS packaging consistent with the existing Linux and Windows post-build sync steps

## Validation
- bash -n .github/scripts/assert-openclaw-bundle.sh
- bash -n .github/scripts/sync-openclaw-build-assets-v2.sh
- YAML parse check for .github/workflows/desktop-installers.yml
- synthetic macOS .app fixture: sync-openclaw-build-assets-v2.sh + assert-openclaw-bundle.sh