### PR TITLE
feat: add desktop downloads to official site

### DIFF
--- a/frontend/apps/web/public/api/releases.json
+++ b/frontend/apps/web/public/api/releases.json
@@ -8,10 +8,10 @@
       "description": "官网按钮会直接下载已经同步到 R2 的最新 Android APK 安装包。",
       "primaryLabel": "下载 Android Beta",
       "primaryHref": "https://fabushi.ombhrum.com/downloads/android/fabushi-android-beta.apk",
-      "version": "v1.0.0-377-mobile.3dd4e4dc806f",
-      "publishedAt": "2026-05-23T05:11:23Z",
+      "version": "v1.0.1-481-mobile.05532d825da8",
+      "publishedAt": "2026-06-09T03:41:54Z",
       "updateSummary": [
-        "改进下载体验与版本信息展示。",
+        "同步最新移动端 1.0.1+481 发布。",
         "优化整体稳定性与页面呈现。"
       ],
       "mirrorLinks": [],
@@ -25,15 +25,15 @@
       "description": "TestFlight 上传成功后，官网会和 Android beta 一起更新这里的测试入口。",
       "primaryLabel": "加入 iOS TestFlight",
       "primaryHref": "https://testflight.apple.com/join/98KFgV2z",
-      "version": "377",
-      "publishedAt": "2026-05-23T05:10:23Z",
+      "version": "481",
+      "publishedAt": "2026-06-09T03:41:00Z",
       "updateSummary": [
-        "改进下载体验与版本信息展示。",
+        "TestFlight 上传已被 App Store Connect 接收。",
         "优化整体稳定性与页面呈现。"
       ],
       "mirrorLinks": [],
       "note": "",
-      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.0-377-mobile.3dd4e4dc806f"
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.1-481-mobile.05532d825da8"
     }
   ],
   "stableChannels": [
@@ -53,10 +53,99 @@
       ],
       "mirrorLinks": [],
       "note": "点击后会打开 Apple App Store 页面。"
+    },
+    {
+      "platform": "macOS",
+      "audience": "stable",
+      "status": "GitHub Release 可下载",
+      "title": "macOS 桌面版",
+      "description": "适合 macOS Apple Silicon 设备安装桌面版。",
+      "primaryLabel": "下载 macOS DMG",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/desktop-v1.0.1-408-49-a0e997f3aa61/global_dharma_sharing-1.0.1-408-macos-arm64.dmg",
+      "version": "1.0.1-408",
+      "publishedAt": "2026-06-08T12:21:06Z",
+      "updateSummary": [
+        "桌面版安装包已发布到 GitHub Release。",
+        "提供 DMG 和 ZIP 两种 macOS 下载格式。"
+      ],
+      "mirrorLinks": [
+        {
+          "label": "下载 macOS ZIP",
+          "href": "https://github.com/bhrumom/fabushi/releases/download/desktop-v1.0.1-408-49-a0e997f3aa61/global_dharma_sharing-1.0.1-408-macos-arm64.zip"
+        }
+      ],
+      "note": "桌面版文件由 GitHub Release 提供。",
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/desktop-v1.0.1-408-49-a0e997f3aa61"
+    },
+    {
+      "platform": "Windows",
+      "audience": "stable",
+      "status": "GitHub Release 可下载",
+      "title": "Windows 桌面版",
+      "description": "适合 Windows x64 设备安装桌面版。",
+      "primaryLabel": "下载 Windows 安装器",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/desktop-v1.0.1-408-49-a0e997f3aa61/global_dharma_sharing-1.0.1-408-windows-x64-setup.exe",
+      "version": "1.0.1-408",
+      "publishedAt": "2026-06-08T12:21:06Z",
+      "updateSummary": [
+        "桌面版安装包已发布到 GitHub Release。",
+        "提供安装器和 ZIP 两种 Windows 下载格式。"
+      ],
+      "mirrorLinks": [
+        {
+          "label": "下载 Windows ZIP",
+          "href": "https://github.com/bhrumom/fabushi/releases/download/desktop-v1.0.1-408-49-a0e997f3aa61/global_dharma_sharing-1.0.1-408-windows-x64.zip"
+        }
+      ],
+      "note": "桌面版文件由 GitHub Release 提供。",
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/desktop-v1.0.1-408-49-a0e997f3aa61"
+    },
+    {
+      "platform": "Linux",
+      "audience": "stable",
+      "status": "GitHub Release 可下载",
+      "title": "Linux 桌面版",
+      "description": "适合 Linux x64 设备安装桌面版。",
+      "primaryLabel": "下载 Linux DEB",
+      "primaryHref": "https://github.com/bhrumom/fabushi/releases/download/desktop-v1.0.1-408-49-a0e997f3aa61/global-dharma-sharing_1.0.1-408_amd64.deb",
+      "version": "1.0.1-408",
+      "publishedAt": "2026-06-08T12:21:06Z",
+      "updateSummary": [
+        "桌面版安装包已发布到 GitHub Release。",
+        "提供 DEB 和 tar.gz 两种 Linux 下载格式。"
+      ],
+      "mirrorLinks": [
+        {
+          "label": "下载 Linux tar.gz",
+          "href": "https://github.com/bhrumom/fabushi/releases/download/desktop-v1.0.1-408-49-a0e997f3aa61/global_dharma_sharing-1.0.1-408-linux-x64.tar.gz"
+        }
+      ],
+      "note": "桌面版文件由 GitHub Release 提供。",
+      "releasePageHref": "https://github.com/bhrumom/fabushi/releases/tag/desktop-v1.0.1-408-49-a0e997f3aa61"
     }
   ],
   "screenshots": {},
   "releases": [
+    {
+      "tag": "v1.0.1-481-mobile.05532d825da8",
+      "title": "Fabushi mobile 1.0.1+481 (05532d825da8)",
+      "publishedAt": "2026-06-09T03:41:54Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/v1.0.1-481-mobile.05532d825da8",
+      "summary": [
+        "同步最新移动端 1.0.1+481 发布。",
+        "TestFlight 上传已被 App Store Connect 接收。"
+      ]
+    },
+    {
+      "tag": "desktop-v1.0.1-408-49-a0e997f3aa61",
+      "title": "Fabushi desktop 1.0.1-408 (a0e997f3aa61)",
+      "publishedAt": "2026-06-08T12:21:06Z",
+      "htmlUrl": "https://github.com/bhrumom/fabushi/releases/tag/desktop-v1.0.1-408-49-a0e997f3aa61",
+      "summary": [
+        "新增 macOS、Windows、Linux 桌面版下载入口。",
+        "桌面版安装包由 GitHub Release 提供。"
+      ]
+    },
     {
       "tag": "v1.0.0-377-mobile.3dd4e4dc806f",
       "title": "Fabushi mobile 1.0.0+377 (3dd4e4dc806f)",
@@ -109,6 +198,7 @@
   "notes": [
     "Android beta APK 已同步到 R2，官网按钮会直接下载 R2 中的最新安装包。",
     "iOS 正式版已上架 App Store，官网正式版入口会直接打开 App Store。",
+    "桌面版已开放 macOS、Windows、Linux GitHub Release 下载入口。",
     "iOS TestFlight 入口会在上传状态成功后同步到官网。",
     "官网展示的 iOS TestFlight 入口来自本次发布携带的上传状态与公开加入链接；如需确认 App Store Connect 后台最终处理态，仍需额外核验。",
     "如果本次 GitHub Release 只带了一个平台，官网会继续保留另一个平台上一版可用信息。"

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -20,9 +20,9 @@ import {
 import { siteHref, siteUrl } from "../../lib/site-url";
 
 const downloadUrl = siteUrl("/download");
-const downloadTitle = `法布施大乘 App 下载 | Android、iOS、版本与安装说明 | ${brand.name}`;
+const downloadTitle = `法布施大乘 App 下载 | iOS、Android、桌面版与安装说明 | ${brand.name}`;
 const downloadDescription =
-  "法布施大乘 App 下载页，集中提供 Android、iOS 下载入口、版本说明、安装步骤与常见下载问题。";
+  "法布施大乘 App 下载页，集中提供 iOS、Android、macOS、Windows、Linux 下载入口、版本说明、安装步骤与常见下载问题。";
 
 const downloadFaqs = [
   {
@@ -38,6 +38,12 @@ const downloadFaqs = [
     answerEn: "Use the main download button on the current card again, then confirm that you downloaded the matching platform and version. If it still fails, send the device model, OS version, and an error screenshot to support.",
   },
   {
+    questionZh: "桌面版从哪里下载？",
+    questionEn: "Where can I download the desktop app?",
+    answerZh: "桌面版按 macOS、Windows、Linux 分开显示，下载按钮会打开对应的 GitHub Release 安装包；同一卡片里也保留备用压缩包格式。",
+    answerEn: "Desktop builds are listed separately for macOS, Windows, and Linux. Buttons open the matching GitHub Release installer, with alternate archive formats on the same card.",
+  },
+  {
     questionZh: "iOS 会打开 TestFlight 还是 App Store？",
     questionEn: "Will iOS open TestFlight or the App Store?",
     answerZh: "iOS 测试版通过 Apple TestFlight 分发；iOS 正式版通过 App Store 安装。下载页会把两个入口分开显示，按你想要的版本选择即可。",
@@ -49,14 +55,14 @@ const installSteps = [
   {
     titleZh: "先确认你的设备平台和版本偏好",
     titleEn: "Confirm your device and version preference first",
-    descriptionZh: "Android 与 iOS 入口分开显示；想先体验新功能可以看测试版，更想稳一点就先看正式版。",
-    descriptionEn: "Android and iOS paths are listed separately. Choose beta for newer features first, or stable for a calmer install path.",
+    descriptionZh: "iOS、Android 和桌面端入口分开显示；普通用户优先选择正式版，需要提前体验再看测试版。",
+    descriptionEn: "iOS, Android, and desktop paths are listed separately. Start with stable for ordinary use, or choose beta for early access.",
   },
   {
     titleZh: "进入对应下载入口并完成安装",
     titleEn: "Open the matching download path and install",
-    descriptionZh: "Android 使用主下载入口直接获取 R2 中的最新安装包；iOS 测试版会打开 TestFlight，正式版会打开 App Store。",
-    descriptionEn: "Use the main Android button to get the latest APK from R2. iOS beta opens TestFlight, while the stable release opens the App Store.",
+    descriptionZh: "iOS 正式版会打开 App Store；桌面版会打开 GitHub Release 安装包；Android 测试版继续使用主下载入口。",
+    descriptionEn: "iOS stable opens the App Store. Desktop builds open GitHub Release installers, while Android beta keeps using the main download path.",
   },
   {
     titleZh: "安装失败时先看 FAQ，再联系支持",
@@ -72,12 +78,16 @@ const DOWNLOAD_NOTES = [
     en: "Check the platform, version, and publish date before downloading so you get the right build.",
   },
   {
-    zh: "Android 安装包由 R2 提供，更新后会直接替换为最新 APK。",
-    en: "Android downloads are served from R2, and each update replaces the APK at the same link.",
+    zh: "iOS 正式版放在最前面，普通用户可直接进入 App Store。",
+    en: "The iOS stable release is listed first and opens the App Store directly.",
   },
   {
-    zh: "iOS 测试版通过 TestFlight 分发，正式版通过 App Store 安装。",
-    en: "iOS beta is distributed through TestFlight, while the stable release installs through the App Store.",
+    zh: "桌面版使用 GitHub Release 下载链接，按 macOS、Windows、Linux 分开显示。",
+    en: "Desktop builds use GitHub Release links and are split by macOS, Windows, and Linux.",
+  },
+  {
+    zh: "Android 测试版使用主下载入口，iOS 测试版通过 TestFlight 分发。",
+    en: "Android beta uses the main download path, while iOS beta is distributed through TestFlight.",
   },
 ] as const;
 
@@ -89,6 +99,10 @@ export const metadata: Metadata = {
     "Fabushi 下载",
     "Android 下载",
     "iOS 下载",
+    "macOS 下载",
+    "Windows 下载",
+    "Linux 下载",
+    "桌面版下载",
     "TestFlight",
     "安装说明",
     "版本说明",
@@ -133,6 +147,27 @@ function getChannelActionCopy(channel: OfficialSiteChannel) {
     return {
       zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
       en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
+    };
+  }
+
+  if (channel.platform === "macOS") {
+    return {
+      zh: "下载 macOS 桌面版",
+      en: "Download macOS Desktop",
+    };
+  }
+
+  if (channel.platform === "Windows") {
+    return {
+      zh: "下载 Windows 桌面版",
+      en: "Download Windows Desktop",
+    };
+  }
+
+  if (channel.platform === "Linux") {
+    return {
+      zh: "下载 Linux 桌面版",
+      en: "Download Linux Desktop",
     };
   }
 
@@ -196,9 +231,14 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
         <DownloadLink className="primary-action" channel={channel}>
           <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
         </DownloadLink>
+        {channel.mirrorLinks.map((link) => (
+          <a key={link.href} className="secondary-action compact-action" href={siteHref(link.href)}>
+            {link.label}
+          </a>
+        ))}
         {channel.releasePageHref ? (
-          <a className="secondary-action" href={siteHref("/download#release-changelog")}>
-            <LocalizedText zh="查看下载内容说明" en="View download notes" />
+          <a className="secondary-action compact-action" href={siteHref(channel.releasePageHref)}>
+            <LocalizedText zh="查看发布页" en="View release page" />
           </a>
         ) : null}
       </div>
@@ -213,9 +253,9 @@ function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
 
 export default async function DownloadPage() {
   const releaseCollection = await getOfficialSiteReleaseCollection();
-  const betaChannels = releaseCollection.betaChannels;
   const stableChannels = releaseCollection.stableChannels;
-  const allChannels = [...betaChannels, ...stableChannels];
+  const betaChannels = releaseCollection.betaChannels;
+  const allChannels = [...stableChannels, ...betaChannels];
   const supportEmail =
     contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
 
@@ -233,7 +273,7 @@ export default async function DownloadPage() {
           name: `${brand.name} Fabushi`,
           url: siteUrl("/"),
         },
-        about: ["App 下载", "Android 下载", "iOS 下载", "安装说明", "版本说明"],
+        about: ["App 下载", "iOS 下载", "Android 下载", "桌面版下载", "安装说明", "版本说明"],
       },
       {
         "@type": "BreadcrumbList",
@@ -256,7 +296,7 @@ export default async function DownloadPage() {
         "@type": "SoftwareApplication",
         name: `${brand.name} Fabushi`,
         applicationCategory: "LifestyleApplication",
-        operatingSystem: "Android, iOS",
+        operatingSystem: "iOS, Android, macOS, Windows, Linux",
         url: downloadUrl,
         downloadUrl,
         description: downloadDescription,
@@ -324,20 +364,36 @@ export default async function DownloadPage() {
           </h1>
           <p className="lede">
             <LocalizedText
-              zh="这一页集中放置 Android、iOS、版本说明和安装步骤，让下载路径更短。"
-              en="This page keeps Android, iOS, release notes, and install steps in one place so the download path stays short."
+              zh="这一页集中放置 iOS、Android、桌面版、版本说明和安装步骤，让下载路径更短。"
+              en="This page keeps iOS, Android, desktop releases, notes, and install steps in one place so the download path stays short."
             />
           </p>
         </div>
       </section>
 
-      <section className="band compact-band" id="beta-channels">
+      <section className="band compact-band" id="stable-channels">
         <div className="section-heading tight">
           <p>
             <LocalizedText zh="下载" en="Download" />
           </p>
           <h2>
-            <LocalizedText zh="先从最合适的平台入口开始。" en="Start with the path that matches your device." />
+            <LocalizedText zh="iOS 正式版在最前面，桌面版也都在这里。" en="iOS stable comes first, with every desktop build beside it." />
+          </h2>
+        </div>
+        <div className="download-grid">
+          {stableChannels.map((channel) => (
+            <ReleaseChannelCard key={`${channel.audience}-${channel.platform}`} channel={channel} />
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="beta-channels">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="测试版" en="Beta" />
+          </p>
+          <h2>
+            <LocalizedText zh="想提前体验，再看测试入口。" en="Use beta paths when you want early access." />
           </h2>
         </div>
         {betaChannels.length > 0 ? (
@@ -372,22 +428,6 @@ export default async function DownloadPage() {
             </article>
           </div>
         )}
-      </section>
-
-      <section className="band alt" id="stable-channels">
-        <div className="section-heading tight">
-          <p>
-            <LocalizedText zh="正式版" en="Stable" />
-          </p>
-          <h2>
-            <LocalizedText zh="适合想要更稳安装的人。" en="For people who would rather wait for a steadier install path." />
-          </h2>
-        </div>
-        <div className="download-grid">
-          {stableChannels.map((channel) => (
-            <ReleaseChannelCard key={`${channel.audience}-${channel.platform}`} channel={channel} />
-          ))}
-        </div>
       </section>
 
       <section className="band" id="install-steps">

--- a/frontend/apps/web/src/app/faq/page.tsx
+++ b/frontend/apps/web/src/app/faq/page.tsx
@@ -6,9 +6,9 @@ import { SiteHeader } from "../../components/site-header";
 import { siteHref, siteUrl } from "../../lib/site-url";
 
 const faqUrl = siteUrl("/faq");
-const faqTitle = `App 下载常见问题 | Android、iOS、安装与版本说明 | ${brand.name}`;
+const faqTitle = `App 下载常见问题 | iOS、Android、桌面版与安装说明 | ${brand.name}`;
 const faqDescription =
-  "集中说明法布施大乘 App 的下载问题：正式版和测试版怎么选、Android 下载慢怎么办、iOS 如何选择 TestFlight 或 App Store、安装失败怎么排查，以及联系支持前需要准备什么。";
+  "集中说明法布施大乘 App 的下载问题：正式版和测试版怎么选、桌面版从哪里下载、Android 下载慢怎么办、iOS 如何选择 TestFlight 或 App Store、安装失败怎么排查，以及联系支持前需要准备什么。";
 
 const faqItems = [
   {
@@ -28,6 +28,12 @@ const faqItems = [
     questionEn: "Should I choose TestFlight or the App Store on iOS?",
     answerZh: "想体验测试版就选择 TestFlight；想直接安装正式版就选择 App Store。现在 iOS 正式版已经上架，普通用户优先选择 App Store 会更稳。",
     answerEn: "Choose TestFlight if you want the beta build. Choose the App Store if you want the stable release. The iOS stable release is now live, so most users should start with the App Store.",
+  },
+  {
+    questionZh: "macOS、Windows、Linux 桌面版在哪里？",
+    questionEn: "Where are the macOS, Windows, and Linux desktop builds?",
+    answerZh: "进入下载页后，iOS 正式版会排在最前面，后面会按 macOS、Windows、Linux 分别显示桌面版 GitHub Release 下载入口和备用格式。",
+    answerEn: "Open the download page: iOS stable appears first, followed by separate macOS, Windows, and Linux GitHub Release download paths with alternate formats.",
   },
   {
     questionZh: "下载前我最少要确认哪些信息？",
@@ -54,6 +60,10 @@ export const metadata: Metadata = {
     "App 下载常见问题",
     "Android 下载",
     "iOS 下载",
+    "macOS 下载",
+    "Windows 下载",
+    "Linux 下载",
+    "桌面版下载",
     "TestFlight",
     "安装失败",
     "R2 下载",

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -290,6 +290,12 @@ h3,
   color: var(--ink);
 }
 
+.compact-action {
+  min-height: 36px;
+  padding: 8px 13px;
+  font-size: 0.88rem;
+}
+
 .nav-cta:hover,
 .primary-action:hover,
 .secondary-action:hover,
@@ -778,6 +784,14 @@ h3,
   text-align: right;
 }
 
+.platform-mirror-links {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
 .platform-meta strong {
   display: block;
   color: var(--ink);
@@ -1115,6 +1129,10 @@ h3,
   .platform-meta {
     min-width: 0;
     text-align: left;
+  }
+
+  .platform-mirror-links {
+    justify-content: flex-start;
   }
 
   .hero-visual {

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ import "./globals.css";
 const homeUrl = siteUrl("/");
 const siteTitle = `${brand.name} | 全球法布施 App 下载官网`;
 const siteDescription =
-  "Fabushi 官网只服务 App 下载与安装转化，提供 iOS 与 Android 下载入口、版本说明、安装支持、下载 FAQ 与基础隐私信息。";
+  "Fabushi 官网只服务 App 下载与安装转化，提供 iOS、Android 与桌面版下载入口、版本说明、安装支持、下载 FAQ 与基础隐私信息。";
 
 export const metadata: Metadata = {
   title: siteTitle,
@@ -20,6 +20,10 @@ export const metadata: Metadata = {
     "App 下载",
     "iOS 下载",
     "Android 下载",
+    "macOS 下载",
+    "Windows 下载",
+    "Linux 下载",
+    "桌面版下载",
     "TestFlight",
     "APK 下载",
     "下载 FAQ",

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -179,6 +179,27 @@ function getChannelActionCopy(channel: OfficialSiteChannel) {
     };
   }
 
+  if (channel.platform === "macOS") {
+    return {
+      zh: "下载 macOS 桌面版",
+      en: "Download macOS Desktop",
+    };
+  }
+
+  if (channel.platform === "Windows") {
+    return {
+      zh: "下载 Windows 桌面版",
+      en: "Download Windows Desktop",
+    };
+  }
+
+  if (channel.platform === "Linux") {
+    return {
+      zh: "下载 Linux 桌面版",
+      en: "Download Linux Desktop",
+    };
+  }
+
   return {
     zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
     en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
@@ -200,6 +221,9 @@ export const metadata: Metadata = {
     "佛经听诵 app",
     "iOS TestFlight",
     "Android APK",
+    "macOS 下载",
+    "Windows 下载",
+    "Linux 下载",
   ],
   openGraph: {
     title: homeTitle,
@@ -222,7 +246,7 @@ export default async function HomePage() {
     ...FALLBACK_SCREENSHOTS,
     ...releaseCollection.screenshots,
   };
-  const channels = [...releaseCollection.betaChannels, ...releaseCollection.stableChannels].slice(0, 2);
+  const channels = [...releaseCollection.stableChannels, ...releaseCollection.betaChannels].slice(0, 2);
   const supportEmail =
     contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
   const latestRelease = releaseCollection.releases[0] ?? null;
@@ -253,7 +277,7 @@ export default async function HomePage() {
         "@type": "SoftwareApplication",
         name: `${brand.name} Fabushi`,
         applicationCategory: "LifestyleApplication",
-        operatingSystem: "iOS, Android",
+        operatingSystem: "iOS, Android, macOS, Windows, Linux",
         downloadUrl: siteUrl("/download"),
         description: homeDescription,
         screenshot: APP_SCREENSHOTS.map((item) => siteUrl(resolveScreenshot(screenshots, item.screenshot))),

--- a/frontend/apps/web/src/components/download-client.tsx
+++ b/frontend/apps/web/src/components/download-client.tsx
@@ -9,9 +9,10 @@ import {
   getUserFacingStatus,
   getUserFacingSummary,
 } from "../lib/channel-display";
+import { siteHref } from "../lib/site-url";
 
 export interface DownloadChannel {
-  platform: "Android" | "iOS";
+  platform: "Android" | "iOS" | "macOS" | "Windows" | "Linux";
   audience: "beta" | "stable";
   status: string;
   title: string;
@@ -26,7 +27,7 @@ export interface DownloadChannel {
   releasePageHref?: string;
 }
 
-type DetectedPlatform = "android" | "ios" | "other";
+type DetectedPlatform = "android" | "ios" | "macos" | "windows" | "linux" | "other";
 
 function detectPlatform(): DetectedPlatform {
   if (typeof navigator === "undefined") return "other";
@@ -34,15 +35,24 @@ function detectPlatform(): DetectedPlatform {
   if (/android/.test(ua)) return "android";
   if (/iphone|ipad|ipod/.test(ua)) return "ios";
   if (/macintosh/.test(ua) && "maxTouchPoints" in navigator && navigator.maxTouchPoints > 1) return "ios";
+  if (/macintosh|mac os x/.test(ua)) return "macos";
+  if (/windows/.test(ua)) return "windows";
+  if (/linux/.test(ua)) return "linux";
   return "other";
 }
 
 function getRecommendedTitle(platform: DetectedPlatform, locale: "zh" | "en"): string {
   switch (platform) {
     case "android":
-      return locale === "zh" ? "推荐 Android 测试版" : "Recommended Android Beta";
+      return locale === "zh" ? "推荐 Android 入口" : "Recommended Android path";
     case "ios":
-      return locale === "zh" ? "推荐 iOS 测试版" : "Recommended iOS Beta";
+      return locale === "zh" ? "推荐 iOS 入口" : "Recommended iOS path";
+    case "macos":
+      return locale === "zh" ? "推荐 macOS 桌面版" : "Recommended macOS Desktop";
+    case "windows":
+      return locale === "zh" ? "推荐 Windows 桌面版" : "Recommended Windows Desktop";
+    case "linux":
+      return locale === "zh" ? "推荐 Linux 桌面版" : "Recommended Linux Desktop";
     default:
       return "";
   }
@@ -51,6 +61,9 @@ function getRecommendedTitle(platform: DetectedPlatform, locale: "zh" | "en"): s
 function matchesPlatform(channel: DownloadChannel, platform: DetectedPlatform): boolean {
   if (platform === "android") return channel.platform === "Android";
   if (platform === "ios") return channel.platform === "iOS";
+  if (platform === "macos") return channel.platform === "macOS";
+  if (platform === "windows") return channel.platform === "Windows";
+  if (platform === "linux") return channel.platform === "Linux";
   return false;
 }
 
@@ -75,6 +88,27 @@ function getChannelActionCopy(channel: DownloadChannel) {
     return {
       zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
       en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
+    };
+  }
+
+  if (channel.platform === "macOS") {
+    return {
+      zh: "下载 macOS 桌面版",
+      en: "Download macOS Desktop",
+    };
+  }
+
+  if (channel.platform === "Windows") {
+    return {
+      zh: "下载 Windows 桌面版",
+      en: "Download Windows Desktop",
+    };
+  }
+
+  if (channel.platform === "Linux") {
+    return {
+      zh: "下载 Linux 桌面版",
+      en: "Download Linux Desktop",
     };
   }
 
@@ -124,6 +158,15 @@ function ChannelCard({ channel, recommended = false }: { channel: DownloadChanne
         <DownloadLink className="primary-action" channel={channel}>
           <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
         </DownloadLink>
+        {channel.mirrorLinks.length > 0 ? (
+          <div className="platform-mirror-links">
+            {channel.mirrorLinks.map((link) => (
+              <a key={link.href} className="secondary-action compact-action" href={siteHref(link.href)}>
+                {link.label}
+              </a>
+            ))}
+          </div>
+        ) : null}
       </div>
     </article>
   );

--- a/frontend/apps/web/src/components/download-link.tsx
+++ b/frontend/apps/web/src/components/download-link.tsx
@@ -5,7 +5,7 @@ import { getDownloadHrefForRegion } from "../lib/download-hrefs";
 import { siteHref } from "../lib/site-url";
 
 interface DownloadLinkChannel {
-  platform: "Android" | "iOS";
+  platform: "Android" | "iOS" | "macOS" | "Windows" | "Linux";
   primaryHref: string;
   audience?: "beta" | "stable";
 }

--- a/frontend/apps/web/src/components/global-network-globe.tsx
+++ b/frontend/apps/web/src/components/global-network-globe.tsx
@@ -230,7 +230,7 @@ export function GlobalNetworkGlobe() {
       const gradient = context.createLinearGradient(tail.x, tail.y, head.x, head.y);
       gradient.addColorStop(0, "rgba(246, 139, 54, 0)");
       gradient.addColorStop(0.72, subtle ? "rgba(246, 139, 54, 0.48)" : "rgba(246, 139, 54, 0.82)");
-      gradient.addColorStop(1, subtle ? "rgba(255, 255, 255, 0.7)" : "rgba(255, 255, 255, 1)");
+      gradient.addColorStop(1, subtle ? "rgba(255, 227, 163, 0.72)" : "rgba(120, 214, 232, 0.92)");
       context.strokeStyle = gradient;
       context.lineWidth = subtle ? 1.6 : 3;
       context.beginPath();
@@ -247,15 +247,16 @@ export function GlobalNetworkGlobe() {
 
       context.clearRect(0, 0, width, height);
       const bg = context.createLinearGradient(width / 2, 0, width / 2, height);
-      bg.addColorStop(0, "#fffefa");
-      bg.addColorStop(0.58, "#fffcf5");
-      bg.addColorStop(1, "#ffffff");
+      bg.addColorStop(0, "#05070d");
+      bg.addColorStop(0.58, "#0c111a");
+      bg.addColorStop(1, "#05070d");
       context.fillStyle = bg;
       context.fillRect(0, 0, width, height);
 
       const halo = context.createRadialGradient(centerX, centerY - radius * 0.08, radius * 0.12, centerX, centerY, radius * 1.15);
-      halo.addColorStop(0, "rgba(255, 180, 84, 0.22)");
-      halo.addColorStop(1, "rgba(255, 180, 84, 0)");
+      halo.addColorStop(0, "rgba(232, 189, 107, 0.3)");
+      halo.addColorStop(0.42, "rgba(120, 214, 232, 0.1)");
+      halo.addColorStop(1, "rgba(232, 189, 107, 0)");
       context.fillStyle = halo;
       context.beginPath();
       context.arc(centerX, centerY, radius * 1.15, 0, Math.PI * 2);
@@ -267,28 +268,32 @@ export function GlobalNetworkGlobe() {
       context.clip();
 
       const ocean = context.createRadialGradient(centerX - radius * 0.18, centerY - radius * 0.42, radius * 0.04, centerX, centerY, radius * 1.16);
-      ocean.addColorStop(0, "#ffffff");
-      ocean.addColorStop(0.44, "#fffcf7");
-      ocean.addColorStop(0.78, "#fff2df");
-      ocean.addColorStop(1, "#fffbf7");
+      ocean.addColorStop(0, "#213344");
+      ocean.addColorStop(0.42, "#132333");
+      ocean.addColorStop(0.78, "#0b121d");
+      ocean.addColorStop(1, "#05070d");
       context.fillStyle = ocean;
       context.beginPath();
       context.arc(centerX, centerY, radius, 0, Math.PI * 2);
       context.fill();
 
       if (runtime) {
+        context.save();
+        context.globalAlpha = 0.66;
+        context.filter = "sepia(1) saturate(1.45) hue-rotate(342deg) brightness(0.82)";
         drawProjectedTexture(runtime.image, centerX, centerY, radius, runtime.rotation);
+        context.restore();
       }
 
       const shine = context.createRadialGradient(centerX - radius * 0.22, centerY - radius * 0.36, radius * 0.08, centerX, centerY, radius * 1.18);
-      shine.addColorStop(0, "rgba(255,255,255,0.14)");
-      shine.addColorStop(0.62, "rgba(255,255,255,0)");
-      shine.addColorStop(1, "rgba(255,255,255,0.22)");
+      shine.addColorStop(0, "rgba(255,227,163,0.2)");
+      shine.addColorStop(0.58, "rgba(120,214,232,0.03)");
+      shine.addColorStop(1, "rgba(5,7,13,0.26)");
       context.fillStyle = shine;
       context.fillRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
       context.restore();
 
-      context.strokeStyle = "rgba(247, 168, 75, 0.42)";
+      context.strokeStyle = "rgba(232, 189, 107, 0.5)";
       context.lineWidth = 1.4;
       context.beginPath();
       context.arc(centerX, centerY, radius * 1.01, 0, Math.PI * 2);
@@ -309,24 +314,24 @@ export function GlobalNetworkGlobe() {
           const alpha = Math.max(0, Math.min(1, 0.38 + projected.visibility * 0.62));
           const nodeRadius = 1.25 + node.tier * 0.72 + (active ? 2 : 0);
 
-          context.fillStyle = `rgba(255,255,255,${alpha * 0.42})`;
+          context.fillStyle = `rgba(232,189,107,${alpha * 0.32})`;
           context.beginPath();
           context.arc(projected.x, projected.y, nodeRadius + 3.2, 0, Math.PI * 2);
           context.fill();
-          context.fillStyle = active ? `rgba(36,62,98,${alpha})` : `rgba(83,103,131,${alpha})`;
+          context.fillStyle = active ? `rgba(120,214,232,${alpha})` : `rgba(255,227,163,${alpha * 0.88})`;
           context.beginPath();
           context.arc(projected.x, projected.y, nodeRadius, 0, Math.PI * 2);
           context.fill();
-          context.strokeStyle = `rgba(255,255,255,${alpha * 0.72})`;
+          context.strokeStyle = `rgba(255,249,235,${alpha * 0.58})`;
           context.lineWidth = 0.75;
           context.stroke();
         });
       }
 
       const fade = context.createLinearGradient(0, height * 0.62, 0, height);
-      fade.addColorStop(0, "rgba(255,255,255,0)");
-      fade.addColorStop(0.62, "rgba(255,255,255,0.82)");
-      fade.addColorStop(1, "rgba(255,255,255,1)");
+      fade.addColorStop(0, "rgba(5,7,13,0)");
+      fade.addColorStop(0.62, "rgba(5,7,13,0.7)");
+      fade.addColorStop(1, "rgba(5,7,13,0.98)");
       context.fillStyle = fade;
       context.fillRect(0, height * 0.62, width, height * 0.38);
 

--- a/frontend/apps/web/src/lib/channel-display.ts
+++ b/frontend/apps/web/src/lib/channel-display.ts
@@ -1,5 +1,5 @@
 export interface DisplayChannel {
-  platform: "Android" | "iOS";
+  platform: "Android" | "iOS" | "macOS" | "Windows" | "Linux";
   audience: "beta" | "stable";
   status: string;
   description: string;
@@ -17,6 +17,13 @@ interface LocalizedCopy {
 const TECHNICAL_COPY_PATTERN = /github|自动同步|仓库|app store connect|凭据|发布记录|release|同步|uploaded|upload|asset|api/i;
 
 function fallbackDescription(channel: DisplayChannel): LocalizedCopy {
+  if (isDesktopPlatform(channel.platform)) {
+    return {
+      zh: `适合在 ${channel.platform} 桌面设备上安装使用。`,
+      en: `For installing the desktop app on ${channel.platform}.`,
+    };
+  }
+
   if (channel.platform === "Android" && channel.audience === "beta") {
     return {
       zh: "适合希望第一时间体验新功能的用户。",
@@ -38,6 +45,19 @@ function fallbackDescription(channel: DisplayChannel): LocalizedCopy {
 }
 
 function fallbackSummary(channel: DisplayChannel): LocalizedCopy[] {
+  if (isDesktopPlatform(channel.platform)) {
+    return [
+      {
+        zh: "桌面版安装包已经开放下载。",
+        en: "The desktop installer is available to download.",
+      },
+      {
+        zh: "如需其他压缩包格式，可使用卡片里的备用入口。",
+        en: "Use the alternate link on the card if you need the archive format.",
+      },
+    ];
+  }
+
   if (channel.platform === "Android" && channel.audience === "beta") {
     return [
       {
@@ -77,6 +97,13 @@ function fallbackSummary(channel: DisplayChannel): LocalizedCopy[] {
 }
 
 export function getUserFacingStatus(channel: DisplayChannel): LocalizedCopy {
+  if (isDesktopPlatform(channel.platform)) {
+    return {
+      zh: "桌面版可下载",
+      en: "Desktop available",
+    };
+  }
+
   if (channel.platform === "Android" && channel.audience === "beta") {
     return {
       zh: "最新测试版",
@@ -134,6 +161,13 @@ export function getUserFacingSummary(channel: DisplayChannel): LocalizedCopy[] {
 }
 
 export function getUserFacingNote(channel: DisplayChannel): LocalizedCopy | null {
+  if (isDesktopPlatform(channel.platform)) {
+    return {
+      zh: "如需校验文件完整性，可在对应的 GitHub Release 页面查看 SHA256SUMS。",
+      en: "Use the linked GitHub Release page if you need SHA256 checksums.",
+    };
+  }
+
   if (channel.platform === "iOS" && channel.audience === "beta") {
     return channel.primaryHref.includes("testflight.apple.com")
       ? {
@@ -154,4 +188,8 @@ export function getUserFacingNote(channel: DisplayChannel): LocalizedCopy | null
   }
 
   return null;
+}
+
+function isDesktopPlatform(platform: DisplayChannel["platform"]) {
+  return platform === "macOS" || platform === "Windows" || platform === "Linux";
 }

--- a/frontend/apps/web/src/lib/download-hrefs.ts
+++ b/frontend/apps/web/src/lib/download-hrefs.ts
@@ -1,5 +1,5 @@
 interface DownloadHrefChannel {
-  platform: "Android" | "iOS";
+  platform: "Android" | "iOS" | "macOS" | "Windows" | "Linux";
   primaryHref: string;
   audience?: "beta" | "stable";
 }

--- a/frontend/apps/web/src/lib/official-site-releases.ts
+++ b/frontend/apps/web/src/lib/official-site-releases.ts
@@ -1,10 +1,15 @@
 const iosTestFlightPublicUrl = process.env.NEXT_PUBLIC_IOS_TESTFLIGHT_PUBLIC_URL?.trim() || "";
 const iosAppStoreUrl = "https://apps.apple.com/cn/app/%E5%A4%A7%E4%B9%98/id6758606957";
+const desktopReleasePageUrl = "https://github.com/bhrumom/fabushi/releases/tag/desktop-v1.0.1-408-49-a0e997f3aa61";
+const desktopDownloadBaseUrl =
+  "https://github.com/bhrumom/fabushi/releases/download/desktop-v1.0.1-408-49-a0e997f3aa61";
 const configuredReleaseApiBaseUrl =
   process.env.NEXT_PUBLIC_OFFICIAL_SITE_RELEASE_API_BASE_URL?.trim() ||
   process.env.NEXT_PUBLIC_FABUSHI_API_BASE_URL?.trim() ||
   process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
   "https://api.ombhrum.com";
+
+export type OfficialSitePlatform = "Android" | "iOS" | "macOS" | "Windows" | "Linux";
 
 export interface OfficialSiteMirrorLink {
   label: string;
@@ -12,7 +17,7 @@ export interface OfficialSiteMirrorLink {
 }
 
 export interface OfficialSiteChannel {
-  platform: "Android" | "iOS";
+  platform: OfficialSitePlatform;
   audience: "beta" | "stable";
   status: string;
   title: string;
@@ -67,10 +72,13 @@ export const FALLBACK_SCREENSHOTS: Record<string, string> = {
 };
 
 const CHANNEL_ORDER: Array<Pick<OfficialSiteChannel, "audience" | "platform">> = [
-  { audience: "beta", platform: "Android" },
-  { audience: "beta", platform: "iOS" },
-  { audience: "stable", platform: "Android" },
   { audience: "stable", platform: "iOS" },
+  { audience: "stable", platform: "macOS" },
+  { audience: "stable", platform: "Windows" },
+  { audience: "stable", platform: "Linux" },
+  { audience: "stable", platform: "Android" },
+  { audience: "beta", platform: "iOS" },
+  { audience: "beta", platform: "Android" },
 ];
 
 const IOS_STABLE_CHANNEL: OfficialSiteChannel = {
@@ -92,6 +100,76 @@ const IOS_STABLE_CHANNEL: OfficialSiteChannel = {
 };
 
 const DEFAULT_STABLE_CHANNELS: OfficialSiteChannel[] = [
+  IOS_STABLE_CHANNEL,
+  {
+    platform: "macOS",
+    audience: "stable",
+    status: "GitHub Release 可下载",
+    title: "macOS 桌面版",
+    description: "适合 macOS Apple Silicon 设备安装桌面版。",
+    primaryLabel: "下载 macOS DMG",
+    primaryHref: `${desktopDownloadBaseUrl}/global_dharma_sharing-1.0.1-408-macos-arm64.dmg`,
+    version: "1.0.1-408",
+    publishedAt: "2026-06-08T12:21:06Z",
+    updateSummary: [
+      "桌面版安装包已发布到 GitHub Release。",
+      "提供 DMG 和 ZIP 两种 macOS 下载格式。",
+    ],
+    mirrorLinks: [
+      {
+        label: "下载 macOS ZIP",
+        href: `${desktopDownloadBaseUrl}/global_dharma_sharing-1.0.1-408-macos-arm64.zip`,
+      },
+    ],
+    note: "桌面版文件由 GitHub Release 提供。",
+    releasePageHref: desktopReleasePageUrl,
+  },
+  {
+    platform: "Windows",
+    audience: "stable",
+    status: "GitHub Release 可下载",
+    title: "Windows 桌面版",
+    description: "适合 Windows x64 设备安装桌面版。",
+    primaryLabel: "下载 Windows 安装器",
+    primaryHref: `${desktopDownloadBaseUrl}/global_dharma_sharing-1.0.1-408-windows-x64-setup.exe`,
+    version: "1.0.1-408",
+    publishedAt: "2026-06-08T12:21:06Z",
+    updateSummary: [
+      "桌面版安装包已发布到 GitHub Release。",
+      "提供安装器和 ZIP 两种 Windows 下载格式。",
+    ],
+    mirrorLinks: [
+      {
+        label: "下载 Windows ZIP",
+        href: `${desktopDownloadBaseUrl}/global_dharma_sharing-1.0.1-408-windows-x64.zip`,
+      },
+    ],
+    note: "桌面版文件由 GitHub Release 提供。",
+    releasePageHref: desktopReleasePageUrl,
+  },
+  {
+    platform: "Linux",
+    audience: "stable",
+    status: "GitHub Release 可下载",
+    title: "Linux 桌面版",
+    description: "适合 Linux x64 设备安装桌面版。",
+    primaryLabel: "下载 Linux DEB",
+    primaryHref: `${desktopDownloadBaseUrl}/global-dharma-sharing_1.0.1-408_amd64.deb`,
+    version: "1.0.1-408",
+    publishedAt: "2026-06-08T12:21:06Z",
+    updateSummary: [
+      "桌面版安装包已发布到 GitHub Release。",
+      "提供 DEB 和 tar.gz 两种 Linux 下载格式。",
+    ],
+    mirrorLinks: [
+      {
+        label: "下载 Linux tar.gz",
+        href: `${desktopDownloadBaseUrl}/global_dharma_sharing-1.0.1-408-linux-x64.tar.gz`,
+      },
+    ],
+    note: "桌面版文件由 GitHub Release 提供。",
+    releasePageHref: desktopReleasePageUrl,
+  },
   {
     platform: "Android",
     audience: "stable",
@@ -107,7 +185,6 @@ const DEFAULT_STABLE_CHANNELS: OfficialSiteChannel[] = [
     mirrorLinks: [],
     note: "正式版上线后，这里会显示已经同步到 Cloudflare 的下载地址。",
   },
-  IOS_STABLE_CHANNEL,
 ];
 
 function trimTrailingSlash(value: string) {
@@ -144,7 +221,7 @@ function normalizeChannel(input: unknown): OfficialSiteChannel | null {
 
   const channel = input as Record<string, unknown>;
   if (
-    (channel.platform !== "Android" && channel.platform !== "iOS") ||
+    !isOfficialSitePlatform(channel.platform) ||
     (channel.audience !== "beta" && channel.audience !== "stable") ||
     typeof channel.status !== "string" ||
     typeof channel.title !== "string" ||
@@ -186,6 +263,16 @@ function normalizeChannel(input: unknown): OfficialSiteChannel | null {
         ? channel.releasePageHref
         : undefined,
   };
+}
+
+function isOfficialSitePlatform(platform: unknown): platform is OfficialSitePlatform {
+  return (
+    platform === "Android" ||
+    platform === "iOS" ||
+    platform === "macOS" ||
+    platform === "Windows" ||
+    platform === "Linux"
+  );
 }
 
 function normalizeScreenshots(input: unknown): OfficialSiteScreenshots | undefined {
@@ -251,6 +338,18 @@ function getChannelKey(channel: Pick<OfficialSiteChannel, "audience" | "platform
   return `${channel.audience}:${channel.platform}`;
 }
 
+function orderChannels(channels: OfficialSiteChannel[]): OfficialSiteChannel[] {
+  const orderedChannels = CHANNEL_ORDER.map((channel) =>
+    channels.find((item) => getChannelKey(item) === getChannelKey(channel)),
+  ).filter(
+    (channel): channel is OfficialSiteChannel => Boolean(channel),
+  );
+  const seenKeys = new Set(orderedChannels.map((channel) => getChannelKey(channel)));
+  const remainingChannels = channels.filter((channel) => !seenKeys.has(getChannelKey(channel)));
+
+  return [...orderedChannels, ...remainingChannels];
+}
+
 function mergeChannels(primary: OfficialSiteChannel[], fallback: OfficialSiteChannel[]): OfficialSiteChannel[] {
   const merged = new Map<string, OfficialSiteChannel>();
 
@@ -262,13 +361,7 @@ function mergeChannels(primary: OfficialSiteChannel[], fallback: OfficialSiteCha
     merged.set(getChannelKey(channel), channel);
   }
 
-  const orderedChannels = CHANNEL_ORDER.map((channel) => merged.get(getChannelKey(channel))).filter(
-    (channel): channel is OfficialSiteChannel => Boolean(channel),
-  );
-  const seenKeys = new Set(orderedChannels.map((channel) => getChannelKey(channel)));
-  const remainingChannels = Array.from(merged.values()).filter((channel) => !seenKeys.has(getChannelKey(channel)));
-
-  return [...orderedChannels, ...remainingChannels];
+  return orderChannels(Array.from(merged.values()));
 }
 
 function applyConfiguredIosTestFlightChannel(channel: OfficialSiteChannel): OfficialSiteChannel {
@@ -359,7 +452,7 @@ function buildFallbackCollection(): OfficialSiteReleaseCollection {
 
 function finalizeCollection(collection: OfficialSiteReleaseCollection): OfficialSiteReleaseCollection {
   return {
-    betaChannels: applyConfiguredIosTestFlightChannels(collection.betaChannels),
+    betaChannels: orderChannels(applyConfiguredIosTestFlightChannels(collection.betaChannels)),
     stableChannels: applyIosStableAppStoreChannels(mergeChannels(collection.stableChannels, DEFAULT_STABLE_CHANNELS)),
     screenshots: collection.screenshots,
     releases: collection.releases,


### PR DESCRIPTION
## Summary
- add macOS, Windows, and Linux desktop download cards using GitHub Release links
- put the iOS App Store stable entry first on the homepage and download page
- restyle the global network globe away from the white background into the site dark/gold visual system

## Verification
- corepack pnpm --filter @fabushi/web typecheck
- corepack pnpm --filter @fabushi/web build
- local Chrome check at http://127.0.0.1:3020/download/