### PR TITLE
feat(mp): replace mini program with unified Dacheng chat

### DIFF
--- a/frontend/apps/mp-wechat/src/app.config.ts
+++ b/frontend/apps/mp-wechat/src/app.config.ts
@@ -1,29 +1,10 @@
 export default defineAppConfig({
-  pages: [
-    "pages/index/index",
-    "pages/sutra/index",
-    "pages/practice/index",
-    "pages/ai/index",
-    "pages/me/index",
-  ],
+  pages: ["pages/index/index"],
   window: {
     backgroundTextStyle: "light",
     navigationBarBackgroundColor: "#101419",
-    navigationBarTitleText: "法布施",
+    navigationBarTitleText: "大乘",
     navigationBarTextStyle: "white",
     backgroundColor: "#080b10",
-  },
-  tabBar: {
-    color: "#8f9a9a",
-    selectedColor: "#e8bd6b",
-    backgroundColor: "#101419",
-    borderStyle: "black",
-    list: [
-      { pagePath: "pages/index/index", text: "首页" },
-      { pagePath: "pages/sutra/index", text: "经文" },
-      { pagePath: "pages/practice/index", text: "修行" },
-      { pagePath: "pages/ai/index", text: "AI" },
-      { pagePath: "pages/me/index", text: "我的" },
-    ],
   },
 });

--- a/frontend/apps/mp-wechat/src/pages/index/index.scss
+++ b/frontend/apps/mp-wechat/src/pages/index/index.scss
@@ -1,150 +1,276 @@
 .page {
   min-height: 100vh;
-  padding: 32px 24px 48px;
+  padding: 24px 22px 180px;
   background:
-    radial-gradient(circle at 18% 4%, rgba(120, 214, 232, 0.16), transparent 34%),
+    radial-gradient(circle at 18% 0%, rgba(120, 214, 232, 0.17), transparent 34%),
     linear-gradient(180deg, #080b10 0%, #101419 100%);
+  color: #fff9eb;
 }
 
-.hero {
-  padding: 28px 0 18px;
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0 24px;
 }
 
-.eyebrow {
-  display: block;
-  color: #78d6e8;
-  font-size: 24px;
-  margin-bottom: 18px;
+.brand {
+  color: #fff9eb;
+  font-size: 40px;
+  font-weight: 850;
+}
+
+.login {
+  min-width: 168px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 249, 235, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.08);
+  color: #ffe3a3;
+  font-size: 25px;
+  font-weight: 750;
+}
+
+.messages {
+  min-height: 44vh;
+}
+
+.empty {
+  padding: 58px 0 30px;
 }
 
 .title {
   display: block;
   color: #fff9eb;
-  font-size: 56px;
-  font-weight: 700;
+  font-size: 54px;
+  font-weight: 780;
   line-height: 1.24;
+  text-align: center;
 }
 
 .subtitle {
   display: block;
-  margin-top: 20px;
+  margin: 18px auto 24px;
   color: #b9c5c7;
-  font-size: 30px;
+  font-size: 28px;
   line-height: 1.65;
+  text-align: center;
 }
 
-.stats {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
-  margin-top: 24px;
-}
-
-.stat,
-.module,
-.prompt,
-.feed {
+.quick,
+.panel,
+.menu-item,
+.bubble,
+.flashcard {
   border: 1px solid rgba(255, 249, 235, 0.14);
-  border-radius: 8px;
+  border-radius: 18px;
   background: rgba(255, 249, 235, 0.06);
 }
 
-.stat {
-  min-height: 112px;
-  padding: 20px;
+.quick {
+  padding: 18px;
+  margin-top: 12px;
+  color: #dbe7e0;
+  font-size: 26px;
+  line-height: 1.55;
 }
 
-.stat-value {
-  display: block;
-  color: #ffe3a3;
-  font-size: 36px;
-  font-weight: 800;
-}
-
-.stat-label {
-  display: block;
-  margin-top: 10px;
-  color: #b9c5c7;
-  font-size: 22px;
-}
-
-.section {
-  margin-top: 32px;
-}
-
-.section-title {
-  display: block;
-  margin-bottom: 16px;
-  color: #fff9eb;
-  font-size: 30px;
-  font-weight: 600;
-}
-
-.module {
+.message {
   display: flex;
-  gap: 18px;
-  align-items: center;
-  padding: 20px;
+  gap: 12px;
+  margin: 16px 0;
 }
 
-.module + .module,
-.prompt + .prompt,
-.feed + .feed {
-  margin-top: 14px;
+.message.user {
+  flex-direction: row-reverse;
 }
 
-.module-icon {
+.avatar {
+  width: 54px;
+  height: 54px;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 72px;
-  height: 72px;
-  flex: 0 0 auto;
-  border-radius: 8px;
-  background: rgba(120, 214, 232, 0.14);
+  border-radius: 50%;
+  background: rgba(120, 214, 232, 0.16);
   color: #78d6e8;
-  font-size: 22px;
-  font-weight: 800;
+  font-size: 24px;
+  font-weight: 900;
 }
 
-.module-gold .module-icon {
-  background: rgba(232, 189, 107, 0.16);
+.user .avatar {
+  background: rgba(255, 227, 163, 0.18);
   color: #ffe3a3;
 }
 
-.module-green .module-icon {
-  background: rgba(158, 215, 191, 0.14);
-  color: #9ed7bf;
-}
-
-.module-rose .module-icon {
-  background: rgba(255, 125, 138, 0.14);
-  color: #ffb1ba;
-}
-
-.module-body {
-  flex: 1;
-}
-
-.card-title {
-  display: block;
-  font-size: 32px;
-  font-weight: 600;
+.bubble {
+  max-width: 590px;
+  padding: 16px 18px;
   color: #fff9eb;
+  font-size: 27px;
+  line-height: 1.68;
 }
 
-.card-copy {
+.user .bubble {
+  background: rgba(120, 214, 232, 0.12);
+}
+
+.side-panels {
+  margin-top: 24px;
+}
+
+.panel {
+  display: block;
+  padding: 20px;
+  margin-top: 16px;
+}
+
+.panel-title {
+  display: block;
+  color: #fff9eb;
+  font-size: 31px;
+  font-weight: 760;
+}
+
+.panel-copy,
+.log,
+.card-kind,
+.card-back {
   display: block;
   margin-top: 10px;
-  font-size: 28px;
-  line-height: 1.7;
   color: #b9c5c7;
+  font-size: 24px;
+  line-height: 1.58;
 }
 
-.prompt,
-.feed {
-  padding: 20px;
+.log {
   color: #dbe7e0;
+}
+
+.flashcard {
+  display: block;
+  margin-top: 16px;
+  padding: 18px;
+  background: rgba(5, 7, 13, 0.34);
+}
+
+.card-front {
+  display: block;
+  margin-top: 12px;
+  color: #fff9eb;
+  font-size: 29px;
+  font-weight: 760;
+  line-height: 1.55;
+}
+
+.card-back {
+  color: #ffe3a3;
+}
+
+.flashcard button,
+.reviews button {
+  min-height: 58px;
+  margin-top: 12px;
+  border-radius: 14px;
+  background: rgba(255, 249, 235, 0.08);
+  color: #fff9eb;
+  font-size: 24px;
+}
+
+.reviews {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.menu {
+  position: fixed;
+  left: 22px;
+  right: 22px;
+  bottom: 138px;
+  z-index: 20;
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(255, 249, 235, 0.14);
+  border-radius: 24px;
+  background: #151922;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.36);
+}
+
+.menu-item {
+  padding: 18px;
+}
+
+.menu-title {
+  display: block;
+  color: #fff9eb;
   font-size: 28px;
-  line-height: 1.6;
+  font-weight: 780;
+}
+
+.menu-copy {
+  display: block;
+  margin-top: 8px;
+  color: #b9c5c7;
+  font-size: 24px;
+  line-height: 1.5;
+}
+
+.composer {
+  position: fixed;
+  left: 18px;
+  right: 18px;
+  bottom: 22px;
+  z-index: 30;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid rgba(255, 249, 235, 0.13);
+  border-radius: 34px;
+  background: #202124;
+}
+
+.plus,
+.mode,
+.send {
+  min-height: 64px;
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.08);
+  color: #fff9eb;
+  font-size: 25px;
+  font-weight: 800;
+}
+
+.plus {
+  width: 64px;
+  font-size: 42px;
+  color: #ffe3a3;
+}
+
+.mode {
+  padding: 0 16px;
+  color: #78d6e8;
+}
+
+.send {
+  padding: 0 18px;
+  background: #ffe3a3;
+  color: #101419;
+}
+
+.input {
+  min-height: 64px;
+  max-height: 160px;
+  padding: 12px 4px;
+  color: #fff9eb;
+  font-size: 28px;
+  line-height: 1.4;
 }

--- a/frontend/apps/mp-wechat/src/pages/index/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/index/index.tsx
@@ -1,67 +1,193 @@
-import { View, Text } from "@tarojs/components";
+import { useState } from "react";
+import { Button, Text, Textarea, View } from "@tarojs/components";
+import Taro from "@tarojs/taro";
 import {
-  aiQuickPrompts,
-  appExperienceStats,
-  appModules,
-  brand,
-  dharmaFeedItems,
+  dachengQuickPrompts,
+  dachengToolEntries,
+  globalDharmaPublicEndpoints,
+  globalDharmaRegions,
+  remnoteInspiredFlashcardPrinciples,
+  type DachengToolId,
 } from "@fabushi/shared";
 import "./index.scss";
 
+type Role = "assistant" | "user";
+
+interface Message {
+  id: string;
+  role: Role;
+  text: string;
+  tag?: string;
+}
+
+interface Card {
+  id: string;
+  front: string;
+  back: string;
+  kind: "挖空" | "双向";
+  due: string;
+}
+
+function id() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeCards(text: string): Card[] {
+  return text
+    .split(/[。！？!?；;\n]+/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 5)
+    .slice(0, 5)
+    .flatMap((sentence) => [
+      {
+        id: id(),
+        front: `${sentence.slice(0, 8)}〔……〕${sentence.slice(14)}`,
+        back: sentence,
+        kind: "挖空" as const,
+        due: "现在",
+      },
+      {
+        id: id(),
+        front: `请背诵并解释：${sentence.slice(0, 16)}…`,
+        back: sentence,
+        kind: "双向" as const,
+        due: "现在",
+      },
+    ]);
+}
+
 export default function IndexPage() {
+  const [messages, setMessages] = useState<Message[]>([
+    { id: "welcome", role: "assistant", text: "欢迎来到大乘。点击 + 可选择全球法布施或背诵闪卡。" },
+  ]);
+  const [input, setInput] = useState("");
+  const [tool, setTool] = useState<DachengToolId | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [cards, setCards] = useState<Card[]>([]);
+  const [cardIndex, setCardIndex] = useState(0);
+  const [showAnswer, setShowAnswer] = useState(false);
+  const activeTool = dachengToolEntries.find((item) => item.id === tool);
+  const activeCard = cards[cardIndex];
+
+  function add(role: Role, text: string, tag?: string) {
+    setMessages((items) => [...items, { id: id(), role, text, tag }]);
+  }
+
+  async function sendGlobal(text: string) {
+    const nextLogs: string[] = [];
+    add("assistant", "开始全球法布施。小程序版只使用 HTTP 全球公共端点，不提供法布施到平台。", "全球法布施");
+    for (const [index, region] of globalDharmaRegions.entries()) {
+      const endpoint = globalDharmaPublicEndpoints[index % globalDharmaPublicEndpoints.length];
+      try {
+        const response = await Taro.request({
+          url: endpoint.url,
+          method: "POST",
+          header: { "Content-Type": "application/json" },
+          data: { source: "dacheng-wechat", region, text, timestamp: Date.now() },
+          timeout: 12000,
+        });
+        nextLogs.push(`${response.statusCode < 400 ? "✓" : "!"} ${region} · ${endpoint.label}`);
+      } catch {
+        nextLogs.push(`! ${region} · ${endpoint.label} · 待重试`);
+      }
+      setLogs([...nextLogs]);
+    }
+    add("assistant", `全球法布施完成：已处理 ${globalDharmaRegions.length} 个地区。`, "全球法布施");
+  }
+
+  function makeDeck(text: string) {
+    const nextCards = makeCards(text);
+    setCards((items) => [...nextCards, ...items]);
+    setCardIndex(0);
+    setShowAnswer(false);
+    add("assistant", nextCards.length ? `已制作 ${nextCards.length} 张背诵闪卡。` : "内容太短，请补充正文后再制卡。", "背诵闪卡");
+  }
+
+  function submit() {
+    const text = input.trim() || "愿以此功德，普及于一切，我等与众生，皆共成佛道。";
+    setInput("");
+    add("user", text, activeTool?.title);
+    if (tool === "global-dharma") void sendGlobal(text);
+    else if (tool === "flashcards") makeDeck(text);
+    else add("assistant", "已收到。可以继续输入，或点 + 进入全球法布施和背诵闪卡。");
+  }
+
+  function review(label: string) {
+    if (!activeCard) return;
+    setCards((items) => items.map((card) => card.id === activeCard.id ? { ...card, due: label } : card));
+    setCardIndex((index) => cards.length ? (index + 1) % cards.length : 0);
+    setShowAnswer(false);
+  }
+
   return (
     <View className="page">
-      <View className="hero">
-        <Text className="eyebrow">Fabushi Mini Program</Text>
-        <Text className="title">大乘微信小程序</Text>
-        <Text className="subtitle">
-          {brand.tagline} 微信内先承接轻浏览、经文续读、修行计划和 AI 找资源。
-        </Text>
+      <View className="topbar">
+        <Text className="brand">大乘</Text>
+        <Button className="login">支付宝登录</Button>
       </View>
 
-      <View className="stats">
-        {appExperienceStats.map((item) => (
-          <View className="stat" key={item.label}>
-            <Text className="stat-value">{item.value}</Text>
-            <Text className="stat-label">
-              {item.label} · {item.unit}
-            </Text>
+      <View className="messages">
+        {messages.length <= 1 && (
+          <View className="empty">
+            <Text className="title">你在忙什么？</Text>
+            <Text className="subtitle">输入问题或正文；点击 + 选择全球法布施、背诵闪卡。</Text>
+            {dachengQuickPrompts.map((prompt) => (
+              <View className="quick" key={prompt} onClick={() => setInput(prompt)}>
+                <Text>{prompt}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+        {messages.map((message) => (
+          <View className={`message ${message.role}`} key={message.id}>
+            <Text className="avatar">{message.role === "user" ? "我" : "大"}</Text>
+            <Text className="bubble">{message.tag ? `${message.tag}：` : ""}{message.text}</Text>
           </View>
         ))}
       </View>
 
-      <View className="section">
-        <Text className="section-title">核心入口</Text>
-        {appModules.map((item) => (
-          <View key={item.id} className={`module module-${item.tone}`}>
-            <Text className="module-icon">{item.shortTitle}</Text>
-            <View className="module-body">
-              <Text className="card-title">{item.title}</Text>
-              <Text className="card-copy">{item.summary}</Text>
+      <View className="side-panels">
+        <View className="panel">
+          <Text className="panel-title">全球法布施</Text>
+          <Text className="panel-copy">Web 和小程序均不显示“法布施到平台”。</Text>
+          {(logs.length ? logs : ["等待发送任务"]).map((line) => <Text className="log" key={line}>{line}</Text>)}
+        </View>
+        <View className="panel">
+          <Text className="panel-title">背诵闪卡</Text>
+          <Text className="panel-copy">{cards.length ? `${cards.length} 张卡片` : "暂无卡片"}</Text>
+          {activeCard && (
+            <View className="flashcard">
+              <Text className="card-kind">{activeCard.kind} · {activeCard.due}</Text>
+              <Text className="card-front">{activeCard.front}</Text>
+              {showAnswer ? <Text className="card-back">{activeCard.back}</Text> : <Button onClick={() => setShowAnswer(true)}>显示答案</Button>}
+              <View className="reviews">
+                {remnoteInspiredFlashcardPrinciples.slice(0, 4).map((_, index) => {
+                  const labels = ["Again", "Hard", "Good", "Easy"];
+                  return <Button key={labels[index]} onClick={() => review(labels[index])}>{labels[index]}</Button>;
+                })}
+              </View>
             </View>
-          </View>
-        ))}
+          )}
+        </View>
       </View>
 
-      <View className="section">
-        <Text className="section-title">AI 快捷任务</Text>
-        {aiQuickPrompts.slice(0, 3).map((prompt) => (
-          <View className="prompt" key={prompt}>
-            <Text>{prompt}</Text>
-          </View>
-        ))}
-      </View>
+      {menuOpen && (
+        <View className="menu">
+          {dachengToolEntries.map((item) => (
+            <View className="menu-item" key={item.id} onClick={() => { setTool(item.id); setMenuOpen(false); }}>
+              <Text className="menu-title">{item.title}</Text>
+              <Text className="menu-copy">{item.description}</Text>
+            </View>
+          ))}
+        </View>
+      )}
 
-      <View className="section">
-        <Text className="section-title">今日法流</Text>
-        {dharmaFeedItems.map((item) => (
-          <View className="feed" key={item.title}>
-            <Text className="card-title">{item.title}</Text>
-            <Text className="card-copy">
-              {item.tag} · {item.readTime}
-            </Text>
-          </View>
-        ))}
+      <View className="composer">
+        <Button className="plus" onClick={() => setMenuOpen(!menuOpen)}>+</Button>
+        <Textarea className="input" value={input} maxlength={1800} onInput={(event) => setInput(event.detail.value)} placeholder="有问题，尽管问" />
+        {activeTool && <Button className="mode" onClick={() => setTool(null)}>{activeTool.shortTitle}×</Button>}
+        <Button className="send" onClick={submit}>发送</Button>
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- point the WeChat mini-program config to a single Dacheng chat entry
- replace the mini-program homepage with the same functional model as the Web chat: + menu, Global Dharma sharing, and recitation flashcards
- keep platform publishing absent from the mini-program surface

## Notes
- Builds on #821 after it merged through the queue.
- The mini-program Global Dharma flow uses the same shared HTTP public endpoint config as the Web entry.

## Tests
- Not run locally; changes were made through GitHub contents API.