### PR TITLE
fix(web): restore official site and keep fast web app

### DIFF
--- a/frontend/apps/web/src/app/app/layout.tsx
+++ b/frontend/apps/web/src/app/app/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import "../fast-home.css";
+
+export default function WebAppLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/frontend/apps/web/src/app/download/page.tsx
+++ b/frontend/apps/web/src/app/download/page.tsx
@@ -1,0 +1,552 @@
+import type { Metadata } from "next";
+import { brand, contactChannels } from "@fabushi/shared";
+import { DownloadClient } from "../../components/download-client";
+import type { DownloadChannel } from "../../components/download-client";
+import { DownloadLink } from "../../components/download-link";
+import { LocalizedText } from "../../components/localized-text";
+import { SiteFooter } from "../../components/site-footer";
+import { SiteHeader } from "../../components/site-header";
+import { GlobalNetworkGlobe } from "../../components/global-network-globe";
+import {
+  getOfficialSiteReleaseCollection,
+  type OfficialSiteChannel,
+} from "../../lib/official-site-releases";
+import {
+  getUserFacingDescription,
+  getUserFacingNote,
+  getUserFacingStatus,
+  getUserFacingSummary,
+} from "../../lib/channel-display";
+import { siteHref, siteUrl } from "../../lib/site-url";
+
+const downloadUrl = siteUrl("/download");
+const downloadTitle = `法布施大乘 App 下载 | iOS、Android、桌面版与安装说明 | ${brand.name}`;
+const downloadDescription =
+  "法布施大乘 App 下载页，集中提供 iOS、Android、macOS、Windows、Linux 下载入口、版本说明、安装步骤与常见下载问题。";
+
+const downloadFaqs = [
+  {
+    questionZh: "我应该下载测试版还是正式版？",
+    questionEn: "Should I choose beta or stable first?",
+    answerZh: "想尽快体验新版本或新功能，可以先看测试版；更在意稳定性，或准备长期使用，就优先看正式版。下载前先确认版本号和发布时间，会更稳。",
+    answerEn: "Choose beta if you want the newest build or features first. Choose stable if you care more about installation stability and long-term use. Checking the version number and publish date first is the steadier path.",
+  },
+  {
+    questionZh: "Android 下载慢或安装失败怎么办？",
+    questionEn: "What should I do if Android download is slow or installation fails?",
+    answerZh: "先重新点击当前卡片里的主下载入口，并确认自己下载的是对应平台和版本；如果仍然失败，把设备型号、系统版本和错误截图发到支持邮箱。",
+    answerEn: "Use the main download button on the current card again, then confirm that you downloaded the matching platform and version. If it still fails, send the device model, OS version, and an error screenshot to support.",
+  },
+  {
+    questionZh: "桌面版从哪里下载？",
+    questionEn: "Where can I download the desktop app?",
+    answerZh: "桌面版按 macOS、Windows、Linux 分开显示，下载按钮会打开对应的 GitHub Release 安装包；同一卡片里也保留备用压缩包格式。",
+    answerEn: "Desktop builds are listed separately for macOS, Windows, and Linux. Buttons open the matching GitHub Release installer, with alternate archive formats on the same card.",
+  },
+  {
+    questionZh: "iOS 会打开 TestFlight 还是 App Store？",
+    questionEn: "Will iOS open TestFlight or the App Store?",
+    answerZh: "iOS 测试版通过 Apple TestFlight 分发；iOS 正式版通过 App Store 安装。下载页会把两个入口分开显示，按你想要的版本选择即可。",
+    answerEn: "iOS beta builds are distributed through Apple TestFlight; the stable iOS release installs through the App Store. The download page separates both paths so you can choose the version you want.",
+  },
+] as const;
+
+const installSteps = [
+  {
+    titleZh: "先确认你的设备平台和版本偏好",
+    titleEn: "Confirm your device and version preference first",
+    descriptionZh: "iOS、Android 和桌面端入口分开显示；普通用户优先选择正式版，需要提前体验再看测试版。",
+    descriptionEn: "iOS, Android, and desktop paths are listed separately. Start with stable for ordinary use, or choose beta for early access.",
+  },
+  {
+    titleZh: "进入对应下载入口并完成安装",
+    titleEn: "Open the matching download path and install",
+    descriptionZh: "iOS 正式版会打开 App Store；桌面版会打开 GitHub Release 安装包；Android 测试版继续使用主下载入口。",
+    descriptionEn: "iOS stable opens the App Store. Desktop builds open GitHub Release installers, while Android beta keeps using the main download path.",
+  },
+  {
+    titleZh: "安装失败时先看 FAQ，再联系支持",
+    titleEn: "Check the FAQ first, then contact support if installation fails",
+    descriptionZh: "下载或安装异常时，先排查常见问题；仍然无法解决，再把设备信息和错误截图发给支持邮箱。",
+    descriptionEn: "If download or installation behaves unexpectedly, check the common questions first. If the issue remains, send device details and screenshots to support.",
+  },
+] as const;
+
+const DOWNLOAD_NOTES = [
+  {
+    zh: "下载前先确认平台、版本号和发布时间，避免下错包。",
+    en: "Check the platform, version, and publish date before downloading so you get the right build.",
+  },
+  {
+    zh: "iOS 正式版放在最前面，普通用户可直接进入 App Store。",
+    en: "The iOS stable release is listed first and opens the App Store directly.",
+  },
+  {
+    zh: "桌面版使用 GitHub Release 下载链接，按 macOS、Windows、Linux 分开显示。",
+    en: "Desktop builds use GitHub Release links and are split by macOS, Windows, and Linux.",
+  },
+  {
+    zh: "Android 测试版使用主下载入口，iOS 测试版通过 TestFlight 分发。",
+    en: "Android beta uses the main download path, while iOS beta is distributed through TestFlight.",
+  },
+] as const;
+
+export const metadata: Metadata = {
+  title: downloadTitle,
+  description: downloadDescription,
+  keywords: [
+    "法布施大乘 App 下载",
+    "Fabushi 下载",
+    "Android 下载",
+    "iOS 下载",
+    "macOS 下载",
+    "Windows 下载",
+    "Linux 下载",
+    "桌面版下载",
+    "TestFlight",
+    "安装说明",
+    "版本说明",
+    "佛教 app",
+  ],
+  alternates: {
+    canonical: downloadUrl,
+  },
+  openGraph: {
+    title: downloadTitle,
+    description: downloadDescription,
+    url: downloadUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: downloadTitle,
+    description: downloadDescription,
+  },
+};
+
+function formatPublishedAt(value?: string) {
+  if (!value) return null;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toISOString().slice(0, 10);
+}
+
+function getChannelActionCopy(channel: OfficialSiteChannel) {
+  if (channel.audience === "stable" && channel.primaryHref.startsWith("/contact")) {
+    return {
+      zh: "查看状态",
+      en: "View status",
+    };
+  }
+
+  if (channel.platform === "iOS") {
+    return {
+      zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
+      en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
+    };
+  }
+
+  if (channel.platform === "macOS") {
+    return {
+      zh: "下载 macOS 桌面版",
+      en: "Download macOS Desktop",
+    };
+  }
+
+  if (channel.platform === "Windows") {
+    return {
+      zh: "下载 Windows 桌面版",
+      en: "Download Windows Desktop",
+    };
+  }
+
+  if (channel.platform === "Linux") {
+    return {
+      zh: "下载 Linux 桌面版",
+      en: "Download Linux Desktop",
+    };
+  }
+
+  return {
+    zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
+    en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
+  };
+}
+
+function ReleaseChannelCard({ channel }: { channel: OfficialSiteChannel }) {
+  const publishedAt = formatPublishedAt(channel.publishedAt);
+  const summary = getUserFacingSummary(channel);
+  const actionCopy = getChannelActionCopy(channel);
+  const statusCopy = getUserFacingStatus(channel);
+  const descriptionCopy = getUserFacingDescription(channel);
+  const noteCopy = getUserFacingNote(channel);
+
+  return (
+    <article className="release-card">
+      <div className="release-card-header">
+        <div>
+          <p className="eyebrow">
+            <LocalizedText
+              zh={channel.audience === "beta" ? "测试版" : "正式版"}
+              en={channel.audience === "beta" ? "Beta" : "Stable"}
+            />
+          </p>
+          <h2>{channel.title}</h2>
+        </div>
+        <span className="download-status">
+          <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
+        </span>
+      </div>
+      <p>
+        <LocalizedText zh={descriptionCopy.zh} en={descriptionCopy.en} />
+      </p>
+      {(channel.version || publishedAt) && (
+        <div className="release-card-meta">
+          {channel.version ? (
+            <span>
+              <LocalizedText zh="版本" en="Version" /> v{channel.version}
+            </span>
+          ) : null}
+          {publishedAt ? (
+            <span>
+              <LocalizedText zh="发布时间" en="Published" /> {publishedAt}
+            </span>
+          ) : null}
+        </div>
+      )}
+      {summary.length > 0 ? (
+        <ul className="release-summary-list">
+          {summary.map((item) => (
+            <li key={item.en}>
+              <LocalizedText zh={item.zh} en={item.en} />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="release-card-actions">
+        <DownloadLink className="primary-action" channel={channel}>
+          <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
+        </DownloadLink>
+        {channel.mirrorLinks.map((link) => (
+          <a key={link.href} className="secondary-action compact-action" href={siteHref(link.href)}>
+            {link.label}
+          </a>
+        ))}
+        {channel.releasePageHref ? (
+          <a className="secondary-action compact-action" href={siteHref(channel.releasePageHref)}>
+            <LocalizedText zh="查看发布页" en="View release page" />
+          </a>
+        ) : null}
+      </div>
+      {noteCopy ? (
+        <p className="release-note">
+          <LocalizedText zh={noteCopy.zh} en={noteCopy.en} />
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
+export default async function DownloadPage() {
+  const releaseCollection = await getOfficialSiteReleaseCollection();
+  const stableChannels = releaseCollection.stableChannels;
+  const betaChannels = releaseCollection.betaChannels;
+  const allChannels = [...stableChannels, ...betaChannels];
+  const supportEmail =
+    contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name: "法布施大乘 App 下载",
+        url: downloadUrl,
+        description: downloadDescription,
+        inLanguage: "zh-CN",
+        isPartOf: {
+          "@type": "WebSite",
+          name: `${brand.name} Fabushi`,
+          url: siteUrl("/"),
+        },
+        about: ["App 下载", "iOS 下载", "Android 下载", "桌面版下载", "安装说明", "版本说明"],
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "首页",
+            item: siteUrl("/"),
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "下载 App",
+            item: downloadUrl,
+          },
+        ],
+      },
+      {
+        "@type": "SoftwareApplication",
+        name: `${brand.name} Fabushi`,
+        applicationCategory: "LifestyleApplication",
+        operatingSystem: "iOS, Android, macOS, Windows, Linux",
+        url: downloadUrl,
+        downloadUrl,
+        description: downloadDescription,
+      },
+      {
+        "@type": "ItemList",
+        itemListElement: allChannels.map((channel, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          item: {
+            "@type": "SoftwareApplication",
+            name: channel.title,
+            operatingSystem: channel.platform,
+            downloadUrl: siteHref(channel.primaryHref),
+            description: channel.description,
+          },
+        })),
+      },
+      {
+        "@type": "HowTo",
+        name: "法布施大乘 App 下载与安装步骤",
+        description: "先确认平台与版本，再选择下载入口，安装失败时先查 FAQ，再联系支持。",
+        step: installSteps.map((item, index) => ({
+          "@type": "HowToStep",
+          position: index + 1,
+          name: item.titleZh,
+          text: item.descriptionZh,
+          url: `${downloadUrl}#install-steps`,
+        })),
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: downloadFaqs.map((item) => ({
+          "@type": "Question",
+          name: item.questionZh,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answerZh,
+          },
+        })),
+      },
+    ],
+  };
+
+  return (
+    <main className="inner-page">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="inner-hero download-hero">
+        <SiteHeader />
+        <GlobalNetworkGlobe />
+        <div className="inner-copy">
+          <p className="eyebrow">
+            <LocalizedText zh="下载" en="Download" />
+          </p>
+          <h1>
+            <LocalizedText
+              zh="选对平台入口，再下载对应版本。"
+              en="Choose the right platform path before downloading the matching version."
+            />
+          </h1>
+          <p className="lede">
+            <LocalizedText
+              zh="这一页集中放置 iOS、Android、桌面版、版本说明和安装步骤，让下载路径更短。"
+              en="This page keeps iOS, Android, desktop releases, notes, and install steps in one place so the download path stays short."
+            />
+          </p>
+        </div>
+      </section>
+
+      <section className="band compact-band" id="stable-channels">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="下载" en="Download" />
+          </p>
+          <h2>
+            <LocalizedText zh="iOS 正式版在最前面，桌面版也都在这里。" en="iOS stable comes first, with every desktop build beside it." />
+          </h2>
+        </div>
+        <div className="download-grid">
+          {stableChannels.map((channel) => (
+            <ReleaseChannelCard key={`${channel.audience}-${channel.platform}`} channel={channel} />
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="beta-channels">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="测试版" en="Beta" />
+          </p>
+          <h2>
+            <LocalizedText zh="想提前体验，再看测试入口。" en="Use beta paths when you want early access." />
+          </h2>
+        </div>
+        {betaChannels.length > 0 ? (
+          <DownloadClient channels={betaChannels as DownloadChannel[]} />
+        ) : (
+          <div className="download-grid">
+            <article className="release-card">
+              <div className="release-card-header">
+                <div>
+                  <p className="eyebrow">
+                    <LocalizedText zh="测试版" en="Beta" />
+                  </p>
+                  <h2>
+                    <LocalizedText zh="测试资格整理中" en="Beta access is being prepared" />
+                  </h2>
+                </div>
+                <span className="download-status">
+                  <LocalizedText zh="暂未开放" en="Not open yet" />
+                </span>
+              </div>
+              <p>
+                <LocalizedText
+                  zh="当前还没有公开可点的测试入口。可以先提交测试申请。"
+                  en="There is no public beta button yet. You can still apply for access first."
+                />
+              </p>
+              <div className="release-card-actions">
+                <a className="primary-action" href={siteHref("/apply")}>
+                  <LocalizedText zh="申请测试" en="Apply" />
+                </a>
+              </div>
+            </article>
+          </div>
+        )}
+      </section>
+
+      <section className="band" id="install-steps">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="安装步骤" en="Install Steps" />
+          </p>
+          <h2>
+            <LocalizedText zh="按这三步走，下载与安装会更稳。" en="Follow these three steps for a steadier download and install flow." />
+          </h2>
+        </div>
+        <div className="editorial-list">
+          {installSteps.map((item, index) => (
+            <article key={item.titleEn} className="editorial-row">
+              <span>
+                <LocalizedText zh={`步骤 ${index + 1}`} en={`Step ${index + 1}`} />
+              </span>
+              <div>
+                <strong>
+                  <LocalizedText zh={item.titleZh} en={item.titleEn} />
+                </strong>
+                <p>
+                  <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="说明" en="Notes" />
+          </p>
+          <h2>
+            <LocalizedText zh="下载前只看这几条。" en="A few things worth checking before you download." />
+          </h2>
+        </div>
+        <div className="note-grid">
+          {DOWNLOAD_NOTES.map((item) => (
+            <p key={item.en}>
+              <LocalizedText zh={item.zh} en={item.en} />
+            </p>
+          ))}
+          <p>
+            <LocalizedText
+              zh={`遇到下载或安装问题，发邮件到 ${supportEmail}。`}
+              en={`If download or install fails, email ${supportEmail}.`}
+            />
+          </p>
+        </div>
+        <div className="inline-cta">
+          <a className="secondary-action" href={siteHref("/faq")}>
+            <LocalizedText zh="查看常见问题" en="View FAQ" />
+          </a>
+          <a className="secondary-action" href={`mailto:${supportEmail}`}>
+            <LocalizedText zh="联系支持" en="Contact support" />
+          </a>
+        </div>
+      </section>
+
+      <section className="band">
+        <div className="section-heading tight">
+          <p>FAQ</p>
+          <h2>
+            <LocalizedText zh="少一点犹豫。" en="Remove the last bit of hesitation." />
+          </h2>
+        </div>
+        <div className="faq-list full">
+          {downloadFaqs.map((item) => (
+            <details key={item.questionEn} className="faq-item">
+              <summary>
+                <LocalizedText zh={item.questionZh} en={item.questionEn} />
+              </summary>
+              <p>
+                <LocalizedText zh={item.answerZh} en={item.answerEn} />
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {releaseCollection.releases.length > 0 && (
+        <section className="band alt" id="release-changelog">
+          <div className="section-heading tight">
+            <p>
+              <LocalizedText zh="更新日志" en="Release log" />
+            </p>
+            <h2>
+              <LocalizedText zh="最近更新了什么。" en="What changed recently." />
+            </h2>
+          </div>
+          <div className="changelog-timeline">
+            {releaseCollection.releases.map((entry) => (
+              <article key={entry.tag} className="changelog-entry">
+                <div className="changelog-meta">
+                  <h3>{entry.title}</h3>
+                  <time dateTime={entry.publishedAt}>{formatPublishedAt(entry.publishedAt)}</time>
+                </div>
+                <div className="release-card-meta compact">
+                  <span>
+                    <LocalizedText zh="版本" en="Version" /> {entry.tag}
+                  </span>
+                </div>
+                {entry.summary.length > 0 && (
+                  <ul className="release-summary-list compact">
+                    {entry.summary.map((line, i) => (
+                      <li key={`${entry.tag}-${i}`}>{line}</li>
+                    ))}
+                  </ul>
+                )}
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/frontend/apps/web/src/app/globals.css
+++ b/frontend/apps/web/src/app/globals.css
@@ -1,62 +1,36 @@
 :root {
   color-scheme: dark;
   --bg: #05070d;
+  --bg-soft: #0c111a;
   --ink: #fff9eb;
+  --ink-dark: #11151d;
   --muted: #b9c5c7;
   --muted-strong: #dbe7e0;
+  --surface: rgba(15, 21, 30, 0.82);
+  --surface-strong: rgba(22, 30, 38, 0.94);
   --line: rgba(255, 249, 235, 0.14);
+  --line-strong: rgba(255, 249, 235, 0.28);
   --gold: #e8bd6b;
   --gold-soft: #ffe3a3;
   --cyan: #78d6e8;
+  --green: #9ed7bf;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
 }
 
 * {
   box-sizing: border-box;
 }
 
-html,
-body {
-  min-height: 100%;
+html {
+  scroll-behavior: smooth;
 }
 
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--ink);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-button,
-textarea {
-  font: inherit;
-}
-
-button {
-  cursor: pointer;
-}
-
-button,
-textarea {
-  -webkit-tap-highlight-color: transparent;
-}
-
-textarea {
-  resize: none;
-}
-
-.localized-text {
-  display: inline;
-}
-
-.locale-en {
+html:not([data-site-locale="en"]) .locale-en {
   display: none;
+}
+
+html:not([data-site-locale="en"]) .locale-zh {
+  display: inline;
 }
 
 html[data-site-locale="en"] .locale-zh {
@@ -67,14 +41,1213 @@ html[data-site-locale="en"] .locale-en {
   display: inline;
 }
 
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+}
+
+html[data-site-locale="en"] body {
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}
+
+img,
+canvas {
+  display: block;
+  max-width: 100%;
+}
+
 h1,
 h2,
 h3,
-p,
-pre {
+p {
   overflow-wrap: anywhere;
 }
 
-[hidden] {
-  display: none !important;
+h1,
+h2,
+h3,
+.site-wordmark span,
+.footer-title {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+.localized-text {
+  display: inline;
+}
+
+.page-shell,
+.inner-page {
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    linear-gradient(115deg, rgba(232, 189, 107, 0.08), transparent 34%),
+    linear-gradient(180deg, #05070d 0%, #0c111a 52%, #05070d 100%);
+}
+
+.hero,
+.band,
+.inner-hero,
+.article-body,
+.site-footer {
+  padding-left: clamp(18px, 4vw, 56px);
+  padding-right: clamp(18px, 4vw, 56px);
+}
+
+.hero {
+  position: relative;
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  padding-top: 16px;
+  padding-bottom: 34px;
+}
+
+.site-nav {
+  position: relative;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  width: 100%;
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.site-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: max-content;
+}
+
+.site-wordmark::before {
+  content: "法";
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(255, 249, 235, 0.2);
+  border-radius: 8px;
+  background: linear-gradient(145deg, rgba(255, 249, 235, 0.18), rgba(120, 214, 232, 0.12));
+  color: var(--gold-soft);
+  font-weight: 900;
+}
+
+.site-wordmark span {
+  display: block;
+  color: var(--ink);
+  font-size: 1.1rem;
+  font-weight: 850;
+}
+
+.site-wordmark small {
+  display: none;
+}
+
+.site-nav-links-wrap,
+.site-nav-links,
+.site-nav-actions,
+.hero-actions,
+.inline-cta,
+.release-card-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.site-nav-links-wrap {
+  flex: 1 1 auto;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.site-nav-actions {
+  margin-left: auto;
+}
+
+.site-nav-links {
+  color: rgba(255, 249, 235, 0.68);
+  font-size: 0.94rem;
+}
+
+.site-nav-links a {
+  transition: color 180ms ease;
+}
+
+.site-nav-links a:hover {
+  color: var(--ink);
+}
+
+.language-switch {
+  position: relative;
+}
+
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.06);
+  color: var(--gold-soft);
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background-color 180ms ease;
+}
+
+.language-toggle:hover,
+.language-toggle[aria-expanded="true"] {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+  background: rgba(255, 249, 235, 0.1);
+}
+
+.language-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.language-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  min-width: 152px;
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(12, 17, 26, 0.96);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.language-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 40px;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted-strong);
+  cursor: pointer;
+  transition: background-color 180ms ease, color 180ms ease;
+}
+
+.language-option:hover,
+.language-option.active {
+  background: rgba(232, 189, 107, 0.16);
+  color: var(--gold-soft);
+}
+
+.nav-cta,
+.primary-action,
+.secondary-action,
+.path-link,
+.tertiary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  border-radius: 999px;
+  padding: 10px 18px;
+  border: 1px solid transparent;
+  font-weight: 800;
+  line-height: 1.2;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.nav-cta,
+.primary-action,
+.path-link {
+  background: linear-gradient(135deg, var(--gold), #ffe2a5);
+  color: var(--ink-dark);
+  box-shadow: 0 10px 30px rgba(232, 189, 107, 0.22);
+}
+
+.secondary-action,
+.tertiary-action {
+  background: rgba(255, 249, 235, 0.08);
+  border-color: var(--line);
+  color: var(--ink);
+}
+
+.compact-action {
+  min-height: 36px;
+  padding: 8px 13px;
+  font-size: 0.88rem;
+}
+
+.nav-cta:hover,
+.primary-action:hover,
+.secondary-action:hover,
+.path-link:hover,
+.tertiary-action:hover {
+  transform: translateY(-1px);
+}
+
+.hero-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(360px, 0.82fr);
+  align-items: center;
+  gap: clamp(32px, 6vw, 74px);
+  width: 100%;
+  max-width: 1220px;
+  margin: auto;
+  padding-top: 28px;
+}
+
+.hero-copy {
+  display: grid;
+  align-content: center;
+  gap: 22px;
+  min-width: 0;
+}
+
+.brand-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  width: max-content;
+  max-width: 100%;
+  padding: 8px 12px 8px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.06);
+  color: var(--gold-soft);
+  font-weight: 800;
+}
+
+.brand-kicker img {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+}
+
+.hero-copy h1 {
+  color: var(--ink);
+  font-size: clamp(4.2rem, 11vw, 8.4rem);
+  line-height: 0.9;
+  font-weight: 900;
+}
+
+.hero-title-line {
+  display: block;
+}
+
+.hero-subtitle,
+.lede {
+  margin: 0;
+  max-width: 680px;
+  color: var(--muted-strong);
+  font-size: clamp(1.08rem, 2vw, 1.48rem);
+  line-height: 1.65;
+}
+
+.hero-actions {
+  margin-top: 2px;
+}
+
+.home-faliu-search {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  width: min(100%, 640px);
+  min-height: 58px;
+  padding: 0 12px 0 18px;
+  border: 1px solid rgba(255, 249, 235, 0.2);
+  border-radius: 8px;
+  background: rgba(255, 249, 235, 0.08);
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.24);
+}
+
+.home-faliu-search-icon {
+  position: relative;
+  width: 17px;
+  height: 17px;
+  border: 3px solid rgba(255, 249, 235, 0.76);
+  border-radius: 999px;
+}
+
+.home-faliu-search-icon::after {
+  content: "";
+  position: absolute;
+  right: -7px;
+  bottom: -5px;
+  width: 8px;
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.76);
+  transform: rotate(45deg);
+}
+
+.home-faliu-search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ink);
+  font-size: 1rem;
+}
+
+.home-faliu-search input::placeholder {
+  color: rgba(255, 249, 235, 0.48);
+}
+
+.home-faliu-search button {
+  min-height: 40px;
+  padding: 0 18px;
+  border: 1px solid rgba(255, 249, 235, 0.16);
+  border-radius: 8px;
+  background: rgba(120, 214, 232, 0.14);
+  color: #ffffff;
+  font-weight: 820;
+  cursor: pointer;
+}
+
+.release-pill-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  width: min(100%, 780px);
+}
+
+.release-pill {
+  display: grid;
+  gap: 8px;
+  min-height: 108px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 249, 235, 0.06);
+}
+
+.release-pill span,
+.platform-name,
+.download-status,
+.eyebrow,
+.section-heading p,
+.article-date,
+.detail-label {
+  display: block;
+  margin: 0 0 8px;
+  color: var(--gold-soft);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.release-pill strong {
+  display: block;
+  color: var(--ink);
+  line-height: 1.35;
+}
+
+.release-pill small,
+.release-pill em,
+.platform-detail-line,
+.release-note,
+.recommended-tag {
+  color: var(--muted);
+  font-style: normal;
+  font-size: 0.88rem;
+}
+
+.release-pill small,
+.release-pill em {
+  display: block;
+  line-height: 1.4;
+}
+
+.hero-visual {
+  position: relative;
+  min-height: 560px;
+  display: grid;
+  place-items: center;
+}
+
+.zen-orbit {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  opacity: 0.96;
+  filter: saturate(1.05);
+}
+
+.zen-orbit canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.global-network-globe {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  opacity: 0.98;
+  filter: saturate(1.02);
+}
+
+.global-network-globe canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.global-network-tooltip {
+  position: absolute;
+  z-index: 3;
+  min-width: 138px;
+  max-width: 210px;
+  transform: translate(-50%, calc(-100% - 14px));
+  pointer-events: none;
+  border: 1px solid rgba(247, 142, 53, 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 14px 38px rgba(17, 24, 39, 0.16);
+  color: #111827;
+  padding: 8px 11px 9px;
+}
+
+.global-network-tooltip strong,
+.global-network-tooltip span,
+.global-network-tooltip em {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.global-network-tooltip strong {
+  font-size: 0.78rem;
+  line-height: 1.25;
+}
+
+.global-network-tooltip span {
+  margin-top: 3px;
+  color: #4b5563;
+  font-size: 0.68rem;
+  font-weight: 600;
+}
+
+.global-network-tooltip em {
+  margin-top: 4px;
+  color: #f78e35;
+  font-size: 0.66rem;
+  font-style: normal;
+  font-weight: 800;
+}
+
+.phone-stack {
+  position: relative;
+  z-index: 2;
+  width: min(88vw, 430px);
+  min-height: 540px;
+}
+
+.phone-frame {
+  position: absolute;
+  overflow: hidden;
+  border: 1px solid rgba(255, 249, 235, 0.2);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(255, 249, 235, 0.06), rgba(5, 7, 13, 0.94)),
+    #0b0e13;
+  box-shadow: var(--shadow);
+  padding: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.phone-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  border-radius: 18px;
+}
+
+.poster-frame {
+  backdrop-filter: blur(6px);
+}
+
+.main-phone {
+  inset: 0 auto auto 42px;
+  width: 270px;
+  aspect-ratio: 480 / 1040;
+}
+
+.side-phone {
+  right: 6px;
+  bottom: 12px;
+  width: 190px;
+  aspect-ratio: 480 / 1040;
+  transform: rotate(4deg);
+  opacity: 0.98;
+}
+
+.band,
+.inner-hero {
+  background: #05070d;
+  padding-top: clamp(64px, 9vw, 112px);
+  padding-bottom: clamp(64px, 9vw, 112px);
+}
+
+.compact-band {
+  padding-top: clamp(48px, 7vw, 78px);
+  padding-bottom: clamp(48px, 7vw, 78px);
+}
+
+.band.alt,
+.feature-band,
+.faq-band {
+  background:
+    linear-gradient(180deg, rgba(120, 214, 232, 0.06), transparent 38%),
+    #080c12;
+}
+
+.inner-hero {
+  position: relative;
+  min-height: 46svh;
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+}
+
+.download-hero .zen-orbit,
+.download-hero .global-network-globe {
+  left: auto;
+  width: min(46vw, 520px);
+  opacity: 0.66;
+  z-index: 0;
+}
+
+.download-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(90deg, #05070d 0%, rgba(5, 7, 13, 0.96) 48%, rgba(5, 7, 13, 0.58) 100%);
+}
+
+.download-hero .inner-copy {
+  z-index: 2;
+}
+
+.inner-copy,
+.section-heading,
+.article-body {
+  max-width: 920px;
+}
+
+.inner-copy {
+  position: relative;
+  z-index: 1;
+  padding-top: clamp(58px, 10vh, 110px);
+}
+
+.inner-copy h1,
+.section-heading h2 {
+  max-width: 820px;
+  color: var(--ink);
+  font-size: clamp(2.35rem, 5vw, 5.4rem);
+  line-height: 1.02;
+}
+
+.section-heading {
+  margin-bottom: 28px;
+}
+
+.section-heading.tight h2 {
+  font-size: clamp(2rem, 4vw, 3.8rem);
+}
+
+.platform-strip,
+.faq-list,
+.editorial-list,
+.release-section-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.feature-grid,
+.moment-grid,
+.download-grid,
+.application-grid,
+.contact-grid,
+.governance-grid,
+.note-grid,
+.definition-grid,
+.path-grid,
+.evidence-grid,
+.compare-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px;
+}
+
+.showcase-grid {
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.platform-row,
+.feature-card,
+.moment-card,
+.release-card,
+.application-card,
+.contact-card,
+.governance-card,
+.faq-item,
+.editorial-row,
+.definition-card,
+.path-card,
+.evidence-card,
+.compare-card,
+.note-grid p {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.platform-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 18px;
+  padding: 20px;
+}
+
+.platform-row.detailed {
+  align-items: start;
+}
+
+.platform-row.accent-row {
+  background:
+    linear-gradient(135deg, rgba(232, 189, 107, 0.15), rgba(120, 214, 232, 0.06)),
+    var(--surface);
+}
+
+.platform-row p,
+.feature-card p,
+.moment-card p,
+.release-card p,
+.release-note,
+.application-card p,
+.application-list,
+.contact-card p,
+.governance-card p,
+.faq-item p,
+.editorial-row p,
+.article-body p,
+.article-body li,
+.definition-card p,
+.path-card p,
+.evidence-card p,
+.compare-card p,
+.note-grid p,
+.platform-summary-list li,
+.release-summary-list li,
+.changelog-entry li,
+.changelog-meta time {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.72;
+}
+
+.platform-meta {
+  min-width: 150px;
+  text-align: right;
+}
+
+.platform-mirror-links {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.platform-meta strong {
+  display: block;
+  color: var(--ink);
+}
+
+.platform-meta span,
+.editorial-row small {
+  color: var(--muted);
+}
+
+.platform-detail-line,
+.release-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.platform-summary-list,
+.release-summary-list {
+  margin: 12px 0 0;
+  padding-left: 18px;
+}
+
+.platform-summary-list.compact,
+.release-summary-list.compact {
+  margin-top: 8px;
+}
+
+.feature-card,
+.moment-card,
+.release-card,
+.application-card,
+.contact-card,
+.governance-card,
+.definition-card,
+.path-card,
+.evidence-card,
+.compare-card {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  padding: 22px;
+}
+
+.feature-card h3,
+.moment-card h3,
+.release-card h2,
+.application-card h2,
+.contact-card strong,
+.governance-card h3,
+.editorial-row strong,
+.definition-card h3,
+.path-card h3,
+.evidence-card strong,
+.compare-card h3 {
+  color: var(--ink);
+  font-size: 1.18rem;
+  line-height: 1.34;
+}
+
+.homepage-release-card {
+  max-width: 820px;
+}
+
+.moment-card {
+  overflow: hidden;
+  padding: 0;
+}
+
+.moment-image {
+  aspect-ratio: 480 / 1040;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top, rgba(232, 189, 107, 0.12), transparent 52%),
+    linear-gradient(180deg, rgba(255, 249, 235, 0.04), rgba(12, 17, 26, 0.96));
+  padding: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.moment-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  border-radius: 18px;
+}
+
+.moment-card h3,
+.moment-card p {
+  padding-left: 18px;
+  padding-right: 18px;
+}
+
+.moment-card h3 {
+  padding-top: 18px;
+}
+
+.moment-card p {
+  padding-bottom: 20px;
+}
+
+.release-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.download-status {
+  width: max-content;
+  max-width: 180px;
+  height: max-content;
+  margin: 0;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(232, 189, 107, 0.1);
+  color: var(--gold-soft);
+  text-align: center;
+}
+
+.release-card-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.release-card-meta.compact {
+  font-size: 0.82rem;
+}
+
+.application-list {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.application-list li + li {
+  margin-top: 8px;
+}
+
+.contact-card span {
+  color: var(--gold-soft);
+}
+
+.note-grid p {
+  padding: 18px;
+}
+
+.faq-item {
+  padding: 20px 22px;
+}
+
+.faq-item summary {
+  cursor: pointer;
+  list-style: none;
+  color: var(--ink);
+  font-weight: 850;
+}
+
+.faq-item p {
+  margin-top: 10px;
+  max-width: 70rem;
+}
+
+.inline-cta {
+  margin-top: 26px;
+}
+
+.recommended-banner,
+.section-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 249, 235, 0.04);
+  color: var(--muted-strong);
+}
+
+.section-divider {
+  justify-content: center;
+}
+
+.recommended-tag {
+  margin-left: 6px;
+  color: var(--gold-soft);
+}
+
+.editorial-row {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+  padding: 22px;
+}
+
+.editorial-row span {
+  color: var(--gold-soft);
+}
+
+.article-body {
+  padding-top: 8px;
+  padding-bottom: 64px;
+}
+
+.article-body p {
+  margin-bottom: 18px;
+  font-size: 1.05rem;
+}
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding-top: 30px;
+  padding-bottom: 44px;
+  border-top: 1px solid var(--line);
+  background: #05070d;
+}
+
+.footer-title {
+  margin: 0 0 6px;
+  font-weight: 850;
+}
+
+.footer-copy {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+@media (max-width: 1020px) {
+  .hero-grid {
+    grid-template-columns: minmax(0, 1fr);
+    padding-top: 54px;
+  }
+
+  .hero-visual {
+    min-height: 470px;
+  }
+
+  .phone-stack {
+    min-height: 470px;
+  }
+
+  .main-phone {
+    left: 50%;
+    width: 232px;
+    transform: translateX(-62%);
+  }
+
+  .side-phone {
+    right: 16%;
+    width: 158px;
+  }
+}
+
+@media (max-width: 760px) {
+  .hero {
+    min-height: auto;
+  }
+
+  .site-nav,
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-nav-links-wrap {
+    width: 100%;
+    align-items: flex-start;
+    gap: 14px;
+  }
+
+  .site-nav-actions {
+    margin-left: auto;
+  }
+
+  .site-nav-links {
+    width: 100%;
+    gap: 10px;
+    font-size: 0.9rem;
+  }
+
+  .nav-cta {
+    display: none;
+  }
+
+  .hero-copy h1 {
+    font-size: clamp(4rem, 23vw, 6.2rem);
+  }
+
+  .home-faliu-search {
+    grid-template-columns: 22px minmax(0, 1fr);
+    padding: 10px 12px 12px;
+  }
+
+  .home-faliu-search button {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .release-pill-grid,
+  .platform-row,
+  .editorial-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .release-pill {
+    min-height: 88px;
+  }
+
+  .platform-meta {
+    min-width: 0;
+    text-align: left;
+  }
+
+  .platform-mirror-links {
+    justify-content: flex-start;
+  }
+
+  .hero-visual {
+    min-height: 390px;
+  }
+
+  .phone-stack {
+    width: 100%;
+    min-height: 390px;
+  }
+
+  .main-phone {
+    width: 194px;
+    left: 46%;
+  }
+
+  .side-phone {
+    right: 6%;
+    bottom: 10px;
+    width: 124px;
+  }
+
+  .download-hero {
+    min-height: 64svh;
+  }
+
+  .download-hero .zen-orbit,
+  .download-hero .global-network-globe {
+    inset: auto -24vw 0 auto;
+    width: min(92vw, 420px);
+    height: 54%;
+    opacity: 0.42;
+  }
+
+  .download-hero::after {
+    background:
+      linear-gradient(180deg, #05070d 0%, rgba(5, 7, 13, 0.94) 48%, rgba(5, 7, 13, 0.74) 100%),
+      linear-gradient(90deg, #05070d 0%, rgba(5, 7, 13, 0.9) 62%, rgba(5, 7, 13, 0.48) 100%);
+  }
+
+  .release-card-header {
+    flex-direction: column;
+  }
+}
+
+.changelog-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.changelog-entry {
+  position: relative;
+  padding: 28px 0 28px 32px;
+  border-left: 2px solid rgba(255, 249, 235, 0.12);
+}
+
+.changelog-entry:last-child {
+  border-left-color: transparent;
+}
+
+.changelog-entry::before {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 34px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--gold);
+}
+
+.changelog-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.changelog-meta h3 {
+  font-size: 1.1rem;
+  font-weight: 680;
+  margin: 0;
+  color: var(--ink);
+}
+
+.changelog-meta h3 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.changelog-meta h3 a:hover {
+  text-decoration: underline;
+}
+
+.changelog-meta time {
+  font-size: 0.85rem;
+}
+
+.changelog-entry .secondary-action {
+  display: inline-block;
+  font-size: 0.88rem;
+  margin-top: 8px;
+}
+
+@media (max-width: 720px) {
+  .changelog-entry {
+    padding: 20px 0 20px 24px;
+  }
+
+  .changelog-meta {
+    flex-direction: column;
+    gap: 4px;
+  }
 }

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -1,56 +1,76 @@
 import type { ReactNode } from "react";
-import type { Metadata, Viewport } from "next";
-import { dachengBrand } from "@fabushi/shared";
+import type { Metadata } from "next";
+import { brand } from "@fabushi/shared";
+import { LocaleProvider } from "../components/locale-provider";
 import { siteUrl } from "../lib/site-url";
 import "./globals.css";
-import "./fast-home.css";
 
 const homeUrl = siteUrl("/");
-const siteTitle = `${dachengBrand.name} | 极速首页`;
-const siteDescription = "大乘 Web 首页提供对话、全球法布施和背诵闪卡，使用静态首屏和轻量交互。";
+const siteTitle = `${brand.name} | 全球法布施 App 下载官网`;
+const siteDescription =
+  "Fabushi 官网只服务 App 下载与安装转化，提供 iOS、Android 与桌面版下载入口、版本说明、安装支持、下载 FAQ 与基础隐私信息。";
 
 export const metadata: Metadata = {
   title: siteTitle,
   description: siteDescription,
-  applicationName: dachengBrand.name,
-  authors: [{ name: dachengBrand.name }],
-  creator: dachengBrand.name,
-  publisher: dachengBrand.name,
+  keywords: [
+    "Fabushi",
+    "法布施",
+    "全球法布施",
+    "App 下载",
+    "iOS 下载",
+    "Android 下载",
+    "macOS 下载",
+    "Windows 下载",
+    "Linux 下载",
+    "桌面版下载",
+    "TestFlight",
+    "APK 下载",
+    "下载 FAQ",
+    "安装支持",
+  ],
+  applicationName: `${brand.name} Fabushi`,
+  authors: [{ name: "Fabushi" }],
+  creator: "Fabushi",
+  publisher: "Fabushi",
   metadataBase: new URL(homeUrl),
   alternates: {
     canonical: homeUrl,
   },
-  keywords: ["大乘", "全球法布施", "背诵闪卡", "极速 Web", "小程序"],
+  category: "utilities",
+  manifest: siteUrl("/manifest.webmanifest"),
   openGraph: {
     title: siteTitle,
     description: siteDescription,
     url: homeUrl,
-    siteName: dachengBrand.name,
+    siteName: "Fabushi",
     locale: "zh_CN",
     type: "website",
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: siteTitle,
     description: siteDescription,
   },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
-};
-
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 1,
-  viewportFit: "cover",
-  themeColor: "#0b1117",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="zh-CN">
-      <body>{children}</body>
+    <html lang="zh-CN" suppressHydrationWarning>
+      <body>
+        <LocaleProvider>{children}</LocaleProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,36 +1,586 @@
 import type { Metadata } from "next";
-import { dachengBrand } from "@fabushi/shared";
-import { FastDachengHome } from "../components/fast-dacheng-home";
-import { siteUrl } from "../lib/site-url";
+import { brand, contactChannels } from "@fabushi/shared";
+import { DownloadLink } from "../components/download-link";
+import { LocalizedText } from "../components/localized-text";
+import { SiteFooter } from "../components/site-footer";
+import { SiteHeader } from "../components/site-header";
+import {
+  FALLBACK_SCREENSHOTS,
+  getOfficialSiteReleaseCollection,
+  type OfficialSiteChannel,
+  type OfficialSiteScreenshots,
+} from "../lib/official-site-releases";
+import {
+  getUserFacingDescription,
+  getUserFacingStatus,
+} from "../lib/channel-display";
+import { siteHref, siteUrl } from "../lib/site-url";
 
+const SCREENSHOT_KEYS = [
+  "global-dharma",
+  "start-meditation",
+  "immersive-meditation",
+  "main-sutra",
+  "group-practice",
+  "global-ranking",
+  "global-donation",
+  "global-donation-leaderboard",
+] as const;
+type ProductScreenshotKey = (typeof SCREENSHOT_KEYS)[number];
+
+interface ProductScreenshot {
+  titleZh: string;
+  titleEn: string;
+  descriptionZh: string;
+  descriptionEn: string;
+  screenshot: ProductScreenshotKey;
+  alt: string;
+}
+
+const HERO_MAIN_IMAGE_KEY: ProductScreenshotKey = "global-dharma";
+const HERO_SIDE_IMAGE_KEY: ProductScreenshotKey = "main-sutra";
 const homeUrl = siteUrl("/");
-const title = `${dachengBrand.name} | 全球法布施与背诵闪卡`;
-const description = "大乘 Web 首页只保留对话、全球法布施和背诵闪卡，首屏使用轻量静态界面。";
+const homeTitle = `全球法布施 App 下载官网 | ${brand.name}`;
+const homeDescription =
+  "全球法布施是法布施大乘 App 的下载官网，集中展示下载入口、核心界面、版本说明、安装支持与下载 FAQ。";
 
-export const dynamic = "force-static";
+const APP_SCREENSHOTS: ProductScreenshot[] = [
+  {
+    titleZh: "全球法布施总览",
+    titleEn: "Global Dharma Overview",
+    descriptionZh: "把法布施、修行和听诵等核心功能收在同一套界面里。",
+    descriptionEn: "Keep giving, practice, and listening inside one core interface.",
+    screenshot: "global-dharma",
+    alt: "Fabushi global dharma overview screenshot",
+  },
+  {
+    titleZh: "开始禅修",
+    titleEn: "Start Meditation",
+    descriptionZh: "更轻地进入一次练习，不需要先做复杂设置。",
+    descriptionEn: "Enter a session lightly without a complex setup first.",
+    screenshot: "start-meditation",
+    alt: "Fabushi start meditation screenshot",
+  },
+  {
+    titleZh: "沉浸式练习",
+    titleEn: "Immersive Practice",
+    descriptionZh: "让一次安静练习更容易稳定留下来。",
+    descriptionEn: "Make a quiet session easier to sustain.",
+    screenshot: "immersive-meditation",
+    alt: "Fabushi immersive meditation screenshot",
+  },
+  {
+    titleZh: "主修功课",
+    titleEn: "Main Practice",
+    descriptionZh: "把当前最重要的功课固定在自己眼前。",
+    descriptionEn: "Keep the main practice path visible every day.",
+    screenshot: "main-sutra",
+    alt: "Fabushi main practice screenshot",
+  },
+  {
+    titleZh: "共修小组",
+    titleEn: "Group Practice",
+    descriptionZh: "把申请、加入和共修关系放回一条清楚的路径里。",
+    descriptionEn: "Keep applying, joining, and practicing together on one clear path.",
+    screenshot: "group-practice",
+    alt: "Fabushi group practice screenshot",
+  },
+  {
+    titleZh: "全球修行排行",
+    titleEn: "Global Rankings",
+    descriptionZh: "更直观看见修行进度与同行者节奏。",
+    descriptionEn: "See progress and community rhythm more clearly.",
+    screenshot: "global-ranking",
+    alt: "Fabushi global rankings screenshot",
+  },
+  {
+    titleZh: "全球法布施入口",
+    titleEn: "Giving Entry",
+    descriptionZh: "把善意送往世界各地，而不是只停在本地。",
+    descriptionEn: "Let giving travel farther than one local circle.",
+    screenshot: "global-donation",
+    alt: "Fabushi global donation screenshot",
+  },
+  {
+    titleZh: "法布施榜单",
+    titleEn: "Giving Leaderboard",
+    descriptionZh: "看见法布施参与的持续性与回响。",
+    descriptionEn: "See the continuity and response around giving.",
+    screenshot: "global-donation-leaderboard",
+    alt: "Fabushi donation leaderboard screenshot",
+  },
+] as const;
+
+const PRODUCT_BENEFITS = [
+  {
+    titleZh: "把修行入口留在手机里",
+    titleEn: "Keep practice close at hand",
+    descriptionZh: "禅修、听诵、佛经与日常节奏可以在同一个 App 里接起来，不需要来回切换很多工具。",
+    descriptionEn: "Meditation, listening, sutras, and daily rhythm stay in one app instead of across many tools.",
+  },
+  {
+    titleZh: "先看懂核心界面，再决定要不要下载",
+    titleEn: "See the product before you install",
+    descriptionZh: "首页直接把关键界面完整摆出来，让人先看清真实体验，而不是只看口号。",
+    descriptionEn: "The homepage shows the key screens up front so people can inspect the actual experience first.",
+  },
+  {
+    titleZh: "下载、支持与版本信息放在同一条线里",
+    titleEn: "Download, support, and release info stay together",
+    descriptionZh: "正式版、测试版、下载说明和支持方式都留在官网，不让安装过程变成找入口。",
+    descriptionEn: "Stable, beta, download notes, and support all stay on the site so installation does not turn into a hunt.",
+  },
+] as const;
+
+const HOME_FAQS = [
+  {
+    questionZh: "首页现在最适合先做什么？",
+    questionEn: "What is the homepage best for now?",
+    answerZh: "首页现在主要承担四件事：说明 App 是什么、促成下载、完整展示核心界面，以及给出最基础的支持与信任信息。非下载型栏目入口已经从官网主入口移除。",
+    answerEn: "The homepage now focuses on four jobs: explain the app, support download, show the core screens, and provide basic support and trust signals. Non-download sections have been removed from the main site entry.",
+  },
+  {
+    questionZh: "我应该从首页直接下载，还是先去下载页？",
+    questionEn: "Should I download from the homepage or open the download page first?",
+    answerZh: "如果你已经知道自己要安装，可以直接从首页进入下载；如果你还想看版本、R2 下载状态和更新说明，再继续进入独立下载页会更稳。",
+    answerEn: "If you already know you want to install, the homepage is enough to start. If you want version notes, R2 download status, and release details first, the dedicated download page is the steadier next step.",
+  },
+  {
+    questionZh: "官网为什么不再把首页做成资讯或内容门户？",
+    questionEn: "Why is the homepage no longer treated like a news or content portal?",
+    answerZh: "因为首页权重最高，也最直接影响下载转化。把资讯和学习类分流入口移除后，首页主体可以更专注地把产品说清楚、把下载链路做顺。",
+    answerEn: "Because the homepage carries the strongest authority and the clearest download intent. Once news and learning detours are removed, the homepage body can focus on product clarity and conversion.",
+  },
+] as const;
+
+function resolveScreenshot(screenshots: OfficialSiteScreenshots, key: ProductScreenshotKey) {
+  return screenshots[key] ?? FALLBACK_SCREENSHOTS[key];
+}
+
+function formatPublishedAt(value?: string) {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+function getChannelActionCopy(channel: OfficialSiteChannel) {
+  if (channel.platform === "iOS") {
+    return {
+      zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
+      en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
+    };
+  }
+
+  if (channel.platform === "macOS") {
+    return {
+      zh: "下载 macOS 桌面版",
+      en: "Download macOS Desktop",
+    };
+  }
+
+  if (channel.platform === "Windows") {
+    return {
+      zh: "下载 Windows 桌面版",
+      en: "Download Windows Desktop",
+    };
+  }
+
+  if (channel.platform === "Linux") {
+    return {
+      zh: "下载 Linux 桌面版",
+      en: "Download Linux Desktop",
+    };
+  }
+
+  return {
+    zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
+    en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
+  };
+}
 
 export const metadata: Metadata = {
-  title,
-  description,
+  title: homeTitle,
+  description: homeDescription,
   alternates: {
     canonical: homeUrl,
   },
-  keywords: ["大乘", "全球法布施", "背诵闪卡", "极速 Web", "小程序"],
+  keywords: [
+    "全球法布施",
+    "法布施大乘",
+    "Fabushi app",
+    "佛教 app 下载",
+    "禅修 app",
+    "佛经听诵 app",
+    "iOS TestFlight",
+    "Android APK",
+    "macOS 下载",
+    "Windows 下载",
+    "Linux 下载",
+  ],
   openGraph: {
-    title,
-    description,
+    title: homeTitle,
+    description: homeDescription,
     url: homeUrl,
-    siteName: dachengBrand.name,
+    siteName: "Fabushi",
     locale: "zh_CN",
     type: "website",
   },
   twitter: {
-    card: "summary",
-    title,
-    description,
+    card: "summary_large_image",
+    title: homeTitle,
+    description: homeDescription,
   },
 };
 
-export default function HomePage() {
-  return <FastDachengHome />;
+export default async function HomePage() {
+  const releaseCollection = await getOfficialSiteReleaseCollection();
+  const screenshots = {
+    ...FALLBACK_SCREENSHOTS,
+    ...releaseCollection.screenshots,
+  };
+  const channels = [...releaseCollection.stableChannels, ...releaseCollection.betaChannels].slice(0, 2);
+  const supportEmail =
+    contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
+  const latestRelease = releaseCollection.releases[0] ?? null;
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        name: "全球法布施首页",
+        url: homeUrl,
+        description: homeDescription,
+        inLanguage: "zh-CN",
+        isPartOf: {
+          "@type": "WebSite",
+          name: `${brand.name} Fabushi`,
+          url: homeUrl,
+        },
+      },
+      {
+        "@type": "Organization",
+        name: `${brand.name} Fabushi`,
+        url: homeUrl,
+        email: supportEmail,
+        description: "Fabushi offers meditation, listening, and global giving in one downloadable app.",
+      },
+      {
+        "@type": "SoftwareApplication",
+        name: `${brand.name} Fabushi`,
+        applicationCategory: "LifestyleApplication",
+        operatingSystem: "iOS, Android, macOS, Windows, Linux",
+        downloadUrl: siteUrl("/download"),
+        description: homeDescription,
+        screenshot: APP_SCREENSHOTS.map((item) => siteUrl(resolveScreenshot(screenshots, item.screenshot))),
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: HOME_FAQS.map((item) => ({
+          "@type": "Question",
+          name: item.questionZh,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answerZh,
+          },
+        })),
+      },
+    ],
+  };
+
+  return (
+    <main className="page-shell">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <header className="hero">
+        <SiteHeader />
+        <div className="hero-grid">
+          <section className="hero-copy" aria-labelledby="home-title">
+            <div className="brand-kicker">
+              <img src={siteHref("/product/app-icon.png")} alt="" />
+              <span>
+                <LocalizedText zh="法布施大乘 App" en="Fabushi App" />
+              </span>
+            </div>
+            <h1 id="home-title">
+              <LocalizedText
+                zh={
+                  <>
+                    <span className="hero-title-line">全球</span>
+                    <span className="hero-title-line">法布施</span>
+                  </>
+                }
+                en="Global Dharma Sharing"
+              />
+            </h1>
+            <p className="hero-subtitle">
+              <LocalizedText
+                zh="用一个 App 连接经文听诵、禅修记录、法流学习与全球法布施。"
+                en="One app for sutra listening, meditation records, Dharma learning, and global giving."
+              />
+            </p>
+            <div className="hero-actions">
+              <a className="primary-action" href={siteHref("/app")}>
+                <LocalizedText zh="打开 Web 版" en="Open Web App" />
+              </a>
+              <a className="secondary-action" href={siteHref("/app/ai")}>
+                <LocalizedText zh="进入大乘 AI" en="Open Dacheng AI" />
+              </a>
+              <a className="secondary-action" href={siteHref("/download")}>
+                <LocalizedText zh="下载 App" en="Download App" />
+              </a>
+            </div>
+            <div className="release-pill-grid" aria-label="Quick service entry / 服务入口">
+              {channels.length > 0 ? (
+                channels.map((item) => {
+                  const statusCopy = getUserFacingStatus(item);
+                  const actionCopy = getChannelActionCopy(item);
+                  const publishedAt = formatPublishedAt(item.publishedAt);
+                  return (
+                    <DownloadLink
+                      key={`${item.audience}-${item.platform}`}
+                      className="release-pill"
+                      channel={item}
+                    >
+                      <span>{item.title}</span>
+                      <strong>
+                        <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
+                      </strong>
+                      {(item.version || publishedAt) && (
+                        <small>
+                          {item.version ? `v${item.version}` : ""}
+                          {item.version && publishedAt ? " · " : ""}
+                          {publishedAt ?? ""}
+                        </small>
+                      )}
+                      <em>
+                        <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
+                      </em>
+                    </DownloadLink>
+                  );
+                })
+              ) : (
+                <a className="release-pill" href={siteHref("/download")}>
+                  <span>
+                    <LocalizedText zh="App 下载" en="App Download" />
+                  </span>
+                  <strong>
+                    <LocalizedText zh="查看全部下载入口" en="See all download paths" />
+                  </strong>
+                </a>
+              )}
+            </div>
+          </section>
+
+          <section className="hero-visual" aria-label="Fabushi product preview">
+            <div className="phone-stack">
+              <div className="phone-frame main-phone poster-frame">
+                <img
+                  src={siteHref(resolveScreenshot(screenshots, HERO_MAIN_IMAGE_KEY))}
+                  alt="Fabushi homepage screenshot"
+                />
+              </div>
+              <div className="phone-frame side-phone poster-frame">
+                <img
+                  src={siteHref(resolveScreenshot(screenshots, HERO_SIDE_IMAGE_KEY))}
+                  alt="Fabushi feature preview screenshot"
+                />
+              </div>
+            </div>
+          </section>
+        </div>
+      </header>
+
+      <section className="band alt product-band" id="app-screenshots">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="App 截图" en="App Screens" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="先把关键界面尽量完整地摆出来，让首页直接承担理解与转化。"
+              en="Show the key screens as fully as possible so the homepage carries both understanding and conversion."
+            />
+          </h2>
+        </div>
+        <div className="moment-grid showcase-grid">
+          {APP_SCREENSHOTS.map((item) => (
+            <article key={item.titleEn} className="moment-card guide-card">
+              <div className="moment-image">
+                <img
+                  src={siteHref(resolveScreenshot(screenshots, item.screenshot))}
+                  alt={item.alt}
+                  loading="lazy"
+                />
+              </div>
+              <h3>
+                <LocalizedText zh={item.titleZh} en={item.titleEn} />
+              </h3>
+              <p>
+                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band" id="product-value">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="产品说明" en="Product Value" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="首页只把最该知道的三件事讲清楚。"
+              en="Keep the homepage focused on the three things people most need to understand."
+            />
+          </h2>
+        </div>
+        <div className="editorial-list">
+          {PRODUCT_BENEFITS.map((item) => (
+            <article key={item.titleEn} className="editorial-row">
+              <span>
+                <LocalizedText zh="核心价值" en="Core Value" />
+              </span>
+              <div>
+                <strong>
+                  <LocalizedText zh={item.titleZh} en={item.titleEn} />
+                </strong>
+                <p>
+                  <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt" id="service-entry">
+        <div className="section-heading tight">
+          <p>
+            <LocalizedText zh="下载与支持" en="Download and Support" />
+          </p>
+          <h2>
+            <LocalizedText
+              zh="把下载、版本、支持和最基础的信任信息放回同一个服务区。"
+              en="Keep download, release details, support, and the basic trust signals inside one service zone."
+            />
+          </h2>
+        </div>
+        <div className="platform-strip">
+          {channels.map((item) => {
+            const descriptionCopy = getUserFacingDescription(item);
+            const statusCopy = getUserFacingStatus(item);
+            const actionCopy = getChannelActionCopy(item);
+            const publishedAt = formatPublishedAt(item.publishedAt);
+            return (
+              <DownloadLink
+                key={`${item.audience}-${item.platform}`}
+                className="platform-row detailed"
+                channel={item}
+              >
+                <div>
+                  <span className="platform-name">{item.title}</span>
+                  <p>
+                    <LocalizedText zh={descriptionCopy.zh} en={descriptionCopy.en} />
+                  </p>
+                  {(item.version || publishedAt) && (
+                    <div className="platform-detail-line">
+                      {item.version ? <span>v{item.version}</span> : null}
+                      {publishedAt ? <span>{publishedAt}</span> : null}
+                    </div>
+                  )}
+                </div>
+                <div className="platform-meta">
+                  <strong>
+                    <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
+                  </strong>
+                  <span>
+                    <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
+                  </span>
+                </div>
+              </DownloadLink>
+            );
+          })}
+          <a className="platform-row accent-row" href={siteHref("/download")}>
+            <div>
+              <span className="platform-name">
+                <LocalizedText zh="全部下载入口" en="All Downloads" />
+              </span>
+              <p>
+                <LocalizedText zh="进入独立下载页，查看正式版、测试版、R2 下载状态和更新日志。" en="Open the dedicated download page for stable, beta, R2 download status, and release notes." />
+              </p>
+            </div>
+            <div className="platform-meta">
+              <strong>
+                <LocalizedText zh="下载页" en="Download Page" />
+              </strong>
+              <span>
+                <LocalizedText zh="进入" en="Open" />
+              </span>
+            </div>
+          </a>
+        </div>
+        <div className="note-grid">
+          <p>
+            <LocalizedText
+              zh={latestRelease ? `最近版本：${latestRelease.title}` : "最近版本与下载说明会同步更新到官网下载页。"}
+              en={latestRelease ? `Latest release: ${latestRelease.title}` : "Latest release notes stay synced on the official download page."}
+            />
+          </p>
+          <p>
+            <LocalizedText zh={`下载或安装遇到问题，可联系 ${supportEmail}。`} en={`If download or install fails, contact ${supportEmail}.`} />
+          </p>
+          <p>
+            <LocalizedText zh="隐私说明、下载 FAQ 和联系支持保留在官网主路径中，避免把下载流程分散出去。" en="Privacy, download FAQ, and support stay in the main path so the install flow does not get scattered." />
+          </p>
+        </div>
+      </section>
+
+      <section className="band faq-band" id="faq">
+        <div className="section-heading tight">
+          <p>FAQ</p>
+          <h2>
+            <LocalizedText
+              zh="只保留最直接影响下载理解的几个问题。"
+              en="Keep only the questions that most directly support understanding and download intent."
+            />
+          </h2>
+        </div>
+        <div className="faq-list">
+          {HOME_FAQS.map((item) => (
+            <details key={item.questionEn} className="faq-item">
+              <summary>
+                <LocalizedText zh={item.questionZh} en={item.questionEn} />
+              </summary>
+              <p>
+                <LocalizedText zh={item.answerZh} en={item.answerEn} />
+              </p>
+            </details>
+          ))}
+        </div>
+        <div className="inline-cta">
+          <a className="secondary-action" href={siteHref("/faq")}>
+            <LocalizedText zh="查看全部常见问题" en="View all FAQs" />
+          </a>
+          <a className="secondary-action" href={`mailto:${supportEmail}`}>
+            <LocalizedText zh="联系支持" en="Contact support" />
+          </a>
+        </div>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
 }

--- a/frontend/apps/web/src/app/privacy/page.tsx
+++ b/frontend/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,154 @@
+import type { Metadata } from "next";
+import { brand, contactChannels } from "@fabushi/shared";
+import { SiteFooter } from "../../components/site-footer";
+import { SiteHeader } from "../../components/site-header";
+import { siteHref, siteUrl } from "../../lib/site-url";
+
+const privacyUrl = siteUrl("/privacy");
+const privacyTitle = `隐私说明 | ${brand.name}`;
+const privacyDescription = "Fabushi 对测试申请、账号、设备信息和支持沟通的隐私说明。";
+
+const privacySections = [
+  {
+    title: "我们会处理什么",
+    text: "测试申请、支持邮件和账号相关流程中，你主动提供的邮箱、平台、设备、问题说明或合作信息。",
+  },
+  {
+    title: "为什么处理",
+    text: "用于发送测试入口、排查下载与安装问题、维护账号服务、回应反馈和沟通合作。",
+  },
+  {
+    title: "不会做什么",
+    text: "不会因为你浏览官网就要求注册，也不会为了无关营销扩大收集范围。",
+  },
+  {
+    title: "如何联系",
+    text: "你可以通过支持邮箱询问、更新或删除与自己相关的申请和反馈信息。",
+  },
+] as const;
+
+const privacyFaqs = [
+  {
+    question: "申请测试需要哪些信息？",
+    answer: "通常需要邮箱、平台、设备型号和你最想体验的功能。",
+  },
+  {
+    question: "只是浏览官网需要注册吗？",
+    answer: "不需要。下载状态、FAQ、隐私说明和联系入口都可以直接查看。",
+  },
+  {
+    question: "如何删除或更正信息？",
+    answer: "通过支持邮箱联系，并说明要查询、更新或删除的信息范围。",
+  },
+] as const;
+
+export const metadata: Metadata = {
+  title: privacyTitle,
+  description: privacyDescription,
+  alternates: {
+    canonical: privacyUrl,
+  },
+  keywords: ["Fabushi 隐私说明", "法布施隐私政策", "法布施测试申请"],
+  openGraph: {
+    title: privacyTitle,
+    description: privacyDescription,
+    url: privacyUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: privacyTitle,
+    description: privacyDescription,
+  },
+};
+
+export default function PrivacyPage() {
+  const supportEmail = contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
+  const supportHref = contactChannels.find((item) => item.href.startsWith("mailto:"))?.href ?? "mailto:support@ombhrum.com";
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        name: `${brand.name} 隐私说明`,
+        url: privacyUrl,
+        inLanguage: "zh-CN",
+        description: privacyDescription,
+        about: {
+          "@type": "Organization",
+          name: `${brand.name} Fabushi`,
+          url: siteUrl("/"),
+          email: supportEmail,
+        },
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: privacyFaqs.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
+      },
+    ],
+  };
+
+  return (
+    <main className="inner-page">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="inner-hero">
+        <SiteHeader />
+        <div className="inner-copy">
+          <p className="eyebrow">隐私说明</p>
+          <h1>只收集完成当前动作所需的信息。</h1>
+          <p className="lede">测试申请、下载反馈、账号支持和合作沟通，都保持用途清楚。</p>
+        </div>
+      </section>
+
+      <section className="band compact-band">
+        <div className="governance-grid">
+          {privacySections.map((item) => (
+            <article key={item.title} className="governance-card">
+              <h3>{item.title}</h3>
+              <p>{item.text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="band alt">
+        <div className="section-heading tight">
+          <p>FAQ</p>
+          <h2>边界说清楚。</h2>
+        </div>
+        <div className="faq-list full">
+          {privacyFaqs.map((item) => (
+            <details key={item.question} className="faq-item">
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
+          ))}
+        </div>
+        <div className="inline-cta">
+          <a className="primary-action" href={supportHref}>
+            联系支持
+          </a>
+          <a className="secondary-action" href={siteHref("/download")}>
+            回到下载
+          </a>
+        </div>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -1,3 +1,56 @@
+import { LocalizedText } from "./localized-text";
+import { siteHref } from "../lib/site-url";
+
+const FOOTER_LINKS = [
+  {
+    href: "/app",
+    zh: "大乘 Web",
+    en: "Dacheng Web",
+  },
+  {
+    href: "/download",
+    zh: "下载 App",
+    en: "Download App",
+  },
+  {
+    href: "/faq",
+    zh: "下载 FAQ",
+    en: "Download FAQ",
+  },
+  {
+    href: "/contact",
+    zh: "联系支持",
+    en: "Contact Support",
+  },
+  {
+    href: "/privacy",
+    zh: "隐私说明",
+    en: "Privacy",
+  },
+] as const;
+
 export function SiteFooter() {
-  return null;
+  return (
+    <footer className="site-footer">
+      <div>
+        <p className="footer-title">
+          <LocalizedText zh="大乘" en="Dacheng" />
+        </p>
+        <p className="footer-copy">
+          <LocalizedText
+            zh="统一聊天入口、全球法布施、背诵闪卡、App 下载与支持信息。"
+            en="Unified chat entry, global Dharma sharing, recitation flashcards, app downloads, and support."
+          />
+        </p>
+      </div>
+      <div className="footer-links">
+        {FOOTER_LINKS.map((item) => (
+          <a key={item.href} href={siteHref(item.href)}>
+            <LocalizedText zh={item.zh} en={item.en} />
+          </a>
+        ))}
+        <a href="mailto:support@ombhrum.com">support@ombhrum.com</a>
+      </div>
+    </footer>
+  );
 }

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -1,16 +1,32 @@
+import { LanguageSwitch } from "./language-switch";
 import { LocalizedText } from "./localized-text";
 import { siteHref } from "../lib/site-url";
 
 const NAV_ITEMS = [
   {
-    href: "/",
-    zh: "首页",
-    en: "Home",
-  },
-  {
     href: "/app",
     zh: "大乘 Web",
     en: "Dacheng Web",
+  },
+  {
+    href: "/faliu",
+    zh: "法流",
+    en: "Faloo",
+  },
+  {
+    href: "/faq",
+    zh: "下载 FAQ",
+    en: "Download FAQ",
+  },
+  {
+    href: "/contact",
+    zh: "联系支持",
+    en: "Contact Support",
+  },
+  {
+    href: "/privacy",
+    zh: "隐私说明",
+    en: "Privacy",
   },
 ] as const;
 
@@ -34,6 +50,7 @@ export function SiteHeader() {
           ))}
         </div>
         <div className="site-nav-actions">
+          <LanguageSwitch />
           <a className="nav-cta" href={siteHref("/app")}>
             <LocalizedText zh="打开大乘" en="Open Dacheng" />
           </a>


### PR DESCRIPTION
## Summary
- Restore the original official website homepage, root layout, global CSS, header, footer, download route, and privacy route from before PR #827.
- Keep the fast Dacheng UI limited to the actual Web App entry at `/app`, which is opened by the official site's top-right “打开大乘” button.
- Keep the WeChat mini-program UI changes and shared Dacheng app helpers.

## Notes
- Direct push to main was rejected because the branch had moved, so this PR contains the corrective follow-up.