### PR TITLE
Add Flutter Web deployment workflow

### DIFF
--- a/.github/workflows/deploy-flutter-web.yml
+++ b/.github/workflows/deploy-flutter-web.yml
@@ -16,12 +16,6 @@ on:
       - '!fabushi/assets/built_in/**'
       - 'fabushi/fonts/**'
   workflow_dispatch:
-    inputs:
-      project_name:
-        description: Cloudflare Pages project name.
-        required: false
-        type: string
-        default: fabushi-web-prod
 
 concurrency:
   group: flutter-web-production
@@ -34,6 +28,8 @@ permissions:
 env:
   FLUTTER_VERSION: '3.41.9'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  CLOUDFLARE_PAGES_PROJECT: fabushi-web-prod
+  EXPECTED_CUSTOM_DOMAIN: flutter.ombhrum.com
 
 jobs:
   deploy-flutter-web:
@@ -46,8 +42,6 @@ jobs:
     defaults:
       run:
         working-directory: fabushi
-    env:
-      CLOUDFLARE_PAGES_PROJECT: ${{ github.event.inputs.project_name || vars.CLOUDFLARE_PAGES_PROJECT || 'fabushi-web-prod' }}
     steps:
       - name: Checkout Flutter Web source
         uses: actions/checkout@v5
@@ -84,6 +78,7 @@ jobs:
           set -euo pipefail
           flutter --version
           echo "Cloudflare Pages project: $CLOUDFLARE_PAGES_PROJECT"
+          echo "Expected custom domain: $EXPECTED_CUSTOM_DOMAIN"
           echo "Deploy source ref: $GITHUB_REF_NAME"
           echo "Deploy source SHA: $GITHUB_SHA"
 
@@ -129,9 +124,51 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
         run: |
           set -euo pipefail
+          [ "$CLOUDFLARE_PAGES_PROJECT" = "fabushi-web-prod" ] || { echo "Refusing to deploy to unexpected Pages project: $CLOUDFLARE_PAGES_PROJECT"; exit 1; }
           [ -n "${CLOUDFLARE_API_TOKEN:-}" ] || { echo "Cloudflare API token is not configured."; exit 1; }
           [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || { echo "Cloudflare account id is not configured."; exit 1; }
           echo "Cloudflare credentials are configured."
+
+      - name: Verify custom domain before deploy
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          response_file="$(mktemp)"
+          status=$(curl -sS -w '%{http_code}' -o "$response_file" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/domains")
+          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+            echo "Failed to read Cloudflare Pages custom domains. HTTP status: $status"
+            cat "$response_file"
+            exit 1
+          fi
+          python3 - "$response_file" "$EXPECTED_CUSTOM_DOMAIN" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_text())
+          expected = sys.argv[2]
+
+          def contains_domain(value):
+              if isinstance(value, dict):
+                  for key in ("name", "domain", "hostname"):
+                      if value.get(key) == expected:
+                          return True
+                  return any(contains_domain(item) for item in value.values())
+              if isinstance(value, list):
+                  return any(contains_domain(item) for item in value)
+              return value == expected
+
+          if not contains_domain(payload):
+              print(f"Expected custom domain {expected} is not bound to this Pages project.")
+              raise SystemExit(1)
+
+          print(f"Verified custom domain before deploy: {expected}")
+          PY
 
       - name: Deploy Flutter Web to Cloudflare Pages
         shell: bash
@@ -145,6 +182,47 @@ jobs:
             --branch "$GITHUB_REF_NAME" \
             --commit-hash "$GITHUB_SHA"
 
+      - name: Verify custom domain after deploy
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          response_file="$(mktemp)"
+          status=$(curl -sS -w '%{http_code}' -o "$response_file" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/domains")
+          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+            echo "Failed to read Cloudflare Pages custom domains after deploy. HTTP status: $status"
+            cat "$response_file"
+            exit 1
+          fi
+          python3 - "$response_file" "$EXPECTED_CUSTOM_DOMAIN" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_text())
+          expected = sys.argv[2]
+
+          def contains_domain(value):
+              if isinstance(value, dict):
+                  for key in ("name", "domain", "hostname"):
+                      if value.get(key) == expected:
+                          return True
+                  return any(contains_domain(item) for item in value.values())
+              if isinstance(value, list):
+                  return any(contains_domain(item) for item in value)
+              return value == expected
+
+          if not contains_domain(payload):
+              print(f"Expected custom domain {expected} is missing after deploy.")
+              raise SystemExit(1)
+
+          print(f"Verified custom domain after deploy: {expected}")
+          PY
+
       - name: Write deployment summary
         shell: bash
         run: |
@@ -154,5 +232,6 @@ jobs:
             echo "- Source SHA: $GITHUB_SHA"
             echo "- Trigger: $GITHUB_EVENT_NAME"
             echo "- Cloudflare Pages project: $CLOUDFLARE_PAGES_PROJECT"
+            echo "- Verified custom domain: $EXPECTED_CUSTOM_DOMAIN"
             echo "- Production URL: https://flutter.ombhrum.com"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-flutter-web.yml
+++ b/.github/workflows/deploy-flutter-web.yml
@@ -21,7 +21,7 @@ on:
         description: Cloudflare Pages project name.
         required: false
         type: string
-        default: fabushi-flutter-web
+        default: fabushi-web-prod
 
 concurrency:
   group: flutter-web-production
@@ -47,7 +47,7 @@ jobs:
       run:
         working-directory: fabushi
     env:
-      CLOUDFLARE_PAGES_PROJECT: ${{ github.event.inputs.project_name || vars.CLOUDFLARE_PAGES_PROJECT || 'fabushi-flutter-web' }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ github.event.inputs.project_name || vars.CLOUDFLARE_PAGES_PROJECT || 'fabushi-web-prod' }}
     steps:
       - name: Checkout Flutter Web source
         uses: actions/checkout@v5

--- a/.github/workflows/deploy-flutter-web.yml
+++ b/.github/workflows/deploy-flutter-web.yml
@@ -1,0 +1,158 @@
+name: CD - Flutter Web
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/deploy-flutter-web.yml'
+      - 'fabushi/analysis_options.yaml'
+      - 'fabushi/l10n.yaml'
+      - 'fabushi/pubspec.yaml'
+      - 'fabushi/pubspec.lock'
+      - 'fabushi/lib/**'
+      - 'fabushi/web/**'
+      - 'fabushi/assets/**'
+      - '!fabushi/assets/built_in/**'
+      - 'fabushi/fonts/**'
+  workflow_dispatch:
+    inputs:
+      project_name:
+        description: Cloudflare Pages project name.
+        required: false
+        type: string
+        default: fabushi-flutter-web
+
+concurrency:
+  group: flutter-web-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+
+env:
+  FLUTTER_VERSION: '3.41.9'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  deploy-flutter-web:
+    name: Build and deploy Flutter Web
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: production
+      url: https://flutter.ombhrum.com
+    defaults:
+      run:
+        working-directory: fabushi
+    env:
+      CLOUDFLARE_PAGES_PROJECT: ${{ github.event.inputs.project_name || vars.CLOUDFLARE_PAGES_PROJECT || 'fabushi-flutter-web' }}
+    steps:
+      - name: Checkout Flutter Web source
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/analysis_options.yaml
+            /fabushi/l10n.yaml
+            /fabushi/pubspec.yaml
+            /fabushi/pubspec.lock
+            /fabushi/lib/**
+            /fabushi/web/**
+            !/fabushi/web/assets/built_in/**
+            /fabushi/assets/**
+            !/fabushi/assets/built_in/**
+            /fabushi/fonts/**
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Show build context
+        shell: bash
+        run: |
+          set -euo pipefail
+          flutter --version
+          echo "Cloudflare Pages project: $CLOUDFLARE_PAGES_PROJECT"
+          echo "Deploy source ref: $GITHUB_REF_NAME"
+          echo "Deploy source SHA: $GITHUB_SHA"
+
+      - name: Get Flutter dependencies
+        run: flutter pub get
+
+      - name: Analyze Flutter Web entrypoint
+        run: flutter analyze lib/main.dart
+
+      - name: Build Flutter Web release
+        run: flutter build web --release
+
+      - name: Smoke test built Flutter Web app
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m http.server 8080 --directory build/web > /tmp/fabushi-flutter-web.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid"' EXIT
+
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/ > /tmp/fabushi-index.html; then
+              break
+            fi
+            sleep 1
+          done
+
+          test -s /tmp/fabushi-index.html
+          grep -Eq 'flutter|main\.dart\.js|flutter_bootstrap\.js' /tmp/fabushi-index.html
+
+      - name: Upload Flutter Web build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: flutter-web-build-${{ github.sha }}
+          path: fabushi/build/web
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Check Cloudflare credential presence
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          [ -n "${CLOUDFLARE_API_TOKEN:-}" ] || { echo "Cloudflare API token is not configured."; exit 1; }
+          [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || { echo "Cloudflare account id is not configured."; exit 1; }
+          echo "Cloudflare credentials are configured."
+
+      - name: Deploy Flutter Web to Cloudflare Pages
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@latest pages deploy build/web \
+            --project-name "$CLOUDFLARE_PAGES_PROJECT" \
+            --branch "$GITHUB_REF_NAME" \
+            --commit-hash "$GITHUB_SHA"
+
+      - name: Write deployment summary
+        shell: bash
+        run: |
+          {
+            echo "## Flutter Web deployment"
+            echo ""
+            echo "- Source SHA: $GITHUB_SHA"
+            echo "- Trigger: $GITHUB_EVENT_NAME"
+            echo "- Cloudflare Pages project: $CLOUDFLARE_PAGES_PROJECT"
+            echo "- Production URL: https://flutter.ombhrum.com"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add a dedicated `CD - Flutter Web` GitHub Actions workflow.
- Automatically deploys on `main` only when Flutter Web related paths change:
  - `.github/workflows/deploy-flutter-web.yml`
  - `fabushi/lib/**`
  - `fabushi/web/**`
  - `fabushi/assets/**` except built-in assets
  - `fabushi/fonts/**`
  - Flutter config files such as `pubspec.yaml`, `pubspec.lock`, `analysis_options.yaml`, and `l10n.yaml`
- Keeps a `workflow_dispatch` entry point so Flutter Web deployment can be triggered manually.
- Builds Flutter Web, performs a small static smoke test, uploads the build artifact, then deploys `fabushi/build/web` to Cloudflare Pages with Wrangler.

## Deployment notes

The workflow is intentionally pinned to Cloudflare Pages project `fabushi-web-prod`.

To protect the existing custom-domain binding, the workflow verifies `flutter.ombhrum.com` is present in the `fabushi-web-prod` custom domains list before deploy and again after deploy. If the binding is missing or cannot be read, the job fails instead of silently deploying to an unsafe target.

The workflow uses these credentials if present:

- `CLOUDFLARE_API_TOKEN` / `CF_API_TOKEN` / `WRANGLER_API_TOKEN` / compatible token vars
- `CLOUDFLARE_ACCOUNT_ID` / `CF_ACCOUNT_ID` / compatible account vars

## Trigger behavior

After this PR is merged through the required merge queue, the merge commit changes `.github/workflows/deploy-flutter-web.yml`, so the new Flutter Web deployment workflow should run on `main` immediately for that merge commit.