### PR TITLE
Add Worker fallback for Flutter Web deploy

### DIFF
--- a/.github/workflows/deploy-flutter-web.yml
+++ b/.github/workflows/deploy-flutter-web.yml
@@ -169,17 +169,79 @@ jobs:
               print(f"::warning::Expected custom domain {expected} is not bound to this Pages project before deploy.")
           PY
 
-      - name: Deploy Flutter Web to Cloudflare Pages
+      - name: Deploy Flutter Web to Cloudflare
+        id: deploy_flutter_web
         shell: bash
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
         run: |
           set -euo pipefail
+
+          set +e
           npx --yes wrangler@latest pages deploy build/web \
             --project-name "$CLOUDFLARE_PAGES_PROJECT" \
             --branch "$GITHUB_REF_NAME" \
-            --commit-hash "$GITHUB_SHA"
+            --commit-hash "$GITHUB_SHA" 2>&1 | tee /tmp/flutter-web-pages-deploy.log
+          pages_status="${PIPESTATUS[0]}"
+          set -e
+
+          if [ "$pages_status" -eq 0 ]; then
+            echo "target=cloudflare-pages" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! grep -Eqi 'Authentication error|permission|not authorized|forbidden|code: 10000' /tmp/flutter-web-pages-deploy.log; then
+            exit "$pages_status"
+          fi
+
+          echo "::warning::Cloudflare Pages deploy failed because the configured token cannot access Pages. Falling back to a Cloudflare Worker static-assets deploy."
+
+          cat > flutter-web-static-worker.js <<'EOF'
+          export default {
+            async fetch(request, env) {
+              const url = new URL(request.url);
+              const pathname = url.pathname;
+
+              let response = await env.ASSETS.fetch(request);
+              if (response.status === 404 && !pathname.startsWith('/api/') && !/\.[^/]+$/.test(pathname)) {
+                response = await env.ASSETS.fetch(new Request(new URL('/index.html', request.url), request));
+              }
+
+              const headers = new Headers(response.headers);
+              headers.set('Access-Control-Allow-Origin', '*');
+              headers.set('X-App-Version', '${GITHUB_SHA}');
+
+              if (pathname === '/' || pathname === '/index.html' || pathname === '/flutter_service_worker.js' || pathname === '/main.dart.js') {
+                headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+              } else if (/\.(js|css|png|jpg|jpeg|gif|svg|woff2?|json|wasm)$/i.test(pathname) && !headers.has('Cache-Control')) {
+                headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+              }
+
+              return new Response(request.method === 'HEAD' ? null : response.body, {
+                status: response.status,
+                statusText: response.statusText,
+                headers,
+              });
+            },
+          };
+          EOF
+
+          cat > wrangler.flutter-web-static.toml <<'EOF'
+          name = "fabushi-flutter-web-static-prod"
+          main = "flutter-web-static-worker.js"
+          compatibility_date = "2026-06-11"
+          workers_dev = false
+
+          [assets]
+          directory = "build/web"
+          EOF
+
+          npx --yes wrangler@latest deploy \
+            --config wrangler.flutter-web-static.toml \
+            --domain "$EXPECTED_CUSTOM_DOMAIN"
+
+          echo "target=cloudflare-worker-static-assets" >> "$GITHUB_OUTPUT"
 
       - name: Inspect custom domain after deploy
         shell: bash
@@ -229,6 +291,7 @@ jobs:
             echo ""
             echo "- Source SHA: $GITHUB_SHA"
             echo "- Trigger: $GITHUB_EVENT_NAME"
+            echo "- Cloudflare deploy target: ${{ steps.deploy_flutter_web.outputs.target }}"
             echo "- Cloudflare Pages project: $CLOUDFLARE_PAGES_PROJECT"
             echo "- Expected custom domain: $EXPECTED_CUSTOM_DOMAIN"
             echo "- Production URL: https://flutter.ombhrum.com"


### PR DESCRIPTION
## Summary\n\n- Keep Cloudflare Pages deploy as the first attempt.\n- When the configured Cloudflare token cannot access Pages, fall back to deploying the Flutter Web build as Cloudflare Worker static assets on flutter.ombhrum.com.\n- Record the actual Cloudflare target in the workflow summary.\n\n## Validation\n\n- YAML parse: ok\n- git diff --check: ok