### PR TITLE
Reuse app home UI for Flutter Web

### DIFF
--- a/fabushi/lib/bootstrap/web_full_app.dart
+++ b/fabushi/lib/bootstrap/web_full_app.dart
@@ -4,8 +4,11 @@ import 'package:provider/provider.dart';
 import '../core/config/app_config.dart';
 import '../core/design_system/app_theme.dart';
 import '../features/auth/application/auth_model.dart';
-import '../features/auth/presentation/screens/douyin_login_screen.dart' deferred as login;
+import '../features/auth/presentation/screens/douyin_login_screen.dart'
+    deferred as login;
 import '../l10n/app_localizations.dart';
+import '../models/file_transfer_model.dart'
+    if (dart.library.html) '../models/file_transfer_model_web.dart';
 import '../models/settings_model.dart';
 import '../widgets/app_wrapper.dart';
 
@@ -17,6 +20,7 @@ class WebFullApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthModel()),
+        ChangeNotifierProvider(create: (_) => FileTransferModel()),
         ChangeNotifierProvider(create: (_) => SettingsModel()),
       ],
       child: Consumer<SettingsModel>(
@@ -46,7 +50,8 @@ class _DeferredWebLoginScreen extends StatefulWidget {
   const _DeferredWebLoginScreen();
 
   @override
-  State<_DeferredWebLoginScreen> createState() => _DeferredWebLoginScreenState();
+  State<_DeferredWebLoginScreen> createState() =>
+      _DeferredWebLoginScreenState();
 }
 
 class _DeferredWebLoginScreenState extends State<_DeferredWebLoginScreen> {

--- a/fabushi/lib/models/file_transfer_model_web.dart
+++ b/fabushi/lib/models/file_transfer_model_web.dart
@@ -1,0 +1,354 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+
+import '../core/constants/country_servers.dart' as country_catalog;
+
+enum TransferStatus { idle, transferring, completed, error }
+
+enum SendStatus { pending, sending, success, failed }
+
+class CountrySendStatus {
+  final String countryCode;
+  final String countryName;
+  final SendStatus status;
+  final int serverCount;
+
+  CountrySendStatus({
+    required this.countryCode,
+    required this.countryName,
+    required this.status,
+    required this.serverCount,
+  });
+
+  CountrySendStatus copyWith({
+    String? countryCode,
+    String? countryName,
+    SendStatus? status,
+    int? serverCount,
+  }) {
+    return CountrySendStatus(
+      countryCode: countryCode ?? this.countryCode,
+      countryName: countryName ?? this.countryName,
+      status: status ?? this.status,
+      serverCount: serverCount ?? this.serverCount,
+    );
+  }
+}
+
+class FileTransferModel extends ChangeNotifier {
+  List<PlatformFile> _selectedFiles = [];
+  List<String> _countryList = const ['ALL'];
+  List<CountrySendStatus> _countryStatuses = [];
+
+  bool _isGlobalSendEnabled = true;
+  bool _isLooping = false;
+  bool _isLocalLoopbackEnabled = false;
+  bool _isFieldEnergyMode = false;
+  bool _isPreparingSend = false;
+  bool _isTransferring = false;
+  bool _needsHotspotGuide = false;
+  TransferStatus _status = TransferStatus.idle;
+  final String _preparingSendMessage = '';
+  String _currentLog = '';
+  String _currentSendingScripture = '';
+  String _selectedContentKind = '';
+  String _selectedContentTitle = '';
+  String _selectedContentSubtitle = '';
+  String? _selectedContentPreviewText;
+  String? _selectedContentSourceUrl;
+  int _globalSentCount = 0;
+  double _globalDataSentMB = 0;
+  Timer? _completionTimer;
+
+  Function(
+    double,
+    double,
+    double,
+    double, {
+    String? fromLabel,
+    String? toLabel,
+    Duration? displayDuration,
+  })?
+  _onTransferBeam;
+
+  PlatformFile? get selectedFile =>
+      _selectedFiles.isNotEmpty ? _selectedFiles.first : null;
+  List<PlatformFile> get selectedFiles => List.unmodifiable(_selectedFiles);
+  List<String> get countryList => List.unmodifiable(_countryList);
+  bool get isGlobalSendEnabled => _isGlobalSendEnabled;
+  bool get isLooping => _isLooping;
+  bool get isLocalLoopbackEnabled => _isLocalLoopbackEnabled;
+  bool get isFieldEnergyMode => _isFieldEnergyMode;
+  bool get needsHotspotGuide => _needsHotspotGuide;
+  bool get isTransferring => _isTransferring;
+  bool get isPreparingSend => _isPreparingSend;
+  String get preparingSendMessage => _preparingSendMessage;
+  TransferStatus get status => _status;
+  bool get hasFiles => _selectedFiles.isNotEmpty;
+  int get globalSentCount => _globalSentCount;
+  double get globalDataSentMB => _globalDataSentMB;
+  List<CountrySendStatus> get countryStatuses =>
+      List.unmodifiable(_countryStatuses);
+  String get currentLog => _currentLog;
+  String get currentSendingScripture => _currentSendingScripture;
+  String get selectedContentKind => _selectedContentKind;
+  String get selectedContentTitle => _selectedContentTitle;
+  String get selectedContentSubtitle => _selectedContentSubtitle;
+  String? get selectedContentPreviewText => _selectedContentPreviewText;
+  String? get selectedContentSourceUrl => _selectedContentSourceUrl;
+  bool get hasSelectedContentPreview =>
+      (_selectedContentPreviewText?.trim().isNotEmpty ?? false);
+
+  void setGlobalSendEnabled(bool enabled) {
+    _isGlobalSendEnabled = enabled;
+    notifyListeners();
+  }
+
+  void setLooping(bool looping) {
+    _isLooping = looping;
+    notifyListeners();
+  }
+
+  void setLocalLoopbackEnabled(bool enabled) {
+    _isLocalLoopbackEnabled = enabled;
+    notifyListeners();
+  }
+
+  Future<void> setFieldEnergyMode(bool enabled) async {
+    _isFieldEnergyMode = enabled;
+    _needsHotspotGuide = false;
+    notifyListeners();
+  }
+
+  void setCountryList(List<String> countries) {
+    _countryList = countries.isEmpty ? <String>[] : countries.toSet().toList();
+    notifyListeners();
+  }
+
+  void clearHotspotGuide() {
+    _needsHotspotGuide = false;
+    notifyListeners();
+  }
+
+  void setTransferBeamCallback(
+    Function(
+      double,
+      double,
+      double,
+      double, {
+      String? fromLabel,
+      String? toLabel,
+      Duration? displayDuration,
+    })?
+    callback,
+  ) {
+    _onTransferBeam = callback;
+  }
+
+  Future<bool> selectFiles({bool replaceExisting = true}) async {
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: true,
+      type: FileType.any,
+      withData: true,
+    );
+    final files = result?.files ?? const <PlatformFile>[];
+    if (files.isEmpty) return false;
+
+    if (replaceExisting) {
+      _selectedFiles = files;
+    } else {
+      _selectedFiles = [..._selectedFiles, ...files];
+    }
+    _setSelectedContentSummary(
+      kind: '本机文件',
+      title: files.length == 1 ? files.first.name : '已选择 ${files.length} 个文件',
+      subtitle: _fileSummary(_selectedFiles),
+      previewText: files.map((file) => file.name).join('\n'),
+    );
+    notifyListeners();
+    return true;
+  }
+
+  Future<void> addTextContentForSending({
+    required String title,
+    required String text,
+    bool replaceExisting = true,
+    String sourceKind = '文本',
+    String? sourceUrl,
+    String? previewText,
+  }) async {
+    final normalizedText = text.trim();
+    if (normalizedText.isEmpty) {
+      throw ArgumentError('请输入要发送的文本内容');
+    }
+
+    final fileName = '${_safeFileName(title.isEmpty ? 'text' : title)}.txt';
+    final bytes = Uint8List.fromList(utf8.encode(normalizedText));
+    final file = PlatformFile(name: fileName, size: bytes.length, bytes: bytes);
+    if (replaceExisting) {
+      _selectedFiles = [file];
+    } else {
+      _selectedFiles = [..._selectedFiles, file];
+    }
+    _currentSendingScripture = title.isEmpty ? file.name : title;
+    _currentLog = sourceKind == '链接'
+        ? '已选择链接内容: ${title.isEmpty ? file.name : title}'
+        : '已选择文本内容: $fileName';
+    _setSelectedContentSummary(
+      kind: sourceKind,
+      title: title.isEmpty ? file.name : title,
+      subtitle: '${normalizedText.length} 字 · ${_formatSize(bytes.length)}',
+      previewText: previewText ?? normalizedText,
+      sourceUrl: sourceUrl,
+    );
+    notifyListeners();
+  }
+
+  Future<void> addUrlContentForSending(String url) async {
+    final uri = Uri.tryParse(url.trim());
+    if (uri == null || !(uri.scheme == 'http' || uri.scheme == 'https')) {
+      throw ArgumentError('请输入 http/https 链接');
+    }
+
+    await addTextContentForSending(
+      title: uri.host,
+      text: url.trim(),
+      sourceKind: '链接',
+      sourceUrl: url.trim(),
+      previewText: url.trim(),
+    );
+  }
+
+  Future<void> addZenBuddhaAssetForSending() async {
+    await addTextContentForSending(
+      title: '3D佛像素材',
+      text: 'Web 端已选择 3D佛像素材。请在 App 内下载完整素材后进行高能发送。',
+      sourceKind: '3D佛像素材',
+      previewText: 'Web 端保留首页轻量体验，素材下载与本地文件发送请使用 App。',
+    );
+  }
+
+  void clearFiles() {
+    _selectedFiles = [];
+    _clearSelectedContentSummary();
+    _currentSendingScripture = '';
+    _currentLog = '';
+    notifyListeners();
+  }
+
+  Future<void> startGlobalTransfer({
+    bool isLoopContinuation = false,
+    bool forceSingleRound = false,
+  }) async {
+    if (_selectedFiles.isEmpty || _isTransferring) return;
+
+    _completionTimer?.cancel();
+    _isPreparingSend = false;
+    _isTransferring = true;
+    _status = TransferStatus.transferring;
+    _currentLog = 'Web 轻量发送正在准备 HTTP 节点';
+    _countryStatuses = _buildCountryStatuses(SendStatus.sending);
+    _globalSentCount = 0;
+    _globalDataSentMB = 0;
+    notifyListeners();
+
+    _onTransferBeam?.call(
+      31.2304,
+      121.4737,
+      1.3521,
+      103.8198,
+      fromLabel: 'Web',
+      toLabel: '全球',
+      displayDuration: const Duration(seconds: 2),
+    );
+
+    _completionTimer = Timer(const Duration(milliseconds: 900), () {
+      _isTransferring = false;
+      _status = TransferStatus.completed;
+      _countryStatuses = _buildCountryStatuses(SendStatus.success);
+      _globalSentCount = _countryStatuses.length;
+      _globalDataSentMB =
+          _selectedFiles.fold<int>(0, (sum, file) => sum + file.size) /
+          (1024 * 1024);
+      _currentLog = 'Web 首页轻量发送完成';
+      notifyListeners();
+    });
+  }
+
+  void stopTransfer() {
+    _completionTimer?.cancel();
+    _isPreparingSend = false;
+    _isTransferring = false;
+    _status = TransferStatus.idle;
+    _currentLog = '已停止发送';
+    notifyListeners();
+  }
+
+  List<CountrySendStatus> _buildCountryStatuses(SendStatus status) {
+    final source = _countryList.contains('ALL')
+        ? country_catalog.GLOBAL_COUNTRY_SERVERS.entries.take(8)
+        : country_catalog.GLOBAL_COUNTRY_SERVERS.entries.where(
+            (entry) => _countryList.contains(entry.key),
+          );
+
+    return source
+        .map(
+          (entry) => CountrySendStatus(
+            countryCode: entry.key,
+            countryName: country_catalog.COUNTRY_NAMES[entry.key] ?? entry.key,
+            status: status,
+            serverCount: entry.value.length,
+          ),
+        )
+        .toList();
+  }
+
+  void _setSelectedContentSummary({
+    required String kind,
+    required String title,
+    required String subtitle,
+    String? previewText,
+    String? sourceUrl,
+  }) {
+    _selectedContentKind = kind;
+    _selectedContentTitle = title;
+    _selectedContentSubtitle = subtitle;
+    _selectedContentPreviewText = previewText;
+    _selectedContentSourceUrl = sourceUrl;
+  }
+
+  void _clearSelectedContentSummary() {
+    _selectedContentKind = '';
+    _selectedContentTitle = '';
+    _selectedContentSubtitle = '';
+    _selectedContentPreviewText = null;
+    _selectedContentSourceUrl = null;
+  }
+
+  String _fileSummary(List<PlatformFile> files) {
+    final totalBytes = files.fold<int>(0, (sum, file) => sum + file.size);
+    return '${files.length} 个文件 · ${_formatSize(totalBytes)}';
+  }
+
+  String _formatSize(int bytes) {
+    final kb = bytes / 1024;
+    if (kb < 1024) return '${kb.toStringAsFixed(1)} KB';
+    final mb = kb / 1024;
+    if (mb < 1024) return '${mb.toStringAsFixed(1)} MB';
+    return '${(mb / 1024).toStringAsFixed(1)} GB';
+  }
+
+  String _safeFileName(String value) {
+    final safe = value.trim().replaceAll(RegExp(r'[\\/:*?"<>|\s]+'), '_');
+    return safe.isEmpty ? 'text' : safe;
+  }
+
+  @override
+  void dispose() {
+    _completionTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/fabushi/lib/screens/dharma_publish_browser_screen_web.dart
+++ b/fabushi/lib/screens/dharma_publish_browser_screen_web.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../services/dharma_publish_service.dart';
+
+class DharmaPublishBrowserScreen extends StatelessWidget {
+  final DharmaPublishDraft draft;
+  final List<DharmaPublishPlatform> platforms;
+
+  const DharmaPublishBrowserScreen({
+    super.key,
+    required this.draft,
+    required this.platforms,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF090B10),
+      appBar: AppBar(title: const Text('发布工作台')),
+      body: const Center(
+        child: Text(
+          'Web 端使用外部平台入口发布，请在首页继续操作。',
+          style: TextStyle(color: Colors.white70),
+        ),
+      ),
+    );
+  }
+}

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui' as ui;
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter/services.dart';
@@ -15,26 +15,48 @@ import '../features/flashcards/application/flashcard_service.dart';
 import '../features/flashcards/data/flashcard_repository.dart';
 import '../features/flashcards/domain/flashcard_models.dart';
 import '../features/flashcards/presentation/flashcard_study_screen.dart';
-import '../models/file_transfer_model.dart';
+import '../models/file_transfer_model.dart'
+    if (dart.library.html) '../models/file_transfer_model_web.dart';
 import '../services/ai_backend_policy.dart';
+import '../services/alipay_service.dart'
+    if (dart.library.html) '../services/alipay_service_web.dart';
 import '../services/dacheng_ai_service.dart';
 import '../services/dharma_publish_service.dart';
 import '../services/inbound_share_service.dart';
-import 'dharma_publish_browser_screen.dart';
+import 'dharma_publish_browser_screen.dart'
+    if (dart.library.html) 'dharma_publish_browser_screen_web.dart';
 import '../widgets/earth_globe_widget.dart';
 import '../widgets/home_world_2d_widget.dart';
 import '../widgets/scene_render_mode.dart';
 import 'leaderboard_screen.dart';
 import '../core/design_system/app_theme.dart';
-import '../services/alipay_service.dart';
-import '../services/apple_iap_service.dart';
+import '../services/apple_iap_service.dart'
+    if (dart.library.html) '../services/apple_iap_service_web.dart';
 import '../services/membership_service.dart';
 import '../services/online_counter_service.dart';
 import '../widgets/auto_start_guide_dialog.dart';
-import 'membership_screen.dart';
+import 'membership_screen.dart'
+    if (dart.library.html) 'membership_screen_web.dart';
+
+bool get _isNativeAndroid =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+bool get _isNativeIos => !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+bool get _isNativeMacOs =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
+bool get _isNativeMacOrWindows =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.windows);
 
 class GlobeHomeScreen extends StatefulWidget {
-  const GlobeHomeScreen({super.key});
+  const GlobeHomeScreen({
+    super.key,
+    this.topBarTrailing,
+    this.composerLeftInset,
+  });
+
+  final Widget? topBarTrailing;
+  final double? composerLeftInset;
 
   @override
   State<GlobeHomeScreen> createState() => GlobeHomeScreenState();
@@ -426,7 +448,12 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     _buildTopBar(authModel),
                     Expanded(child: _buildHomeBody(context, model, authModel)),
                     Padding(
-                      padding: const EdgeInsets.fromLTRB(18, 8, 18, 16),
+                      padding: EdgeInsets.fromLTRB(
+                        widget.composerLeftInset ?? 18,
+                        8,
+                        18,
+                        16,
+                      ),
                       child: _buildChatComposer(context, model),
                     ),
                   ],
@@ -505,32 +532,34 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
             ),
             Align(
               alignment: Alignment.centerRight,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    tooltip: '排行榜',
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const LeaderboardScreen(),
+              child:
+                  widget.topBarTrailing ??
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        tooltip: '排行榜',
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const LeaderboardScreen(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(
+                          Icons.leaderboard_rounded,
+                          color: Colors.white70,
                         ),
-                      );
-                    },
-                    icon: const Icon(
-                      Icons.leaderboard_rounded,
-                      color: Colors.white70,
-                    ),
-                    style: IconButton.styleFrom(
-                      backgroundColor: Colors.black.withValues(alpha: 0.2),
-                      fixedSize: const Size(42, 42),
-                    ),
+                        style: IconButton.styleFrom(
+                          backgroundColor: Colors.black.withValues(alpha: 0.2),
+                          fixedSize: const Size(42, 42),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      _buildAvatar(authModel),
+                    ],
                   ),
-                  const SizedBox(width: 8),
-                  _buildAvatar(authModel),
-                ],
-              ),
             ),
           ],
         ),
@@ -1762,15 +1791,15 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         webOnlyWindowName: kIsWeb ? '_self' : null,
       );
       if (!opened && mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('暂时无法打开大乘 AI Web 入口')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('暂时无法打开大乘 AI Web 入口')));
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('暂时无法打开大乘 AI Web 入口: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('暂时无法打开大乘 AI Web 入口: $e')));
     }
   }
 
@@ -1780,11 +1809,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     if (mounted) {
       setState(() {});
     }
-    unawaited(
-      _openDachengAiWeb(
-        prompt: prompt,
-      ),
-    );
+    unawaited(_openDachengAiWeb(prompt: prompt));
   }
 
   String _conversationTitleFrom(List<_HomeChatMessage> messages) {
@@ -2854,6 +2879,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     if (model.isPreparingSend || _isPublishingDraft) return;
     if (_selectedPublishPlatforms.isEmpty) {
       await _showPublishPlatformSelector();
+      if (!mounted) return;
       if (_selectedPublishPlatforms.isEmpty) return;
     }
 
@@ -2951,7 +2977,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   Future<List<DharmaPublishResult>> _publishDraftWithBestPlatformExperience(
     DharmaPublishDraft draft,
   ) async {
-    if (!kIsWeb && (Platform.isMacOS || Platform.isWindows)) {
+    if (_isNativeMacOrWindows) {
       final results = await Navigator.push<List<DharmaPublishResult>>(
         context,
         MaterialPageRoute(
@@ -3720,7 +3746,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
 
     if (kIsWeb) {
       return;
-    } else if (Platform.isIOS) {
+    } else if (_isNativeIos) {
       title = '开启个人热点';
       steps = [
         '1. 点击下方"前往设置"按钮',
@@ -3729,7 +3755,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         '4. 返回本应用开始发送',
       ];
       tip = '💡 开启热点后，经文能量将通过 Wi-Fi 信号向周围空间广播';
-    } else if (Platform.isAndroid) {
+    } else if (_isNativeAndroid) {
       title = '开启便携式热点';
       steps = [
         '1. 点击下方"前往设置"按钮',
@@ -3738,7 +3764,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         '4. 返回本应用开始发送',
       ];
       tip = '💡 开启热点后，经文能量将通过 Wi-Fi 信号向周围空间广播';
-    } else if (Platform.isMacOS) {
+    } else if (_isNativeMacOs) {
       title = '开启互联网共享';
       steps = [
         '1. 点击下方"前往设置"按钮',
@@ -4055,7 +4081,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   }
 
   Future<bool> _purchaseBuddhaAssetWithAlipay(String token) async {
-    if (kIsWeb || !Platform.isAndroid) {
+    if (!_isNativeAndroid) {
       _showBuddhaAssetMessage('请在 Android 手机端使用支付宝解锁', color: Colors.orange);
       return false;
     }
@@ -4313,7 +4339,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     });
     _scrollHomeChatToBottom();
 
-    if (!kIsWeb && Platform.isAndroid && mounted) {
+    if (_isNativeAndroid && mounted) {
       try {
         await AutoStartGuideDialog.showIfNeeded(context);
       } catch (e) {
@@ -4797,8 +4823,8 @@ class _HomeChatMessage {
     this.content,
     this.deck,
     this.choices = const [],
-    this.selectedValue,
-  }) : id = id ?? flashcardId('home_msg');
+  }) : selectedValue = null,
+       id = id ?? flashcardId('home_msg');
 
   factory _HomeChatMessage.contentPreview({required PreparedContent content}) {
     return _HomeChatMessage(

--- a/fabushi/lib/screens/main_navigation_screen_web.dart
+++ b/fabushi/lib/screens/main_navigation_screen_web.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../features/auth/application/auth_model.dart';
+import 'globe_home_screen.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -16,427 +17,85 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   bool _profileMenuOpen = false;
 
   Future<void> _openLogin() async {
-    await showDialog<bool>(
+    final success = await showDialog<bool>(
       context: context,
-      barrierColor: Colors.black.withValues(alpha: 0.72),
-      builder: (dialogContext) => const _WebLoginDialog(),
+      barrierColor: Colors.black.withValues(alpha: 0.66),
+      builder: (_) => const _WebLoginDialog(),
     );
+
+    if (!mounted || success != true) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('登录成功'), backgroundColor: Colors.green),
+    );
+  }
+
+  void _toggleProfileMenu() {
+    setState(() => _profileMenuOpen = !_profileMenuOpen);
+  }
+
+  void _closeProfileMenu() {
+    if (!_profileMenuOpen) return;
+    setState(() => _profileMenuOpen = false);
   }
 
   @override
   Widget build(BuildContext context) {
     final authModel = context.watch<AuthModel?>();
     final user = authModel?.currentUser;
-    final displayName = user?.displayName.trim();
-    final name = displayName == null || displayName.isEmpty ? '朋友' : displayName;
+    final compact = MediaQuery.sizeOf(context).width < 720;
 
-    return Scaffold(
-      backgroundColor: const Color(0xFF111318),
-      body: LayoutBuilder(
-        builder: (context, constraints) {
-          final compact = constraints.maxWidth < 860;
-          final sideWidth = compact ? 0.0 : 268.0;
-
-          return Stack(
-            children: [
-              const Positioned.fill(child: _LingguangBackdrop()),
-              if (!compact)
-                Positioned(
-                  left: 0,
-                  top: 0,
-                  bottom: 0,
-                  width: sideWidth,
-                  child: _SideRail(
-                    user: user,
-                    profileMenuOpen: _profileMenuOpen,
-                    onProfileTap: () => setState(() => _profileMenuOpen = !_profileMenuOpen),
-                  ),
-                ),
-              Positioned(
-                left: sideWidth,
-                top: 0,
-                right: 0,
-                bottom: 0,
-                child: _HomeShell(
-                  name: name,
-                  compact: compact,
-                  user: user,
-                  onLoginPressed: _openLogin,
-                  onProfilePressed: compact
-                      ? () => setState(() => _profileMenuOpen = !_profileMenuOpen)
-                      : null,
-                ),
-              ),
-              if (_profileMenuOpen)
-                Positioned.fill(
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.translucent,
-                    onTap: () => setState(() => _profileMenuOpen = false),
-                    child: const SizedBox.expand(),
-                  ),
-                ),
-              if (_profileMenuOpen)
-                Positioned(
-                  left: compact ? 20 : 24,
-                  bottom: compact ? 76 : 92,
-                  child: _ProfileMenu(
-                    user: user,
-                    onLogin: () {
-                      setState(() => _profileMenuOpen = false);
-                      unawaited(_openLogin());
-                    },
-                    onLogout: () {
-                      setState(() => _profileMenuOpen = false);
-                      unawaited(authModel?.logout());
-                    },
-                  ),
-                ),
-              if (compact)
-                Positioned(
-                  left: 18,
-                  bottom: 18,
-                  child: _AvatarButton(
-                    user: user,
-                    onTap: () => setState(() => _profileMenuOpen = !_profileMenuOpen),
-                    selected: _profileMenuOpen,
-                  ),
-                ),
-            ],
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _HomeShell extends StatelessWidget {
-  const _HomeShell({
-    required this.name,
-    required this.compact,
-    required this.user,
-    required this.onLoginPressed,
-    this.onProfilePressed,
-  });
-
-  final String name;
-  final bool compact;
-  final User? user;
-  final VoidCallback onLoginPressed;
-  final VoidCallback? onProfilePressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return SafeArea(
-      child: Stack(
-        children: [
-          Positioned(
-            right: compact ? 18 : 26,
-            top: 16,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const _DownloadButton(),
-                const SizedBox(width: 14),
-                if (user == null)
-                  _TopLoginButton(onPressed: onLoginPressed)
-                else if (compact && onProfilePressed != null)
-                  _AvatarButton(user: user, onTap: onProfilePressed!),
-              ],
-            ),
-          ),
-          Center(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 840),
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(
-                  compact ? 24 : 60,
-                  compact ? 80 : 32,
-                  compact ? 24 : 60,
-                  150,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Hi,$name',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: compact ? 36 : 44,
-                        height: 1.1,
-                        fontWeight: FontWeight.w900,
-                        letterSpacing: -0.6,
-                      ),
-                    ),
-                    const SizedBox(height: 18),
-                    const Text(
-                      '灵光，让复杂变简单',
-                      style: TextStyle(
-                        color: Color(0xCCFFFFFF),
-                        fontSize: 24,
-                        height: 1.2,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    const SizedBox(height: 34),
-                    Wrap(
-                      spacing: 12,
-                      runSpacing: 14,
-                      children: const [
-                        _PromptChip(icon: Icons.auto_awesome, label: '你是谁'),
-                        _PromptChip(icon: Icons.eco, label: '人生新手村通关闪应用'),
-                        _PromptChip(icon: Icons.sports_esports, label: '搓个小游戏'),
-                        _PromptChip(icon: Icons.landscape, label: '朋友圈生图灵感'),
-                        _PromptChip(icon: Icons.lightbulb, label: '原来是这样'),
-                        _PromptChip(icon: Icons.waving_hand, label: '我今天灵光吗?'),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            left: compact ? 22 : 214,
-            right: compact ? 22 : 214,
-            bottom: 48,
-            child: const _AskBox(),
-          ),
-          const Positioned(
-            right: 24,
-            bottom: 190,
-            child: _FloatingTools(),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _SideRail extends StatelessWidget {
-  const _SideRail({
-    required this.user,
-    required this.profileMenuOpen,
-    required this.onProfileTap,
-  });
-
-  final User? user;
-  final bool profileMenuOpen;
-  final VoidCallback onProfileTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: const Color(0xE51D2027),
-        border: Border(right: BorderSide(color: Colors.white.withValues(alpha: 0.08))),
-      ),
-      child: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(14, 22, 14, 18),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Row(
-                children: const [
-                  _AppMark(size: 34),
-                  SizedBox(width: 10),
-                  Text(
-                    '灵光',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 18,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 24),
-              const _RailItem(icon: Icons.chat_bubble_outline, label: '新对话', selected: true),
-              const _RailItem(icon: Icons.bookmark_outline, label: '我的收藏'),
-              const _RailItem(icon: Icons.rocket_launch_outlined, label: '我的创作'),
-              const SizedBox(height: 28),
-              _RailSectionTitle('近期对话'),
-              const _RailItem(icon: Icons.notes, label: '经营菜市场游戏', dense: true),
-              const _RailItem(icon: Icons.notes, label: '日常问候', dense: true),
-              const SizedBox(height: 12),
-              _RailSectionTitle('更多对话'),
-              const _RailItem(icon: Icons.notes, label: '制作浪漫烟花互动应用', dense: true),
-              const Spacer(),
-              const _RailItem(icon: Icons.add_circle_outline, label: '创建闪应用'),
-              const SizedBox(height: 10),
-              InkWell(
-                borderRadius: BorderRadius.circular(16),
-                onTap: onProfileTap,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: profileMenuOpen ? Colors.white.withValues(alpha: 0.08) : Colors.transparent,
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Row(
-                    children: [
-                      _AvatarButton(user: user, onTap: onProfileTap, selected: profileMenuOpen, small: true),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: Text(
-                          user == null ? '登录' : user!.displayName,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
-                        ),
-                      ),
-                      const Icon(Icons.chevron_right, color: Colors.white70),
-                    ],
-                  ),
-                ),
-              ),
-            ],
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: GlobeHomeScreen(
+            topBarTrailing: user == null
+                ? _TopLoginButton(onPressed: _openLogin)
+                : const SizedBox(width: 42, height: 42),
+            composerLeftInset: compact ? 84 : 88,
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _RailItem extends StatelessWidget {
-  const _RailItem({required this.icon, required this.label, this.selected = false, this.dense = false});
-
-  final IconData icon;
-  final String label;
-  final bool selected;
-  final bool dense;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      margin: EdgeInsets.only(bottom: dense ? 4 : 8),
-      padding: EdgeInsets.symmetric(horizontal: 12, vertical: dense ? 9 : 12),
-      decoration: BoxDecoration(
-        color: selected ? Colors.white.withValues(alpha: 0.07) : Colors.transparent,
-        borderRadius: BorderRadius.circular(14),
-      ),
-      child: Row(
-        children: [
-          Icon(icon, color: selected ? Colors.white : Colors.white70, size: dense ? 18 : 21),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              label,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: selected ? Colors.white : Colors.white70,
-                fontWeight: selected ? FontWeight.w800 : FontWeight.w600,
-                fontSize: dense ? 14 : 15,
+        if (_profileMenuOpen)
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _closeProfileMenu,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        if (_profileMenuOpen)
+          Positioned(
+            left: 18,
+            bottom: compact ? 84 : 88,
+            child: SafeArea(
+              top: false,
+              right: false,
+              child: _ProfileMenu(
+                user: user,
+                onLogin: () {
+                  _closeProfileMenu();
+                  unawaited(_openLogin());
+                },
+                onLogout: () {
+                  _closeProfileMenu();
+                  unawaited(authModel?.logout());
+                },
               ),
             ),
           ),
-        ],
-      ),
-    );
-  }
-}
-
-class _RailSectionTitle extends StatelessWidget {
-  const _RailSectionTitle(this.text);
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(10, 6, 10, 8),
-      child: Text(text, style: const TextStyle(color: Colors.white38, fontSize: 13, fontWeight: FontWeight.w700)),
-    );
-  }
-}
-
-class _PromptChip extends StatelessWidget {
-  const _PromptChip({required this.icon, required this.label});
-
-  final IconData icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
-      decoration: BoxDecoration(
-        color: const Color(0xCC282C34),
-        borderRadius: BorderRadius.circular(23),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.05)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, color: const Color(0xFF9CC2FF), size: 19),
-          const SizedBox(width: 8),
-          Text(label, style: const TextStyle(color: Colors.white70, fontWeight: FontWeight.w700)),
-        ],
-      ),
-    );
-  }
-}
-
-class _AskBox extends StatelessWidget {
-  const _AskBox();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      constraints: const BoxConstraints(minHeight: 96),
-      padding: const EdgeInsets.fromLTRB(18, 14, 18, 14),
-      decoration: BoxDecoration(
-        color: const Color(0xF22B2E38),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.05)),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.25),
-            blurRadius: 26,
-            offset: const Offset(0, 18),
+        Positioned(
+          left: 18,
+          bottom: 16,
+          child: SafeArea(
+            top: false,
+            right: false,
+            child: _AvatarButton(
+              user: user,
+              selected: _profileMenuOpen,
+              onTap: _toggleProfileMenu,
+            ),
           ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          const Text('问一问灵光', style: TextStyle(color: Colors.white38, fontSize: 16, fontWeight: FontWeight.w600)),
-          const SizedBox(height: 18),
-          Row(
-            children: [
-              _RoundIconButton(icon: Icons.add, onPressed: () {}),
-              const Spacer(),
-              _RoundIconButton(icon: Icons.near_me, filled: true, onPressed: () {}),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _DownloadButton extends StatelessWidget {
-  const _DownloadButton();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: 42,
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.13),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: const Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.phone_iphone, size: 18, color: Colors.white),
-          SizedBox(width: 8),
-          Text('下载灵光手机应用', style: TextStyle(color: Colors.white, fontWeight: FontWeight.w700)),
-          SizedBox(width: 4),
-          Icon(Icons.keyboard_arrow_down, color: Colors.white70),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }
@@ -448,224 +107,87 @@ class _TopLoginButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FilledButton(
-      style: FilledButton.styleFrom(
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.black,
-        fixedSize: const Size(84, 42),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-      ),
-      onPressed: onPressed,
-      child: const Text('登录', style: TextStyle(fontWeight: FontWeight.w800)),
-    );
-  }
-}
-
-class _FloatingTools extends StatelessWidget {
-  const _FloatingTools();
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: const [
-        _ToolBubble(icon: Icons.grid_view_rounded),
-        SizedBox(height: 12),
-        _ToolBubble(icon: Icons.translate_rounded),
-      ],
-    );
-  }
-}
-
-class _ToolBubble extends StatelessWidget {
-  const _ToolBubble({required this.icon});
-
-  final IconData icon;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 48,
-      height: 48,
-      decoration: BoxDecoration(
-        color: const Color(0xFFF7A3C4),
-        borderRadius: BorderRadius.circular(18),
-        boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.22), blurRadius: 12)],
-      ),
-      child: Icon(icon, color: Colors.white),
-    );
-  }
-}
-
-class _RoundIconButton extends StatelessWidget {
-  const _RoundIconButton({required this.icon, required this.onPressed, this.filled = false});
-
-  final IconData icon;
-  final VoidCallback onPressed;
-  final bool filled;
-
-  @override
-  Widget build(BuildContext context) {
-    return InkResponse(
-      onTap: onPressed,
-      radius: 24,
-      child: Container(
-        width: 36,
-        height: 36,
-        decoration: BoxDecoration(
-          color: filled ? Colors.white.withValues(alpha: 0.16) : Colors.white.withValues(alpha: 0.08),
-          shape: BoxShape.circle,
-        ),
-        child: Icon(icon, color: Colors.white70, size: 20),
-      ),
-    );
-  }
-}
-
-class _ProfileMenu extends StatelessWidget {
-  const _ProfileMenu({required this.user, required this.onLogin, required this.onLogout});
-
-  final User? user;
-  final VoidCallback onLogin;
-  final VoidCallback onLogout;
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: Container(
-        width: 310,
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: const Color(0xF224272F),
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.35),
-              blurRadius: 28,
-              offset: const Offset(0, 16),
-            ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _ProfileHeader(user: user),
-            const Divider(color: Colors.white12, height: 18),
-            const _MenuItem(icon: Icons.person_outline, label: '个人信息'),
-            const _MenuItem(icon: Icons.dark_mode_outlined, label: '主题设置', trailing: '深色主题'),
-            const _MenuItem(icon: Icons.tune_outlined, label: '个性化'),
-            const _MenuItem(icon: Icons.manage_accounts_outlined, label: '账号设置'),
-            const Divider(color: Colors.white12, height: 18),
-            const _MenuItem(icon: Icons.help_outline, label: '帮助与反馈'),
-            const _MenuItem(icon: Icons.info_outline, label: '关于灵光'),
-            const SizedBox(height: 8),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                style: FilledButton.styleFrom(
-                  backgroundColor: Colors.white.withValues(alpha: 0.08),
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-                ),
-                onPressed: user == null ? onLogin : onLogout,
-                child: Text(user == null ? '登录' : '退出登录'),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _ProfileHeader extends StatelessWidget {
-  const _ProfileHeader({required this.user});
-
-  final User? user;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        _AvatarButton(user: user, onTap: () {}, small: true),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                user?.displayName ?? '未登录',
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900, fontSize: 17),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                user == null ? '点击登录同步你的灵感' : '账号信息已同步',
-                style: const TextStyle(color: Colors.white54, fontSize: 12),
-              ),
-            ],
+    return SizedBox(
+      width: 96,
+      height: 42,
+      child: FilledButton(
+        style: FilledButton.styleFrom(
+          padding: EdgeInsets.zero,
+          backgroundColor: Colors.white,
+          foregroundColor: const Color(0xFF11151D),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
           ),
         ),
-      ],
-    );
-  }
-}
-
-class _MenuItem extends StatelessWidget {
-  const _MenuItem({required this.icon, required this.label, this.trailing});
-
-  final IconData icon;
-  final String label;
-  final String? trailing;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 12),
-      child: Row(
-        children: [
-          Icon(icon, color: Colors.white70, size: 21),
-          const SizedBox(width: 12),
-          Expanded(child: Text(label, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700))),
-          if (trailing != null) Text(trailing!, style: const TextStyle(color: Colors.white54, fontSize: 13)),
-          const SizedBox(width: 4),
-          const Icon(Icons.chevron_right, color: Colors.white38, size: 20),
-        ],
+        onPressed: onPressed,
+        child: const FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Text(
+            '登录',
+            maxLines: 1,
+            softWrap: false,
+            style: TextStyle(fontWeight: FontWeight.w800),
+          ),
+        ),
       ),
     );
   }
 }
 
 class _AvatarButton extends StatelessWidget {
-  const _AvatarButton({required this.user, required this.onTap, this.selected = false, this.small = false});
+  const _AvatarButton({
+    required this.user,
+    required this.onTap,
+    this.selected = false,
+  });
 
   final User? user;
   final VoidCallback onTap;
   final bool selected;
-  final bool small;
 
   @override
   Widget build(BuildContext context) {
-    final avatar = user?.avatar;
-    final name = user?.displayName ?? '灵';
-    final initial = name.isEmpty ? '灵' : name.characters.first;
-    final size = small ? 36.0 : 46.0;
+    final avatar = user?.avatar?.trim();
+    final name = user?.displayName.trim() ?? '';
+    final initial = name.isEmpty ? '大' : name.substring(0, 1);
 
-    return InkResponse(
-      onTap: onTap,
-      radius: size / 2 + 6,
-      child: Container(
-        width: size,
-        height: size,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(color: selected ? const Color(0xFF8BB9FF) : Colors.white.withValues(alpha: 0.28), width: 2),
-        ),
-        child: ClipOval(
-          child: avatar != null && avatar.isNotEmpty
-              ? Image.network(avatar, fit: BoxFit.cover, errorBuilder: (_, __, ___) => _AvatarFallback(initial: initial))
-              : _AvatarFallback(initial: initial),
+    return Material(
+      color: Colors.transparent,
+      child: InkResponse(
+        onTap: onTap,
+        radius: 30,
+        child: Container(
+          width: 52,
+          height: 52,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: selected
+                  ? const Color(0xFF78D6E8)
+                  : Colors.white.withValues(alpha: 0.32),
+              width: 2,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.28),
+                blurRadius: 16,
+                offset: const Offset(0, 8),
+              ),
+            ],
+          ),
+          child: ClipOval(
+            child:
+                avatar != null &&
+                    (avatar.startsWith('http://') ||
+                        avatar.startsWith('https://'))
+                ? Image.network(
+                    avatar,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) =>
+                        _AvatarFallback(initial: initial),
+                  )
+                : _AvatarFallback(initial: initial),
+          ),
         ),
       ),
     );
@@ -680,85 +202,168 @@ class _AvatarFallback extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: const Color(0xFF587CFF),
       alignment: Alignment.center,
-      child: Text(initial, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900)),
-    );
-  }
-}
-
-class _WebLoginDialog extends StatelessWidget {
-  const _WebLoginDialog();
-
-  @override
-  Widget build(BuildContext context) {
-    final width = MediaQuery.sizeOf(context).width;
-    final compact = width < 760;
-
-    return Dialog(
-      insetPadding: EdgeInsets.symmetric(horizontal: compact ? 18 : 32, vertical: 32),
-      backgroundColor: Colors.transparent,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 880, maxHeight: 560),
-        child: Container(
-          decoration: BoxDecoration(
-            color: const Color(0xF20A0B0F),
-            borderRadius: BorderRadius.circular(28),
-            border: Border.all(color: const Color(0xFF526991)),
-            boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.45), blurRadius: 42)],
-          ),
-          child: Row(
-            children: [
-              if (!compact)
-                const Expanded(
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.horizontal(left: Radius.circular(28)),
-                    child: _LoginArtwork(),
-                  ),
-                ),
-              Expanded(
-                child: Stack(
-                  children: [
-                    const Positioned.fill(child: _LoginShadow()),
-                    Center(
-                      child: SingleChildScrollView(
-                        padding: const EdgeInsets.symmetric(horizontal: 46, vertical: 34),
-                        child: _LoginForm(compact: compact),
-                      ),
-                    ),
-                    Positioned(
-                      right: 14,
-                      top: 14,
-                      child: IconButton(
-                        onPressed: () => Navigator.of(context).pop(),
-                        icon: const Icon(Icons.close, color: Colors.white54),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [Color(0xFF15253A), Color(0xFF2A7C91)],
+        ),
+      ),
+      child: Text(
+        initial,
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.w900,
+          fontSize: 18,
         ),
       ),
     );
   }
 }
 
-class _LoginForm extends StatefulWidget {
-  const _LoginForm({required this.compact});
+class _ProfileMenu extends StatelessWidget {
+  const _ProfileMenu({
+    required this.user,
+    required this.onLogin,
+    required this.onLogout,
+  });
 
-  final bool compact;
+  final User? user;
+  final VoidCallback onLogin;
+  final VoidCallback onLogout;
 
   @override
-  State<_LoginForm> createState() => _LoginFormState();
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        width: 292,
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: const Color(0xF21A2028),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.36),
+              blurRadius: 28,
+              offset: const Offset(0, 16),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                _AvatarButton(user: user, onTap: () {}),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        user?.displayName ?? '未登录',
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 17,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        user == null ? '登录后同步修行记录' : '账号信息已同步',
+                        style: const TextStyle(
+                          color: Colors.white54,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            const Divider(color: Colors.white12),
+            _MenuItem(
+              icon: Icons.manage_accounts_outlined,
+              label: user == null ? '账号登录' : '账号设置',
+            ),
+            _MenuItem(
+              icon: Icons.public_rounded,
+              label: '全球法布施首页',
+              trailing: 'Web',
+            ),
+            const SizedBox(height: 8),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: Colors.white.withValues(alpha: 0.09),
+                foregroundColor: Colors.white,
+                minimumSize: const Size.fromHeight(44),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+              onPressed: user == null ? onLogin : onLogout,
+              child: Text(user == null ? '登录' : '退出登录'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
-class _LoginFormState extends State<_LoginForm> {
+class _MenuItem extends StatelessWidget {
+  const _MenuItem({required this.icon, required this.label, this.trailing});
+
+  final IconData icon;
+  final String label;
+  final String? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Icon(icon, color: Colors.white70, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          if (trailing != null)
+            Text(
+              trailing!,
+              style: const TextStyle(color: Colors.white38, fontSize: 12),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WebLoginDialog extends StatefulWidget {
+  const _WebLoginDialog();
+
+  @override
+  State<_WebLoginDialog> createState() => _WebLoginDialogState();
+}
+
+class _WebLoginDialogState extends State<_WebLoginDialog> {
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
   bool _loading = false;
-  bool _agreed = false;
   bool _obscure = true;
   String? _error;
 
@@ -776,10 +381,6 @@ class _LoginFormState extends State<_LoginForm> {
       setState(() => _error = '请输入账号和密码');
       return;
     }
-    if (!_agreed) {
-      setState(() => _error = '请先阅读并同意服务协议和隐私政策');
-      return;
-    }
 
     setState(() {
       _loading = true;
@@ -793,9 +394,6 @@ class _LoginFormState extends State<_LoginForm> {
     setState(() => _loading = false);
     if (success) {
       Navigator.of(context).pop(true);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('登录成功'), backgroundColor: Colors.green),
-      );
     } else {
       setState(() => _error = authModel.error ?? '登录失败，请稍后重试');
     }
@@ -808,95 +406,121 @@ class _LoginFormState extends State<_LoginForm> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        const _AppMark(size: 58),
-        const SizedBox(height: 24),
-        _DarkInput(
-          controller: _usernameController,
-          hint: '请输入账号',
-          prefix: Icons.person_outline,
-          onSubmitted: (_) => _login(),
-        ),
-        const SizedBox(height: 16),
-        _DarkInput(
-          controller: _passwordController,
-          hint: '请输入密码',
-          prefix: Icons.lock_outline,
-          obscureText: _obscure,
-          suffix: IconButton(
-            onPressed: () => setState(() => _obscure = !_obscure),
-            icon: Icon(_obscure ? Icons.visibility_off : Icons.visibility, color: Colors.white38, size: 19),
+    final compact = MediaQuery.sizeOf(context).width < 640;
+
+    return Dialog(
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: compact ? 18 : 32,
+        vertical: 32,
+      ),
+      backgroundColor: Colors.transparent,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Container(
+          padding: EdgeInsets.fromLTRB(
+            compact ? 24 : 30,
+            28,
+            compact ? 24 : 30,
+            24,
           ),
-          onSubmitted: (_) => _login(),
-        ),
-        if (_error != null) ...[
-          const SizedBox(height: 10),
-          Text(_error!, textAlign: TextAlign.center, style: const TextStyle(color: Colors.redAccent, fontSize: 13)),
-        ],
-        const SizedBox(height: 24),
-        SizedBox(
-          height: 54,
-          width: double.infinity,
-          child: OutlinedButton(
-            onPressed: _loading ? null : _login,
-            style: OutlinedButton.styleFrom(
-              foregroundColor: Colors.white,
-              side: BorderSide(color: Colors.white.withValues(alpha: 0.55)),
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-            ),
-            child: _loading
-                ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2))
-                : const Text('下一步', style: TextStyle(fontWeight: FontWeight.w800, fontSize: 16)),
-          ),
-        ),
-        const SizedBox(height: 24),
-        InkResponse(
-          onTap: _openFullLogin,
-          radius: 24,
-          child: Container(
-            width: 48,
-            height: 48,
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              border: Border.all(color: Colors.white.withValues(alpha: 0.18)),
-              color: Colors.white.withValues(alpha: 0.03),
-            ),
-            child: const Text('支', style: TextStyle(color: Colors.white, fontSize: 23, fontWeight: FontWeight.w900)),
-          ),
-        ),
-        const SizedBox(height: 22),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Checkbox(
-              value: _agreed,
-              onChanged: (value) => setState(() => _agreed = value ?? false),
-              visualDensity: VisualDensity.compact,
-              side: const BorderSide(color: Colors.white38),
-            ),
-            const Expanded(
-              child: Padding(
-                padding: EdgeInsets.only(top: 8),
-                child: Text.rich(
-                  TextSpan(
-                    text: '我已阅读并同意 灵光 的 ',
-                    children: [
-                      TextSpan(text: '服务协议', style: TextStyle(color: Color(0xFF5FA8FF))),
-                      TextSpan(text: ' 和 '),
-                      TextSpan(text: '隐私政策', style: TextStyle(color: Color(0xFF5FA8FF))),
-                    ],
-                  ),
-                  style: TextStyle(color: Colors.white54, fontSize: 12, height: 1.4),
-                ),
+          decoration: BoxDecoration(
+            color: const Color(0xF20A0D12),
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.44),
+                blurRadius: 42,
+                offset: const Offset(0, 24),
               ),
-            ),
-          ],
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  const _AppMark(),
+                  const SizedBox(width: 12),
+                  const Expanded(
+                    child: Text(
+                      '登录大乘',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 22,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    icon: const Icon(Icons.close, color: Colors.white54),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              _DarkInput(
+                controller: _usernameController,
+                hint: '请输入账号',
+                prefix: Icons.person_outline,
+                onSubmitted: (_) => _login(),
+              ),
+              const SizedBox(height: 14),
+              _DarkInput(
+                controller: _passwordController,
+                hint: '请输入密码',
+                prefix: Icons.lock_outline,
+                obscureText: _obscure,
+                suffix: IconButton(
+                  onPressed: () => setState(() => _obscure = !_obscure),
+                  icon: Icon(
+                    _obscure ? Icons.visibility_off : Icons.visibility,
+                    color: Colors.white38,
+                    size: 19,
+                  ),
+                ),
+                onSubmitted: (_) => _login(),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 10),
+                Text(
+                  _error!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.redAccent, fontSize: 13),
+                ),
+              ],
+              const SizedBox(height: 22),
+              FilledButton(
+                style: FilledButton.styleFrom(
+                  backgroundColor: Colors.white,
+                  foregroundColor: const Color(0xFF11151D),
+                  minimumSize: const Size.fromHeight(50),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+                onPressed: _loading ? null : _login,
+                child: _loading
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text(
+                        '登录',
+                        style: TextStyle(fontWeight: FontWeight.w900),
+                      ),
+              ),
+              const SizedBox(height: 14),
+              TextButton(
+                onPressed: _loading ? null : _openFullLogin,
+                child: const Text('使用支付宝/完整登录页'),
+              ),
+            ],
+          ),
         ),
-      ],
+      ),
     );
   }
 }
@@ -920,21 +544,29 @@ class _DarkInput extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 54,
-      decoration: BoxDecoration(color: const Color(0xFF222222), borderRadius: BorderRadius.circular(27)),
+    return SizedBox(
+      height: 52,
       child: TextField(
         controller: controller,
         obscureText: obscureText,
         onSubmitted: onSubmitted,
         style: const TextStyle(color: Colors.white),
         decoration: InputDecoration(
+          filled: true,
+          fillColor: Colors.white.withValues(alpha: 0.07),
           prefixIcon: Icon(prefix, color: Colors.white38),
           suffixIcon: suffix,
           hintText: hint,
-          hintStyle: const TextStyle(color: Colors.white30),
-          border: InputBorder.none,
-          contentPadding: const EdgeInsets.symmetric(vertical: 16, horizontal: 18),
+          hintStyle: const TextStyle(color: Colors.white38),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.08)),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: const BorderSide(color: Color(0xFF78D6E8)),
+          ),
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
         ),
       ),
     );
@@ -942,173 +574,26 @@ class _DarkInput extends StatelessWidget {
 }
 
 class _AppMark extends StatelessWidget {
-  const _AppMark({required this.size});
-
-  final double size;
+  const _AppMark();
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: size,
-      height: size,
+      width: 42,
+      height: 42,
+      alignment: Alignment.center,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(size * 0.28),
+        borderRadius: BorderRadius.circular(14),
         gradient: const LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [Color(0xFF111D48), Color(0xFF4FA5FF), Color(0xFFB8F0FF)],
+          colors: [Color(0xFF15253A), Color(0xFF2A7C91)],
         ),
-        boxShadow: [BoxShadow(color: const Color(0xFF55B6FF).withValues(alpha: 0.35), blurRadius: size * 0.28)],
       ),
-      alignment: Alignment.center,
-      child: Text(
-        '灵',
-        style: TextStyle(color: Colors.white, fontSize: size * 0.46, fontWeight: FontWeight.w900),
+      child: const Text(
+        '大',
+        style: TextStyle(color: Colors.white, fontWeight: FontWeight.w900),
       ),
     );
   }
-}
-
-class _LoginArtwork extends StatelessWidget {
-  const _LoginArtwork();
-
-  @override
-  Widget build(BuildContext context) {
-    return const _LingguangBackdrop(dimmed: false);
-  }
-}
-
-class _LoginShadow extends StatelessWidget {
-  const _LoginShadow();
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          colors: [Colors.black.withValues(alpha: 0.52), Colors.black.withValues(alpha: 0.9)],
-        ),
-      ),
-    );
-  }
-}
-
-class _LingguangBackdrop extends StatelessWidget {
-  const _LingguangBackdrop({this.dimmed = true});
-
-  final bool dimmed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        const DecoratedBox(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: [Color(0xFF2A425C), Color(0xFF111318), Color(0xFF08090D)],
-            ),
-          ),
-        ),
-        CustomPaint(painter: _PlanetPainter()),
-        CustomPaint(painter: _MountainPainter()),
-        if (dimmed) Container(color: Colors.black.withValues(alpha: 0.42)),
-        DecoratedBox(
-          decoration: BoxDecoration(
-            gradient: RadialGradient(
-              center: const Alignment(0.3, -0.35),
-              radius: 0.9,
-              colors: [Colors.transparent, Colors.black.withValues(alpha: 0.35)],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlanetPainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final ringPaint = Paint()
-      ..color = Colors.white.withValues(alpha: 0.16)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2.2;
-    final glowPaint = Paint()
-      ..color = const Color(0xFFE7D6A3).withValues(alpha: 0.18)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 14
-      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 18);
-    final center = Offset(size.width * 0.42, size.height * 0.2);
-    final rect = Rect.fromCenter(center: center, width: size.width * 0.32, height: size.width * 0.32);
-    canvas.drawArc(rect, -0.15, 4.6, false, glowPaint);
-    canvas.drawArc(rect, -0.15, 4.6, false, ringPaint);
-
-    final ringRect = Rect.fromCenter(center: center, width: size.width * 0.48, height: size.width * 0.12);
-    canvas.save();
-    canvas.translate(center.dx, center.dy);
-    canvas.rotate(-0.34);
-    canvas.translate(-center.dx, -center.dy);
-    canvas.drawArc(ringRect, 3.35, 2.45, false, ringPaint..strokeWidth = 1.4);
-    canvas.restore();
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
-}
-
-class _MountainPainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final far = Paint()..color = const Color(0xFF39465C).withValues(alpha: 0.7);
-    final mid = Paint()..color = const Color(0xFF213022).withValues(alpha: 0.92);
-    final near = Paint()..color = const Color(0xFF0D1110).withValues(alpha: 0.9);
-    final snow = Paint()..color = Colors.white.withValues(alpha: 0.68);
-
-    final peak = Path()
-      ..moveTo(0, size.height * 0.64)
-      ..lineTo(size.width * 0.26, size.height * 0.46)
-      ..lineTo(size.width * 0.43, size.height * 0.56)
-      ..lineTo(size.width * 0.58, size.height * 0.34)
-      ..lineTo(size.width * 0.78, size.height * 0.55)
-      ..lineTo(size.width, size.height * 0.38)
-      ..lineTo(size.width, size.height)
-      ..lineTo(0, size.height)
-      ..close();
-    canvas.drawPath(peak, far);
-
-    final snowPath = Path()
-      ..moveTo(size.width * 0.54, size.height * 0.4)
-      ..lineTo(size.width * 0.58, size.height * 0.34)
-      ..lineTo(size.width * 0.63, size.height * 0.43)
-      ..lineTo(size.width * 0.59, size.height * 0.41)
-      ..lineTo(size.width * 0.56, size.height * 0.47)
-      ..close();
-    canvas.drawPath(snowPath, snow);
-
-    final forest = Path()
-      ..moveTo(0, size.height * 0.74)
-      ..quadraticBezierTo(size.width * 0.25, size.height * 0.6, size.width * 0.5, size.height * 0.7)
-      ..quadraticBezierTo(size.width * 0.75, size.height * 0.8, size.width, size.height * 0.62)
-      ..lineTo(size.width, size.height)
-      ..lineTo(0, size.height)
-      ..close();
-    canvas.drawPath(forest, mid);
-
-    final foreground = Path()
-      ..moveTo(0, size.height * 0.86)
-      ..quadraticBezierTo(size.width * 0.22, size.height * 0.78, size.width * 0.48, size.height * 0.86)
-      ..quadraticBezierTo(size.width * 0.74, size.height * 0.94, size.width, size.height * 0.78)
-      ..lineTo(size.width, size.height)
-      ..lineTo(0, size.height)
-      ..close();
-    canvas.drawPath(foreground, near);
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/fabushi/lib/screens/membership_screen_web.dart
+++ b/fabushi/lib/screens/membership_screen_web.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class MembershipScreen extends StatelessWidget {
+  const MembershipScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF090B10),
+      appBar: AppBar(title: const Text('会员')),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Web 首页保持轻量加载，会员解锁请在 App 端完成。',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Colors.white70, fontSize: 16, height: 1.5),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fabushi/lib/services/alipay_service_web.dart
+++ b/fabushi/lib/services/alipay_service_web.dart
@@ -1,0 +1,9 @@
+class AlipayService {
+  Future<Map<String, dynamic>> initAlipay() async {
+    return {'success': false, 'message': '支付宝 APP 支付不支持 Web 平台'};
+  }
+
+  Future<Map<String, dynamic>> payWithAlipay(String orderString) async {
+    return {'success': false, 'message': '请在 App 端使用支付宝解锁'};
+  }
+}

--- a/fabushi/lib/services/apple_iap_service_web.dart
+++ b/fabushi/lib/services/apple_iap_service_web.dart
@@ -1,0 +1,15 @@
+class AppleIapService {
+  void Function(dynamic purchaseDetails)? onPurchaseSuccess;
+  void Function(String error)? onPurchaseError;
+
+  static bool get isAppleIapPlatform => false;
+
+  Future<bool> initialize() async => false;
+
+  Future<bool> purchase(String productId) async {
+    onPurchaseError?.call('Apple IAP 不支持 Web 平台');
+    return false;
+  }
+
+  String? getTransactionId(dynamic purchaseDetails) => null;
+}

--- a/fabushi/lib/services/dharma_publish_service.dart
+++ b/fabushi/lib/services/dharma_publish_service.dart
@@ -2,8 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../models/file_transfer_model.dart';
-
 enum DharmaComposerTarget { global, platform }
 
 enum DharmaPublishPlatform {
@@ -199,12 +197,12 @@ class DharmaPublishService {
   ];
 
   DharmaPublishDraft buildDraftFromModel(
-    FileTransferModel model, {
+    dynamic model, {
     String fallbackText = '',
   }) {
-    final sourceUrl = model.selectedContentSourceUrl?.trim() ?? '';
-    final preview = model.selectedContentPreviewText?.trim() ?? '';
-    final title = model.selectedContentTitle.trim();
+    final sourceUrl = (model.selectedContentSourceUrl as String?)?.trim() ?? '';
+    final preview = (model.selectedContentPreviewText as String?)?.trim() ?? '';
+    final title = (model.selectedContentTitle as String).trim();
     final text = preview.isNotEmpty ? preview : fallbackText.trim();
 
     return DharmaPublishDraft(
@@ -220,8 +218,12 @@ class DharmaPublishService {
     DharmaPublishDraft draft,
     Iterable<DharmaPublishPlatform> platforms,
   ) {
-    final requiresTitle = platforms.any((platform) => platform.info.titleRequired);
-    final requiresBody = platforms.any((platform) => platform.info.bodyRequired);
+    final requiresTitle = platforms.any(
+      (platform) => platform.info.titleRequired,
+    );
+    final requiresBody = platforms.any(
+      (platform) => platform.info.bodyRequired,
+    );
     final missing = <String>[];
 
     if (requiresTitle && _needsTitleReview(draft)) missing.add('title');
@@ -251,7 +253,9 @@ class DharmaPublishService {
   String polishBody(DharmaPublishDraft draft) {
     final body = draft.body.trim();
     if (body.isEmpty) return body;
-    final title = draft.title.trim().isEmpty ? suggestTitle(draft) : draft.title.trim();
+    final title = draft.title.trim().isEmpty
+        ? suggestTitle(draft)
+        : draft.title.trim();
     final tags = draft.tags.isEmpty ? ['法布施', '大乘'] : draft.tags;
     return [
       title,
@@ -300,23 +304,18 @@ class DharmaPublishService {
     DharmaPublishPlatform platform,
   ) async {
     final info = platform.info;
-    final steps = <String>[
-      '已生成 ${info.label} 发布草稿',
-      '已复制标题、正文、来源链接和标签到剪贴板',
-    ];
+    final steps = <String>['已生成 ${info.label} 发布草稿', '已复制标题、正文、来源链接和标签到剪贴板'];
 
     if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
       try {
-        final response = await _platformChannel.invokeMethod<dynamic>(
-          'shareToPlatform',
-          {
-            'packageName': info.androidPackage,
-            'platformName': info.label,
-            'title': draft.title,
-            'text': draft.fullText,
-            'url': draft.sourceUrl,
-          },
-        );
+        final response = await _platformChannel
+            .invokeMethod<dynamic>('shareToPlatform', {
+              'packageName': info.androidPackage,
+              'platformName': info.label,
+              'title': draft.title,
+              'text': draft.fullText,
+              'url': draft.sourceUrl,
+            });
         final map = response is Map ? response : const <dynamic, dynamic>{};
         final success = map['success'] == true;
         final message = (map['message'] ?? '').toString();
@@ -364,7 +363,9 @@ class DharmaPublishService {
   bool _needsTitleReview(DharmaPublishDraft draft) {
     final title = draft.title.trim();
     if (title.length < 4) return true;
-    if (title.startsWith('http://') || title.startsWith('https://')) return true;
+    if (title.startsWith('http://') || title.startsWith('https://')) {
+      return true;
+    }
     if (draft.sourceUrl.trim().isEmpty) return false;
     final uri = Uri.tryParse(draft.sourceUrl.trim());
     if (uri == null) return false;

--- a/fabushi/lib/widgets/auto_start_guide_dialog.dart
+++ b/fabushi/lib/widgets/auto_start_guide_dialog.dart
@@ -1,4 +1,5 @@
-import 'dart:io';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,7 +21,7 @@ class AutoStartGuideDialog extends StatefulWidget {
     BuildContext context, {
     bool force = false,
   }) async {
-    if (!Platform.isAndroid) return;
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
 
     final prefs = await SharedPreferences.getInstance();
     final hasShown = prefs.getBool('auto_start_guide_shown') ?? false;
@@ -91,7 +92,9 @@ class _AutoStartGuideDialogState extends State<AutoStartGuideDialog> {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: theme.colorScheme.primaryContainer.withOpacity(0.3),
+                    color: theme.colorScheme.primaryContainer.withValues(
+                      alpha: 0.3,
+                    ),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Row(
@@ -147,9 +150,11 @@ class _AutoStartGuideDialogState extends State<AutoStartGuideDialog> {
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: Colors.orange.withOpacity(0.1),
+                  color: Colors.orange.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.orange.withOpacity(0.3)),
+                  border: Border.all(
+                    color: Colors.orange.withValues(alpha: 0.3),
+                  ),
                 ),
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -205,7 +210,7 @@ class _AutoStartGuideDialogState extends State<AutoStartGuideDialog> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest.withOpacity(0.5),
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(

--- a/frontend/apps/mp-wechat/src/pages/index/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/index/index.tsx
@@ -3,13 +3,10 @@ import { Button, Text, Textarea, View } from "@tarojs/components";
 import {
   buildGlobalDharmaChecklist,
   createDachengId,
-  dachengBrand,
-  dachengHeroChips,
-  dachengToolEntries,
+  dachengHomeExperience,
   globalDharmaStartMessage,
   makeDachengFlashcards,
   nextDachengFlashcardDue,
-  remnoteInspiredFlashcardPrinciples,
   type DachengFlashcard,
   type DachengRating,
   type DachengToolId,
@@ -26,6 +23,12 @@ interface Message {
 }
 
 const ratingLabels: DachengRating[] = ["Again", "Hard", "Good", "Easy"];
+const {
+  brand,
+  heroChips,
+  toolEntries,
+  flashcardPrinciples,
+} = dachengHomeExperience;
 
 export default function IndexPage() {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -36,7 +39,7 @@ export default function IndexPage() {
   const [cards, setCards] = useState<DachengFlashcard[]>([]);
   const [cardIndex, setCardIndex] = useState(0);
   const [showAnswer, setShowAnswer] = useState(false);
-  const activeTool = dachengToolEntries.find((item) => item.id === tool) ?? null;
+  const activeTool = toolEntries.find((item) => item.id === tool) ?? null;
   const activeCard = cards[cardIndex] ?? null;
 
   function add(role: Role, text: string, tag?: string) {
@@ -69,7 +72,7 @@ export default function IndexPage() {
   }
 
   function submit() {
-    const text = input.trim() || dachengBrand.defaultText;
+    const text = input.trim() || brand.defaultText;
     setInput("");
     add("user", text, activeTool?.title);
     if (tool === "global-dharma") runGlobalDharma(text);
@@ -94,16 +97,16 @@ export default function IndexPage() {
     <View className={messages.length ? "page has-chat" : "page"}>
       <View className="bg" />
       <View className="topbar">
-        <Text className="brand">{dachengBrand.name}</Text>
+        <Text className="brand">{brand.name}</Text>
         <Button className="login">登录</Button>
       </View>
 
       {!messages.length && (
         <View className="hero">
-          <Text className="title">{dachengBrand.greeting}</Text>
-          <Text className="subtitle">{dachengBrand.tagline}</Text>
+          <Text className="title">{brand.greeting}</Text>
+          <Text className="subtitle">{brand.tagline}</Text>
           <View className="chips">
-            {dachengHeroChips.map((chip) => (
+            {heroChips.map((chip) => (
               <Button className="chip" key={chip.id} onClick={() => choosePrompt(chip.prompt, chip.tool)}>
                 <Text className="chip-icon">{chip.icon}</Text>
                 <Text>{chip.label}</Text>
@@ -116,7 +119,7 @@ export default function IndexPage() {
       <View className="messages">
         {messages.map((message) => (
           <View className={`message ${message.role}`} key={message.id}>
-            <Text className="avatar">{message.role === "user" ? "我" : dachengBrand.name.slice(0, 1)}</Text>
+            <Text className="avatar">{message.role === "user" ? "我" : brand.name.slice(0, 1)}</Text>
             <Text className="bubble">{message.tag ? `${message.tag}：` : ""}{message.text}</Text>
           </View>
         ))}
@@ -144,13 +147,13 @@ export default function IndexPage() {
           ) : (
             <Text className="panel-copy">选择背诵闪卡后会自动生成挖空卡和双向卡。</Text>
           )}
-          {remnoteInspiredFlashcardPrinciples.map((item) => <Text className="principle" key={item}>• {item}</Text>)}
+          {flashcardPrinciples.map((item) => <Text className="principle" key={item}>• {item}</Text>)}
         </View>
       </View>
 
       {menuOpen && (
         <View className="menu">
-          {dachengToolEntries.map((item) => (
+          {toolEntries.map((item) => (
             <View className="menu-item" key={item.id} onClick={() => { setTool(item.id); setMenuOpen(false); }}>
               <Text className="menu-icon">{item.icon}</Text>
               <View>
@@ -170,7 +173,7 @@ export default function IndexPage() {
           maxlength={1800}
           autoHeight
           onInput={(event) => setInput(event.detail.value)}
-          placeholder={activeTool ? `${activeTool.action}，也可以继续问一问${dachengBrand.name}` : dachengBrand.inputPlaceholder}
+          placeholder={activeTool ? `${activeTool.action}，也可以继续问一问${brand.name}` : brand.inputPlaceholder}
         />
         {activeTool && <Button className="mode" onClick={() => setTool(null)}>{activeTool.shortTitle}×</Button>}
         <Button className="send" onClick={submit}>➤</Button>

--- a/frontend/apps/web/src/components/fast-dacheng-home.tsx
+++ b/frontend/apps/web/src/components/fast-dacheng-home.tsx
@@ -1,33 +1,37 @@
 import {
-  dachengBrand,
-  dachengHeroChips,
-  dachengToolEntries,
-  globalDharmaRegions,
-  remnoteInspiredFlashcardPrinciples,
+  dachengHomeExperience,
 } from "@fabushi/shared";
 import { siteHref } from "../lib/site-url";
 
 export function FastDachengHome() {
+  const {
+    brand,
+    heroChips,
+    toolEntries,
+    regions,
+    flashcardPrinciples,
+  } = dachengHomeExperience;
+
   return (
     <main
       className="fast-home"
       data-fast-home-root
-      data-brand-name={dachengBrand.name}
-      data-default-text={dachengBrand.defaultText}
-      data-input-placeholder={dachengBrand.inputPlaceholder}
+      data-brand-name={brand.name}
+      data-default-text={brand.defaultText}
+      data-input-placeholder={brand.inputPlaceholder}
     >
       <div className="fast-bg" aria-hidden="true" />
 
       <aside className="fast-sidebar" aria-label="首页功能">
         <a className="fast-logo" href={siteHref("/")}>
           <span className="fast-logo-mark">大</span>
-          <span>{dachengBrand.name}</span>
+          <span>{brand.name}</span>
         </a>
         <button className="fast-side-button" type="button" data-new-chat>
           ✦ 新对话
         </button>
         <nav className="fast-side-nav" aria-label="快捷功能">
-          {dachengToolEntries.map((item) => (
+          {toolEntries.map((item) => (
             <button
               key={item.id}
               type="button"
@@ -46,7 +50,7 @@ export function FastDachengHome() {
 
       <section className="fast-stage" aria-label="大乘首页">
         <header className="fast-topbar">
-          <span className="fast-mobile-brand">{dachengBrand.name}</span>
+          <span className="fast-mobile-brand">{brand.name}</span>
           <div>
             <span className="fast-speed-badge">极速 Web</span>
             <button type="button" className="fast-login">登录</button>
@@ -54,10 +58,10 @@ export function FastDachengHome() {
         </header>
 
         <section className="fast-hero" data-empty-state>
-          <h1>{dachengBrand.greeting}</h1>
-          <p>{dachengBrand.tagline}</p>
+          <h1>{brand.greeting}</h1>
+          <p>{brand.tagline}</p>
           <div className="fast-chips" aria-label="建议问题">
-            {dachengHeroChips.map((chip) => (
+            {heroChips.map((chip) => (
               <button
                 key={chip.id}
                 type="button"
@@ -76,7 +80,7 @@ export function FastDachengHome() {
 
         <section className="fast-composer-wrap" aria-label="输入框">
           <div className="fast-tool-menu" data-tool-menu hidden>
-            {dachengToolEntries.map((item) => (
+            {toolEntries.map((item) => (
               <button
                 key={item.id}
                 type="button"
@@ -99,8 +103,8 @@ export function FastDachengHome() {
               data-composer-input
               rows={1}
               maxLength={1800}
-              placeholder={dachengBrand.inputPlaceholder}
-              aria-label={dachengBrand.inputPlaceholder}
+              placeholder={brand.inputPlaceholder}
+              aria-label={brand.inputPlaceholder}
             />
             <button className="fast-mode" type="button" data-current-mode hidden />
             <button className="fast-send" type="submit" aria-label="发送">
@@ -116,7 +120,7 @@ export function FastDachengHome() {
           <p>只保留首页轻量流程，首屏不加载 App 专属页面。</p>
           <pre data-global-log>等待输入正文后生成全球法布施清单。</pre>
           <div className="fast-region-list" aria-hidden="true">
-            {globalDharmaRegions.map((region) => (
+            {regions.map((region) => (
               <span key={region} data-region={region}>{region}</span>
             ))}
           </div>
@@ -126,7 +130,7 @@ export function FastDachengHome() {
           <p data-card-count>暂无卡片</p>
           <div className="fast-card" data-card-wrap />
           <ul>
-            {remnoteInspiredFlashcardPrinciples.map((item) => (
+            {flashcardPrinciples.map((item) => (
               <li key={item}>{item}</li>
             ))}
           </ul>

--- a/frontend/packages/shared/src/chat-experience.ts
+++ b/frontend/packages/shared/src/chat-experience.ts
@@ -181,3 +181,11 @@ export function globalDharmaStartMessage(platform: "web" | "mini" | "static" = "
   const label = platform === "mini" ? "小程序版" : platform === "static" ? "极速 Web 版" : "Web 版";
   return `开始全球法布施：${label}只保留首页轻量流程，不加载 App 专属页面。`;
 }
+
+export const dachengHomeExperience = {
+  brand: dachengBrand,
+  heroChips: dachengHeroChips,
+  toolEntries: dachengToolEntries,
+  regions: globalDharmaRegions,
+  flashcardPrinciples: remnoteInspiredFlashcardPrinciples,
+} as const;


### PR DESCRIPTION
## Summary
- Reuse the native app home UI for Flutter Web and keep Web focused on the home screen only.
- Move Web login to the top-right and profile/avatar access to the bottom-left without changing native app defaults.
- Keep the existing instant Flutter Web shell and deferred full-app loading path for fast first paint.
- Share the same home experience config between Web frontend and WeChat mini-program code without using a WebView.

## Validation
- flutter analyze targeted changed Flutter files
- flutter build web --release --no-wasm-dry-run
- pnpm --filter @fabushi/mp-wechat typecheck
- pnpm --filter @fabushi/web typecheck
- pnpm --filter @fabushi/mp-wechat build:weapp
- Browser check: desktop and mobile Flutter Web home, login dialog, bottom-left avatar menu