### PR TITLE
Fix Windows CMake policy floor

### DIFF
--- a/fabushi/windows/CMakeLists.txt
+++ b/fabushi/windows/CMakeLists.txt
@@ -10,6 +10,10 @@ set(BINARY_NAME "global_dharma_sharing")
 # versions of CMake.
 cmake_policy(VERSION 3.14...3.25)
 
+# Firebase's vendored C++ SDK still advertises compatibility below CMake 3.5.
+# CMake 4 rejects that floor unless a parent project raises the policy version.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 # Define build configuration option.
 get_property(IS_MULTICONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(IS_MULTICONFIG)


### PR DESCRIPTION
## Summary
- Raise the Windows CMake policy floor to 3.5 so Firebase's vendored C++ SDK can configure under CMake 4.
- This fixes the Windows desktop installer job failure observed after #855.

## Validation
- git diff --check
- Remote validation will rerun the Windows installer workflow on this PR.