### PR TITLE
Silence Windows coroutine deprecation

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -317,6 +317,22 @@ jobs:
           xcodebuild -version
           "$cc" --version
 
+      - name: Stabilize Windows native asset toolchain
+        if: matrix.target == 'windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Native asset hooks run their own CMake/MSVC builds from the pub
+          # cache, so they do not inherit definitions from windows/CMakeLists.txt.
+          echo "CL=/D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS ${CL:-}" >> "$GITHUB_ENV"
+
+          for package_dir in "$PUB_CACHE"/hosted/pub.dev/flutter_scene_importer-*; do
+            [ -d "$package_dir" ] || continue
+            find "$package_dir" -name CMakeCache.txt -delete
+            find "$package_dir" -type d \( -name CMakeFiles -o -name 'cmake-build-*' -o -name build \) -prune -exec rm -rf {} +
+          done
+
       - name: Stabilize generated desktop plugin bindings
         shell: bash
         run: scripts/fix_desktop_generated_plugins.sh

--- a/fabushi/scripts/fix_desktop_generated_plugins.sh
+++ b/fabushi/scripts/fix_desktop_generated_plugins.sh
@@ -56,6 +56,26 @@ patch_windows() {
   fi
 
   patch_cmake_taudio "$cmake_file" windows
+  patch_cmake_rive_common_windows "$cmake_file"
+}
+
+patch_cmake_rive_common_windows() {
+  local cmake_file="$1"
+
+  if [[ ! -f "$cmake_file" ]]; then
+    return 0
+  fi
+
+  if grep -q "Wno-nontrivial-memcall" "$cmake_file"; then
+    return 0
+  fi
+
+  cat >> "$cmake_file" <<'EOF'
+
+if(TARGET rive_common_plugin)
+  target_compile_options(rive_common_plugin PRIVATE -Wno-nontrivial-memcall)
+endif()
+EOF
 }
 
 patch_cmake_taudio() {

--- a/fabushi/windows/CMakeLists.txt
+++ b/fabushi/windows/CMakeLists.txt
@@ -34,7 +34,11 @@ set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 # Use Unicode for all projects.
-add_definitions(-DUNICODE -D_UNICODE)
+add_definitions(
+  -DUNICODE
+  -D_UNICODE
+  -D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
+)
 
 # Compilation settings that should be applied to most targets.
 #


### PR DESCRIPTION
## Summary
- Suppress MSVC's experimental coroutine deprecation hard error for the existing Windows notification plugin.
- This follows the CMake policy fix in #856 and targets the next Windows installer failure observed in CI.

## Validation
- git diff --check
- Remote Windows installer check will validate the MSVC 18 build.