### PR TITLE
[codex] Keep Flutter Web home login visible

### DIFF
--- a/fabushi/lib/screens/main_navigation_screen_web.dart
+++ b/fabushi/lib/screens/main_navigation_screen_web.dart
@@ -48,9 +48,10 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       children: [
         Positioned.fill(
           child: GlobeHomeScreen(
-            topBarTrailing: user == null
-                ? _TopLoginButton(onPressed: _openLogin)
-                : const SizedBox(width: 42, height: 42),
+            topBarTrailing: _TopLoginButton(
+              label: user == null ? '登录' : user.displayName,
+              onPressed: user == null ? _openLogin : _toggleProfileMenu,
+            ),
             composerLeftInset: compact ? 84 : 88,
           ),
         ),
@@ -101,14 +102,15 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
 }
 
 class _TopLoginButton extends StatelessWidget {
-  const _TopLoginButton({required this.onPressed});
+  const _TopLoginButton({required this.label, required this.onPressed});
 
+  final String label;
   final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 96,
+      width: 104,
       height: 42,
       child: FilledButton(
         style: FilledButton.styleFrom(
@@ -120,10 +122,10 @@ class _TopLoginButton extends StatelessWidget {
           ),
         ),
         onPressed: onPressed,
-        child: const FittedBox(
+        child: FittedBox(
           fit: BoxFit.scaleDown,
           child: Text(
-            '登录',
+            label,
             maxLines: 1,
             softWrap: false,
             style: TextStyle(fontWeight: FontWeight.w800),


### PR DESCRIPTION
## Summary
- keep the Flutter Web home action visible in the top-right corner after login
- reuse the existing bottom-left avatar menu instead of leaving a blank spacer when a user is signed in
- keep the change scoped to the real Web entrypoint on `main`

## Why
`flutter.ombhrum.com` was still presenting the older-looking home shell, and one confusing detail in the current `main` web implementation is that the top-right login control disappears after sign-in. This makes it hard to visually confirm the newer shell and weakens the intended homepage layout.

## Root cause
On `main`, the real Flutter Web entrypoint is `fabushi/lib/screens/main_navigation_screen_web.dart`. That file was still swapping the top-right control for an empty box after login.

## Validation
- reviewed the diff against `origin/main`
- attempted `flutter analyze lib/screens/main_navigation_screen_web.dart lib/screens/globe_home_screen.dart`
- analyze could not complete in the sparse clone because local path dependencies under `lib/packages/*` were not fully available in this lightweight checkout
