### PR TITLE
[codex] Build native WeChat mini program shell

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,7 +3,7 @@
 这个目录承接两个新前端入口：
 
 - `apps/web`：官网和新的 Web App，使用 Next.js
-- `apps/mp-wechat`：微信小程序，使用 Taro
+- `apps/mp-wechat`：微信小程序，使用 Taro 和微信原生组件，不使用 `web-view`
 
 共享层拆成两个包：
 
@@ -13,7 +13,7 @@
 ## 为什么这样拆
 
 1. 现有 `fabushi/` 目录继续保持 Flutter 主应用节奏，不被官网和小程序开发打断。
-2. 官网和小程序共享接口层与领域模型，但不强行共享整套 UI。
+2. 小程序复用 Flutter App 的信息架构、设计 token、领域数据和 API 协议；Flutter Widget 本身不能直接在微信原生运行时执行。
 3. 后续如果要扩 H5 活动页、落地页、公众号内页面，可以继续挂在这个 monorepo 里扩展。
 
 ## 快速开始
@@ -29,5 +29,6 @@ pnpm dev:mp
 - 主业务后端继续复用 `https://flutter.ombhrum.com`
 - 新 Web App 路径是 `/app`，大乘 AI Web 入口是 `/app/ai`
 - 官方站 Worker 通过 `/api/dacheng-ai/*` 反代大乘 AI 后端；小程序默认也调用这个 HTTPS 入口
+- 微信小程序不走 WebView，页面由 Taro 编译为原生小程序组件；需要在微信后台配置 HTTPS request 合法域名
 - 新增接口或类型时，优先改 `packages/api-client`
 - 新增品牌文案、导航、固定配置时，优先改 `packages/shared`

--- a/frontend/apps/mp-wechat/README.md
+++ b/frontend/apps/mp-wechat/README.md
@@ -1,0 +1,51 @@
+# Fabushi WeChat Mini Program
+
+This mini program is a native WeChat/Taro implementation. It does not use
+`web-view`.
+
+## Architecture
+
+- Runtime: WeChat native components through Taro.
+- Shared layer: `@fabushi/shared` and `@fabushi/api-client`.
+- Flutter parity sources:
+  - `fabushi/lib/core/design_system/colors.dart`
+  - `fabushi/lib/core/design_system/app_theme.dart`
+  - `fabushi/lib/screens/globe_home_screen.dart`
+  - `fabushi/lib/screens/meditation_room_screen.dart`
+  - `fabushi/lib/screens/my_profile_screen.dart`
+
+Flutter does not officially compile a standard Flutter app to WeChat Mini
+Program native components. This app therefore reuses Flutter information
+architecture, design tokens, product copy, API contracts, and domain data while
+rendering the UI with native mini-program components.
+
+## Commands
+
+```bash
+npm run typecheck
+npm run build:weapp
+npm run open:weapp
+npm run preview:weapp
+```
+
+`open:weapp` and `preview:weapp` require WeChat DevTools CLI. If it is not in
+the default location, set:
+
+```bash
+WECHAT_DEVTOOLS_CLI=/path/to/wechat-devtools/cli npm run preview:weapp
+```
+
+## Preview Checklist
+
+- Home: edit the donation draft, copy it, switch to AI.
+- Sutra: search a sutra, select it, open AI question from the reader panel.
+- Practice: start, pause, add chant count, finish and save the local record.
+- AI: send a prompt and search public dharma resources.
+- Me: open service entries and verify reuse-boundary copy.
+
+## WeChat Console Setup
+
+- Replace `touristappid` in `project.config.json` with the real AppID before
+  upload or QR preview.
+- Add API request domains used by the AI gateway to the mini-program domain
+  allowlist.

--- a/frontend/apps/mp-wechat/config/index.ts
+++ b/frontend/apps/mp-wechat/config/index.ts
@@ -1,9 +1,11 @@
 import type { UserConfigExport } from "@tarojs/cli";
 import path from "node:path";
 
-const sharedSourcePaths = [
+const workspaceSourcePaths = [
   path.resolve(__dirname, "../../../packages/shared/src"),
+  path.resolve(__dirname, "../../../packages/api-client/src"),
   path.resolve(__dirname, "../node_modules/@fabushi/shared/src"),
+  path.resolve(__dirname, "../node_modules/@fabushi/api-client/src"),
 ];
 
 export default {
@@ -23,7 +25,7 @@ export default {
   plugins: [],
   mini: {
     compile: {
-      include: sharedSourcePaths,
+      include: workspaceSourcePaths,
     },
     postcss: {
       pxtransform: {

--- a/frontend/apps/mp-wechat/package.json
+++ b/frontend/apps/mp-wechat/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "dev:weapp": "taro build --type weapp --watch",
     "build:weapp": "taro build --type weapp",
+    "open:weapp": "node scripts/wechat-devtools.mjs open",
+    "preview:weapp": "node scripts/wechat-devtools.mjs preview",
+    "check:preview": "node scripts/wechat-devtools.mjs check",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "tsc -p tsconfig.json --noEmit"
   },

--- a/frontend/apps/mp-wechat/project.config.json
+++ b/frontend/apps/mp-wechat/project.config.json
@@ -1,0 +1,26 @@
+{
+  "appid": "touristappid",
+  "projectname": "fabushi-mp-wechat",
+  "compileType": "miniprogram",
+  "miniprogramRoot": "dist/",
+  "setting": {
+    "urlCheck": true,
+    "es6": true,
+    "enhance": true,
+    "postcss": true,
+    "minified": true,
+    "coverView": true,
+    "lazyloadPlaceholderEnable": false,
+    "uglifyFileName": false,
+    "checkInvalidKey": true,
+    "checkSiteMap": true,
+    "uploadWithSourceMap": true,
+    "useCompilerPlugins": false,
+    "babelSetting": {
+      "ignore": [],
+      "disablePlugins": [],
+      "outputPath": ""
+    }
+  },
+  "condition": {}
+}

--- a/frontend/apps/mp-wechat/scripts/wechat-devtools.mjs
+++ b/frontend/apps/mp-wechat/scripts/wechat-devtools.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const appRoot = resolve(__dirname, "..");
+const distRoot = resolve(appRoot, "dist");
+const action = process.argv[2] || "open";
+
+const cliCandidates = [
+  process.env.WECHAT_DEVTOOLS_CLI,
+  "/Applications/wechatwebdevtools.app/Contents/MacOS/cli",
+  "/Applications/WeChatwebdevtools.app/Contents/MacOS/cli",
+].filter(Boolean);
+
+function findCli() {
+  return cliCandidates.find((candidate) => existsSync(candidate));
+}
+
+function ensureDist() {
+  if (!existsSync(distRoot)) {
+    console.error("Missing dist/. Run npm run build:weapp first.");
+    process.exit(1);
+  }
+}
+
+function ensureCli() {
+  const cli = findCli();
+  if (!cli) {
+    console.error(
+      "WeChat DevTools CLI was not found. Set WECHAT_DEVTOOLS_CLI to the cli executable path.",
+    );
+    process.exit(1);
+  }
+  return cli;
+}
+
+if (action === "check") {
+  ensureDist();
+  const cli = ensureCli();
+  console.log(`WeChat DevTools CLI: ${cli}`);
+  console.log(`Project root: ${appRoot}`);
+  process.exit(0);
+}
+
+if (!["open", "preview"].includes(action)) {
+  console.error(`Unsupported action: ${action}`);
+  process.exit(1);
+}
+
+ensureDist();
+const cli = ensureCli();
+const result = spawnSync(cli, [action, "--project", appRoot], {
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/frontend/apps/mp-wechat/src/app.config.ts
+++ b/frontend/apps/mp-wechat/src/app.config.ts
@@ -1,10 +1,29 @@
 export default defineAppConfig({
-  pages: ["pages/index/index"],
+  pages: [
+    "pages/index/index",
+    "pages/sutra/index",
+    "pages/practice/index",
+    "pages/ai/index",
+    "pages/me/index",
+  ],
   window: {
     backgroundTextStyle: "light",
     navigationBarBackgroundColor: "#101419",
-    navigationBarTitleText: "大乘",
+    navigationBarTitleText: "法布施",
     navigationBarTextStyle: "white",
     backgroundColor: "#080b10",
+  },
+  tabBar: {
+    color: "#8f9a9a",
+    selectedColor: "#e8bd6b",
+    backgroundColor: "#101419",
+    borderStyle: "black",
+    list: [
+      { pagePath: "pages/index/index", text: "首页" },
+      { pagePath: "pages/sutra/index", text: "经文" },
+      { pagePath: "pages/practice/index", text: "修行" },
+      { pagePath: "pages/ai/index", text: "AI" },
+      { pagePath: "pages/me/index", text: "我的" },
+    ],
   },
 });

--- a/frontend/apps/mp-wechat/src/pages/ai/index.config.ts
+++ b/frontend/apps/mp-wechat/src/pages/ai/index.config.ts
@@ -1,3 +1,4 @@
 export default definePageConfig({
+  enableShareAppMessage: true,
   navigationBarTitleText: "大乘 AI",
 });

--- a/frontend/apps/mp-wechat/src/pages/ai/index.scss
+++ b/frontend/apps/mp-wechat/src/pages/ai/index.scss
@@ -2,13 +2,14 @@
   min-height: 100vh;
   padding: 28px 24px 48px;
   background:
-    radial-gradient(circle at 18% 0%, rgba(120, 214, 232, 0.17), transparent 32%),
-    linear-gradient(180deg, #080b10 0%, #101419 100%);
+    radial-gradient(circle at 18% 0%, rgba(123, 31, 162, 0.22), transparent 32%),
+    radial-gradient(circle at 82% 4%, rgba(255, 215, 0, 0.1), transparent 28%),
+    linear-gradient(180deg, #0b0e14 0%, #101419 100%);
 }
 
 .title {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 44px;
   font-weight: 800;
 }
@@ -18,7 +19,7 @@
 .message,
 .resource-copy {
   display: block;
-  color: #b9c5c7;
+  color: rgba(232, 234, 246, 0.72);
   font-size: 27px;
   line-height: 1.62;
 }
@@ -30,14 +31,14 @@
 .panel {
   margin-top: 26px;
   padding: 20px;
-  border: 1px solid rgba(255, 249, 235, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 8px;
-  background: rgba(255, 249, 235, 0.06);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .panel-title {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 31px;
   font-weight: 750;
   margin-bottom: 14px;
@@ -46,10 +47,10 @@
 .textarea,
 .input {
   width: 100%;
-  border: 1px solid rgba(255, 249, 235, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 8px;
-  background: rgba(5, 7, 13, 0.42);
-  color: #fff9eb;
+  background: rgba(11, 14, 20, 0.52);
+  color: #e8eaf6;
   font-size: 28px;
   padding: 18px;
 }
@@ -74,24 +75,24 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #ffe3a3;
-  color: #101419;
+  background: #ffd700;
+  color: #11151d;
   font-size: 28px;
   font-weight: 800;
   border-radius: 8px;
 }
 
 .button.secondary {
-  background: rgba(120, 214, 232, 0.16);
-  color: #78d6e8;
+  background: rgba(232, 234, 246, 0.12);
+  color: #e8eaf6;
 }
 
 .prompt {
   padding: 16px;
-  border: 1px solid rgba(255, 249, 235, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 8px;
-  color: #dbe7e0;
-  background: rgba(5, 7, 13, 0.28);
+  color: #e8eaf6;
+  background: rgba(11, 14, 20, 0.42);
   font-size: 26px;
   line-height: 1.5;
 }
@@ -105,21 +106,21 @@
   margin-top: 16px;
   padding: 18px;
   border-radius: 8px;
-  background: rgba(5, 7, 13, 0.28);
-  color: #fff9eb;
+  background: rgba(11, 14, 20, 0.42);
+  color: #e8eaf6;
   white-space: pre-wrap;
 }
 
 .resource {
   padding: 16px;
-  border: 1px solid rgba(255, 249, 235, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 8px;
-  background: rgba(5, 7, 13, 0.28);
+  background: rgba(11, 14, 20, 0.42);
 }
 
 .resource-title {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 28px;
   font-weight: 750;
 }
@@ -131,6 +132,6 @@
 
 .status {
   margin-top: 12px;
-  color: #9ed7bf;
+  color: #ffd700;
   font-size: 24px;
 }

--- a/frontend/apps/mp-wechat/src/pages/ai/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/ai/index.tsx
@@ -1,26 +1,17 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Input, Text, Textarea, View } from "@tarojs/components";
 import Taro from "@tarojs/taro";
 import { aiQuickPrompts } from "@fabushi/shared";
+import {
+  dachengAiEndpoints,
+  getDachengAiApiBaseUrl,
+  type DachengAiChatResponse,
+  type DharmaResourceSearchItem,
+  type DharmaResourceSearchResponse,
+} from "@fabushi/api-client";
 import "./index.scss";
 
-const AI_BASE =
-  process.env.TARO_APP_DACHENG_AI_API_BASE_URL?.replace(/\/+$/, "") ||
-  "https://fabushi.ombhrum.com/api/dacheng-ai";
-
-interface ChatPayload {
-  success?: boolean;
-  message?: string;
-}
-
-interface ResourceItem {
-  id: string;
-  title: string;
-  sourceName: string;
-  snippet: string;
-  resourceType: string;
-  url: string;
-}
+const AI_BASE = getDachengAiApiBaseUrl();
 
 export default function AiPage() {
   const [prompt, setPrompt] = useState<string>(aiQuickPrompts[0]);
@@ -28,7 +19,15 @@ export default function AiPage() {
   const [status, setStatus] = useState("已连接大乘 AI 网关");
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("心经 可公开分享 经文");
-  const [resources, setResources] = useState<ResourceItem[]>([]);
+  const [resources, setResources] = useState<DharmaResourceSearchItem[]>([]);
+
+  useEffect(() => {
+    const storedPrompt = Taro.getStorageSync("fabushi_mp_ai_prompt") as string | undefined;
+    if (storedPrompt) {
+      setPrompt(storedPrompt);
+      Taro.removeStorageSync("fabushi_mp_ai_prompt");
+    }
+  }, []);
 
   async function sendPrompt() {
     const text = prompt.trim();
@@ -36,8 +35,8 @@ export default function AiPage() {
     setLoading(true);
     setStatus("生成中");
     try {
-      const response = await Taro.request<ChatPayload>({
-        url: `${AI_BASE}/api/ai/chat`,
+      const response = await Taro.request<DachengAiChatResponse>({
+        url: `${AI_BASE}${dachengAiEndpoints.chat}`,
         method: "POST",
         header: {
           Accept: "application/json",
@@ -67,8 +66,8 @@ export default function AiPage() {
     if (!text) return;
     setStatus("搜索资源中");
     try {
-      const response = await Taro.request<{ success?: boolean; items?: ResourceItem[]; message?: string }>({
-        url: `${AI_BASE}/api/resources/search`,
+      const response = await Taro.request<DharmaResourceSearchResponse & { message?: string }>({
+        url: `${AI_BASE}${dachengAiEndpoints.resourceSearch}`,
         method: "POST",
         header: {
           Accept: "application/json",
@@ -91,7 +90,9 @@ export default function AiPage() {
   return (
     <View className="page">
       <Text className="title">大乘 AI</Text>
-      <Text className="subtitle">小程序版使用非流式回答，适合微信内快速问经、找资源和整理发愿文。</Text>
+      <Text className="subtitle">
+        复用 Flutter 的大乘 AI 网关和提示词协议；微信原生端使用非流式回答，适合问经、找资源和整理发愿文。
+      </Text>
 
       <View className="panel">
         <Text className="panel-title">快捷任务</Text>

--- a/frontend/apps/mp-wechat/src/pages/index/index.config.ts
+++ b/frontend/apps/mp-wechat/src/pages/index/index.config.ts
@@ -1,3 +1,4 @@
 export default definePageConfig({
-  navigationBarTitleText: "大乘 Web",
+  enableShareAppMessage: true,
+  navigationBarTitleText: "全球法布施",
 });

--- a/frontend/apps/mp-wechat/src/pages/index/index.scss
+++ b/frontend/apps/mp-wechat/src/pages/index/index.scss
@@ -1,367 +1,299 @@
 .page {
   min-height: 100vh;
-  position: relative;
-  padding: 24px 22px 180px;
-  overflow: hidden;
-  background: #080b10;
-  color: #fff9eb;
-}
-
-.bg {
-  position: fixed;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
+  padding: 32px 24px 56px;
   background:
-    radial-gradient(circle at 52% 4%, rgba(255, 227, 163, 0.22), transparent 16%),
-    radial-gradient(circle at 70% 24%, rgba(120, 214, 232, 0.14), transparent 28%),
-    linear-gradient(180deg, rgba(45, 69, 91, 0.86) 0%, rgba(13, 17, 22, 0.97) 56%, #080a0e 100%);
-}
-
-.bg::before,
-.bg::after {
-  content: "";
-  position: absolute;
-  pointer-events: none;
-}
-
-.bg::before {
-  left: 8%;
-  right: -12%;
-  top: 18%;
-  height: 42%;
-  background:
-    linear-gradient(132deg, transparent 0 22%, rgba(226, 235, 242, 0.24) 23%, transparent 28%),
-    linear-gradient(156deg, transparent 0 46%, rgba(240, 245, 248, 0.2) 47%, transparent 52%),
-    linear-gradient(18deg, transparent 0 55%, rgba(62, 77, 66, 0.7) 56%, rgba(27, 37, 31, 0.86) 70%, transparent 71%);
-  filter: blur(8px);
-  opacity: 0.7;
-}
-
-.bg::after {
-  left: 38%;
-  top: 7%;
-  width: 260px;
-  height: 160px;
-  border: 10px solid rgba(255, 227, 163, 0.13);
-  border-bottom: 0;
-  border-radius: 999px 999px 0 0;
-  filter: blur(2px);
-  transform: rotate(-4deg);
-}
-
-.topbar,
-.hero,
-.messages,
-.side-panels,
-.menu,
-.composer {
-  position: relative;
-  z-index: 1;
-}
-
-button::after {
-  border: 0;
-}
-
-.topbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 0 24px;
-}
-
-.brand {
-  color: #fff;
-  font-size: 40px;
-  font-weight: 850;
-}
-
-.login {
-  min-width: 132px;
-  height: 64px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 18px;
-  background: rgba(247, 248, 251, 0.95);
-  color: #11151d;
-  font-size: 25px;
-  font-weight: 800;
+    radial-gradient(circle at 22% 8%, rgba(123, 31, 162, 0.24), transparent 28%),
+    radial-gradient(circle at 84% 2%, rgba(255, 215, 0, 0.16), transparent 24%),
+    linear-gradient(180deg, #0b0e14 0%, #111827 58%, #080b10 100%);
 }
 
 .hero {
-  padding: 82px 0 34px;
+  padding: 24px 0 20px;
+}
+
+.eyebrow {
+  display: block;
+  color: #ffd700;
+  font-size: 24px;
+  margin-bottom: 18px;
+  font-weight: 700;
 }
 
 .title {
   display: block;
-  color: #fff;
-  font-size: 54px;
-  font-weight: 880;
-  line-height: 1.12;
-  text-align: center;
+  color: #e8eaf6;
+  font-size: 60px;
+  font-weight: 700;
+  line-height: 1.24;
 }
 
 .subtitle {
   display: block;
-  margin: 18px auto 28px;
-  color: rgba(238, 242, 244, 0.72);
-  font-size: 28px;
+  margin-top: 20px;
+  color: rgba(232, 234, 246, 0.76);
+  font-size: 30px;
   line-height: 1.65;
-  text-align: center;
 }
 
-.chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: center;
+.globe {
+  position: relative;
+  height: 432px;
+  margin: 18px 0 28px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 50% 48%, rgba(27, 38, 59, 0.98) 0%, rgba(11, 14, 20, 0.92) 48%, rgba(11, 14, 20, 0.58) 70%),
+    linear-gradient(135deg, rgba(123, 31, 162, 0.34), rgba(27, 38, 59, 0.22));
 }
 
-.chip {
-  min-height: 58px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 20px;
-  border-radius: 999px;
-  background: rgba(34, 39, 47, 0.78);
-  color: rgba(238, 242, 244, 0.72);
-  font-size: 24px;
-  backdrop-filter: blur(12px);
-}
-
-.chip-icon {
-  color: #ffe3a3;
-}
-
-.messages {
-  min-height: 28vh;
-}
-
-.has-chat .messages {
-  min-height: 42vh;
-}
-
-.message {
-  display: flex;
-  gap: 12px;
-  margin: 16px 0;
-}
-
-.message.user {
-  flex-direction: row-reverse;
-}
-
-.avatar {
-  width: 54px;
-  height: 54px;
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.globe::before,
+.globe::after {
+  position: absolute;
+  content: "";
+  inset: 72px 118px;
   border-radius: 50%;
-  background: rgba(120, 214, 232, 0.16);
-  color: #78d6e8;
-  font-size: 24px;
-  font-weight: 900;
+  border: 1px solid rgba(232, 234, 246, 0.12);
 }
 
-.user .avatar {
-  background: rgba(255, 227, 163, 0.18);
-  color: #ffe3a3;
+.globe::after {
+  inset: 112px 158px;
+  border-color: rgba(255, 215, 0, 0.16);
 }
 
-.bubble,
-.panel,
-.menu-item,
-.flashcard {
-  border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: 18px;
-  background: rgba(34, 39, 47, 0.72);
+.orbit {
+  position: absolute;
+  left: 88px;
+  right: 88px;
+  top: 202px;
+  height: 1px;
+  background: rgba(232, 234, 246, 0.18);
 }
 
-.bubble {
-  max-width: 590px;
-  padding: 16px 18px;
-  color: #fff;
-  font-size: 27px;
-  line-height: 1.68;
-  white-space: pre-wrap;
+.orbit-a {
+  transform: rotate(18deg);
 }
 
-.user .bubble {
-  background: rgba(120, 214, 232, 0.13);
+.orbit-b {
+  transform: rotate(-24deg);
 }
 
-.side-panels {
-  margin-top: 24px;
+.beam {
+  position: absolute;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, #ffd700, transparent);
+  box-shadow: 0 0 18px rgba(255, 215, 0, 0.46);
 }
 
-.panel {
-  display: block;
-  padding: 20px;
-  margin-top: 16px;
-  background: rgba(255, 255, 255, 0.055);
+.beam-a {
+  left: 154px;
+  top: 166px;
+  width: 294px;
+  transform: rotate(18deg);
 }
 
-.panel-title {
-  display: block;
-  color: #fff;
-  font-size: 31px;
-  font-weight: 780;
+.beam-b {
+  left: 214px;
+  top: 268px;
+  width: 238px;
+  transform: rotate(-28deg);
 }
 
-.panel-copy,
-.log,
-.card-kind,
-.card-back,
-.principle {
-  display: block;
-  margin-top: 10px;
-  color: rgba(230, 237, 240, 0.68);
-  font-size: 24px;
-  line-height: 1.58;
+.node {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffd700;
+  box-shadow: 0 0 24px rgba(255, 215, 0, 0.72);
 }
 
-.log {
-  color: rgba(219, 231, 224, 0.88);
+.node-cn {
+  left: 426px;
+  top: 178px;
 }
 
-.principle {
+.node-us {
+  left: 148px;
+  top: 214px;
+}
+
+.node-sg {
+  left: 404px;
+  top: 262px;
+}
+
+.node-eu {
+  left: 314px;
+  top: 142px;
+}
+
+.globe-core {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 174px;
+  height: 174px;
+  margin-left: -87px;
+  margin-top: -87px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.globe-value {
+  color: #ffd700;
+  font-size: 54px;
+  font-weight: 800;
+}
+
+.globe-label {
+  margin-top: 8px;
+  color: rgba(232, 234, 246, 0.72);
   font-size: 22px;
 }
 
-.flashcard {
-  display: block;
-  margin-top: 16px;
-  padding: 18px;
-  background: rgba(5, 7, 13, 0.38);
-}
-
-.card-front {
-  display: block;
-  margin-top: 12px;
-  color: #fff;
-  font-size: 29px;
-  font-weight: 760;
-  line-height: 1.55;
-}
-
-.card-back {
-  color: #ffe3a3;
-}
-
-.flashcard button,
-.reviews button {
-  min-height: 58px;
-  margin-top: 12px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.08);
-  color: #fff;
-  font-size: 24px;
-}
-
-.reviews {
+.stats {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
-  margin-top: 12px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+  margin-top: 24px;
 }
 
-.menu {
-  position: fixed;
-  left: 22px;
-  right: 22px;
-  bottom: 138px;
-  z-index: 20;
-  display: grid;
-  gap: 12px;
-  padding: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 24px;
-  background: rgba(22, 26, 34, 0.98);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.38);
+.stat,
+.prompt,
+.feed,
+.composer,
+.action-card,
+.parity {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
 }
 
-.menu-item {
-  display: flex;
-  gap: 12px;
-  padding: 18px;
+.stat {
+  min-height: 112px;
+  padding: 20px;
 }
 
-.menu-icon {
-  font-size: 28px;
-  line-height: 1.3;
-}
-
-.menu-title {
+.stat-value {
   display: block;
-  color: #fff;
-  font-size: 28px;
-  font-weight: 780;
+  color: #ffd700;
+  font-size: 36px;
+  font-weight: 800;
 }
 
-.menu-copy {
+.stat-label {
   display: block;
-  margin-top: 8px;
-  color: rgba(230, 237, 240, 0.68);
-  font-size: 24px;
-  line-height: 1.5;
+  margin-top: 10px;
+  color: rgba(232, 234, 246, 0.66);
+  font-size: 22px;
 }
 
 .composer {
-  position: fixed;
-  left: 18px;
-  right: 18px;
-  bottom: 22px;
-  z-index: 30;
-  display: grid;
-  grid-template-columns: 64px minmax(0, 1fr) auto 64px;
-  gap: 10px;
-  align-items: center;
-  padding: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: 34px;
-  background: rgba(38, 40, 49, 0.96);
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+  padding: 22px;
 }
 
-.plus,
-.mode,
-.send {
-  min-height: 64px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: #fff;
-  font-size: 25px;
-  font-weight: 850;
+.section {
+  margin-top: 32px;
 }
 
-.plus {
-  width: 64px;
-  font-size: 42px;
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.mode {
-  padding: 0 16px;
-  color: #78d6e8;
-  background: rgba(120, 214, 232, 0.12);
-}
-
-.send {
-  width: 64px;
-  background: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.76);
+.section-title {
+  display: block;
+  margin-bottom: 16px;
+  color: #e8eaf6;
+  font-size: 30px;
+  font-weight: 600;
 }
 
 .input {
-  min-height: 64px;
-  max-height: 160px;
-  padding: 12px 4px;
-  color: #fff;
+  width: 100%;
+  height: 82px;
+  padding: 0 18px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  color: #e8eaf6;
+  background: rgba(11, 14, 20, 0.52);
   font-size: 28px;
-  line-height: 1.4;
+}
+
+.actions {
+  display: flex;
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.primary,
+.secondary {
+  flex: 1;
+  height: 78px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.primary {
+  color: #11151d;
+  background: #ffd700;
+}
+
+.secondary {
+  color: #e8eaf6;
+  background: rgba(232, 234, 246, 0.12);
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+
+.action-card {
+  min-height: 188px;
+  padding: 18px;
+}
+
+.action-index {
+  display: block;
+  margin-bottom: 16px;
+  color: rgba(255, 215, 0, 0.82);
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.prompt + .prompt,
+.feed + .feed,
+.parity + .parity {
+  margin-top: 14px;
+}
+
+.card-title {
+  display: block;
+  font-size: 30px;
+  font-weight: 600;
+  color: #e8eaf6;
+}
+
+.card-copy {
+  display: block;
+  margin-top: 10px;
+  font-size: 24px;
+  line-height: 1.55;
+  color: rgba(232, 234, 246, 0.68);
+}
+
+.prompt,
+.feed,
+.parity {
+  padding: 20px;
+  color: #e8eaf6;
+  font-size: 28px;
+  line-height: 1.6;
 }

--- a/frontend/apps/mp-wechat/src/pages/index/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/index/index.tsx
@@ -1,182 +1,123 @@
 import { useState } from "react";
-import { Button, Text, Textarea, View } from "@tarojs/components";
+import { Button, Input, Text, View } from "@tarojs/components";
+import Taro from "@tarojs/taro";
 import {
-  buildGlobalDharmaChecklist,
-  createDachengId,
-  dachengHomeExperience,
-  globalDharmaStartMessage,
-  makeDachengFlashcards,
-  nextDachengFlashcardDue,
-  type DachengFlashcard,
-  type DachengRating,
-  type DachengToolId,
+  aiQuickPrompts,
+  appExperienceStats,
+  brand,
+  dharmaFeedItems,
+  globalDharmaActions,
+  miniProgramFlutterParity,
 } from "@fabushi/shared";
 import "./index.scss";
 
-type Role = "assistant" | "user";
-
-interface Message {
-  id: string;
-  role: Role;
-  text: string;
-  tag?: string;
-}
-
-const ratingLabels: DachengRating[] = ["Again", "Hard", "Good", "Easy"];
-const {
-  brand,
-  heroChips,
-  toolEntries,
-  flashcardPrinciples,
-} = dachengHomeExperience;
-
 export default function IndexPage() {
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [input, setInput] = useState("");
-  const [tool, setTool] = useState<DachengToolId | null>(null);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [logs, setLogs] = useState<string[]>([]);
-  const [cards, setCards] = useState<DachengFlashcard[]>([]);
-  const [cardIndex, setCardIndex] = useState(0);
-  const [showAnswer, setShowAnswer] = useState(false);
-  const activeTool = toolEntries.find((item) => item.id === tool) ?? null;
-  const activeCard = cards[cardIndex] ?? null;
+  const [draft, setDraft] = useState<string>(aiQuickPrompts[0]);
 
-  function add(role: Role, text: string, tag?: string) {
-    setMessages((items) => [...items, { id: createDachengId("mp-msg"), role, text, tag }]);
+  function switchTo(url: string) {
+    Taro.switchTab({ url });
   }
 
-  function choosePrompt(prompt: string, nextTool?: DachengToolId) {
-    setInput(prompt);
-    setTool(nextTool ?? null);
-    setMenuOpen(false);
-  }
-
-  function runGlobalDharma(text: string) {
-    const checklist = buildGlobalDharmaChecklist(text);
-    setLogs(checklist.map((item) => `✓ ${item.label}`));
-    add("assistant", globalDharmaStartMessage("mini"), "全球法布施");
-    add("assistant", `全球法布施完成：已整理 ${checklist.length} 个地区。`, "全球法布施");
-  }
-
-  function makeDeck(text: string) {
-    const nextCards = makeDachengFlashcards(text);
-    setCards((items) => [...nextCards, ...items]);
-    setCardIndex(0);
-    setShowAnswer(false);
-    add(
-      "assistant",
-      nextCards.length ? `已制作 ${nextCards.length} 张背诵闪卡。` : "内容太短，请补充正文后再制卡。",
-      "背诵闪卡",
-    );
-  }
-
-  function submit() {
-    const text = input.trim() || brand.defaultText;
-    setInput("");
-    add("user", text, activeTool?.title);
-    if (tool === "global-dharma") runGlobalDharma(text);
-    else if (tool === "flashcards") makeDeck(text);
-    else add("assistant", "已收到。可以继续输入，或点 + 进入全球法布施和背诵闪卡。");
-  }
-
-  function review(rating: DachengRating) {
-    if (!activeCard) return;
-    setCards((items) =>
-      items.map((card) =>
-        card.id === activeCard.id
-          ? { ...card, reviews: card.reviews + 1, due: nextDachengFlashcardDue(rating) }
-          : card,
-      ),
-    );
-    setCardIndex((index) => (cards.length ? (index + 1) % cards.length : 0));
-    setShowAnswer(false);
+  function copyDraft() {
+    Taro.setClipboardData({
+      data: draft,
+      success: () => Taro.showToast({ title: "已复制", icon: "success" }),
+    });
   }
 
   return (
-    <View className={messages.length ? "page has-chat" : "page"}>
-      <View className="bg" />
-      <View className="topbar">
-        <Text className="brand">{brand.name}</Text>
-        <Button className="login">登录</Button>
+    <View className="page">
+      <View className="hero">
+        <Text className="eyebrow">{brand.englishName}</Text>
+        <Text className="title">全球法布施</Text>
+        <Text className="subtitle">
+          复用 Flutter App 的首页信息架构与视觉 token，用微信原生组件承接发送、问经和共修入口。
+        </Text>
       </View>
 
-      {!messages.length && (
-        <View className="hero">
-          <Text className="title">{brand.greeting}</Text>
-          <Text className="subtitle">{brand.tagline}</Text>
-          <View className="chips">
-            {heroChips.map((chip) => (
-              <Button className="chip" key={chip.id} onClick={() => choosePrompt(chip.prompt, chip.tool)}>
-                <Text className="chip-icon">{chip.icon}</Text>
-                <Text>{chip.label}</Text>
-              </Button>
-            ))}
-          </View>
+      <View className="globe">
+        <View className="orbit orbit-a" />
+        <View className="orbit orbit-b" />
+        <View className="beam beam-a" />
+        <View className="beam beam-b" />
+        <View className="node node-cn" />
+        <View className="node node-us" />
+        <View className="node node-sg" />
+        <View className="node node-eu" />
+        <View className="globe-core">
+          <Text className="globe-value">64</Text>
+          <Text className="globe-label">在线国家</Text>
         </View>
-      )}
+      </View>
 
-      <View className="messages">
-        {messages.map((message) => (
-          <View className={`message ${message.role}`} key={message.id}>
-            <Text className="avatar">{message.role === "user" ? "我" : brand.name.slice(0, 1)}</Text>
-            <Text className="bubble">{message.tag ? `${message.tag}：` : ""}{message.text}</Text>
+      <View className="stats">
+        {appExperienceStats.map((item) => (
+          <View className="stat" key={item.label}>
+            <Text className="stat-value">{item.value}</Text>
+            <Text className="stat-label">
+              {item.label} · {item.unit}
+            </Text>
           </View>
         ))}
       </View>
 
-      <View className="side-panels">
-        <View className="panel">
-          <Text className="panel-title">全球法布施</Text>
-          <Text className="panel-copy">小程序只保留首页轻量流程，不显示 App 专属页面。</Text>
-          {(logs.length ? logs : ["等待输入正文后生成全球法布施清单。"])
-            .map((line) => <Text className="log" key={line}>{line}</Text>)}
-        </View>
-        <View className="panel">
-          <Text className="panel-title">背诵闪卡</Text>
-          <Text className="panel-copy">{cards.length ? `${cards.length} 张卡片` : "暂无卡片"}</Text>
-          {activeCard ? (
-            <View className="flashcard">
-              <Text className="card-kind">{activeCard.kind} · {activeCard.due} · 已复习 {activeCard.reviews} 次</Text>
-              <Text className="card-front">{activeCard.front}</Text>
-              {showAnswer ? <Text className="card-back">{activeCard.back}</Text> : <Button onClick={() => setShowAnswer(true)}>显示答案</Button>}
-              <View className="reviews">
-                {ratingLabels.map((rating) => <Button key={rating} onClick={() => review(rating)}>{rating}</Button>)}
-              </View>
-            </View>
-          ) : (
-            <Text className="panel-copy">选择背诵闪卡后会自动生成挖空卡和双向卡。</Text>
-          )}
-          {flashcardPrinciples.map((item) => <Text className="principle" key={item}>• {item}</Text>)}
+      <View className="composer">
+        <Text className="section-title">法布施输入</Text>
+        <Input
+          className="input"
+          value={draft}
+          maxlength={120}
+          onInput={(event) => setDraft(event.detail.value)}
+        />
+        <View className="actions">
+          <Button className="primary" onClick={() => switchTo("/pages/ai/index")}>
+            AI 润色
+          </Button>
+          <Button className="secondary" onClick={copyDraft}>
+            复制发愿
+          </Button>
         </View>
       </View>
 
-      {menuOpen && (
-        <View className="menu">
-          {toolEntries.map((item) => (
-            <View className="menu-item" key={item.id} onClick={() => { setTool(item.id); setMenuOpen(false); }}>
-              <Text className="menu-icon">{item.icon}</Text>
-              <View>
-                <Text className="menu-title">{item.title}</Text>
-                <Text className="menu-copy">{item.description}</Text>
-              </View>
-            </View>
-          ))}
-        </View>
-      )}
+      <View className="section action-grid">
+        {globalDharmaActions.map((item, index) => (
+          <View className="action-card" key={item.label}>
+            <Text className="action-index">0{index + 1}</Text>
+            <Text className="card-title">{item.label}</Text>
+            <Text className="card-copy">{item.detail}</Text>
+          </View>
+        ))}
+      </View>
 
-      <View className="composer">
-        <Button className="plus" onClick={() => setMenuOpen(!menuOpen)}>+</Button>
-        <Textarea
-          className="input"
-          value={input}
-          maxlength={1800}
-          autoHeight
-          onInput={(event) => setInput(event.detail.value)}
-          placeholder={activeTool ? `${activeTool.action}，也可以继续问一问${brand.name}` : brand.inputPlaceholder}
-        />
-        {activeTool && <Button className="mode" onClick={() => setTool(null)}>{activeTool.shortTitle}×</Button>}
-        <Button className="send" onClick={submit}>➤</Button>
+      <View className="section">
+        <Text className="section-title">AI 快捷任务</Text>
+        {aiQuickPrompts.slice(0, 3).map((prompt) => (
+          <View className="prompt" key={prompt}>
+            <Text>{prompt}</Text>
+          </View>
+        ))}
+      </View>
+
+      <View className="section">
+        <Text className="section-title">Flutter 复用映射</Text>
+        {miniProgramFlutterParity.slice(0, 3).map((item) => (
+          <View className="parity" key={item.flutter}>
+            <Text className="card-title">{item.title}</Text>
+            <Text className="card-copy">{item.reused}</Text>
+          </View>
+        ))}
+      </View>
+
+      <View className="section">
+        <Text className="section-title">今日法流</Text>
+        {dharmaFeedItems.map((item) => (
+          <View className="feed" key={item.title}>
+            <Text className="card-title">{item.title}</Text>
+            <Text className="card-copy">
+              {item.tag} · {item.readTime}
+            </Text>
+          </View>
+        ))}
       </View>
     </View>
   );

--- a/frontend/apps/mp-wechat/src/pages/me/index.config.ts
+++ b/frontend/apps/mp-wechat/src/pages/me/index.config.ts
@@ -1,3 +1,4 @@
 export default definePageConfig({
+  enableShareAppMessage: true,
   navigationBarTitleText: "我的",
 });

--- a/frontend/apps/mp-wechat/src/pages/me/index.scss
+++ b/frontend/apps/mp-wechat/src/pages/me/index.scss
@@ -1,7 +1,9 @@
 .page {
   min-height: 100vh;
   padding: 28px 24px 48px;
-  background: linear-gradient(180deg, #080b10 0%, #101419 100%);
+  background:
+    radial-gradient(circle at 18% 0%, rgba(255, 215, 0, 0.12), transparent 28%),
+    linear-gradient(180deg, #0b0e14 0%, #101419 100%);
 }
 
 .profile {
@@ -9,9 +11,9 @@
   align-items: center;
   gap: 18px;
   padding: 24px;
-  border: 1px solid rgba(255, 249, 235, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 8px;
-  background: rgba(255, 249, 235, 0.06);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .avatar {
@@ -21,15 +23,15 @@
   width: 86px;
   height: 86px;
   border-radius: 8px;
-  background: rgba(232, 189, 107, 0.16);
-  color: #ffe3a3;
+  background: rgba(255, 215, 0, 0.16);
+  color: #ffd700;
   font-size: 32px;
   font-weight: 800;
 }
 
 .name {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 34px;
   font-weight: 800;
 }
@@ -37,9 +39,10 @@
 .copy {
   display: block;
   margin-top: 10px;
-  color: #b9c5c7;
+  color: rgba(232, 234, 246, 0.7);
   font-size: 26px;
   line-height: 1.58;
+  text-align: left;
 }
 
 .section {
@@ -49,16 +52,19 @@
 .section-title {
   display: block;
   margin-bottom: 14px;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 31px;
   font-weight: 750;
 }
 
 .item {
+  display: block;
+  width: 100%;
   padding: 20px;
-  border: 1px solid rgba(255, 249, 235, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 8px;
-  background: rgba(255, 249, 235, 0.06);
+  background: rgba(255, 255, 255, 0.1);
+  text-align: left;
 }
 
 .item + .item {
@@ -67,7 +73,7 @@
 
 .item-title {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 30px;
   font-weight: 750;
 }

--- a/frontend/apps/mp-wechat/src/pages/me/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/me/index.tsx
@@ -1,14 +1,31 @@
-import { View, Text } from "@tarojs/components";
-import { brand } from "@fabushi/shared";
+import { Button, Text, View } from "@tarojs/components";
+import Taro from "@tarojs/taro";
+import {
+  brand,
+  miniProgramFlutterParity,
+  miniProgramNativeLimitations,
+} from "@fabushi/shared";
 import "./index.scss";
 
 const entries = [
-  ["Web 版", "https://fabushi.ombhrum.com/app"],
-  ["大乘 AI", "https://fabushi.ombhrum.com/app/ai"],
+  ["修行记录", "本地记录已接入，云端同步等待微信登录"],
+  ["账号登录", "后续接入微信 code 换取大乘账号会话"],
+  ["隐私与设置", "复用 Flutter 设置页的信息架构"],
   ["支持邮箱", "support@ombhrum.com"],
 ] as const;
 
 export default function MePage() {
+  function handleEntry(title: string, value: string) {
+    if (value.includes("@") || value.startsWith("http")) {
+      Taro.setClipboardData({
+        data: value,
+        success: () => Taro.showToast({ title: "已复制", icon: "success" }),
+      });
+      return;
+    }
+    Taro.showToast({ title, icon: "none" });
+  }
+
   return (
     <View className="page">
       <View className="profile">
@@ -22,18 +39,31 @@ export default function MePage() {
       <View className="section">
         <Text className="section-title">服务入口</Text>
         {entries.map(([title, value]) => (
-          <View className="item" key={title}>
+          <Button className="item" key={title} onClick={() => handleEntry(title, value)}>
             <Text className="item-title">{title}</Text>
             <Text className="copy">{value}</Text>
+          </Button>
+        ))}
+      </View>
+
+      <View className="section">
+        <Text className="section-title">复用边界</Text>
+        {miniProgramFlutterParity.map((item) => (
+          <View className="item" key={item.flutter}>
+            <Text className="item-title">{item.title}</Text>
+            <Text className="copy">{item.nativeScope}</Text>
           </View>
         ))}
       </View>
 
       <View className="section">
-        <Text className="section-title">版本</Text>
+        <Text className="section-title">非 WebView 说明</Text>
         <View className="item">
-          <Text className="item-title">微信小程序首版</Text>
-          <Text className="copy">经文、修行、AI、榜单和 Web 入口已经打通，后续继续补登录与深度共修能力。</Text>
+          {miniProgramNativeLimitations.map((item) => (
+            <Text className="copy" key={item}>
+              {item}
+            </Text>
+          ))}
         </View>
       </View>
     </View>

--- a/frontend/apps/mp-wechat/src/pages/practice/index.config.ts
+++ b/frontend/apps/mp-wechat/src/pages/practice/index.config.ts
@@ -1,3 +1,4 @@
 export default definePageConfig({
-  navigationBarTitleText: "修行",
+  enableShareAppMessage: true,
+  navigationBarTitleText: "禅室修行",
 });

--- a/frontend/apps/mp-wechat/src/pages/practice/index.scss
+++ b/frontend/apps/mp-wechat/src/pages/practice/index.scss
@@ -1,14 +1,15 @@
 .page {
   min-height: 100vh;
-  padding: 28px 24px 44px;
+  padding: 28px 24px 56px;
   background:
-    radial-gradient(circle at 86% 0%, rgba(158, 215, 191, 0.14), transparent 30%),
-    linear-gradient(180deg, #080b10 0%, #101419 100%);
+    radial-gradient(circle at 86% 0%, rgba(123, 31, 162, 0.2), transparent 30%),
+    radial-gradient(circle at 14% 8%, rgba(255, 215, 0, 0.12), transparent 26%),
+    linear-gradient(180deg, #0b0e14 0%, #101419 100%);
 }
 
 .title {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 44px;
   font-weight: 800;
 }
@@ -16,9 +17,99 @@
 .subtitle {
   display: block;
   margin-top: 14px;
-  color: #b9c5c7;
+  color: rgba(232, 234, 246, 0.72);
   font-size: 28px;
   line-height: 1.6;
+}
+
+.timer-panel {
+  margin-top: 24px;
+  padding: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 50% 8%, rgba(255, 215, 0, 0.14), transparent 30%),
+    rgba(255, 255, 255, 0.1);
+}
+
+.timer-label {
+  display: block;
+  color: rgba(255, 215, 0, 0.82);
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.timer-title {
+  display: block;
+  margin-top: 10px;
+  color: #e8eaf6;
+  font-size: 38px;
+  font-weight: 800;
+}
+
+.timer-value {
+  display: block;
+  margin-top: 18px;
+  color: #ffd700;
+  font-size: 86px;
+  font-weight: 900;
+  line-height: 1.05;
+}
+
+.timer-copy {
+  display: block;
+  margin-top: 14px;
+  color: rgba(232, 234, 246, 0.72);
+  font-size: 26px;
+  line-height: 1.58;
+}
+
+.timer-actions {
+  display: flex;
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.primary,
+.secondary,
+.finish {
+  height: 78px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.primary,
+.secondary {
+  flex: 1;
+}
+
+.primary {
+  color: #11151d;
+  background: #ffd700;
+}
+
+.secondary {
+  color: #e8eaf6;
+  background: rgba(232, 234, 246, 0.12);
+}
+
+.session-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 18px;
+  color: rgba(232, 234, 246, 0.74);
+  font-size: 24px;
+}
+
+.finish {
+  width: 100%;
+  margin-top: 18px;
+  color: #e8eaf6;
+  background: rgba(123, 31, 162, 0.62);
 }
 
 .section {
@@ -28,16 +119,49 @@
 .section-title {
   display: block;
   margin-bottom: 16px;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 31px;
   font-weight: 700;
 }
 
+.preset-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+.preset {
+  min-height: 120px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.preset-active {
+  border-color: rgba(255, 215, 0, 0.62);
+  background: rgba(255, 215, 0, 0.1);
+}
+
+.preset-title {
+  display: block;
+  color: #e8eaf6;
+  font-size: 30px;
+  font-weight: 800;
+}
+
+.preset-copy {
+  display: block;
+  margin-top: 12px;
+  color: rgba(232, 234, 246, 0.68);
+  font-size: 24px;
+}
+
 .card,
 .rank {
-  border: 1px solid rgba(255, 249, 235, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 8px;
-  background: rgba(255, 249, 235, 0.06);
+  background: rgba(255, 255, 255, 0.1);
   padding: 20px;
 }
 
@@ -48,7 +172,7 @@
 
 .card-title {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 32px;
   font-weight: 750;
 }
@@ -57,13 +181,13 @@
 .card-copy {
   display: block;
   margin-top: 10px;
-  color: #b9c5c7;
+  color: rgba(232, 234, 246, 0.7);
   font-size: 27px;
   line-height: 1.58;
 }
 
 .card-meta {
-  color: #9ed7bf;
+  color: #ffd700;
 }
 
 .rank {
@@ -79,8 +203,8 @@
   width: 58px;
   height: 58px;
   border-radius: 8px;
-  background: rgba(232, 189, 107, 0.16);
-  color: #ffe3a3;
+  background: rgba(255, 215, 0, 0.16);
+  color: #ffd700;
   font-size: 28px;
   font-weight: 800;
 }
@@ -90,6 +214,6 @@
 }
 
 .rank-value {
-  color: #78d6e8;
+  color: #ffd700;
   font-size: 25px;
 }

--- a/frontend/apps/mp-wechat/src/pages/practice/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/practice/index.tsx
@@ -1,12 +1,92 @@
-import { View, Text } from "@tarojs/components";
-import { leaderboardPreview, practicePlan } from "@fabushi/shared";
+import { useEffect, useMemo, useState } from "react";
+import { Button, Text, View } from "@tarojs/components";
+import Taro from "@tarojs/taro";
+import { leaderboardPreview, practicePlan, practiceSessionPresets } from "@fabushi/shared";
 import "./index.scss";
 
 export default function PracticePage() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [seconds, setSeconds] = useState(0);
+  const [chantCount, setChantCount] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  const activePractice = practiceSessionPresets[activeIndex];
+  const formattedTime = useMemo(() => {
+    const minutes = Math.floor(seconds / 60)
+      .toString()
+      .padStart(2, "0");
+    const rest = (seconds % 60).toString().padStart(2, "0");
+    return `${minutes}:${rest}`;
+  }, [seconds]);
+
+  useEffect(() => {
+    if (!running) return undefined;
+    const timer = setInterval(() => setSeconds((value) => value + 1), 1000);
+    return () => clearInterval(timer);
+  }, [running]);
+
+  function toggleSession() {
+    setRunning((value) => !value);
+  }
+
+  function finishSession() {
+    const minutes = Math.max(1, Math.round(seconds / 60));
+    Taro.setStorageSync("fabushi_mp_last_practice", {
+      title: activePractice.title,
+      minutes,
+      chantCount,
+      finishedAt: new Date().toISOString(),
+    });
+    setRunning(false);
+    setSeconds(0);
+    setChantCount(0);
+    Taro.showToast({ title: "功课已记录", icon: "success" });
+  }
+
   return (
     <View className="page">
-      <Text className="title">今日修行</Text>
-      <Text className="subtitle">把定课、听诵、回向与共修榜单放在同一屏，适合微信内快速查看。</Text>
+      <Text className="title">禅室修行</Text>
+      <Text className="subtitle">
+        复刻 Flutter 禅室的零摩擦节奏：选择功课、开始计时、念诵计数、回向并保存本地记录。
+      </Text>
+
+      <View className="timer-panel">
+        <Text className="timer-label">当前功课</Text>
+        <Text className="timer-title">{activePractice.title}</Text>
+        <Text className="timer-value">{formattedTime}</Text>
+        <Text className="timer-copy">{activePractice.dedication}</Text>
+        <View className="timer-actions">
+          <Button className="primary" onClick={toggleSession}>
+            {running ? "暂停" : "开始修行"}
+          </Button>
+          <Button className="secondary" onClick={() => setChantCount((value) => value + 1)}>
+            念诵 +1
+          </Button>
+        </View>
+        <View className="session-row">
+          <Text>目标 {activePractice.targetMinutes} 分钟</Text>
+          <Text>念诵 {chantCount} 遍</Text>
+        </View>
+        <Button className="finish" disabled={seconds === 0 && chantCount === 0} onClick={finishSession}>
+          功德圆满
+        </Button>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">选择功课</Text>
+        <View className="preset-grid">
+          {practiceSessionPresets.map((item, index) => (
+            <View
+              className={`preset ${index === activeIndex ? "preset-active" : ""}`}
+              key={item.title}
+              onClick={() => setActiveIndex(index)}
+            >
+              <Text className="preset-title">{item.title}</Text>
+              <Text className="preset-copy">{item.targetMinutes} 分钟</Text>
+            </View>
+          ))}
+        </View>
+      </View>
 
       <View className="section">
         <Text className="section-title">计划</Text>

--- a/frontend/apps/mp-wechat/src/pages/sutra/index.config.ts
+++ b/frontend/apps/mp-wechat/src/pages/sutra/index.config.ts
@@ -1,3 +1,4 @@
 export default definePageConfig({
-  navigationBarTitleText: "经文听诵",
+  enableShareAppMessage: true,
+  navigationBarTitleText: "经文续读",
 });

--- a/frontend/apps/mp-wechat/src/pages/sutra/index.scss
+++ b/frontend/apps/mp-wechat/src/pages/sutra/index.scss
@@ -1,7 +1,9 @@
 .page {
   min-height: 100vh;
-  padding: 28px 24px 44px;
-  background: linear-gradient(180deg, #080b10 0%, #101419 100%);
+  padding: 28px 24px 56px;
+  background:
+    radial-gradient(circle at 78% 4%, rgba(255, 215, 0, 0.14), transparent 28%),
+    linear-gradient(180deg, #0b0e14 0%, #101419 100%);
 }
 
 .header {
@@ -10,14 +12,15 @@
 
 .eyebrow {
   display: block;
-  color: #ffe3a3;
+  color: #ffd700;
   font-size: 24px;
   margin-bottom: 12px;
+  font-weight: 700;
 }
 
 .title {
   display: block;
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 44px;
   font-weight: 800;
 }
@@ -25,20 +28,121 @@
 .subtitle {
   display: block;
   margin-top: 14px;
-  color: #b9c5c7;
+  color: rgba(232, 234, 246, 0.72);
   font-size: 28px;
   line-height: 1.6;
 }
 
+.search-panel,
+.active-reader,
 .sutra-card {
   padding: 22px;
-  border: 1px solid rgba(255, 249, 235, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 8px;
-  background: rgba(255, 249, 235, 0.06);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.search-panel {
+  margin-bottom: 16px;
+  padding: 16px;
+}
+
+.search-input {
+  height: 78px;
+  padding: 0 18px;
+  border-radius: 8px;
+  background: rgba(11, 14, 20, 0.52);
+  color: #e8eaf6;
+  font-size: 28px;
+}
+
+.active-reader {
+  margin-bottom: 28px;
+}
+
+.reader-label {
+  display: block;
+  color: rgba(255, 215, 0, 0.82);
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.reader-title {
+  display: block;
+  margin-top: 12px;
+  color: #e8eaf6;
+  font-size: 42px;
+  font-weight: 800;
+}
+
+.reader-copy {
+  display: block;
+  margin-top: 14px;
+  color: rgba(232, 234, 246, 0.72);
+  font-size: 28px;
+  line-height: 1.65;
+}
+
+.reader-progress,
+.progress {
+  margin-top: 18px;
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.reader-progress-bar,
+.progress-bar {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #7b1fa2, #ffd700);
+}
+
+.reader-actions {
+  display: flex;
+  gap: 14px;
+  margin-top: 20px;
+}
+
+.primary,
+.secondary {
+  flex: 1;
+  height: 78px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.primary {
+  color: #11151d;
+  background: #ffd700;
+}
+
+.secondary {
+  color: #e8eaf6;
+  background: rgba(232, 234, 246, 0.12);
+}
+
+.section {
+  margin-bottom: 16px;
+}
+
+.section-title {
+  color: #e8eaf6;
+  font-size: 30px;
+  font-weight: 700;
 }
 
 .sutra-card + .sutra-card {
   margin-top: 16px;
+}
+
+.sutra-card-active {
+  border-color: rgba(255, 215, 0, 0.62);
 }
 
 .sutra-row {
@@ -49,41 +153,34 @@
 }
 
 .sutra-title {
-  color: #fff9eb;
+  color: #e8eaf6;
   font-size: 34px;
   font-weight: 800;
 }
 
 .sutra-meta {
   margin-top: 10px;
-  color: #b9c5c7;
+  color: rgba(232, 234, 246, 0.66);
   font-size: 24px;
 }
 
 .sutra-summary {
   display: block;
   margin-top: 16px;
-  color: #dbe7e0;
+  color: rgba(232, 234, 246, 0.78);
   font-size: 27px;
   line-height: 1.62;
 }
 
-.progress {
-  margin-top: 18px;
-  height: 12px;
-  border-radius: 999px;
-  overflow: hidden;
-  background: rgba(255, 249, 235, 0.12);
-}
-
-.progress-bar {
-  display: block;
-  height: 100%;
-  border-radius: 999px;
-  background: linear-gradient(90deg, #9ed7bf, #ffe3a3);
-}
-
 .duration {
-  color: #78d6e8;
+  color: #ffd700;
   font-size: 24px;
+  flex: 0 0 auto;
+}
+
+.empty {
+  padding: 36px 22px;
+  color: rgba(232, 234, 246, 0.66);
+  font-size: 28px;
+  text-align: center;
 }

--- a/frontend/apps/mp-wechat/src/pages/sutra/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/sutra/index.tsx
@@ -1,18 +1,77 @@
-import { View, Text } from "@tarojs/components";
-import { sutraLibrary } from "@fabushi/shared";
+import { useMemo, useState } from "react";
+import { Button, Input, Text, View } from "@tarojs/components";
+import Taro from "@tarojs/taro";
+import { aiQuickPrompts, sutraLibrary } from "@fabushi/shared";
 import "./index.scss";
 
 export default function SutraPage() {
+  const [query, setQuery] = useState("");
+  const [activeTitle, setActiveTitle] = useState<string>(sutraLibrary[0].title);
+
+  const filtered = useMemo(() => {
+    const keyword = query.trim();
+    if (!keyword) return sutraLibrary;
+    return sutraLibrary.filter((item) =>
+      `${item.title}${item.category}${item.summary}`.includes(keyword),
+    );
+  }, [query]);
+
+  const active = sutraLibrary.find((item) => item.title === activeTitle) ?? sutraLibrary[0];
+
+  function openAiWithSutra() {
+    Taro.setStorageSync(
+      "fabushi_mp_ai_prompt",
+      `${aiQuickPrompts[3]}：请围绕《${active.title}》说明。`,
+    );
+    Taro.switchTab({ url: "/pages/ai/index" });
+  }
+
   return (
     <View className="page">
       <View className="header">
-        <Text className="eyebrow">Sutra Library</Text>
-        <Text className="title">经文听诵</Text>
-        <Text className="subtitle">微信内先承接书架、进度和摘要，完整听诵继续复用大乘后端与原生 App 能力。</Text>
+        <Text className="eyebrow">Sutra Reader</Text>
+        <Text className="title">经文续读</Text>
+        <Text className="subtitle">
+          复刻 Flutter 阅读器的信息层：书架、进度、功德利益、AI 问经入口都用微信原生组件呈现。
+        </Text>
       </View>
 
-      {sutraLibrary.map((item) => (
-        <View className="sutra-card" key={item.title}>
+      <View className="search-panel">
+        <Input
+          className="search-input"
+          value={query}
+          placeholder="搜索经文、分类或摘要"
+          onInput={(event) => setQuery(event.detail.value)}
+        />
+      </View>
+
+      <View className="active-reader">
+        <Text className="reader-label">当前续读</Text>
+        <Text className="reader-title">《{active.title}》</Text>
+        <Text className="reader-copy">{active.summary}</Text>
+        <View className="reader-progress">
+          <View className="reader-progress-bar" style={{ width: `${active.progress}%` }} />
+        </View>
+        <View className="reader-actions">
+          <Button className="primary" onClick={() => Taro.showToast({ title: "已打开续读", icon: "success" })}>
+            继续读诵
+          </Button>
+          <Button className="secondary" onClick={openAiWithSutra}>
+            AI 问经
+          </Button>
+        </View>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">经文书架</Text>
+      </View>
+
+      {filtered.map((item) => (
+        <View
+          className={`sutra-card ${item.title === active.title ? "sutra-card-active" : ""}`}
+          key={item.title}
+          onClick={() => setActiveTitle(item.title)}
+        >
           <View className="sutra-row">
             <View>
               <Text className="sutra-title">{item.title}</Text>
@@ -22,10 +81,16 @@ export default function SutraPage() {
           </View>
           <Text className="sutra-summary">{item.summary}</Text>
           <View className="progress">
-            <Text className="progress-bar" style={{ width: `${item.progress}%` }} />
+            <View className="progress-bar" style={{ width: `${item.progress}%` }} />
           </View>
         </View>
       ))}
+
+      {filtered.length === 0 && (
+        <View className="empty">
+          <Text>没有找到相关经文。</Text>
+        </View>
+      )}
     </View>
   );
 }

--- a/frontend/packages/shared/src/app-experience.ts
+++ b/frontend/packages/shared/src/app-experience.ts
@@ -1,8 +1,71 @@
 export const appExperienceStats = [
   { label: "今日共修", value: "12,086", unit: "人次" },
-  { label: "法布施发送", value: "8.42", unit: "TB" },
+  { label: "全球发送", value: "8.42", unit: "TB" },
   { label: "在线国家", value: "64", unit: "个" },
   { label: "经文素材", value: "1,248", unit: "份" },
+] as const;
+
+export const flutterDesignTokens = {
+  colors: {
+    spaceDeepBlue: "#0b0e14",
+    spaceBlue: "#1b263b",
+    starlightWhite: "#e8eaf6",
+    nebulaPurple: "#7b1fa2",
+    nebulaPink: "#e91e63",
+    cosmicGold: "#ffd700",
+    glassBorder: "rgba(255, 255, 255, 0.15)",
+    glassSurface: "rgba(255, 255, 255, 0.1)",
+  },
+  radius: {
+    panel: 8,
+    control: 8,
+  },
+  sources: [
+    "fabushi/lib/core/design_system/colors.dart",
+    "fabushi/lib/core/design_system/app_theme.dart",
+    "fabushi/lib/screens/main_navigation_screen.dart",
+    "fabushi/lib/screens/globe_home_screen.dart",
+    "fabushi/lib/screens/meditation_room_screen.dart",
+    "fabushi/lib/screens/my_profile_screen.dart",
+  ],
+} as const;
+
+export const miniProgramFlutterParity = [
+  {
+    flutter: "GlobeHomeScreen",
+    miniProgram: "pages/index/index",
+    title: "全球法布施",
+    reused: "品牌、全局统计、AI 快捷任务、全球发送信息架构与宇宙玻璃视觉 token",
+    nativeScope: "微信原生 View/Text/Button/Input 复刻首页与发送入口",
+  },
+  {
+    flutter: "SutraReaderScreen / VideoFeedViewFullTextReader",
+    miniProgram: "pages/sutra/index",
+    title: "经文续读",
+    reused: "经文书架、进度、功德利益和 AI 问经入口",
+    nativeScope: "微信原生列表、搜索和进度条",
+  },
+  {
+    flutter: "MeditationRoomScreen",
+    miniProgram: "pages/practice/index",
+    title: "禅室修行",
+    reused: "零摩擦开始修行、计时、念诵计数、回向和榜单入口",
+    nativeScope: "微信原生计时器、计数器、本地草稿保存",
+  },
+  {
+    flutter: "DachengAiService / SutraAIPage",
+    miniProgram: "pages/ai/index",
+    title: "大乘 AI",
+    reused: "AI 网关、快捷提示词、资源搜索类型与请求协议",
+    nativeScope: "微信原生表单和 HTTPS request",
+  },
+  {
+    flutter: "MyProfileScreen",
+    miniProgram: "pages/me/index",
+    title: "我的",
+    reused: "账号、修行记录、设置、支持入口的信息架构",
+    nativeScope: "微信原生资料卡和服务列表",
+  },
 ] as const;
 
 export const appModules = [
@@ -10,7 +73,7 @@ export const appModules = [
     id: "global-dharma",
     title: "全球法布施",
     shortTitle: "法布施",
-    summary: "选择经文、音频、图片或发愿文，一键发送到全球 HTTP 公共端点。",
+    summary: "选择经文、音频、图片或发愿文，一键发送到全球节点。",
     action: "开始发送",
     tone: "cyan",
     screenshot: "/product/global-dharma.png",
@@ -59,6 +122,15 @@ export const appModules = [
     action: "查看榜单",
     tone: "violet",
     screenshot: "/product/global-ranking.png",
+  },
+  {
+    id: "ai",
+    title: "大乘 AI",
+    shortTitle: "AI",
+    summary: "帮你查找可分享资源、整理经文摘要、生成发愿文和修行计划。",
+    action: "问问 AI",
+    tone: "blue",
+    screenshot: "/product/global-donation.png",
   },
 ] as const;
 
@@ -111,6 +183,13 @@ export const practicePlan = [
   },
 ] as const;
 
+export const practiceSessionPresets = [
+  { title: "心经", targetMinutes: 18, dedication: "回向给今日同行者与一切众生" },
+  { title: "金刚经", targetMinutes: 42, dedication: "愿以读诵功德增长智慧与慈悲" },
+  { title: "地藏经", targetMinutes: 54, dedication: "回向父母眷属、祖先与有缘众生" },
+  { title: "楞严咒", targetMinutes: 24, dedication: "愿身心清明，护持正念" },
+] as const;
+
 export const dharmaFeedItems = [
   {
     title: "如何把一段经文整理成可分享资料",
@@ -136,6 +215,12 @@ export const aiQuickPrompts = [
   "把这段经文解释给初学者听，语气庄重简洁",
 ] as const;
 
+export const globalDharmaActions = [
+  { label: "发送经文", detail: "选择公共领域经文，生成可分享资料" },
+  { label: "AI 找资源", detail: "调用大乘 AI 网关检索可公开传播来源" },
+  { label: "加入共修", detail: "选择一门功课，开始计时与念诵计数" },
+] as const;
+
 export const leaderboardPreview = [
   { name: "明净", region: "中国", value: "328 分钟", rank: 1 },
   { name: "善行", region: "新加坡", value: "271 分钟", rank: 2 },
@@ -144,5 +229,15 @@ export const leaderboardPreview = [
 ] as const;
 
 export const miniProgramTabs = [
-  { pagePath: "pages/index/index", text: "大乘", icon: "home" },
+  { pagePath: "pages/index/index", text: "首页", icon: "home" },
+  { pagePath: "pages/sutra/index", text: "经文", icon: "sutra" },
+  { pagePath: "pages/practice/index", text: "修行", icon: "practice" },
+  { pagePath: "pages/ai/index", text: "AI", icon: "ai" },
+  { pagePath: "pages/me/index", text: "我的", icon: "me" },
+] as const;
+
+export const miniProgramNativeLimitations = [
+  "微信小程序不运行 Flutter Engine，不能直接加载 Flutter Widget tree。",
+  "当前 Flutter App 的 Firebase、3D、音视频、文件、支付、离线模型等插件不能在微信原生运行时无损复用。",
+  "小程序侧复用 Flutter 的信息架构、设计 token、领域数据和 HTTPS API，UI 用微信原生组件等价实现。",
 ] as const;


### PR DESCRIPTION
## What changed

- Reworked the WeChat mini program into a native Taro implementation that does not use `web-view`.
- Added native pages for global dharma sharing, sutra reading, practice timer, Dacheng AI, and profile/service settings.
- Added Flutter parity metadata and design-token reuse notes in `@fabushi/shared`.
- Added WeChat DevTools preview/open scripts plus project configuration and mini-program README.

## Why

The product already has Flutter Web/App, but WeChat Mini Program cannot run the standard Flutter engine or Flutter widget tree as native mini-program components. This PR maximizes reuse without WebView by sharing information architecture, design tokens, domain data, and API contracts while rendering with WeChat native components.

## Validation

- `npm run typecheck` in `frontend/apps/mp-wechat`
- `npm run lint` in `frontend/apps/mp-wechat`
- `npm run build:weapp` in `frontend/apps/mp-wechat`
- Confirmed business source and generated WXML/JSON do not use `web-view`.

## Preview note

`npm run check:preview` was attempted, but this machine does not have WeChat DevTools CLI installed. Set `WECHAT_DEVTOOLS_CLI=/path/to/cli` and run `npm run preview:weapp` after replacing `touristappid` with the real AppID.