### PR TITLE
Support cover images on Faliu page

### DIFF
--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { brand } from "@fabushi/shared";
 import { FaliuContentSearchEnhancer } from "../../components/faliu-content-search-enhancer";
+import { FaliuCoverImageEnhancer } from "../../components/faliu-cover-image-enhancer";
 import { FaliuMeritBenefitEnhancer } from "../../components/faliu-merit-benefit-enhancer";
 import { FaliuShell } from "../../components/faliu-shell";
 import { FaliuSynonymEnhancer } from "../../components/faliu-synonym-enhancer";
@@ -163,6 +164,7 @@ export default async function FaliuPage() {
       />
 
       <FaliuShell {...initialData} />
+      <FaliuCoverImageEnhancer />
       <FaliuSynonymEnhancer />
       <FaliuContentSearchEnhancer />
       <FaliuMeritBenefitEnhancer />

--- a/frontend/apps/web/src/components/faliu-cover-image-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-cover-image-enhancer.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect } from "react";
+
+const COVER_IMAGES: Record<string, string> = {
+  T0251: "/faliu/covers/T0251-heart-sutra-cover-thumb.jpg",
+};
+
+const COVER_STYLE_ID = "faliu-cover-image-enhancer-style";
+
+function ensureCoverStyles() {
+  if (document.getElementById(COVER_STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = COVER_STYLE_ID;
+  style.textContent = `
+    [data-faliu-cover-image="true"] {
+      background-image:
+        linear-gradient(180deg, rgba(5, 8, 12, 0.5), rgba(5, 8, 12, 0.2) 42%, rgba(5, 8, 12, 0.7)),
+        var(--faliu-cover-image) !important;
+      background-size: cover !important;
+      background-position: center !important;
+      background-color: #081018 !important;
+    }
+
+    [data-faliu-cover-image="true"]::before {
+      border-color: rgba(244, 239, 225, 0.38) !important;
+    }
+
+    [data-faliu-cover-image="true"] > div:first-child {
+      opacity: 0.16 !important;
+    }
+
+    [data-faliu-cover-image="true"] h2,
+    [data-faliu-cover-image="true"] p,
+    [data-faliu-cover-image="true"] span {
+      text-shadow: 0 2px 18px rgba(0, 0, 0, 0.62);
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function applyCoverImages() {
+  const cards = Array.from(document.querySelectorAll<HTMLElement>("article"));
+
+  for (const card of cards) {
+    const text = card.textContent ?? "";
+    const coverEntry = Object.entries(COVER_IMAGES).find(([work]) => text.includes(work));
+
+    if (!coverEntry) {
+      continue;
+    }
+
+    const cover = card.querySelector<HTMLElement>("button > div");
+
+    if (!cover) {
+      continue;
+    }
+
+    const [, imageUrl] = coverEntry;
+    cover.dataset.faliuCoverImage = "true";
+    cover.style.setProperty("--faliu-cover-image", `url("${imageUrl}")`);
+  }
+}
+
+export function FaliuCoverImageEnhancer() {
+  useEffect(() => {
+    ensureCoverStyles();
+    applyCoverImages();
+
+    const observer = new MutationObserver(() => applyCoverImages());
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a Faliu cover image enhancer that maps scripture work IDs to cover image assets
- apply the existing T0251 Heart Sutra cover image to its Faliu card
- keep the fallback procedural cover styling for scriptures without generated cover art

## Notes
- This starts the cover-image integration path for the broader CBETA cover system.
- Future covers can be added by extending the `COVER_IMAGES` map.

## Testing
- Not run locally because the workspace cannot clone/install this GitHub repo over the current network path.