### PR TITLE
Fix Faliu cover image rendering

### DIFF
--- a/frontend/apps/web/src/components/faliu-cover-image-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-cover-image-enhancer.tsx
@@ -6,68 +6,52 @@ const COVER_IMAGES: Record<string, string> = {
   T0251: "/faliu/covers/T0251-heart-sutra-cover-thumb.jpg",
 };
 
-const COVER_STYLE_ID = "faliu-cover-image-enhancer-style";
+function findCoverElement(card: HTMLElement, work: string) {
+  const candidates = Array.from(card.querySelectorAll<HTMLElement>("button div"));
+  return candidates.find((element) => (element.textContent ?? "").includes(work) && element.querySelector("h2")) ?? null;
+}
 
-function ensureCoverStyles() {
-  if (document.getElementById(COVER_STYLE_ID)) {
-    return;
+function applyInlineCoverStyle(cover: HTMLElement, imageUrl: string) {
+  cover.dataset.faliuCoverImage = "true";
+  cover.style.backgroundImage = `linear-gradient(180deg, rgba(5, 8, 12, 0.5), rgba(5, 8, 12, 0.2) 42%, rgba(5, 8, 12, 0.7)), url("${imageUrl}")`;
+  cover.style.backgroundSize = "cover";
+  cover.style.backgroundPosition = "center";
+  cover.style.backgroundColor = "#081018";
+
+  const texture = cover.firstElementChild;
+  if (texture instanceof HTMLElement) {
+    texture.style.opacity = "0.16";
   }
 
-  const style = document.createElement("style");
-  style.id = COVER_STYLE_ID;
-  style.textContent = `
-    [data-faliu-cover-image="true"] {
-      background-image:
-        linear-gradient(180deg, rgba(5, 8, 12, 0.5), rgba(5, 8, 12, 0.2) 42%, rgba(5, 8, 12, 0.7)),
-        var(--faliu-cover-image) !important;
-      background-size: cover !important;
-      background-position: center !important;
-      background-color: #081018 !important;
-    }
-
-    [data-faliu-cover-image="true"]::before {
-      border-color: rgba(244, 239, 225, 0.38) !important;
-    }
-
-    [data-faliu-cover-image="true"] > div:first-child {
-      opacity: 0.16 !important;
-    }
-
-    [data-faliu-cover-image="true"] h2,
-    [data-faliu-cover-image="true"] p,
-    [data-faliu-cover-image="true"] span {
-      text-shadow: 0 2px 18px rgba(0, 0, 0, 0.62);
-    }
-  `;
-  document.head.appendChild(style);
+  for (const textElement of cover.querySelectorAll<HTMLElement>("h2, p, span")) {
+    textElement.style.textShadow = "0 2px 18px rgba(0, 0, 0, 0.62)";
+  }
 }
 
 function applyCoverImages() {
   const cards = Array.from(document.querySelectorAll<HTMLElement>("article"));
 
   for (const card of cards) {
-    const text = card.textContent ?? "";
-    const coverEntry = Object.entries(COVER_IMAGES).find(([work]) => text.includes(work));
+    const cardText = card.textContent ?? "";
+    const coverEntry = Object.entries(COVER_IMAGES).find(([work]) => cardText.includes(work));
 
     if (!coverEntry) {
       continue;
     }
 
-    const cover = card.querySelector<HTMLElement>("button > div");
+    const [work, imageUrl] = coverEntry;
+    const cover = findCoverElement(card, work);
 
     if (!cover) {
       continue;
     }
 
-    const [, imageUrl] = coverEntry;
-    cover.dataset.faliuCoverImage = "true";
-    cover.style.setProperty("--faliu-cover-image", `url("${imageUrl}")`);
+    applyInlineCoverStyle(cover, imageUrl);
   }
 }
 
 export function FaliuCoverImageEnhancer() {
   useEffect(() => {
-    ensureCoverStyles();
     applyCoverImages();
 
     const observer = new MutationObserver(() => applyCoverImages());


### PR DESCRIPTION
## Summary
- render Faliu cover images through direct inline background styles instead of injected CSS rules
- keep T0251 mapped to the generated Heart Sutra cover asset
- make the card lookup a little stricter by requiring the cover candidate to contain the matching work ID and title heading

## Why
The first integration added the asset and mounted the enhancer, but the live page can still show the procedural dark cover when the injected CSS rule does not take effect reliably. Applying the image background directly to the cover element avoids that failure mode.

## Testing
- Not run locally because this workspace cannot access the site/repo through normal network clone/install paths.