### PR TITLE
Add T0263 juan 10 Zhulei merit benefits

### DIFF
--- a/frontend/apps/web/src/lib/faliu-merit-benefits-t0263-juan10-zhulei.ts
+++ b/frontend/apps/web/src/lib/faliu-merit-benefits-t0263-juan10-zhulei.ts
@@ -1,0 +1,54 @@
+import type { FaliuMeritBenefit } from "./faliu-merit-benefits";
+
+const ZHULEI_SECTION_TITLE = "囑累品第二十七";
+
+export const T0263_JUAN_10_ZHULEI_MERIT_BENEFITS: FaliuMeritBenefit[] = [
+  {
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    id: "t0263-010-087",
+    category: "付囑受持",
+    text: "當受斯經持諷誦讀，當為眾會分別說之，令諸群生普得見聞。",
+    anchorText: "當受斯經持諷誦讀",
+    note: "佛付嘱诸菩萨受持、讽诵、读诵此经，并为众会分别解说，使众生普得见闻。",
+  },
+  {
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    id: "t0263-010-088",
+    category: "無上法施",
+    text: "心無所著，勿得祕惜此《正法華經》，志無所畏，則施佛慧、如來之慧、自在之慧，則為無上無極法施。",
+    anchorText: "勿得祕惜此《正法華經》",
+    note: "经文明说不秘惜此经、无畏宣示，即是施佛慧、如来慧、自在慧，为无上法施。",
+  },
+  {
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    id: "t0263-010-089",
+    category: "廣示佛慧",
+    text: "當學佛行，無得矜惜慳嫉愛重，宜廣示現斯如來慧，當使通聞至於不至，往所不往，當勤聽受此要經典。",
+    anchorText: "宜廣示現斯如來慧",
+    note: "佛劝学佛行者广示如来智慧，使法音通达未至之处，并勤听受此要典。",
+  },
+  {
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    id: "t0263-010-090",
+    category: "勸入尊法",
+    text: "其不信者，當令信樂，當勸群生入于尊法。諸族姓子，能如是者，則知如來之所建立。",
+    anchorText: "其不信者，當令信樂",
+    note: "对未信者令其信乐，劝众生入于尊法；能如此弘护，即知为如来所建立。",
+  },
+  {
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    id: "t0263-010-091",
+    category: "奉教流布",
+    text: "唯如世尊所勅，不敢違教，請奉行之，具足順從如佛所宣，願勿為慮。」諸菩薩三啟如是，所至到處，周旋十方頒宣聖旨。",
+    anchorText: "請奉行之，具足順從如佛所宣",
+    note: "诸菩萨受佛嘱累，愿奉行佛教，并周旋十方颁宣圣旨。",
+  },
+  {
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    id: "t0263-010-092",
+    category: "聞經歡喜",
+    text: "佛說是經時，十方無量異佛世界諸來大聖，坐佛樹下處師子座，多寶如來及大士等，諸餘學行現佛前者，不可計會無數無量，并從地中踊出菩薩，諸大聲聞四部之眾，諸天、龍、神、阿須倫、揵沓惒，世間人民，聞佛所說，莫不歡喜。",
+    anchorText: "佛說是經時，十方無量異佛世界諸來大聖",
+    note: "本经结尾明示十方诸佛、多宝如来、菩萨、声闻四众及天龙人民闻佛所说，皆大欢喜。",
+  },
+];

--- a/frontend/apps/web/src/lib/faliu-merit-benefits.ts
+++ b/frontend/apps/web/src/lib/faliu-merit-benefits.ts
@@ -3,12 +3,14 @@ export { T0263_JUAN_10_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan1
 export { T0263_JUAN_10_ZONGCHI_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-zongchi";
 export { T0263_JUAN_10_JINGFU_JINGWANG_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-jingfu-jingwang";
 export { T0263_JUAN_10_LEPUXIAN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-lepuxian";
+export { T0263_JUAN_10_ZHULEI_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-zhulei";
 
 import { getFaliuMeritBenefits as getBaseFaliuMeritBenefits } from "./faliu-merit-benefits-original";
 import { T0263_JUAN_10_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10";
 import { T0263_JUAN_10_ZONGCHI_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-zongchi";
 import { T0263_JUAN_10_JINGFU_JINGWANG_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-jingfu-jingwang";
 import { T0263_JUAN_10_LEPUXIAN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-lepuxian";
+import { T0263_JUAN_10_ZHULEI_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10-zhulei";
 
 export function getFaliuMeritBenefits(work: string | null | undefined, juan: string | number | null | undefined) {
   const normalizedWork = work?.trim().toUpperCase();
@@ -20,6 +22,7 @@ export function getFaliuMeritBenefits(work: string | null | undefined, juan: str
       ...T0263_JUAN_10_ZONGCHI_MERIT_BENEFITS,
       ...T0263_JUAN_10_JINGFU_JINGWANG_MERIT_BENEFITS,
       ...T0263_JUAN_10_LEPUXIAN_MERIT_BENEFITS,
+      ...T0263_JUAN_10_ZHULEI_MERIT_BENEFITS,
     ];
   }
 


### PR DESCRIPTION
## Summary
- Add 6 source-grounded merit-benefit entries for T0263《正法華經》卷 10《囑累品第二十七》.
- Register the new T0263 juan 10 Zhulei data in the Faliu merit-benefits selector.

## Validation
- `validate_faliu_merit_entries.py --strict`: 6 entries, 0 failures
- `render_faliu_merit_data.py --strict --mode constant`: 6 entries, 0 warnings
- `node --check /workspace/tmp-cbeta/faliu-merit-benefits-t0263-juan10-zhulei.ts`
- `node --check /workspace/tmp-cbeta/faliu-merit-benefits-updated.ts`

Scope is limited to merit-benefit data for the current scripture segment; no page structure, style, or navigation changes.