### PR TITLE
Fix desktop notarization and build number sequencing

### DIFF
--- a/.github/scripts/fix-macos-bundled-dylibs.sh
+++ b/.github/scripts/fix-macos-bundled-dylibs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 app_path="${1:-}"
 if [ -z "$app_path" ]; then
@@ -103,11 +103,9 @@ done < <(find "$app_path/Contents" -type f \( -perm -111 -o -name '*.dylib' -o -
 
 if [ "${#homebrew_deps[@]}" -eq 0 ]; then
   echo "No Homebrew dynamic library references found in $app_path."
-  exit 0
-fi
-
-index=0
-while [ "$index" -lt "${#homebrew_deps[@]}" ]; do
+else
+  index=0
+  while [ "$index" -lt "${#homebrew_deps[@]}" ]; do
   dep="${homebrew_deps[$index]}"
   if should_bundle_dep "$dep"; then
     dep_path="$(resolve_dep_path "$dep" || true)"
@@ -121,8 +119,9 @@ while [ "$index" -lt "${#homebrew_deps[@]}" ]; do
     done < <(collect_homebrew_deps "$dep_path")
   fi
 
-  index=$((index + 1))
-done
+    index=$((index + 1))
+  done
+fi
 
 for dep in "${homebrew_deps[@]}"; do
   if ! should_bundle_dep "$dep"; then
@@ -166,3 +165,50 @@ if [ -n "$remaining_refs" ]; then
   echo "$remaining_refs" >&2
   exit 1
 fi
+
+
+resolve_codesign_identity() {
+  local identity="${MACOS_CODESIGN_IDENTITY:-}"
+  if [ -z "$identity" ] && command -v security >/dev/null 2>&1; then
+    identity="$(security find-identity -v -p codesigning | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
+  fi
+  printf '%s\n' "$identity"
+}
+
+is_macho_file() {
+  local file="$1"
+  file "$file" 2>/dev/null | grep -q 'Mach-O'
+}
+
+sign_openclaw_native_runtime() {
+  local identity="$1"
+  local openclaw_root="$app_path/Contents/Frameworks/App.framework/Resources/flutter_assets/assets/openclaw"
+  local signed_count=0
+
+  if [ -z "$identity" ]; then
+    echo "No Developer ID identity is available; skipping OpenClaw native runtime signing."
+    return 0
+  fi
+  if [ ! -d "$openclaw_root" ]; then
+    echo "OpenClaw runtime assets were not found in $app_path; skipping native runtime signing."
+    return 0
+  fi
+
+  while IFS= read -r -d '' file; do
+    if ! is_macho_file "$file"; then
+      continue
+    fi
+    chmod u+w "$file" || true
+    codesign --force --timestamp --options runtime --sign "$identity" "$file"
+    signed_count=$((signed_count + 1))
+    echo "Signed OpenClaw native runtime file: $file"
+  done < <(
+    find "$openclaw_root" -type f \
+      \( -name '*.node' -o -name '*.dylib' -o -perm -111 \) \
+      -print0
+  )
+
+  echo "Signed $signed_count OpenClaw native runtime file(s)."
+}
+
+sign_openclaw_native_runtime "$(resolve_codesign_identity)"

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -101,6 +101,7 @@ jobs:
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           INPUT_PUBLISH_RELEASE: ${{ inputs.publish_release }}
           INPUT_UPLOAD_MACOS_APP_STORE: ${{ inputs.upload_macos_app_store }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -117,12 +118,32 @@ jobs:
             pubspec_build_number=0
           fi
 
+          highest_release_build_number="$pubspec_build_number"
+          if command -v gh >/dev/null 2>&1 && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+            release_tag_build_number="$(
+              gh api -H 'Accept: application/vnd.github+json'                 "/repos/$GITHUB_REPOSITORY/releases?per_page=100" --paginate --jq '.[].tag_name' 2>/dev/null |
+                awk -v highest="$highest_release_build_number" '
+                  /^v[0-9].*-mobile(\.|$)/ || /^desktop-v[0-9]/ {
+                    split($0, parts, "-")
+                    build = ($0 ~ /^desktop-v[0-9]/) ? parts[3] : parts[2]
+                    if (build ~ /^[0-9]+$/ && build + 0 > highest) {
+                      highest = build + 0
+                    }
+                  }
+                  END { print highest }
+                '
+            )"
+            if [[ "$release_tag_build_number" =~ ^[0-9]+$ ]] && [ "$release_tag_build_number" -gt "$highest_release_build_number" ]; then
+              highest_release_build_number="$release_tag_build_number"
+            fi
+          fi
+
           release_build_number="${GITHUB_RUN_NUMBER:-0}"
           if ! [[ "$release_build_number" =~ ^[0-9]+$ ]]; then
             release_build_number=0
           fi
-          if [ "$release_build_number" -le "$pubspec_build_number" ]; then
-            release_build_number=$((pubspec_build_number + 1))
+          if [ "$release_build_number" -le "$highest_release_build_number" ]; then
+            release_build_number=$((highest_release_build_number + 1))
           fi
 
           app_version="${version_name}+${release_build_number}"
@@ -169,6 +190,7 @@ jobs:
             echo "- Source SHA: \`$source_sha\`"
             echo "- App version: \`$app_version\`"
             echo "- Release build number: \`$release_build_number\`"
+            echo "- Highest existing mobile/desktop build number: \`$highest_release_build_number\`"
             echo "- Release tag: \`$release_tag\`"
             echo "- Publish release: \`$publish_release\`"
             echo "- Upload macOS App Store Connect build: \`$upload_macos_app_store\`"


### PR DESCRIPTION
## Summary
- Explicitly sign embedded OpenClaw Mach-O runtime files inside the macOS app bundle before notarization.
- Keep the Homebrew dylib rewrite step running even when no Homebrew deps are found, so native runtime signing still runs.
- Resolve desktop build numbers from the highest existing mobile/desktop release build number, then increment when needed.

## Verification
- `bash -n .github/scripts/fix-macos-bundled-dylibs.sh`
- Parsed `.github/workflows/desktop-installers.yml` as YAML
- Tested sample mobile and desktop release tags with the new build-number parser