### PR TITLE
fix: enable desktop Buddha model loading

### DIFF
--- a/fabushi/lib/widgets/buddha_3d_widget.dart
+++ b/fabushi/lib/widgets/buddha_3d_widget.dart
@@ -1,27 +1,37 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+
+import '../screens/buddha_model_screen.dart';
 
 class Buddha3DWidget extends StatelessWidget {
-  const Buddha3DWidget({Key? key}) : super(key: key);
+  final bool autoRotate;
+  final bool isBurning;
+  final double incenseProgress;
+  final bool showBook;
+  final String? bookTitle;
+  final VoidCallback? onBookTap;
+  final bool isVisible;
+
+  const Buddha3DWidget({
+    super.key,
+    this.autoRotate = true,
+    this.isBurning = false,
+    this.incenseProgress = 0.0,
+    this.showBook = false,
+    this.bookTitle,
+    this.onBookTap,
+    this.isVisible = true,
+  });
 
   @override
   Widget build(BuildContext context) {
-    if (kIsWeb) {
-      return Center(child: Text('3D佛像仅在Web平台可用'));
-    } else {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.web, size: 64, color: Colors.grey[400]),
-            const SizedBox(height: 16),
-            Text(
-              '3D佛像仅在Web平台可用',
-              style: TextStyle(fontSize: 16, color: Colors.grey[600]),
-            ),
-          ],
-        ),
-      );
-    }
+    return BuddhaModelScreen(
+      autoRotate: autoRotate,
+      isBurning: isBurning,
+      incenseProgress: incenseProgress,
+      showBook: showBook,
+      bookTitle: bookTitle,
+      onBookTap: onBookTap,
+      isVisible: isVisible,
+    );
   }
 }

--- a/fabushi/lib/widgets/meditation_room_3d_widget.dart
+++ b/fabushi/lib/widgets/meditation_room_3d_widget.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'meditation_room_painter.dart';
 import 'sutra_dialog.dart';
 import 'buddha_3d_widget.dart';
@@ -211,10 +210,9 @@ class _MeditationRoom3DWidgetState extends State<MeditationRoom3DWidget>
               },
             ),
           ),
-          if (kIsWeb)
-            const Center(
-              child: SizedBox(width: 400, height: 500, child: Buddha3DWidget()),
-            ),
+          const Center(
+            child: SizedBox(width: 400, height: 500, child: Buddha3DWidget()),
+          ),
           Positioned(
             top: 20,
             left: 0,


### PR DESCRIPTION
## Summary
- Replace the `Buddha3DWidget` desktop/Web placeholder with the shared `BuddhaModelScreen` renderer.
- Render `Buddha3DWidget` in `MeditationRoom3DWidget` on desktop as well as Web, so native desktop creates the model loader instead of skipping it.

## Verification
- Confirmed the R2 Buddha model endpoint returns `200`, `Content-Length: 308204772`, `Accept-Ranges: bytes`, and CORS headers from the connected VPS.
- Checked the branch diff: only `buddha_3d_widget.dart` and `meditation_room_3d_widget.dart` changed.
- Ran `git diff --check` on the changed files via sparse checkout.

Note: the VPS did not have Dart/Flutter installed, so full `flutter analyze`/test coverage is left to CI.