### PR TITLE
Fix macOS dylib script empty dependency handling

### DIFF
--- a/.github/scripts/fix-macos-bundled-dylibs.sh
+++ b/.github/scripts/fix-macos-bundled-dylibs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 app_path="${1:-}"
 if [ -z "$app_path" ]; then


### PR DESCRIPTION
## Summary
- restore the macOS dylib helper to the shell mode it used before the notarization fix
- avoid `nounset` treating an empty Homebrew dependency array as a fatal error before signing bundled native runtime files

## Validation
- `bash -n .github/scripts/fix-macos-bundled-dylibs.sh`
- `git diff --check`