### PR TITLE
Add Faliu card tabs and Heart Sutra image cards

### DIFF
--- a/frontend/apps/web/src/components/faliu-anki-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-anki-enhancer.tsx
@@ -6,8 +6,13 @@ import { FALIU_ANKI_DECK_MAP, type FaliuAnkiCard, type FaliuAnkiDeck } from "../
 
 const REVIEW_STORAGE_KEY = "fabushi:faliu-anki-review:v1";
 const MAX_FALLBACK_CARDS = 12;
+const READER_SELECTOR = 'section[aria-label="法流"] [class*="readerHtml"]';
+const ANKI_SLOT_SELECTOR = '[data-faliu-anki-slot="true"]';
+const HIGHLIGHT_NAME = "faliu-anki-source-highlight";
+const SKIP_TEXT_SELECTOR = ".lb,.noteAnchor,.gaijiInfo,#cbeta-copyright,script,style,[aria-hidden='true']";
 
 type ReviewGrade = "again" | "hard" | "good" | "easy";
+type CardFilter = "all" | "understanding" | "image";
 
 interface ReviewRecord {
   reviewed: number;
@@ -25,6 +30,17 @@ interface ReaderContext {
   host: HTMLElement;
 }
 
+interface IndexedCharacter {
+  node: Text;
+  offset: number;
+  length: number;
+}
+
+interface TextMatch {
+  range: Range;
+  element: HTMLElement;
+}
+
 function buildContentId(work: string, juan: string) {
   return `cbeta:${work}:${juan}`;
 }
@@ -35,6 +51,10 @@ function getModal() {
 
 function getSidePanel() {
   return document.querySelector<HTMLElement>('section[aria-label="法流"] aside[class*="sidePanel"]');
+}
+
+function getCardHost() {
+  return document.querySelector<HTMLElement>(ANKI_SLOT_SELECTOR) ?? getSidePanel();
 }
 
 function getText(selector: string, root: ParentNode = document) {
@@ -87,6 +107,224 @@ function normalizeReaderLine(value: string) {
   return value.replace(/\s+/g, " ").replace(/[\u2460-\u2473]/g, "").trim();
 }
 
+function normalizeSearchText(value: string) {
+  return value.replace(/\s+/g, "").trim();
+}
+
+function shouldSkipTextNode(node: Node, root: HTMLElement) {
+  const parent = node.parentElement;
+
+  if (!parent || !root.contains(parent)) {
+    return true;
+  }
+
+  return Boolean(parent.closest(SKIP_TEXT_SELECTOR));
+}
+
+function buildVisibleTextIndex(root: HTMLElement) {
+  const characters: IndexedCharacter[] = [];
+  let text = "";
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      return shouldSkipTextNode(node, root) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  let node = walker.nextNode();
+
+  while (node) {
+    const value = node.textContent ?? "";
+    let offset = 0;
+
+    for (const character of value) {
+      if (!/\s/.test(character)) {
+        text += character;
+        characters.push({ node: node as Text, offset, length: character.length });
+      }
+
+      offset += character.length;
+    }
+
+    node = walker.nextNode();
+  }
+
+  return { text, characters };
+}
+
+function getCandidateAnchors(sourceText: string) {
+  const normalizedSource = normalizeSearchText(sourceText);
+  const segments = normalizedSource
+    .split(/[，。；：！？、,.!?;:]/)
+    .map((item) => item.trim())
+    .filter((item) => item.length >= 4)
+    .sort((left, right) => right.length - left.length);
+
+  return Array.from(new Set([normalizedSource, ...segments]));
+}
+
+function getElementForRange(range: Range, reader: HTMLElement) {
+  const startElement = range.startContainer instanceof HTMLElement ? range.startContainer : range.startContainer.parentElement;
+  let current = startElement;
+
+  while (current && current !== reader) {
+    if (["P", "DIV", "LI", "SECTION", "ARTICLE"].includes(current.tagName)) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return startElement ?? reader;
+}
+
+function findTextMatch(reader: HTMLElement, sourceText: string): TextMatch | null {
+  const { text, characters } = buildVisibleTextIndex(reader);
+
+  for (const candidate of getCandidateAnchors(sourceText)) {
+    const startIndex = text.indexOf(candidate);
+
+    if (startIndex < 0) {
+      continue;
+    }
+
+    const endIndex = startIndex + candidate.length - 1;
+    const start = characters[startIndex];
+    const end = characters[endIndex];
+
+    if (!start || !end) {
+      continue;
+    }
+
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset + end.length);
+
+    return {
+      range,
+      element: getElementForRange(range, reader),
+    };
+  }
+
+  return null;
+}
+
+function getScrollableParent(element: HTMLElement | null) {
+  let current = element?.parentElement ?? null;
+
+  while (current) {
+    const style = window.getComputedStyle(current);
+    const canScroll = /(auto|scroll)/.test(`${style.overflow}${style.overflowY}${style.overflowX}`);
+
+    if (canScroll && current.scrollHeight > current.clientHeight) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+function getHighlightsRegistry() {
+  const css = window.CSS as unknown as { highlights?: { delete: (name: string) => void; set: (name: string, value: unknown) => void } };
+  const HighlightConstructor = (window as unknown as { Highlight?: new (range: Range) => unknown }).Highlight;
+
+  if (!css.highlights || !HighlightConstructor) {
+    return null;
+  }
+
+  return { highlights: css.highlights, HighlightConstructor };
+}
+
+function ensureHighlightStyle() {
+  if (document.getElementById("faliu-anki-source-highlight-style")) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = "faliu-anki-source-highlight-style";
+  style.textContent = `
+    ::highlight(${HIGHLIGHT_NAME}) {
+      background: rgba(111, 211, 255, 0.34);
+      color: inherit;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function clearSourceMarks(reader?: HTMLElement | null) {
+  const registry = typeof window !== "undefined" ? getHighlightsRegistry() : null;
+  registry?.highlights.delete(HIGHLIGHT_NAME);
+
+  reader?.querySelectorAll<HTMLElement>('[data-anki-source-highlight="true"]').forEach((node) => {
+    node.style.outline = "";
+    node.style.background = "";
+    node.style.borderRadius = "";
+    node.style.padding = "";
+    node.style.scrollMarginTop = "";
+    node.removeAttribute("data-anki-source-highlight");
+  });
+}
+
+function applySourceHighlight(match: TextMatch) {
+  const registry = getHighlightsRegistry();
+
+  if (registry) {
+    ensureHighlightStyle();
+    registry.highlights.set(HIGHLIGHT_NAME, new registry.HighlightConstructor(match.range));
+  }
+
+  match.element.dataset.ankiSourceHighlight = "true";
+  match.element.style.outline = "1px solid rgba(111, 211, 255, 0.72)";
+  match.element.style.background = "rgba(111, 211, 255, 0.08)";
+  match.element.style.borderRadius = "8px";
+  match.element.style.padding = "4px 6px";
+  match.element.style.scrollMarginTop = "24px";
+}
+
+function scrollToMatch(match: TextMatch) {
+  const scrollParent = getScrollableParent(match.element);
+  const rect = match.range.getBoundingClientRect();
+  const targetRect = rect.height > 0 ? rect : match.element.getBoundingClientRect();
+
+  if (scrollParent) {
+    const parentRect = scrollParent.getBoundingClientRect();
+    scrollParent.scrollTo({
+      top: scrollParent.scrollTop + targetRect.top - parentRect.top - 32,
+      behavior: "smooth",
+    });
+  } else {
+    match.element.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+function scrollToCardSource(card: FaliuAnkiCard) {
+  if (!card.sourceText) {
+    return false;
+  }
+
+  const reader = document.querySelector<HTMLElement>(READER_SELECTOR);
+
+  if (!reader) {
+    return false;
+  }
+
+  clearSourceMarks(reader);
+  const match = findTextMatch(reader, card.sourceText);
+
+  if (!match) {
+    return false;
+  }
+
+  applySourceHighlight(match);
+  scrollToMatch(match);
+  return true;
+}
+
+function getCardType(card: FaliuAnkiCard) {
+  return card.type ?? (card.imagePrompt ? "image" : "understanding");
+}
+
 function buildFallbackDeck(context: ReaderContext): FaliuAnkiDeck {
   const lines = context.readerText
     .split(/[\n。！？!?；;]/)
@@ -107,6 +345,7 @@ function buildFallbackDeck(context: ReaderContext): FaliuAnkiDeck {
     const cue = line.slice(0, cueLength);
     cards.push({
       id: `${context.contentId}:auto-${cards.length + 1}`,
+      type: "recitation",
       front: `請背誦接下來的經文：${cue}……`,
       back: line,
       hint: `摘自第 ${context.juan} 卷正文`,
@@ -130,7 +369,7 @@ function buildFallbackDeck(context: ReaderContext): FaliuAnkiDeck {
 
 function getReaderContext(): ReaderContext | null {
   const modal = getModal();
-  const host = getSidePanel();
+  const host = getCardHost();
 
   if (!modal || !host) {
     return null;
@@ -181,7 +420,9 @@ export function FaliuAnkiEnhancer() {
   const [context, setContext] = useState<ReaderContext | null>(null);
   const [records, setRecords] = useState<Record<string, ReviewRecord>>({});
   const [activeIndex, setActiveIndex] = useState(0);
+  const [activeFilter, setActiveFilter] = useState<CardFilter>("all");
   const [isRevealed, setIsRevealed] = useState(false);
+  const [sourceLookupFailed, setSourceLookupFailed] = useState(false);
 
   useEffect(() => {
     setRecords(readReviewRecords());
@@ -210,8 +451,28 @@ export function FaliuAnkiEnhancer() {
 
   useEffect(() => {
     setActiveIndex(0);
+    setActiveFilter("all");
     setIsRevealed(false);
+    setSourceLookupFailed(false);
   }, [deck?.contentId]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+    setIsRevealed(false);
+    setSourceLookupFailed(false);
+  }, [activeFilter]);
+
+  useEffect(() => {
+    return () => clearSourceMarks(document.querySelector<HTMLElement>(READER_SELECTOR));
+  }, []);
+
+  const filteredCards = useMemo(() => {
+    if (!deck) {
+      return [];
+    }
+
+    return activeFilter === "all" ? deck.cards : deck.cards.filter((card) => getCardType(card) === activeFilter);
+  }, [activeFilter, deck]);
 
   const dueCards = useMemo(() => {
     if (!deck) {
@@ -219,9 +480,9 @@ export function FaliuAnkiEnhancer() {
     }
 
     const now = Date.now();
-    const due = deck.cards.filter((card) => !records[card.id] || records[card.id].due <= now);
-    return due.length > 0 ? due : deck.cards;
-  }, [deck, records]);
+    const due = filteredCards.filter((card) => !records[card.id] || records[card.id].due <= now);
+    return due.length > 0 ? due : filteredCards;
+  }, [deck, filteredCards, records]);
 
   if (!context || !deck) {
     return null;
@@ -230,6 +491,8 @@ export function FaliuAnkiEnhancer() {
   const activeCard = dueCards[activeIndex % Math.max(1, dueCards.length)];
   const finishedCount = deck.cards.filter((card) => records[card.id]?.reviewed).length;
   const isAiDeck = Boolean(FALIU_ANKI_DECK_MAP[context.contentId]);
+  const hasImageCards = deck.cards.some((card) => getCardType(card) === "image");
+  const hasUnderstandingCards = deck.cards.some((card) => getCardType(card) === "understanding");
 
   function review(grade: ReviewGrade) {
     if (!activeCard) {
@@ -244,14 +507,24 @@ export function FaliuAnkiEnhancer() {
     setRecords(nextRecords);
     writeReviewRecords(nextRecords);
     setIsRevealed(false);
+    setSourceLookupFailed(false);
     setActiveIndex((current) => (dueCards.length <= 1 ? 0 : (current + 1) % dueCards.length));
+  }
+
+  function jumpToSource() {
+    if (!activeCard) {
+      return;
+    }
+
+    setSourceLookupFailed(!scrollToCardSource(activeCard));
   }
 
   return createPortal(
     <section
       aria-label="经文背诵卡片"
+      data-faliu-anki-panel="true"
       style={{
-        marginTop: 16,
+        marginTop: context.host.matches(ANKI_SLOT_SELECTOR) ? 0 : 16,
         padding: 18,
         border: "1px solid rgba(232, 189, 107, 0.18)",
         borderRadius: 8,
@@ -260,7 +533,7 @@ export function FaliuAnkiEnhancer() {
     >
       <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12 }}>
         <div>
-          <h4 style={{ margin: "0 0 6px", color: "#ffffff", fontSize: "1rem" }}>背诵卡片</h4>
+          <h4 style={{ margin: "0 0 6px", color: "#ffffff", fontSize: "1rem" }}>卡片</h4>
           <p style={{ margin: 0, color: "rgba(255, 255, 255, 0.56)", fontSize: "0.86rem", lineHeight: 1.55 }}>
             {isAiDeck ? "AI 精修卡片" : "临时摘句卡片，后续可由 AI 批量替换"} · {deck.cards.length} 张
           </p>
@@ -269,6 +542,37 @@ export function FaliuAnkiEnhancer() {
           {finishedCount}/{deck.cards.length}
         </span>
       </div>
+
+      {hasImageCards && hasUnderstandingCards ? (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8, marginTop: 14 }}>
+          {[
+            ["all", `全部 ${deck.cards.length}`],
+            ["understanding", `理解 ${deck.cards.filter((card) => getCardType(card) === "understanding").length}`],
+            ["image", `图像 ${deck.cards.filter((card) => getCardType(card) === "image").length}`],
+          ].map(([filter, label]) => {
+            const isActive = activeFilter === filter;
+            return (
+              <button
+                key={filter}
+                type="button"
+                onClick={() => setActiveFilter(filter as CardFilter)}
+                style={{
+                  minHeight: 34,
+                  border: `1px solid ${isActive ? "rgba(111, 211, 255, 0.42)" : "rgba(255, 255, 255, 0.1)"}`,
+                  borderRadius: 8,
+                  background: isActive ? "rgba(111, 211, 255, 0.14)" : "rgba(255, 255, 255, 0.055)",
+                  color: "#ffffff",
+                  cursor: "pointer",
+                  fontSize: "0.82rem",
+                  fontWeight: 760,
+                }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
 
       {activeCard ? (
         <div style={{ marginTop: 16 }}>
@@ -284,6 +588,27 @@ export function FaliuAnkiEnhancer() {
               border: "1px solid rgba(255, 255, 255, 0.08)",
             }}
           >
+            {getCardType(activeCard) === "image" && activeCard.imagePrompt ? (
+              <div
+                aria-label="图像提示"
+                style={{
+                  padding: 13,
+                  borderRadius: 8,
+                  border: "1px solid rgba(111, 211, 255, 0.22)",
+                  background: "rgba(111, 211, 255, 0.08)",
+                }}
+              >
+                <strong style={{ display: "block", marginBottom: 6, color: "#bfeeff", fontSize: "0.86rem" }}>图像提示</strong>
+                <p style={{ margin: 0, color: "rgba(255, 255, 255, 0.86)", fontSize: "0.92rem", lineHeight: 1.62 }}>
+                  {activeCard.imagePrompt}
+                </p>
+                {activeCard.imageAlt ? (
+                  <small style={{ display: "block", marginTop: 8, color: "rgba(255, 255, 255, 0.48)", lineHeight: 1.5 }}>
+                    {activeCard.imageAlt}
+                  </small>
+                ) : null}
+              </div>
+            ) : null}
             <p style={{ margin: 0, color: "#ffffff", fontSize: "1.02rem", fontWeight: 760, lineHeight: 1.72 }}>
               {activeCard.front}
             </p>
@@ -298,6 +623,33 @@ export function FaliuAnkiEnhancer() {
               </p>
             ) : null}
           </div>
+
+          {activeCard.sourceText ? (
+            <div style={{ marginTop: 12, display: "grid", gap: 8 }}>
+              <button
+                type="button"
+                onClick={jumpToSource}
+                style={{
+                  width: "100%",
+                  minHeight: 38,
+                  border: "1px solid rgba(111, 211, 255, 0.32)",
+                  borderRadius: 8,
+                  background: "rgba(111, 211, 255, 0.1)",
+                  color: "#ffffff",
+                  fontSize: "0.88rem",
+                  fontWeight: 760,
+                  cursor: "pointer",
+                }}
+              >
+                定位原文
+              </button>
+              {sourceLookupFailed ? (
+                <p style={{ margin: 0, color: "rgba(255, 255, 255, 0.5)", fontSize: "0.82rem", lineHeight: 1.5 }}>
+                  暂未在当前正文中匹配到这张卡的来源句。
+                </p>
+              ) : null}
+            </div>
+          ) : null}
 
           {!isRevealed ? (
             <button
@@ -348,7 +700,7 @@ export function FaliuAnkiEnhancer() {
         </div>
       ) : (
         <p style={{ margin: "14px 0 0", color: "rgba(255, 255, 255, 0.58)", lineHeight: 1.65 }}>
-          正文载入后会自动生成可练习的摘句卡；AI 批量卡片导入后会优先显示精修版本。
+          当前筛选下暂无卡片。
         </p>
       )}
     </section>,

--- a/frontend/apps/web/src/components/faliu-merit-benefit-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-merit-benefit-enhancer.tsx
@@ -12,6 +12,8 @@ const HOST_SELECTOR = '[data-faliu-merit-benefit-host="true"]';
 const HIGHLIGHT_NAME = "faliu-merit-benefit-highlight";
 const SKIP_TEXT_SELECTOR = ".lb,.noteAnchor,.gaijiInfo,#cbeta-copyright,script,style,[aria-hidden='true']";
 
+type StudyTab = "benefits" | "cards";
+
 interface IndexedCharacter {
   node: Text;
   offset: number;
@@ -361,9 +363,36 @@ function restorePanelChildren(panel: HTMLElement, host: HTMLElement) {
   }
 }
 
+function StudyTabButton({ tab, activeTab, onSelect, children }: { tab: StudyTab; activeTab: StudyTab; onSelect: (tab: StudyTab) => void; children: React.ReactNode }) {
+  const isActive = tab === activeTab;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => onSelect(tab)}
+      style={{
+        minHeight: 36,
+        border: `1px solid ${isActive ? "rgba(232, 189, 107, 0.48)" : "rgba(255, 255, 255, 0.12)"}`,
+        borderRadius: 8,
+        padding: "7px 10px",
+        background: isActive ? "rgba(232, 189, 107, 0.16)" : "rgba(255, 255, 255, 0.055)",
+        color: isActive ? "#ffffff" : "rgba(255, 255, 255, 0.68)",
+        cursor: "pointer",
+        fontSize: "0.85rem",
+        fontWeight: 780,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
 function MeritBenefitPanel({ benefits }: { benefits: FaliuMeritBenefit[] }) {
   const sections = useMemo(() => getBenefitSections(benefits), [benefits]);
   const hasSectionFilter = sections.length > 1;
+  const [activeTab, setActiveTab] = useState<StudyTab>("benefits");
   const [activeSectionKey, setActiveSectionKey] = useState<string | null>(null);
   const activeSection = sections.find((section) => section.key === activeSectionKey) ?? sections[0] ?? null;
   const visibleBenefits = hasSectionFilter && activeSectionKey !== ALL_SECTIONS_KEY && activeSection ? activeSection.benefits : benefits;
@@ -381,103 +410,122 @@ function MeritBenefitPanel({ benefits }: { benefits: FaliuMeritBenefit[] }) {
   }, [activeSectionKey, hasSectionFilter, sections]);
 
   return (
-    <div data-faliu-merit-benefits="true" style={{ display: "grid", gap: 16 }}>
+    <div data-faliu-study-panel="true" style={{ display: "grid", gap: 16 }}>
       <div>
-        <h4 style={{ margin: "0 0 8px", color: "#ffffff", fontSize: "1rem" }}>{PANEL_TITLE}</h4>
-        <p style={{ margin: 0, color: "rgba(255, 255, 255, 0.58)", fontSize: "0.9rem", lineHeight: 1.65 }}>
-          共 {benefits.length} 句。点击句子可跳到经文对应位置。
-        </p>
+        <div style={{ display: "flex", gap: 8 }} role="tablist" aria-label="法流学习面板">
+          <StudyTabButton tab="benefits" activeTab={activeTab} onSelect={setActiveTab}>
+            功德利益
+          </StudyTabButton>
+          <StudyTabButton tab="cards" activeTab={activeTab} onSelect={setActiveTab}>
+            卡片
+          </StudyTabButton>
+        </div>
+        {activeTab === "benefits" ? (
+          <p style={{ margin: "10px 0 0", color: "rgba(255, 255, 255, 0.58)", fontSize: "0.9rem", lineHeight: 1.65 }}>
+            共 {benefits.length} 句。点击句子可跳到经文对应位置。
+          </p>
+        ) : (
+          <p style={{ margin: "10px 0 0", color: "rgba(255, 255, 255, 0.58)", fontSize: "0.9rem", lineHeight: 1.65 }}>
+            练习理解卡与图像卡；每张卡都可定位原文。
+          </p>
+        )}
       </div>
 
-      {hasSectionFilter ? (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }} role="tablist" aria-label="按品查看功德利益">
-          {sections.map((section) => {
-            const isActive = section.key === activeSectionKey;
-            return (
+      <div style={{ display: activeTab === "cards" ? "block" : "none" }} data-faliu-anki-slot="true" />
+
+      {activeTab === "benefits" ? (
+        <>
+          {hasSectionFilter ? (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }} role="tablist" aria-label="按品查看功德利益">
+              {sections.map((section) => {
+                const isActive = section.key === activeSectionKey;
+                return (
+                  <button
+                    key={section.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    onClick={() => setActiveSectionKey(section.key)}
+                    style={{
+                      minHeight: 34,
+                      maxWidth: "100%",
+                      border: `1px solid ${isActive ? "rgba(232, 189, 107, 0.48)" : "rgba(255, 255, 255, 0.12)"}`,
+                      borderRadius: 8,
+                      padding: "7px 10px",
+                      background: isActive ? "rgba(232, 189, 107, 0.16)" : "rgba(255, 255, 255, 0.055)",
+                      color: isActive ? "#ffffff" : "rgba(255, 255, 255, 0.68)",
+                      cursor: "pointer",
+                      fontSize: "0.82rem",
+                      fontWeight: 760,
+                      lineHeight: 1.25,
+                    }}
+                  >
+                    {section.title} · {section.benefits.length}
+                  </button>
+                );
+              })}
               <button
-                key={section.key}
                 type="button"
                 role="tab"
-                aria-selected={isActive}
-                onClick={() => setActiveSectionKey(section.key)}
+                aria-selected={activeSectionKey === ALL_SECTIONS_KEY}
+                onClick={() => setActiveSectionKey(ALL_SECTIONS_KEY)}
                 style={{
                   minHeight: 34,
-                  maxWidth: "100%",
-                  border: `1px solid ${isActive ? "rgba(232, 189, 107, 0.48)" : "rgba(255, 255, 255, 0.12)"}`,
+                  border: `1px solid ${activeSectionKey === ALL_SECTIONS_KEY ? "rgba(232, 189, 107, 0.48)" : "rgba(255, 255, 255, 0.12)"}`,
                   borderRadius: 8,
                   padding: "7px 10px",
-                  background: isActive ? "rgba(232, 189, 107, 0.16)" : "rgba(255, 255, 255, 0.055)",
-                  color: isActive ? "#ffffff" : "rgba(255, 255, 255, 0.68)",
+                  background: activeSectionKey === ALL_SECTIONS_KEY ? "rgba(232, 189, 107, 0.16)" : "rgba(255, 255, 255, 0.055)",
+                  color: activeSectionKey === ALL_SECTIONS_KEY ? "#ffffff" : "rgba(255, 255, 255, 0.68)",
                   cursor: "pointer",
                   fontSize: "0.82rem",
                   fontWeight: 760,
                   lineHeight: 1.25,
                 }}
               >
-                {section.title} · {section.benefits.length}
+                全部 · {benefits.length}
               </button>
-            );
-          })}
-          <button
-            type="button"
-            role="tab"
-            aria-selected={activeSectionKey === ALL_SECTIONS_KEY}
-            onClick={() => setActiveSectionKey(ALL_SECTIONS_KEY)}
-            style={{
-              minHeight: 34,
-              border: `1px solid ${activeSectionKey === ALL_SECTIONS_KEY ? "rgba(232, 189, 107, 0.48)" : "rgba(255, 255, 255, 0.12)"}`,
-              borderRadius: 8,
-              padding: "7px 10px",
-              background: activeSectionKey === ALL_SECTIONS_KEY ? "rgba(232, 189, 107, 0.16)" : "rgba(255, 255, 255, 0.055)",
-              color: activeSectionKey === ALL_SECTIONS_KEY ? "#ffffff" : "rgba(255, 255, 255, 0.68)",
-              cursor: "pointer",
-              fontSize: "0.82rem",
-              fontWeight: 760,
-              lineHeight: 1.25,
-            }}
-          >
-            全部 · {benefits.length}
-          </button>
-        </div>
-      ) : sections[0] ? (
-        <div style={{ color: "rgba(255, 255, 255, 0.52)", fontSize: "0.82rem", lineHeight: 1.5 }}>
-          {sections[0].title}
-        </div>
-      ) : null}
+            </div>
+          ) : sections[0] ? (
+            <div style={{ color: "rgba(255, 255, 255, 0.52)", fontSize: "0.82rem", lineHeight: 1.5 }}>
+              {sections[0].title}
+            </div>
+          ) : null}
 
-      {Object.entries(groups).map(([category, items]) => (
-        <section key={category} style={{ display: "grid", gap: 10 }}>
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
-            <strong style={{ color: "#e8bd6b", fontSize: "0.92rem" }}>{category}</strong>
-            <span style={{ color: "rgba(255, 255, 255, 0.45)", fontSize: "0.78rem" }}>{items.length}句</span>
-          </div>
+          {Object.entries(groups).map(([category, items]) => (
+            <section key={category} style={{ display: "grid", gap: 10 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+                <strong style={{ color: "#e8bd6b", fontSize: "0.92rem" }}>{category}</strong>
+                <span style={{ color: "rgba(255, 255, 255, 0.45)", fontSize: "0.78rem" }}>{items.length}句</span>
+              </div>
 
-          {items.map((benefit) => (
-            <button
-              key={benefit.id}
-              type="button"
-              onClick={() => scrollToBenefit(benefit)}
-              style={{
-                width: "100%",
-                border: "1px solid rgba(232, 189, 107, 0.18)",
-                borderRadius: 10,
-                padding: "12px 13px",
-                background: "rgba(232, 189, 107, 0.07)",
-                color: "rgba(255, 255, 255, 0.86)",
-                cursor: "pointer",
-                textAlign: "left",
-              }}
-            >
-              <span style={{ display: "block", lineHeight: 1.68, fontSize: "0.92rem" }}>{benefit.text}</span>
-              {benefit.note ? (
-                <small style={{ display: "block", marginTop: 8, color: "rgba(255, 255, 255, 0.5)", lineHeight: 1.55 }}>
-                  {benefit.note}
-                </small>
-              ) : null}
-            </button>
+              {items.map((benefit) => (
+                <button
+                  key={benefit.id}
+                  type="button"
+                  onClick={() => scrollToBenefit(benefit)}
+                  style={{
+                    width: "100%",
+                    border: "1px solid rgba(232, 189, 107, 0.18)",
+                    borderRadius: 10,
+                    padding: "12px 13px",
+                    background: "rgba(232, 189, 107, 0.07)",
+                    color: "rgba(255, 255, 255, 0.86)",
+                    cursor: "pointer",
+                    textAlign: "left",
+                  }}
+                >
+                  <span style={{ display: "block", lineHeight: 1.68, fontSize: "0.92rem" }}>{benefit.text}</span>
+                  {benefit.note ? (
+                    <small style={{ display: "block", marginTop: 8, color: "rgba(255, 255, 255, 0.5)", lineHeight: 1.55 }}>
+                      {benefit.note}
+                    </small>
+                  ) : null}
+                </button>
+              ))}
+            </section>
           ))}
-        </section>
-      ))}
+        </>
+      ) : null}
     </div>
   );
 }

--- a/frontend/apps/web/src/data/faliu-anki-cards.ts
+++ b/frontend/apps/web/src/data/faliu-anki-cards.ts
@@ -1,9 +1,12 @@
 export interface FaliuAnkiCard {
   id: string;
+  type?: "understanding" | "image" | "recitation";
   front: string;
   back: string;
   hint?: string;
   sourceText?: string;
+  imagePrompt?: string;
+  imageAlt?: string;
   tags?: string[];
 }
 
@@ -22,10 +25,11 @@ export interface FaliuAnkiDeck {
  * contentId: "cbeta:T0251:1"
  *
  * Suggested card style:
- * - front: question, cloze prompt, or first half of a verse/sentence.
- * - back: exact memorization answer.
+ * - front: question, cloze prompt, or visual cue.
+ * - back: exact minimal answer.
  * - hint: optional short cue.
- * - sourceText: optional original sentence/paragraph for audit.
+ * - sourceText: exact original sentence/paragraph for audit and source jump.
+ * - imagePrompt/imageAlt: optional imagery prompt for image cards.
  * - tags: work id, title, topic, chapter, or practice label.
  */
 export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
@@ -37,6 +41,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
     cards: [
       {
         id: "cbeta:T0251:1:understand-001",
+        type: "understanding",
         front: "《心經》的實修主軸可怎樣概括？",
         back: "依般若照見五蘊皆空。",
         hint: "先建立全經大意，再記細節。",
@@ -45,6 +50,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-002",
+        type: "understanding",
         front: "經中「照見五蘊皆空」直接對治什麼？",
         back: "一切苦厄。",
         hint: "觀空的作用。",
@@ -53,6 +59,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-003",
+        type: "understanding",
         front: "《心經》中被觀為「皆空」的身心總類是什麼？",
         back: "五蘊。",
         hint: "色、受、想、行、識的總名。",
@@ -61,6 +68,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-004",
+        type: "understanding",
         front: "「色不異空，空不異色」避免把色與空看成什麼？",
         back: "彼此分離的兩物。",
         hint: "先記「不異」。",
@@ -69,6 +77,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-005",
+        type: "understanding",
         front: "「色即是空，空即是色」強調色與空的哪種關係？",
         back: "色空相即。",
         hint: "再記「即是」。",
@@ -77,6 +86,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-006",
+        type: "understanding",
         front: "除色蘊外，經文說哪四蘊也「亦復如是」？",
         back: "受、想、行、識。",
         hint: "這是短枚舉，保留為一張。",
@@ -85,6 +95,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-007",
+        type: "understanding",
         front: "「是諸法空相」先破哪一對相？",
         back: "生／滅。",
         hint: "三對相之一。",
@@ -93,6 +104,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-008",
+        type: "understanding",
         front: "「是諸法空相」第二對破哪一對相？",
         back: "垢／淨。",
         hint: "三對相之一。",
@@ -101,6 +113,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-009",
+        type: "understanding",
         front: "「是諸法空相」最後破哪一對相？",
         back: "增／減。",
         hint: "三對相之一。",
@@ -109,6 +122,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-010",
+        type: "understanding",
         front: "「空中無色，無受、想、行、識」否定的是哪一組分類？",
         back: "五蘊。",
         hint: "不要背整串，先認出分類。",
@@ -117,6 +131,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-011",
+        type: "understanding",
         front: "「無眼、耳、鼻、舌、身、意」否定的是哪一組？",
         back: "六根。",
         hint: "主觀能取的六根。",
@@ -125,6 +140,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-012",
+        type: "understanding",
         front: "「無色、聲、香、味、觸、法」否定的是哪一組？",
         back: "六塵／六境。",
         hint: "六根所對的六境。",
@@ -133,6 +149,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-013",
+        type: "understanding",
         front: "「無眼界，乃至無意識界」攝略哪一法門？",
         back: "十八界。",
         hint: "從眼界略至意識界。",
@@ -141,6 +158,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-014",
+        type: "understanding",
         front: "十二因緣的否定，經文從哪一支說起？",
         back: "無明。",
         hint: "只問起點，避免長枚舉。",
@@ -149,6 +167,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-015",
+        type: "understanding",
         front: "十二因緣的否定，經文攝略到哪一支？",
         back: "老死。",
         hint: "只問終點，避免長枚舉。",
@@ -157,6 +176,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-016",
+        type: "understanding",
         front: "「無苦、集、滅、道」否定的是哪一組佛法分類？",
         back: "四聖諦。",
         hint: "把四項歸成一個已知分類。",
@@ -165,6 +185,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-017",
+        type: "understanding",
         front: "「無智亦無得」的理由是什麼？",
         back: "以無所得故。",
         hint: "經文直接給出原因。",
@@ -173,6 +194,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-018",
+        type: "understanding",
         front: "菩提薩埵心無罣礙，是因為依何法？",
         back: "般若波羅蜜多。",
         hint: "依般若，所以無礙。",
@@ -181,6 +203,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-019",
+        type: "understanding",
         front: "心無罣礙後，經文首先說消除了哪種心理狀態？",
         back: "恐怖。",
         hint: "無礙故無怖。",
@@ -189,6 +212,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-020",
+        type: "understanding",
         front: "菩薩遠離顛倒夢想後，趣向什麼果？",
         back: "究竟涅槃。",
         hint: "離倒夢想，至涅槃。",
@@ -197,6 +221,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-021",
+        type: "understanding",
         front: "三世諸佛依般若波羅蜜多，證得什麼？",
         back: "阿耨多羅三藐三菩提。",
         hint: "諸佛所證的無上正等正覺。",
@@ -205,6 +230,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-022",
+        type: "understanding",
         front: "經文稱般若波羅蜜多為「大神呪、大明呪……」，主要是在讚歎哪一面向？",
         back: "般若的不可思議力用。",
         hint: "不是單純記名號，而是抓功能定位。",
@@ -213,6 +239,7 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-023",
+        type: "understanding",
         front: "般若波羅蜜多呪的作用是什麼？",
         back: "能除一切苦。",
         hint: "問功能，不背整段。",
@@ -221,11 +248,100 @@ export const FALIU_ANKI_CARD_DECKS: FaliuAnkiDeck[] = [
       },
       {
         id: "cbeta:T0251:1:understand-024",
+        type: "understanding",
         front: "經文如何判定般若波羅蜜多呪的可靠性？",
         back: "真實不虛。",
         hint: "問判定語。",
         sourceText: "真實不虛。",
         tags: ["T0251", "心經", "般若呪", "判定"],
+      },
+      {
+        id: "cbeta:T0251:1:image-001",
+        type: "image",
+        front: "圖像卡：五個透明包袱在月光中變空，對應《心經》的哪個核心觀照？",
+        back: "照見五蘊皆空。",
+        hint: "圖像只提示一個核心觀照，不要求背整句。",
+        sourceText: "照見五蘊皆空，度一切苦厄。",
+        imagePrompt: "五個半透明包袱標成色、受、想、行、識，在清澈月光中逐漸透明，遠處苦厄雲散開。",
+        imageAlt: "五蘊透明化，苦雲散開",
+        tags: ["T0251", "心經", "圖像卡", "五蘊", "理解"],
+      },
+      {
+        id: "cbeta:T0251:1:image-002",
+        type: "image",
+        front: "圖像卡：波浪與海水不可分，幫助記住色與空的什麼關係？",
+        back: "色空相即。",
+        hint: "用波與水降低「色/空」干擾。",
+        sourceText: "色不異空，空不異色；色即是空，空即是色。",
+        imagePrompt: "一個波浪由海水升起，波形清楚但與海水無法分開，旁邊不要加入多餘符號。",
+        imageAlt: "波浪與海水不可分",
+        tags: ["T0251", "心經", "圖像卡", "色空", "理解"],
+      },
+      {
+        id: "cbeta:T0251:1:image-003",
+        type: "image",
+        front: "圖像卡：生滅、垢淨、增減三組標籤都淡出，對應「空相」破哪三對相？",
+        back: "生／滅、垢／淨、增／減。",
+        hint: "三對相一起成組，但每對清楚分隔。",
+        sourceText: "是諸法空相，不生不滅，不垢不淨，不增不減。",
+        imagePrompt: "三扇門分別寫生滅、垢淨、增減，字跡在空明背景中淡出。",
+        imageAlt: "三對二元相淡出",
+        tags: ["T0251", "心經", "圖像卡", "空相", "對照"],
+      },
+      {
+        id: "cbeta:T0251:1:image-004",
+        type: "image",
+        front: "圖像卡：六扇感官門標著眼耳鼻舌身意，這張圖對應哪一組分類？",
+        back: "六根。",
+        hint: "只問分類，不要求列整串。",
+        sourceText: "無眼、耳、鼻、舌、身、意。",
+        imagePrompt: "六扇小門依序標示眼、耳、鼻、舌、身、意，門都敞開但內部空明。",
+        imageAlt: "六扇感官門",
+        tags: ["T0251", "心經", "圖像卡", "六根", "分類"],
+      },
+      {
+        id: "cbeta:T0251:1:image-005",
+        type: "image",
+        front: "圖像卡：六個外境泡泡標著色聲香味觸法，這張圖對應哪一組分類？",
+        back: "六塵／六境。",
+        hint: "與六根圖分開，避免混淆。",
+        sourceText: "無色、聲、香、味、觸、法。",
+        imagePrompt: "六個泡泡在六扇門外，分別標色、聲、香、味、觸、法，泡泡清亮而短暫。",
+        imageAlt: "六個外境泡泡",
+        tags: ["T0251", "心經", "圖像卡", "六塵", "分類"],
+      },
+      {
+        id: "cbeta:T0251:1:image-006",
+        type: "image",
+        front: "圖像卡：一雙空手沒有抓到任何東西，對應《心經》的哪個要點？",
+        back: "無所得。",
+        hint: "以簡單畫面提示核心詞。",
+        sourceText: "無智亦無得，以無所得故。",
+        imagePrompt: "一雙放鬆張開的空手，掌心明亮，沒有任何物件可抓取。",
+        imageAlt: "張開的空手",
+        tags: ["T0251", "心經", "圖像卡", "無所得", "理解"],
+      },
+      {
+        id: "cbeta:T0251:1:image-007",
+        type: "image",
+        front: "圖像卡：心上沒有繩結和網，恐怖影子退去，對應菩薩行的哪個結果？",
+        back: "心無罣礙，無有恐怖。",
+        hint: "圖像把無礙與無怖連成因果。",
+        sourceText: "菩提薩埵，依般若波羅蜜多故，心無罣礙；無罣礙故，無有恐怖。",
+        imagePrompt: "一顆心前方的繩結鬆開，黑色恐怖影子向後退去，整體安穩明亮。",
+        imageAlt: "心無繩結，恐怖退散",
+        tags: ["T0251", "心經", "圖像卡", "菩薩行", "因果"],
+      },
+      {
+        id: "cbeta:T0251:1:image-008",
+        type: "image",
+        front: "圖像卡：咒語像渡橋，把苦雲帶到彼岸消散，對應般若呪的哪個作用？",
+        back: "能除一切苦。",
+        hint: "問作用，不背整段咒名。",
+        sourceText: "能除一切苦，真實不虛。",
+        imagePrompt: "金色咒語化成一座簡潔渡橋，灰色苦雲過橋後消散，畫面不加入人物崇拜元素。",
+        imageAlt: "咒語渡橋除苦",
+        tags: ["T0251", "心經", "圖像卡", "般若呪", "作用"],
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Put the study panel behind two top tabs: `功德利益` and `卡片`, so cards sit next to the merit-benefit panel and can be opened by clicking the tab.
- Add card filtering inside the card panel for all / understanding / image cards.
- Add 8 Heart Sutra image cards using SuperMemo-style imagery: each card has one visual cue, one minimal answer, exact `sourceText`, and an `imagePrompt` / `imageAlt` anchor.
- Bring source-jump behavior into the card panel: cards with `sourceText` can use `定位原文` to scroll back to the matching scripture passage.

## Notes
The image cards are mental-image / visual-prompt cards, not blind next-line recitation cards. They follow the 20-rules emphasis on imagery, minimum information, avoiding sets/enumerations, and source-backed auditability.