### PR TITLE
Add Dacheng desktop control bridge

### DIFF
--- a/fabushi/assets/desktop_control/chrome_extension/README.md
+++ b/fabushi/assets/desktop_control/chrome_extension/README.md
@@ -1,0 +1,9 @@
+# Dacheng Chrome Connector
+
+Load this folder as an unpacked extension from `chrome://extensions`, then open
+the extension options and paste the `bridgeUrl` and `token` from
+`dacheng-bridge-config.json`.
+
+The connector exposes tab metadata, visible-page screenshots, sanitized DOM
+summaries, and confirmed click/type/navigation actions. It does not read
+cookies, passwords, or page localStorage.

--- a/fabushi/assets/desktop_control/chrome_extension/background.js
+++ b/fabushi/assets/desktop_control/chrome_extension/background.js
@@ -1,0 +1,297 @@
+const DEFAULT_BRIDGE_URL = "http://127.0.0.1:18790";
+const CONNECTOR_ID_KEY = "connectorId";
+
+async function getSettings() {
+  const settings = await chrome.storage.local.get([
+    "bridgeUrl",
+    "token",
+    CONNECTOR_ID_KEY,
+  ]);
+  let connectorId = settings[CONNECTOR_ID_KEY];
+  if (!connectorId) {
+    connectorId = `chrome_${crypto.randomUUID()}`;
+    await chrome.storage.local.set({ [CONNECTOR_ID_KEY]: connectorId });
+  }
+  return {
+    bridgeUrl: (settings.bridgeUrl || DEFAULT_BRIDGE_URL).replace(/\/$/, ""),
+    token: settings.token || "",
+    connectorId,
+  };
+}
+
+async function bridgeFetch(path, options = {}) {
+  const settings = await getSettings();
+  if (!settings.token) {
+    throw new Error("Missing Dacheng bridge token. Open extension options.");
+  }
+  return fetch(`${settings.bridgeUrl}${path}`, {
+    ...options,
+    headers: {
+      "Authorization": `Bearer ${settings.token}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+}
+
+async function heartbeat() {
+  const settings = await getSettings();
+  if (!settings.token) return;
+  await bridgeFetch("/chrome/heartbeat", {
+    method: "POST",
+    body: JSON.stringify({
+      connectorId: settings.connectorId,
+      version: chrome.runtime.getManifest().version,
+    }),
+  });
+}
+
+async function pollCommands() {
+  const settings = await getSettings();
+  if (!settings.token) return;
+  const response = await bridgeFetch(
+    `/chrome/commands?connectorId=${encodeURIComponent(settings.connectorId)}`,
+  );
+  if (!response.ok) return;
+  const payload = await response.json();
+  for (const command of payload.commands || []) {
+    await runCommand(command);
+  }
+}
+
+async function runCommand(command) {
+  try {
+    const data = await handleCommand(command.tool, command.arguments || {});
+    await postResult(command.id, { ok: true, data });
+  } catch (error) {
+    await postResult(command.id, {
+      ok: false,
+      errorCode: "chrome_command_failed",
+      message: error && error.message ? error.message : String(error),
+    });
+  }
+}
+
+async function postResult(id, result) {
+  await bridgeFetch("/chrome/results", {
+    method: "POST",
+    body: JSON.stringify({ id, ...result }),
+  });
+}
+
+async function handleCommand(tool, args) {
+  switch (tool) {
+    case "chrome.tabs":
+      return { tabs: (await chrome.tabs.query({})).map(sanitizeTab) };
+    case "chrome.navigate": {
+      const tab = await resolveTab(args);
+      const url = String(args.url || "");
+      if (!/^https?:\/\//i.test(url)) {
+        throw new Error("Only http and https navigation is allowed.");
+      }
+      return { tab: sanitizeTab(await chrome.tabs.update(tab.id, { url })) };
+    }
+    case "chrome.screenshot": {
+      const tab = await resolveTab(args);
+      const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, {
+        format: args.format === "jpeg" ? "jpeg" : "png",
+      });
+      return { tab: sanitizeTab(tab), dataUrl };
+    }
+    case "chrome.dom_snapshot": {
+      const tab = await resolveTab(args);
+      const [result] = await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: collectDomSnapshot,
+        args: [args],
+      });
+      return { tab: sanitizeTab(tab), snapshot: result.result };
+    }
+    case "chrome.click": {
+      const tab = await resolveTab(args);
+      const [result] = await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: clickElement,
+        args: [args],
+      });
+      return { tab: sanitizeTab(tab), result: result.result };
+    }
+    case "chrome.type": {
+      const tab = await resolveTab(args);
+      const [result] = await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: typeIntoElement,
+        args: [args],
+      });
+      return { tab: sanitizeTab(tab), result: result.result };
+    }
+    default:
+      throw new Error(`Unknown command: ${tool}`);
+  }
+}
+
+async function resolveTab(args) {
+  if (Number.isInteger(args.tabId)) {
+    return chrome.tabs.get(args.tabId);
+  }
+  const [active] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  if (!active || !active.id) throw new Error("No active Chrome tab.");
+  return active;
+}
+
+function sanitizeTab(tab) {
+  return {
+    id: tab.id,
+    windowId: tab.windowId,
+    active: tab.active,
+    title: tab.title || "",
+    url: tab.url || "",
+    status: tab.status || "",
+    audible: Boolean(tab.audible),
+    pinned: Boolean(tab.pinned),
+  };
+}
+
+function collectDomSnapshot(args) {
+  const limit = Math.max(1, Math.min(Number(args.limit || 120), 500));
+  const nodes = [];
+  const walker = document.createTreeWalker(
+    document.body || document.documentElement,
+    NodeFilter.SHOW_ELEMENT,
+  );
+  while (walker.nextNode() && nodes.length < limit) {
+    const element = walker.currentNode;
+    const rect = element.getBoundingClientRect();
+    const style = window.getComputedStyle(element);
+    if (
+      rect.width <= 0 ||
+      rect.height <= 0 ||
+      style.visibility === "hidden" ||
+      style.display === "none"
+    ) {
+      continue;
+    }
+    const tag = element.tagName.toLowerCase();
+    const type = (element.getAttribute("type") || "").toLowerCase();
+    const text = type === "password" ? "" : visibleText(element);
+    nodes.push({
+      tag,
+      role: element.getAttribute("role") || "",
+      ariaLabel: element.getAttribute("aria-label") || "",
+      placeholder: element.getAttribute("placeholder") || "",
+      type,
+      text,
+      href: tag === "a" ? element.getAttribute("href") || "" : "",
+      selector: cssPath(element),
+      rect: {
+        x: Math.round(rect.x),
+        y: Math.round(rect.y),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      },
+    });
+  }
+  return {
+    title: document.title,
+    url: location.href,
+    nodes,
+  };
+}
+
+function clickElement(args) {
+  const element = findTarget(args);
+  element.scrollIntoView({ block: "center", inline: "center" });
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  return { clicked: true, selector: cssPath(element) };
+}
+
+function typeIntoElement(args) {
+  const element = findTarget(args);
+  const type = (element.getAttribute("type") || "").toLowerCase();
+  if (type === "password") {
+    throw new Error("Typing into password fields is not exposed.");
+  }
+  const text = String(args.text || "");
+  element.focus();
+  if ("value" in element) {
+    element.value = text;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+    return { typed: true, selector: cssPath(element), length: text.length };
+  }
+  document.execCommand("insertText", false, text);
+  return { typed: true, selector: cssPath(element), length: text.length };
+}
+
+function findTarget(args) {
+  if (args.selector) {
+    const element = document.querySelector(String(args.selector));
+    if (!element) throw new Error(`Selector not found: ${args.selector}`);
+    return element;
+  }
+  if (Number.isFinite(args.x) && Number.isFinite(args.y)) {
+    const element = document.elementFromPoint(Number(args.x), Number(args.y));
+    if (!element) throw new Error("No element at requested point.");
+    return element;
+  }
+  throw new Error("A selector or x/y point is required.");
+}
+
+function visibleText(element) {
+  const raw = element.innerText || element.textContent || "";
+  return raw.replace(/\s+/g, " ").trim().slice(0, 240);
+}
+
+function cssPath(element) {
+  const parts = [];
+  let current = element;
+  while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < 5) {
+    let selector = current.tagName.toLowerCase();
+    if (current.id) {
+      selector += `#${CSS.escape(current.id)}`;
+      parts.unshift(selector);
+      break;
+    }
+    const cls = [...current.classList].slice(0, 2).map((name) => `.${CSS.escape(name)}`).join("");
+    selector += cls;
+    const parent = current.parentElement;
+    if (parent) {
+      const siblings = [...parent.children].filter((node) => node.tagName === current.tagName);
+      if (siblings.length > 1) {
+        selector += `:nth-of-type(${siblings.indexOf(current) + 1})`;
+      }
+    }
+    parts.unshift(selector);
+    current = parent;
+  }
+  return parts.join(" > ");
+}
+
+async function tick() {
+  try {
+    await heartbeat();
+    await pollCommands();
+  } catch (_) {
+    // The desktop app may be closed; keep the connector quiet and retry later.
+  }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.alarms.create("dacheng_tick", { periodInMinutes: 0.1 });
+  tick();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  chrome.alarms.create("dacheng_tick", { periodInMinutes: 0.1 });
+  tick();
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "dacheng_tick") tick();
+});
+
+setInterval(tick, 3000);
+tick();

--- a/fabushi/assets/desktop_control/chrome_extension/content.js
+++ b/fabushi/assets/desktop_control/chrome_extension/content.js
@@ -1,0 +1,2 @@
+// Reserved for future page-level helpers. The current connector injects
+// short-lived functions through chrome.scripting so page data is never stored.

--- a/fabushi/assets/desktop_control/chrome_extension/manifest.json
+++ b/fabushi/assets/desktop_control/chrome_extension/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 3,
+  "name": "Dacheng Desktop Chrome Connector",
+  "description": "Connects Chrome tabs to the Dacheng desktop loopback bridge.",
+  "version": "0.1.0",
+  "permissions": ["activeTab", "alarms", "scripting", "storage", "tabs"],
+  "host_permissions": ["<all_urls>", "http://127.0.0.1/*", "http://localhost/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "options_page": "options.html",
+  "action": {
+    "default_title": "Dacheng Chrome Connector"
+  }
+}

--- a/fabushi/assets/desktop_control/chrome_extension/options.html
+++ b/fabushi/assets/desktop_control/chrome_extension/options.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Dacheng Chrome Connector</title>
+    <style>
+      body {
+        color: #202124;
+        font: 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 24px;
+        max-width: 680px;
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin: 16px 0 6px;
+      }
+      input {
+        box-sizing: border-box;
+        font: inherit;
+        padding: 8px;
+        width: 100%;
+      }
+      button {
+        font: inherit;
+        margin-top: 16px;
+        padding: 8px 12px;
+      }
+      #status {
+        margin-top: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Dacheng Chrome Connector</h1>
+    <label for="bridgeUrl">Bridge URL</label>
+    <input id="bridgeUrl" placeholder="http://127.0.0.1:18790">
+    <label for="token">Bridge token</label>
+    <input id="token" type="password" autocomplete="off">
+    <button id="save">Save</button>
+    <p id="status"></p>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/fabushi/assets/desktop_control/chrome_extension/options.js
+++ b/fabushi/assets/desktop_control/chrome_extension/options.js
@@ -1,0 +1,20 @@
+const bridgeUrlInput = document.getElementById("bridgeUrl");
+const tokenInput = document.getElementById("token");
+const statusNode = document.getElementById("status");
+
+async function load() {
+  const settings = await chrome.storage.local.get(["bridgeUrl", "token"]);
+  bridgeUrlInput.value = settings.bridgeUrl || "http://127.0.0.1:18790";
+  tokenInput.value = settings.token || "";
+}
+
+async function save() {
+  await chrome.storage.local.set({
+    bridgeUrl: bridgeUrlInput.value.trim().replace(/\/$/, ""),
+    token: tokenInput.value.trim(),
+  });
+  statusNode.textContent = "Saved.";
+}
+
+document.getElementById("save").addEventListener("click", save);
+load();

--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -50,6 +50,10 @@ class AppConfig {
     'DACHENG_AI_WEB_URL',
     defaultValue: '',
   );
+  static const bool desktopControlEnabled = bool.fromEnvironment(
+    'DACHENG_DESKTOP_CONTROL',
+    defaultValue: false,
+  );
   static const String defaultDachengAiWebUrl =
       'https://fabushi.ombhrum.com/app/ai';
 

--- a/fabushi/lib/screens/settings_screen.dart
+++ b/fabushi/lib/screens/settings_screen.dart
@@ -13,6 +13,8 @@ import '../services/app_settings.dart';
 import '../services/llm_model_config.dart';
 import '../services/llm_model_manager.dart';
 import '../services/device_capability_service.dart';
+import '../services/desktop_control/desktop_control_bridge.dart';
+import '../services/desktop_control/desktop_control_models.dart';
 import '../services/openclaw/openclaw_runtime.dart';
 import '../services/worker_config.dart';
 import '../widgets/model_selection_dialog.dart';
@@ -49,18 +51,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
   // 桌面 AI / OpenClaw 设置
   String _aiBackendModeName = 'auto';
   OpenClawRuntimeStatus? _openClawStatus;
+  DesktopControlBridgeStatus? _desktopControlStatus;
+  List<DesktopControlPendingConfirmation> _desktopControlPending = const [];
   bool _isRestartingOpenClaw = false;
+  bool _isPreparingChromeConnector = false;
+  StreamSubscription<void>? _desktopControlSubscription;
 
   @override
   void initState() {
     super.initState();
     _loadSettings();
     _subscribeToDownloadProgress();
+    _subscribeToDesktopControlConfirmations();
   }
 
   @override
   void dispose() {
     _downloadProgressSubscription?.cancel();
+    _desktopControlSubscription?.cancel();
     super.dispose();
   }
 
@@ -88,6 +96,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
             if (event.isComplete) {
               _refreshModelStatus();
             }
+          }
+        });
+  }
+
+  void _subscribeToDesktopControlConfirmations() {
+    _desktopControlSubscription = DesktopControlBridge
+        .instance
+        .confirmationsChanged
+        .listen((_) {
+          if (mounted) {
+            _refreshDesktopControlStatus();
           }
         });
   }
@@ -125,8 +144,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     final aiBackendModeName = await AppSettings.getAiBackendModeName();
     OpenClawRuntimeStatus? openClawStatus;
+    DesktopControlBridgeStatus? desktopControlStatus;
+    List<DesktopControlPendingConfirmation> desktopControlPending = const [];
     if (AiBackendPolicy.isDesktopNative) {
       openClawStatus = await OpenClawRuntime.instance.getStatus(probe: false);
+      desktopControlStatus = await DesktopControlBridge.instance.getStatus();
+      desktopControlPending = await DesktopControlBridge.instance
+          .pendingConfirmations();
     }
 
     if (mounted) {
@@ -140,6 +164,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _selectedModel = selectedModel;
         _aiBackendModeName = aiBackendModeName;
         _openClawStatus = openClawStatus;
+        _desktopControlStatus = desktopControlStatus;
+        _desktopControlPending = desktopControlPending;
         _isLoading = false;
       });
     }
@@ -172,6 +198,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (mounted) {
       setState(() => _openClawStatus = status);
     }
+    await _refreshDesktopControlStatus();
+  }
+
+  Future<void> _refreshDesktopControlStatus({bool startBridge = false}) async {
+    if (!AiBackendPolicy.isDesktopNative) return;
+    final status = startBridge
+        ? await DesktopControlBridge.instance.ensureStarted()
+        : await DesktopControlBridge.instance.getStatus();
+    final pending = await DesktopControlBridge.instance.pendingConfirmations();
+    if (mounted) {
+      setState(() {
+        _desktopControlStatus = status;
+        _desktopControlPending = pending;
+      });
+    }
   }
 
   Future<void> _restartOpenClawRuntime() async {
@@ -183,10 +224,51 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _openClawStatus = status;
       _isRestartingOpenClaw = false;
     });
+    unawaited(_refreshDesktopControlStatus());
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(status.isHealthy ? '本机 OpenClaw 已启动' : status.message),
         backgroundColor: status.isHealthy ? Colors.green : Colors.redAccent,
+      ),
+    );
+  }
+
+  Future<void> _prepareChromeConnectorInstall() async {
+    if (!AiBackendPolicy.isDesktopNative || _isPreparingChromeConnector) return;
+    setState(() => _isPreparingChromeConnector = true);
+    final path = await DesktopControlBridge.instance
+        .prepareChromeConnectorInstall();
+    await _refreshDesktopControlStatus();
+    if (!mounted) return;
+    setState(() => _isPreparingChromeConnector = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(path == null ? '当前构建未启用 Chrome 连接器' : 'Chrome 连接器目录已打开'),
+        backgroundColor: path == null ? Colors.orange : Colors.green,
+      ),
+    );
+  }
+
+  Future<void> _approveDesktopControlRequest(String id) async {
+    final item = await DesktopControlBridge.instance.approvePendingRequest(id);
+    await _refreshDesktopControlStatus();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(item == null ? '确认请求已失效' : '已允许该动作，工具可继续执行'),
+        backgroundColor: item == null ? Colors.orange : Colors.green,
+      ),
+    );
+  }
+
+  Future<void> _rejectDesktopControlRequest(String id) async {
+    final item = await DesktopControlBridge.instance.rejectPendingRequest(id);
+    await _refreshDesktopControlStatus();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(item == null ? '确认请求已失效' : '已拒绝该动作'),
+        backgroundColor: Colors.orange,
       ),
     );
   }
@@ -566,6 +648,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Widget _buildOpenClawSettingCard() {
     final mode = aiBackendModeFromStorageName(_aiBackendModeName);
     final status = _openClawStatus;
+    final desktopStatus = _desktopControlStatus;
+    final chromeStatus = desktopStatus?.chrome;
     final statusColor = switch (status?.state) {
       OpenClawRuntimeState.running => Colors.greenAccent,
       OpenClawRuntimeState.starting => Colors.amberAccent,
@@ -673,6 +757,49 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ),
             const SizedBox(height: 12),
+            _buildDesktopControlStatusRow(
+              icon: Icons.mouse_outlined,
+              title: '桌面控制',
+              message: desktopStatus == null
+                  ? '尚未检测桌面控制桥'
+                  : desktopStatus.message,
+              color: desktopStatus == null
+                  ? Colors.white38
+                  : !desktopStatus.enabledByBuild
+                  ? Colors.orangeAccent
+                  : desktopStatus.supportedPlatform &&
+                        desktopStatus.bridgeRunning
+                  ? Colors.greenAccent
+                  : Colors.amberAccent,
+            ),
+            const SizedBox(height: 8),
+            _buildDesktopControlStatusRow(
+              icon: Icons.security_outlined,
+              title: '权限',
+              message: desktopStatus == null
+                  ? '尚未检测权限'
+                  : '屏幕录制 ${desktopStatus.screenRecordingGranted ? '已授权' : '未授权'} · 辅助功能 ${desktopStatus.accessibilityGranted ? '已授权' : '未授权'}',
+              color:
+                  desktopStatus != null &&
+                      desktopStatus.screenRecordingGranted &&
+                      desktopStatus.accessibilityGranted
+                  ? Colors.greenAccent
+                  : Colors.orangeAccent,
+            ),
+            const SizedBox(height: 8),
+            _buildDesktopControlStatusRow(
+              icon: Icons.public,
+              title: 'Chrome 连接器',
+              message: chromeStatus?.message ?? '尚未检测 Chrome 连接器',
+              color: chromeStatus?.connected == true
+                  ? Colors.greenAccent
+                  : Colors.orangeAccent,
+            ),
+            if (_desktopControlPending.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _buildPendingDesktopConfirmations(),
+            ],
+            const SizedBox(height: 12),
             Row(
               children: [
                 Expanded(
@@ -705,8 +832,130 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
               ],
             ),
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
+                        _isRestartingOpenClaw || _isPreparingChromeConnector
+                        ? null
+                        : () => _refreshDesktopControlStatus(startBridge: true),
+                    icon: const Icon(Icons.rule_folder_outlined, size: 18),
+                    label: const Text('工具诊断'),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
+                        _isRestartingOpenClaw || _isPreparingChromeConnector
+                        ? null
+                        : _prepareChromeConnectorInstall,
+                    icon: _isPreparingChromeConnector
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.extension_outlined, size: 18),
+                    label: Text(_isPreparingChromeConnector ? '准备中' : '连接器'),
+                  ),
+                ),
+              ],
+            ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildDesktopControlStatusRow({
+    required IconData icon,
+    required String title,
+    required String message,
+    required Color color,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.04),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: Colors.white12),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: color),
+          const SizedBox(width: 8),
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPendingDesktopConfirmations() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.amberAccent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: Colors.amberAccent.withValues(alpha: 0.24)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '待确认动作',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ..._desktopControlPending.map(
+            (item) => Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      item.summary,
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => _rejectDesktopControlRequest(item.id),
+                    child: const Text('拒绝'),
+                  ),
+                  FilledButton(
+                    onPressed: () => _approveDesktopControlRequest(item.id),
+                    child: const Text('允许'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/fabushi/lib/services/app_settings.dart
+++ b/fabushi/lib/services/app_settings.dart
@@ -158,6 +158,10 @@ class AppSettings {
   static const String _openClawGatewayTokenKey = 'openclaw_gateway_token_v1';
   static const String _openClawModelKey = 'openclaw_model_v1';
   static const String _openClawModelOverrideKey = 'openclaw_model_override_v1';
+  static const String _desktopControlBridgePortKey =
+      'desktop_control_bridge_port_v1';
+  static const String _desktopControlBridgeTokenKey =
+      'desktop_control_bridge_token_v1';
 
   /// AI 后端模式：auto / embedded_openclaw / cloud_api。
   ///
@@ -224,5 +228,36 @@ class AppSettings {
   static Future<void> setOpenClawModelOverride(String modelOverride) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_openClawModelOverrideKey, modelOverride.trim());
+  }
+
+  static Future<int> getDesktopControlBridgePort({
+    int defaultValue = 18790,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getInt(_desktopControlBridgePortKey);
+    if (saved == null || saved < 1024 || saved > 65535) {
+      return defaultValue;
+    }
+    return saved;
+  }
+
+  static Future<void> setDesktopControlBridgePort(int port) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_desktopControlBridgePortKey, port.clamp(1024, 65535));
+  }
+
+  /// 生成并持久化桌面工具 loopback bearer token。
+  /// token 只在本机大乘 App、内置 OpenClaw 和 Chrome 扩展之间使用。
+  static Future<String> getDesktopControlBridgeToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    final existing = prefs.getString(_desktopControlBridgeTokenKey);
+    if (existing != null && existing.length >= 32) {
+      return existing;
+    }
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    final token = base64UrlEncode(bytes).replaceAll('=', '');
+    await prefs.setString(_desktopControlBridgeTokenKey, token);
+    return token;
   }
 }

--- a/fabushi/lib/services/desktop_control/desktop_control_bridge.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_bridge.dart
@@ -1,0 +1,2 @@
+export 'desktop_control_bridge_stub.dart'
+    if (dart.library.io) 'desktop_control_bridge_io.dart';

--- a/fabushi/lib/services/desktop_control/desktop_control_bridge_io.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_bridge_io.dart
@@ -1,0 +1,619 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../../core/config/app_config.dart';
+import '../app_settings.dart';
+import 'desktop_control_confirmation_store.dart';
+import 'desktop_control_host_api.dart';
+import 'desktop_control_models.dart';
+import 'desktop_control_policy.dart';
+
+class MethodChannelDesktopControlHostApi implements DesktopControlHostApi {
+  MethodChannelDesktopControlHostApi([
+    this._channel = const MethodChannel('com.ombhrum.fabushi/desktop_control'),
+  ]);
+
+  final MethodChannel _channel;
+
+  @override
+  Future<Map<String, dynamic>> status() => _invoke('status');
+
+  @override
+  Future<Map<String, dynamic>> observe() => _invoke('observe');
+
+  @override
+  Future<Map<String, dynamic>> screenshot(Map<String, dynamic> arguments) {
+    return _invoke('screenshot', arguments);
+  }
+
+  @override
+  Future<Map<String, dynamic>> windows() => _invoke('windows');
+
+  @override
+  Future<Map<String, dynamic>> click(Map<String, dynamic> arguments) {
+    return _invoke('click', arguments);
+  }
+
+  @override
+  Future<Map<String, dynamic>> type(Map<String, dynamic> arguments) {
+    return _invoke('type', arguments);
+  }
+
+  @override
+  Future<Map<String, dynamic>> hotkey(Map<String, dynamic> arguments) {
+    return _invoke('hotkey', arguments);
+  }
+
+  @override
+  Future<Map<String, dynamic>> scroll(Map<String, dynamic> arguments) {
+    return _invoke('scroll', arguments);
+  }
+
+  Future<Map<String, dynamic>> _invoke(
+    String method, [
+    Map<String, dynamic>? arguments,
+  ]) async {
+    final value = await _channel.invokeMapMethod<String, dynamic>(
+      method,
+      arguments ?? const {},
+    );
+    return Map<String, dynamic>.from(value ?? const {});
+  }
+}
+
+class DesktopControlBridge {
+  DesktopControlBridge._({
+    DesktopControlHostApi? hostApi,
+    DesktopControlConfirmationStore? confirmations,
+    bool Function()? enabledByBuild,
+    String Function()? platformProvider,
+    Random? random,
+  }) : _hostApi = hostApi ?? MethodChannelDesktopControlHostApi(),
+       _confirmations = confirmations ?? DesktopControlConfirmationStore(),
+       _enabledByBuild =
+           enabledByBuild ?? (() => AppConfig.desktopControlEnabled),
+       _platformProvider = platformProvider ?? _detectPlatform,
+       _random = random ?? Random.secure();
+
+  @visibleForTesting
+  DesktopControlBridge.test({
+    DesktopControlHostApi? hostApi,
+    DesktopControlConfirmationStore? confirmations,
+    bool Function()? enabledByBuild,
+    String Function()? platformProvider,
+    Random? random,
+  }) : this._(
+         hostApi: hostApi,
+         confirmations: confirmations,
+         enabledByBuild: enabledByBuild,
+         platformProvider: platformProvider,
+         random: random,
+       );
+
+  static final DesktopControlBridge instance = DesktopControlBridge._();
+
+  static const Duration _chromeCommandTimeout = Duration(seconds: 12);
+  static const Duration _chromeHeartbeatTtl = Duration(seconds: 20);
+  static const String _extensionAssetPrefix =
+      'assets/desktop_control/chrome_extension/';
+
+  final DesktopControlHostApi _hostApi;
+  final DesktopControlConfirmationStore _confirmations;
+  final bool Function() _enabledByBuild;
+  final String Function() _platformProvider;
+  final Random _random;
+  final StreamController<void> _confirmationsController =
+      StreamController<void>.broadcast();
+  final Queue<_ChromeCommand> _chromeCommands = Queue<_ChromeCommand>();
+  final Map<String, Completer<Map<String, dynamic>>> _chromeWaiters = {};
+
+  HttpServer? _server;
+  Uri? _bridgeUri;
+  String? _token;
+  DateTime? _chromeLastSeenAt;
+  String? _chromeConnectorId;
+  String? _chromeExtensionVersion;
+
+  Stream<void> get confirmationsChanged => _confirmationsController.stream;
+
+  Future<String?> get bridgeToken async {
+    if (!_enabledByBuild()) return null;
+    _token ??= await AppSettings.getDesktopControlBridgeToken();
+    return _token;
+  }
+
+  Future<DesktopControlBridgeStatus> ensureStarted() async {
+    if (!_enabledByBuild()) {
+      return _statusWithoutServer(message: '当前构建已禁用桌面控制和 Chrome 连接器');
+    }
+
+    final platform = _platformProvider();
+    final port = await AppSettings.getDesktopControlBridgePort();
+    _token ??= await AppSettings.getDesktopControlBridgeToken();
+
+    if (_server == null) {
+      try {
+        _server = await HttpServer.bind(
+          InternetAddress.loopbackIPv4,
+          port,
+          shared: true,
+        );
+        _bridgeUri = Uri.parse('http://127.0.0.1:${_server!.port}');
+        unawaited(_serve(_server!));
+      } catch (error) {
+        return _status(
+          platform: platform,
+          bridgeRunning: false,
+          message: '桌面控制桥启动失败: $error',
+        );
+      }
+    }
+
+    return _status(
+      platform: platform,
+      bridgeRunning: true,
+      message: _platformSupportsSystemControl(platform)
+          ? '桌面控制桥已在本机 loopback 运行'
+          : '当前 $platform 暂不支持系统级电脑控制',
+    );
+  }
+
+  Future<DesktopControlBridgeStatus> getStatus() async {
+    if (!_enabledByBuild()) {
+      return _statusWithoutServer(message: '当前构建已禁用桌面控制和 Chrome 连接器');
+    }
+    final platform = _platformProvider();
+    return _status(
+      platform: platform,
+      bridgeRunning: _server != null,
+      message: _server == null
+          ? '桌面控制桥尚未启动'
+          : _platformSupportsSystemControl(platform)
+          ? '桌面控制桥已在本机 loopback 运行'
+          : '当前 $platform 暂不支持系统级电脑控制',
+    );
+  }
+
+  Future<DesktopControlToolResult> executeTool(
+    String toolName,
+    Map<String, dynamic> arguments, {
+    String? confirmationId,
+  }) async {
+    if (!_enabledByBuild()) {
+      return DesktopControlToolResult.failure(
+        errorCode: 'disabled_by_build',
+        message: '当前构建已禁用桌面控制和 Chrome 连接器',
+      );
+    }
+    if (!DesktopControlPolicy.isSupported(toolName)) {
+      return DesktopControlToolResult.failure(
+        errorCode: 'unknown_tool',
+        message: '未知工具: $toolName',
+      );
+    }
+
+    final platform = _platformProvider();
+    if (toolName.startsWith('desktop.') &&
+        !_platformSupportsSystemControl(platform)) {
+      return DesktopControlPolicy.unsupportedPlatform(platform);
+    }
+
+    if (DesktopControlPolicy.requiresConfirmation(toolName)) {
+      final approved =
+          confirmationId != null &&
+          _confirmations.consumeApproved(
+            id: confirmationId,
+            toolName: toolName,
+            arguments: arguments,
+          );
+      if (!approved) {
+        final pending = _confirmations.create(
+          toolName: toolName,
+          arguments: arguments,
+        );
+        _notifyConfirmationChange();
+        return DesktopControlToolResult.confirmationRequired(pending);
+      }
+      _notifyConfirmationChange();
+    }
+
+    try {
+      if (toolName.startsWith('desktop.')) {
+        return DesktopControlToolResult.success(
+          await _executeDesktopTool(toolName, arguments),
+        );
+      }
+      return await _executeChromeTool(toolName, arguments);
+    } on PlatformException catch (error) {
+      return DesktopControlToolResult.failure(
+        errorCode: error.code,
+        message: error.message ?? error.code,
+        recoverable: true,
+        data: Map<String, dynamic>.from(error.details as Map? ?? const {}),
+      );
+    } catch (error) {
+      return DesktopControlToolResult.failure(
+        errorCode: 'tool_execution_failed',
+        message: error.toString(),
+      );
+    }
+  }
+
+  Future<List<DesktopControlPendingConfirmation>> pendingConfirmations() async {
+    return _confirmations.list();
+  }
+
+  Future<DesktopControlPendingConfirmation?> approvePendingRequest(
+    String id,
+  ) async {
+    final item = _confirmations.approve(id);
+    _notifyConfirmationChange();
+    return item;
+  }
+
+  Future<DesktopControlPendingConfirmation?> rejectPendingRequest(
+    String id,
+  ) async {
+    final item = _confirmations.reject(id);
+    _notifyConfirmationChange();
+    return item;
+  }
+
+  Future<String?> prepareChromeConnectorInstall() async {
+    if (!_enabledByBuild()) return null;
+    final status = await ensureStarted();
+    final token = await bridgeToken;
+    if (status.bridgeUri == null || token == null) return null;
+
+    final support = await getApplicationSupportDirectory();
+    final dir = Directory(
+      p.join(support.path, 'desktop_control', 'chrome_extension'),
+    );
+    await dir.create(recursive: true);
+
+    final assets = await _listAssets(_extensionAssetPrefix);
+    for (final asset in assets) {
+      if (asset.endsWith('/')) continue;
+      final relative = asset.substring(_extensionAssetPrefix.length);
+      if (relative.isEmpty) continue;
+      final data = await rootBundle.load(asset);
+      final file = File(p.join(dir.path, relative));
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(
+        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+        flush: false,
+      );
+    }
+
+    final config = File(p.join(dir.path, 'dacheng-bridge-config.json'));
+    await config.writeAsString(
+      const JsonEncoder.withIndent('  ').convert({
+        'bridgeUrl': status.bridgeUri.toString(),
+        'token': token,
+        'note': 'Chrome 扩展选项页使用此本机 loopback 参数连接大乘桌面端。',
+      }),
+    );
+
+    if (Platform.isMacOS) {
+      unawaited(Process.run('open', [dir.path]));
+    }
+    return dir.path;
+  }
+
+  Future<Map<String, dynamic>> _executeDesktopTool(
+    String toolName,
+    Map<String, dynamic> arguments,
+  ) {
+    switch (toolName) {
+      case 'desktop.observe':
+        return _hostApi.observe();
+      case 'desktop.screenshot':
+        return _hostApi.screenshot(arguments);
+      case 'desktop.windows':
+        return _hostApi.windows();
+      case 'desktop.click':
+        return _hostApi.click(arguments);
+      case 'desktop.type':
+        return _hostApi.type(arguments);
+      case 'desktop.hotkey':
+        return _hostApi.hotkey(arguments);
+      case 'desktop.scroll':
+        return _hostApi.scroll(arguments);
+      default:
+        throw StateError('Unknown desktop tool: $toolName');
+    }
+  }
+
+  Future<DesktopControlToolResult> _executeChromeTool(
+    String toolName,
+    Map<String, dynamic> arguments,
+  ) async {
+    final chromeStatus = _chromeStatus();
+    if (!chromeStatus.connected) {
+      return DesktopControlToolResult.failure(
+        errorCode: 'chrome_connector_not_connected',
+        message: 'Chrome 连接器未连接；请在设置页安装并授权扩展',
+        recoverable: true,
+        data: {'status': chromeStatus.toJson()},
+      );
+    }
+
+    final id = _newCommandId();
+    final completer = Completer<Map<String, dynamic>>();
+    _chromeWaiters[id] = completer;
+    _chromeCommands.add(
+      _ChromeCommand(id: id, toolName: toolName, arguments: arguments),
+    );
+
+    try {
+      final result = await completer.future.timeout(_chromeCommandTimeout);
+      if (result['ok'] == false) {
+        return DesktopControlToolResult.failure(
+          errorCode: (result['errorCode'] ?? 'chrome_command_failed')
+              .toString(),
+          message: (result['message'] ?? 'Chrome 命令执行失败').toString(),
+          recoverable: true,
+          data: Map<String, dynamic>.from(result['data'] as Map? ?? const {}),
+        );
+      }
+      return DesktopControlToolResult.success(
+        Map<String, dynamic>.from(result['data'] as Map? ?? result),
+      );
+    } on TimeoutException {
+      _chromeWaiters.remove(id);
+      return DesktopControlToolResult.failure(
+        errorCode: 'chrome_connector_timeout',
+        message: 'Chrome 连接器响应超时',
+        recoverable: true,
+      );
+    }
+  }
+
+  Future<void> _serve(HttpServer server) async {
+    await for (final request in server) {
+      unawaited(_handleHttpRequest(request));
+    }
+  }
+
+  Future<void> _handleHttpRequest(HttpRequest request) async {
+    _addCorsHeaders(request);
+    if (request.method == 'OPTIONS') {
+      request.response.statusCode = HttpStatus.noContent;
+      await request.response.close();
+      return;
+    }
+
+    if (!_isAuthorized(request)) {
+      await _writeJson(request, HttpStatus.unauthorized, {
+        'ok': false,
+        'errorCode': 'unauthorized',
+        'message': 'Missing or invalid bearer token',
+      });
+      return;
+    }
+
+    try {
+      final path = request.uri.path;
+      if (request.method == 'GET' &&
+          (path == '/status' || path == '/v1/status')) {
+        await _writeJson(request, HttpStatus.ok, (await getStatus()).toJson());
+        return;
+      }
+      if (request.method == 'POST' && path == '/v1/tools/execute') {
+        final body = await _readJson(request);
+        final toolName = (body['tool'] ?? body['toolName'] ?? '').toString();
+        final arguments = Map<String, dynamic>.from(
+          body['arguments'] as Map? ?? const {},
+        );
+        final result = await executeTool(
+          toolName,
+          arguments,
+          confirmationId: body['confirmationId']?.toString(),
+        );
+        await _writeJson(request, HttpStatus.ok, result.toJson());
+        return;
+      }
+      if (request.method == 'GET' && path == '/chrome/commands') {
+        await _writeJson(request, HttpStatus.ok, {
+          'ok': true,
+          'commands': _drainChromeCommands(limit: 4),
+        });
+        return;
+      }
+      if (request.method == 'POST' && path == '/chrome/results') {
+        final body = await _readJson(request);
+        final id = body['id']?.toString() ?? '';
+        final completer = _chromeWaiters.remove(id);
+        if (completer != null && !completer.isCompleted) {
+          completer.complete(Map<String, dynamic>.from(body));
+        }
+        await _writeJson(request, HttpStatus.ok, {'ok': true});
+        return;
+      }
+      if (request.method == 'POST' && path == '/chrome/heartbeat') {
+        final body = await _readJson(request);
+        _chromeLastSeenAt = DateTime.now();
+        _chromeConnectorId = body['connectorId']?.toString();
+        _chromeExtensionVersion = body['version']?.toString();
+        await _writeJson(request, HttpStatus.ok, {
+          'ok': true,
+          'status': (await getStatus()).toJson(),
+        });
+        return;
+      }
+
+      await _writeJson(request, HttpStatus.notFound, {
+        'ok': false,
+        'errorCode': 'not_found',
+        'message': 'Unknown route',
+      });
+    } catch (error) {
+      await _writeJson(request, HttpStatus.internalServerError, {
+        'ok': false,
+        'errorCode': 'bridge_error',
+        'message': error.toString(),
+      });
+    }
+  }
+
+  bool _isAuthorized(HttpRequest request) {
+    final token = _token;
+    if (token == null || token.isEmpty) return false;
+    final header = request.headers.value(HttpHeaders.authorizationHeader);
+    if (header == 'Bearer $token') return true;
+    return request.uri.queryParameters['token'] == token;
+  }
+
+  void _addCorsHeaders(HttpRequest request) {
+    request.response.headers
+      ..set(HttpHeaders.accessControlAllowOriginHeader, '*')
+      ..set(HttpHeaders.accessControlAllowMethodsHeader, 'GET, POST, OPTIONS')
+      ..set(
+        HttpHeaders.accessControlAllowHeadersHeader,
+        'Authorization, Content-Type',
+      )
+      ..set(HttpHeaders.contentTypeHeader, 'application/json; charset=utf-8');
+  }
+
+  Future<Map<String, dynamic>> _readJson(HttpRequest request) async {
+    final text = await utf8.decoder.bind(request).join();
+    if (text.trim().isEmpty) return <String, dynamic>{};
+    final decoded = jsonDecode(text);
+    return Map<String, dynamic>.from(decoded as Map? ?? const {});
+  }
+
+  Future<void> _writeJson(
+    HttpRequest request,
+    int statusCode,
+    Map<String, dynamic> body,
+  ) async {
+    request.response.statusCode = statusCode;
+    request.response.write(jsonEncode(body));
+    await request.response.close();
+  }
+
+  List<Map<String, dynamic>> _drainChromeCommands({required int limit}) {
+    final commands = <Map<String, dynamic>>[];
+    while (_chromeCommands.isNotEmpty && commands.length < limit) {
+      commands.add(_chromeCommands.removeFirst().toJson());
+    }
+    return commands;
+  }
+
+  Future<DesktopControlBridgeStatus> _status({
+    required String platform,
+    required bool bridgeRunning,
+    required String message,
+  }) async {
+    final hostStatus = _platformSupportsSystemControl(platform)
+        ? await _safeHostStatus()
+        : const <String, dynamic>{};
+    return DesktopControlBridgeStatus(
+      enabledByBuild: _enabledByBuild(),
+      supportedPlatform: _platformSupportsSystemControl(platform),
+      bridgeRunning: bridgeRunning,
+      platform: platform,
+      message: message,
+      bridgeUri: _bridgeUri,
+      screenRecordingGranted: hostStatus['screenRecordingGranted'] == true,
+      accessibilityGranted: hostStatus['accessibilityGranted'] == true,
+      chrome: _chromeStatus(),
+      pendingConfirmationCount: _confirmations.list().length,
+    );
+  }
+
+  DesktopControlBridgeStatus _statusWithoutServer({required String message}) {
+    return DesktopControlBridgeStatus(
+      enabledByBuild: _enabledByBuild(),
+      supportedPlatform: false,
+      bridgeRunning: false,
+      platform: _platformProvider(),
+      message: message,
+      screenRecordingGranted: false,
+      accessibilityGranted: false,
+      chrome: ChromeConnectorStatus.disconnected(message),
+      pendingConfirmationCount: _confirmations.list().length,
+    );
+  }
+
+  Future<Map<String, dynamic>> _safeHostStatus() async {
+    try {
+      return await _hostApi.status();
+    } catch (error) {
+      return {'message': error.toString()};
+    }
+  }
+
+  ChromeConnectorStatus _chromeStatus() {
+    final lastSeenAt = _chromeLastSeenAt;
+    final connected =
+        lastSeenAt != null &&
+        DateTime.now().difference(lastSeenAt) <= _chromeHeartbeatTtl;
+    return ChromeConnectorStatus(
+      connected: connected,
+      message: connected ? 'Chrome 连接器已连接' : 'Chrome 连接器未连接',
+      connectorId: _chromeConnectorId,
+      extensionVersion: _chromeExtensionVersion,
+      lastSeenAt: lastSeenAt,
+    );
+  }
+
+  Future<List<String>> _listAssets(String prefix) async {
+    try {
+      final raw = await rootBundle.loadString('AssetManifest.json');
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      return decoded.keys.where((key) => key.startsWith(prefix)).toList()
+        ..sort();
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  void _notifyConfirmationChange() {
+    if (!_confirmationsController.isClosed) {
+      _confirmationsController.add(null);
+    }
+  }
+
+  String _newCommandId() {
+    final millis = DateTime.now().millisecondsSinceEpoch;
+    return 'chrome_${millis}_${_random.nextInt(1 << 32)}';
+  }
+
+  bool _platformSupportsSystemControl(String platform) => platform == 'macos';
+
+  static String _detectPlatform() {
+    if (Platform.isMacOS) return 'macos';
+    if (Platform.isWindows) return 'windows';
+    if (Platform.isLinux) return 'linux';
+    if (Platform.isAndroid) return 'android';
+    if (Platform.isIOS) return 'ios';
+    return 'unknown';
+  }
+}
+
+class _ChromeCommand {
+  final String id;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+
+  const _ChromeCommand({
+    required this.id,
+    required this.toolName,
+    required this.arguments,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'tool': toolName,
+    'arguments': arguments,
+  };
+}

--- a/fabushi/lib/services/desktop_control/desktop_control_bridge_stub.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_bridge_stub.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'desktop_control_models.dart';
+
+class DesktopControlBridge {
+  DesktopControlBridge._();
+
+  DesktopControlBridge.test({
+    Object? hostApi,
+    Object? confirmations,
+    bool Function()? enabledByBuild,
+    String Function()? platformProvider,
+    Object? random,
+  });
+
+  static final DesktopControlBridge instance = DesktopControlBridge._();
+
+  Stream<void> get confirmationsChanged => const Stream<void>.empty();
+
+  Future<String?> get bridgeToken => Future.value();
+
+  Future<DesktopControlBridgeStatus> getStatus() async {
+    return DesktopControlBridgeStatus(
+      enabledByBuild: false,
+      supportedPlatform: false,
+      bridgeRunning: false,
+      platform: 'web',
+      message: '当前平台不支持系统级电脑控制',
+      screenRecordingGranted: false,
+      accessibilityGranted: false,
+      chrome: ChromeConnectorStatus.disconnected(),
+    );
+  }
+
+  Future<DesktopControlBridgeStatus> ensureStarted() => getStatus();
+
+  Future<DesktopControlToolResult> executeTool(
+    String toolName,
+    Map<String, dynamic> arguments, {
+    String? confirmationId,
+  }) async {
+    return DesktopControlToolResult.failure(
+      errorCode: 'unsupported_platform',
+      message: '当前平台不支持系统级电脑控制',
+    );
+  }
+
+  Future<List<DesktopControlPendingConfirmation>> pendingConfirmations() async {
+    return const [];
+  }
+
+  Future<DesktopControlPendingConfirmation?> approvePendingRequest(String id) {
+    return Future.value();
+  }
+
+  Future<DesktopControlPendingConfirmation?> rejectPendingRequest(String id) {
+    return Future.value();
+  }
+
+  Future<String?> prepareChromeConnectorInstall() => Future.value();
+}

--- a/fabushi/lib/services/desktop_control/desktop_control_confirmation_store.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_confirmation_store.dart
@@ -1,0 +1,117 @@
+import 'dart:math';
+
+import 'desktop_control_models.dart';
+import 'desktop_control_policy.dart';
+
+class DesktopControlConfirmationStore {
+  DesktopControlConfirmationStore({
+    this.ttl = const Duration(minutes: 2),
+    Random? random,
+    DateTime Function()? clock,
+  }) : _random = random ?? Random.secure(),
+       _clock = clock ?? DateTime.now;
+
+  final Duration ttl;
+  final Random _random;
+  final DateTime Function() _clock;
+  final Map<String, DesktopControlPendingConfirmation> _items = {};
+
+  DesktopControlPendingConfirmation create({
+    required String toolName,
+    required Map<String, dynamic> arguments,
+  }) {
+    purgeExpired();
+    final now = _clock();
+    final item = DesktopControlPendingConfirmation(
+      id: _newId(),
+      toolName: toolName,
+      arguments: Map<String, dynamic>.from(arguments),
+      summary: DesktopControlPolicy.summarize(toolName, arguments),
+      state: DesktopControlConfirmationState.pending,
+      createdAt: now,
+      expiresAt: now.add(ttl),
+    );
+    _items[item.id] = item;
+    return item;
+  }
+
+  List<DesktopControlPendingConfirmation> list({bool activeOnly = true}) {
+    purgeExpired();
+    final values = _items.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return activeOnly ? values.where((item) => item.isActive).toList() : values;
+  }
+
+  DesktopControlPendingConfirmation? get(String id) {
+    purgeExpired();
+    return _items[id];
+  }
+
+  DesktopControlPendingConfirmation? approve(String id) {
+    final item = get(id);
+    if (item == null || !item.isActive) return null;
+    final approved = item.copyWith(
+      state: DesktopControlConfirmationState.approved,
+    );
+    _items[id] = approved;
+    return approved;
+  }
+
+  DesktopControlPendingConfirmation? reject(String id) {
+    final item = get(id);
+    if (item == null) return null;
+    final rejected = item.copyWith(
+      state: DesktopControlConfirmationState.rejected,
+    );
+    _items[id] = rejected;
+    return rejected;
+  }
+
+  bool consumeApproved({
+    required String id,
+    required String toolName,
+    required Map<String, dynamic> arguments,
+  }) {
+    purgeExpired();
+    final item = _items[id];
+    if (item == null ||
+        item.state != DesktopControlConfirmationState.approved ||
+        item.toolName != toolName ||
+        !_sameArguments(item.arguments, arguments)) {
+      return false;
+    }
+    _items.remove(id);
+    return true;
+  }
+
+  void purgeExpired() {
+    final now = _clock();
+    for (final entry in _items.entries.toList()) {
+      if (entry.value.state == DesktopControlConfirmationState.pending &&
+          now.isAfter(entry.value.expiresAt)) {
+        _items[entry.key] = entry.value.copyWith(
+          state: DesktopControlConfirmationState.expired,
+        );
+      }
+    }
+  }
+
+  String _newId() {
+    final bytes = List<int>.generate(18, (_) => _random.nextInt(256));
+    final chars = StringBuffer('confirm_');
+    const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    for (final byte in bytes) {
+      chars.write(alphabet[byte % alphabet.length]);
+    }
+    return chars.toString();
+  }
+
+  bool _sameArguments(Map<String, dynamic> a, Map<String, dynamic> b) {
+    if (a.length != b.length) return false;
+    for (final entry in a.entries) {
+      if (!b.containsKey(entry.key)) return false;
+      if (b[entry.key]?.toString() != entry.value?.toString()) return false;
+    }
+    return true;
+  }
+}

--- a/fabushi/lib/services/desktop_control/desktop_control_host_api.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_host_api.dart
@@ -1,0 +1,17 @@
+abstract class DesktopControlHostApi {
+  Future<Map<String, dynamic>> status();
+
+  Future<Map<String, dynamic>> observe();
+
+  Future<Map<String, dynamic>> screenshot(Map<String, dynamic> arguments);
+
+  Future<Map<String, dynamic>> windows();
+
+  Future<Map<String, dynamic>> click(Map<String, dynamic> arguments);
+
+  Future<Map<String, dynamic>> type(Map<String, dynamic> arguments);
+
+  Future<Map<String, dynamic>> hotkey(Map<String, dynamic> arguments);
+
+  Future<Map<String, dynamic>> scroll(Map<String, dynamic> arguments);
+}

--- a/fabushi/lib/services/desktop_control/desktop_control_models.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_models.dart
@@ -1,0 +1,272 @@
+enum DesktopControlPermissionState { granted, denied, unknown, notApplicable }
+
+enum DesktopControlConfirmationState { pending, approved, rejected, expired }
+
+class DesktopControlBridgeStatus {
+  final bool enabledByBuild;
+  final bool supportedPlatform;
+  final bool bridgeRunning;
+  final String platform;
+  final String message;
+  final Uri? bridgeUri;
+  final bool screenRecordingGranted;
+  final bool accessibilityGranted;
+  final ChromeConnectorStatus chrome;
+  final int pendingConfirmationCount;
+
+  const DesktopControlBridgeStatus({
+    required this.enabledByBuild,
+    required this.supportedPlatform,
+    required this.bridgeRunning,
+    required this.platform,
+    required this.message,
+    this.bridgeUri,
+    required this.screenRecordingGranted,
+    required this.accessibilityGranted,
+    required this.chrome,
+    this.pendingConfirmationCount = 0,
+  });
+
+  bool get desktopControlAvailable =>
+      enabledByBuild && supportedPlatform && bridgeRunning;
+
+  Map<String, dynamic> toJson() => {
+    'enabledByBuild': enabledByBuild,
+    'supportedPlatform': supportedPlatform,
+    'bridgeRunning': bridgeRunning,
+    'platform': platform,
+    'message': message,
+    'bridgeUri': bridgeUri?.toString(),
+    'screenRecordingGranted': screenRecordingGranted,
+    'accessibilityGranted': accessibilityGranted,
+    'chrome': chrome.toJson(),
+    'pendingConfirmationCount': pendingConfirmationCount,
+  };
+
+  factory DesktopControlBridgeStatus.fromJson(Map<String, dynamic> json) {
+    final bridgeUri = json['bridgeUri']?.toString();
+    return DesktopControlBridgeStatus(
+      enabledByBuild: json['enabledByBuild'] == true,
+      supportedPlatform: json['supportedPlatform'] == true,
+      bridgeRunning: json['bridgeRunning'] == true,
+      platform: (json['platform'] ?? 'unknown').toString(),
+      message: (json['message'] ?? '').toString(),
+      bridgeUri: bridgeUri == null || bridgeUri.isEmpty
+          ? null
+          : Uri.tryParse(bridgeUri),
+      screenRecordingGranted: json['screenRecordingGranted'] == true,
+      accessibilityGranted: json['accessibilityGranted'] == true,
+      chrome: ChromeConnectorStatus.fromJson(
+        Map<String, dynamic>.from(json['chrome'] as Map? ?? const {}),
+      ),
+      pendingConfirmationCount: _readInt(json['pendingConfirmationCount']) ?? 0,
+    );
+  }
+}
+
+class ChromeConnectorStatus {
+  final bool connected;
+  final String message;
+  final String? connectorId;
+  final String? extensionVersion;
+  final DateTime? lastSeenAt;
+
+  const ChromeConnectorStatus({
+    required this.connected,
+    required this.message,
+    this.connectorId,
+    this.extensionVersion,
+    this.lastSeenAt,
+  });
+
+  factory ChromeConnectorStatus.disconnected([String? message]) {
+    return ChromeConnectorStatus(
+      connected: false,
+      message: message ?? 'Chrome 连接器未连接',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'connected': connected,
+    'message': message,
+    if (connectorId != null) 'connectorId': connectorId,
+    if (extensionVersion != null) 'extensionVersion': extensionVersion,
+    if (lastSeenAt != null) 'lastSeenAt': lastSeenAt!.toIso8601String(),
+  };
+
+  factory ChromeConnectorStatus.fromJson(Map<String, dynamic> json) {
+    final rawLastSeen = json['lastSeenAt']?.toString();
+    return ChromeConnectorStatus(
+      connected: json['connected'] == true,
+      message: (json['message'] ?? '').toString(),
+      connectorId: json['connectorId']?.toString(),
+      extensionVersion: json['extensionVersion']?.toString(),
+      lastSeenAt: rawLastSeen == null || rawLastSeen.isEmpty
+          ? null
+          : DateTime.tryParse(rawLastSeen),
+    );
+  }
+}
+
+class DesktopControlToolRequest {
+  final String id;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+  final String? confirmationId;
+
+  const DesktopControlToolRequest({
+    required this.id,
+    required this.toolName,
+    this.arguments = const {},
+    this.confirmationId,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'tool': toolName,
+    'arguments': arguments,
+    if (confirmationId != null) 'confirmationId': confirmationId,
+  };
+
+  factory DesktopControlToolRequest.fromJson(Map<String, dynamic> json) {
+    return DesktopControlToolRequest(
+      id: (json['id'] ?? '').toString(),
+      toolName: (json['tool'] ?? json['toolName'] ?? '').toString(),
+      arguments: Map<String, dynamic>.from(
+        json['arguments'] as Map? ?? const {},
+      ),
+      confirmationId: json['confirmationId']?.toString(),
+    );
+  }
+}
+
+class DesktopControlToolResult {
+  final bool ok;
+  final Map<String, dynamic> data;
+  final String? errorCode;
+  final String? message;
+  final bool requiresConfirmation;
+  final String? pendingConfirmationId;
+  final bool recoverable;
+
+  const DesktopControlToolResult({
+    required this.ok,
+    this.data = const {},
+    this.errorCode,
+    this.message,
+    this.requiresConfirmation = false,
+    this.pendingConfirmationId,
+    this.recoverable = false,
+  });
+
+  factory DesktopControlToolResult.success([Map<String, dynamic>? data]) {
+    return DesktopControlToolResult(ok: true, data: data ?? const {});
+  }
+
+  factory DesktopControlToolResult.failure({
+    required String errorCode,
+    required String message,
+    bool recoverable = false,
+    Map<String, dynamic>? data,
+  }) {
+    return DesktopControlToolResult(
+      ok: false,
+      errorCode: errorCode,
+      message: message,
+      recoverable: recoverable,
+      data: data ?? const {},
+    );
+  }
+
+  factory DesktopControlToolResult.confirmationRequired(
+    DesktopControlPendingConfirmation pending,
+  ) {
+    return DesktopControlToolResult(
+      ok: false,
+      errorCode: 'confirmation_required',
+      message: pending.summary,
+      requiresConfirmation: true,
+      pendingConfirmationId: pending.id,
+      recoverable: true,
+      data: pending.toJson(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'ok': ok,
+    'data': data,
+    if (errorCode != null) 'errorCode': errorCode,
+    if (message != null) 'message': message,
+    'requiresConfirmation': requiresConfirmation,
+    if (pendingConfirmationId != null)
+      'pendingConfirmationId': pendingConfirmationId,
+    'recoverable': recoverable,
+  };
+
+  factory DesktopControlToolResult.fromJson(Map<String, dynamic> json) {
+    return DesktopControlToolResult(
+      ok: json['ok'] == true,
+      data: Map<String, dynamic>.from(json['data'] as Map? ?? const {}),
+      errorCode: json['errorCode']?.toString(),
+      message: json['message']?.toString(),
+      requiresConfirmation: json['requiresConfirmation'] == true,
+      pendingConfirmationId: json['pendingConfirmationId']?.toString(),
+      recoverable: json['recoverable'] == true,
+    );
+  }
+}
+
+class DesktopControlPendingConfirmation {
+  final String id;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+  final String summary;
+  final DesktopControlConfirmationState state;
+  final DateTime createdAt;
+  final DateTime expiresAt;
+
+  const DesktopControlPendingConfirmation({
+    required this.id,
+    required this.toolName,
+    required this.arguments,
+    required this.summary,
+    required this.state,
+    required this.createdAt,
+    required this.expiresAt,
+  });
+
+  bool get isActive =>
+      state == DesktopControlConfirmationState.pending &&
+      DateTime.now().isBefore(expiresAt);
+
+  DesktopControlPendingConfirmation copyWith({
+    DesktopControlConfirmationState? state,
+  }) {
+    return DesktopControlPendingConfirmation(
+      id: id,
+      toolName: toolName,
+      arguments: arguments,
+      summary: summary,
+      state: state ?? this.state,
+      createdAt: createdAt,
+      expiresAt: expiresAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'tool': toolName,
+    'arguments': arguments,
+    'summary': summary,
+    'state': state.name,
+    'createdAt': createdAt.toIso8601String(),
+    'expiresAt': expiresAt.toIso8601String(),
+  };
+}
+
+int? _readInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value);
+  return null;
+}

--- a/fabushi/lib/services/desktop_control/desktop_control_policy.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_policy.dart
@@ -1,0 +1,72 @@
+import 'desktop_control_models.dart';
+
+class DesktopControlPolicy {
+  static const Set<String> supportedTools = {
+    'desktop.observe',
+    'desktop.screenshot',
+    'desktop.windows',
+    'desktop.click',
+    'desktop.type',
+    'desktop.hotkey',
+    'desktop.scroll',
+    'chrome.tabs',
+    'chrome.navigate',
+    'chrome.dom_snapshot',
+    'chrome.screenshot',
+    'chrome.click',
+    'chrome.type',
+  };
+
+  static const Set<String> readOnlyTools = {
+    'desktop.observe',
+    'desktop.screenshot',
+    'desktop.windows',
+    'chrome.tabs',
+    'chrome.dom_snapshot',
+    'chrome.screenshot',
+  };
+
+  static bool isSupported(String toolName) => supportedTools.contains(toolName);
+
+  static bool isReadOnly(String toolName) => readOnlyTools.contains(toolName);
+
+  static bool requiresConfirmation(String toolName) =>
+      isSupported(toolName) && !isReadOnly(toolName);
+
+  static String summarize(String toolName, Map<String, dynamic> arguments) {
+    switch (toolName) {
+      case 'desktop.click':
+        return '确认本机点击 (${arguments['x']}, ${arguments['y']})';
+      case 'desktop.type':
+        return '确认向本机当前焦点输入 ${_describeText(arguments['text'])}';
+      case 'desktop.hotkey':
+        return '确认发送本机快捷键 ${arguments['keys'] ?? arguments['key']}';
+      case 'desktop.scroll':
+        return '确认滚动当前本机界面';
+      case 'chrome.navigate':
+        return '确认 Chrome 导航到 ${arguments['url'] ?? '指定网址'}';
+      case 'chrome.click':
+        return '确认在 Chrome 页面点击 ${arguments['selector'] ?? '指定位置'}';
+      case 'chrome.type':
+        return '确认在 Chrome 页面输入 ${_describeText(arguments['text'])}';
+      default:
+        return '确认执行 $toolName';
+    }
+  }
+
+  static DesktopControlToolResult unsupportedPlatform(String platform) {
+    return DesktopControlToolResult.failure(
+      errorCode: 'unsupported_platform',
+      message: '当前 $platform 暂不支持系统级电脑控制',
+      recoverable: false,
+      data: {'platform': platform},
+    );
+  }
+
+  static String _describeText(Object? value) {
+    final text = value?.toString() ?? '';
+    if (text.isEmpty) return '空文本';
+    if (text.length <= 24) return '"$text"';
+    return '"${text.substring(0, 24)}..."';
+  }
+}

--- a/fabushi/lib/services/openclaw/openclaw_ai_bridge.dart
+++ b/fabushi/lib/services/openclaw/openclaw_ai_bridge.dart
@@ -89,7 +89,12 @@ class OpenClawAiBridge {
       type: 'step',
       text: '本机 OpenClaw 已接管首页 AI 对话',
       conversationId: effectiveConversationId,
-      raw: const {'title': '本机 OpenClaw', 'message': '正在处理请求'},
+      raw: {
+        'title': '本机 OpenClaw',
+        'message': '正在处理请求',
+        if (target.desktopToolsStatus != null)
+          'desktopTools': target.desktopToolsStatus,
+      },
     );
 
     final existing = await _store.get(effectiveConversationId);
@@ -189,6 +194,8 @@ class OpenClawAiBridge {
         'conversationId': effectiveConversationId,
         'provider': 'openclaw-local',
         'sawDone': sawDone,
+        if (target.desktopToolsStatus != null)
+          'desktopTools': target.desktopToolsStatus,
       },
     );
   }

--- a/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
@@ -9,6 +9,8 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import '../app_settings.dart';
+import '../desktop_control/desktop_control_bridge.dart';
+import '../desktop_control/desktop_control_policy.dart';
 
 enum OpenClawRuntimeState {
   unsupported,
@@ -25,6 +27,7 @@ class OpenClawRuntimeStatus {
   final int? port;
   final String? platformKey;
   final String? runtimePath;
+  final Map<String, dynamic>? desktopToolsStatus;
   final DateTime checkedAt;
 
   const OpenClawRuntimeStatus({
@@ -33,6 +36,7 @@ class OpenClawRuntimeStatus {
     this.port,
     this.platformKey,
     this.runtimePath,
+    this.desktopToolsStatus,
     required this.checkedAt,
   });
 
@@ -61,12 +65,18 @@ class OpenClawGatewayTarget {
   final String token;
   final String model;
   final String? modelOverride;
+  final Uri? desktopToolsUri;
+  final String? desktopToolsToken;
+  final Map<String, dynamic>? desktopToolsStatus;
 
   const OpenClawGatewayTarget({
     required this.baseUri,
     required this.token,
     required this.model,
     this.modelOverride,
+    this.desktopToolsUri,
+    this.desktopToolsToken,
+    this.desktopToolsStatus,
   });
 }
 
@@ -87,6 +97,18 @@ class _OpenClawBundleSpec {
     required this.nodeExecutable,
     required this.cliEntrypoint,
     required this.gatewayArgs,
+  });
+}
+
+class _DesktopToolsLaunch {
+  final Uri? uri;
+  final String? token;
+  final Map<String, dynamic> statusJson;
+
+  const _DesktopToolsLaunch({
+    required this.uri,
+    required this.token,
+    required this.statusJson,
   });
 }
 
@@ -263,6 +285,7 @@ class OpenClawRuntime {
     final modelOverride = await AppSettings.getOpenClawModelOverride(
       defaultValue: spec.defaultModelOverride ?? '',
     );
+    final desktopTools = await _ensureDesktopTools();
 
     if (await _probe(port, token)) {
       return OpenClawGatewayTarget(
@@ -272,6 +295,9 @@ class OpenClawRuntime {
         modelOverride: modelOverride.trim().isEmpty
             ? null
             : modelOverride.trim(),
+        desktopToolsUri: desktopTools.uri,
+        desktopToolsToken: desktopTools.token,
+        desktopToolsStatus: desktopTools.statusJson,
       );
     }
 
@@ -281,6 +307,10 @@ class OpenClawRuntime {
       stateRoot: stateRoot,
       port: port,
       token: token,
+    );
+    final desktopToolsManifestPath = await _ensureDesktopToolsManifest(
+      stateRoot: stateRoot,
+      desktopTools: desktopTools,
     );
 
     final nodePath = p.join(runtimeDir.path, spec.nodeExecutable);
@@ -317,6 +347,12 @@ class OpenClawRuntime {
         'OPENCLAW_STATE_DIR': p.join(stateRoot.path, 'state'),
         'OPENCLAW_AGENT_DIR': p.join(stateRoot.path, 'agents'),
         'OPENCLAW_WORKSPACE': p.join(stateRoot.path, 'workspace'),
+        'DACHENG_DESKTOP_TOOLS_ENABLED': desktopTools.uri == null ? '0' : '1',
+        'DACHENG_DESKTOP_TOOLS_MANIFEST': desktopToolsManifestPath.path,
+        if (desktopTools.uri != null)
+          'DACHENG_DESKTOP_TOOLS_URL': desktopTools.uri.toString(),
+        if (desktopTools.token != null)
+          'DACHENG_DESKTOP_TOOLS_TOKEN': desktopTools.token!,
         'DACHENG_APP_RUNTIME': '1',
         if (authToken != null && authToken.isNotEmpty)
           'DACHENG_AUTH_TOKEN': authToken,
@@ -345,6 +381,7 @@ class OpenClawRuntime {
             port: port,
             platformKey: platformKey,
             runtimePath: runtimeDir.path,
+            desktopToolsStatus: desktopTools.statusJson,
             checkedAt: DateTime.now(),
           ),
         );
@@ -355,6 +392,9 @@ class OpenClawRuntime {
           modelOverride: modelOverride.trim().isEmpty
               ? null
               : modelOverride.trim(),
+          desktopToolsUri: desktopTools.uri,
+          desktopToolsToken: desktopTools.token,
+          desktopToolsStatus: desktopTools.statusJson,
         );
       }
 
@@ -559,6 +599,42 @@ class OpenClawRuntime {
     return configPath;
   }
 
+  Future<File> _ensureDesktopToolsManifest({
+    required Directory stateRoot,
+    required _DesktopToolsLaunch desktopTools,
+  }) async {
+    final configDir = Directory(p.join(stateRoot.path, 'config'));
+    await configDir.create(recursive: true);
+    final manifestPath = File(p.join(configDir.path, 'desktop_tools.json'));
+    final tools =
+        DesktopControlPolicy.supportedTools
+            .map(
+              (name) => {
+                'name': name,
+                'endpoint': '/v1/tools/execute',
+                'readOnly': DesktopControlPolicy.isReadOnly(name),
+                'requiresConfirmation':
+                    DesktopControlPolicy.requiresConfirmation(name),
+              },
+            )
+            .toList()
+          ..sort(
+            (a, b) => a['name'].toString().compareTo(b['name'].toString()),
+          );
+
+    await manifestPath.writeAsString(
+      const JsonEncoder.withIndent('  ').convert({
+        'version': 1,
+        'transport': 'http-loopback',
+        'baseUrl': desktopTools.uri?.toString(),
+        'auth': {'type': 'bearer', 'env': 'DACHENG_DESKTOP_TOOLS_TOKEN'},
+        'status': desktopTools.statusJson,
+        'tools': tools,
+      }),
+    );
+    return manifestPath;
+  }
+
   Future<Map<String, dynamic>> _mergeEmbeddedConfig(
     File configPath,
     Map<String, dynamic> defaults,
@@ -635,6 +711,27 @@ class OpenClawRuntime {
     final dir = Directory(p.join(support.path, 'openclaw_embedded'));
     await dir.create(recursive: true);
     return dir;
+  }
+
+  Future<_DesktopToolsLaunch> _ensureDesktopTools() async {
+    try {
+      final status = await DesktopControlBridge.instance.ensureStarted();
+      return _DesktopToolsLaunch(
+        uri: status.bridgeUri,
+        token: await DesktopControlBridge.instance.bridgeToken,
+        statusJson: status.toJson(),
+      );
+    } catch (error) {
+      return _DesktopToolsLaunch(
+        uri: null,
+        token: null,
+        statusJson: {
+          'enabledByBuild': false,
+          'bridgeRunning': false,
+          'message': error.toString(),
+        },
+      );
+    }
   }
 
   Future<Directory> _runtimeDir(

--- a/fabushi/lib/services/openclaw/openclaw_runtime_stub.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_stub.dart
@@ -13,6 +13,7 @@ class OpenClawRuntimeStatus {
   final int? port;
   final String? platformKey;
   final String? runtimePath;
+  final Map<String, dynamic>? desktopToolsStatus;
   final DateTime checkedAt;
 
   const OpenClawRuntimeStatus({
@@ -21,6 +22,7 @@ class OpenClawRuntimeStatus {
     this.port,
     this.platformKey,
     this.runtimePath,
+    this.desktopToolsStatus,
     required this.checkedAt,
   });
 
@@ -49,12 +51,18 @@ class OpenClawGatewayTarget {
   final String token;
   final String model;
   final String? modelOverride;
+  final Uri? desktopToolsUri;
+  final String? desktopToolsToken;
+  final Map<String, dynamic>? desktopToolsStatus;
 
   const OpenClawGatewayTarget({
     required this.baseUri,
     required this.token,
     required this.model,
     this.modelOverride,
+    this.desktopToolsUri,
+    this.desktopToolsToken,
+    this.desktopToolsStatus,
   });
 }
 

--- a/fabushi/macos/Runner.xcodeproj/project.pbxproj
+++ b/fabushi/macos/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		DCD0F1A10123456789ABCDEF /* DesktopControlPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD0F1A00123456789ABCDEF /* DesktopControlPlugin.swift */; };
 		CE24C7FFF43E824EF1D11E9F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9998BBAC6C2E2D37E1EC9DD1 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
@@ -87,6 +88,7 @@
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		9998BBAC6C2E2D37E1EC9DD1 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD240426B76C5C19D11C143 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		DCD0F1A00123456789ABCDEF /* DesktopControlPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopControlPlugin.swift; sourceTree = "<group>"; };
 		FD0D45FD42533769D5957BDC /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -190,6 +192,7 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				DCD0F1A00123456789ABCDEF /* DesktopControlPlugin.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -476,6 +479,7 @@
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
+				DCD0F1A10123456789ABCDEF /* DesktopControlPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/fabushi/macos/Runner/DesktopControlPlugin.swift
+++ b/fabushi/macos/Runner/DesktopControlPlugin.swift
@@ -1,0 +1,338 @@
+import ApplicationServices
+import Carbon.HIToolbox
+import Cocoa
+import FlutterMacOS
+
+final class DesktopControlPlugin: NSObject {
+  private static var retainedInstances: [DesktopControlPlugin] = []
+
+  private let channel: FlutterMethodChannel
+
+  static func register(with controller: FlutterViewController) {
+    let plugin = DesktopControlPlugin(controller: controller)
+    retainedInstances.append(plugin)
+  }
+
+  private init(controller: FlutterViewController) {
+    channel = FlutterMethodChannel(
+      name: "com.ombhrum.fabushi/desktop_control",
+      binaryMessenger: controller.engine.binaryMessenger
+    )
+    super.init()
+    channel.setMethodCallHandler(handle)
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    let args = call.arguments as? [String: Any] ?? [:]
+    switch call.method {
+    case "status":
+      result(statusPayload())
+    case "observe":
+      result([
+        "status": statusPayload(),
+        "activeApplication": activeApplicationPayload(),
+        "windows": enumerateWindows(),
+      ])
+    case "windows":
+      result(["windows": enumerateWindows()])
+    case "screenshot":
+      screenshot(args, result: result)
+    case "click":
+      guard requireAccessibility(result) else { return }
+      click(args, result: result)
+    case "type":
+      guard requireAccessibility(result) else { return }
+      typeText(args, result: result)
+    case "hotkey":
+      guard requireAccessibility(result) else { return }
+      hotkey(args, result: result)
+    case "scroll":
+      guard requireAccessibility(result) else { return }
+      scroll(args, result: result)
+    case "requestScreenRecording":
+      if #available(macOS 10.15, *) {
+        result(["requested": CGRequestScreenCaptureAccess()])
+      } else {
+        result(["requested": false])
+      }
+    case "requestAccessibility":
+      let options = [
+        kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true
+      ] as CFDictionary
+      result(["trusted": AXIsProcessTrustedWithOptions(options)])
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func statusPayload() -> [String: Any] {
+    [
+      "platform": "macos",
+      "screenRecordingGranted": screenRecordingGranted(),
+      "accessibilityGranted": AXIsProcessTrusted(),
+      "activeApplication": activeApplicationPayload(),
+    ]
+  }
+
+  private func activeApplicationPayload() -> [String: Any] {
+    guard let app = NSWorkspace.shared.frontmostApplication else {
+      return [:]
+    }
+    return [
+      "localizedName": app.localizedName ?? "",
+      "bundleIdentifier": app.bundleIdentifier ?? "",
+      "processIdentifier": app.processIdentifier,
+    ]
+  }
+
+  private func screenRecordingGranted() -> Bool {
+    if #available(macOS 10.15, *) {
+      return CGPreflightScreenCaptureAccess()
+    }
+    return true
+  }
+
+  private func enumerateWindows() -> [[String: Any]] {
+    let options: CGWindowListOption = [
+      .optionOnScreenOnly,
+      .excludeDesktopElements,
+    ]
+    let rawList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
+    return rawList.compactMap { item in
+      let ownerName = item[kCGWindowOwnerName as String] as? String ?? ""
+      let windowName = item[kCGWindowName as String] as? String ?? ""
+      let layer = item[kCGWindowLayer as String] as? Int ?? 0
+      let alpha = item[kCGWindowAlpha as String] as? Double ?? 0
+      guard layer == 0, alpha > 0 else { return nil }
+
+      var boundsPayload: [String: Any] = [:]
+      if let boundsDict = item[kCGWindowBounds as String] as? [String: Any],
+         let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) {
+        boundsPayload = [
+          "x": bounds.origin.x,
+          "y": bounds.origin.y,
+          "width": bounds.size.width,
+          "height": bounds.size.height,
+        ]
+      }
+
+      return [
+        "windowId": item[kCGWindowNumber as String] as? Int ?? 0,
+        "ownerName": ownerName,
+        "windowName": windowName,
+        "processIdentifier": item[kCGWindowOwnerPID as String] as? Int ?? 0,
+        "bounds": boundsPayload,
+      ]
+    }
+  }
+
+  private func screenshot(_ args: [String: Any], result: @escaping FlutterResult) {
+    guard screenRecordingGranted() else {
+      result(FlutterError(
+        code: "screen_recording_required",
+        message: "Screen Recording permission is required for screenshots.",
+        details: statusPayload()
+      ))
+      return
+    }
+
+    let rect = captureRect(args)
+    let imageOptions: CGWindowImageOption = [
+      .boundsIgnoreFraming,
+      .bestResolution,
+    ]
+    guard let cgImage = CGWindowListCreateImage(
+      rect,
+      .optionOnScreenOnly,
+      kCGNullWindowID,
+      imageOptions
+    ) else {
+      result(FlutterError(
+        code: "screenshot_failed",
+        message: "Unable to capture the screen.",
+        details: statusPayload()
+      ))
+      return
+    }
+
+    let rep = NSBitmapImageRep(cgImage: cgImage)
+    guard let png = rep.representation(using: .png, properties: [:]) else {
+      result(FlutterError(
+        code: "screenshot_encoding_failed",
+        message: "Unable to encode screenshot.",
+        details: nil
+      ))
+      return
+    }
+
+    result([
+      "format": "png",
+      "width": cgImage.width,
+      "height": cgImage.height,
+      "base64": png.base64EncodedString(),
+    ])
+  }
+
+  private func click(_ args: [String: Any], result: @escaping FlutterResult) {
+    guard let x = doubleArg(args, "x"), let y = doubleArg(args, "y") else {
+      result(FlutterError(
+        code: "invalid_arguments",
+        message: "desktop.click requires x and y.",
+        details: nil
+      ))
+      return
+    }
+
+    let point = CGPoint(x: x, y: y)
+    let buttonName = (args["button"] as? String ?? "left").lowercased()
+    let button: CGMouseButton = buttonName == "right" ? .right : .left
+    let downType: CGEventType = button == .right ? .rightMouseDown : .leftMouseDown
+    let upType: CGEventType = button == .right ? .rightMouseUp : .leftMouseUp
+
+    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: button)?
+      .post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: downType, mouseCursorPosition: point, mouseButton: button)?
+      .post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: upType, mouseCursorPosition: point, mouseButton: button)?
+      .post(tap: .cghidEventTap)
+
+    result(["clicked": true, "x": x, "y": y, "button": buttonName])
+  }
+
+  private func typeText(_ args: [String: Any], result: @escaping FlutterResult) {
+    let text = args["text"] as? String ?? ""
+    for scalar in text.utf16 {
+      var character = scalar
+      let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true)
+      down?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &character)
+      down?.post(tap: .cghidEventTap)
+
+      let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
+      up?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &character)
+      up?.post(tap: .cghidEventTap)
+    }
+    result(["typed": true, "length": text.count])
+  }
+
+  private func hotkey(_ args: [String: Any], result: @escaping FlutterResult) {
+    let rawKeys: [String]
+    if let keys = args["keys"] as? [String] {
+      rawKeys = keys
+    } else if let key = args["key"] as? String {
+      rawKeys = [key]
+    } else {
+      rawKeys = []
+    }
+
+    var flags = CGEventFlags()
+    var keyCode: CGKeyCode?
+    for rawKey in rawKeys {
+      let key = rawKey.lowercased()
+      switch key {
+      case "cmd", "command", "meta":
+        flags.insert(.maskCommand)
+      case "ctrl", "control":
+        flags.insert(.maskControl)
+      case "alt", "option":
+        flags.insert(.maskAlternate)
+      case "shift":
+        flags.insert(.maskShift)
+      default:
+        keyCode = keyCodeFor(key)
+      }
+    }
+
+    guard let code = keyCode else {
+      result(FlutterError(
+        code: "invalid_arguments",
+        message: "desktop.hotkey requires a non-modifier key.",
+        details: nil
+      ))
+      return
+    }
+
+    let down = CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: true)
+    down?.flags = flags
+    down?.post(tap: .cghidEventTap)
+    let up = CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: false)
+    up?.flags = flags
+    up?.post(tap: .cghidEventTap)
+    result(["hotkey": rawKeys])
+  }
+
+  private func scroll(_ args: [String: Any], result: @escaping FlutterResult) {
+    let deltaX = Int32(doubleArg(args, "deltaX") ?? 0)
+    let deltaY = Int32(doubleArg(args, "deltaY") ?? 0)
+    guard deltaX != 0 || deltaY != 0 else {
+      result(FlutterError(
+        code: "invalid_arguments",
+        message: "desktop.scroll requires deltaX or deltaY.",
+        details: nil
+      ))
+      return
+    }
+    CGEvent(
+      scrollWheelEvent2Source: nil,
+      units: .pixel,
+      wheelCount: 2,
+      wheel1: deltaY,
+      wheel2: deltaX,
+      wheel3: 0
+    )?.post(tap: .cghidEventTap)
+    result(["scrolled": true, "deltaX": deltaX, "deltaY": deltaY])
+  }
+
+  private func captureRect(_ args: [String: Any]) -> CGRect {
+    guard let x = doubleArg(args, "x"),
+          let y = doubleArg(args, "y"),
+          let width = doubleArg(args, "width"),
+          let height = doubleArg(args, "height"),
+          width > 0,
+          height > 0 else {
+      return CGRect.null
+    }
+    return CGRect(x: x, y: y, width: width, height: height)
+  }
+
+  private func requireAccessibility(_ result: @escaping FlutterResult) -> Bool {
+    guard AXIsProcessTrusted() else {
+      result(FlutterError(
+        code: "accessibility_required",
+        message: "Accessibility permission is required for input actions.",
+        details: statusPayload()
+      ))
+      return false
+    }
+    return true
+  }
+
+  private func doubleArg(_ args: [String: Any], _ key: String) -> Double? {
+    if let value = args[key] as? Double { return value }
+    if let value = args[key] as? Int { return Double(value) }
+    if let value = args[key] as? NSNumber { return value.doubleValue }
+    if let value = args[key] as? String { return Double(value) }
+    return nil
+  }
+
+  private func keyCodeFor(_ key: String) -> CGKeyCode? {
+    let letters: [String: Int] = [
+      "a": kVK_ANSI_A, "b": kVK_ANSI_B, "c": kVK_ANSI_C, "d": kVK_ANSI_D,
+      "e": kVK_ANSI_E, "f": kVK_ANSI_F, "g": kVK_ANSI_G, "h": kVK_ANSI_H,
+      "i": kVK_ANSI_I, "j": kVK_ANSI_J, "k": kVK_ANSI_K, "l": kVK_ANSI_L,
+      "m": kVK_ANSI_M, "n": kVK_ANSI_N, "o": kVK_ANSI_O, "p": kVK_ANSI_P,
+      "q": kVK_ANSI_Q, "r": kVK_ANSI_R, "s": kVK_ANSI_S, "t": kVK_ANSI_T,
+      "u": kVK_ANSI_U, "v": kVK_ANSI_V, "w": kVK_ANSI_W, "x": kVK_ANSI_X,
+      "y": kVK_ANSI_Y, "z": kVK_ANSI_Z,
+      "0": kVK_ANSI_0, "1": kVK_ANSI_1, "2": kVK_ANSI_2, "3": kVK_ANSI_3,
+      "4": kVK_ANSI_4, "5": kVK_ANSI_5, "6": kVK_ANSI_6, "7": kVK_ANSI_7,
+      "8": kVK_ANSI_8, "9": kVK_ANSI_9,
+      "return": kVK_Return, "enter": kVK_Return, "tab": kVK_Tab,
+      "escape": kVK_Escape, "esc": kVK_Escape, "space": kVK_Space,
+      "delete": kVK_Delete, "backspace": kVK_Delete,
+      "left": kVK_LeftArrow, "right": kVK_RightArrow,
+      "up": kVK_UpArrow, "down": kVK_DownArrow,
+    ]
+    guard let code = letters[key] else { return nil }
+    return CGKeyCode(code)
+  }
+}

--- a/fabushi/macos/Runner/Info.plist
+++ b/fabushi/macos/Runner/Info.plist
@@ -81,5 +81,9 @@
 	<string>此应用需要使用麦克风进行诵经录音和语音识别</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>此应用使用语音识别功能来辅助诵经学习</string>
+	<key>NSScreenCaptureDescription</key>
+	<string>此应用需要屏幕录制权限来为本机 AI 工具提供截图和窗口诊断</string>
+	<key>NSAccessibilityUsageDescription</key>
+	<string>此应用需要辅助功能权限来在用户确认后执行点击、输入、快捷键和滚动</string>
 </dict>
 </plist>

--- a/fabushi/macos/Runner/MainFlutterWindow.swift
+++ b/fabushi/macos/Runner/MainFlutterWindow.swift
@@ -9,6 +9,7 @@ class MainFlutterWindow: NSWindow {
     self.setFrame(windowFrame, display: true)
 
     RegisterGeneratedPlugins(registry: flutterViewController)
+    DesktopControlPlugin.register(with: flutterViewController)
 
     super.awakeFromNib()
   }

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -183,6 +183,7 @@ flutter:
     - assets/sherpa_models/streaming-paraformer-zh-en/
     # 桌面端内置 OpenClaw runtime。Release 打包时由 scripts/build_openclaw_desktop_bundle.sh 填充。
     - assets/openclaw/
+    - assets/desktop_control/chrome_extension/
     # Android/iOS 使用 R2 上的 flutter_scene .model，不再打包 GLB 到 APK/IPA
   
   fonts:

--- a/fabushi/test/unit/services/desktop_control/desktop_control_bridge_test.dart
+++ b/fabushi/test/unit/services/desktop_control/desktop_control_bridge_test.dart
@@ -1,0 +1,211 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/services/desktop_control/desktop_control_bridge.dart';
+import 'package:global_dharma_sharing/services/desktop_control/desktop_control_host_api.dart';
+import 'package:global_dharma_sharing/services/desktop_control/desktop_control_policy.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('desktop read-only tools run without confirmation', () async {
+    final host = _FakeDesktopControlHostApi();
+    final bridge = DesktopControlBridge.test(
+      hostApi: host,
+      enabledByBuild: () => true,
+      platformProvider: () => 'macos',
+      random: Random(1),
+    );
+
+    final result = await bridge.executeTool('desktop.windows', const {});
+
+    expect(result.ok, isTrue);
+    expect(result.requiresConfirmation, isFalse);
+    expect(result.data['windows'], isA<List<dynamic>>());
+    expect(host.calls, ['windows']);
+  });
+
+  test(
+    'mutating desktop tools require explicit approval before execution',
+    () async {
+      final host = _FakeDesktopControlHostApi();
+      final bridge = DesktopControlBridge.test(
+        hostApi: host,
+        enabledByBuild: () => true,
+        platformProvider: () => 'macos',
+        random: Random(2),
+      );
+      final arguments = {'x': 10, 'y': 20};
+
+      final first = await bridge.executeTool('desktop.click', arguments);
+
+      expect(first.ok, isFalse);
+      expect(first.requiresConfirmation, isTrue);
+      expect(first.pendingConfirmationId, isNotEmpty);
+      expect(host.calls, isEmpty);
+
+      await bridge.approvePendingRequest(first.pendingConfirmationId!);
+      final second = await bridge.executeTool(
+        'desktop.click',
+        arguments,
+        confirmationId: first.pendingConfirmationId,
+      );
+
+      expect(second.ok, isTrue);
+      expect(second.data['clicked'], isTrue);
+      expect(host.calls, ['click']);
+    },
+  );
+
+  test('rejected desktop confirmations do not execute the action', () async {
+    final host = _FakeDesktopControlHostApi();
+    final bridge = DesktopControlBridge.test(
+      hostApi: host,
+      enabledByBuild: () => true,
+      platformProvider: () => 'macos',
+      random: Random(3),
+    );
+    final arguments = {'text': 'hello'};
+
+    final first = await bridge.executeTool('desktop.type', arguments);
+    await bridge.rejectPendingRequest(first.pendingConfirmationId!);
+    final second = await bridge.executeTool(
+      'desktop.type',
+      arguments,
+      confirmationId: first.pendingConfirmationId,
+    );
+
+    expect(second.requiresConfirmation, isTrue);
+    expect(host.calls, isEmpty);
+  });
+
+  test('non-macOS desktop tools return unsupported platform', () async {
+    final bridge = DesktopControlBridge.test(
+      hostApi: _FakeDesktopControlHostApi(),
+      enabledByBuild: () => true,
+      platformProvider: () => 'windows',
+      random: Random(4),
+    );
+
+    final result = await bridge.executeTool('desktop.windows', const {});
+
+    expect(result.ok, isFalse);
+    expect(result.errorCode, 'unsupported_platform');
+    expect(result.message, contains('windows'));
+  });
+
+  test(
+    'Chrome tools report recoverable connector state when disconnected',
+    () async {
+      final bridge = DesktopControlBridge.test(
+        hostApi: _FakeDesktopControlHostApi(),
+        enabledByBuild: () => true,
+        platformProvider: () => 'macos',
+        random: Random(5),
+      );
+
+      final result = await bridge.executeTool('chrome.tabs', const {});
+
+      expect(result.ok, isFalse);
+      expect(result.errorCode, 'chrome_connector_not_connected');
+      expect(result.recoverable, isTrue);
+    },
+  );
+
+  test('build flag disables all desktop and Chrome tools', () async {
+    final bridge = DesktopControlBridge.test(
+      hostApi: _FakeDesktopControlHostApi(),
+      enabledByBuild: () => false,
+      platformProvider: () => 'macos',
+      random: Random(6),
+    );
+
+    final status = await bridge.getStatus();
+    final result = await bridge.executeTool('chrome.tabs', const {});
+
+    expect(status.enabledByBuild, isFalse);
+    expect(result.ok, isFalse);
+    expect(result.errorCode, 'disabled_by_build');
+  });
+
+  test('tool policy exposes the expected migration surface', () {
+    expect(
+      DesktopControlPolicy.supportedTools,
+      containsAll({
+        'desktop.observe',
+        'desktop.screenshot',
+        'desktop.windows',
+        'desktop.click',
+        'desktop.type',
+        'desktop.hotkey',
+        'desktop.scroll',
+        'chrome.tabs',
+        'chrome.navigate',
+        'chrome.dom_snapshot',
+        'chrome.screenshot',
+        'chrome.click',
+        'chrome.type',
+      }),
+    );
+    expect(DesktopControlPolicy.isReadOnly('desktop.screenshot'), isTrue);
+    expect(DesktopControlPolicy.requiresConfirmation('chrome.type'), isTrue);
+  });
+}
+
+class _FakeDesktopControlHostApi implements DesktopControlHostApi {
+  final List<String> calls = [];
+
+  @override
+  Future<Map<String, dynamic>> status() async => {
+    'screenRecordingGranted': true,
+    'accessibilityGranted': true,
+  };
+
+  @override
+  Future<Map<String, dynamic>> observe() async {
+    calls.add('observe');
+    return {'activeApplication': 'Test'};
+  }
+
+  @override
+  Future<Map<String, dynamic>> screenshot(
+    Map<String, dynamic> arguments,
+  ) async {
+    calls.add('screenshot');
+    return {'format': 'png', 'base64': ''};
+  }
+
+  @override
+  Future<Map<String, dynamic>> windows() async {
+    calls.add('windows');
+    return {
+      'windows': [
+        {'ownerName': 'Finder', 'windowName': 'Desktop'},
+      ],
+    };
+  }
+
+  @override
+  Future<Map<String, dynamic>> click(Map<String, dynamic> arguments) async {
+    calls.add('click');
+    return {'clicked': true};
+  }
+
+  @override
+  Future<Map<String, dynamic>> type(Map<String, dynamic> arguments) async {
+    calls.add('type');
+    return {'typed': true};
+  }
+
+  @override
+  Future<Map<String, dynamic>> hotkey(Map<String, dynamic> arguments) async {
+    calls.add('hotkey');
+    return {'hotkey': arguments['keys']};
+  }
+
+  @override
+  Future<Map<String, dynamic>> scroll(Map<String, dynamic> arguments) async {
+    calls.add('scroll');
+    return {'scrolled': true};
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a local desktop control bridge with loopback bearer auth, tool protocol, and confirmation gating.
- Adds macOS MethodChannel implementation for observe/windows/screenshot/click/type/hotkey/scroll with permission diagnostics.
- Adds a Chrome MV3 connector asset that exposes tabs, sanitized DOM snapshots, screenshots, and confirmed interactions without cookies/passwords/localStorage.
- Wires OpenClaw startup to publish desktop tool URL/token/manifest in environment and step.raw diagnostics.
- Adds Settings diagnostics for desktop control, Chrome connector status, permission state, and pending confirmations.

## Safety
- DACHENG_DESKTOP_CONTROL defaults to false in app code; release packaging enables it explicitly in a separate PR.
- Mutating desktop and Chrome tools require a pending confirmation to be approved before execution.
- Windows/Linux desktop tools return unsupported_platform.

## Tests
- flutter analyze lib/services/desktop_control lib/services/openclaw/openclaw_runtime_io.dart lib/services/openclaw/openclaw_runtime_stub.dart lib/services/openclaw/openclaw_ai_bridge.dart test/unit/services/desktop_control/desktop_control_bridge_test.dart
- flutter test test/unit/services/desktop_control/desktop_control_bridge_test.dart
- flutter test
- node --check Chrome extension JS
- xcrun swiftc -parse macos/Runner/DesktopControlPlugin.swift

## Local build note
- flutter build macos --release --no-pub --dart-define=DACHENG_DESKTOP_CONTROL=true reached CocoaPods install, but local BoringSSL-GRPC git clone repeatedly failed with RPC/early EOF before Xcode compilation. CI should retry from a clean runner.
