### PR TITLE
Enable desktop control for GitHub installer builds

### DIFF
--- a/.github/scripts/upload-macos-app-store.sh
+++ b/.github/scripts/upload-macos-app-store.sh
@@ -263,6 +263,7 @@ mkdir -p "$(dirname "$archive_path")" "$export_path"
 flutter build macos \
   --release \
   --no-pub \
+  --dart-define=DACHENG_DESKTOP_CONTROL=false \
   --config-only \
   --build-name "$version_name" \
   --build-number "$build_number"

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -397,7 +397,7 @@ jobs:
 
       - name: Build macOS release app
         if: matrix.target == 'macos'
-        run: flutter build macos --release --no-pub
+        run: flutter build macos --release --no-pub --dart-define=DACHENG_DESKTOP_CONTROL=true
 
       - name: Sync macOS OpenClaw assets into release app
         if: matrix.target == 'macos'


### PR DESCRIPTION
## Summary
- Enables `DACHENG_DESKTOP_CONTROL=true` for GitHub macOS installer builds.
- Keeps Mac App Store archive config explicitly disabled with `DACHENG_DESKTOP_CONTROL=false`.

## PR Strategy
This PR intentionally touches `.github/**`, which the repository automerge workflow treats as sensitive. It is stacked on #968 and should be retargeted to `main` after #968 merges, then merged by a human or protected queue.

## Tests
- The application-code PR #968 carries Dart/JS/Swift syntax checks and Flutter test coverage.
- Local `flutter build macos --release --no-pub --dart-define=DACHENG_DESKTOP_CONTROL=true` is currently blocked by repeated CocoaPods BoringSSL-GRPC git clone early EOF on this machine before Xcode compilation.
