### PR TITLE
Avoid pre-signing OpenClaw runtime during dylib fix

### DIFF
--- a/.github/scripts/fix-macos-bundled-dylibs.sh
+++ b/.github/scripts/fix-macos-bundled-dylibs.sh
@@ -167,48 +167,4 @@ if [ -n "$remaining_refs" ]; then
 fi
 
 
-resolve_codesign_identity() {
-  local identity="${MACOS_CODESIGN_IDENTITY:-}"
-  if [ -z "$identity" ] && command -v security >/dev/null 2>&1; then
-    identity="$(security find-identity -v -p codesigning | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
-  fi
-  printf '%s\n' "$identity"
-}
-
-is_macho_file() {
-  local file="$1"
-  file "$file" 2>/dev/null | grep -q 'Mach-O'
-}
-
-sign_openclaw_native_runtime() {
-  local identity="$1"
-  local openclaw_root="$app_path/Contents/Frameworks/App.framework/Resources/flutter_assets/assets/openclaw"
-  local signed_count=0
-
-  if [ -z "$identity" ]; then
-    echo "No Developer ID identity is available; skipping OpenClaw native runtime signing."
-    return 0
-  fi
-  if [ ! -d "$openclaw_root" ]; then
-    echo "OpenClaw runtime assets were not found in $app_path; skipping native runtime signing."
-    return 0
-  fi
-
-  while IFS= read -r -d '' file; do
-    if ! is_macho_file "$file"; then
-      continue
-    fi
-    chmod u+w "$file" || true
-    codesign --force --timestamp --options runtime --sign "$identity" "$file"
-    signed_count=$((signed_count + 1))
-    echo "Signed OpenClaw native runtime file: $file"
-  done < <(
-    find "$openclaw_root" -type f \
-      \( -name '*.node' -o -name '*.dylib' -o -perm -111 \) \
-      -print0
-  )
-
-  echo "Signed $signed_count OpenClaw native runtime file(s)."
-}
-
-sign_openclaw_native_runtime "$(resolve_codesign_identity)"
+echo "OpenClaw native runtime signing is handled by the later app codesign step."


### PR DESCRIPTION
## Summary
- stops `fix-macos-bundled-dylibs.sh` from timestamp-signing every OpenClaw native runtime file during the dylib rewrite step
- leaves runtime/app signing to the later formal `codesign --deep --timestamp` release step
- avoids PR/main desktop installer runs stalling in the dylib fix phase before packaging

## Validation
- `bash -n .github/scripts/fix-macos-bundled-dylibs.sh`

## Context
Desktop installers for #969 reached `Fix bundled macOS dynamic library references` and stayed there after Linux/Windows/App Store jobs had completed. The earlier PR run failed in the same step when the PR event exposed `MACOS_CODESIGN_IDENTITY` without an imported keychain identity. This keeps the dylib-fix step focused on dylib rewriting and lets the dedicated signing step own code signing.