### PR TITLE
Limit macOS dylib fix scan scope

### DIFF
--- a/.github/scripts/fix-macos-bundled-dylibs.sh
+++ b/.github/scripts/fix-macos-bundled-dylibs.sh
@@ -16,6 +16,24 @@ mkdir -p "$frameworks_dir"
 
 homebrew_deps=()
 
+find_macho_candidates() {
+  local macos_dir="$app_path/Contents/MacOS"
+  local openclaw_root="$app_path/Contents/Frameworks/App.framework/Resources/flutter_assets/assets/openclaw"
+
+  if [ -d "$macos_dir" ]; then
+    find "$macos_dir" -type f -perm -111 -print0
+  fi
+  if [ -d "$frameworks_dir" ]; then
+    find "$frameworks_dir" \
+      \( -path "$openclaw_root" -o -path "$openclaw_root/*" \) -prune -o \
+      -type f \( -name '*.dylib' -o -name '*.node' -o -path '*.framework/Versions/*/*' -o -perm -111 \) \
+      -print0
+  fi
+  if [ -d "$openclaw_root" ]; then
+    find "$openclaw_root" -type f \( -name '*.dylib' -o -name '*.node' \) -print0
+  fi
+}
+
 has_dep() {
   local needle="$1"
   local dep
@@ -99,7 +117,7 @@ while IFS= read -r -d '' file; do
   while IFS= read -r dep; do
     add_dep "$dep"
   done < <(collect_homebrew_deps "$file")
-done < <(find "$app_path/Contents" -type f \( -perm -111 -o -name '*.dylib' -o -path '*.framework/Versions/*/*' \) -print0)
+done < <(find_macho_candidates)
 
 if [ "${#homebrew_deps[@]}" -eq 0 ]; then
   echo "No Homebrew dynamic library references found in $app_path."
@@ -152,12 +170,12 @@ while IFS= read -r -d '' file; do
   if [ "$changed" = "true" ]; then
     echo "Rewrote Homebrew references in $file"
   fi
-done < <(find "$app_path/Contents" -type f \( -perm -111 -o -name '*.dylib' -o -path '*.framework/Versions/*/*' \) -print0)
+done < <(find_macho_candidates)
 
 remaining_refs="$(
   while IFS= read -r -d '' file; do
     otool -L "$file" 2>/dev/null | awk 'NR > 1 { print $1 }'
-  done < <(find "$app_path/Contents" -type f \( -perm -111 -o -name '*.dylib' -o -path '*.framework/Versions/*/*' \) -print0) |
+  done < <(find_macho_candidates) |
     grep -E '^(/opt/homebrew|/usr/local/(opt|Cellar))/' || true
 )"
 if [ -n "$remaining_refs" ]; then


### PR DESCRIPTION
## Summary
- scopes `fix-macos-bundled-dylibs.sh` to Mach-O candidates instead of every executable file in the app bundle
- prunes the embedded OpenClaw asset tree from broad Frameworks scanning and only inspects `.node`/`.dylib` files there
- keeps the later formal app codesign step responsible for signing

## Validation
- `bash -n .github/scripts/fix-macos-bundled-dylibs.sh`

## Context
The final main Desktop installers run reached the dylib fix step after Linux/Windows/App Store jobs completed, but remained in that step. The app bundle includes the embedded OpenClaw runtime under Flutter assets; broad `-perm -111` scanning can traverse many executable resource files that cannot have Mach-O Homebrew dylib references. This narrows the scan to the app executable, Frameworks, and OpenClaw native library files.