### PR TITLE
Prune Flutter assets from macOS dylib scan

### DIFF
--- a/.github/scripts/fix-macos-bundled-dylibs.sh
+++ b/.github/scripts/fix-macos-bundled-dylibs.sh
@@ -18,19 +18,16 @@ homebrew_deps=()
 
 find_macho_candidates() {
   local macos_dir="$app_path/Contents/MacOS"
-  local openclaw_root="$app_path/Contents/Frameworks/App.framework/Resources/flutter_assets/assets/openclaw"
+  local flutter_assets="$app_path/Contents/Frameworks/App.framework/Resources/flutter_assets"
 
   if [ -d "$macos_dir" ]; then
     find "$macos_dir" -type f -perm -111 -print0
   fi
   if [ -d "$frameworks_dir" ]; then
     find "$frameworks_dir" \
-      \( -path "$openclaw_root" -o -path "$openclaw_root/*" \) -prune -o \
+      \( -path "$flutter_assets" -o -path "$flutter_assets/*" \) -prune -o \
       -type f \( -name '*.dylib' -o -name '*.node' -o -path '*.framework/Versions/*/*' -o -perm -111 \) \
       -print0
-  fi
-  if [ -d "$openclaw_root" ]; then
-    find "$openclaw_root" -type f \( -name '*.dylib' -o -name '*.node' \) -print0
   fi
 }
 


### PR DESCRIPTION
## Summary
- excludes `App.framework/Resources/flutter_assets` from the broad macOS dylib rewrite scan
- keeps dylib rewriting focused on `Contents/MacOS` and Framework binaries
- relies on the already-run OpenClaw gateway smoke for embedded runtime validation and the later app codesign step for signing

## Validation
- `bash -n .github/scripts/fix-macos-bundled-dylibs.sh`

## Context
Even after removing OpenClaw runtime pre-signing and narrowing broad scanning, the final main Desktop installers run remained in `Fix bundled macOS dynamic library references`. The remaining broad scan still traversed Flutter assets under `App.framework/Resources`; those assets are not the Homebrew-linked framework binaries this script needs to rewrite.