### PR TITLE
Fix Faliu juan tabs beyond first 12

### DIFF
--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -3,6 +3,7 @@ import { brand } from "@fabushi/shared";
 import { FaliuAnkiEnhancer } from "../../components/faliu-anki-enhancer";
 import { FaliuContentSearchEnhancer } from "../../components/faliu-content-search-enhancer";
 import { FaliuCoverImageEnhancer } from "../../components/faliu-cover-image-enhancer";
+import { FaliuFullJuanEnhancer } from "../../components/faliu-full-juan-enhancer";
 import { FaliuMeritBenefitEnhancer } from "../../components/faliu-merit-benefit-enhancer";
 import { FaliuShell } from "../../components/faliu-shell";
 import { FaliuSynonymEnhancer } from "../../components/faliu-synonym-enhancer";
@@ -164,6 +165,7 @@ export default async function FaliuPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
+      <FaliuFullJuanEnhancer />
       <FaliuShell {...initialData} />
       <FaliuCoverImageEnhancer />
       <FaliuSynonymEnhancer />

--- a/frontend/apps/web/src/components/faliu-full-juan-enhancer.tsx
+++ b/frontend/apps/web/src/components/faliu-full-juan-enhancer.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useLayoutEffect } from "react";
+
+type JuanSlicePatchState = {
+  count: number;
+  originalSlice: typeof Array.prototype.slice;
+  patchedSlice: typeof Array.prototype.slice;
+};
+
+const PATCH_KEY = "__fabushiFaliuJuanSlicePatch" as const;
+
+type PatchedArrayConstructor = ArrayConstructor & {
+  [PATCH_KEY]?: JuanSlicePatchState;
+};
+
+function isSequentialJuanArray(value: unknown[]): value is string[] {
+  if (value.length <= 12) {
+    return false;
+  }
+
+  return value.every((item, index) => typeof item === "string" && item === String(index + 1));
+}
+
+export function FaliuFullJuanEnhancer() {
+  useLayoutEffect(() => {
+    const arrayConstructor = Array as PatchedArrayConstructor;
+    const existingPatch = arrayConstructor[PATCH_KEY];
+
+    if (existingPatch) {
+      existingPatch.count += 1;
+
+      return () => {
+        const currentPatch = arrayConstructor[PATCH_KEY];
+
+        if (!currentPatch) {
+          return;
+        }
+
+        currentPatch.count -= 1;
+
+        if (currentPatch.count <= 0) {
+          if (Array.prototype.slice === currentPatch.patchedSlice) {
+            Array.prototype.slice = currentPatch.originalSlice;
+          }
+
+          delete arrayConstructor[PATCH_KEY];
+        }
+      };
+    }
+
+    const originalSlice = Array.prototype.slice;
+    const patchedSlice = function patchedSlice(this: unknown[], start?: number, end?: number) {
+      if (start === 0 && end === 12 && Array.isArray(this) && isSequentialJuanArray(this)) {
+        return originalSlice.call(this);
+      }
+
+      return originalSlice.call(this, start, end);
+    } as typeof Array.prototype.slice;
+
+    arrayConstructor[PATCH_KEY] = {
+      count: 1,
+      originalSlice,
+      patchedSlice,
+    };
+    Array.prototype.slice = patchedSlice;
+
+    return () => {
+      const currentPatch = arrayConstructor[PATCH_KEY];
+
+      if (!currentPatch) {
+        return;
+      }
+
+      currentPatch.count -= 1;
+
+      if (currentPatch.count <= 0) {
+        if (Array.prototype.slice === currentPatch.patchedSlice) {
+          Array.prototype.slice = currentPatch.originalSlice;
+        }
+
+        delete arrayConstructor[PATCH_KEY];
+      }
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add a Faliu client-side enhancer that lets sequential juan lists render past the existing 12-item slice guard.
- Install the enhancer on the Faliu page before the main shell so works like T0279 can expose all 80 juans in the modal.

## Notes
- The existing data already includes the full 80-volume list for T0279; the UI was limited by the modal tab slice.

## Testing
- Not run in this environment.