### PR TITLE
Add T0264 juan 7 Zhulei merit benefits

### DIFF
--- a/frontend/apps/web/src/lib/faliu-merit-benefits-t0264-juan7-zhulei.ts
+++ b/frontend/apps/web/src/lib/faliu-merit-benefits-t0264-juan7-zhulei.ts
@@ -1,0 +1,78 @@
+import type { FaliuMeritBenefit } from "./faliu-merit-benefits";
+
+const ZHULEI_SECTION_TITLE = "囑累品第二十七";
+
+export const T0264_JUAN_7_ZHULEI_MERIT_BENEFITS: FaliuMeritBenefit[] = [
+  {
+    id: "t0264-007-096",
+    category: "付囑難得法",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "我於無量百千萬億阿僧祇劫，修集是難得阿耨多羅三藐三菩提法，今以付囑汝等，汝等應當一心流布此法廣令增益。",
+    anchorText: "修集是難得阿耨多羅三藐三菩提法",
+    note: "佛以久远修集的难得菩提法付嘱诸菩萨，劝一心流布、广令增益。",
+  },
+  {
+    id: "t0264-007-097",
+    category: "受持廣宣",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "汝當受持、讀誦、廣宣此法，令一切眾生普得聞知。",
+    anchorText: "汝當受持、讀誦、廣宣此法",
+    note: "佛嘱诸菩萨受持、读诵、广宣此法，使一切众生普得闻知。",
+  },
+  {
+    id: "t0264-007-098",
+    category: "如來大施",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "如來有大慈悲，無諸慳悋，亦無所畏，能與眾生佛之智慧、如來智慧、自然智慧。如來是一切眾生之大施主",
+    anchorText: "能與眾生佛之智慧、如來智慧、自然智慧",
+    note: "本品说明如来以大慈悲施与众生佛慧、如来智慧与自然智慧。",
+  },
+  {
+    id: "t0264-007-099",
+    category: "隨學如來",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "汝等亦應隨學如來之法，勿生慳悋",
+    anchorText: "隨學如來之法，勿生慳悋",
+    note: "佛劝受嘱者随学如来，不悭惜正法。",
+  },
+  {
+    id: "t0264-007-100",
+    category: "得佛慧故",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "於未來世，若有善男子、善女人信如來智慧者，當為演說此《法華經》使得聞知，為令其人得佛慧故。",
+    anchorText: "演說此《法華經》使得聞知",
+    note: "对信如来智慧者，应演说《法华经》令其闻知，为令其得佛慧。",
+  },
+  {
+    id: "t0264-007-101",
+    category: "示教利喜",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "若有眾生不信受者，當於如來餘深法中示教利喜。",
+    anchorText: "當於如來餘深法中示教利喜",
+    note: "对尚不信受者，佛嘱以如来其他深法示教利喜，循机引导。",
+  },
+  {
+    id: "t0264-007-102",
+    category: "報佛恩",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "汝等若能如是，則為已報諸佛之恩。",
+    anchorText: "則為已報諸佛之恩",
+    note: "依佛所嘱流布、演说、示教利喜，即是报诸佛恩。",
+  },
+  {
+    id: "t0264-007-103",
+    category: "奉行歡喜",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "時諸菩薩摩訶薩聞佛作是說已，皆大歡喜遍滿其身，益加恭敬曲躬低頭，合掌向佛俱發聲言：「如世尊勅，當具奉行。唯然，世尊！願不有慮。」",
+    anchorText: "皆大歡喜遍滿其身，益加恭敬",
+    note: "诸菩萨闻佛付嘱后，欢喜恭敬，承诺如佛所敕具足奉行。",
+  },
+  {
+    id: "t0264-007-104",
+    category: "聞說歡喜",
+    sectionTitle: ZHULEI_SECTION_TITLE,
+    text: "說是語時，十方無量分身諸佛坐寶樹下師子座上者，及多寶佛，并上行等無邊阿僧祇菩薩大眾，舍利弗等聲聞四眾，及一切世間天人阿修羅等，聞佛所說皆大歡喜。",
+    anchorText: "聞佛所說皆大歡喜",
+    note: "本品结尾，大众闻佛所说皆大欢喜。",
+  },
+];

--- a/frontend/apps/web/src/lib/faliu-merit-benefits.ts
+++ b/frontend/apps/web/src/lib/faliu-merit-benefits.ts
@@ -36,6 +36,7 @@ export { T0264_JUAN_7_MIAOYIN_MERIT_BENEFITS } from "./faliu-merit-benefits-t026
 export { T0264_JUAN_7_PUMEN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-pumen";
 export { T0264_JUAN_7_MIAOZHUANGYAN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-miaozhuangyan";
 export { T0264_JUAN_7_PUXIAN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-puxian";
+export { T0264_JUAN_7_ZHULEI_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-zhulei";
 
 import { getFaliuMeritBenefits as getBaseFaliuMeritBenefits } from "./faliu-merit-benefits-original";
 import { T0263_JUAN_10_MERIT_BENEFITS } from "./faliu-merit-benefits-t0263-juan10";
@@ -75,6 +76,7 @@ import { T0264_JUAN_7_MIAOYIN_MERIT_BENEFITS } from "./faliu-merit-benefits-t026
 import { T0264_JUAN_7_PUMEN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-pumen";
 import { T0264_JUAN_7_MIAOZHUANGYAN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-miaozhuangyan";
 import { T0264_JUAN_7_PUXIAN_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-puxian";
+import { T0264_JUAN_7_ZHULEI_MERIT_BENEFITS } from "./faliu-merit-benefits-t0264-juan7-zhulei";
 
 export function getFaliuMeritBenefits(work: string | null | undefined, juan: string | number | null | undefined) {
   const normalizedWork = work?.trim().toUpperCase();
@@ -152,6 +154,7 @@ export function getFaliuMeritBenefits(work: string | null | undefined, juan: str
       ...T0264_JUAN_7_PUMEN_MERIT_BENEFITS,
       ...T0264_JUAN_7_MIAOZHUANGYAN_MERIT_BENEFITS,
       ...T0264_JUAN_7_PUXIAN_MERIT_BENEFITS,
+      ...T0264_JUAN_7_ZHULEI_MERIT_BENEFITS,
     ];
   }
 


### PR DESCRIPTION
## Summary
- Add 9 source-grounded Faliu merit-benefit entries for T0264 juan 7 《囑累品第二十七》.
- Register the new Zhulei data module in the T0264 juan 7 selector after 《普賢菩薩勸發品第二十六》.
- Scope is limited to scripture merit-benefit data; no page structure, styling, navigation, or unrelated scripture data changes.

## Validation
- `validate_faliu_merit_entries.py --strict`: 9 entries, 0 failures
- `render_faliu_merit_data.py --strict --mode constant`: 9 entries, 0 warnings
- `node --check --experimental-strip-types` on the new data file passed