### PR TITLE
修复法流卷次按钮遮挡经文

### DIFF
--- a/frontend/apps/web/src/app/faliu/page.tsx
+++ b/frontend/apps/web/src/app/faliu/page.tsx
@@ -5,6 +5,7 @@ import { FaliuContentSearchEnhancer } from "../../components/faliu-content-searc
 import { FaliuCoverImageEnhancer } from "../../components/faliu-cover-image-enhancer";
 import { FaliuFullJuanEnhancer } from "../../components/faliu-full-juan-enhancer";
 import { FaliuMeritBenefitEnhancer } from "../../components/faliu-merit-benefit-enhancer";
+import { FaliuModalLayoutFix } from "../../components/faliu-modal-layout-fix";
 import { FaliuShell } from "../../components/faliu-shell";
 import { FaliuSynonymEnhancer } from "../../components/faliu-synonym-enhancer";
 import { FALIU_FEATURED_WORKS } from "../../lib/faliu-config";
@@ -166,6 +167,7 @@ export default async function FaliuPage() {
       />
 
       <FaliuFullJuanEnhancer />
+      <FaliuModalLayoutFix />
       <FaliuShell {...initialData} />
       <FaliuCoverImageEnhancer />
       <FaliuSynonymEnhancer />

--- a/frontend/apps/web/src/components/faliu-modal-layout-fix.tsx
+++ b/frontend/apps/web/src/components/faliu-modal-layout-fix.tsx
@@ -1,0 +1,43 @@
+export function FaliuModalLayoutFix() {
+  return (
+    <style
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={{
+        __html: `
+section[aria-label="法流"] [role="dialog"][aria-modal="true"] {
+  display: flex !important;
+  flex-direction: column !important;
+}
+
+section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalHeader"],
+section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalMeta"] {
+  flex: 0 0 auto !important;
+}
+
+section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalTabs"] {
+  flex: 0 1 auto !important;
+  max-height: min(18svh, 126px) !important;
+  overflow-y: auto !important;
+  overscroll-behavior: contain !important;
+  align-content: flex-start !important;
+  padding-bottom: 12px !important;
+  scrollbar-width: thin;
+}
+
+section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalBody"] {
+  flex: 1 1 0 !important;
+  min-height: 0 !important;
+  height: auto !important;
+  max-height: none !important;
+}
+
+@media (max-width: 760px) {
+  section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalTabs"] {
+    max-height: 104px !important;
+  }
+}
+        `,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## 变更
- 新增法流阅读弹窗布局修正样式。
- 当卷次数很多时，将卷次按钮区域限制高度并允许内部滚动。
- 让正文区域使用弹窗剩余空间，避免被卷次按钮挤压或遮挡。

## 验证
- 未在本地运行构建；当前环境无法克隆 GitHub 仓库。