### PR TITLE
Fix 法流经文详情弹窗内容塌陷

### DIFF
--- a/frontend/apps/web/src/components/faliu-modal-layout-fix.tsx
+++ b/frontend/apps/web/src/components/faliu-modal-layout-fix.tsx
@@ -7,6 +7,8 @@ export function FaliuModalLayoutFix() {
 section[aria-label="法流"] [role="dialog"][aria-modal="true"] {
   display: flex !important;
   flex-direction: column !important;
+  height: calc(100svh - 36px) !important;
+  max-height: calc(100svh - 36px) !important;
 }
 
 section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalHeader"],
@@ -25,13 +27,19 @@ section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalTa
 }
 
 section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalBody"] {
-  flex: 1 1 0 !important;
+  flex: 1 1 auto !important;
   min-height: 0 !important;
   height: auto !important;
   max-height: none !important;
+  overflow: hidden !important;
 }
 
 @media (max-width: 760px) {
+  section[aria-label="法流"] [role="dialog"][aria-modal="true"] {
+    height: 100svh !important;
+    max-height: 100svh !important;
+  }
+
   section[aria-label="法流"] [role="dialog"][aria-modal="true"] [class*="modalTabs"] {
     max-height: 104px !important;
   }


### PR DESCRIPTION
## Summary
- give the 法流 scripture detail modal a definite viewport height so its body no longer collapses
- keep the reader and side panels scrollable while preserving the juan tab overflow behavior

## Verification
- Opened `/faliu` locally and opened `T0251`; verified the reader, 功德利益, and 卡片 panels are all present with a non-zero modal body height
- `corepack pnpm --filter @fabushi/web typecheck`
- `corepack pnpm --filter @fabushi/web build`