### PR TITLE
Add Apple export compliance plist flag

### DIFF
--- a/fabushi/ios/Runner/Info.plist
+++ b/fabushi/ios/Runner/Info.plist
@@ -24,6 +24,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/fabushi/macos/Runner/Info.plist
+++ b/fabushi/macos/Runner/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
## Summary
- Add ITSAppUsesNonExemptEncryption=false to iOS and macOS Info.plist files.
- Prevent future Apple/TestFlight builds from being blocked by Missing Compliance when the app does not use non-exempt encryption.

## Verification
- plutil -lint fabushi/ios/Runner/Info.plist
- plutil -lint fabushi/macos/Runner/Info.plist