### PR TITLE
chore: add OpenClaw desktop diagnostics

### DIFF
--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -20,6 +20,7 @@ import '../services/ai_backend_policy.dart';
 import '../services/alipay_service.dart'
     if (dart.library.html) '../services/alipay_service_web.dart';
 import '../services/dacheng_ai_service.dart';
+import '../services/diagnostic_log_service.dart';
 import '../services/dharma_publish_service.dart';
 import '../services/inbound_share_service.dart';
 import 'dharma_publish_browser_screen.dart'
@@ -3530,6 +3531,15 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
 
     HapticFeedback.lightImpact();
     final requestSerial = ++_aiRequestSerial;
+    final requestWatch = Stopwatch()..start();
+    _diagHomeAi(
+      'send.start',
+      data: {
+        'requestSerial': requestSerial,
+        'messageLength': text.length,
+        'activeConversationId': _activeConversationId,
+      },
+    );
     final authModel = Provider.of<AuthModel?>(context, listen: false);
     await _aiStreamSubscription?.cancel();
     _aiStreamSubscription = null;
@@ -3540,12 +3550,15 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       _streamingAiText = '';
       _aiActivityText = '正在思考';
     });
+    _diagHomeAi('send.ui-thinking', data: {'requestSerial': requestSerial});
     _scrollHomeChatToBottom(force: true);
 
     try {
       final stepLines = <String>[];
       var finalText = '';
       String? latestConversationId = _activeConversationId;
+      var eventCount = 0;
+      var deltaCount = 0;
 
       await for (final event in _dachengAiService.sendChatStream(
         message: text,
@@ -3555,12 +3568,23 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         isMember: authModel?.hasPermission('premium') ?? false,
       )) {
         if (!mounted || requestSerial != _aiRequestSerial) return;
+        eventCount++;
 
         if (event.conversationId != null && event.conversationId!.isNotEmpty) {
           latestConversationId = event.conversationId;
         }
 
         if (event.isStep) {
+          _diagHomeAi(
+            'send.event-step',
+            data: {
+              'requestSerial': requestSerial,
+              'eventCount': eventCount,
+              'textLength': event.text.length,
+              'title': event.raw['title']?.toString(),
+              'message': event.raw['message']?.toString(),
+            },
+          );
           final visibleStep = _visibleAiStepLabel(event);
           if (visibleStep != null) {
             stepLines
@@ -3568,11 +3592,37 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
               ..add(visibleStep);
           }
         } else if (event.isDelta) {
+          deltaCount++;
+          if (deltaCount == 1) {
+            _diagHomeAi(
+              'send.first-delta',
+              data: {
+                'requestSerial': requestSerial,
+                'elapsedMs': requestWatch.elapsedMilliseconds,
+                'deltaLength': event.text.length,
+              },
+            );
+          }
           finalText += event.text;
         } else if (event.isDone) {
+          _diagHomeAi(
+            'send.event-done',
+            data: {
+              'requestSerial': requestSerial,
+              'elapsedMs': requestWatch.elapsedMilliseconds,
+              'eventCount': eventCount,
+              'deltaCount': deltaCount,
+              'finalLength': finalText.length,
+              'rawMessageLength': event.raw['message']?.toString().length,
+            },
+          );
           latestConversationId = event.conversationId ?? latestConversationId;
           finalText = (event.raw['message'] ?? finalText).toString();
         } else if (event.isError) {
+          _diagHomeAi(
+            'send.event-error',
+            data: {'requestSerial': requestSerial, 'text': event.text},
+          );
           throw StateError(event.text.isEmpty ? '大乘 AI 生成失败' : event.text);
         }
 
@@ -3587,6 +3637,16 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       }
 
       if (!mounted || requestSerial != _aiRequestSerial) return;
+      _diagHomeAi(
+        'send.complete',
+        data: {
+          'requestSerial': requestSerial,
+          'elapsedMs': requestWatch.elapsedMilliseconds,
+          'finalLength': finalText.trim().length,
+          'deltaCount': deltaCount,
+          'eventCount': eventCount,
+        },
+      );
       setState(() {
         _activeConversationId = latestConversationId;
         if (finalText.trim().isNotEmpty) {
@@ -3600,8 +3660,17 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       });
       _scrollHomeChatToBottom(force: true);
       unawaited(_loadRemoteConversations());
-    } catch (e) {
+    } catch (e, stackTrace) {
       if (!mounted || requestSerial != _aiRequestSerial) return;
+      _diagHomeAi(
+        'send.failed',
+        data: {
+          'requestSerial': requestSerial,
+          'elapsedMs': requestWatch.elapsedMilliseconds,
+        },
+        error: e,
+        stackTrace: stackTrace,
+      );
       setState(() {
         _homeChatMessages.add(
           _HomeChatMessage(
@@ -3619,6 +3688,13 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   }
 
   void _stopAiGeneration() {
+    _diagHomeAi(
+      'send.stop-requested',
+      data: {
+        'requestSerial': _aiRequestSerial,
+        'hasStreamingText': _streamingAiText.trim().isNotEmpty,
+      },
+    );
     _aiRequestSerial++;
     _aiStreamSubscription?.cancel();
     _aiStreamSubscription = null;
@@ -3650,6 +3726,23 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       return title.isNotEmpty ? title : message;
     }
     return null;
+  }
+
+  void _diagHomeAi(
+    String message, {
+    Map<String, Object?> data = const {},
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    unawaited(
+      DiagnosticLogService.instance.log(
+        'home.ai',
+        message,
+        data: data,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
   }
 
   void _scrollHomeChatToBottom({bool force = false}) {

--- a/fabushi/lib/screens/settings_screen.dart
+++ b/fabushi/lib/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'keep_alive_guide_screen.dart';
 import 'practice_privacy_screen.dart';
@@ -15,6 +16,7 @@ import '../services/llm_model_manager.dart';
 import '../services/device_capability_service.dart';
 import '../services/desktop_control/desktop_control_bridge.dart';
 import '../services/desktop_control/desktop_control_models.dart';
+import '../services/diagnostic_log_service.dart';
 import '../services/openclaw/openclaw_runtime.dart';
 import '../services/worker_config.dart';
 import '../widgets/model_selection_dialog.dart';
@@ -397,6 +399,61 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ? Colors.orange
             : Colors.green,
       ),
+    );
+  }
+
+  Future<void> _copyDiagnosticLogTail() async {
+    final path = await DiagnosticLogService.instance.logFilePath();
+    final tail = await DiagnosticLogService.instance.tail(maxLines: 400);
+    await Clipboard.setData(
+      ClipboardData(text: '诊断日志路径: ${path ?? '无持久化日志路径'}\n\n$tail'),
+    );
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(path == null ? '已复制当前诊断日志内容' : '已复制诊断日志内容和路径'),
+        backgroundColor: Colors.green,
+      ),
+    );
+  }
+
+  Future<void> _openDiagnosticLogLocation() async {
+    final path = await DiagnosticLogService.instance.logFilePath();
+    if (path == null || path.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('当前平台没有可打开的诊断日志文件'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    final file = File(path);
+    try {
+      if (Platform.isMacOS) {
+        await Process.run('open', ['-R', path]);
+      } else if (Platform.isWindows) {
+        await Process.run('explorer.exe', ['/select,${file.path}']);
+      } else {
+        await Process.run('xdg-open', [file.parent.path]);
+      }
+    } catch (error) {
+      await Clipboard.setData(ClipboardData(text: path));
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('打开日志位置失败，已复制路径：$error'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('已打开诊断日志位置'), backgroundColor: Colors.green),
     );
   }
 
@@ -1011,6 +1068,26 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           )
                         : const Icon(Icons.extension_outlined, size: 18),
                     label: Text(_isPreparingChromeConnector ? '准备中' : '连接器'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _copyDiagnosticLogTail,
+                    icon: const Icon(Icons.content_copy_outlined, size: 18),
+                    label: const Text('复制日志'),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _openDiagnosticLogLocation,
+                    icon: const Icon(Icons.folder_open_outlined, size: 18),
+                    label: const Text('日志位置'),
                   ),
                 ),
               ],

--- a/fabushi/lib/services/dacheng_ai_service.dart
+++ b/fabushi/lib/services/dacheng_ai_service.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 
 import '../core/config/app_config.dart';
 import 'ai_backend_policy.dart';
+import 'diagnostic_log_service.dart';
 import 'openclaw/openclaw_ai_bridge.dart';
 
 class DachengAiUsage {
@@ -228,7 +229,16 @@ class DachengAiService {
     String? username,
     bool isMember = false,
   }) async* {
-    if (await AiBackendPolicy.shouldUseEmbeddedOpenClaw()) {
+    final useEmbedded = await AiBackendPolicy.shouldUseEmbeddedOpenClaw();
+    _diag(
+      'stream.route',
+      data: {
+        'useEmbeddedOpenClaw': useEmbedded,
+        'messageLength': message.trim().length,
+        'conversationId': conversationId,
+      },
+    );
+    if (useEmbedded) {
       yield* _openClawBridge.sendChatStream(
         message: message,
         conversationId: conversationId,
@@ -240,6 +250,10 @@ class DachengAiService {
     }
 
     final uri = await _buildUri('/api/ai/chat/stream');
+    _diag(
+      'cloud.stream.request',
+      data: {'uri': uri.toString(), 'conversationId': conversationId},
+    );
     final request = http.Request('POST', uri)
       ..headers.addAll(_headers(token))
       ..body = jsonEncode({
@@ -253,8 +267,19 @@ class DachengAiService {
     final response = await _httpClient
         .send(request)
         .timeout(AppConfig.requestTimeout);
+    _diag(
+      'cloud.stream.response',
+      data: {
+        'statusCode': response.statusCode,
+        'contentType': response.headers['content-type'],
+      },
+    );
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final body = await utf8.decodeStream(response.stream);
+      _diag(
+        'cloud.stream.response-error',
+        data: {'statusCode': response.statusCode, 'body': body},
+      );
       throw StateError(body.trim().isEmpty ? '请求失败' : body);
     }
 
@@ -455,6 +480,23 @@ class DachengAiService {
       throw StateError(message.toString());
     }
     return decoded;
+  }
+
+  void _diag(
+    String message, {
+    Map<String, Object?> data = const {},
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    unawaited(
+      DiagnosticLogService.instance.log(
+        'dacheng.ai',
+        message,
+        data: data,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
   }
 }
 

--- a/fabushi/lib/services/diagnostic_log_service.dart
+++ b/fabushi/lib/services/diagnostic_log_service.dart
@@ -1,0 +1,2 @@
+export 'diagnostic_log_service_stub.dart'
+    if (dart.library.io) 'diagnostic_log_service_io.dart';

--- a/fabushi/lib/services/diagnostic_log_service_io.dart
+++ b/fabushi/lib/services/diagnostic_log_service_io.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class DiagnosticLogService {
+  DiagnosticLogService._();
+
+  static final DiagnosticLogService instance = DiagnosticLogService._();
+
+  Future<void> _writeChain = Future<void>.value();
+
+  Future<void> log(
+    String category,
+    String message, {
+    Map<String, Object?> data = const {},
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    final entry = <String, Object?>{
+      'ts': DateTime.now().toIso8601String(),
+      'category': category,
+      'message': message,
+      if (data.isNotEmpty) 'data': _sanitize(data),
+      if (error != null) 'error': error.toString(),
+      if (stackTrace != null) 'stack': _truncate(stackTrace.toString()),
+    };
+    final line = jsonEncode(entry);
+    debugPrint(
+      '[DachengDiag][$category] $message${data.isEmpty ? '' : ' ${jsonEncode(_sanitize(data))}'}',
+    );
+
+    _writeChain = _writeChain
+        .catchError((_) {})
+        .then((_) async {
+          final file = await _logFile();
+          await file.parent.create(recursive: true);
+          await file.writeAsString('$line\n', mode: FileMode.append);
+        })
+        .catchError((error) {
+          debugPrint('[DachengDiag] write failed: $error');
+        });
+    return _writeChain;
+  }
+
+  Future<String?> logFilePath() async => (await _logFile()).path;
+
+  Future<String> tail({int maxLines = 300}) async {
+    final file = await _logFile();
+    if (!await file.exists()) {
+      return '诊断日志不存在: ${file.path}';
+    }
+    final lines = await file.readAsLines();
+    final start = lines.length > maxLines ? lines.length - maxLines : 0;
+    return lines.skip(start).join('\n');
+  }
+
+  Future<File> _logFile() async {
+    final support = await getApplicationSupportDirectory();
+    return File(p.join(support.path, 'diagnostics', 'dacheng-diagnostics.log'));
+  }
+
+  Object? _sanitize(Object? value, [String key = '']) {
+    final lowerKey = key.toLowerCase();
+    if (lowerKey.contains('token') ||
+        lowerKey.contains('password') ||
+        lowerKey.contains('authorization') ||
+        lowerKey.contains('auth')) {
+      return '<redacted>';
+    }
+    if (value is Map) {
+      return value.map(
+        (mapKey, mapValue) =>
+            MapEntry(mapKey.toString(), _sanitize(mapValue, mapKey.toString())),
+      );
+    }
+    if (value is Iterable) {
+      return value.map((item) => _sanitize(item)).toList();
+    }
+    if (value is String) return _truncate(value);
+    return value;
+  }
+
+  String _truncate(String value, {int max = 2000}) {
+    if (value.length <= max) return value;
+    return '${value.substring(0, max)}...<truncated ${value.length - max} chars>';
+  }
+}

--- a/fabushi/lib/services/diagnostic_log_service_stub.dart
+++ b/fabushi/lib/services/diagnostic_log_service_stub.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+class DiagnosticLogService {
+  DiagnosticLogService._();
+
+  static final DiagnosticLogService instance = DiagnosticLogService._();
+
+  Future<void> log(
+    String category,
+    String message, {
+    Map<String, Object?> data = const {},
+    Object? error,
+    StackTrace? stackTrace,
+  }) async {
+    debugPrint(
+      '[DachengDiag][$category] $message${data.isEmpty ? '' : ' ${jsonEncode(data)}'}',
+    );
+    if (error != null) {
+      debugPrint('[DachengDiag][$category] error=$error');
+    }
+    if (stackTrace != null) {
+      debugPrint('[DachengDiag][$category] stack=$stackTrace');
+    }
+  }
+
+  Future<String?> logFilePath() async => null;
+
+  Future<String> tail({int maxLines = 300}) async => '当前平台没有持久化诊断日志文件。';
+}

--- a/fabushi/lib/services/openclaw/openclaw_ai_bridge.dart
+++ b/fabushi/lib/services/openclaw/openclaw_ai_bridge.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 
 import '../dacheng_ai_service.dart';
+import '../diagnostic_log_service.dart';
 import '../local_ai_conversation_store.dart';
 import 'openclaw_runtime.dart';
 
@@ -24,6 +25,9 @@ class OpenClawAiBridge {
   final http.Client _httpClient;
   final LocalAiConversationStore _store;
   static final Uuid _uuid = Uuid();
+  static const Duration _requestTimeout = Duration(seconds: 45);
+  static const Duration _firstTokenTimeout = Duration(seconds: 120);
+  static const Duration _streamIdleTimeout = Duration(seconds: 90);
 
   Future<DachengAiChatResult> sendChat({
     required String message,
@@ -72,132 +76,278 @@ class OpenClawAiBridge {
     String? username,
     bool isMember = false,
   }) async* {
+    final requestId = _uuid.v4();
+    final totalWatch = Stopwatch()..start();
     final normalizedMessage = message.trim();
-    if (normalizedMessage.isEmpty) return;
+    if (normalizedMessage.isEmpty) {
+      _diag('chat.skip-empty', data: {'requestId': requestId});
+      return;
+    }
 
-    final target = await OpenClawRuntime.instance.ensureStarted(
-      authToken: token,
-      username: username,
-      isMember: isMember,
-    );
-    final effectiveConversationId =
-        (conversationId != null && conversationId.trim().isNotEmpty)
-        ? conversationId.trim()
-        : _newConversationId();
+    try {
+      _diag(
+        'chat.start',
+        data: {
+          'requestId': requestId,
+          'messageLength': normalizedMessage.length,
+          'conversationId': conversationId,
+          'hasToken': token != null && token.isNotEmpty,
+          'hasUsername': username != null && username.isNotEmpty,
+          'isMember': isMember,
+        },
+      );
 
-    yield DachengAiStreamEvent(
-      type: 'step',
-      text: '本机 OpenClaw 已接管首页 AI 对话',
-      conversationId: effectiveConversationId,
-      raw: {
-        'title': '本机 OpenClaw',
-        'message': '正在处理请求',
-        if (target.desktopToolsStatus != null)
-          'desktopTools': target.desktopToolsStatus,
-      },
-    );
+      final ensureWatch = Stopwatch()..start();
+      final target = await OpenClawRuntime.instance.ensureStarted(
+        authToken: token,
+        username: username,
+        isMember: isMember,
+      );
+      ensureWatch.stop();
+      _diag(
+        'chat.runtime-ready',
+        data: {
+          'requestId': requestId,
+          'elapsedMs': ensureWatch.elapsedMilliseconds,
+          'baseUri': target.baseUri.toString(),
+          'model': target.model,
+          'modelOverrideSet': target.modelOverride != null,
+          'desktopToolsUri': target.desktopToolsUri?.toString(),
+        },
+      );
 
-    final existing = await _store.get(effectiveConversationId);
-    final requestMessages = <Map<String, dynamic>>[
-      ...(existing?.messages ?? const <LocalAiConversationMessage>[])
-          .where((item) => item.content.trim().isNotEmpty)
-          .map(
-            (item) => {
-              'role': item.role == 'user' ? 'user' : 'assistant',
-              'content': item.content,
-            },
-          ),
-      {'role': 'user', 'content': normalizedMessage},
-    ];
+      final effectiveConversationId =
+          (conversationId != null && conversationId.trim().isNotEmpty)
+          ? conversationId.trim()
+          : _newConversationId();
 
-    final uri = target.baseUri.replace(path: '/v1/chat/completions');
-    final request = http.Request('POST', uri)
-      ..headers.addAll({
-        'Accept': 'text/event-stream',
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ${target.token}',
-        if (target.modelOverride != null)
-          'x-openclaw-model': target.modelOverride!,
-        'x-openclaw-session-key': 'dacheng:$effectiveConversationId',
-        'x-openclaw-message-channel': 'dacheng-desktop',
-      })
-      ..body = jsonEncode({
+      yield DachengAiStreamEvent(
+        type: 'step',
+        text: '本机 OpenClaw 已接管首页 AI 对话',
+        conversationId: effectiveConversationId,
+        raw: {
+          'title': '本机 OpenClaw',
+          'message': '正在处理请求',
+          if (target.desktopToolsStatus != null)
+            'desktopTools': target.desktopToolsStatus,
+        },
+      );
+
+      final existing = await _store.get(effectiveConversationId);
+      final requestMessages = <Map<String, dynamic>>[
+        ...(existing?.messages ?? const <LocalAiConversationMessage>[])
+            .where((item) => item.content.trim().isNotEmpty)
+            .map(
+              (item) => {
+                'role': item.role == 'user' ? 'user' : 'assistant',
+                'content': item.content,
+              },
+            ),
+        {'role': 'user', 'content': normalizedMessage},
+      ];
+
+      final uri = target.baseUri.replace(path: '/v1/chat/completions');
+      final body = jsonEncode({
         'model': target.model,
         'stream': true,
         'stream_options': {'include_usage': true},
         'user': 'dacheng:$effectiveConversationId',
         'messages': requestMessages,
       });
-
-    final response = await _httpClient
-        .send(request)
-        .timeout(const Duration(seconds: 45));
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      final body = await utf8.decodeStream(response.stream);
-      throw StateError(
-        body.trim().isEmpty
-            ? '本机 OpenClaw 请求失败 (${response.statusCode})'
-            : body,
+      final request = http.Request('POST', uri)
+        ..headers.addAll({
+          'Accept': 'text/event-stream',
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ${target.token}',
+          if (target.modelOverride != null)
+            'x-openclaw-model': target.modelOverride!,
+          'x-openclaw-session-key': 'dacheng:$effectiveConversationId',
+          'x-openclaw-message-channel': 'dacheng-desktop',
+        })
+        ..body = body;
+      _diag(
+        'chat.request',
+        data: {
+          'requestId': requestId,
+          'uri': uri.toString(),
+          'conversationId': effectiveConversationId,
+          'messageCount': requestMessages.length,
+          'bodyBytes': utf8.encode(body).length,
+        },
       );
-    }
 
-    var finalText = '';
-    DachengAiUsage? usage;
-    var sawDone = false;
-
-    await for (final line
-        in response.stream
-            .transform(utf8.decoder)
-            .transform(const LineSplitter())) {
-      if (!line.startsWith('data:')) continue;
-      final dataText = line.substring('data:'.length).trim();
-      if (dataText.isEmpty) continue;
-      if (dataText == '[DONE]') {
-        sawDone = true;
-        break;
+      final responseWatch = Stopwatch()..start();
+      final response = await _httpClient.send(request).timeout(_requestTimeout);
+      responseWatch.stop();
+      _diag(
+        'chat.response',
+        data: {
+          'requestId': requestId,
+          'statusCode': response.statusCode,
+          'elapsedMs': responseWatch.elapsedMilliseconds,
+          'contentType': response.headers['content-type'],
+        },
+      );
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        final body = await utf8.decodeStream(response.stream);
+        _diag(
+          'chat.response-error',
+          data: {
+            'requestId': requestId,
+            'statusCode': response.statusCode,
+            'body': body,
+          },
+        );
+        throw StateError(
+          body.trim().isEmpty
+              ? '本机 OpenClaw 请求失败 (${response.statusCode})'
+              : body,
+        );
       }
 
-      final decoded = _safeDecodeMap(dataText);
-      if (decoded == null) continue;
+      var finalText = '';
+      DachengAiUsage? usage;
+      var sawDone = false;
+      var lineCount = 0;
+      var dataCount = 0;
+      var deltaCount = 0;
+      final streamWatch = Stopwatch()..start();
 
-      final usageJson = decoded['usage'];
-      if (usageJson is Map) {
-        usage = DachengAiUsage.fromJson(Map<String, dynamic>.from(usageJson));
+      final lines = response.stream
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .timeout(
+            _streamIdleTimeout,
+            onTimeout: (sink) {
+              sink.addError(
+                TimeoutException(
+                  'OpenClaw SSE stream idle for ${_streamIdleTimeout.inSeconds}s',
+                ),
+              );
+              sink.close();
+            },
+          );
+
+      await for (final line in lines) {
+        lineCount++;
+        if (finalText.isEmpty && streamWatch.elapsed > _firstTokenTimeout) {
+          throw TimeoutException(
+            'OpenClaw first token timeout after ${_firstTokenTimeout.inSeconds}s',
+          );
+        }
+        if (!line.startsWith('data:')) continue;
+        dataCount++;
+        if (dataCount == 1) {
+          _diag(
+            'chat.first-data',
+            data: {
+              'requestId': requestId,
+              'elapsedMs': streamWatch.elapsedMilliseconds,
+              'lineLength': line.length,
+            },
+          );
+        }
+        final dataText = line.substring('data:'.length).trim();
+        if (dataText.isEmpty) continue;
+        if (dataText == '[DONE]') {
+          sawDone = true;
+          _diag(
+            'chat.done-marker',
+            data: {
+              'requestId': requestId,
+              'elapsedMs': streamWatch.elapsedMilliseconds,
+              'lineCount': lineCount,
+              'dataCount': dataCount,
+              'deltaCount': deltaCount,
+            },
+          );
+          break;
+        }
+
+        final decoded = _safeDecodeMap(dataText, requestId: requestId);
+        if (decoded == null) continue;
+
+        final usageJson = decoded['usage'];
+        if (usageJson is Map) {
+          usage = DachengAiUsage.fromJson(Map<String, dynamic>.from(usageJson));
+        }
+
+        final deltaText = _deltaText(decoded);
+        if (deltaText.isEmpty) continue;
+        deltaCount++;
+        if (deltaCount == 1) {
+          _diag(
+            'chat.first-delta',
+            data: {
+              'requestId': requestId,
+              'elapsedMs': streamWatch.elapsedMilliseconds,
+              'deltaLength': deltaText.length,
+            },
+          );
+        }
+        finalText += deltaText;
+        yield DachengAiStreamEvent(
+          type: 'delta',
+          text: deltaText,
+          conversationId: effectiveConversationId,
+          raw: decoded,
+        );
       }
 
-      final deltaText = _deltaText(decoded);
-      if (deltaText.isEmpty) continue;
-      finalText += deltaText;
-      yield DachengAiStreamEvent(
-        type: 'delta',
-        text: deltaText,
-        conversationId: effectiveConversationId,
-        raw: decoded,
+      _diag(
+        'chat.stream-finished',
+        data: {
+          'requestId': requestId,
+          'elapsedMs': streamWatch.elapsedMilliseconds,
+          'totalElapsedMs': totalWatch.elapsedMilliseconds,
+          'lineCount': lineCount,
+          'dataCount': dataCount,
+          'deltaCount': deltaCount,
+          'finalLength': finalText.trim().length,
+          'sawDone': sawDone,
+        },
       );
-    }
 
-    if (finalText.trim().isNotEmpty) {
+      if (finalText.trim().isEmpty) {
+        _diag(
+          'chat.empty-result',
+          data: {'requestId': requestId, 'sawDone': sawDone},
+        );
+        throw StateError('本机 OpenClaw 返回空结果，请复制诊断日志排查');
+      }
+
       await _store.upsertTurn(
         conversationId: effectiveConversationId,
         userText: normalizedMessage,
         assistantText: finalText.trim(),
       );
-    }
 
-    yield DachengAiStreamEvent(
-      type: 'done',
-      text: finalText.trim(),
-      conversationId: effectiveConversationId,
-      usage: usage ?? _zeroUsage,
-      raw: {
-        'message': finalText.trim(),
-        'conversationId': effectiveConversationId,
-        'provider': 'openclaw-local',
-        'sawDone': sawDone,
-        if (target.desktopToolsStatus != null)
-          'desktopTools': target.desktopToolsStatus,
-      },
-    );
+      yield DachengAiStreamEvent(
+        type: 'done',
+        text: finalText.trim(),
+        conversationId: effectiveConversationId,
+        usage: usage ?? _zeroUsage,
+        raw: {
+          'message': finalText.trim(),
+          'conversationId': effectiveConversationId,
+          'provider': 'openclaw-local',
+          'sawDone': sawDone,
+          if (target.desktopToolsStatus != null)
+            'desktopTools': target.desktopToolsStatus,
+        },
+      );
+    } catch (error, stackTrace) {
+      _diag(
+        'chat.error',
+        data: {
+          'requestId': requestId,
+          'elapsedMs': totalWatch.elapsedMilliseconds,
+        },
+        error: error,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
   }
 
   Future<List<DachengConversationSummary>> listConversations() async {
@@ -248,12 +398,23 @@ class OpenClawAiBridge {
     return '';
   }
 
-  Map<String, dynamic>? _safeDecodeMap(String dataText) {
+  Map<String, dynamic>? _safeDecodeMap(String dataText, {String? requestId}) {
     try {
       final decoded = jsonDecode(dataText);
       if (decoded is Map<String, dynamic>) return decoded;
       if (decoded is Map) return Map<String, dynamic>.from(decoded);
-    } catch (_) {}
+    } catch (error) {
+      final logData = <String, Object?>{
+        'payloadLength': dataText.length,
+        'payloadPrefix': dataText.length > 160
+            ? dataText.substring(0, 160)
+            : dataText,
+      };
+      if (requestId != null) {
+        logData['requestId'] = requestId;
+      }
+      _diag('chat.decode-error', data: logData, error: error);
+    }
     return null;
   }
 
@@ -264,4 +425,21 @@ class OpenClawAiBridge {
     remainingTokens: 0,
     monthlyLimit: 0,
   );
+
+  void _diag(
+    String message, {
+    Map<String, Object?> data = const {},
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    unawaited(
+      DiagnosticLogService.instance.log(
+        'openclaw.chat',
+        message,
+        data: data,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
 }

--- a/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import '../app_settings.dart';
+import '../diagnostic_log_service.dart';
 import '../desktop_control/desktop_control_bridge.dart';
 import '../desktop_control/desktop_control_policy.dart';
 
@@ -138,6 +139,10 @@ class OpenClawRuntime {
   Future<OpenClawRuntimeStatus> getStatus({bool probe = true}) async {
     final platformKey = _platformKey;
     final port = await AppSettings.getOpenClawGatewayPort();
+    _diag(
+      'status.start',
+      data: {'platformKey': platformKey, 'port': port, 'probe': probe},
+    );
 
     if (platformKey == null) {
       return _remember(
@@ -155,11 +160,33 @@ class OpenClawRuntime {
       final runtimeDir = await _runtimeDir(spec, platformKey);
       final nodePath = p.join(runtimeDir.path, spec.nodeExecutable);
       final cliPath = p.join(runtimeDir.path, spec.cliEntrypoint);
+      final nodeExists = await File(nodePath).exists();
+      final cliExists = await File(cliPath).exists();
+      _diag(
+        'status.paths',
+        data: {
+          'platformKey': platformKey,
+          'runtimeDir': runtimeDir.path,
+          'nodePath': nodePath,
+          'nodeExists': nodeExists,
+          'cliPath': cliPath,
+          'cliExists': cliExists,
+        },
+      );
 
-      if (!await File(nodePath).exists() || !await File(cliPath).exists()) {
+      if (!nodeExists || !cliExists) {
         final hasBundleAssets = await _hasRequiredBundleAssets(
           platformKey,
           spec,
+        );
+        _diag(
+          'status.bundle-assets',
+          data: {
+            'platformKey': platformKey,
+            'hasBundleAssets': hasBundleAssets,
+            'nodeAsset': 'assets/openclaw/$platformKey/${spec.nodeExecutable}',
+            'cliAsset': 'assets/openclaw/$platformKey/${spec.cliEntrypoint}',
+          },
         );
         return _remember(
           OpenClawRuntimeStatus(
@@ -209,6 +236,7 @@ class OpenClawRuntime {
         ),
       );
     } catch (error) {
+      _diag('status.error', error: error);
       return _remember(
         OpenClawRuntimeStatus(
           state: OpenClawRuntimeState.failed,
@@ -270,6 +298,7 @@ class OpenClawRuntime {
     bool isMember = false,
   }) async {
     final platformKey = _platformKey;
+    _diag('ensure-start.start', data: {'platformKey': platformKey});
     if (platformKey == null) {
       throw const OpenClawRuntimeException('当前平台不支持内置 OpenClaw Gateway');
     }
@@ -286,8 +315,20 @@ class OpenClawRuntime {
       defaultValue: spec.defaultModelOverride ?? '',
     );
     final desktopTools = await _ensureDesktopTools();
+    _diag(
+      'ensure-start.config',
+      data: {
+        'platformKey': platformKey,
+        'port': port,
+        'model': model,
+        'modelOverrideSet': modelOverride.trim().isNotEmpty,
+        'desktopToolsUri': desktopTools.uri?.toString(),
+        'desktopToolsStatus': desktopTools.statusJson,
+      },
+    );
 
-    if (await _probe(port, token)) {
+    if (await _probe(port, token, context: 'pre-start')) {
+      _diag('ensure-start.reuse-existing', data: {'port': port});
       return OpenClawGatewayTarget(
         baseUri: Uri.parse('http://127.0.0.1:$port'),
         token: token,
@@ -316,9 +357,11 @@ class OpenClawRuntime {
     final nodePath = p.join(runtimeDir.path, spec.nodeExecutable);
     final cliPath = p.join(runtimeDir.path, spec.cliEntrypoint);
     if (!await File(nodePath).exists()) {
+      _diag('ensure-start.missing-node', data: {'nodePath': nodePath});
       throw OpenClawRuntimeException('OpenClaw 内置 Node 不存在: $nodePath');
     }
     if (!await File(cliPath).exists()) {
+      _diag('ensure-start.missing-cli', data: {'cliPath': cliPath});
       throw OpenClawRuntimeException('OpenClaw CLI 入口不存在: $cliPath');
     }
 
@@ -337,6 +380,16 @@ class OpenClawRuntime {
       cliPath,
       ...spec.gatewayArgs.map((arg) => arg.replaceAll('{port}', '$port')),
     ];
+    _diag(
+      'process.starting',
+      data: {
+        'nodePath': nodePath,
+        'args': args,
+        'workingDirectory': runtimeDir.path,
+        'configPath': configPath.path,
+        'desktopToolsManifestPath': desktopToolsManifestPath.path,
+      },
+    );
 
     final env = Map<String, String>.from(Platform.environment)
       ..addAll({
@@ -370,10 +423,12 @@ class OpenClawRuntime {
       runInShell: false,
     );
     _captureLogs(_process!);
+    _diag('process.started', data: {'pid': _process!.pid, 'port': port});
 
     final deadline = DateTime.now().add(_startupTimeout);
     while (DateTime.now().isBefore(deadline)) {
-      if (await _probe(port, token)) {
+      if (await _probe(port, token, context: 'startup')) {
+        _diag('process.ready', data: {'pid': _process?.pid, 'port': port});
         _remember(
           OpenClawRuntimeStatus(
             state: OpenClawRuntimeState.running,
@@ -405,6 +460,13 @@ class OpenClawRuntime {
         );
         if (exited != -999999) {
           final logs = _recentLogs.take(12).join('\n');
+          _diag(
+            'process.exited-early',
+            data: {
+              'exitCode': exited,
+              'recentLogs': _recentLogs.take(12).toList(),
+            },
+          );
           throw OpenClawRuntimeException(
             'OpenClaw Gateway 提前退出，exitCode=$exited${logs.isEmpty ? '' : '\n$logs'}',
           );
@@ -414,6 +476,13 @@ class OpenClawRuntime {
     }
 
     final logs = _recentLogs.take(12).join('\n');
+    _diag(
+      'process.startup-timeout',
+      data: {
+        'timeoutSeconds': _startupTimeout.inSeconds,
+        'recentLogs': _recentLogs.take(12).toList(),
+      },
+    );
     throw OpenClawRuntimeException(
       'OpenClaw Gateway 启动超时${logs.isEmpty ? '' : '\n$logs'}',
     );
@@ -439,7 +508,7 @@ class OpenClawRuntime {
             .map((item) => item.toString())
             .toList();
 
-    return _OpenClawBundleSpec(
+    final spec = _OpenClawBundleSpec(
       version: (decoded['version'] ?? 'dev').toString(),
       defaultPort: _readInt(decoded['defaultPort']) ?? 18789,
       defaultModel: (decoded['defaultModel'] ?? 'openclaw/default').toString(),
@@ -450,6 +519,19 @@ class OpenClawRuntime {
           .toString(),
       gatewayArgs: gatewayArgs,
     );
+    _diag(
+      'manifest.loaded',
+      data: {
+        'platformKey': platformKey,
+        'version': spec.version,
+        'defaultPort': spec.defaultPort,
+        'defaultModel': spec.defaultModel,
+        'nodeExecutable': spec.nodeExecutable,
+        'cliEntrypoint': spec.cliEntrypoint,
+        'gatewayArgs': spec.gatewayArgs,
+      },
+    );
+    return spec;
   }
 
   Future<Directory> _prepareBundle(
@@ -464,19 +546,42 @@ class OpenClawRuntime {
     if (await marker.exists() &&
         await nodePath.exists() &&
         await cliPath.exists()) {
+      _diag(
+        'bundle.prepare.cached',
+        data: {
+          'platformKey': platformKey,
+          'runtimeDir': runtimeDir.path,
+          'marker': marker.path,
+        },
+      );
       return runtimeDir;
     }
 
     final prefix = 'assets/openclaw/$platformKey/';
     final assets = await _listAssets(prefix);
-    if (!assets.contains('$prefix${spec.nodeExecutable}') ||
-        !assets.contains('$prefix${spec.cliEntrypoint}')) {
+    final hasNodeAsset = assets.contains('$prefix${spec.nodeExecutable}');
+    final hasCliAsset = assets.contains('$prefix${spec.cliEntrypoint}');
+    _diag(
+      'bundle.prepare.assets',
+      data: {
+        'platformKey': platformKey,
+        'prefix': prefix,
+        'assetCount': assets.length,
+        'hasNodeAsset': hasNodeAsset,
+        'hasCliAsset': hasCliAsset,
+        'nodeAsset': '$prefix${spec.nodeExecutable}',
+        'cliAsset': '$prefix${spec.cliEntrypoint}',
+        'sample': assets.take(8).toList(),
+      },
+    );
+    if (!hasNodeAsset || !hasCliAsset) {
       throw OpenClawRuntimeException(
         '当前安装包没有内置 $platformKey 的 OpenClaw runtime。请在 release 构建中运行 scripts/build_openclaw_desktop_bundle.sh 后再打包。',
       );
     }
 
     if (await runtimeDir.exists()) {
+      _diag('bundle.prepare.remove-old', data: {'runtimeDir': runtimeDir.path});
       await runtimeDir.delete(recursive: true);
     }
     await runtimeDir.create(recursive: true);
@@ -497,6 +602,18 @@ class OpenClawRuntime {
       await Process.run('chmod', ['+x', nodePath.path]);
     }
     await marker.writeAsString(DateTime.now().toIso8601String());
+    _diag(
+      'bundle.prepare.complete',
+      data: {
+        'platformKey': platformKey,
+        'runtimeDir': runtimeDir.path,
+        'assetCount': assets.length,
+        'nodeExists': await nodePath.exists(),
+        'nodeSize': await nodePath.exists() ? await nodePath.length() : 0,
+        'cliExists': await cliPath.exists(),
+        'cliSize': await cliPath.exists() ? await cliPath.length() : 0,
+      },
+    );
     return runtimeDir;
   }
 
@@ -506,27 +623,50 @@ class OpenClawRuntime {
   ) async {
     final prefix = 'assets/openclaw/$platformKey/';
     final assets = await _listAssets(prefix);
-    return assets.contains('$prefix${spec.nodeExecutable}') &&
+    final hasRequired =
+        assets.contains('$prefix${spec.nodeExecutable}') &&
         assets.contains('$prefix${spec.cliEntrypoint}');
+    _diag(
+      'bundle.has-required-assets',
+      data: {
+        'platformKey': platformKey,
+        'assetCount': assets.length,
+        'hasRequired': hasRequired,
+      },
+    );
+    return hasRequired;
   }
 
   Future<List<String>> _listAssets(String prefix) async {
     final assets = <String>{};
+    var jsonCount = 0;
+    var binCount = 0;
+    var indexCount = 0;
+    final failures = <String>[];
 
     try {
       final raw = await rootBundle.loadString('AssetManifest.json');
       final decoded = jsonDecode(raw) as Map<String, dynamic>;
-      assets.addAll(decoded.keys.where((key) => key.startsWith(prefix)));
-    } catch (_) {
+      final items = decoded.keys
+          .where((key) => key.startsWith(prefix))
+          .toList();
+      jsonCount = items.length;
+      assets.addAll(items);
+    } catch (error) {
+      failures.add('AssetManifest.json: $error');
       // Newer Flutter release builds may only include AssetManifest.bin.
     }
 
     try {
       final manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
-      assets.addAll(
-        manifest.listAssets().where((key) => key.startsWith(prefix)),
-      );
-    } catch (_) {
+      final items = manifest
+          .listAssets()
+          .where((key) => key.startsWith(prefix))
+          .toList();
+      binCount = items.length;
+      assets.addAll(items);
+    } catch (error) {
+      failures.add('AssetManifest.bin: $error');
       // App Store archives patched after flutter build carry a JSON/index file.
     }
 
@@ -541,20 +681,39 @@ class OpenClawRuntime {
           ? decoded
           : const [];
       if (indexedAssets is List) {
-        assets.addAll(
-          indexedAssets
-              .map((item) => item.toString())
-              .where((key) => key.startsWith(prefix)),
-        );
+        final items = indexedAssets
+            .map((item) => item.toString())
+            .where((key) => key.startsWith(prefix))
+            .toList();
+        indexCount = items.length;
+        assets.addAll(items);
       }
-    } catch (_) {
+    } catch (error) {
+      failures.add('asset_index.json: $error');
       // Older builds do not have an OpenClaw asset index.
     }
 
-    return assets.toList()..sort();
+    final sortedAssets = assets.toList()..sort();
+    _diag(
+      'asset.list',
+      data: {
+        'prefix': prefix,
+        'total': sortedAssets.length,
+        'jsonCount': jsonCount,
+        'binCount': binCount,
+        'indexCount': indexCount,
+        if (failures.isNotEmpty) 'failures': failures,
+        'sample': sortedAssets.take(8).toList(),
+      },
+    );
+    return sortedAssets;
   }
 
-  Future<bool> _probe(int port, String token) async {
+  Future<bool> _probe(
+    int port,
+    String token, {
+    String context = 'probe',
+  }) async {
     try {
       final modelsResponse = await http
           .get(
@@ -563,6 +722,14 @@ class OpenClawRuntime {
           )
           .timeout(_probeTimeout);
       if (modelsResponse.statusCode < 200 || modelsResponse.statusCode >= 300) {
+        _diag(
+          'probe.models-unhealthy',
+          data: {
+            'context': context,
+            'port': port,
+            'statusCode': modelsResponse.statusCode,
+          },
+        );
         return false;
       }
 
@@ -581,10 +748,27 @@ class OpenClawRuntime {
             body: '{}',
           )
           .timeout(_probeTimeout);
-      return chatResponse.statusCode != 401 &&
+      final healthy =
+          chatResponse.statusCode != 401 &&
           chatResponse.statusCode != 403 &&
           chatResponse.statusCode != 404;
-    } catch (_) {
+      _diag(
+        healthy ? 'probe.healthy' : 'probe.chat-unhealthy',
+        data: {
+          'context': context,
+          'port': port,
+          'chatStatusCode': chatResponse.statusCode,
+        },
+      );
+      return healthy;
+    } catch (error) {
+      if (context != 'startup') {
+        _diag(
+          'probe.error',
+          data: {'context': context, 'port': port},
+          error: error,
+        );
+      }
       return false;
     }
   }
@@ -629,6 +813,14 @@ class OpenClawRuntime {
     await configPath.writeAsString(
       const JsonEncoder.withIndent('  ').convert(merged),
     );
+    _diag(
+      'config.written',
+      data: {
+        'configPath': configPath.path,
+        'port': port,
+        'gatewayMode': _mutableMap(merged['gateway'])['mode'],
+      },
+    );
     return configPath;
   }
 
@@ -664,6 +856,13 @@ class OpenClawRuntime {
         'status': desktopTools.statusJson,
         'tools': tools,
       }),
+    );
+    _diag(
+      'desktop-tools.manifest-written',
+      data: {
+        'manifestPath': manifestPath.path,
+        'hasBaseUrl': desktopTools.uri != null,
+      },
     );
     return manifestPath;
   }
@@ -727,6 +926,7 @@ class OpenClawRuntime {
       if (kDebugMode) {
         debugPrint('[OpenClaw] $text');
       }
+      _diag('process.output', data: {'line': text});
     }
 
     process.stdout
@@ -749,12 +949,21 @@ class OpenClawRuntime {
   Future<_DesktopToolsLaunch> _ensureDesktopTools() async {
     try {
       final status = await DesktopControlBridge.instance.ensureStarted();
+      _diag(
+        'desktop-tools.started',
+        data: {
+          'bridgeRunning': status.bridgeRunning,
+          'bridgeUri': status.bridgeUri?.toString(),
+          'message': status.message,
+        },
+      );
       return _DesktopToolsLaunch(
         uri: status.bridgeUri,
         token: await DesktopControlBridge.instance.bridgeToken,
         statusJson: status.toJson(),
       );
     } catch (error) {
+      _diag('desktop-tools.error', error: error);
       return _DesktopToolsLaunch(
         uri: null,
         token: null,
@@ -803,6 +1012,23 @@ class OpenClawRuntime {
   }
 
   OpenClawRuntimeStatus? get lastStatus => _lastStatus;
+
+  void _diag(
+    String message, {
+    Map<String, Object?> data = const {},
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    unawaited(
+      DiagnosticLogService.instance.log(
+        'openclaw.runtime',
+        message,
+        data: data,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
 }
 
 int? _readInt(Object? value) {


### PR DESCRIPTION
## Summary
- add persistent desktop diagnostic logs for OpenClaw runtime startup, bundle asset discovery, gateway process output, route selection, request streaming, and home-screen thinking state
- add Settings buttons to copy the diagnostic log tail and open the log location
- add first-token/idle/empty-response handling so Windows cannot spin forever without a logged failure

## Current evidence
- Local installed macOS app /Applications/global_dharma_sharing.app is version 1.0.1 (673)
- Its flutter_assets/assets/openclaw folder only contains README.md and bundle_manifest.json
- assert-openclaw-bundle.sh reports missing macos-arm64/node/bin/node, which explains the current macOS “没有内置 runtime” error
- Windows “正在思考” still needs logs from the diagnostics build; this PR adds request/stream/runtime breadcrumbs so the next build exposes the exact failing stage instead of guessing from screenshots

## Validation
- dart format on changed files
- flutter analyze lib/services/openclaw/openclaw_ai_bridge.dart lib/services/openclaw/openclaw_runtime_io.dart lib/services/dacheng_ai_service.dart lib/services/diagnostic_log_service.dart lib/services/diagnostic_log_service_io.dart lib/services/diagnostic_log_service_stub.dart
- flutter test test/unit/services/desktop_control/desktop_control_bridge_test.dart test/unit/practice_privacy_settings_entry_test.dart test/widget_test.dart
- git diff --check