### PR TITLE
Fix Google Play review handoff flag

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -423,9 +423,8 @@ jobs:
               changes_not_sent_for_review=""
               ;;
             true|TRUE|True|1|yes|YES)
-              echo "GOOGLE_PLAY_CHANGES_NOT_SENT_FOR_REVIEW=true is no longer supported for this app because Google Play sends changes for review automatically; omitting changesNotSentForReview."
-              use_changes_not_sent_for_review=false
-              changes_not_sent_for_review=""
+              use_changes_not_sent_for_review=true
+              changes_not_sent_for_review=true
               ;;
             false|FALSE|False|0|no|NO)
               use_changes_not_sent_for_review=true


### PR DESCRIPTION
## Summary

Fix the Android package publishing workflow so `GOOGLE_PLAY_CHANGES_NOT_SENT_FOR_REVIEW=true` is passed through as `changesNotSentForReview: true` instead of being omitted.

The failing run uploaded the AAB successfully, then Google Play rejected the edit commit with:

> Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true.

## Verification

- Confirmed failing step from run `27754292636`: `Build Android release packages` / `Upload Android app bundle to Google Play`.
- Scoped the workflow diff to `.github/workflows/publish-cd-release.yml` only.

Once merged, the original package release workflow should be rerun so the upload uses the corrected review handoff flag.