### PR TITLE
Fix desktop sutra book offset

### DIFF
--- a/fabushi/lib/widgets/zen_buddha_2d_scene.dart
+++ b/fabushi/lib/widgets/zen_buddha_2d_scene.dart
@@ -114,7 +114,7 @@ class ZenBuddha2DSceneState extends State<ZenBuddha2DScene>
               size.width >= 720 && size.width / size.height > 1.18;
           final bookLeft = isWideDesktopScene
               ? safeClamp(
-                  size.width / 2 + buddhaWidth * 0.28,
+                  size.width / 2 + buddhaWidth * 0.5 + 16.0,
                   24.0,
                   size.width - bookWidth - 24.0,
                 )


### PR DESCRIPTION
## Summary
- Move the 2D sutra book to the outside of the Buddha's right edge on wide desktop windows.
- This corrects the prior offset, which was too small for the Mac desktop window shown in verification.

## Tests
- /opt/homebrew/bin/dart format fabushi/lib/widgets/zen_buddha_2d_scene.dart
- git diff --check -- fabushi/lib/widgets/zen_buddha_2d_scene.dart