### PR TITLE
[codex] Fix desktop Alipay login and sutra overlay

### DIFF
--- a/fabushi/lib/models/auth_model.dart
+++ b/fabushi/lib/models/auth_model.dart
@@ -598,12 +598,12 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  Future<bool> alipayLogin(String authCode) async {
+  Future<bool> alipayLogin(String authCode, {String? state}) async {
     _setLoading(true);
     _clearError();
 
     try {
-      final result = await _alipayAuthService.alipayLogin(authCode, null);
+      final result = await _alipayAuthService.alipayLogin(authCode, state);
 
       if (result['success'] == true) {
         _token = result['token'];

--- a/fabushi/lib/screens/douyin_login_screen.dart
+++ b/fabushi/lib/screens/douyin_login_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -55,8 +54,11 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
     if (kIsWeb) {
       _platformService.listenToMessages((event) {
         final data = event.data;
-        if (data is Map && data.containsKey('alipay_auth_code')) {
-          _handleAlipayCallback(data['alipay_auth_code']);
+        if (data is Map &&
+            (data.containsKey('alipay_auth_code') ||
+                data.containsKey('auth_code') ||
+                data.containsKey('token'))) {
+          _handleAlipayCallback(Map<String, dynamic>.from(data));
         }
       });
     } else {
@@ -343,20 +345,9 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
   }
 
   Future<void> _handleAlipayCallback(Map<String, dynamic> params) async {
-    final authModel = Provider.of<AuthModel>(context, listen: false);
-
     try {
-      final alipayUserId = params['alipay_user_id'] as String?;
-      final alipayOpenId = params['alipay_open_id'] as String?;
-      final alipayNickname = params['alipay_nickname'] as String?;
-      final alipayAvatar = params['alipay_avatar'] as String?;
-      final authCode = params['alipay_auth_code'] as String?;
-
-      final success = await authModel.alipayOneClickRegister(
-        alipayUserId ?? authCode ?? '',
-        alipayNickname,
-        alipayAvatar,
-        alipayOpenId,
+      final success = await _completeAlipayLoginFromParams(
+        params.map((key, value) => MapEntry(key, value?.toString() ?? '')),
       );
 
       if (success && mounted) {
@@ -378,6 +369,114 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
     }
   }
 
+  Map<String, String> _parseAlipayCallbackParams(String url) {
+    final decodedUrl = url.replaceAll('&amp;', '&');
+    final params = <String, String>{};
+
+    void addAll(Map<String, String> values) {
+      for (final entry in values.entries) {
+        if (entry.key.isNotEmpty && entry.value.isNotEmpty) {
+          params[entry.key] = entry.value;
+        }
+      }
+    }
+
+    void parseQueryLike(String value) {
+      var query = value.trim();
+      if (query.isEmpty) return;
+
+      final questionIndex = query.indexOf('?');
+      if (questionIndex >= 0) {
+        query = query.substring(questionIndex + 1);
+      }
+
+      final hashIndex = query.indexOf('#');
+      if (hashIndex >= 0) {
+        final beforeHash = query.substring(0, hashIndex);
+        final afterHash = query.substring(hashIndex + 1);
+        parseQueryLike(beforeHash);
+        parseQueryLike(afterHash);
+        return;
+      }
+
+      if (!query.contains('=')) return;
+      try {
+        addAll(Uri.splitQueryString(query));
+      } catch (_) {
+        for (final param in query.split('&')) {
+          final separator = param.indexOf('=');
+          if (separator <= 0) continue;
+          params[param.substring(0, separator)] = Uri.decodeComponent(
+            param.substring(separator + 1),
+          );
+        }
+      }
+    }
+
+    final uri = Uri.tryParse(decodedUrl);
+    if (uri != null) {
+      addAll(uri.queryParameters);
+      parseQueryLike(uri.fragment);
+    }
+
+    parseQueryLike(
+      decodedUrl
+          .replaceFirst('com.ombhrum.fabushi://', '')
+          .replaceFirst('globaldharma://', '')
+          .replaceFirst('fabushi://', ''),
+    );
+
+    return params;
+  }
+
+  Future<bool> _completeAlipayLoginFromParams(
+    Map<String, String> params,
+  ) async {
+    final authModel = Provider.of<AuthModel>(context, listen: false);
+    final token = params['token'];
+    final username = params['username'];
+    final authCode = params['alipay_auth_code'] ?? params['auth_code'];
+    final state = params['state'];
+    final alipayUserId = params['alipay_user_id'] ?? params['user_id'];
+    final alipayOpenId = params['alipay_open_id'] ?? params['open_id'];
+    final alipayNickname = params['alipay_nickname'] ?? params['nick_name'];
+    final alipayAvatar = params['alipay_avatar'] ?? params['avatar'];
+
+    if (token != null && token.isNotEmpty) {
+      await authModel.loginWithToken(
+        token,
+        username?.isNotEmpty == true
+            ? username!
+            : alipayUserId?.isNotEmpty == true
+            ? alipayUserId!
+            : 'alipay_user',
+      );
+      return authModel.isLoggedIn;
+    }
+
+    if (authCode != null && authCode.isNotEmpty) {
+      final success = await authModel.alipayLogin(authCode, state: state);
+      if (success) return true;
+    }
+
+    final isNewUser =
+        params['isNewUser'] == 'true' ||
+        params['is_new_user'] == 'true' ||
+        params['needsRegistration'] == 'true' ||
+        params['needs_registration'] == 'true';
+
+    if (isNewUser && alipayUserId != null && alipayUserId.isNotEmpty) {
+      return authModel.alipayOneClickRegister(
+        alipayUserId,
+        alipayNickname,
+        alipayAvatar,
+        alipayOpenId,
+      );
+    }
+
+    return false;
+  }
+
   Future<void> _handleDeepLinkAlipayCallback(String url) async {
     debugPrint('收到深度链接支付宝回调: $url');
 
@@ -390,23 +489,7 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
     }
 
     try {
-      String decodedUrl = url.replaceAll('&amp;', '&');
-      Map<String, String> params = {};
-
-      String urlWithoutScheme = decodedUrl
-          .replaceFirst('com.ombhrum.fabushi://', '')
-          .replaceFirst('globaldharma://', '')
-          .replaceFirst('fabushi://', '');
-
-      final queryParams = urlWithoutScheme.split('&');
-      for (final param in queryParams) {
-        if (param.contains('=')) {
-          final keyValue = param.split('=');
-          if (keyValue.length == 2) {
-            params[keyValue[0]] = Uri.decodeComponent(keyValue[1]);
-          }
-        }
-      }
+      final params = _parseAlipayCallbackParams(url);
 
       if (params.containsKey('error')) {
         final errorMessage = params['error_message'] ?? '支付宝登录失败';
@@ -421,37 +504,13 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
         return;
       }
 
-      if (params.containsKey('alipay_auth_code')) {
-        final authCode = params['alipay_auth_code']!;
-        final alipayUserId = params['alipay_user_id'];
-        final alipayOpenId = params['alipay_open_id'];
-        final alipayNickname = params['alipay_nickname'];
-        final alipayAvatar = params['alipay_avatar'];
-        final isNewUser = params['isNewUser'] == 'true';
-        final token = params['token'];
-        final username = params['username'];
-
-        final authModel = Provider.of<AuthModel>(context, listen: false);
-        bool success = false;
-
-        if (!isNewUser && token != null && username != null) {
-          try {
-            await authModel.loginWithToken(token, username);
-            success = true;
-          } catch (e) {
-            debugPrint('使用token登录失败: $e');
-            success = false;
-          }
-        } else {
-          success = await authModel.alipayOneClickRegister(
-            alipayUserId ?? authCode,
-            alipayNickname,
-            alipayAvatar,
-            alipayOpenId,
-          );
-        }
+      if (params.containsKey('alipay_auth_code') ||
+          params.containsKey('auth_code') ||
+          params.containsKey('token')) {
+        final success = await _completeAlipayLoginFromParams(params);
 
         if (success && mounted) {
+          final authModel = Provider.of<AuthModel>(context, listen: false);
           Navigator.of(context).pop(true);
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -460,6 +519,7 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
             ),
           );
         } else if (mounted) {
+          final authModel = Provider.of<AuthModel>(context, listen: false);
           final error = authModel.error ?? '';
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/fabushi/lib/screens/meditation_room_screen.dart
+++ b/fabushi/lib/screens/meditation_room_screen.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -975,6 +977,10 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
     return Positioned.fill(
       child: LayoutBuilder(
         builder: (context, constraints) {
+          double safeClamp(double value, double lower, double upper) {
+            return value.clamp(lower, math.max(lower, upper)).toDouble();
+          }
+
           final size = Size(constraints.maxWidth, constraints.maxHeight);
           final title = practice?.title ?? '选择功课';
           final opensSelection =
@@ -993,7 +999,8 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
 
           final centerX = size.width / 2;
           final incenseLeft = centerX - incenseWidth / 2;
-          final bookLeft = centerX - bookWidth / 2;
+          final isWideDesktopScene =
+              size.width >= 720 && size.width / size.height > 1.18;
 
           // Anchor to the bottom of the screen, just above the bottom menu bar
           final bottomBarHeight = 160.0 * baseScale;
@@ -1001,7 +1008,27 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
 
           // Stack components vertically: Book -> Gap -> Incense -> Altar Base
           final incenseTop = altarBaseY - incenseHeight;
-          final bookTop = incenseTop - bookHeight - 16 * baseScale;
+          final buddhaHeight = (size.height * 0.54).clamp(310.0, 570.0);
+          final buddhaWidth = buddhaHeight * 0.75;
+          final buddhaRight = centerX + buddhaWidth / 2;
+          final bookLeft = isWideDesktopScene
+              ? safeClamp(
+                  buddhaRight + 28 * baseScale,
+                  16.0,
+                  size.width - bookWidth - 24.0,
+                )
+              : safeClamp(
+                  centerX - bookWidth / 2,
+                  12.0,
+                  size.width - bookWidth - 12.0,
+                );
+          final bookTop = isWideDesktopScene
+              ? safeClamp(
+                  altarBaseY - bookHeight - 8 * baseScale,
+                  24.0,
+                  size.height - bookHeight - 132.0,
+                )
+              : incenseTop - bookHeight - 16 * baseScale;
 
           // Side offerings (Fruit & Lamps)
           final lampWidth = 76.0 * baseScale;
@@ -1040,7 +1067,8 @@ class MeditationRoomScreenState extends State<MeditationRoomScreen>
                 ),
               ),
 
-              // Center Top: Sutra Book
+              // Sutra book stays outside the Buddha on desktop while retaining
+              // the original centered altar placement on narrow native screens.
               Positioned(
                 left: bookLeft,
                 top: bookTop,

--- a/fabushi/lib/screens/membership_screen.dart
+++ b/fabushi/lib/screens/membership_screen.dart
@@ -225,6 +225,19 @@ class _MembershipScreenState extends State<MembershipScreen>
       return;
     }
 
+    await authModel.refreshUserInfo();
+    final token = authModel.authToken;
+    if (!authModel.isLoggedIn || token == null || token.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('登录已过期，请重新登录后购买会员'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
     setState(() {
       _isLoading = true;
     });
@@ -252,7 +265,7 @@ class _MembershipScreenState extends State<MembershipScreen>
         return; // Apple IAP 通过回调处理结果，直接返回
       } else if (paymentMethod == 'stripe') {
         result = await _membershipService.createPaymentSession(
-          authModel.authToken!,
+          token,
           priceType,
         );
 
@@ -276,7 +289,7 @@ class _MembershipScreenState extends State<MembershipScreen>
         if (kIsWeb || _isDesktopPlatform()) {
           // Web和桌面端使用电脑网站支付
           result = await _membershipService.createAlipayWebOrder(
-            authModel.authToken!,
+            token,
             priceType,
           );
 
@@ -289,14 +302,11 @@ class _MembershipScreenState extends State<MembershipScreen>
           }
         } else {
           // 手机端使用支付宝APP支付
-          result = await _membershipService.createAlipayOrder(
-            authModel.authToken!,
-            priceType,
-          );
+          result = await _membershipService.createAlipayOrder(token, priceType);
 
           if (result['success'] == true) {
             // 调用支付宝APP支付
-            await _processAlipayAppPayment(result, authModel.authToken!);
+            await _processAlipayAppPayment(result, token);
           }
         }
       } else {
@@ -304,9 +314,14 @@ class _MembershipScreenState extends State<MembershipScreen>
       }
 
       if (result['success'] != true && mounted) {
+        final isAuthFailure =
+            result['statusCode'] == 401 ||
+            result['errorKey'] == 'INVALID_TOKEN';
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(result['message'] ?? '购买失败'),
+            content: Text(
+              isAuthFailure ? '登录已过期，请重新登录后购买会员' : result['message'] ?? '购买失败',
+            ),
             backgroundColor: Colors.red,
           ),
         );


### PR DESCRIPTION
## Summary
- Move the native desktop sutra book outside the estimated Buddha bounds while preserving narrow/mobile placement.
- Normalize Alipay web and deep-link callbacks so token/auth_code logins reuse the existing account before any one-click registration fallback.
- Refresh and capture the membership auth token before desktop payment, and show a relogin prompt for 401/invalid-token payment failures.

## Root Cause
Mac desktop uses the native `_buildNativeZenOfferings` path, not the web `ZenBuddha2DScene` path that was fixed earlier. The desktop Alipay callback parser also only handled stripped key/value deep links, while web code passed a string into a Map handler; that could make an existing Alipay account fall through as a new/trial login and then fail payment authentication.

## Validation
- `dart format fabushi/lib/screens/meditation_room_screen.dart fabushi/lib/screens/douyin_login_screen.dart fabushi/lib/models/auth_model.dart fabushi/lib/screens/membership_screen.dart`
- `git diff --check`
- `flutter analyze --no-fatal-infos fabushi/lib/screens/meditation_room_screen.dart fabushi/lib/screens/douyin_login_screen.dart fabushi/lib/models/auth_model.dart fabushi/lib/screens/membership_screen.dart`
- `flutter test test/services/auth_service_test.dart`
- Desktop/mobile geometry check: desktop book/Buddha overlap is 0; mobile placement remains centered.

## Local macOS Run Attempt
I attempted to build and start the macOS app locally. A writable cloned Flutter SDK and redirected CocoaPods cache got past the earlier cache permission errors, but Xcode/CoreSimulator initialization is blocked in this sandbox and reports the workspace as unavailable before it can build the app.