### PR TITLE
Restore macOS App Store sandbox entitlement

### DIFF
--- a/fabushi/macos/Runner/Release.entitlements
+++ b/fabushi/macos/Runner/Release.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.network.client</key>


### PR DESCRIPTION
Fixes the desktop release failure from run 27865326746.

App Store Connect rejected the exported macOS package because the main app executable did not include `com.apple.security.app-sandbox=true`. The recent OpenClaw update removed the sandbox entitlement from `fabushi/macos/Runner/Release.entitlements`, so the Release/App Store archive was signed without sandboxing.

This restores the sandbox entitlement for Release builds while leaving the existing network and file-selection entitlements intact.

Validation target after merge: rerun the Desktop installers workflow and confirm the macOS App Store upload passes, then the GitHub Release publishing job can proceed.