### PR TITLE
Fix macOS OpenClaw sandbox runtime updates

### DIFF
--- a/ai-backend/deploy/openclaw-runtime/README.md
+++ b/ai-backend/deploy/openclaw-runtime/README.md
@@ -43,3 +43,9 @@ GET https://ai.ombhrum.com/api/openclaw/runtime/files/<archive>
 The app validates `sha256`, checks that `nodeExecutable` and `cliEntrypoint`
 exist after extraction, then switches to the downloaded runtime. If anything
 fails, it keeps using the bundled runtime.
+
+macOS App Store/TestFlight builds run in the App Sandbox and must execute the
+bundled runtime signed with inherited sandbox entitlements. The backend therefore
+does not advertise `macos-*` runtime updates by default; set
+`OPENCLAW_RUNTIME_ENABLE_MACOS_UPDATES=true` only for a channel that can safely
+ship macOS-compatible signed child executables.

--- a/ai-backend/src/server.js
+++ b/ai-backend/src/server.js
@@ -23,6 +23,8 @@ const dataDir = process.env.DATA_DIR || path.join(rootDir, 'data');
 const resourcesDir = path.join(dataDir, 'resources');
 const openClawRuntimeUpdatesDir =
   process.env.OPENCLAW_RUNTIME_UPDATES_DIR || path.join(dataDir, 'openclaw-runtime');
+const openClawRuntimeEnableMacosUpdates =
+  process.env.OPENCLAW_RUNTIME_ENABLE_MACOS_UPDATES === 'true';
 const codexHomeDir = process.env.CODEX_HOME || path.join(dataDir, 'codex-home');
 const codexTempDir = process.env.CODEX_TMPDIR || path.join(dataDir, 'codex-tmp');
 const codexRuntimeDir = process.env.XDG_RUNTIME_DIR || path.join(dataDir, 'codex-runtime');
@@ -1900,6 +1902,20 @@ app.get(
         channel: readText(manifest.channel || latest.channel || 'stable'),
         updateAvailable: false,
         reason: platform ? 'platform-unavailable' : 'platform-required',
+        platform,
+        currentVersion,
+        appVersion,
+        latestVersion: version,
+      });
+    }
+
+    if (platform.startsWith('macos-') && !openClawRuntimeEnableMacosUpdates) {
+      return jsonResponse(res, 200, {
+        success: true,
+        schema: Number(manifest.schema || 1),
+        channel: readText(manifest.channel || latest.channel || 'stable'),
+        updateAvailable: false,
+        reason: 'macos-runtime-updates-disabled',
         platform,
         currentVersion,
         appVersion,

--- a/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
@@ -674,18 +674,76 @@ class OpenClawRuntime {
         'gatewayArgs': spec.gatewayArgs,
       },
     );
-    var effectiveSpec =
-        await _loadActiveDownloadedSpec(platformKey, fallbackSpec: spec) ??
-        spec;
-    if (checkUpdates) {
+    final allowDownloadedRuntime = await _allowDownloadedRuntime(platformKey);
+    var effectiveSpec = spec;
+    if (allowDownloadedRuntime) {
+      effectiveSpec =
+          await _loadActiveDownloadedSpec(platformKey, fallbackSpec: spec) ??
+          spec;
+    } else {
+      await _clearActiveDownloadedRuntimeSpec(
+        platformKey: platformKey,
+        reason: 'macos-sandbox',
+      );
+    }
+    if (checkUpdates && allowDownloadedRuntime) {
       effectiveSpec =
           await _maybeInstallRuntimeUpdate(
             platformKey: platformKey,
             currentSpec: effectiveSpec,
           ) ??
           effectiveSpec;
+    } else if (checkUpdates) {
+      _diag(
+        'runtime-update.skip-disabled',
+        data: {'platformKey': platformKey, 'reason': 'macos-sandbox'},
+      );
     }
     return effectiveSpec;
+  }
+
+  Future<bool> _allowDownloadedRuntime(String platformKey) async {
+    if (!Platform.isMacOS) return true;
+
+    final support = await getApplicationSupportDirectory();
+    final sandboxContainerId =
+        Platform.environment['APP_SANDBOX_CONTAINER_ID']?.trim() ?? '';
+    final pathLooksSandboxed = p
+        .split(p.normalize(support.path))
+        .contains('Containers');
+    final sandboxed = sandboxContainerId.isNotEmpty || pathLooksSandboxed;
+    if (!sandboxed) return true;
+
+    // App Store/TestFlight sandboxed apps cannot reliably execute downloaded
+    // Mach-O payloads. Use the bundled runtime that was signed with inherited
+    // sandbox entitlements during packaging.
+    _diag(
+      'runtime-update.disabled-macos-sandbox',
+      data: {
+        'platformKey': platformKey,
+        'supportPath': support.path,
+        'hasSandboxContainerId': sandboxContainerId.isNotEmpty,
+      },
+    );
+    return false;
+  }
+
+  Future<void> _clearActiveDownloadedRuntimeSpec({
+    required String platformKey,
+    required String reason,
+  }) async {
+    final saved = await AppSettings.getOpenClawActiveRuntimeSpec();
+    if (saved == null) return;
+    await AppSettings.clearOpenClawActiveRuntimeSpec();
+    _diag(
+      'runtime-update.active-cleared',
+      data: {
+        'platformKey': platformKey,
+        'reason': reason,
+        'version': saved['version']?.toString(),
+        'downloaded': saved['downloaded'] == true,
+      },
+    );
   }
 
   Future<_OpenClawBundleSpec?> _loadActiveDownloadedSpec(
@@ -1380,6 +1438,11 @@ class OpenClawRuntime {
       xattrResult = await Process.run('/usr/bin/xattr', [
         '-dr',
         'com.apple.quarantine',
+        runtimeDir.path,
+      ]);
+      await Process.run('/usr/bin/xattr', [
+        '-dr',
+        'com.apple.provenance',
         runtimeDir.path,
       ]);
     }


### PR DESCRIPTION
## Summary
- keep macOS sandbox builds on the bundled signed OpenClaw runtime
- clear stale downloaded runtime specs when sandboxed macOS launches
- disable backend macOS runtime update advertising by default

## Verification
- npm run check (ai-backend)
- git diff --check for changed files

Note: Flutter/Dart CLI is not installed in this local shell, so Flutter analyze/test was not run locally.