### PR TITLE
[codex] fix alipay account identity

### DIFF
--- a/fabushi/lib/models/auth_model.dart
+++ b/fabushi/lib/models/auth_model.dart
@@ -59,7 +59,10 @@ class User {
           ? DateTime.parse(json['membershipExpiry'])
           : null,
       isAdmin: json['isAdmin'] ?? false,
-      alipayUserId: json['alipayUserId'],
+      alipayUserId:
+          json['alipayProviderSubject'] ??
+          json['alipay_provider_subject'] ??
+          json['alipayUserId'],
       nickname: json['nickname'],
       avatar: json['avatar'],
       phoneNumber: json['phoneNumber'],
@@ -284,7 +287,11 @@ class AuthModel extends ChangeNotifier {
       membershipType: membershipType,
       membershipExpiry: membershipExpiry,
       isAdmin: isAdmin,
-      alipayUserId: userJson['alipayUserId'] ?? userJson['alipay_user_id'],
+      alipayUserId:
+          userJson['alipayProviderSubject'] ??
+          userJson['alipay_provider_subject'] ??
+          userJson['alipayUserId'] ??
+          userJson['alipay_user_id'],
       nickname: userJson['nickname'],
       avatar: userJson['avatar'],
       phoneNumber:
@@ -598,12 +605,12 @@ class AuthModel extends ChangeNotifier {
     }
   }
 
-  Future<bool> alipayLogin(String authCode, {String? state}) async {
+  Future<bool> alipayLogin(String authCode) async {
     _setLoading(true);
     _clearError();
 
     try {
-      final result = await _alipayAuthService.alipayLogin(authCode, state);
+      final result = await _alipayAuthService.alipayLogin(authCode, null);
 
       if (result['success'] == true) {
         _token = result['token'];
@@ -657,20 +664,22 @@ class AuthModel extends ChangeNotifier {
   }
 
   Future<bool> alipayOneClickRegister(
-    String alipayUserId,
+    String alipayProviderSubject,
     String? nickname,
     String? avatar, [
-    String? alipayOpenId,
+    String? alipaySubjectType,
   ]) async {
     _setLoading(true);
     _clearError();
 
     try {
-      debugPrint('支付宝一键注册开始: alipayUserId=$alipayUserId');
+      debugPrint(
+        '支付宝一键注册开始: providerSubject=$alipayProviderSubject, subjectType=$alipaySubjectType',
+      );
 
       final result = await _alipayAuthService.alipayOneClickRegister(
-        alipayUserId: alipayUserId,
-        alipayOpenId: alipayOpenId,
+        alipayProviderSubject: alipayProviderSubject,
+        alipaySubjectType: alipaySubjectType,
         nickname: nickname,
         avatar: avatar,
       );
@@ -947,14 +956,22 @@ class AuthModel extends ChangeNotifier {
             ? username
             : (alipayUser?['nick_name'] ??
                   '支付宝用户_${DateTime.now().millisecondsSinceEpoch}');
+        final alipayProviderSubject =
+            alipayUser?['providerSubject'] ??
+            alipayUser?['provider_subject'] ??
+            alipayUser?['user_id'] ??
+            authCode;
+        final alipaySubjectType =
+            alipayUser?['subjectType'] ?? alipayUser?['subject_type'];
         final autoEmail = email.isNotEmpty
             ? email
-            : '${alipayUser?['user_id'] ?? authCode}@alipay.user';
+            : '$alipayProviderSubject@alipay.user';
 
         debugPrint('支付宝新用户自动注册: username=$autoUsername, email=$autoEmail');
 
         final result = await _alipayAuthService.alipayRegister(
-          alipayUserId: alipayUser?['user_id'] ?? authCode,
+          alipayProviderSubject: alipayProviderSubject,
+          alipaySubjectType: alipaySubjectType,
           username: autoUsername,
           password: '',
           email: autoEmail,

--- a/fabushi/lib/models/user_model.dart
+++ b/fabushi/lib/models/user_model.dart
@@ -57,16 +57,24 @@ class UserModel {
   factory UserModel.fromJson(Map<String, dynamic> json) {
     return UserModel(
       username: json['username'] as String,
-      userNo: _parseOptionalInt(json['userNo'] ?? json['user_no'] ?? json['id']),
+      userNo: _parseOptionalInt(
+        json['userNo'] ?? json['user_no'] ?? json['id'],
+      ),
       email: json['email'] as String?,
       emailVerified: json['emailVerified'] as bool? ?? false,
       createdAt: json['createdAt'] as String,
-      usernameChangedAt: json['usernameChangedAt'] as String? ?? json['username_changed_at'] as String?,
+      usernameChangedAt:
+          json['usernameChangedAt'] as String? ??
+          json['username_changed_at'] as String?,
       wechatOpenid: json['wechatOpenid'] as String?,
       wechatNickname: json['wechatNickname'] as String?,
       wechatHeadimgurl: json['wechatHeadimgurl'] as String?,
       wechatBoundAt: json['wechatBoundAt'] as String?,
-      alipayUserId: json['alipayUserId'] as String?,
+      alipayUserId:
+          (json['alipayProviderSubject'] ??
+                  json['alipay_provider_subject'] ??
+                  json['alipayUserId'])
+              as String?,
       alipayNickname: json['alipayNickname'] as String?,
       alipayAvatar: json['alipayAvatar'] as String?,
       alipayBoundAt: json['alipayBoundAt'] as String?,

--- a/fabushi/lib/screens/alipay_web_login_screen.dart
+++ b/fabushi/lib/screens/alipay_web_login_screen.dart
@@ -43,8 +43,21 @@ class _AlipayWebLoginScreenState extends State<AlipayWebLoginScreen> {
             setState(() => _errorMessage = error.description);
           },
         ),
-      )
-      ..loadRequest(Uri.parse(widget.loginUrl));
+      );
+
+    _loadLoginUrlWithFreshWebViewSession();
+  }
+
+  Future<void> _loadLoginUrlWithFreshWebViewSession() async {
+    try {
+      await WebViewCookieManager().clearCookies();
+      await _controller.clearLocalStorage();
+    } catch (e) {
+      debugPrint('清理支付宝网页登录缓存失败: $e');
+    }
+
+    if (!mounted) return;
+    await _controller.loadRequest(Uri.parse(widget.loginUrl));
   }
 
   NavigationDecision _handleNavigationRequest(NavigationRequest request) {

--- a/fabushi/lib/screens/douyin_login_screen.dart
+++ b/fabushi/lib/screens/douyin_login_screen.dart
@@ -38,6 +38,7 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
   StreamSubscription? _urlSubscription;
   final PlatformService _platformService = PlatformServiceFactory.create();
   bool _isAlipayWebLoginOpen = false;
+  String? _pendingAlipayState;
 
   @override
   void initState() {
@@ -123,6 +124,11 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
   bool get _isMobile {
     if (kIsWeb) return false;
     return Platform.isIOS || Platform.isAndroid;
+  }
+
+  bool get _shouldUseEmbeddedAlipayWebLogin {
+    if (kIsWeb) return false;
+    return Platform.isIOS || Platform.isAndroid || Platform.isMacOS;
   }
 
   Future<void> _handleAlipayLogin() async {
@@ -223,12 +229,19 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
           // 新用户需要注册
           final alipayUser = loginResult['alipayUser'];
           if (alipayUser != null) {
+            final alipayProviderSubject =
+                alipayUser['providerSubject'] ??
+                alipayUser['provider_subject'] ??
+                alipayUser['userId'] ??
+                '';
+            final alipaySubjectType =
+                alipayUser['subjectType'] ?? alipayUser['subject_type'];
             // 自动一键注册
             final registerResult = await authModel.alipayOneClickRegister(
-              alipayUser['userId'] ?? '',
+              alipayProviderSubject,
               alipayUser['nickname'],
               alipayUser['avatar'],
-              alipayUser['openId'] ?? alipayUser['open_id'],
+              alipaySubjectType,
             );
 
             if (registerResult && mounted) {
@@ -304,11 +317,13 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
     }
 
     final result = await authModel.getAlipayLoginUrl(platform: platform);
+    if (!mounted) return;
 
     if (result['success'] == true && result['loginUrl'] != null) {
       final loginUrl = result['loginUrl'] as String;
+      _pendingAlipayState = result['state']?.toString();
 
-      if (_isMobile) {
+      if (_shouldUseEmbeddedAlipayWebLogin) {
         debugPrint('使用内置 WebView 打开支付宝网页授权');
         _isAlipayWebLoginOpen = true;
         final callbackUrl = await Navigator.of(context).push<String>(
@@ -324,6 +339,7 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
           debugPrint('内置 WebView 捕获到 deep link: $callbackUrl');
           await _handleDeepLinkAlipayCallback(callbackUrl);
         } else {
+          _pendingAlipayState = null;
           setState(() => _isLoading = false);
         }
       } else {
@@ -332,9 +348,18 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
           await launchUrl(uri, mode: LaunchMode.externalApplication);
         } else if (kIsWeb) {
           _platformService.openUrl(loginUrl, '_self');
+        } else {
+          _pendingAlipayState = null;
+          if (mounted) {
+            setState(() {
+              _isLoading = false;
+              _errorMessage = '无法打开支付宝登录页面';
+            });
+          }
         }
       }
     } else {
+      _pendingAlipayState = null;
       if (mounted) {
         setState(() {
           _isLoading = false;
@@ -344,11 +369,40 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
     }
   }
 
+  bool _isExpectedAlipayCallback(Map<String, String> params) {
+    final callbackState = params['state'];
+    final pendingState = _pendingAlipayState;
+    if (pendingState == null || pendingState.isEmpty) {
+      debugPrint('忽略支付宝回调：当前没有待处理的登录请求');
+      return false;
+    }
+    if (callbackState == null || callbackState.isEmpty) {
+      debugPrint('忽略支付宝回调：缺少state');
+      return false;
+    }
+    if (callbackState != pendingState) {
+      debugPrint('忽略支付宝回调：state不匹配');
+      return false;
+    }
+    return true;
+  }
+
+  void _clearPendingAlipayState() {
+    _pendingAlipayState = null;
+  }
+
   Future<void> _handleAlipayCallback(Map<String, dynamic> params) async {
     try {
-      final success = await _completeAlipayLoginFromParams(
-        params.map((key, value) => MapEntry(key, value?.toString() ?? '')),
+      final normalizedParams = params.map(
+        (key, value) => MapEntry(key.toString(), value?.toString() ?? ''),
       );
+      if (!_isExpectedAlipayCallback(normalizedParams)) {
+        if (mounted) setState(() => _isLoading = false);
+        return;
+      }
+      _clearPendingAlipayState();
+
+      final success = await _completeAlipayLoginFromParams(normalizedParams);
 
       if (success && mounted) {
         Navigator.of(context).pop(true);
@@ -436,26 +490,50 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
     final token = params['token'];
     final username = params['username'];
     final authCode = params['alipay_auth_code'] ?? params['auth_code'];
-    final state = params['state'];
-    final alipayUserId = params['alipay_user_id'] ?? params['user_id'];
-    final alipayOpenId = params['alipay_open_id'] ?? params['open_id'];
+    final alipayProviderSubject =
+        params['alipay_provider_subject'] ??
+        params['provider_subject'] ??
+        params['alipay_user_id'] ??
+        params['user_id'];
+    final alipaySubjectType =
+        params['alipay_subject_type'] ?? params['subject_type'];
     final alipayNickname = params['alipay_nickname'] ?? params['nick_name'];
     final alipayAvatar = params['alipay_avatar'] ?? params['avatar'];
+    final userNo = params['user_no'] ?? params['userNo'];
 
     if (token != null && token.isNotEmpty) {
       await authModel.loginWithToken(
         token,
         username?.isNotEmpty == true
             ? username!
-            : alipayUserId?.isNotEmpty == true
-            ? alipayUserId!
+            : alipayProviderSubject?.isNotEmpty == true
+            ? alipayProviderSubject!
             : 'alipay_user',
+        userJson: {
+          if (username != null && username.isNotEmpty) 'username': username,
+          if (userNo != null && userNo.isNotEmpty) 'userNo': userNo,
+          if (alipayProviderSubject != null &&
+              alipayProviderSubject.isNotEmpty) ...{
+            'alipayProviderSubject': alipayProviderSubject,
+            'alipayUserId': alipayProviderSubject,
+          },
+          if (alipaySubjectType != null && alipaySubjectType.isNotEmpty)
+            'alipaySubjectType': alipaySubjectType,
+          if (alipayNickname != null && alipayNickname.isNotEmpty) ...{
+            'nickname': alipayNickname,
+            'alipayNickname': alipayNickname,
+          },
+          if (alipayAvatar != null && alipayAvatar.isNotEmpty) ...{
+            'avatar': alipayAvatar,
+            'alipayAvatar': alipayAvatar,
+          },
+        },
       );
       return authModel.isLoggedIn;
     }
 
     if (authCode != null && authCode.isNotEmpty) {
-      final success = await authModel.alipayLogin(authCode, state: state);
+      final success = await authModel.alipayLogin(authCode);
       if (success) return true;
     }
 
@@ -465,12 +543,14 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
         params['needsRegistration'] == 'true' ||
         params['needs_registration'] == 'true';
 
-    if (isNewUser && alipayUserId != null && alipayUserId.isNotEmpty) {
+    if (isNewUser &&
+        alipayProviderSubject != null &&
+        alipayProviderSubject.isNotEmpty) {
       return authModel.alipayOneClickRegister(
-        alipayUserId,
+        alipayProviderSubject,
         alipayNickname,
         alipayAvatar,
-        alipayOpenId,
+        alipaySubjectType,
       );
     }
 
@@ -480,7 +560,7 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
   Future<void> _handleDeepLinkAlipayCallback(String url) async {
     debugPrint('收到深度链接支付宝回调: $url');
 
-    if (_isMobile && _isAlipayWebLoginOpen && mounted) {
+    if (_shouldUseEmbeddedAlipayWebLogin && _isAlipayWebLoginOpen && mounted) {
       _isAlipayWebLoginOpen = false;
       if (Navigator.of(context).canPop()) {
         Navigator.of(context).pop();
@@ -490,6 +570,17 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
 
     try {
       final params = _parseAlipayCallbackParams(url);
+
+      if (params.containsKey('error') ||
+          params.containsKey('alipay_auth_code') ||
+          params.containsKey('auth_code') ||
+          params.containsKey('token')) {
+        if (!_isExpectedAlipayCallback(params)) {
+          if (mounted) setState(() => _isLoading = false);
+          return;
+        }
+        _clearPendingAlipayState();
+      }
 
       if (params.containsKey('error')) {
         final errorMessage = params['error_message'] ?? '支付宝登录失败';

--- a/fabushi/lib/services/alipay_auth_service.dart
+++ b/fabushi/lib/services/alipay_auth_service.dart
@@ -185,9 +185,10 @@ class AlipayAuthService {
 
   /// 支付宝账号注册（新用户）
   Future<Map<String, dynamic>> alipayRegister({
-    required String alipayUserId,
+    required String alipayProviderSubject,
     required String username,
     required String password,
+    String? alipaySubjectType,
     String? nickname,
     String? avatar,
     String? email,
@@ -198,7 +199,9 @@ class AlipayAuthService {
         Uri.parse('$url/api/auth/alipay/register'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({
-          'alipayUserId': alipayUserId,
+          'alipayProviderSubject': alipayProviderSubject,
+          if (alipaySubjectType != null && alipaySubjectType.isNotEmpty)
+            'alipaySubjectType': alipaySubjectType,
           'username': username,
           'password': password,
           'nickname': nickname,
@@ -222,8 +225,8 @@ class AlipayAuthService {
 
   /// 支付宝一键注册（自动生成用户名和邮箱）
   Future<Map<String, dynamic>> alipayOneClickRegister({
-    required String alipayUserId,
-    String? alipayOpenId,
+    required String alipayProviderSubject,
+    String? alipaySubjectType,
     String? nickname,
     String? avatar,
   }) async {
@@ -233,9 +236,9 @@ class AlipayAuthService {
         Uri.parse('$url/api/auth/alipay/register'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({
-          'alipayUserId': alipayUserId,
-          if (alipayOpenId != null && alipayOpenId.isNotEmpty)
-            'alipayOpenId': alipayOpenId,
+          'alipayProviderSubject': alipayProviderSubject,
+          if (alipaySubjectType != null && alipaySubjectType.isNotEmpty)
+            'alipaySubjectType': alipaySubjectType,
           'alipayNickname': nickname,
           'alipayAvatar': avatar,
           'oneClick': true,

--- a/fabushi/lib/services/auth_service.dart
+++ b/fabushi/lib/services/auth_service.dart
@@ -92,7 +92,11 @@ class AuthService {
       wechatNickname: user['wechatNickname'] as String?,
       wechatHeadimgurl: user['wechatHeadimgurl'] as String?,
       wechatBoundAt: user['wechatBoundAt'] as String?,
-      alipayUserId: user['alipayUserId'] as String?,
+      alipayUserId:
+          (user['alipayProviderSubject'] ??
+                  user['alipay_provider_subject'] ??
+                  user['alipayUserId'])
+              as String?,
       alipayNickname: user['alipayNickname'] as String?,
       alipayAvatar: user['alipayAvatar'] as String?,
       alipayBoundAt: user['alipayBoundAt'] as String?,
@@ -241,7 +245,12 @@ class AuthService {
           _optionalString(data['wechatBoundAt'] ?? data['wechat_bound_at']) ??
           fallbackUser?.wechatBoundAt,
       alipayUserId:
-          _optionalString(data['alipayUserId'] ?? data['alipay_user_id']) ??
+          _optionalString(
+            data['alipayProviderSubject'] ??
+                data['alipay_provider_subject'] ??
+                data['alipayUserId'] ??
+                data['alipay_user_id'],
+          ) ??
           fallbackUser?.alipayUserId,
       alipayNickname:
           _optionalString(data['alipayNickname'] ?? data['alipay_nickname']) ??
@@ -638,18 +647,28 @@ class AuthService {
 
   Future<Map<String, dynamic>> deleteAccount() async {
     if (_currentToken == null) {
+      await _loadStoredAuth();
+    }
+
+    final activeToken = _currentToken;
+    if (activeToken == null || activeToken.isEmpty) {
       return {'success': false, 'error': '未登录'};
     }
+
     try {
       final response = await HttpService.delete(
         AppConfig.deleteAccountUrl,
         useAuth: true,
+        authToken: activeToken,
       );
       if (response.statusCode == 200 || response.statusCode == 204) {
         return {'success': true, 'message': '注销成功'};
       }
 
-      return _failureFromResponse(response, '注销失败 (HTTP ${response.statusCode})');
+      return _failureFromResponse(
+        response,
+        '注销失败 (HTTP ${response.statusCode})',
+      );
     } catch (e) {
       print('注销账户请求失败: $e');
       return {'success': false, 'error': '网络错误，请检查网络连接'};
@@ -702,11 +721,19 @@ class AuthService {
 
           final userInfo = UserModel(
             username: data['username'] ?? userJson?['username'] ?? '',
-            userNo: _parseOptionalInt(userJson?['userNo'] ?? userJson?['user_no'] ?? userJson?['id'] ?? data['userNo'] ?? data['userId']),
+            userNo: _parseOptionalInt(
+              userJson?['userNo'] ??
+                  userJson?['user_no'] ??
+                  userJson?['id'] ??
+                  data['userNo'] ??
+                  data['userId'],
+            ),
             email: userJson?['email'] ?? email ?? '',
             emailVerified: true,
             createdAt: DateTime.now().toIso8601String(),
-            usernameChangedAt: userJson?['usernameChangedAt'] ?? userJson?['username_changed_at'],
+            usernameChangedAt:
+                userJson?['usernameChangedAt'] ??
+                userJson?['username_changed_at'],
             membership: MembershipInfo(
               type: userJson?['membership']?['type'] ?? 'trial',
               isActive: true,
@@ -760,11 +787,19 @@ class AuthService {
 
           final userInfo = UserModel(
             username: data['username'] ?? userJson?['username'] ?? '',
-            userNo: _parseOptionalInt(userJson?['userNo'] ?? userJson?['user_no'] ?? userJson?['id'] ?? data['userNo'] ?? data['userId']),
+            userNo: _parseOptionalInt(
+              userJson?['userNo'] ??
+                  userJson?['user_no'] ??
+                  userJson?['id'] ??
+                  data['userNo'] ??
+                  data['userId'],
+            ),
             email: userJson?['email'] ?? '',
             emailVerified: true,
             createdAt: DateTime.now().toIso8601String(),
-            usernameChangedAt: userJson?['usernameChangedAt'] ?? userJson?['username_changed_at'],
+            usernameChangedAt:
+                userJson?['usernameChangedAt'] ??
+                userJson?['username_changed_at'],
             membership: MembershipInfo(
               type: userJson?['membership']?['type'] ?? 'trial',
               isActive: true,

--- a/fabushi/lib/services/http_service.dart
+++ b/fabushi/lib/services/http_service.dart
@@ -24,14 +24,17 @@ class HttpService {
   }
 
   // 获取认证头
-  static Future<Map<String, String>> _getHeaders({bool useAuth = false}) async {
+  static Future<Map<String, String>> _getHeaders({
+    bool useAuth = false,
+    String? authToken,
+  }) async {
     final headers = <String, String>{
       'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
     if (useAuth) {
-      final token = await _getStoredToken();
+      final token = authToken ?? await _getStoredToken();
       if (token != null) {
         headers['Authorization'] = 'Bearer $token';
         print(
@@ -208,9 +211,10 @@ class HttpService {
   static Future<http.Response> delete(
     String url, {
     bool useAuth = false,
+    String? authToken,
   }) async {
     try {
-      final headers = await _getHeaders(useAuth: useAuth);
+      final headers = await _getHeaders(useAuth: useAuth, authToken: authToken);
 
       return await _retryRequest(
         () => _client
@@ -358,7 +362,9 @@ class HttpService {
       }
       return '未知错误';
     } catch (e) {
-      return response.body.trim().isNotEmpty ? response.body.trim() : '服务器响应格式错误';
+      return response.body.trim().isNotEmpty
+          ? response.body.trim()
+          : '服务器响应格式错误';
     }
   }
 

--- a/fabushi/lib/services/platform_service_native.dart
+++ b/fabushi/lib/services/platform_service_native.dart
@@ -24,6 +24,9 @@ abstract class PlatformService {
 
 /// 非Web平台服务实现
 class NativePlatformService implements PlatformService {
+  static final Set<String> _handledInitialLinks = <String>{};
+  static final Set<String> _dispatchedLinks = <String>{};
+
   MethodChannel? _channel;
   Function(dynamic)? _messageHandler;
   late final AppLinks _appLinks;
@@ -72,7 +75,7 @@ class NativePlatformService implements PlatformService {
       final uri = await _appLinks.getInitialLink();
       if (uri != null) {
         debugPrint('NativePlatformService: 检测到初始深度链接: $uri');
-        _handleDeepLink(uri.toString());
+        _handleDeepLink(uri.toString(), isInitialLink: true);
       }
     } catch (e) {
       debugPrint('NativePlatformService: 检查初始链接失败: $e');
@@ -80,13 +83,27 @@ class NativePlatformService implements PlatformService {
   }
 
   // 处理深度链接
-  void _handleDeepLink(String url) {
+  void _handleDeepLink(String url, {bool isInitialLink = false}) {
     debugPrint('NativePlatformService: 处理深度链接URL: $url');
 
     // Tobias SDK 在 Android 上回调到 pubspec 里声明的 url_scheme。
     if (url.startsWith('com.ombhrum.fabushi://') ||
         url.startsWith('globaldharma://') ||
         url.startsWith('fabushi://')) {
+      if (isInitialLink && !_handledInitialLinks.add(url)) {
+        debugPrint('NativePlatformService: 忽略已处理过的初始深度链接');
+        return;
+      }
+
+      if (!_dispatchedLinks.add(url)) {
+        debugPrint('NativePlatformService: 忽略重复深度链接');
+        return;
+      }
+
+      if (_dispatchedLinks.length > 20) {
+        _dispatchedLinks.remove(_dispatchedLinks.first);
+      }
+
       if (_messageHandler != null) {
         _messageHandler!(url);
       }

--- a/fabushi/lib/widgets/app_wrapper.dart
+++ b/fabushi/lib/widgets/app_wrapper.dart
@@ -265,7 +265,8 @@ class _AppWrapperState extends State<AppWrapper> {
     await app_update.loadLibrary();
     await app_update_dialog.loadLibrary();
 
-    final decision = await app_update.AppUpdateService.instance.checkForUpdate();
+    final decision = await app_update.AppUpdateService.instance
+        .checkForUpdate();
     if (!mounted || decision == null) {
       return;
     }
@@ -579,7 +580,9 @@ class _AppWrapperState extends State<AppWrapper> {
           if (params['alipay_auth_code'] != null &&
               params['needs_binding'] == 'true') {
             final authCode = params['alipay_auth_code']!;
-            final userId = params['alipay_user_id'];
+            final providerSubject =
+                params['alipay_provider_subject'] ?? params['alipay_user_id'];
+            final subjectType = params['alipay_subject_type'];
             final nickname = params['alipay_nickname'] ?? '';
             final avatar = params['alipay_avatar'] ?? '';
 
@@ -588,7 +591,9 @@ class _AppWrapperState extends State<AppWrapper> {
                 '/alipay-binding',
                 arguments: {
                   'alipayAuthCode': authCode,
-                  'alipayUserId': userId,
+                  'alipayProviderSubject': providerSubject,
+                  'alipaySubjectType': subjectType,
+                  'alipayUserId': providerSubject,
                   'alipayNickname': nickname,
                   'alipayAvatar': avatar,
                 },
@@ -604,7 +609,35 @@ class _AppWrapperState extends State<AppWrapper> {
           final loginMethod = params['login_method'] ?? 'traditional';
 
           if (token != null && username != null) {
-            await authModel.setTokenDirectly(token, username);
+            final userNo = params['user_no'];
+            final alipayNickname = params['alipay_nickname'];
+            final alipayAvatar = params['alipay_avatar'];
+            final alipayProviderSubject =
+                params['alipay_provider_subject'] ?? params['alipay_user_id'];
+            final alipaySubjectType = params['alipay_subject_type'];
+            await authModel.setTokenDirectly(
+              token,
+              username,
+              userJson: {
+                'username': username,
+                if (userNo != null && userNo.isNotEmpty) 'userNo': userNo,
+                if (alipayProviderSubject != null &&
+                    alipayProviderSubject.isNotEmpty) ...{
+                  'alipayProviderSubject': alipayProviderSubject,
+                  'alipayUserId': alipayProviderSubject,
+                },
+                if (alipaySubjectType != null && alipaySubjectType.isNotEmpty)
+                  'alipaySubjectType': alipaySubjectType,
+                if (alipayNickname != null && alipayNickname.isNotEmpty) ...{
+                  'nickname': alipayNickname,
+                  'alipayNickname': alipayNickname,
+                },
+                if (alipayAvatar != null && alipayAvatar.isNotEmpty) ...{
+                  'avatar': alipayAvatar,
+                  'alipayAvatar': alipayAvatar,
+                },
+              },
+            );
             _platformService.replaceHistoryState('/');
 
             String welcomeMessage = '登录成功！欢迎 $username';

--- a/fabushi/web/alipay-login-functions.js
+++ b/fabushi/web/alipay-login-functions.js
@@ -3,6 +3,8 @@
 import { generateToken, verifyToken, jsonResponse, verifyPassword, createPasswordHash } from './auth-utils.js';
 import { importPrivateKey, importPublicKey, generateSign, verifySign } from './alipay-utils.js';
 import { calculateTrialEndDate } from './stripe-config.js';
+import { generateUserNo } from './src/services/external-numbers.js';
+import { serializeAccountUser } from './src/contracts/account-user.js';
 
 const DEFAULT_WORKER_URL = 'https://api.ombhrum.com';
 
@@ -221,11 +223,13 @@ async function getAlipayUserInfo(authCode, env) {
     }
 
     const { access_token, user_id, alipay_user_id, open_id } = tokenResult;
+    const subject = getAlipayProviderSubject(tokenResult);
     console.log('成功获取access_token和支付宝身份:', {
-      access_token,
-      user_id,
-      alipay_user_id,
-      open_id
+      hasAccessToken: !!access_token,
+      providerSubjectType: subject.type,
+      hasUserId: !!user_id,
+      hasOpenId: !!open_id,
+      hasDeprecatedAlipayUserId: !!alipay_user_id
     });
 
     // 第二步：使用access_token获取用户详细信息
@@ -236,9 +240,12 @@ async function getAlipayUserInfo(authCode, env) {
       console.error('获取用户信息失败:', userInfoResult);
       // 如果获取用户信息失败，但至少返回了基本的user_id信息
       return {
-        user_id: user_id,
-        alipay_user_id: alipay_user_id || null,
+        user_id: subject.value,
+        provider_subject: subject.value,
+        subject_type: subject.type,
+        legacy_user_id: user_id || alipay_user_id || null,
         open_id: open_id || null,
+        alipay_user_id: alipay_user_id || user_id || null,
         nick_name: userInfoResult?.nick_name || '支付宝用户',
         avatar: userInfoResult?.avatar || '',
         province: userInfoResult?.province || '',
@@ -257,9 +264,12 @@ async function getAlipayUserInfo(authCode, env) {
     console.log('成功获取支付宝用户信息:', userInfo);
 
     return {
-      user_id: user_id, // 兼容旧客户端：优先真实 user_id，否则回退 open_id
-      alipay_user_id: alipay_user_id || null,
+      user_id: subject.value,
+      provider_subject: subject.value,
+      subject_type: subject.type,
+      legacy_user_id: user_id || alipay_user_id || null,
       open_id: open_id || null,
+      alipay_user_id: alipay_user_id || user_id || null,
       nick_name: userInfo.nick_name || '支付宝用户',
       avatar: userInfo.avatar || '',
       province: userInfo.province || '',
@@ -284,42 +294,104 @@ async function getUserById(env, userId) {
   return await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(normalizedUserId).first();
 }
 
-function uniqueAlipayIdentifiers(identity) {
-  const values = [];
-  if (identity && typeof identity === 'object') {
-    values.push(
-      identity.user_id,
-      identity.userId,
-      identity.alipayUserId,
-      identity.alipay_user_id,
-      identity.open_id,
-      identity.openId,
-      identity.alipayOpenId,
-      identity.alipay_open_id
-    );
-  } else {
-    values.push(identity);
+async function getUserByUserNo(env, userNo) {
+  const normalizedUserNo = Number(userNo);
+  if (!Number.isFinite(normalizedUserNo)) return null;
+  return await env.DB.prepare('SELECT * FROM users WHERE user_no = ?').bind(normalizedUserNo).first();
+}
+
+async function generateUniqueAlipayUserNo(env) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const candidate = generateUserNo();
+    const existing = await getUserByUserNo(env, candidate);
+    if (!existing) return candidate;
   }
-  return [...new Set(
-    values
-      .filter((value) => value !== undefined && value !== null)
-      .map((value) => String(value).trim())
-      .filter(Boolean)
-  )];
+  throw new Error('无法生成可用的 9 位用户号');
 }
 
-function getPrimaryAlipayUserId(identity) {
-  if (!identity || typeof identity !== 'object') return identity ? String(identity) : null;
-  return identity.alipay_user_id || identity.alipayUserId || identity.user_id || identity.userId || null;
+function normalizeIdentityValue(value) {
+  if (value === undefined || value === null) return null;
+  const normalized = String(value).trim();
+  return normalized || null;
 }
 
-function getAlipayOpenId(identity) {
-  if (!identity || typeof identity !== 'object') return null;
-  return identity.open_id || identity.openId || identity.alipayOpenId || identity.alipay_open_id || null;
+function getAlipayProviderSubject(identity) {
+  if (!identity || typeof identity !== 'object') {
+    return {
+      value: normalizeIdentityValue(identity),
+      type: 'user_id',
+      legacySubject: null
+    };
+  }
+
+  const explicitSubject = normalizeIdentityValue(
+    identity.provider_subject ||
+      identity.providerSubject ||
+      identity.alipayProviderSubject
+  );
+  if (explicitSubject) {
+    return {
+      value: explicitSubject,
+      type: identity.subject_type || identity.subjectType || identity.alipaySubjectType || 'provider_subject',
+      legacySubject: normalizeIdentityValue(identity.legacy_user_id || identity.legacyUserId)
+    };
+  }
+
+  const openId = normalizeIdentityValue(
+    identity.open_id ||
+      identity.openId ||
+      identity.alipayOpenId ||
+      identity.alipay_open_id
+  );
+  const userId = normalizeIdentityValue(
+    identity.user_id ||
+      identity.userId ||
+      identity.alipayUserId ||
+      identity.alipay_user_id
+  );
+
+  if (openId) {
+    return {
+      value: openId,
+      type: 'open_id',
+      legacySubject: userId && userId !== openId ? userId : null
+    };
+  }
+
+  return {
+    value: userId,
+    type: userId ? 'user_id' : null,
+    legacySubject: null
+  };
+}
+
+function getAlipayLookupSubjects(identity) {
+  const subject = getAlipayProviderSubject(identity);
+  return [subject.value, subject.legacySubject]
+    .map(normalizeIdentityValue)
+    .filter((value, index, values) => value && values.indexOf(value) === index);
+}
+
+function getAlipayPrimarySubject(identity) {
+  return getAlipayProviderSubject(identity).value;
+}
+
+function getAlipayRegistrationIdentity(payload) {
+  return {
+    provider_subject: payload.alipayProviderSubject || payload.providerSubject || payload.alipayUserId,
+    subject_type: payload.alipaySubjectType || payload.subjectType || (payload.alipayProviderSubject ? 'provider_subject' : 'user_id'),
+    legacy_user_id: payload.alipayLegacyUserId || payload.alipay_legacy_user_id || payload.legacyUserId || null
+  };
+}
+
+function sanitizeSyntheticEmailSubject(value) {
+  return String(value || 'unknown')
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .slice(0, 80);
 }
 
 async function getUserByAlipayBinding(env, identity) {
-  const identifiers = uniqueAlipayIdentifiers(identity);
+  const identifiers = getAlipayLookupSubjects(identity);
   if (identifiers.length === 0) return null;
 
   for (const identifier of identifiers) {
@@ -340,8 +412,8 @@ async function getUserByAlipayBinding(env, identity) {
 
   for (const identifier of identifiers) {
     const user = await env.DB.prepare(
-      'SELECT * FROM users WHERE alipay_user_id = ? OR alipay_open_id = ?'
-    ).bind(identifier, identifier).first();
+      'SELECT * FROM users WHERE alipay_user_id = ?'
+    ).bind(identifier).first();
     if (user) return user;
   }
 
@@ -351,8 +423,32 @@ async function getUserByAlipayBinding(env, identity) {
 async function getUserIdentityByUsername(env, username) {
   if (!username) return null;
   return await env.DB.prepare(
-    'SELECT id, username, email FROM users WHERE username = ?'
+    'SELECT * FROM users WHERE username = ?'
   ).bind(username).first();
+}
+
+function alipayCallbackUserParams(user, alipayUser) {
+  const userNo = user.user_no ?? user.id ?? '';
+  const subject = getAlipayProviderSubject(alipayUser);
+  return [
+    `user_no=${encodeURIComponent(String(userNo))}`,
+    `alipay_provider_subject=${encodeURIComponent(subject.value || '')}`,
+    `alipay_subject_type=${encodeURIComponent(subject.type || '')}`,
+    `alipay_user_id=${encodeURIComponent(subject.value || '')}`,
+    `alipay_nickname=${encodeURIComponent(alipayUser.nick_name || user.alipay_nickname || user.nickname || '')}`,
+    `alipay_avatar=${encodeURIComponent(alipayUser.avatar || user.alipay_avatar || user.avatar || '')}`,
+  ].join('&');
+}
+
+function alipayRegistrationParams(alipayUser) {
+  const subject = getAlipayProviderSubject(alipayUser);
+  return [
+    `alipay_provider_subject=${encodeURIComponent(subject.value || '')}`,
+    `alipay_subject_type=${encodeURIComponent(subject.type || '')}`,
+    `alipay_user_id=${encodeURIComponent(subject.value || '')}`,
+    `alipay_nickname=${encodeURIComponent(alipayUser.nick_name || '')}`,
+    `alipay_avatar=${encodeURIComponent(alipayUser.avatar || '')}`,
+  ].join('&');
 }
 
 async function writeEmailUsernameMapping(env, email, user) {
@@ -371,23 +467,18 @@ async function writeAlipayBinding(env, alipayUserId, user, replaceExisting = fal
 }
 
 async function writeAlipayBindings(env, identity, user) {
-  for (const identifier of uniqueAlipayIdentifiers(identity)) {
-    await writeAlipayBinding(env, identifier, user, true);
-  }
+  const providerSubject = getAlipayPrimarySubject(identity);
+  await writeAlipayBinding(env, providerSubject, user, true);
 }
 
 async function backfillAlipayIdentity(env, user, identity, profile = {}) {
   if (!user?.id) return;
 
   const updates = {};
-  const primaryUserId = getPrimaryAlipayUserId(identity);
-  const openId = getAlipayOpenId(identity);
+  const primaryUserId = getAlipayPrimarySubject(identity);
 
   if (primaryUserId && !user.alipay_user_id) {
     updates.alipay_user_id = primaryUserId;
-  }
-  if (openId && !user.alipay_open_id) {
-    updates.alipay_open_id = openId;
   }
   if (profile.nick_name && !user.alipay_nickname) {
     updates.alipay_nickname = profile.nick_name;
@@ -395,7 +486,7 @@ async function backfillAlipayIdentity(env, user, identity, profile = {}) {
   if (profile.avatar && !user.alipay_avatar) {
     updates.alipay_avatar = profile.avatar;
   }
-  if ((primaryUserId || openId) && !user.alipay_bound_at) {
+  if (primaryUserId && !user.alipay_bound_at) {
     updates.alipay_bound_at = new Date().toISOString();
   }
 
@@ -456,19 +547,23 @@ async function handleAlipayLogin(request, env) {
     if (user) {
       await backfillAlipayIdentity(env, user, alipayUser, alipayUser);
       const token = await generateToken({ id: user.id, username: user.username }, env);
+      const subject = getAlipayProviderSubject(alipayUser);
       return jsonResponse({
         success: true,
         token,
         username: user.username,
         userId: user.id,
+        userNo: user.user_no ?? user.id ?? null,
         isNewUser: false,
         loginMethod: 'alipay',
         alipayUser: {
-          userId: alipayUser.user_id,
-          openId: alipayUser.open_id,
+          userId: subject.value,
+          providerSubject: subject.value,
+          subjectType: subject.type,
           nickname: alipayUser.nick_name,
           avatar: alipayUser.avatar
-        }
+        },
+        user: serializeAccountUser(user)
       });
     }
 
@@ -488,26 +583,24 @@ async function handleAlipayLogin(request, env) {
 // 注册新用户（支持一键注册）
 async function registerAlipayUser(request, env) {
   try {
-    const { username, email, password, captcha, alipayUserId, alipayOpenId, alipayNickname, alipayAvatar, oneClick } = await request.json();
+    const payload = await request.json();
+    const { username, email, password, captcha, alipayNickname, alipayAvatar, oneClick } = payload;
+    const alipayIdentity = getAlipayRegistrationIdentity(payload);
+    const alipayProviderSubject = getAlipayPrimarySubject(alipayIdentity);
+    const alipaySubjectType = getAlipayProviderSubject(alipayIdentity).type;
 
     // 一键注册模式：自动生成用户名和邮箱
     if (oneClick === true) {
-      const existingUser = await getUserByAlipayBinding(env, {
-        user_id: alipayUserId,
-        alipayUserId,
-        open_id: alipayOpenId,
-        alipayOpenId,
-      });
+      if (!alipayProviderSubject) {
+        return jsonResponse({ error: '缺少支付宝用户标识' }, 400);
+      }
+
+      const existingUser = await getUserByAlipayBinding(env, alipayIdentity);
       if (existingUser) {
         await backfillAlipayIdentity(
           env,
           existingUser,
-          {
-            user_id: alipayUserId,
-            alipayUserId,
-            open_id: alipayOpenId,
-            alipayOpenId,
-          },
+          alipayIdentity,
           { nick_name: alipayNickname, avatar: alipayAvatar }
         );
         const token = await generateToken({ id: existingUser.id, username: existingUser.username }, env);
@@ -517,9 +610,13 @@ async function registerAlipayUser(request, env) {
           token,
           username: existingUser.username,
           userId: existingUser.id,
+          userNo: existingUser.user_no ?? existingUser.id ?? null,
           email: existingUser.email,
           isNewUser: false,
-          isOneClick: true
+          isOneClick: true,
+          alipayProviderSubject,
+          alipaySubjectType,
+          user: serializeAccountUser(existingUser)
         });
       }
 
@@ -541,17 +638,19 @@ async function registerAlipayUser(request, env) {
       }
 
       // 生成唯一邮箱（添加时间戳确保唯一性）
-      const autoEmail = `alipay_${alipayUserId}_${Date.now()}@alipay.user`;
+      const autoEmail = `alipay_${sanitizeSyntheticEmailSubject(alipayProviderSubject)}_${Date.now()}@alipay.user`;
 
       // 创建新用户
       const creds = await createPasswordHash('alipay_default_password'); // 默认密码
+      const userNo = await generateUniqueAlipayUserNo(env);
 
       const userData = {
         username: autoUsername,
+        userNo,
         email: autoEmail,
         password: creds.passwordHash,
-        alipayUserId: alipayUserId,
-        alipayOpenId: alipayOpenId,
+        alipayProviderSubject,
+        alipaySubjectType,
         alipayNickname: alipayNickname,
         alipayAvatar: alipayAvatar,
         alipayBoundAt: new Date().toISOString(),
@@ -564,17 +663,17 @@ async function registerAlipayUser(request, env) {
 
       await env.DB.prepare(`
         INSERT INTO users (
-          username, email, password_hash, salt, iterations, algo,
+          user_no, username, email, password_hash, salt, iterations, algo,
           email_verified, membership_type, membership_expires_at,
-          alipay_user_id, alipay_open_id, alipay_nickname, alipay_avatar,
+          alipay_user_id, alipay_nickname, alipay_avatar,
           created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).bind(
-        autoUsername, autoEmail, creds.passwordHash, creds.salt, creds.iterations, creds.algo,
+        userNo, autoUsername, autoEmail, creds.passwordHash, creds.salt, creds.iterations, creds.algo,
         1,
         'trial',
         calculateTrialEndDate().toISOString(),
-        alipayUserId, alipayOpenId || null, alipayNickname || '支付宝用户', alipayAvatar || null,
+        alipayProviderSubject, alipayNickname || '支付宝用户', alipayAvatar || null,
         new Date().toISOString(), new Date().toISOString()
       ).run();
 
@@ -586,12 +685,7 @@ async function registerAlipayUser(request, env) {
       await writeEmailUsernameMapping(env, autoEmail, createdUser);
       await writeAlipayBindings(
         env,
-        {
-          user_id: alipayUserId,
-          alipayUserId,
-          open_id: alipayOpenId,
-          alipayOpenId,
-        },
+        alipayIdentity,
         createdUser
       );
 
@@ -603,8 +697,12 @@ async function registerAlipayUser(request, env) {
         token,
         username: createdUser.username,
         userId: createdUser.id,
+        userNo: createdUser.user_no ?? userNo,
         email: createdUser.email,
-        isOneClick: true
+        isOneClick: true,
+        alipayProviderSubject,
+        alipaySubjectType,
+        user: serializeAccountUser(createdUser)
       });
     }
 
@@ -628,6 +726,10 @@ async function registerAlipayUser(request, env) {
       return jsonResponse({ error: '请输入有效的验证码' }, 400);
     }
 
+    if (!alipayProviderSubject) {
+      return jsonResponse({ error: '缺少支付宝用户标识' }, 400);
+    }
+
     const existingEmail = await env.DB.prepare(
       'SELECT user_id, username FROM email_username_mapping WHERE email = ?'
     ).bind(normalizedEmail).first();
@@ -635,29 +737,25 @@ async function registerAlipayUser(request, env) {
       return jsonResponse({ error: '该邮箱已被注册' }, 400);
     }
 
-    const existingAlipay = await getUserByAlipayBinding(env, {
-      user_id: alipayUserId,
-      alipayUserId,
-      open_id: alipayOpenId,
-      alipayOpenId,
-    });
+    const existingAlipay = await getUserByAlipayBinding(env, alipayIdentity);
     if (existingAlipay) {
       return jsonResponse({ error: '该支付宝账号已注册其他用户' }, 400);
     }
 
     const creds = await createPasswordHash(password);
+    const userNo = await generateUniqueAlipayUserNo(env);
 
     await env.DB.prepare(`
       INSERT INTO users (
-        username, email, password_hash, salt, iterations, algo,
+        user_no, username, email, password_hash, salt, iterations, algo,
         email_verified, membership_type,
-        alipay_user_id, alipay_open_id, alipay_nickname, alipay_avatar,
+        alipay_user_id, alipay_nickname, alipay_avatar,
         created_at, updated_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).bind(
-      normalizedUsername, normalizedEmail, creds.passwordHash, creds.salt, creds.iterations, creds.algo,
+      userNo, normalizedUsername, normalizedEmail, creds.passwordHash, creds.salt, creds.iterations, creds.algo,
       1, 'free',
-      alipayUserId, alipayOpenId || null, alipayNickname || '支付宝用户', alipayAvatar || null,
+      alipayProviderSubject, alipayNickname || '支付宝用户', alipayAvatar || null,
       new Date().toISOString(), new Date().toISOString()
     ).run();
 
@@ -669,12 +767,7 @@ async function registerAlipayUser(request, env) {
     await writeEmailUsernameMapping(env, normalizedEmail, createdUser);
     await writeAlipayBindings(
       env,
-      {
-        user_id: alipayUserId,
-        alipayUserId,
-        open_id: alipayOpenId,
-        alipayOpenId,
-      },
+      alipayIdentity,
       createdUser
     );
 
@@ -686,7 +779,11 @@ async function registerAlipayUser(request, env) {
       token,
       username: createdUser.username,
       userId: createdUser.id,
-      email: createdUser.email
+      userNo: createdUser.user_no ?? userNo,
+      email: createdUser.email,
+      alipayProviderSubject,
+      alipaySubjectType,
+      user: serializeAccountUser(createdUser)
     });
 
   } catch (error) {
@@ -698,9 +795,13 @@ async function registerAlipayUser(request, env) {
 // 发送注册验证码
 async function sendRegistrationCaptcha(request, env) {
   try {
-    const { alipayUserId, alipayOpenId, username, password, nickname, avatar, email } = await request.json();
+    const payload = await request.json();
+    const { username, password, nickname, avatar, email } = payload;
+    const alipayIdentity = getAlipayRegistrationIdentity(payload);
+    const alipayProviderSubject = getAlipayPrimarySubject(alipayIdentity);
+    const alipaySubjectType = getAlipayProviderSubject(alipayIdentity).type;
 
-    if (!alipayUserId || !username || !password) {
+    if (!alipayProviderSubject || !username || !password) {
       return jsonResponse({ error: '缺少必要参数' }, 400);
     }
 
@@ -723,30 +824,26 @@ async function sendRegistrationCaptcha(request, env) {
       }
     }
 
-    const existingBinding = await getUserByAlipayBinding(env, {
-      user_id: alipayUserId,
-      alipayUserId,
-      open_id: alipayOpenId,
-      alipayOpenId,
-    });
+    const existingBinding = await getUserByAlipayBinding(env, alipayIdentity);
     if (existingBinding) {
       return jsonResponse({ error: '该支付宝账号已注册其他用户' }, 400);
     }
 
     const creds = await createPasswordHash(password);
+    const userNo = await generateUniqueAlipayUserNo(env);
     const trialEndDate = calculateTrialEndDate();
 
     await env.DB.prepare(`
       INSERT INTO users (
-        username, email, password_hash, salt, iterations, algo,
+        user_no, username, email, password_hash, salt, iterations, algo,
         email_verified, membership_type, membership_expires_at,
-        alipay_user_id, alipay_open_id, alipay_nickname, alipay_avatar,
+        alipay_user_id, alipay_nickname, alipay_avatar,
         created_at, updated_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).bind(
-      normalizedUsername, normalizedEmail, creds.passwordHash, creds.salt, creds.iterations, creds.algo,
+      userNo, normalizedUsername, normalizedEmail, creds.passwordHash, creds.salt, creds.iterations, creds.algo,
       normalizedEmail ? 1 : 0, 'trial', trialEndDate.toISOString(),
-      alipayUserId, alipayOpenId || null, nickname || '支付宝用户', avatar || '',
+      alipayProviderSubject, nickname || '支付宝用户', avatar || '',
       new Date().toISOString(), new Date().toISOString()
     ).run();
 
@@ -760,12 +857,7 @@ async function sendRegistrationCaptcha(request, env) {
     }
     await writeAlipayBindings(
       env,
-      {
-        user_id: alipayUserId,
-        alipayUserId,
-        open_id: alipayOpenId,
-        alipayOpenId,
-      },
+      alipayIdentity,
       createdUser
     );
 
@@ -774,6 +866,10 @@ async function sendRegistrationCaptcha(request, env) {
       token,
       username: createdUser.username,
       userId: createdUser.id,
+      userNo: createdUser.user_no ?? userNo,
+      alipayProviderSubject,
+      alipaySubjectType,
+      user: serializeAccountUser(createdUser),
       message: '注册成功，支付宝账号已注册'
     }, 201);
 
@@ -879,14 +975,14 @@ async function handleAlipayCallback(request, env) {
       await backfillAlipayIdentity(env, user, alipayUser, alipayUser);
       const token = await generateToken({ id: user.id, username: user.username }, env);
       const redirectUrl = new URL('/index.html', request.url);
-      redirectUrl.hash = `token=${token}&username=${user.username}&login_method=alipay`;
+      redirectUrl.hash = `token=${token}&username=${encodeURIComponent(user.username)}&login_method=alipay&${alipayCallbackUserParams(user, alipayUser)}`;
 
       console.log('支付宝登录成功，直接跳转到Flutter主应用:', redirectUrl.toString());
       return Response.redirect(redirectUrl.toString(), 302);
     }
 
     const redirectUrl = new URL('/index.html', request.url);
-    redirectUrl.hash = `alipay_auth_code=${authCode}&alipay_user_id=${alipayUser.user_id}&alipay_open_id=${encodeURIComponent(alipayUser.open_id || '')}&alipay_nickname=${encodeURIComponent(alipayUser.nick_name || '')}&alipay_avatar=${encodeURIComponent(alipayUser.avatar || '')}&needs_registration=true&login_method=alipay`;
+    redirectUrl.hash = `alipay_auth_code=${authCode}&${alipayRegistrationParams(alipayUser)}&needs_registration=true&login_method=alipay`;
 
     console.log('新用户或未注册，直接跳转到Flutter主应用注册页面:', redirectUrl.toString());
     return Response.redirect(redirectUrl.toString(), 302);
@@ -940,11 +1036,11 @@ async function handleMacOSAlipayCallback(request, env) {
     if (user) {
       await backfillAlipayIdentity(env, user, alipayUser, alipayUser);
       const token = await generateToken({ id: user.id, username: user.username }, env);
-      const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state || ''}&token=${token}&username=${user.username}&isNewUser=false&loginMethod=alipay&alipay_user_id=${alipayUser.user_id}&alipay_open_id=${encodeURIComponent(alipayUser.open_id || '')}&alipay_nickname=${encodeURIComponent(alipayUser.nick_name || '')}&alipay_avatar=${encodeURIComponent(alipayUser.avatar || '')}`;
+      const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state || ''}&token=${token}&username=${encodeURIComponent(user.username)}&isNewUser=false&loginMethod=alipay&${alipayCallbackUserParams(user, alipayUser)}`;
       return Response.redirect(redirectUrl, 302);
     }
 
-    const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state || ''}&isNewUser=true&needsRegistration=true&loginMethod=alipay&alipay_user_id=${alipayUser.user_id}&alipay_open_id=${encodeURIComponent(alipayUser.open_id || '')}&alipay_nickname=${encodeURIComponent(alipayUser.nick_name || '')}&alipay_avatar=${encodeURIComponent(alipayUser.avatar || '')}`;
+    const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state || ''}&isNewUser=true&needsRegistration=true&loginMethod=alipay&${alipayRegistrationParams(alipayUser)}`;
     return Response.redirect(redirectUrl, 302);
   } catch (error) {
     console.error('macOS 支付宝回调处理失败:', error);
@@ -1042,12 +1138,21 @@ async function getAccessToken(authCode, env) {
       if (tokenResponse.access_token) {
         const alipayUserId = tokenResponse.user_id || null;
         const alipayOpenId = tokenResponse.open_id || null;
+        const deprecatedAlipayUserId = tokenResponse.alipay_user_id || null;
+        const subject = getAlipayProviderSubject({
+          user_id: alipayUserId,
+          open_id: alipayOpenId,
+          alipay_user_id: deprecatedAlipayUserId
+        });
         return {
           code: '10000',
           access_token: tokenResponse.access_token,
-          user_id: alipayUserId || alipayOpenId,
-          alipay_user_id: alipayUserId,
+          user_id: alipayUserId,
           open_id: alipayOpenId,
+          provider_subject: subject.value,
+          subject_type: subject.type,
+          legacy_user_id: subject.legacySubject,
+          alipay_user_id: deprecatedAlipayUserId,
           expires_in: tokenResponse.expires_in,
           refresh_token: tokenResponse.refresh_token,
           re_expires_in: tokenResponse.re_expires_in
@@ -1275,7 +1380,7 @@ async function handleMobileAlipayCallback(request, env) {
 
       console.log('移动端应用支付宝登录成功，用户已注册:', user.username);
 
-      const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state}&token=${token}&username=${user.username}&isNewUser=false&loginMethod=alipay&alipay_user_id=${alipayUser.user_id}&alipay_open_id=${encodeURIComponent(alipayUser.open_id || '')}&alipay_nickname=${encodeURIComponent(alipayUser.nick_name || '')}&alipay_avatar=${encodeURIComponent(alipayUser.avatar || '')}`;
+      const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state}&token=${token}&username=${encodeURIComponent(user.username)}&isNewUser=false&loginMethod=alipay&${alipayCallbackUserParams(user, alipayUser)}`;
 
       console.log('移动端应用支付宝登录成功，重定向到应用:', redirectUrl);
       return Response.redirect(redirectUrl, 302);
@@ -1283,7 +1388,7 @@ async function handleMobileAlipayCallback(request, env) {
 
     console.log('移动端应用新用户或未注册支付宝账号，重定向到应用进行注册');
 
-    const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state}&isNewUser=true&needsRegistration=true&loginMethod=alipay&alipay_user_id=${alipayUser.user_id}&alipay_open_id=${encodeURIComponent(alipayUser.open_id || '')}&alipay_nickname=${encodeURIComponent(alipayUser.nick_name || '')}&alipay_avatar=${encodeURIComponent(alipayUser.avatar || '')}`;
+    const redirectUrl = `${appScheme}alipay_auth_code=${authCode}&state=${state}&isNewUser=true&needsRegistration=true&loginMethod=alipay&${alipayRegistrationParams(alipayUser)}`;
 
     console.log('移动端应用新用户，重定向到应用进行注册:', redirectUrl);
     return Response.redirect(redirectUrl, 302);
@@ -1415,20 +1520,24 @@ async function handleAlipaySDKLogin(request, env) {
     if (user) {
       await backfillAlipayIdentity(env, user, alipayUser, alipayUser);
       const token = await generateToken({ id: user.id, username: user.username }, env);
+      const subject = getAlipayProviderSubject(alipayUser);
 
       return jsonResponse({
         success: true,
         token,
         username: user.username,
         userId: user.id,
+        userNo: user.user_no ?? user.id ?? null,
         isNewUser: false,
         loginMethod: 'alipay_sdk',
         alipayUser: {
-          userId: alipayUser.user_id,
-          openId: alipayUser.open_id,
+          userId: subject.value,
+          providerSubject: subject.value,
+          subjectType: subject.type,
           nickname: alipayUser.nick_name,
           avatar: alipayUser.avatar
-        }
+        },
+        user: serializeAccountUser(user)
       });
     }
 
@@ -1437,8 +1546,9 @@ async function handleAlipaySDKLogin(request, env) {
       isNewUser: true,
       needsRegistration: true,
       alipayUser: {
-        userId: alipayUser.user_id,
-        openId: alipayUser.open_id,
+        userId: getAlipayPrimarySubject(alipayUser),
+        providerSubject: getAlipayPrimarySubject(alipayUser),
+        subjectType: getAlipayProviderSubject(alipayUser).type,
         nickname: alipayUser.nick_name,
         avatar: alipayUser.avatar
       }

--- a/fabushi/web/src/contracts/account-user.js
+++ b/fabushi/web/src/contracts/account-user.js
@@ -12,6 +12,7 @@ export function serializeAccountUser(user) {
     avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,
     phoneNumber: user.phone_number || null,
     firebaseUid: user.firebase_uid || null,
+    alipayProviderSubject: user.alipay_user_id || null,
     alipayUserId: user.alipay_user_id || null,
     alipayNickname: user.alipay_nickname || null,
     alipayAvatar: user.alipay_avatar || null,

--- a/fabushi/web/src/handlers/admin.js
+++ b/fabushi/web/src/handlers/admin.js
@@ -37,6 +37,7 @@ export async function handleCheckAdminStatus(request, env, db) {
     phoneNumber: user.phone_number || null,
     firebaseUid: user.firebase_uid || null,
     hasPassword: Boolean(user.password_hash && user.salt),
+    alipayProviderSubject: user.alipay_user_id || null,
     alipayUserId: user.alipay_user_id || null,
     alipayNickname: user.alipay_nickname || null,
     alipayAvatar: user.alipay_avatar || null,

--- a/fabushi/web/src/handlers/auth.js
+++ b/fabushi/web/src/handlers/auth.js
@@ -24,6 +24,7 @@ function serializeUser(user) {
     avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,
     phoneNumber: user.phone_number || null,
     firebaseUid: user.firebase_uid || null,
+    alipayProviderSubject: user.alipay_user_id || null,
     alipayUserId: user.alipay_user_id || null,
     alipayNickname: user.alipay_nickname || null,
     alipayAvatar: user.alipay_avatar || null,

--- a/fabushi/web/src/handlers/thirdparty.js
+++ b/fabushi/web/src/handlers/thirdparty.js
@@ -17,6 +17,7 @@ function serializeAlipayAccountUser(user) {
     avatar: user.avatar || user.alipay_avatar || user.wechat_headimgurl || null,
     phoneNumber: user.phone_number || null,
     firebaseUid: user.firebase_uid || null,
+    alipayProviderSubject: user.alipay_user_id || null,
     alipayUserId: user.alipay_user_id || null,
     alipayNickname: user.alipay_nickname || null,
     alipayAvatar: user.alipay_avatar || null,

--- a/fabushi/web/src/router.js
+++ b/fabushi/web/src/router.js
@@ -34,6 +34,7 @@ import { routeAuthRequest } from './routes/auth-routes.js';
 import { routeMembershipRequest } from './routes/membership-routes.js';
 import { routeMeditationRequest } from './routes/meditation-routes.js';
 import { verifyToken } from '../auth-utils.js';
+import { CORS_HEADERS } from './config/constants.js';
 import { jsonResponse } from './utils/response.js';
 
 function jsonStringifyAscii(value) {
@@ -86,7 +87,7 @@ export async function route(request, env, db, ctx) {
   const method = request.method;
 
   if (method === 'OPTIONS') {
-    return new Response(null, { headers: { 'Access-Control-Allow-Origin': '*' } });
+    return new Response(null, { headers: CORS_HEADERS });
   }
 
   if (pathname === '/health') {

--- a/fabushi/web/src/services/database.js
+++ b/fabushi/web/src/services/database.js
@@ -189,8 +189,8 @@ export class DatabaseService {
 
     for (const identifier of identifiers) {
       const user = await this.db.prepare(
-        'SELECT * FROM users WHERE alipay_user_id = ? OR alipay_open_id = ?'
-      ).bind(identifier, identifier).first();
+        'SELECT * FROM users WHERE alipay_user_id = ?'
+      ).bind(identifier).first();
       if (user) return user;
     }
 

--- a/fabushi/web/tests/alipay-user-id.test.js
+++ b/fabushi/web/tests/alipay-user-id.test.js
@@ -24,9 +24,9 @@ function createDbEnv() {
                   const record = state.alipayBindings.find((item) => item.alipayUserId === params[0]);
                   return record ? { user_id: record.userId, username: record.username } : null;
                 }
-                if (sql.includes('SELECT * FROM users WHERE alipay_user_id = ? OR alipay_open_id = ?')) {
+                if (sql.includes('SELECT * FROM users WHERE alipay_user_id = ?')) {
                   return Array.from(state.userByUsername.values()).find((user) => (
-                    user.alipay_user_id === params[0] || user.alipay_open_id === params[1]
+                    user.alipay_user_id === params[0]
                   )) || null;
                 }
                 if (sql.includes('SELECT user_id, username FROM email_username_mapping WHERE email = ?')) {
@@ -43,6 +43,10 @@ function createDbEnv() {
                 if (sql.includes('SELECT * FROM users WHERE id = ?')) {
                   return Array.from(state.userByUsername.values()).find((user) => user.id === Number(params[0])) || null;
                 }
+                if (sql.includes('SELECT * FROM users WHERE user_no = ?')) {
+                  const expectedUserNo = Number(params[0]);
+                  return Array.from(state.userByUsername.values()).find((user) => Number(user.user_no) === expectedUserNo) || null;
+                }
                 if (sql.includes('SELECT * FROM users WHERE username = ?')) {
                   return state.userByUsername.get(params[0]) || null;
                 }
@@ -50,19 +54,25 @@ function createDbEnv() {
               },
               async run() {
                 if (sql.includes('INSERT INTO users')) {
-                  const username = params[0];
-                  const email = params[1];
-                  const hasMembershipExpiry = sql.includes('membership_expires_at');
-                  const alipayUserIdIndex = hasMembershipExpiry ? 9 : 8;
-                  const alipayOpenIdIndex = hasMembershipExpiry ? 10 : 9;
+                  const columns = sql
+                    .match(/INSERT INTO users\s*\(([^)]+)\)/s)?.[1]
+                    ?.split(',')
+                    .map((column) => column.trim()) || [];
+                  const row = Object.fromEntries(
+                    columns.map((column, index) => [column, params[index]])
+                  );
+                  const username = row.username;
+                  const email = row.email;
                   state.userByUsername.set(username, {
                     id: nextId++,
+                    user_no: Number(row.user_no),
                     username,
                     email,
-                    membership_type: params[7],
-                    membership_expires_at: hasMembershipExpiry ? params[8] : null,
-                    alipay_user_id: params[alipayUserIdIndex],
-                    alipay_open_id: params[alipayOpenIdIndex],
+                    membership_type: row.membership_type,
+                    membership_expires_at: row.membership_expires_at || null,
+                    alipay_user_id: row.alipay_user_id,
+                    alipay_nickname: row.alipay_nickname,
+                    alipay_avatar: row.alipay_avatar,
                   });
                 } else if (sql.includes('INSERT INTO email_username_mapping')) {
                   state.emailMappings.push({ email: params[0], username: params[1], userId: params[2] });
@@ -95,14 +105,15 @@ function createDbEnv() {
   return { env, state };
 }
 
-test('one-click Alipay registration stores user_id in mappings and token', async () => {
+test('one-click Alipay registration stores provider subject in mappings and token', async () => {
   const { env, state } = createDbEnv();
   const request = new Request('https://example.com/api/auth/alipay/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       oneClick: true,
-      alipayUserId: 'ali_one_click',
+      alipayProviderSubject: 'open_one_click',
+      alipaySubjectType: 'open_id',
       alipayNickname: '支付宝用户'
     })
   });
@@ -113,19 +124,24 @@ test('one-click Alipay registration stores user_id in mappings and token', async
 
   assert.equal(response.status, 200);
   assert.equal(payload.userId, 100);
+  assert.equal(String(payload.userNo).length, 9);
+  assert.equal(payload.user.userNo, payload.userNo);
+  assert.equal(payload.alipayProviderSubject, 'open_one_click');
   assert.equal(state.emailMappings[0].userId, 100);
   assert.equal(state.alipayBindings[0].userId, 100);
+  assert.equal(state.alipayBindings[0].alipayUserId, 'open_one_click');
   assert.equal(tokenPayload.userId, 100);
   assert.equal(tokenPayload.username, payload.username);
 });
 
-test('one-click Alipay registration reuses an existing user matched by open_id', async () => {
+test('one-click Alipay registration reuses an existing user matched by provider subject', async () => {
   const { env, state } = createDbEnv();
   state.userByUsername.set('paid_user', {
     id: 77,
+    user_no: 123456789,
     username: 'paid_user',
     email: 'paid@example.com',
-    alipay_open_id: 'open_same_account',
+    alipay_user_id: 'same_open_id',
     membership_type: 'paid',
     membership_expires_at: '2099-01-01T00:00:00.000Z',
   });
@@ -135,8 +151,8 @@ test('one-click Alipay registration reuses an existing user matched by open_id',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       oneClick: true,
-      alipayUserId: 'desktop_user_id',
-      alipayOpenId: 'open_same_account',
+      alipayProviderSubject: 'same_open_id',
+      alipaySubjectType: 'open_id',
       alipayNickname: '支付宝用户'
     })
   });
@@ -148,12 +164,54 @@ test('one-click Alipay registration reuses an existing user matched by open_id',
   assert.equal(response.status, 200);
   assert.equal(payload.isNewUser, false);
   assert.equal(payload.userId, 77);
+  assert.equal(payload.userNo, 123456789);
+  assert.equal(payload.user.userNo, 123456789);
   assert.equal(payload.username, 'paid_user');
   assert.equal(tokenPayload.userId, 77);
   assert.equal(state.userByUsername.size, 1);
   assert.deepEqual(
     state.alipayBindings.map((binding) => binding.alipayUserId).sort(),
-    ['desktop_user_id', 'open_same_account'],
+    ['same_open_id'],
+  );
+});
+
+test('one-click Alipay registration migrates a legacy user_id match to open_id binding', async () => {
+  const { env, state } = createDbEnv();
+  state.userByUsername.set('legacy_user', {
+    id: 88,
+    user_no: 223344556,
+    username: 'legacy_user',
+    email: 'legacy@example.com',
+    alipay_user_id: 'legacy_user_id',
+    membership_type: 'paid',
+    membership_expires_at: '2099-01-01T00:00:00.000Z',
+  });
+
+  const request = new Request('https://example.com/api/auth/alipay/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      oneClick: true,
+      alipayProviderSubject: 'new_open_id',
+      alipaySubjectType: 'open_id',
+      alipayLegacyUserId: 'legacy_user_id',
+      alipayNickname: '支付宝用户'
+    })
+  });
+
+  const response = await registerAlipayUser(request, env);
+  const payload = await response.json();
+  const tokenPayload = await verifyToken(payload.token, env);
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.isNewUser, false);
+  assert.equal(payload.userId, 88);
+  assert.equal(payload.alipayProviderSubject, 'new_open_id');
+  assert.equal(tokenPayload.userId, 88);
+  assert.equal(state.userByUsername.size, 1);
+  assert.deepEqual(
+    state.alipayBindings.map((binding) => binding.alipayUserId).sort(),
+    ['new_open_id'],
   );
 });
 
@@ -190,7 +248,7 @@ test('mobile Alipay OAuth URL honors explicit redirect override', async () => {
   assert.equal(authUrl.searchParams.get('redirect_uri'), 'https://example.com/alipay-callback');
 });
 
-test('manual Alipay registration stores user_id in mappings and token', async () => {
+test('manual Alipay registration stores provider subject in mappings and token', async () => {
   const { env, state } = createDbEnv();
   const request = new Request('https://example.com/api/auth/alipay/register', {
     method: 'POST',
@@ -200,7 +258,8 @@ test('manual Alipay registration stores user_id in mappings and token', async ()
       email: 'manual@example.com',
       password: 'secure123',
       captcha: '1234',
-      alipayUserId: 'ali_manual',
+      alipayProviderSubject: 'open_manual',
+      alipaySubjectType: 'open_id',
       alipayNickname: '手动用户'
     })
   });
@@ -211,6 +270,8 @@ test('manual Alipay registration stores user_id in mappings and token', async ()
 
   assert.equal(response.status, 200);
   assert.equal(payload.userId, 100);
+  assert.equal(String(payload.userNo).length, 9);
+  assert.equal(payload.user.userNo, payload.userNo);
   assert.deepEqual(state.emailMappings[0], {
     email: 'manual@example.com',
     username: 'manual_user',
@@ -221,7 +282,7 @@ test('manual Alipay registration stores user_id in mappings and token', async ()
   assert.equal(tokenPayload.username, 'manual_user');
 });
 
-test('registration captcha flow stores user_id in mappings and token', async () => {
+test('registration captcha flow stores provider subject in mappings and token', async () => {
   const { env, state } = createDbEnv();
   const request = new Request('https://example.com/api/auth/alipay/register-captcha', {
     method: 'POST',
@@ -230,7 +291,8 @@ test('registration captcha flow stores user_id in mappings and token', async () 
       username: 'captcha_user',
       password: 'secure123',
       email: 'captcha@example.com',
-      alipayUserId: 'ali_captcha',
+      alipayProviderSubject: 'open_captcha',
+      alipaySubjectType: 'open_id',
       nickname: '验证码用户'
     })
   });
@@ -241,6 +303,8 @@ test('registration captcha flow stores user_id in mappings and token', async () 
 
   assert.equal(response.status, 201);
   assert.equal(payload.userId, 100);
+  assert.equal(String(payload.userNo).length, 9);
+  assert.equal(payload.user.userNo, payload.userNo);
   assert.deepEqual(state.emailMappings[0], {
     email: 'captcha@example.com',
     username: 'captcha_user',

--- a/fabushi/web/tests/router-cors.test.js
+++ b/fabushi/web/tests/router-cors.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { route } from '../src/router.js';
+
+test('router OPTIONS returns full CORS preflight headers', async () => {
+  const response = await route(
+    new Request('https://api.ombhrum.com/api/auth/login', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://flutter.ombhrum.com',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'accept,content-type',
+      },
+    }),
+    {},
+    null,
+    {},
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*');
+  assert.match(
+    response.headers.get('Access-Control-Allow-Methods') ?? '',
+    /\bPOST\b/,
+  );
+  assert.match(
+    response.headers.get('Access-Control-Allow-Headers') ?? '',
+    /\bContent-Type\b/i,
+  );
+});


### PR DESCRIPTION
## Summary

- Normalize Alipay account binding around a single provider subject, preferring `open_id` while keeping legacy `user_id` fallback for existing accounts.
- Return and consume `alipayProviderSubject`, `userNo`, nickname, and avatar consistently across web, SDK, deep-link, and stored-user flows.
- Use a fresh embedded WebView session for mobile Alipay OAuth, keep macOS on the system browser to avoid the blank WebView window, and require matching callback `state` to avoid stale desktop callbacks logging into the wrong account.
- Send the active in-memory auth token when deleting an account so desktop account deletion does not use a stale cached token.
- Return full CORS preflight headers from the backend router so Flutter Web password login and Alipay login requests are not blocked by the browser before reaching the API.

## Root Cause

Desktop and mobile Alipay paths could identify the same Alipay account with different fields (`open_id` versus legacy `user_id`) and stale desktop deep links could be replayed after logout. Account deletion also read the token back from shared preferences instead of using the active login session, which could produce `认证失败，请重新登录` after re-login.

Flutter Web login failed because backend `OPTIONS` responses only returned `Access-Control-Allow-Origin`. Browser preflight for password login and Alipay login also requires allowed methods and headers, so those requests were blocked and surfaced as generic network errors.

The attempted macOS embedded WebView path can render the Alipay authorization window as a blank gray surface, so macOS now opens the OAuth URL in the system browser while still using callback `state` validation.

## Validation

- `node --check web/alipay-login-functions.js`
- `node --check web/src/router.js`
- `node --test web/tests/router-cors.test.js web/tests/alipay-user-id.test.js`
- `dart format ...`
- `flutter test test/services/auth_service_test.dart`
- `flutter analyze --no-fatal-infos --no-fatal-warnings ...` (passes with existing info/warning lint output only)
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/screens/douyin_login_screen.dart lib/screens/alipay_web_login_screen.dart` (passes with existing `withOpacity` info only)
- `git diff --check`
