### PR TITLE
[codex] fix macOS Alipay login launch

### DIFF
--- a/fabushi/lib/screens/douyin_login_screen.dart
+++ b/fabushi/lib/screens/douyin_login_screen.dart
@@ -128,7 +128,7 @@ class _DouyinLoginScreenState extends State<DouyinLoginScreen>
 
   bool get _shouldUseEmbeddedAlipayWebLogin {
     if (kIsWeb) return false;
-    return Platform.isIOS || Platform.isAndroid || Platform.isMacOS;
+    return Platform.isIOS || Platform.isAndroid;
   }
 
   Future<void> _handleAlipayLogin() async {


### PR DESCRIPTION
## Summary

- Keep macOS Alipay OAuth on the system browser instead of the embedded WebView.
- Leave iOS/Android on the embedded WebView path.

## Root Cause

The previous Alipay identity PR switched macOS into the embedded WebView OAuth path. On macOS, the Alipay authorization page can render as a blank gray WebView window, so the desktop flow should continue launching the system browser while relying on the existing deep-link callback and state validation.

## Validation

- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/screens/douyin_login_screen.dart lib/screens/alipay_web_login_screen.dart` (passes with existing `withOpacity` info only)
- `git diff --check origin/main..HEAD`
