### PR TITLE
fix: use Alipay avatar fallback in Flutter profile

### DIFF
--- a/fabushi/lib/models/auth_model.dart
+++ b/fabushi/lib/models/auth_model.dart
@@ -47,6 +47,15 @@ class User {
     return int.tryParse(value.toString());
   }
 
+  static String? _firstNonEmptyString(Iterable<dynamic> values) {
+    for (final value in values) {
+      if (value == null) continue;
+      final text = value.toString().trim();
+      if (text.isNotEmpty) return text;
+    }
+    return null;
+  }
+
   factory User.fromJson(Map<String, dynamic> json) {
     return User(
       username: json['username'] ?? '',
@@ -64,7 +73,15 @@ class User {
           json['alipay_provider_subject'] ??
           json['alipayUserId'],
       nickname: json['nickname'],
-      avatar: json['avatar'],
+      avatar: _firstNonEmptyString([
+        json['avatar'],
+        json['avatarUrl'],
+        json['avatar_url'],
+        json['alipayAvatar'],
+        json['alipay_avatar'],
+        json['wechatHeadimgurl'],
+        json['wechat_headimgurl'],
+      ]),
       phoneNumber: json['phoneNumber'],
       firebaseUid: json['firebaseUid'],
       usernameChangedAt:
@@ -202,6 +219,7 @@ class AuthModel extends ChangeNotifier {
     String? fallbackEmail,
     String? fallbackPhoneNumber,
     String? fallbackFirebaseUid,
+    String? fallbackAvatar,
     String? fallbackMembershipType,
     DateTime? fallbackMembershipExpiry,
   }) {
@@ -213,6 +231,7 @@ class AuthModel extends ChangeNotifier {
         fallbackEmail: fallbackEmail ?? fallbackUser?.email,
         fallbackPhoneNumber: fallbackPhoneNumber ?? fallbackUser?.phoneNumber,
         fallbackFirebaseUid: fallbackFirebaseUid ?? fallbackUser?.firebaseUid,
+        fallbackAvatar: fallbackAvatar ?? fallbackUser?.avatar,
         fallbackMembershipType:
             fallbackMembershipType ?? fallbackUser?.membershipType,
         fallbackMembershipExpiry:
@@ -266,6 +285,7 @@ class AuthModel extends ChangeNotifier {
     String? fallbackEmail,
     String? fallbackPhoneNumber,
     String? fallbackFirebaseUid,
+    String? fallbackAvatar,
     String? fallbackMembershipType,
     DateTime? fallbackMembershipExpiry,
   }) {
@@ -293,7 +313,17 @@ class AuthModel extends ChangeNotifier {
           userJson['alipayUserId'] ??
           userJson['alipay_user_id'],
       nickname: userJson['nickname'],
-      avatar: userJson['avatar'],
+      avatar:
+          User._firstNonEmptyString([
+            userJson['avatar'],
+            userJson['avatarUrl'],
+            userJson['avatar_url'],
+            userJson['alipayAvatar'],
+            userJson['alipay_avatar'],
+            userJson['wechatHeadimgurl'],
+            userJson['wechat_headimgurl'],
+          ]) ??
+          fallbackAvatar,
       phoneNumber:
           userJson['phoneNumber'] ??
           userJson['phone_number'] ??
@@ -1002,6 +1032,7 @@ class AuthModel extends ChangeNotifier {
               fallbackMembershipExpiry: DateTime.now().add(
                 const Duration(days: 3),
               ),
+              fallbackAvatar: alipayUser?['avatar'],
             );
           } else {
             _currentUser = User(

--- a/fabushi/lib/models/user_model.dart
+++ b/fabushi/lib/models/user_model.dart
@@ -8,6 +8,15 @@ int? _parseOptionalInt(dynamic value) {
   return int.tryParse(value.toString());
 }
 
+String? _firstNonEmptyString(Iterable<dynamic> values) {
+  for (final value in values) {
+    if (value == null) continue;
+    final text = value.toString().trim();
+    if (text.isNotEmpty) return text;
+  }
+  return null;
+}
+
 class UserModel {
   final String username;
   final int? userNo;
@@ -68,7 +77,10 @@ class UserModel {
           json['username_changed_at'] as String?,
       wechatOpenid: json['wechatOpenid'] as String?,
       wechatNickname: json['wechatNickname'] as String?,
-      wechatHeadimgurl: json['wechatHeadimgurl'] as String?,
+      wechatHeadimgurl: _firstNonEmptyString([
+        json['wechatHeadimgurl'],
+        json['wechat_headimgurl'],
+      ]),
       wechatBoundAt: json['wechatBoundAt'] as String?,
       alipayUserId:
           (json['alipayProviderSubject'] ??
@@ -76,10 +88,21 @@ class UserModel {
                   json['alipayUserId'])
               as String?,
       alipayNickname: json['alipayNickname'] as String?,
-      alipayAvatar: json['alipayAvatar'] as String?,
+      alipayAvatar: _firstNonEmptyString([
+        json['alipayAvatar'],
+        json['alipay_avatar'],
+      ]),
       alipayBoundAt: json['alipayBoundAt'] as String?,
       nickname: json['nickname'] as String?,
-      avatar: json['avatar'] as String?,
+      avatar: _firstNonEmptyString([
+        json['avatar'],
+        json['avatarUrl'],
+        json['avatar_url'],
+        json['alipayAvatar'],
+        json['alipay_avatar'],
+        json['wechatHeadimgurl'],
+        json['wechat_headimgurl'],
+      ]),
       phoneNumber: (json['phoneNumber'] ?? json['phone_number']) as String?,
       firebaseUid: (json['firebaseUid'] ?? json['firebase_uid']) as String?,
       mainPractice: json['mainPractice'] is Map

--- a/fabushi/lib/services/auth_service.dart
+++ b/fabushi/lib/services/auth_service.dart
@@ -90,7 +90,10 @@ class AuthService {
           (user['usernameChangedAt'] ?? user['username_changed_at']) as String?,
       wechatOpenid: user['wechatOpenid'] as String?,
       wechatNickname: user['wechatNickname'] as String?,
-      wechatHeadimgurl: user['wechatHeadimgurl'] as String?,
+      wechatHeadimgurl: _firstNonEmptyString([
+        user['wechatHeadimgurl'],
+        user['wechat_headimgurl'],
+      ]),
       wechatBoundAt: user['wechatBoundAt'] as String?,
       alipayUserId:
           (user['alipayProviderSubject'] ??
@@ -98,10 +101,21 @@ class AuthService {
                   user['alipayUserId'])
               as String?,
       alipayNickname: user['alipayNickname'] as String?,
-      alipayAvatar: user['alipayAvatar'] as String?,
+      alipayAvatar: _firstNonEmptyString([
+        user['alipayAvatar'],
+        user['alipay_avatar'],
+      ]),
       alipayBoundAt: user['alipayBoundAt'] as String?,
       nickname: user['nickname'] as String?,
-      avatar: user['avatar'] as String?,
+      avatar: _firstNonEmptyString([
+        user['avatar'],
+        user['avatarUrl'],
+        user['avatar_url'],
+        user['alipayAvatar'],
+        user['alipay_avatar'],
+        user['wechatHeadimgurl'],
+        user['wechat_headimgurl'],
+      ]),
       phoneNumber: (user['phoneNumber'] ?? user['phone_number']) as String?,
       firebaseUid: (user['firebaseUid'] ?? user['firebase_uid']) as String?,
       mainPractice: user['mainPractice'] is Map
@@ -116,6 +130,14 @@ class AuthService {
   static String? _optionalString(dynamic value) {
     if (value == null) return null;
     return value.toString();
+  }
+
+  static String? _firstNonEmptyString(Iterable<dynamic> values) {
+    for (final value in values) {
+      final text = _optionalString(value)?.trim();
+      if (text != null && text.isNotEmpty) return text;
+    }
+    return null;
   }
 
   static bool _parseBool(dynamic value, {required bool fallback}) {
@@ -237,9 +259,10 @@ class AuthService {
           _optionalString(data['wechatNickname'] ?? data['wechat_nickname']) ??
           fallbackUser?.wechatNickname,
       wechatHeadimgurl:
-          _optionalString(
-            data['wechatHeadimgurl'] ?? data['wechat_headimgurl'],
-          ) ??
+          _firstNonEmptyString([
+            data['wechatHeadimgurl'],
+            data['wechat_headimgurl'],
+          ]) ??
           fallbackUser?.wechatHeadimgurl,
       wechatBoundAt:
           _optionalString(data['wechatBoundAt'] ?? data['wechat_bound_at']) ??
@@ -256,15 +279,23 @@ class AuthService {
           _optionalString(data['alipayNickname'] ?? data['alipay_nickname']) ??
           fallbackUser?.alipayNickname,
       alipayAvatar:
-          _optionalString(data['alipayAvatar'] ?? data['alipay_avatar']) ??
+          _firstNonEmptyString([data['alipayAvatar'], data['alipay_avatar']]) ??
           fallbackUser?.alipayAvatar,
       alipayBoundAt:
           _optionalString(data['alipayBoundAt'] ?? data['alipay_bound_at']) ??
           fallbackUser?.alipayBoundAt,
       nickname: _optionalString(data['nickname']) ?? fallbackUser?.nickname,
       avatar:
-          _optionalString(data['avatar'] ?? data['avatarUrl']) ??
-          fallbackUser?.avatar,
+          _firstNonEmptyString([
+            data['avatar'],
+            data['avatarUrl'],
+            data['avatar_url'],
+            data['alipayAvatar'],
+            data['alipay_avatar'],
+            data['wechatHeadimgurl'],
+            data['wechat_headimgurl'],
+          ]) ??
+          fallbackUser?.avatarUrl,
       phoneNumber:
           _optionalString(data['phoneNumber'] ?? data['phone_number']) ??
           fallbackUser?.phoneNumber,

--- a/fabushi/test/services/auth_service_test.dart
+++ b/fabushi/test/services/auth_service_test.dart
@@ -1,8 +1,21 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/models/auth_model.dart' as auth_model;
 import 'package:global_dharma_sharing/models/user_model.dart';
 import 'package:global_dharma_sharing/services/auth_service.dart';
 
 void main() {
+  group('AuthModel.User.fromJson', () {
+    test('uses Alipay avatar when the generic avatar field is missing', () {
+      final user = auth_model.User.fromJson({
+        'username': 'alipay_user',
+        'email': '',
+        'alipayAvatar': 'https://example.com/alipay.png',
+      });
+
+      expect(user.avatar, 'https://example.com/alipay.png');
+    });
+  });
+
   group('AuthService.buildLoginUser', () {
     test(
       'tolerates partial user payloads from a successful login response',
@@ -40,6 +53,20 @@ void main() {
       expect(user.username, 'student_user');
       expect(user.userNo, 618273941);
       expect(user.email, 'student@example.com');
+    });
+
+    test('normalizes Alipay avatar into the generic avatar field', () {
+      final user = AuthService.buildLoginUser({
+        'token': 'token-alipay',
+        'user': {
+          'username': 'alipay_user',
+          'alipayAvatar': 'https://example.com/alipay.png',
+        },
+      }, requestedIdentifier: 'alipay_user');
+
+      expect(user.alipayAvatar, 'https://example.com/alipay.png');
+      expect(user.avatar, 'https://example.com/alipay.png');
+      expect(user.avatarUrl, 'https://example.com/alipay.png');
     });
 
     test(
@@ -109,6 +136,18 @@ void main() {
       expect(user.email, 'new@example.com');
       expect(user.membership.type, 'paid');
       expect(user.membership.expiresAt, '2099-02-01T00:00:00.000Z');
+    });
+
+    test('uses provider avatar fallback when refresh payload omits avatar', () {
+      final user = AuthService.buildRefreshedUser({
+        'username': 'alipay_user',
+        'email': '',
+        'alipay_avatar': 'https://example.com/alipay-refresh.png',
+      });
+
+      expect(user.alipayAvatar, 'https://example.com/alipay-refresh.png');
+      expect(user.avatar, 'https://example.com/alipay-refresh.png');
+      expect(user.avatarUrl, 'https://example.com/alipay-refresh.png');
     });
   });
 }


### PR DESCRIPTION
## Summary
- normalize Flutter user avatar parsing across avatar/avatarUrl/alipayAvatar/wechatHeadimgurl payloads
- preserve Alipay avatar fallback for login, refresh, and bootstrap profile paths
- add focused auth service/model tests for provider avatar fallbacks

## Verification
- `/opt/homebrew/share/flutter/bin/dart format fabushi/lib/models/auth_model.dart fabushi/lib/models/user_model.dart fabushi/lib/services/auth_service.dart fabushi/test/services/auth_service_test.dart`
- `/opt/homebrew/share/flutter/bin/dart analyze lib/models/auth_model.dart lib/models/user_model.dart lib/services/auth_service.dart test/services/auth_service_test.dart`
- `/opt/homebrew/share/flutter/bin/flutter test test/services/auth_service_test.dart` was interrupted after the project native asset hook kept the test runner in loading for more than 2 minutes