### PR TITLE
Integrate OpenClaw remote desktop workbench

### DIFF
--- a/fabushi/assets/openclaw/README.md
+++ b/fabushi/assets/openclaw/README.md
@@ -7,8 +7,11 @@ assets/openclaw/macos-arm64/node/bin/node
 assets/openclaw/macos-arm64/openclaw/bin/openclaw.js
 assets/openclaw/macos-arm64/openclaw/package.json
 assets/openclaw/macos-arm64/openclaw/node_modules/...
+assets/openclaw/macos-arm64/plugins/openclaw-weixin/openclaw.plugin.json
 ```
 
 The app copies these assets to the per-user application support directory on first desktop launch, sets executable permissions, and starts `openclaw gateway --port 18789` automatically. End users do not install Node, npm, or OpenClaw separately.
 
 Use `scripts/build_openclaw_desktop_bundle.sh` in CI/release packaging to populate the platform folders before `flutter build macos/windows/linux`.
+
+By default the script also vendors Tencent's official `@tencent-weixin/openclaw-weixin` plugin under `plugins/openclaw-weixin` so the embedded runtime can expose OpenClaw's native WeChat channel without asking end users to install npm packages. Set `OPENCLAW_BUNDLE_WEIXIN=0` only for debug bundles that intentionally omit WeChat support.

--- a/fabushi/assets/openclaw/bundle_manifest.json
+++ b/fabushi/assets/openclaw/bundle_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "version": "openclaw-embedded-2026.06.2",
+  "version": "openclaw-embedded-2026.06.3",
   "defaultPort": 18789,
   "defaultModel": "deepseek/deepseek-chat",
   "defaultModelOverride": "",
@@ -9,6 +9,15 @@
     "--port",
     "{port}",
     "--force"
+  ],
+  "bundledPlugins": [
+    {
+      "id": "openclaw-weixin",
+      "package": "@tencent-weixin/openclaw-weixin",
+      "version": "2.4.3",
+      "path": "plugins/openclaw-weixin",
+      "channel": "openclaw-weixin"
+    }
   ],
   "platforms": {
     "macos-arm64": {

--- a/fabushi/lib/bootstrap/native_bootstrap.dart
+++ b/fabushi/lib/bootstrap/native_bootstrap.dart
@@ -19,77 +19,80 @@ Future<void> bootstrapApplication() async {
   debugPrint('🚀 [native] App starting...');
   await ErrorReportService.instance.initializeGlobalHandlers();
 
-  await runZonedGuarded(() async {
-    debugPrint('🚀 [native] setupDependencies() begin');
-    setupDependencies();
-    debugPrint('🚀 [native] setupDependencies() done');
+  await runZonedGuarded(
+    () async {
+      debugPrint('🚀 [native] setupDependencies() begin');
+      setupDependencies();
+      debugPrint('🚀 [native] setupDependencies() done');
 
-    if (kDebugMode) {
-      AppConfig.printConfigInfo();
-    }
-
-    if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-      await windowManager.ensureInitialized();
-      await windowManager.setMaximizable(false);
-      await windowManager.setResizable(false);
-      await windowManager.maximize();
-    }
-
-    try {
-      if (Firebase.apps.isEmpty) {
-        debugPrint('🚀 [native] Firebase.initializeApp() begin');
-        await Firebase.initializeApp(
-          options: DefaultFirebaseOptions.currentPlatform,
-        ).timeout(const Duration(seconds: 5));
-        debugPrint('✅ [native] Firebase初始化成功');
-      } else {
-        debugPrint('✅ [native] Firebase已初始化，跳过');
+      if (kDebugMode) {
+        AppConfig.printConfigInfo();
       }
-    } catch (error, stackTrace) {
-      debugPrint('⚠️ [native] Firebase初始化失败: $error');
+
+      if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+        await windowManager.ensureInitialized();
+        await windowManager.setMaximizable(true);
+        await windowManager.setResizable(true);
+        await windowManager.maximize();
+      }
+
+      try {
+        if (Firebase.apps.isEmpty) {
+          debugPrint('🚀 [native] Firebase.initializeApp() begin');
+          await Firebase.initializeApp(
+            options: DefaultFirebaseOptions.currentPlatform,
+          ).timeout(const Duration(seconds: 5));
+          debugPrint('✅ [native] Firebase初始化成功');
+        } else {
+          debugPrint('✅ [native] Firebase已初始化，跳过');
+        }
+      } catch (error, stackTrace) {
+        debugPrint('⚠️ [native] Firebase初始化失败: $error');
+        unawaited(
+          ErrorReportService.instance.recordError(
+            error,
+            stackTrace: stackTrace,
+            stage: 'firebase_initialize',
+            source: 'native_bootstrap',
+            extra: {'platform': 'mobile_or_desktop'},
+          ),
+        );
+      }
+
+      Future<void>.delayed(const Duration(milliseconds: 100), () async {
+        debugPrint('🚀 [native] AppInitializer.initialize() begin');
+        try {
+          await AppInitializer.initialize();
+          debugPrint('🚀 [native] AppInitializer.initialize() done');
+        } catch (error, stackTrace) {
+          debugPrint('初始化失败: $error');
+          await ErrorReportService.instance.recordError(
+            error,
+            stackTrace: stackTrace,
+            stage: 'main_delayed_initializer',
+            source: 'native_bootstrap',
+          );
+        }
+      });
+
+      debugPrint('🚀 [native] setupVideoFeedDependencies() begin');
+      setupVideoFeedDependencies();
+      debugPrint('🚀 [native] setupVideoFeedDependencies() done');
+
+      debugPrint('🚀 [native] runApp(NativeApp) begin');
+      runApp(const NativeApp());
+      await maybeRunOpenClawHomeChatE2E();
+    },
+    (error, stackTrace) {
       unawaited(
         ErrorReportService.instance.recordError(
           error,
           stackTrace: stackTrace,
-          stage: 'firebase_initialize',
+          stage: 'run_zoned_guarded',
           source: 'native_bootstrap',
-          extra: {'platform': 'mobile_or_desktop'},
+          fatal: true,
         ),
       );
-    }
-
-    Future<void>.delayed(const Duration(milliseconds: 100), () async {
-      debugPrint('🚀 [native] AppInitializer.initialize() begin');
-      try {
-        await AppInitializer.initialize();
-        debugPrint('🚀 [native] AppInitializer.initialize() done');
-      } catch (error, stackTrace) {
-        debugPrint('初始化失败: $error');
-        await ErrorReportService.instance.recordError(
-          error,
-          stackTrace: stackTrace,
-          stage: 'main_delayed_initializer',
-          source: 'native_bootstrap',
-        );
-      }
-    });
-
-    debugPrint('🚀 [native] setupVideoFeedDependencies() begin');
-    setupVideoFeedDependencies();
-    debugPrint('🚀 [native] setupVideoFeedDependencies() done');
-
-    debugPrint('🚀 [native] runApp(NativeApp) begin');
-    runApp(const NativeApp());
-    await maybeRunOpenClawHomeChatE2E();
-  }, (error, stackTrace) {
-    unawaited(
-      ErrorReportService.instance.recordError(
-        error,
-        stackTrace: stackTrace,
-        stage: 'run_zoned_guarded',
-        source: 'native_bootstrap',
-        fatal: true,
-      ),
-    );
-  });
+    },
+  );
 }

--- a/fabushi/lib/screens/alipay_web_login_screen.dart
+++ b/fabushi/lib/screens/alipay_web_login_screen.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -21,13 +23,15 @@ class _AlipayWebLoginScreenState extends State<AlipayWebLoginScreen> {
   int _progress = 0;
   String? _errorMessage;
 
+  bool get _canSetOpaqueWebViewBackground =>
+      kIsWeb || defaultTargetPlatform != TargetPlatform.macOS;
+
   @override
   void initState() {
     super.initState();
 
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setBackgroundColor(const Color(0xFF0F0F0F))
       ..setUserAgent(_desktopUserAgent)
       ..setNavigationDelegate(
         NavigationDelegate(
@@ -44,6 +48,9 @@ class _AlipayWebLoginScreenState extends State<AlipayWebLoginScreen> {
           },
         ),
       );
+    if (_canSetOpaqueWebViewBackground) {
+      _controller.setBackgroundColor(const Color(0xFF0F0F0F));
+    }
 
     _loadLoginUrlWithFreshWebViewSession();
   }

--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -19,10 +19,14 @@ import '../models/file_transfer_model.dart'
 import '../services/ai_backend_policy.dart';
 import '../services/alipay_service.dart'
     if (dart.library.html) '../services/alipay_service_web.dart';
+import '../services/app_settings.dart';
 import '../services/dacheng_ai_service.dart';
+import '../services/desktop_control/desktop_control_bridge.dart';
+import '../services/desktop_control/desktop_control_models.dart';
 import '../services/diagnostic_log_service.dart';
 import '../services/dharma_publish_service.dart';
 import '../services/inbound_share_service.dart';
+import '../services/openclaw/openclaw_runtime.dart';
 import 'dharma_publish_browser_screen.dart'
     if (dart.library.html) 'dharma_publish_browser_screen_web.dart';
 import '../widgets/earth_globe_widget.dart';
@@ -111,6 +115,15 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   final _membershipService = MembershipService();
   final _alipayService = AlipayService();
   final _appleIapService = AppleIapService();
+  bool _isOpenClawPanelLoading = false;
+  bool _isRunningOpenClawAction = false;
+  bool _isRestartingOpenClaw = false;
+  bool _isPreparingChromeConnector = false;
+  String _openClawRemoteGatewayUrl = '';
+  String _openClawModeLabel = '自动';
+  String _openClawPermissionLabel = '默认权限';
+  OpenClawRuntimeStatus? _openClawStatus;
+  DesktopControlBridgeStatus? _desktopControlStatus;
   bool? _buddhaAssetUnlocked;
   bool _isPurchasingBuddhaAsset = false;
   DateTime? _sendStartedAt;
@@ -227,6 +240,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       unawaited(_loadRemoteConversations());
       unawaited(_refreshBuddhaAssetEntitlement());
       unawaited(_consumeInitialShare());
+      unawaited(_loadOpenClawHomeStatus(probeOpenClaw: false));
     });
   }
 
@@ -458,26 +472,345 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           SafeArea(
             child: Consumer<FileTransferModel>(
               builder: (context, model, _) {
-                return Column(
-                  children: [
-                    _buildTopBar(authModel),
-                    Expanded(child: _buildHomeBody(context, model, authModel)),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(
-                        widget.composerLeftInset ?? 18,
-                        8,
-                        18,
-                        16,
-                      ),
-                      child: _buildChatComposer(context, model),
-                    ),
-                  ],
+                return LayoutBuilder(
+                  builder: (context, constraints) {
+                    final useDesktopWorkbench =
+                        _isNativeMacOrWindows && constraints.maxWidth >= 920;
+                    if (useDesktopWorkbench) {
+                      return _buildDesktopHomeShell(context, model, authModel);
+                    }
+
+                    return Column(
+                      children: [
+                        _buildTopBar(authModel),
+                        Expanded(
+                          child: _buildHomeBody(context, model, authModel),
+                        ),
+                        Padding(
+                          padding: EdgeInsets.fromLTRB(
+                            widget.composerLeftInset ?? 18,
+                            8,
+                            18,
+                            16,
+                          ),
+                          child: _buildChatComposer(context, model),
+                        ),
+                      ],
+                    );
+                  },
                 );
               },
             ),
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildDesktopHomeShell(
+    BuildContext context,
+    FileTransferModel model,
+    AuthModel? authModel,
+  ) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: Color(0xFFF7F8F7)),
+      child: Row(
+        children: [
+          _buildConversationSidebar(model, embedded: true),
+          Expanded(
+            child: Column(
+              children: [
+                _buildDesktopTopBar(),
+                Expanded(
+                  child: _buildDesktopWorkspace(context, model, authModel),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(34, 8, 34, 26),
+                  child: Align(
+                    alignment: Alignment.center,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 960),
+                      child: _buildDesktopChatComposer(context, model),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDesktopTopBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(28, 18, 24, 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          FilledButton.icon(
+            onPressed: _createOpenClawHomeMobilePairingCode,
+            icon: const Icon(Icons.rocket_launch, size: 18),
+            label: const Text('来连接移动端'),
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.white,
+              foregroundColor: const Color(0xFF202124),
+              side: const BorderSide(color: Color(0xFFE5E5E1)),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDesktopWorkspace(
+    BuildContext context,
+    FileTransferModel model,
+    AuthModel? authModel,
+  ) {
+    final showChat =
+        _homeChatMessages.isNotEmpty ||
+        _isAiGenerating ||
+        _shouldShowGlobalSendProcess(model);
+
+    if (showChat) {
+      return Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 980),
+          child: _buildChatTimeline(model, light: true),
+        ),
+      );
+    }
+
+    return _buildDesktopIntroPanel(authModel);
+  }
+
+  Widget _buildDesktopIntroPanel(AuthModel? authModel) {
+    final displayName = authModel?.currentUser?.displayName.trim() ?? '';
+    final greeting = displayName.isEmpty ? '大乘' : 'Hi, $displayName';
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxHeight < 620;
+        return Stack(
+          children: [
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 960),
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.fromLTRB(32, compact ? 24 : 54, 32, 24),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        greeting,
+                        style: TextStyle(
+                          color: const Color(0xFF17181A),
+                          fontSize: compact ? 42 : 50,
+                          fontWeight: FontWeight.w900,
+                          height: 1.02,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '你的本地 OpenClaw 超能力',
+                        style: TextStyle(
+                          color: const Color(0xFF17181A),
+                          fontSize: compact ? 35 : 44,
+                          fontWeight: FontWeight.w900,
+                          height: 1.06,
+                        ),
+                      ),
+                      const SizedBox(height: 22),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          _DesktopModeChip(
+                            icon: Icons.coffee_outlined,
+                            label: '日常办公',
+                            selected: _openClawModeLabel == '自动',
+                            onTap: () =>
+                                setState(() => _openClawModeLabel = '自动'),
+                          ),
+                          _DesktopModeChip(
+                            icon: Icons.code,
+                            label: '代码开发',
+                            selected: _openClawModeLabel == '本机全能',
+                            onTap: () =>
+                                setState(() => _openClawModeLabel = '本机全能'),
+                          ),
+                          _DesktopModeChip(
+                            icon: Icons.palette_outlined,
+                            label: '设计创意',
+                            selected: _openClawModeLabel == '远程接管',
+                            onTap: () =>
+                                setState(() => _openClawModeLabel = '远程接管'),
+                          ),
+                        ],
+                      ),
+                      SizedBox(height: compact ? 36 : 64),
+                      Wrap(
+                        spacing: 10,
+                        runSpacing: 12,
+                        children: [
+                          _DesktopPromptPill(
+                            icon: Icons.description_outlined,
+                            label: '文档处理',
+                            onTap: () => _prefillPrompt('帮我把这份文档整理成清晰摘要和行动清单'),
+                          ),
+                          _DesktopPromptPill(
+                            icon: Icons.public_outlined,
+                            label: '全球法布施',
+                            onTap: () => _prefillPrompt('帮我策划一次全球法布施发布任务'),
+                          ),
+                          _DesktopPromptPill(
+                            icon: Icons.chat_bubble_outline,
+                            label: '微信远程',
+                            onTap: () => _prefillPrompt('帮我检查微信和移动端远程控制是否可用'),
+                          ),
+                          _DesktopPromptPill(
+                            icon: Icons.apps_outlined,
+                            label: '更多',
+                            onTap: () =>
+                                _prefillPrompt('帮我列出当前可用的专家、技能、连接器和自动化能力'),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 18),
+                      _buildDesktopStatusStrip(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              right: 52,
+              top: compact ? 60 : 124,
+              child: _buildDesktopRemoteNotice(),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildDesktopRemoteNotice() {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 286),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+        decoration: BoxDecoration(
+          color: const Color(0xFFEFF7F4),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: const Color(0xFFE3EFEB)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 22,
+                  height: 22,
+                  decoration: const BoxDecoration(
+                    color: Color(0xFF00C49A),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.rocket_launch,
+                    color: Colors.white,
+                    size: 14,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    '远程通知',
+                    style: TextStyle(
+                      color: Color(0xFF303437),
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                InkWell(
+                  onTap: _refreshOpenClawHomeStatus,
+                  child: const Icon(
+                    Icons.refresh,
+                    size: 16,
+                    color: Color(0xFF777777),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              _openClawRemoteGatewayUrl.trim().isEmpty
+                  ? '配置公网入口后，移动端或微信发来的任务会唤醒这台电脑。'
+                  : '移动端或微信已可通过远程入口唤醒本机 OpenClaw。',
+              style: const TextStyle(
+                color: Color(0xFF4C5555),
+                height: 1.45,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: _createOpenClawHomeMobilePairingCode,
+                child: const Text('查看配对'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDesktopStatusStrip() {
+    final openClawHealthy = _openClawStatus?.isHealthy == true;
+    final bridgeReady = _desktopControlStatus?.bridgeRunning == true;
+    final remoteReady = _openClawRemoteGatewayUrl.trim().isNotEmpty;
+    final chromeReady = _desktopControlStatus?.chrome.connected == true;
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        _DesktopStatusPill(
+          icon: Icons.hub_outlined,
+          label: _isOpenClawPanelLoading
+              ? 'OpenClaw 检测中'
+              : openClawHealthy
+              ? 'OpenClaw 运行中'
+              : _openClawStatus?.label ?? 'OpenClaw 未检测',
+          active: openClawHealthy,
+          onTap: _refreshOpenClawHomeStatus,
+        ),
+        _DesktopStatusPill(
+          icon: Icons.desktop_mac_outlined,
+          label: bridgeReady ? '桌面工具已连接' : '桌面工具待启动',
+          active: bridgeReady,
+          onTap: _startDesktopBridgeFromHome,
+        ),
+        _DesktopStatusPill(
+          icon: Icons.chat_bubble_outline,
+          label: remoteReady ? '微信/移动端待命' : '远程未配置',
+          active: remoteReady,
+          onTap: _createOpenClawHomeMobilePairingCode,
+        ),
+        _DesktopStatusPill(
+          icon: Icons.public,
+          label: chromeReady ? 'Chrome 已连接' : 'Chrome 连接器',
+          active: chromeReady,
+          onTap: _prepareHomeChromeConnector,
+        ),
+      ],
     );
   }
 
@@ -644,105 +977,328 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     final drawerWidth = (MediaQuery.sizeOf(context).width * 0.78)
         .clamp(292.0, 360.0)
         .toDouble();
-    final currentTitle = _conversationTitleFrom(_homeChatMessages);
 
     return Drawer(
       width: drawerWidth,
       backgroundColor: const Color(0xFF1E2024),
+      child: Consumer<FileTransferModel>(
+        builder: (context, model, _) {
+          return _buildConversationSidebar(model, embedded: false);
+        },
+      ),
+    );
+  }
+
+  Widget _buildConversationSidebar(
+    FileTransferModel model, {
+    required bool embedded,
+  }) {
+    final currentTitle = _conversationTitleFrom(_homeChatMessages);
+    final authModel = Provider.of<AuthModel?>(context, listen: false);
+    final displayName = authModel?.currentUser?.displayName.trim() ?? '';
+    final userName = displayName.isNotEmpty
+        ? displayName
+        : authModel?.currentUser?.username ?? '大乘用户';
+    final background = embedded
+        ? const Color(0xFFEDEEEE)
+        : const Color(0xFF1E2024);
+    final primaryText = embedded ? const Color(0xFF202124) : Colors.white;
+    final secondaryText = embedded ? const Color(0xFF8D9295) : Colors.white54;
+    final buttonBackground = embedded
+        ? const Color(0xFFDCDDDB)
+        : const Color(0xFF30343A);
+    final isBusy = _isAiGenerating;
+
+    return Container(
+      width: embedded ? 286 : null,
+      decoration: BoxDecoration(
+        color: background,
+        border: embedded
+            ? const Border(right: BorderSide(color: Color(0xFFE0E1E0)))
+            : null,
+      ),
       child: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(18, 18, 18, 18),
-          child: Consumer<FileTransferModel>(
-            builder: (context, model, _) {
-              final isBusy = _isAiGenerating;
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+          padding: EdgeInsets.fromLTRB(
+            embedded ? 16 : 18,
+            18,
+            embedded ? 16 : 18,
+            18,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
                 children: [
-                  Row(
-                    children: [
-                      const Expanded(
-                        child: Text(
-                          '大乘',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 24,
-                            fontWeight: FontWeight.w800,
-                          ),
-                        ),
-                      ),
-                      IconButton(
-                        tooltip: '关闭',
-                        onPressed: () => Navigator.maybePop(context),
-                        icon: const Icon(Icons.close, color: Colors.white70),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 18),
-                  SizedBox(
-                    width: double.infinity,
-                    child: FilledButton.icon(
-                      onPressed: isBusy
-                          ? null
-                          : () => _startNewConversation(model),
-                      icon: const Icon(Icons.add_comment_outlined, size: 20),
-                      label: const Text('开启新对话'),
-                      style: FilledButton.styleFrom(
-                        backgroundColor: const Color(0xFF30343A),
-                        disabledBackgroundColor: Colors.white.withValues(
-                          alpha: 0.08,
-                        ),
-                        foregroundColor: Colors.white,
-                        minimumSize: const Size.fromHeight(50),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 28),
-                  const _DrawerSectionLabel('今天'),
-                  if (_homeChatMessages.isNotEmpty) ...[
-                    _ConversationTile(
-                      title: currentTitle,
-                      selected: true,
-                      running: _shouldShowGlobalSendProcess(model),
-                      onTap: () => Navigator.maybePop(context),
-                    ),
-                    const SizedBox(height: 8),
-                  ],
                   Expanded(
-                    child: _conversationHistory.isEmpty
-                        ? const Center(
-                            child: Text(
-                              '没有更多内容啦',
-                              style: TextStyle(
-                                color: Colors.white70,
-                                fontSize: 16,
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                          )
-                        : ListView.separated(
-                            itemCount: _conversationHistory.length,
-                            separatorBuilder: (_, _) =>
-                                const SizedBox(height: 8),
-                            itemBuilder: (context, index) {
-                              final conversation = _conversationHistory[index];
-                              return _ConversationTile(
-                                title: conversation.title,
-                                selected: false,
-                                running: conversation.isGlobalSendRunning,
-                                onTap: isBusy
-                                    ? null
-                                    : () => _openConversation(conversation),
-                              );
-                            },
-                          ),
+                    child: Text(
+                      '大乘',
+                      style: TextStyle(
+                        color: primaryText,
+                        fontSize: embedded ? 18 : 24,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: '搜索',
+                    onPressed: () => _prefillPrompt('搜索当前对话、本机文件和项目资料：'),
+                    icon: Icon(Icons.search, color: secondaryText),
+                  ),
+                  IconButton(
+                    tooltip: embedded ? '检测' : '关闭',
+                    onPressed: embedded
+                        ? _refreshOpenClawHomeStatus
+                        : () => Navigator.maybePop(context),
+                    icon: Icon(
+                      embedded ? Icons.filter_alt_outlined : Icons.close,
+                      color: secondaryText,
+                    ),
                   ),
                 ],
-              );
-            },
+              ),
+              const SizedBox(height: 18),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: isBusy ? null : () => _startNewConversation(model),
+                  icon: const Icon(Icons.add_comment_outlined, size: 20),
+                  label: const Text('新建任务'),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: buttonBackground,
+                    disabledBackgroundColor: embedded
+                        ? const Color(0xFFE4E5E3)
+                        : Colors.white.withValues(alpha: 0.08),
+                    foregroundColor: primaryText,
+                    minimumSize: const Size.fromHeight(44),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 10),
+              _buildSidebarActionTile(
+                icon: Icons.smart_toy_outlined,
+                label: '助理',
+                embedded: embedded,
+                onTap: () => _prefillPrompt('让本机 OpenClaw 助理接手：'),
+              ),
+              _buildSidebarActionTile(
+                icon: Icons.account_tree_outlined,
+                label: '项目',
+                embedded: embedded,
+                onTap: () => _prefillPrompt('新建一个本机 OpenClaw 项目，目标是：'),
+              ),
+              _buildSidebarActionTile(
+                icon: Icons.hub_outlined,
+                label: '专家',
+                trailing: '技能·连接器',
+                embedded: embedded,
+                onTap: () => _prefillPrompt('召唤适合当前任务的专家和技能：'),
+              ),
+              _buildSidebarActionTile(
+                icon: Icons.alarm_on_outlined,
+                label: '自动化',
+                embedded: embedded,
+                onTap: () => _prefillPrompt('创建一个 OpenClaw 自动化任务：'),
+              ),
+              _buildSidebarActionTile(
+                icon: Icons.apps_outlined,
+                label: '更多',
+                trailing: '资料库·灵感',
+                embedded: embedded,
+                onTap: () => _prefillPrompt('帮我列出可用的资料库、灵感、技能和连接器'),
+              ),
+              const SizedBox(height: 22),
+              _DrawerSectionLabel('任务', light: embedded),
+              if (_homeChatMessages.isNotEmpty) ...[
+                _ConversationTile(
+                  title: currentTitle,
+                  selected: true,
+                  running: _shouldShowGlobalSendProcess(model),
+                  light: embedded,
+                  onTap: () {
+                    if (!embedded) Navigator.maybePop(context);
+                  },
+                ),
+                const SizedBox(height: 8),
+              ],
+              Expanded(
+                child: _conversationHistory.isEmpty
+                    ? Center(
+                        child: Text(
+                          '没有更多内容啦',
+                          style: TextStyle(
+                            color: secondaryText,
+                            fontSize: 15,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      )
+                    : ListView.separated(
+                        itemCount: _conversationHistory.length,
+                        separatorBuilder: (_, _) => const SizedBox(height: 8),
+                        itemBuilder: (context, index) {
+                          final conversation = _conversationHistory[index];
+                          return _ConversationTile(
+                            title: conversation.title,
+                            selected: false,
+                            running: conversation.isGlobalSendRunning,
+                            light: embedded,
+                            onTap: isBusy
+                                ? null
+                                : () => _openConversation(conversation),
+                          );
+                        },
+                      ),
+              ),
+              const SizedBox(height: 14),
+              _DrawerSectionLabel('空间', light: embedded),
+              _buildSidebarSpaceTile(
+                icon: Icons.folder_outlined,
+                title: '本机电脑',
+                subtitle: '浏览器、文件、桌面',
+                embedded: embedded,
+                onTap: _startDesktopBridgeFromHome,
+              ),
+              _buildSidebarSpaceTile(
+                icon: Icons.chat_bubble_outline,
+                title: '微信远程',
+                subtitle: _openClawRemoteGatewayUrl.trim().isEmpty
+                    ? '待配置'
+                    : '已配置',
+                embedded: embedded,
+                onTap: _createOpenClawHomeMobilePairingCode,
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const CircleAvatar(
+                    radius: 18,
+                    backgroundColor: Color(0xFF00B894),
+                    child: Icon(Icons.self_improvement, color: Colors.white),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      userName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: primaryText,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: '移动端配对',
+                    onPressed: _isRunningOpenClawAction
+                        ? null
+                        : _createOpenClawHomeMobilePairingCode,
+                    icon: Icon(Icons.qr_code_2_outlined, color: secondaryText),
+                  ),
+                ],
+              ),
+            ],
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSidebarActionTile({
+    required IconData icon,
+    required String label,
+    required bool embedded,
+    required VoidCallback onTap,
+    String? trailing,
+  }) {
+    final foreground = embedded ? const Color(0xFF252729) : Colors.white70;
+    final muted = embedded ? const Color(0xFF9EA1A3) : Colors.white38;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(10),
+      child: Container(
+        constraints: const BoxConstraints(minHeight: 40),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          children: [
+            Icon(icon, color: foreground, size: 20),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(
+                  color: foreground,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+            if (trailing != null)
+              Text(
+                trailing,
+                style: TextStyle(
+                  color: muted,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSidebarSpaceTile({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required bool embedded,
+    required VoidCallback onTap,
+  }) {
+    final foreground = embedded ? const Color(0xFF303236) : Colors.white70;
+    final muted = embedded ? const Color(0xFF8D9295) : Colors.white38;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(10),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        child: Row(
+          children: [
+            Icon(icon, color: foreground, size: 19),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: foreground,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: muted,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -923,7 +1479,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     );
   }
 
-  Widget _buildChatTimeline(FileTransferModel model) {
+  Widget _buildChatTimeline(FileTransferModel model, {bool light = false}) {
     final hasSendingProcess = _shouldShowGlobalSendProcess(model);
 
     return ListView(
@@ -932,7 +1488,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       padding: const EdgeInsets.fromLTRB(22, 18, 22, 22),
       children: [
         for (final message in _homeChatMessages) ...[
-          _buildChatBubble(message),
+          _buildChatBubble(message, light: light),
           const SizedBox(height: 18),
         ],
         if (_isAiGenerating)
@@ -954,6 +1510,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
                     ],
                     _buildChatBubble(
                       _HomeChatMessage(text: _streamingAiText, isUser: false),
+                      light: light,
                     ),
                   ],
                 ),
@@ -963,8 +1520,14 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     );
   }
 
-  Widget _buildChatBubble(_HomeChatMessage message) {
-    final bubbleColor = message.isUser
+  Widget _buildChatBubble(_HomeChatMessage message, {bool light = false}) {
+    final bubbleColor = light
+        ? message.isUser
+              ? const Color(0xFF1B1B1D)
+              : message.isError
+              ? const Color(0xFFFFE8E8)
+              : Colors.white.withValues(alpha: 0.82)
+        : message.isUser
         ? const Color(0xFF1B1B1D)
         : message.isError
         ? Colors.red.withValues(alpha: 0.20)
@@ -982,39 +1545,64 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     return Align(
       alignment: alignment,
       child: Container(
-        constraints: const BoxConstraints(maxWidth: 430),
+        constraints: BoxConstraints(maxWidth: light ? 680 : 430),
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-        decoration: BoxDecoration(color: bubbleColor, borderRadius: radius),
-        child: _buildChatBubbleBody(message),
+        decoration: BoxDecoration(
+          color: bubbleColor,
+          borderRadius: radius,
+          border: light && !message.isUser
+              ? Border.all(
+                  color: message.isError
+                      ? const Color(0xFFFFC9C9)
+                      : const Color(0xFFE9ECEC),
+                )
+              : null,
+          boxShadow: light && !message.isUser
+              ? [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.04),
+                    blurRadius: 22,
+                    offset: const Offset(0, 10),
+                  ),
+                ]
+              : null,
+        ),
+        child: _buildChatBubbleBody(message, light: light),
       ),
     );
   }
 
-  Widget _buildChatBubbleBody(_HomeChatMessage message) {
+  Widget _buildChatBubbleBody(_HomeChatMessage message, {bool light = false}) {
     switch (message.messageType) {
       case _HomeChatMessageType.contentPreview:
         final content = message.content;
-        if (content == null) return _MarkdownChatText(message.text);
+        if (content == null) {
+          return _MarkdownChatText(message.text, light: light);
+        }
         return _buildContentPreviewMessage(content);
       case _HomeChatMessageType.choice:
         return _buildInlineChoiceMessage(message);
       case _HomeChatMessageType.flashcardPreview:
         final deck = message.deck;
-        if (deck == null) return _MarkdownChatText(message.text);
+        if (deck == null) return _MarkdownChatText(message.text, light: light);
         return _buildFlashcardDeckPreview(deck);
       case _HomeChatMessageType.text:
         if (message.isUser || message.isError) {
           return Text(
             message.text,
             style: TextStyle(
-              color: message.isError ? Colors.red[100] : Colors.white,
+              color: message.isError
+                  ? light
+                        ? const Color(0xFF9D1C1C)
+                        : Colors.red[100]
+                  : Colors.white,
               fontSize: 17,
               height: 1.42,
               fontWeight: message.isUser ? FontWeight.w700 : FontWeight.w500,
             ),
           );
         }
-        return _MarkdownChatText(message.text);
+        return _MarkdownChatText(message.text, light: light);
     }
   }
 
@@ -2186,6 +2774,228 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     );
   }
 
+  Widget _buildDesktopChatComposer(
+    BuildContext context,
+    FileTransferModel model,
+  ) {
+    final isBusy =
+        model.isPreparingSend ||
+        _isPublishingDraft ||
+        _isPreparingFlashcardContent ||
+        _isFlashcardGenerating ||
+        (_isDharmaComposerMode && model.isTransferring);
+    final inputText = _chatInputController.text.trim();
+    final hasFlashcardContext =
+        (_activeFlashcardContent?.text.trim().isNotEmpty ?? false);
+    final canSubmit = _isFlashcardComposerMode
+        ? !_isPreparingFlashcardContent &&
+              !_isFlashcardGenerating &&
+              (inputText.isNotEmpty || hasFlashcardContext)
+        : _isDharmaComposerMode
+        ? _dharmaComposerTarget == DharmaComposerTarget.platform
+              ? (inputText.isNotEmpty || model.hasFiles) &&
+                    _selectedPublishPlatforms.isNotEmpty
+              : (inputText.isNotEmpty || model.hasFiles)
+        : inputText.isNotEmpty;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: const Color(0xFFE4E5E4)),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x11000000),
+            blurRadius: 20,
+            offset: Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: _chatInputController,
+            enabled:
+                !model.isPreparingSend &&
+                !_isPreparingFlashcardContent &&
+                !_isFlashcardGenerating &&
+                (!model.isTransferring || !_isDharmaComposerMode),
+            minLines: 2,
+            maxLines: 5,
+            textInputAction: TextInputAction.newline,
+            style: const TextStyle(
+              color: Color(0xFF202124),
+              fontSize: 15,
+              height: 1.35,
+            ),
+            decoration: const InputDecoration(
+              border: InputBorder.none,
+              hintText: '今天帮你做些什么？  @ 引用对话文件，/ 调用技能与指令',
+              hintStyle: TextStyle(color: Color(0xFF9AA0A6), fontSize: 15),
+              contentPadding: EdgeInsets.fromLTRB(18, 16, 18, 10),
+            ),
+            onChanged: (_) => setState(() {}),
+            onSubmitted: (_) {
+              if (canSubmit) _submitComposer(model);
+            },
+          ),
+          const Divider(height: 1, color: Color(0xFFEDEDEB)),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 10, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      _DesktopComposerButton(
+                        icon: Icons.auto_fix_high_outlined,
+                        label: 'Craft',
+                        onTap: () => _prefillPrompt('帮我把这个任务重写成更清晰的执行指令：'),
+                      ),
+                      _buildDesktopModeMenu(),
+                      _buildDesktopSkillsMenu(),
+                      _buildDesktopConnectMenu(),
+                      _buildDesktopPermissionMenu(),
+                      _DesktopComposerButton(
+                        icon: Icons.folder_outlined,
+                        label: '选择工作空间',
+                        onTap: () => _prefillPrompt('把当前目录作为工作空间，帮我规划接下来的操作'),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: '添加',
+                  onPressed: isBusy
+                      ? null
+                      : () => _openSendContentMenu(context, model),
+                  icon: const Icon(Icons.add, color: Color(0xFF34363A)),
+                ),
+                IconButton(
+                  tooltip: '工具',
+                  onPressed: () => _prefillPrompt('帮我查找并安装适合当前任务的技能'),
+                  icon: const Icon(
+                    Icons.auto_awesome_outlined,
+                    color: Color(0xFF34363A),
+                  ),
+                ),
+                IconButton(
+                  tooltip: '语音输入',
+                  onPressed: () => _prefillPrompt('请根据我的语音输入整理任务：'),
+                  icon: const Icon(Icons.mic_none, color: Color(0xFF34363A)),
+                ),
+                IconButton(
+                  tooltip: _isAiGenerating ? '停止' : '发送',
+                  onPressed: _isAiGenerating
+                      ? _stopAiGeneration
+                      : canSubmit
+                      ? () => _submitComposer(model)
+                      : null,
+                  icon: Icon(_isAiGenerating ? Icons.stop : Icons.arrow_upward),
+                  style: IconButton.styleFrom(
+                    backgroundColor: canSubmit || _isAiGenerating
+                        ? const Color(0xFF9EA0A3)
+                        : const Color(0xFFD6D6D2),
+                    foregroundColor: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDesktopModeMenu() {
+    return PopupMenuButton<String>(
+      tooltip: '模型模式',
+      onSelected: (value) => setState(() => _openClawModeLabel = value),
+      itemBuilder: (context) => const [
+        PopupMenuItem(value: '自动', child: Text('自动')),
+        PopupMenuItem(value: '本机全能', child: Text('本机全能')),
+        PopupMenuItem(value: '远程接管', child: Text('远程接管')),
+        PopupMenuItem(value: '微信待命', child: Text('微信待命')),
+      ],
+      child: _DesktopComposerButton(
+        icon: Icons.psychology_alt_outlined,
+        label: _openClawModeLabel,
+      ),
+    );
+  }
+
+  Widget _buildDesktopSkillsMenu() {
+    return PopupMenuButton<String>(
+      tooltip: '技能',
+      onSelected: _handleDesktopSkillSelection,
+      itemBuilder: (context) => const [
+        PopupMenuItem(value: 'find', child: Text('find-skills')),
+        PopupMenuItem(value: 'publish', child: Text('media-auto-publisher')),
+        PopupMenuItem(
+          value: 'wechat-draft',
+          child: Text('wechat-draft-publisher'),
+        ),
+        PopupMenuItem(value: 'browser', child: Text('Web Access')),
+        PopupMenuItem(value: 'doc', child: Text('PDF / Word / Excel')),
+        PopupMenuDivider(),
+        PopupMenuItem(value: 'import', child: Text('导入技能')),
+      ],
+      child: const _DesktopComposerButton(
+        icon: Icons.handyman_outlined,
+        label: '技能',
+      ),
+    );
+  }
+
+  Widget _buildDesktopConnectMenu() {
+    return PopupMenuButton<String>(
+      tooltip: '连应用',
+      onSelected: _handleDesktopConnectorSelection,
+      itemBuilder: (context) => const [
+        PopupMenuItem(value: 'wechat', child: Text('微信')),
+        PopupMenuItem(value: 'wechatPlugin', child: Text('安装微信插件')),
+        PopupMenuItem(value: 'mobile', child: Text('移动端')),
+        PopupMenuItem(value: 'chrome', child: Text('Chrome')),
+        PopupMenuItem(value: 'desktop', child: Text('本机桌面')),
+        PopupMenuItem(value: 'remote', child: Text('远程入口')),
+        PopupMenuItem(value: 'permissions', child: Text('系统权限')),
+        PopupMenuDivider(),
+        PopupMenuItem(value: 'restart', child: Text('重启本机 AI')),
+        PopupMenuItem(value: 'channels', child: Text('渠道状态')),
+        PopupMenuItem(value: 'log', child: Text('复制诊断日志')),
+      ],
+      child: const _DesktopComposerButton(
+        icon: Icons.link_outlined,
+        label: '连应用',
+      ),
+    );
+  }
+
+  Widget _buildDesktopPermissionMenu() {
+    return PopupMenuButton<String>(
+      tooltip: '权限',
+      onSelected: (value) {
+        setState(() => _openClawPermissionLabel = value);
+        if (value == '完全访问权限') {
+          unawaited(_loadOpenClawHomeStatus(probeOpenClaw: true));
+        }
+      },
+      itemBuilder: (context) => const [
+        PopupMenuItem(value: '默认权限', child: Text('默认权限')),
+        PopupMenuItem(value: '完全访问权限', child: Text('完全访问权限')),
+      ],
+      child: _DesktopComposerButton(
+        icon: Icons.verified_user_outlined,
+        label: _openClawPermissionLabel,
+      ),
+    );
+  }
+
   Widget _buildComposerActionButton(
     FileTransferModel model, {
     required bool canSubmit,
@@ -2401,6 +3211,69 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
       return selected;
     }
     return false;
+  }
+
+  void _handleDesktopSkillSelection(String value) {
+    switch (value) {
+      case 'find':
+        _prefillPrompt('帮我查找并安装适合当前任务的 OpenClaw 技能');
+        break;
+      case 'publish':
+        _prefillPrompt('使用 media-auto-publisher 发布这篇内容');
+        break;
+      case 'wechat-draft':
+        _prefillPrompt('使用 wechat-draft-publisher 上传微信公众号草稿');
+        break;
+      case 'browser':
+        _prefillPrompt('使用浏览器自动化打开网页、截图并提取信息');
+        break;
+      case 'doc':
+        _prefillPrompt('帮我处理 PDF/Word/Excel 文件并生成结果');
+        break;
+      case 'import':
+        _prefillPrompt('帮我导入一个 OpenClaw 技能');
+        break;
+    }
+  }
+
+  void _handleDesktopConnectorSelection(String value) {
+    switch (value) {
+      case 'wechat':
+        unawaited(_loginOpenClawHomeWeChat());
+        break;
+      case 'wechatPlugin':
+        unawaited(_installOpenClawHomeWeChatPlugin());
+        break;
+      case 'mobile':
+        unawaited(_createOpenClawHomeMobilePairingCode());
+        break;
+      case 'chrome':
+        unawaited(_prepareHomeChromeConnector());
+        break;
+      case 'desktop':
+        unawaited(_startDesktopBridgeFromHome());
+        break;
+      case 'remote':
+        unawaited(_editOpenClawHomeRemoteGatewayUrl());
+        break;
+      case 'permissions':
+        unawaited(
+          _requestHomeDesktopPermission(
+            screenRecording:
+                _desktopControlStatus?.screenRecordingGranted != true,
+          ),
+        );
+        break;
+      case 'restart':
+        unawaited(_restartOpenClawFromHome());
+        break;
+      case 'channels':
+        unawaited(_inspectOpenClawHomeChannels());
+        break;
+      case 'log':
+        unawaited(_copyDiagnosticLogTailFromHome());
+        break;
+    }
   }
 
   void _submitComposer(FileTransferModel model) {
@@ -3765,6 +4638,271 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     });
   }
 
+  Future<void> _loadOpenClawHomeStatus({required bool probeOpenClaw}) async {
+    if (!AiBackendPolicy.isDesktopNative) return;
+    if (mounted) setState(() => _isOpenClawPanelLoading = true);
+    try {
+      final values = await Future.wait<dynamic>([
+        AppSettings.getOpenClawRemoteGatewayUrl(),
+        OpenClawRuntime.instance
+            .getStatus(probe: probeOpenClaw)
+            .timeout(const Duration(seconds: 8)),
+        DesktopControlBridge.instance.getStatus().timeout(
+          const Duration(seconds: 5),
+        ),
+      ]);
+      if (!mounted) return;
+      setState(() {
+        _openClawRemoteGatewayUrl = (values[0] as String).trim();
+        _openClawStatus = values[1] as OpenClawRuntimeStatus;
+        _desktopControlStatus = values[2] as DesktopControlBridgeStatus;
+        _isOpenClawPanelLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _openClawStatus = OpenClawRuntimeStatus(
+          state: OpenClawRuntimeState.failed,
+          message: 'OpenClaw 状态检测失败：$error',
+          checkedAt: DateTime.now(),
+        );
+        _isOpenClawPanelLoading = false;
+      });
+    }
+  }
+
+  Future<void> _refreshOpenClawHomeStatus() {
+    return _loadOpenClawHomeStatus(probeOpenClaw: true);
+  }
+
+  Future<void> _restartOpenClawFromHome() async {
+    if (!AiBackendPolicy.isDesktopNative || _isRestartingOpenClaw) return;
+    setState(() => _isRestartingOpenClaw = true);
+    OpenClawRuntimeStatus status;
+    try {
+      status = await OpenClawRuntime.instance.restart().timeout(
+        const Duration(seconds: 75),
+      );
+    } catch (error) {
+      status = OpenClawRuntimeStatus(
+        state: OpenClawRuntimeState.failed,
+        message: 'OpenClaw 重启失败：$error',
+        checkedAt: DateTime.now(),
+      );
+    }
+    if (!mounted) return;
+    setState(() {
+      _openClawStatus = status;
+      _isRestartingOpenClaw = false;
+    });
+    unawaited(_loadOpenClawHomeStatus(probeOpenClaw: true));
+    _showHomeSnack(
+      status.isHealthy ? '本机 OpenClaw 已启动' : status.message,
+      ok: status.isHealthy,
+    );
+  }
+
+  Future<void> _runOpenClawHomeCliAction(
+    String label,
+    Future<OpenClawCliResult> Function() action,
+  ) async {
+    if (!AiBackendPolicy.isDesktopNative || _isRunningOpenClawAction) return;
+    setState(() => _isRunningOpenClawAction = true);
+    OpenClawCliResult? result;
+    Object? error;
+    try {
+      result = await action();
+    } catch (err) {
+      error = err;
+      debugPrint('首页 OpenClaw $label 失败: $err');
+    }
+    if (!mounted) return;
+    setState(() => _isRunningOpenClawAction = false);
+    if (result == null) {
+      _showHomeSnack('$label 失败：$error', ok: false);
+      return;
+    }
+    await _showOpenClawCliResult(label, result);
+    unawaited(_loadOpenClawHomeStatus(probeOpenClaw: true));
+  }
+
+  Future<void> _showOpenClawCliResult(
+    String title,
+    OpenClawCliResult result,
+  ) async {
+    final output = [
+      result.command,
+      'exitCode=${result.exitCode}${result.timedOut ? ' · timed out' : ''}',
+      if (result.combinedOutput.trim().isNotEmpty) '',
+      if (result.combinedOutput.trim().isNotEmpty) result.combinedOutput,
+    ].join('\n');
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: SizedBox(
+          width: 620,
+          child: SingleChildScrollView(
+            child: SelectableText(
+              output,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: output));
+              Navigator.of(context).pop();
+            },
+            child: const Text('复制'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('关闭'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _editOpenClawHomeRemoteGatewayUrl() async {
+    final controller = TextEditingController(text: _openClawRemoteGatewayUrl);
+    final value = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('远程入口'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'wss://...',
+            helperText: '移动端、微信、小程序从公网远程连接这台电脑',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (value == null) return;
+    await AppSettings.setOpenClawRemoteGatewayUrl(value.trim());
+    if (!mounted) return;
+    setState(() => _openClawRemoteGatewayUrl = value.trim());
+    _showHomeSnack('已保存远程入口，重启本机 AI 后生效');
+  }
+
+  Future<void> _createOpenClawHomeMobilePairingCode() async {
+    if (_openClawRemoteGatewayUrl.trim().isEmpty) {
+      await _editOpenClawHomeRemoteGatewayUrl();
+      if (_openClawRemoteGatewayUrl.trim().isEmpty) return;
+    }
+    await _runOpenClawHomeCliAction(
+      '移动端配对码',
+      () => OpenClawRuntime.instance.createMobilePairingCode(remote: true),
+    );
+  }
+
+  Future<void> _installOpenClawHomeWeChatPlugin() {
+    return _runOpenClawHomeCliAction(
+      '安装微信插件',
+      OpenClawRuntime.instance.installWeChatPlugin,
+    );
+  }
+
+  Future<void> _loginOpenClawHomeWeChat() {
+    return _runOpenClawHomeCliAction(
+      '微信扫码登录',
+      OpenClawRuntime.instance.loginWeChat,
+    );
+  }
+
+  Future<void> _inspectOpenClawHomeChannels() {
+    return _runOpenClawHomeCliAction(
+      'OpenClaw 渠道状态',
+      OpenClawRuntime.instance.inspectChannels,
+    );
+  }
+
+  Future<void> _prepareHomeChromeConnector() async {
+    if (!AiBackendPolicy.isDesktopNative || _isPreparingChromeConnector) {
+      return;
+    }
+    setState(() => _isPreparingChromeConnector = true);
+    String? path;
+    Object? error;
+    try {
+      path = await DesktopControlBridge.instance
+          .prepareChromeConnectorInstall()
+          .timeout(const Duration(seconds: 20));
+    } catch (err) {
+      error = err;
+    }
+    if (!mounted) return;
+    setState(() => _isPreparingChromeConnector = false);
+    unawaited(_loadOpenClawHomeStatus(probeOpenClaw: true));
+    _showHomeSnack(
+      error != null
+          ? 'Chrome 连接器准备失败：$error'
+          : path == null
+          ? '当前构建未启用 Chrome 连接器'
+          : 'Chrome 连接器目录已打开',
+      ok: error == null,
+    );
+  }
+
+  Future<void> _startDesktopBridgeFromHome() async {
+    try {
+      final status = await DesktopControlBridge.instance.ensureStarted();
+      if (!mounted) return;
+      setState(() => _desktopControlStatus = status);
+      _showHomeSnack(status.message, ok: status.desktopControlAvailable);
+    } catch (error) {
+      if (!mounted) return;
+      _showHomeSnack('桌面工具启动失败：$error', ok: false);
+    }
+  }
+
+  Future<void> _requestHomeDesktopPermission({
+    required bool screenRecording,
+  }) async {
+    final result = screenRecording
+        ? await DesktopControlBridge.instance.requestScreenRecordingPermission()
+        : await DesktopControlBridge.instance.requestAccessibilityPermission();
+    await _loadOpenClawHomeStatus(probeOpenClaw: true);
+    if (!mounted) return;
+    _showHomeSnack(result['message']?.toString() ?? '已打开系统权限请求');
+  }
+
+  Future<void> _copyDiagnosticLogTailFromHome() async {
+    final path = await DiagnosticLogService.instance.logFilePath();
+    final tail = await DiagnosticLogService.instance.tail(maxLines: 400);
+    await Clipboard.setData(
+      ClipboardData(text: '诊断日志路径: ${path ?? '无持久化日志路径'}\n\n$tail'),
+    );
+    if (!mounted) return;
+    _showHomeSnack(path == null ? '已复制当前诊断日志内容' : '已复制诊断日志内容和路径');
+  }
+
+  void _showHomeSnack(String text, {bool ok = true}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(text),
+        backgroundColor: ok ? Colors.green : Colors.redAccent,
+      ),
+    );
+  }
+
   Future<void> _setLocalLoopbackEnabled(
     FileTransferModel model,
     bool enabled,
@@ -4863,13 +6001,17 @@ class _AiActivityLabel extends StatelessWidget {
 
 class _MarkdownChatText extends StatelessWidget {
   final String data;
+  final bool light;
 
-  const _MarkdownChatText(this.data);
+  const _MarkdownChatText(this.data, {this.light = false});
 
   @override
   Widget build(BuildContext context) {
-    const baseStyle = TextStyle(
-      color: Colors.white,
+    final baseColor = light ? const Color(0xFF23272B) : Colors.white;
+    final mutedColor = light ? const Color(0xFF5E666B) : Colors.white70;
+    final codeColor = light ? const Color(0xFF123B59) : const Color(0xFFE9F4FF);
+    final baseStyle = TextStyle(
+      color: baseColor,
       fontSize: 17,
       height: 1.46,
       fontWeight: FontWeight.w500,
@@ -4886,9 +6028,11 @@ class _MarkdownChatText extends StatelessWidget {
         h1: baseStyle.copyWith(fontSize: 22, fontWeight: FontWeight.w800),
         h2: baseStyle.copyWith(fontSize: 20, fontWeight: FontWeight.w800),
         h3: baseStyle.copyWith(fontSize: 18, fontWeight: FontWeight.w800),
-        blockquote: baseStyle.copyWith(color: Colors.white70),
+        blockquote: baseStyle.copyWith(color: mutedColor),
         blockquoteDecoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.06),
+          color: light
+              ? const Color(0xFFF2F5F5)
+              : Colors.white.withValues(alpha: 0.06),
           borderRadius: BorderRadius.circular(8),
           border: Border(
             left: BorderSide(
@@ -4898,14 +6042,20 @@ class _MarkdownChatText extends StatelessWidget {
           ),
         ),
         code: baseStyle.copyWith(
-          color: const Color(0xFFE9F4FF),
+          color: codeColor,
           fontFamily: 'monospace',
           fontSize: 15,
         ),
         codeblockDecoration: BoxDecoration(
-          color: Colors.black.withValues(alpha: 0.24),
+          color: light
+              ? const Color(0xFFF3F5F6)
+              : Colors.black.withValues(alpha: 0.24),
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+          border: Border.all(
+            color: light
+                ? const Color(0xFFE1E5E6)
+                : Colors.white.withValues(alpha: 0.08),
+          ),
         ),
         listBullet: baseStyle,
         a: baseStyle.copyWith(
@@ -4920,7 +6070,11 @@ class _MarkdownChatText extends StatelessWidget {
         ),
         horizontalRuleDecoration: BoxDecoration(
           border: Border(
-            top: BorderSide(color: Colors.white.withValues(alpha: 0.14)),
+            top: BorderSide(
+              color: light
+                  ? const Color(0xFFE1E5E6)
+                  : Colors.white.withValues(alpha: 0.14),
+            ),
           ),
         ),
       ),
@@ -5130,8 +6284,9 @@ class _HomeConversation {
 
 class _DrawerSectionLabel extends StatelessWidget {
   final String label;
+  final bool light;
 
-  const _DrawerSectionLabel(this.label);
+  const _DrawerSectionLabel(this.label, {this.light = false});
 
   @override
   Widget build(BuildContext context) {
@@ -5139,8 +6294,8 @@ class _DrawerSectionLabel extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 10),
       child: Text(
         label,
-        style: const TextStyle(
-          color: Colors.white38,
+        style: TextStyle(
+          color: light ? const Color(0xFF9EA1A3) : Colors.white38,
           fontSize: 16,
           fontWeight: FontWeight.w800,
         ),
@@ -5153,17 +6308,25 @@ class _ConversationTile extends StatelessWidget {
   final String title;
   final bool selected;
   final bool running;
+  final bool light;
   final VoidCallback? onTap;
 
   const _ConversationTile({
     required this.title,
     required this.selected,
     this.running = false,
+    this.light = false,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
+    final foreground = light ? const Color(0xFF202124) : Colors.white;
+    final muted = light ? const Color(0xFF6E7377) : Colors.white70;
+    final selectedColor = light
+        ? const Color(0xFFDCDDDB)
+        : Colors.white.withValues(alpha: 0.08);
+
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(16),
@@ -5171,9 +6334,7 @@ class _ConversationTile extends StatelessWidget {
         constraints: const BoxConstraints(minHeight: 56),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         decoration: BoxDecoration(
-          color: selected
-              ? Colors.white.withValues(alpha: 0.08)
-              : Colors.transparent,
+          color: selected ? selectedColor : Colors.transparent,
           borderRadius: BorderRadius.circular(16),
         ),
         child: Row(
@@ -5189,15 +6350,15 @@ class _ConversationTile extends StatelessWidget {
                   )
                 : Icon(
                     selected ? Icons.chat_bubble : Icons.history,
-                    color: Colors.white70,
+                    color: muted,
                     size: 18,
                   ),
             const SizedBox(width: 12),
             Expanded(
               child: Text(
                 title,
-                style: const TextStyle(
-                  color: Colors.white,
+                style: TextStyle(
+                  color: foreground,
                   fontSize: 17,
                   fontWeight: FontWeight.w800,
                 ),
@@ -5257,6 +6418,196 @@ class _QuickPromptPill extends StatelessWidget {
                 fontSize: labelSize,
                 fontWeight: FontWeight.w800,
               ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopModeChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _DesktopModeChip({
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        height: 44,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xFF2F3033) : const Color(0xFFE7E7E5),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              color: selected ? Colors.white : const Color(0xFF4E5356),
+              size: 19,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: TextStyle(
+                color: selected ? Colors.white : const Color(0xFF4E5356),
+                fontSize: 15,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopPromptPill extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _DesktopPromptPill({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        height: 44,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: const Color(0xFFE2E3E2)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: const Color(0xFF4E5356), size: 19),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF303236),
+                fontSize: 15,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopStatusPill extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool active;
+  final VoidCallback onTap;
+
+  const _DesktopStatusPill({
+    required this.icon,
+    required this.label,
+    required this.active,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 7),
+        decoration: BoxDecoration(
+          color: active ? const Color(0xFFE4F7EF) : const Color(0xFFE9EAEA),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: active ? const Color(0xFFB6E8D5) : const Color(0xFFDCDDDB),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              color: active ? const Color(0xFF00A37E) : const Color(0xFF6E7377),
+              size: 16,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                color: active
+                    ? const Color(0xFF047B62)
+                    : const Color(0xFF5F6368),
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopComposerButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback? onTap;
+
+  const _DesktopComposerButton({
+    required this.icon,
+    required this.label,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(9),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: const Color(0xFF34363A), size: 18),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF34363A),
+                fontSize: 14,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(width: 3),
+            const Icon(
+              Icons.keyboard_arrow_down,
+              color: Color(0xFF70757A),
+              size: 16,
             ),
           ],
         ),

--- a/fabushi/lib/screens/main_navigation_screen_native.dart
+++ b/fabushi/lib/screens/main_navigation_screen_native.dart
@@ -41,6 +41,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     final tab = Uri.base.queryParameters['tab']?.toLowerCase();
     final initialIndex = switch (tab) {
       'home' => 0,
+      'assistant' || 'openclaw' || 'workbench' => 0,
       'meditation' || 'meditation-room' || 'zen' => 1,
       'profile' || 'me' || 'mine' => 2,
       _ => 0,

--- a/fabushi/lib/screens/settings_screen.dart
+++ b/fabushi/lib/screens/settings_screen.dart
@@ -52,12 +52,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   // 桌面 AI / OpenClaw 设置
   String _aiBackendModeName = 'auto';
+  String _openClawRemoteGatewayUrl = '';
   OpenClawRuntimeStatus? _openClawStatus;
   DesktopControlBridgeStatus? _desktopControlStatus;
   List<DesktopControlPendingConfirmation> _desktopControlPending = const [];
   bool _isRestartingOpenClaw = false;
+  bool _isRunningOpenClawCli = false;
   bool _isPreparingChromeConnector = false;
   StreamSubscription<void>? _desktopControlSubscription;
+  String _settingsCategory = 'system';
 
   @override
   void initState() {
@@ -156,6 +159,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
         AppSettings.getAiBackendModeName(),
         _aiBackendModeName,
       ),
+      _loadSetting<String>(
+        'OpenClaw 远程入口',
+        AppSettings.getOpenClawRemoteGatewayUrl(),
+        _openClawRemoteGatewayUrl,
+      ),
     ]);
 
     if (mounted) {
@@ -165,6 +173,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _matchThreshold = values[2] as double;
         _appVersionLabel = values[3] as String;
         _aiBackendModeName = values[4] as String;
+        _openClawRemoteGatewayUrl = values[5] as String;
         _isLoading = false;
       });
     }
@@ -308,6 +317,163 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (value == null || value.isEmpty) return;
     setState(() => _aiBackendModeName = value);
     await AppSettings.setAiBackendModeName(value);
+  }
+
+  Future<void> _editOpenClawRemoteGatewayUrl() async {
+    final controller = TextEditingController(text: _openClawRemoteGatewayUrl);
+    final value = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('远程入口'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'wss://...',
+            helperText: '移动端远程扫码需要公网 HTTPS/Tailscale Serve/Funnel 入口',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (value == null) return;
+    await AppSettings.setOpenClawRemoteGatewayUrl(value);
+    if (!mounted) return;
+    setState(() => _openClawRemoteGatewayUrl = value.trim());
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('已保存远程入口，重启本机 AI 后生效'),
+        backgroundColor: Colors.green,
+      ),
+    );
+  }
+
+  Future<void> _runOpenClawCliAction(
+    String label,
+    Future<OpenClawCliResult> Function() action,
+  ) async {
+    if (!AiBackendPolicy.isDesktopNative || _isRunningOpenClawCli) return;
+    setState(() => _isRunningOpenClawCli = true);
+    OpenClawCliResult? result;
+    Object? error;
+    try {
+      result = await action();
+    } catch (err) {
+      error = err;
+      debugPrint('Settings: $label 失败: $err');
+    }
+    if (!mounted) return;
+    setState(() => _isRunningOpenClawCli = false);
+    if (result != null) {
+      await _showOpenClawCliResult(label, result);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('$label 失败：$error'),
+          backgroundColor: Colors.redAccent,
+        ),
+      );
+    }
+    unawaited(_loadDesktopRuntimeSettings(probeOpenClaw: true));
+  }
+
+  Future<void> _showOpenClawCliResult(
+    String title,
+    OpenClawCliResult result,
+  ) async {
+    final output = [
+      result.command,
+      'exitCode=${result.exitCode}${result.timedOut ? ' · timed out' : ''}',
+      if (result.combinedOutput.trim().isNotEmpty) '',
+      if (result.combinedOutput.trim().isNotEmpty) result.combinedOutput,
+    ].join('\n');
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: SizedBox(
+          width: 560,
+          child: SingleChildScrollView(
+            child: SelectableText(
+              output,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: output));
+              Navigator.of(context).pop();
+            },
+            child: const Text('复制'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('关闭'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _createOpenClawMobilePairingCode() async {
+    if (_openClawRemoteGatewayUrl.trim().isEmpty) {
+      await _editOpenClawRemoteGatewayUrl();
+      if (_openClawRemoteGatewayUrl.trim().isEmpty) return;
+    }
+    await _runOpenClawCliAction(
+      '移动端配对码',
+      () => OpenClawRuntime.instance.createMobilePairingCode(remote: true),
+    );
+  }
+
+  Future<void> _installOpenClawWeChatPlugin() {
+    return _runOpenClawCliAction(
+      '安装微信插件',
+      OpenClawRuntime.instance.installWeChatPlugin,
+    );
+  }
+
+  Future<void> _loginOpenClawWeChat() {
+    return _runOpenClawCliAction(
+      '微信扫码登录',
+      OpenClawRuntime.instance.loginWeChat,
+    );
+  }
+
+  Future<void> _inspectOpenClawChannels() {
+    return _runOpenClawCliAction(
+      'OpenClaw 渠道状态',
+      OpenClawRuntime.instance.inspectChannels,
+    );
+  }
+
+  Future<void> _requestDesktopPermission({
+    required bool screenRecording,
+  }) async {
+    final result = screenRecording
+        ? await DesktopControlBridge.instance.requestScreenRecordingPermission()
+        : await DesktopControlBridge.instance.requestAccessibilityPermission();
+    await _refreshDesktopControlStatus(startBridge: true);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(result['message']?.toString() ?? '已打开系统权限请求'),
+        backgroundColor: Colors.green,
+      ),
+    );
   }
 
   Future<void> _refreshOpenClawStatus() async {
@@ -740,116 +906,326 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('设置'),
-        backgroundColor: const Color(0xFF121212),
-        foregroundColor: Colors.white,
-      ),
-      backgroundColor: const Color(0xFF121212),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : SingleChildScrollView(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // TODO: 临时隐藏，后续需要再开启
-                  // // AI 模型设置
-                  // _buildModelSettingCard(),
-                  //
-                  // // TTS 默认静音设置
-                  // _buildTtsMuteSettingItem(),
-                  //
-                  // // 读诵匹配阈值设置
-                  // _buildRecitationThresholdSettings(),
-                  if (AiBackendPolicy.isDesktopNative) ...[
-                    _buildOpenClawSettingCard(),
-                    const SizedBox(height: 12),
-                  ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final desktop = constraints.maxWidth >= 900;
+        return Scaffold(
+          appBar: desktop
+              ? null
+              : AppBar(
+                  title: const Text('设置'),
+                  backgroundColor: const Color(0xFF121212),
+                  foregroundColor: Colors.white,
+                ),
+          backgroundColor: desktop
+              ? const Color(0xFFEDEEEE)
+              : const Color(0xFF121212),
+          body: _isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : desktop
+              ? _buildSettingsDesktopLayout()
+              : _buildSettingsMobileList(),
+        );
+      },
+    );
+  }
 
-                  // Android 后台保活设置（仅 Android 显示）
-                  if (Platform.isAndroid)
-                    _buildSettingItem(
-                      context,
-                      icon: Icons.battery_saver,
-                      iconColor: Colors.green,
-                      title: '后台保活设置',
-                      subtitle: '防止应用被系统清理',
-                      onTap: () => Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => const KeepAliveGuideScreen(),
-                        ),
-                      ),
-                    ),
-
-                  _buildSettingItem(
-                    context,
-                    icon: Icons.refresh,
-                    iconColor: Colors.cyan,
-                    title: '刷新数据',
-                    subtitle: '重新同步账户信息',
-                    onTap: () async {
-                      final authModel = Provider.of<AuthModel>(
-                        context,
-                        listen: false,
-                      );
-                      await authModel.refreshUserInfo();
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                            content: Text('数据已刷新'),
-                            backgroundColor: Colors.green,
-                          ),
-                        );
-                      }
-                    },
-                  ),
-
-                  _buildSettingItem(
-                    context,
-                    icon: Icons.visibility_outlined,
-                    iconColor: Colors.purpleAccent,
-                    title: '修行隐私',
-                    subtitle: '控制修行排行榜与公开记录的展示范围',
-                    onTap: () => Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const PracticePrivacyScreen(),
-                      ),
-                    ),
-                  ),
-
-                  _buildSettingItem(
-                    context,
-                    icon: Icons.help_outline,
-                    iconColor: Colors.orange,
-                    title: '帮助与反馈',
-                    subtitle: '提交问题或建议，发送到支持邮箱',
-                    onTap: _showFeedbackDialog,
-                  ),
-
-                  _buildSettingItem(
-                    context,
-                    icon: Icons.info_outline,
-                    iconColor: Colors.blue,
-                    title: '关于',
-                    subtitle: '版本 $_appVersionLabel',
-                    onTap: () => showAboutDialog(
-                      context: context,
-                      applicationName: AppConstants.appName,
-                      applicationVersion: _appVersionLabel,
-                      children: [const Text('传播佛法，利益众生')],
-                    ),
-                  ),
-
-                  _buildDeleteAccountItem(context),
-
-                  _buildLogoutItem(context),
-                ],
+  Widget _buildSettingsMobileList() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (AiBackendPolicy.isDesktopNative) ...[
+            _buildOpenClawSettingCard(),
+            const SizedBox(height: 12),
+          ],
+          if (Platform.isAndroid)
+            _buildSettingItem(
+              context,
+              icon: Icons.battery_saver,
+              iconColor: Colors.green,
+              title: '后台保活设置',
+              subtitle: '防止应用被系统清理',
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const KeepAliveGuideScreen()),
               ),
             ),
+          _buildSettingItem(
+            context,
+            icon: Icons.refresh,
+            iconColor: Colors.cyan,
+            title: '刷新数据',
+            subtitle: '重新同步账户信息',
+            onTap: _refreshAccountData,
+          ),
+          _buildSettingItem(
+            context,
+            icon: Icons.visibility_outlined,
+            iconColor: Colors.purpleAccent,
+            title: '修行隐私',
+            subtitle: '控制修行排行榜与公开记录的展示范围',
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const PracticePrivacyScreen()),
+            ),
+          ),
+          _buildSettingItem(
+            context,
+            icon: Icons.help_outline,
+            iconColor: Colors.orange,
+            title: '帮助与反馈',
+            subtitle: '提交问题或建议，发送到支持邮箱',
+            onTap: _showFeedbackDialog,
+          ),
+          _buildSettingItem(
+            context,
+            icon: Icons.info_outline,
+            iconColor: Colors.blue,
+            title: '关于',
+            subtitle: '版本 $_appVersionLabel',
+            onTap: _showAbout,
+          ),
+          _buildDeleteAccountItem(context),
+          _buildLogoutItem(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSettingsDesktopLayout() {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 1160),
+        child: Container(
+          margin: const EdgeInsets.all(30),
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: const [
+              BoxShadow(
+                color: Color(0x22000000),
+                blurRadius: 24,
+                offset: Offset(0, 12),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              _buildSettingsCategorySidebar(),
+              Expanded(child: _buildSettingsCategoryContent()),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingsCategorySidebar() {
+    final categories = [
+      ('account', Icons.person_outline, '账户管理'),
+      ('system', Icons.settings_outlined, '系统设置'),
+      ('agent', Icons.extension_outlined, '智能体设置'),
+      ('memory', Icons.psychology_outlined, '记忆'),
+      ('model', Icons.view_in_ar_outlined, '模型'),
+      ('data', Icons.storage_outlined, '数据管理'),
+      ('security', Icons.shield_outlined, '安全中心'),
+      ('help', Icons.help_outline, '帮助与反馈'),
+    ];
+
+    return Container(
+      width: 250,
+      color: const Color(0xFFF0F1F0),
+      padding: const EdgeInsets.fromLTRB(12, 34, 12, 20),
+      child: Column(
+        children: [
+          for (final item in categories)
+            _SettingsCategoryTile(
+              icon: item.$2,
+              label: item.$3,
+              selected: _settingsCategory == item.$1,
+              onTap: () => setState(() => _settingsCategory = item.$1),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSettingsCategoryContent() {
+    final title = switch (_settingsCategory) {
+      'account' => '账户管理',
+      'agent' => '智能体设置',
+      'memory' => '记忆',
+      'model' => '模型',
+      'data' => '数据管理',
+      'security' => '安全中心',
+      'help' => '帮助与反馈',
+      _ => '设置',
+    };
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(36, 34, 36, 28),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                    color: Color(0xFF202124),
+                    fontSize: 24,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              IconButton(
+                tooltip: '关闭',
+                onPressed: () => Navigator.maybePop(context),
+                icon: const Icon(Icons.close),
+              ),
+            ],
+          ),
+          const Divider(height: 28),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(children: _settingsCategoryWidgets()),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _settingsCategoryWidgets() {
+    switch (_settingsCategory) {
+      case 'account':
+        return [
+          _SettingsLightRow(
+            icon: Icons.refresh,
+            title: '刷新数据',
+            subtitle: '重新同步账户信息。',
+            onTap: _refreshAccountData,
+          ),
+          _SettingsLightRow(
+            icon: Icons.info_outline,
+            title: '关于',
+            subtitle: '版本 $_appVersionLabel',
+            onTap: _showAbout,
+          ),
+          _buildLogoutItem(context),
+        ];
+      case 'agent':
+        return [
+          if (AiBackendPolicy.isDesktopNative) _buildOpenClawSettingCard(),
+          _SettingsLightRow(
+            icon: Icons.auto_awesome,
+            title: '技能自动更新',
+            subtitle: '保持已安装技能为最新版。',
+            trailing: Switch(value: true, onChanged: (_) {}),
+          ),
+        ];
+      case 'memory':
+        return [
+          _SettingsLightRow(
+            icon: Icons.history,
+            title: '对话记忆',
+            subtitle: '管理本机对话上下文和项目空间。',
+            onTap: _copyDiagnosticLogTail,
+          ),
+          _SettingsLightRow(
+            icon: Icons.article_outlined,
+            title: '诊断日志',
+            subtitle: '复制或打开 OpenClaw 和桌面控制日志。',
+            onTap: _openDiagnosticLogLocation,
+          ),
+        ];
+      case 'model':
+        return [_buildModelSettingCard()];
+      case 'data':
+        return [
+          _buildTtsMuteSettingItem(),
+          _buildRecitationThresholdSettings(),
+        ];
+      case 'security':
+        return [
+          _SettingsLightRow(
+            icon: Icons.visibility_outlined,
+            title: '修行隐私',
+            subtitle: '控制修行排行榜与公开记录的展示范围。',
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const PracticePrivacyScreen()),
+            ),
+          ),
+          _buildDeleteAccountItem(context),
+        ];
+      case 'help':
+        return [
+          _SettingsLightRow(
+            icon: Icons.help_outline,
+            title: '帮助与反馈',
+            subtitle: '提交问题或建议，发送到支持邮箱。',
+            onTap: _showFeedbackDialog,
+          ),
+          _SettingsLightRow(
+            icon: Icons.info_outline,
+            title: '关于',
+            subtitle: '版本 $_appVersionLabel',
+            onTap: _showAbout,
+          ),
+        ];
+      default:
+        return [
+          _SettingsLightRow(
+            icon: Icons.language,
+            title: '显示语言',
+            subtitle: '设置应用程序界面的显示语言。',
+            trailing: const Text('中文(简体)'),
+          ),
+          _SettingsLightRow(
+            icon: Icons.keyboard_return,
+            title: '发送消息',
+            subtitle: '设置聊天输入框中发送消息的快捷键。',
+            trailing: const Text('Enter'),
+          ),
+          _SettingsLightRow(
+            icon: Icons.open_in_full,
+            title: '桌面窗口',
+            subtitle: '已允许调整大小、最大化和系统全屏。',
+          ),
+          if (Platform.isAndroid)
+            _SettingsLightRow(
+              icon: Icons.battery_saver,
+              title: '后台保活设置',
+              subtitle: '防止应用被系统清理。',
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const KeepAliveGuideScreen()),
+              ),
+            ),
+        ];
+    }
+  }
+
+  Future<void> _refreshAccountData() async {
+    final authModel = Provider.of<AuthModel>(context, listen: false);
+    await authModel.refreshUserInfo();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('数据已刷新'), backgroundColor: Colors.green),
+    );
+  }
+
+  void _showAbout() {
+    showAboutDialog(
+      context: context,
+      applicationName: AppConstants.appName,
+      applicationVersion: _appVersionLabel,
+      children: [const Text('传播佛法，利益众生')],
     );
   }
 
@@ -858,6 +1234,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final status = _openClawStatus;
     final desktopStatus = _desktopControlStatus;
     final chromeStatus = desktopStatus?.chrome;
+    final remoteGatewayConfigured = _openClawRemoteGatewayUrl.trim().isNotEmpty;
     final statusColor = switch (status?.state) {
       OpenClawRuntimeState.running => Colors.greenAccent,
       OpenClawRuntimeState.starting => Colors.amberAccent,
@@ -1019,6 +1396,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             const SizedBox(height: 8),
             _buildDesktopControlStatusRow(
+              icon: Icons.qr_code_2_outlined,
+              title: '远程入口',
+              message: remoteGatewayConfigured
+                  ? _openClawRemoteGatewayUrl
+                  : '未配置公网 wss:// 或 Tailscale Serve/Funnel 入口',
+              color: remoteGatewayConfigured
+                  ? Colors.greenAccent
+                  : Colors.orangeAccent,
+            ),
+            const SizedBox(height: 8),
+            _buildDesktopControlStatusRow(
               icon: Icons.public,
               title: 'Chrome 连接器',
               message: chromeStatus?.message ?? '尚未检测 Chrome 连接器',
@@ -1030,12 +1418,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
               const SizedBox(height: 12),
               _buildPendingDesktopConfirmations(),
             ],
-            const SizedBox(height: 12),
+            const SizedBox(height: 14),
             Row(
               children: [
                 Expanded(
                   child: OutlinedButton.icon(
-                    onPressed: _isRestartingOpenClaw
+                    onPressed: _isRestartingOpenClaw || _isRunningOpenClawCli
                         ? null
                         : _refreshOpenClawStatus,
                     icon: const Icon(
@@ -1046,71 +1434,93 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   ),
                 ),
                 const SizedBox(width: 10),
-                Expanded(
-                  child: FilledButton.icon(
-                    onPressed: _isRestartingOpenClaw
-                        ? null
-                        : _restartOpenClawRuntime,
-                    icon: _isRestartingOpenClaw
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.restart_alt, size: 18),
-                    label: Text(_isRestartingOpenClaw ? '启动中' : '重启本机 AI'),
-                  ),
+                FilledButton.icon(
+                  onPressed: _isRestartingOpenClaw || _isRunningOpenClawCli
+                      ? null
+                      : () => unawaited(_restartOpenClawRuntime()),
+                  icon: const Icon(Icons.restart_alt, size: 18),
+                  label: Text(_isRestartingOpenClaw ? '启动中' : '重启本机 AI'),
                 ),
-              ],
-            ),
-            const SizedBox(height: 10),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed:
-                        _isRestartingOpenClaw || _isPreparingChromeConnector
-                        ? null
-                        : () => _refreshDesktopControlStatus(startBridge: true),
-                    icon: const Icon(Icons.rule_folder_outlined, size: 18),
-                    label: const Text('工具诊断'),
-                  ),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed:
-                        _isRestartingOpenClaw || _isPreparingChromeConnector
-                        ? null
-                        : _prepareChromeConnectorInstall,
-                    icon: _isPreparingChromeConnector
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.extension_outlined, size: 18),
-                    label: Text(_isPreparingChromeConnector ? '准备中' : '连接器'),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 10),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _copyDiagnosticLogTail,
-                    icon: const Icon(Icons.content_copy_outlined, size: 18),
-                    label: const Text('复制日志'),
-                  ),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _openDiagnosticLogLocation,
-                    icon: const Icon(Icons.folder_open_outlined, size: 18),
-                    label: const Text('日志位置'),
+                const SizedBox(width: 8),
+                PopupMenuButton<String>(
+                  tooltip: '高级操作',
+                  enabled:
+                      !_isRestartingOpenClaw &&
+                      !_isRunningOpenClawCli &&
+                      !_isPreparingChromeConnector,
+                  onSelected: (value) {
+                    switch (value) {
+                      case 'restart':
+                        unawaited(_restartOpenClawRuntime());
+                        break;
+                      case 'tools':
+                        unawaited(
+                          _refreshDesktopControlStatus(startBridge: true),
+                        );
+                        break;
+                      case 'connector':
+                        unawaited(_prepareChromeConnectorInstall());
+                        break;
+                      case 'remote':
+                        unawaited(_editOpenClawRemoteGatewayUrl());
+                        break;
+                      case 'mobile':
+                        unawaited(_createOpenClawMobilePairingCode());
+                        break;
+                      case 'wechatPlugin':
+                        unawaited(_installOpenClawWeChatPlugin());
+                        break;
+                      case 'wechatLogin':
+                        unawaited(_loginOpenClawWeChat());
+                        break;
+                      case 'channels':
+                        unawaited(_inspectOpenClawChannels());
+                        break;
+                      case 'permissions':
+                        unawaited(
+                          _requestDesktopPermission(
+                            screenRecording:
+                                desktopStatus?.screenRecordingGranted != true,
+                          ),
+                        );
+                        break;
+                      case 'copyLog':
+                        unawaited(_copyDiagnosticLogTail());
+                        break;
+                      case 'openLog':
+                        unawaited(_openDiagnosticLogLocation());
+                        break;
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    const PopupMenuItem(value: 'tools', child: Text('工具诊断')),
+                    PopupMenuItem(
+                      value: 'connector',
+                      child: Text(_isPreparingChromeConnector ? '准备中' : '连接器'),
+                    ),
+                    const PopupMenuDivider(),
+                    const PopupMenuItem(value: 'remote', child: Text('远程入口')),
+                    const PopupMenuItem(value: 'mobile', child: Text('移动配对')),
+                    const PopupMenuItem(
+                      value: 'wechatPlugin',
+                      child: Text('微信插件'),
+                    ),
+                    const PopupMenuItem(
+                      value: 'wechatLogin',
+                      child: Text('微信登录'),
+                    ),
+                    const PopupMenuItem(value: 'channels', child: Text('渠道状态')),
+                    const PopupMenuItem(
+                      value: 'permissions',
+                      child: Text('系统权限'),
+                    ),
+                    const PopupMenuDivider(),
+                    const PopupMenuItem(value: 'copyLog', child: Text('复制日志')),
+                    const PopupMenuItem(value: 'openLog', child: Text('日志位置')),
+                  ],
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                    child: Icon(Icons.more_horiz, color: Colors.white70),
                   ),
                 ),
               ],
@@ -1890,6 +2300,130 @@ class _SettingsScreenState extends State<SettingsScreen> {
             }
           }
         },
+      ),
+    );
+  }
+}
+
+class _SettingsCategoryTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _SettingsCategoryTile({
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        height: 42,
+        margin: const EdgeInsets.only(bottom: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 14),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xFFE0E0DF) : Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: const Color(0xFF26282B), size: 20),
+            const SizedBox(width: 12),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF26282B),
+                fontSize: 15,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsLightRow extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  const _SettingsLightRow({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    this.trailing,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 76),
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF6F6F5),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              Icon(icon, color: const Color(0xFF303236), size: 22),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        color: Color(0xFF252729),
+                        fontSize: 15,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle,
+                      style: const TextStyle(
+                        color: Color(0xFF73777A),
+                        fontSize: 13,
+                        height: 1.35,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (trailing != null) ...[
+                const SizedBox(width: 16),
+                DefaultTextStyle(
+                  style: const TextStyle(
+                    color: Color(0xFF303236),
+                    fontSize: 14,
+                    fontWeight: FontWeight.w800,
+                  ),
+                  child: trailing!,
+                ),
+              ] else if (onTap != null)
+                const Icon(Icons.chevron_right, color: Color(0xFF9EA1A3)),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/fabushi/lib/services/app_settings.dart
+++ b/fabushi/lib/services/app_settings.dart
@@ -159,6 +159,8 @@ class AppSettings {
   static const String _openClawModelKey = 'openclaw_model_v1';
   static const String _openClawModelOverrideKey = 'openclaw_model_override_v1';
   static const String _openClawDeepSeekModelKey = 'openclaw_deepseek_model_v1';
+  static const String _openClawRemoteGatewayUrlKey =
+      'openclaw_remote_gateway_url_v1';
   static const String _openClawActiveRuntimeSpecKey =
       'openclaw_active_runtime_spec_v1';
   static const String _desktopControlBridgePortKey =
@@ -247,6 +249,21 @@ class AppSettings {
   static Future<void> setOpenClawDeepSeekModel(String model) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_openClawDeepSeekModelKey, model.trim());
+  }
+
+  static Future<String> getOpenClawRemoteGatewayUrl() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_openClawRemoteGatewayUrlKey)?.trim() ?? '';
+  }
+
+  static Future<void> setOpenClawRemoteGatewayUrl(String url) async {
+    final prefs = await SharedPreferences.getInstance();
+    final trimmed = url.trim();
+    if (trimmed.isEmpty) {
+      await prefs.remove(_openClawRemoteGatewayUrlKey);
+      return;
+    }
+    await prefs.setString(_openClawRemoteGatewayUrlKey, trimmed);
   }
 
   static Future<Map<String, dynamic>?> getOpenClawActiveRuntimeSpec() async {

--- a/fabushi/lib/services/desktop_control/desktop_control_bridge_io.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_bridge_io.dart
@@ -27,6 +27,16 @@ class MethodChannelDesktopControlHostApi implements DesktopControlHostApi {
   Future<Map<String, dynamic>> status() => _invoke('status');
 
   @override
+  Future<Map<String, dynamic>> requestScreenRecording() {
+    return _invoke('requestScreenRecording');
+  }
+
+  @override
+  Future<Map<String, dynamic>> requestAccessibility() {
+    return _invoke('requestAccessibility');
+  }
+
+  @override
   Future<Map<String, dynamic>> observe() => _invoke('observe');
 
   @override
@@ -79,7 +89,14 @@ class DesktopControlBridge {
   }) : _hostApi = hostApi ?? MethodChannelDesktopControlHostApi(),
        _confirmations = confirmations ?? DesktopControlConfirmationStore(),
        _enabledByBuild =
-           enabledByBuild ?? (() => AppConfig.desktopControlEnabled),
+           enabledByBuild ??
+           (() {
+             final platform = (platformProvider ?? _detectPlatform)();
+             return AppConfig.desktopControlEnabled ||
+                 platform == 'macos' ||
+                 platform == 'windows' ||
+                 platform == 'linux';
+           }),
        _platformProvider = platformProvider ?? _detectPlatform,
        _random = random ?? Random.secure();
 
@@ -180,6 +197,28 @@ class DesktopControlBridge {
           ? '桌面控制桥已在本机 loopback 运行'
           : '当前 $platform 暂不支持系统级电脑控制',
     );
+  }
+
+  Future<Map<String, dynamic>> requestScreenRecordingPermission() async {
+    if (!_enabledByBuild()) {
+      return {'requested': false, 'message': '当前构建已禁用桌面控制和 Chrome 连接器'};
+    }
+    final platform = _platformProvider();
+    if (!_platformSupportsSystemControl(platform)) {
+      return {'requested': false, 'message': '当前 $platform 暂不支持系统级电脑控制'};
+    }
+    return _hostApi.requestScreenRecording();
+  }
+
+  Future<Map<String, dynamic>> requestAccessibilityPermission() async {
+    if (!_enabledByBuild()) {
+      return {'trusted': false, 'message': '当前构建已禁用桌面控制和 Chrome 连接器'};
+    }
+    final platform = _platformProvider();
+    if (!_platformSupportsSystemControl(platform)) {
+      return {'trusted': false, 'message': '当前 $platform 暂不支持系统级电脑控制'};
+    }
+    return _hostApi.requestAccessibility();
   }
 
   Future<DesktopControlToolResult> executeTool(

--- a/fabushi/lib/services/desktop_control/desktop_control_bridge_stub.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_bridge_stub.dart
@@ -34,6 +34,14 @@ class DesktopControlBridge {
 
   Future<DesktopControlBridgeStatus> ensureStarted() => getStatus();
 
+  Future<Map<String, dynamic>> requestScreenRecordingPermission() async {
+    return {'requested': false, 'message': '当前平台不支持系统级电脑控制'};
+  }
+
+  Future<Map<String, dynamic>> requestAccessibilityPermission() async {
+    return {'trusted': false, 'message': '当前平台不支持系统级电脑控制'};
+  }
+
   Future<DesktopControlToolResult> executeTool(
     String toolName,
     Map<String, dynamic> arguments, {

--- a/fabushi/lib/services/desktop_control/desktop_control_host_api.dart
+++ b/fabushi/lib/services/desktop_control/desktop_control_host_api.dart
@@ -1,6 +1,10 @@
 abstract class DesktopControlHostApi {
   Future<Map<String, dynamic>> status();
 
+  Future<Map<String, dynamic>> requestScreenRecording();
+
+  Future<Map<String, dynamic>> requestAccessibility();
+
   Future<Map<String, dynamic>> observe();
 
   Future<Map<String, dynamic>> screenshot(Map<String, dynamic> arguments);

--- a/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
@@ -86,6 +86,50 @@ class OpenClawGatewayTarget {
   });
 }
 
+class OpenClawCliResult {
+  final List<String> args;
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+  final bool timedOut;
+
+  const OpenClawCliResult({
+    required this.args,
+    required this.exitCode,
+    required this.stdout,
+    required this.stderr,
+    this.timedOut = false,
+  });
+
+  bool get succeeded => exitCode == 0 && !timedOut;
+
+  String get command => 'openclaw ${args.join(' ')}';
+
+  String get combinedOutput {
+    final parts = <String>[
+      if (stdout.trim().isNotEmpty) stdout.trimRight(),
+      if (stderr.trim().isNotEmpty) stderr.trimRight(),
+    ];
+    return parts.join('\n');
+  }
+
+  OpenClawCliResult append(OpenClawCliResult next) {
+    return OpenClawCliResult(
+      args: [...args, '&&', ...next.args],
+      exitCode: next.exitCode,
+      stdout: [
+        if (stdout.trim().isNotEmpty) stdout.trimRight(),
+        if (next.stdout.trim().isNotEmpty) next.stdout.trimRight(),
+      ].join('\n'),
+      stderr: [
+        if (stderr.trim().isNotEmpty) stderr.trimRight(),
+        if (next.stderr.trim().isNotEmpty) next.stderr.trimRight(),
+      ].join('\n'),
+      timedOut: timedOut || next.timedOut,
+    );
+  }
+}
+
 class _OpenClawBundleSpec {
   final String version;
   final int defaultPort;
@@ -170,6 +214,28 @@ class _DesktopToolsLaunch {
   });
 }
 
+class _OpenClawCliLaunch {
+  final _OpenClawBundleSpec spec;
+  final Directory runtimeDir;
+  final Directory stateRoot;
+  final File configPath;
+  final String nodePath;
+  final String cliPath;
+  final int port;
+  final String token;
+
+  const _OpenClawCliLaunch({
+    required this.spec,
+    required this.runtimeDir,
+    required this.stateRoot,
+    required this.configPath,
+    required this.nodePath,
+    required this.cliPath,
+    required this.port,
+    required this.token,
+  });
+}
+
 class OpenClawRuntimeException implements Exception {
   final String message;
 
@@ -193,8 +259,12 @@ class OpenClawRuntime {
   static const String _defaultDeepSeekModel =
       AppSettings.defaultOpenClawDeepSeekModel;
   static const String _backendDeepSeekProviderId = 'dacheng-deepseek-proxy';
+  static const String _desktopToolsPluginId = 'dacheng-desktop-tools';
+  static const String _weChatPluginId = 'openclaw-weixin';
+  static const String _weChatPluginPackage = '@tencent-weixin/openclaw-weixin';
   static const Duration _startupTimeout = Duration(seconds: 120);
   static const Duration _probeTimeout = Duration(seconds: 3);
+  static const Duration _cliDefaultTimeout = Duration(seconds: 45);
 
   Process? _process;
   Future<OpenClawGatewayTarget>? _starting;
@@ -370,6 +440,125 @@ class OpenClawRuntime {
     }
   }
 
+  Future<OpenClawCliResult> createMobilePairingCode({bool remote = true}) {
+    return runCli([
+      'qr',
+      if (remote) '--remote',
+      '--json',
+    ], timeout: const Duration(seconds: 30));
+  }
+
+  Future<OpenClawCliResult> loginWeChat() {
+    return runCli([
+      'channels',
+      'login',
+      '--channel',
+      _weChatPluginId,
+    ], timeout: const Duration(minutes: 3));
+  }
+
+  Future<OpenClawCliResult> inspectChannels() {
+    return runCli([
+      'channels',
+      'status',
+      '--probe',
+    ], timeout: const Duration(seconds: 40));
+  }
+
+  Future<OpenClawCliResult> installWeChatPlugin() async {
+    final install = await runCli(
+      ['plugins', 'install', _weChatPluginPackage, '--force'],
+      timeout: const Duration(minutes: 3),
+      ensureGateway: false,
+    );
+    if (!install.succeeded) return install;
+    final enable = await runCli(
+      ['config', 'set', 'plugins.entries.$_weChatPluginId.enabled', 'true'],
+      timeout: const Duration(seconds: 30),
+      ensureGateway: false,
+    );
+    return install.append(enable);
+  }
+
+  Future<OpenClawCliResult> runCli(
+    List<String> args, {
+    Duration timeout = _cliDefaultTimeout,
+    bool ensureGateway = true,
+  }) async {
+    if (args.isEmpty) {
+      throw const OpenClawRuntimeException('OpenClaw CLI 参数不能为空');
+    }
+    final launch = await _prepareCliLaunch(ensureGateway: ensureGateway);
+    final processArgs = <String>[launch.cliPath, ...args];
+    _diag(
+      'cli.start',
+      data: {
+        'args': args,
+        'runtimeDir': launch.runtimeDir.path,
+        'configPath': launch.configPath.path,
+        'timeoutSeconds': timeout.inSeconds,
+      },
+    );
+
+    final process = await Process.start(
+      launch.nodePath,
+      processArgs,
+      workingDirectory: launch.runtimeDir.path,
+      environment: _buildOpenClawEnvironment(
+        runtimeDir: launch.runtimeDir,
+        stateRoot: launch.stateRoot,
+        configPath: launch.configPath,
+        port: launch.port,
+        token: launch.token,
+      ),
+      mode: ProcessStartMode.normal,
+      runInShell: false,
+    );
+    final stdoutBuffer = StringBuffer();
+    final stderrBuffer = StringBuffer();
+    final stdoutSub = process.stdout
+        .transform(utf8.decoder)
+        .listen((chunk) => _appendBounded(stdoutBuffer, chunk));
+    final stderrSub = process.stderr
+        .transform(utf8.decoder)
+        .listen((chunk) => _appendBounded(stderrBuffer, chunk));
+
+    var timedOut = false;
+    int exitCode;
+    try {
+      exitCode = await process.exitCode.timeout(timeout);
+    } on TimeoutException {
+      timedOut = true;
+      process.kill();
+      exitCode = await process.exitCode.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => -1,
+      );
+    } finally {
+      await stdoutSub.cancel();
+      await stderrSub.cancel();
+    }
+
+    final result = OpenClawCliResult(
+      args: args,
+      exitCode: exitCode,
+      stdout: stdoutBuffer.toString(),
+      stderr: stderrBuffer.toString(),
+      timedOut: timedOut,
+    );
+    _diag(
+      result.succeeded ? 'cli.complete' : 'cli.failed',
+      data: {
+        'args': args,
+        'exitCode': exitCode,
+        'timedOut': timedOut,
+        'stdoutPreview': _previewProcessOutput(result.stdout),
+        'stderrPreview': _previewProcessOutput(result.stderr),
+      },
+    );
+    return result;
+  }
+
   Future<OpenClawGatewayTarget> _ensureStartedInternal({
     String? authToken,
     String? username,
@@ -400,6 +589,7 @@ class OpenClawRuntime {
     final modelOverride = await AppSettings.getOpenClawModelOverride(
       defaultValue: spec.defaultModelOverride ?? '',
     );
+    final remoteGatewayUrl = await AppSettings.getOpenClawRemoteGatewayUrl();
     final desktopTools = await _ensureDesktopTools();
     _diag(
       'ensure-start.config',
@@ -412,6 +602,7 @@ class OpenClawRuntime {
         'deepSeekProxyBaseUrl': deepSeekProxyBaseUrl,
         'hasAuthToken': requestedAuthToken.isNotEmpty,
         'modelOverrideSet': modelOverride.trim().isNotEmpty,
+        'remoteGatewayUrlSet': remoteGatewayUrl.trim().isNotEmpty,
         'desktopToolsUri': desktopTools.uri?.toString(),
         'desktopToolsStatus': desktopTools.statusJson,
       },
@@ -446,6 +637,9 @@ class OpenClawRuntime {
 
     final runtimeDir = await _prepareBundle(spec, platformKey);
     final stateRoot = await _stateRoot();
+    final desktopToolsPluginDir = await _ensureDesktopToolsPlugin(
+      stateRoot: stateRoot,
+    );
     if (_process != null) {
       _diag(
         'process.stop-stale-before-start',
@@ -472,11 +666,14 @@ class OpenClawRuntime {
       );
     }
     final configPath = await _ensureConfigFile(
+      runtimeDir: runtimeDir,
       stateRoot: stateRoot,
       port: port,
       token: token,
       backendDeepSeekModel: backendDeepSeekModel,
       deepSeekProxyBaseUrl: deepSeekProxyBaseUrl,
+      remoteGatewayUrl: remoteGatewayUrl,
+      extraPluginLoadPaths: [desktopToolsPluginDir.path],
     );
     await _ensureAgentModelConfig(
       stateRoot: stateRoot,
@@ -521,37 +718,36 @@ class OpenClawRuntime {
         'args': args,
         'workingDirectory': runtimeDir.path,
         'configPath': configPath.path,
+        'desktopToolsPluginPath': desktopToolsPluginDir.path,
         'desktopToolsManifestPath': desktopToolsManifestPath.path,
         'requestedPort': requestedPort,
         'selectedPort': port,
       },
     );
 
-    final env = Map<String, String>.from(Platform.environment)
-      ..addAll({
-        'OPENCLAW_GATEWAY_PORT': '$port',
-        'OPENCLAW_GATEWAY_BIND': 'loopback',
-        'OPENCLAW_GATEWAY_TOKEN': token,
-        'OPENCLAW_CONFIG_PATH': configPath.path,
-        'OPENCLAW_STATE_DIR': p.join(stateRoot.path, 'state'),
-        'OPENCLAW_AGENT_DIR': p.join(stateRoot.path, 'agents'),
-        'OPENCLAW_WORKSPACE': p.join(stateRoot.path, 'workspace'),
-        'DACHENG_DESKTOP_TOOLS_ENABLED': desktopTools.uri == null ? '0' : '1',
-        'DACHENG_DESKTOP_TOOLS_MANIFEST': desktopToolsManifestPath.path,
-        if (desktopTools.uri != null)
-          'DACHENG_DESKTOP_TOOLS_URL': desktopTools.uri.toString(),
-        if (desktopTools.token != null)
-          'DACHENG_DESKTOP_TOOLS_TOKEN': desktopTools.token!,
-        'DACHENG_APP_RUNTIME': '1',
-        'DACHENG_AUTH_TOKEN': (authToken != null && authToken.isNotEmpty)
-            ? authToken
-            : token,
-        if (username != null && username.isNotEmpty)
-          'DACHENG_USERNAME': username,
-        'DACHENG_IS_MEMBER': isMember ? '1' : '0',
-        'DACHENG_OPENCLAW_PROXY_TOKEN': 'dacheng-openclaw-proxy',
-        'OPENCLAW_DISABLE_BONJOUR': '1',
-      });
+    final env =
+        _buildOpenClawEnvironment(
+          runtimeDir: runtimeDir,
+          stateRoot: stateRoot,
+          configPath: configPath,
+          port: port,
+          token: token,
+        )..addAll({
+          'DACHENG_DESKTOP_TOOLS_ENABLED': desktopTools.uri == null ? '0' : '1',
+          'DACHENG_DESKTOP_TOOLS_MANIFEST': desktopToolsManifestPath.path,
+          if (desktopTools.uri != null)
+            'DACHENG_DESKTOP_TOOLS_URL': desktopTools.uri.toString(),
+          if (desktopTools.token != null)
+            'DACHENG_DESKTOP_TOOLS_TOKEN': desktopTools.token!,
+          'DACHENG_APP_RUNTIME': '1',
+          'DACHENG_AUTH_TOKEN': (authToken != null && authToken.isNotEmpty)
+              ? authToken
+              : token,
+          if (username != null && username.isNotEmpty)
+            'DACHENG_USERNAME': username,
+          'DACHENG_IS_MEMBER': isMember ? '1' : '0',
+          'DACHENG_OPENCLAW_PROXY_TOKEN': 'dacheng-openclaw-proxy',
+        });
 
     _process = await Process.start(
       nodePath,
@@ -1644,17 +1840,29 @@ class OpenClawRuntime {
   }
 
   Future<File> _ensureConfigFile({
+    required Directory runtimeDir,
     required Directory stateRoot,
     required int port,
     required String token,
     required String backendDeepSeekModel,
     required String deepSeekProxyBaseUrl,
+    required String remoteGatewayUrl,
+    List<String> extraPluginLoadPaths = const [],
   }) async {
     final configDir = Directory(p.join(stateRoot.path, 'config'));
     await configDir.create(recursive: true);
     final workspace = Directory(p.join(stateRoot.path, 'workspace'));
     await workspace.create(recursive: true);
     final configPath = File(p.join(configDir.path, 'openclaw.json'));
+    final bundledPluginLoadPaths = await _bundledPluginLoadPaths(runtimeDir);
+    final pluginLoadPaths = _mergeStringLists(
+      extraPluginLoadPaths,
+      bundledPluginLoadPaths,
+    );
+    final hasWeChatPlugin = pluginLoadPaths.any(
+      (path) => p.basename(path) == _weChatPluginId,
+    );
+    final remoteUrl = remoteGatewayUrl.trim();
 
     final config = <String, dynamic>{
       'gateway': {
@@ -1662,6 +1870,7 @@ class OpenClawRuntime {
         'port': port,
         'bind': 'loopback',
         'auth': {'mode': 'token', 'token': token},
+        if (remoteUrl.isNotEmpty) 'remote': {'enabled': true, 'url': remoteUrl},
         'http': {
           'endpoints': {
             'chatCompletions': {'enabled': true},
@@ -1706,22 +1915,47 @@ class OpenClawRuntime {
           },
         },
       },
+      'browser': {
+        'enabled': true,
+        'defaultProfile': 'openclaw',
+        'headless': false,
+        'ssrfPolicy': {'dangerouslyAllowPrivateNetwork': true},
+      },
+      'canvas': {
+        'enabled': true,
+        'host': {'enabled': true, 'root': p.join(stateRoot.path, 'canvas')},
+      },
+      'tools': {
+        'profile': 'full',
+        'exec': {'host': 'gateway', 'security': 'full', 'ask': 'off'},
+      },
       'plugins': {
-        'enabled': false,
-        'allow': <String>[],
+        'enabled': true,
         'deny': <String>[],
-        'load': {'paths': <String>[]},
-        'slots': {'memory': 'none'},
+        'load': {'paths': pluginLoadPaths},
+        'slots': {'memory': 'memory-core'},
         'entries': <String, dynamic>{
-          'memory-core': {'enabled': false},
+          'memory-core': {'enabled': true},
           'bonjour': {'enabled': false},
-          'browser': {'enabled': false},
-          'canvas': {'enabled': false},
-          'device-pair': {'enabled': false},
-          'file-transfer': {'enabled': false},
-          'phone-control': {'enabled': false},
-          'talk-voice': {'enabled': false},
+          'browser': {'enabled': true},
+          'canvas': {'enabled': true},
+          'device-pair': {'enabled': true},
+          'file-transfer': {'enabled': true},
+          'phone-control': {'enabled': true},
+          'talk-voice': {'enabled': true},
+          _desktopToolsPluginId: {'enabled': true},
+          if (hasWeChatPlugin) _weChatPluginId: {'enabled': true},
         },
+      },
+      'channels': {
+        'defaults': {'groupPolicy': 'allowlist'},
+        if (hasWeChatPlugin)
+          _weChatPluginId: {
+            'enabled': true,
+            'dmPolicy': 'pairing',
+            'allowFrom': <String>[],
+            'accounts': <String, dynamic>{},
+          },
       },
       'agents': {
         'defaults': {
@@ -1755,6 +1989,9 @@ class OpenClawRuntime {
         'gatewayMode': _mutableMap(merged['gateway'])['mode'],
         'backendDeepSeekModel': backendDeepSeekModel,
         'deepSeekProxyBaseUrl': deepSeekProxyBaseUrl,
+        'remoteGatewayUrlSet': remoteUrl.isNotEmpty,
+        'pluginLoadPaths': pluginLoadPaths,
+        'hasWeChatPlugin': hasWeChatPlugin,
       },
     );
     return configPath;
@@ -1854,6 +2091,298 @@ class OpenClawRuntime {
     return modelsPath;
   }
 
+  Future<_OpenClawCliLaunch> _prepareCliLaunch({
+    required bool ensureGateway,
+  }) async {
+    if (ensureGateway) {
+      await ensureStarted();
+    }
+    final platformKey = _platformKey;
+    if (platformKey == null) {
+      throw const OpenClawRuntimeException('当前平台不支持内置 OpenClaw Gateway');
+    }
+    final spec = await _loadSpec(platformKey, checkUpdates: false);
+    final runtimeDir = await _prepareBundle(spec, platformKey);
+    final stateRoot = await _stateRoot();
+    final desktopToolsPluginDir = await _ensureDesktopToolsPlugin(
+      stateRoot: stateRoot,
+    );
+    final port = await AppSettings.getOpenClawGatewayPort(
+      defaultValue: spec.defaultPort,
+    );
+    final token = await AppSettings.getOpenClawGatewayToken();
+    final backendDeepSeekModel = _backendDeepSeekModelRef(
+      await AppSettings.getOpenClawDeepSeekModel(
+        defaultValue: _defaultDeepSeekModelFor(spec.defaultModel),
+      ),
+    );
+    final configPath = await _ensureConfigFile(
+      runtimeDir: runtimeDir,
+      stateRoot: stateRoot,
+      port: port,
+      token: token,
+      backendDeepSeekModel: backendDeepSeekModel,
+      deepSeekProxyBaseUrl: _deepSeekProxyBaseUrl(),
+      remoteGatewayUrl: await AppSettings.getOpenClawRemoteGatewayUrl(),
+      extraPluginLoadPaths: [desktopToolsPluginDir.path],
+    );
+    final nodePath = p.join(runtimeDir.path, spec.nodeExecutable);
+    final cliPath = p.join(runtimeDir.path, spec.cliEntrypoint);
+    if (!await File(nodePath).exists()) {
+      throw OpenClawRuntimeException('OpenClaw 内置 Node 不存在: $nodePath');
+    }
+    if (!await File(cliPath).exists()) {
+      throw OpenClawRuntimeException('OpenClaw CLI 入口不存在: $cliPath');
+    }
+    return _OpenClawCliLaunch(
+      spec: spec,
+      runtimeDir: runtimeDir,
+      stateRoot: stateRoot,
+      configPath: configPath,
+      nodePath: nodePath,
+      cliPath: cliPath,
+      port: port,
+      token: token,
+    );
+  }
+
+  Map<String, String> _buildOpenClawEnvironment({
+    required Directory runtimeDir,
+    required Directory stateRoot,
+    required File configPath,
+    required int port,
+    required String token,
+  }) {
+    final nodeBinDir = Platform.isWindows
+        ? p.join(runtimeDir.path, 'node')
+        : p.join(runtimeDir.path, 'node', 'bin');
+    final pathKey = Platform.isWindows ? 'Path' : 'PATH';
+    final currentPath =
+        Platform.environment[pathKey] ?? Platform.environment['PATH'] ?? '';
+    final separator = Platform.isWindows ? ';' : ':';
+    final pathValue = currentPath.isEmpty
+        ? nodeBinDir
+        : '$nodeBinDir$separator$currentPath';
+    final env = Map<String, String>.from(Platform.environment)
+      ..addAll({
+        'OPENCLAW_GATEWAY_PORT': '$port',
+        'OPENCLAW_GATEWAY_BIND': 'loopback',
+        'OPENCLAW_GATEWAY_TOKEN': token,
+        'OPENCLAW_CONFIG_PATH': configPath.path,
+        'OPENCLAW_STATE_DIR': p.join(stateRoot.path, 'state'),
+        'OPENCLAW_AGENT_DIR': p.join(stateRoot.path, 'agents'),
+        'OPENCLAW_WORKSPACE': p.join(stateRoot.path, 'workspace'),
+        'OPENCLAW_DISABLE_BONJOUR': '1',
+        pathKey: pathValue,
+        if (pathKey != 'PATH') 'PATH': pathValue,
+      });
+    return env;
+  }
+
+  Future<List<String>> _bundledPluginLoadPaths(Directory runtimeDir) async {
+    final paths = <String>[];
+    final weChatPluginDir = Directory(
+      p.join(runtimeDir.path, 'plugins', _weChatPluginId),
+    );
+    if (await File(
+      p.join(weChatPluginDir.path, 'openclaw.plugin.json'),
+    ).exists()) {
+      paths.add(weChatPluginDir.path);
+    }
+    return paths;
+  }
+
+  Future<Directory> _ensureDesktopToolsPlugin({
+    required Directory stateRoot,
+  }) async {
+    final dir = Directory(
+      p.join(stateRoot.path, 'plugins', _desktopToolsPluginId),
+    );
+    await dir.create(recursive: true);
+    final tools = DesktopControlPolicy.supportedTools.toList()..sort();
+    await File(p.join(dir.path, 'package.json')).writeAsString(
+      const JsonEncoder.withIndent('  ').convert({
+        'name': '@dacheng/openclaw-desktop-tools',
+        'version': '1.0.0',
+        'type': 'module',
+        'openclaw': {
+          'extensions': ['./index.mjs'],
+        },
+      }),
+    );
+    await File(p.join(dir.path, 'openclaw.plugin.json')).writeAsString(
+      const JsonEncoder.withIndent('  ').convert({
+        'id': _desktopToolsPluginId,
+        'name': 'Dacheng Desktop Tools',
+        'description':
+            'Expose Fabushi desktop and Chrome control bridge tools to embedded OpenClaw.',
+        'activation': {'onStartup': true},
+        'contracts': {'tools': tools},
+        'configSchema': {
+          'type': 'object',
+          'additionalProperties': false,
+          'properties': <String, dynamic>{},
+        },
+      }),
+    );
+    await File(
+      p.join(dir.path, 'index.mjs'),
+    ).writeAsString(_desktopToolsPluginSource(tools));
+    _diag(
+      'desktop-tools.plugin-written',
+      data: {'pluginDir': dir.path, 'tools': tools},
+    );
+    return dir;
+  }
+
+  String _desktopToolsPluginSource(List<String> tools) {
+    final toolsJson = jsonEncode(tools);
+    return '''
+const tools = $toolsJson;
+
+const descriptions = {
+  "desktop.observe": "Observe the active desktop application and visible windows.",
+  "desktop.screenshot": "Capture a screenshot of the local desktop.",
+  "desktop.windows": "List visible desktop windows.",
+  "desktop.click": "Click a local desktop coordinate after user confirmation.",
+  "desktop.type": "Type text into the focused local desktop app after user confirmation.",
+  "desktop.hotkey": "Send a keyboard shortcut to the local desktop after user confirmation.",
+  "desktop.scroll": "Scroll the local desktop after user confirmation.",
+  "chrome.tabs": "List tabs from the paired Chrome connector.",
+  "chrome.navigate": "Navigate the active or selected Chrome tab after user confirmation.",
+  "chrome.dom_snapshot": "Read a structured DOM snapshot from the paired Chrome connector.",
+  "chrome.screenshot": "Capture a screenshot from the paired Chrome connector.",
+  "chrome.click": "Click an element or point in the paired Chrome tab after user confirmation.",
+  "chrome.type": "Type into an element in the paired Chrome tab after user confirmation."
+};
+
+const parameterSchemas = {
+  "desktop.click": {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      x: { type: "number" },
+      y: { type: "number" },
+      button: { type: "string", enum: ["left", "right"] }
+    },
+    required: ["x", "y"]
+  },
+  "desktop.type": {
+    type: "object",
+    additionalProperties: true,
+    properties: { text: { type: "string" } },
+    required: ["text"]
+  },
+  "desktop.hotkey": {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      key: { type: "string" },
+      keys: { type: "array", items: { type: "string" } }
+    }
+  },
+  "chrome.navigate": {
+    type: "object",
+    additionalProperties: true,
+    properties: { url: { type: "string" }, tabId: { type: "integer" } },
+    required: ["url"]
+  },
+  "chrome.click": {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      selector: { type: "string" },
+      x: { type: "number" },
+      y: { type: "number" },
+      tabId: { type: "integer" }
+    }
+  },
+  "chrome.type": {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      selector: { type: "string" },
+      x: { type: "number" },
+      y: { type: "number" },
+      text: { type: "string" },
+      tabId: { type: "integer" }
+    },
+    required: ["text"]
+  }
+};
+
+const defaultSchema = {
+  type: "object",
+  additionalProperties: true,
+  properties: {}
+};
+
+function toolResultText(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+async function callBridge(toolName, args) {
+  if (process.env.DACHENG_DESKTOP_TOOLS_ENABLED !== "1") {
+    return {
+      isError: true,
+      content: [{ type: "text", text: "Fabushi desktop tools bridge is not running." }]
+    };
+  }
+  const rawBaseUrl = process.env.DACHENG_DESKTOP_TOOLS_URL || "";
+  const baseUrl = rawBaseUrl.endsWith("/") ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+  const token = process.env.DACHENG_DESKTOP_TOOLS_TOKEN || "";
+  if (!baseUrl || !token) {
+    return {
+      isError: true,
+      content: [{ type: "text", text: "Fabushi desktop tools bridge URL/token is missing." }]
+    };
+  }
+  const response = await fetch(`\${baseUrl}/v1/tools/execute`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer \${token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ tool: toolName, arguments: args || {} })
+  });
+  const payload = await response.json().catch(() => ({}));
+  const ok = response.ok && payload && payload.ok !== false;
+  const data = payload && Object.prototype.hasOwnProperty.call(payload, "data")
+    ? payload.data
+    : payload;
+  return {
+    isError: !ok,
+    content: [{ type: "text", text: toolResultText(data) }],
+    details: data
+  };
+}
+
+export default {
+  id: "dacheng-desktop-tools",
+  name: "Dacheng Desktop Tools",
+  description: "Expose Fabushi desktop and Chrome control tools to embedded OpenClaw.",
+  configSchema: { type: "object", additionalProperties: false, properties: {} },
+  register(api) {
+    for (const name of tools) {
+      api.registerTool({
+        name,
+        label: name,
+        description: descriptions[name] || `Run \${name} through the Fabushi desktop bridge.`,
+        parameters: parameterSchemas[name] || defaultSchema,
+        async execute(_toolCallId, args) {
+          return await callBridge(name, args);
+        }
+      });
+    }
+  }
+};
+''';
+  }
+
   Future<Map<String, dynamic>> _mergeEmbeddedConfig(
     File configPath,
     Map<String, dynamic> defaults,
@@ -1878,6 +2407,19 @@ class OpenClawRuntime {
     gateway['port'] = defaultGateway['port'];
     gateway['bind'] = defaultGateway['bind'];
     gateway['auth'] = Map<String, dynamic>.from(defaultGateway['auth'] as Map);
+    if (defaultGateway.containsKey('remote')) {
+      gateway['remote'] = {
+        ..._mutableMap(gateway['remote']),
+        ..._mutableMap(defaultGateway['remote']),
+      };
+    } else {
+      final remote = _mutableMap(gateway['remote'])..remove('url');
+      if (remote.isEmpty) {
+        gateway.remove('remote');
+      } else {
+        gateway['remote'] = remote;
+      }
+    }
 
     final gatewayHttp = _mutableMap(gateway['http']);
     final endpoints = _mutableMap(gatewayHttp['endpoints']);
@@ -1911,26 +2453,87 @@ class OpenClawRuntime {
     models['providers'] = providers;
     current['models'] = models;
 
+    final defaultBrowser = _mutableMap(defaults['browser']);
+    final browser = _mutableMap(current['browser']);
+    browser.addAll(defaultBrowser);
+    current['browser'] = browser;
+
+    final defaultCanvas = _mutableMap(defaults['canvas']);
+    final canvas = _mutableMap(current['canvas']);
+    canvas.addAll(defaultCanvas);
+    current['canvas'] = canvas;
+
+    final defaultTools = _mutableMap(defaults['tools']);
+    final tools = _mutableMap(current['tools']);
+    tools.remove('toolSearch');
+    tools.remove('fs');
+    final execTools = _mutableMap(tools['exec']);
+    execTools.remove('mode');
+    if (execTools.isNotEmpty) {
+      tools['exec'] = execTools;
+    }
+    tools.addAll(defaultTools);
+    current['tools'] = tools;
+
     final defaultPlugins = _mutableMap(defaults['plugins']);
     final plugins = _mutableMap(current['plugins']);
-    plugins['enabled'] = false;
-    plugins['allow'] = <String>[];
-    plugins['deny'] = <String>[];
-    plugins['load'] = Map<String, dynamic>.from(
-      _mutableMap(defaultPlugins['load']),
-    );
-    plugins['slots'] = Map<String, dynamic>.from(
-      _mutableMap(defaultPlugins['slots']),
-    );
-    final entries = _mutableMap(plugins['entries']);
+    plugins['enabled'] = true;
     final defaultEntries = _mutableMap(defaultPlugins['entries']);
+    final requiredPluginIds = defaultEntries.keys.toSet();
+    final allowList = _stringList(plugins['allow']);
+    if (allowList.isEmpty) {
+      plugins.remove('allow');
+    } else {
+      plugins['allow'] = _mergeStringLists(allowList, requiredPluginIds);
+    }
+    final denyList = _stringList(
+      plugins['deny'],
+    ).where((item) => !requiredPluginIds.contains(item)).toList();
+    if (denyList.isEmpty) {
+      plugins.remove('deny');
+    } else {
+      plugins['deny'] = denyList;
+    }
+    final defaultLoad = _mutableMap(defaultPlugins['load']);
+    final load = _mutableMap(plugins['load']);
+    load['paths'] = _mergeStringLists(load['paths'], defaultLoad['paths']);
+    plugins['load'] = load;
+    final slots = _mutableMap(plugins['slots']);
+    slots.addAll(_mutableMap(defaultPlugins['slots']));
+    plugins['slots'] = slots;
+    final entries = _mutableMap(plugins['entries']);
     for (final entry in defaultEntries.entries) {
-      entries[entry.key] = entry.value is Map
-          ? Map<String, dynamic>.from(entry.value as Map)
-          : entry.value;
+      final currentEntry = _mutableMap(entries[entry.key]);
+      currentEntry.addAll(
+        entry.value is Map
+            ? Map<String, dynamic>.from(entry.value as Map)
+            : {'enabled': true},
+      );
+      entries[entry.key] = currentEntry;
     }
     plugins['entries'] = entries;
     current['plugins'] = plugins;
+
+    final defaultChannels = _mutableMap(defaults['channels']);
+    final channels = _mutableMap(current['channels']);
+    final defaultChannelDefaults = _mutableMap(defaultChannels['defaults']);
+    if (defaultChannelDefaults.isNotEmpty) {
+      channels['defaults'] = {
+        ..._mutableMap(channels['defaults']),
+        ...defaultChannelDefaults,
+      };
+    }
+    for (final entry in defaultChannels.entries) {
+      if (entry.key == 'defaults') continue;
+      final currentChannel = _mutableMap(channels[entry.key]);
+      currentChannel.addAll(
+        entry.value is Map
+            ? Map<String, dynamic>.from(entry.value as Map)
+            : <String, dynamic>{},
+      );
+      channels[entry.key] = currentChannel;
+    }
+    current['channels'] = channels;
 
     final agents = _mutableMap(current['agents']);
     final defaultAgents = _mutableMap(defaults['agents']);
@@ -2010,6 +2613,30 @@ class OpenClawRuntime {
     if (value is Map<String, dynamic>) return Map<String, dynamic>.from(value);
     if (value is Map) return Map<String, dynamic>.from(value);
     return <String, dynamic>{};
+  }
+
+  List<String> _stringList(Object? value) {
+    if (value is! Iterable) return <String>[];
+    return value
+        .map((item) => item.toString().trim())
+        .where((item) => item.isNotEmpty)
+        .toList();
+  }
+
+  List<String> _mergeStringLists(Object? first, Object? second) {
+    final merged = <String>{};
+    merged.addAll(_stringList(first));
+    merged.addAll(_stringList(second));
+    return merged.toList();
+  }
+
+  void _appendBounded(StringBuffer buffer, String chunk) {
+    const maxChars = 120000;
+    if (chunk.isEmpty || buffer.length >= maxChars) return;
+    final remaining = maxChars - buffer.length;
+    buffer.write(
+      chunk.length <= remaining ? chunk : chunk.substring(0, remaining),
+    );
   }
 
   void _captureLogs(Process process) {

--- a/fabushi/lib/services/openclaw/openclaw_runtime_stub.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_stub.dart
@@ -66,6 +66,31 @@ class OpenClawGatewayTarget {
   });
 }
 
+class OpenClawCliResult {
+  final List<String> args;
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+  final bool timedOut;
+
+  const OpenClawCliResult({
+    required this.args,
+    required this.exitCode,
+    required this.stdout,
+    required this.stderr,
+    this.timedOut = false,
+  });
+
+  bool get succeeded => exitCode == 0 && !timedOut;
+
+  String get command => 'openclaw ${args.join(' ')}';
+
+  String get combinedOutput => [
+    if (stdout.trim().isNotEmpty) stdout.trimRight(),
+    if (stderr.trim().isNotEmpty) stderr.trimRight(),
+  ].join('\n');
+}
+
 class OpenClawRuntime {
   OpenClawRuntime._();
 
@@ -90,4 +115,30 @@ class OpenClawRuntime {
   Future<OpenClawRuntimeStatus> restart() => getStatus();
 
   Future<void> stop() async {}
+
+  Future<OpenClawCliResult> createMobilePairingCode({
+    bool remote = true,
+  }) async {
+    throw StateError('当前平台不支持内置 OpenClaw Gateway');
+  }
+
+  Future<OpenClawCliResult> loginWeChat() async {
+    throw StateError('当前平台不支持内置 OpenClaw Gateway');
+  }
+
+  Future<OpenClawCliResult> inspectChannels() async {
+    throw StateError('当前平台不支持内置 OpenClaw Gateway');
+  }
+
+  Future<OpenClawCliResult> installWeChatPlugin() async {
+    throw StateError('当前平台不支持内置 OpenClaw Gateway');
+  }
+
+  Future<OpenClawCliResult> runCli(
+    List<String> args, {
+    Duration timeout = const Duration(seconds: 45),
+    bool ensureGateway = true,
+  }) async {
+    throw StateError('当前平台不支持内置 OpenClaw Gateway');
+  }
 }

--- a/fabushi/macos/Runner/Release.entitlements
+++ b/fabushi/macos/Runner/Release.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/fabushi/pubspec.lock
+++ b/fabushi/pubspec.lock
@@ -714,30 +714,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.0-0"
-  flutter_sound:
-    dependency: "direct main"
-    description:
-      name: flutter_sound
-      sha256: "77f0252a2f08449d621f68b8fd617c3b391e7f862eaa94bb32f53cc2dc3bbe85"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.30.0"
-  flutter_sound_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_sound_platform_interface
-      sha256: "5ffc858fd96c6fa277e3bb25eecc100849d75a8792b1f9674d1ba817aea9f861"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.30.0"
-  flutter_sound_web:
-    dependency: transitive
-    description:
-      name: flutter_sound_web
-      sha256: "3af46f45f44768c01c83ba260855c956d0963673664947926d942aa6fbf6f6fb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.30.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -92,10 +92,9 @@ dependencies:
   workmanager: ^0.6.0  # 后台任务恢复（应用被杀后自动重启）
 
   # 语音识别与录音
-  # - 移动端使用 Sherpa-ONNX + flutter_sound 音频流
+  # - 移动端使用 Sherpa-ONNX + record 音频流
   # - macOS 使用 record 包 + 原生 Speech 框架
   sherpa_onnx: ^1.12.20       # Sherpa-ONNX 离线语音识别（iOS/Android）
-  flutter_sound: ^9.16.3      # 音频流捕获和录音（iOS/Android）
   record: ^6.1.0              # 音频录制（macOS/iOS/Android）
   audio_session: ^0.1.21      # 音频会话管理（iOS 需要）
 

--- a/fabushi/pubspec.yaml
+++ b/fabushi/pubspec.yaml
@@ -92,9 +92,10 @@ dependencies:
   workmanager: ^0.6.0  # 后台任务恢复（应用被杀后自动重启）
 
   # 语音识别与录音
-  # - 移动端使用 Sherpa-ONNX + record 音频流
+  # - 移动端使用 Sherpa-ONNX + flutter_sound 音频流
   # - macOS 使用 record 包 + 原生 Speech 框架
   sherpa_onnx: ^1.12.20       # Sherpa-ONNX 离线语音识别（iOS/Android）
+  flutter_sound: ^9.16.3      # 音频流捕获和录音（iOS/Android）
   record: ^6.1.0              # 音频录制（macOS/iOS/Android）
   audio_session: ^0.1.21      # 音频会话管理（iOS 需要）
 

--- a/fabushi/scripts/build_openclaw_desktop_bundle.sh
+++ b/fabushi/scripts/build_openclaw_desktop_bundle.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 
 PLATFORM="${1:-}"
 OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.6.1}"
+OPENCLAW_WEIXIN_VERSION="${OPENCLAW_WEIXIN_VERSION:-2.4.3}"
+OPENCLAW_WEIXIN_PACKAGE="${OPENCLAW_WEIXIN_PACKAGE:-@tencent-weixin/openclaw-weixin@$OPENCLAW_WEIXIN_VERSION}"
+OPENCLAW_BUNDLE_WEIXIN="${OPENCLAW_BUNDLE_WEIXIN:-1}"
 NODE_VERSION="${NODE_VERSION:-24.2.0}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/assets/openclaw/$PLATFORM"
@@ -72,6 +75,27 @@ else
   "${NPM_CMD[@]}" install --omit=dev --ignore-scripts=false
 fi
 popd >/dev/null
+
+if [[ "$OPENCLAW_BUNDLE_WEIXIN" != "0" ]]; then
+  echo "==> Packing OpenClaw WeChat plugin: $OPENCLAW_WEIXIN_PACKAGE"
+  npm pack "$OPENCLAW_WEIXIN_PACKAGE" --pack-destination "$WORK_DIR" >/dev/null
+  WEIXIN_TGZ="$(find "$WORK_DIR" -maxdepth 1 -name '*openclaw-weixin*.tgz' | sort | tail -n 1)"
+  if [[ -z "$WEIXIN_TGZ" ]]; then
+    echo "failed to locate packed openclaw-weixin tarball" >&2
+    exit 1
+  fi
+  mkdir -p "$OUT_DIR/plugins/openclaw-weixin"
+  tar -xzf "$WEIXIN_TGZ" -C "$OUT_DIR/plugins/openclaw-weixin" --strip-components=1
+
+  echo "==> Installing production dependencies into bundled WeChat plugin"
+  pushd "$OUT_DIR/plugins/openclaw-weixin" >/dev/null
+  if [[ -f package-lock.json ]]; then
+    "${NPM_CMD[@]}" ci --omit=dev
+  else
+    "${NPM_CMD[@]}" install --omit=dev --ignore-scripts=false
+  fi
+  popd >/dev/null
+fi
 
 if [[ "$PLATFORM" != windows-* ]]; then
   chmod +x "$NODE_BIN"

--- a/fabushi/scripts/update_openclaw_bundle_manifest.py
+++ b/fabushi/scripts/update_openclaw_bundle_manifest.py
@@ -17,14 +17,28 @@ def main() -> int:
     else:
         data = {"schema": 1, "platforms": {}}
     data["schema"] = 1
-    data.setdefault("version", "openclaw-embedded-2026.06.2")
+    data.setdefault("version", "openclaw-embedded-2026.06.3")
     if data["version"] == "openclaw-embedded-2026.06":
-        data["version"] = "openclaw-embedded-2026.06.2"
+        data["version"] = "openclaw-embedded-2026.06.3"
+    if data["version"] == "openclaw-embedded-2026.06.2":
+        data["version"] = "openclaw-embedded-2026.06.3"
     data.setdefault("defaultPort", 18789)
     if data.get("defaultModel") in (None, "", "openclaw/default"):
         data["defaultModel"] = "deepseek/deepseek-chat"
     data.setdefault("defaultModelOverride", "")
     data["gatewayArgs"] = ["gateway", "--port", "{port}", "--force"]
+    data.setdefault(
+        "bundledPlugins",
+        [
+            {
+                "id": "openclaw-weixin",
+                "package": "@tencent-weixin/openclaw-weixin",
+                "version": "2.4.3",
+                "path": "plugins/openclaw-weixin",
+                "channel": "openclaw-weixin",
+            }
+        ],
+    )
     platforms = data.setdefault("platforms", {})
     platforms[platform] = {
         "nodeExecutable": "node/node.exe" if platform.startswith("windows-") else "node/bin/node",

--- a/fabushi/test/unit/services/desktop_control/desktop_control_bridge_test.dart
+++ b/fabushi/test/unit/services/desktop_control/desktop_control_bridge_test.dart
@@ -128,6 +128,40 @@ void main() {
     expect(result.errorCode, 'disabled_by_build');
   });
 
+  test('desktop permission requests delegate to the host API', () async {
+    final host = _FakeDesktopControlHostApi();
+    final bridge = DesktopControlBridge.test(
+      hostApi: host,
+      enabledByBuild: () => true,
+      platformProvider: () => 'macos',
+      random: Random(7),
+    );
+
+    final screen = await bridge.requestScreenRecordingPermission();
+    final accessibility = await bridge.requestAccessibilityPermission();
+
+    expect(screen['requested'], isTrue);
+    expect(accessibility['trusted'], isTrue);
+    expect(host.calls, ['requestScreenRecording', 'requestAccessibility']);
+  });
+
+  test('desktop permission requests honor unsupported platforms', () async {
+    final host = _FakeDesktopControlHostApi();
+    final bridge = DesktopControlBridge.test(
+      hostApi: host,
+      enabledByBuild: () => true,
+      platformProvider: () => 'android',
+      random: Random(8),
+    );
+
+    final screen = await bridge.requestScreenRecordingPermission();
+    final accessibility = await bridge.requestAccessibilityPermission();
+
+    expect(screen['requested'], isFalse);
+    expect(accessibility['trusted'], isFalse);
+    expect(host.calls, isEmpty);
+  });
+
   test('tool policy exposes the expected migration surface', () {
     expect(
       DesktopControlPolicy.supportedTools,
@@ -160,6 +194,18 @@ class _FakeDesktopControlHostApi implements DesktopControlHostApi {
     'screenRecordingGranted': true,
     'accessibilityGranted': true,
   };
+
+  @override
+  Future<Map<String, dynamic>> requestScreenRecording() async {
+    calls.add('requestScreenRecording');
+    return {'requested': true};
+  }
+
+  @override
+  Future<Map<String, dynamic>> requestAccessibility() async {
+    calls.add('requestAccessibility');
+    return {'trusted': true};
+  }
 
   @override
   Future<Map<String, dynamic>> observe() async {


### PR DESCRIPTION
## Summary
- add a WorkBuddy-style OpenClaw workbench tab for local assistant, projects, experts, skills, connectors, and automations
- expose mobile/WeChat remote pairing, desktop control, permissions, Chrome connector, channel checks, and diagnostic actions from the workbench
- simplify the messy OpenClaw settings card into a workbench entry, health check, and advanced operations menu
- repair generated OpenClaw config by removing invalid toolSearch/fs/exec.mode fields while preserving full desktop execution defaults

## Validation
- inspected WorkBuddy v5.1.4 UI with Computer Use and ported its core layout patterns
- dart format on touched Dart files
- flutter analyze lib/screens/openclaw_workbench_screen.dart
- flutter analyze lib/screens/openclaw_workbench_screen.dart lib/screens/main_navigation_screen_native.dart lib/screens/settings_screen.dart lib/services/openclaw/openclaw_runtime_io.dart (existing settings/main-nav warnings only)
- flutter test test/unit/services/desktop_control/desktop_control_bridge_test.dart
- xcodebuild -workspace macos/Runner.xcworkspace -scheme Runner -configuration Debug -derivedDataPath build/macos-xcodebuild build
- launched the Debug macOS app and verified 首页 -> 助理 -> 项目 / 专家 / 技能 / 连接器 / 自动化 with Computer Use

Note: flutter run hot reload is blocked on this machine because CocoaPods is not installed; the Debug app was built and tested through Xcode instead.