### PR TITLE
Fix embedded OpenClaw desktop tool startup

### DIFF
--- a/fabushi/lib/services/openclaw/openclaw_ai_bridge.dart
+++ b/fabushi/lib/services/openclaw/openclaw_ai_bridge.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 
@@ -31,6 +32,9 @@ class OpenClawAiBridge {
   static const Duration _requestTimeout = Duration(seconds: 45);
   static const Duration _firstTokenTimeout = Duration(seconds: 120);
   static const Duration _streamIdleTimeout = Duration(seconds: 90);
+  static const String _desktopToolSystemPrompt = '''
+你是大乘桌面端内置 OpenClaw 助理。用户要求打开浏览器、访问网页、点击页面、输入文本、读取本机桌面或操作 Chrome 时，要优先调用可用的 browser、chrome 或 desktop 工具实际执行，不要只给操作教程。涉及本机桌面或 Chrome 写操作时，大乘会弹出确认，请发起工具调用并等待用户确认。
+''';
 
   Future<DachengAiChatResult> sendChat({
     required String message,
@@ -84,6 +88,9 @@ class OpenClawAiBridge {
     final requestId = _uuid.v4();
     final totalWatch = Stopwatch()..start();
     final normalizedMessage = message.trim();
+    final requiresLocalToolExecution = _requiresLocalToolExecution(
+      normalizedMessage,
+    );
     String? fallbackConversationId;
     List<Map<String, dynamic>>? fallbackMessages;
     if (normalizedMessage.isEmpty) {
@@ -142,18 +149,23 @@ class OpenClawAiBridge {
       );
 
       final existing = await _store.get(effectiveConversationId);
+      final historyMessages =
+          (existing?.messages ?? const <LocalAiConversationMessage>[])
+              .where((item) => item.content.trim().isNotEmpty)
+              .map(
+                (item) => {
+                  'role': item.role == 'user' ? 'user' : 'assistant',
+                  'content': item.content,
+                },
+              )
+              .toList();
+      final userMessage = {'role': 'user', 'content': normalizedMessage};
       final requestMessages = <Map<String, dynamic>>[
-        ...(existing?.messages ?? const <LocalAiConversationMessage>[])
-            .where((item) => item.content.trim().isNotEmpty)
-            .map(
-              (item) => {
-                'role': item.role == 'user' ? 'user' : 'assistant',
-                'content': item.content,
-              },
-            ),
-        {'role': 'user', 'content': normalizedMessage},
+        {'role': 'system', 'content': _desktopToolSystemPrompt.trim()},
+        ...historyMessages,
+        userMessage,
       ];
-      fallbackMessages = requestMessages;
+      fallbackMessages = [...historyMessages, userMessage];
 
       final uri = target.baseUri.replace(path: '/v1/chat/completions');
       final body = jsonEncode({
@@ -182,6 +194,7 @@ class OpenClawAiBridge {
           'conversationId': effectiveConversationId,
           'messageCount': requestMessages.length,
           'bodyBytes': utf8.encode(body).length,
+          'requiresLocalToolExecution': requiresLocalToolExecution,
         },
       );
 
@@ -364,7 +377,8 @@ class OpenClawAiBridge {
     } catch (error, stackTrace) {
       if (error is _OpenClawDeepSeekBlockedException &&
           fallbackConversationId != null &&
-          fallbackMessages != null) {
+          fallbackMessages != null &&
+          !requiresLocalToolExecution) {
         _diag(
           'chat.backend-fallback.start',
           data: {
@@ -387,6 +401,19 @@ class OpenClawAiBridge {
           startedAt: totalWatch,
         );
         return;
+      }
+      if (error is _OpenClawDeepSeekBlockedException &&
+          requiresLocalToolExecution) {
+        _diag(
+          'chat.backend-fallback.skipped-local-tool-request',
+          data: {
+            'requestId': requestId,
+            'elapsedMs': totalWatch.elapsedMilliseconds,
+          },
+          error: error,
+          stackTrace: stackTrace,
+        );
+        throw StateError('本机 OpenClaw 工具调用失败，未降级为纯文本模型：${error.message}');
       }
       _diag(
         'chat.error',
@@ -614,6 +641,26 @@ class OpenClawAiBridge {
       r'(403|blocked|forbidden|被拦截)',
       caseSensitive: false,
     ).hasMatch(message);
+  }
+
+  @visibleForTesting
+  bool requiresLocalToolExecutionForTest(String message) {
+    return _requiresLocalToolExecution(message);
+  }
+
+  bool _requiresLocalToolExecution(String message) {
+    final text = message.trim().toLowerCase();
+    if (text.isEmpty) return false;
+    final hasUrl = RegExp(r'https?://|www\.').hasMatch(text);
+    final hasAction = RegExp(
+      r'(open|visit|navigate|go to|click|tap|type|input|screenshot|browser|chrome|desktop|打开|访问|浏览器|网页|点击|点按|输入|截图|屏幕|桌面|chrome)',
+      caseSensitive: false,
+    ).hasMatch(text);
+    if (hasUrl && hasAction) return true;
+    return RegExp(
+      r'(打开浏览器|访问网页|打开网页|点击页面|操作浏览器|操作chrome|操作桌面|本机.*点击|桌面.*点击|浏览器.*点击)',
+      caseSensitive: false,
+    ).hasMatch(text);
   }
 
   Map<String, dynamic>? _safeDecodeMap(String dataText, {String? requestId}) {

--- a/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
@@ -1864,7 +1864,84 @@ class OpenClawRuntime {
     );
     final remoteUrl = remoteGatewayUrl.trim();
 
-    final config = <String, dynamic>{
+    final config = _buildEmbeddedConfig(
+      stateRoot: stateRoot,
+      port: port,
+      token: token,
+      backendDeepSeekModel: backendDeepSeekModel,
+      deepSeekProxyBaseUrl: deepSeekProxyBaseUrl,
+      remoteGatewayUrl: remoteUrl,
+      pluginLoadPaths: pluginLoadPaths,
+      hasWeChatPlugin: hasWeChatPlugin,
+    );
+
+    // Repair older embedded configs in-place. OpenClaw 2026.6 requires
+    // gateway.mode=local, and the home screen requires the OpenAI-compatible
+    // chat endpoint. Preserve unrelated user edits while fixing the fields
+    // needed for the app-owned embedded gateway to start reliably.
+    final merged = await _mergeEmbeddedConfig(configPath, config);
+    await configPath.writeAsString(
+      const JsonEncoder.withIndent('  ').convert(merged),
+    );
+    _diag(
+      'config.written',
+      data: {
+        'configPath': configPath.path,
+        'port': port,
+        'gatewayMode': _mutableMap(merged['gateway'])['mode'],
+        'backendDeepSeekModel': backendDeepSeekModel,
+        'deepSeekProxyBaseUrl': deepSeekProxyBaseUrl,
+        'remoteGatewayUrlSet': remoteUrl.isNotEmpty,
+        'pluginLoadPaths': pluginLoadPaths,
+        'hasWeChatPlugin': hasWeChatPlugin,
+      },
+    );
+    return configPath;
+  }
+
+  @visibleForTesting
+  Map<String, dynamic> buildEmbeddedConfigForTest({
+    required Directory stateRoot,
+    required int port,
+    required String token,
+    required String backendDeepSeekModel,
+    required String deepSeekProxyBaseUrl,
+    String remoteGatewayUrl = '',
+    List<String> pluginLoadPaths = const [],
+    bool hasWeChatPlugin = false,
+  }) {
+    return _buildEmbeddedConfig(
+      stateRoot: stateRoot,
+      port: port,
+      token: token,
+      backendDeepSeekModel: backendDeepSeekModel,
+      deepSeekProxyBaseUrl: deepSeekProxyBaseUrl,
+      remoteGatewayUrl: remoteGatewayUrl,
+      pluginLoadPaths: pluginLoadPaths,
+      hasWeChatPlugin: hasWeChatPlugin,
+    );
+  }
+
+  Map<String, dynamic> _buildEmbeddedConfig({
+    required Directory stateRoot,
+    required int port,
+    required String token,
+    required String backendDeepSeekModel,
+    required String deepSeekProxyBaseUrl,
+    required String remoteGatewayUrl,
+    required List<String> pluginLoadPaths,
+    required bool hasWeChatPlugin,
+  }) {
+    final workspace = p.join(stateRoot.path, 'workspace');
+    final remoteUrl = remoteGatewayUrl.trim();
+    final desktopToolAllowList = DesktopControlPolicy.supportedTools.toList()
+      ..sort();
+    final canvasHostConfig = <String, dynamic>{
+      'enabled': true,
+      'root': p.join(stateRoot.path, 'canvas'),
+    };
+
+    return <String, dynamic>{
       'gateway': {
         'mode': 'local',
         'port': port,
@@ -1921,12 +1998,9 @@ class OpenClawRuntime {
         'headless': false,
         'ssrfPolicy': {'dangerouslyAllowPrivateNetwork': true},
       },
-      'canvas': {
-        'enabled': true,
-        'host': {'enabled': true, 'root': p.join(stateRoot.path, 'canvas')},
-      },
       'tools': {
         'profile': 'full',
+        'alsoAllow': desktopToolAllowList,
         'exec': {'host': 'gateway', 'security': 'full', 'ask': 'off'},
       },
       'plugins': {
@@ -1938,7 +2012,10 @@ class OpenClawRuntime {
           'memory-core': {'enabled': true},
           'bonjour': {'enabled': false},
           'browser': {'enabled': true},
-          'canvas': {'enabled': true},
+          'canvas': {
+            'enabled': true,
+            'config': {'host': canvasHostConfig},
+          },
           'device-pair': {'enabled': true},
           'file-transfer': {'enabled': true},
           'phone-control': {'enabled': true},
@@ -1959,42 +2036,19 @@ class OpenClawRuntime {
       },
       'agents': {
         'defaults': {
-          'workspace': workspace.path,
+          'workspace': workspace,
           'model': {'primary': backendDeepSeekModel},
         },
         'list': [
           {
             'id': 'dacheng',
             'default': true,
-            'workspace': workspace.path,
+            'workspace': workspace,
             'model': {'primary': backendDeepSeekModel},
           },
         ],
       },
     };
-
-    // Repair older embedded configs in-place. OpenClaw 2026.6 requires
-    // gateway.mode=local, and the home screen requires the OpenAI-compatible
-    // chat endpoint. Preserve unrelated user edits while fixing the fields
-    // needed for the app-owned embedded gateway to start reliably.
-    final merged = await _mergeEmbeddedConfig(configPath, config);
-    await configPath.writeAsString(
-      const JsonEncoder.withIndent('  ').convert(merged),
-    );
-    _diag(
-      'config.written',
-      data: {
-        'configPath': configPath.path,
-        'port': port,
-        'gatewayMode': _mutableMap(merged['gateway'])['mode'],
-        'backendDeepSeekModel': backendDeepSeekModel,
-        'deepSeekProxyBaseUrl': deepSeekProxyBaseUrl,
-        'remoteGatewayUrlSet': remoteUrl.isNotEmpty,
-        'pluginLoadPaths': pluginLoadPaths,
-        'hasWeChatPlugin': hasWeChatPlugin,
-      },
-    );
-    return configPath;
   }
 
   Future<File> _ensureDesktopToolsManifest({
@@ -2458,21 +2512,30 @@ export default {
     browser.addAll(defaultBrowser);
     current['browser'] = browser;
 
-    final defaultCanvas = _mutableMap(defaults['canvas']);
-    final canvas = _mutableMap(current['canvas']);
-    canvas.addAll(defaultCanvas);
-    current['canvas'] = canvas;
+    // OpenClaw 2026.6 rejects root-level canvas/canvasHost. Canvas is now
+    // configured through plugins.entries.canvas.config.host.
+    current.remove('canvas');
+    current.remove('canvasHost');
 
     final defaultTools = _mutableMap(defaults['tools']);
     final tools = _mutableMap(current['tools']);
     tools.remove('toolSearch');
     tools.remove('fs');
+    final alsoAllow = _mergeStringLists(
+      tools['alsoAllow'],
+      defaultTools['alsoAllow'],
+    );
     final execTools = _mutableMap(tools['exec']);
     execTools.remove('mode');
     if (execTools.isNotEmpty) {
       tools['exec'] = execTools;
     }
     tools.addAll(defaultTools);
+    if (alsoAllow.isEmpty) {
+      tools.remove('alsoAllow');
+    } else {
+      tools['alsoAllow'] = alsoAllow;
+    }
     current['tools'] = tools;
 
     final defaultPlugins = _mutableMap(defaults['plugins']);
@@ -2576,6 +2639,14 @@ export default {
     current['agents'] = agents;
 
     return current;
+  }
+
+  @visibleForTesting
+  Future<Map<String, dynamic>> mergeEmbeddedConfigForTest(
+    File configPath,
+    Map<String, dynamic> defaults,
+  ) {
+    return _mergeEmbeddedConfig(configPath, defaults);
   }
 
   String _gatewayChatModel(String model) {

--- a/fabushi/test/unit/services/openclaw_ai_bridge_test.dart
+++ b/fabushi/test/unit/services/openclaw_ai_bridge_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/services/openclaw/openclaw_ai_bridge.dart';
+
+void main() {
+  group('OpenClawAiBridge local tool intent', () {
+    late OpenClawAiBridge bridge;
+
+    setUp(() {
+      bridge = OpenClawAiBridge();
+    });
+
+    test('detects browser and click requests', () {
+      expect(
+        bridge.requiresLocalToolExecutionForTest(
+          'Open https://example.com in a browser and click the center.',
+        ),
+        isTrue,
+      );
+      expect(bridge.requiresLocalToolExecutionForTest('打开浏览器访问网页'), isTrue);
+      expect(
+        bridge.requiresLocalToolExecutionForTest('请点击页面中央，然后回复完成'),
+        isTrue,
+      );
+    });
+
+    test('does not classify ordinary chat as local tool execution', () {
+      expect(bridge.requiresLocalToolExecutionForTest('解释一下心经的核心意思'), isFalse);
+      expect(
+        bridge.requiresLocalToolExecutionForTest('Summarize this paragraph.'),
+        isFalse,
+      );
+    });
+  });
+}

--- a/fabushi/test/unit/services/openclaw_runtime_config_test.dart
+++ b/fabushi/test/unit/services/openclaw_runtime_config_test.dart
@@ -1,0 +1,149 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:global_dharma_sharing/services/desktop_control/desktop_control_policy.dart';
+import 'package:global_dharma_sharing/services/openclaw/openclaw_runtime.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('OpenClaw embedded config', () {
+    test('uses plugin-scoped Canvas host config and allows desktop tools', () {
+      final stateRoot = Directory.systemTemp.createTempSync(
+        'openclaw-config-test-',
+      );
+      addTearDown(() async {
+        if (await stateRoot.exists()) {
+          await stateRoot.delete(recursive: true);
+        }
+      });
+
+      final config = OpenClawRuntime.instance.buildEmbeddedConfigForTest(
+        stateRoot: stateRoot,
+        port: 18789,
+        token: 'test-token',
+        backendDeepSeekModel: 'dacheng-deepseek-proxy/deepseek-chat',
+        deepSeekProxyBaseUrl: 'https://api.example.test/v1',
+        pluginLoadPaths: ['/tmp/dacheng-desktop-tools'],
+      );
+
+      expect(config.containsKey('canvas'), isFalse);
+      expect(config.containsKey('canvasHost'), isFalse);
+
+      final tools = _map(config['tools']);
+      expect(tools['profile'], 'full');
+      expect(
+        _strings(tools['alsoAllow']),
+        containsAll({'chrome.navigate', 'chrome.click', 'desktop.click'}),
+      );
+      expect(
+        _strings(tools['alsoAllow']),
+        containsAll(DesktopControlPolicy.supportedTools),
+      );
+
+      final exec = _map(tools['exec']);
+      expect(exec['host'], 'gateway');
+      expect(exec['security'], 'full');
+      expect(exec['ask'], 'off');
+      expect(exec.containsKey('mode'), isFalse);
+
+      final plugins = _map(config['plugins']);
+      final entries = _map(plugins['entries']);
+      final canvas = _map(entries['canvas']);
+      expect(canvas['enabled'], isTrue);
+      expect(_map(_map(canvas['config'])['host']), {
+        'enabled': true,
+        'root': '${stateRoot.path}/canvas',
+      });
+    });
+
+    test('repairs legacy invalid config before gateway startup', () async {
+      final stateRoot = await Directory.systemTemp.createTemp(
+        'openclaw-config-merge-test-',
+      );
+      addTearDown(() async {
+        if (await stateRoot.exists()) {
+          await stateRoot.delete(recursive: true);
+        }
+      });
+      final configPath = File('${stateRoot.path}/openclaw.json');
+      await configPath.writeAsString(
+        jsonEncode({
+          'canvas': {
+            'enabled': true,
+            'host': {'enabled': true},
+          },
+          'canvasHost': {'enabled': true},
+          'tools': {
+            'toolSearch': 'invalid',
+            'fs': {'workspaceOnly': true},
+            'alsoAllow': ['custom.localTool'],
+            'exec': {'mode': 'full', 'security': 'full', 'ask': 'off'},
+          },
+          'plugins': {
+            'enabled': false,
+            'deny': ['dacheng-desktop-tools', 'user-disabled-plugin'],
+            'entries': {
+              'canvas': {'enabled': false},
+              'dacheng-desktop-tools': {'enabled': false},
+            },
+          },
+        }),
+      );
+
+      final defaults = OpenClawRuntime.instance.buildEmbeddedConfigForTest(
+        stateRoot: stateRoot,
+        port: 18790,
+        token: 'test-token',
+        backendDeepSeekModel: 'dacheng-deepseek-proxy/deepseek-chat',
+        deepSeekProxyBaseUrl: 'https://api.example.test/v1',
+        pluginLoadPaths: ['/tmp/dacheng-desktop-tools'],
+      );
+      final merged = await OpenClawRuntime.instance.mergeEmbeddedConfigForTest(
+        configPath,
+        defaults,
+      );
+
+      expect(merged.containsKey('canvas'), isFalse);
+      expect(merged.containsKey('canvasHost'), isFalse);
+
+      final tools = _map(merged['tools']);
+      expect(tools.containsKey('toolSearch'), isFalse);
+      expect(tools.containsKey('fs'), isFalse);
+      expect(_map(tools['exec']).containsKey('mode'), isFalse);
+      expect(_strings(tools['alsoAllow']), contains('custom.localTool'));
+      expect(
+        _strings(tools['alsoAllow']),
+        containsAll(DesktopControlPolicy.supportedTools),
+      );
+
+      final plugins = _map(merged['plugins']);
+      expect(plugins['enabled'], isTrue);
+      expect(
+        _strings(plugins['deny']),
+        allOf(
+          isNot(contains('dacheng-desktop-tools')),
+          contains('user-disabled-plugin'),
+        ),
+      );
+
+      final entries = _map(plugins['entries']);
+      expect(_map(entries['dacheng-desktop-tools'])['enabled'], isTrue);
+      final canvas = _map(entries['canvas']);
+      expect(canvas['enabled'], isTrue);
+      expect(_map(_map(canvas['config'])['host'])['root'], endsWith('/canvas'));
+    });
+  });
+}
+
+Map<String, dynamic> _map(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) return Map<String, dynamic>.from(value);
+  return <String, dynamic>{};
+}
+
+List<String> _strings(Object? value) {
+  if (value is! Iterable) return <String>[];
+  return value.map((item) => item.toString()).toList();
+}


### PR DESCRIPTION
## Summary
- repair embedded OpenClaw config generation for the 2026.6 schema by moving Canvas host config under the Canvas plugin and removing legacy root canvas keys
- expose desktop/Chrome tools through tools.alsoAllow and preserve/repair legacy configs before Gateway startup
- route browser/desktop requests through OpenClaw with a tool-use system prompt and prevent text-only DeepSeek fallback from pretending local tool actions completed

## Tests
- flutter test test/unit/services/openclaw_ai_bridge_test.dart test/unit/services/openclaw_runtime_config_test.dart test/unit/services/openclaw_port_resolver_test.dart test/unit/services/desktop_control/desktop_control_bridge_test.dart
- openclaw config validate against local embedded config

## Manual Notes
- Desktop UI no longer reproduced the red invalid-config startup card after repairing the local config.
- A current installed app build answered a browser-click prompt via fallback without moving Chrome; this PR prevents that false success for local tool requests.