### PR TITLE
Harden embedded OpenClaw cache and desktop approvals

### DIFF
--- a/fabushi/lib/screens/globe_home_screen.dart
+++ b/fabushi/lib/screens/globe_home_screen.dart
@@ -124,6 +124,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   String _openClawPermissionLabel = '默认权限';
   OpenClawRuntimeStatus? _openClawStatus;
   DesktopControlBridgeStatus? _desktopControlStatus;
+  List<DesktopControlPendingConfirmation> _desktopControlPending = const [];
   bool? _buddhaAssetUnlocked;
   bool _isPurchasingBuddhaAsset = false;
   DateTime? _sendStartedAt;
@@ -777,6 +778,9 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
     final bridgeReady = _desktopControlStatus?.bridgeRunning == true;
     final remoteReady = _openClawRemoteGatewayUrl.trim().isNotEmpty;
     final chromeReady = _desktopControlStatus?.chrome.connected == true;
+    final pending = _desktopControlPending.isEmpty
+        ? null
+        : _desktopControlPending.first;
 
     return Wrap(
       spacing: 8,
@@ -810,6 +814,12 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           active: chromeReady,
           onTap: _prepareHomeChromeConnector,
         ),
+        if (pending != null)
+          _DesktopPendingActionPill(
+            summary: pending.summary,
+            onApprove: () => _approveHomeDesktopControlRequest(pending.id),
+            onReject: () => _rejectHomeDesktopControlRequest(pending.id),
+          ),
       ],
     );
   }
@@ -4650,12 +4660,17 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
         DesktopControlBridge.instance.getStatus().timeout(
           const Duration(seconds: 5),
         ),
+        DesktopControlBridge.instance.pendingConfirmations().timeout(
+          const Duration(seconds: 5),
+        ),
       ]);
       if (!mounted) return;
       setState(() {
         _openClawRemoteGatewayUrl = (values[0] as String).trim();
         _openClawStatus = values[1] as OpenClawRuntimeStatus;
         _desktopControlStatus = values[2] as DesktopControlBridgeStatus;
+        _desktopControlPending =
+            values[3] as List<DesktopControlPendingConfirmation>;
         _isOpenClawPanelLoading = false;
       });
     } catch (error) {
@@ -4666,6 +4681,7 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
           message: 'OpenClaw 状态检测失败：$error',
           checkedAt: DateTime.now(),
         );
+        _desktopControlPending = const [];
         _isOpenClawPanelLoading = false;
       });
     }
@@ -4863,13 +4879,36 @@ class GlobeHomeScreenState extends State<GlobeHomeScreen>
   Future<void> _startDesktopBridgeFromHome() async {
     try {
       final status = await DesktopControlBridge.instance.ensureStarted();
+      final pending = await DesktopControlBridge.instance
+          .pendingConfirmations()
+          .timeout(const Duration(seconds: 5));
       if (!mounted) return;
-      setState(() => _desktopControlStatus = status);
+      setState(() {
+        _desktopControlStatus = status;
+        _desktopControlPending = pending;
+      });
       _showHomeSnack(status.message, ok: status.desktopControlAvailable);
     } catch (error) {
       if (!mounted) return;
       _showHomeSnack('桌面工具启动失败：$error', ok: false);
     }
+  }
+
+  Future<void> _approveHomeDesktopControlRequest(String id) async {
+    final item = await DesktopControlBridge.instance.approvePendingRequest(id);
+    await _loadOpenClawHomeStatus(probeOpenClaw: true);
+    if (!mounted) return;
+    _showHomeSnack(
+      item == null ? '确认请求已失效' : '已允许该动作，工具可继续执行',
+      ok: item != null,
+    );
+  }
+
+  Future<void> _rejectHomeDesktopControlRequest(String id) async {
+    final item = await DesktopControlBridge.instance.rejectPendingRequest(id);
+    await _loadOpenClawHomeStatus(probeOpenClaw: true);
+    if (!mounted) return;
+    _showHomeSnack(item == null ? '确认请求已失效' : '已拒绝该动作', ok: false);
   }
 
   Future<void> _requestHomeDesktopPermission({
@@ -6567,6 +6606,88 @@ class _DesktopStatusPill extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _DesktopPendingActionPill extends StatelessWidget {
+  final String summary;
+  final VoidCallback onApprove;
+  final VoidCallback onReject;
+
+  const _DesktopPendingActionPill({
+    required this.summary,
+    required this.onApprove,
+    required this.onReject,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 360),
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 7),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF7E1),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: const Color(0xFFFFD988)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.touch_app_outlined,
+            color: Color(0xFF9A5A00),
+            size: 16,
+          ),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              summary,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Color(0xFF7A4700),
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          InkWell(
+            onTap: onReject,
+            borderRadius: BorderRadius.circular(999),
+            child: const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              child: Text(
+                '拒绝',
+                style: TextStyle(
+                  color: Color(0xFF8A4B00),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+          ),
+          InkWell(
+            onTap: onApprove,
+            borderRadius: BorderRadius.circular(999),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(
+                color: const Color(0xFF00A37E),
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: const Text(
+                '允许',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_io.dart
@@ -2218,6 +2218,7 @@ class OpenClawRuntime {
         ? nodeBinDir
         : '$nodeBinDir$separator$currentPath';
     final env = Map<String, String>.from(Platform.environment)
+      ..remove('NODE_COMPILE_CACHE')
       ..addAll({
         'OPENCLAW_GATEWAY_PORT': '$port',
         'OPENCLAW_GATEWAY_BIND': 'loopback',
@@ -2227,10 +2228,28 @@ class OpenClawRuntime {
         'OPENCLAW_AGENT_DIR': p.join(stateRoot.path, 'agents'),
         'OPENCLAW_WORKSPACE': p.join(stateRoot.path, 'workspace'),
         'OPENCLAW_DISABLE_BONJOUR': '1',
+        'NODE_DISABLE_COMPILE_CACHE': '1',
         pathKey: pathValue,
         if (pathKey != 'PATH') 'PATH': pathValue,
       });
     return env;
+  }
+
+  @visibleForTesting
+  Map<String, String> buildOpenClawEnvironmentForTest({
+    required Directory runtimeDir,
+    required Directory stateRoot,
+    required File configPath,
+    required int port,
+    required String token,
+  }) {
+    return _buildOpenClawEnvironment(
+      runtimeDir: runtimeDir,
+      stateRoot: stateRoot,
+      configPath: configPath,
+      port: port,
+      token: token,
+    );
   }
 
   Future<List<String>> _bundledPluginLoadPaths(Directory runtimeDir) async {

--- a/fabushi/lib/services/openclaw/openclaw_runtime_stub.dart
+++ b/fabushi/lib/services/openclaw/openclaw_runtime_stub.dart
@@ -141,4 +141,34 @@ class OpenClawRuntime {
   }) async {
     throw StateError('当前平台不支持内置 OpenClaw Gateway');
   }
+
+  Map<String, dynamic> buildEmbeddedConfigForTest({
+    required Object stateRoot,
+    required int port,
+    required String token,
+    required String backendDeepSeekModel,
+    required String deepSeekProxyBaseUrl,
+    String remoteGatewayUrl = '',
+    List<String> pluginLoadPaths = const [],
+    bool hasWeChatPlugin = false,
+  }) {
+    return <String, dynamic>{};
+  }
+
+  Future<Map<String, dynamic>> mergeEmbeddedConfigForTest(
+    Object configPath,
+    Map<String, dynamic> defaults,
+  ) async {
+    return defaults;
+  }
+
+  Map<String, String> buildOpenClawEnvironmentForTest({
+    required Object runtimeDir,
+    required Object stateRoot,
+    required Object configPath,
+    required int port,
+    required String token,
+  }) {
+    return <String, String>{};
+  }
 }

--- a/fabushi/test/unit/services/openclaw_runtime_config_test.dart
+++ b/fabushi/test/unit/services/openclaw_runtime_config_test.dart
@@ -134,6 +134,32 @@ void main() {
       expect(canvas['enabled'], isTrue);
       expect(_map(_map(canvas['config'])['host'])['root'], endsWith('/canvas'));
     });
+
+    test('disables inherited Node compile cache for embedded runtime', () {
+      final stateRoot = Directory.systemTemp.createTempSync(
+        'openclaw-env-test-',
+      );
+      final runtimeDir = Directory('${stateRoot.path}/runtime')
+        ..createSync(recursive: true);
+      final configPath = File('${stateRoot.path}/openclaw.json');
+      addTearDown(() async {
+        if (await stateRoot.exists()) {
+          await stateRoot.delete(recursive: true);
+        }
+      });
+
+      final env = OpenClawRuntime.instance.buildOpenClawEnvironmentForTest(
+        runtimeDir: runtimeDir,
+        stateRoot: stateRoot,
+        configPath: configPath,
+        port: 18791,
+        token: 'test-token',
+      );
+
+      expect(env['NODE_DISABLE_COMPILE_CACHE'], '1');
+      expect(env.containsKey('NODE_COMPILE_CACHE'), isFalse);
+      expect(env['OPENCLAW_CONFIG_PATH'], configPath.path);
+    });
   });
 }
 


### PR DESCRIPTION
Follow-up to #1171.

- Disable inherited Node compile cache for embedded OpenClaw launches.
- Add a home-screen approval surface for pending desktop tool actions.
- Keep OpenClaw runtime test helpers visible to analyzer stubs.

Verified:
- flutter analyze lib/screens/globe_home_screen.dart lib/services/openclaw/openclaw_runtime_io.dart lib/services/openclaw/openclaw_runtime_stub.dart test/unit/services/openclaw_runtime_config_test.dart
- flutter test test/unit/services/openclaw_ai_bridge_test.dart test/unit/services/openclaw_runtime_config_test.dart test/unit/services/openclaw_port_resolver_test.dart test/unit/services/desktop_control/desktop_control_bridge_test.dart