### PR TITLE
Update Dacheng entry to Flutter Web

### DIFF
--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -331,13 +331,7 @@ export default async function HomePage() {
               />
             </p>
             <div className="hero-actions">
-              <a className="primary-action" href={siteHref("/app")}>
-                <LocalizedText zh="打开 Web 版" en="Open Web App" />
-              </a>
-              <a className="secondary-action" href={siteHref("/app/ai")}>
-                <LocalizedText zh="进入大乘 AI" en="Open Dacheng AI" />
-              </a>
-              <a className="secondary-action" href={siteHref("/download")}>
+              <a className="primary-action" href={siteHref("/download")}>
                 <LocalizedText zh="下载 App" en="Download App" />
               </a>
             </div>

--- a/frontend/apps/web/src/components/site-footer.tsx
+++ b/frontend/apps/web/src/components/site-footer.tsx
@@ -3,11 +3,6 @@ import { siteHref } from "../lib/site-url";
 
 const FOOTER_LINKS = [
   {
-    href: "/app",
-    zh: "大乘 Web",
-    en: "Dacheng Web",
-  },
-  {
     href: "/download",
     zh: "下载 App",
     en: "Download App",

--- a/frontend/apps/web/src/components/site-header.tsx
+++ b/frontend/apps/web/src/components/site-header.tsx
@@ -2,12 +2,9 @@ import { LanguageSwitch } from "./language-switch";
 import { LocalizedText } from "./localized-text";
 import { siteHref } from "../lib/site-url";
 
+const FLUTTER_WEB_URL = "https://flutter.ombhrum.com";
+
 const NAV_ITEMS = [
-  {
-    href: "/app",
-    zh: "大乘 Web",
-    en: "Dacheng Web",
-  },
   {
     href: "/faliu",
     zh: "法流",
@@ -51,7 +48,7 @@ export function SiteHeader() {
         </div>
         <div className="site-nav-actions">
           <LanguageSwitch />
-          <a className="nav-cta" href={siteHref("/app")}>
+          <a className="nav-cta" href={FLUTTER_WEB_URL}>
             <LocalizedText zh="打开大乘" en="Open Dacheng" />
           </a>
         </div>


### PR DESCRIPTION
## Summary

- Remove the visible Dacheng Web entry from the site header and footer.
- Remove the homepage hero buttons for "打开 Web 版" and "进入大乘 AI".
- Point the top-right "打开大乘" CTA directly to the Flutter Web production URL: https://flutter.ombhrum.com.

## Verification

- Compared `main...fable5/flutter-web-entry` and confirmed only three frontend entry files changed.
- Fetched the branch contents to verify the header CTA URL and homepage hero actions.