### PR TITLE
Update Flutter and Taro sidebar chat UI

### DIFF
--- a/fabushi/lib/screens/main_navigation_screen_native.dart
+++ b/fabushi/lib/screens/main_navigation_screen_native.dart
@@ -1,12 +1,13 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'globe_home_screen.dart';
 import 'meditation_room_screen.dart';
 import 'my_profile_screen.dart';
-import '../core/design_system/app_theme.dart';
-import '../l10n/app_localizations.dart';
 import '../widgets/space_background.dart';
 
 import '../widgets/sidebar/codex_sidebar.dart';
+import '../widgets/sidebar/dacheng_chat_sidebar.dart';
 import 'settings_screen.dart';
 
 class MainNavigationScreen extends StatefulWidget {
@@ -19,25 +20,20 @@ class MainNavigationScreen extends StatefulWidget {
 class _MainNavigationScreenState extends State<MainNavigationScreen> {
   int _currentIndex = 3;
   bool _isGlobeReady = false;
+  bool _mobileSidebarOpen = false;
 
-  // 追踪哪些页面已被激活
   final List<bool> _activatedScreens = [false, false, false, true, false];
 
-  // 用于通知各主页面的可见性变化
   final GlobalKey<MeditationRoomScreenState> _meditationKey = GlobalKey();
   final GlobalKey<GlobeHomeScreenState> _globeKey = GlobalKey();
+
+  bool get _isMobileRuntime => Platform.isAndroid || Platform.isIOS;
 
   @override
   void initState() {
     super.initState();
-    // 立即加载，由 GlobeHomeScreen 内部控制延迟
     _isGlobeReady = true;
     _applyInitialTabFromUrl();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
   }
 
   void _applyInitialTabFromUrl() {
@@ -53,14 +49,11 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     _activatedScreens[initialIndex] = true;
   }
 
-  /// 更新禅室页面可见性状态
   void _updateMeditationRoomVisibility() {
     final isZenRoomVisible = _currentIndex == 2 && _activatedScreens[2];
-    // 使用 GlobalKey 通知禅室页面可见性变化
     _meditationKey.currentState?.setVisible(isZenRoomVisible);
   }
 
-  /// 更新地球页面可见性状态
   void _updateGlobeVisibility() {
     final isGlobeVisible = _currentIndex == 0 || _currentIndex == 1;
     _globeKey.currentState?.setVisible(isGlobeVisible);
@@ -74,11 +67,26 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     });
   }
 
-  // 保持所有页面实例，按需延迟加载
+  void _selectDestination(int index) {
+    setState(() {
+      _currentIndex = index;
+      _mobileSidebarOpen = false;
+      if (!_activatedScreens[index]) {
+        _activatedScreens[index] = true;
+      }
+    });
+    _notifyScreenVisibility();
+
+    if (index == 0) {
+      _globeKey.currentState?.setGlobeMode(false);
+    } else if (index == 1) {
+      _globeKey.currentState?.setGlobeMode(true);
+    }
+  }
+
   List<Widget> get _screens {
     final screens = <Widget>[];
 
-    // 0: 首页 (聊天视图)
     screens.add(
       TickerMode(
         enabled: _currentIndex == 0 || _currentIndex == 1,
@@ -96,11 +104,9 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               ),
       ),
     );
-    
-    // 1: 地球视图 (目前和首页复用 GlobeHomeScreen)
-    screens.add(const SizedBox.shrink()); 
 
-    // 2: 禅室 (佛像3D)
+    screens.add(const SizedBox.shrink());
+
     screens.add(
       TickerMode(
         enabled: _currentIndex == 2,
@@ -110,7 +116,6 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       ),
     );
 
-    // 3: 我的 (个人资料)
     screens.add(
       TickerMode(
         enabled: _currentIndex == 3,
@@ -120,14 +125,11 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       ),
     );
 
-    // 4: 设置
     screens.add(
       TickerMode(
         enabled: _currentIndex == 4,
         child: _activatedScreens[4]
-            ? SettingsScreen(
-                onClose: () => setState(() => _currentIndex = 0),
-              )
+            ? SettingsScreen(onClose: () => setState(() => _currentIndex = 0))
             : const Center(child: CircularProgressIndicator()),
       ),
     );
@@ -140,36 +142,81 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     return SpaceBackground(
       child: Scaffold(
         backgroundColor: Colors.transparent,
-        body: Row(
-          children: [
-            CodexSidebar(
-              selectedIndex: _currentIndex,
-              onDestinationSelected: (index) {
-                setState(() {
-                  _currentIndex = index;
-                  // 标记页面为激活状态
-                  if (!_activatedScreens[index]) {
-                    _activatedScreens[index] = true;
-                  }
-                });
-                _notifyScreenVisibility();
-                
-                if (index == 0) {
-                  _globeKey.currentState?.setGlobeMode(false);
-                } else if (index == 1) {
-                  _globeKey.currentState?.setGlobeMode(true);
-                }
-              },
-            ),
-            Expanded(
-              child: IndexedStack(
-                // 当 currentIndex 为 1 (地球视图) 时，复用 0 的 GlobeHomeScreen
-                index: _currentIndex == 1 ? 0 : _currentIndex, 
-                children: _screens,
-              ),
-            ),
-          ],
+        body: _isMobileRuntime ? _buildMobileShell() : _buildDesktopShell(),
+      ),
+    );
+  }
+
+  Widget _buildDesktopShell() {
+    return Row(
+      children: [
+        CodexSidebar(
+          selectedIndex: _currentIndex,
+          onDestinationSelected: _selectDestination,
         ),
+        Expanded(child: _buildIndexedStack()),
+      ],
+    );
+  }
+
+  Widget _buildMobileShell() {
+    return Stack(
+      children: [
+        Positioned.fill(child: _buildIndexedStack()),
+        Positioned(
+          left: 18,
+          top: 16,
+          child: SafeArea(
+            child: _SidebarOpenButton(
+              onPressed: () => setState(() => _mobileSidebarOpen = true),
+            ),
+          ),
+        ),
+        if (_mobileSidebarOpen)
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => setState(() => _mobileSidebarOpen = false),
+              child: ColoredBox(color: Colors.black.withValues(alpha: 0.42)),
+            ),
+          ),
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOutCubic,
+          left: _mobileSidebarOpen ? 0 : -MediaQuery.sizeOf(context).width,
+          top: 0,
+          bottom: 0,
+          child: DachengChatSidebar(
+            onNewChat: () => _selectDestination(0),
+            onClose: () => setState(() => _mobileSidebarOpen = false),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildIndexedStack() {
+    return IndexedStack(
+      index: _currentIndex == 1 ? 0 : _currentIndex,
+      children: _screens,
+    );
+  }
+}
+
+class _SidebarOpenButton extends StatelessWidget {
+  const _SidebarOpenButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xCC222A30),
+      shape: const CircleBorder(),
+      child: IconButton(
+        tooltip: '打开侧边栏',
+        onPressed: onPressed,
+        icon: const Icon(Icons.menu_rounded, color: Colors.white, size: 28),
       ),
     );
   }

--- a/fabushi/lib/screens/main_navigation_screen_web.dart
+++ b/fabushi/lib/screens/main_navigation_screen_web.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:universal_html/html.dart' as html;
 
 import '../features/auth/application/auth_model.dart';
+import '../widgets/sidebar/dacheng_chat_sidebar.dart';
 import 'globe_home_screen.dart';
 
 class MainNavigationScreen extends StatefulWidget {
@@ -16,6 +17,7 @@ class MainNavigationScreen extends StatefulWidget {
 
 class _MainNavigationScreenState extends State<MainNavigationScreen> {
   bool _profileMenuOpen = false;
+  bool _sidebarOpen = false;
 
   Future<void> _openLogin() async {
     final success = await showDialog<bool>(
@@ -39,6 +41,11 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     setState(() => _profileMenuOpen = false);
   }
 
+  void _closeSidebar() {
+    if (!_sidebarOpen) return;
+    setState(() => _sidebarOpen = false);
+  }
+
   @override
   Widget build(BuildContext context) {
     final authModel = context.watch<AuthModel?>();
@@ -56,14 +63,41 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
             composerLeftInset: compact ? 84 : 88,
           ),
         ),
-        if (_profileMenuOpen)
+        Positioned(
+          left: 18,
+          top: 18,
+          child: SafeArea(
+            child: _SidebarOpenButton(
+              onPressed: () => setState(() => _sidebarOpen = true),
+            ),
+          ),
+        ),
+        if (_profileMenuOpen || _sidebarOpen)
           Positioned.fill(
             child: GestureDetector(
               behavior: HitTestBehavior.translucent,
-              onTap: _closeProfileMenu,
-              child: const SizedBox.expand(),
+              onTap: () {
+                _closeProfileMenu();
+                _closeSidebar();
+              },
+              child: ColoredBox(
+                color: _sidebarOpen
+                    ? Colors.black.withValues(alpha: 0.42)
+                    : Colors.transparent,
+              ),
             ),
           ),
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOutCubic,
+          left: _sidebarOpen ? 0 : -420,
+          top: 0,
+          bottom: 0,
+          child: DachengChatSidebar(
+            onNewChat: _closeSidebar,
+            onClose: _closeSidebar,
+          ),
+        ),
         if (_profileMenuOpen)
           Positioned(
             left: 18,
@@ -102,9 +136,6 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   }
 }
 
-/// Web /login route wrapper.
-///
-/// It reuses the existing Web login dialog instead of loading the App login page.
 class WebLoginRouteScreen extends StatefulWidget {
   const WebLoginRouteScreen({super.key});
 
@@ -147,6 +178,25 @@ class _WebLoginRouteScreenState extends State<WebLoginRouteScreen> {
   @override
   Widget build(BuildContext context) {
     return const MainNavigationScreen();
+  }
+}
+
+class _SidebarOpenButton extends StatelessWidget {
+  const _SidebarOpenButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xCC222A30),
+      shape: const CircleBorder(),
+      child: IconButton(
+        tooltip: '打开侧边栏',
+        onPressed: onPressed,
+        icon: const Icon(Icons.menu_rounded, color: Colors.white, size: 28),
+      ),
+    );
   }
 }
 

--- a/fabushi/lib/widgets/sidebar/dacheng_chat_sidebar.dart
+++ b/fabushi/lib/widgets/sidebar/dacheng_chat_sidebar.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+class DachengChatSidebar extends StatelessWidget {
+  const DachengChatSidebar({
+    super.key,
+    required this.onNewChat,
+    this.onClose,
+    this.width,
+  });
+
+  final VoidCallback onNewChat;
+  final VoidCallback? onClose;
+  final double? width;
+
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.sizeOf(context);
+    final panelWidth = width ?? (media.width < 560 ? media.width * 0.9 : 360.0);
+
+    return Material(
+      color: Colors.transparent,
+      child: SafeArea(
+        right: false,
+        child: Container(
+          width: panelWidth.clamp(300.0, 420.0),
+          height: double.infinity,
+          decoration: const BoxDecoration(
+            color: Color(0xFF1F2025),
+            borderRadius: BorderRadius.only(
+              topRight: Radius.circular(28),
+              bottomRight: Radius.circular(28),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 34, 24, 30),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        '大乘',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 34,
+                          fontWeight: FontWeight.w900,
+                          height: 1,
+                        ),
+                      ),
+                    ),
+                    if (onClose != null)
+                      IconButton(
+                        tooltip: '关闭',
+                        onPressed: onClose,
+                        icon: const Icon(
+                          Icons.close_rounded,
+                          color: Color(0xFFC7C7CB),
+                          size: 34,
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 62),
+                _NewChatButton(onPressed: onNewChat),
+                const SizedBox(height: 50),
+                const Text(
+                  '今天',
+                  style: TextStyle(
+                    color: Color(0xFF777981),
+                    fontSize: 26,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const Spacer(),
+                const Center(
+                  child: Text(
+                    '没有更多内容啦',
+                    style: TextStyle(
+                      color: Color(0xFFBBBCC2),
+                      fontSize: 24,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                const Spacer(flex: 2),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NewChatButton extends StatelessWidget {
+  const _NewChatButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 72,
+      child: FilledButton.icon(
+        onPressed: onPressed,
+        icon: const Icon(Icons.add_comment_outlined, size: 28),
+        label: const Text(
+          '开启新对话',
+          style: TextStyle(fontSize: 22, fontWeight: FontWeight.w800),
+        ),
+        style: FilledButton.styleFrom(
+          backgroundColor: const Color(0xFF30353A),
+          foregroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(24),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/apps/mp-wechat/src/app.config.ts
+++ b/frontend/apps/mp-wechat/src/app.config.ts
@@ -1,29 +1,11 @@
 export default defineAppConfig({
-  pages: [
-    "pages/index/index",
-    "pages/sutra/index",
-    "pages/practice/index",
-    "pages/ai/index",
-    "pages/me/index",
-  ],
+  pages: ["pages/index/index"],
   window: {
     backgroundTextStyle: "light",
-    navigationBarBackgroundColor: "#101419",
-    navigationBarTitleText: "法布施",
+    navigationStyle: "custom",
+    navigationBarBackgroundColor: "#15161a",
+    navigationBarTitleText: "大乘",
     navigationBarTextStyle: "white",
-    backgroundColor: "#080b10",
-  },
-  tabBar: {
-    color: "#8f9a9a",
-    selectedColor: "#e8bd6b",
-    backgroundColor: "#101419",
-    borderStyle: "black",
-    list: [
-      { pagePath: "pages/index/index", text: "首页" },
-      { pagePath: "pages/sutra/index", text: "经文" },
-      { pagePath: "pages/practice/index", text: "修行" },
-      { pagePath: "pages/ai/index", text: "AI" },
-      { pagePath: "pages/me/index", text: "我的" },
-    ],
+    backgroundColor: "#15161a",
   },
 });

--- a/frontend/apps/mp-wechat/src/pages/index/index.scss
+++ b/frontend/apps/mp-wechat/src/pages/index/index.scss
@@ -1,299 +1,274 @@
-.page {
+.chat-page {
+  position: relative;
   min-height: 100vh;
-  padding: 32px 24px 56px;
+  overflow: hidden;
+  padding: 72px 28px 132px;
   background:
-    radial-gradient(circle at 22% 8%, rgba(123, 31, 162, 0.24), transparent 28%),
-    radial-gradient(circle at 84% 2%, rgba(255, 215, 0, 0.16), transparent 24%),
-    linear-gradient(180deg, #0b0e14 0%, #111827 58%, #080b10 100%);
+    radial-gradient(circle at 48% 0%, rgba(34, 75, 86, 0.62), transparent 32%),
+    linear-gradient(180deg, #28313a 0%, #1a2025 48%, #111417 100%);
 }
 
-.hero {
-  padding: 24px 0 20px;
+.topbar {
+  position: fixed;
+  z-index: 8;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 92px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 28px;
 }
 
-.eyebrow {
+.brand {
+  color: #ffffff;
+  font-size: 34px;
+  font-weight: 800;
+}
+
+.menu-button,
+.user-pill {
+  position: absolute;
+  top: 16px;
+  height: 60px;
+}
+
+.menu-button {
+  left: 24px;
+  width: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(19, 28, 34, 0.78);
+  color: #ffffff;
+  font-size: 32px;
+}
+
+.user-pill {
+  right: 24px;
+  min-width: 150px;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #17191f;
+  font-size: 26px;
+  font-weight: 800;
+}
+
+.chat-main {
+  min-height: calc(100vh - 204px);
+}
+
+.intro {
+  margin-top: 120px;
+}
+
+.greeting {
   display: block;
-  color: #ffd700;
-  font-size: 24px;
-  margin-bottom: 18px;
-  font-weight: 700;
-}
-
-.title {
-  display: block;
-  color: #e8eaf6;
-  font-size: 60px;
-  font-weight: 700;
-  line-height: 1.24;
+  color: #ffffff;
+  font-size: 58px;
+  font-weight: 900;
+  line-height: 1.18;
 }
 
 .subtitle {
   display: block;
-  margin-top: 20px;
-  color: rgba(232, 234, 246, 0.76);
+  margin-top: 22px;
+  color: rgba(255, 255, 255, 0.72);
   font-size: 30px;
-  line-height: 1.65;
+  font-weight: 700;
 }
 
-.globe {
-  position: relative;
-  height: 432px;
-  margin: 18px 0 28px;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 8px;
-  background:
-    radial-gradient(circle at 50% 48%, rgba(27, 38, 59, 0.98) 0%, rgba(11, 14, 20, 0.92) 48%, rgba(11, 14, 20, 0.58) 70%),
-    linear-gradient(135deg, rgba(123, 31, 162, 0.34), rgba(27, 38, 59, 0.22));
+.suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 44px;
 }
 
-.globe::before,
-.globe::after {
-  position: absolute;
-  content: "";
-  inset: 72px 118px;
-  border-radius: 50%;
-  border: 1px solid rgba(232, 234, 246, 0.12);
-}
-
-.globe::after {
-  inset: 112px 158px;
-  border-color: rgba(255, 215, 0, 0.16);
-}
-
-.orbit {
-  position: absolute;
-  left: 88px;
-  right: 88px;
-  top: 202px;
-  height: 1px;
-  background: rgba(232, 234, 246, 0.18);
-}
-
-.orbit-a {
-  transform: rotate(18deg);
-}
-
-.orbit-b {
-  transform: rotate(-24deg);
-}
-
-.beam {
-  position: absolute;
-  height: 2px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, transparent, #ffd700, transparent);
-  box-shadow: 0 0 18px rgba(255, 215, 0, 0.46);
-}
-
-.beam-a {
-  left: 154px;
-  top: 166px;
-  width: 294px;
-  transform: rotate(18deg);
-}
-
-.beam-b {
-  left: 214px;
-  top: 268px;
-  width: 238px;
-  transform: rotate(-28deg);
-}
-
-.node {
-  position: absolute;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #ffd700;
-  box-shadow: 0 0 24px rgba(255, 215, 0, 0.72);
-}
-
-.node-cn {
-  left: 426px;
-  top: 178px;
-}
-
-.node-us {
-  left: 148px;
-  top: 214px;
-}
-
-.node-sg {
-  left: 404px;
-  top: 262px;
-}
-
-.node-eu {
-  left: 314px;
-  top: 142px;
-}
-
-.globe-core {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 174px;
-  height: 174px;
-  margin-left: -87px;
-  margin-top: -87px;
+.suggestion {
+  height: 72px;
+  padding: 0 24px;
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.globe-value {
-  color: #ffd700;
-  font-size: 54px;
+  gap: 12px;
+  border-radius: 999px;
+  background: rgba(31, 32, 37, 0.88);
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 27px;
   font-weight: 800;
 }
 
-.globe-label {
-  margin-top: 8px;
-  color: rgba(232, 234, 246, 0.72);
-  font-size: 22px;
+.suggestion-icon {
+  color: #7cc8ff;
+  font-size: 30px;
 }
 
-.stats {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
-  margin-top: 24px;
+.messages {
+  margin-top: 50px;
+  padding-bottom: 24px;
 }
 
-.stat,
-.prompt,
-.feed,
-.composer,
-.action-card,
-.parity {
-  border: 1px solid rgba(255, 255, 255, 0.15);
+.message {
+  max-width: 86%;
+  margin-top: 18px;
+  padding: 20px 24px;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.1);
+  font-size: 28px;
+  line-height: 1.6;
 }
 
-.stat {
-  min-height: 112px;
-  padding: 20px;
+.message.assistant {
+  color: rgba(255, 255, 255, 0.86);
+  background: rgba(255, 255, 255, 0.08);
 }
 
-.stat-value {
-  display: block;
-  color: #ffd700;
+.message.user {
+  margin-left: auto;
+  color: #111417;
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.composer {
+  position: fixed;
+  z-index: 8;
+  left: 24px;
+  right: 24px;
+  bottom: 26px;
+  min-height: 88px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 44px;
+  background: rgba(41, 42, 46, 0.92);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
+}
+
+.add-button,
+.send-button {
+  width: 68px;
+  height: 68px;
+  min-width: 68px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #393b40;
+  color: #ffffff;
+  font-size: 42px;
+  font-weight: 500;
+}
+
+.send-button {
+  background: #45474d;
+  font-size: 34px;
+  font-weight: 800;
+}
+
+.chat-input {
+  flex: 1;
+  height: 64px;
+  padding: 0 18px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 32px;
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.07);
+  font-size: 27px;
+}
+
+.scrim {
+  position: fixed;
+  z-index: 20;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.42);
+}
+
+.sidebar {
+  position: fixed;
+  z-index: 21;
+  left: -92vw;
+  top: 0;
+  bottom: 0;
+  width: 86vw;
+  padding: 82px 42px 42px;
+  border-top-right-radius: 30px;
+  border-bottom-right-radius: 30px;
+  background: #1f2025;
+  transition: left 220ms ease;
+}
+
+.sidebar.open {
+  left: 0;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sidebar-title {
+  color: #ffffff;
+  font-size: 58px;
+  font-weight: 900;
+}
+
+.close-button {
+  width: 70px;
+  height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #c6c7cc;
+  background: transparent;
+  font-size: 58px;
+}
+
+.new-chat {
+  height: 116px;
+  margin-top: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 22px;
+  border-radius: 34px;
+  background: #30353a;
+  color: #ffffff;
   font-size: 36px;
   font-weight: 800;
 }
 
-.stat-label {
+.new-chat-icon {
+  font-size: 44px;
+}
+
+.today {
   display: block;
-  margin-top: 10px;
-  color: rgba(232, 234, 246, 0.66);
-  font-size: 22px;
+  margin-top: 70px;
+  color: #777981;
+  font-size: 40px;
+  font-weight: 900;
 }
 
-.composer {
-  padding: 22px;
-}
-
-.section {
-  margin-top: 32px;
-}
-
-.section-title {
-  display: block;
-  margin-bottom: 16px;
-  color: #e8eaf6;
-  font-size: 30px;
-  font-weight: 600;
-}
-
-.input {
-  width: 100%;
-  height: 82px;
-  padding: 0 18px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 8px;
-  color: #e8eaf6;
-  background: rgba(11, 14, 20, 0.52);
-  font-size: 28px;
-}
-
-.actions {
+.empty {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 58%;
   display: flex;
-  gap: 14px;
-  margin-top: 16px;
-}
-
-.primary,
-.secondary {
-  flex: 1;
-  height: 78px;
-  display: flex;
-  align-items: center;
   justify-content: center;
-  font-size: 28px;
-  font-weight: 700;
-}
-
-.primary {
-  color: #11151d;
-  background: #ffd700;
-}
-
-.secondary {
-  color: #e8eaf6;
-  background: rgba(232, 234, 246, 0.12);
-}
-
-.action-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 14px;
-}
-
-.action-card {
-  min-height: 188px;
-  padding: 18px;
-}
-
-.action-index {
-  display: block;
-  margin-bottom: 16px;
-  color: rgba(255, 215, 0, 0.82);
-  font-size: 22px;
-  font-weight: 800;
-}
-
-.prompt + .prompt,
-.feed + .feed,
-.parity + .parity {
-  margin-top: 14px;
-}
-
-.card-title {
-  display: block;
-  font-size: 30px;
-  font-weight: 600;
-  color: #e8eaf6;
-}
-
-.card-copy {
-  display: block;
-  margin-top: 10px;
-  font-size: 24px;
-  line-height: 1.55;
-  color: rgba(232, 234, 246, 0.68);
-}
-
-.prompt,
-.feed,
-.parity {
-  padding: 20px;
-  color: #e8eaf6;
-  font-size: 28px;
-  line-height: 1.6;
+  color: #bbbcc2;
+  font-size: 38px;
+  font-weight: 900;
 }

--- a/frontend/apps/mp-wechat/src/pages/index/index.tsx
+++ b/frontend/apps/mp-wechat/src/pages/index/index.tsx
@@ -1,123 +1,178 @@
 import { useState } from "react";
 import { Button, Input, Text, View } from "@tarojs/components";
 import Taro from "@tarojs/taro";
+import { aiQuickPrompts } from "@fabushi/shared";
 import {
-  aiQuickPrompts,
-  appExperienceStats,
-  brand,
-  dharmaFeedItems,
-  globalDharmaActions,
-  miniProgramFlutterParity,
-} from "@fabushi/shared";
+  dachengAiEndpoints,
+  getDachengAiApiBaseUrl,
+  type DachengAiChatResponse,
+} from "@fabushi/api-client";
 import "./index.scss";
 
-export default function IndexPage() {
-  const [draft, setDraft] = useState<string>(aiQuickPrompts[0]);
+const AI_BASE = getDachengAiApiBaseUrl();
 
-  function switchTo(url: string) {
-    Taro.switchTab({ url });
+type ChatMessage = {
+  id: string;
+  role: "assistant" | "user";
+  text: string;
+};
+
+const suggestions = [
+  { icon: "✦", label: "大乘能做什么", prompt: aiQuickPrompts[0] },
+  { icon: "◉", label: "开始全球法布施", prompt: "帮我写一段适合公开分享的佛法发愿文。" },
+  { icon: "⌕", label: "AI找资源", prompt: "请帮我找适合初学者阅读的佛经资源。" },
+  { icon: "▣", label: "加入功课本", prompt: "帮我整理一份今天可以完成的简短功课。" },
+  { icon: "♡", label: "发愿文案", prompt: "请帮我润色一段慈悲、简洁的发愿文案。" },
+];
+
+export default function IndexPage() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: "welcome",
+      role: "assistant",
+      text: "你好，我是大乘。你可以问经文、找资源，或让我帮你整理可分享的善法内容。",
+    },
+  ]);
+
+  function startPrompt(prompt: string) {
+    setDraft(prompt);
   }
 
-  function copyDraft() {
-    Taro.setClipboardData({
-      data: draft,
-      success: () => Taro.showToast({ title: "已复制", icon: "success" }),
-    });
+  function startNewChat() {
+    setMessages([]);
+    setDraft("");
+    setSidebarOpen(false);
+  }
+
+  async function sendMessage() {
+    const text = draft.trim();
+    if (!text || loading) return;
+
+    const userMessage: ChatMessage = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      text,
+    };
+    setMessages((current) => [...current, userMessage]);
+    setDraft("");
+    setLoading(true);
+
+    try {
+      const response = await Taro.request<DachengAiChatResponse>({
+        url: `${AI_BASE}${dachengAiEndpoints.chat}`,
+        method: "POST",
+        header: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        data: {
+          message: text,
+          clientMembershipHint: false,
+        },
+        timeout: 60000,
+      });
+
+      if (response.statusCode < 200 || response.statusCode >= 300 || response.data.success === false) {
+        throw new Error(response.data.message || `请求失败 ${response.statusCode}`);
+      }
+
+      setMessages((current) => [
+        ...current,
+        {
+          id: `assistant-${Date.now()}`,
+          role: "assistant",
+          text: response.data.message || "AI 暂未返回内容。",
+        },
+      ]);
+    } catch (error) {
+      setMessages((current) => [
+        ...current,
+        {
+          id: `error-${Date.now()}`,
+          role: "assistant",
+          text: error instanceof Error ? error.message : "大乘 AI 暂不可用，请稍后再试。",
+        },
+      ]);
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
-    <View className="page">
-      <View className="hero">
-        <Text className="eyebrow">{brand.englishName}</Text>
-        <Text className="title">全球法布施</Text>
-        <Text className="subtitle">
-          复用 Flutter App 的首页信息架构与视觉 token，用微信原生组件承接发送、问经和共修入口。
-        </Text>
-      </View>
-
-      <View className="globe">
-        <View className="orbit orbit-a" />
-        <View className="orbit orbit-b" />
-        <View className="beam beam-a" />
-        <View className="beam beam-b" />
-        <View className="node node-cn" />
-        <View className="node node-us" />
-        <View className="node node-sg" />
-        <View className="node node-eu" />
-        <View className="globe-core">
-          <Text className="globe-value">64</Text>
-          <Text className="globe-label">在线国家</Text>
+    <View className="chat-page">
+      <View className="topbar">
+        <Button className="menu-button" onClick={() => setSidebarOpen(true)}>
+          ☰
+        </Button>
+        <Text className="brand">大乘</Text>
+        <View className="user-pill">
+          <Text>bhrum108</Text>
         </View>
       </View>
 
-      <View className="stats">
-        {appExperienceStats.map((item) => (
-          <View className="stat" key={item.label}>
-            <Text className="stat-value">{item.value}</Text>
-            <Text className="stat-label">
-              {item.label} · {item.unit}
-            </Text>
-          </View>
-        ))}
+      <View className="chat-main">
+        <View className="intro">
+          <Text className="greeting">Hi, bhrum108</Text>
+          <Text className="subtitle">把可分享的善法资源，带到全球</Text>
+        </View>
+
+        <View className="suggestions">
+          {suggestions.map((item) => (
+            <Button className="suggestion" key={item.label} onClick={() => startPrompt(item.prompt)}>
+              <Text className="suggestion-icon">{item.icon}</Text>
+              <Text>{item.label}</Text>
+            </Button>
+          ))}
+        </View>
+
+        <View className="messages">
+          {messages.map((message) => (
+            <View className={`message ${message.role}`} key={message.id}>
+              <Text>{message.text}</Text>
+            </View>
+          ))}
+          {loading && (
+            <View className="message assistant">
+              <Text>正在生成...</Text>
+            </View>
+          )}
+        </View>
       </View>
 
       <View className="composer">
-        <Text className="section-title">法布施输入</Text>
+        <Button className="add-button">＋</Button>
         <Input
-          className="input"
+          className="chat-input"
           value={draft}
-          maxlength={120}
+          placeholder="问问大乘"
+          confirmType="send"
           onInput={(event) => setDraft(event.detail.value)}
+          onConfirm={sendMessage}
         />
-        <View className="actions">
-          <Button className="primary" onClick={() => switchTo("/pages/ai/index")}>
-            AI 润色
-          </Button>
-          <Button className="secondary" onClick={copyDraft}>
-            复制发愿
+        <Button className="send-button" loading={loading} onClick={sendMessage}>
+          ↑
+        </Button>
+      </View>
+
+      {sidebarOpen && <View className="scrim" onClick={() => setSidebarOpen(false)} />}
+      <View className={`sidebar ${sidebarOpen ? "open" : ""}`}>
+        <View className="sidebar-header">
+          <Text className="sidebar-title">大乘</Text>
+          <Button className="close-button" onClick={() => setSidebarOpen(false)}>
+            ×
           </Button>
         </View>
-      </View>
-
-      <View className="section action-grid">
-        {globalDharmaActions.map((item, index) => (
-          <View className="action-card" key={item.label}>
-            <Text className="action-index">0{index + 1}</Text>
-            <Text className="card-title">{item.label}</Text>
-            <Text className="card-copy">{item.detail}</Text>
-          </View>
-        ))}
-      </View>
-
-      <View className="section">
-        <Text className="section-title">AI 快捷任务</Text>
-        {aiQuickPrompts.slice(0, 3).map((prompt) => (
-          <View className="prompt" key={prompt}>
-            <Text>{prompt}</Text>
-          </View>
-        ))}
-      </View>
-
-      <View className="section">
-        <Text className="section-title">Flutter 复用映射</Text>
-        {miniProgramFlutterParity.slice(0, 3).map((item) => (
-          <View className="parity" key={item.flutter}>
-            <Text className="card-title">{item.title}</Text>
-            <Text className="card-copy">{item.reused}</Text>
-          </View>
-        ))}
-      </View>
-
-      <View className="section">
-        <Text className="section-title">今日法流</Text>
-        {dharmaFeedItems.map((item) => (
-          <View className="feed" key={item.title}>
-            <Text className="card-title">{item.title}</Text>
-            <Text className="card-copy">
-              {item.tag} · {item.readTime}
-            </Text>
-          </View>
-        ))}
+        <Button className="new-chat" onClick={startNewChat}>
+          <Text className="new-chat-icon">⊞</Text>
+          <Text>开启新对话</Text>
+        </Button>
+        <Text className="today">今天</Text>
+        <View className="empty">
+          <Text>没有更多内容啦</Text>
+        </View>
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary

- add a reusable Flutter `DachengChatSidebar` matching the provided dark drawer reference
- use the new sidebar on Flutter web and mobile while keeping native desktop on the existing `CodexSidebar`
- simplify the Taro WeChat miniapp to a single sidebar + chat page and remove the tabBar/navigation content from the active app config

## Verification

- Confirmed the branch diff touches only the intended Flutter and Taro UI files.
- Could not run Flutter/Taro builds in this container because the repository could not be cloned through the network gateway and `dart` is not installed locally.