### PR TITLE
Fix CBETA proxy upstream for scripture loading

### DIFF
--- a/fabushi/web/src/handlers/cbeta.js
+++ b/fabushi/web/src/handlers/cbeta.js
@@ -2,7 +2,8 @@ import { CORS_HEADERS } from '../config/constants.js';
 import { jsonResponse } from '../utils/response.js';
 
 const CBETA_PUBLIC_API_ROOT = 'https://api.ombhrum.com/api/cbeta';
-const CBETA_DEFAULT_UPSTREAM_API_ROOT = 'https://cbdata.dila.edu.tw/stable';
+const CBETA_SELF_HOSTED_API_ROOT = 'https://ai.ombhrum.com/cbeta';
+const CBETA_OFFICIAL_FALLBACK_API_ROOT = 'https://cbdata.dila.edu.tw/stable';
 const DEFAULT_SEND_WORKS = [
   'T0365',
   'T0251',
@@ -35,8 +36,9 @@ function isPublicProxyRoot(apiRoot) {
 function cbetaApiRoots(env = {}) {
   const roots = [
     env?.CBETA_API_ROOT,
+    CBETA_SELF_HOSTED_API_ROOT,
     env?.CBETA_FALLBACK_API_ROOT,
-    CBETA_DEFAULT_UPSTREAM_API_ROOT,
+    CBETA_OFFICIAL_FALLBACK_API_ROOT,
   ]
     .map(normalizeApiRoot)
     .filter(Boolean)
@@ -45,7 +47,7 @@ function cbetaApiRoots(env = {}) {
   return Array.from(new Set(roots));
 }
 
-function buildCbetaUrl(path, params = {}, apiRoot = CBETA_DEFAULT_UPSTREAM_API_ROOT) {
+function buildCbetaUrl(path, params = {}, apiRoot = CBETA_SELF_HOSTED_API_ROOT) {
   const url = new URL(path.replace(/^\/+/, ''), `${apiRoot}/`);
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value !== null && `${value}` !== '') {

--- a/fabushi/web/src/handlers/cbeta.js
+++ b/fabushi/web/src/handlers/cbeta.js
@@ -2,8 +2,7 @@ import { CORS_HEADERS } from '../config/constants.js';
 import { jsonResponse } from '../utils/response.js';
 
 const CBETA_PUBLIC_API_ROOT = 'https://api.ombhrum.com/api/cbeta';
-const CBETA_SELF_HOSTED_API_ROOT = CBETA_PUBLIC_API_ROOT;
-const CBETA_API_ROOTS = [CBETA_SELF_HOSTED_API_ROOT];
+const CBETA_DEFAULT_UPSTREAM_API_ROOT = 'https://cbdata.dila.edu.tw/stable';
 const DEFAULT_SEND_WORKS = [
   'T0365',
   'T0251',
@@ -25,7 +24,28 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function buildCbetaUrl(path, params = {}, apiRoot = CBETA_SELF_HOSTED_API_ROOT) {
+function normalizeApiRoot(value) {
+  return String(value || '').trim().replace(/\/+$/, '');
+}
+
+function isPublicProxyRoot(apiRoot) {
+  return normalizeApiRoot(apiRoot) === normalizeApiRoot(CBETA_PUBLIC_API_ROOT);
+}
+
+function cbetaApiRoots(env = {}) {
+  const roots = [
+    env?.CBETA_API_ROOT,
+    env?.CBETA_FALLBACK_API_ROOT,
+    CBETA_DEFAULT_UPSTREAM_API_ROOT,
+  ]
+    .map(normalizeApiRoot)
+    .filter(Boolean)
+    .filter(apiRoot => !isPublicProxyRoot(apiRoot));
+
+  return Array.from(new Set(roots));
+}
+
+function buildCbetaUrl(path, params = {}, apiRoot = CBETA_DEFAULT_UPSTREAM_API_ROOT) {
   const url = new URL(path.replace(/^\/+/, ''), `${apiRoot}/`);
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value !== null && `${value}` !== '') {
@@ -68,7 +88,7 @@ function describeUnusablePayload(path, data) {
 async function fetchJsonWithRetry(path, params = {}, options = {}) {
   const retries = options.retries ?? DEFAULT_RETRY_COUNT;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const apiRoots = options.apiRoots ?? CBETA_API_ROOTS;
+  const apiRoots = options.apiRoots ?? cbetaApiRoots(options.env);
   const attempts = [];
 
   for (const apiRoot of apiRoots) {
@@ -271,12 +291,13 @@ function normalizeError(work, juan, error) {
   };
 }
 
-export async function handleGetCbetaSendTexts(request) {
+export async function handleGetCbetaSendTexts(request, env = {}) {
   const url = new URL(request.url);
   const works = parseWorksParam(url.searchParams.get('works'));
   const limit = parseLimit(url.searchParams.get('limit'), DEFAULT_SEND_WORKS.length);
   const juan = parseLimit(url.searchParams.get('juan'), 1);
   const selectedWorks = works.slice(0, limit);
+  const apiRoots = cbetaApiRoots(env);
   const items = [];
   const errors = [];
 
@@ -287,7 +308,7 @@ export async function handleGetCbetaSendTexts(request) {
         juan,
         work_info: 1,
         toc: 1,
-      });
+      }, { apiRoots });
       items.push(toCbetaItem(work, juan, data, attempts, apiRoot));
     } catch (error) {
       errors.push(normalizeError(work, juan, error));
@@ -298,8 +319,8 @@ export async function handleGetCbetaSendTexts(request) {
     success: items.length > 0,
     source: 'CBETA',
     api: CBETA_PUBLIC_API_ROOT,
-    primaryApi: CBETA_SELF_HOSTED_API_ROOT,
-    fallbackApi: null,
+    primaryApi: apiRoots[0] ?? null,
+    fallbackApi: apiRoots[1] ?? null,
     requested: selectedWorks.length,
     count: items.length,
     items,
@@ -320,14 +341,14 @@ function canUseProxyResponse(path, method, bodyText, contentType) {
   }
 }
 
-export async function handleProxyCbetaRequest(request) {
+export async function handleProxyCbetaRequest(request, env = {}) {
   const sourceUrl = new URL(request.url);
   const cbetaPath = sourceUrl.pathname.replace(/^\/api\/cbeta\/?/, '');
   const params = Object.fromEntries(sourceUrl.searchParams);
   const attempts = [];
   let lastOkResponse = null;
 
-  for (const apiRoot of CBETA_API_ROOTS) {
+  for (const apiRoot of cbetaApiRoots(env)) {
     const targetUrl = buildCbetaUrl(cbetaPath || '/', params, apiRoot);
     const startedAt = Date.now();
 

--- a/fabushi/web/tests/cbeta-send-texts.test.js
+++ b/fabushi/web/tests/cbeta-send-texts.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { handleGetCbetaSendTexts } from '../src/handlers/cbeta.js';
 
-const SELF_HOSTED_API = 'https://api.ombhrum.com/api/cbeta';
+const UPSTREAM_API = 'https://cbdata.dila.edu.tw/stable';
 
 const sampleHtml = `
   <html><head><title>Heart Sutra</title></head><body>
@@ -59,7 +59,7 @@ test('CBETA send texts returns real stripped scripture content and detailed part
     const body = await response.json();
     assert.equal(body.success, true);
     assert.equal(body.count, 1);
-    assert.equal(body.primaryApi, SELF_HOSTED_API);
+    assert.equal(body.primaryApi, UPSTREAM_API);
     assert.equal(body.fallbackApi, null);
     assert.equal(body.errors.length, 1);
     assert.equal(body.errors[0].attempts.length, 3);
@@ -67,7 +67,7 @@ test('CBETA send texts returns real stripped scripture content and detailed part
 
     const item = body.items[0];
     assert.equal(item.work, 'T0251');
-    assert.equal(item.sourceApi, SELF_HOSTED_API);
+    assert.equal(item.sourceApi, UPSTREAM_API);
     assert.match(item.fileName, /^T0251_1_/);
     assert.match(item.content, /Avalokitesvara deeply practiced prajna/);
     assert.doesNotMatch(item.content, /T08n0251/);
@@ -105,7 +105,7 @@ test('CBETA send texts reports full upstream errors when no scripture can be fet
   }
 });
 
-test('CBETA send texts never falls back to official API when self-hosted returns empty content', async () => {
+test('CBETA send texts uses the real upstream instead of proxying back into itself', async () => {
   const attemptedHosts = [];
   const restoreFetch = installFetchMock(async url => {
     const parsed = new URL(url);
@@ -116,6 +116,7 @@ test('CBETA send texts never falls back to official API when self-hosted returns
   try {
     const response = await handleGetCbetaSendTexts(
       new Request('https://api.ombhrum.com/api/cbeta/send-texts?works=T0251&limit=1'),
+      { CBETA_API_ROOT: 'https://api.ombhrum.com/api/cbeta' },
     );
     assert.equal(response.status, 502);
 
@@ -124,9 +125,9 @@ test('CBETA send texts never falls back to official API when self-hosted returns
     assert.equal(body.fallbackApi, null);
     assert.equal(body.errors.length, 1);
     assert.deepEqual(attemptedHosts, [
-      'api.ombhrum.com',
-      'api.ombhrum.com',
-      'api.ombhrum.com',
+      'cbdata.dila.edu.tw',
+      'cbdata.dila.edu.tw',
+      'cbdata.dila.edu.tw',
     ]);
   } finally {
     restoreFetch();

--- a/fabushi/web/tests/cbeta-send-texts.test.js
+++ b/fabushi/web/tests/cbeta-send-texts.test.js
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 
 import { handleGetCbetaSendTexts } from '../src/handlers/cbeta.js';
 
-const UPSTREAM_API = 'https://cbdata.dila.edu.tw/stable';
+const SELF_HOSTED_API = 'https://ai.ombhrum.com/cbeta';
+const OFFICIAL_FALLBACK_API = 'https://cbdata.dila.edu.tw/stable';
 
 const sampleHtml = `
   <html><head><title>Heart Sutra</title></head><body>
@@ -59,15 +60,15 @@ test('CBETA send texts returns real stripped scripture content and detailed part
     const body = await response.json();
     assert.equal(body.success, true);
     assert.equal(body.count, 1);
-    assert.equal(body.primaryApi, UPSTREAM_API);
-    assert.equal(body.fallbackApi, null);
+    assert.equal(body.primaryApi, SELF_HOSTED_API);
+    assert.equal(body.fallbackApi, OFFICIAL_FALLBACK_API);
     assert.equal(body.errors.length, 1);
-    assert.equal(body.errors[0].attempts.length, 3);
-    assert.equal(failAttempts, 3);
+    assert.equal(body.errors[0].attempts.length, 6);
+    assert.equal(failAttempts, 6);
 
     const item = body.items[0];
     assert.equal(item.work, 'T0251');
-    assert.equal(item.sourceApi, UPSTREAM_API);
+    assert.equal(item.sourceApi, SELF_HOSTED_API);
     assert.match(item.fileName, /^T0251_1_/);
     assert.match(item.content, /Avalokitesvara deeply practiced prajna/);
     assert.doesNotMatch(item.content, /T08n0251/);
@@ -94,10 +95,10 @@ test('CBETA send texts reports full upstream errors when no scripture can be fet
     const body = await response.json();
     assert.equal(body.success, false);
     assert.equal(body.count, 0);
-    assert.equal(body.fallbackApi, null);
+    assert.equal(body.fallbackApi, OFFICIAL_FALLBACK_API);
     assert.equal(body.errors.length, 1);
-    assert.match(body.errors[0].message, /failed after 3 attempts/);
-    assert.equal(body.errors[0].attempts.length, 3);
+    assert.match(body.errors[0].message, /failed after 6 attempts/);
+    assert.equal(body.errors[0].attempts.length, 6);
     assert.equal(body.errors[0].attempts[0].status, 502);
     assert.match(body.errors[0].attempts[0].body, /bad gateway/);
   } finally {
@@ -105,7 +106,7 @@ test('CBETA send texts reports full upstream errors when no scripture can be fet
   }
 });
 
-test('CBETA send texts uses the real upstream instead of proxying back into itself', async () => {
+test('CBETA send texts skips the public proxy URL and starts with the self-hosted API', async () => {
   const attemptedHosts = [];
   const restoreFetch = installFetchMock(async url => {
     const parsed = new URL(url);
@@ -122,13 +123,12 @@ test('CBETA send texts uses the real upstream instead of proxying back into itse
 
     const body = await response.json();
     assert.equal(body.count, 0);
-    assert.equal(body.fallbackApi, null);
+    assert.equal(body.fallbackApi, OFFICIAL_FALLBACK_API);
     assert.equal(body.errors.length, 1);
-    assert.deepEqual(attemptedHosts, [
-      'cbdata.dila.edu.tw',
-      'cbdata.dila.edu.tw',
-      'cbdata.dila.edu.tw',
-    ]);
+    assert.equal(attemptedHosts[0], 'ai.ombhrum.com');
+    assert.equal(attemptedHosts.filter(host => host === 'ai.ombhrum.com').length, 3);
+    assert.equal(attemptedHosts.filter(host => host === 'cbdata.dila.edu.tw').length, 3);
+    assert.equal(attemptedHosts.includes('api.ombhrum.com'), false);
   } finally {
     restoreFetch();
   }


### PR DESCRIPTION
## Summary
- Point the CBETA Worker proxy at the self-hosted API on bhrum2 first: `https://ai.ombhrum.com/cbeta`
- Keep the official CBETA API (`https://cbdata.dila.edu.tw/stable`) only as a fallback when the self-hosted API is unavailable or returns unusable juan content
- Prevent the public Worker URL (`https://api.ombhrum.com/api/cbeta`) from being used as its own upstream, which caused proxy recursion and empty scripture loads
- Add retry/fallback tests for scripture send-text loading and public-proxy filtering

## bhrum2 runtime check
- The local self-hosted CBETA service is running on `127.0.0.1:3000`
- Added and verified a bhrum2 proxy route through `https://ai.ombhrum.com/cbeta`
- Verified `works?work=T0251` and `juans?work=T0251&juan=1&work_info=1&toc=1` return real scripture JSON from the self-hosted service

## Related
- Complements #1232, which restores scroll auto-loading while stopping the infinite loading flicker