### PR TITLE
fix: enable macOS App Store sandbox entitlement

### DIFF
--- a/fabushi/macos/Runner/Release.entitlements
+++ b/fabushi/macos/Runner/Release.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.network.client</key>


### PR DESCRIPTION
## Summary
- Enable `com.apple.security.app-sandbox` in the macOS Release entitlements so App Store Connect accepts the exported package for ITMS-90296.

## Verification
- `plutil -lint fabushi/macos/Runner/Release.entitlements`
- `/usr/libexec/PlistBuddy -c 'Print :com.apple.security.app-sandbox' fabushi/macos/Runner/Release.entitlements`\n- `rg -n "CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements" fabushi/macos/Runner.xcodeproj/project.pbxproj`\n\nNote: local Flutter build was not run because `flutter` is not installed in this environment.