### PR TITLE
修复桌面端 OpenClaw DeepSeek 代理 404

### DIFF
--- a/fabushi/web/src/handlers/dacheng-ai.js
+++ b/fabushi/web/src/handlers/dacheng-ai.js
@@ -2,13 +2,14 @@ import { CORS_HEADERS } from '../config/constants.js';
 import { jsonResponse } from '../utils/response.js';
 
 const DEFAULT_DACHENG_AI_BACKEND_URL = 'https://ai.ombhrum.com';
-const DEFAULT_DACHENG_AI_BACKEND_TIMEOUT_MS = 8000;
+const DEFAULT_DACHENG_AI_BACKEND_TIMEOUT_MS = 120000;
 const DACHENG_AI_UNAVAILABLE_MESSAGE = '大乘 AI 后端暂时不可用，请稍后重试。';
 
 export function isDachengAiPath(pathname) {
   return (
     pathname.startsWith('/api/ai/') ||
     pathname.startsWith('/api/agent/') ||
+    pathname.startsWith('/api/openclaw/') ||
     pathname.startsWith('/api/resources/') ||
     pathname === '/api/codex/resource-task'
   );

--- a/fabushi/web/tests/dacheng-ai-handler.test.js
+++ b/fabushi/web/tests/dacheng-ai-handler.test.js
@@ -10,8 +10,49 @@ test('Dacheng AI proxy includes first-party agent endpoints', () => {
   assert.equal(isDachengAiPath('/api/agent/messages/msg_1/feedback'), true);
 });
 
+test('Dacheng AI proxy includes OpenClaw DeepSeek fallback endpoints', () => {
+  assert.equal(isDachengAiPath('/api/openclaw/deepseek/v1/chat/completions'), true);
+  assert.equal(isDachengAiPath('/api/openclaw/runtime/manifest'), true);
+});
+
 test('Dacheng AI proxy still rejects unrelated API endpoints', () => {
   assert.equal(isDachengAiPath('/api/auth/login'), false);
+});
+
+test('Dacheng AI proxy forwards OpenClaw DeepSeek fallback requests', async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async (url, init) => {
+    assert.equal(
+      url.toString(),
+      'https://ai.example.test/api/openclaw/deepseek/v1/chat/completions?source=desktop',
+    );
+    assert.equal(init.method, 'POST');
+    assert.equal(init.headers.get('X-Forwarded-Host'), 'api.ombhrum.com');
+    assert.equal(init.headers.get('X-Forwarded-Proto'), 'https');
+    return new Response('data: [DONE]\n\n', {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+    });
+  };
+
+  const response = await handleDachengAiProxy(
+    new Request(
+      'https://api.ombhrum.com/api/openclaw/deepseek/v1/chat/completions?source=desktop',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }], stream: true }),
+      },
+    ),
+    { DACHENG_AI_BACKEND_URL: 'https://ai.example.test' },
+  );
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get('content-type') ?? '', /text\/event-stream/);
 });
 
 test('Dacheng AI proxy converts Cloudflare tunnel HTML into JSON error', async (t) => {


### PR DESCRIPTION
## 根因

桌面端 OpenClaw fallback 会请求 `https://api.ombhrum.com/api/openclaw/deepseek/v1/chat/completions`。生产域名由 Cloudflare Worker 承接，Worker 已经有 `Dacheng AI` 后端代理，但路径白名单漏掉了 `/api/openclaw/`，所以请求没有被转发到 `https://ai.ombhrum.com`，而是落到 Worker 的 backend-only 404 兜底。

## 修复

- 将 `/api/openclaw/` 纳入 `isDachengAiPath`，让 Worker 把桌面端 OpenClaw DeepSeek fallback 和 runtime manifest/files 请求转发到大乘 AI 后端。
- 将 AI 代理默认超时从 8 秒调到 120 秒，避免 DeepSeek/OpenClaw 流式请求被 Worker 代理过早中断。
- 增加单元测试覆盖 OpenClaw DeepSeek fallback 路径识别和实际转发 URL。

## 验证

- 本地最小副本运行：`node --test tests/dacheng-ai-handler.test.js`
- 结果：6 个测试全部通过，包括新增的 OpenClaw DeepSeek fallback 转发用例。

## 发布影响

该改动位于 `fabushi/web/**`，合入 `main` 后会触发生产 Worker CD。预期发布后 `/api/openclaw/deepseek/v1/chat/completions` 不再返回 Worker backend-only 404，而是转发到 AI 后端。