### PR TITLE
社交联系人式首页与固定功能机器人

### DIFF
--- a/fabushi/lib/screens/main_navigation_screen_native.dart
+++ b/fabushi/lib/screens/main_navigation_screen_native.dart
@@ -1,14 +1,11 @@
 import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
-import 'globe_home_screen.dart';
-import 'meditation_room_screen.dart';
-import 'my_profile_screen.dart';
-import '../widgets/space_background.dart';
 
-import '../widgets/sidebar/codex_sidebar.dart';
-import '../widgets/sidebar/dacheng_chat_sidebar.dart';
-import 'settings_screen.dart';
+import '../widgets/social/social_contacts_sidebar.dart';
+import '../widgets/social/social_feature_bot.dart';
+import '../widgets/space_background.dart';
+import 'social_feature_chat_screen.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -18,123 +15,34 @@ class MainNavigationScreen extends StatefulWidget {
 }
 
 class _MainNavigationScreenState extends State<MainNavigationScreen> {
-  int _currentIndex = 3;
-  bool _isGlobeReady = false;
+  SocialFeatureBotType _selectedBot = SocialFeatureBotType.globalDharma;
   bool _mobileSidebarOpen = false;
-
-  final List<bool> _activatedScreens = [false, false, false, true, false];
-
-  final GlobalKey<MeditationRoomScreenState> _meditationKey = GlobalKey();
-  final GlobalKey<GlobeHomeScreenState> _globeKey = GlobalKey();
 
   bool get _isMobileRuntime => Platform.isAndroid || Platform.isIOS;
 
   @override
   void initState() {
     super.initState();
-    _isGlobeReady = true;
-    _applyInitialTabFromUrl();
+    _applyInitialBotFromUrl();
   }
 
-  void _applyInitialTabFromUrl() {
+  void _applyInitialBotFromUrl() {
     final tab = Uri.base.queryParameters['tab']?.toLowerCase();
-    final initialIndex = switch (tab) {
-      'home' => 0,
-      'assistant' || 'openclaw' || 'workbench' => 0,
-      'meditation' || 'meditation-room' || 'zen' => 1,
-      'profile' || 'me' || 'mine' => 2,
-      _ => 0,
+    _selectedBot = switch (tab) {
+      'flashcards' || 'cards' || 'beisong' => SocialFeatureBotType.flashcards,
+      'publish' || 'platform' || 'platform-publish' =>
+        SocialFeatureBotType.platformPublish,
+      'global' || 'globe' || 'dharma' || 'home' || null =>
+        SocialFeatureBotType.globalDharma,
+      _ => SocialFeatureBotType.globalDharma,
     };
-    _currentIndex = initialIndex;
-    _activatedScreens[initialIndex] = true;
   }
 
-  void _updateMeditationRoomVisibility() {
-    final isZenRoomVisible = _currentIndex == 2 && _activatedScreens[2];
-    _meditationKey.currentState?.setVisible(isZenRoomVisible);
-  }
-
-  void _updateGlobeVisibility() {
-    final isGlobeVisible = _currentIndex == 0 || _currentIndex == 1;
-    _globeKey.currentState?.setVisible(isGlobeVisible);
-  }
-
-  void _notifyScreenVisibility() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _updateMeditationRoomVisibility();
-      _updateGlobeVisibility();
-    });
-  }
-
-  void _selectDestination(int index) {
+  void _selectBot(SocialFeatureBotType botType) {
     setState(() {
-      _currentIndex = index;
+      _selectedBot = botType;
       _mobileSidebarOpen = false;
-      if (!_activatedScreens[index]) {
-        _activatedScreens[index] = true;
-      }
     });
-    _notifyScreenVisibility();
-
-    if (index == 0) {
-      _globeKey.currentState?.setGlobeMode(false);
-    } else if (index == 1) {
-      _globeKey.currentState?.setGlobeMode(true);
-    }
-  }
-
-  List<Widget> get _screens {
-    final screens = <Widget>[];
-
-    screens.add(
-      TickerMode(
-        enabled: _currentIndex == 0 || _currentIndex == 1,
-        child: _isGlobeReady
-            ? GlobeHomeScreen(key: _globeKey)
-            : const Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    CircularProgressIndicator(),
-                    SizedBox(height: 16),
-                    Text('正在加载组件...'),
-                  ],
-                ),
-              ),
-      ),
-    );
-
-    screens.add(const SizedBox.shrink());
-
-    screens.add(
-      TickerMode(
-        enabled: _currentIndex == 2,
-        child: _activatedScreens[2]
-            ? MeditationRoomScreen(key: _meditationKey)
-            : const Center(child: CircularProgressIndicator()),
-      ),
-    );
-
-    screens.add(
-      TickerMode(
-        enabled: _currentIndex == 3,
-        child: _activatedScreens[3]
-            ? const MyProfileScreen()
-            : const Center(child: CircularProgressIndicator()),
-      ),
-    );
-
-    screens.add(
-      TickerMode(
-        enabled: _currentIndex == 4,
-        child: _activatedScreens[4]
-            ? SettingsScreen(onClose: () => setState(() => _currentIndex = 0))
-            : const Center(child: CircularProgressIndicator()),
-      ),
-    );
-
-    return screens;
   }
 
   @override
@@ -150,11 +58,13 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   Widget _buildDesktopShell() {
     return Row(
       children: [
-        CodexSidebar(
-          selectedIndex: _currentIndex,
-          onDestinationSelected: _selectDestination,
+        SocialContactsSidebar(
+          selectedBot: _selectedBot,
+          onBotSelected: _selectBot,
         ),
-        Expanded(child: _buildIndexedStack()),
+        Expanded(
+          child: SocialFeatureChatScreen(botType: _selectedBot),
+        ),
       ],
     );
   }
@@ -162,10 +72,12 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   Widget _buildMobileShell() {
     return Stack(
       children: [
-        Positioned.fill(child: _buildIndexedStack()),
+        Positioned.fill(
+          child: SocialFeatureChatScreen(botType: _selectedBot),
+        ),
         Positioned(
-          left: 18,
-          top: 16,
+          left: 12,
+          top: 12,
           child: SafeArea(
             child: _SidebarOpenButton(
               onPressed: () => setState(() => _mobileSidebarOpen = true),
@@ -186,19 +98,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
           left: _mobileSidebarOpen ? 0 : -MediaQuery.sizeOf(context).width,
           top: 0,
           bottom: 0,
-          child: DachengChatSidebar(
-            onNewChat: () => _selectDestination(0),
+          child: SocialContactsSidebar(
+            selectedBot: _selectedBot,
+            onBotSelected: _selectBot,
             onClose: () => setState(() => _mobileSidebarOpen = false),
+            isMobile: true,
           ),
         ),
       ],
-    );
-  }
-
-  Widget _buildIndexedStack() {
-    return IndexedStack(
-      index: _currentIndex == 1 ? 0 : _currentIndex,
-      children: _screens,
     );
   }
 }
@@ -211,12 +118,12 @@ class _SidebarOpenButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: const Color(0xCC222A30),
+      color: const Color(0xCC17212B),
       shape: const CircleBorder(),
       child: IconButton(
-        tooltip: '打开侧边栏',
+        tooltip: '打开联系人',
         onPressed: onPressed,
-        icon: const Icon(Icons.menu_rounded, color: Colors.white, size: 28),
+        icon: const Icon(Icons.menu_rounded, color: Colors.white, size: 26),
       ),
     );
   }

--- a/fabushi/lib/screens/social_feature_chat_screen.dart
+++ b/fabushi/lib/screens/social_feature_chat_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../core/constants/country_servers.dart' as country_catalog;
 import '../features/auth/application/auth_model.dart';
 import '../features/flashcards/application/content_pipeline.dart';
 import '../features/flashcards/application/flashcard_service.dart';
@@ -26,26 +25,20 @@ class SocialFeatureChatScreen extends StatefulWidget {
 }
 
 class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
-  final TextEditingController _composerController = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
-  final Map<SocialFeatureBotType, List<_SocialChatMessage>> _messagesByBot = {};
-
+  final TextEditingController _composer = TextEditingController();
+  final ScrollController _scroll = ScrollController();
+  final Map<SocialFeatureBotType, List<_ChatMessage>> _messages = {};
   late final FlashcardRepository _flashcardRepository;
   late final ContentPipeline _contentPipeline;
   late final FlashcardService _flashcardService;
-  final DharmaPublishService _dharmaPublishService = DharmaPublishService();
-
+  final DharmaPublishService _publishService = DharmaPublishService();
+  final Set<DharmaPublishPlatform> _platforms = {DharmaPublishPlatform.xiaohongshu};
   FlashcardCreationMode _flashcardMode = FlashcardCreationMode.randomCloze;
-  final Set<DharmaPublishPlatform> _selectedPublishPlatforms = {
-    DharmaPublishPlatform.xiaohongshu,
-  };
-  bool _isBusy = false;
-  String _activityText = '';
-
-  List<_SocialChatMessage> get _messages =>
-      _messagesByBot.putIfAbsent(widget.botType, () => []);
+  bool _busy = false;
+  String _activity = '';
 
   SocialFeatureBot get _bot => widget.botType.bot;
+  List<_ChatMessage> get _botMessages => _messages.putIfAbsent(widget.botType, () => []);
 
   @override
   void initState() {
@@ -63,40 +56,37 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
   void didUpdateWidget(covariant SocialFeatureChatScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.botType != widget.botType) {
-      _composerController.clear();
-      _activityText = '';
+      _composer.clear();
       _ensureGreeting(widget.botType);
-      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+      _scrollBottom();
     }
   }
 
   @override
   void dispose() {
-    _composerController.dispose();
-    _scrollController.dispose();
+    _composer.dispose();
+    _scroll.dispose();
     super.dispose();
   }
 
-  void _ensureGreeting(SocialFeatureBotType botType) {
-    final list = _messagesByBot.putIfAbsent(botType, () => []);
-    if (list.isNotEmpty) return;
-    list.add(_SocialChatMessage.bot(botType.bot.greeting));
+  void _ensureGreeting(SocialFeatureBotType type) {
+    final list = _messages.putIfAbsent(type, () => []);
+    if (list.isEmpty) list.add(_ChatMessage.bot(type.bot.greeting));
   }
 
   @override
   Widget build(BuildContext context) {
     final model = Provider.of<FileTransferModel>(context);
-    final canSend = !_isBusy && _canSubmit(model);
-
-    return Container(
+    final canSend = !_busy && _canSubmit(model);
+    return ColoredBox(
       color: const Color(0xFF0F1722),
       child: SafeArea(
         child: Column(
           children: [
             _buildHeader(model),
             _buildModeBar(model),
-            Expanded(child: _buildMessageList(model)),
-            _buildComposer(model, canSend: canSend),
+            Expanded(child: _buildMessages(model)),
+            _buildComposer(model, canSend),
           ],
         ),
       ),
@@ -116,7 +106,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
           CircleAvatar(
             radius: 24,
             backgroundColor: _bot.avatarColor,
-            child: Icon(_bot.icon, color: Colors.white, size: 25),
+            child: Icon(_bot.icon, color: Colors.white),
           ),
           const SizedBox(width: 14),
           Expanded(
@@ -124,36 +114,15 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  _bot.title,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 18,
-                    fontWeight: FontWeight.w900,
-                  ),
-                ),
+                Text(_bot.title, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w900)),
                 const SizedBox(height: 3),
-                Text(
-                  _statusLine(model),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    color: Color(0xFF91A3B7),
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
+                Text(_statusText(model), maxLines: 1, overflow: TextOverflow.ellipsis, style: const TextStyle(color: Color(0xFF91A3B7), fontSize: 13)),
               ],
             ),
           ),
           IconButton(
-            tooltip: '搜索联系人',
-            onPressed: () => _appendBotNotice('请在左侧联系人栏右上角搜索并添加好友。'),
-            icon: const Icon(Icons.search, color: Color(0xFF91A3B7)),
-          ),
-          IconButton(
-            tooltip: '更多设置',
-            onPressed: () => _showModeSheet(model),
+            tooltip: '联系人设置',
+            onPressed: () => _openCurrentSettings(model),
             icon: const Icon(Icons.tune, color: Color(0xFF91A3B7)),
           ),
         ],
@@ -161,266 +130,101 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
     );
   }
 
-  String _statusLine(FileTransferModel model) {
+  String _statusText(FileTransferModel model) {
     switch (widget.botType) {
       case SocialFeatureBotType.globalDharma:
         if (model.isPreparingSend) return model.preparingSendMessage;
-        if (model.isTransferring) return '正在全球法布施 · ${_regionSummary(model)}';
-        return 'bot · ${_regionSummary(model)} · ${model.isLooping ? "循环" : "单轮"}';
+        return model.isTransferring ? '正在发送' : 'bot · ${model.isLooping ? "循环" : "单轮"} · ${model.isGlobalSendEnabled ? "全球" : "本地"}';
       case SocialFeatureBotType.flashcards:
         return 'bot · 当前模式：${_flashcardMode.label}';
       case SocialFeatureBotType.platformPublish:
-        return 'bot · 发布平台：${_platformSummary()}';
+        return 'bot · 平台：${_platformSummary()}';
       case SocialFeatureBotType.assistant:
-        return 'bot · 大乘助理';
+        return 'bot';
     }
   }
 
   Widget _buildModeBar(FileTransferModel model) {
+    final chips = switch (widget.botType) {
+      SocialFeatureBotType.globalDharma => <Widget>[
+          _ControlPill(icon: Icons.public, label: model.isGlobalSendEnabled ? '地区 全球' : '地区 本地', active: true, onTap: () => _showRegionSettings(model)),
+          _ControlPill(icon: Icons.loop, label: model.isLooping ? '循环发送' : '单轮发送', active: model.isLooping, onTap: () { model.setLooping(!model.isLooping); setState(() {}); }),
+          _ControlPill(icon: Icons.attach_file, label: model.hasFiles ? '已选素材' : '添加素材', active: model.hasFiles, onTap: () => unawaited(model.selectFiles())),
+        ],
+      SocialFeatureBotType.flashcards => <Widget>[
+          _ControlPill(icon: _flashcardMode == FlashcardCreationMode.aiCards ? Icons.auto_awesome : Icons.auto_fix_high, label: '模式 ${_flashcardMode.label}', active: true, onTap: _showFlashcardModeSelector),
+        ],
+      SocialFeatureBotType.platformPublish => <Widget>[
+          _ControlPill(icon: Icons.campaign_outlined, label: '平台 ${_platformSummary()}', active: true, onTap: _showPlatformSelector),
+        ],
+      SocialFeatureBotType.assistant => const <Widget>[
+          _ControlPill(icon: Icons.smart_toy_outlined, label: '助理', active: true, onTap: null),
+        ],
+    };
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.fromLTRB(20, 12, 20, 10),
-      decoration: const BoxDecoration(
-        color: Color(0xFF111B26),
-        border: Border(bottom: BorderSide(color: Color(0xFF1F2B38))),
-      ),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: switch (widget.botType) {
-          SocialFeatureBotType.globalDharma => [
-              _ControlPill(
-                icon: Icons.public,
-                label: '地区 ${_regionSummary(model)}',
-                active: true,
-                onTap: _isBusy ? null : () => _showRegionSelector(model),
-              ),
-              _ControlPill(
-                icon: Icons.loop,
-                label: model.isLooping ? '循环发送' : '单轮发送',
-                active: model.isLooping,
-                onTap: _isBusy
-                    ? null
-                    : () {
-                        model.setLooping(!model.isLooping);
-                        setState(() {});
-                      },
-              ),
-              _ControlPill(
-                icon: Icons.folder_outlined,
-                label: model.hasFiles
-                    ? (model.selectedContentTitle.isEmpty
-                        ? '已选择素材'
-                        : model.selectedContentTitle)
-                    : '添加素材',
-                active: model.hasFiles,
-                onTap: _isBusy ? null : () => unawaited(model.selectFiles()),
-              ),
-            ],
-          SocialFeatureBotType.flashcards => [
-              _ControlPill(
-                icon: _flashcardMode == FlashcardCreationMode.aiCards
-                    ? Icons.auto_awesome
-                    : Icons.auto_fix_high,
-                label: '模式 ${_flashcardMode.label}',
-                active: true,
-                onTap: _isBusy ? null : _showFlashcardModeSelector,
-              ),
-              _ControlPill(
-                icon: Icons.help_outline,
-                label: _flashcardMode == FlashcardCreationMode.aiCards
-                    ? '可输入制卡要求'
-                    : '本地随机挖空',
-                active: false,
-                onTap: null,
-              ),
-            ],
-          SocialFeatureBotType.platformPublish => [
-              _ControlPill(
-                icon: Icons.campaign_outlined,
-                label: '平台 ${_platformSummary()}',
-                active: _selectedPublishPlatforms.isNotEmpty,
-                onTap: _isBusy ? null : _showPublishPlatformSelector,
-              ),
-              _ControlPill(
-                icon: Icons.content_paste_go_outlined,
-                label: '复制草稿并打开入口',
-                active: true,
-                onTap: null,
-              ),
-            ],
-          SocialFeatureBotType.assistant => [
-              const _ControlPill(
-                icon: Icons.smart_toy_outlined,
-                label: '助理模式',
-                active: true,
-                onTap: null,
-              ),
-            ],
-        },
-      ),
+      decoration: const BoxDecoration(color: Color(0xFF111B26), border: Border(bottom: BorderSide(color: Color(0xFF1F2B38)))),
+      child: Wrap(spacing: 8, runSpacing: 8, children: chips),
     );
   }
 
-  Widget _buildMessageList(FileTransferModel model) {
+  Widget _buildMessages(FileTransferModel model) {
+    final showProgress = widget.botType == SocialFeatureBotType.globalDharma && (model.isPreparingSend || model.isTransferring);
+    final count = _botMessages.length + (_busy ? 1 : 0) + (showProgress ? 1 : 0);
     return ListView.builder(
-      controller: _scrollController,
+      controller: _scroll,
       padding: const EdgeInsets.fromLTRB(28, 20, 28, 24),
-      itemCount: _messages.length + (_isBusy ? 1 : 0) +
-          (widget.botType == SocialFeatureBotType.globalDharma &&
-                  (model.isPreparingSend || model.isTransferring)
-              ? 1
-              : 0),
+      itemCount: count,
       itemBuilder: (context, index) {
-        if (index < _messages.length) {
-          return _MessageBubble(
-            message: _messages[index],
-            bot: _bot,
-            onOpenDeck: _openFlashcardDeck,
-          );
-        }
-
-        final busyIndex = _messages.length;
-        if (_isBusy && index == busyIndex) {
-          return Padding(
-            padding: const EdgeInsets.only(bottom: 14),
-            child: _ThinkingBubble(
-              label: _activityText.trim().isEmpty ? '正在处理' : _activityText,
-            ),
-          );
-        }
-
-        return _buildGlobalProgressCard(model);
+        if (index < _botMessages.length) return _MessageBubble(message: _botMessages[index], bot: _bot, onDeck: _openDeck);
+        if (_busy && index == _botMessages.length) return _ThinkingBubble(label: _activity.isEmpty ? '正在处理' : _activity);
+        return _GlobalProgress(model: model);
       },
     );
   }
 
-  Widget _buildGlobalProgressCard(FileTransferModel model) {
-    final successCount = model.countryStatuses
-        .where((status) => status.status == SendStatus.success)
-        .length;
-    final total = model.countryStatuses.length;
-    final label = model.isPreparingSend
-        ? model.preparingSendMessage
-        : model.isTransferring
-            ? '正在发送：$successCount / $total'
-            : '正在整理发送状态';
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 14),
-        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
-        constraints: const BoxConstraints(maxWidth: 430),
-        decoration: BoxDecoration(
-          color: const Color(0xFF182433),
-          borderRadius: BorderRadius.circular(18),
-          border: Border.all(color: const Color(0xFF2A3A4A)),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Row(
-              children: [
-                const SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    label,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 10),
-            Text(
-              '已传播 ${model.globalSentCount} 个节点 · ${model.globalDataSentMB.toStringAsFixed(2)} MB',
-              style: const TextStyle(color: Color(0xFF91A3B7), fontSize: 13),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildComposer(FileTransferModel model, {required bool canSend}) {
+  Widget _buildComposer(FileTransferModel model, bool canSend) {
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 10, 20, 18),
-      decoration: const BoxDecoration(
-        color: Color(0xFF17212B),
-        border: Border(top: BorderSide(color: Color(0xFF223040))),
-      ),
+      decoration: const BoxDecoration(color: Color(0xFF17212B), border: Border(top: BorderSide(color: Color(0xFF223040)))),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           IconButton(
-            tooltip: widget.botType == SocialFeatureBotType.flashcards
-                ? '闪卡模式'
-                : '添加素材',
-            onPressed: _isBusy
-                ? null
-                : widget.botType == SocialFeatureBotType.flashcards
-                    ? _showFlashcardModeSelector
-                    : () => unawaited(model.selectFiles()),
+            tooltip: widget.botType == SocialFeatureBotType.flashcards ? '选择模式' : '添加素材',
+            onPressed: _busy ? null : widget.botType == SocialFeatureBotType.flashcards ? _showFlashcardModeSelector : () => unawaited(model.selectFiles()),
             icon: const Icon(Icons.add_circle_outline, color: Color(0xFF91A3B7)),
           ),
           const SizedBox(width: 8),
           Expanded(
             child: TextField(
-              controller: _composerController,
-              enabled: !_isBusy,
+              controller: _composer,
+              enabled: !_busy,
               minLines: 1,
               maxLines: 5,
               textInputAction: TextInputAction.send,
               style: const TextStyle(color: Colors.white, fontSize: 15, height: 1.4),
-              cursorColor: Colors.white,
               decoration: InputDecoration(
-                filled: true,
-                fillColor: const Color(0xFF101923),
                 hintText: _bot.inputHint,
                 hintStyle: const TextStyle(color: Color(0xFF6E7F92)),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(22),
-                  borderSide: const BorderSide(color: Color(0xFF263445)),
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(22),
-                  borderSide: const BorderSide(color: Color(0xFF263445)),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(22),
-                  borderSide: const BorderSide(color: Color(0xFF4F9DFF)),
-                ),
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 12,
-                ),
+                filled: true,
+                fillColor: const Color(0xFF101923),
+                border: OutlineInputBorder(borderRadius: BorderRadius.circular(22), borderSide: const BorderSide(color: Color(0xFF263445))),
+                enabledBorder: OutlineInputBorder(borderRadius: BorderRadius.circular(22), borderSide: const BorderSide(color: Color(0xFF263445))),
+                focusedBorder: OutlineInputBorder(borderRadius: BorderRadius.circular(22), borderSide: const BorderSide(color: Color(0xFF4F9DFF))),
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               ),
               onChanged: (_) => setState(() {}),
-              onSubmitted: (_) {
-                if (canSend) _submit(model);
-              },
+              onSubmitted: (_) { if (canSend) _submit(model); },
             ),
           ),
           const SizedBox(width: 10),
           IconButton.filled(
             tooltip: '发送',
             onPressed: canSend ? () => _submit(model) : null,
-            style: IconButton.styleFrom(
-              backgroundColor: const Color(0xFF3390EC),
-              disabledBackgroundColor: const Color(0xFF263445),
-            ),
-            icon: Icon(
-              _isBusy ? Icons.more_horiz : Icons.arrow_upward,
-              color: Colors.white,
-            ),
+            style: IconButton.styleFrom(backgroundColor: const Color(0xFF3390EC), disabledBackgroundColor: const Color(0xFF263445)),
+            icon: Icon(_busy ? Icons.more_horiz : Icons.arrow_upward, color: Colors.white),
           ),
         ],
       ),
@@ -428,14 +232,14 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
   }
 
   bool _canSubmit(FileTransferModel model) {
-    final text = _composerController.text.trim();
+    final text = _composer.text.trim();
     switch (widget.botType) {
       case SocialFeatureBotType.globalDharma:
         return text.isNotEmpty || model.hasFiles;
       case SocialFeatureBotType.flashcards:
         return text.isNotEmpty;
       case SocialFeatureBotType.platformPublish:
-        return _selectedPublishPlatforms.isNotEmpty && (text.isNotEmpty || model.hasFiles);
+        return _platforms.isNotEmpty && (text.isNotEmpty || model.hasFiles);
       case SocialFeatureBotType.assistant:
         return text.isNotEmpty;
     }
@@ -444,677 +248,229 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
   void _submit(FileTransferModel model) {
     switch (widget.botType) {
       case SocialFeatureBotType.globalDharma:
-        unawaited(_startGlobalDharma(model));
+        unawaited(_startGlobal(model));
+        return;
       case SocialFeatureBotType.flashcards:
-        unawaited(_startFlashcardGeneration());
+        unawaited(_startFlashcards());
+        return;
       case SocialFeatureBotType.platformPublish:
-        unawaited(_startPlatformPublish(model));
+        unawaited(_startPublish(model));
+        return;
       case SocialFeatureBotType.assistant:
-        _appendBotNotice('大乘助理仍保留在原有 OpenClaw 工作台能力中。');
+        _addBotMessage('原有助理能力保留在 OpenClaw 工作台中。');
+        return;
     }
   }
 
-  Future<void> _startGlobalDharma(FileTransferModel model) async {
-    if (_isBusy || model.isTransferring) return;
-    final text = _composerController.text.trim();
-    _composerController.clear();
-    setState(() {
-      if (text.isNotEmpty) _messages.add(_SocialChatMessage.user(text));
-      _isBusy = true;
-      _activityText = '正在准备全球法布施素材...';
-    });
-    _scrollToBottom();
-
+  Future<void> _startGlobal(FileTransferModel model) async {
+    final text = _composer.text.trim();
+    _composer.clear();
+    setState(() { if (text.isNotEmpty) _botMessages.add(_ChatMessage.user(text)); _busy = true; _activity = '正在准备素材...'; });
+    _scrollBottom();
     try {
-      if (text.isNotEmpty) {
-        await model.addTextContentForSending(
-          title: _titleFromText(text, fallback: '全球法布施'),
-          text: text,
-          sourceKind: '文本',
-          replaceExisting: !model.hasFiles,
-        );
-      }
-      if (!model.hasFiles) {
-        throw StateError('请先输入文字/链接，或点击 + 添加素材。');
-      }
-      setState(() => _activityText = '正在启动全球发送...');
+      if (text.isNotEmpty) await _saveTextToModel(model, text, '全球法布施', replaceExisting: !model.hasFiles);
+      if (!model.hasFiles) throw StateError('请先输入文字、链接，或点击 + 添加素材。');
+      setState(() => _activity = '正在启动发送...');
       await model.startGlobalTransfer();
       if (!mounted) return;
-      setState(() {
-        _messages.add(
-          _SocialChatMessage.bot(
-            '本次全球法布施已完成：${model.globalSentCount} 个节点，${model.globalDataSentMB.toStringAsFixed(2)} MB。',
-          ),
-        );
-      });
-    } catch (error) {
-      if (!mounted) return;
-      setState(() => _messages.add(_SocialChatMessage.error('启动失败：$error')));
+      _botMessages.add(_ChatMessage.bot('已完成：${model.globalSentCount} 个节点，${model.globalDataSentMB.toStringAsFixed(2)} MB。'));
+    } catch (e) {
+      if (mounted) _botMessages.add(_ChatMessage.error('启动失败：$e'));
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isBusy = false;
-        _activityText = '';
-      });
-      _scrollToBottom();
+      if (mounted) setState(() { _busy = false; _activity = ''; });
+      _scrollBottom();
     }
   }
 
-  Future<void> _startFlashcardGeneration() async {
-    if (_isBusy) return;
-    final text = _composerController.text.trim();
+  Future<void> _startFlashcards() async {
+    final text = _composer.text.trim();
     if (text.isEmpty) return;
-    _composerController.clear();
-    final progressMessage = _SocialChatMessage.bot('正在准备内容...');
-    setState(() {
-      _messages.add(_SocialChatMessage.user(text));
-      _messages.add(progressMessage);
-      _isBusy = true;
-      _activityText = '正在提取正文...';
-    });
-    _scrollToBottom();
-
+    _composer.clear();
+    final progress = _ChatMessage.bot('正在准备内容...');
+    setState(() { _botMessages.add(_ChatMessage.user(text)); _botMessages.add(progress); _busy = true; _activity = '正在提取正文...'; });
+    _scrollBottom();
     try {
-      final content = await _contentPipeline.prepare(
-        ContentInput(
-          text: text,
-          url: ContentPipeline.firstHttpUrl(text),
-          title: ContentPipeline.firstHttpUrl(text) == null ? '背诵内容' : '链接内容',
-          sourceType: ContentPipeline.firstHttpUrl(text) == null
-              ? 'composer_text'
-              : 'composer_url',
-        ),
-      );
-      if (content.isFailed) {
-        throw StateError(content.errorMessage ?? '内容提取失败');
-      }
-
-      final authModel = Provider.of<AuthModel?>(context, listen: false);
-      final input = FlashcardInput(
-        title: content.title,
-        text: content.text,
-        documentId: content.document?.id,
-        sourceUrl: content.sourceUrl,
-      );
+      final url = ContentPipeline.firstHttpUrl(text);
+      final content = await _contentPipeline.prepare(ContentInput(text: text, url: url, title: url == null ? '背诵内容' : '链接内容'));
+      if (content.isFailed) throw StateError(content.errorMessage ?? '内容提取失败');
+      final auth = Provider.of<AuthModel?>(context, listen: false);
+      final input = FlashcardInput(title: content.title, text: content.text, documentId: content.document?.id, sourceUrl: content.sourceUrl);
       final stream = _flashcardMode == FlashcardCreationMode.aiCards
-          ? _flashcardService.generateAiCardsStream(
-              input,
-              token: authModel?.authToken,
-              username: authModel?.currentUser?.username,
-              isMember: authModel?.hasPermission('premium') ?? false,
-            )
+          ? _flashcardService.generateAiCardsStream(input, token: auth?.authToken, username: auth?.currentUser?.username, isMember: auth?.hasPermission('premium') ?? false)
           : _flashcardService.generateRandomClozeStream(input);
-
       await for (final event in stream) {
         if (!mounted) return;
-        setState(() {
-          _activityText = event.message;
-          progressMessage.text = event.progress > 0
-              ? '${event.message} (${event.progress}%)'
-              : event.message;
-        });
-        _scrollToBottom();
-        if (event.isDone && event.deck != null) {
-          setState(() {
-            _messages.add(
-              _SocialChatMessage.deck(
-                '制卡完成：${event.deck!.cardCount} 张 · ${event.deck!.mode.label}',
-                event.deck!,
-              ),
-            );
-          });
-        }
-        if (event.isError) {
-          throw StateError(event.message);
-        }
+        setState(() { _activity = event.message; progress.text = event.progress > 0 ? '${event.message} (${event.progress}%)' : event.message; });
+        if (event.isDone && event.deck != null) _botMessages.add(_ChatMessage.deck('制卡完成：${event.deck!.cardCount} 张 · ${event.deck!.mode.label}', event.deck!));
+        if (event.isError) throw StateError(event.message);
+        _scrollBottom();
       }
-    } catch (error) {
-      if (!mounted) return;
-      setState(() => _messages.add(_SocialChatMessage.error('制卡失败：$error')));
+    } catch (e) {
+      if (mounted) _botMessages.add(_ChatMessage.error('制卡失败：$e'));
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isBusy = false;
-        _activityText = '';
-      });
-      _scrollToBottom();
+      if (mounted) setState(() { _busy = false; _activity = ''; });
+      _scrollBottom();
     }
   }
 
-  Future<void> _startPlatformPublish(FileTransferModel model) async {
-    if (_isBusy) return;
-    final text = _composerController.text.trim();
-    _composerController.clear();
-    setState(() {
-      if (text.isNotEmpty) _messages.add(_SocialChatMessage.user(text));
-      _isBusy = true;
-      _activityText = '正在整理发布草稿...';
-    });
-    _scrollToBottom();
-
+  Future<void> _startPublish(FileTransferModel model) async {
+    final text = _composer.text.trim();
+    _composer.clear();
+    setState(() { if (text.isNotEmpty) _botMessages.add(_ChatMessage.user(text)); _busy = true; _activity = '正在生成发布草稿...'; });
+    _scrollBottom();
     try {
-      if (text.isNotEmpty) {
-        final uri = Uri.tryParse(text);
-        if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
-          await model.addUrlContentForSending(text);
-        } else {
-          await model.addTextContentForSending(
-            title: _titleFromText(text, fallback: '法布施发布'),
-            text: text,
-            sourceKind: '文本',
-            replaceExisting: true,
-          );
-        }
-      }
-      if (!model.hasFiles && text.isEmpty) {
-        throw StateError('请先输入要发布的文字/链接，或点击 + 添加素材。');
-      }
-
-      var draft = _dharmaPublishService.buildDraftFromModel(
-        model,
-        fallbackText: text,
-      );
-      if (draft.title.trim().isEmpty) {
-        draft = draft.copyWith(title: _dharmaPublishService.suggestTitle(draft));
-      }
-      if (draft.body.trim().length < 12) {
-        draft = draft.copyWith(body: _dharmaPublishService.polishBody(draft));
-      }
-
-      setState(() {
-        _messages.add(
-          _SocialChatMessage.bot(
-            _dharmaPublishService.buildPreviewMarkdown(
-              draft,
-              _selectedPublishPlatforms,
-            ),
-          ),
-        );
-        _activityText = '正在复制草稿并打开平台入口...';
-      });
-
-      final results = await _dharmaPublishService.publishDraft(
-        draft: draft,
-        platforms: _selectedPublishPlatforms,
-      );
+      if (text.isNotEmpty) await _saveTextToModel(model, text, '法布施发布', replaceExisting: true);
+      if (!model.hasFiles && text.isEmpty) throw StateError('请输入正文/链接，或点击 + 添加素材。');
+      var draft = _publishService.buildDraftFromModel(model, fallbackText: text);
+      if (draft.title.trim().isEmpty) draft = draft.copyWith(title: _publishService.suggestTitle(draft));
+      if (draft.body.trim().length < 12) draft = draft.copyWith(body: _publishService.polishBody(draft));
+      _botMessages.add(_ChatMessage.bot(_publishService.buildPreviewMarkdown(draft, _platforms)));
+      setState(() => _activity = '正在复制草稿并打开入口...');
+      final results = await _publishService.publishDraft(draft: draft, platforms: _platforms);
       if (!mounted) return;
-      final summary = results
-          .map((result) => '${result.platform.info.shortLabel}：${result.message}')
-          .join('\n');
-      setState(() => _messages.add(_SocialChatMessage.bot(summary)));
-    } catch (error) {
-      if (!mounted) return;
-      setState(() => _messages.add(_SocialChatMessage.error('发布失败：$error')));
+      _botMessages.add(_ChatMessage.bot(results.map((r) => '${r.platform.info.shortLabel}：${r.message}').join('\n')));
+    } catch (e) {
+      if (mounted) _botMessages.add(_ChatMessage.error('发布失败：$e'));
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isBusy = false;
-        _activityText = '';
-      });
-      _scrollToBottom();
+      if (mounted) setState(() { _busy = false; _activity = ''; });
+      _scrollBottom();
     }
   }
 
-  String _titleFromText(String text, {required String fallback}) {
+  Future<void> _saveTextToModel(FileTransferModel model, String text, String fallbackTitle, {required bool replaceExisting}) async {
+    final uri = Uri.tryParse(text);
+    final isLink = uri != null && (uri.scheme == 'http' || uri.scheme == 'https');
+    await model.addTextContentForSending(
+      title: isLink ? uri.host : _shortTitle(text, fallbackTitle),
+      text: isLink ? '来源链接: ${uri.toString()}\n\n${uri.toString()}' : text,
+      sourceKind: isLink ? '链接' : '文本',
+      sourceUrl: isLink ? uri.toString() : null,
+      previewText: text,
+      replaceExisting: replaceExisting,
+    );
+  }
+
+  String _shortTitle(String text, String fallback) {
     final normalized = text.replaceAll(RegExp(r'\s+'), ' ').trim();
     if (normalized.isEmpty) return fallback;
     return normalized.length <= 18 ? normalized : normalized.substring(0, 18);
   }
 
-  void _appendBotNotice(String text) {
-    setState(() => _messages.add(_SocialChatMessage.bot(text)));
-    _scrollToBottom();
-  }
-
-  void _showModeSheet(FileTransferModel model) {
+  void _openCurrentSettings(FileTransferModel model) {
     switch (widget.botType) {
       case SocialFeatureBotType.globalDharma:
-        unawaited(_showRegionSelector(model));
+        _showRegionSettings(model);
+        return;
       case SocialFeatureBotType.flashcards:
         _showFlashcardModeSelector();
+        return;
       case SocialFeatureBotType.platformPublish:
-        unawaited(_showPublishPlatformSelector());
+        _showPlatformSelector();
+        return;
       case SocialFeatureBotType.assistant:
-        _appendBotNotice('暂无更多设置。');
+        _addBotMessage('暂无更多设置。');
+        return;
     }
   }
 
   void _showFlashcardModeSelector() {
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: Colors.transparent,
-      builder: (sheetContext) {
-        return SafeArea(
-          child: Container(
-            padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
-            decoration: const BoxDecoration(
-              color: Color(0xFF17212B),
-              borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+    showModalBottomSheet<void>(context: context, backgroundColor: Colors.transparent, builder: (ctx) => _BottomPanel(children: [
+      _ModeTile(icon: Icons.auto_fix_high, title: '随机挖空', subtitle: '本地快速生成，无需 AI。', selected: _flashcardMode == FlashcardCreationMode.randomCloze, onTap: () { setState(() => _flashcardMode = FlashcardCreationMode.randomCloze); Navigator.pop(ctx); }),
+      _ModeTile(icon: Icons.auto_awesome, title: 'AI 制卡', subtitle: '按要求生成问答/挖空卡。', selected: _flashcardMode == FlashcardCreationMode.aiCards, onTap: () { setState(() => _flashcardMode = FlashcardCreationMode.aiCards); Navigator.pop(ctx); }),
+    ]));
+  }
+
+  Future<void> _showPlatformSelector() async {
+    final selected = Set<DharmaPublishPlatform>.from(_platforms);
+    await showModalBottomSheet<void>(context: context, isScrollControlled: true, backgroundColor: Colors.transparent, builder: (ctx) {
+      return StatefulBuilder(builder: (ctx, setSheetState) => _BottomPanel(maxHeightFactor: 0.74, children: [
+        const Text('选择发布平台', style: TextStyle(color: Colors.white, fontSize: 19, fontWeight: FontWeight.w900)),
+        const SizedBox(height: 8),
+        Flexible(child: ListView(children: [
+          for (final platform in DharmaPublishService.allPlatforms)
+            CheckboxListTile(
+              value: selected.contains(platform),
+              onChanged: (v) => setSheetState(() { if (v == true) { selected.add(platform); } else { selected.remove(platform); } }),
+              title: Text(platform.info.label, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w800)),
+              subtitle: Text(platform.info.description, style: const TextStyle(color: Color(0xFF91A3B7))),
             ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const _SheetHandle(),
-                const SizedBox(height: 8),
-                _ModeTile(
-                  icon: Icons.auto_fix_high,
-                  title: '随机挖空',
-                  subtitle: '本地快速生成，无需 AI。',
-                  selected: _flashcardMode == FlashcardCreationMode.randomCloze,
-                  onTap: () {
-                    setState(() => _flashcardMode = FlashcardCreationMode.randomCloze);
-                    Navigator.pop(sheetContext);
-                  },
-                ),
-                _ModeTile(
-                  icon: Icons.auto_awesome,
-                  title: 'AI 制卡',
-                  subtitle: '按要求生成问答/挖空卡，失败会自动回退。',
-                  selected: _flashcardMode == FlashcardCreationMode.aiCards,
-                  onTap: () {
-                    setState(() => _flashcardMode = FlashcardCreationMode.aiCards);
-                    Navigator.pop(sheetContext);
-                  },
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
+        ])),
+        FilledButton(onPressed: selected.isEmpty ? null : () { setState(() { _platforms..clear()..addAll(selected); }); Navigator.pop(ctx); }, child: const Text('完成')),
+      ]));
+    });
   }
 
-  Future<void> _showPublishPlatformSelector() async {
-    final selected = Set<DharmaPublishPlatform>.from(_selectedPublishPlatforms);
-    await showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (sheetContext) {
-        return StatefulBuilder(
-          builder: (sheetContext, setSheetState) {
-            return SafeArea(
-              child: Container(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.sizeOf(sheetContext).height * 0.78,
-                ),
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
-                decoration: const BoxDecoration(
-                  color: Color(0xFF17212B),
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Center(child: _SheetHandle()),
-                    const SizedBox(height: 14),
-                    Row(
-                      children: [
-                        const Expanded(
-                          child: Text(
-                            '选择发布平台',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 19,
-                              fontWeight: FontWeight.w900,
-                            ),
-                          ),
-                        ),
-                        TextButton(
-                          onPressed: () => setSheetState(() {
-                            selected
-                              ..clear()
-                              ..addAll(DharmaPublishService.allPlatforms);
-                          }),
-                          child: const Text('全选'),
-                        ),
-                        TextButton(
-                          onPressed: () => setSheetState(selected.clear),
-                          child: const Text('清空'),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                    Expanded(
-                      child: ListView(
-                        children: [
-                          for (final platform in DharmaPublishService.allPlatforms)
-                            CheckboxListTile(
-                              value: selected.contains(platform),
-                              onChanged: (value) => setSheetState(() {
-                                if (value == true) {
-                                  selected.add(platform);
-                                } else {
-                                  selected.remove(platform);
-                                }
-                              }),
-                              activeColor: const Color(0xFF3390EC),
-                              checkColor: Colors.white,
-                              title: Text(
-                                platform.info.label,
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w800,
-                                ),
-                              ),
-                              subtitle: Text(
-                                platform.info.description,
-                                style: const TextStyle(color: Color(0xFF91A3B7)),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton(
-                        onPressed: selected.isEmpty
-                            ? null
-                            : () {
-                                setState(() {
-                                  _selectedPublishPlatforms
-                                    ..clear()
-                                    ..addAll(selected);
-                                });
-                                Navigator.pop(sheetContext);
-                              },
-                        child: const Text('完成'),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        );
-      },
-    );
-  }
-
-  Future<void> _showRegionSelector(FileTransferModel model) async {
-    final selectedCountries = Set<String>.from(model.countryList);
-    var globalEnabled = model.isGlobalSendEnabled;
-    var fieldEnergy = model.isFieldEnergyMode;
-    var localLoopback = model.isLocalLoopbackEnabled;
-
-    await showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (sheetContext) {
-        return StatefulBuilder(
-          builder: (sheetContext, setSheetState) {
-            return SafeArea(
-              child: Container(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.sizeOf(sheetContext).height * 0.82,
-                ),
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
-                decoration: const BoxDecoration(
-                  color: Color(0xFF17212B),
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Center(child: _SheetHandle()),
-                    const SizedBox(height: 14),
-                    const Text(
-                      '全球法布施设置',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 19,
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    SwitchListTile(
-                      value: globalEnabled,
-                      onChanged: (value) => setSheetState(() => globalEnabled = value),
-                      title: const Text('全球/国家节点', style: TextStyle(color: Colors.white)),
-                      subtitle: const Text('开启后可选择全部国家或指定国家', style: TextStyle(color: Color(0xFF91A3B7))),
-                    ),
-                    SwitchListTile(
-                      value: fieldEnergy,
-                      onChanged: (value) => setSheetState(() => fieldEnergy = value),
-                      title: const Text('本地场能', style: TextStyle(color: Colors.white)),
-                      subtitle: const Text('无网场景下使用本地广播', style: TextStyle(color: Color(0xFF91A3B7))),
-                    ),
-                    SwitchListTile(
-                      value: localLoopback,
-                      onChanged: (value) => setSheetState(() => localLoopback = value),
-                      title: const Text('本地转经轮', style: TextStyle(color: Colors.white)),
-                      subtitle: const Text('在本机持续运行回环法布施', style: TextStyle(color: Color(0xFF91A3B7))),
-                    ),
-                    const Divider(color: Color(0xFF263445)),
-                    Row(
-                      children: [
-                        TextButton(
-                          onPressed: () => setSheetState(() {
-                            selectedCountries
-                              ..clear()
-                              ..add('ALL');
-                          }),
-                          child: const Text('全球'),
-                        ),
-                        TextButton(
-                          onPressed: () => setSheetState(selectedCountries.clear),
-                          child: const Text('清空国家'),
-                        ),
-                      ],
-                    ),
-                    Expanded(
-                      child: ListView(
-                        children: [
-                          for (final entry in _countryOptions)
-                            CheckboxListTile(
-                              value: selectedCountries.contains('ALL') ||
-                                  selectedCountries.contains(entry.key),
-                              onChanged: selectedCountries.contains('ALL')
-                                  ? null
-                                  : (value) => setSheetState(() {
-                                        if (value == true) {
-                                          selectedCountries.add(entry.key);
-                                        } else {
-                                          selectedCountries.remove(entry.key);
-                                        }
-                                      }),
-                              title: Text(entry.value, style: const TextStyle(color: Colors.white)),
-                              dense: true,
-                            ),
-                        ],
-                      ),
-                    ),
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton(
-                        onPressed: () async {
-                          model.setGlobalSendEnabled(globalEnabled);
-                          model.setCountryList(selectedCountries.toList());
-                          await model.setFieldEnergyMode(fieldEnergy);
-                          model.setLocalLoopbackEnabled(localLoopback);
-                          if (mounted) setState(() {});
-                          if (sheetContext.mounted) Navigator.pop(sheetContext);
-                        },
-                        child: const Text('完成'),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        );
-      },
-    );
-  }
-
-  List<MapEntry<String, String>> get _countryOptions {
-    final entries = country_catalog.GLOBAL_COUNTRY_SERVERS.keys
-        .map((code) => MapEntry(code, country_catalog.COUNTRY_NAMES[code] ?? code))
-        .toList();
-    entries.sort((a, b) => a.value.compareTo(b.value));
-    return entries;
-  }
-
-  String _regionSummary(FileTransferModel model) {
-    final labels = <String>[];
-    if (model.isGlobalSendEnabled && model.countryList.isNotEmpty) {
-      if (model.countryList.contains('ALL')) {
-        labels.add('全球');
-      } else {
-        final names = model.countryList
-            .map((code) => country_catalog.COUNTRY_NAMES[code] ?? code)
-            .take(2)
-            .toList();
-        labels.add(model.countryList.length > 2
-            ? '${names.join('、')} 等 ${model.countryList.length} 个'
-            : names.join('、'));
-      }
-    }
-    if (model.isFieldEnergyMode) labels.add('本地场能');
-    if (model.isLocalLoopbackEnabled) labels.add('本地转经轮');
-    return labels.isEmpty ? '未选择' : labels.join('、');
+  Future<void> _showRegionSettings(FileTransferModel model) async {
+    var global = model.isGlobalSendEnabled;
+    var local = model.isLocalLoopbackEnabled;
+    var field = model.isFieldEnergyMode;
+    await showModalBottomSheet<void>(context: context, backgroundColor: Colors.transparent, builder: (ctx) {
+      return StatefulBuilder(builder: (ctx, setSheetState) => _BottomPanel(children: [
+        const Text('全球法布施设置', style: TextStyle(color: Colors.white, fontSize: 19, fontWeight: FontWeight.w900)),
+        SwitchListTile(value: global, onChanged: (v) => setSheetState(() => global = v), title: const Text('全球节点', style: TextStyle(color: Colors.white))),
+        SwitchListTile(value: field, onChanged: (v) => setSheetState(() => field = v), title: const Text('本地场能', style: TextStyle(color: Colors.white))),
+        SwitchListTile(value: local, onChanged: (v) => setSheetState(() => local = v), title: const Text('本地转经轮', style: TextStyle(color: Colors.white))),
+        FilledButton(onPressed: () async { model.setGlobalSendEnabled(global); model.setCountryList(global ? ['ALL'] : const []); await model.setFieldEnergyMode(field); model.setLocalLoopbackEnabled(local); if (mounted) setState(() {}); if (ctx.mounted) Navigator.pop(ctx); }, child: const Text('完成')),
+      ]));
+    });
   }
 
   String _platformSummary() {
-    if (_selectedPublishPlatforms.isEmpty) return '未选择';
-    final labels = _selectedPublishPlatforms.map((p) => p.info.shortLabel).toList();
-    if (labels.length <= 2) return labels.join('、');
-    return '${labels.take(2).join('、')} 等 ${labels.length} 个';
+    if (_platforms.isEmpty) return '未选择';
+    final labels = _platforms.map((p) => p.info.shortLabel).toList();
+    return labels.length <= 2 ? labels.join('、') : '${labels.take(2).join('、')} 等 ${labels.length} 个';
   }
 
-  void _openFlashcardDeck(FlashcardDeck deck) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => FlashcardStudyScreen(
-          deck: deck,
-          repository: _flashcardRepository,
-        ),
-      ),
-    );
+  void _addBotMessage(String text) { setState(() => _botMessages.add(_ChatMessage.bot(text))); _scrollBottom(); }
+
+  void _openDeck(FlashcardDeck deck) {
+    Navigator.push(context, MaterialPageRoute(builder: (_) => FlashcardStudyScreen(deck: deck, repository: _flashcardRepository)));
   }
 
-  void _scrollToBottom() {
+  void _scrollBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!_scrollController.hasClients) return;
-      _scrollController.animateTo(
-        _scrollController.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 220),
-        curve: Curves.easeOut,
-      );
+      if (!_scroll.hasClients) return;
+      _scroll.animateTo(_scroll.position.maxScrollExtent, duration: const Duration(milliseconds: 220), curve: Curves.easeOut);
     });
   }
 }
 
-class _SocialChatMessage {
-  _SocialChatMessage({
-    required this.text,
-    required this.isUser,
-    this.isError = false,
-    this.deck,
-  });
-
+class _ChatMessage {
+  _ChatMessage(this.text, {required this.isUser, this.isError = false, this.deck});
   String text;
   final bool isUser;
   final bool isError;
   final FlashcardDeck? deck;
-
-  factory _SocialChatMessage.user(String text) =>
-      _SocialChatMessage(text: text, isUser: true);
-  factory _SocialChatMessage.bot(String text) =>
-      _SocialChatMessage(text: text, isUser: false);
-  factory _SocialChatMessage.error(String text) =>
-      _SocialChatMessage(text: text, isUser: false, isError: true);
-  factory _SocialChatMessage.deck(String text, FlashcardDeck deck) =>
-      _SocialChatMessage(text: text, isUser: false, deck: deck);
+  factory _ChatMessage.user(String text) => _ChatMessage(text, isUser: true);
+  factory _ChatMessage.bot(String text) => _ChatMessage(text, isUser: false);
+  factory _ChatMessage.error(String text) => _ChatMessage(text, isUser: false, isError: true);
+  factory _ChatMessage.deck(String text, FlashcardDeck deck) => _ChatMessage(text, isUser: false, deck: deck);
 }
 
 class _MessageBubble extends StatelessWidget {
-  const _MessageBubble({
-    required this.message,
-    required this.bot,
-    required this.onOpenDeck,
-  });
-
-  final _SocialChatMessage message;
+  const _MessageBubble({required this.message, required this.bot, required this.onDeck});
+  final _ChatMessage message;
   final SocialFeatureBot bot;
-  final ValueChanged<FlashcardDeck> onOpenDeck;
-
+  final ValueChanged<FlashcardDeck> onDeck;
   @override
   Widget build(BuildContext context) {
-    final isUser = message.isUser;
+    final user = message.isUser;
     return Align(
-      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      alignment: user ? Alignment.centerRight : Alignment.centerLeft,
       child: Container(
         margin: const EdgeInsets.only(bottom: 14),
         constraints: const BoxConstraints(maxWidth: 620),
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
         decoration: BoxDecoration(
-          color: isUser
-              ? const Color(0xFF2B5278)
-              : message.isError
-                  ? const Color(0xFF4B2028)
-                  : const Color(0xFF182433),
-          borderRadius: BorderRadius.only(
-            topLeft: const Radius.circular(18),
-            topRight: const Radius.circular(18),
-            bottomLeft: Radius.circular(isUser ? 18 : 6),
-            bottomRight: Radius.circular(isUser ? 6 : 18),
-          ),
-          border: Border.all(
-            color: message.isError ? const Color(0xFF7A3340) : const Color(0xFF263445),
-          ),
+          color: user ? const Color(0xFF2B5278) : message.isError ? const Color(0xFF4B2028) : const Color(0xFF182433),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: const Color(0xFF263445)),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (!isUser)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 6),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    CircleAvatar(
-                      radius: 11,
-                      backgroundColor: bot.avatarColor,
-                      child: Icon(bot.icon, color: Colors.white, size: 13),
-                    ),
-                    const SizedBox(width: 7),
-                    Text(
-                      bot.title,
-                      style: const TextStyle(
-                        color: Color(0xFF91A3B7),
-                        fontSize: 12,
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            Text(
-              message.text,
-              style: TextStyle(
-                color: message.isError ? const Color(0xFFFFD4D8) : Colors.white,
-                fontSize: 15,
-                height: 1.48,
-                fontWeight: isUser ? FontWeight.w700 : FontWeight.w500,
-              ),
-            ),
-            if (message.deck != null) ...[
-              const SizedBox(height: 12),
-              FilledButton.icon(
-                onPressed: () => onOpenDeck(message.deck!),
-                icon: const Icon(Icons.play_arrow_rounded),
-                label: const Text('开始背诵'),
-              ),
-            ],
-          ],
-        ),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, mainAxisSize: MainAxisSize.min, children: [
+          if (!user) Padding(padding: const EdgeInsets.only(bottom: 6), child: Text(bot.title, style: const TextStyle(color: Color(0xFF91A3B7), fontSize: 12, fontWeight: FontWeight.w800))),
+          Text(message.text, style: TextStyle(color: message.isError ? const Color(0xFFFFD4D8) : Colors.white, fontSize: 15, height: 1.48, fontWeight: user ? FontWeight.w700 : FontWeight.w500)),
+          if (message.deck != null) Padding(padding: const EdgeInsets.only(top: 12), child: FilledButton.icon(onPressed: () => onDeck(message.deck!), icon: const Icon(Icons.play_arrow_rounded), label: const Text('开始背诵'))),
+        ]),
       ),
     );
   }
@@ -1122,142 +478,43 @@ class _MessageBubble extends StatelessWidget {
 
 class _ThinkingBubble extends StatelessWidget {
   const _ThinkingBubble({required this.label});
-
   final String label;
-
   @override
-  Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: Container(
-        constraints: const BoxConstraints(maxWidth: 430),
-        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 12),
-        decoration: BoxDecoration(
-          color: const Color(0xFF182433),
-          borderRadius: BorderRadius.circular(18),
-          border: Border.all(color: const Color(0xFF263445)),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const SizedBox(
-              width: 16,
-              height: 16,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
-            const SizedBox(width: 10),
-            Flexible(
-              child: Text(
-                label,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => Align(alignment: Alignment.centerLeft, child: Container(margin: const EdgeInsets.only(bottom: 14), padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 12), decoration: BoxDecoration(color: const Color(0xFF182433), borderRadius: BorderRadius.circular(18), border: Border.all(color: const Color(0xFF263445))), child: Row(mainAxisSize: MainAxisSize.min, children: [const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)), const SizedBox(width: 10), Flexible(child: Text(label, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700)))])));
+}
+
+class _GlobalProgress extends StatelessWidget {
+  const _GlobalProgress({required this.model});
+  final FileTransferModel model;
+  @override
+  Widget build(BuildContext context) => Align(alignment: Alignment.centerLeft, child: Container(margin: const EdgeInsets.only(bottom: 14), padding: const EdgeInsets.all(14), decoration: BoxDecoration(color: const Color(0xFF182433), borderRadius: BorderRadius.circular(18), border: Border.all(color: const Color(0xFF263445))), child: Text(model.isPreparingSend ? model.preparingSendMessage : '已传播 ${model.globalSentCount} 个节点 · ${model.globalDataSentMB.toStringAsFixed(2)} MB', style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700))));
 }
 
 class _ControlPill extends StatelessWidget {
-  const _ControlPill({
-    required this.icon,
-    required this.label,
-    required this.active,
-    required this.onTap,
-  });
-
+  const _ControlPill({required this.icon, required this.label, required this.active, required this.onTap});
   final IconData icon;
   final String label;
   final bool active;
   final VoidCallback? onTap;
-
   @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(999),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        decoration: BoxDecoration(
-          color: active ? const Color(0xFF253A52) : const Color(0xFF172432),
-          borderRadius: BorderRadius.circular(999),
-          border: Border.all(
-            color: active ? const Color(0xFF3F8FE5) : const Color(0xFF263445),
-          ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(icon, color: const Color(0xFF9EC7FF), size: 17),
-            const SizedBox(width: 7),
-            Text(
-              label,
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 13,
-                fontWeight: FontWeight.w800,
-              ),
-            ),
-            if (onTap != null) ...[
-              const SizedBox(width: 4),
-              const Icon(Icons.keyboard_arrow_down, color: Color(0xFF91A3B7), size: 16),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => InkWell(onTap: onTap, borderRadius: BorderRadius.circular(999), child: Container(padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8), decoration: BoxDecoration(color: active ? const Color(0xFF253A52) : const Color(0xFF172432), borderRadius: BorderRadius.circular(999), border: Border.all(color: active ? const Color(0xFF3F8FE5) : const Color(0xFF263445))), child: Row(mainAxisSize: MainAxisSize.min, children: [Icon(icon, color: const Color(0xFF9EC7FF), size: 17), const SizedBox(width: 7), Text(label, style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w800)), if (onTap != null) const Icon(Icons.keyboard_arrow_down, color: Color(0xFF91A3B7), size: 16)])));
 }
 
 class _ModeTile extends StatelessWidget {
-  const _ModeTile({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    required this.selected,
-    required this.onTap,
-  });
-
+  const _ModeTile({required this.icon, required this.title, required this.subtitle, required this.selected, required this.onTap});
   final IconData icon;
   final String title;
   final String subtitle;
   final bool selected;
   final VoidCallback onTap;
-
   @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      onTap: onTap,
-      leading: CircleAvatar(
-        backgroundColor: selected ? const Color(0xFF3390EC) : const Color(0xFF253445),
-        child: Icon(icon, color: Colors.white),
-      ),
-      title: Text(
-        title,
-        style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900),
-      ),
-      subtitle: Text(subtitle, style: const TextStyle(color: Color(0xFF91A3B7))),
-      trailing: selected ? const Icon(Icons.check_circle, color: Color(0xFF4DDE7A)) : null,
-    );
-  }
+  Widget build(BuildContext context) => ListTile(onTap: onTap, leading: CircleAvatar(backgroundColor: selected ? const Color(0xFF3390EC) : const Color(0xFF253445), child: Icon(icon, color: Colors.white)), title: Text(title, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900)), subtitle: Text(subtitle, style: const TextStyle(color: Color(0xFF91A3B7))), trailing: selected ? const Icon(Icons.check_circle, color: Color(0xFF4DDE7A)) : null);
 }
 
-class _SheetHandle extends StatelessWidget {
-  const _SheetHandle();
-
+class _BottomPanel extends StatelessWidget {
+  const _BottomPanel({required this.children, this.maxHeightFactor});
+  final List<Widget> children;
+  final double? maxHeightFactor;
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 42,
-      height: 4,
-      decoration: BoxDecoration(
-        color: const Color(0xFF6E7F92),
-        borderRadius: BorderRadius.circular(999),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => SafeArea(child: Container(constraints: maxHeightFactor == null ? null : BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * maxHeightFactor!), padding: const EdgeInsets.fromLTRB(18, 12, 18, 18), decoration: const BoxDecoration(color: Color(0xFF17212B), borderRadius: BorderRadius.vertical(top: Radius.circular(24))), child: Column(mainAxisSize: MainAxisSize.min, crossAxisAlignment: CrossAxisAlignment.stretch, children: [Center(child: Container(width: 42, height: 4, decoration: BoxDecoration(color: const Color(0xFF6E7F92), borderRadius: BorderRadius.circular(999)))), const SizedBox(height: 12), ...children])));
 }

--- a/fabushi/lib/screens/social_feature_chat_screen.dart
+++ b/fabushi/lib/screens/social_feature_chat_screen.dart
@@ -1,0 +1,1263 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../core/constants/country_servers.dart' as country_catalog;
+import '../features/auth/application/auth_model.dart';
+import '../features/flashcards/application/content_pipeline.dart';
+import '../features/flashcards/application/flashcard_service.dart';
+import '../features/flashcards/data/flashcard_repository.dart';
+import '../features/flashcards/domain/flashcard_models.dart';
+import '../features/flashcards/presentation/flashcard_study_screen.dart';
+import '../models/file_transfer_model.dart'
+    if (dart.library.html) '../models/file_transfer_model_web.dart';
+import '../services/dacheng_ai_service.dart';
+import '../services/dharma_publish_service.dart';
+import '../widgets/social/social_feature_bot.dart';
+
+class SocialFeatureChatScreen extends StatefulWidget {
+  const SocialFeatureChatScreen({super.key, required this.botType});
+
+  final SocialFeatureBotType botType;
+
+  @override
+  State<SocialFeatureChatScreen> createState() => _SocialFeatureChatScreenState();
+}
+
+class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
+  final TextEditingController _composerController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final Map<SocialFeatureBotType, List<_SocialChatMessage>> _messagesByBot = {};
+
+  late final FlashcardRepository _flashcardRepository;
+  late final ContentPipeline _contentPipeline;
+  late final FlashcardService _flashcardService;
+  final DharmaPublishService _dharmaPublishService = DharmaPublishService();
+
+  FlashcardCreationMode _flashcardMode = FlashcardCreationMode.randomCloze;
+  final Set<DharmaPublishPlatform> _selectedPublishPlatforms = {
+    DharmaPublishPlatform.xiaohongshu,
+  };
+  bool _isBusy = false;
+  String _activityText = '';
+
+  List<_SocialChatMessage> get _messages =>
+      _messagesByBot.putIfAbsent(widget.botType, () => []);
+
+  SocialFeatureBot get _bot => widget.botType.bot;
+
+  @override
+  void initState() {
+    super.initState();
+    _flashcardRepository = FlashcardRepository();
+    _contentPipeline = ContentPipeline(repository: _flashcardRepository);
+    _flashcardService = FlashcardService(
+      repository: _flashcardRepository,
+      aiService: DachengAiService(),
+    );
+    _ensureGreeting(widget.botType);
+  }
+
+  @override
+  void didUpdateWidget(covariant SocialFeatureChatScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.botType != widget.botType) {
+      _composerController.clear();
+      _activityText = '';
+      _ensureGreeting(widget.botType);
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+    }
+  }
+
+  @override
+  void dispose() {
+    _composerController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _ensureGreeting(SocialFeatureBotType botType) {
+    final list = _messagesByBot.putIfAbsent(botType, () => []);
+    if (list.isNotEmpty) return;
+    list.add(_SocialChatMessage.bot(botType.bot.greeting));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final model = Provider.of<FileTransferModel>(context);
+    final canSend = !_isBusy && _canSubmit(model);
+
+    return Container(
+      color: const Color(0xFF0F1722),
+      child: SafeArea(
+        child: Column(
+          children: [
+            _buildHeader(model),
+            _buildModeBar(model),
+            Expanded(child: _buildMessageList(model)),
+            _buildComposer(model, canSend: canSend),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(FileTransferModel model) {
+    return Container(
+      height: 74,
+      padding: const EdgeInsets.symmetric(horizontal: 22),
+      decoration: const BoxDecoration(
+        color: Color(0xFF17212B),
+        border: Border(bottom: BorderSide(color: Color(0xFF223040))),
+      ),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 24,
+            backgroundColor: _bot.avatarColor,
+            child: Icon(_bot.icon, color: Colors.white, size: 25),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _bot.title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  _statusLine(model),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF91A3B7),
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            tooltip: '搜索联系人',
+            onPressed: () => _appendBotNotice('请在左侧联系人栏右上角搜索并添加好友。'),
+            icon: const Icon(Icons.search, color: Color(0xFF91A3B7)),
+          ),
+          IconButton(
+            tooltip: '更多设置',
+            onPressed: () => _showModeSheet(model),
+            icon: const Icon(Icons.tune, color: Color(0xFF91A3B7)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _statusLine(FileTransferModel model) {
+    switch (widget.botType) {
+      case SocialFeatureBotType.globalDharma:
+        if (model.isPreparingSend) return model.preparingSendMessage;
+        if (model.isTransferring) return '正在全球法布施 · ${_regionSummary(model)}';
+        return 'bot · ${_regionSummary(model)} · ${model.isLooping ? "循环" : "单轮"}';
+      case SocialFeatureBotType.flashcards:
+        return 'bot · 当前模式：${_flashcardMode.label}';
+      case SocialFeatureBotType.platformPublish:
+        return 'bot · 发布平台：${_platformSummary()}';
+      case SocialFeatureBotType.assistant:
+        return 'bot · 大乘助理';
+    }
+  }
+
+  Widget _buildModeBar(FileTransferModel model) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 10),
+      decoration: const BoxDecoration(
+        color: Color(0xFF111B26),
+        border: Border(bottom: BorderSide(color: Color(0xFF1F2B38))),
+      ),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: switch (widget.botType) {
+          SocialFeatureBotType.globalDharma => [
+              _ControlPill(
+                icon: Icons.public,
+                label: '地区 ${_regionSummary(model)}',
+                active: true,
+                onTap: _isBusy ? null : () => _showRegionSelector(model),
+              ),
+              _ControlPill(
+                icon: Icons.loop,
+                label: model.isLooping ? '循环发送' : '单轮发送',
+                active: model.isLooping,
+                onTap: _isBusy
+                    ? null
+                    : () {
+                        model.setLooping(!model.isLooping);
+                        setState(() {});
+                      },
+              ),
+              _ControlPill(
+                icon: Icons.folder_outlined,
+                label: model.hasFiles
+                    ? (model.selectedContentTitle.isEmpty
+                        ? '已选择素材'
+                        : model.selectedContentTitle)
+                    : '添加素材',
+                active: model.hasFiles,
+                onTap: _isBusy ? null : () => unawaited(model.selectFiles()),
+              ),
+            ],
+          SocialFeatureBotType.flashcards => [
+              _ControlPill(
+                icon: _flashcardMode == FlashcardCreationMode.aiCards
+                    ? Icons.auto_awesome
+                    : Icons.auto_fix_high,
+                label: '模式 ${_flashcardMode.label}',
+                active: true,
+                onTap: _isBusy ? null : _showFlashcardModeSelector,
+              ),
+              _ControlPill(
+                icon: Icons.help_outline,
+                label: _flashcardMode == FlashcardCreationMode.aiCards
+                    ? '可输入制卡要求'
+                    : '本地随机挖空',
+                active: false,
+                onTap: null,
+              ),
+            ],
+          SocialFeatureBotType.platformPublish => [
+              _ControlPill(
+                icon: Icons.campaign_outlined,
+                label: '平台 ${_platformSummary()}',
+                active: _selectedPublishPlatforms.isNotEmpty,
+                onTap: _isBusy ? null : _showPublishPlatformSelector,
+              ),
+              _ControlPill(
+                icon: Icons.content_paste_go_outlined,
+                label: '复制草稿并打开入口',
+                active: true,
+                onTap: null,
+              ),
+            ],
+          SocialFeatureBotType.assistant => [
+              const _ControlPill(
+                icon: Icons.smart_toy_outlined,
+                label: '助理模式',
+                active: true,
+                onTap: null,
+              ),
+            ],
+        },
+      ),
+    );
+  }
+
+  Widget _buildMessageList(FileTransferModel model) {
+    return ListView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.fromLTRB(28, 20, 28, 24),
+      itemCount: _messages.length + (_isBusy ? 1 : 0) +
+          (widget.botType == SocialFeatureBotType.globalDharma &&
+                  (model.isPreparingSend || model.isTransferring)
+              ? 1
+              : 0),
+      itemBuilder: (context, index) {
+        if (index < _messages.length) {
+          return _MessageBubble(
+            message: _messages[index],
+            bot: _bot,
+            onOpenDeck: _openFlashcardDeck,
+          );
+        }
+
+        final busyIndex = _messages.length;
+        if (_isBusy && index == busyIndex) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 14),
+            child: _ThinkingBubble(
+              label: _activityText.trim().isEmpty ? '正在处理' : _activityText,
+            ),
+          );
+        }
+
+        return _buildGlobalProgressCard(model);
+      },
+    );
+  }
+
+  Widget _buildGlobalProgressCard(FileTransferModel model) {
+    final successCount = model.countryStatuses
+        .where((status) => status.status == SendStatus.success)
+        .length;
+    final total = model.countryStatuses.length;
+    final label = model.isPreparingSend
+        ? model.preparingSendMessage
+        : model.isTransferring
+            ? '正在发送：$successCount / $total'
+            : '正在整理发送状态';
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 14),
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+        constraints: const BoxConstraints(maxWidth: 430),
+        decoration: BoxDecoration(
+          color: const Color(0xFF182433),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: const Color(0xFF2A3A4A)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    label,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              '已传播 ${model.globalSentCount} 个节点 · ${model.globalDataSentMB.toStringAsFixed(2)} MB',
+              style: const TextStyle(color: Color(0xFF91A3B7), fontSize: 13),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComposer(FileTransferModel model, {required bool canSend}) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 10, 20, 18),
+      decoration: const BoxDecoration(
+        color: Color(0xFF17212B),
+        border: Border(top: BorderSide(color: Color(0xFF223040))),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          IconButton(
+            tooltip: widget.botType == SocialFeatureBotType.flashcards
+                ? '闪卡模式'
+                : '添加素材',
+            onPressed: _isBusy
+                ? null
+                : widget.botType == SocialFeatureBotType.flashcards
+                    ? _showFlashcardModeSelector
+                    : () => unawaited(model.selectFiles()),
+            icon: const Icon(Icons.add_circle_outline, color: Color(0xFF91A3B7)),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              controller: _composerController,
+              enabled: !_isBusy,
+              minLines: 1,
+              maxLines: 5,
+              textInputAction: TextInputAction.send,
+              style: const TextStyle(color: Colors.white, fontSize: 15, height: 1.4),
+              cursorColor: Colors.white,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: const Color(0xFF101923),
+                hintText: _bot.inputHint,
+                hintStyle: const TextStyle(color: Color(0xFF6E7F92)),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(22),
+                  borderSide: const BorderSide(color: Color(0xFF263445)),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(22),
+                  borderSide: const BorderSide(color: Color(0xFF263445)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(22),
+                  borderSide: const BorderSide(color: Color(0xFF4F9DFF)),
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
+              ),
+              onChanged: (_) => setState(() {}),
+              onSubmitted: (_) {
+                if (canSend) _submit(model);
+              },
+            ),
+          ),
+          const SizedBox(width: 10),
+          IconButton.filled(
+            tooltip: '发送',
+            onPressed: canSend ? () => _submit(model) : null,
+            style: IconButton.styleFrom(
+              backgroundColor: const Color(0xFF3390EC),
+              disabledBackgroundColor: const Color(0xFF263445),
+            ),
+            icon: Icon(
+              _isBusy ? Icons.more_horiz : Icons.arrow_upward,
+              color: Colors.white,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _canSubmit(FileTransferModel model) {
+    final text = _composerController.text.trim();
+    switch (widget.botType) {
+      case SocialFeatureBotType.globalDharma:
+        return text.isNotEmpty || model.hasFiles;
+      case SocialFeatureBotType.flashcards:
+        return text.isNotEmpty;
+      case SocialFeatureBotType.platformPublish:
+        return _selectedPublishPlatforms.isNotEmpty && (text.isNotEmpty || model.hasFiles);
+      case SocialFeatureBotType.assistant:
+        return text.isNotEmpty;
+    }
+  }
+
+  void _submit(FileTransferModel model) {
+    switch (widget.botType) {
+      case SocialFeatureBotType.globalDharma:
+        unawaited(_startGlobalDharma(model));
+      case SocialFeatureBotType.flashcards:
+        unawaited(_startFlashcardGeneration());
+      case SocialFeatureBotType.platformPublish:
+        unawaited(_startPlatformPublish(model));
+      case SocialFeatureBotType.assistant:
+        _appendBotNotice('大乘助理仍保留在原有 OpenClaw 工作台能力中。');
+    }
+  }
+
+  Future<void> _startGlobalDharma(FileTransferModel model) async {
+    if (_isBusy || model.isTransferring) return;
+    final text = _composerController.text.trim();
+    _composerController.clear();
+    setState(() {
+      if (text.isNotEmpty) _messages.add(_SocialChatMessage.user(text));
+      _isBusy = true;
+      _activityText = '正在准备全球法布施素材...';
+    });
+    _scrollToBottom();
+
+    try {
+      if (text.isNotEmpty) {
+        await model.addTextContentForSending(
+          title: _titleFromText(text, fallback: '全球法布施'),
+          text: text,
+          sourceKind: '文本',
+          replaceExisting: !model.hasFiles,
+        );
+      }
+      if (!model.hasFiles) {
+        throw StateError('请先输入文字/链接，或点击 + 添加素材。');
+      }
+      setState(() => _activityText = '正在启动全球发送...');
+      await model.startGlobalTransfer();
+      if (!mounted) return;
+      setState(() {
+        _messages.add(
+          _SocialChatMessage.bot(
+            '本次全球法布施已完成：${model.globalSentCount} 个节点，${model.globalDataSentMB.toStringAsFixed(2)} MB。',
+          ),
+        );
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _messages.add(_SocialChatMessage.error('启动失败：$error')));
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isBusy = false;
+        _activityText = '';
+      });
+      _scrollToBottom();
+    }
+  }
+
+  Future<void> _startFlashcardGeneration() async {
+    if (_isBusy) return;
+    final text = _composerController.text.trim();
+    if (text.isEmpty) return;
+    _composerController.clear();
+    final progressMessage = _SocialChatMessage.bot('正在准备内容...');
+    setState(() {
+      _messages.add(_SocialChatMessage.user(text));
+      _messages.add(progressMessage);
+      _isBusy = true;
+      _activityText = '正在提取正文...';
+    });
+    _scrollToBottom();
+
+    try {
+      final content = await _contentPipeline.prepare(
+        ContentInput(
+          text: text,
+          url: ContentPipeline.firstHttpUrl(text),
+          title: ContentPipeline.firstHttpUrl(text) == null ? '背诵内容' : '链接内容',
+          sourceType: ContentPipeline.firstHttpUrl(text) == null
+              ? 'composer_text'
+              : 'composer_url',
+        ),
+      );
+      if (content.isFailed) {
+        throw StateError(content.errorMessage ?? '内容提取失败');
+      }
+
+      final authModel = Provider.of<AuthModel?>(context, listen: false);
+      final input = FlashcardInput(
+        title: content.title,
+        text: content.text,
+        documentId: content.document?.id,
+        sourceUrl: content.sourceUrl,
+      );
+      final stream = _flashcardMode == FlashcardCreationMode.aiCards
+          ? _flashcardService.generateAiCardsStream(
+              input,
+              token: authModel?.authToken,
+              username: authModel?.currentUser?.username,
+              isMember: authModel?.hasPermission('premium') ?? false,
+            )
+          : _flashcardService.generateRandomClozeStream(input);
+
+      await for (final event in stream) {
+        if (!mounted) return;
+        setState(() {
+          _activityText = event.message;
+          progressMessage.text = event.progress > 0
+              ? '${event.message} (${event.progress}%)'
+              : event.message;
+        });
+        _scrollToBottom();
+        if (event.isDone && event.deck != null) {
+          setState(() {
+            _messages.add(
+              _SocialChatMessage.deck(
+                '制卡完成：${event.deck!.cardCount} 张 · ${event.deck!.mode.label}',
+                event.deck!,
+              ),
+            );
+          });
+        }
+        if (event.isError) {
+          throw StateError(event.message);
+        }
+      }
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _messages.add(_SocialChatMessage.error('制卡失败：$error')));
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isBusy = false;
+        _activityText = '';
+      });
+      _scrollToBottom();
+    }
+  }
+
+  Future<void> _startPlatformPublish(FileTransferModel model) async {
+    if (_isBusy) return;
+    final text = _composerController.text.trim();
+    _composerController.clear();
+    setState(() {
+      if (text.isNotEmpty) _messages.add(_SocialChatMessage.user(text));
+      _isBusy = true;
+      _activityText = '正在整理发布草稿...';
+    });
+    _scrollToBottom();
+
+    try {
+      if (text.isNotEmpty) {
+        final uri = Uri.tryParse(text);
+        if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+          await model.addUrlContentForSending(text);
+        } else {
+          await model.addTextContentForSending(
+            title: _titleFromText(text, fallback: '法布施发布'),
+            text: text,
+            sourceKind: '文本',
+            replaceExisting: true,
+          );
+        }
+      }
+      if (!model.hasFiles && text.isEmpty) {
+        throw StateError('请先输入要发布的文字/链接，或点击 + 添加素材。');
+      }
+
+      var draft = _dharmaPublishService.buildDraftFromModel(
+        model,
+        fallbackText: text,
+      );
+      if (draft.title.trim().isEmpty) {
+        draft = draft.copyWith(title: _dharmaPublishService.suggestTitle(draft));
+      }
+      if (draft.body.trim().length < 12) {
+        draft = draft.copyWith(body: _dharmaPublishService.polishBody(draft));
+      }
+
+      setState(() {
+        _messages.add(
+          _SocialChatMessage.bot(
+            _dharmaPublishService.buildPreviewMarkdown(
+              draft,
+              _selectedPublishPlatforms,
+            ),
+          ),
+        );
+        _activityText = '正在复制草稿并打开平台入口...';
+      });
+
+      final results = await _dharmaPublishService.publishDraft(
+        draft: draft,
+        platforms: _selectedPublishPlatforms,
+      );
+      if (!mounted) return;
+      final summary = results
+          .map((result) => '${result.platform.info.shortLabel}：${result.message}')
+          .join('\n');
+      setState(() => _messages.add(_SocialChatMessage.bot(summary)));
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _messages.add(_SocialChatMessage.error('发布失败：$error')));
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isBusy = false;
+        _activityText = '';
+      });
+      _scrollToBottom();
+    }
+  }
+
+  String _titleFromText(String text, {required String fallback}) {
+    final normalized = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (normalized.isEmpty) return fallback;
+    return normalized.length <= 18 ? normalized : normalized.substring(0, 18);
+  }
+
+  void _appendBotNotice(String text) {
+    setState(() => _messages.add(_SocialChatMessage.bot(text)));
+    _scrollToBottom();
+  }
+
+  void _showModeSheet(FileTransferModel model) {
+    switch (widget.botType) {
+      case SocialFeatureBotType.globalDharma:
+        unawaited(_showRegionSelector(model));
+      case SocialFeatureBotType.flashcards:
+        _showFlashcardModeSelector();
+      case SocialFeatureBotType.platformPublish:
+        unawaited(_showPublishPlatformSelector());
+      case SocialFeatureBotType.assistant:
+        _appendBotNotice('暂无更多设置。');
+    }
+  }
+
+  void _showFlashcardModeSelector() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
+            decoration: const BoxDecoration(
+              color: Color(0xFF17212B),
+              borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const _SheetHandle(),
+                const SizedBox(height: 8),
+                _ModeTile(
+                  icon: Icons.auto_fix_high,
+                  title: '随机挖空',
+                  subtitle: '本地快速生成，无需 AI。',
+                  selected: _flashcardMode == FlashcardCreationMode.randomCloze,
+                  onTap: () {
+                    setState(() => _flashcardMode = FlashcardCreationMode.randomCloze);
+                    Navigator.pop(sheetContext);
+                  },
+                ),
+                _ModeTile(
+                  icon: Icons.auto_awesome,
+                  title: 'AI 制卡',
+                  subtitle: '按要求生成问答/挖空卡，失败会自动回退。',
+                  selected: _flashcardMode == FlashcardCreationMode.aiCards,
+                  onTap: () {
+                    setState(() => _flashcardMode = FlashcardCreationMode.aiCards);
+                    Navigator.pop(sheetContext);
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showPublishPlatformSelector() async {
+    final selected = Set<DharmaPublishPlatform>.from(_selectedPublishPlatforms);
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (sheetContext, setSheetState) {
+            return SafeArea(
+              child: Container(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.sizeOf(sheetContext).height * 0.78,
+                ),
+                padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF17212B),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Center(child: _SheetHandle()),
+                    const SizedBox(height: 14),
+                    Row(
+                      children: [
+                        const Expanded(
+                          child: Text(
+                            '选择发布平台',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 19,
+                              fontWeight: FontWeight.w900,
+                            ),
+                          ),
+                        ),
+                        TextButton(
+                          onPressed: () => setSheetState(() {
+                            selected
+                              ..clear()
+                              ..addAll(DharmaPublishService.allPlatforms);
+                          }),
+                          child: const Text('全选'),
+                        ),
+                        TextButton(
+                          onPressed: () => setSheetState(selected.clear),
+                          child: const Text('清空'),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Expanded(
+                      child: ListView(
+                        children: [
+                          for (final platform in DharmaPublishService.allPlatforms)
+                            CheckboxListTile(
+                              value: selected.contains(platform),
+                              onChanged: (value) => setSheetState(() {
+                                if (value == true) {
+                                  selected.add(platform);
+                                } else {
+                                  selected.remove(platform);
+                                }
+                              }),
+                              activeColor: const Color(0xFF3390EC),
+                              checkColor: Colors.white,
+                              title: Text(
+                                platform.info.label,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                              subtitle: Text(
+                                platform.info.description,
+                                style: const TextStyle(color: Color(0xFF91A3B7)),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
+                        onPressed: selected.isEmpty
+                            ? null
+                            : () {
+                                setState(() {
+                                  _selectedPublishPlatforms
+                                    ..clear()
+                                    ..addAll(selected);
+                                });
+                                Navigator.pop(sheetContext);
+                              },
+                        child: const Text('完成'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _showRegionSelector(FileTransferModel model) async {
+    final selectedCountries = Set<String>.from(model.countryList);
+    var globalEnabled = model.isGlobalSendEnabled;
+    var fieldEnergy = model.isFieldEnergyMode;
+    var localLoopback = model.isLocalLoopbackEnabled;
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (sheetContext, setSheetState) {
+            return SafeArea(
+              child: Container(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.sizeOf(sheetContext).height * 0.82,
+                ),
+                padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF17212B),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Center(child: _SheetHandle()),
+                    const SizedBox(height: 14),
+                    const Text(
+                      '全球法布施设置',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 19,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    SwitchListTile(
+                      value: globalEnabled,
+                      onChanged: (value) => setSheetState(() => globalEnabled = value),
+                      title: const Text('全球/国家节点', style: TextStyle(color: Colors.white)),
+                      subtitle: const Text('开启后可选择全部国家或指定国家', style: TextStyle(color: Color(0xFF91A3B7))),
+                    ),
+                    SwitchListTile(
+                      value: fieldEnergy,
+                      onChanged: (value) => setSheetState(() => fieldEnergy = value),
+                      title: const Text('本地场能', style: TextStyle(color: Colors.white)),
+                      subtitle: const Text('无网场景下使用本地广播', style: TextStyle(color: Color(0xFF91A3B7))),
+                    ),
+                    SwitchListTile(
+                      value: localLoopback,
+                      onChanged: (value) => setSheetState(() => localLoopback = value),
+                      title: const Text('本地转经轮', style: TextStyle(color: Colors.white)),
+                      subtitle: const Text('在本机持续运行回环法布施', style: TextStyle(color: Color(0xFF91A3B7))),
+                    ),
+                    const Divider(color: Color(0xFF263445)),
+                    Row(
+                      children: [
+                        TextButton(
+                          onPressed: () => setSheetState(() {
+                            selectedCountries
+                              ..clear()
+                              ..add('ALL');
+                          }),
+                          child: const Text('全球'),
+                        ),
+                        TextButton(
+                          onPressed: () => setSheetState(selectedCountries.clear),
+                          child: const Text('清空国家'),
+                        ),
+                      ],
+                    ),
+                    Expanded(
+                      child: ListView(
+                        children: [
+                          for (final entry in _countryOptions)
+                            CheckboxListTile(
+                              value: selectedCountries.contains('ALL') ||
+                                  selectedCountries.contains(entry.key),
+                              onChanged: selectedCountries.contains('ALL')
+                                  ? null
+                                  : (value) => setSheetState(() {
+                                        if (value == true) {
+                                          selectedCountries.add(entry.key);
+                                        } else {
+                                          selectedCountries.remove(entry.key);
+                                        }
+                                      }),
+                              title: Text(entry.value, style: const TextStyle(color: Colors.white)),
+                              dense: true,
+                            ),
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
+                        onPressed: () async {
+                          model.setGlobalSendEnabled(globalEnabled);
+                          model.setCountryList(selectedCountries.toList());
+                          await model.setFieldEnergyMode(fieldEnergy);
+                          model.setLocalLoopbackEnabled(localLoopback);
+                          if (mounted) setState(() {});
+                          if (sheetContext.mounted) Navigator.pop(sheetContext);
+                        },
+                        child: const Text('完成'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  List<MapEntry<String, String>> get _countryOptions {
+    final entries = country_catalog.GLOBAL_COUNTRY_SERVERS.keys
+        .map((code) => MapEntry(code, country_catalog.COUNTRY_NAMES[code] ?? code))
+        .toList();
+    entries.sort((a, b) => a.value.compareTo(b.value));
+    return entries;
+  }
+
+  String _regionSummary(FileTransferModel model) {
+    final labels = <String>[];
+    if (model.isGlobalSendEnabled && model.countryList.isNotEmpty) {
+      if (model.countryList.contains('ALL')) {
+        labels.add('全球');
+      } else {
+        final names = model.countryList
+            .map((code) => country_catalog.COUNTRY_NAMES[code] ?? code)
+            .take(2)
+            .toList();
+        labels.add(model.countryList.length > 2
+            ? '${names.join('、')} 等 ${model.countryList.length} 个'
+            : names.join('、'));
+      }
+    }
+    if (model.isFieldEnergyMode) labels.add('本地场能');
+    if (model.isLocalLoopbackEnabled) labels.add('本地转经轮');
+    return labels.isEmpty ? '未选择' : labels.join('、');
+  }
+
+  String _platformSummary() {
+    if (_selectedPublishPlatforms.isEmpty) return '未选择';
+    final labels = _selectedPublishPlatforms.map((p) => p.info.shortLabel).toList();
+    if (labels.length <= 2) return labels.join('、');
+    return '${labels.take(2).join('、')} 等 ${labels.length} 个';
+  }
+
+  void _openFlashcardDeck(FlashcardDeck deck) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => FlashcardStudyScreen(
+          deck: deck,
+          repository: _flashcardRepository,
+        ),
+      ),
+    );
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scrollController.hasClients) return;
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+}
+
+class _SocialChatMessage {
+  _SocialChatMessage({
+    required this.text,
+    required this.isUser,
+    this.isError = false,
+    this.deck,
+  });
+
+  String text;
+  final bool isUser;
+  final bool isError;
+  final FlashcardDeck? deck;
+
+  factory _SocialChatMessage.user(String text) =>
+      _SocialChatMessage(text: text, isUser: true);
+  factory _SocialChatMessage.bot(String text) =>
+      _SocialChatMessage(text: text, isUser: false);
+  factory _SocialChatMessage.error(String text) =>
+      _SocialChatMessage(text: text, isUser: false, isError: true);
+  factory _SocialChatMessage.deck(String text, FlashcardDeck deck) =>
+      _SocialChatMessage(text: text, isUser: false, deck: deck);
+}
+
+class _MessageBubble extends StatelessWidget {
+  const _MessageBubble({
+    required this.message,
+    required this.bot,
+    required this.onOpenDeck,
+  });
+
+  final _SocialChatMessage message;
+  final SocialFeatureBot bot;
+  final ValueChanged<FlashcardDeck> onOpenDeck;
+
+  @override
+  Widget build(BuildContext context) {
+    final isUser = message.isUser;
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 14),
+        constraints: const BoxConstraints(maxWidth: 620),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+        decoration: BoxDecoration(
+          color: isUser
+              ? const Color(0xFF2B5278)
+              : message.isError
+                  ? const Color(0xFF4B2028)
+                  : const Color(0xFF182433),
+          borderRadius: BorderRadius.only(
+            topLeft: const Radius.circular(18),
+            topRight: const Radius.circular(18),
+            bottomLeft: Radius.circular(isUser ? 18 : 6),
+            bottomRight: Radius.circular(isUser ? 6 : 18),
+          ),
+          border: Border.all(
+            color: message.isError ? const Color(0xFF7A3340) : const Color(0xFF263445),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (!isUser)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 6),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CircleAvatar(
+                      radius: 11,
+                      backgroundColor: bot.avatarColor,
+                      child: Icon(bot.icon, color: Colors.white, size: 13),
+                    ),
+                    const SizedBox(width: 7),
+                    Text(
+                      bot.title,
+                      style: const TextStyle(
+                        color: Color(0xFF91A3B7),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            Text(
+              message.text,
+              style: TextStyle(
+                color: message.isError ? const Color(0xFFFFD4D8) : Colors.white,
+                fontSize: 15,
+                height: 1.48,
+                fontWeight: isUser ? FontWeight.w700 : FontWeight.w500,
+              ),
+            ),
+            if (message.deck != null) ...[
+              const SizedBox(height: 12),
+              FilledButton.icon(
+                onPressed: () => onOpenDeck(message.deck!),
+                icon: const Icon(Icons.play_arrow_rounded),
+                label: const Text('开始背诵'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ThinkingBubble extends StatelessWidget {
+  const _ThinkingBubble({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 430),
+        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 12),
+        decoration: BoxDecoration(
+          color: const Color(0xFF182433),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: const Color(0xFF263445)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const SizedBox(width: 10),
+            Flexible(
+              child: Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ControlPill extends StatelessWidget {
+  const _ControlPill({
+    required this.icon,
+    required this.label,
+    required this.active,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool active;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: active ? const Color(0xFF253A52) : const Color(0xFF172432),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: active ? const Color(0xFF3F8FE5) : const Color(0xFF263445),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: const Color(0xFF9EC7FF), size: 17),
+            const SizedBox(width: 7),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            if (onTap != null) ...[
+              const SizedBox(width: 4),
+              const Icon(Icons.keyboard_arrow_down, color: Color(0xFF91A3B7), size: 16),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ModeTile extends StatelessWidget {
+  const _ModeTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: onTap,
+      leading: CircleAvatar(
+        backgroundColor: selected ? const Color(0xFF3390EC) : const Color(0xFF253445),
+        child: Icon(icon, color: Colors.white),
+      ),
+      title: Text(
+        title,
+        style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900),
+      ),
+      subtitle: Text(subtitle, style: const TextStyle(color: Color(0xFF91A3B7))),
+      trailing: selected ? const Icon(Icons.check_circle, color: Color(0xFF4DDE7A)) : null,
+    );
+  }
+}
+
+class _SheetHandle extends StatelessWidget {
+  const _SheetHandle();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 42,
+      height: 4,
+      decoration: BoxDecoration(
+        color: const Color(0xFF6E7F92),
+        borderRadius: BorderRadius.circular(999),
+      ),
+    );
+  }
+}

--- a/fabushi/lib/services/social_friend_service.dart
+++ b/fabushi/lib/services/social_friend_service.dart
@@ -1,0 +1,259 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'unified_api_service.dart';
+
+class SocialFriendContact {
+  const SocialFriendContact({
+    required this.id,
+    required this.displayName,
+    this.username = '',
+    this.avatarUrl = '',
+    this.status = 'friend',
+  });
+
+  final String id;
+  final String displayName;
+  final String username;
+  final String avatarUrl;
+  final String status;
+
+  factory SocialFriendContact.fromJson(Map<String, dynamic> json) {
+    final id = (json['id'] ?? json['userId'] ?? json['uid'] ?? '').toString();
+    final username = (json['username'] ?? json['userNo'] ?? '').toString();
+    return SocialFriendContact(
+      id: id.isEmpty ? username : id,
+      displayName: (json['displayName'] ??
+              json['nickname'] ??
+              json['name'] ??
+              username ??
+              '大乘好友')
+          .toString(),
+      username: username,
+      avatarUrl: (json['avatarUrl'] ?? json['avatar'] ?? '').toString(),
+      status: (json['status'] ?? 'friend').toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'displayName': displayName,
+        'username': username,
+        'avatarUrl': avatarUrl,
+        'status': status,
+      };
+}
+
+class SocialFriendRequest {
+  const SocialFriendRequest({
+    required this.id,
+    required this.fromUser,
+    required this.createdAt,
+    this.message = '',
+  });
+
+  final String id;
+  final SocialFriendContact fromUser;
+  final DateTime createdAt;
+  final String message;
+
+  factory SocialFriendRequest.fromJson(Map<String, dynamic> json) {
+    final userJson = json['fromUser'] is Map<String, dynamic>
+        ? json['fromUser'] as Map<String, dynamic>
+        : json['user'] is Map<String, dynamic>
+            ? json['user'] as Map<String, dynamic>
+            : json;
+    return SocialFriendRequest(
+      id: (json['id'] ?? json['requestId'] ?? '').toString(),
+      fromUser: SocialFriendContact.fromJson(userJson),
+      createdAt: DateTime.tryParse((json['createdAt'] ?? '').toString()) ??
+          DateTime.now(),
+      message: (json['message'] ?? '').toString(),
+    );
+  }
+}
+
+class SocialFriendService {
+  SocialFriendService({UnifiedApiService? api}) : _api = api ?? UnifiedApiService();
+
+  static const String _localFriendsKey = 'social_friends_cache_v1';
+  static const String _pendingSentKey = 'social_friend_pending_sent_v1';
+
+  final UnifiedApiService _api;
+
+  Future<List<SocialFriendContact>> listFriends({String? token}) async {
+    _api.initialize();
+    try {
+      final response = await _api.get(
+        '/api/social/friends',
+        headers: _authHeaders(token),
+      );
+      final payload = jsonDecode(response.body);
+      final friends = _readList(payload)
+          .whereType<Map<String, dynamic>>()
+          .map(SocialFriendContact.fromJson)
+          .where((friend) => friend.id.isNotEmpty)
+          .toList();
+      await _saveContacts(_localFriendsKey, friends);
+      return friends;
+    } catch (error) {
+      debugPrint('加载好友列表失败，使用本地缓存: $error');
+      return _loadContacts(_localFriendsKey);
+    }
+  }
+
+  Future<List<SocialFriendContact>> searchUsers(
+    String keyword, {
+    String? token,
+  }) async {
+    final query = keyword.trim();
+    if (query.isEmpty) return const [];
+    _api.initialize();
+    try {
+      final response = await _api.get(
+        '/api/social/users/search',
+        queryParams: {'q': query},
+        headers: _authHeaders(token),
+      );
+      final payload = jsonDecode(response.body);
+      return _readList(payload)
+          .whereType<Map<String, dynamic>>()
+          .map(SocialFriendContact.fromJson)
+          .where((user) => user.id.isNotEmpty)
+          .toList();
+    } catch (error) {
+      debugPrint('搜索好友接口暂不可用: $error');
+      final cached = await _loadContacts(_localFriendsKey);
+      final lower = query.toLowerCase();
+      return cached
+          .where(
+            (item) =>
+                item.displayName.toLowerCase().contains(lower) ||
+                item.username.toLowerCase().contains(lower),
+          )
+          .toList();
+    }
+  }
+
+  Future<void> sendFriendRequest(
+    SocialFriendContact user, {
+    String? token,
+    String message = '',
+  }) async {
+    if (user.id.isEmpty) return;
+    _api.initialize();
+    try {
+      await _api.post(
+        '/api/social/friend-requests',
+        headers: _authHeaders(token),
+        body: {
+          'targetUserId': user.id,
+          if (message.trim().isNotEmpty) 'message': message.trim(),
+        },
+      );
+    } catch (error) {
+      debugPrint('发送好友申请接口暂不可用，已保存为本地待发送: $error');
+      await _appendContact(_pendingSentKey, user.copyWith(status: 'pending'));
+    }
+  }
+
+  Future<List<SocialFriendRequest>> listIncomingRequests({String? token}) async {
+    _api.initialize();
+    try {
+      final response = await _api.get(
+        '/api/social/friend-requests/incoming',
+        headers: _authHeaders(token),
+      );
+      final payload = jsonDecode(response.body);
+      return _readList(payload)
+          .whereType<Map<String, dynamic>>()
+          .map(SocialFriendRequest.fromJson)
+          .where((request) => request.id.isNotEmpty)
+          .toList();
+    } catch (error) {
+      debugPrint('加载好友申请失败: $error');
+      return const [];
+    }
+  }
+
+  Future<void> acceptFriendRequest(String requestId, {String? token}) async {
+    if (requestId.trim().isEmpty) return;
+    _api.initialize();
+    await _api.post(
+      '/api/social/friend-requests/$requestId/accept',
+      headers: _authHeaders(token),
+    );
+  }
+
+  Map<String, String>? _authHeaders(String? token) {
+    final value = token?.trim();
+    if (value == null || value.isEmpty) return null;
+    return {'Authorization': 'Bearer $value'};
+  }
+
+  List<dynamic> _readList(dynamic payload) {
+    if (payload is List) return payload;
+    if (payload is Map<String, dynamic>) {
+      final data = payload['data'];
+      if (data is List) return data;
+      if (data is Map<String, dynamic>) {
+        final users = data['users'];
+        if (users is List) return users;
+        final friends = data['friends'];
+        if (friends is List) return friends;
+        final requests = data['requests'];
+        if (requests is List) return requests;
+      }
+    }
+    return const [];
+  }
+
+  Future<List<SocialFriendContact>> _loadContacts(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(key);
+    if (raw == null || raw.isEmpty) return const [];
+    try {
+      final list = jsonDecode(raw) as List<dynamic>;
+      return list
+          .whereType<Map<String, dynamic>>()
+          .map(SocialFriendContact.fromJson)
+          .toList();
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  Future<void> _saveContacts(
+    String key,
+    List<SocialFriendContact> contacts,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      key,
+      jsonEncode(contacts.map((item) => item.toJson()).toList()),
+    );
+  }
+
+  Future<void> _appendContact(String key, SocialFriendContact contact) async {
+    final contacts = await _loadContacts(key);
+    final next = [
+      contact,
+      ...contacts.where((item) => item.id != contact.id),
+    ];
+    await _saveContacts(key, next);
+  }
+}
+
+extension on SocialFriendContact {
+  SocialFriendContact copyWith({String? status}) {
+    return SocialFriendContact(
+      id: id,
+      displayName: displayName,
+      username: username,
+      avatarUrl: avatarUrl,
+      status: status ?? this.status,
+    );
+  }
+}

--- a/fabushi/lib/widgets/social/social_contacts_sidebar.dart
+++ b/fabushi/lib/widgets/social/social_contacts_sidebar.dart
@@ -1,0 +1,796 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../features/auth/application/auth_model.dart';
+import '../../services/social_friend_service.dart';
+import 'social_feature_bot.dart';
+
+class SocialContactsSidebar extends StatefulWidget {
+  const SocialContactsSidebar({
+    super.key,
+    required this.selectedBot,
+    required this.onBotSelected,
+    this.onClose,
+    this.isMobile = false,
+  });
+
+  final SocialFeatureBotType selectedBot;
+  final ValueChanged<SocialFeatureBotType> onBotSelected;
+  final VoidCallback? onClose;
+  final bool isMobile;
+
+  @override
+  State<SocialContactsSidebar> createState() => _SocialContactsSidebarState();
+}
+
+class _SocialContactsSidebarState extends State<SocialContactsSidebar> {
+  static const List<SocialFeatureBotType> _fixedBots = [
+    SocialFeatureBotType.globalDharma,
+    SocialFeatureBotType.flashcards,
+    SocialFeatureBotType.platformPublish,
+  ];
+
+  final SocialFriendService _friendService = SocialFriendService();
+  final TextEditingController _filterController = TextEditingController();
+  List<SocialFriendContact> _friends = const [];
+  bool _isLoadingFriends = false;
+  String _filter = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _filterController.addListener(() {
+      setState(() => _filter = _filterController.text.trim());
+    });
+    unawaited(_loadFriends());
+  }
+
+  @override
+  void dispose() {
+    _filterController.dispose();
+    super.dispose();
+  }
+
+  String? get _authToken {
+    try {
+      return Provider.of<AuthModel?>(context, listen: false)?.authToken;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _loadFriends() async {
+    setState(() => _isLoadingFriends = true);
+    final friends = await _friendService.listFriends(token: _authToken);
+    if (!mounted) return;
+    setState(() {
+      _friends = friends;
+      _isLoadingFriends = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = widget.isMobile
+        ? (MediaQuery.sizeOf(context).width * 0.86).clamp(312.0, 380.0)
+        : 364.0;
+    final authModel = Provider.of<AuthModel?>(context);
+    final friends = _filteredFriends;
+
+    return Container(
+      width: width,
+      decoration: const BoxDecoration(
+        color: Color(0xFF17212B),
+        border: Border(right: BorderSide(color: Color(0xFF223040))),
+      ),
+      child: SafeArea(
+        child: Column(
+          children: [
+            _buildAccountHeader(authModel),
+            _buildSearchRow(),
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: _loadFriends,
+                child: ListView(
+                  padding: EdgeInsets.zero,
+                  children: [
+                    _SectionLabel(
+                      label: '固定机器人',
+                      trailing: 'PINNED',
+                    ),
+                    for (final type in _fixedBots)
+                      _FeatureBotTile(
+                        bot: type.bot,
+                        selected: widget.selectedBot == type,
+                        onTap: () => widget.onBotSelected(type),
+                      ),
+                    const SizedBox(height: 8),
+                    _SectionLabel(
+                      label: '好友',
+                      trailing: _isLoadingFriends ? '同步中' : '${friends.length}',
+                    ),
+                    if (_isLoadingFriends)
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 28),
+                        child: Center(
+                          child: SizedBox(
+                            width: 22,
+                            height: 22,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        ),
+                      )
+                    else if (friends.isEmpty)
+                      _EmptyFriendHint(
+                        onAddFriend: _showAddFriendDialog,
+                      )
+                    else
+                      for (final friend in friends)
+                        _FriendTile(
+                          friend: friend,
+                          onTap: () => _showFriendPendingNotice(friend),
+                        ),
+                  ],
+                ),
+              ),
+            ),
+            _buildBottomBar(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<SocialFriendContact> get _filteredFriends {
+    final query = _filter.toLowerCase();
+    if (query.isEmpty) return _friends;
+    return _friends
+        .where(
+          (friend) =>
+              friend.displayName.toLowerCase().contains(query) ||
+              friend.username.toLowerCase().contains(query),
+        )
+        .toList();
+  }
+
+  Widget _buildAccountHeader(AuthModel? authModel) {
+    final name = _displayName(authModel);
+    final initial = name.isEmpty ? 'BO' : name.substring(0, 1).toUpperCase();
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 18, 12, 12),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 28,
+            backgroundColor: const Color(0xFFFF9F43),
+            child: Text(
+              initial,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w900,
+                fontSize: 18,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  name.isEmpty ? 'bhrum om' : name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w900,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                const Text(
+                  '社交联系人 · 功能机器人',
+                  style: TextStyle(
+                    color: Color(0xFF91A3B7),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (widget.onClose != null)
+            IconButton(
+              tooltip: '关闭',
+              onPressed: widget.onClose,
+              icon: const Icon(Icons.close, color: Color(0xFF91A3B7)),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _displayName(AuthModel? authModel) {
+    final user = authModel?.currentUser;
+    final display = user?.displayName.trim() ?? '';
+    if (display.isNotEmpty) return display;
+    return user?.username ?? '';
+  }
+
+  Widget _buildSearchRow() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 6, 14, 14),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _filterController,
+              style: const TextStyle(color: Colors.white, fontSize: 14),
+              decoration: InputDecoration(
+                hintText: '搜索联系人',
+                hintStyle: const TextStyle(color: Color(0xFF728196)),
+                prefixIcon: const Icon(Icons.search, color: Color(0xFF728196)),
+                isDense: true,
+                filled: true,
+                fillColor: const Color(0xFF101923),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(22),
+                  borderSide: BorderSide.none,
+                ),
+                contentPadding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton.filled(
+            tooltip: '添加好友',
+            onPressed: _showAddFriendDialog,
+            style: IconButton.styleFrom(
+              backgroundColor: const Color(0xFF243446),
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.person_add_alt_1),
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            tooltip: '好友申请',
+            onPressed: _showFriendRequestsSheet,
+            icon: const Icon(Icons.notifications_none, color: Color(0xFF91A3B7)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBottomBar() {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 10, 14, 14),
+      decoration: const BoxDecoration(
+        border: Border(top: BorderSide(color: Color(0xFF223040))),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: _BottomAction(
+              icon: Icons.person_outline,
+              label: '资料',
+              onTap: () => _showSnack('个人资料入口保持原有功能，后续可接入完整资料页。'),
+            ),
+          ),
+          Expanded(
+            child: _BottomAction(
+              icon: Icons.refresh,
+              label: '同步',
+              onTap: _loadFriends,
+            ),
+          ),
+          Expanded(
+            child: _BottomAction(
+              icon: Icons.settings_outlined,
+              label: '设置',
+              onTap: () => _showSnack('设置入口保持原有功能，后续可接入完整设置页。'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showAddFriendDialog() async {
+    final controller = TextEditingController(text: _filter);
+    List<SocialFriendContact> results = const [];
+    var searching = false;
+    String? message;
+
+    Future<void> runSearch(StateSetter setDialogState) async {
+      final keyword = controller.text.trim();
+      if (keyword.isEmpty) {
+        setDialogState(() => message = '请输入昵称、用户名或手机号');
+        return;
+      }
+      setDialogState(() {
+        searching = true;
+        message = null;
+      });
+      final found = await _friendService.searchUsers(keyword, token: _authToken);
+      if (!mounted) return;
+      setDialogState(() {
+        results = found;
+        searching = false;
+        message = found.isEmpty ? '没有找到匹配的用户' : null;
+      });
+    }
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            return AlertDialog(
+              backgroundColor: const Color(0xFF17212B),
+              surfaceTintColor: Colors.transparent,
+              title: const Text(
+                '添加好友',
+                style: TextStyle(color: Colors.white, fontWeight: FontWeight.w900),
+              ),
+              content: SizedBox(
+                width: 460,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: controller,
+                      autofocus: true,
+                      style: const TextStyle(color: Colors.white),
+                      decoration: InputDecoration(
+                        hintText: '搜索好友账号',
+                        hintStyle: const TextStyle(color: Color(0xFF728196)),
+                        filled: true,
+                        fillColor: const Color(0xFF101923),
+                        prefixIcon: const Icon(Icons.search, color: Color(0xFF728196)),
+                        suffixIcon: IconButton(
+                          onPressed: searching ? null : () => runSearch(setDialogState),
+                          icon: const Icon(Icons.arrow_forward, color: Color(0xFF91A3B7)),
+                        ),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(14),
+                          borderSide: const BorderSide(color: Color(0xFF263445)),
+                        ),
+                      ),
+                      onSubmitted: (_) => runSearch(setDialogState),
+                    ),
+                    const SizedBox(height: 14),
+                    if (searching)
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 18),
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    else if (message != null)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        child: Text(
+                          message!,
+                          style: const TextStyle(color: Color(0xFF91A3B7)),
+                        ),
+                      )
+                    else if (results.isNotEmpty)
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxHeight: 320),
+                        child: ListView.separated(
+                          shrinkWrap: true,
+                          itemCount: results.length,
+                          separatorBuilder: (_, _) => const Divider(color: Color(0xFF263445)),
+                          itemBuilder: (context, index) {
+                            final user = results[index];
+                            return ListTile(
+                              contentPadding: EdgeInsets.zero,
+                              leading: _ContactAvatar(contact: user),
+                              title: Text(
+                                user.displayName,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                              subtitle: Text(
+                                user.username.isEmpty ? user.id : '@${user.username}',
+                                style: const TextStyle(color: Color(0xFF91A3B7)),
+                              ),
+                              trailing: FilledButton(
+                                onPressed: () async {
+                                  await _friendService.sendFriendRequest(
+                                    user,
+                                    token: _authToken,
+                                    message: '请求添加好友',
+                                  );
+                                  if (!mounted) return;
+                                  _showSnack('已发送好友申请');
+                                  if (dialogContext.mounted) Navigator.pop(dialogContext);
+                                },
+                                child: const Text('添加'),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(dialogContext),
+                  child: const Text('关闭'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    ).whenComplete(controller.dispose);
+  }
+
+  Future<void> _showFriendRequestsSheet() async {
+    final requests = await _friendService.listIncomingRequests(token: _authToken);
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
+            decoration: const BoxDecoration(
+              color: Color(0xFF17212B),
+              borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 42,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF728196),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '好友申请',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                if (requests.isEmpty)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 28),
+                    child: Center(
+                      child: Text(
+                        '暂无新的好友申请',
+                        style: TextStyle(color: Color(0xFF91A3B7)),
+                      ),
+                    ),
+                  )
+                else
+                  Flexible(
+                    child: ListView.separated(
+                      shrinkWrap: true,
+                      itemCount: requests.length,
+                      separatorBuilder: (_, _) => const Divider(color: Color(0xFF263445)),
+                      itemBuilder: (context, index) {
+                        final request = requests[index];
+                        return ListTile(
+                          leading: _ContactAvatar(contact: request.fromUser),
+                          title: Text(
+                            request.fromUser.displayName,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                          subtitle: Text(
+                            request.message.isEmpty ? '请求添加你为好友' : request.message,
+                            style: const TextStyle(color: Color(0xFF91A3B7)),
+                          ),
+                          trailing: FilledButton(
+                            onPressed: () async {
+                              try {
+                                await _friendService.acceptFriendRequest(
+                                  request.id,
+                                  token: _authToken,
+                                );
+                                if (!mounted) return;
+                                _showSnack('已同意好友申请');
+                                unawaited(_loadFriends());
+                                if (sheetContext.mounted) Navigator.pop(sheetContext);
+                              } catch (error) {
+                                if (!mounted) return;
+                                _showSnack('同意失败：$error', isError: true);
+                              }
+                            },
+                            child: const Text('同意'),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showFriendPendingNotice(SocialFriendContact friend) {
+    _showSnack('${friend.displayName} 的私聊会在下一步接入消息服务');
+  }
+
+  void _showSnack(String text, {bool isError = false}) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(text),
+        backgroundColor: isError ? Colors.redAccent : const Color(0xFF2B5278),
+      ),
+    );
+  }
+}
+
+class _FeatureBotTile extends StatelessWidget {
+  const _FeatureBotTile({
+    required this.bot,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final SocialFeatureBot bot;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(18, 10, 14, 10),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xFF2B5278) : Colors.transparent,
+        ),
+        child: Row(
+          children: [
+            CircleAvatar(
+              radius: 25,
+              backgroundColor: bot.avatarColor,
+              child: Icon(bot.icon, color: Colors.white, size: 24),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    bot.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    bot.subtitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: selected ? const Color(0xFFD9ECFF) : const Color(0xFF91A3B7),
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (selected)
+              const Icon(Icons.done_all, color: Color(0xFFD9ECFF), size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FriendTile extends StatelessWidget {
+  const _FriendTile({required this.friend, required this.onTap});
+
+  final SocialFriendContact friend;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(18, 9, 14, 9),
+        child: Row(
+          children: [
+            _ContactAvatar(contact: friend),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    friend.displayName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    friend.status == 'pending'
+                        ? '等待通过'
+                        : (friend.username.isEmpty ? '已添加好友' : '@${friend.username}'),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Color(0xFF91A3B7),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ContactAvatar extends StatelessWidget {
+  const _ContactAvatar({required this.contact});
+
+  final SocialFriendContact contact;
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = contact.displayName.isEmpty
+        ? '友'
+        : contact.displayName.substring(0, 1).toUpperCase();
+    final avatar = contact.avatarUrl.trim();
+    return CircleAvatar(
+      radius: 24,
+      backgroundColor: const Color(0xFF3D8BFF),
+      backgroundImage: avatar.startsWith('http') ? NetworkImage(avatar) : null,
+      child: avatar.startsWith('http')
+          ? null
+          : Text(
+              initial,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label, required this.trailing});
+
+  final String label;
+  final String trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(18, 12, 18, 7),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF728196),
+                fontSize: 12,
+                fontWeight: FontWeight.w900,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          Text(
+            trailing,
+            style: const TextStyle(
+              color: Color(0xFF728196),
+              fontSize: 11,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyFriendHint extends StatelessWidget {
+  const _EmptyFriendHint({required this.onAddFriend});
+
+  final VoidCallback onAddFriend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 28),
+      child: Column(
+        children: [
+          const Icon(Icons.people_outline, color: Color(0xFF728196), size: 34),
+          const SizedBox(height: 10),
+          const Text(
+            '还没有好友，搜索账号并发送申请，对方同意后会出现在这里。',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Color(0xFF91A3B7), height: 1.4),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: onAddFriend,
+            icon: const Icon(Icons.person_add_alt_1),
+            label: const Text('添加好友'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BottomAction extends StatelessWidget {
+  const _BottomAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: const Color(0xFF91A3B7), size: 21),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF91A3B7),
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fabushi/lib/widgets/social/social_feature_bot.dart
+++ b/fabushi/lib/widgets/social/social_feature_bot.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+/// 固定在社交联系人列表顶部的功能机器人。
+enum SocialFeatureBotType { globalDharma, flashcards, platformPublish, assistant }
+
+class SocialFeatureBot {
+  const SocialFeatureBot({
+    required this.type,
+    required this.title,
+    required this.subtitle,
+    required this.initials,
+    required this.icon,
+    required this.avatarColor,
+    required this.destinationIndex,
+    required this.greeting,
+    required this.inputHint,
+  });
+
+  final SocialFeatureBotType type;
+  final String title;
+  final String subtitle;
+  final String initials;
+  final IconData icon;
+  final Color avatarColor;
+  final int destinationIndex;
+  final String greeting;
+  final String inputHint;
+}
+
+extension SocialFeatureBotTypeX on SocialFeatureBotType {
+  SocialFeatureBot get bot {
+    switch (this) {
+      case SocialFeatureBotType.globalDharma:
+        return const SocialFeatureBot(
+          type: SocialFeatureBotType.globalDharma,
+          title: '全球法布施',
+          subtitle: '地区、循环、场能都在对话框上方设置',
+          initials: '法',
+          icon: Icons.public,
+          avatarColor: Color(0xFF4CAF7A),
+          destinationIndex: 0,
+          greeting: '把要分享的文字、链接或素材发给我，我会按上方选择的地区与模式启动全球法布施。',
+          inputHint: '输入要法布施的文字/链接，或点 + 添加素材',
+        );
+      case SocialFeatureBotType.flashcards:
+        return const SocialFeatureBot(
+          type: SocialFeatureBotType.flashcards,
+          title: '背诵闪卡制作',
+          subtitle: '随机挖空 / AI 制卡从顶部模式按钮选择',
+          initials: '卡',
+          icon: Icons.style_outlined,
+          avatarColor: Color(0xFF7E57C2),
+          destinationIndex: 1,
+          greeting: '粘贴经文、文章正文或链接即可制作背诵闪卡。制卡模式请在上方按钮切换，不会再插入聊天选择消息。',
+          inputHint: '粘贴链接或正文，发送后制作闪卡',
+        );
+      case SocialFeatureBotType.platformPublish:
+        return const SocialFeatureBot(
+          type: SocialFeatureBotType.platformPublish,
+          title: '法布施到平台',
+          subtitle: '选择平台后生成发布草稿并打开入口',
+          initials: '发',
+          icon: Icons.campaign_outlined,
+          avatarColor: Color(0xFFFF9F43),
+          destinationIndex: 2,
+          greeting: '把要发布的正文或链接发给我，上方选择平台后，我会生成发布草稿、复制到剪贴板并打开对应平台入口。',
+          inputHint: '输入要发布到平台的正文/链接',
+        );
+      case SocialFeatureBotType.assistant:
+        return const SocialFeatureBot(
+          type: SocialFeatureBotType.assistant,
+          title: '大乘助理',
+          subtitle: '原有 OpenClaw / AI / 桌面控制入口',
+          initials: 'AI',
+          icon: Icons.smart_toy_outlined,
+          avatarColor: Color(0xFF3D8BFF),
+          destinationIndex: 3,
+          greeting: '继续使用原有大乘助理。',
+          inputHint: '问问大乘',
+        );
+    }
+  }
+}


### PR DESCRIPTION
## 改动内容

- 将 native 桌面/移动主界面改为 Telegram/微信式联系人布局：左侧联系人栏，右侧聊天对话框。
- 固定置顶三个功能机器人联系人：
  - 全球法布施
  - 背诵闪卡制作
  - 法布施到平台
- 每个机器人进入独立聊天界面，并把功能设置放到对话框上方：
  - 全球法布施：地区/全局、本地场能、本地转经轮、循环、素材入口。
  - 背诵闪卡制作：顶部“模式”按钮切换随机挖空 / AI 制卡，不再通过聊天消息选择。
  - 法布施到平台：顶部“平台”按钮选择发布平台。
- 新增社交联系人侧边栏与好友功能入口：搜索好友、发送好友申请、查看/同意好友申请、好友列表缓存。
- 复用现有功能服务进行对接：
  - `FileTransferModel.startGlobalTransfer` / `addTextContentForSending`
  - `FlashcardService` / `ContentPipeline`
  - `DharmaPublishService`

## 主要文件

- `fabushi/lib/screens/main_navigation_screen_native.dart`
- `fabushi/lib/screens/social_feature_chat_screen.dart`
- `fabushi/lib/widgets/social/social_contacts_sidebar.dart`
- `fabushi/lib/widgets/social/social_feature_bot.dart`
- `fabushi/lib/services/social_friend_service.dart`

## 注意

当前运行环境无法拉取 GitHub 仓库到本地执行 `flutter analyze` / `flutter test`，合并前请在本地运行：

```bash
cd fabushi
flutter analyze
flutter test
```
