### PR TITLE
Fix desktop installer checkout when LFS budget is exhausted

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -238,13 +238,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-release-context.outputs.source_sha }}
-          lfs: true
+          lfs: false
           fetch-depth: 1
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /*
             !/fabushi/assets/built_in/**
             !/fabushi/web/assets/built_in/**
+            !/fabushi/temp_models/**
 
       - name: Install Linux desktop dependencies
         if: matrix.target == 'linux'
@@ -652,13 +653,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-release-context.outputs.source_sha }}
-          lfs: true
+          lfs: false
           fetch-depth: 1
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /*
             !/fabushi/assets/built_in/**
             !/fabushi/web/assets/built_in/**
+            !/fabushi/temp_models/**
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary

This fixes the desktop installer workflow checkout step that failed before packaging could start because Git LFS tried to smudge `fabushi/temp_models/佛像模型.glb` after the repository exceeded its LFS budget.

Changes:
- Disable LFS download during desktop installer checkout.
- Exclude `fabushi/temp_models/**` from the sparse checkout for both installer builds and macOS App Store upload.

## Verification

Observed failure in Actions run 28163309455: checkout failed with `This repository exceeded its LFS budget` while downloading `fabushi/temp_models/佛像模型.glb`. This PR prevents that file from being downloaded by the release workflow checkout.