### PR TITLE
Stabilize release smoke workflow checkouts

### DIFF
--- a/.github/workflows/android-real-device-e2e.yml
+++ b/.github/workflows/android-real-device-e2e.yml
@@ -86,12 +86,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
         with:
-          lfs: true
+          lfs: false
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /fabushi/**
             !/fabushi/assets/built_in/**
             !/fabushi/web/assets/built_in/**
+            !/fabushi/temp_models/**
 
       - name: Set up Java
         uses: actions/setup-java@v5

--- a/.github/workflows/deploy-miniapps-cloudflare.yml
+++ b/.github/workflows/deploy-miniapps-cloudflare.yml
@@ -15,6 +15,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            frontend/apps/web/**
+            frontend/packages/**
+            frontend/package.json
+            frontend/pnpm-lock.yaml
+            frontend/pnpm-workspace.yaml
+            frontend/tsconfig.base.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -27,9 +36,11 @@ jobs:
           version: 10
 
       - name: Install dependencies
+        working-directory: frontend
         run: pnpm install --frozen-lockfile
 
       - name: Build Web App
+        working-directory: frontend
         run: pnpm --filter @fabushi/web build
 
       - name: Deploy to Cloudflare Pages

--- a/.github/workflows/desktop-package-cli-smoke.yml
+++ b/.github/workflows/desktop-package-cli-smoke.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   package-cli-smoke:
     name: Smoke installed ${{ matrix.target }} package CLI
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'desktop-')
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -44,6 +45,10 @@ jobs:
     steps:
       - name: Checkout smoke scripts
         uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github/scripts/assert-openclaw-bundle.sh
 
       - name: Download release package
         shell: bash


### PR DESCRIPTION
## Problem
Hourly release E2E triage for `desktop-v1.0.1-947-196-34e876c79fc1` / `v1.0.1-958-mobile.34e876c79fc1` found that several platform checks failed before exercising product behavior:

- Android Real Device E2E failed during checkout because `lfs: true` tried to smudge `fabushi/temp_models/佛像模型.glb`, and GitHub reported the repository exceeded its LFS budget.
- Desktop package CLI smoke ran on a mobile Release event, then looked for desktop ZIP assets under `v1.0.1-958-mobile.34e876c79fc1`, causing macOS/Windows download failures.
- The Linux desktop CLI smoke and Mini Apps deploy checkout hit repository assets with filenames longer than the runner filesystem supports.

## Root Cause
The affected workflows checked out more of the monorepo than they need, or ran against a release type that does not contain their expected assets.

## Fix
- Android Real Device E2E now avoids LFS smudge and excludes `fabushi/temp_models/**` from its sparse checkout.
- Desktop package CLI smoke now skips non-desktop Release events and checks out only the smoke assertion script.
- Mini Apps deploy now checks out only the frontend workspace needed for the web build and runs pnpm from `frontend`.

## Impact
This is limited to GitHub Actions workflow orchestration. It does not change app code or packaged runtime behavior.

## Verification
- Basic workflow text checks passed locally on the automation host.
- The failed release assets were independently downloaded and SHA-256 verified during the E2E triage.
- Full behavioral verification should be the follow-up GitHub Actions run for this PR, then a re-run of the affected release smoke jobs.

## Remaining Risk
This PR fixes pre-test infrastructure blockers. It does not prove Android/iOS/macOS/Windows runtime behavior; those still need the corresponding platform runners or device labs after checkout/download blockers are removed.