### PR TITLE
Fix desktop smoke CLI exit codes

### DIFF
--- a/fabushi/tool/desktop_package_cli.dart
+++ b/fabushi/tool/desktop_package_cli.dart
@@ -6,10 +6,11 @@ import 'dart:io';
 const String appExecutableName = 'global_dharma_sharing';
 const String cliExecutableName = 'global_dharma_sharing_cli';
 
-Future<int> main(List<String> args) async {
+Future<void> main(List<String> args) async {
   final cli = DesktopSmokeCli(args);
   try {
-    return await cli.run();
+    exitCode = await cli.run();
+    return;
   } on CliFailure catch (error) {
     if (cli.jsonOutput) {
       cli.writeJson({
@@ -29,7 +30,8 @@ Future<int> main(List<String> args) async {
         }
       }
     }
-    return error.exitCode;
+    exitCode = error.exitCode;
+    return;
   } catch (error, stackTrace) {
     if (cli.jsonOutput) {
       cli.writeJson({
@@ -43,7 +45,7 @@ Future<int> main(List<String> args) async {
       stderr.writeln('ERROR: $error');
       stderr.writeln(stackTrace);
     }
-    return 1;
+    exitCode = 1;
   }
 }
 


### PR DESCRIPTION
## Problem
Hourly mac desktop release patrol for `desktop-v1.0.1-947-196-34e876c79fc1` triggered `Desktop package CLI smoke` run https://github.com/bhrumom/fabushi/actions/runs/28318685296.

The macOS job was marked `success`, but the step log contained a machine-readable failure from the packaged CLI:

- `command`: `gateway-smoke`
- `ok`: `false`
- `error`: `TimeoutException after 0:00:10.000000: Future not completed`
- First failing operation: POST to `/v1/chat/completions` in `DesktopSmokeCli._httpPostJson`

That means the current CI gate can report success even when the desktop smoke CLI emits a failed JSON result.

## Root Cause
`main()` returned an integer from the Dart entrypoint, but the compiled executable did not propagate that integer as the process exit status in the observed macOS package job. The workflow therefore continued even though the CLI emitted `ok: false`.

## Fix
Set `dart:io` `exitCode` explicitly for success, `CliFailure`, and unexpected exception paths in `fabushi/tool/desktop_package_cli.dart`.

## Impact
This is limited to the desktop package smoke CLI test gate. It does not change app runtime behavior or packaged product logic.

## Verification
- Reproduced the gate weakness through run https://github.com/bhrumom/fabushi/actions/runs/28318685296: macOS job success with `gateway-smoke` JSON `ok: false`.
- Sanity-checked the patch diff on the automation host; only the CLI entrypoint exit-code handling changed.

## Remaining Risk
This fixes false-green smoke reporting. It does not itself resolve the underlying macOS `gateway-smoke` chat route timeout, nor does it add full GUI E2E screenshots for desktop main flow and in-desktop mini-app enter/load/core interaction/back/exception recovery/state consistency.