### PR TITLE
Fail desktop smoke when JSON reports ok false

### DIFF
--- a/.github/workflows/desktop-package-cli-smoke.yml
+++ b/.github/workflows/desktop-package-cli-smoke.yml
@@ -84,8 +84,12 @@ jobs:
             exit 1
           fi
           ./.github/scripts/assert-openclaw-bundle.sh "$RUNNER_TEMP/installed" linux-x64
-          "$cli" doctor --json
-          "$cli" gateway-smoke --timeout-seconds 120 --json
+          doctor_json="$($cli doctor --json)"
+          echo "$doctor_json"
+          jq -e '.ok == true' <<<"$doctor_json" >/dev/null
+          gateway_json="$($cli gateway-smoke --timeout-seconds 120 --json)"
+          echo "$gateway_json"
+          jq -e '.ok == true' <<<"$gateway_json" >/dev/null
 
       - name: Install macOS package and smoke CLI
         if: matrix.target == 'macos'
@@ -117,8 +121,12 @@ jobs:
             exit 1
           fi
           ./.github/scripts/assert-openclaw-bundle.sh "$RUNNER_TEMP/installed/global_dharma_sharing.app" "$openclaw_platform"
-          "$cli" doctor --json
-          "$cli" gateway-smoke --timeout-seconds 120 --json
+          doctor_json="$($cli doctor --json)"
+          echo "$doctor_json"
+          jq -e '.ok == true' <<<"$doctor_json" >/dev/null
+          gateway_json="$($cli gateway-smoke --timeout-seconds 120 --json)"
+          echo "$gateway_json"
+          jq -e '.ok == true' <<<"$gateway_json" >/dev/null
 
       - name: Install Windows package and smoke CLI
         if: matrix.target == 'windows'
@@ -132,5 +140,11 @@ jobs:
           Expand-Archive -Path $zip.FullName -DestinationPath $installDir -Force
           $cli = Join-Path $installDir "${{ matrix.cli }}"
           if (-not (Test-Path $cli)) { throw "Installed package CLI not found: $cli" }
-          & $cli doctor --json
-          & $cli gateway-smoke --timeout-seconds 120 --json
+          $doctorJson = & $cli doctor --json | Out-String
+          Write-Output $doctorJson
+          $doctorResult = $doctorJson | ConvertFrom-Json
+          if (-not $doctorResult.ok) { throw "doctor returned ok=false" }
+          $gatewayJson = & $cli gateway-smoke --timeout-seconds 120 --json | Out-String
+          Write-Output $gatewayJson
+          $gatewayResult = $gatewayJson | ConvertFrom-Json
+          if (-not $gatewayResult.ok) { throw "gateway-smoke returned ok=false" }


### PR DESCRIPTION
## Problem
Hourly mac desktop patrol triggered `Desktop package CLI smoke` for `desktop-v1.0.1-947-196-34e876c79fc1`:

- Run: https://github.com/bhrumom/fabushi/actions/runs/28318685296
- macOS job: `83896546329`
- The job was marked `success`, but the packaged CLI printed `gateway-smoke` JSON with `ok: false` and `TimeoutException after 0:00:10.000000: Future not completed`.

PR #1334 fixes future packaged CLIs by setting `dart:io` `exitCode`, but current already-published desktop packages still need the workflow to enforce the JSON result directly.

## Root Cause
The workflow trusted the packaged CLI process exit status. For already-built packages with the old CLI behavior, a JSON failure can still be reported as a successful job.

## Fix
Parse the `doctor --json` and `gateway-smoke --json` output in the workflow and explicitly fail when `.ok != true`:

- Linux/macOS use `jq -e '.ok == true'`.
- Windows uses `ConvertFrom-Json` and throws on `ok=false`.

## Impact
This changes only CI gating. It does not change product runtime behavior or release artifacts.

## Verification
- Text sanity checked the workflow patch on the automation host.
- Confirmed the patch has no malformed `printf` quoting after an initial local correction.
- The next workflow_dispatch against `desktop-v1.0.1-947-196-34e876c79fc1` should now fail on the observed macOS `gateway-smoke` `ok:false`, allowing the timeout to be tracked honestly.

## Remaining Risk
This does not fix the underlying `/v1/chat/completions` timeout. It makes the failure visible so the next patrol can continue root-cause analysis with a red macOS job.