### PR TITLE
Harden gateway smoke chat route probe

### DIFF
--- a/fabushi/tool/desktop_package_cli.dart
+++ b/fabushi/tool/desktop_package_cli.dart
@@ -374,11 +374,11 @@ Examples:
         'status=${models.statusCode} body=${_compact(models.body)}',
       );
 
-      final chat = await _httpPostJson(
+      final chat = await _httpPostRaw(
         baseUri.replace(path: '/v1/chat/completions'),
         token,
-        <String, dynamic>{},
-        const Duration(seconds: 10),
+        '{',
+        const Duration(seconds: 5),
       );
       final chatRouteOk =
           chat.statusCode != 404 &&
@@ -387,7 +387,7 @@ Examples:
       _check(
         'openai chat route',
         chatRouteOk,
-        'status=${chat.statusCode} body=${_compact(chat.body)}',
+        'fast-fail status=${chat.statusCode} body=${_compact(chat.body)}',
       );
     } finally {
       if (process != null) {
@@ -503,10 +503,10 @@ Examples:
     }
   }
 
-  Future<HttpResult> _httpPostJson(
+  Future<HttpResult> _httpPostRaw(
     Uri uri,
     String token,
-    Map<String, dynamic> body,
+    String body,
     Duration timeout,
   ) async {
     final client = HttpClient()..connectionTimeout = timeout;
@@ -517,7 +517,7 @@ Examples:
         HttpHeaders.contentTypeHeader,
         ContentType.json.mimeType,
       );
-      request.write(jsonEncode(body));
+      request.write(body);
       final response = await request.close().timeout(timeout);
       final responseBody = await utf8.decodeStream(response).timeout(timeout);
       return HttpResult(response.statusCode, responseBody);


### PR DESCRIPTION
## Problem
The hourly macOS desktop E2E guard repeatedly fails in the packaged CLI `gateway-smoke` step after the OpenClaw gateway is already up and `/health` plus `/v1/models` have passed.

The failing probe is an empty JSON POST to `/v1/chat/completions`. In the macOS Release package, that can enter model handling and wait until the HTTP client timeout, which makes a route/auth smoke check depend on model execution behavior.

## Root cause
`gateway-smoke` is using the chat completions endpoint to prove route wiring, but the request body `{}` is not a deterministic route/auth probe. It can hang behind model-processing code even though the route exists and token auth has been accepted.

## Fix
Change the packaged CLI chat route check to send malformed JSON (`{`) with the same bearer token and a shorter timeout. This keeps the smoke test focused on:

- the route exists
- the request reaches the authenticated endpoint
- the endpoint responds quickly with a non-404/non-auth failure

It no longer waits on model generation or agent execution.

## Impact
Future desktop packages will have a more deterministic `gateway-smoke`. Existing Release assets are unchanged, so the current `desktop-v1.0.1-947-196-34e876c79fc1` package can still fail until a new desktop Release includes this CLI.

## Validation
- Reproduced the failure in macOS desktop E2E run https://github.com/bhrumom/fabushi/actions/runs/28326471118, job https://github.com/bhrumom/fabushi/actions/runs/28326471118/job/83917226750.
- Evidence artifact: https://github.com/bhrumom/fabushi/actions/runs/28326471118/artifacts/7935857976.
- Static diff checked locally on the repair branch.

## Remaining risk
This fixes the future package CLI probe, not the already-published Release binary. Mini-app GUI step-level automation remains tracked separately, with PR #1339 covering host-contract smoke and issue #1332 tracking the full mac GUI chain.