### PR TITLE
Fix mini apps deploy GitHub deployment permission

### DIFF
--- a/.github/workflows/deploy-miniapps-cloudflare.yml
+++ b/.github/workflows/deploy-miniapps-cloudflare.yml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/deploy-miniapps-cloudflare.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  deployments: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The high-standard hourly mac desktop E2E guard reviewed recent Actions failures and reran the latest failing `Deploy Mini Apps to Cloudflare Pages` job on `main`.

The rerun still failed after a successful dependency install and web build:

- Run: https://github.com/bhrumom/fabushi/actions/runs/28355418000
- Rerun job: https://github.com/bhrumom/fabushi/actions/runs/28355418000/job/84005056968
- First failing step: `Deploy to Cloudflare Pages`
- Error: GitHub deployments API `403 Resource not accessible by integration`
- GitHub response header: `x-accepted-github-permissions: deployments=write`

## Root Cause Judgement

The workflow calls `cloudflare/pages-action@v1` with `gitHubToken: ${{ secrets.GITHUB_TOKEN }}`. That action creates a GitHub deployment before publishing Pages. The workflow did not declare `deployments: write`, so the token had only read-style permissions and GitHub rejected deployment creation.

## Fix

Add the minimal explicit workflow permissions required by this deploy path:

- `contents: read`
- `deployments: write`

## Impact

This is CI/deploy workflow configuration only. It does not change application runtime code, desktop packaging, or mini-app source content.

## Validation

Observed before fix:

- The latest macOS desktop E2E run passed: https://github.com/bhrumom/fabushi/actions/runs/28357729860
- The mini-app deploy rerun on `main` failed at GitHub deployment creation with `deployments=write` required: https://github.com/bhrumom/fabushi/actions/runs/28355418000/job/84005056968

Expected validation after this PR:

- CI should validate workflow syntax.
- After merge, rerun or next push to `main` should allow `cloudflare/pages-action@v1` to create the GitHub deployment and proceed to Cloudflare Pages publishing.

## Remaining Risk

This fixes the currently observed GitHub deployment permission failure. If Cloudflare credentials or project permissions are also invalid, the workflow may expose a later Cloudflare-side failure after this permission gate is cleared.