### PR TITLE
fix: stabilize mini app host command bridge

### DIFF
--- a/ai-backend/src/server.js
+++ b/ai-backend/src/server.js
@@ -386,10 +386,11 @@ function readText(value) {
   return String(value).replace(/\u0000/g, '').trim();
 }
 
-const miniAppHostApiVersion = '1.2';
+const miniAppHostApiVersion = '1.4';
 const miniAppHighRiskPermissions = new Set([
   'auth.token',
   'payments.alipay',
+  'payments.fudeGold',
   'desktop.control',
   'wifi.hotspot',
   'local.loopback',
@@ -420,6 +421,9 @@ function officialMiniAppRegistry(req) {
         'app.context',
         'bot.chat',
         'auth.session',
+        'wallet.balance',
+        'payments.entitlement',
+        'payments.fudeGold',
         'payments.alipay',
         'dharma.share',
         'files.pick',
@@ -495,7 +499,7 @@ function officialMiniAppRegistry(req) {
       entryUrl:
         bot.entryUrl ||
         `${webBase.replace(/\/+$/, '')}/miniapps/${encodeURIComponent(bot.miniAppId)}`,
-      version: '1.2.0',
+      version: '1.4.0',
       permissions: bot.permissions,
       surfaces: ['homePinned', 'chatPanel'],
       theme: 'telegramDark',
@@ -566,6 +570,9 @@ function inferMiniAppPermissionsFromText(...values) {
     ['auth.session', [/auth\.(getsession|requirelogin)/, /登录|用户信息|宿主账号/]],
     ['auth.token', [/auth\.getaccesstoken/, /access token|访问 token/]],
     ['payments.alipay', [/payments\.alipay/, /支付宝|支付|购买|订单/]],
+    ['payments.entitlement', [/payments\.checkentitlement|权益|解锁状态|购买状态/]],
+    ['payments.fudeGold', [/payments\.requestpayment|福德金|代币|钱包|余额/]],
+    ['wallet.balance', [/wallet\.getbalance|福德金|代币|钱包|余额/]],
     ['dharma.share', [/dharma\./, /全球法布施|法布施发送/]],
     ['wifi.hotspot', [/wifihotspot\./, /wifi|wi-fi|热点|本地场能/]],
     ['local.loopback', [/localloopback\./, /localhost|127\.0\.0\.1|本地回环|本地转经轮/]],
@@ -681,6 +688,40 @@ function generatedMiniAppHtml({ title, prompt }) {
     document.getElementById('chat').onclick = () => invoke('bot.sendMessage', {
       message: '请简要说明这个小程序能做什么：' + prompt
     });
+    const seenCommands = new Set();
+    function deliverMiniAppCommand(detail) {
+      if (!detail || typeof detail !== 'object') return;
+      const commandKey = detail.commandId || detail.id || [detail.createdAt, detail.command, detail.rawText || detail.text].filter(Boolean).join(':');
+      if (commandKey) {
+        if (seenCommands.has(commandKey)) return;
+        seenCommands.add(commandKey);
+      }
+      handleMiniAppCommand(detail);
+    }
+    async function handleMiniAppCommand(detail) {
+      out.textContent = '收到后台命令：' + JSON.stringify(detail, null, 2);
+      try {
+        await invoke('bot.postMessage', {
+          commandId: detail.commandId || detail.id,
+          message: '「${safeTitle}」已收到后台命令：' + (detail.args || detail.text || '')
+        });
+        await invoke('bot.reportCommandResult', {
+          commandId: detail.commandId || detail.id,
+          status: 'completed',
+          message: '「${safeTitle}」后台命令已处理。'
+        });
+      } catch (error) {
+        out.textContent = String(error && error.message || error);
+      }
+    }
+    window.addEventListener('fabushi-miniapp-command', (event) => {
+      deliverMiniAppCommand(event.detail || {});
+    });
+    if (window.__fabushiLastMiniAppCommand) {
+      (window.queueMicrotask || ((fn) => setTimeout(fn, 0)))(() => {
+        deliverMiniAppCommand(window.__fabushiLastMiniAppCommand);
+      });
+    }
   </script>
 </body>
 </html>`;
@@ -712,8 +753,9 @@ async function generateBotFatherMiniAppHtml({ title, prompt, user }) {
             '只输出一个完整静态 HTML 文件，不要 Markdown，不要解释。',
             '小程序只能通过 window.FabushiMiniApp.invoke(method, params) 调用宿主能力。',
             '先调用 app.getHostApiSpec 或 app.getCapabilities 判断宿主版本和已授权权限，再显示对应 UI。',
-            '标准能力：auth.getSession/auth.requireLogin 复用宿主登录；payments.alipay.pay 拉起支付宝并把支付结果传回小程序；payments.alipay.createOrder 仅作为宿主官方订单服务的可选能力；小程序商品、购买记录、权益状态由小程序自己保存；dharma.prepareContent/dharma.startGlobalSend 接入全球法布施；wifiHotspot.enable 接入本地场能热点；flashcards.createDeck 接入背诵闪卡；platformPublish.createDraft 接入发布草稿；fs.writeFile/fs.readFile、shell.execute、browser.open 用于本地文件处理、终端和浏览器。',
-            '高危权限包括 auth.token、payments.alipay、wifi.hotspot、local.loopback、fs.readWrite、shell.execute、browser.external、desktop.control；只有用户需求明确需要时才使用。',
+            '聊天后台调用协议：优先使用 window.FabushiMiniApp.bot.onCommand("/start", handler) 或 bot.onAnyCommand(handler)；如果手写监听 window 的 fabushi-miniapp-command 事件，注册后也要读取 window.__fabushiLastMiniAppCommand 并按 commandId 去重补处理。detail.command 默认为 /start，detail.args 是用户文本；处理完成后调用 bot.postMessage 或 bot.reportCommandResult 把进度/结果写回聊天框。',
+            '标准能力：auth.getSession/auth.requireLogin 复用宿主登录；payments.requestPayment 使用福德金支付并由宿主登记权益；payments.checkEntitlement 查询商品是否已解锁；payments.alipay.pay/createOrder 仅作为宿主官方现金支付兜底；dharma.prepareContent/dharma.startGlobalSend 接入全球法布施；wifiHotspot.enable 接入本地场能热点；flashcards.createDeck 接入背诵闪卡；platformPublish.createDraft 接入发布草稿；fs.writeFile/fs.readFile、shell.execute、browser.open 用于本地文件处理、终端和浏览器。',
+            '高危权限包括 auth.token、payments.alipay、payments.fudeGold、wifi.hotspot、local.loopback、fs.readWrite、shell.execute、browser.external、desktop.control；只有用户需求明确需要时才使用。',
             '禁止外链脚本、eval、Authorization token、桌面桥 token、OpenClaw token。',
             '不要调用 auth.getAccessToken，除非用户明确要求对接需要 token 的受信服务。',
             '优先实现一个可点击、可立即使用的小面板，包含 app.getContext 或 bot.sendMessage 示例。',

--- a/fabushi/lib/core/config/app_config.dart
+++ b/fabushi/lib/core/config/app_config.dart
@@ -244,10 +244,13 @@ class AppConfig {
       buildBackendUrl('/api/apple/verify-receipt');
   static String get purchaseEntitlementUrl =>
       buildBackendUrl('/api/purchases/entitlement');
+  static String get walletBalanceUrl => buildBackendUrl('/api/wallet/balance');
+  static String get walletSpendUrl => buildBackendUrl('/api/wallet/spend');
 
   static const String zenBuddhaAssetProductId = 'zen_buddha_asset';
   static const String zenBuddhaAssetDisplayName = '3D佛像素材';
   static const String zenBuddhaAssetPriceLabel = '¥33.00';
+  static const int zenBuddhaAssetFudeGoldPrice = 33;
   static const String zenBuddhaAssetCardImagePath =
       'assets/images/zen_buddha_material_card.png';
 

--- a/fabushi/lib/models/mini_app_model.dart
+++ b/fabushi/lib/models/mini_app_model.dart
@@ -163,7 +163,7 @@ class MiniAppRegistry {
   factory MiniAppRegistry.fromJson(Map<String, dynamic> json) {
     return MiniAppRegistry(
       schemaVersion: _readInt(json['schemaVersion']) ?? 1,
-      hostApiVersion: _readString(json, 'hostApiVersion', fallback: '1.2'),
+      hostApiVersion: _readString(json, 'hostApiVersion', fallback: '1.4'),
       bots: (json['bots'] as List? ?? const [])
           .whereType<Map>()
           .map((item) => MiniAppBot.fromJson(Map<String, dynamic>.from(item)))
@@ -275,6 +275,9 @@ MiniAppRegistry defaultMiniAppRegistry() {
     'app.context',
     'bot.chat',
     'auth.session',
+    'wallet.balance',
+    'payments.entitlement',
+    'payments.fudeGold',
     'payments.alipay',
     'dharma.share',
     'flashcards.create',
@@ -350,7 +353,7 @@ MiniAppRegistry defaultMiniAppRegistry() {
   ];
   return MiniAppRegistry(
     schemaVersion: 1,
-    hostApiVersion: '1.2',
+    hostApiVersion: '1.4',
     bots: bots,
     miniApps: [
       for (final bot in bots)
@@ -359,8 +362,8 @@ MiniAppRegistry defaultMiniAppRegistry() {
           botId: bot.botId,
           title: bot.title,
           subtitle: bot.subtitle,
-          entryUrl: 'https://fabushi.ombhrum.com/miniapps/${bot.miniAppId}',
-          version: '1.2.0',
+          entryUrl: 'https://fabushi-miniapps.pages.dev/miniapps/${bot.miniAppId}',
+          version: '1.4.0',
           permissions: bot.permissions,
           surfaces: const ['homePinned', 'chatPanel'],
           theme: 'telegramDark',

--- a/fabushi/lib/screens/mini_app_host_screen.dart
+++ b/fabushi/lib/screens/mini_app_host_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -11,6 +12,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 
+import '../core/config/app_config.dart';
 import '../features/auth/application/auth_model.dart';
 import '../features/flashcards/application/content_pipeline.dart';
 import '../features/flashcards/application/flashcard_service.dart';
@@ -31,21 +33,136 @@ import '../services/openclaw/openclaw_runtime.dart';
 import '../services/project_service.dart';
 import '../widgets/social/social_feature_bot.dart';
 
+typedef MiniAppHostEventCallback = void Function(Map<String, dynamic> event);
+
+class MiniAppHostCommand {
+  MiniAppHostCommand({
+    required this.text,
+    String? commandId,
+    String? command,
+    String? args,
+    this.background = true,
+    DateTime? createdAt,
+  }) : commandId = commandId ?? 'cmd_${DateTime.now().microsecondsSinceEpoch}',
+       command = command ?? _defaultCommandFor(text),
+       args = args ?? _defaultArgsFor(text),
+       createdAt = createdAt ?? DateTime.now();
+
+  final String commandId;
+  final String text;
+  final String command;
+  final String args;
+  final bool background;
+  final DateTime createdAt;
+
+  Map<String, dynamic> toJson() => {
+    'id': commandId,
+    'commandId': commandId,
+    'command': command,
+    'args': args,
+    'text': text,
+    'rawText': text,
+    'background': background,
+    'source': 'chat',
+    'createdAt': createdAt.toIso8601String(),
+  };
+
+  static String _defaultCommandFor(String text) {
+    final trimmed = text.trim();
+    if (!trimmed.startsWith('/')) return '/start';
+    final firstSpace = trimmed.indexOf(RegExp(r'\s'));
+    return firstSpace < 0 ? trimmed : trimmed.substring(0, firstSpace);
+  }
+
+  static String _defaultArgsFor(String text) {
+    final trimmed = text.trim();
+    if (!trimmed.startsWith('/')) return trimmed;
+    final firstSpace = trimmed.indexOf(RegExp(r'\s'));
+    if (firstSpace < 0) return '';
+    return trimmed.substring(firstSpace).trim();
+  }
+}
+
+class MiniAppHostController {
+  _MiniAppHostScreenState? _state;
+  Completer<_MiniAppHostScreenState> _attachedCompleter =
+      Completer<_MiniAppHostScreenState>();
+
+  bool get isAttached => _state != null;
+
+  void _attach(_MiniAppHostScreenState state) {
+    _state = state;
+    if (!_attachedCompleter.isCompleted) {
+      _attachedCompleter.complete(state);
+    }
+  }
+
+  void _detach(_MiniAppHostScreenState state) {
+    if (!identical(_state, state)) return;
+    _state = null;
+    if (_attachedCompleter.isCompleted) {
+      _attachedCompleter = Completer<_MiniAppHostScreenState>();
+    }
+  }
+
+  Future<Map<String, dynamic>> runCommand(
+    String text, {
+    String? command,
+    String? args,
+    String? commandId,
+    bool background = true,
+  }) async {
+    final state = await _waitForAttached();
+    return state._runCommand(
+      MiniAppHostCommand(
+        text: text,
+        command: command,
+        args: args,
+        commandId: commandId,
+        background: background,
+      ),
+    );
+  }
+
+  Future<_MiniAppHostScreenState> _waitForAttached() async {
+    final state = _state;
+    if (state != null) return state;
+    return _attachedCompleter.future.timeout(
+      const Duration(seconds: 8),
+      onTimeout: () {
+        throw const MiniAppHostException('host_not_ready', '小程序后台尚未挂载');
+      },
+    );
+  }
+}
+
 class MiniAppHostScreen extends StatefulWidget {
   const MiniAppHostScreen({
     super.key,
     required this.bot,
     this.inline = false,
-    this.messageStream,
+    this.headless = false,
+    this.onMinimize,
+    this.onClose,
+    this.startParam,
+    this.controller,
+    this.onMiniAppEvent,
     this.onCliStart,
     this.onCliLog,
+    this.reloadToken,
   });
 
   final SocialFeatureBot bot;
   final bool inline;
-  final Stream<String>? messageStream;
+  final bool headless;
+  final VoidCallback? onMinimize;
+  final VoidCallback? onClose;
+  final String? startParam;
+  final MiniAppHostController? controller;
+  final MiniAppHostEventCallback? onMiniAppEvent;
   final void Function(String title, String taskId)? onCliStart;
-  final void Function(String taskId, String log)? onCliLog;
+  final void Function(String taskId, String data)? onCliLog;
+  final String? reloadToken;
 
   @override
   State<MiniAppHostScreen> createState() => _MiniAppHostScreenState();
@@ -62,17 +179,21 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
   late final FlashcardService _flashcardService;
   bool _loading = true;
   String? _error;
-  
-  StreamSubscription<String>? _messageSub;
+
   InAppWebViewController? _webViewController;
   bool _hostReady = false;
-  final List<String> _pendingMessages = [];
+  Completer<void> _hostReadyCompleter = Completer<void>();
+  final Map<String, Map<String, dynamic>> _exposedBotCommands = {};
+  final List<Map<String, dynamic>> _pendingBotCommands = [];
+  final String _cacheBuster = DateTime.now().millisecondsSinceEpoch.toString();
 
   bool get _trustedOfficial => widget.bot.source == MiniAppSource.official;
 
   @override
   void initState() {
     super.initState();
+    widget.controller?._attach(this);
+    _seedBuiltInBotCommands();
     _flashcardRepository = FlashcardRepository();
     _contentPipeline = ContentPipeline(
       repository: _flashcardRepository,
@@ -82,46 +203,32 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
       repository: _flashcardRepository,
       aiService: _aiService,
     );
-    _messageSub = widget.messageStream?.listen(_sendMessageToWeb);
   }
 
   @override
   void didUpdateWidget(covariant MiniAppHostScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller?._detach(this);
+      widget.controller?._attach(this);
+    }
     final oldEntryUrl = _entryUrlFor(oldWidget.bot);
     final nextEntryUrl = _entryUrlFor(widget.bot);
-    if (oldEntryUrl != nextEntryUrl ||
-        oldWidget.bot.stableMiniAppId != widget.bot.stableMiniAppId) {
-      _hostReady = false;
-      _pendingMessages.clear();
-      if (mounted) {
-        setState(() {
-          _loading = true;
-          _error = null;
-        });
-      }
-      _webViewController?.loadUrl(
-        urlRequest: URLRequest(url: WebUri(nextEntryUrl)),
-      );
-    }
-    if (widget.messageStream != oldWidget.messageStream) {
-      _messageSub?.cancel();
-      _messageSub = widget.messageStream?.listen(_sendMessageToWeb);
-    }
-  }
 
-  void _sendMessageToWeb(String msg) {
-    if (_hostReady && _webViewController != null) {
-      final script = "window.dispatchEvent(new CustomEvent('fabushi-bot-message', { detail: { text: ${jsonEncode(msg)} } }));";
-      _webViewController!.evaluateJavascript(source: script);
-    } else {
-      _pendingMessages.add(msg);
+    if (oldEntryUrl != nextEntryUrl ||
+        oldWidget.bot.stableMiniAppId != widget.bot.stableMiniAppId ||
+        oldWidget.startParam != widget.startParam ||
+        oldWidget.reloadToken != widget.reloadToken) {
+      _markHostNotReady();
+      _exposedBotCommands.clear();
+      _seedBuiltInBotCommands();
+      if (mounted) setState(() {});
     }
   }
 
   @override
   void dispose() {
-    _messageSub?.cancel();
+    widget.controller?._detach(this);
     _httpClient.close();
     super.dispose();
   }
@@ -133,6 +240,13 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
         InAppWebView(
           key: ValueKey(_entryUrl),
           initialUrlRequest: URLRequest(url: WebUri(_entryUrl)),
+          initialUserScripts: UnmodifiableListView<UserScript>([
+            UserScript(
+              source: _hostSdkScript,
+              injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+              contentWorld: ContentWorld.PAGE,
+            ),
+          ]),
           initialSettings: InAppWebViewSettings(
             javaScriptEnabled: true,
             transparentBackground: false,
@@ -152,7 +266,7 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
             );
           },
           onLoadStart: (controller, url) {
-            _hostReady = false;
+            _markHostNotReady();
             if (mounted) {
               setState(() {
                 _loading = true;
@@ -163,14 +277,8 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
           onLoadStop: (controller, _) async {
             _webViewController = controller;
             await controller.evaluateJavascript(source: _hostSdkScript);
-            _hostReady = true;
+            _markHostReady();
             if (mounted) setState(() => _loading = false);
-            
-            for (final msg in _pendingMessages) {
-              final script = "window.dispatchEvent(new CustomEvent('fabushi-bot-message', { detail: { text: ${jsonEncode(msg)} } }));";
-              controller.evaluateJavascript(source: script);
-            }
-            _pendingMessages.clear();
           },
           onReceivedError: (controller, request, error) {
             if (mounted) {
@@ -203,10 +311,87 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
       ],
     );
 
+    if (widget.headless) {
+      return ColoredBox(color: const Color(0xFF0F1722), child: content);
+    }
+
     if (widget.inline) {
       return ClipRRect(
         borderRadius: BorderRadius.circular(18),
-        child: ColoredBox(color: const Color(0xFF0F1722), child: content),
+        child: ColoredBox(
+          color: const Color(0xFF0F1722),
+          child: Column(
+            children: [
+              Container(
+                height: 48,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF17212B),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        widget.bot.title,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(
+                        Icons.more_vert,
+                        size: 20,
+                        color: Colors.white70,
+                      ),
+                      onPressed: () {},
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(),
+                    ),
+                    if (widget.onMinimize != null) ...[
+                      const SizedBox(width: 16),
+                      IconButton(
+                        tooltip: '收起到后台',
+                        icon: const Icon(
+                          Icons.keyboard_tab,
+                          size: 20,
+                          color: Colors.white70,
+                        ),
+                        onPressed: widget.onMinimize,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+                    ],
+                    const SizedBox(width: 16),
+                    IconButton(
+                      tooltip: '关闭并销毁',
+                      icon: const Icon(
+                        Icons.close,
+                        size: 20,
+                        color: Colors.white70,
+                      ),
+                      onPressed: () {
+                        if (widget.onClose != null) {
+                          widget.onClose!();
+                        } else if (Navigator.of(context).canPop()) {
+                          Navigator.of(context).pop();
+                        }
+                      },
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(child: content),
+            ],
+          ),
+        ),
       );
     }
 
@@ -227,21 +412,300 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
 
   String _entryUrlFor(SocialFeatureBot bot) {
     final explicitEntryUrl = bot.stableMiniAppEntryUrl;
-    if (explicitEntryUrl.isNotEmpty) return explicitEntryUrl;
-    final id = Uri.encodeComponent(bot.stableMiniAppId);
-    return 'https://fabushi.ombhrum.com/miniapps/$id';
+    var base = explicitEntryUrl.isNotEmpty
+        ? explicitEntryUrl
+        : 'https://fabushi.ombhrum.com/miniapps/${Uri.encodeComponent(bot.stableMiniAppId)}';
+
+    final uri = Uri.parse(base);
+    final queryParams = Map<String, String>.from(uri.queryParameters);
+    queryParams['_t'] = _cacheBuster;
+    if (widget.startParam != null && widget.startParam!.isNotEmpty) {
+      queryParams['tgWebAppStartParam'] = base64UrlEncode(
+        utf8.encode(widget.startParam!),
+      );
+    }
+    if (widget.reloadToken != null && widget.reloadToken!.isNotEmpty) {
+      queryParams['_cmd'] = widget.reloadToken!;
+    }
+    return uri.replace(queryParameters: queryParams).toString();
+  }
+
+  void _markHostNotReady() {
+    _hostReady = false;
+    if (_hostReadyCompleter.isCompleted) {
+      _hostReadyCompleter = Completer<void>();
+    }
+  }
+
+  void _markHostReady() {
+    _hostReady = true;
+    if (!_hostReadyCompleter.isCompleted) {
+      _hostReadyCompleter.complete();
+    }
+  }
+
+  Future<void> _waitForHostReady() async {
+    if (_hostReady && _webViewController != null) return;
+    await _hostReadyCompleter.future.timeout(
+      const Duration(seconds: 20),
+      onTimeout: () {
+        throw const MiniAppHostException('host_not_ready', '小程序后台加载超时');
+      },
+    );
+  }
+
+  void _seedBuiltInBotCommands() {
+    final description = switch (widget.bot.effectiveKind) {
+      MiniAppBotKind.globalDharma => '启动全球法布施',
+      MiniAppBotKind.flashcards => '开始制作背诵闪卡',
+      MiniAppBotKind.platformPublish => '生成平台发布草稿',
+      MiniAppBotKind.botFather ||
+      MiniAppBotKind.assistant ||
+      MiniAppBotKind.thirdParty => null,
+    };
+    if (description == null) return;
+    _exposedBotCommands['/start'] = {
+      'command': '/start',
+      'description': description,
+      'source': 'manifest',
+      'registeredAt': DateTime.now().toIso8601String(),
+    };
+  }
+
+  Future<void> _waitForCommandExposed(String command) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 8));
+    while (mounted && DateTime.now().isBefore(deadline)) {
+      if (_exposedBotCommands.containsKey(command)) return;
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    throw MiniAppHostException(
+      'command_not_exposed',
+      '小程序未暴露 $command 能力',
+      data: {
+        'command': command,
+        'exposedCommands': _exposedBotCommands.keys.toList(),
+      },
+    );
+  }
+
+  Future<Map<String, dynamic>> _runCommand(MiniAppHostCommand command) async {
+    await _waitForHostReady();
+    final controller = _webViewController;
+    if (controller == null) {
+      throw const MiniAppHostException('host_not_ready', '小程序后台尚未就绪');
+    }
+    await _waitForCommandExposed(command.command);
+    final commandJson = command.toJson();
+    _enqueueBotCommand(commandJson);
+    final payload = jsonEncode(commandJson);
+    await controller.evaluateJavascript(
+      source:
+          '''
+(function () {
+  var detail = $payload;
+  if (window.FabushiMiniApp && window.FabushiMiniApp.__deliverCommand) {
+    window.FabushiMiniApp.__deliverCommand(detail);
+    return;
+  }
+  window.__fabushiLastMiniAppCommand = detail;
+  window.__fabushiMiniAppCommandQueue = window.__fabushiMiniAppCommandQueue || [];
+  window.__fabushiMiniAppCommandQueue.push(detail);
+  try {
+    var commandQueue = JSON.parse(window.localStorage.getItem('__fabushiMiniAppCommandQueue') || '[]');
+    commandQueue.push(detail);
+    window.localStorage.setItem('__fabushiMiniAppCommandQueue', JSON.stringify(commandQueue.slice(-50)));
+  } catch (e) {}
+  window.dispatchEvent(new CustomEvent('fabushi-miniapp-command', { detail: detail }));
+})();
+''',
+    );
+    return {
+      'accepted': true,
+      'delivered': true,
+      'queued': true,
+      'commandId': command.commandId,
+      'command': command.command,
+      'args': command.args,
+      'background': command.background,
+    };
+  }
+
+  void _enqueueBotCommand(Map<String, dynamic> command) {
+    _pendingBotCommands.add(command);
+    if (_pendingBotCommands.length > 50) {
+      _pendingBotCommands.removeRange(0, _pendingBotCommands.length - 50);
+    }
+  }
+
+  Map<String, dynamic> _takePendingBotCommands(Map<String, dynamic> params) {
+    _requirePermission('bot.chat');
+    final requestedCommand = params['command']?.toString().trim();
+    final taken = <Map<String, dynamic>>[];
+    final kept = <Map<String, dynamic>>[];
+    for (final command in _pendingBotCommands) {
+      if (requestedCommand == null ||
+          requestedCommand.isEmpty ||
+          command['command']?.toString() == requestedCommand) {
+        taken.add(command);
+      } else {
+        kept.add(command);
+      }
+    }
+    _pendingBotCommands
+      ..clear()
+      ..addAll(kept);
+    return {'commands': taken};
   }
 
   String get _hostSdkScript {
     return '''
 (function () {
   if (window.FabushiMiniApp) return;
+  function invoke(method, params) {
+    return window.flutter_inappwebview.callHandler('FabushiMiniAppInvoke', {
+      method: method,
+      params: params || {}
+    });
+  }
+  function commandKey(detail) {
+    if (!detail || typeof detail !== "object") return "";
+    return detail.commandId ||
+      detail.id ||
+      [detail.createdAt, detail.command, detail.rawText || detail.text]
+        .filter(Boolean)
+        .join(":");
+  }
+  function readStoredCommandQueue() {
+    try {
+      var raw = window.localStorage.getItem('__fabushiMiniAppCommandQueue') || '[]';
+      var parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      return [];
+    }
+  }
+  function writeStoredCommandQueue(queue) {
+    try {
+      window.localStorage.setItem('__fabushiMiniAppCommandQueue', JSON.stringify(queue.slice(-50)));
+    } catch (e) {}
+  }
+  function rememberCommand(detail) {
+    window.__fabushiLastMiniAppCommand = detail;
+    window.__fabushiMiniAppCommandQueue = window.__fabushiMiniAppCommandQueue || [];
+    window.__fabushiMiniAppCommandQueue.push(detail);
+    var stored = readStoredCommandQueue();
+    stored.push(detail);
+    writeStoredCommandQueue(stored);
+    try {
+      var log = JSON.parse(window.localStorage.getItem('__fabushiMiniAppCommandLog') || '[]');
+      log.push(detail);
+      window.localStorage.setItem('__fabushiMiniAppCommandLog', JSON.stringify(log.slice(-50)));
+    } catch (e) {}
+  }
+  function queuedCommands() {
+    var commands = [];
+    if (window.__fabushiLastMiniAppCommand) commands.push(window.__fabushiLastMiniAppCommand);
+    if (Array.isArray(window.__fabushiMiniAppCommandQueue)) {
+      commands = commands.concat(window.__fabushiMiniAppCommandQueue);
+      window.__fabushiMiniAppCommandQueue = [];
+    }
+    commands = commands.concat(readStoredCommandQueue());
+    writeStoredCommandQueue([]);
+    return commands;
+  }
+  function deliverCommand(callback, seen, detail) {
+    if (!detail || typeof detail !== "object") return;
+    var key = commandKey(detail);
+    if (key) {
+      if (seen.has(key)) return;
+      seen.add(key);
+    }
+    callback(detail);
+  }
+  function drainQueuedCommands(callback, seen) {
+    var commands = queuedCommands();
+    commands.forEach(function(detail) {
+      deliverCommand(callback, seen, detail);
+    });
+  }
+  function onAnyCommand(callback) {
+    var seen = new Set();
+    var handler = function(event) {
+      deliverCommand(callback, seen, event && event.detail);
+    };
+    window.addEventListener("fabushi-miniapp-command", handler);
+    (window.queueMicrotask || function(fn) { setTimeout(fn, 0); })(function() {
+      drainQueuedCommands(callback, seen);
+    });
+    return function() {
+      window.removeEventListener("fabushi-miniapp-command", handler);
+    };
+  }
+  function onCommand(command, callback) {
+    return onAnyCommand(function(detail) {
+      if (detail.command === command) callback(detail.args || "", detail);
+    });
+  }
+  function exposeCommand(command, callback, options) {
+    options = options || {};
+    var commands = [{
+      command: command,
+      description: options.description || ''
+    }];
+    invoke('bot.setCommands', { commands: commands }).catch(function() {});
+    return onCommand(command, callback);
+  }
+  function deliverFromHost(detail) {
+    rememberCommand(detail);
+    window.dispatchEvent(new CustomEvent('fabushi-miniapp-command', { detail: detail }));
+  }
   window.FabushiMiniApp = {
-    invoke: function(method, params) {
-      return window.flutter_inappwebview.callHandler('FabushiMiniAppInvoke', {
-        method: method,
-        params: params || {}
-      });
+    version: '1.4.0',
+    invoke: invoke,
+    __deliverCommand: deliverFromHost,
+    app: {
+      getContext: function() { return invoke('app.getContext'); },
+      getCapabilities: function() { return invoke('app.getCapabilities'); },
+      getHostApiSpec: function() { return invoke('app.getHostApiSpec'); },
+      getTheme: function() { return invoke('app.getTheme'); }
+    },
+    auth: {
+      getSession: function() { return invoke('auth.getSession'); },
+      requireLogin: function() { return invoke('auth.requireLogin'); },
+      getAccessToken: function() { return invoke('auth.getAccessToken'); }
+    },
+    payments: {
+      requestPayment: function(params) { return invoke('payments.requestPayment', params || {}); },
+      checkEntitlement: function(params) { return invoke('payments.checkEntitlement', params || {}); },
+      alipay: {
+        createOrder: function(params) { return invoke('payments.alipay.createOrder', params || {}); },
+        pay: function(params) { return invoke('payments.alipay.pay', params || {}); },
+        queryOrder: function(params) { return invoke('payments.alipay.queryOrder', params || {}); },
+        checkEntitlement: function(params) { return invoke('payments.alipay.checkEntitlement', params || {}); }
+      }
+    },
+    wallet: {
+      getBalance: function(params) { return invoke('wallet.getBalance', params || {}); }
+    },
+    bot: {
+      sendMessage: function(params) { return invoke('bot.sendMessage', params || {}); },
+      postMessage: function(params) { return invoke('bot.postMessage', params || {}); },
+      reportCommandResult: function(params) { return invoke('bot.reportCommandResult', params || {}); },
+      takePendingCommands: function(params) { return invoke('bot.takePendingCommands', params || {}); },
+      openPanel: function(params) { return invoke('bot.openPanel', params || {}); },
+      setPanelState: function(params) { return invoke('bot.setPanelState', params || {}); },
+      setCommands: function(params) { return invoke('bot.setCommands', params || {}); },
+      close: function(params) { return invoke('bot.close', params || {}); },
+      onAnyCommand: onAnyCommand,
+      onCommand: onCommand,
+      exposeCommand: exposeCommand
+    },
+    dharma: {
+      getSendStatus: function() { return invoke('dharma.getSendStatus'); },
+      setSendOptions: function(params) { return invoke('dharma.setSendOptions', params || {}); },
+      selectHighEnergyMaterial: function() { return invoke('dharma.selectHighEnergyMaterial'); },
+      startGlobalSend: function(params) { return invoke('dharma.startGlobalSend', params || {}); },
+      stopGlobalSend: function() { return invoke('dharma.stopGlobalSend'); }
     },
     ready: true
   };
@@ -294,6 +758,13 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
         return _requireLogin();
       case 'auth.getAccessToken':
         return _authAccessToken();
+      case 'wallet.getBalance':
+        return _getWalletBalance(params);
+      case 'payments.requestPayment':
+        return _requestFudeGoldPayment(params);
+      case 'payments.checkEntitlement':
+      case 'payments.alipay.checkEntitlement':
+        return _checkPurchaseEntitlement(params);
       case 'payments.alipay.createOrder':
         return _createAlipayOrder(params);
       case 'payments.alipay.pay':
@@ -308,8 +779,23 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
         return _disableWifiHotspot();
       case 'bot.sendMessage':
         return _botSendMessage(params);
+      case 'bot.postMessage':
+        return _botPostMessage(params);
+      case 'bot.reportCommandResult':
+        return _botReportCommandResult(params);
+      case 'bot.takePendingCommands':
+        return _takePendingBotCommands(params);
       case 'bot.openPanel':
       case 'bot.setPanelState':
+        return {'accepted': true};
+      case 'bot.setCommands':
+        return _botSetCommands(params);
+      case 'bot.close':
+        if (widget.onClose != null) {
+          widget.onClose!();
+        } else if (Navigator.of(context).canPop()) {
+          Navigator.of(context).pop();
+        }
         return {'accepted': true};
       case 'ai.chat':
         return _aiChat(params);
@@ -367,7 +853,8 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
 
   Map<String, dynamic> _appContext() {
     return {
-      'hostApiVersion': '1.2',
+      'hostApiVersion': '1.4',
+      'hostSdkVersion': '1.4.0',
       'bot': {
         'botId': widget.bot.stableBotId,
         'title': widget.bot.title,
@@ -399,11 +886,35 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
 
   Map<String, dynamic> _hostApiSpec() {
     return {
-      'hostApiVersion': '1.2',
+      'hostApiVersion': '1.4',
+      'hostSdkVersion': '1.4.0',
       'invokePattern': 'window.FabushiMiniApp.invoke(method, params)',
+      'commandProtocol': {
+        'event': 'fabushi-miniapp-command',
+        'lastCommandCache': 'window.__fabushiLastMiniAppCommand',
+        'helpers': [
+          'window.FabushiMiniApp.bot.onAnyCommand(callback)',
+          'window.FabushiMiniApp.bot.onCommand(command, callback)',
+        ],
+        'defaultCommand': '/start',
+        'detail': {
+          'id': 'stable command id',
+          'command': '/start',
+          'args': 'message text without command prefix',
+          'text': 'raw chat text',
+          'background': true,
+          'source': 'chat',
+        },
+        'resultMethods': ['bot.postMessage', 'bot.reportCommandResult'],
+      },
       'permissionGroups': {
         'identity': ['auth.session', 'auth.token'],
-        'payments': ['payments.alipay'],
+        'payments': [
+          'payments.alipay',
+          'payments.entitlement',
+          'payments.fudeGold',
+          'wallet.balance',
+        ],
         'dharma': ['dharma.share', 'wifi.hotspot', 'local.loopback'],
         'creation': ['flashcards.create', 'platform.publish'],
         'localAutomation': [
@@ -425,6 +936,21 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
           'description': '读取当前小程序已获准的权限列表。',
         },
         {
+          'method': 'bot.postMessage',
+          'permission': 'bot.chat',
+          'description': '小程序把后台命令进度、结果或错误写回机器人聊天框。',
+        },
+        {
+          'method': 'bot.reportCommandResult',
+          'permission': 'bot.chat',
+          'description': '小程序按 commandId 上报后台命令完成、失败或仍在运行。',
+        },
+        {
+          'method': 'bot.takePendingCommands',
+          'permission': 'bot.chat',
+          'description': '小程序从宿主消息队列拉取聊天命令；宿主只做消息媒介，不执行业务逻辑。',
+        },
+        {
           'method': 'auth.getSession',
           'permission': 'auth.session',
           'description': '读取宿主登录态、脱敏用户资料和会员状态，不返回 token。',
@@ -443,6 +969,21 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
           'method': 'payments.alipay.createOrder',
           'permission': 'payments.alipay',
           'description': '可选：用宿主官方支付后台创建支付宝订单；小程序自己的商品和购买记录仍由小程序保存。',
+        },
+        {
+          'method': 'payments.checkEntitlement',
+          'permission': 'payments.entitlement',
+          'description': '查询宿主后端是否已解锁一次性付费商品，供小程序避免重复购买。',
+        },
+        {
+          'method': 'payments.requestPayment',
+          'permission': 'payments.fudeGold',
+          'description': '请求宿主弹出原生确认并扣除福德金，成功后由宿主登记权益。',
+        },
+        {
+          'method': 'wallet.getBalance',
+          'permission': 'wallet.balance',
+          'description': '读取当前用户福德金余额。',
         },
         {
           'method': 'payments.alipay.pay',
@@ -541,15 +1082,28 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     };
   }
 
-  Future<Map<String, dynamic>> _requireLogin() async {
+  Future<Map<String, dynamic>> _requireLogin({bool force = false}) async {
     _requirePermission('auth.session');
     final auth = Provider.of<AuthModel?>(context, listen: false);
-    if (auth?.isLoggedIn == true) return _authSession();
+    if (!force && auth?.isLoggedIn == true) return _authSession();
     if (!mounted) {
       throw const MiniAppHostException('host_disposed', '小程序宿主已关闭');
     }
+    if (force && auth?.isLoggedIn == true) {
+      await auth!.logout();
+      if (!mounted) {
+        throw const MiniAppHostException('host_disposed', '小程序宿主已关闭');
+      }
+    }
     await Navigator.of(context, rootNavigator: true).pushNamed('/login');
-    return _authSession();
+    final session = _authSession();
+    if (session['authenticated'] != true) {
+      throw MiniAppHostException(
+        'login_required',
+        force ? '登录已过期，请重新登录' : '请先登录',
+      );
+    }
+    return session;
   }
 
   Map<String, dynamic> _authAccessToken() {
@@ -562,16 +1116,129 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     return {'token': token, 'tokenType': 'Bearer'};
   }
 
+  Future<Map<String, dynamic>> _getWalletBalance(
+    Map<String, dynamic> params,
+  ) async {
+    _requirePermission('wallet.balance');
+    final currency = params['currency']?.toString().trim().toUpperCase();
+    final result = await _runMembershipRequestWithAuthRetry(
+      (token) => _membershipService.getWalletBalance(
+        token,
+        currency: currency == null || currency.isEmpty ? 'FUDE_GOLD' : currency,
+      ),
+    );
+    _throwIfAuthFailure(result);
+    if (result['success'] != true) {
+      throw MiniAppHostException(
+        'wallet_balance_failed',
+        result['message']?.toString() ?? '查询福德金余额失败',
+      );
+    }
+    return {
+      'currency': result['currency'] ?? 'FUDE_GOLD',
+      'displayName': result['displayName'] ?? '福德金',
+      'balance': result['balance'] ?? 0,
+    };
+  }
+
+  Future<Map<String, dynamic>> _requestFudeGoldPayment(
+    Map<String, dynamic> params,
+  ) async {
+    _requirePermission('payments.fudeGold');
+    final currency =
+        (params['currency']?.toString().trim().toUpperCase() ?? 'FUDE_GOLD');
+    if (currency != 'FUDE_GOLD') {
+      throw const MiniAppHostException('unsupported_currency', '暂仅支持福德金支付');
+    }
+    final productId = _readProductId(params);
+    final amount = _readPaymentAmount(params);
+    final rawTitle = params['title']?.toString().trim() ?? '';
+    final title = rawTitle.isNotEmpty
+        ? rawTitle
+        : AppConfig.zenBuddhaAssetDisplayName;
+    final confirmed = await _confirmFudeGoldPayment(
+      title: title,
+      amount: amount,
+    );
+    if (!confirmed) {
+      throw const MiniAppHostException('payment_cancelled', '已取消福德金支付');
+    }
+
+    final result = await _runMembershipRequestWithAuthRetry(
+      (token) => _membershipService.spendWalletBalance(
+        token,
+        productId: productId,
+        amount: amount,
+        currency: currency,
+        miniAppId: widget.bot.stableMiniAppId,
+        idempotencyKey: params['idempotencyKey']?.toString(),
+        description: title,
+      ),
+    );
+    _throwIfAuthFailure(result);
+    if (result['success'] != true) {
+      final details = result['details'];
+      throw MiniAppHostException(
+        result['statusCode'] == 402
+            ? 'wallet_insufficient_funds'
+            : 'wallet_payment_failed',
+        result['message']?.toString() ?? '福德金支付失败',
+        data: details,
+      );
+    }
+
+    return {
+      'paid': result['paid'] == true,
+      'provider': result['provider'] ?? 'fude_gold',
+      'currency': result['currency'] ?? currency,
+      'productId': result['productId'] ?? productId,
+      'amount': result['amount'] ?? amount,
+      'transactionId': result['transactionId'],
+      'balance': result['balance'],
+      'unlocked': result['unlocked'] == true,
+      'alreadyProcessed': result['alreadyProcessed'] == true,
+    };
+  }
+
+  Future<bool> _confirmFudeGoldPayment({
+    required String title,
+    required int amount,
+  }) async {
+    if (!mounted) {
+      throw const MiniAppHostException('host_disposed', '小程序宿主已关闭');
+    }
+    final accepted = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('确认福德金支付'),
+        content: Text('是否支付 $amount 福德金解锁「$title」？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('取消'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('支付'),
+          ),
+        ],
+      ),
+    );
+    return accepted == true;
+  }
+
   Future<Map<String, dynamic>> _createAlipayOrder(
     Map<String, dynamic> params,
   ) async {
     _requirePermission('payments.alipay');
-    final token = _requireAuthToken();
     final plan = _readProductId(params);
     final useWeb = params['web'] == true || !_isNativeAndroid;
-    final result = useWeb
-        ? await _membershipService.createAlipayWebOrder(token, plan)
-        : await _membershipService.createAlipayOrder(token, plan);
+    final result = await _runMembershipRequestWithAuthRetry(
+      (token) => useWeb
+          ? _membershipService.createAlipayWebOrder(token, plan)
+          : _membershipService.createAlipayOrder(token, plan),
+    );
+    _throwIfAuthFailure(result);
     if (result['success'] != true) {
       throw MiniAppHostException(
         'alipay_order_failed',
@@ -588,6 +1255,33 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
       'qrCode': result['qrCode'],
       'orderString': result['orderString'],
       'web': useWeb,
+    };
+  }
+
+  Future<Map<String, dynamic>> _checkPurchaseEntitlement(
+    Map<String, dynamic> params,
+  ) async {
+    _requireAnyPermission(const [
+      'payments.entitlement',
+      'payments.alipay',
+      'payments.fudeGold',
+    ]);
+    final productId = _readProductId(params);
+    final token = _requireAuthToken();
+    final result = await _membershipService.checkPurchaseEntitlement(
+      token,
+      productId,
+    );
+    _throwIfAuthFailure(result);
+    if (result['success'] != true) {
+      throw MiniAppHostException(
+        'entitlement_check_failed',
+        result['message']?.toString() ?? '查询付费项目状态失败',
+      );
+    }
+    return {
+      'productId': result['product'] ?? productId,
+      'unlocked': result['unlocked'] == true,
     };
   }
 
@@ -659,6 +1353,9 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     Map<String, dynamic> result;
     if (auth?.isLoggedIn == true && token != null && token.isNotEmpty) {
       result = await _membershipService.queryAlipayOrderStatus(token, orderId);
+      if (_isAuthFailureResponse(result)) {
+        result = await _membershipService.queryAlipayOrderPublic(orderId);
+      }
     } else {
       result = await _membershipService.queryAlipayOrderPublic(orderId);
     }
@@ -672,14 +1369,15 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     final nestedOrder = result['order'] is Map
         ? Map<String, dynamic>.from(result['order'] as Map)
         : const <String, dynamic>{};
-    final status = (result['status'] ??
-            result['tradeStatus'] ??
-            result['resultStatus'] ??
-            nestedOrder['status'] ??
-            nestedOrder['tradeStatus'] ??
-            '')
-        .toString()
-        .toUpperCase();
+    final status =
+        (result['status'] ??
+                result['tradeStatus'] ??
+                result['resultStatus'] ??
+                nestedOrder['status'] ??
+                nestedOrder['tradeStatus'] ??
+                '')
+            .toString()
+            .toUpperCase();
     final paidStatuses = {'PAID', 'SUCCESS', 'TRADE_SUCCESS', '9000'};
     final pendingStatuses = {'PENDING', 'WAIT_BUYER_PAY', '8000', '6004'};
     return {
@@ -726,6 +1424,37 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     return '本地场能未开启';
   }
 
+  Map<String, dynamic> _botSetCommands(Map<String, dynamic> params) {
+    _requirePermission('bot.chat');
+    final commands = params['commands'];
+    if (commands is! List) {
+      throw const MiniAppHostException('invalid_request', 'commands 必须是数组');
+    }
+
+    final registered = <Map<String, dynamic>>[];
+    for (final item in commands) {
+      if (item is! Map) continue;
+      final spec = Map<String, dynamic>.from(item);
+      final rawCommand = spec['command']?.toString().trim() ?? '';
+      if (rawCommand.isEmpty) continue;
+      final command = rawCommand.startsWith('/') ? rawCommand : '/$rawCommand';
+      final normalizedSpec = <String, dynamic>{
+        ...spec,
+        'command': command,
+        'source': 'mini_app',
+        'registeredAt': DateTime.now().toIso8601String(),
+      };
+      _exposedBotCommands[command] = normalizedSpec;
+      registered.add(normalizedSpec);
+    }
+
+    return {
+      'accepted': true,
+      'commands': registered,
+      'exposedCommands': _exposedBotCommands.keys.toList()..sort(),
+    };
+  }
+
   Future<Map<String, dynamic>> _botSendMessage(
     Map<String, dynamic> params,
   ) async {
@@ -734,6 +1463,53 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
       throw const MiniAppHostException('invalid_request', 'message 不能为空');
     }
     return _aiChat({'message': message});
+  }
+
+  Map<String, dynamic> _botPostMessage(Map<String, dynamic> params) {
+    _requirePermission('bot.chat');
+    final message = params['message']?.toString().trim().isNotEmpty == true
+        ? params['message'].toString().trim()
+        : params['text']?.toString().trim() ?? '';
+    if (message.isEmpty) {
+      throw const MiniAppHostException('invalid_request', 'message 不能为空');
+    }
+    final level = params['level']?.toString().trim().toLowerCase() ?? 'info';
+    final event = {
+      'type': 'bot.message',
+      'miniAppId': widget.bot.stableMiniAppId,
+      'botId': widget.bot.stableBotId,
+      'text': message,
+      'level': level,
+      'isError': level == 'error',
+      if (params['commandId'] != null) 'commandId': params['commandId'],
+      if (params['data'] != null) 'data': params['data'],
+      'createdAt': DateTime.now().toIso8601String(),
+    };
+    widget.onMiniAppEvent?.call(event);
+    return {'accepted': true};
+  }
+
+  Map<String, dynamic> _botReportCommandResult(Map<String, dynamic> params) {
+    _requirePermission('bot.chat');
+    final status =
+        params['status']?.toString().trim().toLowerCase() ?? 'completed';
+    final message = params['message']?.toString().trim().isNotEmpty == true
+        ? params['message'].toString().trim()
+        : params['text']?.toString().trim() ?? '';
+    final event = {
+      'type': 'bot.commandResult',
+      'miniAppId': widget.bot.stableMiniAppId,
+      'botId': widget.bot.stableBotId,
+      'status': status,
+      'text': message,
+      'level': status == 'failed' ? 'error' : 'info',
+      'isError': status == 'failed',
+      if (params['commandId'] != null) 'commandId': params['commandId'],
+      if (params['data'] != null) 'data': params['data'],
+      'createdAt': DateTime.now().toIso8601String(),
+    };
+    widget.onMiniAppEvent?.call(event);
+    return {'accepted': true};
   }
 
   Future<Map<String, dynamic>> _aiChat(Map<String, dynamic> params) async {
@@ -776,6 +1552,9 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
         content.errorMessage ?? '内容提取失败',
       );
     }
+    if (!mounted) {
+      throw const MiniAppHostException('host_disposed', '小程序宿主已关闭');
+    }
     final model = Provider.of<FileTransferModel>(context, listen: false);
     await model.addTextContentForSending(
       title: content.title,
@@ -815,7 +1594,9 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
 
     if (touchesGlobal) {
       model.setGlobalSendEnabled(wantsGlobal);
-      model.setCountryList(wantsGlobal ? (countryCodes.isEmpty ? ['ALL'] : countryCodes) : []);
+      model.setCountryList(
+        wantsGlobal ? (countryCodes.isEmpty ? ['ALL'] : countryCodes) : [],
+      );
     }
 
     if (params.containsKey('loop')) {
@@ -836,6 +1617,9 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
       final enableLoopback =
           params['localLoopback'] == true || regionMode == 'loopback';
       if (enableLoopback) {
+        if (!mounted) {
+          throw const MiniAppHostException('host_disposed', '小程序宿主已关闭');
+        }
         final auth = Provider.of<AuthModel?>(context, listen: false);
         final hasPremiumAccess = auth?.hasPermission('premium') ?? false;
         if (!hasPremiumAccess) {
@@ -853,6 +1637,10 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
 
   Future<Map<String, dynamic>> _selectHighEnergyMaterial() async {
     _requirePermission('dharma.share');
+    await _requireProductEntitlement(AppConfig.zenBuddhaAssetProductId);
+    if (!mounted) {
+      throw const MiniAppHostException('host_disposed', '小程序宿主已关闭');
+    }
     final model = Provider.of<FileTransferModel>(context, listen: false);
     await model.addZenBuddhaAssetForSending();
     return _globalDharmaStatus();
@@ -954,9 +1742,7 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
         url: url == null || url.isEmpty ? null : url,
         title: title.isEmpty ? defaultTitle : title,
         sourceApp: sourceApp,
-        sourceType: url == null || url.isEmpty
-            ? 'miniapp_text'
-            : 'miniapp_url',
+        sourceType: url == null || url.isEmpty ? 'miniapp_text' : 'miniapp_url',
       ),
     );
   }
@@ -1002,6 +1788,9 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
       requirement: requirement,
       maxCards: maxCards,
     );
+    if (!mounted) {
+      throw const MiniAppHostException('host_disposed', '小程序宿主已关闭');
+    }
     final auth = Provider.of<AuthModel?>(context, listen: false);
     final stream = mode == 'ai'
         ? _flashcardService.generateAiCardsStream(
@@ -1059,10 +1848,8 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     }
     await Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
-        builder: (_) => FlashcardStudyScreen(
-          deck: deck!,
-          repository: _flashcardRepository,
-        ),
+        builder: (_) =>
+            FlashcardStudyScreen(deck: deck!, repository: _flashcardRepository),
       ),
     );
     return {'opened': true, 'deckId': deckId};
@@ -1285,7 +2072,7 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     if (path.isEmpty) {
       throw const MiniAppHostException('invalid_request', '路径不能为空');
     }
-    
+
     // Convert to absolute path if relative, storing in Documents
     final resolvedPath = await _resolvePath(path);
     final file = File(resolvedPath);
@@ -1303,7 +2090,7 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     if (path.isEmpty) {
       throw const MiniAppHostException('invalid_request', '路径不能为空');
     }
-    
+
     final resolvedPath = await _resolvePath(path);
     final file = File(resolvedPath);
     if (!await file.exists()) {
@@ -1313,7 +2100,9 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     return {'ok': true, 'content': content, 'path': resolvedPath};
   }
 
-  Future<Map<String, dynamic>> _shellExecute(Map<String, dynamic> params) async {
+  Future<Map<String, dynamic>> _shellExecute(
+    Map<String, dynamic> params,
+  ) async {
     _requirePermission('shell.execute');
     if (!AiBackendPolicy.isDesktopNative) {
       throw const MiniAppHostException('unsupported_platform', '当前平台不支持执行终端命令');
@@ -1324,7 +2113,7 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
         .toList();
     final workingDirectory = params['workingDirectory']?.toString();
     final title = params['title']?.toString() ?? '执行终端命令';
-    
+
     if (command.isEmpty) {
       throw const MiniAppHostException('invalid_request', '命令不能为空');
     }
@@ -1332,28 +2121,25 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     try {
       final taskId = DateTime.now().millisecondsSinceEpoch.toString();
       widget.onCliStart?.call(title, taskId);
-      
+
       final process = await Process.start(
         command,
         arguments,
         workingDirectory: workingDirectory,
         runInShell: true,
       );
-      
+
       process.stdout.transform(utf8.decoder).listen((data) {
         widget.onCliLog?.call(taskId, data);
       });
       process.stderr.transform(utf8.decoder).listen((data) {
         widget.onCliLog?.call(taskId, data);
       });
-      
+
       final exitCode = await process.exitCode;
       widget.onCliLog?.call(taskId, '\\n[进程已结束，退出码: $exitCode]');
-      
-      return {
-        'ok': exitCode == 0,
-        'exitCode': exitCode,
-      };
+
+      return {'ok': exitCode == 0, 'exitCode': exitCode};
     } catch (e) {
       throw MiniAppHostException('execution_failed', '执行失败: $e');
     }
@@ -1383,13 +2169,25 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
   Future<String> _resolvePath(String inputPath) async {
     if (p.isAbsolute(inputPath)) return inputPath;
     final docs = await getApplicationDocumentsDirectory();
-    final miniAppDir = Directory(p.join(docs.path, 'fabushi_miniapps', widget.bot.stableMiniAppId));
+    final miniAppDir = Directory(
+      p.join(docs.path, 'fabushi_miniapps', widget.bot.stableMiniAppId),
+    );
     return p.normalize(p.join(miniAppDir.path, inputPath));
   }
 
   void _requirePermission(String permission) {
     if (widget.bot.permissions.contains(permission)) return;
     throw MiniAppHostException('permission_denied', '小程序未声明或未获准使用 $permission');
+  }
+
+  void _requireAnyPermission(List<String> permissions) {
+    for (final permission in permissions) {
+      if (widget.bot.permissions.contains(permission)) return;
+    }
+    throw MiniAppHostException(
+      'permission_denied',
+      '小程序未声明或未获准使用 ${permissions.join('/')}',
+    );
   }
 
   String _requireAuthToken() {
@@ -1401,6 +2199,41 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     return token;
   }
 
+  Future<Map<String, dynamic>> _runMembershipRequestWithAuthRetry(
+    Future<Map<String, dynamic>> Function(String token) request,
+  ) async {
+    var token = _requireAuthToken();
+    var result = await request(token);
+    if (_isAuthFailureResponse(result)) {
+      await _requireLogin(force: true);
+      token = _requireAuthToken();
+      result = await request(token);
+    }
+    return result;
+  }
+
+  Future<void> _requireProductEntitlement(String productId) async {
+    final entitlement = await _checkPurchaseEntitlement({
+      'productId': productId,
+    });
+    if (entitlement['unlocked'] != true) {
+      throw MiniAppHostException(
+        'purchase_required',
+        '${AppConfig.zenBuddhaAssetDisplayName}尚未解锁',
+      );
+    }
+  }
+
+  bool _isAuthFailureResponse(Map<String, dynamic> result) {
+    return result['statusCode'] == 401 || result['errorKey'] == 'INVALID_TOKEN';
+  }
+
+  void _throwIfAuthFailure(Map<String, dynamic> result) {
+    if (_isAuthFailureResponse(result)) {
+      throw const MiniAppHostException('login_required', '登录已过期，请重新登录');
+    }
+  }
+
   String _readProductId(Map<String, dynamic> params) {
     final rawProductId = params['productId']?.toString().trim() ?? '';
     final rawPlan = params['plan']?.toString().trim() ?? '';
@@ -1409,6 +2242,20 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
       throw const MiniAppHostException('invalid_request', 'productId 不能为空');
     }
     return productId;
+  }
+
+  int _readPaymentAmount(Map<String, dynamic> params) {
+    final raw = params['amount'];
+    final parsed = switch (raw) {
+      int v => v,
+      num v => v.toInt(),
+      String v => int.tryParse(v),
+      _ => null,
+    };
+    if (parsed == null || parsed <= 0) {
+      throw const MiniAppHostException('invalid_request', '福德金金额不能为空');
+    }
+    return parsed;
   }
 
   bool get _isNativeAndroid {

--- a/fabushi/lib/screens/social_feature_chat_screen.dart
+++ b/fabushi/lib/screens/social_feature_chat_screen.dart
@@ -7,11 +7,7 @@ import 'package:provider/provider.dart';
 
 import '../core/config/app_config.dart';
 import '../features/auth/application/auth_model.dart';
-import '../features/flashcards/application/content_pipeline.dart';
-import '../features/flashcards/application/flashcard_service.dart';
-import '../features/flashcards/data/flashcard_repository.dart';
 import '../features/flashcards/domain/flashcard_models.dart';
-import '../features/flashcards/presentation/flashcard_study_screen.dart';
 import '../models/file_transfer_model.dart'
     if (dart.library.html) '../models/file_transfer_model_web.dart';
 import '../models/mini_app_model.dart';
@@ -33,11 +29,12 @@ class SocialFeatureChatScreen extends StatefulWidget {
 class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
   final TextEditingController _composer = TextEditingController();
   final ScrollController _scroll = ScrollController();
-  final Map<String, List<_ChatMessage>> _messages = {};
-  late final FlashcardRepository _flashcardRepository;
-  late final ContentPipeline _contentPipeline;
-  late final FlashcardService _flashcardService;
-  final DharmaPublishService _publishService = DharmaPublishService();
+  static final Map<String, List<_ChatMessage>> _sharedMessages = {};
+  static final Map<String, _MiniAppSession> _sharedMiniAppSessions = {};
+
+  final Map<String, List<_ChatMessage>> _messages = _sharedMessages;
+  final Map<String, _MiniAppSession> _miniAppSessions = _sharedMiniAppSessions;
+  final Map<String, String> _cliTaskBotIds = {};
   final http.Client _httpClient = http.Client();
   final Set<DharmaPublishPlatform> _platforms = {
     DharmaPublishPlatform.xiaohongshu,
@@ -46,11 +43,9 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
   bool _busy = false;
   String _activity = '';
   bool _miniAppPanelOpen = false;
-  SocialFeatureBot? _panelBot;
-  final StreamController<String> _miniAppMessageController = StreamController<String>.broadcast();
+  String? _visibleMiniAppKey;
 
   SocialFeatureBot get _bot => widget.bot;
-  SocialFeatureBot get _activePanelBot => _panelBot ?? _bot;
   MiniAppBotKind get _kind => widget.bot.effectiveKind;
   List<_ChatMessage> get _botMessages =>
       _messages.putIfAbsent(widget.bot.stableBotId, () => []);
@@ -58,12 +53,6 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
   @override
   void initState() {
     super.initState();
-    _flashcardRepository = FlashcardRepository();
-    _contentPipeline = ContentPipeline(repository: _flashcardRepository);
-    _flashcardService = FlashcardService(
-      repository: _flashcardRepository,
-      aiService: DachengAiService(),
-    );
     _ensureGreeting(widget.bot);
   }
 
@@ -73,7 +62,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
     if (oldWidget.bot.stableBotId != widget.bot.stableBotId) {
       _composer.clear();
       _miniAppPanelOpen = false;
-      _panelBot = null;
+      _visibleMiniAppKey = null;
       _ensureGreeting(widget.bot);
       _scrollBottom();
     }
@@ -81,7 +70,6 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
 
   @override
   void dispose() {
-    _miniAppMessageController.close();
     _httpClient.close();
     _composer.dispose();
     _scroll.dispose();
@@ -114,6 +102,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
       builder: (context, constraints) {
         final wide = constraints.maxWidth >= 980;
         final chatPaddingRight = (wide && _miniAppPanelOpen) ? 430.0 : 0.0;
+        final sessions = _orderedMiniAppSessions();
 
         return Stack(
           children: [
@@ -130,51 +119,77 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
                   child: Container(color: Colors.black54),
                 ),
               ),
-            AnimatedPositioned(
-              duration: const Duration(milliseconds: 250),
-              curve: Curves.easeInOut,
-              top: wide ? 0 : (_miniAppPanelOpen ? constraints.maxHeight * 0.14 : constraints.maxHeight),
-              bottom: wide ? 0 : (_miniAppPanelOpen ? 0 : -constraints.maxHeight * 0.86),
-              right: wide ? (_miniAppPanelOpen ? 0 : -430) : 0,
-              left: wide ? null : 0,
-              width: wide ? 430 : null,
-              child: Container(
-                padding: wide ? const EdgeInsets.all(12) : const EdgeInsets.fromLTRB(10, 10, 10, 10),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF0B111A),
-                  border: wide ? const Border(left: BorderSide(color: Color(0xFF223040))) : null,
-                  borderRadius: wide ? null : const BorderRadius.vertical(top: Radius.circular(24)),
-                ),
-                child: MiniAppHostScreen(
-                  key: ValueKey(
-                    '${_activePanelBot.stableBotId}:${_activePanelBot.stableMiniAppId}:${_activePanelBot.stableMiniAppEntryUrl}',
-                  ),
-                  bot: _activePanelBot,
-                  inline: true,
-                  messageStream: _miniAppMessageController.stream,
-                  onCliStart: (title, taskId) {
-                    if (!mounted) return;
-                    setState(() {
-                      _botMessages.add(_ChatMessage.cliTask(title, taskId));
-                    });
-                    _scrollBottom();
-                  },
-                  onCliLog: (taskId, log) {
-                    if (!mounted) return;
-                    setState(() {
-                      final msg = _botMessages.lastWhere((m) => m.cliTaskId == taskId, orElse: () => _botMessages.first);
-                      if (msg.cliLogs != null) {
-                        msg.cliLogs!.add(log);
-                      }
-                    });
-                    _scrollBottom();
-                  },
-                ),
+            for (var i = 0; i < sessions.length; i++)
+              _buildMiniAppSessionHost(
+                sessions[i],
+                index: i,
+                constraints: constraints,
+                wide: wide,
               ),
-            ),
           ],
         );
       },
+    );
+  }
+
+  List<_MiniAppSession> _orderedMiniAppSessions() {
+    final sessions = _miniAppSessions.values.toList(growable: false);
+    sessions.sort((a, b) {
+      final aVisible = a.key == _visibleMiniAppKey;
+      final bVisible = b.key == _visibleMiniAppKey;
+      if (aVisible == bVisible) return 0;
+      return aVisible ? 1 : -1;
+    });
+    return sessions;
+  }
+
+  Widget _buildMiniAppSessionHost(
+    _MiniAppSession session, {
+    required int index,
+    required BoxConstraints constraints,
+    required bool wide,
+  }) {
+    assert(index >= 0);
+    final visible = _miniAppPanelOpen && session.key == _visibleMiniAppKey;
+    final compactTop = constraints.maxHeight * 0.14;
+
+    // 不把后台小程序移出屏幕。macOS/桌面端 PlatformView/WebView 在被移出可见区域后，
+    // 再回到前台时可能重新挂载，导致 React 内存态日志丢失，看起来像“新小程序”。
+    // 保持同一个 WebView 在原位置，只做透明和 IgnorePointer，打开时就是刚刚后台调用的实例。
+    return Positioned(
+      key: ValueKey('miniapp-position:${session.key}'),
+      top: wide ? 0 : compactTop,
+      bottom: 0,
+      right: 0,
+      left: wide ? null : 0,
+      width: wide ? 430 : null,
+      child: IgnorePointer(
+        ignoring: !visible,
+        child: AnimatedOpacity(
+          opacity: visible ? 1 : 0.001,
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeInOut,
+          child: _MiniAppHostFrame(
+            wide: wide,
+            child: MiniAppHostScreen(
+              key: ValueKey('miniapp-session:${session.key}'),
+              bot: session.bot,
+              inline: true,
+              onMinimize: _hideMiniAppPanel,
+              onClose: _closeVisibleMiniAppSession,
+              startParam: session.startParam,
+              reloadToken: session.startParamVersion == 0
+                  ? null
+                  : session.startParamVersion.toString(),
+              controller: session.controller,
+              onMiniAppEvent: _handleMiniAppEvent,
+              onCliStart: (title, taskId) =>
+                  _handleMiniAppCliStart(session.bot.stableBotId, title, taskId),
+              onCliLog: _handleMiniAppCliLog,
+            ),
+          ),
+        ),
+      ),
     );
   }
 
@@ -239,7 +254,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
           ),
           IconButton(
             tooltip: _miniAppPanelOpen ? '关闭侧栏' : '打开侧栏',
-            onPressed: _openMiniAppPanel,
+            onPressed: _toggleMiniAppPanel,
             icon: Icon(
               _miniAppPanelOpen ? Icons.web_asset_off : Icons.web_asset,
               color: const Color(0xFF91A3B7),
@@ -298,7 +313,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
           icon: _bot.icon,
           label: '小程序面板',
           active: _miniAppPanelOpen,
-          onTap: _openMiniAppPanel,
+          onTap: _toggleMiniAppPanel,
         ),
       ],
     };
@@ -328,12 +343,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
       itemCount: count,
       itemBuilder: (context, index) {
         if (index < _botMessages.length) {
-          return _MessageBubble(
-            message: _botMessages[index],
-            bot: _bot,
-            onDeck: _openDeck,
-            onOpenMiniApp: () => setState(() => _miniAppPanelOpen = true),
-          );
+          return _MessageBubble(message: _botMessages[index], bot: _bot);
         }
         if (_busy && index == _botMessages.length) {
           return _ThinkingBubble(label: _activity.isEmpty ? '正在处理' : _activity);
@@ -345,7 +355,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
 
   Widget _buildComposer(FileTransferModel model, bool canSend) {
     final hasMiniApp = _bot.miniAppId != null && _bot.miniAppId!.isNotEmpty;
-    
+
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 10, 20, 18),
       decoration: const BoxDecoration(
@@ -366,7 +376,10 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(16),
                   ),
-                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 10,
+                  ),
                   elevation: 0,
                 ),
                 icon: const Icon(Icons.web_asset, size: 20),
@@ -379,10 +392,7 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
           IconButton(
             tooltip: '附件',
             onPressed: () {},
-            icon: const Icon(
-              Icons.attach_file,
-              color: Color(0xFF91A3B7),
-            ),
+            icon: const Icon(Icons.attach_file, color: Color(0xFF91A3B7)),
           ),
           Expanded(
             child: TextField(
@@ -410,7 +420,10 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
                   vertical: 10,
                 ),
                 suffixIcon: IconButton(
-                  icon: const Icon(Icons.sentiment_satisfied_alt, color: Color(0xFF91A3B7)),
+                  icon: const Icon(
+                    Icons.sentiment_satisfied_alt,
+                    color: Color(0xFF91A3B7),
+                  ),
                   onPressed: () {},
                 ),
               ),
@@ -461,37 +474,162 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
   }
 
   void _submit(FileTransferModel model) {
+    if (_shouldRouteMessageToMiniApp) {
+      unawaited(_startMiniAppCommand());
+      return;
+    }
+
     switch (_kind) {
-      case MiniAppBotKind.globalDharma:
-      case MiniAppBotKind.flashcards:
-      case MiniAppBotKind.platformPublish:
-        _startMiniAppChat();
-        return;
       case MiniAppBotKind.botFather:
         unawaited(_startBotFather());
         return;
       case MiniAppBotKind.assistant:
-      case MiniAppBotKind.thirdParty:
         unawaited(_startGenericBotChat());
+        return;
+      case MiniAppBotKind.globalDharma:
+      case MiniAppBotKind.flashcards:
+      case MiniAppBotKind.platformPublish:
+      case MiniAppBotKind.thirdParty:
+        unawaited(_startMiniAppCommand());
         return;
     }
   }
 
-  void _startMiniAppChat() {
+  bool get _shouldRouteMessageToMiniApp {
+    final hasMiniApp = _bot.miniAppId?.trim().isNotEmpty == true;
+    if (!hasMiniApp) return false;
+    return switch (_kind) {
+      MiniAppBotKind.globalDharma ||
+      MiniAppBotKind.flashcards ||
+      MiniAppBotKind.platformPublish ||
+      MiniAppBotKind.thirdParty => true,
+      MiniAppBotKind.botFather || MiniAppBotKind.assistant => false,
+    };
+  }
+
+  Future<void> _startMiniAppCommand() async {
     final text = _composer.text.trim();
     if (text.isEmpty) return;
     _composer.clear();
     setState(() {
       _botMessages.add(_ChatMessage.user(text));
-      _botMessages.add(_ChatMessage.miniAppAction(
-        '已收到消息，正在后台静默处理。您随时可以点击下方组件进入应用查看。',
-        '打开 ${_bot.title}',
-      ));
+      _busy = true;
+      _activity = '正在调用 ${_bot.title}...';
     });
     _scrollBottom();
-    
-    // Send to background silent webview
-    _miniAppMessageController.add(text);
+
+    try {
+      final session = await _ensureMiniAppSession(_bot);
+      final wasForeground =
+          _miniAppPanelOpen && _visibleMiniAppKey == session.key;
+      final result = await session.controller.runCommand(text);
+      session
+        ..lastCommandAt = DateTime.now()
+        ..lastCommandText = text;
+      if (!mounted) return;
+      setState(() {
+        _botMessages.add(
+          _ChatMessage.bot(
+            wasForeground
+                ? '已发送给当前打开的「${_bot.title}」，由小程序执行。\n命令：${result['command'] ?? '/start'}'
+                : '已发送给后台运行的「${_bot.title}」，由小程序执行。\n点击「打开应用」会回到同一个小程序实例。\n命令：${result['command'] ?? '/start'}',
+          ),
+        );
+      });
+    } catch (e) {
+      if (mounted) _botMessages.add(_ChatMessage.error('调用失败：$e'));
+    } finally {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          _activity = '';
+        });
+      }
+      _scrollBottom();
+    }
+  }
+
+  Future<_MiniAppSession> _ensureMiniAppSession(
+    SocialFeatureBot bot, {
+    String? startParam,
+  }) async {
+    final key = _miniAppSessionKey(bot);
+    var session = _miniAppSessions[key];
+    if (session == null) {
+      session = _MiniAppSession(
+        key: key,
+        bot: bot,
+        startParam: startParam,
+        controller: MiniAppHostController(),
+      );
+      setState(() => _miniAppSessions[key] = session!);
+      await WidgetsBinding.instance.endOfFrame;
+    } else {
+      if (startParam != null) {
+        setState(() {
+          session!
+            ..bot = bot
+            ..startParam = startParam
+            ..startParamVersion += 1;
+        });
+        await WidgetsBinding.instance.endOfFrame;
+      } else {
+        session.bot = bot;
+      }
+    }
+    return session;
+  }
+
+  String _miniAppSessionKey(SocialFeatureBot bot) {
+    return '${bot.stableBotId}:${bot.stableMiniAppId}';
+  }
+
+  void _handleMiniAppEvent(Map<String, dynamic> event) {
+    if (!mounted) return;
+    final text = event['text']?.toString().trim() ?? '';
+    if (text.isEmpty) return;
+    final isError = event['isError'] == true || event['level'] == 'error';
+    final botId = event['botId']?.toString().trim() ?? _bot.stableBotId;
+    setState(() {
+      final messages = _messages.putIfAbsent(botId, () => []);
+      messages.add(isError ? _ChatMessage.error(text) : _ChatMessage.bot(text));
+    });
+    if (botId == _bot.stableBotId) _scrollBottom();
+  }
+
+  void _handleMiniAppCliStart(String botId, String title, String taskId) {
+    if (!mounted) return;
+    _cliTaskBotIds[taskId] = botId;
+    setState(() {
+      final messages = _messages.putIfAbsent(botId, () => []);
+      messages.add(_ChatMessage.cliTask(title, taskId));
+    });
+    if (botId == _bot.stableBotId) _scrollBottom();
+  }
+
+  void _handleMiniAppCliLog(String taskId, String data) {
+    if (!mounted) return;
+    setState(() {
+      _ChatMessage? message;
+      final botId = _cliTaskBotIds[taskId];
+      final candidateLists = botId == null
+          ? _messages.values
+          : [_messages.putIfAbsent(botId, () => [])];
+      for (final list in candidateLists) {
+        for (final item in list) {
+          if (item.cliTaskId == taskId) message = item;
+        }
+      }
+      final logs = message?.cliLogs;
+      if (logs == null) return;
+      logs.addAll(
+        data.split(RegExp(r'\r?\n')).where((line) => line.trim().isNotEmpty),
+      );
+      if (logs.length > 160) {
+        logs.removeRange(0, logs.length - 160);
+      }
+    });
+    if (_cliTaskBotIds[taskId] == _bot.stableBotId) _scrollBottom();
   }
 
   Future<void> _startBotFather() async {
@@ -615,207 +753,48 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
     }
   }
 
-  void _openMiniAppPanel([SocialFeatureBot? panelBot]) {
-    setState(() {
-      if (panelBot != null) _panelBot = panelBot;
-      _miniAppPanelOpen = panelBot != null ? true : !_miniAppPanelOpen;
-    });
-  }
-
-  Future<void> _startGlobal(FileTransferModel model) async {
-    final text = _composer.text.trim();
-    _composer.clear();
-    setState(() {
-      if (text.isNotEmpty) {
-        _botMessages.add(_ChatMessage.user(text));
-      }
-      _busy = true;
-      _activity = '正在准备素材...';
-    });
-    _scrollBottom();
-    try {
-      if (text.isNotEmpty) {
-        await _saveTextToModel(
-          model,
-          text,
-          '全球法布施',
-          replaceExisting: !model.hasFiles,
-        );
-      }
-      if (!model.hasFiles) throw StateError('请先输入文字、链接，或点击 + 添加素材。');
-      setState(() => _activity = '正在启动发送...');
-      await model.startGlobalTransfer();
-      if (!mounted) return;
-      _botMessages.add(
-        _ChatMessage.bot(
-          '已完成：${model.globalSentCount} 个节点，${model.globalDataSentMB.toStringAsFixed(2)} MB。',
-        ),
-      );
-    } catch (e) {
-      if (mounted) _botMessages.add(_ChatMessage.error('启动失败：$e'));
-    } finally {
-      if (mounted) {
-        setState(() {
-          _busy = false;
-          _activity = '';
-        });
-      }
-      _scrollBottom();
+  void _toggleMiniAppPanel() {
+    if (_miniAppPanelOpen) {
+      _hideMiniAppPanel();
+    } else {
+      _openMiniAppPanel();
     }
   }
 
-  Future<void> _startFlashcards() async {
-    final text = _composer.text.trim();
-    if (text.isEmpty) return;
-    _composer.clear();
-    final progress = _ChatMessage.bot('正在准备内容...');
-    setState(() {
-      _botMessages.add(_ChatMessage.user(text));
-      _botMessages.add(progress);
-      _busy = true;
-      _activity = '正在提取正文...';
-    });
-    _scrollBottom();
-    try {
-      final url = ContentPipeline.firstHttpUrl(text);
-      final content = await _contentPipeline.prepare(
-        ContentInput(
-          text: text,
-          url: url,
-          title: url == null ? '背诵内容' : '链接内容',
-        ),
-      );
-      if (content.isFailed) throw StateError(content.errorMessage ?? '内容提取失败');
-      if (!mounted) return;
-      final auth = Provider.of<AuthModel?>(context, listen: false);
-      final input = FlashcardInput(
-        title: content.title,
-        text: content.text,
-        documentId: content.document?.id,
-        sourceUrl: content.sourceUrl,
-      );
-      final stream = _flashcardMode == FlashcardCreationMode.aiCards
-          ? _flashcardService.generateAiCardsStream(
-              input,
-              token: auth?.authToken,
-              username: auth?.currentUser?.username,
-              isMember: auth?.hasPermission('premium') ?? false,
-            )
-          : _flashcardService.generateRandomClozeStream(input);
-      await for (final event in stream) {
-        if (!mounted) return;
-        setState(() {
-          _activity = event.message;
-          progress.text = event.progress > 0
-              ? '${event.message} (${event.progress}%)'
-              : event.message;
-        });
-        if (event.isDone && event.deck != null) {
-          _botMessages.add(
-            _ChatMessage.deck(
-              '制卡完成：${event.deck!.cardCount} 张 · ${event.deck!.mode.label}',
-              event.deck!,
-            ),
-          );
-        }
-        if (event.isError) throw StateError(event.message);
-        _scrollBottom();
-      }
-    } catch (e) {
-      if (mounted) _botMessages.add(_ChatMessage.error('制卡失败：$e'));
-    } finally {
-      if (mounted) {
-        setState(() {
-          _busy = false;
-          _activity = '';
-        });
-      }
-      _scrollBottom();
-    }
+  void _hideMiniAppPanel() {
+    setState(() => _miniAppPanelOpen = false);
   }
 
-  Future<void> _startPublish(FileTransferModel model) async {
-    final text = _composer.text.trim();
-    _composer.clear();
-    setState(() {
-      if (text.isNotEmpty) {
-        _botMessages.add(_ChatMessage.user(text));
-      }
-      _busy = true;
-      _activity = '正在生成发布草稿...';
-    });
-    _scrollBottom();
-    try {
-      if (text.isNotEmpty) {
-        await _saveTextToModel(model, text, '法布施发布', replaceExisting: true);
-      }
-      if (!model.hasFiles && text.isEmpty) {
-        throw StateError('请输入正文/链接，或点击 + 添加素材。');
-      }
-      var draft = _publishService.buildDraftFromModel(
-        model,
-        fallbackText: text,
-      );
-      if (draft.title.trim().isEmpty) {
-        draft = draft.copyWith(title: _publishService.suggestTitle(draft));
-      }
-      if (draft.body.trim().length < 12) {
-        draft = draft.copyWith(body: _publishService.polishBody(draft));
-      }
-      _botMessages.add(
-        _ChatMessage.bot(
-          _publishService.buildPreviewMarkdown(draft, _platforms),
-        ),
-      );
-      setState(() => _activity = '正在复制草稿并打开入口...');
-      final results = await _publishService.publishDraft(
-        draft: draft,
-        platforms: _platforms,
-      );
-      if (!mounted) return;
-      _botMessages.add(
-        _ChatMessage.bot(
-          results
-              .map((r) => '${r.platform.info.shortLabel}：${r.message}')
-              .join('\n'),
-        ),
-      );
-    } catch (e) {
-      if (mounted) _botMessages.add(_ChatMessage.error('发布失败：$e'));
-    } finally {
-      if (mounted) {
-        setState(() {
-          _busy = false;
-          _activity = '';
-        });
-      }
-      _scrollBottom();
-    }
+  void _openMiniAppPanel([SocialFeatureBot? bot, String? startParam]) {
+    unawaited(_showMiniAppPanel(bot, startParam));
   }
 
-  Future<void> _saveTextToModel(
-    FileTransferModel model,
-    String text,
-    String fallbackTitle, {
-    required bool replaceExisting,
-  }) async {
-    final uri = Uri.tryParse(text);
-    final isLink =
-        uri != null && (uri.scheme == 'http' || uri.scheme == 'https');
-    await model.addTextContentForSending(
-      title: isLink ? uri.host : _shortTitle(text, fallbackTitle),
-      text: isLink ? '来源链接: ${uri.toString()}\n\n${uri.toString()}' : text,
-      sourceKind: isLink ? '链接' : '文本',
-      sourceUrl: isLink ? uri.toString() : null,
-      previewText: text,
-      replaceExisting: replaceExisting,
+  Future<void> _showMiniAppPanel([
+    SocialFeatureBot? bot,
+    String? startParam,
+  ]) async {
+    final session = await _ensureMiniAppSession(
+      bot ?? _bot,
+      startParam: startParam,
     );
+    if (!mounted) return;
+    setState(() {
+      _visibleMiniAppKey = session.key;
+      _miniAppPanelOpen = true;
+    });
   }
 
-  String _shortTitle(String text, String fallback) {
-    final normalized = text.replaceAll(RegExp(r'\s+'), ' ').trim();
-    if (normalized.isEmpty) return fallback;
-    return normalized.length <= 18 ? normalized : normalized.substring(0, 18);
+  void _closeVisibleMiniAppSession() {
+    final key = _visibleMiniAppKey;
+    if (key == null) {
+      _hideMiniAppPanel();
+      return;
+    }
+    setState(() {
+      _miniAppSessions.remove(key);
+      _visibleMiniAppKey = null;
+      _miniAppPanelOpen = false;
+    });
   }
 
   void _openCurrentSettings(FileTransferModel model) {
@@ -1007,16 +986,6 @@ class _SocialFeatureChatScreenState extends State<SocialFeatureChatScreen> {
         : '${labels.take(2).join('、')} 等 ${labels.length} 个';
   }
 
-  void _openDeck(FlashcardDeck deck) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) =>
-            FlashcardStudyScreen(deck: deck, repository: _flashcardRepository),
-      ),
-    );
-  }
-
   void _scrollBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!_scroll.hasClients) return;
@@ -1034,18 +1003,12 @@ class _ChatMessage {
     this.text, {
     required this.isUser,
     this.isError = false,
-    this.deck,
-    this.isMiniAppAction = false,
-    this.actionLabel,
     this.cliTaskId,
     this.cliLogs,
   });
   String text;
   final bool isUser;
   final bool isError;
-  final FlashcardDeck? deck;
-  final bool isMiniAppAction;
-  final String? actionLabel;
   final String? cliTaskId;
   List<String>? cliLogs;
 
@@ -1053,25 +1016,31 @@ class _ChatMessage {
   factory _ChatMessage.bot(String text) => _ChatMessage(text, isUser: false);
   factory _ChatMessage.error(String text) =>
       _ChatMessage(text, isUser: false, isError: true);
-  factory _ChatMessage.deck(String text, FlashcardDeck deck) =>
-      _ChatMessage(text, isUser: false, deck: deck);
-  factory _ChatMessage.miniAppAction(String text, String actionLabel) =>
-      _ChatMessage(text, isUser: false, isMiniAppAction: true, actionLabel: actionLabel);
   factory _ChatMessage.cliTask(String text, String taskId) =>
       _ChatMessage(text, isUser: false, cliTaskId: taskId, cliLogs: []);
 }
 
-class _MessageBubble extends StatelessWidget {
-  const _MessageBubble({
-    required this.message,
+class _MiniAppSession {
+  _MiniAppSession({
+    required this.key,
     required this.bot,
-    required this.onDeck,
-    required this.onOpenMiniApp,
+    required this.controller,
+    this.startParam,
   });
+
+  final String key;
+  SocialFeatureBot bot;
+  final MiniAppHostController controller;
+  String? startParam;
+  int startParamVersion = 0;
+  DateTime? lastCommandAt;
+  String? lastCommandText;
+}
+
+class _MessageBubble extends StatelessWidget {
+  const _MessageBubble({required this.message, required this.bot});
   final _ChatMessage message;
   final SocialFeatureBot bot;
-  final ValueChanged<FlashcardDeck> onDeck;
-  final VoidCallback onOpenMiniApp;
 
   @override
   Widget build(BuildContext context) {
@@ -1120,7 +1089,9 @@ class _MessageBubble extends StatelessWidget {
                   child: Text(
                     message.text,
                     style: TextStyle(
-                      color: message.isError ? const Color(0xFFFFD4D8) : Colors.white,
+                      color: message.isError
+                          ? const Color(0xFFFFD4D8)
+                          : Colors.white,
                       fontSize: 15,
                       height: 1.4,
                       fontWeight: FontWeight.w400,
@@ -1133,45 +1104,24 @@ class _MessageBubble extends StatelessWidget {
                     Text(
                       '10:42', // Placeholder time
                       style: TextStyle(
-                        color: user ? const Color(0xFF75AEEB) : const Color(0xFF728196),
+                        color: user
+                            ? const Color(0xFF75AEEB)
+                            : const Color(0xFF728196),
                         fontSize: 11,
                       ),
                     ),
                     if (user) ...[
                       const SizedBox(width: 4),
-                      const Icon(Icons.done_all, color: Color(0xFF40A7E3), size: 14),
+                      const Icon(
+                        Icons.done_all,
+                        color: Color(0xFF40A7E3),
+                        size: 14,
+                      ),
                     ],
                   ],
                 ),
               ],
             ),
-            if (message.deck != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: FilledButton.icon(
-                  onPressed: () => onDeck(message.deck!),
-                  icon: const Icon(Icons.play_arrow_rounded),
-                  label: const Text('开始背诵'),
-                  style: FilledButton.styleFrom(
-                    backgroundColor: const Color(0xFF2A394C),
-                    foregroundColor: Colors.white,
-                  ),
-                ),
-              ),
-            if (message.isMiniAppAction)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: FilledButton.icon(
-                  onPressed: onOpenMiniApp,
-                  icon: const Icon(Icons.web_asset),
-                  label: Text(message.actionLabel ?? '打开应用'),
-                  style: FilledButton.styleFrom(
-                    backgroundColor: const Color(0xFF2A394C),
-                    foregroundColor: Colors.white,
-                    minimumSize: const Size(double.infinity, 44),
-                  ),
-                ),
-              ),
             if (message.cliTaskId != null && message.cliLogs != null)
               Container(
                 margin: const EdgeInsets.only(top: 8),
@@ -1187,15 +1137,42 @@ class _MessageBubble extends StatelessWidget {
                   children: [
                     const Row(
                       children: [
-                        Icon(Icons.terminal, color: Colors.greenAccent, size: 16),
+                        Icon(
+                          Icons.terminal,
+                          color: Colors.greenAccent,
+                          size: 16,
+                        ),
                         SizedBox(width: 8),
-                        Text('执行日志', style: TextStyle(color: Colors.white70, fontSize: 12, fontWeight: FontWeight.bold)),
+                        Text(
+                          '执行日志',
+                          style: TextStyle(
+                            color: Colors.white70,
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
                       ],
                     ),
                     const SizedBox(height: 8),
                     if (message.cliLogs!.isEmpty)
-                      const Text('等待输出...', style: TextStyle(color: Colors.grey, fontSize: 13, fontFamily: 'monospace')),
-                    ...message.cliLogs!.map((log) => Text(log, style: const TextStyle(color: Colors.greenAccent, fontSize: 13, fontFamily: 'monospace'))),
+                      const Text(
+                        '等待输出...',
+                        style: TextStyle(
+                          color: Colors.grey,
+                          fontSize: 13,
+                          fontFamily: 'monospace',
+                        ),
+                      ),
+                    ...message.cliLogs!.map(
+                      (log) => Text(
+                        log,
+                        style: const TextStyle(
+                          color: Colors.greenAccent,
+                          fontSize: 13,
+                          fontFamily: 'monospace',
+                        ),
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -1242,6 +1219,32 @@ class _ThinkingBubble extends StatelessWidget {
       ),
     ),
   );
+}
+
+class _MiniAppHostFrame extends StatelessWidget {
+  const _MiniAppHostFrame({required this.wide, required this.child});
+
+  final bool wide;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: wide
+          ? const EdgeInsets.all(12)
+          : const EdgeInsets.fromLTRB(10, 10, 10, 10),
+      decoration: BoxDecoration(
+        color: const Color(0xFF0B111A),
+        border: wide
+            ? const Border(left: BorderSide(color: Color(0xFF223040)))
+            : null,
+        borderRadius: wide
+            ? null
+            : const BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      child: child,
+    );
+  }
 }
 
 class _GlobalProgress extends StatelessWidget {

--- a/fabushi/lib/services/membership_service.dart
+++ b/fabushi/lib/services/membership_service.dart
@@ -139,6 +139,84 @@ class MembershipService {
     }
   }
 
+  Future<Map<String, dynamic>> getWalletBalance(
+    String token, {
+    String currency = 'FUDE_GOLD',
+  }) async {
+    try {
+      final endpoint = Uri.parse(AppConfig.walletBalanceUrl).path;
+      final response = await _apiClient.get(
+        endpoint,
+        token: token,
+        queryParams: {'currency': currency},
+      );
+
+      if (_isSuccess(response)) {
+        final wallet = response['wallet'] is Map
+            ? Map<String, dynamic>.from(response['wallet'] as Map)
+            : const <String, dynamic>{};
+        return {
+          'success': true,
+          'currency': wallet['currency'] ?? currency,
+          'balance': wallet['balance'] ?? 0,
+          'displayName': wallet['displayName'] ?? currency,
+        };
+      }
+
+      return _failureResponse(response, '查询福德金余额失败');
+    } catch (e) {
+      debugPrint('查询福德金余额失败: $e');
+      return {'success': false, 'message': '网络连接失败'};
+    }
+  }
+
+  Future<Map<String, dynamic>> spendWalletBalance(
+    String token, {
+    required String productId,
+    required int amount,
+    String currency = 'FUDE_GOLD',
+    String? miniAppId,
+    String? idempotencyKey,
+    String? description,
+  }) async {
+    try {
+      final endpoint = Uri.parse(AppConfig.walletSpendUrl).path;
+      final body = <String, dynamic>{
+        'productId': productId,
+        'amount': amount,
+        'currency': currency,
+        'miniAppId': miniAppId,
+        'idempotencyKey': idempotencyKey,
+        'description': description,
+      }..removeWhere((_, value) => value == null);
+      final response = await _apiClient.post(
+        endpoint,
+        token: token,
+        body: body,
+      );
+
+      if (_isSuccess(response)) {
+        return {
+          'success': true,
+          'paid': response['paid'] == true,
+          'provider': response['provider'],
+          'currency': response['currency'] ?? currency,
+          'productId': response['productId'] ?? productId,
+          'amount': response['amount'] ?? amount,
+          'transactionId': response['transactionId'],
+          'balance': response['balance'],
+          'unlocked': response['unlocked'] == true,
+          'alreadyProcessed': response['alreadyProcessed'] == true,
+        };
+      }
+
+      return _failureResponse(response, '福德金支付失败');
+    } catch (e) {
+      debugPrint('福德金支付失败: $e');
+      return {'success': false, 'message': '网络连接失败'};
+    }
+  }
+
   Future<Map<String, dynamic>> queryAlipayOrderStatus(
     String token,
     String orderId,

--- a/frontend/apps/web/src/app/miniapps/[id]/FlashcardsApp.tsx
+++ b/frontend/apps/web/src/app/miniapps/[id]/FlashcardsApp.tsx
@@ -2,15 +2,8 @@
 
 import React, { useState } from "react";
 import { BookOpenCheck, Layers, Sparkles, WandSparkles } from "lucide-react";
+import { miniAppHost } from "./miniapp-sdk";
 import "./miniapps.css";
-
-async function invokeHost(method: string, params: Record<string, any> = {}) {
-  const sdk = (window as any).FabushiMiniApp;
-  if (!sdk?.invoke) throw new Error("SDK 尚未就绪");
-  const res = await sdk.invoke(method, params);
-  if (!res?.ok) throw new Error(res?.message || "宿主调用失败");
-  return res.data;
-}
 
 export default function FlashcardsApp() {
   const [text, setText] = useState("");
@@ -22,8 +15,38 @@ export default function FlashcardsApp() {
 
   const log = (msg: string) => setLogs((prev) => [...prev, `[${new Date().toLocaleTimeString()}] ${msg}`]);
 
-  const handleCreate = async () => {
-    const fullText = text.trim();
+  const handleCreateRef = React.useRef<(overrideText?: string, commandId?: string) => Promise<void>>();
+
+  React.useEffect(() => {
+    const { startParam } = miniAppHost.bot.getInitData?.() || {};
+    if (startParam) {
+      setText(startParam);
+      log(`收到启动参数: ${startParam}`);
+      if (startParam.trim().startsWith("http://") || startParam.trim().startsWith("https://")) {
+        setTimeout(() => handleCreateRef.current?.(startParam), 100);
+      }
+    }
+    const unsubscribeStart = (
+      miniAppHost.bot.exposeCommand?.(
+        "/start",
+        (args, event) => {
+          if (args) setText(args);
+          log("收到 /start 制卡命令");
+          void handleCreateRef.current?.(args, event?.commandId);
+        },
+        { description: "用正文或链接生成背诵闪卡" },
+      ) ||
+      miniAppHost.bot.onCommand?.("/start", (args, event) => {
+        if (args) setText(args);
+        log("收到 /start 制卡命令");
+        void handleCreateRef.current?.(args, event?.commandId);
+      })
+    );
+    return () => unsubscribeStart?.();
+  }, []);
+
+  const handleCreate = async (overrideText?: string, commandId?: string) => {
+    const fullText = (overrideText ?? text).trim();
     if (!fullText) {
       log("请输入需要制卡的内容");
       return;
@@ -33,7 +56,7 @@ export default function FlashcardsApp() {
     setDeck(null);
     try {
       log(`正在使用${mode === "ai" ? "AI 制卡" : "随机挖空"}模式...`);
-      const data = await invokeHost("flashcards.createDeck", {
+      const data = await miniAppHost.flashcards.createDeck({
         title: "背诵闪卡",
         text: fullText,
         mode,
@@ -42,17 +65,33 @@ export default function FlashcardsApp() {
       });
       setDeck(data.deck);
       log(data.message || `制卡完成：${data.deck?.cardCount || 0} 张`);
+      if (commandId) {
+        await miniAppHost.bot.reportCommandResult?.({
+          commandId,
+          status: "completed",
+          message: data.message || `制卡完成：${data.deck?.cardCount || 0} 张`,
+          data,
+        });
+      }
     } catch (error: any) {
       log(error.message || "制卡失败");
+      if (commandId) {
+        await miniAppHost.bot.reportCommandResult?.({
+          commandId,
+          status: "failed",
+          message: error.message || "制卡失败",
+        }).catch(() => {});
+      }
     } finally {
       setLoading(false);
     }
   };
+  handleCreateRef.current = handleCreate;
 
   const handleOpenDeck = async () => {
     if (!deck?.id) return;
     try {
-      await invokeHost("flashcards.openDeck", { deckId: deck.id });
+      await miniAppHost.flashcards.openDeck(deck.id);
     } catch (error: any) {
       log(error.message || "打开卡组失败");
     }
@@ -99,7 +138,7 @@ export default function FlashcardsApp() {
         </>
       )}
 
-      <button className="ma-btn" onClick={handleCreate} disabled={loading}>
+      <button className="ma-btn" onClick={() => handleCreate()} disabled={loading}>
         <BookOpenCheck size={19} />
         {loading ? "生成中" : "生成卡组"}
       </button>

--- a/frontend/apps/web/src/app/miniapps/[id]/GlobalDharmaApp.tsx
+++ b/frontend/apps/web/src/app/miniapps/[id]/GlobalDharmaApp.tsx
@@ -3,6 +3,14 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { CircleStop, Globe, Link2, RefreshCw, Send, Sparkles } from "lucide-react";
 import * as THREE from "three";
+import {
+  createEntitlementCache,
+  EntitlementState,
+  isHostErrorCode,
+  isHostReady,
+  miniAppHost,
+  onMiniAppReady,
+} from "./miniapp-sdk";
 import "./miniapps.css";
 
 type RegionPreset = {
@@ -28,27 +36,34 @@ const HIGH_ENERGY_PRODUCT = {
   title: "3D佛像素材",
   priceLabel: "¥33.00",
   amount: 33,
+  fudeGoldPrice: 33,
+  fudeGoldPriceLabel: "33 福德金",
 };
 const HIGH_ENERGY_PURCHASE_KEY = "fabushi.official.global-dharma.purchase.zen_buddha_asset";
+const highEnergyPurchaseCache = createEntitlementCache(
+  HIGH_ENERGY_PURCHASE_KEY,
+  HIGH_ENERGY_PRODUCT,
+);
+const GLOBAL_DHARMA_LOGS_KEY = "fabushi.official.global-dharma.session.logs";
 
-class HostInvokeError extends Error {
-  code?: string;
-  data?: any;
-
-  constructor(response: any) {
-    super(response?.message || "宿主调用失败");
-    this.name = "HostInvokeError";
-    this.code = response?.errorCode;
-    this.data = response?.data;
+function readStoredGlobalDharmaLogs() {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(GLOBAL_DHARMA_LOGS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.slice(-120).map(String) : [];
+  } catch {
+    return [];
   }
 }
 
-async function invokeHost(method: string, params: Record<string, any> = {}) {
-  const sdk = (window as any).FabushiMiniApp;
-  if (!sdk?.invoke) throw new Error("SDK 尚未就绪");
-  const res = await sdk.invoke(method, params);
-  if (!res?.ok) throw new HostInvokeError(res);
-  return res.data;
+function storeGlobalDharmaLogs(logs: string[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(GLOBAL_DHARMA_LOGS_KEY, JSON.stringify(logs.slice(-120)));
+  } catch {
+    // 忽略私密模式或存储配额错误；内存态日志仍然可用。
+  }
 }
 
 export default function GlobalDharmaApp() {
@@ -58,42 +73,36 @@ export default function GlobalDharmaApp() {
   const [loopEnabled, setLoopEnabled] = useState(false);
   const [highEnergyUnlocked, setHighEnergyUnlocked] = useState(false);
   const [selectedMaterial, setSelectedMaterial] = useState<any>(null);
-  const [logs, setLogs] = useState<string[]>([]);
+  const [logs, setLogs] = useState<string[]>(readStoredGlobalDharmaLogs);
   const [busy, setBusy] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const earthRef = useRef<THREE.Mesh | null>(null);
   const particlesRef = useRef<THREE.Points | null>(null);
   const transferringRef = useRef(false);
+  const handleStartRef = useRef<((overrideText?: string, commandId?: string) => Promise<void>) | null>(null);
   const selectedRegion = useMemo(
     () => regionPresets.find((item) => item.id === regionId) || regionPresets[0],
     [regionId],
   );
 
-  const log = (msg: string) => setLogs((prev) => [...prev, `[${new Date().toLocaleTimeString()}] ${msg}`]);
-
-  const readHighEnergyPurchase = () => {
-    try {
-      const raw = window.localStorage.getItem(HIGH_ENERGY_PURCHASE_KEY);
-      if (!raw) return false;
-      const record = JSON.parse(raw);
-      return record?.productId === HIGH_ENERGY_PRODUCT.productId && record?.paid === true;
-    } catch {
-      return false;
-    }
+  const log = (msg: string) => {
+    const line = `[${new Date().toLocaleTimeString()}] ${msg}`;
+    setLogs((prev) => {
+      const next = [...prev, line].slice(-120);
+      storeGlobalDharmaLogs(next);
+      return next;
+    });
   };
 
   const saveHighEnergyPurchase = (payment: any) => {
-    const record = {
-      productId: HIGH_ENERGY_PRODUCT.productId,
-      title: HIGH_ENERGY_PRODUCT.title,
-      priceLabel: HIGH_ENERGY_PRODUCT.priceLabel,
-      paid: true,
-      paidAt: new Date().toISOString(),
-      payment,
-    };
-    window.localStorage.setItem(HIGH_ENERGY_PURCHASE_KEY, JSON.stringify(record));
+    highEnergyPurchaseCache.save(payment);
     setHighEnergyUnlocked(true);
+  };
+
+  const clearHighEnergyPurchase = () => {
+    highEnergyPurchaseCache.clear();
+    setHighEnergyUnlocked(false);
   };
 
   const isPaidPayment = (payment: any) => {
@@ -101,59 +110,157 @@ export default function GlobalDharmaApp() {
     return payment?.paid === true || status === "PAID" || status === "SUCCESS" || status === "9000";
   };
 
+  const checkHighEnergyEntitlement = async (
+    options: { silent?: boolean } = {},
+  ): Promise<EntitlementState> => {
+    try {
+      const entitlement = await miniAppHost.payments.checkEntitlement(HIGH_ENERGY_PRODUCT.productId);
+      if (entitlement === "unlocked") {
+        saveHighEnergyPurchase({
+          provider: "host",
+          source: "entitlement",
+          productId: HIGH_ENERGY_PRODUCT.productId,
+        });
+        return "unlocked";
+      }
+      if (entitlement === "unavailable") return "unavailable";
+      clearHighEnergyPurchase();
+      return "locked";
+    } catch (error: any) {
+      if (!options.silent) {
+        log(error.message || "购买权益查询失败");
+      }
+      return "unavailable";
+    }
+  };
+
   useEffect(() => {
     transferringRef.current = Boolean(status?.isTransferring);
   }, [status?.isTransferring]);
 
   useEffect(() => {
-    setHighEnergyUnlocked(readHighEnergyPurchase());
+    setHighEnergyUnlocked(highEnergyPurchaseCache.read());
     const refresh = () => {
-      if (!(window as any).FabushiMiniApp?.ready) return;
-      invokeHost("dharma.getSendStatus")
+      if (!isHostReady()) return;
+      checkHighEnergyEntitlement({ silent: true });
+      miniAppHost.dharma.getSendStatus()
         .then((data) => {
           setStatus(data);
           setSelectedMaterial(data?.selectedContent);
         })
         .catch((error) => log(error.message));
     };
-    refresh();
-    window.addEventListener("fabushi-miniapp-ready", refresh);
-    return () => window.removeEventListener("fabushi-miniapp-ready", refresh);
+    const unsubscribeReady = onMiniAppReady(refresh);
+    const unsubscribeMessage = miniAppHost.bot.onMessage?.((msg) => {
+      setText(msg);
+      log(`已收到内容: ${msg}`);
+      if (msg.trim().startsWith("http://") || msg.trim().startsWith("https://")) {
+        handleStartRef.current?.(msg);
+      }
+    });
+    const unsubscribeCommand = (
+      miniAppHost.bot.exposeCommand?.(
+        "/start",
+        (args, event) => {
+          log(`收到 /start 命令`);
+          if (args) setText(args);
+          handleStartRef.current?.(args || undefined, event?.commandId);
+        },
+        { description: "启动全球法布施" },
+      ) ||
+      miniAppHost.bot.onCommand?.("/start", (args, event) => {
+        log(`收到 /start 命令`);
+        if (args) setText(args);
+        handleStartRef.current?.(args || undefined, event?.commandId);
+      })
+    );
+
+    const { startParam } = miniAppHost.bot.getInitData?.() || {};
+    if (startParam) {
+      setText(startParam);
+      log(`收到启动参数: ${startParam}`);
+      if (startParam.trim().startsWith("http://") || startParam.trim().startsWith("https://")) {
+        setTimeout(() => handleStartRef.current?.(startParam), 100);
+      }
+    }
+
+    return () => {
+      unsubscribeReady();
+      unsubscribeMessage?.();
+      unsubscribeCommand?.();
+    };
   }, []);
 
   const waitForPaymentConfirmation = async (orderId: string) => {
     for (let i = 0; i < 8; i += 1) {
       await new Promise((resolve) => window.setTimeout(resolve, i === 0 ? 600 : 2500));
-      const queried = await invokeHost("payments.alipay.queryOrder", { orderId });
+      const queried = await miniAppHost.payments.alipay.queryOrder(orderId);
       if (isPaidPayment(queried)) return queried;
     }
     return null;
   };
 
   const ensureHighEnergyPurchase = async () => {
-    if (highEnergyUnlocked || readHighEnergyPurchase()) {
-      setHighEnergyUnlocked(true);
-      return true;
+    const localUnlocked = highEnergyUnlocked || highEnergyPurchaseCache.read();
+    if (localUnlocked) {
+      const entitlement = await checkHighEnergyEntitlement({ silent: true });
+      if (entitlement !== "locked") {
+        if (entitlement === "unavailable") setHighEnergyUnlocked(true);
+        return true;
+      }
+      log("本地购买记录未在宿主后端确认，将重新发起支付。");
     }
     log(`${HIGH_ENERGY_PRODUCT.title}需要购买，正在请求宿主支付能力。`);
     try {
-      await invokeHost("auth.requireLogin");
+      await miniAppHost.auth.requireLogin();
     } catch (error: any) {
-      if (error?.code === "unknown_method" || error?.code === "permission_denied") {
+      if (isHostErrorCode(error, "unknown_method", "permission_denied")) {
         log("宿主没有提供登录确认接口，将继续尝试支付。");
       } else {
         throw error;
       }
     }
+    const entitlement = await checkHighEnergyEntitlement();
+    if (entitlement === "unlocked") {
+      log(`${HIGH_ENERGY_PRODUCT.title}已同步购买权益。`);
+      return true;
+    }
 
-    const order = await invokeHost("payments.alipay.createOrder", {
+    try {
+      const tokenPayment = await miniAppHost.payments.requestPayment({
+        productId: HIGH_ENERGY_PRODUCT.productId,
+        title: HIGH_ENERGY_PRODUCT.title,
+        amount: HIGH_ENERGY_PRODUCT.fudeGoldPrice,
+        currency: "FUDE_GOLD",
+        idempotencyKey: `${HIGH_ENERGY_PRODUCT.productId}:${Date.now()}`,
+      });
+      if (isPaidPayment(tokenPayment)) {
+        saveHighEnergyPurchase(tokenPayment);
+        log(`福德金支付成功，剩余 ${tokenPayment?.balance ?? 0} 福德金。`);
+        return true;
+      }
+    } catch (error: any) {
+      if (isHostErrorCode(error, "payment_cancelled")) {
+        log("已取消福德金支付。");
+        return false;
+      }
+      if (isHostErrorCode(error, "wallet_insufficient_funds")) {
+        log("福德金余额不足，将尝试支付宝支付。");
+      } else if (isHostErrorCode(error, "unknown_method", "permission_denied", "unsupported_currency")) {
+        log("宿主暂未提供福德金支付，将尝试支付宝支付。");
+      } else {
+        throw error;
+      }
+    }
+
+    const order = await miniAppHost.payments.alipay.createOrder({
       productId: HIGH_ENERGY_PRODUCT.productId,
       title: HIGH_ENERGY_PRODUCT.title,
       subject: HIGH_ENERGY_PRODUCT.title,
       amount: HIGH_ENERGY_PRODUCT.amount,
       priceLabel: HIGH_ENERGY_PRODUCT.priceLabel,
     });
-    const payment = await invokeHost("payments.alipay.pay", {
+    const payment = await miniAppHost.payments.alipay.pay({
       ...order,
       productId: HIGH_ENERGY_PRODUCT.productId,
       title: HIGH_ENERGY_PRODUCT.title,
@@ -248,7 +355,7 @@ export default function GlobalDharmaApp() {
   }, []);
 
   const applyOptions = async (preset = selectedRegion, loop = loopEnabled) => {
-    const data = await invokeHost("dharma.setSendOptions", {
+    const data = await miniAppHost.dharma.setSendOptions({
       regionMode: preset.id,
       global: preset.global === true,
       countryCodes: preset.countryCodes || [],
@@ -260,8 +367,9 @@ export default function GlobalDharmaApp() {
     return data;
   };
 
-  const handleStart = async () => {
-    if (!text.trim() && !selectedMaterial) {
+  const handleStart = async (overrideText?: string, commandId?: string) => {
+    const t = overrideText ?? text;
+    if (!t.trim() && !selectedMaterial) {
       log("请先输入链接、正文，或选择高能素材");
       return;
     }
@@ -269,9 +377,9 @@ export default function GlobalDharmaApp() {
     try {
       log("正在提取内容并启动全球法布施...");
       await applyOptions();
-      const data = await invokeHost("dharma.startGlobalSend", {
+      const data = await miniAppHost.dharma.startGlobalSend({
         title: selectedMaterial?.title || "小程序全球法布施",
-        text: text.trim(),
+        text: t.trim(),
         global: selectedRegion.global === true,
         countryCodes: selectedRegion.countryCodes || [],
         fieldEnergy: selectedRegion.fieldEnergy === true,
@@ -281,20 +389,36 @@ export default function GlobalDharmaApp() {
       setStatus(data);
       setSelectedMaterial(data?.selectedContent);
       log("启动成功，正在发送。");
+      if (commandId) {
+        await miniAppHost.bot.reportCommandResult?.({
+          commandId,
+          status: "completed",
+          message: `全球法布施已启动：${data?.selectedContent?.title || "小程序内容"}`,
+          data,
+        });
+      }
       if (selectedRegion.fieldEnergy && data?.wifiHotspot?.message) {
         log(data.wifiHotspot.message);
       }
     } catch (error: any) {
       log(error.message || "启动失败");
+      if (commandId) {
+        await miniAppHost.bot.reportCommandResult?.({
+          commandId,
+          status: "failed",
+          message: error.message || "全球法布施启动失败",
+        }).catch(() => {});
+      }
     } finally {
       setBusy(false);
     }
   };
+  handleStartRef.current = handleStart;
 
   const handleStop = async () => {
     try {
       log("正在停止全球传输...");
-      const data = await invokeHost("dharma.stopGlobalSend");
+      const data = await miniAppHost.dharma.stopGlobalSend();
       setStatus(data);
       log("传输已停止。");
     } catch (error: any) {
@@ -322,18 +446,18 @@ export default function GlobalDharmaApp() {
       log("正在准备高能素材...");
       const unlocked = await ensureHighEnergyPurchase();
       if (!unlocked) return;
-      const data = await invokeHost("dharma.selectHighEnergyMaterial");
+      const data = await miniAppHost.dharma.selectHighEnergyMaterial();
       setStatus(data);
       setSelectedMaterial(data?.selectedContent);
       log("已选择高能素材。");
     } catch (error: any) {
-      if (error?.code === "login_required") {
+      if (isHostErrorCode(error, "login_required")) {
         log("需要先登录，正在请求宿主打开登录。");
         try {
-          await invokeHost("auth.requireLogin");
+          await miniAppHost.auth.requireLogin();
           const unlocked = await ensureHighEnergyPurchase();
           if (!unlocked) return;
-          const data = await invokeHost("dharma.selectHighEnergyMaterial");
+          const data = await miniAppHost.dharma.selectHighEnergyMaterial();
           setStatus(data);
           setSelectedMaterial(data?.selectedContent);
           log("已选择高能素材。");
@@ -365,7 +489,7 @@ export default function GlobalDharmaApp() {
           <h1 className="ma-header-title">全球法布施</h1>
           <p className="ma-header-subtitle">已发送 {status?.sentCount || 0} 个节点 · {(status?.sentMB || 0).toFixed(2)} MB</p>
         </div>
-        <button className="ma-icon-btn" onClick={() => invokeHost("dharma.getSendStatus").then(setStatus).catch((error) => log(error.message))} aria-label="刷新状态">
+        <button className="ma-icon-btn" onClick={() => miniAppHost.dharma.getSendStatus().then(setStatus).catch((error) => log(error.message))} aria-label="刷新状态">
           <RefreshCw size={18} />
         </button>
       </div>
@@ -403,7 +527,7 @@ export default function GlobalDharmaApp() {
       <label className="ma-label">高能素材</label>
       <button className={`ma-material-button ${selectedMaterial ? "selected" : ""}`} onClick={handleMaterial} disabled={busy}>
         <Sparkles size={18} />
-        <span>{selectedMaterial?.title || `${HIGH_ENERGY_PRODUCT.title}${highEnergyUnlocked ? " · 已购买" : ` · ${HIGH_ENERGY_PRODUCT.priceLabel}`}`}</span>
+        <span>{selectedMaterial?.title || `${HIGH_ENERGY_PRODUCT.title}${highEnergyUnlocked ? " · 已购买" : ` · ${HIGH_ENERGY_PRODUCT.fudeGoldPriceLabel}`}`}</span>
       </button>
 
       <label className="ma-label">链接或正文</label>

--- a/frontend/apps/web/src/app/miniapps/[id]/PlatformPublishApp.tsx
+++ b/frontend/apps/web/src/app/miniapps/[id]/PlatformPublishApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ExternalLink, FileText, FolderOpen, Play, RefreshCw, Terminal, Upload } from "lucide-react";
 import "./miniapps.css";
 
@@ -47,6 +47,9 @@ export default function PlatformPublishApp() {
   const [running, setRunning] = useState(false);
   const [capabilities, setCapabilities] = useState<string[]>([]);
   const [logs, setLogs] = useState<string[]>([]);
+  const handleChatCommandRef = useRef<
+    ((body: string, commandId?: string, mode?: "draft" | "run") => Promise<void>) | null
+  >(null);
 
   const platform = useMemo(
     () => platforms.find((item) => item.id === platformId) || platforms[0],
@@ -69,7 +72,117 @@ export default function PlatformPublishApp() {
     return () => window.removeEventListener("fabushi-miniapp-ready", refresh);
   }, []);
 
+  useEffect(() => {
+    const { startParam } = miniAppHost.bot.getInitData?.() || {};
+    if (startParam) {
+      setText(startParam);
+      log(`收到启动参数: ${startParam}`);
+    }
+    const unsubscribeStart = (
+      miniAppHost.bot.exposeCommand?.(
+        "/start",
+        (args, event) => {
+          log("收到 /start 发布草稿命令");
+          void handleChatCommandRef.current?.(args, event?.commandId, "draft");
+        },
+        { description: "生成发布草稿" },
+      ) ||
+      miniAppHost.bot.onCommand?.("/start", (args, event) => {
+        log("收到 /start 发布草稿命令");
+        void handleChatCommandRef.current?.(args, event?.commandId, "draft");
+      })
+    );
+    const unsubscribeRun = (
+      miniAppHost.bot.exposeCommand?.(
+        "/run",
+        (args, event) => {
+          log("收到 /run 发布流水线命令");
+          void handleChatCommandRef.current?.(args, event?.commandId, "run");
+        },
+        { description: "生成草稿并运行本地发布流水线" },
+      ) ||
+      miniAppHost.bot.onCommand?.("/run", (args, event) => {
+        log("收到 /run 发布流水线命令");
+        void handleChatCommandRef.current?.(args, event?.commandId, "run");
+      })
+    );
+    return () => {
+      unsubscribeStart?.();
+      unsubscribeRun?.();
+    };
+  }, []);
+
   const hasCapability = (permission: string) => capabilities.includes(permission);
+
+  const handleChatCommand = async (
+    body: string,
+    commandId?: string,
+    mode: "draft" | "run" = "draft",
+  ) => {
+    const fullText = body.trim();
+    if (!fullText) {
+      log("请在命令后输入正文或链接。");
+      return;
+    }
+    setText(fullText);
+    setRunning(true);
+    try {
+      const data = await miniAppHost.platformPublish.createDraft({ title, text: fullText });
+      setDraft(data);
+      setTitle(data?.title || title);
+      if (data?.body) setText(data.body);
+      log("草稿已生成。");
+
+      let resultMessage = `发布草稿已生成：${data?.title || title}`;
+      if (mode === "run") {
+        const bodyText = data?.body || fullText;
+        const markdown = `# ${data?.title || title}\n\n${bodyText}\n`;
+        const saved = await miniAppHost.fs.writeFile({
+          path: `platform-publish/${platform.id}-${slugTime()}.md`,
+          content: markdown,
+        });
+        setSavedPath(saved?.path || "");
+        const script = [
+          `console.log("Fabushi platform pipeline: ${platform.label}");`,
+          `console.log("title: ${JSON.stringify(data?.title || title)}");`,
+          `console.log("body chars: ${bodyText.length}");`,
+          `console.log("draft file: ${JSON.stringify(saved?.path || "")}");`,
+          `console.log("ready to hand off to browser automation.");`,
+        ].join("\n");
+        const file = await miniAppHost.fs.writeFile({
+          path: `platform-publish/run-${platform.id}-${slugTime()}.js`,
+          content: script,
+        });
+        await miniAppHost.shell.execute({
+          title: `${platform.label} 发布流水线`,
+          command: "node",
+          arguments: [file.path],
+        });
+        resultMessage = `${platform.label} 发布流水线已启动。`;
+      }
+
+      if (commandId) {
+        await miniAppHost.bot.reportCommandResult?.({
+          commandId,
+          status: "completed",
+          message: resultMessage,
+          data,
+        });
+      }
+    } catch (error: any) {
+      log(error.message || "发布命令执行失败");
+      if (commandId) {
+        await miniAppHost.bot.reportCommandResult?.({
+          commandId,
+          status: "failed",
+          message: error.message || "发布命令执行失败",
+        }).catch(() => {});
+      }
+    } finally {
+      setRunning(false);
+    }
+  };
+  handleChatCommandRef.current = handleChatCommand;
 
   const handlePickFiles = async () => {
     try {

--- a/frontend/apps/web/src/app/miniapps/[id]/miniapp-sdk.ts
+++ b/frontend/apps/web/src/app/miniapps/[id]/miniapp-sdk.ts
@@ -1,0 +1,397 @@
+"use client";
+
+export const MINIAPP_SDK_VERSION = "1.4.0";
+
+export type HostInvokeResponse<T = any> = {
+  ok?: boolean;
+  requestId?: string;
+  data?: T;
+  errorCode?: string;
+  message?: string;
+};
+
+export type MiniAppProduct = {
+  productId: string;
+  title?: string;
+  priceLabel?: string;
+};
+
+export type EntitlementState = "unlocked" | "locked" | "unavailable";
+
+export type MiniAppCommandEvent = {
+  id?: string;
+  commandId?: string;
+  command?: string;
+  args?: string;
+  text?: string;
+  rawText?: string;
+  background?: boolean;
+  source?: string;
+  createdAt?: string;
+};
+
+export class HostInvokeError extends Error {
+  code?: string;
+  data?: any;
+  requestId?: string;
+
+  constructor(response: HostInvokeResponse) {
+    super(response?.message || "宿主调用失败");
+    this.name = "HostInvokeError";
+    this.code = response?.errorCode;
+    this.data = response?.data;
+    this.requestId = response?.requestId;
+  }
+}
+
+function hostSdk() {
+  return (window as any).FabushiMiniApp;
+}
+
+export function isHostReady() {
+  return Boolean(hostSdk()?.ready);
+}
+
+export function getInitData() {
+  if (typeof window === "undefined") return { startParam: null };
+  const searchParams = new URLSearchParams(window.location.search);
+  const startParamBase64 = searchParams.get("tgWebAppStartParam");
+  if (startParamBase64) {
+    try {
+      let b64 = startParamBase64.replace(/-/g, '+').replace(/_/g, '/');
+      const pad = b64.length % 4;
+      if (pad) b64 += '='.repeat(4 - pad);
+      const decodedStr = new TextDecoder().decode(
+        Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+      );
+      return { startParam: decodedStr };
+    } catch (e) {
+      console.error("Failed to parse startParam:", e);
+    }
+  }
+  return { startParam: null };
+}
+
+export function onBotMessage(callback: (msg: string) => void) {
+  const handler = (event: any) => {
+    if (event.detail && typeof event.detail.text === "string") {
+      callback(event.detail.text);
+    }
+  };
+  window.addEventListener("fabushi-bot-message", handler);
+
+  return () => {
+    window.removeEventListener("fabushi-bot-message", handler);
+  };
+}
+
+function commandKey(commandEvent: MiniAppCommandEvent) {
+  return (
+    commandEvent.commandId ||
+    commandEvent.id ||
+    [
+      commandEvent.createdAt,
+      commandEvent.command,
+      commandEvent.rawText || commandEvent.text,
+    ]
+      .filter(Boolean)
+      .join(":")
+  );
+}
+
+function readStoredCommandQueue(): MiniAppCommandEvent[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem("__fabushiMiniAppCommandQueue") || "[]";
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function clearStoredCommandQueue() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem("__fabushiMiniAppCommandQueue", "[]");
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function pendingCommands(): MiniAppCommandEvent[] {
+  if (typeof window === "undefined") return [];
+  const commands: MiniAppCommandEvent[] = [];
+  const anyWindow = window as any;
+  if (anyWindow.__fabushiLastMiniAppCommand) {
+    commands.push(anyWindow.__fabushiLastMiniAppCommand);
+  }
+  if (Array.isArray(anyWindow.__fabushiMiniAppCommandQueue)) {
+    commands.push(...anyWindow.__fabushiMiniAppCommandQueue);
+    anyWindow.__fabushiMiniAppCommandQueue = [];
+  }
+  commands.push(...readStoredCommandQueue());
+  clearStoredCommandQueue();
+  return commands;
+}
+
+export function onAnyBotCommand(callback: (event: MiniAppCommandEvent) => void) {
+  if (typeof window === "undefined") return () => {};
+
+  const seenCommandIds = new Set<string>();
+  const deliver = (detail: unknown) => {
+    if (!detail || typeof detail !== "object") return;
+    const commandEvent = detail as MiniAppCommandEvent;
+    const key = commandKey(commandEvent);
+    if (key) {
+      if (seenCommandIds.has(key)) return;
+      seenCommandIds.add(key);
+    }
+    callback(commandEvent);
+  };
+
+  const handler = (event: any) => {
+    deliver(event.detail);
+  };
+  window.addEventListener("fabushi-miniapp-command", handler);
+
+  const drainHostQueue = async () => {
+    if (!isHostReady()) return;
+    try {
+      const data = await invokeHost<{ commands?: MiniAppCommandEvent[] }>(
+        "bot.takePendingCommands",
+        {},
+      );
+      (data?.commands || []).forEach(deliver);
+    } catch {
+      // The host queue is a best-effort message bus fallback. Event delivery
+      // and localStorage delivery above remain available when this fails.
+    }
+  };
+
+  const schedule =
+    window.queueMicrotask || ((fn: VoidFunction) => window.setTimeout(fn, 0));
+  schedule(() => {
+    pendingCommands().forEach(deliver);
+    drainHostQueue();
+  });
+  const unsubscribeReady = onMiniAppReady(drainHostQueue);
+  const pollId = window.setInterval(drainHostQueue, 1000);
+  const stopPollId = window.setTimeout(() => window.clearInterval(pollId), 30000);
+
+  return () => {
+    window.removeEventListener("fabushi-miniapp-command", handler);
+    unsubscribeReady();
+    window.clearInterval(pollId);
+    window.clearTimeout(stopPollId);
+  };
+}
+
+export function onBotCommand(
+  command: string,
+  callback: (args: string, event?: MiniAppCommandEvent) => void,
+) {
+  return onAnyBotCommand((event) => {
+    if (event.command === command) {
+      callback(event.args || "", event);
+    }
+  });
+}
+
+function registerBotCommandWhenReady(
+  command: string,
+  description: string,
+) {
+  if (typeof window === "undefined") return () => {};
+
+  let disposed = false;
+  const commandSpec = [{ command, description }];
+  const register = () => {
+    if (disposed || !isHostReady()) return;
+    miniAppHost.bot.setCommands(commandSpec).catch(() => {});
+  };
+
+  register();
+  const unsubscribeReady = onMiniAppReady(register);
+  window.setTimeout(register, 250);
+  window.setTimeout(register, 1000);
+
+  return () => {
+    disposed = true;
+    unsubscribeReady();
+  };
+}
+
+export function exposeBotCommand(
+  command: string,
+  callback: (args: string, event?: MiniAppCommandEvent) => void | Promise<void>,
+  options: { description?: string } = {},
+) {
+  const unregisterCommand = registerBotCommandWhenReady(
+    command,
+    options.description || "",
+  );
+  const unsubscribeCommand = onBotCommand(command, callback);
+  return () => {
+    unregisterCommand();
+    unsubscribeCommand();
+  };
+}
+
+export function onMiniAppReady(callback: () => void) {
+  if (isHostReady()) {
+    window.queueMicrotask(callback);
+    return () => {};
+  }
+  window.addEventListener("fabushi-miniapp-ready", callback);
+  return () => window.removeEventListener("fabushi-miniapp-ready", callback);
+}
+
+export function isHostErrorCode(error: unknown, ...codes: string[]) {
+  return error instanceof HostInvokeError && typeof error.code === "string" && codes.includes(error.code);
+}
+
+export async function invokeHost<T = any>(
+  method: string,
+  params: Record<string, any> = {},
+): Promise<T> {
+  const sdk = hostSdk();
+  if (!sdk?.invoke) throw new Error("SDK 尚未就绪");
+  
+  let res = await sdk.invoke(method, params);
+  
+  // 拦截并自动处理需要登录的错误
+  if (!res?.ok && res?.errorCode === "login_required" && method !== "auth.requireLogin") {
+    const loginRes = await sdk.invoke("auth.requireLogin", { force: false });
+    if (loginRes?.ok) {
+      // 重新尝试原始请求
+      res = await sdk.invoke(method, params);
+    }
+  }
+
+  if (!res?.ok) throw new HostInvokeError(res);
+  return res.data as T;
+}
+
+export function createEntitlementCache(storageKey: string, product: MiniAppProduct) {
+  const read = () => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) return false;
+      const record = JSON.parse(raw);
+      return record?.productId === product.productId && record?.paid === true;
+    } catch {
+      return false;
+    }
+  };
+
+  const save = (payment: any) => {
+    const record = {
+      productId: product.productId,
+      title: product.title,
+      priceLabel: product.priceLabel,
+      paid: true,
+      paidAt: new Date().toISOString(),
+      payment,
+    };
+    window.localStorage.setItem(storageKey, JSON.stringify(record));
+  };
+
+  const clear = () => {
+    window.localStorage.removeItem(storageKey);
+  };
+
+  return { read, save, clear };
+}
+
+async function checkEntitlement(productId: string): Promise<EntitlementState> {
+  try {
+    const entitlement = await invokeHost<{ unlocked?: boolean }>(
+      "payments.checkEntitlement",
+      { productId },
+    );
+    return entitlement?.unlocked === true ? "unlocked" : "locked";
+  } catch (error) {
+    if (isHostErrorCode(error, "unknown_method")) {
+      const entitlement = await invokeHost<{ unlocked?: boolean }>(
+        "payments.alipay.checkEntitlement",
+        { productId },
+      );
+      return entitlement?.unlocked === true ? "unlocked" : "locked";
+    }
+    if (isHostErrorCode(error, "permission_denied")) return "unavailable";
+    if (isHostErrorCode(error, "login_required")) return "locked";
+    throw error;
+  }
+}
+
+export const miniAppHost = {
+  invoke: invokeHost,
+  app: {
+    getContext: () => invokeHost("app.getContext"),
+    getCapabilities: () => invokeHost<{ capabilities?: string[] }>("app.getCapabilities"),
+    getHostApiSpec: () => invokeHost("app.getHostApiSpec"),
+    getTheme: () => invokeHost("app.getTheme"),
+  },
+  auth: {
+    getSession: () => invokeHost("auth.getSession"),
+    requireLogin: () => invokeHost("auth.requireLogin"),
+    getAccessToken: () => invokeHost("auth.getAccessToken"),
+  },
+  payments: {
+    checkEntitlement,
+    requestPayment: (params: Record<string, any>) => invokeHost("payments.requestPayment", params),
+    alipay: {
+      createOrder: (params: Record<string, any>) => invokeHost("payments.alipay.createOrder", params),
+      pay: (params: Record<string, any>) => invokeHost("payments.alipay.pay", params),
+      queryOrder: (orderId: string) => invokeHost("payments.alipay.queryOrder", { orderId }),
+      checkEntitlement,
+    },
+  },
+  wallet: {
+    getBalance: (currency = "FUDE_GOLD") => invokeHost("wallet.getBalance", { currency }),
+  },
+  bot: {
+    sendMessage: (params: Record<string, any>) => invokeHost("bot.sendMessage", params),
+    postMessage: (params: Record<string, any>) => invokeHost("bot.postMessage", params),
+    reportCommandResult: (params: Record<string, any>) => invokeHost("bot.reportCommandResult", params),
+    takePendingCommands: () => invokeHost<{ commands?: MiniAppCommandEvent[] }>("bot.takePendingCommands", {}),
+    openPanel: (params: Record<string, any> = {}) => invokeHost("bot.openPanel", params),
+    setPanelState: (params: Record<string, any>) => invokeHost("bot.setPanelState", params),
+    setCommands: (commands: Array<{ command: string; description: string }>) => invokeHost("bot.setCommands", { commands }),
+    close: () => invokeHost("bot.close", {}),
+    getInitData,
+    onMessage: onBotMessage,
+    onAnyCommand: onAnyBotCommand,
+    onCommand: onBotCommand,
+    exposeCommand: exposeBotCommand,
+  },
+  dharma: {
+    getSendStatus: () => invokeHost("dharma.getSendStatus"),
+    setSendOptions: (params: Record<string, any>) => invokeHost("dharma.setSendOptions", params),
+    selectHighEnergyMaterial: () => invokeHost("dharma.selectHighEnergyMaterial"),
+    startGlobalSend: (params: Record<string, any>) => invokeHost("dharma.startGlobalSend", params),
+    stopGlobalSend: () => invokeHost("dharma.stopGlobalSend"),
+  },
+  flashcards: {
+    createDeck: (params: Record<string, any>) => invokeHost("flashcards.createDeck", params),
+    openDeck: (deckId: string) => invokeHost("flashcards.openDeck", { deckId }),
+  },
+  platformPublish: {
+    createDraft: (params: Record<string, any>) => invokeHost("platformPublish.createDraft", params),
+    publishDraft: (params: Record<string, any>) => invokeHost("platformPublish.publishDraft", params),
+  },
+  files: {
+    pick: (params: Record<string, any> = {}) => invokeHost("files.pick", params),
+  },
+  fs: {
+    writeFile: (params: Record<string, any>) => invokeHost("fs.writeFile", params),
+    readFile: (path: string) => invokeHost("fs.readFile", { path }),
+  },
+  shell: {
+    execute: (params: Record<string, any>) => invokeHost("shell.execute", params),
+  },
+  browser: {
+    open: (url: string) => invokeHost("browser.open", { url }),
+  },
+};


### PR DESCRIPTION
## 变更内容

- 将小程序宿主协议升级到 1.4，增加聊天命令对象、宿主命令队列和 `bot.takePendingCommands` 拉取能力。
- 在 WebView document-start 注入 `FabushiMiniApp` SDK，降低 React 小程序初始化早于宿主注入导致的通信丢失概率。
- 社交聊天侧只做小程序命令投递，不再让宿主代写全球法布施业务逻辑。
- 小程序 SDK 增加 `onAnyCommand` / `onCommand` / `exposeCommand`、命令去重、localStorage/宿主队列兜底拉取。
- 全球法布施、背诵闪卡、平台发布小程序接入 `/start` 命令并通过 `bot.reportCommandResult` 回传执行结果。
- 官方小程序入口改为 `fabushi-miniapps.pages.dev`，避免旧自定义域仍指向旧构建。

## 验证

- `flutter analyze lib/core/config/app_config.dart lib/services/membership_service.dart lib/models/mini_app_model.dart lib/screens/mini_app_host_screen.dart lib/screens/social_feature_chat_screen.dart`
- `pnpm --filter @fabushi/web build`

## 备注

- 这是从最新 `origin/main` 拉出的干净分支，避免混入旧的 `feat/telegram-ui-redesign` 分支历史。
- 宿主仅作为消息媒介和能力提供者，小程序业务逻辑仍在小程序侧执行。