### PR TITLE
docs: design global dharma as local Rust runtime mini app

### DIFF
--- a/docs/global-dharma-rust-runtime-miniapp.md
+++ b/docs/global-dharma-rust-runtime-miniapp.md
@@ -1,0 +1,372 @@
+# 全球法布施小程序：本地 Rust 程序运行时设计
+
+## 结论
+
+全球法布施不应继续设计成“WebView 里点击一次、调用一次 HTTP/UDP”的普通小程序。它应设计成：
+
+```text
+小程序 UI / Bot 面板
+  -> 准备任务参数、内容、权限声明、运行配置
+  -> 调用宿主 Rust Program Runtime
+  -> 宿主在本地受控容器中启动 Rust worker
+  -> Rust worker 负责循环发送、队列、重试、回执、日志、暂停/恢复
+  -> 小程序只订阅状态和控制生命周期
+```
+
+也就是说，复杂逻辑运行在本地 Rust 程序里；Web 小程序只负责交互、配置、展示和生命周期控制。宿主 App 不写全球法布施业务逻辑，只提供“运行 Rust 程序容器 + 能力原语 + 权限审计”。
+
+## 为什么要这样设计
+
+全球法布施和“单次发送”不一样，它天然是长任务：
+
+- 需要循环发送，而不是一次按钮调用；
+- 需要跨地区、跨节点、HTTP/UDP/本地场能等多通道调度；
+- 需要队列、重试、失败恢复、速率限制、回执记录；
+- 需要 Keep Awake、防止电脑休眠；
+- 需要本地持久化，App 重启后可以恢复任务；
+- 需要运行日志、实时状态和停止控制；
+- 未来还会加入素材准备、内容哈希、分片、节点健康检查、风控策略等复杂逻辑。
+
+这些逻辑如果全部写在 React 小程序里，会变成脆弱的前端定时器。一旦 WebView 被挂起、刷新、崩溃或网络闪断，任务就不可靠。因此需要把核心循环调度下沉到本地 Rust worker。
+
+## 角色边界
+
+| 组件 | 负责什么 | 不负责什么 |
+|---|---|---|
+| 小程序 UI | 输入链接/正文、选择地区、选择循环模式、展示日志、发出 start/stop/status 命令 | 不直接做长循环、不持有底层网络 socket、不直接访问系统 API |
+| Rust worker | 内容准备后的任务执行、循环发送、队列、重试、回执、日志、状态机、本地持久化 | 不直接拿宿主账号 token、不绕过宿主权限、不控制 UI |
+| 宿主 App | 提供 Rust 程序容器、权限授权、网络/文件/KeepAwake 原语、审计、进程生命周期 | 不写全球法布施业务策略、不把任意系统 API 暴露给小程序 |
+| Host Adapter | `rust.program.*`、`runtime.storage.*`、`network.*`、`system.keepAwake` 等能力实现 | 不根据小程序动态安装未知系统能力 |
+
+关键原则：小程序只能声明并调用宿主已经预置的能力。宿主没有内置的 adapter，小程序不能凭空获得新的系统 API。
+
+## 推荐架构
+
+```text
+GlobalDharmaApp.tsx
+  ├─ 收集输入：链接/正文/素材/地区/循环策略
+  ├─ 调用 rust.program.prepare
+  ├─ 调用 rust.program.start
+  ├─ 订阅 rust.program.events
+  └─ 显示 status/logs/receipts
+
+Host MiniApp Bridge
+  ├─ 能力协商：app.getCapabilities / app.requestCapabilities
+  ├─ 权限校验：MiniAppPermissionManager
+  ├─ 审计：MiniAppAuditLogger
+  └─ 分发到 RustProgramRuntimeAdapter
+
+RustProgramRuntimeAdapter
+  ├─ 校验 manifest、签名、hash、权限、资源限额
+  ├─ 创建本地 sandbox/container
+  ├─ 启动 worker 进程或 WASI runtime
+  ├─ 管理 stdin/stdout/stderr/event channel
+  ├─ 管理 stop/pause/resume/restart
+  └─ 写入本地 job store
+
+Rust worker: global-dharma-worker
+  ├─ prepare_content
+  ├─ delivery_queue
+  ├─ retry_scheduler
+  ├─ http_delivery
+  ├─ udp_delivery
+  ├─ receipts_store
+  ├─ rate_limiter
+  └─ event_stream
+```
+
+## Rust Program Runtime 能力
+
+新增能力组建议命名为 `rust.program`，只给官方/受信小程序开放，默认桌面端优先。
+
+| 方法 | 作用 | 风险 | 说明 |
+|---|---|---:|---|
+| `rust.program.prepare` | 解析 manifest，准备本地 worker 包、校验 hash/signature | High | 不启动任务，只完成本地准备 |
+| `rust.program.start` | 启动一个 worker job | Critical | 返回 `jobId`、`runId` |
+| `rust.program.stop` | 停止指定 job | High | 支持 graceful timeout 后强制 kill |
+| `rust.program.pause` | 暂停循环调度 | High | 保留队列和状态 |
+| `rust.program.resume` | 恢复暂停任务 | High | 继续上一状态 |
+| `rust.program.getStatus` | 读取 job 状态 | Medium | UI 轮询/恢复状态 |
+| `rust.program.readLogs` | 读取日志片段 | Medium | 支持 cursor |
+| `rust.program.listJobs` | 列出当前小程序 jobs | Medium | 只允许看到本小程序 namespace |
+| `rust.program.subscribeEvents` | 订阅事件流 | Medium | 用于日志、回执、进度更新 |
+
+后续如果不想暴露通用 Rust 程序能力，也可以收窄成 `globalDharma.worker.*`。但底层仍建议复用同一个 `RustProgramRuntimeAdapter`。
+
+## 小程序 manifest 示例
+
+```json
+{
+  "schemaVersion": 3,
+  "miniAppId": "official.global-dharma",
+  "title": "全球法布施",
+  "source": "official",
+  "reviewStatus": "trusted",
+  "entryUrl": "https://fabushi.ombhrum.com/miniapps/global-dharma",
+  "runtime": {
+    "type": "rust-program",
+    "programId": "global-dharma-worker",
+    "version": "1.0.0",
+    "entry": "bin/global-dharma-worker",
+    "packageUrl": "https://fabushi.ombhrum.com/runtime/global-dharma-worker/1.0.0/package.tar.zst",
+    "sha256": "<package-sha256>",
+    "signature": "<ed25519-signature>",
+    "targetTriples": [
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-linux-gnu"
+    ]
+  },
+  "permissions": [
+    {
+      "name": "rust.program",
+      "reason": "在本地受控容器中运行全球法布施循环发送 worker"
+    },
+    {
+      "name": "runtime.storage",
+      "reason": "保存任务队列、回执、重试状态和恢复点"
+    },
+    {
+      "name": "network.http",
+      "reason": "读取佛法链接正文并向全球法布施节点提交任务"
+    },
+    {
+      "name": "network.udp",
+      "reason": "向本地场能节点或转经轮节点发送 UDP 数据包"
+    },
+    {
+      "name": "system.keepAwake",
+      "reason": "循环发送期间防止电脑休眠"
+    }
+  ],
+  "resources": {
+    "maxMemoryMb": 256,
+    "maxCpuPercent": 50,
+    "maxLogMb": 50,
+    "networkAllowlist": [
+      "https://api.ombhrum.com",
+      "https://book.bfnn.org",
+      "udp://127.0.0.1:9999"
+    ]
+  }
+}
+```
+
+## 小程序调用流程
+
+### 1. 打开小程序时协商能力
+
+```ts
+const caps = await fbApp.invoke("app.getCapabilities");
+await fbApp.invoke("app.requestCapabilities", {
+  permissions: [
+    "rust.program",
+    "runtime.storage",
+    "network.http",
+    "network.udp",
+    "system.keepAwake"
+  ]
+});
+```
+
+### 2. 准备本地 Rust 程序
+
+```ts
+const prepared = await fbApp.invoke("rust.program.prepare", {
+  miniAppId: "official.global-dharma",
+  programId: "global-dharma-worker",
+  version: "1.0.0"
+});
+```
+
+`prepare` 阶段只做：下载/校验/解包/缓存/权限检查。不要开始发送。
+
+### 3. 启动循环发送 job
+
+```ts
+const job = await fbApp.invoke("rust.program.start", {
+  programId: "global-dharma-worker",
+  args: {
+    content: {
+      title: "金刚般若波罗蜜经",
+      sourceUrl: "https://book.bfnn.org/books/0040.htm",
+      text: "..."
+    },
+    region: "global",
+    loop: true,
+    intervalMs: 30000,
+    channels: ["http", "udp"],
+    commandId: "cmd_..."
+  },
+  restartPolicy: {
+    mode: "on-failure",
+    maxRestarts: 3
+  }
+});
+```
+
+### 4. 订阅状态
+
+```ts
+fbApp.on("rust.program.event", (event) => {
+  if (event.jobId !== job.jobId) return;
+  // event.type: log | progress | receipt | retry | failed | stopped
+});
+```
+
+### 5. 停止任务
+
+```ts
+await fbApp.invoke("rust.program.stop", {
+  jobId: job.jobId,
+  graceMs: 5000
+});
+```
+
+## Rust worker 输入输出协议
+
+为了让宿主不用理解全球法布施业务，worker 与宿主之间使用稳定 JSON Lines 事件协议。
+
+### 启动输入
+
+```json
+{
+  "runId": "run_20260702_001",
+  "miniAppId": "official.global-dharma",
+  "jobId": "job_global_dharma_001",
+  "args": {
+    "content": {
+      "title": "金刚般若波罗蜜经",
+      "text": "...",
+      "sourceUrl": "https://book.bfnn.org/books/0040.htm"
+    },
+    "loop": true,
+    "intervalMs": 30000,
+    "region": "global",
+    "channels": ["http", "udp"]
+  },
+  "capabilities": {
+    "networkHttp": true,
+    "networkUdp": true,
+    "storage": true,
+    "keepAwake": true
+  }
+}
+```
+
+### 事件输出
+
+```json
+{"type":"started","jobId":"job_global_dharma_001","at":"2026-07-02T03:43:41Z"}
+{"type":"log","level":"info","message":"已读取链接正文：金刚般若波罗蜜经"}
+{"type":"receipt","channel":"http","countryCode":"ALL","bytes":91234,"status":"queued"}
+{"type":"retry","attempt":2,"nextAt":"2026-07-02T03:44:11Z","reason":"node_timeout"}
+{"type":"progress","sentCount":12,"bytesSent":1094823,"loopRound":4}
+{"type":"stopped","reason":"user_stop"}
+```
+
+## 本地容器策略
+
+宿主提供的“Rust 程序容器”不是 Docker 依赖，而是跨平台的受控运行环境。桌面端建议分层实现：
+
+1. **进程隔离**：独立子进程，固定 working directory，环境变量白名单；
+2. **文件隔离**：只能访问小程序 appData/jobData 目录；
+3. **网络隔离**：只允许 manifest 中声明的 domain、protocol、port；
+4. **资源限制**：CPU、内存、日志大小、运行时长、并发 job 数限制；
+5. **生命周期管理**：start、stop、pause、resume、crash restart；
+6. **审计**：记录程序 hash、签名、参数摘要、权限、开始/停止、网络目标、失败原因；
+7. **恢复**：App 重启后从 job store 恢复 queued/running/paused 状态。
+
+平台映射：
+
+| 平台 | 建议实现 |
+|---|---|
+| macOS | 子进程 + app sandbox/appData + hardened runtime；后续可加 seatbelt profile |
+| Windows | 子进程 + Job Object + appData 隔离 + 防火墙/网络白名单策略 |
+| Linux | 子进程 + cgroup/resource limit；后续可接 bubblewrap/firejail |
+| iOS/Android | 默认不运行外部本地二进制，降级为宿主内置 Rust library 或云端 worker |
+| Web | 不支持本地 Rust program，降级为 HTTP API |
+
+## 全球法布施 worker 内部状态机
+
+```text
+created
+  -> prepared
+  -> running
+     -> sending_round
+     -> waiting_interval
+     -> retrying
+     -> paused
+  -> stopping
+  -> stopped
+  -> failed
+  -> completed
+```
+
+关键规则：
+
+- `loop=true` 时，任务不以一次发送成功为结束；
+- 每轮发送必须产生 round id；
+- 回执必须持久化，不能只放 React state；
+- 失败必须进入 retry/backoff，不允许静默丢失；
+- 用户点击停止必须优先于下一轮循环；
+- crash 后如果 restartPolicy 允许，宿主可以重启 worker；
+- 所有外部网络目标必须在权限 scope 内。
+
+## 与当前前端实现的迁移关系
+
+当前 `GlobalDharmaApp.tsx` 和 `global-dharma-send-service.ts` 已经能完成真实 HTTP/UDP 发送，但循环依赖 WebView 的 `setInterval`。迁移后应改为：
+
+| 当前逻辑 | 迁移后 |
+|---|---|
+| React `setInterval` 循环发送 | Rust worker 内部 loop scheduler |
+| 前端 `sendViaHttp/sendViaUdp` | Rust worker 调用宿主网络能力或使用受控网络代理 |
+| React state 保存回执 | `runtime.storage` 保存 job/receipts |
+| 前端日志数组 | worker JSONL event stream + 宿主 log store |
+| stop 按钮清 timer | `rust.program.stop(jobId)` |
+| keepAwake 在 UI 层开启 | worker job 生命周期绑定 keepAwake lease |
+
+前端仍保留 UI、命令入口、状态展示，但业务执行入口改成 `GlobalDharmaWorkerClient`。
+
+## 最小落地顺序
+
+### Phase 1：协议先落地
+
+- [ ] 在 Host API spec 中新增 `rust.program` 能力组；
+- [ ] 定义 `RustProgramManifest`、`RustProgramStartRequest`、`RustProgramEvent`；
+- [ ] 小程序 manifest 增加 `runtime.type = rust-program`；
+- [ ] 前端增加 `GlobalDharmaWorkerClient`，先用 mock adapter 跑通状态流。
+
+### Phase 2：桌面宿主 runtime
+
+- [ ] 实现 `RustProgramRuntimeAdapter.prepare/start/stop/status/logs`；
+- [ ] 将 worker 包缓存在 appData；
+- [ ] 校验 sha256/signature；
+- [ ] 子进程启动并读取 JSONL stdout；
+- [ ] job store 持久化 running/paused/stopped/failed 状态。
+
+### Phase 3：全球法布施 worker
+
+- [ ] 新建 `native/global-dharma-worker` Rust crate；
+- [ ] 实现内容哈希、HTTP 投递、UDP 投递、回执、重试、循环调度；
+- [ ] 将日志和回执全部输出为 JSONL 事件；
+- [ ] 将状态保存到 runtime storage；
+- [ ] 支持 graceful shutdown。
+
+### Phase 4：安全与生产化
+
+- [ ] 网络 allowlist；
+- [ ] CPU/内存/日志限制；
+- [ ] crash restart policy；
+- [ ] 用户授权页展示“本地 Rust 程序将持续运行”；
+- [ ] 设置页可停止/删除 worker/job；
+- [ ] 审计页面可查看每轮发送和网络目标。
+
+## 最重要的产品表达
+
+用户看到的仍然是“全球法布施小程序”。技术上，它不是一次网页请求，而是小程序在本地启动一个受控 Rust worker：
+
+> 小程序负责发愿与配置，Rust worker 负责持续运行，宿主负责安全容器和权限。
+
+这样才能支撑循环全球发送和后续复杂调度，而不会把宿主 App 写死成某一个业务工具。

--- a/docs/miniapp-autostart-runtime.md
+++ b/docs/miniapp-autostart-runtime.md
@@ -1,0 +1,389 @@
+# 小程序启动即运行脚本/程序：Autostart Runtime 设计
+
+## 目标
+
+Fabushi 小程序可以支持一种模式：用户打开小程序后，不需要再点击“开始”，小程序声明的脚本、worker 或本机任务可以直接启动。
+
+但这个能力必须设计成平台能力，而不是让网页随便执行本机命令。
+
+```text
+用户打开小程序
+  -> 宿主读取 manifest
+  -> 校验官方身份、签名、hash、宿主版本、权限
+  -> 准备 runtime
+  -> 自动执行 onLaunch / autostart 任务
+  -> UI 订阅状态、日志、回执
+```
+
+核心原则：**可以自动运行，但必须经过宿主 runtime；小程序不能绕过宿主直接拿本机系统权限。**
+
+## 适用场景
+
+- 全球法布施：打开后自动准备内容、恢复上次任务、启动循环 worker；
+- 佛经整理：打开后自动扫描 appData 里的待处理内容并开始整理；
+- AI 制卡：打开后自动执行本地生成队列；
+- 自动发布：打开后自动恢复上次未完成的发布任务；
+- 本地知识库：打开后自动启动索引 worker；
+- 创意小程序：打开即运行官方脚本/程序，UI 只作为控制台。
+
+## Manifest 新增字段
+
+建议在小程序 manifest 中加入 `launch` 字段。
+
+```json
+{
+  "schemaVersion": 3,
+  "miniAppId": "official.global-dharma",
+  "title": "全球法布施",
+  "source": "official",
+  "reviewStatus": "trusted",
+  "entryUrl": "https://fabushi.ombhrum.com/miniapps/global-dharma",
+  "launch": {
+    "mode": "auto",
+    "entrypoint": "onLaunch",
+    "runBeforeUiReady": false,
+    "resumePreviousJob": true,
+    "requiresUserGesture": false,
+    "showRunningIndicator": true,
+    "failurePolicy": "showErrorAndOpenUi"
+  },
+  "runtime": {
+    "type": "rust-program",
+    "programId": "global-dharma-worker",
+    "version": "1.0.0",
+    "sha256": "<package-sha256>",
+    "signature": "<ed25519-signature>"
+  },
+  "permissions": [
+    {
+      "name": "rust.program",
+      "reason": "打开小程序后自动启动全球法布施 worker"
+    },
+    {
+      "name": "runtime.storage",
+      "reason": "恢复任务队列、状态和回执"
+    },
+    {
+      "name": "network.http",
+      "reason": "向全球法布施节点提交任务"
+    },
+    {
+      "name": "system.keepAwake",
+      "reason": "循环发送期间防止设备休眠"
+    }
+  ]
+}
+```
+
+## launch.mode
+
+| mode | 行为 | 适用场景 |
+|---|---|---|
+| `manual` | 默认模式，用户点击按钮后运行 | 普通小程序 |
+| `auto` | 打开小程序后自动运行 | 官方任务型小程序 |
+| `resume-only` | 只恢复上次未完成任务，不创建新任务 | 长任务恢复 |
+| `headless` | 可以不打开完整 UI，只运行后台任务入口 | 桌面端、官方小程序、系统托盘任务 |
+
+早期为了快速创新，可以先支持：
+
+```text
+manual
+auto
+resume-only
+```
+
+`headless` 等安全模型稳定后再开放。
+
+## 启动顺序
+
+### 标准 UI 启动
+
+```text
+1. 用户打开小程序
+2. 宿主下载/读取 manifest
+3. 校验 source = official、reviewStatus = trusted、signature、sha256
+4. 检查 hostVersion、runtime、capabilities
+5. 检查用户是否已经同意 autostart 权限
+6. 创建 launch session
+7. 加载小程序 UI
+8. UI bootMiniApp
+9. 宿主触发 launch.entrypoint
+10. runtime 启动脚本/worker
+11. UI 订阅 events/logs/status
+```
+
+### 先运行再打开 UI
+
+某些官方小程序可以设置：
+
+```json
+{
+  "launch": {
+    "mode": "auto",
+    "runBeforeUiReady": true
+  }
+}
+```
+
+流程变成：
+
+```text
+1. 用户打开小程序
+2. 宿主先启动 runtime job
+3. UI 加载后自动 attach 到 job
+4. UI 展示状态、日志、停止按钮
+```
+
+这个模式适合“打开就是执行”的任务型小程序，但必须满足：
+
+```text
+source = official
+reviewStatus = trusted
+runtime 已签名
+权限已预授权或用户曾经授权
+showRunningIndicator = true
+job 可停止
+```
+
+## Autostart Host API
+
+新增通用能力组：`runtime.launch`。
+
+| 方法 | 作用 |
+|---|---|
+| `runtime.launch.getPolicy` | 读取当前小程序自动运行策略 |
+| `runtime.launch.requestAutostart` | 请求用户允许打开即运行 |
+| `runtime.launch.revokeAutostart` | 关闭打开即运行 |
+| `runtime.launch.getSession` | 获取当前 launch session |
+| `runtime.launch.attachJob` | UI 加载后绑定已启动 job |
+
+与本机代码执行能力配合：
+
+| runtime | 自动运行方式 |
+|---|---|
+| `script.js` | 宿主内置 JS runtime / WebView 执行 `onLaunch` |
+| `script.lua` | 宿主内置 Lua runtime 执行入口 |
+| `wasm` | 宿主 WASM runtime 调用 exported `on_launch` |
+| `rust-program` | 桌面端启动独立 Rust worker |
+| `rust-library` | 移动/桌面调用内置 Rust library 函数 |
+| `cloud-worker` | 移动/Web 提交云端任务并订阅状态 |
+
+## 小程序 SDK 入口
+
+小程序侧建议约定生命周期函数。
+
+```ts
+export async function onLaunch(ctx: MiniAppLaunchContext) {
+  const existing = await ctx.host.invoke("rust.program.listJobs", {
+    miniAppId: "official.global-dharma",
+    status: ["running", "paused", "queued"]
+  });
+
+  if (existing.jobs.length > 0) {
+    return ctx.host.invoke("rust.program.resume", {
+      jobId: existing.jobs[0].jobId
+    });
+  }
+
+  return ctx.host.invoke("rust.program.start", {
+    programId: "global-dharma-worker",
+    args: ctx.launchArgs,
+    restartPolicy: {
+      mode: "on-failure",
+      maxRestarts: 3
+    }
+  });
+}
+```
+
+如果是移动端：
+
+```ts
+export async function onLaunch(ctx: MiniAppLaunchContext) {
+  if (ctx.host.capabilities.includes("rust.globalDharmaCore")) {
+    return ctx.host.invoke("rust.globalDharmaCore.start", ctx.launchArgs);
+  }
+
+  return ctx.host.invoke("cloudWorker.start", {
+    workerId: "global-dharma-worker",
+    args: ctx.launchArgs
+  });
+}
+```
+
+## 首次授权与后续自动运行
+
+为了符合用户预期，第一次打开需要展示一次“此小程序会自动运行本地任务”。
+
+授权文案示例：
+
+```text
+全球法布施希望在打开小程序时自动启动本地任务。
+
+它可能会：
+- 持续运行循环发送任务；
+- 访问网络节点；
+- 保存任务状态和回执；
+- 在运行期间请求保持唤醒。
+
+你可以随时停止任务，或在设置中关闭自动运行。
+```
+
+用户同意后，宿主保存 grant：
+
+```json
+{
+  "userId": "...",
+  "miniAppId": "official.global-dharma",
+  "permission": "runtime.launch.autostart",
+  "runtime": "rust-program",
+  "decision": "granted",
+  "expiresAt": null,
+  "createdAt": "2026-07-02T00:00:00Z"
+}
+```
+
+官方内置小程序可以预授权，但仍要：
+
+```text
+显示运行指示
+可停止
+可查看日志
+可撤销自动运行
+写审计日志
+```
+
+## 全局和小程序级开关
+
+宿主设置页必须提供两级开关：
+
+```text
+全局：允许官方小程序启动时自动运行任务
+单个小程序：全球法布施 -> 打开时自动运行
+```
+
+如果用户关闭全局开关，小程序只能打开 UI，不能自动运行脚本/worker。
+
+## 移动端规则
+
+移动端也可以“打开小程序就运行脚本”，但含义是：**App 前台打开小程序时立即执行受控脚本/内置能力**。
+
+移动端允许的 autostart 类型：
+
+| 类型 | 是否推荐 | 说明 |
+|---|---:|---|
+| Web JS `onLaunch` | 推荐 | UI 和轻逻辑 |
+| WASM `on_launch` | 推荐 | 算法、解析、hash |
+| 内置 Rust library | 推荐 | 宿主 App 已打包的 Rust 能力 |
+| 云端 worker | 强烈推荐 | 长任务、循环任务 |
+| 外部本机二进制 | 不推荐 | 移动端不要动态下载运行 |
+| 任意 shell | 不支持 | 移动端不应开放 |
+
+移动端启动后可以自动：
+
+```text
+读取 manifest
+运行 JS/WASM/onLaunch
+调用内置 Rust library
+提交云端 worker
+恢复上次任务状态
+订阅回执和日志
+```
+
+但不要承诺：
+
+```text
+App 被系统杀掉后仍一直本地循环
+后台无限运行
+动态下载原生二进制并执行
+```
+
+如果全球法布施需要真正持续循环，移动端应提交给云端 worker；桌面端才运行本地 Rust worker。
+
+## 桌面端规则
+
+桌面端可以支持更强的 autostart：
+
+```text
+打开小程序即启动本地 Rust worker
+UI 关闭后 worker 可继续运行
+系统托盘显示任务状态
+用户可从任务管理器停止
+App 重启后可恢复 queued/running/paused 任务
+```
+
+桌面端必须有：
+
+```text
+jobId
+runId
+stop/kill
+log cursor
+receipt store
+resource limit
+audit log
+network allowlist
+signature/hash 校验
+```
+
+## 全球法布施推荐行为
+
+全球法布施小程序打开时建议这样做：
+
+```text
+1. 自动检查是否有未完成 job
+2. 有 job：自动 attach + resume
+3. 没有 job，但用户已开启“打开即运行”：自动 start
+4. 没有授权：打开 UI，并显示一键开启自动运行
+5. 运行中：UI 实时展示日志、回执、停止按钮
+```
+
+伪代码：
+
+```ts
+async function globalDharmaOnLaunch(ctx: MiniAppLaunchContext) {
+  const policy = await ctx.host.invoke("runtime.launch.getPolicy", {
+    miniAppId: "official.global-dharma"
+  });
+
+  const jobs = await ctx.host.invoke("rust.program.listJobs", {
+    miniAppId: "official.global-dharma",
+    status: ["running", "paused", "queued"]
+  });
+
+  if (jobs.length > 0) {
+    return ctx.host.invoke("runtime.launch.attachJob", {
+      jobId: jobs[0].jobId
+    });
+  }
+
+  if (!policy.autostartAllowed) {
+    return { mode: "ui-only", reason: "autostart_not_granted" };
+  }
+
+  return ctx.host.invoke("rust.program.start", {
+    programId: "global-dharma-worker",
+    args: ctx.launchArgs,
+    restartPolicy: {
+      mode: "on-failure",
+      maxRestarts: 3
+    }
+  });
+}
+```
+
+## 最小实现版本
+
+第一版可以先做得很简单：
+
+```text
+1. manifest 支持 launch.mode = auto
+2. 只允许 source=official + reviewStatus=trusted
+3. 只支持桌面端 rust-program 和移动端 cloud-worker/rust-library
+4. 打开小程序后自动调用 onLaunch
+5. UI 必须展示运行状态和停止按钮
+6. 设置页可以关闭自动运行
+7. 所有启动、停止、失败写审计日志
+```
+
+这样既满足“打开小程序就直接运行脚本/程序”，又不会把平台做成不可控的任意代码执行器。


### PR DESCRIPTION
## Summary

- Adds a dedicated design document for making the 全球法布施 mini app run a local Rust worker instead of relying on one-shot WebView calls or React timers.
- Defines the host-provided Rust program container boundary, capability model, manifest shape, lifecycle APIs, event protocol, sandboxing, and phased rollout.
- Clarifies that the host only provides prebuilt runtime adapters and system primitives; the mini app prepares and controls a local worker, while the Rust worker owns loop delivery, retries, receipts, logs, and recovery.

## Notes

This is a design-only change. The next implementation step is to add the `rust.program` Host API capability and a `GlobalDharmaWorkerClient` that can first run against a mock adapter.