### PR TITLE
Codex Transport Abstraction for Cross-Platform SDK

### DIFF
--- a/native/miniapp-core/src/codex/mod.rs
+++ b/native/miniapp-core/src/codex/mod.rs
@@ -1,0 +1,9 @@
+pub mod transport;
+pub mod config;
+pub mod event;
+pub mod gateway;
+
+pub use transport::{CodexTransport, CodexTransportKind};
+pub use config::{CodexConfig, CodexModelConfig, ModelProviderType};
+pub use event::{CodexEvent, CodexEventStream};
+pub use gateway::CodexModelGateway;

--- a/native/miniapp-core/src/codex/transport.rs
+++ b/native/miniapp-core/src/codex/transport.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use futures::stream::BoxStream;
+
+pub trait CodexTransport: Send + Sync {
+    fn send_message(&mut self, payload: String) -> Result<()>;
+    fn receive_stream(&mut self) -> Result<BoxStream<'static, String>>;
+    fn terminate(&mut self) -> Result<()>;
+}
+
+pub enum CodexTransportKind {
+    Subprocess,
+    Embedded,
+    WebSocket,
+}
+
+impl CodexTransportKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodexTransportKind::Subprocess => "subprocess",
+            CodexTransportKind::Embedded => "embedded",
+            CodexTransportKind::WebSocket => "websocket",
+        }
+    }
+}


### PR DESCRIPTION
Implements Phase 1 of Codex integration: introduces CodexTransport abstraction layer to decouple Codex SDK communication from platform-specific execution (subprocess / embedded / websocket).

This enables future integration of Codex Rust SDK across desktop, mobile, and WebAssembly environments under a unified transport interface.