### PR TITLE
Connect T0278 juan 14 great compassion benefits

### DIFF
--- a/frontend/apps/web/src/lib/faliu-merit-benefits.ts
+++ b/frontend/apps/web/src/lib/faliu-merit-benefits.ts
@@ -115,6 +115,7 @@ export * from "./faliu-merit-benefits-t0278-juan11-zunzhong";
 export * from "./faliu-merit-benefits-t0278-juan12";
 export * from "./faliu-merit-benefits-t0278-juan13";
 export * from "./faliu-merit-benefits-t0278-juan14";
+export * from "./faliu-merit-benefits-t0278-juan14-great-compassion-burden";
 
 import { getFaliuMeritBenefits as getBaseFaliuMeritBenefits } from "./faliu-merit-benefits-original";
 import * as t0263Juan10 from "./faliu-merit-benefits-t0263-juan10";
@@ -233,6 +234,7 @@ import * as t0278Juan11Zunzhong from "./faliu-merit-benefits-t0278-juan11-zunzho
 import * as t0278Juan12 from "./faliu-merit-benefits-t0278-juan12";
 import * as t0278Juan13 from "./faliu-merit-benefits-t0278-juan13";
 import * as t0278Juan14 from "./faliu-merit-benefits-t0278-juan14";
+import * as t0278Juan14GreatCompassionBurden from "./faliu-merit-benefits-t0278-juan14-great-compassion-burden";
 
 const overrideMeritBenefits = {
   "T0263:10": [
@@ -402,7 +404,10 @@ const overrideMeritBenefits = {
   ],
   "T0278:12": t0278Juan12.T0278_JUAN_12_MERIT_BENEFITS,
   "T0278:13": t0278Juan13.T0278_JUAN_13_MERIT_BENEFITS,
-  "T0278:14": t0278Juan14.T0278_JUAN_14_MERIT_BENEFITS,
+  "T0278:14": [
+    ...t0278Juan14.T0278_JUAN_14_MERIT_BENEFITS,
+    ...t0278Juan14GreatCompassionBurden.T0278_JUAN_14_GREAT_COMPASSION_BURDEN_MERIT_BENEFITS,
+  ],
 };
 
 export function getFaliuMeritBenefits(work: string | null | undefined, juan: string | number | null | undefined) {


### PR DESCRIPTION
## Summary

- Connect the existing T0278 juan 14 great-compassion-burden merit-benefit module to the Faliu merit-benefit selector.
- Export/import `faliu-merit-benefits-t0278-juan14-great-compassion-burden`.
- Return `t0278-014-068` through `t0278-014-072` from `T0278:14` together with the existing juan 14 entries.

## Scope

This PR only updates the Faliu merit-benefit data entry point. It does not change page structure, styling, or unrelated scripture data.

## Verification

- Compared branch against `main`: one modified file, `frontend/apps/web/src/lib/faliu-merit-benefits.ts`, with 6 additions and 1 deletion.
- Re-read the branch file and confirmed `T0278:14` now spreads both `T0278_JUAN_14_MERIT_BENEFITS` and `T0278_JUAN_14_GREAT_COMPASSION_BURDEN_MERIT_BENEFITS`.
- The five entries were already strictly validated in Memory: `t0278-014-068` through `t0278-014-072`.