### PR TITLE
fix(miniapp): 修复小程序 URL 结尾斜杠 307 重定向导致的 macOS 白屏与后台超时问题并延长初始化容错时长

### DIFF
--- a/PRD/global_dharma_daemon_and_stream_ipc_prd.md
+++ b/PRD/global_dharma_daemon_and_stream_ipc_prd.md
@@ -87,3 +87,27 @@
 ### 5.3 自动化验证与边界说明
 - 执行 `cargo test` 测试通过，套接字 HTTP 服务、内存 Job Start/Stop 接口用例 100% 成功。
 - 边界说明：本次演进恪守“不做磁盘持久化”要求，任务状态和回执完全托管在内存。若 UI 关闭，循环发包不受影响；但若机器重启或操作系统主动杀掉 Rust 守护进程，循环任务不会从磁盘恢复。
+
+## 6. macOS/桌面端 WKWebView 路由重定向与生命周期容错深度演进 (PR #1546)
+
+在实际桌面端平台（macOS/Windows）与实际移动端加载在线小程序过程中，发现并解决了点击打开应用白屏及发送链接提示“小程序后台加载超时”的关键问题：
+
+### 6.1 根因分析：307 重定向对 WebKit 桥接脚本的破坏
+1. **重定向引发的桥接丢失**：
+   - 小程序前端 Web 工程在 `next.config.ts` 中开启了 `trailingSlash: true`（尾随斜杠强约束）。此前客户端 `_entryUrlFor` 构造的 URL 默认形式为 `https://fabushi.ombhrum.com/miniapps/official.global-dharma`（结尾无斜杠）。
+   - 当 macOS/iOS 底层 WKWebView 发起请求时，服务器端返回 HTTP 307 Temporary Redirect 至带 `/` 的地址。
+   - 在 WebKit 底层机制中，重定向会导致在 `atDocumentStart` 时机注入的宿主 SDK 桥接脚本 `_hostSdkScript` 丢失或被跳过，同时干扰 WebKit 内部 navigation delegate 的 `onLoadStop` 事件同步。
+2. **生命周期超时与加载停滞**：
+   - 由于 `onLoadStop` 未及时触发或被重定向吃掉，客户端未执行 `_markHostReady()`，导致聊天界面静默发送内容时触发 20 秒超时抛错；
+   - 在小程序 Web 端内部，React 启动并调用 `bootMiniApp` 时，因找不到 `window.FabushiMiniApp` 桥接对象，SDK 在默认 800ms 内快速超时并渲染兜底界面或陷入加载白屏。
+
+### 6.2 工业级容错与兼容性改进
+1. **URL 规范化零重定向**：在客户端 `_entryUrlFor` 及 `desktop_package_cli` 生成器中强约束：若目标 URL 既无查询参数又无尾随斜杠，必须自动追加 `/`，彻底杜绝 Next.js/Cloudflare 产生任何 307 重定向。
+2. **容器双层生命周期保底 (`onProgressChanged`)**：为防范复杂网络或 SPA 路由机制对 `onLoadStop` 吞没，新增 Web 容器加载进度回调。当 `progress == 100` 且尚未标记 Ready 时，立即主动执行 `evaluateJavascript` 注入桥接脚本并激活宿主状态。
+3. **环境权限与容错窗口调整**：
+   - 在 `InAppWebViewSettings` 中显式开启 `domStorageEnabled: true` 与 `databaseEnabled: true`，消除 macOS WebKit 对 Next.js LocalStorage/SessionStorage 访问的 DOMException 防火墙；
+   - 将 Web 端 SDK 宿主准备超时阈值 (`timeoutMs`) 由 800ms 延长至 8000ms，为桌面端内核初始化与网络请求让出充足时间容忍度。
+
+### 6.3 宿主与小程序核心权责声明
+- **宿主（Flutter 客户端/App）的角色**：纯粹提供底层操作系统原生能力（Rust 原生网络推流程序调起、设备硬件标号、keepAwake 系统后台保活、数字回执管道），并在聊天窗口或侧边栏提供展示容器。
+- **小程序（Next.js Web 工程）的角色**：**主导全部业务逻辑、聊天框交互数字菜单生成、参数解析验证、发送频率控制与状态机展示。** 宿主只是小程序的画布与驱动底层硬件的工具链，所有业务闭环全部在小程序内优雅流转。

--- a/fabushi/lib/screens/mini_app_host_screen.dart
+++ b/fabushi/lib/screens/mini_app_host_screen.dart
@@ -295,6 +295,8 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
             transparentBackground: false,
             mediaPlaybackRequiresUserGesture: false,
             supportZoom: false,
+            domStorageEnabled: true,
+            databaseEnabled: true,
           ),
           onWebViewCreated: (controller) {
             _webViewController = controller;
@@ -322,6 +324,29 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
             await controller.evaluateJavascript(source: _hostSdkScript);
             _markHostReady();
             if (mounted) setState(() => _loading = false);
+          },
+          onProgressChanged: (controller, progress) async {
+            if (progress == 100 && !_hostReady) {
+              _webViewController = controller;
+              await controller.evaluateJavascript(source: _hostSdkScript);
+              _markHostReady();
+              if (mounted) setState(() => _loading = false);
+            }
+          },
+          onConsoleMessage: (controller, consoleMessage) {
+            debugPrint(
+              'MiniApp[${widget.bot.stableBotId}] (${consoleMessage.messageLevel}): ${consoleMessage.message}',
+            );
+          },
+          onReceivedHttpError: (controller, request, errorResponse) {
+            if (request.isForMainFrame ?? true) {
+              if (mounted) {
+                setState(() {
+                  _loading = false;
+                  _error = 'HTTP ${errorResponse.statusCode}: 加载页面失败';
+                });
+              }
+            }
           },
           onReceivedError: (controller, request, error) {
             if (mounted) {
@@ -457,7 +482,10 @@ class _MiniAppHostScreenState extends State<MiniAppHostScreen> {
     final explicitEntryUrl = bot.stableMiniAppEntryUrl;
     var base = explicitEntryUrl.isNotEmpty
         ? explicitEntryUrl
-        : 'https://fabushi.ombhrum.com/miniapps/${Uri.encodeComponent(bot.stableMiniAppId)}';
+        : 'https://fabushi.ombhrum.com/miniapps/${Uri.encodeComponent(bot.stableMiniAppId)}/';
+    if (!base.contains('?') && !base.endsWith('/')) {
+      base = '$base/';
+    }
 
     final uri = Uri.parse(base);
     final queryParams = Map<String, String>.from(uri.queryParameters);

--- a/fabushi/tool/desktop_package_cli.dart
+++ b/fabushi/tool/desktop_package_cli.dart
@@ -833,7 +833,7 @@ class MiniAppSmokeRegistry {
           MiniAppSmokeManifest(
             miniAppId: bot.miniAppId,
             botId: bot.botId,
-            entryUrl: 'https://fabushi.ombhrum.com/miniapps/${bot.miniAppId}',
+            entryUrl: 'https://fabushi.ombhrum.com/miniapps/${bot.miniAppId}/',
             permissions: bot.permissions,
             surfaces: const ['homePinned', 'chatPanel'],
           ),

--- a/frontend/apps/web/src/app/miniapps/[id]/miniapp-runtime.ts
+++ b/frontend/apps/web/src/app/miniapps/[id]/miniapp-runtime.ts
@@ -3,7 +3,7 @@ import { fbApp, MiniAppHostError } from "@fabushi/miniapp-sdk";
 export { fbApp, MiniAppHostError };
 
 export async function bootMiniApp(miniAppId: string, title: string): Promise<boolean> {
-  const hostReady = await fbApp.ready({ timeoutMs: 800, miniAppId });
+  const hostReady = await fbApp.ready({ timeoutMs: 8000, miniAppId });
   if (!hostReady) {
     fbApp.showFallback({
       mode: "open-in-app",


### PR DESCRIPTION
### 问题背景与修复原因
1. **macOS/桌面端点击打开小程序白屏与发消息提示加载超时**：由于小程序 Web 路由在 Next.js () 中配置了 `trailingSlash: true`，此前客户端 `_entryUrlFor` 构建的 URL 结尾未带斜杠 `/`，导致 WKWebView 发起请求时被服务器 307 重定向至带 `/` 的地址。在 WKWebView 中，307 重定向不仅会导致 `atDocumentStart` 注入的宿主桥接脚本 (`_hostSdkScript`) 丢失，且会干扰 `onLoadStop` 回调的触发，导致页面状态永远处于 loading 白屏，且后台静默发消息时触发 20 秒超时抛错。
2. **容错与兼容性提升**：
   - 客户端在 `_entryUrlFor` 与 `desktop_package_cli` 中强制为小程序 URL 补齐尾随斜杠 `/`；
   - 在 `InAppWebViewSettings` 中开启 `domStorageEnabled: true` 与 `databaseEnabled: true`；
   - 增加 `onProgressChanged` (100% 进度) 回调作为 `onLoadStop` 的保底方案，确保在任何重定向或复杂路由下宿主桥接脚本均能成功注入；
   - 将 Web 小程序端的宿主准备超时时长 (`timeoutMs`) 从 800ms 调整为 8000ms，充分适应网络波动与桌面端容器加载延迟。