### PR TITLE
test: ChatGPT 自动确认插件 E2E

### DIFF
--- a/.github/auto-confirm-e2e-20260720.md
+++ b/.github/auto-confirm-e2e-20260720.md
@@ -1,0 +1,3 @@
+# ChatGPT auto-confirm E2E
+
+Temporary file used only to trigger and verify the desktop authorization card. The draft pull request will be closed after the test.


### PR DESCRIPTION
临时草稿 PR，仅用于触发 ChatGPT 高后果授权卡并验证大乘 CLI 生成的自动确认插件。验证后关闭并删除分支。