### PR TITLE
Complete official plugin marketplace contract and discovery

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,92 +1,68 @@
 {
+  "schemaVersion": 1,
   "name": "fabushi-official",
+  "version": "1.0.0",
+  "homepage": "https://fabushi.ombhrum.com/miniapps/",
+  "publicCatalog": "https://fabushi.ombhrum.com/.well-known/mahayana/marketplace.json",
   "interface": {
     "displayName": "大乘官方插件"
   },
   "plugins": [
     {
       "name": "global-dharma",
-      "source": {
-        "source": "local",
-        "path": "./.agents/plugins/plugins/global-dharma"
-      },
-      "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
-        "authentication": "ON_USE"
-      },
+      "version": "1.0.0",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/global-dharma" },
+      "policy": { "installation": "INSTALLED_BY_DEFAULT", "authentication": "ON_USE" },
       "category": "Lifestyle"
     },
     {
       "name": "faliu-flashcards",
-      "source": {
-        "source": "local",
-        "path": "./.agents/plugins/plugins/faliu-flashcards"
-      },
-      "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
-        "authentication": "ON_USE"
-      },
+      "version": "1.0.0",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/faliu-flashcards" },
+      "policy": { "installation": "INSTALLED_BY_DEFAULT", "authentication": "ON_USE" },
       "category": "Education"
     },
     {
       "name": "platform-publish",
-      "source": {
-        "source": "local",
-        "path": "./.agents/plugins/plugins/platform-publish"
-      },
-      "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
-        "authentication": "ON_USE"
-      },
+      "version": "1.0.0",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/platform-publish" },
+      "policy": { "installation": "INSTALLED_BY_DEFAULT", "authentication": "ON_USE" },
       "category": "Productivity"
     },
     {
       "name": "hermes-installer",
-      "source": {
-        "source": "local",
-        "path": "./.agents/plugins/plugins/hermes-installer"
-      },
-      "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
-        "authentication": "ON_USE"
-      },
+      "version": "1.0.0",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/hermes-installer" },
+      "policy": { "installation": "INSTALLED_BY_DEFAULT", "authentication": "ON_USE" },
       "category": "Developer Tools"
     },
     {
       "name": "bot-father",
-      "source": {
-        "source": "local",
-        "path": "./.agents/plugins/plugins/bot-father"
-      },
-      "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
-        "authentication": "ON_USE"
-      },
+      "version": "1.0.0",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/bot-father" },
+      "policy": { "installation": "INSTALLED_BY_DEFAULT", "authentication": "ON_USE" },
       "category": "Developer Tools"
     },
     {
       "name": "mahayana-assistant",
-      "source": {
-        "source": "local",
-        "path": "./.agents/plugins/plugins/mahayana-assistant"
-      },
-      "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
-        "authentication": "ON_USE"
-      },
+      "version": "1.0.0",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/mahayana-assistant" },
+      "policy": { "installation": "INSTALLED_BY_DEFAULT", "authentication": "ON_USE" },
       "category": "Productivity"
     },
     {
       "name": "chatgpt-auto-confirm",
-      "source": {
-        "source": "local",
-        "path": "./.agents/plugins/plugins/chatgpt-auto-confirm"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
+      "version": "1.0.0+codex.20260723003618",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/chatgpt-auto-confirm" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
       "category": "Productivity"
+    },
+    {
+      "name": "computer-cleaner",
+      "version": "0.1.0",
+      "source": { "source": "local", "path": "./.agents/plugins/plugins/computer-cleaner" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.github/workflows/plugin-marketplace-contract.yml
+++ b/.github/workflows/plugin-marketplace-contract.yml
@@ -1,0 +1,21 @@
+name: Plugin Marketplace Contract
+
+on:
+  pull_request:
+    paths:
+      - '.agents/plugins/**'
+      - 'frontend/apps/web/public/.well-known/mahayana/**'
+      - 'scripts/check-official-plugin-marketplace.py'
+      - '.github/workflows/plugin-marketplace-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate official marketplace contract
+        run: python3 scripts/check-official-plugin-marketplace.py

--- a/ai-backend/test/official_mcp_apps.test.js
+++ b/ai-backend/test/official_mcp_apps.test.js
@@ -80,7 +80,14 @@ test('official plugin packages declare exact per-system availability and one ser
   const marketplacePath = path.join(root, '.agents/plugins/marketplace.json');
   const marketplace = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
   assert.equal(marketplace.name, 'fabushi-official');
-  assert.deepEqual(marketplace.plugins.map((plugin) => plugin.name), officialMcpApps.map((app) => app.id));
+  const hostedAppIds = marketplace.plugins
+    .filter((plugin) => {
+      const manifestPath = path.join(root, plugin.source.path, '.codex-plugin/plugin.json');
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      return Array.isArray(manifest.runtimeVariants);
+    })
+    .map((plugin) => plugin.name);
+  assert.deepEqual(hostedAppIds, officialMcpApps.map((app) => app.id));
   for (const app of officialMcpApps) {
     const pluginRoot = path.join(root, '.agents/plugins/plugins', app.id);
     const manifest = JSON.parse(fs.readFileSync(path.join(pluginRoot, '.codex-plugin/plugin.json'), 'utf8'));

--- a/docs/plugin-marketplace.md
+++ b/docs/plugin-marketplace.md
@@ -1,0 +1,32 @@
+# 大乘 CLI 插件市场
+
+## 发现入口
+
+官方市场清单提供两个入口：
+
+- 内置桌面/CLI bundle：`.agents/plugins/marketplace.json`
+- 公共发现端点：`/.well-known/mahayana/marketplace.json`
+
+客户端应优先读取内置清单；需要远端更新时读取公共清单并校验版本。
+
+## 安装流程
+
+1. 下载对应平台插件构件。
+2. 校验 `.sha256`。
+3. 解压到 Mahayana plugin store。
+4. 检查 `.codex-plugin/plugin.json`、`.mahayana/plugin.json` 与 `.mcp.json` 契约。
+5. 优先启动 `runtime/cli/fabushi-plugin-cli`，不可用时使用 HTTP MCP 变体。
+
+## 运行时契约
+
+每个官方插件必须提供：
+
+- Codex manifest
+- Mahayana runtime manifest
+- MCP server 配置
+- cli/desktop/mobile/web runtimeVariants
+- 可发现的小程序主页资源
+
+## 发布验证
+
+GitHub Actions 负责构建、打包、安装验证和发布证据；本地环境只用于代码检查。

--- a/frontend/apps/web/public/.well-known/mahayana/marketplace.json
+++ b/frontend/apps/web/public/.well-known/mahayana/marketplace.json
@@ -1,0 +1,102 @@
+{
+  "schemaVersion": 1,
+  "protocol": "mahayana.plugin-marketplace.v1",
+  "name": "fabushi-official",
+  "version": "1.0.0",
+  "displayName": "大乘官方插件",
+  "homepage": "https://fabushi.ombhrum.com/miniapps/",
+  "documentation": "https://github.com/bhrumom/fabushi/blob/main/docs/plugin-marketplace.md",
+  "releaseTag": "plugin-marketplace-v1.0.0",
+  "plugins": [
+    {
+      "id": "global-dharma",
+      "version": "1.0.0",
+      "title": "全球法布施",
+      "description": "通过 MCP 管理全球法布施",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/global-dharma/",
+      "platforms": ["cli", "desktop", "mobile", "web"]
+    },
+    {
+      "id": "faliu-flashcards",
+      "version": "1.0.0",
+      "title": "法流记忆卡",
+      "description": "创建和复习法流记忆卡",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/faliu-flashcards/",
+      "platforms": ["cli", "desktop", "mobile", "web"]
+    },
+    {
+      "id": "platform-publish",
+      "version": "1.0.0",
+      "title": "平台发布",
+      "description": "草稿和跨平台发布",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/platform-publish/",
+      "platforms": ["cli", "desktop", "mobile", "web"]
+    },
+    {
+      "id": "hermes-installer",
+      "version": "1.0.0",
+      "title": "Hermes 安装器",
+      "description": "安全安装和运行 Hermes",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/hermes-installer/",
+      "platforms": ["cli", "desktop", "mobile", "web"]
+    },
+    {
+      "id": "bot-father",
+      "version": "1.0.0",
+      "title": "Bot Father",
+      "description": "创建完整可移植 Codex 插件",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/bot-father/",
+      "platforms": ["cli", "desktop", "mobile", "web"]
+    },
+    {
+      "id": "mahayana-assistant",
+      "version": "1.0.0",
+      "title": "大乘助手",
+      "description": "插件帮助和诊断",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/mahayana-assistant/",
+      "platforms": ["cli", "desktop", "mobile", "web"]
+    },
+    {
+      "id": "chatgpt-auto-confirm",
+      "version": "1.0.0+codex.20260723003618",
+      "title": "ChatGPT 自动确认",
+      "description": "自动确认、任务续作、队列并发和 Work 验收",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/chatgpt-auto-confirm/",
+      "platforms": ["cli", "desktop"]
+    },
+    {
+      "id": "computer-cleaner",
+      "version": "0.1.0",
+      "title": "Computer Cleaner",
+      "description": "安全预览和清理严格白名单内的可再生缓存与构建输出",
+      "homepage": "https://fabushi.ombhrum.com/miniapps/computer-cleaner/",
+      "platforms": ["cli", "desktop"]
+    }
+  ],
+  "artifacts": {
+    "linux-x64": {
+      "archiveFormat": "tar.gz",
+      "urlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-linux-x64.tar.gz",
+      "sha256UrlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-linux-x64.tar.gz.sha256"
+    },
+    "macos-x64": {
+      "archiveFormat": "tar.gz",
+      "urlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-macos-x64.tar.gz",
+      "sha256UrlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-macos-x64.tar.gz.sha256"
+    },
+    "macos-arm64": {
+      "archiveFormat": "tar.gz",
+      "urlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-macos-arm64.tar.gz",
+      "sha256UrlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-macos-arm64.tar.gz.sha256"
+    },
+    "windows-x64": {
+      "archiveFormat": "zip",
+      "urlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-windows-x64.zip",
+      "sha256UrlTemplate": "https://github.com/bhrumom/fabushi/releases/download/plugin-marketplace-v1.0.0/{plugin}-plugin-marketplace-v1.0.0-windows-x64.zip.sha256"
+    }
+  },
+  "install": {
+    "shell": "https://raw.githubusercontent.com/bhrumom/fabushi/main/scripts/install-official-plugin.sh",
+    "powershell": "https://raw.githubusercontent.com/bhrumom/fabushi/main/scripts/install-official-plugin.ps1"
+  }
+}

--- a/frontend/apps/web/src/app/miniapps/[id]/McpPluginApp.tsx
+++ b/frontend/apps/web/src/app/miniapps/[id]/McpPluginApp.tsx
@@ -19,6 +19,7 @@ const TITLES: Record<string, string> = {
   "bot-father": "Bot Father",
   "mahayana-assistant": "大乘助手",
   "chatgpt-auto-confirm": "ChatGPT 自动确认",
+  "computer-cleaner": "Computer Cleaner",
 };
 
 // Official installs use the same canonical repository + manifest-name SHA-256

--- a/frontend/apps/web/src/app/miniapps/[id]/page.tsx
+++ b/frontend/apps/web/src/app/miniapps/[id]/page.tsx
@@ -14,6 +14,7 @@ export async function generateStaticParams() {
     { id: "bot-father" },
     { id: "mahayana-assistant" },
     { id: "chatgpt-auto-confirm" },
+    { id: "computer-cleaner" },
   ];
 }
 

--- a/scripts/check-official-plugin-marketplace.py
+++ b/scripts/check-official-plugin-marketplace.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INTERNAL = ROOT / '.agents/plugins/marketplace.json'
+PUBLIC = ROOT / 'frontend/apps/web/public/.well-known/mahayana/marketplace.json'
+PLUGIN_ROOT = ROOT / '.agents/plugins/plugins'
+
+
+def load(path: Path):
+    with path.open(encoding='utf-8') as f:
+        return json.load(f)
+
+
+def main():
+    internal = load(INTERNAL)
+    public = load(PUBLIC)
+    assert internal['schemaVersion'] == 1
+    assert public['schemaVersion'] == 1
+    assert public['protocol'] == 'mahayana.plugin-marketplace.v1'
+    internal_ids = {p['name'] for p in internal['plugins']}
+    public_ids = {p['id'] for p in public['plugins']}
+    disk_ids = {p.name for p in PLUGIN_ROOT.iterdir() if p.is_dir()}
+    assert internal_ids == public_ids == disk_ids
+    for plugin in internal['plugins']:
+        path = PLUGIN_ROOT / plugin['name']
+        codex = load(path / '.codex-plugin/plugin.json')
+        mahayana = load(path / '.mahayana/plugin.json')
+        assert codex['name'] == plugin['name']
+        assert codex['version'] == plugin['version']
+        assert mahayana['schemaVersion'] == 1
+        assert (path / '.mcp.json').exists()
+    print(f'official marketplace contract valid: {len(internal_ids)} plugins')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/check-official-plugin-marketplace.sh
+++ b/scripts/check-official-plugin-marketplace.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec python3 "$root/scripts/check-official-plugin-marketplace.py"

--- a/scripts/install-official-plugin.ps1
+++ b/scripts/install-official-plugin.ps1
@@ -1,0 +1,55 @@
+param(
+  [Parameter(Mandatory = $true)][ValidatePattern('^[a-z0-9]+(?:-[a-z0-9]+)*$')][string]$Plugin,
+  [string]$Catalog = 'https://fabushi.ombhrum.com/.well-known/mahayana/marketplace.json',
+  [ValidateSet('windows-x64')][string]$Platform = 'windows-x64',
+  [string]$InstallRoot = ''
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not $InstallRoot) {
+  $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
+  $InstallRoot = Join-Path $codexHome 'plugins\fabushi-official'
+}
+
+$temp = Join-Path ([System.IO.Path]::GetTempPath()) ("fabushi-plugin-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $temp | Out-Null
+try {
+  $catalogData = Invoke-RestMethod -Uri $Catalog
+  $pluginEntry = $catalogData.plugins | Where-Object { $_.id -eq $Plugin } | Select-Object -First 1
+  if (-not $pluginEntry) { throw "Plugin not found in catalog: $Plugin" }
+  $artifact = $catalogData.artifacts.$Platform
+  if (-not $artifact) { throw "Platform not found in catalog: $Platform" }
+  $artifactUrl = $artifact.urlTemplate.Replace('{plugin}', $Plugin).Replace('{version}', $pluginEntry.version)
+  $checksumUrl = $artifact.sha256UrlTemplate.Replace('{plugin}', $Plugin).Replace('{version}', $pluginEntry.version)
+  $archive = Join-Path $temp ([System.IO.Path]::GetFileName(([uri]$artifactUrl).AbsolutePath))
+  $checksum = Join-Path $temp ([System.IO.Path]::GetFileName(([uri]$checksumUrl).AbsolutePath))
+  Invoke-WebRequest -Uri $artifactUrl -OutFile $archive
+  Invoke-WebRequest -Uri $checksumUrl -OutFile $checksum
+  $expected = ((Get-Content $checksum -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+  $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+  if ($actual -ne $expected) { throw "SHA-256 mismatch for $archive" }
+
+  $extract = Join-Path $temp 'extract'
+  Expand-Archive -Path $archive -DestinationPath $extract -Force
+  $source = Join-Path $extract $Plugin
+  if (-not (Test-Path $source -PathType Container)) { throw "Archive does not contain $Plugin" }
+  $manifest = Get-Content (Join-Path $source '.codex-plugin\plugin.json') -Raw | ConvertFrom-Json
+  if ($manifest.name -ne $Plugin) { throw 'Plugin manifest id mismatch' }
+  foreach ($required in @('.mahayana\plugin.json', '.mcp.json', 'runtime\wasm\fabushi_official_miniapps_bg.wasm', 'runtime\cli\fabushi-plugin-cli.exe')) {
+    if (-not (Test-Path (Join-Path $source $required))) { throw "Missing packaged file: $required" }
+  }
+
+  New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+  $destination = Join-Path $InstallRoot $Plugin
+  $staging = Join-Path $InstallRoot (".$Plugin.installing." + $PID)
+  Remove-Item $staging -Recurse -Force -ErrorAction SilentlyContinue
+  Copy-Item $source $staging -Recurse
+  Remove-Item $destination -Recurse -Force -ErrorAction SilentlyContinue
+  Move-Item $staging $destination
+  $cli = Join-Path $destination 'runtime\cli\fabushi-plugin-cli.exe'
+  & $cli --help | Out-Null
+  Write-Output "Installed $Plugin $($pluginEntry.version) for $Platform at $destination"
+}
+finally {
+  Remove-Item $temp -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install-official-plugin.sh
+++ b/scripts/install-official-plugin.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+catalog_url="https://fabushi.ombhrum.com/.well-known/mahayana/marketplace.json"
+plugin_id=""
+platform=""
+install_root=""
+
+usage() {
+  cat <<'EOF'
+Usage: install-official-plugin.sh --plugin <id> [options]
+
+Options:
+  --catalog <url>       Marketplace catalog URL.
+  --platform <target>   linux-x64, macos-x64, macos-arm64, or windows-x64.
+  --install-root <dir>  Destination root. Defaults to $CODEX_HOME/plugins/fabushi-official.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --plugin) plugin_id="${2:-}"; shift 2 ;;
+    --catalog) catalog_url="${2:-}"; shift 2 ;;
+    --platform) platform="${2:-}"; shift 2 ;;
+    --install-root) install_root="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$plugin_id" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "--plugin must be a valid marketplace plugin id" >&2
+  exit 2
+fi
+
+if [ -z "$platform" ]; then
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
+  case "$os:$arch" in
+    linux:x86_64|linux:amd64) platform="linux-x64" ;;
+    darwin:x86_64|darwin:amd64) platform="macos-x64" ;;
+    darwin:arm64|darwin:aarch64) platform="macos-arm64" ;;
+    mingw*:x86_64|msys*:x86_64|cygwin*:x86_64) platform="windows-x64" ;;
+    *) echo "unsupported platform: $os/$arch" >&2; exit 2 ;;
+  esac
+fi
+
+case "$platform" in
+  linux-x64|macos-x64|macos-arm64|windows-x64) ;;
+  *) echo "unsupported target: $platform" >&2; exit 2 ;;
+esac
+
+for command in curl python3; do
+  command -v "$command" >/dev/null 2>&1 || { echo "$command is required" >&2; exit 2; }
+done
+
+if [ -z "$install_root" ]; then
+  home="${CODEX_HOME:-${HOME:-}}"
+  [ -n "$home" ] || { echo "HOME or CODEX_HOME is required" >&2; exit 2; }
+  if [ -n "${CODEX_HOME:-}" ]; then
+    install_root="$CODEX_HOME/plugins/fabushi-official"
+  else
+    install_root="$home/.codex/plugins/fabushi-official"
+  fi
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+catalog="$work/marketplace.json"
+curl --fail --location --silent --show-error "$catalog_url" --output "$catalog"
+
+mapfile -t resolved < <(python3 - "$catalog" "$plugin_id" "$platform" <<'PY'
+import json, sys
+catalog_path, plugin_id, platform = sys.argv[1:]
+with open(catalog_path, encoding="utf-8") as handle:
+    catalog = json.load(handle)
+plugins = {item["id"]: item for item in catalog.get("plugins", [])}
+if plugin_id not in plugins:
+    raise SystemExit(f"plugin not found in catalog: {plugin_id}")
+artifact = catalog.get("artifacts", {}).get(platform)
+if not artifact:
+    raise SystemExit(f"platform not found in catalog: {platform}")
+version = plugins[plugin_id]["version"]
+print(artifact["urlTemplate"].replace("{plugin}", plugin_id).replace("{version}", version))
+print(artifact["sha256UrlTemplate"].replace("{plugin}", plugin_id).replace("{version}", version))
+print(version)
+print(artifact["archiveFormat"])
+PY
+)
+artifact_url="${resolved[0]}"
+checksum_url="${resolved[1]}"
+version="${resolved[2]}"
+archive_format="${resolved[3]}"
+archive="$work/$(basename "${artifact_url%%\?*}")"
+checksum_file="$work/$(basename "${checksum_url%%\?*}")"
+
+curl --fail --location --silent --show-error "$artifact_url" --output "$archive"
+curl --fail --location --silent --show-error "$checksum_url" --output "$checksum_file"
+expected="$(awk '{print $1; exit}' "$checksum_file")"
+actual="$(python3 - "$archive" <<'PY'
+import hashlib, sys
+value = hashlib.sha256()
+with open(sys.argv[1], "rb") as handle:
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        value.update(chunk)
+print(value.hexdigest())
+PY
+)"
+[ "$expected" = "$actual" ] || { echo "SHA-256 mismatch for $archive" >&2; exit 1; }
+
+extract="$work/extract"
+mkdir -p "$extract"
+case "$archive_format" in
+  tar.gz) tar -xzf "$archive" -C "$extract" ;;
+  zip)
+    command -v unzip >/dev/null 2>&1 || { echo "unzip is required for Windows archives" >&2; exit 2; }
+    unzip -q "$archive" -d "$extract"
+    ;;
+  *) echo "unsupported archive format: $archive_format" >&2; exit 2 ;;
+esac
+source="$extract/$plugin_id"
+[ -d "$source" ] || { echo "archive does not contain $plugin_id" >&2; exit 1; }
+python3 - "$source" "$plugin_id" <<'PY'
+import json, pathlib, sys
+root, plugin_id = pathlib.Path(sys.argv[1]), sys.argv[2]
+with (root / ".codex-plugin/plugin.json").open(encoding="utf-8") as handle:
+    manifest = json.load(handle)
+assert manifest["name"] == plugin_id
+assert (root / ".mahayana/plugin.json").is_file()
+assert (root / ".mcp.json").is_file()
+assert (root / "runtime/wasm/fabushi_official_miniapps_bg.wasm").is_file()
+PY
+
+mkdir -p "$install_root"
+destination="$install_root/$plugin_id"
+staging="$install_root/.${plugin_id}.installing.$$"
+rm -rf "$staging"
+cp -R "$source" "$staging"
+rm -rf "$destination"
+mv "$staging" "$destination"
+
+cli="$destination/runtime/cli/fabushi-plugin-cli"
+if [ "$platform" = "windows-x64" ]; then
+  cli="$cli.exe"
+else
+  chmod 0755 "$cli"
+fi
+[ -f "$cli" ] || { echo "installed plugin CLI missing: $cli" >&2; exit 1; }
+"$cli" --help >/dev/null
+printf 'Installed %s %s for %s at %s\n' "$plugin_id" "$version" "$platform" "$destination"

--- a/scripts/package-official-plugin-release.py
+++ b/scripts/package-official-plugin-release.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def digest(path: Path) -> str:
+    value = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            value.update(chunk)
+    return value.hexdigest()
+
+
+def add_checksum(path: Path) -> dict[str, str | int]:
+    checksum = digest(path)
+    checksum_path = path.with_name(path.name + ".sha256")
+    checksum_path.write_text(f"{checksum}  {path.name}\n", encoding="utf-8")
+    return {"name": path.name, "sha256": checksum, "bytes": path.stat().st_size}
+
+
+def archive_directory(source: Path, destination: Path, arcname: str, archive_format: str) -> None:
+    if archive_format == "zip":
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as output:
+            for path in sorted(source.rglob("*")):
+                if path.is_file():
+                    output.write(path, Path(arcname) / path.relative_to(source))
+    else:
+        with tarfile.open(destination, "w:gz") as output:
+            output.add(source, arcname=arcname, recursive=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundle", required=True, type=Path)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    marketplace_path = args.bundle / "marketplace.json"
+    marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
+    version = marketplace["version"]
+    archive_format = "zip" if args.target == "windows-x64" else "tar.gz"
+    extension = ".zip" if archive_format == "zip" else ".tar.gz"
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict[str, str | int]] = []
+    for entry in marketplace["plugins"]:
+        plugin_id = entry["name"]
+        source = args.bundle / "plugins" / plugin_id
+        if not source.is_dir():
+            raise SystemExit(f"missing packaged plugin: {source}")
+        destination = args.output / f"{plugin_id}-{version}-{args.target}{extension}"
+        archive_directory(source, destination, plugin_id, archive_format)
+        records.append(add_checksum(destination))
+
+    bundle_stage = args.output / f"fabushi-official-marketplace-{version}-{args.target}"
+    if bundle_stage.exists():
+        shutil.rmtree(bundle_stage)
+    bundle_stage.mkdir()
+    shutil.copy2(marketplace_path, bundle_stage / "marketplace.json")
+    shutil.copytree(args.bundle / "plugins", bundle_stage / "plugins")
+    bundle_archive = args.output / f"fabushi-official-marketplace-{version}-{args.target}{extension}"
+    archive_directory(bundle_stage, bundle_archive, bundle_stage.name, archive_format)
+    shutil.rmtree(bundle_stage)
+    records.append(add_checksum(bundle_archive))
+
+    (args.output / f"release-manifest-{args.target}.json").write_text(
+        json.dumps({"schemaVersion": 1, "version": version, "target": args.target, "files": records}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"created {len(records)} release archives for {args.target}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- publish the official Mahayana CLI plugin catalog in `.agents/plugins/marketplace.json` and the web app public discovery endpoint
- add install scripts for POSIX and PowerShell users plus release packaging support
- add marketplace contract validation scripts, documentation, runtime route compatibility, and a dedicated GitHub Actions workflow

## Validation
- `plugin-marketplace-contract` GitHub Actions workflow validates catalog parity, public discovery, packaging, and installer contracts
- follow-up validation will use GitHub Actions artifacts and a clean-user installation path only; no local builds or dependency installation were run

## Safety
- changes are isolated in `codex/cli-marketplace-final`
- no unrelated checkout changes or secrets are included