### PR TITLE
fix(ios): export Mahayana symbols in debug builds

### DIFF
--- a/fabushi/ios/Flutter/Debug.xcconfig
+++ b/fabushi/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,6 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+
+// Dart FFI resolves the statically linked Mahayana ABI through
+// DynamicLibrary.process(), so debug exports must retain global C symbols.
+OTHER_LDFLAGS = $(inherited) -Wl,-export_dynamic

--- a/fabushi/ios/Runner.xcodeproj/project.pbxproj
+++ b/fabushi/ios/Runner.xcodeproj/project.pbxproj
@@ -643,6 +643,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
+					"-Wl,-export_dynamic",
 					"-lc++",
 					"-all_load",
 				);
@@ -836,6 +837,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
+					"-Wl,-export_dynamic",
 					"-lc++",
 					"-all_load",
 				);
@@ -872,6 +874,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
+					"-Wl,-export_dynamic",
 					"-lc++",
 					"-all_load",
 				);


### PR DESCRIPTION
## Summary

- export the statically linked Mahayana C ABI from iOS Debug builds
- keep Debug behavior aligned with the existing Release/Profile linker configuration
- fix the Native smoke failure at its root cause so `DynamicLibrary.process()` can resolve the runtime and product symbols

## Root cause

PR #1628 added iOS native symbol validation. Release/Profile already use `-Wl,-export_dynamic`, but Debug did not, so the unsigned Debug app built successfully while `nm -gU` could not find the Mahayana symbols.

## Validation

- `git diff --check` passed in the continuation checkout
- GitHub Actions Native smoke and repository-required checks are the source of truth

Supersedes the check-relaxation approach in #1631.