### PR TITLE
fix: upload ChatGPT auto-confirm runtime artifact correctly

### DIFF
--- a/.github/workflows/chatgpt-auto-confirm-runtime.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runtime.yml
@@ -34,4 +34,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: chatgpt-auto-confirm-macos-runtime
-          path: runtime/macos/chatgpt-auto-confirm
+          if-no-files-found: error
+          path: .agents/plugins/plugins/chatgpt-auto-confirm/runtime/macos/chatgpt-auto-confirm


### PR DESCRIPTION
Fixes the runtime evidence artifact upload path. The previous workflow used a path relative to the plugin working directory while upload-artifact resolves from repository root, causing missing artifacts. This changes the path to the repository-root path and makes missing artifacts fail the workflow.