### PR TITLE
fix: trigger release packaging for official plugin changes

### DIFF
--- a/.github/scripts/assert-mahayana-bundle.sh
+++ b/.github/scripts/assert-mahayana-bundle.sh
@@ -32,7 +32,7 @@ if [ ! -f "$runtime" ]; then
   exit 1
 fi
 
-"$cli" help >/dev/null
+"$cli" --help >/dev/null
 smoke_home="$(mktemp -d)"
 trap 'rm -rf "$smoke_home"' EXIT
 status_json="$(MAHAYANA_HOME="$smoke_home" "$cli" status)"

--- a/.github/scripts/build-mahayana-desktop-bundle.sh
+++ b/.github/scripts/build-mahayana-desktop-bundle.sh
@@ -113,7 +113,7 @@ if [ "$target" != "windows" ]; then
   fi
 fi
 
-"$cli_destination" help >/dev/null
+"$cli_destination" --help >/dev/null
 smoke_home="$(mktemp -d)"
 trap 'rm -rf "$smoke_home"' EXIT
 status_json="$(MAHAYANA_HOME="$smoke_home" "$cli_destination" status)"

--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -7,6 +7,7 @@ import sys
 
 deploy_workflow = Path('.github/workflows/deploy-production.yml').read_text(encoding='utf-8')
 publish_release_workflow = Path('.github/workflows/publish-cd-release.yml').read_text(encoding='utf-8')
+desktop_installers_workflow = Path('.github/workflows/desktop-installers.yml').read_text(encoding='utf-8')
 auth_utils = Path('fabushi/web/auth-utils.js').read_text(encoding='utf-8')
 auth_handler = Path('fabushi/web/src/handlers/auth.js').read_text(encoding='utf-8')
 password_login = Path('fabushi/web/src/handlers/password-login.js').read_text(encoding='utf-8')
@@ -55,6 +56,9 @@ for required in (
     'CI/CD guardrail input does not require mobile install packages',
     'PR label explicitly requests fresh install packages',
     'force[- ]?mobile[- ]?release|mobile[- ]?release|build[- ]?mobile[- ]?package|build[- ]?app[- ]?package',
+    '.agents/plugins/*)',
+    'bundled official plugin input changed: $path',
+    'package release workflow changed; validate Android and iOS release package paths: $path',
     'Android package build when Android or shared Flutter app inputs changed, or an explicit PR label requests it',
     'iOS package build when iOS or shared Flutter app inputs changed, or an explicit PR label requests it',
     'This workflow publishes install packages after the main production CD workflow succeeds and the change detector finds mobile app package inputs.',
@@ -64,6 +68,12 @@ for required in (
 ):
     if required not in publish_release_workflow:
         missing.append(f'publish release workflow missing: {required}')
+
+for required in (
+    "      - .agents/plugins/**",
+):
+    if desktop_installers_workflow.count(required) < 2:
+        missing.append(f'desktop installers workflow must trigger for pull requests and pushes containing: {required.strip()}')
 
 for forbidden in (
     '      - name: Checkout source for change detection\n        uses: actions/checkout@v5\n        with:\n          ref: ${{ steps.source.outputs.source_sha }}\n          fetch-depth: 0\n\n      - name: Detect changed mobile package targets',

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - fabushi/**
+      - .agents/plugins/**
       - third_party/mahayana
       - third_party/mahayana/**
       - .github/scripts/package-desktop-*
@@ -23,6 +24,7 @@ on:
       - main
     paths:
       - fabushi/**
+      - .agents/plugins/**
       - third_party/mahayana
       - third_party/mahayana/**
       - .github/scripts/package-desktop-*

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -591,7 +591,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y "$deb_path"
           ../.github/scripts/assert-mahayana-bundle.sh /opt/global-dharma-sharing linux
-          mahayana help >/dev/null
+          mahayana --help >/dev/null
           global-dharma-sharing-cli doctor --json
           global-dharma-sharing-cli gateway-smoke --timeout-seconds 120 --json
           global-dharma-sharing-cli miniapp-smoke --json
@@ -648,7 +648,7 @@ jobs:
           $mahayanaRuntime = Join-Path $installDir "mahayana_runtime.dll"
           if (-not (Test-Path $mahayana)) { throw "Bundled Mahayana CLI not found: $mahayana" }
           if (-not (Test-Path $mahayanaRuntime)) { throw "Bundled Mahayana Runtime not found: $mahayanaRuntime" }
-          & $mahayana help | Out-Null
+          & $mahayana --help | Out-Null
           $mahayanaHome = Join-Path $env:RUNNER_TEMP "mahayana-home"
           New-Item -ItemType Directory -Force -Path $mahayanaHome | Out-Null
           $env:MAHAYANA_HOME = $mahayanaHome

--- a/.github/workflows/desktop-package-cli-smoke.yml
+++ b/.github/workflows/desktop-package-cli-smoke.yml
@@ -153,7 +153,7 @@ jobs:
           $mahayanaRuntime = Join-Path $installDir "mahayana_runtime.dll"
           if (-not (Test-Path $mahayana)) { throw "Bundled Mahayana CLI not found: $mahayana" }
           if (-not (Test-Path $mahayanaRuntime)) { throw "Bundled Mahayana Runtime not found: $mahayanaRuntime" }
-          & $mahayana help | Out-Null
+          & $mahayana --help | Out-Null
           $mahayanaHome = Join-Path $env:RUNNER_TEMP "mahayana-home"
           New-Item -ItemType Directory -Force -Path $mahayanaHome | Out-Null
           $env:MAHAYANA_HOME = $mahayanaHome

--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -204,6 +204,9 @@ jobs:
               fabushi/lib/*|fabushi/assets/*|fabushi/fonts/*|fabushi/pubspec.yaml|fabushi/pubspec.lock|fabushi/analysis_options.yaml|fabushi/l10n.yaml)
                 add_both "shared Flutter package input changed: $path"
                 ;;
+              .agents/plugins/*)
+                add_both "bundled official plugin input changed: $path"
+                ;;
               frontend/*)
                 ignore_mobile_package "official site input does not require mobile install packages: $path"
                 ;;
@@ -214,7 +217,7 @@ jobs:
                 ignore_mobile_package "Worker/API input does not require mobile install packages: $path"
                 ;;
               .github/workflows/publish-cd-release.yml)
-                add_android "package release workflow changed; validate Android release package path: $path"
+                add_both "package release workflow changed; validate Android and iOS release package paths: $path"
                 ;;
               .github/workflows/*|.github/scripts/*)
                 ignore_mobile_package "CI/CD guardrail input does not require mobile install packages: $path"


### PR DESCRIPTION
Follow-up after PR #1636 merge.

Adds release trigger coverage for bundled official plugin changes:
- desktop installers now run when .agents/plugins changes
- mobile package release detection treats bundled plugins as app package input
- release contract checks cover these paths

Commit: e07cdbe31960fb9ae5edbe13eeb72c2711b9c96a