### PR TITLE
fix: trigger desktop packaging for plugin packager changes

### DIFF
--- a/.github/scripts/build-mahayana-desktop-bundle.sh
+++ b/.github/scripts/build-mahayana-desktop-bundle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 target="${1:-}"
 if [ -z "$target" ]; then
@@ -16,6 +16,28 @@ if [ ! -f "pubspec.yaml" ]; then
   echo "Run this script from the fabushi Flutter project directory." >&2
   exit 2
 fi
+
+diagnostics_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+diagnostics_file="$diagnostics_dir/mahayana-bundle-${target}-failure.txt"
+mkdir -p "$diagnostics_dir"
+record_failure() {
+  local status="$1"
+  local line="$2"
+  local command="$3"
+  trap - ERR
+  if [ ! -s "$diagnostics_file" ]; then
+    {
+      printf 'target=%s\n' "$target"
+      printf 'script=%s\n' "${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+      printf 'line=%s\n' "$line"
+      printf 'exit_status=%s\n' "$status"
+      printf 'command=%s\n' "$command"
+    } >"$diagnostics_file"
+  fi
+  cat "$diagnostics_file" >&2
+  exit "$status"
+}
+trap 'record_failure "$?" "$LINENO" "$BASH_COMMAND"' ERR
 
 repo_root="$(cd .. && pwd)"
 runtime_root="$repo_root/third_party/mahayana"

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - fabushi/**
       - .agents/plugins/**
+      - scripts/package-official-plugins.sh
       - third_party/mahayana
       - third_party/mahayana/**
       - .github/scripts/package-desktop-*
@@ -25,6 +26,7 @@ on:
     paths:
       - fabushi/**
       - .agents/plugins/**
+      - scripts/package-official-plugins.sh
       - third_party/mahayana
       - third_party/mahayana/**
       - .github/scripts/package-desktop-*

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -607,6 +607,15 @@ jobs:
         shell: bash
         run: ../.github/scripts/build-mahayana-desktop-bundle.sh windows
 
+      - name: Upload Mahayana bundle failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mahayana-bundle-diagnostics-${{ matrix.target }}
+          path: ${{ runner.temp }}/mahayana-bundle-${{ matrix.target }}-failure.txt
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Sync Windows OpenClaw assets into release build
         if: matrix.target == 'windows'
         shell: bash

--- a/scripts/package-official-plugins.sh
+++ b/scripts/package-official-plugins.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 target="${1:-}"
 destination="${2:-}"
@@ -7,6 +7,26 @@ if [ -z "$target" ] || [ -z "$destination" ]; then
   echo "usage: $0 <macos|linux|windows> <destination>" >&2
   exit 2
 fi
+
+diagnostics_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+diagnostics_file="$diagnostics_dir/mahayana-bundle-${target}-failure.txt"
+mkdir -p "$diagnostics_dir"
+record_failure() {
+  local status="$1"
+  local line="$2"
+  local command="$3"
+  trap - ERR
+  {
+    printf 'target=%s\n' "$target"
+    printf 'script=%s\n' "${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+    printf 'line=%s\n' "$line"
+    printf 'exit_status=%s\n' "$status"
+    printf 'command=%s\n' "$command"
+  } >"$diagnostics_file"
+  cat "$diagnostics_file" >&2
+  exit "$status"
+}
+trap 'record_failure "$?" "$LINENO" "$BASH_COMMAND"' ERR
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source_root="$repo_root/.agents/plugins"


### PR DESCRIPTION
Follow-up to PR #1636 release packaging validation.

The desktop installer workflow already packages bundled official plugins through `scripts/package-official-plugins.sh`, but changes to that script were not included in the workflow path filters. Add the script to both pull-request and main-push triggers so packaging fixes are validated and published by the desktop installer workflow.

Commit: ac13e451f