### PR TITLE
fix(ci): remove obsolete Mahayana platform package checks

### DIFF
--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -49,7 +49,6 @@ jobs:
           --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml
           --package mahayana-agent-codex
           --package mahayana-agent-responses
-          --package mahayana-platform-client
           --package mahayana-cli
 
   test-flutter-codex-binding:

--- a/.github/workflows/global-dharma-rust.yml
+++ b/.github/workflows/global-dharma-rust.yml
@@ -42,7 +42,6 @@ jobs:
           --package mahayana-core
           --package mahayana-agent-codex
           --package mahayana-agent-responses
-          --package mahayana-platform-client
           --package mahayana-runtime
           --package mahayana-ffi
           --package mahayana-cli


### PR DESCRIPTION
Follow-up to PR #1644 and the PR #1636 release validation chain.

The updated Mahayana runtime no longer exposes the `mahayana-platform-client` workspace package, but two repository workflows still request it explicitly. Remove only those obsolete package selectors so CI validates the current runtime workspace.

Changes:
- remove `mahayana-platform-client` from `.github/workflows/ci_codex_sync.yml`
- remove `mahayana-platform-client` from `.github/workflows/global-dharma-rust.yml`

No project builds or tests were run locally; GitHub Actions is the source of truth.