### PR TITLE
Trigger mobile Mahayana runtime release packaging

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -207,6 +207,9 @@ jobs:
               .agents/plugins/*)
                 add_both "bundled official plugin input changed: $path"
                 ;;
+              third_party/mahayana|third_party/mahayana/*)
+                add_both "Mahayana runtime input changed: $path"
+                ;;
               frontend/*)
                 ignore_mobile_package "official site input does not require mobile install packages: $path"
                 ;;


### PR DESCRIPTION
Update publish workflow trigger coverage so third_party/mahayana runtime changes trigger mobile and release packaging workflows.