### PR TITLE
fix(ci): tolerate iOS Mach-O symbol underscore prefix

### DIFF
--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -911,9 +911,9 @@ jobs:
           symbols_file="$(mktemp)"
           nm -gU "$app_path/$executable" > "$symbols_file"
           for symbol in create execute receive interrupt resolve_approval close free_string; do
-            grep -q "_mahayana_runtime_${symbol}$" "$symbols_file"
+            grep -Eq "_+mahayana_runtime_${symbol}$" "$symbols_file"
           done
-          grep -q '_fabushi_mahayana_product_execute$' "$symbols_file"
+          grep -Eq '_+fabushi_mahayana_product_execute$' "$symbols_file"
           rm -f "$symbols_file"
           cp "$ipa_path" "../ios-release-assets/fabushi-ios-${short_sha}.ipa"
 


### PR DESCRIPTION
基于当前 main 的最小修复。

修复发布 iOS IPA 验证脚本对 Mach-O 符号前导下划线处理不一致的问题。

变更：
- 使用兼容 Mach-O 符号前缀的正则匹配 Mahayana runtime ABI 符号。
- 保留现有 IPA 构建和符号验收流程。

不包含 ChatGPT auto-confirm 调试改动或无关插件变更。