### PR TITLE
fix(ios): keep Mahayana runtime create ABI linked in release

### DIFF
--- a/fabushi/ios/Runner/AppDelegate.swift
+++ b/fabushi/ios/Runner/AppDelegate.swift
@@ -8,6 +8,9 @@ private func fabushiTelegramForceLink() -> UInt32
 @_silgen_name("mahayana_runtime_force_link")
 private func mahayanaRuntimeForceLink() -> UInt32
 
+@_silgen_name("mahayana_runtime_create")
+private func mahayanaRuntimeCreate(_ config: UnsafePointer<CChar>?) -> UInt64
+
 @_silgen_name("mahayana_product_execute")
 private func mahayanaProductExecute(
     _ requestJson: UnsafePointer<CChar>?
@@ -51,6 +54,10 @@ func fabushiMahayanaProductExecute(
             mahayanaRuntimeForceLink() == 1,
             "Mahayana Rust runtime failed to link"
         )
+        // Keep the primary runtime ABI entry point reachable in optimized Release
+        // executables. The linker may otherwise dead-strip the exported Rust
+        // symbol even though DynamicLibrary.process() resolves it at runtime.
+        _ = mahayanaRuntimeCreate(nil)
         // Keep the product-only C ABI entry point in the final executable.
         // Rust turns a nil request into an owned error response, which is
         // immediately released after the linker-visible probe.


### PR DESCRIPTION
## Summary
- retain `mahayana_runtime_create` in optimized iOS release executables
- add an explicit Swift linker-visible reference before Dart resolves the ABI via `DynamicLibrary.process()`
- keep the change minimal and scoped to `AppDelegate.swift`

## Validation
- local checkout was used only for Git metadata and source inspection
- all build, test, signing, IPA upload, artifact, and release verification will be performed through GitHub Actions