### PR TITLE
fix(cd): trigger mobile release retry marker

### DIFF
--- a/.github/cd-retry.txt
+++ b/.github/cd-retry.txt
@@ -1,3 +1,3 @@
 Retry CD after Cloudflare credentials were configured.
 
-Latest retry reason: verify staging deploy, profile UI E2E matrix, Android native install, iOS native install, production deploy, and production smoke.
+Latest retry reason: force a fresh Android and iOS release after the iOS Mahayana runtime ABI retention fix merged as 2d4a5ccde72932186bc68894ceaffe65aa346406.

--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -60,6 +60,8 @@ for required in (
     'force[- ]?mobile[- ]?release|mobile[- ]?release|build[- ]?mobile[- ]?package|build[- ]?app[- ]?package',
     '.agents/plugins/*)',
     'bundled official plugin input changed: $path',
+    '.github/cd-retry.txt)',
+    'explicit CD retry marker changed: $path',
     'package release workflow changed; validate Android and iOS release package paths: $path',
     'Android package build when Android or shared Flutter app inputs changed, or an explicit PR label requests it',
     'iOS package build when iOS or shared Flutter app inputs changed, or an explicit PR label requests it',

--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -38,6 +38,8 @@ for required in (
     'cp -R ../.github/scripts/. ../release-artifact/github-scripts',
     'run: bash ../../github-scripts/run-wrangler-d1-migrations.sh DB development',
     'run: bash ../../github-scripts/run-wrangler-d1-migrations.sh DB production',
+    '.github/cd-retry.txt)',
+    'explicit CD retry marker changed: $path',
 ):
     if required not in deploy_workflow:
         missing.append(f'deploy workflow missing: {required}')

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -112,6 +112,9 @@ jobs:
               fabushi/web/*|fabushi/e2e/*)
                 mark_deploy "worker runtime or staging gate input changed: $path"
                 ;;
+              .github/cd-retry.txt)
+                mark_deploy "explicit CD retry marker changed: $path"
+                ;;
               .github/workflows/deploy-production.yml|.github/scripts/*)
                 mark_deploy "deployment pipeline input changed: $path"
                 ;;

--- a/.github/workflows/publish-cd-release.yml
+++ b/.github/workflows/publish-cd-release.yml
@@ -219,6 +219,9 @@ jobs:
               fabushi/web/*|workers/*|worker/*|functions/*|api/*|server/*|migrations/*|drizzle/*|supabase/*|cloudflare/*|wrangler.toml|wrangler.*.toml|package.json|package-lock.json|pnpm-lock.yaml|yarn.lock)
                 ignore_mobile_package "Worker/API input does not require mobile install packages: $path"
                 ;;
+              .github/cd-retry.txt)
+                add_both "explicit CD retry marker changed: $path"
+                ;;
               .github/workflows/publish-cd-release.yml)
                 add_both "package release workflow changed; validate Android and iOS release package paths: $path"
                 ;;


### PR DESCRIPTION
## Summary
- make `.github/cd-retry.txt` a deploy-relevant CD trigger marker
- update the retry marker reason for the iOS Mahayana runtime ABI release fix
- keep release guardrails aware of the retry marker path

## Validation
- Verified existing checkout state with bhrum2 before changes
- Did not run local builds/tests
- Changes are intended for GitHub Actions CD validation only

## Goal
Allow the post-#1657 merged commit release chain to run a fresh mobile package publication path and produce verifiable GitHub Release/TestFlight evidence.