### PR TITLE
fix(ios): retain full mahayana runtime ABI in release link

### DIFF
--- a/fabushi/ios/Flutter/Debug.xcconfig
+++ b/fabushi/ios/Flutter/Debug.xcconfig
@@ -3,7 +3,7 @@
 
 // Dart FFI resolves the statically linked Mahayana ABI through
 // DynamicLibrary.process(), so debug exports must retain global C symbols.
-OTHER_LDFLAGS = $(inherited) -Wl,-export_dynamic -Wl,-u,_mahayana_product_execute -Wl,-u,_fabushi_mahayana_product_execute
+OTHER_LDFLAGS = $(inherited) -Wl,-export_dynamic -Wl,-u,_mahayana_runtime_force_link -Wl,-u,_mahayana_runtime_create -Wl,-u,_mahayana_runtime_execute -Wl,-u,_mahayana_runtime_receive -Wl,-u,_mahayana_runtime_interrupt -Wl,-u,_mahayana_runtime_resolve_approval -Wl,-u,_mahayana_runtime_close -Wl,-u,_mahayana_runtime_free_string -Wl,-u,_mahayana_product_execute -Wl,-u,_fabushi_mahayana_product_execute
 
 // Keep the embedded Rust C ABI visible to Dart DynamicLibrary.process().
 EXPORTED_SYMBOLS_FILE = $(PROJECT_DIR)/Runner/RuntimeExports.txt

--- a/fabushi/ios/Flutter/Release.xcconfig
+++ b/fabushi/ios/Flutter/Release.xcconfig
@@ -3,7 +3,7 @@
 
 // Dart FFI resolves the statically linked Mahayana ABI through
 // DynamicLibrary.process(), so release exports must retain global C symbols.
-OTHER_LDFLAGS = $(inherited) -Wl,-export_dynamic -Wl,-u,_mahayana_product_execute -Wl,-u,_fabushi_mahayana_product_execute
+OTHER_LDFLAGS = $(inherited) -Wl,-export_dynamic -Wl,-u,_mahayana_runtime_force_link -Wl,-u,_mahayana_runtime_create -Wl,-u,_mahayana_runtime_execute -Wl,-u,_mahayana_runtime_receive -Wl,-u,_mahayana_runtime_interrupt -Wl,-u,_mahayana_runtime_resolve_approval -Wl,-u,_mahayana_runtime_close -Wl,-u,_mahayana_runtime_free_string -Wl,-u,_mahayana_product_execute -Wl,-u,_fabushi_mahayana_product_execute
 
 // Keep the embedded Rust C ABI visible to Dart DynamicLibrary.process().
 EXPORTED_SYMBOLS_FILE = $(PROJECT_DIR)/Runner/RuntimeExports.txt


### PR DESCRIPTION
## Summary
- retain all process-visible Mahayana runtime ABI entry points during iOS release linking
- add linker undefined-symbol anchors for runtime create/execute/receive/interrupt/approval/close/free functions
- keep the fix scoped to iOS linker configuration

## Root cause
Publish CD packages to GitHub Release #1270 built the IPA successfully, but the post-build Mach-O symbol gate failed because the exported IPA did not contain `mahayana_runtime_create`.

## Validation
- Checked failed GitHub Actions log: `flutter build ipa` succeeded; failure occurred in the symbol validation step.
- No local project build/test/package was run.
- Validation will be performed by GitHub Actions after merge.