### PR TITLE
fix(ios): retain runtime exports in release linker config

### DIFF
--- a/.github/scripts/package-desktop-windows.ps1
+++ b/.github/scripts/package-desktop-windows.ps1
@@ -85,11 +85,48 @@ SectionEnd
 
 Set-Content -Path $NsisPath -Value $NsiContent -Encoding UTF8
 
-$MakeNsis = "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
-if (-not (Test-Path $MakeNsis)) {
-  $MakeNsis = "makensis"
+$MakeNsisCandidates = @()
+if (${env:ProgramFiles(x86)}) {
+  $MakeNsisCandidates += Join-Path ${env:ProgramFiles(x86)} "NSIS\makensis.exe"
+  $MakeNsisCandidates += Join-Path ${env:ProgramFiles(x86)} "NSIS\Bin\makensis.exe"
+}
+if ($env:ProgramFiles) {
+  $MakeNsisCandidates += Join-Path $env:ProgramFiles "NSIS\makensis.exe"
+  $MakeNsisCandidates += Join-Path $env:ProgramFiles "NSIS\Bin\makensis.exe"
+}
+if ($env:ChocolateyInstall) {
+  $MakeNsisCandidates += Join-Path $env:ChocolateyInstall "bin\makensis.exe"
 }
 
+$MakeNsis = $MakeNsisCandidates |
+  Where-Object { Test-Path $_ -PathType Leaf } |
+  Select-Object -First 1
+
+if (-not $MakeNsis) {
+  $MakeNsisCommand = Get-Command makensis.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($MakeNsisCommand) {
+    $MakeNsis = $MakeNsisCommand.Source
+  }
+}
+
+if (-not $MakeNsis) {
+  $SearchRoots = @(${env:ProgramFiles(x86)}, $env:ProgramFiles, $env:ChocolateyInstall) |
+    Where-Object { $_ -and (Test-Path $_ -PathType Container) } |
+    Select-Object -Unique
+  foreach ($SearchRoot in $SearchRoots) {
+    $MakeNsis = Get-ChildItem -Path $SearchRoot -Filter makensis.exe -File -Recurse -ErrorAction SilentlyContinue |
+      Select-Object -First 1 -ExpandProperty FullName
+    if ($MakeNsis) {
+      break
+    }
+  }
+}
+
+if (-not $MakeNsis) {
+  throw "NSIS makensis.exe was not found after toolchain installation. Checked: $($MakeNsisCandidates -join ', ')"
+}
+
+Write-Host "Using NSIS compiler: $MakeNsis"
 & $MakeNsis $NsisPath
 
 Write-Host "Created $InstallerPath"

--- a/fabushi/ios/Flutter/Release.xcconfig
+++ b/fabushi/ios/Flutter/Release.xcconfig
@@ -1,6 +1,12 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
 
+// Xcode app targets can otherwise pass -no_exported_symbols for optimized
+// executables. Keep the process ABI global so Dart DynamicLibrary.process()
+// can resolve the embedded Rust runtime after App Store export stripping.
+LD_EXPORT_SYMBOLS = YES
+GCC_SYMBOLS_PRIVATE_EXTERN = NO
+
 // Dart FFI resolves the statically linked Mahayana ABI through
 // DynamicLibrary.process(), so release exports must retain global C symbols.
 OTHER_LDFLAGS = $(inherited) -Wl,-export_dynamic -Wl,-u,_mahayana_runtime_force_link -Wl,-u,_mahayana_runtime_create -Wl,-u,_mahayana_runtime_execute -Wl,-u,_mahayana_runtime_receive -Wl,-u,_mahayana_runtime_interrupt -Wl,-u,_mahayana_runtime_resolve_approval -Wl,-u,_mahayana_runtime_close -Wl,-u,_mahayana_runtime_free_string -Wl,-u,_mahayana_product_execute -Wl,-u,_fabushi_mahayana_product_execute


### PR DESCRIPTION
## Summary
- keep optimized iOS Release app targets exporting process-visible symbols
- disable private-extern defaults for the embedded Rust runtime ABI
- preserve existing explicit Mahayana export list and linker retention flags

## Context
The merged release workflow for commit `9b729f311c453cab77ba6e85f75a3dde5168d685` built the signed IPA successfully, but post-export validation failed because `mahayana_runtime_create` was absent from the final IPA export trie. This change targets the optimized Release linker configuration so Dart `DynamicLibrary.process()` can resolve the embedded runtime after App Store export stripping.

## Validation
- local validation limited to Git metadata and `git diff --check` per repository execution policy
- full build, IPA export, symbol validation, packaging, and publication must run in GitHub Actions