### PR TITLE
fix(ios): preserve Mahayana runtime exports during IPA stripping

### DIFF
--- a/fabushi/ios/Flutter/Release.xcconfig
+++ b/fabushi/ios/Flutter/Release.xcconfig
@@ -7,6 +7,12 @@
 LD_EXPORT_SYMBOLS = YES
 GCC_SYMBOLS_PRIVATE_EXTERN = NO
 
+// Application targets default to the "all" strip style during archive/export,
+// which removes the global C ABI even when the linker emitted it. Preserve
+// external symbols while still stripping local implementation details.
+STRIP_INSTALLED_PRODUCT = YES
+STRIP_STYLE = non-global
+
 // Dart FFI resolves the statically linked Mahayana ABI through
 // DynamicLibrary.process(), so release exports must retain global C symbols.
 OTHER_LDFLAGS = $(inherited) -Wl,-export_dynamic -Wl,-u,_mahayana_runtime_force_link -Wl,-u,_mahayana_runtime_create -Wl,-u,_mahayana_runtime_execute -Wl,-u,_mahayana_runtime_receive -Wl,-u,_mahayana_runtime_interrupt -Wl,-u,_mahayana_runtime_resolve_approval -Wl,-u,_mahayana_runtime_close -Wl,-u,_mahayana_runtime_free_string -Wl,-u,_mahayana_product_execute -Wl,-u,_fabushi_mahayana_product_execute


### PR DESCRIPTION
## Summary
- preserve global Mahayana runtime ABI symbols during signed IPA export stripping
- keep the existing linker retention and export table configuration

## Root cause
The release IPA build completed, but exported Mach-O symbols removed `mahayana_runtime_create` during post-export validation. The previous linker retention was insufficient after archive/export stripping.

## Validation
- Local environment used only for Git metadata and source inspection.
- Full build, IPA export, symbol validation, packaging, and publication must run through GitHub Actions.