### PR TITLE
Load ChatGPT queue tasks from a repository file

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/import-actions-task-inbox.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/import-actions-task-inbox.mjs
@@ -1,11 +1,11 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 
 const statePath = process.env.CHATGPT_AUTO_CONFIRM_QUEUE_STATE;
-const encoded = process.env.CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64?.trim();
+const inboxPath = process.env.CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE?.trim();
 if (!statePath) throw new Error('CHATGPT_AUTO_CONFIRM_QUEUE_STATE is required');
-if (!encoded) process.exit(0);
+if (!inboxPath) throw new Error('CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE is required');
 
-const inbox = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+const inbox = JSON.parse(readFileSync(inboxPath, 'utf8'));
 const incoming = Array.isArray(inbox.tasks) ? inbox.tasks : [];
 const state = JSON.parse(readFileSync(statePath, 'utf8'));
 const tasks = Array.isArray(state.automationTasks) ? state.automationTasks : [];

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "maxConcurrent": 2,
+  "reviewGate": false,
+  "tasks": [
+    {
+      "id": "mahayana-marketplace-parallel-20260726",
+      "title": "并行完善大乘 CLI 云端插件市场",
+      "promptTemplate": "continue-to-complete",
+      "connector": "GitHub",
+      "priority": 50,
+      "timeout": 7200,
+      "maxTaskContinuations": 20,
+      "maxRuntimeRetries": 2,
+      "dependsOn": [],
+      "resourceLocks": [
+        "worktree:mahayana-marketplace",
+        "service:mahayana-marketplace"
+      ],
+      "prompt": "在 fabushi 仓库内继续完成大乘 CLI 云端插件市场，不得拆分为另一个仓库。检查并完善云端市场浏览、插件包下载、SHA-256 与大小校验、安全安装和版本元数据；创建一个可从市场安装的真实插件，并用大乘 CLI 完成发布、浏览、下载、安装和运行的端到端验证。测试账号必须通过 TEST_ACCOUNT_TOKEN 使用现有 TestAccount 无限测试配额逻辑，严禁把令牌写入代码、任务文件或日志。使用隔离 worktree/分支工作，提交 PR 并通过必需 CI 后合并。并行能力必须提供真实证据：在另一个任务仍为 running 时动态加入或启动本任务；同一次 queue_status 观测中至少两个 worker 同时为 running，effectiveMaxConcurrent >= 2，两个 workerTargetId 不同，两个窗口均保持 hidden/visibilityVerified，执行时间区间存在重叠。只有市场端到端测试与上述并行证据都通过，任务才可报告 complete。"
+    }
+  ]
+}

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-inbox.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-inbox.test.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 test('Actions inbox appends a dynamic task once and enables parallel scheduling', () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), 'chatgpt-actions-inbox-'));
   const statePath = path.join(directory, 'state.json');
+  const inboxPath = path.join(directory, 'actions-inbox.json');
   const script = fileURLToPath(
     new URL('../scripts/import-actions-task-inbox.mjs', import.meta.url));
   const inbox = {
@@ -24,11 +25,11 @@ test('Actions inbox appends a dynamic task once and enables parallel scheduling'
   const env = {
     ...process.env,
     CHATGPT_AUTO_CONFIRM_QUEUE_STATE: statePath,
-    CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64:
-      Buffer.from(JSON.stringify(inbox)).toString('base64'),
+    CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE: inboxPath,
   };
   try {
     writeFileSync(statePath, JSON.stringify({ automationTasks: [] }));
+    writeFileSync(inboxPath, JSON.stringify(inbox));
     execFileSync(process.execPath, [script], { env });
     execFileSync(process.execPath, [script], { env });
     const state = JSON.parse(readFileSync(statePath, 'utf8'));

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -31,7 +31,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /parallel_queue_smoke/);
   assert.match(actionsWorkflow, /verify-parallel-actions-queue\.mjs/);
   assert.match(actionsWorkflow, /parallel-queue-evidence\.json/);
-  assert.match(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64/);
+  assert.doesNotMatch(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64/);
+  assert.match(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE/);
+  assert.match(actionsWorkflow, /tasks\/actions-inbox\.json/);
   assert.match(actionsWorkflow, /import-actions-task-inbox\.mjs/);
   assert.doesNotMatch(actionsWorkflow, /pull_request:/);
   assert.doesNotMatch(actionsWorkflow, /push:/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -36,7 +36,6 @@ jobs:
       CHATGPT_CODEX_AUTH_B64: ${{ secrets.CHATGPT_CODEX_AUTH_B64 }}
       CHATGPT_AUTO_CONFIRM_STATE_KEY: ${{ secrets.CHATGPT_AUTO_CONFIRM_STATE_KEY }}
       CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64: ${{ secrets.CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64 }}
-      CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64: ${{ secrets.CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64 }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout trusted runner implementation
@@ -95,6 +94,7 @@ jobs:
       - name: Import dynamic parallel task inbox
         env:
           CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
+          CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE: ${{ github.workspace }}/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/import-actions-task-inbox.mjs
 
       - name: Restore ChatGPT login credentials


### PR DESCRIPTION
## Summary
- replace the secret-backed Actions task inbox with a versioned repository JSON file
- keep task imports idempotent by task id and preserve dynamic queue concurrency settings
- add the Mahayana marketplace task and its strict real-overlap acceptance criteria to the file
- remove all workflow references to `CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64`

## Validation
- `node --test .agents/plugins/plugins/chatgpt-auto-confirm/test/*.test.mjs` (20 passed, 4 platform skips)
- deleted the obsolete `CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64` repository secret