### PR TITLE
fix(release): sign bundled macOS runtimes with hardened timestamp

### DIFF
--- a/.github/scripts/upload-macos-app-store.sh
+++ b/.github/scripts/upload-macos-app-store.sh
@@ -123,7 +123,7 @@ prepare_openclaw_for_macos_app_store() {
       continue
     fi
 
-    options=(--force --sign "$identity")
+    options=(--force --timestamp --options runtime --sign "$identity")
     if [ -x "$file" ]; then
       options+=(--entitlements "$entitlements")
       executable_count=$((executable_count + 1))
@@ -186,9 +186,9 @@ prepare_mahayana_for_macos_app_store() {
     return 1
   fi
 
-  codesign --force --sign "$identity" "$runtime"
+  codesign --force --timestamp --options runtime --sign "$identity" "$runtime"
   codesign --verify --strict --verbose=2 "$runtime"
-  codesign --force --sign "$identity" --entitlements "$entitlements" "$cli"
+  codesign --force --timestamp --options runtime --sign "$identity" --entitlements "$entitlements" "$cli"
   codesign --verify --strict --verbose=2 "$cli"
   {
     echo "cli=$cli"


### PR DESCRIPTION
Fixes the macOS release signing gap found after PR #1678.

Changes:
- sign bundled macOS App Store payload Mach-O files with hardened runtime options
- add secure timestamps to bundled runtime signatures
- sign Mahayana runtime and CLI with hardened runtime options

Validation remains delegated to GitHub Actions.