### PR TITLE
[automerge-force] fix(release): sign bundled plugin runtimes for macOS notarization

### DIFF
--- a/.github/scripts/upload-macos-app-store.sh
+++ b/.github/scripts/upload-macos-app-store.sh
@@ -159,6 +159,52 @@ prepare_openclaw_for_macos_app_store() {
   echo "Prepared OpenClaw App Store payload at $openclaw_assets (signed Mach-O files=$signed_count, executable entitlements=$executable_count)."
 }
 
+
+prepare_official_plugin_runtimes_for_macos_app_store() {
+  local app_path="$1"
+  local plugins_root="$app_path/Contents/Resources/mahayana/share/mahayana/plugins/plugins"
+  local entitlements="$PWD/macos/Runner/OpenClawChild.entitlements"
+  local identity
+  local signed_count=0
+  local signing_report="$status_dir/MACOS_APP_STORE_PLUGIN_RUNTIME_SIGNING.txt"
+
+  if [ ! -d "$plugins_root" ]; then
+    echo "Official plugin runtime directory missing: $plugins_root" >&2
+    return 1
+  fi
+  if [ ! -f "$entitlements" ]; then
+    echo "Missing plugin runtime entitlements: $entitlements" >&2
+    return 1
+  fi
+
+  identity="$(resolve_macos_app_store_signing_identity)"
+  if [ -z "$identity" ]; then
+    echo "Unable to resolve signing identity for official plugin runtimes." >&2
+    return 1
+  fi
+
+  echo "signing_identity=$identity" > "$signing_report"
+  while IFS= read -r -d '' file; do
+    if ! is_macho_file "$file"; then
+      continue
+    fi
+    if [ -x "$file" ]; then
+      codesign --force --timestamp --options runtime --sign "$identity" --entitlements "$entitlements" "$file"
+    else
+      codesign --force --timestamp --options runtime --sign "$identity" "$file"
+    fi
+    codesign --verify --strict --verbose=2 "$file"
+    echo "$file" >> "$signing_report"
+    signed_count=$((signed_count + 1))
+  done < <(find "$plugins_root" -type f \( -name 'fabushi-plugin-cli' -o -name 'fabushi-plugin-cli.exe' -o -name '*.dylib' -o -name '*.node' -o -perm -111 \) -print0)
+
+  if [ "$signed_count" -eq 0 ]; then
+    echo "No official plugin Mach-O runtimes found under $plugins_root." >&2
+    return 1
+  fi
+  echo "signed_macho_files=$signed_count" >> "$signing_report"
+}
+
 prepare_mahayana_for_macos_app_store() {
   local app_path="$1"
   local cli="$app_path/Contents/MacOS/mahayana"
@@ -504,6 +550,7 @@ if [ -x "$fix_bundled_dylibs_script" ]; then
   "$fix_bundled_dylibs_script" "$archived_app_path"
 fi
 prepare_mahayana_for_macos_app_store "$archived_app_path"
+prepare_official_plugin_runtimes_for_macos_app_store "$archived_app_path"
 
 case "$(uname -m)" in
   arm64) openclaw_platform="macos-arm64" ;;

--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -483,6 +483,41 @@ jobs:
             exit 1
           fi
           app_path="build/macos/Build/Products/Release/global_dharma_sharing.app"
+          plugins_root="$app_path/Contents/Resources/mahayana/share/mahayana/plugins/plugins"
+          child_entitlements="$PWD/macos/Runner/OpenClawChild.entitlements"
+          signed_plugin_runtimes=0
+
+          if [ ! -d "$plugins_root" ]; then
+            echo "Bundled official plugin runtime directory is missing: $plugins_root" >&2
+            exit 1
+          fi
+          if [ ! -f "$child_entitlements" ]; then
+            echo "Bundled runtime entitlements are missing: $child_entitlements" >&2
+            exit 1
+          fi
+
+          while IFS= read -r -d '' runtime_file; do
+            if ! file -b "$runtime_file" 2>/dev/null | grep -Eq 'Mach-O'; then
+              continue
+            fi
+
+            signing_args=(--force --timestamp --options runtime --sign "$identity")
+            if [ -x "$runtime_file" ]; then
+              signing_args+=(--entitlements "$child_entitlements")
+            fi
+
+            echo "Signing bundled official plugin runtime: $runtime_file"
+            codesign "${signing_args[@]}" "$runtime_file"
+            codesign --verify --strict --verbose=2 "$runtime_file"
+            signed_plugin_runtimes=$((signed_plugin_runtimes + 1))
+          done < <(find "$plugins_root" -depth -type f -print0)
+
+          if [ "$signed_plugin_runtimes" -eq 0 ]; then
+            echo "No bundled official plugin Mach-O runtimes were found under $plugins_root" >&2
+            exit 1
+          fi
+
+          echo "Signed $signed_plugin_runtimes bundled official plugin Mach-O runtimes."
           codesign --force --deep --timestamp --options runtime --sign "$identity" "$app_path"
           codesign --verify --deep --strict --verbose=2 "$app_path"
 


### PR DESCRIPTION
Fix the macOS notarization failure found after PR #1678/#1684.

Changes:
- sign bundled official Mahayana plugin Mach-O runtimes before App Store export
- enable hardened runtime and secure timestamps for plugin executables
- verify nested plugin signatures before packaging

Validation remains delegated to GitHub Actions.