### PR TITLE
chore(ci): decouple desktop installer builds from plugin changes

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -6,8 +6,6 @@ on:
       - main
     paths:
       - fabushi/**
-      - .agents/plugins/**
-      - scripts/package-official-plugins.sh
       - third_party/mahayana
       - third_party/mahayana/**
       - .github/scripts/package-desktop-*
@@ -25,8 +23,6 @@ on:
       - main
     paths:
       - fabushi/**
-      - .agents/plugins/**
-      - scripts/package-official-plugins.sh
       - third_party/mahayana
       - third_party/mahayana/**
       - .github/scripts/package-desktop-*


### PR DESCRIPTION
As requested, plugins are distributed via the marketplace and do not require rebuilding the full desktop binaries. Removing these paths from the workflow triggers.

Autonomous PR review result: closing without merge because the repository's release guardrail explicitly requires Desktop installers to trigger for `.agents/plugins/**`. CI failed at `check-publish-cd-release.sh` with that exact protection missing, so merging this change would weaken a required release invariant.