### PR TITLE
fix(actions): avoid blank ChatGPT shell on hosted runner

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -35,10 +35,10 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /CHATGPT_CODEX_AUTH_B64/);
   assert.match(actionsWorkflow, /CHATGPT_SESSION_COOKIES_B64/);
   assert.match(actionsWorkflow, /restore-session-cookies\.mjs/);
-  assert.match(actionsWorkflow, /CHATGPT_SESSION_MODE=restore-and-verify/);
-  assert.match(actionsWorkflow, /for attempt in 1 2/);
-  assert.match(actionsWorkflow, /retrying the proven bootstrap in the same app instance/);
-  assert.match(restoreSessionScript, /setTimeout\(\(\) => location\.reload\(\), 0\)/);
+  assert.match(actionsWorkflow, /CHATGPT_SESSION_MODE=seed/);
+  assert.match(actionsWorkflow, /without reloading the controller/);
+  assert.match(actionsWorkflow, /native queue's hidden-Chat probe is the authoritative end-to-end/);
+  assert.match(restoreSessionScript, /mode === 'seed'/);
   assert.match(restoreSessionScript, /process\.exit\(0\)/);
   assert.doesNotMatch(actionsWorkflow, /pkill -x ChatGPT/);
   assert.match(actionsWorkflow, /Launch authenticated desktop shell/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -142,20 +142,16 @@ jobs:
           open -na /Applications/ChatGPT.app --args \
             --user-data-dir="$PROFILE_DIR" \
             --remote-debugging-port="$CHATGPT_CDP_PORT"
-          shell_ready=false
-          for attempt in 1 2; do
-            if CHATGPT_SESSION_MODE=restore-and-verify \
-              node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs; then
-              shell_ready=true
-              break
-            fi
-            echo "::warning::Authenticated Chat shell attempt $attempt failed; retrying the proven bootstrap in the same app instance."
-          done
-          test "$shell_ready" = true
+          # Seed the authenticated partition without reloading the controller.
+          # On fresh hosted macOS runners the visible Electron shell can remain
+          # on its lightweight startup page while the real Chat renderer is
+          # created by the native queue. Reloading that startup page races the
+          # app bootstrap and leaves it permanently blank.
+          CHATGPT_SESSION_MODE=seed \
+            node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
           # The native queue's hidden-Chat probe is the authoritative end-to-end
-          # authentication check. The bundled `codex login status` command can
-          # wait indefinitely on a hosted desktop session after the shell is
-          # already authenticated, so do not block queue startup on it.
+          # authentication check, including a real Chat page. Do not require
+          # the visible controller shell to render before that probe runs.
 
       - name: Verify dynamic parallel task queue
         if: ${{ inputs.parallel_queue_smoke }}


### PR DESCRIPTION
Seeds the saved ChatGPT session without reloading the Electron controller during its startup phase. The native queue remains the authoritative probe for a real hidden Chat surface.