### PR TITLE
fix(queue): unblock dedicated Chat worker launch

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -9,6 +9,10 @@ let sharedConversationQueueWorkerMode = "single-process-hidden-chat-conversation
 let parallelHiddenWindowQueueWorkerMode = "single-process-hidden-chat-windows"
 let parallelDedicatedProcessQueueWorkerMode = "parallel-dedicated-hidden-chat-processes"
 let legacyIsolatedQueueWorkerMode = "isolated-dedicated-process"
+// Electron stays alive after its executable is launched. Keep the launcher
+// objects alive for the lifetime of each dedicated worker; otherwise releasing
+// `Process` can tear down the child before its CDP endpoint is ready.
+var dedicatedQueueChatLaunchers: [Int: Process] = [:]
 
 enum QueueTargetRuntimeState {
   case missing
@@ -701,8 +705,14 @@ func launchDedicatedQueueChatProcess(profilePath: String, port: Int) -> Bool {
     launcher.standardOutput = FileHandle.nullDevice
     launcher.standardError = FileHandle.nullDevice
     try launcher.run()
-    launcher.waitUntilExit()
-    guard launcher.terminationStatus == 0 else { return false }
+    dedicatedQueueChatLaunchers[port] = launcher
+    // Do not wait for Electron to exit: it is the long-lived worker process.
+    // Waiting here blocked the queue scheduler until the smoke action timed out.
+    Thread.sleep(forTimeInterval: 0.25)
+    if !launcher.isRunning && launcher.terminationStatus != 0 {
+      dedicatedQueueChatLaunchers.removeValue(forKey: port)
+      return false
+    }
 
     // Direct Electron launch creates a dedicated instance, but the renderer
     // still reports `document.visibilityState == visible` until it is hidden.
@@ -1367,6 +1377,9 @@ func terminateDedicatedChatProcess(profilePath: String) {
   process.standardError = FileHandle.nullDevice
   try? process.run()
   process.waitUntilExit()
+  dedicatedQueueChatLaunchers = dedicatedQueueChatLaunchers.filter { _, launcher in
+    launcher.isRunning
+  }
   Thread.sleep(forTimeInterval: 0.2)
   try? FileManager.default.removeItem(atPath: profilePath)
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -248,6 +248,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /copyProfileForDedicatedQueueWorker/);
   assert.match(nativeSource, /launchDedicatedQueueChatProcess/);
   assert.match(nativeSource, /Applications\/ChatGPT\.app\/Contents\/MacOS\/ChatGPT/);
+  assert.match(nativeSource, /var dedicatedQueueChatLaunchers: \[Int: Process\] = \[:\]/);
+  assert.match(nativeSource, /dedicatedQueueChatLaunchers\[port\] = launcher/);
+  assert.doesNotMatch(nativeSource, /launcher\.run\(\)\s*launcher\.waitUntilExit\(\)/);
   assert.match(nativeSource, /existingApplicationPids/);
   assert.match(nativeSource, /application\.hide\(\)/);
   assert.match(nativeSource, /application\.isHidden/);


### PR DESCRIPTION
The parallel queue smoke run #147 stalls because the worker waits for its long-lived Electron process to exit. Retain the launcher process, continue to discover and hide the dedicated Chat process, and cover the non-blocking behavior with the existing contract test.