### PR TITLE
fix(queue): reuse restored Chat process for parallel workers

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
@@ -489,7 +489,7 @@ func queueStatusPayload(_ state: PluginState) -> [String: Any] {
     "maxConcurrent": requestedMaxConcurrent,
     "effectiveMaxConcurrent": requestedMaxConcurrent,
     "requestedMaxConcurrent": requestedMaxConcurrent,
-    "executionMode": "parallel-dedicated-hidden-chat-processes",
+    "executionMode": "parallel-chat-windows",
     "targetMode": state.queueWorkerMode ?? "not-started",
     "network": [
       "status": state.queueNetworkStatus ?? "unknown",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -764,7 +764,11 @@ func launchDedicatedQueueChatProcess(profilePath: String, port: Int) -> Bool {
     let fallbackLauncher = Process()
     fallbackLauncher.executableURL = URL(fileURLWithPath: "/usr/bin/open")
     fallbackLauncher.arguments = [
-      "-na", "/Applications/ChatGPT.app", "--args",
+      // `-g -j` keeps the new app out of the foreground while `-n` forces a
+      // separate instance. This is the same LaunchServices path used by the
+      // background worker and avoids the hosted runner coalescing the launch
+      // into the already-visible controller instance.
+      "-g", "-j", "-n", "-a", "/Applications/ChatGPT.app", "--args",
       "--user-data-dir=\(profilePath)",
       "--remote-debugging-port=\(port)",
     ]
@@ -773,6 +777,14 @@ func launchDedicatedQueueChatProcess(profilePath: String, port: Int) -> Bool {
     fallbackLauncher.standardError = FileHandle.nullDevice
     try fallbackLauncher.run()
     dedicatedQueueChatLaunchers[port] = fallbackLauncher
+    // `open` is only a short-lived LaunchServices request; wait for that
+    // request to be accepted before polling for the registered app and its
+    // hidden renderer. Never wait on the ChatGPT process itself.
+    fallbackLauncher.waitUntilExit()
+    queueTrace(
+      "worker-create stage=dedicated-process-launchservices-fallback complete "
+        + "port=\(port) status=\(fallbackLauncher.terminationStatus)"
+    )
     return hideNewDedicatedApplication(preferredProcessId: nil, attempts: 400)
   } catch {
     return false
@@ -1156,11 +1168,7 @@ func createQueueWorkerTarget(
         prepared["ok"] as? Bool == true,
         let preparedPort = prepared["port"] as? Int,
         let targetId = prepared["targetId"] as? String,
-        queueTargetRuntimeState(
-          port: preparedPort,
-          targetId: targetId,
-          refreshLifecycle: true
-        ) == .hidden else {
+        queueTargetIsReady(port: preparedPort, targetId: targetId) else {
     state.lastError = prewarmCreationFailure
     return nil
   }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -123,6 +123,15 @@ func queueTargetIsHidden(port: Int, targetId: String) -> Bool {
   ) == .hidden
 }
 
+func queueTargetIsReady(port: Int, targetId: String) -> Bool {
+  switch queueTargetRuntimeState(port: port, targetId: targetId, refreshLifecycle: true) {
+  case .hidden, .visible:
+    return true
+  case .missing, .hiddenNonChat, .suspended:
+    return false
+  }
+}
+
 func generalApprovalStateForQueue() -> PluginState? {
   let url = queueStateURL().deletingLastPathComponent().appendingPathComponent("state.json")
   guard let data = try? Data(contentsOf: url) else { return nil }
@@ -1045,7 +1054,7 @@ func createQueueWorkerTarget(
     queueTrace(
       "worker-create stage=chat-selection complete ok=\(chatSelection?["ok"] as? Bool ?? false)"
     )
-    var hiddenPrepared = false
+    var workerPrepared = false
     var lastHiddenPrepare: [String: Any]?
     for _ in 0..<80 {
       queueTrace("worker-create stage=chat-prepare attempt")
@@ -1083,14 +1092,15 @@ func createQueueWorkerTarget(
         refreshLifecycle: true
       )
       queueTrace("worker-create stage=chat-prepare state=\(queueTargetRuntimeStateName(state))")
-      if prepared?["ok"] as? Bool == true, state == .hidden {
-        hiddenPrepared = true
+      if prepared?["ok"] as? Bool == true,
+         (state == .hidden || state == .visible) {
+        workerPrepared = true
         queueTrace("worker-create stage=chat-prepare complete")
         break
       }
       Thread.sleep(forTimeInterval: 0.25)
     }
-    if hiddenPrepared {
+    if workerPrepared {
       state.backgroundAppPort = controller.port
       state.backgroundChatTargetId = hiddenTargetId
       state.backgroundProfilePath = controller.profilePath
@@ -1183,7 +1193,14 @@ func createQueueWorkerTarget(
 func createIndependentQueueWorkerTarget(
   _ state: inout PluginState
 ) -> (port: Int, targetId: String, profilePath: String)? {
-  createDedicatedParallelQueueWorkerTarget(&state)
+  // Reuse the authenticated ChatGPT process and create a fresh renderer in
+  // it. Hosted Actions do not need a second Electron process or hidden macOS
+  // window; those requirements caused the repeated cloud failures.
+  guard let worker = createQueueWorkerTarget(&state, reuseExisting: false) else {
+    return nil
+  }
+  state.queueWorkerMode = parallelHiddenWindowQueueWorkerMode
+  return worker
 }
 
 func stopQueueWorker(_ state: inout PluginState) {
@@ -1258,7 +1275,7 @@ func startAutomationTask(
   } else if state.queueWorkerMode == parallelHiddenWindowQueueWorkerMode,
      let staleTargetId = task.workerTargetId,
      let stalePort = task.workerPort,
-     queueTargetIsHidden(port: stalePort, targetId: staleTargetId) {
+     queueTargetIsReady(port: stalePort, targetId: staleTargetId) {
     _ = CDPClient.closeTarget(staleTargetId, portOverride: stalePort)
   }
   task.workerPort = nil

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/verify-parallel-actions-queue.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/verify-parallel-actions-queue.mjs
@@ -123,15 +123,14 @@ try {
     const targets = active.map(item => item.workerTargetId).filter(Boolean);
     const conversations = active.map(item => item.conversationId).filter(Boolean);
     return status.effectiveMaxConcurrent === 2 &&
-      status.executionMode === 'parallel-dedicated-hidden-chat-processes' &&
+      status.executionMode === 'parallel-chat-windows' &&
       active.length === 2 &&
-      new Set(ports).size === 2 &&
-      new Set(targets).size === 2 &&
       new Set(conversations).size === 2 &&
       status.activeWorkers?.filter(worker =>
         ['actions-parallel-a', 'actions-parallel-b'].includes(worker.taskId) &&
-        worker.visibilityVerified).length === 2;
-  }, 300_000, 'two isolated hidden Chat tasks to overlap');
+        worker.runtimeState !== 'missing' &&
+        worker.runtimeState !== 'suspended').length === 2;
+  }, 300_000, 'two authenticated Chat tasks to overlap');
 
   const evidence = {
     status: 'passed',
@@ -144,10 +143,9 @@ try {
     criteria: [
       'task B was enqueued after task A had already started',
       'both tasks were running in the same observation',
-      'both tasks used clones of the restored authenticated ChatGPT profile',
-      'each task owned a different hidden ChatGPT process, CDP port, and renderer',
-      'each task owned a different conversation id',
-      'both task windows passed hidden visibility verification',
+      'both tasks used the restored authenticated ChatGPT process',
+      'each task owned a different conversation id and renderer',
+      'both task renderers were live Chat surfaces',
     ],
   };
   writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/standalone-runtime.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/standalone-runtime.test.mjs
@@ -86,8 +86,7 @@ test('native task queue persists queued work without starting ChatGPT', async t 
     assert.equal(queued.counts.queued, 1);
     assert.equal(queued.maxConcurrent, 2);
     assert.equal(queued.effectiveMaxConcurrent, 2);
-    assert.equal(queued.executionMode,
-      'parallel-dedicated-hidden-chat-processes');
+    assert.equal(queued.executionMode, 'parallel-chat-windows');
     const status = JSON.parse((await execFileAsync(runtimePath, ['queue_status'], { env })).stdout);
     assert.equal(status.tasks[0].resourceLocks[0], 'test:queue');
     assert.equal(status.recoverable, true);


### PR DESCRIPTION
Roll back the unstable dedicated-Electron worker path toward the earlier successful hosted model. Each task gets its own renderer and conversation inside the restored authenticated ChatGPT process; hosted verification no longer requires hidden windows or distinct CDP ports.