### PR TITLE
fix(queue): keep parallel workers in dedicated processes

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1193,14 +1193,9 @@ func createQueueWorkerTarget(
 func createIndependentQueueWorkerTarget(
   _ state: inout PluginState
 ) -> (port: Int, targetId: String, profilePath: String)? {
-  // Reuse the authenticated ChatGPT process and create a fresh renderer in
-  // it. Hosted Actions do not need a second Electron process or hidden macOS
-  // window; those requirements caused the repeated cloud failures.
-  guard let worker = createQueueWorkerTarget(&state, reuseExisting: false) else {
-    return nil
-  }
-  state.queueWorkerMode = parallelHiddenWindowQueueWorkerMode
-  return worker
+  // Parallel smoke verification requires an isolated ChatGPT process, CDP
+  // port, profile, and hidden renderer for every task.
+  return createDedicatedParallelQueueWorkerTarget(&state)
 }
 
 func stopQueueWorker(_ state: inout PluginState) {


### PR DESCRIPTION
PR #1706 made the smoke pass by reusing the restored ChatGPT process, but that violates the required parallel verification contract. Restore the dedicated worker path; each task must use its own hidden Chat process, CDP port, profile, and session.