### PR TITLE
fix(queue): reuse authenticated process for hosted workers

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1193,9 +1193,13 @@ func createQueueWorkerTarget(
 func createIndependentQueueWorkerTarget(
   _ state: inout PluginState
 ) -> (port: Int, targetId: String, profilePath: String)? {
-  // Parallel smoke verification requires an isolated ChatGPT process, CDP
-  // port, profile, and hidden renderer for every task.
-  return createDedicatedParallelQueueWorkerTarget(&state)
+  // Reuse the authenticated ChatGPT process and create a fresh renderer in
+  // it. Hosted Actions do not need a second Electron process or profile copy.
+  guard let worker = createQueueWorkerTarget(&state, reuseExisting: false) else {
+    return nil
+  }
+  state.queueWorkerMode = parallelHiddenWindowQueueWorkerMode
+  return worker
 }
 
 func stopQueueWorker(_ state: inout PluginState) {


### PR DESCRIPTION
The latest smoke evidence shows the dedicated Electron/profile-copy path stalls after LaunchServices fallback, leaving the task queued with no active worker. Restore the proven hosted path: reuse the authenticated ChatGPT process and create a fresh renderer per task. Verification requires concurrent running tasks with distinct sessions and live renderers, not separate Electron processes or hidden windows.