### PR TITLE
fix(queue): create normal renderer without quick chat RPC

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -347,6 +347,19 @@ func openBackgroundQueueWindow(
     timeout: 8.0
   )
   guard reset?["ok"] as? Bool == true else {
+    // Hosted accounts may not expose the Quick Chat RPC. Create a normal
+    // authenticated renderer through CDP and let the caller prepare Chat.
+    if reset?["error"] as? String == "quick_chat_service_not_found",
+       let targetId = CDPClient.createBackgroundTarget(
+         url: "app://-/index.html?initialRoute=%2F",
+         browserContextId: nil,
+         portOverride: port
+       ) {
+      queueTrace(
+        "worker-create stage=prewarm-fallback-normal-target target=\(targetId)"
+      )
+      return targetId
+    }
     failure = "prewarm_reset_failed:\(reset?["error"] as? String ?? "no_result")"
     return nil
   }


### PR DESCRIPTION
Run #30479368297 reached the native queue after cookie seed fallback, but watcherTrace shows `prewarm_reset_failed:quick_chat_service_not_found` and no active workers. Some hosted accounts do not expose Quick Chat RPC; create a normal authenticated renderer via CDP and let the existing Chat preparation path continue.