### PR TITLE
fix(queue): preserve browser context for fallback renderer

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -350,9 +350,13 @@ func openBackgroundQueueWindow(
     // Hosted accounts may not expose the Quick Chat RPC. Create a normal
     // authenticated renderer through CDP and let the caller prepare Chat.
     if reset?["error"] as? String == "quick_chat_service_not_found",
+       let controllerContextId = CDPClient.targetInfo(
+         targetId: controllerTargetId,
+         portOverride: port
+       )?["browserContextId"] as? String,
        let targetId = CDPClient.createBackgroundTarget(
          url: "app://-/index.html?initialRoute=%2F",
-         browserContextId: nil,
+         browserContextId: controllerContextId,
          portOverride: port
        ) {
       queueTrace(


### PR DESCRIPTION
The Quick Chat RPC is unavailable on hosted accounts, so the queue creates a normal renderer fallback. The fallback was created without the controller's browser context, leaving it suspended/blank and preventing Chat preparation. Reuse the controller context so the renderer inherits the authenticated app partition.