### PR TITLE
fix(queue): compile active renderer target creation

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
@@ -345,10 +345,11 @@ struct CDPClient {
       let contextJSON = contextId.map {
         ",\"browserContextId\":\(jsonStringLiteral($0))"
       } ?? ""
+      let backgroundJSON = background ? "true" : "false"
       guard let response = sendCommand(
             wsURLString: browserWS,
             method: "Target.createTarget",
-            paramsJSON: "{\"url\":\(jsonStringLiteral(url)),\"background\":\(background ? \"true\" : \"false\")\(contextJSON)}",
+            paramsJSON: "{\"url\":\(jsonStringLiteral(url)),\"background\":\(backgroundJSON)\(contextJSON)}",
             timeout: 4.0
           ),
             let result = response["result"] as? [String: Any] else { return nil }


### PR DESCRIPTION
The hosted smoke run reached native runtime build and exposed a Swift parser error in the new Target.createTarget JSON construction. Hoist the boolean string out of nested interpolation; behavior is unchanged. This is the minimal build fix.