### PR TITLE
fix(queue): load hosted workers from authenticated web chat

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
@@ -345,11 +345,16 @@ struct CDPClient {
       let contextJSON = contextId.map {
         ",\"browserContextId\":\(jsonStringLiteral($0))"
       } ?? ""
-      let backgroundJSON = background ? "true" : "false"
+      let paramsJSON: String
+      if background {
+        paramsJSON = "{\"url\":\(jsonStringLiteral(url)),\"background\":true\(contextJSON)}"
+      } else {
+        paramsJSON = "{\"url\":\(jsonStringLiteral(url)),\"background\":false\(contextJSON)}"
+      }
       guard let response = sendCommand(
             wsURLString: browserWS,
             method: "Target.createTarget",
-            paramsJSON: "{\"url\":\(jsonStringLiteral(url)),\"background\":\(backgroundJSON)\(contextJSON)}",
+            paramsJSON: paramsJSON,
             timeout: 4.0
           ),
             let result = response["result"] as? [String: Any] else { return nil }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -344,12 +344,12 @@ func openBackgroundQueueWindow(
   // normal active renderer in the authenticated browser context so Electron
   // does not suspend the page or leave it on the sign-in prewarm shell.
   if ProcessInfo.processInfo.environment["CHATGPT_AUTO_CONFIRM_HOSTED"] == "true",
-     let controllerContextId = CDPClient.targetInfo(
+    let controllerContextId = CDPClient.targetInfo(
        targetId: controllerTargetId,
        portOverride: port
      )?["browserContextId"] as? String,
      let targetId = CDPClient.createTarget(
-       url: "app://-/index.html?initialRoute=%2F",
+       url: "https://chatgpt.com/",
        browserContextId: controllerContextId,
        background: false,
        portOverride: port
@@ -374,7 +374,7 @@ func openBackgroundQueueWindow(
          portOverride: port
        )?["browserContextId"] as? String,
        let targetId = CDPClient.createTarget(
-         url: "app://-/index.html?initialRoute=%2F",
+         url: "https://chatgpt.com/",
          browserContextId: controllerContextId,
          background: false,
          portOverride: port


### PR DESCRIPTION
The hosted active-renderer path was creating app:// targets that remained on the desktop sign-in shell, so queue preparation found no Chat surface. Open the same browser context at https://chatgpt.com/ instead so shared session cookies can mount the real Chat renderer.