### PR TITLE
fix(chat): exclude new project from model picker

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -353,7 +353,7 @@ func sendMessageJS(
       ].filter(Boolean).join(' ')).toLowerCase();
       const isProjectPicker = button => {
         const label = controlLabel(button);
-        return /(?:choose|select)\\s+project|project\\s+(?:source|folder)|source\\s+folders|add\\s+folders|选择项目|项目文件夹|源文件夹|添加文件夹/i.test(label);
+        return /(?:choose|select|new)\\s+project|project\\s+(?:source|folder)|source\\s+folders|add\\s+folders|选择项目|项目文件夹|源文件夹|添加文件夹|新建项目|创建项目/i.test(label);
       };
       const isModelPickerLabel = button => {
         if (isProjectPicker(button)) return false;

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -357,6 +357,22 @@ func openBackgroundQueueWindow(
     queueTrace(
       "worker-create stage=hosted-active-renderer target=\(targetId)"
     )
+    // A newly created visible web renderer can expose its document before
+    // ChatGPT has mounted the composer. Let the page finish loading before
+    // the caller performs mode selection and surface detection.
+    for _ in 0..<240 {
+      let loaded = cdpValue(
+        port: port,
+        targetId: targetId,
+        expression: "(() => ({ready: document.readyState, input: !!document.querySelector('#prompt-textarea, [contenteditable=\\\"true\\\"]'), bodyLength: (document.body?.innerText || '').length}))()",
+        timeout: 3.0
+      )
+      let ready = loaded?["ready"] as? String
+      let hasInput = (loaded?["input"] as? NSNumber)?.boolValue == true
+      let bodyLength = (loaded?["bodyLength"] as? NSNumber)?.intValue ?? 0
+      if ready == "complete" && (hasInput || bodyLength > 50) { break }
+      Thread.sleep(forTimeInterval: 0.25)
+    }
     return targetId
   }
   let reset = cdpValue(


### PR DESCRIPTION
Hosted Chat now loads successfully, but the model selector heuristic picked the New project button because its label matched generic model controls. Treat New project and localized equivalents as project pickers so GPT-5.6 Sol / High selection can proceed.