### PR TITLE
fix(chat): avoid workspace control as model picker

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -536,6 +536,26 @@ func sendMessageJS(
         picker.getAttribute('aria-label'),
         picker.getAttribute('title')
       ].filter(Boolean).join(' '));
+      // The web Chat shell exposes a workspace/profile trigger beside the
+      // composer. Its label can contain words such as "business" and was
+      // occasionally selected as the model picker by generic fallbacks.
+      // Prefer the explicit High/model control when that happens.
+      if (/workspace|profile|account|business/i.test(pickerBefore)) {
+        const explicitModel = [...document.querySelectorAll(
+          'button, [role="button"], [role="tab"]'
+        )].find(candidate => {
+          if (!visible(candidate)) return false;
+          const label = normalize([
+            candidate.textContent,
+            candidate.getAttribute('aria-label'),
+            candidate.getAttribute('title')
+          ].filter(Boolean).join(' ')).toLowerCase();
+          return label === 'high'
+            || label === '高'
+            || label.includes(desiredModel.toLowerCase());
+        });
+        if (explicitModel) picker = explicitModel;
+      }
       let selectedLabel = normalize(picker.textContent).toLowerCase();
       // Desktop Quick Chat is the authenticated orchestration surface. It
       // exposes ChatGPT choices such as Instant/Thinking, not the Codex


### PR DESCRIPTION
The hosted parallel smoke reached a live authenticated Chat surface but model selection picked the workspaceBusiness/profile trigger. Explicitly reject workspace/profile/account/business labels and prefer the High or GPT-5.6 Sol control.