### PR TITLE
fix(chat): scope connector selection to apps menu

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -958,9 +958,16 @@ func sendMessageJS(
       let found = evidence.length > 0;
 
       if (!found) {
-        const visibleAppItem = () => [...document.querySelectorAll(
-          'button[data-list-navigation-item="true"], [role="menuitemradio"], [role="option"], button'
-        )].find(el => visible(el) && textMatches(el));
+        const visibleAppItem = () => {
+          const menuRoots = [...document.querySelectorAll(
+            '[role="menu"], [role="listbox"], [data-composer-overlay-floating-ui], '
+              + '[data-radix-menu-content], [data-radix-popper-content-wrapper]'
+          )].filter(visible);
+          const scopes = menuRoots.length ? menuRoots : [document];
+          return scopes.flatMap(root => [...root.querySelectorAll(
+            'button[data-list-navigation-item="true"], [role="menuitemradio"], [role="option"], button'
+          )]).find(el => visible(el) && textMatches(el));
+        };
         const addButton = document.querySelector('button[aria-label="添加文件等"]')
           || document.querySelector('button[aria-label="添加文件等内容"]')
           || document.querySelector('button[aria-label="附加文件或连接应用"]')

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -536,6 +536,26 @@ func sendMessageJS(
         picker.getAttribute('aria-label'),
         picker.getAttribute('title')
       ].filter(Boolean).join(' '));
+      // The web Chat shell exposes a workspace/profile trigger beside the
+      // composer. Its label can contain words such as "business" and was
+      // occasionally selected as the model picker by generic fallbacks.
+      // Prefer the explicit High/model control when that happens.
+      if (/workspace|profile|account|business/i.test(pickerBefore)) {
+        const explicitModel = [...document.querySelectorAll(
+          'button, [role="button"], [role="tab"]'
+        )].find(candidate => {
+          if (!visible(candidate)) return false;
+          const label = normalize([
+            candidate.textContent,
+            candidate.getAttribute('aria-label'),
+            candidate.getAttribute('title')
+          ].filter(Boolean).join(' ')).toLowerCase();
+          return label === 'high'
+            || label === '高'
+            || label.includes(desiredModel.toLowerCase());
+        });
+        if (explicitModel) picker = explicitModel;
+      }
       let selectedLabel = normalize(picker.textContent).toLowerCase();
       // Desktop Quick Chat is the authenticated orchestration surface. It
       // exposes ChatGPT choices such as Instant/Thinking, not the Codex


### PR DESCRIPTION
The connector selector was treating a sidebar GitHub history button as an already-open Apps item, so no connector chip was added. Restrict app-item discovery to visible Apps/menu overlays before clicking and confirming GitHub.