### PR TITLE
fix(chat): detect connector chip in composer overlay

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -958,9 +958,16 @@ func sendMessageJS(
       let found = evidence.length > 0;
 
       if (!found) {
-        const visibleAppItem = () => [...document.querySelectorAll(
-          'button[data-list-navigation-item="true"], [role="menuitemradio"], [role="option"], button'
-        )].find(el => visible(el) && textMatches(el));
+        const visibleAppItem = () => {
+          const menuRoots = [...document.querySelectorAll(
+            '[role="menu"], [role="listbox"], [data-composer-overlay-floating-ui], '
+              + '[data-radix-menu-content], [data-radix-popper-content-wrapper]'
+          )].filter(visible);
+          const scopes = menuRoots.length ? menuRoots : [document];
+          return scopes.flatMap(root => [...root.querySelectorAll(
+            'button[data-list-navigation-item="true"], [role="menuitemradio"], [role="option"], button'
+          )]).find(el => visible(el) && textMatches(el));
+        };
         const addButton = document.querySelector('button[aria-label="添加文件等"]')
           || document.querySelector('button[aria-label="添加文件等内容"]')
           || document.querySelector('button[aria-label="附加文件或连接应用"]')

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -792,7 +792,7 @@ func sendMessageJS(
         'button, [role="button"], [role="option"], [data-state], span, div'
       )].filter(element => {
         if (!visible(element) || !connectorMatches(element.textContent, target)) return false;
-        if (element.closest('[data-composer-overlay-floating-ui]')) return false;
+        if (element.closest('[role="menu"], [role="listbox"], [role="option"]')) return false;
         const rect = element.getBoundingClientRect();
         const overlapsPromptHorizontally = rect.right >= promptRect.left
           && rect.left <= promptRect.right;

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -536,6 +536,26 @@ func sendMessageJS(
         picker.getAttribute('aria-label'),
         picker.getAttribute('title')
       ].filter(Boolean).join(' '));
+      // The web Chat shell exposes a workspace/profile trigger beside the
+      // composer. Its label can contain words such as "business" and was
+      // occasionally selected as the model picker by generic fallbacks.
+      // Prefer the explicit High/model control when that happens.
+      if (/workspace|profile|account|business/i.test(pickerBefore)) {
+        const explicitModel = [...document.querySelectorAll(
+          'button, [role="button"], [role="tab"]'
+        )].find(candidate => {
+          if (!visible(candidate)) return false;
+          const label = normalize([
+            candidate.textContent,
+            candidate.getAttribute('aria-label'),
+            candidate.getAttribute('title')
+          ].filter(Boolean).join(' ')).toLowerCase();
+          return label === 'high'
+            || label === '高'
+            || label.includes(desiredModel.toLowerCase());
+        });
+        if (explicitModel) picker = explicitModel;
+      }
       let selectedLabel = normalize(picker.textContent).toLowerCase();
       // Desktop Quick Chat is the authenticated orchestration surface. It
       // exposes ChatGPT choices such as Instant/Thinking, not the Codex

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -800,7 +800,30 @@ func sendMessageJS(
           && rect.bottom <= promptRect.bottom + 24;
         return overlapsPromptHorizontally && isInComposerBand;
       }) : [];
-      return [...composerMatches, ...checkedMenuMatches, ...inlineMentionMatches, ...nearbyExactMatches];
+      // In the current web Chat surface the selected app can be rendered as a
+      // standalone chip/button outside the composer form (and outside the
+      // menu), with only its app label exposed.  Treat that stable selected
+      // control as evidence too; do not count menu options that are merely
+      // available for selection.
+      const standaloneSelectedMatches = [...document.querySelectorAll(
+        '[data-connector-id], [data-app-name], button[aria-label], [role="button"]'
+      )].filter(element => {
+        if (!visible(element) || !connectorMatches([
+          element.getAttribute('aria-label'), element.getAttribute('title'),
+          element.getAttribute('data-testid'), element.getAttribute('data-connector-id'),
+          element.getAttribute('data-app-name'), element.textContent
+        ].filter(Boolean).join(' '), target)) return false;
+        if (element.closest('[role="menu"], [role="listbox"], [role="option"]')) return false;
+        return element.closest('form')
+          || element.getAttribute('aria-pressed') === 'true'
+          || element.getAttribute('aria-checked') === 'true'
+          || element.getAttribute('data-state') === 'checked'
+          || element.getAttribute('data-state') === 'on'
+          || element.getAttribute('data-selected') === 'true'
+          || element.getAttribute('data-active') === 'true';
+      });
+      return [...composerMatches, ...checkedMenuMatches, ...inlineMentionMatches,
+        ...nearbyExactMatches, ...standaloneSelectedMatches];
     }
 
     function chatModeIsActive() {


### PR DESCRIPTION
The GitHub app is selected successfully, but its chip can live inside the composer overlay without connector attributes. Keep overlay chip evidence while still ignoring real menu/listbox options.