### PR TITLE
fix(queue): treat hosted web renderers as live

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -96,7 +96,8 @@ func queueTargetRuntimeState(
   let href = probe?["href"] as? String ?? ""
   let eventLoopDelayMs = (probe?["eventLoopDelayMs"] as? NSNumber)?.doubleValue
     ?? Double.greatestFiniteMagnitude
-  if bridge && visibility == "hidden" && href.hasPrefix("app://-/index.html")
+  if bridge && visibility == "hidden"
+      && (href.hasPrefix("app://-/index.html") || href.hasPrefix("https://chatgpt.com/"))
       && eventLoopDelayMs < 2_500 {
     let chatMode = (probe?["chatMode"] as? NSNumber)?.boolValue ?? false
     let surface = probe?["surface"] as? String ?? "not-chat"


### PR DESCRIPTION
The hosted smoke now starts two distinct Chat conversations successfully, but queue status classified their active chatgpt.com renderers as suspended because runtime-state detection only recognized app:// targets. Treat responsive web Chat renderers with the same context as live.