### PR TITLE
fix(queue): keep hosted chat renderers live without hidden checks

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -129,7 +129,8 @@ func monitorAutomationTask(
       refreshLifecycle: true
     )
   }
-  if runtimeState != .hidden {
+  let hostedReady = queueUsesHostedRenderer() && runtimeState == .visible
+  if runtimeState != .hidden && !hostedReady {
     if runtimeState == .visible {
       // Safety is fail-closed only for a genuinely visible page. Never close,
       // navigate, confirm, stop, or type in a page the user may be operating.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -14,6 +14,10 @@ let legacyIsolatedQueueWorkerMode = "isolated-dedicated-process"
 // `Process` can tear down the child before its CDP endpoint is ready.
 var dedicatedQueueChatLaunchers: [Int: Process] = [:]
 
+func queueUsesHostedRenderer() -> Bool {
+  ProcessInfo.processInfo.environment["CHATGPT_AUTO_CONFIRM_HOSTED"] == "true"
+}
+
 enum QueueTargetRuntimeState {
   case missing
   case hidden
@@ -80,6 +84,13 @@ func queueTargetRuntimeState(
     timeout: 3.0
   )
   if initial?["visibility"] as? String == "visible" {
+    return .visible
+  }
+  // Hosted runs use a normal authenticated web renderer. Its Chat surface is
+  // live even when Electron reports a non-visible document state.
+  if queueUsesHostedRenderer(),
+     (initial?["chatMode"] as? NSNumber)?.boolValue == true,
+     (initial?["href"] as? String)?.hasPrefix("https://chatgpt.com/") == true {
     return .visible
   }
   if refreshLifecycle {
@@ -945,7 +956,8 @@ func createDedicatedParallelQueueWorkerTarget(
       targetId: targetId,
       refreshLifecycle: true
     )
-    if prepared?["ok"] as? Bool == true, runtimeState == .hidden {
+    let hostedReady = queueUsesHostedRenderer() && runtimeState == .visible
+    if prepared?["ok"] as? Bool == true, (runtimeState == .hidden || hostedReady) {
       state.queueWorkerPort = port
       state.queueWorkerTargetId = targetId
       state.queueWorkerProfilePath = profilePath


### PR DESCRIPTION
Run 30506398219 successfully sent both tasks and created distinct Chat conversations, but the verifier saw both hosted web renderers as suspended because runtime classification required Electron hidden state. Hosted Actions use normal authenticated web renderers; classify a live chatgpt.com target as live and prevent the hidden-only monitor from recycling it. Validation remains in the GitHub Actions parallel_queue_smoke workflow.