### PR TITLE
fix: expose live Chat queue diagnostics

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -18,6 +18,7 @@ func queueContinuation(
   report: AutomationTaskReport?,
   reason: String
 ) {
+  writeQueueConversationDiagnostic(task, finalReason: reason)
   let now = isoFormatter.string(from: Date())
   let depth = task.continuationDepth ?? 0
   if task.maxTaskContinuations > 0 && depth >= task.maxTaskContinuations {
@@ -414,6 +415,7 @@ func monitorAutomationTask(
     "chatUrl": task.chatURL as Any,
     "reviewConversationId": task.reviewConversationId as Any,
   ])
+  writeQueueConversationDiagnostic(task)
 
   // A sent Chat that never creates any assistant or tool activity is not a
   // long-running build. It is a failed renderer/send state. Recover quickly
@@ -465,6 +467,7 @@ func monitorAutomationTask(
         + "actions=\(actionEvidence) "
         + "report=\(parsedReport?.status ?? "none")"
     )
+    writeQueueConversationDiagnostic(task, finalReason: "terminal_observed")
   }
   if terminal, let report = parsedReport {
     if let requestedConnector = normalizedConnector(report.nextConnector) {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
@@ -22,6 +22,99 @@ func queueTraceURL() -> URL {
   queueDirectoryURL().appendingPathComponent("watcher-trace.log")
 }
 
+let retainedConversationDiagnosticCount = 5
+
+func queueConversationDiagnosticsDirectoryURL() -> URL {
+  queueStateURL().deletingLastPathComponent()
+    .appendingPathComponent("diagnostics", isDirectory: true)
+}
+
+func queueConversationDiagnosticBaseName(_ task: AutomationTask) -> String {
+  let reviewing = task.reviewStatus == "running"
+  let rawConversation = reviewing ? task.reviewConversationId : task.conversationId
+  let conversation = (rawConversation ?? "conversation-pending")
+    .replacingOccurrences(
+      of: "[^A-Za-z0-9_-]+",
+      with: "-",
+      options: .regularExpression
+    )
+  let kind = reviewing ? "review" : "work"
+  return "\(task.id)-attempt-\(task.attempts)-review-\(task.reviewRound)-\(kind)-\(conversation.prefix(80))"
+}
+
+func writeQueueConversationDiagnostic(
+  _ task: AutomationTask,
+  finalReason: String? = nil
+) {
+  guard let rawResult = task.lastResultJSON,
+        let resultData = rawResult.data(using: .utf8),
+        let result = try? JSONSerialization.jsonObject(with: resultData) else { return }
+  let directory = queueConversationDiagnosticsDirectoryURL()
+  try? FileManager.default.createDirectory(
+    at: directory,
+    withIntermediateDirectories: true
+  )
+  let baseName = queueConversationDiagnosticBaseName(task)
+  let liveURL = directory.appendingPathComponent("\(baseName).live.json")
+  let finalURL = directory.appendingPathComponent("\(baseName).final.json")
+  let payload: [String: Any] = [
+    "recordedAt": isoFormatter.string(from: Date()),
+    "taskId": task.id,
+    "attempts": task.attempts,
+    "reviewRound": task.reviewRound,
+    "conversationId": task.conversationId ?? NSNull(),
+    "reviewConversationId": task.reviewConversationId ?? NSNull(),
+    "status": finalReason == nil ? "live" : "final",
+    "finalReason": finalReason ?? NSNull(),
+    "result": result,
+  ]
+  guard let data = try? JSONSerialization.data(
+    withJSONObject: payload,
+    options: [.prettyPrinted, .sortedKeys]
+  ) else { return }
+  let targetURL = finalReason == nil ? liveURL : finalURL
+  do {
+    try data.write(to: targetURL, options: .atomic)
+    try? FileManager.default.setAttributes(
+      [.posixPermissions: 0o600],
+      ofItemAtPath: targetURL.path
+    )
+    if finalReason != nil {
+      try? FileManager.default.removeItem(at: liveURL)
+      pruneQueueConversationDiagnostics(taskId: task.id)
+    }
+  } catch {
+    queueTrace(
+      "task=\(task.id) stage=diagnostic-write-failed error=\(error.localizedDescription)"
+    )
+  }
+}
+
+func pruneQueueConversationDiagnostics(taskId: String) {
+  let directory = queueConversationDiagnosticsDirectoryURL()
+  guard let urls = try? FileManager.default.contentsOfDirectory(
+    at: directory,
+    includingPropertiesForKeys: [.contentModificationDateKey],
+    options: [.skipsHiddenFiles]
+  ) else { return }
+  let prefix = "\(taskId)-"
+  let finalized = urls.filter {
+    $0.lastPathComponent.hasPrefix(prefix)
+      && $0.lastPathComponent.hasSuffix(".final.json")
+  }.sorted {
+    let lhs = (try? $0.resourceValues(
+      forKeys: [.contentModificationDateKey]
+    ).contentModificationDate) ?? .distantPast
+    let rhs = (try? $1.resourceValues(
+      forKeys: [.contentModificationDateKey]
+    ).contentModificationDate) ?? .distantPast
+    return lhs > rhs
+  }
+  for staleURL in finalized.dropFirst(retainedConversationDiagnosticCount) {
+    try? FileManager.default.removeItem(at: staleURL)
+  }
+}
+
 func queueTrace(_ message: String) {
   let url = queueTraceURL()
   try? FileManager.default.createDirectory(
@@ -433,6 +526,47 @@ func taskPublicPayload(_ task: AutomationTask, includeResult: Bool = false) -> [
      let reportData = try? encoder.encode(report),
      let reportObject = try? JSONSerialization.jsonObject(with: reportData) {
     payload["reviewReport"] = reportObject
+  }
+  if let raw = task.lastResultJSON,
+     let data = raw.data(using: .utf8),
+     let result = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+    let reply = (result["reply"] as? [String: Any])
+      ?? (result["reviewReply"] as? [String: Any])
+    if let reply {
+      payload["replyDiagnostics"] = [
+        "kind": result["reviewReply"] == nil ? "reply" : "reviewReply",
+        "hasCurrentDispatchMarker": result["hasCurrentDispatchMarker"] ?? NSNull(),
+        "done": reply["done"] ?? NSNull(),
+        "pending": reply["pending"] ?? NSNull(),
+        "streaming": reply["streaming"] ?? NSNull(),
+        "waitingForApproval": reply["waitingForApproval"] ?? NSNull(),
+        "approvalTitle": reply["approvalTitle"] ?? NSNull(),
+        "stopAvailable": reply["stopAvailable"] ?? NSNull(),
+        "completionCandidate": reply["completionCandidate"] ?? NSNull(),
+        "terminalIncomplete": reply["terminalIncomplete"] ?? NSNull(),
+        "hasClosedTaskReport": reply["hasClosedTaskReport"] ?? NSNull(),
+        "structuredComplete": reply["structuredComplete"] ?? NSNull(),
+        "structuredIncomplete": reply["structuredIncomplete"] ?? NSNull(),
+        "explicitlyIncomplete": reply["explicitlyIncomplete"] ?? NSNull(),
+        "explicitFinalResult": reply["explicitFinalResult"] ?? NSNull(),
+        "responseActions": reply["responseActions"] ?? NSNull(),
+        "responseActionsComplete": reply["responseActionsComplete"] ?? NSNull(),
+        "responseControlLabels": reply["responseControlLabels"] ?? NSNull(),
+        "messageCount": reply["messageCount"] ?? NSNull(),
+        "userMessageCount": reply["userMessageCount"] ?? NSNull(),
+        "charCount": reply["charCount"] ?? NSNull(),
+        "activityCharCount": reply["activityCharCount"] ?? NSNull(),
+        "completedThinkingTitle": reply["completedThinkingTitle"] ?? NSNull(),
+        "pageSnapshot": [
+          "pageContent": reply["pageContent"] ?? NSNull(),
+          "userContent": reply["userContent"] ?? NSNull(),
+          "assistantContent": reply["content"] ?? NSNull(),
+          "thinking": reply["thinking"] ?? NSNull(),
+          "completedActivity": reply["completedActivity"] ?? NSNull(),
+          "devspaceActivity": reply["devspaceActivity"] ?? NSNull(),
+        ],
+      ]
+    }
   }
   if includeResult, let raw = task.lastResultJSON,
      let data = raw.data(using: .utf8),

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
@@ -42,6 +42,12 @@ const run = (command, params = undefined) => {
   return payload;
 };
 
+const recognitionDiagnostics = task => {
+  if (!task.replyDiagnostics) return null;
+  const { pageSnapshot: _pageSnapshot, ...recognition } = task.replyDiagnostics;
+  return recognition;
+};
+
 const taskDiagnostics = (queue) => (Array.isArray(queue?.tasks) ? queue.tasks : [])
   .map(task => ({
     id: task.id,
@@ -53,6 +59,15 @@ const taskDiagnostics = (queue) => (Array.isArray(queue?.tasks) ? queue.tasks : 
     lastError: task.lastError || null,
     hiddenWorkerLastError: task.hiddenWorkerLastError || null,
     lastProgressAt: task.lastProgressAt || null,
+    replyDiagnostics: recognitionDiagnostics(task),
+  }));
+
+const pageDiagnostics = queue => (Array.isArray(queue?.tasks) ? queue.tasks : [])
+  .filter(task => task.replyDiagnostics?.pageSnapshot)
+  .map(task => ({
+    id: task.id,
+    conversationId: task.conversationId || null,
+    page: task.replyDiagnostics.pageSnapshot,
   }));
 
 const writeResult = (status, queue, reason) => {
@@ -97,6 +112,8 @@ const initialRecovery = run('queue_watchdog', { staleAfterSeconds: 300, force: t
 process.stdout.write(`WATCHDOG_INITIAL ${JSON.stringify(watchdogDiagnostics(initialRecovery))}\n`);
 let lastRecovery = 0;
 let lastQueueFingerprint = '';
+let lastPageFingerprint = '';
+let lastTraceFingerprint = '';
 let lastFailureFingerprint = '';
 let sameFailureRecoveries = 0;
 while (Date.now() < deadline) {
@@ -104,8 +121,19 @@ while (Date.now() < deadline) {
   const tasks = Array.isArray(queue.tasks) ? queue.tasks : [];
   const fingerprint = queueFingerprint(queue);
   if (fingerprint !== lastQueueFingerprint) {
-    process.stdout.write(`QUEUE_STATUS ${fingerprint}\n`);
+    process.stdout.write(`QUEUE_RECOGNITION ${fingerprint}\n`);
     lastQueueFingerprint = fingerprint;
+  }
+  const pageFingerprint = JSON.stringify(pageDiagnostics(queue));
+  if (pageFingerprint !== lastPageFingerprint) {
+    process.stdout.write(`QUEUE_PAGE ${pageFingerprint}\n`);
+    lastPageFingerprint = pageFingerprint;
+  }
+  const trace = Array.isArray(queue.watcherTrace) ? queue.watcherTrace : [];
+  const traceFingerprint = JSON.stringify(trace);
+  if (traceFingerprint !== lastTraceFingerprint) {
+    process.stdout.write(`QUEUE_TRACE ${traceFingerprint}\n`);
+    lastTraceFingerprint = traceFingerprint;
   }
   if (tasks.length === 0) {
     writeResult('failed', queue, 'no_tasks_configured');

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
@@ -34,7 +34,17 @@ if (command === 'queue_watchdog') {
       attempts: 3,
       lastError: 'new_chat_prepare_failed',
       hiddenWorkerLastError: 'queue_monitor_hidden_target_rebuild_failed:missing',
+      replyDiagnostics: {
+        done: false,
+        responseActionsComplete: false,
+        responseControlLabels: ['复制', '在新任务中继续'],
+        pageSnapshot: {
+          pageContent: '最终结果\\n复制\\n在新任务中继续',
+          assistantContent: '最终结果',
+        },
+      },
     }],
+    watcherTrace: ['[2026-07-30T08:00:00Z] task=broken-task stage=monitor'],
   }));
 } else {
   console.log(JSON.stringify({ ok: false, message: 'unexpected command' }));
@@ -65,6 +75,11 @@ if (command === 'queue_watchdog') {
     assert.deepEqual(report.counts, { failed: 1 });
     assert.equal(report.tasks[0].id, 'broken-task');
     assert.equal(report.tasks[0].lastError, 'new_chat_prepare_failed');
+    assert.equal(report.tasks[0].replyDiagnostics.done, false);
+    assert.match(result.stdout, /QUEUE_TRACE/);
+    assert.match(result.stdout, /responseControlLabels/);
+    assert.match(result.stdout, /QUEUE_PAGE/);
+    assert.match(result.stdout, /最终结果/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -137,6 +137,12 @@ test('send_and_watch streams visible thinking and uses bounded same-task recover
   assert.match(nativeSource, /responseActions\.branch/);
   assert.match(nativeSource, /responseActions\.like/);
   assert.match(nativeSource, /responseActions\.dislike/);
+  assert.match(nativeSource, /retainedConversationDiagnosticCount = 5/);
+  assert.match(nativeSource, /\.live\.json/);
+  assert.match(nativeSource, /\.final\.json/);
+  assert.match(nativeSource, /writeQueueConversationDiagnostic\(task\)/);
+  assert.match(nativeSource, /finalReason: "terminal_observed"/);
+  assert.match(nativeSource, /pruneQueueConversationDiagnostics/);
   assert.match(nativeSource, /data-content-search-unit-key\$=":assistant"/);
   assert.match(nativeSource, /data-content-search-unit-key\$=":user"/);
   assert.match(nativeSource, /const appUserBubbles =/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -85,6 +85,10 @@ jobs:
               -pass env:CHATGPT_AUTO_CONFIRM_STATE_KEY \
               -in "$RUNNER_TEMP/previous-state/queue-state.enc" \
               -out "$STATE_PATH"
+            if [[ -d "$RUNNER_TEMP/previous-state/diagnostics" ]]; then
+              ditto "$RUNNER_TEMP/previous-state/diagnostics" \
+                "$(dirname "$STATE_PATH")/diagnostics"
+            fi
           else
             test -n "$CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64"
             printf '%s' "$CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64" |


### PR DESCRIPTION
## Summary
- stream redacted Chat page snapshots and every completion-recognition field into Actions logs
- persist live per-conversation diagnostics, finalize them at conversation end, and retain the latest five per task
- restore and upload diagnostic files across continuous runner sessions

## Validation
- GitHub Actions only, per repository runner policy