### PR TITLE
fix: recognize ChatGPT overflow continuation controls

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -1223,6 +1223,8 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
   (async () => {
     const expectedConversationId = \(expected);
     const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const visible = element => !!(element
+      && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
     const normalizeConversationId = value => {
       const raw = (value || '').trim();
       if (!raw) return '';
@@ -1263,19 +1265,48 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
       node.getAttribute?.('title') || '',
       node.textContent || ''
     ].join(' ').replace(/\\s+/g, ' ').trim().toLowerCase();
-    const button = controls.find(node => {
+    const isContinueControl = node => {
       const text = label(node);
       return /\\bcontinue\\s+in\\s+(?:a\\s+)?new\\s+(?:chat|task)\\b/.test(text)
         || /(?:在|从这里).*(?:新任务|新聊天).*(?:继续|分支)/.test(text)
         || /从这里(?:继续|分支).*(?:新任务|新聊天)/.test(text)
         || /在新(?:的)?聊天中(?:创建)?分支/.test(text);
-    });
+    };
+    let button = controls.find(node => visible(node) && isContinueControl(node));
+    let overflowOpened = false;
+    let overflowCandidates = [];
+    if (!button) {
+      const overflow = controls.find(node => {
+        const text = label(node);
+        return visible(node) && (
+          /^more actions(?:\\s|$)/.test(text)
+          || /^more(?:\\s|$)/.test(text)
+          || /^更多(?:操作|动作)?(?:\\s|$)/.test(text)
+        );
+      });
+      if (overflow) {
+        overflow.click();
+        overflowOpened = true;
+        for (let index = 0; index < 30 && !button; index += 1) {
+          await sleep(100);
+          const menuControls = [...document.querySelectorAll(
+            '[role="menuitem"], [role="menu"] button, [role="menu"] a, '
+              + '[data-radix-menu-content] button, [data-radix-menu-content] [role="button"], '
+              + '[data-headlessui-state] [role="menuitem"]'
+          )].filter(visible);
+          overflowCandidates = menuControls.map(label).filter(Boolean).slice(-30);
+          button = menuControls.find(isContinueControl) || null;
+        }
+      }
+    }
     if (!button) {
       return {
         ok: false,
         error: 'continue_in_new_task_button_not_found',
         conversationId: current,
-        candidateControls: controls.map(label).filter(Boolean).slice(-20)
+        overflowOpened,
+        candidateControls: controls.map(label).filter(Boolean).slice(-20),
+        overflowCandidates
       };
     }
 
@@ -1302,6 +1333,7 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
           return {
             ok: true,
             continuationClicked: true,
+            overflowOpened,
             previousConversationId: current,
             conversationId: nextConversationId,
             stableSamples
@@ -1315,6 +1347,7 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
     return {
       ok: false,
       error: 'continue_in_new_task_not_confirmed',
+      overflowOpened,
       previousConversationId: current,
       conversationId: currentConversationId()
     };
@@ -1410,11 +1443,26 @@ func getReplyJS() -> String {
         /(?:在|从这里).*(?:新任务|新聊天).*(?:继续|分支)/,
         /从这里(?:继续|分支).*(?:新任务|新聊天)/,
       ]),
-      like: hasResponseControl([/^like(?:\s|$)/, /^喜欢(?:\s|$)/]),
-      dislike: hasResponseControl([/^dislike(?:\s|$)/, /^不喜欢(?:\s|$)/]),
+      moreActions: hasResponseControl([
+        /^more actions(?:\s|$)/,
+        /^more(?:\s|$)/,
+        /^更多(?:操作|动作)?(?:\s|$)/,
+      ]),
+      like: hasResponseControl([
+        /^like(?:\s|$)/,
+        /^good response(?:\s|$)/,
+        /^喜欢(?:\s|$)/,
+        /^好的回答(?:\s|$)/,
+      ]),
+      dislike: hasResponseControl([
+        /^dislike(?:\s|$)/,
+        /^bad response(?:\s|$)/,
+        /^不喜欢(?:\s|$)/,
+        /^不好的回答(?:\s|$)/,
+      ]),
     };
     const responseActionsComplete = responseActions.copy
-      && responseActions.branch
+      && (responseActions.branch || responseActions.moreActions)
       && responseActions.like
       && responseActions.dislike;
 

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
@@ -70,6 +70,76 @@ const pageDiagnostics = queue => (Array.isArray(queue?.tasks) ? queue.tasks : []
     page: task.replyDiagnostics.pageSnapshot,
   }));
 
+const maxLogChunkChars = 2_000;
+const writeChunkedEvent = (label, payload) => {
+  const serialized = JSON.stringify(payload);
+  const total = Math.max(1, Math.ceil(serialized.length / maxLogChunkChars));
+  for (let index = 0; index < total; index += 1) {
+    const chunk = serialized.slice(
+      index * maxLogChunkChars,
+      (index + 1) * maxLogChunkChars,
+    );
+    process.stdout.write(
+      `${label}_CHUNK ${index + 1}/${total} ${JSON.stringify(chunk)}\n`,
+    );
+  }
+};
+
+const commonPrefixLength = (left, right) => {
+  const limit = Math.min(left.length, right.length);
+  let index = 0;
+  while (index < limit && left[index] === right[index]) index += 1;
+  return index;
+};
+
+const pageFieldState = new Map();
+const emitPageDiagnostics = queue => {
+  for (const task of pageDiagnostics(queue)) {
+    for (const [field, rawValue] of Object.entries(task.page)) {
+      const value = typeof rawValue === 'string'
+        ? rawValue
+        : JSON.stringify(rawValue);
+      const key = `${task.id}:${task.conversationId}:${field}`;
+      const previous = pageFieldState.get(key);
+      if (previous === undefined) {
+        writeChunkedEvent('QUEUE_PAGE_FULL', {
+          id: task.id,
+          conversationId: task.conversationId,
+          field,
+          value,
+        });
+      } else if (previous !== value) {
+        const prefixLength = commonPrefixLength(previous, value);
+        writeChunkedEvent('QUEUE_PAGE_DELTA', {
+          id: task.id,
+          conversationId: task.conversationId,
+          field,
+          prefixLength,
+          removedLength: previous.length - prefixLength,
+          append: value.slice(prefixLength),
+        });
+      }
+      pageFieldState.set(key, value);
+    }
+  }
+};
+
+let previousTrace = [];
+const emitTraceEvents = queue => {
+  const trace = Array.isArray(queue.watcherTrace) ? queue.watcherTrace : [];
+  let overlap = Math.min(previousTrace.length, trace.length);
+  while (
+    overlap > 0
+    && previousTrace.slice(-overlap).some((entry, index) => entry !== trace[index])
+  ) {
+    overlap -= 1;
+  }
+  for (const event of trace.slice(overlap)) {
+    writeChunkedEvent('QUEUE_TRACE_EVENT', { event });
+  }
+  previousTrace = trace;
+};
+
 const writeResult = (status, queue, reason) => {
   const result = {
     status,
@@ -112,8 +182,6 @@ const initialRecovery = run('queue_watchdog', { staleAfterSeconds: 300, force: t
 process.stdout.write(`WATCHDOG_INITIAL ${JSON.stringify(watchdogDiagnostics(initialRecovery))}\n`);
 let lastRecovery = 0;
 let lastQueueFingerprint = '';
-let lastPageFingerprint = '';
-let lastTraceFingerprint = '';
 let lastFailureFingerprint = '';
 let sameFailureRecoveries = 0;
 while (Date.now() < deadline) {
@@ -124,17 +192,8 @@ while (Date.now() < deadline) {
     process.stdout.write(`QUEUE_RECOGNITION ${fingerprint}\n`);
     lastQueueFingerprint = fingerprint;
   }
-  const pageFingerprint = JSON.stringify(pageDiagnostics(queue));
-  if (pageFingerprint !== lastPageFingerprint) {
-    process.stdout.write(`QUEUE_PAGE ${pageFingerprint}\n`);
-    lastPageFingerprint = pageFingerprint;
-  }
-  const trace = Array.isArray(queue.watcherTrace) ? queue.watcherTrace : [];
-  const traceFingerprint = JSON.stringify(trace);
-  if (traceFingerprint !== lastTraceFingerprint) {
-    process.stdout.write(`QUEUE_TRACE ${traceFingerprint}\n`);
-    lastTraceFingerprint = traceFingerprint;
-  }
+  emitPageDiagnostics(queue);
+  emitTraceEvents(queue);
   if (tasks.length === 0) {
     writeResult('failed', queue, 'no_tasks_configured');
     process.exit(1);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
@@ -76,10 +76,12 @@ if (command === 'queue_watchdog') {
     assert.equal(report.tasks[0].id, 'broken-task');
     assert.equal(report.tasks[0].lastError, 'new_chat_prepare_failed');
     assert.equal(report.tasks[0].replyDiagnostics.done, false);
-    assert.match(result.stdout, /QUEUE_TRACE/);
+    assert.match(result.stdout, /QUEUE_TRACE_EVENT_CHUNK/);
     assert.match(result.stdout, /responseControlLabels/);
-    assert.match(result.stdout, /QUEUE_PAGE/);
+    assert.match(result.stdout, /QUEUE_PAGE_FULL_CHUNK/);
     assert.match(result.stdout, /最终结果/);
+    assert.doesNotMatch(result.stdout, /QUEUE_PAGE \[/);
+    assert.ok(result.stdout.split('\n').every(line => line.length < 4_096));
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -135,8 +135,18 @@ test('send_and_watch streams visible thinking and uses bounded same-task recover
   assert.match(nativeSource, /responseActionsComplete/);
   assert.match(nativeSource, /responseActions\.copy/);
   assert.match(nativeSource, /responseActions\.branch/);
+  assert.match(nativeSource, /responseActions\.moreActions/);
   assert.match(nativeSource, /responseActions\.like/);
   assert.match(nativeSource, /responseActions\.dislike/);
+  assert.match(nativeSource, /good response/);
+  assert.match(nativeSource, /bad response/);
+  assert.match(nativeSource, /more actions/);
+  assert.match(
+    nativeSource,
+    /responseActions\.branch \|\| responseActions\.moreActions/,
+  );
+  assert.match(nativeSource, /overflowOpened/);
+  assert.match(nativeSource, /overflowCandidates/);
   assert.match(nativeSource, /retainedConversationDiagnosticCount = 5/);
   assert.match(nativeSource, /\.live\.json/);
   assert.match(nativeSource, /\.final\.json/);


### PR DESCRIPTION
## Root cause observed in Action #185

The reply had already stopped (`pending=false`, `streaming=false`, `stopAvailable=false`) and its closed task report was parsed as incomplete, but the current ChatGPT UI exposed `Copy`, `Good response`, `Bad response`, and `More actions`. The runtime required a directly visible branch control plus labels named Like/Dislike, so `responseActionsComplete` remained false and the queue never continued.

## Fix

- recognize Good response / Bad response as the feedback controls
- accept More actions as the stable response-row continuation entry point
- open the overflow menu and click Continue in new task / 在新任务中继续
- log whether the overflow opened and all menu candidates when continuation is not found
- retain the rolling live/final diagnostic files and chunked Action output from the already-merged diagnostics changes

## Validation

- GitHub Actions only