### PR TITLE
fix: preserve Action continuation conversation

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
@@ -28,8 +28,10 @@ for (const task of state.automationTasks || []) {
     task.status = 'queued';
     task.startedAt = null;
     task.finishedAt = null;
-    task.conversationId = null;
-    task.chatURL = null;
+    // Keep the finished/active Chat identity across hosted runner rotation.
+    // startAutomationTask will reopen this conversation and click
+    // "Continue in new task" when continuationDepth is non-zero. Clearing it
+    // here silently turns a serial continuation into an unrelated fresh Chat.
     task.lastProgressAt = null;
     task.lastError = 'github_actions_runner_continuation';
     const note = 'GitHub Actions 已在新托管 Runner 中接管。请从同一 checkout 的最新落盘进度继续。';

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const scriptPath = new URL('../scripts/prepare-action-state.mjs', import.meta.url);
+
+test('hosted runner rotation preserves the conversation needed for serial continuation', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'chatgpt-action-state-'));
+  const statePath = join(directory, 'queue-state.json');
+  writeFileSync(statePath, JSON.stringify({
+    enabled: true,
+    automationTasks: [{
+      id: 'continuation-task',
+      status: 'running',
+      attempts: 7,
+      continuationDepth: 2,
+      conversationId: 'conversation-to-continue',
+      chatURL: 'https://chatgpt.com/c/conversation-to-continue',
+      workerPid: 123,
+      workerPort: 9324,
+      workerTargetId: 'old-target',
+    }],
+  }));
+
+  const result = spawnSync(process.execPath, [scriptPath], {
+    env: {
+      ...process.env,
+      CHATGPT_AUTO_CONFIRM_QUEUE_STATE: statePath,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+
+  const prepared = JSON.parse(readFileSync(statePath, 'utf8'));
+  const [task] = prepared.automationTasks;
+  assert.equal(task.status, 'queued');
+  assert.equal(task.conversationId, 'conversation-to-continue');
+  assert.equal(task.chatURL, 'https://chatgpt.com/c/conversation-to-continue');
+  assert.equal(task.workerPid, null);
+  assert.equal(task.workerPort, null);
+  assert.equal(task.workerTargetId, null);
+  assert.equal(task.lastError, 'github_actions_runner_continuation');
+});


### PR DESCRIPTION
## Root cause observed in Action #187

The encrypted state restored attempt 7 correctly, but `prepare-action-state.mjs` cleared `conversationId` and `chatURL` whenever a running task was re-queued on a new hosted runner. `startAutomationTask` already knows how to reopen a preserved conversation and click Continue in new task when `continuationDepth > 0`; clearing the ID bypassed that path and created an unrelated fresh Chat.

## Fix

- preserve the conversation identity during hosted runner rotation
- continue clearing only runner-local process/target bindings
- add a regression test that executes the state preparation script and verifies the conversation survives while worker bindings are removed

## Validation

- GitHub Actions only