### PR TITLE
fix: confirm and trace automatic Chat approvals

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -1484,7 +1484,11 @@ func getReplyJS() -> String {
 
     const approvalButton = [...main.querySelectorAll('button, a, [role="button"]')].find(button => {
       const text = (button.innerText || button.getAttribute('aria-label') || button.getAttribute('title') || '').trim().toLowerCase();
-      return visible(button) && ['允许一次', 'allow once', 'approve once'].includes(text);
+      return visible(button) && [
+        '完全访问', 'full access', 'allow', 'allow once',
+        '允许', '允许一次', 'approve', 'approve once',
+        'confirm', '确认'
+      ].includes(text);
     });
     const thinkingActive = !responseActionsComplete && !!latestThinking && (
       latestThinking.getAttribute('aria-expanded') !== null

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -1167,21 +1167,61 @@ func autoConfirmChatContinuationJS() -> String {
 
 func autoApproveDedicatedAuthorizationJS() -> String {
   #"""
-  (() => {
+  (async () => {
+    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
     const normalize = value => (value || '').replace(/[\s↵]+/g, ' ').trim().toLowerCase();
+    const visible = element => !!(element
+      && !element.disabled
+      && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
     const allowed = new Set([
       '完全访问', 'full access', 'allow', 'allow once', '允许', '允许一次',
       'approve', 'approve once', 'confirm', '确认'
     ]);
-    const button = [...document.querySelectorAll('button')].find(button => {
-      if (button.disabled || !(button.offsetWidth || button.offsetHeight || button.getClientRects().length)) return false;
-      return allowed.has(normalize(button.innerText || button.textContent || button.getAttribute('aria-label')));
-    });
-    if (!button) return { ok: true, clicked: false };
-    setTimeout(() => {
-      try { button.click(); } catch (_) {}
-    }, 0);
-    return { ok: true, clicked: true, dispatchOnly: true };
+    const label = button => normalize(
+      button.innerText || button.textContent
+        || button.getAttribute('aria-label') || button.getAttribute('title')
+    );
+    const candidates = [...document.querySelectorAll('button')]
+      .filter(visible)
+      .map(button => ({ button, label: label(button) }))
+      .filter(candidate => allowed.has(candidate.label));
+    const candidateLabels = candidates.map(candidate => candidate.label);
+    const candidate = candidates[0];
+    if (!candidate) {
+      return { ok: true, clicked: false, confirmed: false, candidateLabels };
+    }
+    try {
+      candidate.button.click();
+    } catch (error) {
+      return {
+        ok: false,
+        clicked: false,
+        confirmed: false,
+        label: candidate.label,
+        candidateLabels,
+        error: String(error?.message || error || 'approval_click_failed')
+      };
+    }
+    for (let index = 0; index < 20; index += 1) {
+      await sleep(100);
+      if (!candidate.button.isConnected || !visible(candidate.button)) {
+        return {
+          ok: true,
+          clicked: true,
+          confirmed: true,
+          label: candidate.label,
+          candidateLabels
+        };
+      }
+    }
+    return {
+      ok: false,
+      clicked: true,
+      confirmed: false,
+      label: candidate.label,
+      candidateLabels,
+      error: 'approval_click_not_confirmed'
+    };
   })()
   """#
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -13,6 +13,27 @@ func taskReportFingerprint(_ report: AutomationTaskReport) -> String {
     .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
 }
 
+func traceQueueApproval(
+  _ result: [String: Any]?,
+  taskId: String,
+  stage: String
+) {
+  guard let result else { return }
+  guard result["clicked"] as? Bool == true
+          || result["error"] as? String != nil else { return }
+  let candidates = jsonString([
+    "labels": result["candidateLabels"] ?? [],
+  ]) ?? "{\"labels\":[]}"
+  queueTrace(
+    "task=\(taskId) stage=approval-\(stage) "
+      + "clicked=\(result["clicked"] as? Bool == true) "
+      + "confirmed=\(result["confirmed"] as? Bool == true) "
+      + "label=\(result["label"] as? String ?? "none") "
+      + "error=\(result["error"] as? String ?? "none") "
+      + "candidates=\(candidates)"
+  )
+}
+
 func queueContinuation(
   _ task: inout AutomationTask,
   report: AutomationTaskReport?,
@@ -209,12 +230,13 @@ func monitorAutomationTask(
   // A permission card can replace the normal conversation body temporarily.
   // Confirm it before restoring a task through its exact hidden-page route, so
   // an unloaded conversation cannot suppress automatic authorization.
-  _ = cdpValue(
+  let initialApproval = cdpValue(
     port: port,
     targetId: targetId,
     expression: autoApproveDedicatedAuthorizationJS(),
     timeout: 4.0
   )
+  traceQueueApproval(initialApproval, taskId: task.id, stage: "before-read")
   let now = isoFormatter.string(from: Date())
   guard var liveStatus = cdpValue(
           port: port, targetId: targetId, expression: chatStatusJS(), timeout: 5.0) else {
@@ -373,12 +395,13 @@ func monitorAutomationTask(
     expression: autoConfirmChatContinuationJS(),
     timeout: 4.0
   )
-  _ = cdpValue(
+  let followupApproval = cdpValue(
     port: port,
     targetId: targetId,
     expression: autoApproveDedicatedAuthorizationJS(),
     timeout: 4.0
   )
+  traceQueueApproval(followupApproval, taskId: task.id, stage: "after-read")
   task.lastError = nil
   // A new local id is the authoritative identity. The sidebar can keep the
   // previous row marked current briefly, so never replace a local id with

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -147,6 +147,10 @@ test('send_and_watch streams visible thinking and uses bounded same-task recover
   );
   assert.match(nativeSource, /overflowOpened/);
   assert.match(nativeSource, /overflowCandidates/);
+  assert.match(nativeSource, /approval_click_not_confirmed/);
+  assert.match(nativeSource, /traceQueueApproval/);
+  assert.match(nativeSource, /stage=approval-/);
+  assert.match(nativeSource, /candidateLabels/);
   assert.match(nativeSource, /retainedConversationDiagnosticCount = 5/);
   assert.match(nativeSource, /\.live\.json/);
   assert.match(nativeSource, /\.final\.json/);


### PR DESCRIPTION
## Problem

The queue already recognized the visible labels Allow / 允许, but it deferred the click and discarded the result. Reply diagnostics only treated Allow once / 允许一次 as approval state. A failed click therefore looked identical to a successful one in Action logs.

## Fix

- click authorization controls and wait for the exact control to disappear
- return explicit clicked/confirmed/error evidence and candidate labels
- emit approval evidence as `QUEUE_TRACE_EVENT_CHUNK`
- align reply diagnostics with Allow, 允许, Full access, Approve, and Confirm variants

## Validation

- GitHub Actions only