### PR TITLE
fix: resume running Chat across hosted Actions

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
@@ -25,14 +25,12 @@ for (const task of state.automationTasks || []) {
   task.workerProfilePath = null;
   task.resultPath = null;
   if (task.status === 'running') {
-    task.status = 'queued';
-    task.startedAt = null;
-    task.finishedAt = null;
-    // Keep the finished/active Chat identity across hosted runner rotation.
-    // startAutomationTask will reopen this conversation and click
-    // "Continue in new task" when continuationDepth is non-zero. Clearing it
-    // here silently turns a serial continuation into an unrelated fresh Chat.
-    task.lastProgressAt = null;
+    // Keep both the active state and Chat identity across hosted runner
+    // rotation. monitorAutomationTask recreates only the hidden renderer,
+    // navigates back to this durable conversation, confirms pending
+    // authorization, and observes its real terminal state. Re-queuing here
+    // would skip that recovery and create a new Chat before the prior one had
+    // actually finished.
     task.lastError = 'github_actions_runner_continuation';
     const note = 'GitHub Actions 已在新托管 Runner 中接管。请从同一 checkout 的最新落盘进度继续。';
     task.reviewFeedback = [task.reviewFeedback, note].filter(Boolean).join('\n\n');

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
@@ -17,6 +17,8 @@ test('hosted runner rotation preserves the conversation needed for serial contin
       status: 'running',
       attempts: 7,
       continuationDepth: 2,
+      startedAt: '2026-07-30T08:58:58Z',
+      lastProgressAt: '2026-07-30T09:03:00Z',
       conversationId: 'conversation-to-continue',
       chatURL: 'https://chatgpt.com/c/conversation-to-continue',
       workerPid: 123,
@@ -36,7 +38,9 @@ test('hosted runner rotation preserves the conversation needed for serial contin
 
   const prepared = JSON.parse(readFileSync(statePath, 'utf8'));
   const [task] = prepared.automationTasks;
-  assert.equal(task.status, 'queued');
+  assert.equal(task.status, 'running');
+  assert.equal(task.startedAt, '2026-07-30T08:58:58Z');
+  assert.equal(task.lastProgressAt, '2026-07-30T09:03:00Z');
   assert.equal(task.conversationId, 'conversation-to-continue');
   assert.equal(task.chatURL, 'https://chatgpt.com/c/conversation-to-continue');
   assert.equal(task.workerPid, null);


### PR DESCRIPTION
## Root cause

Preserving the conversation ID was necessary but not sufficient: the hosted state preparation still changed a running task to queued. The scheduler therefore called `startAutomationTask` and tried to create/branch before first reattaching to the prior conversation. This prevents a new runtime from resolving a permission card or reading a final reply that appeared during runner rotation.

## Fix

- keep running tasks running across hosted runner rotation
- clear only runner-local worker/process bindings
- let `monitorAutomationTask` recreate a hidden renderer, navigate the durable conversation, auto-confirm authorization, and observe the true terminal state
- preserve started/progress timestamps and assert them in the executable regression test

## Validation

- GitHub Actions only