### PR TITLE
fix: grace hosted Chat reattachment before watchdog recovery

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
@@ -31,6 +31,9 @@ for (const task of state.automationTasks || []) {
     // authorization, and observes its real terminal state. Re-queuing here
     // would skip that recovery and create a new Chat before the prior one had
     // actually finished.
+    // Refresh only the handoff heartbeat so the startup watchdog does not
+    // declare the task stale before the first monitor pass can reattach.
+    task.lastProgressAt = new Date().toISOString();
     task.lastError = 'github_actions_runner_continuation';
     const note = 'GitHub Actions 已在新托管 Runner 中接管。请从同一 checkout 的最新落盘进度继续。';
     task.reviewFeedback = [task.reviewFeedback, note].filter(Boolean).join('\n\n');

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
@@ -43,7 +43,8 @@ test('hosted runner rotation preserves the conversation needed for serial contin
   const [task] = prepared.automationTasks;
   assert.equal(task.status, 'running');
   assert.equal(task.startedAt, '2026-07-30T08:58:58Z');
-  assert.equal(task.lastProgressAt, '2026-07-30T09:03:00Z');
+  assert.notEqual(task.lastProgressAt, '2026-07-30T09:03:00Z');
+  assert.ok(Number.isFinite(Date.parse(task.lastProgressAt)));
   assert.equal(task.conversationId, 'conversation-to-continue');
   assert.equal(task.chatURL, 'https://chatgpt.com/c/conversation-to-continue');
   assert.equal(task.workerPid, null);


### PR DESCRIPTION
## Root cause observed in Action #188

The runner correctly restored a running task and kept its conversation, but the startup watchdog evaluated the old progress timestamp before the first monitor pass. It immediately emitted `continuation-queued reason=github_actions_watchdog_recovery`, bypassing same-conversation reattachment.

## Fix

Refresh only the handoff heartbeat during hosted state preparation. Preserve status, startedAt, conversationId, and chatURL. This gives the new monitor a normal reattachment window while retaining the true task start time and all page diagnostics.

The executable regression test now asserts the handoff heartbeat is refreshed and parseable.

## Validation

- GitHub Actions only