### PR TITLE
fix(queue): recover hosted continuation into a fresh chat

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -290,12 +290,41 @@ func navigateHiddenConversation(
         let wsURL = target["webSocketDebuggerUrl"] as? String,
         CDPClient.navigate(wsURLString: wsURL, url: url) else { return false }
   Thread.sleep(forTimeInterval: 0.5)
-  guard wakeHiddenRenderer(port: port, targetId: targetId, wsURL: wsURL) else {
+  let initialRuntimeState = queueTargetRuntimeState(
+    port: port,
+    targetId: targetId,
+    refreshLifecycle: false
+  )
+  switch initialRuntimeState {
+  case .hidden, .hiddenNonChat:
+    guard wakeHiddenRenderer(port: port, targetId: targetId, wsURL: wsURL) else {
+      return false
+    }
+  case .visible:
+    // GitHub-hosted verification deliberately reuses an authenticated visible
+    // web renderer. Treat it as a valid dedicated queue surface instead of
+    // requiring Electron's show:false visibility contract.
+    guard queueUsesHostedRenderer() else { return false }
+    _ = CDPClient.setWebLifecycleActive(wsURLString: wsURL)
+    _ = CDPClient.setHiddenPageUserActive(wsURLString: wsURL)
+  case .missing, .suspended:
     return false
   }
   let deadline = Date().addingTimeInterval(timeout)
   repeat {
-    guard queueTargetIsHidden(port: port, targetId: targetId) else { return false }
+    let runtimeState = queueTargetRuntimeState(
+      port: port,
+      targetId: targetId,
+      refreshLifecycle: true
+    )
+    switch runtimeState {
+    case .hidden, .hiddenNonChat:
+      break
+    case .visible:
+      guard queueUsesHostedRenderer() else { return false }
+    case .missing, .suspended:
+      return false
+    }
     if let status = cdpValue(
       port: port,
       targetId: targetId,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1322,6 +1322,7 @@ func startAutomationTask(
   // authenticated ChatGPT process. This preserves the proven real Chat UI path
   // without navigating away from another task's streaming conversation.
   var prepared: [String: Any]?
+  var preparationFailure: String?
   var port: Int?
   var targetId: String?
   var workerProfilePath: String?
@@ -1369,32 +1370,57 @@ func startAutomationTask(
       "task=\(task.id) stage=prepare-continuation begin "
         + "previousConversation=\(previousConversationId)"
     )
-    guard navigateHiddenConversation(
+    let navigationSucceeded = navigateHiddenConversation(
       port: worker.port,
       targetId: worker.targetId,
       conversationId: previousConversationId
-    ) else {
-      throw NSError(
-        domain: "chatgpt-auto-confirm",
-        code: 34,
-        userInfo: [
-          NSLocalizedDescriptionKey:
-            "任务 \(task.id) 无法恢复上一轮会话，未点击“在新任务中继续”"
-        ]
-      )
-    }
-    prepared = cdpValue(
-      port: worker.port,
-      targetId: worker.targetId,
-      expression: continueInNewTaskJS(expectedConversationId: previousConversationId),
-      timeout: 35.0
     )
+    if navigationSucceeded {
+      prepared = cdpValue(
+        port: worker.port,
+        targetId: worker.targetId,
+        expression: continueInNewTaskJS(expectedConversationId: previousConversationId),
+        timeout: 35.0
+      )
+    } else {
+      prepared = [
+        "ok": false,
+        "error": "continuation_navigation_failed",
+        "conversationId": previousConversationId,
+      ]
+    }
     queueTrace(
       "task=\(task.id) stage=prepare-continuation "
+        + "navigated=\(navigationSucceeded) "
         + "clicked=\(prepared?["continuationClicked"] as? Bool == true) "
         + "newConversation=\(prepared?["conversationId"] as? String ?? "none") "
         + "error=\(prepared?["error"] as? String ?? "none")"
     )
+    if prepared?["ok"] as? Bool != true {
+      let continuationError = prepared?["error"] as? String ?? "continuation_no_result"
+      preparationFailure = continuationError
+      let screenshot = captureHiddenChatScreenshot(
+        port: worker.port,
+        targetId: worker.targetId,
+        label: "continuation-fallback"
+      )
+      queueTrace(
+        "task=\(task.id) stage=prepare-continuation fallback=new-chat "
+          + "reason=\(continuationError) "
+          + "screenshot=\(screenshot ?? "none")"
+      )
+      if var fallback = prepareNewChatTarget(
+        port: worker.port,
+        targetId: worker.targetId,
+        timeout: 4.0,
+        allowBlankConversationReuse: true
+      ) {
+        fallback["continuationFallback"] = true
+        fallback["continuationFailure"] = continuationError
+        fallback["previousConversationId"] = previousConversationId
+        prepared = fallback
+      }
+    }
   } else {
     queueTrace("task=\(task.id) stage=prepare-new-chat begin")
     prepared = prepareNewChatTarget(
@@ -1411,7 +1437,10 @@ func startAutomationTask(
     throw NSError(
       domain: "chatgpt-auto-confirm",
       code: 22,
-      userInfo: [NSLocalizedDescriptionKey: "无法为任务 \(task.id) 准备已登录隐藏 Chat"]
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "无法为任务 \(task.id) 准备已登录 Chat（\(preparationFailure ?? "unknown")）"
+      ]
     )
   }
   queueTrace(

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -88,6 +88,11 @@ test('initial outbound messages create a new Chat and same-task continuations us
   assert.match(nativeSource, /continuationClicked/);
   assert.match(nativeSource, /continue_in_new_task_button_not_found/);
   assert.match(nativeSource, /stage=prepare-continuation/);
+  assert.match(nativeSource, /continuation_navigation_failed/);
+  assert.match(nativeSource, /fallback=new-chat/);
+  assert.match(nativeSource, /continuationFallback/);
+  assert.match(nativeSource, /case \.visible:[\s\S]*queueUsesHostedRenderer\(\)/);
+  assert.doesNotMatch(nativeSource, /无法恢复上一轮会话，未点击/);
 });
 
 test('send_and_watch streams visible thinking and uses bounded same-task recovery', async () => {


### PR DESCRIPTION
## Root cause

The hosted Actions runner successfully created a new Chat renderer, but same-task continuation failed before the `Continue in new task` control was ever evaluated. `navigateHiddenConversation` required the worker renderer to remain `hidden`, while hosted verification deliberately uses a visible authenticated web renderer (`hosted-active-renderer`). The navigation guard therefore returned false immediately and emitted the misleading `未点击“在新任务中继续”` error.

## Fix

- Accept a visible renderer during conversation navigation only in hosted mode.
- Preserve the hidden Electron renderer checks for normal desktop operation.
- Trace navigation and continuation-button failures separately.
- Capture a diagnostic screenshot when continuation preparation fails.
- Fall back to creating a genuinely fresh Chat in the same independent worker window, preserving the queued task feedback and previous conversation metadata.
- Add contract coverage for hosted visible navigation and the fresh-Chat fallback.

## Verification

- `git diff --check`
- Tests/builds are delegated to GitHub Actions per repository policy.