### PR TITLE
fix(approvals): capture connector authorization diagnostics

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -186,7 +186,7 @@ func captureHiddenChatScreenshot(
         }),
         let wsURL = target["webSocketDebuggerUrl"] as? String else { return nil }
   let formatter = DateFormatter()
-  formatter.dateFormat = "yyyyMMdd-HHmmss"
+  formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
   let outputURL = stateURL().deletingLastPathComponent()
     .appendingPathComponent("diagnostics", isDirectory: true)
     .appendingPathComponent("chat-\(label)-\(formatter.string(from: Date())).png")
@@ -1194,6 +1194,109 @@ func autoConfirmChatContinuationJS() -> String {
   """#
 }
 
+func detectDedicatedAuthorizationJS() -> String {
+  #"""
+  (() => {
+    const normalize = value => (value || '').replace(/[\s↵]+/g, ' ').trim().toLowerCase();
+    const visible = element => !!(element
+      && !element.disabled
+      && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
+    const label = button => normalize(
+      button.innerText || button.textContent
+        || button.getAttribute('aria-label') || button.getAttribute('title')
+    );
+    const allowLabels = new Set([
+      'allow', 'allow once', 'approve', 'approve once', 'confirm', 'confirm once',
+      '允许', '允许一次', '同意', '同意一次', '确认', '确认一次',
+      'full access', '完全访问'
+    ]);
+    const rejectLabels = new Set([
+      'deny', 'reject', 'cancel', 'deny once', 'reject once',
+      '拒绝', '拒绝一次', '不允许', '不允许一次', '取消'
+    ]);
+    const sessionHints = [
+      'this chat', 'this conversation', 'for this chat', 'for this conversation',
+      'for this session', 'during this chat', 'always allow in this chat',
+      '本次会话', '这次会话', '此会话', '当前会话', '在此聊天中', '本次聊天',
+      '始终允许', '会话期间'
+    ];
+    const buttons = [...document.querySelectorAll('button, a, [role="button"]')]
+      .filter(visible);
+    const candidates = buttons
+      .map((button, index) => ({ button, index, label: label(button) }))
+      .filter(candidate => allowLabels.has(candidate.label));
+    const candidate = candidates[0];
+    if (!candidate) {
+      return {
+        ok: true,
+        found: false,
+        candidates: 0,
+        candidateLabels: [],
+        selectedLabel: '',
+        cardButtonLabels: [],
+        sessionScopeLabels: [],
+        menuTriggerLabels: [],
+        menuTriggerCount: 0,
+        unlabeledControlCount: 0
+      };
+    }
+
+    let container = candidate.button.parentElement;
+    for (let index = 0; index < 15 && container; index += 1) {
+      const cardButtons = [...container.querySelectorAll('button, a, [role="button"]')]
+        .filter(visible);
+      const cardLabels = cardButtons.map(label);
+      const hasReject = cardLabels.some(value => rejectLabels.has(value));
+      const cardText = normalize(container.innerText || container.textContent || '');
+      if (hasReject || cardText.includes('allow chatgpt to use') || cardText.includes('允许 chatgpt 使用')) {
+        const nonDecisionControls = cardButtons.filter(button => {
+          const value = label(button);
+          return !allowLabels.has(value) && !rejectLabels.has(value);
+        });
+        const menuTriggers = nonDecisionControls.filter(button =>
+          button.getAttribute('aria-haspopup') === 'menu'
+            || button.getAttribute('aria-expanded') !== null
+            || normalize(button.getAttribute('data-state')) === 'open'
+            || /menu|dropdown|chevron|more/.test(normalize(
+              button.getAttribute('data-testid') || button.getAttribute('data-slot')
+                || button.getAttribute('class') || ''
+            ))
+        );
+        const sessionScopeLabels = cardLabels.filter(value =>
+          value && sessionHints.some(hint => value.includes(hint))
+        );
+        return {
+          ok: true,
+          found: true,
+          candidates: candidates.length,
+          candidateLabels: candidates.map(item => item.label),
+          selectedLabel: candidate.label,
+          cardButtonLabels: cardLabels.filter(Boolean),
+          sessionScopeLabels,
+          menuTriggerLabels: menuTriggers.map(label).filter(Boolean),
+          menuTriggerCount: menuTriggers.length,
+          unlabeledControlCount: nonDecisionControls.filter(button => !label(button)).length
+        };
+      }
+      container = container.parentElement;
+    }
+
+    return {
+      ok: true,
+      found: true,
+      candidates: candidates.length,
+      candidateLabels: candidates.map(item => item.label),
+      selectedLabel: candidate.label,
+      cardButtonLabels: [],
+      sessionScopeLabels: [],
+      menuTriggerLabels: [],
+      menuTriggerCount: 0,
+      unlabeledControlCount: 0
+    };
+  })()
+  """#
+}
+
 func autoApproveDedicatedAuthorizationJS() -> String {
   #"""
   (async () => {
@@ -1204,16 +1307,26 @@ func autoApproveDedicatedAuthorizationJS() -> String {
       && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
     const allowed = new Set([
       '完全访问', 'full access', 'allow', 'allow once', '允许', '允许一次',
-      'approve', 'approve once', 'confirm', '确认'
+      'approve', 'approve once', 'confirm', 'confirm once', '确认', '确认一次',
+      '同意', '同意一次'
     ]);
     const label = button => normalize(
       button.innerText || button.textContent
         || button.getAttribute('aria-label') || button.getAttribute('title')
     );
+    const priority = new Map([
+      ['allow', 0], ['允许', 0], ['approve', 0], ['同意', 0], ['confirm', 0], ['确认', 0],
+      ['allow once', 1], ['允许一次', 1], ['approve once', 1], ['同意一次', 1],
+      ['confirm once', 1], ['确认一次', 1], ['full access', 20], ['完全访问', 20]
+    ]);
     const candidates = [...document.querySelectorAll('button')]
       .filter(visible)
-      .map(button => ({ button, label: label(button) }))
-      .filter(candidate => allowed.has(candidate.label));
+      .map((button, index) => ({ button, index, label: label(button) }))
+      .filter(candidate => allowed.has(candidate.label))
+      .sort((left, right) =>
+        (priority.get(left.label) ?? 10) - (priority.get(right.label) ?? 10)
+          || left.index - right.index
+      );
     const candidateLabels = candidates.map(candidate => candidate.label);
     const candidate = candidates[0];
     if (!candidate) {
@@ -1773,6 +1886,30 @@ func scanIPC(_ state: inout PluginState) -> [String: Any]? {
 
   for endpoint in pageTargets {
     guard let wsURL = endpoint.target["webSocketDebuggerUrl"] as? String else { continue }
+    let targetId = endpoint.target["id"] as? String ?? "unknown-target"
+    var approvalDetection: [String: Any]?
+    var approvalScreenshotPath: String?
+    if let detectionEval = CDPClient.evaluate(
+          wsURLString: wsURL,
+          expression: detectDedicatedAuthorizationJS()
+        ),
+       let detectionResult = detectionEval["result"] as? [String: Any],
+       let detectionValue = ((detectionResult["result"] as? [String: Any])?["value"]
+         ?? detectionResult["value"]) as? [String: Any],
+       detectionValue["found"] as? Bool == true {
+      approvalDetection = detectionValue
+      approvalScreenshotPath = captureHiddenChatScreenshot(
+        port: endpoint.port,
+        targetId: targetId,
+        label: "approval-watcher-before"
+      )
+      queueTrace(
+        "task=approval-watcher stage=approval-ipc-detected strategy=per-card "
+          + "target=\(targetId) selected=\(detectionValue["selectedLabel"] as? String ?? "none") "
+          + "screenshot=\(approvalScreenshotPath ?? "none") "
+          + approvalDetectionTraceFields(detectionValue)
+      )
+    }
     guard let evalRes = CDPClient.evaluate(wsURLString: wsURL, expression: jsScript),
           let result = evalRes["result"] as? [String: Any],
           let value = ((result["result"] as? [String: Any])?["value"] ?? result["value"]) as? [String: Any] else { continue }
@@ -1790,6 +1927,28 @@ func scanIPC(_ state: inout PluginState) -> [String: Any]? {
     totalUnmatched += u
     totalInternalActions += internalActions
     totalDOMEvents += domEvents
+
+    if approvalDetection != nil || a > 0 || b > 0 {
+      queueTrace(
+        "task=approval-watcher stage=approval-ipc-result strategy=per-card "
+          + "target=\(targetId) approved=\(a) pending=\(p) blocked=\(b) unmatched=\(u) "
+          + "internalActions=\(internalActions) domEvents=\(domEvents) "
+          + "screenshot=\(approvalScreenshotPath ?? "none") "
+          + approvalDetectionTraceFields(approvalDetection)
+      )
+      if approvalDetection != nil && a == 0 {
+        let afterPath = captureHiddenChatScreenshot(
+          port: endpoint.port,
+          targetId: targetId,
+          label: "approval-watcher-after"
+        )
+        queueTrace(
+          "task=approval-watcher stage=approval-ipc-unconfirmed strategy=per-card "
+            + "target=\(targetId) beforeScreenshot=\(approvalScreenshotPath ?? "none") "
+            + "afterScreenshot=\(afterPath ?? "none")"
+        )
+      }
+    }
 
     if let audits = value["audits"] as? [[String: Any]] {
       for item in audits {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -13,10 +13,36 @@ func taskReportFingerprint(_ report: AutomationTaskReport) -> String {
     .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
 }
 
+func approvalDiagnosticToken(_ value: String) -> String {
+  let normalized = value.replacingOccurrences(
+    of: "[^A-Za-z0-9_-]+",
+    with: "-",
+    options: .regularExpression
+  )
+  return String(normalized.prefix(80)).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+}
+
+func approvalDetectionTraceFields(_ detection: [String: Any]?) -> String {
+  guard let detection else {
+    return "detection=none"
+  }
+  let details = jsonString([
+    "candidateLabels": detection["candidateLabels"] ?? [],
+    "cardButtonLabels": detection["cardButtonLabels"] ?? [],
+    "sessionScopeLabels": detection["sessionScopeLabels"] ?? [],
+    "menuTriggerLabels": detection["menuTriggerLabels"] ?? [],
+    "menuTriggerCount": detection["menuTriggerCount"] ?? 0,
+    "unlabeledControlCount": detection["unlabeledControlCount"] ?? 0,
+  ]) ?? "{}"
+  return "detection=\(details)"
+}
+
 func traceQueueApproval(
   _ result: [String: Any]?,
   taskId: String,
-  stage: String
+  stage: String,
+  detection: [String: Any]? = nil,
+  screenshotPath: String? = nil
 ) {
   guard let result else { return }
   guard result["clicked"] as? Bool == true
@@ -25,13 +51,74 @@ func traceQueueApproval(
     "labels": result["candidateLabels"] ?? [],
   ]) ?? "{\"labels\":[]}"
   queueTrace(
-    "task=\(taskId) stage=approval-\(stage) "
+    "task=\(taskId) stage=approval-\(stage) strategy=per-card "
       + "clicked=\(result["clicked"] as? Bool == true) "
       + "confirmed=\(result["confirmed"] as? Bool == true) "
       + "label=\(result["label"] as? String ?? "none") "
       + "error=\(result["error"] as? String ?? "none") "
-      + "candidates=\(candidates)"
+      + "screenshot=\(screenshotPath ?? "none") "
+      + "candidates=\(candidates) "
+      + approvalDetectionTraceFields(detection)
   )
+}
+
+@discardableResult
+func approveDedicatedAuthorizationWithDiagnostics(
+  port: Int,
+  targetId: String,
+  taskId: String,
+  stage: String
+) -> [String: Any]? {
+  let detection = cdpValue(
+    port: port,
+    targetId: targetId,
+    expression: detectDedicatedAuthorizationJS(),
+    timeout: 4.0
+  )
+  guard detection?["found"] as? Bool == true else { return nil }
+
+  let safeTask = approvalDiagnosticToken(taskId)
+  let safeStage = approvalDiagnosticToken(stage)
+  let screenshotPath = captureHiddenChatScreenshot(
+    port: port,
+    targetId: targetId,
+    label: "approval-\(safeTask)-\(safeStage)-before"
+  )
+  queueTrace(
+    "task=\(taskId) stage=approval-\(stage)-detected strategy=per-card "
+      + "selected=\(detection?["selectedLabel"] as? String ?? "none") "
+      + "screenshot=\(screenshotPath ?? "none") "
+      + approvalDetectionTraceFields(detection)
+  )
+
+  let result = cdpValue(
+    port: port,
+    targetId: targetId,
+    expression: autoApproveDedicatedAuthorizationJS(),
+    timeout: 4.0
+  )
+  traceQueueApproval(
+    result,
+    taskId: taskId,
+    stage: stage,
+    detection: detection,
+    screenshotPath: screenshotPath
+  )
+
+  if result?["clicked"] as? Bool != true || result?["confirmed"] as? Bool != true {
+    let afterPath = captureHiddenChatScreenshot(
+      port: port,
+      targetId: targetId,
+      label: "approval-\(safeTask)-\(safeStage)-after"
+    )
+    queueTrace(
+      "task=\(taskId) stage=approval-\(stage)-unconfirmed strategy=per-card "
+        + "beforeScreenshot=\(screenshotPath ?? "none") "
+        + "afterScreenshot=\(afterPath ?? "none") "
+        + "error=\(result?["error"] as? String ?? "none")"
+    )
+  }
+  return result
 }
 
 func queueContinuation(
@@ -230,13 +317,12 @@ func monitorAutomationTask(
   // A permission card can replace the normal conversation body temporarily.
   // Confirm it before restoring a task through its exact hidden-page route, so
   // an unloaded conversation cannot suppress automatic authorization.
-  let initialApproval = cdpValue(
+  _ = approveDedicatedAuthorizationWithDiagnostics(
     port: port,
     targetId: targetId,
-    expression: autoApproveDedicatedAuthorizationJS(),
-    timeout: 4.0
+    taskId: task.id,
+    stage: "before-read"
   )
-  traceQueueApproval(initialApproval, taskId: task.id, stage: "before-read")
   let now = isoFormatter.string(from: Date())
   guard var liveStatus = cdpValue(
           port: port, targetId: targetId, expression: chatStatusJS(), timeout: 5.0) else {
@@ -395,13 +481,12 @@ func monitorAutomationTask(
     expression: autoConfirmChatContinuationJS(),
     timeout: 4.0
   )
-  let followupApproval = cdpValue(
+  _ = approveDedicatedAuthorizationWithDiagnostics(
     port: port,
     targetId: targetId,
-    expression: autoApproveDedicatedAuthorizationJS(),
-    timeout: 4.0
+    taskId: task.id,
+    stage: "after-read"
   )
-  traceQueueApproval(followupApproval, taskId: task.id, stage: "after-read")
   task.lastError = nil
   // A new local id is the authoritative identity. The sidebar can keep the
   // previous row marked current briefly, so never replace a local id with

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
@@ -8,7 +8,7 @@ func queueDirectoryURL() -> URL {
   queueStateURL().deletingLastPathComponent().appendingPathComponent("task-queue", isDirectory: true)
 }
 
-let currentQueueRuntimeRevision = "mahayana.task-queue.v83"
+let currentQueueRuntimeRevision = "mahayana.task-queue.v84"
 
 func queueStateURL() -> URL {
   if let override = ProcessInfo.processInfo.environment["CHATGPT_AUTO_CONFIRM_QUEUE_STATE"],

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -156,6 +156,14 @@ test('send_and_watch streams visible thinking and uses bounded same-task recover
   assert.match(nativeSource, /traceQueueApproval/);
   assert.match(nativeSource, /stage=approval-/);
   assert.match(nativeSource, /candidateLabels/);
+  assert.match(nativeSource, /detectDedicatedAuthorizationJS/);
+  assert.match(nativeSource, /sessionScopeLabels/);
+  assert.match(nativeSource, /menuTriggerCount/);
+  assert.match(nativeSource, /strategy=per-card/);
+  assert.match(nativeSource, /approval-watcher-before/);
+  assert.match(nativeSource, /approval-ipc-detected/);
+  assert.match(nativeSource, /approval-.*-before/);
+  assert.match(nativeSource, /yyyyMMdd-HHmmss-SSS/);
   assert.match(nativeSource, /retainedConversationDiagnosticCount = 5/);
   assert.match(nativeSource, /\.live\.json/);
   assert.match(nativeSource, /\.final\.json/);


### PR DESCRIPTION
## Evidence

The hosted queue showed bhrum2 working during the first part of the Chat. At 09:42:02 the web UI displayed `Allow ChatGPT to use bhrum2?`; by 09:42:17 `waitingForApproval` was false and the task continued to a report. The old runtime therefore approved the prompt, but did not record which button was clicked or save a screenshot.

## Behavior in this change

- Keep the current conservative per-card strategy: click the ordinary Allow/Allow once button for every authorization prompt.
- Do not automatically select the broader “this chat / this conversation / this session” scope yet.
- Before each authorization click, capture a diagnostic PNG.
- Detect and log all visible decision labels, adjacent/menu controls, unlabeled controls, and any session-scope wording already present in the DOM.
- Record selected label, click confirmation, errors, screenshot path, and the per-card strategy in `watcher-trace.log`.
- Capture a second screenshot when a click is not confirmed.
- Cover both the task queue monitoring path and the global IPC approval watcher path.
- Add millisecond precision to screenshot names to prevent collisions.

## Verification

- `git diff --check`
- Runtime, source-contract, and CI validation delegated to GitHub Actions.