### PR TITLE
Fix Chat continuation recovery and session-scoped approvals

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -339,6 +339,61 @@ func navigateHiddenConversation(
   return false
 }
 
+func restoreHiddenConversation(
+  port: Int,
+  targetId: String,
+  conversationId: String,
+  timeout: TimeInterval = 35.0
+) -> [String: Any] {
+  // Prefer the live sidebar. A direct Page.navigate on the hosted desktop
+  // renderer can leave the app on its startup spinner, which also poisons the
+  // subsequent fresh-chat fallback.
+  let sidebar = cdpValue(
+    port: port,
+    targetId: targetId,
+    expression: selectBackgroundConversationJS(conversationId),
+    timeout: min(timeout, 20.0)
+  )
+  if sidebar?["ok"] as? Bool == true,
+     let status = cdpValue(
+       port: port,
+       targetId: targetId,
+       expression: chatStatusJS(),
+       timeout: 5.0
+     ), normalizedConversationId(status["conversationId"] as? String) == conversationId,
+        status["chatMode"] as? Bool == true {
+    var result = sidebar ?? [:]
+    result["ok"] = true
+    result["strategy"] = "sidebar"
+    return result
+  }
+
+  let sidebarError = sidebar?["error"] as? String
+    ?? "continuation_sidebar_selection_failed"
+  if queueUsesHostedRenderer() {
+    return [
+      "ok": false,
+      "error": sidebarError,
+      "strategy": "sidebar",
+      "conversationId": conversationId,
+    ]
+  }
+
+  let navigated = navigateHiddenConversation(
+    port: port,
+    targetId: targetId,
+    conversationId: conversationId,
+    timeout: timeout
+  )
+  return [
+    "ok": navigated,
+    "error": navigated ? "" : "continuation_route_navigation_failed",
+    "strategy": "route",
+    "sidebarError": sidebarError,
+    "conversationId": conversationId,
+  ]
+}
+
 func selectBackgroundConversationJS(_ conversationId: String) -> String {
   let expected = jsonStringLiteral(conversationId)
   return """
@@ -1301,23 +1356,67 @@ func autoApproveDedicatedAuthorizationJS() -> String {
   #"""
   (async () => {
     const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
-    const normalize = value => (value || '').replace(/[\s↵]+/g, ' ').trim().toLowerCase();
-    const visible = element => !!(element
-      && !element.disabled
+    const normalize = value => (value || '').replace(/[\s\u21b5]+/g, ' ').trim().toLowerCase();
+    const rendered = element => !!(element
       && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
+    const visible = element => rendered(element) && !element.disabled;
     const allowed = new Set([
-      '完全访问', 'full access', 'allow', 'allow once', '允许', '允许一次',
-      'approve', 'approve once', 'confirm', 'confirm once', '确认', '确认一次',
-      '同意', '同意一次'
+      '\u5b8c\u5168\u8bbf\u95ee', 'full access', 'allow', 'allow once',
+      '\u5141\u8bb8', '\u5141\u8bb8\u4e00\u6b21', 'approve', 'approve once',
+      'confirm', 'confirm once', '\u786e\u8ba4', '\u786e\u8ba4\u4e00\u6b21',
+      '\u540c\u610f', '\u540c\u610f\u4e00\u6b21'
     ]);
+    const rejectLabels = new Set([
+      'deny', 'reject', 'cancel', 'deny once', 'reject once',
+      '\u62d2\u7edd', '\u62d2\u7edd\u4e00\u6b21', '\u4e0d\u5141\u8bb8',
+      '\u4e0d\u5141\u8bb8\u4e00\u6b21', '\u53d6\u6d88'
+    ]);
+    const sessionHints = [
+      'this chat', 'this conversation', 'for this chat', 'for this conversation',
+      'for this session', 'during this chat', 'always allow in this chat',
+      '\u672c\u6b21\u4f1a\u8bdd', '\u8fd9\u6b21\u4f1a\u8bdd',
+      '\u6b64\u4f1a\u8bdd', '\u5f53\u524d\u4f1a\u8bdd',
+      '\u5728\u6b64\u804a\u5929\u4e2d', '\u672c\u6b21\u804a\u5929',
+      '\u59cb\u7ec8\u5141\u8bb8', '\u4f1a\u8bdd\u671f\u95f4'
+    ];
     const label = button => normalize(
       button.innerText || button.textContent
         || button.getAttribute('aria-label') || button.getAttribute('title')
     );
+    const isSessionScope = value => !!value
+      && sessionHints.some(hint => value.includes(hint));
+    const dispatchPointerClick = candidate => {
+      const rect = candidate.getBoundingClientRect?.();
+      const clientX = rect ? rect.left + Math.min(12, Math.max(1, rect.width / 2)) : 1;
+      const clientY = rect ? rect.top + Math.min(12, Math.max(1, rect.height / 2)) : 1;
+      const pressed = {
+        bubbles: true, cancelable: true, composed: true,
+        button: 0, buttons: 1, clientX, clientY
+      };
+      candidate.dispatchEvent(new PointerEvent('pointerdown', {
+        ...pressed, pointerId: 1, pointerType: 'mouse', isPrimary: true
+      }));
+      candidate.dispatchEvent(new MouseEvent('mousedown', pressed));
+      candidate.dispatchEvent(new PointerEvent('pointerup', {
+        ...pressed, buttons: 0, pointerId: 1, pointerType: 'mouse', isPrimary: true
+      }));
+      candidate.dispatchEvent(new MouseEvent('mouseup', { ...pressed, buttons: 0 }));
+      candidate.dispatchEvent(new MouseEvent('click', { ...pressed, buttons: 0 }));
+    };
+    const confirmCardClosed = async candidate => {
+      for (let index = 0; index < 30; index += 1) {
+        await sleep(100);
+        if (!candidate.isConnected || !rendered(candidate)) return true;
+      }
+      return false;
+    };
     const priority = new Map([
-      ['allow', 0], ['允许', 0], ['approve', 0], ['同意', 0], ['confirm', 0], ['确认', 0],
-      ['allow once', 1], ['允许一次', 1], ['approve once', 1], ['同意一次', 1],
-      ['confirm once', 1], ['确认一次', 1], ['full access', 20], ['完全访问', 20]
+      ['allow', 0], ['\u5141\u8bb8', 0], ['approve', 0], ['\u540c\u610f', 0],
+      ['confirm', 0], ['\u786e\u8ba4', 0], ['allow once', 1],
+      ['\u5141\u8bb8\u4e00\u6b21', 1], ['approve once', 1],
+      ['\u540c\u610f\u4e00\u6b21', 1], ['confirm once', 1],
+      ['\u786e\u8ba4\u4e00\u6b21', 1], ['full access', 20],
+      ['\u5b8c\u5168\u8bbf\u95ee', 20]
     ]);
     const candidates = [...document.querySelectorAll('button')]
       .filter(visible)
@@ -1332,37 +1431,109 @@ func autoApproveDedicatedAuthorizationJS() -> String {
     if (!candidate) {
       return { ok: true, clicked: false, confirmed: false, candidateLabels };
     }
+
+    let card = candidate.button.parentElement;
+    let cardButtons = [];
+    for (let index = 0; index < 15 && card; index += 1) {
+      cardButtons = [...card.querySelectorAll('button, a, [role="button"]')]
+        .filter(visible);
+      const cardLabels = cardButtons.map(label);
+      const cardText = normalize(card.innerText || card.textContent || '');
+      if (cardLabels.some(value => rejectLabels.has(value))
+          || cardText.includes('allow chatgpt to use')
+          || cardText.includes('\u5141\u8bb8 chatgpt \u4f7f\u7528')) {
+        break;
+      }
+      card = card.parentElement;
+      cardButtons = [];
+    }
+
+    const sessionControl = cardButtons.find(button =>
+      button !== candidate.button && isSessionScope(label(button))
+    ) || cardButtons.find(button => {
+      if (button === candidate.button) return false;
+      const value = label(button);
+      return !allowed.has(value) && !rejectLabels.has(value) && (
+        button.getAttribute('aria-haspopup') === 'menu'
+          || button.getAttribute('aria-expanded') !== null
+          || /menu|dropdown|chevron|more/.test(normalize(
+            button.getAttribute('data-testid') || button.getAttribute('data-slot')
+              || button.getAttribute('class') || ''
+          ))
+      );
+    });
+
+    if (sessionControl) {
+      const menuTriggerLabel = label(sessionControl);
+      try {
+        dispatchPointerClick(sessionControl);
+      } catch (error) {
+        return {
+          ok: false, clicked: false, confirmed: false,
+          strategy: 'session-scope', label: menuTriggerLabel, candidateLabels,
+          error: String(error?.message || error || 'session_scope_menu_click_failed')
+        };
+      }
+      let menuCandidates = [];
+      for (let index = 0; index < 40; index += 1) {
+        await sleep(100);
+        if (!candidate.button.isConnected || !rendered(candidate.button)) {
+          return {
+            ok: true, clicked: true, confirmed: true,
+            strategy: 'session-scope-direct', label: menuTriggerLabel,
+            menuTriggerLabel, candidateLabels
+          };
+        }
+        const menuItems = [...document.querySelectorAll(
+          '[role="menuitem"], [role="menuitemradio"], [role="option"], '
+            + '[role="menu"] button, [role="listbox"] button, '
+            + '[data-radix-menu-content] button, '
+            + '[data-radix-popper-content-wrapper] button'
+        )].filter(item => item !== sessionControl && visible(item));
+        menuCandidates = menuItems.map(label).filter(Boolean).slice(-30);
+        const sessionOption = menuItems.find(item => isSessionScope(label(item)));
+        if (!sessionOption) continue;
+        const sessionScopeLabel = label(sessionOption);
+        try {
+          dispatchPointerClick(sessionOption);
+        } catch (error) {
+          return {
+            ok: false, clicked: true, confirmed: false,
+            strategy: 'session-scope', label: sessionScopeLabel,
+            menuTriggerLabel, candidateLabels, menuCandidates,
+            error: String(error?.message || error || 'session_scope_option_click_failed')
+          };
+        }
+        const confirmed = await confirmCardClosed(candidate.button);
+        return {
+          ok: confirmed, clicked: true, confirmed,
+          strategy: 'session-scope', label: sessionScopeLabel,
+          menuTriggerLabel, sessionScopeLabel, candidateLabels, menuCandidates,
+          error: confirmed ? null : 'session_scope_approval_not_confirmed'
+        };
+      }
+      return {
+        ok: false, clicked: true, confirmed: false,
+        strategy: 'session-scope', label: menuTriggerLabel,
+        menuTriggerLabel, candidateLabels, menuCandidates,
+        error: 'session_scope_option_not_found'
+      };
+    }
+
     try {
-      candidate.button.click();
+      dispatchPointerClick(candidate.button);
     } catch (error) {
       return {
-        ok: false,
-        clicked: false,
-        confirmed: false,
-        label: candidate.label,
-        candidateLabels,
+        ok: false, clicked: false, confirmed: false,
+        strategy: 'single-approval', label: candidate.label, candidateLabels,
         error: String(error?.message || error || 'approval_click_failed')
       };
     }
-    for (let index = 0; index < 20; index += 1) {
-      await sleep(100);
-      if (!candidate.button.isConnected || !visible(candidate.button)) {
-        return {
-          ok: true,
-          clicked: true,
-          confirmed: true,
-          label: candidate.label,
-          candidateLabels
-        };
-      }
-    }
+    const confirmed = await confirmCardClosed(candidate.button);
     return {
-      ok: false,
-      clicked: true,
-      confirmed: false,
-      label: candidate.label,
-      candidateLabels,
-      error: 'approval_click_not_confirmed'
+      ok: confirmed, clicked: true, confirmed,
+      strategy: 'single-approval', label: candidate.label, candidateLabels,
+      error: confirmed ? null : 'approval_click_not_confirmed'
     };
   })()
   """#
@@ -1413,6 +1584,32 @@ func prepareNewChatTarget(
   let previousConversationId = baseline["conversationId"] as? String
   let baselineWasBlank = (baseline["messageCount"] as? Int ?? 1) == 0 &&
     (baseline["inputTextLength"] as? Int ?? 1) == 0
+  if allowBlankConversationReuse && baselineWasBlank {
+    var stableBlankSamples = 0
+    for _ in 0..<12 {
+      let current = cdpValue(
+        port: port,
+        targetId: targetId,
+        expression: prepareBackgroundChatJS(
+          newChat: false,
+          confirmedChatMode: chatModeConfirmed
+        ),
+        timeout: timeout
+      )
+      let blankAndReady = current?["ok"] as? Bool == true
+        && (current?["messageCount"] as? Int ?? 1) == 0
+        && (current?["inputTextLength"] as? Int ?? 1) == 0
+      stableBlankSamples = blankAndReady ? stableBlankSamples + 1 : 0
+      if stableBlankSamples >= 3 {
+        var result = current ?? [:]
+        result["newChatClicked"] = false
+        result["blankConversationReused"] = true
+        result["stableSamples"] = stableBlankSamples
+        return result
+      }
+      Thread.sleep(forTimeInterval: 0.15)
+    }
+  }
   guard let clicked = cdpValue(
     port: port,
     targetId: targetId,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -49,9 +49,13 @@ func traceQueueApproval(
           || result["error"] as? String != nil else { return }
   let candidates = jsonString([
     "labels": result["candidateLabels"] ?? [],
+    "menuTriggerLabel": result["menuTriggerLabel"] ?? "",
+    "sessionScopeLabel": result["sessionScopeLabel"] ?? "",
+    "menuCandidates": result["menuCandidates"] ?? [],
   ]) ?? "{\"labels\":[]}"
   queueTrace(
-    "task=\(taskId) stage=approval-\(stage) strategy=per-card "
+    "task=\(taskId) stage=approval-\(stage) "
+      + "strategy=\(result["strategy"] as? String ?? "per-card") "
       + "clicked=\(result["clicked"] as? Bool == true) "
       + "confirmed=\(result["confirmed"] as? Bool == true) "
       + "label=\(result["label"] as? String ?? "none") "
@@ -95,7 +99,7 @@ func approveDedicatedAuthorizationWithDiagnostics(
     port: port,
     targetId: targetId,
     expression: autoApproveDedicatedAuthorizationJS(),
-    timeout: 4.0
+    timeout: 8.0
   )
   traceQueueApproval(
     result,
@@ -112,7 +116,8 @@ func approveDedicatedAuthorizationWithDiagnostics(
       label: "approval-\(safeTask)-\(safeStage)-after"
     )
     queueTrace(
-      "task=\(taskId) stage=approval-\(stage)-unconfirmed strategy=per-card "
+      "task=\(taskId) stage=approval-\(stage)-unconfirmed "
+        + "strategy=\(result?["strategy"] as? String ?? "per-card") "
         + "beforeScreenshot=\(screenshotPath ?? "none") "
         + "afterScreenshot=\(afterPath ?? "none") "
         + "error=\(result?["error"] as? String ?? "none")"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1351,7 +1351,7 @@ func startAutomationTask(
   task.workerTargetId = nil
   task.workerProfilePath = nil
   queueTrace("task=\(task.id) stage=create-worker begin")
-  guard let worker = createIndependentQueueWorkerTarget(&state) else {
+  guard var worker = createIndependentQueueWorkerTarget(&state) else {
     let detail = state.lastError ?? "unknown"
     throw NSError(
       domain: "chatgpt-auto-confirm",
@@ -1370,12 +1370,13 @@ func startAutomationTask(
       "task=\(task.id) stage=prepare-continuation begin "
         + "previousConversation=\(previousConversationId)"
     )
-    let navigationSucceeded = navigateHiddenConversation(
+    let restoration = restoreHiddenConversation(
       port: worker.port,
       targetId: worker.targetId,
       conversationId: previousConversationId
     )
-    if navigationSucceeded {
+    let restorationSucceeded = restoration["ok"] as? Bool == true
+    if restorationSucceeded {
       prepared = cdpValue(
         port: worker.port,
         targetId: worker.targetId,
@@ -1385,13 +1386,15 @@ func startAutomationTask(
     } else {
       prepared = [
         "ok": false,
-        "error": "continuation_navigation_failed",
+        "error": restoration["error"] as? String
+          ?? "continuation_navigation_failed",
         "conversationId": previousConversationId,
       ]
     }
     queueTrace(
       "task=\(task.id) stage=prepare-continuation "
-        + "navigated=\(navigationSucceeded) "
+        + "restored=\(restorationSucceeded) "
+        + "strategy=\(restoration["strategy"] as? String ?? "none") "
         + "clicked=\(prepared?["continuationClicked"] as? Bool == true) "
         + "newConversation=\(prepared?["conversationId"] as? String ?? "none") "
         + "error=\(prepared?["error"] as? String ?? "none")"
@@ -1409,16 +1412,43 @@ func startAutomationTask(
           + "reason=\(continuationError) "
           + "screenshot=\(screenshot ?? "none")"
       )
-      if var fallback = prepareNewChatTarget(
-        port: worker.port,
-        targetId: worker.targetId,
-        timeout: 4.0,
-        allowBlankConversationReuse: true
-      ) {
-        fallback["continuationFallback"] = true
-        fallback["continuationFailure"] = continuationError
-        fallback["previousConversationId"] = previousConversationId
-        prepared = fallback
+      let staleTargetId = worker.targetId
+      let stalePort = worker.port
+      let staleClosed = CDPClient.closeTarget(staleTargetId, portOverride: stalePort)
+      queueTrace(
+        "task=\(task.id) stage=prepare-continuation fallback=recreate-worker "
+          + "begin staleTarget=\(staleTargetId) closed=\(staleClosed)"
+      )
+      port = nil
+      targetId = nil
+      workerProfilePath = nil
+      if let replacement = createIndependentQueueWorkerTarget(&state) {
+        worker = replacement
+        port = replacement.port
+        targetId = replacement.targetId
+        workerProfilePath = replacement.profilePath
+        queueTrace(
+          "task=\(task.id) stage=prepare-continuation fallback=recreate-worker "
+            + "complete target=\(replacement.targetId)"
+        )
+        if var fallback = prepareNewChatTarget(
+          port: replacement.port,
+          targetId: replacement.targetId,
+          timeout: 4.0,
+          allowBlankConversationReuse: true
+        ) {
+          fallback["continuationFallback"] = true
+          fallback["continuationFailure"] = continuationError
+          fallback["previousConversationId"] = previousConversationId
+          fallback["replacementTarget"] = true
+          prepared = fallback
+        } else {
+          preparationFailure = "continuation_fallback_new_chat_failed"
+          prepared = nil
+        }
+      } else {
+        preparationFailure = "continuation_fallback_worker_create_failed"
+        prepared = nil
       }
     }
   } else {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -1,7 +1,18 @@
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import test from 'node:test';
+import { runInNewContext } from 'node:vm';
 import worker from '../worker/src/index.ts';
+
+const hiddenApprovalSource = readFileSync(
+  new URL('../native/HiddenChatAndApproval.swift', import.meta.url),
+  'utf8',
+);
+const approvalScriptMatch = hiddenApprovalSource.match(
+  /func autoApproveDedicatedAuthorizationJS\(\) -> String \{[\s\S]*?#"""([\s\S]*?)"""#/,
+);
+assert.ok(approvalScriptMatch, 'embedded authorization script must be extractable');
+const approvalScript = approvalScriptMatch[1].trim();
 
 const nativeDirectory = new URL('../native/', import.meta.url);
 const nativeSource = readdirSync(nativeDirectory)
@@ -89,6 +100,11 @@ test('initial outbound messages create a new Chat and same-task continuations us
   assert.match(nativeSource, /continue_in_new_task_button_not_found/);
   assert.match(nativeSource, /stage=prepare-continuation/);
   assert.match(nativeSource, /continuation_navigation_failed/);
+  assert.match(nativeSource, /restoreHiddenConversation/);
+  assert.match(nativeSource, /strategy=.*restoration/);
+  assert.match(nativeSource, /fallback=recreate-worker/);
+  assert.match(nativeSource, /continuation_fallback_new_chat_failed/);
+  assert.match(nativeSource, /blankConversationReused/);
   assert.match(nativeSource, /fallback=new-chat/);
   assert.match(nativeSource, /continuationFallback/);
   assert.match(nativeSource, /case \.visible:[\s\S]*queueUsesHostedRenderer\(\)/);
@@ -159,6 +175,12 @@ test('send_and_watch streams visible thinking and uses bounded same-task recover
   assert.match(nativeSource, /detectDedicatedAuthorizationJS/);
   assert.match(nativeSource, /sessionScopeLabels/);
   assert.match(nativeSource, /menuTriggerCount/);
+  assert.match(nativeSource, /session-scope/);
+  assert.match(nativeSource, /session_scope_option_not_found/);
+  assert.match(nativeSource, /dispatchPointerClick\(sessionControl\)/);
+  assert.match(nativeSource, /dispatchPointerClick\(sessionOption\)/);
+  assert.match(nativeSource, /sessionScopeLabel/);
+  assert.match(nativeSource, /timeout: 8\.0/);
   assert.match(nativeSource, /strategy=per-card/);
   assert.match(nativeSource, /approval-watcher-before/);
   assert.match(nativeSource, /approval-ipc-detected/);
@@ -521,6 +543,80 @@ test('native runtime stays in the background and never takes over the UI', () =>
   assert.match(nativeSource, /idleSystemSleepDisabled/);
   assert.match(nativeSource, /userInitiatedAllowingIdleSystemSleep/);
   assert.match(nativeSource, /flock\(descriptor, LOCK_EX\)/);
+});
+
+test('session-scoped approval opens the adjacent menu and selects the conversation option', async () => {
+  const clicks = [];
+  let menuOpen = false;
+  class FakeEvent {
+    constructor(type) { this.type = type; }
+  }
+  class FakeElement {
+    constructor(id, text, attributes = {}) {
+      this.id = id;
+      this.innerText = text;
+      this.textContent = text;
+      this.attributes = attributes;
+      this.disabled = false;
+      this.offsetWidth = 80;
+      this.offsetHeight = 24;
+      this.isConnected = true;
+      this.parentElement = null;
+    }
+    getAttribute(name) { return this.attributes[name] ?? null; }
+    getClientRects() { return this.isConnected ? [{}] : []; }
+    getBoundingClientRect() {
+      return { left: 0, top: 0, width: this.offsetWidth, height: this.offsetHeight };
+    }
+    querySelectorAll() { return []; }
+    dispatchEvent(event) {
+      if (event.type !== 'click') return true;
+      clicks.push(this.id);
+      if (this.id === 'session-trigger') menuOpen = true;
+      if (this.id === 'session-option') {
+        allow.isConnected = false;
+        allow.offsetWidth = 0;
+        allow.offsetHeight = 0;
+      }
+      return true;
+    }
+  }
+  const deny = new FakeElement('deny', 'Deny');
+  const allow = new FakeElement('allow', 'Allow');
+  const sessionTrigger = new FakeElement(
+    'session-trigger',
+    '',
+    { 'aria-label': 'Allow bhrum2 for this conversation', 'aria-haspopup': 'menu' },
+  );
+  const sessionOption = new FakeElement(
+    'session-option',
+    'Allow bhrum2 for this conversation',
+    { role: 'menuitem' },
+  );
+  const card = new FakeElement('card', 'Allow ChatGPT to use bhrum2?');
+  card.querySelectorAll = () => [deny, allow, sessionTrigger];
+  deny.parentElement = card;
+  allow.parentElement = card;
+  sessionTrigger.parentElement = card;
+  const document = {
+    querySelectorAll(selector) {
+      if (selector === 'button') return [deny, allow, sessionTrigger];
+      if (selector.includes('[role="menuitem"]')) return menuOpen ? [sessionOption] : [];
+      return [];
+    },
+  };
+  const result = await runInNewContext(approvalScript, {
+    document,
+    PointerEvent: FakeEvent,
+    MouseEvent: FakeEvent,
+    setTimeout,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.confirmed, true);
+  assert.equal(result.strategy, 'session-scope');
+  assert.equal(result.sessionScopeLabel, 'allow bhrum2 for this conversation');
+  assert.deepEqual(clicks, ['session-trigger', 'session-option']);
+  assert.equal(clicks.includes('allow'), false);
 });
 
 test('approval decisions do not inspect or block card contents', () => {


### PR DESCRIPTION
## Summary
- restore continuation conversations through the live Chat sidebar before attempting route navigation
- replace a renderer that becomes stuck on the startup spinner before falling back to a fresh Chat
- reuse a stable blank replacement Chat instead of unnecessarily navigating it again
- open the control beside `Allow` and select the conversation-scoped authorization option
- record the selected authorization strategy and menu labels in diagnostics
- add an executable DOM regression test proving the regular `Allow` button is not clicked when a session option exists

## Verification
- `npm run build:content`
- `node --experimental-strip-types --test test/*.test.mjs`
- 30 tests: 26 passed, 4 macOS-only tests skipped on bhrum2
- focused session-approval test passes
