### PR TITLE
Fix continuation control clicking after restored chats

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -1224,7 +1224,26 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
     const expectedConversationId = \(expected);
     const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
     const visible = element => !!(element
+      && !element.disabled
       && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
+    const dispatchPointerClick = element => {
+      const rect = element.getBoundingClientRect?.();
+      const clientX = rect ? rect.left + Math.max(1, rect.width / 2) : 1;
+      const clientY = rect ? rect.top + Math.max(1, rect.height / 2) : 1;
+      const pressed = {
+        bubbles: true, cancelable: true, composed: true,
+        button: 0, buttons: 1, clientX, clientY
+      };
+      element.dispatchEvent(new PointerEvent('pointerdown', {
+        ...pressed, pointerId: 1, pointerType: 'mouse', isPrimary: true
+      }));
+      element.dispatchEvent(new MouseEvent('mousedown', pressed));
+      element.dispatchEvent(new PointerEvent('pointerup', {
+        ...pressed, buttons: 0, pointerId: 1, pointerType: 'mouse', isPrimary: true
+      }));
+      element.dispatchEvent(new MouseEvent('mouseup', { ...pressed, buttons: 0 }));
+      element.dispatchEvent(new MouseEvent('click', { ...pressed, buttons: 0 }));
+    };
     const normalizeConversationId = value => {
       const raw = (value || '').trim();
       if (!raw) return '';
@@ -1257,9 +1276,16 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
       'article, [data-testid^="conversation-turn-"], '
         + '[data-content-search-turn-key], [data-turn-key]'
     ) || last?.parentElement?.parentElement || last;
-    const controls = [...(responseTurn?.querySelectorAll(
+    const responseControls = [...(responseTurn?.querySelectorAll(
       'button, a, [role="button"], [aria-label], [title]'
     ) || [])];
+    // Desktop releases sometimes portal the latest response actions outside
+    // the turn container. Include global controls, then prefer the last match
+    // so an older response cannot receive the continuation click.
+    const globalControls = [...document.querySelectorAll(
+      'button, a, [role="button"], [aria-label], [title]'
+    )];
+    const controls = [...new Set([...responseControls, ...globalControls])];
     const label = node => [
       node.getAttribute?.('aria-label') || '',
       node.getAttribute?.('title') || '',
@@ -1272,11 +1298,12 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
         || /从这里(?:继续|分支).*(?:新任务|新聊天)/.test(text)
         || /在新(?:的)?聊天中(?:创建)?分支/.test(text);
     };
-    let button = controls.find(node => visible(node) && isContinueControl(node));
+    let button = [...controls].reverse()
+      .find(node => visible(node) && isContinueControl(node));
     let overflowOpened = false;
     let overflowCandidates = [];
     if (!button) {
-      const overflow = controls.find(node => {
+      const overflow = [...controls].reverse().find(node => {
         const text = label(node);
         return visible(node) && (
           /^more actions(?:\\s|$)/.test(text)
@@ -1285,7 +1312,7 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
         );
       });
       if (overflow) {
-        overflow.click();
+        dispatchPointerClick(overflow);
         overflowOpened = true;
         for (let index = 0; index < 30 && !button; index += 1) {
           await sleep(100);
@@ -1295,7 +1322,7 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
               + '[data-headlessui-state] [role="menuitem"]'
           )].filter(visible);
           overflowCandidates = menuControls.map(label).filter(Boolean).slice(-30);
-          button = menuControls.find(isContinueControl) || null;
+          button = [...menuControls].reverse().find(isContinueControl) || null;
         }
       }
     }
@@ -1310,7 +1337,8 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
       };
     }
 
-    button.click();
+    const continuationLabel = label(button);
+    dispatchPointerClick(button);
     let stableConversationId = '';
     let stableSamples = 0;
     for (let index = 0; index < 120; index += 1) {
@@ -1334,6 +1362,7 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
             ok: true,
             continuationClicked: true,
             overflowOpened,
+            continuationLabel,
             previousConversationId: current,
             conversationId: nextConversationId,
             stableSamples
@@ -1348,6 +1377,7 @@ func continueInNewTaskJS(expectedConversationId: String? = nil) -> String {
       ok: false,
       error: 'continue_in_new_task_not_confirmed',
       overflowOpened,
+      continuationLabel,
       previousConversationId: current,
       conversationId: currentConversationId()
     };

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -400,6 +400,26 @@ func selectBackgroundConversationJS(_ conversationId: String) -> String {
   (async () => {
     const expected = \(expected);
     const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const rendered = element => !!(element
+      && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
+    const dispatchPointerClick = element => {
+      const rect = element.getBoundingClientRect?.();
+      const clientX = rect ? rect.left + Math.max(1, rect.width / 2) : 1;
+      const clientY = rect ? rect.top + Math.max(1, rect.height / 2) : 1;
+      const pressed = {
+        bubbles: true, cancelable: true, composed: true,
+        button: 0, buttons: 1, clientX, clientY
+      };
+      element.dispatchEvent(new PointerEvent('pointerdown', {
+        ...pressed, pointerId: 1, pointerType: 'mouse', isPrimary: true
+      }));
+      element.dispatchEvent(new MouseEvent('mousedown', pressed));
+      element.dispatchEvent(new PointerEvent('pointerup', {
+        ...pressed, buttons: 0, pointerId: 1, pointerType: 'mouse', isPrimary: true
+      }));
+      element.dispatchEvent(new MouseEvent('mouseup', { ...pressed, buttons: 0 }));
+      element.dispatchEvent(new MouseEvent('click', { ...pressed, buttons: 0 }));
+    };
     const portalId = () => {
       const raw = document.querySelector('[data-above-composer-conversation-id]')
         ?.getAttribute('data-above-composer-conversation-id') || '';
@@ -431,9 +451,16 @@ func selectBackgroundConversationJS(_ conversationId: String) -> String {
       let decoded = value;
       try { decoded = decodeURIComponent(value); } catch {}
       return decoded === expected || decoded.endsWith(`:${expected}`)
+        || decoded.endsWith(`/c/${expected}`)
+        || decoded.endsWith(`/work/conversation/${expected}`)
         || (expected.startsWith('local-chatgpt:') && decoded.includes(expected));
     };
     const rowMatches = row => {
+      const domCandidates = [
+        row.getAttribute?.('href'), row.getAttribute?.('data-conversation-id'),
+        row.getAttribute?.('data-thread-id'), row.getAttribute?.('data-testid')
+      ];
+      if (domCandidates.some(matches)) return true;
       const fiberKey = Object.keys(row).find(key => key.startsWith('__reactFiber$'));
       let fiber = fiberKey ? row[fiberKey] : null;
       // Stop before the virtual-list parent. That parent contains every item
@@ -455,25 +482,52 @@ func selectBackgroundConversationJS(_ conversationId: String) -> String {
         ? { ok: true, selected: false, alreadyActive: true, messagesReady: true, conversationId: current }
         : { ok: false, error: ready.error, expected, conversationId: current };
     }
-    const rows = [...document.querySelectorAll('[data-thread-title="true"]')]
-      .map(title => title.closest('[role="button"]')).filter(Boolean);
+    const directLinks = [...document.querySelectorAll(
+      `a[href*="/c/${expected}"], a[href*="/work/conversation/${expected}"], `
+        + `[data-conversation-id="${expected}"], [data-thread-id="${expected}"]`
+    )];
+    const titledRows = [...document.querySelectorAll('[data-thread-title="true"]')]
+      .map(title => title.closest('a, button, [role="button"]')).filter(Boolean);
+    const rows = [...new Set([...directLinks, ...titledRows])].filter(rendered);
     const row = rows.find(rowMatches);
-    if (!row) return { ok: false, error: 'conversation_sidebar_row_not_found', expected };
+    if (!row) {
+      return {
+        ok: false,
+        error: 'conversation_sidebar_row_not_found',
+        expected,
+        candidateRowCount: rows.length,
+        directLinkCount: directLinks.length
+      };
+    }
     const previousFingerprint = conversationFingerprint();
-    row.click();
+    const clickStrategy = directLinks.includes(row) ? 'direct-link' : 'sidebar-row';
+    dispatchPointerClick(row);
     for (let index = 0; index < 40; index += 1) {
       await sleep(150);
       const resolved = portalId();
       const input = document.querySelector('#prompt-textarea')
         || document.querySelector('[contenteditable="true"]');
       if (resolved && input && (matches(resolved) || rowMatches(row))) {
-        const ready = await waitForConversationBody(previousFingerprint, true);
+        const exactConversation = matches(resolved);
+        const ready = await waitForConversationBody(previousFingerprint, !exactConversation);
         return ready.ok
-          ? { ok: true, selected: true, messagesReady: true, conversationId: resolved }
-          : { ok: false, error: ready.error, expected, conversationId: resolved };
+          ? {
+              ok: true, selected: true, messagesReady: true,
+              conversationId: resolved, clickStrategy,
+              candidateRowCount: rows.length, directLinkCount: directLinks.length
+            }
+          : {
+              ok: false, error: ready.error, expected,
+              conversationId: resolved, clickStrategy,
+              candidateRowCount: rows.length, directLinkCount: directLinks.length
+            };
       }
     }
-    return { ok: false, error: 'conversation_sidebar_selection_timeout', expected };
+    return {
+      ok: false,
+      error: 'conversation_sidebar_selection_timeout', expected, clickStrategy,
+      candidateRowCount: rows.length, directLinkCount: directLinks.length
+    };
   })()
   """
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1387,7 +1387,7 @@ func startAutomationTask(
       prepared = [
         "ok": false,
         "error": restoration["error"] as? String
-          ?? "continuation_navigation_failed",
+          ?? "continuation_conversation_click_failed",
         "conversationId": previousConversationId,
       ]
     }
@@ -1395,7 +1395,9 @@ func startAutomationTask(
       "task=\(task.id) stage=prepare-continuation "
         + "restored=\(restorationSucceeded) "
         + "strategy=\(restoration["strategy"] as? String ?? "none") "
+        + "conversationClick=\(restoration["clickStrategy"] as? String ?? "none") "
         + "clicked=\(prepared?["continuationClicked"] as? Bool == true) "
+        + "continuationLabel=\(prepared?["continuationLabel"] as? String ?? "none") "
         + "newConversation=\(prepared?["conversationId"] as? String ?? "none") "
         + "error=\(prepared?["error"] as? String ?? "none")"
     )

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -14,6 +14,33 @@ const approvalScriptMatch = hiddenApprovalSource.match(
 assert.ok(approvalScriptMatch, 'embedded authorization script must be extractable');
 const approvalScript = approvalScriptMatch[1].trim();
 
+const chatScriptsSource = readFileSync(
+  new URL('../native/ChatScripts.swift', import.meta.url),
+  'utf8',
+);
+const extractTripleQuotedScript = (source, functionSignature) => {
+  const functionStart = source.indexOf(functionSignature);
+  assert.notEqual(functionStart, -1, `${functionSignature} must exist`);
+  const scriptStartMarker = 'return """';
+  const scriptStart = source.indexOf(scriptStartMarker, functionStart);
+  assert.notEqual(scriptStart, -1, `${functionSignature} script must start`);
+  const contentStart = scriptStart + scriptStartMarker.length;
+  const contentEnd = source.indexOf('"""', contentStart);
+  assert.notEqual(contentEnd, -1, `${functionSignature} script must end`);
+  return source.slice(contentStart, contentEnd).trim();
+};
+const selectConversationScript = extractTripleQuotedScript(
+  hiddenApprovalSource,
+  'func selectBackgroundConversationJS(_ conversationId: String) -> String',
+);
+const continueInNewTaskScript = extractTripleQuotedScript(
+  chatScriptsSource,
+  'func continueInNewTaskJS(expectedConversationId: String? = nil) -> String',
+);
+const renderInterpolatedSwiftScript = (script, expected) => script
+  .replace('\\(expected)', JSON.stringify(expected))
+  .replaceAll('\\\\', '\\');
+
 const nativeDirectory = new URL('../native/', import.meta.url);
 const nativeSource = readdirSync(nativeDirectory)
   .filter(name => name.endsWith('.swift'))
@@ -99,7 +126,7 @@ test('initial outbound messages create a new Chat and same-task continuations us
   assert.match(nativeSource, /continuationClicked/);
   assert.match(nativeSource, /continue_in_new_task_button_not_found/);
   assert.match(nativeSource, /stage=prepare-continuation/);
-  assert.match(nativeSource, /continuation_navigation_failed/);
+  assert.match(nativeSource, /continuation_conversation_click_failed/);
   assert.match(nativeSource, /restoreHiddenConversation/);
   assert.match(nativeSource, /strategy=.*restoration/);
   assert.match(nativeSource, /fallback=recreate-worker/);
@@ -543,6 +570,133 @@ test('native runtime stays in the background and never takes over the UI', () =>
   assert.match(nativeSource, /idleSystemSleepDisabled/);
   assert.match(nativeSource, /userInitiatedAllowingIdleSystemSleep/);
   assert.match(nativeSource, /flock\(descriptor, LOCK_EX\)/);
+});
+
+test('continuation clicks the original conversation and then Continue in new task', async () => {
+  const previousConversationId = '6a6b3d26-c654-83e8-8b6a-55ee1eb0719f';
+  const nextConversationId = '7b7c4e37-d765-94f9-9c77-66ff2fc072a0';
+  const clicks = [];
+  let activeConversationId = 'different-chat';
+  let overflowOpen = false;
+  class FakeEvent {
+    constructor(type) { this.type = type; }
+  }
+  class FakeElement {
+    constructor(id, text = '', attributes = {}) {
+      this.id = id;
+      this.innerText = text;
+      this.textContent = text;
+      this.attributes = attributes;
+      this.disabled = false;
+      this.offsetWidth = 120;
+      this.offsetHeight = 28;
+      this.isConnected = true;
+      this.parentElement = null;
+    }
+    getAttribute(name) { return this.attributes[name] ?? null; }
+    hasAttribute(name) { return this.attributes[name] !== undefined; }
+    getClientRects() { return this.isConnected ? [{}] : []; }
+    getBoundingClientRect() {
+      return { left: 0, top: 0, width: this.offsetWidth, height: this.offsetHeight };
+    }
+    closest() { return this.parentElement; }
+    querySelectorAll() { return []; }
+    dispatchEvent(event) {
+      if (event.type !== 'click') return true;
+      clicks.push(this.id);
+      if (this.id === 'conversation-row') activeConversationId = previousConversationId;
+      if (this.id === 'more-actions') overflowOpen = true;
+      if (this.id === 'continue-option') activeConversationId = nextConversationId;
+      return true;
+    }
+  }
+  const assistant = new FakeElement('assistant', 'Completed response');
+  assistant.attributes['data-message-author-role'] = 'assistant';
+  const conversationRow = new FakeElement(
+    'conversation-row',
+    'Marketplace continuation',
+    { href: `/c/${previousConversationId}` },
+  );
+  const prompt = new FakeElement('prompt');
+  const portal = {
+    getAttribute(name) {
+      return name === 'data-above-composer-conversation-id'
+        ? `chatgpt:${activeConversationId}` : null;
+    },
+  };
+  const selectDocument = {
+    querySelector(selector) {
+      if (selector === '[data-above-composer-conversation-id]') return portal;
+      if (selector === '#prompt-textarea') return prompt;
+      if (selector === '[contenteditable="true"]') return null;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector.includes('[data-message-author-role]')) return [assistant];
+      if (selector.startsWith('a[href*=')) return [conversationRow];
+      if (selector === '[data-thread-title="true"]') return [];
+      return [];
+    },
+  };
+  const renderedSelectScript = renderInterpolatedSwiftScript(
+    selectConversationScript,
+    previousConversationId,
+  );
+  const selectResult = await runInNewContext(renderedSelectScript, {
+    document: selectDocument,
+    PointerEvent: FakeEvent,
+    MouseEvent: FakeEvent,
+    setTimeout,
+  });
+  assert.equal(selectResult.ok, true);
+  assert.equal(selectResult.clickStrategy, 'direct-link');
+  assert.equal(selectResult.conversationId, previousConversationId);
+
+  const moreActions = new FakeElement('more-actions', '', { 'aria-label': 'More actions' });
+  const continueOption = new FakeElement(
+    'continue-option',
+    'Continue in new task',
+    { role: 'menuitem' },
+  );
+  const responseTurn = new FakeElement('response-turn');
+  responseTurn.querySelectorAll = () => [moreActions];
+  assistant.parentElement = responseTurn;
+  assistant.closest = () => responseTurn;
+  const main = {
+    querySelectorAll() { return [assistant]; },
+  };
+  const continueDocument = {
+    querySelector(selector) {
+      if (selector === '[data-above-composer-conversation-id]') return portal;
+      if (selector === 'main') return main;
+      if (selector.includes('textarea')) return prompt;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector.startsWith('button, a')) return [moreActions];
+      if (selector.includes('[role="menuitem"]')) return overflowOpen ? [continueOption] : [];
+      return [];
+    },
+  };
+  const renderedContinueScript = renderInterpolatedSwiftScript(
+    continueInNewTaskScript,
+    previousConversationId,
+  );
+  const continueResult = await runInNewContext(renderedContinueScript, {
+    document: continueDocument,
+    PointerEvent: FakeEvent,
+    MouseEvent: FakeEvent,
+    setTimeout,
+  });
+  assert.equal(continueResult.ok, true);
+  assert.equal(continueResult.continuationClicked, true);
+  assert.equal(continueResult.continuationLabel, 'continue in new task');
+  assert.equal(continueResult.conversationId, nextConversationId);
+  assert.deepEqual(clicks, [
+    'conversation-row',
+    'more-actions',
+    'continue-option',
+  ]);
 });
 
 test('session-scoped approval opens the adjacent menu and selects the conversation option', async () => {


### PR DESCRIPTION
## Root cause
Run 30538192243 repeatedly logged `continuation_navigation_failed`. Its diagnostic screenshots show the renderer stuck on the ChatGPT startup spinner after direct page navigation, so the runtime never reached the response action that creates a continuation.

A second concrete bug was found while reproducing the click chain: the sidebar lookup discovered links such as `/c/<conversationId>`, but its ownership matcher only accepted a bare ID or `chatgpt:<ID>`. The real conversation link was therefore rejected and not clicked.

## Fix
- recognize `/c/<conversationId>` and `/work/conversation/<conversationId>` links as the target conversation
- click the target sidebar/direct conversation entry with full pointer and mouse events
- accept the exact portal conversation ID without requiring a stale virtualized body fingerprint to change
- search the latest response actions globally when desktop portals them outside the response turn
- click `More actions` and `Continue in new task` with full pointer events
- record the conversation click strategy and the exact continuation label in queue traces
- replace the misleading fallback error `continuation_navigation_failed` with `continuation_conversation_click_failed`
- add an executable DOM regression test proving the complete click sequence: original conversation → More actions → Continue in new task

## Verification
- `npm run build:content`
- `node --experimental-strip-types --test test/*.test.mjs`
- 31 tests: 27 passed, 4 macOS-only tests skipped
- the executable continuation test passes and asserts the exact click order