### PR TITLE
Keep ChatGPT continuous runner alive after transient connector failures

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
@@ -161,12 +161,14 @@ const failureFingerprint = tasks => JSON.stringify(tasks
     lastError: task.lastError || null,
     hiddenWorkerLastError: task.hiddenWorkerLastError || null,
   })));
-const isNonRecoverableFailure = task => {
-  const detail = [task.lastError, task.hiddenWorkerLastError]
-    .filter(Boolean)
-    .join(' ');
-  return /model_selection\s*:|model_picker_not_found|quick_chat_thinking_not_selected|reasoning_high_not_selected|target_model_not_selected|connector_selection_not_confirmed|task_continuation_limit_reached|dependency_not_completed/.test(detail.replace(/\s+/g, ' '));
-};
+const failureDetail = task => [task.lastError, task.hiddenWorkerLastError]
+  .filter(Boolean)
+  .join(' ')
+  .replace(/\s+/g, ' ');
+const isNonRecoverableFailure = task =>
+  /model_selection\s*:|model_picker_not_found|quick_chat_thinking_not_selected|reasoning_high_not_selected|target_model_not_selected|task_continuation_limit_reached|dependency_not_completed/.test(
+    failureDetail(task),
+  );
 const watchdogDiagnostics = result => ({
   ok: result?.ok !== false,
   recovered: result?.recovered === true,
@@ -206,16 +208,19 @@ while (Date.now() < deadline) {
   }
   const allTerminal = tasks.length > 0 && tasks.every(task =>
     ['completed', 'cancelled', 'failed', 'blocked'].includes(task.status));
-  const hasRecoverableTerminalFailure = tasks.some(task =>
+  const recoverableTerminalTasks = tasks.filter(task =>
     ['failed', 'blocked'].includes(task.status) && !isNonRecoverableFailure(task));
+  const hasRecoverableTerminalFailure = recoverableTerminalTasks.length > 0;
   if (allTerminal && !hasRecoverableTerminalFailure) {
     writeResult('failed', queue, 'terminal_task_failure');
     process.exit(1);
   }
 
-  const needsRecovery = tasks.some(task =>
-    (['failed', 'blocked'].includes(task.status) && !isNonRecoverableFailure(task)) ||
-    (task.lastError && String(task.lastError).includes('not_chat_surface')));
+  const needsWatchdogRecovery = tasks.some(task =>
+    task.status === 'running'
+    && task.lastError
+    && String(task.lastError).includes('not_chat_surface'));
+  const needsRecovery = hasRecoverableTerminalFailure || needsWatchdogRecovery;
   if (needsRecovery && Date.now() - lastRecovery >= recoveryIntervalMs) {
     const currentFailureFingerprint = failureFingerprint(tasks);
     if (currentFailureFingerprint === lastFailureFingerprint) {
@@ -225,14 +230,46 @@ while (Date.now() < deadline) {
       sameFailureRecoveries = 1;
     }
     if (sameFailureRecoveries > maxSameFailureRecoveries) {
-      writeResult('failed', queue, 'repeated_terminal_task_failure');
-      process.exit(1);
+      // A recoverable UI/runtime failure must never cut the continuous runner
+      // chain. Yield the encrypted queue state to the next Actions run instead
+      // of reporting a terminal failure.
+      writeResult('incomplete', queue, 'repeated_recoverable_task_failure');
+      process.exit(0);
     }
-    const recovery = run('queue_watchdog', { staleAfterSeconds: 300, force: true });
-    process.stdout.write(
-      `WATCHDOG_RECOVERY attempt=${sameFailureRecoveries} ` +
-      `${JSON.stringify(watchdogDiagnostics(recovery))}\n`,
-    );
+
+    const retryResults = [];
+    for (const task of recoverableTerminalTasks) {
+      try {
+        const retry = run('queue_retry', {
+          taskId: task.id,
+          feedback: 'GitHub Actions 检测到可恢复的 Chat/连接器运行时失败。请重建隐藏 Chat，并从同一 checkout 的最新落盘进度继续。',
+        });
+        retryResults.push({
+          id: task.id,
+          ok: true,
+          status: retry?.retriedTask?.status || null,
+        });
+      } catch (error) {
+        retryResults.push({
+          id: task.id,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (retryResults.length > 0) {
+      process.stdout.write(
+        `QUEUE_RETRY_RECOVERY attempt=${sameFailureRecoveries} ${JSON.stringify(retryResults)}\n`,
+      );
+    }
+
+    if (needsWatchdogRecovery || retryResults.some(result => !result.ok)) {
+      const recovery = run('queue_watchdog', { staleAfterSeconds: 300, force: true });
+      process.stdout.write(
+        `WATCHDOG_RECOVERY attempt=${sameFailureRecoveries} ` +
+        `${JSON.stringify(watchdogDiagnostics(recovery))}\n`,
+      );
+    }
     lastRecovery = Date.now();
   }
   await new Promise(resolve => setTimeout(resolve, pollIntervalMs));

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'node:url';
 const controller = fileURLToPath(
   new URL('../scripts/run-actions-controller.mjs', import.meta.url));
 
-test('Actions controller reports repeated terminal failures without chaining for six hours', () => {
+test('Actions controller yields repeated recoverable failures to the next workflow run', () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), 'chatgpt-actions-controller-'));
   const runtimePath = path.join(directory, 'fake-runtime.mjs');
   const resultPath = path.join(directory, 'action-result.json');
@@ -24,6 +24,8 @@ test('Actions controller reports repeated terminal failures without chaining for
 const command = process.argv[2];
 if (command === 'queue_watchdog') {
   console.log(JSON.stringify({ ok: true, recovered: true }));
+} else if (command === 'queue_retry') {
+  console.log(JSON.stringify({ ok: true, retriedTask: { status: 'queued' } }));
 } else if (command === 'queue_status') {
   console.log(JSON.stringify({
     ok: true,
@@ -66,12 +68,12 @@ if (command === 'queue_watchdog') {
         ACTION_MAX_SAME_FAILURE_RECOVERIES: '1',
       },
     });
-    assert.equal(result.status, 1);
-    assert.match(result.stdout, /WATCHDOG_RECOVERY/);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /QUEUE_RETRY_RECOVERY/);
     assert.match(result.stdout, /ACTION_RESULT/);
     const report = JSON.parse(readFileSync(resultPath, 'utf8'));
-    assert.equal(report.status, 'failed');
-    assert.equal(report.reason, 'repeated_terminal_task_failure');
+    assert.equal(report.status, 'incomplete');
+    assert.equal(report.reason, 'repeated_recoverable_task_failure');
     assert.deepEqual(report.counts, { failed: 1 });
     assert.equal(report.tasks[0].id, 'broken-task');
     assert.equal(report.tasks[0].lastError, 'new_chat_prepare_failed');
@@ -82,6 +84,59 @@ if (command === 'queue_watchdog') {
     assert.match(result.stdout, /最终结果/);
     assert.doesNotMatch(result.stdout, /QUEUE_PAGE \[/);
     assert.ok(result.stdout.split('\n').every(line => line.length < 4_096));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('Actions controller retries transient connector-selection failures', () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'chatgpt-actions-connector-'));
+  const runtimePath = path.join(directory, 'fake-runtime.mjs');
+  const resultPath = path.join(directory, 'action-result.json');
+  try {
+    writeFileSync(runtimePath, `#!/usr/bin/env node
+const command = process.argv[2];
+if (command === 'queue_watchdog') {
+  console.log(JSON.stringify({ ok: true, recovered: false }));
+} else if (command === 'queue_retry') {
+  console.log(JSON.stringify({ ok: true, retriedTask: { status: 'queued' } }));
+} else if (command === 'queue_status') {
+  console.log(JSON.stringify({
+    ok: true,
+    counts: { failed: 1 },
+    tasks: [{
+      id: 'connector-task',
+      status: 'failed',
+      attempts: 18,
+      lastError: '页面发送失败（connector_confirmation: connector_selection_not_confirmed）',
+      hiddenWorkerLastError: null,
+    }],
+  }));
+} else {
+  console.log(JSON.stringify({ ok: false, message: 'unexpected command' }));
+  process.exitCode = 1;
+}
+`);
+    chmodSync(runtimePath, 0o755);
+    const result = spawnSync(process.execPath, [controller], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        CHATGPT_AUTO_CONFIRM_NATIVE: runtimePath,
+        ACTION_RESULT_PATH: resultPath,
+        ACTION_SESSION_SECONDS: '2',
+        ACTION_POLL_INTERVAL_MS: '10',
+        ACTION_RECOVERY_INTERVAL_MS: '10',
+        ACTION_MAX_SAME_FAILURE_RECOVERIES: '1',
+      },
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /QUEUE_RETRY_RECOVERY/);
+    const report = JSON.parse(readFileSync(resultPath, 'utf8'));
+    assert.equal(report.status, 'incomplete');
+    assert.equal(report.reason, 'repeated_recoverable_task_failure');
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -128,7 +183,7 @@ if (command === 'queue_watchdog') {
       },
     });
     assert.equal(result.status, 1);
-    assert.doesNotMatch(result.stdout, /WATCHDOG_RECOVERY/);
+    assert.doesNotMatch(result.stdout, /WATCHDOG_RECOVERY|QUEUE_RETRY_RECOVERY/);
     const report = JSON.parse(readFileSync(resultPath, 'utf8'));
     assert.equal(report.status, 'failed');
     assert.equal(report.reason, 'terminal_task_failure');


### PR DESCRIPTION
## 问题

Actions run `30544271011` 在第 27 次续作创建新 Chat 时遇到 `connector_selection_not_confirmed`。控制器把该瞬时 UI/连接器失败分类成永久失败，写出 `terminal_task_failure`；工作流末尾只会对 `incomplete` 派发下一轮，因此持续队列被切断。

## 修复

- 将连接器选择失败视为可恢复的运行时失败，而不是确定性永久失败。
- 对失败/阻塞的可恢复任务调用原生 `queue_retry`，清理旧隐藏 Chat 并从同一 checkout 的落盘进度继续。
- 同一种可恢复错误超过本轮恢复预算时，写出 `incomplete` / `repeated_recoverable_task_failure` 并正常退出，让现有工作流上传加密状态并派发下一轮。
- 保留模型选择失败、任务续作上限、依赖失败等确定性错误的终止行为。
- 增加连接器失败和跨 Run 交棒的回归测试。

## 目标行为

一次或多次 Chat/连接器 UI 波动不会再导致连续 runner 永久停止；状态会在当前 Run 内重试，必要时跨 Run 持续续跑。