### PR TITLE
fix(auto-confirm): tolerate stalled desktop CDP bootstrap

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -77,30 +77,68 @@ const connect = async target => {
     socket.addEventListener('error', onError, { once: true });
   });
   let sequence = 0;
-  const call = (method, params = {}) => new Promise((resolve, reject) => {
+  const call = (method, params = {}, timeoutMs = 30_000) => new Promise((resolve, reject) => {
     const id = ++sequence;
-    const timer = setTimeout(() => {
-      socket.removeEventListener('message', onMessage);
-      reject(new Error(`${method} timed out`));
-    }, 30_000);
-    const onMessage = event => {
-      const message = JSON.parse(String(event.data));
-      if (message.id !== id) return;
+    let settled = false;
+    const cleanup = () => {
       clearTimeout(timer);
       socket.removeEventListener('message', onMessage);
-      if (message.error) reject(new Error(`${method} failed`));
-      else resolve(message.result || {});
+      socket.removeEventListener('close', onClose);
+      socket.removeEventListener('error', onError);
     };
+    const finish = (handler, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      handler(value);
+    };
+    const onMessage = event => {
+      let message;
+      try {
+        message = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      if (message.id !== id) return;
+      if (message.error) {
+        finish(reject, new Error(`${method} failed: ${JSON.stringify(message.error)}`));
+      } else {
+        finish(resolve, message.result || {});
+      }
+    };
+    const onClose = () => finish(reject, new Error(`${method} failed because the CDP socket closed`));
+    const onError = () => finish(reject, new Error(`${method} failed because the CDP socket errored`));
+    const timer = setTimeout(() => {
+      finish(reject, new Error(`${method} timed out`));
+    }, timeoutMs);
     socket.addEventListener('message', onMessage);
-    socket.send(JSON.stringify({ id, method, params }));
+    socket.addEventListener('close', onClose, { once: true });
+    socket.addEventListener('error', onError, { once: true });
+    try {
+      socket.send(JSON.stringify({ id, method, params }));
+    } catch (error) {
+      finish(reject, error instanceof Error ? error : new Error(String(error)));
+    }
   });
   return { socket, call };
 };
 
+const optionalCall = async (call, method, params = {}, timeoutMs = 5_000) => {
+  try {
+    await call(method, params, timeoutMs);
+    return true;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Optional CDP command ${method} failed: ${detail}\n`);
+    return false;
+  }
+};
+
 const activate = async call => {
-  await call('Page.setWebLifecycleState', { state: 'active' });
-  await call('Emulation.setFocusEmulationEnabled', { enabled: true });
-  await call('Emulation.setIdleOverride', {
+  // New ChatGPT desktop builds can leave Page.setWebLifecycleState unanswered.
+  // Focus hints improve hosted rendering but must never abort cookie bootstrap.
+  await optionalCall(call, 'Emulation.setFocusEmulationEnabled', { enabled: true });
+  await optionalCall(call, 'Emulation.setIdleOverride', {
     isUserActive: true,
     isScreenUnlocked: true,
   });
@@ -108,7 +146,6 @@ const activate = async call => {
 
 const target = await findTarget(120_000, 'ChatGPT app shell');
 const { socket, call } = await connect(target);
-await activate(call);
 
 if (mode !== 'verify') {
   await call('Network.setCookies', { cookies: payload.cookies });
@@ -127,17 +164,12 @@ if (mode !== 'verify') {
   }
 }
 
-if (mode === 'restore-and-verify') {
-  await call('Runtime.evaluate', {
-    expression: `(() => {
-      document.dispatchEvent(new Event('visibilitychange'));
-      window.dispatchEvent(new Event('focus'));
-      setTimeout(() => location.reload(), 0);
-      return true;
-    })()`,
-    returnByValue: true,
-  });
+if (mode === 'restore' || mode === 'restore-and-verify') {
+  // Page.reload is a bounded request and is more reliable than evaluating
+  // location.reload() inside a renderer that may still be suspended.
+  await optionalCall(call, 'Page.reload', { ignoreCache: true }, 10_000);
 }
+await activate(call);
 
 // Hosted macOS can leave the visible controller blank after reload. The
 // native queue must be allowed to create and verify the real Chat renderer.
@@ -157,46 +189,53 @@ let verified = false;
 let lastState = {};
 while (Date.now() < verificationDeadline) {
   await sleep(2_000);
-  await activate(call);
-  const evaluation = await call('Runtime.evaluate', {
-    expression: `(() => {
-      const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
-      const visible = element => !!(element && (
-        element.offsetWidth || element.offsetHeight || element.getClientRects().length
-      ));
-      const bodyText = normalize(document.body?.innerText).slice(0, 12000);
-      const controls = [...document.querySelectorAll(
-        'button, [role="button"], [role="tab"], [aria-label]'
-      )].filter(visible);
-      const labels = controls.map(element => normalize([
-        element.innerText,
-        element.textContent,
-        element.getAttribute('aria-label'),
-        element.getAttribute('title')
-      ].filter(Boolean).join(' ')));
-      const exact = label => labels.some(value => value.toLowerCase() === label);
-      const hasChat = exact('chat') || exact('聊天');
-      const hasWork = exact('work') || exact('工作');
-      const currentMode = labels.find(value =>
-        /current mode|当前模式|目前模式/i.test(value)
-      ) || '';
-      const asksForLogin = /(^|\\n)(log in|sign up|登录|登入|註冊|注册)(\\n|$)/i.test(bodyText);
-      const workComposer = !!document.querySelector('[data-codex-composer="true"]');
-      return {
-        hasChat,
-        hasWork,
-        currentMode: currentMode.slice(0, 160),
-        asksForLogin,
-        workComposer,
-        bodyLength: bodyText.length,
-        url: location.href,
-        bridge: !!window.electronBridge,
-        visibility: document.visibilityState,
-        readyState: document.readyState
-      };
-    })()`,
-    returnByValue: true,
-  });
+  let evaluation;
+  try {
+    evaluation = await call('Runtime.evaluate', {
+      expression: `(() => {
+        const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+        const visible = element => !!(element && (
+          element.offsetWidth || element.offsetHeight || element.getClientRects().length
+        ));
+        const bodyText = normalize(document.body?.innerText).slice(0, 12000);
+        const controls = [...document.querySelectorAll(
+          'button, [role="button"], [role="tab"], [aria-label]'
+        )].filter(visible);
+        const labels = controls.map(element => normalize([
+          element.innerText,
+          element.textContent,
+          element.getAttribute('aria-label'),
+          element.getAttribute('title')
+        ].filter(Boolean).join(' ')));
+        const exact = label => labels.some(value => value.toLowerCase() === label);
+        const hasChat = exact('chat') || exact('聊天');
+        const hasWork = exact('work') || exact('工作');
+        const currentMode = labels.find(value =>
+          /current mode|当前模式|目前模式/i.test(value)
+        ) || '';
+        const asksForLogin = /(^|\\n)(log in|sign up|登录|登入|註冊|注册)(\\n|$)/i.test(bodyText);
+        const workComposer = !!document.querySelector('[data-codex-composer="true"]');
+        return {
+          hasChat,
+          hasWork,
+          currentMode: currentMode.slice(0, 160),
+          asksForLogin,
+          workComposer,
+          bodyLength: bodyText.length,
+          url: location.href,
+          bridge: !!window.electronBridge,
+          visibility: document.visibilityState,
+          readyState: document.readyState
+        };
+      })()`,
+      returnByValue: true,
+    }, 15_000);
+  } catch (error) {
+    lastState = {
+      cdpError: error instanceof Error ? error.message : String(error),
+    };
+    continue;
+  }
   lastState = evaluation.result?.value || {};
   if (
     !lastState.asksForLogin

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -40,6 +40,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /verification script waits for the refreshed authenticated shell/);
   assert.match(restoreSessionScript, /mode === 'restore'/);
   assert.match(restoreSessionScript, /process\.exit\(0\)/);
+  assert.match(restoreSessionScript, /Page\.reload/);
+  assert.match(restoreSessionScript, /Optional CDP command/);
+  assert.doesNotMatch(restoreSessionScript, /Page\.setWebLifecycleState/);
   assert.doesNotMatch(actionsWorkflow, /pkill -x ChatGPT/);
   assert.match(actionsWorkflow, /Launch authenticated desktop shell/);
   assert.match(actionsWorkflow, /Launch authenticated desktop shell\n\s+timeout-minutes: 6/);


### PR DESCRIPTION
## Summary
- stop treating `Page.setWebLifecycleState` as a required desktop bootstrap command
- make focus/idle CDP hints best-effort with bounded timeouts
- use bounded `Page.reload` after restoring ChatGPT cookies
- harden CDP request cleanup when the socket closes or errors
- add a contract regression test so lifecycle activation cannot become a fatal dependency again

## Root cause
Run 30555519922 job 90914857631 exited in `Launch authenticated desktop shell` because `Page.setWebLifecycleState` timed out. The retry then observed `targets=[]`, and the fallback restore path failed before the persistent queue could start.

## Expected result
A transient or unsupported lifecycle/focus CDP command no longer terminates the six-hour runner. Cookie restoration proceeds, the renderer is reloaded with a bounded request, and verification continues.