### PR TITLE
Make ChatGPT Actions tasks live, versioned, and machine-reportable

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
@@ -103,6 +103,9 @@ const syncControl = () => {
   const existing = Array.isArray(queue.tasks) ? queue.tasks : [];
   const desiredTasks = Array.isArray(control.tasks) ? control.tasks : [];
   const desiredIds = new Set(desiredTasks.map(runtimeId));
+  const runtimeIdsByLogicalId = new Map(
+    desiredTasks.filter(task => task?.id).map(task => [task.id, runtimeId(task)]),
+  );
   const cancelled = [];
   const enqueued = [];
 
@@ -135,6 +138,8 @@ const syncControl = () => {
       tasks: [{
         ...task,
         id: desiredId,
+        dependsOn: (Array.isArray(task.dependsOn) ? task.dependsOn : [])
+          .map(dependency => runtimeIdsByLogicalId.get(dependency) || dependency),
         prompt,
       }],
       start: true,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
@@ -1,0 +1,241 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const runtime = process.env.CHATGPT_AUTO_CONFIRM_NATIVE ||
+  fileURLToPath(new URL('../runtime/macos/chatgpt-auto-confirm', import.meta.url));
+const controller = fileURLToPath(new URL('./run-actions-controller.mjs', import.meta.url));
+const resultPath = process.env.ACTION_RESULT_PATH || 'action-result.json';
+const repository = process.env.GITHUB_REPOSITORY || 'bhrumom/fabushi';
+const controlPath = process.env.CHATGPT_AUTO_CONFIRM_TASK_CONTROL_PATH ||
+  '.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json';
+const controlRef = process.env.CHATGPT_AUTO_CONFIRM_TASK_CONTROL_REF || 'main';
+const pollSeconds = Math.max(15, Number(
+  process.env.CHATGPT_AUTO_CONFIRM_TASK_CONTROL_POLL_SECONDS || 30,
+));
+const sessionSeconds = Math.min(
+  20_700,
+  Math.max(300, Number(process.env.ACTION_SESSION_SECONDS || 20_100)),
+);
+const deadline = Date.now() + sessionSeconds * 1_000;
+
+const native = (command, params = undefined) => {
+  const args = [command];
+  if (params !== undefined) args.push(JSON.stringify(params));
+  const result = spawnSync(runtime, args, {
+    encoding: 'utf8',
+    env: process.env,
+    timeout: 120_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const line = result.stdout.trim().split(/\r?\n/).at(-1);
+  if (!line) throw new Error(`${command} returned no JSON: ${result.stderr}`);
+  const payload = JSON.parse(line);
+  if (result.status !== 0 || payload.ok === false) {
+    throw new Error(`${command} failed: ${payload.errorCode || payload.message || result.stderr}`);
+  }
+  return payload;
+};
+
+const fetchControl = () => {
+  const result = spawnSync('gh', [
+    'api', '--method', 'GET',
+    `repos/${repository}/contents/${controlPath}`,
+    '-f', `ref=${controlRef}`,
+  ], {
+    encoding: 'utf8',
+    env: process.env,
+    timeout: 60_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`task control fetch failed: ${result.stderr || result.stdout}`);
+  }
+  const envelope = JSON.parse(result.stdout);
+  const raw = Buffer.from(String(envelope.content || '').replace(/\s+/g, ''), 'base64')
+    .toString('utf8');
+  const control = JSON.parse(raw);
+  control._blobSha = envelope.sha;
+  control._source = envelope.html_url ||
+    `https://github.com/${repository}/blob/${controlRef}/${controlPath}`;
+  return control;
+};
+
+const reportContract = `
+\n最终回复协议（必须执行，优先于任何旧版“完成时正常回复”的说明）：
+无论任务完成、未完成还是阻塞，最终回复末尾都必须输出且只输出一个完整机器报告。不要把 JSON 放进 Markdown 代码块。
+MAHAYANA_TASK_REPORT_V1_BEGIN
+{"protocol":"mahayana.task-report.v1","status":"complete|incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项；complete 时必须为空数组"],"blockers":["真实卡点；complete 时必须为空数组"],"verification":["可复核验证证据"],"next_connector":"下一新 Chat 的 connector；无需切换则为空字符串","next_task":"下一轮完整续作指令；complete 时必须为空字符串"}
+MAHAYANA_TASK_REPORT_V1_END
+任务全部完成时 status 必须为 complete，remaining、blockers 必须为空数组，next_task 必须为空字符串。不得仅用自然语言声称完成。
+`;
+
+const specificationBlock = (control, task) => {
+  const files = [...new Set([
+    ...(Array.isArray(control.specificationFiles) ? control.specificationFiles : []),
+    ...(Array.isArray(task.specificationFiles) ? task.specificationFiles : []),
+  ])];
+  const urls = [...new Set([
+    ...(Array.isArray(control.specificationURLs) ? control.specificationURLs : []),
+    ...(Array.isArray(task.specificationURLs) ? task.specificationURLs : []),
+  ])];
+  if (files.length === 0 && urls.length === 0) return '';
+  return `\n\n任务规范（开始工作前必须读取；与旧聊天冲突时以当前 goalVersion 和这些规范为准）：\n` +
+    files.map(value => `- 仓库文件：${value}`).concat(
+      urls.map(value => `- 在线链接：${value}`),
+    ).join('\n');
+};
+
+const runtimeId = task => `${task.id}--v${Math.max(1, Number(task.goalVersion || 1))}`;
+const logicalPrefix = task => `${task.id}--v`;
+
+let activeControl = null;
+let lastBlobSha = '';
+
+const syncControl = () => {
+  const control = fetchControl();
+  activeControl = control;
+  if (control._blobSha === lastBlobSha) {
+    return { changed: false, revision: control.revision || control._blobSha };
+  }
+
+  const queue = native('queue_status');
+  const existing = Array.isArray(queue.tasks) ? queue.tasks : [];
+  const desiredTasks = Array.isArray(control.tasks) ? control.tasks : [];
+  const desiredIds = new Set(desiredTasks.map(runtimeId));
+  const cancelled = [];
+  const enqueued = [];
+
+  for (const task of desiredTasks) {
+    if (!task?.id || !task?.title || !task?.prompt) continue;
+    const desiredId = runtimeId(task);
+    for (const current of existing) {
+      const staleVersion = current.id === task.id ||
+        (current.id.startsWith(logicalPrefix(task)) && current.id !== desiredId);
+      if (staleVersion && !['cancelled', 'completed'].includes(current.status)) {
+        try {
+          native('queue_cancel', { taskId: current.id });
+          cancelled.push(current.id);
+        } catch (error) {
+          process.stderr.write(`TASK_CONTROL_CANCEL_WARNING ${current.id} ${error.message}\n`);
+        }
+      }
+    }
+    if (existing.some(current => current.id === desiredId)) continue;
+
+    const prompt = [
+      `动态任务控制版本：${control.revision || control._blobSha}。`,
+      `逻辑任务：${task.id}；目标版本：${Math.max(1, Number(task.goalVersion || 1))}。`,
+      task.prompt,
+      specificationBlock(control, task),
+      reportContract,
+    ].filter(Boolean).join('\n\n');
+
+    native('queue_enqueue', {
+      tasks: [{
+        ...task,
+        id: desiredId,
+        prompt,
+      }],
+      start: true,
+      maxConcurrent: Math.min(4, Math.max(1, Number(control.maxConcurrent || 2))),
+      reviewGate: control.reviewGate ?? false,
+    });
+    enqueued.push(desiredId);
+  }
+
+  if (control.authoritative === true) {
+    for (const current of existing) {
+      const managed = desiredTasks.some(task =>
+        current.id === task.id || current.id.startsWith(logicalPrefix(task)));
+      if (!managed && !desiredIds.has(current.id) &&
+          !['cancelled', 'completed'].includes(current.status)) {
+        try {
+          native('queue_cancel', { taskId: current.id });
+          cancelled.push(current.id);
+        } catch (error) {
+          process.stderr.write(`TASK_CONTROL_CANCEL_WARNING ${current.id} ${error.message}\n`);
+        }
+      }
+    }
+  }
+
+  lastBlobSha = control._blobSha;
+  const result = {
+    changed: true,
+    revision: control.revision || control._blobSha,
+    source: control._source,
+    enqueued,
+    cancelled,
+    keepAlive: control.keepAlive === true,
+  };
+  process.stdout.write(`TASK_CONTROL_SYNC ${JSON.stringify(result)}\n`);
+  return result;
+};
+
+const writeIncomplete = reason => {
+  let queue = {};
+  try { queue = native('queue_status'); } catch {}
+  const result = {
+    status: 'incomplete',
+    reason,
+    finishedAt: new Date().toISOString(),
+    counts: queue.counts || {},
+    tasks: queue.tasks || [],
+    taskControl: activeControl ? {
+      revision: activeControl.revision || activeControl._blobSha,
+      source: activeControl._source,
+      keepAlive: activeControl.keepAlive === true,
+    } : null,
+  };
+  writeFileSync(resultPath, `${JSON.stringify(result)}\n`);
+  process.stdout.write(`ACTION_RESULT ${JSON.stringify(result)}\n`);
+};
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+let child = null;
+let stopping = false;
+const stopChild = () => {
+  if (child && child.exitCode === null) child.kill('SIGTERM');
+};
+process.on('SIGTERM', () => { stopping = true; stopChild(); });
+process.on('SIGINT', () => { stopping = true; stopChild(); });
+
+try {
+  syncControl();
+} catch (error) {
+  process.stderr.write(`TASK_CONTROL_INITIAL_WARNING ${error.message}\n`);
+}
+
+let nextSyncAt = Date.now() + pollSeconds * 1_000;
+while (!stopping && Date.now() < deadline) {
+  if (!child || child.exitCode !== null) {
+    const remainingSeconds = Math.max(300, Math.ceil((deadline - Date.now()) / 1_000));
+    child = spawn(process.execPath, [controller], {
+      env: {
+        ...process.env,
+        ACTION_SESSION_SECONDS: String(Math.min(remainingSeconds, 20_100)),
+      },
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+  }
+
+  if (Date.now() >= nextSyncAt) {
+    try { syncControl(); }
+    catch (error) { process.stderr.write(`TASK_CONTROL_SYNC_WARNING ${error.message}\n`); }
+    nextSyncAt = Date.now() + pollSeconds * 1_000;
+  }
+
+  if (child.exitCode !== null) {
+    let status = '';
+    try { status = JSON.parse(readFileSync(resultPath, 'utf8')).status || ''; } catch {}
+    if (activeControl?.keepAlive !== true) process.exit(child.exitCode || (status === 'complete' ? 0 : 1));
+    await sleep(Math.min(5_000, pollSeconds * 1_000));
+  } else {
+    await sleep(1_000);
+  }
+}
+
+stopChild();
+writeIncomplete(stopping ? 'dynamic_controller_interrupted' : 'hosted_runner_session_deadline');

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/DYNAMIC_TASK_SPEC.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/DYNAMIC_TASK_SPEC.md
@@ -1,0 +1,96 @@
+# ChatGPT 自动确认动态任务规范
+
+本文件定义 GitHub Actions 持续运行器的任务控制协议。运行中的 Action 每 30 秒读取 `tasks/actions-inbox.json`，不需要停止、重建或手动续跑当前 Action。
+
+## 控制文件
+
+唯一控制入口：
+
+`.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json`
+
+顶层字段：
+
+- `schemaVersion`: 当前为 `2`。
+- `revision`: 人类可读控制版本。每次改动建议递增。
+- `keepAlive`: `true` 时，即使当前任务全部完成，Action 仍继续轮询新任务；本轮 runner 到期后会自动续接下一轮。
+- `authoritative`: `true` 时，文件中不存在的未完成任务会被取消。
+- `maxConcurrent`: 同时运行的独立 Chat 数，范围 1-4。
+- `reviewGate`: 是否让待验收任务阻塞其他任务调度。
+- `specificationFiles`: 注入每条任务消息的仓库规范文件。
+- `specificationURLs`: 注入每条任务消息的在线规范链接。
+- `tasks`: 当前期望任务集合。
+
+## 任务字段
+
+每个任务至少需要：
+
+- `id`: 稳定逻辑任务 ID，只能使用字母、数字、短横线和下划线。
+- `goalVersion`: 正整数。任务目标发生任何实质变化时必须递增。
+- `title`: 简短标题。
+- `prompt`: 当前任务目标。它是可变内容，不再被首次启动输入永久冻结。
+
+可选字段包括：
+
+- `promptTemplate`
+- `connector`
+- `priority`
+- `timeout`
+- `maxTaskContinuations`
+- `maxRuntimeRetries`
+- `dependsOn`
+- `resourceLocks`
+- `specificationFiles`
+- `specificationURLs`
+
+控制器会把逻辑任务 `example` 的第 3 版映射成运行任务 `example--v3`。当 `goalVersion` 从 3 增加到 4 时，只取消旧版 `example--v3`，随后在新的独立 Chat 中派发 `example--v4`。其他正在运行的任务不会停止。
+
+## 动态新增任务
+
+在 `tasks` 数组中追加一个新的对象，并提交到 `main`：
+
+```json
+{
+  "id": "new-task-20260731",
+  "goalVersion": 1,
+  "title": "新增任务",
+  "prompt": "完成新的任务目标并验证。",
+  "connector": "GitHub",
+  "priority": 40,
+  "dependsOn": [],
+  "resourceLocks": ["worktree:new-task"]
+}
+```
+
+运行中的 Action 会在下一次轮询时调用原生加锁的 `queue_enqueue`，然后按照 `maxConcurrent`、依赖和资源锁并行派发。
+
+## 动态更新已有任务
+
+修改 `prompt` 或任务规范时，同时把 `goalVersion` 加 1。只修改 `revision` 而不提高 `goalVersion`，不会重复执行同一个已存在版本，这是防止重复派发的幂等规则。
+
+## 完成回执
+
+所有工作 Chat，无论完成、未完成或阻塞，最终回复都必须包含一个闭合的机器报告：
+
+```text
+MAHAYANA_TASK_REPORT_V1_BEGIN
+{"protocol":"mahayana.task-report.v1","status":"complete|incomplete|blocked","summary":"本轮实际结果","completed":[],"remaining":[],"blockers":[],"verification":[],"next_connector":"","next_task":""}
+MAHAYANA_TASK_REPORT_V1_END
+```
+
+完成时必须满足：
+
+- `status` 为 `complete`
+- `remaining` 为空数组
+- `blockers` 为空数组
+- `next_task` 为空字符串
+
+不能只用自然语言说“已完成”。这样小程序不再依赖页面按钮或自然语言启发式判断，也不会把已完成任务再次续发。
+
+## 任务规范传递
+
+ChatGPT 消息框目前不能由本控制器可靠上传本地附件，因此采用等价且可审计的双通道：
+
+1. 消息中列出仓库文件路径，Chat 可通过当前 checkout 读取。
+2. 消息中列出 GitHub 在线链接，Chat 可通过 GitHub connector 读取。
+
+每次派发都会明确要求先读取这些规范，并声明当前 `goalVersion` 与规范优先于旧 Chat 内容。

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
@@ -1,11 +1,20 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "revision": "2026-07-31.1",
+  "keepAlive": true,
   "authoritative": true,
-  "maxConcurrent": 1,
+  "maxConcurrent": 2,
   "reviewGate": false,
+  "specificationFiles": [
+    ".agents/plugins/plugins/chatgpt-auto-confirm/tasks/DYNAMIC_TASK_SPEC.md"
+  ],
+  "specificationURLs": [
+    "https://github.com/bhrumom/fabushi/blob/main/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/DYNAMIC_TASK_SPEC.md"
+  ],
   "tasks": [
     {
       "id": "mahayana-marketplace-cloudflare-20260730",
+      "goalVersion": 1,
       "title": "完善大乘 CLI 云端插件市场",
       "promptTemplate": "continue-to-complete",
       "connector": "GitHub",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const controller = readFileSync(
+  new URL('../scripts/run-dynamic-actions-controller.mjs', import.meta.url),
+  'utf8',
+);
+const workflow = readFileSync(
+  new URL('../../../../../.github/workflows/chatgpt-auto-confirm-runner.yml', import.meta.url),
+  'utf8',
+);
+const inbox = JSON.parse(readFileSync(
+  new URL('../tasks/actions-inbox.json', import.meta.url),
+  'utf8',
+));
+const specification = readFileSync(
+  new URL('../tasks/DYNAMIC_TASK_SPEC.md', import.meta.url),
+  'utf8',
+);
+
+test('persistent Actions runner polls the main-branch task control file', () => {
+  assert.match(workflow, /run-dynamic-actions-controller\.mjs/);
+  assert.match(workflow, /CHATGPT_AUTO_CONFIRM_TASK_CONTROL_REF: main/);
+  assert.match(workflow, /CHATGPT_AUTO_CONFIRM_TASK_CONTROL_POLL_SECONDS: "30"/);
+  assert.match(workflow, /Import dynamic parallel task inbox\n\s+if: \$\{\{ inputs\.parallel_queue_smoke \}\}/);
+  assert.match(controller, /spawnSync\('gh'/);
+  assert.match(controller, /repos\/\$\{repository\}\/contents\/\$\{controlPath\}/);
+  assert.match(controller, /setTimeout\(resolve, pollSeconds/);
+});
+
+test('goal versions are idempotent and updates replace only stale versions', () => {
+  assert.match(controller, /\$\{task\.id\}--v\$\{/);
+  assert.match(controller, /native\('queue_cancel'/);
+  assert.match(controller, /native\('queue_enqueue'/);
+  assert.match(controller, /runtimeIdsByLogicalId/);
+  assert.match(controller, /dependsOn:[\s\S]*runtimeIdsByLogicalId\.get/);
+  assert.equal(inbox.schemaVersion, 2);
+  assert.equal(inbox.keepAlive, true);
+  assert.ok(inbox.maxConcurrent >= 2);
+  assert.ok(inbox.tasks.every(task => Number.isInteger(task.goalVersion)));
+});
+
+test('every dispatched work Chat receives a complete machine report contract', () => {
+  assert.match(controller, /status":"complete\|incomplete\|blocked/);
+  assert.match(controller, /不得仅用自然语言声称完成/);
+  assert.match(controller, /remaining、blockers 必须为空数组/);
+  assert.match(controller, /next_task 必须为空字符串/);
+});
+
+test('task specifications are injected as repository files and online links', () => {
+  assert.match(controller, /specificationFiles/);
+  assert.match(controller, /specificationURLs/);
+  assert.deepEqual(inbox.specificationFiles, [
+    '.agents/plugins/plugins/chatgpt-auto-confirm/tasks/DYNAMIC_TASK_SPEC.md',
+  ]);
+  assert.equal(inbox.specificationURLs.length, 1);
+  assert.match(specification, /每 30 秒读取/);
+  assert.match(specification, /goalVersion/);
+  assert.match(specification, /动态新增任务/);
+});

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
@@ -26,7 +26,7 @@ test('persistent Actions runner polls the main-branch task control file', () => 
   assert.match(workflow, /Import dynamic parallel task inbox\n\s+if: \$\{\{ inputs\.parallel_queue_smoke \}\}/);
   assert.match(controller, /spawnSync\('gh'/);
   assert.match(controller, /repos\/\$\{repository\}\/contents\/\$\{controlPath\}/);
-  assert.match(controller, /setTimeout\(resolve, pollSeconds/);
+  assert.match(controller, /pollSeconds \* 1_000/);
 });
 
 test('goal versions are idempotent and updates replace only stale versions', () => {

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -103,6 +103,7 @@ jobs:
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
 
       - name: Import dynamic parallel task inbox
+        if: ${{ inputs.parallel_queue_smoke }}
         env:
           CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
           CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE: ${{ github.workspace }}/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
@@ -163,7 +164,7 @@ jobs:
           CHATGPT_AUTO_CONFIRM_PROFILE_PATH: ${{ steps.paths.outputs.profile_dir }}
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/verify-parallel-actions-queue.mjs
 
-      - name: Run persistent task queue
+      - name: Run dynamic persistent task queue
         if: ${{ !inputs.smoke_only && !inputs.parallel_queue_smoke }}
         id: controller
         continue-on-error: true
@@ -172,9 +173,12 @@ jobs:
           CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
           CHATGPT_AUTO_CONFIRM_CDP_PORT: ${{ env.CHATGPT_CDP_PORT }}
           CHATGPT_AUTO_CONFIRM_PROFILE_PATH: ${{ steps.paths.outputs.profile_dir }}
+          CHATGPT_AUTO_CONFIRM_TASK_CONTROL_REF: main
+          CHATGPT_AUTO_CONFIRM_TASK_CONTROL_PATH: .agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
+          CHATGPT_AUTO_CONFIRM_TASK_CONTROL_POLL_SECONDS: "30"
           ACTION_SESSION_SECONDS: "20100"
           ACTION_RESULT_PATH: ${{ steps.paths.outputs.runtime_dir }}/action-result.json
-        run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
+        run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
 
       - name: Record successful hosted verification
         if: ${{ inputs.smoke_only || inputs.parallel_queue_smoke }}


### PR DESCRIPTION
## 问题

Run 30621522649 证明当前持续运行器存在两个控制面缺陷：

1. 工作提示词要求“完成时正常回复、不要输出机器模板”，导致完成态依赖页面启发式识别；完成任务可能被当作未完成再次派发。
2. `actions-inbox.json` 只在 Action 启动时导入一次，运行中的 Action 无法接收目标更新或新增任务。

## 实现

- 新增 live task controller，每 30 秒从 `main` 读取版本化 `actions-inbox.json`。
- 使用原生加锁的 `queue_cancel` / `queue_enqueue`，避免直接并发改写队列状态。
- 通过 `goalVersion` 将逻辑任务映射为 `id--vN`；版本提升时只替换该任务，其他任务继续运行。
- 支持运行中追加任务，并按 `maxConcurrent`、`dependsOn`、`resourceLocks` 并行调度。
- `keepAlive: true` 时当前队列完成后仍持续监听新任务，runner 到期后继续链式运行。
- 每条工作消息强制注入 complete/incomplete/blocked 都必须返回的 `MAHAYANA_TASK_REPORT_V1`，完成态不再依赖自然语言猜测。
- 新增独立任务规范文件，并把仓库路径与 GitHub 在线链接同时注入任务消息。
- 保留旧的一次性 inbox import 仅用于 parallel smoke，防止恢复状态在每轮 Action 被旧逻辑任务 ID 覆盖。

## 使用方法

编辑并提交：

`.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json`

- 新增任务：追加新对象，`goalVersion: 1`。
- 更新任务目标：修改 `prompt` 并把 `goalVersion` 加 1。
- 运行中的 Action 最迟约 30 秒发现变化并派发。

## 验证

- 新增契约测试覆盖工作流接入、轮询、版本幂等、依赖映射、强制完成回执、规范文件/链接注入。
- 等待 PR Actions 验证 Node 测试和现有插件契约。