### PR TITLE
Apply dynamic task updates only between Chat rounds

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
@@ -13,6 +13,9 @@ const controlRef = process.env.CHATGPT_AUTO_CONFIRM_TASK_CONTROL_REF || 'main';
 const pollSeconds = Math.max(15, Number(
   process.env.CHATGPT_AUTO_CONFIRM_TASK_CONTROL_POLL_SECONDS || 30,
 ));
+const boundaryRetrySeconds = Math.max(2, Number(
+  process.env.CHATGPT_AUTO_CONFIRM_TASK_BOUNDARY_RETRY_SECONDS || 5,
+));
 const sessionSeconds = Math.min(
   20_700,
   Math.max(300, Number(process.env.ACTION_SESSION_SECONDS || 20_100)),
@@ -94,26 +97,33 @@ const taskDocumentBlock = task => {
 
 const runtimeId = task => `${task.id}--v${Math.max(1, Number(task.goalVersion || 1))}`;
 const logicalPrefix = task => `${task.id}--v`;
+const managedBy = (current, task) =>
+  current.id === task.id || current.id.startsWith(logicalPrefix(task));
+const isRunning = task => task.status === 'running';
+const isTerminal = task => ['completed', 'cancelled'].includes(task.status);
+
+const taskPrompt = (control, task) => [
+  `动态任务控制版本：${control.revision || control._blobSha}。`,
+  `逻辑任务：${task.id}；目标版本：${Math.max(1, Number(task.goalVersion || 1))}。`,
+  task.prompt,
+  taskDocumentBlock(task),
+  reportContract,
+].filter(Boolean).join('\n\n');
 
 let activeControl = null;
 let lastBlobSha = '';
 
-const syncControl = () => {
-  const control = fetchControl();
+const reconcileControl = control => {
   activeControl = control;
-  if (control._blobSha === lastBlobSha) {
-    return { changed: false, revision: control.revision || control._blobSha };
-  }
-
   const queue = native('queue_status');
   const existing = Array.isArray(queue.tasks) ? queue.tasks : [];
   const desiredTasks = Array.isArray(control.tasks) ? control.tasks : [];
-  const desiredIds = new Set(desiredTasks.map(runtimeId));
   const runtimeIdsByLogicalId = new Map(
     desiredTasks.filter(task => task?.id).map(task => [task.id, runtimeId(task)]),
   );
   const cancelled = [];
   const enqueued = [];
+  const deferred = [];
 
   for (const task of desiredTasks) {
     if (!task?.id || !task?.title || !task?.prompt ||
@@ -126,11 +136,25 @@ const syncControl = () => {
       );
       continue;
     }
+
     const desiredId = runtimeId(task);
-    for (const current of existing) {
-      const staleVersion = current.id === task.id ||
-        (current.id.startsWith(logicalPrefix(task)) && current.id !== desiredId);
-      if (staleVersion && !['cancelled', 'completed'].includes(current.status)) {
+    const managed = existing.filter(current => managedBy(current, task));
+    const running = managed.filter(isRunning);
+
+    // A task update is never allowed to stop the Chat that is currently
+    // working. The new goal is held until that Chat reaches a round boundary.
+    if (running.length > 0) {
+      deferred.push({
+        logicalTaskId: task.id,
+        desiredId,
+        runningIds: running.map(current => current.id),
+      });
+      continue;
+    }
+
+    for (const current of managed) {
+      const staleVersion = current.id !== desiredId;
+      if (staleVersion && !isTerminal(current)) {
         try {
           native('queue_cancel', { taskId: current.id });
           cancelled.push(current.id);
@@ -139,15 +163,8 @@ const syncControl = () => {
         }
       }
     }
-    if (existing.some(current => current.id === desiredId)) continue;
 
-    const prompt = [
-      `动态任务控制版本：${control.revision || control._blobSha}。`,
-      `逻辑任务：${task.id}；目标版本：${Math.max(1, Number(task.goalVersion || 1))}。`,
-      task.prompt,
-      taskDocumentBlock(task),
-      reportContract,
-    ].filter(Boolean).join('\n\n');
+    if (managed.some(current => current.id === desiredId)) continue;
 
     native('queue_enqueue', {
       tasks: [{
@@ -155,9 +172,11 @@ const syncControl = () => {
         id: desiredId,
         dependsOn: (Array.isArray(task.dependsOn) ? task.dependsOn : [])
           .map(dependency => runtimeIdsByLogicalId.get(dependency) || dependency),
-        prompt,
+        prompt: taskPrompt(control, task),
       }],
-      start: true,
+      // Dispatch is opened explicitly only after the latest control file has
+      // been read at the next Chat boundary.
+      start: false,
       maxConcurrent: Math.min(4, Math.max(1, Number(control.maxConcurrent || 2))),
       reviewGate: control.reviewGate ?? false,
     });
@@ -166,31 +185,77 @@ const syncControl = () => {
 
   if (control.authoritative === true) {
     for (const current of existing) {
-      const managed = desiredTasks.some(task =>
-        current.id === task.id || current.id.startsWith(logicalPrefix(task)));
-      if (!managed && !desiredIds.has(current.id) &&
-          !['cancelled', 'completed'].includes(current.status)) {
-        try {
-          native('queue_cancel', { taskId: current.id });
-          cancelled.push(current.id);
-        } catch (error) {
-          process.stderr.write(`TASK_CONTROL_CANCEL_WARNING ${current.id} ${error.message}\n`);
-        }
+      const managed = desiredTasks.some(task => managedBy(current, task));
+      if (managed || isTerminal(current)) continue;
+      if (isRunning(current)) {
+        deferred.push({
+          logicalTaskId: null,
+          desiredId: null,
+          runningIds: [current.id],
+          removal: true,
+        });
+        continue;
+      }
+      try {
+        native('queue_cancel', { taskId: current.id });
+        cancelled.push(current.id);
+      } catch (error) {
+        process.stderr.write(`TASK_CONTROL_CANCEL_WARNING ${current.id} ${error.message}\n`);
       }
     }
   }
 
+  const changed = control._blobSha !== lastBlobSha;
   lastBlobSha = control._blobSha;
   const result = {
-    changed: true,
+    changed,
     revision: control.revision || control._blobSha,
     source: control._source,
     enqueued,
     cancelled,
+    deferred,
     keepAlive: control.keepAlive === true,
   };
   process.stdout.write(`TASK_CONTROL_SYNC ${JSON.stringify(result)}\n`);
   return result;
+};
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const dispatchFreshRound = async reason => {
+  // queue_pause does not interrupt running Chats. It only closes the gate that
+  // creates another Chat, which gives us a deterministic update boundary.
+  native('queue_pause');
+  const control = fetchControl();
+  const sync = reconcileControl(control);
+  const queue = native('queue_status');
+  const tasks = Array.isArray(queue.tasks) ? queue.tasks : [];
+  const queued = tasks.filter(task => task.status === 'queued');
+  const runningCount = tasks.filter(isRunning).length;
+  const maxConcurrent = Math.min(4, Math.max(1, Number(
+    control.maxConcurrent || queue.maxConcurrent || 2,
+  )));
+
+  if (queued.length > 0 && runningCount < maxConcurrent) {
+    process.stdout.write(`TASK_CHAT_BOUNDARY ${JSON.stringify({
+      reason,
+      revision: sync.revision,
+      queuedIds: queued.map(task => task.id),
+      runningCount,
+      maxConcurrent,
+      action: 'resume_after_fresh_control_read',
+    })}\n`);
+    native('queue_resume', {
+      maxConcurrent,
+      reviewGate: control.reviewGate ?? false,
+    });
+    // Let the watcher select eligible queued work. If it is already inside
+    // startAutomationTask, queue_pause waits for that locked send to finish and
+    // then closes the gate before any later Chat can be selected.
+    await sleep(1_000);
+    native('queue_pause');
+  }
+  return sync;
 };
 
 const writeIncomplete = reason => {
@@ -212,8 +277,6 @@ const writeIncomplete = reason => {
   process.stdout.write(`ACTION_RESULT ${JSON.stringify(result)}\n`);
 };
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
-
 let child = null;
 let stopping = false;
 const stopChild = () => {
@@ -223,12 +286,14 @@ process.on('SIGTERM', () => { stopping = true; stopChild(); });
 process.on('SIGINT', () => { stopping = true; stopChild(); });
 
 try {
-  syncControl();
+  await dispatchFreshRound('startup');
 } catch (error) {
   process.stderr.write(`TASK_CONTROL_INITIAL_WARNING ${error.message}\n`);
 }
 
-let nextSyncAt = Date.now() + pollSeconds * 1_000;
+let nextControlPollAt = Date.now() + pollSeconds * 1_000;
+let nextBoundaryRetryAt = Date.now();
+let previousRunningIds = new Set();
 while (!stopping && Date.now() < deadline) {
   if (!child || child.exitCode !== null) {
     const remainingSeconds = Math.max(300, Math.ceil((deadline - Date.now()) / 1_000));
@@ -241,10 +306,38 @@ while (!stopping && Date.now() < deadline) {
     });
   }
 
-  if (Date.now() >= nextSyncAt) {
-    try { syncControl(); }
+  let queue = null;
+  try { queue = native('queue_status'); }
+  catch (error) { process.stderr.write(`TASK_QUEUE_STATUS_WARNING ${error.message}\n`); }
+  const tasks = Array.isArray(queue?.tasks) ? queue.tasks : [];
+  const runningIds = new Set(tasks.filter(isRunning).map(task => task.id));
+  const runningEnded = [...previousRunningIds].some(id => !runningIds.has(id));
+  const hasQueued = tasks.some(task => task.status === 'queued');
+  const controlPollDue = Date.now() >= nextControlPollAt;
+  const boundaryRetryDue = hasQueued && Date.now() >= nextBoundaryRetryAt;
+
+  if (runningEnded || controlPollDue || boundaryRetryDue) {
+    const reason = runningEnded
+      ? 'previous_chat_finished'
+      : controlPollDue
+        ? 'periodic_control_refresh'
+        : 'queued_chat_boundary';
+    try { await dispatchFreshRound(reason); }
     catch (error) { process.stderr.write(`TASK_CONTROL_SYNC_WARNING ${error.message}\n`); }
-    nextSyncAt = Date.now() + pollSeconds * 1_000;
+    if (controlPollDue) nextControlPollAt = Date.now() + pollSeconds * 1_000;
+    nextBoundaryRetryAt = Date.now() + boundaryRetrySeconds * 1_000;
+    try {
+      queue = native('queue_status');
+      previousRunningIds = new Set(
+        (Array.isArray(queue.tasks) ? queue.tasks : [])
+          .filter(isRunning)
+          .map(task => task.id),
+      );
+    } catch {
+      previousRunningIds = runningIds;
+    }
+  } else {
+    previousRunningIds = runningIds;
   }
 
   if (child.exitCode !== null) {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
@@ -25,7 +25,7 @@ test('persistent Actions runner polls the main-branch task control file', () => 
   assert.match(controller, /pollSeconds \* 1_000/);
 });
 
-test('goal versions are idempotent and updates replace only stale versions', () => {
+test('goal versions are idempotent and dependencies use desired runtime ids', () => {
   assert.match(controller, /\$\{task\.id\}--v\$\{/);
   assert.match(controller, /native\('queue_cancel'/);
   assert.match(controller, /native\('queue_enqueue'/);
@@ -35,6 +35,33 @@ test('goal versions are idempotent and updates replace only stale versions', () 
   assert.equal(inbox.keepAlive, true);
   assert.ok(inbox.maxConcurrent >= 2);
   assert.ok(inbox.tasks.every(task => Number.isInteger(task.goalVersion)));
+});
+
+test('task updates never cancel the currently running Chat', () => {
+  assert.match(controller, /const running = managed\.filter\(isRunning\)/);
+  assert.match(controller, /if \(running\.length > 0\) \{[\s\S]*deferred\.push/);
+  assert.match(controller, /A task update is never allowed to stop the Chat/);
+  assert.doesNotMatch(
+    controller,
+    /if \(staleVersion && !\['cancelled', 'completed'\]\.includes\(current\.status\)\)/,
+  );
+});
+
+test('every new Chat is dispatched only after a fresh control read', () => {
+  assert.match(controller, /const dispatchFreshRound = async reason =>/);
+  assert.match(controller, /native\('queue_pause'\);[\s\S]*const control = fetchControl\(\)/);
+  assert.match(controller, /start: false/);
+  assert.match(controller, /native\('queue_resume'/);
+  assert.match(controller, /await sleep\(1_000\);\n\s+native\('queue_pause'\)/);
+  assert.match(controller, /runningEnded[\s\S]*previous_chat_finished/);
+  assert.match(controller, /queued_chat_boundary/);
+});
+
+test('unchanged tasks continue while changed tasks replace only at the boundary', () => {
+  assert.match(controller, /if \(managed\.some\(current => current\.id === desiredId\)\) continue/);
+  assert.match(controller, /staleVersion && !isTerminal\(current\)/);
+  assert.match(controller, /action: 'resume_after_fresh_control_read'/);
+  assert.match(controller, /queue_pause does not interrupt running Chats/);
 });
 
 test('every dispatched work Chat receives a complete machine report contract', () => {


### PR DESCRIPTION
## 目标

任务目标或文档更新后，不再立即取消正在运行的 Chat。当前 Chat 完成本轮工作后，控制器才在创建下一轮新 Chat 之前读取最新任务控制文件。

## 新行为

- 队列在 Chat 轮次之间保持暂停。
- 当前正在运行的 Chat 不会因 `goalVersion` 更新或任务删除而被停止。
- 每次准备派发新 Chat 时按以下顺序执行：
  1. `queue_pause` 关闭新 Chat 调度入口，但不影响正在运行的 Chat；
  2. 从 GitHub `main` 重新读取 `actions-inbox.json`；
  3. 比较任务 ID 和 `goalVersion`；
  4. 没有变化时恢复原任务继续下一轮；
  5. 有变化时仅在轮次边界替换旧的非运行版本；
  6. `queue_resume` 创建下一 Chat，随后再次关闭调度入口。
- 运行中的旧版本只记录为 `deferred`，不会调用 `queue_cancel`。
- 新任务仍可在并发容量允许时加入，不需要等待其他长任务结束。
- 被删除的运行任务也先完成当前 Chat，离开运行态后再取消。

## 验证

契约测试新增检查：

- 更新不能取消 `running` Chat；
- 入队使用 `start: false`；
- 每次 `queue_resume` 前必须执行新的 GitHub 控制文件读取；
- 当前 Chat 结束和存在 queued 任务都会触发轮次边界刷新；
- 无变化继续同一版本，有变化只在边界替换。