### PR TITLE
fix: verify hosted Chat sessions before dispatch

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -372,6 +372,7 @@ func openBackgroundQueueWindow(
     // A newly created visible web renderer can expose its document before
     // ChatGPT has mounted the composer. Let the page finish loading before
     // the caller performs mode selection and surface detection.
+    var hostedLoaded = false
     for _ in 0..<240 {
       let loaded = cdpValue(
         port: port,
@@ -382,9 +383,31 @@ func openBackgroundQueueWindow(
       let ready = loaded?["ready"] as? String
       let hasInput = (loaded?["input"] as? NSNumber)?.boolValue == true
       let bodyLength = (loaded?["bodyLength"] as? NSNumber)?.intValue ?? 0
-      if ready == "complete" && (hasInput || bodyLength > 50) { break }
+      if ready == "complete" && (hasInput || bodyLength > 50) {
+        hostedLoaded = true
+        break
+      }
       Thread.sleep(forTimeInterval: 0.25)
     }
+    guard hostedLoaded,
+          let target = CDPClient.fetchTargets(portOverride: port).first(where: {
+            $0["id"] as? String == targetId
+          }),
+          let wsURL = target["webSocketDebuggerUrl"] as? String,
+          let url = target["url"] as? String,
+          let loginState = actionsLoginState(ActionsLoginTarget(
+            port: port,
+            targetId: targetId,
+            wsURL: wsURL,
+            url: url
+          )),
+          loginState["authenticated"] as? Bool == true else {
+      failure = "hosted_chat_login_required"
+      queueTrace("worker-create stage=hosted-authentication failed")
+      _ = CDPClient.closeTarget(targetId, portOverride: port)
+      return nil
+    }
+    queueTrace("worker-create stage=hosted-authentication complete target=\(targetId)")
     return targetId
   }
   let reset = cdpValue(

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -213,20 +213,57 @@ struct ActionsLoginTarget {
   let port: Int
   let targetId: String
   let wsURL: String
+  let url: String
 }
 
-func actionsLoginTarget() -> ActionsLoginTarget? {
+func actionsLoginTarget(requireWeb: Bool = false) -> ActionsLoginTarget? {
   let port = CDPClient.port()
-  let target = CDPClient.fetchTargets(portOverride: port).first { target in
+  let targets = CDPClient.fetchTargets(portOverride: port).filter { target in
     guard isLoadedApprovalRendererTarget(target),
           let url = target["url"] as? String else { return false }
     return !url.contains("avatar-overlay")
       && (url.hasPrefix("app://-/index.html") || url.contains("chatgpt.com"))
   }
+  let webTarget = targets.first { target in
+    let url = target["url"] as? String ?? ""
+    return url.hasPrefix("https://chatgpt.com/")
+  }
+  let target: [String: Any]? = requireWeb ? webTarget : (webTarget ?? targets.first)
   guard let target,
         let targetId = target["id"] as? String,
-        let wsURL = target["webSocketDebuggerUrl"] as? String else { return nil }
-  return ActionsLoginTarget(port: port, targetId: targetId, wsURL: wsURL)
+        let wsURL = target["webSocketDebuggerUrl"] as? String,
+        let url = target["url"] as? String else { return nil }
+  return ActionsLoginTarget(port: port, targetId: targetId, wsURL: wsURL, url: url)
+}
+
+func createActionsWebLoginTarget() -> ActionsLoginTarget? {
+  guard let controller = actionsLoginTarget(),
+        let contextId = CDPClient.targetInfo(
+          targetId: controller.targetId,
+          portOverride: controller.port
+        )?["browserContextId"] as? String,
+        let targetId = CDPClient.createTarget(
+          url: "https://chatgpt.com/",
+          browserContextId: contextId,
+          background: false,
+          portOverride: controller.port
+        ) else { return nil }
+  let deadline = Date().addingTimeInterval(15)
+  while Date() < deadline {
+    if let target = CDPClient.fetchTargets(portOverride: controller.port).first(where: {
+      $0["id"] as? String == targetId
+    }), let wsURL = target["webSocketDebuggerUrl"] as? String,
+       let url = target["url"] as? String {
+      return ActionsLoginTarget(
+        port: controller.port,
+        targetId: targetId,
+        wsURL: wsURL,
+        url: url
+      )
+    }
+    Thread.sleep(forTimeInterval: 0.25)
+  }
+  return nil
 }
 
 func activateChatGPTForLogin() {
@@ -255,7 +292,7 @@ func actionsLoginState(_ target: ActionsLoginTarget) -> [String: Any]? {
     port: target.port,
     targetId: target.targetId,
     expression: #"""
-    (() => {
+    (async () => {
       const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
       const bodyText = normalize(document.body?.innerText).slice(0, 12000);
       const loginLabels = new Set(['log in', 'login', 'sign up', '登录', '登入', '注册', '註冊']);
@@ -277,11 +314,30 @@ func actionsLoginState(_ target: ActionsLoginTarget) -> [String: Any]? {
       )].some(element => /account|profile|账户|帳戶/i.test(
         element.getAttribute('aria-label') || ''
       ));
+      const webOrigin = location.protocol === 'https:' &&
+        (location.hostname === 'chatgpt.com' || location.hostname.endsWith('.chatgpt.com'));
+      let webSessionAuthenticated = false;
+      let webSessionStatus = 0;
+      if (webOrigin) {
+        try {
+          const response = await fetch('/api/auth/session', {
+            credentials: 'include', cache: 'no-store'
+          });
+          webSessionStatus = response.status;
+          const session = response.ok ? await response.json() : null;
+          webSessionAuthenticated = !!(session && session.user && (
+            session.user.id || session.user.account_id || session.user.user_id
+          ));
+        } catch {}
+      }
       return {
-        authenticated: !loginPrompt && hasComposer,
+        authenticated: webOrigin && webSessionAuthenticated && !loginPrompt && hasComposer,
         loginPrompt,
         hasComposer,
         hasAccountControl,
+        webOrigin,
+        webSessionAuthenticated,
+        webSessionStatus,
         bodyLength: bodyText.length,
         url: location.href,
         readyState: document.readyState
@@ -290,6 +346,27 @@ func actionsLoginState(_ target: ActionsLoginTarget) -> [String: Any]? {
     """#,
     timeout: 5.0
   )
+}
+
+func verifiedActionsWebLogin(
+  timeout: TimeInterval,
+  createIfMissing: Bool = true
+) -> (target: ActionsLoginTarget, state: [String: Any])? {
+  let deadline = Date().addingTimeInterval(timeout)
+  var target = actionsLoginTarget(requireWeb: true)
+  if target == nil && createIfMissing {
+    target = createActionsWebLoginTarget()
+  }
+  while Date() < deadline {
+    if let current = target,
+       let state = actionsLoginState(current),
+       state["authenticated"] as? Bool == true {
+      return (current, state)
+    }
+    target = actionsLoginTarget(requireWeb: true) ?? target
+    Thread.sleep(forTimeInterval: 1)
+  }
+  return nil
 }
 
 func clickChatGPTLogin(_ target: ActionsLoginTarget) {
@@ -382,6 +459,56 @@ func actionsRunnerScriptURL() -> URL {
     .deletingLastPathComponent()
     .appendingPathComponent("scripts")
     .appendingPathComponent("dispatch-actions-runner.sh")
+}
+
+func macOSCookieExtractorURL() -> URL {
+  actionsRunnerScriptURL().deletingLastPathComponent()
+    .appendingPathComponent("extract-macos-chatgpt-cookies.py")
+}
+
+func extractVerifiedMacOSBrowserCookies() -> (ok: Bool, message: String, cookieCount: Int) {
+  let scriptURL = macOSCookieExtractorURL()
+  let authURL = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".codex/auth.json")
+  let outputURL = actionsSessionCookiesURL()
+  guard FileManager.default.fileExists(atPath: scriptURL.path) else {
+    return (false, "macos_cookie_extractor_missing", 0)
+  }
+  guard FileManager.default.fileExists(atPath: authURL.path) else {
+    return (false, "codex_auth_missing", 0)
+  }
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+  process.arguments = [
+    scriptURL.path,
+    "--output", outputURL.path,
+    "--auth", authURL.path,
+  ]
+  let stdout = Pipe()
+  let stderr = Pipe()
+  process.standardOutput = stdout
+  process.standardError = stderr
+  do {
+    try process.run()
+    process.waitUntilExit()
+    let outputText = String(
+      data: stdout.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard let line = outputText.split(separator: "\n").last,
+          let data = String(line).data(using: .utf8),
+          let summary = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return (false, "macos_cookie_extractor_response_invalid", 0)
+    }
+    let ok = process.terminationStatus == 0 && summary["ok"] as? Bool == true
+    return (
+      ok,
+      summary["message"] as? String ?? (ok ? "Chrome web session verified" : "cookie extraction failed"),
+      summary["cookieCount"] as? Int ?? 0
+    )
+  } catch {
+    return (false, error.localizedDescription, 0)
+  }
 }
 
 func runActionsRunnerDispatch(
@@ -950,8 +1077,9 @@ case "queue_watchdog":
 case "verify_chatgpt_login":
   let authenticationDeadline = Date().addingTimeInterval(120)
   var lastLoginState: [String: Any] = [:]
+  var webTarget = actionsLoginTarget(requireWeb: true) ?? createActionsWebLoginTarget()
   while Date() < authenticationDeadline {
-    if let target = actionsLoginTarget(),
+    if let target = webTarget,
        let loginState = actionsLoginState(target) {
       lastLoginState = loginState
       if loginState["authenticated"] as? Bool == true {
@@ -967,6 +1095,7 @@ case "verify_chatgpt_login":
         ])
       }
     }
+    webTarget = actionsLoginTarget(requireWeb: true) ?? webTarget
     Thread.sleep(forTimeInterval: 2)
   }
   output([
@@ -986,18 +1115,28 @@ case "verify_chatgpt_login":
 case "sync_actions_credentials":
   let params = commandJSONParams()
   let startRunner = params["start"] as? Bool ?? false
-  guard let target = actionsLoginTarget(),
-        let loginState = actionsLoginState(target),
-        loginState["authenticated"] as? Bool == true else {
-    output([
-      "ok": false,
-      "errorCode": "chatgpt_login_required",
-      "message": "当前 ChatGPT 桌面会话未登录；请先运行 login_and_sync_actions。",
-    ], exitCode: 1)
-  }
-  let cookies = CDPClient.allCookies(wsURLString: target.wsURL, timeout: 8.0)
   do {
-    let cookieURL = try writeActionsSessionCookies(cookies)
+    let cookieURL: URL
+    let cookieCount: Int
+    let credentialSource: String
+    if let verified = verifiedActionsWebLogin(timeout: 20) {
+      let cookies = CDPClient.allCookies(wsURLString: verified.target.wsURL, timeout: 8.0)
+      cookieURL = try writeActionsSessionCookies(cookies)
+      cookieCount = cookies.count
+      credentialSource = "chatgpt-web-renderer"
+    } else {
+      let extraction = extractVerifiedMacOSBrowserCookies()
+      guard extraction.ok else {
+        output([
+          "ok": false,
+          "errorCode": "chatgpt_web_login_required",
+          "message": extraction.message,
+        ], exitCode: 1)
+      }
+      cookieURL = actionsSessionCookiesURL()
+      cookieCount = extraction.cookieCount
+      credentialSource = "chrome"
+    }
     let dispatch = runActionsRunnerDispatch(
       sessionCookiesPath: cookieURL.path,
       startRunner: startRunner
@@ -1007,13 +1146,14 @@ case "sync_actions_credentials":
         "ok": false,
         "errorCode": "github_cli_failed",
         "message": dispatch.message,
-        "cookieCount": cookies.count,
+        "cookieCount": cookieCount,
       ], exitCode: 1)
     }
     output([
       "ok": true,
       "credentialsSynchronized": true,
-      "cookieCount": cookies.count,
+      "cookieCount": cookieCount,
+      "credentialSource": credentialSource,
       "started": startRunner,
       "secrets": ["CHATGPT_CODEX_AUTH_B64", "CHATGPT_SESSION_COOKIES_B64"],
       "repository": "bhrumom/fabushi",
@@ -1031,7 +1171,8 @@ case "login_and_sync_actions":
   let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? true
   activateChatGPTForLogin()
-  guard var target = waitForActionsLoginTarget() else {
+  guard var target = actionsLoginTarget(requireWeb: true)
+    ?? createActionsWebLoginTarget() else {
     output([
       "ok": false,
       "errorCode": "chatgpt_cdp_unavailable",
@@ -1049,7 +1190,7 @@ case "login_and_sync_actions":
       authenticatedState = state
       break
     }
-    if let refreshedTarget = actionsLoginTarget() {
+    if let refreshedTarget = actionsLoginTarget(requireWeb: true) {
       target = refreshedTarget
       if let state = actionsLoginState(target), state["loginPrompt"] as? Bool == true {
         clickChatGPTLogin(target)
@@ -1058,7 +1199,7 @@ case "login_and_sync_actions":
     Thread.sleep(forTimeInterval: 2.0)
   }
   guard authenticatedState != nil,
-        let refreshedTarget = actionsLoginTarget() ?? Optional(target) else {
+        let refreshedTarget = actionsLoginTarget(requireWeb: true) ?? Optional(target) else {
     output([
       "ok": false,
       "errorCode": "chatgpt_login_required",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/extract-macos-chatgpt-cookies.py
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/extract-macos-chatgpt-cookies.py
@@ -1,0 +1,279 @@
+"""Extract and verify a matching ChatGPT Chrome session on macOS.
+
+Cookie values are written only to the requested private output file. Stdout is
+limited to a non-sensitive JSON summary so credentials never enter CLI or CI
+logs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+DOMAINS = ("chatgpt.com", "openai.com")
+CHROME_ROOT = Path.home() / "Library/Application Support/Google/Chrome"
+
+
+class ExtractionError(RuntimeError):
+    pass
+
+
+def validate_auth_bundle(auth_path: Path):
+    auth = json.loads(auth_path.read_text(encoding="utf-8"))
+    tokens = auth.get("tokens") or {}
+    account_id = tokens.get("account_id")
+    id_token = tokens.get("id_token", "")
+    if not account_id or not id_token or len(id_token.split(".")) < 2:
+        raise ExtractionError("Codex auth bundle is incomplete")
+    encoded_payload = id_token.split(".")[1]
+    encoded_payload += "=" * ((4 - len(encoded_payload) % 4) % 4)
+    payload = json.loads(base64.urlsafe_b64decode(encoded_payload))
+    claims = payload.get("https://api.openai.com/auth") or {}
+    if claims.get("chatgpt_account_id") != account_id:
+        raise ExtractionError("Codex auth bundle account identifiers do not match")
+    user_id = claims.get("chatgpt_user_id")
+    if not user_id:
+        raise ExtractionError("Codex auth bundle is missing the ChatGPT user identifier")
+    return {"accountId": str(account_id), "userId": str(user_id)}
+
+
+def chrome_password():
+    try:
+        result = subprocess.run(
+            ["/usr/bin/security", "find-generic-password", "-w", "-s", "Chrome Safe Storage"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ExtractionError(
+            "Chrome Safe Storage access was not granted; allow the macOS Keychain prompt and retry"
+        ) from error
+    password = result.stdout.rstrip(b"\r\n")
+    if not password:
+        raise ExtractionError("Chrome Safe Storage returned an empty password")
+    return password
+
+
+def chrome_key(password: bytes):
+    return hashlib.pbkdf2_hmac("sha1", password, b"saltysalt", 1003, dklen=16)
+
+
+def decrypt_cookie(encrypted_value, key: bytes, host: str, integrity_check: bool):
+    encrypted = bytes(encrypted_value or b"")
+    if not encrypted:
+        return ""
+    if encrypted[:3] not in (b"v10", b"v11"):
+        raise ExtractionError("Chrome cookie uses an unsupported encryption format")
+    try:
+        result = subprocess.run(
+            [
+                "/usr/bin/openssl", "enc", "-d", "-aes-128-cbc",
+                "-K", key.hex(), "-iv", (b" " * 16).hex(), "-nopad",
+            ],
+            input=encrypted[3:],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ExtractionError("Chrome cookie decryption failed") from error
+    value = result.stdout
+    if not value:
+        return ""
+    padding = value[-1]
+    if padding < 1 or padding > 16 or value[-padding:] != bytes([padding]) * padding:
+        raise ExtractionError("Chrome cookie padding is invalid")
+    value = value[:-padding]
+    if integrity_check:
+        expected = hashlib.sha256(host.encode("utf-8")).digest()
+        if not value.startswith(expected):
+            raise ExtractionError("Chrome cookie host integrity check failed")
+        value = value[len(expected):]
+    return value.decode("utf-8")
+
+
+def cookie_databases():
+    if not CHROME_ROOT.is_dir():
+        return []
+    profiles = [CHROME_ROOT / "Default"] + sorted(CHROME_ROOT.glob("Profile *"))
+    databases = []
+    for profile in profiles:
+        for candidate in (profile / "Network/Cookies", profile / "Cookies"):
+            if candidate.is_file():
+                databases.append(candidate)
+                break
+    return databases
+
+
+def chromium_expiry(value):
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        return None
+    if raw <= 0:
+        return None
+    unix_seconds = raw / 1_000_000 - 11_644_473_600
+    return unix_seconds if unix_seconds > 0 else None
+
+
+def profile_cookies(cookie_db: Path, key: bytes):
+    with tempfile.TemporaryDirectory(prefix="fabushi-cookie-") as temporary:
+        copied_db = Path(temporary) / "Cookies"
+        shutil.copy2(cookie_db, copied_db)
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(str(cookie_db) + suffix)
+            if sidecar.is_file():
+                shutil.copy2(sidecar, Path(str(copied_db) + suffix))
+        connection = sqlite3.connect(str(copied_db))
+        try:
+            version_row = connection.execute(
+                "SELECT value FROM meta WHERE key='version'"
+            ).fetchone()
+            integrity_check = bool(version_row and int(version_row[0]) >= 24)
+            rows = connection.execute(
+                "SELECT host_key,path,is_secure,name,value,encrypted_value,is_httponly,"
+                "samesite,expires_utc FROM cookies "
+                "WHERE host_key LIKE '%chatgpt.com' OR host_key LIKE '%openai.com'"
+            ).fetchall()
+        finally:
+            connection.close()
+
+    cookies = []
+    for host, path, secure, name, plain, encrypted, http_only, same_site, expires in rows:
+        try:
+            value = plain or decrypt_cookie(encrypted, key, host, integrity_check)
+        except (ExtractionError, UnicodeDecodeError):
+            continue
+        lower_host = str(host or "").lower().lstrip(".")
+        if not name or not value or not any(
+            lower_host == domain or lower_host.endswith("." + domain) for domain in DOMAINS
+        ):
+            continue
+        cookie = {
+            "name": str(name),
+            "value": value,
+            "domain": str(host),
+            "path": str(path or "/"),
+            "secure": bool(secure),
+            "httpOnly": bool(http_only),
+        }
+        same_site_name = {0: "None", 1: "Lax", 2: "Strict"}.get(same_site)
+        if same_site_name:
+            cookie["sameSite"] = same_site_name
+        expiry = chromium_expiry(expires)
+        if expiry:
+            cookie["expires"] = expiry
+        cookies.append(cookie)
+    return cookies
+
+
+def verify_web_account(cookies, identity):
+    chatgpt_cookies = [
+        cookie for cookie in cookies
+        if str(cookie.get("domain", "")).lower().lstrip(".") == "chatgpt.com"
+        or str(cookie.get("domain", "")).lower().lstrip(".").endswith(".chatgpt.com")
+    ]
+    cookie_header = "; ".join(
+        f"{cookie['name']}={cookie['value']}" for cookie in chatgpt_cookies
+    )
+    request = urllib.request.Request(
+        "https://chatgpt.com/api/auth/session",
+        headers={
+            "Accept": "application/json",
+            "Cookie": cookie_header,
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+                          "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            session = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError, OSError) as error:
+        raise ExtractionError("ChatGPT web session could not be verified") from error
+    observed_ids = set()
+    user = session.get("user") if isinstance(session, dict) else None
+    if isinstance(user, dict):
+        for name in ("id", "user_id", "account_id"):
+            if user.get(name):
+                observed_ids.add(str(user[name]))
+    if isinstance(session, dict):
+        for name in ("user_id", "chatgpt_user_id", "account_id", "chatgpt_account_id"):
+            if session.get(name):
+                observed_ids.add(str(session[name]))
+    expected_ids = {identity["userId"], identity["accountId"]}
+    if not observed_ids.intersection(expected_ids):
+        raise ExtractionError("ChatGPT web session belongs to a different account")
+
+
+def extract(output_path: Path, auth_path: Path):
+    identity = validate_auth_bundle(auth_path)
+    key = chrome_key(chrome_password())
+    failures = []
+    for cookie_db in cookie_databases():
+        try:
+            cookies = profile_cookies(cookie_db, key)
+            names = {cookie["name"] for cookie in cookies}
+            if not any(name.startswith("__Secure-next-auth.session-token") for name in names):
+                continue
+            verify_web_account(cookies, identity)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps({"cookies": cookies}, ensure_ascii=False, separators=(",", ":")),
+                encoding="utf-8",
+            )
+            os.chmod(output_path, 0o600)
+            return len(cookies), cookie_db.parent.name
+        except (ExtractionError, OSError, sqlite3.Error) as error:
+            failures.append(str(error))
+    if failures:
+        raise ExtractionError("no Chrome ChatGPT session matched the current Codex account")
+    raise ExtractionError("no authenticated ChatGPT Chrome session was found")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--auth", required=True)
+    args = parser.parse_args()
+    try:
+        count, profile = extract(Path(args.output).resolve(), Path(args.auth).resolve())
+        print(json.dumps({
+            "ok": True,
+            "cookieCount": count,
+            "credentialSource": "chrome",
+            "profile": profile,
+            "accountVerified": True,
+        }, separators=(",", ":")))
+        return 0
+    except ExtractionError as error:
+        print(json.dumps({
+            "ok": False,
+            "errorCode": "chatgpt_cookie_extraction_failed",
+            "message": str(error),
+        }, separators=(",", ":")))
+        return 1
+    except Exception:
+        print(json.dumps({
+            "ok": False,
+            "errorCode": "chatgpt_cookie_extraction_failed",
+            "message": "no usable matching ChatGPT Chrome session was found",
+        }, separators=(",", ":")))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
@@ -262,7 +262,7 @@ const failureDetail = task => [task.lastError, task.hiddenWorkerLastError]
   .join(' ')
   .replace(/\s+/g, ' ');
 const isNonRecoverableFailure = task =>
-  /model_selection\s*:|model_picker_not_found|quick_chat_thinking_not_selected|reasoning_high_not_selected|target_model_not_selected|task_continuation_limit_reached|dependency_not_completed/.test(
+  /model_selection\s*:|model_picker_not_found|quick_chat_thinking_not_selected|reasoning_high_not_selected|target_model_not_selected|hosted_chat_login_required|chatgpt_web_login_required|task_continuation_limit_reached|dependency_not_completed/.test(
     failureDetail(task),
   );
 const watchdogDiagnostics = result => ({

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
@@ -282,6 +282,19 @@ let stopping = false;
 const stopChild = () => {
   if (child && child.exitCode === null) child.kill('SIGTERM');
 };
+const handleFinishedChild = async () => {
+  if (!child || child.exitCode === null) return false;
+  const exitCode = child.exitCode;
+  let status = '';
+  try { status = JSON.parse(readFileSync(resultPath, 'utf8')).status || ''; } catch {}
+  if (status === 'failed') process.exit(exitCode || 1);
+  if (activeControl?.keepAlive !== true) {
+    process.exit(exitCode || (status === 'complete' ? 0 : 1));
+  }
+  child = null;
+  await sleep(Math.min(5_000, pollSeconds * 1_000));
+  return true;
+};
 process.on('SIGTERM', () => { stopping = true; stopChild(); });
 process.on('SIGINT', () => { stopping = true; stopChild(); });
 
@@ -295,7 +308,12 @@ let nextControlPollAt = Date.now() + pollSeconds * 1_000;
 let nextBoundaryRetryAt = Date.now();
 let previousRunningIds = new Set();
 while (!stopping && Date.now() < deadline) {
-  if (!child || child.exitCode !== null) {
+  // Consume the terminal result before considering a replacement child. The
+  // previous order could overwrite a just-finished failed child at the top of
+  // the loop, causing a deterministic failure to restart until the six-hour
+  // hosted deadline.
+  if (await handleFinishedChild()) continue;
+  if (!child) {
     const remainingSeconds = Math.max(300, Math.ceil((deadline - Date.now()) / 1_000));
     child = spawn(process.execPath, [controller], {
       env: {
@@ -340,17 +358,8 @@ while (!stopping && Date.now() < deadline) {
     previousRunningIds = runningIds;
   }
 
-  if (child.exitCode !== null) {
-    let status = '';
-    try { status = JSON.parse(readFileSync(resultPath, 'utf8')).status || ''; } catch {}
-    if (status === 'failed') {
-      process.exit(child.exitCode || 1);
-    }
-    if (activeControl?.keepAlive !== true) process.exit(child.exitCode || (status === 'complete' ? 0 : 1));
-    await sleep(Math.min(5_000, pollSeconds * 1_000));
-  } else {
-    await sleep(1_000);
-  }
+  if (await handleFinishedChild()) continue;
+  await sleep(1_000);
 }
 
 stopChild();

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -25,6 +25,10 @@ const windowsCookieExtractor = readFileSync(
   new URL('../scripts/extract-windows-chatgpt-cookies.py', import.meta.url),
   'utf8',
 );
+const macOSCookieExtractor = readFileSync(
+  new URL('../scripts/extract-macos-chatgpt-cookies.py', import.meta.url),
+  'utf8',
+);
 const dynamicController = readFileSync(
   new URL('../scripts/run-dynamic-actions-controller.mjs', import.meta.url),
   'utf8',
@@ -113,6 +117,7 @@ test('login sync uploads both credential forms without printing values', () => {
   assert.match(dispatchActionsScript, /CHATGPT_AUTO_CONFIRM_DISPATCH/);
   assert.doesNotMatch(dispatchActionsScript, /echo .*CHATGPT_(CODEX_AUTH|SESSION_COOKIES)_B64/);
   assert.match(dynamicController, /status === 'failed'/);
+  assert.match(dynamicController, /await handleFinishedChild\(\)[\s\S]*if \(!child\)/);
 });
 test('Windows credential sync keeps secrets out of logs and supports optional dispatch', () => {
   assert.match(nativeServer, /sync-actions-credentials\.ps1/);
@@ -139,6 +144,10 @@ test('Windows credential sync keeps secrets out of logs and supports optional di
   assert.match(windowsCookieExtractor, /OpenAI\.Codex_/);
   assert.match(windowsCookieExtractor, /desktop-app/);
   assert.doesNotMatch(windowsCookieExtractor, /B64_START/);
+  assert.match(macOSCookieExtractor, /Chrome Safe Storage/);
+  assert.match(macOSCookieExtractor, /__Secure-next-auth\.session-token/);
+  assert.match(macOSCookieExtractor, /https:\/\/chatgpt\.com\/api\/auth\/session/);
+  assert.match(macOSCookieExtractor, /ChatGPT web session belongs to a different account/);
 });
 test('worker exposes the interactive login sync command', async () => {
   const response = await worker.fetch(new Request('https://example.test/mcp', {
@@ -159,6 +168,10 @@ test('worker exposes the interactive login sync command', async () => {
   assert.match(nativeSource, /case "sync_actions_credentials"/);
   assert.match(nativeSource, /CDPClient\.allCookies/);
   assert.match(nativeSource, /authenticationDeadline/);
+  assert.match(nativeSource, /actionsLoginTarget\(requireWeb: true\)/);
+  assert.match(nativeSource, /fetch\('\/api\/auth\/session'/);
+  assert.match(nativeSource, /webSessionAuthenticated/);
+  assert.match(nativeSource, /extractVerifiedMacOSBrowserCookies/);
   assert.match(nativeSource, /loginLabels\.has\(label\)/);
   assert.match(nativeSource, /!url\.contains\("avatar-overlay"\)/);
   assert.match(nativeServer, /-OpenLogin/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -446,6 +446,8 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /prewarm_hidden_target_not_chat/);
   assert.match(nativeSource, /entryScripts/);
   assert.match(nativeSource, /prewarmCreationFailure/);
+  assert.match(nativeSource, /hosted_chat_login_required/);
+  assert.match(nativeSource, /stage=hosted-authentication complete/);
   assert.match(nativeSource, /conversation_changed_before_send/);
   assert.match(nativeSource, /conversation_changed_during_send/);
   assert.match(nativeSource, /conversation_changed_before_dispatch/);


### PR DESCRIPTION
## Summary
- verify the real `https://chatgpt.com` session through `/api/auth/session` before hosted dispatch
- reject desktop-shell false positives and fail hidden worker creation when the web session is logged out
- add a macOS Chrome credential fallback that validates the browser account against local Codex auth without logging values
- consume terminal child results before restarting the dynamic controller

## Validation
- GitHub Actions only, per the plugin Actions-first workflow
- real hosted task run will start after CI passes and this PR is merged