### PR TITLE
fix(actions): sync credentials from local files

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -1116,26 +1116,29 @@ case "sync_actions_credentials":
   let params = commandJSONParams()
   let startRunner = params["start"] as? Bool ?? false
   do {
-    let cookieURL: URL
-    let cookieCount: Int
-    let credentialSource: String
-    if let verified = verifiedActionsWebLogin(timeout: 20) {
-      let cookies = CDPClient.allCookies(wsURLString: verified.target.wsURL, timeout: 8.0)
-      cookieURL = try writeActionsSessionCookies(cookies)
-      cookieCount = cookies.count
-      credentialSource = "chatgpt-web-renderer"
-    } else {
-      let extraction = extractVerifiedMacOSBrowserCookies()
-      guard extraction.ok else {
-        output([
-          "ok": false,
-          "errorCode": "chatgpt_web_login_required",
-          "message": extraction.message,
-        ], exitCode: 1)
-      }
-      cookieURL = actionsSessionCookiesURL()
-      cookieCount = extraction.cookieCount
-      credentialSource = "chrome"
+    // This command is the repeatable cloud-refresh path: use the credentials
+    // already saved by the miniapp instead of re-capturing a browser renderer.
+    // Login-and-sync remains available when those local files are missing.
+    let authURL = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".codex/auth.json")
+    let cookieURL = actionsSessionCookiesURL()
+    guard FileManager.default.fileExists(atPath: authURL.path) else {
+      output(["ok": false, "errorCode": "codex_auth_missing",
+              "message": "本机 Codex 凭证不存在，请先登录 ChatGPT。"], exitCode: 1)
+    }
+    guard FileManager.default.fileExists(atPath: cookieURL.path) else {
+      output(["ok": false, "errorCode": "session_cookies_missing",
+              "message": "本机 ChatGPT 会话凭证不存在，请先使用登录同步命令。"], exitCode: 1)
+    }
+    let cookieCount: Int = {
+      guard let data = try? Data(contentsOf: cookieURL),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let cookies = object["cookies"] as? [[String: Any]] else { return 0 }
+      return cookies.count
+    }()
+    guard cookieCount > 0 else {
+      output(["ok": false, "errorCode": "session_cookies_empty",
+              "message": "本机 ChatGPT 会话凭证为空，请先登录同步。"], exitCode: 1)
     }
     let dispatch = runActionsRunnerDispatch(
       sessionCookiesPath: cookieURL.path,
@@ -1153,7 +1156,7 @@ case "sync_actions_credentials":
       "ok": true,
       "credentialsSynchronized": true,
       "cookieCount": cookieCount,
-      "credentialSource": credentialSource,
+      "credentialSource": "local-files",
       "started": startRunner,
       "secrets": ["CHATGPT_CODEX_AUTH_B64", "CHATGPT_SESSION_COOKIES_B64"],
       "repository": "bhrumom/fabushi",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/compile-content.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/compile-content.mjs
@@ -40,7 +40,7 @@ items.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt) || a.id.localeCo
 const source = JSON.stringify({ welcome, tips, items, resources });
 const quickReplies = [
   { id: 'web-login-and-sync-actions', label: '浏览器登录并同步 Action 凭证', aliases: ['浏览器登录', '同步网页凭证'], action: { type: 'tool', name: 'web_login_and_sync_actions', arguments: {} } },
-  { id: 'sync-actions-credentials', label: '同步已登录凭证', aliases: [], action: { type: 'tool', name: 'sync_actions_credentials', arguments: {} } },
+  { id: 'sync-actions-credentials', label: '一键更新凭证到 GitHub Secrets', aliases: ['同步已登录凭证', '更新 Action 凭证', '一键更新凭证'], action: { type: 'tool', name: 'sync_actions_credentials', arguments: {} } },
   { id: 'login-and-sync-actions', label: '登录并同步 Action 凭证', aliases: [], action: { type: 'tool', name: 'login_and_sync_actions', arguments: {} } },
   { id: 'queue-status', label: '查看任务队列', aliases: [], action: { type: 'tool', name: 'queue_status', arguments: {} } },
   { id: 'start-actions-runner', label: '启动 6 小时 Action', aliases: [], action: { type: 'tool', name: 'start_actions_runner', arguments: {} } },

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: sync-action-credentials
+description: 将当前已登录且已验证为同一账号的 ChatGPT/Codex 凭证安全同步到 GitHub Actions Secrets，并可选择立即启动自动确认 Action。用户要求更新、刷新、重新保存或一键同步云端凭证时使用。
+---
+
+# 一键同步 Action 凭证
+
+使用自动确认小程序的 `sync_actions_credentials` 命令完成同步；不要自行读取、打印或复制凭证明文。
+
+## 流程
+
+1. 确认本机存在以下文件；本流程不会重新抓取浏览器 renderer：
+   - `~/.codex/auth.json`
+   - `~/Library/Application Support/Mahayana/plugins/chatgpt-auto-confirm/session-cookies.json`
+   - `~/Library/Application Support/Mahayana/plugins/chatgpt-auto-confirm/queue-state.json`
+2. 调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true }`；只更新密钥时传入 `{ "start": false }`。
+3. 宿主读取上述本机文件，使用 `base64` 管道传给 `gh secret set`；登录或账号校验由 `login_and_sync_actions` 负责。
+4. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称和 cookie 数量；绝不返回 token、cookie、auth 文件内容或 Base64 值。
+5. 如果需要登录或账号不一致，改用 `login_and_sync_actions`，让用户完成登录后再同步。
+
+## 目标 Secrets
+
+- `CHATGPT_CODEX_AUTH_B64`
+- `CHATGPT_SESSION_COOKIES_B64`
+- 可选的队列状态密钥：`CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64`、`CHATGPT_AUTO_CONFIRM_STATE_KEY`
+
+## 安全边界
+
+- 必须经过宿主的显式授权卡；skill 不绕过用户确认。
+- 不读取 GitHub Secret 明文，也不在日志、聊天或错误信息中输出凭证。
+- 只有此前已经完成账号验证的本机凭证文件才应使用本命令；账号不一致时先运行 `login_and_sync_actions`。
+- 每次都会更新 `CHATGPT_CODEX_AUTH_B64`、`CHATGPT_SESSION_COOKIES_B64` 和 `CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64`；仅当不存在时生成 `CHATGPT_AUTO_CONFIRM_STATE_KEY`。
+- 同步失败时只报告阶段性错误和下一步，不尝试把凭证写入普通文件、Issue、PR 或任务 prompt。

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/agents/openai.yaml
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "一键同步 Action 凭证"
+  short_description: "安全更新 ChatGPT 凭证到 GitHub Secrets"
+  default_prompt: "Use $sync-action-credentials to update the verified ChatGPT/Codex credentials to GitHub Actions Secrets without exposing secret values."

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
@@ -1,6 +1,6 @@
 export const HOME = {
   "schema": "mahayana.miniapp.home.v1",
-  "revision": "7ef18f9ff25af9d7baf651d730a11fb7f72084d876fc683c9b99ae8edc73b839",
+  "revision": "f85553ae01df36820bfde933b86c4740fe3c2c5d0c4fa98b9d173f41ce2d926c",
   "app": {
     "id": "chatgpt-auto-confirm",
     "title": "ChatGPT 自动确认",
@@ -33,8 +33,12 @@ export const HOME = {
     },
     {
       "id": "sync-actions-credentials",
-      "label": "同步已登录凭证",
-      "aliases": [],
+      "label": "一键更新凭证到 GitHub Secrets",
+      "aliases": [
+        "同步已登录凭证",
+        "更新 Action 凭证",
+        "一键更新凭证"
+      ],
       "action": {
         "type": "tool",
         "name": "sync_actions_credentials",


### PR DESCRIPTION
Use the already-saved local Codex auth, ChatGPT session cookies, and queue state for repeatable credential refresh. Upload only encoded values to GitHub Actions Secrets, without recapturing a browser renderer. Add the reusable sync-action-credentials skill and explicit miniapp shortcut. The login_and_sync_actions command remains available for fresh login/account verification.