### PR TITLE
fix(actions): capture live Chat credentials

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -86,7 +86,7 @@ func nativeCommandExample(_ command: String, executable: String) -> String? {
   case "start_actions_runner":
     return "\(executable) start_actions_runner"
   case "sync_actions_credentials":
-    return "\(executable) sync_actions_credentials '{\"start\":true}'"
+    return "\(executable) sync_actions_credentials '{\"waitSeconds\":600,\"start\":true}'"
   case "login_and_sync_actions":
     return "\(executable) login_and_sync_actions '{\"waitSeconds\":600,\"start\":true}'"
   case "send_message":
@@ -318,6 +318,7 @@ func actionsLoginState(_ target: ActionsLoginTarget) -> [String: Any]? {
         (location.hostname === 'chatgpt.com' || location.hostname.endsWith('.chatgpt.com'));
       let webSessionAuthenticated = false;
       let webSessionStatus = 0;
+      const webSessionIdentifiers = [];
       if (webOrigin) {
         try {
           const response = await fetch('/api/auth/session', {
@@ -325,9 +326,17 @@ func actionsLoginState(_ target: ActionsLoginTarget) -> [String: Any]? {
           });
           webSessionStatus = response.status;
           const session = response.ok ? await response.json() : null;
-          webSessionAuthenticated = !!(session && session.user && (
-            session.user.id || session.user.account_id || session.user.user_id
-          ));
+          const collect = object => {
+            if (!object || typeof object !== 'object') return;
+            for (const key of [
+              'id', 'user_id', 'account_id', 'chatgpt_user_id', 'chatgpt_account_id'
+            ]) {
+              if (object[key]) webSessionIdentifiers.push(String(object[key]));
+            }
+          };
+          collect(session);
+          collect(session?.user);
+          webSessionAuthenticated = webSessionIdentifiers.length > 0;
         } catch {}
       }
       return {
@@ -338,6 +347,7 @@ func actionsLoginState(_ target: ActionsLoginTarget) -> [String: Any]? {
         webOrigin,
         webSessionAuthenticated,
         webSessionStatus,
+        webSessionIdentifiers: [...new Set(webSessionIdentifiers)],
         bodyLength: bodyText.length,
         url: location.href,
         readyState: document.readyState
@@ -346,6 +356,46 @@ func actionsLoginState(_ target: ActionsLoginTarget) -> [String: Any]? {
     """#,
     timeout: 5.0
   )
+}
+
+func base64URLDecodedData(_ value: String) -> Data? {
+  var normalized = value.replacingOccurrences(of: "-", with: "+")
+    .replacingOccurrences(of: "_", with: "/")
+  let remainder = normalized.count % 4
+  if remainder > 0 {
+    normalized.append(String(repeating: "=", count: 4 - remainder))
+  }
+  return Data(base64Encoded: normalized)
+}
+
+func codexChatGPTIdentifiers() -> Set<String> {
+  let authURL = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".codex/auth.json")
+  guard let data = try? Data(contentsOf: authURL),
+        let auth = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let tokens = auth["tokens"] as? [String: Any],
+        let accountId = tokens["account_id"] as? String,
+        let idToken = tokens["id_token"] as? String else { return [] }
+  var identifiers = Set([accountId])
+  let parts = idToken.split(separator: ".", omittingEmptySubsequences: false)
+  guard parts.count >= 2,
+        let payloadData = base64URLDecodedData(String(parts[1])),
+        let payload = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+        let claims = payload["https://api.openai.com/auth"] as? [String: Any] else {
+    return identifiers
+  }
+  for key in ["chatgpt_account_id", "chatgpt_user_id"] {
+    if let value = claims[key] as? String, !value.isEmpty {
+      identifiers.insert(value)
+    }
+  }
+  return identifiers
+}
+
+func actionsWebSessionMatchesCodex(_ state: [String: Any]) -> Bool {
+  let expected = codexChatGPTIdentifiers()
+  let observed = Set(state["webSessionIdentifiers"] as? [String] ?? [])
+  return !expected.isEmpty && !observed.isDisjoint(with: expected)
 }
 
 func verifiedActionsWebLogin(
@@ -360,7 +410,8 @@ func verifiedActionsWebLogin(
   while Date() < deadline {
     if let current = target,
        let state = actionsLoginState(current),
-       state["authenticated"] as? Bool == true {
+       state["authenticated"] as? Bool == true,
+       actionsWebSessionMatchesCodex(state) {
       return (current, state)
     }
     target = actionsLoginTarget(requireWeb: true) ?? target
@@ -551,6 +602,101 @@ func runActionsRunnerDispatch(
     )
   } catch {
     return (false, error.localizedDescription)
+  }
+}
+
+func syncLiveActionsCredentials(
+  waitSeconds: Int,
+  startRunner: Bool
+) -> Never {
+  guard !codexChatGPTIdentifiers().isEmpty else {
+    output([
+      "ok": false,
+      "errorCode": "codex_auth_missing",
+      "message": "本机 Codex 凭证不存在或不完整，请先登录 ChatGPT。",
+    ], exitCode: 1)
+  }
+  activateChatGPTForLogin()
+  guard var target = actionsLoginTarget(requireWeb: true)
+    ?? createActionsWebLoginTarget() else {
+    output([
+      "ok": false,
+      "errorCode": "chatgpt_cdp_unavailable",
+      "message": "找不到 ChatGPT 网页会话；请确认 ChatGPT 已安装并正在运行。",
+    ], exitCode: 1)
+  }
+  let deadline = Date().addingTimeInterval(TimeInterval(waitSeconds))
+  var lastState: [String: Any] = [:]
+  var verifiedTarget: ActionsLoginTarget?
+  while Date() < deadline {
+    if let state = actionsLoginState(target) {
+      lastState = state
+      if state["authenticated"] as? Bool == true {
+        guard actionsWebSessionMatchesCodex(state) else {
+          output([
+            "ok": false,
+            "errorCode": "chatgpt_account_mismatch",
+            "message": "ChatGPT 网页会话与当前 Codex 账号不一致；没有上传任何凭证。",
+          ], exitCode: 1)
+        }
+        verifiedTarget = target
+        break
+      }
+      if state["loginPrompt"] as? Bool == true {
+        clickChatGPTLogin(target)
+      }
+    }
+    target = actionsLoginTarget(requireWeb: true) ?? target
+    Thread.sleep(forTimeInterval: 2)
+  }
+  guard let verifiedTarget else {
+    output([
+      "ok": false,
+      "errorCode": lastState.isEmpty
+        ? "chatgpt_login_state_unavailable"
+        : "chatgpt_login_required",
+      "message": "请在 ChatGPT 网页登录页完成当前 Codex 账号登录后重试；没有上传任何凭证。",
+    ], exitCode: 1)
+  }
+  let cookies = CDPClient.allCookies(wsURLString: verifiedTarget.wsURL, timeout: 8.0)
+  do {
+    let cookieURL = try writeActionsSessionCookies(cookies)
+    let dispatch = runActionsRunnerDispatch(
+      sessionCookiesPath: cookieURL.path,
+      startRunner: startRunner
+    )
+    guard dispatch.ok else {
+      output([
+        "ok": false,
+        "errorCode": "github_cli_failed",
+        "message": dispatch.message,
+        "cookieCount": cookies.count,
+      ], exitCode: 1)
+    }
+    output([
+      "ok": true,
+      "credentialsSynchronized": true,
+      "accountVerified": true,
+      "cookieCount": cookies.count,
+      "credentialSource": "live-chat-renderer",
+      "started": startRunner,
+      "secrets": [
+        "CHATGPT_CODEX_AUTH_B64",
+        "CHATGPT_SESSION_COOKIES_B64",
+        "CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64",
+      ],
+      "repository": "bhrumom/fabushi",
+      "workflow": startRunner ? "chatgpt-auto-confirm-runner.yml" : "",
+      "message": startRunner
+        ? "已验证并同步当前 ChatGPT 网页会话，GitHub Actions 已启动。"
+        : "已验证并同步当前 ChatGPT 网页会话。",
+    ])
+  } catch {
+    output([
+      "ok": false,
+      "errorCode": "actions_credentials_sync_failed",
+      "message": error.localizedDescription,
+    ], exitCode: 1)
   }
 }
 
@@ -1082,7 +1228,8 @@ case "verify_chatgpt_login":
     if let target = webTarget,
        let loginState = actionsLoginState(target) {
       lastLoginState = loginState
-      if loginState["authenticated"] as? Bool == true {
+      if loginState["authenticated"] as? Bool == true,
+         actionsWebSessionMatchesCodex(loginState) {
         output([
           "ok": true,
           "authenticated": true,
@@ -1114,131 +1261,14 @@ case "verify_chatgpt_login":
   ], exitCode: 1)
 case "sync_actions_credentials":
   let params = commandJSONParams()
+  let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? false
-  do {
-    // This command is the repeatable cloud-refresh path: use the credentials
-    // already saved by the miniapp instead of re-capturing a browser renderer.
-    // Login-and-sync remains available when those local files are missing.
-    let authURL = FileManager.default.homeDirectoryForCurrentUser
-      .appendingPathComponent(".codex/auth.json")
-    let cookieURL = actionsSessionCookiesURL()
-    guard FileManager.default.fileExists(atPath: authURL.path) else {
-      output(["ok": false, "errorCode": "codex_auth_missing",
-              "message": "本机 Codex 凭证不存在，请先登录 ChatGPT。"], exitCode: 1)
-    }
-    guard FileManager.default.fileExists(atPath: cookieURL.path) else {
-      output(["ok": false, "errorCode": "session_cookies_missing",
-              "message": "本机 ChatGPT 会话凭证不存在，请先使用登录同步命令。"], exitCode: 1)
-    }
-    let cookieCount: Int = {
-      guard let data = try? Data(contentsOf: cookieURL),
-            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let cookies = object["cookies"] as? [[String: Any]] else { return 0 }
-      return cookies.count
-    }()
-    guard cookieCount > 0 else {
-      output(["ok": false, "errorCode": "session_cookies_empty",
-              "message": "本机 ChatGPT 会话凭证为空，请先登录同步。"], exitCode: 1)
-    }
-    let dispatch = runActionsRunnerDispatch(
-      sessionCookiesPath: cookieURL.path,
-      startRunner: startRunner
-    )
-    guard dispatch.ok else {
-      output([
-        "ok": false,
-        "errorCode": "github_cli_failed",
-        "message": dispatch.message,
-        "cookieCount": cookieCount,
-      ], exitCode: 1)
-    }
-    output([
-      "ok": true,
-      "credentialsSynchronized": true,
-      "cookieCount": cookieCount,
-      "credentialSource": "local-files",
-      "started": startRunner,
-      "secrets": ["CHATGPT_CODEX_AUTH_B64", "CHATGPT_SESSION_COOKIES_B64"],
-      "repository": "bhrumom/fabushi",
-      "message": startRunner ? "凭证已同步，GitHub Actions 已启动。" : "凭证已同步。",
-    ])
-  } catch {
-    output([
-      "ok": false,
-      "errorCode": "actions_credentials_sync_failed",
-      "message": error.localizedDescription,
-    ], exitCode: 1)
-  }
+  syncLiveActionsCredentials(waitSeconds: waitSeconds, startRunner: startRunner)
 case "login_and_sync_actions":
   let params = commandJSONParams()
   let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? true
-  activateChatGPTForLogin()
-  guard var target = actionsLoginTarget(requireWeb: true)
-    ?? createActionsWebLoginTarget() else {
-    output([
-      "ok": false,
-      "errorCode": "chatgpt_cdp_unavailable",
-      "message": "找不到 ChatGPT 窗口；请确认 ChatGPT 已安装并正在运行",
-    ], exitCode: 1)
-  }
-  if let initialState = actionsLoginState(target),
-     initialState["loginPrompt"] as? Bool == true {
-    clickChatGPTLogin(target)
-  }
-  let deadline = Date().addingTimeInterval(TimeInterval(waitSeconds))
-  var authenticatedState: [String: Any]?
-  while Date() < deadline {
-    if let state = actionsLoginState(target), state["authenticated"] as? Bool == true {
-      authenticatedState = state
-      break
-    }
-    if let refreshedTarget = actionsLoginTarget(requireWeb: true) {
-      target = refreshedTarget
-      if let state = actionsLoginState(target), state["loginPrompt"] as? Bool == true {
-        clickChatGPTLogin(target)
-      }
-    }
-    Thread.sleep(forTimeInterval: 2.0)
-  }
-  guard authenticatedState != nil,
-        let refreshedTarget = actionsLoginTarget(requireWeb: true) ?? Optional(target) else {
-    output([
-      "ok": false,
-      "errorCode": "chatgpt_login_required",
-      "message": "请在 ChatGPT 窗口完成登录后重试；没有上传任何凭证",
-    ], exitCode: 1)
-  }
-  let cookies = CDPClient.allCookies(wsURLString: refreshedTarget.wsURL, timeout: 8.0)
-  do {
-    let cookieURL = try writeActionsSessionCookies(cookies)
-    let dispatch = runActionsRunnerDispatch(
-      sessionCookiesPath: cookieURL.path,
-      startRunner: startRunner
-    )
-    guard dispatch.ok else {
-      output([
-        "ok": false,
-        "errorCode": "github_cli_failed",
-        "message": dispatch.message,
-        "cookieCount": cookies.count,
-      ], exitCode: 1)
-    }
-    output([
-      "ok": true,
-      "credentialsSynchronized": true,
-      "cookieCount": cookies.count,
-      "repository": "bhrumom/fabushi",
-      "workflow": startRunner ? "chatgpt-auto-confirm-runner.yml" : "",
-      "message": startRunner ? "登录凭证已同步，GitHub Actions 已启动" : "登录凭证已同步",
-    ])
-  } catch {
-    output([
-      "ok": false,
-      "errorCode": "actions_credentials_sync_failed",
-      "message": error.localizedDescription,
-    ], exitCode: 1)
-  }
+  syncLiveActionsCredentials(waitSeconds: waitSeconds, startRunner: startRunner)
 case "start_actions_runner":
   let executableURL = URL(
     fileURLWithPath: CommandLine.arguments[0]

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-action-credentials
-description: 将当前已登录且已验证为同一账号的 ChatGPT/Codex 凭证安全同步到 GitHub Actions Secrets，并可选择立即启动自动确认 Action。用户要求更新、刷新、重新保存或一键同步云端凭证时使用。
+description: 从当前 ChatGPT 桌面应用的真实网页 Chat renderer 实时抓取会话，验证其与本机 Codex 属于同一账号，再安全同步到 GitHub Actions Secrets；可选择立即启动自动确认 Action。用户要求更新、刷新、重新保存或一键同步云端 ChatGPT 凭证时使用。
 ---
 
 # 一键同步 Action 凭证
@@ -9,14 +9,12 @@ description: 将当前已登录且已验证为同一账号的 ChatGPT/Codex 凭�
 
 ## 流程
 
-1. 确认本机存在以下文件；本流程不会重新抓取浏览器 renderer：
-   - `~/.codex/auth.json`
-   - `~/Library/Application Support/Mahayana/plugins/chatgpt-auto-confirm/session-cookies.json`
-   - `~/Library/Application Support/Mahayana/plugins/chatgpt-auto-confirm/queue-state.json`
-2. 调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true }`；只更新密钥时传入 `{ "start": false }`。
-3. 宿主读取上述本机文件，使用 `base64` 管道传给 `gh secret set`；登录或账号校验由 `login_and_sync_actions` 负责。
-4. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称和 cookie 数量；绝不返回 token、cookie、auth 文件内容或 Base64 值。
-5. 如果需要登录或账号不一致，改用 `login_and_sync_actions`，让用户完成登录后再同步。
+1. 调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true, "waitSeconds": 600 }`；只更新密钥时传入 `{ "start": false, "waitSeconds": 600 }`。
+2. 命令打开或复用桌面应用中的 `https://chatgpt.com` renderer，并通过 `/api/auth/session` 验证网页会话；不得把 Work/Codex 的 `app://` 页面当作网页 Chat 登录。
+3. 将网页会话返回的用户/账号 ID 与 `~/.codex/auth.json` 中的 Codex 身份比对。未登录或账号不一致时停止，不上传任何凭证。
+4. 验证成功后，立即通过 CDP `Network.getAllCookies` 抓取当前 renderer 的 Cookie，规范化后原子写入本机私有 `session-cookies.json`。
+5. 使用 `base64` 管道向 `gh secret set` 同步 Codex 凭证、刚抓取的 ChatGPT 会话和队列初始状态；不得复用未验证的旧 Cookie 文件。
+6. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称、Cookie 数量和账号已验证状态；绝不返回 token、Cookie、auth 文件内容、账号 ID 或 Base64 值。
 
 ## 目标 Secrets
 
@@ -28,6 +26,7 @@ description: 将当前已登录且已验证为同一账号的 ChatGPT/Codex 凭�
 
 - 必须经过宿主的显式授权卡；skill 不绕过用户确认。
 - 不读取 GitHub Secret 明文，也不在日志、聊天或错误信息中输出凭证。
-- 只有此前已经完成账号验证的本机凭证文件才应使用本命令；账号不一致时先运行 `login_and_sync_actions`。
+- 每次命令都必须重新验证并实时抓取当前网页 Chat renderer；现有 `session-cookies.json` 只能作为成功抓取后的输出，不能作为上传来源。
+- 未登录时允许打开登录入口并等待用户完成登录；账号不一致时立即失败，禁止覆盖 GitHub Secret。
 - 每次都会更新 `CHATGPT_CODEX_AUTH_B64`、`CHATGPT_SESSION_COOKIES_B64` 和 `CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64`；仅当不存在时生成 `CHATGPT_AUTO_CONFIRM_STATE_KEY`。
 - 同步失败时只报告阶段性错误和下一步，不尝试把凭证写入普通文件、Issue、PR 或任务 prompt。

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/agents/openai.yaml
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "一键同步 Action 凭证"
-  short_description: "安全更新 ChatGPT 凭证到 GitHub Secrets"
-  default_prompt: "Use $sync-action-credentials to update the verified ChatGPT/Codex credentials to GitHub Actions Secrets without exposing secret values."
+  short_description: "实时验证并更新 ChatGPT 凭证到 GitHub Secrets"
+  default_prompt: "Use $sync-action-credentials to capture the current verified ChatGPT web session from the desktop app, confirm it matches Codex, and update GitHub Actions Secrets without exposing secret values."

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -71,15 +71,13 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /CHATGPT_CODEX_AUTH_B64/);
   assert.match(actionsWorkflow, /CHATGPT_SESSION_COOKIES_B64/);
   assert.match(actionsWorkflow, /restore-session-cookies\.mjs/);
-  assert.match(actionsWorkflow, /CHATGPT_SESSION_MODE=restore/);
+  assert.match(actionsWorkflow, /CHATGPT_SESSION_MODE=restore-and-verify/);
   assert.match(actionsWorkflow, /Verify authenticated ChatGPT session/);
   assert.match(actionsWorkflow, /verify_chatgpt_login/);
   assert.match(actionsWorkflow, /AUTHENTICATION_VERIFIED/);
   assert.match(actionsWorkflow, /no continuation was dispatched/);
-  assert.match(actionsWorkflow, /Bootstrap only: persist cookies and request one bounded renderer reload/);
-  assert.match(actionsWorkflow, /native queue owns authenticated Chat creation and verification/);
-  assert.doesNotMatch(actionsWorkflow, /CHATGPT_SESSION_MODE=restore-and-verify/);
-  assert.doesNotMatch(actionsWorkflow, /Authenticated Chat shell attempt/);
+  assert.match(actionsWorkflow, /for attempt in 1 2/);
+  assert.match(actionsWorkflow, /Authenticated Chat shell attempt/);
   assert.match(restoreSessionScript, /mode === 'restore'/);
   assert.match(restoreSessionScript, /process\.exit\(0\)/);
   assert.match(restoreSessionScript, /Page\.reload/);
@@ -87,7 +85,7 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.doesNotMatch(restoreSessionScript, /call\([^\n]*['"]Page\.setWebLifecycleState['"]/);
   assert.doesNotMatch(actionsWorkflow, /pkill -x ChatGPT/);
   assert.match(actionsWorkflow, /Launch authenticated desktop shell/);
-  assert.match(actionsWorkflow, /Launch authenticated desktop shell\r?\n\s+timeout-minutes: 4/);
+  assert.match(actionsWorkflow, /Launch authenticated desktop shell\r?\n\s+timeout-minutes: 6/);
   assert.doesNotMatch(actionsWorkflow, /login_status=\$\(/);
   assert.match(actionsWorkflow, /Build native queue runtime/);
   assert.match(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_STATE_KEY/);
@@ -163,6 +161,7 @@ test('worker exposes the interactive login sync command', async () => {
   const credentialTool = tools.find(item => item.name === 'sync_actions_credentials');
   assert.ok(credentialTool);
   assert.equal(credentialTool.inputSchema.properties.start.default, false);
+  assert.equal(credentialTool.inputSchema.properties.waitSeconds.default, 600);
   assert.match(workerSource, /actions-runner-credential-sync/);
   assert.match(nativeServer, /\['sync_actions_credentials', 'sync_actions_credentials'\]/);
   assert.match(nativeSource, /case "sync_actions_credentials"/);
@@ -171,6 +170,11 @@ test('worker exposes the interactive login sync command', async () => {
   assert.match(nativeSource, /actionsLoginTarget\(requireWeb: true\)/);
   assert.match(nativeSource, /fetch\('\/api\/auth\/session'/);
   assert.match(nativeSource, /webSessionAuthenticated/);
+  assert.match(nativeSource, /webSessionIdentifiers/);
+  assert.match(nativeSource, /actionsWebSessionMatchesCodex/);
+  assert.match(nativeSource, /syncLiveActionsCredentials/);
+  assert.match(nativeSource, /credentialSource": "live-chat-renderer"/);
+  assert.doesNotMatch(nativeSource, /credentialSource": "local-files"/);
   assert.match(nativeSource, /extractVerifiedMacOSBrowserCookies/);
   assert.match(nativeSource, /loginLabels\.has\(label\)/);
   assert.match(nativeSource, /!url\.contains\("avatar-overlay"\)/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
@@ -71,10 +71,11 @@ const tools = [
       start: { type: 'boolean', default: false },
     },
   } },
-  { name: 'sync_actions_credentials', description: 'Extract the already signed-in ChatGPT desktop-app session and local Codex credentials, then upload both to GitHub Secrets.', annotations: {
+  { name: 'sync_actions_credentials', description: 'Capture the live authenticated ChatGPT web renderer from the desktop app, verify it matches local Codex, then upload both credentials to GitHub Secrets.', annotations: {
     readOnlyHint: false, destructiveHint: false, openWorldHint: true,
   }, inputSchema: {
     type: 'object', additionalProperties: false, properties: {
+      waitSeconds: { type: 'integer', minimum: 30, maximum: 1800, default: 600 },
       start: { type: 'boolean', default: false, description: 'After syncing, optionally start the GitHub Actions runner.' },
     },
   } },

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -138,7 +138,7 @@ jobs:
         run: sh .agents/plugins/plugins/chatgpt-auto-confirm/scripts/build-macos-runtime.sh
 
       - name: Launch authenticated desktop shell
-        timeout-minutes: 4
+        timeout-minutes: 6
         shell: bash
         env:
           PROFILE_DIR: ${{ steps.paths.outputs.profile_dir }}
@@ -148,21 +148,19 @@ jobs:
           open -na /Applications/ChatGPT.app --args \
             --user-data-dir="$PROFILE_DIR" \
             --remote-debugging-port="$CHATGPT_CDP_PORT"
-          # Bootstrap only: persist cookies and request one bounded renderer reload
-          # in persistent mode; parallel smoke seeds the shared app context. The
-          # parallel smoke verifier creates the real Chat renderers itself;
-          # forcing a controller reload here can leave hosted macOS blank.
-          # The native queue owns authenticated Chat creation and verification. Making
-          # the visible controller pass Runtime.evaluate here can stall hosted macOS
-          # before the real hidden-Chat queue gets a chance to start.
-          # CHATGPT_SESSION_MODE=restore remains the persistent-runner default;
-          # parallel smoke uses seed so its queue can create the real renderer.
-          CHATGPT_SESSION_MODE=${{ inputs.parallel_queue_smoke && 'seed' || 'restore' }} \
-            node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+          shell_ready=false
+          for attempt in 1 2; do
+            if CHATGPT_SESSION_MODE=restore-and-verify \
+              node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs; then
+              shell_ready=true
+              break
+            fi
+            echo "::warning::Authenticated Chat shell attempt $attempt failed; retrying in the same app instance."
+          done
+          test "$shell_ready" = true
 
       - name: Verify authenticated ChatGPT session
         id: auth_verify
-        continue-on-error: ${{ inputs.parallel_queue_smoke }}
         timeout-minutes: 3
         env:
           CHATGPT_AUTO_CONFIRM_CDP_PORT: ${{ env.CHATGPT_CDP_PORT }}
@@ -244,7 +242,7 @@ jobs:
           AUTHENTICATION_VERIFIED: ${{ steps.auth_verify.outcome == 'success' }}
         run: |
           set -euo pipefail
-          if [[ "$AUTHENTICATION_VERIFIED" != "true" && "$VERIFICATION_ONLY" != "true" ]]; then
+          if [[ "$AUTHENTICATION_VERIFIED" != "true" ]]; then
             echo "::error::ChatGPT authentication preflight failed; no continuation was dispatched."
             exit 1
           fi


### PR DESCRIPTION
## 问题

云端 Secret 曾由本地缓存 Cookie 文件直接上传。桌面端仍可通过 Codex OAuth 发送消息，并不代表缓存的 chatgpt.com 网页会话有效，因此 Action 会停在登录页。

## 修复

- `sync_actions_credentials` 每次打开或复用桌面端真实 `https://chatgpt.com` 页面
- 读取 `/api/auth/session` 并与本机 Codex 身份比对，不一致时禁止上传
- 验证成功后立即通过 CDP 抓取当前 Cookie，再更新三个 Actions Secrets
- 将相同流程写入小程序 Skill 和工具命令
- 云端恢复历史成功版本的 `restore-and-verify` 刷新与重试流程
- 添加契约测试，防止回退为读取旧 Cookie 文件

## 验证

不在本机运行项目构建或测试；由 GitHub Actions 完成运行时编译和测试。Skill 结构校验已通过。