### PR TITLE
fix(plugin): discover background Chat port

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -36,7 +36,7 @@ let nativeCommandSummaries: [String: String] = [
   "queue_cancel": "取消指定任务并停止其隐藏 worker。",
   "queue_watchdog": "超过阈值仍未完成时安全重建隐藏 Chat，并重启队列守护。",
   "start_actions_runner": "刷新加密任务状态与登录 Secret，并启动最长六小时的 GitHub Actions 持续运行器。",
-  "sync_actions_credentials": "自动读取当前 Codex 凭证与已登录的 ChatGPT 桌面会话，并同步到 GitHub Secrets。",
+  "sync_actions_credentials": "实时验证桌面端 Chat 网页会话与 Codex 为同一账号，再同步到 GitHub Secrets。",
   "login_and_sync_actions": "打开 ChatGPT 登录页，等待登录完成后同步 ChatGPT 与 Codex 凭证，并启动 GitHub Actions。",
   "verify_chatgpt_login": "只读验证当前 ChatGPT 网页会话是否仍处于登录状态。",
   "send_message": "在插件隐藏 Chat 页面中发送一条消息。",
@@ -216,24 +216,45 @@ struct ActionsLoginTarget {
   let url: String
 }
 
+func actionsLoginPorts() -> [Int] {
+  let state = loadState()
+  var ports = [CDPClient.port()]
+  if let backgroundPort = state.backgroundAppPort {
+    ports.append(backgroundPort)
+  }
+  ports.append(9324)
+  var seen = Set<Int>()
+  return ports.filter { seen.insert($0).inserted }
+}
+
 func actionsLoginTarget(requireWeb: Bool = false) -> ActionsLoginTarget? {
-  let port = CDPClient.port()
-  let targets = CDPClient.fetchTargets(portOverride: port).filter { target in
-    guard isLoadedApprovalRendererTarget(target),
-          let url = target["url"] as? String else { return false }
-    return !url.contains("avatar-overlay")
-      && (url.hasPrefix("app://-/index.html") || url.contains("chatgpt.com"))
+  var fallback: ActionsLoginTarget?
+  for port in actionsLoginPorts() {
+    let targets = CDPClient.fetchTargets(portOverride: port).filter { target in
+      guard isLoadedApprovalRendererTarget(target),
+            let url = target["url"] as? String else { return false }
+      return !url.contains("avatar-overlay")
+        && (url.hasPrefix("app://-/index.html") || url.contains("chatgpt.com"))
+    }
+    for target in targets {
+      guard let targetId = target["id"] as? String,
+            let wsURL = target["webSocketDebuggerUrl"] as? String,
+            let url = target["url"] as? String else { continue }
+      let resolved = ActionsLoginTarget(
+        port: port,
+        targetId: targetId,
+        wsURL: wsURL,
+        url: url
+      )
+      if url.hasPrefix("https://chatgpt.com/") {
+        return resolved
+      }
+      if fallback == nil {
+        fallback = resolved
+      }
+    }
   }
-  let webTarget = targets.first { target in
-    let url = target["url"] as? String ?? ""
-    return url.hasPrefix("https://chatgpt.com/")
-  }
-  let target: [String: Any]? = requireWeb ? webTarget : (webTarget ?? targets.first)
-  guard let target,
-        let targetId = target["id"] as? String,
-        let wsURL = target["webSocketDebuggerUrl"] as? String,
-        let url = target["url"] as? String else { return nil }
-  return ActionsLoginTarget(port: port, targetId: targetId, wsURL: wsURL, url: url)
+  return requireWeb ? nil : fallback
 }
 
 func createActionsWebLoginTarget() -> ActionsLoginTarget? {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -171,6 +171,8 @@ test('worker exposes the interactive login sync command', async () => {
   assert.match(nativeSource, /fetch\('\/api\/auth\/session'/);
   assert.match(nativeSource, /webSessionAuthenticated/);
   assert.match(nativeSource, /webSessionIdentifiers/);
+  assert.match(nativeSource, /actionsLoginPorts/);
+  assert.match(nativeSource, /ports\.append\(9324\)/);
   assert.match(nativeSource, /actionsWebSessionMatchesCodex/);
   assert.match(nativeSource, /syncLiveActionsCredentials/);
   assert.match(nativeSource, /credentialSource": "live-chat-renderer"/);


### PR DESCRIPTION
## 问题

新版实时凭证同步命令默认探测 9223，而小程序已经运行的桌面 Chat 实例使用持久后台端口 9324，导致第一次实际执行安全地返回 `chatgpt_cdp_unavailable`。

## 修复

- 同时探测显式配置端口、队列保存的后台端口和默认后台端口 9324
- 跨端口优先选择真实 `https://chatgpt.com` renderer
- 保持未登录/账号不一致时禁止上传的安全边界
- 补充契约保护并更新命令帮助说明

## 验证

由 GitHub Actions 编译并测试原生运行时。