### PR TITLE
Relaunch ChatGPT desktop with CDP when credential sync needs it

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -252,7 +252,15 @@ func actionsDesktopTarget() -> ActionsLoginTarget? {
 }
 
 func ensureChatGPTDesktopRunning() {
-  if !runningChatGptApplications().isEmpty { return }
+  if actionsDesktopTarget() != nil { return }
+  let runningApplications = runningChatGptApplications()
+  for application in runningApplications {
+    application.terminate()
+  }
+  Thread.sleep(forTimeInterval: 1.0)
+  for application in runningApplications where !application.isTerminated {
+    application.forceTerminate()
+  }
   let applicationURL = URL(fileURLWithPath: "/Applications/ChatGPT.app")
   guard FileManager.default.fileExists(atPath: applicationURL.path) else { return }
   let configuration = NSWorkspace.OpenConfiguration()

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -37,7 +37,7 @@ let nativeCommandSummaries: [String: String] = [
   "queue_watchdog": "超过阈值仍未完成时安全重建隐藏 Chat，并重启队列守护。",
   "start_actions_runner": "刷新加密任务状态与登录 Secret，并启动最长六小时的 GitHub Actions 持续运行器。",
   "sync_actions_credentials": "从已打开的 ChatGPT 桌面 app renderer 实时导出会话并同步到 GitHub Secrets。",
-  "login_and_sync_actions": "打开 ChatGPT 登录页，等待登录完成后同步 ChatGPT 与 Codex 凭证，并启动 GitHub Actions。",
+  "login_and_sync_actions": "按需打开 ChatGPT 桌面应用，等待 app renderer 登录完成后实时同步 ChatGPT 与 Codex 凭证，并启动 GitHub Actions。",
   "verify_chatgpt_login": "只读验证当前 ChatGPT 桌面 app renderer 是否仍处于登录状态。",
   "send_message": "在插件隐藏 Chat 页面中发送一条消息。",
   "add_connector": "在隐藏 Chat 页面中选择一个 ChatGPT connector。",
@@ -125,7 +125,7 @@ func nativeHelpText(topic: String? = nil) -> (text: String, known: Bool) {
   }
 
   let text = """
-  login_and_sync_actions JSON  login to ChatGPT, sync both Action credentials, and start the runner
+  login_and_sync_actions JSON  open the ChatGPT desktop app, sync both live credentials, and start the runner
 
 ChatGPT 自动确认 macOS 原生运行时
 
@@ -164,7 +164,8 @@ ChatGPT 自动确认 macOS 原生运行时
   queue_cancel JSON      取消任务
   queue_watchdog JSON    检查超时并安全恢复队列
   start_actions_runner   启动六小时 GitHub Actions 持续运行器
-  sync_actions_credentials JSON  自动抓取当前两份登录凭证并同步，可选启动 Actions
+  sync_actions_credentials JSON  从已打开的桌面 app renderer 实时抓取当前两份登录凭证并同步，可选启动 Actions
+  login_and_sync_actions JSON    按需打开桌面应用后使用相同实时抓取方式同步凭证
 
 隐藏 Chat：
   send_message JSON      发送消息
@@ -356,8 +357,14 @@ func writeActionsSessionCookies(_ cookies: [[String: Any]]) throws -> URL {
           let value = cookie["value"] as? String,
           let domain = cookie["domain"] as? String,
           !name.isEmpty, !value.isEmpty, !domain.isEmpty else { return nil }
-    let lowerDomain = domain.lowercased()
-    guard lowerDomain.contains("chatgpt.com") || lowerDomain.contains("openai.com") else {
+    let lowerDomain = domain.lowercased().hasPrefix(".")
+      ? String(domain.lowercased().dropFirst())
+      : domain.lowercased()
+    let allowedDomain = lowerDomain == "chatgpt.com"
+      || lowerDomain.hasSuffix(".chatgpt.com")
+      || lowerDomain == "openai.com"
+      || lowerDomain.hasSuffix(".openai.com")
+    guard allowedDomain else {
       return nil
     }
     var result: [String: Any] = [
@@ -493,7 +500,8 @@ func finishActionsCredentialSync(
 
 func syncLiveActionsCredentials(
   waitSeconds: Int,
-  startRunner: Bool
+  startRunner: Bool,
+  openDesktopIfNeeded: Bool = false
 ) -> Never {
   guard !codexChatGPTIdentifiers().isEmpty else {
     output([
@@ -506,7 +514,7 @@ func syncLiveActionsCredentials(
   var lastState: [String: Any] = [:]
   var verifiedTarget: ActionsLoginTarget?
   var target = actionsDesktopTarget()
-  if target == nil {
+  if target == nil && openDesktopIfNeeded {
     ensureChatGPTDesktopRunning()
   }
   while Date() < deadline {
@@ -1109,12 +1117,20 @@ case "sync_actions_credentials":
   let params = commandJSONParams()
   let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? false
-  syncLiveActionsCredentials(waitSeconds: waitSeconds, startRunner: startRunner)
+  syncLiveActionsCredentials(
+    waitSeconds: waitSeconds,
+    startRunner: startRunner,
+    openDesktopIfNeeded: false
+  )
 case "login_and_sync_actions":
   let params = commandJSONParams()
   let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? true
-  syncLiveActionsCredentials(waitSeconds: waitSeconds, startRunner: startRunner)
+  syncLiveActionsCredentials(
+    waitSeconds: waitSeconds,
+    startRunner: startRunner,
+    openDesktopIfNeeded: true
+  )
 case "start_actions_runner":
   let executableURL = URL(
     fileURLWithPath: CommandLine.arguments[0]

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/compile-content.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/compile-content.mjs
@@ -39,7 +39,6 @@ for (const [folder, kind] of kinds) {
 items.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt) || a.id.localeCompare(b.id));
 const source = JSON.stringify({ welcome, tips, items, resources });
 const quickReplies = [
-  { id: 'web-login-and-sync-actions', label: '桌面端登录并同步 Action 凭证', aliases: ['桌面端登录', '同步桌面凭证'], action: { type: 'tool', name: 'web_login_and_sync_actions', arguments: {} } },
   { id: 'sync-actions-credentials', label: '一键更新凭证到 GitHub Secrets', aliases: ['同步已登录凭证', '更新 Action 凭证', '一键更新凭证'], action: { type: 'tool', name: 'sync_actions_credentials', arguments: {} } },
   { id: 'login-and-sync-actions', label: '登录并同步 Action 凭证', aliases: [], action: { type: 'tool', name: 'login_and_sync_actions', arguments: {} } },
   { id: 'queue-status', label: '查看任务队列', aliases: [], action: { type: 'tool', name: 'queue_status', arguments: {} } },

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/sync-actions-credentials.ps1
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/sync-actions-credentials.ps1
@@ -2,10 +2,7 @@
 param(
   [string]$Repository = $(if ($env:CHATGPT_AUTO_CONFIRM_REPOSITORY) { $env:CHATGPT_AUTO_CONFIRM_REPOSITORY } else { 'bhrumom/fabushi' }),
   [int]$WaitSeconds = 600,
-  [switch]$OpenLogin,
   [switch]$DesktopLogin,
-  # Kept as a compatibility alias. It now opens the ChatGPT desktop app too.
-  [switch]$WebLogin,
   [switch]$Start
 )
 
@@ -92,10 +89,7 @@ try {
   & $script:GitHubCli.Source auth status *> $null
   if ($LASTEXITCODE -ne 0) { throw 'GitHub CLI is not authenticated; run gh auth login first' }
 
-  $desktopLoginRequested = $OpenLogin -or $DesktopLogin -or $WebLogin
-  if ((@($OpenLogin, $DesktopLogin, $WebLogin) | Where-Object { $_ }).Count -gt 1) {
-    throw 'desktop login was requested more than once'
-  }
+  $desktopLoginRequested = $DesktopLogin
 
   $authPath = if ($env:CHATGPT_CODEX_AUTH_PATH) {
     [string]$env:CHATGPT_CODEX_AUTH_PATH

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/server/index.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/server/index.mjs
@@ -12,7 +12,6 @@ const windowsCredentialScript = fileURLToPath(new URL(
 const windowsCredentialTools = new Set([
   'sync_actions_credentials',
   'login_and_sync_actions',
-  'web_login_and_sync_actions',
 ]);
 const nativeCommands = new Map([
   ['start', 'start'], ['stop', 'stop'], ['status', 'status'],
@@ -53,12 +52,7 @@ function runWindowsCredentialTool(rpc) {
     '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', windowsCredentialScript,
   ];
   if (tool === 'login_and_sync_actions') {
-    args.push('-OpenLogin', '-WaitSeconds', String(
-      Math.min(1800, Math.max(30, Number(rpc.params?.arguments?.waitSeconds ?? 600))),
-    ));
-  }
-  if (tool === 'web_login_and_sync_actions') {
-    args.push('-OpenLogin', '-WaitSeconds', String(
+    args.push('-DesktopLogin', '-WaitSeconds', String(
       Math.min(1800, Math.max(30, Number(rpc.params?.arguments?.waitSeconds ?? 600))),
     ));
   }
@@ -110,7 +104,7 @@ function runNativeTool(rpc) {
     : ['start_queue', 'wait_for_review'].includes(tool)
       ? 7_300_000
     : ['start', 'scan_once', 'relaunch_and_confirm'].includes(tool) ? 620_000
-    : ['start_actions_runner', 'sync_actions_credentials', 'login_and_sync_actions', 'web_login_and_sync_actions'].includes(tool) ? 1_200_000 : 15_000;
+    : ['start_actions_runner', 'sync_actions_credentials', 'login_and_sync_actions'].includes(tool) ? 1_200_000 : 15_000;
   const invocation = spawnSync(nativeRuntime, args, {
     encoding: 'utf8', timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024,
     env: process.env,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
@@ -9,13 +9,14 @@ description: 从已经打开并登录的 ChatGPT 桌面应用 app:// renderer �
 
 ## 流程
 
-1. 调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true, "waitSeconds": 600 }`；只更新密钥时传入 `{ "start": false, "waitSeconds": 600 }`。
-2. 命令只复用已经打开的 ChatGPT 桌面应用 `app://-/index.html` renderer；不得新建、打开或依赖 `https://chatgpt.com` 网页 renderer，也不得使用外部浏览器。
-3. 通过桌面 renderer 的 `electronBridge`、登录提示、模式控件和 composer 状态验证桌面实例已经登录；同时验证 `~/.codex/auth.json` 结构完整。未登录时停止，不上传任何凭证。
-4. 验证成功后，立即通过该桌面 renderer 的 CDP `Network.getAllCookies` 实时导出 Cookie，规范化后原子写入本机私有 `session-cookies.json`。禁止读取、复制或解密任何浏览器、Codex 或 ChatGPT 桌面资料库中的 Cookie 数据库。
-5. 使用 `base64` 管道向 `gh secret set` 同步 Codex 凭证和刚抓取的 ChatGPT 会话；不得读取或上传本地任务队列状态，也不得复用未验证的旧 Cookie 文件。
-6. 任务目标与任务文档只来自仓库内的 `tasks/actions-inbox.json`、`documentDirectory` 和 `specSources`。运行器启动后持续读取这些可动态更新的文件；不得用 Secret 固化任务定义。
-7. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称、Cookie 数量和账号已验证状态；绝不返回 token、Cookie、auth 文件内容、账号 ID 或 Base64 值。
+1. 已有打开且登录的桌面实例时，调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true, "waitSeconds": 600 }`；只更新密钥时传入 `{ "start": false, "waitSeconds": 600 }`。
+2. `sync_actions_credentials` 只复用已经打开的 ChatGPT 桌面应用 `app://-/index.html` renderer；找不到时必须失败，不得隐式打开其他实例。只有用户明确要求打开桌面应用并等待登录时才调用 `login_and_sync_actions`，且打开后仍必须使用完全相同的 `app://` + CDP 实时导出流程。
+3. 不得提供或调用任何名为“web login”或“browser login”的兼容入口；不得新建、打开或依赖 `https://chatgpt.com` 网页 renderer，也不得使用外部浏览器。
+4. 通过桌面 renderer 的 `electronBridge`、登录提示、模式控件和 composer 状态验证桌面实例已经登录；同时验证 `~/.codex/auth.json` 结构完整。未登录时停止，不上传任何凭证。
+5. 验证成功后，立即通过该桌面 renderer 的 CDP `Network.getAllCookies` 实时导出 Cookie，规范化后原子写入本机私有 `session-cookies.json`。禁止读取、复制或解密任何浏览器、Codex 或 ChatGPT 桌面资料库中的 Cookie 数据库。
+6. 使用 `base64` 管道向 `gh secret set` 同步 Codex 凭证和刚抓取的 ChatGPT 会话；不得读取或上传本地任务队列状态，也不得复用未验证的旧 Cookie 文件。
+7. 任务目标与任务文档只来自仓库内的 `tasks/actions-inbox.json`、`documentDirectory` 和 `specSources`。运行器启动后持续读取这些可动态更新的文件；不得用 Secret 固化任务定义。
+8. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称、Cookie 数量和账号已验证状态；绝不返回 token、Cookie、auth 文件内容、账号 ID 或 Base64 值。
 
 ## 目标 Secrets
 

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -53,12 +53,10 @@ test('home contract', () => {
   assert.ok(Buffer.byteLength(JSON.stringify(HOME)) <= 32768);
   assert.ok(HOME.feed.items.length <= 10);
   assert.deepEqual(HOME.quickReplies.map(item => item.action.name), [
-    'web_login_and_sync_actions', 'sync_actions_credentials', 'login_and_sync_actions', 'queue_status', 'start_actions_runner',
+    'sync_actions_credentials', 'login_and_sync_actions', 'queue_status', 'start_actions_runner',
     'prompt_templates', 'wait_for_review',
   ]);
-  const webLoginReply = HOME.quickReplies.find(item => item.action.name === 'web_login_and_sync_actions');
-  assert.equal(webLoginReply.label, '桌面端登录并同步 Action 凭证');
-  assert.deepEqual(webLoginReply.aliases, ['桌面端登录', '同步桌面凭证']);
+  assert.equal(HOME.quickReplies.some(item => item.action.name === 'web_login_and_sync_actions'), false);
 });
 test('article bodies stay lazy', () => assert.ok(Object.keys(RESOURCES).length >= 1));
 test('continuous Actions runner preserves secrets and chains incomplete sessions', () => {
@@ -138,6 +136,8 @@ test('Windows credential sync keeps secrets out of logs and supports optional di
   assert.doesNotMatch(windowsSyncScript, /chatgpt-cookie-capture-extension/);
   assert.doesNotMatch(windowsSyncScript, /auth\.openai\.com\/oauth/);
   assert.match(windowsSyncScript, /WaitSeconds/);
+  assert.match(windowsSyncScript, /\[switch\]\$DesktopLogin/);
+  assert.doesNotMatch(windowsSyncScript, /\$OpenLogin|\$WebLogin/);
   assert.match(liveSessionExporter, /Network\.getAllCookies/);
   assert.match(liveSessionExporter, /Runtime\.evaluate/);
   assert.match(liveSessionExporter, /app:\/\/-\/index\.html/);
@@ -174,19 +174,20 @@ test('worker exposes the interactive login sync command', async () => {
   assert.doesNotMatch(nativeSource, /createActionsWebLoginTarget|actionsWebSessionMatchesCodex/);
   assert.doesNotMatch(nativeSource, /actionsWebLoginState|api\/auth\/session/);
   assert.match(nativeSource, /syncLiveActionsCredentials/);
+  assert.match(nativeSource, /openDesktopIfNeeded: Bool = false/);
+  assert.match(nativeSource, /startRunner: startRunner,\s+openDesktopIfNeeded: false/);
+  assert.match(nativeSource, /startRunner: startRunner,\s+openDesktopIfNeeded: true/);
   assert.match(nativeSource, /credentialSource": "live-desktop-renderer"/);
   assert.doesNotMatch(nativeSource, /credentialSource": "local-files"/);
   assert.doesNotMatch(nativeSource, /extractVerifiedMacOS|macOSCookieExtractor/);
   assert.doesNotMatch(nativeSource, /webSessionIdentifiers/);
   assert.match(nativeSource, /!url\.contains\("avatar-overlay"\)/);
-  assert.match(nativeServer, /-OpenLogin/);
+  assert.match(nativeServer, /-DesktopLogin/);
   assert.match(nativeServer, /-WaitSeconds/);
   const webTool = tools.find(item => item.name === 'web_login_and_sync_actions');
-  assert.ok(webTool);
-  assert.equal(webTool.inputSchema.properties.start.default, false);
-  assert.equal(webTool.inputSchema.properties.waitSeconds.default, 600);
-  assert.match(workerSource, /actions-runner-web-login-sync/);
-  assert.match(nativeServer, /-OpenLogin/);
+  assert.equal(webTool, undefined);
+  assert.doesNotMatch(workerSource, /web_login_and_sync_actions|actions-runner-web-login-sync/);
+  assert.doesNotMatch(nativeServer, /web_login_and_sync_actions|-OpenLogin|-WebLogin/);
   assert.match(windowsSyncScript, /OpenAI\.Codex_2p2nqsd0c76g0!App/);
   assert.match(windowsSyncScript, /credentialSource/);
 });

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -167,6 +167,9 @@ test('worker exposes the interactive login sync command', async () => {
   assert.match(nativeSource, /CDPClient\.allCookies/);
   assert.match(nativeSource, /authenticationDeadline/);
   assert.match(nativeSource, /actionsDesktopTarget\(\)/);
+  assert.match(nativeSource, /if actionsDesktopTarget\(\) != nil \{ return \}/);
+  assert.match(nativeSource, /application\.forceTerminate\(\)/);
+  assert.match(nativeSource, /--remote-debugging-port=\\\(CDPClient\.port\(\)\)/);
   assert.match(nativeSource, /actionsDesktopState/);
   assert.match(nativeSource, /electronBridge/);
   assert.match(nativeSource, /actionsLoginPorts/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
@@ -1,6 +1,6 @@
 export const HOME = {
   "schema": "mahayana.miniapp.home.v1",
-  "revision": "f85553ae01df36820bfde933b86c4740fe3c2c5d0c4fa98b9d173f41ce2d926c",
+  "revision": "83125fe73a9a2085ec542be6831fc1ca11a1496b9941dc6d66e822981998c055",
   "app": {
     "id": "chatgpt-auto-confirm",
     "title": "ChatGPT 自动确认",
@@ -18,19 +18,6 @@ export const HOME = {
     }
   ],
   "quickReplies": [
-    {
-      "id": "web-login-and-sync-actions",
-      "label": "桌面端登录并同步 Action 凭证",
-      "aliases": [
-        "桌面端登录",
-        "同步桌面凭证"
-      ],
-      "action": {
-        "type": "tool",
-        "name": "web_login_and_sync_actions",
-        "arguments": {}
-      }
-    },
     {
       "id": "sync-actions-credentials",
       "label": "一键更新凭证到 GitHub Secrets",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
@@ -55,20 +55,12 @@ const queuedTaskSchema = {
   },
 };
 const tools = [
-  { name: 'login_and_sync_actions', description: 'Open the ChatGPT desktop app, wait for its signed-in session, verify it matches the Codex credential, then sync both to GitHub Secrets and optionally start the Action.', annotations: {
+  { name: 'login_and_sync_actions', description: 'Open the ChatGPT desktop app when needed, validate its signed-in app:// renderer and local Codex auth, then export the live renderer session over CDP and sync both credentials to GitHub Secrets.', annotations: {
     readOnlyHint: false, destructiveHint: false, openWorldHint: true,
   }, inputSchema: {
     type: 'object', additionalProperties: false, properties: {
       waitSeconds: { type: 'integer', minimum: 30, maximum: 1800, default: 600 },
       start: { type: 'boolean', default: true },
-    },
-  } },
-  { name: 'web_login_and_sync_actions', description: 'Compatibility command: open the ChatGPT desktop app, wait for its signed-in session, verify it matches the Codex credential, then upload both credentials to GitHub Secrets.', annotations: {
-    readOnlyHint: false, destructiveHint: false, openWorldHint: true,
-  }, inputSchema: {
-    type: 'object', additionalProperties: false, properties: {
-      waitSeconds: { type: 'integer', minimum: 30, maximum: 1800, default: 600 },
-      start: { type: 'boolean', default: false },
     },
   } },
   { name: 'sync_actions_credentials', description: 'Export the live authenticated app:// renderer session from an already-open ChatGPT desktop instance over CDP, validate local Codex auth, then upload both credentials to GitHub Secrets.', annotations: {
@@ -365,11 +357,6 @@ export default {
         rpc.id, 'desktop.chatgpt-approvals.actions-runner-login-sync', {
           waitSeconds: Math.min(1800, Math.max(30, Number(args.waitSeconds ?? 600))),
           start: args.start !== false,
-        }, 'required');
-      if (name === 'web_login_and_sync_actions') return hostResult(
-        rpc.id, 'desktop.chatgpt-approvals.actions-runner-web-login-sync', {
-          waitSeconds: Math.min(1800, Math.max(30, Number(args.waitSeconds ?? 600))),
-          start: args.start === true,
         }, 'required');
       if (name === 'sync_actions_credentials') return hostResult(
         rpc.id, 'desktop.chatgpt-approvals.actions-runner-credential-sync', {


### PR DESCRIPTION
## What changed

- if explicit desktop credential sync finds a running ChatGPT app without a live CDP renderer, terminate that ordinary instance and relaunch ChatGPT with the configured remote-debugging port
- preserve direct reuse when a valid app:// renderer is already exposed
- add contract coverage for the fallback behavior

## Validation

- credential contract tests pass (8/8)