### PR TITLE
fix(actions): require terminal task reports

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/content/articles/guide.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/content/articles/guide.md
@@ -1,6 +1,6 @@
 ---
 id: guide
-revision: '5'
+revision: '6'
 title: 使用指南
 publishedAt: 2026-07-19
 summary: 在同一实例中创建隐藏任务队列、后台确认会话、自动续作并独立验收。
@@ -12,8 +12,8 @@ tags: [指南, 任务队列, 自动续作]
 
 1. 用「内置任务提示词」选择实现、诊断、审查或持续完成模板。
 2. 用 `enqueue_tasks` 一次加入多个任务。任务会进入持久队列，并与通用确认共用同一个已登录的 ChatGPT 实例。每个运行中任务使用独立的隐藏预热页面；无依赖且资源锁不冲突的任务按 `maxConcurrent` 并行执行。
-3. 每个 Chat 的最终回答必须包含 `mahayana.task-report.v1` 总结。若状态为 `incomplete` 或 `blocked`，小程序会根据 `remaining`、`blockers` 和 `next_task` 自动新建 Chat 续作。
-4. 完成项会由程序自动在同一实例的隐藏页面中新建 Chat 独立验收；验收 Chat 返回 `complete` 后直接启动下一项，不向用户索要确认。`review_task` 仅保留为人工恢复/兼容入口，Worker 页面只展示状态。
+3. 每个 Chat 的最终回答必须包含 `mahayana.task-report.v1` 总结。全部完成时必须返回 `status=complete`，并把 `remaining`、`blockers`、`next_task` 设为空数组或空字符串；未完成时返回 `status=incomplete` 或 `blocked`，小程序会根据 `remaining`、`blockers` 和 `next_task` 自动新建 Chat 续作。
+4. 完成报告会由程序自动在同一实例的隐藏页面中新建 Chat 独立验收；验收 Chat 返回同一任务修订的 `status=complete` 报告后，任务进入终态，不会再次派发。`review_task` 仅保留为人工恢复/兼容入口，Worker 页面只展示状态。
 
 ## 中断恢复
 

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -7,12 +7,19 @@ import SystemConfiguration
 
 // MARK: - CDP interaction JS scripts
 
-func taskReportContract() -> String {
-  """
+func legacyTaskReportContract(
+  taskId: String? = nil,
+  appliedRevision: Int? = nil,
+  appliedDigest: String? = nil
+) -> String {
+  let reportTaskId = jsonStringLiteral(taskId ?? "CURRENT_TASK_ID")
+  let reportRevision = String(appliedRevision ?? 1)
+  let reportDigest = jsonStringLiteral(appliedDigest ?? "CURRENT_SPEC_DIGEST")
+  return """
 
-持续执行要求：不要只描述下一步、不要阶段性收尾、不要回复等待时间。没有完成目标不要停，一直工作下去直到实现目标！需要时间跑的异步任务（如 GitHub Actions）必须自己运行 sleep 睡眠命令，睡眠之后起来检查是否完成，未完成则继续执行 sleep 等待，直到出结果并立刻继续。全部目标完成时直接给出正常最终结果，不要输出机器模板；小程序会把该结果发送到新的独立验收 Chat。
+// Retained only as a compatibility symbol; all outbound task messages use taskReportContract below.
 
-只有出现当前权限和工具确实无法绕过的阻塞，或平台硬性终止本次会话且任务仍未完成时，才在回答末尾输出以下未完成续作模板。不要把 JSON 放进 Markdown 代码块：
+// Legacy report text intentionally disabled.
 MAHAYANA_TASK_REPORT_V1_BEGIN
 {"protocol":"mahayana.task-report.v1","task_id":"必须与当前任务编号一致","applied_task_revision":1,"applied_spec_digest":"必须与当前规范指纹一致","status":"incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项"],"blockers":["真实卡点；没有则用空数组"],"verification":["已取得的验证证据"],"next_connector":"下一新 Chat 要使用的 connector；无需切换则为空字符串","next_task":"给下一个工作 Chat 的完整可执行续作指令"}
 MAHAYANA_TASK_REPORT_V1_END
@@ -20,8 +27,44 @@ MAHAYANA_TASK_REPORT_V1_END
 """
 }
 
-func messageWithTaskReportContract(_ message: String) -> String {
-  message.contains("MAHAYANA_TASK_REPORT_V1_BEGIN") ? message : message + taskReportContract()
+func taskReportContract(
+  taskId: String? = nil,
+  appliedRevision: Int? = nil,
+  appliedDigest: String? = nil
+) -> String {
+  let reportTaskId = jsonStringLiteral(taskId ?? "CURRENT_TASK_ID")
+  let reportRevision = String(appliedRevision ?? 1)
+  let reportDigest = jsonStringLiteral(appliedDigest ?? "CURRENT_SPEC_DIGEST")
+  return """
+
+每一轮 Chat 的最终回复都必须包含一个完整的机器报告；不要只写自然语言，也不要把 JSON 放进 Markdown 代码块。报告中的 task_id、applied_task_revision 和 applied_spec_digest 必须使用当前任务的真实值。
+
+全部目标和验证已经完成时，必须使用完成模板：
+MAHAYANA_TASK_REPORT_V1_BEGIN
+{"protocol":"mahayana.task-report.v1","task_id":\(reportTaskId),"applied_task_revision":\(reportRevision),"applied_spec_digest":\(reportDigest),"status":"complete","summary":"本轮实际结果","completed":["已完成项"],"remaining":[],"blockers":[],"verification":["可复核验证证据"],"wait_seconds":0,"wait_reason":"","next_connector":"","next_task":""}
+MAHAYANA_TASK_REPORT_V1_END
+
+只有确实未完成或被真实阻塞时，才使用未完成模板，并且 remaining 和 next_task 必须如实填写：
+MAHAYANA_TASK_REPORT_V1_BEGIN
+{"protocol":"mahayana.task-report.v1","task_id":\(reportTaskId),"applied_task_revision":\(reportRevision),"applied_spec_digest":\(reportDigest),"status":"incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项"],"blockers":["真实卡点；没有则用空数组"],"verification":["已取得的验证证据"],"wait_seconds":0,"wait_reason":"","next_connector":"","next_task":"给下一个 Chat 的完整可执行续作指令"}
+MAHAYANA_TASK_REPORT_V1_END
+未完成报告会触发新 Chat 续作；完成报告会被小程序标记为完成并停止该任务的重复派发。
+"""
+}
+
+func messageWithTaskReportContract(
+  _ message: String,
+  taskId: String? = nil,
+  appliedRevision: Int? = nil,
+  appliedDigest: String? = nil
+) -> String {
+  message.contains("MAHAYANA_TASK_REPORT_V1_BEGIN")
+    ? message
+    : message + taskReportContract(
+      taskId: taskId,
+      appliedRevision: appliedRevision,
+      appliedDigest: appliedDigest
+    )
 }
 
 func parseTaskReport(_ content: String) -> [String: Any]? {
@@ -37,6 +80,12 @@ func parseTaskReport(_ content: String) -> [String: Any]? {
   guard let data = raw.data(using: .utf8),
         let report = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
         report["protocol"] as? String == "mahayana.task-report.v1",
+        let taskId = report["task_id"] as? String,
+        !taskId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+        let appliedRevision = report["applied_task_revision"] as? Int,
+        appliedRevision >= 1,
+        let appliedDigest = report["applied_spec_digest"] as? String,
+        !appliedDigest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
         let status = report["status"] as? String,
         ["complete", "incomplete", "blocked"].contains(status),
         report["summary"] is String,
@@ -92,7 +141,12 @@ func continuationFromTaskReport(
 
 先核实这些修改是否已落盘，再继续剩余实现与验证。只有全部完成后才能报告 complete。
 """
-  return messageWithTaskReportContract(body)
+  return messageWithTaskReportContract(
+    body,
+    taskId: report["task_id"] as? String,
+    appliedRevision: report["applied_task_revision"] as? Int,
+    appliedDigest: report["applied_spec_digest"] as? String
+  )
 }
 
 func relayFreshChatContinuation(_ params: [String: Any]) -> Never {
@@ -1594,7 +1648,7 @@ func getReplyJS() -> String {
       && completedActivity.length > 0
       && !toolOnlyCompletedActivity
       && !explicitlyIncomplete
-      && explicitFinalResult;
+      && (explicitFinalResult || structuredComplete);
     const terminalIncomplete = (!active || hasClosedTaskReport)
       && !waitingForApproval
       && !stopBtn

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
@@ -399,7 +399,7 @@ func automationReviewMessage(
   已完成项：\(completed)
   被验收 Chat 的验证：\(verification)
 
-  请检查工作树、关键实现、Git/GitHub/Actions 或发布构件等与任务目标相关的证据。云端 GitHub 状态必须通过 GitHub 连接器核验；本地 checkout 仅通过 bhrum2 读取或安全同步。重型测试、构建和安装包验证必须以 GitHub Actions 结果为准，不要在本机生成构建产物。若 Actions、部署、发布审核或网络恢复仍在进行，必须留在这个验收 Chat 内自行等待并轮询，拿到结果后继续验收，不得回复等待时间后退出。重复卡点不能只照抄旧错误，应诊断并换可行路径。只有全部目标可复核且验证通过时，最后单独输出一行 `MAHAYANA_REVIEW_ACCEPTED`；不要输出完成态 JSON。若验收不通过，输出未完成续作模板，准确写出 remaining、blockers、verification 和 next_task，供小程序新建工作 Chat 继续；只有真实不可绕过的阻塞才可使用 blocked。
+  请检查工作树、关键实现、Git/GitHub/Actions 或发布构件等与任务目标相关的证据。云端 GitHub 状态必须通过 GitHub 连接器核验；本地 checkout 仅通过 bhrum2 读取或安全同步。重型测试、构建和安装包验证必须以 GitHub Actions 结果为准，不要在本机生成构建产物。若 Actions、部署、发布审核或网络恢复仍在进行，必须留在这个验收 Chat 内自行等待并轮询，拿到结果后继续验收，不得回复等待时间后退出。重复卡点不能只照抄旧错误，应诊断并换可行路径。验收全部通过时，必须按消息末尾的完成模板输出同一任务修订的 `status=complete` 报告；验收不通过时，必须按未完成模板输出 `status=incomplete` 或 `status=blocked` 报告。`MAHAYANA_REVIEW_ACCEPTED` 可以作为辅助证据，但不是完成识别的唯一条件。
   """
 }
 
@@ -417,7 +417,12 @@ func startAutomationReview(
   ), prepared["ok"] as? Bool == true else {
     return false
   }
-  let outbound = messageWithTaskReportContract(automationReviewMessage(task, report: report))
+  let outbound = messageWithTaskReportContract(
+    automationReviewMessage(task, report: report),
+    taskId: task.id,
+    appliedRevision: task.currentRevision,
+    appliedDigest: task.specDigest
+  )
   guard let sendResult = cdpValue(
     port: port,
     targetId: targetId,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1416,7 +1416,12 @@ func startAutomationTask(
   task.appliedRevision = max(1, task.currentRevision ?? 1)
   task.appliedSpecDigest = task.specDigest
   task.pendingRevision = nil
-  let outbound = messageWithTaskReportContract(automationTaskMessage(task))
+  let outbound = messageWithTaskReportContract(
+    automationTaskMessage(task),
+    taskId: task.id,
+    appliedRevision: task.appliedRevision,
+    appliedDigest: task.appliedSpecDigest
+  )
   queueTrace("task=\(task.id) stage=send begin")
   guard let sendResult = cdpValue(
     port: port,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -2115,20 +2115,21 @@ case "send_and_watch":
 
   var resultPayload: [String: Any] = [:]
   let terminalIncomplete = finalReply["terminalIncomplete"] as? Bool ?? false
-  let taskReport = parseTaskReport(replyContent)
+  let reportSource = [
+    replyContent,
+    finalReply["completedActivity"] as? String ?? "",
+  ].joined(separator: "\n")
+  let taskReport = parseTaskReport(reportSource)
   let taskStatus = taskReport?["status"] as? String
   let finalChatStatus = cdpEvaluateOnChatGPT(chatStatusJS(), preferredURL: activeChatURL) ?? [:]
   let finalConversationId = finalChatStatus["conversationId"] as? String
     ?? state.backgroundConversationId
   let finalChatURL = finalChatStatus["chatUrl"] as? String
   let explicitlyIncomplete = finalReply["explicitlyIncomplete"] as? Bool ?? false
-  let normalCompletion = !resumeExisting && !surfaceDrift && !stalled && !timedOut
-    && finalReply["done"] as? Bool == true && taskReport == nil
-    && !terminalIncomplete && !explicitlyIncomplete
-  let effectiveTaskStatus = taskStatus ?? (normalCompletion ? "complete" : nil)
+  let effectiveTaskStatus = taskStatus
   let reportMissing = !resumeExisting && !surfaceDrift && !stalled && !timedOut
     && finalReply["done"] as? Bool == true && taskReport == nil
-    && !normalCompletion
+    && !terminalIncomplete && !explicitlyIncomplete
   resultPayload["ok"] = !stalled && !timedOut && !surfaceDrift && !terminalIncomplete
     && !reportMissing && effectiveTaskStatus == "complete" && (finalReply["done"] as? Bool == true)
   resultPayload["sent"] = resumeExisting ? false : (sendResult["messageConfirmed"] as? Bool ?? false)

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -252,7 +252,15 @@ func actionsDesktopTarget() -> ActionsLoginTarget? {
 }
 
 func ensureChatGPTDesktopRunning() {
-  if !runningChatGptApplications().isEmpty { return }
+  if actionsDesktopTarget() != nil { return }
+  let runningApplications = runningChatGptApplications()
+  for application in runningApplications {
+    application.terminate()
+  }
+  Thread.sleep(forTimeInterval: 1.0)
+  for application in runningApplications where !application.isTerminated {
+    application.forceTerminate()
+  }
   let applicationURL = URL(fileURLWithPath: "/Applications/ChatGPT.app")
   guard FileManager.default.fileExists(atPath: applicationURL.path) else { return }
   let configuration = NSWorkspace.OpenConfiguration()

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -37,7 +37,7 @@ let nativeCommandSummaries: [String: String] = [
   "queue_watchdog": "超过阈值仍未完成时安全重建隐藏 Chat，并重启队列守护。",
   "start_actions_runner": "刷新加密任务状态与登录 Secret，并启动最长六小时的 GitHub Actions 持续运行器。",
   "sync_actions_credentials": "从已打开的 ChatGPT 桌面 app renderer 实时导出会话并同步到 GitHub Secrets。",
-  "login_and_sync_actions": "打开 ChatGPT 登录页，等待登录完成后同步 ChatGPT 与 Codex 凭证，并启动 GitHub Actions。",
+  "login_and_sync_actions": "按需打开 ChatGPT 桌面应用，等待 app renderer 登录完成后实时同步 ChatGPT 与 Codex 凭证，并启动 GitHub Actions。",
   "verify_chatgpt_login": "只读验证当前 ChatGPT 桌面 app renderer 是否仍处于登录状态。",
   "send_message": "在插件隐藏 Chat 页面中发送一条消息。",
   "add_connector": "在隐藏 Chat 页面中选择一个 ChatGPT connector。",
@@ -125,7 +125,7 @@ func nativeHelpText(topic: String? = nil) -> (text: String, known: Bool) {
   }
 
   let text = """
-  login_and_sync_actions JSON  login to ChatGPT, sync both Action credentials, and start the runner
+  login_and_sync_actions JSON  open the ChatGPT desktop app, sync both live credentials, and start the runner
 
 ChatGPT 自动确认 macOS 原生运行时
 
@@ -164,7 +164,8 @@ ChatGPT 自动确认 macOS 原生运行时
   queue_cancel JSON      取消任务
   queue_watchdog JSON    检查超时并安全恢复队列
   start_actions_runner   启动六小时 GitHub Actions 持续运行器
-  sync_actions_credentials JSON  自动抓取当前两份登录凭证并同步，可选启动 Actions
+  sync_actions_credentials JSON  从已打开的桌面 app renderer 实时抓取当前两份登录凭证并同步，可选启动 Actions
+  login_and_sync_actions JSON    按需打开桌面应用后使用相同实时抓取方式同步凭证
 
 隐藏 Chat：
   send_message JSON      发送消息
@@ -356,8 +357,14 @@ func writeActionsSessionCookies(_ cookies: [[String: Any]]) throws -> URL {
           let value = cookie["value"] as? String,
           let domain = cookie["domain"] as? String,
           !name.isEmpty, !value.isEmpty, !domain.isEmpty else { return nil }
-    let lowerDomain = domain.lowercased()
-    guard lowerDomain.contains("chatgpt.com") || lowerDomain.contains("openai.com") else {
+    let lowerDomain = domain.lowercased().hasPrefix(".")
+      ? String(domain.lowercased().dropFirst())
+      : domain.lowercased()
+    let allowedDomain = lowerDomain == "chatgpt.com"
+      || lowerDomain.hasSuffix(".chatgpt.com")
+      || lowerDomain == "openai.com"
+      || lowerDomain.hasSuffix(".openai.com")
+    guard allowedDomain else {
       return nil
     }
     var result: [String: Any] = [
@@ -493,7 +500,8 @@ func finishActionsCredentialSync(
 
 func syncLiveActionsCredentials(
   waitSeconds: Int,
-  startRunner: Bool
+  startRunner: Bool,
+  openDesktopIfNeeded: Bool = false
 ) -> Never {
   guard !codexChatGPTIdentifiers().isEmpty else {
     output([
@@ -506,7 +514,7 @@ func syncLiveActionsCredentials(
   var lastState: [String: Any] = [:]
   var verifiedTarget: ActionsLoginTarget?
   var target = actionsDesktopTarget()
-  if target == nil {
+  if target == nil && openDesktopIfNeeded {
     ensureChatGPTDesktopRunning()
   }
   while Date() < deadline {
@@ -1109,12 +1117,20 @@ case "sync_actions_credentials":
   let params = commandJSONParams()
   let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? false
-  syncLiveActionsCredentials(waitSeconds: waitSeconds, startRunner: startRunner)
+  syncLiveActionsCredentials(
+    waitSeconds: waitSeconds,
+    startRunner: startRunner,
+    openDesktopIfNeeded: false
+  )
 case "login_and_sync_actions":
   let params = commandJSONParams()
   let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? true
-  syncLiveActionsCredentials(waitSeconds: waitSeconds, startRunner: startRunner)
+  syncLiveActionsCredentials(
+    waitSeconds: waitSeconds,
+    startRunner: startRunner,
+    openDesktopIfNeeded: true
+  )
 case "start_actions_runner":
   let executableURL = URL(
     fileURLWithPath: CommandLine.arguments[0]

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/compile-content.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/compile-content.mjs
@@ -39,7 +39,6 @@ for (const [folder, kind] of kinds) {
 items.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt) || a.id.localeCompare(b.id));
 const source = JSON.stringify({ welcome, tips, items, resources });
 const quickReplies = [
-  { id: 'web-login-and-sync-actions', label: '桌面端登录并同步 Action 凭证', aliases: ['桌面端登录', '同步桌面凭证'], action: { type: 'tool', name: 'web_login_and_sync_actions', arguments: {} } },
   { id: 'sync-actions-credentials', label: '一键更新凭证到 GitHub Secrets', aliases: ['同步已登录凭证', '更新 Action 凭证', '一键更新凭证'], action: { type: 'tool', name: 'sync_actions_credentials', arguments: {} } },
   { id: 'login-and-sync-actions', label: '登录并同步 Action 凭证', aliases: [], action: { type: 'tool', name: 'login_and_sync_actions', arguments: {} } },
   { id: 'queue-status', label: '查看任务队列', aliases: [], action: { type: 'tool', name: 'queue_status', arguments: {} } },

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -22,6 +22,8 @@ if (mode !== 'verify') {
 const sleep = milliseconds =>
   new Promise(resolve => setTimeout(resolve, milliseconds));
 
+const appRootURL = 'app://-/index.html?initialRoute=%2F';
+
 const listTargets = async () =>
   fetch(`http://127.0.0.1:${port}/json/list`, {
     signal: AbortSignal.timeout(5_000),
@@ -29,7 +31,9 @@ const listTargets = async () =>
 
 const findTarget = async (timeoutMs, label) => {
   const deadline = Date.now() + timeoutMs;
+  const avatarOverlayFallbackDeadline = Date.now() + Math.min(10_000, timeoutMs);
   let lastTargets = [];
+  let avatarOverlayTarget;
   while (Date.now() < deadline) {
     try {
       lastTargets = await listTargets();
@@ -40,9 +44,23 @@ const findTarget = async (timeoutMs, label) => {
         && !String(item.url || '').includes('/avatar-overlay')
       );
       if (target) return target;
+      avatarOverlayTarget = lastTargets.find(item =>
+        item.type === 'page'
+        && item.webSocketDebuggerUrl
+        && String(item.url || '').startsWith('app://-/index.html')
+        && String(item.url || '').includes('/avatar-overlay')
+      ) || avatarOverlayTarget;
+      // The desktop app can expose only its startup avatar overlay while the
+      // normal renderer is being bootstrapped. It is still a valid CDP page;
+      // recover it to the app root after connecting instead of waiting for a
+      // renderer that the app will not create on its own.
+      if (avatarOverlayTarget && Date.now() >= avatarOverlayFallbackDeadline) {
+        return avatarOverlayTarget;
+      }
     } catch {}
     await sleep(1_000);
   }
+  if (avatarOverlayTarget) return avatarOverlayTarget;
   const safeTargets = lastTargets.map(item => ({
     type: item.type,
     url: String(item.url || '').slice(0, 160),
@@ -123,6 +141,21 @@ const connect = async target => {
   return { socket, call };
 };
 
+const restoreAppRootIfNeeded = async call => {
+  let currentURL = '';
+  try {
+    const evaluation = await call('Runtime.evaluate', {
+      expression: 'location.href',
+      returnByValue: true,
+    }, 5_000);
+    currentURL = String(evaluation.result?.value || '');
+  } catch {}
+  if (!currentURL.includes('/avatar-overlay')) return false;
+  const navigated = await optionalCall(call, 'Page.navigate', { url: appRootURL }, 10_000);
+  if (navigated) await sleep(1_000);
+  return navigated;
+};
+
 const optionalCall = async (call, method, params = {}, timeoutMs = 5_000) => {
   try {
     await call(method, params, timeoutMs);
@@ -164,10 +197,16 @@ if (mode !== 'verify') {
   }
 }
 
+// A fresh hosted desktop launch can land on the internal avatar overlay
+// instead of the normal app shell. The overlay is blank but remains a live
+// renderer, so navigate that same target back to the authenticated app root.
+await restoreAppRootIfNeeded(call);
+
 if (mode === 'restore' || mode === 'restore-and-verify') {
   // Page.reload is a bounded request and is more reliable than evaluating
   // location.reload() inside a renderer that may still be suspended.
   await optionalCall(call, 'Page.reload', { ignoreCache: true }, 10_000);
+  await restoreAppRootIfNeeded(call);
 }
 await activate(call);
 
@@ -189,6 +228,7 @@ let verified = false;
 let lastState = {};
 while (Date.now() < verificationDeadline) {
   await sleep(2_000);
+  await restoreAppRootIfNeeded(call);
   let evaluation;
   try {
     evaluation = await call('Runtime.evaluate', {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/sync-actions-credentials.ps1
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/sync-actions-credentials.ps1
@@ -2,10 +2,7 @@
 param(
   [string]$Repository = $(if ($env:CHATGPT_AUTO_CONFIRM_REPOSITORY) { $env:CHATGPT_AUTO_CONFIRM_REPOSITORY } else { 'bhrumom/fabushi' }),
   [int]$WaitSeconds = 600,
-  [switch]$OpenLogin,
   [switch]$DesktopLogin,
-  # Kept as a compatibility alias. It now opens the ChatGPT desktop app too.
-  [switch]$WebLogin,
   [switch]$Start
 )
 
@@ -92,10 +89,7 @@ try {
   & $script:GitHubCli.Source auth status *> $null
   if ($LASTEXITCODE -ne 0) { throw 'GitHub CLI is not authenticated; run gh auth login first' }
 
-  $desktopLoginRequested = $OpenLogin -or $DesktopLogin -or $WebLogin
-  if ((@($OpenLogin, $DesktopLogin, $WebLogin) | Where-Object { $_ }).Count -gt 1) {
-    throw 'desktop login was requested more than once'
-  }
+  $desktopLoginRequested = $DesktopLogin
 
   $authPath = if ($env:CHATGPT_CODEX_AUTH_PATH) {
     [string]$env:CHATGPT_CODEX_AUTH_PATH

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/server/index.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/server/index.mjs
@@ -12,7 +12,6 @@ const windowsCredentialScript = fileURLToPath(new URL(
 const windowsCredentialTools = new Set([
   'sync_actions_credentials',
   'login_and_sync_actions',
-  'web_login_and_sync_actions',
 ]);
 const nativeCommands = new Map([
   ['start', 'start'], ['stop', 'stop'], ['status', 'status'],
@@ -53,12 +52,7 @@ function runWindowsCredentialTool(rpc) {
     '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', windowsCredentialScript,
   ];
   if (tool === 'login_and_sync_actions') {
-    args.push('-OpenLogin', '-WaitSeconds', String(
-      Math.min(1800, Math.max(30, Number(rpc.params?.arguments?.waitSeconds ?? 600))),
-    ));
-  }
-  if (tool === 'web_login_and_sync_actions') {
-    args.push('-OpenLogin', '-WaitSeconds', String(
+    args.push('-DesktopLogin', '-WaitSeconds', String(
       Math.min(1800, Math.max(30, Number(rpc.params?.arguments?.waitSeconds ?? 600))),
     ));
   }
@@ -110,7 +104,7 @@ function runNativeTool(rpc) {
     : ['start_queue', 'wait_for_review'].includes(tool)
       ? 7_300_000
     : ['start', 'scan_once', 'relaunch_and_confirm'].includes(tool) ? 620_000
-    : ['start_actions_runner', 'sync_actions_credentials', 'login_and_sync_actions', 'web_login_and_sync_actions'].includes(tool) ? 1_200_000 : 15_000;
+    : ['start_actions_runner', 'sync_actions_credentials', 'login_and_sync_actions'].includes(tool) ? 1_200_000 : 15_000;
   const invocation = spawnSync(nativeRuntime, args, {
     encoding: 'utf8', timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024,
     env: process.env,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/actions-first-task-queue/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/actions-first-task-queue/SKILL.md
@@ -32,15 +32,15 @@ Do not repeat the same failed command or connector path. Diagnose the cause firs
 
 Do not stop a task just because an external operation is slow. Keep the active Chat working and poll normal asynchronous operations (Actions, deployments, releases, network recovery, remote checks) whenever possible. Do not ask the user to wait and do not return a wait countdown for normal waiting. Only emit an unfinished report when the current execution cannot continue due to a real blocker or the platform requires a handoff.
 
-Use the task report only for unfinished handoff cases. A completed task returns a normal final result and then a separate acceptance Chat verifies it. Do not include the machine report in every successful completion.
+Every work and acceptance Chat must end with the machine report. A completed work Chat returns `status=complete` and then a separate acceptance Chat verifies it; the acceptance Chat also returns a same-revision `status=complete` report before the queue marks the task terminal. Do not rely on a natural-language completion or a standalone acceptance marker.
 
 ```text
 MAHAYANA_TASK_REPORT_V1_BEGIN
-{"protocol":"mahayana.task-report.v1","status":"incomplete|blocked","summary":"...","completed":["..."],"remaining":["..."],"blockers":["..."],"verification":["..."],"wait_seconds":0,"wait_reason":"","next_connector":"GitHub|bhrum2|","next_task":"..."}
+{"protocol":"mahayana.task-report.v1","task_id":"current task id","applied_task_revision":1,"applied_spec_digest":"current spec digest","status":"complete|incomplete|blocked","summary":"...","completed":["..."],"remaining":[],"blockers":[],"verification":["..."],"wait_seconds":0,"wait_reason":"","next_connector":"GitHub|bhrum2|","next_task":""}
 MAHAYANA_TASK_REPORT_V1_END
 ```
 
-- For completed work, do not output this machine report; send the result to a separate acceptance Chat.
+- For completed work, output the complete machine report; the queue then sends the result to a separate acceptance Chat.
 - For unfinished work, use `incomplete` or `blocked`, keep `wait_seconds` as `0`, and provide a concrete `next_task` for the next Chat.
 - Normal Actions/deployment/network polling is not a reason to end the Chat.
 - For a real unsolved blocker, state exactly what is needed: permission, account, tool, environment variable, command, or external service recovery condition.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
@@ -9,13 +9,14 @@ description: 从已经打开并登录的 ChatGPT 桌面应用 app:// renderer �
 
 ## 流程
 
-1. 调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true, "waitSeconds": 600 }`；只更新密钥时传入 `{ "start": false, "waitSeconds": 600 }`。
-2. 命令只复用已经打开的 ChatGPT 桌面应用 `app://-/index.html` renderer；不得新建、打开或依赖 `https://chatgpt.com` 网页 renderer，也不得使用外部浏览器。
-3. 通过桌面 renderer 的 `electronBridge`、登录提示、模式控件和 composer 状态验证桌面实例已经登录；同时验证 `~/.codex/auth.json` 结构完整。未登录时停止，不上传任何凭证。
-4. 验证成功后，立即通过该桌面 renderer 的 CDP `Network.getAllCookies` 实时导出 Cookie，规范化后原子写入本机私有 `session-cookies.json`。禁止读取、复制或解密任何浏览器、Codex 或 ChatGPT 桌面资料库中的 Cookie 数据库。
-5. 使用 `base64` 管道向 `gh secret set` 同步 Codex 凭证和刚抓取的 ChatGPT 会话；不得读取或上传本地任务队列状态，也不得复用未验证的旧 Cookie 文件。
-6. 任务目标与任务文档只来自仓库内的 `tasks/actions-inbox.json`、`documentDirectory` 和 `specSources`。运行器启动后持续读取这些可动态更新的文件；不得用 Secret 固化任务定义。
-7. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称、Cookie 数量和账号已验证状态；绝不返回 token、Cookie、auth 文件内容、账号 ID 或 Base64 值。
+1. 已有打开且登录的桌面实例时，调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true, "waitSeconds": 600 }`；只更新密钥时传入 `{ "start": false, "waitSeconds": 600 }`。
+2. `sync_actions_credentials` 只复用已经打开的 ChatGPT 桌面应用 `app://-/index.html` renderer；找不到时必须失败，不得隐式打开其他实例。只有用户明确要求打开桌面应用并等待登录时才调用 `login_and_sync_actions`，且打开后仍必须使用完全相同的 `app://` + CDP 实时导出流程。
+3. 不得提供或调用任何名为“web login”或“browser login”的兼容入口；不得新建、打开或依赖 `https://chatgpt.com` 网页 renderer，也不得使用外部浏览器。
+4. 通过桌面 renderer 的 `electronBridge`、登录提示、模式控件和 composer 状态验证桌面实例已经登录；同时验证 `~/.codex/auth.json` 结构完整。未登录时停止，不上传任何凭证。
+5. 验证成功后，立即通过该桌面 renderer 的 CDP `Network.getAllCookies` 实时导出 Cookie，规范化后原子写入本机私有 `session-cookies.json`。禁止读取、复制或解密任何浏览器、Codex 或 ChatGPT 桌面资料库中的 Cookie 数据库。
+6. 使用 `base64` 管道向 `gh secret set` 同步 Codex 凭证和刚抓取的 ChatGPT 会话；不得读取或上传本地任务队列状态，也不得复用未验证的旧 Cookie 文件。
+7. 任务目标与任务文档只来自仓库内的 `tasks/actions-inbox.json`、`documentDirectory` 和 `specSources`。运行器启动后持续读取这些可动态更新的文件；不得用 Secret 固化任务定义。
+8. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称、Cookie 数量和账号已验证状态；绝不返回 token、Cookie、auth 文件内容、账号 ID 或 Base64 值。
 
 ## 目标 Secrets
 

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -53,12 +53,10 @@ test('home contract', () => {
   assert.ok(Buffer.byteLength(JSON.stringify(HOME)) <= 32768);
   assert.ok(HOME.feed.items.length <= 10);
   assert.deepEqual(HOME.quickReplies.map(item => item.action.name), [
-    'web_login_and_sync_actions', 'sync_actions_credentials', 'login_and_sync_actions', 'queue_status', 'start_actions_runner',
+    'sync_actions_credentials', 'login_and_sync_actions', 'queue_status', 'start_actions_runner',
     'prompt_templates', 'wait_for_review',
   ]);
-  const webLoginReply = HOME.quickReplies.find(item => item.action.name === 'web_login_and_sync_actions');
-  assert.equal(webLoginReply.label, '桌面端登录并同步 Action 凭证');
-  assert.deepEqual(webLoginReply.aliases, ['桌面端登录', '同步桌面凭证']);
+  assert.equal(HOME.quickReplies.some(item => item.action.name === 'web_login_and_sync_actions'), false);
 });
 test('article bodies stay lazy', () => assert.ok(Object.keys(RESOURCES).length >= 1));
 test('continuous Actions runner preserves secrets and chains incomplete sessions', () => {
@@ -138,6 +136,8 @@ test('Windows credential sync keeps secrets out of logs and supports optional di
   assert.doesNotMatch(windowsSyncScript, /chatgpt-cookie-capture-extension/);
   assert.doesNotMatch(windowsSyncScript, /auth\.openai\.com\/oauth/);
   assert.match(windowsSyncScript, /WaitSeconds/);
+  assert.match(windowsSyncScript, /\[switch\]\$DesktopLogin/);
+  assert.doesNotMatch(windowsSyncScript, /\$OpenLogin|\$WebLogin/);
   assert.match(liveSessionExporter, /Network\.getAllCookies/);
   assert.match(liveSessionExporter, /Runtime\.evaluate/);
   assert.match(liveSessionExporter, /app:\/\/-\/index\.html/);
@@ -174,19 +174,20 @@ test('worker exposes the interactive login sync command', async () => {
   assert.doesNotMatch(nativeSource, /createActionsWebLoginTarget|actionsWebSessionMatchesCodex/);
   assert.doesNotMatch(nativeSource, /actionsWebLoginState|api\/auth\/session/);
   assert.match(nativeSource, /syncLiveActionsCredentials/);
+  assert.match(nativeSource, /openDesktopIfNeeded: Bool = false/);
+  assert.match(nativeSource, /startRunner: startRunner,\s+openDesktopIfNeeded: false/);
+  assert.match(nativeSource, /startRunner: startRunner,\s+openDesktopIfNeeded: true/);
   assert.match(nativeSource, /credentialSource": "live-desktop-renderer"/);
   assert.doesNotMatch(nativeSource, /credentialSource": "local-files"/);
   assert.doesNotMatch(nativeSource, /extractVerifiedMacOS|macOSCookieExtractor/);
   assert.doesNotMatch(nativeSource, /webSessionIdentifiers/);
   assert.match(nativeSource, /!url\.contains\("avatar-overlay"\)/);
-  assert.match(nativeServer, /-OpenLogin/);
+  assert.match(nativeServer, /-DesktopLogin/);
   assert.match(nativeServer, /-WaitSeconds/);
   const webTool = tools.find(item => item.name === 'web_login_and_sync_actions');
-  assert.ok(webTool);
-  assert.equal(webTool.inputSchema.properties.start.default, false);
-  assert.equal(webTool.inputSchema.properties.waitSeconds.default, 600);
-  assert.match(workerSource, /actions-runner-web-login-sync/);
-  assert.match(nativeServer, /-OpenLogin/);
+  assert.equal(webTool, undefined);
+  assert.doesNotMatch(workerSource, /web_login_and_sync_actions|actions-runner-web-login-sync/);
+  assert.doesNotMatch(nativeServer, /web_login_and_sync_actions|-OpenLogin|-WebLogin/);
   assert.match(windowsSyncScript, /OpenAI\.Codex_2p2nqsd0c76g0!App/);
   assert.match(windowsSyncScript, /credentialSource/);
 });

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -167,6 +167,9 @@ test('worker exposes the interactive login sync command', async () => {
   assert.match(nativeSource, /CDPClient\.allCookies/);
   assert.match(nativeSource, /authenticationDeadline/);
   assert.match(nativeSource, /actionsDesktopTarget\(\)/);
+  assert.match(nativeSource, /if actionsDesktopTarget\(\) != nil \{ return \}/);
+  assert.match(nativeSource, /application\.forceTerminate\(\)/);
+  assert.match(nativeSource, /--remote-debugging-port=\\\(CDPClient\.port\(\)\)/);
   assert.match(nativeSource, /actionsDesktopState/);
   assert.match(nativeSource, /electronBridge/);
   assert.match(nativeSource, /actionsLoginPorts/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -75,6 +75,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(restoreSessionScript, /mode === 'restore'/);
   assert.match(restoreSessionScript, /process\.exit\(0\)/);
   assert.match(restoreSessionScript, /Page\.reload/);
+  assert.match(restoreSessionScript, /Page\.navigate/);
+  assert.match(restoreSessionScript, /avatar-overlay/);
+  assert.match(restoreSessionScript, /initialRoute=%2F/);
   assert.match(restoreSessionScript, /Optional CDP command/);
   assert.doesNotMatch(restoreSessionScript, /call\([^\n]*['"]Page\.setWebLifecycleState['"]/);
   assert.doesNotMatch(actionsWorkflow, /pkill -x ChatGPT/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -96,6 +96,19 @@ test('outbound sends discard old chat URLs while read-only reply requests keep t
   assert.equal(reply.result.structuredContent.hostRequest.params.chatUrl, chatUrl);
 });
 
+test('every task Chat receives complete and unfinished report templates', () => {
+  assert.match(chatScriptsSource, /func taskReportContract\(/);
+  assert.match(chatScriptsSource, /"status":"complete"/);
+  assert.match(chatScriptsSource, /"remaining":\[\],"blockers":\[\]/);
+  assert.match(chatScriptsSource, /"next_task":""/);
+  assert.match(chatScriptsSource, /"status":"incomplete\|blocked"/);
+  assert.doesNotMatch(chatScriptsSource, /不要输出完成态 JSON/);
+  assert.match(nativeSource, /taskId: task\.id/);
+  assert.match(nativeSource, /appliedRevision: task\.currentRevision/);
+  assert.match(nativeSource, /let reportSource = \[/);
+  assert.match(nativeSource, /reportMissing/);
+});
+
 test('initial outbound messages create a new Chat and same-task continuations use the reply action', async () => {
   const conversationId = '6a5f93ae-5118-83e8-a96a-2a7f321dd0e8';
   const sent = await call('send_and_watch', {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
@@ -1,6 +1,6 @@
 export const HOME = {
   "schema": "mahayana.miniapp.home.v1",
-  "revision": "f85553ae01df36820bfde933b86c4740fe3c2c5d0c4fa98b9d173f41ce2d926c",
+  "revision": "83125fe73a9a2085ec542be6831fc1ca11a1496b9941dc6d66e822981998c055",
   "app": {
     "id": "chatgpt-auto-confirm",
     "title": "ChatGPT 自动确认",
@@ -18,19 +18,6 @@ export const HOME = {
     }
   ],
   "quickReplies": [
-    {
-      "id": "web-login-and-sync-actions",
-      "label": "桌面端登录并同步 Action 凭证",
-      "aliases": [
-        "桌面端登录",
-        "同步桌面凭证"
-      ],
-      "action": {
-        "type": "tool",
-        "name": "web_login_and_sync_actions",
-        "arguments": {}
-      }
-    },
     {
       "id": "sync-actions-credentials",
       "label": "一键更新凭证到 GitHub Secrets",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
@@ -55,20 +55,12 @@ const queuedTaskSchema = {
   },
 };
 const tools = [
-  { name: 'login_and_sync_actions', description: 'Open the ChatGPT desktop app, wait for its signed-in session, verify it matches the Codex credential, then sync both to GitHub Secrets and optionally start the Action.', annotations: {
+  { name: 'login_and_sync_actions', description: 'Open the ChatGPT desktop app when needed, validate its signed-in app:// renderer and local Codex auth, then export the live renderer session over CDP and sync both credentials to GitHub Secrets.', annotations: {
     readOnlyHint: false, destructiveHint: false, openWorldHint: true,
   }, inputSchema: {
     type: 'object', additionalProperties: false, properties: {
       waitSeconds: { type: 'integer', minimum: 30, maximum: 1800, default: 600 },
       start: { type: 'boolean', default: true },
-    },
-  } },
-  { name: 'web_login_and_sync_actions', description: 'Compatibility command: open the ChatGPT desktop app, wait for its signed-in session, verify it matches the Codex credential, then upload both credentials to GitHub Secrets.', annotations: {
-    readOnlyHint: false, destructiveHint: false, openWorldHint: true,
-  }, inputSchema: {
-    type: 'object', additionalProperties: false, properties: {
-      waitSeconds: { type: 'integer', minimum: 30, maximum: 1800, default: 600 },
-      start: { type: 'boolean', default: false },
     },
   } },
   { name: 'sync_actions_credentials', description: 'Export the live authenticated app:// renderer session from an already-open ChatGPT desktop instance over CDP, validate local Codex auth, then upload both credentials to GitHub Secrets.', annotations: {
@@ -365,11 +357,6 @@ export default {
         rpc.id, 'desktop.chatgpt-approvals.actions-runner-login-sync', {
           waitSeconds: Math.min(1800, Math.max(30, Number(args.waitSeconds ?? 600))),
           start: args.start !== false,
-        }, 'required');
-      if (name === 'web_login_and_sync_actions') return hostResult(
-        rpc.id, 'desktop.chatgpt-approvals.actions-runner-web-login-sync', {
-          waitSeconds: Math.min(1800, Math.max(30, Number(args.waitSeconds ?? 600))),
-          start: args.start === true,
         }, 'required');
       if (name === 'sync_actions_credentials') return hostResult(
         rpc.id, 'desktop.chatgpt-approvals.actions-runner-credential-sync', {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
@@ -315,6 +315,7 @@ export default {
             protocol: 'mahayana.task-report.v1',
             markers: ['MAHAYANA_TASK_REPORT_V1_BEGIN', 'MAHAYANA_TASK_REPORT_V1_END'],
             statuses: ['complete', 'incomplete', 'blocked'],
+            completion: 'status=complete requires remaining=[], blockers=[], next_task=""',
             fields: ['task_id', 'applied_task_revision', 'applied_spec_digest', 'summary', 'completed', 'remaining', 'blockers', 'verification', 'wait_seconds', 'wait_reason', 'next_connector', 'next_task'],
           },
         },


### PR DESCRIPTION
修复任务队列完成状态识别与重复派发：

- 每轮 Chat 注入 complete/incomplete/blocked 机器报告模板
- 完成报告绑定 task_id、revision、spec digest，并严格校验
- 验收 Chat 用同一 complete 报告收口，避免已完成任务被重新发送
- 将最终报告从 completedActivity 一并解析
- 增加契约测试与文档说明

项目测试与 macOS runtime 构建由 GitHub Actions 执行。