### PR TITLE
fix(actions): require terminal task reports

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/content/articles/guide.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/content/articles/guide.md
@@ -1,6 +1,6 @@
 ---
 id: guide
-revision: '5'
+revision: '6'
 title: 使用指南
 publishedAt: 2026-07-19
 summary: 在同一实例中创建隐藏任务队列、后台确认会话、自动续作并独立验收。
@@ -12,8 +12,8 @@ tags: [指南, 任务队列, 自动续作]
 
 1. 用「内置任务提示词」选择实现、诊断、审查或持续完成模板。
 2. 用 `enqueue_tasks` 一次加入多个任务。任务会进入持久队列，并与通用确认共用同一个已登录的 ChatGPT 实例。每个运行中任务使用独立的隐藏预热页面；无依赖且资源锁不冲突的任务按 `maxConcurrent` 并行执行。
-3. 每个 Chat 的最终回答必须包含 `mahayana.task-report.v1` 总结。若状态为 `incomplete` 或 `blocked`，小程序会根据 `remaining`、`blockers` 和 `next_task` 自动新建 Chat 续作。
-4. 完成项会由程序自动在同一实例的隐藏页面中新建 Chat 独立验收；验收 Chat 返回 `complete` 后直接启动下一项，不向用户索要确认。`review_task` 仅保留为人工恢复/兼容入口，Worker 页面只展示状态。
+3. 每个 Chat 的最终回答必须包含 `mahayana.task-report.v1` 总结。全部完成时必须返回 `status=complete`，并把 `remaining`、`blockers`、`next_task` 设为空数组或空字符串；未完成时返回 `status=incomplete` 或 `blocked`，小程序会根据 `remaining`、`blockers` 和 `next_task` 自动新建 Chat 续作。
+4. 完成报告会由程序自动在同一实例的隐藏页面中新建 Chat 独立验收；验收 Chat 返回同一任务修订的 `status=complete` 报告后，任务进入终态，不会再次派发。`review_task` 仅保留为人工恢复/兼容入口，Worker 页面只展示状态。
 
 ## 中断恢复
 

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -7,12 +7,19 @@ import SystemConfiguration
 
 // MARK: - CDP interaction JS scripts
 
-func taskReportContract() -> String {
-  """
+func legacyTaskReportContract(
+  taskId: String? = nil,
+  appliedRevision: Int? = nil,
+  appliedDigest: String? = nil
+) -> String {
+  let reportTaskId = jsonStringLiteral(taskId ?? "CURRENT_TASK_ID")
+  let reportRevision = String(appliedRevision ?? 1)
+  let reportDigest = jsonStringLiteral(appliedDigest ?? "CURRENT_SPEC_DIGEST")
+  return """
 
-持续执行要求：不要只描述下一步、不要阶段性收尾、不要回复等待时间。没有完成目标不要停，一直工作下去直到实现目标！需要时间跑的异步任务（如 GitHub Actions）必须自己运行 sleep 睡眠命令，睡眠之后起来检查是否完成，未完成则继续执行 sleep 等待，直到出结果并立刻继续。全部目标完成时直接给出正常最终结果，不要输出机器模板；小程序会把该结果发送到新的独立验收 Chat。
+// Retained only as a compatibility symbol; all outbound task messages use taskReportContract below.
 
-只有出现当前权限和工具确实无法绕过的阻塞，或平台硬性终止本次会话且任务仍未完成时，才在回答末尾输出以下未完成续作模板。不要把 JSON 放进 Markdown 代码块：
+// Legacy report text intentionally disabled.
 MAHAYANA_TASK_REPORT_V1_BEGIN
 {"protocol":"mahayana.task-report.v1","task_id":"必须与当前任务编号一致","applied_task_revision":1,"applied_spec_digest":"必须与当前规范指纹一致","status":"incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项"],"blockers":["真实卡点；没有则用空数组"],"verification":["已取得的验证证据"],"next_connector":"下一新 Chat 要使用的 connector；无需切换则为空字符串","next_task":"给下一个工作 Chat 的完整可执行续作指令"}
 MAHAYANA_TASK_REPORT_V1_END
@@ -20,8 +27,44 @@ MAHAYANA_TASK_REPORT_V1_END
 """
 }
 
-func messageWithTaskReportContract(_ message: String) -> String {
-  message.contains("MAHAYANA_TASK_REPORT_V1_BEGIN") ? message : message + taskReportContract()
+func taskReportContract(
+  taskId: String? = nil,
+  appliedRevision: Int? = nil,
+  appliedDigest: String? = nil
+) -> String {
+  let reportTaskId = jsonStringLiteral(taskId ?? "CURRENT_TASK_ID")
+  let reportRevision = String(appliedRevision ?? 1)
+  let reportDigest = jsonStringLiteral(appliedDigest ?? "CURRENT_SPEC_DIGEST")
+  return """
+
+每一轮 Chat 的最终回复都必须包含一个完整的机器报告；不要只写自然语言，也不要把 JSON 放进 Markdown 代码块。报告中的 task_id、applied_task_revision 和 applied_spec_digest 必须使用当前任务的真实值。
+
+全部目标和验证已经完成时，必须使用完成模板：
+MAHAYANA_TASK_REPORT_V1_BEGIN
+{"protocol":"mahayana.task-report.v1","task_id":\(reportTaskId),"applied_task_revision":\(reportRevision),"applied_spec_digest":\(reportDigest),"status":"complete","summary":"本轮实际结果","completed":["已完成项"],"remaining":[],"blockers":[],"verification":["可复核验证证据"],"wait_seconds":0,"wait_reason":"","next_connector":"","next_task":""}
+MAHAYANA_TASK_REPORT_V1_END
+
+只有确实未完成或被真实阻塞时，才使用未完成模板，并且 remaining 和 next_task 必须如实填写：
+MAHAYANA_TASK_REPORT_V1_BEGIN
+{"protocol":"mahayana.task-report.v1","task_id":\(reportTaskId),"applied_task_revision":\(reportRevision),"applied_spec_digest":\(reportDigest),"status":"incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项"],"blockers":["真实卡点；没有则用空数组"],"verification":["已取得的验证证据"],"wait_seconds":0,"wait_reason":"","next_connector":"","next_task":"给下一个 Chat 的完整可执行续作指令"}
+MAHAYANA_TASK_REPORT_V1_END
+未完成报告会触发新 Chat 续作；完成报告会被小程序标记为完成并停止该任务的重复派发。
+"""
+}
+
+func messageWithTaskReportContract(
+  _ message: String,
+  taskId: String? = nil,
+  appliedRevision: Int? = nil,
+  appliedDigest: String? = nil
+) -> String {
+  message.contains("MAHAYANA_TASK_REPORT_V1_BEGIN")
+    ? message
+    : message + taskReportContract(
+      taskId: taskId,
+      appliedRevision: appliedRevision,
+      appliedDigest: appliedDigest
+    )
 }
 
 func parseTaskReport(_ content: String) -> [String: Any]? {
@@ -37,6 +80,12 @@ func parseTaskReport(_ content: String) -> [String: Any]? {
   guard let data = raw.data(using: .utf8),
         let report = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
         report["protocol"] as? String == "mahayana.task-report.v1",
+        let taskId = report["task_id"] as? String,
+        !taskId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+        let appliedRevision = report["applied_task_revision"] as? Int,
+        appliedRevision >= 1,
+        let appliedDigest = report["applied_spec_digest"] as? String,
+        !appliedDigest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
         let status = report["status"] as? String,
         ["complete", "incomplete", "blocked"].contains(status),
         report["summary"] is String,
@@ -92,7 +141,12 @@ func continuationFromTaskReport(
 
 先核实这些修改是否已落盘，再继续剩余实现与验证。只有全部完成后才能报告 complete。
 """
-  return messageWithTaskReportContract(body)
+  return messageWithTaskReportContract(
+    body,
+    taskId: report["task_id"] as? String,
+    appliedRevision: report["applied_task_revision"] as? Int,
+    appliedDigest: report["applied_spec_digest"] as? String
+  )
 }
 
 func relayFreshChatContinuation(_ params: [String: Any]) -> Never {
@@ -1594,7 +1648,7 @@ func getReplyJS() -> String {
       && completedActivity.length > 0
       && !toolOnlyCompletedActivity
       && !explicitlyIncomplete
-      && explicitFinalResult;
+      && (explicitFinalResult || structuredComplete);
     const terminalIncomplete = (!active || hasClosedTaskReport)
       && !waitingForApproval
       && !stopBtn

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
@@ -399,7 +399,7 @@ func automationReviewMessage(
   已完成项：\(completed)
   被验收 Chat 的验证：\(verification)
 
-  请检查工作树、关键实现、Git/GitHub/Actions 或发布构件等与任务目标相关的证据。云端 GitHub 状态必须通过 GitHub 连接器核验；本地 checkout 仅通过 bhrum2 读取或安全同步。重型测试、构建和安装包验证必须以 GitHub Actions 结果为准，不要在本机生成构建产物。若 Actions、部署、发布审核或网络恢复仍在进行，必须留在这个验收 Chat 内自行等待并轮询，拿到结果后继续验收，不得回复等待时间后退出。重复卡点不能只照抄旧错误，应诊断并换可行路径。只有全部目标可复核且验证通过时，最后单独输出一行 `MAHAYANA_REVIEW_ACCEPTED`；不要输出完成态 JSON。若验收不通过，输出未完成续作模板，准确写出 remaining、blockers、verification 和 next_task，供小程序新建工作 Chat 继续；只有真实不可绕过的阻塞才可使用 blocked。
+  请检查工作树、关键实现、Git/GitHub/Actions 或发布构件等与任务目标相关的证据。云端 GitHub 状态必须通过 GitHub 连接器核验；本地 checkout 仅通过 bhrum2 读取或安全同步。重型测试、构建和安装包验证必须以 GitHub Actions 结果为准，不要在本机生成构建产物。若 Actions、部署、发布审核或网络恢复仍在进行，必须留在这个验收 Chat 内自行等待并轮询，拿到结果后继续验收，不得回复等待时间后退出。重复卡点不能只照抄旧错误，应诊断并换可行路径。验收全部通过时，必须按消息末尾的完成模板输出同一任务修订的 `status=complete` 报告；验收不通过时，必须按未完成模板输出 `status=incomplete` 或 `status=blocked` 报告。`MAHAYANA_REVIEW_ACCEPTED` 可以作为辅助证据，但不是完成识别的唯一条件。
   """
 }
 
@@ -417,7 +417,12 @@ func startAutomationReview(
   ), prepared["ok"] as? Bool == true else {
     return false
   }
-  let outbound = messageWithTaskReportContract(automationReviewMessage(task, report: report))
+  let outbound = messageWithTaskReportContract(
+    automationReviewMessage(task, report: report),
+    taskId: task.id,
+    appliedRevision: task.currentRevision,
+    appliedDigest: task.specDigest
+  )
   guard let sendResult = cdpValue(
     port: port,
     targetId: targetId,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1416,7 +1416,12 @@ func startAutomationTask(
   task.appliedRevision = max(1, task.currentRevision ?? 1)
   task.appliedSpecDigest = task.specDigest
   task.pendingRevision = nil
-  let outbound = messageWithTaskReportContract(automationTaskMessage(task))
+  let outbound = messageWithTaskReportContract(
+    automationTaskMessage(task),
+    taskId: task.id,
+    appliedRevision: task.appliedRevision,
+    appliedDigest: task.appliedSpecDigest
+  )
   queueTrace("task=\(task.id) stage=send begin")
   guard let sendResult = cdpValue(
     port: port,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -2115,20 +2115,21 @@ case "send_and_watch":
 
   var resultPayload: [String: Any] = [:]
   let terminalIncomplete = finalReply["terminalIncomplete"] as? Bool ?? false
-  let taskReport = parseTaskReport(replyContent)
+  let reportSource = [
+    replyContent,
+    finalReply["completedActivity"] as? String ?? "",
+  ].joined(separator: "\n")
+  let taskReport = parseTaskReport(reportSource)
   let taskStatus = taskReport?["status"] as? String
   let finalChatStatus = cdpEvaluateOnChatGPT(chatStatusJS(), preferredURL: activeChatURL) ?? [:]
   let finalConversationId = finalChatStatus["conversationId"] as? String
     ?? state.backgroundConversationId
   let finalChatURL = finalChatStatus["chatUrl"] as? String
   let explicitlyIncomplete = finalReply["explicitlyIncomplete"] as? Bool ?? false
-  let normalCompletion = !resumeExisting && !surfaceDrift && !stalled && !timedOut
-    && finalReply["done"] as? Bool == true && taskReport == nil
-    && !terminalIncomplete && !explicitlyIncomplete
-  let effectiveTaskStatus = taskStatus ?? (normalCompletion ? "complete" : nil)
+  let effectiveTaskStatus = taskStatus
   let reportMissing = !resumeExisting && !surfaceDrift && !stalled && !timedOut
     && finalReply["done"] as? Bool == true && taskReport == nil
-    && !normalCompletion
+    && !terminalIncomplete && !explicitlyIncomplete
   resultPayload["ok"] = !stalled && !timedOut && !surfaceDrift && !terminalIncomplete
     && !reportMissing && effectiveTaskStatus == "complete" && (finalReply["done"] as? Bool == true)
   resultPayload["sent"] = resumeExisting ? false : (sendResult["messageConfirmed"] as? Bool ?? false)

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/actions-first-task-queue/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/actions-first-task-queue/SKILL.md
@@ -32,15 +32,15 @@ Do not repeat the same failed command or connector path. Diagnose the cause firs
 
 Do not stop a task just because an external operation is slow. Keep the active Chat working and poll normal asynchronous operations (Actions, deployments, releases, network recovery, remote checks) whenever possible. Do not ask the user to wait and do not return a wait countdown for normal waiting. Only emit an unfinished report when the current execution cannot continue due to a real blocker or the platform requires a handoff.
 
-Use the task report only for unfinished handoff cases. A completed task returns a normal final result and then a separate acceptance Chat verifies it. Do not include the machine report in every successful completion.
+Every work and acceptance Chat must end with the machine report. A completed work Chat returns `status=complete` and then a separate acceptance Chat verifies it; the acceptance Chat also returns a same-revision `status=complete` report before the queue marks the task terminal. Do not rely on a natural-language completion or a standalone acceptance marker.
 
 ```text
 MAHAYANA_TASK_REPORT_V1_BEGIN
-{"protocol":"mahayana.task-report.v1","status":"incomplete|blocked","summary":"...","completed":["..."],"remaining":["..."],"blockers":["..."],"verification":["..."],"wait_seconds":0,"wait_reason":"","next_connector":"GitHub|bhrum2|","next_task":"..."}
+{"protocol":"mahayana.task-report.v1","task_id":"current task id","applied_task_revision":1,"applied_spec_digest":"current spec digest","status":"complete|incomplete|blocked","summary":"...","completed":["..."],"remaining":[],"blockers":[],"verification":["..."],"wait_seconds":0,"wait_reason":"","next_connector":"GitHub|bhrum2|","next_task":""}
 MAHAYANA_TASK_REPORT_V1_END
 ```
 
-- For completed work, do not output this machine report; send the result to a separate acceptance Chat.
+- For completed work, output the complete machine report; the queue then sends the result to a separate acceptance Chat.
 - For unfinished work, use `incomplete` or `blocked`, keep `wait_seconds` as `0`, and provide a concrete `next_task` for the next Chat.
 - Normal Actions/deployment/network polling is not a reason to end the Chat.
 - For a real unsolved blocker, state exactly what is needed: permission, account, tool, environment variable, command, or external service recovery condition.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -96,6 +96,19 @@ test('outbound sends discard old chat URLs while read-only reply requests keep t
   assert.equal(reply.result.structuredContent.hostRequest.params.chatUrl, chatUrl);
 });
 
+test('every task Chat receives complete and unfinished report templates', () => {
+  assert.match(chatScriptsSource, /func taskReportContract\(/);
+  assert.match(chatScriptsSource, /"status":"complete"/);
+  assert.match(chatScriptsSource, /"remaining":\[\],"blockers":\[\]/);
+  assert.match(chatScriptsSource, /"next_task":""/);
+  assert.match(chatScriptsSource, /"status":"incomplete\|blocked"/);
+  assert.doesNotMatch(chatScriptsSource, /不要输出完成态 JSON/);
+  assert.match(nativeSource, /taskId: task\.id/);
+  assert.match(nativeSource, /appliedRevision: task\.currentRevision/);
+  assert.match(nativeSource, /let reportSource = \[/);
+  assert.match(nativeSource, /reportMissing/);
+});
+
 test('initial outbound messages create a new Chat and same-task continuations use the reply action', async () => {
   const conversationId = '6a5f93ae-5118-83e8-a96a-2a7f321dd0e8';
   const sent = await call('send_and_watch', {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/index.ts
@@ -315,6 +315,7 @@ export default {
             protocol: 'mahayana.task-report.v1',
             markers: ['MAHAYANA_TASK_REPORT_V1_BEGIN', 'MAHAYANA_TASK_REPORT_V1_END'],
             statuses: ['complete', 'incomplete', 'blocked'],
+            completion: 'status=complete requires remaining=[], blockers=[], next_task=""',
             fields: ['task_id', 'applied_task_revision', 'applied_spec_digest', 'summary', 'completed', 'remaining', 'blockers', 'verification', 'wait_seconds', 'wait_reason', 'next_connector', 'next_task'],
           },
         },


### PR DESCRIPTION
修复任务队列完成状态识别与重复派发：

- 每轮 Chat 注入 complete/incomplete/blocked 机器报告模板
- 完成报告绑定 task_id、revision、spec digest，并严格校验
- 验收 Chat 用同一 complete 报告收口，避免已完成任务被重新发送
- 将最终报告从 completedActivity 一并解析
- 增加契约测试与文档说明

项目测试与 macOS runtime 构建由 GitHub Actions 执行。