### PR TITLE
test(actions): align terminal report contract

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -12,9 +12,9 @@ func legacyTaskReportContract(
   appliedRevision: Int? = nil,
   appliedDigest: String? = nil
 ) -> String {
-  let reportTaskId = jsonStringLiteral(taskId ?? "CURRENT_TASK_ID")
-  let reportRevision = String(appliedRevision ?? 1)
-  let reportDigest = jsonStringLiteral(appliedDigest ?? "CURRENT_SPEC_DIGEST")
+  _ = taskId
+  _ = appliedRevision
+  _ = appliedDigest
   return """
 
 // Retained only as a compatibility symbol; all outbound task messages use taskReportContract below.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -272,7 +272,7 @@ test('send_and_watch streams visible thinking and uses bounded same-task recover
   assert.match(nativeSource, /liveSurface\["chatMode"\]/);
   assert.match(nativeSource, /never approve or type on Work/);
   assert.match(nativeSource, /explicitFinalResult/);
-  assert.match(nativeSource, /&& !explicitlyIncomplete\s*&& explicitFinalResult/);
+  assert.match(nativeSource, /&& !explicitlyIncomplete\s*&& \(explicitFinalResult \|\| structuredComplete\)/);
   assert.match(nativeSource, /尚未\.\{0,12\}完成/);
   assert.match(nativeSource, /Date\(\)\.timeIntervalSince\(candidateSince\) >= 4\.0/);
   assert.doesNotMatch(nativeSource,


### PR DESCRIPTION
修复 #1786 合并后由远程 macOS runtime 验证发现的两处问题：

- 更新 completionCandidate 契约测试，覆盖 structuredComplete
- 移除旧兼容报告函数的未使用变量警告

仅包含本次回归修正。