### PR TITLE
fix(queue): require terminal task reports

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -12,9 +12,9 @@ func legacyTaskReportContract(
   appliedRevision: Int? = nil,
   appliedDigest: String? = nil
 ) -> String {
-  let reportTaskId = jsonStringLiteral(taskId ?? "CURRENT_TASK_ID")
-  let reportRevision = String(appliedRevision ?? 1)
-  let reportDigest = jsonStringLiteral(appliedDigest ?? "CURRENT_SPEC_DIGEST")
+  _ = taskId
+  _ = appliedRevision
+  _ = appliedDigest
   return """
 
 // Retained only as a compatibility symbol; all outbound task messages use taskReportContract below.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -648,62 +648,14 @@ func monitorAutomationTask(
     return
   }
   if terminal {
-    if terminalIncomplete {
-      closeDedicatedAutomationTarget(task, state: state)
-      queueContinuation(&task, report: nil, reason: "unfinished_reply_missing_continuation_report")
-      return
-    }
-    let normalResult = reportText.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !normalResult.isEmpty else {
-      closeDedicatedAutomationTarget(task, state: state)
-      queueContinuation(&task, report: nil, reason: "empty_terminal_reply")
-      return
-    }
-    let acceptedResult = AutomationTaskReport(
-      protocolName: "mahayana.task-report.v1",
-      taskId: task.id,
-      appliedTaskRevision: task.appliedRevision,
-      appliedSpecDigest: task.appliedSpecDigest,
-      status: "complete",
-      summary: normalResult,
-      completed: [],
-      remaining: [],
-      blockers: [],
-      verification: [],
-      nextTask: "",
-      waitSeconds: 0,
-      waitReason: "",
-      nextConnector: nil
-    )
-    if monitoringReview {
-      guard normalResult.contains("MAHAYANA_REVIEW_ACCEPTED") else {
-        closeDedicatedAutomationTarget(task, state: state)
-        queueContinuation(&task, report: nil, reason: "review_result_missing_acceptance_marker")
-        return
-      }
-      task.reviewReport = acceptedResult
-      task.reviewStatus = "complete"
-      task.status = "completed"
-      task.lastError = nil
-      task.finishedAt = now
-      task.reviewedAt = now
-      return
-    }
-    task.report = acceptedResult
-    guard startAutomationReview(
+    closeDedicatedAutomationTarget(task, state: state)
+    queueContinuation(
       &task,
-      report: acceptedResult,
-      port: port,
-      targetId: targetId
-    ) else {
-      task.status = "blocked"
-      task.lastError = "chat_review_start_failed"
-      task.finishedAt = now
-      return
-    }
-    task.status = "running"
-    task.lastError = nil
-    task.finishedAt = nil
+      report: nil,
+      reason: terminalIncomplete
+        ? "unfinished_reply_missing_continuation_report"
+        : "terminal_reply_missing_task_report"
+    )
     return
   }
 

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -107,6 +107,9 @@ test('every task Chat receives complete and unfinished report templates', () => 
   assert.match(nativeSource, /appliedRevision: task\.currentRevision/);
   assert.match(nativeSource, /let reportSource = \[/);
   assert.match(nativeSource, /reportMissing/);
+  assert.match(nativeSource, /terminal_reply_missing_task_report/);
+  assert.doesNotMatch(nativeSource, /let acceptedResult = AutomationTaskReport\(/);
+  assert.doesNotMatch(nativeSource, /let normalResult = reportText/);
 });
 
 test('initial outbound messages create a new Chat and same-task continuations use the reply action', async () => {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -272,7 +272,7 @@ test('send_and_watch streams visible thinking and uses bounded same-task recover
   assert.match(nativeSource, /liveSurface\["chatMode"\]/);
   assert.match(nativeSource, /never approve or type on Work/);
   assert.match(nativeSource, /explicitFinalResult/);
-  assert.match(nativeSource, /&& !explicitlyIncomplete\s*&& explicitFinalResult/);
+  assert.match(nativeSource, /&& !explicitlyIncomplete\s*&& \(explicitFinalResult \|\| structuredComplete\)/);
   assert.match(nativeSource, /尚未\.\{0,12\}完成/);
   assert.match(nativeSource, /Date\(\)\.timeIntervalSince\(candidateSince\) >= 4\.0/);
   assert.doesNotMatch(nativeSource,


### PR DESCRIPTION
## Summary
- stop synthesizing completion from a natural-language terminal reply
- queue a continuation when a terminal Chat reply lacks a valid task report
- add a contract assertion for the no-report path

## Validation
- GitHub Actions runtime validation will run on this PR; local project tests/builds were not run per repository task policy.