### PR TITLE
test(actions): allow cancellation guard

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -7,26 +7,6 @@ import SystemConfiguration
 
 // MARK: - CDP interaction JS scripts
 
-func legacyTaskReportContract(
-  taskId: String? = nil,
-  appliedRevision: Int? = nil,
-  appliedDigest: String? = nil
-) -> String {
-  _ = taskId
-  _ = appliedRevision
-  _ = appliedDigest
-  return """
-
-// Retained only as a compatibility symbol; all outbound task messages use taskReportContract below.
-
-// Legacy report text intentionally disabled.
-MAHAYANA_TASK_REPORT_V1_BEGIN
-{"protocol":"mahayana.task-report.v1","task_id":"必须与当前任务编号一致","applied_task_revision":1,"applied_spec_digest":"必须与当前规范指纹一致","status":"incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项"],"blockers":["真实卡点；没有则用空数组"],"verification":["已取得的验证证据"],"next_connector":"下一新 Chat 要使用的 connector；无需切换则为空字符串","next_task":"给下一个工作 Chat 的完整可执行续作指令"}
-MAHAYANA_TASK_REPORT_V1_END
-未完成时 remaining 和 next_task 必须非空。云端 GitHub 阶段 next_connector 填 GitHub，本地阶段填 bhrum2。
-"""
-}
-
 func taskReportContract(
   taskId: String? = nil,
   appliedRevision: Int? = nil,
@@ -37,7 +17,8 @@ func taskReportContract(
   let reportDigest = jsonStringLiteral(appliedDigest ?? "CURRENT_SPEC_DIGEST")
   return """
 
-每一轮 Chat 的最终回复都必须包含一个完整的机器报告；不要只写自然语言，也不要把 JSON 放进 Markdown 代码块。报告中的 task_id、applied_task_revision 和 applied_spec_digest 必须使用当前任务的真实值。
+MAHAYANA_TASK_REPORT_CONTRACT_V2
+以下最终回复协议位于消息末尾，优先于正文中任何旧版或冲突说明，包括“完成时正常回复”“完成时不要输出机器模板”。每一轮 Chat 的最终回复都必须包含一个完整的机器报告；不要只写自然语言，也不要把 JSON 放进 Markdown 代码块。报告中的 task_id、applied_task_revision 和 applied_spec_digest 必须使用当前任务的真实值。Chat 必须根据实际结果在下面两个模板中选择一个。
 
 全部目标和验证已经完成时，必须使用完成模板：
 MAHAYANA_TASK_REPORT_V1_BEGIN
@@ -58,7 +39,7 @@ func messageWithTaskReportContract(
   appliedRevision: Int? = nil,
   appliedDigest: String? = nil
 ) -> String {
-  message.contains("MAHAYANA_TASK_REPORT_V1_BEGIN")
+  message.contains("MAHAYANA_TASK_REPORT_CONTRACT_V2")
     ? message
     : message + taskReportContract(
       taskId: taskId,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
@@ -357,7 +357,7 @@ func automationTaskMessage(_ task: AutomationTask) -> String {
   if let snapshot = task.specSnapshot, !snapshot.isEmpty {
     sections.append("当前规范快照（以此内容为准）：\n\(snapshot)")
   }
-  sections.append("未完成机器报告必须额外包含 task_id=\(task.id)、applied_task_revision=\(revision) 和 applied_spec_digest=\(digest)。旧修订报告不会被接受为完成。")
+  sections.append("完成和未完成机器报告都必须包含 task_id=\(task.id)、applied_task_revision=\(revision) 和 applied_spec_digest=\(digest)。缺少这些字段或使用旧修订的报告都不会被接受。")
   sections.append("任务发送轮次：\(task.attempts + 1)。")
   if let rawFeedback = task.reviewFeedback {
     let feedback = chatOnlyInstruction(rawFeedback)

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/cancel-persisted-task.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/cancel-persisted-task.mjs
@@ -1,0 +1,37 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const statePath = process.env.CHATGPT_AUTO_CONFIRM_QUEUE_STATE;
+const resultPath = process.env.ACTION_RESULT_PATH;
+const requestedTaskId = String(process.env.CHATGPT_AUTO_CONFIRM_CANCEL_TASK_ID || '').trim();
+
+if (!statePath) throw new Error('CHATGPT_AUTO_CONFIRM_QUEUE_STATE is required');
+if (!resultPath) throw new Error('ACTION_RESULT_PATH is required');
+if (!requestedTaskId || requestedTaskId.length > 240 || /[\r\n]/.test(requestedTaskId)) {
+  throw new Error('CHATGPT_AUTO_CONFIRM_CANCEL_TASK_ID must be a nonempty task id');
+}
+
+const state = JSON.parse(readFileSync(statePath, 'utf8'));
+const tasks = Array.isArray(state.automationTasks) ? state.automationTasks : [];
+const matches = task => task?.id === requestedTaskId
+  || String(task?.id || '').startsWith(`${requestedTaskId}--v`);
+const cancelledTaskIds = tasks.filter(matches).map(task => task.id);
+
+state.automationTasks = tasks.filter(task => !matches(task));
+state.queueEnabled = false;
+state.queuePaused = true;
+state.queueWatcherPid = null;
+state.queueWorkerPort = null;
+state.queueWorkerTargetId = null;
+state.queueWorkerProfilePath = null;
+state.queueWorkerMode = null;
+writeFileSync(statePath, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+
+const result = {
+  status: 'complete',
+  reason: cancelledTaskIds.length > 0 ? 'persisted_task_cancelled' : 'persisted_task_already_absent',
+  requestedTaskId,
+  cancelledTaskIds,
+  remainingTaskIds: state.automationTasks.map(task => task.id),
+};
+writeFileSync(resultPath, `${JSON.stringify(result)}\n`, { mode: 0o600 });
+process.stdout.write(`PERSISTED_TASK_CANCELLATION ${JSON.stringify(result)}\n`);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
@@ -103,14 +103,26 @@ const fetchControl = () => {
   return control;
 };
 
-const reportContract = `
-\n最终回复协议（必须执行，优先于任何旧版“完成时正常回复”的说明）：
-无论任务完成、未完成还是阻塞，最终回复末尾都必须输出且只输出一个完整机器报告。不要把 JSON 放进 Markdown 代码块。
+const reportContract = task => {
+  const taskId = JSON.stringify(runtimeId(task));
+  const revision = taskRevision(task);
+  const digest = JSON.stringify(task._specDigest || '');
+  return `
+MAHAYANA_TASK_REPORT_CONTRACT_V2
+以下最终回复协议优先于消息中任何旧版或冲突说明，包括“完成时正常回复”“完成时不要输出机器模板”。每一轮 Chat 都必须根据实际结果在下面两个模板中选择一个；不要只写自然语言，也不要把 JSON 放进 Markdown 代码块。
+
+任务和全部验证已经完成时，使用完成模板：
 MAHAYANA_TASK_REPORT_V1_BEGIN
-{"protocol":"mahayana.task-report.v1","status":"complete|incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项；complete 时必须为空数组"],"blockers":["真实卡点；complete 时必须为空数组"],"verification":["可复核验证证据"],"next_connector":"下一新 Chat 的 connector；无需切换则为空字符串","next_task":"下一轮完整续作指令；complete 时必须为空字符串"}
+{"protocol":"mahayana.task-report.v1","task_id":${taskId},"applied_task_revision":${revision},"applied_spec_digest":${digest},"status":"complete","summary":"本轮实际结果","completed":["已完成项"],"remaining":[],"blockers":[],"verification":["可复核验证证据"],"wait_seconds":0,"wait_reason":"","next_connector":"","next_task":""}
 MAHAYANA_TASK_REPORT_V1_END
-任务全部完成时 status 必须为 complete，remaining、blockers 必须为空数组，next_task 必须为空字符串。不得仅用自然语言声称完成。
+
+任务确实未完成或被真实阻塞时，使用未完成模板：
+MAHAYANA_TASK_REPORT_V1_BEGIN
+{"protocol":"mahayana.task-report.v1","task_id":${taskId},"applied_task_revision":${revision},"applied_spec_digest":${digest},"status":"incomplete|blocked","summary":"本轮实际结果","completed":["已完成项"],"remaining":["未完成项"],"blockers":["真实卡点；没有则用空数组"],"verification":["可复核验证证据"],"wait_seconds":0,"wait_reason":"","next_connector":"","next_task":"下一轮完整续作指令"}
+MAHAYANA_TASK_REPORT_V1_END
+未完成时 remaining 和 next_task 必须非空；完成时 remaining、blockers 和 next_task 必须为空。完成报告会停止该任务的重复派发。
 `;
+};
 
 const normalizedDirectory = value => String(value || '')
   .trim()
@@ -150,7 +162,7 @@ const taskPrompt = (control, task) => [
   `逻辑任务：${task.id}；目标版本：${taskRevision(task)}；规范摘要：${task._specDigest}。`,
   task.prompt,
   taskDocumentBlock(task),
-  reportContract,
+  reportContract(task),
 ].filter(Boolean).join('\n\n');
 
 let activeControl = null;
@@ -183,6 +195,7 @@ const reconcileControl = control => {
 
     const desiredId = runtimeId(task);
     const managed = existing.filter(current => managedBy(current, task));
+    const exact = managed.find(current => current.id === desiredId);
     const running = managed.filter(isRunning);
 
     // A task update is never allowed to stop the Chat that is currently
@@ -208,7 +221,6 @@ const reconcileControl = control => {
       }
     }
 
-    const exact = managed.find(current => current.id === desiredId);
     if (exact && ['failed', 'blocked', 'cancelled'].includes(exact.status)) {
       native('queue_retry', {
         taskId: exact.id,
@@ -223,6 +235,9 @@ const reconcileControl = control => {
       tasks: [{
         ...task,
         id: desiredId,
+        revision: taskRevision(task),
+        specDigest: task._specDigest,
+        specSources: task._specFiles,
         dependsOn: (Array.isArray(task.dependsOn) ? task.dependsOn : [])
           .map(dependency => runtimeIdsByLogicalId.get(dependency) || dependency),
         prompt: taskPrompt(control, task),

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/cancel-persisted-task.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/cancel-persisted-task.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(
+  new URL('../scripts/cancel-persisted-task.mjs', import.meta.url),
+);
+
+test('cancellation-only action removes a logical task and all versioned runtime ids', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'chatgpt-cancel-task-'));
+  const statePath = join(directory, 'queue-state.json');
+  const resultPath = join(directory, 'action-result.json');
+  writeFileSync(statePath, JSON.stringify({
+    queueEnabled: true,
+    queuePaused: false,
+    automationTasks: [
+      { id: 'queue-contract', status: 'running' },
+      { id: 'queue-contract--v2--supdated', status: 'queued' },
+      { id: 'keep-me--v1--sabc', status: 'running' },
+    ],
+  }));
+
+  const result = spawnSync(process.execPath, [scriptPath], {
+    env: {
+      ...process.env,
+      CHATGPT_AUTO_CONFIRM_QUEUE_STATE: statePath,
+      CHATGPT_AUTO_CONFIRM_CANCEL_TASK_ID: 'queue-contract',
+      ACTION_RESULT_PATH: resultPath,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+
+  const state = JSON.parse(readFileSync(statePath, 'utf8'));
+  assert.deepEqual(state.automationTasks.map(task => task.id), ['keep-me--v1--sabc']);
+  assert.equal(state.queueEnabled, false);
+  assert.equal(state.queuePaused, true);
+
+  const actionResult = JSON.parse(readFileSync(resultPath, 'utf8'));
+  assert.equal(actionResult.status, 'complete');
+  assert.equal(actionResult.reason, 'persisted_task_cancelled');
+  assert.deepEqual(actionResult.cancelledTaskIds, [
+    'queue-contract',
+    'queue-contract--v2--supdated',
+  ]);
+});
+
+test('cancellation-only action is idempotent when the task is already absent', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'chatgpt-cancel-task-'));
+  const statePath = join(directory, 'queue-state.json');
+  const resultPath = join(directory, 'action-result.json');
+  writeFileSync(statePath, JSON.stringify({ automationTasks: [] }));
+
+  const result = spawnSync(process.execPath, [scriptPath], {
+    env: {
+      ...process.env,
+      CHATGPT_AUTO_CONFIRM_QUEUE_STATE: statePath,
+      CHATGPT_AUTO_CONFIRM_CANCEL_TASK_ID: 'queue-contract',
+      ACTION_RESULT_PATH: resultPath,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    JSON.parse(readFileSync(resultPath, 'utf8')).reason,
+    'persisted_task_already_absent',
+  );
+});

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -91,6 +91,11 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /queue-state\.enc/);
   assert.match(actionsWorkflow, /previous_run_id="\$GITHUB_RUN_ID"/);
   assert.match(actionsWorkflow, /parallel_queue_smoke/);
+  assert.match(actionsWorkflow, /cancel_task_id/);
+  assert.match(actionsWorkflow, /Cancel persisted task without launching Chat/);
+  assert.match(actionsWorkflow, /cancel-persisted-task\.mjs/);
+  assert.match(actionsWorkflow, /Persisted task cancellation completed/);
+  assert.match(actionsWorkflow, /inputs\.cancel_task_id == ''/);
   assert.match(actionsWorkflow, /chatgpt-auto-confirm-parallel-smoke/);
   assert.match(actionsWorkflow, /verify-parallel-actions-queue\.mjs/);
   assert.match(actionsWorkflow, /parallel-queue-evidence\.json/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -82,7 +82,10 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.doesNotMatch(restoreSessionScript, /call\([^\n]*['"]Page\.setWebLifecycleState['"]/);
   assert.doesNotMatch(actionsWorkflow, /pkill -x ChatGPT/);
   assert.match(actionsWorkflow, /Launch authenticated desktop shell/);
-  assert.match(actionsWorkflow, /Launch authenticated desktop shell\r?\n\s+timeout-minutes: 6/);
+  assert.match(
+    actionsWorkflow,
+    /Launch authenticated desktop shell\r?\n\s+if: \$\{\{ inputs\.cancel_task_id == '' \}\}\r?\n\s+timeout-minutes: 6/,
+  );
   assert.doesNotMatch(actionsWorkflow, /login_status=\$\(/);
   assert.match(actionsWorkflow, /Build native queue runtime/);
   assert.match(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_STATE_KEY/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -98,6 +98,7 @@ test('outbound sends discard old chat URLs while read-only reply requests keep t
 
 test('every task Chat receives complete and unfinished report templates', () => {
   assert.match(chatScriptsSource, /func taskReportContract\(/);
+  assert.match(chatScriptsSource, /MAHAYANA_TASK_REPORT_CONTRACT_V2/);
   assert.match(chatScriptsSource, /"status":"complete"/);
   assert.match(chatScriptsSource, /"remaining":\[\],"blockers":\[\]/);
   assert.match(chatScriptsSource, /"next_task":""/);
@@ -107,6 +108,9 @@ test('every task Chat receives complete and unfinished report templates', () => 
   assert.match(nativeSource, /appliedRevision: task\.currentRevision/);
   assert.match(nativeSource, /let reportSource = \[/);
   assert.match(nativeSource, /reportMissing/);
+  assert.match(nativeSource, /message\.contains\("MAHAYANA_TASK_REPORT_CONTRACT_V2"\)/);
+  assert.doesNotMatch(nativeSource, /message\.contains\("MAHAYANA_TASK_REPORT_V1_BEGIN"\)/);
+  assert.doesNotMatch(nativeSource, /func legacyTaskReportContract/);
   assert.match(nativeSource, /terminal_reply_missing_task_report/);
   assert.doesNotMatch(nativeSource, /let acceptedResult = AutomationTaskReport\(/);
   assert.doesNotMatch(nativeSource, /let normalResult = reportText/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
@@ -19,7 +19,10 @@ test('persistent Actions runner polls the main-branch task control file', () => 
   assert.match(workflow, /run-dynamic-actions-controller\.mjs/);
   assert.match(workflow, /CHATGPT_AUTO_CONFIRM_TASK_CONTROL_REF: main/);
   assert.match(workflow, /CHATGPT_AUTO_CONFIRM_TASK_CONTROL_POLL_SECONDS: "30"/);
-  assert.match(workflow, /Import dynamic parallel task inbox\r?\n\s+if: \$\{\{ inputs\.parallel_queue_smoke \}\}/);
+  assert.match(
+    workflow,
+    /Import dynamic parallel task inbox\r?\n\s+if: \$\{\{ inputs\.cancel_task_id == '' && inputs\.parallel_queue_smoke \}\}/,
+  );
   assert.match(controller, /spawnSync\('gh'/);
   assert.match(controller, /repos\/\$\{repository\}\/contents\/\$\{repositoryPath\}/);
   assert.match(controller, /fetchRepositoryContent\(controlPath\)/);
@@ -34,6 +37,8 @@ test('goal versions are idempotent and dependencies use desired runtime ids', ()
   assert.match(controller, /native\('queue_cancel'/);
   assert.match(controller, /native\('queue_enqueue'/);
   assert.match(controller, /runtimeIdsByLogicalId/);
+  assert.match(controller, /specDigest: task\._specDigest/);
+  assert.match(controller, /specSources: task\._specFiles/);
   assert.match(controller, /dependsOn:[\s\S]*runtimeIdsByLogicalId\.get/);
   assert.equal(inbox.schemaVersion, 3);
   assert.equal(inbox.keepAlive, true);
@@ -72,10 +77,11 @@ test('unchanged tasks continue while changed tasks replace only at the boundary'
 });
 
 test('every dispatched work Chat receives a complete machine report contract', () => {
-  assert.match(controller, /status":"complete\|incomplete\|blocked/);
-  assert.match(controller, /不得仅用自然语言声称完成/);
-  assert.match(controller, /remaining、blockers 必须为空数组/);
-  assert.match(controller, /next_task 必须为空字符串/);
+  assert.match(controller, /MAHAYANA_TASK_REPORT_CONTRACT_V2/);
+  assert.match(controller, /"status":"complete"/);
+  assert.match(controller, /"status":"incomplete\|blocked"/);
+  assert.match(controller, /"task_id":\$\{taskId\}/);
+  assert.match(controller, /完成报告会停止该任务的重复派发/);
 });
 
 test('each task sends one document folder path and link without document bodies', () => {

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -17,6 +17,10 @@ on:
         required: false
         default: false
         type: boolean
+      cancel_task_id:
+        description: Remove one logical task from restored persistent state without launching Chat
+        required: false
+        type: string
 
 permissions:
   actions: write
@@ -100,14 +104,23 @@ jobs:
           CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
 
+      - name: Cancel persisted task without launching Chat
+        if: ${{ inputs.cancel_task_id != '' }}
+        env:
+          CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
+          CHATGPT_AUTO_CONFIRM_CANCEL_TASK_ID: ${{ inputs.cancel_task_id }}
+          ACTION_RESULT_PATH: ${{ steps.paths.outputs.runtime_dir }}/action-result.json
+        run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/cancel-persisted-task.mjs
+
       - name: Import dynamic parallel task inbox
-        if: ${{ inputs.parallel_queue_smoke }}
+        if: ${{ inputs.cancel_task_id == '' && inputs.parallel_queue_smoke }}
         env:
           CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
           CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE: ${{ github.workspace }}/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/import-actions-task-inbox.mjs
 
       - name: Restore ChatGPT login credentials
+        if: ${{ inputs.cancel_task_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -117,6 +130,7 @@ jobs:
           chmod 600 "$HOME/.codex/auth.json"
 
       - name: Install official ChatGPT desktop app
+        if: ${{ inputs.cancel_task_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -132,10 +146,12 @@ jobs:
           xattr -dr com.apple.quarantine /Applications/ChatGPT.app || true
 
       - name: Build native queue runtime
+        if: ${{ inputs.cancel_task_id == '' }}
         shell: bash
         run: sh .agents/plugins/plugins/chatgpt-auto-confirm/scripts/build-macos-runtime.sh
 
       - name: Launch authenticated desktop shell
+        if: ${{ inputs.cancel_task_id == '' }}
         timeout-minutes: 6
         shell: bash
         env:
@@ -158,6 +174,7 @@ jobs:
           test "$shell_ready" = true
 
       - name: Verify authenticated ChatGPT session
+        if: ${{ inputs.cancel_task_id == '' }}
         id: auth_verify
         timeout-minutes: 3
         env:
@@ -165,7 +182,7 @@ jobs:
         run: .agents/plugins/plugins/chatgpt-auto-confirm/runtime/macos/chatgpt-auto-confirm verify_chatgpt_login
 
       - name: Verify dynamic parallel task queue
-        if: ${{ inputs.parallel_queue_smoke }}
+        if: ${{ inputs.cancel_task_id == '' && inputs.parallel_queue_smoke }}
         env:
           CHATGPT_AUTO_CONFIRM_PARALLEL_STATE: ${{ steps.paths.outputs.runtime_dir }}/parallel-smoke-state.json
           CHATGPT_AUTO_CONFIRM_PARALLEL_EVIDENCE: ${{ steps.paths.outputs.runtime_dir }}/parallel-queue-evidence.json
@@ -174,7 +191,7 @@ jobs:
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/verify-parallel-actions-queue.mjs
 
       - name: Run dynamic persistent task queue
-        if: ${{ !inputs.smoke_only && !inputs.parallel_queue_smoke }}
+        if: ${{ inputs.cancel_task_id == '' && !inputs.smoke_only && !inputs.parallel_queue_smoke }}
         id: controller
         continue-on-error: true
         env:
@@ -190,7 +207,7 @@ jobs:
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
 
       - name: Record successful hosted verification
-        if: ${{ inputs.smoke_only || inputs.parallel_queue_smoke }}
+        if: ${{ inputs.cancel_task_id == '' && (inputs.smoke_only || inputs.parallel_queue_smoke) }}
         shell: bash
         env:
           VERIFICATION_REASON: ${{ inputs.parallel_queue_smoke && 'dynamic_parallel_queue_verified' || 'chatgpt_login_smoke_verified' }}
@@ -238,13 +255,20 @@ jobs:
           RESULT_PATH: ${{ steps.paths.outputs.runtime_dir }}/action-result.json
           VERIFICATION_ONLY: ${{ inputs.smoke_only || inputs.parallel_queue_smoke }}
           AUTHENTICATION_VERIFIED: ${{ steps.auth_verify.outcome == 'success' }}
+          CANCELLATION_ONLY: ${{ inputs.cancel_task_id != '' }}
         run: |
           set -euo pipefail
+          status=$(jq -r '.status // "incomplete"' "$RESULT_PATH")
+          if [[ "$CANCELLATION_ONLY" == "true" ]]; then
+            [[ "$status" == "complete" ]]
+            jq '{status, reason, requestedTaskId, cancelledTaskIds, remainingTaskIds}' "$RESULT_PATH"
+            echo "Persisted task cancellation completed; no Chat was launched and no continuation was dispatched."
+            exit 0
+          fi
           if [[ "$AUTHENTICATION_VERIFIED" != "true" ]]; then
             echo "::error::ChatGPT authentication preflight failed; no continuation was dispatched."
             exit 1
           fi
-          status=$(jq -r '.status // "incomplete"' "$RESULT_PATH")
           if [[ "$status" == "complete" ]]; then
             echo "All queued tasks completed; no continuation was dispatched."
             exit 0


### PR DESCRIPTION
## Summary
- update the runtime contract assertion for the new cancellation-only `if` guard between the step name and timeout

## Evidence
- the prior runtime run failed only on this source-regex assertion; all cancellation and dual-template tests passed in that run