### PR TITLE
fix(queue): prevent persistence tests from launching Chat

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -931,6 +931,7 @@ case "queue_update":
   do {
     let payload = try withQueueStateLock { state -> [String: Any] in
       var tasks = state.automationTasks ?? []
+      let queueWasEnabled = state.queueEnabled == true
       guard let index = tasks.firstIndex(where: { $0.id == taskId }) else {
         throw NSError(
           domain: "chatgpt-auto-confirm",
@@ -1041,9 +1042,11 @@ case "queue_update":
         tasks[index].waitReason = nil
       }
       state.automationTasks = tasks
-      state.queueEnabled = true
-      state.queuePaused = false
-      try startQueueWatcher(&state)
+      if queueWasEnabled {
+        state.queueEnabled = true
+        state.queuePaused = false
+        try startQueueWatcher(&state)
+      }
       var result = queueStatusPayload(state)
       result["updatedTask"] = taskPublicPayload(tasks[index])
       result["updateApplied"] = true

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/standalone-runtime.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/standalone-runtime.test.mjs
@@ -109,6 +109,8 @@ test('native task queue persists queued work without starting ChatGPT', async t 
     assert.equal(updated.updatedTask.currentRevision, 2);
     assert.equal(updated.updatedTask.pendingRevision, 2);
     assert.equal(updated.applyMode, 'interrupt');
+    assert.equal(updated.enabled, false);
+    assert.equal(updated.running, false);
     assert.equal(updated.updatedTask.originalPrompt, '验证队列持久化');
     assert.equal(updated.updatedTask.taskUpdateCount, 1);
     assert.equal(updated.updatedTask.taskUpdates[0].source, 'test-operator');


### PR DESCRIPTION
## 原因
`queue_update` 会无条件启用队列并启动 watcher，即使任务通过 `start: false` 入队。这使“只验证持久化”的 `queue-contract` 测试夹具逃逸到真实 Chat，并持续重试。

## 修复
- 仅当队列在更新前已启用时，`queue_update` 才保持运行并启动 watcher。
- 为 `start: false` 场景增加 `enabled === false`、`running === false` 回归断言。

## 验证
仅通过 GitHub Actions 执行构建和测试。