### PR TITLE
fix(actions): restart stalled ChatGPT shell

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -72,6 +72,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /no continuation was dispatched/);
   assert.match(actionsWorkflow, /for attempt in 1 2/);
   assert.match(actionsWorkflow, /Authenticated Chat shell attempt/);
+  assert.match(actionsWorkflow, /restarting the app before retrying/);
+  assert.match(actionsWorkflow, /pkill -f "user-data-dir=\$PROFILE_DIR"/);
+  assert.match(actionsWorkflow, /SingletonLock/);
   assert.match(restoreSessionScript, /mode === 'restore'/);
   assert.match(restoreSessionScript, /process\.exit\(0\)/);
   assert.match(restoreSessionScript, /Page\.reload/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -169,7 +169,21 @@ jobs:
               shell_ready=true
               break
             fi
-            echo "::warning::Authenticated Chat shell attempt $attempt failed; retrying in the same app instance."
+            if [[ "$attempt" -lt 2 ]]; then
+              echo "::warning::Authenticated Chat shell attempt $attempt failed; restarting the app before retrying."
+              pkill -f "user-data-dir=$PROFILE_DIR" || true
+              for _ in {1..20}; do
+                pgrep -f "user-data-dir=$PROFILE_DIR" >/dev/null || break
+                sleep 1
+              done
+              rm -f \
+                "$PROFILE_DIR/SingletonCookie" \
+                "$PROFILE_DIR/SingletonLock" \
+                "$PROFILE_DIR/SingletonSocket"
+              open -na /Applications/ChatGPT.app --args \
+                --user-data-dir="$PROFILE_DIR" \
+                --remote-debugging-port="$CHATGPT_CDP_PORT"
+            fi
           done
           test "$shell_ready" = true
 


### PR DESCRIPTION
## 原因
连续两次 hosted runner 都在登录预检时停留于 `app://-/index.html` 空壳页面。现有重试复用同一个卡死应用实例，因此第二次检测没有恢复机会。

## 修复
- 第一次登录预检失败后，只终止使用当前临时 profile 的 ChatGPT 进程。
- 等待进程退出并清理 Chromium singleton 锁。
- 重新启动 ChatGPT 后执行第二次恢复与验证。
- 增加 workflow contract 回归断言。

## 验证
仅通过 GitHub Actions 执行测试与真实 hosted 登录验证。