### PR TITLE
fix(actions): accept authenticated controller shell

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -22,6 +22,12 @@ if (mode !== 'verify') {
 const sleep = milliseconds =>
   new Promise(resolve => setTimeout(resolve, milliseconds));
 
+const authenticatedControllerIsReady = state =>
+  !state.asksForLogin
+  && state.bridge
+  && state.readyState === 'complete'
+  && state.bodyLength > 50;
+
 const appRootURL = 'app://-/index.html?initialRoute=%2F';
 
 const listTargets = async () =>
@@ -277,18 +283,7 @@ while (Date.now() < verificationDeadline) {
     continue;
   }
   lastState = evaluation.result?.value || {};
-  if (
-    !lastState.asksForLogin
-    && lastState.bridge
-    && lastState.readyState === 'complete'
-    && lastState.bodyLength > 50
-    && (
-      lastState.currentMode
-      || lastState.workComposer
-      || lastState.hasChat
-      || lastState.hasWork
-    )
-  ) {
+  if (authenticatedControllerIsReady(lastState)) {
     verified = true;
     break;
   }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -82,6 +82,12 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(restoreSessionScript, /avatar-overlay/);
   assert.match(restoreSessionScript, /initialRoute=%2F/);
   assert.match(restoreSessionScript, /Optional CDP command/);
+  assert.match(restoreSessionScript, /authenticatedControllerIsReady/);
+  assert.match(restoreSessionScript, /!state\.asksForLogin/);
+  assert.doesNotMatch(
+    restoreSessionScript,
+    /lastState\.currentMode\s*\|\|\s*lastState\.workComposer/,
+  );
   assert.doesNotMatch(restoreSessionScript, /call\([^\n]*['"]Page\.setWebLifecycleState['"]/);
   assert.doesNotMatch(actionsWorkflow, /pkill -x ChatGPT/);
   assert.match(actionsWorkflow, /Launch authenticated desktop shell/);


### PR DESCRIPTION
## 原因
`restore-session-cookies.mjs` 的注释允许 hosted controller 保持空白并由后续原生队列创建 Chat，但成功条件仍强制要求 controller 自身出现 Chat/Work 控件。连续三次运行均在已加载、无登录提示、Electron bridge 可用的壳页面被提前拒绝。

## 修复
- Cookie 预检只确认无登录提示、Electron bridge 可用、文档加载完成且页面正文已初始化。
- 不再要求 controller 自身渲染 Chat/Work 控件。
- 后续 `verify_chatgpt_login` 仍严格验证真实 Chat 会话。
- 添加 contract 回归断言，防止重新引入错误耦合。

## 验证
仅通过 GitHub Actions 执行测试和 hosted 登录验证。