### PR TITLE
fix: bind default account runtime credentials

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -88,7 +88,7 @@
     },
     {
       "name": "chatgpt-auto-confirm",
-      "version": "1.0.0+codex.20260802193301",
+      "version": "1.0.0+codex.20260802195408",
       "source": {
         "source": "local",
         "path": "./plugins/chatgpt-auto-confirm"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/.codex-plugin/plugin.json
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-auto-confirm",
-  "version": "1.0.0+codex.20260802193301",
+  "version": "1.0.0+codex.20260802195408",
   "description": "\u81ea\u52a8\u786e\u8ba4 ChatGPT \u6388\u6743\u5361\uff0c\u5e76\u7f16\u6392\u53ef\u6062\u590d\u3001\u53ef\u5e76\u53d1\u3001\u9700\u9a8c\u6536\u7684\u4efb\u52a1\u961f\u5217",
   "author": {
     "name": "Fabushi"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -1749,6 +1749,11 @@ func ensureHiddenChatTarget(
         "--user-data-dir=\(profilePath)",
         "--remote-debugging-port=\(port)",
       ]
+      if let codexHomePath = state.backgroundCodexHomePath {
+        var environment = ProcessInfo.processInfo.environment
+        environment["CODEX_HOME"] = codexHomePath
+        launcher.environment = environment
+      }
       launcher.standardInput = FileHandle.nullDevice
       launcher.standardOutput = FileHandle.nullDevice
       launcher.standardError = FileHandle.nullDevice

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/Models.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/Models.swift
@@ -32,6 +32,7 @@ struct PluginState: Codable {
   var backgroundAppPort: Int?
   var backgroundChatTargetId: String?
   var backgroundProfilePath: String?
+  var backgroundCodexHomePath: String?
   var backgroundConversationId: String?
   var intervalMs = 750
   var watcherPid: Int32?

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1211,8 +1211,13 @@ func createIndependentQueueWorkerTarget(
   _ state: inout PluginState,
   accountId: String? = nil
 ) -> (port: Int, targetId: String, profilePath: String)? {
-  if let account = resolveAccount(accountId),
-     FileManager.default.fileExists(atPath: account.profilePath) {
+  if let accountId {
+    guard let account = resolveAccount(accountId),
+          FileManager.default.fileExists(atPath: account.profilePath) else {
+      // A task with an explicit account must never fall back to another
+      // account's renderer or the user's shared ChatGPT process.
+      return nil
+    }
     guard let worker = createDedicatedParallelQueueWorkerTarget(
       &state,
       sourceProfilePath: account.profilePath,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -1550,9 +1550,37 @@ case "login_and_sync_actions":
 case "start_actions_runner":
   let runnerParams = commandJSONParams()
   let requestedRunnerAccount = (runnerParams["accountId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-  if let requestedRunnerAccount, !requestedRunnerAccount.isEmpty,
-     resolveAccount(requestedRunnerAccount) == nil {
-    output(["ok": false, "errorCode": "account_not_found", "message": "指定账号不存在。"], exitCode: 1)
+  let resolvedRunnerAccount: AccountRecord?
+  if let requestedRunnerAccount, !requestedRunnerAccount.isEmpty {
+    guard let account = resolveAccount(requestedRunnerAccount) else {
+      output(["ok": false, "errorCode": "account_not_found", "message": "指定账号不存在。"], exitCode: 1)
+    }
+    resolvedRunnerAccount = account
+  } else {
+    resolvedRunnerAccount = resolveAccount(nil)
+  }
+  if let account = resolvedRunnerAccount {
+    guard let credentials = accountCredentialData(account) else {
+      output(["ok": false, "errorCode": "account_credentials_missing", "message": "账号没有可上传的完整凭据，请先重新登录或同步。"], exitCode: 1)
+    }
+    let dispatch = accountDispatch(
+      account,
+      authData: credentials.auth,
+      cookieData: credentials.cookies,
+      startRunner: true
+    )
+    guard dispatch.ok else {
+      output(["ok": false, "errorCode": "github_cli_failed", "accountId": account.id, "message": dispatch.message], exitCode: 1)
+    }
+    output([
+      "ok": true,
+      "dispatched": true,
+      "accountId": account.id,
+      "repository": "bhrumom/fabushi",
+      "workflow": "chatgpt-auto-confirm-runner.yml",
+      "ref": "main",
+      "message": dispatch.message,
+    ])
   }
   let executableURL = URL(
     fileURLWithPath: CommandLine.arguments[0]
@@ -2126,12 +2154,24 @@ case "send_and_watch":
   // the first poll can mistake the previous assistant message for the reply to
   // the new instruction and return immediately.
   var state = loadState()
-  if let requestedAccountId = params["accountId"] as? String {
+  let requestedAccountId = (params["accountId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+  let selectedAccount: AccountRecord?
+  if let requestedAccountId, !requestedAccountId.isEmpty {
     guard let account = resolveAccount(requestedAccountId) else {
       output(["ok": false, "errorCode": "account_not_found", "message": "指定账号不存在。"], exitCode: 1)
     }
+    selectedAccount = account
+  } else {
+    selectedAccount = resolveAccount(nil)
+  }
+  if let account = selectedAccount {
     state.backgroundProfilePath = account.profilePath
+    state.backgroundCodexHomePath = account.codexHomePath
     state.backgroundAppPort = accountAvailableCDPPort()
+  } else if loadAccounts().isEmpty {
+    state.backgroundProfilePath = nil
+    state.backgroundCodexHomePath = nil
+    state.backgroundAppPort = nil
   }
   let prepared = ensureHiddenChatTarget(
     &state,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
@@ -4,7 +4,7 @@ export const HOME = {
   "app": {
     "id": "chatgpt-auto-confirm",
     "title": "ChatGPT 自动确认",
-    "version": "1.0.0+codex.20260802193301"
+    "version": "1.0.0+codex.20260802195408"
   },
   "welcome": {
     "id": "welcome",

--- a/frontend/apps/web/public/.well-known/mahayana/marketplace.json
+++ b/frontend/apps/web/public/.well-known/mahayana/marketplace.json
@@ -58,7 +58,7 @@
     },
     {
       "id": "chatgpt-auto-confirm",
-      "version": "1.0.0+codex.20260802193301",
+      "version": "1.0.0+codex.20260802195408",
       "title": "ChatGPT 自动确认",
       "description": "自动确认、任务续作、队列并发和独立验收",
       "homepage": "https://fabushi.ombhrum.com/miniapps/chatgpt-auto-confirm/",


### PR DESCRIPTION
## Summary
- resolve the default registered account when accountId is omitted from runner and send-and-watch calls
- upload the selected account's Keychain credentials for start_actions_runner
- keep account-bound workers fail-closed instead of falling back to another renderer
- propagate the account CODEX_HOME into isolated hidden Chat launches

## Validation
The original multi-account feature PR #1799 is already merged. This follow-up runs the same hosted macOS Swift and contract checks.