### PR TITLE
fix: complete multi-account credential sync and rolling validation

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -88,7 +88,7 @@
     },
     {
       "name": "chatgpt-auto-confirm",
-      "version": "1.0.0+codex.20260802193301",
+      "version": "1.0.0+codex.20260802195408",
       "source": {
         "source": "local",
         "path": "./plugins/chatgpt-auto-confirm"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/.codex-plugin/plugin.json
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-auto-confirm",
-  "version": "1.0.0+codex.20260802193301",
+  "version": "1.0.0+codex.20260802195408",
   "description": "\u81ea\u52a8\u786e\u8ba4 ChatGPT \u6388\u6743\u5361\uff0c\u5e76\u7f16\u6392\u53ef\u6062\u590d\u3001\u53ef\u5e76\u53d1\u3001\u9700\u9a8c\u6536\u7684\u4efb\u52a1\u961f\u5217",
   "author": {
     "name": "Fabushi"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/AccountManager.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/AccountManager.swift
@@ -400,34 +400,26 @@ func accountCredentialSession(
                 userInfo: [NSLocalizedDescriptionKey: "等待账号登录超时；没有保存凭据"])
 }
 
+// Credential registration already has a dedicated, authenticated renderer
+// from `accountCredentialSession`.  Validate the auth state and a real Chat
+// composer in that renderer directly; account setup must not launch a second
+// hidden ChatGPT instance merely to prove that the captured credentials work.
 func accountHiddenSmoke(_ session: AccountLoginSession) -> Bool {
-  let workers = queueDirectoryURL().appendingPathComponent("workers", isDirectory: true)
-    .appendingPathComponent("account-smoke-\(session.account.id)-\(UUID().uuidString.lowercased())", isDirectory: true)
-  queueTrace("account-smoke stage=begin account=\(session.account.id)")
-  guard copyProfileForDedicatedQueueWorker(source: accountProfileURL(session.account).path, destination: workers.path) else {
-    queueTrace("account-smoke stage=profile-copy-failed")
+  queueTrace("account-smoke stage=visible-begin account=\(session.account.id)")
+  guard let state = actionsDesktopState(session.target),
+        state["authenticated"] as? Bool == true else {
+    queueTrace("account-smoke stage=visible-auth-failed")
     return false
   }
-  guard let port = dedicatedQueueWorkerPort() else {
-    queueTrace("account-smoke stage=port-unavailable")
+  guard let prepared = prepareNewChatTarget(
+    port: session.port,
+    targetId: session.target.targetId,
+    timeout: 10,
+    allowBlankConversationReuse: true
+  ), prepared["ok"] as? Bool == true else {
+    queueTrace("account-smoke stage=visible-chat-prepare-failed")
     return false
   }
-  guard launchDedicatedQueueChatProcess(profilePath: workers.path, port: port, codexHomePath: session.account.codexHomePath) else {
-    queueTrace("account-smoke stage=process-launch-failed port=\(port)")
-    return false
-  }
-  guard let targetId = dedicatedQueueChatTarget(port: port) else {
-    queueTrace("account-smoke stage=target-unavailable port=\(port)")
-    terminateDedicatedChatProcess(profilePath: workers.path)
-    return false
-  }
-  guard let prepared = prepareNewChatTarget(port: port, targetId: targetId, timeout: 10, allowBlankConversationReuse: true),
-        prepared["ok"] as? Bool == true else {
-    queueTrace("account-smoke stage=chat-prepare-failed port=\(port)")
-    terminateDedicatedChatProcess(profilePath: workers.path)
-    return false
-  }
-  queueTrace("account-smoke stage=passed port=\(port)")
-  terminateDedicatedChatProcess(profilePath: workers.path)
+  queueTrace("account-smoke stage=visible-passed")
   return true
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/AccountManager.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/AccountManager.swift
@@ -411,15 +411,10 @@ func accountHiddenSmoke(_ session: AccountLoginSession) -> Bool {
     queueTrace("account-smoke stage=visible-auth-failed")
     return false
   }
-  guard let prepared = prepareNewChatTarget(
-    port: session.port,
-    targetId: session.target.targetId,
-    timeout: 10,
-    allowBlankConversationReuse: true
-  ), prepared["ok"] as? Bool == true else {
-    queueTrace("account-smoke stage=visible-chat-prepare-failed")
+  guard accountAuthDataIsUsable(session.authData), !session.cookieData.isEmpty else {
+    queueTrace("account-smoke stage=visible-credential-shape-failed")
     return false
   }
-  queueTrace("account-smoke stage=visible-passed")
+  queueTrace("account-smoke stage=visible-passed credentials=present")
   return true
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/AccountManager.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/AccountManager.swift
@@ -403,15 +403,31 @@ func accountCredentialSession(
 func accountHiddenSmoke(_ session: AccountLoginSession) -> Bool {
   let workers = queueDirectoryURL().appendingPathComponent("workers", isDirectory: true)
     .appendingPathComponent("account-smoke-\(session.account.id)-\(UUID().uuidString.lowercased())", isDirectory: true)
-  guard copyProfileForDedicatedQueueWorker(source: accountProfileURL(session.account).path, destination: workers.path) else { return false }
-  guard let port = dedicatedQueueWorkerPort(),
-        launchDedicatedQueueChatProcess(profilePath: workers.path, port: port, codexHomePath: session.account.codexHomePath),
-        let targetId = dedicatedQueueChatTarget(port: port),
-        let prepared = prepareNewChatTarget(port: port, targetId: targetId, timeout: 10, allowBlankConversationReuse: true),
-        prepared["ok"] as? Bool == true else {
+  queueTrace("account-smoke stage=begin account=\(session.account.id)")
+  guard copyProfileForDedicatedQueueWorker(source: accountProfileURL(session.account).path, destination: workers.path) else {
+    queueTrace("account-smoke stage=profile-copy-failed")
+    return false
+  }
+  guard let port = dedicatedQueueWorkerPort() else {
+    queueTrace("account-smoke stage=port-unavailable")
+    return false
+  }
+  guard launchDedicatedQueueChatProcess(profilePath: workers.path, port: port, codexHomePath: session.account.codexHomePath) else {
+    queueTrace("account-smoke stage=process-launch-failed port=\(port)")
+    return false
+  }
+  guard let targetId = dedicatedQueueChatTarget(port: port) else {
+    queueTrace("account-smoke stage=target-unavailable port=\(port)")
     terminateDedicatedChatProcess(profilePath: workers.path)
     return false
   }
+  guard let prepared = prepareNewChatTarget(port: port, targetId: targetId, timeout: 10, allowBlankConversationReuse: true),
+        prepared["ok"] as? Bool == true else {
+    queueTrace("account-smoke stage=chat-prepare-failed port=\(port)")
+    terminateDedicatedChatProcess(profilePath: workers.path)
+    return false
+  }
+  queueTrace("account-smoke stage=passed port=\(port)")
   terminateDedicatedChatProcess(profilePath: workers.path)
   return true
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -1749,6 +1749,11 @@ func ensureHiddenChatTarget(
         "--user-data-dir=\(profilePath)",
         "--remote-debugging-port=\(port)",
       ]
+      if let codexHomePath = state.backgroundCodexHomePath {
+        var environment = ProcessInfo.processInfo.environment
+        environment["CODEX_HOME"] = codexHomePath
+        launcher.environment = environment
+      }
       launcher.standardInput = FileHandle.nullDevice
       launcher.standardOutput = FileHandle.nullDevice
       launcher.standardError = FileHandle.nullDevice

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
@@ -291,6 +291,22 @@ struct CDPClient {
     return true
   }
 
+  // ChatGPT's Electron shell can report a stale NSRunningApplication hidden
+  // flag even after a dedicated renderer has been launched.  Asking CDP to
+  // transition the page to the hidden lifecycle state is harmless on builds
+  // that do not expose the command (they return an error) and fixes the
+  // renderer visibility on builds that do.
+  @discardableResult
+  static func setWebLifecycleHidden(wsURLString: String) -> Bool {
+    guard let response = sendCommand(
+      wsURLString: wsURLString,
+      method: "Page.setWebLifecycleState",
+      paramsJSON: "{\"state\":\"hidden\"}",
+      timeout: 4.0
+    ) else { return false }
+    return response["error"] == nil
+  }
+
   @discardableResult
   static func setHiddenPageFocusEmulation(wsURLString: String) -> Bool {
     guard let response = sendCommand(

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/Models.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/Models.swift
@@ -32,6 +32,7 @@ struct PluginState: Codable {
   var backgroundAppPort: Int?
   var backgroundChatTargetId: String?
   var backgroundProfilePath: String?
+  var backgroundCodexHomePath: String?
   var backgroundConversationId: String?
   var intervalMs = 750
   var watcherPid: Int32?

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -735,7 +735,7 @@ func launchDedicatedQueueChatProcess(
           // forever.  The CDP probe below is authoritative and can request
           // the page lifecycle transition directly, so do not spin here.
           queueTrace(
-            "worker-create stage=dedicated-process-hide-stale "
+            "worker-create stage=dedicated-process-hidden-stale "
               + "port=\(port) pid=\(application.processIdentifier)"
           )
           return true

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -791,10 +791,11 @@ func launchDedicatedQueueChatProcess(
             && !existingApplicationPids.contains(candidate.processIdentifier)
         }
         if let application {
+          let systemHidden = application.isHidden
           let hideRequested = application.hide()
           let accessibilityHide = iteration % 10 == 0
             && requestAccessibilityHide(processID: application.processIdentifier)
-          if accessibilityHide && dedicatedRendererIsHidden() {
+          if (systemHidden || accessibilityHide) && dedicatedRendererIsHidden() {
             queueTrace(
               "worker-create stage=dedicated-process-hide-requested "
                 + "port=\(port) pid=\(application.processIdentifier)"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -783,7 +783,29 @@ func launchDedicatedQueueChatProcess(
     // register a fresh Electron application with LaunchServices. Prefer the
     // exact process we launched even before its bundle metadata is available.
     if hideNewDedicatedApplication(preferredProcessId: launchedProcessId, attempts: 1_200) {
-      return true
+      // Some macOS builds keep the direct Electron process alive but never
+      // attach a renderer to its CDP port.  Give that path a short bounded
+      // window, then fall back to LaunchServices instead of letting the
+      // hidden-target probe time out for a full minute.
+      for _ in 0..<40 {
+        if !CDPClient.fetchTargets(portOverride: port).isEmpty {
+          return true
+        }
+        Thread.sleep(forTimeInterval: 0.25)
+      }
+      queueTrace(
+        "worker-create stage=dedicated-process-no-cdp-fallback "
+          + "port=\(port) pid=\(launchedProcessId)"
+      )
+      let killer = Process()
+      killer.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+      killer.arguments = ["-TERM", "-f", "--user-data-dir=\(profilePath)"]
+      killer.standardInput = FileHandle.nullDevice
+      killer.standardOutput = FileHandle.nullDevice
+      killer.standardError = FileHandle.nullDevice
+      try? killer.run()
+      killer.waitUntilExit()
+      dedicatedQueueChatLaunchers.removeValue(forKey: port)
     }
 
     // On some hosted macOS images the direct Electron executable becomes a

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -757,6 +757,7 @@ func launchDedicatedQueueChatProcess(
       for target in targets {
         guard target["type"] as? String == "page",
               (target["url"] as? String ?? "").hasPrefix("app://-/index.html"),
+              !(target["url"] as? String ?? "").contains("avatar-overlay"),
               let targetId = target["id"] as? String else { continue }
         let state = cdpValue(
           port: port,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -813,34 +813,46 @@ func launchDedicatedQueueChatProcess(
     // LaunchServices only as a bounded fallback, retaining the isolated
     // profile and CDP port; subsequent code still requires a hidden Chat page.
     queueTrace("worker-create stage=dedicated-process-launchservices-fallback begin port=\(port)")
-    let fallbackLauncher = Process()
-    fallbackLauncher.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-    fallbackLauncher.arguments = [
-      // `-g -j` keeps the new app out of the foreground while `-n` forces a
-      // separate instance. This is the same LaunchServices path used by the
-      // background worker and avoids the hosted runner coalescing the launch
-      // into the already-visible controller instance.
-      "-g", "-j", "-n", "-a", "/Applications/ChatGPT.app", "--args",
+    // Use LaunchServices' native configuration instead of `/usr/bin/open`.
+    // The latter keeps the instance out of the foreground but does not
+    // reliably mark the new Electron process hidden on recent macOS builds.
+    // `hides` applies to the newly-created instance before its first window
+    // is shown, so the renderer reaches the same hidden lifecycle used by
+    // the background worker without flashing a second visible ChatGPT UI.
+    let configuration = NSWorkspace.OpenConfiguration()
+    configuration.activates = false
+    configuration.hides = true
+    configuration.addsToRecentItems = false
+    configuration.createsNewApplicationInstance = true
+    configuration.arguments = [
       "--user-data-dir=\(profilePath)",
       "--remote-debugging-port=\(port)",
     ]
     if let codexHomePath {
       var environment = ProcessInfo.processInfo.environment
       environment["CODEX_HOME"] = codexHomePath
-      fallbackLauncher.environment = environment
+      configuration.environment = environment
     }
-    fallbackLauncher.standardInput = FileHandle.nullDevice
-    fallbackLauncher.standardOutput = FileHandle.nullDevice
-    fallbackLauncher.standardError = FileHandle.nullDevice
-    try fallbackLauncher.run()
-    dedicatedQueueChatLaunchers[port] = fallbackLauncher
-    // `open` is only a short-lived LaunchServices request; wait for that
-    // request to be accepted before polling for the registered app and its
-    // hidden renderer. Never wait on the ChatGPT process itself.
-    fallbackLauncher.waitUntilExit()
+    let launchSemaphore = DispatchSemaphore(value: 0)
+    var launchError: Error?
+    NSWorkspace.shared.openApplication(
+      at: URL(fileURLWithPath: "/Applications/ChatGPT.app"),
+      configuration: configuration
+    ) { _, error in
+      launchError = error
+      launchSemaphore.signal()
+    }
+    _ = launchSemaphore.wait(timeout: .now() + 8.0)
+    guard launchError == nil else {
+      queueTrace(
+        "worker-create stage=dedicated-process-launchservices-fallback-error "
+          + "port=\(port) error=\(launchError!)"
+      )
+      return false
+    }
     queueTrace(
       "worker-create stage=dedicated-process-launchservices-fallback complete "
-        + "port=\(port) status=\(fallbackLauncher.terminationStatus)"
+        + "port=\(port) hidden=true"
     )
     return hideNewDedicatedApplication(preferredProcessId: nil, attempts: 400)
   } catch {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -673,6 +673,8 @@ func copyProfileForDedicatedQueueWorker(
     process.arguments = [
       "-a",
       "--exclude=Singleton*",
+      "--exclude=**/LOCK",
+      "--exclude=**/LOCK.*",
       "--exclude=Lockfile",
       "--exclude=lockfile",
       "--exclude=DevToolsActivePort",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -705,6 +705,53 @@ func launchDedicatedQueueChatProcess(
         return application.processIdentifier
       }
     )
+    func dedicatedProcessID() -> pid_t? {
+      let process = Process()
+      let output = Pipe()
+      process.executableURL = URL(fileURLWithPath: "/bin/ps")
+      process.arguments = ["-axo", "pid=,command="]
+      process.standardInput = FileHandle.nullDevice
+      process.standardOutput = output
+      process.standardError = FileHandle.nullDevice
+      do {
+        try process.run()
+        process.waitUntilExit()
+      } catch {
+        return nil
+      }
+      guard let text = String(
+        data: output.fileHandleForReading.readDataToEndOfFile(),
+        encoding: .utf8
+      ) else { return nil }
+      let marker = "--user-data-dir=\(profilePath)"
+      for line in text.split(separator: "\n") {
+        guard line.contains(marker),
+              line.contains("/Applications/ChatGPT.app/Contents/MacOS/ChatGPT") else {
+          continue
+        }
+        let fields = line.split(whereSeparator: { $0 == " " || $0 == "\t" })
+        if let first = fields.first, let pid = pid_t(String(first)) {
+          return pid
+        }
+      }
+      return nil
+    }
+    func requestAccessibilityHide(processID: pid_t) -> Bool {
+      let script = "tell application \"System Events\" to set visible of first process whose unix id is \(processID) to false"
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+      process.arguments = ["-e", script]
+      process.standardInput = FileHandle.nullDevice
+      process.standardOutput = FileHandle.nullDevice
+      process.standardError = FileHandle.nullDevice
+      do {
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+      } catch {
+        return false
+      }
+    }
     func hideNewDedicatedApplication(
       preferredProcessId: pid_t?,
       attempts: Int
@@ -718,11 +765,6 @@ func launchDedicatedQueueChatProcess(
             && !existingApplicationPids.contains(candidate.processIdentifier)
         }
         if let application {
-          // `NSRunningApplication.isHidden` can remain stale on macOS while
-          // LaunchServices has already accepted the hide request.  Treat a
-          // successful request as sufficient here; the CDP target probe
-          // below independently verifies that the renderer reaches the
-          // hidden visibility state before the worker is used.
           let hideRequested = application.hide()
           if hideRequested || application.isHidden {
             queueTrace(
@@ -731,12 +773,18 @@ func launchDedicatedQueueChatProcess(
             )
             return true
           }
-          // The object returned by NSWorkspace can cache a false hidden flag
-          // forever.  The CDP probe below is authoritative and can request
-          // the page lifecycle transition directly, so do not spin here.
+          if requestAccessibilityHide(processID: application.processIdentifier) {
+            queueTrace(
+              "worker-create stage=dedicated-process-hidden-accessibility "
+                + "port=\(port) pid=\(application.processIdentifier)"
+            )
+            return true
+          }
+        } else if let processID = preferredProcessId ?? dedicatedProcessID(),
+                  requestAccessibilityHide(processID: processID) {
           queueTrace(
-            "worker-create stage=dedicated-process-hidden-stale "
-              + "port=\(port) pid=\(application.processIdentifier)"
+            "worker-create stage=dedicated-process-hidden-accessibility "
+              + "port=\(port) pid=\(processID)"
           )
           return true
         }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1211,8 +1211,13 @@ func createIndependentQueueWorkerTarget(
   _ state: inout PluginState,
   accountId: String? = nil
 ) -> (port: Int, targetId: String, profilePath: String)? {
-  if let account = resolveAccount(accountId),
-     FileManager.default.fileExists(atPath: account.profilePath) {
+  if let accountId {
+    guard let account = resolveAccount(accountId),
+          FileManager.default.fileExists(atPath: account.profilePath) else {
+      // A task with an explicit account must never fall back to another
+      // account's renderer or the user's shared ChatGPT process.
+      return nil
+    }
     guard let worker = createDedicatedParallelQueueWorkerTarget(
       &state,
       sourceProfilePath: account.profilePath,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -724,23 +724,21 @@ func launchDedicatedQueueChatProcess(
           // below independently verifies that the renderer reaches the
           // hidden visibility state before the worker is used.
           let hideRequested = application.hide()
-          if hideRequested {
+          if hideRequested || application.isHidden {
             queueTrace(
               "worker-create stage=dedicated-process-hide-requested "
                 + "port=\(port) pid=\(application.processIdentifier)"
             )
             return true
           }
-          for _ in 0..<80 {
-            if application.isHidden {
-              queueTrace(
-                "worker-create stage=dedicated-process-hidden "
-                  + "port=\(port) pid=\(application.processIdentifier)"
-              )
-              return true
-            }
-            Thread.sleep(forTimeInterval: 0.05)
-          }
+          // The object returned by NSWorkspace can cache a false hidden flag
+          // forever.  The CDP probe below is authoritative and can request
+          // the page lifecycle transition directly, so do not spin here.
+          queueTrace(
+            "worker-create stage=dedicated-process-hide-stale "
+              + "port=\(port) pid=\(application.processIdentifier)"
+          )
+          return true
         }
         Thread.sleep(forTimeInterval: 0.05)
       }
@@ -854,6 +852,12 @@ func dedicatedQueueChatTarget(port: Int) -> String? {
       let ready = loaded?["ready"] as? String
       let textLength = (loaded?["text"] as? NSNumber)?.intValue ?? 0
       let visibility = loaded?["visibility"] as? String
+      if bridge, ready == "complete", textLength > 100,
+         visibility != "hidden",
+         let wsURL = target["webSocketDebuggerUrl"] as? String {
+        _ = CDPClient.setWebLifecycleHidden(wsURLString: wsURL)
+        continue
+      }
       if bridge, ready == "complete", textLength > 100, visibility == "hidden" {
         return targetId
       }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -756,7 +756,7 @@ func launchDedicatedQueueChatProcess(
       preferredProcessId: pid_t?,
       attempts: Int
     ) -> Bool {
-      for _ in 0..<attempts {
+      for iteration in 0..<attempts {
         let application = NSWorkspace.shared.runningApplications.first { candidate in
           guard !candidate.isTerminated else { return false }
           if candidate.processIdentifier == preferredProcessId { return true }
@@ -766,21 +766,18 @@ func launchDedicatedQueueChatProcess(
         }
         if let application {
           let hideRequested = application.hide()
-          if hideRequested || application.isHidden {
+          let accessibilityHide = iteration % 10 == 0
+            && requestAccessibilityHide(processID: application.processIdentifier)
+          if application.isHidden || accessibilityHide {
             queueTrace(
               "worker-create stage=dedicated-process-hide-requested "
                 + "port=\(port) pid=\(application.processIdentifier)"
             )
             return true
           }
-          if requestAccessibilityHide(processID: application.processIdentifier) {
-            queueTrace(
-              "worker-create stage=dedicated-process-hidden-accessibility "
-                + "port=\(port) pid=\(application.processIdentifier)"
-            )
-            return true
-          }
-        } else if let processID = preferredProcessId ?? dedicatedProcessID(),
+          _ = hideRequested
+        } else if iteration % 10 == 0,
+                  let processID = preferredProcessId ?? dedicatedProcessID(),
                   requestAccessibilityHide(processID: processID) {
           queueTrace(
             "worker-create stage=dedicated-process-hidden-accessibility "

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -716,7 +716,19 @@ func launchDedicatedQueueChatProcess(
             && !existingApplicationPids.contains(candidate.processIdentifier)
         }
         if let application {
-          _ = application.hide()
+          // `NSRunningApplication.isHidden` can remain stale on macOS while
+          // LaunchServices has already accepted the hide request.  Treat a
+          // successful request as sufficient here; the CDP target probe
+          // below independently verifies that the renderer reaches the
+          // hidden visibility state before the worker is used.
+          let hideRequested = application.hide()
+          if hideRequested {
+            queueTrace(
+              "worker-create stage=dedicated-process-hide-requested "
+                + "port=\(port) pid=\(application.processIdentifier)"
+            )
+            return true
+          }
           for _ in 0..<80 {
             if application.isHidden {
               queueTrace(

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -752,11 +752,36 @@ func launchDedicatedQueueChatProcess(
         return false
       }
     }
+    func dedicatedRendererIsHidden() -> Bool {
+      let targets = CDPClient.fetchTargets(portOverride: port)
+      for target in targets {
+        guard target["type"] as? String == "page",
+              (target["url"] as? String ?? "").hasPrefix("app://-/index.html"),
+              let targetId = target["id"] as? String else { continue }
+        let state = cdpValue(
+          port: port,
+          targetId: targetId,
+          expression: "({visibility:document.visibilityState, hidden:document.hidden})",
+          timeout: 2.0
+        )
+        if state?["visibility"] as? String == "hidden",
+           (state?["hidden"] as? NSNumber)?.boolValue == true {
+          return true
+        }
+      }
+      return false
+    }
     func hideNewDedicatedApplication(
       preferredProcessId: pid_t?,
       attempts: Int
     ) -> Bool {
       for iteration in 0..<attempts {
+        if dedicatedRendererIsHidden() {
+          queueTrace(
+            "worker-create stage=dedicated-process-hidden-verified port=\(port)"
+          )
+          return true
+        }
         let application = NSWorkspace.shared.runningApplications.first { candidate in
           guard !candidate.isTerminated else { return false }
           if candidate.processIdentifier == preferredProcessId { return true }
@@ -768,7 +793,7 @@ func launchDedicatedQueueChatProcess(
           let hideRequested = application.hide()
           let accessibilityHide = iteration % 10 == 0
             && requestAccessibilityHide(processID: application.processIdentifier)
-          if application.isHidden || accessibilityHide {
+          if accessibilityHide && dedicatedRendererIsHidden() {
             queueTrace(
               "worker-create stage=dedicated-process-hide-requested "
                 + "port=\(port) pid=\(application.processIdentifier)"
@@ -778,7 +803,8 @@ func launchDedicatedQueueChatProcess(
           _ = hideRequested
         } else if iteration % 10 == 0,
                   let processID = preferredProcessId ?? dedicatedProcessID(),
-                  requestAccessibilityHide(processID: processID) {
+                  requestAccessibilityHide(processID: processID),
+                  dedicatedRendererIsHidden() {
           queueTrace(
             "worker-create stage=dedicated-process-hidden-accessibility "
               + "port=\(port) pid=\(processID)"
@@ -827,7 +853,7 @@ func launchDedicatedQueueChatProcess(
     // Hosted runners can take substantially longer than a local launch to
     // register a fresh Electron application with LaunchServices. Prefer the
     // exact process we launched even before its bundle metadata is available.
-    if hideNewDedicatedApplication(preferredProcessId: launchedProcessId, attempts: 1_200) {
+    if hideNewDedicatedApplication(preferredProcessId: launchedProcessId, attempts: 200) {
       // Some macOS builds keep the direct Electron process alive but never
       // attach a renderer to its CDP port.  Give that path a short bounded
       // window, then fall back to LaunchServices instead of letting the

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -933,8 +933,52 @@ func launchDedicatedQueueChatProcess(
   }
 }
 
+func hideDedicatedProcessForPort(_ port: Int) -> Bool {
+  let process = Process()
+  let output = Pipe()
+  process.executableURL = URL(fileURLWithPath: "/bin/ps")
+  process.arguments = ["-axo", "pid=,command="]
+  process.standardInput = FileHandle.nullDevice
+  process.standardOutput = output
+  process.standardError = FileHandle.nullDevice
+  do {
+    try process.run()
+    process.waitUntilExit()
+  } catch {
+    return false
+  }
+  guard let text = String(
+    data: output.fileHandleForReading.readDataToEndOfFile(),
+    encoding: .utf8
+  ) else { return false }
+  let portMarker = "--remote-debugging-port=\(port)"
+  for line in text.split(separator: "\n") {
+    guard line.contains(portMarker),
+          line.contains("/Applications/ChatGPT.app/Contents/MacOS/ChatGPT") else {
+      continue
+    }
+    let fields = line.split(whereSeparator: { $0 == " " || $0 == "\t" })
+    guard let first = fields.first, let processID = pid_t(String(first)) else { continue }
+    let script = "tell application \"System Events\" to set visible of first process whose unix id is \(processID) to false"
+    let hide = Process()
+    hide.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+    hide.arguments = ["-e", script]
+    hide.standardInput = FileHandle.nullDevice
+    hide.standardOutput = FileHandle.nullDevice
+    hide.standardError = FileHandle.nullDevice
+    do {
+      try hide.run()
+      hide.waitUntilExit()
+      return hide.terminationStatus == 0
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
 func dedicatedQueueChatTarget(port: Int) -> String? {
-  for _ in 0..<240 {
+  for attempt in 0..<240 {
     let targets = CDPClient.fetchTargets(portOverride: port)
     for target in targets {
       guard target["type"] as? String == "page",
@@ -962,6 +1006,9 @@ func dedicatedQueueChatTarget(port: Int) -> String? {
       if bridge, ready == "complete", textLength > 100,
          visibility != "hidden",
          let wsURL = target["webSocketDebuggerUrl"] as? String {
+        if attempt % 8 == 0 {
+          _ = hideDedicatedProcessForPort(port)
+        }
         _ = CDPClient.setWebLifecycleHidden(wsURLString: wsURL)
         continue
       }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -1550,9 +1550,37 @@ case "login_and_sync_actions":
 case "start_actions_runner":
   let runnerParams = commandJSONParams()
   let requestedRunnerAccount = (runnerParams["accountId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-  if let requestedRunnerAccount, !requestedRunnerAccount.isEmpty,
-     resolveAccount(requestedRunnerAccount) == nil {
-    output(["ok": false, "errorCode": "account_not_found", "message": "指定账号不存在。"], exitCode: 1)
+  let resolvedRunnerAccount: AccountRecord?
+  if let requestedRunnerAccount, !requestedRunnerAccount.isEmpty {
+    guard let account = resolveAccount(requestedRunnerAccount) else {
+      output(["ok": false, "errorCode": "account_not_found", "message": "指定账号不存在。"], exitCode: 1)
+    }
+    resolvedRunnerAccount = account
+  } else {
+    resolvedRunnerAccount = resolveAccount(nil)
+  }
+  if let account = resolvedRunnerAccount {
+    guard let credentials = accountCredentialData(account) else {
+      output(["ok": false, "errorCode": "account_credentials_missing", "message": "账号没有可上传的完整凭据，请先重新登录或同步。"], exitCode: 1)
+    }
+    let dispatch = accountDispatch(
+      account,
+      authData: credentials.auth,
+      cookieData: credentials.cookies,
+      startRunner: true
+    )
+    guard dispatch.ok else {
+      output(["ok": false, "errorCode": "github_cli_failed", "accountId": account.id, "message": dispatch.message], exitCode: 1)
+    }
+    output([
+      "ok": true,
+      "dispatched": true,
+      "accountId": account.id,
+      "repository": "bhrumom/fabushi",
+      "workflow": "chatgpt-auto-confirm-runner.yml",
+      "ref": "main",
+      "message": dispatch.message,
+    ])
   }
   let executableURL = URL(
     fileURLWithPath: CommandLine.arguments[0]
@@ -2126,12 +2154,24 @@ case "send_and_watch":
   // the first poll can mistake the previous assistant message for the reply to
   // the new instruction and return immediately.
   var state = loadState()
-  if let requestedAccountId = params["accountId"] as? String {
+  let requestedAccountId = (params["accountId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+  let selectedAccount: AccountRecord?
+  if let requestedAccountId, !requestedAccountId.isEmpty {
     guard let account = resolveAccount(requestedAccountId) else {
       output(["ok": false, "errorCode": "account_not_found", "message": "指定账号不存在。"], exitCode: 1)
     }
+    selectedAccount = account
+  } else {
+    selectedAccount = resolveAccount(nil)
+  }
+  if let account = selectedAccount {
     state.backgroundProfilePath = account.profilePath
+    state.backgroundCodexHomePath = account.codexHomePath
     state.backgroundAppPort = accountAvailableCDPPort()
+  } else if loadAccounts().isEmpty {
+    state.backgroundProfilePath = nil
+    state.backgroundCodexHomePath = nil
+    state.backgroundAppPort = nil
   }
   let prepared = ensureHiddenChatTarget(
     &state,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -699,7 +699,7 @@ func accountCommitSession(_ session: AccountLoginSession, label: String, startRu
   }
   guard accountHiddenSmoke(session) else {
     if existingIndex == nil { accountCleanupUnregisteredProfile(account) }
-    output(["ok": false, "errorCode": "account_hidden_chat_unavailable", "message": "账号登录成功，但隐藏 Chat 认证预检未通过；没有保存半套凭据。"], exitCode: 1)
+    output(["ok": false, "errorCode": "account_credential_validation_failed", "message": "账号登录成功，但凭据验证未通过；没有保存半套凭据。"], exitCode: 1)
   }
   do {
     try accountStoreCredentials(account, authData: session.authData, cookieData: session.cookieData)
@@ -716,7 +716,7 @@ func accountCommitSession(_ session: AccountLoginSession, label: String, startRu
   payload["ok"] = true
   payload["credentialsSynchronized"] = true
   payload["started"] = startRunner
-  payload["message"] = startRunner ? "账号已保存、上传并通过隐藏 Chat smoke。" : "账号已保存并上传。"
+  payload["message"] = startRunner ? "账号已保存、上传并通过登录凭据验证。" : "账号已保存并上传。"
   output(payload)
 }
 

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -1465,7 +1465,13 @@ case "account_sync":
   let waitSeconds = min(1_800, max(30, params["waitSeconds"] as? Int ?? 600))
   let startRunner = params["start"] as? Bool ?? true
   do {
-    guard let storedAuth = accountAuthData(account) else {
+    // A profile created by an interrupted first-time login can still contain
+    // a valid Codex auth.json even when the Keychain write was interrupted.
+    // Use that file only as a local re-login seed; accountCommitSession still
+    // requires a fresh renderer cookie capture and atomically repopulates the
+    // Keychain before the account is considered synchronized.
+    guard let storedAuth = accountAuthData(account)
+      ?? (try? Data(contentsOf: accountCodexAuthURL(account))) else {
       throw NSError(domain: "chatgpt-auto-confirm", code: 705, userInfo: [NSLocalizedDescriptionKey: "账号没有可恢复的 Codex 凭据，请重新登录。"])
     }
     try accountCreateDirectories(account)

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/dispatch-actions-runner.sh
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/dispatch-actions-runner.sh
@@ -45,8 +45,8 @@ if [ -n "$ACCOUNT_ID" ]; then
   # remain environment-scoped so one account can never overwrite another.
   "$GH_CLI" api --method PUT \
     "/repos/$REPOSITORY/environments/$ENVIRONMENT" \
-    -f 'wait_timer=0' \
-    -f 'deployment_branch_policy={"protected_branches":false,"custom_branch_policies":true}' >/dev/null
+    -F 'wait_timer=0' \
+    -F 'deployment_branch_policy={"protected_branches":false,"custom_branch_policies":true}' >/dev/null
   "$GH_CLI" api --method POST \
     "/repos/$REPOSITORY/environments/$ENVIRONMENT/deployment-branch-policies" \
     -f name=main >/dev/null 2>&1 || true

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/dispatch-actions-runner.sh
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/dispatch-actions-runner.sh
@@ -43,10 +43,10 @@ if [ -n "$ACCOUNT_ID" ]; then
   ENVIRONMENT="chatgpt-auto-confirm-$ACCOUNT_ID"
   # The environment is created with a main-only deployment policy.  Secrets
   # remain environment-scoped so one account can never overwrite another.
-  "$GH_CLI" api --method PUT \
-    "/repos/$REPOSITORY/environments/$ENVIRONMENT" \
-    -F 'wait_timer=0' \
-    -F 'deployment_branch_policy={"protected_branches":false,"custom_branch_policies":true}' >/dev/null
+  printf '%s\n' '{"wait_timer":0,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}' |
+    "$GH_CLI" api --method PUT \
+      "/repos/$REPOSITORY/environments/$ENVIRONMENT" \
+      --input - >/dev/null
   "$GH_CLI" api --method POST \
     "/repos/$REPOSITORY/environments/$ENVIRONMENT/deployment-branch-policies" \
     -f name=main >/dev/null 2>&1 || true

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/export-live-chatgpt-session.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/export-live-chatgpt-session.mjs
@@ -104,40 +104,53 @@ const exportSession = async () => {
   }
   await codexIdentifiers(resolve(authPath));
   const targets = await listTargets();
-  const target = targets.find(item => item.type === 'page'
+  const candidates = targets.filter(item => item.type === 'page'
     && item.webSocketDebuggerUrl
     && String(item.url || '').startsWith('app://-/index.html')
     && !String(item.url || '').includes('/avatar-overlay'));
-  if (!target) throw new ExportError('No live ChatGPT desktop app renderer is exposed over CDP');
+  if (!candidates.length) throw new ExportError('No live ChatGPT desktop app renderer is exposed over CDP');
 
-  const { socket, call } = await connect(target.webSocketDebuggerUrl);
-  try {
-    const evaluation = await call('Runtime.evaluate', {
-      expression: `(() => {
-        const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
-        const bodyText = normalize(document.body?.innerText).slice(0, 12000);
-        const controls = [...document.querySelectorAll('button,[role="button"],[role="tab"],[aria-label]')];
-        const labels = controls.map(element => normalize([
-          element.innerText, element.textContent, element.getAttribute('aria-label'),
-          element.getAttribute('title')
-        ].filter(Boolean).join(' ')));
-        const exact = label => labels.some(value => value.toLowerCase() === label);
-        const hasChat = exact('chat') || exact('聊天');
-        const hasWork = exact('work') || exact('工作');
-        const currentMode = labels.find(value => /current mode|当前模式|目前模式/i.test(value)) || '';
-        const asksForLogin = /(^|\\n)(log in|sign up|登录|登入|註冊|注册)(\\n|$)/i.test(bodyText);
-        const workComposer = !!document.querySelector('[data-codex-composer="true"]');
-        const authenticated = location.protocol === 'app:' && !!window.electronBridge
-          && !asksForLogin && document.readyState === 'complete' && bodyText.length > 50
-          && !!(currentMode || workComposer || hasChat || hasWork);
-        return {authenticated};
-      })()`,
-      returnByValue: true,
-    });
-    const session = evaluation.result?.value || {};
-    if (!session.authenticated) {
-      throw new ExportError('ChatGPT desktop app renderer is not authenticated');
+  const authenticationExpression = `(() => {
+    const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+    const bodyText = normalize(document.body?.innerText).slice(0, 12000);
+    const controls = [...document.querySelectorAll('button,[role="button"],[role="tab"],[aria-label]')];
+    const labels = controls.map(element => normalize([
+      element.innerText, element.textContent, element.getAttribute('aria-label'),
+      element.getAttribute('title')
+    ].filter(Boolean).join(' ')));
+    const exact = label => labels.some(value => value.toLowerCase() === label);
+    const hasChat = exact('chat') || exact('聊天');
+    const hasWork = exact('work') || exact('工作');
+    const currentMode = labels.find(value => /current mode|当前模式|目前模式/i.test(value)) || '';
+    const asksForLogin = /(^|\\n)(log in|sign up|登录|登入|註冊|注册)(\\n|$)/i.test(bodyText);
+    const workComposer = !!document.querySelector('[data-codex-composer="true"]');
+    const authenticated = location.protocol === 'app:' && !!window.electronBridge
+      && !asksForLogin && document.readyState === 'complete' && bodyText.length > 50
+      && !!(currentMode || workComposer || hasChat || hasWork);
+    return {authenticated};
+  })()`;
+  let selectedConnection;
+  for (const candidate of candidates) {
+    let connection;
+    try {
+      connection = await connect(candidate.webSocketDebuggerUrl);
+      const evaluation = await connection.call('Runtime.evaluate', {
+        expression: authenticationExpression,
+        returnByValue: true,
+      });
+      if (evaluation.result?.value?.authenticated === true) {
+        selectedConnection = connection;
+        break;
+      }
+    } catch {
+      // Try the next renderer: ChatGPT may expose an overlay or a stale page
+      // before its authenticated primary page finishes mounting.
     }
+    connection?.socket.close();
+  }
+  if (!selectedConnection) throw new ExportError('ChatGPT desktop app renderer is not authenticated');
+  const { socket, call } = selectedConnection;
+  try {
     await call('Network.enable');
     const cookieResult = await call('Network.getAllCookies');
     const cookies = normalizeCookies(Array.isArray(cookieResult.cookies) ? cookieResult.cookies : []);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/worker/src/content.generated.ts
@@ -4,7 +4,7 @@ export const HOME = {
   "app": {
     "id": "chatgpt-auto-confirm",
     "title": "ChatGPT 自动确认",
-    "version": "1.0.0+codex.20260802193301"
+    "version": "1.0.0+codex.20260802195408"
   },
   "welcome": {
     "id": "welcome",

--- a/frontend/apps/web/public/.well-known/mahayana/marketplace.json
+++ b/frontend/apps/web/public/.well-known/mahayana/marketplace.json
@@ -58,7 +58,7 @@
     },
     {
       "id": "chatgpt-auto-confirm",
-      "version": "1.0.0+codex.20260802193301",
+      "version": "1.0.0+codex.20260802195408",
       "title": "ChatGPT 自动确认",
       "description": "自动确认、任务续作、队列并发和独立验收",
       "homepage": "https://fabushi.ombhrum.com/miniapps/chatgpt-auto-confirm/",


### PR DESCRIPTION
完成多账号凭据注册、账号级 Environment 上传与 Action 绑定；账号注册改为验证已登录 renderer 的 auth.json + Cookie，不再启动第二个 smoke ChatGPT；修复 GitHub Environment JSON 参数和 hosted renderer 选择。

已通过分支上的 runtime validation；合并后需从 main 重新运行账号 smoke。