### PR TITLE
fix(plugins): validate complete WeChat archives accurately

### DIFF
--- a/.github/workflows/wechat-article-downloader.yml
+++ b/.github/workflows/wechat-article-downloader.yml
@@ -159,9 +159,17 @@ jobs:
             actual="$(find artifacts/wechat-archive/articles -mindepth 2 -maxdepth 2 -name "$file" | wc -l | tr -d ' ')"
             test "$actual" = "$expected"
           done
-          test "$(find artifacts/wechat-archive/articles -name content.txt -size +100c | wc -l | tr -d ' ')" = "$expected"
-          if grep -RIEq 'https?://[^" ]*(mmbiz|qpic|qlogo)\.(cn|com)'             artifacts/wechat-archive/articles/*/index.html             artifacts/wechat-archive/articles/*/content.html; then
-            echo 'remote WeChat image reference remains in offline article files' >&2
+          nonempty_text="$(find artifacts/wechat-archive/articles -name content.txt -size +0c | wc -l | tr -d ' ')"
+          if [ "$nonempty_text" != "$expected" ]; then
+            echo "non-empty content.txt count mismatch: actual=$nonempty_text expected=$expected" >&2
+            find artifacts/wechat-archive/articles -name content.txt -size 0 -print >&2
+            exit 1
+          fi
+          if grep -RInE 'https?://[^" ]*(mmbiz|qpic|qlogo)\.(cn|com)' \
+            artifacts/wechat-archive/articles/*/index.html \
+            artifacts/wechat-archive/articles/*/content.html > artifacts/remote-media-references.txt; then
+            echo 'remote WeChat media reference remains in offline article files:' >&2
+            cat artifacts/remote-media-references.txt >&2
             exit 1
           fi
           jq '{account,stats,albumCount:(.albums|length),warnings,failures}' "$manifest" | tee artifacts/archive-summary.json
@@ -185,6 +193,7 @@ jobs:
             inspect.json
             artifacts/download-result.json
             artifacts/archive-summary.json
+            artifacts/remote-media-references.txt
             artifacts/wechat-archive/manifest.json
             artifacts/wechat-archive/index.html
             artifacts/wechat-archive.tar.gz

--- a/third_party/mahayana/mahayana-rs/providers/official-miniapps/src/wechat_downloader.rs
+++ b/third_party/mahayana/mahayana-rs/providers/official-miniapps/src/wechat_downloader.rs
@@ -1414,7 +1414,7 @@ fn download_image(
 
 fn extract_image_urls(html: &str) -> Vec<String> {
     let attribute_regex = match Regex::new(
-        r#"(?is)(?:src|data-src|data-original|data-croporisrc|poster)\s*=\s*["']([^"']+)["']"#,
+        r#"(?is)(?:src|data-src|data-original|data-croporisrc|data-headimg|poster)\s*=\s*["']([^"']+)["']"#,
     ) {
         Ok(regex) => regex,
         Err(_) => return Vec::new(),
@@ -1851,9 +1851,13 @@ mod tests {
 
     #[test]
     fn extracts_and_localizes_all_wechat_image_attributes() {
-        let source = r#"<img src="https://mmbiz.qpic.cn/a.jpg?x=1&amp;y=2" data-croporisrc="//mmbiz.qpic.cn/original.png"><div style="background:url('https://mmbiz.qpic.cn/bg.webp')"></div>"#;
+        let source = r#"<img src="https://mmbiz.qpic.cn/a.jpg?x=1&amp;y=2" data-croporisrc="//mmbiz.qpic.cn/original.png"><mpprofile data-headimg="http://mmbiz.qpic.cn/avatar.png"></mpprofile><div style="background:url('https://mmbiz.qpic.cn/bg.webp')"></div>"#;
         let urls = extract_image_urls(source);
-        assert_eq!(urls.len(), 3);
+        assert_eq!(urls.len(), 4);
+        assert!(
+            urls.iter()
+                .any(|url| url == "http://mmbiz.qpic.cn/avatar.png")
+        );
         let localized = localize_media_reference(
             source,
             "https://mmbiz.qpic.cn/a.jpg?x=1&y=2",
@@ -1861,6 +1865,12 @@ mod tests {
         );
         assert!(localized.contains("src=\"images/a.jpg\""));
         assert!(!localized.contains("a.jpg?x=1"));
+        let profile_localized = localize_media_reference(
+            source,
+            "http://mmbiz.qpic.cn/avatar.png",
+            "images/profile-avatar.png",
+        );
+        assert!(profile_localized.contains("data-headimg=\"images/profile-avatar.png\""));
     }
 
     #[test]


### PR DESCRIPTION
## Root cause
The full main-branch archive run successfully downloaded 458 articles and 3,181/3,181 media files, but the final verification step failed for two reasons:

1. three legitimate resource-download posts have short non-empty text bodies (33, 66, and 78 bytes), while CI incorrectly required every `content.txt` to exceed 100 bytes;
2. an embedded WeChat profile card used `data-headimg`, which was not included in media extraction, leaving one remote avatar URL in `index.html` and `content.html`.

## Fix
- treat any non-empty `content.txt` as a valid local body and print explicit diagnostics for empty files;
- recognize, download, and localize `data-headimg` media;
- retain a remote-media diagnostic file when validation fails;
- add unit coverage for profile-card avatar extraction and path rewriting.

## Validation
- Rust downloader tests: 11/11 passed;
- focused `data-headimg` localization test passed;
- official marketplace contract passed;
- actionlint passed;
- replayed the failed run validation against the completed 458-article archive and confirmed the old failure conditions exactly.