### PR TITLE
fix(chatgpt-auto-confirm): isolate parallel smoke bootstrap

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -131,9 +131,10 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /parallel-queue-evidence\.json/);
   assert.match(actionsWorkflow, /task-queue\/watcher-trace\.log/);
   assert.doesNotMatch(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_TASK_INBOX_B64/);
-  assert.match(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE/);
+  assert.doesNotMatch(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE/);
+  assert.match(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_TASK_CONTROL_PATH/);
   assert.match(actionsWorkflow, /tasks\/actions-inbox\.json/);
-  assert.match(actionsWorkflow, /import-actions-task-inbox\.mjs/);
+  assert.doesNotMatch(actionsWorkflow, /import-actions-task-inbox\.mjs/);
   assert.match(actionsWorkflow, /status" != "incomplete"/);
   assert.match(actionsWorkflow, /VERIFICATION_ONLY/);
   assert.match(actionsWorkflow, /no continuation was dispatched/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
@@ -21,8 +21,10 @@ test('persistent Actions runner polls the main-branch task control file', () => 
   assert.match(workflow, /CHATGPT_AUTO_CONFIRM_TASK_CONTROL_POLL_SECONDS: "30"/);
   assert.match(
     workflow,
-    /Import dynamic parallel task inbox\r?\n\s+if: \$\{\{ inputs\.cancel_task_id == '' && inputs\.parallel_queue_smoke \}\}/,
+    /inputs\.parallel_queue_smoke && format\('chatgpt-auto-confirm-parallel-smoke-\{0\}-\{1\}'/,
   );
+  assert.doesNotMatch(workflow, /Import dynamic parallel task inbox/);
+  assert.match(workflow, /Verify dynamic parallel task queue/);
   assert.match(controller, /spawnSync\('gh'/);
   assert.match(controller, /repos\/\$\{repository\}\/contents\/\$\{repositoryPath\}/);
   assert.match(controller, /fetchRepositoryContent\(controlPath\)/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -39,7 +39,7 @@ concurrency:
   # Parallel smoke creates its own ephemeral queue state, so it can validate
   # the hosted Chat surface without waiting behind the persistent runner.
   # Persistent runners keep the shared-state serialization guard.
-  group: ${{ inputs.account_id != '' && format('chatgpt-auto-confirm-account-{0}', inputs.account_id) || (inputs.parallel_queue_smoke && format('chatgpt-auto-confirm-parallel-smoke-{0}', github.ref) || 'chatgpt-auto-confirm-fix-test-runner') }}
+  group: ${{ inputs.parallel_queue_smoke && format('chatgpt-auto-confirm-parallel-smoke-{0}-{1}', github.ref, inputs.account_id) || (inputs.account_id != '' && format('chatgpt-auto-confirm-account-{0}', inputs.account_id) || 'chatgpt-auto-confirm-fix-test-runner') }}
   cancel-in-progress: false
 
 jobs:
@@ -187,13 +187,6 @@ jobs:
           CHATGPT_AUTO_CONFIRM_CANCEL_TASK_ID: ${{ inputs.cancel_task_id }}
           ACTION_RESULT_PATH: ${{ steps.paths.outputs.runtime_dir }}/action-result.json
         run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/cancel-persisted-task.mjs
-
-      - name: Import dynamic parallel task inbox
-        if: ${{ inputs.cancel_task_id == '' && inputs.parallel_queue_smoke }}
-        env:
-          CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
-          CHATGPT_AUTO_CONFIRM_TASK_INBOX_FILE: ${{ github.workspace }}/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
-        run: node .agents/plugins/plugins/chatgpt-auto-confirm/scripts/import-actions-task-inbox.mjs
 
       - name: Restore ChatGPT login credentials
         if: ${{ inputs.cancel_task_id == '' }}


### PR DESCRIPTION
## Failure found by hosted verification

The parallel smoke failed before ChatGPT launched because it imported the full production task inbox. One task specification snapshot now exceeds 60,000 characters, but the smoke script already creates its own two synthetic tasks and never needed the production inbox.

## Fix

- Remove the unnecessary production inbox import from `parallel_queue_smoke`.
- Put parallel smoke in its own concurrency group even when `account_id` is provided, so it can validate alongside the persistent account runner.
- Update workflow contract tests.

## Verification

- `npm test`: 54 passed, 0 failed.
- `git diff --check`: passed.