### PR TITLE
fix(actions): preserve active authorization chats

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -932,6 +932,52 @@ func watchdogAnchorDate(_ task: AutomationTask) -> Date? {
   .max()
 }
 
+// The watchdog runs in a separate process from the queue renderer. Keep the
+// last renderer reply in durable task state so a restart cannot mistake an
+// authorization card or an in-flight response for a dead renderer.
+func watchdogReply(_ task: AutomationTask) -> [String: Any]? {
+  guard let rawResult = task.lastResultJSON,
+        let data = rawResult.data(using: .utf8),
+        let result = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+    return nil
+  }
+  return (result["reply"] as? [String: Any])
+    ?? (result["reviewReply"] as? [String: Any])
+}
+
+func watchdogActiveResponseFlags(_ task: AutomationTask) -> [String] {
+  guard let reply = watchdogReply(task) else { return [] }
+  return [
+    "waitingForApproval",
+    "pending",
+    "streaming",
+    "stopAvailable",
+    "devspaceWaiting",
+  ].filter { reply[$0] as? Bool == true }
+}
+
+func watchdogRunningTaskProtection(
+  _ task: AutomationTask,
+  now: Date,
+  staleAfterSeconds: Int
+) -> String? {
+  guard task.status == "running" else { return nil }
+  let activeFlags = watchdogActiveResponseFlags(task)
+  if !activeFlags.isEmpty {
+    return "active_response:\(activeFlags.joined(separator: ","))"
+  }
+  // A force recovery may repair a genuinely stale worker, but never during
+  // the handoff immediately after send. The watcher may not have persisted its
+  // first reply yet, and restarting here strands the authorization card and
+  // creates a duplicate Chat.
+  guard let anchor = watchdogAnchorDate(task) else { return nil }
+  let age = now.timeIntervalSince(anchor)
+  guard age >= Double(staleAfterSeconds) else {
+    return "startup_grace:\(Int(max(0, age)))s<\(staleAfterSeconds)s"
+  }
+  return nil
+}
+
 func watchdogTaskIsEligible(
   _ task: AutomationTask,
   now: Date,
@@ -940,6 +986,16 @@ func watchdogTaskIsEligible(
 ) -> Bool {
   guard watchdogRecoverableStatuses.contains(task.status) else { return false }
   guard !watchdogTaskHasNonRecoverableFailure(task) else { return false }
+  // Never detach a running Chat while it is waiting for authorization or still
+  // responding. `force` is reserved for stale renderer recovery and must not
+  // override this protection.
+  if watchdogRunningTaskProtection(
+    task,
+    now: now,
+    staleAfterSeconds: staleAfterSeconds
+  ) != nil {
+    return false
+  }
   if force { return true }
   if task.status == "waiting",
      let waitingUntil = task.waitingUntil.flatMap(isoFormatter.date(from:)),
@@ -959,6 +1015,17 @@ func recoverQueueWithWatchdog(
   let nowDate = Date()
   let now = isoFormatter.string(from: nowDate)
   var tasks = state.automationTasks ?? []
+  let deferredTaskIds = tasks.indices.compactMap { index -> String? in
+    guard let reason = watchdogRunningTaskProtection(
+      tasks[index],
+      now: nowDate,
+      staleAfterSeconds: staleAfterSeconds
+    ) else { return nil }
+    queueTrace(
+      "task=\(tasks[index].id) stage=watchdog-deferred reason=\(reason)"
+    )
+    return tasks[index].id
+  }
   let eligibleIndexes = tasks.indices.filter {
     watchdogTaskIsEligible(
       tasks[$0],
@@ -975,6 +1042,7 @@ func recoverQueueWithWatchdog(
       "dryRun": dryRun,
       "staleAfterSeconds": staleAfterSeconds,
       "eligibleTaskIds": eligibleIds,
+      "deferredTaskIds": deferredTaskIds,
       "queue": queueStatusPayload(state),
     ]
   }
@@ -986,6 +1054,7 @@ func recoverQueueWithWatchdog(
       "dryRun": true,
       "staleAfterSeconds": staleAfterSeconds,
       "eligibleTaskIds": eligibleIds,
+      "deferredTaskIds": deferredTaskIds,
       "queue": queueStatusPayload(state),
     ]
   }
@@ -1071,6 +1140,7 @@ func recoverQueueWithWatchdog(
     "dryRun": false,
     "staleAfterSeconds": staleAfterSeconds,
     "eligibleTaskIds": eligibleIds,
+    "deferredTaskIds": deferredTaskIds,
     "watcherPid": state.queueWatcherPid as Any,
     "queue": queueStatusPayload(state),
   ]

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-actions-controller.mjs
@@ -269,12 +269,24 @@ const watchdogDiagnostics = result => ({
   ok: result?.ok !== false,
   recovered: result?.recovered === true,
   eligibleTaskIds: result?.eligibleTaskIds || [],
+  deferredTaskIds: result?.deferredTaskIds || [],
   watcherPid: result?.watcherPid || null,
   queue: {
     counts: result?.queue?.counts || {},
     tasks: taskDiagnostics(result?.queue),
   },
 });
+
+const taskHasActiveChatResponse = task => {
+  const diagnostics = task?.replyDiagnostics || {};
+  return [
+    'waitingForApproval',
+    'pending',
+    'streaming',
+    'stopAvailable',
+    'devspaceWaiting',
+  ].some(field => diagnostics[field] === true);
+};
 
 const initialRecovery = run('queue_watchdog', { staleAfterSeconds: 300, force: true });
 process.stdout.write(`WATCHDOG_INITIAL ${JSON.stringify(watchdogDiagnostics(initialRecovery))}\n`);
@@ -340,7 +352,11 @@ while (Date.now() < deadline) {
   const needsWatchdogRecovery = tasks.some(task =>
     task.status === 'running'
     && task.lastError
-    && String(task.lastError).includes('not_chat_surface'));
+    && String(task.lastError).includes('not_chat_surface')
+    // A renderer can report `not_chat_surface` while the same Chat is already
+    // streaming or waiting for a permission card. Keep polling that Chat so
+    // its response/authorization can finish instead of opening a duplicate.
+    && !taskHasActiveChatResponse(task));
   const needsRecovery = needsWatchdogRecovery;
   if (needsRecovery && Date.now() - lastRecovery >= recoveryIntervalMs) {
     const currentFailureFingerprint = failureFingerprint(tasks);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/actions-controller.test.mjs
@@ -194,6 +194,69 @@ if (command === 'queue_watchdog') {
   }
 });
 
+test('Actions controller preserves a pending authorization Chat instead of watchdog-restarting it', () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'chatgpt-actions-approval-'));
+  const runtimePath = path.join(directory, 'fake-runtime.mjs');
+  const resultPath = path.join(directory, 'action-result.json');
+  const callsPath = path.join(directory, 'watchdog-calls.log');
+  try {
+    writeFileSync(runtimePath, `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+const command = process.argv[2];
+if (command === 'queue_watchdog') {
+  appendFileSync(process.env.CALLS_PATH, (process.argv[3] || '{}') + '\\n');
+  console.log(JSON.stringify({ ok: true, recovered: false, deferredTaskIds: ['approval-task'] }));
+} else if (command === 'queue_status') {
+  console.log(JSON.stringify({
+    ok: true,
+    counts: { running: 1 },
+    tasks: [{
+      id: 'approval-task',
+      status: 'running',
+      attempts: 1,
+      lastError: 'not_chat_surface',
+      hiddenWorkerLastError: null,
+      replyDiagnostics: {
+        pending: true,
+        waitingForApproval: true,
+        streaming: false,
+        stopAvailable: false,
+        devspaceWaiting: false,
+      },
+    }],
+  }));
+} else {
+  console.log(JSON.stringify({ ok: false, message: 'unexpected command' }));
+  process.exitCode = 1;
+}
+`);
+    chmodSync(runtimePath, 0o755);
+    const result = spawnSync(process.execPath, [controller], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        CHATGPT_AUTO_CONFIRM_NATIVE: runtimePath,
+        ACTION_RESULT_PATH: resultPath,
+        ACTION_SESSION_SECONDS: '1',
+        ACTION_POLL_INTERVAL_MS: '10',
+        ACTION_RECOVERY_INTERVAL_MS: '10',
+        CALLS_PATH: callsPath,
+      },
+    });
+    assert.equal(result.status, 0);
+    assert.doesNotMatch(result.stdout, /WATCHDOG_RECOVERY/);
+    const report = JSON.parse(readFileSync(resultPath, 'utf8'));
+    assert.equal(report.status, 'incomplete');
+    assert.equal(report.reason, 'hosted_runner_session_deadline');
+    const watchdogCalls = readFileSync(callsPath, 'utf8').trim().split('\n').filter(Boolean);
+    assert.equal(watchdogCalls.length, 2);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('Actions controller refreshes task revisions from the active branch', () => {
   const source = readFileSync(controller, 'utf8');
   assert.match(source, /ACTION_TASK_REFRESH_INTERVAL_MS/);


### PR DESCRIPTION
## Root cause\nThe Actions watchdog force-recovered a running task while its Chat was still pending or waiting for authorization, leaving the original Chat at the permission card and opening duplicate continuation Chats.\n\n## Fix\n- Protect running tasks with pending, streaming, stop, devspace, or authorization state from watchdog recovery.\n- Add a startup grace window even when recovery is forced.\n- Keep the JS controller from triggering recovery for active response diagnostics.\n- Add a regression test for a pending authorization Chat.\n\nValidation runs on GitHub Actions.