### PR TITLE
fix(actions): avoid interrupting renderer loading

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1140,6 +1140,9 @@ func dedicatedQueueChatTarget(
   let deadline = startedAt.addingTimeInterval(timeout)
   var attempt = 0
   var navigatedBlankTargets = Set<String>()
+  var bootstrapRecoveryCounts: [String: Int] = [:]
+  var lastProbeDiagnosticAttempt = -8
+  var lastProbe: [String: Any]?
   let appRootURL = "app://-/index.html?initialRoute=%2F"
   let allowVisibleRenderer = queueAllowsVisibleDedicatedRenderer()
   while Date() < deadline {
@@ -1181,10 +1184,43 @@ func dedicatedQueueChatTarget(
         """,
         timeout: 3.0
       )
+      lastProbe = loaded
       let bridge = (loaded?["bridge"] as? NSNumber)?.boolValue ?? false
       let ready = loaded?["ready"] as? String
       let textLength = (loaded?["text"] as? NSNumber)?.intValue ?? 0
       let visibility = loaded?["visibility"] as? String
+      guard bridge, ready == "complete" else {
+        // A renderer can expose the correct app URL while its preload bridge
+        // is still suspended. Wake the page without changing the user's
+        // visible/hidden policy, then navigate once so a stale document and
+        // its old CDP websocket are replaced by a fresh renderer.
+        let recoveryCount = bootstrapRecoveryCounts[targetId, default: 0]
+        if attempt % 8 == 0, recoveryCount < 3 {
+          bootstrapRecoveryCounts[targetId] = recoveryCount + 1
+          _ = CDPClient.setWebLifecycleActive(wsURLString: wsURL)
+          _ = CDPClient.setHiddenPageFocusEmulation(wsURLString: wsURL)
+          _ = CDPClient.setHiddenPageUserActive(wsURLString: wsURL)
+          queueTrace(
+            "worker-create stage=dedicated-renderer-bootstrap-recovery "
+              + "port=\(port) target=\(targetId) attempt=\(recoveryCount + 1) "
+              + "bridge=\(bridge) ready=\(ready ?? \"none\")"
+          )
+          _ = CDPClient.navigate(
+            wsURLString: wsURL,
+            url: appRootURL
+          )
+        }
+        if attempt - lastProbeDiagnosticAttempt >= 8 {
+          lastProbeDiagnosticAttempt = attempt
+          queueTrace(
+            "worker-create stage=dedicated-renderer-probe "
+              + "port=\(port) target=\(targetId) bridge=\(bridge) "
+              + "ready=\(ready ?? \"none\") text=\(textLength) "
+              + "visibility=\(visibility ?? \"none\")"
+          )
+        }
+        continue
+      }
       if bridge, ready == "complete", textLength <= 100,
          navigatedBlankTargets.insert(targetId).inserted {
         // A dedicated copy may finish on the root URL with an empty shell
@@ -1230,7 +1266,11 @@ func dedicatedQueueChatTarget(
   queueTrace(
     "worker-create stage=dedicated-chat-target-timeout port=\(port) "
       + "elapsedMs=\(elapsedMs) "
-      + "targets=\(dedicatedRendererTargetSummary(port: port))"
+      + "targets=\(dedicatedRendererTargetSummary(port: port)) "
+      + "probeBridge=\((lastProbe?[\"bridge\"] as? NSNumber)?.boolValue ?? false) "
+      + "probeReady=\(lastProbe?[\"ready\"] as? String ?? \"none\") "
+      + "probeText=\((lastProbe?[\"text\"] as? NSNumber)?.intValue ?? -1) "
+      + "probeVisibility=\(lastProbe?[\"visibility\"] as? String ?? \"none\")"
   )
   return nil
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1202,15 +1202,24 @@ func dedicatedQueueChatTarget(
           _ = CDPClient.setWebLifecycleActive(wsURLString: wsURL)
           _ = CDPClient.setHiddenPageFocusEmulation(wsURLString: wsURL)
           _ = CDPClient.setHiddenPageUserActive(wsURLString: wsURL)
+          // Do not replace a document that is still naturally loading. The
+          // first renderer can take several seconds to attach its preload
+          // bridge; navigating during that interval closes the only target
+          // and leaves the dedicated process with no renderer at all.
+          let shouldNavigate = (loaded != nil && ready == "complete")
+            || recoveryCount >= 2
           queueTrace(
             "worker-create stage=dedicated-renderer-bootstrap-recovery "
               + "port=\(port) target=\(targetId) attempt=\(recoveryCount + 1) "
-              + "bridge=\(bridge) ready=\(readyValue)"
+              + "bridge=\(bridge) ready=\(readyValue) "
+              + "navigate=\(shouldNavigate)"
           )
-          _ = CDPClient.navigate(
-            wsURLString: wsURL,
-            url: appRootURL
-          )
+          if shouldNavigate {
+            _ = CDPClient.navigate(
+              wsURLString: wsURL,
+              url: appRootURL
+            )
+          }
         }
         if attempt - lastProbeDiagnosticAttempt >= 8 {
           lastProbeDiagnosticAttempt = attempt

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1189,6 +1189,8 @@ func dedicatedQueueChatTarget(
       let ready = loaded?["ready"] as? String
       let textLength = (loaded?["text"] as? NSNumber)?.intValue ?? 0
       let visibility = loaded?["visibility"] as? String
+      let readyValue = ready ?? "none"
+      let visibilityValue = visibility ?? "none"
       guard bridge, ready == "complete" else {
         // A renderer can expose the correct app URL while its preload bridge
         // is still suspended. Wake the page without changing the user's
@@ -1203,7 +1205,7 @@ func dedicatedQueueChatTarget(
           queueTrace(
             "worker-create stage=dedicated-renderer-bootstrap-recovery "
               + "port=\(port) target=\(targetId) attempt=\(recoveryCount + 1) "
-              + "bridge=\(bridge) ready=\(ready ?? \"none\")"
+              + "bridge=\(bridge) ready=\(readyValue)"
           )
           _ = CDPClient.navigate(
             wsURLString: wsURL,
@@ -1215,8 +1217,8 @@ func dedicatedQueueChatTarget(
           queueTrace(
             "worker-create stage=dedicated-renderer-probe "
               + "port=\(port) target=\(targetId) bridge=\(bridge) "
-              + "ready=\(ready ?? \"none\") text=\(textLength) "
-              + "visibility=\(visibility ?? \"none\")"
+              + "ready=\(readyValue) text=\(textLength) "
+              + "visibility=\(visibilityValue)"
           )
         }
         continue
@@ -1263,14 +1265,18 @@ func dedicatedQueueChatTarget(
     Thread.sleep(forTimeInterval: 0.25)
   }
   let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
+  let probeBridge = (lastProbe?["bridge"] as? NSNumber)?.boolValue ?? false
+  let probeReady = lastProbe?["ready"] as? String ?? "none"
+  let probeText = (lastProbe?["text"] as? NSNumber)?.intValue ?? -1
+  let probeVisibility = lastProbe?["visibility"] as? String ?? "none"
   queueTrace(
     "worker-create stage=dedicated-chat-target-timeout port=\(port) "
       + "elapsedMs=\(elapsedMs) "
       + "targets=\(dedicatedRendererTargetSummary(port: port)) "
-      + "probeBridge=\((lastProbe?[\"bridge\"] as? NSNumber)?.boolValue ?? false) "
-      + "probeReady=\(lastProbe?[\"ready\"] as? String ?? \"none\") "
-      + "probeText=\((lastProbe?[\"text\"] as? NSNumber)?.intValue ?? -1) "
-      + "probeVisibility=\(lastProbe?[\"visibility\"] as? String ?? \"none\")"
+      + "probeBridge=\(probeBridge) "
+      + "probeReady=\(probeReady) "
+      + "probeText=\(probeText) "
+      + "probeVisibility=\(probeVisibility)"
   )
   return nil
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -420,6 +420,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /dedicatedRendererTargetSummary/);
   assert.match(nativeSource, /dedicatedRendererBootstrapTimeout/);
   assert.match(nativeSource, /dedicated-process-renderer-timeout/);
+  assert.match(nativeSource, /dedicated-renderer-bootstrap-recovery/);
+  assert.match(nativeSource, /setHiddenPageFocusEmulation/);
+  assert.match(nativeSource, /probeBridge=/);
   assert.match(nativeSource, /single-process-hidden-chat-conversations/);
   assert.match(nativeSource, /single-process-hidden-chat-windows/);
   assert.match(nativeSource, /createDedicatedParallelQueueWorkerTarget/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -421,6 +421,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /dedicatedRendererBootstrapTimeout/);
   assert.match(nativeSource, /dedicated-process-renderer-timeout/);
   assert.match(nativeSource, /dedicated-renderer-bootstrap-recovery/);
+  assert.match(nativeSource, /Do not replace a document that is still naturally loading/);
   assert.match(nativeSource, /setHiddenPageFocusEmulation/);
   assert.match(nativeSource, /probeBridge=/);
   assert.match(nativeSource, /single-process-hidden-chat-conversations/);


### PR DESCRIPTION
## Summary
- let a renderer with `ready=loading` finish its natural bootstrap before navigating
- only replace the document after repeated stalled probes
- keep the active/focus wake-up and redacted diagnostics for genuinely stuck pages

## Validation
- GitHub Actions runtime validation passed on the latest commit
- hosted parallel smoke will be rerun after merge
