### PR TITLE
fix(actions): avoid interrupting renderer loading

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1202,15 +1202,24 @@ func dedicatedQueueChatTarget(
           _ = CDPClient.setWebLifecycleActive(wsURLString: wsURL)
           _ = CDPClient.setHiddenPageFocusEmulation(wsURLString: wsURL)
           _ = CDPClient.setHiddenPageUserActive(wsURLString: wsURL)
+          // Do not replace a document that is still naturally loading. The
+          // first renderer can take several seconds to attach its preload
+          // bridge; navigating during that interval closes the only target
+          // and leaves the dedicated process with no renderer at all.
+          let shouldNavigate = (loaded != nil && ready == "complete")
+            || recoveryCount >= 2
           queueTrace(
             "worker-create stage=dedicated-renderer-bootstrap-recovery "
               + "port=\(port) target=\(targetId) attempt=\(recoveryCount + 1) "
-              + "bridge=\(bridge) ready=\(readyValue)"
+              + "bridge=\(bridge) ready=\(readyValue) "
+              + "navigate=\(shouldNavigate)"
           )
-          _ = CDPClient.navigate(
-            wsURLString: wsURL,
-            url: appRootURL
-          )
+          if shouldNavigate {
+            _ = CDPClient.navigate(
+              wsURLString: wsURL,
+              url: appRootURL
+            )
+          }
         }
         if attempt - lastProbeDiagnosticAttempt >= 8 {
           lastProbeDiagnosticAttempt = attempt

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -421,6 +421,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /dedicatedRendererBootstrapTimeout/);
   assert.match(nativeSource, /dedicated-process-renderer-timeout/);
   assert.match(nativeSource, /dedicated-renderer-bootstrap-recovery/);
+  assert.match(nativeSource, /Do not replace a document that is still naturally loading/);
   assert.match(nativeSource, /setHiddenPageFocusEmulation/);
   assert.match(nativeSource, /probeBridge=/);
   assert.match(nativeSource, /single-process-hidden-chat-conversations/);


### PR DESCRIPTION
## Summary
- let a renderer with `ready=loading` finish its natural bootstrap before navigating
- only replace the document after repeated stalled probes
- keep the active/focus wake-up and redacted diagnostics for genuinely stuck pages

## Validation
- GitHub Actions runtime validation passed on the equivalent commit
- hosted parallel smoke will be rerun after merge
