### PR TITLE
fix(actions): wait for natural renderer bootstrap

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1211,8 +1211,7 @@ func dedicatedQueueChatTarget(
           // the only page in a dedicated process, so let the bounded startup
           // retry replace the process instead.  Only navigate a renderer
           // whose latest probe was actually received.
-          let shouldNavigate = loaded != nil
-            && ((ready == "complete") || recoveryCount >= 2)
+          let shouldNavigate = loaded != nil && ready == "complete"
           queueTrace(
             "worker-create stage=dedicated-renderer-bootstrap-recovery "
               + "port=\(port) target=\(targetId) attempt=\(recoveryCount + 1) "

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -425,6 +425,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /dedicated-process-bootstrap-attempt/);
   assert.match(nativeSource, /dedicated-process-bootstrap-retry/);
   assert.match(nativeSource, /let shouldNavigate = loaded != nil/);
+  assert.match(nativeSource, /let shouldNavigate = loaded != nil && ready == "complete"/);
   assert.match(nativeSource, /setHiddenPageFocusEmulation/);
   assert.match(nativeSource, /probeBridge=/);
   assert.match(nativeSource, /single-process-hidden-chat-conversations/);


### PR DESCRIPTION
## Summary
- never navigate a dedicated renderer while it is only interactive or its probe is stale
- keep the existing bounded fresh-process retry for an actually failed renderer
- retain fail-closed authentication and contract coverage

## Validation
- hosted macOS runtime validation
- rerun the real parallel queue smoke after merge