### PR TITLE
fix(actions): keep headless renderer active during bootstrap

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
@@ -281,6 +281,17 @@ struct CDPClient {
   }
 
   @discardableResult
+  static func bringPageToFront(wsURLString: String) -> Bool {
+    guard let response = sendCommand(
+      wsURLString: wsURLString,
+      method: "Page.bringToFront",
+      paramsJSON: "{}",
+      timeout: 4.0
+    ) else { return false }
+    return response["error"] == nil
+  }
+
+  @discardableResult
   static func setWebLifecycleActive(wsURLString: String) -> Bool {
     guard let response = sendCommand(
       wsURLString: wsURLString,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1211,6 +1211,13 @@ func dedicatedQueueChatTarget(
           // the only page in a dedicated process, so let the bounded startup
           // retry replace the process instead.  Only navigate a renderer
           // whose latest probe was actually received.
+          if allowVisibleRenderer {
+            // GitHub Actions has no user-facing desktop window to protect.
+            // Keep the dedicated renderer in the foreground so macOS does not
+            // silently transition its document to hidden and suspend the
+            // preload bridge while the app is still bootstrapping.
+            _ = CDPClient.bringPageToFront(wsURLString: wsURL)
+          }
           let shouldNavigate = loaded != nil && ready == "complete"
           queueTrace(
             "worker-create stage=dedicated-renderer-bootstrap-recovery "

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -427,6 +427,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /let shouldNavigate = loaded != nil/);
   assert.match(nativeSource, /let shouldNavigate = loaded != nil && ready == "complete"/);
   assert.match(nativeSource, /setHiddenPageFocusEmulation/);
+  assert.match(nativeSource, /bringPageToFront/);
   assert.match(nativeSource, /probeBridge=/);
   assert.match(nativeSource, /single-process-hidden-chat-conversations/);
   assert.match(nativeSource, /single-process-hidden-chat-windows/);


### PR DESCRIPTION
## Summary
- use CDP Page.bringToFront for hosted dedicated renderers while they bootstrap
- keep headless Actions workers visible/active instead of letting macOS suspend the preload bridge
- preserve the existing safe navigation and fail-closed authentication checks

## Validation
- hosted macOS runtime validation
- rerun the parallel queue smoke after merge