### PR TITLE
fix(actions): keep background runtime fail-closed

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1133,7 +1133,7 @@ func hideDedicatedProcessForPort(_ port: Int) -> Bool {
 }
 
 @discardableResult
-func activateDedicatedProcessForPort(_ port: Int) -> Bool {
+func unhideDedicatedProcessForPort(_ port: Int) -> Bool {
   let process = Process()
   let output = Pipe()
   process.executableURL = URL(fileURLWithPath: "/bin/ps")
@@ -1162,7 +1162,7 @@ func activateDedicatedProcessForPort(_ port: Int) -> Bool {
           let application = NSRunningApplication(processIdentifier: processID) else {
       continue
     }
-    return application.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+    return application.unhide()
   }
   return false
 }
@@ -1232,7 +1232,7 @@ func dedicatedQueueChatTarget(
          (loaded == nil || ready != "complete" || visibility != "visible" || textLength <= 100),
          attempt - lastVisibleWakeAttempt >= 4 {
         lastVisibleWakeAttempt = attempt
-        let processActivated = activateDedicatedProcessForPort(port)
+        let processUnhidden = unhideDedicatedProcessForPort(port)
         let targetActivated = CDPClient.activateTarget(targetId, portOverride: port)
         let pageBroughtToFront = CDPClient.bringPageToFront(wsURLString: wsURL)
         _ = CDPClient.setWebLifecycleActive(wsURLString: wsURL)
@@ -1241,7 +1241,7 @@ func dedicatedQueueChatTarget(
         queueTrace(
           "worker-create stage=dedicated-visible-renderer-wake "
             + "port=\(port) target=\(targetId) "
-            + "processActivated=\(processActivated) "
+            + "processUnhidden=\(processUnhidden) "
             + "targetActivated=\(targetActivated) "
             + "pageBroughtToFront=\(pageBroughtToFront)"
         )

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -450,7 +450,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /func queueAllowsVisibleDedicatedRenderer\(\)/);
   assert.match(nativeSource, /CHATGPT_AUTO_CONFIRM_HEADLESS/);
   assert.match(nativeSource, /dedicated-chat-target-visible-headless/);
-  assert.match(nativeSource, /activateDedicatedProcessForPort/);
+  assert.match(nativeSource, /unhideDedicatedProcessForPort/);
   assert.match(nativeSource, /Target\.activateTarget/);
   assert.match(nativeSource, /dedicated-visible-renderer-wake/);
   assert.match(nativeSource, /blankNavigationCount < 3/);


### PR DESCRIPTION
## What changed
- replace the headless-only process activation call with a non-foreground unhide operation
- retain CDP target activation, page wake, and bounded empty-shell remounts
- preserve the desktop invariant that background automation never takes over the UI

## Validation
The hosted runtime build previously caught the foreground activation regression. This branch is based on the merged renderer-wakeup fix and will be validated by the hosted macOS build and parallel queue smoke before merge.
