### PR TITLE
fix(actions): bound dedicated renderer bootstrap

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -18,7 +18,11 @@ var dedicatedQueueChatLaunchers: [Int: Process] = [:]
 // browser target (or an about:blank page), not the renderer that owns the
 // authenticated app. Starting the Chat target timeout from that first target
 // made a slow second worker look dead just before its app renderer appeared.
-let dedicatedRendererBootstrapTimeout: TimeInterval = 120.0
+// Keep each direct/LaunchServices bootstrap bounded: the parallel verifier
+// waits 300 seconds for both workers, and two isolated attempts must be able
+// to fail and retry within that window instead of holding the queue lock for
+// several minutes with no renderer target.
+let dedicatedRendererBootstrapTimeout: TimeInterval = 20.0
 
 enum QueueTargetRuntimeState {
   case missing

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -419,6 +419,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /dedicatedRendererTargetExists/);
   assert.match(nativeSource, /dedicatedRendererTargetSummary/);
   assert.match(nativeSource, /dedicatedRendererBootstrapTimeout/);
+  assert.match(nativeSource, /let dedicatedRendererBootstrapTimeout: TimeInterval = 20\.0/);
   assert.match(nativeSource, /dedicated-process-renderer-timeout/);
   assert.match(nativeSource, /dedicated-renderer-bootstrap-recovery/);
   assert.match(nativeSource, /Do not replace a document that is still naturally loading/);


### PR DESCRIPTION
The parallel smoke run showed worker B could launch a dedicated ChatGPT process but hold the queue lock for several minutes without a CDP renderer.

Bound direct and LaunchServices renderer bootstrap waits to 20 seconds so two isolated attempts can fail/retry inside the verifier window. Preserve visible headless renderer and authentication checks.