### PR TITLE
fix(actions): hard-timeout dedicated renderer probes

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
@@ -205,7 +205,14 @@ struct CDPClient {
       semaphore.signal()
     }
     task.resume()
-    _ = semaphore.wait(timeout: .now() + 1.8)
+    if semaphore.wait(timeout: .now() + 1.8) == .timedOut {
+      // A dedicated Electron process can keep an unopened CDP port around
+      // while its first renderer is starting.  Cancel the request when the
+      // bounded probe expires so timed-out attempts do not accumulate in the
+      // shared URLSession connection pool and stall the next worker probe.
+      task.cancel()
+      return []
+    }
     guard let data = resultData,
           let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
       return []

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -815,6 +815,33 @@ func dedicatedRendererTargetExists(port: Int) -> Bool {
   }
 }
 
+func boundedDedicatedRendererTargetExists(
+  port: Int,
+  timeout: TimeInterval = 2.0
+) -> Bool {
+  let semaphore = DispatchSemaphore(value: 0)
+  let lock = NSLock()
+  var result = false
+  DispatchQueue.global(qos: .utility).async {
+    let found = dedicatedRendererTargetExists(port: port)
+    lock.lock()
+    result = found
+    lock.unlock()
+    semaphore.signal()
+  }
+  let boundedTimeout = max(0.2, timeout)
+  guard semaphore.wait(timeout: .now() + boundedTimeout) == .success else {
+    queueTrace(
+      "worker-create stage=dedicated-renderer-target-probe-timeout "
+        + "port=\(port) timeoutMs=\(Int(boundedTimeout * 1_000))"
+    )
+    return false
+  }
+  lock.lock()
+  defer { lock.unlock() }
+  return result
+}
+
 func dedicatedRendererTargetSummary(port: Int) -> String {
   let summaries = CDPClient.fetchTargets(portOverride: port).prefix(8).map { target in
     let type = target["type"] as? String ?? "unknown"
@@ -840,7 +867,10 @@ func waitForDedicatedRendererTarget(
 ) -> Bool {
   let deadline = Date().addingTimeInterval(timeout)
   while Date() < deadline {
-    if dedicatedRendererTargetExists(port: port) {
+    if boundedDedicatedRendererTargetExists(
+      port: port,
+      timeout: min(2.0, max(0.2, timeout))
+    ) {
       return true
     }
     Thread.sleep(forTimeInterval: 0.25)

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -417,6 +417,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /dedicated-empty-shell-navigation/);
   assert.match(nativeSource, /dedicated-chat-target-timeout/);
   assert.match(nativeSource, /dedicatedRendererTargetExists/);
+  assert.match(nativeSource, /boundedDedicatedRendererTargetExists/);
   assert.match(nativeSource, /dedicatedRendererTargetSummary/);
   assert.match(nativeSource, /dedicatedRendererBootstrapTimeout/);
   assert.match(nativeSource, /let dedicatedRendererBootstrapTimeout: TimeInterval = 20\.0/);


### PR DESCRIPTION
The parallel smoke run on main 3607020 showed task A completing while task B's dedicated ChatGPT process never exposed a CDP renderer. The bounded startup probe could leave URLSession requests pending, so the worker remained stuck waiting instead of entering its retry/fallback path.

This patch cancels expired CDP target requests and wraps renderer discovery in a hard timeout, preserving visible headless behavior and fail-closed authentication. It adds static coverage for the bounded probe.

Validation is expected through the required CI and macOS runtime build; after merge, rerun parallel_queue_smoke=true.