### PR TITLE
fix(actions): preserve primary CDP session transport

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
@@ -374,7 +374,13 @@ struct CDPClient {
   static func fetchTargets(portOverride: Int? = nil) -> [[String: Any]] {
     let resolvedPort = portOverride ?? port()
     let resolvedHost = host().lowercased()
-    if resolvedHost == "127.0.0.1" || resolvedHost == "localhost" {
+    // Keep the proven URLSession path for the primary authenticated renderer
+    // (usually 9324 and the integration-test's ephemeral port). The isolated
+    // worker range is the only path that needs the independent socket probe:
+    // a second Electron process can otherwise wedge URLSession's shared local
+    // connection pool while its CDP endpoint is still opening.
+    if (resolvedHost == "127.0.0.1" || resolvedHost == "localhost"),
+       (9330...9380).contains(resolvedPort) {
       return fetchTargetsOverLocalSocket(port: resolvedPort)
     }
     return fetchTargetsOverURLSession(port: resolvedPort)

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -423,6 +423,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /fetchTargetsOverLocalSocket/);
   assert.match(nativeSource, /Darwin\.socket\(AF_INET, SOCK_STREAM, 0\)/);
   assert.match(nativeSource, /transfer-encoding: chunked/);
+  assert.match(nativeSource, /9330\.\.\.9380/);
   assert.match(nativeSource, /dedicatedRendererTargetSummary/);
   assert.match(nativeSource, /dedicatedRendererBootstrapTimeout/);
   assert.match(nativeSource, /let dedicatedRendererBootstrapTimeout: TimeInterval = 20\.0/);


### PR DESCRIPTION
## What changed
- limit the raw local socket probe to isolated dedicated worker ports 9330-9380
- keep the primary authenticated renderer and integration-test ports on the existing URLSession path
- preserve strict hidden Chat and login verification

## Validation
- remote macOS runtime validation and the parallel Actions smoke will be rerun after merge