### PR TITLE
fix(actions): recover headless ChatGPT shell after cookie restore

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -339,6 +339,7 @@ const sessionStateExpression = `(() => {
 export async function restoreSession({
   port = Number(process.env.CHATGPT_CDP_PORT || defaultPort),
   mode = process.env.CHATGPT_SESSION_MODE || 'restore-and-verify',
+  headless = process.env.CHATGPT_AUTO_CONFIRM_HEADLESS === '1',
   encoded = process.env.CHATGPT_SESSION_COOKIES_B64,
   fetchImpl = globalThis.fetch,
   WebSocketImpl = globalThis.WebSocket,
@@ -406,9 +407,25 @@ export async function restoreSession({
     });
 
     if (mode === 'restore' || mode === 'restore-and-verify') {
-      // Page.reload can replace the renderer. Re-discover the target after the
-      // command instead of issuing Runtime calls through the stale socket.
-      await optionalCall(connection.call, 'Page.reload', { ignoreCache: true }, 10_000, log);
+      // Hosted macOS runs have no user-facing window. In that environment a
+      // Chromium Page.reload can tear down the only Electron renderer before
+      // it answers the CDP command, leaving /json/list empty for the whole
+      // recovery window. Navigating to the app root exercises the same cookie
+      // bootstrap while keeping the renderer lifecycle recoverable. The local
+      // desktop path retains the stronger cache-busting reload behavior.
+      if (headless) {
+        await optionalCall(
+          connection.call,
+          'Page.navigate',
+          { url: appRootURL },
+          10_000,
+          log,
+        );
+      } else {
+        // Page.reload can replace the renderer. Re-discover the target after
+        // the command instead of issuing Runtime calls through the stale socket.
+        await optionalCall(connection.call, 'Page.reload', { ignoreCache: true }, 10_000, log);
+      }
       closeConnection(connection);
       connection = await recoverAppRootConnection({
         connection: null,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
@@ -168,6 +168,18 @@ test('reconnects to the replacement renderer after avatar-overlay navigation and
   assert.ok(server.connections.some(item => item.target?.id === 'after-reload'));
 });
 
+test('uses root navigation instead of reload for a headless desktop shell', async () => {
+  const server = new FakeCDPServer({
+    initialURL: 'app://-/index.html?initialRoute=%2F',
+  });
+
+  const output = await run(server, { headless: true });
+  assert.match(output, /^Verified authenticated desktop shell/);
+  assert.equal(server.reloads, 0);
+  assert.equal(server.navigations, 1);
+  assert.ok(server.connections.some(item => item.target?.id === 'after-navigation'));
+});
+
 test('recovers when the active renderer fails during Runtime.evaluate', async () => {
   const server = new FakeCDPServer({
     initialURL: 'app://-/index.html?initialRoute=%2F',


### PR DESCRIPTION
修复 macOS Actions 中会话恢复卡在空白渲染器的问题。

- 无头环境用 app 根路由导航替代 Page.reload，随后重新发现并连接主渲染器。
- 本机非无头路径继续使用带缓存清理的 reload。
- 新增无外部依赖测试覆盖无头导航分支。
- 保持严格的登录页拒绝与隐藏 Chat 最终验证。

验证方式：GitHub Actions 原生构建、插件测试、真实 parallel_queue_smoke。