### PR TITLE
fix(actions): auto-approve headless ChatGPT network prompt

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -47,6 +47,72 @@ func queueAllowsVisibleDedicatedRenderer() -> Bool {
   return environment["GITHUB_ACTIONS"]?.lowercased() == "true"
 }
 
+// A fresh copied ChatGPT profile can trigger macOS's one-time local-network
+// privacy alert before its preload bridge is mounted. On hosted Actions there
+// is no person who can click that native alert, so the dedicated worker would
+// otherwise remain an empty/overlay renderer forever. Scope this helper to the
+// headless worker path and require the exact macOS prompt text; ChatGPT's own
+// in-page authorization cards continue through the normal CDP approval flow.
+func approveHeadlessChatGPTLocalNetworkPrompt() -> Bool {
+  guard queueAllowsVisibleDedicatedRenderer() else { return false }
+  let script = #"""
+  tell application "System Events"
+    repeat with processRef in (application processes whose name is "ChatGPT")
+      repeat with windowRef in (windows of processRef)
+        try
+          set promptTexts to (value of static texts of windowRef) as text
+          if (promptTexts contains "find devices on local networks") or ¬
+             (promptTexts contains "在本地网络上查找设备") or ¬
+             (promptTexts contains "在本地網絡上查找設備") then
+            if exists (button "Allow" of windowRef) then
+              click button "Allow" of windowRef
+              return "clicked"
+            end if
+            if exists (button "允许" of windowRef) then
+              click button "允许" of windowRef
+              return "clicked"
+            end if
+            if exists (button "允許" of windowRef) then
+              click button "允許" of windowRef
+              return "clicked"
+            end if
+          end if
+        end try
+      end repeat
+    end repeat
+  end tell
+  return "none"
+  """#
+  let process = Process()
+  let output = Pipe()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+  process.arguments = ["-e", script]
+  process.standardInput = FileHandle.nullDevice
+  process.standardOutput = output
+  process.standardError = FileHandle.nullDevice
+  do {
+    try process.run()
+  } catch {
+    return false
+  }
+  let deadline = Date().addingTimeInterval(1.5)
+  while process.isRunning && Date() < deadline {
+    Thread.sleep(forTimeInterval: 0.05)
+  }
+  guard !process.isRunning else {
+    process.terminate()
+    return false
+  }
+  guard process.terminationStatus == 0,
+        let result = String(
+          data: output.fileHandleForReading.readDataToEndOfFile(),
+          encoding: .utf8
+        ) else {
+    return false
+  }
+  return result.contains("clicked")
+}
+
 func queueTargetStateIsUsableForQueue(
   _ runtimeState: QueueTargetRuntimeState,
   workerMode: String?
@@ -1232,6 +1298,13 @@ func dedicatedQueueChatTarget(
   let appRootURL = "app://-/index.html?initialRoute=%2F"
   let allowVisibleRenderer = queueAllowsVisibleDedicatedRenderer()
   while Date() < deadline {
+    if allowVisibleRenderer, attempt % 4 == 0,
+       approveHeadlessChatGPTLocalNetworkPrompt() {
+      queueTrace(
+        "worker-create stage=dedicated-native-local-network-permission-allowed "
+          + "port=\(port)"
+      )
+    }
     let targets = boundedDedicatedRendererTargets(port: port)
     for target in targets {
       guard target["type"] as? String == "page",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -339,6 +339,7 @@ const sessionStateExpression = `(() => {
 export async function restoreSession({
   port = Number(process.env.CHATGPT_CDP_PORT || defaultPort),
   mode = process.env.CHATGPT_SESSION_MODE || 'restore-and-verify',
+  headless = process.env.CHATGPT_AUTO_CONFIRM_HEADLESS === '1',
   encoded = process.env.CHATGPT_SESSION_COOKIES_B64,
   fetchImpl = globalThis.fetch,
   WebSocketImpl = globalThis.WebSocket,
@@ -406,9 +407,25 @@ export async function restoreSession({
     });
 
     if (mode === 'restore' || mode === 'restore-and-verify') {
-      // Page.reload can replace the renderer. Re-discover the target after the
-      // command instead of issuing Runtime calls through the stale socket.
-      await optionalCall(connection.call, 'Page.reload', { ignoreCache: true }, 10_000, log);
+      // Hosted macOS runs have no user-facing window. In that environment a
+      // Chromium Page.reload can tear down the only Electron renderer before
+      // it answers the CDP command, leaving /json/list empty for the whole
+      // recovery window. Navigating to the app root exercises the same cookie
+      // bootstrap while keeping the renderer lifecycle recoverable. The local
+      // desktop path retains the stronger cache-busting reload behavior.
+      if (headless) {
+        await optionalCall(
+          connection.call,
+          'Page.navigate',
+          { url: appRootURL },
+          10_000,
+          log,
+        );
+      } else {
+        // Page.reload can replace the renderer. Re-discover the target after
+        // the command instead of issuing Runtime calls through the stale socket.
+        await optionalCall(connection.call, 'Page.reload', { ignoreCache: true }, 10_000, log);
+      }
       closeConnection(connection);
       connection = await recoverAppRootConnection({
         connection: null,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -463,6 +463,10 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /func queueAllowsVisibleDedicatedRenderer\(\)/);
   assert.match(nativeSource, /CHATGPT_AUTO_CONFIRM_HEADLESS/);
   assert.match(nativeSource, /dedicated-chat-target-visible-headless/);
+  assert.match(nativeSource, /approveHeadlessChatGPTLocalNetworkPrompt/);
+  assert.match(nativeSource, /find devices on local networks/);
+  assert.match(nativeSource, /dedicated-native-local-network-permission-allowed/);
+  assert.match(nativeSource, /button \"Allow\"/);
   assert.match(nativeSource, /unhideDedicatedProcessForPort/);
   assert.match(nativeSource, /Target\.activateTarget/);
   assert.match(nativeSource, /dedicated-visible-renderer-wake/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
@@ -168,6 +168,18 @@ test('reconnects to the replacement renderer after avatar-overlay navigation and
   assert.ok(server.connections.some(item => item.target?.id === 'after-reload'));
 });
 
+test('uses root navigation instead of reload for a headless desktop shell', async () => {
+  const server = new FakeCDPServer({
+    initialURL: 'app://-/index.html?initialRoute=%2F',
+  });
+
+  const output = await run(server, { headless: true });
+  assert.match(output, /^Verified authenticated desktop shell/);
+  assert.equal(server.reloads, 0);
+  assert.equal(server.navigations, 1);
+  assert.ok(server.connections.some(item => item.target?.id === 'after-navigation'));
+});
+
 test('recovers when the active renderer fails during Runtime.evaluate', async () => {
   const server = new FakeCDPServer({
     initialURL: 'app://-/index.html?initialRoute=%2F',


### PR DESCRIPTION
真实 smoke 截图确认，专用 ChatGPT 进程被 macOS 原生“允许 ChatGPT 在本地网络上查找设备？”弹窗阻塞，导致 renderer bridge 未挂载。

- 仅在无头 Actions/专用 worker 路径检测精确的 macOS 本地网络隐私弹窗。
- 发现对应文案后点击 Allow/允许；其他 ChatGPT 页面授权仍由现有 CDP 审批逻辑处理。
- AppleScript 调用有界且失败安全，不改变登录验证标准。
- 增加契约测试断言。

验证：合并后重新跑真实 parallel_queue_smoke。