### PR TITLE
fix(actions): accept inaccessible native network alert

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -60,8 +60,16 @@ func approveHeadlessChatGPTLocalNetworkPrompt() -> Bool {
     repeat with processRef in (application processes whose name is "ChatGPT")
       repeat with windowRef in (windows of processRef)
         try
-          set promptTexts to (value of static texts of windowRef) as text
-          if (promptTexts contains "find devices on local networks") or ¬
+          set promptTexts to ""
+          try
+            set promptTexts to (value of static texts of windowRef) as text
+          end try
+          set dialogRole to ""
+          try
+            set dialogRole to (subrole of windowRef) as text
+          end try
+          if (dialogRole is "AXSystemDialog") or ¬
+             (promptTexts contains "find devices on local networks") or ¬
              (promptTexts contains "在本地网络上查找设备") or ¬
              (promptTexts contains "在本地網絡上查找設備") then
             if exists (button "Allow" of windowRef) then
@@ -75,6 +83,9 @@ func approveHeadlessChatGPTLocalNetworkPrompt() -> Bool {
             if exists (button "允許" of windowRef) then
               click button "允許" of windowRef
               return "clicked"
+            end if
+            if (dialogRole is "AXSystemDialog") and (frontmost of processRef) then
+              return "dialog"
             end if
           end if
         end try
@@ -110,7 +121,31 @@ func approveHeadlessChatGPTLocalNetworkPrompt() -> Bool {
         ) else {
     return false
   }
-  return result.contains("clicked")
+  if result.contains("clicked") { return true }
+  guard result.contains("dialog") else { return false }
+  let keyPress = Process()
+  keyPress.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+  keyPress.arguments = [
+    "-e",
+    "tell application \"System Events\" to key code 36",
+  ]
+  keyPress.standardInput = FileHandle.nullDevice
+  keyPress.standardOutput = FileHandle.nullDevice
+  keyPress.standardError = FileHandle.nullDevice
+  do {
+    try keyPress.run()
+  } catch {
+    return false
+  }
+  let keyDeadline = Date().addingTimeInterval(1.0)
+  while keyPress.isRunning && Date() < keyDeadline {
+    Thread.sleep(forTimeInterval: 0.05)
+  }
+  guard !keyPress.isRunning else {
+    keyPress.terminate()
+    return false
+  }
+  return keyPress.terminationStatus == 0
 }
 
 func queueTargetStateIsUsableForQueue(

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -43,8 +43,16 @@ tell application "System Events"
   repeat with processRef in (application processes whose name is "ChatGPT")
     repeat with windowRef in (windows of processRef)
       try
-        set promptTexts to (value of static texts of windowRef) as text
-        if (promptTexts contains "find devices on local networks") or ¬
+        set promptTexts to ""
+        try
+          set promptTexts to (value of static texts of windowRef) as text
+        end try
+        set dialogRole to ""
+        try
+          set dialogRole to (subrole of windowRef) as text
+        end try
+        if (dialogRole is "AXSystemDialog") or ¬
+           (promptTexts contains "find devices on local networks") or ¬
            (promptTexts contains "在本地网络上查找设备") or ¬
            (promptTexts contains "在本地網絡上查找設備") then
           if exists (button "Allow" of windowRef) then
@@ -59,6 +67,9 @@ tell application "System Events"
             click button "允許" of windowRef
             return "clicked"
           end if
+          if (dialogRole is "AXSystemDialog") and (frontmost of processRef) then
+            return "dialog"
+          end if
         end if
       end try
     end repeat
@@ -72,7 +83,16 @@ return "none"
       timeout: 1_500,
       stdio: ['ignore', 'pipe', 'ignore'],
     });
-    return result?.status === 0 && String(result.stdout || '').includes('clicked');
+    if (result?.status !== 0) return false;
+    const output = String(result.stdout || '');
+    if (output.includes('clicked')) return true;
+    if (!output.includes('dialog')) return false;
+    const keyPress = spawnImpl(
+      '/usr/bin/osascript',
+      ['-e', 'tell application "System Events" to key code 36'],
+      { encoding: 'utf8', timeout: 1_000, stdio: ['ignore', 'ignore', 'ignore'] },
+    );
+    return keyPress?.status === 0;
   } catch {
     return false;
   }
@@ -422,10 +442,11 @@ export async function restoreSession({
   let connection;
   const beforeProbeImpl = headless
     ? async () => {
-      if (typeof nativePromptImpl === 'function') {
-        nativePromptImpl();
-      } else {
-        approveHeadlessChatGPTLocalNetworkPrompt();
+      const approved = typeof nativePromptImpl === 'function'
+        ? nativePromptImpl()
+        : approveHeadlessChatGPTLocalNetworkPrompt();
+      if (approved) {
+        log('Headless ChatGPT native local-network prompt approved');
       }
     }
     : undefined;

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -100,6 +100,8 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(restoreSessionScript, /avatar-overlay/);
   assert.match(restoreSessionScript, /approveHeadlessChatGPTLocalNetworkPrompt/);
   assert.match(restoreSessionScript, /find devices on local networks/);
+  assert.match(restoreSessionScript, /AXSystemDialog/);
+  assert.match(restoreSessionScript, /key code 36/);
   assert.match(restoreSessionScript, /nativePromptImpl/);
   assert.match(restoreSessionScript, /initialRoute=%2F/);
   assert.match(restoreSessionScript, /Optional CDP command/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -465,6 +465,8 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /dedicated-chat-target-visible-headless/);
   assert.match(nativeSource, /approveHeadlessChatGPTLocalNetworkPrompt/);
   assert.match(nativeSource, /find devices on local networks/);
+  assert.match(nativeSource, /AXSystemDialog/);
+  assert.match(nativeSource, /key code 36/);
   assert.match(nativeSource, /dedicated-native-local-network-permission-allowed/);
   assert.match(nativeSource, /button \"Allow\"/);
   assert.match(nativeSource, /unhideDedicatedProcessForPort/);


### PR DESCRIPTION
真实 smoke 截图显示，macOS 原生本地网络隐私弹窗在 Accessibility 树中可能只有 AXSystemDialog，没有可见按钮或静态文案；此前仅按按钮/文案匹配未能放行。

- 识别前台 ChatGPT 的 AXSystemDialog。
- 若按钮不可访问，发送一次系统默认确认键（该阶段没有任务发送），接受默认 Allow。
- 主壳恢复脚本与专用 worker 保持相同的有界、无头、失败安全处理。
- 保持 ChatGPT 内部授权卡和登录验证不变。

合并后再跑真实 parallel_queue_smoke。