### PR TITLE
fix(actions): click compact native network alert

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -84,6 +84,19 @@ func approveHeadlessChatGPTLocalNetworkPrompt() -> Bool {
               click button "允許" of windowRef
               return "clicked"
             end if
+            try
+              set windowSize to size of windowRef
+              set windowWidth to item 1 of windowSize
+              set windowHeight to item 2 of windowSize
+              if (windowWidth is greater than 180) and (windowWidth is less than 420) and ¬
+                 (windowHeight is greater than 180) and (windowHeight is less than 360) then
+                set windowPosition to position of windowRef
+                set clickX to ((item 1 of windowPosition) + (windowWidth * 72 / 100)) as integer
+                set clickY to ((item 2 of windowPosition) + (windowHeight * 87 / 100)) as integer
+                click at {clickX, clickY}
+                return "clicked"
+              end if
+            end try
             if (dialogRole is "AXSystemDialog") and (frontmost of processRef) then
               return "dialog"
             end if

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -67,6 +67,19 @@ tell application "System Events"
             click button "允許" of windowRef
             return "clicked"
           end if
+          try
+            set windowSize to size of windowRef
+            set windowWidth to item 1 of windowSize
+            set windowHeight to item 2 of windowSize
+            if (windowWidth is greater than 180) and (windowWidth is less than 420) and ¬
+               (windowHeight is greater than 180) and (windowHeight is less than 360) then
+              set windowPosition to position of windowRef
+              set clickX to ((item 1 of windowPosition) + (windowWidth * 72 / 100)) as integer
+              set clickY to ((item 2 of windowPosition) + (windowHeight * 87 / 100)) as integer
+              click at {clickX, clickY}
+              return "clicked"
+            end if
+          end try
           if (dialogRole is "AXSystemDialog") and (frontmost of processRef) then
             return "dialog"
           end if


### PR DESCRIPTION
第八次 smoke 仍截到同一原生本地网络弹窗；Accessibility 只给出系统对话框，没有可按的按钮，默认键也没有关闭。

- 在确认 ChatGPT 前台小型系统对话框后，按弹窗相对几何位置点击右侧 Allow。
- 保留按钮、文案和默认键兜底；调用仍有界、只在无头启动阶段执行。
- 不触碰任务发送、ChatGPT 内部授权卡或登录认证标准。

合并后继续真实 parallel_queue_smoke。