### PR TITLE
fix(actions): activate dedicated renderer process

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1403,6 +1403,19 @@ func hideDedicatedProcessForPort(_ port: Int) -> Bool {
 
 @discardableResult
 func unhideDedicatedProcessForPort(_ port: Int) -> Bool {
+  // Directly launched Electron instances are not always discoverable through
+  // `ps` with the original command line (the app can hand off to a helper
+  // process before its renderer is ready).  Keep the launcher PID as the
+  // primary identity and explicitly bring that application to the foreground
+  // so Chromium can resume the root renderer and attach its preload bridge.
+  if let launcher = dedicatedQueueChatLaunchers[port],
+     let application = NSRunningApplication(processIdentifier: launcher.processIdentifier) {
+    let unhidden = application.unhide()
+    let activated = application.activate(options: [.activateIgnoringOtherApps])
+    if unhidden || activated || !application.isHidden {
+      return true
+    }
+  }
   let process = Process()
   let output = Pipe()
   process.executableURL = URL(fileURLWithPath: "/bin/ps")
@@ -1431,7 +1444,9 @@ func unhideDedicatedProcessForPort(_ port: Int) -> Bool {
           let application = NSRunningApplication(processIdentifier: processID) else {
       continue
     }
-    return application.unhide()
+    let unhidden = application.unhide()
+    let activated = application.activate(options: [.activateIgnoringOtherApps])
+    return unhidden || activated || !application.isHidden
   }
   return false
 }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -485,6 +485,8 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /parallelDedicatedProcessQueueWorkerMode/);
   assert.match(nativeSource, /CHATGPT_AUTO_CONFIRM_PROFILE_PATH/);
   assert.match(nativeSource, /configuredHiddenChatProfilePath\(\)/);
+  assert.match(nativeSource, /launcher\.processIdentifier/);
+  assert.match(nativeSource, /activate\(options: \[\.activateIgnoringOtherApps\]\)/);
   assert.match(nativeSource, /"conversationId": task\.conversationId/);
   assert.match(nativeSource, /stableSamples >= 3/);
   assert.match(nativeSource, /openBackgroundQueueWindow\(/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -662,6 +662,9 @@ test('native runtime stays in the background and never takes over the UI', () =>
   const backgroundNativeSource = nativeSource.replace(
     /func activateChatGPTForLogin\(\) \{[\s\S]*?\n\}\n\nfunc waitForActionsLoginTarget/,
     'func waitForActionsLoginTarget',
+  ).replace(
+    /func unhideDedicatedProcessForPort\([\s\S]*?\) -> Bool \{[\s\S]*?\n\}\n\nfunc dedicatedQueueChatTarget/,
+    'func dedicatedQueueChatTarget',
   );
   assert.match(nativeSource, /AXUIElementPerformAction\(candidate\.element, kAXPressAction/);
   assert.match(nativeSource, /AXPress 已发送，等待授权卡消失/);
@@ -676,6 +679,7 @@ test('native runtime stays in the background and never takes over the UI', () =>
   assert.doesNotMatch(nativeSource, /CGWarpMouseCursorPosition|postToPid/);
   assert.match(nativeSource, /clickCompactChatGPTLocalNetworkWindowViaQuartz/);
   assert.match(nativeSource, /mouseDown\.post\(tap: \.cghidEventTap\)/);
+  assert.match(nativeSource, /application\.activate\(options: \[\.activateIgnoringOtherApps\]\)/);
   assert.doesNotMatch(backgroundNativeSource, /\.activate\s*\(|postToPid|kAXFocusedAttribute/);
   assert.doesNotMatch(nativeSource,
     /navigateChat|scanTargetChats|sweepHiddenChats|sidebarTaskButton|switchApplicationMode/);


### PR DESCRIPTION
## What changed
- resolve the dedicated ChatGPT process by its retained launcher PID before falling back to process-list discovery
- explicitly unhide and activate the process so the root renderer can attach its preload bridge in hosted macOS
- keep ChatGPT authorization and login checks fail-closed

## Validation
- remote ChatGPT auto-confirm runtime validation
- merge queue CI
- parallel queue smoke after merge