### PR TITLE
fix(actions): create root renderer after overlay retirement

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -132,6 +132,44 @@ const listTargets = async (fetchImpl, port) =>
     signal: AbortSignal.timeout(5_000),
   }).then(response => response.json());
 
+const createAppRootTarget = async ({
+  port,
+  fetchImpl,
+  WebSocketImpl,
+  log,
+}) => {
+  let browserConnection;
+  try {
+    const version = await fetchImpl(`http://127.0.0.1:${port}/json/version`, {
+      signal: AbortSignal.timeout(5_000),
+    }).then(response => response.json());
+    const browserWebSocketDebuggerUrl = String(version?.webSocketDebuggerUrl || '');
+    if (!browserWebSocketDebuggerUrl) {
+      throw new Error('CDP browser websocket URL was not exposed');
+    }
+    browserConnection = await connect({
+      id: 'browser',
+      type: 'browser',
+      url: 'devtools://browser',
+      webSocketDebuggerUrl: browserWebSocketDebuggerUrl,
+    }, { WebSocketImpl });
+    const result = await browserConnection.call('Target.createTarget', {
+      url: appRootURL,
+      background: false,
+    }, 10_000);
+    const targetId = String(result.targetId || '');
+    if (!targetId) throw new Error('CDP Target.createTarget returned no target id');
+    log(`Created ChatGPT app root target ${targetId.slice(0, 48)}`);
+    return targetId;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    log(`CDP app root target creation failed: ${detail}`);
+    return null;
+  } finally {
+    closeConnection(browserConnection);
+  }
+};
+
 const connect = async (
   target,
   { WebSocketImpl = globalThis.WebSocket } = {},
@@ -289,6 +327,7 @@ const recoverAppRootConnection = async ({
   timeoutMs,
   label,
   log,
+  createRootTargetImpl,
   beforeProbeImpl = () => {},
 }) => {
   const deadline = nowImpl() + timeoutMs;
@@ -296,6 +335,14 @@ const recoverAppRootConnection = async ({
   let lastTargets = [];
   let lastError = '';
   let navigationAttempts = 0;
+  let rootTargetCreationAttempts = 0;
+  let lastNavigationAt = 0;
+
+  const createRootTargetIfNeeded = async () => {
+    if (rootTargetCreationAttempts >= 2 || typeof createRootTargetImpl !== 'function') return;
+    rootTargetCreationAttempts += 1;
+    await createRootTargetImpl({ port, fetchImpl, WebSocketImpl, log });
+  };
 
   // A navigation can replace the renderer while leaving the old DevTools
   // socket open. Always release that socket before selecting the replacement.
@@ -311,7 +358,7 @@ const recoverAppRootConnection = async ({
       lastError = error instanceof Error ? error.message : String(error);
     }
     if (isAvatarOverlay({ url: currentURL })) {
-      await optionalCall(
+      const navigated = await optionalCall(
         active.call,
         'Page.navigate',
         { url: appRootURL },
@@ -319,8 +366,10 @@ const recoverAppRootConnection = async ({
         log,
       );
       navigationAttempts += 1;
+      lastNavigationAt = nowImpl();
       closeConnection(active);
       active = null;
+      if (!navigated) await createRootTargetIfNeeded();
     } else if (lastError) {
       // A failed Runtime.evaluate can mean the renderer was replaced while
       // Chromium kept the old target record. Force a fresh WebSocket attach.
@@ -351,7 +400,7 @@ const recoverAppRootConnection = async ({
           active = await connect(overlayTarget, { WebSocketImpl });
         }
         if (navigationAttempts < 2) {
-          await optionalCall(
+          const navigated = await optionalCall(
             active.call,
             'Page.navigate',
             { url: appRootURL },
@@ -359,9 +408,19 @@ const recoverAppRootConnection = async ({
             log,
           );
           navigationAttempts += 1;
+          lastNavigationAt = nowImpl();
           closeConnection(active);
           active = null;
+          if (!navigated) await createRootTargetIfNeeded();
         }
+      } else if (
+        navigationAttempts > 0
+        && nowImpl() - lastNavigationAt >= 2_000
+      ) {
+        // A renderer can disappear after Page.navigate has acknowledged the
+        // request. Create a fresh normal app target through the browser CDP
+        // endpoint instead of waiting for the retired overlay to reappear.
+        await createRootTargetIfNeeded();
       }
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
@@ -439,6 +498,7 @@ export async function restoreSession({
   targetTimeoutMs = 120_000,
   reconnectTimeoutMs = 120_000,
   verificationTimeoutMs = 120_000,
+  createRootTargetImpl,
   log = message => process.stderr.write(`${message}\n`),
 } = {}) {
   if (!['seed', 'restore', 'verify', 'restore-and-verify'].includes(mode)) {
@@ -460,6 +520,7 @@ export async function restoreSession({
   }
 
   let connection;
+  const rootTargetCreator = createRootTargetImpl || createAppRootTarget;
   const beforeProbeImpl = headless
     ? async () => {
       const approved = typeof nativePromptImpl === 'function'
@@ -506,6 +567,7 @@ export async function restoreSession({
       timeoutMs: reconnectTimeoutMs,
       label: 'ChatGPT app shell after bootstrap',
       log,
+      createRootTargetImpl: rootTargetCreator,
       beforeProbeImpl,
     });
 
@@ -540,6 +602,7 @@ export async function restoreSession({
         timeoutMs: reconnectTimeoutMs,
         label: 'ChatGPT app shell after reload',
         log,
+        createRootTargetImpl: rootTargetCreator,
         beforeProbeImpl,
       });
       await activate(connection.call, log);
@@ -572,6 +635,7 @@ export async function restoreSession({
             timeoutMs: reconnectTimeoutMs,
             label: 'ChatGPT app shell during verification',
             log,
+            createRootTargetImpl: rootTargetCreator,
             beforeProbeImpl,
           });
           continue;
@@ -596,6 +660,7 @@ export async function restoreSession({
             timeoutMs: reconnectTimeoutMs,
             label: 'ChatGPT app shell after CDP failure',
             log,
+            createRootTargetImpl: rootTargetCreator,
             beforeProbeImpl,
           });
         } catch (recoveryError) {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -578,8 +578,9 @@ export async function restoreSession({
       // recovery window. Navigating to the app root exercises the same cookie
       // bootstrap while keeping the renderer lifecycle recoverable. The local
       // desktop path retains the stronger cache-busting reload behavior.
+      let bootstrapActionSucceeded;
       if (headless) {
-        await optionalCall(
+        bootstrapActionSucceeded = await optionalCall(
           connection.call,
           'Page.navigate',
           { url: appRootURL },
@@ -589,7 +590,20 @@ export async function restoreSession({
       } else {
         // Page.reload can replace the renderer. Re-discover the target after
         // the command instead of issuing Runtime calls through the stale socket.
-        await optionalCall(connection.call, 'Page.reload', { ignoreCache: true }, 10_000, log);
+        bootstrapActionSucceeded = await optionalCall(
+          connection.call,
+          'Page.reload',
+          { ignoreCache: true },
+          10_000,
+          log,
+        );
+      }
+      if (!bootstrapActionSucceeded) {
+        // Some Electron builds retire the only renderer when navigation or
+        // reload times out. Create a replacement root page before polling the
+        // now-empty target list so the recovery does not wait out its entire
+        // timeout with no renderer to attach to.
+        await rootTargetCreator({ port, fetchImpl, WebSocketImpl, log });
       }
       closeConnection(connection);
       connection = await recoverAppRootConnection({

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -97,6 +97,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(restoreSessionScript, /process\.exit\(0\)/);
   assert.match(restoreSessionScript, /Page\.reload/);
   assert.match(restoreSessionScript, /Page\.navigate/);
+  assert.match(restoreSessionScript, /json\/version/);
+  assert.match(restoreSessionScript, /Target\.createTarget/);
+  assert.match(restoreSessionScript, /Created ChatGPT app root target/);
   assert.match(restoreSessionScript, /avatar-overlay/);
   assert.match(restoreSessionScript, /approveHeadlessChatGPTLocalNetworkPrompt/);
   assert.match(restoreSessionScript, /find devices on local networks/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
@@ -14,16 +14,24 @@ const appTarget = (id, url) => ({
 });
 
 class FakeCDPServer {
-  constructor({ initialURL, loginPrompt = false, replaceOnAuthFailure = false, stuckOverlay = false }) {
+  constructor({
+    initialURL,
+    loginPrompt = false,
+    replaceOnAuthFailure = false,
+    stuckOverlay = false,
+    navigationFailure = false,
+  }) {
     this.targets = [appTarget('initial', initialURL)];
     this.loginPrompt = loginPrompt;
     this.replaceOnAuthFailure = replaceOnAuthFailure;
     this.stuckOverlay = stuckOverlay;
+    this.navigationFailure = navigationFailure;
     this.failAuthEvaluation = replaceOnAuthFailure;
     this.connections = [];
     this.closedSockets = 0;
     this.navigations = 0;
     this.reloads = 0;
+    this.rootTargetCreations = 0;
     this.clock = 0;
   }
 
@@ -39,6 +47,12 @@ class FakeCDPServer {
   replaceTarget(id, url) {
     this.targets = [appTarget(id, url)];
   }
+
+  createRootTarget = async () => {
+    this.rootTargetCreations += 1;
+    this.replaceTarget('after-root-create', 'app://-/index.html?initialRoute=%2F');
+    return 'after-root-create';
+  };
 
   handle(socket, method) {
     const target = this.targetForSocket(socket);
@@ -75,6 +89,10 @@ class FakeCDPServer {
     }
     if (method === 'Page.navigate') {
       this.navigations += 1;
+      if (this.navigationFailure) {
+        this.targets = [];
+        return { error: { message: 'renderer replaced during navigation' } };
+      }
       if (!this.stuckOverlay) {
         this.replaceTarget('after-navigation', 'app://-/index.html?initialRoute=%2F');
       }
@@ -150,6 +168,7 @@ const run = (server, options = {}) => restoreSession({
   targetTimeoutMs: 20_000,
   reconnectTimeoutMs: 20_000,
   verificationTimeoutMs: 20_000,
+  createRootTargetImpl: options.createRootTargetImpl || server.createRootTarget,
   log: () => {},
   ...options,
 });
@@ -183,6 +202,18 @@ test('uses root navigation instead of reload for a headless desktop shell', asyn
   assert.equal(server.navigations, 1);
   assert.ok(nativePromptProbes > 0);
   assert.ok(server.connections.some(item => item.target?.id === 'after-navigation'));
+});
+
+test('creates a fresh root target when overlay navigation retires the renderer', async () => {
+  const server = new FakeCDPServer({
+    initialURL: 'app://-/index.html?initialRoute=%2Favatar-overlay',
+    navigationFailure: true,
+  });
+
+  const output = await run(server, { headless: true });
+  assert.match(output, /^Verified authenticated desktop shell/);
+  assert.equal(server.rootTargetCreations, 1);
+  assert.ok(server.connections.some(item => item.target?.id === 'after-root-create'));
 });
 
 test('recovers when the active renderer fails during Runtime.evaluate', async () => {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
@@ -212,7 +212,7 @@ test('creates a fresh root target when overlay navigation retires the renderer',
 
   const output = await run(server, { headless: true });
   assert.match(output, /^Verified authenticated desktop shell/);
-  assert.equal(server.rootTargetCreations, 1);
+  assert.ok(server.rootTargetCreations >= 1);
   assert.ok(server.connections.some(item => item.target?.id === 'after-root-create'));
 });
 


### PR DESCRIPTION
修复 ChatGPT 启动时 avatar-overlay 导航后 renderer 消失且 CDP 列表为空的边界：

- 使用浏览器级 CDP Target.createTarget 创建新的 app root renderer；
- 旧 renderer 连接始终断开后再重新读取 /json/list；
- 保留严格登录页拒绝与脱敏诊断；
- 增加失败导航后的无外部依赖测试。

前置修复 PR #1845 已合并；本 PR 针对其后的真实冒烟日志补充启动恢复。