### PR TITLE
fix(actions): inherit authenticated renderer browser context

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -888,9 +888,21 @@ func openHeadlessParallelQueueWindow(
     failure = "headless_window_controller_target_missing"
     return nil
   }
+  // Electron may expose a default browser context without the ChatGPT
+  // partition/preload bridge. Reuse the authenticated controller's context
+  // when it is available; CDPClient still falls back to the default context
+  // for older desktop builds that reject the reported id.
+  let browserContextId = CDPClient.targetInfo(
+    targetId: controllerTargetId,
+    portOverride: port
+  )?["browserContextId"] as? String
+  queueTrace(
+    "worker-create stage=headless-window-context "
+      + "present=\(browserContextId?.isEmpty == false)"
+  )
   guard let targetId = CDPClient.createTarget(
     url: appRootURL,
-    browserContextId: nil,
+    browserContextId: browserContextId,
     background: false,
     portOverride: port
   ) else {


### PR DESCRIPTION
真实并行冒烟已证明独立窗口创建成功，但页面落在默认 browser context，导致 bridge=false。让 Target.createTarget 继承已认证主 renderer 的 browserContextId，并保留旧版本无效 context 时的 CDP fallback。

前置修复：#1845、#1846。