### PR TITLE
feat(chatgpt-auto-confirm): add renderer recovery skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -88,7 +88,7 @@
     },
     {
       "name": "chatgpt-auto-confirm",
-      "version": "1.0.0+codex.20260802195408",
+      "version": "1.0.0+codex.20260805001321",
       "source": {
         "source": "local",
         "path": "./plugins/chatgpt-auto-confirm"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/.codex-plugin/plugin.json
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/.codex-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "chatgpt-auto-confirm",
-  "version": "1.0.0+codex.20260802195408",
+  "version": "1.0.0+codex.20260805001321",
   "description": "\u81ea\u52a8\u786e\u8ba4 ChatGPT \u6388\u6743\u5361\uff0c\u5e76\u7f16\u6392\u53ef\u6062\u590d\u3001\u53ef\u5e76\u53d1\u3001\u9700\u9a8c\u6536\u7684\u4efb\u52a1\u961f\u5217",
   "author": {
     "name": "Fabushi"
   },
   "homepage": "https://fabushi.ombhrum.com/miniapps/chatgpt-auto-confirm",
   "license": "Proprietary",
+  "skills": "./skills",
   "keywords": [
     "chatgpt",
     "desktop",

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/recover-actions-chatgpt-renderer/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/recover-actions-chatgpt-renderer/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: recover-actions-chatgpt-renderer
+description: Diagnose and repair GitHub Actions ChatGPT auto-confirm failures where an avatar-overlay or blank renderer, stale CDP connection, native local-network dialog, or authorization card prevents an authenticated Chat or parallel queue from starting. Use when the runner must be safely repaired, verified, merged, and resumed without weakening login checks.
+---
+
+# Recover Actions ChatGPT Renderer
+
+Use this skill for the `chatgpt-auto-confirm` miniapp when an Actions run starts
+ChatGPT but remains on a blank page, reports a dead renderer, retries with a
+timeout, or leaves a ChatGPT authorization card waiting. It turns the failure
+into evidence, repairs renderer ownership/lifecycle, and proves the fix on
+`main` before starting the persistent queue.
+
+## Safety boundaries
+
+- Keep authentication strict. The native `verify_chatgpt_login` check remains a
+  required success condition; an explicit login prompt is `needs_login`, not a
+  reason to bypass verification.
+- A headless Actions runner does not require every renderer to be hidden. A
+  visible headless window is valid when it is a live Chat surface. Do not turn
+  “hidden” into an authentication requirement.
+- Never print or copy cookies, Codex auth, tokens, full page text, screenshots
+  containing secrets, or task prompts. Use redacted booleans, labels, target ids,
+  route classes, and text lengths only. Credential refresh belongs to
+  `sync-action-credentials`.
+- For project tests, builds, packaging, installation, and artifact validation,
+  use GitHub Actions. Locally limit work to reading code, the skill validator,
+  Git, and `gh` metadata.
+- Start from a clean branch based on the latest `origin/main`; preserve
+  unrelated changes and do not change queue business logic while fixing
+  renderer lifecycle.
+
+## Diagnose before changing code
+
+1. Inspect the failed run and its artifacts. Prefer
+   `parallel-queue-evidence.json`, `action-result.json`, and
+   `task-queue/watcher-trace.log`; compare the failing renderer target with the
+   renderer inventory after launch/navigation. Download artifacts with `gh`,
+   but do not expose their sensitive contents.
+2. Separate the two permission surfaces:
+   - An in-page ChatGPT card has expected labels such as `deny` and `allow
+     once`. Handle it only when the scan reports a candidate; success requires
+     `clicked=true` and `confirmed=true` in the redacted trace.
+   - A native macOS “find devices on local networks” dialog is an OS permission
+     prompt. Use the existing accessibility approval helper and record only that
+     it was found/approved. Do not kill the app, disable the OS policy, or
+     confuse this dialog with ChatGPT's card.
+3. Treat an explicit login page or login prompt as a real authentication
+   failure. Stop with `needs_login` and use the existing credential-sync flow;
+   never accept a blank page as proof of login.
+4. Classify the renderer failure:
+   - `avatar-overlay`, a stale WebSocket, or a target that changes after
+     navigation means the old CDP connection is invalid.
+   - `window.open` returning `false` means the app rejected the popup; repeated
+     popup attempts are not recovery.
+   - A CDP `Target.createTarget` page with `bridge=false`, no meaningful text,
+     or an empty non-app document is not a usable Chat surface.
+
+## Repair the renderer lifecycle
+
+1. After every `Page.navigate`, reload, or renderer disconnect, fetch a fresh
+   renderer list and select a new WebSocket. Close/forget the old overlay
+   connection; never send CDP commands through it after navigation.
+2. Prefer an already authenticated app renderer in the same ChatGPT process.
+   Probe each candidate for app-root route, `bridge=true`, document readiness,
+   visibility/runtime state, meaningful text, and absence of a login prompt.
+   Prefer a normal primary renderer over a prewarm/controller renderer, but
+   allow a visible headless renderer.
+3. Allocate targets exclusively. Exclude the controller and every target
+   already recorded in queue task ownership; task A and task B must not share a
+   renderer or conversation. Persist the selected target in queue state before
+   sending work.
+4. Keep the recovery entry point internally injectable for fetch, WebSocket,
+   and timer dependencies so renderer switching and bounded retries can be
+   tested without external services. Keep the command-line invocation
+   unchanged.
+5. Retry only within a bounded deadline. Emit redacted diagnostics for target
+   id, route class, bridge/readiness, runtime visibility, text length, selected
+   target, timeout stage, and final page state. On exhaustion, fail clearly
+   instead of looping.
+
+## Preserve and verify authorization
+
+Scan only known ChatGPT approval controls. When `allow once` is detected, click
+that card and then verify the card's confirmed state; a click event alone is not
+success. Do not click arbitrary buttons on a page whose surface or
+authentication state is uncertain.
+
+The final hidden-Chat verification remains the native login/Chat-surface check.
+A successful renderer probe is a prerequisite, not a replacement for
+authentication. Keep the existing rejection of real login pages and the
+existing credential-sync path.
+
+## Verify remotely and resume safely
+
+1. Create a focused branch from current `origin/main`, edit only the miniapp
+   skill/manifest/tests, commit named files, push, open a PR, and wait for the
+   merge queue. Do not validate against a stale feature branch.
+2. Require the plugin contract, bundled runtime, and macOS runtime checks to
+   pass in Actions. Run the real smoke from `main` with
+   `parallel_queue_smoke=true` and restored credentials. Use the repository's
+   workflow inputs rather than inventing a web-login path.
+3. Accept parallel smoke only when the evidence says `status=passed`, requested
+   and effective concurrency are at least 2, task B was enqueued after task A
+   started, both were observed running together, and each has a distinct
+   non-empty `conversationId` and renderer `targetId`. Every worker must report
+   `visibilityVerified=true` and a live Chat surface; the runtime state may be
+   `visible` or `hidden-chat`.
+4. Do not require a legacy execution-mode string. Read the mode emitted by the
+   current runtime (currently `parallel-chat-windows`) and reject only an
+   unknown/non-Chat mode. Inspect the trace for
+   `headless-existing-window-probe`, `headless-existing-window-ready`, and
+   `headless-parallel-existing-window-complete`; a
+   `headless_window_target_not_ready` failure requires another diagnosis pass.
+5. After smoke passes, start the normal run with
+   `parallel_queue_smoke=false`. Confirm the job passed credential restoration
+   and login verification and that `Run dynamic persistent task queue` is
+   actually `in_progress`. Do not claim task processing merely because the
+   workflow was dispatched.
+
+See [references/renderer-diagnostics.md](references/renderer-diagnostics.md) for
+the evidence schema, failure signatures, and the bounded retry matrix.
+
+## Completion report
+
+When this skill is used through the task queue, finish with the queue's
+structured `MAHAYANA_TASK_REPORT_V1` report. Include the merged commit, smoke
+run, persistent run step, and any remaining external work; never put
+credentials or full diagnostics in the report.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/recover-actions-chatgpt-renderer/agents/openai.yaml
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/recover-actions-chatgpt-renderer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "修复 Actions ChatGPT 渲染器"
+  short_description: "诊断并修复 Actions ChatGPT 空白页授权卡片与并行渲染器故障"
+  default_prompt: "Use $recover-actions-chatgpt-renderer to diagnose and verify a ChatGPT Actions renderer or authorization-card failure."

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/recover-actions-chatgpt-renderer/references/renderer-diagnostics.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/recover-actions-chatgpt-renderer/references/renderer-diagnostics.md
@@ -1,0 +1,74 @@
+# Renderer diagnostics reference
+
+Use this reference after reading the main skill. It keeps the operational details
+out of the always-loaded instructions while preserving the evidence that made
+the renderer fix reliable.
+
+## Redacted evidence fields
+
+Safe fields to retain in a trace or report:
+
+| Field | Meaning | Safe representation |
+| --- | --- | --- |
+| `targetId` | CDP target ownership | full id is acceptable in a short-lived Action artifact; do not pair it with cookies or page text |
+| `bridge` | preload/electron bridge is available | boolean |
+| `ready` | document lifecycle | `loading`, `interactive`, or `complete` |
+| `visibility` / `runtimeState` | renderer presentation | `visible`, `hidden`, `hidden-chat`, or `missing` |
+| `text` | page content probe | character count, never the full text |
+| `candidateLabels` | approval-card detection | normalized labels such as `allow once` |
+| `clicked` / `confirmed` | approval result | boolean |
+| `conversationId` | task isolation | compare distinctness; avoid exposing unrelated prompt content |
+
+Never include cookie values, auth headers, page HTML, full screenshots, local
+profile paths, or the body of a user's task in diagnostics.
+
+## Expected successful trace
+
+The exact target ids vary. A successful repair has the following shape:
+
+```text
+controller-discovery complete target=<controller> probes=1
+headless-existing-window-probe target=<primary> visibility=visible bridge=true ready=complete text=<positive>
+headless-existing-window-ready target=<primary> visibility=visible
+headless-parallel-existing-window-complete target=<primary>
+task=actions-parallel-a ... conversation=<a>
+headless-existing-window-probe target=<second> visibility=hidden bridge=true ready=complete text=<positive>
+headless-existing-window-ready target=<second> visibility=hidden-chat
+headless-parallel-existing-window-complete target=<second>
+task=actions-parallel-b ... conversation=<b>
+approval-before-read-detected ... candidateLabels=["allow once"]
+approval-before-read ... clicked=true confirmed=true label=allow once
+```
+
+The primary renderer may be visible on a headless runner. The acceptance rule is
+that both targets are live Chat surfaces and are distinct, not that both are
+hidden.
+
+## Failure signatures and next action
+
+| Signature | Interpretation | Next action |
+| --- | --- | --- |
+| `avatar-overlay` or old WebSocket timeout after navigation | stale CDP binding | refresh target inventory and reconnect to the new app renderer |
+| `window.open ... opened=false` | ChatGPT rejected popup creation | stop retrying popups; reuse an existing authenticated renderer |
+| `Target.createTarget` with `bridge=false` or `text=0` | bare page without app preload | reject it and continue bounded candidate scan |
+| `not_chat_surface` | candidate is a shell, prewarm page, or unrelated route | try the next unowned app renderer |
+| `candidateLabels=[]` | no approval card present | do not click; continue surface/authentication checks |
+| `clicked=true confirmed=false` | click was not accepted | capture redacted state, retry the bounded approval scan, then fail if confirmation never appears |
+| explicit login prompt / `needs_login` | credentials are not valid for this process | stop and run credential synchronization; do not weaken verification |
+| `headless_window_target_not_ready` after bounded retries | no usable main renderer appeared | fail with the redacted inventory and final page state; do not start the task queue |
+
+## Action sequence
+
+```text
+PR checks -> merge queue -> verify main
+  -> parallel_queue_smoke=true
+  -> inspect parallel-queue-evidence.json and watcher-trace.log
+  -> parallel smoke passed
+  -> parallel_queue_smoke=false
+  -> verify "Run dynamic persistent task queue" is in_progress
+```
+
+The smoke artifact must show two overlapping tasks, distinct conversations and
+targets, effective concurrency 2, and `visibilityVerified=true` for both. The
+persistent run is the final operational handoff; a dispatched or queued workflow
+alone is not proof that tasks are being processed.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -53,6 +53,18 @@ const actionsInbox = JSON.parse(readFileSync(
   new URL('../tasks/actions-inbox.json', import.meta.url),
   'utf8',
 ));
+const rendererRecoverySkill = readFileSync(
+  new URL('../skills/recover-actions-chatgpt-renderer/SKILL.md', import.meta.url),
+  'utf8',
+);
+const rendererRecoveryReference = readFileSync(
+  new URL('../skills/recover-actions-chatgpt-renderer/references/renderer-diagnostics.md', import.meta.url),
+  'utf8',
+);
+const rendererRecoveryMetadata = readFileSync(
+  new URL('../skills/recover-actions-chatgpt-renderer/agents/openai.yaml', import.meta.url),
+  'utf8',
+);
 
 test('home contract', () => {
   assert.equal(HOME.schema, 'mahayana.miniapp.home.v1');
@@ -67,6 +79,18 @@ test('home contract', () => {
   ]);
   assert.equal(HOME.quickReplies.some(item => item.action.name === 'web_login_and_sync_actions'), false);
   assert.equal(HOME.quickReplies.some(item => item.action.name === 'account_list'), true);
+});
+test('renderer recovery skill is packaged with the miniapp', () => {
+  assert.equal(plugin.skills, './skills');
+  assert.match(rendererRecoverySkill, /name: recover-actions-chatgpt-renderer/);
+  assert.match(rendererRecoverySkill, /verify_chatgpt_login/);
+  assert.match(rendererRecoverySkill, /window\.open/);
+  assert.match(rendererRecoverySkill, /clicked=true/);
+  assert.match(rendererRecoverySkill, /parallel_queue_smoke/);
+  assert.match(rendererRecoveryReference, /headless-existing-window-ready/);
+  assert.match(rendererRecoveryReference, /needs_login/);
+  assert.match(rendererRecoveryMetadata, /display_name:/);
+  assert.match(rendererRecoveryMetadata, /\$recover-actions-chatgpt-renderer/);
 });
 test('article bodies stay lazy', () => assert.ok(Object.keys(RESOURCES).length >= 1));
 test('continuous Actions runner preserves secrets and chains incomplete sessions', () => {

--- a/frontend/apps/web/public/.well-known/mahayana/marketplace.json
+++ b/frontend/apps/web/public/.well-known/mahayana/marketplace.json
@@ -58,7 +58,7 @@
     },
     {
       "id": "chatgpt-auto-confirm",
-      "version": "1.0.0+codex.20260802195408",
+      "version": "1.0.0+codex.20260805001321",
       "title": "ChatGPT 自动确认",
       "description": "自动确认、任务续作、队列并发和独立验收",
       "homepage": "https://fabushi.ombhrum.com/miniapps/chatgpt-auto-confirm/",


### PR DESCRIPTION
## Summary
- add a reusable model Skill for blank ChatGPT renderer, stale CDP, native permission, and authorization-card recovery
- document redacted diagnostics, renderer ownership, visible headless acceptance, and parallel queue evidence
- expose the skill through the miniapp manifest and add contract coverage
- bump the local plugin version for the new packaged skill

## Validation
- local skill structure validation passed
- GitHub Actions plugin contract and runtime checks
- merge queue validation before landing