### PR TITLE
fix(actions): retry ChatGPT DMG detach

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -117,6 +117,12 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /restarting the app before retrying/);
   assert.match(actionsWorkflow, /pkill -f "user-data-dir=\$PROFILE_DIR"/);
   assert.match(actionsWorkflow, /SingletonLock/);
+  assert.match(actionsWorkflow, /detach_mount\(\)/);
+  assert.match(actionsWorkflow, /for attempt in 1 2 3 4 5/);
+  assert.match(actionsWorkflow, /hdiutil detach "\$mount_dir" -wait/);
+  assert.match(actionsWorkflow, /hdiutil detach "\$mount_dir" -force -wait/);
+  assert.match(actionsWorkflow, /hdiutil info/);
+  assert.match(actionsWorkflow, /trap cleanup_mount EXIT/);
   assert.match(restoreSessionScript, /mode === 'restore'/);
   assert.match(restoreSessionScript, /process\.exit\(0\)/);
   assert.match(restoreSessionScript, /Page\.reload/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -224,10 +224,42 @@ jobs:
             --output "$RUNNER_TEMP/ChatGPT.dmg"
           mount_dir="$RUNNER_TEMP/chatgpt-mount"
           mkdir -p "$mount_dir"
+          mounted=false
+          detach_mount() {
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              if hdiutil detach "$mount_dir" -wait; then
+                mounted=false
+                return 0
+              fi
+              echo "::warning::ChatGPT DMG detach attempt $attempt failed; waiting for open handles to close."
+              sleep "$((attempt * 2))"
+            done
+
+            echo "::warning::ChatGPT DMG is still busy; attempting a forced detach."
+            if hdiutil detach "$mount_dir" -force -wait; then
+              mounted=false
+              return 0
+            fi
+
+            echo "::error::Unable to detach ChatGPT DMG mount after bounded retries."
+            hdiutil info || true
+            return 1
+          }
+          cleanup_mount() {
+            local exit_status=$?
+            if [[ "$mounted" == true ]]; then
+              detach_mount || true
+            fi
+            return "$exit_status"
+          }
+          trap cleanup_mount EXIT
           hdiutil attach "$RUNNER_TEMP/ChatGPT.dmg" \
             -nobrowse -readonly -mountpoint "$mount_dir"
+          mounted=true
           ditto "$mount_dir/ChatGPT.app" /Applications/ChatGPT.app
-          hdiutil detach "$mount_dir"
+          detach_mount
+          trap - EXIT
           xattr -dr com.apple.quarantine /Applications/ChatGPT.app || true
 
       - name: Build native queue runtime


### PR DESCRIPTION
## What changed
- retry normal DMG detach with bounded backoff
- fall back to forced detach and emit hdiutil diagnostics if the mount remains busy
- preserve the original exit status during cleanup
- extend the workflow contract test to cover the cleanup guard

## Why
Run #30957534517 stopped at the macOS installer because `hdiutil detach` returned `Resource busy` before ChatGPT launched.

## Validation
Project validation is delegated to the GitHub Actions checks per repository workflow.