### PR TITLE
fix(actions): use supported hdiutil detach flags

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -119,8 +119,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /SingletonLock/);
   assert.match(actionsWorkflow, /detach_mount\(\)/);
   assert.match(actionsWorkflow, /for attempt in 1 2 3 4 5/);
-  assert.match(actionsWorkflow, /hdiutil detach "\$mount_dir" -wait/);
-  assert.match(actionsWorkflow, /hdiutil detach "\$mount_dir" -force -wait/);
+  assert.match(actionsWorkflow, /hdiutil detach "\$mount_dir"/);
+  assert.match(actionsWorkflow, /hdiutil detach "\$mount_dir" -force/);
+  assert.doesNotMatch(actionsWorkflow, /hdiutil detach "\$mount_dir" .* -wait/);
   assert.match(actionsWorkflow, /hdiutil info/);
   assert.match(actionsWorkflow, /trap cleanup_mount EXIT/);
   assert.match(restoreSessionScript, /mode === 'restore'/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -228,7 +228,7 @@ jobs:
           detach_mount() {
             local attempt
             for attempt in 1 2 3 4 5; do
-              if hdiutil detach "$mount_dir" -wait; then
+              if hdiutil detach "$mount_dir"; then
                 mounted=false
                 return 0
               fi
@@ -237,7 +237,7 @@ jobs:
             done
 
             echo "::warning::ChatGPT DMG is still busy; attempting a forced detach."
-            if hdiutil detach "$mount_dir" -force -wait; then
+            if hdiutil detach "$mount_dir" -force; then
               mounted=false
               return 0
             fi


### PR DESCRIPTION
Follow-up to #1852.

The macOS runner log showed that `hdiutil detach` does not support `-wait`; the first validation therefore retried an invalid command and never reached forced detach. Remove the unsupported flag while retaining bounded retries, forced detach fallback, diagnostics, and the contract assertion.