### PR TITLE
fix(actions): keep persistent queue renderer ownership

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -516,6 +516,55 @@ func sendMessageJS(
       });
     }
 
+    function quickChatLabel(picker) {
+      return normalize([
+        picker?.textContent,
+        picker?.getAttribute('aria-label'),
+        picker?.getAttribute('title')
+      ].filter(Boolean).join(' ')).toLowerCase();
+    }
+
+    function quickChatStrongMode(value) {
+      const text = normalize(value).toLowerCase();
+      return text.includes('thinking')
+        || text.includes('思考')
+        || text.includes('extra high')
+        || text.includes('极高')
+        || text.includes('额外高');
+    }
+
+    function quickChatKeyboardTarget() {
+      const candidates = [
+        document.activeElement,
+        ...document.querySelectorAll(
+          '[role="slider"], [aria-valuenow], [aria-label*="of 5"], '
+            + '[aria-label*="adjust power"], [aria-label*="调整强度"], '
+            + '[tabindex], button, [role="button"]'
+        )
+      ].filter((element, index, all) => element && all.indexOf(element) === index);
+      return candidates.find(element => {
+        if (!visible(element)) return false;
+        const label = quickChatLabel(element);
+        return /(?:of 5|adjust power|调整强度|model|effort|instant|thinking|extra high|高|思考)/i.test(label);
+      }) || null;
+    }
+
+    function dispatchQuickChatArrowRight(element) {
+      if (!element) return false;
+      element.focus?.();
+      const event = {
+        bubbles: true,
+        cancelable: true,
+        key: 'ArrowRight',
+        code: 'ArrowRight',
+        keyCode: 39,
+        which: 39
+      };
+      element.dispatchEvent(new KeyboardEvent('keydown', event));
+      element.dispatchEvent(new KeyboardEvent('keyup', event));
+      return true;
+    }
+
     function selectedChoice(element) {
       if (!element) return false;
       const selectedValues = [
@@ -608,6 +657,8 @@ func sendMessageJS(
         );
       if (quickChatModelSurface) {
         let quickChatChoiceClicked = false;
+        let quickChatKeyboardAttempts = 0;
+        let quickChatKeyboardTargetLabel = '';
         let quickChatConfirmed = selectedLabel === 'extra high'
           || selectedLabel === '极高'
           || selectedLabel.startsWith('extra high ')
@@ -619,25 +670,45 @@ func sendMessageJS(
           // on pointerdown; HTMLElement.click() alone leaves the menu closed.
           dispatchPointerClick(picker);
           await sleep(500);
-          const extraHighChoice = [
+          // Some desktop builds expose Thinking as a normal menu item; newer
+          // builds expose the same control as a five-position model/effort
+          // slider whose only accessible text says "1 of 5". Try the stable
+          // menu item first, then use the control's documented ArrowRight
+          // interaction and rediscover the picker after every navigation.
+          const quickChatChoice = [
+            ...allPrefixedModelChoices('Thinking'),
+            ...allPrefixedModelChoices('思考'),
             ...allPrefixedModelChoices('Extra High'),
             ...allPrefixedModelChoices('极高'),
             ...allPrefixedModelChoices('Extra\\u00a0High'),
             ...allPrefixedModelChoices('额外高')
           ][0] || null;
-          if (extraHighChoice) {
-            if (!selectedChoice(extraHighChoice)) extraHighChoice.click();
+          if (quickChatChoice) {
+            if (!selectedChoice(quickChatChoice)) quickChatChoice.click();
             quickChatChoiceClicked = true;
             await sleep(350);
           }
           picker = modelPickerButton();
-          selectedLabel = normalize(picker?.textContent).toLowerCase();
-          quickChatConfirmed = selectedLabel === 'extra high'
-            || selectedLabel === '极高'
-            || selectedLabel.startsWith('extra high ')
-            || selectedLabel === 'extra\\u00a0high'
-            || selectedLabel === '额外高'
-            || selectedLabel.startsWith('extra\\u00a0high ');
+          selectedLabel = quickChatLabel(picker);
+          quickChatConfirmed = quickChatStrongMode(selectedLabel)
+            || selectedChoice(quickChatChoice);
+          for (let attempt = 0; attempt < 4 && !quickChatConfirmed; attempt += 1) {
+            if (visibleModelMenus().length === 0) {
+              picker = modelPickerButton();
+              if (picker) {
+                dispatchPointerClick(picker);
+                await sleep(250);
+              }
+            }
+            const keyboardTarget = quickChatKeyboardTarget() || picker;
+            quickChatKeyboardTargetLabel = quickChatLabel(keyboardTarget).slice(0, 240);
+            if (!dispatchQuickChatArrowRight(keyboardTarget)) break;
+            quickChatKeyboardAttempts += 1;
+            await sleep(450);
+            picker = modelPickerButton();
+            selectedLabel = quickChatLabel(picker);
+            quickChatConfirmed = quickChatStrongMode(selectedLabel);
+          }
         }
         if (!quickChatConfirmed) {
           return {
@@ -650,6 +721,8 @@ func sendMessageJS(
             pickerBefore,
             selectedLabel,
             quickChatChoiceClicked,
+            quickChatKeyboardAttempts,
+            quickChatKeyboardTargetLabel,
             visibleMenuText: visibleModelMenus()
               .map(menu => normalize(menu.textContent).slice(0, 500)),
             surface: chatSurfaceEvidence()
@@ -663,8 +736,12 @@ func sendMessageJS(
           reasoningConfirmed: true,
           pickerBefore,
           selectedLabel,
-          pickerEvidence: 'quick-chat-extra-high-selection',
+          pickerEvidence: quickChatKeyboardAttempts > 0
+            ? 'quick-chat-thinking-keyboard-selection'
+            : 'quick-chat-extra-high-selection',
           quickChatChoiceClicked,
+          quickChatKeyboardAttempts,
+          quickChatKeyboardTargetLabel,
           verificationModelSelected: true,
           submenuExtraHighSelected: true,
           submenuHighSelected: true,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -49,6 +49,10 @@ func queueAllowsVisibleDedicatedRenderer() -> Bool {
   return environment["GITHUB_ACTIONS"]?.lowercased() == "true"
 }
 
+func runningOnGitHubActions() -> Bool {
+  ProcessInfo.processInfo.environment["GITHUB_ACTIONS"]?.lowercased() == "true"
+}
+
 func cgWindowNumber(_ value: Any?) -> CGFloat? {
   if let number = value as? NSNumber {
     return CGFloat(number.doubleValue)
@@ -2332,6 +2336,10 @@ func existingHeadlessParallelQueueTarget(
       return target["type"] as? String == "page"
         && (target["url"] as? String ?? "").hasPrefix("app://-/index.html")
         && !queueOwnedTargetIds.contains(targetId)
+        // The controller renderer owns the authenticated desktop session and
+        // must never become a task renderer. Closing it during task cleanup
+        // leaves the next retry with only an empty bridge-less shell.
+        && targetId != controllerTargetId
         && target["webSocketDebuggerUrl"] as? String != nil
     }
     .sorted { lhs, rhs in
@@ -2542,14 +2550,12 @@ func createIndependentQueueWorkerTarget(
     .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
   let hostedAccountId = hostedAccountValue.isEmpty ? nil : hostedAccountValue
   if let effectiveAccountId = explicitAccountId ?? hostedAccountId {
-    // GitHub Actions has already authenticated the primary ChatGPT process.
-    // Create independent normal BrowserWindows in that process on a headless
-    // runner: the official quick-chat prewarm RPC clears its previous window
-    // whenever it starts the next one, while a second Electron process can
-    // expose only an empty app:// root target. Each task still receives its
-    // own renderer and conversation; local desktop account sessions keep the
-    // isolated-process path below.
-    if queueAllowsVisibleDedicatedRenderer() {
+    // A local headless desktop run can create an independent BrowserWindow in
+    // the authenticated process. Hosted Actions deliberately uses the
+    // dedicated-process path below: the primary renderer is the controller,
+    // and borrowing it would let task cleanup close the controller or leave a
+    // bridge-less window for the next retry.
+    if queueAllowsVisibleDedicatedRenderer() && !runningOnGitHubActions() {
       queueTrace(
         "worker-create stage=headless-parallel-hidden-window-begin "
           + "account=\(effectiveAccountId)"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -395,6 +395,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /submenuExtraHighSelected: true/);
   assert.match(nativeSource, /const scope = quickChatRoot\(\) \|\| document;/);
   assert.match(nativeSource, /allPrefixedModelChoices\('Extra High'\)/);
+  assert.match(nativeSource, /quickChatKeyboardTarget/);
+  assert.match(nativeSource, /dispatchQuickChatArrowRight/);
+  assert.match(nativeSource, /quick-chat-thinking-keyboard-selection/);
   assert.match(nativeSource, /dispatchPointerClick\(picker\)/);
   assert.match(nativeSource, /model switcher is a Radix trigger/);
   assert.match(nativeSource, /\['instant', 'thinking', 'pro', 'extra high', 'high', 'medium', '极高', '额外高'\]\.some/);
@@ -411,6 +414,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource,
     /let maxConcurrent = min\(4, max\(1, state\.queueMaxConcurrent \?\? 2\)\)/);
   assert.match(nativeSource, /createIndependentQueueWorkerTarget/);
+  assert.match(nativeSource, /targetId != controllerTargetId/);
+  assert.match(nativeSource,
+    /queueAllowsVisibleDedicatedRenderer\(\) && !runningOnGitHubActions\(\)/);
   assert.match(nativeSource, /headless-parallel-hidden-window-begin/);
   assert.match(nativeSource, /headless-parallel-hidden-window-complete/);
   assert.match(nativeSource, /parallel-headless-chat-windows/);


### PR DESCRIPTION
## Root cause
Hosted Actions reused the controller renderer as a task window. Task cleanup then closed the controller, and retries only saw a bridge-less app shell. The first send also failed because the current model control is a five-position keyboard picker rather than a text menu.

## Fix
- Use a dedicated ChatGPT process for hosted Actions task renderers.
- Never select the controller renderer as a parallel task target.
- Select Thinking/Extra High through menu choices or the documented ArrowRight control, with redacted diagnostics.
- Extend contract assertions for renderer ownership and model-picker recovery.

Validation is performed by the GitHub Actions macOS build and plugin test workflow.