### PR TITLE
fix(actions): bootstrap hosted worker through launch services

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1307,12 +1307,66 @@ func waitForDedicatedRendererTarget(
   return false
 }
 
+func launchDedicatedQueueChatProcessViaLaunchServices(
+  profilePath: String,
+  port: Int,
+  codexHomePath: String? = nil
+) -> Bool {
+  // The hosted runner's direct Electron executable can expose an app root
+  // target without loading ChatGPT's preload bridge. The workflow's proven
+  // `open -na ... --args` path goes through LaunchServices and creates the
+  // renderer with the normal application bootstrap instead.
+  let configuration = NSWorkspace.OpenConfiguration()
+  configuration.activates = true
+  configuration.hides = false
+  configuration.addsToRecentItems = false
+  configuration.createsNewApplicationInstance = true
+  configuration.arguments = [
+    "--user-data-dir=\(profilePath)",
+    "--remote-debugging-port=\(port)",
+  ]
+  if let codexHomePath {
+    var environment = ProcessInfo.processInfo.environment
+    environment["CODEX_HOME"] = codexHomePath
+    configuration.environment = environment
+  }
+  let launchSemaphore = DispatchSemaphore(value: 0)
+  var launchError: Error?
+  NSWorkspace.shared.openApplication(
+    at: URL(fileURLWithPath: "/Applications/ChatGPT.app"),
+    configuration: configuration
+  ) { _, error in
+    launchError = error
+    launchSemaphore.signal()
+  }
+  _ = launchSemaphore.wait(timeout: .now() + 10.0)
+  guard launchError == nil else {
+    queueTrace(
+      "worker-create stage=dedicated-launchservices-first-error "
+        + "port=\(port) error=\(String(describing: launchError))"
+    )
+    return false
+  }
+  queueTrace(
+    "worker-create stage=dedicated-launchservices-first-start "
+      + "port=\(port) visible=true"
+  )
+  return true
+}
+
 func launchDedicatedQueueChatProcess(
   profilePath: String,
   port: Int,
   codexHomePath: String? = nil
 ) -> Bool {
   do {
+    if queueAllowsVisibleDedicatedRenderer() {
+      return launchDedicatedQueueChatProcessViaLaunchServices(
+        profilePath: profilePath,
+        port: port,
+        codexHomePath: codexHomePath
+      )
+    }
     let existingApplicationPids = Set(
       NSWorkspace.shared.runningApplications.compactMap { application -> pid_t? in
         guard let bundleIdentifier = application.bundleIdentifier,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -424,6 +424,8 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /Target.createTarget/);
   assert.match(nativeSource, /headless-window-target-ready/);
   assert.match(nativeSource, /dedicated-hosted-profile/);
+  assert.match(nativeSource, /launchDedicatedQueueChatProcessViaLaunchServices/);
+  assert.match(nativeSource, /dedicated-launchservices-first-start/);
   assert.match(nativeSource, /effectiveAccountId == hostedAccountId/);
   assert.match(nativeSource, /dedicated-avatar-overlay-navigation/);
   assert.match(nativeSource, /dedicated-empty-shell-navigation/);


### PR DESCRIPTION
Hosted Actions dedicated ChatGPT workers exposed an app root with bridge=false when launched through the Electron executable. Use the same LaunchServices open -na path already used by workflow authentication for hosted workers, then retain the strict renderer and login checks before model selection or sending.