### PR TITLE
fix(actions): capture model selection failure evidence

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -533,8 +533,62 @@ func sendMessageJS(
         || text.includes('额外高');
     }
 
+    function quickChatSliderElements() {
+      return [...document.querySelectorAll(
+        'input[type="range"], [role="slider"], [aria-valuenow], [aria-label*="of 5"], '
+          + '[aria-label*="adjust power"], [aria-label*="调整强度"]'
+      )].filter((element, index, all) => {
+        return element && all.indexOf(element) === index && visible(element);
+      });
+    }
+
+    function quickChatElementEvidence(element) {
+      if (!element) return null;
+      const rect = element.getBoundingClientRect?.();
+      return {
+        tag: element.tagName || '',
+        type: element.getAttribute('type') || '',
+        role: element.getAttribute('role') || '',
+        ariaLabel: element.getAttribute('aria-label') || '',
+        ariaValueNow: element.getAttribute('aria-valuenow') || '',
+        ariaValueMin: element.getAttribute('aria-valuemin') || '',
+        ariaValueMax: element.getAttribute('aria-valuemax') || '',
+        ariaValueText: element.getAttribute('aria-valuetext') || '',
+        tabIndex: element.getAttribute('tabindex') || '',
+        value: element.value == null ? '' : String(element.value),
+        selected: selectedChoice(element),
+        text: normalize(element.textContent).slice(0, 500),
+        outerHTML: (element.outerHTML || '').replace(/\\s+/g, ' ').slice(0, 900),
+        rect: rect ? {
+          x: Math.round(rect.x), y: Math.round(rect.y),
+          width: Math.round(rect.width), height: Math.round(rect.height)
+        } : null
+      };
+    }
+
+    function quickChatSelectionEvidence() {
+      const active = document.activeElement;
+      const menus = visibleModelMenus().map(menu => ({
+        tag: menu.tagName || '',
+        role: menu.getAttribute('role') || '',
+        text: normalize(menu.textContent).slice(0, 1200),
+        items: [...menu.querySelectorAll(
+          'button, [role="option"], [role="menuitem"], [role="menuitemradio"], '
+            + 'input, [role="slider"], [aria-valuenow]'
+        )].filter(visible).slice(0, 30).map(quickChatElementEvidence)
+      }));
+      return {
+        activeElement: quickChatElementEvidence(active),
+        sliders: quickChatSliderElements().slice(0, 20).map(quickChatElementEvidence),
+        picker: quickChatElementEvidence(modelPickerButton()),
+        menus,
+        visibleText: normalize(document.body?.innerText || '').slice(0, 5000)
+      };
+    }
+
     function quickChatKeyboardTarget() {
       const candidates = [
+        ...quickChatSliderElements(),
         document.activeElement,
         ...document.querySelectorAll(
           '[role="slider"], [aria-valuenow], [aria-label*="of 5"], '
@@ -560,8 +614,36 @@ func sendMessageJS(
         keyCode: 39,
         which: 39
       };
-      element.dispatchEvent(new KeyboardEvent('keydown', event));
-      element.dispatchEvent(new KeyboardEvent('keyup', event));
+      const keyDown = new KeyboardEvent('keydown', event);
+      const keyPress = new KeyboardEvent('keypress', event);
+      const keyUp = new KeyboardEvent('keyup', event);
+      // Chromium ignores keyCode/which in the KeyboardEvent constructor. Some
+      // Electron builds still use those legacy fields in their React handler,
+      // so define them explicitly before dispatching the synthetic event.
+      for (const keyboardEvent of [keyDown, keyPress, keyUp]) {
+        for (const [name, value] of [['keyCode', 39], ['which', 39]]) {
+          try { Object.defineProperty(keyboardEvent, name, {value}); } catch {}
+        }
+      }
+      element.dispatchEvent(keyDown);
+      element.dispatchEvent(keyPress);
+      element.dispatchEvent(keyUp);
+      return true;
+    }
+
+    function dispatchQuickChatEnter(element) {
+      if (!element) return false;
+      element.focus?.();
+      const event = {bubbles: true, cancelable: true, key: 'Enter', code: 'Enter'};
+      const keyDown = new KeyboardEvent('keydown', event);
+      const keyUp = new KeyboardEvent('keyup', event);
+      for (const keyboardEvent of [keyDown, keyUp]) {
+        for (const [name, value] of [['keyCode', 13], ['which', 13]]) {
+          try { Object.defineProperty(keyboardEvent, name, {value}); } catch {}
+        }
+      }
+      element.dispatchEvent(keyDown);
+      element.dispatchEvent(keyUp);
       return true;
     }
 
@@ -709,6 +791,17 @@ func sendMessageJS(
             selectedLabel = quickChatLabel(picker);
             quickChatConfirmed = quickChatStrongMode(selectedLabel);
           }
+          if (!quickChatConfirmed) {
+            // The five-position control commits its value on Enter in some
+            // desktop builds. Keep the menu open while committing so the
+            // subsequent evidence shows the exact active control and value.
+            const keyboardTarget = quickChatKeyboardTarget() || picker;
+            dispatchQuickChatEnter(keyboardTarget);
+            await sleep(500);
+            picker = modelPickerButton();
+            selectedLabel = quickChatLabel(picker);
+            quickChatConfirmed = quickChatStrongMode(selectedLabel);
+          }
         }
         if (!quickChatConfirmed) {
           return {
@@ -725,6 +818,7 @@ func sendMessageJS(
             quickChatKeyboardTargetLabel,
             visibleMenuText: visibleModelMenus()
               .map(menu => normalize(menu.textContent).slice(0, 500)),
+            modelSelectionEvidence: quickChatSelectionEvidence(),
             surface: chatSurfaceEvidence()
           };
         }
@@ -742,6 +836,7 @@ func sendMessageJS(
           quickChatChoiceClicked,
           quickChatKeyboardAttempts,
           quickChatKeyboardTargetLabel,
+          modelSelectionEvidence: quickChatSelectionEvidence(),
           verificationModelSelected: true,
           submenuExtraHighSelected: true,
           submenuHighSelected: true,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -2979,6 +2979,15 @@ func startAutomationTask(
   queueTrace(
     "task=\(task.id) stage=\(previousConversationId == nil ? "prepare-new-chat" : "prepare-continuation") complete"
   )
+  let modelSelectionBeforeScreenshot = captureHiddenChatScreenshot(
+    port: port,
+    targetId: targetId,
+    label: "model-selection-before"
+  )
+  queueTrace(
+    "task=\(task.id) stage=model-selection-before "
+      + "screenshot=\(modelSelectionBeforeScreenshot ?? "none")"
+  )
   let attempt = task.attempts + 1
   task.appliedRevision = max(1, task.currentRevision ?? 1)
   task.appliedSpecDigest = task.specDigest
@@ -3020,11 +3029,33 @@ func startAutomationTask(
     } else {
       stageDetails = "[]"
     }
+    let failureScreenshot = captureHiddenChatScreenshot(
+      port: port,
+      targetId: targetId,
+      label: "model-selection-failed"
+    )
+    let pageDiagnostic = cdpValue(
+      port: port,
+      targetId: targetId,
+      expression: pageDiagnosticJS(),
+      timeout: 5.0
+    )
+    var failureEvidence = sendResult
+    failureEvidence["screenshotPath"] = failureScreenshot as Any
+    failureEvidence["modelSelectionBeforeScreenshot"] = modelSelectionBeforeScreenshot as Any
+    failureEvidence["pageDiagnostic"] = pageDiagnostic as Any
+    task.lastResultJSON = jsonString(failureEvidence)
+    writeQueueConversationDiagnostic(task, finalReason: "start_failed")
+    queueTrace(
+      "task=\(task.id) stage=model-selection diagnostics "
+        + "screenshot=\(failureScreenshot ?? "none") "
+        + "beforeScreenshot=\(modelSelectionBeforeScreenshot ?? "none")"
+    )
     throw NSError(
       domain: "chatgpt-auto-confirm",
       code: 23,
       userInfo: [
-        NSLocalizedDescriptionKey: "任务 \(task.id) 页面发送失败（\(stage): \(error)） candidates: \(candidates) stages: \(stageDetails)"
+        NSLocalizedDescriptionKey: "任务 \(task.id) 页面发送失败（\(stage): \(error)） candidates: \(candidates) stages: \(stageDetails) screenshot: \(failureScreenshot ?? "none")"
       ]
     )
   }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -396,6 +396,10 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /const scope = quickChatRoot\(\) \|\| document;/);
   assert.match(nativeSource, /allPrefixedModelChoices\('Extra High'\)/);
   assert.match(nativeSource, /quickChatKeyboardTarget/);
+  assert.match(nativeSource, /quickChatSliderElements/);
+  assert.match(nativeSource, /quickChatSelectionEvidence/);
+  assert.match(nativeSource, /dispatchQuickChatEnter/);
+  assert.match(nativeSource, /modelSelectionEvidence/);
   assert.match(nativeSource, /dispatchQuickChatArrowRight/);
   assert.match(nativeSource, /quick-chat-thinking-keyboard-selection/);
   assert.match(nativeSource, /dispatchPointerClick\(picker\)/);
@@ -427,6 +431,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /hostedPersistentQueueUsesPrewarmWorker/);
   assert.match(nativeSource, /hosted-prewarm-worker-begin/);
   assert.match(nativeSource, /hosted-prewarm-worker-complete/);
+  assert.match(nativeSource, /model-selection-before/);
+  assert.match(nativeSource, /model-selection-failed/);
+  assert.match(nativeSource, /writeQueueConversationDiagnostic\(task, finalReason: "start_failed"\)/);
   assert.match(nativeSource, /CHATGPT_AUTO_CONFIRM_PARALLEL_STATE/);
   assert.match(nativeSource, /launchDedicatedQueueChatProcessViaLaunchServices/);
   assert.match(nativeSource, /dedicated-launchservices-first-start/);

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -408,6 +408,29 @@ jobs:
             -in "$STATE_PATH" \
             -out "${{ steps.paths.outputs.runtime_dir }}/queue-state.enc"
 
+      - name: Report diagnostic evidence inventory
+        if: always()
+        shell: bash
+        env:
+          RUNTIME_DIR: ${{ steps.paths.outputs.runtime_dir }}
+        run: |
+          set -euo pipefail
+          echo "Action diagnostic evidence:"
+          if [[ -d "$RUNTIME_DIR/diagnostics" ]]; then
+            find "$RUNTIME_DIR/diagnostics" -type f -print \
+              | sort \
+              | while IFS= read -r path; do
+                  bytes=$(stat -f '%z' "$path" 2>/dev/null || stat -c '%s' "$path")
+                  echo "  $path (${bytes} bytes)"
+                  if [[ "$path" == *.png ]] && command -v sips >/dev/null 2>&1; then
+                    sips -g pixelWidth -g pixelHeight "$path" 2>/dev/null \
+                      | sed 's#^#    #' || true
+                  fi
+                done
+          else
+            echo "  no diagnostics directory"
+          fi
+
       - name: Upload encrypted continuation state
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## What changed
- capture queue model-selection screenshots before and at failure
- persist structured slider/menu/ARIA diagnostics in the Action artifact
- use Chromium-compatible legacy key fields and Enter commit for the five-position picker
- print diagnostic inventory and PNG dimensions in the workflow log

## Validation
- GitHub Actions runtime validation will exercise the authenticated persistent queue.
- No authentication checks are relaxed.