### PR TITLE
fix(actions): retry empty renderer bootstrap with evidence

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -533,8 +533,62 @@ func sendMessageJS(
         || text.includes('额外高');
     }
 
+    function quickChatSliderElements() {
+      return [...document.querySelectorAll(
+        'input[type="range"], [role="slider"], [aria-valuenow], [aria-label*="of 5"], '
+          + '[aria-label*="adjust power"], [aria-label*="调整强度"]'
+      )].filter((element, index, all) => {
+        return element && all.indexOf(element) === index && visible(element);
+      });
+    }
+
+    function quickChatElementEvidence(element) {
+      if (!element) return null;
+      const rect = element.getBoundingClientRect?.();
+      return {
+        tag: element.tagName || '',
+        type: element.getAttribute('type') || '',
+        role: element.getAttribute('role') || '',
+        ariaLabel: element.getAttribute('aria-label') || '',
+        ariaValueNow: element.getAttribute('aria-valuenow') || '',
+        ariaValueMin: element.getAttribute('aria-valuemin') || '',
+        ariaValueMax: element.getAttribute('aria-valuemax') || '',
+        ariaValueText: element.getAttribute('aria-valuetext') || '',
+        tabIndex: element.getAttribute('tabindex') || '',
+        value: element.value == null ? '' : String(element.value),
+        selected: selectedChoice(element),
+        text: normalize(element.textContent).slice(0, 500),
+        outerHTML: (element.outerHTML || '').replace(/\\s+/g, ' ').slice(0, 900),
+        rect: rect ? {
+          x: Math.round(rect.x), y: Math.round(rect.y),
+          width: Math.round(rect.width), height: Math.round(rect.height)
+        } : null
+      };
+    }
+
+    function quickChatSelectionEvidence() {
+      const active = document.activeElement;
+      const menus = visibleModelMenus().map(menu => ({
+        tag: menu.tagName || '',
+        role: menu.getAttribute('role') || '',
+        text: normalize(menu.textContent).slice(0, 1200),
+        items: [...menu.querySelectorAll(
+          'button, [role="option"], [role="menuitem"], [role="menuitemradio"], '
+            + 'input, [role="slider"], [aria-valuenow]'
+        )].filter(visible).slice(0, 30).map(quickChatElementEvidence)
+      }));
+      return {
+        activeElement: quickChatElementEvidence(active),
+        sliders: quickChatSliderElements().slice(0, 20).map(quickChatElementEvidence),
+        picker: quickChatElementEvidence(modelPickerButton()),
+        menus,
+        visibleText: normalize(document.body?.innerText || '').slice(0, 5000)
+      };
+    }
+
     function quickChatKeyboardTarget() {
       const candidates = [
+        ...quickChatSliderElements(),
         document.activeElement,
         ...document.querySelectorAll(
           '[role="slider"], [aria-valuenow], [aria-label*="of 5"], '
@@ -560,8 +614,36 @@ func sendMessageJS(
         keyCode: 39,
         which: 39
       };
-      element.dispatchEvent(new KeyboardEvent('keydown', event));
-      element.dispatchEvent(new KeyboardEvent('keyup', event));
+      const keyDown = new KeyboardEvent('keydown', event);
+      const keyPress = new KeyboardEvent('keypress', event);
+      const keyUp = new KeyboardEvent('keyup', event);
+      // Chromium ignores keyCode/which in the KeyboardEvent constructor. Some
+      // Electron builds still use those legacy fields in their React handler,
+      // so define them explicitly before dispatching the synthetic event.
+      for (const keyboardEvent of [keyDown, keyPress, keyUp]) {
+        for (const [name, value] of [['keyCode', 39], ['which', 39]]) {
+          try { Object.defineProperty(keyboardEvent, name, {value}); } catch {}
+        }
+      }
+      element.dispatchEvent(keyDown);
+      element.dispatchEvent(keyPress);
+      element.dispatchEvent(keyUp);
+      return true;
+    }
+
+    function dispatchQuickChatEnter(element) {
+      if (!element) return false;
+      element.focus?.();
+      const event = {bubbles: true, cancelable: true, key: 'Enter', code: 'Enter'};
+      const keyDown = new KeyboardEvent('keydown', event);
+      const keyUp = new KeyboardEvent('keyup', event);
+      for (const keyboardEvent of [keyDown, keyUp]) {
+        for (const [name, value] of [['keyCode', 13], ['which', 13]]) {
+          try { Object.defineProperty(keyboardEvent, name, {value}); } catch {}
+        }
+      }
+      element.dispatchEvent(keyDown);
+      element.dispatchEvent(keyUp);
       return true;
     }
 
@@ -709,6 +791,17 @@ func sendMessageJS(
             selectedLabel = quickChatLabel(picker);
             quickChatConfirmed = quickChatStrongMode(selectedLabel);
           }
+          if (!quickChatConfirmed) {
+            // The five-position control commits its value on Enter in some
+            // desktop builds. Keep the menu open while committing so the
+            // subsequent evidence shows the exact active control and value.
+            const keyboardTarget = quickChatKeyboardTarget() || picker;
+            dispatchQuickChatEnter(keyboardTarget);
+            await sleep(500);
+            picker = modelPickerButton();
+            selectedLabel = quickChatLabel(picker);
+            quickChatConfirmed = quickChatStrongMode(selectedLabel);
+          }
         }
         if (!quickChatConfirmed) {
           return {
@@ -725,6 +818,7 @@ func sendMessageJS(
             quickChatKeyboardTargetLabel,
             visibleMenuText: visibleModelMenus()
               .map(menu => normalize(menu.textContent).slice(0, 500)),
+            modelSelectionEvidence: quickChatSelectionEvidence(),
             surface: chatSurfaceEvidence()
           };
         }
@@ -742,6 +836,7 @@ func sendMessageJS(
           quickChatChoiceClicked,
           quickChatKeyboardAttempts,
           quickChatKeyboardTargetLabel,
+          modelSelectionEvidence: quickChatSelectionEvidence(),
           verificationModelSelected: true,
           submenuExtraHighSelected: true,
           submenuHighSelected: true,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -2979,6 +2979,15 @@ func startAutomationTask(
   queueTrace(
     "task=\(task.id) stage=\(previousConversationId == nil ? "prepare-new-chat" : "prepare-continuation") complete"
   )
+  let modelSelectionBeforeScreenshot = captureHiddenChatScreenshot(
+    port: port,
+    targetId: targetId,
+    label: "model-selection-before"
+  )
+  queueTrace(
+    "task=\(task.id) stage=model-selection-before "
+      + "screenshot=\(modelSelectionBeforeScreenshot ?? "none")"
+  )
   let attempt = task.attempts + 1
   task.appliedRevision = max(1, task.currentRevision ?? 1)
   task.appliedSpecDigest = task.specDigest
@@ -3020,11 +3029,33 @@ func startAutomationTask(
     } else {
       stageDetails = "[]"
     }
+    let failureScreenshot = captureHiddenChatScreenshot(
+      port: port,
+      targetId: targetId,
+      label: "model-selection-failed"
+    )
+    let pageDiagnostic = cdpValue(
+      port: port,
+      targetId: targetId,
+      expression: pageDiagnosticJS(),
+      timeout: 5.0
+    )
+    var failureEvidence = sendResult
+    failureEvidence["screenshotPath"] = failureScreenshot as Any
+    failureEvidence["modelSelectionBeforeScreenshot"] = modelSelectionBeforeScreenshot as Any
+    failureEvidence["pageDiagnostic"] = pageDiagnostic as Any
+    task.lastResultJSON = jsonString(failureEvidence)
+    writeQueueConversationDiagnostic(task, finalReason: "start_failed")
+    queueTrace(
+      "task=\(task.id) stage=model-selection diagnostics "
+        + "screenshot=\(failureScreenshot ?? "none") "
+        + "beforeScreenshot=\(modelSelectionBeforeScreenshot ?? "none")"
+    )
     throw NSError(
       domain: "chatgpt-auto-confirm",
       code: 23,
       userInfo: [
-        NSLocalizedDescriptionKey: "任务 \(task.id) 页面发送失败（\(stage): \(error)） candidates: \(candidates) stages: \(stageDetails)"
+        NSLocalizedDescriptionKey: "任务 \(task.id) 页面发送失败（\(stage): \(error)） candidates: \(candidates) stages: \(stageDetails) screenshot: \(failureScreenshot ?? "none")"
       ]
     )
   }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -1,4 +1,6 @@
 import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const defaultPort = 9324;
@@ -32,6 +34,44 @@ const safeTargetSummary = targets => targets.map(target => ({
 }));
 
 const targetKey = target => `${target?.id || ''}|${target?.webSocketDebuggerUrl || ''}`;
+
+const diagnosticTimestamp = () => new Date().toISOString()
+  .replace(/[^0-9]/g, '')
+  .slice(0, 17);
+
+const writeDiagnosticEvidence = ({ directory, label, payload }) => {
+  if (!directory) return null;
+  try {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const path = join(directory, `renderer-${label}-${diagnosticTimestamp()}.json`);
+    writeFileSync(path, `${JSON.stringify({
+      recordedAt: new Date().toISOString(),
+      ...payload,
+    }, null, 2)}\n`, { mode: 0o600 });
+    return path;
+  } catch {
+    return null;
+  }
+};
+
+const captureDiagnosticScreenshot = async ({ connection, directory, label }) => {
+  if (!connection || !directory) return null;
+  try {
+    const result = await connection.call('Page.captureScreenshot', {
+      format: 'png',
+      captureBeyondViewport: true,
+      fromSurface: true,
+    }, 5_000);
+    const encoded = String(result?.data || '');
+    if (!encoded) return null;
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const path = join(directory, `renderer-${label}-${diagnosticTimestamp()}.png`);
+    writeFileSync(path, Buffer.from(encoded, 'base64'), { mode: 0o600 });
+    return path;
+  } catch {
+    return null;
+  }
+};
 
 const approveHeadlessChatGPTLocalNetworkPrompt = ({
   platform = process.platform,
@@ -329,6 +369,7 @@ const recoverAppRootConnection = async ({
   log,
   createRootTargetImpl,
   beforeProbeImpl = () => {},
+  diagnosticsDir,
 }) => {
   const deadline = nowImpl() + timeoutMs;
   let active = connection;
@@ -337,6 +378,39 @@ const recoverAppRootConnection = async ({
   let navigationAttempts = 0;
   let rootTargetCreationAttempts = 0;
   let lastNavigationAt = 0;
+
+  const recordEvidence = async (label, extra = {}, screenshotConnection = active) => {
+    const screenshotPath = await captureDiagnosticScreenshot({
+      connection: screenshotConnection,
+      directory: diagnosticsDir,
+      label,
+    });
+    const evidencePath = writeDiagnosticEvidence({
+      directory: diagnosticsDir,
+      label,
+      payload: {
+        phase: label,
+        label,
+        targets: safeTargetSummary(lastTargets),
+        navigationAttempts,
+        rootTargetCreationAttempts,
+        lastError,
+        screenshotPath,
+        ...extra,
+      },
+    });
+    if (diagnosticsDir) {
+      log(`Renderer diagnostic ${label}: ${JSON.stringify({
+        screenshotPath: screenshotPath || null,
+        evidencePath: evidencePath || null,
+        targetCount: lastTargets.length,
+        navigationAttempts,
+        rootTargetCreationAttempts,
+        lastError: lastError || null,
+      })}`);
+    }
+    return { screenshotPath, evidencePath };
+  };
 
   const createRootTargetIfNeeded = async () => {
     if (rootTargetCreationAttempts >= 2 || typeof createRootTargetImpl !== 'function') return;
@@ -358,6 +432,7 @@ const recoverAppRootConnection = async ({
       lastError = error instanceof Error ? error.message : String(error);
     }
     if (isAvatarOverlay({ url: currentURL })) {
+      await recordEvidence('before-overlay-navigation', { currentURL });
       const navigated = await optionalCall(
         active.call,
         'Page.navigate',
@@ -384,6 +459,10 @@ const recoverAppRootConnection = async ({
       lastTargets = await listTargets(fetchImpl, port);
       const normalTarget = pickTarget(lastTargets, isNormalAppTarget);
       if (normalTarget) {
+        await recordEvidence('normal-renderer-ready', {
+          targetId: String(normalTarget.id || '').slice(0, 48),
+          targetURL: targetURL(normalTarget),
+        }, active);
         if (active && targetKey(active.target) === targetKey(normalTarget)) {
           return active;
         }
@@ -400,6 +479,10 @@ const recoverAppRootConnection = async ({
           active = await connect(overlayTarget, { WebSocketImpl });
         }
         if (navigationAttempts < 2) {
+          await recordEvidence('before-overlay-retry-navigation', {
+            targetId: String(overlayTarget.id || '').slice(0, 48),
+            targetURL: targetURL(overlayTarget),
+          });
           const navigated = await optionalCall(
             active.call,
             'Page.navigate',
@@ -421,6 +504,16 @@ const recoverAppRootConnection = async ({
         // request. Create a fresh normal app target through the browser CDP
         // endpoint instead of waiting for the retired overlay to reappear.
         await createRootTargetIfNeeded();
+      } else if (rootTargetCreationAttempts < 2) {
+        // Page.navigate can retire the only renderer before the caller gets
+        // here. In that state there is no overlay and no navigation attempt
+        // left to trigger the old fallback, so actively ask the browser CDP
+        // endpoint for a fresh authenticated app root instead of polling an
+        // empty target list until the timeout.
+        await recordEvidence('empty-target-list-before-root-retry', {
+          reason: 'no_normal_or_overlay_target',
+        }, null);
+        await createRootTargetIfNeeded();
       }
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
@@ -431,6 +524,9 @@ const recoverAppRootConnection = async ({
   }
 
   closeConnection(active);
+  await recordEvidence('renderer-recovery-timeout', {
+    reason: 'reconnect_deadline_exhausted',
+  }, active);
   throw new Error(`${label} was not ready (${JSON.stringify({
     lastError,
     navigationAttempts,
@@ -500,6 +596,7 @@ export async function restoreSession({
   verificationTimeoutMs = 120_000,
   createRootTargetImpl,
   log = message => process.stderr.write(`${message}\n`),
+  diagnosticsDir = process.env.CHATGPT_AUTO_CONFIRM_DIAGNOSTICS_DIR || '',
 } = {}) {
   if (!['seed', 'restore', 'verify', 'restore-and-verify'].includes(mode)) {
     throw new Error(`Unsupported CHATGPT_SESSION_MODE: ${mode}`);
@@ -569,6 +666,7 @@ export async function restoreSession({
       log,
       createRootTargetImpl: rootTargetCreator,
       beforeProbeImpl,
+      diagnosticsDir,
     });
 
     if (mode === 'restore' || mode === 'restore-and-verify') {
@@ -618,6 +716,7 @@ export async function restoreSession({
         log,
         createRootTargetImpl: rootTargetCreator,
         beforeProbeImpl,
+        diagnosticsDir,
       });
       await activate(connection.call, log);
     }
@@ -651,6 +750,7 @@ export async function restoreSession({
             log,
             createRootTargetImpl: rootTargetCreator,
             beforeProbeImpl,
+            diagnosticsDir,
           });
           continue;
         }
@@ -676,6 +776,7 @@ export async function restoreSession({
             log,
             createRootTargetImpl: rootTargetCreator,
             beforeProbeImpl,
+            diagnosticsDir,
           });
         } catch (recoveryError) {
           lastState.recoveryError = recoveryError instanceof Error

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -396,6 +396,10 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /const scope = quickChatRoot\(\) \|\| document;/);
   assert.match(nativeSource, /allPrefixedModelChoices\('Extra High'\)/);
   assert.match(nativeSource, /quickChatKeyboardTarget/);
+  assert.match(nativeSource, /quickChatSliderElements/);
+  assert.match(nativeSource, /quickChatSelectionEvidence/);
+  assert.match(nativeSource, /dispatchQuickChatEnter/);
+  assert.match(nativeSource, /modelSelectionEvidence/);
   assert.match(nativeSource, /dispatchQuickChatArrowRight/);
   assert.match(nativeSource, /quick-chat-thinking-keyboard-selection/);
   assert.match(nativeSource, /dispatchPointerClick\(picker\)/);
@@ -427,6 +431,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /hostedPersistentQueueUsesPrewarmWorker/);
   assert.match(nativeSource, /hosted-prewarm-worker-begin/);
   assert.match(nativeSource, /hosted-prewarm-worker-complete/);
+  assert.match(nativeSource, /model-selection-before/);
+  assert.match(nativeSource, /model-selection-failed/);
+  assert.match(nativeSource, /writeQueueConversationDiagnostic\(task, finalReason: "start_failed"\)/);
   assert.match(nativeSource, /CHATGPT_AUTO_CONFIRM_PARALLEL_STATE/);
   assert.match(nativeSource, /launchDedicatedQueueChatProcessViaLaunchServices/);
   assert.match(nativeSource, /dedicated-launchservices-first-start/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
@@ -20,12 +20,14 @@ class FakeCDPServer {
     replaceOnAuthFailure = false,
     stuckOverlay = false,
     navigationFailure = false,
+    rootTargetFailures = 0,
   }) {
     this.targets = [appTarget('initial', initialURL)];
     this.loginPrompt = loginPrompt;
     this.replaceOnAuthFailure = replaceOnAuthFailure;
     this.stuckOverlay = stuckOverlay;
     this.navigationFailure = navigationFailure;
+    this.rootTargetFailures = rootTargetFailures;
     this.failAuthEvaluation = replaceOnAuthFailure;
     this.connections = [];
     this.closedSockets = 0;
@@ -50,6 +52,10 @@ class FakeCDPServer {
 
   createRootTarget = async () => {
     this.rootTargetCreations += 1;
+    if (this.rootTargetCreations <= this.rootTargetFailures) {
+      this.targets = [];
+      return null;
+    }
     this.replaceTarget('after-root-create', 'app://-/index.html?initialRoute=%2F');
     return 'after-root-create';
   };
@@ -208,11 +214,12 @@ test('creates a fresh root target when overlay navigation retires the renderer',
   const server = new FakeCDPServer({
     initialURL: 'app://-/index.html?initialRoute=%2Favatar-overlay',
     navigationFailure: true,
+    rootTargetFailures: 1,
   });
 
   const output = await run(server, { headless: true });
   assert.match(output, /^Verified authenticated desktop shell/);
-  assert.ok(server.rootTargetCreations >= 1);
+  assert.ok(server.rootTargetCreations >= 2);
   assert.ok(server.connections.some(item => item.target?.id === 'after-root-create'));
 });
 

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -275,6 +275,7 @@ jobs:
         shell: bash
         env:
           PROFILE_DIR: ${{ steps.paths.outputs.profile_dir }}
+          CHATGPT_AUTO_CONFIRM_DIAGNOSTICS_DIR: ${{ steps.paths.outputs.runtime_dir }}/diagnostics
         run: |
           set -euo pipefail
           test -n "$CHATGPT_SESSION_COOKIES_B64"

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -408,6 +408,29 @@ jobs:
             -in "$STATE_PATH" \
             -out "${{ steps.paths.outputs.runtime_dir }}/queue-state.enc"
 
+      - name: Report diagnostic evidence inventory
+        if: always()
+        shell: bash
+        env:
+          RUNTIME_DIR: ${{ steps.paths.outputs.runtime_dir }}
+        run: |
+          set -euo pipefail
+          echo "Action diagnostic evidence:"
+          if [[ -d "$RUNTIME_DIR/diagnostics" ]]; then
+            find "$RUNTIME_DIR/diagnostics" -type f -print \
+              | sort \
+              | while IFS= read -r path; do
+                  bytes=$(stat -f '%z' "$path" 2>/dev/null || stat -c '%s' "$path")
+                  echo "  $path (${bytes} bytes)"
+                  if [[ "$path" == *.png ]] && command -v sips >/dev/null 2>&1; then
+                    sips -g pixelWidth -g pixelHeight "$path" 2>/dev/null \
+                      | sed 's#^#    #' || true
+                  fi
+                done
+          else
+            echo "  no diagnostics directory"
+          fi
+
       - name: Upload encrypted continuation state
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Root cause from hosted Action 30971132902
- Page.navigate timed out after the avatar/normal renderer was replaced.
- Target.createTarget also timed out, leaving /json/list empty.
- Recovery then polled an empty target list without another root-target creation attempt, so auth preflight failed before the queue.

## Fix
- retry authenticated app-root creation when no normal or overlay renderer exists
- persist redacted renderer target diagnostics and capture CDP screenshots at recovery stages
- print screenshot/evidence inventory in the Action log

## Validation
- remote runtime validation and tests will run on GitHub Actions
- login-page rejection remains unchanged