### PR TITLE
fix(actions): recover throttled Chat queue dispatches

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -547,6 +547,18 @@ func monitorAutomationTask(
      let chatURL = liveStatus["chatUrl"] as? String {
     task.chatURL = chatURL
   }
+  let completedActivity = reply["completedActivity"] as? String ?? ""
+  let visibleContent = reply["content"] as? String ?? ""
+  let connectionText = [
+    visibleContent,
+    completedActivity,
+    reply["devspaceActivity"] as? String ?? "",
+    // `pageContent` also contains the queue's own user instruction, which
+    // deliberately documents network errors. Inspect only assistant/tool
+    // activity so the prompt can never trigger a false network outage.
+    reply["thinking"] as? String ?? ""
+  ].joined(separator: "\n")
+  let recoverySignal = networkRecoverySignal(connectionText)
   let activitySignature = reply["activitySignature"] as? String ?? ""
   let activityCharCount = reply["activityCharCount"] as? Int ?? 0
   if !activitySignature.isEmpty && activitySignature != task.lastActivitySignature {
@@ -557,10 +569,12 @@ func monitorAutomationTask(
     // real task progress or postpone interruption recovery.
     if activityCharCount >= 80 {
       task.lastProgressAt = now
-      state.queueNetworkFailureCount = 0
-      state.queueNetworkStatus = "online"
-      state.queueNetworkLastError = nil
-      state.queueNetworkWaitUntil = nil
+      if recoverySignal == nil {
+        state.queueNetworkFailureCount = 0
+        state.queueNetworkStatus = "online"
+        state.queueNetworkLastError = nil
+        state.queueNetworkWaitUntil = nil
+      }
     }
   }
   task.updatedAt = now
@@ -588,18 +602,7 @@ func monitorAutomationTask(
     return
   }
 
-  let completedActivity = reply["completedActivity"] as? String ?? ""
-  let visibleContent = reply["content"] as? String ?? ""
-  let connectionText = [
-    visibleContent,
-    completedActivity,
-    reply["devspaceActivity"] as? String ?? "",
-    // `pageContent` also contains the queue's own user instruction, which
-    // deliberately documents network errors. Inspect only assistant/tool
-    // activity so the prompt can never trigger a false network outage.
-    reply["thinking"] as? String ?? ""
-  ].joined(separator: "\n")
-  if let signal = networkRecoverySignal(connectionText) {
+  if let signal = recoverySignal {
     closeDedicatedAutomationTarget(task, state: state)
     queueNetworkRecovery(&task, state: &state, reason: signal)
     return

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueState.swift
@@ -263,8 +263,10 @@ func networkRecoverySignal(_ value: String) -> String? {
     "internet disconnected", "could not resolve host", "dns lookup failed",
     "connection reset", "connection refused", "connection timed out",
     "upstream 502", "http 502", "http 503", "http 504",
+    "request failed with status 429", "http 429", "too many requests",
     "devspace_tool_timeout", "网络断开", "网络不可用", "无法解析主机",
-    "连接被重置", "连接超时", "上游 502", "上游 503", "上游 504"
+    "连接被重置", "连接超时", "上游 502", "上游 503", "上游 504",
+    "请求过于频繁"
   ]
   guard let marker = markers.first(where: { text.contains($0) }) else { return nil }
   return marker

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/prepare-action-state.mjs
@@ -38,18 +38,31 @@ for (const task of state.automationTasks || []) {
   task.workerProfilePath = null;
   task.resultPath = null;
   if (task.status === 'running') {
-    // Keep both the active state and Chat identity across hosted runner
-    // rotation. monitorAutomationTask recreates only the hidden renderer,
-    // navigates back to this durable conversation, confirms pending
-    // authorization, and observes its real terminal state. Re-queuing here
-    // would skip that recovery and create a new Chat before the prior one had
-    // actually finished.
-    // Refresh only the handoff heartbeat so the startup watchdog does not
-    // declare the task stale before the first monitor pass can reattach.
-    task.lastProgressAt = new Date().toISOString();
-    task.lastError = 'github_actions_runner_continuation';
-    const note = 'GitHub Actions 已在新托管 Runner 中接管。请从同一 checkout 的最新落盘进度继续。';
-    task.reviewFeedback = [task.reviewFeedback, note].filter(Boolean).join('\n\n');
+    if (String(task.conversationId || '').startsWith('local-chatgpt:')) {
+      // A local-only id belongs to the renderer on the previous hosted VM.
+      // It has no server route to restore, so preserving it as running makes
+      // every continuation stare at a provisional Chat that can never appear
+      // in the account sidebar. Requeue once and create a fresh Chat instead.
+      task.status = 'queued';
+      task.startedAt = null;
+      task.lastProgressAt = null;
+      task.conversationId = null;
+      task.chatURL = null;
+      task.lastError = 'github_actions_local_chat_requeued';
+      const note = '上一托管 Runner 只留下本地临时 Chat，无法恢复；请在新 Chat 中从同一 checkout 的落盘进度继续。';
+      task.reviewFeedback = [task.reviewFeedback, note].filter(Boolean).join('\n\n');
+    } else {
+      // Keep both the active state and durable Chat identity across hosted
+      // runner rotation. monitorAutomationTask recreates only the hidden
+      // renderer, navigates back to this conversation, confirms pending
+      // authorization, and observes its real terminal state.
+      // Refresh only the handoff heartbeat so the startup watchdog does not
+      // declare the task stale before the first monitor pass can reattach.
+      task.lastProgressAt = new Date().toISOString();
+      task.lastError = 'github_actions_runner_continuation';
+      const note = 'GitHub Actions 已在新托管 Runner 中接管。请从同一 checkout 的最新落盘进度继续。';
+      task.reviewFeedback = [task.reviewFeedback, note].filter(Boolean).join('\n\n');
+    }
   }
   if (['failed', 'blocked'].includes(task.status)) {
     task.status = 'queued';

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/run-dynamic-actions-controller.mjs
@@ -438,6 +438,10 @@ while (!stopping && Date.now() < deadline) {
       env: {
         ...process.env,
         ACTION_SESSION_SECONDS: String(Math.min(remainingSeconds, 20_100)),
+        // The outer dynamic controller owns versioned task reconciliation.
+        // Disable the legacy child refresher so it neither targets the
+        // logical id nor tries to inline a specification larger than 60 KB.
+        ACTION_DISABLE_TASK_REFRESH: 'true',
       },
       stdio: ['ignore', 'inherit', 'inherit'],
     });

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -676,6 +676,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /waiting_for_network_recovery/);
   assert.match(nativeSource, /queueNetworkRecovery/);
   assert.match(nativeSource, /SCNetworkReachabilityCreateWithName/);
+  assert.match(nativeSource, /request failed with status 429/);
+  assert.match(nativeSource, /too many requests/);
+  assert.match(nativeSource, /recoverySignal == nil/);
   assert.match(nativeSource, /next_connector/);
   assert.match(nativeSource, /云端 GitHub 状态必须通过 GitHub 连接器核验/);
   assert.match(nativeSource, /本地 checkout、Git\/gh 元数据与安全同步必须使用 bhrum2/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/dynamic-actions-controller.test.mjs
@@ -32,6 +32,7 @@ test('persistent Actions runner polls the main-branch task control file', () => 
   assert.match(controller, /entry\.sha/);
   assert.match(controller, /createHash\('sha256'\)/);
   assert.match(controller, /pollSeconds \* 1_000/);
+  assert.match(controller, /ACTION_DISABLE_TASK_REFRESH: 'true'/);
 });
 
 test('goal versions are idempotent and dependencies use desired runtime ids', () => {

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/prepare-action-state.test.mjs
@@ -52,3 +52,46 @@ test('hosted runner rotation preserves the conversation needed for serial contin
   assert.equal(task.workerTargetId, null);
   assert.equal(task.lastError, 'github_actions_runner_continuation');
 });
+
+test('hosted runner rotation requeues a local-only provisional Chat', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'chatgpt-action-local-state-'));
+  const statePath = join(directory, 'queue-state.json');
+  writeFileSync(statePath, JSON.stringify({
+    enabled: true,
+    automationTasks: [{
+      id: 'local-continuation-task',
+      status: 'running',
+      attempts: 38,
+      continuationDepth: 37,
+      startedAt: '2026-08-06T14:14:11Z',
+      lastProgressAt: '2026-08-06T14:15:00Z',
+      conversationId: 'local-chatgpt:provisional-id',
+      chatURL: null,
+      workerPid: 123,
+      workerPort: 9324,
+      workerTargetId: 'old-target',
+    }],
+  }));
+
+  const result = spawnSync(process.execPath, [scriptPath], {
+    env: {
+      ...process.env,
+      CHATGPT_AUTO_CONFIRM_QUEUE_STATE: statePath,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+
+  const prepared = JSON.parse(readFileSync(statePath, 'utf8'));
+  const [task] = prepared.automationTasks;
+  assert.equal(task.status, 'queued');
+  assert.equal(task.startedAt, null);
+  assert.equal(task.lastProgressAt, null);
+  assert.equal(task.conversationId, null);
+  assert.equal(task.chatURL, null);
+  assert.equal(task.workerPid, null);
+  assert.equal(task.workerPort, null);
+  assert.equal(task.workerTargetId, null);
+  assert.equal(task.lastError, 'github_actions_local_chat_requeued');
+  assert.match(task.reviewFeedback, /本地临时 Chat/);
+});


### PR DESCRIPTION
## What changed

- treat ChatGPT HTTP 429 / rate-limit responses as recoverable upstream failures
- keep exponential recovery state instead of resetting it when the error text changes
- close the failed provisional renderer, wait with bounded backoff, and retry in a fresh Chat
- requeue `local-chatgpt:` identities when a hosted runner rotates because they have no durable server route
- disable the legacy child task refresher; the dynamic controller remains the single owner of versioned task reconciliation and no longer rejects the >60 KB specification snapshot
- add focused regression coverage for provisional Chat restoration, 429 classification, backoff state, and controller ownership

## Root cause

Run 31109731727 had a running task with a `local-chatgpt:` conversation id, zero assistant messages, `Request failed with status 429`, about 38 attempts, and 37 continuation levels. The queue classified the page as pending progress, repeatedly restored/continued the provisional Chat, and never obtained a durable conversation id that could appear in the ChatGPT sidebar. The legacy task refresher also rejected the current specification because it exceeded 60,000 characters.

## Validation

Per repository policy, project tests/builds are delegated to GitHub Actions. No project test, build, package, install, or dependency command was run on bhrum2. The local preparation check was limited to clean Git diff validation.