### PR TITLE
fix(actions): recognize approval Enter-key hints

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -1769,7 +1769,9 @@ func getReplyJS() -> String {
     }
 
     const approvalButton = [...main.querySelectorAll('button, a, [role="button"]')].find(button => {
-      const text = (button.innerText || button.getAttribute('aria-label') || button.getAttribute('title') || '').trim().toLowerCase();
+      const text = (button.innerText || button.getAttribute('aria-label') || button.getAttribute('title') || '')
+        .replace(/[\s\u21b5\u23ce]+/g, ' ')
+        .trim().toLowerCase();
       return visible(button) && [
         '完全访问', 'full access', 'allow', 'allow once',
         '允许', '允许一次', 'approve', 'approve once',

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -1295,7 +1295,7 @@ func autoConfirmChatContinuationJS() -> String {
 func detectDedicatedAuthorizationJS() -> String {
   #"""
   (() => {
-    const normalize = value => (value || '').replace(/[\s↵]+/g, ' ').trim().toLowerCase();
+    const normalize = value => (value || '').replace(/[\s↵⏎]+/g, ' ').trim().toLowerCase();
     const visible = element => !!(element
       && !element.disabled
       && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
@@ -1399,7 +1399,7 @@ func autoApproveDedicatedAuthorizationJS() -> String {
   #"""
   (async () => {
     const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
-    const normalize = value => (value || '').replace(/[\s\u21b5]+/g, ' ').trim().toLowerCase();
+    const normalize = value => (value || '').replace(/[\s\u21b5\u23ce]+/g, ' ').trim().toLowerCase();
     const rendered = element => !!(element
       && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
     const visible = element => rendered(element) && !element.disabled;

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -933,6 +933,57 @@ test('session-scoped approval opens the adjacent menu and selects the conversati
   assert.equal(clicks.includes('allow'), false);
 });
 
+test('allow-once approval ignores the rendered Enter keyboard hint', async () => {
+  const clicks = [];
+  class FakeEvent {
+    constructor(type) { this.type = type; }
+  }
+  class FakeElement {
+    constructor(id, text) {
+      this.id = id;
+      this.innerText = text;
+      this.textContent = text;
+      this.disabled = false;
+      this.offsetWidth = 80;
+      this.offsetHeight = 24;
+      this.isConnected = true;
+      this.parentElement = null;
+    }
+    getAttribute() { return null; }
+    getClientRects() { return this.isConnected ? [{}] : []; }
+    getBoundingClientRect() {
+      return { left: 0, top: 0, width: this.offsetWidth, height: this.offsetHeight };
+    }
+    querySelectorAll() { return []; }
+    dispatchEvent(event) {
+      if (event.type !== 'click') return true;
+      clicks.push(this.id);
+      if (this.id === 'allow-once') {
+        this.isConnected = false;
+        this.offsetWidth = 0;
+        this.offsetHeight = 0;
+      }
+      return true;
+    }
+  }
+  const deny = new FakeElement('deny', 'Deny\nEscape');
+  const allowOnce = new FakeElement('allow-once', 'Allow once\n⏎');
+  const card = new FakeElement('card', 'Allow ChatGPT to use bhrum2?');
+  card.querySelectorAll = () => [deny, allowOnce];
+  deny.parentElement = card;
+  allowOnce.parentElement = card;
+  const document = { querySelectorAll: selector => selector === 'button' ? [deny, allowOnce] : [] };
+  const result = await runInNewContext(approvalScript, {
+    document, PointerEvent: FakeEvent, MouseEvent: FakeEvent, setTimeout,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.confirmed, true);
+  assert.equal(result.strategy, 'single-approval');
+  assert.equal(result.label, 'allow once');
+  assert.deepEqual(clicks, ['allow-once']);
+  assert.match(chatScriptsSource, /\\u21b5\\u23ce/);
+});
+
 test('approval decisions do not inspect or block card contents', () => {
   assert.match(nativeSource, /allRecognizedApprovalsEnabled/);
   assert.match(nativeSource, /自动确认所有 ChatGPT 授权卡/);


### PR DESCRIPTION
## Root cause

The current ChatGPT authorization card renders the primary action as `Allow once` plus a visible Enter-key hint (`⏎`). Approval detection normalized the older `↵` glyph only, so the exact-label match failed. The queue kept streaming until it reached the card, then stopped making progress without invoking the approval flow.

## Fix

- normalize both Enter glyph variants in approval discovery and clicking
- apply the same normalization to queue reply-state detection
- add a focused regression test reproducing `Allow once\n⏎`

## Live evidence

Run 31116648791 reached the `bhrum2` authorization card with `attempts: 1`, no HTTP 429, and no task-definition refresh warning, but `approvalTitle` stayed empty and progress stopped at the card.

Validation is delegated to GitHub Actions.