### PR TITLE
fix(actions): persist durable ChatGPT conversations

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/ChatScripts.swift
@@ -1382,11 +1382,17 @@ func sendMessageJS(
     result.dispatchOnly = true;
     result.ok = true;
     result.url = window.location.href || '';
-    const activeRow = [...document.querySelectorAll('[data-thread-title="true"]')]
+    const activeRowAnchor = document.querySelector(
+      'a[aria-current="page"][href*="/c/"], a[aria-current="page"][href*="/work/conversation/"]'
+    );
+    const activeRow = activeRowAnchor || [...document.querySelectorAll('[data-thread-title="true"]')]
       .map(title => title.closest('[role="button"]'))
       .find(row => row?.getAttribute('aria-current') === 'page');
     const activeRowConversationIds = [];
     if (activeRow) {
+      const hrefMatch = activeRow.getAttribute('href')
+        ?.match(/\\/(?:c|work\\/conversation)\\/([^/?#]+)/);
+      if (hrefMatch) activeRowConversationIds.push(decodeURIComponent(hrefMatch[1]));
       const fiberKey = Object.keys(activeRow).find(key => key.startsWith('__reactFiber$'));
       let fiber = fiberKey ? activeRow[fiberKey] : null;
       for (let depth = 0; fiber && depth < 8; depth += 1, fiber = fiber.return) {
@@ -1981,11 +1987,17 @@ func chatStatusJS() -> String {
   const portalConversationId = portalConversation.startsWith('chatgpt:')
     ? portalConversation.slice('chatgpt:'.length)
     : portalConversation;
-  const activeRow = [...document.querySelectorAll('[data-thread-title="true"]')]
+  const activeRowAnchor = document.querySelector(
+    'a[aria-current="page"][href*="/c/"], a[aria-current="page"][href*="/work/conversation/"]'
+  );
+  const activeRow = activeRowAnchor || [...document.querySelectorAll('[data-thread-title="true"]')]
     .map(title => title.closest('[role="button"]'))
     .find(row => row?.getAttribute('aria-current') === 'page');
   const activeRowConversationIds = [];
   if (activeRow) {
+    const hrefMatch = activeRow.getAttribute('href')
+      ?.match(/\\/(?:c|work\\/conversation)\\/([^/?#]+)/);
+    if (hrefMatch) activeRowConversationIds.push(decodeURIComponent(hrefMatch[1]));
     const fiberKey = Object.keys(activeRow).find(key => key.startsWith('__reactFiber$'));
     let fiber = fiberKey ? activeRow[fiberKey] : null;
     for (let depth = 0; fiber && depth < 8; depth += 1, fiber = fiber.return) {
@@ -1998,12 +2010,17 @@ func chatStatusJS() -> String {
     || activeRowConversationIds[0]
     || null;
   const conversationId = routeConversationId
-    || portalConversationId
+    || (portalConversationId && !portalConversationId.startsWith('local-chatgpt:')
+      ? portalConversationId : null)
     || activeConversationId
+    || portalConversationId
     || null;
   const conversationSource = routeConversationId
     ? 'route'
-    : (portalConversationId ? 'portal' : (activeConversationId ? 'active-row' : 'none'));
+    : (portalConversationId && !portalConversationId.startsWith('local-chatgpt:')
+      ? 'portal'
+      : (activeConversationId ? 'active-row'
+        : (portalConversationId ? 'portal-local' : 'none')));
   const chatUrl = conversationId && !conversationId.startsWith('local-chatgpt:')
     ? `https://chatgpt.com/c/${conversationId}`
     : null;

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -688,15 +688,34 @@ func resolveDispatchedConversationJS(
     );
     const rowCandidates = () => {
       const values = [];
-      const rows = [...document.querySelectorAll('[data-thread-title="true"]')]
-        .map(title => title.closest('[role="button"]'))
-        .filter(Boolean);
+      const rows = [...new Set(
+        [...document.querySelectorAll(
+          '[data-thread-title="true"], a[href*="/c/"], a[href*="/work/conversation/"]'
+        )]
+          .map(element => element.closest('[role="button"], a[href]'))
+          .filter(Boolean)
+      )];
       for (const row of rows) {
-        const title = (row.querySelector('[data-thread-title="true"]')?.textContent || '').trim();
+        const title = (
+          row.querySelector('[data-thread-title="true"]')?.textContent
+            || row.textContent || ''
+        ).trim();
         const fiberKey = Object.keys(row).find(key => key.startsWith('__reactFiber$'));
         let fiber = fiberKey ? row[fiberKey] : null;
         const identities = [];
         const durableIds = [];
+        for (const attribute of ['data-conversation-id', 'data-thread-id']) {
+          identities.push(row.getAttribute(attribute));
+        }
+        const routeValues = [
+          row.getAttribute('href'),
+          ...[...row.querySelectorAll('a[href]')].map(anchor => anchor.getAttribute('href'))
+        ];
+        for (const route of routeValues) {
+          if (typeof route !== 'string') continue;
+          const match = route.match(/\\/(?:c|work\\/conversation)\\/([^/?#]+)/);
+          if (match) identities.push(match[1]), durableIds.push(match[1]);
+        }
         for (let depth = 0; fiber && depth < 8; depth += 1, fiber = fiber.return) {
           const props = fiber.memoizedProps || {};
           identities.push(props.conversationId, props.conversation?.id);
@@ -705,7 +724,7 @@ func resolveDispatchedConversationJS(
           }
           for (const route of [props.route, props.shortcutKey]) {
             if (typeof route !== 'string') continue;
-            const match = route.match(/^\\/work\\/conversation\\/([^/?#]+)/);
+            const match = route.match(/\\/(?:c|work\\/conversation)\\/([^/?#]+)/);
             if (match) identities.push(match[1]);
           }
         }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -420,9 +420,10 @@ func monitorAutomationTask(
       // authoritative enough to replace that local id; an active-row-only id
       // must not bind the task to the stale sidebar conversation.
       let identitySource = liveStatus["conversationSource"] as? String
-      let canPromoteLocalId = !conversationId.hasPrefix("local-chatgpt:")
-        || identitySource == "route"
-        || identitySource == "portal"
+      let canPromoteLocalId = !observed.hasPrefix("local-chatgpt:")
+        && (!conversationId.hasPrefix("local-chatgpt:")
+          || identitySource == "route"
+          || identitySource == "portal")
       if canPromoteLocalId {
         if !monitoringReview {
           task.conversationId = observed

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -657,6 +657,10 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /expectedLocalId/);
   assert.match(nativeSource, /local-row-mapping/);
   assert.match(nativeSource, /exact local->durable mapping/);
+  assert.match(nativeSource, /a\[href\*=\"\/c\/\"\]/);
+  assert.match(nativeSource, /\(\?:c\|work\\\/conversation\)/);
+  assert.match(nativeSource, /!observed\.hasPrefix\("local-chatgpt:"\)/);
+  assert.match(nativeSource, /portal-local/);
   assert.match(nativeSource, /first id absent from the baseline.*is unsafe/);
   assert.doesNotMatch(nativeSource, /source: 'new-sidebar-row'/);
   assert.match(nativeSource, /durable_conversation_id_pending/);


### PR DESCRIPTION
## Summary

- recognize current ChatGPT sidebar `/c/<conversation-id>` links when resolving dispatched chats
- prefer durable route/sidebar identifiers over provisional `local-chatgpt:*` identifiers
- prevent a later provisional observation from replacing an already durable conversation binding
- add contract assertions for the current sidebar route shape and local-to-durable promotion

## Why

The hosted queue is authenticated to the same Business ChatGPT account as the visible sidebar, but live runs still report only `local-chatgpt:*`. The current ChatGPT sidebar exposes durable conversations as `/c/<id>` anchors, while the runner primarily inspected the older `data-thread-title`/React-fiber shape.

## Validation

Per repository policy, no local project tests, builds, packaging, installation, or runtime validation were run. All validation is delegated to GitHub Actions and the protected merge queue.