### PR TITLE
test(actions): expect durable sidebar identity first

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -368,7 +368,7 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /userContent: userContent\.substring/);
   assert.match(nativeSource, /identitySource == "portal"/);
   assert.match(nativeSource, /conversationSource/);
-  assert.match(nativeSource, /portalConversationId\s*\n\s*\|\| activeConversationId/);
+  assert.match(nativeSource, /activeConversationId\s*\n\s*\|\| portalConversationId/);
   assert.match(nativeSource, /freshly prepared blank Chat owns a stable local id/);
   assert.match(nativeSource, /never replace a local id with/);
   assert.match(nativeSource, /appendTextPreservingConnector/);


### PR DESCRIPTION
## Summary

Update the runtime contract assertion after #1868 changed identity precedence from provisional portal IDs to durable sidebar IDs.

## Validation

The preceding runtime Action compiled the implementation successfully and failed only on this now-stale assertion. No local project tests or builds were run; GitHub Actions remains the validation authority.