### PR TITLE
fix(actions): fall back to normal Chat window

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -2678,19 +2678,44 @@ func createIndependentQueueWorkerTarget(
         "worker-create stage=hosted-prewarm-worker-begin "
           + "account=\(effectiveAccountId)"
       )
-      guard let worker = createQueueWorkerTarget(&state, reuseExisting: false) else {
+      if let worker = createQueueWorkerTarget(&state, reuseExisting: false) {
+        state.queueWorkerMode = sharedConversationQueueWorkerMode
         queueTrace(
-          "worker-create stage=hosted-prewarm-worker-failed "
-            + "account=\(effectiveAccountId) error=\(state.lastError ?? "unknown")"
+          "worker-create stage=hosted-prewarm-worker-complete "
+            + "account=\(effectiveAccountId) target=\(worker.targetId)"
         )
-        return nil
+        return worker
       }
-      state.queueWorkerMode = sharedConversationQueueWorkerMode
+      let prewarmError = state.lastError ?? "unknown"
       queueTrace(
-        "worker-create stage=hosted-prewarm-worker-complete "
-          + "account=\(effectiveAccountId) target=\(worker.targetId)"
+        "worker-create stage=hosted-prewarm-worker-failed "
+          + "account=\(effectiveAccountId) error=\(prewarmError)"
       )
-      return worker
+      // A workspace can exhaust Codex/Work credits while ordinary Chat is
+      // still available. In that state ChatGPT's official quick-chat prewarm
+      // window renders only an Oops/Try again page. Fall back to a normal,
+      // independently owned BrowserWindow in the same authenticated process,
+      // then explicitly select Chat. This keeps account and task isolation;
+      // it never borrows the controller or another task's renderer.
+      queueTrace(
+        "worker-create stage=hosted-headless-window-fallback-begin "
+          + "account=\(effectiveAccountId)"
+      )
+      if let fallback = createHeadlessParallelQueueWorkerTarget(&state) {
+        state.queueWorkerMode = parallelHeadlessWindowQueueWorkerMode
+        queueTrace(
+          "worker-create stage=hosted-headless-window-fallback-complete "
+            + "account=\(effectiveAccountId) target=\(fallback.targetId)"
+        )
+        return fallback
+      }
+      let fallbackError = state.lastError ?? "unknown"
+      state.lastError = "\(prewarmError); hosted_headless_fallback=\(fallbackError)"
+      queueTrace(
+        "worker-create stage=hosted-headless-window-fallback-failed "
+          + "account=\(effectiveAccountId) error=\(fallbackError)"
+      )
+      return nil
     }
     // A local headless desktop run can create an independent BrowserWindow in
     // the authenticated process. The parallel Actions smoke keeps the

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -664,6 +664,9 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /prewarm-transient-error-retry/);
   assert.match(nativeSource, /new Set\(\['try again', '重试', '再试一次'\]\)/);
   assert.match(nativeSource, /transientErrorRetryCount < 3/);
+  assert.match(nativeSource, /hosted-headless-window-fallback-begin/);
+  assert.match(nativeSource, /createHeadlessParallelQueueWorkerTarget\(&state\)/);
+  assert.match(nativeSource, /hosted_headless_fallback=/);
   assert.match(nativeSource, /first id absent from the baseline.*is unsafe/);
   assert.doesNotMatch(nativeSource, /source: 'new-sidebar-row'/);
   assert.match(nativeSource, /durable_conversation_id_pending/);


### PR DESCRIPTION
## Summary

- keep the official hidden prewarm path as the primary hosted strategy
- when prewarm remains on the authenticated `Oops / Try again` page, create a normal independent BrowserWindow in the same authenticated ChatGPT process
- explicitly select Chat and preserve account/task isolation
- retain both the prewarm and fallback errors if neither path is usable

## Evidence

Run 31142293544 checked out main `b99644a`, restored the correct Business account, and clicked `Try again` three times per attempt. The uploaded authenticated primary-renderer screenshot shows `You're out of Codex and Work usage / Your workspace is out of credits`, while ordinary Chat remains the intended surface. The official quick-chat prewarm path never mounted a composer and exhausted the task retry budget.

## Validation

No local project tests or builds were run. GitHub Actions is the sole validation authority.