### PR TITLE
fix(queue): force a real Work to Chat transition

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -1184,12 +1184,19 @@ func resetStaleChatModeIfNeeded(
     expression: composerSurfaceStateJS(),
     timeout: 5.0
   )
-  guard initial?["workComposer"] as? Bool == true else { return initial }
+  let initialHasInput = initial?["hasInput"] as? Bool == true
+  let initialChatModel = initial?["chatModel"] as? Bool == true
+  let initialQuickChat = initial?["quickChatRoot"] as? Bool == true
+  let initialWorkComposer = initial?["workComposer"] as? Bool == true
+  let initialChatReady = initialHasInput && !initialWorkComposer
+    && (initialChatModel || initialQuickChat)
+  guard !initialChatReady else { return initial }
 
-  // The hosted shell can persist "chat" while the mounted composer is still
-  // Work. Re-selecting ChatGPT is then a no-op because the atom already has
-  // that value. Use the real compact mode menu to cross the state boundary
-  // through Codex once, then return to Chat before creating the hidden window.
+  // The hosted shell can persist "chat" while the mounted page is still Work
+  // or while no composer has mounted at all. Re-selecting ChatGPT is then a
+  // no-op because the atom already has that value. Use the real Chat/Work
+  // control to cross the state boundary through Work once, then return to
+  // Chat and require a real Chat composer before creating the hidden window.
   queueTrace("worker-create stage=\(stage) reset-stale-mode begin")
   var codexSelection: [String: Any]?
   for _ in 0..<12 {
@@ -2652,8 +2659,8 @@ func createHostedControllerQueueWorkerTarget(
   _ state: inout PluginState
 ) -> (port: Int, targetId: String, profilePath: String)? {
   // The persistent Actions runner executes one queue task at a time. If the
-  // quick-chat service cannot create its hidden window (for example when the
-  // workspace has exhausted Codex/Work credits), the already authenticated
+  // quick-chat service cannot create its hidden window after the real
+  // Work-to-Chat transition, the already authenticated
   // primary renderer is the only Electron-backed surface guaranteed to
   // remain available. Reuse it only while no task is running, and mark it as
   // shared so task cleanup never closes ChatGPT's primary window.
@@ -2777,12 +2784,11 @@ func createIndependentQueueWorkerTarget(
         "worker-create stage=hosted-prewarm-worker-failed "
           + "account=\(effectiveAccountId) error=\(prewarmError)"
       )
-      // A workspace can exhaust Codex/Work credits while ordinary Chat is
-      // still available. In that state ChatGPT's official quick-chat prewarm
-      // window renders only an Oops/Try again page. Fall back to a normal,
-      // independently owned BrowserWindow in the same authenticated process,
-      // then explicitly select Chat. This keeps account and task isolation;
-      // it never borrows the controller or another task's renderer.
+      // If the official quick-chat prewarm window cannot mount a Chat surface,
+      // try a normal independently owned BrowserWindow in the same verified
+      // dual-credential process. The caller has already forced a real
+      // Work-to-Chat transition; this fallback preserves task isolation and
+      // never treats a Work usage page as a valid Chat surface.
       queueTrace(
         "worker-create stage=hosted-headless-window-fallback-begin "
           + "account=\(effectiveAccountId)"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/skills/sync-action-credentials/SKILL.md
@@ -12,11 +12,14 @@ description: 从已经打开并登录的 ChatGPT 桌面应用 app:// renderer �
 1. 已有打开且登录的桌面实例时，调用 `sync_actions_credentials`。需要同步后立即启动云端运行器时传入 `{ "start": true, "waitSeconds": 600 }`；只更新密钥时传入 `{ "start": false, "waitSeconds": 600 }`。
 2. `sync_actions_credentials` 只复用已经打开的 ChatGPT 桌面应用 `app://-/index.html` renderer；找不到时必须失败，不得隐式打开其他实例。只有用户明确要求打开桌面应用并等待登录时才调用 `login_and_sync_actions`，且打开后仍必须使用完全相同的 `app://` + CDP 实时导出流程。
 3. 不得提供或调用任何名为“web login”或“browser login”的兼容入口；不得新建、打开或依赖 `https://chatgpt.com` 网页 renderer，也不得使用外部浏览器。
-4. 通过桌面 renderer 的 `electronBridge`、登录提示、模式控件和 composer 状态验证桌面实例已经登录；同时验证 `~/.codex/auth.json` 结构完整。未登录时停止，不上传任何凭证。
-5. 验证成功后，立即通过该桌面 renderer 的 CDP `Network.getAllCookies` 实时导出 Cookie，规范化后原子写入本机私有 `session-cookies.json`。禁止读取、复制或解密任何浏览器、Codex 或 ChatGPT 桌面资料库中的 Cookie 数据库。
-6. 使用 `base64` 管道向 `gh secret set` 同步 Codex 凭证和刚抓取的 ChatGPT 会话；不得读取或上传本地任务队列状态，也不得复用未验证的旧 Cookie 文件。
-7. 任务目标与任务文档只来自仓库内的 `tasks/actions-inbox.json`、`documentDirectory` 和 `specSources`。运行器启动后持续读取这些可动态更新的文件；不得用 Secret 固化任务定义。
-8. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称、Cookie 数量和账号已验证状态；绝不返回 token、Cookie、auth 文件内容、账号 ID 或 Base64 值。
+4. 把 Codex 凭证与 ChatGPT Session 当作两个独立且都必需的凭证。不得因 `~/.codex/auth.json` 可用就推断 ChatGPT Session 已注入，也不得只凭桌面进程已启动或页面显示 Work 就判定验证成功。
+5. 验证 `~/.codex/auth.json` 结构完整，并从当前桌面 renderer 的已认证状态取得非敏感账号标识；两边账号必须一致。任一凭证缺失、无法确认身份或身份不一致时立即失败，禁止上传或启动 Action。
+6. 启动时没有 Chat composer、停在 Work、或显示 Codex/Work usage 页面，都只表示当前界面未进入真实 Chat，不表示 Chat 额度耗尽或 Session 缺失。必须通过顶部 `Chat/Work`、`聊天/工作` 或紧凑模式菜单执行一次真实的 `Work → Chat` 切换，再要求同时出现 Chat 输入框、ChatGPT 模型控件和可读取的 Chat 侧边栏；仅修改持久化模式值不算切换成功。
+7. 真实 Chat 复验成功后，立即通过该桌面 renderer 的 CDP `Network.getAllCookies` 实时导出 Cookie，规范化后原子写入本机私有 `session-cookies.json`。禁止读取、复制或解密任何浏览器、Codex 或 ChatGPT 桌面资料库中的 Cookie 数据库。
+8. 使用 `base64` 管道在同一次操作中同步 Codex 凭证和刚抓取的 ChatGPT Session；任何一项为空都必须失败。不得读取或上传本地任务队列状态，也不得复用未验证的旧 Cookie 文件。
+9. Action 恢复后必须再次验证两类凭证均存在、账号一致，并完成真实 `Work → Chat` 切换与 composer 复验；失败时停止队列，不得把 Work usage 页面当作 Chat 页面继续重试。
+10. 任务目标与任务文档只来自仓库内的 `tasks/actions-inbox.json`、`documentDirectory` 和 `specSources`。运行器启动后持续读取这些可动态更新的文件；不得用 Secret 固化任务定义。
+11. 仅返回非敏感摘要：是否成功、仓库、写入的 Secret 名称、Cookie 数量、双凭证存在状态和账号已验证状态；绝不返回 token、Cookie、auth 文件内容、账号 ID 或 Base64 值。
 
 ## 目标 Secrets
 
@@ -30,7 +33,8 @@ description: 从已经打开并登录的 ChatGPT 桌面应用 app:// renderer �
 - 不读取 GitHub Secret 明文，也不在日志、聊天或错误信息中输出凭证。
 - 每次命令都必须重新验证并实时导出当前桌面 app renderer；现有 `session-cookies.json` 只能作为成功导出后的输出，不能作为上传来源。
 - 禁止使用 Cookie SQLite 数据库、`Codex Safe Storage`、`Chrome Safe Storage`、DPAPI 或其他本地密钥解密路径；不得回退到这类方式。
-- 未登录时允许打开登录入口并等待用户完成登录；账号不一致时立即失败，禁止覆盖 GitHub Secret。
+- 未登录时允许打开登录入口并等待用户完成登录；任一凭证缺失、账号无法比对或账号不一致时立即失败，禁止覆盖 GitHub Secret。
+- 禁止把 Codex/Work usage 提示解释为普通 Chat 额度不足。若预期 Chat 可用，必须先执行真实的 Work → Chat 切换并验证 Chat composer；无法验证就停止。
 - 每次只更新 `CHATGPT_CODEX_AUTH_B64` 和 `CHATGPT_SESSION_COOKIES_B64`；仅当不存在时生成 `CHATGPT_AUTO_CONFIRM_STATE_KEY`。
 - 禁止创建或使用 `CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64`。首次运行必须从空执行状态开始并读取仓库任务文件；跨 Runner 续作只能使用显式 `previous_run_id` 对应的短期加密构件。
 - 同步失败时只报告阶段性错误和下一步，不尝试把凭证写入普通文件、Issue、PR 或任务 prompt。

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -65,6 +65,10 @@ const rendererRecoveryMetadata = readFileSync(
   new URL('../skills/recover-actions-chatgpt-renderer/agents/openai.yaml', import.meta.url),
   'utf8',
 );
+const syncCredentialSkill = readFileSync(
+  new URL('../skills/sync-action-credentials/SKILL.md', import.meta.url),
+  'utf8',
+);
 
 test('home contract', () => {
   assert.equal(HOME.schema, 'mahayana.miniapp.home.v1');
@@ -98,6 +102,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(actionsWorkflow, /timeout-minutes: 355/);
   assert.match(actionsWorkflow, /CHATGPT_CODEX_AUTH_B64/);
   assert.match(actionsWorkflow, /CHATGPT_SESSION_COOKIES_B64/);
+  assert.match(syncCredentialSkill, /Codex 凭证与 ChatGPT Session.*独立且都必需/);
+  assert.match(syncCredentialSkill, /Work → Chat/);
+  assert.match(syncCredentialSkill, /不得把 Work usage 页面当作 Chat 页面/);
   assert.match(actionsWorkflow, /restore-session-cookies\.mjs/);
   assert.match(actionsWorkflow, /CHATGPT_SESSION_MODE=restore-and-verify/);
   assert.match(actionsWorkflow, /Verify authenticated ChatGPT session/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -669,6 +669,8 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /createHostedControllerQueueWorkerTarget/);
   assert.match(nativeSource, /hosted_controller_unavailable_or_busy/);
   assert.match(nativeSource, /state\.queueWorkerMode = sharedConversationQueueWorkerMode/);
+  assert.match(nativeSource, /initialChatReady/);
+  assert.match(nativeSource, /Work-to-Chat transition/);
   assert.match(nativeSource, /createHeadlessParallelQueueWorkerTarget\(&state\)/);
   assert.match(nativeSource, /hosted_headless_fallback=/);
   assert.match(nativeSource, /first id absent from the baseline.*is unsafe/);


### PR DESCRIPTION
## Summary
- treat Codex auth and ChatGPT Session as independent, mandatory credentials in the sync skill
- when startup claims Chat but has no real Chat composer, force a true Work → Chat UI transition
- require input plus ChatGPT model/quick-chat surface before accepting Chat
- stop interpreting a Work usage page as ordinary Chat quota state

## Evidence
The local account-scoped second ChatGPT process (`acct_6fe593e530e2`, port 9324) has both credentials: its registered Codex fingerprint matches the local identity, and the same process currently exposes a real Chat composer, model picker, and durable sidebar conversations. Run #442 also restored the credential bundle, verified the authenticated ChatGPT session, and exported refreshed credentials successfully before cancellation. The missing Chat page was therefore stale UI mode initialization, not a missing Session.

## Validation
All project tests and runtime validation are delegated to GitHub Actions.