### PR TITLE
fix(queue): monitor hosted visible Chat controller

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -298,6 +298,12 @@ func queueTargetStateIsUsableForQueue(
       && (
         workerMode == parallelDedicatedProcessQueueWorkerMode
           || workerMode == parallelHeadlessWindowQueueWorkerMode
+          // The hosted controller fallback deliberately borrows the primary
+          // renderer after proving it is a real Chat surface. GitHub Actions
+          // has no interactive user who can collide with that visible page,
+          // and shared mode prevents task cleanup from closing it.
+          || (runningOnGitHubActions()
+            && workerMode == sharedConversationQueueWorkerMode)
       )
   case .missing, .hiddenNonChat, .suspended:
     return false

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -669,6 +669,8 @@ test('task queue tools preserve dependencies, resource locks, review gate and co
   assert.match(nativeSource, /createHostedControllerQueueWorkerTarget/);
   assert.match(nativeSource, /hosted_controller_unavailable_or_busy/);
   assert.match(nativeSource, /state\.queueWorkerMode = sharedConversationQueueWorkerMode/);
+  assert.match(nativeSource,
+    /runningOnGitHubActions\(\)[\s\S]*?workerMode == sharedConversationQueueWorkerMode/);
   assert.match(nativeSource, /initialChatReady/);
   assert.match(nativeSource, /Work-to-Chat transition/);
   assert.match(nativeSource, /createHeadlessParallelQueueWorkerTarget\(&state\)/);


### PR DESCRIPTION
## Summary
- allow the verified shared Chat controller to remain visible only on GitHub Actions
- keep local desktop runs fail-closed for visible shared renderers
- preserve shared-mode cleanup protection so the primary Chat window is never closed

## Runtime evidence
Run #443 successfully sent the queued task and resolved durable conversation `6a755ace-e970-83e8-af4d-d9bff1a2bbd8`, but the monitor paused it with `queue_worker_visibility_not_hidden` because the final hosted fallback intentionally uses the primary visible Chat renderer.

## Validation
All project tests and runtime validation are delegated to GitHub Actions.