### PR TITLE
fix(queue): stabilize approval transitions

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/HiddenChatAndApproval.swift
@@ -1315,6 +1315,14 @@ func detectDedicatedAuthorizationJS() -> String {
   #"""
   (() => {
     const normalize = value => (value || '').replace(/[\s↵⏎]+/g, ' ').trim().toLowerCase();
+    const fingerprint = value => {
+      let hash = 2166136261;
+      for (const character of value) {
+        hash ^= character.codePointAt(0);
+        hash = Math.imul(hash, 16777619);
+      }
+      return `fnv1a32:${(hash >>> 0).toString(16).padStart(8, '0')}`;
+    };
     const visible = element => !!(element
       && !element.disabled
       && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
@@ -1392,6 +1400,7 @@ func detectDedicatedAuthorizationJS() -> String {
           sessionScopeLabels,
           menuTriggerLabels: menuTriggers.map(label).filter(Boolean),
           menuTriggerCount: menuTriggers.length,
+          cardFingerprint: fingerprint(cardText),
           unlabeledControlCount: nonDecisionControls.filter(button => !label(button)).length
         };
       }

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueMonitoring.swift
@@ -34,6 +34,7 @@ func approvalDetectionTraceFields(_ detection: [String: Any]?) -> String {
     "sessionScopeLabels": detection["sessionScopeLabels"] ?? [],
     "menuTriggerLabels": detection["menuTriggerLabels"] ?? [],
     "menuTriggerCount": detection["menuTriggerCount"] ?? 0,
+    "cardFingerprint": detection["cardFingerprint"] ?? "",
     "unlabeledControlCount": detection["unlabeledControlCount"] ?? 0,
   ]) ?? "{}"
   return "detection=\(details)"
@@ -360,13 +361,26 @@ func monitorAutomationTask(
   // A permission card can replace the normal conversation body temporarily.
   // Confirm it before restoring a task through its exact hidden-page route, so
   // an unloaded conversation cannot suppress automatic authorization.
-  _ = approveDedicatedAuthorizationWithDiagnostics(
+  let now = isoFormatter.string(from: Date())
+  let approval = approveDedicatedAuthorizationWithDiagnostics(
     port: port,
     targetId: targetId,
     taskId: task.id,
     stage: "before-read"
   )
-  let now = isoFormatter.string(from: Date())
+  // The authorization card is replaced asynchronously after a confirmed
+  // decision. Reading the conversation during that renderer transition can
+  // fail even though the click succeeded, which used to leave a false
+  // queue_monitor_cdp_failed error and immediately poll the next card. Treat
+  // the confirmed authorization itself as progress and resume normal
+  // conversation monitoring on the next queue tick.
+  if approval?["clicked"] as? Bool == true,
+     approval?["confirmed"] as? Bool == true {
+    task.lastError = nil
+    task.lastProgressAt = now
+    task.updatedAt = now
+    return
+  }
   guard var liveStatus = cdpValue(
           port: port, targetId: targetId, expression: chatStatusJS(), timeout: 5.0) else {
     task.lastError = "queue_monitor_cdp_failed"

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -236,6 +236,8 @@ test('send_and_watch streams visible thinking and recovers in a fresh Chat after
   assert.match(nativeSource, /detectDedicatedAuthorizationJS/);
   assert.match(nativeSource, /sessionScopeLabels/);
   assert.match(nativeSource, /menuTriggerCount/);
+  assert.match(nativeSource, /cardFingerprint/);
+  assert.match(nativeSource, /fnv1a32:/);
   assert.match(nativeSource, /session-scope/);
   assert.match(nativeSource, /session_scope_option_not_found/);
   assert.match(nativeSource, /dispatchPointerClick\(sessionControl\)/);
@@ -243,6 +245,10 @@ test('send_and_watch streams visible thinking and recovers in a fresh Chat after
   assert.match(nativeSource, /sessionScopeLabel/);
   assert.match(nativeSource, /timeout: 8\.0/);
   assert.match(nativeSource, /strategy=per-card/);
+  assert.match(
+    nativeSource,
+    /approval\?\["confirmed"\] as\? Bool == true[\s\S]*task\.lastError = nil[\s\S]*task\.lastProgressAt = now[\s\S]*return/,
+  );
   assert.match(nativeSource, /approval-watcher-before/);
   assert.match(nativeSource, /approval-ipc-detected/);
   assert.match(nativeSource, /approval-.*-before/);


### PR DESCRIPTION
## Summary

- treat a confirmed `Allow once` decision as queue progress and defer conversation reads until the renderer transition settles
- clear the transient `queue_monitor_cdp_failed` state after confirmed authorization
- emit a non-content fingerprint for approval cards so repeated-card behavior can be distinguished without exposing prompt text
- add contract coverage

## Validation

Per repository policy, project tests, builds, packaging, installation, and runtime validation are delegated to GitHub Actions. Locally only `git diff --check` was run.