### PR TITLE
fix(actions): recover transient ChatGPT shell

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/IPCAndCDP.swift
@@ -422,6 +422,41 @@ struct CDPClient {
     )
   }
 
+  @discardableResult
+  static func clickTarget(
+    _ targetId: String,
+    x: Double,
+    y: Double,
+    portOverride: Int? = nil
+  ) -> Bool {
+    guard x.isFinite, y.isFinite,
+          let target = fetchTargets(portOverride: portOverride).first(where: {
+            $0["id"] as? String == targetId
+          }),
+          let wsURL = target["webSocketDebuggerUrl"] as? String else { return false }
+    let coordinates = String(
+      format: "\"x\":%.3f,\"y\":%.3f",
+      locale: Locale(identifier: "en_US_POSIX"),
+      x,
+      y
+    )
+    let pressed = "{\"type\":\"mousePressed\",\(coordinates),\"button\":\"left\",\"buttons\":1,\"clickCount\":1}"
+    let released = "{\"type\":\"mouseReleased\",\(coordinates),\"button\":\"left\",\"buttons\":0,\"clickCount\":1}"
+    guard let pressedResponse = sendCommand(
+      wsURLString: wsURL,
+      method: "Input.dispatchMouseEvent",
+      paramsJSON: pressed,
+      timeout: 4.0
+    ), pressedResponse["error"] == nil else { return false }
+    guard let releasedResponse = sendCommand(
+      wsURLString: wsURL,
+      method: "Input.dispatchMouseEvent",
+      paramsJSON: released,
+      timeout: 4.0
+    ) else { return false }
+    return releasedResponse["error"] == nil
+  }
+
   static func allCookies(wsURLString: String, timeout: TimeInterval = 5.0) -> [[String: Any]] {
     guard let response = sendCommand(
       wsURLString: wsURLString,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -896,15 +896,33 @@ func openBackgroundQueueWindow(
             ].filter(Boolean).join(' ')))
               && !node.disabled
               && node.getAttribute('aria-disabled') !== 'true');
-          if (!button) return { clicked: false };
+          if (!button) return { found: false };
           const label = normalize(button.innerText || button.getAttribute('aria-label'));
-          button.click();
-          return { clicked: true, label };
+          const rect = button.getBoundingClientRect();
+          return {
+            found: true,
+            label,
+            x: rect.left + rect.width / 2,
+            y: rect.top + rect.height / 2
+          };
         })()
         """,
         timeout: 4.0
       )
-      if retry?["clicked"] as? Bool == true {
+      let retryClicked: Bool
+      if retry?["found"] as? Bool == true,
+         let x = (retry?["x"] as? NSNumber)?.doubleValue,
+         let y = (retry?["y"] as? NSNumber)?.doubleValue {
+        retryClicked = CDPClient.clickTarget(
+          targetId,
+          x: x,
+          y: y,
+          portOverride: port
+        )
+      } else {
+        retryClicked = false
+      }
+      if retryClicked {
         transientErrorRetryCount += 1
         queueTrace(
           "worker-create stage=prewarm-transient-error-retry "

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -310,6 +310,10 @@ func actionsDesktopState(_ target: ActionsLoginTarget) -> [String: Any]? {
       ) || '';
       const asksForLogin = /(^|\n)(log in|sign up|登录|登入|註冊|注册)(\n|$)/i.test(bodyText);
       const workComposer = !!document.querySelector('[data-codex-composer="true"]');
+      const retryAvailable = labels.some(value => {
+        const normalized = value.toLowerCase();
+        return normalized === 'try again' || normalized === '重试' || normalized === '再试一次';
+      }) && /oops|error|出错/i.test(bodyText);
       const appOrigin = location.protocol === 'app:';
       const bridge = !!window.electronBridge;
       const authenticated = appOrigin && bridge && !asksForLogin
@@ -324,6 +328,7 @@ func actionsDesktopState(_ target: ActionsLoginTarget) -> [String: Any]? {
         hasWork,
         workComposer,
         currentMode: currentMode.slice(0, 160),
+        retryAvailable,
         bodyLength: bodyText.length,
         url: location.href,
         readyState: document.readyState
@@ -335,11 +340,41 @@ func actionsDesktopState(_ target: ActionsLoginTarget) -> [String: Any]? {
 }
 
 func actionsControllerShellIsReady(_ state: [String: Any]) -> Bool {
-  (state["appOrigin"] as? Bool ?? false)
-    && (state["bridge"] as? Bool ?? false)
-    && !(state["asksForLogin"] as? Bool ?? false)
-    && state["readyState"] as? String == "complete"
-    && (state["bodyLength"] as? Int ?? 0) > 50
+  state["authenticated"] as? Bool ?? false
+}
+
+@discardableResult
+func retryActionsDesktopTransientError(_ target: ActionsLoginTarget) -> Bool {
+  guard let retry = cdpValue(
+    port: target.port,
+    targetId: target.targetId,
+    expression: #"""
+    (() => {
+      const normalize = value => (value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+      const allowed = new Set(['try again', '重试', '再试一次']);
+      const button = [...document.querySelectorAll('button, [role="button"]')]
+        .find(node => allowed.has(normalize([
+          node.innerText,
+          node.getAttribute('aria-label'),
+          node.getAttribute('title')
+        ].filter(Boolean).join(' ')))
+          && !node.disabled
+          && node.getAttribute('aria-disabled') !== 'true');
+      if (!button) return { found: false };
+      const rect = button.getBoundingClientRect();
+      return {
+        found: true,
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2
+      };
+    })()
+    """#,
+    timeout: 4.0
+  ), retry["found"] as? Bool == true,
+     let x = (retry["x"] as? NSNumber)?.doubleValue,
+     let y = (retry["y"] as? NSNumber)?.doubleValue else { return false }
+  _ = CDPClient.activateTarget(target.targetId, portOverride: target.port)
+  return CDPClient.clickTarget(target.targetId, x: x, y: y, portOverride: target.port)
 }
 
 func base64URLDecodedData(_ value: String) -> Data? {
@@ -1322,6 +1357,11 @@ case "verify_chatgpt_login":
       if actionsControllerShellIsReady(controllerState) {
         controllerVerified = true
         break
+      }
+      if controllerState["retryAvailable"] as? Bool == true,
+         retryActionsDesktopTransientError(target) {
+        Thread.sleep(forTimeInterval: 2)
+        continue
       }
     }
     desktopTarget = actionsDesktopTarget() ?? desktopTarget

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -238,6 +238,9 @@ test('send_and_watch streams visible thinking and recovers in a fresh Chat after
   assert.match(nativeSource, /menuTriggerCount/);
   assert.match(nativeSource, /cardFingerprint/);
   assert.match(nativeSource, /fnv1a32:/);
+  assert.match(nativeSource, /Input\.dispatchMouseEvent/);
+  assert.match(nativeSource, /retryActionsDesktopTransientError/);
+  assert.match(nativeSource, /state\["authenticated"\] as\? Bool \?\? false/);
   assert.match(nativeSource, /session-scope/);
   assert.match(nativeSource, /session_scope_option_not_found/);
   assert.match(nativeSource, /dispatchPointerClick\(sessionControl\)/);


### PR DESCRIPTION
## Summary

- reject the static `Oops / Try again` renderer as an authenticated controller shell
- use a trusted CDP mouse click to retry the visible controller and hidden prewarm renderer
- require actual Chat/Work authentication markers before login preflight succeeds
- add contract coverage for the trusted retry path

## Failure evidence

Continuous run #445 restored both account credentials but failed with `prewarm_hidden_chat_surface_timeout` while the only visible control was `Try again`.

## Validation

Project tests, builds, packaging, installation, and runtime validation are delegated to GitHub Actions per repository policy. Locally only `git diff --check` was run.