### PR TITLE
fix(actions): recognize duplicated control labels

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueWorker.swift
@@ -888,16 +888,16 @@ func openBackgroundQueueWindow(
         (() => {
           const normalize = value => (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
           const allowed = new Set(['try again', '重试', '再试一次']);
+          const labelFor = node => normalize(
+            node.getAttribute('aria-label') || node.innerText || node.textContent
+              || node.getAttribute('title')
+          );
           const button = [...document.querySelectorAll('button, [role="button"]')]
-            .find(node => allowed.has(normalize([
-              node.innerText,
-              node.getAttribute('aria-label'),
-              node.getAttribute('title')
-            ].filter(Boolean).join(' ')))
+            .find(node => allowed.has(labelFor(node))
               && !node.disabled
               && node.getAttribute('aria-disabled') !== 'true');
           if (!button) return { found: false };
-          const label = normalize(button.innerText || button.getAttribute('aria-label'));
+          const label = labelFor(button);
           const rect = button.getBoundingClientRect();
           return {
             found: true,

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/main.swift
@@ -296,12 +296,16 @@ func actionsDesktopState(_ target: ActionsLoginTarget) -> [String: Any]? {
       const controls = [...document.querySelectorAll(
         'button, [role="button"], [role="tab"], [aria-label]'
       )];
-      const labels = controls.map(element => normalize([
+      // Keep each label source independent. Electron controls commonly expose
+      // the same visible value through both innerText and textContent; joining
+      // them turns "Chat" into "Chat Chat" and "Try again" into
+      // "Try again Try again", defeating exact control recognition.
+      const labels = controls.flatMap(element => [
         element.innerText,
         element.textContent,
         element.getAttribute('aria-label'),
         element.getAttribute('title')
-      ].filter(Boolean).join(' ')));
+      ]).map(normalize).filter(Boolean);
       const exact = label => labels.some(value => value.toLowerCase() === label);
       const hasChat = exact('chat') || exact('聊天');
       const hasWork = exact('work') || exact('工作');
@@ -352,12 +356,12 @@ func retryActionsDesktopTransientError(_ target: ActionsLoginTarget) -> Bool {
     (() => {
       const normalize = value => (value || '').replace(/\s+/g, ' ').trim().toLowerCase();
       const allowed = new Set(['try again', '重试', '再试一次']);
+      const label = node => normalize(
+        node.getAttribute('aria-label') || node.innerText || node.textContent
+          || node.getAttribute('title')
+      );
       const button = [...document.querySelectorAll('button, [role="button"]')]
-        .find(node => allowed.has(normalize([
-          node.innerText,
-          node.getAttribute('aria-label'),
-          node.getAttribute('title')
-        ].filter(Boolean).join(' ')))
+        .find(node => allowed.has(label(node))
           && !node.disabled
           && node.getAttribute('aria-disabled') !== 'true');
       if (!button) return { found: false };

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/desktop-approval.test.mjs
@@ -241,6 +241,8 @@ test('send_and_watch streams visible thinking and recovers in a fresh Chat after
   assert.match(nativeSource, /Input\.dispatchMouseEvent/);
   assert.match(nativeSource, /retryActionsDesktopTransientError/);
   assert.match(nativeSource, /state\["authenticated"\] as\? Bool \?\? false/);
+  assert.match(nativeSource, /controls\.flatMap\(element =>/);
+  assert.match(nativeSource, /allowed\.has\(labelFor\(node\)\)/);
   assert.match(nativeSource, /session-scope/);
   assert.match(nativeSource, /session_scope_option_not_found/);
   assert.match(nativeSource, /dispatchPointerClick\(sessionControl\)/);


### PR DESCRIPTION
## Summary

- keep `innerText`, `textContent`, ARIA labels, and titles as independent control labels
- prevent Electron controls such as `Chat` and `Try again` from becoming unmatchable duplicated strings
- use the normalized preferred label for trusted retry clicks in both controller and hidden renderer paths
- add contract coverage

## Failure evidence

Continuous run #446 correctly rejected the error shell but could not recognize its `Try again` button because the same text was exposed through two DOM fields and concatenated.

## Validation

Project tests, builds, packaging, installation, and runtime validation are delegated to GitHub Actions per repository policy. Locally only `git diff --check` was run.