### PR TITLE
fix: resolve Android SDK tools on hosted runner

### DIFF
--- a/.github/workflows/chatgpt-android-apk-runner.yml
+++ b/.github/workflows/chatgpt-android-apk-runner.yml
@@ -98,10 +98,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          yes | sdkmanager --licenses >/dev/null || true
-          sdkmanager 'platform-tools' 'emulator' "$AVD_PACKAGE"
-          emulator -version | head -n 1
-          adb version | head -n 1
+          sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
+          test -d "$sdk_root"
+          sdkmanager_bin=$(find "$sdk_root/cmdline-tools" -type f -path '*/bin/sdkmanager' -perm -u+x -print \
+            | sort -V | tail -n 1)
+          if [[ -z "$sdkmanager_bin" || ! -x "$sdkmanager_bin" ]]; then
+            echo "::error::No executable sdkmanager found under $sdk_root/cmdline-tools."
+            find "$sdk_root/cmdline-tools" -maxdepth 3 -type f -name sdkmanager -print || true
+            exit 1
+          fi
+          tools_bin=$(dirname "$sdkmanager_bin")
+          test -x "$tools_bin/avdmanager"
+          {
+            echo "ANDROID_HOME=$sdk_root"
+            echo "ANDROID_SDK_ROOT=$sdk_root"
+          } >> "$GITHUB_ENV"
+          {
+            echo "$tools_bin"
+            echo "$sdk_root/platform-tools"
+            echo "$sdk_root/emulator"
+          } >> "$GITHUB_PATH"
+          yes | "$sdkmanager_bin" --licenses >/dev/null || true
+          "$sdkmanager_bin" 'platform-tools' 'emulator' "$AVD_PACKAGE"
+          "$sdk_root/emulator/emulator" -version | head -n 1
+          "$sdk_root/platform-tools/adb" version | head -n 1
 
       - name: Restore or create AVD
         id: avd

--- a/.github/workflows/chatgpt-android-controller-test.yml
+++ b/.github/workflows/chatgpt-android-controller-test.yml
@@ -30,3 +30,21 @@ jobs:
           node-version: '22'
       - run: npm test
       - run: bash -n scripts/avd-state.sh
+      - name: Verify hosted Android SDK discovery
+        working-directory: .
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
+          test -d "$sdk_root"
+          sdkmanager_bin=$(find "$sdk_root/cmdline-tools" -type f -path '*/bin/sdkmanager' -perm -u+x -print \
+            | sort -V | tail -n 1)
+          test -n "$sdkmanager_bin"
+          test -x "$sdkmanager_bin"
+          tools_bin=$(dirname "$sdkmanager_bin")
+          test -x "$tools_bin/avdmanager"
+          test -x "$sdk_root/platform-tools/adb"
+          test -x "$sdk_root/emulator/emulator"
+          "$sdkmanager_bin" --version
+          "$sdk_root/platform-tools/adb" version | head -n 1
+          "$sdk_root/emulator/emulator" -version | head -n 1

--- a/.github/workflows/chatgpt-android-controller-test.yml
+++ b/.github/workflows/chatgpt-android-controller-test.yml
@@ -36,15 +36,20 @@ jobs:
         run: |
           set -euo pipefail
           sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
+          echo "Android SDK root: $sdk_root"
           test -d "$sdk_root"
           sdkmanager_bin=$(find "$sdk_root/cmdline-tools" -type f -path '*/bin/sdkmanager' -perm -u+x -print \
             | sort -V | tail -n 1)
+          echo "sdkmanager: ${sdkmanager_bin:-missing}"
           test -n "$sdkmanager_bin"
           test -x "$sdkmanager_bin"
           tools_bin=$(dirname "$sdkmanager_bin")
           test -x "$tools_bin/avdmanager"
           test -x "$sdk_root/platform-tools/adb"
-          test -x "$sdk_root/emulator/emulator"
           "$sdkmanager_bin" --version
           "$sdk_root/platform-tools/adb" version | head -n 1
-          "$sdk_root/emulator/emulator" -version | head -n 1
+          if [[ -x "$sdk_root/emulator/emulator" ]]; then
+            "$sdk_root/emulator/emulator" -version | head -n 1
+          else
+            echo 'Android emulator is not preinstalled; the APK runner installs it with sdkmanager.'
+          fi


### PR DESCRIPTION
## Root cause
First real `ChatGPT Android APK continuous runner` on `main` (run `31185179743`) failed before emulator startup because `sdkmanager` and `adb` were installed in the Ubuntu runner image but their Android SDK directories were not directly available as shell commands.

## Fix
- Resolve the existing SDK root from `ANDROID_HOME` / `ANDROID_SDK_ROOT` with `/usr/local/lib/android/sdk` fallback.
- Discover an executable `sdkmanager` under `cmdline-tools/**/bin` instead of assuming a versioned directory.
- Validate the paired `avdmanager`.
- Export command-line tools, `platform-tools`, and `emulator` directories through `GITHUB_PATH` for all later steps.
- Invoke `sdkmanager`, `emulator`, and `adb` by absolute path in the setup step itself.
- Keep using the preinstalled GitHub runner SDK rather than downloading a duplicate SDK distribution.

The Android runner image documents the SDK at `/usr/local/lib/android/sdk` with Android Command Line Tools and Platform Tools preinstalled; the failure was PATH resolution, not missing SDK content.

## Verification
The existing `ChatGPT Android Controller` PR workflow syntax-checks the runner workflow and plugin scripts. After merge, the `main` push will automatically rerun the real APK workflow and should advance to AVD creation/emulator/APK installation.