### PR TITLE
fix: install Android emulator runtime library

### DIFF
--- a/.github/workflows/chatgpt-android-apk-runner.yml
+++ b/.github/workflows/chatgpt-android-apk-runner.yml
@@ -118,8 +118,25 @@ jobs:
             echo "$sdk_root/platform-tools"
             echo "$sdk_root/emulator"
           } >> "$GITHUB_PATH"
+
+          # The current ubuntu-24.04 image does not include libpulse.so.0, but
+          # the Android QEMU binary links against it even when we launch with
+          # -noaudio. Install only the required runtime library.
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends libpulse0
+
           yes | "$sdkmanager_bin" --licenses >/dev/null || true
           "$sdkmanager_bin" 'platform-tools' 'emulator' "$AVD_PACKAGE"
+
+          qemu_bin="$sdk_root/emulator/qemu/linux-x86_64/qemu-system-x86_64"
+          test -x "$qemu_bin"
+          missing=$(ldd "$qemu_bin" | awk '/not found/{print $1}')
+          if [[ -n "$missing" ]]; then
+            echo "::error::Android emulator has unresolved shared libraries: $missing"
+            ldd "$qemu_bin" || true
+            exit 1
+          fi
+
           "$sdk_root/emulator/emulator" -version | head -n 1
           "$sdk_root/platform-tools/adb" version | head -n 1
 

--- a/.github/workflows/chatgpt-android-apk-runner.yml
+++ b/.github/workflows/chatgpt-android-apk-runner.yml
@@ -119,25 +119,21 @@ jobs:
             echo "$sdk_root/emulator"
           } >> "$GITHUB_PATH"
 
-          # The current ubuntu-24.04 image does not include libpulse.so.0, but
-          # the Android QEMU binary links against it even when we launch with
-          # -noaudio. Install only the required runtime library.
+          # Android Emulator's Linux launcher links PulseAudio even with
+          # -noaudio. Install only the missing host runtime library.
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libpulse0
 
           yes | "$sdkmanager_bin" --licenses >/dev/null || true
           "$sdkmanager_bin" 'platform-tools' 'emulator' "$AVD_PACKAGE"
 
-          qemu_bin="$sdk_root/emulator/qemu/linux-x86_64/qemu-system-x86_64"
-          test -x "$qemu_bin"
-          missing=$(ldd "$qemu_bin" | awk '/not found/{print $1}')
-          if [[ -n "$missing" ]]; then
-            echo "::error::Android emulator has unresolved shared libraries: $missing"
-            ldd "$qemu_bin" || true
+          emulator_bin="$sdk_root/emulator/emulator"
+          test -x "$emulator_bin"
+          if ! emulator_version=$("$emulator_bin" -version 2>&1); then
+            printf '%s\n' "$emulator_version"
             exit 1
           fi
-
-          "$sdk_root/emulator/emulator" -version | head -n 1
+          printf '%s\n' "$emulator_version" | head -n 1
           "$sdk_root/platform-tools/adb" version | head -n 1
 
       - name: Restore or create AVD

--- a/.github/workflows/chatgpt-android-controller-test.yml
+++ b/.github/workflows/chatgpt-android-controller-test.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '22'
       - run: npm test
       - run: bash -n scripts/avd-state.sh
-      - name: Verify hosted Android SDK discovery
+      - name: Verify hosted Android emulator runtime
         working-directory: .
         shell: bash
         run: |
@@ -46,10 +46,21 @@ jobs:
           tools_bin=$(dirname "$sdkmanager_bin")
           test -x "$tools_bin/avdmanager"
           test -x "$sdk_root/platform-tools/adb"
+
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends libpulse0
+          yes | "$sdkmanager_bin" --licenses >/dev/null || true
+          "$sdkmanager_bin" emulator
+
+          qemu_bin="$sdk_root/emulator/qemu/linux-x86_64/qemu-system-x86_64"
+          test -x "$qemu_bin"
+          missing=$(ldd "$qemu_bin" | awk '/not found/{print $1}')
+          if [[ -n "$missing" ]]; then
+            echo "::error::Android emulator has unresolved shared libraries: $missing"
+            ldd "$qemu_bin" || true
+            exit 1
+          fi
+
           "$sdkmanager_bin" --version
           "$sdk_root/platform-tools/adb" version | head -n 1
-          if [[ -x "$sdk_root/emulator/emulator" ]]; then
-            "$sdk_root/emulator/emulator" -version | head -n 1
-          else
-            echo 'Android emulator is not preinstalled; the APK runner installs it with sdkmanager.'
-          fi
+          "$sdk_root/emulator/emulator" -version | head -n 1

--- a/.github/workflows/chatgpt-android-controller-test.yml
+++ b/.github/workflows/chatgpt-android-controller-test.yml
@@ -52,15 +52,13 @@ jobs:
           yes | "$sdkmanager_bin" --licenses >/dev/null || true
           "$sdkmanager_bin" emulator
 
-          qemu_bin="$sdk_root/emulator/qemu/linux-x86_64/qemu-system-x86_64"
-          test -x "$qemu_bin"
-          missing=$(ldd "$qemu_bin" | awk '/not found/{print $1}')
-          if [[ -n "$missing" ]]; then
-            echo "::error::Android emulator has unresolved shared libraries: $missing"
-            ldd "$qemu_bin" || true
+          emulator_bin="$sdk_root/emulator/emulator"
+          test -x "$emulator_bin"
+          if ! emulator_version=$("$emulator_bin" -version 2>&1); then
+            printf '%s\n' "$emulator_version"
             exit 1
           fi
 
           "$sdkmanager_bin" --version
           "$sdk_root/platform-tools/adb" version | head -n 1
-          "$sdk_root/emulator/emulator" -version | head -n 1
+          printf '%s\n' "$emulator_version" | head -n 1


### PR DESCRIPTION
## Root cause from real APK runner
`ChatGPT Android APK continuous runner` run `31186431577` successfully resolved `sdkmanager`, downloaded the Android Emulator, Android 35 Google Play x86_64 system image, and Platform Tools. It then failed when executing the installed emulator launcher because the Ubuntu host lacked `libpulse.so.0`.

## Fix
- Install only the missing Ubuntu runtime package `libpulse0` before running Android Emulator.
- Keep the existing headless `-noaudio` launch mode; the current Emulator launcher links PulseAudio even when audio is disabled.
- Validate the actual Android Emulator launcher with `emulator -version` after install.

## Important diagnostic correction
An earlier validation attempted `ldd` directly on `qemu-system-x86_64`. That bypasses the Android Emulator launcher and therefore does not apply the Emulator package's own bundled-library search paths; it incorrectly reported bundled Qt / `libandroid-emu-*` libraries as host dependencies. That raw-QEMU gate has been removed from both the test and production workflow.

## Pre-merge hosted verification
The Android-specific PR workflow now uses the same `ubuntu-24.04` hosted image to:
1. resolve the existing Android SDK,
2. install `libpulse0`,
3. download the real Android Emulator with `sdkmanager`,
4. execute the official `emulator -version` launcher successfully.

This hosted verification has already passed on the updated PR head. After merge, the main APK runner should advance from SDK/system-image installation to AVD creation, KVM and emulator boot.