### PR TITLE
fix(actions): fail fast on unready ChatGPT shell

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/scripts/restore-session-cookies.mjs
@@ -165,7 +165,8 @@ const authenticatedControllerIsReady = state =>
   !state.asksForLogin
   && state.bridge
   && state.readyState === 'complete'
-  && state.bodyLength > 50;
+  && state.bodyLength > 50
+  && !!(state.currentMode || state.workComposer || state.hasChat || state.hasWork);
 
 const listTargets = async (fetchImpl, port) =>
   fetchImpl(`http://127.0.0.1:${port}/json/list`, {
@@ -553,12 +554,15 @@ const sessionStateExpression = `(() => {
   const controls = [...document.querySelectorAll(
     'button, [role="button"], [role="tab"], [aria-label]'
   )].filter(visible);
-  const labels = controls.map(element => normalize([
+  // Keep label sources independent. Electron controls frequently expose the
+  // same visible label through innerText and textContent; concatenating them
+  // turns "Chat" into "Chat Chat" and breaks exact control detection.
+  const labels = controls.flatMap(element => [
     element.innerText,
     element.textContent,
     element.getAttribute('aria-label'),
     element.getAttribute('title')
-  ].filter(Boolean).join(' ')));
+  ]).map(normalize).filter(Boolean);
   const exact = label => labels.some(value => value.toLowerCase() === label);
   const hasChat = exact('chat') || exact('聊天');
   const hasWork = exact('work') || exact('工作');

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/contract.test.mjs
@@ -148,9 +148,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   assert.match(restoreSessionScript, /Optional CDP command/);
   assert.match(restoreSessionScript, /authenticatedControllerIsReady/);
   assert.match(restoreSessionScript, /!state\.asksForLogin/);
-  assert.doesNotMatch(
+  assert.match(
     restoreSessionScript,
-    /lastState\.currentMode\s*\|\|\s*lastState\.workComposer/,
+    /state\.currentMode\s*\|\|\s*state\.workComposer\s*\|\|\s*state\.hasChat\s*\|\|\s*state\.hasWork/,
   );
   assert.doesNotMatch(restoreSessionScript, /call\([^\n]*['"]Page\.setWebLifecycleState['"]/);
   assert.doesNotMatch(actionsWorkflow, /pkill -x ChatGPT/);
@@ -161,6 +161,9 @@ test('continuous Actions runner preserves secrets and chains incomplete sessions
   );
   assert.doesNotMatch(actionsWorkflow, /login_status=\$\(/);
   assert.match(actionsWorkflow, /Build native queue runtime/);
+  assert.match(actionsWorkflow, /native-auth-verify\.log/);
+  assert.match(actionsWorkflow, /native-auth-targets\.json/);
+  assert.match(actionsWorkflow, /Native ChatGPT authentication verification failed/);
   assert.match(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_STATE_KEY/);
   assert.doesNotMatch(actionsWorkflow, /CHATGPT_AUTO_CONFIRM_INITIAL_STATE_B64/);
   assert.match(actionsWorkflow, /\{"automationTasks":\[\]\}/);

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
@@ -21,6 +21,7 @@ class FakeCDPServer {
     stuckOverlay = false,
     navigationFailure = false,
     rootTargetFailures = 0,
+    controllerReady = true,
   }) {
     this.targets = [appTarget('initial', initialURL)];
     this.loginPrompt = loginPrompt;
@@ -28,6 +29,7 @@ class FakeCDPServer {
     this.stuckOverlay = stuckOverlay;
     this.navigationFailure = navigationFailure;
     this.rootTargetFailures = rootTargetFailures;
+    this.controllerReady = controllerReady;
     this.failAuthEvaluation = replaceOnAuthFailure;
     this.connections = [];
     this.closedSockets = 0;
@@ -85,6 +87,10 @@ class FakeCDPServer {
               readyState: 'complete',
               url: target?.url || '',
               visibility: 'visible',
+              hasChat: this.controllerReady,
+              hasWork: false,
+              currentMode: '',
+              workComposer: false,
             },
           },
         },
@@ -233,6 +239,19 @@ test('recovers when the active renderer fails during Runtime.evaluate', async ()
 
   assert.match(output, /^Verified authenticated desktop shell/);
   assert.ok(server.connections.some(item => item.target?.id === 'after-cdp-failure'));
+});
+
+
+test('does not accept a non-login placeholder shell without controller controls', async () => {
+  const server = new FakeCDPServer({
+    initialURL: 'app://-/index.html?initialRoute=%2F',
+    controllerReady: false,
+  });
+
+  await assert.rejects(
+    run(server, { verificationTimeoutMs: 4_000 }),
+    /Authenticated desktop shell was not verified/,
+  );
 });
 
 test('does not accept a real login prompt as an authenticated shell', async () => {

--- a/.github/workflows/chatgpt-auto-confirm-runner.yml
+++ b/.github/workflows/chatgpt-auto-confirm-runner.yml
@@ -353,13 +353,27 @@ jobs:
         if: ${{ inputs.cancel_task_id == '' }}
         id: auth_verify
         timeout-minutes: 6
+        shell: bash
         env:
           CHATGPT_AUTO_CONFIRM_STATE: ${{ steps.paths.outputs.state_path }}
           CHATGPT_AUTO_CONFIRM_QUEUE_STATE: ${{ steps.paths.outputs.state_path }}
           CHATGPT_AUTO_CONFIRM_CDP_PORT: ${{ env.CHATGPT_CDP_PORT }}
           CHATGPT_AUTO_CONFIRM_BACKGROUND_PORT: ${{ env.CHATGPT_CDP_PORT }}
           CHATGPT_AUTO_CONFIRM_PROFILE_PATH: ${{ steps.paths.outputs.profile_dir }}
-        run: .agents/plugins/plugins/chatgpt-auto-confirm/runtime/macos/chatgpt-auto-confirm verify_chatgpt_login
+          DIAGNOSTICS_DIR: ${{ steps.paths.outputs.runtime_dir }}/diagnostics
+        run: |
+          set -euo pipefail
+          mkdir -p "$DIAGNOSTICS_DIR"
+          log="$DIAGNOSTICS_DIR/native-auth-verify.log"
+          targets="$DIAGNOSTICS_DIR/native-auth-targets.json"
+          curl --silent --show-error --max-time 5 \
+            "http://127.0.0.1:$CHATGPT_AUTO_CONFIRM_CDP_PORT/json/list" \
+            > "$targets" || printf '%s\n' '[]' > "$targets"
+          if ! .agents/plugins/plugins/chatgpt-auto-confirm/runtime/macos/chatgpt-auto-confirm verify_chatgpt_login \
+            > >(tee "$log") 2> >(tee -a "$log" >&2); then
+            echo "::error::Native ChatGPT authentication verification failed. See $log and $targets in the diagnostic artifact."
+            exit 1
+          fi
 
       - name: Export and encrypt refreshed account credentials
         if: ${{ inputs.cancel_task_id == '' && inputs.account_id != '' && steps.auth_verify.outcome == 'success' }}


### PR DESCRIPTION
## Summary
- align JS session readiness with the native controller readiness contract
- stop accepting placeholder/error shells as authenticated
- persist native auth verification output and CDP target snapshots in diagnostics before failing
- add regression coverage for placeholder shells

## Evidence
Latest failed run 31183827889 restored cookies but JS accepted a shell with no Chat/Work/currentMode/workComposer and bodyLength=66; native verify then failed with chatgpt_controller_shell_unavailable.

## Tests
- node --test .agents/plugins/plugins/chatgpt-auto-confirm/test/restore-session-cookies.test.mjs
- targeted continuous Actions runner contract test

A branch smoke dispatch was attempted, but the account environment correctly rejected non-main deployment due to protection rules.