### PR TITLE
chore(queue): sync task revision 19

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 3,
-  "revision": "2026-08-09.13",
+  "revision": "2026-08-10.19",
   "keepAlive": true,
   "authoritative": true,
   "maxConcurrent": 2,
@@ -9,15 +9,17 @@
     {
       "id": "mahayana-marketplace-cloudflare-20260730",
       "goalVersion": 12,
-      "revision": 13,
+      "revision": 19,
       "applyMode": "next_chat",
       "title": "本地优先生成、双 GitHub 源码托管与分级上线的大乘 MCP Apps 平台",
       "promptTemplate": "continue-to-complete",
-      "directive": "这是对当前活动任务的 v12.3 执行位置纠偏，使用 next_chat 承接现有进度，不重启任务、不丢弃已完成工作。先读取 EXECUTION_TASKS_V12.md 与 LOCAL_GENERATION_GITHUB_DEPLOYMENT.md，再从当前首个未通过原子门禁继续。以本地 Workspace 为生成代码的第一事实源；只有用户明确上线才创建远程资源。官方托管仓库必须进入与 bhrumom 官方源码组织隔离的 managed user apps 组织，用户无需 GitHub 账号；用户自有 GitHub 路径只能通过官方 GitHub MCP/连接器并由用户明确选择 owner/repository。源码托管与网页运行部署是两个独立维度：GitHub Pages 仅用于用户明确同意公开且满足其使用政策的纯静态项目，不得宣称无限或作为商业 SaaS 的通用主机；Cloudflare 保留给动态、鉴权、API、实时或其他 Pages 不适用的线上运行。吸收 cloudflare/cloudflare-os 的 Workspace、Blueprint、能力授权、沙箱、可恢复动作队列和 source/instance 分离思想，但不得照搬其高成本每用户远程运行时。本地队列控制器必须在本地 Workspace 构建、测试、打包和安装；只有控制器本身运行在 GitHub Actions 时，才在该 Actions runner 内完成这些步骤。发布、部署、受保护分支检查与必须由 GitHub 产生的云端验收证据仍在 GitHub Actions 完成。",
+      "directive": "由小程序在每次派发前读取任务控制文件与全部规范文件并比较目标指纹。未更新时才沿原任务分支续作；目标或规范更新时必须新建 Chat，发送更新后的完整目标和任务目录，并重新创建立项邮件。第一轮、每一轮续作和验收轮发送前都必须重新选择 GPT-5.6 Sol 与 Extra High，并明确使用 GitHub 连接器操作 bhrumom/fabushi：任务文件在 .agents/plugins/plugins/chatgpt-auto-confirm/tasks/mahayana-marketplace-cloudflare-20260730，实际代码根目录是 fabushi/web。T01.1 已开始的精确实现入口为 fabushi/web/migrations/20260810_mcp_app_identity_schema.sql、fabushi/web/src/domain/mcp-app-identity.js、fabushi/web/tests/mcp-app-identity.test.js；若远端尚无这些文件就创建，已有则从现有内容续改，不得再次只做定位。Chat 每轮都必须直接产生代码变更并运行对应测试；只阅读、检查、规划、发邮件或总结不算工作，除非正在等待已启动的外部作业或确有人工卡点，否则不得结束。若旧 Chat 没有产生任何助手回复而恢复器必须新开 Chat，新 Chat 必须重新发送完整目标，绝不能误发续作短提示。只有全部完成才回复完成模板，外部长期等待才回复简短等待指令。",
       "connector": "GitHub",
+      "repository": "bhrumom/fabushi",
+      "codeDirectory": "fabushi/web",
       "priority": 90,
       "timeout": 21600,
-      "maxTaskContinuations": 6,
+      "maxTaskContinuations": 0,
       "maxRuntimeRetries": 2,
       "dependsOn": [],
       "resourceLocks": [


### PR DESCRIPTION
## 变更

- 将 `actions-inbox.json` 从 revision 13 更新到 revision 19
- 明确每轮使用 `GPT-5.6 Sol`、`Extra High` 和 GitHub 连接器
- 明确仓库 `bhrumom/fabushi`、任务目录、代码目录 `fabushi/web`
- 指定 T01.1 的三个精确实现入口，并禁止只读取/规划后结束
- 无助手回复而新开 Chat 时，要求重新发送完整目标

## 原因

云端持续任务控制器读取 `main` 上的任务文件；本地修订尚未同步，导致 GitHub Chat 继续使用旧的 revision 13 指令。

## 范围

该分支基于最新 `main`，只修改一份文件：
`.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json`

## 验证

- JSON 任务控制测试：10/10 通过
- GitHub compare：ahead 1、behind 0，仅该任务文件有 10 行变更