### PR TITLE
feat: establish Mahayana Host fast functional E2E foundation

### DIFF
--- a/.github/workflows/host-fast-e2e.yml
+++ b/.github/workflows/host-fast-e2e.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     steps:
       - name: Checkout only Host test inputs
         uses: actions/checkout@v5

--- a/.github/workflows/host-fast-e2e.yml
+++ b/.github/workflows/host-fast-e2e.yml
@@ -1,0 +1,92 @@
+name: Host fast E2E
+
+on:
+  pull_request:
+    paths:
+      - frontend/apps/web/src/app/host/**
+      - frontend/apps/web/src/lib/mahayana-host/**
+      - frontend/apps/web/tsconfig.host.json
+      - frontend/apps/web/package.json
+      - frontend/packages/shared/src/mahayana-host-features.ts
+      - frontend/packages/shared/src/index.ts
+      - frontend/pnpm-lock.yaml
+      - fabushi/e2e/package.json
+      - fabushi/e2e/package-lock.json
+      - fabushi/e2e/playwright.host.config.js
+      - fabushi/e2e/tests/host-fast-user-journey.spec.ts
+      - .github/workflows/host-fast-e2e.yml
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/apps/web/src/app/host/**
+      - frontend/apps/web/src/lib/mahayana-host/**
+      - frontend/apps/web/tsconfig.host.json
+      - frontend/packages/shared/src/mahayana-host-features.ts
+      - fabushi/e2e/**
+      - .github/workflows/host-fast-e2e.yml
+  workflow_dispatch:
+
+concurrency:
+  group: host-fast-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  host-fast-e2e:
+    name: React Host complete user journey
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+    steps:
+      - name: Checkout only Host test inputs
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /frontend/**
+            /fabushi/e2e/**
+
+      - name: Enable pnpm through Corepack
+        run: corepack enable
+
+      - name: Install frontend dependencies from lockfile
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Strictly typecheck the new Host boundary
+        working-directory: frontend
+        run: pnpm --filter @fabushi/web typecheck:host
+
+      - name: Install Playwright test package
+        working-directory: fabushi/e2e
+        run: npm ci
+
+      - name: Run complete Host user journey under execution budget
+        id: journey
+        working-directory: fabushi/e2e
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_at="$(date +%s)"
+          npm run test:host-fast
+          elapsed="$(( $(date +%s) - started_at ))"
+          echo "elapsed_seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          echo "Host user journey elapsed: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$elapsed" -gt 120 ]; then
+            echo "Host fast E2E exceeded the 120-second execution budget." >&2
+            exit 1
+          fi
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: host-fast-e2e-diagnostics
+          path: |
+            fabushi/e2e/playwright-report/host-fast
+            fabushi/e2e/test-results
+          if-no-files-found: ignore

--- a/.github/workflows/host-fast-e2e.yml
+++ b/.github/workflows/host-fast-e2e.yml
@@ -38,9 +38,7 @@ jobs:
   host-fast-e2e:
     name: React Host complete user journey
     runs-on: ubuntu-latest
-    timeout-minutes: 8
-    container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    timeout-minutes: 5
     steps:
       - name: Checkout only Host test inputs
         uses: actions/checkout@v5
@@ -50,7 +48,7 @@ jobs:
             /frontend/**
             /fabushi/e2e/**
 
-      - name: Enable pnpm through Corepack
+      - name: Enable pinned pnpm through Corepack
         run: corepack enable
 
       - name: Install frontend dependencies from lockfile
@@ -61,9 +59,14 @@ jobs:
         working-directory: frontend
         run: pnpm --filter @fabushi/web typecheck:host
 
-      - name: Install Playwright test package
+      - name: Install Playwright test package without browser download
         working-directory: fabushi/e2e
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: npm ci
+
+      - name: Verify system Chrome is available
+        run: google-chrome --version
 
       - name: Run complete Host user journey under execution budget
         id: journey
@@ -76,8 +79,8 @@ jobs:
           elapsed="$(( $(date +%s) - started_at ))"
           echo "elapsed_seconds=$elapsed" >> "$GITHUB_OUTPUT"
           echo "Host user journey elapsed: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
-          if [ "$elapsed" -gt 120 ]; then
-            echo "Host fast E2E exceeded the 120-second execution budget." >&2
+          if [ "$elapsed" -gt 60 ]; then
+            echo "Host fast E2E exceeded the 60-second execution budget." >&2
             exit 1
           fi
 

--- a/.github/workflows/mahayana-fast-checks.yml
+++ b/.github/workflows/mahayana-fast-checks.yml
@@ -1,0 +1,67 @@
+name: Mahayana fast checks
+
+on:
+  pull_request:
+    paths:
+      - third_party/mahayana/mahayana-rs/**
+      - .github/workflows/mahayana-fast-checks.yml
+  push:
+    branches:
+      - main
+    paths:
+      - third_party/mahayana/mahayana-rs/**
+      - .github/workflows/mahayana-fast-checks.yml
+  workflow_dispatch:
+
+concurrency:
+  group: mahayana-fast-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  protocol-and-bridge:
+    name: Rust protocol and bridge fast gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    defaults:
+      run:
+        working-directory: third_party/mahayana/mahayana-rs
+    steps:
+      - name: Checkout Mahayana sources
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /third_party/mahayana/**
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Restore targeted Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: third_party/mahayana/mahayana-rs -> target
+          shared-key: mahayana-fast-v1
+          cache-all-crates: true
+
+      - name: Verify formatting
+        run: cargo fmt --all -- --check
+
+      - name: Test protocol and MiniApp bridge
+        run: >-
+          cargo test
+          -p mahayana-miniapp-protocol
+          -p mahayana-miniapp-bridge
+          --profile ci
+
+      - name: Check minimal embedded FFI boundary
+        run: >-
+          cargo check
+          -p mahayana-ffi
+          --profile ci
+          --no-default-features
+          --features local-only

--- a/.github/workflows/mahayana-fast-checks.yml
+++ b/.github/workflows/mahayana-fast-checks.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   protocol-and-bridge:
-    name: Rust protocol and bridge fast gate
+    name: Rust protocol, Host, and bridge fast gate
     runs-on: ubuntu-latest
     timeout-minutes: 12
     env:
@@ -47,7 +47,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: mahayana-fast-v2
+          shared-key: mahayana-fast-v3
           cache-all-crates: true
 
       - name: Verify formatting
@@ -59,6 +59,14 @@ jobs:
           -p mahayana-miniapp-protocol
           -p mahayana-miniapp-bridge
           --profile ci
+
+      - name: Test direct Mahayana Host
+        run: >-
+          cargo test
+          -p mahayana-host
+          --profile ci
+          --no-default-features
+          --features local-only
 
       - name: Check minimal embedded FFI boundary
         run: >-

--- a/.github/workflows/mahayana-fast-checks.yml
+++ b/.github/workflows/mahayana-fast-checks.yml
@@ -25,6 +25,8 @@ jobs:
     name: Rust protocol and bridge fast gate
     runs-on: ubuntu-latest
     timeout-minutes: 12
+    env:
+      CARGO_INCREMENTAL: "1"
     defaults:
       run:
         working-directory: third_party/mahayana/mahayana-rs
@@ -45,7 +47,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: mahayana-fast-v1
+          shared-key: mahayana-fast-v2
           cache-all-crates: true
 
       - name: Verify formatting

--- a/.github/workflows/migration-surface-contract.yml
+++ b/.github/workflows/migration-surface-contract.yml
@@ -1,0 +1,45 @@
+name: Migration surface contract
+
+on:
+  pull_request:
+    paths:
+      - fabushi/lib/features/**
+      - fabushi/lib/screens/**
+      - fabushi/lib/services/**
+      - frontend/packages/shared/src/mahayana-host-features.ts
+      - contracts/migration/legacy-surface.json
+      - scripts/check-migration-surface.mjs
+      - .github/workflows/migration-surface-contract.yml
+  push:
+    branches: [main]
+    paths:
+      - fabushi/lib/features/**
+      - fabushi/lib/screens/**
+      - fabushi/lib/services/**
+      - contracts/migration/legacy-surface.json
+      - scripts/check-migration-surface.mjs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  migration-surface:
+    name: Every legacy feature has an explicit migration disposition
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout only migration inputs
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/lib/features/**
+            /fabushi/lib/screens/**
+            /fabushi/lib/services/**
+            /frontend/packages/shared/src/mahayana-host-features.ts
+            /contracts/migration/legacy-surface.json
+            /scripts/check-migration-surface.mjs
+
+      - name: Verify exact legacy surface and E2E evidence references
+        run: node scripts/check-migration-surface.mjs

--- a/contracts/migration/legacy-surface.json
+++ b/contracts/migration/legacy-surface.json
@@ -1,0 +1,176 @@
+{
+  "schemaVersion": 1,
+  "trackedRoots": [
+    "fabushi/lib/features",
+    "fabushi/lib/screens",
+    "fabushi/lib/services"
+  ],
+  "featureCatalogPath": "frontend/packages/shared/src/mahayana-host-features.ts",
+  "expected": {
+    "fileCount": 266,
+    "sha256": "a35b9780092cd9836b629069240aabd6dfad0b6fc280f7a3c13cb365103b8852"
+  },
+  "domains": [
+    {
+      "id": "auth-account",
+      "target": "mahayana-host + React Host + secure platform storage",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/features/auth/",
+        "^fabushi/lib/screens/(alipay_web_login|douyin_login|forgot_password|register|telegram_authorization)_screen\\.dart$",
+        "^fabushi/lib/services/(auth_service|firebase_auth_service|mock_auth_service|alipay_auth_service)\\.dart$"
+      ],
+      "e2eFeatureIds": ["session.clear"]
+    },
+    {
+      "id": "profile-membership",
+      "target": "mahayana-product + React Host",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/features/(membership|profile)/",
+        "^fabushi/lib/screens/(edit_profile|membership|membership_screen_web|my_profile|profile)_screen\\.dart$",
+        "^fabushi/lib/services/membership_service\\.dart$"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "conversations-social",
+      "target": "mahayana-social/telegram + React Host",
+      "status": "in-progress",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(social_|telegram_friend_chat)",
+        "^fabushi/lib/services/(social_|comment_service|user_block_service|feed_service|like_service)",
+        "^fabushi/lib/services/telegram/"
+      ],
+      "e2eFeatureIds": ["chat.send"]
+    },
+    {
+      "id": "ai-runtime",
+      "target": "mahayana-host/runtime + React Host",
+      "status": "in-progress",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/sutra_ai_page\\.dart$",
+        "^fabushi/lib/services/(agent_service|ai_backend_policy|dacheng_ai_service|llm_|multimodal_|mahayana_)",
+        "^fabushi/lib/services/openclaw/"
+      ],
+      "e2eFeatureIds": [
+        "runtime.boot",
+        "chat.send",
+        "capability.approval",
+        "operation.interrupt"
+      ]
+    },
+    {
+      "id": "miniapp-marketplace",
+      "target": "mahayana-miniapp + isolated React/WebView Host",
+      "status": "in-progress",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/mini_app_host_screen\\.dart$",
+        "^fabushi/lib/services/(mini_app_registry_service|codex_plugin_catalog)",
+        "^fabushi/lib/services/miniapp/"
+      ],
+      "e2eFeatureIds": [
+        "marketplace.install",
+        "miniapp.open",
+        "capability.approval"
+      ]
+    },
+    {
+      "id": "payments",
+      "target": "Rust payment state machine + thin Apple/Alipay plugins",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/services/(alipay_service|apple_iap_service)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "dharma-study",
+      "target": "official signed MiniApps",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/features/flashcards/",
+        "^fabushi/lib/screens/(content_detail|dharma_|global_dharma|liked_content|search|sutra_|work_player)",
+        "^fabushi/lib/services/(cbeta_|cloudflare_text|content_|dharma_|favorite_|merit_|recitation_|semantic_|sentence_|sutra_|text_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "practice-meditation",
+      "target": "official MiniApps + shared Rust data services",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(leaderboard|meditation_|practice_)",
+        "^fabushi/lib/services/(achievement_|co_practice_|leaderboard_|meditation_|practice_|user_activity_|zen_recitation_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "media-feed",
+      "target": "optional MiniApps or explicit product deletion",
+      "status": "pending",
+      "requiredForCutover": false,
+      "patterns": [
+        "^fabushi/lib/screens/video_feed_screen\\.dart$",
+        "^fabushi/lib/services/(audio_|offline_asr_|sherpa_|tts_|video_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "global-transfer",
+      "target": "Rust platform services + capability-gated Host UI",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(asset|globe_home)_screen\\.dart$",
+        "^fabushi/lib/services/(abstract_file|download|downloaded_assets|file_|global_|hotspot_|inbound_share|platform_global|real_global|shared_asset|udp_|web_bluetooth|wifi_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "settings-platform",
+      "target": "React Host settings + thin platform plugins",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(eula|keep_alive_guide|loading|main_navigation|settings|test_info)_screen\\.dart$",
+        "^fabushi/lib/services/(api_client|app_|device_|diagnostic_|error_report|eula_|http_|keep_alive_|memory_|network_|platform_service|project_|unified_api|worker_config|workmanager_|workspace_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "desktop-control",
+      "target": "capability-gated Rust/Tauri commands",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": ["^fabushi/lib/services/desktop_control/"],
+      "e2eFeatureIds": ["capability.approval"]
+    },
+    {
+      "id": "visualization-demos",
+      "target": "delete unless explicitly retained as a MiniApp",
+      "status": "pending",
+      "requiredForCutover": false,
+      "patterns": [
+        "^fabushi/lib/screens/(beautiful_trajectory_demo|buddha_model|earth_globe_demo)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "unclassified-legacy",
+      "target": "must be classified or deleted before cutover",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [".*"],
+      "e2eFeatureIds": []
+    }
+  ]
+}

--- a/docs/fast-feature-testing.md
+++ b/docs/fast-feature-testing.md
@@ -1,0 +1,50 @@
+# Fabushi 极速功能测试开发规范
+
+## 目标
+
+业务逻辑优先进入 Mahayana Rust Core；React Host 只负责交互。普通 Pull Request 不启动 iOS Simulator、Android Emulator 或完整安装包构建。只有平台桥接和发布候选才运行重型测试。
+
+## 新功能的最短路径
+
+1. 在 `frontend/packages/shared/src/mahayana-host-features.ts` 增加稳定 feature id。
+2. 在 `frontend/apps/web/src/lib/mahayana-host/contracts.ts` 增加命令或事件契约。
+3. 先在 `MockMahayanaHostTransport` 实现确定性行为，让 UI 和用户旅程立即可测试。
+4. 在 Host 页面增加真实用户操作入口，并通过 Runtime 事件更新 feature state。
+5. 在 `host-fast-user-journey.spec.ts` 增加最短用户操作。
+6. 实现 Rust/Tauri transport 后，复用同一契约和同一用户旅程；不得复制业务规则到 UI。
+
+只要功能被加入 feature catalog，却没有在用户旅程中被实际触发，它会保持 `pending`，`Host fast E2E` 会失败。
+
+## 本地快速命令
+
+```bash
+cd frontend
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter @fabushi/web typecheck:host
+
+cd ../fabushi/e2e
+npm ci
+npm run test:host-fast
+```
+
+Rust 核心定向检查：
+
+```bash
+cd third_party/mahayana/mahayana-rs
+cargo test -p mahayana-miniapp-protocol -p mahayana-miniapp-bridge --profile ci
+cargo check -p mahayana-ffi --profile ci --no-default-features --features local-only
+```
+
+## Gate 分层
+
+- **每次 PR，秒级到分钟级：** Host TypeScript、Playwright MockTransport 用户旅程、受影响 Rust crate。
+- **平台桥接改动：** Tauri command contract、Swift/Kotlin 插件 smoke。
+- **主分支或发布候选：** 安装包、签名、真实设备、升级与回滚。
+
+## 性能预算
+
+- Host 用户旅程自身不超过 120 秒，包括 Next 开发服务器冷启动。
+- 新测试不得依赖固定 `sleep`；使用可观察状态和 Playwright 自动等待。
+- 不在普通 PR 中执行 Rust release LTO、五平台打包或全量 Flutter E2E。
+- 失败时上传 trace、截图和 HTML 报告；成功时不上传大体积 artifact。

--- a/fabushi/e2e/package-lock.json
+++ b/fabushi/e2e/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "fabushi-staging-e2e",
       "devDependencies": {
-        "@playwright/test": "^1.57.0"
+        "@playwright/test": "1.59.1"
       }
     },
     "node_modules/@playwright/test": {

--- a/fabushi/e2e/package.json
+++ b/fabushi/e2e/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "playwright test tests/staging-profile-api.spec.js tests/staging_social_privacy.spec.ts",
-    "test:ui": "playwright test tests/staging-profile-api.spec.js tests/staging_social_privacy.spec.ts"
+    "test:ui": "playwright test tests/staging-profile-api.spec.js tests/staging_social_privacy.spec.ts",
+    "test:host-fast": "playwright test --config=playwright.host.config.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0"

--- a/fabushi/e2e/package.json
+++ b/fabushi/e2e/package.json
@@ -8,6 +8,6 @@
     "test:host-fast": "playwright test --config=playwright.host.config.js"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0"
+    "@playwright/test": "1.59.1"
   }
 }

--- a/fabushi/e2e/playwright.host.config.js
+++ b/fabushi/e2e/playwright.host.config.js
@@ -1,0 +1,31 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "host-fast-user-journey.spec.ts",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  reporter: [
+    ["line"],
+    ["html", { outputFolder: "playwright-report/host-fast", open: "never" }],
+  ],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+  webServer: {
+    command:
+      "corepack pnpm --dir ../../frontend --filter @fabushi/web exec next dev --hostname 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173/host",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/fabushi/e2e/playwright.host.config.js
+++ b/fabushi/e2e/playwright.host.config.js
@@ -21,10 +21,10 @@ export default defineConfig({
   },
   webServer: {
     // Run Next directly from the package installed by the pinned pnpm workspace.
-    // This keeps Playwright's container-bundled pnpm version out of the runtime
-    // path and makes local/CI startup deterministic.
+    // Pin both the executable and working directory so Playwright's container
+    // package manager cannot change startup behavior.
     command:
-      "node ../../frontend/apps/web/node_modules/next/dist/bin/next dev --hostname 127.0.0.1 --port 4173",
+      "cd ../../frontend/apps/web && node ./node_modules/next/dist/bin/next dev --hostname 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173/host",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/fabushi/e2e/playwright.host.config.js
+++ b/fabushi/e2e/playwright.host.config.js
@@ -20,8 +20,11 @@ export default defineConfig({
     video: "off",
   },
   webServer: {
+    // Run Next directly from the package installed by the pinned pnpm workspace.
+    // This keeps Playwright's container-bundled pnpm version out of the runtime
+    // path and makes local/CI startup deterministic.
     command:
-      "corepack pnpm --dir ../../frontend --filter @fabushi/web exec next dev --hostname 127.0.0.1 --port 4173",
+      "node ../../frontend/apps/web/node_modules/next/dist/bin/next dev --hostname 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173/host",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/fabushi/e2e/playwright.host.config.js
+++ b/fabushi/e2e/playwright.host.config.js
@@ -15,14 +15,15 @@ export default defineConfig({
   ],
   use: {
     baseURL: "http://127.0.0.1:4173",
+    // GitHub's Ubuntu image already ships Google Chrome. Reusing it removes the
+    // 20+ second Playwright container pull while keeping the browser version
+    // explicit in the runner image release metadata.
+    channel: process.env.CI ? "chrome" : undefined,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "off",
   },
   webServer: {
-    // Run Next directly from the package installed by the pinned pnpm workspace.
-    // Pin both the executable and working directory so Playwright's container
-    // package manager cannot change startup behavior.
     command:
       "cd ../../frontend/apps/web && node ./node_modules/next/dist/bin/next dev --hostname 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173/host",

--- a/fabushi/e2e/tests/host-fast-user-journey.spec.ts
+++ b/fabushi/e2e/tests/host-fast-user-journey.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+test("Mahayana Host 的所有声明功能可由用户操作完成", async ({ page }) => {
+  await page.goto("/host");
+  await expect(page.getByTestId("host-status")).toHaveText("ready");
+
+  await page.getByTestId("chat-input").fill("验证极速自动化测试");
+  await page.getByTestId("send-message").click();
+  await expect(page.getByTestId("messages")).toContainText(
+    "收到：验证极速自动化测试",
+  );
+
+  await page.getByTestId("install-miniapp").click();
+  await expect(page.getByTestId("marketplace-state")).toHaveText("installed");
+
+  await page.getByTestId("open-miniapp").click();
+  await expect(page.getByTestId("miniapp-panel")).toBeVisible();
+
+  await page.getByTestId("request-capability").click();
+  await expect(page.getByRole("dialog", { name: "能力审批" })).toBeVisible();
+  await page.getByTestId("approve-capability").click();
+  await expect(page.getByTestId("approval-state")).toHaveText("allowed");
+
+  await page.getByTestId("start-long-operation").click();
+  await expect(page.getByTestId("operation-state")).toHaveText("running");
+  await page.getByTestId("interrupt-operation").click();
+  await expect(page.getByTestId("operation-state")).toHaveText("interrupted");
+
+  await page.getByTestId("clear-session").click();
+  await expect(page.getByTestId("session-state")).toHaveText("cleared");
+
+  const featureResults = page.locator('[data-testid^="feature-result-"]');
+  const featureCount = await featureResults.count();
+  expect(featureCount).toBeGreaterThanOrEqual(7);
+  for (let index = 0; index < featureCount; index += 1) {
+    await expect(featureResults.nth(index)).toHaveAttribute("data-state", "passed");
+  }
+});

--- a/fabushi/e2e/tests/host-fast-user-journey.spec.ts
+++ b/fabushi/e2e/tests/host-fast-user-journey.spec.ts
@@ -1,38 +1,53 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+import {
+  mahayanaHostFeatures,
+  type MahayanaHostJourneyStep,
+} from "../../../frontend/packages/shared/src/mahayana-host-features";
 
-test("Mahayana Host 的所有声明功能可由用户操作完成", async ({ page }) => {
+async function runJourneyStep(
+  page: Page,
+  step: MahayanaHostJourneyStep,
+): Promise<void> {
+  switch (step.action) {
+    case "expectText":
+      await expect(page.getByTestId(step.testId)).toHaveText(step.text);
+      return;
+    case "expectContainsText":
+      await expect(page.getByTestId(step.testId)).toContainText(step.text);
+      return;
+    case "fill":
+      await page.getByTestId(step.testId).fill(step.value);
+      return;
+    case "click":
+      await page.getByTestId(step.testId).click();
+      return;
+    case "expectVisible":
+      await expect(page.getByTestId(step.testId)).toBeVisible();
+      return;
+    case "expectDialog":
+      await expect(page.getByRole("dialog", { name: step.name })).toBeVisible();
+      return;
+    default: {
+      const unhandled: never = step;
+      throw new Error(`Unhandled Host journey step: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+test("Mahayana Host 的所有声明功能可由目录驱动的用户操作完成", async ({
+  page,
+}) => {
   await page.goto("/host");
-  await expect(page.getByTestId("host-status")).toHaveText("ready");
 
-  await page.getByTestId("chat-input").fill("验证极速自动化测试");
-  await page.getByTestId("send-message").click();
-  await expect(page.getByTestId("messages")).toContainText(
-    "收到：验证极速自动化测试",
-  );
-
-  await page.getByTestId("install-miniapp").click();
-  await expect(page.getByTestId("marketplace-state")).toHaveText("installed");
-
-  await page.getByTestId("open-miniapp").click();
-  await expect(page.getByTestId("miniapp-panel")).toBeVisible();
-
-  await page.getByTestId("request-capability").click();
-  await expect(page.getByRole("dialog", { name: "能力审批" })).toBeVisible();
-  await page.getByTestId("approve-capability").click();
-  await expect(page.getByTestId("approval-state")).toHaveText("allowed");
-
-  await page.getByTestId("start-long-operation").click();
-  await expect(page.getByTestId("operation-state")).toHaveText("running");
-  await page.getByTestId("interrupt-operation").click();
-  await expect(page.getByTestId("operation-state")).toHaveText("interrupted");
-
-  await page.getByTestId("clear-session").click();
-  await expect(page.getByTestId("session-state")).toHaveText("cleared");
-
-  const featureResults = page.locator('[data-testid^="feature-result-"]');
-  const featureCount = await featureResults.count();
-  expect(featureCount).toBeGreaterThanOrEqual(7);
-  for (let index = 0; index < featureCount; index += 1) {
-    await expect(featureResults.nth(index)).toHaveAttribute("data-state", "passed");
+  for (const feature of mahayanaHostFeatures) {
+    await test.step(`${feature.id}: ${feature.label}`, async () => {
+      for (const step of feature.journey) {
+        await runJourneyStep(page, step);
+      }
+      await expect(page.getByTestId(`feature-result-${feature.id}`)).toHaveAttribute(
+        "data-state",
+        "passed",
+      );
+    });
   }
 });

--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "echo 'Skipping typecheck due to React 19 migration' && exit 0"
+    "typecheck": "echo 'Skipping typecheck due to React 19 migration' && exit 0",
+    "typecheck:host": "tsc -p tsconfig.host.json --noEmit"
   },
   "dependencies": {
     "@fabushi/api-client": "workspace:*",

--- a/frontend/apps/web/src/app/host/host-client.tsx
+++ b/frontend/apps/web/src/app/host/host-client.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import {
+  mahayanaHostFeatures,
+  type MahayanaHostFeatureId,
+  type MahayanaHostFeatureState,
+} from "@fabushi/shared";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+import styles from "./host.module.css";
+import type {
+  ApprovalRequestedEvent,
+  RuntimeCommand,
+} from "../../lib/mahayana-host/contracts";
+import { MockMahayanaHostTransport } from "../../lib/mahayana-host/mock-transport";
+import type { MahayanaHostTransport } from "../../lib/mahayana-host/transport";
+
+const miniAppId = "global-dharma";
+
+type FeatureStates = Record<
+  MahayanaHostFeatureId,
+  MahayanaHostFeatureState
+>;
+
+function createInitialFeatureStates(): FeatureStates {
+  return Object.fromEntries(
+    mahayanaHostFeatures.map((feature) => [feature.id, "pending"]),
+  ) as FeatureStates;
+}
+
+export default function HostClient() {
+  const transport = useMemo<MahayanaHostTransport>(
+    () => new MockMahayanaHostTransport(),
+    [],
+  );
+  const requestSequence = useRef(0);
+  const [hostStatus, setHostStatus] = useState("initializing");
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<
+    Array<{ role: "user" | "assistant"; text: string }>
+  >([]);
+  const [marketplaceState, setMarketplaceState] = useState("not-installed");
+  const [openedMiniApp, setOpenedMiniApp] = useState<string | null>(null);
+  const [approval, setApproval] = useState<ApprovalRequestedEvent | null>(null);
+  const [approvalState, setApprovalState] = useState("not-requested");
+  const [activeOperationId, setActiveOperationId] = useState<string | null>(null);
+  const [operationState, setOperationState] = useState("idle");
+  const [sessionState, setSessionState] = useState("active");
+  const [featureStates, setFeatureStates] = useState<FeatureStates>(
+    createInitialFeatureStates,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const pass = (featureId: MahayanaHostFeatureId) => {
+      setFeatureStates((current) => ({
+        ...current,
+        [featureId]: "passed",
+      }));
+    };
+
+    const unsubscribe = transport.subscribe((event) => {
+      switch (event.type) {
+        case "host.ready":
+          setHostStatus("ready");
+          pass("runtime.boot");
+          break;
+        case "chat.message":
+          setMessages((current) => [
+            ...current,
+            { role: event.role, text: event.text },
+          ]);
+          if (event.role === "assistant") pass("chat.send");
+          break;
+        case "marketplace.installed":
+          setMarketplaceState("installed");
+          pass("marketplace.install");
+          break;
+        case "miniapp.opened":
+          setOpenedMiniApp(event.miniAppId);
+          pass("miniapp.open");
+          break;
+        case "approval.requested":
+          setApproval(event);
+          setApprovalState("pending");
+          break;
+        case "approval.resolved":
+          setApproval(null);
+          setApprovalState(event.decision === "allow-once" ? "allowed" : "denied");
+          pass("capability.approval");
+          break;
+        case "operation.started":
+          if (event.interruptible) {
+            setActiveOperationId(event.operationId);
+            setOperationState("running");
+          }
+          break;
+        case "operation.interrupted":
+          setActiveOperationId(null);
+          setOperationState("interrupted");
+          pass("operation.interrupt");
+          break;
+        case "session.cleared":
+          setSessionState("cleared");
+          pass("session.clear");
+          break;
+        case "host.closed":
+          setHostStatus("closed");
+          break;
+      }
+    });
+
+    void transport
+      .initialize({ profileId: "fast-e2e", mode: "test" })
+      .catch((cause: unknown) => {
+        setHostStatus("failed");
+        setError(cause instanceof Error ? cause.message : String(cause));
+      });
+
+    return () => {
+      unsubscribe();
+      void transport.close();
+    };
+  }, [transport]);
+
+  const nextRequestId = (prefix: string) => {
+    requestSequence.current += 1;
+    return `${prefix}-${requestSequence.current}`;
+  };
+
+  const run = async (action: () => Promise<unknown>) => {
+    setError(null);
+    try {
+      await action();
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const execute = (command: RuntimeCommand) => transport.execute(command);
+
+  const sendMessage = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const text = input.trim();
+    if (!text) return;
+    setInput("");
+    await run(() =>
+      execute({ type: "chat.send", requestId: nextRequestId("chat"), text }),
+    );
+  };
+
+  return (
+    <main className={styles.page} data-testid="mahayana-host">
+      <header className={styles.header}>
+        <div>
+          <p className={styles.eyebrow}>Mahayana Rust Core · React Host</p>
+          <h1>极速功能自动化测试宿主</h1>
+        </div>
+        <output
+          className={styles.status}
+          data-testid="host-status"
+          aria-live="polite"
+        >
+          {hostStatus}
+        </output>
+      </header>
+
+      {error ? <p role="alert" className={styles.error}>{error}</p> : null}
+
+      <div className={styles.grid}>
+        <section className={styles.card} aria-labelledby="chat-title">
+          <h2 id="chat-title">聊天</h2>
+          <div className={styles.messages} data-testid="messages" aria-live="polite">
+            {messages.length === 0 ? (
+              <p className={styles.muted}>发送一条消息验证 Runtime 事件链。</p>
+            ) : (
+              messages.map((message, index) => (
+                <p
+                  key={`${message.role}-${index}`}
+                  data-testid={`message-${message.role}`}
+                  className={styles.message}
+                >
+                  <strong>{message.role === "user" ? "用户" : "Mahayana"}：</strong>
+                  {message.text}
+                </p>
+              ))
+            )}
+          </div>
+          <form className={styles.form} onSubmit={(event) => void sendMessage(event)}>
+            <input
+              data-testid="chat-input"
+              aria-label="消息内容"
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="输入消息"
+              disabled={hostStatus !== "ready"}
+            />
+            <button data-testid="send-message" type="submit" disabled={hostStatus !== "ready"}>
+              发送
+            </button>
+          </form>
+        </section>
+
+        <section className={styles.card} aria-labelledby="marketplace-title">
+          <h2 id="marketplace-title">Marketplace 与 MiniApp</h2>
+          <p>官方小程序：全球法布施</p>
+          <div className={styles.actions}>
+            <button
+              data-testid="install-miniapp"
+              type="button"
+              onClick={() =>
+                void run(() =>
+                  execute({
+                    type: "marketplace.install",
+                    requestId: nextRequestId("install"),
+                    miniAppId,
+                  }),
+                )
+              }
+            >
+              安装
+            </button>
+            <button
+              data-testid="open-miniapp"
+              type="button"
+              disabled={marketplaceState !== "installed"}
+              onClick={() =>
+                void run(() =>
+                  execute({
+                    type: "miniapp.open",
+                    requestId: nextRequestId("open"),
+                    miniAppId,
+                  }),
+                )
+              }
+            >
+              打开
+            </button>
+          </div>
+          <output data-testid="marketplace-state">{marketplaceState}</output>
+
+          {openedMiniApp ? (
+            <article className={styles.miniApp} data-testid="miniapp-panel">
+              <h3>{openedMiniApp}</h3>
+              <p>隔离 MiniApp 容器已打开。</p>
+              <button
+                data-testid="request-capability"
+                type="button"
+                onClick={() =>
+                  void run(() =>
+                    execute({
+                      type: "capability.request",
+                      requestId: nextRequestId("capability"),
+                      miniAppId,
+                      capability: "microphone.request",
+                      reason: "为语音布施功能录制音频",
+                    }),
+                  )
+                }
+              >
+                请求麦克风权限
+              </button>
+            </article>
+          ) : null}
+          <output data-testid="approval-state">{approvalState}</output>
+        </section>
+
+        <section className={styles.card} aria-labelledby="runtime-title">
+          <h2 id="runtime-title">Runtime 控制</h2>
+          <div className={styles.actions}>
+            <button
+              data-testid="start-long-operation"
+              type="button"
+              onClick={() =>
+                void run(() =>
+                  execute({
+                    type: "runtime.longTask",
+                    requestId: nextRequestId("long-task"),
+                    label: "长任务测试",
+                  }),
+                )
+              }
+            >
+              启动长任务
+            </button>
+            <button
+              data-testid="interrupt-operation"
+              type="button"
+              disabled={!activeOperationId}
+              onClick={() =>
+                activeOperationId
+                  ? void run(() => transport.interrupt(activeOperationId))
+                  : undefined
+              }
+            >
+              中断
+            </button>
+          </div>
+          <output data-testid="operation-state">{operationState}</output>
+
+          <button
+            data-testid="clear-session"
+            type="button"
+            onClick={() =>
+              void run(() =>
+                execute({
+                  type: "session.clear",
+                  requestId: nextRequestId("session"),
+                }),
+              )
+            }
+          >
+            清除安全会话
+          </button>
+          <output data-testid="session-state">{sessionState}</output>
+        </section>
+
+        <section className={styles.card} aria-labelledby="coverage-title">
+          <h2 id="coverage-title">功能覆盖 Gate</h2>
+          <p className={styles.muted}>
+            新功能加入目录后默认是 pending；用户旅程没有覆盖它时，Actions 会失败。
+          </p>
+          <ul className={styles.coverage} data-testid="feature-coverage">
+            {mahayanaHostFeatures.map((feature) => (
+              <li
+                key={feature.id}
+                data-testid={`feature-result-${feature.id}`}
+                data-state={featureStates[feature.id]}
+              >
+                <span>{feature.label}</span>
+                <strong>{featureStates[feature.id]}</strong>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      {approval ? (
+        <div className={styles.backdrop}>
+          <section className={styles.dialog} role="dialog" aria-modal="true" aria-labelledby="approval-title">
+            <h2 id="approval-title">能力审批</h2>
+            <p>{approval.miniAppId} 请求 {approval.capability}</p>
+            <p>{approval.reason}</p>
+            <div className={styles.actions}>
+              <button
+                data-testid="approve-capability"
+                type="button"
+                onClick={() =>
+                  void run(() =>
+                    transport.resolveApproval({
+                      approvalId: approval.approvalId,
+                      decision: "allow-once",
+                    }),
+                  )
+                }
+              >
+                本次允许
+              </button>
+              <button
+                data-testid="deny-capability"
+                type="button"
+                onClick={() =>
+                  void run(() =>
+                    transport.resolveApproval({
+                      approvalId: approval.approvalId,
+                      decision: "deny",
+                    }),
+                  )
+                }
+              >
+                拒绝
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/frontend/apps/web/src/app/host/host.module.css
+++ b/frontend/apps/web/src/app/host/host.module.css
@@ -1,0 +1,170 @@
+.page {
+  min-height: 100vh;
+  padding: 32px;
+  background: #f5f4ef;
+  color: #1d2520;
+}
+
+.header {
+  max-width: 1180px;
+  margin: 0 auto 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.header h1 {
+  margin: 4px 0 0;
+  font-size: clamp(28px, 4vw, 48px);
+}
+
+.eyebrow {
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #526158;
+}
+
+.status {
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: #dff3e6;
+  font-weight: 700;
+}
+
+.grid {
+  max-width: 1180px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.card {
+  padding: 22px;
+  border: 1px solid #d9ddd7;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgb(29 37 32 / 7%);
+}
+
+.card h2,
+.card h3 {
+  margin-top: 0;
+}
+
+.messages {
+  min-height: 120px;
+  max-height: 260px;
+  overflow: auto;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f6f8f5;
+}
+
+.message {
+  margin: 8px 0;
+}
+
+.form,
+.actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.form input {
+  min-width: 0;
+  flex: 1;
+  padding: 11px 12px;
+  border: 1px solid #bcc5bd;
+  border-radius: 10px;
+}
+
+.page button {
+  padding: 10px 14px;
+  border: 0;
+  border-radius: 10px;
+  background: #264d38;
+  color: #ffffff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.page button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.miniApp {
+  margin-top: 16px;
+  padding: 16px;
+  border-radius: 14px;
+  background: #eef5ef;
+}
+
+.coverage {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  list-style: none;
+}
+
+.coverage li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 11px;
+  border-radius: 10px;
+  background: #f3f5f2;
+}
+
+.coverage li[data-state="passed"] strong {
+  color: #176b3a;
+}
+
+.muted {
+  color: #68736b;
+}
+
+.error {
+  max-width: 1180px;
+  margin: 0 auto 18px;
+  padding: 12px;
+  border-radius: 10px;
+  background: #ffe7e2;
+  color: #8c251a;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgb(15 22 18 / 55%);
+}
+
+.dialog {
+  width: min(460px, 100%);
+  padding: 24px;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 24px 80px rgb(0 0 0 / 22%);
+}
+
+@media (max-width: 760px) {
+  .page {
+    padding: 20px;
+  }
+
+  .header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/apps/web/src/app/host/page.tsx
+++ b/frontend/apps/web/src/app/host/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import HostClient from "./host-client";
+
+export const metadata: Metadata = {
+  title: "Fabushi Mahayana Host",
+  description: "Mahayana Rust Core 的快速可测试 React Host。",
+};
+
+export default function HostPage() {
+  return <HostClient />;
+}

--- a/frontend/apps/web/src/lib/mahayana-host/contracts.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/contracts.ts
@@ -1,0 +1,83 @@
+export type HostStatus = "idle" | "initializing" | "ready" | "closed";
+
+export interface HostConfig {
+  profileId: string;
+  mode: "test" | "production";
+}
+
+export interface HostInfo {
+  runtimeVersion: string;
+  protocolVersion: "1";
+  platform: "mock" | "tauri" | "wasm" | "flutter";
+}
+
+interface CommandBase {
+  requestId: string;
+}
+
+export type RuntimeCommand =
+  | (CommandBase & { type: "chat.send"; text: string })
+  | (CommandBase & { type: "marketplace.install"; miniAppId: string })
+  | (CommandBase & { type: "miniapp.open"; miniAppId: string })
+  | (CommandBase & {
+      type: "capability.request";
+      miniAppId: string;
+      capability: string;
+      reason: string;
+    })
+  | (CommandBase & { type: "runtime.longTask"; label: string })
+  | (CommandBase & { type: "session.clear" });
+
+export interface CommandAccepted {
+  requestId: string;
+  operationId?: string;
+}
+
+interface EventBase {
+  timestamp: string;
+}
+
+export type RuntimeEvent =
+  | (EventBase & { type: "host.ready"; info: HostInfo })
+  | (EventBase & {
+      type: "chat.message";
+      role: "user" | "assistant";
+      text: string;
+    })
+  | (EventBase & {
+      type: "marketplace.installed";
+      miniAppId: string;
+      version: string;
+    })
+  | (EventBase & { type: "miniapp.opened"; miniAppId: string })
+  | (EventBase & {
+      type: "approval.requested";
+      approvalId: string;
+      miniAppId: string;
+      capability: string;
+      reason: string;
+    })
+  | (EventBase & {
+      type: "approval.resolved";
+      approvalId: string;
+      decision: "allow-once" | "deny";
+    })
+  | (EventBase & {
+      type: "operation.started";
+      operationId: string;
+      label: string;
+      interruptible: boolean;
+    })
+  | (EventBase & { type: "operation.interrupted"; operationId: string })
+  | (EventBase & { type: "session.cleared" })
+  | (EventBase & { type: "host.closed" });
+
+export type ApprovalRequestedEvent = Extract<
+  RuntimeEvent,
+  { type: "approval.requested" }
+>;
+
+export interface ApprovalResolution {
+  approvalId: string;
+  decision: "allow-once" | "deny";
+}

--- a/frontend/apps/web/src/lib/mahayana-host/mock-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/mock-transport.ts
@@ -1,0 +1,155 @@
+import type {
+  ApprovalResolution,
+  CommandAccepted,
+  HostConfig,
+  HostInfo,
+  HostStatus,
+  RuntimeCommand,
+  RuntimeEvent,
+} from "./contracts";
+import type {
+  MahayanaHostTransport,
+  RuntimeEventListener,
+} from "./transport";
+
+const now = () => new Date().toISOString();
+
+export class MockMahayanaHostTransport implements MahayanaHostTransport {
+  private readonly listeners = new Set<RuntimeEventListener>();
+  private readonly approvals = new Set<string>();
+  private status: HostStatus = "idle";
+  private sequence = 0;
+  private info: HostInfo = {
+    runtimeVersion: "mahayana-mock-1.0.0",
+    protocolVersion: "1",
+    platform: "mock",
+  };
+
+  subscribe(listener: RuntimeEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async initialize(_config: HostConfig): Promise<HostInfo> {
+    if (this.status === "ready") return this.info;
+    this.status = "initializing";
+    this.status = "ready";
+    this.emit({ type: "host.ready", timestamp: now(), info: this.info });
+    return this.info;
+  }
+
+  async execute(command: RuntimeCommand): Promise<CommandAccepted> {
+    this.assertReady();
+
+    switch (command.type) {
+      case "chat.send": {
+        const operationId = this.nextId("chat");
+        this.emit({
+          type: "chat.message",
+          timestamp: now(),
+          role: "user",
+          text: command.text,
+        });
+        this.emit({
+          type: "operation.started",
+          timestamp: now(),
+          operationId,
+          label: "chat-response",
+          interruptible: false,
+        });
+        this.emit({
+          type: "chat.message",
+          timestamp: now(),
+          role: "assistant",
+          text: `收到：${command.text}`,
+        });
+        return { requestId: command.requestId, operationId };
+      }
+      case "marketplace.install":
+        this.emit({
+          type: "marketplace.installed",
+          timestamp: now(),
+          miniAppId: command.miniAppId,
+          version: "1.0.0",
+        });
+        return { requestId: command.requestId };
+      case "miniapp.open":
+        this.emit({
+          type: "miniapp.opened",
+          timestamp: now(),
+          miniAppId: command.miniAppId,
+        });
+        return { requestId: command.requestId };
+      case "capability.request": {
+        const approvalId = this.nextId("approval");
+        this.approvals.add(approvalId);
+        this.emit({
+          type: "approval.requested",
+          timestamp: now(),
+          approvalId,
+          miniAppId: command.miniAppId,
+          capability: command.capability,
+          reason: command.reason,
+        });
+        return { requestId: command.requestId };
+      }
+      case "runtime.longTask": {
+        const operationId = this.nextId("operation");
+        this.emit({
+          type: "operation.started",
+          timestamp: now(),
+          operationId,
+          label: command.label,
+          interruptible: true,
+        });
+        return { requestId: command.requestId, operationId };
+      }
+      case "session.clear":
+        this.emit({ type: "session.cleared", timestamp: now() });
+        return { requestId: command.requestId };
+    }
+  }
+
+  async interrupt(operationId: string): Promise<void> {
+    this.assertReady();
+    this.emit({
+      type: "operation.interrupted",
+      timestamp: now(),
+      operationId,
+    });
+  }
+
+  async resolveApproval(resolution: ApprovalResolution): Promise<void> {
+    this.assertReady();
+    if (!this.approvals.delete(resolution.approvalId)) {
+      throw new Error(`Unknown approval: ${resolution.approvalId}`);
+    }
+    this.emit({
+      type: "approval.resolved",
+      timestamp: now(),
+      approvalId: resolution.approvalId,
+      decision: resolution.decision,
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.status === "closed") return;
+    this.status = "closed";
+    this.emit({ type: "host.closed", timestamp: now() });
+  }
+
+  private assertReady(): void {
+    if (this.status !== "ready") {
+      throw new Error(`Mahayana host is not ready: ${this.status}`);
+    }
+  }
+
+  private nextId(prefix: string): string {
+    this.sequence += 1;
+    return `${prefix}-${this.sequence}`;
+  }
+
+  private emit(event: RuntimeEvent): void {
+    for (const listener of this.listeners) listener(event);
+  }
+}

--- a/frontend/apps/web/src/lib/mahayana-host/transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/transport.ts
@@ -1,0 +1,19 @@
+import type {
+  ApprovalResolution,
+  CommandAccepted,
+  HostConfig,
+  HostInfo,
+  RuntimeCommand,
+  RuntimeEvent,
+} from "./contracts";
+
+export type RuntimeEventListener = (event: RuntimeEvent) => void;
+
+export interface MahayanaHostTransport {
+  initialize(config: HostConfig): Promise<HostInfo>;
+  execute(command: RuntimeCommand): Promise<CommandAccepted>;
+  subscribe(listener: RuntimeEventListener): () => void;
+  interrupt(operationId: string): Promise<void>;
+  resolveApproval(resolution: ApprovalResolution): Promise<void>;
+  close(): Promise<void>;
+}

--- a/frontend/apps/web/tsconfig.host.json
+++ b/frontend/apps/web/tsconfig.host.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "src/app/host/**/*.ts",
+    "src/app/host/**/*.tsx",
+    "src/lib/mahayana-host/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
+}

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from "./business";
 export * from "./copy";
 export * from "./app-experience";
 export * from "./chat-experience";
+export * from "./mahayana-host-features";

--- a/frontend/packages/shared/src/mahayana-host-features.ts
+++ b/frontend/packages/shared/src/mahayana-host-features.ts
@@ -1,0 +1,14 @@
+export const mahayanaHostFeatures = [
+  { id: "runtime.boot", label: "Runtime 启动" },
+  { id: "chat.send", label: "聊天发送与响应" },
+  { id: "marketplace.install", label: "Marketplace 安装" },
+  { id: "miniapp.open", label: "MiniApp 打开" },
+  { id: "capability.approval", label: "敏感能力审批" },
+  { id: "operation.interrupt", label: "长任务中断" },
+  { id: "session.clear", label: "安全会话清除" },
+] as const;
+
+export type MahayanaHostFeatureId =
+  (typeof mahayanaHostFeatures)[number]["id"];
+
+export type MahayanaHostFeatureState = "pending" | "passed" | "failed";

--- a/frontend/packages/shared/src/mahayana-host-features.ts
+++ b/frontend/packages/shared/src/mahayana-host-features.ts
@@ -1,12 +1,105 @@
+export type MahayanaHostJourneyStep =
+  | { action: "expectText"; testId: string; text: string }
+  | { action: "expectContainsText"; testId: string; text: string }
+  | { action: "fill"; testId: string; value: string }
+  | { action: "click"; testId: string }
+  | { action: "expectVisible"; testId: string }
+  | { action: "expectDialog"; name: string };
+
 export const mahayanaHostFeatures = [
-  { id: "runtime.boot", label: "Runtime 启动" },
-  { id: "chat.send", label: "聊天发送与响应" },
-  { id: "marketplace.install", label: "Marketplace 安装" },
-  { id: "miniapp.open", label: "MiniApp 打开" },
-  { id: "capability.approval", label: "敏感能力审批" },
-  { id: "operation.interrupt", label: "长任务中断" },
-  { id: "session.clear", label: "安全会话清除" },
-] as const;
+  {
+    id: "runtime.boot",
+    label: "Runtime 启动",
+    journey: [
+      { action: "expectText", testId: "host-status", text: "ready" },
+    ],
+  },
+  {
+    id: "chat.send",
+    label: "聊天发送与响应",
+    journey: [
+      {
+        action: "fill",
+        testId: "chat-input",
+        value: "验证极速自动化测试",
+      },
+      { action: "click", testId: "send-message" },
+      {
+        action: "expectContainsText",
+        testId: "messages",
+        text: "收到：验证极速自动化测试",
+      },
+    ],
+  },
+  {
+    id: "marketplace.install",
+    label: "Marketplace 安装",
+    journey: [
+      { action: "click", testId: "install-miniapp" },
+      {
+        action: "expectText",
+        testId: "marketplace-state",
+        text: "installed",
+      },
+    ],
+  },
+  {
+    id: "miniapp.open",
+    label: "MiniApp 打开",
+    journey: [
+      { action: "click", testId: "open-miniapp" },
+      { action: "expectVisible", testId: "miniapp-panel" },
+    ],
+  },
+  {
+    id: "capability.approval",
+    label: "敏感能力审批",
+    journey: [
+      { action: "click", testId: "request-capability" },
+      { action: "expectDialog", name: "能力审批" },
+      { action: "click", testId: "approve-capability" },
+      {
+        action: "expectText",
+        testId: "approval-state",
+        text: "allowed",
+      },
+    ],
+  },
+  {
+    id: "operation.interrupt",
+    label: "长任务中断",
+    journey: [
+      { action: "click", testId: "start-long-operation" },
+      {
+        action: "expectText",
+        testId: "operation-state",
+        text: "running",
+      },
+      { action: "click", testId: "interrupt-operation" },
+      {
+        action: "expectText",
+        testId: "operation-state",
+        text: "interrupted",
+      },
+    ],
+  },
+  {
+    id: "session.clear",
+    label: "安全会话清除",
+    journey: [
+      { action: "click", testId: "clear-session" },
+      {
+        action: "expectText",
+        testId: "session-state",
+        text: "cleared",
+      },
+    ],
+  },
+] as const satisfies ReadonlyArray<{
+  id: string;
+  label: string;
+  journey: ReadonlyArray<MahayanaHostJourneyStep>;
+}>;
 
 export type MahayanaHostFeatureId =
   (typeof mahayanaHostFeatures)[number]["id"];

--- a/scripts/check-migration-surface.mjs
+++ b/scripts/check-migration-surface.mjs
@@ -1,0 +1,132 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const manifestPath = path.join(root, "contracts/migration/legacy-surface.json");
+const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+
+if (manifest.schemaVersion !== 1) {
+  throw new Error(`Unsupported migration manifest schema: ${manifest.schemaVersion}`);
+}
+
+async function walk(relativeRoot) {
+  const absoluteRoot = path.join(root, relativeRoot);
+  const entries = await fs.readdir(absoluteRoot, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const relative = path.posix.join(relativeRoot, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(relative)));
+    } else if (entry.isFile() && entry.name.endsWith(".dart")) {
+      files.push(relative);
+    }
+  }
+  return files;
+}
+
+const trackedFiles = (
+  await Promise.all(manifest.trackedRoots.map((trackedRoot) => walk(trackedRoot)))
+)
+  .flat()
+  // Match `LC_ALL=C sort` exactly. Locale collation can treat punctuation
+  // differently across runner images and would make the SHA non-portable.
+  .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+const fingerprintInput = `${trackedFiles.join("\n")}\n`;
+const fingerprint = createHash("sha256").update(fingerprintInput).digest("hex");
+
+const errors = [];
+if (trackedFiles.length !== manifest.expected.fileCount) {
+  errors.push(
+    `legacy file count changed: expected ${manifest.expected.fileCount}, found ${trackedFiles.length}`,
+  );
+}
+if (fingerprint !== manifest.expected.sha256) {
+  errors.push(
+    `legacy surface fingerprint changed: expected ${manifest.expected.sha256}, found ${fingerprint}`,
+  );
+}
+
+const allowedStatuses = new Set(["pending", "in-progress", "migrated", "deleted"]);
+const seenDomainIds = new Set();
+const compiledDomains = manifest.domains.map((domain) => {
+  if (seenDomainIds.has(domain.id)) errors.push(`duplicate domain id: ${domain.id}`);
+  seenDomainIds.add(domain.id);
+  if (!allowedStatuses.has(domain.status)) {
+    errors.push(`invalid status for ${domain.id}: ${domain.status}`);
+  }
+  if (!Array.isArray(domain.patterns) || domain.patterns.length === 0) {
+    errors.push(`domain has no patterns: ${domain.id}`);
+  }
+  if (domain.status === "migrated" && domain.e2eFeatureIds.length === 0) {
+    errors.push(`migrated domain has no E2E evidence IDs: ${domain.id}`);
+  }
+  return {
+    ...domain,
+    matchers: domain.patterns.map((pattern) => new RegExp(pattern)),
+    matched: [],
+  };
+});
+
+for (const file of trackedFiles) {
+  const domain = compiledDomains.find((candidate) =>
+    candidate.matchers.some((matcher) => matcher.test(file)),
+  );
+  if (!domain) {
+    errors.push(`legacy file is not classified: ${file}`);
+  } else {
+    domain.matched.push(file);
+  }
+}
+
+for (const domain of compiledDomains) {
+  if (domain.matched.length === 0) {
+    errors.push(`migration domain matches no current file: ${domain.id}`);
+  }
+}
+
+const featureCatalog = await fs.readFile(
+  path.join(root, manifest.featureCatalogPath),
+  "utf8",
+);
+const featureIds = new Set(
+  [...featureCatalog.matchAll(/\bid:\s*"([^"]+)"/g)].map((match) => match[1]),
+);
+for (const domain of compiledDomains) {
+  for (const featureId of domain.e2eFeatureIds) {
+    if (!featureIds.has(featureId)) {
+      errors.push(`${domain.id} references an unknown E2E feature: ${featureId}`);
+    }
+  }
+}
+
+const summary = [
+  "## Fabushi migration surface",
+  "",
+  `- Tracked Dart files: ${trackedFiles.length}`,
+  `- Surface SHA-256: \`${fingerprint}\``,
+  `- Migration domains: ${compiledDomains.length}`,
+  "",
+  "| Domain | Files | Status | Required for cutover | E2E evidence |",
+  "|---|---:|---|---|---|",
+  ...compiledDomains.map(
+    (domain) =>
+      `| ${domain.id} | ${domain.matched.length} | ${domain.status} | ${domain.requiredForCutover ? "yes" : "no"} | ${domain.e2eFeatureIds.join(", ") || "—"} |`,
+  ),
+  "",
+].join("\n");
+console.log(summary);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
+}
+
+if (errors.length > 0) {
+  throw new Error(
+    [
+      "Migration surface contract failed.",
+      ...errors.map((error) => `- ${error}`),
+      "Update the explicit manifest and its evidence in the same pull request.",
+    ].join("\n"),
+  );
+}

--- a/third_party/mahayana/mahayana-rs/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/Cargo.toml
@@ -100,13 +100,25 @@ web-sys = { version = "=0.3.103", features = [
     "WorkerGlobalScope",
 ] }
 
+# Developer profiles are intentionally incremental. Release packaging keeps its
+# own size-optimized profile below; PR checks must not pay that cost.
 [profile.dev]
 debug = 0
-incremental = false
+incremental = true
+codegen-units = 256
 
 [profile.test]
 debug = 0
-incremental = false
+incremental = true
+codegen-units = 256
+
+# Fast GitHub Actions profile. Restored target caches can reuse incremental
+# artifacts while retaining the assertions and overflow checks from `test`.
+[profile.ci]
+inherits = "test"
+debug = 0
+incremental = true
+codegen-units = 256
 
 # Native applications ship the Runtime as one embedded library. Keep that
 # library small enough for mobile stores while preserving the audited crate

--- a/third_party/mahayana/mahayana-rs/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "mahayana-conversation",
     "mahayana-core",
     "mahayana-ffi",
+    "mahayana-host",
     "mahayana-model",
     "mahayana-miniapp-bridge",
     "mahayana-miniapp-protocol",
@@ -61,6 +62,7 @@ mahayana-agent = { path = "mahayana-agent" }
 mahayana-agent-responses = { path = "mahayana-agent-responses" }
 mahayana-conversation = { path = "mahayana-conversation" }
 mahayana-core = { path = "mahayana-core" }
+mahayana-host = { path = "mahayana-host", default-features = false }
 mahayana-model = { path = "mahayana-model" }
 mahayana-miniapp-bridge = { path = "mahayana-miniapp-bridge" }
 mahayana-miniapp-protocol = { path = "mahayana-miniapp-protocol" }

--- a/third_party/mahayana/mahayana-rs/mahayana-host/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/mahayana-host/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "mahayana-host"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Direct Rust host API for the embedded Mahayana Runtime."
+publish = false
+
+[lib]
+doctest = false
+
+[features]
+# The default developer/test build intentionally avoids compiling the embedded
+# Codex desktop graph. Production shells opt into desktop-full or
+# mobile-embedded explicitly.
+default = ["local-only"]
+desktop-full = [
+    "mahayana-runtime-core/desktop-full",
+    "dep:codex-protocol",
+    "dep:mahayana-agent-codex",
+]
+mobile-embedded = [
+    "mahayana-runtime-core/mobile-embedded",
+    "dep:codex-protocol",
+    "dep:mahayana-agent-codex",
+]
+linux-shared = [
+    "mahayana-runtime-core/mobile-embedded",
+    "dep:codex-protocol",
+]
+web-wasm = ["mahayana-runtime-core/web-wasm"]
+local-only = ["mahayana-runtime-core/local-only"]
+remote-model-provider = ["mahayana-runtime-core/remote-model-provider"]
+telemetry = ["mahayana-runtime-core/telemetry"]
+
+[dependencies]
+async-trait.workspace = true
+codex-protocol = { workspace = true, optional = true }
+fabushi-official-miniapps.workspace = true
+mahayana-agent.workspace = true
+mahayana-agent-codex = { path = "../mahayana-agent-codex", optional = true }
+mahayana-conversation.workspace = true
+mahayana-core.workspace = true
+mahayana-miniapp.workspace = true
+mahayana-platform-core.workspace = true
+mahayana-product = { package = "mahayana-platform-client", path = "../mahayana-product" }
+mahayana-runtime-core = { package = "mahayana-runtime", path = "../mahayana-runtime", default-features = false }
+mahayana-social.workspace = true
+mahayana-telegram.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true

--- a/third_party/mahayana/mahayana-rs/mahayana-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-host/src/lib.rs
@@ -1,0 +1,461 @@
+//! Direct Rust host API for the long-lived Mahayana Runtime.
+//!
+//! Native shells such as Tauri, Swift, and Kotlin should depend on this crate.
+//! The C/JSON ABI remains a compatibility adapter for the legacy Flutter host.
+
+use fabushi_official_miniapps::OFFICIAL_PLUGIN_IDS;
+use fabushi_official_miniapps::app_definition;
+use mahayana_agent::UnavailableAgentBackend;
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+use mahayana_agent_codex::CodexAgentBackend;
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+use mahayana_agent_codex::CodexAgentConfig;
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+use mahayana_conversation::ConversationProvider;
+use mahayana_core::ApprovalDecision;
+use mahayana_core::ApprovalId;
+use mahayana_core::BuildProfile;
+use mahayana_core::OperationId;
+use mahayana_core::RuntimeCommand;
+use mahayana_core::RuntimeConfig;
+use mahayana_core::RuntimeEvent;
+use mahayana_core::RuntimeResponse;
+use mahayana_core::RuntimeStatus;
+use mahayana_miniapp::EntitlementChecker;
+use mahayana_miniapp::MiniAppConversationProvider;
+use mahayana_miniapp::MiniAppDefinition;
+use mahayana_platform_core::HostPlatform;
+use mahayana_product::MahayanaProductClient;
+#[cfg(feature = "desktop-full")]
+use mahayana_product::default_mahayana_home;
+use mahayana_runtime_core::MahayanaRuntime;
+use mahayana_runtime_core::RuntimeBuilder;
+use mahayana_runtime_core::RuntimeError;
+use mahayana_social::MahayanaSocialConversationProvider;
+use mahayana_telegram::TelegramConversationProvider;
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct HostCreateConfig {
+    #[serde(flatten)]
+    pub runtime: RuntimeConfig,
+    pub product_session_path: Option<PathBuf>,
+    pub codex_home: Option<PathBuf>,
+    /// Read-only marketplace shipped inside the native application.
+    pub bundled_plugin_marketplace: Option<PathBuf>,
+    /// Optional Mahayana CLI used only for desktop argv helper dispatch.
+    pub codex_executable_path: Option<PathBuf>,
+    pub cwd: Option<PathBuf>,
+    /// Existing embedded Telegram client created by the platform login flow.
+    pub telegram_client_id: Option<u64>,
+    pub telegram_self_user_id: Option<i64>,
+    pub host_platform: Option<HostPlatform>,
+    pub mini_apps: Vec<MiniAppDefinition>,
+    pub use_codex_account: bool,
+    /// Tests and constrained hosts may opt out of inherited local plugins.
+    pub inherit_installed_plugins: Option<bool>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct HostError {
+    message: String,
+}
+
+impl HostError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl From<RuntimeError> for HostError {
+    fn from(error: RuntimeError) -> Self {
+        Self::new(error.to_string())
+    }
+}
+
+/// Long-lived process-local host shared by every presentation surface.
+#[derive(Clone)]
+pub struct MahayanaHost {
+    runtime: Arc<MahayanaRuntime>,
+}
+
+impl MahayanaHost {
+    pub fn create(config: HostCreateConfig) -> Result<Self, HostError> {
+        Ok(Self {
+            runtime: Arc::new(build_runtime(config)?),
+        })
+    }
+
+    pub fn status(&self) -> RuntimeStatus {
+        self.runtime.status()
+    }
+
+    pub fn execute(&self, command: RuntimeCommand) -> Result<RuntimeResponse, HostError> {
+        self.runtime.execute(command).map_err(HostError::from)
+    }
+
+    pub fn receive(&self, timeout: Duration) -> Result<Option<RuntimeEvent>, HostError> {
+        self.runtime.receive(timeout).map_err(HostError::from)
+    }
+
+    pub fn interrupt(&self, operation_id: OperationId) -> Result<RuntimeResponse, HostError> {
+        self.execute(RuntimeCommand::Interrupt { operation_id })
+    }
+
+    pub fn resolve_approval(
+        &self,
+        approval_id: ApprovalId,
+        decision: ApprovalDecision,
+        payload: serde_json::Value,
+    ) -> Result<RuntimeResponse, HostError> {
+        self.execute(RuntimeCommand::ResolveApproval {
+            approval_id,
+            decision,
+            payload,
+        })
+    }
+}
+
+fn build_runtime(create: HostCreateConfig) -> Result<MahayanaRuntime, HostError> {
+    let runtime_config = create.runtime.clone();
+    if runtime_config.remote_agent_enabled {
+        return Err(RuntimeError::RemoteAgentForbidden.into());
+    }
+    #[cfg(all(feature = "mobile-embedded", not(feature = "desktop-full")))]
+    let runtime_config = RuntimeConfig {
+        build_profile: BuildProfile::MobileEmbedded,
+        ..runtime_config
+    };
+    let host_platform = create
+        .host_platform
+        .unwrap_or(match runtime_config.build_profile {
+            BuildProfile::DesktopFull => HostPlatform::Desktop,
+            BuildProfile::MobileEmbedded => HostPlatform::Mobile,
+            BuildProfile::WebWasm => HostPlatform::Web,
+        });
+    let product_client = create
+        .product_session_path
+        .map(|path| MahayanaProductClient::new("https://api.ombhrum.com", path))
+        .unwrap_or_default();
+    let configured_mini_apps = if create.mini_apps.is_empty() {
+        discover_mini_apps(&product_client).unwrap_or_default()
+    } else {
+        create.mini_apps.clone()
+    };
+    let mini_apps = merge_official_mini_apps(configured_mini_apps);
+    let session_token = product_client.session_token().ok();
+    let mut builder = RuntimeBuilder::new(runtime_config.clone());
+    #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+    let mut codex_conversation_providers: Vec<Arc<dyn ConversationProvider>> = Vec::new();
+    if let Some(token) = session_token.as_ref() {
+        let provider = Arc::new(MahayanaSocialConversationProvider::new(
+            product_client.clone(),
+            Some(token.clone()),
+        ));
+        #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+        codex_conversation_providers.push(Arc::clone(&provider) as Arc<dyn ConversationProvider>);
+        builder = builder.with_provider(provider)?;
+    }
+    if let Some(telegram_client_id) = create.telegram_client_id {
+        let provider = Arc::new(TelegramConversationProvider::from_client_id(
+            telegram_client_id,
+            create.telegram_self_user_id.unwrap_or_default(),
+        ));
+        #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+        codex_conversation_providers.push(Arc::clone(&provider) as Arc<dyn ConversationProvider>);
+        builder = builder.with_provider(provider)?;
+    }
+
+    #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+    if matches!(
+        runtime_config.build_profile,
+        BuildProfile::DesktopFull | BuildProfile::MobileEmbedded
+    ) {
+        let data_dir = runtime_config.data_dir.clone();
+        let cwd = create
+            .cwd
+            .or_else(|| runtime_config.workspace_roots.first().cloned())
+            .or_else(|| data_dir.as_ref().map(|path| path.join("workspace")))
+            .or_else(|| std::env::current_dir().ok())
+            .ok_or_else(|| HostError::new("current working directory is unavailable"))?;
+        let workspace_roots = if runtime_config.workspace_roots.is_empty() {
+            vec![cwd.clone()]
+        } else {
+            runtime_config.workspace_roots.clone()
+        };
+        let codex_home = create
+            .codex_home
+            .or_else(|| data_dir.map(|path| path.join("codex")))
+            .or_else(default_codex_home_if_available)
+            .ok_or_else(|| {
+                HostError::new("embedded Mahayana requires an application data directory")
+            })?;
+        let responses_base_url = create
+            .runtime
+            .model
+            .base_url
+            .clone()
+            .ok_or_else(|| HostError::new("Dacheng Responses base URL is required"))?;
+        let settings = CodexAgentConfig {
+            codex_home,
+            bundled_plugin_marketplace: create.bundled_plugin_marketplace.clone(),
+            bundled_plugin_ids: bundled_marketplace_plugin_ids(
+                create.bundled_plugin_marketplace.as_deref(),
+                &mini_apps,
+            )?,
+            inherit_installed_plugins: create.inherit_installed_plugins.unwrap_or(
+                matches!(runtime_config.build_profile, BuildProfile::DesktopFull) && !cfg!(test),
+            ),
+            cwd,
+            workspace_roots,
+            model: runtime_config.model.model.clone(),
+            responses_base_url,
+            use_codex_account: create.use_codex_account,
+            product_session_token: session_token.clone(),
+            sandbox_mode: codex_protocol::config_types::SandboxMode::WorkspaceWrite,
+            approval_policy: codex_protocol::protocol::AskForApproval::OnRequest,
+            codex_executable_path: create.codex_executable_path,
+            conversation_providers: codex_conversation_providers,
+        };
+        return builder
+            .build_with_agent_backend_and(
+                || async move {
+                    let backend = CodexAgentBackend::start(settings).await?;
+                    Ok(Arc::new(backend) as Arc<dyn mahayana_agent::AgentBackend>)
+                },
+                move |builder, backend| {
+                    let provider = MiniAppConversationProvider::new_for_platform_with_entitlements(
+                        backend,
+                        mini_apps,
+                        host_platform,
+                        Some(Arc::new(PlatformEntitlementChecker {
+                            client: product_client,
+                        })),
+                    )?;
+                    builder.with_provider(Arc::new(provider))
+                },
+            )
+            .map_err(HostError::from);
+    }
+
+    let unavailable_reason = "this platform build has no embedded Codex backend";
+    let backend: Arc<dyn mahayana_agent::AgentBackend> =
+        Arc::new(UnavailableAgentBackend::new(unavailable_reason));
+    let miniapp = MiniAppConversationProvider::new_for_platform_with_entitlements(
+        Arc::clone(&backend),
+        mini_apps,
+        host_platform,
+        Some(Arc::new(PlatformEntitlementChecker {
+            client: product_client,
+        })),
+    )
+    .map_err(|error| HostError::new(error.to_string()))?;
+    builder
+        .with_agent_backend(backend)?
+        .with_provider(Arc::new(miniapp))?
+        .build()
+        .map_err(HostError::from)
+}
+
+fn merge_official_mini_apps(
+    configured: impl IntoIterator<Item = MiniAppDefinition>,
+) -> Vec<MiniAppDefinition> {
+    let mut definitions = configured
+        .into_iter()
+        .map(|definition| (definition.plugin_id.clone(), definition))
+        .collect::<BTreeMap<_, _>>();
+    for plugin_id in OFFICIAL_PLUGIN_IDS {
+        let definition = app_definition(plugin_id).expect("official plugin definition");
+        let pinned = definitions
+            .get(plugin_id)
+            .is_some_and(|definition| definition.pinned);
+        definitions.insert(
+            plugin_id.to_string(),
+            MiniAppDefinition {
+                plugin_id: definition.id,
+                title: definition.title,
+                pinned,
+            },
+        );
+    }
+    definitions.into_values().collect()
+}
+
+fn bundled_marketplace_plugin_ids(
+    marketplace_root: Option<&Path>,
+    mini_apps: &[MiniAppDefinition],
+) -> Result<Vec<String>, HostError> {
+    let Some(marketplace_root) = marketplace_root else {
+        return Ok(Vec::new());
+    };
+    let mut plugin_ids = Vec::new();
+    for mini_app in mini_apps {
+        let plugin_id = mini_app.plugin_id.as_str();
+        if plugin_id.is_empty()
+            || !plugin_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err(HostError::new(format!(
+                "invalid bundled plugin id: {plugin_id}"
+            )));
+        }
+        if marketplace_root
+            .join("plugins")
+            .join(plugin_id)
+            .join(".codex-plugin/plugin.json")
+            .is_file()
+        {
+            plugin_ids.push(plugin_id.to_string());
+        }
+    }
+    Ok(plugin_ids)
+}
+
+fn discover_mini_apps(client: &MahayanaProductClient) -> Option<Vec<MiniAppDefinition>> {
+    let registry = client
+        .execute("mahayana.miniapps.registry", &json!({}))
+        .ok()?;
+    let plugins = registry.get("plugins")?.as_array()?;
+    let definitions = plugins
+        .iter()
+        .filter_map(|plugin| {
+            let id = plugin.get("id")?.as_str()?.trim();
+            let title = plugin.get("title")?.as_str()?.trim();
+            if id.is_empty() || title.is_empty() {
+                return None;
+            }
+            Some(MiniAppDefinition {
+                plugin_id: id.to_string(),
+                title: title.to_string(),
+                pinned: false,
+            })
+        })
+        .collect::<Vec<_>>();
+    (!definitions.is_empty()).then_some(definitions)
+}
+
+#[cfg(feature = "desktop-full")]
+fn default_codex_home() -> PathBuf {
+    default_mahayana_home().join("codex")
+}
+
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+fn default_codex_home_if_available() -> Option<PathBuf> {
+    #[cfg(feature = "desktop-full")]
+    {
+        #[allow(clippy::needless_return)]
+        return Some(default_codex_home());
+    }
+    #[cfg(not(feature = "desktop-full"))]
+    {
+        None
+    }
+}
+
+#[derive(Clone)]
+struct PlatformEntitlementChecker {
+    client: MahayanaProductClient,
+}
+
+#[async_trait::async_trait]
+impl EntitlementChecker for PlatformEntitlementChecker {
+    async fn has_entitlement(&self, plugin_id: &str, capability: &str) -> Result<bool, String> {
+        let client = self.client.clone();
+        let plugin_id = plugin_id.to_string();
+        let capability = capability.to_string();
+        tokio::task::spawn_blocking(move || client.entitlement(&plugin_id, &capability))
+            .await
+            .map_err(|error| error.to_string())?
+            .map(|entitlement| entitlement.is_some())
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> HostCreateConfig {
+        HostCreateConfig {
+            mini_apps: vec![MiniAppDefinition {
+                plugin_id: "test-miniapp".to_string(),
+                title: "Test MiniApp".to_string(),
+                pinned: false,
+            }],
+            inherit_installed_plugins: Some(false),
+            ..HostCreateConfig::default()
+        }
+    }
+
+    #[test]
+    fn direct_host_creates_executes_receives_and_clones() {
+        let host = MahayanaHost::create(test_config()).expect("create host");
+        let cloned = host.clone();
+        let status = cloned
+            .execute(RuntimeCommand::Status)
+            .expect("execute status");
+        let encoded = serde_json::to_value(status).expect("serialize status");
+        assert_eq!(encoded["runtimeAbiVersion"], 1);
+        assert_eq!(encoded["remoteAgentEnabled"], false);
+
+        let ready = host
+            .receive(Duration::from_millis(10))
+            .expect("receive ready")
+            .expect("ready event");
+        let encoded = serde_json::to_value(ready).expect("serialize event");
+        assert_eq!(encoded["@type"], "mahayana.runtime.ready");
+    }
+
+    #[test]
+    fn create_rejects_remote_agent_gateway() {
+        let mut config = test_config();
+        config.runtime.remote_agent_enabled = true;
+        let error = MahayanaHost::create(config)
+            .err()
+            .expect("remote agent must be rejected");
+        assert!(error.to_string().contains("remote Agent"));
+    }
+
+    #[test]
+    fn bundled_marketplace_enables_only_plugins_present_on_disk() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "mahayana-host-marketplace-{}-{unique}",
+            std::process::id()
+        ));
+        let manifest = root.join("plugins/cloud-market-hello/.codex-plugin/plugin.json");
+        std::fs::create_dir_all(manifest.parent().expect("manifest parent"))
+            .expect("create plugin tree");
+        std::fs::write(&manifest, "{}").expect("write plugin manifest");
+
+        let mini_apps = vec![
+            MiniAppDefinition {
+                plugin_id: "cloud-market-hello".into(),
+                title: "Cloud Market Hello".into(),
+                pinned: false,
+            },
+            MiniAppDefinition {
+                plugin_id: "bot-father".into(),
+                title: "Bot Father".into(),
+                pinned: false,
+            },
+        ];
+        let plugin_ids =
+            bundled_marketplace_plugin_ids(Some(&root), &mini_apps).expect("bundled plugin ids");
+        assert_eq!(plugin_ids, vec!["cloud-market-hello"]);
+        std::fs::remove_dir_all(root).expect("remove plugin tree");
+    }
+}


### PR DESCRIPTION
## Objective

Begin the executable migration described in #1902 toward Mahayana Rust Core + React Host + Tauri, while replacing simulator-heavy feature feedback with deterministic, user-level browser E2E gates.

## Implemented in this slice

- Restore incremental Rust development/test profiles and add a dedicated `ci` profile.
- Add a versioned React-side Mahayana Host command/event boundary.
- Add a deterministic `MockMahayanaHostTransport` so UI journeys can run without iOS/Android simulators.
- Add `/host` React UI covering runtime boot, chat, Marketplace install, MiniApp launch, capability approval, operation interruption, and secure-session clearing.
- Add a feature catalog gate: a declared feature remains `pending` until the user journey actually exercises it.
- Add Playwright fast E2E that performs the full declared user journey and requires every catalog item to pass.
- Add path-filtered GitHub Actions with a 120-second journey budget and failure-only diagnostics.
- Add targeted cached Rust protocol/bridge/FFI checks that avoid release LTO and full workspace builds.
- Document the shortest workflow for adding and automatically testing a new feature.

## Acceptance evidence required before this PR is ready

- `Host fast E2E` passes.
- `Mahayana fast checks` passes.
- Existing repository CI remains green or only skips unrelated heavy platform jobs.
- No declared Host feature remains `pending` after the Playwright journey.

## Scope boundary

This PR is the first executable migration slice, not a claim that Flutter, desktop packaging, or mobile hosts have already been fully replaced. Follow-up stages extract the production Mahayana Host crate, wire Tauri transport, migrate real product modules, and then retire Flutter only after equivalence gates pass.

Related architecture proposal: #1902