### PR TITLE
refactor(ffi): make the legacy ABI a thin Mahayana Host adapter

### DIFF
--- a/.github/workflows/mahayana-fast-checks.yml
+++ b/.github/workflows/mahayana-fast-checks.yml
@@ -22,9 +22,11 @@ permissions:
 
 jobs:
   protocol-and-bridge:
-    name: Rust protocol, Host, and bridge fast gate
+    name: Rust protocol, Host, FFI, and bridge fast gate
     runs-on: ubuntu-latest
     timeout-minutes: 12
+    env:
+      CARGO_INCREMENTAL: "1"
     defaults:
       run:
         working-directory: third_party/mahayana/mahayana-rs
@@ -45,7 +47,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: mahayana-fast-v1
+          shared-key: mahayana-fast-v4
           cache-all-crates: true
 
       - name: Verify formatting
@@ -66,9 +68,9 @@ jobs:
           --no-default-features
           --features local-only
 
-      - name: Check minimal embedded FFI boundary
+      - name: Test legacy FFI compatibility and direct Host parity
         run: >-
-          cargo check
+          cargo test
           -p mahayana-ffi
           --profile ci
           --no-default-features

--- a/.github/workflows/mahayana-fast-checks.yml
+++ b/.github/workflows/mahayana-fast-checks.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   protocol-and-bridge:
-    name: Rust protocol and bridge fast gate
+    name: Rust protocol, Host, and bridge fast gate
     runs-on: ubuntu-latest
     timeout-minutes: 12
     defaults:
@@ -57,6 +57,14 @@ jobs:
           -p mahayana-miniapp-protocol
           -p mahayana-miniapp-bridge
           --profile ci
+
+      - name: Test direct Mahayana Host
+        run: >-
+          cargo test
+          -p mahayana-host
+          --profile ci
+          --no-default-features
+          --features local-only
 
       - name: Check minimal embedded FFI boundary
         run: >-

--- a/third_party/mahayana/mahayana-rs/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/Cargo.toml
@@ -62,7 +62,7 @@ mahayana-agent = { path = "mahayana-agent" }
 mahayana-agent-responses = { path = "mahayana-agent-responses" }
 mahayana-conversation = { path = "mahayana-conversation" }
 mahayana-core = { path = "mahayana-core" }
-mahayana-host = { path = "mahayana-host" }
+mahayana-host = { path = "mahayana-host", default-features = false }
 mahayana-model = { path = "mahayana-model" }
 mahayana-miniapp-bridge = { path = "mahayana-miniapp-bridge" }
 mahayana-miniapp-protocol = { path = "mahayana-miniapp-protocol" }

--- a/third_party/mahayana/mahayana-rs/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "mahayana-conversation",
     "mahayana-core",
     "mahayana-ffi",
+    "mahayana-host",
     "mahayana-model",
     "mahayana-miniapp-bridge",
     "mahayana-miniapp-protocol",
@@ -61,6 +62,7 @@ mahayana-agent = { path = "mahayana-agent" }
 mahayana-agent-responses = { path = "mahayana-agent-responses" }
 mahayana-conversation = { path = "mahayana-conversation" }
 mahayana-core = { path = "mahayana-core" }
+mahayana-host = { path = "mahayana-host" }
 mahayana-model = { path = "mahayana-model" }
 mahayana-miniapp-bridge = { path = "mahayana-miniapp-bridge" }
 mahayana-miniapp-protocol = { path = "mahayana-miniapp-protocol" }

--- a/third_party/mahayana/mahayana-rs/mahayana-ffi/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/mahayana-ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "mahayana-ffi"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Stable C/JSON ABI for the embedded Mahayana Runtime."
+description = "Stable C/JSON compatibility ABI for the embedded Mahayana Host."
 publish = false
 
 [lib]
@@ -18,41 +18,19 @@ doctest = false
 
 [features]
 default = ["desktop-full", "local-only"]
-desktop-full = [
-    "mahayana-runtime-core/desktop-full",
-    "dep:codex-protocol",
-    "dep:mahayana-agent-codex",
-]
-mobile-embedded = [
-    "mahayana-runtime-core/mobile-embedded",
-    "dep:codex-protocol",
-    "dep:mahayana-agent-codex",
-]
-linux-shared = [
-    "mahayana-runtime-core/mobile-embedded",
-    "dep:codex-protocol",
-]
-web-wasm = ["mahayana-runtime-core/web-wasm"]
-local-only = ["mahayana-runtime-core/local-only"]
-remote-model-provider = ["mahayana-runtime-core/remote-model-provider"]
-telemetry = ["mahayana-runtime-core/telemetry"]
+desktop-full = ["mahayana-host/desktop-full"]
+mobile-embedded = ["mahayana-host/mobile-embedded"]
+linux-shared = ["mahayana-host/linux-shared"]
+web-wasm = ["mahayana-host/web-wasm"]
+local-only = ["mahayana-host/local-only"]
+remote-model-provider = ["mahayana-host/remote-model-provider"]
+telemetry = ["mahayana-host/telemetry"]
 
 [dependencies]
-async-trait.workspace = true
-codex-protocol = { workspace = true, optional = true }
-fabushi-official-miniapps.workspace = true
 fabushi-telegram-runtime = { path = "../providers/telegram-runtime" }
-mahayana-agent.workspace = true
-mahayana-agent-codex = { path = "../mahayana-agent-codex", optional = true }
-mahayana-conversation.workspace = true
 mahayana-core.workspace = true
-mahayana-miniapp.workspace = true
-mahayana-platform-core.workspace = true
+mahayana-host = { workspace = true, default-features = false }
 mahayana-product = { package = "mahayana-platform-client", path = "../mahayana-product" }
-mahayana-runtime-core = { package = "mahayana-runtime", path = "../mahayana-runtime", default-features = false }
-mahayana-social.workspace = true
-mahayana-telegram.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true

--- a/third_party/mahayana/mahayana-rs/mahayana-ffi/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-ffi/src/lib.rs
@@ -1,42 +1,24 @@
-//! C/JSON ABI for native Mahayana hosts.
+//! Stable C/JSON compatibility ABI for native Mahayana hosts.
+//!
+//! Runtime construction and behavior live in `mahayana-host`. This crate owns
+//! only C pointers, JSON conversion, process-local numeric handles, and the
+//! legacy symbols used by Flutter during migration.
 
-use fabushi_official_miniapps::OFFICIAL_PLUGIN_IDS;
-use fabushi_official_miniapps::app_definition;
-use mahayana_agent::UnavailableAgentBackend;
-#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-use mahayana_agent_codex::CodexAgentBackend;
-#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-use mahayana_agent_codex::CodexAgentConfig;
-#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-use mahayana_conversation::ConversationProvider;
 use mahayana_core::ApprovalDecision;
 use mahayana_core::ApprovalId;
-use mahayana_core::BuildProfile;
 use mahayana_core::OperationId;
 use mahayana_core::RuntimeCommand;
-use mahayana_core::RuntimeConfig;
-use mahayana_miniapp::EntitlementChecker;
-use mahayana_miniapp::MiniAppConversationProvider;
-use mahayana_miniapp::MiniAppDefinition;
-use mahayana_platform_core::HostPlatform;
+use mahayana_host::HostCreateConfig;
+use mahayana_host::MahayanaHost;
 use mahayana_product::MahayanaProductClient;
-#[cfg(feature = "desktop-full")]
-use mahayana_product::default_mahayana_home;
-use mahayana_runtime_core::MahayanaRuntime;
-use mahayana_runtime_core::RuntimeBuilder;
-use mahayana_runtime_core::RuntimeError;
-use mahayana_social::MahayanaSocialConversationProvider;
-use mahayana_telegram::TelegramConversationProvider;
 use once_cell::sync::Lazy;
 use serde_json::Value;
 use serde_json::json;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_char;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
@@ -44,39 +26,16 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
-static RUNTIMES: Lazy<Mutex<HashMap<u64, Arc<MahayanaRuntime>>>> =
+static RUNTIMES: Lazy<Mutex<HashMap<u64, Arc<MahayanaHost>>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 thread_local! {
     static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
-#[derive(Debug, Default, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct RuntimeCreateConfig {
-    #[serde(flatten)]
-    runtime: RuntimeConfig,
-    product_session_path: Option<PathBuf>,
-    codex_home: Option<PathBuf>,
-    /// Read-only marketplace shipped inside the desktop application. Its
-    /// plugin directories contain the matching native CLI and WASM artifacts.
-    bundled_plugin_marketplace: Option<PathBuf>,
-    /// Optional Mahayana CLI executable that supports desktop argv helper
-    /// dispatch. SDK hosts omit it and use in-process Mahayana workspace tools.
-    codex_executable_path: Option<PathBuf>,
-    cwd: Option<PathBuf>,
-    /// Existing embedded Telegram client created by the platform login flow.
-    telegram_client_id: Option<u64>,
-    telegram_self_user_id: Option<i64>,
-    host_platform: Option<HostPlatform>,
-    mini_apps: Vec<MiniAppDefinition>,
-    use_codex_account: bool,
-    /// Desktop hosts inherit enabled local plugins from the user's standard
-    /// Codex installation by default. Tests and constrained hosts may opt out.
-    inherit_installed_plugins: Option<bool>,
-}
-
-/// Creates a long-lived runtime. A null config pointer uses safe defaults.
+/// Creates a long-lived direct Rust host and stores it behind a stable numeric
+/// handle. A null config pointer uses safe defaults.
+///
 /// Returns zero on error; call [`mahayana_runtime_last_error`] for details.
 ///
 /// # Safety
@@ -86,8 +45,8 @@ struct RuntimeCreateConfig {
 pub unsafe extern "C" fn mahayana_runtime_create(config_json: *const c_char) -> u64 {
     clear_last_error();
     let result = (|| {
-        let create_config: RuntimeCreateConfig = if config_json.is_null() {
-            RuntimeCreateConfig::default()
+        let create_config: HostCreateConfig = if config_json.is_null() {
+            HostCreateConfig::default()
         } else {
             let source = unsafe { CStr::from_ptr(config_json) }
                 .to_str()
@@ -95,12 +54,12 @@ pub unsafe extern "C" fn mahayana_runtime_create(config_json: *const c_char) -> 
             serde_json::from_str(source)
                 .map_err(|error| format!("runtime config must be valid JSON: {error}"))?
         };
-        let runtime = build_runtime(create_config)?;
+        let host = MahayanaHost::create(create_config).map_err(|error| error.to_string())?;
         let runtime_id = NEXT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed);
         RUNTIMES
             .lock()
             .map_err(|_| "runtime registry mutex poisoned".to_string())?
-            .insert(runtime_id, Arc::new(runtime));
+            .insert(runtime_id, Arc::new(host));
         Ok::<_, String>(runtime_id)
     })();
     match result {
@@ -112,248 +71,7 @@ pub unsafe extern "C" fn mahayana_runtime_create(config_json: *const c_char) -> 
     }
 }
 
-fn build_runtime(create: RuntimeCreateConfig) -> Result<MahayanaRuntime, String> {
-    let runtime_config = create.runtime.clone();
-    if runtime_config.remote_agent_enabled {
-        return Err(RuntimeError::RemoteAgentForbidden.to_string());
-    }
-    #[cfg(all(feature = "mobile-embedded", not(feature = "desktop-full")))]
-    let runtime_config = RuntimeConfig {
-        build_profile: BuildProfile::MobileEmbedded,
-        ..runtime_config
-    };
-    let host_platform = create
-        .host_platform
-        .unwrap_or(match runtime_config.build_profile {
-            BuildProfile::DesktopFull => HostPlatform::Desktop,
-            BuildProfile::MobileEmbedded => HostPlatform::Mobile,
-            BuildProfile::WebWasm => HostPlatform::Web,
-        });
-    let product_client = create
-        .product_session_path
-        .map(|path| MahayanaProductClient::new("https://api.ombhrum.com", path))
-        .unwrap_or_default();
-    let configured_mini_apps = if create.mini_apps.is_empty() {
-        discover_mini_apps(&product_client).unwrap_or_default()
-    } else {
-        create.mini_apps.clone()
-    };
-    let mini_apps = merge_official_mini_apps(configured_mini_apps);
-    let session_token = product_client.session_token().ok();
-    let mut builder = RuntimeBuilder::new(runtime_config.clone());
-    #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-    let mut codex_conversation_providers: Vec<Arc<dyn ConversationProvider>> = Vec::new();
-    if let Some(token) = session_token.as_ref() {
-        let provider = Arc::new(MahayanaSocialConversationProvider::new(
-            product_client.clone(),
-            Some(token.clone()),
-        ));
-        #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-        codex_conversation_providers.push(Arc::clone(&provider) as Arc<dyn ConversationProvider>);
-        builder = builder
-            .with_provider(provider)
-            .map_err(|error| error.to_string())?;
-    }
-    if let Some(telegram_client_id) = create.telegram_client_id {
-        let provider = Arc::new(TelegramConversationProvider::from_client_id(
-            telegram_client_id,
-            create.telegram_self_user_id.unwrap_or_default(),
-        ));
-        #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-        codex_conversation_providers.push(Arc::clone(&provider) as Arc<dyn ConversationProvider>);
-        builder = builder
-            .with_provider(provider)
-            .map_err(|error| error.to_string())?;
-    }
-
-    #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-    if matches!(
-        runtime_config.build_profile,
-        BuildProfile::DesktopFull | BuildProfile::MobileEmbedded
-    ) {
-        let data_dir = runtime_config.data_dir.clone();
-        let cwd = create
-            .cwd
-            .or_else(|| runtime_config.workspace_roots.first().cloned())
-            .or_else(|| data_dir.as_ref().map(|path| path.join("workspace")))
-            .or_else(|| std::env::current_dir().ok())
-            .ok_or_else(|| "current working directory is unavailable".to_string())?;
-        let workspace_roots = if runtime_config.workspace_roots.is_empty() {
-            vec![cwd.clone()]
-        } else {
-            runtime_config.workspace_roots.clone()
-        };
-        let codex_home = create
-            .codex_home
-            .or_else(|| data_dir.map(|path| path.join("codex")))
-            .or_else(default_codex_home_if_available)
-            .ok_or_else(|| {
-                "embedded Mahayana requires an application data directory".to_string()
-            })?;
-        let responses_base_url = create
-            .runtime
-            .model
-            .base_url
-            .clone()
-            .ok_or_else(|| "Dacheng Responses base URL is required".to_string())?;
-        let settings = CodexAgentConfig {
-            codex_home,
-            bundled_plugin_marketplace: create.bundled_plugin_marketplace.clone(),
-            bundled_plugin_ids: bundled_marketplace_plugin_ids(
-                create.bundled_plugin_marketplace.as_deref(),
-                &mini_apps,
-            )?,
-            inherit_installed_plugins: create.inherit_installed_plugins.unwrap_or(
-                matches!(runtime_config.build_profile, BuildProfile::DesktopFull) && !cfg!(test),
-            ),
-            cwd,
-            workspace_roots,
-            model: runtime_config.model.model.clone(),
-            responses_base_url,
-            use_codex_account: create.use_codex_account,
-            product_session_token: session_token.clone(),
-            sandbox_mode: codex_protocol::config_types::SandboxMode::WorkspaceWrite,
-            approval_policy: codex_protocol::protocol::AskForApproval::OnRequest,
-            codex_executable_path: create.codex_executable_path,
-            conversation_providers: codex_conversation_providers,
-        };
-        return builder
-            .build_with_agent_backend_and(
-                || async move {
-                    let backend = CodexAgentBackend::start(settings).await?;
-                    Ok(Arc::new(backend) as Arc<dyn mahayana_agent::AgentBackend>)
-                },
-                move |builder, backend| {
-                    let provider = MiniAppConversationProvider::new_for_platform_with_entitlements(
-                        backend,
-                        mini_apps,
-                        host_platform,
-                        Some(Arc::new(PlatformEntitlementChecker {
-                            client: product_client,
-                        })),
-                    )?;
-                    builder.with_provider(Arc::new(provider))
-                },
-            )
-            .map_err(|error| error.to_string());
-    }
-
-    let unavailable_reason = "this platform build has no embedded Codex backend";
-    let backend: Arc<dyn mahayana_agent::AgentBackend> =
-        Arc::new(UnavailableAgentBackend::new(unavailable_reason));
-    let miniapp = MiniAppConversationProvider::new_for_platform_with_entitlements(
-        Arc::clone(&backend),
-        mini_apps,
-        host_platform,
-        Some(Arc::new(PlatformEntitlementChecker {
-            client: product_client,
-        })),
-    )
-    .map_err(|error| error.to_string())?;
-    builder
-        .with_agent_backend(backend)
-        .map_err(|error| error.to_string())?
-        .with_provider(Arc::new(miniapp))
-        .map_err(|error| error.to_string())?
-        .build()
-        .map_err(|error| error.to_string())
-}
-
-fn merge_official_mini_apps(
-    configured: impl IntoIterator<Item = MiniAppDefinition>,
-) -> Vec<MiniAppDefinition> {
-    let mut definitions = configured
-        .into_iter()
-        .map(|definition| (definition.plugin_id.clone(), definition))
-        .collect::<BTreeMap<_, _>>();
-    for plugin_id in OFFICIAL_PLUGIN_IDS {
-        let definition = app_definition(plugin_id).expect("official plugin definition");
-        let pinned = definitions
-            .get(plugin_id)
-            .is_some_and(|definition| definition.pinned);
-        definitions.insert(
-            plugin_id.to_string(),
-            MiniAppDefinition {
-                plugin_id: definition.id,
-                title: definition.title,
-                pinned,
-            },
-        );
-    }
-    definitions.into_values().collect()
-}
-
-fn bundled_marketplace_plugin_ids(
-    marketplace_root: Option<&std::path::Path>,
-    mini_apps: &[MiniAppDefinition],
-) -> Result<Vec<String>, String> {
-    let Some(marketplace_root) = marketplace_root else {
-        return Ok(Vec::new());
-    };
-    let mut plugin_ids = Vec::new();
-    for mini_app in mini_apps {
-        let plugin_id = mini_app.plugin_id.as_str();
-        if plugin_id.is_empty()
-            || !plugin_id
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
-        {
-            return Err(format!("invalid bundled plugin id: {plugin_id}"));
-        }
-        if marketplace_root
-            .join("plugins")
-            .join(plugin_id)
-            .join(".codex-plugin/plugin.json")
-            .is_file()
-        {
-            plugin_ids.push(plugin_id.to_string());
-        }
-    }
-    Ok(plugin_ids)
-}
-
-fn discover_mini_apps(client: &MahayanaProductClient) -> Option<Vec<MiniAppDefinition>> {
-    let registry = client
-        .execute("mahayana.miniapps.registry", &json!({}))
-        .ok()?;
-    let plugins = registry.get("plugins")?.as_array()?;
-    let definitions = plugins
-        .iter()
-        .filter_map(|plugin| {
-            let id = plugin.get("id")?.as_str()?.trim();
-            let title = plugin.get("title")?.as_str()?.trim();
-            if id.is_empty() || title.is_empty() {
-                return None;
-            }
-            Some(MiniAppDefinition {
-                plugin_id: id.to_string(),
-                title: title.to_string(),
-                pinned: false,
-            })
-        })
-        .collect::<Vec<_>>();
-    (!definitions.is_empty()).then_some(definitions)
-}
-
-#[cfg(feature = "desktop-full")]
-fn default_codex_home() -> PathBuf {
-    default_mahayana_home().join("codex")
-}
-
-#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
-fn default_codex_home_if_available() -> Option<PathBuf> {
-    #[cfg(feature = "desktop-full")]
-    {
-        #[allow(clippy::needless_return)]
-        Some(default_codex_home())
-    }
-    #[cfg(not(feature = "desktop-full"))]
-    {
-        None
-    }
-}
-
-/// Executes one command against a runtime and returns an owned JSON string.
+/// Executes one typed Runtime command and returns an owned JSON envelope.
 ///
 /// # Safety
 /// `command_json` must be a valid NUL-terminated UTF-8 string. Release the
@@ -364,21 +82,21 @@ pub unsafe extern "C" fn mahayana_runtime_execute(
     command_json: *const c_char,
 ) -> *mut c_char {
     ffi_response(|| {
-        let runtime = runtime(runtime_id)?;
         let command: RuntimeCommand = unsafe { parse_json(command_json, "command") }?;
-        runtime.execute(command).map_err(|error| error.to_string())
+        runtime(runtime_id)?
+            .execute(command)
+            .map_err(|error| error.to_string())
     })
 }
 
-/// Receives the next runtime event, waiting for at most `timeout_ms`.
+/// Receives the next Runtime event, waiting for at most `timeout_ms`.
 ///
 /// # Safety
 /// Release the returned pointer with [`mahayana_runtime_free_string`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mahayana_runtime_receive(runtime_id: u64, timeout_ms: u64) -> *mut c_char {
     ffi_response(|| {
-        let runtime = runtime(runtime_id)?;
-        runtime
+        runtime(runtime_id)?
             .receive(Duration::from_millis(timeout_ms))
             .map_err(|error| error.to_string())
     })
@@ -396,11 +114,10 @@ pub unsafe extern "C" fn mahayana_runtime_interrupt(
 ) -> *mut c_char {
     ffi_response(|| {
         let payload: Value = unsafe { parse_json(operation_json, "operation") }?;
-        let operation_id = required_string(&payload, "operationId")?;
+        let operation_id = OperationId::new(required_string(&payload, "operationId")?)
+            .map_err(|error| error.to_string())?;
         runtime(runtime_id)?
-            .execute(RuntimeCommand::Interrupt {
-                operation_id: OperationId::new(operation_id).map_err(|error| error.to_string())?,
-            })
+            .interrupt(operation_id)
             .map_err(|error| error.to_string())
     })
 }
@@ -408,7 +125,7 @@ pub unsafe extern "C" fn mahayana_runtime_interrupt(
 /// Resolves an approval using `{ "approvalId", "decision", "payload"? }`.
 ///
 /// # Safety
-/// `approval_json` must be a valid NUL-terminated UTF-8 string. Release the
+/// `approval_json` must point to valid NUL-terminated UTF-8. Release the
 /// returned pointer with [`mahayana_runtime_free_string`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mahayana_runtime_resolve_approval(
@@ -427,16 +144,16 @@ pub unsafe extern "C" fn mahayana_runtime_resolve_approval(
         )
         .map_err(|error| format!("approval decision is invalid: {error}"))?;
         runtime(runtime_id)?
-            .execute(RuntimeCommand::ResolveApproval {
+            .resolve_approval(
                 approval_id,
                 decision,
-                payload: payload.get("payload").cloned().unwrap_or(Value::Null),
-            })
+                payload.get("payload").cloned().unwrap_or(Value::Null),
+            )
             .map_err(|error| error.to_string())
     })
 }
 
-/// Closes and removes a runtime handle.
+/// Closes and removes a Runtime handle.
 ///
 /// # Safety
 /// Release the returned pointer with [`mahayana_runtime_free_string`].
@@ -466,9 +183,7 @@ pub unsafe extern "C" fn mahayana_runtime_last_error() -> *mut c_char {
 }
 
 /// Executes first-party account, contact-management, or direct-message
-/// commands. Conversation reads/sends should use the long-lived runtime ABI;
-/// this side API exists for login and contact-management operations that are
-/// not conversations themselves.
+/// commands that are outside the long-lived conversation Runtime.
 ///
 /// # Safety
 /// `request_json` must point to valid NUL-terminated UTF-8 JSON. Release the
@@ -484,8 +199,8 @@ pub unsafe extern "C" fn mahayana_product_execute(request_json: *const c_char) -
     })
 }
 
-/// Linker anchor for Flutter builds that load the shared Mahayana library and
-/// resolve the Telegram symbols from that same artifact.
+/// Linker anchor for legacy Flutter builds that resolve Runtime and Telegram
+/// symbols from one shared artifact.
 #[unsafe(no_mangle)]
 pub extern "C" fn mahayana_runtime_force_link() -> u32 {
     let runtime_symbols = [
@@ -521,7 +236,7 @@ pub unsafe extern "C" fn mahayana_runtime_free_string(pointer: *mut c_char) {
     }
 }
 
-fn runtime(runtime_id: u64) -> Result<Arc<MahayanaRuntime>, String> {
+fn runtime(runtime_id: u64) -> Result<Arc<MahayanaHost>, String> {
     RUNTIMES
         .lock()
         .map_err(|_| "runtime registry mutex poisoned".to_string())?
@@ -598,39 +313,6 @@ mod tests {
     }
 
     #[test]
-    fn bundled_marketplace_enables_only_plugins_present_on_disk() {
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "mahayana-ffi-marketplace-{}-{unique}",
-            std::process::id()
-        ));
-        let manifest = root.join("plugins/cloud-market-hello/.codex-plugin/plugin.json");
-        std::fs::create_dir_all(manifest.parent().expect("manifest parent"))
-            .expect("create plugin tree");
-        std::fs::write(&manifest, "{}").expect("write plugin manifest");
-
-        let mini_apps = vec![
-            MiniAppDefinition {
-                plugin_id: "cloud-market-hello".into(),
-                title: "Cloud Market Hello".into(),
-                pinned: false,
-            },
-            MiniAppDefinition {
-                plugin_id: "bot-father".into(),
-                title: "Bot Father".into(),
-                pinned: false,
-            },
-        ];
-        let plugin_ids =
-            bundled_marketplace_plugin_ids(Some(&root), &mini_apps).expect("bundled plugin ids");
-        assert_eq!(plugin_ids, vec!["cloud-market-hello"]);
-        std::fs::remove_dir_all(root).expect("remove plugin tree");
-    }
-
-    #[test]
     fn lifecycle_abi_creates_executes_receives_and_closes() {
         let runtime_id = unsafe { mahayana_runtime_create(std::ptr::null()) };
         assert_ne!(runtime_id, 0);
@@ -661,22 +343,13 @@ mod tests {
                 .contains("remote Agent")
         );
     }
-}
-#[derive(Clone)]
-struct PlatformEntitlementChecker {
-    client: MahayanaProductClient,
-}
 
-#[async_trait::async_trait]
-impl EntitlementChecker for PlatformEntitlementChecker {
-    async fn has_entitlement(&self, plugin_id: &str, capability: &str) -> Result<bool, String> {
-        let client = self.client.clone();
-        let plugin_id = plugin_id.to_string();
-        let capability = capability.to_string();
-        tokio::task::spawn_blocking(move || client.entitlement(&plugin_id, &capability))
-            .await
-            .map_err(|error| error.to_string())?
-            .map(|entitlement| entitlement.is_some())
-            .map_err(|error| error.to_string())
+    #[test]
+    fn unknown_handle_preserves_legacy_error_envelope() {
+        let command = CString::new(r#"{"@type":"mahayana.runtime.status"}"#).unwrap();
+        let response = take(unsafe { mahayana_runtime_execute(u64::MAX, command.as_ptr()) });
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["errorCode"], "mahayana_runtime_error");
+        assert!(response["message"].as_str().unwrap().contains("not found"));
     }
 }

--- a/third_party/mahayana/mahayana-rs/mahayana-ffi/tests/direct_host_parity.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-ffi/tests/direct_host_parity.rs
@@ -1,0 +1,57 @@
+use mahayana_core::RuntimeCommand;
+use mahayana_host::HostCreateConfig;
+use mahayana_host::MahayanaHost;
+use mahayana_runtime::mahayana_runtime_close;
+use mahayana_runtime::mahayana_runtime_create;
+use mahayana_runtime::mahayana_runtime_execute;
+use mahayana_runtime::mahayana_runtime_free_string;
+use mahayana_runtime::mahayana_runtime_receive;
+use serde_json::Value;
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::time::Duration;
+
+fn take(pointer: *mut c_char) -> Value {
+    assert!(!pointer.is_null(), "FFI response pointer must not be null");
+    let text = unsafe { CStr::from_ptr(pointer) }
+        .to_str()
+        .expect("FFI response must be UTF-8")
+        .to_string();
+    unsafe { mahayana_runtime_free_string(pointer) };
+    serde_json::from_str(&text).expect("FFI response must be JSON")
+}
+
+#[test]
+fn direct_host_and_legacy_ffi_return_the_same_status_and_ready_event() {
+    let direct = MahayanaHost::create(HostCreateConfig::default()).expect("create direct Host");
+    let direct_status = serde_json::to_value(
+        direct
+            .execute(RuntimeCommand::Status)
+            .expect("direct status command"),
+    )
+    .expect("serialize direct status");
+    let direct_ready = serde_json::to_value(
+        direct
+            .receive(Duration::from_millis(10))
+            .expect("receive direct ready event")
+            .expect("direct ready event"),
+    )
+    .expect("serialize direct ready event");
+
+    let runtime_id = unsafe { mahayana_runtime_create(std::ptr::null()) };
+    assert_ne!(runtime_id, 0, "create FFI Host");
+    let command = CString::new(r#"{"@type":"mahayana.runtime.status"}"#)
+        .expect("status command CString");
+    let ffi_status = take(unsafe { mahayana_runtime_execute(runtime_id, command.as_ptr()) });
+    let ffi_ready = take(unsafe { mahayana_runtime_receive(runtime_id, 10) });
+
+    assert_eq!(ffi_status["ok"], true);
+    assert_eq!(ffi_status["data"], direct_status);
+    assert_eq!(ffi_ready["ok"], true);
+    assert_eq!(ffi_ready["data"], direct_ready);
+
+    let closed = take(unsafe { mahayana_runtime_close(runtime_id) });
+    assert_eq!(closed["ok"], true);
+    assert_eq!(closed["data"]["closed"], true);
+}

--- a/third_party/mahayana/mahayana-rs/mahayana-host/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/mahayana-host/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "mahayana-host"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Direct Rust host API for the embedded Mahayana Runtime."
+publish = false
+
+[lib]
+doctest = false
+
+[features]
+# The default developer/test build intentionally avoids compiling the embedded
+# Codex desktop graph. Production shells opt into desktop-full or
+# mobile-embedded explicitly.
+default = ["local-only"]
+desktop-full = [
+    "mahayana-runtime-core/desktop-full",
+    "dep:codex-protocol",
+    "dep:mahayana-agent-codex",
+]
+mobile-embedded = [
+    "mahayana-runtime-core/mobile-embedded",
+    "dep:codex-protocol",
+    "dep:mahayana-agent-codex",
+]
+linux-shared = [
+    "mahayana-runtime-core/mobile-embedded",
+    "dep:codex-protocol",
+]
+web-wasm = ["mahayana-runtime-core/web-wasm"]
+local-only = ["mahayana-runtime-core/local-only"]
+remote-model-provider = ["mahayana-runtime-core/remote-model-provider"]
+telemetry = ["mahayana-runtime-core/telemetry"]
+
+[dependencies]
+async-trait.workspace = true
+codex-protocol = { workspace = true, optional = true }
+fabushi-official-miniapps.workspace = true
+mahayana-agent.workspace = true
+mahayana-agent-codex = { path = "../mahayana-agent-codex", optional = true }
+mahayana-conversation.workspace = true
+mahayana-core.workspace = true
+mahayana-miniapp.workspace = true
+mahayana-platform-core.workspace = true
+mahayana-product = { package = "mahayana-platform-client", path = "../mahayana-product" }
+mahayana-runtime-core = { package = "mahayana-runtime", path = "../mahayana-runtime", default-features = false }
+mahayana-social.workspace = true
+mahayana-telegram.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true

--- a/third_party/mahayana/mahayana-rs/mahayana-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-host/src/lib.rs
@@ -1,0 +1,461 @@
+//! Direct Rust host API for the long-lived Mahayana Runtime.
+//!
+//! Native shells such as Tauri, Swift, and Kotlin should depend on this crate.
+//! The C/JSON ABI remains a compatibility adapter for the legacy Flutter host.
+
+use fabushi_official_miniapps::OFFICIAL_PLUGIN_IDS;
+use fabushi_official_miniapps::app_definition;
+use mahayana_agent::UnavailableAgentBackend;
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+use mahayana_agent_codex::CodexAgentBackend;
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+use mahayana_agent_codex::CodexAgentConfig;
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+use mahayana_conversation::ConversationProvider;
+use mahayana_core::ApprovalDecision;
+use mahayana_core::ApprovalId;
+use mahayana_core::BuildProfile;
+use mahayana_core::OperationId;
+use mahayana_core::RuntimeCommand;
+use mahayana_core::RuntimeConfig;
+use mahayana_core::RuntimeEvent;
+use mahayana_core::RuntimeResponse;
+use mahayana_core::RuntimeStatus;
+use mahayana_miniapp::EntitlementChecker;
+use mahayana_miniapp::MiniAppConversationProvider;
+use mahayana_miniapp::MiniAppDefinition;
+use mahayana_platform_core::HostPlatform;
+use mahayana_product::MahayanaProductClient;
+#[cfg(feature = "desktop-full")]
+use mahayana_product::default_mahayana_home;
+use mahayana_runtime_core::MahayanaRuntime;
+use mahayana_runtime_core::RuntimeBuilder;
+use mahayana_runtime_core::RuntimeError;
+use mahayana_social::MahayanaSocialConversationProvider;
+use mahayana_telegram::TelegramConversationProvider;
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct HostCreateConfig {
+    #[serde(flatten)]
+    pub runtime: RuntimeConfig,
+    pub product_session_path: Option<PathBuf>,
+    pub codex_home: Option<PathBuf>,
+    /// Read-only marketplace shipped inside the native application.
+    pub bundled_plugin_marketplace: Option<PathBuf>,
+    /// Optional Mahayana CLI used only for desktop argv helper dispatch.
+    pub codex_executable_path: Option<PathBuf>,
+    pub cwd: Option<PathBuf>,
+    /// Existing embedded Telegram client created by the platform login flow.
+    pub telegram_client_id: Option<u64>,
+    pub telegram_self_user_id: Option<i64>,
+    pub host_platform: Option<HostPlatform>,
+    pub mini_apps: Vec<MiniAppDefinition>,
+    pub use_codex_account: bool,
+    /// Tests and constrained hosts may opt out of inherited local plugins.
+    pub inherit_installed_plugins: Option<bool>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct HostError {
+    message: String,
+}
+
+impl HostError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl From<RuntimeError> for HostError {
+    fn from(error: RuntimeError) -> Self {
+        Self::new(error.to_string())
+    }
+}
+
+/// Long-lived process-local host shared by every presentation surface.
+#[derive(Clone)]
+pub struct MahayanaHost {
+    runtime: Arc<MahayanaRuntime>,
+}
+
+impl MahayanaHost {
+    pub fn create(config: HostCreateConfig) -> Result<Self, HostError> {
+        Ok(Self {
+            runtime: Arc::new(build_runtime(config)?),
+        })
+    }
+
+    pub fn status(&self) -> RuntimeStatus {
+        self.runtime.status()
+    }
+
+    pub fn execute(&self, command: RuntimeCommand) -> Result<RuntimeResponse, HostError> {
+        self.runtime.execute(command).map_err(HostError::from)
+    }
+
+    pub fn receive(&self, timeout: Duration) -> Result<Option<RuntimeEvent>, HostError> {
+        self.runtime.receive(timeout).map_err(HostError::from)
+    }
+
+    pub fn interrupt(&self, operation_id: OperationId) -> Result<RuntimeResponse, HostError> {
+        self.execute(RuntimeCommand::Interrupt { operation_id })
+    }
+
+    pub fn resolve_approval(
+        &self,
+        approval_id: ApprovalId,
+        decision: ApprovalDecision,
+        payload: serde_json::Value,
+    ) -> Result<RuntimeResponse, HostError> {
+        self.execute(RuntimeCommand::ResolveApproval {
+            approval_id,
+            decision,
+            payload,
+        })
+    }
+}
+
+fn build_runtime(create: HostCreateConfig) -> Result<MahayanaRuntime, HostError> {
+    let runtime_config = create.runtime.clone();
+    if runtime_config.remote_agent_enabled {
+        return Err(RuntimeError::RemoteAgentForbidden.into());
+    }
+    #[cfg(all(feature = "mobile-embedded", not(feature = "desktop-full")))]
+    let runtime_config = RuntimeConfig {
+        build_profile: BuildProfile::MobileEmbedded,
+        ..runtime_config
+    };
+    let host_platform = create
+        .host_platform
+        .unwrap_or(match runtime_config.build_profile {
+            BuildProfile::DesktopFull => HostPlatform::Desktop,
+            BuildProfile::MobileEmbedded => HostPlatform::Mobile,
+            BuildProfile::WebWasm => HostPlatform::Web,
+        });
+    let product_client = create
+        .product_session_path
+        .map(|path| MahayanaProductClient::new("https://api.ombhrum.com", path))
+        .unwrap_or_default();
+    let configured_mini_apps = if create.mini_apps.is_empty() {
+        discover_mini_apps(&product_client).unwrap_or_default()
+    } else {
+        create.mini_apps.clone()
+    };
+    let mini_apps = merge_official_mini_apps(configured_mini_apps);
+    let session_token = product_client.session_token().ok();
+    let mut builder = RuntimeBuilder::new(runtime_config.clone());
+    #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+    let mut codex_conversation_providers: Vec<Arc<dyn ConversationProvider>> = Vec::new();
+    if let Some(token) = session_token.as_ref() {
+        let provider = Arc::new(MahayanaSocialConversationProvider::new(
+            product_client.clone(),
+            Some(token.clone()),
+        ));
+        #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+        codex_conversation_providers.push(Arc::clone(&provider) as Arc<dyn ConversationProvider>);
+        builder = builder.with_provider(provider)?;
+    }
+    if let Some(telegram_client_id) = create.telegram_client_id {
+        let provider = Arc::new(TelegramConversationProvider::from_client_id(
+            telegram_client_id,
+            create.telegram_self_user_id.unwrap_or_default(),
+        ));
+        #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+        codex_conversation_providers.push(Arc::clone(&provider) as Arc<dyn ConversationProvider>);
+        builder = builder.with_provider(provider)?;
+    }
+
+    #[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+    if matches!(
+        runtime_config.build_profile,
+        BuildProfile::DesktopFull | BuildProfile::MobileEmbedded
+    ) {
+        let data_dir = runtime_config.data_dir.clone();
+        let cwd = create
+            .cwd
+            .or_else(|| runtime_config.workspace_roots.first().cloned())
+            .or_else(|| data_dir.as_ref().map(|path| path.join("workspace")))
+            .or_else(|| std::env::current_dir().ok())
+            .ok_or_else(|| HostError::new("current working directory is unavailable"))?;
+        let workspace_roots = if runtime_config.workspace_roots.is_empty() {
+            vec![cwd.clone()]
+        } else {
+            runtime_config.workspace_roots.clone()
+        };
+        let codex_home = create
+            .codex_home
+            .or_else(|| data_dir.map(|path| path.join("codex")))
+            .or_else(default_codex_home_if_available)
+            .ok_or_else(|| {
+                HostError::new("embedded Mahayana requires an application data directory")
+            })?;
+        let responses_base_url = create
+            .runtime
+            .model
+            .base_url
+            .clone()
+            .ok_or_else(|| HostError::new("Dacheng Responses base URL is required"))?;
+        let settings = CodexAgentConfig {
+            codex_home,
+            bundled_plugin_marketplace: create.bundled_plugin_marketplace.clone(),
+            bundled_plugin_ids: bundled_marketplace_plugin_ids(
+                create.bundled_plugin_marketplace.as_deref(),
+                &mini_apps,
+            )?,
+            inherit_installed_plugins: create.inherit_installed_plugins.unwrap_or(
+                matches!(runtime_config.build_profile, BuildProfile::DesktopFull) && !cfg!(test),
+            ),
+            cwd,
+            workspace_roots,
+            model: runtime_config.model.model.clone(),
+            responses_base_url,
+            use_codex_account: create.use_codex_account,
+            product_session_token: session_token.clone(),
+            sandbox_mode: codex_protocol::config_types::SandboxMode::WorkspaceWrite,
+            approval_policy: codex_protocol::protocol::AskForApproval::OnRequest,
+            codex_executable_path: create.codex_executable_path,
+            conversation_providers: codex_conversation_providers,
+        };
+        return builder
+            .build_with_agent_backend_and(
+                || async move {
+                    let backend = CodexAgentBackend::start(settings).await?;
+                    Ok(Arc::new(backend) as Arc<dyn mahayana_agent::AgentBackend>)
+                },
+                move |builder, backend| {
+                    let provider = MiniAppConversationProvider::new_for_platform_with_entitlements(
+                        backend,
+                        mini_apps,
+                        host_platform,
+                        Some(Arc::new(PlatformEntitlementChecker {
+                            client: product_client,
+                        })),
+                    )?;
+                    builder.with_provider(Arc::new(provider))
+                },
+            )
+            .map_err(HostError::from);
+    }
+
+    let unavailable_reason = "this platform build has no embedded Codex backend";
+    let backend: Arc<dyn mahayana_agent::AgentBackend> =
+        Arc::new(UnavailableAgentBackend::new(unavailable_reason));
+    let miniapp = MiniAppConversationProvider::new_for_platform_with_entitlements(
+        Arc::clone(&backend),
+        mini_apps,
+        host_platform,
+        Some(Arc::new(PlatformEntitlementChecker {
+            client: product_client,
+        })),
+    )
+    .map_err(|error| HostError::new(error.to_string()))?;
+    builder
+        .with_agent_backend(backend)?
+        .with_provider(Arc::new(miniapp))?
+        .build()
+        .map_err(HostError::from)
+}
+
+fn merge_official_mini_apps(
+    configured: impl IntoIterator<Item = MiniAppDefinition>,
+) -> Vec<MiniAppDefinition> {
+    let mut definitions = configured
+        .into_iter()
+        .map(|definition| (definition.plugin_id.clone(), definition))
+        .collect::<BTreeMap<_, _>>();
+    for plugin_id in OFFICIAL_PLUGIN_IDS {
+        let definition = app_definition(plugin_id).expect("official plugin definition");
+        let pinned = definitions
+            .get(plugin_id)
+            .is_some_and(|definition| definition.pinned);
+        definitions.insert(
+            plugin_id.to_string(),
+            MiniAppDefinition {
+                plugin_id: definition.id,
+                title: definition.title,
+                pinned,
+            },
+        );
+    }
+    definitions.into_values().collect()
+}
+
+fn bundled_marketplace_plugin_ids(
+    marketplace_root: Option<&Path>,
+    mini_apps: &[MiniAppDefinition],
+) -> Result<Vec<String>, HostError> {
+    let Some(marketplace_root) = marketplace_root else {
+        return Ok(Vec::new());
+    };
+    let mut plugin_ids = Vec::new();
+    for mini_app in mini_apps {
+        let plugin_id = mini_app.plugin_id.as_str();
+        if plugin_id.is_empty()
+            || !plugin_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err(HostError::new(format!(
+                "invalid bundled plugin id: {plugin_id}"
+            )));
+        }
+        if marketplace_root
+            .join("plugins")
+            .join(plugin_id)
+            .join(".codex-plugin/plugin.json")
+            .is_file()
+        {
+            plugin_ids.push(plugin_id.to_string());
+        }
+    }
+    Ok(plugin_ids)
+}
+
+fn discover_mini_apps(client: &MahayanaProductClient) -> Option<Vec<MiniAppDefinition>> {
+    let registry = client
+        .execute("mahayana.miniapps.registry", &json!({}))
+        .ok()?;
+    let plugins = registry.get("plugins")?.as_array()?;
+    let definitions = plugins
+        .iter()
+        .filter_map(|plugin| {
+            let id = plugin.get("id")?.as_str()?.trim();
+            let title = plugin.get("title")?.as_str()?.trim();
+            if id.is_empty() || title.is_empty() {
+                return None;
+            }
+            Some(MiniAppDefinition {
+                plugin_id: id.to_string(),
+                title: title.to_string(),
+                pinned: false,
+            })
+        })
+        .collect::<Vec<_>>();
+    (!definitions.is_empty()).then_some(definitions)
+}
+
+#[cfg(feature = "desktop-full")]
+fn default_codex_home() -> PathBuf {
+    default_mahayana_home().join("codex")
+}
+
+#[cfg(any(feature = "desktop-full", feature = "mobile-embedded"))]
+fn default_codex_home_if_available() -> Option<PathBuf> {
+    #[cfg(feature = "desktop-full")]
+    {
+        #[allow(clippy::needless_return)]
+        return Some(default_codex_home());
+    }
+    #[cfg(not(feature = "desktop-full"))]
+    {
+        None
+    }
+}
+
+#[derive(Clone)]
+struct PlatformEntitlementChecker {
+    client: MahayanaProductClient,
+}
+
+#[async_trait::async_trait]
+impl EntitlementChecker for PlatformEntitlementChecker {
+    async fn has_entitlement(&self, plugin_id: &str, capability: &str) -> Result<bool, String> {
+        let client = self.client.clone();
+        let plugin_id = plugin_id.to_string();
+        let capability = capability.to_string();
+        tokio::task::spawn_blocking(move || client.entitlement(&plugin_id, &capability))
+            .await
+            .map_err(|error| error.to_string())?
+            .map(|entitlement| entitlement.is_some())
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> HostCreateConfig {
+        HostCreateConfig {
+            mini_apps: vec![MiniAppDefinition {
+                plugin_id: "test-miniapp".to_string(),
+                title: "Test MiniApp".to_string(),
+                pinned: false,
+            }],
+            inherit_installed_plugins: Some(false),
+            ..HostCreateConfig::default()
+        }
+    }
+
+    #[test]
+    fn direct_host_creates_executes_receives_and_clones() {
+        let host = MahayanaHost::create(test_config()).expect("create host");
+        let cloned = host.clone();
+        let status = cloned
+            .execute(RuntimeCommand::Status)
+            .expect("execute status");
+        let encoded = serde_json::to_value(status).expect("serialize status");
+        assert_eq!(encoded["runtimeAbiVersion"], 1);
+        assert_eq!(encoded["remoteAgentEnabled"], false);
+
+        let ready = host
+            .receive(Duration::from_millis(10))
+            .expect("receive ready")
+            .expect("ready event");
+        let encoded = serde_json::to_value(ready).expect("serialize event");
+        assert_eq!(encoded["@type"], "mahayana.runtime.ready");
+    }
+
+    #[test]
+    fn create_rejects_remote_agent_gateway() {
+        let mut config = test_config();
+        config.runtime.remote_agent_enabled = true;
+        let error = MahayanaHost::create(config)
+            .err()
+            .expect("remote agent must be rejected");
+        assert!(error.to_string().contains("remote Agent"));
+    }
+
+    #[test]
+    fn bundled_marketplace_enables_only_plugins_present_on_disk() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "mahayana-host-marketplace-{}-{unique}",
+            std::process::id()
+        ));
+        let manifest = root.join("plugins/cloud-market-hello/.codex-plugin/plugin.json");
+        std::fs::create_dir_all(manifest.parent().expect("manifest parent"))
+            .expect("create plugin tree");
+        std::fs::write(&manifest, "{}").expect("write plugin manifest");
+
+        let mini_apps = vec![
+            MiniAppDefinition {
+                plugin_id: "cloud-market-hello".into(),
+                title: "Cloud Market Hello".into(),
+                pinned: false,
+            },
+            MiniAppDefinition {
+                plugin_id: "bot-father".into(),
+                title: "Bot Father".into(),
+                pinned: false,
+            },
+        ];
+        let plugin_ids =
+            bundled_marketplace_plugin_ids(Some(&root), &mini_apps).expect("bundled plugin ids");
+        assert_eq!(plugin_ids, vec!["cloud-market-hello"]);
+        std::fs::remove_dir_all(root).expect("remove plugin tree");
+    }
+}


### PR DESCRIPTION
## Objective

Remove the duplicated Runtime assembly and platform-provider graph from the legacy C/JSON layer while preserving every exported symbol used by Flutter and native bundles.

## Changes

- Make `mahayana-ffi` depend on the direct `mahayana-host` crate.
- Delegate create, execute, receive, interrupt, approval resolution, and close to `MahayanaHost`.
- Retain numeric handles, C string ownership, JSON envelopes, product side API, and the Runtime/Telegram force-link anchor.
- Forward all build features to `mahayana-host`.
- Remove direct Codex, provider, MiniApp, social, and Telegram assembly dependencies from the FFI crate.
- Add an explicit unknown-handle compatibility test.

## Compatibility contract

The following symbols and response envelopes remain unchanged:

- `mahayana_runtime_create`
- `mahayana_runtime_execute`
- `mahayana_runtime_receive`
- `mahayana_runtime_interrupt`
- `mahayana_runtime_resolve_approval`
- `mahayana_runtime_close`
- `mahayana_runtime_last_error`
- `mahayana_product_execute`
- `mahayana_runtime_force_link`
- `mahayana_runtime_free_string`

## Acceptance evidence

- direct Host tests pass
- FFI lifecycle, remote-gateway rejection, and error-envelope tests pass
- existing minimal embedded FFI check remains green
- existing native bundle workflows remain compatible

Stacked on #1910.