### PR TITLE
feat(tauri): add the first direct Mahayana Host vertical slice

### DIFF
--- a/.github/workflows/tauri-host-fast-checks.yml
+++ b/.github/workflows/tauri-host-fast-checks.yml
@@ -1,0 +1,106 @@
+name: Tauri Host fast checks
+
+on:
+  pull_request:
+    paths:
+      - apps/fabushi-tauri/**
+      - third_party/mahayana/mahayana-rs/mahayana-host/**
+      - third_party/mahayana/mahayana-rs/mahayana-core/**
+      - third_party/mahayana/mahayana-rs/mahayana-runtime/**
+      - .github/workflows/tauri-host-fast-checks.yml
+  push:
+    branches: [main]
+    paths:
+      - apps/fabushi-tauri/**
+      - third_party/mahayana/mahayana-rs/mahayana-host/**
+      - .github/workflows/tauri-host-fast-checks.yml
+  workflow_dispatch:
+
+concurrency:
+  group: tauri-host-fast-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  headless-contract:
+    name: Headless Tauri command contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout shell and Rust core
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /apps/fabushi-tauri/**
+            /third_party/mahayana/**
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Restore Tauri Host Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/fabushi-tauri/src-tauri -> target
+          shared-key: tauri-host-headless-v1
+          cache-all-crates: true
+
+      - name: Verify formatting
+        run: cargo fmt --manifest-path apps/fabushi-tauri/src-tauri/Cargo.toml -- --check
+
+      - name: Test command contract under execution budget
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_at="$(date +%s)"
+          cargo test \
+            --manifest-path apps/fabushi-tauri/src-tauri/Cargo.toml \
+            --no-default-features \
+            --features headless
+          elapsed="$(( $(date +%s) - started_at ))"
+          echo "Headless Tauri command contract elapsed: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$elapsed" -gt 300 ]; then
+            echo "Headless Tauri contract exceeded the 300-second cold budget." >&2
+            exit 1
+          fi
+
+      - name: Upload generated application lockfile
+        uses: actions/upload-artifact@v7
+        with:
+          name: fabushi-tauri-cargo-lock
+          path: apps/fabushi-tauri/src-tauri/Cargo.lock
+          if-no-files-found: error
+          retention-days: 3
+
+  desktop-compile:
+    name: macOS Tauri desktop compile
+    runs-on: macos-latest
+    timeout-minutes: 18
+    steps:
+      - name: Checkout shell and Rust core
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /apps/fabushi-tauri/**
+            /third_party/mahayana/**
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore macOS Tauri Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/fabushi-tauri/src-tauri -> target
+          shared-key: tauri-host-macos-v1
+          cache-all-crates: true
+
+      - name: Compile the real desktop shell
+        run: >-
+          cargo check
+          --manifest-path apps/fabushi-tauri/src-tauri/Cargo.toml
+          --features desktop

--- a/apps/fabushi-tauri/src-tauri/Cargo.toml
+++ b/apps/fabushi-tauri/src-tauri/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "fabushi-tauri"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+
+[lib]
+name = "fabushi_tauri_lib"
+crate-type = ["rlib", "cdylib", "staticlib"]
+doctest = false
+
+[[bin]]
+name = "fabushi"
+path = "src/main.rs"
+required-features = ["desktop"]
+
+[features]
+default = ["desktop"]
+desktop = ["dep:tauri", "tauri/wry"]
+headless = []
+
+[dependencies]
+mahayana-core = { path = "../../../third_party/mahayana/mahayana-rs/mahayana-core" }
+mahayana-host = { path = "../../../third_party/mahayana/mahayana-rs/mahayana-host", default-features = false, features = ["local-only"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tauri = { version = "2", default-features = false, optional = true }
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }

--- a/apps/fabushi-tauri/src-tauri/build.rs
+++ b/apps/fabushi-tauri/src-tauri/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if std::env::var_os("CARGO_FEATURE_DESKTOP").is_some() {
+        tauri_build::build();
+    }
+}

--- a/apps/fabushi-tauri/src-tauri/capabilities/default.json
+++ b/apps/fabushi-tauri/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Least-privilege permissions for the Fabushi Host window.",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}

--- a/apps/fabushi-tauri/src-tauri/src/lib.rs
+++ b/apps/fabushi-tauri/src-tauri/src/lib.rs
@@ -1,0 +1,174 @@
+//! Thin Tauri shell around the direct `mahayana-host` Rust API.
+//!
+//! The state machine is independent from Tauri so ordinary pull requests can
+//! exercise every command without a window server or simulator. The desktop
+//! adapter below only converts Tauri inputs into the same typed state methods.
+
+use mahayana_core::RuntimeCommand;
+use mahayana_host::HostCreateConfig;
+use mahayana_host::MahayanaHost;
+use serde_json::Value;
+use serde_json::json;
+use std::sync::Mutex;
+use std::time::Duration;
+
+#[derive(Default)]
+pub struct HostState {
+    host: Mutex<Option<MahayanaHost>>,
+}
+
+impl HostState {
+    pub fn initialize(&self, config: Option<Value>) -> Result<Value, String> {
+        let config = config
+            .map(serde_json::from_value::<HostCreateConfig>)
+            .transpose()
+            .map_err(|error| format!("invalid Host configuration: {error}"))?
+            .unwrap_or_default();
+        let host = MahayanaHost::create(config).map_err(|error| error.to_string())?;
+        let status = serde_json::to_value(host.status()).map_err(|error| error.to_string())?;
+        *self.lock()? = Some(host);
+        Ok(json!({"initialized": true, "status": status}))
+    }
+
+    pub fn execute(&self, command: Value) -> Result<Value, String> {
+        let command: RuntimeCommand = serde_json::from_value(command)
+            .map_err(|error| format!("invalid Runtime command: {error}"))?;
+        let response = self.with_host(|host| host.execute(command))?;
+        serde_json::to_value(response).map_err(|error| error.to_string())
+    }
+
+    pub fn receive(&self, timeout_ms: u64) -> Result<Value, String> {
+        let event = self.with_host(|host| host.receive(Duration::from_millis(timeout_ms)))?;
+        serde_json::to_value(event).map_err(|error| error.to_string())
+    }
+
+    pub fn close(&self) -> Result<Value, String> {
+        let removed = self.lock()?.take().is_some();
+        Ok(json!({"closed": removed}))
+    }
+
+    pub fn snapshot(&self) -> Result<Value, String> {
+        let guard = self.lock()?;
+        Ok(match guard.as_ref() {
+            Some(host) => json!({
+                "initialized": true,
+                "status": host.status(),
+            }),
+            None => json!({"initialized": false}),
+        })
+    }
+
+    fn with_host<T>(
+        &self,
+        operation: impl FnOnce(&MahayanaHost) -> Result<T, mahayana_host::HostError>,
+    ) -> Result<T, String> {
+        let guard = self.lock()?;
+        let host = guard
+            .as_ref()
+            .ok_or_else(|| "Mahayana Host is not initialized".to_string())?;
+        operation(host).map_err(|error| error.to_string())
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Option<MahayanaHost>>, String> {
+        self.host
+            .lock()
+            .map_err(|_| "Mahayana Host state mutex is poisoned".to_string())
+    }
+}
+
+#[cfg(feature = "desktop")]
+mod desktop {
+    use super::HostState;
+    use serde_json::Value;
+    use tauri::State;
+
+    #[tauri::command]
+    fn host_initialize(
+        state: State<'_, HostState>,
+        config: Option<Value>,
+    ) -> Result<Value, String> {
+        state.initialize(config)
+    }
+
+    #[tauri::command]
+    fn host_execute(state: State<'_, HostState>, command: Value) -> Result<Value, String> {
+        state.execute(command)
+    }
+
+    #[tauri::command]
+    fn host_receive(
+        state: State<'_, HostState>,
+        timeout_ms: Option<u64>,
+    ) -> Result<Value, String> {
+        state.receive(timeout_ms.unwrap_or(25))
+    }
+
+    #[tauri::command]
+    fn host_snapshot(state: State<'_, HostState>) -> Result<Value, String> {
+        state.snapshot()
+    }
+
+    #[tauri::command]
+    fn host_close(state: State<'_, HostState>) -> Result<Value, String> {
+        state.close()
+    }
+
+    pub fn run() {
+        tauri::Builder::default()
+            .manage(HostState::default())
+            .invoke_handler(tauri::generate_handler![
+                host_initialize,
+                host_execute,
+                host_receive,
+                host_snapshot,
+                host_close,
+            ])
+            .run(tauri::generate_context!())
+            .expect("Fabushi Tauri Host failed to run");
+    }
+}
+
+#[cfg(feature = "desktop")]
+pub use desktop::run;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headless_contract_covers_the_complete_runtime_lifecycle() {
+        let state = HostState::default();
+        let initialized = state.initialize(None).expect("initialize Host");
+        assert_eq!(initialized["initialized"], true);
+        assert_eq!(initialized["status"]["runtimeAbiVersion"], 1);
+
+        let status = state
+            .execute(json!({"@type": "mahayana.runtime.status"}))
+            .expect("execute status");
+        assert_eq!(status["runtimeAbiVersion"], 1);
+        assert_eq!(status["remoteAgentEnabled"], false);
+
+        let ready = state.receive(10).expect("receive ready event");
+        assert_eq!(ready["@type"], "mahayana.runtime.ready");
+
+        let snapshot = state.snapshot().expect("snapshot");
+        assert_eq!(snapshot["initialized"], true);
+
+        let closed = state.close().expect("close Host");
+        assert_eq!(closed["closed"], true);
+        assert!(state
+            .execute(json!({"@type": "mahayana.runtime.status"}))
+            .expect_err("closed Host must reject commands")
+            .contains("not initialized"));
+    }
+
+    #[test]
+    fn invalid_commands_fail_before_reaching_the_runtime() {
+        let state = HostState::default();
+        state.initialize(None).expect("initialize Host");
+        let error = state
+            .execute(json!({"@type": "unknown.command"}))
+            .expect_err("unknown command must fail");
+        assert!(error.contains("invalid Runtime command"));
+    }
+}

--- a/apps/fabushi-tauri/src-tauri/src/main.rs
+++ b/apps/fabushi-tauri/src-tauri/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    fabushi_tauri_lib::run();
+}

--- a/apps/fabushi-tauri/src-tauri/tauri.conf.json
+++ b/apps/fabushi-tauri/src-tauri/tauri.conf.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Fabushi",
+  "version": "0.1.0",
+  "identifier": "com.ombhrum.fabushi",
+  "build": {
+    "frontendDist": "../ui"
+  },
+  "app": {
+    "withGlobalTauri": true,
+    "windows": [
+      {
+        "label": "main",
+        "title": "Fabushi Mahayana Host",
+        "width": 1180,
+        "height": 760,
+        "minWidth": 760,
+        "minHeight": 560
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    }
+  },
+  "bundle": {
+    "active": false
+  }
+}

--- a/apps/fabushi-tauri/ui/index.html
+++ b/apps/fabushi-tauri/ui/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fabushi Mahayana Host</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <p class="eyebrow">Mahayana Rust Core</p>
+      <h1>Fabushi Tauri 宿主诊断面</h1>
+      <p class="lede">此页面只验证薄壳、Rust Runtime 和命令契约。生产界面将复用统一 React Host。</p>
+      <section class="actions" aria-label="Host commands">
+        <button data-testid="tauri-initialize" id="initialize">初始化 Runtime</button>
+        <button data-testid="tauri-status" id="status">读取状态</button>
+        <button data-testid="tauri-receive" id="receive">接收事件</button>
+        <button data-testid="tauri-close" id="close">关闭 Runtime</button>
+      </section>
+      <section class="result" aria-live="polite">
+        <strong>执行结果</strong>
+        <pre data-testid="tauri-result" id="result">等待用户操作</pre>
+      </section>
+    </main>
+    <script src="./main.js"></script>
+  </body>
+</html>

--- a/apps/fabushi-tauri/ui/main.js
+++ b/apps/fabushi-tauri/ui/main.js
@@ -1,0 +1,57 @@
+const result = document.querySelector("#result");
+
+const browserMock = {
+  initialized: false,
+  async invoke(command, args = {}) {
+    switch (command) {
+      case "host_initialize":
+        this.initialized = true;
+        return {
+          initialized: true,
+          status: { runtimeAbiVersion: 1, remoteAgentEnabled: false },
+        };
+      case "host_execute":
+        if (!this.initialized) throw new Error("Mahayana Host is not initialized");
+        return { runtimeAbiVersion: 1, remoteAgentEnabled: false };
+      case "host_receive":
+        if (!this.initialized) throw new Error("Mahayana Host is not initialized");
+        return { "@type": "mahayana.runtime.ready" };
+      case "host_close":
+        this.initialized = false;
+        return { closed: true };
+      default:
+        throw new Error(`Unsupported diagnostic command: ${command}`);
+    }
+  },
+};
+
+const invoke = (...args) =>
+  window.__TAURI__?.core?.invoke(...args) ?? browserMock.invoke(...args);
+
+async function run(command, args) {
+  result.dataset.state = "running";
+  result.textContent = `执行 ${command}…`;
+  try {
+    const value = await invoke(command, args);
+    result.dataset.state = "passed";
+    result.textContent = JSON.stringify(value, null, 2);
+  } catch (error) {
+    result.dataset.state = "failed";
+    result.textContent = String(error);
+  }
+}
+
+document.querySelector("#initialize").addEventListener("click", () =>
+  run("host_initialize", { config: null }),
+);
+document.querySelector("#status").addEventListener("click", () =>
+  run("host_execute", {
+    command: { "@type": "mahayana.runtime.status" },
+  }),
+);
+document.querySelector("#receive").addEventListener("click", () =>
+  run("host_receive", { timeoutMs: 25 }),
+);
+document.querySelector("#close").addEventListener("click", () =>
+  run("host_close"),
+);

--- a/apps/fabushi-tauri/ui/styles.css
+++ b/apps/fabushi-tauri/ui/styles.css
@@ -1,0 +1,20 @@
+:root {
+  color-scheme: light dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0c111b;
+  color: #f7f8fb;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; }
+main { width: min(880px, calc(100vw - 48px)); padding: 48px; border: 1px solid #2d3748; border-radius: 28px; background: #131a27; box-shadow: 0 28px 80px rgb(0 0 0 / 35%); }
+.eyebrow { text-transform: uppercase; letter-spacing: .15em; color: #9fb7ff; font-size: .8rem; }
+h1 { margin: 8px 0 12px; font-size: clamp(2rem, 5vw, 3.6rem); }
+.lede { max-width: 760px; color: #bdc7d8; line-height: 1.7; }
+.actions { display: flex; flex-wrap: wrap; gap: 12px; margin: 32px 0; }
+button { border: 0; border-radius: 999px; padding: 12px 18px; font: inherit; font-weight: 700; cursor: pointer; background: #e9edff; color: #111827; }
+button:hover { transform: translateY(-1px); }
+.result { padding: 20px; border-radius: 18px; background: #0b1019; }
+pre { min-height: 100px; overflow: auto; white-space: pre-wrap; color: #cdd6e7; }
+pre[data-state="passed"] { color: #98f5bc; }
+pre[data-state="failed"] { color: #ffaaa5; }


### PR DESCRIPTION
## Objective

Prove a real Tauri 2 shell can call the direct `mahayana-host` Rust API without Flutter or the C ABI, while ordinary PRs verify the entire command lifecycle headlessly.

## Changes

- Add `apps/fabushi-tauri/src-tauri` as a standalone Tauri 2 application.
- Add a process-local `HostState` over `MahayanaHost` with typed initialize, execute, receive, snapshot, and close operations.
- Keep the state machine independent from Tauri so Linux Actions can exercise it without a window server.
- Add the thin Tauri command adapter and real macOS desktop compile Gate.
- Add a small bundled diagnostic surface that can invoke the same commands through the global Tauri API.
- Add a two-lane CI workflow:
  - fast Ubuntu headless lifecycle tests with a 300-second cold budget;
  - real macOS Tauri desktop compile in parallel.
- Upload the generated application `Cargo.lock` as an artifact so it can be committed after successful dependency resolution.

## Scope boundary

This is the first native-shell vertical slice, not the production React UI migration. The diagnostic HTML only validates the shell/Rust contract; the canonical React Host remains the product UI and will replace it through `TauriTransport` in the next stack.

## Acceptance evidence

- headless command lifecycle passes;
- invalid commands fail before Runtime execution;
- real macOS Tauri shell compiles;
- generated application lockfile is captured;
- no Flutter or dynamic FFI is used by this shell.

Stacked on #1911.