### PR TITLE
perf(e2e): remove the Playwright container startup tax

### DIFF
--- a/.github/workflows/host-fast-e2e.yml
+++ b/.github/workflows/host-fast-e2e.yml
@@ -38,9 +38,7 @@ jobs:
   host-fast-e2e:
     name: React Host complete user journey
     runs-on: ubuntu-latest
-    timeout-minutes: 8
-    container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    timeout-minutes: 5
     steps:
       - name: Checkout only Host test inputs
         uses: actions/checkout@v5
@@ -50,7 +48,7 @@ jobs:
             /frontend/**
             /fabushi/e2e/**
 
-      - name: Enable pnpm through Corepack
+      - name: Enable pinned pnpm through Corepack
         run: corepack enable
 
       - name: Install frontend dependencies from lockfile
@@ -61,9 +59,14 @@ jobs:
         working-directory: frontend
         run: pnpm --filter @fabushi/web typecheck:host
 
-      - name: Install Playwright test package
+      - name: Install Playwright test package without browser download
         working-directory: fabushi/e2e
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: npm ci
+
+      - name: Verify system Chrome is available
+        run: google-chrome --version
 
       - name: Run complete Host user journey under execution budget
         id: journey
@@ -76,8 +79,8 @@ jobs:
           elapsed="$(( $(date +%s) - started_at ))"
           echo "elapsed_seconds=$elapsed" >> "$GITHUB_OUTPUT"
           echo "Host user journey elapsed: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
-          if [ "$elapsed" -gt 120 ]; then
-            echo "Host fast E2E exceeded the 120-second execution budget." >&2
+          if [ "$elapsed" -gt 60 ]; then
+            echo "Host fast E2E exceeded the 60-second execution budget." >&2
             exit 1
           fi
 

--- a/fabushi/e2e/playwright.host.config.js
+++ b/fabushi/e2e/playwright.host.config.js
@@ -15,14 +15,15 @@ export default defineConfig({
   ],
   use: {
     baseURL: "http://127.0.0.1:4173",
+    // GitHub's Ubuntu image already ships Google Chrome. Reusing it removes the
+    // 20+ second Playwright container pull while keeping the browser version
+    // explicit in the runner image release metadata.
+    channel: process.env.CI ? "chrome" : undefined,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "off",
   },
   webServer: {
-    // Run Next directly from the package installed by the pinned pnpm workspace.
-    // Pin both the executable and working directory so Playwright's container
-    // package manager cannot change startup behavior.
     command:
       "cd ../../frontend/apps/web && node ./node_modules/next/dist/bin/next dev --hostname 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173/host",


### PR DESCRIPTION
## Objective

Reduce the already-green Host user journey from roughly 53 seconds of wall time by removing the 20+ second browser image pull on every GitHub runner.

## Changes

- Run the same pinned Playwright test package directly on `ubuntu-latest`.
- Reuse Google Chrome already present in the GitHub runner image through Playwright's explicit `channel: chrome`.
- Skip Playwright browser downloads during `npm ci`.
- Verify the system Chrome binary before executing tests.
- Tighten the user-journey execution budget from 120 seconds to 60 seconds.
- Reduce the workflow timeout from 8 minutes to 5 minutes.

## Baseline

The parent PR is objectively green:

- user journey: 9.4 seconds on #1909;
- dependency install: 7.7 seconds;
- container image pull: about 23 seconds;
- complete job: about 53 seconds.

## Acceptance evidence

- strict Host typecheck remains green;
- every declarative feature journey remains green;
- no browser download occurs;
- complete job wall time is materially below the container baseline.

Stacked on #1909.