### PR TITLE
test(migration): make the complete legacy feature surface auditable

### DIFF
--- a/.github/workflows/migration-surface-contract.yml
+++ b/.github/workflows/migration-surface-contract.yml
@@ -1,0 +1,45 @@
+name: Migration surface contract
+
+on:
+  pull_request:
+    paths:
+      - fabushi/lib/features/**
+      - fabushi/lib/screens/**
+      - fabushi/lib/services/**
+      - frontend/packages/shared/src/mahayana-host-features.ts
+      - contracts/migration/legacy-surface.json
+      - scripts/check-migration-surface.mjs
+      - .github/workflows/migration-surface-contract.yml
+  push:
+    branches: [main]
+    paths:
+      - fabushi/lib/features/**
+      - fabushi/lib/screens/**
+      - fabushi/lib/services/**
+      - contracts/migration/legacy-surface.json
+      - scripts/check-migration-surface.mjs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  migration-surface:
+    name: Every legacy feature has an explicit migration disposition
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout only migration inputs
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /fabushi/lib/features/**
+            /fabushi/lib/screens/**
+            /fabushi/lib/services/**
+            /frontend/packages/shared/src/mahayana-host-features.ts
+            /contracts/migration/legacy-surface.json
+            /scripts/check-migration-surface.mjs
+
+      - name: Verify exact legacy surface and E2E evidence references
+        run: node scripts/check-migration-surface.mjs

--- a/contracts/migration/legacy-surface.json
+++ b/contracts/migration/legacy-surface.json
@@ -1,0 +1,176 @@
+{
+  "schemaVersion": 1,
+  "trackedRoots": [
+    "fabushi/lib/features",
+    "fabushi/lib/screens",
+    "fabushi/lib/services"
+  ],
+  "featureCatalogPath": "frontend/packages/shared/src/mahayana-host-features.ts",
+  "expected": {
+    "fileCount": 266,
+    "sha256": "a35b9780092cd9836b629069240aabd6dfad0b6fc280f7a3c13cb365103b8852"
+  },
+  "domains": [
+    {
+      "id": "auth-account",
+      "target": "mahayana-host + React Host + secure platform storage",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/features/auth/",
+        "^fabushi/lib/screens/(alipay_web_login|douyin_login|forgot_password|register|telegram_authorization)_screen\\.dart$",
+        "^fabushi/lib/services/(auth_service|firebase_auth_service|mock_auth_service|alipay_auth_service)\\.dart$"
+      ],
+      "e2eFeatureIds": ["session.clear"]
+    },
+    {
+      "id": "profile-membership",
+      "target": "mahayana-product + React Host",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/features/(membership|profile)/",
+        "^fabushi/lib/screens/(edit_profile|membership|membership_screen_web|my_profile|profile)_screen\\.dart$",
+        "^fabushi/lib/services/membership_service\\.dart$"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "conversations-social",
+      "target": "mahayana-social/telegram + React Host",
+      "status": "in-progress",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(social_|telegram_friend_chat)",
+        "^fabushi/lib/services/(social_|comment_service|user_block_service|feed_service|like_service)",
+        "^fabushi/lib/services/telegram/"
+      ],
+      "e2eFeatureIds": ["chat.send"]
+    },
+    {
+      "id": "ai-runtime",
+      "target": "mahayana-host/runtime + React Host",
+      "status": "in-progress",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/sutra_ai_page\\.dart$",
+        "^fabushi/lib/services/(agent_service|ai_backend_policy|dacheng_ai_service|llm_|multimodal_|mahayana_)",
+        "^fabushi/lib/services/openclaw/"
+      ],
+      "e2eFeatureIds": [
+        "runtime.boot",
+        "chat.send",
+        "capability.approval",
+        "operation.interrupt"
+      ]
+    },
+    {
+      "id": "miniapp-marketplace",
+      "target": "mahayana-miniapp + isolated React/WebView Host",
+      "status": "in-progress",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/mini_app_host_screen\\.dart$",
+        "^fabushi/lib/services/(mini_app_registry_service|codex_plugin_catalog)",
+        "^fabushi/lib/services/miniapp/"
+      ],
+      "e2eFeatureIds": [
+        "marketplace.install",
+        "miniapp.open",
+        "capability.approval"
+      ]
+    },
+    {
+      "id": "payments",
+      "target": "Rust payment state machine + thin Apple/Alipay plugins",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/services/(alipay_service|apple_iap_service)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "dharma-study",
+      "target": "official signed MiniApps",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/features/flashcards/",
+        "^fabushi/lib/screens/(content_detail|dharma_|global_dharma|liked_content|search|sutra_|work_player)",
+        "^fabushi/lib/services/(cbeta_|cloudflare_text|content_|dharma_|favorite_|merit_|recitation_|semantic_|sentence_|sutra_|text_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "practice-meditation",
+      "target": "official MiniApps + shared Rust data services",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(leaderboard|meditation_|practice_)",
+        "^fabushi/lib/services/(achievement_|co_practice_|leaderboard_|meditation_|practice_|user_activity_|zen_recitation_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "media-feed",
+      "target": "optional MiniApps or explicit product deletion",
+      "status": "pending",
+      "requiredForCutover": false,
+      "patterns": [
+        "^fabushi/lib/screens/video_feed_screen\\.dart$",
+        "^fabushi/lib/services/(audio_|offline_asr_|sherpa_|tts_|video_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "global-transfer",
+      "target": "Rust platform services + capability-gated Host UI",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(asset|globe_home)_screen\\.dart$",
+        "^fabushi/lib/services/(abstract_file|download|downloaded_assets|file_|global_|hotspot_|inbound_share|platform_global|real_global|shared_asset|udp_|web_bluetooth|wifi_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "settings-platform",
+      "target": "React Host settings + thin platform plugins",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [
+        "^fabushi/lib/screens/(eula|keep_alive_guide|loading|main_navigation|settings|test_info)_screen\\.dart$",
+        "^fabushi/lib/services/(api_client|app_|device_|diagnostic_|error_report|eula_|http_|keep_alive_|memory_|network_|platform_service|project_|unified_api|worker_config|workmanager_|workspace_)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "desktop-control",
+      "target": "capability-gated Rust/Tauri commands",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": ["^fabushi/lib/services/desktop_control/"],
+      "e2eFeatureIds": ["capability.approval"]
+    },
+    {
+      "id": "visualization-demos",
+      "target": "delete unless explicitly retained as a MiniApp",
+      "status": "pending",
+      "requiredForCutover": false,
+      "patterns": [
+        "^fabushi/lib/screens/(beautiful_trajectory_demo|buddha_model|earth_globe_demo)"
+      ],
+      "e2eFeatureIds": []
+    },
+    {
+      "id": "unclassified-legacy",
+      "target": "must be classified or deleted before cutover",
+      "status": "pending",
+      "requiredForCutover": true,
+      "patterns": [".*"],
+      "e2eFeatureIds": []
+    }
+  ]
+}

--- a/scripts/check-migration-surface.mjs
+++ b/scripts/check-migration-surface.mjs
@@ -1,0 +1,132 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const manifestPath = path.join(root, "contracts/migration/legacy-surface.json");
+const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+
+if (manifest.schemaVersion !== 1) {
+  throw new Error(`Unsupported migration manifest schema: ${manifest.schemaVersion}`);
+}
+
+async function walk(relativeRoot) {
+  const absoluteRoot = path.join(root, relativeRoot);
+  const entries = await fs.readdir(absoluteRoot, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const relative = path.posix.join(relativeRoot, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(relative)));
+    } else if (entry.isFile() && entry.name.endsWith(".dart")) {
+      files.push(relative);
+    }
+  }
+  return files;
+}
+
+const trackedFiles = (
+  await Promise.all(manifest.trackedRoots.map((trackedRoot) => walk(trackedRoot)))
+)
+  .flat()
+  // Match `LC_ALL=C sort` exactly. Locale collation can treat punctuation
+  // differently across runner images and would make the SHA non-portable.
+  .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+const fingerprintInput = `${trackedFiles.join("\n")}\n`;
+const fingerprint = createHash("sha256").update(fingerprintInput).digest("hex");
+
+const errors = [];
+if (trackedFiles.length !== manifest.expected.fileCount) {
+  errors.push(
+    `legacy file count changed: expected ${manifest.expected.fileCount}, found ${trackedFiles.length}`,
+  );
+}
+if (fingerprint !== manifest.expected.sha256) {
+  errors.push(
+    `legacy surface fingerprint changed: expected ${manifest.expected.sha256}, found ${fingerprint}`,
+  );
+}
+
+const allowedStatuses = new Set(["pending", "in-progress", "migrated", "deleted"]);
+const seenDomainIds = new Set();
+const compiledDomains = manifest.domains.map((domain) => {
+  if (seenDomainIds.has(domain.id)) errors.push(`duplicate domain id: ${domain.id}`);
+  seenDomainIds.add(domain.id);
+  if (!allowedStatuses.has(domain.status)) {
+    errors.push(`invalid status for ${domain.id}: ${domain.status}`);
+  }
+  if (!Array.isArray(domain.patterns) || domain.patterns.length === 0) {
+    errors.push(`domain has no patterns: ${domain.id}`);
+  }
+  if (domain.status === "migrated" && domain.e2eFeatureIds.length === 0) {
+    errors.push(`migrated domain has no E2E evidence IDs: ${domain.id}`);
+  }
+  return {
+    ...domain,
+    matchers: domain.patterns.map((pattern) => new RegExp(pattern)),
+    matched: [],
+  };
+});
+
+for (const file of trackedFiles) {
+  const domain = compiledDomains.find((candidate) =>
+    candidate.matchers.some((matcher) => matcher.test(file)),
+  );
+  if (!domain) {
+    errors.push(`legacy file is not classified: ${file}`);
+  } else {
+    domain.matched.push(file);
+  }
+}
+
+for (const domain of compiledDomains) {
+  if (domain.matched.length === 0) {
+    errors.push(`migration domain matches no current file: ${domain.id}`);
+  }
+}
+
+const featureCatalog = await fs.readFile(
+  path.join(root, manifest.featureCatalogPath),
+  "utf8",
+);
+const featureIds = new Set(
+  [...featureCatalog.matchAll(/\bid:\s*"([^"]+)"/g)].map((match) => match[1]),
+);
+for (const domain of compiledDomains) {
+  for (const featureId of domain.e2eFeatureIds) {
+    if (!featureIds.has(featureId)) {
+      errors.push(`${domain.id} references an unknown E2E feature: ${featureId}`);
+    }
+  }
+}
+
+const summary = [
+  "## Fabushi migration surface",
+  "",
+  `- Tracked Dart files: ${trackedFiles.length}`,
+  `- Surface SHA-256: \`${fingerprint}\``,
+  `- Migration domains: ${compiledDomains.length}`,
+  "",
+  "| Domain | Files | Status | Required for cutover | E2E evidence |",
+  "|---|---:|---|---|---|",
+  ...compiledDomains.map(
+    (domain) =>
+      `| ${domain.id} | ${domain.matched.length} | ${domain.status} | ${domain.requiredForCutover ? "yes" : "no"} | ${domain.e2eFeatureIds.join(", ") || "—"} |`,
+  ),
+  "",
+].join("\n");
+console.log(summary);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
+}
+
+if (errors.length > 0) {
+  throw new Error(
+    [
+      "Migration surface contract failed.",
+      ...errors.map((error) => `- ${error}`),
+      "Update the explicit manifest and its evidence in the same pull request.",
+    ].join("\n"),
+  );
+}


### PR DESCRIPTION
## Objective

Turn “all functions are migrated and tested” into an enforceable repository contract instead of an informal claim.

## Changes

- Fingerprint every Dart file under the existing Flutter `features`, `screens`, and `services` surfaces.
- Record the current objective baseline: 266 files (54 feature files, 43 screens, 169 services).
- Classify the surface into migration domains with target architecture, current status, cutover requirement, and Host E2E evidence IDs.
- Validate every referenced E2E feature against the executable Mahayana Host catalog.
- Fail Actions when any legacy feature file is added, removed, renamed, or left outside the explicit manifest.
- Fail when a domain is marked migrated without E2E evidence.
- Add a path-aware three-minute Migration Surface Contract workflow.

## Why this matters

The current Flutter tree contains far more than the seven first Host journeys. This Gate prevents the project from declaring completion while auth, profile, payments, social, Dharma, media, transfer, settings, platform, or other legacy surfaces remain unclassified or unverified.

## Acceptance evidence

- exact file count and SHA-256 match;
- all 266 legacy files receive a deterministic domain disposition;
- every linked E2E feature exists in the typed Host catalog;
- workflow completes within the three-minute budget.

Stacked on #1908.