### PR TITLE
perf(actions): stop unrelated Host changes from running Global Dharma full checks

### DIFF
--- a/.github/workflows/global-dharma-rust.yml
+++ b/.github/workflows/global-dharma-rust.yml
@@ -4,13 +4,24 @@ on:
   pull_request:
     paths:
       - native/global-dharma/**
-      - third_party/mahayana
-      - third_party/mahayana/**
+      - third_party/mahayana/codex-rs/**
+      - third_party/mahayana/mahayana-rs/Cargo.toml
+      - third_party/mahayana/mahayana-rs/Cargo.lock
+      - third_party/mahayana/mahayana-rs/mahayana-agent-codex/**
+      - third_party/mahayana/mahayana-rs/mahayana-agent-responses/**
+      - third_party/mahayana/mahayana-rs/mahayana-cli/**
+      - third_party/mahayana/mahayana-rs/mahayana-core/**
+      - third_party/mahayana/mahayana-rs/mahayana-ffi/**
+      - third_party/mahayana/mahayana-rs/mahayana-runtime/**
       - scripts/install-mahayana.sh
       - scripts/test-install-mahayana.sh
       - .github/workflows/global-dharma-rust.yml
   push:
     tags: ["global-dharma-v*", "mahayana-v*"]
+
+concurrency:
+  group: global-dharma-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -19,22 +30,40 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CARGO_INCREMENTAL: "1"
     defaults:
       run:
         working-directory: native/global-dharma
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - name: Restore Global Dharma Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native/global-dharma -> target
+          shared-key: global-dharma-pr-v1
+          cache-all-crates: true
       - run: cargo fmt --all --check
       - run: cargo test --workspace
 
   mahayana-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CARGO_INCREMENTAL: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - name: Restore Mahayana Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: third_party/mahayana/mahayana-rs -> target
+          shared-key: global-dharma-mahayana-v1
+          cache-all-crates: true
       - run: cargo fmt --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml --all -- --check
       - run: >-
           cargo test --locked
@@ -55,7 +84,7 @@ jobs:
         target: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: taiki-e/install-action@cross


### PR DESCRIPTION
## Objective

Remove the second major source of Actions queueing during Mahayana Host, React, and Tauri development.

## Root cause

`global-dharma-rust.yml` currently matches the entire `third_party/mahayana/**` tree. A change limited to `mahayana-host` therefore launches both Global Dharma and the legacy Mahayana package suite even though neither Global Dharma nor its published packages changed.

## Changes

- Restrict pull-request paths to Global Dharma itself and the exact Mahayana/Codex packages exercised or published by this workflow.
- Keep tag-based release behavior unchanged.
- Add concurrency cancellation for superseded commits.
- Enable incremental compilation explicitly and add scoped Cargo caches.
- Add time budgets to the two PR test jobs.
- Keep the signed cross-compiled Linux release and publication flow unchanged.

## Expected result

- `mahayana-host`, React Host, and Tauri-only PRs no longer trigger this workflow.
- Actual Global Dharma, CLI, Runtime, FFI, Codex-agent, installer, and release-surface changes still run the same relevant tests.
- Release tags still build, checksum, archive, sign, and publish both artifacts.

## Acceptance evidence

- GitHub accepts the workflow syntax.
- This PR runs the two PR test jobs and skips tag-only release jobs.
- After merge, a Host-only PR no longer matches Global Dharma Rust.
