### PR TITLE
fix(build): commit pure-Dart scene importer lock resolution

### DIFF
--- a/fabushi/pubspec.lock
+++ b/fabushi/pubspec.lock
@@ -710,10 +710,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_scene_importer
-      sha256: "81c544627dcbfc7227625b41abeaf23054fec5c36c57d2d6cb61518b3bd8a6cd"
+      sha256: "11c3e699cf9794aaa225642776cfae33d1f3a1c1fabcd7573a1cd27d03d792fe"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0-0"
+    version: "0.11.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -961,6 +961,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   html:
     dependency: transitive
     description:
@@ -1575,6 +1583,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   record_web:
     dependency: transitive
     description:


### PR DESCRIPTION
## Objective

Complete the Flutter scene importer migration that was merged in #1923 by committing the exact dependency resolution produced by `flutter pub get`.

## Why this is required

#1923 merged the `^0.11.0` declarations and removed the obsolete CMake hook, but auto-merge completed before the generated `pubspec.lock` update was pushed. Without the lock update, CI and developer machines can resolve different transitive graphs and may retain the legacy importer entry.

## Changes

- Lock `flutter_scene_importer` to `0.11.0` with the pub.dev digest.
- Add its `hooks 1.0.3` and `record_use 0.6.0` transitive dependencies.

## Local acceptance evidence

- `flutter pub get` completed successfully.
- `flutter analyze lib/main.dart` passed in 3.6 seconds.
- `flutter build web --release` passed in 56.6 seconds.

## Acceptance criteria

- `flutter pub get --enforce-lockfile` succeeds in CI.
- Repository CI, Native smoke, Android and desktop build workflows resolve the pure-Dart importer graph.