### PR TITLE
feat(auth): add production identity bridge for browser login

### DIFF
--- a/fabushi/web/alipay-login-functions.js
+++ b/fabushi/web/alipay-login-functions.js
@@ -927,6 +927,22 @@ async function checkEmailAvailability(request, env) {
 async function handleAlipayCallback(request, env) {
   try {
     const url = new URL(request.url);
+    const brokerState = url.searchParams.get('state') || '';
+    if (/^fbs_[a-f0-9]{32}$/i.test(brokerState)) {
+      const returnBase = String(env.AUTH_PROVIDER_BRIDGE_RETURN_BASE || '').replace(/\/+$/, '');
+      if (!returnBase) {
+        return jsonResponse({ error: 'Fabushi browser auth return is not configured' }, 503);
+      }
+      const target = new URL('/api/auth/oauth/callback', returnBase);
+      target.searchParams.set('state', brokerState);
+      const authCode = url.searchParams.get('auth_code');
+      const error = url.searchParams.get('error');
+      if (authCode) target.searchParams.set('auth_code', authCode);
+      if (error) target.searchParams.set('error', error);
+      const errorDescription = url.searchParams.get('error_description');
+      if (errorDescription) target.searchParams.set('error_description', errorDescription);
+      return Response.redirect(target.toString(), 302);
+    }
     const authCode = url.searchParams.get('auth_code');
     const state = url.searchParams.get('state');
 

--- a/fabushi/web/src/handlers/auth-provider-bridge.js
+++ b/fabushi/web/src/handlers/auth-provider-bridge.js
@@ -1,0 +1,174 @@
+import { jsonResponse } from '../utils/response.js';
+
+const BRIDGE_HEADER = 'X-Fabushi-Auth-Bridge';
+const ALIPAY_AUTHORIZE_URL = 'https://openauth.alipay.com/oauth2/publicAppAuthorize.htm';
+const FABUSHI_BROWSER_STATE = /^fbs_[a-f0-9]{32}$/i;
+
+function timingSafeEqualText(left, right) {
+  const a = new TextEncoder().encode(String(left || ''));
+  const b = new TextEncoder().encode(String(right || ''));
+  if (a.byteLength !== b.byteLength) return false;
+  let difference = 0;
+  for (let i = 0; i < a.byteLength; i += 1) difference |= a[i] ^ b[i];
+  return difference === 0;
+}
+
+function bridgeAuthorized(request, env) {
+  const expected = String(env.AUTH_PROVIDER_BRIDGE_SECRET || '');
+  const provided = request.headers.get(BRIDGE_HEADER) || '';
+  return expected.length >= 32 && timingSafeEqualText(expected, provided);
+}
+
+function alipayConfigured(env) {
+  return Boolean(env.ALIPAY_APP_ID && env.ALIPAY_PRIVATE_KEY && env.ALIPAY_PUBLIC_KEY);
+}
+
+function emailConfigured(env) {
+  return Boolean(env.RESEND_API_KEY && env.FROM_EMAIL);
+}
+
+function bridgeUnauthorized() {
+  return jsonResponse({ ok: false, error: 'bridge_unauthorized' }, 403);
+}
+
+function alipayCallbackUrl(env) {
+  return env.ALIPAY_MOBILE_AUTH_REDIRECT_URL
+    || env.ALIPAY_AUTH_REDIRECT_URL
+    || `${String(env.WORKER_URL || '').replace(/\/+$/, '')}/api/auth/alipay/callback`;
+}
+
+async function handleCapabilities(request, env) {
+  if (!bridgeAuthorized(request, env)) return bridgeUnauthorized();
+  return jsonResponse({
+    ok: true,
+    alipay: alipayConfigured(env),
+    email: emailConfigured(env),
+  });
+}
+
+async function handleAlipayAuthorize(request, env) {
+  const url = new URL(request.url);
+  const state = url.searchParams.get('state') || '';
+  if (!FABUSHI_BROWSER_STATE.test(state)) {
+    return jsonResponse({ ok: false, error: 'invalid_state' }, 400);
+  }
+  if (!alipayConfigured(env)) {
+    return jsonResponse({ ok: false, error: 'alipay_unavailable' }, 503);
+  }
+  const redirectUri = alipayCallbackUrl(env);
+  if (!redirectUri) {
+    return jsonResponse({ ok: false, error: 'alipay_callback_unavailable' }, 503);
+  }
+  const target = new URL(ALIPAY_AUTHORIZE_URL);
+  target.searchParams.set('app_id', env.ALIPAY_APP_ID);
+  target.searchParams.set('scope', 'auth_user');
+  target.searchParams.set('redirect_uri', redirectUri);
+  target.searchParams.set('state', state);
+  return Response.redirect(target.toString(), 302);
+}
+
+async function handleAlipayExchange(request, env) {
+  if (!bridgeAuthorized(request, env)) return bridgeUnauthorized();
+  if (!alipayConfigured(env)) {
+    return jsonResponse({ ok: false, error: 'alipay_unavailable' }, 503);
+  }
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ ok: false, error: 'invalid_request' }, 400);
+  }
+  const authCode = String(body?.authCode || '').trim();
+  if (authCode.length < 10 || authCode.length > 2048) {
+    return jsonResponse({ ok: false, error: 'invalid_auth_code' }, 400);
+  }
+  const { getAlipayUserInfo } = await import('../../alipay-login-functions.js');
+  const identity = await getAlipayUserInfo(authCode, env);
+  if (!identity || identity.error || identity.isMock) {
+    return jsonResponse({ ok: false, error: 'alipay_identity_exchange_failed' }, 401);
+  }
+  const subject = String(
+    identity.provider_subject
+      || identity.providerSubject
+      || identity.open_id
+      || identity.openId
+      || identity.user_id
+      || identity.userId
+      || identity.alipay_user_id
+      || '',
+  ).trim();
+  if (!subject) {
+    return jsonResponse({ ok: false, error: 'alipay_subject_missing' }, 502);
+  }
+  const legacySubject = String(
+    identity.legacy_user_id
+      || identity.legacyUserId
+      || (identity.alipay_user_id && identity.alipay_user_id !== subject ? identity.alipay_user_id : '')
+      || '',
+  ).trim();
+  return jsonResponse({
+    ok: true,
+    identity: {
+      subject,
+      legacySubject: legacySubject || null,
+      displayName: identity.nick_name || identity.nickname || null,
+      avatarUrl: identity.avatar || null,
+    },
+  });
+}
+
+async function handleRegistrationEmail(request, env) {
+  if (!bridgeAuthorized(request, env)) return bridgeUnauthorized();
+  if (!emailConfigured(env)) {
+    return jsonResponse({ ok: false, error: 'email_provider_unavailable' }, 503);
+  }
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ ok: false, error: 'invalid_request' }, 400);
+  }
+  const email = String(body?.email || '').trim().toLowerCase();
+  const code = String(body?.code || '').trim();
+  if (email.length > 254 || !email.includes('@') || !/^\d{6}$/.test(code)) {
+    return jsonResponse({ ok: false, error: 'invalid_registration_email' }, 400);
+  }
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: env.FROM_EMAIL,
+      to: [email],
+      subject: 'Fabushi 注册验证码',
+      text: `你的 Fabushi 注册验证码是：${code}\n\n验证码 10 分钟内有效。如果不是你本人操作，请忽略这封邮件。`,
+    }),
+  });
+  if (!response.ok) {
+    response.body?.cancel?.();
+    return jsonResponse({ ok: false, error: 'email_delivery_failed' }, 502);
+  }
+  return jsonResponse({ ok: true });
+}
+
+export async function handleAuthProviderBridgeRequest({ pathname, method, request, env }) {
+  if (pathname === '/api/internal/auth-provider/capabilities' && method === 'GET') {
+    return await handleCapabilities(request, env);
+  }
+  if (pathname === '/api/internal/auth-provider/alipay/authorize' && method === 'GET') {
+    return await handleAlipayAuthorize(request, env);
+  }
+  if (pathname === '/api/internal/auth-provider/alipay/exchange' && method === 'POST') {
+    return await handleAlipayExchange(request, env);
+  }
+  if (pathname === '/api/internal/auth-provider/email/send-registration-code' && method === 'POST') {
+    return await handleRegistrationEmail(request, env);
+  }
+  return null;
+}
+
+export function isFabushiBrowserAlipayState(state) {
+  return FABUSHI_BROWSER_STATE.test(String(state || ''));
+}

--- a/fabushi/web/src/routes/auth-routes.js
+++ b/fabushi/web/src/routes/auth-routes.js
@@ -1,3 +1,4 @@
+import { handleAuthProviderBridgeRequest } from '../handlers/auth-provider-bridge.js';
 import {
   handleRegister,
   handleLogin,
@@ -28,6 +29,8 @@ import {
 } from '../handlers/verification.js';
 
 export async function routeAuthRequest({ pathname, method, request, env, db, ctx }) {
+  const bridgeResponse = await handleAuthProviderBridgeRequest({ pathname, method, request, env });
+  if (bridgeResponse) return bridgeResponse;
   if (pathname === '/api/auth/register' && method === 'POST') return await handleRegister(request, env, db);
   if (pathname === '/api/auth/login' && method === 'POST') return await handleLogin(request, env, db);
   if (pathname === '/api/auth/user-info' && method === 'GET') return await handleGetUserInfo(request, env, db);

--- a/fabushi/web/tests/auth-provider-bridge.test.js
+++ b/fabushi/web/tests/auth-provider-bridge.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { handleAuthProviderBridgeRequest, isFabushiBrowserAlipayState } from '../src/handlers/auth-provider-bridge.js';
+
+assert.equal(isFabushiBrowserAlipayState(`fbs_${'a'.repeat(32)}`), true);
+assert.equal(isFabushiBrowserAlipayState('legacy-state'), false);
+
+const baseEnv = {
+  AUTH_PROVIDER_BRIDGE_SECRET: 'x'.repeat(48),
+  ALIPAY_APP_ID: '2021000000000000',
+  ALIPAY_PRIVATE_KEY: 'private',
+  ALIPAY_PUBLIC_KEY: 'public',
+  ALIPAY_MOBILE_AUTH_REDIRECT_URL: 'https://legacy.example/api/auth/alipay/callback',
+};
+
+const unauthorized = await handleAuthProviderBridgeRequest({
+  pathname: '/api/internal/auth-provider/capabilities',
+  method: 'GET',
+  request: new Request('https://legacy.example/api/internal/auth-provider/capabilities'),
+  env: baseEnv,
+});
+assert.equal(unauthorized.status, 403);
+
+const headers = { 'X-Fabushi-Auth-Bridge': baseEnv.AUTH_PROVIDER_BRIDGE_SECRET };
+const authorized = await handleAuthProviderBridgeRequest({
+  pathname: '/api/internal/auth-provider/capabilities',
+  method: 'GET',
+  request: new Request('https://legacy.example/api/internal/auth-provider/capabilities', { headers }),
+  env: baseEnv,
+});
+assert.equal(authorized.status, 200);
+assert.deepEqual(await authorized.json(), { ok: true, alipay: true, email: false });
+
+const state = `fbs_${'b'.repeat(32)}`;
+const redirect = await handleAuthProviderBridgeRequest({
+  pathname: '/api/internal/auth-provider/alipay/authorize',
+  method: 'GET',
+  request: new Request(`https://legacy.example/api/internal/auth-provider/alipay/authorize?state=${state}`),
+  env: baseEnv,
+});
+assert.equal(redirect.status, 302);
+const location = new URL(redirect.headers.get('location'));
+assert.equal(location.origin + location.pathname, 'https://openauth.alipay.com/oauth2/publicAppAuthorize.htm');
+assert.equal(location.searchParams.get('state'), state);
+assert.equal(location.searchParams.get('scope'), 'auth_user');
+assert.equal(location.searchParams.get('redirect_uri'), baseEnv.ALIPAY_MOBILE_AUTH_REDIRECT_URL);
+
+console.log('auth-provider-bridge.test.js passed');


### PR DESCRIPTION
Adds the minimal legacy-Worker side of Fabushi's browser-first identity migration, without changing the legacy Worker into the session issuer.

- adds a narrow server-to-server provider bridge protected by a dedicated high-entropy header secret
- reuses the existing Alipay signing/exchange implementation and stable provider subject
- reuses existing Resend configuration only for registration-code delivery
- accepts only bounded Fabushi browser state for the public Alipay authorize entrypoint
- returns `fbs_...` Alipay callbacks to the Rust browser-auth callback without exposing tokens in the custom scheme
- keeps all existing legacy/mobile auth routes unchanged
- adds contract coverage for the bridge boundary and Alipay authorization redirect

This PR is intentionally limited to four `fabushi/web` files so it can be deployed through the existing production Worker pipeline before the Rust staging broker is switched on.