### PR TITLE
feat(auth): send signup codes with Cloudflare Email Service

### DIFF
--- a/fabushi/web/src/handlers/auth-provider-bridge.js
+++ b/fabushi/web/src/handlers/auth-provider-bridge.js
@@ -24,7 +24,7 @@ function alipayConfigured(env) {
 }
 
 function emailConfigured(env) {
-  return Boolean(env.RESEND_API_KEY && env.FROM_EMAIL);
+  return Boolean(env.EMAIL || (env.RESEND_API_KEY && env.FROM_EMAIL));
 }
 
 function bridgeUnauthorized() {
@@ -133,24 +133,30 @@ async function handleRegistrationEmail(request, env) {
   if (email.length > 254 || !email.includes('@') || !/^\d{6}$/.test(code)) {
     return jsonResponse({ ok: false, error: 'invalid_registration_email' }, 400);
   }
-  const response = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${env.RESEND_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      from: env.FROM_EMAIL,
-      to: [email],
-      subject: 'Fabushi 注册验证码',
-      text: `你的 Fabushi 注册验证码是：${code}\n\n验证码 10 分钟内有效。如果不是你本人操作，请忽略这封邮件。`,
-    }),
-  });
-  if (!response.ok) {
-    response.body?.cancel?.();
+  const subject = 'Fabushi 注册验证码';
+  const text = `你的 Fabushi 注册验证码是：${code}\n\n验证码 10 分钟内有效。如果不是你本人操作，请忽略这封邮件。`;
+  const from = env.FROM_EMAIL || 'amitabha@ombhrum.com';
+  try {
+    if (env.EMAIL?.send) {
+      await env.EMAIL.send({ to: email, from, subject, text });
+      return jsonResponse({ ok: true, provider: 'cloudflare-email' });
+    }
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from, to: [email], subject, text }),
+    });
+    if (!response.ok) {
+      response.body?.cancel?.();
+      return jsonResponse({ ok: false, error: 'email_delivery_failed' }, 502);
+    }
+    return jsonResponse({ ok: true, provider: 'resend' });
+  } catch {
     return jsonResponse({ ok: false, error: 'email_delivery_failed' }, 502);
   }
-  return jsonResponse({ ok: true });
 }
 
 export async function handleAuthProviderBridgeRequest({ pathname, method, request, env }) {

--- a/fabushi/web/tests/auth-provider-bridge.test.js
+++ b/fabushi/web/tests/auth-provider-bridge.test.js
@@ -30,6 +30,38 @@ const authorized = await handleAuthProviderBridgeRequest({
 assert.equal(authorized.status, 200);
 assert.deepEqual(await authorized.json(), { ok: true, alipay: true, email: false });
 
+let sentEmail = null;
+const emailEnv = {
+  ...baseEnv,
+  FROM_EMAIL: 'amitabha@ombhrum.com',
+  EMAIL: {
+    async send(message) { sentEmail = message; return { messageId: 'test-message' }; },
+  },
+};
+const emailCapabilities = await handleAuthProviderBridgeRequest({
+  pathname: '/api/internal/auth-provider/capabilities',
+  method: 'GET',
+  request: new Request('https://legacy.example/api/internal/auth-provider/capabilities', { headers }),
+  env: emailEnv,
+});
+assert.deepEqual(await emailCapabilities.json(), { ok: true, alipay: true, email: true });
+
+const emailResponse = await handleAuthProviderBridgeRequest({
+  pathname: '/api/internal/auth-provider/email/send-registration-code',
+  method: 'POST',
+  request: new Request('https://legacy.example/api/internal/auth-provider/email/send-registration-code', {
+    method: 'POST',
+    headers: { ...headers, 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@example.com', code: '123456' }),
+  }),
+  env: emailEnv,
+});
+assert.equal(emailResponse.status, 200);
+assert.equal((await emailResponse.json()).provider, 'cloudflare-email');
+assert.equal(sentEmail.to, 'user@example.com');
+assert.equal(sentEmail.from, 'amitabha@ombhrum.com');
+assert.match(sentEmail.text, /123456/);
+
 const state = `fbs_${'b'.repeat(32)}`;
 const redirect = await handleAuthProviderBridgeRequest({
   pathname: '/api/internal/auth-provider/alipay/authorize',


### PR DESCRIPTION
Uses the existing `EMAIL` send_email binding on the legacy Worker as the primary registration-code delivery path, with Resend retained only as a fallback.

This is intentionally a narrow production bridge change:
- no new session issuer
- no auth tokens cross the bridge
- existing server-to-server bridge proof remains required
- registration code delivery uses the Worker-native Cloudflare Email Service binding already present in development and production Wrangler config
- contract tests verify capability detection and the exact outbound email payload

Cloudflare's current Email Service docs explicitly support Workers `send_email` bindings for signup/verification flows, so this removes the unnecessary dependency on a Resend secret while keeping the Rust Worker as the only new browser-account/session authority.