### PR TITLE
fix(auth): gate signup on Email Sending readiness

### DIFF
--- a/fabushi/web/src/handlers/auth-provider-bridge.js
+++ b/fabushi/web/src/handlers/auth-provider-bridge.js
@@ -23,8 +23,12 @@ function alipayConfigured(env) {
   return Boolean(env.ALIPAY_APP_ID && env.ALIPAY_PRIVATE_KEY && env.ALIPAY_PUBLIC_KEY);
 }
 
+function cloudflareEmailReady(env) {
+  return Boolean(env.EMAIL && String(env.AUTH_REGISTRATION_EMAIL_READY || '').toLowerCase() === 'true');
+}
+
 function emailConfigured(env) {
-  return Boolean(env.EMAIL || (env.RESEND_API_KEY && env.FROM_EMAIL));
+  return Boolean(cloudflareEmailReady(env) || (env.RESEND_API_KEY && env.FROM_EMAIL));
 }
 
 function bridgeUnauthorized() {
@@ -137,7 +141,7 @@ async function handleRegistrationEmail(request, env) {
   const text = `你的 Fabushi 注册验证码是：${code}\n\n验证码 10 分钟内有效。如果不是你本人操作，请忽略这封邮件。`;
   const from = env.FROM_EMAIL || 'amitabha@ombhrum.com';
   try {
-    if (env.EMAIL?.send) {
+    if (cloudflareEmailReady(env) && env.EMAIL?.send) {
       await env.EMAIL.send({ to: email, from, subject, text });
       return jsonResponse({ ok: true, provider: 'cloudflare-email' });
     }

--- a/fabushi/web/tests/auth-provider-bridge.test.js
+++ b/fabushi/web/tests/auth-provider-bridge.test.js
@@ -31,9 +31,22 @@ assert.equal(authorized.status, 200);
 assert.deepEqual(await authorized.json(), { ok: true, alipay: true, email: false });
 
 let sentEmail = null;
-const emailEnv = {
+const bindingOnlyEnv = {
   ...baseEnv,
   FROM_EMAIL: 'amitabha@ombhrum.com',
+  EMAIL: { async send() { throw new Error('must stay gated'); } },
+};
+const bindingOnlyCapabilities = await handleAuthProviderBridgeRequest({
+  pathname: '/api/internal/auth-provider/capabilities',
+  method: 'GET',
+  request: new Request('https://legacy.example/api/internal/auth-provider/capabilities', { headers }),
+  env: bindingOnlyEnv,
+});
+assert.deepEqual(await bindingOnlyCapabilities.json(), { ok: true, alipay: true, email: false });
+
+const emailEnv = {
+  ...bindingOnlyEnv,
+  AUTH_REGISTRATION_EMAIL_READY: 'true',
   EMAIL: {
     async send(message) { sentEmail = message; return { messageId: 'test-message' }; },
   },


### PR DESCRIPTION
Prevents the browser registration UI from advertising email signup merely because an `EMAIL` Worker binding exists.

Cloudflare Email Routing and Email Sending are separate services. The current `ombhrum.com` zone has routing DNS but no `cf-bounce` Email Sending records, so arbitrary signup delivery is not yet possible. This patch requires an explicit server-side `AUTH_REGISTRATION_EMAIL_READY=true` before the Cloudflare Email binding is exposed as a registration capability; Resend remains a separate valid fallback.

The feature-branch repair flow independently determines readiness from Cloudflare's public Email Sending DNS fingerprints and will set the flag automatically after the domain is genuinely onboarded. Contract tests cover both the binding-only disabled state and the explicitly-ready enabled state.