### PR TITLE
ci(auth): sync Apple Services ID into staging worker

### DIFF
--- a/.github/workflows/auth-config-diagnostic.yml
+++ b/.github/workflows/auth-config-diagnostic.yml
@@ -49,6 +49,15 @@ jobs:
           env | grep '^HAS_SECRET_' | sort
           printf '%s\n' 'Apple repository variable presence (values are never printed):'
           env | grep '^HAS_VAR_' | sort
+          if [ "$HAS_SECRET_OAUTH_APPLE_CLIENT_ID" = true ] || [ "$HAS_VAR_OAUTH_APPLE_CLIENT_ID" = true ] \
+            || [ "$HAS_SECRET_APPLE_SERVICES_ID" = true ] || [ "$HAS_VAR_APPLE_SERVICES_ID" = true ] \
+            || [ "$HAS_SECRET_APPLE_SERVICE_ID" = true ] || [ "$HAS_VAR_APPLE_SERVICE_ID" = true ] \
+            || [ "$HAS_SECRET_APPLE_CLIENT_ID" = true ] || [ "$HAS_VAR_APPLE_CLIENT_ID" = true ] \
+            || [ "$HAS_SECRET_SIGN_IN_WITH_APPLE_CLIENT_ID" = true ] || [ "$HAS_VAR_SIGN_IN_WITH_APPLE_CLIENT_ID" = true ]; then
+            echo 'Apple browser Services ID source: configured'
+          else
+            echo 'Apple browser Services ID source: missing'
+          fi
 
       - name: Inspect deployed Mahayana Worker secret names
         shell: bash

--- a/.github/workflows/mahayana-staging-auth-repair.yml
+++ b/.github/workflows/mahayana-staging-auth-repair.yml
@@ -22,6 +22,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
       TEST_ACCOUNT_TOKEN: ${{ secrets.TEST_ACCOUNT_TOKEN || secrets.MAHAYANA_TEST_ACCOUNT_TOKEN }}
+      OAUTH_APPLE_CLIENT_ID: ${{ secrets.OAUTH_APPLE_CLIENT_ID || vars.OAUTH_APPLE_CLIENT_ID || secrets.APPLE_SERVICES_ID || vars.APPLE_SERVICES_ID || secrets.APPLE_SERVICE_ID || vars.APPLE_SERVICE_ID || secrets.APPLE_CLIENT_ID || vars.APPLE_CLIENT_ID || secrets.SIGN_IN_WITH_APPLE_CLIENT_ID || vars.SIGN_IN_WITH_APPLE_CLIENT_ID }}
 
     steps:
       - name: Checkout
@@ -88,6 +89,19 @@ jobs:
         shell: bash
         run: printf 'y\n' | npx --yes wrangler@4 d1 migrations apply ACCOUNT_DB --remote
 
+      - id: apple-provider
+        name: Sync Apple Services ID when configured
+        working-directory: ${{ env.PLATFORM_WORKER_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          enabled=false
+          if [ -n "${OAUTH_APPLE_CLIENT_ID:-}" ]; then
+            printf '%s' "$OAUTH_APPLE_CLIENT_ID" | npx --yes wrangler@4 secret put OAUTH_APPLE_CLIENT_ID >/dev/null
+            enabled=true
+          fi
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+
       - name: Deploy Mahayana staging Worker
         id: platform
         working-directory: ${{ env.PLATFORM_WORKER_DIR }}
@@ -118,10 +132,16 @@ jobs:
           PLATFORM_URL: ${{ steps.platform.outputs.url }}
           BRIDGE_URL: ${{ steps.identity-bridge.outputs.bridge_url }}
           REGISTRATION_EMAIL_READY: ${{ steps.identity-bridge.outputs.email_ready }}
+          APPLE_READY: ${{ steps.apple-provider.outputs.enabled }}
         run: |
           set -euo pipefail
           providers="$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 "$PLATFORM_URL/api/auth/oauth/providers")"
           jq -e '.providers | map(.id) | index("alipay") != null' <<<"$providers" >/dev/null
+          if [ "$APPLE_READY" = true ]; then
+            jq -e '.providers | map(.id) | index("apple") != null' <<<"$providers" >/dev/null
+          else
+            jq -e '.providers | map(.id) | index("apple") == null' <<<"$providers" >/dev/null
+          fi
 
           start="$(curl --fail --silent --show-error --retry 5 --retry-all-errors \
             -H 'content-type: application/json' \


### PR DESCRIPTION
Prepare the unified browser-auth rollout for Sign in with Apple without changing the existing native iOS login.

- resolve the browser Apple client ID from OAUTH_APPLE_CLIENT_ID first, with compatibility aliases for prior naming
- when configured, sync the Services ID into the Mahayana Worker as OAUTH_APPLE_CLIENT_ID
- require the Apple provider to appear in staging smoke when the Services ID was synchronized
- report whether any supported repository Apple Services ID key is configured

No Apple credential value is added in this PR; the remaining value must come from the Apple Developer Services ID.