### PR TITLE
fix(auth): avoid macOS Keychain prompt and add hot Mac packages

### DIFF
--- a/.github/scripts/assert-auth-entry-flow.py
+++ b/.github/scripts/assert-auth-entry-flow.py
@@ -53,6 +53,7 @@ required = {
     'product browser start': (product, 'mahayana.auth.browser.start'),
     'product browser poll': (product, 'mahayana.auth.browser.poll'),
     'product encrypts browser poll verifier': (product, 'save_browser_login_poll_secret'),
+    'product keeps browser poll verifier out of OS keyring': (product, 'browser_login_poll_secret_path'),
     'product strips browser poll verifier': (product, 'object.remove("pollSecret")'),
     'worker requires browser poll verifier': (worker, 'browser_poll_forbidden'),
     'worker browser poll proof body': (worker, 'let poll: BrowserLoginProofRequest = match request.json().await'),
@@ -122,6 +123,15 @@ for label, (text, marker) in required.items():
 
 if '.find_map(|(key, value)| (key == "pollSecret")' in worker or '&[("pollSecret", poll_secret.as_str())]' in product:
     raise SystemExit('auth entry gate: browser poll verifier must not be sent in a URL query string')
+
+poll_storage_start = product.find('fn browser_login_poll_secret_path')
+poll_storage_end = product.find('fn save_session', poll_storage_start)
+if poll_storage_start < 0 or poll_storage_end < 0:
+    raise SystemExit('auth entry gate: browser poll verifier private-file storage is missing')
+poll_storage = product[poll_storage_start:poll_storage_end]
+for forbidden in ['.managed_secrets', '.secrets_manager', 'SecretScope::']:
+    if forbidden in poll_storage:
+        raise SystemExit(f'auth entry gate: browser poll verifier must not touch OS keyring-backed secrets: {forbidden}')
 
 for forbidden in [
     'data-testid={`oauth-${provider.id}`}',

--- a/.github/scripts/install-electron-macos-hot-update.sh
+++ b/.github/scripts/install-electron-macos-hot-update.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload_dir="${1:-$(cd "$(dirname "$0")" && pwd)}"
+app_path="${FABUSHI_APP_PATH:-/Applications/fabushi.app}"
+manifest="$payload_dir/manifest.json"
+marker="$HOME/Library/Application Support/@fabushi/desktop/installed-source-sha.txt"
+
+[ -f "$manifest" ] || { echo "Missing hot-update manifest: $manifest" >&2; exit 2; }
+[ -d "$app_path" ] || { echo "Fabushi is not installed at $app_path; install one full Mac package first." >&2; exit 2; }
+
+read_json() {
+  /usr/bin/plutil -extract "$1" raw -o - "$manifest"
+}
+
+source_sha="$(read_json sourceSha)"
+base_sha="$(read_json baseSha)"
+target_arch="$(read_json arch)"
+host_included="$(read_json hostIncluded)"
+asr_included="$(read_json asrIncluded)"
+
+[ "$(uname -m)" = "$target_arch" ] || { echo "Hot update targets $target_arch, but this Mac is $(uname -m)." >&2; exit 2; }
+app_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Contents/Info.plist" 2>/dev/null || true)"
+[ "$app_id" = "com.ombhrum.fabushi" ] || { echo "Unexpected app bundle id: ${app_id:-missing}" >&2; exit 2; }
+
+if [ -f "$marker" ]; then
+  installed_sha="$(tr -d '[:space:]' < "$marker")"
+  if [ "$installed_sha" != "$base_sha" ] && [ "$installed_sha" != "$source_sha" ] && [ "${FABUSHI_HOT_UPDATE_FORCE:-0}" != "1" ]; then
+    echo "Installed source $installed_sha does not match hot-update base $base_sha." >&2
+    echo "Install the missing incremental update or a fresh full package first." >&2
+    exit 3
+  fi
+elif [ "${FABUSHI_HOT_UPDATE_FORCE:-0}" != "1" ]; then
+  echo "Installed source marker is missing; refusing a blind incremental patch." >&2
+  echo "Set FABUSHI_HOT_UPDATE_FORCE=1 only if this app is known to match base $base_sha." >&2
+  exit 3
+fi
+
+[ -f "$payload_dir/app.asar" ] || { echo "Missing app.asar in hot update." >&2; exit 2; }
+
+pkill -TERM -f "$app_path/Contents/MacOS/fabushi" 2>/dev/null || true
+pkill -TERM -f "$app_path/Contents/Resources/bin/mahayana-app-host" 2>/dev/null || true
+for _ in $(seq 1 40); do
+  if ! pgrep -f "$app_path/Contents/MacOS/fabushi" >/dev/null 2>&1; then break; fi
+  sleep 0.1
+done
+
+atomic_copy() {
+  local source="$1"
+  local destination="$2"
+  local mode="$3"
+  local temp="${destination}.hot-update.$$"
+  install -m "$mode" "$source" "$temp"
+  mv -f "$temp" "$destination"
+}
+
+atomic_copy "$payload_dir/app.asar" "$app_path/Contents/Resources/app.asar" 0644
+
+if [ "$host_included" = "true" ]; then
+  [ -f "$payload_dir/mahayana-app-host" ] || { echo "Manifest requires Mahayana Host, but it is missing." >&2; exit 2; }
+  atomic_copy "$payload_dir/mahayana-app-host" "$app_path/Contents/Resources/bin/mahayana-app-host" 0755
+fi
+
+if [ "$asr_included" = "true" ]; then
+  [ -d "$payload_dir/asr" ] || { echo "Manifest requires ASR payload, but it is missing." >&2; exit 2; }
+  rm -rf "$app_path/Contents/Resources/asr"
+  mkdir -p "$app_path/Contents/Resources/asr"
+  ditto "$payload_dir/asr" "$app_path/Contents/Resources/asr"
+fi
+
+mkdir -p "$(dirname "$marker")"
+printf '%s\n' "$source_sha" > "$marker"
+open -n "$app_path"
+echo "Fabushi hot update installed: $source_sha"

--- a/.github/workflows/electron-macos-hot-package.yml
+++ b/.github/workflows/electron-macos-hot-package.yml
@@ -1,0 +1,261 @@
+name: Fabushi macOS hot package
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'desktop/**'
+      - 'frontend/apps/web/src/app/host/**'
+      - 'frontend/apps/web/src/lib/fabushi-runtime/**'
+      - 'frontend/apps/web/src/lib/mahayana-host/**'
+      - 'frontend/packages/shared/**'
+      - 'third_party/mahayana/mahayana-rs/Cargo.toml'
+      - 'third_party/mahayana/mahayana-rs/Cargo.lock'
+      - 'third_party/mahayana/mahayana-rs/mahayana-agent-codex/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-app-host/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-app-host-desktop/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-feature-host/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-host/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-host-protocol/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-product/**'
+      - 'third_party/mahayana/codex-rs/**'
+      - '.github/scripts/build-offline-asr-engine.mjs'
+      - '.github/scripts/install-electron-macos-hot-update.sh'
+      - '.github/workflows/electron-macos-hot-package.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fabushi-macos-hot-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  portable-payload:
+    name: Build portable Mac hot payload
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    outputs:
+      source_sha: ${{ steps.classify.outputs.source_sha }}
+      base_sha: ${{ steps.classify.outputs.base_sha }}
+      short_sha: ${{ steps.classify.outputs.short_sha }}
+      host_changed: ${{ steps.classify.outputs.host_changed }}
+      asr_changed: ${{ steps.classify.outputs.asr_changed }}
+      full_required: ${{ steps.classify.outputs.full_required }}
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - id: classify
+        name: Classify the minimum install delta
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+        run: |
+          set -euo pipefail
+          source_sha="$(git rev-parse HEAD)"
+          short_sha="${source_sha:0:12}"
+          zero=0000000000000000000000000000000000000000
+          if [ "$EVENT_NAME" = push ] && [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "$zero" ]; then
+            base_sha="$BEFORE_SHA"
+          else
+            base_sha="$(git rev-parse HEAD^ 2>/dev/null || printf '%s' "$source_sha")"
+          fi
+          git fetch --no-tags --depth=1 origin "$base_sha" >/dev/null 2>&1 || true
+          changed="$(git diff --name-only "$base_sha" "$source_sha" 2>/dev/null || true)"
+          printf '%s\n' "$changed" | sed '/^$/d' >> "$GITHUB_STEP_SUMMARY"
+
+          host_changed=false
+          asr_changed=false
+          full_required=false
+
+          if printf '%s\n' "$changed" | grep -Eq '^third_party/mahayana/(codex-rs/|mahayana-rs/(Cargo\.toml$|Cargo\.lock$|mahayana-agent-codex/|mahayana-app-host/|mahayana-app-host-desktop/|mahayana-feature-host/|mahayana-host/|mahayana-host-protocol/|mahayana-product/))'; then
+            host_changed=true
+          fi
+          if printf '%s\n' "$changed" | grep -Eq '^(desktop/electron/offline-asr-engine\.json|\.github/scripts/build-offline-asr-engine\.mjs)$'; then
+            asr_changed=true
+          fi
+          if printf '%s\n' "$changed" | grep -Eq '^(desktop/package\.json|desktop/package-lock\.json)$'; then
+            full_required=true
+          fi
+          if printf '%s\n' "$changed" | grep -E '^desktop/resources/' | grep -Ev '^desktop/resources/asr/' >/dev/null; then
+            full_required=true
+          fi
+
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "host_changed=$host_changed" >> "$GITHUB_OUTPUT"
+          echo "asr_changed=$asr_changed" >> "$GITHUB_OUTPUT"
+          echo "full_required=$full_required" >> "$GITHUB_OUTPUT"
+          printf '\nsource=%s\nbase=%s\nhost=%s asr=%s full=%s\n' "$source_sha" "$base_sha" "$host_changed" "$asr_changed" "$full_required" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Explain full-package fallback
+        if: steps.classify.outputs.full_required == 'true'
+        run: |
+          echo 'This change modifies the Electron framework/dependency envelope, so an incremental overlay is intentionally skipped.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Run Electron desktop quality gate with workflow_dispatch to create a fresh full Mac package.' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set up Node.js
+        if: steps.classify.outputs.full_required != 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Install build-only JavaScript dependencies without Electron download
+        if: steps.classify.outputs.full_required != 'true'
+        working-directory: desktop
+        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+
+      - name: Build renderer without the release typecheck duplicate
+        if: steps.classify.outputs.full_required != 'true'
+        working-directory: desktop
+        run: npx --no-install vite build
+
+      - name: Assemble app.asar delta
+        if: steps.classify.outputs.full_required != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          runtime="$RUNNER_TEMP/fabushi-runtime"
+          payload="$RUNNER_TEMP/fabushi-hot"
+          rm -rf "$runtime" "$payload"
+          mkdir -p "$runtime" "$payload"
+          cp desktop/package.json desktop/package-lock.json "$runtime/"
+          npm ci --prefix "$runtime" --omit=dev --ignore-scripts --prefer-offline --no-audit --no-fund
+          rm -f "$runtime/package-lock.json"
+          cp -R desktop/dist "$runtime/dist"
+          cp -R desktop/electron "$runtime/electron"
+          node desktop/node_modules/@electron/asar/bin/asar.js pack "$runtime" "$payload/app.asar"
+          cp .github/scripts/install-electron-macos-hot-update.sh "$payload/install.sh"
+          chmod +x "$payload/install.sh"
+          cat > "$payload/manifest.json" <<EOF
+          {"schemaVersion":1,"sourceSha":"${{ steps.classify.outputs.source_sha }}","baseSha":"${{ steps.classify.outputs.base_sha }}","arch":"arm64","hostIncluded":false,"asrIncluded":false}
+          EOF
+          du -h "$payload/app.asar" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload final JS-only hot install
+        if: steps.classify.outputs.full_required != 'true' && steps.classify.outputs.host_changed != 'true' && steps.classify.outputs.asr_changed != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: fabushi-macos-hot-${{ steps.classify.outputs.short_sha }}
+          path: ${{ runner.temp }}/fabushi-hot
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 6
+
+      - name: Hand portable payload to native delta job
+        if: steps.classify.outputs.full_required != 'true' && (steps.classify.outputs.host_changed == 'true' || steps.classify.outputs.asr_changed == 'true')
+        uses: actions/upload-artifact@v7
+        with:
+          name: fabushi-macos-hot-input-${{ steps.classify.outputs.short_sha }}
+          path: ${{ runner.temp }}/fabushi-hot
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 1
+
+  native-delta:
+    name: Add changed native Mac payload only
+    needs: portable-payload
+    if: needs.portable-payload.outputs.full_required != 'true' && (needs.portable-payload.outputs.host_changed == 'true' || needs.portable-payload.outputs.asr_changed == 'true')
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.portable-payload.outputs.source_sha }}
+          fetch-depth: 1
+
+      - name: Download portable hot payload
+        uses: actions/download-artifact@v8
+        with:
+          name: fabushi-macos-hot-input-${{ needs.portable-payload.outputs.short_sha }}
+          path: ${{ runner.temp }}/fabushi-hot
+
+      - name: Set up Rust only when Host changed
+        if: needs.portable-payload.outputs.host_changed == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore incremental Rust compiler state
+        if: needs.portable-payload.outputs.host_changed == 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: third_party/mahayana/mahayana-rs -> target
+          shared-key: electron-mac-package-only-v1
+          cache-bin: true
+          cache-on-failure: true
+
+      - name: Build only the changed Mahayana Host
+        if: needs.portable-payload.outputs.host_changed == 'true'
+        working-directory: desktop
+        run: npm run build:host:ci
+
+      - name: Sign Host with the stable Developer ID identity
+        if: needs.portable-payload.outputs.host_changed == 'true'
+        shell: bash
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+        run: |
+          set -euo pipefail
+          [ -n "${MACOS_CERTIFICATE_P12_BASE64:-}" ] || { echo 'MACOS_CERTIFICATE_P12_BASE64 is required for stable Keychain access.' >&2; exit 1; }
+          [ -n "${MACOS_CERTIFICATE_PASSWORD:-}" ] || { echo 'MACOS_CERTIFICATE_PASSWORD is required for stable Keychain access.' >&2; exit 1; }
+          cert="$RUNNER_TEMP/fabushi-developer-id.p12"
+          keychain="$RUNNER_TEMP/fabushi-build.keychain-db"
+          keychain_password="$(openssl rand -hex 24)"
+          printf '%s' "$MACOS_CERTIFICATE_P12_BASE64" | base64 --decode > "$cert"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$cert" -k "$keychain" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain"
+          identity="${MACOS_CODESIGN_IDENTITY:-}"
+          if [ -z "$identity" ]; then
+            identity="$(security find-identity -v -p codesigning "$keychain" | awk -F '"' '/Developer ID Application/ {print $2; exit}')"
+          fi
+          [ -n "$identity" ] || { echo 'Developer ID Application identity was not found.' >&2; exit 1; }
+          host=desktop/resources/bin/mahayana-app-host
+          codesign --force --options runtime --timestamp=none --sign "$identity" "$host"
+          codesign --verify --strict --verbose=2 "$host"
+          cp "$host" "$RUNNER_TEMP/fabushi-hot/mahayana-app-host"
+
+      - name: Rebuild pinned ASR only when its source changed
+        if: needs.portable-payload.outputs.asr_changed == 'true'
+        run: |
+          set -euo pipefail
+          node .github/scripts/build-offline-asr-engine.mjs
+          mkdir -p "$RUNNER_TEMP/fabushi-hot/asr"
+          cp -R desktop/resources/asr/darwin-arm64 "$RUNNER_TEMP/fabushi-hot/asr/"
+
+      - name: Mark included native payloads
+        shell: bash
+        env:
+          HOST_INCLUDED: ${{ needs.portable-payload.outputs.host_changed }}
+          ASR_INCLUDED: ${{ needs.portable-payload.outputs.asr_changed }}
+        run: |
+          node - "$RUNNER_TEMP/fabushi-hot/manifest.json" <<'NODE'
+          const fs = require('fs');
+          const path = process.argv[2];
+          const manifest = JSON.parse(fs.readFileSync(path, 'utf8'));
+          manifest.hostIncluded = process.env.HOST_INCLUDED === 'true';
+          manifest.asrIncluded = process.env.ASR_INCLUDED === 'true';
+          fs.writeFileSync(path, JSON.stringify(manifest) + '\n');
+          NODE
+
+      - name: Upload final native hot install
+        uses: actions/upload-artifact@v7
+        with:
+          name: fabushi-macos-hot-${{ needs.portable-payload.outputs.short_sha }}
+          path: ${{ runner.temp }}/fabushi-hot
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 6

--- a/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
@@ -441,6 +441,9 @@ pub struct MahayanaProductClient {
     session_path: PathBuf,
     /// Shared non-secret product state used by CLI and native application shells.
     surface_state_path: PathBuf,
+    /// Short-lived browser-login poll proofs live in caller-owned private files.
+    /// They never need OS keyring access and are removed on terminal auth states.
+    browser_login_poll_dir: PathBuf,
     skills_root: PathBuf,
     secrets_manager: SecretsManager,
     managed_secrets: SecretsManager,
@@ -560,10 +563,12 @@ impl MahayanaProductClient {
             .filter(|path| !path.as_os_str().is_empty())
             .unwrap_or_else(|| Path::new("."))
             .to_path_buf();
+        let browser_login_poll_dir = mahayana_home.join("browser-login");
         let client = Self {
             api_base_url: api_base_url.into().trim_end_matches('/').to_string(),
             session_path,
             surface_state_path: surface_state_path.into(),
+            browser_login_poll_dir,
             skills_root: default_codex_skills_root(),
             secrets_manager: SecretsManager::new_with_namespace(
                 mahayana_home.clone(),
@@ -2334,6 +2339,13 @@ impl MahayanaProductClient {
         Ok(None)
     }
 
+    fn browser_login_poll_secret_path(&self, attempt_id: &str) -> Result<PathBuf, ProductError> {
+        let attempt_id = safe_path_identifier(attempt_id, "attemptId")?;
+        Ok(self
+            .browser_login_poll_dir
+            .join(format!("{attempt_id}.poll-secret")))
+    }
+
     fn save_browser_login_poll_secret(
         &self,
         attempt_id: &str,
@@ -2344,28 +2356,45 @@ impl MahayanaProductClient {
                 "browser login poll secret is invalid".into(),
             ));
         }
-        let name = browser_login_poll_secret_name(attempt_id)?;
-        self.managed_secrets
-            .set(&SecretScope::Global, &name, poll_secret)
-            .map_err(secrets_error)
+        let path = self.browser_login_poll_secret_path(attempt_id)?;
+        // This verifier is short-lived attempt state, not an account credential.
+        // Keeping it in a mode-0600 app-data file preserves secure browser-login
+        // resume without asking macOS Keychain to authorize a frequently changing
+        // helper binary. It never crosses the renderer or appears in a URL.
+        write_private_file(&path, poll_secret)
     }
 
     fn load_browser_login_poll_secret(
         &self,
         attempt_id: &str,
     ) -> Result<Option<String>, ProductError> {
-        let name = browser_login_poll_secret_name(attempt_id)?;
-        self.managed_secrets
-            .get(&SecretScope::Global, &name)
-            .map_err(secrets_error)
+        let path = self.browser_login_poll_secret_path(attempt_id)?;
+        match std::fs::read_to_string(&path) {
+            Ok(value) => {
+                let value = value.trim();
+                if value.len() < 32 || value.len() > 256 {
+                    return Err(ProductError::Session(
+                        "stored browser login poll secret is invalid".into(),
+                    ));
+                }
+                Ok(Some(value.to_string()))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(ProductError::Session(format!(
+                "read browser login poll state: {error}"
+            ))),
+        }
     }
 
     fn remove_browser_login_poll_secret(&self, attempt_id: &str) -> Result<(), ProductError> {
-        let name = browser_login_poll_secret_name(attempt_id)?;
-        self.managed_secrets
-            .delete(&SecretScope::Global, &name)
-            .map(|_| ())
-            .map_err(secrets_error)
+        let path = self.browser_login_poll_secret_path(attempt_id)?;
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(ProductError::Session(format!(
+                "remove browser login poll state: {error}"
+            ))),
+        }
     }
 
     fn save_session(&self, session: &Value) -> Result<(), ProductError> {
@@ -2653,11 +2682,6 @@ fn safe_test_account_token(value: &str) -> Result<&str, ProductError> {
     } else {
         Err(ProductError::InvalidParameter("testAccountToken"))
     }
-}
-
-fn browser_login_poll_secret_name(attempt_id: &str) -> Result<SecretName, ProductError> {
-    let attempt_id = safe_path_identifier(attempt_id, "attemptId")?;
-    managed_secret_name(&format!("browser-login-poll:{attempt_id}"))
 }
 
 fn account_session_secret_name() -> Result<SecretName, ProductError> {
@@ -3235,6 +3259,59 @@ mod tests {
         assert!(session.get("token").is_none());
         assert!(session.get("accessToken").is_none());
         assert!(session.get("refreshToken").is_none());
+    }
+
+    #[test]
+    fn browser_login_poll_secrets_use_private_files_without_keyring() {
+        let unique = format!(
+            "mahayana-browser-poll-test-{}-{}",
+            std::process::id(),
+            surface_now_millis()
+        );
+        let root = std::env::temp_dir().join(unique);
+        let client = MahayanaProductClient::new_with_surface_state_path(
+            "https://example.invalid",
+            root.join("session.json"),
+            root.join("product-surface.json"),
+        );
+        let attempt_id = "attempt-private-poll-1234";
+        let poll_secret = "p".repeat(64);
+
+        client
+            .save_browser_login_poll_secret(attempt_id, &poll_secret)
+            .expect("save poll secret");
+        let path = client
+            .browser_login_poll_secret_path(attempt_id)
+            .expect("poll path");
+        assert!(path.starts_with(root.join("browser-login")));
+        assert!(!path.starts_with(root.join("secrets")));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read poll secret"),
+            poll_secret
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("poll metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        assert_eq!(
+            client
+                .load_browser_login_poll_secret(attempt_id)
+                .expect("load poll secret"),
+            Some(poll_secret)
+        );
+        client
+            .remove_browser_login_poll_secret(attempt_id)
+            .expect("remove poll secret");
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
Fixes the login failure shown by the packaged Mac app when the user denies the Keychain prompt, and introduces an incremental GitHub Actions path for Mac testing.

Auth fix:
- browser-login `pollSecret` no longer uses the generic `ManagedSecrets` namespace backed by the `codex` Keychain service;
- the short-lived poll verifier is kept in a caller-owned mode-0600 app-data file and removed on terminal auth states;
- account credentials remain in the Mahayana account secrets backend;
- auth guardrails now reject any regression that routes the browser poll verifier back through OS-keyring-backed secrets.

Fast Mac test packaging:
- new `Fabushi macOS hot package` workflow builds JS/app.asar on Ubuntu, so UI/Electron-JS-only changes do not allocate a macOS runner;
- skips Electron framework copying, DMG creation, Windows/Linux packaging, duplicate release typecheck, and unrelated E2E;
- only starts a macOS job when Host or ASR native payloads changed;
- reuses the existing incremental Rust cache and signs changed Host binaries with the repository's stable macOS Developer ID credentials;
- emits a small incremental install artifact plus an installer that atomically overlays `/Applications/fabushi.app` and advances a source-SHA marker;
- dependency/framework envelope changes intentionally fall back to the full package workflow.

Local validation performed without building on the Mac: bash syntax, YAML parse, rustfmt check, Python syntax, and `git diff --check`.