### PR TITLE
fix(ci): include Tauri workspace in Mac host delta

### DIFF
--- a/.github/workflows/electron-macos-hot-package.yml
+++ b/.github/workflows/electron-macos-hot-package.yml
@@ -189,6 +189,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             .github/scripts
+            apps/fabushi-tauri/src-tauri
             desktop
             third_party/mahayana/codex-rs
             third_party/mahayana/mahayana-rs


### PR DESCRIPTION
The forced macOS Host hot build fails after the sparse-checkout optimization because the Mahayana Cargo workspace includes apps/fabushi-tauri/src-tauri, but the native delta checkout omitted that workspace member. Include the Tauri Cargo member so force_host can build the signed Host again.\n\nReproduced in workflow run 32375508142: missing apps/fabushi-tauri/src-tauri/Cargo.toml. Validated with git diff --check.