### PR TITLE
fix(ci): unblock Apple Store signing builds

### DIFF
--- a/.github/workflows/apple-store-delivery.yml
+++ b/.github/workflows/apple-store-delivery.yml
@@ -121,7 +121,6 @@ jobs:
       MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.MACOS_APP_STORE_PROVISIONING_PROFILE_BASE64 }}
       CSC_LINK: ${{ secrets.MACOS_APP_STORE_CERTIFICATE_P12_BASE64 }}
       CSC_KEY_PASSWORD: ${{ secrets.MACOS_APP_STORE_CERTIFICATE_PASSWORD }}
-      CSC_NAME: ${{ vars.MACOS_APP_STORE_SIGNING_CERTIFICATE }}
       CSC_INSTALLER_LINK: ${{ secrets.MACOS_APP_STORE_INSTALLER_CERTIFICATE_P12_BASE64 }}
       CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.MACOS_APP_STORE_INSTALLER_CERTIFICATE_PASSWORD }}
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -329,6 +328,8 @@ jobs:
 
       - name: Build Mahayana static library for iOS devices
         working-directory: third_party/mahayana/mahayana-rs
+        env:
+          IPHONEOS_DEPLOYMENT_TARGET: '17.0'
         run: cargo build --release -p mahayana-app-host-mobile --target aarch64-apple-ios
 
       - name: Stage iOS device static library


### PR DESCRIPTION
Fixes both failures from the first manual Apple Store delivery run (#32380438548).\n\n- Electron MAS: let electron-builder select the imported Mac App Distribution identity from CSC_LINK instead of passing the legacy full certificate prefix in CSC_NAME.\n- Native iOS: set IPHONEOS_DEPLOYMENT_TARGET=17.0 for the Rust device build so Rust and C dependencies link against the same supported iOS deployment floor instead of Rust defaulting to iOS 10 while QuickJS was built for a modern SDK.\n\nStatic validation: YAML parse and git diff --check.