### PR TITLE
chore(release): set canonical app version to 1.0.2

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "1.0.2",
   "androidVersionCode": 1,
   "iosBuildNumber": 1
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/desktop",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/desktop",
-      "version": "0.1.0",
+      "version": "1.0.2",
       "dependencies": {
         "lucide-react": "^1.14.0",
         "react": "19.1.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/desktop",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "description": "全球法布施 Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,7 +30,7 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 0.1.0
+        MARKETING_VERSION: 1.0.2
         CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/native-mobile",
-      "version": "0.1.0"
+      "version": "1.0.2"
     }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
Aligns the canonical application version with the Apple Store delivery version now being uploaded. Updates app-version.json plus Electron/native-mobile package metadata and the generated iOS project source version. Platform build numbers remain CI-controlled.