### PR TITLE
fix(ci): avoid Android SDK pipefail release crash

### DIFF
--- a/.github/workflows/google-play-delivery.yml
+++ b/.github/workflows/google-play-delivery.yml
@@ -145,12 +145,12 @@ jobs:
         run: |
           set -euo pipefail
           available_packages="$(sdkmanager --list --channel=3)"
-          platform_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/platforms;android-(37([.]0)?|CinnamonBun)/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; exit}')"
-          build_tools_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/build-tools;37[.]/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; exit}')"
+          platform_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/platforms;android-(37([.]0)?|CinnamonBun)/ && !found {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; found=1}')"
+          build_tools_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/build-tools;37[.]/ && !found {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; found=1}')"
           test -n "$platform_package" && test -n "$build_tools_package"
           sdkmanager --channel=3 "$platform_package" "$build_tools_package" 'ndk;28.2.13676358'
           if [ ! -e "$ANDROID_HOME/platforms/android-37" ]; then
-            installed_platform="$(find "$ANDROID_HOME/platforms" -maxdepth 1 -type d \( -name 'android-37*' -o -name 'android-CinnamonBun*' \) | head -n 1)"
+            installed_platform="$(find "$ANDROID_HOME/platforms" -maxdepth 1 -type d \( -name 'android-37*' -o -name 'android-CinnamonBun*' \) -print -quit)"
             test -n "$installed_platform"
             ln -s "$installed_platform" "$ANDROID_HOME/platforms/android-37"
           fi

--- a/.github/workflows/native-electron-release.yml
+++ b/.github/workflows/native-electron-release.yml
@@ -154,12 +154,12 @@ jobs:
         run: |
           set -euo pipefail
           available_packages="$(sdkmanager --list --channel=3)"
-          platform_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/platforms;android-(37([.]0)?|CinnamonBun)/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; exit}')"
-          build_tools_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/build-tools;37[.]/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; exit}')"
+          platform_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/platforms;android-(37([.]0)?|CinnamonBun)/ && !found {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; found=1}')"
+          build_tools_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/build-tools;37[.]/ && !found {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; found=1}')"
           test -n "$platform_package" && test -n "$build_tools_package"
           sdkmanager --channel=3 "$platform_package" "$build_tools_package" 'ndk;28.2.13676358'
           if [ ! -e "$ANDROID_HOME/platforms/android-37" ]; then
-            installed_platform="$(find "$ANDROID_HOME/platforms" -maxdepth 1 -type d \( -name 'android-37*' -o -name 'android-CinnamonBun*' \) | head -n 1)"
+            installed_platform="$(find "$ANDROID_HOME/platforms" -maxdepth 1 -type d \( -name 'android-37*' -o -name 'android-CinnamonBun*' \) -print -quit)"
             test -n "$installed_platform"
             ln -s "$installed_platform" "$ANDROID_HOME/platforms/android-37"
           fi


### PR DESCRIPTION
## Summary
- prevent `sdkmanager --list` package parsing from failing under `set -o pipefail` when awk finds the first match
- remove the second latent `find | head` SIGPIPE path in Android release workflows
- apply the fix to both Google Play delivery and the shared native Electron release workflow

## Root cause
The first production Google Play delivery from main failed before any build/upload at `Install Android 17 SDK and NDK`: `awk ... exit` closed the pipe early, `printf` received SIGPIPE, and `pipefail` converted that into a workflow failure.

## Verification
- `git diff --check`
- canonical architecture guard passed
- release/publish contract guard passed
- no application code changed

Heavy verification remains in GitHub Actions.