### PR TITLE
fix(messaging): land post-merge gate fixes

### DIFF
--- a/.github/workflows/native-mobile.yml
+++ b/.github/workflows/native-mobile.yml
@@ -202,7 +202,12 @@ jobs:
 
       - name: Install cargo-ndk only when needed
         if: steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'
-        run: cargo install cargo-ndk --locked
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v cargo-ndk >/dev/null 2>&1; then
+            cargo install cargo-ndk --locked
+          fi
 
       - name: Save cargo-ndk immediately
         if: steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'
@@ -382,6 +387,8 @@ jobs:
           -scheme Fabushi
           -destination 'platform=iOS Simulator,id=${{ steps.simulator.outputs.udid }}'
           -derivedDataPath "${{ runner.temp }}/FabushiDerivedData"
+          -retry-tests-on-failure
+          -test-iterations 2
           CODE_SIGNING_ALLOWED=NO
           -resultBundlePath "$RUNNER_TEMP/FabushiTests.xcresult"
 

--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -60,7 +60,7 @@ test('desktop Messenger exposes Telegram-class navigation and preserves the real
       '支付',
       '设置',
     ]) {
-      await expect(page.getByTitle(label)).toBeVisible();
+      await expect(page.getByTitle(label, { exact: true })).toBeVisible();
     }
 
     const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
@@ -99,8 +99,9 @@ test('desktop Messenger creates a self-hosted channel and executes message mutat
     await page.getByPlaceholder('频道简介').fill('不依赖 Telegram API');
     await page.getByRole('button', { name: '创建频道' }).click();
 
-    await expect(page.getByText('自建频道验收')).toBeVisible();
-    await expect(page.getByText('不依赖 Telegram API')).toBeVisible();
+    const channelPeer = page.locator('[data-testid^="peer-selfhosted:channel:"]').filter({ hasText: '自建频道验收' }).first();
+    await expect(channelPeer).toBeVisible();
+    await expect(page.getByText('不依赖 Telegram API').first()).toBeVisible();
 
     await page.getByTestId('messenger-input').fill('自建频道消息');
     await page.getByTestId('messenger-send').click();
@@ -152,8 +153,9 @@ test('desktop Messenger creates a real Bot collaboration group and sends into it
     if (await researchBot.isVisible().catch(() => false)) await researchBot.click();
     await page.getByRole('button', { name: '创建群组' }).click();
 
-    await expect(page.getByText('人机协作验收群')).toBeVisible();
-    await page.getByText('人机协作验收群').click();
+    const groupPeer = page.locator('[data-testid^="peer-legacy:group:"]').filter({ hasText: '人机协作验收群' }).first();
+    await expect(groupPeer).toBeVisible();
+    await groupPeer.click();
     await page.getByTestId('messenger-input').fill('群组消息链路验收');
     await page.getByTestId('messenger-send').click();
     await expect(page.getByText('群组消息链路验收')).toBeVisible();

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -906,6 +906,7 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
         description: '',
         memberIds: [...newDialog.selectedBotIds],
       });
+      await execute({ type: 'group.list', requestId: nextRequestId('group-list-after-create') });
       setNewDialog(null);
       setSection('groups');
     } catch (cause) {

--- a/native/mahayana-messaging/src/service.rs
+++ b/native/mahayana-messaging/src/service.rs
@@ -228,7 +228,10 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     conversation_id: message.conversation_id.clone(),
                     command: command.clone(),
                     text: text.clone(),
-                    reply_to_message_id: message.reply_to_message_id.clone(),
+                    reply_to_message_id: message
+                        .reply_to_message_id
+                        .as_ref()
+                        .map(|id| id.0.clone()),
                     metadata: std::collections::BTreeMap::from([
                         ("source".into(), "messaging-service".into()),
                         ("messageId".into(), message.id.0.clone()),


### PR DESCRIPTION
Clean follow-up to #1961, rebased directly on main after the merge queue accepted the feature PR. This PR contains exactly four files and only the remaining verified gate fixes:

- fix BotInvocation reply-to conversion at the Rust boundary;
- refresh real AI groups immediately after group creation and use stable Messenger E2E selectors;
- avoid reinstalling cargo-ndk when the hosted runner already has it;
- retry only failed iOS XCTest cases once to absorb the observed CoreSimulator background-assertion launch flake.

Verified before push: diff against main is exactly four files; messaging core all-target tests passed with zero failures; Electron Feature Host architecture contract passed; YAML parsed; git diff --check passed.