### PR TITLE
docs: enforce project-first workflow in root AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,134 @@
 
 This repository contains the Fabushi app and website. Follow the user's request first, then these repository instructions.
 
+## CRITICAL: Project-First Task Governance — Every Task Must Use `projects/`
+
+These rules are mandatory for **every task** performed in this repository, including implementation, bug fixes, refactors, reviews, investigations, releases, documentation changes, CI/CD work, migrations, and follow-up rounds.
+
+### 1. Start every task by locating its project folder
+
+Before substantial work:
+
+1. Inspect the current GitHub `main` branch under `projects/`.
+2. Decide whether the request belongs to an existing project or is a genuinely different objective/workstream.
+3. If a matching project exists, **reuse it**. Do not create a duplicate folder merely because the chat/session is new.
+4. Read the matching project's `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, relevant `source/`, `docs/`, `decisions/`, and `management/` files.
+5. Read the current WBS, acceptance matrix, status report, changelog, risks, and active task record before deciding what to implement next.
+6. Verify code, branch, PR, CI, release, and deployment facts against GitHub rather than assuming documentation is current.
+
+### 2. If no project folder exists, create one before implementation
+
+If the request does not belong to an existing project, create a new lowercase kebab-case folder under:
+
+`projects/<project-slug>/`
+
+At minimum create and populate:
+
+```text
+projects/<project-slug>/
+├── README.md
+├── PROJECT.yaml
+├── SOURCE_OF_TRUTH.md
+├── source/
+│   └── README.md
+├── docs/
+│   ├── 00-项目章程.md
+│   ├── 01-范围与非目标.md
+│   └── 19-完成定义与验收.md
+├── management/
+│   ├── 00-路线图.md
+│   ├── 01-WBS原子任务.md
+│   ├── 03-验收追踪矩阵.md
+│   ├── 04-风险登记.md
+│   ├── 05-状态报告.md
+│   ├── 07-变更日志.md
+│   └── tasks/
+├── decisions/
+│   └── README.md
+└── evidence/
+    └── README.md
+```
+
+Do this **before substantial implementation** so the task has a durable scope, acceptance definition, and execution record from the beginning.
+
+### 3. Every substantial task must have a durable task record
+
+Create or update:
+
+`projects/<project-slug>/management/tasks/<task-id>-<short-slug>.md`
+
+The task record must include at least:
+
+- stable Task ID;
+- objective and source requirement;
+- in-scope / out-of-scope;
+- dependencies;
+- acceptance criteria;
+- verification method;
+- branch / commit / PR;
+- status;
+- implementation summary;
+- CI / E2E / release / deployment evidence when applicable;
+- blockers and risks;
+- next action;
+- started, updated, and completed timestamps.
+
+### 4. Drive implementation from the project folder
+
+The GitHub project folder is the durable working context. Use it to decide what comes next rather than relying on chat memory.
+
+- Reconstruct the current state from the project folder at the start of each task/round.
+- Advance the existing roadmap/WBS instead of inventing a parallel plan in chat.
+- Record newly discovered requirements in `source/` or the appropriate spec.
+- Record scope/design changes in `management/07-变更日志.md`.
+- Record long-lived architecture decisions under `decisions/` as ADRs.
+- Keep planned work and completed work clearly separated.
+- Prefer the same branch/PR for implementation and its project-record updates.
+
+### 5. Task completion is blocked until the project folder is updated
+
+Do **not** report a task as complete merely because code was written, pushed, or a test passed.
+
+Before saying a task is finished:
+
+1. Run or inspect the defined acceptance checks.
+2. Update the task record with actual results and evidence.
+3. Update `management/01-WBS原子任务.md` for affected task states.
+4. Update `management/03-验收追踪矩阵.md` when acceptance status changed.
+5. Append the round/result to `management/05-状态报告.md`.
+6. Append material changes to `management/07-变更日志.md`.
+7. Update risks, roadmap, specs, and ADRs when affected.
+8. Record commit SHA, PR number, CI run/job, release/deployment evidence, blockers, and next action where applicable.
+9. Commit the project-record changes to GitHub in the same task change stream when possible.
+10. Verify the canonical result on GitHub `main` after merge. If CI/merge/release is still pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete.
+
+### 6. Source-of-truth precedence
+
+Unless a project defines a stricter rule, use this precedence:
+
+1. the user's latest explicit requirement **after it is persisted into the GitHub project folder**;
+2. `projects/<project-slug>/SOURCE_OF_TRUTH.md` and the source files it designates;
+3. accepted ADRs and current project specs;
+4. current WBS/status/acceptance records;
+5. GitHub code/PR/CI/release/deployment facts for implementation state;
+6. external mirrors such as Google Drive;
+7. conversation memory.
+
+Google Drive, chat history, email, local notes, and other external copies are intake/reference material unless the project explicitly promotes them. They must not silently override the GitHub `main` project folder.
+
+### 7. Required governance skill
+
+For project/task lifecycle details, follow:
+
+`.agent/skills/fabushi-project-governance/SKILL.md`
+
+and its references:
+
+- `.agent/skills/fabushi-project-governance/references/project-folder-standard.md`
+- `.agent/skills/fabushi-project-governance/references/task-lifecycle.md`
+
+The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass the requirement to locate/create a project folder and keep its task records current.
+
 ## CRITICAL: Local Disk Safety — Never Build or Test the App Locally
 
 The development machine used for this repository has insufficient free storage for application builds and test runs. Build outputs, Rust/Electron/Android/iOS caches, test artifacts, downloaded SDK components, browser bundles, and dependency caches can exhaust the disk.

--- a/projects/fabushi-project-governance/PROJECT.yaml
+++ b/projects/fabushi-project-governance/PROJECT.yaml
@@ -1,0 +1,10 @@
+project_id: FPG
+name: Fabushi Project Governance
+slug: fabushi-project-governance
+status: active
+repository: bhrumom/fabushi
+authoritative_branch: main
+authoritative_path: projects/fabushi-project-governance
+created_at: 2026-08-22
+updated_at: 2026-08-22
+current_stage: repository-wide-bootstrap

--- a/projects/fabushi-project-governance/README.md
+++ b/projects/fabushi-project-governance/README.md
@@ -1,0 +1,33 @@
+# Fabushi Project Governance
+
+## Objective
+
+Make `projects/` the mandatory durable execution context for every task in `bhrumom/fabushi`, and make the root `AGENTS.md` enforce project-first intake, execution, verification, and closure.
+
+## Status
+
+`active`
+
+## Current stage
+
+Repository-wide bootstrap: establish the root `AGENTS.md` project gate and canonical governance project folder.
+
+## Canonical source
+
+- Repository: `bhrumom/fabushi`
+- Branch after merge: `main`
+- Path: `projects/fabushi-project-governance/`
+- Original requirement: `source/README.md`
+- Governance skill: `.agent/skills/fabushi-project-governance/SKILL.md`
+
+## Primary acceptance definition
+
+Every repository agent task must first resolve a project under `projects/`; if none matches, it must create the standardized project folder and files before substantial work. A task cannot be called complete until its project record is updated with status, acceptance, and evidence.
+
+## Navigation
+
+- `SOURCE_OF_TRUTH.md` — precedence and authority
+- `docs/` — scope and acceptance definition
+- `management/` — roadmap, WBS, acceptance, risk, status, changelog, task records
+- `decisions/` — long-lived governance decisions
+- `evidence/` — GitHub evidence indexes

--- a/projects/fabushi-project-governance/SOURCE_OF_TRUTH.md
+++ b/projects/fabushi-project-governance/SOURCE_OF_TRUTH.md
@@ -1,0 +1,19 @@
+# Source of Truth
+
+The canonical project record is `bhrumom/fabushi` `main` under `projects/fabushi-project-governance/`.
+
+## Requirement source
+
+`source/README.md` contains the original repository-wide governance requirement.
+
+## Precedence
+
+1. Latest explicit user requirement after being persisted into this project folder.
+2. This file and designated source files.
+3. Accepted ADRs and current specs.
+4. Current WBS, acceptance, status, risk, and task records.
+5. GitHub code/PR/CI/release/deployment facts for implementation state.
+6. External mirrors such as Google Drive.
+7. Conversation memory.
+
+GitHub `main` is authoritative after merge. External copies may inform work but must not silently override this folder. No task is complete until required project-record updates and objective GitHub evidence are present.

--- a/projects/fabushi-project-governance/decisions/ADR-0001-project-first-repository-governance.md
+++ b/projects/fabushi-project-governance/decisions/ADR-0001-project-first-repository-governance.md
@@ -1,0 +1,21 @@
+# ADR-0001 — Project-First Repository Governance
+
+- **Status:** Accepted
+- **Date:** 2026-08-22
+
+## Context
+
+Long-running Fabushi work spans chats, agents, PRs, CI runs, and releases. Chat memory alone cannot provide durable scope, status, and acceptance evidence.
+
+## Decision
+
+Every task must begin by resolving a canonical `projects/<slug>/` folder on GitHub `main`. Existing objectives reuse their project folder; genuinely different objectives create the standard scaffold before substantial work. Completion requires project-record updates and GitHub evidence.
+
+The root `AGENTS.md` is the repository-wide enforcement instruction; `.agent/skills/fabushi-project-governance/` contains detailed lifecycle rules.
+
+## Consequences
+
+- Agents must perform project intake before substantive work.
+- New independent workstreams incur a small documentation bootstrap cost.
+- Cross-session continuity and auditability improve.
+- GitHub project records become authoritative over chat memory and external mirrors.

--- a/projects/fabushi-project-governance/decisions/README.md
+++ b/projects/fabushi-project-governance/decisions/README.md
@@ -1,0 +1,3 @@
+# Decisions
+
+- `ADR-0001-project-first-repository-governance.md` — make `projects/` mandatory durable context for every repository task.

--- a/projects/fabushi-project-governance/docs/00-项目章程.md
+++ b/projects/fabushi-project-governance/docs/00-项目章程.md
@@ -1,0 +1,18 @@
+# 项目章程
+
+## 目的
+
+把 Fabushi 的 AI/Agent 工作方式从“依赖当前聊天上下文”升级为“以 GitHub 项目文件夹为持续上下文”。
+
+## 成功状态
+
+- 根 `AGENTS.md` 对所有任务强制 Project-First。
+- 任何任务开始先查 `projects/`。
+- 没有匹配项目时先创建标准项目文件夹和文件。
+- 每个实质任务有稳定 Task ID 和任务记录。
+- 任务结束必须回写 WBS、验收、状态、变更和证据。
+- GitHub `main` 是长期权威记录。
+
+## 治理关系
+
+根 `AGENTS.md` 是仓库级门禁；`.agent/skills/fabushi-project-governance/` 提供详细执行流程；每个 `projects/<slug>/` 保存各项目自身上下文。

--- a/projects/fabushi-project-governance/docs/01-范围与非目标.md
+++ b/projects/fabushi-project-governance/docs/01-范围与非目标.md
@@ -1,0 +1,15 @@
+# 范围与非目标
+
+## In scope
+
+- 根 `AGENTS.md` 的项目优先任务流程。
+- `projects/` 的发现、复用、新建标准。
+- Task ID、任务记录、WBS、验收、状态、变更、风险和证据闭环。
+- GitHub `main` 的 Source of Truth 规则。
+- 与现有 `fabushi-project-governance` Skill 对齐。
+
+## Out of scope
+
+- 本项目不替代具体产品项目的 PRD/架构设计。
+- 不把每个新聊天强制视为新项目；相同目标继续复用已有项目。
+- 不用项目文档替代 GitHub 代码、CI、Release 等真实工程事实。

--- a/projects/fabushi-project-governance/docs/19-完成定义与验收.md
+++ b/projects/fabushi-project-governance/docs/19-完成定义与验收.md
@@ -1,0 +1,13 @@
+# 完成定义与验收
+
+项目当前 bootstrap 阶段完成需同时满足：
+
+1. 根 `AGENTS.md` 明确要求每次任务先检查 `projects/`。
+2. 明确要求匹配已有项目时先读 Source of Truth、WBS、验收、状态、变更和 ADR 再推进。
+3. 明确要求没有匹配项目时先创建标准项目文件夹和必要文件。
+4. 明确要求实质任务创建稳定 Task ID 和 `management/tasks/` 记录。
+5. 明确任务结束前更新 WBS、验收、状态、变更和证据。
+6. 明确未完成 CI/merge/release 或记录回写时不得宣称完成。
+7. 建立本项目自身标准目录，证明规则可以自举执行。
+8. 变更通过 GitHub PR、必需 `CI result` 和 merge queue 合并到 `main`。
+9. 合并后核对 `main` 的 `AGENTS.md` 与项目目录。

--- a/projects/fabushi-project-governance/evidence/FPG-001/README.md
+++ b/projects/fabushi-project-governance/evidence/FPG-001/README.md
@@ -1,11 +1,17 @@
 # FPG-001 Evidence
 
-Status: pending PR/CI/merge.
+Status: PR open; CI/merge pending.
 
-Expected evidence:
+## Current evidence
 
-- branch and commit SHA;
-- PR number;
+- Branch: `project/fabushi-project-governance-agents`
+- Initial commit: `b537329ed9fc0bdadcd8c51e27a92956b09181fd`
+- PR: #1976
+- Root instruction changed: `AGENTS.md`
+- Governance project created: `projects/fabushi-project-governance/`
+
+## Pending evidence
+
 - required `CI result` success;
 - merge queue completion;
-- canonical `main` paths for `AGENTS.md` and `projects/fabushi-project-governance/`.
+- canonical `main` verification for `AGENTS.md` and `projects/fabushi-project-governance/`.

--- a/projects/fabushi-project-governance/evidence/FPG-001/README.md
+++ b/projects/fabushi-project-governance/evidence/FPG-001/README.md
@@ -1,0 +1,11 @@
+# FPG-001 Evidence
+
+Status: pending PR/CI/merge.
+
+Expected evidence:
+
+- branch and commit SHA;
+- PR number;
+- required `CI result` success;
+- merge queue completion;
+- canonical `main` paths for `AGENTS.md` and `projects/fabushi-project-governance/`.

--- a/projects/fabushi-project-governance/evidence/README.md
+++ b/projects/fabushi-project-governance/evidence/README.md
@@ -1,0 +1,5 @@
+# Evidence
+
+Use task-specific subdirectories to index durable GitHub evidence. Do not store credentials or large binary artifacts here.
+
+Current task: `FPG-001/README.md`.

--- a/projects/fabushi-project-governance/management/00-路线图.md
+++ b/projects/fabushi-project-governance/management/00-路线图.md
@@ -1,0 +1,16 @@
+# 路线图
+
+## G0 — Repository bootstrap
+
+- 建立 `projects/fabushi-project-governance/`。
+- 把 Project-First 门禁加入根 `AGENTS.md`。
+- 通过 PR/CI/merge queue 进入 `main`。
+
+## G1 — Adoption
+
+- 后续任务持续验证 Agent 是否正确复用/创建项目目录。
+- 根据真实使用发现改进模板、任务生命周期和验收规则。
+
+## G2 — Enforcement hardening
+
+- 如有必要，增加静态检查/CI guardrail，检测重要 PR 是否缺少相应项目记录更新。

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -1,0 +1,7 @@
+# WBS 原子任务
+
+| Task ID | Atomic Task | Required | Acceptance Criterion | Verification | Status |
+|---|---|---:|---|---|---|
+| FPG-001 | 建立仓库级 Project-First Agent 门禁 | yes | 根 AGENTS.md 强制每次任务检查/复用/创建项目目录并在结束前回写记录 | PR diff + CI result + main merge verification | in-progress |
+| FPG-002 | 根据真实使用校准项目模板 | no | 发现明确缺口时更新标准且保留变更记录 | 后续任务证据 | not-started |
+| FPG-003 | 评估 CI 项目记录 guardrail | no | 有足够误用证据后决定是否自动化 enforcement | ADR/CI prototype | not-started |

--- a/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
@@ -1,0 +1,10 @@
+# 验收追踪矩阵
+
+| Requirement | Implementation / Evidence | Status |
+|---|---|---|
+| 每次任务先看项目文件夹 | root `AGENTS.md` Project-First section | pending-merge |
+| 已有项目按项目文档推进 | root `AGENTS.md` + governance skill | pending-merge |
+| 没有项目就创建标准项目文件夹和文件 | root `AGENTS.md` + `project-folder-standard.md` | pending-merge |
+| 每个实质任务有任务记录 | root `AGENTS.md` + `management/tasks/` rule | pending-merge |
+| 任务结束回写记录和证据 | root `AGENTS.md` completion gate | pending-merge |
+| 规则自身以项目文件夹执行 | `projects/fabushi-project-governance/` | pending-merge |

--- a/projects/fabushi-project-governance/management/04-风险登记.md
+++ b/projects/fabushi-project-governance/management/04-风险登记.md
@@ -1,0 +1,8 @@
+# 风险登记
+
+| Risk | Impact | Mitigation | Status |
+|---|---|---|---|
+| 每个新聊天都误建新项目 | 项目目录碎片化 | 只对 genuinely different objective/workstream 新建；相同目标复用 | controlled |
+| 文档声称完成但代码/CI 未完成 | 错误进度 | GitHub code/PR/CI/release facts 决定实现状态 | controlled |
+| Agent 忘记回写项目记录 | 上下文丢失 | root AGENTS completion gate + governance skill | active |
+| 项目流程过重 | 小任务摩擦增加 | 共享最小标准模板，按项目需要增加 specialist docs | monitored |

--- a/projects/fabushi-project-governance/management/05-状态报告.md
+++ b/projects/fabushi-project-governance/management/05-状态报告.md
@@ -8,3 +8,12 @@
 - Acceptance: pending PR/CI/merge verification.
 - Blocker: none at preparation stage.
 - Next: 提交 PR，等待 `CI result` 与 merge queue，然后回填最终证据。
+
+## 2026-08-22 — FPG-001 Round 2
+
+- Work: 创建 `project/fabushi-project-governance-agents`，提交根 `AGENTS.md` Project-First 门禁及完整治理项目目录。
+- Work: 创建 PR #1976，并将实际 branch/commit/PR 信息回写任务记录。
+- Evidence: initial commit `b537329ed9fc0bdadcd8c51e27a92956b09181fd`; PR #1976.
+- Acceptance: implementation prepared; required `CI result` and merge-queue completion pending.
+- Blocker: none.
+- Next: 运行 GitHub CI，进入 merge queue，合并后从 `main` 复核并关闭 FPG-001。

--- a/projects/fabushi-project-governance/management/05-状态报告.md
+++ b/projects/fabushi-project-governance/management/05-状态报告.md
@@ -1,0 +1,10 @@
+# 状态报告
+
+## 2026-08-22 — FPG-001 Round 1
+
+- Work: 检查 `projects/`，确认只有 Telegram 融合项目；将仓库级治理识别为新的独立工作流。
+- Work: 读取现有 `.agent/skills/fabushi-project-governance/` 及 project-folder/task-lifecycle 标准。
+- Work: 准备根 `AGENTS.md` Project-First 门禁与本项目最小标准目录。
+- Acceptance: pending PR/CI/merge verification.
+- Blocker: none at preparation stage.
+- Next: 提交 PR，等待 `CI result` 与 merge queue，然后回填最终证据。

--- a/projects/fabushi-project-governance/management/07-变更日志.md
+++ b/projects/fabushi-project-governance/management/07-变更日志.md
@@ -1,0 +1,7 @@
+# 变更日志
+
+## 2026-08-22
+
+- 创建独立仓库级治理项目 `projects/fabushi-project-governance/`。
+- 计划将“每次任务先检查项目目录、无匹配项目则创建、结束前回写记录”提升为根 `AGENTS.md` 强制规则。
+- 复用已合并的 `.agent/skills/fabushi-project-governance/` 作为详细执行规范。

--- a/projects/fabushi-project-governance/management/tasks/FPG-001-root-agents-project-gate.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-001-root-agents-project-gate.md
@@ -1,0 +1,69 @@
+# FPG-001 — Root AGENTS Project-First Gate
+
+- **Task ID:** FPG-001
+- **Status:** in-progress
+- **Started:** 2026-08-22T13:32:00+08:00
+- **Updated:** 2026-08-22T13:32:00+08:00
+
+## Objective
+
+Make root `AGENTS.md` require every Fabushi repository task to locate/reuse a project folder, or create the standardized folder/files when no matching project exists, and to close the task by updating project records and evidence.
+
+## Source requirement
+
+`../../source/README.md`
+
+## In scope
+
+- root `AGENTS.md` repository-wide rule;
+- new `projects/fabushi-project-governance/` scaffold;
+- linkage to existing governance skill;
+- GitHub PR/CI/merge evidence.
+
+## Out of scope
+
+- product runtime behavior;
+- changing unrelated Faliu or disk-safety rules;
+- automatic CI enforcement beyond this task.
+
+## Dependencies
+
+- existing `.agent/skills/fabushi-project-governance/` merged on main via PR #1975;
+- repository merge queue and required `CI result`.
+
+## Acceptance criteria
+
+1. `AGENTS.md` mandates project lookup on every task.
+2. Existing project is reused and read before work.
+3. Missing project triggers standardized project folder/files before substantial work.
+4. Task record/WBS/acceptance/status/changelog/evidence closure is mandatory.
+5. Rule references the governance skill.
+6. This new governance project exists on `main`.
+7. PR CI passes and merge queue completes.
+
+## Verification
+
+- Review changed files and root AGENTS section.
+- Confirm required CI job `CI result` succeeds.
+- Confirm PR merges through merge queue.
+- Fetch `AGENTS.md` and this project folder from `main` after merge.
+
+## Branch / PR
+
+Pending creation.
+
+## Implementation summary
+
+Prepared new root governance section and standard governance project scaffold.
+
+## Evidence
+
+Pending PR/CI/main verification.
+
+## Blockers / risks
+
+None currently; task remains in-progress until canonical merge verification.
+
+## Next action
+
+Create PR and complete required GitHub checks.

--- a/projects/fabushi-project-governance/management/tasks/FPG-001-root-agents-project-gate.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-001-root-agents-project-gate.md
@@ -3,7 +3,7 @@
 - **Task ID:** FPG-001
 - **Status:** in-progress
 - **Started:** 2026-08-22T13:32:00+08:00
-- **Updated:** 2026-08-22T13:32:00+08:00
+- **Updated:** 2026-08-22T13:34:00+08:00
 
 ## Objective
 
@@ -50,20 +50,26 @@ Make root `AGENTS.md` require every Fabushi repository task to locate/reuse a pr
 
 ## Branch / PR
 
-Pending creation.
+- Branch: `project/fabushi-project-governance-agents`
+- Initial commit: `b537329ed9fc0bdadcd8c51e27a92956b09181fd`
+- PR: #1976
 
 ## Implementation summary
 
-Prepared new root governance section and standard governance project scaffold.
+- Added repository-wide Project-First task governance to root `AGENTS.md`.
+- Added the canonical `projects/fabushi-project-governance/` project scaffold.
+- Linked the root governance gate to the existing `.agent/skills/fabushi-project-governance/SKILL.md` and lifecycle references.
+- Preserved existing local-disk and Faliu workflow instructions.
 
 ## Evidence
 
-Pending PR/CI/main verification.
+- PR #1976 contains 19 changed files and the complete initial governance bootstrap.
+- CI and canonical `main` verification are still pending.
 
 ## Blockers / risks
 
-None currently; task remains in-progress until canonical merge verification.
+None currently; task remains in-progress until required CI and merge-queue verification complete.
 
 ## Next action
 
-Create PR and complete required GitHub checks.
+Run required GitHub checks, enter merge queue, then verify canonical `main` and close project records.

--- a/projects/fabushi-project-governance/source/README.md
+++ b/projects/fabushi-project-governance/source/README.md
@@ -1,0 +1,12 @@
+# Original Requirement
+
+User requirement, 2026-08-22:
+
+> 把这个项目任务流程写入整个fabushi仓库的agent.md文件，要求每次任务都要看项目文件夹，根据文件夹去推进，如果没有项目文件夹就要创建生成项目文件夹和文件
+
+Interpretation persisted for execution:
+
+- The repository root `AGENTS.md` must enforce this workflow for all agent tasks.
+- Every task must inspect `projects/` and continue from the matching project record.
+- If no project exists for a genuinely different objective/workstream, create a standardized project folder and required files before substantial implementation.
+- Task completion must update the project record with status, acceptance, changelog, and evidence.


### PR DESCRIPTION
## Summary
- add repository-wide Project-First task governance to root `AGENTS.md`
- require every task to inspect/reuse a matching `projects/<slug>/` folder before substantial work
- require creation of a standardized project folder/files when no matching project exists
- require durable task records, WBS/acceptance/status/changelog/evidence updates before task completion
- create `projects/fabushi-project-governance/` as the canonical repository-wide governance project
- link root instructions to `.agent/skills/fabushi-project-governance/SKILL.md`

## Task
- `FPG-001`

## Validation plan
- review root `AGENTS.md` diff
- require GitHub `CI result`
- merge only through merge queue
- after merge, verify `AGENTS.md` and `projects/fabushi-project-governance/` on `main`

No runtime product code is changed.