### PR TITLE
docs: close FPG-001 governance bootstrap

### DIFF
--- a/projects/fabushi-project-governance/PROJECT.yaml
+++ b/projects/fabushi-project-governance/PROJECT.yaml
@@ -7,4 +7,4 @@ authoritative_branch: main
 authoritative_path: projects/fabushi-project-governance
 created_at: 2026-08-22
 updated_at: 2026-08-22
-current_stage: repository-wide-bootstrap
+current_stage: adoption

--- a/projects/fabushi-project-governance/evidence/FPG-001/README.md
+++ b/projects/fabushi-project-governance/evidence/FPG-001/README.md
@@ -1,17 +1,24 @@
 # FPG-001 Evidence
 
-Status: PR open; CI/merge pending.
+Status: passed.
 
-## Current evidence
+## GitHub evidence
 
-- Branch: `project/fabushi-project-governance-agents`
+- Governance branch: `project/fabushi-project-governance-agents`
 - Initial commit: `b537329ed9fc0bdadcd8c51e27a92956b09181fd`
+- Final PR head: `1a14b963f727dd98bbc73de414afbb13897d270d`
 - PR: #1976
-- Root instruction changed: `AGENTS.md`
-- Governance project created: `projects/fabushi-project-governance/`
+- Required CI: `CI result` — success
+- Merge queue: completed
+- Merge commit on `main`: `eaf273dafc140619b06b46a4d7d234997acde05d`
+- Canonical root instruction: `AGENTS.md` on `main`
+- Canonical governance project: `projects/fabushi-project-governance/` on `main`
 
-## Pending evidence
+## Verified behavior encoded in AGENTS.md
 
-- required `CI result` success;
-- merge queue completion;
-- canonical `main` verification for `AGENTS.md` and `projects/fabushi-project-governance/`.
+- every task first inspects `projects/`;
+- matching projects are reused and read before work;
+- missing projects trigger creation of standard project files;
+- substantial tasks create durable task records;
+- work is driven from project WBS/specs/ADRs/status rather than chat memory;
+- completion is blocked until project records and objective evidence are updated.

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -2,6 +2,6 @@
 
 | Task ID | Atomic Task | Required | Acceptance Criterion | Verification | Status |
 |---|---|---:|---|---|---|
-| FPG-001 | 建立仓库级 Project-First Agent 门禁 | yes | 根 AGENTS.md 强制每次任务检查/复用/创建项目目录并在结束前回写记录 | PR diff + CI result + main merge verification | in-progress |
+| FPG-001 | 建立仓库级 Project-First Agent 门禁 | yes | 根 AGENTS.md 强制每次任务检查/复用/创建项目目录并在结束前回写记录 | PR #1976 + CI result success + main merge `eaf273dafc140619b06b46a4d7d234997acde05d` | passed |
 | FPG-002 | 根据真实使用校准项目模板 | no | 发现明确缺口时更新标准且保留变更记录 | 后续任务证据 | not-started |
 | FPG-003 | 评估 CI 项目记录 guardrail | no | 有足够误用证据后决定是否自动化 enforcement | ADR/CI prototype | not-started |

--- a/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
@@ -2,9 +2,10 @@
 
 | Requirement | Implementation / Evidence | Status |
 |---|---|---|
-| 每次任务先看项目文件夹 | root `AGENTS.md` Project-First section | pending-merge |
-| 已有项目按项目文档推进 | root `AGENTS.md` + governance skill | pending-merge |
-| 没有项目就创建标准项目文件夹和文件 | root `AGENTS.md` + `project-folder-standard.md` | pending-merge |
-| 每个实质任务有任务记录 | root `AGENTS.md` + `management/tasks/` rule | pending-merge |
-| 任务结束回写记录和证据 | root `AGENTS.md` completion gate | pending-merge |
-| 规则自身以项目文件夹执行 | `projects/fabushi-project-governance/` | pending-merge |
+| 每次任务先看项目文件夹 | root `AGENTS.md` Project-First section on `main` | passed |
+| 已有项目按项目文档推进 | root `AGENTS.md` + governance skill | passed |
+| 没有项目就创建标准项目文件夹和文件 | root `AGENTS.md` + `project-folder-standard.md` | passed |
+| 每个实质任务有任务记录 | root `AGENTS.md` + `management/tasks/` rule | passed |
+| 任务结束回写记录和证据 | root `AGENTS.md` completion gate | passed |
+| 规则自身以项目文件夹执行 | `projects/fabushi-project-governance/` | passed |
+| GitHub 必需检查和 merge queue | PR #1976; `CI result` success; merge commit `eaf273dafc140619b06b46a4d7d234997acde05d` | passed |

--- a/projects/fabushi-project-governance/management/05-状态报告.md
+++ b/projects/fabushi-project-governance/management/05-状态报告.md
@@ -17,3 +17,13 @@
 - Acceptance: implementation prepared; required `CI result` and merge-queue completion pending.
 - Blocker: none.
 - Next: 运行 GitHub CI，进入 merge queue，合并后从 `main` 复核并关闭 FPG-001。
+
+## 2026-08-22 — FPG-001 Round 3
+
+- Work: PR #1976 的 `CI result` 成功，运行时代码相关 jobs 因仅文档治理变更而正确跳过。
+- Work: PR #1976 进入 merge queue 并成功合并到 `main`。
+- Work: 从 `main` 重新读取根 `AGENTS.md`，确认 Project-First 门禁已经成为仓库级指令。
+- Evidence: PR #1976; merge commit `eaf273dafc140619b06b46a4d7d234997acde05d`; canonical `AGENTS.md` on `main`.
+- Acceptance: all FPG-001 functional acceptance criteria passed.
+- Blocker: none.
+- Next: 完成本轮 closure record 合并；后续所有仓库任务按该规则执行。

--- a/projects/fabushi-project-governance/management/07-变更日志.md
+++ b/projects/fabushi-project-governance/management/07-变更日志.md
@@ -3,5 +3,7 @@
 ## 2026-08-22
 
 - 创建独立仓库级治理项目 `projects/fabushi-project-governance/`。
-- 计划将“每次任务先检查项目目录、无匹配项目则创建、结束前回写记录”提升为根 `AGENTS.md` 强制规则。
+- 将“每次任务先检查项目目录、无匹配项目则创建、结束前回写记录”提升为根 `AGENTS.md` 强制规则。
 - 复用已合并的 `.agent/skills/fabushi-project-governance/` 作为详细执行规范。
+- PR #1976 通过必需 `CI result` 和 merge queue 合并到 `main`，合并提交 `eaf273dafc140619b06b46a4d7d234997acde05d`。
+- FPG-001 完成功能验收，项目阶段从 repository-wide-bootstrap 转入 adoption。

--- a/projects/fabushi-project-governance/management/tasks/FPG-001-root-agents-project-gate.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-001-root-agents-project-gate.md
@@ -1,9 +1,10 @@
 # FPG-001 — Root AGENTS Project-First Gate
 
 - **Task ID:** FPG-001
-- **Status:** in-progress
+- **Status:** passed
 - **Started:** 2026-08-22T13:32:00+08:00
-- **Updated:** 2026-08-22T13:34:00+08:00
+- **Updated:** 2026-08-22T13:38:00+08:00
+- **Completed:** 2026-08-22T13:38:00+08:00
 
 ## Objective
 
@@ -31,45 +32,46 @@ Make root `AGENTS.md` require every Fabushi repository task to locate/reuse a pr
 - existing `.agent/skills/fabushi-project-governance/` merged on main via PR #1975;
 - repository merge queue and required `CI result`.
 
-## Acceptance criteria
+## Acceptance result
 
-1. `AGENTS.md` mandates project lookup on every task.
-2. Existing project is reused and read before work.
-3. Missing project triggers standardized project folder/files before substantial work.
-4. Task record/WBS/acceptance/status/changelog/evidence closure is mandatory.
-5. Rule references the governance skill.
-6. This new governance project exists on `main`.
-7. PR CI passes and merge queue completes.
+1. `AGENTS.md` mandates project lookup on every task — **passed**.
+2. Existing project is reused and read before work — **passed**.
+3. Missing project triggers standardized project folder/files before substantial work — **passed**.
+4. Task record/WBS/acceptance/status/changelog/evidence closure is mandatory — **passed**.
+5. Rule references the governance skill — **passed**.
+6. New governance project exists on `main` — **passed**.
+7. PR CI passes and merge queue completes — **passed**.
 
 ## Verification
 
-- Review changed files and root AGENTS section.
-- Confirm required CI job `CI result` succeeds.
-- Confirm PR merges through merge queue.
-- Fetch `AGENTS.md` and this project folder from `main` after merge.
+- Root `AGENTS.md` fetched from `main` after merge and contains the Project-First repository gate.
+- Required `CI result` on PR #1976 concluded success.
+- PR #1976 merged through merge queue.
+- Merge commit: `eaf273dafc140619b06b46a4d7d234997acde05d`.
 
 ## Branch / PR
 
 - Branch: `project/fabushi-project-governance-agents`
 - Initial commit: `b537329ed9fc0bdadcd8c51e27a92956b09181fd`
+- Final PR head: `1a14b963f727dd98bbc73de414afbb13897d270d`
 - PR: #1976
+- Merge commit: `eaf273dafc140619b06b46a4d7d234997acde05d`
 
 ## Implementation summary
 
 - Added repository-wide Project-First task governance to root `AGENTS.md`.
-- Added the canonical `projects/fabushi-project-governance/` project scaffold.
-- Linked the root governance gate to the existing `.agent/skills/fabushi-project-governance/SKILL.md` and lifecycle references.
+- Added canonical `projects/fabushi-project-governance/` project scaffold.
+- Linked root governance gate to `.agent/skills/fabushi-project-governance/SKILL.md` and lifecycle references.
 - Preserved existing local-disk and Faliu workflow instructions.
 
 ## Evidence
 
-- PR #1976 contains 19 changed files and the complete initial governance bootstrap.
-- CI and canonical `main` verification are still pending.
+See `../../evidence/FPG-001/README.md`.
 
 ## Blockers / risks
 
-None currently; task remains in-progress until required CI and merge-queue verification complete.
+None for FPG-001.
 
 ## Next action
 
-Run required GitHub checks, enter merge queue, then verify canonical `main` and close project records.
+Use this project for future repository-governance refinements; every other Fabushi task must resolve its own canonical project folder according to root `AGENTS.md`.


### PR DESCRIPTION
## Summary
- mark FPG-001 passed after PR #1976 merged to `main`
- record required `CI result` success and merge-queue evidence
- update WBS, acceptance matrix, status report, changelog, task record, and evidence index
- move the governance project from bootstrap to adoption

## Evidence
- implementation PR: #1976
- implementation merge commit: `eaf273dafc140619b06b46a4d7d234997acde05d`
- canonical root `AGENTS.md` verified on `main`

This PR contains project-record closure only.