### PR TITLE
ci: add fast risk-tiered merge queue and change-aware CD

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,76 +1,128 @@
-# Branch protection and release policy
+# Branch protection, merge queue, and release policy
 
-This repository uses a mature-team delivery model:
+Fabushi uses a protected-trunk delivery model designed for high throughput without weakening safety.
+
+## Core delivery model
 
 1. Pull requests prove that a change is safe to merge.
-2. The default branch is protected and stays deployable.
-3. Production deploys happen only from `main` after staging and smoke gates pass.
-4. Fully automatic merge is explicit, label-gated, and blocked for sensitive paths.
+2. `main` is protected and should remain deployable.
+3. One aggregate required check, `CI result`, represents the selected checks for the exact diff.
+4. GitHub merge queue owns the final merge into `main` and validates the queued candidate against the latest target branch.
+5. CI is risk-tiered and change-aware; unrelated product suites must not run merely because a PR entered the merge queue.
+6. Production CD is also change-aware; an unrelated documentation merge must not deploy Worker, Fabushi Pay, or other products.
+7. Sensitive delivery/security changes require explicit authorization and still pass through the merge queue.
 
-## Required GitHub settings
+## Required GitHub settings for `main`
 
-Enable these repository settings for `main` under **Settings -> Branches -> Branch protection rules**.
-
-### Main branch protection
+Configure the repository/ruleset so `main` enforces:
 
 - Require a pull request before merging.
 - Require status checks to pass before merging.
-- Require branches to be up to date before merging, or enable GitHub merge queue.
+- Require `CI result` as the aggregate status check.
+- Require GitHub merge queue rather than direct protected-branch merging.
 - Require conversation resolution before merging.
-- Require linear history when practical.
+- Prefer squash/linear history for normal changes.
 - Do not allow force pushes.
-- Do not allow deletions.
-- Restrict bypasses to maintainers only.
+- Do not allow branch deletion.
+- Restrict protection bypasses to emergency maintainers only and audit every bypass.
 
-### Required checks
+## CI risk tiers
 
-Require this aggregate check instead of every internal job:
+### Tier 0 — documentation and project governance
+
+Examples include `projects/**`, repository-root Markdown, and direct `.github/*.md` policy documents.
+
+These changes still produce the required `CI result` on both the PR head and the merge-group candidate, but they do not run unrelated Frontend, Worker, MCP, or Electron suites.
+
+### Tier 1 — known product-domain changes
+
+The CI classifier maps files to domain checks. Multiple affected domains run in parallel.
+
+Current canonical domains include:
+
+- Frontend checks
+- Worker checks
+- MCP plugin contracts
+- Canonical architecture/workflow guardrails
+- Electron Feature Host contract
+
+### Tier 2 — unknown/unclassified non-document paths
+
+Unknown runtime paths fail safe by selecting all current canonical domain checks. They must never become green simply because the classifier does not recognize the file.
+
+A follow-up governance task should explicitly classify frequently changed unknown paths instead of leaving them permanently on the expensive fallback.
+
+### Tier 3 — sensitive delivery/security changes
+
+CI/CD workflows/actions/scripts, authentication, payments, deployments, and database-sensitive changes are not eligible for unattended protected-branch merging. They require explicit authorization and merge-queue validation.
+
+## Merge queue behavior
+
+The queue is intentionally retained. It protects `main` from stale-green PRs by testing the synthetic queued candidate on top of the latest base and any earlier queued changes.
+
+The `CI` workflow listens to `merge_group: checks_requested` and classifies the exact range:
+
+`merge_group.base_sha .. merge_group.head_sha`
+
+The queue must **not** force all product suites for every PR. The same risk/domain classification used for PR validation is applied again to the merge-group candidate.
+
+## Aggregate required check
+
+Require only:
 
 - `CI result`
 
-The aggregate check depends on:
+`CI result` depends on the internal jobs selected by the classifier. A selected job must succeed; an unrelated job may be skipped. The classifier itself is also part of the aggregate gate.
 
-- `Frontend checks`
-- `Worker checks`
-- `MCP plugin contracts`
-- `Canonical architecture guardrails`
-- `Electron Feature Host contract`
-
-### Merge queue
-
-For best protection against stale green PRs, enable GitHub merge queue for `main`.
-
-The `CI` workflow supports the `merge_group` event, so queued merge candidates are validated against the latest `main` before they land.
+This keeps branch rules stable while internal CI can evolve without continually editing required-check settings.
 
 ## Automerge policy
 
 Automerge is opt-in, not global.
 
-A PR can be merged automatically only when all of these are true:
+A PR may be automatically authorized only when all of these are true:
 
 - It targets `main`.
 - It is not a draft.
 - It comes from this repository, not a fork.
 - It has the `automerge` label.
-- Its latest head commit has a successful `CI` run.
-- It does not touch sensitive paths.
+- Its latest head commit has a successful `CI` workflow.
+- It does not touch sensitive paths unless explicitly authorized.
 
-Sensitive paths include CI/CD configuration, deployment scripts, auth, payment, and database-related files. Those changes require a human merge even when CI is green.
+The automerge workflow does **not** directly merge into `main`. It arms GitHub-native auto-merge/protected merge behavior. GitHub merge queue remains responsible for final queue entry, merge-group CI, ordering, and merge.
+
+Sensitive paths include CI/CD configuration, deployment scripts, auth, payment, and database-related files. Those changes need explicit maintainer/user authorization even when CI is green.
 
 ## CD policy
 
-CD runs only after a successful `CI` workflow from a `main` push, or by explicit manual dispatch.
+CD runs only from validated `main` state or explicit manual dispatch.
 
-The production path is:
+For workflows triggered after successful `CI` on a `main` push, the first job must resolve the source SHA and determine whether that product's deployment inputs actually changed.
 
-1. Build release artifact.
-2. Deploy staging.
-3. Run staging API and app UI E2E.
-4. Run Android native install smoke.
-5. Run iOS native install smoke.
-6. Deploy production.
-7. Run production smoke test.
+- If the domain changed: continue staging / migration / deploy / smoke gates.
+- If the domain did not change: stop after the lightweight impact resolver.
+- If impact detection is uncertain because a diff exceeds the safety limit: fail safe by deploying/validating rather than silently skipping.
+- Manual dispatch remains an explicit force-deploy path for controlled redeploys and rollback validation.
 
-Production deploys are serialized with a single `cd-production-main` concurrency group. This avoids two production deployments racing each other.
+The production promotion model remains:
 
-Manual CD dispatch accepts an optional `source_sha` for controlled redeploys and rollback validation.
+1. Validate the exact source commit.
+2. Deploy staging where applicable.
+3. Run staging API/UI E2E and smoke gates.
+4. Run required native/install smoke gates for relevant products.
+5. Deploy production.
+6. Run production smoke/health validation.
+7. Record release/deployment evidence.
+
+Production deployments are serialized by product/environment concurrency groups to prevent races.
+
+## Latency policy
+
+Optimize for developer feedback without bypassing safety:
+
+- Tier 0 docs/governance: classifier + `CI result`; target seconds-to-low-tens-of-seconds runner time, subject to GitHub-hosted runner queueing.
+- Tier 1 product code: only impacted suites, parallelized.
+- Merge queue: revalidate the same impacted domains on the synthetic candidate.
+- Expensive packaging, device E2E, store delivery, and production deployment run only when their product/release path requires them.
+
+Do not make a low-risk change wait for unrelated compilation, device tests, migrations, or production deployments.

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -33,11 +33,11 @@ permissions:
 
 jobs:
   automerge:
-    name: Merge explicitly authorized green PRs
+    name: Authorize green PRs for protected merge
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Evaluate and merge authorized PR
+      - name: Evaluate and arm authorized PR
         uses: actions/github-script@v7
         with:
           script: |
@@ -124,6 +124,21 @@ jobs:
               });
             }
 
+            async function getProtectedMergeState(pullNumber) {
+              return github.graphql(
+                `query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      id
+                      autoMergeRequest { enabledAt }
+                      mergeQueueEntry { position }
+                    }
+                  }
+                }`,
+                { owner, repo, number: pullNumber },
+              );
+            }
+
             const pr = await findPr();
             if (!pr) {
               core.info('No open main-targeting PR found for automerge evaluation.');
@@ -151,7 +166,7 @@ jobs:
                 owner,
                 repo,
                 issue_number: pr.number,
-                body: 'Automerge skipped: this PR changes protected CI/CD, auth, payment, deployment, or database files and needs a human merge.',
+                body: 'Automerge skipped: this PR changes protected CI/CD, auth, payment, deployment, or database files and needs explicit human authorization before entering the merge queue.',
               });
               core.info(`PR #${pr.number} touches sensitive paths; skipping.`);
               return;
@@ -168,19 +183,32 @@ jobs:
               return;
             }
 
-            await github.rest.pulls.merge({
-              owner,
-              repo,
-              pull_number: pr.number,
-              merge_method: 'squash',
-              commit_title: freshPr.title,
-              commit_message: `Automerge PR #${pr.number} after successful CI.`,
-              sha: freshPr.head.sha,
-            });
+            const state = await getProtectedMergeState(pr.number);
+            const protectedPr = state.repository.pullRequest;
+            if (protectedPr.mergeQueueEntry) {
+              core.info(`PR #${pr.number} is already in the merge queue at position ${protectedPr.mergeQueueEntry.position}.`);
+              return;
+            }
+            if (protectedPr.autoMergeRequest) {
+              core.info(`PR #${pr.number} already has native auto-merge armed.`);
+              return;
+            }
+
+            await github.graphql(
+              `mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: SQUASH
+                }) {
+                  pullRequest { number }
+                }
+              }`,
+              { pullRequestId: protectedPr.id },
+            );
 
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pr.number,
-              body: `Automerge completed after successful ${requiredWorkflowName}. CD will run from main and gate production through staging E2E and native install smoke tests.`,
+              body: `Automerge authorized after successful ${requiredWorkflowName}. GitHub's protected merge/merge queue now owns the final merge and merge-group revalidation; this workflow does not directly merge into main.`,
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   merge_group:
+    types:
+      - checks_requested
     branches:
       - main
   push:
@@ -13,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -33,45 +35,170 @@ jobs:
       mcp: ${{ steps.classify.outputs.mcp }}
       workflows: ${{ steps.classify.outputs.workflows }}
       electron: ${{ steps.classify.outputs.electron }}
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      unknown: ${{ steps.classify.outputs.unknown }}
     steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 1
       - id: classify
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
-          FORCE_ALL: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
-        run: |
-          set -euo pipefail
-          if [ "$FORCE_ALL" = "true" ] || [ -z "$BASE_SHA" ]; then
-            frontend=true
-            worker=true
-            mcp=true
-            workflows=true
-            electron=true
-          else
-            git fetch --no-tags --depth=1 origin "$BASE_SHA"
-            changed="$(git diff --name-only "$BASE_SHA" HEAD)"
-            printf '%s\n' "$changed" >> "$GITHUB_STEP_SUMMARY"
-            frontend=false
-            worker=false
-            mcp=false
-            workflows=false
-            electron=false
-            if printf '%s\n' "$changed" | grep -Eq '^(frontend/|contracts/automation/cross-platform-journeys\.json$)'; then frontend=true; fi
-            if printf '%s\n' "$changed" | grep -Eq '^(fabushi/web/|third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/)'; then worker=true; fi
-            if printf '%s\n' "$changed" | grep -Eq '^(\.agents/plugins/|ai-backend/|frontend/packages/mcp-app-sdk/|plugins/)'; then mcp=true; fi
-            if printf '%s\n' "$changed" | grep -Eq '^\.github/workflows/'; then workflows=true; fi
-            if printf '%s\n' "$changed" | grep -Eq '^(\.github/scripts/(assert-electron-feature-host-bridge\.sh|assert-feature-command-router-coverage\.py|assert-fabushi-desktop-architecture\.py)$|desktop/electron/|desktop/src/|frontend/apps/host/|frontend/apps/web/src/app/(host|remote-computer)/|frontend/apps/web/src/lib/(fabushi-runtime|mahayana-host|remote-computer)/|third_party/mahayana/mahayana-rs/(mahayana-agent-codex/|mahayana-app-host/|mahayana-computer/|mahayana-feature-host/|mahayana-host-protocol/))'; then electron=true; fi
-          fi
-          echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
-          echo "worker=$worker" >> "$GITHUB_OUTPUT"
-          echo "mcp=$mcp" >> "$GITHUB_OUTPUT"
-          echo "workflows=$workflows" >> "$GITHUB_OUTPUT"
-          echo "electron=$electron" >> "$GITHUB_OUTPUT"
-          printf 'frontend=%s worker=%s mcp=%s workflows=%s electron=%s\n' "$frontend" "$worker" "$mcp" "$workflows" "$electron" >> "$GITHUB_STEP_SUMMARY"
+        name: Classify changed paths without checkout
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const eventName = context.eventName;
+
+            const domainMatchers = {
+              frontend: [
+                /^frontend\//,
+                /^contracts\/automation\/cross-platform-journeys\.json$/,
+              ],
+              worker: [
+                /^fabushi\/web\//,
+                /^third_party\/mahayana\/mahayana-rs\/mahayana-platform-worker\/migrations\//,
+              ],
+              mcp: [
+                /^\.agents\/plugins\//,
+                /^ai-backend\//,
+                /^frontend\/packages\/mcp-app-sdk\//,
+                /^plugins\//,
+              ],
+              workflows: [
+                /^\.github\/workflows\//,
+              ],
+              electron: [
+                /^\.github\/scripts\/(assert-electron-feature-host-bridge\.sh|assert-feature-command-router-coverage\.py|assert-fabushi-desktop-architecture\.py)$/,
+                /^desktop\/electron\//,
+                /^desktop\/src\//,
+                /^frontend\/apps\/host\//,
+                /^frontend\/apps\/web\/src\/app\/(host|remote-computer)\//,
+                /^frontend\/apps\/web\/src\/lib\/(fabushi-runtime|mahayana-host|remote-computer)\//,
+                /^third_party\/mahayana\/mahayana-rs\/(mahayana-agent-codex\/|mahayana-app-host\/|mahayana-computer\/|mahayana-feature-host\/|mahayana-host-protocol\/)/,
+              ],
+            };
+
+            const isDocsSafe = (filename) =>
+              /^projects\//.test(filename) ||
+              /^docs\//.test(filename) ||
+              /^[^/]+\.md$/.test(filename) ||
+              /^\.github\/[^/]+\.md$/.test(filename);
+
+            async function compareFiles(base, head) {
+              if (!base || !head || /^0+$/.test(base)) {
+                return { files: [], forceAll: true, reason: 'missing or zero base/head SHA' };
+              }
+              const { data } = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${base}...${head}`,
+                per_page: 100,
+              });
+              const files = (data.files || []).map((file) => file.filename);
+              const forceAll = files.length >= 300;
+              return {
+                files,
+                forceAll,
+                reason: forceAll ? 'compare API reached the 300-file safety limit' : '',
+              };
+            }
+
+            let files = [];
+            let forceAll = false;
+            let forceReason = '';
+            let source = eventName;
+
+            if (eventName === 'workflow_dispatch') {
+              forceAll = true;
+              forceReason = 'manual dispatch intentionally validates all canonical domains';
+            } else if (eventName === 'pull_request') {
+              const pullNumber = context.payload.pull_request.number;
+              const changed = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                per_page: 100,
+              });
+              files = changed.map((file) => file.filename);
+              source = `pull_request #${pullNumber}`;
+            } else if (eventName === 'merge_group') {
+              const mergeGroup = context.payload.merge_group || {};
+              const compared = await compareFiles(mergeGroup.base_sha, mergeGroup.head_sha);
+              files = compared.files;
+              forceAll = compared.forceAll;
+              forceReason = compared.reason;
+              source = `merge_group ${mergeGroup.base_sha || '?'}..${mergeGroup.head_sha || '?'}`;
+            } else if (eventName === 'push') {
+              const compared = await compareFiles(context.payload.before, context.payload.after || context.sha);
+              files = compared.files;
+              forceAll = compared.forceAll;
+              forceReason = compared.reason;
+              source = `push ${context.payload.before || '?'}..${context.payload.after || context.sha}`;
+            } else {
+              forceAll = true;
+              forceReason = `unsupported event ${eventName}`;
+            }
+
+            const selected = {
+              frontend: false,
+              worker: false,
+              mcp: false,
+              workflows: false,
+              electron: false,
+            };
+
+            const matchesAnyDomain = (filename) => {
+              let matched = false;
+              for (const [domain, matchers] of Object.entries(domainMatchers)) {
+                if (matchers.some((matcher) => matcher.test(filename))) {
+                  selected[domain] = true;
+                  matched = true;
+                }
+              }
+              return matched;
+            };
+
+            const unknownFiles = [];
+            if (!forceAll) {
+              for (const filename of files) {
+                const matched = matchesAnyDomain(filename);
+                if (!matched && !isDocsSafe(filename)) {
+                  unknownFiles.push(filename);
+                }
+              }
+
+              if (unknownFiles.length > 0) {
+                forceAll = true;
+                forceReason = `unclassified non-document paths: ${unknownFiles.join(', ')}`;
+              }
+            }
+
+            if (forceAll) {
+              for (const domain of Object.keys(selected)) {
+                selected[domain] = true;
+              }
+            }
+
+            const docsOnly = !forceAll && files.length > 0 && files.every(isDocsSafe);
+            const unknown = unknownFiles.length > 0;
+
+            for (const [domain, value] of Object.entries(selected)) {
+              core.setOutput(domain, value ? 'true' : 'false');
+            }
+            core.setOutput('docs_only', docsOnly ? 'true' : 'false');
+            core.setOutput('unknown', unknown ? 'true' : 'false');
+
+            await core.summary
+              .addHeading('CI impact classification')
+              .addTable([
+                [{ data: 'Source', header: true }, source],
+                [{ data: 'Changed files', header: true }, String(files.length)],
+                [{ data: 'Docs-only fast path', header: true }, String(docsOnly)],
+                [{ data: 'Unknown non-doc paths', header: true }, String(unknown)],
+                [{ data: 'Force all canonical domains', header: true }, String(forceAll)],
+                [{ data: 'Reason', header: true }, forceReason || 'exact changed-path classification'],
+              ])
+              .addRaw(`\nfrontend=${selected.frontend} worker=${selected.worker} mcp=${selected.mcp} workflows=${selected.workflows} electron=${selected.electron}\n`)
+              .addDetails('Changed files', files.length ? files.map((file) => `- ${file}`).join('\n') : '(none)')
+              .write();
 
   frontend:
     name: Frontend checks

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   resolve-source:
-    name: Resolve Worker source
+    name: Resolve Worker source and deployment impact
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       source_sha: ${{ steps.source.outputs.source_sha }}
+      should_deploy: ${{ steps.impact.outputs.should_deploy }}
     steps:
       - name: Resolve source commit
         id: source
@@ -54,10 +55,46 @@ jobs:
           fi
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "Resolved Worker source: $source_sha"
+      - name: Check whether Worker deployment inputs changed
+        id: impact
+        uses: actions/github-script@v7
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          FORCE_DEPLOY: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          script: |
+            if (process.env.FORCE_DEPLOY === 'true') {
+              core.setOutput('should_deploy', 'true');
+              core.info('Manual dispatch explicitly requests a Worker deployment.');
+              return;
+            }
+
+            const { data: commit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.SOURCE_SHA,
+              per_page: 100,
+            });
+            const files = (commit.files || []).map((file) => file.filename);
+            const safetyLimitReached = files.length >= 300;
+            const relevant = files.some((filename) =>
+              filename.startsWith('fabushi/web/') ||
+              filename.startsWith('third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/'),
+            );
+            const shouldDeploy = safetyLimitReached || relevant;
+            core.setOutput('should_deploy', shouldDeploy ? 'true' : 'false');
+            await core.summary
+              .addHeading('Worker deployment impact')
+              .addRaw(`source=${process.env.SOURCE_SHA}\n`)
+              .addRaw(`changed_files=${files.length}\n`)
+              .addRaw(`should_deploy=${shouldDeploy}\n`)
+              .addRaw(safetyLimitReached ? 'reason=300-file safety limit reached; fail-safe deploy\n' : '')
+              .write();
 
   deploy-staging:
     name: Deploy staging Worker
     needs: resolve-source
+    if: needs.resolve-source.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/.github/workflows/fabushi-pay-production.yml
+++ b/.github/workflows/fabushi-pay-production.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   resolve-source:
-    name: Resolve Fabushi Pay source
+    name: Resolve Fabushi Pay source and deployment impact
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
@@ -35,6 +35,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       source_sha: ${{ steps.source.outputs.source_sha }}
+      should_deploy: ${{ steps.impact.outputs.should_deploy }}
     steps:
       - id: source
         name: Resolve source commit
@@ -51,10 +52,47 @@ jobs:
             source_sha="${{ github.sha }}"
           fi
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+      - id: impact
+        name: Check whether Fabushi Pay deployment inputs changed
+        uses: actions/github-script@v7
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          FORCE_DEPLOY: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          script: |
+            if (process.env.FORCE_DEPLOY === 'true') {
+              core.setOutput('should_deploy', 'true');
+              core.info('Manual dispatch explicitly requests a Fabushi Pay deployment.');
+              return;
+            }
+
+            const { data: commit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.SOURCE_SHA,
+              per_page: 100,
+            });
+            const files = (commit.files || []).map((file) => file.filename);
+            const safetyLimitReached = files.length >= 300;
+            const relevant = files.some((filename) =>
+              filename.startsWith('third_party/mahayana/mahayana-rs/mahayana-pay-worker/') ||
+              filename.startsWith('third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/') ||
+              filename === 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/payment_api.rs',
+            );
+            const shouldDeploy = safetyLimitReached || relevant;
+            core.setOutput('should_deploy', shouldDeploy ? 'true' : 'false');
+            await core.summary
+              .addHeading('Fabushi Pay deployment impact')
+              .addRaw(`source=${process.env.SOURCE_SHA}\n`)
+              .addRaw(`changed_files=${files.length}\n`)
+              .addRaw(`should_deploy=${shouldDeploy}\n`)
+              .addRaw(safetyLimitReached ? 'reason=300-file safety limit reached; fail-safe deploy\n' : '')
+              .write();
 
   deploy-production:
     name: Migrate and deploy Fabushi Pay
     needs: resolve-source
+    if: needs.resolve-source.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:

--- a/projects/fabushi-cicd-merge-governance/PROJECT.yaml
+++ b/projects/fabushi-cicd-merge-governance/PROJECT.yaml
@@ -1,0 +1,10 @@
+project_id: FCM
+name: Fabushi CI/CD & Merge Governance
+slug: fabushi-cicd-merge-governance
+status: active
+repository: bhrumom/fabushi
+authoritative_branch: main
+authoritative_path: projects/fabushi-cicd-merge-governance
+created_at: 2026-08-22
+updated_at: 2026-08-22
+current_stage: g0-fast-safe-merge

--- a/projects/fabushi-cicd-merge-governance/README.md
+++ b/projects/fabushi-cicd-merge-governance/README.md
@@ -1,0 +1,37 @@
+# Fabushi CI/CD & Merge Governance
+
+## Objective
+
+把 Fabushi 的 CI/CD 和合并链路优化为高吞吐、低等待、可审计的工程体系：文档/治理类变更走极轻量快车道；代码按影响域执行最小必需测试；所有进入 `main` 的 PR 仍通过 merge queue 在最新主干组合上重新验证；生产部署只在对应产品域真实变化时触发。
+
+## Current status
+
+`active`
+
+## Current stage
+
+G0 — diagnose and optimize required CI / merge queue / post-merge CD.
+
+## Canonical source
+
+- Repository: `bhrumom/fabushi`
+- Branch after merge: `main`
+- Path: `projects/fabushi-cicd-merge-governance/`
+- Original requirement: `source/README.md`
+
+## Key acceptance targets
+
+- 文档/项目治理-only PR 不再在 merge queue 强制运行全部产品测试。
+- merge queue 仍执行必需 `CI result`，但按 merge-group 实际 diff 分类。
+- 未分类的非文档代码默认 fail-safe 为全量 canonical checks，而不是静默放行。
+- 自动合并只负责授权/进入 merge queue，不直接绕过主干保护。
+- Worker / Fabushi Pay CD 不因纯文档 main push 触发完整生产部署。
+- CI/CD 敏感变更继续由 PR + required check + merge queue 进入主干。
+
+## Navigation
+
+- `SOURCE_OF_TRUTH.md`
+- `docs/02-enterprise-cicd-model.md`
+- `docs/19-完成定义与验收.md`
+- `management/01-WBS原子任务.md`
+- `management/tasks/FCM-001-fast-safe-ci-merge.md`

--- a/projects/fabushi-cicd-merge-governance/SOURCE_OF_TRUTH.md
+++ b/projects/fabushi-cicd-merge-governance/SOURCE_OF_TRUTH.md
@@ -1,0 +1,18 @@
+# Source of Truth
+
+Canonical project record: `bhrumom/fabushi` `main` → `projects/fabushi-cicd-merge-governance/`.
+
+## Requirement source
+
+`source/README.md` preserves the user requirement and the diagnosed cause.
+
+## Precedence
+
+1. Latest explicit user requirement once persisted here.
+2. This file and `source/`.
+3. Accepted ADRs and current CI/CD model docs.
+4. WBS, acceptance matrix, status, risk and task records.
+5. Actual GitHub workflow files, rules/check results, PRs, merge queue and deployments for implementation facts.
+6. Conversation memory.
+
+No workflow is considered optimized merely because a document says so; objective GitHub Actions and merge evidence is required.

--- a/projects/fabushi-cicd-merge-governance/decisions/ADR-0001-risk-tiered-ci-merge-queue.md
+++ b/projects/fabushi-cicd-merge-governance/decisions/ADR-0001-risk-tiered-ci-merge-queue.md
@@ -1,0 +1,16 @@
+# ADR-0001 — Risk-tiered CI with merge queue retained
+
+- **Status:** Accepted
+- **Date:** 2026-08-22
+
+## Context
+
+The repository already has a protected `main` and merge queue, but current merge-group handling forces every canonical product test for every change, creating unnecessary latency and cost.
+
+## Decision
+
+Retain PR checks, aggregate required `CI result`, merge queue and merge-group validation. Select internal checks by actual changed domains on both PR and merge-group candidates. Treat explicitly safe documentation/project paths as Tier 0 and unknown non-doc paths as fail-safe all-checks. Production deployment is separately change-aware.
+
+## Consequences
+
+Low-risk changes become fast without bypassing protected-main safety. Classifier maintenance becomes a governed CI concern; unknown paths deliberately cost more until classified.

--- a/projects/fabushi-cicd-merge-governance/decisions/README.md
+++ b/projects/fabushi-cicd-merge-governance/decisions/README.md
@@ -1,0 +1,3 @@
+# Decisions
+
+- ADR-0001: risk-tiered CI with merge queue retained.

--- a/projects/fabushi-cicd-merge-governance/docs/00-项目章程.md
+++ b/projects/fabushi-cicd-merge-governance/docs/00-项目章程.md
@@ -1,0 +1,16 @@
+# 项目章程
+
+## Purpose
+
+建设高吞吐、低等待、主干始终可发布的 Fabushi CI/CD 与合并治理体系。
+
+## Principles
+
+- Trunk-based / short-lived branch.
+- One required aggregate gate (`CI result`) with domain-selected internal jobs.
+- Merge queue validates the exact candidate on top of latest `main`.
+- Risk-tiered checks: documentation is cheap; product/runtime and sensitive infrastructure are strict.
+- Fail closed for unknown runtime paths.
+- No direct/force merge to `main`.
+- CD is change-aware and promotion-based; unrelated changes do not deploy unrelated products.
+- Expensive tests/builds are parallelized and cached; they do not block unrelated changes.

--- a/projects/fabushi-cicd-merge-governance/docs/01-范围与非目标.md
+++ b/projects/fabushi-cicd-merge-governance/docs/01-范围与非目标.md
@@ -1,0 +1,18 @@
+# 范围与非目标
+
+## In scope
+
+- `.github/workflows/ci.yml` impact classification and merge-group behavior.
+- queue-aware automerge behavior.
+- Worker and Fabushi Pay post-main deployment impact gates.
+- `.github/BRANCH_PROTECTION.md` enterprise merge policy.
+- objective CI timing/result evidence for this change.
+
+## Out of scope for FCM-001
+
+- Rewriting every legacy workflow in one PR.
+- Bypassing branch protection or merge queue for speed.
+- Removing security/auth/payment review requirements.
+- Self-hosted runners.
+
+Further cache/build/test decomposition can continue as later FCM tasks after the critical merge-group bug is fixed.

--- a/projects/fabushi-cicd-merge-governance/docs/02-enterprise-cicd-model.md
+++ b/projects/fabushi-cicd-merge-governance/docs/02-enterprise-cicd-model.md
@@ -1,0 +1,37 @@
+# Enterprise CI/CD & Merge Model
+
+## Merge lifecycle
+
+`branch -> PR impact classification -> selected required checks -> CI result -> merge queue -> merge-group impact classification -> selected checks -> main -> change-aware CD`
+
+## Risk tiers
+
+### Tier 0 — docs / project governance
+
+Examples: `projects/**`, repository-root Markdown, `.github/*.md`.
+
+Required path: classifier + aggregate `CI result`; merge queue remains mandatory but must not force unrelated product suites.
+
+### Tier 1 — product-domain code
+
+Run only checks mapped to affected domains (Frontend, Worker, MCP, Electron, etc.). If multiple domains change, run them in parallel.
+
+### Tier 2 — unknown/unclassified runtime path
+
+Fail safe by selecting all canonical checks. Never silently mark green simply because the path classifier does not know the file.
+
+### Tier 3 — sensitive delivery/security infrastructure
+
+CI/CD workflows/actions/scripts, auth, payment, deployment and database-sensitive paths are not eligible for unattended direct merging. They require explicit authorization and merge queue validation.
+
+## Merge queue
+
+The merge queue is retained because it validates a synthetic candidate containing the PR on top of the latest target branch/queued changes. `merge_group.base_sha..head_sha` must be classified exactly like a PR diff; merge-group events must not blindly force all domains.
+
+## Automerge
+
+Automerge is an authorization mechanism, not a protection bypass. An authorized low-risk PR may be armed/enqueued automatically only after its PR-head CI is green. GitHub merge queue still owns the final merge and reruns the required gate on the merge-group candidate.
+
+## CD
+
+Production workflows triggered after successful main CI must independently determine whether their product domain changed. If not, they exit at the lightweight resolver stage. A docs-only merge must never run migrations or production deploy steps for Worker or Fabushi Pay.

--- a/projects/fabushi-cicd-merge-governance/docs/19-完成定义与验收.md
+++ b/projects/fabushi-cicd-merge-governance/docs/19-完成定义与验收.md
@@ -1,0 +1,15 @@
+# 完成定义与验收
+
+FCM-001 is complete only when all required items pass:
+
+1. `merge_group` no longer forces every canonical product CI job.
+2. PR and merge-group classification use the correct base/head SHAs and are change-aware.
+3. Known docs/project-only diffs select no product-domain jobs while still producing successful required `CI result`.
+4. Unknown non-doc runtime paths fail safe to all canonical checks.
+5. Workflow-file changes still run workflow guardrails.
+6. Custom automerge no longer attempts a direct REST merge that conflicts with required merge queue; it authorizes/enqueues through GitHub-native protected merge behavior.
+7. Worker CD skips heavy deployment when the validated main commit did not change Worker deployment inputs.
+8. Fabushi Pay CD skips heavy deployment when the validated main commit did not change payment deployment inputs.
+9. Branch protection documentation describes risk tiers, aggregate check and merge-queue policy.
+10. The implementation PR's required CI succeeds and the PR itself lands through merge queue.
+11. Post-merge project records capture actual timings/results and remaining optimization work.

--- a/projects/fabushi-cicd-merge-governance/evidence/FCM-001/README.md
+++ b/projects/fabushi-cicd-merge-governance/evidence/FCM-001/README.md
@@ -1,0 +1,12 @@
+# FCM-001 Evidence
+
+Status: implementation pending.
+
+Planned evidence:
+
+- PR and head SHA;
+- PR CI run and job selection;
+- merge queue / merge-group CI run and job selection;
+- final merge SHA;
+- before/after latency observations;
+- canonical workflow paths on `main`.

--- a/projects/fabushi-cicd-merge-governance/evidence/README.md
+++ b/projects/fabushi-cicd-merge-governance/evidence/README.md
@@ -1,0 +1,3 @@
+# Evidence
+
+Task evidence is indexed under `evidence/<task-id>/`. Do not store secrets or large artifacts.

--- a/projects/fabushi-cicd-merge-governance/management/00-路线图.md
+++ b/projects/fabushi-cicd-merge-governance/management/00-路线图.md
@@ -1,0 +1,17 @@
+# 路线图
+
+## G0 — Fast safe merge
+
+Fix merge-group over-testing, fail-safe impact classification, queue-aware automerge, and unrelated production deploy triggers.
+
+## G1 — CI latency budget
+
+Measure P50/P95 by change tier, reduce checkout/setup time, reuse caches, split slow tests, and establish latency SLOs.
+
+## G2 — Release train / deployment promotion
+
+Standardize artifact promotion, environment gates, rollback evidence, and release observability across web/worker/desktop/mobile.
+
+## G3 — Policy automation
+
+Add CODEOWNERS/ruleset/PR policy automation where it materially improves safety without slowing low-risk changes.

--- a/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
@@ -1,0 +1,11 @@
+# WBS 原子任务
+
+| Task ID | Atomic task | Required | Acceptance | Status |
+|---|---|---:|---|---|
+| FCM-001.1 | Fix merge-group impact classification | yes | merge-group diff no longer force-all; correct base/head | in-progress |
+| FCM-001.2 | Add docs fast path + unknown fail-safe | yes | docs selects no product jobs; unknown code selects all | in-progress |
+| FCM-001.3 | Make automerge merge-queue-aware | yes | no direct protected-branch REST merge | in-progress |
+| FCM-001.4 | Gate Worker CD by changed inputs | yes | docs-only main push skips deploy | in-progress |
+| FCM-001.5 | Gate Fabushi Pay CD by changed inputs | yes | docs-only main push skips deploy | in-progress |
+| FCM-001.6 | Update enterprise branch/merge policy | yes | policy matches implementation | in-progress |
+| FCM-001.7 | Validate PR + merge queue + record timing | yes | CI success and merge through queue | not-started |

--- a/projects/fabushi-cicd-merge-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-cicd-merge-governance/management/03-验收追踪矩阵.md
@@ -1,0 +1,11 @@
+# 验收追踪矩阵
+
+| Requirement | Planned evidence | Status |
+|---|---|---|
+| docs merge-group does not force all | `ci.yml` diff + PR/merge-group jobs | in-progress |
+| unknown code fails safe | classifier implementation + workflow test | in-progress |
+| merge queue retained | PR queue evidence | in-progress |
+| automerge queue-aware | `automerge.yml` implementation | in-progress |
+| unrelated Worker deploy skipped | `deploy-production.yml` resolver output | in-progress |
+| unrelated Pay deploy skipped | `fabushi-pay-production.yml` resolver output | in-progress |
+| enterprise policy documented | `.github/BRANCH_PROTECTION.md` | in-progress |

--- a/projects/fabushi-cicd-merge-governance/management/04-风险登记.md
+++ b/projects/fabushi-cicd-merge-governance/management/04-风险登记.md
@@ -1,0 +1,9 @@
+# 风险登记
+
+| Risk | Impact | Mitigation | Status |
+|---|---|---|---|
+| path classifier misses runtime file | unsafe green merge | unknown non-doc paths force all canonical checks | active |
+| merge-group diff classification wrong | stale/incompatible merge | use official merge_group base_sha/head_sha and keep required CI result | active |
+| CD impact gate false-negative | required deploy skipped | fail safe on API/large-diff uncertainty; manual dispatch retained | active |
+| sensitive CI change auto-merges | delivery policy regression | keep CI/CD paths sensitive; explicit authorization + merge queue | active |
+| optimizing for speed reduces coverage | regressions | risk-tiered, not test-removal; queue remains final gate | active |

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -1,0 +1,8 @@
+# 状态报告
+
+## 2026-08-22 — FCM-001 Round 1
+
+- Diagnosed: `ci.yml` explicitly sets `FORCE_ALL=true` on every `merge_group`, causing documentation changes to run every product suite in the queue.
+- Diagnosed: Worker and Fabushi Pay production workflows trigger after any successful main-push CI without product-domain change gating.
+- Confirmed: GitHub merge queue itself should remain; official GitHub behavior requires a `merge_group` required check but does not require unrelated suites.
+- Next: implement change-aware merge-group classification, CD impact gates and queue-aware automerge in one governed PR.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -1,0 +1,6 @@
+# 变更日志
+
+## 2026-08-22
+
+- Created `projects/fabushi-cicd-merge-governance/` for repository-wide CI/CD and merge optimization.
+- Adopted risk-tiered CI, required aggregate gate, merge-group diff classification, queue-owned final merge, and change-aware CD as the target model.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-001-fast-safe-ci-merge.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-001-fast-safe-ci-merge.md
@@ -3,7 +3,7 @@
 - **Task ID:** FCM-001
 - **Status:** in-progress
 - **Started:** 2026-08-22T13:43:00+08:00
-- **Updated:** 2026-08-22T13:51:00+08:00
+- **Updated:** 2026-08-22T13:55:00+08:00
 
 ## Objective
 
@@ -21,7 +21,7 @@ See `../../docs/19-完成定义与验收.md`.
 
 - `.github/workflows/ci.yml`
   - merge-group now uses exact `base_sha..head_sha` impact classification instead of force-all;
-  - classifier no longer needs repository checkout for path discovery;
+  - classifier discovers changed paths through GitHub APIs without a repository checkout;
   - Tier-0 documentation/project paths select no unrelated product suites;
   - unknown non-document paths fail safe by selecting all canonical domains;
   - merge-group trigger is explicitly limited to `checks_requested`.
@@ -47,16 +47,20 @@ See `../../docs/19-完成定义与验收.md`.
 
 - Branch: `project/fabushi-cicd-merge-governance`
 - Bootstrap commit: `c7581c7b21070e17e3a344d1b079bec51f59d46a`
-- PR: pending creation.
+- PR: #1978
 
-## Evidence
+## Evidence so far
 
-Pending PR/CI/merge evidence.
+- PR #1978 opened with 24 changed files.
+- PR-head CI run `32555241279` parsed the new workflow successfully.
+- `Classify CI changes` completed successfully without checkout.
+- For this CI/CD-only diff, Frontend, Worker, MCP and Electron jobs were skipped; only `Canonical architecture guardrails` was selected and it passed.
+- Final required `CI result` / merge-group validation remain pending after this record update.
 
 ## Risks
 
-Workflow files are sensitive delivery infrastructure, so this task must not use unattended automerge. It requires explicit authorization plus required CI and merge-queue validation.
+Workflow files are sensitive delivery infrastructure, so this task must not use unattended automerge. The user's explicit request authorizes proceeding, but the change still requires successful required CI and GitHub merge-queue validation.
 
 ## Next action
 
-Create the implementation PR, inspect workflow parsing and required CI, fix any failures, then enqueue explicitly after green checks.
+Let the updated PR rerun required CI, then explicitly enqueue the green PR into the merge queue and inspect merge-group job selection before merge.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-001-fast-safe-ci-merge.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-001-fast-safe-ci-merge.md
@@ -3,7 +3,7 @@
 - **Task ID:** FCM-001
 - **Status:** in-progress
 - **Started:** 2026-08-22T13:43:00+08:00
-- **Updated:** 2026-08-22T13:43:00+08:00
+- **Updated:** 2026-08-22T13:51:00+08:00
 
 ## Objective
 
@@ -17,30 +17,46 @@ Remove unnecessary CI/CD latency for documentation and low-impact changes while 
 
 See `../../docs/19-完成定义与验收.md`.
 
-## Planned implementation
+## Implementation
 
 - `.github/workflows/ci.yml`
+  - merge-group now uses exact `base_sha..head_sha` impact classification instead of force-all;
+  - classifier no longer needs repository checkout for path discovery;
+  - Tier-0 documentation/project paths select no unrelated product suites;
+  - unknown non-document paths fail safe by selecting all canonical domains;
+  - merge-group trigger is explicitly limited to `checks_requested`.
 - `.github/workflows/automerge.yml`
+  - removes direct protected-branch REST merge behavior;
+  - arms GitHub-native auto-merge/protected merge so merge queue owns final merge-group validation.
 - `.github/workflows/deploy-production.yml`
+  - lightweight source-impact resolver skips Worker staging/migration/deploy when Worker inputs did not change.
 - `.github/workflows/fabushi-pay-production.yml`
+  - lightweight source-impact resolver skips payment migration/deploy when payment inputs did not change.
 - `.github/BRANCH_PROTECTION.md`
+  - codifies risk tiers, aggregate `CI result`, merge-queue ownership, change-aware CD and latency policy.
 
 ## Verification
 
-- PR-head required CI result.
-- Inspect selected/skipped job set.
+- PR-head required `CI result`.
+- Inspect selected/skipped job set for this CI/CD-only change.
 - Merge through GitHub merge queue.
-- Inspect merge-group selected/skipped job set.
+- Inspect merge-group selected/skipped job set; it should not force Frontend/Worker/MCP/Electron solely because of `merge_group`.
 - Verify canonical main workflow files.
 
 ## Branch / PR
 
-Pending.
+- Branch: `project/fabushi-cicd-merge-governance`
+- Bootstrap commit: `c7581c7b21070e17e3a344d1b079bec51f59d46a`
+- PR: pending creation.
 
 ## Evidence
 
-Pending.
+Pending PR/CI/merge evidence.
+
+## Risks
+
+Workflow files are sensitive delivery infrastructure, so this task must not use unattended automerge. It requires explicit authorization plus required CI and merge-queue validation.
 
 ## Next action
 
-Create governed implementation branch and patch workflows.
+Create the implementation PR, inspect workflow parsing and required CI, fix any failures, then enqueue explicitly after green checks.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-001-fast-safe-ci-merge.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-001-fast-safe-ci-merge.md
@@ -1,0 +1,46 @@
+# FCM-001 — Fast, Safe CI & Merge Queue
+
+- **Task ID:** FCM-001
+- **Status:** in-progress
+- **Started:** 2026-08-22T13:43:00+08:00
+- **Updated:** 2026-08-22T13:43:00+08:00
+
+## Objective
+
+Remove unnecessary CI/CD latency for documentation and low-impact changes while preserving enterprise-grade protected-main and merge-queue safety.
+
+## Source requirement
+
+`../../source/README.md`
+
+## Acceptance criteria
+
+See `../../docs/19-完成定义与验收.md`.
+
+## Planned implementation
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/automerge.yml`
+- `.github/workflows/deploy-production.yml`
+- `.github/workflows/fabushi-pay-production.yml`
+- `.github/BRANCH_PROTECTION.md`
+
+## Verification
+
+- PR-head required CI result.
+- Inspect selected/skipped job set.
+- Merge through GitHub merge queue.
+- Inspect merge-group selected/skipped job set.
+- Verify canonical main workflow files.
+
+## Branch / PR
+
+Pending.
+
+## Evidence
+
+Pending.
+
+## Next action
+
+Create governed implementation branch and patch workflows.

--- a/projects/fabushi-cicd-merge-governance/source/README.md
+++ b/projects/fabushi-cicd-merge-governance/source/README.md
@@ -1,0 +1,15 @@
+# Original Requirement
+
+User requirement, 2026-08-22:
+
+> 优化cicd，为什么你更新文档也要这么久？，还有合并这些都按照大厂的流程来做
+
+## Diagnosed cause
+
+Current `.github/workflows/ci.yml` sets `FORCE_ALL=true` for every `merge_group` event. As a result, even project-document-only changes that correctly skip product jobs on the PR head are forced through Frontend, Worker, MCP, workflow and Electron checks again after entering the merge queue.
+
+The repository also has production workflows triggered by any successful `CI` workflow on a `main` push; without product-domain impact gating, documentation-only merges can start heavyweight Worker/Fabushi Pay deployment workflows.
+
+## Required outcome
+
+Keep the safety properties of PR review, required checks and merge queue while making validation proportional to risk and changed domains, with explicit fail-safe behavior for unknown code paths.


### PR DESCRIPTION
## Summary
- fix `merge_group` so it classifies the actual queued diff instead of forcing every product suite
- add a Tier-0 docs/project fast path while keeping required `CI result`
- fail safe on unknown non-doc paths by selecting all canonical domains
- make custom automerge authorize GitHub-native protected merging instead of direct REST merge
- skip Worker and Fabushi Pay production deployment chains when the validated main commit did not change those product inputs
- document the enterprise merge/CI/CD policy
- create `projects/fabushi-cicd-merge-governance/` and track this as `FCM-001`

## Why
The old CI set `FORCE_ALL=true` for every merge-group event. A docs-only PR could be fast on its PR head, then become expensive again in merge queue by running Frontend, Worker, MCP and Electron suites. Post-main Worker/Pay CD also lacked product-impact gating.

## Safety
- required aggregate check remains `CI result`
- merge queue remains mandatory and revalidates the synthetic queued candidate
- workflow/CI/CD paths remain sensitive and are not eligible for unattended automerge
- unknown runtime paths fail safe
- manual CD dispatch still forces an explicit deploy

## Task
`FCM-001`

This PR changes CI/CD infrastructure and should merge only after explicit review/authorization, successful required CI, and merge-queue validation.