### PR TITLE
docs: adopt enterprise project standard across agents and skills

### DIFF
--- a/.agent/skills/fabushi-project-governance/SKILL.md
+++ b/.agent/skills/fabushi-project-governance/SKILL.md
@@ -1,96 +1,135 @@
 ---
 name: fabushi-project-governance
-description: Govern Fabushi engineering work through durable GitHub project folders. Use for any Fabushi task that starts, continues, finishes, changes scope, creates a new independent workstream, updates a project plan, merges code, verifies CI, or needs a persistent execution record. Treat `bhrumom/fabushi` GitHub `main` and its `projects/project-slug/` folders as the authoritative project documentation source. Reuse an existing project folder for continuations; create a new standardized project folder for a genuinely different task/workstream. Before declaring work complete, update the project status, WBS/acceptance state, changelog, evidence, and GitHub commit/PR references in that folder.
+description: Govern every Fabushi repository task through durable, enterprise-standard GitHub project folders. Use for any implementation, bug fix, refactor, investigation, release, migration, documentation change, AGENTS.md change, Skill creation/update, CI/CD or merge-policy change, architecture/governance change, or follow-up round. Treat `bhrumom/fabushi` GitHub `main` and `projects/<project-slug>/` as the authoritative engineering project record. Reuse an existing matching project; create the full standard project folder before substantial work when none exists; and do not declare completion until WBS, acceptance, status, changelog, evidence, and GitHub facts are synchronized.
 ---
 
 # Fabushi Project Governance
 
 ## Core rule
 
-Treat GitHub as the durable project system of record.
+Treat GitHub as Fabushi's durable engineering project system of record.
 
 - Repository: `bhrumom/fabushi` unless the user explicitly names another repository.
-- Authoritative branch: `main` after changes are merged.
+- Authoritative branch: `main` after merge.
 - Authoritative project root: `projects/<project-slug>/`.
-- For an existing project, read `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, relevant `docs/`, `decisions/`, and `management/` files.
-- Use chat messages, Google Drive files, emails, and local files as intake/reference material. Do not let them silently override the GitHub project folder.
-- Verify code, PR, CI, release, and deployment facts against GitHub rather than documentation claims.
+- Read repository/root/nested `AGENTS.md` instructions before substantial work.
+- For an existing project, read `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, `OWNERS.md`, relevant `source/`, `docs/`, `decisions/`, `management/`, `evidence/`, and `runbooks/` files.
+- Use chat, Google Drive, Gmail, Calendar, and local files as intake/reference material unless the project explicitly designates otherwise. They must not silently override the GitHub project folder.
+- Verify code, PR, CI, release, and deployment facts against GitHub/live systems rather than documentation claims.
 
-Read `references/project-folder-standard.md` when creating or restructuring a project folder. Read `references/task-lifecycle.md` for every execution round.
+Read `references/project-folder-standard.md` whenever creating, restructuring, auditing, or migrating a project folder. Read `references/task-lifecycle.md` for every execution round.
+
+## No meta-work exemptions
+
+Project governance applies to repository infrastructure itself.
+
+The following are normal governed tasks and must locate/reuse or create a project folder before substantial work:
+
+- root or nested `AGENTS.md` changes;
+- Skill creation, update, packaging, installation, or removal;
+- CI/CD, workflow, merge queue, automerge, branch protection, or release-policy changes;
+- repository-wide architecture/governance standards;
+- documentation-system changes;
+- build/release tooling changes;
+- security/governance automation.
+
+If the objective belongs to an existing governance project, reuse it. Do not create a new project just because the task is about agents or Skills.
 
 ## Decide whether to reuse or create
 
 1. Search `projects/` on `main` before creating anything.
-2. Reuse an existing project folder when the request is a continuation, refinement, bug fix, implementation stage, verification round, or release step for the same objective.
-3. Create a new `projects/<project-slug>/` folder when the user starts a genuinely different objective/workstream with its own scope and completion criteria.
-4. Do not create duplicate folders just because the conversation is new.
+2. Reuse an existing project folder when the request is a continuation, refinement, bug fix, implementation stage, verification round, migration, release step, or governance update for the same objective.
+3. Create a new `projects/<project-slug>/` folder only when the user starts a genuinely independent objective/workstream with its own scope and completion criteria.
+4. Do not create duplicate folders because a conversation, branch, PR, or agent session is new.
 5. If two folders overlap materially, select one canonical folder and record the consolidation decision before further work.
+
+## Enterprise project-folder gate
+
+When a new project is needed, create the mandatory scaffold in `references/project-folder-standard.md` before substantial implementation.
+
+The standard includes:
+
+- `README.md`, `PROJECT.yaml`, `SOURCE_OF_TRUTH.md`, `OWNERS.md`;
+- original-source intake under `source/`;
+- charter, scope/non-goals, requirements/success metrics, architecture/implementation, quality/test strategy, release/migration/rollback, observability/SLO, security/privacy/compliance, and Definition of Done under `docs/`;
+- roadmap, WBS, milestones, acceptance traceability, risk register, status report, dependency/blocker register, changelog, issues/actions, and per-task records under `management/`;
+- ADRs under `decisions/`;
+- acceptance evidence under `evidence/`;
+- operational procedures under `runbooks/`.
+
+Do not leave mandatory standard files blank. If a document is not applicable, keep it and record `N/A`, reason, owner, and revisit trigger.
 
 ## Start every task from GitHub
 
 Before implementation:
 
-1. Read the current `main` project folder and reconstruct scope from it.
-2. Read current WBS, status, acceptance criteria, changelog, and relevant ADRs.
-3. Inspect current code/branches/PRs/CI needed for the task.
-4. Assign or reuse a stable task ID.
-5. Create/update `management/tasks/<task-id>-<slug>.md` with objective, dependencies, acceptance checks, planned evidence, status, and next action.
-6. Record any newly discovered requirement in the appropriate project document before or alongside implementation.
+1. Read current `main` project folder and reconstruct scope/state.
+2. Read current requirements, WBS, milestones, acceptance matrix, risks, dependencies, status report, changelog, open issues/actions, and relevant ADRs.
+3. Inspect current code/branches/PRs/CI/releases/deployments needed for the task.
+4. Assign or reuse a stable Task ID.
+5. Create/update `management/tasks/<task-id>-<slug>.md` with source requirements, scope, dependencies, acceptance checks, planned evidence, branch/PR, status, risks, and next action.
+6. Record newly discovered requirements in `source/` and/or the normalized specification before or alongside implementation.
 
-Do not rely on remembered requirements when the GitHub project folder can resolve them.
+Do not rely on remembered requirements when the project folder can resolve them.
 
 ## Execute with documentation in the same change stream
 
-- Prefer one task branch/PR containing both implementation and its project-record updates.
+- Prefer one task branch/PR containing implementation and project-record updates.
 - Avoid a second documentation-only PR when the active task PR can carry the records.
 - Keep project documentation factual: planned work is not completed work.
-- Record important architecture changes as ADRs under `decisions/`.
-- Record scope changes in source/requirements plus `management/07-变更日志.md`.
-- Store durable textual evidence or evidence indexes under `evidence/<task-id>/`; link large build artifacts, workflow runs, releases, PRs, or commits instead of copying binaries into the project folder.
+- Use stable requirement/task/milestone/risk/ADR identifiers.
+- Record durable architecture, protocol, security, data, deployment, CI/CD, governance, or vendor decisions as ADRs.
+- Record scope/requirement/design changes in source/spec plus `management/07-变更日志.md`.
+- Track dependencies/blockers in `management/06-依赖与阻塞.md` and open questions/actions in `management/08-问题与行动项.md`.
+- Store durable evidence or indexes under `evidence/<task-id>/`; link large build artifacts, workflow runs, releases, PRs, commits, or deployment checks instead of copying binaries.
+- Update runbooks when a task changes repeatable operational procedures.
 
 ## Completion gate
 
-Do not tell the user that a task is finished until the project folder has been updated for that task.
+Do not tell the user a task is finished until implementation, verification, evidence, protected merge state, and project records agree.
 
-At minimum, before completion:
+Before completion:
 
-1. Run the defined acceptance checks.
-2. Update `management/tasks/<task-id>-<slug>.md` with actual result and evidence.
+1. Run or inspect the defined objective acceptance checks.
+2. Update `management/tasks/<task-id>-<slug>.md` with actual result/evidence.
 3. Update `management/01-WBS原子任务.md` for affected task states.
-4. Update `management/03-验收追踪矩阵.md` when an acceptance item changed.
-5. Append the execution result to `management/05-状态报告.md`.
-6. Append a dated entry to `management/07-变更日志.md`.
-7. Update risk/ADR/roadmap documents if the task changed them.
-8. Record branch, commit SHA, PR number, CI/run/release evidence, blockers, and next action where applicable.
-9. Commit the record updates to GitHub in the same task change stream.
-10. Verify the resulting canonical state on GitHub `main` after merge. If merge is blocked, report the task as pending/blocked rather than complete.
+4. Update `management/02-里程碑.md` when a milestone gate changes.
+5. Update `management/03-验收追踪矩阵.md` when requirement/acceptance status changes.
+6. Append the round/result to `management/05-状态报告.md`.
+7. Append material changes to `management/07-变更日志.md`.
+8. Update risks, dependencies/blockers, issues/actions, roadmap, specs, ADRs, security docs, release/rollback docs, SLOs, or runbooks when affected.
+9. Record branch, commit SHA, PR number, CI/run/test/release/deployment evidence where applicable.
+10. Commit project-record changes in the same task change stream when possible.
+11. Merge through the repository's required protected-main process.
+12. Verify the canonical result on GitHub `main` after merge.
 
-A code push alone is not completion. A passing test without the required project record is not completion.
+If CI, review, merge queue, release, deployment, migration, or another required acceptance gate is pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete.
 
-## New independent task/workstream
-
-When a new request does not belong to an existing project:
-
-1. Create a unique lowercase kebab-case slug.
-2. Create `projects/<slug>/` using the minimum scaffold in `references/project-folder-standard.md`.
-3. Put the user's original requirement or linked source into `source/` or record a durable source pointer.
-4. Create `SOURCE_OF_TRUTH.md` defining precedence.
-5. Establish scope, architecture/implementation notes as needed, acceptance criteria, WBS, status, changelog, risks, and task log before substantial implementation.
-6. Add the first task record and begin work from that folder.
+A code push alone is not completion. A passing test without required project records is not completion. A project record claiming completion without live evidence is not completion.
 
 ## Source-of-truth precedence
 
-Use this precedence unless the project explicitly documents a stricter rule:
+Use this precedence unless the project documents a stricter rule:
 
-1. User's latest explicit scope change, once persisted into the GitHub project folder.
-2. `projects/<slug>/SOURCE_OF_TRUTH.md` and files it designates.
-3. Accepted ADRs and current project specs.
-4. Current management/WBS/status records.
-5. GitHub code/PR/CI/release facts for implementation state.
-6. External mirrors such as Google Drive.
+1. User's latest explicit requirement, once persisted into the GitHub project folder.
+2. `projects/<slug>/SOURCE_OF_TRUTH.md` and designated source files.
+3. Accepted ADRs and current normalized project specs.
+4. Current management/WBS/milestone/acceptance/status records.
+5. GitHub code/PR/CI/release/deployment facts for implementation state.
+6. External mirrors/control views such as Google Drive/Sheets.
 7. Conversation memory.
 
-If documentation conflicts with actual code/CI state, do not rewrite history silently. Record the discrepancy and update the project record with verified evidence.
+If documentation conflicts with actual implementation evidence, do not rewrite history silently. Record the discrepancy and correct project state with verified evidence.
+
+## Task Orchestration alignment
+
+When Task Orchestration is available, use the same Project ID, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links across the repository project folder and external control view.
+
+For Fabushi engineering work:
+
+- GitHub `projects/<slug>/` is the authoritative durable specification and execution record.
+- Google Sheets may be used as portfolio/control-plane view, not as a replacement for repository specifications or live engineering evidence.
+- Gmail/Drive/Calendar remain intake, external specification, scheduling, or reporting systems as appropriate.
 
 ## Final response requirements
 
@@ -100,8 +139,8 @@ For engineering work governed by this skill, report:
 - task ID;
 - implementation result;
 - acceptance/test result;
-- commit/PR/CI evidence;
+- commit/PR/CI/release/deployment evidence;
 - project documentation files updated;
 - remaining blocker or next action.
 
-Never claim the project record was updated unless the GitHub write actually succeeded.
+Never claim project records, Skill updates, CI changes, or canonical main state were updated unless the corresponding write/merge/verification actually succeeded.

--- a/.agent/skills/fabushi-project-governance/references/project-folder-standard.md
+++ b/.agent/skills/fabushi-project-governance/references/project-folder-standard.md
@@ -1,45 +1,61 @@
-# Fabushi GitHub project folder standard
+# Fabushi Enterprise GitHub Project Folder Standard
 
-## Canonical location
+## 1. Canonical location and identity
 
-All durable project folders live under:
+All durable Fabushi project folders live under:
 
 `projects/<project-slug>/`
 
-Use lowercase kebab-case slugs. A project folder represents one coherent objective/workstream, not one chat session.
+Use lowercase kebab-case. A project folder represents one coherent objective/workstream, not a chat session, branch, or individual PR.
 
-## Minimum scaffold for a new project
+Reuse an existing project when the request is a continuation, fix, migration, release, verification round, or refinement of the same objective. Create a new project only when scope, success criteria, and lifecycle are materially independent.
+
+## 2. Mandatory standard scaffold
+
+Create this scaffold for every new project:
 
 ```text
 projects/<project-slug>/
 ├── README.md
 ├── PROJECT.yaml
 ├── SOURCE_OF_TRUTH.md
+├── OWNERS.md
 ├── source/
 │   └── README.md
 ├── docs/
 │   ├── 00-项目章程.md
 │   ├── 01-范围与非目标.md
+│   ├── 02-需求与成功指标.md
+│   ├── 03-架构与实现策略.md
+│   ├── 04-质量与测试策略.md
+│   ├── 05-发布迁移与回滚.md
+│   ├── 06-运维可观测性与SLO.md
+│   ├── 07-安全隐私与合规.md
 │   └── 19-完成定义与验收.md
 ├── management/
 │   ├── 00-路线图.md
 │   ├── 01-WBS原子任务.md
+│   ├── 02-里程碑.md
 │   ├── 03-验收追踪矩阵.md
 │   ├── 04-风险登记.md
 │   ├── 05-状态报告.md
+│   ├── 06-依赖与阻塞.md
 │   ├── 07-变更日志.md
+│   ├── 08-问题与行动项.md
 │   └── tasks/
 ├── decisions/
 │   └── README.md
-└── evidence/
+├── evidence/
+│   └── README.md
+└── runbooks/
     └── README.md
 ```
 
-Add specialist docs only when the project needs them. Do not create empty ceremony for its own sake.
+Do not leave required files blank. If a standard document is genuinely not applicable, keep the file and state `N/A`, the reason, the owner for revisiting it, and the condition that would make it applicable.
 
-## Required metadata
+## 3. Required metadata
 
-`PROJECT.yaml` should include at least:
+`PROJECT.yaml` must include at least:
 
 ```yaml
 project_id: <stable-id>
@@ -49,77 +65,223 @@ status: active
 repository: bhrumom/fabushi
 authoritative_branch: main
 authoritative_path: projects/<project-slug>
+owner: <person/team/agent responsibility>
+reviewers: []
+current_stage: <stage-id-or-name>
 created_at: YYYY-MM-DD
 updated_at: YYYY-MM-DD
 ```
 
-## SOURCE_OF_TRUTH.md
+Recommended optional fields:
+
+```yaml
+risk_tier: tier-0|tier-1|tier-2|tier-3
+security_classification: public|internal|confidential|restricted
+target_finish: YYYY-MM-DD|null
+related_projects: []
+source_systems: []
+```
+
+Never store credentials, tokens, signing material, or other secrets.
+
+## 4. Root files
+
+### README.md
+
+Provide an onboarding-quality entry point containing objective, current verified status, current stage and next gate, scope/non-goals summary, source-of-truth pointer, owners/reviewers, primary acceptance definition, and navigation to specs, management, ADRs, evidence, and runbooks.
+
+A new engineer or agent must be able to understand the project without reading the originating chat.
+
+### SOURCE_OF_TRUTH.md
 
 State:
 
-- the authoritative repository, branch, and folder;
-- which source files carry original requirements;
-- precedence among source, specs, ADRs, management records, and external mirrors;
-- rule that GitHub code/CI/release evidence determines implementation facts;
-- rule that external Drive copies are mirrors/reference only unless explicitly promoted.
+- authoritative repository, branch, and project path;
+- original source/requirement files or external references;
+- precedence among latest persisted user requirements, source files, specs, ADRs, management state, GitHub/CI facts, external mirrors, and chat memory;
+- implementation-fact rule: code/PR/CI/release/deployment state must be verified from live systems;
+- conflict-resolution rule so corrections are recorded rather than silently rewriting history.
 
-## README.md
+### OWNERS.md
 
-Include:
+Define accountable owner, execution owner, required reviewers, consulted stakeholders, and escalation path. Use a lightweight RACI-style table when multiple teams are involved.
 
-- objective;
-- current status;
-- key scope;
-- canonical source links/paths;
-- current stage;
-- primary acceptance definition;
-- navigation to docs, management, decisions, evidence.
+## 5. Source intake
 
-## Management files
+`source/` preserves original requirements and durable pointers.
+
+Include original user/task requirements, linked email/file/issue/PR identifiers when applicable, external references needed to interpret scope, and dated requirement changes.
+
+Do not silently rewrite original source material. Put interpretation and normalized requirements in `docs/`.
+
+## 6. Product and engineering documents
+
+### `00-项目章程.md`
+
+State problem, objective, users/stakeholders, business value, constraints, assumptions, high-level deliverables, success definition, and governance model.
+
+### `01-范围与非目标.md`
+
+Maintain explicit in-scope and out-of-scope boundaries. Separate deferred items from rejected/non-goal items.
+
+### `02-需求与成功指标.md`
+
+Use stable requirement IDs. Define functional/non-functional requirements and measurable success metrics. Link critical requirements to acceptance criteria.
+
+### `03-架构与实现策略.md`
+
+Describe current state, target state, components, interfaces, data/control flow, deployment topology, compatibility/migration strategy, performance constraints, and major design tradeoffs. Link durable decisions to ADRs.
+
+### `04-质量与测试策略.md`
+
+Define unit/contract/integration/E2E/security/performance tests as applicable, test data strategy, environments, required CI checks, flaky-test handling, and evidence retention.
+
+### `05-发布迁移与回滚.md`
+
+Define rollout strategy, migration sequence, feature flags/canary when used, rollback triggers/steps, data rollback limits, release ownership, and post-release validation.
+
+### `06-运维可观测性与SLO.md`
+
+For runtime/user-facing systems, define SLI/SLO targets, logging/metrics/tracing, dashboards, alerts, runbook links, capacity assumptions, and incident signals. For non-runtime projects, mark N/A with reason.
+
+### `07-安全隐私与合规.md`
+
+Record data classes, authentication/authorization boundaries, threat considerations, secrets handling, privacy/compliance requirements, dependency/supply-chain risks, and required security review. Never store secrets.
+
+### `19-完成定义与验收.md`
+
+Define project-level Definition of Done. Every required criterion needs an objective verification method and evidence type. Distinguish implementation complete, release complete, migration complete, and project complete where they differ.
+
+## 7. Management documents
+
+### `00-路线图.md`
+
+Use a stage-based roadmap with entry/exit gates and explicit ordering/dependencies.
 
 ### `01-WBS原子任务.md`
-Use stable task IDs. Every required task has an acceptance criterion and objective verification method.
+
+Use stable task IDs. Every required task includes action, dependency, acceptance criterion, verification method, evidence requirement, status, blocker, and next action. Avoid subjective completion percentages.
+
+### `02-里程碑.md`
+
+Track milestone ID, target, required tasks/gates, planned date, actual date, status, and evidence.
 
 ### `03-验收追踪矩阵.md`
-Map requirements -> implementation/evidence -> status. Mark passed only when evidence exists.
+
+Trace:
+
+`Requirement -> Task/implementation -> Verification -> Evidence -> Status`
+
+Mark `passed` only when objective evidence exists.
+
+### `04-风险登记.md`
+
+Use a RAID-style register: risk ID, description, probability, impact, severity, owner, mitigation, trigger, contingency, status, and review date.
 
 ### `05-状态报告.md`
-Append round-by-round factual progress. Include date/time, task ID, completed work, tests, evidence, blockers, next action.
+
+Append-only round history. Record timestamp, task/stage, completed work, acceptance result, evidence, blocker/risk, next action, and verified progress change.
+
+### `06-依赖与阻塞.md`
+
+Track internal/external dependencies, required version/date/owner, blocking relation, fallback, and state.
 
 ### `07-变更日志.md`
-Append scope/design/implementation-record changes. Do not erase previous entries.
+
+Append scope, requirement, design, governance, migration, or implementation-record changes. Never erase prior entries to make history cleaner.
+
+### `08-问题与行动项.md`
+
+Track open question/action ID, owner, due date, decision deadline, resolution, and linked ADR/task when closed.
 
 ### `management/tasks/`
-Create one durable execution record per task/round when substantial work begins. File naming:
+
+Create one durable record for each substantial atomic task:
 
 `<task-id>-<short-slug>.md`
 
 Minimum fields:
 
-- Task ID
-- Objective
-- Source requirement
-- In scope / out of scope
-- Dependencies
-- Acceptance criteria
-- Verification commands/checks
-- Branch / PR
-- Status
-- Implementation summary
-- Evidence
-- Blockers/risks
-- Next action
-- Started/updated/completed timestamps
+- stable Task ID;
+- objective;
+- source requirement IDs/references;
+- in scope / out of scope;
+- dependencies;
+- acceptance criteria;
+- verification/checks;
+- branch/commit/PR;
+- status;
+- implementation summary;
+- evidence;
+- blockers/risks;
+- next action;
+- started/updated/completed timestamps.
 
-## Evidence
+## 8. ADRs
 
-Use `evidence/<task-id>/README.md` as an index when evidence is non-trivial. Prefer durable GitHub links to:
+Use `decisions/ADR-XXXX-<slug>.md` for decisions expensive to reverse or that materially constrain architecture, protocol, data model, security, deployment, CI/CD, governance, or vendor choice.
 
-- commits;
-- PRs;
-- Actions runs/jobs;
-- test reports;
-- releases/artifacts;
-- deployment checks.
+Each ADR should include status, date/decision owners, context, decision, alternatives, consequences/tradeoffs, rollout/migration implications when relevant, and superseding/superseded links.
 
-Do not commit credentials, tokens, signing secrets, private user data, or large binary artifacts as evidence.
+Do not use ADRs for routine implementation details.
+
+## 9. Evidence
+
+Use `evidence/<task-id>/README.md` as an index for non-trivial evidence.
+
+Prefer durable references to commit SHA, PR/review, Actions run/job/check, test/security/performance reports, release/artifact, and deployment/environment checks.
+
+Do not commit credentials, tokens, private customer data, signing material, or large build binaries as project evidence.
+
+## 10. Runbooks
+
+Use `runbooks/` for deploy, rollback, recovery, migration, incident response, data repair, key rotation, or other repeatable operational procedures. Link each runbook to its owning component/task and last validation date.
+
+## 11. AGENTS.md, Skills, CI/CD, docs governance are not exempt
+
+Repository meta/governance changes must follow the same project standard as product code.
+
+The following require an existing matching project folder or a newly created one **before substantial work**:
+
+- root or nested `AGENTS.md` changes;
+- Skill creation, update, removal, packaging, or installation work;
+- CI/CD/workflow/merge-policy changes;
+- branch protection and release governance;
+- architecture standards and repository-wide policies;
+- documentation-system migrations;
+- build/release tooling changes;
+- security/governance automation.
+
+If a matching governance project already exists, reuse it. Otherwise create a separate governance project with its own source, scope, WBS, acceptance criteria, evidence, and completion gate.
+
+## 12. Completion gate
+
+Before declaring a repository task complete:
+
+1. Execute the defined acceptance check.
+2. Update the task record with actual result/evidence.
+3. Update WBS.
+4. Update acceptance traceability.
+5. Append status report.
+6. Append material changelog.
+7. Update risks/dependencies/issues/roadmap/ADRs/specs when affected.
+8. Record commit/PR/CI/release/deployment evidence.
+9. Merge through the repository's required protected-main process.
+10. Verify canonical state on `main`.
+
+If any required gate is pending, keep the task `in-progress`, `blocked`, or `failed`.
+
+## 13. Quality audit checklist
+
+A project folder passes audit only when:
+
+- a new engineer/agent can reconstruct objective, scope, current state, and next action without chat history;
+- every required task has stable identity and objective acceptance;
+- requirements trace to implementation and evidence;
+- completed claims are supported by live/verifiable evidence;
+- risks and dependencies have owners;
+- durable architecture/governance choices have ADRs;
+- status/change history is append-only;
+- release/migration/rollback and SLO/runbook material exists where operational risk requires it;
+- secrets/private data are absent;
+- project and external control views use the same stable IDs.

--- a/.agent/skills/fabushi-project-governance/references/task-lifecycle.md
+++ b/.agent/skills/fabushi-project-governance/references/task-lifecycle.md
@@ -1,71 +1,105 @@
 # Task lifecycle
 
-## 1. Intake
+## 1. Intake and project routing
 
-- Classify the request as continuation vs new independent workstream.
+- Read the user's originating source first.
+- Read root/nested `AGENTS.md` instructions before substantial repository work.
 - Search GitHub `projects/` before creating a folder.
+- Classify the request as continuation vs genuinely independent workstream.
 - Resolve the canonical project path.
+- Treat AGENTS.md, Skill, CI/CD, repository-governance, architecture-standard, documentation-system, release-tooling, and security-governance work exactly like product work for project routing.
 
-## 2. Reconstruct current state
+## 2. Create or audit the project folder
+
+If no matching project exists, create the enterprise scaffold in `project-folder-standard.md` before substantial implementation.
+
+If a project exists, audit whether it has the current mandatory standard files. Add missing standard files as part of the active governance/project task; do not fork a second project solely to migrate the folder standard.
+
+Required standard areas include ownership, source, charter/scope/requirements, architecture, quality, release/rollback, SLO/operations, security, DoD, roadmap, WBS, milestones, acceptance, risks, dependencies, status, changelog, issues/actions, ADRs, evidence, runbooks, and per-task records.
+
+Use `N/A` with reason/owner/revisit trigger when a standard document genuinely does not apply.
+
+## 3. Reconstruct current state
 
 Read from `main`:
 
-1. `SOURCE_OF_TRUTH.md`
-2. `README.md` and `PROJECT.yaml`
-3. relevant `source/` and `docs/`
-4. relevant ADRs
-5. `management/01-WBS原子任务.md`
-6. `management/03-验收追踪矩阵.md`
-7. `management/05-状态报告.md`
-8. `management/07-变更日志.md`
-9. current task record, if any
+1. `SOURCE_OF_TRUTH.md`;
+2. `README.md`, `PROJECT.yaml`, `OWNERS.md`;
+3. relevant `source/` and `docs/`;
+4. relevant ADRs;
+5. `management/00-路线图.md`;
+6. `management/01-WBS原子任务.md`;
+7. `management/02-里程碑.md`;
+8. `management/03-验收追踪矩阵.md`;
+9. `management/04-风险登记.md`;
+10. `management/05-状态报告.md`;
+11. `management/06-依赖与阻塞.md`;
+12. `management/07-变更日志.md`;
+13. `management/08-问题与行动项.md`;
+14. current task record and evidence index, if any;
+15. relevant runbooks.
 
-Then verify current GitHub code, open PRs, CI, releases, or deployments that materially affect the task.
+Then verify live GitHub code, open PRs, CI, releases, or deployments that materially affect the task.
 
-## 3. Open/update the task record
+## 4. Open/update the task record
 
-Create or update `management/tasks/<task-id>-<slug>.md` before substantial work. Keep planned and completed states separate.
+Create or update `management/tasks/<task-id>-<slug>.md` before substantial work.
 
-## 4. Implement
+Keep planned and completed states separate. Include stable requirement IDs, dependencies, acceptance criteria, verification, branch/PR, evidence plan, risks, blockers, timestamps, and next action.
+
+## 5. Implement
 
 - Use a task branch/PR when appropriate.
-- Keep code and project-record updates together.
-- If requirements change during work, update the durable spec and changelog, not just chat.
-- Record architecture decisions as ADRs.
+- Keep implementation and project-record updates together.
+- If requirements change during work, update source/spec and changelog, not just chat.
+- Record durable decisions as ADRs.
+- Update dependency/risk/action registers when new facts emerge.
+- Update release/rollback, security, SLO/observability, and runbooks when the implementation changes operational behavior.
 
-## 5. Verify
+## 6. Verify
 
-Run the objective checks stated in the task/WBS. Capture:
+Run the objective checks stated in the task/WBS/DoD. Capture:
 
-- command/check;
+- check/test name;
 - expected result;
 - actual result;
 - commit SHA;
-- PR;
-- CI run/job;
-- release/deployment evidence if relevant.
+- PR/review;
+- CI run/job/check;
+- security/performance evidence when required;
+- release/deployment/migration evidence when relevant.
 
 A failed or missing required check blocks `passed` status.
 
-## 6. Close the task record
+## 7. Close project records
 
 Before saying “done”:
 
 - update task record;
 - update WBS;
-- update acceptance matrix if applicable;
+- update milestone state when affected;
+- update acceptance traceability;
 - append status report;
 - append changelog;
-- update risk/roadmap/ADR if affected;
+- update risks, dependencies, issues/actions, roadmap, specs, ADRs, security, release/rollback, SLOs, or runbooks when affected;
 - add evidence index when useful;
 - ensure these changes are committed in GitHub.
 
-## 7. Merge and canonical verification
+## 8. Merge and canonical verification
 
-Prefer the same PR for implementation and record updates. After merge, verify the expected files on `main`.
+Prefer the same PR for implementation and record updates. Use the repository's protected branch/required checks/merge queue policy. After merge, verify expected project and implementation files on `main`.
 
-If the implementation is ready but merge/CI/release is still pending, use `in-progress`, `blocked`, or `failed`; do not mark complete.
+If implementation is ready but review/CI/merge/release/deployment/migration is still pending, use `in-progress`, `blocked`, or `failed`; do not mark complete.
 
-## 8. Next task
+## 9. Synchronize external control views
 
-For a continuation, begin from the same project folder and prior task history. For a genuinely different objective, create a new standardized project folder before implementation.
+When Task Orchestration/Google Sheets/Drive/Calendar/Gmail are used:
+
+- preserve the same Project/Stage/Task/Requirement IDs;
+- keep GitHub engineering specifications/evidence authoritative for Fabushi repository work;
+- synchronize verified state into the external portfolio/control view;
+- use Drive/Gmail as source/intake or mirror, Calendar as schedule, not as silent overrides of GitHub project state.
+
+## 10. Next task
+
+For a continuation, begin from the same project folder and prior task history. For a genuinely different objective, create a new enterprise-standard project folder before substantial implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,55 +4,94 @@ This repository contains the Fabushi app and website. Follow the user's request 
 
 ## CRITICAL: Project-First Task Governance — Every Task Must Use `projects/`
 
-These rules are mandatory for **every task** performed in this repository, including implementation, bug fixes, refactors, reviews, investigations, releases, documentation changes, CI/CD work, migrations, and follow-up rounds.
+These rules are mandatory for **every task** performed in this repository, including product implementation, bug fixes, refactors, reviews, investigations, releases, migrations, documentation changes, CI/CD work, repository governance, `AGENTS.md` changes, Skill creation/update, architecture standards, branch/merge policy, and follow-up rounds.
+
+There are **no meta-work exemptions**. Work that changes this `AGENTS.md`, `.agent/skills/**`, `.github/**`, project standards, build/release tooling, security/governance automation, or other repository-control files must itself belong to a governed project folder.
 
 ### 1. Start every task by locating its project folder
 
 Before substantial work:
 
-1. Inspect the current GitHub `main` branch under `projects/`.
-2. Decide whether the request belongs to an existing project or is a genuinely different objective/workstream.
-3. If a matching project exists, **reuse it**. Do not create a duplicate folder merely because the chat/session is new.
-4. Read the matching project's `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, relevant `source/`, `docs/`, `decisions/`, and `management/` files.
-5. Read the current WBS, acceptance matrix, status report, changelog, risks, and active task record before deciding what to implement next.
-6. Verify code, branch, PR, CI, release, and deployment facts against GitHub rather than assuming documentation is current.
+1. Inspect current GitHub `main` under `projects/`.
+2. Decide whether the request belongs to an existing project or is a genuinely independent objective/workstream.
+3. If a matching project exists, **reuse it**. Do not create a duplicate because the chat, branch, PR, or agent session is new.
+4. Read the matching project's `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, `OWNERS.md`, relevant `source/`, `docs/`, `decisions/`, `management/`, `evidence/`, and `runbooks/` files.
+5. Read current roadmap, WBS, milestones, acceptance matrix, risk register, dependency/blocker register, status report, changelog, open issues/actions, active task record, and relevant ADRs before deciding what to implement next.
+6. Verify code, branch, PR, CI, release, deployment, and migration facts against live GitHub/engineering systems rather than assuming project documentation is current.
 
-### 2. If no project folder exists, create one before implementation
+### 2. If no project folder exists, create the enterprise standard before implementation
 
-If the request does not belong to an existing project, create a new lowercase kebab-case folder under:
+If the request does not belong to an existing project, create a lowercase kebab-case folder under:
 
 `projects/<project-slug>/`
 
-At minimum create and populate:
+Create and populate this standard scaffold **before substantial implementation**:
 
 ```text
 projects/<project-slug>/
 ├── README.md
 ├── PROJECT.yaml
 ├── SOURCE_OF_TRUTH.md
+├── OWNERS.md
 ├── source/
 │   └── README.md
 ├── docs/
 │   ├── 00-项目章程.md
 │   ├── 01-范围与非目标.md
+│   ├── 02-需求与成功指标.md
+│   ├── 03-架构与实现策略.md
+│   ├── 04-质量与测试策略.md
+│   ├── 05-发布迁移与回滚.md
+│   ├── 06-运维可观测性与SLO.md
+│   ├── 07-安全隐私与合规.md
 │   └── 19-完成定义与验收.md
 ├── management/
 │   ├── 00-路线图.md
 │   ├── 01-WBS原子任务.md
+│   ├── 02-里程碑.md
 │   ├── 03-验收追踪矩阵.md
 │   ├── 04-风险登记.md
 │   ├── 05-状态报告.md
+│   ├── 06-依赖与阻塞.md
 │   ├── 07-变更日志.md
+│   ├── 08-问题与行动项.md
 │   └── tasks/
 ├── decisions/
 │   └── README.md
-└── evidence/
+├── evidence/
+│   └── README.md
+└── runbooks/
     └── README.md
 ```
 
-Do this **before substantial implementation** so the task has a durable scope, acceptance definition, and execution record from the beginning.
+Do not create blank ceremony. If a mandatory standard document is genuinely not applicable, keep the file and state `N/A`, why it is not applicable, who owns revisiting it, and what condition would make it applicable.
 
-### 3. Every substantial task must have a durable task record
+### 3. Enterprise project-document requirements
+
+Every project must be reconstructable by a new engineer/agent without the originating chat.
+
+At minimum:
+
+- `README.md`: objective, current verified status, current stage/next gate, scope summary, owners, source-of-truth pointer, acceptance summary, navigation.
+- `PROJECT.yaml`: stable project identity, slug, status, repository, authoritative branch/path, owner/reviewers, current stage, timestamps; optional risk/security classification.
+- `SOURCE_OF_TRUTH.md`: authoritative source precedence and conflict-resolution rules.
+- `OWNERS.md`: accountable/execution owners, reviewers, consulted stakeholders, escalation path.
+- `source/`: original requirements and durable source references; do not silently rewrite source history.
+- `docs/00-项目章程.md`: problem, objective, stakeholders, value, constraints, deliverables, success definition.
+- `docs/01-范围与非目标.md`: explicit in-scope, out-of-scope, deferred items.
+- `docs/02-需求与成功指标.md`: stable requirement IDs, functional/non-functional requirements, measurable success metrics.
+- `docs/03-架构与实现策略.md`: current/target state, components, interfaces, data/control flow, deployment/migration strategy, tradeoffs.
+- `docs/04-质量与测试策略.md`: unit/contract/integration/E2E/security/performance strategy as applicable, environments, required CI/evidence.
+- `docs/05-发布迁移与回滚.md`: rollout, migration, canary/flags when used, rollback triggers/steps, release validation.
+- `docs/06-运维可观测性与SLO.md`: SLI/SLO, logs/metrics/traces, alerts, capacity, runbook links for runtime systems; otherwise N/A with reason.
+- `docs/07-安全隐私与合规.md`: data classification, auth boundaries, threats, secrets handling, privacy/compliance, supply-chain/security review.
+- `docs/19-完成定义与验收.md`: objective project Definition of Done with evidence type for every required gate.
+- `management/`: roadmap, WBS, milestones, acceptance traceability, RAID/risk, append-only status, dependencies/blockers, append-only changelog, open issues/actions, per-task records.
+- `decisions/`: ADRs for expensive-to-reverse architecture/protocol/data/security/deployment/CI/CD/governance/vendor decisions.
+- `evidence/`: durable evidence indexes for commits, PRs, reviews, CI checks, tests, releases, deployments, migrations.
+- `runbooks/`: deploy/rollback/recovery/migration/incident/data-repair/key-rotation or other repeatable operational procedures when applicable.
+
+### 4. Every substantial task must have a durable task record
 
 Create or update:
 
@@ -61,32 +100,33 @@ Create or update:
 The task record must include at least:
 
 - stable Task ID;
-- objective and source requirement;
+- objective and source requirement IDs/references;
 - in-scope / out-of-scope;
 - dependencies;
 - acceptance criteria;
-- verification method;
+- verification method/checks;
 - branch / commit / PR;
 - status;
 - implementation summary;
-- CI / E2E / release / deployment evidence when applicable;
+- CI / E2E / security / performance / release / deployment / migration evidence when applicable;
 - blockers and risks;
 - next action;
 - started, updated, and completed timestamps.
 
-### 4. Drive implementation from the project folder
+### 5. Drive implementation from the project folder
 
 The GitHub project folder is the durable working context. Use it to decide what comes next rather than relying on chat memory.
 
-- Reconstruct the current state from the project folder at the start of each task/round.
+- Reconstruct current state from the project folder at the start of each task/round.
 - Advance the existing roadmap/WBS instead of inventing a parallel plan in chat.
-- Record newly discovered requirements in `source/` or the appropriate spec.
-- Record scope/design changes in `management/07-变更日志.md`.
-- Record long-lived architecture decisions under `decisions/` as ADRs.
-- Keep planned work and completed work clearly separated.
+- Record newly discovered requirements in `source/` and/or normalized specs.
+- Record scope/design/governance changes in `management/07-变更日志.md`.
+- Record durable architecture/governance decisions as ADRs.
+- Update risk, dependency/blocker, issue/action, release/rollback, security, SLO, and runbook records when affected.
+- Keep planned work and verified completed work clearly separated.
 - Prefer the same branch/PR for implementation and its project-record updates.
 
-### 5. Task completion is blocked until the project folder is updated
+### 6. Task completion is blocked until project records and evidence are current
 
 Do **not** report a task as complete merely because code was written, pushed, or a test passed.
 
@@ -95,40 +135,46 @@ Before saying a task is finished:
 1. Run or inspect the defined acceptance checks.
 2. Update the task record with actual results and evidence.
 3. Update `management/01-WBS原子任务.md` for affected task states.
-4. Update `management/03-验收追踪矩阵.md` when acceptance status changed.
-5. Append the round/result to `management/05-状态报告.md`.
-6. Append material changes to `management/07-变更日志.md`.
-7. Update risks, roadmap, specs, and ADRs when affected.
-8. Record commit SHA, PR number, CI run/job, release/deployment evidence, blockers, and next action where applicable.
-9. Commit the project-record changes to GitHub in the same task change stream when possible.
-10. Verify the canonical result on GitHub `main` after merge. If CI/merge/release is still pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete.
+4. Update `management/02-里程碑.md` when milestone gates change.
+5. Update `management/03-验收追踪矩阵.md` when acceptance status changes.
+6. Append the round/result to `management/05-状态报告.md`.
+7. Append material changes to `management/07-变更日志.md`.
+8. Update risks, dependencies/blockers, issues/actions, roadmap, specs, ADRs, security docs, release/rollback docs, SLOs, and runbooks when affected.
+9. Record commit SHA, PR/review, CI run/job/check, test, release, deployment, migration, blockers, and next action where applicable.
+10. Commit project-record changes to GitHub in the same task change stream when possible.
+11. Merge through required protected-main checks/merge queue.
+12. Verify canonical state on GitHub `main` after merge.
 
-### 6. Source-of-truth precedence
+If any required review/CI/merge/release/deployment/migration/acceptance gate is pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete.
+
+### 7. Source-of-truth precedence
 
 Unless a project defines a stricter rule, use this precedence:
 
 1. the user's latest explicit requirement **after it is persisted into the GitHub project folder**;
-2. `projects/<project-slug>/SOURCE_OF_TRUTH.md` and the source files it designates;
+2. `projects/<project-slug>/SOURCE_OF_TRUTH.md` and designated source files;
 3. accepted ADRs and current project specs;
-4. current WBS/status/acceptance records;
+4. current WBS/milestone/status/acceptance records;
 5. GitHub code/PR/CI/release/deployment facts for implementation state;
-6. external mirrors such as Google Drive;
+6. external mirrors/control views such as Google Drive/Sheets;
 7. conversation memory.
 
-Google Drive, chat history, email, local notes, and other external copies are intake/reference material unless the project explicitly promotes them. They must not silently override the GitHub `main` project folder.
+External systems are intake, scheduling, reporting, portfolio, or mirror systems unless explicitly promoted. They must not silently override the GitHub `main` project folder for Fabushi engineering work.
 
-### 7. Required governance skill
+### 8. Required governance skill and Task Orchestration alignment
 
-For project/task lifecycle details, follow:
+For lifecycle details, follow:
 
 `.agent/skills/fabushi-project-governance/SKILL.md`
 
-and its references:
+and:
 
 - `.agent/skills/fabushi-project-governance/references/project-folder-standard.md`
 - `.agent/skills/fabushi-project-governance/references/task-lifecycle.md`
 
-The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass the requirement to locate/create a project folder and keep its task records current.
+When Task Orchestration is used, preserve the same Project ID, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links in external control views. Google Sheets is a portfolio/control-plane view; for Fabushi repository work the GitHub project folder and live GitHub/CI facts remain authoritative.
+
+The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass project-folder creation/reuse, task records, acceptance evidence, or completion closure.
 
 ## CRITICAL: Local Disk Safety — Never Build or Test the App Locally
 

--- a/projects/fabushi-project-governance/OWNERS.md
+++ b/projects/fabushi-project-governance/OWNERS.md
@@ -1,0 +1,26 @@
+# Owners and Review Responsibility
+
+## Accountability
+
+| Role | Owner | Responsibility |
+|---|---|---|
+| Accountable owner | Repository maintainers | Approve repository-wide governance policy and protected-main behavior |
+| Execution owner | Active task agent/engineer | Implement the governed task and keep project records current |
+| Required reviewers | Repository maintainers for sensitive governance/CI/security changes | Review changes that alter enforcement, delivery, security, or repository-wide policy |
+| Consulted stakeholders | Project owners affected by a governance change | Validate compatibility with project-specific needs |
+| Informed stakeholders | Contributors/agents working in `bhrumom/fabushi` | Follow current `main` governance rules |
+
+## Escalation
+
+Escalate when:
+
+- two project folders claim authority over the same objective;
+- a requested change conflicts with root `AGENTS.md`, protected-main policy, or accepted ADRs;
+- a task would weaken required CI, merge, release, security, or evidence gates;
+- a project cannot meet the enterprise standard without a justified N/A or migration plan.
+
+Escalation target: repository maintainers and the accountable owner of the affected project.
+
+## Review rule
+
+Changes to root `AGENTS.md`, repository Skills, CI/CD, merge policy, security/governance automation, or the enterprise project-folder standard are governance-sensitive and require objective validation plus the repository's protected merge process.

--- a/projects/fabushi-project-governance/PROJECT.yaml
+++ b/projects/fabushi-project-governance/PROJECT.yaml
@@ -5,6 +5,17 @@ status: active
 repository: bhrumom/fabushi
 authoritative_branch: main
 authoritative_path: projects/fabushi-project-governance
+owner: repository-governance
+reviewers:
+  - repository-maintainers
+current_stage: enterprise-standardization
+risk_tier: tier-2
+security_classification: internal
 created_at: 2026-08-22
 updated_at: 2026-08-22
-current_stage: adoption
+target_finish: null
+related_projects:
+  - fabushi-cicd-merge-governance
+source_systems:
+  - GitHub
+  - ChatGPT Task Orchestration

--- a/projects/fabushi-project-governance/README.md
+++ b/projects/fabushi-project-governance/README.md
@@ -2,32 +2,60 @@
 
 ## Objective
 
-Make `projects/` the mandatory durable execution context for every task in `bhrumom/fabushi`, and make the root `AGENTS.md` enforce project-first intake, execution, verification, and closure.
+Make `projects/` the mandatory durable execution context for every task in `bhrumom/fabushi`, enforce an enterprise-standard project-folder model, and make root `AGENTS.md`, repository Skills, and Task Orchestration follow the same project-first lifecycle.
 
-## Status
+## Current verified status
 
-`active`
+`active` — FPG-001 established the repository-wide project gate. FPG-002 is upgrading the folder standard from a minimal scaffold to an enterprise project package and aligning Task Orchestration, root `AGENTS.md`, and the governance Skill.
 
-## Current stage
+## Current stage / next gate
 
-Repository-wide bootstrap: establish the root `AGENTS.md` project gate and canonical governance project folder.
+Stage: `enterprise-standardization`.
+
+Next gate: FPG-002 must pass Skill validation, GitHub `CI result`, protected merge/merge-queue policy, and canonical `main` verification before being marked complete.
+
+## Scope summary
+
+- mandatory project routing for every Fabushi task;
+- enterprise project folder/file standard;
+- project lifecycle and completion gates;
+- stable task/requirement/evidence IDs;
+- root `AGENTS.md` enforcement;
+- `.agent/skills/fabushi-project-governance` enforcement;
+- Task Orchestration alignment;
+- project-folder governance for AGENTS/Skill/CI/CD/governance work itself.
+
+## Major non-goals
+
+- replacing GitHub code/CI/release evidence with project-document claims;
+- storing credentials or private data in project records;
+- creating a new project for every chat, branch, or PR;
+- requiring empty documentation ceremony without an explicit N/A rationale.
 
 ## Canonical source
 
 - Repository: `bhrumom/fabushi`
-- Branch after merge: `main`
+- Authoritative branch after merge: `main`
 - Path: `projects/fabushi-project-governance/`
-- Original requirement: `source/README.md`
+- Source intake: `source/`
 - Governance skill: `.agent/skills/fabushi-project-governance/SKILL.md`
+- Root enforcement: `AGENTS.md`
+
+## Ownership
+
+See `OWNERS.md`.
 
 ## Primary acceptance definition
 
-Every repository agent task must first resolve a project under `projects/`; if none matches, it must create the standardized project folder and files before substantial work. A task cannot be called complete until its project record is updated with status, acceptance, and evidence.
+Every repository task must first resolve a project under `projects/`; if none matches, it must create the enterprise-standard project folder and files before substantial work. AGENTS.md, Skill, CI/CD, documentation-governance, architecture-policy, and other meta work have no exemption. A task cannot be called complete until implementation, protected GitHub state, objective acceptance evidence, and project records agree.
 
 ## Navigation
 
 - `SOURCE_OF_TRUTH.md` — precedence and authority
-- `docs/` — scope and acceptance definition
-- `management/` — roadmap, WBS, acceptance, risk, status, changelog, task records
-- `decisions/` — long-lived governance decisions
-- `evidence/` — GitHub evidence indexes
+- `OWNERS.md` — accountability/review/escalation
+- `source/` — original requirements and dated changes
+- `docs/` — charter, scope, requirements, architecture, quality, release, SLO, security, DoD
+- `management/` — roadmap, WBS, milestones, acceptance, RAID/risk, status, dependencies, changelog, issues/actions, task records
+- `decisions/` — long-lived governance ADRs
+- `evidence/` — GitHub/Skill validation evidence indexes
+- `runbooks/` — repeatable governance operations when needed

--- a/projects/fabushi-project-governance/SOURCE_OF_TRUTH.md
+++ b/projects/fabushi-project-governance/SOURCE_OF_TRUTH.md
@@ -2,18 +2,29 @@
 
 The canonical project record is `bhrumom/fabushi` `main` under `projects/fabushi-project-governance/`.
 
-## Requirement source
+## Designated requirement sources
 
-`source/README.md` contains the original repository-wide governance requirement.
+- `source/README.md` — original repository-wide project-first governance requirement.
+- `source/2026-08-22-FPG-002-enterprise-project-standard.md` — requirement to align Task Orchestration, root `AGENTS.md`, repository Skills, and project folders with an enterprise-standard project-document model.
 
 ## Precedence
 
 1. Latest explicit user requirement after being persisted into this project folder.
 2. This file and designated source files.
-3. Accepted ADRs and current specs.
-4. Current WBS, acceptance, status, risk, and task records.
-5. GitHub code/PR/CI/release/deployment facts for implementation state.
-6. External mirrors such as Google Drive.
+3. Accepted ADRs and current normalized specs under `docs/`.
+4. Current roadmap, WBS, milestones, acceptance, risks, dependencies, status, changelog, issues/actions, and task records.
+5. Live GitHub code/PR/review/CI/release/deployment/migration facts for implementation state.
+6. External portfolio/control/mirror systems such as Google Sheets or Google Drive.
 7. Conversation memory.
 
-GitHub `main` is authoritative after merge. External copies may inform work but must not silently override this folder. No task is complete until required project-record updates and objective GitHub evidence are present.
+## Conflict resolution
+
+- Do not silently rewrite source history when a requirement changes; append the new dated source/change and update normalized specs/changelog.
+- If project records conflict with live code/CI/release/deployment state, record the discrepancy and correct the project record using verified evidence.
+- If two project folders overlap, choose one canonical project and record the consolidation decision before continuing.
+
+## Engineering fact rule
+
+GitHub `main` is authoritative after protected merge. A commit push alone is not equivalent to accepted/released/deployed state unless the project's Definition of Done explicitly says so and evidence proves it.
+
+External copies may inform work but must not silently override this folder. No task is complete until required project-record updates and objective evidence are present.

--- a/projects/fabushi-project-governance/decisions/ADR-0002-enterprise-project-folder-standard.md
+++ b/projects/fabushi-project-governance/decisions/ADR-0002-enterprise-project-folder-standard.md
@@ -1,0 +1,57 @@
+# ADR-0002 — Enterprise Project Folder Standard
+
+- **Status:** Accepted for FPG-002 implementation; canonical after protected merge
+- **Date:** 2026-08-22
+- **Decision owners:** repository governance / maintainers
+
+## Context
+
+FPG-001 established a minimal `projects/<slug>/` scaffold and root Project-First gate. Real usage showed that the minimum scaffold did not explicitly cover ownership, stable requirements/success metrics, milestones, dependencies/blockers, issues/actions, quality strategy, release/rollback, observability/SLO, security/privacy/compliance, or runbooks. Task Orchestration also lacked a repository project-folder contract, and meta work such as AGENTS/Skill changes needed an explicit no-exemption rule.
+
+## Decision
+
+Adopt the enterprise project-folder standard defined in `.agent/skills/fabushi-project-governance/references/project-folder-standard.md`.
+
+Mandatory project areas are:
+
+- project identity/ownership/source-of-truth;
+- source intake;
+- charter, scope, requirements/success metrics, architecture, quality, release/rollback, SLO/operations, security/privacy/compliance, DoD;
+- roadmap, WBS, milestones, acceptance traceability, risks, dependencies/blockers, append-only status/changelog, issues/actions, task records;
+- ADRs, evidence indexes, runbooks.
+
+Mandatory files that do not apply must contain an explicit N/A with reason, owner, and revisit trigger rather than being omitted or left empty.
+
+AGENTS.md, Skills, CI/CD, merge/release policy, architecture standards, documentation governance, build/release tooling, and security/governance automation have no exemption from project routing.
+
+Task Orchestration should use the same repository project model for engineering work while keeping Google Sheets as portfolio/control-plane view rather than replacing repository specifications or live GitHub evidence.
+
+## Alternatives considered
+
+1. Keep the minimal scaffold only — rejected because important enterprise execution/operations fields remain implicit and drift between projects.
+2. Require every possible specialist document with no N/A mechanism — rejected as excessive ceremony for small/non-runtime projects.
+3. Put all project state only in Google Sheets/Drive — rejected for Fabushi engineering work because repository specs, code, PR, CI, release, and evidence need durable co-location and protected version history.
+
+## Consequences
+
+Positive:
+
+- new agents/engineers can reconstruct projects without chat history;
+- stronger requirement-to-evidence traceability;
+- meta/governance work follows its own policy;
+- shared stable IDs across Task Orchestration and GitHub;
+- operational/security/release concerns become explicit when relevant.
+
+Costs:
+
+- more standard files per project;
+- existing projects need incremental migration when touched;
+- maintainers must prevent low-value boilerplate by using meaningful N/A rationale.
+
+## Migration
+
+Do not mass-rewrite every historical project immediately. Audit and migrate an existing project when it receives substantive work or an explicit governance migration task. `projects/fabushi-project-governance/` is migrated during FPG-002 as the reference implementation.
+
+## Supersedes / superseded by
+
+Extends ADR-0001 project-first repository governance. Does not supersede the Project-First principle.

--- a/projects/fabushi-project-governance/docs/02-需求与成功指标.md
+++ b/projects/fabushi-project-governance/docs/02-需求与成功指标.md
@@ -1,0 +1,28 @@
+# 需求与成功指标
+
+## Stable requirements
+
+| Requirement ID | Requirement | Success metric |
+|---|---|---|
+| FPG-R01 | 每个 Fabushi 仓库任务在实质工作前必须定位/复用或创建 `projects/<slug>/` | 100% 新任务有可追踪 Project ID/Task ID |
+| FPG-R02 | 新项目必须使用企业标准项目目录和必需文档 | 新项目目录审计无缺失 mandatory 文件，N/A 均有理由/owner/revisit trigger |
+| FPG-R03 | AGENTS.md、Skill、CI/CD、架构治理等 meta work 不得豁免 | 此类任务均可追溯到治理/对应项目任务记录 |
+| FPG-R04 | 任务完成必须同时具备实现、验收、证据和项目记录 | `passed` 任务 100% 有 objective evidence |
+| FPG-R05 | GitHub `main` 项目目录与 live GitHub/CI/release facts 为工程主基线 | 不允许外部镜像静默覆盖工程状态 |
+| FPG-R06 | Task Orchestration 与 GitHub 项目目录共享稳定 ID 和项目路由规则 | 同一项目的 Project/Stage/Task/Requirement ID 无平行编号体系 |
+| FPG-R07 | 项目记录可由新工程师/agent 在无聊天上下文下重建当前状态 | 项目审计可定位 objective/scope/current status/next action/evidence |
+
+## Non-functional requirements
+
+- 项目历史必须可审计，状态报告/变更日志采用 append-only 语义。
+- 不在项目文件中保存 token、密码、签名材料或其他 secret。
+- 文档要求必须与项目风险相称；不适用项使用显式 N/A，而不是空文件。
+- 工程事实必须由 GitHub/CI/release/deployment 系统验证，不能仅依赖文档自报。
+
+## FPG-002 success metrics
+
+- Task Orchestration 更新包通过 Skill validator/package 流程。
+- 根 `AGENTS.md` 明确完整企业项目目录和 no-meta-exemption。
+- Fabushi governance Skill 与 lifecycle/reference 与同一标准一致。
+- `projects/fabushi-project-governance/` 本身升级到完整标准。
+- PR required `CI result` 成功并经受保护合并流程进入 `main`。

--- a/projects/fabushi-project-governance/docs/03-架构与实现策略.md
+++ b/projects/fabushi-project-governance/docs/03-架构与实现策略.md
@@ -1,0 +1,47 @@
+# 架构与实现策略
+
+## Current state
+
+Fabushi 已有 root `AGENTS.md`、`.agent/skills/fabushi-project-governance/` 和 `projects/`，但初始项目目录是最小脚手架，Task Orchestration 尚未定义统一的 GitHub enterprise project-folder contract。
+
+## Target state
+
+建立一套一致的治理控制面：
+
+`User/source -> Project routing -> Enterprise project folder -> Atomic task -> Protected PR/CI/merge -> Evidence -> Project closure -> External control-view sync`
+
+## Components
+
+- **Root `AGENTS.md`**: repository-wide mandatory gate.
+- **Fabushi governance Skill**: lifecycle rules and reusable project standard.
+- **Task Orchestration Skill**: cross-system intake/control workflow; repository work遵守同一 project-folder standard.
+- **`projects/<slug>/`**: durable specification, execution history, acceptance, ADR, evidence, runbook source.
+- **GitHub/CI/release/deploy systems**: implementation fact authority.
+- **Sheets/Drive/Gmail/Calendar**: portfolio/control, external spec/mirror, intake/reporting, schedule roles.
+
+## Identity and traceability
+
+Use stable Project ID, Stage ID, Task ID, Requirement ID, Milestone ID, Risk ID, ADR ID across repository project records and external control views. Do not create parallel ID systems.
+
+## Lifecycle
+
+1. Read repository agent instructions.
+2. Search `projects/`.
+3. Reuse existing project or create enterprise scaffold.
+4. Persist original source and normalized requirements.
+5. Create atomic task/acceptance/evidence plan.
+6. Implement in a protected branch/PR flow.
+7. Run objective checks.
+8. Update project records in the same change stream when possible.
+9. Merge through required branch protection/merge queue.
+10. Verify canonical `main`, then close/synchronize task state.
+
+## Tradeoffs
+
+- More files than the old minimal scaffold, but each file has a defined management/engineering purpose.
+- To avoid ceremony, mandatory files may be explicit N/A with reason/owner/revisit trigger.
+- Repository project folders remain detailed; external Sheets should stay normalized and link to project records rather than duplicating specs.
+
+## Migration strategy
+
+Existing projects are not automatically rewritten in one bulk migration. When an existing project is touched for substantive work or governance standardization, audit it against the current standard and add missing mandatory files as part of that project's change stream.

--- a/projects/fabushi-project-governance/docs/04-质量与测试策略.md
+++ b/projects/fabushi-project-governance/docs/04-质量与测试策略.md
@@ -1,0 +1,31 @@
+# 质量与测试策略
+
+## Quality gates
+
+治理/文档/Skill 变更仍需要客观验收，但测试范围按风险选择，不以“全量测试”作为默认安全感来源。
+
+### FPG-002 required checks
+
+1. Task Orchestration Skill `quick_validate.py` 通过。
+2. Task Orchestration Skill `package_skill.py` 成功产出 `skill.zip`。
+3. Root `AGENTS.md` 静态检查：包含 enterprise scaffold、no-meta-exemption、completion gate、Task Orchestration alignment。
+4. Governance Skill/reference 静态检查：标准目录和 lifecycle 一致。
+5. Governance project audit：mandatory files 全部存在或显式 N/A。
+6. GitHub PR required `CI result` 成功。
+7. 使用仓库要求的 protected-main / merge queue 流程。
+8. 合并后从 `main` 重新读取关键文件进行 canonical verification。
+
+## Test strategy by layer
+
+- **Skill validation**: Skill Creator validators/package process.
+- **Repository syntax/contract checks**: GitHub CI diff-selected checks.
+- **Governance consistency review**: compare root AGENTS, governance Skill, project-folder reference, lifecycle, and project self-implementation.
+- **Traceability check**: FPG-002 source -> requirements -> task -> acceptance -> evidence.
+
+## Evidence retention
+
+Store durable evidence links/IDs under `evidence/FPG-002/README.md`, including Skill validator/package result, branch/commit/PR, CI run/job, merge commit, and post-merge `main` verification.
+
+## Flaky/failed checks
+
+A failed required check cannot be hidden by manually setting `passed`. Fix the cause or explicitly mark blocked/failed with evidence. Re-run only the failed/narrow necessary check when tooling supports it.

--- a/projects/fabushi-project-governance/docs/05-发布迁移与回滚.md
+++ b/projects/fabushi-project-governance/docs/05-发布迁移与回滚.md
@@ -1,0 +1,31 @@
+# 发布迁移与回滚
+
+## Change type
+
+本项目主要修改 repository governance、`AGENTS.md`、Skills 和项目模板，不包含用户运行时数据迁移。
+
+## Rollout strategy
+
+1. 在独立 task branch 修改 root `AGENTS.md`、governance Skill/reference 和治理项目文档。
+2. Task Orchestration 作为独立 Skill bundle 进行 validator/package 验证；不将“打包成功”误认为已安装到所有客户端。
+3. 创建 PR，执行 required `CI result`。
+4. 按仓库 branch protection / merge queue 合并。
+5. 合并后从 `main` 验证关键治理文件。
+6. 后续新项目立即采用新标准；已有项目在下一次实质变更时按项目内 migration task 补齐标准文件，而不是无差别一次性重写历史项目。
+
+## Rollback triggers
+
+- Root `AGENTS.md` 导致明显循环/冲突或无法执行的治理门禁。
+- Governance Skill 与 root AGENTS 标准不一致。
+- 项目标准导致关键工作无法合理建模且无法通过 N/A 机制解决。
+- CI/merge 流程出现由本治理变更引发的阻断。
+
+## Rollback procedure
+
+- 通过新的受保护 PR revert 导致问题的治理 commit；禁止 force-push main。
+- 保留 FPG-002 变更记录、失败证据和原因，不删除历史。
+- 若只需修订标准，优先新增修正任务/ADR，而不是整体回退 project-first 原则。
+
+## Data rollback limitations
+
+N/A — 本次无产品数据库 schema/data migration。Owner: repository-governance。若未来治理自动化写入外部管理数据库，则必须重新启用数据迁移/回滚章节。

--- a/projects/fabushi-project-governance/docs/06-运维可观测性与SLO.md
+++ b/projects/fabushi-project-governance/docs/06-运维可观测性与SLO.md
@@ -1,0 +1,38 @@
+# 运维可观测性与 SLO
+
+## Runtime applicability
+
+本治理项目不直接承载用户流量，因此传统服务 uptime/latency SLO 不适用。
+
+## Governance SLOs
+
+| SLI | Target |
+|---|---|
+| 新 repository task 在实质工作前可定位到 Project ID/项目目录 | 100% |
+| `passed` task 具备 objective evidence | 100% |
+| 新 enterprise project mandatory files 完整或显式 N/A | 100% |
+| AGENTS/Skill/CI/governance meta tasks 具有项目任务记录 | 100% |
+| 变更后 canonical `main` 验证 | 100% required completed tasks |
+
+## Observability
+
+- GitHub project folder: durable status/evidence history.
+- GitHub PR/CI: merge and acceptance telemetry.
+- Task Orchestration/Sheets when used: portfolio/control view, linked to stable IDs.
+- `management/05-状态报告.md`: append-only execution rounds.
+- `management/04-风险登记.md` and `06-依赖与阻塞.md`: governance health signals.
+
+## Alerts / triggers
+
+Treat the following as governance incidents requiring follow-up:
+
+- work begins without a project/task record;
+- task is reported complete while CI/merge/release evidence is pending;
+- duplicate project folders are created for the same objective;
+- external mirror overwrites canonical project state;
+- secrets/private data appear in project records;
+- root AGENTS, Skill, and project standard drift materially.
+
+## Runbook
+
+See `runbooks/README.md` for standard governance recovery/audit procedures.

--- a/projects/fabushi-project-governance/docs/07-安全隐私与合规.md
+++ b/projects/fabushi-project-governance/docs/07-安全隐私与合规.md
@@ -1,0 +1,38 @@
+# 安全、隐私与合规
+
+## Data classification
+
+项目治理文档默认按 repository visibility 和项目 `security_classification` 管理。`PROJECT.yaml` 可标记 `public|internal|confidential|restricted`，但分类本身不会授予额外访问权限。
+
+## Prohibited content
+
+不得在 `projects/`、task records、evidence index、Sheets/Drive mirror 或 PR 描述中保存：
+
+- passwords / OTP / access tokens / API keys;
+- signing private keys / certificates containing secret material;
+- unredacted payment credentials;
+- private customer/user data unless repository policy explicitly allows且有最小化处理;
+- sensitive connector/session secrets.
+
+Evidence 应链接到受控系统中的 run/artifact，而不是复制 secret-bearing logs。
+
+## Authorization boundaries
+
+- `AGENTS.md` / Skill 只能定义工作流程，不能绕过工具本身的授权、安全确认、branch protection、review 或 release permission。
+- 高风险/不可逆操作继续遵守平台安全确认，即使项目 task 写了自动执行。
+- Meta/governance task 不得使用“治理文件”身份绕过 project/CI/merge gate。
+
+## Supply-chain / Skill integrity
+
+- Skill 更新必须经过 Skill validator/package 流程。
+- 保持 Skill frontmatter 和 bundle 结构有效。
+- 不在 Skill assets/references 中放 secret。
+- 对 repository Skill 的变更通过 GitHub PR/CI/merge 记录；对外部 Task Orchestration bundle 记录可验证的 package/checksum 证据。
+
+## Privacy
+
+外部 Gmail/Drive/Calendar/Sheets 信息只同步完成任务所需最小字段。不要把不必要的私人内容复制到公开/更宽权限的 GitHub 项目目录。
+
+## Compliance review trigger
+
+当项目涉及支付、身份、医疗/金融等受监管数据、数据保留/删除、跨境数据、第三方受限许可证或新的用户遥测时，应在项目内增加专门合规/法律审核任务和证据。

--- a/projects/fabushi-project-governance/docs/19-完成定义与验收.md
+++ b/projects/fabushi-project-governance/docs/19-完成定义与验收.md
@@ -1,13 +1,40 @@
 # 完成定义与验收
 
-项目当前 bootstrap 阶段完成需同时满足：
+## Project-level Definition of Done
+
+Fabushi Project Governance 只有在 required governance tasks 均满足客观证据后才算对应里程碑完成。
+
+### Repository governance baseline
 
 1. 根 `AGENTS.md` 明确要求每次任务先检查 `projects/`。
-2. 明确要求匹配已有项目时先读 Source of Truth、WBS、验收、状态、变更和 ADR 再推进。
-3. 明确要求没有匹配项目时先创建标准项目文件夹和必要文件。
-4. 明确要求实质任务创建稳定 Task ID 和 `management/tasks/` 记录。
-5. 明确任务结束前更新 WBS、验收、状态、变更和证据。
-6. 明确未完成 CI/merge/release 或记录回写时不得宣称完成。
-7. 建立本项目自身标准目录，证明规则可以自举执行。
-8. 变更通过 GitHub PR、必需 `CI result` 和 merge queue 合并到 `main`。
-9. 合并后核对 `main` 的 `AGENTS.md` 与项目目录。
+2. 匹配已有项目时按 Source of Truth、requirements、WBS、milestones、acceptance、risk/dependency/status/changelog、ADR/task records 推进。
+3. 没有匹配项目时先创建 enterprise-standard project folder。
+4. 每个实质任务使用稳定 Task ID 和 `management/tasks/` 记录。
+5. 完成前回写 WBS、milestone/acceptance、status、changelog、evidence，及受影响的 risk/dependency/issue/ADR/spec/runbook。
+6. 未完成 required CI/review/merge/release/deployment/migration/main verification 时不得宣称完成。
+7. 工程事实必须用 live GitHub/CI/release/deployment evidence 验证。
+
+### Enterprise project-folder standard
+
+8. 新项目包含 `README.md`, `PROJECT.yaml`, `SOURCE_OF_TRUTH.md`, `OWNERS.md`, `source/`, standard `docs/`, standard `management/`, `decisions/`, `evidence/`, `runbooks/`。
+9. mandatory 文件不适用时必须明确 N/A + reason + owner + revisit trigger，不得留空或静默省略。
+10. Requirement -> Task/implementation -> Verification -> Evidence -> Status 可追踪。
+11. Ownership、risks、dependencies、open actions、long-lived decisions 有明确责任和记录。
+12. AGENTS.md、Skills、CI/CD、merge/release policy、architecture/documentation governance、build tooling、安全治理等 meta work 同样需要项目目录，无豁免。
+
+### Task Orchestration alignment
+
+13. Task Orchestration repository workflow 定义相同 enterprise project-folder contract。
+14. GitHub engineering project folder 是 Fabushi 持久工程 spec/execution record；Sheets 可作为 portfolio/control view，但不能替代 live engineering facts。
+15. Project/Stage/Task/Requirement IDs 在 repository project records 与外部 control view 之间保持一致。
+16. Task Orchestration Skill 更新必须通过 Skill validator/package；package creation 不得被误报为已安装到用户产品环境。
+
+### Protected delivery
+
+17. 治理变更通过 GitHub PR 和 required `CI result`。
+18. 使用仓库要求的 protected-main / merge queue 流程，不 force push/bypass。
+19. 合并后从 `main` 重新验证 root AGENTS、governance Skill/reference 和 project records。
+
+## FPG-002 completion gate
+
+FPG-002 只有在 `management/tasks/FPG-002-enterprise-project-standard.md` 的 10 条 acceptance criteria 全部通过、FPG-002.1–FPG-002.8 均为 passed、evidence index 完整、并从 `main` 验证后才能关闭。

--- a/projects/fabushi-project-governance/evidence/FPG-002/README.md
+++ b/projects/fabushi-project-governance/evidence/FPG-002/README.md
@@ -1,6 +1,6 @@
 # FPG-002 Evidence Index
 
-Status: in-progress pending PR/CI/protected merge/canonical main verification.
+Status: in-progress pending CI/protected merge/canonical main verification.
 
 ## Source / requirements
 
@@ -20,7 +20,11 @@ Status: in-progress pending PR/CI/protected merge/canonical main verification.
 
 ## GitHub implementation evidence
 
-Branch: `project/fpg-002-enterprise-project-standard`
+- Branch: `project/fpg-002-enterprise-project-standard`
+- Implementation PR: #1980
+- PR URL: `https://github.com/bhrumom/fabushi/pull/1980`
+- Initial PR head at creation: `79d80ba3aab78fbdefd613802f194c5064473122`
+- Project-record update commit after PR creation: `8822003d4d84d18abaa66e17774e41ded202ba8a`
 
 Implemented on branch:
 
@@ -29,12 +33,17 @@ Implemented on branch:
 - governance `references/project-folder-standard.md`;
 - governance `references/task-lifecycle.md`;
 - `projects/fabushi-project-governance/` enterprise-standard self-migration;
-- ADR-0002 enterprise project-folder standard.
+- ADR-0002 enterprise project-folder standard;
+- FPG-002 task, acceptance traceability, risk/dependency/action, runbook and project-folder audit records.
+
+## Branch audit
+
+- `evidence/FPG-002/project-folder-audit.md` confirms all mandatory enterprise scaffold files exist on the implementation branch.
+- This proves branch structure only; canonical acceptance still requires protected merge and post-merge verification.
 
 ## Pending evidence
 
-- final branch head SHA before PR;
-- PR number/review state;
+- final PR head SHA after record updates;
 - required `CI result` run/job;
 - merge queue/protected merge result;
 - merge commit SHA;

--- a/projects/fabushi-project-governance/evidence/FPG-002/README.md
+++ b/projects/fabushi-project-governance/evidence/FPG-002/README.md
@@ -1,0 +1,41 @@
+# FPG-002 Evidence Index
+
+Status: in-progress pending PR/CI/protected merge/canonical main verification.
+
+## Source / requirements
+
+- `source/2026-08-22-FPG-002-enterprise-project-standard.md`
+- `docs/02-需求与成功指标.md`
+- `management/tasks/FPG-002-enterprise-project-standard.md`
+
+## Task Orchestration Skill evidence
+
+- Complete updated Skill bundle generated: `skill.zip`
+- Size: `16128 bytes`
+- SHA-256: `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61`
+- Skill Creator `quick_validate.py /mnt/data/task-orchestration`: `Skill is valid!`
+- Skill Creator `package_skill.py /mnt/data/task-orchestration /mnt/data/task-orchestration-dist`: validation and packaging succeeded.
+- Bundle contains `task-orchestration/SKILL.md`, existing agents/assets/references, plus new `references/project-folder-standard.md`.
+- Installation/activation in the user's current ChatGPT Skill library is **not** asserted by this evidence; delivery/install remains an external action.
+
+## GitHub implementation evidence
+
+Branch: `project/fpg-002-enterprise-project-standard`
+
+Implemented on branch:
+
+- root `AGENTS.md` enterprise project-folder enforcement;
+- `.agent/skills/fabushi-project-governance/SKILL.md`;
+- governance `references/project-folder-standard.md`;
+- governance `references/task-lifecycle.md`;
+- `projects/fabushi-project-governance/` enterprise-standard self-migration;
+- ADR-0002 enterprise project-folder standard.
+
+## Pending evidence
+
+- final branch head SHA before PR;
+- PR number/review state;
+- required `CI result` run/job;
+- merge queue/protected merge result;
+- merge commit SHA;
+- canonical `main` verification of root AGENTS, governance Skill/reference, and governance project standard files.

--- a/projects/fabushi-project-governance/evidence/FPG-002/project-folder-audit.md
+++ b/projects/fabushi-project-governance/evidence/FPG-002/project-folder-audit.md
@@ -1,0 +1,57 @@
+# FPG-002 Project Folder Audit
+
+Audit target: `projects/fabushi-project-governance/`
+
+Audit date: 2026-08-22
+
+## Mandatory root
+
+- [x] `README.md`
+- [x] `PROJECT.yaml`
+- [x] `SOURCE_OF_TRUTH.md`
+- [x] `OWNERS.md`
+
+## Source
+
+- [x] `source/README.md`
+- [x] dated FPG-002 source requirement
+
+## Standard docs
+
+- [x] `00-项目章程.md`
+- [x] `01-范围与非目标.md`
+- [x] `02-需求与成功指标.md`
+- [x] `03-架构与实现策略.md`
+- [x] `04-质量与测试策略.md`
+- [x] `05-发布迁移与回滚.md`
+- [x] `06-运维可观测性与SLO.md`
+- [x] `07-安全隐私与合规.md`
+- [x] `19-完成定义与验收.md`
+
+## Management
+
+- [x] `00-路线图.md`
+- [x] `01-WBS原子任务.md`
+- [x] `02-里程碑.md`
+- [x] `03-验收追踪矩阵.md`
+- [x] `04-风险登记.md`
+- [x] `05-状态报告.md`
+- [x] `06-依赖与阻塞.md`
+- [x] `07-变更日志.md`
+- [x] `08-问题与行动项.md`
+- [x] `management/tasks/FPG-002-enterprise-project-standard.md`
+
+## Decisions / evidence / runbooks
+
+- [x] `decisions/README.md`
+- [x] `decisions/ADR-0001-project-first-repository-governance.md`
+- [x] `decisions/ADR-0002-enterprise-project-folder-standard.md`
+- [x] `evidence/README.md`
+- [x] `evidence/FPG-002/README.md`
+- [x] `runbooks/README.md`
+
+## Audit result
+
+Mandatory enterprise scaffold is present on the implementation branch. Content is non-empty; runtime-inapplicable concerns are represented with explicit N/A/rationale where appropriate rather than omitted.
+
+This audit proves branch structure only. Canonical completion still requires PR CI, protected merge, and post-merge `main` verification.

--- a/projects/fabushi-project-governance/management/00-路线图.md
+++ b/projects/fabushi-project-governance/management/00-路线图.md
@@ -1,16 +1,30 @@
 # 路线图
 
-## G0 — Repository bootstrap
+## G0 — Repository Project-First bootstrap — passed
 
 - 建立 `projects/fabushi-project-governance/`。
 - 把 Project-First 门禁加入根 `AGENTS.md`。
 - 通过 PR/CI/merge queue 进入 `main`。
+- 主要证据：FPG-001、PR #1976/#1977。
 
-## G1 — Adoption
+## G1 — Enterprise project standardization — in-progress
+
+- 将最小项目脚手架升级为 enterprise project folder standard。
+- 增加 ownership、requirements/success metrics、architecture、quality/test、release/rollback、SLO/operations、security/privacy/compliance。
+- 增加 milestones、dependencies/blockers、issues/actions、runbooks。
+- 明确 AGENTS.md、Skills、CI/CD、repository governance 等 meta work 无豁免。
+- 对齐 Task Orchestration 与 GitHub 项目目录的稳定 Project/Stage/Task/Requirement ID。
+- 以 `projects/fabushi-project-governance/` 自身完成标准迁移作为参考实现。
+- 通过 Skill validator/package + GitHub PR/CI/merge queue + canonical main verification 完成 FPG-002。
+
+## G2 — Adoption and measurement
 
 - 后续任务持续验证 Agent 是否正确复用/创建项目目录。
-- 根据真实使用发现改进模板、任务生命周期和验收规则。
+- 对已有项目采用“触及时迁移”，避免无差别重写历史项目。
+- 统计缺失项目记录、重复项目、无证据 passed、N/A 滥用等治理质量信号。
 
-## G2 — Enforcement hardening
+## G3 — Enforcement hardening
 
-- 如有必要，增加静态检查/CI guardrail，检测重要 PR 是否缺少相应项目记录更新。
+- 基于真实误用证据评估 FPG-003。
+- 如有必要，增加静态检查/CI guardrail 检查 mandatory files、Task ID/evidence 关联或重要 PR 项目记录更新。
+- 自动化不得取代项目 owner/reviewer 对 scope/acceptance 的判断。

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -2,6 +2,18 @@
 
 | Task ID | Atomic Task | Required | Acceptance Criterion | Verification | Status |
 |---|---|---:|---|---|---|
-| FPG-001 | 建立仓库级 Project-First Agent 门禁 | yes | 根 AGENTS.md 强制每次任务检查/复用/创建项目目录并在结束前回写记录 | PR #1976 + CI result success + main merge `eaf273dafc140619b06b46a4d7d234997acde05d` | passed |
-| FPG-002 | 根据真实使用校准项目模板 | no | 发现明确缺口时更新标准且保留变更记录 | 后续任务证据 | not-started |
+| FPG-001 | 建立仓库级 Project-First Agent 门禁 | yes | 根 AGENTS.md 强制每次任务检查/复用/创建项目目录并在结束前回写记录 | PR #1976 + CI result + main merge | passed |
+| FPG-002 | 建立 enterprise project-folder standard 并对齐 Task Orchestration/AGENTS/Skill | yes | FPG-002.1–FPG-002.8 全部通过 | FPG-002 task/evidence | in-progress |
+| FPG-002.1 | 定义 enterprise project folder / stable ID / N/A / no-meta-exemption 标准 | yes | governance standard/reference + ADR-0002 完整 | branch review | in-progress |
+| FPG-002.2 | 更新 root `AGENTS.md` | yes | 包含 enterprise scaffold、meta work 无豁免、completion gate、Task Orchestration alignment | branch/main file review | in-progress |
+| FPG-002.3 | 更新 Fabushi governance Skill/lifecycle | yes | Skill + project-folder standard + task lifecycle 使用同一规则 | branch/main file review | in-progress |
+| FPG-002.4 | 更新并验证 Task Orchestration Skill bundle | yes | quick_validate + package_skill 成功；包含 repository/meta-work project rules | Skill evidence + SHA-256 | passed |
+| FPG-002.5 | 治理项目自身迁移为 enterprise standard | yes | mandatory files 全部存在或显式 N/A | project-folder audit | in-progress |
+| FPG-002.6 | 完成 FPG-002 requirement/acceptance/evidence traceability | yes | source -> requirement -> WBS/task -> evidence 可追踪 | acceptance matrix/evidence index | in-progress |
+| FPG-002.7 | GitHub PR/required CI/protected merge | yes | `CI result` success 且按仓库保护流程合并 | PR/CI/merge evidence | not-started |
+| FPG-002.8 | Canonical `main` verification and closure | yes | main 上关键控制文件和项目目录验证后关闭 FPG-002 | post-merge fetch | not-started |
 | FPG-003 | 评估 CI 项目记录 guardrail | no | 有足够误用证据后决定是否自动化 enforcement | ADR/CI prototype | not-started |
+
+## Status rule
+
+`passed` 只用于 acceptance evidence 已存在的原子任务。代码/文档写入 branch 但 required CI/merge/main verification 尚未完成时，不将其提前等同于整个 parent task 完成。

--- a/projects/fabushi-project-governance/management/02-里程碑.md
+++ b/projects/fabushi-project-governance/management/02-里程碑.md
@@ -1,0 +1,11 @@
+# 里程碑
+
+| Milestone ID | Target | Required gates | Planned | Actual | Status | Evidence |
+|---|---|---|---|---|---|---|
+| FPG-M01 | Repository Project-First bootstrap | FPG-001 + root AGENTS + governance project | 2026-08-22 | 2026-08-22 | passed | PR #1976/#1977, main merge evidence |
+| FPG-M02 | Enterprise project-folder standard | FPG-002 + Task Orchestration package + root AGENTS + governance Skill + self-migrated governance project | 2026-08-22 | pending | in-progress | FPG-002 evidence index |
+| FPG-M03 | Automated governance guardrails | FPG-003 decision/prototype if justified | TBD | pending | not-started | future ADR/CI evidence |
+
+## Gate rules
+
+A milestone cannot be `passed` until every required task/gate is passed with objective evidence and the canonical `main` state is verified where repository changes are involved.

--- a/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
@@ -1,11 +1,26 @@
 # 验收追踪矩阵
 
-| Requirement | Implementation / Evidence | Status |
-|---|---|---|
-| 每次任务先看项目文件夹 | root `AGENTS.md` Project-First section on `main` | passed |
-| 已有项目按项目文档推进 | root `AGENTS.md` + governance skill | passed |
-| 没有项目就创建标准项目文件夹和文件 | root `AGENTS.md` + `project-folder-standard.md` | passed |
-| 每个实质任务有任务记录 | root `AGENTS.md` + `management/tasks/` rule | passed |
-| 任务结束回写记录和证据 | root `AGENTS.md` completion gate | passed |
-| 规则自身以项目文件夹执行 | `projects/fabushi-project-governance/` | passed |
-| GitHub 必需检查和 merge queue | PR #1976; `CI result` success; merge commit `eaf273dafc140619b06b46a4d7d234997acde05d` | passed |
+| Requirement | Implementation / Verification | Evidence | Status |
+|---|---|---|---|
+| FPG-R01 每次任务先定位/复用/创建项目文件夹 | root `AGENTS.md` + governance Skill lifecycle | FPG-001 main evidence; FPG-002 branch review | passed-baseline |
+| FPG-R02 新项目使用 enterprise standard | project-folder-standard + root scaffold + self-migrated governance project | FPG-002 project audit pending | in-progress |
+| FPG-R03 AGENTS/Skill/CI/governance meta work 无豁免 | root `AGENTS.md`, governance Skill, Task Orchestration standard | FPG-002 source/task + branch review | in-progress |
+| FPG-R04 `passed` 必须有 objective evidence | completion gate + task/evidence model | FPG-002 evidence index; main verification pending | in-progress |
+| FPG-R05 GitHub 项目目录/live engineering facts 为工程主基线 | SOURCE_OF_TRUTH + AGENTS + Skills | post-merge main verification pending | in-progress |
+| FPG-R06 Task Orchestration 与 GitHub 使用稳定 IDs | updated Task Orchestration SKILL/reference + governance Skill | Skill validator/package evidence | passed-package |
+| FPG-R07 无聊天上下文可重建项目 | enterprise root/docs/management/ADR/evidence/runbook set | self-migration project audit pending | in-progress |
+| Task Orchestration Skill validator | `quick_validate.py` | `Skill is valid!`; SHA-256 package evidence | passed |
+| Task Orchestration Skill package | `package_skill.py` | `skill.zip`, 16128 bytes, SHA-256 `95385f...efd61` | passed |
+| Root AGENTS enterprise scaffold | static file review | branch file + PR/main evidence pending | in-progress |
+| Governance Skill/reference/lifecycle alignment | static file review | branch file + PR/main evidence pending | in-progress |
+| Governance project mandatory files | folder audit | docs/management/owners/runbooks/ADR/task/evidence; final audit pending | in-progress |
+| GitHub required check | `CI result` | pending PR | not-started |
+| Protected merge / merge queue | repository merge policy | pending PR | not-started |
+| Canonical `main` verification | fetch key files after merge | pending | not-started |
+
+## Status semantics
+
+- `passed`: objective evidence complete for that acceptance item.
+- `passed-baseline` / `passed-package`: a scoped prerequisite is proven, but parent FPG-002 remains open until all required gates pass.
+- `in-progress`: implementation exists or is underway but required evidence/merge/main verification remains.
+- `not-started`: required downstream gate has not run yet.

--- a/projects/fabushi-project-governance/management/04-风险登记.md
+++ b/projects/fabushi-project-governance/management/04-风险登记.md
@@ -1,8 +1,12 @@
 # 风险登记
 
-| Risk | Impact | Mitigation | Status |
-|---|---|---|---|
-| 每个新聊天都误建新项目 | 项目目录碎片化 | 只对 genuinely different objective/workstream 新建；相同目标复用 | controlled |
-| 文档声称完成但代码/CI 未完成 | 错误进度 | GitHub code/PR/CI/release facts 决定实现状态 | controlled |
-| Agent 忘记回写项目记录 | 上下文丢失 | root AGENTS completion gate + governance skill | active |
-| 项目流程过重 | 小任务摩擦增加 | 共享最小标准模板，按项目需要增加 specialist docs | monitored |
+| Risk ID | Description | Probability | Impact | Severity | Owner | Mitigation | Trigger / contingency | Status | Review date |
+|---|---|---|---|---|---|---|---|---|---|
+| FPG-RK01 | 每个新聊天都误建新项目，造成目录碎片化 | medium | high | high | repository-governance | 只对 genuinely independent objective/workstream 新建；相同目标复用 | 发现重复目录时执行 duplicate-project recovery runbook | controlled | 2026-08-22 |
+| FPG-RK02 | 文档声称完成但代码/CI/release 尚未完成 | medium | high | high | task owner | live GitHub/CI/release evidence 决定工程事实；completion gate 禁止提前 passed | discrepancy 立即降级 task 状态并补证据/修正记录 | controlled | 2026-08-22 |
+| FPG-RK03 | Agent 忘记回写项目记录 | medium | high | high | task owner | root AGENTS completion gate + governance Skill + task lifecycle | completion report 前审计 WBS/acceptance/status/changelog/evidence | active | 2026-08-22 |
+| FPG-RK04 | Enterprise standard 变成低价值文档仪式 | medium | medium | medium | repository-governance | mandatory files 可显式 N/A，但必须 reason/owner/revisit trigger；避免空模板 | 发现大量空/复制模板时收紧质量审计而非继续加文件 | monitored | 2026-08-22 |
+| FPG-RK05 | Root AGENTS、governance Skill、Task Orchestration 标准漂移 | medium | high | high | repository-governance | 同一 FPG task 统一修改并记录 ADR/acceptance | 发现语义冲突时执行 governance-drift recovery runbook | active | 2026-08-22 |
+| FPG-RK06 | 把 Task Orchestration `skill.zip` 生成误报为已安装 | medium | medium | medium | task owner | 将 package evidence 与 install/activation state 分离 | 无安装证据时保持 external action open | controlled | 2026-08-22 |
+| FPG-RK07 | 项目文件中泄露 secret/private data | low | critical | critical | all contributors | security doc 禁止 secrets；evidence 使用受控链接而非复制敏感日志 | 发现后立即停止传播、按安全流程移除/轮换并记录 incident | active | 2026-08-22 |
+| FPG-RK08 | 一次性重写所有历史项目导致噪声/冲突 | medium | medium | medium | repository-governance | 采用“触及时迁移”策略 | 只有明确治理任务才批量迁移，默认逐项目演进 | controlled | 2026-08-22 |

--- a/projects/fabushi-project-governance/management/05-状态报告.md
+++ b/projects/fabushi-project-governance/management/05-状态报告.md
@@ -27,3 +27,35 @@
 - Acceptance: all FPG-001 functional acceptance criteria passed.
 - Blocker: none.
 - Next: 完成本轮 closure record 合并；后续所有仓库任务按该规则执行。
+
+## 2026-08-22 — FPG-002 Round 1
+
+- Work: 读取 Task Orchestration Skill、control-table reference、Skill Creator 指南以及 Fabushi root AGENTS/governance Skill/current project standard。
+- Finding: Task Orchestration 有 Project→Stage→Atomic Task→Evidence→Report Round 和 Sheets control model，但没有 enterprise GitHub project-folder contract；Fabushi 原标准是 minimal scaffold。
+- Work: 将用户需求归入已有 `projects/fabushi-project-governance/` 的 FPG-002，而不是创建重复治理项目。
+- Work: 创建 branch `project/fpg-002-enterprise-project-standard`。
+- Acceptance: enterprise standard design started.
+- Blocker: none.
+- Next: 实施 Task Orchestration/AGENTS/Skill 对齐并迁移治理项目自身。
+
+## 2026-08-22 — FPG-002 Round 2
+
+- Work: 更新 root `AGENTS.md`，加入完整 enterprise project scaffold、稳定 ID/证据/DoD 要求和 no-meta-exemption。
+- Work: 更新 `.agent/skills/fabushi-project-governance/SKILL.md`、`references/project-folder-standard.md`、`references/task-lifecycle.md`。
+- Work: 扩展治理项目 `PROJECT.yaml`, `README.md`, `SOURCE_OF_TRUTH.md`, 新增 `OWNERS.md` 与 dated source requirement。
+- Work: 新增 requirements/success metrics、architecture、quality/test、release/rollback、SLO/observability、security/privacy/compliance 文档。
+- Work: 新增 milestones、dependencies/blockers、issues/actions、runbook 和 ADR-0002。
+- Work: 打开 `FPG-002-enterprise-project-standard.md` task record 与 evidence index。
+- Evidence: branch commit stream under `project/fpg-002-enterprise-project-standard`.
+- Acceptance: implementation records present; GitHub PR/CI/merge gates pending.
+- Blocker: none.
+- Next: 完成 WBS/acceptance/status/changelog audit，创建 PR。
+
+## 2026-08-22 — FPG-002 Round 3
+
+- Work: 构建完整更新版 Task Orchestration Skill，保留原 agents/assets/references 并新增 `references/project-folder-standard.md`。
+- Acceptance: Skill Creator `quick_validate.py` returned `Skill is valid!`; `package_skill.py` succeeded.
+- Evidence: `skill.zip`, 16128 bytes, SHA-256 `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61`.
+- Important state: package creation/validation passed; installation into the user's current ChatGPT Skill library is not asserted and remains an external action.
+- Blocker: GitHub PR/CI/protected merge/main verification pending.
+- Next: create PR and complete canonical repository gates.

--- a/projects/fabushi-project-governance/management/06-依赖与阻塞.md
+++ b/projects/fabushi-project-governance/management/06-依赖与阻塞.md
@@ -1,0 +1,13 @@
+# 依赖与阻塞
+
+| Dependency ID | Dependency | Owner | Blocking relation | Fallback | Status |
+|---|---|---|---|---|---|
+| FPG-D01 | GitHub `projects/` and root `AGENTS.md` available on `main` | repository-maintainers | Required for repository-wide enforcement | none | available |
+| FPG-D02 | `.agent/skills/fabushi-project-governance/` | repository-governance | Required reusable lifecycle/standard | root AGENTS contains minimum enforcement | available |
+| FPG-D03 | Task Orchestration Skill packaging toolchain | Skill Creator | Required to validate/distribute external Task Orchestration update | repository standard remains independently usable | available |
+| FPG-D04 | GitHub required `CI result` / protected merge flow | repository-maintainers | Required for canonical governance changes | keep task in-progress until available | available |
+| FPG-D05 | External Task Orchestration installation/activation by product runtime/user | ChatGPT product/user | Required only for replacing currently installed Skill bundle | provide validated `skill.zip`; do not falsely claim installation | external-action |
+
+## Current blockers
+
+No implementation blocker for FPG-002. External installation of the packaged Task Orchestration Skill is tracked separately from successful package creation/validation.

--- a/projects/fabushi-project-governance/management/07-变更日志.md
+++ b/projects/fabushi-project-governance/management/07-变更日志.md
@@ -1,9 +1,26 @@
 # 变更日志
 
-## 2026-08-22
+## 2026-08-22 — FPG-001
 
 - 创建独立仓库级治理项目 `projects/fabushi-project-governance/`。
 - 将“每次任务先检查项目目录、无匹配项目则创建、结束前回写记录”提升为根 `AGENTS.md` 强制规则。
 - 复用已合并的 `.agent/skills/fabushi-project-governance/` 作为详细执行规范。
 - PR #1976 通过必需 `CI result` 和 merge queue 合并到 `main`，合并提交 `eaf273dafc140619b06b46a4d7d234997acde05d`。
 - FPG-001 完成功能验收，项目阶段从 repository-wide-bootstrap 转入 adoption。
+
+## 2026-08-22 — FPG-002 enterprise standardization
+
+- 将 project-folder standard 从 minimal scaffold 升级为 enterprise project package。
+- 新 mandatory root files: `OWNERS.md`；新增 runbooks area。
+- 新 standard docs: requirements/success metrics、architecture/implementation、quality/test、release/migration/rollback、observability/SLO、security/privacy/compliance。
+- 新 management files: milestones、dependencies/blockers、issues/actions。
+- 引入稳定 Requirement/Project/Stage/Task/Milestone/Risk/ADR/Evidence IDs 和 requirement-to-evidence traceability。
+- 引入 mandatory-file N/A 规则：必须写 reason + owner + revisit trigger，禁止空文件式合规。
+- 明确 root/nested `AGENTS.md`、Skills、CI/CD、merge/release policy、architecture/documentation governance、build tooling、安全治理等 meta work 没有项目治理豁免。
+- 更新 root `AGENTS.md` 与 `.agent/skills/fabushi-project-governance/` 控制面。
+- 新增 ADR-0002 记录 enterprise standard 决策及增量迁移策略。
+- 将 `projects/fabushi-project-governance/` 自身迁移为新标准参考实现。
+- 更新 Task Orchestration Skill：repository engineering work 使用相同 enterprise project-folder contract；Sheets 保持 portfolio/control view，不替代 GitHub engineering facts。
+- Task Orchestration Skill validator/package 已通过；生成 `skill.zip` SHA-256 `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61`。
+- 明确 Skill package creation 与实际安装/激活分离，禁止把“已打包”误记为“已安装”。
+- GitHub PR/CI/protected merge/canonical main verification 尚未完成，因此 FPG-002 仍为 `in-progress`。

--- a/projects/fabushi-project-governance/management/08-问题与行动项.md
+++ b/projects/fabushi-project-governance/management/08-问题与行动项.md
@@ -1,0 +1,13 @@
+# 问题与行动项
+
+| Item ID | Type | Question / Action | Owner | Due / decision trigger | Status | Resolution / link |
+|---|---|---|---|---|---|---|
+| FPG-I01 | action | 将 enterprise project-folder standard 写入 root AGENTS 与 governance Skill | repository-governance | FPG-002 | in-progress | branch `project/fpg-002-enterprise-project-standard` |
+| FPG-I02 | action | 构建并验证更新后的 Task Orchestration Skill bundle | Skill Creator workflow | FPG-002 | passed-local | validated `skill.zip`; GitHub evidence index pending |
+| FPG-I03 | action | 将 governance project 自身迁移到 enterprise standard | repository-governance | FPG-002 | in-progress | this project change stream |
+| FPG-I04 | decision | 是否未来用 CI 自动检查 mandatory project files | repository-maintainers | FPG-003 | open | evaluate after real adoption evidence |
+| FPG-I05 | external action | 更新后的 Task Orchestration bundle 是否已在用户环境安装/替换 | user / ChatGPT product | after package delivery | open | package creation != installation |
+
+## Rule
+
+Close an item only with a recorded resolution or linked task/ADR/evidence. Do not delete unresolved historical items.

--- a/projects/fabushi-project-governance/management/tasks/FPG-002-enterprise-project-standard.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-002-enterprise-project-standard.md
@@ -1,0 +1,91 @@
+# FPG-002 — Enterprise Project Folder Standard
+
+- **Task ID:** FPG-002
+- **Status:** in-progress
+- **Started:** 2026-08-22T14:09:00+08:00
+- **Updated:** 2026-08-22T14:09:00+08:00
+- **Completed:** pending
+
+## Objective
+
+Upgrade Fabushi project governance from the original minimal project scaffold to an enterprise-standard project folder and align Task Orchestration, root `AGENTS.md`, and `.agent/skills/fabushi-project-governance` with the same rules, including no exemptions for AGENTS/Skill/CI/governance work.
+
+## Source requirement
+
+- `../../source/2026-08-22-FPG-002-enterprise-project-standard.md`
+- Requirements: FPG-R01 through FPG-R07 in `../../docs/02-需求与成功指标.md`
+
+## In scope
+
+- enterprise project-folder standard;
+- root `AGENTS.md` project scaffold and no-meta-exemption rule;
+- governance Skill and lifecycle references;
+- Task Orchestration Skill bundle update;
+- migrate `projects/fabushi-project-governance/` itself to the new standard;
+- FPG-002 WBS/acceptance/status/change/evidence closure;
+- protected GitHub PR/CI/merge verification.
+
+## Out of scope
+
+- automatically installing the packaged Task Orchestration Skill into every ChatGPT product/runtime;
+- mass-migrating every historical Fabushi project in the same PR;
+- adding CI enforcement for project-folder mandatory files (candidate FPG-003);
+- product runtime code changes.
+
+## Dependencies
+
+See `../06-依赖与阻塞.md`.
+
+## Acceptance criteria
+
+1. Task Orchestration includes enterprise repository project-folder rules and a reusable `references/project-folder-standard.md`.
+2. Task Orchestration explicitly covers AGENTS.md, Skills, CI/CD, architecture/documentation governance, and other meta work.
+3. Task Orchestration validator passes and `skill.zip` packages successfully.
+4. Root `AGENTS.md` contains the enterprise scaffold and no-meta-exemption rule.
+5. Governance Skill/reference/lifecycle align with the same standard.
+6. `projects/fabushi-project-governance/` contains all mandatory standard files or explicit N/A rationale.
+7. An ADR records adoption of the enterprise standard.
+8. FPG-002 project records/evidence are complete.
+9. GitHub required `CI result` passes and changes merge through protected main/merge queue.
+10. Canonical `main` is verified after merge.
+
+## Verification
+
+- Skill Creator `quick_validate.py` on Task Orchestration bundle.
+- Skill Creator `package_skill.py` and SHA-256 evidence.
+- Inspect root `AGENTS.md`, governance Skill and standard/lifecycle references.
+- Project-folder audit against the mandatory scaffold.
+- GitHub PR/CI/merge queue evidence.
+- Post-merge fetch from `main`.
+
+## Branch / PR
+
+- Branch: `project/fpg-002-enterprise-project-standard`
+- PR: pending creation
+
+## Implementation summary
+
+In progress. The branch now contains enterprise standard changes to root `AGENTS.md`, governance Skill/reference/lifecycle, expanded project metadata/source/ownership, new governance engineering documents, milestones/dependencies/issues, ADR-0002, and runbook index.
+
+The Task Orchestration Skill has been rebuilt as a complete bundle with the new standard and validated locally with Skill Creator tooling.
+
+## Skill package evidence
+
+- Bundle: `skill.zip`
+- SHA-256: `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61`
+- Size: `16128 bytes`
+- `quick_validate.py`: passed
+- `package_skill.py`: passed
+- Installation state: not claimed; package delivery/installation is a separate external action.
+
+## Evidence
+
+See `../../evidence/FPG-002/README.md`.
+
+## Blockers / risks
+
+No implementation blocker. Canonical completion remains blocked on GitHub PR required checks, protected merge, post-merge verification, and project-record closure.
+
+## Next action
+
+Finish standard project self-migration records, create PR, run required CI, merge through repository policy, verify `main`, and then close FPG-002.

--- a/projects/fabushi-project-governance/management/tasks/FPG-002-enterprise-project-standard.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-002-enterprise-project-standard.md
@@ -3,7 +3,7 @@
 - **Task ID:** FPG-002
 - **Status:** in-progress
 - **Started:** 2026-08-22T14:09:00+08:00
-- **Updated:** 2026-08-22T14:09:00+08:00
+- **Updated:** 2026-08-22T14:22:00+08:00
 - **Completed:** pending
 
 ## Objective
@@ -61,13 +61,15 @@ See `../06-依赖与阻塞.md`.
 ## Branch / PR
 
 - Branch: `project/fpg-002-enterprise-project-standard`
-- PR: pending creation
+- Implementation PR: #1980
+- Initial PR head before this evidence update: `79d80ba3aab78fbdefd613802f194c5064473122`
+- Current branch head: this task-record update and subsequent project-record commits; final PR head will be read from GitHub before CI/merge evidence is closed.
 
 ## Implementation summary
 
-In progress. The branch now contains enterprise standard changes to root `AGENTS.md`, governance Skill/reference/lifecycle, expanded project metadata/source/ownership, new governance engineering documents, milestones/dependencies/issues, ADR-0002, and runbook index.
+In progress. The branch contains enterprise standard changes to root `AGENTS.md`, governance Skill/reference/lifecycle, expanded project metadata/source/ownership, new governance engineering documents, milestones/dependencies/issues, ADR-0002, runbook index, FPG-002 task/evidence, and a branch project-folder audit.
 
-The Task Orchestration Skill has been rebuilt as a complete bundle with the new standard and validated locally with Skill Creator tooling.
+The Task Orchestration Skill has been rebuilt as a complete bundle with the new standard and validated with Skill Creator tooling.
 
 ## Skill package evidence
 
@@ -84,8 +86,8 @@ See `../../evidence/FPG-002/README.md`.
 
 ## Blockers / risks
 
-No implementation blocker. Canonical completion remains blocked on GitHub PR required checks, protected merge, post-merge verification, and project-record closure.
+No implementation blocker. Canonical completion remains blocked on GitHub PR #1980 required checks, protected merge, post-merge verification, and project-record closure.
 
 ## Next action
 
-Finish standard project self-migration records, create PR, run required CI, merge through repository policy, verify `main`, and then close FPG-002.
+Run PR #1980 required CI, inspect selected/skipped jobs, merge through repository policy, verify `main`, then close FPG-002 in a final records-only change if required.

--- a/projects/fabushi-project-governance/runbooks/README.md
+++ b/projects/fabushi-project-governance/runbooks/README.md
@@ -1,0 +1,40 @@
+# Governance Runbooks
+
+Use this directory for repeatable repository-governance procedures.
+
+## Standard project intake / recovery
+
+1. Read root/nested `AGENTS.md`.
+2. Search `projects/` for a matching objective.
+3. Reuse the matching project or create the enterprise scaffold.
+4. Read `SOURCE_OF_TRUTH.md`, metadata/owners, relevant specs, WBS/milestones/acceptance/risks/dependencies/status/changelog/issues/actions, ADRs, task record, and evidence.
+5. Verify live GitHub branch/PR/CI/release/deployment facts.
+6. Open/update a stable task record before substantial work.
+7. Execute and verify only eligible work.
+8. Update project records/evidence in the same change stream when possible.
+9. Merge through protected-main policy.
+10. Re-read canonical `main` before marking passed.
+
+## Duplicate project recovery
+
+If two project folders overlap:
+
+1. Stop creating new tasks in both folders.
+2. Compare source-of-truth/scope/active tasks.
+3. Choose one canonical folder based on the user's objective and existing evidence.
+4. Record the consolidation decision in changelog/ADR when material.
+5. Move or cross-reference outstanding task/evidence history without rewriting prior facts.
+6. Mark the non-canonical folder archived/superseded rather than deleting audit history.
+
+## Governance drift recovery
+
+If root `AGENTS.md`, governance Skill, Task Orchestration standard, or project template drift:
+
+1. Open a governance task under this project.
+2. Identify the canonical current standard from user requirement + accepted ADR/spec.
+3. Patch all affected control planes in one change stream when possible.
+4. Validate Skills independently from GitHub CI.
+5. Update WBS/acceptance/status/changelog/evidence.
+6. Verify merged `main` and document any external Skill installation action still required.
+
+Last validated: 2026-08-22 (FPG-002 implementation branch; canonical validation pending merge).

--- a/projects/fabushi-project-governance/source/2026-08-22-FPG-002-enterprise-project-standard.md
+++ b/projects/fabushi-project-governance/source/2026-08-22-FPG-002-enterprise-project-standard.md
@@ -1,0 +1,28 @@
+# FPG-002 Source Requirement — Enterprise Project Folder Standard
+
+Date: 2026-08-22
+
+## User requirement
+
+Standardize the project-folder structure created for Fabushi into Task Orchestration, using an enterprise/large-company project-document standard. The same project-folder requirement must apply to GitHub root `AGENTS.md` and repository Skills: AGENTS/Skill work must also be performed under a standard project folder rather than being treated as an exception.
+
+## Normalized intent
+
+1. Upgrade the Fabushi project-folder standard from a minimal scaffold to an enterprise project package.
+2. Align root `AGENTS.md` with the same standard.
+3. Align `.agent/skills/fabushi-project-governance` with the same standard.
+4. Update Task Orchestration so repository engineering work locates/reuses or creates the standard project folder before substantial work.
+5. Explicitly state that AGENTS.md, Skill, CI/CD, documentation governance, architecture-policy, release-tooling, and similar meta work has no exemption.
+6. Upgrade `projects/fabushi-project-governance/` itself to the new standard as proof the governance task follows its own rule.
+7. Preserve live GitHub/CI/release evidence as authoritative for engineering facts; external Sheets/Drive views may be management/control/mirror systems but must not silently override repository state.
+
+## Acceptance intent
+
+The task is complete only when:
+
+- the Task Orchestration Skill package validates with the new project-folder reference and repository/meta-work rules;
+- root `AGENTS.md` contains the enterprise scaffold and no-meta-exemption rule;
+- the Fabushi governance Skill and lifecycle references contain the same model;
+- the governance project itself contains all mandatory standard files (or explicit N/A with reason);
+- FPG-002 task/WBS/acceptance/status/changelog/evidence records are updated;
+- GitHub required CI/merge policy succeeds and canonical `main` is verified.


### PR DESCRIPTION
## Summary
- upgrade Fabushi `projects/<slug>/` from the minimal scaffold to an enterprise project package
- add ownership, stable requirements/success metrics, architecture, quality/test, release/rollback, SLO/operations, security/privacy/compliance, milestones, dependencies/blockers, issues/actions, ADR/evidence/runbook rules
- make root `AGENTS.md` explicitly require the same project standard for every task, including AGENTS.md, Skill, CI/CD, merge/release, architecture/documentation governance and other repository meta work
- align `.agent/skills/fabushi-project-governance` and its lifecycle/reference files with the same rules
- self-migrate `projects/fabushi-project-governance/` to the enterprise standard as the reference implementation
- align Task Orchestration with the same Project/Stage/Task/Requirement ID model and repository project-folder contract; validated full `skill.zip` is recorded as external package evidence

## Task
`FPG-002`

## Governance model
For Fabushi engineering work, GitHub `projects/<slug>/` is the durable engineering specification/execution record and live GitHub/CI/release/deployment state is authoritative for engineering facts. Google Sheets may remain a portfolio/control view; Drive/Gmail/Calendar retain source/mirror/reporting/scheduling roles.

## Safety / scope
- no product runtime code changes
- no secrets or private data added
- no mass migration of all historical projects; existing projects migrate incrementally when substantively touched
- mandatory documents may use explicit N/A only with reason, owner and revisit trigger
- creating a Task Orchestration package is not asserted as installing it into the user's current ChatGPT Skill library

## Validation
- Task Orchestration `quick_validate.py`: passed
- Task Orchestration `package_skill.py`: passed
- package SHA-256: `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61`
- branch project-folder audit: mandatory enterprise scaffold present
- require GitHub `CI result`
- merge only through protected main / merge queue
- after merge, fetch root `AGENTS.md`, governance Skill/reference and governance project files from `main`
