### PR TITLE
ci: classify Agent Skills as governance-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
             const isDocsSafe = (filename) =>
               /^projects\//.test(filename) ||
               /^docs\//.test(filename) ||
+              /^\.agent\/skills\//.test(filename) ||
               /^[^/]+\.md$/.test(filename) ||
               /^\.github\/[^/]+\.md$/.test(filename);
 

--- a/projects/fabushi-cicd-merge-governance/evidence/FCM-003/README.md
+++ b/projects/fabushi-cicd-merge-governance/evidence/FCM-003/README.md
@@ -1,0 +1,25 @@
+# FCM-003 Evidence Index
+
+Status: in-progress.
+
+## Trigger
+
+- FPG-002 PR #1980.
+- CI run `32556780549`: `.agent/skills/**` entered unknown non-document fallback and selected unrelated product suites.
+
+## Implementation
+
+- Branch: `project/fcm-003-agent-skill-ci-classification`.
+- `.github/workflows/ci.yml`: exact `.agent/skills/**` governance-safe classifier addition.
+- `.agents/plugins/**` remains MCP runtime input.
+- `.github/workflows/**` remains workflow guardrail input.
+- Unknown non-document paths retain force-all fallback.
+
+## Pending gates
+
+- commit SHA
+- PR number
+- required PR CI / `CI result`
+- merge-group CI
+- merge commit
+- canonical `main` verification

--- a/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
@@ -10,4 +10,4 @@
 | FCM-001.6 | Update enterprise branch/merge policy | yes | policy matches implementation | passed |
 | FCM-001.7 | Validate PR + merge queue + record timing | yes | required CI success and merge through queue | passed |
 | FCM-002 | Establish CI latency SLO dashboard/measurement | no | P50/P95 by change tier tracked | not-started |
-| FCM-003 | Classify remaining unknown runtime paths | no | common runtime paths mapped to dedicated checks | not-started |
+| FCM-003 | Classify Agent/Skill governance paths without weakening runtime fail-safe | yes | `.agent/skills/**` is governance-safe; `.agents/plugins/**`, workflows, and unknown runtime paths retain dedicated/fail-safe checks | in-progress |

--- a/projects/fabushi-cicd-merge-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-cicd-merge-governance/management/03-验收追踪矩阵.md
@@ -10,3 +10,4 @@
 | unrelated Worker deploy skipped | `deploy-production.yml` has source-impact gate before staging/deploy | passed |
 | unrelated Pay deploy skipped | `fabushi-pay-production.yml` has source-impact gate before migration/deploy | passed |
 | enterprise policy documented | `.github/BRANCH_PROTECTION.md` | passed |
+| Agent/Skill governance fast path | `.agent/skills/**` is docs/governance-safe while `.agents/plugins/**` remains MCP and unknown non-doc paths still force all | in-progress |

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -22,3 +22,11 @@
 - Explicitly authorized the sensitive CI/CD change after green checks; GitHub merge queue created the queue entry and performed final protected validation.
 - PR #1978 merged to `main` as `ac94b40d4a05a0211146c2bb5904aa936a7bc928`.
 - Implementation acceptance passed; next stage is latency measurement and further domain coverage.
+
+## 2026-08-22 — FCM-003 Round 1
+
+- Reconstructed the task from canonical `main` and FPG-002 evidence.
+- Confirmed the root cause: `.agent/skills/**` is not recognized by `isDocsSafe()`, so governance-only Skill changes enter the unknown non-document fail-safe and select every canonical product domain.
+- Preserved `.agents/plugins/**` as MCP runtime input, `.github/workflows/**` as workflow guardrail input, and the unknown non-document force-all fail-safe.
+- Implemented the narrow classifier change adding only `.agent/skills/**` to the governance/docs-safe matcher.
+- PR/required CI/merge-queue evidence remains pending; FCM-003 stays in-progress until protected-main verification.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -9,3 +9,4 @@
 - Added Worker and Fabushi Pay product-impact deployment gates.
 - Updated `.github/BRANCH_PROTECTION.md` with enterprise merge and latency policy.
 - PR #1978 merged through the protected merge queue at commit `ac94b40d4a05a0211146c2bb5904aa936a7bc928`.
+- Opened FCM-003 and classified `.agent/skills/**` as governance-safe without changing `.agents/plugins/**`, workflow guardrails, or the unknown runtime fail-safe.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-003-agent-skill-governance-fast-path.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-003-agent-skill-governance-fast-path.md
@@ -1,0 +1,72 @@
+# FCM-003 — Agent/Skill Governance CI Classification
+
+- **Task ID:** FCM-003
+- **Status:** in-progress
+- **Started:** 2026-08-22T14:24:00+08:00
+- **Updated:** 2026-08-22T14:50:00+08:00
+- **Completed:** pending
+
+## Objective
+
+Prevent repository-governance-only changes under `.agent/skills/**`, root Markdown governance files, `projects/**`, and `docs/**` from triggering the unknown-path fail-safe and unrelated Frontend/Worker/MCP/Electron suites, without weakening safety for runtime paths.
+
+## Source / trigger
+
+- FPG-002 PR #1980 / CI run `32556780549` proved `.agent/skills/**` was treated as an unknown non-document path.
+- User requested cleanup and completion of the unfinished FCM-003 branch on 2026-08-22.
+
+## In scope
+
+- add `.agent/skills/**` to governance/docs-safe classification;
+- preserve `.agents/plugins/**` in MCP runtime classification;
+- preserve `.github/workflows/**` in workflow guardrails;
+- preserve unknown non-document force-all behavior;
+- validate through required PR CI and merge queue.
+
+## Out of scope
+
+- changing product test semantics;
+- weakening the required aggregate `CI result`;
+- bypassing protected `main` / merge queue;
+- treating arbitrary `.agent/**` or unknown runtime paths as docs-safe.
+
+## Acceptance criteria
+
+1. `.agent/skills/**`, root Markdown, `projects/**`, and `docs/**` do not force all product domains when no runtime files changed.
+2. `.agents/plugins/**` still selects MCP contracts.
+3. `.github/workflows/**` still selects workflow guardrails.
+4. Unknown non-document paths still fail safe to all canonical product domains.
+5. Required `CI result` succeeds.
+6. The change merges through protected `main` / merge queue.
+7. Canonical `main` is re-read after merge and project records are closed with objective evidence.
+
+## Implementation
+
+- `.github/workflows/ci.yml`: add the exact matcher `^\.agent\/skills\/` to `isDocsSafe()`.
+- No change to domain matchers or force-all logic.
+
+## Verification
+
+- Lightweight static classifier assertions before push.
+- PR-head GitHub Actions selection.
+- Merge-group required CI.
+- Post-merge read from `main`.
+
+## Branch / PR
+
+- Branch: `project/fcm-003-agent-skill-ci-classification`
+- PR: pending
+
+## Evidence
+
+- Trigger: PR #1980 / CI run `32556780549`.
+- Implementation/CI/merge evidence: pending.
+
+## Blockers / risks
+
+- No implementation blocker.
+- Local repository disk is nearly full; repository policy forbids local builds/tests, so verification is delegated to GitHub Actions.
+
+## Next action
+
+Commit and push the classifier + project records, open PR, verify required CI and merge queue, then close FCM-003 on canonical `main`.


### PR DESCRIPTION
## Summary
- complete FCM-003 from the existing `projects/fabushi-cicd-merge-governance/` project
- classify only `.agent/skills/**` as governance/docs-safe in the CI impact classifier
- preserve `.agents/plugins/**` as MCP runtime input
- preserve `.github/workflows/**` as workflow guardrail input
- preserve the unknown non-document force-all fail-safe
- add FCM-003 task, WBS, acceptance, status, changelog, and evidence records

## Why
FPG-002 PR #1980 / CI run `32556780549` proved governance-only changes under `.agent/skills/**` were incorrectly treated as unknown runtime paths, selecting unrelated product suites.

## Validation
Lightweight static assertions passed before push for:
- `.agent/skills/**` => governance/docs-safe
- `.agents/plugins/**` => MCP domain
- `.github/workflows/**` => workflow domain
- unknown runtime paths => remain non-doc/non-domain and therefore force-all
- `git diff --check`

Heavy/authoritative verification is intentionally delegated to GitHub Actions per repository disk-safety policy.

## Task
FCM-003

## Merge policy
Required CI must pass and the PR must merge through protected `main` / merge queue. FCM-003 remains in-progress until post-merge main verification and closure evidence are recorded.