### PR TITLE
docs: close FCM-003 and verify Agent Skill fast path

### DIFF
--- a/.agent/skills/fabushi-project-governance/SKILL.md
+++ b/.agent/skills/fabushi-project-governance/SKILL.md
@@ -83,6 +83,7 @@ Do not rely on remembered requirements when the project folder can resolve them.
 - Track dependencies/blockers in `management/06-依赖与阻塞.md` and open questions/actions in `management/08-问题与行动项.md`.
 - Store durable evidence or indexes under `evidence/<task-id>/`; link large build artifacts, workflow runs, releases, PRs, commits, or deployment checks instead of copying binaries.
 - Update runbooks when a task changes repeatable operational procedures.
+- CI classification note: repository-governance files under `.agent/skills/**` are governance/docs-safe inputs; runtime plugin code under `.agents/plugins/**` remains an MCP product-domain input and unknown non-document paths must continue to fail safe.
 
 ## Completion gate
 

--- a/projects/fabushi-cicd-merge-governance/evidence/FCM-003/README.md
+++ b/projects/fabushi-cicd-merge-governance/evidence/FCM-003/README.md
@@ -1,6 +1,6 @@
 # FCM-003 Evidence Index
 
-Status: in-progress.
+Status: passed after protected merge and canonical `main` verification; closure smoke pending merge.
 
 ## Trigger
 
@@ -10,16 +10,33 @@ Status: in-progress.
 ## Implementation
 
 - Branch: `project/fcm-003-agent-skill-ci-classification`.
+- Commit: `9187fb6f8cfbca8e9ac1f25a61aa12bb6a4fa0a5`.
+- PR: #1984.
 - `.github/workflows/ci.yml`: exact `.agent/skills/**` governance-safe classifier addition.
 - `.agents/plugins/**` remains MCP runtime input.
 - `.github/workflows/**` remains workflow guardrail input.
 - Unknown non-document paths retain force-all fallback.
 
-## Pending gates
+## PR validation
 
-- commit SHA
-- PR number
-- required PR CI / `CI result`
-- merge-group CI
-- merge commit
-- canonical `main` verification
+- PR CI run: `32558117683` — success.
+- `Classify CI changes` — success.
+- `Canonical architecture guardrails` — success because this PR changed `ci.yml`.
+- Frontend / Worker / MCP / Electron product suites — skipped.
+- Required `CI result` — success.
+
+## Merge queue validation
+
+- Merge-group CI run: `32558147639` — success.
+- Frontend / Worker / MCP / Electron product suites — skipped.
+- Required `CI result` — success.
+- Merge commit: `3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`.
+
+## Canonical main verification
+
+- Re-read `main:.github/workflows/ci.yml`; `isDocsSafe()` contains `^\.agent\/skills\/`.
+- No domain matcher or unknown force-all behavior was removed.
+
+## Closure smoke
+
+This closure PR intentionally changes `.agent/skills/fabushi-project-governance/SKILL.md` plus `projects/**`. It must prove that governance-only Skill/project changes do not trigger Frontend, Worker, MCP, Electron, or workflow guardrail suites. Required aggregate `CI result` must still pass on both PR and merge-group events.

--- a/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
@@ -10,4 +10,4 @@
 | FCM-001.6 | Update enterprise branch/merge policy | yes | policy matches implementation | passed |
 | FCM-001.7 | Validate PR + merge queue + record timing | yes | required CI success and merge through queue | passed |
 | FCM-002 | Establish CI latency SLO dashboard/measurement | no | P50/P95 by change tier tracked | not-started |
-| FCM-003 | Classify Agent/Skill governance paths without weakening runtime fail-safe | yes | `.agent/skills/**` is governance-safe; `.agents/plugins/**`, workflows, and unknown runtime paths retain dedicated/fail-safe checks | in-progress |
+| FCM-003 | Classify Agent/Skill governance paths without weakening runtime fail-safe | yes | `.agent/skills/**` is governance-safe; `.agents/plugins/**`, workflows, and unknown runtime paths retain dedicated/fail-safe checks | passed |

--- a/projects/fabushi-cicd-merge-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-cicd-merge-governance/management/03-验收追踪矩阵.md
@@ -10,4 +10,4 @@
 | unrelated Worker deploy skipped | `deploy-production.yml` has source-impact gate before staging/deploy | passed |
 | unrelated Pay deploy skipped | `fabushi-pay-production.yml` has source-impact gate before migration/deploy | passed |
 | enterprise policy documented | `.github/BRANCH_PROTECTION.md` | passed |
-| Agent/Skill governance fast path | `.agent/skills/**` is docs/governance-safe while `.agents/plugins/**` remains MCP and unknown non-doc paths still force all | in-progress |
+| Agent/Skill governance fast path | PR #1984 + PR CI `32558117683` + merge-group CI `32558147639`; `.agent/skills/**` closure smoke is governance-safe while `.agents/plugins/**` remains MCP and unknown non-doc paths retain force-all | passed |

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -30,3 +30,12 @@
 - Preserved `.agents/plugins/**` as MCP runtime input, `.github/workflows/**` as workflow guardrail input, and the unknown non-document force-all fail-safe.
 - Implemented the narrow classifier change adding only `.agent/skills/**` to the governance/docs-safe matcher.
 - PR/required CI/merge-queue evidence remains pending; FCM-003 stays in-progress until protected-main verification.
+
+## 2026-08-22 — FCM-003 Round 2
+
+- Implementation PR #1984 head `9187fb6f8cfbca8e9ac1f25a61aa12bb6a4fa0a5` passed PR CI run `32558117683`.
+- PR-head classification selected only `Canonical architecture guardrails`; Frontend, Worker, MCP, and Electron product suites were skipped.
+- PR #1984 entered the protected merge queue; merge-group CI run `32558147639` passed with the same narrow selection and required `CI result` success.
+- GitHub merge queue merged PR #1984 to `main` as `3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`.
+- Canonical `main` was re-read and contains the exact `.agent/skills/**` governance-safe matcher.
+- This closure change intentionally touches `.agent/skills/**` plus project records to smoke-test the new governance fast path after merge.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -10,3 +10,4 @@
 - Updated `.github/BRANCH_PROTECTION.md` with enterprise merge and latency policy.
 - PR #1978 merged through the protected merge queue at commit `ac94b40d4a05a0211146c2bb5904aa936a7bc928`.
 - Opened FCM-003 and classified `.agent/skills/**` as governance-safe without changing `.agents/plugins/**`, workflow guardrails, or the unknown runtime fail-safe.
+- FCM-003 merged through PR #1984 / merge queue (`3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`); added a governance Skill note and closure smoke to verify `.agent/skills/**` remains on the safe fast path.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-003-agent-skill-governance-fast-path.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-003-agent-skill-governance-fast-path.md
@@ -1,10 +1,10 @@
 # FCM-003 — Agent/Skill Governance CI Classification
 
 - **Task ID:** FCM-003
-- **Status:** in-progress
+- **Status:** passed
 - **Started:** 2026-08-22T14:24:00+08:00
-- **Updated:** 2026-08-22T14:50:00+08:00
-- **Completed:** pending
+- **Updated:** 2026-08-22T14:55:00+08:00
+- **Completed:** 2026-08-22T14:54:20+08:00
 
 ## Objective
 
@@ -55,18 +55,22 @@ Prevent repository-governance-only changes under `.agent/skills/**`, root Markdo
 ## Branch / PR
 
 - Branch: `project/fcm-003-agent-skill-ci-classification`
-- PR: pending
+- PR: #1984
 
 ## Evidence
 
 - Trigger: PR #1980 / CI run `32556780549`.
-- Implementation/CI/merge evidence: pending.
+- Implementation commit: `9187fb6f8cfbca8e9ac1f25a61aa12bb6a4fa0a5`.
+- PR CI: run `32558117683`, success.
+- Merge-group CI: run `32558147639`, success; required `CI result` passed.
+- Merge queue commit on `main`: `3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`.
+- Post-merge `main` read verified the `.agent/skills/**` matcher.
 
 ## Blockers / risks
 
-- No implementation blocker.
-- Local repository disk is nearly full; repository policy forbids local builds/tests, so verification is delegated to GitHub Actions.
+- No remaining blocker.
+- Local heavy verification was intentionally not run; repository policy delegates builds/tests to GitHub Actions.
 
 ## Next action
 
-Commit and push the classifier + project records, open PR, verify required CI and merge queue, then close FCM-003 on canonical `main`.
+Merge this closure/smoke PR, verify the `.agent/skills/**`-only governance fast path on PR and merge-group CI, then verify canonical `main`.


### PR DESCRIPTION
## Summary
- close FCM-003 records after implementation PR #1984 merged through protected main
- record PR CI `32558117683`, merge-group CI `32558147639`, merge commit `3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`, and canonical main verification
- add one governance note to `.agent/skills/fabushi-project-governance/SKILL.md`

## Purpose of this PR
This is also the real post-fix smoke test for FCM-003. Its changed paths are only `.agent/skills/**` plus `projects/**`.

Expected CI behavior:
- `Classify CI changes`: run and pass
- Frontend: skipped
- Worker: skipped
- MCP: skipped (`.agents/plugins/**` is MCP; `.agent/skills/**` is not)
- Canonical architecture guardrails: skipped (no workflow file changed)
- Electron: skipped
- required `CI result`: run and pass

The same narrow behavior must hold in the merge-group run. The PR must merge through protected `main` / merge queue.