### PR TITLE
docs: record final FCM-003 acceptance evidence

### DIFF
--- a/projects/fabushi-cicd-merge-governance/evidence/FCM-003/README.md
+++ b/projects/fabushi-cicd-merge-governance/evidence/FCM-003/README.md
@@ -1,6 +1,6 @@
 # FCM-003 Evidence Index
 
-Status: passed after protected merge and canonical `main` verification; closure smoke pending merge.
+Status: passed; implementation and post-fix governance smoke both passed protected PR + merge-group CI and merged to canonical `main`.
 
 ## Trigger
 
@@ -39,4 +39,10 @@ Status: passed after protected merge and canonical `main` verification; closure 
 
 ## Closure smoke
 
-This closure PR intentionally changes `.agent/skills/fabushi-project-governance/SKILL.md` plus `projects/**`. It must prove that governance-only Skill/project changes do not trigger Frontend, Worker, MCP, Electron, or workflow guardrail suites. Required aggregate `CI result` must still pass on both PR and merge-group events.
+- Closure/smoke PR: #1985.
+- Head commit: `c0b89c4c115d9065df57d7dd36d8510f05ce1182`.
+- PR CI run: `32558243330` — success.
+- Merge-group CI run: `32558267502` — success.
+- Both runs executed only `Classify CI changes` + required `CI result`; Frontend, Worker, MCP, Electron, and Canonical architecture guardrails were skipped.
+- Merge commit: `fc4e0521a0bac8729632432acb6149cad5ab403d`.
+- Result: real `.agent/skills/**` + `projects/**` changes now use the intended governance fast path in both PR and merge-group contexts.

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -39,3 +39,11 @@
 - GitHub merge queue merged PR #1984 to `main` as `3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`.
 - Canonical `main` was re-read and contains the exact `.agent/skills/**` governance-safe matcher.
 - This closure change intentionally touches `.agent/skills/**` plus project records to smoke-test the new governance fast path after merge.
+
+## 2026-08-22 — FCM-003 Round 3
+
+- Closure/smoke PR #1985 changed only `.agent/skills/**` and `projects/**`.
+- PR CI run `32558243330` passed with only `Classify CI changes` and required `CI result`; Frontend, Worker, MCP, Electron, and workflow guardrails were skipped.
+- Merge-group CI run `32558267502` passed with the same narrow selection.
+- PR #1985 merged through the protected queue as `fc4e0521a0bac8729632432acb6149cad5ab403d`.
+- FCM-003 is fully accepted; this final project-only record sync persists the closure evidence.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -11,3 +11,4 @@
 - PR #1978 merged through the protected merge queue at commit `ac94b40d4a05a0211146c2bb5904aa936a7bc928`.
 - Opened FCM-003 and classified `.agent/skills/**` as governance-safe without changing `.agents/plugins/**`, workflow guardrails, or the unknown runtime fail-safe.
 - FCM-003 merged through PR #1984 / merge queue (`3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`); added a governance Skill note and closure smoke to verify `.agent/skills/**` remains on the safe fast path.
+- FCM-003 closure smoke PR #1985 proved `.agent/skills/**` + `projects/**` run only classifier + aggregate result in PR and merge-group CI; merged as `fc4e0521a0bac8729632432acb6149cad5ab403d`.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-003-agent-skill-governance-fast-path.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-003-agent-skill-governance-fast-path.md
@@ -3,7 +3,7 @@
 - **Task ID:** FCM-003
 - **Status:** passed
 - **Started:** 2026-08-22T14:24:00+08:00
-- **Updated:** 2026-08-22T14:55:00+08:00
+- **Updated:** 2026-08-22T14:58:00+08:00
 - **Completed:** 2026-08-22T14:54:20+08:00
 
 ## Objective
@@ -65,6 +65,10 @@ Prevent repository-governance-only changes under `.agent/skills/**`, root Markdo
 - Merge-group CI: run `32558147639`, success; required `CI result` passed.
 - Merge queue commit on `main`: `3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`.
 - Post-merge `main` read verified the `.agent/skills/**` matcher.
+- Closure smoke PR: #1985.
+- Closure PR CI: run `32558243330`, success; only classifier + `CI result` ran.
+- Closure merge-group CI: run `32558267502`, success; product/workflow suites skipped.
+- Closure merge commit: `fc4e0521a0bac8729632432acb6149cad5ab403d`.
 
 ## Blockers / risks
 
@@ -73,4 +77,4 @@ Prevent repository-governance-only changes under `.agent/skills/**`, root Markdo
 
 ## Next action
 
-Merge this closure/smoke PR, verify the `.agent/skills/**`-only governance fast path on PR and merge-group CI, then verify canonical `main`.
+No remaining FCM-003 action. Continue with the next CI governance task only when prioritized.


### PR DESCRIPTION
## Summary
Persist the final FCM-003 acceptance evidence after the real `.agent/skills/** + projects/**` closure smoke merged.

## Evidence recorded
- implementation PR #1984
- implementation PR CI `32558117683`
- implementation merge-group CI `32558147639`
- implementation merge `3a06560ce2b9d8d850f6f15e008ae9b0cf1f997b`
- closure/smoke PR #1985
- closure PR CI `32558243330`
- closure merge-group CI `32558267502`
- closure merge `fc4e0521a0bac8729632432acb6149cad5ab403d`
- closure smoke proved only classifier + required aggregate result ran; Frontend/Worker/MCP/Electron/workflow guardrails were all skipped

## Scope
Project records only under `projects/fabushi-cicd-merge-governance/**`. No runtime or workflow behavior changes.

This PR must still pass required CI and protected merge queue before the project record is considered canonical on `main`.