### PR TITLE
feat(messaging): add SQLite state storage

### DIFF
--- a/native/mahayana-messaging/Cargo.toml
+++ b/native/mahayana-messaging/Cargo.toml
@@ -17,6 +17,7 @@ chacha20poly1305 = "0.10"
 getrandom = "0.2"
 hkdf = "0.12"
 hmac = "0.12"
+rusqlite = { version = "0.32", features = ["bundled"] }
 sha2 = "0.10"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 zeroize = "1"

--- a/native/mahayana-messaging/Cargo.toml
+++ b/native/mahayana-messaging/Cargo.toml
@@ -17,7 +17,7 @@ chacha20poly1305 = "0.10"
 getrandom = "0.2"
 hkdf = "0.12"
 hmac = "0.12"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 sha2 = "0.10"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 zeroize = "1"

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -173,8 +173,7 @@ impl MessagingStateStore for SqliteStateStore {
         let connection = self.open_initialized()?;
         let row = connection
             .query_row(
-                "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json\
-                 FROM messaging_snapshot WHERE singleton = 1",
+                "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json FROM messaging_snapshot WHERE singleton = 1",
                 [],
                 |row| {
                     Ok((
@@ -206,14 +205,7 @@ impl MessagingStateStore for SqliteStateStore {
         let transaction = connection.transaction()?;
         let state_json = serde_json::to_string(&snapshot.state)?;
         transaction.execute(
-            "INSERT INTO messaging_snapshot (\
-                 singleton, snapshot_schema_version, cursor, saved_at_ms, state_json\
-             ) VALUES (1, ?1, ?2, ?3, ?4)\
-             ON CONFLICT(singleton) DO UPDATE SET\
-                 snapshot_schema_version = excluded.snapshot_schema_version,\
-                 cursor = excluded.cursor,\
-                 saved_at_ms = excluded.saved_at_ms,\
-                 state_json = excluded.state_json",
+            "INSERT INTO messaging_snapshot (singleton, snapshot_schema_version, cursor, saved_at_ms, state_json) VALUES (1, ?1, ?2, ?3, ?4) ON CONFLICT(singleton) DO UPDATE SET snapshot_schema_version = excluded.snapshot_schema_version, cursor = excluded.cursor, saved_at_ms = excluded.saved_at_ms, state_json = excluded.state_json",
             params![
                 snapshot.schema_version,
                 snapshot.cursor.to_string(),
@@ -246,15 +238,15 @@ fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
     }
     if actual == 0 {
         connection.execute_batch(
-            "BEGIN IMMEDIATE;\
-             CREATE TABLE IF NOT EXISTS messaging_snapshot (\
-                 singleton INTEGER PRIMARY KEY CHECK (singleton = 1),\
-                 snapshot_schema_version INTEGER NOT NULL,\
-                 cursor TEXT NOT NULL,\
-                 saved_at_ms INTEGER NOT NULL,\
-                 state_json TEXT NOT NULL\
-             );\
-             PRAGMA user_version = 1;\
+            "BEGIN IMMEDIATE;
+             CREATE TABLE IF NOT EXISTS messaging_snapshot (
+                 singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                 snapshot_schema_version INTEGER NOT NULL,
+                 cursor TEXT NOT NULL,
+                 saved_at_ms INTEGER NOT NULL,
+                 state_json TEXT NOT NULL
+             );
+             PRAGMA user_version = 1;
              COMMIT;",
         )?;
     }

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -303,7 +303,9 @@ mod tests {
         assert_eq!(store.load().expect("load replacement"), Some(second));
         let connection = Connection::open(&path).expect("open database");
         let count: i64 = connection
-            .query_row("SELECT COUNT(*) FROM messaging_snapshot", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM messaging_snapshot", [], |row| {
+                row.get(0)
+            })
             .expect("count snapshots");
         assert_eq!(count, 1);
         remove_db(&path);

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -1,4 +1,5 @@
 use crate::engine::MessagingState;
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::io::{Read, Write};
@@ -6,6 +7,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 pub const MESSAGING_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const MESSAGING_SQLITE_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -33,8 +35,14 @@ pub enum StoreError {
     Io(#[from] std::io::Error),
     #[error("messaging store JSON failed: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("messaging store SQLite failed: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("messaging cursor is invalid: {0}")]
+    InvalidCursor(#[from] std::num::ParseIntError),
     #[error("unsupported messaging snapshot schema {actual}; expected {expected}")]
     UnsupportedSchema { expected: u32, actual: u32 },
+    #[error("unsupported messaging SQLite schema {actual}; expected at most {expected}")]
+    UnsupportedSqliteSchema { expected: u32, actual: u32 },
 }
 
 pub trait MessagingStateStore: Send {
@@ -59,6 +67,7 @@ impl MessagingStateStore for MemoryStateStore {
     }
 
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
+        validate_snapshot_schema(snapshot.schema_version)?;
         self.snapshot = Some(snapshot.clone());
         Ok(())
     }
@@ -100,16 +109,12 @@ impl MessagingStateStore for JsonFileStateStore {
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes)?;
         let snapshot: MessagingSnapshot = serde_json::from_slice(&bytes)?;
-        if snapshot.schema_version != MESSAGING_SNAPSHOT_SCHEMA_VERSION {
-            return Err(StoreError::UnsupportedSchema {
-                expected: MESSAGING_SNAPSHOT_SCHEMA_VERSION,
-                actual: snapshot.schema_version,
-            });
-        }
+        validate_snapshot_schema(snapshot.schema_version)?;
         Ok(Some(snapshot))
     }
 
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
+        validate_snapshot_schema(snapshot.schema_version)?;
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -127,5 +132,232 @@ impl MessagingStateStore for JsonFileStateStore {
             }
         }
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SqliteStateStore {
+    path: PathBuf,
+}
+
+impl SqliteStateStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn initialize(&self) -> Result<(), StoreError> {
+        let connection = self.open()?;
+        migrate_sqlite(&connection)
+    }
+
+    fn open(&self) -> Result<Connection, StoreError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        Ok(Connection::open(&self.path)?)
+    }
+
+    fn open_initialized(&self) -> Result<Connection, StoreError> {
+        let connection = self.open()?;
+        migrate_sqlite(&connection)?;
+        Ok(connection)
+    }
+}
+
+impl MessagingStateStore for SqliteStateStore {
+    fn load(&self) -> Result<Option<MessagingSnapshot>, StoreError> {
+        let connection = self.open_initialized()?;
+        let row = connection
+            .query_row(
+                "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json\
+                 FROM messaging_snapshot WHERE singleton = 1",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, u32>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, String>(3)?,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let Some((schema_version, cursor, saved_at_ms, state_json)) = row else {
+            return Ok(None);
+        };
+        validate_snapshot_schema(schema_version)?;
+        let state = serde_json::from_str(&state_json)?;
+        Ok(Some(MessagingSnapshot {
+            schema_version,
+            cursor: cursor.parse()?,
+            saved_at_ms,
+            state,
+        }))
+    }
+
+    fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
+        validate_snapshot_schema(snapshot.schema_version)?;
+        let mut connection = self.open_initialized()?;
+        let transaction = connection.transaction()?;
+        let state_json = serde_json::to_string(&snapshot.state)?;
+        transaction.execute(
+            "INSERT INTO messaging_snapshot (\
+                 singleton, snapshot_schema_version, cursor, saved_at_ms, state_json\
+             ) VALUES (1, ?1, ?2, ?3, ?4)\
+             ON CONFLICT(singleton) DO UPDATE SET\
+                 snapshot_schema_version = excluded.snapshot_schema_version,\
+                 cursor = excluded.cursor,\
+                 saved_at_ms = excluded.saved_at_ms,\
+                 state_json = excluded.state_json",
+            params![
+                snapshot.schema_version,
+                snapshot.cursor.to_string(),
+                snapshot.saved_at_ms,
+                state_json
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+}
+
+fn validate_snapshot_schema(actual: u32) -> Result<(), StoreError> {
+    if actual != MESSAGING_SNAPSHOT_SCHEMA_VERSION {
+        return Err(StoreError::UnsupportedSchema {
+            expected: MESSAGING_SNAPSHOT_SCHEMA_VERSION,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
+    let actual: u32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if actual > MESSAGING_SQLITE_SCHEMA_VERSION {
+        return Err(StoreError::UnsupportedSqliteSchema {
+            expected: MESSAGING_SQLITE_SCHEMA_VERSION,
+            actual,
+        });
+    }
+    if actual == 0 {
+        connection.execute_batch(
+            "BEGIN IMMEDIATE;\
+             CREATE TABLE IF NOT EXISTS messaging_snapshot (\
+                 singleton INTEGER PRIMARY KEY CHECK (singleton = 1),\
+                 snapshot_schema_version INTEGER NOT NULL,\
+                 cursor TEXT NOT NULL,\
+                 saved_at_ms INTEGER NOT NULL,\
+                 state_json TEXT NOT NULL\
+             );\
+             PRAGMA user_version = 1;\
+             COMMIT;",
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temporary_db(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock must be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "fabushi-messaging-{name}-{}-{nonce}.sqlite3",
+            std::process::id()
+        ))
+    }
+
+    fn remove_db(path: &Path) {
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(path.with_extension("sqlite3-wal"));
+        let _ = fs::remove_file(path.with_extension("sqlite3-shm"));
+    }
+
+    #[test]
+    fn sqlite_store_initializes_and_round_trips_snapshot() {
+        let path = temporary_db("roundtrip");
+        let mut store = SqliteStateStore::new(&path);
+        assert_eq!(store.load().expect("load empty database"), None);
+
+        let snapshot = MessagingSnapshot::new(MessagingState::default(), u64::MAX, 42);
+        store.save(&snapshot).expect("save snapshot");
+        drop(store);
+
+        let reopened = SqliteStateStore::new(&path);
+        assert_eq!(reopened.load().expect("reload snapshot"), Some(snapshot));
+        remove_db(&path);
+    }
+
+    #[test]
+    fn sqlite_store_overwrites_singleton_snapshot_transactionally() {
+        let path = temporary_db("overwrite");
+        let mut store = SqliteStateStore::new(&path);
+        let first = MessagingSnapshot::new(MessagingState::default(), 1, 10);
+        let second = MessagingSnapshot::new(MessagingState::default(), 2, 20);
+
+        store.save(&first).expect("save first snapshot");
+        store.save(&second).expect("replace snapshot");
+
+        assert_eq!(store.load().expect("load replacement"), Some(second));
+        let connection = Connection::open(&path).expect("open database");
+        let count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM messaging_snapshot", [], |row| row.get(0))
+            .expect("count snapshots");
+        assert_eq!(count, 1);
+        remove_db(&path);
+    }
+
+    #[test]
+    fn sqlite_store_rejects_newer_database_schema() {
+        let path = temporary_db("future-schema");
+        let connection = Connection::open(&path).expect("open database");
+        connection
+            .execute_batch("PRAGMA user_version = 999;")
+            .expect("set future schema");
+        drop(connection);
+
+        let store = SqliteStateStore::new(&path);
+        assert!(matches!(
+            store.load(),
+            Err(StoreError::UnsupportedSqliteSchema {
+                expected: MESSAGING_SQLITE_SCHEMA_VERSION,
+                actual: 999
+            })
+        ));
+        remove_db(&path);
+    }
+
+    #[test]
+    fn all_state_stores_reject_unknown_snapshot_schema() {
+        let invalid = MessagingSnapshot {
+            schema_version: MESSAGING_SNAPSHOT_SCHEMA_VERSION + 1,
+            cursor: 0,
+            saved_at_ms: 0,
+            state: MessagingState::default(),
+        };
+
+        let mut memory = MemoryStateStore::default();
+        assert!(matches!(
+            memory.save(&invalid),
+            Err(StoreError::UnsupportedSchema { .. })
+        ));
+
+        let path = temporary_db("invalid-snapshot");
+        let mut sqlite = SqliteStateStore::new(&path);
+        assert!(matches!(
+            sqlite.save(&invalid),
+            Err(StoreError::UnsupportedSchema { .. })
+        ));
+        remove_db(&path);
     }
 }

--- a/projects/telegram-fabushi-integration/decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md
+++ b/projects/telegram-fabushi-integration/decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md
@@ -1,0 +1,45 @@
+# ADR-0008 — 固定 Fabushi Messaging Core，冻结旧 Telegram 栈
+
+- **状态**：ACCEPTED（待 PR 合并成为 main 权威事实）
+- **日期**：2026-08-22
+- **项目**：FABUSHI-TELEGRAM-FUSION
+
+## Context
+
+仓库同时存在新的 `native/mahayana-messaging` 自建消息域，以及历史 `native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 实现。如果不固定边界，后续功能可能继续进入两套状态机/网络栈，违背“自主协议、自建服务、真人/Bot/Agent 统一消息内核”的项目目标。
+
+PR #1961 已把自建消息核心、Electron Messenger V2、Feature Host bridge、统一 Actor/Conversation/Message 和大量 Telegram-class 产品能力合并进 `main`，因此无需再创建一套平行 Rust chat core。
+
+## Decision
+
+1. `native/mahayana-messaging/` 是 Fabushi 唯一 canonical Messaging Core。
+2. `native/telegram-*`、`third_party/mahayana/mahayana-rs/mahayana-telegram/`、`third_party/mahayana/mahayana-rs/providers/telegram-*` 全部标为 **LEGACY/FROZEN**。
+3. LEGACY/FROZEN 路径不得接受新产品功能，只允许：依赖拆除、数据/协议迁移、兼容性修复、删除准备、安全修复。
+4. Electron、iOS、Android 必须通过共享 Rust Core / Host bridge / UniFFI 或等价统一边界使用同一协议和状态机。
+5. canonical wire schema 暂以 `native/mahayana-messaging/src/protocol.rs` 的版本化 Serde protocol v2 为准；未来 protobuf/UniFFI IDL 必须由 canonical schema 驱动或具备自动双向兼容测试。
+6. M14 只有在依赖为零、数据迁移完成、CI/E2E 证明无 fallback 后，才能删除 LEGACY/FROZEN Telegram 路径。
+
+## Consequences
+
+### Positive
+
+- 防止继续出现双聊天栈、双联系人、双 Bot/Agent channel。
+- 当前已合并的自建 Rust 能力成为后续迭代基础。
+- Telegram 仅保留 UX/feature reference 角色，不再成为产品核心后端。
+
+### Negative / cost
+
+- 旧 Telegram crates 暂时仍占据仓库和 CI 复杂度。
+- 部分旧 social/AI adapter 必须逐步迁移到统一 MessagingService。
+- M14 删除前需要严格的依赖图和迁移证明。
+
+## Alternatives rejected
+
+- **重新按 `crates/fabushi-*` 目录重写一遍**：会复制现有 `native/mahayana-messaging` 的业务状态机，制造第二套实现。
+- **继续把 Telegram provider 当兼容后端长期保留**：违反自主协议/自建服务目标，并阻碍 M14。
+
+## Verification
+
+- GitHub `main` 存在 `native/mahayana-messaging` 且 PR #1961 已合并。
+- GitHub `main` 仍存在旧 `native/telegram-*` 与 `providers/telegram-*` 路径。
+- 项目 feature matrix/WBS/状态报告必须引用本 ADR，后续新增通信功能的 PR 必须落入 canonical domain。

--- a/projects/telegram-fabushi-integration/docs/20-现状审计与迁移边界.md
+++ b/projects/telegram-fabushi-integration/docs/20-现状审计与迁移边界.md
@@ -1,0 +1,84 @@
+# 现状审计与迁移边界
+
+- **项目**：Fabushi Telegram 全量融合
+- **文档 ID**：DOC-20
+- **状态**：IMPLEMENTED（待 PR/CI 验收）
+- **审计日期**：2026-08-22
+- **权威分支**：`main`
+
+## 结论
+
+Fabushi 当前已经存在一套自建、Rust-first 的通信主干，项目不应重新创建第二套聊天核心。当前唯一应继续演进的通信核心确定为：
+
+`native/mahayana-messaging/`
+
+该核心通过 Mahayana Feature Host 与 Electron Messenger V2 连接；协议、状态机、消息、联系人/Actor、群组、频道、Topic、Bot/Agent、Mini App、支付消息、媒体/Blob、搜索、通知、Stories、WebRTC signaling、设备会话、安全访问与 Secret Chat 等能力均已进入这一自建域。Telegram Desktop/Unigram 只能作为功能与交互参考，不作为运行时网络依赖。
+
+## GitHub 已确认事实
+
+### 已合并主干
+
+PR #1961 已合并到 `main`，merge commit 为 `8062abb850020a702b4c8a85d8bd23d6b0470cb2`。其最终提交范围包含：
+
+- `native/mahayana-messaging/**` 自建 Rust 消息核心；
+- `desktop/src/messaging-shell-v2.tsx` 与 `selfhosted-messaging-client-v2.ts`；
+- Electron native bridge / signaling client；
+- Mahayana Feature Host / Host Protocol / Social 投影；
+- Messaging Product Gate、Rust gate 与 Messenger E2E；
+- forwarding、Blob 上传、Secret Chat、账号/设备访问令牌、WebRTC signaling、Bot execution 等后续收敛。
+
+### 历史 CI 与当前源码必须区分
+
+PR #1961 的一个历史 `Messaging Product Gate` run 曾在 Rust test 阶段因 `reply_to_message_id: Option<MessageId>` 与 `Option<String>` 类型不一致失败；当前 `main` 已在 `service.rs` 中显式转换为 `message.reply_to_message_id.as_ref().map(|id| id.0.clone())`。因此该日志属于历史失败证据，不再代表当前源码仍有同一编译错误；但在新的当前-head CI 通过前，也不能据此把功能提升到 `TESTED`。
+
+## 唯一架构边界
+
+| 分类 | 路径 | 结论 | 后续规则 |
+|---|---|---|---|
+| KEEP / CANONICAL | `native/mahayana-messaging/` | 唯一 Fabushi Messaging Core | 所有新 IM 业务状态机继续在此域演进 |
+| KEEP / CLIENT | `desktop/src/messaging-shell-v2.tsx`、`desktop/src/selfhosted-messaging-client-v2.ts` | Electron 主通信 UI/客户端桥 | UI 只消费统一协议，不复制消息状态机 |
+| KEEP / HOST BRIDGE | `third_party/mahayana/mahayana-rs/mahayana-feature-host/` 与 host protocol | 产品 Host 桥 | 继续作为统一产品能力入口 |
+| REFACTOR / MIGRATE | 现有 social / legacy AI group adapter | 仍需完全收敛到统一 Actor/Conversation/Message | 不得新增第二套联系人/群聊状态机 |
+| LEGACY / FREEZE | `native/telegram-*` | 旧 Telegram 网络/runtime 实现仍在仓库 | 禁止新增产品功能；只允许迁移/兼容/删除所需改动 |
+| LEGACY / FREEZE | `third_party/mahayana/mahayana-rs/mahayana-telegram/` | 旧 Telegram provider/runtime 集成 | 禁止作为 Fabushi 主通信后端 |
+| LEGACY / FREEZE | `third_party/mahayana/mahayana-rs/providers/telegram-*` | telegram-core/media/network/protocol/runtime/storage/wasm 仍存在 | M14 在依赖清零和迁移验证后删除 |
+
+## Workspace 决策
+
+源计划中的 `crates/fabushi-*` 是目标模块分层示意，不要求为了目录名称重新造一套实现。当前主干已经将这些领域聚合在 `native/mahayana-messaging` 内部模块中，因此 M0 阶段接受以下实际 workspace：
+
+- Canonical messaging domain: `native/mahayana-messaging/`
+- Product composition/host: `third_party/mahayana/mahayana-rs/`
+- Desktop client: `desktop/`
+- Native clients: `ios/` / `android/` 的现有原生目录按当前仓库结构接入共享 Rust Core
+
+后续只有在可验证地改善编译边界、依赖方向或跨端复用时，才把单体 crate 拆分为多个 `fabushi-*` crates；不得因文档示例路径而重复实现现有能力。
+
+## 协议 IDL 决策
+
+当前 canonical IDL 为 `native/mahayana-messaging/src/protocol.rs` 中的版本化 Serde schema：
+
+- `FABUSHI_MESSAGING_PROTOCOL_VERSION = 2`
+- `ClientEnvelope` + `RequestContext` + `ClientCommand`
+- `ServerEnvelope` + `ServerEvent`
+- Electron/Host 通过 `messaging.execute` / `messaging.event` 适配该协议
+
+在跨语言绑定需要 protobuf/UniFFI schema 生成之前，这一 Rust schema 是协议事实来源；未来新增 IDL 必须从它生成或与其拥有自动兼容性测试，不能形成第二套手工协议。
+
+## 当前最早未满足的路线图要求
+
+M1.T06 `SQLite schema` 尚未满足。当前 `native/mahayana-messaging/src/store.rs` 只提供 `MemoryStateStore` 与原子 `JsonFileStateStore`，没有项目路线图要求的 SQLite schema/storage。这个缺口比继续追加 UI 功能更早，应该在 M0 基线纠正后优先推进。
+
+## M0 完成门槛
+
+本审计文档落盘后：
+
+- M0.T01 代码现状审查：实现完成，待 PR 验收；
+- M0.T02 旧 Telegram / 联系人 / Agent 路径清单：实现完成，待 PR 验收；
+- M0.T03 保留/重构/删除分类：实现完成，待 PR 验收；
+- M0.T04 workspace：已固定实际 canonical 路径；
+- M0.T05 protocol IDL：已固定为 Messaging Protocol v2；
+- M0.T06 feature matrix：由 `management/03-验收追踪矩阵.md` 按当前证据回填；
+- M0.T07 migration ADR：由 ADR-0008 固化。
+
+在本 PR 合并并验证 `main` 前，M0 整体仍保持 `IN_PROGRESS`，不宣称 `TESTED` 或 `E2E_VERIFIED`。

--- a/projects/telegram-fabushi-integration/evidence/M1-T06/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M1-T06/README.md
@@ -1,0 +1,38 @@
+# M1.T06 Evidence — SQLite schema / durable local-first storage
+
+## Scope
+
+Task `M1.T06` implements versioned SQLite persistence behind the canonical `MessagingStateStore` contract in `native/mahayana-messaging`.
+
+## Code evidence
+
+- `native/mahayana-messaging/Cargo.toml`
+- `native/mahayana-messaging/src/store.rs`
+- PR #1988
+- Verified PR head: `fc8197a8b5b1d738ae1a4d1d6110cd3bf5a92f39`
+
+## GitHub Actions evidence
+
+| Gate | Run | Result | Coverage |
+|---|---:|---|---|
+| Messaging Product Gate | 32559222693 | SUCCESS | rustfmt, all-target messaging tests, Clippy, Feature Host/contact projection, Electron Messenger contract |
+| Mahayana fast checks | 32559222679 | SUCCESS | Mahayana source boundary + product Host/protocol/bridge regression |
+| Explicit automerge | 32559222681 | SUCCESS | merge-policy automation precondition |
+
+## Acceptance covered
+
+- versioned database initialization;
+- transactional save/reopen recovery;
+- singleton overwrite semantics;
+- full `u64` cursor persistence;
+- future SQLite schema rejection;
+- unknown snapshot schema rejection;
+- compatibility with current Feature Host and Electron Messenger contracts.
+
+## Resolved CI defect
+
+The first implementation used `rusqlite 0.32`, which attempted to link `libsqlite3-sys 0.30` next to the Mahayana/Codex workspace `libsqlite3-sys 0.37`. Because Cargo permits only one crate with `links = "sqlite3"`, the dependency was aligned to `rusqlite 0.39`; both required gates then passed.
+
+## Landing status
+
+Current implementation status: `TESTED` on PR head. Final landed closure requires protected merge queue completion and canonical `main` verification.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -2,30 +2,36 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：MGMT-03
-- **版本**：v1.0
-- **状态**：BASELINE
+- **版本**：v1.1-live-audit
+- **状态**：LIVE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
 
-> 本文档由源计划结构化拆分而来。源计划未明确的管理字段会标记为“项目管理补充/待确认”，避免把推导内容冒充既有事实。
-
-
 ## 规则
 
-每个功能域必须从“需求 → 模块 → 原子任务 → 测试 → 证据”可追踪。以下为基线矩阵，具体 PR/测试名在实施阶段补齐。
+每个功能域必须从“需求 → 模块 → 原子任务 → 测试 → 证据”可追踪。`IMPLEMENTED` 只表示当前 `main` 存在对应产品实现；没有当前-head CI/E2E 证据时不得提升为 `TESTED` 或 `E2E_VERIFIED`。
 
-| 功能域 | 主要模块 | 主要阶段 | 必须验证 | 当前状态 |
-|---|---|---|---|---|
-| 统一协议/模型 | fabushi-protocol / messaging | M1-M2 | 编解码、版本兼容、状态机 | NOT_STARTED |
-| 私聊 | messaging / sync / gateway | M2-M3 | 发送、ACK、重试、已读、编辑/删除/转发 | NOT_STARTED |
-| 媒体 | fabushi-media / media-service | M4 | 上传下载、断点续传、权限、缓存 | NOT_STARTED |
-| 联系人/群组 | identity / conversations / group-service | M5 | owner/admin/member/restricted 权限矩阵 | NOT_STARTED |
-| 频道/Topic | conversations / channel-service | M6 | 广播、分页、Topic 独立状态 | NOT_STARTED |
-| Bot/Agent | fabushi-agent-network | M7 | 统一 Participant、Agent-to-Agent、审计 | NOT_STARTED |
-| Mini Apps | fabushi-miniapp-core | M8 | 签名上下文、授权、撤销、沙箱 | NOT_STARTED |
-| 支付 | fabushi-pay-core / payment-service | M9 | PaymentIntent、webhook 幂等、ledger、退款 | NOT_STARTED |
-| 音视频 | fabushi-call-core | M10 | 跨端 1:1、设备切换、网络恢复 | NOT_STARTED |
-| 移动端共享 Core | client-sdk / UniFFI | M11 | iOS/Android/Electron 互通且不复制状态机 | NOT_STARTED |
-| 高级 IM | 多域 | M12 | 功能矩阵对标范围 | NOT_STARTED |
-| E2EE | crypto / messaging | M13 | 服务端不可读、设备验证、密钥轮换 | NOT_STARTED |
-| 旧栈移除 | 全局 | M14 | 无隐式 fallback、完整测试通过 | NOT_STARTED |
+## 2026-08-22 GitHub main 现状回填
+
+主要实现证据：PR #1961 / merge commit `8062abb850020a702b4c8a85d8bd23d6b0470cb2`、`native/mahayana-messaging/**`、Electron Messenger V2 与 Feature Host bridge。详细分类见 `../docs/20-现状审计与迁移边界.md`。
+
+| 功能域 | 当前 canonical 模块 | 主要阶段 | 必须验证 | 当前状态 | 现有证据 / 缺口 |
+|---|---|---|---|---|---|
+| 统一协议/模型 | `native/mahayana-messaging/protocol` + actor/conversation/message | M1-M2 | 编解码、版本兼容、状态机 | IMPLEMENTED | protocol v2 已版本化；需当前-head Rust gate |
+| 本地持久化 | `native/mahayana-messaging/store` | M1 | SQLite schema、恢复、迁移 | NOT_STARTED | 目前只有 Memory + JSON snapshot；M1.T06 为最早明确缺口 |
+| 私聊 | messaging service/engine/realtime/server | M2-M3 | 发送、ACK、重试、已读、编辑/删除/转发 | IMPLEMENTED | PR #1961 包含 forwarding、sync、read/edit/delete；需当前 E2E 复验 |
+| 媒体 | media / blob_store + desktop attachment bridge | M4 | 上传下载、断点续传、权限、缓存 | IMPLEMENTED | resumable BlobStore + desktop upload 已进入合并提交；需大文件/失败恢复证据 |
+| 联系人/群组 | actor / conversation / community + social projection | M5 | owner/admin/member/restricted 权限矩阵 | IMPLEMENTED | community + real social projection 已存在；需权限矩阵 CI |
+| 频道/Topic | conversation / community | M6 | 广播、分页、Topic 独立状态 | IMPLEMENTED | channels/forums/topics/moderation 已存在；需规模与分页验证 |
+| Bot/Agent | bot + Feature Host / Actor model | M7 | 统一 Actor、Agent-to-Agent、审计 | IMPLEMENTED | Bot/Assistant 共用 Actor/Conversation/Message；legacy AI adapter 仍需完全迁移 |
+| Mini Apps | miniapp + Host bridge | M8 | 签名上下文、授权、撤销、沙箱 | IMPLEMENTED | manifest/grant/session/call 已进入统一协议；权限/E2E 需当前证据 |
+| 支付 | payment / settlement / wallet + Fabushi Pay | M9 | PaymentIntent、webhook 幂等、ledger、退款 | IMPLEMENTED | invoice/order/wallet settlement 已接入；生产支付另有 Fabushi Pay 项目证据 |
+| 音视频 | realtime / signaling / signaling_server + desktop WebRTC | M10 | 跨端 1:1、设备切换、网络恢复 | IMPLEMENTED | self-hosted signaling + desktop controller 已存在；TURN/SFU/跨移动端仍需实测证据 |
+| 移动端共享 Core | native bridge / Mahayana Host | M11 | iOS/Android/Electron 互通且不复制状态机 | IN_PROGRESS | 共享 Rust 方向已建立，但本项目尚无足够当前跨端 E2E 证据 |
+| 高级 IM | story/search/notification/community/message | M12 | 功能矩阵对标范围 | IMPLEMENTED | stories/search/reactions/scheduled 等代码存在；逐项 E2E 仍需回填 |
+| E2EE | secret_chat / access | M13 | 服务端不可读、设备验证、密钥轮换 | IMPLEMENTED | Secret Chat 已进入最终 #1961 合并提交；仍需独立安全/密钥生命周期验收 |
+| 旧栈移除 | `native/telegram-*`, `mahayana-telegram`, `providers/telegram-*` | M14 | 无隐式 fallback、完整测试通过 | NOT_STARTED | 旧 Telegram 栈仍存在；已由 ADR-0008 冻结，待依赖清零后删除 |
+
+## 历史 CI 说明
+
+PR #1961 曾有一轮 `Messaging Product Gate` 的 Rust job 因 `reply_to_message_id` 类型不匹配失败；当前 `main` 源码已修复该具体错误。历史失败不能作为当前失败结论，也不能替代新的当前-head CI。Electron Messenger contract 在该历史 run 中为 success。

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -2,38 +2,41 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：MGMT-05
-- **版本**：v1.0
+- **版本**：v1.1
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
 
-> 本文档由源计划结构化拆分而来。源计划未明确的管理字段会标记为“项目管理补充/待确认”，避免把推导内容冒充既有事实。
-
-
 ## 当前状态
 
-- **整体阶段**：规划基线已建立，实施状态待通过仓库/PR/CI 事实回填。
-- **当前默认状态**：所有 WBS 项目为 `NOT_STARTED`，除非 GitHub 证据证明已有实现。
-- **下一执行入口**：M0 现状清点与边界固定。
-- **完成百分比**：不手填。应按“通过验收的必需原子任务 / 全部必需原子任务”计算。
+- **整体阶段**：M0 现状清点与边界固定 — `IN_PROGRESS`（实现记录已完成，等待本轮 PR/CI/merge 后成为 `main` 基线）。
+- **Canonical Messaging Core**：`native/mahayana-messaging/`。
+- **旧 Telegram 栈**：`native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 已标为 LEGACY/FROZEN，禁止新增产品功能。
+- **协议事实来源**：`native/mahayana-messaging/src/protocol.rs`，Messaging Protocol v2。
+- **下一执行入口**：M1.T06 SQLite schema / durable local-first storage。
+- **完成百分比**：不手填；继续按通过验收的必需原子任务计算。
 
-## 本轮已完成（文档工程）
+## 已验证的主干事实
 
-- 建立标准化项目资料夹。
-- 将总计划拆分为专题规范。
-- 建立 M0-M14 WBS、里程碑、验收追踪、风险、ADR 和模板。
+- PR #1961 已于 2026-08-22 合并，merge commit `8062abb850020a702b4c8a85d8bd23d6b0470cb2`。
+- `native/mahayana-messaging` 已覆盖统一 Actor/Conversation/Message、私聊/群组/频道/Topic、Bot/Agent、媒体/Blob、Mini Apps、支付消息/ledger、搜索、通知、Stories、设备/访问控制、WebRTC signaling、Secret Chat 等广泛产品域。
+- Electron Messenger V2 与 Mahayana Feature Host 已接入自建 messaging protocol。
+- 历史 Messaging Product Gate 的 `reply_to_message_id` 编译错误在当前 `main` 已修正；历史 run 不能代表当前源码仍失败，也不能替代新的 current-head CI。
+- 当前持久化仍以 `MemoryStateStore` / `JsonFileStateStore` 为主，项目 M1 明确要求的 SQLite schema 尚未实现，是最早确定的功能缺口。
 
-## 待回填事实
+## 2026-08-22 — M0 live audit
 
-- Fabushi 当前实际目录与 workspace 结构。
-- 已存在通信相关模块及保留/重构/删除结论。
-- 当前开放 PR、分支、CI 状态。
-- 已实现能力与对应测试证据。
+- **任务**：`M0.T01` 为主任务，同时完成 M0.T02-T07 的审计输出。
+- **分支**：`project/telegram-m0-live-audit`
+- **已完成**：
+  - 新增 `docs/20-现状审计与迁移边界.md`；
+  - 新增 ADR-0008，固定 canonical Messaging Core 并冻结旧 Telegram 栈；
+  - 回填 M0 WBS 与 feature/acceptance matrix；
+  - 确认 actual workspace 与 protocol IDL；
+  - 确认 M1.T06 SQLite schema 为下一最早缺口。
+- **验收状态**：`IN_PROGRESS`，因为本轮 PR 尚未完成 CI/merge/main 复核。
+- **下一步**：创建 PR，取得门禁结果；合并后回填 main evidence，然后进入 M1.T06。
 
 ## 2026-08-22 — TFI-GOV-001 GitHub 项目治理迁移
 
-- **本轮目标**：把 Telegram 融合项目迁入 GitHub，并把 GitHub `main` 项目目录升级为唯一长期项目基线。
-- **已完成**：建立 GitHub-first 项目治理规则；创建 `fabushi-project-governance` Skill；Skill validator 已通过；补建任务记录与 evidence 索引。
-- **进行中**：向 `bhrumom/fabushi` 提交 `projects/telegram-fabushi-integration/` 与 `.agent/skills/fabushi-project-governance/`。
-- **验收状态**：IN_PROGRESS，必须在 GitHub main 路径验证后才能关闭。
-- **下一步**：提交、验证 main、回填 commit/路径证据并关闭 TFI-GOV-001。
+- GitHub `main` 的 `projects/telegram-fabushi-integration/` 已成为权威项目目录；后续所有工程事实继续在此回填。

--- a/projects/telegram-fabushi-integration/management/tasks/M0-T01-current-messaging-audit.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M0-T01-current-messaging-audit.md
@@ -1,0 +1,68 @@
+# M0.T01 — 审查现有 Fabushi 通信相关代码
+
+- **Project**: `FABUSHI-TELEGRAM-FUSION`
+- **Task ID**: `M0.T01`
+- **Stage**: `M0 现状清点与边界固定`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-22`
+- **Updated**: `2026-08-22`
+- **Source**: `../../source/完整telegram融合进fabushi.txt`; `../wbs/M0.md`
+
+## Objective
+
+以 GitHub `main` 的真实代码、已合并 PR 与 CI 事实为依据，审查当前 Fabushi 通信实现，纠正项目基线中“全部 NOT_STARTED”的占位状态，并确定唯一通信核心、客户端桥、旧栈边界以及下一阶段最早未满足的验收门槛。
+
+## In scope
+
+- `native/mahayana-messaging/**`
+- `desktop/**` 中 Messenger / native bridge / WebRTC 相关路径
+- `third_party/mahayana/mahayana-rs/**` 中 Feature Host、social、旧 Telegram provider/runtime 路径
+- 与通信核心直接相关的 GitHub Actions / E2E
+- 已合并 PR #1961 及后续修复/收敛提交在当前 `main` 的事实核对
+
+## Out of scope
+
+- 本任务不凭代码存在直接宣称后续功能 `TESTED` / `E2E_VERIFIED` / `RELEASED`。
+- 不在本任务中删除旧 Telegram 栈；删除归 M14，并必须先完成依赖审计和迁移证明。
+
+## Dependencies
+
+- GitHub `main` 可读。
+- 项目基线 `projects/telegram-fabushi-integration/` 已存在。
+
+## Acceptance criteria
+
+1. 形成当前通信实现的可追踪清单，并标明唯一核心路径和旧/兼容路径。
+2. 对已合并实现给出 commit/PR/文件证据，不能只依赖聊天记忆。
+3. 对 CI 历史失败与当前代码是否已修复作出区分。
+4. 给出最早未满足的阶段/任务，作为下一实现入口。
+5. 更新 WBS、状态报告、验收矩阵和证据索引；状态不得高于现有客观证据。
+
+## Verification
+
+- GitHub file/PR/commit inspection on authoritative `main`.
+- PR #1961 changed-file inventory and merged commit evidence.
+- Historical Messaging Product Gate log compared with current `main` source.
+- 新 PR 的 GitHub Actions 作为本轮文档/架构变更最终门禁。
+
+## Branch / PR
+
+- Branch: `project/telegram-m0-live-audit`
+- PR: pending
+
+## Implementation summary
+
+In progress.
+
+## Evidence
+
+Pending final round update.
+
+## Blockers / risks
+
+- 历史 PR 检查存在失败记录，不能把“已合并”误当“测试通过”。
+- 当前本地开发工作区连接不可用，因此本轮工程事实以 GitHub 连接器与 Actions 为准，不在本机执行构建/测试。
+
+## Next action
+
+完成当前代码清点，落盘 M0 审计结论并更新项目状态。

--- a/projects/telegram-fabushi-integration/management/tasks/M0-T01-current-messaging-audit.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M0-T01-current-messaging-audit.md
@@ -18,51 +18,57 @@
 - `desktop/**` 中 Messenger / native bridge / WebRTC 相关路径
 - `third_party/mahayana/mahayana-rs/**` 中 Feature Host、social、旧 Telegram provider/runtime 路径
 - 与通信核心直接相关的 GitHub Actions / E2E
-- 已合并 PR #1961 及后续修复/收敛提交在当前 `main` 的事实核对
+- 已合并 PR #1961 及其最终收敛提交在当前 `main` 的事实核对
 
 ## Out of scope
 
-- 本任务不凭代码存在直接宣称后续功能 `TESTED` / `E2E_VERIFIED` / `RELEASED`。
-- 不在本任务中删除旧 Telegram 栈；删除归 M14，并必须先完成依赖审计和迁移证明。
-
-## Dependencies
-
-- GitHub `main` 可读。
-- 项目基线 `projects/telegram-fabushi-integration/` 已存在。
+- 不凭代码存在直接宣称后续功能 `TESTED` / `E2E_VERIFIED` / `RELEASED`。
+- 不在本任务中删除旧 Telegram 栈；实际删除归 M14，并必须先完成依赖清零和迁移证明。
 
 ## Acceptance criteria
 
-1. 形成当前通信实现的可追踪清单，并标明唯一核心路径和旧/兼容路径。
-2. 对已合并实现给出 commit/PR/文件证据，不能只依赖聊天记忆。
-3. 对 CI 历史失败与当前代码是否已修复作出区分。
-4. 给出最早未满足的阶段/任务，作为下一实现入口。
-5. 更新 WBS、状态报告、验收矩阵和证据索引；状态不得高于现有客观证据。
+1. 当前通信实现有可追踪清单，并标明唯一核心路径和旧/兼容路径。
+2. 已合并实现有 commit/PR/文件证据。
+3. 历史 CI 失败与当前源码状态分开记录。
+4. 明确最早未满足的阶段/任务。
+5. 更新 WBS、状态报告、验收矩阵和迁移 ADR。
 
-## Verification
+## Verification completed
 
-- GitHub file/PR/commit inspection on authoritative `main`.
-- PR #1961 changed-file inventory and merged commit evidence.
-- Historical Messaging Product Gate log compared with current `main` source.
-- 新 PR 的 GitHub Actions 作为本轮文档/架构变更最终门禁。
+- PR #1961 已合并，merge commit: `8062abb850020a702b4c8a85d8bd23d6b0470cb2`。
+- `native/mahayana-messaging` README/lib/protocol/store/service 等当前 `main` 源码已核对。
+- 旧 `native/telegram-runtime` 与 `third_party/mahayana/mahayana-rs/providers/telegram-*` 当前仍存在。
+- 历史 Messaging Product Gate 的 `reply_to_message_id` 类型错误已与当前 `service.rs` 对比；当前源码已经显式转换 `MessageId.0`，该具体错误已不在当前源码中。
+- 当前 `store.rs` 只有 Memory / JSON snapshot，没有 SQLite，实现确认 M1.T06 尚未满足。
 
 ## Branch / PR
 
 - Branch: `project/telegram-m0-live-audit`
-- PR: pending
+- PR: pending creation
 
 ## Implementation summary
 
-In progress.
+- 新增 `docs/20-现状审计与迁移边界.md`，固定现有实现、迁移边界、workspace 与 canonical protocol。
+- 新增 ADR-0008：`native/mahayana-messaging` 为唯一 canonical Messaging Core；旧 Telegram network/provider/runtime 全部冻结。
+- 回填 M0.T01-T07 为 `IMPLEMENTED`，但在 PR 合并前 M0 整体仍是 `IN_PROGRESS`。
+- 更新 feature/acceptance matrix，区分“代码已实现”与“当前 CI/E2E 已验证”。
+- 将 M1.T06 SQLite schema/storage 识别为下一最早明确功能缺口。
 
 ## Evidence
 
-Pending final round update.
+- Canonical implementation: `native/mahayana-messaging/**`
+- Merged implementation: PR #1961 / `8062abb850020a702b4c8a85d8bd23d6b0470cb2`
+- Audit: `../../docs/20-现状审计与迁移边界.md`
+- Decision: `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
+- Matrix: `../03-验收追踪矩阵.md`
+- WBS: `../wbs/M0.md`
+- CI evidence: historical run documented; current branch CI pending PR creation
 
 ## Blockers / risks
 
-- 历史 PR 检查存在失败记录，不能把“已合并”误当“测试通过”。
-- 当前本地开发工作区连接不可用，因此本轮工程事实以 GitHub 连接器与 Actions 为准，不在本机执行构建/测试。
+- 当前-head CI 尚未产生，因此不能将本轮提升到 `TESTED`。
+- 旧 Telegram crates 仍被保留，实际删除必须等 M14 依赖清零。
 
 ## Next action
 
-完成当前代码清点，落盘 M0 审计结论并更新项目状态。
+创建 PR 并取得 CI/merge 证据；主干验收后立即领取 M1.T06，增加 SQLite schema 与 durable local-first storage，而不是继续新增另一套 UI/消息核心。

--- a/projects/telegram-fabushi-integration/management/tasks/M1-T06-sqlite-storage.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M1-T06-sqlite-storage.md
@@ -12,38 +12,46 @@
 
 补齐 canonical `native/mahayana-messaging` 的 SQLite 持久化，使项目不再只依赖 Memory/JSON snapshot，并为后续 local-first 会话/消息索引和跨端恢复建立版本化数据库基础。
 
-## In scope
+## Implemented
 
-- versioned SQLite schema and migration entrypoint;
-- `SqliteStateStore` implementing existing `MessagingStateStore`;
-- crash-safe transactional singleton snapshot persistence;
-- schema/snapshot version validation;
-- Rust tests for create/save/load/overwrite/reopen/schema rejection;
-- Messaging Product Gate verification.
-
-## Out of scope
-
-- 本轮不把每个 message/conversation 拆成完整关系表；先建立可靠的 SQLite persistence boundary，后续按查询/索引需求增量规范化。
-- 不删除 JSON store，保留为兼容/测试 adapter，默认产品切换另立任务验证。
+- 新增 bundled `rusqlite` dependency；
+- 新增 `MESSAGING_SQLITE_SCHEMA_VERSION = 1`；
+- 新增 `SqliteStateStore`，直接实现既有 `MessagingStateStore`，不创建第二套消息核心；
+- SQLite `PRAGMA user_version` migration；
+- singleton snapshot schema；
+- transaction + UPSERT 覆盖保存；
+- cursor 以十进制文本保存，避免 `u64` 被 SQLite signed integer 截断；
+- snapshot schema 与 database schema 显式兼容性错误；
+- Memory / JSON store 同步增加 snapshot schema write validation；
+- Rust tests：空库初始化、重开 round-trip、singleton overwrite、future DB schema reject、unknown snapshot schema reject。
 
 ## Acceptance criteria
 
-1. 新数据库可自动创建明确版本的 SQLite schema。
-2. `MessagingSnapshot` 可事务性保存并在重新打开数据库后完整恢复。
-3. 重复 save 覆盖 singleton snapshot，不产生多份冲突状态。
-4. 不支持的 DB schema / snapshot schema 返回显式错误。
-5. `cargo fmt`、`cargo test --all-targets`、`cargo clippy --all-targets -D warnings` 由 GitHub `Messaging Product Gate` 验证。
+1. 新数据库可自动创建明确版本的 SQLite schema。**IMPLEMENTED**
+2. `MessagingSnapshot` 可事务性保存并在重新打开数据库后完整恢复。**IMPLEMENTED / CI PENDING**
+3. 重复 save 覆盖 singleton snapshot，不产生多份冲突状态。**IMPLEMENTED / CI PENDING**
+4. 不支持的 DB schema / snapshot schema 返回显式错误。**IMPLEMENTED / CI PENDING**
+5. `cargo fmt`、`cargo test --all-targets`、`cargo clippy --all-targets -D warnings`。**GITHUB ACTIONS PENDING**
 
 ## Branch / PR
 
 - Branch: `feat/telegram-m1-sqlite-storage`
-- Base: `project/telegram-m0-live-audit` (stacked after M0 audit)
-- PR: pending
+- Base: `project/telegram-m0-live-audit` (stacked after PR #1987)
+- PR: #1988 `feat(messaging): add SQLite state storage`
 
 ## Evidence
 
-Pending implementation and CI.
+- `native/mahayana-messaging/Cargo.toml`
+- `native/mahayana-messaging/src/store.rs`
+- `management/wbs/M1.md`
+- PR #1988
+- Current head at time of update: preceding implementation commit `488bba7f251407b4e9535c3d1d0990599a6c9402`; subsequent documentation commits only update project records.
+
+## Blockers / risks
+
+- GitHub Actions status has not appeared yet for the current stacked PR head, so the task remains `IN_PROGRESS` and is not called `TESTED`.
+- JSON store remains available intentionally; switching product default to SQLite should be a separate verified cutover after storage CI is green.
 
 ## Next action
 
-实现 SQLite store + tests，创建 stacked PR 并依据 GitHub Actions 结果修复。
+Wait for the repository's normal PR event to expose Messaging Product Gate results; once available, fix any rustfmt/test/clippy issue, then promote M1.T06 only with the actual CI evidence. After that, normalize conversation/message indexes and product-default SQLite cutover in the next atomic task.

--- a/projects/telegram-fabushi-integration/management/tasks/M1-T06-sqlite-storage.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M1-T06-sqlite-storage.md
@@ -3,55 +3,72 @@
 - **Project**: `FABUSHI-TELEGRAM-FUSION`
 - **Task ID**: `M1.T06`
 - **Stage**: `M1 Rust Core 骨架`
-- **Status**: `IN_PROGRESS`
+- **Status**: `TESTED`
 - **Started**: `2026-08-22`
 - **Updated**: `2026-08-22`
 - **Source**: `../../source/完整telegram融合进fabushi.txt`; `../wbs/M1.md`
 
 ## Objective
 
-补齐 canonical `native/mahayana-messaging` 的 SQLite 持久化，使项目不再只依赖 Memory/JSON snapshot，并为后续 local-first 会话/消息索引和跨端恢复建立版本化数据库基础。
+补齐 canonical `native/mahayana-messaging` 的 SQLite 持久化，使项目不再只依赖 Memory/JSON snapshot，并为 local-first 恢复建立版本化数据库基础。
 
 ## Implemented
 
-- 新增 bundled `rusqlite` dependency；
-- 新增 `MESSAGING_SQLITE_SCHEMA_VERSION = 1`；
-- 新增 `SqliteStateStore`，直接实现既有 `MessagingStateStore`，不创建第二套消息核心；
+- `rusqlite 0.39`，与 Mahayana/Codex workspace 的 `libsqlite3-sys 0.37` 对齐；
+- `MESSAGING_SQLITE_SCHEMA_VERSION = 1`；
+- `SqliteStateStore` 实现既有 `MessagingStateStore`；
 - SQLite `PRAGMA user_version` migration；
 - singleton snapshot schema；
-- transaction + UPSERT 覆盖保存；
-- cursor 以十进制文本保存，避免 `u64` 被 SQLite signed integer 截断；
-- snapshot schema 与 database schema 显式兼容性错误；
-- Memory / JSON store 同步增加 snapshot schema write validation；
-- Rust tests：空库初始化、重开 round-trip、singleton overwrite、future DB schema reject、unknown snapshot schema reject。
+- transaction + UPSERT；
+- cursor 以 decimal text 持久化，完整覆盖 `u64`；
+- snapshot/database schema compatibility errors；
+- Memory / JSON write schema validation；
+- tests：empty DB initialization、reopen round-trip、singleton overwrite、future DB schema rejection、unknown snapshot schema rejection。
 
-## Acceptance criteria
+## Acceptance result
 
-1. 新数据库可自动创建明确版本的 SQLite schema。**IMPLEMENTED**
-2. `MessagingSnapshot` 可事务性保存并在重新打开数据库后完整恢复。**IMPLEMENTED / CI PENDING**
-3. 重复 save 覆盖 singleton snapshot，不产生多份冲突状态。**IMPLEMENTED / CI PENDING**
-4. 不支持的 DB schema / snapshot schema 返回显式错误。**IMPLEMENTED / CI PENDING**
-5. `cargo fmt`、`cargo test --all-targets`、`cargo clippy --all-targets -D warnings`。**GITHUB ACTIONS PENDING**
+1. 新数据库自动创建明确版本 schema：PASS。
+2. `MessagingSnapshot` 事务保存并在重开后恢复：PASS。
+3. 重复 save 只保留 singleton state：PASS。
+4. 不支持的 DB/snapshot schema 显式拒绝：PASS。
+5. Rust fmt/test all-targets/clippy `-D warnings`：PASS。
+6. Production Feature Host/contact projection compatibility：PASS。
+7. Electron Messenger contract / Native Edge parity / TypeScript bridge：PASS。
+
+## CI evidence
+
+- PR: #1988 `feat(messaging): add SQLite state storage`
+- Head verified: `fc8197a8b5b1d738ae1a4d1d6110cd3bf5a92f39`
+- Messaging Product Gate run: `32559222693` — SUCCESS
+  - Rustfmt: success
+  - messaging all-target tests: success
+  - Clippy: success
+  - Feature Host/contact projection: success
+  - Electron Messenger contract: success
+- Mahayana fast checks run: `32559222679` — SUCCESS
+- Explicit automerge workflow run: `32559222681` — SUCCESS
+
+## CI issue resolved
+
+Initial CI exposed a single-native-link conflict: `rusqlite 0.32` required `libsqlite3-sys 0.30`, while Mahayana/Codex uses `libsqlite3-sys 0.37`. The dependency was aligned to `rusqlite 0.39`, after which both required product gates passed.
 
 ## Branch / PR
 
 - Branch: `feat/telegram-m1-sqlite-storage`
-- Base: `project/telegram-m0-live-audit` (stacked after PR #1987)
-- PR: #1988 `feat(messaging): add SQLite state storage`
+- Base: `main`
+- PR: #1988
 
-## Evidence
+## Evidence files
 
 - `native/mahayana-messaging/Cargo.toml`
 - `native/mahayana-messaging/src/store.rs`
 - `management/wbs/M1.md`
-- PR #1988
-- Current head at time of update: preceding implementation commit `488bba7f251407b4e9535c3d1d0990599a6c9402`; subsequent documentation commits only update project records.
+- `evidence/M1-T06/README.md`
 
-## Blockers / risks
+## Remaining gate
 
-- GitHub Actions status has not appeared yet for the current stacked PR head, so the task remains `IN_PROGRESS` and is not called `TESTED`.
-- JSON store remains available intentionally; switching product default to SQLite should be a separate verified cutover after storage CI is green.
+`TESTED` reflects current-head CI. Task closure as landed work still requires protected merge queue completion and canonical `main` verification.
 
 ## Next action
 
-Wait for the repository's normal PR event to expose Messaging Product Gate results; once available, fix any rustfmt/test/clippy issue, then promote M1.T06 only with the actual CI evidence. After that, normalize conversation/message indexes and product-default SQLite cutover in the next atomic task.
+Enter protected merge queue for #1988. After merge, verify the SQLite code and task record on `main`, then let M1.T02 / #1990 make SQLite the production default with one-time legacy JSON migration.

--- a/projects/telegram-fabushi-integration/management/tasks/M1-T06-sqlite-storage.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M1-T06-sqlite-storage.md
@@ -1,0 +1,49 @@
+# M1.T06 — SQLite schema / durable local-first storage
+
+- **Project**: `FABUSHI-TELEGRAM-FUSION`
+- **Task ID**: `M1.T06`
+- **Stage**: `M1 Rust Core 骨架`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-22`
+- **Updated**: `2026-08-22`
+- **Source**: `../../source/完整telegram融合进fabushi.txt`; `../wbs/M1.md`
+
+## Objective
+
+补齐 canonical `native/mahayana-messaging` 的 SQLite 持久化，使项目不再只依赖 Memory/JSON snapshot，并为后续 local-first 会话/消息索引和跨端恢复建立版本化数据库基础。
+
+## In scope
+
+- versioned SQLite schema and migration entrypoint;
+- `SqliteStateStore` implementing existing `MessagingStateStore`;
+- crash-safe transactional singleton snapshot persistence;
+- schema/snapshot version validation;
+- Rust tests for create/save/load/overwrite/reopen/schema rejection;
+- Messaging Product Gate verification.
+
+## Out of scope
+
+- 本轮不把每个 message/conversation 拆成完整关系表；先建立可靠的 SQLite persistence boundary，后续按查询/索引需求增量规范化。
+- 不删除 JSON store，保留为兼容/测试 adapter，默认产品切换另立任务验证。
+
+## Acceptance criteria
+
+1. 新数据库可自动创建明确版本的 SQLite schema。
+2. `MessagingSnapshot` 可事务性保存并在重新打开数据库后完整恢复。
+3. 重复 save 覆盖 singleton snapshot，不产生多份冲突状态。
+4. 不支持的 DB schema / snapshot schema 返回显式错误。
+5. `cargo fmt`、`cargo test --all-targets`、`cargo clippy --all-targets -D warnings` 由 GitHub `Messaging Product Gate` 验证。
+
+## Branch / PR
+
+- Branch: `feat/telegram-m1-sqlite-storage`
+- Base: `project/telegram-m0-live-audit` (stacked after M0 audit)
+- PR: pending
+
+## Evidence
+
+Pending implementation and CI.
+
+## Next action
+
+实现 SQLite store + tests，创建 stacked PR 并依据 GitHub Actions 结果修复。

--- a/projects/telegram-fabushi-integration/management/wbs/M0.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M0.md
@@ -1,79 +1,80 @@
 # WBS 原子任务 — M0 现状清点与边界固定
 
+> 2026-08-22 live audit 已将项目基线与 GitHub `main` 的真实实现对齐。以下任务的实现证据集中在 `../../docs/20-现状审计与迁移边界.md` 与 `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`。在本分支 PR 合并前统一保持 `IMPLEMENTED`，不提升到 `TESTED`/`E2E_VERIFIED`。
+
 ### M0.T01 — 审查现有 Fabushi 通信相关代码
 
-- **交付物**：审查现有 Fabushi 通信相关代码
+- **交付物**：当前通信代码审计与主干路径确认
 - **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **客观验证**：PR #1961 / merge commit `8062abb850020a702b4c8a85d8bd23d6b0470cb2`；当前 `main` 文件审计；本轮 PR CI
 - **来源**：源计划 M0
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：待本轮 PR 合并后验证 `main`
+- **证据位置**：`../../docs/20-现状审计与迁移边界.md`；`../tasks/M0-T01-current-messaging-audit.md`
+- **下一步**：完成本轮 PR CI/merge，并在 `main` 验证后关闭任务记录。
 
 ### M0.T02 — 列出 Telegram/Grok Bot/旧联系人/旧 Agent 相关实现
 
-- **交付物**：列出 Telegram/Grok Bot/旧联系人/旧 Agent 相关实现
-- **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：canonical / migrate / legacy 路径清单
+- **验收标准**：旧 Telegram provider/runtime、social/AI adapter 与新 Messaging Core 边界明确
+- **客观验证**：GitHub `main` 路径检查；`native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 与 `native/mahayana-messaging` 均已核实
 - **来源**：源计划 M0
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：待本轮 PR 合并后验证 `main`
+- **证据位置**：`../../docs/20-现状审计与迁移边界.md`
+- **下一步**：M14 前持续维护依赖清零清单。
 
 ### M0.T03 — 标记保留/重构/删除
 
-- **交付物**：标记保留/重构/删除
-- **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：KEEP / REFACTOR-MIGRATE / LEGACY-FREEZE 分类
+- **验收标准**：任何通信路径都有唯一迁移结论
+- **客观验证**：DOC-20 分类表 + ADR-0008
 - **来源**：源计划 M0
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：实际删除延后至 M14，不属于 M0
+- **证据位置**：`../../docs/20-现状审计与迁移边界.md`; `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
+- **下一步**：所有新增通信功能只进入 canonical Messaging Core。
 
 ### M0.T04 — 确定 workspace 目录
 
-- **交付物**：确定 workspace 目录
-- **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：固定实际 canonical workspace
+- **验收标准**：有唯一通信模块 owner/目录
+- **客观验证**：`native/mahayana-messaging/` 为唯一 Messaging Core；Mahayana workspace 为产品组合层；`desktop/` 为 Electron 客户端
 - **来源**：源计划 M0
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：无
+- **证据位置**：`../../docs/20-现状审计与迁移边界.md`
+- **下一步**：只有明确改善依赖/跨端复用时才拆 crate，不按旧示意目录重复实现。
 
 ### M0.T05 — 确定协议 IDL
 
-- **交付物**：确定协议 IDL
-- **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：固定 canonical messaging schema
+- **验收标准**：协议版本化且客户端不得维护第二套手工 schema
+- **客观验证**：`native/mahayana-messaging/src/protocol.rs`，`FABUSHI_MESSAGING_PROTOCOL_VERSION = 2`
 - **来源**：源计划 M0
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：未来跨语言生成 IDL 需兼容性测试
+- **证据位置**：`../../docs/20-现状审计与迁移边界.md`; `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
+- **下一步**：M11 绑定阶段从 canonical schema 生成/验证 UniFFI 或等价绑定。
 
 ### M0.T06 — 建立 feature matrix
 
-- **交付物**：建立 feature matrix
-- **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：按 GitHub 事实回填功能矩阵
+- **验收标准**：需求 → 模块 → 任务 → 测试/CI → 状态可追踪
+- **客观验证**：`../03-验收追踪矩阵.md` live-audit section
 - **来源**：源计划 M0
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：历史 CI 失败不能作为当前 `TESTED` 证据；需当前-head gate
+- **证据位置**：`../03-验收追踪矩阵.md`
+- **下一步**：后续每轮以当前 CI/E2E 证据提升状态。
 
 ### M0.T07 — 建立迁移 ADR
 
-- **交付物**：建立迁移 ADR
-- **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：固定 canonical Messaging Core 并冻结旧 Telegram 栈
+- **验收标准**：新功能不得进入旧栈；M14 删除条件明确
+- **客观验证**：ADR-0008
 - **来源**：源计划 M0
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
-
+- **状态**：IMPLEMENTED
+- **阻塞**：待本轮 PR 合并后成为 `main` 权威决策
+- **证据位置**：`../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
+- **下一步**：进入最早真实缺口 M1.T06 SQLite schema/storage。

--- a/projects/telegram-fabushi-integration/management/wbs/M1.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M1.md
@@ -7,9 +7,9 @@
 - **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
 - **来源**：源计划 M1
 - **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **阻塞**：待后续事实回填
+- **证据位置**：待填写
+- **下一步**：按 live audit 对现有 protocol v2 进行任务回填。
 
 ### M1.T02 — fabushi-storage
 
@@ -18,9 +18,9 @@
 - **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
 - **来源**：源计划 M1
 - **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **阻塞**：待 M1.T06 SQLite adapter 验证后回填 storage domain
+- **证据位置**：待填写
+- **下一步**：完成 M1.T06 CI 后决定默认 store cutover 与关系化索引拆分。
 
 ### M1.T03 — fabushi-messaging
 
@@ -29,9 +29,9 @@
 - **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
 - **来源**：源计划 M1
 - **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **阻塞**：待现有 `native/mahayana-messaging` 事实回填
+- **证据位置**：待填写
+- **下一步**：按 M0 live audit 回填现有实现/测试证据。
 
 ### M1.T04 — fabushi-sync
 
@@ -40,9 +40,9 @@
 - **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
 - **来源**：源计划 M1
 - **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **阻塞**：待现有 sync/service 事实回填
+- **证据位置**：待填写
+- **下一步**：回填当前 cursor/delta sync 证据。
 
 ### M1.T05 — fabushi-client-sdk
 
@@ -51,20 +51,20 @@
 - **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
 - **来源**：源计划 M1
 - **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **阻塞**：待 desktop/host/native bindings 事实回填
+- **证据位置**：待填写
+- **下一步**：核对 Electron bridge 与移动端共享绑定。
 
 ### M1.T06 — SQLite schema
 
-- **交付物**：SQLite schema
-- **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron 能通过 bridge 获取本地会话列表
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：版本化 SQLite schema + `SqliteStateStore`
+- **验收标准**：Rust 单测通过；snapshot 可在进程重开后恢复；schema 版本不兼容可显式拒绝；Electron 仍可通过现有 bridge 使用同一消息核心
+- **客观验证**：PR #1988；`Messaging Product Gate` 的 rustfmt/test/clippy/Feature Host/desktop contract
 - **来源**：源计划 M1
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：GitHub Actions 尚未给出 current-head 结果
+- **证据位置**：`../tasks/M1-T06-sqlite-storage.md`; `../../../native/mahayana-messaging/src/store.rs`; PR #1988
+- **下一步**：依据 PR #1988 CI 修复；通过后提升为 TESTED，并规划默认 store cutover/关系化索引。
 
 ### M1.T07 — Conversation/Message/Participant 基础模型
 
@@ -73,7 +73,6 @@
 - **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
 - **来源**：源计划 M1
 - **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
-
+- **阻塞**：待现有 actor/conversation/message 事实回填
+- **证据位置**：待填写
+- **下一步**：按 M0 live audit 回填现有模型与测试证据。

--- a/projects/telegram-fabushi-integration/management/wbs/M1.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M1.md
@@ -2,77 +2,77 @@
 
 ### M1.T01 — fabushi-protocol
 
-- **交付物**：fabushi-protocol
+- **交付物**：canonical Messaging Protocol v2
 - **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron 能通过 bridge 获取本地会话列表
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **客观验证**：current `native/mahayana-messaging/src/protocol.rs` + all-target messaging tests + Electron contract
 - **来源**：源计划 M1
-- **状态**：NOT_STARTED
-- **阻塞**：待后续事实回填
-- **证据位置**：待填写
-- **下一步**：按 live audit 对现有 protocol v2 进行任务回填。
+- **状态**：IMPLEMENTED
+- **阻塞**：待 M1 acceptance reconciliation 将 current-head evidence 绑定到本任务
+- **证据位置**：PR #1961；`../../../native/mahayana-messaging/src/protocol.rs`
+- **下一步**：使用 current Messaging Product Gate 关闭 protocol/model 基线验收。
 
 ### M1.T02 — fabushi-storage
 
-- **交付物**：fabushi-storage
-- **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron 能通过 bridge 获取本地会话列表
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：production local-first storage
+- **验收标准**：Rust 单测通过；可恢复会话/消息状态；production server 默认使用 durable store
+- **客观验证**：M1.T06 SQLite foundation + M1.T02 production cutover PR #1990
 - **来源**：源计划 M1
-- **状态**：NOT_STARTED
-- **阻塞**：待 M1.T06 SQLite adapter 验证后回填 storage domain
-- **证据位置**：待填写
-- **下一步**：完成 M1.T06 CI 后决定默认 store cutover 与关系化索引拆分。
+- **状态**：IN_PROGRESS
+- **阻塞**：依赖 M1.T06 先进入 main；#1990 CI/merge pending
+- **证据位置**：`../tasks/M1-T02-production-storage.md`（active branch）；PR #1990
+- **下一步**：通过 #1990 gate，完成 production SQLite + legacy JSON one-time migration。
 
 ### M1.T03 — fabushi-messaging
 
-- **交付物**：fabushi-messaging
-- **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron 能通过 bridge 获取本地会话列表
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：canonical Rust messaging state machine/service
+- **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron bridge 可消费同一消息核心
+- **客观验证**：`engine.rs` / `service.rs` / integration tests / Messaging Product Gate
 - **来源**：源计划 M1
-- **状态**：NOT_STARTED
-- **阻塞**：待现有 `native/mahayana-messaging` 事实回填
-- **证据位置**：待填写
-- **下一步**：按 M0 live audit 回填现有实现/测试证据。
+- **状态**：IMPLEMENTED
+- **阻塞**：待 project-scoped acceptance reconciliation
+- **证据位置**：PR #1961；`../../../native/mahayana-messaging/`
+- **下一步**：把 current-head all-target test evidence绑定到 M1 验收记录。
 
 ### M1.T04 — fabushi-sync
 
-- **交付物**：fabushi-sync
-- **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron 能通过 bridge 获取本地会话列表
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：cursor / delta sync foundation
+- **验收标准**：Rust 单测通过；状态可通过统一事件/同步接口恢复
+- **客观验证**：service/realtime/device sync paths + current Rust tests
 - **来源**：源计划 M1
-- **状态**：NOT_STARTED
-- **阻塞**：待现有 sync/service 事实回填
-- **证据位置**：待填写
-- **下一步**：回填当前 cursor/delta sync 证据。
+- **状态**：IMPLEMENTED
+- **阻塞**：待 sync-specific acceptance reconciliation
+- **证据位置**：PR #1961；messaging service/device/realtime modules
+- **下一步**：增加/绑定 reconnect、cursor、idempotency 验收证据。
 
 ### M1.T05 — fabushi-client-sdk
 
-- **交付物**：fabushi-client-sdk
-- **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron 能通过 bridge 获取本地会话列表
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：Electron/Host client bridge foundation
+- **验收标准**：Electron 能通过 bridge 获取/操作同一 messaging state；客户端不得复制第二套状态机
+- **客观验证**：Feature Host bridge + Electron Messenger contract + Native Edge parity
 - **来源**：源计划 M1
-- **状态**：NOT_STARTED
-- **阻塞**：待 desktop/host/native bindings 事实回填
-- **证据位置**：待填写
-- **下一步**：核对 Electron bridge 与移动端共享绑定。
+- **状态**：IMPLEMENTED
+- **阻塞**：M11 原生移动绑定仍需独立跨端验证
+- **证据位置**：PR #1961；Messaging Product Gate Electron contract
+- **下一步**：M1 先关闭 Electron/Host bridge 基线，移动端完整共享验收归 M11。
 
 ### M1.T06 — SQLite schema
 
 - **交付物**：版本化 SQLite schema + `SqliteStateStore`
 - **验收标准**：Rust 单测通过；snapshot 可在进程重开后恢复；schema 版本不兼容可显式拒绝；Electron 仍可通过现有 bridge 使用同一消息核心
-- **客观验证**：PR #1988；`Messaging Product Gate` 的 rustfmt/test/clippy/Feature Host/desktop contract
+- **客观验证**：PR #1988；Messaging Product Gate run `32559222693`; Mahayana fast checks `32559222679`
 - **来源**：源计划 M1
-- **状态**：IMPLEMENTED
-- **阻塞**：GitHub Actions 尚未给出 current-head 结果
-- **证据位置**：`../tasks/M1-T06-sqlite-storage.md`; `../../../native/mahayana-messaging/src/store.rs`; PR #1988
-- **下一步**：依据 PR #1988 CI 修复；通过后提升为 TESTED，并规划默认 store cutover/关系化索引。
+- **状态**：TESTED
+- **阻塞**：protected merge queue / canonical main verification pending
+- **证据位置**：`../tasks/M1-T06-sqlite-storage.md`; `../../evidence/M1-T06/README.md`; PR #1988
+- **下一步**：merge queue 后在 main 关闭 landed evidence；production default 由 M1.T02/#1990 完成。
 
 ### M1.T07 — Conversation/Message/Participant 基础模型
 
-- **交付物**：Conversation/Message/Participant 基础模型
-- **验收标准**：Rust 单测通过；可本地创建会话/消息；Electron 能通过 bridge 获取本地会话列表
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：Actor/Conversation/Message 基础模型
+- **验收标准**：Rust 单测通过；可创建会话/消息；Electron bridge 使用同一模型
+- **客观验证**：actor/conversation/message modules + messaging contract tests + Electron contract
 - **来源**：源计划 M1
-- **状态**：NOT_STARTED
-- **阻塞**：待现有 actor/conversation/message 事实回填
-- **证据位置**：待填写
-- **下一步**：按 M0 live audit 回填现有模型与测试证据。
+- **状态**：IMPLEMENTED
+- **阻塞**：待 project-scoped acceptance reconciliation
+- **证据位置**：PR #1961；`../../../native/mahayana-messaging/src/{actor,conversation,message}.rs`
+- **下一步**：把 current-head tests/bridge evidence 回填为 M1 acceptance proof。


### PR DESCRIPTION
## Objective
Implement Telegram integration task `M1.T06` directly on the authoritative M0 baseline now merged to `main`.

## Changes
- add versioned SQLite schema and `SqliteStateStore` behind the existing `MessagingStateStore` contract
- transactional singleton snapshot persistence with full `u64` cursor fidelity
- reject unsupported DB/snapshot schema versions explicitly
- validate reopen/overwrite/future-schema behavior in Rust tests
- align `rusqlite 0.39` with the Mahayana/Codex workspace `libsqlite3-sys 0.37` dependency graph
- backfill project WBS/task/evidence with current CI results

## Verification
- Messaging Product Gate run `32559222693`: SUCCESS
  - Rustfmt: success
  - messaging all-target tests: success
  - Clippy: success
  - Feature Host/contact projection: success
  - Electron Messenger contract: success
- Mahayana fast checks run `32559222679`: SUCCESS
- Explicit automerge workflow run `32559222681`: SUCCESS

The verified code head is `fc8197a8b5b1d738ae1a4d1d6110cd3bf5a92f39`; later commits on this PR are project-record/evidence updates only.

## Task
`M1.T06`

## Status
`TESTED`; pending protected merge queue and canonical `main` verification for landed closure.