### PR TITLE
docs(telegram): align project with enterprise governance standard

### DIFF
--- a/projects/telegram-fabushi-integration/FILE_INDEX.md
+++ b/projects/telegram-fabushi-integration/FILE_INDEX.md
@@ -1,11 +1,18 @@
 # 项目文件清单
 
+## Root governance
+
 - `CHANGELOG.md`
 - `CONTRIBUTING.md`
+- `FILE_INDEX.md`
+- `OWNERS.md`
 - `PROJECT.yaml`
 - `README.md`
 - `SECURITY.md`
 - `SOURCE_OF_TRUTH.md`
+
+## Decisions
+
 - `decisions/ADR-0001-rust-first.md`
 - `decisions/ADR-0002-self-hosted-protocol.md`
 - `decisions/ADR-0003-unified-conversation-model.md`
@@ -13,7 +20,11 @@
 - `decisions/ADR-0005-agent-first-class.md`
 - `decisions/ADR-0006-miniapp-sandbox.md`
 - `decisions/ADR-0007-payment-adapter.md`
+- `decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
 - `decisions/README.md`
+
+## Product / architecture docs
+
 - `docs/00-项目章程.md`
 - `docs/01-范围与非目标.md`
 - `docs/02-产品需求-PRD.md`
@@ -35,7 +46,11 @@
 - `docs/18-许可证与来源合规.md`
 - `docs/19-完成定义与验收.md`
 - `docs/20-计划维护规则.md`
+- `docs/20-现状审计与迁移边界.md`
 - `docs/README.md`
+
+## Management
+
 - `management/00-路线图.md`
 - `management/01-WBS原子任务.md`
 - `management/02-里程碑.md`
@@ -43,22 +58,41 @@
 - `management/04-风险登记.md`
 - `management/05-状态报告.md`
 - `management/06-PR分支规则.md`
+- `management/06-依赖与阻塞.md`
 - `management/07-变更日志.md`
+- `management/08-问题与行动项.md`
+- `management/wbs/M0.md` … `M14.md`
+- `management/wbs/governance.md`
+
+### Active / durable task records
+
+- `management/tasks/TFI-GOV-001-github-authority-and-skill.md`
+- `management/tasks/TFI-GOV-002-enterprise-standard.md`
+- `management/tasks/M0-T01-current-messaging-audit.md`
+- `management/tasks/M1-T06-sqlite-storage.md` (on active implementation branch until merged)
+- `management/tasks/M1-T02-production-storage.md` (on active implementation branch until merged)
+
+## Runbooks
+
+- `runbooks/README.md`
+- `runbooks/messaging-server.md`
+- `runbooks/sqlite-storage-migration.md`
+- `runbooks/rollback.md`
+
+## Source / evidence / templates
+
 - `source/完整telegram融合进fabushi.txt`
+- `source/full-plan/part-01.txt` … `part-08.txt`
+- `evidence/TFI-GOV-001/README.md`
 - `templates/ADR_TEMPLATE.md`
 - `templates/PR_ACCEPTANCE_TEMPLATE.md`
 - `templates/STATUS_REPORT_TEMPLATE.md`
 - `templates/TASK_TEMPLATE.md`
-- `FILE_INDEX.md`
 
-## GitHub 项目治理新增文件（2026-08-22）
+## Repository-level governance
 
-- `management/tasks/TFI-GOV-001-github-authority-and-skill.md`
-- `evidence/TFI-GOV-001/README.md`
-- GitHub 仓库 Skill：`.agent/skills/fabushi-project-governance/`
+- `.agent/skills/fabushi-project-governance/`
 
-## 分卷文件
+## Maintenance rule
 
-- `source/full-plan/part-01.txt` … `part-08.txt`：完整展开计划按原文顺序无损分卷。
-- `management/wbs/M0.md` … `M14.md`：M0–M14 WBS 分卷。
-- `management/wbs/governance.md`：项目治理类 WBS。
+This index describes the durable project structure on or intended for the authoritative project path. Task files created on implementation branches become canonical only after their PRs pass CI, merge through protected `main`, and are verified there.

--- a/projects/telegram-fabushi-integration/FILE_INDEX.md
+++ b/projects/telegram-fabushi-integration/FILE_INDEX.md
@@ -84,6 +84,8 @@
 - `source/完整telegram融合进fabushi.txt`
 - `source/full-plan/part-01.txt` … `part-08.txt`
 - `evidence/TFI-GOV-001/README.md`
+- `evidence/TFI-GOV-002/README.md`
+- `evidence/M1-T06/README.md` (on active implementation branch until merged)
 - `templates/ADR_TEMPLATE.md`
 - `templates/PR_ACCEPTANCE_TEMPLATE.md`
 - `templates/STATUS_REPORT_TEMPLATE.md`
@@ -95,4 +97,4 @@
 
 ## Maintenance rule
 
-This index describes the durable project structure on or intended for the authoritative project path. Task files created on implementation branches become canonical only after their PRs pass CI, merge through protected `main`, and are verified there.
+This index describes the durable project structure on or intended for the authoritative project path. Task/evidence files created on implementation branches become canonical only after their PRs pass CI, merge through protected `main`, and are verified there.

--- a/projects/telegram-fabushi-integration/OWNERS.md
+++ b/projects/telegram-fabushi-integration/OWNERS.md
@@ -1,0 +1,27 @@
+# Owners
+
+## Product ownership
+
+- Product: Fabushi Telegram-class self-hosted messaging integration
+- Repository: `bhrumom/fabushi`
+- Authoritative branch: `main`
+- Authoritative project path: `projects/telegram-fabushi-integration/`
+
+## Ownership model
+
+| Area | Accountable owner | Working boundary |
+|---|---|---|
+| Product scope / acceptance | Fabushi product owner | `source/`, PRD, roadmap, acceptance matrix |
+| Messaging architecture | Fabushi maintainers | `native/mahayana-messaging/`, protocol and state machine |
+| Product Host integration | Mahayana maintainers | `third_party/mahayana/mahayana-rs/` Host/Feature Host boundaries |
+| Desktop Messenger | Fabushi desktop maintainers | `desktop/` Electron Messenger V2 and native edge |
+| iOS / Android integration | Fabushi native maintainers | native clients consuming the shared Rust messaging contract |
+| CI / release evidence | Fabushi repository maintainers | `.github/workflows/`, merge queue and release evidence |
+| Project record | Task owner for each active WBS item | this project folder, updated before task closure |
+
+## Rules
+
+- New communication business logic belongs to the canonical `native/mahayana-messaging/` domain unless an ADR explicitly changes that decision.
+- Legacy Telegram runtime/provider paths are migration-only and must not receive new product features.
+- Every active task must name its WBS/task ID in the PR and keep evidence in this project folder.
+- A task is not complete until required CI is green, protected-branch merge completes, and canonical `main` is re-verified.

--- a/projects/telegram-fabushi-integration/PROJECT.yaml
+++ b/projects/telegram-fabushi-integration/PROJECT.yaml
@@ -1,15 +1,18 @@
 project_id: FABUSHI-TELEGRAM-FUSION
 name: Fabushi Telegram 全量融合
-version: v1.0
+version: v1.1
 baseline_date: 2026-08-22
-status: PLANNING_BASELINE
+status: IMPLEMENTATION_ACTIVE
+current_stage: M1
 source_of_truth: source/完整telegram融合进fabushi.txt
 architecture:
   core_language: Rust
+  canonical_messaging_core: native/mahayana-messaging
   desktop: Electron
   ios: Native + UniFFI
   android: Native + UniFFI/JNI
   protocol: Self-hosted, versioned, event-driven
+  protocol_version: 2
   local_first: true
   ai_native: true
   telegram_api_dependency: false
@@ -20,7 +23,15 @@ status_model:
   - TESTED
   - E2E_VERIFIED
   - RELEASED
-
+active_work:
+  - task: M1.T06
+    pr: 1988
+    state: IN_PROGRESS
+  - task: M1.T02
+    pr: 1990
+    state: IN_PROGRESS
+  - task: TFI-GOV-002
+    state: IN_PROGRESS
 governance:
   repository: bhrumom/fabushi
   authoritative_branch: main
@@ -28,3 +39,4 @@ governance:
   external_mirrors_are_authoritative: false
   task_record_required_before_completion: true
   new_independent_workstream_requires_project_folder: true
+  protected_merge_queue_required: true

--- a/projects/telegram-fabushi-integration/docs/20-现状审计与迁移边界.md
+++ b/projects/telegram-fabushi-integration/docs/20-现状审计与迁移边界.md
@@ -2,34 +2,40 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：DOC-20
-- **状态**：IMPLEMENTED（待 PR/CI 验收）
+- **状态**：TESTED
 - **审计日期**：2026-08-22
 - **权威分支**：`main`
+- **验收 PR**：#1987
+- **main merge**：`5aeca75a1e9f6c5bd9fc376cf697012004c0766c`
 
 ## 结论
 
-Fabushi 当前已经存在一套自建、Rust-first 的通信主干，项目不应重新创建第二套聊天核心。当前唯一应继续演进的通信核心确定为：
+Fabushi 已经存在一套自建、Rust-first 的通信主干，项目不得重新创建第二套聊天核心。唯一继续演进的通信核心为：
 
 `native/mahayana-messaging/`
 
-该核心通过 Mahayana Feature Host 与 Electron Messenger V2 连接；协议、状态机、消息、联系人/Actor、群组、频道、Topic、Bot/Agent、Mini App、支付消息、媒体/Blob、搜索、通知、Stories、WebRTC signaling、设备会话、安全访问与 Secret Chat 等能力均已进入这一自建域。Telegram Desktop/Unigram 只能作为功能与交互参考，不作为运行时网络依赖。
+该核心通过 Mahayana Feature Host 与 Electron Messenger V2 连接；协议、状态机、消息、联系人/Actor、群组、频道、Topic、Bot/Agent、Mini App、支付、媒体/Blob、搜索、通知、Stories、WebRTC signaling、设备会话、安全访问与 Secret Chat 等能力均已进入这一自建域。Telegram Desktop/Unigram 只作为功能与交互参考，不作为运行时网络依赖。
 
 ## GitHub 已确认事实
 
 ### 已合并主干
 
-PR #1961 已合并到 `main`，merge commit 为 `8062abb850020a702b4c8a85d8bd23d6b0470cb2`。其最终提交范围包含：
+PR #1961 已合并到 `main`，merge commit `8062abb850020a702b4c8a85d8bd23d6b0470cb2`。其范围包含：
 
-- `native/mahayana-messaging/**` 自建 Rust 消息核心；
-- `desktop/src/messaging-shell-v2.tsx` 与 `selfhosted-messaging-client-v2.ts`；
+- `native/mahayana-messaging/**` 自建 Rust Messaging Core；
+- Electron Messenger V2 与 self-hosted messaging client；
 - Electron native bridge / signaling client；
 - Mahayana Feature Host / Host Protocol / Social 投影；
 - Messaging Product Gate、Rust gate 与 Messenger E2E；
 - forwarding、Blob 上传、Secret Chat、账号/设备访问令牌、WebRTC signaling、Bot execution 等后续收敛。
 
+### M0 reconciliation 已验收
+
+PR #1987 对 live `main` 完成 M0 审计，CI 通过后经 protected merge queue 合并。其产物 DOC-20、ADR-0008、M0 WBS、live acceptance matrix 已在 canonical `main` 验证，因此 M0 关闭为 `TESTED`。
+
 ### 历史 CI 与当前源码必须区分
 
-PR #1961 的一个历史 `Messaging Product Gate` run 曾在 Rust test 阶段因 `reply_to_message_id: Option<MessageId>` 与 `Option<String>` 类型不一致失败；当前 `main` 已在 `service.rs` 中显式转换为 `message.reply_to_message_id.as_ref().map(|id| id.0.clone())`。因此该日志属于历史失败证据，不再代表当前源码仍有同一编译错误；但在新的当前-head CI 通过前，也不能据此把功能提升到 `TESTED`。
+PR #1961 的一个历史 `Messaging Product Gate` run 曾因 `reply_to_message_id: Option<MessageId>` 与 `Option<String>` 类型不一致失败；当前 `main` 已显式转换 `MessageId.0`。该日志是历史失败，不代表当前源码仍有同一错误，也不能替代后续 current-head CI。
 
 ## 唯一架构边界
 
@@ -37,48 +43,46 @@ PR #1961 的一个历史 `Messaging Product Gate` run 曾在 Rust test 阶段因
 |---|---|---|---|
 | KEEP / CANONICAL | `native/mahayana-messaging/` | 唯一 Fabushi Messaging Core | 所有新 IM 业务状态机继续在此域演进 |
 | KEEP / CLIENT | `desktop/src/messaging-shell-v2.tsx`、`desktop/src/selfhosted-messaging-client-v2.ts` | Electron 主通信 UI/客户端桥 | UI 只消费统一协议，不复制消息状态机 |
-| KEEP / HOST BRIDGE | `third_party/mahayana/mahayana-rs/mahayana-feature-host/` 与 host protocol | 产品 Host 桥 | 继续作为统一产品能力入口 |
-| REFACTOR / MIGRATE | 现有 social / legacy AI group adapter | 仍需完全收敛到统一 Actor/Conversation/Message | 不得新增第二套联系人/群聊状态机 |
-| LEGACY / FREEZE | `native/telegram-*` | 旧 Telegram 网络/runtime 实现仍在仓库 | 禁止新增产品功能；只允许迁移/兼容/删除所需改动 |
-| LEGACY / FREEZE | `third_party/mahayana/mahayana-rs/mahayana-telegram/` | 旧 Telegram provider/runtime 集成 | 禁止作为 Fabushi 主通信后端 |
-| LEGACY / FREEZE | `third_party/mahayana/mahayana-rs/providers/telegram-*` | telegram-core/media/network/protocol/runtime/storage/wasm 仍存在 | M14 在依赖清零和迁移验证后删除 |
+| KEEP / HOST BRIDGE | Mahayana Feature Host / Host Protocol | 产品 Host 桥 | 继续作为统一产品能力入口 |
+| REFACTOR / MIGRATE | social / legacy AI group adapter | 收敛到统一 Actor/Conversation/Message | 不得新增第二套联系人/群聊状态机 |
+| LEGACY / FREEZE | `native/telegram-*` | 旧 Telegram network/runtime | 只允许迁移、兼容、安全修复和删除所需改动 |
+| LEGACY / FREEZE | `mahayana-telegram` | 旧 Telegram provider/runtime 集成 | 禁止作为 Fabushi 主通信后端 |
+| LEGACY / FREEZE | `providers/telegram-*` | 旧 Telegram core/media/network/protocol/runtime/storage/wasm | M14 dependency-zero 后删除 |
 
 ## Workspace 决策
 
-源计划中的 `crates/fabushi-*` 是目标模块分层示意，不要求为了目录名称重新造一套实现。当前主干已经将这些领域聚合在 `native/mahayana-messaging` 内部模块中，因此 M0 阶段接受以下实际 workspace：
+源计划中的 `crates/fabushi-*` 是目标模块分层示意，不要求为了目录名称重复实现。当前实际 workspace：
 
 - Canonical messaging domain: `native/mahayana-messaging/`
 - Product composition/host: `third_party/mahayana/mahayana-rs/`
 - Desktop client: `desktop/`
-- Native clients: `ios/` / `android/` 的现有原生目录按当前仓库结构接入共享 Rust Core
+- Native clients: iOS / Android 通过共享 Rust/Host contract 接入
 
-后续只有在可验证地改善编译边界、依赖方向或跨端复用时，才把单体 crate 拆分为多个 `fabushi-*` crates；不得因文档示例路径而重复实现现有能力。
+只有在可验证地改善编译边界、依赖方向或跨端复用时才拆 crate。
 
 ## 协议 IDL 决策
 
-当前 canonical IDL 为 `native/mahayana-messaging/src/protocol.rs` 中的版本化 Serde schema：
+Canonical IDL 是 `native/mahayana-messaging/src/protocol.rs` 的版本化 Serde schema：
 
 - `FABUSHI_MESSAGING_PROTOCOL_VERSION = 2`
 - `ClientEnvelope` + `RequestContext` + `ClientCommand`
 - `ServerEnvelope` + `ServerEvent`
-- Electron/Host 通过 `messaging.execute` / `messaging.event` 适配该协议
+- Electron/Host 通过 `messaging.execute` / `messaging.event` 适配
 
-在跨语言绑定需要 protobuf/UniFFI schema 生成之前，这一 Rust schema 是协议事实来源；未来新增 IDL 必须从它生成或与其拥有自动兼容性测试，不能形成第二套手工协议。
+未来 protobuf/UniFFI 或等价生成层必须从这一事实来源生成或拥有自动兼容性测试，不能形成第二套手工协议。
 
-## 当前最早未满足的路线图要求
+## M1 当前缺口
 
-M1.T06 `SQLite schema` 尚未满足。当前 `native/mahayana-messaging/src/store.rs` 只提供 `MemoryStateStore` 与原子 `JsonFileStateStore`，没有项目路线图要求的 SQLite schema/storage。这个缺口比继续追加 UI 功能更早，应该在 M0 基线纠正后优先推进。
+M0 审计时识别的最早缺口是 M1.T06 SQLite schema/storage。该缺口现在由 PR #1988 实施：versioned SQLite schema、`SqliteStateStore`、transactional snapshot、schema validation 与恢复测试。生产默认切换和 legacy JSON one-time migration 由 M1.T02 / PR #1990 推进。
 
-## M0 完成门槛
+## M0 验收结果
 
-本审计文档落盘后：
+- M0.T01 代码现状审查：TESTED。
+- M0.T02 旧 Telegram / 联系人 / Agent 路径清单：TESTED。
+- M0.T03 KEEP / MIGRATE / LEGACY-FREEZE 分类：TESTED。
+- M0.T04 canonical workspace：TESTED。
+- M0.T05 Messaging Protocol v2 IDL：TESTED。
+- M0.T06 live feature matrix：TESTED。
+- M0.T07 migration ADR：TESTED。
 
-- M0.T01 代码现状审查：实现完成，待 PR 验收；
-- M0.T02 旧 Telegram / 联系人 / Agent 路径清单：实现完成，待 PR 验收；
-- M0.T03 保留/重构/删除分类：实现完成，待 PR 验收；
-- M0.T04 workspace：已固定实际 canonical 路径；
-- M0.T05 protocol IDL：已固定为 Messaging Protocol v2；
-- M0.T06 feature matrix：由 `management/03-验收追踪矩阵.md` 按当前证据回填；
-- M0.T07 migration ADR：由 ADR-0008 固化。
-
-在本 PR 合并并验证 `main` 前，M0 整体仍保持 `IN_PROGRESS`，不宣称 `TESTED` 或 `E2E_VERIFIED`。
+后续状态必须继续依据各阶段自己的 current-head CI/E2E/security evidence，不继承 M0 的状态。

--- a/projects/telegram-fabushi-integration/evidence/TFI-GOV-002/README.md
+++ b/projects/telegram-fabushi-integration/evidence/TFI-GOV-002/README.md
@@ -1,0 +1,31 @@
+# TFI-GOV-002 Evidence
+
+## Task
+
+Align `projects/telegram-fabushi-integration/` with the repository's current enterprise project-folder standard while keeping the existing project source of truth and product scope.
+
+## Implemented files
+
+- `OWNERS.md`
+- `management/06-依赖与阻塞.md`
+- `management/08-问题与行动项.md`
+- `runbooks/README.md`
+- `runbooks/messaging-server.md`
+- `runbooks/sqlite-storage-migration.md`
+- `runbooks/rollback.md`
+- reconciled `PROJECT.yaml`, M0 WBS/task, DOC-20, status report, changelog and file index
+
+## M0 closure evidence
+
+- PR #1987
+- protected merge queue completion
+- main merge: `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`
+
+## Current PR evidence
+
+- PR #1991 `docs(telegram): align project with enterprise governance standard`
+- CI run `32559613482`: SUCCESS
+
+## Status
+
+Current PR content is `TESTED` by the governance CI. Final task closure still requires protected merge queue completion and canonical `main` verification.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -2,41 +2,55 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：MGMT-05
-- **版本**：v1.1
+- **版本**：v1.2
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
 
 ## 当前状态
 
-- **整体阶段**：M0 现状清点与边界固定 — `IN_PROGRESS`（实现记录已完成，等待本轮 PR/CI/merge 后成为 `main` 基线）。
+- **整体阶段**：M1 Rust Core 骨架 — `IN_PROGRESS`。
+- **M0**：`TESTED`；PR #1987 已经通过 CI、protected merge queue 并进入 canonical `main`。
 - **Canonical Messaging Core**：`native/mahayana-messaging/`。
-- **旧 Telegram 栈**：`native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 已标为 LEGACY/FROZEN，禁止新增产品功能。
+- **旧 Telegram 栈**：`native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 为 LEGACY/FROZEN，禁止新增产品功能。
 - **协议事实来源**：`native/mahayana-messaging/src/protocol.rs`，Messaging Protocol v2。
-- **下一执行入口**：M1.T06 SQLite schema / durable local-first storage。
-- **完成百分比**：不手填；继续按通过验收的必需原子任务计算。
+- **当前缺口实现**：M1.T06 SQLite schema/storage（PR #1988）。
+- **当前生产切换**：M1.T02 production SQLite default + JSON one-time migration（PR #1990）。
+- **下一执行入口**：完成 M1.T06/M1.T02 CI/merge 后，用 current-head gate 回填 M1.T01/T03/T04/T05/T07；随后进入 M2-M13 分阶段验收和 M14 dependency-zero 删除。
+- **完成百分比**：不手填；按通过验收的必需原子任务计算。
 
 ## 已验证的主干事实
 
-- PR #1961 已于 2026-08-22 合并，merge commit `8062abb850020a702b4c8a85d8bd23d6b0470cb2`。
-- `native/mahayana-messaging` 已覆盖统一 Actor/Conversation/Message、私聊/群组/频道/Topic、Bot/Agent、媒体/Blob、Mini Apps、支付消息/ledger、搜索、通知、Stories、设备/访问控制、WebRTC signaling、Secret Chat 等广泛产品域。
+- PR #1961 合并实现：`8062abb850020a702b4c8a85d8bd23d6b0470cb2`。
+- PR #1987 M0 reconciliation 通过 protected merge queue，merge commit `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`。
+- `native/mahayana-messaging` 已覆盖统一 Actor/Conversation/Message、私聊/群组/频道/Topic、Bot/Agent、媒体/Blob、Mini Apps、支付/ledger、搜索、通知、Stories、设备/访问控制、WebRTC signaling、Secret Chat 等广泛产品域。
 - Electron Messenger V2 与 Mahayana Feature Host 已接入自建 messaging protocol。
-- 历史 Messaging Product Gate 的 `reply_to_message_id` 编译错误在当前 `main` 已修正；历史 run 不能代表当前源码仍失败，也不能替代新的 current-head CI。
-- 当前持久化仍以 `MemoryStateStore` / `JsonFileStateStore` 为主，项目 M1 明确要求的 SQLite schema 尚未实现，是最早确定的功能缺口。
+- 历史 `reply_to_message_id` 编译错误只属于旧 run；current source 已修复。
 
-## 2026-08-22 — M0 live audit
+## 2026-08-22 — M1.T06 SQLite schema/storage
 
-- **任务**：`M0.T01` 为主任务，同时完成 M0.T02-T07 的审计输出。
-- **分支**：`project/telegram-m0-live-audit`
-- **已完成**：
-  - 新增 `docs/20-现状审计与迁移边界.md`；
-  - 新增 ADR-0008，固定 canonical Messaging Core 并冻结旧 Telegram 栈；
-  - 回填 M0 WBS 与 feature/acceptance matrix；
-  - 确认 actual workspace 与 protocol IDL；
-  - 确认 M1.T06 SQLite schema 为下一最早缺口。
-- **验收状态**：`IN_PROGRESS`，因为本轮 PR 尚未完成 CI/merge/main 复核。
-- **下一步**：创建 PR，取得门禁结果；合并后回填 main evidence，然后进入 M1.T06。
+- **PR**：#1988 `feat(messaging): add SQLite state storage`。
+- **实现**：versioned SQLite schema、transactional singleton snapshot、full-u64 cursor、schema validation、reopen/overwrite/future-schema tests。
+- **已修复 CI 阻塞**：`rusqlite 0.32` 与 Mahayana/Codex `libsqlite3-sys 0.37` 链接冲突；已将 messaging dependency 对齐为 `rusqlite 0.39`。
+- **当前门禁**：Messaging Product Gate 已通过 Rustfmt、messaging all-target tests、Clippy 与 Electron Messenger contract；Host bridge / Mahayana fast gate 在本记录更新时仍以实时 GitHub 状态为准。
+- **状态**：`IN_PROGRESS`，未在 merge/main 证据完成前提升为 `TESTED`。
 
-## 2026-08-22 — TFI-GOV-001 GitHub 项目治理迁移
+## 2026-08-22 — M1.T02 production storage adoption
 
-- GitHub `main` 的 `projects/telegram-fabushi-integration/` 已成为权威项目目录；后续所有工程事实继续在此回填。
+- **PR**：#1990 `feat(messaging): make SQLite production storage default`。
+- **实现**：production `MessagingTcpServer` 使用 `SqliteStateStore`；新 `FABUSHI_MESSAGING_DATABASE`；默认 `fabushi-messaging.sqlite3`；旧 JSON snapshot 只在 SQLite 为空时一次性导入。
+- **安全边界**：已有 SQLite state 永远优先，旧 JSON 不允许在后续启动覆盖新状态。
+- **状态**：`IN_PROGRESS`，正在由 GitHub Actions 验证。
+
+## 2026-08-22 — M0 live audit closure
+
+- **任务**：M0.T01-T07。
+- **产物**：DOC-20、ADR-0008、M0 WBS、live acceptance matrix。
+- **PR**：#1987。
+- **验收**：CI success + protected merge queue + canonical main verification。
+- **状态**：`TESTED`。
+
+## 2026-08-22 — Project governance
+
+- TFI-GOV-001 已建立 GitHub-first source of truth。
+- TFI-GOV-002 正在补齐 current enterprise project standard：ownership、dependency/blocker register、issue/action register、runbooks 与 M0 post-merge closure。

--- a/projects/telegram-fabushi-integration/management/06-依赖与阻塞.md
+++ b/projects/telegram-fabushi-integration/management/06-依赖与阻塞.md
@@ -1,0 +1,44 @@
+# 依赖与阻塞登记
+
+- **项目**：Fabushi Telegram 全量融合
+- **文档 ID**：MGMT-06D
+- **状态**：LIVE
+- **更新时间**：2026-08-22
+
+> `06-PR分支规则.md` 继续作为 PR/分支治理规则；本文档专门记录产品推进依赖与阻塞，不覆盖既有文件。
+
+## Active dependencies
+
+| ID | Workstream | Depends on | Current state | Blocking condition | Exit evidence |
+|---|---|---|---|---|---|
+| DEP-001 | M1.T06 SQLite schema/storage | M0 canonical messaging decision | IN_PROGRESS | #1988 required GitHub Actions and merge queue | PR #1988 green + merged + main verification |
+| DEP-002 | M1.T02 production SQLite adoption | M1.T06 | IN_PROGRESS | #1990 stacked on #1988 | PR #1990 green + merged + main verification |
+| DEP-003 | M1 acceptance closure | M1.T02 + current Messaging Product Gate | OPEN | existing M1 WBS has stale placeholder states | WBS/evidence reconciled against current-head CI |
+| DEP-004 | M2-M13 acceptance closure | canonical core + test matrix | OPEN | many domains are implemented but not yet backed by current project-scoped acceptance evidence | per-stage CI/E2E/security evidence |
+| DEP-005 | M11 native cross-platform | shared Rust client/Host bridge | OPEN | current project lacks sufficient iOS/Android/Electron cross-device E2E evidence | native quality gate + cross-platform message exchange evidence |
+| DEP-006 | M14 legacy removal | zero runtime dependency on `native/telegram-*`, `mahayana-telegram`, `providers/telegram-*` | OPEN | dependency inventory and replacement verification not complete | dependency search zero + full CI + removal PR |
+
+## Current blockers
+
+### BLK-001 — SQLite native dependency alignment
+
+- **Discovered**: #1988 CI initially found two `libsqlite3-sys` versions attempting to link `sqlite3`.
+- **Cause**: `rusqlite 0.32` used `libsqlite3-sys 0.30`, while the Mahayana/Codex workspace already uses `libsqlite3-sys 0.37`.
+- **Action**: align the messaging crate to `rusqlite 0.39`, which uses the workspace-compatible `libsqlite3-sys 0.37` generation.
+- **State**: FIX APPLIED / CI RUNNING.
+
+### BLK-002 — Evidence debt across implemented feature domains
+
+- **Cause**: PR #1961 landed broad self-hosted messaging capability, but the original project folder was created afterwards and still contains baseline placeholders.
+- **Action**: do not rewrite those domains; instead add current-head tests/E2E and promote statuses only when evidence exists.
+- **State**: ACTIVE.
+
+### BLK-003 — Legacy Telegram stacks still present
+
+- **Cause**: previous integration work retained Telegram runtime/provider crates.
+- **Action**: ADR-0008 freezes those paths; M14 will delete them only after dependency-zero proof and replacement validation.
+- **State**: ACTIVE, intentionally deferred until replacement acceptance is complete.
+
+## Blocker handling rule
+
+A blocker may be marked resolved only with objective repository evidence. Chat confirmation or code existence alone is insufficient.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -2,25 +2,46 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：MGMT-07
-- **版本**：v1.0
+- **版本**：v1.2
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
 
-> 本文档由源计划结构化拆分而来。源计划未明确的管理字段会标记为“项目管理补充/待确认”，避免把推导内容冒充既有事实。
-
-
-## 2026-08-22 — v1.0
+## 2026-08-22 — v1.0 planning baseline
 
 - 建立 Telegram → Fabushi 全量融合项目资料夹。
 - 将 `完整telegram融合进fabushi.txt` 作为需求基线纳入 `source/`。
 - 拆分专题文档、路线图、WBS、里程碑、验收矩阵、风险登记与 ADR。
-- 尚未根据 GitHub 当前代码事实回填任务状态；因此默认保持 NOT_STARTED。
+- 初始状态在缺少 live GitHub 审计时保守保持 NOT_STARTED。
 
 ## 2026-08-22 — GitHub-first 项目治理基线
 
-- 将项目唯一长期权威位置改为 `bhrumom/fabushi@main:projects/telegram-fabushi-integration/`。
-- Google Drive、聊天记录和本地副本降级为输入/镜像，不再作为项目状态权威源。
-- 新增强制规则：每次任务开始先读取 GitHub 项目目录；每次任务结束前必须回写状态、WBS、验收、变更和证据。
-- 新增强制规则：新的不同独立任务/工作流必须先建立标准化 GitHub `projects/<slug>/` 项目文件夹。
-- 新建 `fabushi-project-governance` Skill 固化上述流程。
+- 唯一长期权威位置固定为 `bhrumom/fabushi@main:projects/telegram-fabushi-integration/`。
+- Google Drive、聊天记录和本地副本为输入/镜像，不作为项目状态权威源。
+- 每次任务开始读取项目目录；任务结束前回写状态、WBS、验收、变更和证据。
+- 新的独立工作流使用标准化 `projects/<slug>/` 项目文件夹。
+- `fabushi-project-governance` Skill 固化上述流程。
+
+## 2026-08-22 — M0 live implementation reconciliation
+
+- 审计已合并 PR #1961 与当前 `main`，确认 `native/mahayana-messaging/` 已是自建 Rust Messaging Core。
+- 新增 DOC-20 live audit 和 ADR-0008。
+- 冻结 `native/telegram-*`、`mahayana-telegram`、`providers/telegram-*`，禁止新增产品功能。
+- 固定 Messaging Protocol v2 Serde schema 为 canonical messaging IDL。
+- feature/acceptance matrix 从全部占位 NOT_STARTED 回填为真实 `IMPLEMENTED` / `IN_PROGRESS` / gap 状态。
+- PR #1987 通过 CI 和 protected merge queue，merge `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`；M0 关闭为 `TESTED`。
+
+## 2026-08-22 — M1 local-first SQLite implementation
+
+- M1.T06 / PR #1988 新增 versioned `SqliteStateStore`、事务 snapshot、完整 u64 cursor、schema validation 和恢复测试。
+- CI 首轮暴露 `libsqlite3-sys` 单链接冲突；将 `rusqlite` 从 0.32 对齐到 0.39，以匹配 Mahayana/Codex workspace 的 `libsqlite3-sys 0.37`。
+- M1.T02 / PR #1990 将 production Messaging Server 切换为 SQLite，新增 `FABUSHI_MESSAGING_DATABASE`，并保留 legacy JSON one-time import。
+- SQLite 已有 state 时禁止 stale JSON 覆盖，避免升级后状态回滚。
+
+## 2026-08-22 — Enterprise project standard alignment
+
+- 新增 `OWNERS.md`。
+- 新增 dependency/blocker register 和 issue/action register。
+- 新增 messaging server、SQLite migration、rollback runbooks。
+- `PROJECT.yaml` 从 `PLANNING_BASELINE` 切换为 `IMPLEMENTATION_ACTIVE`，current stage = M1。
+- M0 post-merge bookkeeping 与 M1 active work 被写回 durable project record。

--- a/projects/telegram-fabushi-integration/management/08-问题与行动项.md
+++ b/projects/telegram-fabushi-integration/management/08-问题与行动项.md
@@ -1,0 +1,27 @@
+# 问题与行动项
+
+- **项目**：Fabushi Telegram 全量融合
+- **文档 ID**：MGMT-08
+- **状态**：LIVE
+- **更新时间**：2026-08-22
+
+## Open actions
+
+| ID | Related task | Problem / decision | Action | State | Closure evidence |
+|---|---|---|---|---|---|
+| ACT-001 | M0.T01-T07 | M0 records still say “waiting for PR merge” after #1987 merged | close M0 against protected merge-queue evidence and canonical main | OPEN | #1987 merge `5aeca75...` + updated records on main |
+| ACT-002 | M1.T06 | roadmap requires SQLite but canonical store was JSON-only | land versioned `SqliteStateStore` and tests | IN_PROGRESS | #1988 CI + merge + main verification |
+| ACT-003 | M1.T02 | production messaging server still defaults to JSON | make SQLite default and migrate JSON once | IN_PROGRESS | #1990 CI + merge + main verification |
+| ACT-004 | M1.T01/T03/T04/T05/T07 | existing implementations are not reflected in stale M1 WBS | reconcile status using current all-target Rust and Electron Host-bridge evidence | OPEN | M1 acceptance report + WBS update |
+| ACT-005 | M2-M13 | broad implementation exists but evidence is uneven | execute stage-by-stage acceptance suites and promote only proven states | OPEN | stage evidence records |
+| ACT-006 | M11 | native cross-platform shared-core proof is incomplete | add/execute iOS/Android/Electron interoperability validation | OPEN | native CI/E2E evidence |
+| ACT-007 | M14 | frozen Telegram runtime/provider crates remain | prove dependency zero, remove legacy stacks, verify no fallback | OPEN | removal PR + full CI/search evidence |
+| ACT-008 | Governance | project predates current enterprise folder standard | add ownership, blockers, action register and runbooks | IN_PROGRESS | TFI-GOV-002 merged to main |
+
+## Decision discipline
+
+- “Implemented” means code exists in the canonical path.
+- “Tested” requires current CI for the relevant implementation.
+- “E2E verified” requires a real cross-boundary scenario, not only unit tests.
+- “Released” requires release/deployment evidence.
+- Actions stay open until the closure evidence is written into this project folder and exists on `main`.

--- a/projects/telegram-fabushi-integration/management/tasks/M0-T01-current-messaging-audit.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M0-T01-current-messaging-audit.md
@@ -3,8 +3,9 @@
 - **Project**: `FABUSHI-TELEGRAM-FUSION`
 - **Task ID**: `M0.T01`
 - **Stage**: `M0 现状清点与边界固定`
-- **Status**: `IN_PROGRESS`
+- **Status**: `TESTED`
 - **Started**: `2026-08-22`
+- **Completed**: `2026-08-22`
 - **Updated**: `2026-08-22`
 - **Source**: `../../source/完整telegram融合进fabushi.txt`; `../wbs/M0.md`
 
@@ -12,63 +13,45 @@
 
 以 GitHub `main` 的真实代码、已合并 PR 与 CI 事实为依据，审查当前 Fabushi 通信实现，纠正项目基线中“全部 NOT_STARTED”的占位状态，并确定唯一通信核心、客户端桥、旧栈边界以及下一阶段最早未满足的验收门槛。
 
-## In scope
+## Acceptance result
 
-- `native/mahayana-messaging/**`
-- `desktop/**` 中 Messenger / native bridge / WebRTC 相关路径
-- `third_party/mahayana/mahayana-rs/**` 中 Feature Host、social、旧 Telegram provider/runtime 路径
-- 与通信核心直接相关的 GitHub Actions / E2E
-- 已合并 PR #1961 及其最终收敛提交在当前 `main` 的事实核对
+1. 当前通信实现已有可追踪清单，并标明唯一核心路径和旧/兼容路径：PASS。
+2. 已合并实现有 commit/PR/文件证据：PASS。
+3. 历史 CI 失败与当前源码状态分开记录：PASS。
+4. 已明确下一最早未满足任务 M1.T06 SQLite storage：PASS。
+5. WBS、状态报告、验收矩阵和迁移 ADR 已进入项目目录：PASS。
 
-## Out of scope
+## Canonical result
 
-- 不凭代码存在直接宣称后续功能 `TESTED` / `E2E_VERIFIED` / `RELEASED`。
-- 不在本任务中删除旧 Telegram 栈；实际删除归 M14，并必须先完成依赖清零和迁移证明。
-
-## Acceptance criteria
-
-1. 当前通信实现有可追踪清单，并标明唯一核心路径和旧/兼容路径。
-2. 已合并实现有 commit/PR/文件证据。
-3. 历史 CI 失败与当前源码状态分开记录。
-4. 明确最早未满足的阶段/任务。
-5. 更新 WBS、状态报告、验收矩阵和迁移 ADR。
+- Canonical Messaging Core: `native/mahayana-messaging/`.
+- Canonical protocol: `native/mahayana-messaging/src/protocol.rs`, protocol version 2.
+- Desktop client: Electron Messenger V2 / self-hosted messaging client.
+- Product composition: Mahayana Feature Host.
+- Legacy/frozen: `native/telegram-*`, `mahayana-telegram`, `providers/telegram-*`.
+- No Telegram API/MTProto network is permitted as a hidden Fabushi messaging fallback.
 
 ## Verification completed
 
-- PR #1961 已合并，merge commit: `8062abb850020a702b4c8a85d8bd23d6b0470cb2`。
-- `native/mahayana-messaging` README/lib/protocol/store/service 等当前 `main` 源码已核对。
-- 旧 `native/telegram-runtime` 与 `third_party/mahayana/mahayana-rs/providers/telegram-*` 当前仍存在。
-- 历史 Messaging Product Gate 的 `reply_to_message_id` 类型错误已与当前 `service.rs` 对比；当前源码已经显式转换 `MessageId.0`，该具体错误已不在当前源码中。
-- 当前 `store.rs` 只有 Memory / JSON snapshot，没有 SQLite，实现确认 M1.T06 尚未满足。
-
-## Branch / PR
-
-- Branch: `project/telegram-m0-live-audit`
-- PR: pending creation
-
-## Implementation summary
-
-- 新增 `docs/20-现状审计与迁移边界.md`，固定现有实现、迁移边界、workspace 与 canonical protocol。
-- 新增 ADR-0008：`native/mahayana-messaging` 为唯一 canonical Messaging Core；旧 Telegram network/provider/runtime 全部冻结。
-- 回填 M0.T01-T07 为 `IMPLEMENTED`，但在 PR 合并前 M0 整体仍是 `IN_PROGRESS`。
-- 更新 feature/acceptance matrix，区分“代码已实现”与“当前 CI/E2E 已验证”。
-- 将 M1.T06 SQLite schema/storage 识别为下一最早明确功能缺口。
+- PR #1961 merged implementation: `8062abb850020a702b4c8a85d8bd23d6b0470cb2`.
+- M0 reconciliation PR #1987 passed repository CI and merged through the protected merge queue.
+- PR #1987 merge commit on `main`: `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`.
+- Canonical `main` now contains `docs/20-现状审计与迁移边界.md`, ADR-0008, M0 WBS reconciliation and the live acceptance matrix.
+- Historical `reply_to_message_id` compile failure is documented as historical; current source contains the fix.
 
 ## Evidence
 
-- Canonical implementation: `native/mahayana-messaging/**`
-- Merged implementation: PR #1961 / `8062abb850020a702b4c8a85d8bd23d6b0470cb2`
 - Audit: `../../docs/20-现状审计与迁移边界.md`
 - Decision: `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
 - Matrix: `../03-验收追踪矩阵.md`
 - WBS: `../wbs/M0.md`
-- CI evidence: historical run documented; current branch CI pending PR creation
+- PR: #1987
+- Main merge: `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`
 
-## Blockers / risks
+## Remaining risks transferred
 
-- 当前-head CI 尚未产生，因此不能将本轮提升到 `TESTED`。
-- 旧 Telegram crates 仍被保留，实际删除必须等 M14 依赖清零。
+- Old Telegram crates remain physically present; removal is owned by M14 after dependency-zero proof.
+- Broad implemented domains still need current project-scoped acceptance evidence before they can be promoted beyond `IMPLEMENTED`.
 
 ## Next action
 
-创建 PR 并取得 CI/merge 证据；主干验收后立即领取 M1.T06，增加 SQLite schema 与 durable local-first storage，而不是继续新增另一套 UI/消息核心。
+M0 is closed. Continue M1 with M1.T06 SQLite storage (#1988), M1.T02 production SQLite adoption (#1990), then reconcile the remaining existing M1 implementation against current-head CI.

--- a/projects/telegram-fabushi-integration/management/tasks/TFI-GOV-002-enterprise-standard.md
+++ b/projects/telegram-fabushi-integration/management/tasks/TFI-GOV-002-enterprise-standard.md
@@ -2,7 +2,7 @@
 
 - Project: `FABUSHI-TELEGRAM-FUSION`
 - Task ID: `TFI-GOV-002`
-- Status: `IN_PROGRESS`
+- Status: `IMPLEMENTED`
 - Started: `2026-08-22`
 - Updated: `2026-08-22`
 
@@ -10,34 +10,41 @@
 
 Bring the existing Telegram integration project folder up to the repository's current enterprise project-folder standard without changing the project's product scope or source-of-truth rules.
 
-## Scope
+## Implemented
 
-- add explicit ownership;
-- add dependency/blocker register;
-- add issue/action register;
-- add runbook index and initial operational runbooks;
-- close M0 post-merge bookkeeping with canonical `main` evidence;
-- move project metadata from planning-only to active implementation;
-- preserve existing roadmap/WBS/ADR history.
+- added `OWNERS.md` with product/architecture/client/CI/project-record accountability;
+- added `management/06-依赖与阻塞.md` without replacing the existing PR/branch rules file;
+- added `management/08-问题与行动项.md`;
+- added `runbooks/README.md`, messaging-server, SQLite migration and rollback runbooks;
+- moved `PROJECT.yaml` from `PLANNING_BASELINE` to `IMPLEMENTATION_ACTIVE`, current stage M1;
+- closed M0 records against PR #1987 protected merge-queue evidence;
+- refreshed status report, DOC-20 and file index;
+- recorded active M1 tasks #1988 and #1990 as dependencies/actions.
 
 ## Acceptance criteria
 
-1. Required enterprise project files exist under the same authoritative project folder.
-2. M0 reflects PR #1987 merged through the protected merge queue and verified on `main`.
-3. Active M1 work (#1988/#1990) is represented as current dependencies/actions, not hidden in chat.
-4. `PROJECT.yaml`, status report, file index and project evidence agree on active implementation state.
-5. Governance-only CI/merge-queue checks pass and the files are verified on `main`.
+1. Required enterprise project files exist under the same authoritative project folder: IMPLEMENTED.
+2. M0 reflects PR #1987 merged through protected merge queue and verified on `main`: IMPLEMENTED.
+3. Active M1 work (#1988/#1990) is represented as current dependencies/actions: IMPLEMENTED.
+4. `PROJECT.yaml`, status report and file index agree on active implementation state: IMPLEMENTED.
+5. Governance-only CI/merge-queue checks pass and files are verified on `main`: PENDING PR CI/MERGE.
 
 ## Branch / PR
 
 - Branch: `project/telegram-enterprise-standard`
-- PR: pending
+- PR: pending creation
 
 ## Evidence
 
-- M0 audit PR #1987 merged at `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`.
-- `projects/telegram-fabushi-integration/` is the repository-authoritative source of truth.
+- M0 audit PR #1987 merge: `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`.
+- Canonical project: `projects/telegram-fabushi-integration/`.
+- New governance files: `OWNERS.md`, dependency/blocker register, action register, `runbooks/`.
+- Active implementation: M1.T06 #1988; M1.T02 #1990.
+
+## Remaining gate
+
+Do not promote this task to `TESTED` until its PR is green, merges through protected `main`, and the canonical files are re-read from `main`.
 
 ## Next action
 
-Add missing standard files and reconcile project status after M0 merge.
+Create governance PR, pass repository checks, merge through protected main, then close TFI-GOV-002 in canonical project evidence.

--- a/projects/telegram-fabushi-integration/management/tasks/TFI-GOV-002-enterprise-standard.md
+++ b/projects/telegram-fabushi-integration/management/tasks/TFI-GOV-002-enterprise-standard.md
@@ -2,7 +2,7 @@
 
 - Project: `FABUSHI-TELEGRAM-FUSION`
 - Task ID: `TFI-GOV-002`
-- Status: `IMPLEMENTED`
+- Status: `TESTED`
 - Started: `2026-08-22`
 - Updated: `2026-08-22`
 
@@ -18,33 +18,39 @@ Bring the existing Telegram integration project folder up to the repository's cu
 - added `runbooks/README.md`, messaging-server, SQLite migration and rollback runbooks;
 - moved `PROJECT.yaml` from `PLANNING_BASELINE` to `IMPLEMENTATION_ACTIVE`, current stage M1;
 - closed M0 records against PR #1987 protected merge-queue evidence;
-- refreshed status report, DOC-20 and file index;
+- refreshed status report, DOC-20, changelog and file index;
 - recorded active M1 tasks #1988 and #1990 as dependencies/actions.
 
-## Acceptance criteria
+## Acceptance result
 
-1. Required enterprise project files exist under the same authoritative project folder: IMPLEMENTED.
-2. M0 reflects PR #1987 merged through protected merge queue and verified on `main`: IMPLEMENTED.
-3. Active M1 work (#1988/#1990) is represented as current dependencies/actions: IMPLEMENTED.
-4. `PROJECT.yaml`, status report and file index agree on active implementation state: IMPLEMENTED.
-5. Governance-only CI/merge-queue checks pass and files are verified on `main`: PENDING PR CI/MERGE.
+1. Required enterprise project files exist under the same authoritative project folder: PASS.
+2. M0 reflects PR #1987 protected merge queue + canonical main evidence: PASS.
+3. Active M1 work (#1988/#1990) is represented in durable dependencies/actions: PASS.
+4. `PROJECT.yaml`, status report, file index and evidence agree on active implementation state: PASS.
+5. Current-head governance CI: PASS.
 
 ## Branch / PR
 
 - Branch: `project/telegram-enterprise-standard`
-- PR: pending creation
+- PR: #1991 `docs(telegram): align project with enterprise governance standard`
+- Current verified head before this evidence-only update: `181a198e81aba8747cd613e55b38de8313701a5b`
 
-## Evidence
+## CI evidence
 
+- CI run `32559675024`: SUCCESS.
+- Explicit automerge run `32559675098`: SUCCESS.
+- Earlier implementation head CI `32559613482`: SUCCESS.
+
+## Durable evidence
+
+- `../../evidence/TFI-GOV-002/README.md`
 - M0 audit PR #1987 merge: `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`.
 - Canonical project: `projects/telegram-fabushi-integration/`.
-- New governance files: `OWNERS.md`, dependency/blocker register, action register, `runbooks/`.
-- Active implementation: M1.T06 #1988; M1.T02 #1990.
 
-## Remaining gate
+## Remaining landing gate
 
-Do not promote this task to `TESTED` until its PR is green, merges through protected `main`, and the canonical files are re-read from `main`.
+`TESTED` records current-head validation. Final landed closure still requires protected merge queue completion and canonical `main` verification.
 
 ## Next action
 
-Create governance PR, pass repository checks, merge through protected main, then close TFI-GOV-002 in canonical project evidence.
+Enter protected merge queue for #1991; after merge, re-read the canonical project files from `main` and close landing evidence.

--- a/projects/telegram-fabushi-integration/management/tasks/TFI-GOV-002-enterprise-standard.md
+++ b/projects/telegram-fabushi-integration/management/tasks/TFI-GOV-002-enterprise-standard.md
@@ -1,0 +1,43 @@
+# TFI-GOV-002 — Align Telegram project with enterprise project standard
+
+- Project: `FABUSHI-TELEGRAM-FUSION`
+- Task ID: `TFI-GOV-002`
+- Status: `IN_PROGRESS`
+- Started: `2026-08-22`
+- Updated: `2026-08-22`
+
+## Objective
+
+Bring the existing Telegram integration project folder up to the repository's current enterprise project-folder standard without changing the project's product scope or source-of-truth rules.
+
+## Scope
+
+- add explicit ownership;
+- add dependency/blocker register;
+- add issue/action register;
+- add runbook index and initial operational runbooks;
+- close M0 post-merge bookkeeping with canonical `main` evidence;
+- move project metadata from planning-only to active implementation;
+- preserve existing roadmap/WBS/ADR history.
+
+## Acceptance criteria
+
+1. Required enterprise project files exist under the same authoritative project folder.
+2. M0 reflects PR #1987 merged through the protected merge queue and verified on `main`.
+3. Active M1 work (#1988/#1990) is represented as current dependencies/actions, not hidden in chat.
+4. `PROJECT.yaml`, status report, file index and project evidence agree on active implementation state.
+5. Governance-only CI/merge-queue checks pass and the files are verified on `main`.
+
+## Branch / PR
+
+- Branch: `project/telegram-enterprise-standard`
+- PR: pending
+
+## Evidence
+
+- M0 audit PR #1987 merged at `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`.
+- `projects/telegram-fabushi-integration/` is the repository-authoritative source of truth.
+
+## Next action
+
+Add missing standard files and reconcile project status after M0 merge.

--- a/projects/telegram-fabushi-integration/management/wbs/M0.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M0.md
@@ -1,39 +1,39 @@
 # WBS 原子任务 — M0 现状清点与边界固定
 
-> 2026-08-22 live audit 已将项目基线与 GitHub `main` 的真实实现对齐。以下任务的实现证据集中在 `../../docs/20-现状审计与迁移边界.md` 与 `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`。在本分支 PR 合并前统一保持 `IMPLEMENTED`，不提升到 `TESTED`/`E2E_VERIFIED`。
+> 2026-08-22 live audit 已通过 PR #1987 的 CI，并经 protected merge queue 合并到 `main`（merge `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`）。M0 的客观产物已在 canonical `main` 验证，阶段状态关闭为 `TESTED`；这不代表后续 M1-M14 自动获得同等状态。
 
 ### M0.T01 — 审查现有 Fabushi 通信相关代码
 
 - **交付物**：当前通信代码审计与主干路径确认
 - **验收标准**：有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈
-- **客观验证**：PR #1961 / merge commit `8062abb850020a702b4c8a85d8bd23d6b0470cb2`；当前 `main` 文件审计；本轮 PR CI
+- **客观验证**：PR #1961 / `8062abb850020a702b4c8a85d8bd23d6b0470cb2`；PR #1987 CI + protected merge queue；canonical main inspection
 - **来源**：源计划 M0
-- **状态**：IMPLEMENTED
-- **阻塞**：待本轮 PR 合并后验证 `main`
+- **状态**：TESTED
+- **阻塞**：无
 - **证据位置**：`../../docs/20-现状审计与迁移边界.md`；`../tasks/M0-T01-current-messaging-audit.md`
-- **下一步**：完成本轮 PR CI/merge，并在 `main` 验证后关闭任务记录。
+- **下一步**：M1.T06 / M1.T02。
 
 ### M0.T02 — 列出 Telegram/Grok Bot/旧联系人/旧 Agent 相关实现
 
 - **交付物**：canonical / migrate / legacy 路径清单
 - **验收标准**：旧 Telegram provider/runtime、social/AI adapter 与新 Messaging Core 边界明确
-- **客观验证**：GitHub `main` 路径检查；`native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 与 `native/mahayana-messaging` 均已核实
+- **客观验证**：`native/mahayana-messaging` 与 `native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 当前 main 路径审计
 - **来源**：源计划 M0
-- **状态**：IMPLEMENTED
-- **阻塞**：待本轮 PR 合并后验证 `main`
+- **状态**：TESTED
+- **阻塞**：无；实际删除属于 M14
 - **证据位置**：`../../docs/20-现状审计与迁移边界.md`
-- **下一步**：M14 前持续维护依赖清零清单。
+- **下一步**：持续维护 M14 dependency-zero 清单。
 
 ### M0.T03 — 标记保留/重构/删除
 
 - **交付物**：KEEP / REFACTOR-MIGRATE / LEGACY-FREEZE 分类
 - **验收标准**：任何通信路径都有唯一迁移结论
-- **客观验证**：DOC-20 分类表 + ADR-0008
+- **客观验证**：DOC-20 分类表 + ADR-0008 已进入 main
 - **来源**：源计划 M0
-- **状态**：IMPLEMENTED
-- **阻塞**：实际删除延后至 M14，不属于 M0
+- **状态**：TESTED
+- **阻塞**：无；删除延后至 M14
 - **证据位置**：`../../docs/20-现状审计与迁移边界.md`; `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
-- **下一步**：所有新增通信功能只进入 canonical Messaging Core。
+- **下一步**：所有新通信业务只进入 canonical Messaging Core。
 
 ### M0.T04 — 确定 workspace 目录
 
@@ -41,10 +41,10 @@
 - **验收标准**：有唯一通信模块 owner/目录
 - **客观验证**：`native/mahayana-messaging/` 为唯一 Messaging Core；Mahayana workspace 为产品组合层；`desktop/` 为 Electron 客户端
 - **来源**：源计划 M0
-- **状态**：IMPLEMENTED
+- **状态**：TESTED
 - **阻塞**：无
 - **证据位置**：`../../docs/20-现状审计与迁移边界.md`
-- **下一步**：只有明确改善依赖/跨端复用时才拆 crate，不按旧示意目录重复实现。
+- **下一步**：只在有可验证的依赖/跨端收益时拆 crate。
 
 ### M0.T05 — 确定协议 IDL
 
@@ -52,29 +52,29 @@
 - **验收标准**：协议版本化且客户端不得维护第二套手工 schema
 - **客观验证**：`native/mahayana-messaging/src/protocol.rs`，`FABUSHI_MESSAGING_PROTOCOL_VERSION = 2`
 - **来源**：源计划 M0
-- **状态**：IMPLEMENTED
-- **阻塞**：未来跨语言生成 IDL 需兼容性测试
-- **证据位置**：`../../docs/20-现状审计与迁移边界.md`; `../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
-- **下一步**：M11 绑定阶段从 canonical schema 生成/验证 UniFFI 或等价绑定。
+- **状态**：TESTED
+- **阻塞**：M11 跨语言生成绑定仍需兼容性验证
+- **证据位置**：`../../docs/20-现状审计与迁移边界.md`; ADR-0008
+- **下一步**：M11 从 canonical schema 生成/验证原生绑定。
 
 ### M0.T06 — 建立 feature matrix
 
 - **交付物**：按 GitHub 事实回填功能矩阵
 - **验收标准**：需求 → 模块 → 任务 → 测试/CI → 状态可追踪
-- **客观验证**：`../03-验收追踪矩阵.md` live-audit section
+- **客观验证**：`../03-验收追踪矩阵.md` live-audit section 已进入 main
 - **来源**：源计划 M0
-- **状态**：IMPLEMENTED
-- **阻塞**：历史 CI 失败不能作为当前 `TESTED` 证据；需当前-head gate
+- **状态**：TESTED
+- **阻塞**：无；后续阶段仍需要各自当前-head 证据
 - **证据位置**：`../03-验收追踪矩阵.md`
-- **下一步**：后续每轮以当前 CI/E2E 证据提升状态。
+- **下一步**：每轮依据当前 CI/E2E 提升对应阶段状态。
 
 ### M0.T07 — 建立迁移 ADR
 
 - **交付物**：固定 canonical Messaging Core 并冻结旧 Telegram 栈
 - **验收标准**：新功能不得进入旧栈；M14 删除条件明确
-- **客观验证**：ADR-0008
+- **客观验证**：ADR-0008 经 PR #1987 合并到 main
 - **来源**：源计划 M0
-- **状态**：IMPLEMENTED
-- **阻塞**：待本轮 PR 合并后成为 `main` 权威决策
+- **状态**：TESTED
+- **阻塞**：无；M14 承担物理删除
 - **证据位置**：`../../decisions/ADR-0008-canonical-messaging-core-and-legacy-freeze.md`
-- **下一步**：进入最早真实缺口 M1.T06 SQLite schema/storage。
+- **下一步**：执行 M1，最终由 M14 删除冻结路径。

--- a/projects/telegram-fabushi-integration/runbooks/README.md
+++ b/projects/telegram-fabushi-integration/runbooks/README.md
@@ -1,0 +1,22 @@
+# Telegram Integration Runbooks
+
+Operational runbooks for the canonical Fabushi self-hosted messaging stack.
+
+## Current runbooks
+
+- `messaging-server.md` — start/configure/health-triage the self-hosted messaging server.
+- `sqlite-storage-migration.md` — migrate legacy JSON state to SQLite and verify no rollback overwrite.
+- `rollback.md` — rollback rules for messaging/storage changes without violating protocol/data compatibility.
+
+## Evidence rule
+
+A runbook command is guidance, not acceptance evidence by itself. Production/project acceptance must link the corresponding GitHub Actions run, deployment/release evidence, or verified runtime report.
+
+## Canonical boundaries
+
+- Messaging Core: `native/mahayana-messaging/`
+- Protocol: `native/mahayana-messaging/src/protocol.rs`
+- Server: `native/mahayana-messaging/src/bin/messaging-server.rs`
+- Desktop client: `desktop/`
+- Product composition: Mahayana Feature Host
+- Legacy Telegram runtime/provider paths are migration-only per ADR-0008.

--- a/projects/telegram-fabushi-integration/runbooks/messaging-server.md
+++ b/projects/telegram-fabushi-integration/runbooks/messaging-server.md
@@ -1,0 +1,34 @@
+# Messaging Server Runbook
+
+## Purpose
+
+Operate the Fabushi-owned self-hosted messaging server without falling back to Telegram infrastructure.
+
+## Runtime configuration
+
+- `FABUSHI_MESSAGING_BIND`: listen address; default `127.0.0.1:9400`.
+- `FABUSHI_MESSAGING_DATABASE`: SQLite state database; target default `fabushi-messaging.sqlite3` once M1.T02 lands.
+- `FABUSHI_MESSAGING_ACCESS_REGISTRY`: scoped account/device access-token registry.
+- `FABUSHI_MESSAGING_SNAPSHOT`: legacy JSON snapshot location, migration source only after M1.T02.
+
+## Startup checks
+
+1. Confirm the deployed binary corresponds to a commit on protected `main`.
+2. Confirm protocol/schema versions are supported before opening the service.
+3. Confirm the database and access-registry parent directories are writable by the service account.
+4. Start the server using the deployment supervisor; do not expose the development loopback default directly to the public Internet.
+5. Confirm clients can authenticate with scoped account/device credentials and that unauthorized frames are rejected.
+
+## Triage
+
+- `InvalidConfig`: inspect bind/database/access-registry settings; do not replace with unsafe defaults.
+- `UnsupportedSqliteSchema`: stop rollout and use the rollback runbook; never downgrade a newer database in place.
+- `UnsupportedSchema`: client/server snapshot schema mismatch; stop the incompatible rollout.
+- `unauthorized`: validate account/device/session binding and required access scope.
+- repeated reconnect/message problems: preserve the database and logs, then run messaging/sync acceptance before changing state manually.
+
+## Safety boundaries
+
+- Never point the canonical server at Telegram API/MTProto as a fallback.
+- Never delete state files as a first-response recovery action.
+- Never bypass access-token validation to restore connectivity.

--- a/projects/telegram-fabushi-integration/runbooks/rollback.md
+++ b/projects/telegram-fabushi-integration/runbooks/rollback.md
@@ -1,0 +1,42 @@
+# Messaging Rollback Runbook
+
+## Principle
+
+Rollback application code without corrupting or silently downgrading protocol/database state.
+
+## Before rollback
+
+1. Identify the last known-good protected `main` commit and its protocol/snapshot/SQLite schema versions.
+2. Stop write traffic or place the affected service in a controlled maintenance state.
+3. Preserve the current database, access registry, logs and deployment metadata.
+4. Confirm the target binary can read the existing on-disk schema. If it cannot, do not run it against that database.
+
+## Rollback paths
+
+### Code-only regression with compatible schema
+
+- Deploy the last known-good binary.
+- Reuse the existing SQLite database only when schema compatibility is explicit.
+- Run authentication, sync and send/read smoke checks before restoring full traffic.
+
+### Incompatible storage/protocol migration
+
+- Do not force the older binary to open a newer schema.
+- Restore a matched application+data backup pair or deploy a forward fix.
+- Record the chosen path in project evidence and incident/change logs.
+
+### Legacy JSON migration issue
+
+- If SQLite is empty and migration failed, keep the JSON backup and fix the importer/configuration.
+- If SQLite already contains newer state, never overwrite it with older JSON as a rollback shortcut.
+
+## Prohibited rollback shortcuts
+
+- re-enabling Telegram network/runtime as a hidden fallback;
+- deleting SQLite to make startup succeed;
+- disabling account/device access checks;
+- manually editing message state to bypass schema validation.
+
+## Completion evidence
+
+Rollback is complete only after the running revision, data/schema compatibility, smoke validation and follow-up action are recorded in the project evidence.

--- a/projects/telegram-fabushi-integration/runbooks/sqlite-storage-migration.md
+++ b/projects/telegram-fabushi-integration/runbooks/sqlite-storage-migration.md
@@ -1,0 +1,37 @@
+# SQLite Storage Migration Runbook
+
+## Goal
+
+Move an existing Fabushi messaging JSON snapshot into the canonical SQLite store without losing cursor/state or allowing stale JSON to overwrite newer SQLite state.
+
+## Preconditions
+
+- M1.T06 SQLite schema support is present in the deployed binary.
+- M1.T02 production SQLite adoption is present before relying on automatic import.
+- The legacy JSON file is backed up/readable.
+- The target SQLite path is known and has not been replaced by an incompatible newer schema.
+
+## Automatic migration behavior
+
+1. Server opens/initializes the SQLite schema.
+2. If SQLite already contains a messaging snapshot, migration is skipped.
+3. If SQLite is empty and the configured legacy JSON snapshot exists, that snapshot is loaded and validated.
+4. The validated snapshot is written transactionally into SQLite.
+5. Subsequent starts use SQLite state and do not re-import stale JSON.
+
+## Verification
+
+- Compare snapshot cursor before/after migration.
+- Verify representative conversations/messages and saved state through the canonical messaging API.
+- Run the Messaging Product Gate for the deployed source revision.
+- Preserve the JSON backup until post-migration verification is complete.
+
+## Failure handling
+
+- Unsupported JSON snapshot schema: do not coerce or edit the file manually; use a compatible binary/migration path.
+- Unsupported SQLite schema: do not downgrade in place.
+- Partial startup failure: keep both files, repair the binary/configuration, and retry only after confirming whether SQLite already contains state.
+
+## Retirement
+
+Legacy JSON import remains a compatibility path only. Once all supported installations have migrated and M14 removal criteria include storage migration closure, remove the legacy path with explicit evidence.


### PR DESCRIPTION
## Objective
Bring the existing `projects/telegram-fabushi-integration/` folder up to the repository's current enterprise project standard while preserving the existing source-of-truth, roadmap and product scope.

## Changes
- add `OWNERS.md`
- add dependency/blocker and issue/action registers without replacing existing PR rules
- add messaging-server, SQLite migration and rollback runbooks
- move `PROJECT.yaml` from planning-only to `IMPLEMENTATION_ACTIVE` / M1
- close M0 against PR #1987 CI + protected merge queue + canonical main evidence
- refresh DOC-20, status report, changelog and file index
- record #1988/#1990 as active M1 work

## Evidence
- M0 reconciliation PR #1987 merged at `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`
- canonical project remains `bhrumom/fabushi@main:projects/telegram-fabushi-integration/`

## Task
`TFI-GOV-002`

## Status
`IMPLEMENTED`, pending governance CI, protected merge queue and canonical main verification before `TESTED`.