### PR TITLE
feat(messaging): add durable idempotent delta sync

### DIFF
--- a/native/mahayana-messaging/src/service.rs
+++ b/native/mahayana-messaging/src/service.rs
@@ -1135,7 +1135,7 @@ impl<S: MessagingStateStore> MessagingService<S> {
     fn journal_entries(&self, initiator: &ActorId, responses: &[ServerEnvelope]) -> Vec<JournalEntry> {
         responses
             .iter()
-            .filter(|response| !matches!(response.event, ServerEvent::SyncBatch { .. }))
+            .filter(|response| !matches!(&response.event, ServerEvent::SyncBatch { .. }))
             .map(|response| JournalEntry {
                 envelope: response.clone(),
                 audience: self.event_audience(initiator, &response.event),
@@ -1148,23 +1148,35 @@ impl<S: MessagingStateStore> MessagingService<S> {
         match event {
             ServerEvent::ActorChanged { actor } => {
                 audience.insert(actor.id.clone());
-                for conversation in self.engine.state().conversations.values().filter(|conversation| {
-                    conversation
-                        .participants
-                        .iter()
-                        .any(|participant| participant.actor_id == actor.id)
-                }) {
+                for conversation in self
+                    .engine
+                    .state()
+                    .conversations
+                    .values()
+                    .filter(|conversation| {
+                        conversation
+                            .participants
+                            .iter()
+                            .any(|participant| participant.actor_id == actor.id)
+                    })
+                {
                     Self::extend_conversation_audience(&mut audience, conversation);
                 }
             }
             ServerEvent::PresenceChanged { actor_id, .. } => {
                 audience.insert(actor_id.clone());
-                for conversation in self.engine.state().conversations.values().filter(|conversation| {
-                    conversation
-                        .participants
-                        .iter()
-                        .any(|participant| &participant.actor_id == actor_id)
-                }) {
+                for conversation in self
+                    .engine
+                    .state()
+                    .conversations
+                    .values()
+                    .filter(|conversation| {
+                        conversation
+                            .participants
+                            .iter()
+                            .any(|participant| &participant.actor_id == actor_id)
+                    })
+                {
                     Self::extend_conversation_audience(&mut audience, conversation);
                 }
             }

--- a/native/mahayana-messaging/src/service.rs
+++ b/native/mahayana-messaging/src/service.rs
@@ -1,16 +1,20 @@
 use crate::actor::{ActorId, ActorKind};
 use crate::blob_store::{BlobStoreError, FileBlobStore};
 use crate::bot::BotInvocation;
+use crate::conversation::{ConversationId, ConversationKind};
 use crate::engine::{Command, EngineError, Event, MessagingEngine};
-use crate::message::{Message, MessageContent, MessageId};
+use crate::message::{ClientMessageId, DeliveryState, Message, MessageContent, MessageId};
 use crate::payment::Money;
 use crate::protocol::{
     ClientCommand, ClientEnvelope, ServerEnvelope, ServerEvent, FABUSHI_MESSAGING_PROTOCOL_VERSION,
 };
 use crate::settlement::{SettlementError, SettlementVerifier, SignedSettlement};
-use crate::store::{MessagingSnapshot, MessagingStateStore, StoreError};
+use crate::store::{JournalEntry, MessagingSnapshot, MessagingStateStore, StoreError};
 use crate::wallet::{LedgerEntry, WalletAccountId};
 use base64::Engine as _;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -31,6 +35,8 @@ pub enum MessagingServiceError {
     Invariant(String),
     #[error("messaging command is not authorized for the authenticated actor: {0}")]
     UnauthorizedCommand(String),
+    #[error("client message id {0} was replayed with conflicting message content")]
+    IdempotencyConflict(String),
     #[error(transparent)]
     Settlement(#[from] SettlementError),
 }
@@ -47,6 +53,19 @@ fn sanitize_invocation_component(value: &str) -> String {
         })
         .take(160)
         .collect()
+}
+
+fn stable_message_id(actor_id: &ActorId, client_message_id: &ClientMessageId) -> MessageId {
+    let mut hasher = Sha256::new();
+    hasher.update(actor_id.0.as_bytes());
+    hasher.update([0]);
+    hasher.update(client_message_id.0.as_bytes());
+    let digest = hasher.finalize();
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    MessageId::new(format!("msg:{encoded}"))
 }
 
 pub struct MessagingService<S: MessagingStateStore> {
@@ -110,7 +129,11 @@ impl<S: MessagingStateStore> MessagingService<S> {
         match command {
             ClientCommand::BeginBlobUpload { metadata } => {
                 let status = self.blob_store()?.begin_upload(&metadata)?;
-                self.single_service_event(ServerEvent::BlobUploadChanged { status }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobUploadChanged { status },
+                    server_time_ms,
+                )
             }
             ClientCommand::AppendBlobChunk {
                 blob_id,
@@ -121,22 +144,40 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     .decode(data_base64.as_bytes())
                     .map_err(|error| MessagingServiceError::InvalidBlobBase64(error.to_string()))?;
                 let status = self.blob_store()?.append_chunk(&blob_id, offset, &bytes)?;
-                self.single_service_event(ServerEvent::BlobUploadChanged { status }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobUploadChanged { status },
+                    server_time_ms,
+                )
             }
             ClientCommand::FinishBlobUpload { blob_id } => {
                 let metadata = self.blob_store()?.finish_upload(&blob_id)?;
-                self.single_service_event(ServerEvent::BlobReady { metadata }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobReady { metadata },
+                    server_time_ms,
+                )
             }
             ClientCommand::DeleteBlob { blob_id } => {
                 self.blob_store()?.delete(&blob_id)?;
-                self.single_service_event(ServerEvent::BlobDeleted { blob_id }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobDeleted { blob_id },
+                    server_time_ms,
+                )
             }
             ClientCommand::WalletStatus => {
                 Ok(vec![self.wallet_status_envelope(&actor_id, server_time_ms)])
             }
+            ClientCommand::Sync { cursor, limit } => {
+                self.mark_direct_messages_delivered(&actor_id, server_time_ms)?;
+                self.sync_response(&actor_id, cursor.as_deref(), limit, server_time_ms)
+            }
             command => {
-                if let ClientCommand::Sync { limit, .. } = &command {
-                    return Ok(vec![self.sync_envelope(&actor_id, *limit, server_time_ms)]);
+                if let Some(replay) =
+                    self.idempotent_send_replay(&actor_id, &command, server_time_ms)?
+                {
+                    return Ok(replay);
                 }
 
                 let commands = self.project_command(&actor_id, command, server_time_ms);
@@ -157,7 +198,6 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     .flat_map(|message| self.bot_invocations_for_message(message))
                     .collect::<Vec<_>>();
                 self.cursor = self.cursor.saturating_add(events.len() as u64);
-                self.persist(server_time_ms)?;
                 let mut responses = events
                     .into_iter()
                     .filter_map(|event| self.project_event(event, server_time_ms))
@@ -172,9 +212,68 @@ impl<S: MessagingStateStore> MessagingService<S> {
                             event: ServerEvent::BotInvocationRequested { invocation },
                         }),
                 );
+                let journal = self.journal_entries(&actor_id, &responses);
+                self.persist_with_events(server_time_ms, &journal)?;
                 Ok(responses)
             }
         }
+    }
+
+    fn idempotent_send_replay(
+        &self,
+        actor_id: &ActorId,
+        command: &ClientCommand,
+        server_time_ms: i64,
+    ) -> Result<Option<Vec<ServerEnvelope>>, MessagingServiceError> {
+        let ClientCommand::SendMessage {
+            conversation_id,
+            client_message_id,
+            content,
+            reply_to_message_id,
+            thread_root_message_id,
+            scheduled_at_ms,
+            silent,
+            protected_content,
+        } = command
+        else {
+            return Ok(None);
+        };
+        let stable_id = stable_message_id(actor_id, client_message_id);
+        let legacy_id = MessageId::new(format!("local:{}", client_message_id.0));
+        let existing = self
+            .engine
+            .state()
+            .messages
+            .get(conversation_id)
+            .and_then(|messages| {
+                messages
+                    .get(&stable_id)
+                    .or_else(|| messages.get(&legacy_id))
+            });
+        let Some(existing) = existing else {
+            return Ok(None);
+        };
+        if &existing.sender_id != actor_id
+            || existing.client_message_id.as_ref() != Some(client_message_id)
+            || &existing.content != content
+            || &existing.reply_to_message_id != reply_to_message_id
+            || &existing.thread_root_message_id != thread_root_message_id
+            || &existing.scheduled_at_ms != scheduled_at_ms
+            || &existing.silent != silent
+            || &existing.protected_content != protected_content
+        {
+            return Err(MessagingServiceError::IdempotencyConflict(
+                client_message_id.0.clone(),
+            ));
+        }
+        Ok(Some(vec![ServerEnvelope {
+            protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
+            cursor: Some(self.cursor.to_string()),
+            server_time_ms,
+            event: ServerEvent::MessageChanged {
+                message: existing.clone(),
+            },
+        }]))
     }
 
     fn bot_invocations_for_message(&self, message: &Message) -> Vec<BotInvocation> {
@@ -315,17 +414,20 @@ impl<S: MessagingStateStore> MessagingService<S> {
 
     fn single_service_event(
         &mut self,
+        actor_id: &ActorId,
         event: ServerEvent,
         server_time_ms: i64,
     ) -> Result<Vec<ServerEnvelope>, MessagingServiceError> {
         self.cursor = self.cursor.saturating_add(1);
-        self.persist(server_time_ms)?;
-        Ok(vec![ServerEnvelope {
+        let response = ServerEnvelope {
             protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
             cursor: Some(self.cursor.to_string()),
             server_time_ms,
             event,
-        }])
+        };
+        let journal = self.journal_entries(actor_id, std::slice::from_ref(&response));
+        self.persist_with_events(server_time_ms, &journal)?;
+        Ok(vec![response])
     }
 
     pub fn apply_signed_settlement(
@@ -409,6 +511,62 @@ impl<S: MessagingStateStore> MessagingService<S> {
         }
     }
 
+    fn sync_response(
+        &self,
+        actor_id: &ActorId,
+        cursor: Option<&str>,
+        limit: u32,
+        server_time_ms: i64,
+    ) -> Result<Vec<ServerEnvelope>, MessagingServiceError> {
+        let Some(requested_cursor) = cursor.and_then(|value| value.parse::<u64>().ok()) else {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        };
+        if requested_cursor > self.cursor {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        }
+        let Some(slice) = self.store.load_event_journal_after(
+            requested_cursor,
+            usize::try_from(limit.max(1)).unwrap_or(usize::MAX),
+        )? else {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        };
+        if requested_cursor < slice.floor_cursor
+            || (slice.entries.is_empty() && requested_cursor < slice.current_cursor)
+        {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        }
+        let mut responses = slice
+            .entries
+            .into_iter()
+            .filter(|entry| entry.audience.iter().any(|candidate| candidate == actor_id))
+            .map(|entry| entry.envelope)
+            .collect::<Vec<_>>();
+        responses.push(self.sync_checkpoint_envelope(slice.checkpoint_cursor, server_time_ms));
+        Ok(responses)
+    }
+
+    fn sync_checkpoint_envelope(&self, cursor: u64, server_time_ms: i64) -> ServerEnvelope {
+        ServerEnvelope {
+            protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
+            cursor: Some(cursor.to_string()),
+            server_time_ms,
+            event: ServerEvent::SyncBatch {
+                actors: Vec::new(),
+                conversations: Vec::new(),
+                messages: Vec::new(),
+                folders: Vec::new(),
+                invoices: Vec::new(),
+                orders: Vec::new(),
+                stories: Vec::new(),
+                communities: Vec::new(),
+                bots: Vec::new(),
+                bot_executions: Vec::new(),
+                mini_apps: Vec::new(),
+                next_cursor: Some(cursor.to_string()),
+            },
+        }
+    }
+
     fn sync_envelope(&self, actor_id: &ActorId, limit: u32, server_time_ms: i64) -> ServerEnvelope {
         let state = self.engine.state();
         let max_items = usize::try_from(limit.max(1)).unwrap_or(usize::MAX);
@@ -423,7 +581,7 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     || conversation.owner_id.as_ref() == Some(actor_id)
             })
             .map(|conversation| conversation.id.clone())
-            .collect::<std::collections::BTreeSet<_>>();
+            .collect::<BTreeSet<_>>();
         let visible_actor_ids = visible_conversation_ids
             .iter()
             .filter_map(|conversation_id| state.conversations.get(conversation_id))
@@ -434,7 +592,7 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     .map(|participant| participant.actor_id.clone())
             })
             .chain(std::iter::once(actor_id.clone()))
-            .collect::<std::collections::BTreeSet<_>>();
+            .collect::<BTreeSet<_>>();
         ServerEnvelope {
             protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
             cursor: Some(self.cursor.to_string()),
@@ -525,6 +683,59 @@ impl<S: MessagingStateStore> MessagingService<S> {
         }
     }
 
+    fn mark_direct_messages_delivered(
+        &mut self,
+        actor_id: &ActorId,
+        server_time_ms: i64,
+    ) -> Result<(), MessagingServiceError> {
+        let pending = self
+            .engine
+            .state()
+            .conversations
+            .values()
+            .filter(|conversation| {
+                matches!(conversation.kind, ConversationKind::Direct | ConversationKind::Secret)
+                    && conversation
+                        .participants
+                        .iter()
+                        .any(|participant| &participant.actor_id == actor_id)
+            })
+            .flat_map(|conversation| {
+                self.engine
+                    .state()
+                    .messages
+                    .get(&conversation.id)
+                    .into_iter()
+                    .flat_map(|messages| messages.values())
+                    .filter(|message| {
+                        &message.sender_id != actor_id
+                            && message.delivery_state == DeliveryState::Sent
+                    })
+                    .map(|message| (conversation.id.clone(), message.id.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        if pending.is_empty() {
+            return Ok(());
+        }
+        let mut events = Vec::new();
+        for (conversation_id, message_id) in pending {
+            events.extend(self.engine.execute(Command::SetDeliveryState {
+                conversation_id,
+                message_id,
+                state: DeliveryState::Delivered,
+            })?);
+        }
+        self.cursor = self.cursor.saturating_add(events.len() as u64);
+        let responses = events
+            .into_iter()
+            .filter_map(|event| self.project_event(event, server_time_ms))
+            .collect::<Vec<_>>();
+        let journal = self.journal_entries(actor_id, &responses);
+        self.persist_with_events(server_time_ms, &journal)?;
+        Ok(())
+    }
+
     fn project_command(
         &self,
         actor_id: &ActorId,
@@ -574,19 +785,30 @@ impl<S: MessagingStateStore> MessagingService<S> {
                 scheduled_at_ms,
                 silent,
                 protected_content,
-            } => vec![Command::QueueMessage {
-                conversation_id,
-                local_message_id: MessageId::new(format!("local:{}", client_message_id.0)),
-                client_message_id,
-                sender_id: actor_id.clone(),
-                content,
-                reply_to_message_id,
-                thread_root_message_id,
-                created_at_ms: now_ms,
-                scheduled_at_ms,
-                silent,
-                protected_content,
-            }],
+            } => {
+                let message_id = stable_message_id(actor_id, &client_message_id);
+                vec![
+                    Command::QueueMessage {
+                        conversation_id: conversation_id.clone(),
+                        local_message_id: message_id.clone(),
+                        client_message_id,
+                        sender_id: actor_id.clone(),
+                        content,
+                        reply_to_message_id,
+                        thread_root_message_id,
+                        created_at_ms: now_ms,
+                        scheduled_at_ms,
+                        silent,
+                        protected_content,
+                    },
+                    Command::AcknowledgeMessage {
+                        conversation_id,
+                        local_message_id: message_id.clone(),
+                        server_message_id: message_id,
+                        accepted_at_ms: now_ms,
+                    },
+                ]
+            }
             ClientCommand::ForwardMessage {
                 source_conversation_id,
                 message_id,
@@ -622,11 +844,36 @@ impl<S: MessagingStateStore> MessagingService<S> {
             ClientCommand::MarkRead {
                 conversation_id,
                 message_id,
-            } => vec![Command::MarkRead {
-                conversation_id,
-                actor_id: actor_id.clone(),
-                message_id,
-            }],
+            } => {
+                let mut commands = vec![Command::MarkRead {
+                    conversation_id: conversation_id.clone(),
+                    actor_id: actor_id.clone(),
+                    message_id: message_id.clone(),
+                }];
+                let should_mark_message_read = self
+                    .engine
+                    .state()
+                    .conversations
+                    .get(&conversation_id)
+                    .is_some_and(|conversation| {
+                        matches!(conversation.kind, ConversationKind::Direct | ConversationKind::Secret)
+                    })
+                    && self
+                        .engine
+                        .state()
+                        .messages
+                        .get(&conversation_id)
+                        .and_then(|messages| messages.get(&message_id))
+                        .is_some_and(|message| &message.sender_id != actor_id);
+                if should_mark_message_read {
+                    commands.push(Command::SetDeliveryState {
+                        conversation_id,
+                        message_id,
+                        state: DeliveryState::Read,
+                    });
+                }
+                commands
+            }
             ClientCommand::SetReaction {
                 conversation_id,
                 message_id,
@@ -883,6 +1130,138 @@ impl<S: MessagingStateStore> MessagingService<S> {
             server_time_ms,
             event: server_event,
         })
+    }
+
+    fn journal_entries(&self, initiator: &ActorId, responses: &[ServerEnvelope]) -> Vec<JournalEntry> {
+        responses
+            .iter()
+            .filter(|response| !matches!(response.event, ServerEvent::SyncBatch { .. }))
+            .map(|response| JournalEntry {
+                envelope: response.clone(),
+                audience: self.event_audience(initiator, &response.event),
+            })
+            .collect()
+    }
+
+    fn event_audience(&self, initiator: &ActorId, event: &ServerEvent) -> Vec<ActorId> {
+        let mut audience = BTreeSet::from([initiator.clone()]);
+        match event {
+            ServerEvent::ActorChanged { actor } => {
+                audience.insert(actor.id.clone());
+                for conversation in self.engine.state().conversations.values().filter(|conversation| {
+                    conversation
+                        .participants
+                        .iter()
+                        .any(|participant| participant.actor_id == actor.id)
+                }) {
+                    Self::extend_conversation_audience(&mut audience, conversation);
+                }
+            }
+            ServerEvent::PresenceChanged { actor_id, .. } => {
+                audience.insert(actor_id.clone());
+                for conversation in self.engine.state().conversations.values().filter(|conversation| {
+                    conversation
+                        .participants
+                        .iter()
+                        .any(|participant| &participant.actor_id == actor_id)
+                }) {
+                    Self::extend_conversation_audience(&mut audience, conversation);
+                }
+            }
+            ServerEvent::ConversationChanged { conversation } => {
+                Self::extend_conversation_audience(&mut audience, conversation);
+            }
+            ServerEvent::MessageAdded { message } | ServerEvent::MessageChanged { message } => {
+                self.extend_conversation_id_audience(&mut audience, &message.conversation_id);
+            }
+            ServerEvent::MessagesDeleted { conversation_id, .. }
+            | ServerEvent::ReadChanged { conversation_id, .. }
+            | ServerEvent::TypingChanged { conversation_id, .. } => {
+                self.extend_conversation_id_audience(&mut audience, conversation_id);
+            }
+            ServerEvent::InvoiceChanged { invoice } => {
+                self.extend_conversation_id_audience(&mut audience, &invoice.conversation_id);
+            }
+            ServerEvent::OrderChanged { order } => {
+                audience.insert(order.buyer_id.clone());
+                if let Some(invoice) = self.engine.state().invoices.get(&order.invoice_id) {
+                    audience.insert(invoice.seller_id.clone());
+                }
+            }
+            ServerEvent::StoryChanged { story } => {
+                audience.insert(story.owner_id.clone());
+            }
+            ServerEvent::CommunityChanged { community } => {
+                self.extend_conversation_id_audience(&mut audience, &community.conversation_id);
+            }
+            ServerEvent::BotChanged { profile, execution } => {
+                if let Some(profile) = profile {
+                    audience.insert(profile.actor_id.clone());
+                }
+                if let Some(execution) = execution {
+                    audience.insert(execution.bot_id.clone());
+                }
+            }
+            ServerEvent::BotInvocationRequested { invocation } => {
+                audience.insert(invocation.sender_id.clone());
+                audience.insert(invocation.bot_id.clone());
+                self.extend_conversation_id_audience(&mut audience, &invocation.conversation_id);
+            }
+            ServerEvent::MiniAppOpened { session } => {
+                audience.insert(session.actor_id.clone());
+            }
+            ServerEvent::MiniAppResult { session_id, .. } => {
+                if let Some(session) = self.engine.state().mini_app_sessions.get(session_id) {
+                    audience.insert(session.actor_id.clone());
+                }
+            }
+            ServerEvent::SyncBatch { .. }
+            | ServerEvent::FolderChanged { .. }
+            | ServerEvent::FolderDeleted { .. }
+            | ServerEvent::BlobUploadChanged { .. }
+            | ServerEvent::BlobReady { .. }
+            | ServerEvent::BlobDeleted { .. }
+            | ServerEvent::WalletStatus { .. }
+            | ServerEvent::StoryDeleted { .. }
+            | ServerEvent::MiniAppChanged { .. }
+            | ServerEvent::Error { .. } => {}
+        }
+        audience.into_iter().collect()
+    }
+
+    fn extend_conversation_id_audience(
+        &self,
+        audience: &mut BTreeSet<ActorId>,
+        conversation_id: &ConversationId,
+    ) {
+        if let Some(conversation) = self.engine.state().conversations.get(conversation_id) {
+            Self::extend_conversation_audience(audience, conversation);
+        }
+    }
+
+    fn extend_conversation_audience(
+        audience: &mut BTreeSet<ActorId>,
+        conversation: &crate::conversation::Conversation,
+    ) {
+        audience.extend(
+            conversation
+                .participants
+                .iter()
+                .map(|participant| participant.actor_id.clone()),
+        );
+        if let Some(owner_id) = &conversation.owner_id {
+            audience.insert(owner_id.clone());
+        }
+    }
+
+    fn persist_with_events(
+        &mut self,
+        now_ms: i64,
+        events: &[JournalEntry],
+    ) -> Result<(), MessagingServiceError> {
+        let snapshot = MessagingSnapshot::new(self.engine.state().clone(), self.cursor, now_ms);
+        self.store.save_with_events(&snapshot, events)?;
+        Ok(())
     }
 
     fn persist(&mut self, now_ms: i64) -> Result<(), MessagingServiceError> {

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -1,5 +1,7 @@
+use crate::actor::ActorId;
 use crate::engine::MessagingState;
-use rusqlite::{params, Connection, OptionalExtension};
+use crate::protocol::ServerEnvelope;
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::io::{Read, Write};
@@ -7,7 +9,8 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 pub const MESSAGING_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
-pub const MESSAGING_SQLITE_SCHEMA_VERSION: u32 = 1;
+pub const MESSAGING_SQLITE_SCHEMA_VERSION: u32 = 2;
+pub const MESSAGING_EVENT_JOURNAL_LIMIT: usize = 10_000;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,6 +32,22 @@ impl MessagingSnapshot {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalEntry {
+    pub envelope: ServerEnvelope,
+    pub audience: Vec<ActorId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventJournalSlice {
+    pub floor_cursor: u64,
+    pub current_cursor: u64,
+    pub checkpoint_cursor: u64,
+    pub has_more: bool,
+    pub entries: Vec<JournalEntry>,
+}
+
 #[derive(Debug, Error)]
 pub enum StoreError {
     #[error("messaging store I/O failed: {0}")]
@@ -39,6 +58,8 @@ pub enum StoreError {
     Sqlite(#[from] rusqlite::Error),
     #[error("messaging cursor is invalid: {0}")]
     InvalidCursor(#[from] std::num::ParseIntError),
+    #[error("messaging journal event is missing a server cursor")]
+    MissingEventCursor,
     #[error("unsupported messaging snapshot schema {actual}; expected {expected}")]
     UnsupportedSchema { expected: u32, actual: u32 },
     #[error("unsupported messaging SQLite schema {actual}; expected at most {expected}")]
@@ -48,11 +69,29 @@ pub enum StoreError {
 pub trait MessagingStateStore: Send {
     fn load(&self) -> Result<Option<MessagingSnapshot>, StoreError>;
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError>;
+
+    fn save_with_events(
+        &mut self,
+        snapshot: &MessagingSnapshot,
+        _events: &[JournalEntry],
+    ) -> Result<(), StoreError> {
+        self.save(snapshot)
+    }
+
+    fn load_event_journal_after(
+        &self,
+        _cursor: u64,
+        _cursor_group_limit: usize,
+    ) -> Result<Option<EventJournalSlice>, StoreError> {
+        Ok(None)
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct MemoryStateStore {
     snapshot: Option<MessagingSnapshot>,
+    journal: Vec<JournalEntry>,
+    journal_floor_cursor: u64,
 }
 
 impl MemoryStateStore {
@@ -69,7 +108,49 @@ impl MessagingStateStore for MemoryStateStore {
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
         validate_snapshot_schema(snapshot.schema_version)?;
         self.snapshot = Some(snapshot.clone());
+        self.journal.clear();
+        self.journal_floor_cursor = snapshot.cursor;
         Ok(())
+    }
+
+    fn save_with_events(
+        &mut self,
+        snapshot: &MessagingSnapshot,
+        events: &[JournalEntry],
+    ) -> Result<(), StoreError> {
+        validate_snapshot_schema(snapshot.schema_version)?;
+        for event in events {
+            journal_cursor(event)?;
+        }
+        self.snapshot = Some(snapshot.clone());
+        self.journal.extend_from_slice(events);
+        if self.journal.len() > MESSAGING_EVENT_JOURNAL_LIMIT {
+            let excess = self.journal.len() - MESSAGING_EVENT_JOURNAL_LIMIT;
+            let prune_cursor = journal_cursor(&self.journal[excess - 1])?;
+            let remove_count = self
+                .journal
+                .iter()
+                .take_while(|entry| journal_cursor(entry).is_ok_and(|cursor| cursor <= prune_cursor))
+                .count();
+            self.journal.drain(0..remove_count);
+            self.journal_floor_cursor = prune_cursor;
+        }
+        Ok(())
+    }
+
+    fn load_event_journal_after(
+        &self,
+        cursor: u64,
+        cursor_group_limit: usize,
+    ) -> Result<Option<EventJournalSlice>, StoreError> {
+        let current_cursor = self.snapshot.as_ref().map_or(0, |snapshot| snapshot.cursor);
+        Ok(Some(slice_journal(
+            &self.journal,
+            self.journal_floor_cursor,
+            current_cursor,
+            cursor,
+            cursor_group_limit,
+        )?))
     }
 }
 
@@ -150,8 +231,8 @@ impl SqliteStateStore {
     }
 
     pub fn initialize(&self) -> Result<(), StoreError> {
-        let connection = self.open()?;
-        migrate_sqlite(&connection)
+        let mut connection = self.open()?;
+        migrate_sqlite(&mut connection)
     }
 
     pub fn import_json_if_empty(
@@ -176,8 +257,8 @@ impl SqliteStateStore {
     }
 
     fn open_initialized(&self) -> Result<Connection, StoreError> {
-        let connection = self.open()?;
-        migrate_sqlite(&connection)?;
+        let mut connection = self.open()?;
+        migrate_sqlite(&mut connection)?;
         Ok(connection)
     }
 }
@@ -185,50 +266,80 @@ impl SqliteStateStore {
 impl MessagingStateStore for SqliteStateStore {
     fn load(&self) -> Result<Option<MessagingSnapshot>, StoreError> {
         let connection = self.open_initialized()?;
-        let row = connection
-            .query_row(
-                "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json FROM messaging_snapshot WHERE singleton = 1",
-                [],
-                |row| {
-                    Ok((
-                        row.get::<_, u32>(0)?,
-                        row.get::<_, String>(1)?,
-                        row.get::<_, i64>(2)?,
-                        row.get::<_, String>(3)?,
-                    ))
-                },
-            )
-            .optional()?;
-
-        let Some((schema_version, cursor, saved_at_ms, state_json)) = row else {
-            return Ok(None);
-        };
-        validate_snapshot_schema(schema_version)?;
-        let state = serde_json::from_str(&state_json)?;
-        Ok(Some(MessagingSnapshot {
-            schema_version,
-            cursor: cursor.parse()?,
-            saved_at_ms,
-            state,
-        }))
+        load_sqlite_snapshot(&connection)
     }
 
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
         validate_snapshot_schema(snapshot.schema_version)?;
         let mut connection = self.open_initialized()?;
         let transaction = connection.transaction()?;
-        let state_json = serde_json::to_string(&snapshot.state)?;
-        transaction.execute(
-            "INSERT INTO messaging_snapshot (singleton, snapshot_schema_version, cursor, saved_at_ms, state_json) VALUES (1, ?1, ?2, ?3, ?4) ON CONFLICT(singleton) DO UPDATE SET snapshot_schema_version = excluded.snapshot_schema_version, cursor = excluded.cursor, saved_at_ms = excluded.saved_at_ms, state_json = excluded.state_json",
-            params![
-                snapshot.schema_version,
-                snapshot.cursor.to_string(),
-                snapshot.saved_at_ms,
-                state_json
-            ],
-        )?;
+        write_snapshot(&transaction, snapshot)?;
+        transaction.execute("DELETE FROM messaging_event_journal", [])?;
+        set_journal_floor(&transaction, snapshot.cursor)?;
         transaction.commit()?;
         Ok(())
+    }
+
+    fn save_with_events(
+        &mut self,
+        snapshot: &MessagingSnapshot,
+        events: &[JournalEntry],
+    ) -> Result<(), StoreError> {
+        validate_snapshot_schema(snapshot.schema_version)?;
+        let mut connection = self.open_initialized()?;
+        let transaction = connection.transaction()?;
+        write_snapshot(&transaction, snapshot)?;
+        for event in events {
+            let cursor = journal_cursor(event)?;
+            transaction.execute(
+                "INSERT INTO messaging_event_journal (cursor, audience_json, envelope_json) VALUES (?1, ?2, ?3)",
+                params![
+                    cursor.to_string(),
+                    serde_json::to_string(&event.audience)?,
+                    serde_json::to_string(&event.envelope)?
+                ],
+            )?;
+        }
+        prune_sqlite_journal(&transaction)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    fn load_event_journal_after(
+        &self,
+        cursor: u64,
+        cursor_group_limit: usize,
+    ) -> Result<Option<EventJournalSlice>, StoreError> {
+        let connection = self.open_initialized()?;
+        let floor_cursor = connection
+            .query_row(
+                "SELECT value FROM messaging_metadata WHERE key = 'journal_floor_cursor'",
+                [],
+                |row| row.get::<_, String>(0),
+            )?
+            .parse()?;
+        let current_cursor = load_sqlite_snapshot(&connection)?.map_or(0, |snapshot| snapshot.cursor);
+        let mut statement = connection.prepare(
+            "SELECT audience_json, envelope_json FROM messaging_event_journal ORDER BY sequence ASC",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut entries = Vec::new();
+        for row in rows {
+            let (audience_json, envelope_json) = row?;
+            entries.push(JournalEntry {
+                audience: serde_json::from_str(&audience_json)?,
+                envelope: serde_json::from_str(&envelope_json)?,
+            });
+        }
+        Ok(Some(slice_journal(
+            &entries,
+            floor_cursor,
+            current_cursor,
+            cursor,
+            cursor_group_limit,
+        )?))
     }
 }
 
@@ -242,7 +353,143 @@ fn validate_snapshot_schema(actual: u32) -> Result<(), StoreError> {
     Ok(())
 }
 
-fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
+fn journal_cursor(entry: &JournalEntry) -> Result<u64, StoreError> {
+    entry
+        .envelope
+        .cursor
+        .as_deref()
+        .ok_or(StoreError::MissingEventCursor)?
+        .parse()
+        .map_err(StoreError::from)
+}
+
+fn slice_journal(
+    entries: &[JournalEntry],
+    floor_cursor: u64,
+    current_cursor: u64,
+    requested_cursor: u64,
+    cursor_group_limit: usize,
+) -> Result<EventJournalSlice, StoreError> {
+    let limit = cursor_group_limit.max(1);
+    let mut selected = Vec::new();
+    let mut selected_groups = 0usize;
+    let mut last_selected_cursor = None;
+    let mut has_more = false;
+
+    for entry in entries {
+        let cursor = journal_cursor(entry)?;
+        if cursor <= requested_cursor {
+            continue;
+        }
+        if last_selected_cursor != Some(cursor) {
+            if selected_groups >= limit {
+                has_more = true;
+                break;
+            }
+            selected_groups += 1;
+            last_selected_cursor = Some(cursor);
+        }
+        selected.push(entry.clone());
+    }
+
+    let checkpoint_cursor = if has_more {
+        last_selected_cursor.unwrap_or(requested_cursor)
+    } else if selected.is_empty() && requested_cursor < current_cursor {
+        requested_cursor
+    } else {
+        current_cursor
+    };
+
+    Ok(EventJournalSlice {
+        floor_cursor,
+        current_cursor,
+        checkpoint_cursor,
+        has_more,
+        entries: selected,
+    })
+}
+
+fn load_sqlite_snapshot(connection: &Connection) -> Result<Option<MessagingSnapshot>, StoreError> {
+    let row = connection
+        .query_row(
+            "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json FROM messaging_snapshot WHERE singleton = 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, u32>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((schema_version, cursor, saved_at_ms, state_json)) = row else {
+        return Ok(None);
+    };
+    validate_snapshot_schema(schema_version)?;
+    Ok(Some(MessagingSnapshot {
+        schema_version,
+        cursor: cursor.parse()?,
+        saved_at_ms,
+        state: serde_json::from_str(&state_json)?,
+    }))
+}
+
+fn write_snapshot(
+    transaction: &Transaction<'_>,
+    snapshot: &MessagingSnapshot,
+) -> Result<(), StoreError> {
+    let state_json = serde_json::to_string(&snapshot.state)?;
+    transaction.execute(
+        "INSERT INTO messaging_snapshot (singleton, snapshot_schema_version, cursor, saved_at_ms, state_json) VALUES (1, ?1, ?2, ?3, ?4) ON CONFLICT(singleton) DO UPDATE SET snapshot_schema_version = excluded.snapshot_schema_version, cursor = excluded.cursor, saved_at_ms = excluded.saved_at_ms, state_json = excluded.state_json",
+        params![
+            snapshot.schema_version,
+            snapshot.cursor.to_string(),
+            snapshot.saved_at_ms,
+            state_json
+        ],
+    )?;
+    Ok(())
+}
+
+fn set_journal_floor(transaction: &Transaction<'_>, cursor: u64) -> Result<(), StoreError> {
+    transaction.execute(
+        "INSERT INTO messaging_metadata (key, value) VALUES ('journal_floor_cursor', ?1) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![cursor.to_string()],
+    )?;
+    Ok(())
+}
+
+fn prune_sqlite_journal(transaction: &Transaction<'_>) -> Result<(), StoreError> {
+    let count: usize = transaction.query_row(
+        "SELECT COUNT(*) FROM messaging_event_journal",
+        [],
+        |row| row.get(0),
+    )?;
+    if count <= MESSAGING_EVENT_JOURNAL_LIMIT {
+        return Ok(());
+    }
+    let excess = count - MESSAGING_EVENT_JOURNAL_LIMIT;
+    let prune_cursor: String = transaction.query_row(
+        "SELECT cursor FROM messaging_event_journal ORDER BY sequence ASC LIMIT 1 OFFSET ?1",
+        params![i64::try_from(excess.saturating_sub(1)).unwrap_or(i64::MAX)],
+        |row| row.get(0),
+    )?;
+    let max_sequence: i64 = transaction.query_row(
+        "SELECT MAX(sequence) FROM messaging_event_journal WHERE cursor = ?1",
+        params![&prune_cursor],
+        |row| row.get(0),
+    )?;
+    transaction.execute(
+        "DELETE FROM messaging_event_journal WHERE sequence <= ?1",
+        params![max_sequence],
+    )?;
+    set_journal_floor(transaction, prune_cursor.parse()?)?;
+    Ok(())
+}
+
+fn migrate_sqlite(connection: &mut Connection) -> Result<(), StoreError> {
     let actual: u32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if actual > MESSAGING_SQLITE_SCHEMA_VERSION {
         return Err(StoreError::UnsupportedSqliteSchema {
@@ -251,18 +498,60 @@ fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
         });
     }
     if actual == 0 {
-        connection.execute_batch(
-            "BEGIN IMMEDIATE;
-             CREATE TABLE IF NOT EXISTS messaging_snapshot (
+        let transaction = connection.transaction()?;
+        transaction.execute_batch(
+            "CREATE TABLE IF NOT EXISTS messaging_snapshot (
                  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
                  snapshot_schema_version INTEGER NOT NULL,
                  cursor TEXT NOT NULL,
                  saved_at_ms INTEGER NOT NULL,
                  state_json TEXT NOT NULL
              );
-             PRAGMA user_version = 1;
-             COMMIT;",
+             CREATE TABLE IF NOT EXISTS messaging_event_journal (
+                 sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                 cursor TEXT NOT NULL,
+                 audience_json TEXT NOT NULL,
+                 envelope_json TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS messaging_metadata (
+                 key TEXT PRIMARY KEY,
+                 value TEXT NOT NULL
+             );",
         )?;
+        transaction.execute(
+            "INSERT OR IGNORE INTO messaging_metadata (key, value) VALUES ('journal_floor_cursor', '0')",
+            [],
+        )?;
+        transaction.execute_batch("PRAGMA user_version = 2;")?;
+        transaction.commit()?;
+    } else if actual == 1 {
+        let current_cursor = connection
+            .query_row(
+                "SELECT cursor FROM messaging_snapshot WHERE singleton = 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .unwrap_or_else(|| "0".into());
+        let transaction = connection.transaction()?;
+        transaction.execute_batch(
+            "CREATE TABLE IF NOT EXISTS messaging_event_journal (
+                 sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                 cursor TEXT NOT NULL,
+                 audience_json TEXT NOT NULL,
+                 envelope_json TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS messaging_metadata (
+                 key TEXT PRIMARY KEY,
+                 value TEXT NOT NULL
+             );",
+        )?;
+        transaction.execute(
+            "INSERT OR REPLACE INTO messaging_metadata (key, value) VALUES ('journal_floor_cursor', ?1)",
+            params![current_cursor],
+        )?;
+        transaction.execute_batch("PRAGMA user_version = 2;")?;
+        transaction.commit()?;
     }
     Ok(())
 }
@@ -270,6 +559,7 @@ fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::{ServerEvent, FABUSHI_MESSAGING_PROTOCOL_VERSION};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temporary_db(name: &str) -> PathBuf {
@@ -287,6 +577,20 @@ mod tests {
         let _ = fs::remove_file(path);
         let _ = fs::remove_file(path.with_extension("sqlite3-wal"));
         let _ = fs::remove_file(path.with_extension("sqlite3-shm"));
+    }
+
+    fn journal_entry(cursor: u64, actor: &str) -> JournalEntry {
+        JournalEntry {
+            envelope: ServerEnvelope {
+                protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
+                cursor: Some(cursor.to_string()),
+                server_time_ms: i64::try_from(cursor).unwrap_or(i64::MAX),
+                event: ServerEvent::FolderDeleted {
+                    folder_id: format!("folder-{cursor}"),
+                },
+            },
+            audience: vec![ActorId::new(actor)],
+        }
     }
 
     #[test]
@@ -356,6 +660,92 @@ mod tests {
             .expect("count snapshots");
         assert_eq!(count, 1);
         remove_db(&path);
+    }
+
+    #[test]
+    fn sqlite_v1_migration_sets_journal_floor_to_existing_cursor() {
+        let path = temporary_db("v1-migration");
+        let connection = Connection::open(&path).expect("open database");
+        connection
+            .execute_batch(
+                "CREATE TABLE messaging_snapshot (
+                    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                    snapshot_schema_version INTEGER NOT NULL,
+                    cursor TEXT NOT NULL,
+                    saved_at_ms INTEGER NOT NULL,
+                    state_json TEXT NOT NULL
+                 );
+                 INSERT INTO messaging_snapshot VALUES (1, 1, '41', 100, '{}');
+                 PRAGMA user_version = 1;",
+            )
+            .expect("create v1 database");
+        drop(connection);
+
+        let store = SqliteStateStore::new(&path);
+        let slice = store
+            .load_event_journal_after(40, 100)
+            .expect("load migrated journal")
+            .expect("sqlite journal");
+        assert_eq!(slice.floor_cursor, 41);
+        assert_eq!(slice.current_cursor, 41);
+        remove_db(&path);
+    }
+
+    #[test]
+    fn sqlite_store_persists_journal_with_snapshot() {
+        let path = temporary_db("journal");
+        let mut store = SqliteStateStore::new(&path);
+        let snapshot = MessagingSnapshot::new(MessagingState::default(), 3, 30);
+        store
+            .save_with_events(
+                &snapshot,
+                &[journal_entry(2, "human:a"), journal_entry(3, "human:b")],
+            )
+            .expect("save snapshot and journal");
+        drop(store);
+
+        let reopened = SqliteStateStore::new(&path);
+        let slice = reopened
+            .load_event_journal_after(1, 100)
+            .expect("load journal")
+            .expect("sqlite journal");
+        assert_eq!(slice.floor_cursor, 0);
+        assert_eq!(slice.current_cursor, 3);
+        assert_eq!(slice.checkpoint_cursor, 3);
+        assert_eq!(slice.entries.len(), 2);
+        assert_eq!(slice.entries[0].audience, vec![ActorId::new("human:a")]);
+        remove_db(&path);
+    }
+
+    #[test]
+    fn journal_pagination_never_splits_a_cursor_group() {
+        let mut store = MemoryStateStore::default();
+        let snapshot = MessagingSnapshot::new(MessagingState::default(), 3, 30);
+        store
+            .save_with_events(
+                &snapshot,
+                &[
+                    journal_entry(1, "human:a"),
+                    journal_entry(2, "human:a"),
+                    journal_entry(2, "human:b"),
+                    journal_entry(3, "human:a"),
+                ],
+            )
+            .expect("save memory journal");
+        let first = store
+            .load_event_journal_after(0, 2)
+            .expect("load first page")
+            .expect("memory journal");
+        assert!(first.has_more);
+        assert_eq!(first.checkpoint_cursor, 2);
+        assert_eq!(first.entries.len(), 3);
+        let second = store
+            .load_event_journal_after(first.checkpoint_cursor, 2)
+            .expect("load second page")
+            .expect("memory journal");
+        assert!(!second.has_more);
+        assert_eq!(second.checkpoint_cursor, 3);
+        assert_eq!(second.entries.len(), 1);
     }
 
     #[test]

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -107,9 +107,10 @@ impl MessagingStateStore for MemoryStateStore {
 
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
         validate_snapshot_schema(snapshot.schema_version)?;
+        if self.journal.is_empty() {
+            self.journal_floor_cursor = self.journal_floor_cursor.max(snapshot.cursor);
+        }
         self.snapshot = Some(snapshot.clone());
-        self.journal.clear();
-        self.journal_floor_cursor = snapshot.cursor;
         Ok(())
     }
 
@@ -274,8 +275,14 @@ impl MessagingStateStore for SqliteStateStore {
         let mut connection = self.open_initialized()?;
         let transaction = connection.transaction()?;
         write_snapshot(&transaction, snapshot)?;
-        transaction.execute("DELETE FROM messaging_event_journal", [])?;
-        set_journal_floor(&transaction, snapshot.cursor)?;
+        let journal_count: i64 = transaction.query_row(
+            "SELECT COUNT(*) FROM messaging_event_journal",
+            [],
+            |row| row.get(0),
+        )?;
+        if journal_count == 0 {
+            set_journal_floor(&transaction, snapshot.cursor)?;
+        }
         transaction.commit()?;
         Ok(())
     }
@@ -462,18 +469,19 @@ fn set_journal_floor(transaction: &Transaction<'_>, cursor: u64) -> Result<(), S
 }
 
 fn prune_sqlite_journal(transaction: &Transaction<'_>) -> Result<(), StoreError> {
-    let count: usize = transaction.query_row(
+    let count: i64 = transaction.query_row(
         "SELECT COUNT(*) FROM messaging_event_journal",
         [],
         |row| row.get(0),
     )?;
-    if count <= MESSAGING_EVENT_JOURNAL_LIMIT {
+    let limit = i64::try_from(MESSAGING_EVENT_JOURNAL_LIMIT).unwrap_or(i64::MAX);
+    if count <= limit {
         return Ok(());
     }
-    let excess = count - MESSAGING_EVENT_JOURNAL_LIMIT;
+    let excess = count.saturating_sub(limit);
     let prune_cursor: String = transaction.query_row(
         "SELECT cursor FROM messaging_event_journal ORDER BY sequence ASC LIMIT 1 OFFSET ?1",
-        params![i64::try_from(excess.saturating_sub(1)).unwrap_or(i64::MAX)],
+        params![excess.saturating_sub(1)],
         |row| row.get(0),
     )?;
     let max_sequence: i64 = transaction.query_row(
@@ -659,6 +667,25 @@ mod tests {
             })
             .expect("count snapshots");
         assert_eq!(count, 1);
+        remove_db(&path);
+    }
+
+    #[test]
+    fn plain_snapshot_save_preserves_existing_journal() {
+        let path = temporary_db("journal-preserve");
+        let mut store = SqliteStateStore::new(&path);
+        let first = MessagingSnapshot::new(MessagingState::default(), 1, 10);
+        store
+            .save_with_events(&first, &[journal_entry(1, "human:a")])
+            .expect("save journal entry");
+        let second = MessagingSnapshot::new(MessagingState::default(), 2, 20);
+        store.save(&second).expect("save plain snapshot");
+        let slice = store
+            .load_event_journal_after(0, 100)
+            .expect("load preserved journal")
+            .expect("sqlite journal");
+        assert_eq!(slice.entries.len(), 1);
+        assert_eq!(slice.current_cursor, 2);
         remove_db(&path);
     }
 

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -144,7 +144,10 @@ impl MessagingStateStore for MemoryStateStore {
         cursor: u64,
         cursor_group_limit: usize,
     ) -> Result<Option<EventJournalSlice>, StoreError> {
-        let current_cursor = self.snapshot.as_ref().map_or(0, |snapshot| snapshot.cursor);
+        let current_cursor = self
+            .snapshot
+            .as_ref()
+            .map_or(0, |snapshot| snapshot.cursor);
         Ok(Some(slice_journal(
             &self.journal,
             self.journal_floor_cursor,
@@ -325,7 +328,8 @@ impl MessagingStateStore for SqliteStateStore {
                 |row| row.get::<_, String>(0),
             )?
             .parse()?;
-        let current_cursor = load_sqlite_snapshot(&connection)?.map_or(0, |snapshot| snapshot.cursor);
+        let current_cursor =
+            load_sqlite_snapshot(&connection)?.map_or(0, |snapshot| snapshot.cursor);
         let mut statement = connection.prepare(
             "SELECT audience_json, envelope_json FROM messaging_event_journal ORDER BY sequence ASC",
         )?;
@@ -416,7 +420,9 @@ fn slice_journal(
     })
 }
 
-fn load_sqlite_snapshot(connection: &Connection) -> Result<Option<MessagingSnapshot>, StoreError> {
+fn load_sqlite_snapshot(
+    connection: &Connection,
+) -> Result<Option<MessagingSnapshot>, StoreError> {
     let row = connection
         .query_row(
             "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json FROM messaging_snapshot WHERE singleton = 1",
@@ -726,7 +732,10 @@ mod tests {
         store
             .save_with_events(
                 &snapshot,
-                &[journal_entry(2, "human:a"), journal_entry(3, "human:b")],
+                &[
+                    journal_entry(2, "human:a"),
+                    journal_entry(3, "human:b"),
+                ],
             )
             .expect("save snapshot and journal");
         drop(store);
@@ -740,7 +749,10 @@ mod tests {
         assert_eq!(slice.current_cursor, 3);
         assert_eq!(slice.checkpoint_cursor, 3);
         assert_eq!(slice.entries.len(), 2);
-        assert_eq!(slice.entries[0].audience, vec![ActorId::new("human:a")]);
+        assert_eq!(
+            slice.entries[0].audience,
+            vec![ActorId::new("human:a")]
+        );
         remove_db(&path);
     }
 

--- a/native/mahayana-messaging/tests/delta_sync_contract.rs
+++ b/native/mahayana-messaging/tests/delta_sync_contract.rs
@@ -1,0 +1,395 @@
+use fabushi_messaging_core::*;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn context(actor_id: &str, device_id: &str, session_id: &str, request_id: &str) -> RequestContext {
+    RequestContext {
+        request_id: request_id.into(),
+        device_id: device_id.into(),
+        actor_id: ActorId::new(actor_id),
+        session_id: session_id.into(),
+        sent_at_ms: 1,
+    }
+}
+
+fn envelope(actor_id: &str, request_id: &str, command: ClientCommand) -> ClientEnvelope {
+    ClientEnvelope::new(
+        context(actor_id, "desktop:1", "session:1", request_id),
+        command,
+    )
+}
+
+fn second_device_envelope(
+    actor_id: &str,
+    request_id: &str,
+    command: ClientCommand,
+) -> ClientEnvelope {
+    ClientEnvelope::new(
+        context(actor_id, "mobile:2", "session:2", request_id),
+        command,
+    )
+}
+
+fn participant(actor_id: &str, role: ParticipantRole) -> Participant {
+    Participant {
+        actor_id: ActorId::new(actor_id),
+        role,
+        joined_at_ms: 1,
+        muted_until_ms: None,
+    }
+}
+
+fn send_text(client_message_id: &str, text: &str) -> ClientCommand {
+    ClientCommand::SendMessage {
+        conversation_id: ConversationId::new("chat:direct"),
+        client_message_id: ClientMessageId(client_message_id.into()),
+        content: MessageContent::Text {
+            text: FormattedText::plain(text),
+        },
+        reply_to_message_id: None,
+        thread_root_message_id: None,
+        scheduled_at_ms: None,
+        silent: false,
+        protected_content: false,
+    }
+}
+
+fn setup_direct_conversation<S: MessagingStateStore>(service: &mut MessagingService<S>) {
+    service
+        .handle(
+            envelope(
+                "human:alice",
+                "actor:alice",
+                ClientCommand::UpsertProfile {
+                    actor: Actor::human("human:alice", "Alice"),
+                },
+            ),
+            10,
+        )
+        .expect("upsert alice");
+    service
+        .handle(
+            envelope(
+                "human:bob",
+                "actor:bob",
+                ClientCommand::UpsertProfile {
+                    actor: Actor::human("human:bob", "Bob"),
+                },
+            ),
+            11,
+        )
+        .expect("upsert bob");
+    service
+        .handle(
+            envelope(
+                "human:outsider",
+                "actor:outsider",
+                ClientCommand::UpsertProfile {
+                    actor: Actor::human("human:outsider", "Outsider"),
+                },
+            ),
+            12,
+        )
+        .expect("upsert outsider");
+    service
+        .handle(
+            envelope(
+                "human:alice",
+                "conversation:create",
+                ClientCommand::CreateConversation {
+                    conversation: Conversation::direct(
+                        "chat:direct",
+                        "Alice and Bob",
+                        vec![
+                            participant("human:alice", ParticipantRole::Owner),
+                            participant("human:bob", ParticipantRole::Member),
+                        ],
+                        13,
+                    ),
+                },
+            ),
+            13,
+        )
+        .expect("create direct conversation");
+}
+
+fn sync_cursor(events: &[ServerEnvelope]) -> String {
+    events
+        .iter()
+        .rev()
+        .find_map(|event| match &event.event {
+            ServerEvent::SyncBatch {
+                next_cursor: Some(cursor),
+                ..
+            } => Some(cursor.clone()),
+            _ => None,
+        })
+        .expect("sync checkpoint cursor")
+}
+
+fn message_from_events(events: &[ServerEnvelope]) -> Message {
+    events
+        .iter()
+        .rev()
+        .find_map(|event| match &event.event {
+            ServerEvent::MessageChanged { message } | ServerEvent::MessageAdded { message } => {
+                Some(message.clone())
+            }
+            _ => None,
+        })
+        .expect("message event")
+}
+
+fn temporary_db(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "fabushi-delta-sync-{name}-{}-{nonce}.sqlite3",
+        std::process::id()
+    ))
+}
+
+fn remove_db(path: &PathBuf) {
+    let _ = fs::remove_file(path);
+    let _ = fs::remove_file(path.with_extension("sqlite3-wal"));
+    let _ = fs::remove_file(path.with_extension("sqlite3-shm"));
+}
+
+#[test]
+fn send_message_is_idempotent_and_server_acknowledged() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
+    setup_direct_conversation(&mut service);
+
+    let first = service
+        .handle(
+            envelope("human:alice", "send:first", send_text("client:idem", "hello")),
+            20,
+        )
+        .expect("send first message");
+    let first_message = message_from_events(&first);
+    assert!(first_message.id.0.starts_with("msg:"));
+    assert_eq!(first_message.delivery_state, DeliveryState::Sent);
+
+    let cursor_after_first = service.cursor();
+    let retry = service
+        .handle(
+            envelope("human:alice", "send:retry", send_text("client:idem", "hello")),
+            21,
+        )
+        .expect("retry idempotent message");
+    let retry_message = message_from_events(&retry);
+    assert_eq!(retry_message.id, first_message.id);
+    assert_eq!(retry_message.delivery_state, DeliveryState::Sent);
+    assert_eq!(service.cursor(), cursor_after_first);
+    assert_eq!(
+        service.engine().state().messages[&ConversationId::new("chat:direct")].len(),
+        1
+    );
+}
+
+#[test]
+fn reusing_client_message_id_with_different_payload_is_rejected() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
+    setup_direct_conversation(&mut service);
+    service
+        .handle(
+            envelope("human:alice", "send:first", send_text("client:conflict", "one")),
+            20,
+        )
+        .expect("send first message");
+
+    let error = service
+        .handle(
+            envelope("human:alice", "send:conflict", send_text("client:conflict", "two")),
+            21,
+        )
+        .expect_err("conflicting retry must fail");
+    assert!(matches!(error, MessagingServiceError::IdempotencyConflict(_)));
+}
+
+#[test]
+fn recipient_sync_marks_direct_message_delivered_and_mark_read_moves_it_to_read() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
+    setup_direct_conversation(&mut service);
+    let sent = service
+        .handle(
+            envelope("human:alice", "send:delivery", send_text("client:delivery", "hello bob")),
+            20,
+        )
+        .expect("send message");
+    let message_id = message_from_events(&sent).id;
+
+    service
+        .handle(
+            envelope(
+                "human:bob",
+                "sync:delivery",
+                ClientCommand::Sync {
+                    cursor: None,
+                    limit: 100,
+                },
+            ),
+            21,
+        )
+        .expect("recipient sync");
+    assert_eq!(
+        service.engine().state().messages[&ConversationId::new("chat:direct")][&message_id]
+            .delivery_state,
+        DeliveryState::Delivered
+    );
+
+    let read_events = service
+        .handle(
+            envelope(
+                "human:bob",
+                "read:delivery",
+                ClientCommand::MarkRead {
+                    conversation_id: ConversationId::new("chat:direct"),
+                    message_id: message_id.clone(),
+                },
+            ),
+            22,
+        )
+        .expect("mark read");
+    assert!(read_events.iter().any(|event| matches!(
+        event.event,
+        ServerEvent::ReadChanged { .. }
+    )));
+    assert_eq!(
+        service.engine().state().messages[&ConversationId::new("chat:direct")][&message_id]
+            .delivery_state,
+        DeliveryState::Read
+    );
+}
+
+#[test]
+fn durable_delta_sync_survives_restart_and_is_audience_scoped() {
+    let path = temporary_db("restart");
+    let mut service =
+        MessagingService::load(SqliteStateStore::new(&path)).expect("load sqlite service");
+    setup_direct_conversation(&mut service);
+
+    let bob_baseline = service
+        .handle(
+            envelope(
+                "human:bob",
+                "sync:bob:baseline",
+                ClientCommand::Sync {
+                    cursor: None,
+                    limit: 100,
+                },
+            ),
+            20,
+        )
+        .expect("bob baseline sync");
+    let bob_cursor = sync_cursor(&bob_baseline);
+
+    let outsider_baseline = service
+        .handle(
+            envelope(
+                "human:outsider",
+                "sync:outsider:baseline",
+                ClientCommand::Sync {
+                    cursor: None,
+                    limit: 100,
+                },
+            ),
+            21,
+        )
+        .expect("outsider baseline sync");
+    let outsider_cursor = sync_cursor(&outsider_baseline);
+
+    let sent = service
+        .handle(
+            envelope("human:alice", "send:delta", send_text("client:delta", "after baseline")),
+            22,
+        )
+        .expect("send delta message");
+    let message_id = message_from_events(&sent).id;
+    let cursor_after_send = service.cursor();
+    drop(service);
+
+    let mut restarted =
+        MessagingService::load(SqliteStateStore::new(&path)).expect("restart sqlite service");
+    assert_eq!(restarted.cursor(), cursor_after_send);
+
+    let bob_delta = restarted
+        .handle(
+            second_device_envelope(
+                "human:bob",
+                "sync:bob:device2",
+                ClientCommand::Sync {
+                    cursor: Some(bob_cursor),
+                    limit: 100,
+                },
+            ),
+            23,
+        )
+        .expect("bob device2 delta sync");
+    assert!(bob_delta.iter().any(|event| matches!(
+        &event.event,
+        ServerEvent::MessageAdded { message } | ServerEvent::MessageChanged { message }
+            if message.id == message_id
+    )));
+    assert!(bob_delta.iter().any(|event| matches!(
+        &event.event,
+        ServerEvent::SyncBatch { next_cursor: Some(_), .. }
+    )));
+
+    let outsider_delta = restarted
+        .handle(
+            second_device_envelope(
+                "human:outsider",
+                "sync:outsider:device2",
+                ClientCommand::Sync {
+                    cursor: Some(outsider_cursor),
+                    limit: 100,
+                },
+            ),
+            24,
+        )
+        .expect("outsider delta sync");
+    assert!(!outsider_delta.iter().any(|event| matches!(
+        &event.event,
+        ServerEvent::MessageAdded { .. } | ServerEvent::MessageChanged { .. }
+    )));
+
+    remove_db(&path);
+}
+
+#[test]
+fn cursor_older_than_migrated_journal_floor_falls_back_to_scoped_full_sync() {
+    let path = temporary_db("floor-fallback");
+    let mut legacy = SqliteStateStore::new(&path);
+    let mut state = MessagingState::default();
+    state
+        .actors
+        .insert(ActorId::new("human:alice"), Actor::human("human:alice", "Alice"));
+    legacy
+        .save(&MessagingSnapshot::new(state, 41, 100))
+        .expect("seed snapshot without journal");
+    drop(legacy);
+
+    let mut service =
+        MessagingService::load(SqliteStateStore::new(&path)).expect("load migrated service");
+    let events = service
+        .handle(
+            envelope(
+                "human:alice",
+                "sync:old-cursor",
+                ClientCommand::Sync {
+                    cursor: Some("40".into()),
+                    limit: 100,
+                },
+            ),
+            101,
+        )
+        .expect("fallback full sync");
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0].event, ServerEvent::SyncBatch { .. }));
+    assert_eq!(events[0].cursor.as_deref(), Some("41"));
+    remove_db(&path);
+}

--- a/native/mahayana-messaging/tests/delta_sync_contract.rs
+++ b/native/mahayana-messaging/tests/delta_sync_contract.rs
@@ -216,7 +216,11 @@ fn recipient_sync_marks_direct_message_delivered_and_mark_read_moves_it_to_read(
     setup_direct_conversation(&mut service);
     let sent = service
         .handle(
-            envelope("human:alice", "send:delivery", send_text("client:delivery", "hello bob")),
+            envelope(
+                "human:alice",
+                "send:delivery",
+                send_text("client:delivery", "hello bob"),
+            ),
             20,
         )
         .expect("send message");
@@ -254,10 +258,9 @@ fn recipient_sync_marks_direct_message_delivered_and_mark_read_moves_it_to_read(
             22,
         )
         .expect("mark read");
-    assert!(read_events.iter().any(|event| matches!(
-        event.event,
-        ServerEvent::ReadChanged { .. }
-    )));
+    assert!(read_events
+        .iter()
+        .any(|event| matches!(&event.event, ServerEvent::ReadChanged { .. })));
     assert_eq!(
         service.engine().state().messages[&ConversationId::new("chat:direct")][&message_id]
             .delivery_state,
@@ -304,7 +307,11 @@ fn durable_delta_sync_survives_restart_and_is_audience_scoped() {
 
     let sent = service
         .handle(
-            envelope("human:alice", "send:delta", send_text("client:delta", "after baseline")),
+            envelope(
+                "human:alice",
+                "send:delta",
+                send_text("client:delta", "after baseline"),
+            ),
             22,
         )
         .expect("send delta message");
@@ -365,9 +372,10 @@ fn cursor_older_than_migrated_journal_floor_falls_back_to_scoped_full_sync() {
     let path = temporary_db("floor-fallback");
     let mut legacy = SqliteStateStore::new(&path);
     let mut state = MessagingState::default();
-    state
-        .actors
-        .insert(ActorId::new("human:alice"), Actor::human("human:alice", "Alice"));
+    state.actors.insert(
+        ActorId::new("human:alice"),
+        Actor::human("human:alice", "Alice"),
+    );
     legacy
         .save(&MessagingSnapshot::new(state, 41, 100))
         .expect("seed snapshot without journal");
@@ -389,7 +397,7 @@ fn cursor_older_than_migrated_journal_floor_falls_back_to_scoped_full_sync() {
         )
         .expect("fallback full sync");
     assert_eq!(events.len(), 1);
-    assert!(matches!(events[0].event, ServerEvent::SyncBatch { .. }));
+    assert!(matches!(&events[0].event, ServerEvent::SyncBatch { .. }));
     assert_eq!(events[0].cursor.as_deref(), Some("41"));
     remove_db(&path);
 }

--- a/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-001-durable-delta-sync.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-001-durable-delta-sync.md
@@ -1,0 +1,56 @@
+# M2-SYNC-001 — Durable sequence, idempotent send/ACK, and delta sync
+
+- Project: `FABUSHI-TELEGRAM-FUSION`
+- Execution task: `M2-SYNC-001`
+- WBS coverage: `M2.T05 reconnect`, `M2.T06 message send/ack`, `M2.T07 server sequence`, `M2.T08 delta sync`, `M2.T09 delivery/read state`
+- Stage: `M2 自建实时网络 + 1:1 文本消息`
+- Status: `IN_PROGRESS`
+- Started: `2026-08-22`
+- Updated: `2026-08-22`
+- Depends on: `M2-NET-001`, M1 production SQLite
+
+## Objective
+
+Turn the existing snapshot-based recovery into a real durable incremental-sync protocol. A repeated send using the same `client_message_id` must be idempotent, accepted messages must receive a server ACK/sequence, and reconnecting devices must consume only authorized events after their cursor when durable history is available, with a safe full-sync fallback when it is not.
+
+## Security boundary
+
+The durable journal must never become a global unfiltered event feed. Delta events must be filtered using the same actor/conversation visibility rules as full sync. If completeness or visibility cannot be proven for a requested cursor, the server falls back to the existing scoped full `SyncBatch`.
+
+## Scope
+
+- durable SQLite event journal with schema migration from existing SQLite v1;
+- monotonically increasing server cursor persisted with state and journal writes;
+- idempotent `SendMessage` keyed by deterministic local/server message identity derived from `client_message_id`;
+- automatic server ACK moves accepted message from Pending to Sent without client-side duplicate creation;
+- `Sync.cursor` honored: delta when journal coverage is sufficient, empty delta when already current, scoped full-sync fallback when history is incomplete;
+- conversation/actor visibility filtering for journal replay;
+- reconnect and second-device contract tests;
+- read-state propagation verification for the 1:1 acceptance path;
+- current Messaging Product Gate and Mahayana fast checks.
+
+## Acceptance criteria
+
+1. Retrying the same `client_message_id` does not create a second message and does not fail as a duplicate request.
+2. A successful send produces a stable accepted message identity and `Sent` state.
+3. Server cursor is monotonic across restart because snapshot and event journal are persisted transactionally.
+4. A client reconnecting with a covered cursor receives only later visible events.
+5. A client with a cursor older than retained/known journal coverage receives a scoped full sync instead of incomplete deltas.
+6. A second device for the same actor can resume from its own cursor and observe the same conversation state.
+7. An actor outside a conversation cannot receive its delta events.
+8. Mark-read remains scoped to authorized participants and is observable after sync.
+9. Rust fmt/test/clippy plus Host/desktop contracts remain green.
+
+## Branch / PR
+
+- Branch: `feat/telegram-m2-durable-delta-sync`
+- Base: `feat/telegram-m2-websocket-gateway` while dependency PRs land in order.
+- PR: pending
+
+## Evidence
+
+Pending implementation and GitHub Actions.
+
+## Next action
+
+Implement a bounded, visibility-aware SQLite journal and idempotent server ACK path, then add reconnect/multi-device integration tests.


### PR DESCRIPTION
## Objective
Implement the remaining M2 realtime semantics after the self-hosted WebSocket gateway without introducing a second messaging engine.

## WBS
- M2.T05 reconnect
- M2.T06 message send/ack
- M2.T07 server sequence
- M2.T08 delta sync
- M2.T09 delivery/read state
- execution task: `M2-SYNC-001`

## Changes
- upgrade messaging SQLite schema v1 -> v2 with a durable event journal and conservative `journal_floor_cursor`
- persist snapshot + audience-scoped journal entries transactionally
- retain complete cursor groups during journal pagination/pruning
- deterministic server message IDs derived from sender + `client_message_id`
- repeated identical sends return the same accepted message without advancing cursor or creating duplicates
- conflicting reuse of a client message ID is rejected explicitly
- successful sends automatically enter the existing engine ACK path and become `Sent`
- direct/secret recipient sync promotes `Sent -> Delivered`; MarkRead promotes recipient-visible message to `Read`
- honor `Sync.cursor` with authorized delta replay and checkpoint cursor
- fall back to scoped full SyncBatch when requested history predates known journal coverage or coverage is incomplete
- preserve event journal across snapshot-only persistence paths
- add restart, second-device, outsider-isolation, idempotency, delivery/read, migration-floor contract tests

## Security
Journal entries carry their allowed Actor audience at mutation time. Delta replay filters by audience; it is never a global event feed. Incomplete history falls back to the existing scoped full sync.

## Verification
GitHub Messaging Product Gate and Mahayana fast checks are required. No local build/test is used for acceptance.

## Status
`IMPLEMENTED`, pending CI. This PR is stacked on #1993 while #1990 -> #1993 land in dependency order.