### PR TITLE
docs(project): create DeepSeek Harness Rust fusion project folder

### DIFF
--- a/projects/deepseek-harness-rust-fusion/OWNERS.md
+++ b/projects/deepseek-harness-rust-fusion/OWNERS.md
@@ -1,0 +1,11 @@
+# Owners
+
+| Role | Owner | Responsibility |
+|---|---|---|
+| Accountable | Fabushi project owner | Product direction, scope and acceptance |
+| Execution | Fabushi engineering / agent | Rust implementation, tests and durable records |
+| Architecture | Mahayana sovereign-runtime maintainers | Product-owned contract and dependency boundaries |
+| Review | Required GitHub reviewers / CI gates | Quality, security, compatibility and merge acceptance |
+| Consulted | DeepSeek Harness public source/docs | Capability and behavior reference only |
+
+Escalation: unresolved security, license/provenance, product-boundary or destructive migration decisions remain open in `management/08-问题与行动项.md` and must not be bypassed.

--- a/projects/deepseek-harness-rust-fusion/PROJECT.yaml
+++ b/projects/deepseek-harness-rust-fusion/PROJECT.yaml
@@ -1,0 +1,20 @@
+project_id: DHRF
+name: DeepSeek Harness Rust Fusion
+slug: deepseek-harness-rust-fusion
+status: active
+repository: bhrumom/fabushi
+authoritative_branch: main
+authoritative_path: projects/deepseek-harness-rust-fusion
+owner: Fabushi engineering
+reviewers: []
+current_stage: M0-source-audit-and-gap-baseline
+created_at: 2026-08-22
+updated_at: 2026-08-22
+risk_tier: tier-1
+security_classification: public
+target_finish: null
+related_projects:
+  - mahayana-sovereign-runtime
+source_systems:
+  - GitHub:bhrumom/fabushi
+  - GitHub:deepseek-ai/deepseek-harness@b150a551b8d465e31e418e1b2eaf5e79bbb7d28e

--- a/projects/deepseek-harness-rust-fusion/README.md
+++ b/projects/deepseek-harness-rust-fusion/README.md
@@ -1,0 +1,39 @@
+# DeepSeek Harness Rust Fusion
+
+## Objective
+Use the public `deepseek-ai/deepseek-harness` project as a capability and behavior reference, then converge its valuable agent-harness functionality into Fabushi's existing Mahayana Rust runtime without embedding Node.js, Cordis, Python, or a second product runtime.
+
+This is a related workstream of `projects/mahayana-sovereign-runtime/`, focused specifically on DeepSeek Harness capability parity and productization.
+
+## Current verified state
+- Upstream baseline reviewed for project intake: `deepseek-ai/deepseek-harness` `0.1.1-rc.2`, commit `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e` (2026-08-21).
+- Upstream identifies itself as MIT licensed and developer preview with compatibility-breaking changes expected.
+- Fabushi already contains Rust-native `mahayana-harness`, `mahayana-harness-services`, `mahayana-harness-advanced`, `mahayana-harness-adapters`, `mahayana-harness-agent`, and `mahayana-harness-protocol` crates.
+- `mahayana-fast-checks.yml` already tests those Harness crates in GitHub Actions.
+- Existing `mahayana-harness/README.md` contains a broad DeepSeek Harness capability map with both implemented and pending areas. This project must close and prove those gaps rather than create a duplicate runtime.
+
+## Current stage
+`M0 — source audit and gap baseline`
+
+Next gate: inventory the pinned upstream capability surface and reconcile it against the existing Mahayana Harness crates, producing a requirement-to-code-to-test gap matrix.
+
+## In scope
+Rust-native parity for the pinned upstream capability surface: composable services/plugins, profiles/bundles/overlays, session/event model, agent loop, tools/policy, model adapters/streaming, persistence/query, shell/PTY/filesystem/LSP/code runtime, sandbox, MCP/web/attachments, subagents/teams/jobs/goals/workflows, settings/credentials/identity, SDK/JSON ABI/ACP/headless, scheduling/feedback, and cross-surface product integration where relevant.
+
+## Non-goals
+- Vendoring the TypeScript application as Fabushi's runtime.
+- Adding Node.js/Cordis as a required Mahayana product dependency.
+- Replacing Mahayana-owned public protocol, IDs, policy, conversation model, or lifecycle with DeepSeek product contracts.
+- Claiming parity against a moving `master`; acceptance is pinned to the recorded revision until a new audit round deliberately advances it.
+
+## Primary acceptance definition
+The project is complete only when every required capability at the pinned upstream baseline is classified, mapped to a Mahayana-owned Rust contract, implemented or explicitly rejected with rationale, objectively verified in GitHub Actions, exposed through the canonical Mahayana Host/FeatureHost surfaces where applicable, and license/provenance/security gates pass.
+
+## Navigation
+- Source intake and pinned upstream: `source/`
+- Product/engineering specs: `docs/`
+- Capability baseline: `docs/08-DeepSeek-Harness能力映射.md`
+- Roadmap/WBS/status: `management/`
+- ADRs: `decisions/`
+- Evidence indexes: `evidence/`
+- Operational procedures: `runbooks/`

--- a/projects/deepseek-harness-rust-fusion/SOURCE_OF_TRUTH.md
+++ b/projects/deepseek-harness-rust-fusion/SOURCE_OF_TRUTH.md
@@ -1,0 +1,37 @@
+# Source of Truth
+
+## Authoritative engineering state
+1. `bhrumom/fabushi` GitHub `main` for implementation facts.
+2. `projects/deepseek-harness-rust-fusion/` for this workstream's durable requirements, WBS, ADRs, acceptance and evidence indexes.
+3. Accepted ADRs/current specifications in this project.
+4. Live GitHub PR/CI/release facts.
+5. The related `projects/mahayana-sovereign-runtime/` project for product-wide sovereign-runtime boundaries.
+6. Upstream DeepSeek Harness source at the explicitly pinned revision for behavioral reference.
+7. Chat/external mirrors only as intake unless persisted here.
+
+## Original requirement
+On 2026-08-22 the user requested that `https://github.com/deepseek-ai/deepseek-harness` be fused into Fabushi using Rust, and requested a project folder for that plan.
+
+## Pinned upstream baseline
+- Repository: `deepseek-ai/deepseek-harness`
+- Branch observed: `master`
+- Version observed: `0.1.1-rc.2`
+- Commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+- Commit date: 2026-08-21
+- License: MIT for the upstream first-party project; third-party notices still require separate audit.
+- Upstream status: developer preview; compatibility-breaking changes are explicitly expected.
+
+## Existing Fabushi implementation baseline
+- `third_party/mahayana/mahayana-rs/mahayana-harness*`
+- `third_party/mahayana/mahayana-rs/mahayana-feature-host`
+- `third_party/mahayana/mahayana-rs/mahayana-host*`
+- `third_party/mahayana/mahayana-rs/mahayana-tool-host`
+- `third_party/mahayana/mahayana-rs/mahayana-plugin-runtime`
+- `.github/workflows/mahayana-fast-checks.yml`
+- `docs/mahayana-sovereign-kernel.md`
+
+## Conflict rule
+Live code/CI facts override stale project claims about implementation state. The latest persisted user requirement controls scope. Upstream behavior is a reference, not Fabushi's public ABI. Discrepancies are appended to status/changelog rather than silently rewritten.
+
+## Revision advancement rule
+Do not silently change the acceptance baseline from `b150a551...`. A later upstream sync requires a dated source update, new gap audit, changelog entry and explicit task/evidence round.

--- a/projects/deepseek-harness-rust-fusion/decisions/ADR-0001-rust-native-harness-boundary.md
+++ b/projects/deepseek-harness-rust-fusion/decisions/ADR-0001-rust-native-harness-boundary.md
@@ -1,0 +1,21 @@
+# ADR-0001 — Rust-native Harness boundary
+
+Status: Accepted
+Date: 2026-08-22
+Decision owners: Fabushi project owner / engineering
+
+## Context
+DeepSeek Harness is a rapidly evolving TypeScript/Node product built around Cordis and an everything-is-a-plugin architecture. Fabushi already has a Rust-native Mahayana runtime and dedicated Harness crates. Embedding the upstream runtime would create a second lifecycle/config/plugin system and weaken Mahayana product ownership.
+
+## Decision
+Use DeepSeek Harness's public behavior, architecture and MIT-licensed source as a reference for capability parity, but implement/bridge required functionality through the existing Rust-native Mahayana Harness and product-owned interfaces. Node.js, Cordis and upstream product types are not required default-runtime dependencies.
+
+Equivalent existing Fabushi capabilities must be adapted into Harness service/provider seams rather than duplicated. Public desktop/mobile/Web/CLI integrations go through Mahayana Host/FeatureHost contracts.
+
+## Alternatives considered
+1. Vendor and run the TypeScript/Cordis application inside Fabushi — rejected: duplicate runtime, larger attack/supply-chain surface and product coupling.
+2. Mechanical TypeScript-to-Rust translation package-by-package — rejected: preserves implementation structure rather than product contracts and duplicates existing Mahayana capabilities.
+3. Ignore upstream behavior and only borrow ideas — rejected: cannot objectively claim full requested fusion/parity.
+
+## Consequences
+Requires capability inventory and scenario-level conformance tests, but preserves one Rust runtime, cross-platform capability truth and replaceable providers. Upstream revisions are consumed deliberately through new audit rounds rather than silently controlling Fabushi releases.

--- a/projects/deepseek-harness-rust-fusion/decisions/README.md
+++ b/projects/deepseek-harness-rust-fusion/decisions/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+- `ADR-0001-rust-native-harness-boundary.md` — DeepSeek Harness is a behavior/capability reference; Mahayana remains the Rust-owned product/runtime boundary.
+
+Future ADRs are required for expensive-to-reverse persistence, plugin trust, sandbox, identity/credential, protocol or default-provider decisions.

--- a/projects/deepseek-harness-rust-fusion/docs/00-项目章程.md
+++ b/projects/deepseek-harness-rust-fusion/docs/00-项目章程.md
@@ -1,0 +1,26 @@
+# 00 项目章程
+
+## Problem
+Fabushi already has a Rust-native Mahayana Harness foundation, but its own capability map identifies many DeepSeek Harness-inspired areas as pending or partially bridged. Without a governed parity project, the implementation can drift, duplicate existing crates, or expose upstream concepts inconsistently across product surfaces.
+
+## Objective
+Complete and productize the useful DeepSeek Harness capability surface in Rust behind Mahayana-owned contracts, using the existing `mahayana-harness*` crates as the convergence point.
+
+## Users/stakeholders
+Fabushi desktop/mobile/Web/CLI users; Mahayana runtime/plugin/tool authors; product/engineering maintainers.
+
+## Value
+A composable, replayable, policy-gated, extensible agent runtime that remains one Rust-owned Fabushi runtime across devices and can evolve independently of upstream JavaScript/Cordis releases.
+
+## Constraints
+- Electron is the canonical desktop architecture; iOS/Android are native.
+- No local heavy builds/tests; GitHub Actions is authoritative for Rust/application verification.
+- New public product contracts remain Mahayana-owned and vendor-neutral.
+- Existing working Harness crates are extended/reconciled, not duplicated.
+- License/provenance obligations are preserved.
+
+## High-level deliverables
+Pinned capability inventory; gap matrix; Rust implementations/adapters; host/UI integration; conformance/security/performance suites; migration/rollback records; release evidence.
+
+## Success
+Every required pinned-baseline capability has an explicit disposition and objective evidence; default product paths do not require DeepSeek's Node/Cordis runtime; cross-surface behavior remains governed by Mahayana contracts.

--- a/projects/deepseek-harness-rust-fusion/docs/01-范围与非目标.md
+++ b/projects/deepseek-harness-rust-fusion/docs/01-范围与非目标.md
@@ -1,0 +1,20 @@
+# 01 范围与非目标
+
+## In scope
+- Full audit of DeepSeek Harness `b150a551...` packages, docs, config/catalogs, tools, events, persistence and user surfaces.
+- Reconciliation with existing `mahayana-harness*` implementation.
+- Rust-native services/plugins/profiles/session/agent/tool/model/policy/workflow/persistence/provider seams.
+- Shell, subprocess, PTY, filesystem, LSP, code runtime, sandbox, MCP/web/content/attachment bridges where supported by Fabushi policy.
+- Subagents, teams, goals, jobs, workflows, schedule, settings, credentials, identity and feedback semantics where product-relevant.
+- Canonical Mahayana Host/FeatureHost ABI and Electron/iOS/Android/Web/CLI/headless/ACP integration where capabilities are supported.
+- Conformance, security, performance and upgrade-drift evidence.
+
+## Out of scope
+- Embedding DeepSeek Harness's TypeScript application as the canonical runtime.
+- Making Cordis or Node.js mandatory in Mahayana.
+- Replacing Fabushi conversations, product auth, MiniApps, messaging, capability router or host protocol with upstream product contracts.
+- Blind source translation when an existing Mahayana capability already provides equivalent or stronger behavior.
+- Claiming compatibility with future upstream commits without a new audit.
+
+## Deferred, not rejected
+Capabilities that require platform-specific work may be capability-gated on mobile/Web until their owning task passes. Optional remote/E2B providers may remain non-default if local-first policy is preserved and the provider abstraction is complete.

--- a/projects/deepseek-harness-rust-fusion/docs/02-需求与成功指标.md
+++ b/projects/deepseek-harness-rust-fusion/docs/02-需求与成功指标.md
@@ -1,0 +1,18 @@
+# 02 需求与成功指标
+
+| ID | Requirement | Success metric |
+|---|---|---|
+| DHRF-R01 | Pinned upstream surface is completely inventoried | every package/tool/event/config/persistence/user-surface category has a disposition in the matrix |
+| DHRF-R02 | One Rust-owned runtime | no Node.js, Python or Cordis runtime required by the default Mahayana Harness path |
+| DHRF-R03 | Product contracts remain Mahayana-owned | source-boundary/architecture audit finds no DeepSeek product ABI exposed as canonical Fabushi ABI |
+| DHRF-R04 | Composable service/plugin/profile semantics | mount/unmount, scope, overlay and provider replacement tests pass |
+| DHRF-R05 | Replayable model-visible session state | session log, transcript, fork/resume/persistence/query and model-history invariants pass |
+| DHRF-R06 | Policy-gated tools/runtime capabilities | approval, interception, sandbox, filesystem/process/network/tool security tests fail closed |
+| DHRF-R07 | Agent/workflow parity | lifecycle, cancellation/recovery, subagents/teams/jobs/goals/workflows/schedule scenarios pass |
+| DHRF-R08 | Provider-neutral model/extension stack | LLM streaming, settings/credentials, MCP/plugins/skills and supported providers work behind Mahayana seams |
+| DHRF-R09 | Canonical host and cross-surface integration | relevant Electron/iOS/Android/Web/CLI/headless/ACP contract/E2E gates pass |
+| DHRF-R10 | Objective parity against pinned baseline | every required matrix row is passed, rejected-with-rationale, or explicitly capability-gated with acceptance approval |
+| DHRF-R11 | License/provenance/supply-chain compliance | MIT notices and third-party obligations are recorded; no hidden vendored runtime/source provenance |
+| DHRF-R12 | Performance/reliability are production-safe | agreed budgets for event log, tool dispatch, streaming, persistence and long-running workflows pass in CI |
+
+No percentage-based completion is authoritative; completion is required-task and acceptance-evidence based.

--- a/projects/deepseek-harness-rust-fusion/docs/03-架构与实现策略.md
+++ b/projects/deepseek-harness-rust-fusion/docs/03-架构与实现策略.md
@@ -1,0 +1,48 @@
+# 03 架构与实现策略
+
+## Current state
+Fabushi already contains six dedicated `mahayana-harness*` crates plus FeatureHost/Host/ToolHost/PluginRuntime integration points. The existing Harness README reports implemented core registry/session/tool/profile primitives and numerous pending provider/product bridges.
+
+## Target state
+```text
+Electron / iOS / Android / Web / CLI / Headless / ACP
+                         |
+                Mahayana Host Protocol
+                         |
+              FeatureHost / Harness Bridge
+                         |
+       +-----------------+------------------+
+       |                 |                  |
+  Harness Core      Harness Services   Harness Advanced
+  session/events    providers/policy   workflows/teams/jobs
+       |                 |                  |
+       +---------- Mahayana Kernel ---------+
+                         |
+    ToolHost / PluginRuntime / MCP / Model / Workspace
+                         |
+        Local platform providers + optional adapters
+```
+
+## DeepSeek-to-Mahayana translation principles
+1. Translate behavior and capability seams, not JavaScript class structure.
+2. Cordis context/effects become Rust registries, scoped providers, typed event streams and reversible mount guards.
+3. Profiles/bundles/patches become typed Mahayana configuration layers with deterministic precedence and dump/inspection support.
+4. Upstream session/event semantics map to append-only Rust events; anything model-visible must be reconstructable from durable events.
+5. Tool execution always crosses Mahayana policy/approval and platform ToolHost boundaries.
+6. Provider definitions separate interface, implementation and consumer so local/remote backends are replaceable.
+7. Public UI/native code uses Mahayana Host ABI, never direct Harness internals.
+8. Existing equivalent Fabushi functionality is adapted into Harness seams instead of duplicated.
+
+## Migration strategy
+Audit -> classify -> contract -> implement/bridge -> conformance -> surface integration -> default-path switch -> compatibility cleanup. Each capability moves independently behind stable Mahayana contracts.
+
+## Key integration points
+- `mahayana-harness*`: native core and capability crates.
+- `mahayana-feature-host`: product-facing controller/feature aggregation.
+- `mahayana-host-protocol` / `mahayana-host`: canonical command/event ABI.
+- `mahayana-tool-host`: platform capability truth and execution boundary.
+- `mahayana-plugin-runtime`: installed plugin lifecycle.
+- `mahayana-model`, `mahayana-mcp-runtime`, `mahayana-workspace-engine`, `mahayana-orchestrator`: provider and orchestration backends.
+
+## Tradeoff
+Exact implementation structure may differ from upstream as long as scenario-level semantics and project requirements are met. This preserves Rust-native product ownership while still demanding objective behavioral parity.

--- a/projects/deepseek-harness-rust-fusion/docs/04-质量与测试策略.md
+++ b/projects/deepseek-harness-rust-fusion/docs/04-质量与测试策略.md
@@ -1,0 +1,19 @@
+# 04 质量与测试策略
+
+## Test layers
+- Rust unit/state-machine tests for registrations, scopes, overlays, events, turns/steps, cancellation and persistence.
+- Contract tests for service/provider/tool/model/host interfaces.
+- Conformance scenario tests derived from pinned upstream behavior and tests without copying proprietary/non-applicable product assumptions.
+- Security tests for approvals, sandbox, path/process/network boundaries, credentials and model-authored extensions.
+- Persistence/replay tests for append-only events, fork/resume, crash recovery, query and schema migration.
+- Cross-surface contract/E2E tests for affected Electron/native/Web/CLI/headless/ACP flows.
+- Performance/stress tests for event-log growth, stream fanout, tool dispatch, plugin mount churn and long-running jobs/workflows.
+
+## CI
+Heavy verification runs only in GitHub Actions. At minimum maintain/extend `.github/workflows/mahayana-fast-checks.yml` for the Harness crates, then invoke broader desktop/native workflows only when their surfaces change.
+
+## Required evidence
+Each passed WBS item records commit SHA, PR, exact CI run/job/check, test name/result and any security/performance artifact. A code review or local inspection alone cannot mark runtime parity passed.
+
+## Flaky handling
+A flaky conformance test remains blocking until root cause is fixed or the test is replaced by an equally objective deterministic check; do not waive parity by retrying indefinitely.

--- a/projects/deepseek-harness-rust-fusion/docs/05-发布迁移与回滚.md
+++ b/projects/deepseek-harness-rust-fusion/docs/05-发布迁移与回滚.md
@@ -1,0 +1,18 @@
+# 05 发布迁移与回滚
+
+## Rollout
+Migrate capability-by-capability behind stable Mahayana interfaces. Preserve existing working provider paths until the replacement passes conformance and affected surface tests.
+
+Sequence: inventory -> contract -> native implementation/bridge -> conformance -> surface exposure -> feature/default switch -> compatibility cleanup.
+
+## Rollback triggers
+Security regression, event/persistence incompatibility, crash/recovery regression, cross-surface breakage, unacceptable latency/resource growth, or failed required CI/E2E.
+
+## Rollback
+Revert the affected capability provider/default switch while retaining the product-owned interface and durable event compatibility. Do not restore Node/Cordis as the canonical runtime and do not roll back Electron/native product architecture.
+
+## Data migration
+Event/persistence schema changes require versioned readers/migrations and backward-read tests before default rollout. Irreversible migrations require a dedicated ADR and backup/recovery runbook.
+
+## Release validation
+Protected-main merge, post-merge Harness CI, affected product E2E and canonical main inspection are required before a migration/release task is closed.

--- a/projects/deepseek-harness-rust-fusion/docs/06-运维可观测性与SLO.md
+++ b/projects/deepseek-harness-rust-fusion/docs/06-运维可观测性与SLO.md
@@ -1,0 +1,23 @@
+# 06 运维可观测性与 SLO
+
+Runtime project; not N/A.
+
+## Required signals
+- agent/turn/step lifecycle and terminal status;
+- tool call, approval, interception and duration outcomes;
+- plugin/profile mount/unmount/config generation;
+- model stream start/first-token/end/error/cancel;
+- session append/persist/replay/fork/recovery outcomes;
+- job/workflow/subagent state transitions;
+- capability rejection/fallback reason.
+
+## Initial SLO direction
+- No silent loss of durable session events after acknowledged persistence.
+- Every admitted turn/job/workflow reaches an observable terminal or suspended state.
+- Unsupported local capabilities fail explicitly; no silent remote-agent fallback.
+- Tool approvals remain fail-closed on policy errors.
+- Runtime snapshot/config dump is deterministic for the same profile/config inputs.
+
+Concrete latency/throughput/resource budgets are set by DHRF-603 after baseline measurements exist.
+
+Telemetry must avoid secrets, credentials and private prompt/tool payloads by default; use redacted identifiers and aggregate metrics.

--- a/projects/deepseek-harness-rust-fusion/docs/07-安全隐私与合规.md
+++ b/projects/deepseek-harness-rust-fusion/docs/07-安全隐私与合规.md
@@ -1,0 +1,17 @@
+# 07 安全隐私与合规
+
+## Security boundaries
+- Tool execution crosses Mahayana policy/approval and ToolHost capability checks.
+- Filesystem/process/network/sandbox/MCP/computer-control capabilities are explicit grants, not implicit plugin powers.
+- Credentials are referenced through secure product-owned storage; raw secrets never enter project records/session telemetry by default.
+- Plugin mount/unmount and model-authored extension behavior require trust/provenance policy and constrained scopes.
+- Remote providers cannot silently replace the local agent runtime.
+
+## Privacy
+Durable session events may contain user/model/tool data and must follow existing Fabushi data classification, retention and redaction rules. Telemetry uses minimized/redacted metadata unless the user explicitly opts into richer diagnostics.
+
+## License/provenance
+DeepSeek Harness first-party source is MIT at the pinned baseline. If source or substantial portions are reused/translated, preserve required copyright/license notice. Audit `THIRD_PARTY_NOTICES.md` and transitive/ported components before copying implementation. Prefer clean Rust implementations against documented behavior when practical.
+
+## Supply chain
+Pin reviewed upstream references per audit round; record source provenance; run dependency/license/security checks in CI; do not import npm/Cordis runtime dependencies into the default Mahayana path merely for parity.

--- a/projects/deepseek-harness-rust-fusion/docs/08-DeepSeek-Harness能力映射.md
+++ b/projects/deepseek-harness-rust-fusion/docs/08-DeepSeek-Harness能力映射.md
@@ -1,0 +1,39 @@
+# 08 DeepSeek Harness 能力映射
+
+Status: intake baseline; DHRF-101/102 must replace assumptions with package/test-backed evidence.
+
+| Capability domain | Upstream documented behavior | Existing Mahayana landing point | Intake status |
+|---|---|---|---|
+| Composition | everything-as-plugin, scoped/reversible effects | `mahayana-harness`, plugin runtime | partial; parity audit required |
+| Profiles/config | profiles, bundles, patch overlays, config dump | Harness profiles/config | partial; filesystem/overlay parity pending |
+| Session | append-only events, transcript, fork/resume | Harness session log | core present; concrete stores/query/recovery audit required |
+| Prompt/context | sections/tool schemas/model-visible invariant | Harness + agent/model path | partial |
+| Agent loop | inbox, turn/step lifecycle, intercept/cancel/recovery | Harness agent + native agent/orchestrator | partial |
+| Tools | scoped registry, pre/execute/post pipeline | Harness + ToolHost | core present; provider bridges/guards pending |
+| Approval/policy | guarded execution | Harness/FeatureHost/kernel policy | partial; UI/security parity required |
+| LLM | provider-neutral streaming seam | `mahayana-model` + Harness adapters | seam present; adapter parity pending |
+| Persistence/query | stores, replay, session query/FTS | Harness storage seam/product storage | pending/partial |
+| Shell/process/PTY | subprocess, shell, persistent terminal | ToolHost/workspace/native engines | bridge parity pending |
+| Filesystem/LSP/code | capability providers/tools | ToolHost/workspace/JS runtime | bridge parity pending |
+| Sandbox | provider-controlled confinement | kernel/platform policy | unified Harness seam pending |
+| MCP/web | MCP, web search/fetch | MCP runtime/connectors | bridge parity pending |
+| Attachments/spill | normalized content/addressing/offload | app attachments + Harness hash primitive | partial |
+| Skills/plugins | installable/reversible extensions | plugin runtime/FeatureHost | bridge/loader parity pending |
+| Compaction | explicit context compaction | model/runtime backends | explicit Harness service pending |
+| Subagents/teams | continuable subagents, team roster/task/mailbox | Harness agents + FeatureHost groups | partial |
+| Jobs/goals | background jobs and objective state | Harness records/orchestrator | core records present; executors pending |
+| Workflow/hooks | long-running workflows/hooks | Harness advanced/orchestrator | partial |
+| Todo/plan/presets | agent work state and presets | product task/plan + profiles | dedicated parity pending |
+| Guards | repetition/deadline/tool safety guards | interceptors/policy | seam present; defaults pending |
+| Runtime extension | model/runtime extension within policy | plugin runtime | policy/product flow pending |
+| Settings/credentials | configured services and credential refs | product settings/auth | generic Harness seams pending |
+| Workspace | workspace entity/capabilities | workspace engine | integration pending |
+| SDK/JSON ABI | programmatic client/server surface | Mahayana Host protocol | Harness command/event ABI pending |
+| ACP | editor/agent client protocol | existing transports | bridge parity pending |
+| Schedule | scheduled work | Fabushi automations/orchestrator | Harness seam pending |
+| Feedback | feedback/reporting path | product feedback | seam pending |
+| Identity | runtime/user identity | Fabushi product identity | shared seam pending |
+| Remote providers | optional remote/E2B-like providers | provider abstractions | optional; local-first default |
+| UI/headless | Web UI and headless runner | Electron/native/Web/CLI | product wiring pending/partial |
+
+A row becomes `passed` only when DHRF traceability names the Rust implementation and objective CI evidence.

--- a/projects/deepseek-harness-rust-fusion/docs/19-完成定义与验收.md
+++ b/projects/deepseek-harness-rust-fusion/docs/19-完成定义与验收.md
@@ -1,0 +1,17 @@
+# 19 完成定义与验收
+
+Project complete requires objective evidence for all required criteria:
+1. Pinned upstream `b150a551...` capability inventory is complete and reviewable.
+2. Every required capability is mapped to a Mahayana-owned Rust contract and implementation/disposition.
+3. No default Mahayana Harness path requires Node.js, Python or Cordis.
+4. Service/plugin/profile/scoping semantics pass reversible-composition tests.
+5. Model-visible state is fully reconstructable from durable session events; persistence/fork/resume/recovery/query gates pass.
+6. Agent turn/step/tool/cancel/recovery semantics and workflow/subagent/job behaviors pass conformance scenarios.
+7. Tool, approval, sandbox, filesystem/process/network/MCP/credential/plugin security gates pass fail-closed tests.
+8. Model/provider/settings/extension capabilities are exposed through provider-neutral Mahayana seams.
+9. Canonical Host/FeatureHost ABI and all affected Electron/iOS/Android/Web/CLI/headless/ACP paths pass required contract/E2E gates.
+10. License/provenance/third-party notices and dependency security checks pass.
+11. Defined performance/reliability budgets pass.
+12. Migration/rollback/runbook material is current, protected-main merge is complete and post-merge canonical state is verified.
+
+`implemented` is not the same as `accepted`; a matrix row is accepted only with its required evidence.

--- a/projects/deepseek-harness-rust-fusion/evidence/DHRF-001/README.md
+++ b/projects/deepseek-harness-rust-fusion/evidence/DHRF-001/README.md
@@ -1,0 +1,19 @@
+# DHRF-001 Evidence
+
+## Source evidence reviewed
+- DeepSeek Harness README: project identity, developer-preview warning and MIT license pointer.
+- DeepSeek Harness architecture docs: Cordis plugin composition, profiles/bundles, core packages, event/turn/session model and capability seams.
+- DeepSeek Harness root package: version `0.1.1-rc.2` and Node/pnpm workspace baseline.
+- DeepSeek Harness LICENSE: MIT.
+- Upstream latest reviewed merge commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`.
+
+## Fabushi evidence reviewed
+- Root `AGENTS.md` project-first governance.
+- Fabushi project-governance skill and project-folder/task lifecycle standards.
+- `docs/mahayana-sovereign-kernel.md`.
+- `third_party/mahayana/mahayana-rs/Cargo.toml`, showing dedicated `mahayana-harness*` workspace members.
+- `third_party/mahayana/mahayana-rs/mahayana-harness/README.md`, showing current implemented/pending capability mapping.
+- `.github/workflows/mahayana-fast-checks.yml`, showing Rust Harness CI coverage.
+
+## GitHub write/merge evidence
+Pending until this project folder is committed, PR-created, merged and verified on `main`.

--- a/projects/deepseek-harness-rust-fusion/evidence/README.md
+++ b/projects/deepseek-harness-rust-fusion/evidence/README.md
@@ -1,0 +1,8 @@
+# Evidence index
+
+Evidence is task-scoped under `evidence/<task-id>/` and should link durable GitHub facts rather than copy large artifacts.
+
+Required evidence types as applicable: commit SHA, PR/review, Actions run/job/check, test/conformance report, security/license report, benchmark/stress artifact, release and post-merge canonical verification.
+
+Current index:
+- `DHRF-001/README.md` — project establishment evidence.

--- a/projects/deepseek-harness-rust-fusion/management/00-路线图.md
+++ b/projects/deepseek-harness-rust-fusion/management/00-路线图.md
@@ -1,0 +1,36 @@
+# 00 路线图
+
+## M0 — Source audit and gap baseline
+Pin upstream, inventory the complete capability surface, audit existing Mahayana Harness crates, and produce a source/code/test gap matrix.
+
+Exit gate: DHRF-101/102/103 passed; every required capability has a disposition and owning task.
+
+## M1 — Core composition/session parity
+Close service/plugin scope, profiles/config overlays, session persistence/query/replay, prompt/model-visible invariants and compaction.
+
+Exit gate: DHRF-201..204 passed.
+
+## M2 — Tool/runtime/security capability parity
+Close tool pipeline, filesystem/process/PTY/LSP/code providers, sandbox/policy, MCP/web/attachment/spill bridges.
+
+Exit gate: DHRF-301..304 passed with security evidence.
+
+## M3 — Agent/workflow/long-running parity
+Close agent lifecycle/cancellation/recovery, subagents/teams/jobs/goals/todo/plan/presets, workflows/hooks/schedule and guard policies.
+
+Exit gate: DHRF-401..404 passed.
+
+## M4 — Provider/protocol/product surfaces
+Close LLM/settings/credentials/identity, Host ABI/SDK/ACP/headless, cross-surface UI integration, skills/plugin loaders.
+
+Exit gate: DHRF-501..504 passed.
+
+## M5 — Conformance, security and performance
+Run pinned upstream scenario corpus, supply-chain/security audit and defined performance/reliability/stress gates.
+
+Exit gate: DHRF-601..603 passed with evidence.
+
+## M6 — Default-path convergence and release
+Switch accepted native paths to default, remove obsolete compatibility/duplicate paths, validate release/E2E and canonical main.
+
+Exit gate: DHRF-701..703 passed; project DoD satisfied.

--- a/projects/deepseek-harness-rust-fusion/management/01-WBS原子任务.md
+++ b/projects/deepseek-harness-rust-fusion/management/01-WBS原子任务.md
@@ -1,0 +1,32 @@
+# 01 WBS 原子任务
+
+Statuses: `planned`, `in-progress`, `blocked`, `passed`, `failed`.
+
+| ID | Action / deliverable | Dependency | Acceptance | Verification | Status | Next action |
+|---|---|---|---|---|---|---|
+| DHRF-001 | Establish governed project folder and pinned intake | none | standard scaffold, source pin, roadmap/WBS/acceptance/ADR/evidence exist on main | repository audit | in-progress | merge project folder |
+| DHRF-101 | Inventory upstream packages/tools/events/config/persistence/user surfaces at pin | DHRF-001 | no unclassified required capability | source/package/test inventory review | planned | inspect pinned tree |
+| DHRF-102 | Audit existing `mahayana-harness*` and integration code | DHRF-101 | every upstream row mapped to code/test/gap | code + CI evidence audit | planned | inspect all Harness crates |
+| DHRF-103 | Freeze parity/gap matrix and task ownership | DHRF-102 | every required gap owns a task or explicit rejection | traceability review | planned | normalize matrix |
+| DHRF-201 | Close service/plugin scoped and reversible composition parity | DHRF-103 | mount/unmount/scope/provider replacement semantics pass | Rust tests | planned | design/implement |
+| DHRF-202 | Close profiles/bundles/patch overlay/config inspection parity | DHRF-103 | deterministic precedence/load/dump tests pass | Rust tests | planned | implement loaders |
+| DHRF-203 | Close session persistence/replay/fork/resume/query/FTS/recovery | DHRF-103 | durable state and crash/replay scenarios pass | Rust integration tests | planned | select store strategy |
+| DHRF-204 | Close prompt sections/model-visible invariant/compaction | DHRF-103 | all model-visible inputs reconstructable; compaction deterministic | property/conformance tests | planned | implement service |
+| DHRF-301 | Close tool pipeline/interceptors/approvals/default guards | DHRF-103 | pre/execute/post and fail-closed approval scenarios pass | security/conformance tests | planned | bridge ToolHost |
+| DHRF-302 | Register fs/subprocess/shell/PTY/LSP/code runtime providers | DHRF-301 | supported capabilities work through one provider seam | integration tests | planned | map providers |
+| DHRF-303 | Unify sandbox/capability policy | DHRF-301 | filesystem/process/network/sandbox denial/allow scenarios pass | security tests | planned | design policy seam |
+| DHRF-304 | Bridge MCP/web search/fetch/attachments/spill | DHRF-301 | supported providers and content lifecycle pass | integration tests | planned | map existing services |
+| DHRF-401 | Close agent loop/inbox/turn/step/cancel/recovery semantics | DHRF-203,DHRF-301 | lifecycle conformance scenarios pass | state-machine tests | planned | implement gaps |
+| DHRF-402 | Close subagents/teams/goals/jobs/todo/plan/presets | DHRF-401 | persistence/resume/coordination scenarios pass | integration tests | planned | implement gaps |
+| DHRF-403 | Close workflows/hooks/schedule/background execution | DHRF-401 | pause/resume/cancel/restart scenarios pass | orchestrator tests | planned | bridge executor |
+| DHRF-404 | Add repetition/deadline/loop/self-extension guards | DHRF-301,DHRF-401 | unsafe/unbounded scenarios terminate or require policy | security/stress tests | planned | define defaults |
+| DHRF-501 | Close LLM streaming/settings/credentials/identity seams | DHRF-103 | provider replacement/stream/cancel/credential-reference tests pass | model/security tests | planned | bridge model/product |
+| DHRF-502 | Expose canonical Harness Host ABI, SDK, ACP and headless commands/events | DHRF-401,DHRF-501 | protocol contract tests pass | Host/ACP tests | planned | extend protocol |
+| DHRF-503 | Wire supported Electron/iOS/Android/Web/CLI surfaces | DHRF-502 | capability negotiation and affected E2E pass | GitHub Actions E2E | planned | surface integration |
+| DHRF-504 | Bridge skills/plugins/artifacts/preset loaders | DHRF-201,DHRF-202 | installed extension lifecycle passes | plugin integration tests | planned | bridge runtime |
+| DHRF-601 | Build pinned upstream scenario conformance corpus | DHRF-201..DHRF-504 | all required matrix rows have objective scenario evidence | CI conformance suite | planned | derive scenarios |
+| DHRF-602 | Complete security/license/provenance/supply-chain gate | DHRF-601 | no unresolved critical findings; notices complete | security/license CI | planned | audit |
+| DHRF-603 | Define and pass performance/reliability/stress budgets | DHRF-601 | agreed budgets pass | benchmark/stress CI | planned | baseline then gate |
+| DHRF-701 | Switch accepted Rust-native Harness path to product defaults | DHRF-601,DHRF-602,DHRF-603 | default paths use accepted native providers | integration/E2E | planned | staged switch |
+| DHRF-702 | Remove duplicate/obsolete compatibility paths and finalize notices | DHRF-701 | no required behavior depends on obsolete path | dependency/source audit | planned | cleanup |
+| DHRF-703 | Release, post-merge verification and project closure | DHRF-702 | all DoD gates/evidence pass on canonical main | release/E2E/main audit | planned | close project |

--- a/projects/deepseek-harness-rust-fusion/management/02-里程碑.md
+++ b/projects/deepseek-harness-rust-fusion/management/02-里程碑.md
@@ -1,0 +1,13 @@
+# 02 里程碑
+
+| Milestone | Target | Required tasks | Planned date | Actual date | Status | Evidence |
+|---|---|---|---|---|---|---|
+| M0 | Complete source/gap baseline | DHRF-101..103 | TBD | - | planned | - |
+| M1 | Core composition/session parity | DHRF-201..204 | TBD | - | planned | - |
+| M2 | Tool/runtime/security parity | DHRF-301..304 | TBD | - | planned | - |
+| M3 | Agent/workflow parity | DHRF-401..404 | TBD | - | planned | - |
+| M4 | Provider/protocol/surface parity | DHRF-501..504 | TBD | - | planned | - |
+| M5 | Conformance/security/performance acceptance | DHRF-601..603 | TBD | - | planned | - |
+| M6 | Default convergence/release | DHRF-701..703 | TBD | - | planned | - |
+
+Dates are not invented; they will be set when an actual delivery schedule is approved.

--- a/projects/deepseek-harness-rust-fusion/management/03-验收追踪矩阵.md
+++ b/projects/deepseek-harness-rust-fusion/management/03-验收追踪矩阵.md
@@ -1,0 +1,18 @@
+# 03 验收追踪矩阵
+
+| Requirement | Primary tasks | Verification | Evidence | Status |
+|---|---|---|---|---|
+| DHRF-R01 | 101,102,103 | source/code/test inventory | `evidence/` | planned |
+| DHRF-R02 | 201..504,702 | dependency/runtime audit | CI + source audit | planned |
+| DHRF-R03 | 102,103,502,702 | public ABI/source-boundary audit | CI + review | planned |
+| DHRF-R04 | 201,202,504 | composition/profile/plugin tests | CI | planned |
+| DHRF-R05 | 203,204,401 | persistence/replay/model-history tests | CI | planned |
+| DHRF-R06 | 301..304,404,602 | fail-closed security tests | CI/security report | planned |
+| DHRF-R07 | 401..404,601 | lifecycle/workflow conformance | CI | planned |
+| DHRF-R08 | 501,504,601 | provider/extension contract tests | CI | planned |
+| DHRF-R09 | 502,503,701,703 | Host contract + surface E2E | Actions/release | planned |
+| DHRF-R10 | 103,601 | full capability matrix review | conformance index | planned |
+| DHRF-R11 | 101,602,702 | license/provenance/dependency audit | report/notices | planned |
+| DHRF-R12 | 603,703 | benchmark/stress/reliability gates | CI artifacts | planned |
+
+A status changes to `passed` only when the named evidence exists and is linked.

--- a/projects/deepseek-harness-rust-fusion/management/04-风险登记.md
+++ b/projects/deepseek-harness-rust-fusion/management/04-风险登记.md
@@ -1,0 +1,15 @@
+# 04 风险登记
+
+| ID | Risk | Probability | Impact | Severity | Owner | Mitigation / contingency | Status |
+|---|---|---|---|---|---|---|---|
+| DHRF-RISK-01 | Upstream developer-preview breaking changes cause scope drift | high | medium | high | project | pin baseline; advance only by explicit audit round | open |
+| DHRF-RISK-02 | Reimplementing Cordis semantics incorrectly breaks plugin lifecycle/scoping | medium | high | high | runtime | scenario/property tests for reversible effects/scopes | open |
+| DHRF-RISK-03 | Tool/sandbox/approval parity introduces security regression | medium | critical | critical | security/runtime | fail-closed policy, dedicated security gates, staged rollout | open |
+| DHRF-RISK-04 | Duplicate implementation diverges from existing `mahayana-harness*` | medium | high | high | architecture | mandatory DHRF-102 audit; extend existing crates only | open |
+| DHRF-RISK-05 | MIT/third-party provenance obligations are missed during porting | low-medium | high | high | project/security | source pin, notices audit, prefer clean Rust behavior implementation | open |
+| DHRF-RISK-06 | Desktop capabilities cannot safely exist on mobile/Web | high | medium | high | platform | explicit capability negotiation; no silent proxy | open |
+| DHRF-RISK-07 | Event/persistence schema changes break old sessions | medium | high | high | runtime | versioned migration/backward-read/recovery tests | open |
+| DHRF-RISK-08 | Long-running/team/workflow features cause runaway resource usage | medium | high | high | runtime | deadlines/quotas/loop guards/stress budgets | open |
+| DHRF-RISK-09 | Model-authored runtime extensions expand trust boundary | medium | critical | critical | security | signed/provenance policy, explicit grants, constrained scopes | open |
+
+Review risks at each milestone exit and whenever a new upstream revision is proposed.

--- a/projects/deepseek-harness-rust-fusion/management/05-状态报告.md
+++ b/projects/deepseek-harness-rust-fusion/management/05-状态报告.md
@@ -1,0 +1,11 @@
+# 05 状态报告
+
+Append-only.
+
+## 2026-08-22 — Project intake / DHRF-001
+- Stage: M0 source audit and gap baseline.
+- Completed in this round: reviewed Fabushi governance; confirmed no existing dedicated DeepSeek Harness project folder; reviewed upstream README/architecture/license/version; verified existing Mahayana Harness crates and CI baseline; drafted governed project scaffold, pin, roadmap, WBS, acceptance and ADR.
+- Acceptance result: project-folder content prepared; canonical-main merge still required before DHRF-001 can be marked `passed`.
+- Evidence: upstream `b150a551...`; Fabushi `mahayana-harness/README.md`; `mahayana-fast-checks.yml`; repository `AGENTS.md` and project-governance skill.
+- Blocker/risk: protected-main merge/verification pending.
+- Next action: merge the project-folder change, verify on `main`, then begin DHRF-101.

--- a/projects/deepseek-harness-rust-fusion/management/06-依赖与阻塞.md
+++ b/projects/deepseek-harness-rust-fusion/management/06-依赖与阻塞.md
@@ -1,0 +1,12 @@
+# 06 依赖与阻塞
+
+| ID | Dependency | Required state | Blocking relation | Fallback | State |
+|---|---|---|---|---|---|
+| DHRF-DEP-01 | `projects/mahayana-sovereign-runtime` | product-owned runtime boundaries remain authoritative | all implementation | escalate conflicts to ADR/project action | available |
+| DHRF-DEP-02 | `mahayana-harness*` crates | current main audited before changes | DHRF-102 onward | none; do not duplicate | available |
+| DHRF-DEP-03 | FeatureHost/Host protocol | canonical public bridge | DHRF-502/503 | capability-gate until bridge exists | available |
+| DHRF-DEP-04 | ToolHost/plugin runtime/MCP/model/workspace/orchestrator | provider integration boundaries | M2-M4 | staged adapters | available |
+| DHRF-DEP-05 | GitHub Actions | heavy Rust/app verification | all acceptance | no local heavy build/test | available |
+| DHRF-DEP-06 | DeepSeek Harness pinned source | behavior/reference baseline | DHRF-101/601 | retain pin if upstream moves | available |
+
+Current blocker for DHRF-001: project folder must be merged and verified on `main`.

--- a/projects/deepseek-harness-rust-fusion/management/07-变更日志.md
+++ b/projects/deepseek-harness-rust-fusion/management/07-变更日志.md
@@ -1,0 +1,10 @@
+# 07 变更日志
+
+Append-only.
+
+## 2026-08-22
+- Created project `DHRF` for Rust-native DeepSeek Harness capability convergence.
+- Pinned intake baseline to upstream `0.1.1-rc.2` / `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`.
+- Classified this as a related workstream of `mahayana-sovereign-runtime`, not a replacement for its product-wide architecture.
+- Recorded that existing `mahayana-harness*` crates are the mandatory convergence target; duplicate runtime creation is a non-goal.
+- Established seven milestone stages M0-M6 and stable requirement/task IDs.

--- a/projects/deepseek-harness-rust-fusion/management/08-问题与行动项.md
+++ b/projects/deepseek-harness-rust-fusion/management/08-问题与行动项.md
@@ -1,0 +1,9 @@
+# 08 问题与行动项
+
+| ID | Type | Question / action | Owner | Due | Resolution / link | Status |
+|---|---|---|---|---|---|---|
+| DHRF-ACT-001 | action | Complete pinned upstream package/tool/event/config/persistence inventory | engineering | M0 | DHRF-101 | open |
+| DHRF-ACT-002 | action | Audit all existing Mahayana Harness crates before implementing gaps | engineering | M0 | DHRF-102 | open |
+| DHRF-Q-001 | decision | Choose concrete Harness persistence/query strategy after current stores are audited | runtime | M1 | future ADR if expensive to reverse | open |
+| DHRF-Q-002 | decision | Define allowed scope for model-authored runtime extensions/plugins | security/runtime | M3 | future security ADR | open |
+| DHRF-Q-003 | decision | Determine which optional remote provider semantics are product requirements vs supported extension points | product/runtime | M4 | DHRF-103/501 | open |

--- a/projects/deepseek-harness-rust-fusion/management/tasks/DHRF-001-establish-project.md
+++ b/projects/deepseek-harness-rust-fusion/management/tasks/DHRF-001-establish-project.md
@@ -1,0 +1,49 @@
+# DHRF-001 — Establish governed project
+
+- Status: `in-progress`
+- Started: 2026-08-22
+- Updated: 2026-08-22
+- Completed: -
+
+## Objective
+Create the enterprise-standard GitHub project folder that will govern Rust-native DeepSeek Harness convergence into Fabushi.
+
+## Source requirements
+- `source/user-requirement-2026-08-22.md`
+- `source/upstream-baseline.md`
+- Repository `AGENTS.md` and Fabushi project-governance skill.
+
+## In scope
+Project identity/ownership; source pin; scope/requirements/architecture/quality/release/SLO/security/DoD; roadmap/WBS/milestones/acceptance/risks/dependencies/status/changelog/actions; ADR; evidence/runbook indexes.
+
+## Out of scope
+Runtime feature implementation. That begins with DHRF-101 source inventory and subsequent WBS tasks.
+
+## Dependencies
+None beyond GitHub repository access and current `main` governance rules.
+
+## Acceptance criteria
+1. Full mandatory project scaffold exists and is non-empty.
+2. Original requirement and pinned upstream baseline are durable.
+3. Stable Project/Requirement/Task/Milestone IDs exist.
+4. Existing Mahayana Harness code is acknowledged as the convergence baseline.
+5. Architecture boundary and non-goals are explicit.
+6. Project change is merged through GitHub and verified on canonical `main`.
+
+## Verification
+Repository tree inspection and post-merge file fetch from `main`.
+
+## Branch / commit / PR
+To be recorded after GitHub write/PR creation.
+
+## Implementation summary
+Prepared project documentation only; no runtime code changed.
+
+## Evidence
+See `evidence/DHRF-001/README.md`.
+
+## Blockers / risks
+Protected-main merge and canonical verification pending.
+
+## Next action
+Open/merge project documentation PR, verify `main`, then close DHRF-001 and start DHRF-101.

--- a/projects/deepseek-harness-rust-fusion/runbooks/README.md
+++ b/projects/deepseek-harness-rust-fusion/runbooks/README.md
@@ -1,0 +1,16 @@
+# Runbooks
+
+## Capability migration runbook baseline
+For each capability:
+1. Reconstruct current state from this project and live `main`.
+2. Confirm upstream pinned behavior and current Mahayana implementation.
+3. Add/update the product-owned Rust contract before changing providers.
+4. Implement or bridge behind an explicit capability/provider boundary.
+5. Run required unit/contract/conformance/security checks in GitHub Actions.
+6. Integrate only the supported product surfaces; capability-gate unsupported platforms explicitly.
+7. Switch defaults only after acceptance evidence exists.
+8. On regression, revert the provider/default switch while preserving compatible durable state and product-owned ABI.
+9. Update task, WBS, acceptance, status, changelog, risks/dependencies and evidence in the same workstream.
+
+## Upstream revision runbook
+Do not move the DeepSeek Harness acceptance pin silently. Open a new audit task, record the new commit/version/date, diff capability/catalog/test changes, update source/changelog/matrix, then schedule only the new/changed gaps.

--- a/projects/deepseek-harness-rust-fusion/source/README.md
+++ b/projects/deepseek-harness-rust-fusion/source/README.md
@@ -1,0 +1,7 @@
+# Source intake
+
+Authoritative intake records:
+- `user-requirement-2026-08-22.md` — originating request.
+- `upstream-baseline.md` — pinned DeepSeek Harness revision, license/status and architecture facts used for planning.
+
+Do not replace these records with later interpretations. New upstream audit rounds append dated source records and update the project changelog.

--- a/projects/deepseek-harness-rust-fusion/source/upstream-baseline.md
+++ b/projects/deepseek-harness-rust-fusion/source/upstream-baseline.md
@@ -1,0 +1,22 @@
+# Upstream baseline — DeepSeek Harness
+
+Audit date: 2026-08-22
+
+## Pin
+- Repository: `deepseek-ai/deepseek-harness`
+- Observed version: `0.1.1-rc.2`
+- Commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+- Commit timestamp: 2026-08-21T12:03:37Z
+- License: MIT (`LICENSE`, copyright DeepSeek 2026)
+- Upstream explicitly labels the project developer preview and warns of compatibility-breaking changes.
+
+## Architecture facts used for intake
+Upstream documents an “everything is a plugin” Cordis composition model. Profiles stack bundles and patch overlays. Core extension domains include session log, system prompt assembly, tool registry/execution pipeline, agent registry/loop, scoped registration and LLM streaming adapters.
+
+Upstream's documented turn model includes durable turn/step/user/assistant/tool events plus live interception points. Model-visible history is derived from an append-only session log. Capability seams separate service definitions, providers and consumers. Documented seams/features include models, tools, shell/subprocess/PTY, filesystem, sandbox, subagents/teams, jobs, goals, workflows, plugins, persistence/query, settings, credentials, workspace, SDK/JSON-RPC, ACP, schedule, feedback, identity and Web/headless surfaces.
+
+## Planning rule
+Mahayana will reproduce required behavior through Rust-native, Mahayana-owned contracts. Cordis/Node.js are reference implementation details, not required product runtimes.
+
+## Follow-up audit requirement
+DHRF-101 must inventory packages, tools, events, configuration rows, persistence contracts, user-visible flows and tests at this exact commit before the project claims complete parity.

--- a/projects/deepseek-harness-rust-fusion/source/user-requirement-2026-08-22.md
+++ b/projects/deepseek-harness-rust-fusion/source/user-requirement-2026-08-22.md
@@ -1,0 +1,7 @@
+# User requirement — 2026-08-22
+
+Source type: direct user request in ChatGPT.
+
+Requirement: use Rust to fuse the project `https://github.com/deepseek-ai/deepseek-harness` into Fabushi, and establish a project folder for the plan.
+
+Normalized interpretation belongs in `docs/`; this file preserves the originating intent and repository pointer.


### PR DESCRIPTION
## Summary
- Create the governed project folder for DeepSeek Harness Rust fusion.
- Pin upstream DeepSeek Harness baseline and record provenance.
- Define roadmap, WBS, acceptance matrix, risks, ADR and evidence structure.
- Align implementation with existing Mahayana Rust Harness crates instead of creating a second runtime.

## Scope
Documentation/project governance only. No runtime code changed.

## Next steps
After merge, begin DHRF-101 source inventory and DHRF-102 existing Mahayana Harness audit.