### PR TITLE
feat(governance): establish immutable global project IDs

### DIFF
--- a/.agent/skills/fabushi-project-governance/SKILL.md
+++ b/.agent/skills/fabushi-project-governance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fabushi-project-governance
-description: Govern every Fabushi repository task through durable, enterprise-standard GitHub project folders. Use for any implementation, bug fix, refactor, investigation, release, migration, documentation change, AGENTS.md change, Skill creation/update, CI/CD or merge-policy change, architecture/governance change, or follow-up round. Treat `bhrumom/fabushi` GitHub `main` and `projects/<project-slug>/` as the authoritative engineering project record. Reuse an existing matching project; create the full standard project folder before substantial work when none exists; and do not declare completion until WBS, acceptance, status, changelog, evidence, and GitHub facts are synchronized.
+description: Govern every Fabushi repository task through durable, enterprise-standard GitHub project folders and immutable portfolio Project IDs. Use for any implementation, bug fix, refactor, investigation, release, migration, documentation change, AGENTS.md change, Skill creation/update, CI/CD or merge-policy change, architecture/governance change, or follow-up round. Treat `bhrumom/fabushi` GitHub `main`, `projects/PORTFOLIO.json`, and `projects/<project-slug>/` as the authoritative engineering project record. Reuse an existing matching project; create the full standard project folder with the next registered `FAB-Pxxxx` ID before substantial work when none exists; and do not declare completion until WBS, acceptance, status, changelog, evidence, and GitHub facts are synchronized.
 ---
 
 # Fabushi Project Governance
@@ -11,7 +11,11 @@ Treat GitHub as Fabushi's durable engineering project system of record.
 
 - Repository: `bhrumom/fabushi` unless the user explicitly names another repository.
 - Authoritative branch: `main` after merge.
+- Authoritative project registry: `projects/PORTFOLIO.json`.
+- Project identity policy: `projects/PROJECT_ID_POLICY.md`.
 - Authoritative project root: `projects/<project-slug>/`.
+- Canonical cross-project identity: immutable `project_id: FAB-Pxxxx`.
+- Human-readable project namespace: stable `project_key` such as `TFI`, `FPG`, `FCM`, `GBF`, or `MSR`.
 - Read repository/root/nested `AGENTS.md` instructions before substantial work.
 - For an existing project, read `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, `OWNERS.md`, relevant `source/`, `docs/`, `decisions/`, `management/`, `evidence/`, and `runbooks/` files.
 - Use chat, Google Drive, Gmail, Calendar, and local files as intake/reference material unless the project explicitly designates otherwise. They must not silently override the GitHub project folder.
@@ -37,15 +41,19 @@ If the objective belongs to an existing governance project, reuse it. Do not cre
 
 ## Decide whether to reuse or create
 
-1. Search `projects/` on `main` before creating anything.
-2. Reuse an existing project folder when the request is a continuation, refinement, bug fix, implementation stage, verification round, migration, release step, or governance update for the same objective.
+1. Read canonical `projects/PORTFOLIO.json` and search `projects/` on `main` before creating anything.
+2. Reuse an existing project folder and its existing `FAB-Pxxxx` Project ID when the request is a continuation, refinement, bug fix, implementation stage, verification round, migration, release step, or governance update for the same objective.
 3. Create a new `projects/<project-slug>/` folder only when the user starts a genuinely independent objective/workstream with its own scope and completion criteria.
-4. Do not create duplicate folders because a conversation, branch, PR, or agent session is new.
-5. If two folders overlap materially, select one canonical folder and record the consolidation decision before further work.
+4. For a genuinely new project, allocate exactly the registry's current `next_sequence` as `FAB-P%04d`; in the same change append the registry entry, increment `next_sequence`, and create `PROJECT.yaml` with the same `project_id` and a stable `project_key`.
+5. Never edit, swap, compact, recycle, or reassign an allocated Project ID. Rename/archive/cancel/split/merge changes lifecycle metadata, not historical identity.
+6. Preserve historical identifiers in `legacy_project_ids`; never assign a legacy alias to a different project.
+7. If concurrent project creation causes a `PORTFOLIO.json` merge conflict, re-read canonical `main` and reallocate the later project from the new high-water mark. Do not force or reuse the losing sequence.
+8. Do not create duplicate folders because a conversation, branch, PR, or agent session is new.
+9. If two folders overlap materially, select one canonical folder and record the consolidation decision; keep all allocated Project IDs registered for historical traceability.
 
 ## Enterprise project-folder gate
 
-When a new project is needed, create the mandatory scaffold in `references/project-folder-standard.md` before substantial implementation.
+When a new project is needed, allocate its portfolio Project ID first and create the mandatory scaffold in `references/project-folder-standard.md` before substantial implementation.
 
 The standard includes:
 
@@ -63,14 +71,14 @@ Do not leave mandatory standard files blank. If a document is not applicable, ke
 
 Before implementation:
 
-1. Read current `main` project folder and reconstruct scope/state.
+1. Read canonical `main` `projects/PORTFOLIO.json`, resolve the project's immutable `project_id` and `project_key`, then read the current project folder and reconstruct scope/state.
 2. Read current requirements, WBS, milestones, acceptance matrix, risks, dependencies, status report, changelog, open issues/actions, and relevant ADRs.
 3. Inspect current code/branches/PRs/CI/releases/deployments needed for the task.
-4. Assign or reuse a stable Task ID.
+4. Assign or reuse a stable Task ID within the project's `project_key` namespace when applicable.
 5. Create/update `management/tasks/<task-id>-<slug>.md` with source requirements, scope, dependencies, acceptance checks, planned evidence, branch/PR, status, risks, and next action.
 6. Record newly discovered requirements in `source/` and/or the normalized specification before or alongside implementation.
 
-Do not rely on remembered requirements when the project folder can resolve them.
+Do not rely on remembered requirements or remembered `next_sequence` values when GitHub `main` can resolve them.
 
 ## Execute with documentation in the same change stream
 
@@ -78,6 +86,7 @@ Do not rely on remembered requirements when the project folder can resolve them.
 - Avoid a second documentation-only PR when the active task PR can carry the records.
 - Keep project documentation factual: planned work is not completed work.
 - Use stable requirement/task/milestone/risk/ADR identifiers.
+- Never mutate the project's registered `project_id`; validate project metadata changes against the base-branch registry.
 - Record durable architecture, protocol, security, data, deployment, CI/CD, governance, or vendor decisions as ADRs.
 - Record scope/requirement/design changes in source/spec plus `management/07-变更日志.md`.
 - Track dependencies/blockers in `management/06-依赖与阻塞.md` and open questions/actions in `management/08-问题与行动项.md`.
@@ -91,7 +100,7 @@ Do not tell the user a task is finished until implementation, verification, evid
 
 Before completion:
 
-1. Run or inspect the defined objective acceptance checks.
+1. Run or inspect the defined objective acceptance checks, including `Project portfolio governance` when project identity/registry metadata is affected.
 2. Update `management/tasks/<task-id>-<slug>.md` with actual result/evidence.
 3. Update `management/01-WBS原子任务.md` for affected task states.
 4. Update `management/02-里程碑.md` when a milestone gate changes.
@@ -102,7 +111,7 @@ Before completion:
 9. Record branch, commit SHA, PR number, CI/run/test/release/deployment evidence where applicable.
 10. Commit project-record changes in the same task change stream when possible.
 11. Merge through the repository's required protected-main process.
-12. Verify the canonical result on GitHub `main` after merge.
+12. Verify the canonical result on GitHub `main` after merge, including registry/project metadata parity when identity changed.
 
 If CI, review, merge queue, release, deployment, migration, or another required acceptance gate is pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete.
 
@@ -113,22 +122,23 @@ A code push alone is not completion. A passing test without required project rec
 Use this precedence unless the project documents a stricter rule:
 
 1. User's latest explicit requirement, once persisted into the GitHub project folder.
-2. `projects/<slug>/SOURCE_OF_TRUTH.md` and designated source files.
-3. Accepted ADRs and current normalized project specs.
-4. Current management/WBS/milestone/acceptance/status records.
-5. GitHub code/PR/CI/release/deployment facts for implementation state.
-6. External mirrors/control views such as Google Drive/Sheets.
-7. Conversation memory.
+2. For portfolio identity/allocation: canonical `projects/PORTFOLIO.json` and `projects/PROJECT_ID_POLICY.md` on `main`.
+3. `projects/<slug>/SOURCE_OF_TRUTH.md` and designated source files.
+4. Accepted ADRs and current normalized project specs.
+5. Current management/WBS/milestone/acceptance/status records.
+6. GitHub code/PR/CI/release/deployment facts for implementation state.
+7. External mirrors/control views such as Google Drive/Sheets.
+8. Conversation memory.
 
-If documentation conflicts with actual implementation evidence, do not rewrite history silently. Record the discrepancy and correct project state with verified evidence.
+If documentation conflicts with actual implementation evidence, do not rewrite history silently. Record the discrepancy and correct project state with verified evidence. If project identity fields conflict, stop and reconcile them with the canonical portfolio registry rather than inventing a replacement ID.
 
 ## Task Orchestration alignment
 
-When Task Orchestration is available, use the same Project ID, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links across the repository project folder and external control view.
+When Task Orchestration is available, use the same immutable `FAB-Pxxxx` Project ID, Project Key, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links across the repository project folder and external control view.
 
 For Fabushi engineering work:
 
-- GitHub `projects/<slug>/` is the authoritative durable specification and execution record.
+- GitHub `projects/PORTFOLIO.json` + `projects/<slug>/` are the authoritative durable portfolio/project specification and execution record.
 - Google Sheets may be used as portfolio/control-plane view, not as a replacement for repository specifications or live engineering evidence.
 - Gmail/Drive/Calendar remain intake, external specification, scheduling, or reporting systems as appropriate.
 
@@ -136,12 +146,12 @@ For Fabushi engineering work:
 
 For engineering work governed by this skill, report:
 
-- project folder path;
-- task ID;
+- immutable portfolio Project ID and project folder path;
+- Project Key / task ID;
 - implementation result;
 - acceptance/test result;
 - commit/PR/CI/release/deployment evidence;
 - project documentation files updated;
 - remaining blocker or next action.
 
-Never claim project records, Skill updates, CI changes, or canonical main state were updated unless the corresponding write/merge/verification actually succeeded.
+Never claim project records, Skill updates, CI changes, Project ID allocation, or canonical main state were updated unless the corresponding write/merge/verification actually succeeded.

--- a/.agent/skills/fabushi-project-governance/references/project-folder-standard.md
+++ b/.agent/skills/fabushi-project-governance/references/project-folder-standard.md
@@ -8,7 +8,31 @@ All durable Fabushi project folders live under:
 
 Use lowercase kebab-case. A project folder represents one coherent objective/workstream, not a chat session, branch, or individual PR.
 
-Reuse an existing project when the request is a continuation, fix, migration, release, verification round, or refinement of the same objective. Create a new project only when scope, success criteria, and lifecycle are materially independent.
+Portfolio identity is governed by:
+
+- `projects/PORTFOLIO.json` — authoritative machine-readable allocation registry;
+- `projects/PROJECT_ID_POLICY.md` — immutable Project ID lifecycle and allocation policy;
+- `projects/README.md` — human portfolio index.
+
+Every canonical project has:
+
+- an immutable global `project_id` in the form `FAB-P0001`;
+- a stable mnemonic `project_key` such as `TFI`, `FPG`, `FCM`, `GBF`, or `MSR` for requirement/task namespaces;
+- zero or more `legacy_project_ids` that preserve historical aliases and are never reassigned.
+
+Reuse an existing project and its existing Project ID when the request is a continuation, fix, migration, release, verification round, or refinement of the same objective. Create a new project only when scope, success criteria, and lifecycle are materially independent.
+
+### New-project allocation gate
+
+Before creating a new project:
+
+1. Re-read canonical GitHub `main` `projects/PORTFOLIO.json`; never allocate from chat memory or a stale branch.
+2. Search existing registry/project folders and reuse a matching project if one exists.
+3. If the work is genuinely independent, allocate exactly the current `next_sequence` as `FAB-P%04d`.
+4. In the same change, append the registry entry, increment `next_sequence`, and create `projects/<slug>/PROJECT.yaml` with the same `project_id`, `project_key`, slug, and authoritative path.
+5. Never edit, swap, compact, recycle, or reassign an allocated Project ID. Lifecycle changes update status/history, not identity.
+6. Preserve historical identifiers in `legacy_project_ids`.
+7. If concurrent project creation causes a registry conflict, re-read canonical `main` and allocate the later project from the new high-water mark. The conflict is intentional allocation serialization.
 
 ## 2. Mandatory standard scaffold
 
@@ -58,7 +82,9 @@ Do not leave required files blank. If a standard document is genuinely not appli
 `PROJECT.yaml` must include at least:
 
 ```yaml
-project_id: <stable-id>
+project_id: FAB-P0006
+project_key: XYZ
+legacy_project_ids: []
 name: <human-readable name>
 slug: <project-slug>
 status: active
@@ -71,6 +97,10 @@ current_stage: <stage-id-or-name>
 created_at: YYYY-MM-DD
 updated_at: YYYY-MM-DD
 ```
+
+`project_id` is the cross-project surrogate identity and is immutable after allocation. `project_key` is the human-readable namespace for project-internal IDs such as `XYZ-001`; it does not replace the portfolio Project ID. `legacy_project_ids` preserves identifiers used before or during migrations and must never be reassigned to another project.
+
+The example `FAB-P0006` is illustrative only. Always read the live registry and use its actual `next_sequence` for a new project.
 
 Recommended optional fields:
 
@@ -88,7 +118,7 @@ Never store credentials, tokens, signing material, or other secrets.
 
 ### README.md
 
-Provide an onboarding-quality entry point containing objective, current verified status, current stage and next gate, scope/non-goals summary, source-of-truth pointer, owners/reviewers, primary acceptance definition, and navigation to specs, management, ADRs, evidence, and runbooks.
+Provide an onboarding-quality entry point containing Project ID/Project Key, objective, current verified status, current stage and next gate, scope/non-goals summary, source-of-truth pointer, owners/reviewers, primary acceptance definition, and navigation to specs, management, ADRs, evidence, and runbooks.
 
 A new engineer or agent must be able to understand the project without reading the originating chat.
 
@@ -96,7 +126,9 @@ A new engineer or agent must be able to understand the project without reading t
 
 State:
 
+- immutable `FAB-Pxxxx` Project ID and mnemonic Project Key;
 - authoritative repository, branch, and project path;
+- portfolio registry/policy as the authority for identity allocation;
 - original source/requirement files or external references;
 - precedence among latest persisted user requirements, source files, specs, ADRs, management state, GitHub/CI facts, external mirrors, and chat memory;
 - implementation-fact rule: code/PR/CI/release/deployment state must be verified from live systems;
@@ -134,7 +166,7 @@ Describe current state, target state, components, interfaces, data/control flow,
 
 ### `04-质量与测试策略.md`
 
-Define unit/contract/integration/E2E/security/performance tests as applicable, test data strategy, environments, required CI checks, flaky-test handling, and evidence retention.
+Define unit/contract/integration/E2E/security/performance tests as applicable, test data strategy, environments, required CI checks, flaky-test handling, and evidence retention. Project/registry changes must include the `Project portfolio governance` validator or its successor.
 
 ### `05-发布迁移与回滚.md`
 
@@ -160,7 +192,7 @@ Use a stage-based roadmap with entry/exit gates and explicit ordering/dependenci
 
 ### `01-WBS原子任务.md`
 
-Use stable task IDs. Every required task includes action, dependency, acceptance criterion, verification method, evidence requirement, status, blocker, and next action. Avoid subjective completion percentages.
+Use stable task IDs inside the project-key namespace where practical. Every required task includes action, dependency, acceptance criterion, verification method, evidence requirement, status, blocker, and next action. Avoid subjective completion percentages.
 
 ### `02-里程碑.md`
 
@@ -202,6 +234,7 @@ Create one durable record for each substantial atomic task:
 
 Minimum fields:
 
+- immutable portfolio Project ID and Project Key;
 - stable Task ID;
 - objective;
 - source requirement IDs/references;
@@ -241,7 +274,7 @@ Use `runbooks/` for deploy, rollback, recovery, migration, incident response, da
 
 Repository meta/governance changes must follow the same project standard as product code.
 
-The following require an existing matching project folder or a newly created one **before substantial work**:
+The following require an existing matching project folder or a newly allocated Project ID + project folder **before substantial work**:
 
 - root or nested `AGENTS.md` changes;
 - Skill creation, update, removal, packaging, or installation work;
@@ -252,22 +285,23 @@ The following require an existing matching project folder or a newly created one
 - build/release tooling changes;
 - security/governance automation.
 
-If a matching governance project already exists, reuse it. Otherwise create a separate governance project with its own source, scope, WBS, acceptance criteria, evidence, and completion gate.
+If a matching governance project already exists, reuse it. Otherwise allocate the next global Project ID and create a separate governance project with its own source, scope, WBS, acceptance criteria, evidence, and completion gate.
 
 ## 12. Completion gate
 
 Before declaring a repository task complete:
 
 1. Execute the defined acceptance check.
-2. Update the task record with actual result/evidence.
-3. Update WBS.
-4. Update acceptance traceability.
-5. Append status report.
-6. Append material changelog.
-7. Update risks/dependencies/issues/roadmap/ADRs/specs when affected.
-8. Record commit/PR/CI/release/deployment evidence.
-9. Merge through the repository's required protected-main process.
-10. Verify canonical state on `main`.
+2. Run/inspect portfolio identity validation when project registry/metadata is touched.
+3. Update the task record with actual result/evidence.
+4. Update WBS.
+5. Update acceptance traceability.
+6. Append status report.
+7. Append material changelog.
+8. Update risks/dependencies/issues/roadmap/ADRs/specs when affected.
+9. Record commit/PR/CI/release/deployment evidence.
+10. Merge through the repository's required protected-main process.
+11. Verify canonical state on `main`, including portfolio registry/project metadata parity when applicable.
 
 If any required gate is pending, keep the task `in-progress`, `blocked`, or `failed`.
 
@@ -275,6 +309,8 @@ If any required gate is pending, keep the task `in-progress`, `blocked`, or `fai
 
 A project folder passes audit only when:
 
+- its `FAB-Pxxxx` Project ID exists in `projects/PORTFOLIO.json` and matches `PROJECT.yaml`;
+- Project ID, Project Key, slug, and authoritative path are unique/consistent;
 - a new engineer/agent can reconstruct objective, scope, current state, and next action without chat history;
 - every required task has stable identity and objective acceptance;
 - requirements trace to implementation and evidence;
@@ -284,4 +320,4 @@ A project folder passes audit only when:
 - status/change history is append-only;
 - release/migration/rollback and SLO/runbook material exists where operational risk requires it;
 - secrets/private data are absent;
-- project and external control views use the same stable IDs.
+- project and external control views use the same immutable Project ID and stable scoped IDs.

--- a/.agent/skills/fabushi-project-governance/references/task-lifecycle.md
+++ b/.agent/skills/fabushi-project-governance/references/task-lifecycle.md
@@ -4,16 +4,26 @@
 
 - Read the user's originating source first.
 - Read root/nested `AGENTS.md` instructions before substantial repository work.
-- Search GitHub `projects/` before creating a folder.
+- Read canonical GitHub `main` `projects/PORTFOLIO.json` and search `projects/` before creating a folder.
 - Classify the request as continuation vs genuinely independent workstream.
-- Resolve the canonical project path.
+- Resolve the canonical project path, immutable `FAB-Pxxxx` Project ID, and Project Key.
 - Treat AGENTS.md, Skill, CI/CD, repository-governance, architecture-standard, documentation-system, release-tooling, and security-governance work exactly like product work for project routing.
 
 ## 2. Create or audit the project folder
 
-If no matching project exists, create the enterprise scaffold in `project-folder-standard.md` before substantial implementation.
+If no matching project exists, allocate a global Project ID and create the enterprise scaffold in `project-folder-standard.md` before substantial implementation.
 
-If a project exists, audit whether it has the current mandatory standard files. Add missing standard files as part of the active governance/project task; do not fork a second project solely to migrate the folder standard.
+For a new independent project, the allocation is atomic:
+
+1. Re-read `projects/PORTFOLIO.json` from canonical `main`; never use a remembered/stale `next_sequence`.
+2. Allocate exactly the current `next_sequence` as `FAB-P%04d`.
+3. Choose a stable uppercase mnemonic `project_key` for project-internal requirement/task namespaces.
+4. In the same branch/PR, append the registry entry, increment `next_sequence`, and create matching `projects/<slug>/PROJECT.yaml`.
+5. Run the portfolio validator and preserve the new ID after allocation.
+6. If a concurrent project consumes the same sequence first, re-read `main`, resolve the registry conflict, and move the later project to the new next sequence before merge.
+7. Never reuse an ID from an archived, cancelled, renamed, split, merged, superseded, or otherwise historical project. Preserve legacy IDs as aliases.
+
+If a project exists, reuse its registered Project ID and audit whether it has the current mandatory standard files. Add missing standard files as part of the active governance/project task; do not fork a second project solely to migrate the folder standard.
 
 Required standard areas include ownership, source, charter/scope/requirements, architecture, quality, release/rollback, SLO/operations, security, DoD, roadmap, WBS, milestones, acceptance, risks, dependencies, status, changelog, issues/actions, ADRs, evidence, runbooks, and per-task records.
 
@@ -23,34 +33,36 @@ Use `N/A` with reason/owner/revisit trigger when a standard document genuinely d
 
 Read from `main`:
 
-1. `SOURCE_OF_TRUTH.md`;
-2. `README.md`, `PROJECT.yaml`, `OWNERS.md`;
-3. relevant `source/` and `docs/`;
-4. relevant ADRs;
-5. `management/00-路线图.md`;
-6. `management/01-WBS原子任务.md`;
-7. `management/02-里程碑.md`;
-8. `management/03-验收追踪矩阵.md`;
-9. `management/04-风险登记.md`;
-10. `management/05-状态报告.md`;
-11. `management/06-依赖与阻塞.md`;
-12. `management/07-变更日志.md`;
-13. `management/08-问题与行动项.md`;
-14. current task record and evidence index, if any;
-15. relevant runbooks.
+1. `projects/PORTFOLIO.json` and resolve the project's registered `project_id`/`project_key`;
+2. `SOURCE_OF_TRUTH.md`;
+3. `README.md`, `PROJECT.yaml`, `OWNERS.md`;
+4. relevant `source/` and `docs/`;
+5. relevant ADRs;
+6. `management/00-路线图.md`;
+7. `management/01-WBS原子任务.md`;
+8. `management/02-里程碑.md`;
+9. `management/03-验收追踪矩阵.md`;
+10. `management/04-风险登记.md`;
+11. `management/05-状态报告.md`;
+12. `management/06-依赖与阻塞.md`;
+13. `management/07-变更日志.md`;
+14. `management/08-问题与行动项.md`;
+15. current task record and evidence index, if any;
+16. relevant runbooks.
 
-Then verify live GitHub code, open PRs, CI, releases, or deployments that materially affect the task.
+Then verify live GitHub code, open PRs, CI, releases, or deployments that materially affect the task. If project identity fields disagree with the canonical portfolio registry, stop and reconcile the inconsistency before implementation.
 
 ## 4. Open/update the task record
 
 Create or update `management/tasks/<task-id>-<slug>.md` before substantial work.
 
-Keep planned and completed states separate. Include stable requirement IDs, dependencies, acceptance criteria, verification, branch/PR, evidence plan, risks, blockers, timestamps, and next action.
+Record the immutable portfolio Project ID and Project Key in addition to the stable Task ID. Keep planned and completed states separate. Include stable requirement IDs, dependencies, acceptance criteria, verification, branch/PR, evidence plan, risks, blockers, timestamps, and next action.
 
 ## 5. Implement
 
 - Use a task branch/PR when appropriate.
 - Keep implementation and project-record updates together.
+- Do not mutate an already-registered Project ID or reassign a Project Key/legacy alias to another project.
 - If requirements change during work, update source/spec and changelog, not just chat.
 - Record durable decisions as ADRs.
 - Update dependency/risk/action registers when new facts emerge.
@@ -58,7 +70,9 @@ Keep planned and completed states separate. Include stable requirement IDs, depe
 
 ## 6. Verify
 
-Run the objective checks stated in the task/WBS/DoD. Capture:
+Run the objective checks stated in the task/WBS/DoD. If project identity, the project registry, project metadata, AGENTS/governance controls, or project creation behavior changed, the `Project portfolio governance` workflow (or its successor) is required.
+
+Capture:
 
 - check/test name;
 - expected result;
@@ -66,6 +80,7 @@ Run the objective checks stated in the task/WBS/DoD. Capture:
 - commit SHA;
 - PR/review;
 - CI run/job/check;
+- portfolio-validator result when applicable;
 - security/performance evidence when required;
 - release/deployment/migration evidence when relevant.
 
@@ -89,17 +104,19 @@ Before saying “done”:
 
 Prefer the same PR for implementation and record updates. Use the repository's protected branch/required checks/merge queue policy. After merge, verify expected project and implementation files on `main`.
 
+For project-ID/registry changes, explicitly re-read canonical `projects/PORTFOLIO.json` and affected `PROJECT.yaml` files and verify the registry high-water mark after merge.
+
 If implementation is ready but review/CI/merge/release/deployment/migration is still pending, use `in-progress`, `blocked`, or `failed`; do not mark complete.
 
 ## 9. Synchronize external control views
 
 When Task Orchestration/Google Sheets/Drive/Calendar/Gmail are used:
 
-- preserve the same Project/Stage/Task/Requirement IDs;
-- keep GitHub engineering specifications/evidence authoritative for Fabushi repository work;
+- preserve the same immutable `FAB-Pxxxx` Project ID, Project Key, Stage ID, Task ID, and Requirement IDs;
+- keep GitHub portfolio/project engineering specifications/evidence authoritative for Fabushi repository work;
 - synchronize verified state into the external portfolio/control view;
 - use Drive/Gmail as source/intake or mirror, Calendar as schedule, not as silent overrides of GitHub project state.
 
 ## 10. Next task
 
-For a continuation, begin from the same project folder and prior task history. For a genuinely different objective, create a new enterprise-standard project folder before substantial implementation.
+For a continuation, begin from the same registered Project ID/project folder and prior task history. For a genuinely different objective, re-read canonical `projects/PORTFOLIO.json`, allocate the current next Project ID atomically, and create a new enterprise-standard project folder before substantial implementation.

--- a/.github/workflows/project-portfolio-governance.yml
+++ b/.github/workflows/project-portfolio-governance.yml
@@ -1,0 +1,54 @@
+name: Project portfolio governance
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "projects/**"
+      - "AGENTS.md"
+      - ".agent/skills/fabushi-project-governance/**"
+      - "scripts/check-project-portfolio.py"
+      - ".github/workflows/project-portfolio-governance.yml"
+  push:
+    branches: [main, develop]
+    paths:
+      - "projects/**"
+      - "AGENTS.md"
+      - ".agent/skills/fabushi-project-governance/**"
+      - "scripts/check-project-portfolio.py"
+      - ".github/workflows/project-portfolio-governance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-project-portfolio:
+    name: Validate immutable Project IDs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Materialize baseline registry
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f /tmp/fabushi-portfolio-baseline.json
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            git show "origin/${GITHUB_BASE_REF}:projects/PORTFOLIO.json" > /tmp/fabushi-portfolio-baseline.json 2>/dev/null || true
+          elif git rev-parse HEAD^ >/dev/null 2>&1; then
+            git show "HEAD^:projects/PORTFOLIO.json" > /tmp/fabushi-portfolio-baseline.json 2>/dev/null || true
+          fi
+
+      - name: Validate portfolio registry and project metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -s /tmp/fabushi-portfolio-baseline.json ]]; then
+            python3 scripts/check-project-portfolio.py --baseline /tmp/fabushi-portfolio-baseline.json
+          else
+            python3 scripts/check-project-portfolio.py
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,16 +12,36 @@ There are **no meta-work exemptions**. Work that changes this `AGENTS.md`, `.age
 
 Before substantial work:
 
-1. Inspect current GitHub `main` under `projects/`.
+1. Inspect current GitHub `main` under `projects/` and read canonical `projects/PORTFOLIO.json`.
 2. Decide whether the request belongs to an existing project or is a genuinely independent objective/workstream.
-3. If a matching project exists, **reuse it**. Do not create a duplicate because the chat, branch, PR, or agent session is new.
-4. Read the matching project's `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, `OWNERS.md`, relevant `source/`, `docs/`, `decisions/`, `management/`, `evidence/`, and `runbooks/` files.
-5. Read current roadmap, WBS, milestones, acceptance matrix, risk register, dependency/blocker register, status report, changelog, open issues/actions, active task record, and relevant ADRs before deciding what to implement next.
-6. Verify code, branch, PR, CI, release, deployment, and migration facts against live GitHub/engineering systems rather than assuming project documentation is current.
+3. If a matching project exists, **reuse it and its registered `FAB-Pxxxx` Project ID**. Do not create a duplicate because the chat, branch, PR, or agent session is new.
+4. Resolve the project's `project_id`, `project_key`, slug, and authoritative path from the registry and `PROJECT.yaml`.
+5. Read the matching project's `SOURCE_OF_TRUTH.md` first, then `README.md`, `PROJECT.yaml`, `OWNERS.md`, relevant `source/`, `docs/`, `decisions/`, `management/`, `evidence/`, and `runbooks/` files.
+6. Read current roadmap, WBS, milestones, acceptance matrix, risk register, dependency/blocker register, status report, changelog, open issues/actions, active task record, and relevant ADRs before deciding what to implement next.
+7. Verify code, branch, PR, CI, release, deployment, and migration facts against live GitHub/engineering systems rather than assuming project documentation is current.
+
+### 1A. Global Project ID allocation gate
+
+Fabushi has one immutable portfolio identity namespace for projects:
+
+- `project_id`: global cross-project identity in the form `FAB-P0001`, `FAB-P0002`, ... . It is immutable and never reused.
+- `project_key`: stable mnemonic namespace such as `TFI`, `FPG`, `FCM`, `GBF`, or `MSR`; use this for human-readable requirement/task IDs. It is not the portfolio Project ID.
+- `legacy_project_ids`: historical aliases preserved for traceability; never reassign an alias to another project.
+- `projects/PORTFOLIO.json`: authoritative machine-readable registry and allocation high-water mark.
+- `projects/PROJECT_ID_POLICY.md`: authoritative lifecycle/allocation policy.
+
+If no matching project exists and the work is genuinely independent:
+
+1. Re-read `projects/PORTFOLIO.json` from canonical GitHub `main` immediately before allocation. Never allocate from chat memory or a stale branch.
+2. Allocate **exactly** the registry's current `next_sequence` using `FAB-P%04d`.
+3. In the same branch/PR, append the new registry entry, increment `next_sequence`, and create `projects/<project-slug>/PROJECT.yaml` with the identical `project_id`, a unique stable `project_key`, slug, and authoritative path.
+4. Never edit, swap, compact, recycle, or reassign an allocated Project ID. Rename, archive, cancellation, split, merge, or supersession changes project status/history, not its historical identity.
+5. If concurrent project creation causes a `PORTFOLIO.json` merge conflict, re-read canonical `main` and reallocate the later project from the new high-water mark. Do not force, duplicate, or reuse the losing sequence.
+6. Project/registry changes must pass the `Project portfolio governance` GitHub Actions validator before completion.
 
 ### 2. If no project folder exists, create the enterprise standard before implementation
 
-If the request does not belong to an existing project, create a lowercase kebab-case folder under:
+If the request does not belong to an existing project, first allocate the portfolio Project ID under the gate above, then create a lowercase kebab-case folder under:
 
 `projects/<project-slug>/`
 
@@ -72,8 +92,8 @@ Every project must be reconstructable by a new engineer/agent without the origin
 
 At minimum:
 
-- `README.md`: objective, current verified status, current stage/next gate, scope summary, owners, source-of-truth pointer, acceptance summary, navigation.
-- `PROJECT.yaml`: stable project identity, slug, status, repository, authoritative branch/path, owner/reviewers, current stage, timestamps; optional risk/security classification.
+- `README.md`: immutable Project ID/Project Key, objective, current verified status, current stage/next gate, scope summary, owners, source-of-truth pointer, acceptance summary, navigation.
+- `PROJECT.yaml`: registered `project_id: FAB-Pxxxx`, stable `project_key`, `legacy_project_ids`, slug, status, repository, authoritative branch/path, owner/reviewers, current stage, timestamps; optional risk/security classification. These identity fields must match `projects/PORTFOLIO.json`.
 - `SOURCE_OF_TRUTH.md`: authoritative source precedence and conflict-resolution rules.
 - `OWNERS.md`: accountable/execution owners, reviewers, consulted stakeholders, escalation path.
 - `source/`: original requirements and durable source references; do not silently rewrite source history.
@@ -99,6 +119,7 @@ Create or update:
 
 The task record must include at least:
 
+- immutable portfolio Project ID and Project Key;
 - stable Task ID;
 - objective and source requirement IDs/references;
 - in-scope / out-of-scope;
@@ -115,9 +136,9 @@ The task record must include at least:
 
 ### 5. Drive implementation from the project folder
 
-The GitHub project folder is the durable working context. Use it to decide what comes next rather than relying on chat memory.
+The GitHub portfolio registry and project folder are the durable working context. Use them to decide what comes next rather than relying on chat memory.
 
-- Reconstruct current state from the project folder at the start of each task/round.
+- Reconstruct current state from `projects/PORTFOLIO.json` and the project folder at the start of each task/round.
 - Advance the existing roadmap/WBS instead of inventing a parallel plan in chat.
 - Record newly discovered requirements in `source/` and/or normalized specs.
 - Record scope/design/governance changes in `management/07-变更日志.md`.
@@ -125,6 +146,7 @@ The GitHub project folder is the durable working context. Use it to decide what 
 - Update risk, dependency/blocker, issue/action, release/rollback, security, SLO, and runbook records when affected.
 - Keep planned work and verified completed work clearly separated.
 - Prefer the same branch/PR for implementation and its project-record updates.
+- Never mutate an existing registered Project ID to make a registry conflict disappear.
 
 ### 6. Task completion is blocked until project records and evidence are current
 
@@ -132,7 +154,7 @@ Do **not** report a task as complete merely because code was written, pushed, or
 
 Before saying a task is finished:
 
-1. Run or inspect the defined acceptance checks.
+1. Run or inspect the defined acceptance checks, including `Project portfolio governance` when project identity/registry metadata is affected.
 2. Update the task record with actual results and evidence.
 3. Update `management/01-WBS原子任务.md` for affected task states.
 4. Update `management/02-里程碑.md` when milestone gates change.
@@ -143,7 +165,7 @@ Before saying a task is finished:
 9. Record commit SHA, PR/review, CI run/job/check, test, release, deployment, migration, blockers, and next action where applicable.
 10. Commit project-record changes to GitHub in the same task change stream when possible.
 11. Merge through required protected-main checks/merge queue.
-12. Verify canonical state on GitHub `main` after merge.
+12. Verify canonical state on GitHub `main` after merge, including registry/project metadata parity when applicable.
 
 If any required review/CI/merge/release/deployment/migration/acceptance gate is pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete.
 
@@ -152,14 +174,15 @@ If any required review/CI/merge/release/deployment/migration/acceptance gate is 
 Unless a project defines a stricter rule, use this precedence:
 
 1. the user's latest explicit requirement **after it is persisted into the GitHub project folder**;
-2. `projects/<project-slug>/SOURCE_OF_TRUTH.md` and designated source files;
-3. accepted ADRs and current project specs;
-4. current WBS/milestone/status/acceptance records;
-5. GitHub code/PR/CI/release/deployment facts for implementation state;
-6. external mirrors/control views such as Google Drive/Sheets;
-7. conversation memory.
+2. for portfolio identity/allocation, canonical `projects/PORTFOLIO.json` and `projects/PROJECT_ID_POLICY.md` on GitHub `main`;
+3. `projects/<project-slug>/SOURCE_OF_TRUTH.md` and designated source files;
+4. accepted ADRs and current project specs;
+5. current WBS/milestone/status/acceptance records;
+6. GitHub code/PR/CI/release/deployment facts for implementation state;
+7. external mirrors/control views such as Google Drive/Sheets;
+8. conversation memory.
 
-External systems are intake, scheduling, reporting, portfolio, or mirror systems unless explicitly promoted. They must not silently override the GitHub `main` project folder for Fabushi engineering work.
+External systems are intake, scheduling, reporting, portfolio, or mirror systems unless explicitly promoted. They must not silently override the GitHub `main` portfolio registry/project folder for Fabushi engineering work.
 
 ### 8. Required governance skill and Task Orchestration alignment
 
@@ -172,9 +195,9 @@ and:
 - `.agent/skills/fabushi-project-governance/references/project-folder-standard.md`
 - `.agent/skills/fabushi-project-governance/references/task-lifecycle.md`
 
-When Task Orchestration is used, preserve the same Project ID, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links in external control views. Google Sheets is a portfolio/control-plane view; for Fabushi repository work the GitHub project folder and live GitHub/CI facts remain authoritative.
+When Task Orchestration is used, preserve the same immutable `FAB-Pxxxx` Project ID, Project Key, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links in external control views. Google Sheets is a portfolio/control-plane view; for Fabushi repository work the GitHub portfolio registry/project folder and live GitHub/CI facts remain authoritative.
 
-The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass project-folder creation/reuse, task records, acceptance evidence, or completion closure.
+The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass portfolio Project ID allocation, project-folder creation/reuse, task records, acceptance evidence, or completion closure.
 
 ## CRITICAL: Local Disk Safety — Never Build or Test the App Locally
 

--- a/projects/PORTFOLIO.json
+++ b/projects/PORTFOLIO.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "portfolio": "FAB",
+  "project_id_format": "FAB-P%04d",
+  "project_id_regex": "^FAB-P[0-9]{4}$",
+  "allocation_policy": "monotonic-no-reuse",
+  "ordering_basis": "first-formal-project-folder-commit-on-canonical-main",
+  "next_sequence": 6,
+  "projects": [
+    {
+      "project_id": "FAB-P0001",
+      "project_key": "TFI",
+      "slug": "telegram-fabushi-integration",
+      "name": "Fabushi Telegram 全量融合",
+      "authoritative_path": "projects/telegram-fabushi-integration",
+      "status": "active",
+      "registered_at": "2026-08-22",
+      "first_canonical_main_commit": "99cd4b227a34b49fc04c3265c1dfdee585344160",
+      "legacy_project_ids": ["FABUSHI-TELEGRAM-FUSION"]
+    },
+    {
+      "project_id": "FAB-P0002",
+      "project_key": "FPG",
+      "slug": "fabushi-project-governance",
+      "name": "Fabushi Project Governance",
+      "authoritative_path": "projects/fabushi-project-governance",
+      "status": "active",
+      "registered_at": "2026-08-22",
+      "first_canonical_main_commit": "eaf273dafc140619b06b46a4d7d234997acde05d",
+      "legacy_project_ids": ["FPG"]
+    },
+    {
+      "project_id": "FAB-P0003",
+      "project_key": "FCM",
+      "slug": "fabushi-cicd-merge-governance",
+      "name": "Fabushi CI/CD & Merge Governance",
+      "authoritative_path": "projects/fabushi-cicd-merge-governance",
+      "status": "active",
+      "registered_at": "2026-08-22",
+      "first_canonical_main_commit": "ac94b40d4a05a0211146c2bb5904aa936a7bc928",
+      "legacy_project_ids": ["FCM"]
+    },
+    {
+      "project_id": "FAB-P0004",
+      "project_key": "GBF",
+      "slug": "grok-bot-fabushi-integration",
+      "name": "Grok Bot -> Fabushi 全量能力与源码融合",
+      "authoritative_path": "projects/grok-bot-fabushi-integration",
+      "status": "active",
+      "registered_at": "2026-08-22",
+      "first_canonical_main_commit": "6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c",
+      "legacy_project_ids": ["FABUSHI-GROK-BOT-FUSION"]
+    },
+    {
+      "project_id": "FAB-P0005",
+      "project_key": "MSR",
+      "slug": "mahayana-sovereign-runtime",
+      "name": "Mahayana Sovereign Runtime",
+      "authoritative_path": "projects/mahayana-sovereign-runtime",
+      "status": "active",
+      "registered_at": "2026-08-22",
+      "first_canonical_main_commit": "88db63c328c3cba39971f3942509cb0b582502bc",
+      "legacy_project_ids": ["MSR"]
+    }
+  ]
+}

--- a/projects/PROJECT_ID_POLICY.md
+++ b/projects/PROJECT_ID_POLICY.md
@@ -1,0 +1,63 @@
+# Fabushi Portfolio Project ID Policy
+
+## Purpose
+
+Provide one immutable, globally unique identity for every canonical Fabushi project while keeping human-readable project keys and historical task namespaces stable.
+
+## Canonical identity model
+
+Each project has two distinct identifiers:
+
+- **Project ID** — global portfolio identity, format `FAB-P0001`, `FAB-P0002`, ... . This is immutable and unique across Fabushi.
+- **Project Key** — short mnemonic namespace such as `TFI`, `FPG`, `FCM`, `GBF`, `MSR`. This is used by WBS/task/requirement identifiers and remains stable for human readability.
+
+Historical values that were previously called `project_id` are retained in `legacy_project_ids`; they are aliases only and must never be reassigned to another project.
+
+## Allocation rules
+
+1. `projects/PORTFOLIO.json` is the authoritative allocation registry.
+2. A new project MUST allocate exactly the registry's current `next_sequence` using `FAB-P%04d`.
+3. The same pull request MUST:
+   - add the registry entry;
+   - increment `next_sequence` by one;
+   - create the project folder and `PROJECT.yaml` with the same `project_id` and `project_key`.
+4. Existing IDs MUST NOT be edited, swapped, compacted, recycled, or reassigned.
+5. Archived, cancelled, merged, superseded, or renamed projects keep their Project ID forever. Keep the registry entry and mark status rather than deleting it.
+6. Project directory rename does not change Project ID. Update `slug`/`authoritative_path` and preserve aliases/history.
+7. Project split creates new Project IDs for the new independent projects; the original ID remains with the original historical project record.
+8. Project merge/consolidation keeps all historical IDs registered. One project may become canonical, but other IDs are marked superseded/merged rather than reused.
+9. Concurrent project creation intentionally contends on `PORTFOLIO.json`. Resolve the merge conflict by re-reading canonical `main` and reallocating the later project to the new `next_sequence`.
+
+## Backfill rule for pre-policy projects
+
+Existing canonical projects are numbered by the timestamp of their first formal `projects/<slug>/` project-folder commit merged to GitHub `main`. This provides deterministic, auditable ordering and avoids subjective priority-based numbering.
+
+## Required PROJECT.yaml fields
+
+```yaml
+project_id: FAB-P0001
+project_key: TFI
+legacy_project_ids:
+  - FABUSHI-TELEGRAM-FUSION
+name: <human-readable name>
+slug: <project-slug>
+authoritative_path: projects/<project-slug>
+```
+
+`project_id` is the cross-project identity. `project_key` is the mnemonic namespace for internal IDs such as `TFI-GOV-002` or `MSR-103`.
+
+## Validation and governance
+
+CI validates:
+
+- Project ID regex and sequence;
+- uniqueness of Project IDs, project keys, slugs, and authoritative paths;
+- `next_sequence == max(sequence) + 1`;
+- exact parity between registry entries and canonical project folders;
+- `PROJECT.yaml` identity/path consistency;
+- immutable Project ID and project key for already-registered slugs when compared with the pull request base branch;
+- preservation of prior registry entries, preventing silent deletion/reuse.
+
+## External systems
+
+Google Sheets, Drive, Calendar, Gmail, issue trackers, release systems, and other control planes must mirror the same `FAB-Pxxxx` Project ID when they represent a Fabushi project. GitHub `main`, `projects/PORTFOLIO.json`, and the project's `PROJECT.yaml` remain authoritative for repository engineering identity.

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,28 @@
+# Fabushi Project Portfolio
+
+Canonical machine registry: [`PORTFOLIO.json`](./PORTFOLIO.json)  
+Identity policy: [`PROJECT_ID_POLICY.md`](./PROJECT_ID_POLICY.md)
+
+| Project ID | Project Key | Project | Canonical path | First formal main commit |
+|---|---|---|---|---|
+| `FAB-P0001` | `TFI` | Fabushi Telegram 全量融合 | `projects/telegram-fabushi-integration/` | `99cd4b227a34b49fc04c3265c1dfdee585344160` |
+| `FAB-P0002` | `FPG` | Fabushi Project Governance | `projects/fabushi-project-governance/` | `eaf273dafc140619b06b46a4d7d234997acde05d` |
+| `FAB-P0003` | `FCM` | Fabushi CI/CD & Merge Governance | `projects/fabushi-cicd-merge-governance/` | `ac94b40d4a05a0211146c2bb5904aa936a7bc928` |
+| `FAB-P0004` | `GBF` | Grok Bot -> Fabushi 全量能力与源码融合 | `projects/grok-bot-fabushi-integration/` | `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c` |
+| `FAB-P0005` | `MSR` | Mahayana Sovereign Runtime | `projects/mahayana-sovereign-runtime/` | `88db63c328c3cba39971f3942509cb0b582502bc` |
+
+## Next Project ID
+
+The registry high-water mark is authoritative. At this migration baseline the next allocatable ID is:
+
+`FAB-P0006`
+
+Do not reserve or allocate it from chat memory. Always re-read `PORTFOLIO.json` on canonical `main` immediately before creating a new independent project.
+
+## Identifier semantics
+
+- `FAB-Pxxxx`: immutable portfolio Project ID across all Fabushi projects.
+- Project Key (`TFI`, `FPG`, `FCM`, `GBF`, `MSR`, ...): mnemonic namespace for requirements/tasks/milestones.
+- Task IDs (`MSR-103`, `FPG-004`, ...): project-internal work identifiers; they are not portfolio Project IDs.
+
+Project IDs are never reused, even after archive, cancellation, consolidation, split, or rename.

--- a/projects/fabushi-cicd-merge-governance/PROJECT.yaml
+++ b/projects/fabushi-cicd-merge-governance/PROJECT.yaml
@@ -1,4 +1,7 @@
-project_id: FCM
+project_id: FAB-P0003
+project_key: FCM
+legacy_project_ids:
+  - FCM
 name: Fabushi CI/CD & Merge Governance
 slug: fabushi-cicd-merge-governance
 status: active

--- a/projects/fabushi-project-governance/PROJECT.yaml
+++ b/projects/fabushi-project-governance/PROJECT.yaml
@@ -1,4 +1,7 @@
-project_id: FPG
+project_id: FAB-P0002
+project_key: FPG
+legacy_project_ids:
+  - FPG
 name: Fabushi Project Governance
 slug: fabushi-project-governance
 status: active

--- a/projects/fabushi-project-governance/SOURCE_OF_TRUTH.md
+++ b/projects/fabushi-project-governance/SOURCE_OF_TRUTH.md
@@ -2,29 +2,34 @@
 
 The canonical project record is `bhrumom/fabushi` `main` under `projects/fabushi-project-governance/`.
 
+The canonical repository-wide project identity registry is `projects/PORTFOLIO.json`; its lifecycle/allocation policy is `projects/PROJECT_ID_POLICY.md`. This governance project is registered as `FAB-P0002` with Project Key `FPG`.
+
 ## Designated requirement sources
 
 - `source/README.md` — original repository-wide project-first governance requirement.
 - `source/2026-08-22-FPG-002-enterprise-project-standard.md` — requirement to align Task Orchestration, root `AGENTS.md`, repository Skills, and project folders with an enterprise-standard project-document model.
+- `source/2026-08-22-FPG-004-global-project-identifiers.md` — requirement to establish immutable numbering between Fabushi projects.
 
 ## Precedence
 
 1. Latest explicit user requirement after being persisted into this project folder.
-2. This file and designated source files.
-3. Accepted ADRs and current normalized specs under `docs/`.
-4. Current roadmap, WBS, milestones, acceptance, risks, dependencies, status, changelog, issues/actions, and task records.
-5. Live GitHub code/PR/review/CI/release/deployment/migration facts for implementation state.
-6. External portfolio/control/mirror systems such as Google Sheets or Google Drive.
-7. Conversation memory.
+2. For cross-project identity/allocation: canonical `projects/PORTFOLIO.json` and `projects/PROJECT_ID_POLICY.md` on `main`.
+3. This file and designated source files.
+4. Accepted ADRs and current normalized specs under `docs/`.
+5. Current roadmap, WBS, milestones, acceptance, risks, dependencies, status, changelog, issues/actions, and task records.
+6. Live GitHub code/PR/review/CI/release/deployment/migration facts for implementation state.
+7. External portfolio/control/mirror systems such as Google Sheets or Google Drive.
+8. Conversation memory.
 
 ## Conflict resolution
 
 - Do not silently rewrite source history when a requirement changes; append the new dated source/change and update normalized specs/changelog.
 - If project records conflict with live code/CI/release/deployment state, record the discrepancy and correct the project record using verified evidence.
-- If two project folders overlap, choose one canonical project and record the consolidation decision before continuing.
+- If a `PROJECT.yaml` identity conflicts with `projects/PORTFOLIO.json`, stop and reconcile to the canonical registry. Never mint a replacement ID from memory.
+- If two project folders overlap, choose one canonical project and record the consolidation decision before continuing; already allocated portfolio IDs remain registered for historical traceability and are never reused.
 
 ## Engineering fact rule
 
 GitHub `main` is authoritative after protected merge. A commit push alone is not equivalent to accepted/released/deployed state unless the project's Definition of Done explicitly says so and evidence proves it.
 
-External copies may inform work but must not silently override this folder. No task is complete until required project-record updates and objective evidence are present.
+Project IDs become canonical only after their registry/project metadata change is merged and verified on `main`. External copies may inform work but must not silently override the portfolio registry or project folder. No task is complete until required project-record updates and objective evidence are present.

--- a/projects/fabushi-project-governance/decisions/ADR-0003-global-portfolio-project-identifiers.md
+++ b/projects/fabushi-project-governance/decisions/ADR-0003-global-portfolio-project-identifiers.md
@@ -1,0 +1,88 @@
+# ADR-0003 — Immutable Global Portfolio Project Identifiers
+
+- Status: Accepted
+- Date: 2026-08-22
+- Decision owners: repository-governance / repository-maintainers
+- Task: FPG-004
+
+## Context
+
+Fabushi project folders historically used heterogeneous `project_id` values such as `FPG`, `MSR`, `FCM`, `FABUSHI-TELEGRAM-FUSION`, and `FABUSHI-GROK-BOT-FUSION`. Those values were useful as mnemonic namespaces but did not provide one globally ordered, immutable portfolio identity across projects.
+
+As the number of independent initiatives grows, project routing, portfolio reporting, external control-plane synchronization, archive/merge history, and automation need a single identifier whose meaning is independent of project name, directory, task prefix, or product branding.
+
+## Decision
+
+Fabushi adopts a two-layer identity model:
+
+1. **Canonical portfolio Project ID**: `FAB-P0001`, `FAB-P0002`, ... .
+   - unique across the Fabushi portfolio;
+   - immutable after allocation;
+   - monotonically allocated from the high-water mark in `projects/PORTFOLIO.json`;
+   - never reused, recycled, compacted, or reassigned.
+2. **Project Key**: short stable mnemonic such as `TFI`, `FPG`, `FCM`, `GBF`, `MSR`.
+   - used as the human-readable namespace for requirements, WBS tasks, milestones, risks, and other internal identifiers;
+   - does not replace the global Project ID.
+3. Previous project identifiers are retained as `legacy_project_ids` aliases for traceability and must not be reassigned.
+4. `projects/PORTFOLIO.json` is the authoritative machine-readable allocation registry. Every canonical project `PROJECT.yaml` must mirror its registered `project_id`, `project_key`, `slug`, and authoritative path.
+5. Pre-policy projects are backfilled by the timestamp of the first formal project-folder commit merged to canonical GitHub `main`.
+6. New-project creation is serialized through the registry: a PR must allocate the current `next_sequence`, increment it, and create matching project metadata atomically.
+7. CI compares the current registry to the target-branch registry and rejects mutation/removal of existing IDs, duplicate identities, malformed sequences, or registry/project-folder divergence.
+
+## Initial allocation
+
+| Project ID | Key | Project |
+|---|---|---|
+| FAB-P0001 | TFI | Telegram integration |
+| FAB-P0002 | FPG | Project governance |
+| FAB-P0003 | FCM | CI/CD & merge governance |
+| FAB-P0004 | GBF | Grok Bot fusion |
+| FAB-P0005 | MSR | Mahayana sovereign runtime |
+
+Next allocation after migration: `FAB-P0006`.
+
+## Alternatives considered
+
+### A. Keep mnemonic strings as the only Project ID
+
+Rejected. They are readable but not globally ordered, historically inconsistent, and easy to rename or collide as the portfolio grows.
+
+### B. Encode product/team/date into the numeric ID
+
+Rejected. Semantic IDs become unstable when ownership, branding, scope, or organizational structure changes. Stable surrogate identity should not carry mutable business meaning.
+
+### C. Use UUID/ULID as the primary human project identifier
+
+Rejected as the primary portfolio identifier because it is unnecessarily opaque for a repository-sized engineering portfolio. A monotonic zero-padded surrogate is easier to communicate and audit. UUIDs may still be used by external systems internally.
+
+### D. Renumber projects after archive or consolidation to keep the sequence dense
+
+Rejected. Renumbering destroys historical referential integrity. Density is less important than permanence.
+
+## Consequences
+
+### Positive
+
+- Stable identity survives rename, archive, split, merge, or branding changes.
+- Portfolio views and external systems can share one durable identifier.
+- Project keys and task IDs remain human-friendly without carrying cross-project identity responsibility.
+- Merge conflicts on `PORTFOLIO.json` deliberately serialize concurrent project creation and prevent duplicate allocation.
+
+### Costs / tradeoffs
+
+- Existing projects require a one-time migration and alias preservation.
+- New project creation includes one additional registry edit.
+- The numeric ID does not encode business meaning by design; users must consult the registry for project name/path.
+
+## Migration and rollback
+
+- Backfill all current canonical project folders in one governance change.
+- Preserve every prior identifier under `legacy_project_ids`; do not rewrite historical PRs/commits/tasks.
+- If the rollout must be reverted before merge, discard the branch. After merge, Project IDs are permanent; a future policy change must supersede this ADR without reassigning already-issued IDs.
+
+## Verification
+
+- `scripts/check-project-portfolio.py`
+- `.github/workflows/project-portfolio-governance.yml`
+- FPG-004 acceptance matrix/evidence
+- Protected merge and post-merge canonical `main` verification

--- a/projects/fabushi-project-governance/decisions/README.md
+++ b/projects/fabushi-project-governance/decisions/README.md
@@ -1,3 +1,5 @@
 # Decisions
 
 - `ADR-0001-project-first-repository-governance.md` — make `projects/` mandatory durable context for every repository task.
+- `ADR-0002-enterprise-project-folder-standard.md` — adopt the enterprise project-folder/document standard and no-meta-exemption model.
+- `ADR-0003-global-portfolio-project-identifiers.md` — adopt immutable global `FAB-Pxxxx` Project IDs, stable Project Keys, legacy aliases, and monotonic no-reuse allocation.

--- a/projects/fabushi-project-governance/docs/02-需求与成功指标.md
+++ b/projects/fabushi-project-governance/docs/02-需求与成功指标.md
@@ -11,6 +11,11 @@
 | FPG-R05 | GitHub `main` 项目目录与 live GitHub/CI/release facts 为工程主基线 | 不允许外部镜像静默覆盖工程状态 |
 | FPG-R06 | Task Orchestration 与 GitHub 项目目录共享稳定 ID 和项目路由规则 | 同一项目的 Project/Stage/Task/Requirement ID 无平行编号体系 |
 | FPG-R07 | 项目记录可由新工程师/agent 在无聊天上下文下重建当前状态 | 项目审计可定位 objective/scope/current status/next action/evidence |
+| FPG-R08 | 每个 canonical Fabushi 项目必须有全局唯一不可变 Portfolio Project ID | 100% `projects/*/PROJECT.yaml` 使用唯一 `FAB-Pxxxx` 且 registry parity 通过 |
+| FPG-R09 | Portfolio Project ID 必须单调分配且永久不复用 | `next_sequence=max+1`，archive/merge/cancel 后历史 ID 仍保留 |
+| FPG-R10 | Portfolio Project ID、Project Key、Task ID 必须职责分离 | `project_id=FAB-Pxxxx`; `project_key` 作为任务/需求命名空间；历史 ID 保留 aliases |
+| FPG-R11 | 项目编号必须由自动化阻止重复、改号、漏登记与序列回退 | baseline-aware CI validator 对违规 PR fail closed |
+| FPG-R12 | 新项目创建流程必须先读 registry 并在同一变更原子分配 Project ID | AGENTS/Skill/lifecycle/standard 全部使用同一 allocation contract |
 
 ## Non-functional requirements
 
@@ -18,6 +23,9 @@
 - 不在项目文件中保存 token、密码、签名材料或其他 secret。
 - 文档要求必须与项目风险相称；不适用项使用显式 N/A，而不是空文件。
 - 工程事实必须由 GitHub/CI/release/deployment 系统验证，不能仅依赖文档自报。
+- Project ID 是 surrogate identity，不编码 mutable business meaning（团队、产品名、日期、阶段）。
+- 已分配 Project ID 不得因 rename/archive/split/merge/cancel 被回收或重新编号。
+- 并发创建项目时对 `projects/PORTFOLIO.json` 的 merge conflict 是预期的 allocation serialization，不得绕过。
 
 ## FPG-002 success metrics
 
@@ -26,3 +34,11 @@
 - Fabushi governance Skill 与 lifecycle/reference 与同一标准一致。
 - `projects/fabushi-project-governance/` 本身升级到完整标准。
 - PR required `CI result` 成功并经受保护合并流程进入 `main`。
+
+## FPG-004 success metrics
+
+- 现有 5 个 canonical project 按 first formal main commit 确定性回填 `FAB-P0001`–`FAB-P0005`。
+- `projects/PORTFOLIO.json` 的 `next_sequence` 为 6，且 validator 验证连续、唯一、folder parity。
+- 旧项目 ID 全部保留在 `legacy_project_ids`，原任务 namespace 不被改写。
+- PR 上 Project portfolio governance workflow 成功。
+- 编号治理规则经保护合并后可从 canonical `main` 复核。

--- a/projects/fabushi-project-governance/docs/03-架构与实现策略.md
+++ b/projects/fabushi-project-governance/docs/03-架构与实现策略.md
@@ -2,46 +2,67 @@
 
 ## Current state
 
-Fabushi 已有 root `AGENTS.md`、`.agent/skills/fabushi-project-governance/` 和 `projects/`，但初始项目目录是最小脚手架，Task Orchestration 尚未定义统一的 GitHub enterprise project-folder contract。
+Fabushi 已有 root `AGENTS.md`、`.agent/skills/fabushi-project-governance/` 和 `projects/`，并已完成 enterprise project-folder standard。现有项目历史上仍存在 heterogeneous project identity（如 `FPG`, `MSR`, `FABUSHI-TELEGRAM-FUSION`），这些值适合作为 mnemonic namespace，但不足以承担跨项目永久身份。
 
 ## Target state
 
 建立一套一致的治理控制面：
 
-`User/source -> Project routing -> Enterprise project folder -> Atomic task -> Protected PR/CI/merge -> Evidence -> Project closure -> External control-view sync`
+`User/source -> Project routing -> Portfolio ID allocation -> Enterprise project folder -> Atomic task -> Protected PR/CI/merge -> Evidence -> Project closure -> External control-view sync`
 
 ## Components
 
 - **Root `AGENTS.md`**: repository-wide mandatory gate.
 - **Fabushi governance Skill**: lifecycle rules and reusable project standard.
 - **Task Orchestration Skill**: cross-system intake/control workflow; repository work遵守同一 project-folder standard.
+- **`projects/PORTFOLIO.json`**: canonical machine-readable portfolio identity registry and allocation high-water mark.
+- **`projects/PROJECT_ID_POLICY.md`**: Project ID lifecycle/allocation policy.
+- **`projects/<slug>/PROJECT.yaml`**: project-local mirror of registered identity.
 - **`projects/<slug>/`**: durable specification, execution history, acceptance, ADR, evidence, runbook source.
+- **`scripts/check-project-portfolio.py` + GitHub Actions**: fail-closed portfolio identity guardrail.
 - **GitHub/CI/release/deploy systems**: implementation fact authority.
 - **Sheets/Drive/Gmail/Calendar**: portfolio/control, external spec/mirror, intake/reporting, schedule roles.
 
 ## Identity and traceability
 
-Use stable Project ID, Stage ID, Task ID, Requirement ID, Milestone ID, Risk ID, ADR ID across repository project records and external control views. Do not create parallel ID systems.
+Identity is deliberately layered:
 
-## Lifecycle
+- `project_id`: immutable cross-project portfolio identity (`FAB-P0001`).
+- `project_key`: stable mnemonic namespace (`TFI`, `FPG`, `FCM`, `GBF`, `MSR`).
+- `legacy_project_ids`: historical aliases that remain queryable and never get reassigned.
+- Stage ID / Task ID / Requirement ID / Milestone ID / Risk ID / ADR ID: scoped identifiers using the project key when human-readable namespacing is useful.
+
+Do not use task IDs or mnemonic project keys as a substitute for the portfolio Project ID in cross-project portfolio views.
+
+## Allocation flow
+
+1. Read repository agent instructions and canonical `projects/PORTFOLIO.json` from `main`.
+2. Search `projects/` and reuse a matching project when one exists.
+3. If the objective is genuinely independent, read `next_sequence` and allocate exactly `FAB-P%04d` for that value.
+4. In the same change, append the registry entry, increment `next_sequence`, and create the project folder/`PROJECT.yaml` with matching `project_id` and `project_key`.
+5. If another project wins a concurrent merge and consumes the sequence, re-read `main`, resolve the registry conflict, and allocate the new next value.
+6. Never delete/reassign prior registry entries; change lifecycle status instead.
+
+## Task lifecycle
 
 1. Read repository agent instructions.
-2. Search `projects/`.
-3. Reuse existing project or create enterprise scaffold.
+2. Search `projects/` and portfolio registry.
+3. Reuse existing project or allocate a new portfolio ID + create enterprise scaffold.
 4. Persist original source and normalized requirements.
 5. Create atomic task/acceptance/evidence plan.
 6. Implement in a protected branch/PR flow.
-7. Run objective checks.
+7. Run objective checks, including the portfolio validator when governance/project metadata changes.
 8. Update project records in the same change stream when possible.
 9. Merge through required branch protection/merge queue.
 10. Verify canonical `main`, then close/synchronize task state.
 
 ## Tradeoffs
 
-- More files than the old minimal scaffold, but each file has a defined management/engineering purpose.
-- To avoid ceremony, mandatory files may be explicit N/A with reason/owner/revisit trigger.
+- More explicit identity fields than the historical one-string model, but cross-project identity no longer depends on mutable names or internal task namespaces.
+- Monotonic numeric IDs are intentionally non-semantic; project meaning lives in name/key/slug, allowing the ID to survive organizational/product changes.
+- Concurrent project creation may cause a registry merge conflict. This is desired serialization, not a defect.
 - Repository project folders remain detailed; external Sheets should stay normalized and link to project records rather than duplicating specs.
 
 ## Migration strategy
 
-Existing projects are not automatically rewritten in one bulk migration. When an existing project is touched for substantive work or governance standardization, audit it against the current standard and add missing mandatory files as part of that project's change stream.
+For the FPG-004 migration, all currently canonical project folders are backfilled together using the timestamp of their first formal project-folder commit on `main`. Historical IDs are preserved as aliases; historical PRs, commits, requirement IDs, and task IDs are not rewritten. After merge, new allocations are append-only from the registry high-water mark.

--- a/projects/fabushi-project-governance/evidence/FPG-004/README.md
+++ b/projects/fabushi-project-governance/evidence/FPG-004/README.md
@@ -1,0 +1,40 @@
+# FPG-004 Evidence Index
+
+Status: in-progress
+
+## Source and decision evidence
+
+- Source requirement: `projects/fabushi-project-governance/source/2026-08-22-FPG-004-global-project-identifiers.md`
+- Task record: `projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md`
+- ADR: `projects/fabushi-project-governance/decisions/ADR-0003-global-portfolio-project-identifiers.md`
+
+## Historical ordering evidence
+
+Initial numbering is derived from the first formal project-folder commits on canonical `main`:
+
+| Project ID | First formal project commit | PR |
+|---|---|---|
+| FAB-P0001 | `99cd4b227a34b49fc04c3265c1dfdee585344160` | #1975 |
+| FAB-P0002 | `eaf273dafc140619b06b46a4d7d234997acde05d` | #1976 |
+| FAB-P0003 | `ac94b40d4a05a0211146c2bb5904aa936a7bc928` | #1978 |
+| FAB-P0004 | `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c` | #1982 |
+| FAB-P0005 | `88db63c328c3cba39971f3942509cb0b582502bc` | #1989 |
+
+## Implementation evidence
+
+- Registry: `projects/PORTFOLIO.json`
+- Policy: `projects/PROJECT_ID_POLICY.md`
+- Human portfolio index: `projects/README.md`
+- Validator: `scripts/check-project-portfolio.py`
+- CI gate: `.github/workflows/project-portfolio-governance.yml`
+- Project metadata: all current `projects/*/PROJECT.yaml` files.
+
+## Pending evidence before closure
+
+- Validator workflow success on PR head.
+- Repository required CI success.
+- PR number/review/merge evidence.
+- Protected merge / merge queue evidence when applicable.
+- Canonical `main` re-fetch showing registry, all project IDs, governance instructions, and CI validator after merge.
+
+Do not mark FPG-004 passed until all pending evidence exists.

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -13,7 +13,15 @@
 | FPG-002.7 | GitHub PR/required CI/protected merge | yes | `CI result` success 且按仓库保护流程合并 | PR #1980 / CI 32556780549 / merge e77e11d4 | passed |
 | FPG-002.8 | Canonical `main` verification and closure | yes | main 上关键控制文件和项目目录验证后关闭 FPG-002 | post-merge fetch + closure PR | passed |
 | FPG-003 | 评估 CI 项目记录 guardrail | no | 有足够误用证据后决定是否自动化 enforcement | ADR/CI prototype | not-started |
+| FPG-004 | 建立跨项目全局不可变 Project ID 体系 | yes | FPG-004.1–FPG-004.7 全部通过 | FPG-004 task/evidence | in-progress |
+| FPG-004.1 | 定义 `FAB-P0001` 单调不复用编号政策与 ADR | yes | policy + ADR-0003 明确 ID/key/legacy alias 生命周期 | file review | implemented |
+| FPG-004.2 | 建立 `projects/PORTFOLIO.json` 与项目总览 | yes | 5 个 canonical project 全部登记，next_sequence=6 | validator | implemented |
+| FPG-004.3 | 回填全部 canonical `PROJECT.yaml` | yes | 5 个项目均有唯一 `project_id`、`project_key`、slug/path 一致 | validator | implemented |
+| FPG-004.4 | 建立自动 Project ID validator | yes | 校验格式、唯一性、连续性、folder parity、base immutability | `scripts/check-project-portfolio.py` | implemented |
+| FPG-004.5 | 将编号流程写入 AGENTS/governance Skill/lifecycle/standard | yes | 新项目必须先读取 registry 并原子分配 next_sequence | main file review | in-progress |
+| FPG-004.6 | GitHub Actions portfolio governance gate | yes | PR 上 validator workflow success | Actions evidence | pending |
+| FPG-004.7 | Protected merge + canonical main verification | yes | 合并后 registry、5 项目 metadata、控制规则均可从 main 验证 | PR/merge/main fetch | pending |
 
 ## Status rule
 
-`passed` 只用于 objective acceptance evidence 已存在的原子任务。后续治理改动继续遵守同一规则。
+`passed` 只用于 objective acceptance evidence 已存在的原子任务。`implemented` 仅表示 branch 上实现已存在但最终 CI/merge/main gate 尚未完成。后续治理改动继续遵守同一规则。

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -18,7 +18,7 @@
 | FPG-004.2 | 建立 `projects/PORTFOLIO.json` 与项目总览 | yes | 5 个 canonical project 全部登记，next_sequence=6 | validator | implemented |
 | FPG-004.3 | 回填全部 canonical `PROJECT.yaml` | yes | 5 个项目均有唯一 `project_id`、`project_key`、slug/path 一致 | validator | implemented |
 | FPG-004.4 | 建立自动 Project ID validator | yes | 校验格式、唯一性、连续性、folder parity、base immutability | `scripts/check-project-portfolio.py` | implemented |
-| FPG-004.5 | 将编号流程写入 AGENTS/governance Skill/lifecycle/standard | yes | 新项目必须先读取 registry 并原子分配 next_sequence | main file review | in-progress |
+| FPG-004.5 | 将编号流程写入 AGENTS/governance Skill/lifecycle/standard | yes | 新项目必须先读取 registry 并原子分配 next_sequence | branch file review | implemented |
 | FPG-004.6 | GitHub Actions portfolio governance gate | yes | PR 上 validator workflow success | Actions evidence | pending |
 | FPG-004.7 | Protected merge + canonical main verification | yes | 合并后 registry、5 项目 metadata、控制规则均可从 main 验证 | PR/merge/main fetch | pending |
 

--- a/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
@@ -9,15 +9,18 @@
 | FPG-R05 GitHub 项目目录/live engineering facts 为工程主基线 | SOURCE_OF_TRUTH + AGENTS + Skills | main verification | passed |
 | FPG-R06 Task Orchestration 与 GitHub 使用稳定 IDs | Task Orchestration SKILL/reference + governance Skill | Skill validator/package evidence | passed |
 | FPG-R07 无聊天上下文可重建项目 | enterprise root/docs/management/ADR/evidence/runbook set | main project-folder audit | passed |
+| FPG-R08 每个项目有全局唯一且不可变的 Portfolio Project ID | `projects/PORTFOLIO.json` + all `PROJECT.yaml` + ADR-0003 | FPG-004 registry/metadata review | implemented |
+| FPG-R09 新项目 ID 单调分配且永不复用 | `FAB-P%04d`, next_sequence high-water mark, archived IDs retained | policy + validator | implemented |
+| FPG-R10 Project ID 与 Project Key/Task ID 分层 | `project_id` + `project_key` + `legacy_project_ids` schema | 5 project metadata files | implemented |
+| FPG-R11 编号规则自动阻止重复/改号/漏登记 | baseline-aware portfolio validator in GitHub Actions | FPG-004 workflow run | pending |
+| FPG-R12 编号流程进入仓库 Agent/Skill/lifecycle 控制面 | AGENTS + governance Skill + project standard + task lifecycle | PR/main file review | in-progress |
 | Task Orchestration Skill validator | `quick_validate.py` | `Skill is valid!` | passed |
 | Task Orchestration Skill package | `package_skill.py` | `skill.zip`, 16128 bytes, SHA-256 `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61` | passed |
 | Root AGENTS enterprise scaffold | post-merge file review | main `AGENTS.md` | passed |
 | Governance Skill/reference/lifecycle alignment | post-merge file review | main `.agent/skills/fabushi-project-governance/` | passed |
 | Governance project mandatory files | project-folder audit | main FPG-002 audit | passed |
-| GitHub required check | `CI result` | Actions run `32556780549` | passed |
-| Protected merge / merge queue | repository merge policy | PR #1980 merged `e77e11d4cb4e96e59ae35859cc159874bb93180d` | passed |
-| Canonical `main` verification | fetch key files after merge | main AGENTS/Skill/audit | passed |
+| FPG-004 protected merge / canonical verification | repository merge process + post-merge fetch | PR/CI/merge/main evidence | pending |
 
 ## External installation state
 
-The updated Task Orchestration `skill.zip` is validated and packaged. Installation/activation into the user's current ChatGPT Skill library remains an external action and is not falsely represented as a repository acceptance failure or as already installed.
+The updated Task Orchestration `skill.zip` from FPG-002 is validated and packaged. Installation/activation into the user's current ChatGPT Skill library remains an external action and is not falsely represented as a repository acceptance failure or as already installed.

--- a/projects/fabushi-project-governance/management/05-状态报告.md
+++ b/projects/fabushi-project-governance/management/05-状态报告.md
@@ -71,3 +71,15 @@
 - Acceptance: FPG-002 10 条验收全部通过；Task Orchestration package 已验证/打包但未虚假声明已安装。
 - Blocker: none for FPG-002. External Skill installation remains open action FPG-I05.
 - Next: adoption/measurement；是否增加自动 project-record guardrail 由 FPG-003 基于真实误用证据决定。
+
+## 2026-08-22 — FPG-004 Round 1
+
+- Work: 将用户“每个项目之间的编号”需求归入现有 `projects/fabushi-project-governance/`，创建 `FPG-004` task/source record。
+- Finding: canonical `main` 当前有 5 个正式项目，且现有 `project_id` 形式不统一；Git history 提供了可审计的 first formal project-folder merge 顺序。
+- Decision: 采用 immutable global `project_id=FAB-Pxxxx` + mnemonic `project_key` + `legacy_project_ids` 的两层身份模型，并由 ADR-0003 固化。
+- Work: 建立 `projects/PORTFOLIO.json`、`projects/PROJECT_ID_POLICY.md`、`projects/README.md`，初始分配 FAB-P0001–FAB-P0005，next_sequence=6。
+- Work: 回填 Telegram/FPG/FCM/Grok/Mahayana 五个 `PROJECT.yaml`；旧 ID 保留为 alias。
+- Work: 新增 stdlib-only `scripts/check-project-portfolio.py` 和 GitHub Actions `Project portfolio governance`，校验唯一性、连续性、folder parity 与 base-branch immutability。
+- Acceptance: branch implementation present; Agent/Skill lifecycle alignment, PR CI, protected merge and canonical main verification pending.
+- Blocker: none.
+- Next: 将 allocation contract 写入 AGENTS/governance Skill/reference/lifecycle，创建 PR 并以 Actions 结果验收。

--- a/projects/fabushi-project-governance/management/07-变更日志.md
+++ b/projects/fabushi-project-governance/management/07-变更日志.md
@@ -24,6 +24,17 @@
 - Task Orchestration Skill validator/package 已通过；生成 `skill.zip` SHA-256 `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61`。
 - 明确 Skill package creation 与实际安装/激活分离，禁止把“已打包”误记为“已安装”。
 - PR #1980 required `CI result` 成功并通过 merge queue 合并到 `main`，合并提交 `e77e11d4cb4e96e59ae35859cc159874bb93180d`。
-- 合并后已验证 canonical `main` 的 root `AGENTS.md`、governance Skill 和 enterprise project-folder audit。
+- 合并后已验证 canonical `main` 的 root `AGENTS.md`、governance Skill 和 project-folder audit。
 - FPG-002 标记 passed，项目进入 adoption-and-measurement 阶段。
 - PR #1980 暴露的 `.agent/skills/**` CI 分类低效已分离到 CI/CD 项目 FCM-003，不与本治理任务耦合。
+
+## 2026-08-22 — FPG-004 global project identifiers
+
+- 新增仓库级 machine registry `projects/PORTFOLIO.json`、人工索引 `projects/README.md` 与政策 `projects/PROJECT_ID_POLICY.md`。
+- 采用 `project_id=FAB-Pxxxx` + `project_key` + `legacy_project_ids` 两层身份模型，ADR-0003 固化“单调递增、永久不复用、surrogate ID 不编码可变业务语义”。
+- 按 first formal project-folder commit on canonical `main` 确定性回填：Telegram=`FAB-P0001`、Project Governance=`FAB-P0002`、CI/CD Governance=`FAB-P0003`、Grok Bot=`FAB-P0004`、Mahayana=`FAB-P0005`；next sequence=`FAB-P0006`。
+- 全部 5 个 canonical `PROJECT.yaml` 改为统一 global Project ID，并保留历史 project identifiers 作为 aliases，不重写历史 PR/commit/task IDs。
+- 新增 `scripts/check-project-portfolio.py`，校验 Project ID/key/slug/path 唯一性、连续 sequence、registry/folder parity、`next_sequence=max+1` 与 base-branch immutability。
+- 新增 `.github/workflows/project-portfolio-governance.yml`，在 project/governance changes 上 fail closed 验证编号体系。
+- 根 `AGENTS.md`、governance Skill、project-folder standard、task lifecycle 统一要求：创建独立项目先读取 canonical `main` registry，在同一 PR 原子领取 next sequence + 更新 registry + 创建 PROJECT.yaml；并发冲突必须 re-read/reallocate，禁止强行复用。
+- FPG-004 当前保持 `in-progress`，等待 PR Actions、protected merge 与 canonical `main` 验证后才能标记 passed。

--- a/projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md
@@ -1,0 +1,92 @@
+# FPG-004 — Global Project Identifiers
+
+- Task ID: `FPG-004`
+- Project: Fabushi Project Governance
+- Status: `in-progress`
+- Started: 2026-08-22T16:06:00+08:00
+- Updated: 2026-08-22T16:06:00+08:00
+- Completed: pending
+- Branch: `governance/global-project-identifiers`
+- Commit: pending
+- PR: pending
+
+## Objective
+
+Introduce a portfolio-wide immutable Project ID system for all Fabushi repository projects, backfill current canonical projects, and enforce future allocation through repository governance and CI.
+
+## Source requirements
+
+- `source/2026-08-22-FPG-004-global-project-identifiers.md`
+- User requirement: implement numbering **between projects** using enterprise/large-company governance practices.
+
+## In scope
+
+- Define canonical Project ID format and lifecycle.
+- Create authoritative machine-readable portfolio registry and human index/policy.
+- Backfill every canonical `projects/*/PROJECT.yaml` on `main` with a global Project ID and stable project key/legacy aliases.
+- Preserve existing task namespaces and historical identifiers.
+- Update repository project standard, governance Skill/lifecycle, and root Agent instructions.
+- Add CI validation for format, uniqueness, registry parity, monotonic allocation, and immutability.
+- Record ADR, WBS, acceptance, status, changelog, and evidence.
+
+## Out of scope
+
+- Renaming project directories solely to match numeric IDs.
+- Rewriting historical task IDs, PR numbers, commit messages, or document history.
+- Creating a separate external portfolio database as the engineering source of truth.
+
+## Deterministic migration ordering
+
+Existing projects are ordered by the first formal project-folder commit merged to canonical `main`:
+
+1. Telegram project — PR #1975 / commit `99cd4b227a34b49fc04c3265c1dfdee585344160`.
+2. Project Governance — PR #1976 / commit `eaf273dafc140619b06b46a4d7d234997acde05d`.
+3. CI/CD & Merge Governance — PR #1978 / commit `ac94b40d4a05a0211146c2bb5904aa936a7bc928`.
+4. Grok Bot fusion — PR #1982 / commit `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c`.
+5. Mahayana sovereign runtime — PR #1989 / commit `88db63c328c3cba39971f3942509cb0b582502bc`.
+
+## Planned allocation
+
+| Portfolio Project ID | Project Key | Slug |
+|---|---|---|
+| FAB-P0001 | TFI | telegram-fabushi-integration |
+| FAB-P0002 | FPG | fabushi-project-governance |
+| FAB-P0003 | FCM | fabushi-cicd-merge-governance |
+| FAB-P0004 | GBF | grok-bot-fabushi-integration |
+| FAB-P0005 | MSR | mahayana-sovereign-runtime |
+
+Next allocatable ID after migration: `FAB-P0006`.
+
+## Acceptance criteria
+
+1. All current canonical project folders have one unique `project_id` matching `^FAB-P[0-9]{4}$`.
+2. Existing mnemonic IDs remain available as `project_key` and/or `legacy_project_ids`.
+3. `projects/PORTFOLIO.json` is the authoritative allocation registry and its `next_sequence` equals max allocated sequence + 1.
+4. Registry entries exactly match canonical project folders and each `PROJECT.yaml` identity/path.
+5. CI rejects duplicate IDs/keys/slugs, malformed IDs, gaps/reuse, registry/folder divergence, and mutation/removal of already-registered IDs when compared with the target branch.
+6. Root `AGENTS.md`, governance Skill, project-folder standard, and task lifecycle describe the same allocation process.
+7. PR CI passes, protected merge completes, and canonical `main` is re-fetched before closure.
+
+## Verification
+
+- Static registry validator in GitHub Actions.
+- Review all `PROJECT.yaml` files and registry entries.
+- PR required checks / merge queue.
+- Post-merge `main` verification.
+
+## Evidence plan
+
+- `projects/fabushi-project-governance/evidence/FPG-004/README.md`
+- Branch commit SHAs.
+- PR number and review/check evidence.
+- Workflow run/job for portfolio validator.
+- Post-merge main file reads.
+
+## Risks
+
+- Historical references may call old values “project_id”; mitigate by preserving aliases and documenting `project_key` versus canonical portfolio `project_id`.
+- Concurrent new project creation can race for the same next sequence; registry merge conflicts are intentional serialization and must be resolved before merge.
+
+## Next action
+
+Implement registry/policy, backfill all canonical project metadata, add validator + CI, align repository governance instructions, then run GitHub Actions and close only after protected merge/main verification.

--- a/projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md
@@ -1,14 +1,16 @@
 # FPG-004 — Global Project Identifiers
 
+- Portfolio Project ID: `FAB-P0002`
+- Project Key: `FPG`
 - Task ID: `FPG-004`
 - Project: Fabushi Project Governance
 - Status: `in-progress`
 - Started: 2026-08-22T16:06:00+08:00
-- Updated: 2026-08-22T16:06:00+08:00
+- Updated: 2026-08-22T16:18:00+08:00
 - Completed: pending
 - Branch: `governance/global-project-identifiers`
-- Commit: pending
-- PR: pending
+- Implementation head before PR evidence update: `9d11de5d90b9e284904071845bd4c391f2785a2b`
+- PR: `#1996`
 
 ## Objective
 
@@ -45,7 +47,7 @@ Existing projects are ordered by the first formal project-folder commit merged t
 4. Grok Bot fusion — PR #1982 / commit `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c`.
 5. Mahayana sovereign runtime — PR #1989 / commit `88db63c328c3cba39971f3942509cb0b582502bc`.
 
-## Planned allocation
+## Allocation
 
 | Portfolio Project ID | Project Key | Slug |
 |---|---|---|
@@ -56,6 +58,15 @@ Existing projects are ordered by the first formal project-folder commit merged t
 | FAB-P0005 | MSR | mahayana-sovereign-runtime |
 
 Next allocatable ID after migration: `FAB-P0006`.
+
+## Implementation summary
+
+- Added authoritative `projects/PORTFOLIO.json`, human index, and Project ID policy.
+- Added ADR-0003 for immutable global Project IDs and stable Project Keys.
+- Backfilled all five canonical project `PROJECT.yaml` files while retaining historical aliases.
+- Added stdlib-only `scripts/check-project-portfolio.py` for format/uniqueness/sequence/folder-parity/base-immutability checks.
+- Added `Project portfolio governance` GitHub Actions workflow.
+- Updated root `AGENTS.md`, governance Skill, project-folder standard, task lifecycle, requirements, architecture, WBS, acceptance, status, changelog, evidence, and source-of-truth records.
 
 ## Acceptance criteria
 
@@ -71,22 +82,25 @@ Next allocatable ID after migration: `FAB-P0006`.
 
 - Static registry validator in GitHub Actions.
 - Review all `PROJECT.yaml` files and registry entries.
-- PR required checks / merge queue.
+- PR #1996 required checks / merge queue.
 - Post-merge `main` verification.
 
-## Evidence plan
+## Evidence
 
 - `projects/fabushi-project-governance/evidence/FPG-004/README.md`
-- Branch commit SHAs.
-- PR number and review/check evidence.
-- Workflow run/job for portfolio validator.
-- Post-merge main file reads.
+- Implementation branch head before PR evidence update: `9d11de5d90b9e284904071845bd4c391f2785a2b`.
+- PR #1996.
+- CI/run/merge/main evidence: pending.
 
 ## Risks
 
-- Historical references may call old values “project_id”; mitigate by preserving aliases and documenting `project_key` versus canonical portfolio `project_id`.
+- Historical references may call old values “project_id”; mitigated by preserving aliases and documenting `project_key` versus canonical portfolio `project_id`.
 - Concurrent new project creation can race for the same next sequence; registry merge conflicts are intentional serialization and must be resolved before merge.
+
+## Blockers
+
+- PR #1996 CI and merge/main verification are pending.
 
 ## Next action
 
-Implement registry/policy, backfill all canonical project metadata, add validator + CI, align repository governance instructions, then run GitHub Actions and close only after protected merge/main verification.
+Wait for GitHub Actions on the current PR head, fix any portfolio/governance failure without weakening the checks, merge through the normal protected process, then re-fetch canonical `main` and close FPG-004 only after evidence is complete.

--- a/projects/fabushi-project-governance/source/2026-08-22-FPG-004-global-project-identifiers.md
+++ b/projects/fabushi-project-governance/source/2026-08-22-FPG-004-global-project-identifiers.md
@@ -1,0 +1,29 @@
+# FPG-004 Source Requirement — Global Project Identifiers
+
+Date: 2026-08-22
+Source: explicit user requirement in ChatGPT
+
+## Original requirement
+
+“开始落地项目编号，按照大厂行业规范标准去做”
+
+The request follows the clarification that Fabushi needs a numbering scheme **between projects**, not only task IDs inside one project.
+
+## Normalized requirement
+
+Fabushi SHALL establish a repository-wide portfolio identity system with these properties:
+
+1. Every canonical project under `projects/<slug>/` has one globally unique, immutable portfolio Project ID.
+2. Portfolio IDs use the Fabushi namespace and a monotonic sequence: `FAB-P0001`, `FAB-P0002`, ... .
+3. IDs are never reused, recycled, or reassigned after project rename, archive, merge, split, cancellation, or deletion request.
+4. Existing project/task mnemonic identifiers remain available as `project_key` / legacy aliases so historical PRs, WBS items, and task IDs are not broken.
+5. A machine-readable repository registry is authoritative for allocation and contains the high-water mark / next sequence.
+6. Existing canonical projects are backfilled deterministically from the timestamp of their first formal project-folder commit on GitHub `main`.
+7. New projects allocate exactly the next registry sequence in the same change that creates the project folder.
+8. CI validates uniqueness, format, registry/folder parity, path/key consistency, monotonic allocation, and immutability against the target branch.
+9. Root `AGENTS.md` and the Fabushi project-governance Skill/lifecycle must require registry lookup/allocation before creating a new project.
+10. GitHub `main` plus the portfolio registry and each project `PROJECT.yaml` remain authoritative; external control planes mirror the same IDs.
+
+## Acceptance intent
+
+The migration is complete only when all existing canonical projects have assigned IDs, the registry and policy exist, automated validation passes, governance instructions are aligned, the change is merged through normal repository gates, and canonical `main` is re-verified.

--- a/projects/grok-bot-fabushi-integration/PROJECT.yaml
+++ b/projects/grok-bot-fabushi-integration/PROJECT.yaml
@@ -1,4 +1,7 @@
-project_id: FABUSHI-GROK-BOT-FUSION
+project_id: FAB-P0004
+project_key: GBF
+legacy_project_ids:
+  - FABUSHI-GROK-BOT-FUSION
 name: Grok Bot -> Fabushi 全量能力与源码融合
 slug: grok-bot-fabushi-integration
 status: active

--- a/projects/mahayana-sovereign-runtime/PROJECT.yaml
+++ b/projects/mahayana-sovereign-runtime/PROJECT.yaml
@@ -1,4 +1,7 @@
-project_id: MSR
+project_id: FAB-P0005
+project_key: MSR
+legacy_project_ids:
+  - MSR
 name: Mahayana Sovereign Runtime
 slug: mahayana-sovereign-runtime
 status: active

--- a/projects/telegram-fabushi-integration/PROJECT.yaml
+++ b/projects/telegram-fabushi-integration/PROJECT.yaml
@@ -1,10 +1,15 @@
-project_id: FABUSHI-TELEGRAM-FUSION
+project_id: FAB-P0001
+project_key: TFI
+legacy_project_ids:
+  - FABUSHI-TELEGRAM-FUSION
 name: Fabushi Telegram 全量融合
+slug: telegram-fabushi-integration
 version: v1.1
 baseline_date: 2026-08-22
 status: IMPLEMENTATION_ACTIVE
 current_stage: M1
 source_of_truth: source/完整telegram融合进fabushi.txt
+authoritative_path: projects/telegram-fabushi-integration
 architecture:
   core_language: Rust
   canonical_messaging_core: native/mahayana-messaging

--- a/scripts/check-project-portfolio.py
+++ b/scripts/check-project-portfolio.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Validate Fabushi portfolio Project IDs without third-party dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECTS_ROOT = ROOT / "projects"
+REGISTRY_PATH = PROJECTS_ROOT / "PORTFOLIO.json"
+ID_RE = re.compile(r"^FAB-P([0-9]{4})$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+KEY_RE = re.compile(r"^[A-Z][A-Z0-9]{1,11}$")
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing required registry: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        fail(f"registry root must be an object: {path}")
+    return data
+
+
+def top_level_yaml_scalars(path: Path) -> dict[str, str]:
+    """Read simple top-level scalar fields from PROJECT.yaml.
+
+    Fabushi PROJECT.yaml files contain nested YAML, but portfolio validation only needs
+    top-level identity scalars. Keeping this parser intentionally narrow avoids adding a
+    PyYAML dependency to a repository-governance gate.
+    """
+
+    result: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing project metadata: {path}") from exc
+
+    for raw in lines:
+        if not raw or raw[0].isspace() or raw.lstrip().startswith("#") or ":" not in raw:
+            continue
+        key, value = raw.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not value or value in {"|", ">"}:
+            continue
+        if value.startswith(("'", '"')) and value.endswith(("'", '"')) and len(value) >= 2:
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def validate_registry(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    if registry.get("schema_version") != 1:
+        fail("PORTFOLIO.json schema_version must be 1")
+    if registry.get("portfolio") != "FAB":
+        fail("PORTFOLIO.json portfolio must be FAB")
+    if registry.get("allocation_policy") != "monotonic-no-reuse":
+        fail("allocation_policy must be monotonic-no-reuse")
+
+    projects = registry.get("projects")
+    if not isinstance(projects, list) or not projects:
+        fail("registry projects must be a non-empty array")
+
+    seen_ids: set[str] = set()
+    seen_keys: set[str] = set()
+    seen_slugs: set[str] = set()
+    seen_paths: set[str] = set()
+    sequences: list[int] = []
+
+    for index, item in enumerate(projects, start=1):
+        if not isinstance(item, dict):
+            fail(f"projects[{index}] must be an object")
+        project_id = item.get("project_id")
+        project_key = item.get("project_key")
+        slug = item.get("slug")
+        path = item.get("authoritative_path")
+        first_commit = item.get("first_canonical_main_commit")
+
+        if not isinstance(project_id, str):
+            fail(f"projects[{index}].project_id must be a string")
+        match = ID_RE.fullmatch(project_id)
+        if not match:
+            fail(f"malformed Project ID {project_id!r}; expected FAB-P0001 style")
+        sequence = int(match.group(1))
+        if sequence == 0:
+            fail("FAB-P0000 is reserved and may not be allocated")
+        sequences.append(sequence)
+
+        if not isinstance(project_key, str) or not KEY_RE.fullmatch(project_key):
+            fail(f"invalid project_key for {project_id}: {project_key!r}")
+        if not isinstance(slug, str) or not slug or slug.lower() != slug:
+            fail(f"invalid lowercase project slug for {project_id}: {slug!r}")
+        if not isinstance(path, str) or path != f"projects/{slug}":
+            fail(f"authoritative_path mismatch for {project_id}: {path!r}")
+        if not isinstance(first_commit, str) or not SHA_RE.fullmatch(first_commit):
+            fail(f"first_canonical_main_commit must be a 40-char lowercase SHA for {project_id}")
+
+        for value, seen, label in (
+            (project_id, seen_ids, "project_id"),
+            (project_key, seen_keys, "project_key"),
+            (slug, seen_slugs, "slug"),
+            (path, seen_paths, "authoritative_path"),
+        ):
+            if value in seen:
+                fail(f"duplicate {label}: {value}")
+            seen.add(value)
+
+        legacy_ids = item.get("legacy_project_ids", [])
+        if not isinstance(legacy_ids, list) or any(not isinstance(x, str) or not x for x in legacy_ids):
+            fail(f"legacy_project_ids must be an array of non-empty strings for {project_id}")
+
+    expected = list(range(1, len(projects) + 1))
+    if sorted(sequences) != expected:
+        fail(f"Project ID sequences must be contiguous and never removed: expected {expected}, got {sorted(sequences)}")
+
+    next_sequence = registry.get("next_sequence")
+    if not isinstance(next_sequence, int) or next_sequence != max(sequences) + 1:
+        fail(f"next_sequence must equal max allocated sequence + 1 ({max(sequences) + 1})")
+
+    return projects
+
+
+def validate_project_folders(projects: list[dict[str, Any]]) -> None:
+    actual_slugs = sorted(
+        path.name
+        for path in PROJECTS_ROOT.iterdir()
+        if path.is_dir() and (path / "PROJECT.yaml").is_file()
+    )
+    registry_slugs = sorted(str(project["slug"]) for project in projects)
+    if actual_slugs != registry_slugs:
+        fail(
+            "registry/project-folder mismatch:\n"
+            f"  registry={registry_slugs}\n"
+            f"  folders={actual_slugs}"
+        )
+
+    for project in projects:
+        slug = str(project["slug"])
+        metadata_path = PROJECTS_ROOT / slug / "PROJECT.yaml"
+        metadata = top_level_yaml_scalars(metadata_path)
+        expected = {
+            "project_id": str(project["project_id"]),
+            "project_key": str(project["project_key"]),
+            "slug": slug,
+            "authoritative_path": str(project["authoritative_path"]),
+        }
+        for key, value in expected.items():
+            actual = metadata.get(key)
+            if actual != value:
+                fail(f"{metadata_path}: {key}={actual!r}, expected {value!r}")
+
+
+def validate_immutability(current: dict[str, Any], baseline_path: Path | None) -> None:
+    if baseline_path is None or not baseline_path.exists() or baseline_path.stat().st_size == 0:
+        return
+
+    baseline = load_json(baseline_path)
+    baseline_projects = baseline.get("projects", [])
+    current_projects = current.get("projects", [])
+    if not isinstance(baseline_projects, list) or not isinstance(current_projects, list):
+        fail("baseline/current projects must be arrays")
+
+    current_by_id = {item.get("project_id"): item for item in current_projects if isinstance(item, dict)}
+    baseline_ids: set[str] = set()
+    for old in baseline_projects:
+        if not isinstance(old, dict):
+            continue
+        project_id = old.get("project_id")
+        if not isinstance(project_id, str):
+            continue
+        baseline_ids.add(project_id)
+        new = current_by_id.get(project_id)
+        if new is None:
+            fail(f"registered Project ID {project_id} was removed; IDs are permanent")
+        if new.get("project_key") != old.get("project_key"):
+            fail(f"project_key mutation is forbidden for {project_id}: {old.get('project_key')} -> {new.get('project_key')}")
+        if new.get("first_canonical_main_commit") != old.get("first_canonical_main_commit"):
+            fail(f"first_canonical_main_commit mutation is forbidden for {project_id}")
+        old_legacy = set(old.get("legacy_project_ids", []))
+        new_legacy = set(new.get("legacy_project_ids", []))
+        if not old_legacy.issubset(new_legacy):
+            fail(f"legacy aliases may not be removed for {project_id}")
+
+    baseline_next = baseline.get("next_sequence")
+    if isinstance(baseline_next, int):
+        new_ids = [
+            item.get("project_id")
+            for item in current_projects
+            if isinstance(item, dict) and item.get("project_id") not in baseline_ids
+        ]
+        new_sequences = sorted(
+            int(match.group(1))
+            for value in new_ids
+            if isinstance(value, str) and (match := ID_RE.fullmatch(value))
+        )
+        if new_sequences:
+            expected = list(range(baseline_next, baseline_next + len(new_sequences)))
+            if new_sequences != expected:
+                fail(f"new projects must allocate from baseline next_sequence {baseline_next}: expected {expected}, got {new_sequences}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", type=Path, default=None, help="Optional base-branch PORTFOLIO.json")
+    args = parser.parse_args()
+
+    try:
+        registry = load_json(REGISTRY_PATH)
+        projects = validate_registry(registry)
+        validate_project_folders(projects)
+        validate_immutability(registry, args.baseline)
+    except ValidationError as exc:
+        print(f"project portfolio validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"project portfolio validation passed: {len(projects)} projects, "
+        f"next={registry['project_id_format'] % registry['next_sequence']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objective
Implement enterprise-grade numbering **between Fabushi projects**, distinct from project-internal task IDs.

## Identity model
- immutable global `project_id`: `FAB-P0001`, `FAB-P0002`, ...
- stable mnemonic `project_key`: `TFI`, `FPG`, `FCM`, `GBF`, `MSR`
- historical identifiers preserved in `legacy_project_ids`
- IDs are monotonic and never reused after rename/archive/cancel/split/merge/supersession

## Initial deterministic allocation
Backfilled by each project's first formal project-folder commit on canonical `main`:
- `FAB-P0001` / `TFI` / Telegram — #1975
- `FAB-P0002` / `FPG` / Project Governance — #1976
- `FAB-P0003` / `FCM` / CI/CD & Merge Governance — #1978
- `FAB-P0004` / `GBF` / Grok Bot fusion — #1982
- `FAB-P0005` / `MSR` / Mahayana Sovereign Runtime — #1989
- next allocation: `FAB-P0006`

## Enforcement
- add authoritative `projects/PORTFOLIO.json`
- add `projects/PROJECT_ID_POLICY.md` and portfolio index
- backfill every canonical `PROJECT.yaml`
- add baseline-aware `scripts/check-project-portfolio.py`
- add `Project portfolio governance` GitHub Actions gate
- update root `AGENTS.md`, governance Skill, project-folder standard and task lifecycle so new projects must atomically allocate the live registry `next_sequence`
- concurrent project creation is serialized by the registry merge conflict and must re-read/reallocate from canonical `main`

## Project governance
Tracked as `FAB-P0002 / FPG-004` under `projects/fabushi-project-governance/`, with source requirement, ADR-0003, WBS, acceptance matrix, status/changelog and evidence index.

## Verification
No application builds/tests are run locally. GitHub Actions are authoritative. FPG-004 remains `in-progress` until the portfolio validator, repository gates, protected merge, and canonical `main` verification pass.