### PR TITLE
docs(governance): close FPG-004 global project IDs

### DIFF
--- a/projects/fabushi-project-governance/evidence/FPG-004/README.md
+++ b/projects/fabushi-project-governance/evidence/FPG-004/README.md
@@ -1,9 +1,12 @@
 # FPG-004 Evidence Index
 
-Status: in-progress
+Status: passed
 
 ## Source and decision evidence
 
+- Portfolio Project ID: `FAB-P0002`
+- Project Key: `FPG`
+- Task: `FPG-004`
 - Source requirement: `projects/fabushi-project-governance/source/2026-08-22-FPG-004-global-project-identifiers.md`
 - Task record: `projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md`
 - ADR: `projects/fabushi-project-governance/decisions/ADR-0003-global-portfolio-project-identifiers.md`
@@ -12,13 +15,13 @@ Status: in-progress
 
 Initial numbering is derived from the first formal project-folder commits on canonical `main`:
 
-| Project ID | First formal project commit | PR |
-|---|---|---|
-| FAB-P0001 | `99cd4b227a34b49fc04c3265c1dfdee585344160` | #1975 |
-| FAB-P0002 | `eaf273dafc140619b06b46a4d7d234997acde05d` | #1976 |
-| FAB-P0003 | `ac94b40d4a05a0211146c2bb5904aa936a7bc928` | #1978 |
-| FAB-P0004 | `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c` | #1982 |
-| FAB-P0005 | `88db63c328c3cba39971f3942509cb0b582502bc` | #1989 |
+| Project ID | Project Key | First formal project commit | PR |
+|---|---|---|---|
+| `FAB-P0001` | `TFI` | `99cd4b227a34b49fc04c3265c1dfdee585344160` | #1975 |
+| `FAB-P0002` | `FPG` | `eaf273dafc140619b06b46a4d7d234997acde05d` | #1976 |
+| `FAB-P0003` | `FCM` | `ac94b40d4a05a0211146c2bb5904aa936a7bc928` | #1978 |
+| `FAB-P0004` | `GBF` | `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c` | #1982 |
+| `FAB-P0005` | `MSR` | `88db63c328c3cba39971f3942509cb0b582502bc` | #1989 |
 
 ## Implementation evidence
 
@@ -28,13 +31,48 @@ Initial numbering is derived from the first formal project-folder commits on can
 - Validator: `scripts/check-project-portfolio.py`
 - CI gate: `.github/workflows/project-portfolio-governance.yml`
 - Project metadata: all current `projects/*/PROJECT.yaml` files.
+- Root enforcement: `AGENTS.md` global Project ID allocation gate.
+- Governance enforcement: `.agent/skills/fabushi-project-governance/SKILL.md` plus project-folder/task-lifecycle references.
 
-## Pending evidence before closure
+## Pull request and CI evidence
 
-- Validator workflow success on PR head.
-- Repository required CI success.
-- PR number/review/merge evidence.
-- Protected merge / merge queue evidence when applicable.
-- Canonical `main` re-fetch showing registry, all project IDs, governance instructions, and CI validator after merge.
+- Implementation PR: `#1996` — `feat(governance): establish immutable global project IDs`.
+- Final PR head used for the successful validation round: `a50dd46b2bedf152356c14ac195021ffc9443013`.
+- `Project portfolio governance` run `32561929188`:
+  - job `Validate immutable Project IDs` — success;
+  - checkout history — success;
+  - baseline registry materialization — success;
+  - registry/project metadata validation — success.
+- Repository `CI` run `32561929208` — success:
+  - Classify CI changes — success;
+  - Frontend checks — success;
+  - Worker checks — success;
+  - Electron Feature Host contract — success;
+  - MCP plugin contracts — success;
+  - Canonical architecture guardrails — success;
+  - final `CI result` — success.
+- Explicit automerge run `32561929220` — success.
+- A direct merge attempt after checks returned `Pull Request is in the merge queue`, proving the PR was routed through the protected merge queue rather than bypassing it.
+- PR #1996 merged at `2026-08-22T08:21:57Z`.
+- Canonical merge commit: `87462b14017b08f0f4dcd6f97fbea67b5c12d791`.
 
-Do not mark FPG-004 passed until all pending evidence exists.
+## Canonical `main` verification
+
+Post-merge reads from GitHub `main` confirmed:
+
+1. `projects/PORTFOLIO.json` contains exactly the five migrated canonical projects with unique `FAB-P0001`–`FAB-P0005` identities and `next_sequence=6`.
+2. `projects/telegram-fabushi-integration/PROJECT.yaml` = `FAB-P0001 / TFI`.
+3. `projects/fabushi-project-governance/PROJECT.yaml` = `FAB-P0002 / FPG`.
+4. `projects/fabushi-cicd-merge-governance/PROJECT.yaml` = `FAB-P0003 / FCM`.
+5. `projects/grok-bot-fabushi-integration/PROJECT.yaml` = `FAB-P0004 / GBF`.
+6. `projects/mahayana-sovereign-runtime/PROJECT.yaml` = `FAB-P0005 / MSR`.
+7. Root `AGENTS.md` requires every new independent project to re-read the live registry, allocate exactly the current `next_sequence`, update the registry, and create matching project metadata atomically.
+8. `.github/workflows/project-portfolio-governance.yml` is present on `main` and enforces the validator for relevant project/governance changes.
+
+## Acceptance result
+
+All FPG-004 required acceptance criteria passed. The portfolio identity system is implemented, automated, protected by CI/merge governance, and verified on canonical `main`.
+
+## Next allocation note
+
+`FAB-P0006` is the current next candidate according to the verified registry high-water mark. It is **not reserved**. A future genuinely independent project must re-read canonical `main` immediately before allocation and use whatever `next_sequence` is live at that time.

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -13,14 +13,14 @@
 | FPG-002.7 | GitHub PR/required CI/protected merge | yes | `CI result` success 且按仓库保护流程合并 | PR #1980 / CI 32556780549 / merge e77e11d4 | passed |
 | FPG-002.8 | Canonical `main` verification and closure | yes | main 上关键控制文件和项目目录验证后关闭 FPG-002 | post-merge fetch + closure PR | passed |
 | FPG-003 | 评估 CI 项目记录 guardrail | no | 有足够误用证据后决定是否自动化 enforcement | ADR/CI prototype | not-started |
-| FPG-004 | 建立跨项目全局不可变 Project ID 体系 | yes | FPG-004.1–FPG-004.7 全部通过 | FPG-004 task/evidence | in-progress |
-| FPG-004.1 | 定义 `FAB-P0001` 单调不复用编号政策与 ADR | yes | policy + ADR-0003 明确 ID/key/legacy alias 生命周期 | file review | implemented |
-| FPG-004.2 | 建立 `projects/PORTFOLIO.json` 与项目总览 | yes | 5 个 canonical project 全部登记，next_sequence=6 | validator | implemented |
-| FPG-004.3 | 回填全部 canonical `PROJECT.yaml` | yes | 5 个项目均有唯一 `project_id`、`project_key`、slug/path 一致 | validator | implemented |
-| FPG-004.4 | 建立自动 Project ID validator | yes | 校验格式、唯一性、连续性、folder parity、base immutability | `scripts/check-project-portfolio.py` | implemented |
-| FPG-004.5 | 将编号流程写入 AGENTS/governance Skill/lifecycle/standard | yes | 新项目必须先读取 registry 并原子分配 next_sequence | branch file review | implemented |
-| FPG-004.6 | GitHub Actions portfolio governance gate | yes | PR 上 validator workflow success | Actions evidence | pending |
-| FPG-004.7 | Protected merge + canonical main verification | yes | 合并后 registry、5 项目 metadata、控制规则均可从 main 验证 | PR/merge/main fetch | pending |
+| FPG-004 | 建立跨项目全局不可变 Project ID 体系 | yes | FPG-004.1–FPG-004.7 全部通过 | FPG-004 task/evidence | passed |
+| FPG-004.1 | 定义 `FAB-P0001` 单调不复用编号政策与 ADR | yes | policy + ADR-0003 明确 ID/key/legacy alias 生命周期 | main file review | passed |
+| FPG-004.2 | 建立 `projects/PORTFOLIO.json` 与项目总览 | yes | 5 个 canonical project 全部登记，next_sequence=6 | main registry + validator | passed |
+| FPG-004.3 | 回填全部 canonical `PROJECT.yaml` | yes | 5 个项目均有唯一 `project_id`、`project_key`、slug/path 一致 | main PROJECT.yaml reads + validator | passed |
+| FPG-004.4 | 建立自动 Project ID validator | yes | 校验格式、唯一性、连续性、folder parity、base immutability | workflow run 32561929188 | passed |
+| FPG-004.5 | 将编号流程写入 AGENTS/governance Skill/lifecycle/standard | yes | 新项目必须先读取 registry 并原子分配 next_sequence | canonical main file review | passed |
+| FPG-004.6 | GitHub Actions portfolio governance gate | yes | PR 上 validator workflow success | run 32561929188 | passed |
+| FPG-004.7 | Protected merge + canonical main verification | yes | 合并后 registry、5 项目 metadata、控制规则均可从 main 验证 | PR #1996 / merge 87462b14 / main fetch | passed |
 
 ## Status rule
 

--- a/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
@@ -9,17 +9,17 @@
 | FPG-R05 GitHub 项目目录/live engineering facts 为工程主基线 | SOURCE_OF_TRUTH + AGENTS + Skills | main verification | passed |
 | FPG-R06 Task Orchestration 与 GitHub 使用稳定 IDs | Task Orchestration SKILL/reference + governance Skill | Skill validator/package evidence | passed |
 | FPG-R07 无聊天上下文可重建项目 | enterprise root/docs/management/ADR/evidence/runbook set | main project-folder audit | passed |
-| FPG-R08 每个项目有全局唯一且不可变的 Portfolio Project ID | `projects/PORTFOLIO.json` + all `PROJECT.yaml` + ADR-0003 | FPG-004 registry/metadata review | implemented |
-| FPG-R09 新项目 ID 单调分配且永不复用 | `FAB-P%04d`, next_sequence high-water mark, archived IDs retained | policy + validator | implemented |
-| FPG-R10 Project ID 与 Project Key/Task ID 分层 | `project_id` + `project_key` + `legacy_project_ids` schema | 5 project metadata files | implemented |
-| FPG-R11 编号规则自动阻止重复/改号/漏登记 | baseline-aware portfolio validator in GitHub Actions | FPG-004 workflow run | pending |
-| FPG-R12 编号流程进入仓库 Agent/Skill/lifecycle 控制面 | AGENTS + governance Skill + project standard + task lifecycle | PR/main file review | in-progress |
+| FPG-R08 每个项目有全局唯一且不可变的 Portfolio Project ID | `projects/PORTFOLIO.json` + all `PROJECT.yaml` + ADR-0003 | PR #1996 + main registry/metadata reads | passed |
+| FPG-R09 新项目 ID 单调分配且永不复用 | `FAB-P%04d`, next_sequence high-water mark, archived IDs retained | policy + validator run 32561929188 | passed |
+| FPG-R10 Project ID 与 Project Key/Task ID 分层 | `project_id` + `project_key` + `legacy_project_ids` schema | 5 canonical PROJECT.yaml files on main | passed |
+| FPG-R11 编号规则自动阻止重复/改号/漏登记 | baseline-aware portfolio validator in GitHub Actions | Project portfolio governance run 32561929188 | passed |
+| FPG-R12 编号流程进入仓库 Agent/Skill/lifecycle 控制面 | AGENTS + governance Skill + project standard + task lifecycle | canonical main file review after #1996 | passed |
 | Task Orchestration Skill validator | `quick_validate.py` | `Skill is valid!` | passed |
 | Task Orchestration Skill package | `package_skill.py` | `skill.zip`, 16128 bytes, SHA-256 `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61` | passed |
 | Root AGENTS enterprise scaffold | post-merge file review | main `AGENTS.md` | passed |
 | Governance Skill/reference/lifecycle alignment | post-merge file review | main `.agent/skills/fabushi-project-governance/` | passed |
 | Governance project mandatory files | project-folder audit | main FPG-002 audit | passed |
-| FPG-004 protected merge / canonical verification | repository merge process + post-merge fetch | PR/CI/merge/main evidence | pending |
+| FPG-004 protected merge / canonical verification | merge queue + post-merge fetch | PR #1996 / merge `87462b14017b08f0f4dcd6f97fbea67b5c12d791` / main verification | passed |
 
 ## External installation state
 

--- a/projects/fabushi-project-governance/management/05-状态报告.md
+++ b/projects/fabushi-project-governance/management/05-状态报告.md
@@ -83,3 +83,15 @@
 - Acceptance: branch implementation present; Agent/Skill lifecycle alignment, PR CI, protected merge and canonical main verification pending.
 - Blocker: none.
 - Next: 将 allocation contract 写入 AGENTS/governance Skill/reference/lifecycle，创建 PR 并以 Actions 结果验收。
+
+## 2026-08-22 — FPG-004 Round 2 — Closure
+
+- Work: root `AGENTS.md`、Fabushi governance Skill、project-folder standard 与 task lifecycle 全部加入 global Project ID allocation gate。
+- Verification: Project portfolio governance run `32561929188` / `Validate immutable Project IDs` 成功。
+- Verification: repository CI run `32561929208` 所选 Frontend/Worker/Electron/MCP/architecture jobs 及最终 `CI result` 全部成功。
+- Merge: PR #1996 经 auto-merge/merge queue 保护流程合并；merge commit `87462b14017b08f0f4dcd6f97fbea67b5c12d791`。
+- Main verification: `projects/PORTFOLIO.json` 在 canonical `main` 登记 FAB-P0001–FAB-P0005 且 `next_sequence=6`；五个项目 `PROJECT.yaml` 的 ID/key/path 与 registry 一致。
+- Main verification: root `AGENTS.md` 已要求新项目先读 live registry、原子领取 current next sequence；Project portfolio governance workflow 已存在于 `main`。
+- Acceptance: FPG-R08–FPG-R12、FPG-004.1–FPG-004.7 全部有客观证据并通过。
+- Blocker: none.
+- Next: FPG-004 closed. Future new projects must re-read live canonical registry; current `FAB-P0006` is next candidate, not a reservation.

--- a/projects/fabushi-project-governance/management/07-变更日志.md
+++ b/projects/fabushi-project-governance/management/07-变更日志.md
@@ -37,4 +37,6 @@
 - 新增 `scripts/check-project-portfolio.py`，校验 Project ID/key/slug/path 唯一性、连续 sequence、registry/folder parity、`next_sequence=max+1` 与 base-branch immutability。
 - 新增 `.github/workflows/project-portfolio-governance.yml`，在 project/governance changes 上 fail closed 验证编号体系。
 - 根 `AGENTS.md`、governance Skill、project-folder standard、task lifecycle 统一要求：创建独立项目先读取 canonical `main` registry，在同一 PR 原子领取 next sequence + 更新 registry + 创建 PROJECT.yaml；并发冲突必须 re-read/reallocate，禁止强行复用。
-- FPG-004 当前保持 `in-progress`，等待 PR Actions、protected merge 与 canonical `main` 验证后才能标记 passed。
+- PR #1996 的 Project portfolio governance run `32561929188` 与 repository CI run `32561929208` 全部成功。
+- PR #1996 通过 merge queue 合并到 `main`，merge commit `87462b14017b08f0f4dcd6f97fbea67b5c12d791`。
+- 合并后已回读 canonical `main` 的 registry、五个 `PROJECT.yaml`、root `AGENTS.md` 与 Project portfolio governance workflow；FPG-004 验收完成并关闭。

--- a/projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-004-global-project-identifiers.md
@@ -4,13 +4,14 @@
 - Project Key: `FPG`
 - Task ID: `FPG-004`
 - Project: Fabushi Project Governance
-- Status: `in-progress`
+- Status: `passed`
 - Started: 2026-08-22T16:06:00+08:00
-- Updated: 2026-08-22T16:18:00+08:00
-- Completed: pending
-- Branch: `governance/global-project-identifiers`
-- Implementation head before PR evidence update: `9d11de5d90b9e284904071845bd4c391f2785a2b`
-- PR: `#1996`
+- Updated: 2026-08-22T16:22:30+08:00
+- Completed: 2026-08-22T16:22:30+08:00
+- Implementation branch: `governance/global-project-identifiers`
+- Closure branch: `docs/fpg-004-project-id-closure`
+- Implementation PR: `#1996`
+- Implementation merge commit: `87462b14017b08f0f4dcd6f97fbea67b5c12d791`
 
 ## Objective
 
@@ -21,86 +22,84 @@ Introduce a portfolio-wide immutable Project ID system for all Fabushi repositor
 - `source/2026-08-22-FPG-004-global-project-identifiers.md`
 - User requirement: implement numbering **between projects** using enterprise/large-company governance practices.
 
-## In scope
+## Scope delivered
 
-- Define canonical Project ID format and lifecycle.
-- Create authoritative machine-readable portfolio registry and human index/policy.
-- Backfill every canonical `projects/*/PROJECT.yaml` on `main` with a global Project ID and stable project key/legacy aliases.
-- Preserve existing task namespaces and historical identifiers.
-- Update repository project standard, governance Skill/lifecycle, and root Agent instructions.
-- Add CI validation for format, uniqueness, registry parity, monotonic allocation, and immutability.
-- Record ADR, WBS, acceptance, status, changelog, and evidence.
+- Defined canonical Project ID format and lifecycle.
+- Created authoritative machine-readable portfolio registry and human index/policy.
+- Backfilled every canonical `projects/*/PROJECT.yaml` with a global Project ID and stable Project Key/legacy aliases.
+- Preserved existing task namespaces and historical identifiers.
+- Updated repository project standard, governance Skill/lifecycle, and root Agent instructions.
+- Added CI validation for format, uniqueness, registry parity, monotonic allocation, and immutability.
+- Recorded ADR, WBS, acceptance, status, changelog, and evidence.
 
-## Out of scope
+## Deterministic migration ordering and final allocation
 
-- Renaming project directories solely to match numeric IDs.
-- Rewriting historical task IDs, PR numbers, commit messages, or document history.
-- Creating a separate external portfolio database as the engineering source of truth.
+Existing projects were ordered by the first formal project-folder commit merged to canonical `main`:
 
-## Deterministic migration ordering
+| Portfolio Project ID | Project Key | Slug | First formal main commit |
+|---|---|---|---|
+| `FAB-P0001` | `TFI` | `telegram-fabushi-integration` | `99cd4b227a34b49fc04c3265c1dfdee585344160` |
+| `FAB-P0002` | `FPG` | `fabushi-project-governance` | `eaf273dafc140619b06b46a4d7d234997acde05d` |
+| `FAB-P0003` | `FCM` | `fabushi-cicd-merge-governance` | `ac94b40d4a05a0211146c2bb5904aa936a7bc928` |
+| `FAB-P0004` | `GBF` | `grok-bot-fabushi-integration` | `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c` |
+| `FAB-P0005` | `MSR` | `mahayana-sovereign-runtime` | `88db63c328c3cba39971f3942509cb0b582502bc` |
 
-Existing projects are ordered by the first formal project-folder commit merged to canonical `main`:
+Canonical `main` registry high-water mark after migration: `next_sequence=6`, so the next *candidate* allocation is `FAB-P0006`. It is not reserved; future creation must re-read live `main` before allocation.
 
-1. Telegram project — PR #1975 / commit `99cd4b227a34b49fc04c3265c1dfdee585344160`.
-2. Project Governance — PR #1976 / commit `eaf273dafc140619b06b46a4d7d234997acde05d`.
-3. CI/CD & Merge Governance — PR #1978 / commit `ac94b40d4a05a0211146c2bb5904aa936a7bc928`.
-4. Grok Bot fusion — PR #1982 / commit `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c`.
-5. Mahayana sovereign runtime — PR #1989 / commit `88db63c328c3cba39971f3942509cb0b582502bc`.
+## Implementation result
 
-## Allocation
+- `projects/PORTFOLIO.json` is the authoritative allocation registry.
+- `projects/PROJECT_ID_POLICY.md` defines immutable, monotonic, no-reuse lifecycle semantics.
+- `projects/README.md` provides the human portfolio index.
+- All five canonical project folders mirror their registered `project_id`, `project_key`, slug, and path.
+- Historical identifiers remain under `legacy_project_ids` and are not reassigned.
+- `scripts/check-project-portfolio.py` validates schema, format, uniqueness, contiguous allocation, `next_sequence=max+1`, folder parity, metadata parity, baseline immutability, and new-allocation sequencing.
+- `.github/workflows/project-portfolio-governance.yml` runs the validator on relevant PR/push changes.
+- Root `AGENTS.md`, governance Skill, project-folder standard, and task lifecycle require new independent projects to allocate the current registry `next_sequence` atomically in the same PR as project creation.
 
-| Portfolio Project ID | Project Key | Slug |
-|---|---|---|
-| FAB-P0001 | TFI | telegram-fabushi-integration |
-| FAB-P0002 | FPG | fabushi-project-governance |
-| FAB-P0003 | FCM | fabushi-cicd-merge-governance |
-| FAB-P0004 | GBF | grok-bot-fabushi-integration |
-| FAB-P0005 | MSR | mahayana-sovereign-runtime |
+## Acceptance results
 
-Next allocatable ID after migration: `FAB-P0006`.
+1. **PASS** — all current canonical project folders have unique `FAB-P0001`–`FAB-P0005` Project IDs.
+2. **PASS** — mnemonic namespaces remain as Project Keys and historical identifiers remain as aliases.
+3. **PASS** — canonical `projects/PORTFOLIO.json` exists with `next_sequence=6=max(sequence)+1`.
+4. **PASS** — registry/project-folder parity passed the automated validator and was re-read from `main`.
+5. **PASS** — baseline-aware CI validator passed on PR #1996 and enforces malformed/duplicate/gap/reuse/mutation/removal failures.
+6. **PASS** — root Agent and governance Skill/reference/lifecycle all contain the same allocation contract.
+7. **PASS** — required CI passed, PR entered merge queue, merged, and canonical `main` was re-verified.
 
-## Implementation summary
+## Verification evidence
 
-- Added authoritative `projects/PORTFOLIO.json`, human index, and Project ID policy.
-- Added ADR-0003 for immutable global Project IDs and stable Project Keys.
-- Backfilled all five canonical project `PROJECT.yaml` files while retaining historical aliases.
-- Added stdlib-only `scripts/check-project-portfolio.py` for format/uniqueness/sequence/folder-parity/base-immutability checks.
-- Added `Project portfolio governance` GitHub Actions workflow.
-- Updated root `AGENTS.md`, governance Skill, project-folder standard, task lifecycle, requirements, architecture, WBS, acceptance, status, changelog, evidence, and source-of-truth records.
+- Implementation PR: #1996, merged 2026-08-22T08:21:57Z.
+- PR head used for final PR checks: `a50dd46b2bedf152356c14ac195021ffc9443013`.
+- Project portfolio governance run: `32561929188` — `Validate immutable Project IDs` = success.
+- Repository CI run: `32561929208` — selected jobs and final `CI result` = success.
+- Explicit automerge run: `32561929220` = success.
+- Merge queue: GitHub rejected an immediate merge attempt with `Pull Request is in the merge queue`, confirming protected queue routing.
+- Merge commit on canonical main: `87462b14017b08f0f4dcd6f97fbea67b5c12d791`.
+- Post-merge main reads verified:
+  - `projects/PORTFOLIO.json` with five entries and `next_sequence=6`;
+  - Telegram `PROJECT.yaml` = `FAB-P0001 / TFI`;
+  - Project Governance `PROJECT.yaml` = `FAB-P0002 / FPG`;
+  - CI/CD Governance `PROJECT.yaml` = `FAB-P0003 / FCM`;
+  - Grok Bot `PROJECT.yaml` = `FAB-P0004 / GBF`;
+  - Mahayana `PROJECT.yaml` = `FAB-P0005 / MSR`;
+  - root `AGENTS.md` global Project ID allocation gate;
+  - `.github/workflows/project-portfolio-governance.yml` validator workflow.
 
-## Acceptance criteria
-
-1. All current canonical project folders have one unique `project_id` matching `^FAB-P[0-9]{4}$`.
-2. Existing mnemonic IDs remain available as `project_key` and/or `legacy_project_ids`.
-3. `projects/PORTFOLIO.json` is the authoritative allocation registry and its `next_sequence` equals max allocated sequence + 1.
-4. Registry entries exactly match canonical project folders and each `PROJECT.yaml` identity/path.
-5. CI rejects duplicate IDs/keys/slugs, malformed IDs, gaps/reuse, registry/folder divergence, and mutation/removal of already-registered IDs when compared with the target branch.
-6. Root `AGENTS.md`, governance Skill, project-folder standard, and task lifecycle describe the same allocation process.
-7. PR CI passes, protected merge completes, and canonical `main` is re-fetched before closure.
-
-## Verification
-
-- Static registry validator in GitHub Actions.
-- Review all `PROJECT.yaml` files and registry entries.
-- PR #1996 required checks / merge queue.
-- Post-merge `main` verification.
-
-## Evidence
+## Evidence index
 
 - `projects/fabushi-project-governance/evidence/FPG-004/README.md`
-- Implementation branch head before PR evidence update: `9d11de5d90b9e284904071845bd4c391f2785a2b`.
-- PR #1996.
-- CI/run/merge/main evidence: pending.
 
-## Risks
+## Risks / residual notes
 
-- Historical references may call old values “project_id”; mitigated by preserving aliases and documenting `project_key` versus canonical portfolio `project_id`.
-- Concurrent new project creation can race for the same next sequence; registry merge conflicts are intentional serialization and must be resolved before merge.
+- Historical documents may still use old values under the label `project_id`; the migration deliberately preserves those values as aliases instead of rewriting history.
+- Concurrent project creation remains intentionally serialized through `projects/PORTFOLIO.json` merge conflicts.
+- `FAB-P0006` is only the current next value, not a reservation. A future project must allocate whatever live canonical `main` says at creation time.
 
 ## Blockers
 
-- PR #1996 CI and merge/main verification are pending.
+None.
 
 ## Next action
 
-Wait for GitHub Actions on the current PR head, fix any portfolio/governance failure without weakening the checks, merge through the normal protected process, then re-fetch canonical `main` and close FPG-004 only after evidence is complete.
+No further FPG-004 implementation is required. Future independent Fabushi projects must follow the canonical registry allocation gate; continuations must reuse their existing Project ID.


### PR DESCRIPTION
## Purpose
Close `FAB-P0002 / FPG-004` after the implementation in #1996 passed its portfolio validator, repository CI, merge queue, and canonical `main` verification.

## Scope
This is a **closure-only** project-record change. It does not allocate a new Project ID and does not change `projects/PORTFOLIO.json`, the numbering policy, validator behavior, or any product/runtime code.

## Evidence recorded
- Project portfolio governance run `32561929188`: `Validate immutable Project IDs` success
- Repository CI run `32561929208`: final `CI result` success
- Explicit automerge run `32561929220`: success
- #1996 routed through merge queue and merged at `87462b14017b08f0f4dcd6f97fbea67b5c12d791`
- Post-merge canonical `main` verification of `PORTFOLIO.json`, all five `PROJECT.yaml` identities, root `AGENTS.md`, and portfolio governance workflow

## Closure updates
- FPG-004 task status -> `passed`
- WBS FPG-004.1–FPG-004.7 -> `passed`
- acceptance FPG-R08–FPG-R12 -> `passed`
- append closure status/changelog
- finalize FPG-004 evidence index

No local application build/test was used; GitHub Actions remain authoritative.