### PR TITLE
feat(messaging): land production SQLite on current main

### DIFF
--- a/native/mahayana-messaging/src/bin/messaging-server.rs
+++ b/native/mahayana-messaging/src/bin/messaging-server.rs
@@ -11,13 +11,22 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let bind = env::var("FABUSHI_MESSAGING_BIND").unwrap_or_else(|_| "127.0.0.1:9400".into());
-    let snapshot = env::var_os("FABUSHI_MESSAGING_SNAPSHOT")
+    let legacy_snapshot_env = env::var_os("FABUSHI_MESSAGING_SNAPSHOT").map(PathBuf::from);
+    let database = env::var_os("FABUSHI_MESSAGING_DATABASE")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("fabushi-messaging-snapshot.json"));
+        .or_else(|| {
+            legacy_snapshot_env
+                .as_ref()
+                .map(|path| path.with_extension("sqlite3"))
+        })
+        .unwrap_or_else(|| PathBuf::from("fabushi-messaging.sqlite3"));
+    let legacy_snapshot =
+        legacy_snapshot_env.unwrap_or_else(|| PathBuf::from("fabushi-messaging-snapshot.json"));
     let access_registry = env::var_os("FABUSHI_MESSAGING_ACCESS_REGISTRY")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("fabushi-messaging-access.json"));
-    let config = MessagingServerConfig::new(bind, snapshot, access_registry);
+    let config = MessagingServerConfig::new(bind, database, access_registry)
+        .with_legacy_snapshot(legacy_snapshot);
     let server = MessagingTcpServer::load(config)?;
     server.serve()?;
     Ok(())

--- a/native/mahayana-messaging/src/server.rs
+++ b/native/mahayana-messaging/src/server.rs
@@ -2,7 +2,7 @@ use crate::access::{AccessScope, FileAccessTokenStore};
 use crate::blob_store::FileBlobStore;
 use crate::protocol::{ClientCommand, ClientEnvelope, ServerEnvelope};
 use crate::service::{MessagingService, MessagingServiceError};
-use crate::store::JsonFileStateStore;
+use crate::store::{JsonFileStateStore, SqliteStateStore, StoreError};
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::net::{TcpListener, TcpStream};
@@ -35,7 +35,8 @@ pub enum ServerFrame {
 #[derive(Debug, Clone)]
 pub struct MessagingServerConfig {
     pub bind_address: String,
-    pub snapshot_path: PathBuf,
+    pub database_path: PathBuf,
+    pub legacy_snapshot_path: Option<PathBuf>,
     pub access_registry_path: PathBuf,
     pub max_frame_bytes: usize,
 }
@@ -43,21 +44,32 @@ pub struct MessagingServerConfig {
 impl MessagingServerConfig {
     pub fn new(
         bind_address: impl Into<String>,
-        snapshot_path: impl Into<PathBuf>,
+        database_path: impl Into<PathBuf>,
         access_registry_path: impl Into<PathBuf>,
     ) -> Self {
         Self {
             bind_address: bind_address.into(),
-            snapshot_path: snapshot_path.into(),
+            database_path: database_path.into(),
+            legacy_snapshot_path: None,
             access_registry_path: access_registry_path.into(),
             max_frame_bytes: MAX_SERVER_FRAME_BYTES,
         }
+    }
+
+    pub fn with_legacy_snapshot(mut self, path: impl Into<PathBuf>) -> Self {
+        self.legacy_snapshot_path = Some(path.into());
+        self
     }
 
     pub fn validate(&self) -> Result<(), MessagingServerError> {
         if self.bind_address.trim().is_empty() {
             return Err(MessagingServerError::InvalidConfig(
                 "bind address is empty".into(),
+            ));
+        }
+        if self.database_path.as_os_str().is_empty() {
+            return Err(MessagingServerError::InvalidConfig(
+                "database path is empty".into(),
             ));
         }
         if self.access_registry_path.as_os_str().is_empty() {
@@ -82,23 +94,33 @@ pub enum MessagingServerError {
     Io(#[from] std::io::Error),
     #[error("messaging server JSON failed: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("messaging store failed: {0}")]
+    Store(#[from] StoreError),
     #[error("messaging service failed: {0}")]
     Service(#[from] MessagingServiceError),
     #[error("messaging service lock is poisoned")]
     Poisoned,
 }
 
+/// Production self-hosted messaging server.
+///
+/// Durable product state is authoritative in SQLite. A configured legacy JSON
+/// snapshot is only an import source while that SQLite database is still empty.
 pub struct MessagingTcpServer {
     config: MessagingServerConfig,
-    service: Arc<Mutex<MessagingService<JsonFileStateStore>>>,
+    service: Arc<Mutex<MessagingService<SqliteStateStore>>>,
 }
 
 impl MessagingTcpServer {
     pub fn load(config: MessagingServerConfig) -> Result<Self, MessagingServerError> {
         config.validate()?;
-        let store = JsonFileStateStore::new(config.snapshot_path.clone());
+        let mut store = SqliteStateStore::new(config.database_path.clone());
+        if let Some(legacy_path) = config.legacy_snapshot_path.as_ref() {
+            let legacy = JsonFileStateStore::new(legacy_path);
+            store.import_json_if_empty(&legacy)?;
+        }
         let blob_root = config
-            .snapshot_path
+            .database_path
             .parent()
             .unwrap_or_else(|| Path::new("."))
             .join("blobs");
@@ -109,8 +131,12 @@ impl MessagingTcpServer {
         })
     }
 
+    pub fn database_path(&self) -> &Path {
+        &self.config.database_path
+    }
+
     pub fn snapshot_path(&self) -> &Path {
-        &self.config.snapshot_path
+        self.database_path()
     }
 
     pub fn serve(self) -> Result<(), MessagingServerError> {
@@ -143,7 +169,7 @@ impl MessagingTcpServer {
 
 fn handle_connection(
     stream: TcpStream,
-    service: Arc<Mutex<MessagingService<JsonFileStateStore>>>,
+    service: Arc<Mutex<MessagingService<SqliteStateStore>>>,
     access_store: Arc<FileAccessTokenStore>,
     max_frame_bytes: usize,
 ) -> Result<(), MessagingServerError> {
@@ -282,8 +308,12 @@ mod tests {
     }
 
     #[test]
-    fn production_config_requires_access_registry_path() {
-        let config = MessagingServerConfig::new("127.0.0.1:9400", "/tmp/messages.json", "");
-        assert!(config.validate().is_err());
+    fn production_config_requires_database_and_access_registry_paths() {
+        let missing_database = MessagingServerConfig::new("127.0.0.1:9400", "", "/tmp/access.json");
+        assert!(missing_database.validate().is_err());
+
+        let missing_access =
+            MessagingServerConfig::new("127.0.0.1:9400", "/tmp/messages.sqlite3", "");
+        assert!(missing_access.validate().is_err());
     }
 }

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -154,6 +154,20 @@ impl SqliteStateStore {
         migrate_sqlite(&connection)
     }
 
+    pub fn import_json_if_empty(
+        &mut self,
+        legacy: &JsonFileStateStore,
+    ) -> Result<bool, StoreError> {
+        if self.load()?.is_some() {
+            return Ok(false);
+        }
+        let Some(snapshot) = legacy.load()? else {
+            return Ok(false);
+        };
+        self.save(&snapshot)?;
+        Ok(true)
+    }
+
     fn open(&self) -> Result<Connection, StoreError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)?;
@@ -288,6 +302,39 @@ mod tests {
         let reopened = SqliteStateStore::new(&path);
         assert_eq!(reopened.load().expect("reload snapshot"), Some(snapshot));
         remove_db(&path);
+    }
+
+    #[test]
+    fn sqlite_store_imports_legacy_json_once() {
+        let path = temporary_db("legacy-import");
+        let legacy_path = path.with_extension("json");
+        let mut legacy = JsonFileStateStore::new(&legacy_path);
+        let original = MessagingSnapshot::new(MessagingState::default(), 41, 100);
+        legacy.save(&original).expect("save legacy snapshot");
+
+        let mut store = SqliteStateStore::new(&path);
+        assert!(store
+            .import_json_if_empty(&legacy)
+            .expect("import legacy snapshot"));
+        assert_eq!(
+            store.load().expect("load imported snapshot"),
+            Some(original)
+        );
+
+        let replacement = MessagingSnapshot::new(MessagingState::default(), 99, 200);
+        legacy
+            .save(&replacement)
+            .expect("replace legacy snapshot after import");
+        assert!(!store
+            .import_json_if_empty(&legacy)
+            .expect("skip second legacy import"));
+        assert_eq!(
+            store.load().expect("keep sqlite snapshot").unwrap().cursor,
+            41
+        );
+
+        remove_db(&path);
+        let _ = fs::remove_file(legacy_path);
     }
 
     #[test]

--- a/projects/telegram-fabushi-integration/evidence/M1-T02-current-main/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M1-T02-current-main/README.md
@@ -1,0 +1,49 @@
+# M1.T02 current-main landing evidence
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task**: `M1.T02`
+- **Status**: `IMPLEMENTED / CURRENT-HEAD CI PENDING`
+- **Branch**: `feat/telegram-m1-sqlite-main-sync`
+
+## Why this landing exists
+
+PR #1990 contains the intended production-SQLite implementation and previously passed its product gates, but it also contains older project-document snapshots that predate the repository-wide immutable `FAB-Pxxxx` governance. The current landing starts from canonical `main` and carries only the runtime delta plus fresh project evidence so it cannot regress `FAB-P0001 / TFI` metadata or newer governance records.
+
+## Runtime evidence in branch
+
+- `native/mahayana-messaging/src/store.rs`
+  - `SqliteStateStore::import_json_if_empty`
+  - validates legacy snapshot through the existing store contract
+  - imports only when SQLite is empty
+  - preserves SQLite authority after first import
+  - unit test proves stale JSON cannot overwrite existing SQLite state
+- `native/mahayana-messaging/src/server.rs`
+  - production `MessagingTcpServer` uses `SqliteStateStore`
+  - optional legacy JSON import source
+  - explicit database-path validation
+  - blob root remains adjacent to authoritative production state
+- `native/mahayana-messaging/src/bin/messaging-server.rs`
+  - `FABUSHI_MESSAGING_DATABASE`
+  - default `fabushi-messaging.sqlite3`
+  - compatibility import from `FABUSHI_MESSAGING_SNAPSHOT`
+
+## Historical verified evidence
+
+The same intended implementation path in PR #1990 passed:
+
+| Gate | Run | Result |
+|---|---:|---|
+| Messaging Product Gate | 32559833779 | SUCCESS |
+| Mahayana fast checks | 32559833770 | SUCCESS |
+| Explicit automerge | 32559833763 | SUCCESS |
+
+These runs are historical implementation evidence only. Completion still requires green current-head checks on this clean branch, protected merge, and canonical-main verification.
+
+## Current-head evidence
+
+Pending replacement PR creation and GitHub Actions runs.
+
+## Completion gate
+
+Do not mark M1.T02 landed/closed until current-head CI is green, protected-main merge completes, and canonical `main` is re-read to verify SQLite is the production default without project-governance regression.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -1,8 +1,10 @@
 # 项目状态报告
 
 - **项目**：Fabushi Telegram 全量融合
+- **Project ID**：`FAB-P0001`
+- **Project Key**：`TFI`
 - **文档 ID**：MGMT-05
-- **版本**：v1.2
+- **版本**：v1.3
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
@@ -10,37 +12,36 @@
 ## 当前状态
 
 - **整体阶段**：M1 Rust Core 骨架 — `IN_PROGRESS`。
-- **M0**：`TESTED`；PR #1987 已经通过 CI、protected merge queue 并进入 canonical `main`。
+- **M0**：`TESTED`；PR #1987 已通过 CI、protected merge queue 并进入 canonical `main`。
 - **Canonical Messaging Core**：`native/mahayana-messaging/`。
 - **旧 Telegram 栈**：`native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 为 LEGACY/FROZEN，禁止新增产品功能。
 - **协议事实来源**：`native/mahayana-messaging/src/protocol.rs`，Messaging Protocol v2。
-- **当前缺口实现**：M1.T06 SQLite schema/storage（PR #1988）。
-- **当前生产切换**：M1.T02 production SQLite default + JSON one-time migration（PR #1990）。
-- **下一执行入口**：完成 M1.T06/M1.T02 CI/merge 后，用 current-head gate 回填 M1.T01/T03/T04/T05/T07；随后进入 M2-M13 分阶段验收和 M14 dependency-zero 删除。
+- **M1.T06**：SQLite schema/storage 已通过 PR #1988 落入 canonical `main`，merge `1b78e4fbc1a666fc725c21450b11d3ab643ac0fa`。
+- **M1.T02**：production SQLite default 正在从 latest `main` 的 clean branch `feat/telegram-m1-sqlite-main-sync` 重新落地；历史 PR #1990 继续保留已验证实现证据，但不允许其旧项目文档覆盖当前 `FAB-P0001 / TFI` 基线。
+- **下一执行入口**：M1.T02 current-head CI/merge/main verification → M1 acceptance reconciliation → M2 WebSocket gateway → durable delta sync。
 - **完成百分比**：不手填；按通过验收的必需原子任务计算。
 
 ## 已验证的主干事实
 
 - PR #1961 合并实现：`8062abb850020a702b4c8a85d8bd23d6b0470cb2`。
-- PR #1987 M0 reconciliation 通过 protected merge queue，merge commit `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`。
+- PR #1987 M0 reconciliation 合并：`5aeca75a1e9f6c5bd9fc376cf697012004c0766c`。
+- PR #1988 M1.T06 SQLite foundation 合并：`1b78e4fbc1a666fc725c21450b11d3ab643ac0fa`。
 - `native/mahayana-messaging` 已覆盖统一 Actor/Conversation/Message、私聊/群组/频道/Topic、Bot/Agent、媒体/Blob、Mini Apps、支付/ledger、搜索、通知、Stories、设备/访问控制、WebRTC signaling、Secret Chat 等广泛产品域。
 - Electron Messenger V2 与 Mahayana Feature Host 已接入自建 messaging protocol。
-- 历史 `reply_to_message_id` 编译错误只属于旧 run；current source 已修复。
+
+## 2026-08-22 — M1.T02 clean current-main landing
+
+- **原因**：原 PR #1990 的运行时代码已经通过 Messaging Product Gate `32559833779`、Mahayana fast checks `32559833770` 和 Explicit automerge `32559833763`，但该分支同时携带 immutable Project ID 治理之前的旧项目文档快照。
+- **治理处理**：不强行合并旧文档；从 canonical `main` 新建 `feat/telegram-m1-sqlite-main-sync`，只重放经过验证的运行时变更及新 task/evidence/source 记录。
+- **实现**：production `MessagingTcpServer` 使用 `SqliteStateStore`；`FABUSHI_MESSAGING_DATABASE`；legacy JSON 仅在 SQLite 为空时一次性导入；已有 SQLite 永远优先。
+- **状态**：`IMPLEMENTED`；current-head GitHub Actions、protected merge 和 canonical-main verification 尚未完成，因此不得提升为 landed/closed。
 
 ## 2026-08-22 — M1.T06 SQLite schema/storage
 
 - **PR**：#1988 `feat(messaging): add SQLite state storage`。
 - **实现**：versioned SQLite schema、transactional singleton snapshot、full-u64 cursor、schema validation、reopen/overwrite/future-schema tests。
-- **已修复 CI 阻塞**：`rusqlite 0.32` 与 Mahayana/Codex `libsqlite3-sys 0.37` 链接冲突；已将 messaging dependency 对齐为 `rusqlite 0.39`。
-- **当前门禁**：Messaging Product Gate 已通过 Rustfmt、messaging all-target tests、Clippy 与 Electron Messenger contract；Host bridge / Mahayana fast gate 在本记录更新时仍以实时 GitHub 状态为准。
-- **状态**：`IN_PROGRESS`，未在 merge/main 证据完成前提升为 `TESTED`。
-
-## 2026-08-22 — M1.T02 production storage adoption
-
-- **PR**：#1990 `feat(messaging): make SQLite production storage default`。
-- **实现**：production `MessagingTcpServer` 使用 `SqliteStateStore`；新 `FABUSHI_MESSAGING_DATABASE`；默认 `fabushi-messaging.sqlite3`；旧 JSON snapshot 只在 SQLite 为空时一次性导入。
-- **安全边界**：已有 SQLite state 永远优先，旧 JSON 不允许在后续启动覆盖新状态。
-- **状态**：`IN_PROGRESS`，正在由 GitHub Actions 验证。
+- **CI**：Messaging Product Gate `32559222693` SUCCESS；Mahayana fast checks `32559222679` SUCCESS；Explicit automerge `32559222681` SUCCESS。
+- **状态**：`TESTED / LANDED`；最终 M1 stage closure 与 M1.T02 一起归档。
 
 ## 2026-08-22 — M0 live audit closure
 
@@ -52,5 +53,5 @@
 
 ## 2026-08-22 — Project governance
 
-- TFI-GOV-001 已建立 GitHub-first source of truth。
-- TFI-GOV-002 正在补齐 current enterprise project standard：ownership、dependency/blocker register、issue/action register、runbooks 与 M0 post-merge closure。
+- GitHub `main` 的 `projects/telegram-fabushi-integration/` 为唯一工程权威基线。
+- immutable portfolio identity 已固定为 `FAB-P0001 / TFI`；任何旧分支不得覆盖该身份或将项目状态回退到旧 planning baseline。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -2,7 +2,7 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：MGMT-07
-- **版本**：v1.2
+- **版本**：v1.3
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
@@ -35,7 +35,10 @@
 
 - M1.T06 / PR #1988 新增 versioned `SqliteStateStore`、事务 snapshot、完整 u64 cursor、schema validation 和恢复测试。
 - CI 首轮暴露 `libsqlite3-sys` 单链接冲突；将 `rusqlite` 从 0.32 对齐到 0.39，以匹配 Mahayana/Codex workspace 的 `libsqlite3-sys 0.37`。
-- M1.T02 / PR #1990 将 production Messaging Server 切换为 SQLite，新增 `FABUSHI_MESSAGING_DATABASE`，并保留 legacy JSON one-time import。
+- M1.T06 已通过 protected merge 并进入 canonical `main`，merge `1b78e4fbc1a666fc725c21450b11d3ab643ac0fa`。
+- M1.T02 / PR #1990 实现 production Messaging Server 切 SQLite、`FABUSHI_MESSAGING_DATABASE` 和 legacy JSON one-time import；该实现曾通过 product CI。
+- 发现 #1990 同时携带 immutable portfolio Project ID 治理之前的旧项目文档，若直接合并会覆盖当前 `FAB-P0001 / TFI` 基线。
+- 因此创建 `feat/telegram-m1-sqlite-main-sync` 从 current `main` 干净重落 M1.T02，仅带运行时变更和新的 task/evidence/source 记录；#1990 保留为历史实现证据，不再作为项目文档落地主路径。
 - SQLite 已有 state 时禁止 stale JSON 覆盖，避免升级后状态回滚。
 
 ## 2026-08-22 — Enterprise project standard alignment
@@ -44,4 +47,5 @@
 - 新增 dependency/blocker register 和 issue/action register。
 - 新增 messaging server、SQLite migration、rollback runbooks。
 - `PROJECT.yaml` 从 `PLANNING_BASELINE` 切换为 `IMPLEMENTATION_ACTIVE`，current stage = M1。
+- immutable portfolio identity 固定为 `FAB-P0001 / TFI`；后续旧分支不得覆盖该身份。
 - M0 post-merge bookkeeping 与 M1 active work 被写回 durable project record。

--- a/projects/telegram-fabushi-integration/management/tasks/M1-T02-production-storage-current-main.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M1-T02-production-storage-current-main.md
@@ -1,0 +1,64 @@
+# M1.T02 — Production local-first storage on current main
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M1.T02`
+- **Stage**: `M1 Rust Core 骨架`
+- **Status**: `IMPLEMENTED`
+- **Started**: `2026-08-22`
+- **Updated**: `2026-08-22`
+- **Source**: `../../source/完整telegram融合进fabushi.txt`; `../wbs/M1.md`
+- **Depends on**: `M1.T06` (PR #1988, landed on canonical `main`)
+
+## Objective
+
+Make SQLite the authoritative production store for the canonical `native/mahayana-messaging` server while preserving a safe one-time import path for historical JSON snapshots.
+
+## Current-main reconciliation
+
+The original implementation PR #1990 had successful product CI on its implementation head, but its branch also carried project-document snapshots created before the repository-wide immutable `FAB-Pxxxx` portfolio-ID governance landed. Because those stale documents must not overwrite the canonical `FAB-P0001 / TFI` project state, this task is re-landed from the latest `main` on `feat/telegram-m1-sqlite-main-sync` with only the intended runtime changes plus current project evidence.
+
+## Implemented
+
+- `MessagingTcpServer` uses `SqliteStateStore` for authoritative durable product state.
+- `FABUSHI_MESSAGING_DATABASE` selects the production SQLite database; default is `fabushi-messaging.sqlite3`.
+- `FABUSHI_MESSAGING_SNAPSHOT` is a legacy import source, not the continuing production store.
+- If only a legacy snapshot path is supplied, the SQLite path is derived as the sibling `.sqlite3` file.
+- `SqliteStateStore::import_json_if_empty` imports only when SQLite has no state.
+- Existing SQLite state always wins over stale JSON on later starts.
+- `snapshot_path()` remains a compatibility accessor but resolves to the production database path.
+- Unit coverage includes one-time import and protection against stale legacy overwrite.
+
+## Acceptance criteria
+
+1. New production starts default to SQLite.
+2. Existing valid JSON state can be imported exactly once into an empty SQLite database.
+3. Existing SQLite state cannot be overwritten by stale legacy JSON.
+4. Database/access-registry configuration rejects invalid empty paths.
+5. Rust formatting, all-target messaging tests, Clippy and product bridge contracts pass in GitHub Actions.
+6. Required repository/project-governance checks pass.
+7. The change merges through the protected-main process and is verified on canonical `main`.
+
+## Verification
+
+- Historical implementation evidence from #1990: Messaging Product Gate `32559833779` SUCCESS; Mahayana fast checks `32559833770` SUCCESS; Explicit automerge `32559833763` SUCCESS.
+- Historical evidence proves the intended code path was tested, but **does not replace current-head CI** for this clean main-based landing.
+- Current-head CI / PR / merge evidence: pending.
+
+## Branch / PR
+
+- Branch: `feat/telegram-m1-sqlite-main-sync`
+- Base: latest canonical `main`
+- Replacement PR: pending creation.
+- Supersedes landing path of PR #1990; #1990 remains historical implementation evidence until the replacement is merged.
+
+## Evidence locations
+
+- `native/mahayana-messaging/src/store.rs`
+- `native/mahayana-messaging/src/server.rs`
+- `native/mahayana-messaging/src/bin/messaging-server.rs`
+- `../../evidence/M1-T02-current-main/README.md`
+
+## Next action
+
+Open the clean current-main PR, obtain current GitHub Actions evidence, merge through protected-main governance, then verify and close the M1 storage gate on canonical `main`.

--- a/projects/telegram-fabushi-integration/management/wbs/M1.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M1.md
@@ -15,12 +15,12 @@
 
 - **交付物**：production local-first storage
 - **验收标准**：Rust 单测通过；可恢复会话/消息状态；production server 默认使用 durable store
-- **客观验证**：M1.T06 SQLite foundation + M1.T02 production cutover PR #1990
+- **客观验证**：M1.T06 SQLite foundation + clean current-main production cutover
 - **来源**：源计划 M1
-- **状态**：IN_PROGRESS
-- **阻塞**：依赖 M1.T06 先进入 main；#1990 CI/merge pending
-- **证据位置**：`../tasks/M1-T02-production-storage.md`（active branch）；PR #1990
-- **下一步**：通过 #1990 gate，完成 production SQLite + legacy JSON one-time migration。
+- **状态**：IMPLEMENTED
+- **阻塞**：clean current-head CI / protected merge / canonical-main verification pending
+- **证据位置**：`../tasks/M1-T02-production-storage-current-main.md`; `../../evidence/M1-T02-current-main/README.md`; historical PR #1990
+- **下一步**：在 latest `main` 派生的 clean branch 上完成当前 CI 与保护合并，避免旧项目文档覆盖 `FAB-P0001 / TFI` 基线。
 
 ### M1.T03 — fabushi-messaging
 
@@ -62,9 +62,9 @@
 - **客观验证**：PR #1988；Messaging Product Gate run `32559222693`; Mahayana fast checks `32559222679`
 - **来源**：源计划 M1
 - **状态**：TESTED
-- **阻塞**：protected merge queue / canonical main verification pending
-- **证据位置**：`../tasks/M1-T06-sqlite-storage.md`; `../../evidence/M1-T06/README.md`; PR #1988
-- **下一步**：merge queue 后在 main 关闭 landed evidence；production default 由 M1.T02/#1990 完成。
+- **阻塞**：无实现阻塞；PR #1988 已进入 canonical `main`，仅剩 durable record closure 与 M1 总体验收归档
+- **证据位置**：`../tasks/M1-T06-sqlite-storage.md`; `../../evidence/M1-T06/README.md`; PR #1988; merge `1b78e4fbc1a666fc725c21450b11d3ab643ac0fa`
+- **下一步**：由 M1.T02 完成 production default 后，在 M1 acceptance reconciliation 中一起关闭 landed evidence。
 
 ### M1.T07 — Conversation/Message/Participant 基础模型
 

--- a/projects/telegram-fabushi-integration/source/2026-08-22-M1-T02-current-main-relanding.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-22-M1-T02-current-main-relanding.md
@@ -1,0 +1,16 @@
+# M1.T02 current-main re-landing source record
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task**: `M1.T02`
+- **Date**: `2026-08-22`
+
+## Source requirement
+
+Continue FAB-P0001 until the Telegram-to-Fabushi integration is fully landed. For M1.T02, production messaging storage must use the self-owned Rust/SQLite path and preserve safe migration from the historical JSON snapshot.
+
+## Execution clarification discovered during this round
+
+PR #1990 contains the intended storage implementation but also carries project-document versions from before immutable portfolio IDs (`FAB-P0001 / TFI`) were established on canonical `main`. Those stale project records must not be merged over the current project baseline.
+
+Therefore the implementation is being re-landed from current `main` on `feat/telegram-m1-sqlite-main-sync`, carrying only the intended M1.T02 runtime change and fresh durable task/evidence records. This is an execution correction, not a scope change.


### PR DESCRIPTION
## Project
- Project ID: `FAB-P0001`
- Project Key: `TFI`
- Task: `M1.T02`

## Objective
Land the already-tested production SQLite cutover on the current canonical `main` without allowing stale pre-portfolio-governance project documents from PR #1990 to overwrite the current `FAB-P0001 / TFI` baseline.

## Runtime changes
- production `MessagingTcpServer` uses `SqliteStateStore`
- `FABUSHI_MESSAGING_DATABASE`, default `fabushi-messaging.sqlite3`
- legacy `FABUSHI_MESSAGING_SNAPSHOT` remains a one-time import source
- JSON import occurs only while SQLite is empty
- existing SQLite state always wins over stale JSON
- compatibility `snapshot_path()` points at the authoritative database path
- configuration/import tests preserved

## Governance reconciliation
This branch was created directly from current `main`. It replays only the intended M1.T02 runtime delta and fresh FAB-P0001 task/evidence/source/status records. Historical PR #1990 remains evidence of the earlier implementation but is not used to land stale project documents.

## Historical verification
The equivalent implementation path in #1990 passed:
- Messaging Product Gate `32559833779`: SUCCESS
- Mahayana fast checks `32559833770`: SUCCESS
- Explicit automerge `32559833763`: SUCCESS

Those runs are historical evidence only. This PR requires current-head CI, protected merge, and canonical-main verification before M1.T02 is closed.

## Verification required
- Messaging Product Gate
- Mahayana fast checks
- repository/project governance checks triggered by the changed project records
- protected-main merge / merge queue
- post-merge canonical-main verification

## Supersession
After this clean PR lands, PR #1990 should be closed as superseded for landing purposes, while retaining its historical CI evidence.