### PR TITLE
feat(messaging): land durable delta sync on clean stack

### DIFF
--- a/native/mahayana-messaging/src/service.rs
+++ b/native/mahayana-messaging/src/service.rs
@@ -1,16 +1,20 @@
 use crate::actor::{ActorId, ActorKind};
 use crate::blob_store::{BlobStoreError, FileBlobStore};
 use crate::bot::BotInvocation;
+use crate::conversation::{ConversationId, ConversationKind};
 use crate::engine::{Command, EngineError, Event, MessagingEngine};
-use crate::message::{Message, MessageContent, MessageId};
+use crate::message::{ClientMessageId, DeliveryState, Message, MessageContent, MessageId};
 use crate::payment::Money;
 use crate::protocol::{
     ClientCommand, ClientEnvelope, ServerEnvelope, ServerEvent, FABUSHI_MESSAGING_PROTOCOL_VERSION,
 };
 use crate::settlement::{SettlementError, SettlementVerifier, SignedSettlement};
-use crate::store::{MessagingSnapshot, MessagingStateStore, StoreError};
+use crate::store::{JournalEntry, MessagingSnapshot, MessagingStateStore, StoreError};
 use crate::wallet::{LedgerEntry, WalletAccountId};
 use base64::Engine as _;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -31,6 +35,8 @@ pub enum MessagingServiceError {
     Invariant(String),
     #[error("messaging command is not authorized for the authenticated actor: {0}")]
     UnauthorizedCommand(String),
+    #[error("client message id {0} was replayed with conflicting message content")]
+    IdempotencyConflict(String),
     #[error(transparent)]
     Settlement(#[from] SettlementError),
 }
@@ -47,6 +53,19 @@ fn sanitize_invocation_component(value: &str) -> String {
         })
         .take(160)
         .collect()
+}
+
+fn stable_message_id(actor_id: &ActorId, client_message_id: &ClientMessageId) -> MessageId {
+    let mut hasher = Sha256::new();
+    hasher.update(actor_id.0.as_bytes());
+    hasher.update([0]);
+    hasher.update(client_message_id.0.as_bytes());
+    let digest = hasher.finalize();
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    MessageId::new(format!("msg:{encoded}"))
 }
 
 pub struct MessagingService<S: MessagingStateStore> {
@@ -110,7 +129,11 @@ impl<S: MessagingStateStore> MessagingService<S> {
         match command {
             ClientCommand::BeginBlobUpload { metadata } => {
                 let status = self.blob_store()?.begin_upload(&metadata)?;
-                self.single_service_event(ServerEvent::BlobUploadChanged { status }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobUploadChanged { status },
+                    server_time_ms,
+                )
             }
             ClientCommand::AppendBlobChunk {
                 blob_id,
@@ -121,22 +144,40 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     .decode(data_base64.as_bytes())
                     .map_err(|error| MessagingServiceError::InvalidBlobBase64(error.to_string()))?;
                 let status = self.blob_store()?.append_chunk(&blob_id, offset, &bytes)?;
-                self.single_service_event(ServerEvent::BlobUploadChanged { status }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobUploadChanged { status },
+                    server_time_ms,
+                )
             }
             ClientCommand::FinishBlobUpload { blob_id } => {
                 let metadata = self.blob_store()?.finish_upload(&blob_id)?;
-                self.single_service_event(ServerEvent::BlobReady { metadata }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobReady { metadata },
+                    server_time_ms,
+                )
             }
             ClientCommand::DeleteBlob { blob_id } => {
                 self.blob_store()?.delete(&blob_id)?;
-                self.single_service_event(ServerEvent::BlobDeleted { blob_id }, server_time_ms)
+                self.single_service_event(
+                    &actor_id,
+                    ServerEvent::BlobDeleted { blob_id },
+                    server_time_ms,
+                )
             }
             ClientCommand::WalletStatus => {
                 Ok(vec![self.wallet_status_envelope(&actor_id, server_time_ms)])
             }
+            ClientCommand::Sync { cursor, limit } => {
+                self.mark_direct_messages_delivered(&actor_id, server_time_ms)?;
+                self.sync_response(&actor_id, cursor.as_deref(), limit, server_time_ms)
+            }
             command => {
-                if let ClientCommand::Sync { limit, .. } = &command {
-                    return Ok(vec![self.sync_envelope(&actor_id, *limit, server_time_ms)]);
+                if let Some(replay) =
+                    self.idempotent_send_replay(&actor_id, &command, server_time_ms)?
+                {
+                    return Ok(replay);
                 }
 
                 let commands = self.project_command(&actor_id, command, server_time_ms);
@@ -157,7 +198,6 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     .flat_map(|message| self.bot_invocations_for_message(message))
                     .collect::<Vec<_>>();
                 self.cursor = self.cursor.saturating_add(events.len() as u64);
-                self.persist(server_time_ms)?;
                 let mut responses = events
                     .into_iter()
                     .filter_map(|event| self.project_event(event, server_time_ms))
@@ -172,9 +212,69 @@ impl<S: MessagingStateStore> MessagingService<S> {
                             event: ServerEvent::BotInvocationRequested { invocation },
                         }),
                 );
+                let journal = self.journal_entries(&actor_id, &responses);
+                self.persist_with_events(server_time_ms, &journal)?;
                 Ok(responses)
             }
         }
+    }
+
+    fn idempotent_send_replay(
+        &self,
+        actor_id: &ActorId,
+        command: &ClientCommand,
+        server_time_ms: i64,
+    ) -> Result<Option<Vec<ServerEnvelope>>, MessagingServiceError> {
+        let ClientCommand::SendMessage {
+            conversation_id,
+            client_message_id,
+            content,
+            reply_to_message_id,
+            thread_root_message_id,
+            scheduled_at_ms,
+            silent,
+            protected_content,
+        } = command
+        else {
+            return Ok(None);
+        };
+        let stable_id = stable_message_id(actor_id, client_message_id);
+        let legacy_id = MessageId::new(format!("local:{}", client_message_id.0));
+        let existing = self
+            .engine
+            .state()
+            .messages
+            .get(conversation_id)
+            .and_then(|messages| {
+                messages
+                    .get(&stable_id)
+                    .or_else(|| messages.get(&legacy_id))
+            });
+        let Some(existing) = existing else {
+            return Ok(None);
+        };
+        // The stable/legacy lookup key already binds this replay to the authenticated
+        // actor + client_message_id, without extending the canonical Message schema.
+        if &existing.sender_id != actor_id
+            || &existing.content != content
+            || &existing.reply_to_message_id != reply_to_message_id
+            || &existing.thread_root_message_id != thread_root_message_id
+            || &existing.scheduled_at_ms != scheduled_at_ms
+            || &existing.silent != silent
+            || &existing.protected_content != protected_content
+        {
+            return Err(MessagingServiceError::IdempotencyConflict(
+                client_message_id.0.clone(),
+            ));
+        }
+        Ok(Some(vec![ServerEnvelope {
+            protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
+            cursor: Some(self.cursor.to_string()),
+            server_time_ms,
+            event: ServerEvent::MessageChanged {
+                message: existing.clone(),
+            },
+        }]))
     }
 
     fn bot_invocations_for_message(&self, message: &Message) -> Vec<BotInvocation> {
@@ -315,17 +415,20 @@ impl<S: MessagingStateStore> MessagingService<S> {
 
     fn single_service_event(
         &mut self,
+        actor_id: &ActorId,
         event: ServerEvent,
         server_time_ms: i64,
     ) -> Result<Vec<ServerEnvelope>, MessagingServiceError> {
         self.cursor = self.cursor.saturating_add(1);
-        self.persist(server_time_ms)?;
-        Ok(vec![ServerEnvelope {
+        let response = ServerEnvelope {
             protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
             cursor: Some(self.cursor.to_string()),
             server_time_ms,
             event,
-        }])
+        };
+        let journal = self.journal_entries(actor_id, std::slice::from_ref(&response));
+        self.persist_with_events(server_time_ms, &journal)?;
+        Ok(vec![response])
     }
 
     pub fn apply_signed_settlement(
@@ -409,6 +512,63 @@ impl<S: MessagingStateStore> MessagingService<S> {
         }
     }
 
+    fn sync_response(
+        &self,
+        actor_id: &ActorId,
+        cursor: Option<&str>,
+        limit: u32,
+        server_time_ms: i64,
+    ) -> Result<Vec<ServerEnvelope>, MessagingServiceError> {
+        let Some(requested_cursor) = cursor.and_then(|value| value.parse::<u64>().ok()) else {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        };
+        if requested_cursor > self.cursor {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        }
+        let Some(slice) = self.store.load_event_journal_after(
+            requested_cursor,
+            usize::try_from(limit.max(1)).unwrap_or(usize::MAX),
+        )?
+        else {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        };
+        if requested_cursor < slice.floor_cursor
+            || (slice.entries.is_empty() && requested_cursor < slice.current_cursor)
+        {
+            return Ok(vec![self.sync_envelope(actor_id, limit, server_time_ms)]);
+        }
+        let mut responses = slice
+            .entries
+            .into_iter()
+            .filter(|entry| entry.audience.iter().any(|candidate| candidate == actor_id))
+            .map(|entry| entry.envelope)
+            .collect::<Vec<_>>();
+        responses.push(self.sync_checkpoint_envelope(slice.checkpoint_cursor, server_time_ms));
+        Ok(responses)
+    }
+
+    fn sync_checkpoint_envelope(&self, cursor: u64, server_time_ms: i64) -> ServerEnvelope {
+        ServerEnvelope {
+            protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
+            cursor: Some(cursor.to_string()),
+            server_time_ms,
+            event: ServerEvent::SyncBatch {
+                actors: Vec::new(),
+                conversations: Vec::new(),
+                messages: Vec::new(),
+                folders: Vec::new(),
+                invoices: Vec::new(),
+                orders: Vec::new(),
+                stories: Vec::new(),
+                communities: Vec::new(),
+                bots: Vec::new(),
+                bot_executions: Vec::new(),
+                mini_apps: Vec::new(),
+                next_cursor: Some(cursor.to_string()),
+            },
+        }
+    }
+
     fn sync_envelope(&self, actor_id: &ActorId, limit: u32, server_time_ms: i64) -> ServerEnvelope {
         let state = self.engine.state();
         let max_items = usize::try_from(limit.max(1)).unwrap_or(usize::MAX);
@@ -423,7 +583,7 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     || conversation.owner_id.as_ref() == Some(actor_id)
             })
             .map(|conversation| conversation.id.clone())
-            .collect::<std::collections::BTreeSet<_>>();
+            .collect::<BTreeSet<_>>();
         let visible_actor_ids = visible_conversation_ids
             .iter()
             .filter_map(|conversation_id| state.conversations.get(conversation_id))
@@ -434,7 +594,7 @@ impl<S: MessagingStateStore> MessagingService<S> {
                     .map(|participant| participant.actor_id.clone())
             })
             .chain(std::iter::once(actor_id.clone()))
-            .collect::<std::collections::BTreeSet<_>>();
+            .collect::<BTreeSet<_>>();
         ServerEnvelope {
             protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
             cursor: Some(self.cursor.to_string()),
@@ -525,6 +685,61 @@ impl<S: MessagingStateStore> MessagingService<S> {
         }
     }
 
+    fn mark_direct_messages_delivered(
+        &mut self,
+        actor_id: &ActorId,
+        server_time_ms: i64,
+    ) -> Result<(), MessagingServiceError> {
+        let pending = self
+            .engine
+            .state()
+            .conversations
+            .values()
+            .filter(|conversation| {
+                matches!(
+                    conversation.kind,
+                    ConversationKind::Direct | ConversationKind::Secret
+                ) && conversation
+                    .participants
+                    .iter()
+                    .any(|participant| &participant.actor_id == actor_id)
+            })
+            .flat_map(|conversation| {
+                self.engine
+                    .state()
+                    .messages
+                    .get(&conversation.id)
+                    .into_iter()
+                    .flat_map(|messages| messages.values())
+                    .filter(|message| {
+                        &message.sender_id != actor_id
+                            && message.delivery_state == DeliveryState::Sent
+                    })
+                    .map(|message| (conversation.id.clone(), message.id.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        if pending.is_empty() {
+            return Ok(());
+        }
+        let mut events = Vec::new();
+        for (conversation_id, message_id) in pending {
+            events.extend(self.engine.execute(Command::SetDeliveryState {
+                conversation_id,
+                message_id,
+                state: DeliveryState::Delivered,
+            })?);
+        }
+        self.cursor = self.cursor.saturating_add(events.len() as u64);
+        let responses = events
+            .into_iter()
+            .filter_map(|event| self.project_event(event, server_time_ms))
+            .collect::<Vec<_>>();
+        let journal = self.journal_entries(actor_id, &responses);
+        self.persist_with_events(server_time_ms, &journal)?;
+        Ok(())
+    }
+
     fn project_command(
         &self,
         actor_id: &ActorId,
@@ -574,19 +789,30 @@ impl<S: MessagingStateStore> MessagingService<S> {
                 scheduled_at_ms,
                 silent,
                 protected_content,
-            } => vec![Command::QueueMessage {
-                conversation_id,
-                local_message_id: MessageId::new(format!("local:{}", client_message_id.0)),
-                client_message_id,
-                sender_id: actor_id.clone(),
-                content,
-                reply_to_message_id,
-                thread_root_message_id,
-                created_at_ms: now_ms,
-                scheduled_at_ms,
-                silent,
-                protected_content,
-            }],
+            } => {
+                let message_id = stable_message_id(actor_id, &client_message_id);
+                vec![
+                    Command::QueueMessage {
+                        conversation_id: conversation_id.clone(),
+                        local_message_id: message_id.clone(),
+                        client_message_id,
+                        sender_id: actor_id.clone(),
+                        content,
+                        reply_to_message_id,
+                        thread_root_message_id,
+                        created_at_ms: now_ms,
+                        scheduled_at_ms,
+                        silent,
+                        protected_content,
+                    },
+                    Command::AcknowledgeMessage {
+                        conversation_id,
+                        local_message_id: message_id.clone(),
+                        server_message_id: message_id,
+                        accepted_at_ms: now_ms,
+                    },
+                ]
+            }
             ClientCommand::ForwardMessage {
                 source_conversation_id,
                 message_id,
@@ -622,11 +848,39 @@ impl<S: MessagingStateStore> MessagingService<S> {
             ClientCommand::MarkRead {
                 conversation_id,
                 message_id,
-            } => vec![Command::MarkRead {
-                conversation_id,
-                actor_id: actor_id.clone(),
-                message_id,
-            }],
+            } => {
+                let mut commands = vec![Command::MarkRead {
+                    conversation_id: conversation_id.clone(),
+                    actor_id: actor_id.clone(),
+                    message_id: message_id.clone(),
+                }];
+                let should_mark_message_read = self
+                    .engine
+                    .state()
+                    .conversations
+                    .get(&conversation_id)
+                    .is_some_and(|conversation| {
+                        matches!(
+                            conversation.kind,
+                            ConversationKind::Direct | ConversationKind::Secret
+                        )
+                    })
+                    && self
+                        .engine
+                        .state()
+                        .messages
+                        .get(&conversation_id)
+                        .and_then(|messages| messages.get(&message_id))
+                        .is_some_and(|message| &message.sender_id != actor_id);
+                if should_mark_message_read {
+                    commands.push(Command::SetDeliveryState {
+                        conversation_id,
+                        message_id,
+                        state: DeliveryState::Read,
+                    });
+                }
+                commands
+            }
             ClientCommand::SetReaction {
                 conversation_id,
                 message_id,
@@ -883,6 +1137,160 @@ impl<S: MessagingStateStore> MessagingService<S> {
             server_time_ms,
             event: server_event,
         })
+    }
+
+    fn journal_entries(
+        &self,
+        initiator: &ActorId,
+        responses: &[ServerEnvelope],
+    ) -> Vec<JournalEntry> {
+        responses
+            .iter()
+            .filter(|response| !matches!(&response.event, ServerEvent::SyncBatch { .. }))
+            .map(|response| JournalEntry {
+                envelope: response.clone(),
+                audience: self.event_audience(initiator, &response.event),
+            })
+            .collect()
+    }
+
+    fn event_audience(&self, initiator: &ActorId, event: &ServerEvent) -> Vec<ActorId> {
+        let mut audience = BTreeSet::from([initiator.clone()]);
+        match event {
+            ServerEvent::ActorChanged { actor } => {
+                audience.insert(actor.id.clone());
+                for conversation in
+                    self.engine
+                        .state()
+                        .conversations
+                        .values()
+                        .filter(|conversation| {
+                            conversation
+                                .participants
+                                .iter()
+                                .any(|participant| participant.actor_id == actor.id)
+                        })
+                {
+                    Self::extend_conversation_audience(&mut audience, conversation);
+                }
+            }
+            ServerEvent::PresenceChanged { actor_id, .. } => {
+                audience.insert(actor_id.clone());
+                for conversation in
+                    self.engine
+                        .state()
+                        .conversations
+                        .values()
+                        .filter(|conversation| {
+                            conversation
+                                .participants
+                                .iter()
+                                .any(|participant| &participant.actor_id == actor_id)
+                        })
+                {
+                    Self::extend_conversation_audience(&mut audience, conversation);
+                }
+            }
+            ServerEvent::ConversationChanged { conversation } => {
+                Self::extend_conversation_audience(&mut audience, conversation);
+            }
+            ServerEvent::MessageAdded { message } | ServerEvent::MessageChanged { message } => {
+                self.extend_conversation_id_audience(&mut audience, &message.conversation_id);
+            }
+            ServerEvent::MessagesDeleted {
+                conversation_id, ..
+            }
+            | ServerEvent::ReadChanged {
+                conversation_id, ..
+            }
+            | ServerEvent::TypingChanged {
+                conversation_id, ..
+            } => {
+                self.extend_conversation_id_audience(&mut audience, conversation_id);
+            }
+            ServerEvent::InvoiceChanged { invoice } => {
+                self.extend_conversation_id_audience(&mut audience, &invoice.conversation_id);
+            }
+            ServerEvent::OrderChanged { order } => {
+                audience.insert(order.buyer_id.clone());
+                if let Some(invoice) = self.engine.state().invoices.get(&order.invoice_id) {
+                    audience.insert(invoice.seller_id.clone());
+                }
+            }
+            ServerEvent::StoryChanged { story } => {
+                audience.insert(story.owner_id.clone());
+            }
+            ServerEvent::CommunityChanged { community } => {
+                self.extend_conversation_id_audience(&mut audience, &community.conversation_id);
+            }
+            ServerEvent::BotChanged { profile, execution } => {
+                if let Some(profile) = profile {
+                    audience.insert(profile.actor_id.clone());
+                }
+                if let Some(execution) = execution {
+                    audience.insert(execution.bot_id.clone());
+                }
+            }
+            ServerEvent::BotInvocationRequested { invocation } => {
+                audience.insert(invocation.sender_id.clone());
+                audience.insert(invocation.bot_id.clone());
+                self.extend_conversation_id_audience(&mut audience, &invocation.conversation_id);
+            }
+            ServerEvent::MiniAppOpened { session } => {
+                audience.insert(session.actor_id.clone());
+            }
+            ServerEvent::MiniAppResult { session_id, .. } => {
+                if let Some(session) = self.engine.state().mini_app_sessions.get(session_id) {
+                    audience.insert(session.actor_id.clone());
+                }
+            }
+            ServerEvent::SyncBatch { .. }
+            | ServerEvent::FolderChanged { .. }
+            | ServerEvent::FolderDeleted { .. }
+            | ServerEvent::BlobUploadChanged { .. }
+            | ServerEvent::BlobReady { .. }
+            | ServerEvent::BlobDeleted { .. }
+            | ServerEvent::WalletStatus { .. }
+            | ServerEvent::StoryDeleted { .. }
+            | ServerEvent::MiniAppChanged { .. }
+            | ServerEvent::Error { .. } => {}
+        }
+        audience.into_iter().collect()
+    }
+
+    fn extend_conversation_id_audience(
+        &self,
+        audience: &mut BTreeSet<ActorId>,
+        conversation_id: &ConversationId,
+    ) {
+        if let Some(conversation) = self.engine.state().conversations.get(conversation_id) {
+            Self::extend_conversation_audience(audience, conversation);
+        }
+    }
+
+    fn extend_conversation_audience(
+        audience: &mut BTreeSet<ActorId>,
+        conversation: &crate::conversation::Conversation,
+    ) {
+        audience.extend(
+            conversation
+                .participants
+                .iter()
+                .map(|participant| participant.actor_id.clone()),
+        );
+        if let Some(owner_id) = &conversation.owner_id {
+            audience.insert(owner_id.clone());
+        }
+    }
+
+    fn persist_with_events(
+        &mut self,
+        now_ms: i64,
+        events: &[JournalEntry],
+    ) -> Result<(), MessagingServiceError> {
+        let snapshot = MessagingSnapshot::new(self.engine.state().clone(), self.cursor, now_ms);
+        self.store.save_with_events(&snapshot, events)?;
+        Ok(())
     }
 
     fn persist(&mut self, now_ms: i64) -> Result<(), MessagingServiceError> {

--- a/native/mahayana-messaging/src/store.rs
+++ b/native/mahayana-messaging/src/store.rs
@@ -1,5 +1,7 @@
+use crate::actor::ActorId;
 use crate::engine::MessagingState;
-use rusqlite::{params, Connection, OptionalExtension};
+use crate::protocol::ServerEnvelope;
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::io::{Read, Write};
@@ -7,7 +9,8 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 pub const MESSAGING_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
-pub const MESSAGING_SQLITE_SCHEMA_VERSION: u32 = 1;
+pub const MESSAGING_SQLITE_SCHEMA_VERSION: u32 = 2;
+pub const MESSAGING_EVENT_JOURNAL_LIMIT: usize = 10_000;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,6 +32,22 @@ impl MessagingSnapshot {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalEntry {
+    pub envelope: ServerEnvelope,
+    pub audience: Vec<ActorId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventJournalSlice {
+    pub floor_cursor: u64,
+    pub current_cursor: u64,
+    pub checkpoint_cursor: u64,
+    pub has_more: bool,
+    pub entries: Vec<JournalEntry>,
+}
+
 #[derive(Debug, Error)]
 pub enum StoreError {
     #[error("messaging store I/O failed: {0}")]
@@ -39,6 +58,8 @@ pub enum StoreError {
     Sqlite(#[from] rusqlite::Error),
     #[error("messaging cursor is invalid: {0}")]
     InvalidCursor(#[from] std::num::ParseIntError),
+    #[error("messaging journal event is missing a server cursor")]
+    MissingEventCursor,
     #[error("unsupported messaging snapshot schema {actual}; expected {expected}")]
     UnsupportedSchema { expected: u32, actual: u32 },
     #[error("unsupported messaging SQLite schema {actual}; expected at most {expected}")]
@@ -48,11 +69,29 @@ pub enum StoreError {
 pub trait MessagingStateStore: Send {
     fn load(&self) -> Result<Option<MessagingSnapshot>, StoreError>;
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError>;
+
+    fn save_with_events(
+        &mut self,
+        snapshot: &MessagingSnapshot,
+        _events: &[JournalEntry],
+    ) -> Result<(), StoreError> {
+        self.save(snapshot)
+    }
+
+    fn load_event_journal_after(
+        &self,
+        _cursor: u64,
+        _cursor_group_limit: usize,
+    ) -> Result<Option<EventJournalSlice>, StoreError> {
+        Ok(None)
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct MemoryStateStore {
     snapshot: Option<MessagingSnapshot>,
+    journal: Vec<JournalEntry>,
+    journal_floor_cursor: u64,
 }
 
 impl MemoryStateStore {
@@ -68,8 +107,53 @@ impl MessagingStateStore for MemoryStateStore {
 
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
         validate_snapshot_schema(snapshot.schema_version)?;
+        if self.journal.is_empty() {
+            self.journal_floor_cursor = self.journal_floor_cursor.max(snapshot.cursor);
+        }
         self.snapshot = Some(snapshot.clone());
         Ok(())
+    }
+
+    fn save_with_events(
+        &mut self,
+        snapshot: &MessagingSnapshot,
+        events: &[JournalEntry],
+    ) -> Result<(), StoreError> {
+        validate_snapshot_schema(snapshot.schema_version)?;
+        for event in events {
+            journal_cursor(event)?;
+        }
+        self.snapshot = Some(snapshot.clone());
+        self.journal.extend_from_slice(events);
+        if self.journal.len() > MESSAGING_EVENT_JOURNAL_LIMIT {
+            let excess = self.journal.len() - MESSAGING_EVENT_JOURNAL_LIMIT;
+            let prune_cursor = journal_cursor(&self.journal[excess - 1])?;
+            let remove_count = self
+                .journal
+                .iter()
+                .take_while(|entry| {
+                    journal_cursor(entry).is_ok_and(|cursor| cursor <= prune_cursor)
+                })
+                .count();
+            self.journal.drain(0..remove_count);
+            self.journal_floor_cursor = prune_cursor;
+        }
+        Ok(())
+    }
+
+    fn load_event_journal_after(
+        &self,
+        cursor: u64,
+        cursor_group_limit: usize,
+    ) -> Result<Option<EventJournalSlice>, StoreError> {
+        let current_cursor = self.snapshot.as_ref().map_or(0, |snapshot| snapshot.cursor);
+        Ok(Some(slice_journal(
+            &self.journal,
+            self.journal_floor_cursor,
+            current_cursor,
+            cursor,
+            cursor_group_limit,
+        )?))
     }
 }
 
@@ -150,8 +234,8 @@ impl SqliteStateStore {
     }
 
     pub fn initialize(&self) -> Result<(), StoreError> {
-        let connection = self.open()?;
-        migrate_sqlite(&connection)
+        let mut connection = self.open()?;
+        migrate_sqlite(&mut connection)
     }
 
     pub fn import_json_if_empty(
@@ -176,8 +260,8 @@ impl SqliteStateStore {
     }
 
     fn open_initialized(&self) -> Result<Connection, StoreError> {
-        let connection = self.open()?;
-        migrate_sqlite(&connection)?;
+        let mut connection = self.open()?;
+        migrate_sqlite(&mut connection)?;
         Ok(connection)
     }
 }
@@ -185,50 +269,86 @@ impl SqliteStateStore {
 impl MessagingStateStore for SqliteStateStore {
     fn load(&self) -> Result<Option<MessagingSnapshot>, StoreError> {
         let connection = self.open_initialized()?;
-        let row = connection
-            .query_row(
-                "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json FROM messaging_snapshot WHERE singleton = 1",
-                [],
-                |row| {
-                    Ok((
-                        row.get::<_, u32>(0)?,
-                        row.get::<_, String>(1)?,
-                        row.get::<_, i64>(2)?,
-                        row.get::<_, String>(3)?,
-                    ))
-                },
-            )
-            .optional()?;
-
-        let Some((schema_version, cursor, saved_at_ms, state_json)) = row else {
-            return Ok(None);
-        };
-        validate_snapshot_schema(schema_version)?;
-        let state = serde_json::from_str(&state_json)?;
-        Ok(Some(MessagingSnapshot {
-            schema_version,
-            cursor: cursor.parse()?,
-            saved_at_ms,
-            state,
-        }))
+        load_sqlite_snapshot(&connection)
     }
 
     fn save(&mut self, snapshot: &MessagingSnapshot) -> Result<(), StoreError> {
         validate_snapshot_schema(snapshot.schema_version)?;
         let mut connection = self.open_initialized()?;
         let transaction = connection.transaction()?;
-        let state_json = serde_json::to_string(&snapshot.state)?;
-        transaction.execute(
-            "INSERT INTO messaging_snapshot (singleton, snapshot_schema_version, cursor, saved_at_ms, state_json) VALUES (1, ?1, ?2, ?3, ?4) ON CONFLICT(singleton) DO UPDATE SET snapshot_schema_version = excluded.snapshot_schema_version, cursor = excluded.cursor, saved_at_ms = excluded.saved_at_ms, state_json = excluded.state_json",
-            params![
-                snapshot.schema_version,
-                snapshot.cursor.to_string(),
-                snapshot.saved_at_ms,
-                state_json
-            ],
-        )?;
+        write_snapshot(&transaction, snapshot)?;
+        let journal_count: i64 =
+            transaction.query_row("SELECT COUNT(*) FROM messaging_event_journal", [], |row| {
+                row.get(0)
+            })?;
+        if journal_count == 0 {
+            set_journal_floor(&transaction, snapshot.cursor)?;
+        }
         transaction.commit()?;
         Ok(())
+    }
+
+    fn save_with_events(
+        &mut self,
+        snapshot: &MessagingSnapshot,
+        events: &[JournalEntry],
+    ) -> Result<(), StoreError> {
+        validate_snapshot_schema(snapshot.schema_version)?;
+        let mut connection = self.open_initialized()?;
+        let transaction = connection.transaction()?;
+        write_snapshot(&transaction, snapshot)?;
+        for event in events {
+            let cursor = journal_cursor(event)?;
+            transaction.execute(
+                "INSERT INTO messaging_event_journal (cursor, audience_json, envelope_json) VALUES (?1, ?2, ?3)",
+                params![
+                    cursor.to_string(),
+                    serde_json::to_string(&event.audience)?,
+                    serde_json::to_string(&event.envelope)?
+                ],
+            )?;
+        }
+        prune_sqlite_journal(&transaction)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    fn load_event_journal_after(
+        &self,
+        cursor: u64,
+        cursor_group_limit: usize,
+    ) -> Result<Option<EventJournalSlice>, StoreError> {
+        let connection = self.open_initialized()?;
+        let floor_cursor = connection
+            .query_row(
+                "SELECT value FROM messaging_metadata WHERE key = 'journal_floor_cursor'",
+                [],
+                |row| row.get::<_, String>(0),
+            )?
+            .parse()?;
+        let current_cursor =
+            load_sqlite_snapshot(&connection)?.map_or(0, |snapshot| snapshot.cursor);
+        let mut statement = connection.prepare(
+            "SELECT audience_json, envelope_json FROM messaging_event_journal ORDER BY sequence ASC",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut entries = Vec::new();
+        for row in rows {
+            let (audience_json, envelope_json) = row?;
+            entries.push(JournalEntry {
+                audience: serde_json::from_str(&audience_json)?,
+                envelope: serde_json::from_str(&envelope_json)?,
+            });
+        }
+        Ok(Some(slice_journal(
+            &entries,
+            floor_cursor,
+            current_cursor,
+            cursor,
+            cursor_group_limit,
+        )?))
     }
 }
 
@@ -242,7 +362,143 @@ fn validate_snapshot_schema(actual: u32) -> Result<(), StoreError> {
     Ok(())
 }
 
-fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
+fn journal_cursor(entry: &JournalEntry) -> Result<u64, StoreError> {
+    entry
+        .envelope
+        .cursor
+        .as_deref()
+        .ok_or(StoreError::MissingEventCursor)?
+        .parse()
+        .map_err(StoreError::from)
+}
+
+fn slice_journal(
+    entries: &[JournalEntry],
+    floor_cursor: u64,
+    current_cursor: u64,
+    requested_cursor: u64,
+    cursor_group_limit: usize,
+) -> Result<EventJournalSlice, StoreError> {
+    let limit = cursor_group_limit.max(1);
+    let mut selected = Vec::new();
+    let mut selected_groups = 0usize;
+    let mut last_selected_cursor = None;
+    let mut has_more = false;
+
+    for entry in entries {
+        let cursor = journal_cursor(entry)?;
+        if cursor <= requested_cursor {
+            continue;
+        }
+        if last_selected_cursor != Some(cursor) {
+            if selected_groups >= limit {
+                has_more = true;
+                break;
+            }
+            selected_groups += 1;
+            last_selected_cursor = Some(cursor);
+        }
+        selected.push(entry.clone());
+    }
+
+    let checkpoint_cursor = if has_more {
+        last_selected_cursor.unwrap_or(requested_cursor)
+    } else if selected.is_empty() && requested_cursor < current_cursor {
+        requested_cursor
+    } else {
+        current_cursor
+    };
+
+    Ok(EventJournalSlice {
+        floor_cursor,
+        current_cursor,
+        checkpoint_cursor,
+        has_more,
+        entries: selected,
+    })
+}
+
+fn load_sqlite_snapshot(connection: &Connection) -> Result<Option<MessagingSnapshot>, StoreError> {
+    let row = connection
+        .query_row(
+            "SELECT snapshot_schema_version, cursor, saved_at_ms, state_json FROM messaging_snapshot WHERE singleton = 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, u32>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((schema_version, cursor, saved_at_ms, state_json)) = row else {
+        return Ok(None);
+    };
+    validate_snapshot_schema(schema_version)?;
+    Ok(Some(MessagingSnapshot {
+        schema_version,
+        cursor: cursor.parse()?,
+        saved_at_ms,
+        state: serde_json::from_str(&state_json)?,
+    }))
+}
+
+fn write_snapshot(
+    transaction: &Transaction<'_>,
+    snapshot: &MessagingSnapshot,
+) -> Result<(), StoreError> {
+    let state_json = serde_json::to_string(&snapshot.state)?;
+    transaction.execute(
+        "INSERT INTO messaging_snapshot (singleton, snapshot_schema_version, cursor, saved_at_ms, state_json) VALUES (1, ?1, ?2, ?3, ?4) ON CONFLICT(singleton) DO UPDATE SET snapshot_schema_version = excluded.snapshot_schema_version, cursor = excluded.cursor, saved_at_ms = excluded.saved_at_ms, state_json = excluded.state_json",
+        params![
+            snapshot.schema_version,
+            snapshot.cursor.to_string(),
+            snapshot.saved_at_ms,
+            state_json
+        ],
+    )?;
+    Ok(())
+}
+
+fn set_journal_floor(transaction: &Transaction<'_>, cursor: u64) -> Result<(), StoreError> {
+    transaction.execute(
+        "INSERT INTO messaging_metadata (key, value) VALUES ('journal_floor_cursor', ?1) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![cursor.to_string()],
+    )?;
+    Ok(())
+}
+
+fn prune_sqlite_journal(transaction: &Transaction<'_>) -> Result<(), StoreError> {
+    let count: i64 =
+        transaction.query_row("SELECT COUNT(*) FROM messaging_event_journal", [], |row| {
+            row.get(0)
+        })?;
+    let limit = i64::try_from(MESSAGING_EVENT_JOURNAL_LIMIT).unwrap_or(i64::MAX);
+    if count <= limit {
+        return Ok(());
+    }
+    let excess = count.saturating_sub(limit);
+    let prune_cursor: String = transaction.query_row(
+        "SELECT cursor FROM messaging_event_journal ORDER BY sequence ASC LIMIT 1 OFFSET ?1",
+        params![excess.saturating_sub(1)],
+        |row| row.get(0),
+    )?;
+    let max_sequence: i64 = transaction.query_row(
+        "SELECT MAX(sequence) FROM messaging_event_journal WHERE cursor = ?1",
+        params![&prune_cursor],
+        |row| row.get(0),
+    )?;
+    transaction.execute(
+        "DELETE FROM messaging_event_journal WHERE sequence <= ?1",
+        params![max_sequence],
+    )?;
+    set_journal_floor(transaction, prune_cursor.parse()?)?;
+    Ok(())
+}
+
+fn migrate_sqlite(connection: &mut Connection) -> Result<(), StoreError> {
     let actual: u32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if actual > MESSAGING_SQLITE_SCHEMA_VERSION {
         return Err(StoreError::UnsupportedSqliteSchema {
@@ -251,18 +507,60 @@ fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
         });
     }
     if actual == 0 {
-        connection.execute_batch(
-            "BEGIN IMMEDIATE;
-             CREATE TABLE IF NOT EXISTS messaging_snapshot (
+        let transaction = connection.transaction()?;
+        transaction.execute_batch(
+            "CREATE TABLE IF NOT EXISTS messaging_snapshot (
                  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
                  snapshot_schema_version INTEGER NOT NULL,
                  cursor TEXT NOT NULL,
                  saved_at_ms INTEGER NOT NULL,
                  state_json TEXT NOT NULL
              );
-             PRAGMA user_version = 1;
-             COMMIT;",
+             CREATE TABLE IF NOT EXISTS messaging_event_journal (
+                 sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                 cursor TEXT NOT NULL,
+                 audience_json TEXT NOT NULL,
+                 envelope_json TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS messaging_metadata (
+                 key TEXT PRIMARY KEY,
+                 value TEXT NOT NULL
+             );",
         )?;
+        transaction.execute(
+            "INSERT OR IGNORE INTO messaging_metadata (key, value) VALUES ('journal_floor_cursor', '0')",
+            [],
+        )?;
+        transaction.execute_batch("PRAGMA user_version = 2;")?;
+        transaction.commit()?;
+    } else if actual == 1 {
+        let current_cursor = connection
+            .query_row(
+                "SELECT cursor FROM messaging_snapshot WHERE singleton = 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .unwrap_or_else(|| "0".into());
+        let transaction = connection.transaction()?;
+        transaction.execute_batch(
+            "CREATE TABLE IF NOT EXISTS messaging_event_journal (
+                 sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                 cursor TEXT NOT NULL,
+                 audience_json TEXT NOT NULL,
+                 envelope_json TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS messaging_metadata (
+                 key TEXT PRIMARY KEY,
+                 value TEXT NOT NULL
+             );",
+        )?;
+        transaction.execute(
+            "INSERT OR REPLACE INTO messaging_metadata (key, value) VALUES ('journal_floor_cursor', ?1)",
+            params![current_cursor],
+        )?;
+        transaction.execute_batch("PRAGMA user_version = 2;")?;
+        transaction.commit()?;
     }
     Ok(())
 }
@@ -270,6 +568,7 @@ fn migrate_sqlite(connection: &Connection) -> Result<(), StoreError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::{ServerEvent, FABUSHI_MESSAGING_PROTOCOL_VERSION};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temporary_db(name: &str) -> PathBuf {
@@ -287,6 +586,20 @@ mod tests {
         let _ = fs::remove_file(path);
         let _ = fs::remove_file(path.with_extension("sqlite3-wal"));
         let _ = fs::remove_file(path.with_extension("sqlite3-shm"));
+    }
+
+    fn journal_entry(cursor: u64, actor: &str) -> JournalEntry {
+        JournalEntry {
+            envelope: ServerEnvelope {
+                protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
+                cursor: Some(cursor.to_string()),
+                server_time_ms: i64::try_from(cursor).unwrap_or(i64::MAX),
+                event: ServerEvent::FolderDeleted {
+                    folder_id: format!("folder-{cursor}"),
+                },
+            },
+            audience: vec![ActorId::new(actor)],
+        }
     }
 
     #[test]
@@ -356,6 +669,111 @@ mod tests {
             .expect("count snapshots");
         assert_eq!(count, 1);
         remove_db(&path);
+    }
+
+    #[test]
+    fn plain_snapshot_save_preserves_existing_journal() {
+        let path = temporary_db("journal-preserve");
+        let mut store = SqliteStateStore::new(&path);
+        let first = MessagingSnapshot::new(MessagingState::default(), 1, 10);
+        store
+            .save_with_events(&first, &[journal_entry(1, "human:a")])
+            .expect("save journal entry");
+        let second = MessagingSnapshot::new(MessagingState::default(), 2, 20);
+        store.save(&second).expect("save plain snapshot");
+        let slice = store
+            .load_event_journal_after(0, 100)
+            .expect("load preserved journal")
+            .expect("sqlite journal");
+        assert_eq!(slice.entries.len(), 1);
+        assert_eq!(slice.current_cursor, 2);
+        remove_db(&path);
+    }
+
+    #[test]
+    fn sqlite_v1_migration_sets_journal_floor_to_existing_cursor() {
+        let path = temporary_db("v1-migration");
+        let connection = Connection::open(&path).expect("open database");
+        connection
+            .execute_batch(
+                "CREATE TABLE messaging_snapshot (
+                    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                    snapshot_schema_version INTEGER NOT NULL,
+                    cursor TEXT NOT NULL,
+                    saved_at_ms INTEGER NOT NULL,
+                    state_json TEXT NOT NULL
+                 );
+                 INSERT INTO messaging_snapshot VALUES (1, 1, '41', 100, '{}');
+                 PRAGMA user_version = 1;",
+            )
+            .expect("create v1 database");
+        drop(connection);
+
+        let store = SqliteStateStore::new(&path);
+        let slice = store
+            .load_event_journal_after(40, 100)
+            .expect("load migrated journal")
+            .expect("sqlite journal");
+        assert_eq!(slice.floor_cursor, 41);
+        assert_eq!(slice.current_cursor, 41);
+        remove_db(&path);
+    }
+
+    #[test]
+    fn sqlite_store_persists_journal_with_snapshot() {
+        let path = temporary_db("journal");
+        let mut store = SqliteStateStore::new(&path);
+        let snapshot = MessagingSnapshot::new(MessagingState::default(), 3, 30);
+        store
+            .save_with_events(
+                &snapshot,
+                &[journal_entry(2, "human:a"), journal_entry(3, "human:b")],
+            )
+            .expect("save snapshot and journal");
+        drop(store);
+
+        let reopened = SqliteStateStore::new(&path);
+        let slice = reopened
+            .load_event_journal_after(1, 100)
+            .expect("load journal")
+            .expect("sqlite journal");
+        assert_eq!(slice.floor_cursor, 0);
+        assert_eq!(slice.current_cursor, 3);
+        assert_eq!(slice.checkpoint_cursor, 3);
+        assert_eq!(slice.entries.len(), 2);
+        assert_eq!(slice.entries[0].audience, vec![ActorId::new("human:a")]);
+        remove_db(&path);
+    }
+
+    #[test]
+    fn journal_pagination_never_splits_a_cursor_group() {
+        let mut store = MemoryStateStore::default();
+        let snapshot = MessagingSnapshot::new(MessagingState::default(), 3, 30);
+        store
+            .save_with_events(
+                &snapshot,
+                &[
+                    journal_entry(1, "human:a"),
+                    journal_entry(2, "human:a"),
+                    journal_entry(2, "human:b"),
+                    journal_entry(3, "human:a"),
+                ],
+            )
+            .expect("save memory journal");
+        let first = store
+            .load_event_journal_after(0, 2)
+            .expect("load first page")
+            .expect("memory journal");
+        assert!(first.has_more);
+        assert_eq!(first.checkpoint_cursor, 2);
+        assert_eq!(first.entries.len(), 3);
+        let second = store
+            .load_event_journal_after(first.checkpoint_cursor, 2)
+            .expect("load second page")
+            .expect("memory journal");
+        assert!(!second.has_more);
+        assert_eq!(second.checkpoint_cursor, 3);
+        assert_eq!(second.entries.len(), 1);
     }
 
     #[test]

--- a/native/mahayana-messaging/tests/delta_sync_contract.rs
+++ b/native/mahayana-messaging/tests/delta_sync_contract.rs
@@ -1,0 +1,425 @@
+use fabushi_messaging_core::*;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn context(actor_id: &str, device_id: &str, session_id: &str, request_id: &str) -> RequestContext {
+    RequestContext {
+        request_id: request_id.into(),
+        device_id: device_id.into(),
+        actor_id: ActorId::new(actor_id),
+        session_id: session_id.into(),
+        sent_at_ms: 1,
+    }
+}
+
+fn envelope(actor_id: &str, request_id: &str, command: ClientCommand) -> ClientEnvelope {
+    ClientEnvelope::new(
+        context(actor_id, "desktop:1", "session:1", request_id),
+        command,
+    )
+}
+
+fn second_device_envelope(
+    actor_id: &str,
+    request_id: &str,
+    command: ClientCommand,
+) -> ClientEnvelope {
+    ClientEnvelope::new(
+        context(actor_id, "mobile:2", "session:2", request_id),
+        command,
+    )
+}
+
+fn participant(actor_id: &str, role: ParticipantRole) -> Participant {
+    Participant {
+        actor_id: ActorId::new(actor_id),
+        role,
+        joined_at_ms: 1,
+        muted_until_ms: None,
+    }
+}
+
+fn send_text(client_message_id: &str, text: &str) -> ClientCommand {
+    ClientCommand::SendMessage {
+        conversation_id: ConversationId::new("chat:direct"),
+        client_message_id: ClientMessageId(client_message_id.into()),
+        content: MessageContent::Text {
+            text: FormattedText::plain(text),
+        },
+        reply_to_message_id: None,
+        thread_root_message_id: None,
+        scheduled_at_ms: None,
+        silent: false,
+        protected_content: false,
+    }
+}
+
+fn setup_direct_conversation<S: MessagingStateStore>(service: &mut MessagingService<S>) {
+    service
+        .handle(
+            envelope(
+                "human:alice",
+                "actor:alice",
+                ClientCommand::UpsertProfile {
+                    actor: Actor::human("human:alice", "Alice"),
+                },
+            ),
+            10,
+        )
+        .expect("upsert alice");
+    service
+        .handle(
+            envelope(
+                "human:bob",
+                "actor:bob",
+                ClientCommand::UpsertProfile {
+                    actor: Actor::human("human:bob", "Bob"),
+                },
+            ),
+            11,
+        )
+        .expect("upsert bob");
+    service
+        .handle(
+            envelope(
+                "human:outsider",
+                "actor:outsider",
+                ClientCommand::UpsertProfile {
+                    actor: Actor::human("human:outsider", "Outsider"),
+                },
+            ),
+            12,
+        )
+        .expect("upsert outsider");
+    service
+        .handle(
+            envelope(
+                "human:alice",
+                "conversation:create",
+                ClientCommand::CreateConversation {
+                    conversation: Conversation::direct(
+                        "chat:direct",
+                        "Alice and Bob",
+                        vec![
+                            participant("human:alice", ParticipantRole::Owner),
+                            participant("human:bob", ParticipantRole::Member),
+                        ],
+                        13,
+                    ),
+                },
+            ),
+            13,
+        )
+        .expect("create direct conversation");
+}
+
+fn sync_cursor(events: &[ServerEnvelope]) -> String {
+    events
+        .iter()
+        .rev()
+        .find_map(|event| match &event.event {
+            ServerEvent::SyncBatch {
+                next_cursor: Some(cursor),
+                ..
+            } => Some(cursor.clone()),
+            _ => None,
+        })
+        .expect("sync checkpoint cursor")
+}
+
+fn message_from_events(events: &[ServerEnvelope]) -> Message {
+    events
+        .iter()
+        .rev()
+        .find_map(|event| match &event.event {
+            ServerEvent::MessageChanged { message } | ServerEvent::MessageAdded { message } => {
+                Some(message.clone())
+            }
+            _ => None,
+        })
+        .expect("message event")
+}
+
+fn temporary_db(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "fabushi-delta-sync-{name}-{}-{nonce}.sqlite3",
+        std::process::id()
+    ))
+}
+
+fn remove_db(path: &PathBuf) {
+    let _ = fs::remove_file(path);
+    let _ = fs::remove_file(path.with_extension("sqlite3-wal"));
+    let _ = fs::remove_file(path.with_extension("sqlite3-shm"));
+}
+
+#[test]
+fn send_message_is_idempotent_and_server_acknowledged() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
+    setup_direct_conversation(&mut service);
+
+    let first = service
+        .handle(
+            envelope(
+                "human:alice",
+                "send:first",
+                send_text("client:idem", "hello"),
+            ),
+            20,
+        )
+        .expect("send first message");
+    let first_message = message_from_events(&first);
+    assert!(first_message.id.0.starts_with("msg:"));
+    assert_eq!(first_message.delivery_state, DeliveryState::Sent);
+
+    let cursor_after_first = service.cursor();
+    let retry = service
+        .handle(
+            envelope(
+                "human:alice",
+                "send:retry",
+                send_text("client:idem", "hello"),
+            ),
+            21,
+        )
+        .expect("retry idempotent message");
+    let retry_message = message_from_events(&retry);
+    assert_eq!(retry_message.id, first_message.id);
+    assert_eq!(retry_message.delivery_state, DeliveryState::Sent);
+    assert_eq!(service.cursor(), cursor_after_first);
+    assert_eq!(
+        service.engine().state().messages[&ConversationId::new("chat:direct")].len(),
+        1
+    );
+}
+
+#[test]
+fn reusing_client_message_id_with_different_payload_is_rejected() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
+    setup_direct_conversation(&mut service);
+    service
+        .handle(
+            envelope(
+                "human:alice",
+                "send:first",
+                send_text("client:conflict", "one"),
+            ),
+            20,
+        )
+        .expect("send first message");
+
+    let error = service
+        .handle(
+            envelope(
+                "human:alice",
+                "send:conflict",
+                send_text("client:conflict", "two"),
+            ),
+            21,
+        )
+        .expect_err("conflicting retry must fail");
+    assert!(matches!(
+        error,
+        MessagingServiceError::IdempotencyConflict(_)
+    ));
+}
+
+#[test]
+fn recipient_sync_marks_direct_message_delivered_and_mark_read_moves_it_to_read() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
+    setup_direct_conversation(&mut service);
+    let sent = service
+        .handle(
+            envelope(
+                "human:alice",
+                "send:delivery",
+                send_text("client:delivery", "hello bob"),
+            ),
+            20,
+        )
+        .expect("send message");
+    let message_id = message_from_events(&sent).id;
+
+    service
+        .handle(
+            envelope(
+                "human:bob",
+                "sync:delivery",
+                ClientCommand::Sync {
+                    cursor: None,
+                    limit: 100,
+                },
+            ),
+            21,
+        )
+        .expect("recipient sync");
+    assert_eq!(
+        service.engine().state().messages[&ConversationId::new("chat:direct")][&message_id]
+            .delivery_state,
+        DeliveryState::Delivered
+    );
+
+    let read_events = service
+        .handle(
+            envelope(
+                "human:bob",
+                "read:delivery",
+                ClientCommand::MarkRead {
+                    conversation_id: ConversationId::new("chat:direct"),
+                    message_id: message_id.clone(),
+                },
+            ),
+            22,
+        )
+        .expect("mark read");
+    assert!(read_events
+        .iter()
+        .any(|event| matches!(&event.event, ServerEvent::ReadChanged { .. })));
+    assert_eq!(
+        service.engine().state().messages[&ConversationId::new("chat:direct")][&message_id]
+            .delivery_state,
+        DeliveryState::Read
+    );
+}
+
+#[test]
+fn durable_delta_sync_survives_restart_and_is_audience_scoped() {
+    let path = temporary_db("restart");
+    let mut service =
+        MessagingService::load(SqliteStateStore::new(&path)).expect("load sqlite service");
+    setup_direct_conversation(&mut service);
+
+    let bob_baseline = service
+        .handle(
+            envelope(
+                "human:bob",
+                "sync:bob:baseline",
+                ClientCommand::Sync {
+                    cursor: None,
+                    limit: 100,
+                },
+            ),
+            20,
+        )
+        .expect("bob baseline sync");
+    let bob_cursor = sync_cursor(&bob_baseline);
+
+    let outsider_baseline = service
+        .handle(
+            envelope(
+                "human:outsider",
+                "sync:outsider:baseline",
+                ClientCommand::Sync {
+                    cursor: None,
+                    limit: 100,
+                },
+            ),
+            21,
+        )
+        .expect("outsider baseline sync");
+    let outsider_cursor = sync_cursor(&outsider_baseline);
+
+    let sent = service
+        .handle(
+            envelope(
+                "human:alice",
+                "send:delta",
+                send_text("client:delta", "after baseline"),
+            ),
+            22,
+        )
+        .expect("send delta message");
+    let message_id = message_from_events(&sent).id;
+    let cursor_after_send = service.cursor();
+    drop(service);
+
+    let mut restarted =
+        MessagingService::load(SqliteStateStore::new(&path)).expect("restart sqlite service");
+    assert_eq!(restarted.cursor(), cursor_after_send);
+
+    let bob_delta = restarted
+        .handle(
+            second_device_envelope(
+                "human:bob",
+                "sync:bob:device2",
+                ClientCommand::Sync {
+                    cursor: Some(bob_cursor),
+                    limit: 100,
+                },
+            ),
+            23,
+        )
+        .expect("bob device2 delta sync");
+    assert!(bob_delta.iter().any(|event| matches!(
+        &event.event,
+        ServerEvent::MessageAdded { message } | ServerEvent::MessageChanged { message }
+            if message.id == message_id
+    )));
+    assert!(bob_delta.iter().any(|event| matches!(
+        &event.event,
+        ServerEvent::SyncBatch {
+            next_cursor: Some(_),
+            ..
+        }
+    )));
+
+    let outsider_delta = restarted
+        .handle(
+            second_device_envelope(
+                "human:outsider",
+                "sync:outsider:device2",
+                ClientCommand::Sync {
+                    cursor: Some(outsider_cursor),
+                    limit: 100,
+                },
+            ),
+            24,
+        )
+        .expect("outsider delta sync");
+    assert!(!outsider_delta.iter().any(|event| matches!(
+        &event.event,
+        ServerEvent::MessageAdded { .. } | ServerEvent::MessageChanged { .. }
+    )));
+
+    remove_db(&path);
+}
+
+#[test]
+fn cursor_older_than_migrated_journal_floor_falls_back_to_scoped_full_sync() {
+    let path = temporary_db("floor-fallback");
+    let mut legacy = SqliteStateStore::new(&path);
+    let mut state = MessagingState::default();
+    state.actors.insert(
+        ActorId::new("human:alice"),
+        Actor::human("human:alice", "Alice"),
+    );
+    legacy
+        .save(&MessagingSnapshot::new(state, 41, 100))
+        .expect("seed snapshot without journal");
+    drop(legacy);
+
+    let mut service =
+        MessagingService::load(SqliteStateStore::new(&path)).expect("load migrated service");
+    let events = service
+        .handle(
+            envelope(
+                "human:alice",
+                "sync:old-cursor",
+                ClientCommand::Sync {
+                    cursor: Some("40".into()),
+                    limit: 100,
+                },
+            ),
+            101,
+        )
+        .expect("fallback full sync");
+    assert_eq!(events.len(), 1);
+    assert!(matches!(&events[0].event, ServerEvent::SyncBatch { .. }));
+    assert_eq!(events[0].cursor.as_deref(), Some("41"));
+    remove_db(&path);
+}

--- a/projects/telegram-fabushi-integration/evidence/M2-SYNC-001-current-main/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M2-SYNC-001-current-main/README.md
@@ -1,0 +1,39 @@
+# M2-SYNC-001 clean-stack evidence
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task**: `M2-SYNC-001`
+- **Status**: `IN_PROGRESS / FINAL-HEAD CI PENDING`
+- **PR**: #2002
+- **Branch**: `feat/telegram-m2-delta-main-sync`
+
+## Runtime provenance
+
+Historical #1994 runtime blobs are replayed exactly; historical project-document snapshots are not imported:
+
+- `native/mahayana-messaging/src/service.rs` → `24037aa3892ad61c17f95441185e612b02a2ee43`
+- `native/mahayana-messaging/src/store.rs` → `1e46a1c52931ed58da10b803c9d0cf8231e17618`
+- `native/mahayana-messaging/tests/delta_sync_contract.rs` → `6a437b8ce7c4d2266b152fff26639774e670d632`
+
+## Final clean-stack restack
+
+- Lower-stack parent: #2001 head `1030a489a5b4ed12f93464c95325e5d6d2ca7535`.
+- Clean runtime replay commit: `fd76ebd828f62b82ff0eecf34e85b24860e2a342`.
+- Subsequent #2002 commits only refresh current FAB-P0001 task/evidence records before final CI.
+- PR compare against #2001 remains intended M2-SYNC runtime/test/task/evidence/WBS scope.
+
+## Behavior covered
+
+- SQLite schema v2 event journal and migration from v1.
+- Transactional snapshot + journal persistence.
+- Restart/reconnect recovery and journal-floor fallback.
+- Idempotent send/ACK and conflicting client-message-ID rejection.
+- Durable server cursor/checkpoint semantics.
+- Audience-scoped delta replay and outsider isolation.
+- Second-device synchronization.
+- `Sent -> Delivered -> Read` transitions.
+- Cursor-group-aware journal pagination and pruning.
+
+## Completion rule
+
+M2-SYNC-001 is not complete merely because historical code was replayed. The final #2002 head must pass current GitHub Actions, #2001 must land, #2002 must be retargeted/revalidated on `main`, then merged and verified on canonical `main`.

--- a/projects/telegram-fabushi-integration/evidence/M2-SYNC-001-current-main/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M2-SYNC-001-current-main/README.md
@@ -9,18 +9,23 @@
 
 ## Runtime provenance
 
-Historical #1994 runtime blobs are replayed exactly; historical project-document snapshots are not imported:
+Historical #1994 supplied the original durable-sync implementation, but stale historical project-document snapshots are not imported. The final current-main landing keeps the canonical current `Message` schema and reuses the intended durable store/service/test behavior.
 
-- `native/mahayana-messaging/src/service.rs` → `24037aa3892ad61c17f95441185e612b02a2ee43`
-- `native/mahayana-messaging/src/store.rs` → `1e46a1c52931ed58da10b803c9d0cf8231e17618`
-- `native/mahayana-messaging/tests/delta_sync_contract.rs` → `6a437b8ce7c4d2266b152fff26639774e670d632`
+## Current-main compatibility reconciliation
 
-## Final clean-stack restack
+Final current-head CI on the historical replay exposed two real compatibility deltas:
 
-- Lower-stack parent: #2001 head `1030a489a5b4ed12f93464c95325e5d6d2ca7535`.
-- Clean runtime replay commit: `fd76ebd828f62b82ff0eecf34e85b24860e2a342`.
-- Subsequent #2002 commits only refresh current FAB-P0001 task/evidence records before final CI.
-- PR compare against #2001 remains intended M2-SYNC runtime/test/task/evidence/WBS scope.
+1. Rust stable/rustfmt advanced to 1.98; the three M2-SYNC Rust files were reformatted with current stable rustfmt.
+2. Current canonical `Message` no longer has a `client_message_id` field. Idempotent replay already derives a deterministic `stable_message_id(actor_id, client_message_id)` (with legacy local-key lookup), so the obsolete field comparison was removed without extending or reverting `Message` schema. Sender/content/reply/thread/schedule/silent/protected-content conflict checks remain.
+
+## Final clean landing
+
+- M2-NET prerequisite: PR #2001 merged through the protected queue as `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
+- Final base: canonical `main` at `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
+- Clean runtime commit: `5602f96bcb806b2c09981241ab88d99c15f07fc9`.
+- Compare immediately after rebuild: ahead by 1, behind by 0, exactly six changed files.
+- Final runtime blobs include corrected `service.rs` blob `d05ec7160997ff449bbfcf5aa4151ce7938d8a03`, formatted `store.rs` blob `2ffb60eab5986e92e6a296a9c8c90e05ba37fb8a`, and formatted `delta_sync_contract.rs` blob `3e31d0a0e3f566b0b7606d12ece863ed535048b9`.
+- Temporary workflow experiments are absent from the final current-main commit history.
 
 ## Behavior covered
 
@@ -36,4 +41,4 @@ Historical #1994 runtime blobs are replayed exactly; historical project-document
 
 ## Completion rule
 
-M2-SYNC-001 is not complete merely because historical code was replayed. The final #2002 head must pass current GitHub Actions, #2001 must land, #2002 must be retargeted/revalidated on `main`, then merged and verified on canonical `main`.
+M2-SYNC-001 is not complete merely because historical code was replayed. The final #2002 head must pass fresh current GitHub Actions on canonical `main`, merge through protected-main governance, and be re-read from canonical `main` before M2.T05-T09 or the M2 stage can be closed.

--- a/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-001-durable-delta-sync-current-main.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-001-durable-delta-sync-current-main.md
@@ -1,0 +1,65 @@
+# M2-SYNC-001 — Durable idempotent delta sync on clean stack
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M2-SYNC-001`
+- **WBS**: `M2.T05`–`M2.T09`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-22`
+- **Updated**: `2026-08-22`
+- **Depends on**: M2-NET-001 / PR #2001
+
+## Objective
+
+Complete M2 realtime semantics on the canonical Rust messaging engine: durable reconnect recovery, idempotent send/ACK, durable server cursor, audience-scoped delta sync, and Sent/Delivered/Read state transitions.
+
+## Runtime implementation
+
+- SQLite schema v2 durable event journal.
+- Snapshot + audience-scoped journal entries persist transactionally.
+- Cursor-group-aware pagination/pruning.
+- Stable server message IDs derived from authenticated sender + `client_message_id`.
+- Identical retries return the accepted message without duplicating state or advancing cursor again.
+- Conflicting reuse of a client message ID is rejected.
+- Successful send enters ACK path and reaches `Sent`.
+- Direct/secret recipient sync promotes `Sent -> Delivered`.
+- Recipient `MarkRead` promotes visible messages to `Read`.
+- `Sync.cursor` replays authorized delta events and emits checkpoint cursor.
+- Old/incomplete journal history falls back to actor-scoped full sync.
+- Journal audiences are captured at mutation time and filtered on replay.
+
+## Clean stack provenance
+
+Historical PR #1994 is implementation provenance only. The clean PR #2002 replays only the intended runtime blobs plus current task/evidence/WBS on top of the clean #2001 stack.
+
+After the final #2001 governance reconciliation, #2002 was restacked again with parent `1030a489a5b4ed12f93464c95325e5d6d2ca7535` and clean runtime replay commit `fd76ebd828f62b82ff0eecf34e85b24860e2a342`. This prevents stale lower-stack project records from entering the M2-SYNC diff.
+
+## Acceptance criteria
+
+1. Process restart preserves state and delta journal sufficiently for reconnect recovery.
+2. Repeated identical `client_message_id` is idempotent; conflicting reuse is rejected.
+3. Server cursor never silently rolls backward across persisted state.
+4. Authorized second-device delta sync recovers changes after known cursor.
+5. Outsiders cannot observe journal events for unauthorized conversations.
+6. Missing/expired journal coverage falls back to actor-scoped full sync.
+7. Delivery/read transitions reach `Sent`, `Delivered`, `Read` in defined recipient flows.
+8. Final clean-head Messaging Product Gate, Mahayana fast checks and applicable repository/governance checks pass.
+9. #2001 lands first; #2002 is retargeted to final `main`, revalidated, merged and verified on canonical `main`.
+
+## Branch / PR
+
+- Branch: `feat/telegram-m2-delta-main-sync`
+- PR: #2002
+- Temporary base: `feat/telegram-m2-websocket-main-sync` / #2001
+- Historical PR: #1994 — provenance only; to be closed as superseded after clean landing.
+
+## Evidence
+
+- `native/mahayana-messaging/src/store.rs`
+- `native/mahayana-messaging/src/service.rs`
+- `native/mahayana-messaging/tests/delta_sync_contract.rs`
+- `../../evidence/M2-SYNC-001-current-main/README.md`
+
+## Next action
+
+Run final clean-stack CI. After #2001 lands, retarget #2002 to `main`, revalidate the final head/base pair, merge through protected-main governance, then perform canonical-main verification and close M2.T05-T09.

--- a/projects/telegram-fabushi-integration/management/wbs/M2.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M2.md
@@ -46,55 +46,55 @@
 
 ### M2.T05 — reconnect
 
-- **交付物**：reconnect
-- **验收标准**：断网恢复后消息不丢；从已知 cursor 继续同步
-- **客观验证**：durable event journal + restart/reconnect contract
+- **交付物**：reconnect / cursor resume
+- **验收标准**：断网或进程重启后从已知 cursor 继续同步；日志覆盖不足时安全回退 scoped full sync
+- **客观验证**：`delta_sync_contract.rs`; SQLite journal restart contracts; Messaging Product Gate
 - **来源**：源计划 M2
-- **状态**：IN_PROGRESS
-- **阻塞**：依赖 M2-NET-001 clean landing；实现来自 historical PR #1994，待 clean re-land
-- **证据位置**：historical PR #1994；clean M2-SYNC task pending
-- **下一步**：在 clean M2-NET stack 上重落 durable delta sync。
+- **状态**：IMPLEMENTED
+- **阻塞**：clean delta-stack current-head CI / lower-stack merge / canonical-main verification pending
+- **证据位置**：`../tasks/M2-SYNC-001-durable-delta-sync-current-main.md`; `../../evidence/M2-SYNC-001-current-main/README.md`; historical PR #1994
+- **下一步**：通过 clean current-head gate 并按栈顺序落 main。
 
 ### M2.T06 — message send/ack
 
 - **交付物**：idempotent message send + server ACK
-- **验收标准**：重复 client message id 不产生重复消息；合法 retry 返回同一已接受消息；冲突 payload 显式拒绝
-- **客观验证**：service/store contract + Messaging Product Gate
+- **验收标准**：重复相同 `client_message_id` 不产生重复消息；相同 retry 返回既有 accepted message；冲突 payload 显式拒绝
+- **客观验证**：`delta_sync_contract.rs`; service/store contracts; Messaging Product Gate
 - **来源**：源计划 M2
-- **状态**：IN_PROGRESS
-- **阻塞**：historical PR #1994 待 clean re-land/current-head CI
-- **证据位置**：historical PR #1994；clean M2-SYNC task pending
-- **下一步**：重落 stable server message id + ACK path。
+- **状态**：IMPLEMENTED
+- **阻塞**：clean delta-stack current-head CI / merge pending
+- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
+- **下一步**：通过 clean current-head gate 后提升 TESTED。
 
 ### M2.T07 — server sequence
 
 - **交付物**：durable server cursor/sequence
-- **验收标准**：服务重启后 cursor 不回退；event journal 与 snapshot 事务一致
-- **客观验证**：SQLite schema v2 journal/restart contracts
+- **验收标准**：服务重启后 cursor 不回退；event journal 与 snapshot 事务一致；分页保留完整 cursor group
+- **客观验证**：SQLite schema v2 + journal restart/pagination contracts
 - **来源**：源计划 M2
-- **状态**：IN_PROGRESS
-- **阻塞**：historical PR #1994 待 clean re-land/current-head CI
-- **证据位置**：historical PR #1994；clean M2-SYNC task pending
-- **下一步**：重落 durable journal 与 cursor persistence。
+- **状态**：IMPLEMENTED
+- **阻塞**：clean delta-stack current-head CI / merge pending
+- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
+- **下一步**：通过 clean current-head gate 后提升 TESTED。
 
 ### M2.T08 — delta sync
 
 - **交付物**：audience-scoped cursor delta sync
-- **验收标准**：从有效 cursor 增量恢复；过期/不完整 cursor 安全回退 scoped full sync；越权 actor 不获得其它会话事件
-- **客观验证**：journal pagination/restart/outsider isolation contracts
+- **验收标准**：有效 cursor 增量恢复；过期/不完整 cursor 安全回退 scoped full sync；越权 actor 不获得其它会话事件
+- **客观验证**：`delta_sync_contract.rs`; journal outsider-isolation/restart/migration-floor contracts
 - **来源**：源计划 M2
-- **状态**：IN_PROGRESS
-- **阻塞**：historical PR #1994 待 clean re-land/current-head CI
-- **证据位置**：historical PR #1994；clean M2-SYNC task pending
-- **下一步**：重落 audience-scoped journal replay 和 checkpoint。
+- **状态**：IMPLEMENTED
+- **阻塞**：clean delta-stack current-head CI / merge pending
+- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
+- **下一步**：通过 clean current-head gate 后提升 TESTED。
 
 ### M2.T09 — delivery/read state
 
 - **交付物**：Sent → Delivered → Read state transitions
-- **验收标准**：发送成功进入 Sent；direct/secret recipient sync 标记 Delivered；recipient MarkRead 标记 Read
-- **客观验证**：service delivery/read contract
+- **验收标准**：发送成功进入 Sent；direct/secret recipient sync 标记 Delivered；recipient `MarkRead` 标记 Read
+- **客观验证**：`delta_sync_contract.rs`; service delivery/read contracts
 - **来源**：源计划 M2
-- **状态**：IN_PROGRESS
-- **阻塞**：historical PR #1994 待 clean re-land/current-head CI
-- **证据位置**：historical PR #1994；clean M2-SYNC task pending
-- **下一步**：重落并通过 current-head messaging gate。
+- **状态**：IMPLEMENTED
+- **阻塞**：clean delta-stack current-head CI / merge pending
+- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
+- **下一步**：通过 clean current-head gate 后提升 TESTED。


### PR DESCRIPTION
## Project
- Project ID: `FAB-P0001`
- Project Key: `TFI`
- Tasks: `M2.T05`–`M2.T09` / execution `M2-SYNC-001`

## Objective
Land durable reconnect/delta-sync semantics directly on canonical `main` after M2-NET (#2001), without importing stale historical project records or reverting the current Message schema.

## Runtime changes
- SQLite schema v2 durable event journal
- transactional snapshot + audience-scoped journal persistence
- cursor-group-aware pagination/pruning
- stable sender + `client_message_id` server IDs
- idempotent retry and explicit conflicting-ID rejection
- send ACK → `Sent`
- recipient sync → `Delivered`
- recipient `MarkRead` → `Read`
- cursor-based authorized delta replay + checkpoint
- scoped full-sync fallback when journal coverage is old/incomplete
- outsider isolation, restart, second-device and migration-floor contracts

## Current-main compatibility repair
Final current-head CI found that historical #1994 referenced a removed `Message.client_message_id` field. The clean landing preserves the canonical current `Message` schema. Replay identity is already bound by deterministic `stable_message_id(actor_id, client_message_id)` (plus the legacy local key), so the obsolete field comparison was removed while retaining sender/content/reply/thread/schedule/silent/protected-content conflict checks. Existing idempotency contracts must prove the behavior on current CI.

## Clean landing
- Base: canonical `main` merge `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6` (#2001)
- Clean commit: `5602f96bcb806b2c09981241ab88d99c15f07fc9`
- Scope: exactly six intended M2-SYNC runtime/test/task/evidence/WBS files
- Temporary workflow experiments are absent from the final commit history.

## Completion gate
Fresh current-head Messaging Product Gate + Mahayana fast checks + applicable repository/governance checks, protected merge, canonical-main verification, then M2 stage closure and historical #1994 retirement.