### PR TITLE
refactor(gbf): converge Electron edge and host lifecycle

### DIFF
--- a/.github/scripts/assert-auth-entry-flow.py
+++ b/.github/scripts/assert-auth-entry-flow.py
@@ -87,7 +87,7 @@ required = {
     'renderer single browser CTA': (host, 'data-testid="browser-login-start"'),
     'feature browser credential-boundary regression': (feature, 'deterministic_browser_login_keeps_credentials_out_of_the_presentation_boundary'),
     'desktop packaged Product API uses production origin': (host_process, "PRODUCTION_PRODUCT_API_BASE_URL = 'https://api.ombhrum.com'"),
-    'desktop packaged/runtime environment selects production explicitly': (host_process, 'return app.isPackaged ? PRODUCTION_PRODUCT_API_BASE_URL : DEVELOPMENT_PRODUCT_API_BASE_URL;'),
+    'desktop packaged/runtime environment selects production explicitly': (host_process, 'return appImpl.isPackaged ? PRODUCTION_PRODUCT_API_BASE_URL : DEVELOPMENT_PRODUCT_API_BASE_URL;'),
     'desktop forwards Product API override to Host': (host_process, 'MAHAYANA_API_BASE_URL:'),
     'browser registration code route': (worker, '/api/auth/browser/register/code'),
     'browser registration submit route': (worker, '/api/auth/browser/register'),

--- a/.github/scripts/assert-electron-feature-host-bridge.sh
+++ b/.github/scripts/assert-electron-feature-host-bridge.sh
@@ -44,7 +44,10 @@ done
 
 grep -Fq "defineEdge('mahayana-host'" "$edge" || { echo "Mahayana edge descriptor is not declared" >&2; exit 1; }
 grep -Fq "['runtime-event']" "$edge" || { echo "Mahayana runtime-event declaration is missing" >&2; exit 1; }
-grep -Fq 'const allowedHostMethods = new Set(Object.keys(MAHAYANA_EDGE.methods));' "$main" || { echo "Electron main does not derive its compatibility allowlist from MAHAYANA_EDGE" >&2; exit 1; }
+if grep -Fq "ipcMain.handle('fabushi:host'" "$main"; then
+  echo "Electron main must not expose the retired generic fabushi:host IPC channel" >&2
+  exit 1
+fi
 grep -Fq 'Object.keys(MAHAYANA_EDGE.methods).map((method)' "$main" || { echo "Electron main does not derive edge handlers from MAHAYANA_EDGE" >&2; exit 1; }
 grep -Fq 'serveMainEdge(ipcMain, MAHAYANA_EDGE, handlers' "$main" || { echo "Electron main does not serve MAHAYANA_EDGE through the shared edge runtime" >&2; exit 1; }
 grep -Fq "host.request('feature.receive', {})" "$main" || { echo "Electron main runtime event pump is missing" >&2; exit 1; }
@@ -55,6 +58,8 @@ if grep -Eq "require\(['\"]\./" "$preload"; then
   exit 1
 fi
 grep -Fq "const MAHAYANA_EDGE = 'mahayana-host';" "$preload" || { echo "Electron preload Mahayana edge name is missing" >&2; exit 1; }
+grep -Fq 'const EDGE_CONTRACT_VERSION = 1;' "$preload" || { echo "Electron preload edge contract version is missing" >&2; exit 1; }
+grep -Fq 'contractVersion: EDGE_CONTRACT_VERSION' "$preload" || { echo "Electron preload does not expose the edge contract version" >&2; exit 1; }
 grep -Fq 'return `fabushi-edge:${edge}:call:${method}`;' "$preload" || { echo "Electron preload edge call-channel construction is missing" >&2; exit 1; }
 grep -Fq "contextBridge.exposeInMainWorld('mahayana', mahayana)" "$preload" || { echo "Electron preload does not expose the Mahayana bridge" >&2; exit 1; }
 grep -Fq 'return subscribeEdge(MAHAYANA_EDGE, MAHAYANA_RUNTIME_EVENT, listener);' "$preload" || { echo "Electron preload runtime-event subscription is missing" >&2; exit 1; }
@@ -68,6 +73,11 @@ grep -Fq 'isElectronMahayanaHostAvailable()' "$host_client" || {
   echo "Host UI does not select production mode for Electron" >&2
   exit 1
 }
+grep -Fq 'window.mahayana?.contractVersion === ELECTRON_EDGE_CONTRACT_VERSION' "$electron_transport" || { echo "Electron transport does not bind to the versioned Mahayana bridge" >&2; exit 1; }
+if grep -Fq 'window.fabushi?.invoke' "$electron_transport"; then
+  echo "Electron transport must not route Host calls through the generic Fabushi shell facade" >&2
+  exit 1
+fi
 grep -Fq "ipcMain.handle('fabushi:window-focused'" "$main" || { echo "window focus IPC missing" >&2; exit 1; }
 grep -Fq "ipcMain.handle('fabushi:open-system-settings'" "$main" || { echo "system settings IPC missing" >&2; exit 1; }
 grep -Fq 'openSystemSettings(pane)' "$preload" || { echo "system settings preload bridge missing" >&2; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,8 +425,8 @@ jobs:
         run: python3 .github/scripts/assert-product-ui-contracts.py
       - name: Reject native capability stubs
         run: python3 .github/scripts/assert-native-capability-semantics.py
-      - name: Verify offline ASR provider contracts
-        run: node --test desktop/electron/offline-asr.test.cjs
+      - name: Verify Electron edge, host lifecycle, and offline ASR contracts
+        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
       - name: Verify Electron to Rust Feature Host bridge
         shell: bash
         run: bash .github/scripts/assert-electron-feature-host-bridge.sh

--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -120,8 +120,8 @@ jobs:
         run: python3 .github/scripts/assert-product-ui-contracts.py
       - name: Reject native capability stubs
         run: python3 .github/scripts/assert-native-capability-semantics.py
-      - name: Verify offline ASR provider contracts
-        run: node --test desktop/electron/offline-asr.test.cjs
+      - name: Verify Electron edge, host lifecycle, and offline ASR contracts
+        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/desktop/e2e/smoke.spec.ts
+++ b/desktop/e2e/smoke.spec.ts
@@ -133,20 +133,21 @@ test('desktop package drives every declared Host journey through Electron IPC an
       nodeRequire: typeof (window as unknown as { require?: unknown }).require,
       processGlobal: typeof (window as unknown as { process?: unknown }).process,
       bridgeKeys: Object.keys(window.fabushi).sort(),
+      mahayanaKeys: Object.keys(window.mahayana ?? {}).sort(),
     }));
     expect(security.nodeRequire).toBe('undefined');
     expect(security.processGlobal).toBe('undefined');
     expect(security.bridgeKeys).toEqual([
-      'invoke',
+      'contractVersion',
       'notify',
       'openExternal',
       'openSystemSettings',
       'pickFile',
-      'subscribe',
       'windowFocused',
     ]);
+    expect(security.mahayanaKeys).toEqual(['contractVersion', 'invoke', 'subscribe']);
 
-    const hostInfo = await page.evaluate(() => window.fabushi.invoke<{
+    const hostInfo = await page.evaluate(() => window.mahayana!.invoke<{
       platform: string;
       protocolVersion: string;
       runtimeVersion: string;

--- a/desktop/e2e/surfaces.spec.ts
+++ b/desktop/e2e/surfaces.spec.ts
@@ -98,10 +98,10 @@ test('installed desktop exposes product surfaces, browser lifecycle, and safe na
 
     await test.step('browser auth start, secure reopen, and cancel stay secret-free', async () => {
       const lifecycle = await page.evaluate(async () => {
-        const start = await window.fabushi.invoke<Record<string, unknown>>('feature.auth.browserStart');
+        const start = await window.mahayana!.invoke<Record<string, unknown>>('feature.auth.browserStart');
         const attemptId = String(start.attemptId ?? '');
-        const reopen = await window.fabushi.invoke<Record<string, unknown>>('feature.auth.browserReopen', { attemptId });
-        const cancel = await window.fabushi.invoke<Record<string, unknown>>('feature.auth.browserCancel', { attemptId });
+        const reopen = await window.mahayana!.invoke<Record<string, unknown>>('feature.auth.browserReopen', { attemptId });
+        const cancel = await window.mahayana!.invoke<Record<string, unknown>>('feature.auth.browserCancel', { attemptId });
         return { start, reopen, cancel };
       });
       expect(String(lifecycle.start.attemptId ?? '')).not.toBe('');

--- a/desktop/electron/edge-ipc.cjs
+++ b/desktop/electron/edge-ipc.cjs
@@ -12,10 +12,12 @@ function pushChannel(edge, event) {
   return `fabushi-edge:${edge}:event:${event}`;
 }
 
-function defineEdge(edge, methods, events = []) {
+function defineEdge(edge, methods, events = [], version = 1) {
+  if (!Number.isInteger(version) || version < 1) throw new Error('Edge contract version must be a positive integer.');
   const eventNames = Object.freeze([...events]);
   return Object.freeze({
     edge,
+    version,
     methods: Object.freeze({ ...methods }),
     events: eventNames,
     eventSet: new Set(eventNames),

--- a/desktop/electron/edge-ipc.test.cjs
+++ b/desktop/electron/edge-ipc.test.cjs
@@ -1,0 +1,127 @@
+"use strict";
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  BRIDGE_INVOKE_FAILED,
+  BRIDGE_MISSING_HANDLER,
+  BRIDGE_UNTRUSTED_SENDER,
+  EdgeInvocationError,
+  callChannel,
+  createRendererEdge,
+  defineEdge,
+  pushChannel,
+  serveMainEdge,
+} = require('./edge-ipc.cjs');
+
+function fakeIpcMain() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      assert.equal(handlers.has(channel), false, `duplicate handler ${channel}`);
+      handlers.set(channel, handler);
+    },
+    removeHandler(channel) {
+      handlers.delete(channel);
+    },
+  };
+}
+
+function fakeIpcRenderer(ipcMain, event = { senderFrame: { url: 'app://bundle/index.html' } }) {
+  const listeners = new Map();
+  return {
+    listeners,
+    async invoke(channel, args) {
+      const handler = ipcMain.handlers.get(channel);
+      if (!handler) throw new Error(`missing channel ${channel}`);
+      return handler(event, args);
+    },
+    on(channel, listener) {
+      const list = listeners.get(channel) ?? [];
+      list.push(listener);
+      listeners.set(channel, list);
+    },
+    off(channel, listener) {
+      listeners.set(channel, (listeners.get(channel) ?? []).filter((entry) => entry !== listener));
+    },
+  };
+}
+
+test('edge exposes only declared methods and normalizes no-arg invocations', async () => {
+  const edge = defineEdge('test', { ping: { args: 'none' }, echo: { args: 'object' } }, ['changed']);
+  assert.equal(edge.version, 1);
+  assert.throws(() => defineEdge('invalid', {}, [], 0), /positive integer/);
+  const ipcMain = fakeIpcMain();
+  serveMainEdge(ipcMain, edge, {
+    ping: async (args) => ({ keys: Object.keys(args) }),
+    echo: async (args) => args,
+  });
+  const renderer = fakeIpcRenderer(ipcMain);
+  const client = createRendererEdge(renderer, edge);
+  assert.equal(Object.isFrozen(client), true);
+  assert.equal(client.unknown, undefined);
+  assert.deepEqual(await client.ping(), { keys: [] });
+  assert.deepEqual(await client.echo({ value: 7 }), { value: 7 });
+});
+
+test('main edge fails closed for untrusted senders and missing handlers', async () => {
+  const edge = defineEdge('secure', { secret: { args: 'object' }, missing: { args: 'none' } });
+  const ipcMain = fakeIpcMain();
+  serveMainEdge(ipcMain, edge, { secret: async () => 'never' }, { isTrustedSender: () => false });
+  const denied = await ipcMain.handlers.get(callChannel('secure', 'secret'))({}, {});
+  assert.equal(denied.ok, false);
+  assert.equal(denied.failure.code, BRIDGE_UNTRUSTED_SENDER);
+
+  const second = fakeIpcMain();
+  serveMainEdge(second, edge, { secret: async () => 'ok' });
+  const missing = await second.handlers.get(callChannel('secure', 'missing'))({}, {});
+  assert.equal(missing.ok, false);
+  assert.equal(missing.failure.code, BRIDGE_MISSING_HANDLER);
+});
+
+test('handler exceptions become stable bridge failures and renderer raises EdgeInvocationError', async () => {
+  const edge = defineEdge('errors', { explode: { args: 'none' } });
+  const ipcMain = fakeIpcMain();
+  const observed = [];
+  serveMainEdge(ipcMain, edge, { explode: async () => { throw new Error('boom'); } }, {
+    onHandlerError: (method, error) => observed.push([method, error.message]),
+  });
+  const client = createRendererEdge(fakeIpcRenderer(ipcMain), edge);
+  await assert.rejects(client.explode(), (error) => {
+    assert.equal(error instanceof EdgeInvocationError, true);
+    assert.equal(error.code, BRIDGE_INVOKE_FAILED);
+    assert.match(error.detail, /boom/);
+    return true;
+  });
+  assert.deepEqual(observed, [['explode', 'boom']]);
+});
+
+test('event emission is allowlisted and dispose removes every registered handler', () => {
+  const edge = defineEdge('events', { ping: { args: 'none' } }, ['changed']);
+  const ipcMain = fakeIpcMain();
+  const server = serveMainEdge(ipcMain, edge, { ping: async () => true });
+  const sent = [];
+  server.emit({ send: (...args) => sent.push(args) }, 'changed', { value: 1 });
+  assert.deepEqual(sent, [[pushChannel('events', 'changed'), { value: 1 }]]);
+  assert.throws(() => server.emit({ send() {} }, 'unknown', {}), /Unknown edge event/);
+  assert.equal(ipcMain.handlers.size, 1);
+  server.dispose();
+  assert.equal(ipcMain.handlers.size, 0);
+});
+
+test('renderer subscriptions are scoped to declared events and can be disposed idempotently', () => {
+  const edge = defineEdge('events', {}, ['changed', 'other']);
+  const renderer = fakeIpcRenderer(fakeIpcMain());
+  const client = createRendererEdge(renderer, edge);
+  let seen = 0;
+  const dispose = client.subscribe({ changed: () => { seen += 1; }, unknown: () => { seen += 100; } });
+  const channel = pushChannel('events', 'changed');
+  assert.equal(renderer.listeners.has(pushChannel('events', 'unknown')), false);
+  renderer.listeners.get(channel)[0]({}, { value: 1 });
+  assert.equal(seen, 1);
+  dispose();
+  dispose();
+  assert.deepEqual(renderer.listeners.get(channel), []);
+});

--- a/desktop/electron/host-process.cjs
+++ b/desktop/electron/host-process.cjs
@@ -6,8 +6,8 @@ const readline = require('node:readline');
 const PRODUCTION_PRODUCT_API_BASE_URL = 'https://api.ombhrum.com';
 const DEVELOPMENT_PRODUCT_API_BASE_URL = 'https://mahayana-platform.bhrumom.workers.dev';
 
-function productApiBaseUrl() {
-  const configured = process.env.MAHAYANA_API_BASE_URL?.trim();
+function productApiBaseUrl(appImpl = app, env = process.env) {
+  const configured = env.MAHAYANA_API_BASE_URL?.trim();
   if (configured) {
     const parsed = new URL(configured);
     if (parsed.protocol !== 'https:' || parsed.username || parsed.password || parsed.search || parsed.hash) {
@@ -15,96 +15,192 @@ function productApiBaseUrl() {
     }
     return parsed.toString().replace(/\/$/, '');
   }
-  return app.isPackaged ? PRODUCTION_PRODUCT_API_BASE_URL : DEVELOPMENT_PRODUCT_API_BASE_URL;
+  return appImpl.isPackaged ? PRODUCTION_PRODUCT_API_BASE_URL : DEVELOPMENT_PRODUCT_API_BASE_URL;
 }
 
 class MahayanaHostProcess {
-  constructor() {
+  constructor(options = {}) {
+    this.app = options.app ?? app;
+    this.spawn = options.spawn ?? spawn;
+    this.readline = options.readline ?? readline;
+    this.env = options.env ?? process.env;
+    this.platform = options.platform ?? process.platform;
+    this.resourcesPath = options.resourcesPath ?? process.resourcesPath;
+    this.now = options.now ?? Date.now;
+
     this.child = null;
+    this.currentGeneration = 0;
     this.nextId = 1;
     this.pending = new Map();
+    this.closed = false;
+    this.state = 'stopped';
+    this.startedAt = null;
+    this.lastExit = null;
+    this.unexpectedExitCount = 0;
   }
 
   executablePath() {
-    if (!app.isPackaged && process.env.MAHAYANA_APP_HOST_BIN) {
-      return process.env.MAHAYANA_APP_HOST_BIN;
+    if (!this.app.isPackaged && this.env.MAHAYANA_APP_HOST_BIN) {
+      return this.env.MAHAYANA_APP_HOST_BIN;
     }
-    const name = process.platform === 'win32' ? 'mahayana-app-host.exe' : 'mahayana-app-host';
-    if (app.isPackaged) return path.join(process.resourcesPath, 'bin', name);
+    const name = this.platform === 'win32' ? 'mahayana-app-host.exe' : 'mahayana-app-host';
+    if (this.app.isPackaged) return path.join(this.resourcesPath, 'bin', name);
     return path.resolve(__dirname, '..', '..', 'third_party', 'mahayana', 'mahayana-rs', 'target', 'release', name);
   }
 
+  health() {
+    return Object.freeze({
+      state: this.state,
+      closed: this.closed,
+      generation: this.currentGeneration,
+      pid: this.child?.pid ?? null,
+      pending: this.pending.size,
+      startedAt: this.startedAt,
+      lastExit: this.lastExit ? { ...this.lastExit } : null,
+      unexpectedExitCount: this.unexpectedExitCount,
+    });
+  }
+
   start() {
-    if (this.child) return;
-    const child = spawn(this.executablePath(), [], {
+    if (this.closed) throw new Error('Mahayana host is closed.');
+    if (this.child) return this.child;
+
+    const generation = this.currentGeneration + 1;
+    const child = this.spawn(this.executablePath(), [], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
-        ...process.env,
-        MAHAYANA_API_BASE_URL: productApiBaseUrl(),
-        FABUSHI_APP_DATA: app.getPath('userData'),
+        ...this.env,
+        MAHAYANA_API_BASE_URL: productApiBaseUrl(this.app, this.env),
+        FABUSHI_APP_DATA: this.app.getPath('userData'),
       },
       windowsHide: true,
     });
-    this.child = child;
 
-    const lines = readline.createInterface({ input: child.stdout });
+    this.currentGeneration = generation;
+    this.child = child;
+    this.state = 'running';
+    this.startedAt = this.now();
+
+    const lines = this.readline.createInterface({ input: child.stdout });
     lines.on('line', (line) => {
       let message;
       try {
         message = JSON.parse(line);
       } catch (error) {
-        this.rejectAll(new Error(`Invalid Mahayana host response: ${error}`));
+        this.rejectGeneration(generation, new Error(`Invalid Mahayana host response: ${error}`));
         return;
       }
       const key = String(message.id ?? '');
       const pending = this.pending.get(key);
-      if (!pending) return;
+      if (!pending || pending.generation !== generation) return;
       this.pending.delete(key);
       if (message.ok) pending.resolve(message.result);
       else pending.reject(new Error(message.error || 'Mahayana host request failed'));
     });
+
     child.stderr.on('data', (chunk) => console.error(`[mahayana-app-host] ${String(chunk).trimEnd()}`));
-    child.on('error', (error) => this.rejectAll(error));
-    child.on('exit', (code, signal) => {
-      this.child = null;
-      this.rejectAll(new Error(`Mahayana host exited (${code ?? 'null'}, ${signal ?? 'none'})`));
+    child.on('error', (error) => {
+      this.handleTermination(child, generation, error, { error: error.message });
     });
+    child.on('exit', (code, signal) => {
+      lines.close();
+      this.handleTermination(
+        child,
+        generation,
+        new Error(`Mahayana host exited (${code ?? 'null'}, ${signal ?? 'none'})`),
+        { code: code ?? null, signal: signal ?? null },
+      );
+    });
+
+    return child;
+  }
+
+  handleTermination(child, generation, error, metadata) {
+    const isCurrent = this.child === child && this.currentGeneration === generation;
+    if (isCurrent) {
+      this.child = null;
+      this.startedAt = null;
+      if (!this.closed) {
+        this.state = 'stopped';
+        this.unexpectedExitCount += 1;
+        this.lastExit = Object.freeze({ ...metadata, at: this.now() });
+      }
+    }
+    this.rejectGeneration(generation, error);
   }
 
   request(method, params = {}, timeoutMs = 120000) {
-    this.start();
+    let child;
+    try {
+      child = this.start();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    const generation = this.currentGeneration;
     const id = this.nextId++;
     const key = String(id);
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
+        const pending = this.pending.get(key);
+        if (!pending || pending.generation !== generation) return;
         this.pending.delete(key);
         reject(new Error(`Mahayana host request timed out: ${method}`));
       }, timeoutMs);
       timer.unref?.();
       this.pending.set(key, {
+        generation,
         resolve: (value) => { clearTimeout(timer); resolve(value); },
         reject: (error) => { clearTimeout(timer); reject(error); },
       });
       const payload = JSON.stringify({ id, method, params });
-      this.child.stdin.write(`${payload}\n`, (error) => {
+      child.stdin.write(`${payload}\n`, (error) => {
         if (!error) return;
         const pending = this.pending.get(key);
+        if (!pending || pending.generation !== generation) return;
         this.pending.delete(key);
-        pending?.reject(error);
+        pending.reject(error);
       });
     });
   }
 
-  rejectAll(error) {
-    for (const pending of this.pending.values()) pending.reject(error);
-    this.pending.clear();
+  rejectGeneration(generation, error) {
+    for (const [key, pending] of this.pending.entries()) {
+      if (pending.generation !== generation) continue;
+      this.pending.delete(key);
+      pending.reject(error);
+    }
+  }
+
+  restart(reason = 'manual restart') {
+    if (this.closed) throw new Error('Mahayana host is closed.');
+    const child = this.child;
+    const generation = this.currentGeneration;
+    if (child) {
+      this.child = null;
+      this.startedAt = null;
+      this.state = 'stopped';
+      this.rejectGeneration(generation, new Error(`Mahayana host restarted: ${reason}`));
+      child.kill();
+    }
+    return this.start();
   }
 
   close() {
-    if (!this.child) return;
-    this.child.kill();
+    if (this.closed) return;
+    this.closed = true;
+    this.state = 'closed';
+    const child = this.child;
+    const generation = this.currentGeneration;
     this.child = null;
+    this.startedAt = null;
+    this.rejectGeneration(generation, new Error('Mahayana host closed.'));
+    child?.kill();
   }
 }
 
-module.exports = { MahayanaHostProcess };
+module.exports = {
+  DEVELOPMENT_PRODUCT_API_BASE_URL,
+  MahayanaHostProcess,
+  PRODUCTION_PRODUCT_API_BASE_URL,
+  productApiBaseUrl,
+};

--- a/desktop/electron/host-process.test.cjs
+++ b/desktop/electron/host-process.test.cjs
@@ -1,0 +1,157 @@
+"use strict";
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const Module = require('node:module');
+const { PassThrough } = require('node:stream');
+const test = require('node:test');
+
+const defaultApp = {
+  isPackaged: false,
+  getPath(name) {
+    if (name !== 'userData') throw new Error(`unexpected path: ${name}`);
+    return '/tmp/fabushi-host-test';
+  },
+};
+const originalLoad = Module._load;
+Module._load = function load(request, parent, isMain) {
+  if (request === 'electron') return { app: defaultApp };
+  return originalLoad.call(this, request, parent, isMain);
+};
+const {
+  DEVELOPMENT_PRODUCT_API_BASE_URL,
+  MahayanaHostProcess,
+  PRODUCTION_PRODUCT_API_BASE_URL,
+  productApiBaseUrl,
+} = require('./host-process.cjs');
+Module._load = originalLoad;
+
+class FakeChild extends EventEmitter {
+  constructor(pid) {
+    super();
+    this.pid = pid;
+    this.killed = false;
+    this.stdout = new PassThrough();
+    this.stderr = new PassThrough();
+    this.writes = [];
+    this.stdin = {
+      write: (data, callback) => {
+        this.writes.push(String(data));
+        queueMicrotask(() => callback?.(null));
+        return true;
+      },
+    };
+  }
+
+  requestAt(index = this.writes.length - 1) {
+    return JSON.parse(this.writes[index]);
+  }
+
+  respond(id, result) {
+    this.stdout.write(`${JSON.stringify({ id, ok: true, result })}\n`);
+  }
+
+  fail(id, error) {
+    this.stdout.write(`${JSON.stringify({ id, ok: false, error })}\n`);
+  }
+
+  kill() {
+    if (this.killed) return false;
+    this.killed = true;
+    this.emit('exit', 0, null);
+    return true;
+  }
+}
+
+function harness() {
+  const children = [];
+  let now = 1000;
+  const host = new MahayanaHostProcess({
+    app: defaultApp,
+    env: { MAHAYANA_API_BASE_URL: 'https://api.example.test/' },
+    platform: 'linux',
+    now: () => ++now,
+    spawn: (_bin, _args, options) => {
+      assert.equal(options.env.MAHAYANA_API_BASE_URL, 'https://api.example.test');
+      assert.equal(options.env.FABUSHI_APP_DATA, '/tmp/fabushi-host-test');
+      const child = new FakeChild(7000 + children.length);
+      children.push(child);
+      return child;
+    },
+  });
+  return { host, children };
+}
+
+test('product API base URL is environment-aware and rejects unsafe overrides', () => {
+  assert.equal(productApiBaseUrl({ isPackaged: false }, {}), DEVELOPMENT_PRODUCT_API_BASE_URL);
+  assert.equal(productApiBaseUrl({ isPackaged: true }, {}), PRODUCTION_PRODUCT_API_BASE_URL);
+  assert.equal(productApiBaseUrl({ isPackaged: true }, { MAHAYANA_API_BASE_URL: 'https://api.example.test/' }), 'https://api.example.test');
+  assert.throws(() => productApiBaseUrl({ isPackaged: true }, { MAHAYANA_API_BASE_URL: 'http://api.example.test' }), /clean HTTPS/);
+  assert.throws(() => productApiBaseUrl({ isPackaged: true }, { MAHAYANA_API_BASE_URL: 'https://u:p@api.example.test' }), /clean HTTPS/);
+  assert.throws(() => productApiBaseUrl({ isPackaged: true }, { MAHAYANA_API_BASE_URL: 'https://api.example.test?x=1' }), /clean HTTPS/);
+});
+
+test('host resolves structured requests and reports health for the active generation', async () => {
+  const { host, children } = harness();
+  const pending = host.request('feature.info', { hello: 'world' });
+  assert.equal(children.length, 1);
+  const request = children[0].requestAt();
+  assert.equal(request.method, 'feature.info');
+  children[0].respond(request.id, { ready: true });
+  assert.deepEqual(await pending, { ready: true });
+  const health = host.health();
+  assert.equal(health.state, 'running');
+  assert.equal(health.generation, 1);
+  assert.equal(health.pid, 7000);
+  assert.equal(health.pending, 0);
+  assert.equal(health.unexpectedExitCount, 0);
+  host.close();
+});
+
+test('stale process termination cannot reject requests from a newer generation', async () => {
+  const { host, children } = harness();
+  const first = host.request('feature.receive', {});
+  const old = children[0];
+  old.emit('error', new Error('old generation failed'));
+  await assert.rejects(first, /old generation failed/);
+  assert.equal(host.health().state, 'stopped');
+  assert.equal(host.health().unexpectedExitCount, 1);
+
+  const second = host.request('feature.info', {});
+  assert.equal(children.length, 2);
+  const current = children[1];
+  assert.equal(host.health().generation, 2);
+
+  old.emit('exit', 1, 'SIGTERM');
+  assert.equal(host.health().generation, 2);
+  assert.equal(host.health().state, 'running');
+  assert.equal(host.health().unexpectedExitCount, 1);
+
+  const request = current.requestAt();
+  current.respond(request.id, { generation: 2 });
+  assert.deepEqual(await second, { generation: 2 });
+  host.close();
+});
+
+test('restart rejects only the active generation and immediately creates a fresh process', async () => {
+  const { host, children } = harness();
+  const pending = host.request('feature.receive', {});
+  const previous = children[0];
+  const fresh = host.restart('fault injection');
+  await assert.rejects(pending, /restarted: fault injection/);
+  assert.equal(previous.killed, true);
+  assert.equal(fresh, children[1]);
+  assert.equal(host.health().generation, 2);
+  assert.equal(host.health().state, 'running');
+  host.close();
+});
+
+test('close rejects pending work and makes shutdown terminal', async () => {
+  const { host } = harness();
+  const pending = host.request('feature.receive', {});
+  host.close();
+  await assert.rejects(pending, /host closed/);
+  assert.equal(host.health().state, 'closed');
+  assert.equal(host.health().closed, true);
+  await assert.rejects(host.request('feature.info', {}), /host is closed/);
+});

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -26,7 +26,6 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 const host = new MahayanaHostProcess();
-const allowedHostMethods = new Set(Object.keys(MAHAYANA_EDGE.methods));
 let mahayanaEdgeServer = null;
 let nativeEdgeServer = null;
 let hostEventPumpStopped = false;
@@ -679,15 +678,6 @@ function startHostEventPump() {
 function installIpcHandlers() {
   installMahayanaEdge();
   installNativeEdge();
-
-  // Temporary compatibility channel for older renderer builds. Current preload
-  // routes window.fabushi.invoke through MAHAYANA_EDGE instead.
-  ipcMain.handle('fabushi:host', async (event, request) => {
-    assertTrustedSender(event);
-    const method = String(request?.method || '');
-    if (!allowedHostMethods.has(method)) throw new Error(`Host method is not allowed: ${method}`);
-    return host.request(method, normalizeParams(request?.params));
-  });
 
   ipcMain.handle('fabushi:pick-file', async (event) => {
     assertTrustedSender(event);

--- a/desktop/electron/native-capability-handlers.test.cjs
+++ b/desktop/electron/native-capability-handlers.test.cjs
@@ -1,0 +1,119 @@
+"use strict";
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { createNativeCapabilityHandlers } = require('./native-capability-handlers.cjs');
+
+async function harness(run, options = {}) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'fabushi-native-cap-test-'));
+  let state = { preferences: {}, clientPersistence: {} };
+  const safeStorage = options.safeStorage ?? {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (bytes) => bytes.toString('utf8').replace(/^encrypted:/, ''),
+  };
+  const app = {
+    isPackaged: false,
+    getPath(name) {
+      if (name === 'userData') return path.join(root, 'user-data');
+      if (name === 'downloads') return path.join(root, 'downloads');
+      if (name === 'temp') return path.join(root, 'temp');
+      throw new Error(`unexpected app path ${name}`);
+    },
+    getVersion: () => 'test',
+  };
+  for (const name of ['userData', 'downloads', 'temp']) await fs.mkdir(app.getPath(name), { recursive: true });
+  const handlers = createNativeCapabilityHandlers({
+    app,
+    autoUpdater: {},
+    dialog: {},
+    net: options.net ?? { fetch: async () => { throw new Error('unexpected fetch'); } },
+    nativeTheme: {},
+    safeStorage,
+    shell: {},
+    host: options.host ?? { request: async () => ({ ok: true, data: null }) },
+    readNativeState: async () => state,
+    mutateNativeState: async (mutator) => { state = await mutator(state); return state; },
+    windowForEvent: () => ({}),
+    broadcastNativeEvent: () => {},
+  });
+  try {
+    await run({ root, app, handlers, getState: () => state });
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+test('local tool permission cannot exceed the administrator ceiling', async () => {
+  const previous = process.env.FABUSHI_LOCAL_TOOL_PERMISSION_CEILING;
+  process.env.FABUSHI_LOCAL_TOOL_PERMISSION_CEILING = 'ask';
+  try {
+    await harness(async ({ handlers, getState }) => {
+      await assert.rejects(handlers.setLocalToolPermission({ permission: 'always' }), /administrator ceiling/);
+      assert.equal(await handlers.setLocalToolPermission({ permission: 'ask' }), 'ask');
+      assert.equal(getState().preferences.localToolPermission, 'ask');
+      await assert.rejects(handlers.setLocalToolPermission({ permission: 'root' }), /Unsupported local tool permission/);
+    });
+  } finally {
+    if (previous === undefined) delete process.env.FABUSHI_LOCAL_TOOL_PERMISSION_CEILING;
+    else process.env.FABUSHI_LOCAL_TOOL_PERMISSION_CEILING = previous;
+  }
+});
+
+test('secret operations fail closed when OS-backed encryption is unavailable', async () => {
+  await harness(async ({ handlers }) => {
+    await assert.rejects(handlers.revealSecret({ name: 'api/token' }), /OS-backed secret encryption is not available/);
+    await assert.rejects(handlers.upsertSecrets({ name: 'api/token', value: 'plaintext' }), /OS-backed secret encryption is not available/);
+  }, { safeStorage: { isEncryptionAvailable: () => false } });
+});
+
+test('secret vault never persists plaintext and listSecrets does not reveal values', async () => {
+  await harness(async ({ app, handlers }) => {
+    const listed = await handlers.upsertSecrets({ name: 'api/token', value: 'super-secret-value' });
+    assert.deepEqual(listed.map((item) => item.name), ['api/token']);
+    assert.equal(Object.prototype.hasOwnProperty.call(listed[0], 'value'), false);
+    assert.equal(await handlers.revealSecret({ name: 'api/token' }), 'super-secret-value');
+    const raw = await fs.readFile(path.join(app.getPath('userData'), 'secure', 'secrets.json'), 'utf8');
+    assert.equal(raw.includes('super-secret-value'), false);
+    assert.equal(raw.includes('encrypted:'), false, 'encrypted bytes are stored base64 encoded');
+  });
+});
+
+test('managed attachment operations reject path escape attempts', async () => {
+  await harness(async ({ root, handlers }) => {
+    const outside = path.join(root, 'outside.bin');
+    await fs.writeFile(outside, Buffer.from('outside'));
+    await assert.rejects(handlers.commitStagedAttachments({ paths: [outside] }), /escaped the managed desktop storage root/);
+    await assert.rejects(handlers.discardStagedAttachment({ path: outside }), /escaped the managed desktop storage root/);
+  });
+});
+
+test('attachment download rejects non-HTTPS URLs before network access', async () => {
+  let fetches = 0;
+  await harness(async ({ handlers }) => {
+    await assert.rejects(handlers.downloadAttachment({ url: 'http://example.test/file.bin' }), /Only HTTPS attachments/);
+    assert.equal(fetches, 0);
+  }, { net: { fetch: async () => { fetches += 1; throw new Error('must not fetch'); } } });
+});
+
+test('diagnostic reports redact nested secrets before persistence', async () => {
+  await harness(async ({ app, handlers }) => {
+    await handlers.reportClientFailure({
+      token: 'token-value',
+      ordinary: 'safe-value',
+      nested: { password: 'password-value', authorization: 'bearer value' },
+    });
+    const raw = await fs.readFile(path.join(app.getPath('userData'), 'diagnostics', 'native-events.ndjson'), 'utf8');
+    const record = JSON.parse(raw.trim());
+    assert.equal(record.payload.token, '[redacted]');
+    assert.equal(record.payload.nested.password, '[redacted]');
+    assert.equal(record.payload.nested.authorization, '[redacted]');
+    assert.equal(record.payload.ordinary, 'safe-value');
+    assert.equal(raw.includes('token-value'), false);
+    assert.equal(raw.includes('password-value'), false);
+  });
+});

--- a/desktop/electron/preload.cjs
+++ b/desktop/electron/preload.cjs
@@ -8,6 +8,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 const MAHAYANA_EDGE = 'mahayana-host';
 const NATIVE_EDGE = 'native-desktop';
 const MAHAYANA_RUNTIME_EVENT = 'runtime-event';
+const EDGE_CONTRACT_VERSION = 1;
 const NATIVE_EVENTS = new Set([
   'mcp-auth-completed',
   'focus-agent',
@@ -72,6 +73,7 @@ function subscribeEdge(edge, eventName, listener) {
 }
 
 const mahayana = Object.freeze({
+  contractVersion: EDGE_CONTRACT_VERSION,
   invoke(method, params = {}) {
     return invokeEdge(MAHAYANA_EDGE, method, params);
   },
@@ -83,6 +85,7 @@ const mahayana = Object.freeze({
 contextBridge.exposeInMainWorld('mahayana', mahayana);
 
 contextBridge.exposeInMainWorld('fabushiNative', Object.freeze({
+  contractVersion: EDGE_CONTRACT_VERSION,
   invoke(method, params = {}) {
     return invokeEdge(NATIVE_EDGE, method, params);
   },
@@ -98,14 +101,7 @@ contextBridge.exposeInMainWorld('fabushiNative', Object.freeze({
 }));
 
 contextBridge.exposeInMainWorld('fabushi', Object.freeze({
-  // Compatibility facade while HostClient call sites migrate to the explicit
-  // Mahayana and native desktop bridges.
-  invoke(method, params = {}) {
-    return mahayana.invoke(method, params);
-  },
-  subscribe(listener) {
-    return mahayana.subscribe(listener);
-  },
+  contractVersion: EDGE_CONTRACT_VERSION,
   pickFile() {
     return ipcRenderer.invoke('fabushi:pick-file');
   },

--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -19,9 +19,14 @@ import type {
   RuntimeEventListener,
 } from "./transport";
 
-type ElectronBridge = {
+type MahayanaElectronBridge = {
+  contractVersion: number;
   invoke<T>(method: string, params?: Record<string, unknown>): Promise<T>;
   subscribe?(listener: RuntimeEventListener): () => void;
+};
+
+type ElectronShellBridge = {
+  contractVersion: number;
   notify(title: string, body: string): Promise<boolean | void>;
   openExternal(url: string): Promise<boolean | void>;
   openSystemSettings(pane: "screen-recording" | "accessibility"): Promise<boolean | void>;
@@ -30,10 +35,12 @@ type ElectronBridge = {
 
 declare global {
   interface Window {
-    fabushi: ElectronBridge;
-    mahayana?: Pick<ElectronBridge, "invoke" | "subscribe">;
+    fabushi: ElectronShellBridge;
+    mahayana?: MahayanaElectronBridge;
   }
 }
+
+const ELECTRON_EDGE_CONTRACT_VERSION = 1;
 
 const idle = (milliseconds = 10) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
@@ -41,13 +48,21 @@ const idle = (milliseconds = 10) =>
 export function isElectronMahayanaHostAvailable(): boolean {
   return (
     typeof window !== "undefined" &&
-    typeof window.fabushi?.invoke === "function"
+    window.mahayana?.contractVersion === ELECTRON_EDGE_CONTRACT_VERSION &&
+    typeof window.mahayana.invoke === "function"
   );
 }
 
-function bridge(): ElectronBridge {
-  if (typeof window === "undefined" || typeof window.fabushi?.invoke !== "function") {
-    throw new Error("Electron Mahayana Host is not available");
+function mahayanaBridge(): MahayanaElectronBridge {
+  if (!isElectronMahayanaHostAvailable() || !window.mahayana) {
+    throw new Error("Electron Mahayana Host is not available or uses an unsupported bridge contract");
+  }
+  return window.mahayana;
+}
+
+function shellBridge(): ElectronShellBridge {
+  if (typeof window === "undefined" || window.fabushi?.contractVersion !== ELECTRON_EDGE_CONTRACT_VERSION) {
+    throw new Error("Electron shell bridge is not available or uses an unsupported contract");
   }
   return window.fabushi;
 }
@@ -64,7 +79,7 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   }
 
   async initialize(_config: HostConfig): Promise<HostInfo> {
-    const info = await bridge().invoke<HostInfo>("feature.info");
+    const info = await mahayanaBridge().invoke<HostInfo>("feature.info");
     this.closed = false;
     this.attachRuntimeEvents();
     // The main process owns the long-lived event pump and may observe the
@@ -81,47 +96,47 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   }
 
   execute(command: RuntimeCommand): Promise<CommandAccepted> {
-    return bridge().invoke<CommandAccepted>("feature.execute", { command });
+    return mahayanaBridge().invoke<CommandAccepted>("feature.execute", { command });
   }
 
   authStatus(): Promise<AuthState> {
-    return bridge().invoke<AuthState>("feature.auth.status");
+    return mahayanaBridge().invoke<AuthState>("feature.auth.status");
   }
 
   authProviders(): Promise<AuthProvider[]> {
-    return bridge().invoke<AuthProvider[]>("feature.auth.providers");
+    return mahayanaBridge().invoke<AuthProvider[]>("feature.auth.providers");
   }
 
   browserLoginStart(): Promise<BrowserLoginAttempt> {
-    return bridge().invoke<BrowserLoginAttempt>("feature.auth.browserStart");
+    return mahayanaBridge().invoke<BrowserLoginAttempt>("feature.auth.browserStart");
   }
 
   browserLoginPoll(attemptId: string): Promise<BrowserLoginPollResult> {
-    return bridge().invoke<BrowserLoginPollResult>("feature.auth.browserPoll", { attemptId });
+    return mahayanaBridge().invoke<BrowserLoginPollResult>("feature.auth.browserPoll", { attemptId });
   }
 
   browserLoginCancel(attemptId: string): Promise<BrowserLoginPollResult> {
-    return bridge().invoke<BrowserLoginPollResult>("feature.auth.browserCancel", { attemptId });
+    return mahayanaBridge().invoke<BrowserLoginPollResult>("feature.auth.browserCancel", { attemptId });
   }
 
   browserLoginReopen(attemptId: string): Promise<BrowserLoginReopenResult> {
-    return bridge().invoke<BrowserLoginReopenResult>("feature.auth.browserReopen", { attemptId });
+    return mahayanaBridge().invoke<BrowserLoginReopenResult>("feature.auth.browserReopen", { attemptId });
   }
 
   passwordLogin(username: string, password: string): Promise<AuthState> {
-    return bridge().invoke<AuthState>("feature.auth.passwordLogin", { username, password });
+    return mahayanaBridge().invoke<AuthState>("feature.auth.passwordLogin", { username, password });
   }
 
   oauthStart(provider: AuthProviderId): Promise<OAuthAttempt> {
-    return bridge().invoke<OAuthAttempt>("feature.auth.oauthStart", { provider });
+    return mahayanaBridge().invoke<OAuthAttempt>("feature.auth.oauthStart", { provider });
   }
 
   oauthPoll(attemptId: string): Promise<OAuthPollResult> {
-    return bridge().invoke<OAuthPollResult>("feature.auth.oauthPoll", { attemptId });
+    return mahayanaBridge().invoke<OAuthPollResult>("feature.auth.oauthPoll", { attemptId });
   }
 
   logout(): Promise<AuthState> {
-    return bridge().invoke<AuthState>("feature.auth.logout");
+    return mahayanaBridge().invoke<AuthState>("feature.auth.logout");
   }
 
   openExternal(url: string): Promise<void> {
@@ -135,27 +150,27 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     ) {
       return Promise.resolve();
     }
-    return bridge().openExternal(url).then(() => undefined);
+    return shellBridge().openExternal(url).then(() => undefined);
   }
 
   openSystemSettings(pane: "screen-recording" | "accessibility"): Promise<void> {
-    return bridge().openSystemSettings(pane).then(() => undefined);
+    return shellBridge().openSystemSettings(pane).then(() => undefined);
   }
 
   windowFocused(): Promise<boolean> {
-    return bridge().windowFocused();
+    return shellBridge().windowFocused();
   }
 
   showNotification(title: string, body: string): Promise<void> {
-    return bridge().notify(title, body).then(() => undefined);
+    return shellBridge().notify(title, body).then(() => undefined);
   }
 
   interrupt(operationId: string): Promise<void> {
-    return bridge().invoke<void>("feature.interrupt", { operationId });
+    return mahayanaBridge().invoke<void>("feature.interrupt", { operationId });
   }
 
   resolveApproval(resolution: ApprovalResolution): Promise<void> {
-    return bridge().invoke<void>("feature.approval.resolve", { resolution });
+    return mahayanaBridge().invoke<void>("feature.approval.resolve", { resolution });
   }
 
   async close(): Promise<void> {
@@ -172,7 +187,7 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     this.unsubscribeBridge?.();
     this.unsubscribeBridge = null;
 
-    const electronBridge = bridge();
+    const electronBridge = mahayanaBridge();
     if (typeof electronBridge.subscribe === "function") {
       this.unsubscribeBridge = electronBridge.subscribe((event) => this.dispatchEvent(event));
       return;
@@ -193,7 +208,7 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     try {
       while (!this.closed) {
         try {
-          const event = await bridge().invoke<RuntimeEvent | null>("feature.receive");
+          const event = await mahayanaBridge().invoke<RuntimeEvent | null>("feature.receive");
           if (event) this.dispatchEvent(event);
           else await idle(10);
         } catch (error) {

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-201/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-201/README.md
@@ -1,0 +1,10 @@
+# GBF-201 Evidence — Electron main audit
+
+Pinned source: `7174a70567ae98ef534b0eebcbe66935f1471cc1`; M2 base main: `d8b502726dc14f0a7963f67f58e44ebfb9887b01`.
+
+- `desktop/electron/main.cjs`: source->main diff is +197/-0, therefore current main strictly supersedes the pinned latest source in this file rather than losing source behavior.
+- Current main already serves per-method `MAHAYANA_EDGE` and `NATIVE_EDGE` with trusted-sender enforcement.
+- M2 removes the retired generic `fabushi:host` compatibility channel; current renderer routes Host calls through per-method edge channels only.
+- Existing product/security fixes after the source branch are retained; no historical branch overwrite was used.
+
+Verification: canonical Electron architecture guard, Feature Host bridge guard, auth entry guard, product UI contract, diff review.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-202/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-202/README.md
@@ -1,0 +1,7 @@
+# GBF-202 Evidence — preload / IPC contract
+
+- Dedicated `window.mahayana`, `window.fabushiNative`, and shell-only `window.fabushi` bridges are separated.
+- Contract version `1` is explicit in preload and shared edge descriptors.
+- Host transport binds to `window.mahayana.contractVersion === 1`; it no longer routes through `window.fabushi.invoke`.
+- Generic `ipcMain.handle('fabushi:host')` is removed and guarded against reintroduction by CI.
+- `edge-ipc.test.cjs` verifies declared-method-only client construction, trust denial, missing handler, stable failures, event allowlist, disposal and subscriptions.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-203/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-203/README.md
@@ -1,0 +1,5 @@
+# GBF-203 Evidence — Host process lifecycle
+
+`MahayanaHostProcess` now tracks a monotonic generation and terminal closed state. Pending requests are generation-bound. Stale stdout/error/exit events from an old child cannot resolve/reject requests owned by a replacement child. `health()` reports state/generation/pid/pending/lastExit; `restart()` deterministically rejects only the active generation and starts a fresh host.
+
+Fault tests cover normal request/health, unexpected process failure and recovery, stale late exit, explicit restart, and terminal close.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-204/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-204/README.md
@@ -1,0 +1,6 @@
+# GBF-204 Evidence — native capability handlers
+
+- Static catalog parity: 156 methods, all implemented.
+- Semantic stub gate: 156/156 pass.
+- Security tests verify administrator permission ceiling, fail-closed OS secret encryption, encrypted-at-rest Secret Vault with no plaintext list leakage, managed attachment path containment, HTTPS-only downloads, and recursive telemetry redaction.
+- Native edge remains trusted-sender gated; no generic renderer IPC bypass is retained.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-205/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-205/README.md
@@ -1,0 +1,6 @@
+# GBF-205 Evidence — native/edge IPC
+
+- Shared edge descriptor is explicitly versioned.
+- Main registers one IPC handler per declared method rather than a universal method dispatcher channel.
+- Unknown/missing handlers, untrusted sender, handler exception, unknown event, subscription cleanup and dispose behavior have deterministic tests.
+- Native desktop parity gate reports 156 methods / 28 events with every event produced.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-206/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-206/README.md
@@ -1,0 +1,3 @@
+# GBF-206 Evidence — Offline ASR
+
+Existing Fabushi offline ASR is retained as the product-owned path. Tests prove local whisper-compatible execution without shell interpolation, HTTPS-only model download, mandatory SHA-256 verification, cleanup on integrity mismatch, and stable provider/status result semantics. No Grok vendor runtime is required.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-207/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-207/README.md
@@ -1,0 +1,3 @@
+# GBF-207 Evidence — Electron E2E
+
+Implementation changes update Electron smoke/surface E2E to use the dedicated versioned `window.mahayana` bridge. GitHub Actions / packaged Playwright evidence is pending on the M2 PR; this task remains IN_PROGRESS until those jobs and protected-main post-merge verification pass.

--- a/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
@@ -5,18 +5,18 @@
 | ID | Stage | Action | Dependency | Acceptance | Verification | Evidence | Status | Blocker | Next action |
 |---|---|---|---|---|---|---|---|---|---|
 | GBF-001 | M0 | 建立企业级项目基线 | none | 标准 scaffold + PR/CI/main 验证 | project audit + GitHub facts | evidence/GBF-001 | RELEASED | none | GBF-101 固定 source/main refs |
-| GBF-101 | M1 | 固定 source/main 基线 ref | GBF-001 | 3 个权威 ref/commit 固化 | GitHub ref read | evidence/GBF-101 | TESTED | PR/CI/main closure pending | M1 PR 验证并合并 |
-| GBF-102 | M1 | 生成来源递归 file manifest | GBF-101 | 来源文件 path/hash/type 100% 入表 | manifest completeness check | evidence/GBF-102 | TESTED | PR/CI/main closure pending | M1 PR 验证并合并 |
-| GBF-103 | M1 | 建立功能能力矩阵 | GBF-102 | 关键文件全部映射能力域 | zero-unclassified check | evidence/GBF-103 | TESTED | PR/CI/main closure pending | M1 PR 验证并合并 |
-| GBF-104 | M1 | 建立 main/source 差异矩阵 | GBF-102,103 | 每项有处理分类 | matrix enum validation | evidence/GBF-104 | TESTED | PR/CI/main closure pending | M1 PR 验证并合并 |
-| GBF-105 | M1 | 建立 provenance ledger | GBF-102 | 来源/许可/复用/重写决策齐全 | zero unknown retained source | evidence/GBF-105 | TESTED | PR/CI/main closure pending | 审查迁移 PR；vendor snapshot 保持 reference-only |
-| GBF-201 | M2 | 审计 Electron main.cjs | GBF-104 | 生命周期/IPC 独有差异有决策 | file/behavior diff review | evidence/GBF-201 | NOT_STARTED | M1 | 建原子实施任务 |
-| GBF-202 | M2 | 收敛 preload/IPC contract | GBF-201 | 无通用 IPC；版本化 contract | allow/deny contract tests | evidence/GBF-202 | NOT_STARTED | GBF-201 | 设计最小 preload API |
-| GBF-203 | M2 | 收敛 host-process | GBF-201 | 单一 host lifecycle/health/restart | host integration/fault tests | evidence/GBF-203 | NOT_STARTED | GBF-201 | 比较并重构 host |
-| GBF-204 | M2 | 收敛 native capability handlers | GBF-202,203 | 所有高风险 handler 过 gate | capability unit/security tests | evidence/GBF-204 | NOT_STARTED | GBF-202/203 | 建 handler inventory |
-| GBF-205 | M2 | 收敛 native/edge IPC | GBF-202 | schema/error contract 唯一 | schema/version tests | evidence/GBF-205 | NOT_STARTED | GBF-202 | 统一 edge contracts |
-| GBF-206 | M2 | 评估并迁移 Offline ASR | GBF-104 | 产品归属、资源/性能证据清晰 | unit + runtime benchmark | evidence/GBF-206 | NOT_STARTED | M1 | 比较现有 ASR 路径 |
-| GBF-207 | M2 | 迁移有效 Electron E2E | GBF-201..206 | 当前 main 架构可运行 | Playwright/Electron E2E | evidence/GBF-207 | NOT_STARTED | M2 impl | 迁移/重写旧 E2E |
+| GBF-101 | M1 | 固定 source/main 基线 ref | GBF-001 | 3 个权威 ref/commit 固化 | GitHub ref read | evidence/GBF-101 | RELEASED | none | M2/M3/M5 downstream audit |
+| GBF-102 | M1 | 生成来源递归 file manifest | GBF-101 | 来源文件 path/hash/type 100% 入表 | manifest completeness check | evidence/GBF-102 | RELEASED | none | M2/M3/M5 downstream audit |
+| GBF-103 | M1 | 建立功能能力矩阵 | GBF-102 | 关键文件全部映射能力域 | zero-unclassified check | evidence/GBF-103 | RELEASED | none | M2/M3/M5 downstream audit |
+| GBF-104 | M1 | 建立 main/source 差异矩阵 | GBF-102,103 | 每项有处理分类 | matrix enum validation | evidence/GBF-104 | RELEASED | none | M2/M3/M5 downstream audit |
+| GBF-105 | M1 | 建立 provenance ledger | GBF-102 | 来源/许可/复用/重写决策齐全 | zero unknown retained source | evidence/GBF-105 | RELEASED | none | GBF-703 release provenance audit |
+| GBF-201 | M2 | 审计 Electron main.cjs | GBF-104 | 生命周期/IPC 独有差异有决策 | file/behavior diff review | evidence/GBF-201 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
+| GBF-202 | M2 | 收敛 preload/IPC contract | GBF-201 | 无通用 IPC；版本化 contract | allow/deny contract tests | evidence/GBF-202 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
+| GBF-203 | M2 | 收敛 host-process | GBF-201 | 单一 host lifecycle/health/restart | host integration/fault tests | evidence/GBF-203 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
+| GBF-204 | M2 | 收敛 native capability handlers | GBF-202,203 | 所有高风险 handler 过 gate | capability unit/security tests | evidence/GBF-204 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
+| GBF-205 | M2 | 收敛 native/edge IPC | GBF-202 | schema/error contract 唯一 | schema/version tests | evidence/GBF-205 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
+| GBF-206 | M2 | 评估并迁移 Offline ASR | GBF-104 | 产品归属、资源/性能证据清晰 | unit + runtime benchmark | evidence/GBF-206 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
+| GBF-207 | M2 | 迁移有效 Electron E2E | GBF-201..206 | 当前 main 架构可运行 | Playwright/Electron E2E | evidence/GBF-207 | IN_PROGRESS | GitHub packaged E2E pending | PR + Electron Actions/Playwright |
 | GBF-301 | M3 | 盘点 coordinator/supervisor/host 行为 | GBF-103,104 | 重复执行链全部识别 | architecture walk + call graph | evidence/GBF-301 | NOT_STARTED | M1 | 生成行为规格 |
 | GBF-302 | M3 | 统一 Agent loop 到 Mahayana | GBF-301 | 唯一正式 agent runtime | integration/call-path tests | evidence/GBF-302 | NOT_STARTED | GBF-301 | 收敛入口 |
 | GBF-303 | M3 | 统一 tool/MCP/extension dispatch | GBF-302 | 同一 policy/result contract | contract + integration tests | evidence/GBF-303 | NOT_STARTED | GBF-302 | 合并 dispatch contract |

--- a/projects/grok-bot-fabushi-integration/management/02-里程碑.md
+++ b/projects/grok-bot-fabushi-integration/management/02-里程碑.md
@@ -5,8 +5,8 @@
 | ID | Target | Required tasks / exit gate | Planned | Actual | Status | Evidence |
 |---|---|---|---|---|---|---|
 | M0 | 企业级项目基线 | GBF-001：scaffold + PR + CI + main verify | 2026-08-22 | 2026-08-22 | RELEASED | PR #1982; CI #6089; merge `6d1e9cd7...`; main verification |
-| M1 | 全量源码/能力盘点 | GBF-101..105 全通过；zero unclassified | TBD | — | IN_PROGRESS | `evidence/GBF-101..105`; PR/CI/main closure pending |
-| M2 | Electron/IPC/Host 收敛 | GBF-201..207；当前架构 E2E | TBD | — | NOT_STARTED | M2 task evidence |
+| M1 | 全量源码/能力盘点 | GBF-101..105 全通过；zero unclassified | TBD | 2026-08-22 | RELEASED | PR #2003; CI #6172; portfolio #30; merge `d8b502726...`; post-merge main verify |
+| M2 | Electron/IPC/Host 收敛 | GBF-201..207；当前架构 E2E | TBD | — | IN_PROGRESS | GBF-201..207 task evidence |
 | M3 | 单一 Agent/Tool/LocalExec runtime | GBF-301..306；无重复正式主通道 | TBD | — | NOT_STARTED | M3 task evidence |
 | M4 | 电脑控制能力闭环 | GBF-401..407；三桌面平台/浏览器/权限 E2E | TBD | — | NOT_STARTED | M4 task evidence |
 | M5 | Fabushi UI/动态头像动画引擎 | GBF-501..505；性能/无障碍/依赖审计 | TBD | — | NOT_STARTED | M5 task evidence |

--- a/projects/grok-bot-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/grok-bot-fabushi-integration/management/03-验收追踪矩阵.md
@@ -2,10 +2,10 @@
 
 | Requirement | Tasks | Required evidence | State |
 |---|---|---|---|
-| GBR-001 全盘点 | GBF-101..105 | refs + manifest + matrix | IN_PROGRESS (local audit passed; merge pending) |
+| GBR-001 全盘点 | GBF-101..105 | refs + manifest + matrix | PASSED / M1 RELEASED |
 | GBR-002 正式融合 | GBF-201..604 | implementation PRs + tests | OPEN |
 | GBR-003 单一 runtime | GBF-301..306 | architecture diff + integration tests | OPEN |
-| GBR-004 Electron 安全收敛 | GBF-201..205,701..702 | contract/security/E2E | OPEN |
+| GBR-004 Electron 安全收敛 | GBF-201..205,701..702 | contract/security/E2E | IN_PROGRESS (M2 local contract/security passed; CI/M7 pending) |
 | GBR-005 电脑控制可审计可撤销 | GBF-401..407 | permission/recovery E2E | OPEN |
 | GBR-006 自研动画引擎 | GBF-501..505 | source + behavior + performance tests | OPEN |
 | GBR-007 自动化验证 | 全部实施任务 | CI/test/E2E links | OPEN |

--- a/projects/grok-bot-fabushi-integration/management/05-状态报告.md
+++ b/projects/grok-bot-fabushi-integration/management/05-状态报告.md
@@ -41,3 +41,21 @@
 - Blocker/Risk: 无 M1 数据阻塞；PR/CI/main closure pending。外部 Grok production snapshot 明确 `PROVENANCE_BLOCKED`/reference-only，后续不得原样发布。
 - Next: 提交 M1 PR；随后按能力矩阵立即推进 M2 Electron/Host 收敛和 M3 runtime 收敛，不等待聊天确认。
 - Verified progress: M0 RELEASED；M1 5/5 tasks 已达到 TESTED，但 0/5 完成 protected-main closure。
+
+## 2026-08-22 17:01+08 / Round 5
+
+- Task/Stage: GBF-101..105 / M1.
+- Completed: PR #2003 通过 `CI` run #6172 和 `Project portfolio governance` run #30，经 merge queue 合入 `main`；merge commit `d8b502726dc14f0a7963f67f58e44ebfb9887b01`。随后从 `origin/main` 重新读取 `M1-validation.json` 与 GBF-101..105 task records，确认 canonical evidence 存在且六项 M1 validation 全 true。
+- Acceptance: GBF-101..105 RELEASED；M1 RELEASED；GBR-001 PASSED。
+- Evidence: PR #2003; CI #6172; portfolio #30; merge `d8b502726...`; `main:projects/grok-bot-fabushi-integration/evidence/M1-validation.json`.
+- Blocker/Risk: M1 无 blocker；vendor 0.20 reference-only provenance 风险继续由 GBF-703 在发布前清零确认。
+- Next: M2 GBF-201..207 Electron/IPC/Host 收敛；并行准备 M3 runtime audit。
+
+## 2026-08-22 17:09+08 / Round 6
+
+- Task/Stage: GBF-201..207 / M2.
+- Completed locally: 删除通用 `fabushi:host` IPC；Host transport 收敛到 versioned `window.mahayana`; edge contract version=1；MahayanaHostProcess 增加 generation-bound lifecycle/health/restart/closed 语义；新增 edge/host/native security 测试并接入 CI；保留并验证现有 Offline ASR。
+- Verification: 19/19 Node fault/security/ASR tests pass；FeatureCommand 98/98；native capability 156/156；native events 28/28；canonical Electron、Feature Host bridge、auth entry、product UI、portfolio guards pass。
+- Acceptance: GBF-201..206 = TESTED（GitHub CI/merge pending）；GBF-207 = IN_PROGRESS（packaged Electron/Playwright evidence pending）。
+- Risk: 不把本地轻量测试替代为最终 E2E/CI；M2 尚未 RELEASED。
+- Next: 提交 M2 PR；Actions 运行期间继续 GBF-301..306 runtime audit。

--- a/projects/grok-bot-fabushi-integration/management/07-变更日志.md
+++ b/projects/grok-bot-fabushi-integration/management/07-变更日志.md
@@ -10,3 +10,5 @@
 
 - 2026-08-22 M1 Round 4：固定 `main=e621c653...`、`latest=7174a705...`、`0.16=a8bd854b...`；新增可重复生成的 M1 inventory 工具与全量 source manifests/capability/diff/provenance evidence。
 - 追溯 `8bb9f6a09` 的 Grok Bot 0.20 production vendor snapshot（148 entries）及 `25e02683d` 删除节点；正式规定该 snapshot 为 `PROVENANCE_BLOCKED` reference-only，current main 不保留 vendor runtime。
+- 2026-08-22 17:01+08：M1 经 PR #2003 / CI #6172 / portfolio #30 / merge `d8b502726...` / post-merge main verify 正式 RELEASED；进入 M2。
+- 2026-08-22 17:09+08：M2 移除通用 `fabushi:host` IPC，建立 versioned 专用 Mahayana edge，强化 Host generation/restart/health，并新增 edge/native/security/ASR fault tests 与 CI gate。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-101-pin-source-refs.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-101-pin-source-refs.md
@@ -6,15 +6,15 @@
 - Objective: 固化本轮审计使用的 `main`、`grok-bot-latest-source-fusion`、`grok-bot-0.16-source-fusion` 精确 commit/tree refs，作为 M1 后续 manifest、能力矩阵、差异矩阵和 provenance 的不可变输入。
 - Source requirement IDs/references: GBR-001, GBR-008; `source/grok-bot融合优化.txt`
 - Stage: M1-source-inventory
-- Status: TESTED (merge/main closure pending)
+- Status: RELEASED
 - In scope: 读取远端分支 head、tree、commit 时间/签名状态、merge-base/reachability；写入项目 evidence/依赖/行动项。
 - Out of scope: 在本任务中直接迁移运行时代码或宣称 GBF-102..105 完成。
 - Dependencies: GBF-001 RELEASED; GitHub `main`; two historical Grok source branches.
 - Implementation branch: `gbf/gbf-101-m1-inventory-20260822`
-- PR: pending M1 PR
+- PR: #2003
 - Started: 2026-08-22 16:47+08
 - Updated: 2026-08-22 16:47+08
-- Completed: —
+- Completed: 2026-08-22 17:01+08
 
 ## Acceptance criteria / checks
 

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-102-recursive-source-manifests.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-102-recursive-source-manifests.md
@@ -4,7 +4,7 @@
 - Project Key: GBF
 - Task ID: GBF-102
 - Stage: M1-source-inventory
-- Status: TESTED (merge/main closure pending)
+- Status: RELEASED
 - Objective: 对两个固定历史来源 head 递归枚举 Git mode/type/object/size/path，保证来源树 100% 可重建、可校验。
 - Source requirements: GBR-001, GBR-008
 - Dependencies: GBF-101 pinned refs.
@@ -26,3 +26,5 @@
 ## Result / next
 
 文件级清单已本地轻量验证。继续 GBF-103/104/105 并在同一 M1 PR 中接受 CI。
+
+- Completed: 2026-08-22 17:01+08

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-103-capability-matrix.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-103-capability-matrix.md
@@ -4,7 +4,7 @@
 - Project Key: GBF
 - Task ID: GBF-103
 - Stage: M1-source-inventory
-- Status: TESTED (merge/main closure pending)
+- Status: RELEASED
 - Objective: 将共同基线到两个历史 Grok 输入 head 的全部变化文件映射到稳定 capability domain，避免功能漏盘点。
 - Source requirements: GBR-001, GBR-002
 - Dependencies: GBF-102.
@@ -26,3 +26,5 @@
 ## Result / next
 
 能力映射已建立；继续 GBF-104 将每一个 source/main path difference 赋予处理决策。
+
+- Completed: 2026-08-22 17:01+08

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-104-main-source-diff-matrix.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-104-main-source-diff-matrix.md
@@ -4,7 +4,7 @@
 - Project Key: GBF
 - Task ID: GBF-104
 - Stage: M1-source-inventory
-- Status: TESTED (merge/main closure pending)
+- Status: RELEASED
 - Objective: 对每个固定 source head 与固定 main 的全部 path difference 给出明确处理分类，禁止无决策的大规模覆盖。
 - Source requirements: GBR-001, GBR-002, GBR-009
 - Dependencies: GBF-102, GBF-103.
@@ -26,3 +26,5 @@
 ## Result / next
 
 差异已无空处理分类；继续 GBF-105 provenance，之后按 capability domain 进入 M2-M7 原子审计/实现。
+
+- Completed: 2026-08-22 17:01+08

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-105-provenance-ledger.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-105-provenance-ledger.md
@@ -4,7 +4,7 @@
 - Project Key: GBF
 - Task ID: GBF-105
 - Stage: M1-source-inventory
-- Status: TESTED (merge/main closure pending)
+- Status: RELEASED
 - Objective: 对 Grok 迁移变化面和 0.20 vendor 历史快照建立来源/许可状态/复用策略，保证不明授权代码不会静默进入产品。
 - Source requirements: GBR-008, GBR-009
 - Dependencies: GBF-102.
@@ -28,3 +28,5 @@
 ## Result / next
 
 来源阻塞已显式化且生产 main 不保留 vendor snapshot。后续 GBF-703 需要持续审计迁移 PR，确保 release retained-source blocking=0。
+
+- Completed: 2026-08-22 17:01+08

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-201-electron-main-audit.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-201-electron-main-audit.md
@@ -1,0 +1,44 @@
+# GBF-201 — 审计并收敛 Electron main.cjs 生命周期/IPC 行为
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-201
+- Objective: 审计并收敛 Electron main.cjs 生命周期/IPC 行为。
+- Source requirement IDs/references: GBR-002, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
+- Stage: M2
+- Status: TESTED (GitHub CI/merge pending)
+- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
+- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Dependencies: GBF-104.
+- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
+- PR: pending
+- Started: 2026-08-22 17:03+08
+- Updated: 2026-08-22 17:09+08
+- Completed: —
+
+## Acceptance criteria
+
+- [x] main/source lifecycle+IPC diff；保留 main 后续修复；每个独有行为有 retain/rewrite/deprecate 决策。
+- [x] 相关拒绝/错误/恢复路径有客观验证。
+- [ ] GitHub Actions required checks 通过。
+- [ ] merge queue 合入 main 并完成 post-merge verification。
+
+## Verification
+
+file/behavior diff + CI contract.
+
+## Implementation / local verification
+
+本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+
+## Evidence
+
+`evidence/GBF-201/`（实现后补 commit/PR/CI/test/main verification）。
+
+## Risks
+
+R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
+
+## Next action
+
+执行当前 main/source audit，修复真实缺口并补最小自动化测试。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-202-preload-ipc-contract.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-202-preload-ipc-contract.md
@@ -1,0 +1,44 @@
+# GBF-202 — 收敛 preload/IPC 为最小版本化 contract
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-202
+- Objective: 收敛 preload/IPC 为最小版本化 contract。
+- Source requirement IDs/references: GBR-002, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
+- Stage: M2
+- Status: TESTED (GitHub CI/merge pending)
+- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
+- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Dependencies: GBF-201.
+- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
+- PR: pending
+- Started: 2026-08-22 17:03+08
+- Updated: 2026-08-22 17:09+08
+- Completed: —
+
+## Acceptance criteria
+
+- [x] renderer 无通用 IPC；所有公开调用来自 allowlisted edge/compat API；deny path 可测试。
+- [x] 相关拒绝/错误/恢复路径有客观验证。
+- [ ] GitHub Actions required checks 通过。
+- [ ] merge queue 合入 main 并完成 post-merge verification。
+
+## Verification
+
+edge contract unit/security tests + bridge CI.
+
+## Implementation / local verification
+
+本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+
+## Evidence
+
+`evidence/GBF-202/`（实现后补 commit/PR/CI/test/main verification）。
+
+## Risks
+
+R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
+
+## Next action
+
+执行当前 main/source audit，修复真实缺口并补最小自动化测试。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-203-host-process-lifecycle.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-203-host-process-lifecycle.md
@@ -1,0 +1,44 @@
+# GBF-203 — 收敛 Mahayana host 子进程生命周期/health/restart
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-203
+- Objective: 收敛 Mahayana host 子进程生命周期/health/restart。
+- Source requirement IDs/references: GBR-002, GBR-003, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
+- Stage: M2
+- Status: TESTED (GitHub CI/merge pending)
+- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
+- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Dependencies: GBF-201.
+- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
+- PR: pending
+- Started: 2026-08-22 17:03+08
+- Updated: 2026-08-22 17:09+08
+- Completed: —
+
+## Acceptance criteria
+
+- [x] 单一 host 生命周期；并发 start 安全；退出/close 不污染新 generation；pending 有确定失败；health 可观测。
+- [x] 相关拒绝/错误/恢复路径有客观验证。
+- [ ] GitHub Actions required checks 通过。
+- [ ] merge queue 合入 main 并完成 post-merge verification。
+
+## Verification
+
+host-process unit/fault tests + Electron CI.
+
+## Implementation / local verification
+
+本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+
+## Evidence
+
+`evidence/GBF-203/`（实现后补 commit/PR/CI/test/main verification）。
+
+## Risks
+
+R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
+
+## Next action
+
+执行当前 main/source audit，修复真实缺口并补最小自动化测试。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-204-native-capability-handlers.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-204-native-capability-handlers.md
@@ -1,0 +1,44 @@
+# GBF-204 — 收敛 native capability handlers 权限与输入验证
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-204
+- Objective: 收敛 native capability handlers 权限与输入验证。
+- Source requirement IDs/references: GBR-002, GBR-004, GBR-005; `source/grok-bot融合优化.txt`; M1 evidence.
+- Stage: M2
+- Status: TESTED (GitHub CI/merge pending)
+- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
+- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Dependencies: GBF-202, GBF-203.
+- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
+- PR: pending
+- Started: 2026-08-22 17:03+08
+- Updated: 2026-08-22 17:09+08
+- Completed: —
+
+## Acceptance criteria
+
+- [x] 高风险 handler 有显式安全语义；无 renderer 绕过；静态语义门禁与 deny tests 通过。
+- [x] 相关拒绝/错误/恢复路径有客观验证。
+- [ ] GitHub Actions required checks 通过。
+- [ ] merge queue 合入 main 并完成 post-merge verification。
+
+## Verification
+
+native semantic/parity gates + security tests.
+
+## Implementation / local verification
+
+本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+
+## Evidence
+
+`evidence/GBF-204/`（实现后补 commit/PR/CI/test/main verification）。
+
+## Risks
+
+R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
+
+## Next action
+
+执行当前 main/source audit，修复真实缺口并补最小自动化测试。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-205-native-edge-contract.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-205-native-edge-contract.md
@@ -1,0 +1,44 @@
+# GBF-205 — 收敛 native/edge IPC schema 与错误合同
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-205
+- Objective: 收敛 native/edge IPC schema 与错误合同。
+- Source requirement IDs/references: GBR-002, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
+- Stage: M2
+- Status: TESTED (GitHub CI/merge pending)
+- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
+- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Dependencies: GBF-202.
+- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
+- PR: pending
+- Started: 2026-08-22 17:03+08
+- Updated: 2026-08-22 17:09+08
+- Completed: —
+
+## Acceptance criteria
+
+- [x] edge method/event catalog 唯一；unknown event/handler/trust failure 可确定；dispose 无残留 handler。
+- [x] 相关拒绝/错误/恢复路径有客观验证。
+- [ ] GitHub Actions required checks 通过。
+- [ ] merge queue 合入 main 并完成 post-merge verification。
+
+## Verification
+
+edge-ipc unit tests + parity gate.
+
+## Implementation / local verification
+
+本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+
+## Evidence
+
+`evidence/GBF-205/`（实现后补 commit/PR/CI/test/main verification）。
+
+## Risks
+
+R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
+
+## Next action
+
+执行当前 main/source audit，修复真实缺口并补最小自动化测试。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-206-offline-asr.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-206-offline-asr.md
@@ -1,0 +1,44 @@
+# GBF-206 — 验证并保留 Offline ASR 的本机安全实现
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-206
+- Objective: 验证并保留 Offline ASR 的本机安全实现。
+- Source requirement IDs/references: GBR-002, GBR-007; `source/grok-bot融合优化.txt`; M1 evidence.
+- Stage: M2
+- Status: TESTED (GitHub CI/merge pending)
+- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
+- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Dependencies: GBF-104.
+- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
+- PR: pending
+- Started: 2026-08-22 17:03+08
+- Updated: 2026-08-22 17:09+08
+- Completed: —
+
+## Acceptance criteria
+
+- [x] 本机执行不经 shell；模型仅 HTTPS 且 SHA-256 验证；状态/下载/转写测试通过。
+- [x] 相关拒绝/错误/恢复路径有客观验证。
+- [ ] GitHub Actions required checks 通过。
+- [ ] merge queue 合入 main 并完成 post-merge verification。
+
+## Verification
+
+offline-asr node tests + package/CI gate.
+
+## Implementation / local verification
+
+本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+
+## Evidence
+
+`evidence/GBF-206/`（实现后补 commit/PR/CI/test/main verification）。
+
+## Risks
+
+R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
+
+## Next action
+
+执行当前 main/source audit，修复真实缺口并补最小自动化测试。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-207-electron-e2e.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-207-electron-e2e.md
@@ -1,0 +1,40 @@
+# GBF-207 — 验证当前 Electron 架构关键 Grok/Fabushi 用户旅程
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-207
+- Objective: 验证当前 Electron 架构关键 Grok/Fabushi 用户旅程。
+- Source requirement IDs/references: GBR-002, GBR-007; `source/grok-bot融合优化.txt`; M1 evidence.
+- Stage: M2
+- Status: IN_PROGRESS (GitHub E2E pending)
+- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
+- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Dependencies: GBF-201..206.
+- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
+- PR: pending
+- Started: 2026-08-22 17:03+08
+- Updated: 2026-08-22 17:09+08
+- Completed: —
+
+## Acceptance criteria
+
+- [ ] Playwright Electron smoke/surfaces 可运行；桥/Host/ASR/renderer 受 CI 覆盖。
+- [ ] 相关拒绝/错误/恢复路径有客观验证。
+- [ ] GitHub Actions required checks 通过。
+- [ ] merge queue 合入 main 并完成 post-merge verification。
+
+## Verification
+
+GitHub Actions Electron E2E + required CI.
+
+## Evidence
+
+`evidence/GBF-207/`（实现后补 commit/PR/CI/test/main verification）。
+
+## Risks
+
+R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
+
+## Next action
+
+执行当前 main/source audit，修复真实缺口并补最小自动化测试。


### PR DESCRIPTION
## FAB-P0004 / GBF — M2 Electron / IPC / Host convergence

Advances GBF-201..207 on top of released M1.

### Product changes
- remove the retired generic `fabushi:host` IPC dispatcher
- split renderer bridges into versioned dedicated `window.mahayana`, `window.fabushiNative`, and shell-only `window.fabushi`
- require Mahayana bridge contract version 1 in the Electron transport
- strengthen `MahayanaHostProcess` with generation-bound pending work, health state, deterministic restart, terminal close, and stale-child isolation
- keep the existing Fabushi-owned Offline ASR path; no Grok vendor runtime is restored

### Automated tests / guards
- add edge IPC contract tests
- add Host process fault/restart/generation tests
- add native capability deny/security tests
- keep Offline ASR security/integrity tests
- wire all four suites into CI and Electron Desktop Actions
- update E2E to exercise the dedicated Mahayana bridge
- guard against reintroducing `fabushi:host` or Host calls through the generic shell facade

### Local lightweight evidence
- 19/19 Node edge/host/native-security/ASR tests pass
- FeatureCommand router 98/98
- native capability semantics 156/156
- native desktop parity 156 methods / 28 events / all events produced
- canonical Electron architecture, Feature Host bridge, auth entry, product UI, portfolio and diff checks pass

### Project state
GBF-201..206 remain TESTED until authoritative GitHub CI/merge/post-merge verification. GBF-207 remains IN_PROGRESS until packaged Electron / Playwright evidence is green. No historical Grok branch is wholesale-merged.