### PR TITLE
docs(gbf): close M2 after packaged Electron verification

### DIFF
--- a/projects/grok-bot-fabushi-integration/PROJECT.yaml
+++ b/projects/grok-bot-fabushi-integration/PROJECT.yaml
@@ -12,7 +12,7 @@ owner: Fabushi/Mahayana maintainers
 reviewers:
   - Fabushi maintainers
   - Security reviewer for high-risk capabilities
-current_stage: M1-source-inventory
+current_stage: M3-runtime-convergence
 created_at: 2026-08-22
 updated_at: 2026-08-22
 source_requirement: source/grok-bot融合优化.txt

--- a/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
@@ -10,20 +10,20 @@
 | GBF-103 | M1 | 建立功能能力矩阵 | GBF-102 | 关键文件全部映射能力域 | zero-unclassified check | evidence/GBF-103 | RELEASED | none | M2/M3/M5 downstream audit |
 | GBF-104 | M1 | 建立 main/source 差异矩阵 | GBF-102,103 | 每项有处理分类 | matrix enum validation | evidence/GBF-104 | RELEASED | none | M2/M3/M5 downstream audit |
 | GBF-105 | M1 | 建立 provenance ledger | GBF-102 | 来源/许可/复用/重写决策齐全 | zero unknown retained source | evidence/GBF-105 | RELEASED | none | GBF-703 release provenance audit |
-| GBF-201 | M2 | 审计 Electron main.cjs | GBF-104 | 生命周期/IPC 独有差异有决策 | file/behavior diff review | evidence/GBF-201 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
-| GBF-202 | M2 | 收敛 preload/IPC contract | GBF-201 | 无通用 IPC；版本化 contract | allow/deny contract tests | evidence/GBF-202 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
-| GBF-203 | M2 | 收敛 host-process | GBF-201 | 单一 host lifecycle/health/restart | host integration/fault tests | evidence/GBF-203 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
-| GBF-204 | M2 | 收敛 native capability handlers | GBF-202,203 | 所有高风险 handler 过 gate | capability unit/security tests | evidence/GBF-204 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
-| GBF-205 | M2 | 收敛 native/edge IPC | GBF-202 | schema/error contract 唯一 | schema/version tests | evidence/GBF-205 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
-| GBF-206 | M2 | 评估并迁移 Offline ASR | GBF-104 | 产品归属、资源/性能证据清晰 | unit + runtime benchmark | evidence/GBF-206 | TESTED | GitHub CI/merge pending | PR + Actions + merge queue |
-| GBF-207 | M2 | 迁移有效 Electron E2E | GBF-201..206 | 当前 main 架构可运行 | Playwright/Electron E2E | evidence/GBF-207 | IN_PROGRESS | GitHub packaged E2E pending | PR + Electron Actions/Playwright |
+| GBF-201 | M2 | 审计 Electron main.cjs | GBF-104 | 生命周期/IPC 独有差异有决策 | file/behavior diff review + post-main | evidence/GBF-201 | RELEASED | none | GBF-301 runtime convergence |
+| GBF-202 | M2 | 收敛 preload/IPC contract | GBF-201 | 无通用 IPC；版本化 contract | allow/deny contract + packaged E2E | evidence/GBF-202 | RELEASED | none | GBF-301 runtime convergence |
+| GBF-203 | M2 | 收敛 host-process | GBF-201 | 单一 host lifecycle/health/restart | host fault + real Host E2E | evidence/GBF-203 | RELEASED | none | GBF-301 runtime convergence |
+| GBF-204 | M2 | 收敛 native capability handlers | GBF-202,203 | 所有高风险 handler 过 gate | capability/security tests | evidence/GBF-204 | RELEASED | none | GBF-701 security closure |
+| GBF-205 | M2 | 收敛 native/edge IPC | GBF-202 | schema/error contract 唯一 | schema/version/sender tests | evidence/GBF-205 | RELEASED | none | GBF-301 runtime convergence |
+| GBF-206 | M2 | 评估并迁移 Offline ASR | GBF-104 | 产品归属、资源/性能证据清晰 | unit + CI contract | evidence/GBF-206 | RELEASED | none | GBF-604 perf closure |
+| GBF-207 | M2 | 迁移有效 Electron E2E | GBF-201..206 | 当前 main 架构可运行 | Host smoke + macOS/Windows/Linux packaged E2E | evidence/GBF-207 | RELEASED | none | GBF-801 final RC |
 | GBF-301 | M3 | 盘点 coordinator/supervisor/host 行为 | GBF-103,104 | 重复执行链全部识别 | architecture walk + call graph | evidence/GBF-301 | NOT_STARTED | M1 | 生成行为规格 |
 | GBF-302 | M3 | 统一 Agent loop 到 Mahayana | GBF-301 | 唯一正式 agent runtime | integration/call-path tests | evidence/GBF-302 | NOT_STARTED | GBF-301 | 收敛入口 |
 | GBF-303 | M3 | 统一 tool/MCP/extension dispatch | GBF-302 | 同一 policy/result contract | contract + integration tests | evidence/GBF-303 | NOT_STARTED | GBF-302 | 合并 dispatch contract |
 | GBF-304 | M3 | 统一 session/checkpoint/resume/cancel | GBF-302 | crash/resume/cancel 语义唯一 | fault/recovery integration | evidence/GBF-304 | NOT_STARTED | GBF-302 | 规范 session lifecycle |
 | GBF-305 | M3 | 统一 local exec | GBF-303 | 无绕过 capability gate 的执行口 | deny-path + code-path audit | evidence/GBF-305 | NOT_STARTED | GBF-303 | 删除/桥接绕过入口 |
 | GBF-306 | M3 | 统一错误/重试/超时/并发 | GBF-303..305 | 行为确定且可取消 | deterministic integration suite | evidence/GBF-306 | NOT_STARTED | GBF-303/304/305 | 定义错误状态机 |
-| GBF-401 | M4 | 定义 computer-control capability schema | GBF-204,305 | versioned target-bound contract | schema/threat review | evidence/GBF-401 | NOT_STARTED | M2/M3 | 定义 capability IDs |
+| GBF-401 | M4 | 定义 computer-control capability schema | GBF-204,305 | versioned target-bound contract | schema/threat review | evidence/GBF-401 | NOT_STARTED | M3 | 定义 capability IDs |
 | GBF-402 | M4 | 实现/验证 macOS adapter | GBF-401 | observe/input/window 能力受控 | macOS E2E | evidence/GBF-402 | NOT_STARTED | GBF-401 | 对齐平台 API |
 | GBF-403 | M4 | 实现/验证 Windows adapter | GBF-401 | observe/input/window 能力受控 | Windows E2E | evidence/GBF-403 | NOT_STARTED | GBF-401 | 对齐平台 API |
 | GBF-404 | M4 | 实现/验证 Linux adapter | GBF-401 | X11/Wayland 能力与降级明确 | Linux E2E | evidence/GBF-404 | NOT_STARTED | GBF-401 | 对齐 X11/Wayland |
@@ -35,11 +35,11 @@
 | GBF-503 | M5 | 动画 timeline/composition engine | GBF-502 | 可组合可确定渲染 | deterministic animation tests | evidence/GBF-503 | NOT_STARTED | GBF-502 | 实现时间线/曲线 |
 | GBF-504 | M5 | 动画性能与无障碍 | GBF-503 | offscreen/reduced-motion/预算可验证 | perf + accessibility tests | evidence/GBF-504 | NOT_STARTED | GBF-503 | 测量 frame baseline |
 | GBF-505 | M5 | 移除生产 Grok 视觉/runtime 依赖 | GBF-501..504 | production dependency audit clean | dependency/source audit | evidence/GBF-505 | NOT_STARTED | M5 | 替换剩余依赖 |
-| GBF-601 | M6 | canonical data model 映射 | GBF-104,302 | 无长期重复会话/tool/permission model | schema review/migration test | evidence/GBF-601 | NOT_STARTED | M1/M3 | 建 schema map |
+| GBF-601 | M6 | canonical data model 映射 | GBF-104,302 | 无长期重复会话/tool/permission model | schema review/migration test | evidence/GBF-601 | NOT_STARTED | M3 | 建 schema map |
 | GBF-602 | M6 | crash/restart 恢复 | GBF-304,601 | 关键状态可恢复且无重复副作用 | fault injection | evidence/GBF-602 | NOT_STARTED | GBF-304/601 | 建恢复矩阵 |
 | GBF-603 | M6 | 统一 correlation/structured logging | GBF-203,303 | renderer->tool 链路可追踪且无秘密 | trace assertions/log audit | evidence/GBF-603 | NOT_STARTED | runtime | 统一 event fields |
 | GBF-604 | M6 | 性能基线与 regression gate | GBF-207,407,504 | 真实 baseline 固化并可阻止严重回归 | benchmark + CI gate | evidence/GBF-604 | NOT_STARTED | feature E2E | 收集 baseline |
-| GBF-701 | M7 | IPC/host threat model | GBF-201..205 | 威胁/缓解/残余风险齐全 | security review | evidence/GBF-701 | NOT_STARTED | M2 | 建 threat inventory |
+| GBF-701 | M7 | IPC/host threat model | GBF-201..205 | 威胁/缓解/残余风险齐全 | security review | evidence/GBF-701 | NOT_STARTED | M4 | 建 threat inventory |
 | GBF-702 | M7 | 权限/拒绝路径安全测试 | GBF-401..407,701 | high-risk denial suite green | security test suite | evidence/GBF-702 | NOT_STARTED | M4/M7 | 扩充安全用例 |
 | GBF-703 | M7 | 来源/许可证阻塞清零 | GBF-105 + impl | retained source blocking=0 | provenance audit | evidence/GBF-703 | NOT_STARTED | GBF-105 | 审查每个迁移 PR |
 | GBF-704 | M7 | secret/log/privacy 审计 | GBF-603,702 | 无秘密泄漏/多余持久化 | log/privacy tests | evidence/GBF-704 | NOT_STARTED | GBF-603/702 | 扫描 telemetry |

--- a/projects/grok-bot-fabushi-integration/management/02-里程碑.md
+++ b/projects/grok-bot-fabushi-integration/management/02-里程碑.md
@@ -6,8 +6,8 @@
 |---|---|---|---|---|---|---|
 | M0 | 企业级项目基线 | GBF-001：scaffold + PR + CI + main verify | 2026-08-22 | 2026-08-22 | RELEASED | PR #1982; CI #6089; merge `6d1e9cd7...`; main verification |
 | M1 | 全量源码/能力盘点 | GBF-101..105 全通过；zero unclassified | TBD | 2026-08-22 | RELEASED | PR #2003; CI #6172; portfolio #30; merge `d8b502726...`; post-merge main verify |
-| M2 | Electron/IPC/Host 收敛 | GBF-201..207；当前架构 E2E | TBD | — | IN_PROGRESS | GBF-201..207 task evidence |
-| M3 | 单一 Agent/Tool/LocalExec runtime | GBF-301..306；无重复正式主通道 | TBD | — | NOT_STARTED | M3 task evidence |
+| M2 | Electron/IPC/Host 收敛 | GBF-201..207；当前架构 E2E | TBD | 2026-08-22 | RELEASED | PR #2005/#2009; CI #6212; Electron #521; merge `dcdc329c...`; post-main verify |
+| M3 | 单一 Agent/Tool/LocalExec runtime | GBF-301..306；无重复正式主通道 | TBD | — | IN_PROGRESS | PR #2007 / M3 task evidence |
 | M4 | 电脑控制能力闭环 | GBF-401..407；三桌面平台/浏览器/权限 E2E | TBD | — | NOT_STARTED | M4 task evidence |
 | M5 | Fabushi UI/动态头像动画引擎 | GBF-501..505；性能/无障碍/依赖审计 | TBD | — | NOT_STARTED | M5 task evidence |
 | M6 | 可靠性/可观测/性能 | GBF-601..604；恢复/trace/perf gate | TBD | — | NOT_STARTED | M6 task evidence |

--- a/projects/grok-bot-fabushi-integration/management/05-状态报告.md
+++ b/projects/grok-bot-fabushi-integration/management/05-状态报告.md
@@ -67,3 +67,12 @@
 - Fixed: in-app edit dialog；group create requires selected Bot；stable `group-bot-*` selector；E2E verifies Bot selected；browser-login helper tolerates already-ready authenticated state.
 - Acceptance: implementation repaired；authoritative Electron smoke rerun still required, so GBF-207/M2 remain IN_PROGRESS.
 - Next: push PR #2009 update and require Electron desktop green before M2 release.
+
+## 2026-08-22 20:12+08 / Round 10
+
+- Task/Stage: GBF-201..207 / M2 closure.
+- Completed: 后续 E2E 依次修复 context-menu `置顶` strict selector 和账单 native `prompt()`；账单改为真实 InvoiceDialog + 正金额校验。PR #2009 head `82beaf0e...` 的 CI #6212、Messaging #57、Self-hosted Messaging #121、Portfolio #65 均成功；Electron run #521 的 real Rust Host smoke、macOS/Windows/Linux packaging 与 packaged user journeys 全部成功。
+- Merge: PR #2009 经 merge queue 合入 `main`，merge commit `dcdc329cb76e609c469eaabbcccb707c0005f56d`；GitHub branch API 重新读取确认 main HEAD 正是该 merge commit，且 main 中 InvoiceDialog 与 dedicated Mahayana edge 仍存在。
+- Acceptance: GBF-201..207 RELEASED；M2 RELEASED。
+- Blocker/Risk: M2 无 blocker；后续阶段不得重新引入 generic Host IPC 或 native prompt product flows。
+- Next: M3 PR #2007 同步最新 main，重新跑 single-runtime/Mahayana gates，满足后 merge/post-main closure。

--- a/projects/grok-bot-fabushi-integration/management/07-变更日志.md
+++ b/projects/grok-bot-fabushi-integration/management/07-变更日志.md
@@ -13,3 +13,4 @@
 - 2026-08-22 17:01+08：M1 经 PR #2003 / CI #6172 / portfolio #30 / merge `d8b502726...` / post-merge main verify 正式 RELEASED；进入 M2。
 - 2026-08-22 17:09+08：M2 移除通用 `fabushi:host` IPC，建立 versioned 专用 Mahayana edge，强化 Host generation/restart/health，并新增 edge/native/security/ASR fault tests 与 CI gate。
 - 2026-08-22 17:51+08：依据 Electron failure artifact 修复 Messenger 内原生 `prompt()` 编辑和空 Bot 群组提交，并增强登录 E2E helper；GBF-207 等待复验。
+- 2026-08-22 20:12+08：继续修复 message pin strict selector 与账单 native prompt，账单迁移到真实 InvoiceDialog；Electron #521 的 real Host + macOS/Windows/Linux package/journey 全绿，PR #2009 合入 `main` 为 `dcdc329c...`，post-main verify 后 M2 正式 RELEASED，进入 M3。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-201-electron-main-audit.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-201-electron-main-audit.md
@@ -1,44 +1,20 @@
 # GBF-201 — 审计并收敛 Electron main.cjs 生命周期/IPC 行为
 
 - Project ID: FAB-P0004
-- Project Key: GBF
 - Task ID: GBF-201
-- Objective: 审计并收敛 Electron main.cjs 生命周期/IPC 行为。
-- Source requirement IDs/references: GBR-002, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
 - Stage: M2
-- Status: TESTED (GitHub CI/merge pending)
-- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
-- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Status: RELEASED
+- Objective: 审计并收敛 Electron main.cjs 生命周期/IPC 行为，保留 main 后续修复并移除历史旁路。
 - Dependencies: GBF-104.
-- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
-- PR: pending
-- Started: 2026-08-22 17:03+08
-- Updated: 2026-08-22 17:09+08
-- Completed: —
+- Implementation PRs: #2005, #2009
+- Completed: 2026-08-22 20:12+08
 
-## Acceptance criteria
-
-- [x] main/source lifecycle+IPC diff；保留 main 后续修复；每个独有行为有 retain/rewrite/deprecate 决策。
-- [x] 相关拒绝/错误/恢复路径有客观验证。
-- [ ] GitHub Actions required checks 通过。
-- [ ] merge queue 合入 main 并完成 post-merge verification。
-
-## Verification
-
-file/behavior diff + CI contract.
-
-## Implementation / local verification
-
-本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+## Acceptance
+- [x] main/source lifecycle + IPC 差异完成 capability-level 决策。
+- [x] 生命周期、拒绝、错误、恢复路径有自动化证据。
+- [x] authoritative CI / Electron Host smoke / packaged macOS-Windows-Linux journeys 全绿。
+- [x] merge queue 合入 `main`，merge `dcdc329cb76e609c469eaabbcccb707c0005f56d`。
+- [x] post-merge `main` 重新读取验证 canonical implementation。
 
 ## Evidence
-
-`evidence/GBF-201/`（实现后补 commit/PR/CI/test/main verification）。
-
-## Risks
-
-R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
-
-## Next action
-
-执行当前 main/source audit，修复真实缺口并补最小自动化测试。
+`evidence/GBF-201/`; PR #2005/#2009; Electron run #521; CI #6212; canonical main `dcdc329c...`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-202-preload-ipc-contract.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-202-preload-ipc-contract.md
@@ -1,44 +1,20 @@
-# GBF-202 — 收敛 preload/IPC 为最小版本化 contract
+# GBF-202 — 收敛 preload/IPC contract
 
 - Project ID: FAB-P0004
-- Project Key: GBF
 - Task ID: GBF-202
-- Objective: 收敛 preload/IPC 为最小版本化 contract。
-- Source requirement IDs/references: GBR-002, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
 - Stage: M2
-- Status: TESTED (GitHub CI/merge pending)
-- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
-- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Status: RELEASED
+- Objective: renderer 仅通过版本化专用 preload/native edge 调用 Host 与系统能力，删除通用 `fabushi:host` 旁路。
 - Dependencies: GBF-201.
-- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
-- PR: pending
-- Started: 2026-08-22 17:03+08
-- Updated: 2026-08-22 17:09+08
-- Completed: —
+- Implementation PRs: #2005, #2009
+- Completed: 2026-08-22 20:12+08
 
-## Acceptance criteria
-
-- [x] renderer 无通用 IPC；所有公开调用来自 allowlisted edge/compat API；deny path 可测试。
-- [x] 相关拒绝/错误/恢复路径有客观验证。
-- [ ] GitHub Actions required checks 通过。
-- [ ] merge queue 合入 main 并完成 post-merge verification。
-
-## Verification
-
-edge contract unit/security tests + bridge CI.
-
-## Implementation / local verification
-
-本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+## Acceptance
+- [x] generic `fabushi:host` IPC 已删除。
+- [x] `window.mahayana` / edge contract versioned 且 sender allow/deny fail-closed。
+- [x] edge contract/failure/security tests 进入 CI。
+- [x] Electron Host smoke 与三平台 packaged journeys 全绿。
+- [x] main merge `dcdc329c...` 后重新读取验证专用 Mahayana edge 仍为 canonical path。
 
 ## Evidence
-
-`evidence/GBF-202/`（实现后补 commit/PR/CI/test/main verification）。
-
-## Risks
-
-R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
-
-## Next action
-
-执行当前 main/source audit，修复真实缺口并补最小自动化测试。
+`evidence/GBF-202/`; PR #2005/#2009; Electron #521; main `dcdc329cb76e609c469eaabbcccb707c0005f56d`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-203-host-process-lifecycle.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-203-host-process-lifecycle.md
@@ -1,44 +1,20 @@
-# GBF-203 — 收敛 Mahayana host 子进程生命周期/health/restart
+# GBF-203 — 收敛 host-process lifecycle
 
 - Project ID: FAB-P0004
-- Project Key: GBF
 - Task ID: GBF-203
-- Objective: 收敛 Mahayana host 子进程生命周期/health/restart。
-- Source requirement IDs/references: GBR-002, GBR-003, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
 - Stage: M2
-- Status: TESTED (GitHub CI/merge pending)
-- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
-- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Status: RELEASED
+- Objective: 将 Rust Host 进程生命周期、health/restart、pending request 与 generation 隔离收敛为单一实现。
 - Dependencies: GBF-201.
-- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
-- PR: pending
-- Started: 2026-08-22 17:03+08
-- Updated: 2026-08-22 17:09+08
-- Completed: —
+- Implementation PRs: #2005, #2009
+- Completed: 2026-08-22 20:12+08
 
-## Acceptance criteria
-
-- [x] 单一 host 生命周期；并发 start 安全；退出/close 不污染新 generation；pending 有确定失败；health 可观测。
-- [x] 相关拒绝/错误/恢复路径有客观验证。
-- [ ] GitHub Actions required checks 通过。
-- [ ] merge queue 合入 main 并完成 post-merge verification。
-
-## Verification
-
-host-process unit/fault tests + Electron CI.
-
-## Implementation / local verification
-
-本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+## Acceptance
+- [x] spawn generation 防止旧进程迟到 exit/error/stdout 污染新 generation。
+- [x] `health()` / explicit `restart()` / closed state / generation-scoped pending cleanup 已实现。
+- [x] host fault/restart tests 进入 CI 并通过。
+- [x] Electron Host smoke 与 packaged journeys 使用真实 Rust Host 通过。
+- [x] merge queue + post-main verification 完成。
 
 ## Evidence
-
-`evidence/GBF-203/`（实现后补 commit/PR/CI/test/main verification）。
-
-## Risks
-
-R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
-
-## Next action
-
-执行当前 main/source audit，修复真实缺口并补最小自动化测试。
+`evidence/GBF-203/`; PR #2005/#2009; Electron #521; main `dcdc329c...`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-204-native-capability-handlers.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-204-native-capability-handlers.md
@@ -1,44 +1,20 @@
-# GBF-204 — 收敛 native capability handlers 权限与输入验证
+# GBF-204 — 收敛 native capability handlers
 
 - Project ID: FAB-P0004
-- Project Key: GBF
 - Task ID: GBF-204
-- Objective: 收敛 native capability handlers 权限与输入验证。
-- Source requirement IDs/references: GBR-002, GBR-004, GBR-005; `source/grok-bot融合优化.txt`; M1 evidence.
 - Stage: M2
-- Status: TESTED (GitHub CI/merge pending)
-- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
-- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Status: RELEASED
+- Objective: 将桌面高风险系统能力收敛到 allowlisted native handlers，并对拒绝、路径、秘密、网络与诊断行为 fail-closed。
 - Dependencies: GBF-202, GBF-203.
-- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
-- PR: pending
-- Started: 2026-08-22 17:03+08
-- Updated: 2026-08-22 17:09+08
-- Completed: —
+- Implementation PRs: #2005, #2009
+- Completed: 2026-08-22 20:12+08
 
-## Acceptance criteria
-
-- [x] 高风险 handler 有显式安全语义；无 renderer 绕过；静态语义门禁与 deny tests 通过。
-- [x] 相关拒绝/错误/恢复路径有客观验证。
-- [ ] GitHub Actions required checks 通过。
-- [ ] merge queue 合入 main 并完成 post-merge verification。
-
-## Verification
-
-native semantic/parity gates + security tests.
-
-## Implementation / local verification
-
-本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+## Acceptance
+- [x] native capability semantic gate 156/156；event source 28/28。
+- [x] permission ceiling、OS encryption unavailable、Secret Vault plaintext、path escape、non-HTTPS download、diagnostic redaction tests 通过。
+- [x] handler error path 只通过版本化 edge 返回稳定 failure。
+- [x] authoritative CI/Electron tests 通过并合入 main。
+- [x] post-main verification 完成。
 
 ## Evidence
-
-`evidence/GBF-204/`（实现后补 commit/PR/CI/test/main verification）。
-
-## Risks
-
-R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
-
-## Next action
-
-执行当前 main/source audit，修复真实缺口并补最小自动化测试。
+`evidence/GBF-204/`; PR #2005/#2009; CI #6212; main `dcdc329c...`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-205-native-edge-contract.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-205-native-edge-contract.md
@@ -1,44 +1,20 @@
-# GBF-205 — 收敛 native/edge IPC schema 与错误合同
+# GBF-205 — 收敛 native/edge contract
 
 - Project ID: FAB-P0004
-- Project Key: GBF
 - Task ID: GBF-205
-- Objective: 收敛 native/edge IPC schema 与错误合同。
-- Source requirement IDs/references: GBR-002, GBR-004; `source/grok-bot融合优化.txt`; M1 evidence.
 - Stage: M2
-- Status: TESTED (GitHub CI/merge pending)
-- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
-- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Status: RELEASED
+- Objective: 统一 native/Mahayana edge method、event、schema、error 与 sender trust contract。
 - Dependencies: GBF-202.
-- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
-- PR: pending
-- Started: 2026-08-22 17:03+08
-- Updated: 2026-08-22 17:09+08
-- Completed: —
+- Implementation PRs: #2005, #2009
+- Completed: 2026-08-22 20:12+08
 
-## Acceptance criteria
-
-- [x] edge method/event catalog 唯一；unknown event/handler/trust failure 可确定；dispose 无残留 handler。
-- [x] 相关拒绝/错误/恢复路径有客观验证。
-- [ ] GitHub Actions required checks 通过。
-- [ ] merge queue 合入 main 并完成 post-merge verification。
-
-## Verification
-
-edge-ipc unit tests + parity gate.
-
-## Implementation / local verification
-
-本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+## Acceptance
+- [x] edge contract version=1，method/event allowlist 唯一。
+- [x] untrusted sender、missing handler、handler failure、subscription/dispose 测试通过。
+- [x] renderer 不再拥有通用 Host IPC。
+- [x] CI、Electron Host smoke、三平台 packaged journeys 全绿。
+- [x] merge queue + post-main verification 完成。
 
 ## Evidence
-
-`evidence/GBF-205/`（实现后补 commit/PR/CI/test/main verification）。
-
-## Risks
-
-R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
-
-## Next action
-
-执行当前 main/source audit，修复真实缺口并补最小自动化测试。
+`evidence/GBF-205/`; PR #2005/#2009; Electron #521; main `dcdc329c...`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-206-offline-asr.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-206-offline-asr.md
@@ -1,44 +1,20 @@
-# GBF-206 — 验证并保留 Offline ASR 的本机安全实现
+# GBF-206 — 评估并保留/迁移 Offline ASR
 
 - Project ID: FAB-P0004
-- Project Key: GBF
 - Task ID: GBF-206
-- Objective: 验证并保留 Offline ASR 的本机安全实现。
-- Source requirement IDs/references: GBR-002, GBR-007; `source/grok-bot融合优化.txt`; M1 evidence.
 - Stage: M2
-- Status: TESTED (GitHub CI/merge pending)
-- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
-- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Status: RELEASED
+- Objective: 确认 Offline ASR 的产品归属、受控下载/校验/执行边界，并纳入当前 Electron 架构。
 - Dependencies: GBF-104.
-- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
-- PR: pending
-- Started: 2026-08-22 17:03+08
-- Updated: 2026-08-22 17:09+08
-- Completed: —
+- Implementation PRs: #2005, #2009
+- Completed: 2026-08-22 20:12+08
 
-## Acceptance criteria
-
-- [x] 本机执行不经 shell；模型仅 HTTPS 且 SHA-256 验证；状态/下载/转写测试通过。
-- [x] 相关拒绝/错误/恢复路径有客观验证。
-- [ ] GitHub Actions required checks 通过。
-- [ ] merge queue 合入 main 并完成 post-merge verification。
-
-## Verification
-
-offline-asr node tests + package/CI gate.
-
-## Implementation / local verification
-
-本轮实现与轻量验证已通过；权威 CI/merge 仍待 GitHub。
+## Acceptance
+- [x] Offline ASR 为 Fabushi 当前架构能力，不依赖 Grok runtime。
+- [x] 模型 acquisition 仅 HTTPS 且支持 SHA-256 校验。
+- [x] ASR process 是桌面唯一允许的隔离 provider 进程面之一。
+- [x] offline-asr contract/failure tests 纳入 CI 并通过。
+- [x] merge queue + post-main verification 完成。
 
 ## Evidence
-
-`evidence/GBF-206/`（实现后补 commit/PR/CI/test/main verification）。
-
-## Risks
-
-R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
-
-## Next action
-
-执行当前 main/source audit，修复真实缺口并补最小自动化测试。
+`evidence/GBF-206/`; PR #2005/#2009; CI #6212; main `dcdc329c...`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-207-electron-e2e.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-207-electron-e2e.md
@@ -1,40 +1,23 @@
-# GBF-207 — 验证当前 Electron 架构关键 Grok/Fabushi 用户旅程
+# GBF-207 — Electron E2E closure
 
 - Project ID: FAB-P0004
-- Project Key: GBF
 - Task ID: GBF-207
-- Objective: 验证当前 Electron 架构关键 Grok/Fabushi 用户旅程。
-- Source requirement IDs/references: GBR-002, GBR-007; `source/grok-bot融合优化.txt`; M1 evidence.
 - Stage: M2
-- Status: IN_PROGRESS (E2E defects fixed; rerun pending)
-- In scope: 当前 `main` 与 pinned Grok source 的能力级差异、正式 Fabushi/Mahayana 归属、实现/测试/CI/证据。
-- Out of scope: wholesale merge 历史 Grok 分支；把 vendor 0.20 二进制/构建产物重新带回生产。
+- Status: RELEASED
+- Objective: 用真实 Electron sandbox + Rust Host + 三平台 packaged application user journeys 证明当前桌面架构可运行。
 - Dependencies: GBF-201..206.
-- Implementation branch: `gbf/m2-electron-host-convergence-20260822`
-- PR: pending
-- Started: 2026-08-22 17:03+08
-- Updated: 2026-08-22 17:51+08
-- Completed: —
+- Implementation PRs: #2005, #2009
+- Completed: 2026-08-22 20:12+08
 
-## Acceptance criteria
-
-- [ ] Playwright Electron smoke/surfaces 可运行；桥/Host/ASR/renderer 受 CI 覆盖。
-- [ ] 相关拒绝/错误/恢复路径有客观验证。
-- [ ] GitHub Actions required checks 通过。
-- [ ] merge queue 合入 main 并完成 post-merge verification。
-
-## Verification
-
-GitHub Actions Electron E2E + required CI.
+## Acceptance
+- [x] Messenger edit 使用应用内受控对话框，不依赖原生 `prompt()`。
+- [x] AI 群组创建必须选择 Bot；Host 零 Agent 拒绝路径保持 fail-closed。
+- [x] message pin selector 与 invoice flow 均按真实产品 UI 修复。
+- [x] Electron Host simulated user smoke SUCCESS。
+- [x] macOS / Windows / Linux package + packaged user journey 全部 SUCCESS。
+- [x] `Electron desktop result` SUCCESS；CI #6212 / Messaging #57 / Self-hosted Messaging #121 / Portfolio #65 SUCCESS。
+- [x] PR #2009 merge queue 合入 main，merge `dcdc329cb76e609c469eaabbcccb707c0005f56d`。
+- [x] post-main canonical verification 完成。
 
 ## Evidence
-
-`evidence/GBF-207/`（实现后补 commit/PR/CI/test/main verification）。
-
-## Risks
-
-R1/R3/R4/R9/R10；涉及本机能力时同时受 R5/R6。
-
-## Next action
-
-执行当前 main/source audit，修复真实缺口并补最小自动化测试。
+`evidence/GBF-207/`; Electron run #521; PR #2009; canonical main `dcdc329c...`.


### PR DESCRIPTION
## FAB-P0004 / GBF — M2 release closure

This is the governance-only closure after the implementation already landed in PR #2005/#2009.

### Authoritative acceptance
- CI #6212 success
- Electron run #521: real Rust Host smoke success
- macOS package + packaged user journey success
- Windows package + packaged user journey success
- Linux package + packaged user journey success
- Electron desktop result success
- Messaging #57, Self-hosted Messaging #121, Portfolio #65 success
- PR #2009 merged through merge queue as `dcdc329cb76e609c469eaabbcccb707c0005f56d`
- post-merge GitHub branch re-read confirms `main` HEAD is that merge and canonical InvoiceDialog/dedicated Mahayana edge remain present

### Project records
- GBF-201..207 -> RELEASED
- M2 -> RELEASED
- project stage -> M3 runtime convergence
- WBS/status/changelog synchronized

No implementation is added in this PR.