### PR TITLE
docs(tfi): close M2 and advance FAB-P0001 to M3

### DIFF
--- a/projects/telegram-fabushi-integration/PROJECT.yaml
+++ b/projects/telegram-fabushi-integration/PROJECT.yaml
@@ -4,10 +4,10 @@ legacy_project_ids:
   - FABUSHI-TELEGRAM-FUSION
 name: Fabushi Telegram 全量融合
 slug: telegram-fabushi-integration
-version: v1.2
+version: v1.3
 baseline_date: 2026-08-22
 status: IMPLEMENTATION_ACTIVE
-current_stage: M2
+current_stage: M3
 source_of_truth: source/完整telegram融合进fabushi.txt
 authoritative_path: projects/telegram-fabushi-integration
 architecture:
@@ -29,14 +29,15 @@ status_model:
   - E2E_VERIFIED
   - RELEASED
 active_work:
-  - task: M2-NET-001
-    pr: 2001
-    state: IN_PROGRESS
-  - task: M2-SYNC-001
-    pr: 2002
+  - task: M3-DESKTOP-001
+    branch: feat/telegram-m3-desktop-ux
     state: IN_PROGRESS
   - task: TFI-GOV-002
     state: IN_PROGRESS
+completed_stage_evidence:
+  M0: PR-1987
+  M1: M1-ACCEPT-001
+  M2: M2-ACCEPT-001
 governance:
   repository: bhrumom/fabushi
   authoritative_branch: main

--- a/projects/telegram-fabushi-integration/evidence/M2-ACCEPT-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M2-ACCEPT-001/README.md
@@ -1,0 +1,41 @@
+# M2-ACCEPT-001 evidence index
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Stage**: `M2`
+- **Status**: `TESTED`
+
+## Network layer
+
+PR #2001 landed `MessagingWebSocketGateway` and real localhost WebSocket contracts on canonical main as `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
+
+Verified artifacts:
+- `native/mahayana-messaging/src/gateway.rs`
+- `native/mahayana-messaging/src/server.rs`
+- `native/mahayana-messaging/tests/websocket_gateway_contract.rs`
+
+## Durable sync layer
+
+PR #2002 landed schema-v2 durable event journaling, idempotent send/ACK, cursor delta replay, restart recovery and Sent/Delivered/Read on canonical main as `d4611f9433eb4d6cbfa934c574cec1da96210edb`.
+
+Verified artifacts:
+- `native/mahayana-messaging/src/store.rs`
+- `native/mahayana-messaging/src/service.rs`
+- `native/mahayana-messaging/tests/delta_sync_contract.rs`
+
+## Current-head gates for final M2 landing
+
+- Messaging Product Gate `32575120937` — SUCCESS.
+- Mahayana fast checks `32575120857` — SUCCESS.
+- Fabushi self-hosted messaging `32575120877` — SUCCESS.
+- Repository CI `32575120874` — SUCCESS.
+- Project portfolio governance `32575120961` — SUCCESS.
+- Explicit automerge `32575120853` — SUCCESS.
+
+## Compatibility evidence
+
+The clean final landing intentionally preserved the current canonical `Message` schema. Historical code's obsolete `Message.client_message_id` check was removed because deterministic `stable_message_id(actor_id, client_message_id)` already binds replay identity; all current Rust tests and Clippy passed after the reconciliation.
+
+## Canonical-main result
+
+`main` head `d4611f9433eb4d6cbfa934c574cec1da96210edb` was re-read and contains the corrected deterministic-idempotency code and all M2 runtime/test artifacts. M2.T01-T09 therefore satisfy the stage completion gate at `TESTED`.

--- a/projects/telegram-fabushi-integration/evidence/M2-NET-001-current-main/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M2-NET-001-current-main/README.md
@@ -1,39 +1,28 @@
-# M2-NET-001 clean-stack evidence
+# M2-NET-001 canonical-main evidence
 
 - **Project ID**: `FAB-P0001`
 - **Project Key**: `TFI`
 - **Task**: `M2-NET-001`
-- **Status**: `IN_PROGRESS / FINAL-HEAD CI PENDING`
+- **Status**: `TESTED / LANDED`
 - **PR**: #2001
-- **Branch**: `feat/telegram-m2-websocket-main-sync`
+- **Merge**: `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`
 
-## Runtime evidence
+## Verified runtime
 
-- `native/mahayana-messaging/src/gateway.rs`: self-hosted WebSocket gateway, frame bounds, Ping/Pong heartbeat, timeout, Protocol v2 UTF-8 JSON application frames.
-- `native/mahayana-messaging/src/server.rs`: TCP/WebSocket share one `MessagingService<SqliteStateStore>` loader and one authenticated executor.
-- `native/mahayana-messaging/tests/websocket_gateway_contract.rs`: real localhost handshake/protocol execution, identity mismatch rejection, heartbeat, frame-size and binary rejection.
-- `native/mahayana-messaging/Cargo.toml`: `tungstenite 0.30`.
-- `native/mahayana-messaging/src/lib.rs`: gateway exported by the canonical messaging crate.
+- `native/mahayana-messaging/src/gateway.rs`
+- `native/mahayana-messaging/src/server.rs`
+- `native/mahayana-messaging/tests/websocket_gateway_contract.rs`
+- shared `MessagingService<SqliteStateStore>` and shared authenticated executor
+- real localhost handshake/auth/heartbeat/frame contracts
 
-## Clean rebase evidence
+## Final-head acceptance
 
-- Canonical rebase base: `c9bfa320ac4e3e27cc2dee3e80bbd558c08f4cb5` (`main` at rebase time).
-- Clean M2-NET runtime/project replay commit: `c1ddb97a16df5eccab7310ba1fb3fe17b161a003`.
-- Compare immediately after rebuild: branch ahead by exactly one commit and behind by zero; diff contained only the intended M2-NET runtime/test/task/evidence/WBS files.
-- Additional commits on the same branch only reconcile current FAB-P0001 project acceptance/governance records and therefore require a fresh final-head CI round before closure.
+Final clean head `1030a489a5b4ed12f93464c95325e5d6d2ca7535` passed Messaging Product Gate, Mahayana fast checks, self-hosted messaging, repository CI, project portfolio governance and Explicit automerge before protected merge.
 
-## Historical verified evidence
+## Canonical-main verification
 
-Equivalent implementation on historical PR #1993:
+After merge, `main` was re-read and confirmed the WebSocket gateway and contract tests are present. Historical #1993 was closed as superseded landing provenance.
 
-| Gate | Run | Result |
-|---|---:|---|
-| Messaging Product Gate | `32560118577` | SUCCESS |
-| Mahayana fast checks | `32560118567` | SUCCESS |
-| Explicit automerge | `32560118574` | SUCCESS |
+## Result
 
-Historical evidence is provenance only; it does not satisfy the final clean-head gate.
-
-## Completion rule
-
-Do not close M2-NET-001 until the final #2001 head passes required GitHub Actions, merges to `main`, and canonical `main` is re-read to verify the gateway/shared executor/test files are present without project-state regression.
+M2.T01-T04 satisfy their stage acceptance gate at `TESTED`. See `../M2-ACCEPT-001/README.md` for full M2 closure.

--- a/projects/telegram-fabushi-integration/evidence/M2-SYNC-001-current-main/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M2-SYNC-001-current-main/README.md
@@ -1,44 +1,37 @@
-# M2-SYNC-001 clean-stack evidence
+# M2-SYNC-001 canonical-main evidence
 
 - **Project ID**: `FAB-P0001`
 - **Project Key**: `TFI`
 - **Task**: `M2-SYNC-001`
-- **Status**: `IN_PROGRESS / FINAL-HEAD CI PENDING`
+- **Status**: `TESTED / LANDED`
 - **PR**: #2002
-- **Branch**: `feat/telegram-m2-delta-main-sync`
+- **Merge**: `d4611f9433eb4d6cbfa934c574cec1da96210edb`
 
-## Runtime provenance
+## Runtime evidence
 
-Historical #1994 supplied the original durable-sync implementation, but stale historical project-document snapshots are not imported. The final current-main landing keeps the canonical current `Message` schema and reuses the intended durable store/service/test behavior.
+- `native/mahayana-messaging/src/store.rs`: SQLite schema v2 journal, transactional snapshot+journal, cursor-group pagination/pruning.
+- `native/mahayana-messaging/src/service.rs`: stable-message idempotency, ACK/Delivered/Read, authorized delta replay/fallback.
+- `native/mahayana-messaging/tests/delta_sync_contract.rs`: restart, second-device, outsider isolation, idempotency, delivery/read and migration-floor contracts.
 
 ## Current-main compatibility reconciliation
 
-Final current-head CI on the historical replay exposed two real compatibility deltas:
+Current stable rustfmt required reformatting. Historical code also referenced removed `Message.client_message_id`; the final implementation retained current `Message` schema and relies on deterministic `stable_message_id(actor_id, client_message_id)` plus legacy local-key lookup. All payload-conflict checks remain.
 
-1. Rust stable/rustfmt advanced to 1.98; the three M2-SYNC Rust files were reformatted with current stable rustfmt.
-2. Current canonical `Message` no longer has a `client_message_id` field. Idempotent replay already derives a deterministic `stable_message_id(actor_id, client_message_id)` (with legacy local-key lookup), so the obsolete field comparison was removed without extending or reverting `Message` schema. Sender/content/reply/thread/schedule/silent/protected-content conflict checks remain.
+## Final-head GitHub Actions
 
-## Final clean landing
+| Gate | Run | Result |
+|---|---:|---|
+| Messaging Product Gate | `32575120937` | SUCCESS |
+| Mahayana fast checks | `32575120857` | SUCCESS |
+| Fabushi self-hosted messaging | `32575120877` | SUCCESS |
+| Repository CI | `32575120874` | SUCCESS |
+| Project portfolio governance | `32575120961` | SUCCESS |
+| Explicit automerge | `32575120853` | SUCCESS |
 
-- M2-NET prerequisite: PR #2001 merged through the protected queue as `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
-- Final base: canonical `main` at `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
-- Clean runtime commit: `5602f96bcb806b2c09981241ab88d99c15f07fc9`.
-- Compare immediately after rebuild: ahead by 1, behind by 0, exactly six changed files.
-- Final runtime blobs include corrected `service.rs` blob `d05ec7160997ff449bbfcf5aa4151ce7938d8a03`, formatted `store.rs` blob `2ffb60eab5986e92e6a296a9c8c90e05ba37fb8a`, and formatted `delta_sync_contract.rs` blob `3e31d0a0e3f566b0b7606d12ece863ed535048b9`.
-- Temporary workflow experiments are absent from the final current-main commit history.
+## Canonical-main verification
 
-## Behavior covered
+After protected landing, `main` head `d4611f9433eb4d6cbfa934c574cec1da96210edb` was re-read. It contains corrected stable-message idempotency and all durable-sync artifacts.
 
-- SQLite schema v2 event journal and migration from v1.
-- Transactional snapshot + journal persistence.
-- Restart/reconnect recovery and journal-floor fallback.
-- Idempotent send/ACK and conflicting client-message-ID rejection.
-- Durable server cursor/checkpoint semantics.
-- Audience-scoped delta replay and outsider isolation.
-- Second-device synchronization.
-- `Sent -> Delivered -> Read` transitions.
-- Cursor-group-aware journal pagination and pruning.
+## Result
 
-## Completion rule
-
-M2-SYNC-001 is not complete merely because historical code was replayed. The final #2002 head must pass fresh current GitHub Actions on canonical `main`, merge through protected-main governance, and be re-read from canonical `main` before M2.T05-T09 or the M2 stage can be closed.
+M2.T05-T09 satisfy their stage acceptance gate at `TESTED`. See `../M2-ACCEPT-001/README.md` for full M2 closure.

--- a/projects/telegram-fabushi-integration/management/02-里程碑.md
+++ b/projects/telegram-fabushi-integration/management/02-里程碑.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-02
-- **版本**：v1.1
+- **版本**：v1.2
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
@@ -13,27 +13,28 @@
 
 | ID | 名称 | 原子任务数 | 完成条件 | 状态 |
 |---|---|---:|---|---|
-| M0 | 现状清点与边界固定 | 7 | 有唯一通信架构文档；有唯一模块 owner/目录；新功能不得再落到旧通信栈 | TESTED |
-| M1 | Rust Core 骨架 | 7 | Rust 单测通过；可创建会话/消息；Electron 能通过 bridge 使用同一 Rust Core；production durable store 落 main | TESTED |
-| M2 | 自建实时网络 + 1:1 文本消息 | 9 | WebSocket/auth/heartbeat + 断线恢复 + 幂等发送/ACK + durable cursor/delta sync + delivery/read 通过 current-head CI 并落 main | IN_PROGRESS |
-| M3 | 桌面聊天完整交互 | 9 | 桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程 | NOT_STARTED |
-| M4 | 媒体与文件 | 8 | 大文件断点续传；失败可重试；消息和媒体权限一致 | NOT_STARTED |
-| M5 | 联系人 + 群组 | 8 | 联系人和群组完整可用；权限测试覆盖 owner/admin/member/restricted | NOT_STARTED |
-| M6 | 频道 + Topic + 管理能力 | 6 | 频道广播稳定；大成员列表分页；Topic 独立状态正确 | NOT_STARTED |
-| M7 | Bot/Agent 统一联系人体系 | 7 | 真人和 Agent 使用同一消息内核；Agent-to-Agent 可通信；UI 不再使用独立第二套聊天实现 | NOT_STARTED |
-| M8 | Mini Apps | 7 | 聊天按钮可打开 Mini App；Mini App 可安全读取授权上下文；未授权 API 无法调用；权限可撤销 | NOT_STARTED |
-| M9 | 支付 | 7 | Mini App/Bot/Agent 可以创建支付意图；沙盒支付端到端完成；重复 webhook 不重复记账 | NOT_STARTED |
-| M10 | 语音/视频通话 | 6 | 桌面/移动跨端 1:1 通话；网络切换后具备合理恢复能力 | NOT_STARTED |
-| M11 | 移动端共享 Rust Core | 5 | iOS/Android 与 Electron 互发；共享协议/状态机；不出现三套消息业务实现 | NOT_STARTED |
-| M12 | 高级 IM 能力 | 8 | 功能矩阵达到既定 Telegram Desktop 对标范围 | NOT_STARTED |
-| M13 | 安全强化 + E2EE | 6 | E2EE 会话服务端无法读取正文；多设备密钥生命周期测试通过 | NOT_STARTED |
-| M14 | 全量替换旧通信栈 | 5 | 主路径仅剩 Fabushi Messaging Core；无旧栈隐式 fallback；main 分支通过完整测试 | NOT_STARTED |
+| M0 | 现状清点与边界固定 | 7 | 唯一通信架构、owner/目录、旧栈冻结 | TESTED |
+| M1 | Rust Core 骨架 | 7 | Rust Core + production SQLite + desktop/Host bridge current-head 验收 | TESTED |
+| M2 | 自建实时网络 + 1:1 文本消息 | 9 | WebSocket/auth/heartbeat + reconnect/idempotency/delta/delivery-read 落 main | TESTED |
+| M3 | 桌面聊天完整交互 | 9 | 桌面日常 IM 完整使用；Playwright 覆盖核心流程 | IN_PROGRESS |
+| M4 | 媒体与文件 | 8 | 大文件断点续传；失败可重试；媒体权限一致 | NOT_STARTED |
+| M5 | 联系人 + 群组 | 8 | 联系人与群组完整可用；角色权限矩阵通过 | NOT_STARTED |
+| M6 | 频道 + Topic + 管理能力 | 6 | 广播稳定；成员分页；Topic 独立状态正确 | NOT_STARTED |
+| M7 | Bot/Agent 统一联系人体系 | 7 | 真人/Agent 同一内核；Agent-to-Agent；无第二套聊天 | NOT_STARTED |
+| M8 | Mini Apps | 7 | 聊天打开 Mini App；授权上下文安全；权限可撤销 | NOT_STARTED |
+| M9 | 支付 | 7 | 支付意图/沙盒端到端/webhook 幂等 | NOT_STARTED |
+| M10 | 语音/视频通话 | 6 | 桌面/移动跨端 1:1 通话与网络恢复 | NOT_STARTED |
+| M11 | 移动端共享 Rust Core | 5 | iOS/Android/Electron 互发且共享协议/状态机 | NOT_STARTED |
+| M12 | 高级 IM 能力 | 8 | 达到既定 Telegram Desktop 对标范围 | NOT_STARTED |
+| M13 | 安全强化 + E2EE | 6 | 服务端不可读正文；多设备密钥生命周期通过 | NOT_STARTED |
+| M14 | 全量替换旧通信栈 | 5 | 仅剩 Fabushi Messaging Core；无旧 fallback；完整测试通过 | NOT_STARTED |
 
 ## 已关闭里程碑证据
 
-- M0: PR #1987, merge `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`.
-- M1: `management/tasks/M1-ACCEPT-001-stage-closure.md` and `evidence/M1-ACCEPT-001/README.md`; production cutover PR #1998 merge `6ad86ccc809a6f00130888087f22cbb201e853fd`.
+- M0: PR #1987 / `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`.
+- M1: `M1-ACCEPT-001`; PR #1998 / `6ad86ccc809a6f00130888087f22cbb201e853fd`.
+- M2: `M2-ACCEPT-001`; PR #2001 / `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`; PR #2002 / `d4611f9433eb4d6cbfa934c574cec1da96210edb`.
 
 ## 当前门禁
 
-M2 只有在 M2-NET-001 与 M2-SYNC-001 均通过 current-head CI、保护合并和 canonical-main verification 后才可提升为 `TESTED`。
+M3 由 `M3-DESKTOP-001` 推进。只有 desktop typecheck/Playwright、相关 messaging product gates、protected merge 和 canonical-main verification 全部完成后才提升为 `TESTED`/`E2E_VERIFIED`。

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -4,45 +4,46 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-03
-- **版本**：v1.2
+- **版本**：v1.3
 - **状态**：LIVE
 - **基线日期**：2026-08-22
-- **源计划**：`../source/完整telegram融合进fabushi.txt`
 
 ## 规则
 
-每个功能域必须从“需求 → 模块 → 原子任务 → 测试 → 证据”可追踪。`IMPLEMENTED` 只表示对应产品实现存在；没有 current-head CI/E2E/安全证据时不得提升为 `TESTED` 或 `E2E_VERIFIED`。阶段验收不得把后续阶段的跨端、规模、安全或发布要求提前算作完成。
+每个功能域必须从“需求 → 模块 → 原子任务 → 测试 → 证据”可追踪。`IMPLEMENTED` 不等于验收完成；只有 current-head CI/E2E/安全证据 + protected merge + canonical-main verification 才能晋级。
 
-## 2026-08-22 live acceptance state
+## Live acceptance state
 
-| 功能域 | 当前 canonical 模块 | 主要阶段 | 必须验证 | 当前状态 | 现有证据 / 缺口 |
-|---|---|---|---|---|---|
-| 统一协议/模型 | `native/mahayana-messaging/protocol` + actor/conversation/message | M1-M2 | 编解码、版本兼容、状态机 | TESTED | M1-ACCEPT-001；Messaging Product Gate `32563424543`；M2 继续验证网络/delta 语义 |
-| 本地持久化 | `native/mahayana-messaging/store` | M1-M2 | SQLite schema、恢复、迁移、journal | TESTED | M1 SQLite foundation #1988 + production cutover #1998 已落 main；schema v2 journal 属 M2-SYNC-001 current acceptance |
-| 自建 WebSocket/Auth/Heartbeat | gateway/server/access | M2 | real socket、身份隔离、heartbeat、frame limits | IN_PROGRESS | clean PR #2001；historical #1993 已验证；current-head CI/merge/main verification 进行中 |
-| 私聊实时语义 | messaging service/engine/store | M2-M3 | 发送、ACK、重试、断线恢复、已读、delta sync | IN_PROGRESS | M2-SYNC-001 clean PR #2002；historical #1994 provenance；待 lower-stack landing/current-head gate |
-| 媒体 | media / blob_store + desktop attachment bridge | M4 | 上传下载、断点续传、权限、缓存 | IMPLEMENTED | resumable BlobStore + desktop upload 已存在；需 M4 大文件/失败恢复验收 |
-| 联系人/群组 | actor / conversation / community + social projection | M5 | owner/admin/member/restricted 权限矩阵 | IMPLEMENTED | community + real social projection 已存在；需 M5 权限矩阵 CI/E2E |
-| 频道/Topic | conversation / community | M6 | 广播、分页、Topic 独立状态 | IMPLEMENTED | channels/forums/topics/moderation 已存在；需 M6 规模与分页验证 |
-| Bot/Agent | bot + Feature Host / Actor model | M7 | 统一 Actor、Agent-to-Agent、审计 | IMPLEMENTED | Bot/Assistant 共用 Actor/Conversation/Message；需 M7 统一联系人/Agent-to-Agent acceptance |
-| Mini Apps | miniapp + Host bridge | M8 | 签名上下文、授权、撤销、沙箱 | IMPLEMENTED | manifest/grant/session/call 已进入统一协议；权限/E2E 需 M8 current evidence |
-| 支付 | payment / settlement / wallet + Fabushi Pay | M9 | PaymentIntent、webhook 幂等、ledger、退款 | IMPLEMENTED | invoice/order/wallet settlement 已接入；需 M9 sandbox E2E / replay evidence |
-| 音视频 | realtime / signaling / signaling_server + desktop WebRTC | M10 | 跨端 1:1、设备切换、网络恢复 | IMPLEMENTED | self-hosted signaling + desktop controller 已存在；TURN/SFU/移动跨端需 M10 实测 |
-| 移动端共享 Core | native bridge / Mahayana Host | M11 | iOS/Android/Electron 互通且不复制状态机 | IN_PROGRESS | M1 只关闭 desktop/Host baseline；M11 仍需 iOS/Android/Electron cross-device E2E |
-| 高级 IM | story/search/notification/community/message | M12 | 功能矩阵对标范围 | IMPLEMENTED | stories/search/reactions/scheduled 等代码存在；逐项 E2E 需 M12 回填 |
-| E2EE | secret_chat / access | M13 | 服务端不可读、设备验证、密钥轮换 | IMPLEMENTED | Secret Chat 已存在；仍需 M13 独立安全/密钥生命周期验收 |
-| 旧栈移除 | `native/telegram-*`, `mahayana-telegram`, `providers/telegram-*` | M14 | 无隐式 fallback、完整测试通过 | NOT_STARTED | ADR-0008 已冻结；待 M3-M13 replacement acceptance 和 dependency-zero 证明后删除 |
+| 功能域 | canonical 模块 | 阶段 | 当前状态 | 证据 / 下一缺口 |
+|---|---|---|---|---|
+| 统一协议/模型 | protocol + actor/conversation/message | M1-M2 | TESTED | M1-ACCEPT-001 + M2-ACCEPT-001 |
+| 本地持久化 / durable journal | store | M1-M2 | TESTED | #1988/#1998 + #2002 schema v2 journal |
+| WebSocket/Auth/Heartbeat | gateway/server/access | M2 | TESTED | #2001 merge `2a4124a7...`; real socket contracts |
+| 1:1 realtime sync | service/engine/store | M2 | TESTED | #2002 merge `d4611f94...`; run `32575120937` + `32575120857` |
+| 桌面聊天完整交互 | Electron Messenger V2 | M3 | IN_PROGRESS | M3-DESKTOP-001：windowing/search/draft/typing + Playwright |
+| 媒体 | media/blob_store + desktop attachment | M4 | IMPLEMENTED | 需大文件 resume/retry/permissions/cache 验收 |
+| 联系人/群组 | actor/conversation/community | M5 | IMPLEMENTED | 需 owner/admin/member/restricted 权限矩阵 |
+| 频道/Topic | conversation/community | M6 | IMPLEMENTED | 需广播/分页/Topic 状态规模验收 |
+| Bot/Agent | bot + Actor/Feature Host | M7 | IMPLEMENTED | 需统一联系人/Agent-to-Agent acceptance |
+| Mini Apps | miniapp + Host bridge | M8 | IMPLEMENTED | 需授权/撤销/沙箱 E2E |
+| 支付 | payment/settlement/wallet | M9 | IMPLEMENTED | 需 sandbox E2E / webhook replay evidence |
+| 音视频 | realtime/signaling + desktop WebRTC | M10 | IMPLEMENTED | 需跨端/TURN/SFU/网络切换实测 |
+| 移动端共享 Core | native bridge / Host | M11 | IN_PROGRESS | 需 iOS/Android/Electron cross-device E2E |
+| 高级 IM | story/search/notification/community/message | M12 | IMPLEMENTED | 需逐项 E2E |
+| E2EE | secret_chat/access | M13 | IMPLEMENTED | 需密钥生命周期/服务端不可读安全验收 |
+| 旧栈移除 | legacy Telegram paths | M14 | NOT_STARTED | 待 M3-M13 replacement acceptance + dependency-zero |
 
-## M1 closure evidence
+## Closed stage evidence
 
-- M1 stage task: `management/tasks/M1-ACCEPT-001-stage-closure.md`.
-- Evidence index: `evidence/M1-ACCEPT-001/README.md`.
-- PR #1998 merge: `6ad86ccc809a6f00130888087f22cbb201e853fd`.
-- Messaging Product Gate `32563424543`: Rust self-hosted product + Electron Messenger contract SUCCESS.
-- Mahayana fast checks `32563424539`, repository CI `32563424556`, project portfolio governance `32563424574`, self-hosted messaging `32563424511`: SUCCESS.
+- M1: `management/tasks/M1-ACCEPT-001-stage-closure.md`; `evidence/M1-ACCEPT-001/README.md`.
+- M2: `management/tasks/M2-ACCEPT-001-stage-closure.md`; `evidence/M2-ACCEPT-001/README.md`.
 
-## M2 active acceptance
+## M2 final evidence
 
-- M2-NET-001 / PR #2001: WebSocket gateway, scoped auth reuse, heartbeat and real socket contract.
-- M2-SYNC-001 / PR #2002: durable cursor journal, reconnect, idempotent ACK, audience-scoped delta replay and Sent/Delivered/Read.
-- Neither task may be promoted to `TESTED` until its clean current-head checks, protected merge and canonical-main verification complete.
+- PR #2001: M2.T01-T04, protected merge `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
+- PR #2002: M2.T05-T09, protected merge `d4611f9433eb4d6cbfa934c574cec1da96210edb`.
+- Final #2002 gates: Messaging Product Gate `32575120937`, Mahayana fast `32575120857`, self-hosted messaging `32575120877`, repository CI `32575120874`, portfolio governance `32575120961`, automerge `32575120853` — all SUCCESS.
+
+## Active M3 acceptance
+
+M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded peer/message rendering, typing semantics and existing Messenger interactions with current GitHub typecheck/Playwright evidence before M3 closes.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -4,56 +4,56 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-05
-- **版本**：v1.4
+- **版本**：v1.5
 - **状态**：LIVE
 - **基线日期**：2026-08-22
-- **源计划**：`../source/完整telegram融合进fabushi.txt`
 
 ## 当前状态
 
-- **整体阶段**：M2 自建实时网络 + 1:1 文本消息 — `IN_PROGRESS`。
-- **M0**：`TESTED`；PR #1987 / merge `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`。
-- **M1**：`TESTED`；`M1-ACCEPT-001` 已将 current-head Rust/Host/Electron gate、SQLite production cutover 与 canonical-main readback 绑定到 M1.T01-T07。
+- **整体阶段**：M3 桌面聊天完整交互 — `IN_PROGRESS`。
+- **M0**：`TESTED`。
+- **M1**：`TESTED`，证据 `M1-ACCEPT-001`。
+- **M2**：`TESTED`，证据 `M2-ACCEPT-001`。
 - **Canonical Messaging Core**：`native/mahayana-messaging/`。
-- **旧 Telegram 栈**：`native/telegram-*`、`mahayana-telegram`、`providers/telegram-*` 为 LEGACY/FROZEN，禁止新增产品功能。
-- **协议事实来源**：`native/mahayana-messaging/src/protocol.rs`，Messaging Protocol v2。
-- **当前网络任务**：M2-NET-001 / PR #2001，clean branch 已重建为 latest `main` + 单个 WebSocket 增量提交。
-- **当前同步任务**：M2-SYNC-001 / PR #2002，clean branch 已重建为 M2-NET clean head + 单个 durable delta 增量提交。
-- **完成百分比**：不手填；按通过验收的必需原子任务计算。
+- **当前产品任务**：`M3-DESKTOP-001`，分支 `feat/telegram-m3-desktop-ux`。
+- **旧 Telegram 栈**：继续 LEGACY/FROZEN；M14 前不得新增产品功能。
 
-## 已验证的主干事实
+## M2 final landing
 
-- PR #1961 canonical messaging core merge：`8062abb850020a702b4c8a85d8bd23d6b0470cb2`。
-- PR #1988 SQLite foundation merge：`1b78e4fbc1a666fc725c21450b11d3ab643ac0fa`。
-- PR #1998 production SQLite clean landing merge：`6ad86ccc809a6f00130888087f22cbb201e853fd`。
-- #1998 current-head verification：Messaging Product Gate `32563424543` SUCCESS；Mahayana fast checks `32563424539` SUCCESS；repository CI `32563424556` SUCCESS；Project portfolio governance `32563424574` SUCCESS；self-hosted messaging `32563424511` SUCCESS。
-- Product Gate `Rust self-hosted product` job `97008408512` 验证 rustfmt、messaging all-target tests、Clippy、Feature Host bridge/contact projection。
-- Product Gate `Electron Messenger contract` job `97008408644` 验证 Electron Feature Host architecture、self-hosted signaling policy、Native Edge parity、Messenger V2 typecheck。
-- canonical `main` 已回读确认 production `MessagingTcpServer` 使用 `SqliteStateStore`，legacy JSON 仅在 SQLite 为空时导入。
+### M2-NET-001
 
-## 2026-08-22 — M1 acceptance closure
+- PR #2001 merged `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6` through protected merge queue.
+- WebSocket gateway、scoped auth、shared executor、heartbeat/frame contracts 均落 canonical main。
+- Historical #1993 已关闭为 superseded provenance。
 
-- **任务**：`M1-ACCEPT-001`。
-- **结果**：M1.T01-T07 提升到 `TESTED`；M1 milestone = `TESTED`。
-- **边界**：这里只关闭 Rust Core + desktop/Host foundation；iOS/Android 三端互发属于 M11，M2 reconnect/delta 属 M2，后续 product-domain E2E 属 M3-M13。
-- **证据**：`../evidence/M1-ACCEPT-001/README.md`。
+### M2-SYNC-001
 
-## 2026-08-22 — M2-NET-001 clean landing
+- PR #2002 merged `d4611f9433eb4d6cbfa934c574cec1da96210edb`。
+- Final head `b4d56161a4b409e04e9a0a0850900ac9cf3fae08` current-head gates：
+  - Messaging Product Gate `32575120937` SUCCESS；
+  - Mahayana fast checks `32575120857` SUCCESS；
+  - self-hosted messaging `32575120877` SUCCESS；
+  - repository CI `32575120874` SUCCESS；
+  - project portfolio governance `32575120961` SUCCESS；
+  - Explicit automerge `32575120853` SUCCESS。
+- canonical main 回读确认 corrected stable-message idempotency、SQLite v2 journal、delta sync contracts 全部存在。
 
-- **PR**：#2001。
-- **运行时**：self-hosted WebSocket gateway、同一 `MessagingService<SqliteStateStore>`、同一 actor/device/session token authorization、Ping/Pong heartbeat、frame limit、binary rejection、real localhost WebSocket contracts。
-- **rebase 处理**：因 `main` 在 #1998 后继续前进，#2001 分支已重建为最新 canonical `main` + 单个 M2-NET commit，避免旧 M1 历史/项目快照进入 diff。
-- **当前门禁**：current-head GitHub Actions 运行中；未完成 protected merge/main verification 前保持 `IN_PROGRESS`。
+## M3 live audit / implementation
 
-## 2026-08-22 — M2-SYNC-001 clean stack
+已有桌面能力包括导航、peer 搜索、置顶/静音/归档、群组/频道/收藏、reply/forward/edit/delete、reaction/pin、附件/投票/位置/定时/静默发送、支付/Mini App/Story 入口和 Bot collaboration flow。
 
-- **PR**：#2002，base = clean M2-NET branch。
-- **运行时**：SQLite schema v2 durable event journal、idempotent send/ACK、durable cursor/checkpoint、audience-scoped delta replay、restart/second-device recovery、Sent→Delivered→Read。
-- **rebase 处理**：分支已重建为 clean M2-NET head + 单个 M2-SYNC commit，仅重放目标 runtime blobs 和当前项目证据。
-- **当前门禁**：等待 lower stack #2001 落 main 后 retarget/revalidate；不得提前标记 `TESTED`。
+已确认并开始补齐的真实缺口：
 
-## Project governance
+1. peer/message 大列表有界窗口化；
+2. 当前会话搜索真正过滤消息；
+3. per-peer draft 持久化与切换恢复；
+4. Protocol v2 typing end-to-end；
+5. 对已有 interaction surface 补 Playwright acceptance。
 
-- GitHub `main` 的 `projects/telegram-fabushi-integration/` 为唯一工程权威基线。
-- immutable portfolio identity 固定为 `FAB-P0001 / TFI`。
-- 每个阶段只按 current evidence 晋级；旧 PR 可作为 provenance，但不能替代 final-head CI / protected merge / canonical-main verification。
+M3 第一批 UI 改动已在 `feat/telegram-m3-desktop-ux` 实现，后续必须在 M2 closure main 基线上 clean restack、通过 GitHub typecheck/Playwright 后才能合并。
+
+## 治理事实
+
+- GitHub `main:projects/telegram-fabushi-integration/` 为唯一工程权威源。
+- immutable identity = `FAB-P0001 / TFI`。
+- 任何阶段都必须 current-head CI + protected merge + canonical-main verification 才能关账。

--- a/projects/telegram-fabushi-integration/management/06-依赖与阻塞.md
+++ b/projects/telegram-fabushi-integration/management/06-依赖与阻塞.md
@@ -7,47 +7,39 @@
 - **状态**：LIVE
 - **更新时间**：2026-08-22
 
-> `06-PR分支规则.md` 继续作为 PR/分支治理规则；本文档专门记录产品推进依赖与阻塞，不覆盖既有文件。
-
 ## Dependency register
 
-| ID | Workstream | Depends on | Current state | Blocking condition | Exit evidence |
-|---|---|---|---|---|---|
-| DEP-001 | M1.T06 SQLite schema/storage | M0 canonical messaging decision | RESOLVED | — | PR #1988 merged `1b78e4fbc1a666fc725c21450b11d3ab643ac0fa` + CI evidence |
-| DEP-002 | M1.T02 production SQLite adoption | M1.T06 | RESOLVED | — | clean PR #1998 merged `6ad86ccc809a6f00130888087f22cbb201e853fd` + main verification |
-| DEP-003 | M1 acceptance closure | M1.T02 + current Messaging Product Gate | RESOLVED | — | `M1-ACCEPT-001`; Messaging Product Gate `32563424543`; Electron/Host bridge jobs green |
-| DEP-004 | M2-M13 acceptance closure | canonical core + stage test matrices | OPEN | implemented domains still need stage-scoped current evidence | per-stage CI/E2E/security evidence |
-| DEP-005 | M11 native cross-platform | shared Rust client/Host bridge | OPEN | project lacks sufficient iOS/Android/Electron cross-device E2E evidence | native quality gate + cross-platform message exchange evidence |
-| DEP-006 | M14 legacy removal | zero runtime dependency on legacy Telegram paths | OPEN | dependency inventory and replacement verification not complete | dependency search zero + full CI + removal PR |
-| DEP-007 | M2-NET-001 clean WebSocket landing | M1 tested foundation | IN_PROGRESS | PR #2001 current-head CI / protected merge / canonical-main verification | PR #2001 green + merged + main readback |
-| DEP-008 | M2-SYNC-001 durable delta sync | M2-NET-001 | IN_PROGRESS | PR #2002 is stacked until #2001 lands; then retarget/revalidate | #2002 green on final main base + merged + main readback |
+| ID | Workstream | Depends on | State | Exit evidence / next gate |
+|---|---|---|---|---|
+| DEP-001 | M1.T06 SQLite | M0 | RESOLVED | #1988 merged |
+| DEP-002 | M1.T02 production SQLite | M1.T06 | RESOLVED | #1998 merged + main verification |
+| DEP-003 | M1 closure | current product gates | RESOLVED | M1-ACCEPT-001 |
+| DEP-007 | M2-NET-001 | M1 | RESOLVED | #2001 merged `2a4124a7...` + main readback |
+| DEP-008 | M2-SYNC-001 | M2-NET | RESOLVED | #2002 merged `d4611f94...` + six final gates + main readback |
+| DEP-009 | M3-DESKTOP-001 | M2 tested realtime semantics | IN_PROGRESS | desktop typecheck + Messenger Playwright + protected merge + main readback |
+| DEP-004 | M4-M13 acceptance closure | canonical core + stage matrices | OPEN | per-stage CI/E2E/security evidence |
+| DEP-005 | M11 native cross-platform | shared Rust client/Host bridge | OPEN | iOS/Android/Electron cross-device E2E |
+| DEP-006 | M14 legacy removal | M3-M13 replacement acceptance | OPEN | dependency-zero + full CI + removal PR |
 
 ## Current blockers
 
 ### BLK-001 — SQLite native dependency alignment
+State: **RESOLVED** via `rusqlite 0.39`, #1988/#1998.
 
-- **Discovered**: #1988 CI initially found two `libsqlite3-sys` versions attempting to link `sqlite3`.
-- **Resolution**: messaging crate aligned to `rusqlite 0.39`; #1988 and #1998 are merged and verified.
-- **State**: RESOLVED.
-
-### BLK-002 — Evidence debt across implemented feature domains
-
-- **Cause**: PR #1961 landed broad self-hosted messaging capability before this project folder had stage-scoped acceptance records.
-- **Action**: do not rewrite implemented domains; add current-head stage-specific tests/E2E and promote only when objective evidence exists.
-- **State**: ACTIVE. M1 is now reconciled; M2 is active; M3-M13 remain.
+### BLK-002 — Evidence debt across implemented domains
+State: **ACTIVE**. M1 and M2 are reconciled; M3 is active; M4-M13 still require stage-scoped evidence.
 
 ### BLK-003 — Legacy Telegram stacks still present
+State: **ACTIVE / intentionally deferred**. ADR-0008 freezes old paths; M14 deletes only after replacement acceptance and dependency-zero proof.
 
-- **Cause**: previous integration work retained Telegram runtime/provider crates.
-- **Action**: ADR-0008 freezes those paths; M14 deletes them only after dependency-zero proof and replacement validation.
-- **State**: ACTIVE, intentionally deferred until replacement acceptance is complete.
+### BLK-004 — Fast-moving main during stacked landing
+State: **RESOLVED for M2**. #2001/#2002 were rebuilt from final canonical bases and passed current-head CI. The same clean-restack discipline remains mandatory for future stacked work.
 
-### BLK-004 — Fast-moving main while clean stack is landing
+### BLK-005 — M3 desktop interaction gaps
+State: **ACTIVE**.
+Confirmed gaps: bounded list rendering, real in-conversation search, per-peer draft persistence, Protocol v2 typing completion, and explicit Playwright acceptance for existing interaction flows.
+Exit: `M3-DESKTOP-001` current-head typecheck/E2E + protected merge + canonical-main verification.
 
-- **Cause**: unrelated Fabushi projects continue merging into `main`, so stacked TFI branches can diverge even when their runtime delta is correct.
-- **Action**: rebuild each landing branch from the latest canonical base tree and replay only the intended verified blobs/project records; require current-head CI after every final rebase.
-- **State**: ACTIVE until M2 stack is merged; #2001 and #2002 have been rebuilt as one-commit clean deltas against their current bases.
+## Rule
 
-## Blocker handling rule
-
-A blocker may be marked resolved only with objective repository evidence. Chat confirmation or code existence alone is insufficient.
+No blocker may be marked resolved from chat confirmation or code existence alone; objective repository evidence is mandatory.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -4,59 +4,51 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-07
-- **版本**：v1.4
+- **版本**：v1.5
 - **状态**：LIVE
 - **基线日期**：2026-08-22
-- **源计划**：`../source/完整telegram融合进fabushi.txt`
 
-## 2026-08-22 — v1.0 planning baseline
+## 2026-08-22 — planning / governance baseline
 
-- 建立 Telegram → Fabushi 全量融合项目资料夹。
-- 将 `完整telegram融合进fabushi.txt` 作为需求基线纳入 `source/`。
-- 拆分专题文档、路线图、WBS、里程碑、验收矩阵、风险登记与 ADR。
-- 初始状态在缺少 live GitHub 审计时保守保持 NOT_STARTED。
-
-## 2026-08-22 — GitHub-first 项目治理基线
-
-- 唯一长期权威位置固定为 `bhrumom/fabushi@main:projects/telegram-fabushi-integration/`。
-- Google Drive、聊天记录和本地副本为输入/镜像，不作为项目状态权威源。
-- 每次任务开始读取项目目录；任务结束前回写状态、WBS、验收、变更和证据。
-- 新的独立工作流使用标准化 `projects/<slug>/` 项目文件夹。
+- 建立 Telegram → Fabushi 全量融合项目文件夹与 source/WBS/里程碑/验收/风险/ADR。
+- GitHub `main:projects/telegram-fabushi-integration/` 固定为唯一工程权威源。
 - immutable portfolio identity 固定为 `FAB-P0001 / TFI`。
 
-## 2026-08-22 — M0 live implementation reconciliation
+## 2026-08-22 — M0 closure
 
-- 审计已合并 PR #1961 与当前 `main`，确认 `native/mahayana-messaging/` 已是自建 Rust Messaging Core。
-- 新增 DOC-20 live audit 和 ADR-0008。
-- 冻结 `native/telegram-*`、`mahayana-telegram`、`providers/telegram-*`，禁止新增产品功能。
-- 固定 Messaging Protocol v2 Serde schema 为 canonical messaging IDL。
-- PR #1987 通过 CI 和 protected merge，merge `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`；M0 关闭为 `TESTED`。
+- PR #1961 确认 canonical self-hosted Rust Messaging Core。
+- ADR-0008 冻结 legacy Telegram paths。
+- PR #1987 merge `5aeca75a1e9f6c5bd9fc376cf697012004c0766c`; M0 = TESTED。
 
-## 2026-08-22 — M1 local-first SQLite implementation
+## 2026-08-22 — M1 closure
 
-- M1.T06 / PR #1988 新增 versioned `SqliteStateStore`、事务 snapshot、完整 u64 cursor、schema validation 和恢复测试；merge `1b78e4fbc1a666fc725c21450b11d3ab643ac0fa`。
-- CI 首轮暴露 `libsqlite3-sys` 单链接冲突；将 messaging dependency 对齐到 `rusqlite 0.39`。
-- 历史 PR #1990 实现 production SQLite cutover，但同时携带 immutable Project ID 治理之前的旧项目文档。
-- 从 current `main` 创建 clean replacement PR #1998，只落运行时改动和当前项目记录；merge `6ad86ccc809a6f00130888087f22cbb201e853fd`。
-- 旧 #1990 关闭为 superseded landing path，保留历史 CI/provenance。
+- #1988 落 versioned SQLite foundation，merge `1b78e4fbc1a666fc725c21450b11d3ab643ac0fa`。
+- stale #1990 不直接落地；clean #1998 在 current main 上完成 production SQLite cutover，merge `6ad86ccc809a6f00130888087f22cbb201e853fd`。
+- `M1-ACCEPT-001` 使用 #1998 current-head product/Host/Electron/governance gates 关闭 M1.T01-T07 为 TESTED。
 
-## 2026-08-22 — M1 acceptance closure
+## 2026-08-22 — M2 network landing
 
-- 新增 `M1-ACCEPT-001` 任务与 evidence index。
-- 使用 #1998 current-head Messaging Product Gate `32563424543`、Mahayana fast `32563424539`、repository CI `32563424556`、Project portfolio governance `32563424574`、self-hosted messaging `32563424511` 作为 M1 acceptance evidence。
-- `Rust self-hosted product` job `97008408512` 与 `Electron Messenger contract` job `97008408644` 均成功。
-- M1.T01-T07 与 M1 milestone 提升为 `TESTED`；PROJECT current stage 切换到 M2。
-- 明确不把 M11 移动跨端或 M3-M13 product-domain E2E 计入 M1 closure。
+- historical #1993 仅保留 provenance。
+- clean #2001 落 self-hosted WebSocket、scoped auth、shared executor、heartbeat/frame contracts。
+- #2001 final current-head gates 全绿并通过 protected merge queue，merge `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`。
+- canonical-main readback 验证 gateway 和 real socket tests；#1993 closed superseded。
 
-## 2026-08-22 — M2 clean-stack landing strategy
+## 2026-08-22 — M2 durable sync landing
 
-- historical #1993/#1994 只保留为实现 provenance，不允许旧项目记录直接进入主线。
-- #2001 M2-NET 分支因 `main` 持续前进被重建为 latest `main` + 单个 WebSocket delta commit；最终 diff 只保留 M2 网络目标文件与当前项目记录。
-- #2002 M2-SYNC 分支被重建为 clean #2001 head + 单个 durable delta sync commit；只重放 `service.rs`、`store.rs`、`delta_sync_contract.rs` 及 current task/evidence/WBS。
-- 新增 BLK-004 记录 fast-moving main 对 stacked landing 的治理策略：每次 final landing 都从最新权威 base tree 重放目标 delta 并重新跑 current-head CI。
+- historical #1994 作为原始实现 provenance，不直接导入 stale project records。
+- current CI 暴露 rustfmt 1.98 和已移除 `Message.client_message_id` 两项兼容变化。
+- final implementation 保留当前 Message schema，依赖 deterministic `stable_message_id(actor_id, client_message_id)` 绑定 retry identity，并保留全部 payload-conflict checks。
+- #2002 final head `b4d56161a4b409e04e9a0a0850900ac9cf3fae08` 六组门禁全部 SUCCESS。
+- #2002 merge `d4611f9433eb4d6cbfa934c574cec1da96210edb`; canonical-main readback 验证 schema-v2 journal、delta sync、idempotency、delivery/read contracts。
+- 新增 `M2-ACCEPT-001`; M2.T01-T09 与 M2 milestone 提升 TESTED。
 
-## 2026-08-22 — Enterprise project standard alignment
+## 2026-08-22 — M3 started
 
-- 新增 `OWNERS.md`、dependency/blocker register、issue/action register 与 messaging/SQLite runbooks。
-- `PROJECT.yaml` 已从 planning baseline 转入 `IMPLEMENTATION_ACTIVE`。
-- GitHub `main` 项目目录持续作为唯一工程状态权威源。
+- live audit 确认现有 Electron Messenger 已具备导航、peer 搜索、置顶/静音/归档、群组/频道/收藏、reply/forward/edit/delete、reaction/pin、附件/投票/位置/定时/静默发送、支付/Mini App/Story 与 Bot collaboration flows。
+- `M3-DESKTOP-001` 记录真实缺口：bounded peer/message rendering、真实当前会话搜索、per-peer draft persistence、Protocol v2 typing、Playwright acceptance expansion。
+- `feat/telegram-m3-desktop-ux` 已开始第一批实现；最终必须 clean-restack 到 M2 closure main 并通过 GitHub typecheck/Playwright 后合并。
+
+## Enterprise project standard
+
+- OWNERS、dependency/blocker register、issue/action register 与 messaging/SQLite runbooks 持续维护。
+- 每轮工作必须同步 task/WBS/acceptance/status/changelog/evidence；未有客观证据不得标记完成。

--- a/projects/telegram-fabushi-integration/management/tasks/M2-ACCEPT-001-stage-closure.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M2-ACCEPT-001-stage-closure.md
@@ -1,0 +1,51 @@
+# M2-ACCEPT-001 — M2 realtime messaging stage closure
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M2-ACCEPT-001`
+- **Stage**: `M2 自建实时网络 + 1:1 文本消息`
+- **Status**: `TESTED`
+- **Completed**: `2026-08-22`
+
+## Result
+
+M2.T01-T09 are accepted at `TESTED` on canonical `main`.
+
+## Landed product evidence
+
+- PR #2001 — self-hosted WebSocket/Auth/Heartbeat; merge `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
+- PR #2002 — durable reconnect/idempotent delta sync; merge `d4611f9433eb4d6cbfa934c574cec1da96210edb`.
+- Canonical main was re-read after both merges and contains the gateway, WebSocket contracts, SQLite v2 journal, current-schema idempotency logic and delta-sync contracts.
+
+## Final #2002 current-head gates
+
+| Gate | Run | Result |
+|---|---:|---|
+| Messaging Product Gate | `32575120937` | SUCCESS |
+| Mahayana fast checks | `32575120857` | SUCCESS |
+| Fabushi self-hosted messaging | `32575120877` | SUCCESS |
+| Repository CI | `32575120874` | SUCCESS |
+| Project portfolio governance | `32575120961` | SUCCESS |
+| Explicit automerge | `32575120853` | SUCCESS |
+
+Messaging Product Gate proved current rustfmt, all-target messaging tests, Clippy, Feature Host bridge/contact projection and Electron Messenger contract. Mahayana fast proved direct Host, feature adapters and embedded FFI boundary.
+
+## Acceptance coverage
+
+- real WebSocket Protocol v2 execution;
+- actor/device/session token isolation;
+- Ping/Pong heartbeat and bounded frames;
+- reconnect/restart recovery through durable cursor journal;
+- idempotent send/ACK and conflicting-ID rejection;
+- durable server cursor/checkpoint semantics;
+- audience-scoped delta replay and outsider isolation;
+- safe full-sync fallback when journal coverage is incomplete;
+- `Sent -> Delivered -> Read` recipient state transitions.
+
+## Scope boundary
+
+This closes realtime transport and 1:1 synchronization semantics. Desktop interaction completeness remains M3; media, communities, Bot/Agent, Mini Apps, payment, calls, mobile, advanced IM, E2EE and legacy removal remain M4-M14.
+
+## Evidence index
+
+`../../evidence/M2-ACCEPT-001/README.md`

--- a/projects/telegram-fabushi-integration/management/tasks/M2-NET-001-websocket-current-main.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M2-NET-001-websocket-current-main.md
@@ -1,61 +1,39 @@
-# M2-NET-001 — Self-hosted WebSocket gateway on clean stack
+# M2-NET-001 — Self-hosted WebSocket gateway on canonical main
 
 - **Project ID**: `FAB-P0001`
 - **Project Key**: `TFI`
 - **Task ID**: `M2-NET-001`
-- **WBS**: `M2.T01`, `M2.T02`, `M2.T03`, `M2.T04`
-- **Status**: `IN_PROGRESS`
-- **Started**: `2026-08-22`
-- **Updated**: `2026-08-22`
-- **Depends on**: M1 tested foundation — resolved
+- **WBS**: `M2.T01`–`M2.T04`
+- **Status**: `TESTED`
+- **Completed**: `2026-08-22`
 
-## Objective
+## Result
 
-Expose the canonical Rust `MessagingService<SqliteStateStore>` over a self-hosted WebSocket transport without creating a second messaging engine, protocol, authorization model, or state store.
+Canonical Rust `MessagingService<SqliteStateStore>` is exposed through a self-hosted WebSocket transport without introducing a second messaging engine, protocol, authorization model or state store.
 
-## Implementation
+## Verified implementation
 
-- `tungstenite 0.30` self-hosted WebSocket transport.
-- Messaging Protocol v2 text/JSON envelopes.
-- Existing scoped `FileAccessTokenStore` actor/device/session authorization.
-- TCP and WebSocket share one authenticated command executor and one `MessagingService<SqliteStateStore>` loader.
-- Bounded application/message frames and explicit binary-frame rejection.
-- Server Ping/Pong heartbeat with inactivity timeout.
-- Deterministic `serve_one` entrypoint for real localhost socket contracts.
+- `tungstenite 0.30` WebSocket transport.
+- Protocol v2 UTF-8 JSON frames.
+- scoped actor/device/session access-token authorization.
+- TCP/WebSocket share one authenticated executor and one messaging service loader.
+- bounded frames and explicit binary-frame rejection.
+- server Ping/Pong heartbeat and inactivity timeout.
+- real localhost handshake/auth/heartbeat/frame contracts.
 
-## Clean-current-main landing
+## Landing evidence
 
-Historical PR #1993 contained the intended implementation and passed its product gates, but it was stacked on older project history. Clean PR #2001 was created instead.
-
-After #1998 landed, unrelated Fabushi projects advanced `main`; therefore #2001 was rebuilt again from canonical `main` commit `c9bfa320ac4e3e27cc2dee3e80bbd558c08f4cb5`. Runtime/project delta was replayed into one clean code commit `c1ddb97a16df5eccab7310ba1fb3fe17b161a003`, after which project governance/acceptance records were reconciled on the same branch.
-
-The clean compare at that point was `main` + one M2-NET delta with only the intended gateway/server/test/project files; no historical M1 commit stack remained.
-
-## Acceptance criteria
-
-1. Valid actor/device/session token executes Protocol v2 over a real WebSocket — implementation present; current-head CI required.
-2. Identity mismatch is rejected — contract test present; current-head CI required.
-3. Ping/Pong keeps healthy connection alive and invalid heartbeat configuration is rejected — contract/unit tests present.
-4. Oversized application frames are rejected — contract test present.
-5. Binary application frames are rejected — contract test present.
-6. TCP/WebSocket share one messaging service and authorization executor — implementation present.
-7. Messaging Product Gate, Mahayana fast checks, repository/self-hosted/governance checks pass on the final clean head — **PENDING final-head results**.
-8. Protected merge and canonical-main verification complete — **PENDING**.
-
-## Branch / PR
-
-- Branch: `feat/telegram-m2-websocket-main-sync`
-- PR: #2001
-- Base: `main`
-- Historical PR: #1993 — provenance only; to be closed as superseded after #2001 lands.
+- Clean PR #2001.
+- Final head `1030a489a5b4ed12f93464c95325e5d6d2ca7535` passed all required current-head GitHub Actions.
+- Protected merge queue landed PR #2001 as `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`.
+- Post-merge canonical-main reads confirmed `gateway.rs` and `websocket_gateway_contract.rs` are present.
+- Historical PR #1993 is closed as superseded landing provenance.
 
 ## Evidence
 
-- `native/mahayana-messaging/src/gateway.rs`
-- `native/mahayana-messaging/src/server.rs`
-- `native/mahayana-messaging/tests/websocket_gateway_contract.rs`
 - `../../evidence/M2-NET-001-current-main/README.md`
+- `../../evidence/M2-ACCEPT-001/README.md`
 
 ## Next action
 
-Use the final branch head after governance reconciliation, require fresh current-head GitHub Actions, merge #2001, re-read canonical `main`, then update this record to `TESTED` and retarget #2002.
+No M2-NET blocker remains. Desktop interaction completeness proceeds in M3.

--- a/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-001-durable-delta-sync-current-main.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-001-durable-delta-sync-current-main.md
@@ -1,65 +1,50 @@
-# M2-SYNC-001 — Durable idempotent delta sync on clean stack
+# M2-SYNC-001 — Durable idempotent delta sync on canonical main
 
 - **Project ID**: `FAB-P0001`
 - **Project Key**: `TFI`
 - **Task ID**: `M2-SYNC-001`
 - **WBS**: `M2.T05`–`M2.T09`
-- **Status**: `IN_PROGRESS`
-- **Started**: `2026-08-22`
-- **Updated**: `2026-08-22`
-- **Depends on**: M2-NET-001 / PR #2001
+- **Status**: `TESTED`
+- **Completed**: `2026-08-22`
+- **Depends on**: M2-NET-001 — resolved
 
-## Objective
+## Result
 
-Complete M2 realtime semantics on the canonical Rust messaging engine: durable reconnect recovery, idempotent send/ACK, durable server cursor, audience-scoped delta sync, and Sent/Delivered/Read state transitions.
+The canonical Rust messaging engine now provides durable reconnect recovery, idempotent send/ACK, durable server cursor, audience-scoped delta sync and Sent/Delivered/Read transitions.
 
-## Runtime implementation
+## Verified implementation
 
 - SQLite schema v2 durable event journal.
-- Snapshot + audience-scoped journal entries persist transactionally.
-- Cursor-group-aware pagination/pruning.
-- Stable server message IDs derived from authenticated sender + `client_message_id`.
-- Identical retries return the accepted message without duplicating state or advancing cursor again.
-- Conflicting reuse of a client message ID is rejected.
-- Successful send enters ACK path and reaches `Sent`.
-- Direct/secret recipient sync promotes `Sent -> Delivered`.
-- Recipient `MarkRead` promotes visible messages to `Read`.
-- `Sync.cursor` replays authorized delta events and emits checkpoint cursor.
-- Old/incomplete journal history falls back to actor-scoped full sync.
-- Journal audiences are captured at mutation time and filtered on replay.
+- transactional snapshot + audience-scoped journal entries.
+- complete cursor-group pagination/pruning.
+- deterministic stable message IDs from authenticated sender + client message id.
+- identical retry is idempotent; conflicting payload reuse is rejected.
+- successful send reaches `Sent`; recipient sync reaches `Delivered`; recipient `MarkRead` reaches `Read`.
+- cursor delta replay with checkpoint; old/incomplete history safely falls back to scoped full sync.
+- outsider isolation, process restart, second-device and migration-floor contracts.
 
-## Clean stack provenance
+## Current-main compatibility reconciliation
 
-Historical PR #1994 is implementation provenance only. The clean PR #2002 replays only the intended runtime blobs plus current task/evidence/WBS on top of the clean #2001 stack.
+Historical #1994 referenced a removed `Message.client_message_id`. The final clean implementation preserves the current canonical Message schema because deterministic stable-message lookup already binds actor + client message id. The obsolete field comparison was removed while all payload-conflict checks remain. Current rustfmt, all-target Rust tests and Clippy proved the reconciled implementation.
 
-After the final #2001 governance reconciliation, #2002 was restacked again with parent `1030a489a5b4ed12f93464c95325e5d6d2ca7535` and clean runtime replay commit `fd76ebd828f62b82ff0eecf34e85b24860e2a342`. This prevents stale lower-stack project records from entering the M2-SYNC diff.
+## Final GitHub evidence
 
-## Acceptance criteria
+PR #2002 final head `b4d56161a4b409e04e9a0a0850900ac9cf3fae08` passed:
 
-1. Process restart preserves state and delta journal sufficiently for reconnect recovery.
-2. Repeated identical `client_message_id` is idempotent; conflicting reuse is rejected.
-3. Server cursor never silently rolls backward across persisted state.
-4. Authorized second-device delta sync recovers changes after known cursor.
-5. Outsiders cannot observe journal events for unauthorized conversations.
-6. Missing/expired journal coverage falls back to actor-scoped full sync.
-7. Delivery/read transitions reach `Sent`, `Delivered`, `Read` in defined recipient flows.
-8. Final clean-head Messaging Product Gate, Mahayana fast checks and applicable repository/governance checks pass.
-9. #2001 lands first; #2002 is retargeted to final `main`, revalidated, merged and verified on canonical `main`.
+- Messaging Product Gate `32575120937` — SUCCESS.
+- Mahayana fast checks `32575120857` — SUCCESS.
+- Fabushi self-hosted messaging `32575120877` — SUCCESS.
+- Repository CI `32575120874` — SUCCESS.
+- Project portfolio governance `32575120961` — SUCCESS.
+- Explicit automerge `32575120853` — SUCCESS.
 
-## Branch / PR
-
-- Branch: `feat/telegram-m2-delta-main-sync`
-- PR: #2002
-- Temporary base: `feat/telegram-m2-websocket-main-sync` / #2001
-- Historical PR: #1994 — provenance only; to be closed as superseded after clean landing.
+PR #2002 merged as `d4611f9433eb4d6cbfa934c574cec1da96210edb`. Canonical-main re-read confirmed the corrected deterministic-idempotency code and all durable-sync artifacts.
 
 ## Evidence
 
-- `native/mahayana-messaging/src/store.rs`
-- `native/mahayana-messaging/src/service.rs`
-- `native/mahayana-messaging/tests/delta_sync_contract.rs`
 - `../../evidence/M2-SYNC-001-current-main/README.md`
+- `../../evidence/M2-ACCEPT-001/README.md`
 
 ## Next action
 
-Run final clean-stack CI. After #2001 lands, retarget #2002 to `main`, revalidate the final head/base pair, merge through protected-main governance, then perform canonical-main verification and close M2.T05-T09.
+No M2-SYNC blocker remains. M3 consumes these realtime semantics in the desktop interaction layer.

--- a/projects/telegram-fabushi-integration/management/wbs/M2.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M2.md
@@ -1,100 +1,91 @@
 # WBS 原子任务 — M2 自建实时网络 + 1:1 文本消息
 
 ### M2.T01 — gateway
-
 - **交付物**：self-hosted gateway
-- **验收标准**：真实 WebSocket 连接可执行 Messaging Protocol v2，复用 canonical Rust messaging service，不创建第二状态机
-- **客观验证**：`websocket_gateway_contract.rs`; Messaging Product Gate; Mahayana fast checks
+- **验收标准**：真实 WebSocket 可执行 Messaging Protocol v2，复用 canonical Rust messaging service
+- **客观验证**：`websocket_gateway_contract.rs`; PR #2001 current-head gates
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean-stack current-head CI / protected merge / canonical-main verification pending
-- **证据位置**：`../tasks/M2-NET-001-websocket-current-main.md`; `../../evidence/M2-NET-001-current-main/README.md`; historical PR #1993
-- **下一步**：完成 clean stacked PR gate，M1.T02 落地后 retarget `main` 并合并。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：`../tasks/M2-NET-001-websocket-current-main.md`; `../../evidence/M2-ACCEPT-001/README.md`
+- **下一步**：桌面交互完整性进入 M3。
 
 ### M2.T02 — auth session
-
 - **交付物**：actor/device/session scoped auth session
-- **验收标准**：错误 actor/device/session 身份无法使用合法 token 冒充，权限 scope 沿用 canonical access model
-- **客观验证**：`access.rs`; shared authenticated executor; WebSocket identity-mismatch contract
+- **验收标准**：错误 actor/device/session 无法冒用合法 token
+- **客观验证**：shared authenticated executor + WebSocket identity-mismatch contract
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：M2 clean-stack acceptance reconciliation pending
-- **证据位置**：PR #1961 existing access foundation; M2-NET-001 current-main evidence
-- **下一步**：随 M2-NET-001 current-head CI 绑定到 M2 stage 验收。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：M2-NET-001 + M2-ACCEPT-001
+- **下一步**：后续阶段复用同一 access model。
 
 ### M2.T03 — websocket connection
-
 - **交付物**：WebSocket connection
-- **验收标准**：真实 localhost WebSocket handshake + authenticated Protocol v2 command/response 成功；超限/非法 frame 显式拒绝
+- **验收标准**：真实 localhost handshake + Protocol v2 request/response；非法 frame 显式拒绝
 - **客观验证**：`websocket_gateway_contract.rs`
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean-stack current-head CI / protected merge pending
-- **证据位置**：M2-NET-001 task/evidence; historical PR #1993
-- **下一步**：通过 clean-stack gate 后提升为 TESTED。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：PR #2001 merge `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`
+- **下一步**：无 M2 blocker。
 
 ### M2.T04 — heartbeat
-
-- **交付物**：server Ping/Pong heartbeat + peer inactivity timeout
-- **验收标准**：健康连接通过 Ping/Pong 保活；超时配置拒绝 zero/inverted values；peer inactivity 到达 timeout 后连接失败关闭
-- **客观验证**：gateway unit contract + real socket heartbeat test
+- **交付物**：server Ping/Pong heartbeat + inactivity timeout
+- **验收标准**：健康连接保活；错误 heartbeat 配置拒绝；超时退出
+- **客观验证**：gateway unit + real socket heartbeat contract
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean-stack current-head CI / protected merge pending
-- **证据位置**：M2-NET-001 task/evidence; historical PR #1993
-- **下一步**：通过 clean-stack gate 后提升为 TESTED。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：M2-NET-001 / PR #2001
+- **下一步**：无 M2 blocker。
 
 ### M2.T05 — reconnect
-
 - **交付物**：reconnect / cursor resume
-- **验收标准**：断网或进程重启后从已知 cursor 继续同步；日志覆盖不足时安全回退 scoped full sync
-- **客观验证**：`delta_sync_contract.rs`; SQLite journal restart contracts; Messaging Product Gate
+- **验收标准**：断网/进程重启后从 cursor 恢复；覆盖不足安全 full-sync fallback
+- **客观验证**：`delta_sync_contract.rs`; schema-v2 journal restart contracts
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean delta-stack current-head CI / lower-stack merge / canonical-main verification pending
-- **证据位置**：`../tasks/M2-SYNC-001-durable-delta-sync-current-main.md`; `../../evidence/M2-SYNC-001-current-main/README.md`; historical PR #1994
-- **下一步**：通过 clean current-head gate 并按栈顺序落 main。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：`../tasks/M2-SYNC-001-durable-delta-sync-current-main.md`; `../../evidence/M2-ACCEPT-001/README.md`
+- **下一步**：桌面使用体验由 M3 验收。
 
 ### M2.T06 — message send/ack
-
 - **交付物**：idempotent message send + server ACK
-- **验收标准**：重复相同 `client_message_id` 不产生重复消息；相同 retry 返回既有 accepted message；冲突 payload 显式拒绝
-- **客观验证**：`delta_sync_contract.rs`; service/store contracts; Messaging Product Gate
+- **验收标准**：重复 client id 不重复；冲突 payload 拒绝；成功进入 Sent
+- **客观验证**：current `service.rs` + `delta_sync_contract.rs`; Messaging Product Gate `32575120937`
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean delta-stack current-head CI / merge pending
-- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
-- **下一步**：通过 clean current-head gate 后提升 TESTED。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：PR #2002 merge `d4611f9433eb4d6cbfa934c574cec1da96210edb`
+- **下一步**：无 M2 blocker。
 
 ### M2.T07 — server sequence
-
 - **交付物**：durable server cursor/sequence
-- **验收标准**：服务重启后 cursor 不回退；event journal 与 snapshot 事务一致；分页保留完整 cursor group
-- **客观验证**：SQLite schema v2 + journal restart/pagination contracts
+- **验收标准**：重启 cursor 不回退；snapshot+journal 事务一致；分页不拆 cursor group
+- **客观验证**：schema-v2 journal contracts
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean delta-stack current-head CI / merge pending
-- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
-- **下一步**：通过 clean current-head gate 后提升 TESTED。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：M2-SYNC-001 / M2-ACCEPT-001
+- **下一步**：无 M2 blocker。
 
 ### M2.T08 — delta sync
-
 - **交付物**：audience-scoped cursor delta sync
-- **验收标准**：有效 cursor 增量恢复；过期/不完整 cursor 安全回退 scoped full sync；越权 actor 不获得其它会话事件
-- **客观验证**：`delta_sync_contract.rs`; journal outsider-isolation/restart/migration-floor contracts
+- **验收标准**：有效 cursor 增量恢复；越权 actor 不获得其它会话事件；旧 cursor 安全 fallback
+- **客观验证**：outsider isolation / restart / migration-floor contracts
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean delta-stack current-head CI / merge pending
-- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
-- **下一步**：通过 clean current-head gate 后提升 TESTED。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：M2-SYNC-001 / PR #2002
+- **下一步**：无 M2 blocker。
 
 ### M2.T09 — delivery/read state
-
-- **交付物**：Sent → Delivered → Read state transitions
-- **验收标准**：发送成功进入 Sent；direct/secret recipient sync 标记 Delivered；recipient `MarkRead` 标记 Read
-- **客观验证**：`delta_sync_contract.rs`; service delivery/read contracts
+- **交付物**：Sent → Delivered → Read
+- **验收标准**：发送成功 Sent；recipient sync Delivered；recipient MarkRead Read
+- **客观验证**：service delivery/read + delta sync contracts
 - **来源**：源计划 M2
-- **状态**：IMPLEMENTED
-- **阻塞**：clean delta-stack current-head CI / merge pending
-- **证据位置**：M2-SYNC-001 current-main task/evidence; historical PR #1994
-- **下一步**：通过 clean current-head gate 后提升 TESTED。
+- **状态**：TESTED
+- **阻塞**：无
+- **证据位置**：M2-SYNC-001 / M2-ACCEPT-001
+- **下一步**：M3 UI 正确呈现/交互这些状态。


### PR DESCRIPTION
## Project
- Project ID: `FAB-P0001`
- Project Key: `TFI`
- Stage closure: `M2`

## Objective
Synchronize the durable project record with the already-landed and current-head-verified M2 runtime implementation, then advance the authoritative project stage to M3.

## Verified landed evidence
- #2001 WebSocket/Auth/Heartbeat merge `2a4124a7b4b769be1320f88621e4eb3ad7f1a3f6`
- #2002 durable delta sync merge `d4611f9433eb4d6cbfa934c574cec1da96210edb`
- #2002 final head `b4d56161a4b409e04e9a0a0850900ac9cf3fae08`
- Messaging Product Gate `32575120937`: SUCCESS
- Mahayana fast checks `32575120857`: SUCCESS
- Fabushi self-hosted messaging `32575120877`: SUCCESS
- Repository CI `32575120874`: SUCCESS
- Project portfolio governance `32575120961`: SUCCESS
- Explicit automerge `32575120853`: SUCCESS
- canonical-main readback confirmed M2 runtime/test artifacts and corrected idempotency logic

## Project updates
- add `M2-ACCEPT-001` task and evidence index
- M2.T01-T09 -> TESTED
- M2 milestone -> TESTED
- M3 milestone -> IN_PROGRESS
- PROJECT current_stage -> M3
- resolve M2 dependencies/blockers
- synchronize status, acceptance matrix and changelog

## Scope
Documentation/governance closure only. No runtime code change. M3 product implementation continues in `feat/telegram-m3-desktop-ux` and must pass its own typecheck/Playwright/current-head gates.