### PR TITLE
feat(messenger): complete M3 desktop interaction gaps

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -39,6 +39,56 @@ async function openMessenger(page: Page): Promise<void> {
   await expect(page.getByTitle('聊天')).toBeVisible();
 }
 
+async function getMessagingIdentity(page: Page): Promise<{ actorId: string; deviceId: string; sessionId: string }> {
+  return page.evaluate(async () => {
+    const bridge = (window as unknown as {
+      fabushiNative: {
+        invoke<T>(method: string, params?: Record<string, unknown>): Promise<T>;
+      };
+    }).fabushiNative;
+    return bridge.invoke<{ actorId: string; deviceId: string; sessionId: string }>('getMessagingIdentity', {
+      deviceId: 'desktop:e2e-unread',
+      sessionId: `messenger-e2e:${Date.now()}`,
+    });
+  });
+}
+
+async function executeMessagingCommand(
+  page: Page,
+  actorId: string,
+  command: Record<string, unknown>,
+  suffix: string,
+): Promise<void> {
+  await page.evaluate(
+    async ({ actorId: envelopeActorId, command: envelopeCommand, suffix: requestSuffix }) => {
+      const bridge = (window as unknown as {
+        mahayana: {
+          invoke<T>(method: string, params?: Record<string, unknown>): Promise<T>;
+        };
+      }).mahayana;
+      const requestId = `messaging-e2e-${requestSuffix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      await bridge.invoke('feature.execute', {
+        command: {
+          type: 'messaging.execute',
+          requestId,
+          envelope: {
+            protocolVersion: 2,
+            context: {
+              requestId,
+              deviceId: `e2e:${envelopeActorId}`,
+              actorId: envelopeActorId,
+              sessionId: `e2e:${envelopeActorId}`,
+              sentAtMs: Date.now(),
+            },
+            command: envelopeCommand,
+          },
+        },
+      });
+    },
+    { actorId, command, suffix },
+  );
+}
+
 test('desktop Messenger exposes Telegram-class navigation and preserves the real AI Host', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-e2e-'));
   const app = await launchDesktopApp(appDataDir);
@@ -230,6 +280,94 @@ test('desktop Messenger persists per-peer drafts and performs real in-conversati
 
     await search.fill('绝对不存在的会话内搜索结果-20260822');
     await expect(page.getByTestId('message-search-empty')).toBeVisible();
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});
+
+test('desktop Messenger projects unread from another self-hosted actor and consumes it on open', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-unread-e2e-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    await openMessenger(page);
+
+    const identity = await getMessagingIdentity(page);
+    const now = Date.now();
+    const peerActorId = `human:e2e:unread:${now}`;
+    const conversationId = `direct:e2e-unread-${now}`;
+    const permissions = {
+      canSendMessages: true,
+      canSendMedia: true,
+      canSendPolls: true,
+      canAddMembers: true,
+      canPinMessages: true,
+      canManageTopics: true,
+      canManageCalls: true,
+    };
+
+    await executeMessagingCommand(page, peerActorId, {
+      type: 'upsertProfile',
+      actor: {
+        id: peerActorId,
+        kind: 'human',
+        displayName: 'Unread E2E Peer',
+        capabilities: ['messages'],
+        presence: { status: 'online', lastSeenAtMs: now },
+        verified: false,
+      },
+    }, 'peer-profile');
+
+    await executeMessagingCommand(page, identity.actorId, {
+      type: 'createConversation',
+      conversation: {
+        id: conversationId,
+        kind: 'direct',
+        title: 'Unread E2E Conversation',
+        participants: [
+          { actorId: identity.actorId, role: 'owner', joinedAtMs: now },
+          { actorId: peerActorId, role: 'member', joinedAtMs: now },
+        ],
+        ownerId: identity.actorId,
+        unreadCount: 0,
+        mentionCount: 0,
+        pinnedMessageIds: [],
+        notificationSettings: { showPreview: true, notifyMentions: true },
+        permissions,
+        historyVisibility: 'allMembers',
+        topics: [],
+        folderIds: [],
+        archived: false,
+        pinned: false,
+        markedUnread: false,
+        createdAtMs: now,
+        updatedAtMs: now,
+      },
+    }, 'conversation');
+
+    const incomingText = `unread-e2e-${now}`;
+    await executeMessagingCommand(page, peerActorId, {
+      type: 'sendMessage',
+      conversationId,
+      clientMessageId: `e2e:${now}`,
+      content: { type: 'text', data: { text: { text: incomingText, entities: [] } } },
+      replyToMessageId: null,
+      threadRootMessageId: null,
+      scheduledAtMs: null,
+      silent: false,
+      protectedContent: false,
+    }, 'incoming-message');
+
+    const peer = page.getByTestId(`peer-selfhosted:${conversationId}`);
+    await expect(peer).toBeVisible({ timeout: 15_000 });
+    await expect(peer.locator('b')).toHaveText('1');
+
+    await peer.click();
+    await expect(page.getByText(incomingText, { exact: true })).toBeVisible();
+    await expect(peer.locator('b')).toHaveCount(0, { timeout: 15_000 });
   } finally {
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -196,3 +196,42 @@ test('installed Mini App opens from the unified Messenger surface', async () => 
     await rm(appDataDir, { recursive: true, force: true });
   }
 });
+
+test('desktop Messenger persists per-peer drafts and performs real in-conversation search', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-draft-search-e2e-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    await openMessenger(page);
+
+    const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+    await assistant.click();
+    const input = page.getByTestId('messenger-input');
+    const draft = '每个会话独立保存的草稿';
+    await input.fill(draft);
+
+    await page.reload();
+    await completeBrowserLogin(page);
+    await openMessenger(page);
+    await page.getByTestId('peer-legacy:conversation:codex:agent:assistant').click();
+    await expect(page.getByTestId('messenger-input')).toHaveValue(draft);
+
+    const marker = `会话搜索唯一标记-${Date.now()}`;
+    await page.getByTestId('messenger-input').fill(marker);
+    await page.getByTestId('messenger-send').click();
+    await expect(page.getByText(marker, { exact: true })).toBeVisible();
+
+    await page.getByTitle('搜索当前会话').click();
+    const search = page.getByTestId('conversation-search-input');
+    await search.fill(marker);
+    await expect(page.locator('article').filter({ hasText: marker })).toHaveCount(1);
+
+    await search.fill('绝对不存在的会话内搜索结果-20260822');
+    await expect(page.getByTestId('message-search-empty')).toBeVisible();
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -145,6 +145,9 @@ type InfoTab = 'media' | 'files' | 'links';
 
 const rootSurfaceKey = 'fabushi.desktop.root-surface.v2';
 const messengerSettingsKey = 'fabushi.desktop.messenger-settings.v2';
+const messengerDraftsKey = 'fabushi.desktop.messenger-drafts.v2';
+const initialPeerRenderCount = 120;
+const initialMessageRenderCount = 240;
 const defaultMiniApps = [
   { id: 'global-dharma', title: '全球法布施', description: '任务、日志与部署' },
   { id: 'faliu-flashcards', title: '法流记忆卡', description: '经文牌组与复习' },
@@ -329,14 +332,19 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
   const [activePeerKey, setActivePeerKey] = useState<string | null>(null);
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [composer, setComposer] = useState('');
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [replyTo, setReplyTo] = useState<DisplayMessage | null>(null);
   const [silentSend, setSilentSend] = useState(false);
   const [scheduledAtMs, setScheduledAtMs] = useState<number | undefined>();
   const [search, setSearch] = useState('');
   const [conversationSearchOpen, setConversationSearchOpen] = useState(false);
+  const [conversationSearch, setConversationSearch] = useState('');
+  const [peerRenderCount, setPeerRenderCount] = useState(initialPeerRenderCount);
+  const [messageRenderCount, setMessageRenderCount] = useState(initialMessageRenderCount);
   const [infoOpen, setInfoOpen] = useState(true);
   const [infoTab, setInfoTab] = useState<InfoTab>('media');
   const [pendingSend, setPendingSend] = useState(false);
+  const [typingByConversation, setTypingByConversation] = useState<Record<string, Record<string, number>>>({});
   const [newDialog, setNewDialog] = useState<NewDialog>(null);
   const [messageMenu, setMessageMenu] = useState<MessageMenu>(null);
   const [forwardDialog, setForwardDialog] = useState<ForwardDialogState>(null);
@@ -352,6 +360,9 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
   const [pinnedPeerKeys, setPinnedPeerKeys] = useState<Set<string>>(() => new Set());
   const [archivedPeerKeys, setArchivedPeerKeys] = useState<Set<string>>(() => new Set());
   const activePeerKeyRef = useRef<string | null>(null);
+  const messagingCursorRef = useRef<string | null>(null);
+  const syncInFlightRef = useRef(false);
+  const typingStopTimerRef = useRef<number | null>(null);
   const peersRef = useRef<PeerItem[]>([]);
   const webRtcRef = useRef<FabushiWebRtcController | null>(null);
   const localVideoRef = useRef<HTMLVideoElement>(null);
@@ -363,6 +374,30 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
 
   useEffect(() => {
     activePeerKeyRef.current = activePeerKey;
+  }, [activePeerKey]);
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(window.localStorage.getItem(messengerDraftsKey) || '{}') as Record<string, unknown>;
+      setDrafts(Object.fromEntries(Object.entries(stored).filter((entry): entry is [string, string] => typeof entry[1] === 'string')));
+    } catch {
+      setDrafts({});
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(messengerDraftsKey, JSON.stringify(drafts));
+    } catch {
+      // Draft persistence is best-effort and must never block messaging.
+    }
+  }, [drafts]);
+
+  useEffect(() => {
+    if (!activePeerKey) return;
+    setComposer(drafts[activePeerKey] ?? '');
+    setConversationSearch('');
+    setMessageRenderCount(initialMessageRenderCount);
   }, [activePeerKey]);
 
   useEffect(() => {
@@ -475,6 +510,27 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
     };
   }, [transport, selfHosted]);
 
+  useEffect(() => {
+    if (!hostReady) return;
+    const timer = window.setInterval(() => {
+      const now = Date.now();
+      setTypingByConversation((current) => {
+        const next: Record<string, Record<string, number>> = {};
+        for (const [conversationId, actors] of Object.entries(current)) {
+          const active = Object.fromEntries(Object.entries(actors).filter(([, expiresAt]) => expiresAt > now));
+          if (Object.keys(active).length) next[conversationId] = active;
+        }
+        return next;
+      });
+      if (syncInFlightRef.current) return;
+      syncInFlightRef.current = true;
+      void selfHosted.sync(1000, messagingCursorRef.current)
+        .catch(() => {})
+        .finally(() => { syncInFlightRef.current = false; });
+    }, 2_000);
+    return () => window.clearInterval(timer);
+  }, [hostReady, selfHosted]);
+
   function nextRequestId(prefix: string): string {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   }
@@ -522,6 +578,7 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
   function handleSelfHostedEvent(runtimeEvent: RuntimeEvent): boolean {
     const hostEvent = asMessagingHostEvent(runtimeEvent);
     if (!hostEvent) return false;
+    if (hostEvent.envelope.cursor) messagingCursorRef.current = hostEvent.envelope.cursor;
     const event = hostEvent.envelope.event;
     switch (event.type) {
       case 'syncBatch': {
@@ -592,6 +649,20 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
       case 'actorChanged': {
         const actor = (event as unknown as { actor: MessagingActor }).actor;
         setSelfActors((current) => upsertById(current, actor));
+        break;
+      }
+      case 'typingChanged': {
+        const payload = event as unknown as { conversationId: string; actorId: string; action?: string | null; expiresAtMs?: number | null };
+        if (payload.actorId === selfHosted.actorId) break;
+        setTypingByConversation((current) => {
+          const actors = { ...(current[payload.conversationId] ?? {}) };
+          if (payload.action && (payload.expiresAtMs ?? 0) > Date.now()) actors[payload.actorId] = payload.expiresAtMs!;
+          else delete actors[payload.actorId];
+          const next = { ...current };
+          if (Object.keys(actors).length) next[payload.conversationId] = actors;
+          else delete next[payload.conversationId];
+          return next;
+        });
         break;
       }
       case 'storyChanged': {
@@ -809,15 +880,55 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
 
   peersRef.current = peers;
   const activePeer = peers.find((peer) => peer.key === activePeerKey) ?? null;
+  const activeTypingActors = activePeer?.source === 'selfhosted' && activePeer.conversationId
+    ? Object.keys(typingByConversation[activePeer.conversationId] ?? {})
+    : [];
   const visiblePeers = peers.filter((peer) => {
     if (['chats', 'contacts', 'bots', 'groups', 'channels', 'saved', 'archive'].includes(section) && !matchesSection(peer, section)) return false;
     const query = search.trim().toLowerCase();
     return !query || `${peer.title} ${peer.subtitle}`.toLowerCase().includes(query);
   });
   const sectionIsPeerList = ['chats', 'contacts', 'bots', 'groups', 'channels', 'saved', 'archive'].includes(section);
+  const renderedPeers = visiblePeers.slice(0, peerRenderCount);
+  const conversationQuery = conversationSearch.trim().toLowerCase();
+  const matchingMessages = conversationQuery
+    ? messages.filter((message) => message.text.toLowerCase().includes(conversationQuery))
+    : messages;
+  const renderedMessages = matchingMessages.slice(Math.max(0, matchingMessages.length - messageRenderCount));
+
+  useEffect(() => {
+    setPeerRenderCount(initialPeerRenderCount);
+  }, [section, search]);
+
+  function updateComposer(value: string) {
+    setComposer(value);
+    const activeKey = activePeerKeyRef.current;
+    if (!activeKey) return;
+    if (activeKey.startsWith('selfhosted:')) {
+      const conversationId = activeKey.slice('selfhosted:'.length);
+      if (typingStopTimerRef.current) window.clearTimeout(typingStopTimerRef.current);
+      if (value.trim()) {
+        void selfHosted.startTyping(conversationId).catch(() => {});
+        typingStopTimerRef.current = window.setTimeout(() => {
+          void selfHosted.stopTyping(conversationId).catch(() => {});
+        }, 3_000);
+      } else {
+        void selfHosted.stopTyping(conversationId).catch(() => {});
+      }
+    }
+    setDrafts((current) => {
+      const next = { ...current };
+      if (value) next[activePeerKeyRef.current!] = value;
+      else delete next[activePeerKeyRef.current!];
+      return next;
+    });
+  }
 
   async function openPeer(peer: PeerItem) {
     setActivePeerKey(peer.key);
+    setComposer(drafts[peer.key] ?? '');
+    setConversationSearch('');
+    setMessageRenderCount(initialMessageRenderCount);
     setReplyTo(null);
     setError(null);
     setConversationSearchOpen(false);
@@ -852,7 +963,7 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
     const text = composer.trim();
     if (!text || !activePeer || pendingSend) return;
     setPendingSend(true);
-    setComposer('');
+    updateComposer('');
     try {
       if (activePeer.source === 'selfhosted' && activePeer.conversationId) {
         await selfHosted.sendText(activePeer.conversationId, text, {
@@ -874,7 +985,7 @@ function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
       setReplyTo(null);
       setScheduledAtMs(undefined);
     } catch (cause) {
-      setComposer(text);
+      updateComposer(text);
       setPendingSend(false);
       setError(cause instanceof Error ? cause.message : String(cause));
     }
@@ -1404,7 +1515,7 @@ async function saveInvoiceDialog() {
               <button type="button" onClick={() => setNewDialog({ type: 'group', name: '', selectedBotIds: new Set() })}><Users size={17} /><span>新建群组</span></button>
               <button type="button" onClick={() => setNewDialog({ type: 'channel', name: '', description: '' })}><Radio size={17} /><span>新建频道</span></button>
             </div>
-            {visiblePeers.map((peer) => (
+            {renderedPeers.map((peer) => (
               <button data-testid={`peer-${peer.key}`} key={peer.key} type="button" className={peer.key === activePeerKey ? styles.peerActive : styles.peer} onClick={() => void openPeer(peer)}>
                 <span className={styles.avatar}>{peer.avatar ? <img src={peer.avatar} alt="" /> : avatarText(peer.title)}<i data-kind={peer.kind} /></span>
                 <span className={styles.peerCopy}>
@@ -1414,6 +1525,7 @@ async function saveInvoiceDialog() {
                 <span className={styles.peerMeta}>{peer.pinned ? <Pin size={12} /> : null}{mutedPeerKeys.has(peer.key) ? <BellOff size={12} /> : null}{peer.unread ? <b>{peer.unread}</b> : null}</span>
               </button>
             ))}
+            {visiblePeers.length > renderedPeers.length ? <button type="button" data-testid="peer-list-load-more" onClick={() => setPeerRenderCount((count) => count + initialPeerRenderCount)}>显示更多会话</button> : null}
             {!visiblePeers.length ? <EmptyList section={section} /> : null}
           </div>
         ) : (
@@ -1427,7 +1539,7 @@ async function saveInvoiceDialog() {
             <header className={styles.chatHeader}>
               <div className={styles.chatIdentity}>
                 <span className={styles.avatar}>{avatarText(activePeer.title)}<i data-kind={activePeer.kind} /></span>
-                <div><strong>{activePeer.title}</strong><small>{activePeer.subtitle}{hostReady ? ' · 在线' : ' · 正在连接'}</small></div>
+                <div><strong>{activePeer.title}</strong><small data-testid="conversation-status">{activeTypingActors.length ? '正在输入…' : `${activePeer.subtitle}${hostReady ? ' · 在线' : ' · 正在连接'}`}</small></div>
               </div>
               <div className={styles.headerActions}>
                 <button type="button" title="语音通话" onClick={() => void startCall('voice')}><PhoneCall size={18} /></button>
@@ -1439,11 +1551,12 @@ async function saveInvoiceDialog() {
                 <button type="button" title="资料" data-active={infoOpen} onClick={() => setInfoOpen((value) => !value)}><MoreVertical size={18} /></button>
               </div>
             </header>
-            {conversationSearchOpen ? <label className={styles.inChatSearch}><Search size={15} /><input placeholder="在当前会话中搜索" autoFocus /><button type="button" onClick={() => setConversationSearchOpen(false)}><X size={14} /></button></label> : null}
+            {conversationSearchOpen ? <label className={styles.inChatSearch}><Search size={15} /><input data-testid="conversation-search-input" value={conversationSearch} onChange={(event) => { setConversationSearch(event.target.value); setMessageRenderCount(initialMessageRenderCount); }} placeholder="在当前会话中搜索" autoFocus /><button type="button" onClick={() => { setConversationSearch(''); setConversationSearchOpen(false); }}><X size={14} /></button></label> : null}
             {error ? <div className={styles.errorBanner} role="alert"><span>{error}</span><button type="button" onClick={() => setError(null)}><X size={14} /></button></div> : null}
             <div className={styles.messageArea}>
               <div className={styles.dayDivider}>今天</div>
-              {messages.map((message) => (
+              {matchingMessages.length > renderedMessages.length ? <button type="button" data-testid="message-list-load-earlier" onClick={() => setMessageRenderCount((count) => count + initialMessageRenderCount)}>加载更早消息</button> : null}
+              {renderedMessages.map((message) => (
                 <article
                   key={`${message.source}:${message.id}`}
                   className={message.role === 'me' ? styles.messageMine : styles.messagePeer}
@@ -1462,7 +1575,7 @@ async function saveInvoiceDialog() {
                   <small>{formatTime(message.createdAtMs)} {message.role === 'me' ? <Check size={12} /> : null}</small>
                 </article>
               ))}
-              {!messages.length ? <div className={styles.chatEmpty}><span className={styles.avatarLarge}>{avatarText(activePeer.title)}</span><strong>{activePeer.title}</strong><p>联系人、AI Bot、群组和频道使用同一个 Fabushi 消息产品层。</p></div> : null}
+              {!matchingMessages.length ? <div className={styles.chatEmpty} data-testid="message-search-empty"><span className={styles.avatarLarge}>{avatarText(activePeer.title)}</span><strong>{conversationQuery ? '没有匹配消息' : activePeer.title}</strong><p>{conversationQuery ? '换一个关键词继续搜索。' : '联系人、AI Bot、群组和频道使用同一个 Fabushi 消息产品层。'}</p></div> : null}
             </div>
             {replyTo ? <div className={extra.composerBanner}><Reply size={15} /><div><strong>回复</strong><span>{replyTo.text}</span></div><button type="button" onClick={() => setReplyTo(null)}><X size={14} /></button></div> : null}
             {scheduledAtMs ? <div className={extra.composerBanner}><span>⏱</span><div><strong>定时发送</strong><span>{new Date(scheduledAtMs).toLocaleString()}</span></div><button type="button" onClick={() => setScheduledAtMs(undefined)}><X size={14} /></button></div> : null}
@@ -1478,7 +1591,7 @@ async function saveInvoiceDialog() {
               <input ref={mediaInputRef} type="file" accept="image/*,video/*" hidden onChange={(event) => { const file = event.currentTarget.files?.[0]; event.currentTarget.value = ''; if (file) void sendAttachmentFile(file); }} />
               <input ref={fileInputRef} type="file" hidden onChange={(event) => { const file = event.currentTarget.files?.[0]; event.currentTarget.value = ''; if (file) void sendAttachmentFile(file); }} />
               {attachmentProgress ? <span className={extra.uploadProgress}>{attachmentProgress}</span> : null}
-              <textarea data-testid="messenger-input" value={composer} onChange={(event) => setComposer(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); event.currentTarget.form?.requestSubmit(); } }} placeholder="消息" rows={1} />
+              <textarea data-testid="messenger-input" value={composer} onChange={(event) => updateComposer(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); event.currentTarget.form?.requestSubmit(); } }} placeholder="消息" rows={1} />
               <button type="button" title="表情"><Smile size={20} /></button>
               <button type="button" data-active={silentSend} title={silentSend ? '关闭静默发送' : '静默发送'} onClick={() => setSilentSend((value) => !value)}><BellOff size={19} /></button>
               {composer.trim() ? <button data-testid="messenger-send" className={styles.sendButton} type="submit" disabled={!hostReady || pendingSend}><Send size={19} /></button> : <button type="button" title="语音消息"><Mic size={20} /></button>}

--- a/desktop/src/selfhosted-messaging-client-v2.ts
+++ b/desktop/src/selfhosted-messaging-client-v2.ts
@@ -466,8 +466,16 @@ export class SelfHostedMessagingClientV2 {
     });
   }
 
-  async sync(limit = 1000): Promise<void> {
-    await this.execute({ type: 'sync', cursor: null, limit });
+  async sync(limit = 1000, cursor: string | null = null): Promise<void> {
+    await this.execute({ type: 'sync', cursor, limit });
+  }
+
+  startTyping(conversationId: string, action = 'typing'): Promise<void> {
+    return this.execute({ type: 'startTyping', conversationId, action });
+  }
+
+  stopTyping(conversationId: string): Promise<void> {
+    return this.execute({ type: 'stopTyping', conversationId });
   }
 
   async createConversation(kind: ConversationKind, title: string, description = '', participantActorIds: string[] = []): Promise<MessagingConversation> {

--- a/native/mahayana-messaging/src/service.rs
+++ b/native/mahayana-messaging/src/service.rs
@@ -17,6 +17,8 @@ use std::collections::BTreeSet;
 use std::fmt::Write as _;
 use thiserror::Error;
 
+const TYPING_TTL_MS: i64 = 5_000;
+
 #[derive(Debug, Error)]
 pub enum MessagingServiceError {
     #[error("unsupported messaging protocol version {actual}; expected {expected}")]
@@ -173,6 +175,19 @@ impl<S: MessagingStateStore> MessagingService<S> {
                 self.mark_direct_messages_delivered(&actor_id, server_time_ms)?;
                 self.sync_response(&actor_id, cursor.as_deref(), limit, server_time_ms)
             }
+            ClientCommand::StartTyping {
+                conversation_id,
+                action,
+            } => self.typing_event(
+                &actor_id,
+                conversation_id,
+                Some(action),
+                Some(server_time_ms.saturating_add(TYPING_TTL_MS)),
+                server_time_ms,
+            ),
+            ClientCommand::StopTyping { conversation_id } => {
+                self.typing_event(&actor_id, conversation_id, None, None, server_time_ms)
+            }
             command => {
                 if let Some(replay) =
                     self.idempotent_send_replay(&actor_id, &command, server_time_ms)?
@@ -217,6 +232,50 @@ impl<S: MessagingStateStore> MessagingService<S> {
                 Ok(responses)
             }
         }
+    }
+
+    fn typing_event(
+        &mut self,
+        actor_id: &ActorId,
+        conversation_id: ConversationId,
+        action: Option<String>,
+        expires_at_ms: Option<i64>,
+        server_time_ms: i64,
+    ) -> Result<Vec<ServerEnvelope>, MessagingServiceError> {
+        let conversation = self
+            .engine
+            .state()
+            .conversations
+            .get(&conversation_id)
+            .ok_or_else(|| {
+                MessagingServiceError::UnauthorizedCommand(
+                    "typing conversation does not exist".into(),
+                )
+            })?;
+        if !conversation
+            .participants
+            .iter()
+            .any(|participant| &participant.actor_id == actor_id)
+        {
+            return Err(MessagingServiceError::UnauthorizedCommand(
+                "typing requires conversation membership".into(),
+            ));
+        }
+        self.cursor = self.cursor.saturating_add(1);
+        let response = ServerEnvelope {
+            protocol_version: FABUSHI_MESSAGING_PROTOCOL_VERSION,
+            cursor: Some(self.cursor.to_string()),
+            server_time_ms,
+            event: ServerEvent::TypingChanged {
+                conversation_id,
+                actor_id: actor_id.clone(),
+                action,
+                expires_at_ms,
+            },
+        };
+        let journal = self.journal_entries(actor_id, std::slice::from_ref(&response));
+        self.persist_with_events(server_time_ms, &journal)?;
+        Ok(vec![response])
     }
 
     fn idempotent_send_replay(
@@ -541,6 +600,13 @@ impl<S: MessagingStateStore> MessagingService<S> {
             .entries
             .into_iter()
             .filter(|entry| entry.audience.iter().any(|candidate| candidate == actor_id))
+            .filter(|entry| match &entry.envelope.event {
+                ServerEvent::TypingChanged {
+                    expires_at_ms: Some(expires_at_ms),
+                    ..
+                } => *expires_at_ms > server_time_ms,
+                _ => true,
+            })
             .map(|entry| entry.envelope)
             .collect::<Vec<_>>();
         responses.push(self.sync_checkpoint_envelope(slice.checkpoint_cursor, server_time_ms));

--- a/native/mahayana-messaging/tests/typing_contract.rs
+++ b/native/mahayana-messaging/tests/typing_contract.rs
@@ -1,0 +1,173 @@
+use fabushi_messaging_core::*;
+
+fn context(actor_id: &str, request: &str) -> RequestContext {
+    RequestContext {
+        request_id: request.into(),
+        device_id: format!("device:{actor_id}"),
+        actor_id: ActorId::new(actor_id),
+        session_id: format!("session:{actor_id}"),
+        sent_at_ms: 1,
+    }
+}
+
+fn direct_conversation() -> Conversation {
+    Conversation::direct(
+        "chat:typing",
+        "Typing",
+        vec![
+            Participant {
+                actor_id: ActorId::new("human:a"),
+                role: ParticipantRole::Owner,
+                joined_at_ms: 1,
+                muted_until_ms: None,
+            },
+            Participant {
+                actor_id: ActorId::new("human:b"),
+                role: ParticipantRole::Member,
+                joined_at_ms: 1,
+                muted_until_ms: None,
+            },
+        ],
+        1,
+    )
+}
+
+#[test]
+fn typing_is_audience_scoped_and_expires_from_delta_replay() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).unwrap();
+    for actor in ["human:a", "human:b", "human:outsider"] {
+        service
+            .handle(
+                ClientEnvelope::new(
+                    context(actor, "profile"),
+                    ClientCommand::UpsertProfile {
+                        actor: Actor::human(actor, actor),
+                    },
+                ),
+                1,
+            )
+            .unwrap();
+    }
+    service
+        .handle(
+            ClientEnvelope::new(
+                context("human:a", "conversation"),
+                ClientCommand::CreateConversation {
+                    conversation: direct_conversation(),
+                },
+            ),
+            2,
+        )
+        .unwrap();
+    let before = service.cursor();
+    let start = service
+        .handle(
+            ClientEnvelope::new(
+                context("human:a", "typing"),
+                ClientCommand::StartTyping {
+                    conversation_id: ConversationId::new("chat:typing"),
+                    action: "typing".into(),
+                },
+            ),
+            100,
+        )
+        .unwrap();
+    assert!(
+        matches!(&start[0].event, ServerEvent::TypingChanged { actor_id, action: Some(action), expires_at_ms: Some(5100), .. } if actor_id == &ActorId::new("human:a") && action == "typing")
+    );
+
+    let recipient = service
+        .handle(
+            ClientEnvelope::new(
+                context("human:b", "sync-b"),
+                ClientCommand::Sync {
+                    cursor: Some(before.to_string()),
+                    limit: 100,
+                },
+            ),
+            200,
+        )
+        .unwrap();
+    assert!(recipient.iter().any(|event| matches!(&event.event, ServerEvent::TypingChanged { actor_id, action: Some(_), .. } if actor_id == &ActorId::new("human:a"))));
+
+    let outsider = service
+        .handle(
+            ClientEnvelope::new(
+                context("human:outsider", "sync-o"),
+                ClientCommand::Sync {
+                    cursor: Some(before.to_string()),
+                    limit: 100,
+                },
+            ),
+            200,
+        )
+        .unwrap();
+    assert!(!outsider
+        .iter()
+        .any(|event| matches!(event.event, ServerEvent::TypingChanged { .. })));
+
+    let expired = service
+        .handle(
+            ClientEnvelope::new(
+                context("human:b", "sync-expired"),
+                ClientCommand::Sync {
+                    cursor: Some(before.to_string()),
+                    limit: 100,
+                },
+            ),
+            6_000,
+        )
+        .unwrap();
+    assert!(!expired.iter().any(|event| matches!(
+        event.event,
+        ServerEvent::TypingChanged {
+            action: Some(_),
+            ..
+        }
+    )));
+}
+
+#[test]
+fn non_member_cannot_publish_typing_state() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).unwrap();
+    for actor in ["human:a", "human:b", "human:outsider"] {
+        service
+            .handle(
+                ClientEnvelope::new(
+                    context(actor, "profile"),
+                    ClientCommand::UpsertProfile {
+                        actor: Actor::human(actor, actor),
+                    },
+                ),
+                1,
+            )
+            .unwrap();
+    }
+    service
+        .handle(
+            ClientEnvelope::new(
+                context("human:a", "conversation"),
+                ClientCommand::CreateConversation {
+                    conversation: direct_conversation(),
+                },
+            ),
+            2,
+        )
+        .unwrap();
+    let error = service
+        .handle(
+            ClientEnvelope::new(
+                context("human:outsider", "typing"),
+                ClientCommand::StartTyping {
+                    conversation_id: ConversationId::new("chat:typing"),
+                    action: "typing".into(),
+                },
+            ),
+            100,
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        MessagingServiceError::UnauthorizedCommand(_)
+    ));
+}

--- a/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-001/README.md
@@ -1,0 +1,50 @@
+# M3-DESKTOP-001 evidence index
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Stage**: `M3`
+- **Status**: `IMPLEMENTED / CURRENT-HEAD CI PENDING`
+
+## Desktop implementation
+
+- `desktop/src/messaging-shell-v2.tsx`
+  - bounded peer render window: 120 rows per batch;
+  - bounded message render window: latest 240 per batch with explicit older-message expansion;
+  - controlled in-conversation search with real message filtering and no-match state;
+  - per-peer draft persistence through `fabushi.desktop.messenger-drafts.v2`;
+  - cursor-aware incremental sync poll;
+  - recipient-visible typing status with expiry cleanup.
+- `desktop/src/selfhosted-messaging-client-v2.ts`
+  - cursor-aware `sync`;
+  - Protocol v2 `startTyping` / `stopTyping` commands.
+
+## Rust typing semantics
+
+- `native/mahayana-messaging/src/service.rs`
+  - `StartTyping` and `StopTyping` become audience-scoped `TypingChanged` events;
+  - 5-second TTL on active typing;
+  - conversation-membership authorization;
+  - expired active typing events filtered from delta replay.
+- `native/mahayana-messaging/tests/typing_contract.rs`
+  - recipient receives active typing;
+  - outsider cannot observe typing delta;
+  - expired typing is not replayed;
+  - non-member cannot publish typing state.
+
+## Playwright evidence added
+
+`desktop/e2e/messenger.spec.ts` adds a real renderer lifecycle flow:
+
+1. open known Messenger peer;
+2. write draft;
+3. reload renderer using the same app data;
+4. reopen same peer and verify draft restored;
+5. send unique marker message;
+6. in-conversation search finds exactly that message;
+7. impossible query shows no-match state.
+
+Existing Messenger Playwright coverage continues to verify navigation, self-hosted channel creation, reaction/edit/pin/delete/invoice, group Bot collaboration and Mini App opening.
+
+## Completion gate
+
+Do not promote M3 to TESTED/E2E_VERIFIED until current-head Rust tests/Clippy, Electron Messenger typecheck, Messenger Playwright, protected merge and canonical-main verification pass. M3.T07 unread also requires an explicit desktop E2E assertion before stage closure.

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-001-messenger-complete-ux.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-001-messenger-complete-ux.md
@@ -1,0 +1,59 @@
+# M3-DESKTOP-001 — Desktop Messenger complete interaction
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M3-DESKTOP-001`
+- **Stage**: `M3 桌面聊天完整交互`
+- **WBS**: `M3.T01`–`M3.T09`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-22`
+- **Depends on**: M2-SYNC-001 / PR #2002
+
+## Objective
+
+Close the real desktop-chat gaps on the canonical Electron Messenger V2 and prove the existing Telegram-parity interaction surface with Playwright, without introducing a second desktop messaging state machine.
+
+## Live implementation audit
+
+Already implemented in `desktop/src/messaging-shell-v2.tsx` / `desktop/e2e/messenger.spec.ts` and therefore primarily needs acceptance expansion rather than reimplementation:
+
+- navigation rail + peer list + chat workspace + info panel;
+- global peer/contact/Bot search;
+- pinned/muted/archive conversation controls;
+- new groups/channels and saved messages;
+- reply/forward/edit/delete;
+- reaction/pin message;
+- attachments/polls/location/scheduled/silent send;
+- self-hosted payments/Mini Apps/story entry points;
+- real Bot collaboration group flow.
+
+## Confirmed product gaps
+
+1. **M3.T03 message-list virtualization/windowing**: current UI renders the entire `messages` array with `messages.map`.
+2. **M3.T07 in-conversation search**: the current search bar is visual-only; it has no query state/filter/highlight behavior.
+3. **M3.T08 draft persistence**: composer state is one global React string and is not persisted/restored per conversation.
+4. **M3.T09 typing semantics**: Protocol v2 defines `StartTyping`, `StopTyping`, and `TypingChanged`, but desktop client/service do not currently complete the end-to-end path.
+5. **M3.T02 high-count peer list**: current peer list maps all visible peers; use lightweight windowing so large contact/channel lists do not render unbounded rows.
+6. Existing M3.T01/T04/T05/T06 flows need explicit Playwright assertions before promotion to `TESTED`/`E2E_VERIFIED`.
+
+## Acceptance criteria
+
+- Peer/message lists cap rendered rows while preserving access to recent/current items.
+- Current-conversation search filters matching visible messages and can be cleared without mutating the underlying message state.
+- Draft text is stored per peer key and restored when switching back or reopening the workspace; successful send clears that peer draft; failed send restores it.
+- Self-hosted composer emits Protocol v2 start/stop typing signals with bounded expiry; recipient-visible typing state is represented by `TypingChanged` and never becomes permanent message history.
+- Existing reply/forward/edit/delete/reaction/pin/search/navigation flows have deterministic Playwright coverage.
+- Messaging Product Gate typecheck and Rust product tests pass; desktop E2E relevant to Messenger passes in GitHub Actions.
+- Final branch is rebased/retargeted onto landed M2 and merged through protected main before M3 closes.
+
+## Expected code scope
+
+- `desktop/src/messaging-shell-v2.tsx`
+- `desktop/src/selfhosted-messaging-client-v2.ts`
+- `desktop/e2e/messenger.spec.ts`
+- canonical Rust service/protocol code only where typing semantics require server support
+- M3 WBS/evidence/status records
+
+## Completion rule
+
+Code existence is insufficient. M3 remains `IN_PROGRESS` until final-head CI, Messenger Playwright evidence, protected merge, and canonical-main readback exist.

--- a/projects/telegram-fabushi-integration/management/wbs/M3.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M3.md
@@ -1,101 +1,91 @@
 # WBS 原子任务 — M3 桌面聊天完整交互
 
 ### M3.T01 — 会话列表
-
-- **交付物**：会话列表
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：统一 peer/conversation list
+- **验收标准**：人、Bot、群、频道在同一 Messenger surface 可导航
+- **客观验证**：existing Messenger Playwright navigation + bounded peer rendering
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：final-head Playwright/CI pending
+- **证据位置**：M3-DESKTOP-001; `desktop/e2e/messenger.spec.ts`
+- **下一步**：GitHub E2E 后提升 TESTED。
 
 ### M3.T02 — 消息虚拟列表
-
-- **交付物**：消息虚拟列表
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：有界 message/peer windowing
+- **验收标准**：大列表不无界渲染；可显式加载更多 peer/更早消息
+- **客观验证**：`initialPeerRenderCount=120`, `initialMessageRenderCount=240`, load-more controls + typecheck
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：current-head typecheck/CI pending
+- **证据位置**：`desktop/src/messaging-shell-v2.tsx`
+- **下一步**：final gate。
 
 ### M3.T03 — 回复/编辑/删除/转发
-
-- **交付物**：回复/编辑/删除/转发
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：reply/edit/delete/forward
+- **验收标准**：mutation flows 在桌面可执行并反映 canonical state
+- **客观验证**：existing Messenger Playwright channel mutation flow
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：final-head Playwright evidence pending
+- **证据位置**：`desktop/e2e/messenger.spec.ts`
+- **下一步**：E2E 后提升 TESTED。
 
 ### M3.T04 — 草稿
-
-- **交付物**：草稿
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：per-peer persistent draft
+- **验收标准**：按 peer 独立保存；reload/switch 恢复；send 清理；失败恢复
+- **客观验证**：localStorage `fabushi.desktop.messenger-drafts.v2` + new Playwright reload contract
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：Playwright pending
+- **证据位置**：M3-DESKTOP-001; Messenger source/E2E
+- **下一步**：current-head E2E。
 
 ### M3.T05 — 置顶/静音
-
-- **交付物**：置顶/静音
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：pin/mute/archive controls
+- **验收标准**：设置可修改并持久化
+- **客观验证**：existing Messenger Playwright + `messenger-settings.v2`
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：final E2E evidence pending
+- **证据位置**：Messenger source/E2E
+- **下一步**：current-head E2E。
 
 ### M3.T06 — 搜索
-
-- **交付物**：搜索
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：global peer search + in-conversation message search
+- **验收标准**：当前会话搜索真实过滤消息并提供无匹配空态
+- **客观验证**：`conversation-search-input`; `message-search-empty`; new Playwright unique-marker search
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：Playwright pending
+- **证据位置**：Messenger source/E2E
+- **下一步**：current-head E2E。
 
 ### M3.T07 — unread
-
-- **交付物**：unread
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：unread projection / read consumption
+- **验收标准**：peer unread count 能由 Host/self-hosted projection 展示；打开/MarkRead 后与 M2 Read 语义一致
+- **客观验证**：existing `unreadCount` projection + M2 delivery/read contracts
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：desktop-specific unread Playwright assertion pending
+- **证据位置**：Messenger/client source; M2-ACCEPT-001
+- **下一步**：补 E2E assertion 后关闭。
 
 ### M3.T08 — typing
-
-- **交付物**：typing
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：Protocol v2 typing end-to-end
+- **验收标准**：member 可发 start/stop；non-member 拒绝；5 秒 expiry；recipient delta 可见；过期不重放；UI 显示正在输入
+- **客观验证**：`typing_contract.rs`; service/client/shell current-head tests/typecheck
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **状态**：IMPLEMENTED
+- **阻塞**：GitHub Rust tests/typecheck pending
+- **证据位置**：M3-DESKTOP-001; `native/mahayana-messaging/tests/typing_contract.rs`
+- **下一步**：Messaging Product Gate。
 
 ### M3.T09 — reaction 基础
-
-- **交付物**：reaction 基础
-- **验收标准**：桌面端日常 IM 能力可完整使用；Playwright 覆盖核心流程
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **交付物**：reaction + pin basic interaction
+- **验收标准**：桌面可 reaction/pin 并看到更新
+- **客观验证**：existing channel mutation Playwright flow
 - **来源**：源计划 M3
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
-
+- **状态**：IMPLEMENTED
+- **阻塞**：final-head E2E evidence pending
+- **证据位置**：`desktop/e2e/messenger.spec.ts`
+- **下一步**：E2E 后提升 TESTED。


### PR DESCRIPTION
## Project
- Project ID: `FAB-P0001`
- Project Key: `TFI`
- Stage: `M3`
- Task: `M3-DESKTOP-001`

## Objective
Close the real desktop Messenger interaction gaps on top of the tested M2 realtime core, while preserving one canonical Rust messaging state machine.

## Product changes
- bounded peer rendering (120 rows/batch)
- bounded recent-message rendering (240 rows/batch + load earlier)
- real in-conversation message search and no-match state
- per-peer persistent drafts, restore across renderer reload/switch, clear on successful send and restore on send failure
- cursor-aware incremental self-hosted sync
- Protocol v2 start/stop typing end-to-end
- audience-scoped typing journal events with 5s TTL and expired-event replay filtering
- non-member typing authorization rejection
- recipient-visible `正在输入…` UI

## Tests
- new Rust `typing_contract.rs`: recipient visibility, outsider isolation, expiry filtering, non-member denial
- new Messenger Playwright lifecycle: draft persistence across reload + real in-conversation search
- existing Messenger Playwright continues navigation, channel mutation, reaction/edit/pin/delete, Bot collaboration group and Mini App coverage

## Clean stack
Branch was rebuilt directly from M2 closure main `f6f6060129cee2c33bd075ee04874c30e99e79ea`; no historical M2 stacked commits remain.

## Completion gate
Current-head Messaging Product Gate/Rust tests/Clippy/Electron typecheck + explicit Messenger Playwright + protected merge + canonical-main verification. M3 remains IN_PROGRESS until all evidence is bound.