### PR TITLE
[automerge-force] ci(tfi): add one-time M3 unread patch driver

### DIFF
--- a/.github/workflows/fab-p0001-m3-unread-patch-driver.yml
+++ b/.github/workflows/fab-p0001-m3-unread-patch-driver.yml
@@ -1,0 +1,449 @@
+name: FAB-P0001 M3 unread patch driver
+
+on:
+  workflow_run:
+    workflows:
+      - Electron desktop quality gate
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_branch == 'fix/fab-p0001-m3-e2e-closure' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: fix/fab-p0001-m3-e2e-closure
+          fetch-depth: 1
+      - name: Apply exact actor-scoped unread patch
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          engine = Path('native/mahayana-messaging/src/engine.rs')
+          if 'pub read_cursors: BTreeMap<ConversationId, BTreeMap<ActorId, MessageId>>' in engine.read_text():
+              print('actor-scoped unread patch is already present; nothing to change')
+              raise SystemExit(0)
+
+          def replace_once(path: str, old: str, new: str) -> None:
+              p = Path(path)
+              text = p.read_text()
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f'{path}: expected exactly one match, got {count}')
+              p.write_text(text.replace(old, new, 1))
+
+          replace_once(
+              'native/mahayana-messaging/src/engine.rs',
+              '''    pub conversations: BTreeMap<ConversationId, Conversation>,
+    pub folders: BTreeMap<String, ConversationFolder>,
+    pub messages: BTreeMap<ConversationId, BTreeMap<MessageId, Message>>,
+''',
+              '''    pub conversations: BTreeMap<ConversationId, Conversation>,
+    pub folders: BTreeMap<String, ConversationFolder>,
+    pub messages: BTreeMap<ConversationId, BTreeMap<MessageId, Message>>,
+    pub read_cursors: BTreeMap<ConversationId, BTreeMap<ActorId, MessageId>>,
+''',
+          )
+
+          replace_once(
+              'native/mahayana-messaging/src/engine.rs',
+              '''            Event::ConversationRead {
+                conversation_id,
+                message_id,
+                ..
+            } => {
+                if let Some(conversation) = self.state.conversations.get_mut(&conversation_id) {
+                    conversation.last_read_message_id = Some(message_id.0);
+                    conversation.unread_count = 0;
+                    conversation.marked_unread = false;
+                }
+            }
+''',
+              '''            Event::ConversationRead {
+                conversation_id,
+                actor_id,
+                message_id,
+            } => {
+                self.state
+                    .read_cursors
+                    .entry(conversation_id.clone())
+                    .or_default()
+                    .insert(actor_id, message_id.clone());
+                // Keep legacy snapshot fields coherent for older readers. Actor-specific
+                // clients receive the authoritative read state from the projected sync view.
+                if let Some(conversation) = self.state.conversations.get_mut(&conversation_id) {
+                    conversation.last_read_message_id = Some(message_id.0);
+                    conversation.unread_count = 0;
+                    conversation.marked_unread = false;
+                }
+            }
+''',
+          )
+
+          replace_once(
+              'native/mahayana-messaging/src/service.rs',
+              'use crate::conversation::{ConversationId, ConversationKind};\n',
+              'use crate::conversation::{Conversation, ConversationId, ConversationKind};\n',
+          )
+
+          replace_once(
+              'native/mahayana-messaging/src/service.rs',
+              '''    fn sync_envelope(&self, actor_id: &ActorId, limit: u32, server_time_ms: i64) -> ServerEnvelope {
+''',
+              '''    fn project_conversation_for_actor(
+        &self,
+        actor_id: &ActorId,
+        conversation: &Conversation,
+        server_time_ms: i64,
+    ) -> Conversation {
+        let state = self.engine.state();
+        let mut projected = conversation.clone();
+        let last_read = state
+            .read_cursors
+            .get(&conversation.id)
+            .and_then(|cursors| cursors.get(actor_id));
+        projected.last_read_message_id = last_read.map(|message_id| message_id.0.clone());
+
+        let mut ordered_messages = state
+            .messages
+            .get(&conversation.id)
+            .into_iter()
+            .flat_map(|messages| messages.values())
+            .collect::<Vec<_>>();
+        ordered_messages.sort_by(|left, right| {
+            left.created_at_ms
+                .cmp(&right.created_at_ms)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        let read_index = last_read
+            .and_then(|message_id| ordered_messages.iter().position(|message| &message.id == message_id));
+        let unread = ordered_messages
+            .iter()
+            .enumerate()
+            .filter(|(index, message)| {
+                let after_read = match read_index {
+                    Some(read_index) => *index > read_index,
+                    None => true,
+                };
+                let scheduled_is_visible = match message.scheduled_at_ms {
+                    Some(scheduled_at_ms) => scheduled_at_ms <= server_time_ms,
+                    None => true,
+                };
+                after_read
+                    && scheduled_is_visible
+                    && !message.deleted
+                    && &message.sender_id != actor_id
+            })
+            .count();
+        projected.unread_count = u32::try_from(unread).unwrap_or(u32::MAX);
+        projected
+    }
+
+    fn sync_envelope(&self, actor_id: &ActorId, limit: u32, server_time_ms: i64) -> ServerEnvelope {
+''',
+          )
+
+          replace_once(
+              'native/mahayana-messaging/src/service.rs',
+              '''                conversations: visible_conversation_ids
+                    .iter()
+                    .filter_map(|id| state.conversations.get(id))
+                    .take(max_items)
+                    .cloned()
+                    .collect(),
+''',
+              '''                conversations: visible_conversation_ids
+                    .iter()
+                    .filter_map(|id| state.conversations.get(id))
+                    .take(max_items)
+                    .map(|conversation| {
+                        self.project_conversation_for_actor(actor_id, conversation, server_time_ms)
+                    })
+                    .collect(),
+''',
+          )
+
+          replace_once(
+              'desktop/src/messaging-shell-v2.tsx',
+              '''      case 'conversationChanged': {
+        const conversation = (event as unknown as { conversation: MessagingConversation }).conversation;
+        setSelfConversations((current) => upsertById(current, conversation));
+        break;
+      }
+''',
+              '''      case 'conversationChanged': {
+        const conversation = (event as unknown as { conversation: MessagingConversation }).conversation;
+        setSelfConversations((current) => {
+          const existing = current.find((item) => item.id === conversation.id);
+          return upsertById(current, existing
+            ? {
+                ...conversation,
+                lastReadMessageId: existing.lastReadMessageId,
+                unreadCount: existing.unreadCount,
+                markedUnread: existing.markedUnread,
+              }
+            : conversation);
+        });
+        break;
+      }
+''',
+          )
+
+          replace_once(
+              'desktop/src/messaging-shell-v2.tsx',
+              '''      case 'messageAdded':
+      case 'messageChanged': {
+        const message = (event as unknown as { message: MessagingMessage }).message;
+        setSelfMessages((current) => {
+          const list = upsertById(current[message.conversationId] ?? [], message)
+            .sort((a, b) => a.createdAtMs - b.createdAtMs);
+          const next = { ...current, [message.conversationId]: list };
+          if (activePeerKeyRef.current === `selfhosted:${message.conversationId}`) {
+            setMessages(list.filter((item) => !item.deleted).map(displaySelfMessage));
+          }
+          return next;
+        });
+        setPendingSend(false);
+        break;
+      }
+      case 'messagesDeleted': {
+''',
+              '''      case 'messageAdded':
+      case 'messageChanged': {
+        const message = (event as unknown as { message: MessagingMessage }).message;
+        const isActiveConversation = activePeerKeyRef.current === `selfhosted:${message.conversationId}`;
+        const isIncoming = message.senderId !== selfHosted.actorId;
+        setSelfMessages((current) => {
+          const list = upsertById(current[message.conversationId] ?? [], message)
+            .sort((a, b) => a.createdAtMs - b.createdAtMs);
+          const next = { ...current, [message.conversationId]: list };
+          if (isActiveConversation) {
+            setMessages(list.filter((item) => !item.deleted).map(displaySelfMessage));
+          }
+          return next;
+        });
+        if (event.type === 'messageAdded') {
+          setSelfConversations((current) => current.map((conversation) => conversation.id === message.conversationId
+            ? {
+                ...conversation,
+                lastMessageId: message.id,
+                updatedAtMs: Math.max(conversation.updatedAtMs, message.createdAtMs),
+                unreadCount: isIncoming && !isActiveConversation
+                  ? conversation.unreadCount + 1
+                  : conversation.unreadCount,
+              }
+            : conversation));
+          if (isIncoming && isActiveConversation) {
+            void selfHosted.markRead(message.conversationId, message.id).catch(() => {});
+          }
+        }
+        setPendingSend(false);
+        break;
+      }
+      case 'readChanged': {
+        const payload = event as unknown as { conversationId: string; actorId: string; messageId: string };
+        if (payload.actorId === selfHosted.actorId) {
+          setSelfConversations((current) => current.map((conversation) => conversation.id === payload.conversationId
+            ? {
+                ...conversation,
+                lastReadMessageId: payload.messageId,
+                unreadCount: 0,
+                markedUnread: false,
+              }
+            : conversation));
+        }
+        break;
+      }
+      case 'messagesDeleted': {
+''',
+          )
+
+          Path('native/mahayana-messaging/tests/unread_projection_contract.rs').write_text(r'''use fabushi_messaging_core::*;
+
+fn context(actor_id: &str, request_id: &str) -> RequestContext {
+    RequestContext {
+        request_id: request_id.into(),
+        device_id: format!("device:{actor_id}"),
+        actor_id: ActorId::new(actor_id),
+        session_id: format!("session:{actor_id}"),
+        sent_at_ms: 1,
+    }
+}
+
+fn handle(
+    service: &mut MessagingService<MemoryStateStore>,
+    actor_id: &str,
+    request_id: &str,
+    command: ClientCommand,
+    now_ms: i64,
+) -> Vec<ServerEnvelope> {
+    service
+        .handle(
+            ClientEnvelope::new(context(actor_id, request_id), command),
+            now_ms,
+        )
+        .unwrap()
+}
+
+fn synced_conversation(
+    service: &mut MessagingService<MemoryStateStore>,
+    actor_id: &str,
+    conversation_id: &str,
+    now_ms: i64,
+) -> Conversation {
+    handle(
+        service,
+        actor_id,
+        "sync",
+        ClientCommand::Sync {
+            cursor: None,
+            limit: 100,
+        },
+        now_ms,
+    )
+    .into_iter()
+    .find_map(|envelope| match envelope.event {
+        ServerEvent::SyncBatch { conversations, .. } => conversations
+            .into_iter()
+            .find(|conversation| conversation.id == ConversationId::new(conversation_id)),
+        _ => None,
+    })
+    .expect("conversation should be visible in actor sync")
+}
+
+#[test]
+fn unread_projection_is_actor_scoped_and_read_cursor_survives_reload() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).unwrap();
+    let me = ActorId::new("human:me");
+    let peer = ActorId::new("human:peer");
+    let conversation_id = "direct:unread-contract";
+
+    handle(
+        &mut service,
+        "human:me",
+        "profile-me",
+        ClientCommand::UpsertProfile {
+            actor: Actor::human("human:me", "Me"),
+        },
+        1,
+    );
+    handle(
+        &mut service,
+        "human:peer",
+        "profile-peer",
+        ClientCommand::UpsertProfile {
+            actor: Actor::human("human:peer", "Peer"),
+        },
+        2,
+    );
+    handle(
+        &mut service,
+        "human:me",
+        "conversation",
+        ClientCommand::CreateConversation {
+            conversation: Conversation::direct(
+                conversation_id,
+                "Unread contract",
+                vec![
+                    Participant {
+                        actor_id: me.clone(),
+                        role: ParticipantRole::Owner,
+                        joined_at_ms: 3,
+                        muted_until_ms: None,
+                    },
+                    Participant {
+                        actor_id: peer.clone(),
+                        role: ParticipantRole::Member,
+                        joined_at_ms: 3,
+                        muted_until_ms: None,
+                    },
+                ],
+                3,
+            ),
+        },
+        3,
+    );
+
+    let incoming = handle(
+        &mut service,
+        "human:peer",
+        "send-1",
+        ClientCommand::SendMessage {
+            conversation_id: ConversationId::new(conversation_id),
+            client_message_id: ClientMessageId("client:unread:1".into()),
+            content: MessageContent::Text {
+                text: FormattedText::plain("first unread"),
+            },
+            reply_to_message_id: None,
+            thread_root_message_id: None,
+            scheduled_at_ms: None,
+            silent: false,
+            protected_content: false,
+        },
+        4,
+    );
+    let first_message_id = incoming
+        .iter()
+        .find_map(|envelope| match &envelope.event {
+            ServerEvent::MessageAdded { message } => Some(message.id.clone()),
+            _ => None,
+        })
+        .expect("send should emit MessageAdded");
+
+    let my_projection = synced_conversation(&mut service, "human:me", conversation_id, 5);
+    assert_eq!(my_projection.unread_count, 1);
+    assert_eq!(my_projection.last_read_message_id, None);
+
+    let peer_projection = synced_conversation(&mut service, "human:peer", conversation_id, 6);
+    assert_eq!(peer_projection.unread_count, 0);
+
+    handle(
+        &mut service,
+        "human:me",
+        "read-1",
+        ClientCommand::MarkRead {
+            conversation_id: ConversationId::new(conversation_id),
+            message_id: first_message_id.clone(),
+        },
+        7,
+    );
+    let my_projection = synced_conversation(&mut service, "human:me", conversation_id, 8);
+    assert_eq!(my_projection.unread_count, 0);
+    assert_eq!(
+        my_projection.last_read_message_id.as_deref(),
+        Some(first_message_id.0.as_str())
+    );
+
+    let store = service.into_store();
+    let mut restored = MessagingService::load(store).unwrap();
+    let restored_projection = synced_conversation(&mut restored, "human:me", conversation_id, 9);
+    assert_eq!(restored_projection.unread_count, 0);
+    assert_eq!(
+        restored_projection.last_read_message_id.as_deref(),
+        Some(first_message_id.0.as_str())
+    );
+}
+''')
+          PY
+      - name: Commit patch back to the M3 branch
+        shell: bash
+        run: |
+          if git diff --quiet -- native/mahayana-messaging/src/engine.rs native/mahayana-messaging/src/service.rs desktop/src/messaging-shell-v2.tsx native/mahayana-messaging/tests/unread_projection_contract.rs; then
+            echo "No patch required."
+            exit 0
+          fi
+          git config user.name "fabushi-ci"
+          git config user.email "fabushi-ci@users.noreply.github.com"
+          git add native/mahayana-messaging/src/engine.rs native/mahayana-messaging/src/service.rs desktop/src/messaging-shell-v2.tsx native/mahayana-messaging/tests/unread_projection_contract.rs
+          git commit -m "fix(tfi): make unread projection actor scoped"
+          git push origin HEAD:fix/fab-p0001-m3-e2e-closure


### PR DESCRIPTION
FAB-P0001 recovery utility for PR #2022 only. It runs from trusted main after the Electron desktop quality gate fails on the exact same-repo branch `fix/fab-p0001-m3-e2e-closure`, applies exact text replacements for actor-scoped unread semantics, adds a Rust contract test, and pushes the patch back to that branch. It does not execute PR code. This workflow will be removed immediately after the patch lands.