### PR TITLE
feat(gbf): land M6 reliability observability on clean stack

### DIFF
--- a/.github/scripts/assert-gbf-canonical-data-model.py
+++ b/.github/scripts/assert-gbf-canonical-data-model.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+root=Path('.')
+data=json.loads((root/'projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json').read_text())
+for name,target in data['models'].items():
+    path=target.split('::',1)[0]
+    if not (root/path).exists(): raise SystemExit(f'GBF canonical model missing {name}: {path}')
+for path in data['forbiddenParallelAuthorities']:
+    if (root/path).exists(): raise SystemExit(f'GBF parallel authority returned: {path}')
+print(f"GBF canonical data model passed: {len(data['models'])} authorities, zero Grok parallel authorities.")

--- a/.github/scripts/assert-gbf-canonical-data-model.py
+++ b/.github/scripts/assert-gbf-canonical-data-model.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
-from pathlib import Path
+import subprocess
 
-root = Path('.')
+
+def tracked(path: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "HEAD", "--", path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
 
 # Keep the executable CI contract self-contained because the Electron Feature
-# Host job intentionally uses a narrow sparse checkout. The matching JSON file
-# under projects/.../evidence/GBF-601 remains the human/audit representation of
-# this same authority map.
+# Host job intentionally uses a narrow sparse checkout. Existence is checked
+# against the Git commit tree rather than the materialized worktree, so the gate
+# remains exact even when an authority is intentionally not checked out.
 models = {
     "sessionLifecycle": "third_party/mahayana/mahayana-rs/mahayana-kernel/src/resilience.rs::SessionRegistry",
     "operationLifecycle": "third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs::operations",
@@ -20,16 +29,16 @@ models = {
 }
 
 for name, target in models.items():
-    path = target.split('::', 1)[0]
-    if not (root / path).exists():
-        raise SystemExit(f'GBF canonical model missing {name}: {path}')
+    path = target.split("::", 1)[0]
+    if not tracked(path):
+        raise SystemExit(f"GBF canonical model missing {name}: {path}")
 
 for path in (
     "frontend/apps/web/src/lib/grok-agent",
     "frontend/apps/web/src/lib/grok-bot",
     "vendor/grok-bot-0.20.0",
 ):
-    if (root / path).exists():
-        raise SystemExit(f'GBF parallel authority returned: {path}')
+    if tracked(path):
+        raise SystemExit(f"GBF parallel authority returned: {path}")
 
 print(f"GBF canonical data model passed: {len(models)} authorities, zero Grok parallel authorities.")

--- a/.github/scripts/assert-gbf-canonical-data-model.py
+++ b/.github/scripts/assert-gbf-canonical-data-model.py
@@ -1,11 +1,35 @@
 #!/usr/bin/env python3
-import json
 from pathlib import Path
-root=Path('.')
-data=json.loads((root/'projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json').read_text())
-for name,target in data['models'].items():
-    path=target.split('::',1)[0]
-    if not (root/path).exists(): raise SystemExit(f'GBF canonical model missing {name}: {path}')
-for path in data['forbiddenParallelAuthorities']:
-    if (root/path).exists(): raise SystemExit(f'GBF parallel authority returned: {path}')
-print(f"GBF canonical data model passed: {len(data['models'])} authorities, zero Grok parallel authorities.")
+
+root = Path('.')
+
+# Keep the executable CI contract self-contained because the Electron Feature
+# Host job intentionally uses a narrow sparse checkout. The matching JSON file
+# under projects/.../evidence/GBF-601 remains the human/audit representation of
+# this same authority map.
+models = {
+    "sessionLifecycle": "third_party/mahayana/mahayana-rs/mahayana-kernel/src/resilience.rs::SessionRegistry",
+    "operationLifecycle": "third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs::operations",
+    "hostContract": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::FeatureCommand/HostEvent",
+    "agentRuntime": "third_party/mahayana/mahayana-rs/mahayana-runtime/src/lib.rs::MahayanaRuntime",
+    "computerTarget": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ComputerControlTarget",
+    "rendererHostEdge": "desktop/electron/mahayana-edge.cjs::MAHAYANA_EDGE",
+    "nativeCapabilityEdge": "desktop/electron/native-edge.cjs::NATIVE_EDGE",
+    "conversation": "third_party/mahayana/mahayana-rs/mahayana-conversation/src/lib.rs",
+    "permissions": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ProductHostSettings",
+}
+
+for name, target in models.items():
+    path = target.split('::', 1)[0]
+    if not (root / path).exists():
+        raise SystemExit(f'GBF canonical model missing {name}: {path}')
+
+for path in (
+    "frontend/apps/web/src/lib/grok-agent",
+    "frontend/apps/web/src/lib/grok-bot",
+    "vendor/grok-bot-0.20.0",
+):
+    if (root / path).exists():
+        raise SystemExit(f'GBF parallel authority returned: {path}')
+
+print(f"GBF canonical data model passed: {len(models)} authorities, zero Grok parallel authorities.")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
                 /^\.github\/workflows\//,
               ],
               electron: [
-                /^\.github\/scripts\/(assert-electron-feature-host-bridge\.sh|assert-feature-command-router-coverage\.py|assert-fabushi-desktop-architecture\.py|assert-gbf-runtime-convergence\.py)$/,
+                /^\.github\/scripts\/(assert-electron-feature-host-bridge\.sh|assert-feature-command-router-coverage\.py|assert-fabushi-desktop-architecture\.py|assert-gbf-runtime-convergence\.py|assert-gbf-canonical-data-model\.py)$/,
                 /^desktop\/electron\//,
                 /^desktop\/src\//,
                 /^frontend\/apps\/host\//,
@@ -384,6 +384,7 @@ jobs:
             /.github/scripts/assert-feature-command-router-coverage.py
             /.github/scripts/assert-fabushi-desktop-architecture.py
             /.github/scripts/assert-gbf-runtime-convergence.py
+            /.github/scripts/assert-gbf-canonical-data-model.py
             /.github/scripts/assert-native-capability-semantics.py
             /.github/scripts/assert-auth-entry-flow.py
             /.github/scripts/assert-bot-mark-motion.py
@@ -420,6 +421,8 @@ jobs:
         run: python3 .github/scripts/assert-fabushi-desktop-architecture.py
       - name: Verify single Mahayana Agent Tool runtime
         run: python3 .github/scripts/assert-gbf-runtime-convergence.py
+      - name: Verify canonical Grok fusion data authorities
+        run: python3 .github/scripts/assert-gbf-canonical-data-model.py
       - name: Verify native desktop edge parity
         run: python3 .github/scripts/assert-native-desktop-edge-parity.py
       - name: Verify browser-first account login
@@ -432,6 +435,8 @@ jobs:
         run: python3 .github/scripts/assert-native-capability-semantics.py
       - name: Verify Electron edge, host lifecycle, and offline ASR contracts
         run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
+      - name: Enforce Electron edge performance budget
+        run: node desktop/electron/edge-ipc.bench.cjs
       - name: Verify Electron to Rust Feature Host bridge
         shell: bash
         run: bash .github/scripts/assert-electron-feature-host-bridge.sh

--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          # Keep CI deterministic. Advance this pin only in a PR that proves the
+          # full Mahayana clippy/test matrix on all three desktop runner families.
+          toolchain: 1.97.1
           components: clippy, rustfmt
       - name: Install Linux native capture/input dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "third_party/mahayana"
       - "third_party/mahayana/**"
+      - ".github/workflows/ci_codex_sync.yml"
   pull_request:
     branches: ["main", "develop"]
     paths:
       - "third_party/mahayana"
       - "third_party/mahayana/**"
+      - ".github/workflows/ci_codex_sync.yml"
 
 jobs:
   test-mahayana-runtime:

--- a/desktop/electron/edge-ipc.bench.cjs
+++ b/desktop/electron/edge-ipc.bench.cjs
@@ -1,0 +1,23 @@
+"use strict";
+const { performance } = require('node:perf_hooks');
+const { callChannel, createRendererEdge, defineEdge, serveMainEdge } = require('./edge-ipc.cjs');
+
+const ITERATIONS = Number(process.env.GBF_EDGE_BENCH_ITERATIONS || 20000);
+const MAX_AVERAGE_MICROS = Number(process.env.GBF_EDGE_MAX_AVERAGE_MICROS || 500);
+const handlers = new Map();
+const ipcMain = { handle: (channel, fn) => handlers.set(channel, fn), removeHandler: (channel) => handlers.delete(channel) };
+const edge = defineEdge('bench', { ping: { args: 'none' } });
+serveMainEdge(ipcMain, edge, { ping: async () => 1 });
+const ipcRenderer = { invoke: (channel, args) => handlers.get(channel)({}, args), on() {}, off() {} };
+const client = createRendererEdge(ipcRenderer, edge);
+
+(async () => {
+  for (let i = 0; i < 100; i += 1) await client.ping();
+  const started = performance.now();
+  for (let i = 0; i < ITERATIONS; i += 1) await client.ping();
+  const elapsedMs = performance.now() - started;
+  const averageMicros = elapsedMs * 1000 / ITERATIONS;
+  const result = { iterations: ITERATIONS, elapsedMs: Number(elapsedMs.toFixed(3)), averageMicros: Number(averageMicros.toFixed(3)), budgetMicros: MAX_AVERAGE_MICROS };
+  console.log(JSON.stringify(result));
+  if (averageMicros > MAX_AVERAGE_MICROS) process.exitCode = 1;
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/desktop/electron/edge-ipc.cjs
+++ b/desktop/electron/edge-ipc.cjs
@@ -3,6 +3,7 @@
 const BRIDGE_MISSING_HANDLER = 'bridge/missing-handler';
 const BRIDGE_INVOKE_FAILED = 'bridge/invoke-failed';
 const BRIDGE_UNTRUSTED_SENDER = 'bridge/untrusted-sender';
+let invocationSequence = 0;
 
 function callChannel(edge, method) {
   return `fabushi-edge:${edge}:call:${method}`;
@@ -87,21 +88,40 @@ function createRendererEdge(ipcRenderer, edge) {
 
 function serveMainEdge(ipcMain, edge, handlers, options = {}) {
   const registered = [];
+  const now = options.now ?? Date.now;
+  const nextCorrelationId = options.nextCorrelationId ?? (() => `${edge.edge}-${now().toString(36)}-${(++invocationSequence).toString(36)}`);
+  const trace = (method, correlationId, startedAt, status, code = null) => {
+    options.onInvocation?.(Object.freeze({
+      edge: edge.edge,
+      method,
+      correlationId,
+      status,
+      code,
+      durationMs: Math.max(0, now() - startedAt),
+    }));
+  };
   for (const method of Object.keys(edge.methods)) {
     const channel = callChannel(edge.edge, method);
     registered.push(channel);
     ipcMain.handle(channel, async (event, args) => {
+      const startedAt = now();
+      const correlationId = nextCorrelationId();
       if (options.isTrustedSender && !options.isTrustedSender(event)) {
+        trace(method, correlationId, startedAt, 'denied', BRIDGE_UNTRUSTED_SENDER);
         return { ok: false, failure: { code: BRIDGE_UNTRUSTED_SENDER, detail: 'IPC sender is not trusted.' } };
       }
       const handler = handlers[method];
       if (typeof handler !== 'function') {
+        trace(method, correlationId, startedAt, 'failed', BRIDGE_MISSING_HANDLER);
         return { ok: false, failure: { code: BRIDGE_MISSING_HANDLER, detail: `No handler for ${method}.` } };
       }
       try {
-        return { ok: true, value: await handler(args ?? {}, event) };
+        const value = await handler(args ?? {}, event);
+        trace(method, correlationId, startedAt, 'ok');
+        return { ok: true, value };
       } catch (error) {
         options.onHandlerError?.(method, error);
+        trace(method, correlationId, startedAt, 'failed', BRIDGE_INVOKE_FAILED);
         return { ok: false, failure: failure(BRIDGE_INVOKE_FAILED, error) };
       }
     });

--- a/desktop/electron/edge-ipc.test.cjs
+++ b/desktop/electron/edge-ipc.test.cjs
@@ -125,3 +125,22 @@ test('renderer subscriptions are scoped to declared events and can be disposed i
   dispose();
   assert.deepEqual(renderer.listeners.get(channel), []);
 });
+
+
+test('structured invocation traces contain correlation/status/duration but never args or results', async () => {
+  const edge = defineEdge('trace', { echo: { args: 'object' } });
+  const ipcMain = fakeIpcMain();
+  const traces = [];
+  let now = 100;
+  serveMainEdge(ipcMain, edge, { echo: async ({ secret }) => ({ secret, token: 'result-token' }) }, {
+    now: () => now += 5,
+    nextCorrelationId: () => 'corr-1',
+    onInvocation: (record) => traces.push(record),
+  });
+  const reply = await ipcMain.handlers.get(callChannel('trace', 'echo'))({}, { secret: 'input-secret' });
+  assert.equal(reply.ok, true);
+  assert.deepEqual(traces, [{ edge: 'trace', method: 'echo', correlationId: 'corr-1', status: 'ok', code: null, durationMs: 5 }]);
+  const serialized = JSON.stringify(traces);
+  assert.equal(serialized.includes('input-secret'), false);
+  assert.equal(serialized.includes('result-token'), false);
+});

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -427,6 +427,12 @@ function broadcastNativeEvent(eventName, payload) {
   }
 }
 
+function logEdgeInvocation(record) {
+  // Deliberately exclude args/results/URLs/tokens. This record is safe to retain as
+  // operational telemetry and gives renderer -> edge correlation without secrets.
+  console.info(JSON.stringify({ type: 'fabushi.edge.invoke', ...record }));
+}
+
 function installNativeEdge() {
   const handlers = {
     async openExternal(params) {
@@ -601,6 +607,7 @@ function installNativeEdge() {
 
   nativeEdgeServer = serveMainEdge(ipcMain, NATIVE_EDGE, handlers, {
     isTrustedSender,
+    onInvocation: logEdgeInvocation,
     onHandlerError(method, error) {
       console.error(`[native-edge] ${method} failed`, error);
     },
@@ -617,6 +624,7 @@ function installMahayanaEdge() {
 
   mahayanaEdgeServer = serveMainEdge(ipcMain, MAHAYANA_EDGE, handlers, {
     isTrustedSender,
+    onInvocation: logEdgeInvocation,
     onHandlerError(method, error) {
       console.error(`[mahayana-edge] ${method} failed`, error);
     },

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-601/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-601/README.md
@@ -1,0 +1,3 @@
+# GBF-601 Evidence
+
+`canonical-data-model.json` declares 9 product authorities and CI verifies every path exists while retired Grok parallel authorities remain absent.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "models": {
+    "sessionLifecycle": "third_party/mahayana/mahayana-rs/mahayana-kernel/src/resilience.rs::SessionRegistry",
+    "operationLifecycle": "third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs::operations",
+    "hostContract": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::FeatureCommand/HostEvent",
+    "agentRuntime": "third_party/mahayana/mahayana-rs/mahayana-runtime/src/lib.rs::MahayanaRuntime",
+    "computerTarget": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ComputerControlTarget",
+    "rendererHostEdge": "desktop/electron/mahayana-edge.cjs::MAHAYANA_EDGE",
+    "nativeCapabilityEdge": "desktop/electron/native-edge.cjs::NATIVE_EDGE",
+    "conversation": "third_party/mahayana/mahayana-rs/mahayana-conversation/src/lib.rs",
+    "permissions": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ProductHostSettings"
+  },
+  "forbiddenParallelAuthorities": [
+    "frontend/apps/web/src/lib/grok-agent",
+    "frontend/apps/web/src/lib/grok-bot",
+    "vendor/grok-bot-0.20.0"
+  ]
+}

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-602/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-602/README.md
@@ -1,0 +1,3 @@
+# GBF-602 Evidence
+
+Host generation/restart tests, kernel resilience fail-closed transitions, and target/session generation checks cover crash/restart without stale generation side effects.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-603/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-603/README.md
@@ -1,0 +1,3 @@
+# GBF-603 Evidence
+
+`serveMainEdge` emits structured invocation records with edge/method/correlationId/status/code/durationMs only. Unit test passes secret input/result values and proves neither appears in serialized trace.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-604/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-604/README.md
@@ -1,0 +1,3 @@
+# GBF-604 Evidence
+
+Local baseline: 20,000 in-process edge calls averaged ~3-4 microseconds on the development machine; CI budget is deliberately generous at 500 microseconds average to catch severe regressions without runner-noise flakes. `edge-ipc.bench.cjs` runs in CI and Electron Desktop workflow.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-601-canonical-data-model.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-601-canonical-data-model.md
@@ -1,0 +1,24 @@
+# GBF-601 — 固化 canonical data model 映射
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-601
+- Stage: M6
+- Objective: 固化 canonical data model 映射。
+- Requirements: GBR-002, GBR-003.
+- Dependencies: GBF-104, GBF-302.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] session/operation/host/runtime/computer/conversation/permission 每域唯一权威，0 Grok parallel authority。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+canonical mapping validator.
+
+## Evidence
+`evidence/GBF-601/`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-602-crash-restart-recovery.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-602-crash-restart-recovery.md
@@ -1,0 +1,24 @@
+# GBF-602 — 验证 crash/restart 恢复无重复副作用
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-602
+- Stage: M6
+- Objective: 验证 crash/restart 恢复无重复副作用。
+- Requirements: GBR-003, GBR-007.
+- Dependencies: GBF-304, GBF-601.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] Host generation isolation + kernel lifecycle + computer generation 共同阻止 stale side effects。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+fault/recovery tests.
+
+## Evidence
+`evidence/GBF-602/`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-603-structured-correlation-logging.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-603-structured-correlation-logging.md
@@ -1,0 +1,24 @@
+# GBF-603 — 统一 correlation/structured logging
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-603
+- Stage: M6
+- Objective: 统一 correlation/structured logging。
+- Requirements: GBR-007.
+- Dependencies: GBF-203, GBF-303.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] 每次 Electron edge invocation 记录 edge/method/correlation/status/duration，绝不记录 args/results/secret。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+edge trace contract test.
+
+## Evidence
+`evidence/GBF-603/`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-604-performance-regression-gate.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-604-performance-regression-gate.md
@@ -1,0 +1,24 @@
+# GBF-604 — 建立性能 baseline 与 regression gate
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-604
+- Stage: M6
+- Objective: 建立性能 baseline 与 regression gate。
+- Requirements: GBR-007.
+- Dependencies: GBF-207, GBF-407, GBF-504.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] edge contract benchmark 有真实运行 baseline 与明确预算；CI 超预算失败。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+Node benchmark + CI budget.
+
+## Evidence
+`evidence/GBF-604/`.


### PR DESCRIPTION
## FAB-P0004 / GBF — clean M6 landing

Rebuilt directly on canonical `main@2480fb095c7e9208a662f839b45834d800ed4f1b` after M5/#2029 merged. The branch now carries only the M6 reliability/observability delta plus the CI reproducibility fix discovered during post-M5 validation.

### M6 scope
- GBF-601 canonical data authority validator and model map
- GBF-602 crash/restart recovery evidence
- GBF-603 structured privacy-safe edge correlation/logging
- GBF-604 executable edge IPC performance benchmark and regression budget
- preserves current M4/M5 Electron workflow behavior; does not reintroduce stale stacked workflow changes

### Runtime gate stabilization
The post-M5 run proved Rama alpha dependency and Linux native-library closure, then failed only because `dtolnay/rust-toolchain@stable` advanced from Rust 1.97.x to 1.98.0 and introduced new clippy diagnostics in unchanged Mahayana code. This PR pins the canonical embedded Runtime gate to Rust `1.97.1`, keeping `cargo fmt`, `cargo clippy --locked ... -D warnings`, and tests strict while making the release gate reproducible. Toolchain upgrades must now be deliberate PRs that prove the full three-OS matrix.

### Acceptance
No RELEASED claim until current-main merge-ref CI passes, protected merge completes, post-main verification is recorded, and M8 formal release succeeds.