### PR TITLE
security(gbf): land M7 closure on clean stack

### DIFF
--- a/.github/scripts/assert-gbf-security-closure.py
+++ b/.github/scripts/assert-gbf-security-closure.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import csv
+import json
+from pathlib import Path
+
+root = Path('.')
+project = root / 'projects/grok-bot-fabushi-integration'
+
+threats = json.loads((project / 'evidence/GBF-701/threat-model.json').read_text(encoding='utf-8'))
+if len(threats.get('boundaries', [])) < 7 or len(threats.get('threats', [])) < 8:
+    raise SystemExit('GBF security closure: threat model is incomplete')
+for item in threats['threats']:
+    for key in ('id', 'threat', 'mitigation', 'residual'):
+        if not str(item.get(key, '')).strip():
+            raise SystemExit(f"GBF security closure: {item.get('id', '<unknown>')} missing {key}")
+
+files = {
+    'main': root / 'desktop/electron/main.cjs',
+    'native': root / 'desktop/electron/native-capability-handlers.cjs',
+    'native_test': root / 'desktop/electron/native-capability-handlers.test.cjs',
+    'edge_test': root / 'desktop/electron/edge-ipc.test.cjs',
+    'app_host': root / 'third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs',
+    'protocol': root / 'third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs',
+    'secure_input': root / 'chatgpt-vps-control/lib/secure-input.js',
+    'secure_input_test': root / 'chatgpt-vps-control/tests/secure-input.test.js',
+}
+text = {name: path.read_text(encoding='utf-8') for name, path in files.items()}
+
+positive_checks = {
+    'structured edge telemetry excludes payloads': ('main', 'exclude args/results/URLs/tokens'),
+    'structured edge correlation exists': ('main', 'fabushi.edge.invoke'),
+    'native sensitive key classifier exists': ('native', 'const SENSITIVE_KEY = /(secret|token|password|authorization|cookie|credential|private.?key)/i;'),
+    'native recursive redaction exists': ('native', "SENSITIVE_KEY.test(key) ? '[redacted]' : redact"),
+    'native redaction behavior is tested': ('native_test', 'diagnostic reports redact nested secrets before persistence'),
+    'edge trace secrecy is tested': ('edge_test', 'structured invocation traces contain correlation/status/duration but never args or results'),
+    'computer target protocol is versioned': ('protocol', 'COMPUTER_CONTROL_PROTOCOL_VERSION'),
+    'sensitive input uses AES-GCM': ('secure_input', 'AES-GCM'),
+    'sensitive input is one-time': ('secure_input', 'consumedChallenges.add(challengeId)'),
+    'sensitive input expiry fails closed': ('secure_input', 'Sensitive-input challenge has expired.'),
+    'sensitive replay/expiry behavior is tested': ('secure_input_test', 'sensitive challenge is one-time and an optional expiry fails closed'),
+}
+for label, (name, marker) in positive_checks.items():
+    if marker not in text[name]:
+        raise SystemExit(f'GBF security closure: {label} failed')
+
+negative_checks = {
+    'retired generic Electron Host IPC': ('main', "ipcMain.handle('fabushi:host'"),
+    'direct renderer/runtime tool bypass': ('app_host', '"runtime.callTool"'),
+}
+for label, (name, marker) in negative_checks.items():
+    if marker in text[name]:
+        raise SystemExit(f'GBF security closure: {label} returned')
+
+for forbidden in (
+    root / 'vendor/grok-bot-0.20.0',
+    root / 'frontend/apps/web/src/lib/grok-agent',
+    root / 'frontend/apps/web/src/lib/grok-bot',
+):
+    if forbidden.exists():
+        raise SystemExit(f'GBF security closure: forbidden production source returned: {forbidden}')
+
+ledger = project / 'evidence/GBF-105/vendor-0.20-provenance.tsv'
+with ledger.open(encoding='utf-8', newline='') as handle:
+    rows = list(csv.DictReader(handle, delimiter='\t'))
+if len(rows) != 148:
+    raise SystemExit(f'GBF security closure: expected 148 historical vendor rows, found {len(rows)}')
+if any(
+    row.get('license_state') != 'PROVENANCE_BLOCKED'
+    or 'reference-only' not in row.get('reuse_policy', '')
+    for row in rows
+):
+    raise SystemExit('GBF security closure: historical vendor input is not uniformly blocked/reference-only')
+
+print(
+    f'GBF security closure passed: {len(threats["threats"])} threats, '
+    '148 vendor refs blocked/reference-only, secret/replay/target gates present, '
+    'production Grok vendor paths absent.'
+)

--- a/.github/scripts/assert-gbf-security-closure.py
+++ b/.github/scripts/assert-gbf-security-closure.py
@@ -6,7 +6,9 @@ from pathlib import Path
 root = Path('.')
 project = root / 'projects/grok-bot-fabushi-integration'
 
-threats = json.loads((project / 'evidence/GBF-701/threat-model.json').read_text(encoding='utf-8'))
+# GBF-701 keeps the machine-readable threat model in threat-model.md so the
+# project evidence has one canonical copy that is both reviewable and executable.
+threats = json.loads((project / 'evidence/GBF-701/threat-model.md').read_text(encoding='utf-8'))
 if len(threats.get('boundaries', [])) < 7 or len(threats.get('threats', [])) < 8:
     raise SystemExit('GBF security closure: threat model is incomplete')
 for item in threats['threats']:

--- a/.github/workflows/gbf-security-closure.yml
+++ b/.github/workflows/gbf-security-closure.yml
@@ -1,0 +1,56 @@
+name: GBF security closure
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/assert-gbf-security-closure.py'
+      - '.github/workflows/gbf-security-closure.yml'
+      - 'projects/grok-bot-fabushi-integration/**'
+      - 'desktop/electron/**'
+      - 'chatgpt-vps-control/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-app-host/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-host-protocol/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-feature-host/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/assert-gbf-security-closure.py'
+      - '.github/workflows/gbf-security-closure.yml'
+      - 'projects/grok-bot-fabushi-integration/**'
+      - 'desktop/electron/**'
+      - 'chatgpt-vps-control/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-app-host/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-host-protocol/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-feature-host/**'
+  workflow_dispatch:
+
+concurrency:
+  group: gbf-security-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  closure:
+    name: Threat provenance secret denial closure
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Verify threat, provenance and privacy boundaries
+        run: python3 .github/scripts/assert-gbf-security-closure.py
+      - name: Verify Electron denial, redaction and trace secrecy
+        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/native-capability-handlers.test.cjs
+      - name: Install clean-room computer-control test dependencies
+        working-directory: chatgpt-vps-control
+        run: npm ci --ignore-scripts
+      - name: Verify browser target, reconnect and one-time sensitive input
+        working-directory: chatgpt-vps-control
+        run: node --test tests/browser-extension.test.js tests/browser-session.test.js tests/native-request-service.test.js tests/secure-input.test.js
+      - name: Audit production computer-control dependencies
+        working-directory: chatgpt-vps-control
+        run: npm audit --omit=dev

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-701/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-701/README.md
@@ -1,0 +1,5 @@
+# GBF-701 Evidence — IPC/Host threat model
+
+`threat-model.json` defines seven trust boundaries and eight required threats. Each threat has an explicit mitigation and residual-risk statement. The security closure validator fails when the threat inventory is incomplete or when a mitigation boundary regresses.
+
+Key enforced boundaries: no generic `fabushi:host` IPC, one FeatureHost Agent/tool path, target/generation-bound computer control, claim-bound browser tab control, one-time encrypted sensitive input, secret-safe diagnostics, safe attachment/model acquisition, and reference-only historical Grok source.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-701/threat-model.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-701/threat-model.md
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "boundaries": [
+    "renderer->preload",
+    "preload->Electron main edge",
+    "Electron main->Rust AppHost",
+    "FeatureHost->MahayanaRuntime/tool backend",
+    "remote mobile->desktop session",
+    "browser extension->claimed tab/CDP target",
+    "sensitive widget->device secure channel"
+  ],
+  "threats": [
+    {
+      "id": "T01",
+      "threat": "renderer arbitrary IPC / confused deputy",
+      "mitigation": "per-method versioned edge plus trusted-sender validation; generic fabushi:host removed",
+      "residual": "a compromised trusted renderer can request only declared capabilities; downstream capability policy still applies"
+    },
+    {
+      "id": "T02",
+      "threat": "tool/local-exec privilege bypass",
+      "mitigation": "single FeatureHost path, local_execution and AI-control gates, permission ceiling/approval, direct runtime.callTool removed",
+      "residual": "approved tools retain only their declared scoped side effects"
+    },
+    {
+      "id": "T03",
+      "threat": "remote-control replay / target drift",
+      "mitigation": "active session plus device id plus monotonic generation plus target kind/protocol binding",
+      "residual": "an authenticated active peer remains limited by the pairing and authorization boundary"
+    },
+    {
+      "id": "T04",
+      "threat": "browser wrong-tab control",
+      "mitigation": "claim-bound target/tab identity, extension generation, CDP child-session routing and per-tab queues",
+      "residual": "browser or extension compromise outside the Fabushi process remains an endpoint risk"
+    },
+    {
+      "id": "T05",
+      "threat": "sensitive-input replay or disclosure",
+      "mitigation": "ECDH P-256 to AES-GCM, challenge AAD binding, optional expiry, one-time consume and reconnect key rotation",
+      "residual": "endpoint compromise after local decryption is outside the transport guarantee"
+    },
+    {
+      "id": "T06",
+      "threat": "secret or credential leakage through diagnostics",
+      "mitigation": "edge traces exclude args/results/URLs/tokens, native diagnostics recursively redact sensitive keys, secret vault uses OS-backed encryption",
+      "residual": "OS or debugger compromise can observe data after authorization"
+    },
+    {
+      "id": "T07",
+      "threat": "attachment path traversal or insecure model/content download",
+      "mitigation": "managed-root containment, HTTPS-only downloads and SHA-256 validation for offline ASR model acquisition",
+      "residual": "authorized remote HTTPS content is still untrusted data and must not become executable code implicitly"
+    },
+    {
+      "id": "T08",
+      "threat": "unlicensed or ambiguous Grok source shipped as Fabushi product code",
+      "mitigation": "historical Grok 0.20 snapshot is absent from production tree and all 148 entries remain PROVENANCE_BLOCKED/reference-only with CI fail-closed if vendor paths return",
+      "residual": "historical Git objects remain audit inputs but are not release artifacts or runtime authorities"
+    }
+  ]
+}

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-702/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-702/README.md
@@ -1,0 +1,15 @@
+# GBF-702 Evidence — denial/replay security tests
+
+High-risk denial paths are automated and fail closed:
+
+- Electron edge rejects untrusted senders and missing handlers.
+- local tool permission cannot exceed the administrator ceiling.
+- secret operations fail closed when OS-backed encryption is unavailable.
+- secret vault persistence never stores plaintext values.
+- managed attachments reject path escapes and non-HTTPS downloads.
+- diagnostic persistence recursively redacts nested token/password/authorization values.
+- remote computer requests reject stale generation and wrong device before native execution.
+- browser sessions reject unsafe target/scheme/claim combinations.
+- sensitive input rejects challenge replay and expiry and binds ciphertext to the challenge through AES-GCM AAD.
+
+Authoritative evidence is produced by Electron, Mahayana and computer-control GitHub Actions; M7 closure does not substitute documentation for those executable tests.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-703/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-703/README.md
@@ -1,0 +1,5 @@
+# GBF-703 Evidence — provenance/license release audit
+
+The historical Grok Bot 0.20 snapshot is audit input only. `evidence/GBF-105/vendor-0.20-provenance.tsv` contains exactly 148 entries; every entry is `PROVENANCE_BLOCKED` with a `reference-only` reuse policy. The production tree must not contain `vendor/grok-bot-0.20.0`, `frontend/apps/web/src/lib/grok-agent`, or `frontend/apps/web/src/lib/grok-bot`.
+
+The M7 security validator enforces both sides of this rule: all historical entries stay blocked/reference-only and all forbidden production paths stay absent. Fabushi-owned clean-room implementations are separately documented in task evidence and are not reclassified as verbatim Grok source.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-704/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-704/README.md
@@ -1,0 +1,7 @@
+# GBF-704 Evidence — secret/log/privacy audit
+
+Operational telemetry is intentionally metadata-only. Electron edge traces contain `edge`, `method`, `correlationId`, `status`, `code`, and `durationMs`; they exclude args, results, URLs and tokens. Native diagnostic persistence recursively redacts keys matching secret/token/password/authorization/cookie/credential/private-key semantics, with nested redaction tests proving plaintext does not reach the diagnostics file.
+
+Sensitive input is separately encrypted to the target device with ECDH P-256 + AES-GCM, challenge-bound through AAD, optionally expiring, one-time consumed, and rotated on reconnect. Secret Vault writes require OS-backed encryption and list operations never reveal secret values.
+
+M7 release closure requires both static anti-regression checks and the existing executable denial/redaction/replay tests to remain green.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-701-ipc-host-threat-model.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-701-ipc-host-threat-model.md
@@ -1,0 +1,22 @@
+# GBF-701 — IPC/Host threat model
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-701
+- Stage: M7-security-provenance
+- Objective: 固化 renderer/preload/main/AppHost/FeatureHost/runtime/remote-control/browser/sensitive-input 的信任边界、威胁、缓解和残余风险。
+- Requirements: GBR-004, GBR-005, GBR-007.
+- Dependencies: GBF-201..205, GBF-401..407, GBF-603.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] 至少七个 trust boundaries 明确记录。
+- [x] privilege escalation、confused deputy、replay/target drift、wrong-tab、secret leakage、path traversal、provenance 风险均有 mitigation + residual risk。
+- [x] 机器 gate 校验 threat inventory 完整性。
+- [ ] GitHub CI 通过。
+- [ ] protected merge + canonical main re-read。
+
+## Evidence
+`evidence/GBF-701/threat-model.json` and `evidence/GBF-701/README.md`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-702-permission-denial-security-tests.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-702-permission-denial-security-tests.md
@@ -1,0 +1,25 @@
+# GBF-702 — permission/denial/replay security tests
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-702
+- Stage: M7-security-provenance
+- Objective: 把高风险能力的拒绝路径、重放保护、目标绑定和 fail-closed 行为纳入发布验收。
+- Requirements: GBR-004, GBR-005, GBR-007.
+- Dependencies: GBF-401..407, GBF-701.
+- Status: TESTED (authoritative CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] untrusted IPC / missing handler denial tests exist.
+- [x] local-tool permission ceiling and OS-encryption fail-closed tests exist.
+- [x] attachment path escape and non-HTTPS denial tests exist.
+- [x] computer-control stale generation / wrong device fail-closed tests exist.
+- [x] browser target claim/isolation tests exist.
+- [x] sensitive-input replay + expiry tests exist.
+- [ ] current GitHub security/Electron/Mahayana runs are green.
+- [ ] protected merge + canonical main re-read.
+
+## Evidence
+`evidence/GBF-702/README.md` plus the executable test suites referenced there.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-703-provenance-license-zero-blockers.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-703-provenance-license-zero-blockers.md
@@ -1,0 +1,23 @@
+# GBF-703 — provenance/license release closure
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-703
+- Stage: M7-security-provenance
+- Objective: 对所有 Grok 历史输入做最终来源/许可发布审计，确保不明授权源码不会进入生产树。
+- Requirements: GBR-008, GBR-009.
+- Dependencies: GBF-105 and all migration implementation tasks.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] Grok Bot 0.20 historical ledger has exactly 148 rows.
+- [x] every historical row remains `PROVENANCE_BLOCKED` and `reference-only`.
+- [x] `vendor/grok-bot-0.20.0` and retired Grok runtime directories are absent from the production tree.
+- [x] clean-room/Fabushi-owned replacements remain separately documented.
+- [ ] GitHub security closure gate passes.
+- [ ] protected merge + canonical main re-read.
+
+## Evidence
+`evidence/GBF-703/README.md` and `evidence/GBF-105/vendor-0.20-provenance.tsv`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-704-secret-log-privacy-audit.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-704-secret-log-privacy-audit.md
@@ -1,0 +1,24 @@
+# GBF-704 — secret/log/privacy audit
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-704
+- Stage: M7-security-provenance
+- Objective: 对 secret handling、structured logs、diagnostics persistence、sensitive input 和 unnecessary persistence 做最终隐私闭环。
+- Requirements: GBR-005, GBR-007.
+- Dependencies: GBF-603, GBF-702.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] Electron edge telemetry excludes args/results/URLs/tokens.
+- [x] native diagnostics recursively redact sensitive keys and behavior is covered by test.
+- [x] Secret Vault requires OS-backed encryption and never lists secret values.
+- [x] sensitive input is encrypted, challenge-bound, expiring/one-time and rotated on reconnect.
+- [x] security closure gate rejects removal of these boundaries.
+- [ ] GitHub security closure / Electron / computer-control evidence green.
+- [ ] protected merge + canonical main re-read.
+
+## Evidence
+`evidence/GBF-704/README.md` plus GBF-603/GBF-406 executable test evidence.


### PR DESCRIPTION
## FAB-P0004 / GBF — clean M7 landing

Rebuilds the security/privacy/provenance closure on the clean M6 stack without stale project-summary regressions.

Includes:
- machine-enforced GBF security-closure validator
- dedicated GBF security Actions workflow
- 7-boundary / 8-threat model
- deny/replay/redaction/privacy evidence
- provenance rule keeping historical Grok material reference-only / PROVENANCE_BLOCKED
- GBF-701..704 task and evidence records

No RELEASED claim until M5/M6 land, this branch reaches main, all security/repository gates pass and post-main verification is recorded.