### PR TITLE
[automerge-force] ci(tfi): retrigger existing FAB-P0001 M3 patch kick

### DIFF
--- a/.github/workflows/fab-p0001-m3-patch-kick-v2.yml
+++ b/.github/workflows/fab-p0001-m3-patch-kick-v2.yml
@@ -1,4 +1,5 @@
 name: FAB-P0001 M3 canonical patch kick v2
+# retrigger: 2026-08-23T00:19Z after workflow exists on default branch
 
 on:
   push:


### PR DESCRIPTION
## FAB-P0001 / TFI / M3 deterministic retrigger

The kick workflow is now already present on canonical `main`. This PR changes only a comment in that exact workflow file so the subsequent protected push to `main` deterministically matches its own `push.paths` trigger.

No product code or patch logic changes. The workflow still reuses the canonical M3 patch driver and limits target changes to the six allowlisted M3 closure files. Remove the temporary drivers after #2022 lands.