### PR TITLE
docs(fam): establish FAB-P0006 always-on marketing project

### DIFF
--- a/projects/PORTFOLIO.json
+++ b/projects/PORTFOLIO.json
@@ -5,7 +5,7 @@
   "project_id_regex": "^FAB-P[0-9]{4}$",
   "allocation_policy": "monotonic-no-reuse",
   "ordering_basis": "first-formal-project-folder-commit-on-canonical-main",
-  "next_sequence": 6,
+  "next_sequence": 7,
   "projects": [
     {
       "project_id": "FAB-P0001",
@@ -61,6 +61,17 @@
       "registered_at": "2026-08-22",
       "first_canonical_main_commit": "88db63c328c3cba39971f3942509cb0b582502bc",
       "legacy_project_ids": ["MSR"]
+    },
+    {
+      "project_id": "FAB-P0006",
+      "project_key": "FAM",
+      "slug": "fabushi-always-on-marketing",
+      "name": "Fabushi Always-on Marketing",
+      "authoritative_path": "projects/fabushi-always-on-marketing",
+      "status": "active",
+      "registered_at": "2026-08-23",
+      "first_canonical_main_commit": "173e7f793987b6d0a9303b55e2060e2584552da9",
+      "legacy_project_ids": []
     }
   ]
 }

--- a/projects/fabushi-always-on-marketing/OWNERS.md
+++ b/projects/fabushi-always-on-marketing/OWNERS.md
@@ -1,0 +1,11 @@
+# Owners
+
+| Role | Responsibility |
+|---|---|
+| Accountable owner | Fabushi product/growth owner |
+| Execution owner | Fabushi engineering + growth automation |
+| Required reviewers | Product claim owner for high-risk claims; security/privacy reviewer for sensitive captures |
+| Consulted | Feature owners, release engineering, community operations |
+| Escalation | Disable publishing path first when authenticity, credentials, privacy, legal or platform-policy risk is uncertain |
+
+No social-platform credential, session secret, API token, signing key or private customer data may be stored in this folder.

--- a/projects/fabushi-always-on-marketing/PROJECT.yaml
+++ b/projects/fabushi-always-on-marketing/PROJECT.yaml
@@ -1,0 +1,23 @@
+project_id: FAB-P0006
+project_key: FAM
+legacy_project_ids: []
+name: Fabushi Always-on Marketing
+slug: fabushi-always-on-marketing
+status: active
+repository: bhrumom/fabushi
+authoritative_branch: main
+authoritative_path: projects/fabushi-always-on-marketing
+owner: Fabushi growth + engineering
+reviewers: []
+current_stage: M0-foundation-and-evidence-pipeline
+created_at: 2026-08-23
+updated_at: 2026-08-23
+risk_tier: tier-1
+security_classification: internal
+target_finish: null
+related_projects:
+  - telegram-fabushi-integration
+  - grok-bot-fabushi-integration
+  - mahayana-sovereign-runtime
+source_systems:
+  - GitHub:bhrumom/fabushi

--- a/projects/fabushi-always-on-marketing/README.md
+++ b/projects/fabushi-always-on-marketing/README.md
@@ -1,0 +1,49 @@
+# Fabushi Always-on Marketing
+
+- Project ID: `FAB-P0006`
+- Project Key: `FAM`
+- Status: active
+- Canonical path: `projects/fabushi-always-on-marketing`
+
+## Objective
+
+Build a permanent growth engine that turns verified Fabushi development progress into authentic daily content across major self-media platforms. GitHub Actions should exercise real product features, capture reproducible screenshots/video and test evidence, package approved media assets, and feed a governed publishing pipeline.
+
+## Core principle
+
+**No fabricated demos.** Public product claims must be traceable to a real build/test run, commit, feature state, or explicitly labeled roadmap/prototype material.
+
+## Current stage
+
+`M0-foundation-and-evidence-pipeline`
+
+Next gate: establish the GitHub Actions media-evidence pipeline and platform-neutral content package format.
+
+## Scope
+
+- CI/E2E-driven video and screenshot capture for real Fabushi features.
+- Daily development-progress content generation.
+- Multi-platform content adaptation and publishing architecture.
+- Editorial review, secrets/privacy redaction, claim verification, asset retention and audit trail.
+- Metrics, attribution, experiments, weekly/monthly learning loops.
+- Reusable runbooks for daily operations and incidents.
+
+## Non-goals
+
+- Fake engagement, fake reviews, undisclosed astroturfing or misleading product claims.
+- Publishing credentials in repository files or test artifacts.
+- Replacing product CI quality gates with marketing-only demonstrations.
+
+## Primary acceptance
+
+A daily campaign package can be generated from a verified Fabushi CI run containing: source commit, test result, feature metadata, screenshots, video clips, captions/scripts, redaction status and publish eligibility; approved packages can be routed to supported channels without manual re-creation of source media.
+
+## Navigation
+
+- Source of truth: [SOURCE_OF_TRUTH.md](SOURCE_OF_TRUTH.md)
+- Charter: [docs/00-项目章程.md](docs/00-项目章程.md)
+- Requirements: [docs/02-需求与成功指标.md](docs/02-需求与成功指标.md)
+- Architecture: [docs/03-架构与实现策略.md](docs/03-架构与实现策略.md)
+- Roadmap/WBS: [management/00-路线图.md](management/00-路线图.md), [management/01-WBS原子任务.md](management/01-WBS原子任务.md)
+- Acceptance: [docs/19-完成定义与验收.md](docs/19-完成定义与验收.md)
+- Runbooks: [runbooks/README.md](runbooks/README.md)

--- a/projects/fabushi-always-on-marketing/SOURCE_OF_TRUTH.md
+++ b/projects/fabushi-always-on-marketing/SOURCE_OF_TRUTH.md
@@ -1,0 +1,23 @@
+# Source of Truth
+
+## Authority
+
+1. User's latest explicit requirement after it is persisted in this project folder.
+2. `projects/PORTFOLIO.json` and project identity policy for portfolio identity.
+3. This project folder on GitHub `main`.
+4. Accepted ADRs and current specs.
+5. Live GitHub code, CI, releases and deployments for implementation facts.
+6. External analytics/publishing systems for their own measured facts.
+7. Conversation history.
+
+## Original requirement
+
+Create a long-term Fabushi marketing project that continuously broadcasts development progress and markets the product across self-media platforms. Use GitHub Actions to automatically test each feature and capture real video/screenshots; use those authentic assets as the source material for published marketing content.
+
+## Evidence rule
+
+A claim such as "feature X works" is publishable only when its package references objective evidence (CI run/test/build/release or an explicitly approved manual verification). Planned or prototype functionality must be labeled as such.
+
+## Conflict handling
+
+Do not silently rewrite history. Record requirement or design changes in `management/07-变更日志.md`, and record durable technical/governance decisions in `decisions/`.

--- a/projects/fabushi-always-on-marketing/decisions/ADR-0001-evidence-first-marketing.md
+++ b/projects/fabushi-always-on-marketing/decisions/ADR-0001-evidence-first-marketing.md
@@ -1,0 +1,23 @@
+# ADR-0001 — Evidence-first marketing
+
+- Status: Accepted
+- Date: 2026-08-23
+- Owners: Fabushi growth + engineering
+
+## Context
+
+Daily marketing must scale without creating fake demos or requiring teams to manually re-record product functionality.
+
+## Decision
+
+GitHub Actions/E2E verification artifacts are the canonical source for product-function marketing. A platform-neutral campaign package separates capture/evidence from content transformation and publishing. Successful-feature claims require passing verification; prototypes/roadmap content must be labeled.
+
+## Alternatives
+
+- Manually record every post: rejected as non-scalable and weakly traceable.
+- Generate synthetic product demos: rejected for authenticity risk.
+- Build directly against one social platform: rejected due to lock-in and policy volatility.
+
+## Consequences
+
+More engineering work upfront, but stronger authenticity, reuse, auditability, safety and cross-platform portability.

--- a/projects/fabushi-always-on-marketing/decisions/README.md
+++ b/projects/fabushi-always-on-marketing/decisions/README.md
@@ -1,0 +1,5 @@
+# Decisions
+
+Durable architecture/governance choices are recorded as ADRs.
+
+- ADR-0001: evidence-first marketing and platform-neutral publishing architecture.

--- a/projects/fabushi-always-on-marketing/docs/00-项目章程.md
+++ b/projects/fabushi-always-on-marketing/docs/00-项目章程.md
@@ -1,0 +1,42 @@
+# 00 项目章程
+
+## Problem
+
+Fabushi development produces valuable proof of progress, but without a durable content system those proofs are scattered, manually recreated, or never reach potential users.
+
+## Objective
+
+Create an always-on, evidence-backed growth loop: **build -> test -> capture -> verify -> package -> adapt -> publish -> measure -> learn -> feed product/growth decisions**.
+
+## Stakeholders
+
+Product, engineering, release engineering, growth/content operations, community, prospective users and existing users.
+
+## Business value
+
+- Turn engineering output into compounding distribution.
+- Make product progress publicly visible and credible.
+- Reduce the marginal cost of daily content production.
+- Build a reusable asset/evidence library around real functionality.
+- Close the loop from audience response back to product priorities.
+
+## Constraints
+
+- Heavy tests/builds run in GitHub Actions, not local developer machines.
+- Marketing content cannot overstate unverified functionality.
+- Captures must prevent secrets/private data leakage.
+- Platform automation must respect platform terms, API availability and rate limits.
+
+## Deliverables
+
+1. CI media-capture workflow and feature scenario registry.
+2. Normalized campaign-package manifest.
+3. Content generation/adaptation pipeline.
+4. Human/automated approval gates by risk class.
+5. Publisher adapters and queue architecture.
+6. Analytics/attribution loop.
+7. Daily/weekly/monthly operating runbooks.
+
+## Governance
+
+This is a permanent active project. Individual capability milestones can complete while the parent project remains active for continuous operations and optimization.

--- a/projects/fabushi-always-on-marketing/docs/01-范围与非目标.md
+++ b/projects/fabushi-always-on-marketing/docs/01-范围与非目标.md
@@ -1,0 +1,21 @@
+# 01 范围与非目标
+
+## In scope
+
+- Desktop/web/mobile feature capture where CI runners can reproduce the feature.
+- Screenshot, short-form vertical clip, landscape clip and raw evidence generation.
+- Development logs, feature demos, release highlights, engineering stories, comparisons grounded in evidence, tutorials and roadmap updates clearly labeled.
+- Platform-specific title/caption/thumbnail/script variants.
+- Publishing queue, retries, deduplication, audit log and manual fallback.
+- Analytics ingestion and experiment tracking.
+
+## Out of scope
+
+- Purchased/fake engagement, fake testimonials, spam, hidden advertising identities or deceptive claims.
+- Credential storage in source control.
+- Recording production user data without explicit authorization and redaction controls.
+- Treating a passing marketing demo as a replacement for release quality assurance.
+
+## Deferred until adapters are validated
+
+Fully automatic posting to every platform. Each platform is enabled only after a supported API/automation route, policy review, credentials model, rate-limit handling and rollback path are proven.

--- a/projects/fabushi-always-on-marketing/docs/02-需求与成功指标.md
+++ b/projects/fabushi-always-on-marketing/docs/02-需求与成功指标.md
@@ -1,0 +1,38 @@
+# 02 需求与成功指标
+
+## Functional requirements
+
+| ID | Requirement |
+|---|---|
+| FAM-R001 | Every publishable product claim traces to a source commit and verification evidence. |
+| FAM-R002 | Feature scenarios can capture screenshots and video in GitHub Actions. |
+| FAM-R003 | CI emits a normalized campaign package with manifest, media, test metadata and claim state. |
+| FAM-R004 | Sensitive data is scanned/redacted before an asset becomes publish-eligible. |
+| FAM-R005 | One source package can generate multiple platform variants without re-recording the feature. |
+| FAM-R006 | Publishing is adapter-based, idempotent, retryable and auditable. |
+| FAM-R007 | Daily development progress can be summarized from merged/verified changes. |
+| FAM-R008 | Analytics ties content back to campaign, platform, feature and source evidence. |
+| FAM-R009 | Failed tests never produce a misleading "working feature" post. |
+| FAM-R010 | Human approval is available and mandatory for high-risk claims or captures. |
+
+## Non-functional requirements
+
+- Reproducibility: manifests include commit SHA, workflow run and scenario ID.
+- Security: no secrets in media or manifests; credentials live in protected secret stores.
+- Reliability: duplicate workflow retries must not duplicate public posts.
+- Portability: publisher core does not depend on one platform.
+- Observability: every package has lifecycle status from capture through publication and analytics.
+
+## Initial success metrics
+
+| Metric | Target |
+|---|---|
+| Verified-media coverage | >= 90% of publicly marketed shipped feature changes have reusable evidence assets |
+| Claim traceability | 100% of product-function claims have evidence pointers |
+| Daily continuity | >= 1 eligible development/content package per active development day when verified changes exist |
+| Asset reuse | >= 3 platform variants per qualifying source package once adapters are enabled |
+| Secret/privacy incidents | 0 |
+| Duplicate post rate | < 0.5% |
+| Publish pipeline success | >= 99% excluding platform-wide outages |
+
+Growth metrics (reach, qualified visits, activation, retention and conversion) are measured per channel and cohort; targets are established after a 30-day baseline instead of being invented now.

--- a/projects/fabushi-always-on-marketing/docs/03-架构与实现策略.md
+++ b/projects/fabushi-always-on-marketing/docs/03-架构与实现策略.md
@@ -1,0 +1,59 @@
+# 03 架构与实现策略
+
+## Target pipeline
+
+```text
+Git change / release
+        |
+        v
+Feature Scenario Registry
+        |
+        v
+GitHub Actions E2E runners
+  test + screen/video capture
+        |
+        v
+Evidence Gate
+ test result + provenance + redaction + claim policy
+        |
+        v
+Campaign Package
+ manifest.json + raw media + selected clips + screenshots
+        |
+        +--> Content Transformer -> titles/captions/scripts/thumbnails/subtitles
+        |
+        +--> Approval Queue
+                 |
+                 v
+          Publisher Adapters
+                 |
+                 v
+     Platform post IDs / URLs
+                 |
+                 v
+        Analytics + learning loop
+```
+
+## Campaign package schema (planned)
+
+Each package should carry: `campaign_id`, `scenario_id`, `feature_id`, commit SHA, workflow run ID/URL, build/version, test outcome, capture timestamps, media checksums, privacy scan outcome, claim classification, language variants, platform renderings, approval record, publisher outcomes and analytics identifiers.
+
+## Capture strategy
+
+- Reuse existing E2E frameworks where possible.
+- Record the complete deterministic scenario as raw evidence; derive short clips after the run.
+- Capture key-state screenshots at named checkpoints.
+- Preserve original dimensions; generate 9:16, 1:1 and 16:9 derivatives without discarding source material.
+- Emit subtitles/transcript only from observed/demo narration or approved generated copy; never invent feature behavior.
+
+## Content strategy
+
+A single verified feature can produce multiple honest angles: what changed, before/after, how it works, why it matters, engineering challenge, test proof, tutorial, release note, FAQ and community question. Variants remain linked to the same evidence package.
+
+## Publishing strategy
+
+Use a platform-neutral queue and adapter interface. Prefer official APIs where available. Browser/RPA publishing is isolated, policy-reviewed and used only when reliable/allowed. Idempotency key: `(campaign_id, platform, account, variant_id)`.
+
+## Storage
+
+Large videos should live as CI artifacts/object storage/release assets rather than Git history. Repository stores manifests, schemas, policies, code and durable evidence pointers.

--- a/projects/fabushi-always-on-marketing/docs/04-质量与测试策略.md
+++ b/projects/fabushi-always-on-marketing/docs/04-质量与测试策略.md
@@ -1,0 +1,19 @@
+# 04 质量与测试策略
+
+## Quality layers
+
+1. Scenario unit/contract checks: schema, metadata and selector stability.
+2. E2E feature check: product behavior must pass before marketing eligibility.
+3. Media validation: video decodes, duration/dimensions valid, screenshots non-empty, checksums recorded.
+4. Privacy/security scan: secrets/PII/test credentials/windows outside intended surface are rejected or redacted.
+5. Claim validation: generated text may not claim more than evidence supports.
+6. Publisher contract tests: dry-run payloads, idempotency, retry/backoff, status reconciliation.
+7. End-to-end campaign dry run: capture -> package -> approve -> sandbox/draft destination -> analytics record.
+
+## CI evidence
+
+Required evidence includes scenario/test result, workflow run, source SHA, media manifest and policy-gate outcome. Failed scenarios remain useful internally for debugging content but are not publish-eligible as successful feature demos.
+
+## Flaky tests
+
+Flaky scenarios are quarantined from automatic publishing. A retry may produce evidence, but publish eligibility requires the scenario's configured stability threshold and a final passing run.

--- a/projects/fabushi-always-on-marketing/docs/05-发布迁移与回滚.md
+++ b/projects/fabushi-always-on-marketing/docs/05-发布迁移与回滚.md
@@ -1,0 +1,21 @@
+# 05 发布迁移与回滚
+
+## Rollout
+
+1. Dry-run packages only.
+2. Enable evidence capture on selected stable scenarios.
+3. Enable draft/private/unlisted publishing where supported.
+4. Enable one production account/platform at a time.
+5. Expand only after duplicate prevention, deletion/correction and analytics reconciliation are proven.
+
+## Rollback triggers
+
+- Secret/private data exposure.
+- Duplicate or runaway posting.
+- Incorrect product claim.
+- Platform policy/rate-limit violation.
+- Broken attribution causing misleading analytics.
+
+## Rollback
+
+Disable publisher adapter/queue, revoke affected credentials if exposure is suspected, remove/correct public posts where possible, preserve audit evidence, open incident/action item, and do not auto-resume until the cause is verified fixed.

--- a/projects/fabushi-always-on-marketing/docs/06-运维可观测性与SLO.md
+++ b/projects/fabushi-always-on-marketing/docs/06-运维可观测性与SLO.md
@@ -1,0 +1,24 @@
+# 06 运维可观测性与 SLO
+
+## Lifecycle states
+
+`discovered -> tested -> captured -> scanned -> packaged -> approved -> queued -> published -> reconciled -> measured` with explicit terminal failure states.
+
+## SLIs
+
+- package generation success rate
+- media validation success rate
+- publish queue latency
+- publisher success/retry rate
+- duplicate prevention rate
+- analytics reconciliation delay
+- daily eligible-content count
+
+## Initial SLOs
+
+- 99% successful processing for valid eligible packages excluding external platform outages.
+- 100% product-claim provenance retention.
+- 0 secret/privacy publish incidents.
+- 100% publisher attempts have an audit record.
+
+Alerts should prioritize privacy/security, duplicate publishing, queue runaway, credential failures and sustained adapter failures.

--- a/projects/fabushi-always-on-marketing/docs/07-安全隐私与合规.md
+++ b/projects/fabushi-always-on-marketing/docs/07-安全隐私与合规.md
@@ -1,0 +1,23 @@
+# 07 安全隐私与合规
+
+## Security boundaries
+
+- Publishing credentials are stored only in protected GitHub/environment/platform secret stores.
+- Fork/untrusted PR workflows must not receive production publisher secrets.
+- Capture jobs use dedicated test accounts/data where possible.
+- Media is treated as potentially sensitive until privacy scan/approval passes.
+
+## Capture safeguards
+
+- Hide notifications, unrelated windows, personal accounts and secret-bearing terminals.
+- Use deterministic seeded test data.
+- Scan text metadata/logs and inspect visual captures for tokens, emails, private messages, filesystem paths and user identifiers.
+- High-risk scenarios require human review.
+
+## Content integrity
+
+Do not fabricate user counts, benchmarks, testimonials, competitor claims or functionality. Clearly distinguish shipped, beta, prototype and roadmap states.
+
+## Platform compliance
+
+Publisher adapters must respect platform terms, API rules, disclosure requirements, rate limits and account permissions. Unsupported automation remains disabled until reviewed.

--- a/projects/fabushi-always-on-marketing/docs/19-完成定义与验收.md
+++ b/projects/fabushi-always-on-marketing/docs/19-完成定义与验收.md
@@ -1,0 +1,22 @@
+# 19 完成定义与验收
+
+This is a permanent operations project; the project itself remains active while milestones/tasks complete.
+
+## Foundation DoD
+
+- [ ] `FAB-P0006` is registered and project-folder governance passes.
+- [ ] Scenario registry has stable IDs and feature ownership.
+- [ ] GitHub Actions can capture at least one real Fabushi feature video and checkpoint screenshots.
+- [ ] Campaign manifest contains source/test/media provenance.
+- [ ] Failed tests cannot become success-marketing packages.
+- [ ] Privacy/secret gate exists before publish eligibility.
+- [ ] At least one short-form and one landscape derivative can be generated from source media.
+- [ ] Approval state and immutable audit history are recorded.
+- [ ] Publisher adapter contract passes dry-run/idempotency tests.
+- [ ] At least one production platform adapter completes controlled end-to-end publication and reconciliation.
+- [ ] Analytics can map a published item back to campaign/feature/evidence.
+- [ ] Daily runbook and incident rollback runbook are validated.
+
+## Evidence required
+
+Git commit/PR, GitHub Actions run/job, generated manifest, media artifact references, policy-gate output, publisher/draft/public post identifier where applicable, and analytics reconciliation evidence.

--- a/projects/fabushi-always-on-marketing/evidence/FAM-001/README.md
+++ b/projects/fabushi-always-on-marketing/evidence/FAM-001/README.md
@@ -1,0 +1,11 @@
+# FAM-001 Evidence
+
+Planned evidence:
+
+- branch/commit creating project baseline;
+- `projects/PORTFOLIO.json` registration;
+- Project portfolio governance workflow run;
+- pull request and merge commit;
+- canonical `main` verification.
+
+Status: pending until CI/merge.

--- a/projects/fabushi-always-on-marketing/evidence/README.md
+++ b/projects/fabushi-always-on-marketing/evidence/README.md
@@ -1,0 +1,5 @@
+# Evidence index
+
+Large videos/screenshots remain in CI artifacts/object storage or approved media storage. This directory stores durable indexes and pointers, not bulky binaries.
+
+- `FAM-001/README.md`: project establishment evidence.

--- a/projects/fabushi-always-on-marketing/management/00-路线图.md
+++ b/projects/fabushi-always-on-marketing/management/00-路线图.md
@@ -1,0 +1,14 @@
+# 00 路线图
+
+| Stage | Objective | Exit gate |
+|---|---|---|
+| M0 | Project foundation + evidence architecture | project registered; schema/scenario design accepted |
+| M1 | CI real-feature capture | stable scenarios generate verified screenshots/video |
+| M2 | Content package + transformation | one evidence package yields reusable multi-format assets/copy |
+| M3 | Safety + editorial governance | redaction/claim/approval gates pass adversarial tests |
+| M4 | Publisher platform | queue + adapter contract + draft/sandbox publication passes |
+| M5 | Controlled multi-platform rollout | supported production adapters publish/reconcile safely |
+| M6 | Analytics + growth experiments | content attribution and experiment loop operational |
+| M7 | Always-on operations | daily/weekly/monthly cadence sustained and continuously optimized |
+
+The parent project does not end at M7; it transitions to steady-state operations with new atomic tasks for platform additions, content formats, growth experiments and reliability improvements.

--- a/projects/fabushi-always-on-marketing/management/01-WBS原子任务.md
+++ b/projects/fabushi-always-on-marketing/management/01-WBS原子任务.md
@@ -1,0 +1,19 @@
+# 01 WBS 原子任务
+
+| Task | Action | Dependency | Acceptance | Verification | Status | Next |
+|---|---|---|---|---|---|---|
+| FAM-001 | Establish canonical project record | none | full standard folder + portfolio registration | governance validator + PR/main evidence | in-progress | merge baseline |
+| FAM-101 | Inventory existing E2E/workflows and map marketable feature scenarios | FAM-001 | scenario registry with stable IDs/owners | source audit | planned | inspect workflows/tests |
+| FAM-102 | Define campaign package manifest/schema | FAM-001 | versioned schema covers provenance/media/policy/publish states | schema tests | planned | implement schema |
+| FAM-201 | Implement GitHub Actions video/screenshot capture | FAM-101 | one real feature produces valid raw video + checkpoints | CI run artifacts | planned | pilot stable scenario |
+| FAM-202 | Add media derivative pipeline | FAM-201 | source -> 9:16/1:1/16:9 + subtitle-ready outputs | media validation CI | planned | implement transform |
+| FAM-203 | Add privacy/secret visual/content gate | FAM-201 | unsafe captures blocked before eligibility | adversarial fixtures | planned | implement gate |
+| FAM-301 | Generate evidence-grounded content variants | FAM-102,FAM-202 | captions/scripts never exceed evidence state | claim-policy tests | planned | implement transformer |
+| FAM-302 | Editorial approval + audit state machine | FAM-203,FAM-301 | review decisions durable/auditable | state-machine tests | planned | implement |
+| FAM-401 | Implement platform-neutral publish queue/adapter contract | FAM-302 | idempotent retries and reconciliation | contract tests | planned | implement core |
+| FAM-402 | Integrate first supported publishing platform | FAM-401 | controlled real publication/reconciliation | production evidence | planned | choose adapter by supported API |
+| FAM-403 | Add additional self-media adapters | FAM-402 | each adapter passes policy/contract/rollback gates | adapter CI + production smoke | planned | platform-by-platform |
+| FAM-501 | Daily dev-progress campaign generator | FAM-301 | verified merged changes become eligible daily package | daily workflow dry run | planned | implement |
+| FAM-502 | Analytics + attribution ingestion | FAM-402 | post -> campaign -> feature/evidence mapping | reconciliation test | planned | implement |
+| FAM-503 | Experiment framework | FAM-502 | title/hook/format experiments measured without fake engagement | experiment audit | planned | implement |
+| FAM-601 | Always-on operations and reliability | FAM-403,FAM-501,FAM-502 | sustained cadence + SLO/runbooks | 30-day ops evidence | planned | operate/iterate |

--- a/projects/fabushi-always-on-marketing/management/02-里程碑.md
+++ b/projects/fabushi-always-on-marketing/management/02-里程碑.md
@@ -1,0 +1,10 @@
+# 02 里程碑
+
+| Milestone | Required tasks | Planned date | Actual | Status | Evidence |
+|---|---|---|---|---|---|
+| M0 Foundation | FAM-001,FAM-101,FAM-102 | rolling | - | in-progress | project/CI evidence |
+| M1 Capture | FAM-201,FAM-202,FAM-203 | rolling | - | planned | CI media artifacts |
+| M2 Content governance | FAM-301,FAM-302 | rolling | - | planned | policy tests/audit |
+| M3 Publishing | FAM-401,FAM-402,FAM-403 | rolling | - | planned | adapter/publication evidence |
+| M4 Growth loop | FAM-501,FAM-502,FAM-503 | rolling | - | planned | daily runs/analytics |
+| M5 Steady state | FAM-601 | continuous | - | planned | operating history |

--- a/projects/fabushi-always-on-marketing/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-always-on-marketing/management/03-验收追踪矩阵.md
@@ -1,0 +1,14 @@
+# 03 验收追踪矩阵
+
+| Requirement | Tasks | Verification | Evidence | Status |
+|---|---|---|---|---|
+| FAM-R001 provenance | FAM-102,FAM-301 | schema + claim-policy tests | manifest/CI | planned |
+| FAM-R002 capture | FAM-201 | GitHub Actions E2E | video/screenshots/run | planned |
+| FAM-R003 package | FAM-102,FAM-201 | schema/integration tests | manifest/artifact | planned |
+| FAM-R004 privacy | FAM-203 | adversarial scans | gate report | planned |
+| FAM-R005 reuse | FAM-202,FAM-301 | derivative/content tests | generated variants | planned |
+| FAM-R006 publishing | FAM-401,FAM-402,FAM-403 | contract + production smoke | publish records | planned |
+| FAM-R007 daily progress | FAM-501 | scheduled dry run | daily package | planned |
+| FAM-R008 analytics | FAM-502,FAM-503 | reconciliation | metrics record | planned |
+| FAM-R009 failure safety | FAM-201,FAM-301 | forced-failure test | ineligible package proof | planned |
+| FAM-R010 approval | FAM-302 | state transition tests | approval audit | planned |

--- a/projects/fabushi-always-on-marketing/management/04-风险登记.md
+++ b/projects/fabushi-always-on-marketing/management/04-风险登记.md
@@ -1,0 +1,11 @@
+# 04 风险登记
+
+| ID | Risk | P | Impact | Owner | Mitigation | Trigger/contingency | Status |
+|---|---|---|---|---|---|---|---|
+| FAM-RISK-01 | secrets/private data appear in captures | M | critical | security/growth | seeded test data + scan + review | disable publishing/revoke creds/remove post | open |
+| FAM-RISK-02 | generated copy overclaims functionality | M | high | product/growth | evidence-bound claim policy | block/retract/correct | open |
+| FAM-RISK-03 | duplicate/runaway publishing | M | high | engineering | idempotency + rate caps + kill switch | disable adapter | open |
+| FAM-RISK-04 | platform API/TOS changes | H | medium | growth engineering | adapter isolation + policy review | disable affected adapter/manual fallback | open |
+| FAM-RISK-05 | flaky E2E creates misleading media | M | high | QA | quarantine/stability threshold | mark ineligible | open |
+| FAM-RISK-06 | content becomes repetitive/spammy | M | medium | growth | editorial diversity + frequency caps + analytics | reduce cadence/change formats | open |
+| FAM-RISK-07 | large media costs/storage growth | M | medium | platform engineering | retention tiers/object storage | prune derived artifacts, keep manifests | open |

--- a/projects/fabushi-always-on-marketing/management/05-状态报告.md
+++ b/projects/fabushi-always-on-marketing/management/05-状态报告.md
@@ -1,0 +1,9 @@
+# 05 状态报告
+
+## 2026-08-23 — Round 1
+
+- Stage: M0 foundation.
+- Work: initialized permanent Fabushi always-on marketing project structure and normalized the evidence-backed marketing requirement.
+- Acceptance: pending portfolio registration, governance CI and merge to `main`.
+- Risk: publishing adapters are intentionally not enabled before policy/credential/idempotency gates exist.
+- Next: register FAB-P0006; inventory current E2E/workflows and implement campaign schema/capture pilot.

--- a/projects/fabushi-always-on-marketing/management/06-依赖与阻塞.md
+++ b/projects/fabushi-always-on-marketing/management/06-依赖与阻塞.md
@@ -1,0 +1,10 @@
+# 06 依赖与阻塞
+
+| ID | Dependency | Blocks | State | Fallback |
+|---|---|---|---|---|
+| FAM-DEP-01 | stable Fabushi CI/E2E scenarios | FAM-201 | available but inventory required | create dedicated marketing capture scenarios |
+| FAM-DEP-02 | platform-supported publishing auth/API | FAM-402/403 | platform-specific | draft/manual handoff adapter |
+| FAM-DEP-03 | safe artifact/object storage retention | media scale | design required | short GitHub artifact retention + durable manifest pointers |
+| FAM-DEP-04 | analytics identifiers/platform metrics | FAM-502 | platform-specific | UTM/campaign IDs + manual import until API exists |
+
+No current blocker prevents project foundation or CI capture work.

--- a/projects/fabushi-always-on-marketing/management/07-变更日志.md
+++ b/projects/fabushi-always-on-marketing/management/07-变更日志.md
@@ -1,0 +1,8 @@
+# 07 变更日志
+
+## 2026-08-23
+
+- Created permanent marketing/growth workstream from the user's requirement.
+- Established `FAB-P0006` / `FAM` identity plan.
+- Adopted evidence-first marketing: real CI test video/screenshots are canonical feature marketing source material.
+- Added platform-neutral publishing and safety/approval architecture instead of hard-coding one social network.

--- a/projects/fabushi-always-on-marketing/management/08-问题与行动项.md
+++ b/projects/fabushi-always-on-marketing/management/08-问题与行动项.md
@@ -1,0 +1,8 @@
+# 08 问题与行动项
+
+| ID | Question/action | Owner | Due | Resolution |
+|---|---|---|---|---|
+| FAM-ACT-01 | Inventory current web/Electron/native E2E workflows suitable for recording | engineering | M0 | open |
+| FAM-ACT-02 | Select first production publishing adapter based on supported API/policy and target audience | growth | M3 | open |
+| FAM-ACT-03 | Establish 30-day channel baseline before setting reach/conversion targets | growth analytics | after first launch | open |
+| FAM-ACT-04 | Define artifact retention/cost policy after capture-size measurement | platform engineering | M1 | open |

--- a/projects/fabushi-always-on-marketing/management/tasks/FAM-001-establish-project.md
+++ b/projects/fabushi-always-on-marketing/management/tasks/FAM-001-establish-project.md
@@ -1,0 +1,47 @@
+# FAM-001 — Establish canonical project record
+
+- Project ID: `FAB-P0006`
+- Project Key: `FAM`
+- Status: in-progress
+- Started: 2026-08-23
+- Updated: 2026-08-23
+
+## Objective
+
+Create the enterprise-standard permanent project folder and portfolio registration for Fabushi's always-on evidence-backed marketing program.
+
+## Source
+
+User requirement dated 2026-08-23 preserved in `source/README.md`.
+
+## In scope
+
+Project identity, source traceability, charter, requirements, architecture, quality, security, roadmap, WBS, acceptance, risks, dependencies, status, ADR/evidence/runbook scaffolding.
+
+## Out of scope
+
+Implementing the media capture/publisher code in this baseline task.
+
+## Acceptance
+
+- Project folder is reconstructable without chat history.
+- Portfolio registry contains matching FAB-P0006/FAM identity.
+- Project portfolio governance CI passes.
+- PR is merged and canonical `main` is verified.
+
+## Verification
+
+Project portfolio validator + PR/CI/main verification.
+
+## Branch / PR / commit
+
+Branch: `project/fab-p0006-always-on-marketing`.
+PR/commit: pending.
+
+## Evidence
+
+See `evidence/FAM-001/README.md`.
+
+## Next action
+
+Complete registry update, open PR, verify governance checks and merge.

--- a/projects/fabushi-always-on-marketing/runbooks/README.md
+++ b/projects/fabushi-always-on-marketing/runbooks/README.md
@@ -1,0 +1,11 @@
+# Runbooks
+
+## Planned operational runbooks
+
+1. Daily content cycle: discover verified changes -> capture/package -> review -> publish -> reconcile.
+2. Capture failure: classify product failure vs runner/media failure; never publish success claim from failed run.
+3. Privacy/security incident: freeze queue, revoke credentials if necessary, remove/correct affected content, preserve evidence, remediate and review.
+4. Duplicate/runaway posting: activate kill switch, reconcile platform IDs, deduplicate queue and resume only after idempotency validation.
+5. Platform outage/rate limit: pause adapter, preserve queue and retry within policy; use manual handoff if business-critical.
+6. Weekly growth review: inspect content/feature/channel cohorts and choose experiments.
+7. Monthly strategy review: platform mix, funnel quality, content fatigue, retention and product feedback themes.

--- a/projects/fabushi-always-on-marketing/source/README.md
+++ b/projects/fabushi-always-on-marketing/source/README.md
@@ -1,0 +1,7 @@
+# Source intake
+
+## 2026-08-23 — Initial requirement
+
+The project is permanent and continuous. Every day, Fabushi development progress should become marketing content across self-media platforms. GitHub Actions should automatically test product functions and record videos/screenshots. Those real test artifacts should be the marketing source material.
+
+Normalized interpretation lives under `docs/`; this file preserves the original intent and dated requirement changes.


### PR DESCRIPTION
## Summary

Creates the permanent Fabushi Always-on Marketing project (`FAB-P0006`, key `FAM`) and registers it in the canonical portfolio.

The project defines an evidence-first growth system where real GitHub Actions/E2E product tests generate screenshots and videos, which become traceable source material for daily multi-platform content. It includes the enterprise project scaffold, roadmap/WBS, acceptance matrix, risks, ADR, evidence index and operational runbooks.

## Core governance

- No fabricated product demos or unsupported claims.
- Successful feature claims must trace to passing verification evidence.
- Publishing credentials must stay out of repository content/artifacts.
- Platform publishing is adapter-based, idempotent, auditable and enabled only after policy/security checks.

## Next implementation stages

1. Inventory existing E2E/workflows and create a feature scenario registry.
2. Define campaign package schema.
3. Add GitHub Actions screenshot/video capture pilot.
4. Add privacy/claim gates and media derivatives.
5. Build publisher adapters, daily campaign generator and analytics loop.

## Validation

Requires `Project portfolio governance` and normal PR checks before canonical completion.