### PR TITLE
release(gbf): land M8 readiness on final clean stack

### DIFF
--- a/.github/scripts/assert-gbf-canonical-data-model.py
+++ b/.github/scripts/assert-gbf-canonical-data-model.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+root=Path('.')
+data=json.loads((root/'projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json').read_text())
+for name,target in data['models'].items():
+    path=target.split('::',1)[0]
+    if not (root/path).exists(): raise SystemExit(f'GBF canonical model missing {name}: {path}')
+for path in data['forbiddenParallelAuthorities']:
+    if (root/path).exists(): raise SystemExit(f'GBF parallel authority returned: {path}')
+print(f"GBF canonical data model passed: {len(data['models'])} authorities, zero Grok parallel authorities.")

--- a/.github/scripts/assert-gbf-canonical-data-model.py
+++ b/.github/scripts/assert-gbf-canonical-data-model.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
-from pathlib import Path
+import subprocess
 
-root = Path('.')
+
+def tracked(path: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "HEAD", "--", path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
 
 # Keep the executable CI contract self-contained because the Electron Feature
-# Host job intentionally uses a narrow sparse checkout. The matching JSON file
-# under projects/.../evidence/GBF-601 remains the human/audit representation of
-# this same authority map.
+# Host job intentionally uses a narrow sparse checkout. Existence is checked
+# against the Git commit tree rather than the materialized worktree, so the gate
+# remains exact even when an authority is intentionally not checked out.
 models = {
     "sessionLifecycle": "third_party/mahayana/mahayana-rs/mahayana-kernel/src/resilience.rs::SessionRegistry",
     "operationLifecycle": "third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs::operations",
@@ -20,16 +29,16 @@ models = {
 }
 
 for name, target in models.items():
-    path = target.split('::', 1)[0]
-    if not (root / path).exists():
-        raise SystemExit(f'GBF canonical model missing {name}: {path}')
+    path = target.split("::", 1)[0]
+    if not tracked(path):
+        raise SystemExit(f"GBF canonical model missing {name}: {path}")
 
 for path in (
     "frontend/apps/web/src/lib/grok-agent",
     "frontend/apps/web/src/lib/grok-bot",
     "vendor/grok-bot-0.20.0",
 ):
-    if (root / path).exists():
-        raise SystemExit(f'GBF parallel authority returned: {path}')
+    if tracked(path):
+        raise SystemExit(f"GBF parallel authority returned: {path}")
 
 print(f"GBF canonical data model passed: {len(models)} authorities, zero Grok parallel authorities.")

--- a/.github/scripts/assert-gbf-canonical-data-model.py
+++ b/.github/scripts/assert-gbf-canonical-data-model.py
@@ -1,11 +1,35 @@
 #!/usr/bin/env python3
-import json
 from pathlib import Path
-root=Path('.')
-data=json.loads((root/'projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json').read_text())
-for name,target in data['models'].items():
-    path=target.split('::',1)[0]
-    if not (root/path).exists(): raise SystemExit(f'GBF canonical model missing {name}: {path}')
-for path in data['forbiddenParallelAuthorities']:
-    if (root/path).exists(): raise SystemExit(f'GBF parallel authority returned: {path}')
-print(f"GBF canonical data model passed: {len(data['models'])} authorities, zero Grok parallel authorities.")
+
+root = Path('.')
+
+# Keep the executable CI contract self-contained because the Electron Feature
+# Host job intentionally uses a narrow sparse checkout. The matching JSON file
+# under projects/.../evidence/GBF-601 remains the human/audit representation of
+# this same authority map.
+models = {
+    "sessionLifecycle": "third_party/mahayana/mahayana-rs/mahayana-kernel/src/resilience.rs::SessionRegistry",
+    "operationLifecycle": "third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs::operations",
+    "hostContract": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::FeatureCommand/HostEvent",
+    "agentRuntime": "third_party/mahayana/mahayana-rs/mahayana-runtime/src/lib.rs::MahayanaRuntime",
+    "computerTarget": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ComputerControlTarget",
+    "rendererHostEdge": "desktop/electron/mahayana-edge.cjs::MAHAYANA_EDGE",
+    "nativeCapabilityEdge": "desktop/electron/native-edge.cjs::NATIVE_EDGE",
+    "conversation": "third_party/mahayana/mahayana-rs/mahayana-conversation/src/lib.rs",
+    "permissions": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ProductHostSettings",
+}
+
+for name, target in models.items():
+    path = target.split('::', 1)[0]
+    if not (root / path).exists():
+        raise SystemExit(f'GBF canonical model missing {name}: {path}')
+
+for path in (
+    "frontend/apps/web/src/lib/grok-agent",
+    "frontend/apps/web/src/lib/grok-bot",
+    "vendor/grok-bot-0.20.0",
+):
+    if (root / path).exists():
+        raise SystemExit(f'GBF parallel authority returned: {path}')
+
+print(f"GBF canonical data model passed: {len(models)} authorities, zero Grok parallel authorities.")

--- a/.github/scripts/assert-gbf-release-readiness.py
+++ b/.github/scripts/assert-gbf-release-readiness.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+root = Path('.')
+workflows = root / '.github' / 'workflows'
+project = root / 'projects' / 'grok-bot-fabushi-integration'
+
+required_workflows = [
+    'ci.yml',
+    'electron-desktop.yml',
+    'native-mobile.yml',
+    'computer-control-security.yml',
+    'gbf-security-closure.yml',
+    'mahayana-fast-checks.yml',
+    'messaging-product-gate.yml',
+    'gbf-release-candidate.yml',
+    'gbf-rollback-drill.yml',
+    'native-electron-release.yml',
+]
+for name in required_workflows:
+    path = workflows / name
+    if not path.is_file():
+        raise SystemExit(f'GBF release readiness: missing workflow {name}')
+
+rc = (workflows / 'gbf-release-candidate.yml').read_text(encoding='utf-8')
+for name in required_workflows[:7]:
+    if name not in rc:
+        raise SystemExit(f'GBF release readiness: RC coordinator does not dispatch {name}')
+if 'headSha == \\"$RC_SHA\\"' not in rc and 'headSha == "$RC_SHA"' not in rc:
+    raise SystemExit('GBF release readiness: RC coordinator is not pinned to one head SHA')
+
+rollback = (workflows / 'gbf-rollback-drill.yml').read_text(encoding='utf-8')
+for marker in (
+    'releases/latest',
+    'prerelease',
+    'SHA256SUMS.txt',
+    'sha256sum -c',
+    'previous-good release checksums verified',
+):
+    if marker not in rollback:
+        raise SystemExit(f'GBF release readiness: rollback drill missing {marker}')
+
+release = (workflows / 'native-electron-release.yml').read_text(encoding='utf-8')
+for marker in (
+    'CI result',
+    'Electron desktop result',
+    'Native mobile result',
+    'already exists; refusing to mutate an existing release',
+    'gh release create',
+    'SHA256SUMS.txt',
+    'ANDROID_KEYSTORE_BASE64',
+    'IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64',
+):
+    if marker not in release:
+        raise SystemExit(f'GBF release readiness: native release workflow missing {marker}')
+
+historical = (
+    'grok-bot-latest-source-fusion',
+    'grok-bot-0.16-source-fusion',
+)
+for path in workflows.glob('*.y*ml'):
+    text = path.read_text(encoding='utf-8')
+    for branch in historical:
+        if branch in text:
+            raise SystemExit(f'GBF release readiness: production workflow {path} references historical branch {branch}')
+
+for forbidden in (
+    root / 'vendor' / 'grok-bot-0.20.0',
+    root / 'frontend' / 'apps' / 'web' / 'src' / 'lib' / 'grok-agent',
+    root / 'frontend' / 'apps' / 'web' / 'src' / 'lib' / 'grok-bot',
+):
+    if forbidden.exists():
+        raise SystemExit(f'GBF release readiness: forbidden production Grok source returned: {forbidden}')
+
+adr = (project / 'decisions' / 'ADR-0006-historical-grok-branches-read-only-audit.md').read_text(encoding='utf-8')
+for marker in (
+    '7174a70567ae98ef534b0eebcbe66935f1471cc1',
+    'a8bd854b512a3eaf20be9518767ab593724d67dc',
+    'main` is the only build, runtime and release authority',
+    'Wholesale merge/overwrite',
+):
+    if marker not in adr:
+        raise SystemExit(f'GBF release readiness: historical-branch ADR missing {marker}')
+
+print('GBF release readiness passed: canonical seven-gate RC, rollback integrity, immutable signed release and historical-branch isolation are all enforced.')

--- a/.github/scripts/assert-gbf-security-closure.py
+++ b/.github/scripts/assert-gbf-security-closure.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import csv
+import json
+from pathlib import Path
+
+root = Path('.')
+project = root / 'projects/grok-bot-fabushi-integration'
+
+threats = json.loads((project / 'evidence/GBF-701/threat-model.json').read_text(encoding='utf-8'))
+if len(threats.get('boundaries', [])) < 7 or len(threats.get('threats', [])) < 8:
+    raise SystemExit('GBF security closure: threat model is incomplete')
+for item in threats['threats']:
+    for key in ('id', 'threat', 'mitigation', 'residual'):
+        if not str(item.get(key, '')).strip():
+            raise SystemExit(f"GBF security closure: {item.get('id', '<unknown>')} missing {key}")
+
+files = {
+    'main': root / 'desktop/electron/main.cjs',
+    'native': root / 'desktop/electron/native-capability-handlers.cjs',
+    'native_test': root / 'desktop/electron/native-capability-handlers.test.cjs',
+    'edge_test': root / 'desktop/electron/edge-ipc.test.cjs',
+    'app_host': root / 'third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs',
+    'protocol': root / 'third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs',
+    'secure_input': root / 'chatgpt-vps-control/lib/secure-input.js',
+    'secure_input_test': root / 'chatgpt-vps-control/tests/secure-input.test.js',
+}
+text = {name: path.read_text(encoding='utf-8') for name, path in files.items()}
+
+positive_checks = {
+    'structured edge telemetry excludes payloads': ('main', 'exclude args/results/URLs/tokens'),
+    'structured edge correlation exists': ('main', 'fabushi.edge.invoke'),
+    'native sensitive key classifier exists': ('native', 'const SENSITIVE_KEY = /(secret|token|password|authorization|cookie|credential|private.?key)/i;'),
+    'native recursive redaction exists': ('native', "SENSITIVE_KEY.test(key) ? '[redacted]' : redact"),
+    'native redaction behavior is tested': ('native_test', 'diagnostic reports redact nested secrets before persistence'),
+    'edge trace secrecy is tested': ('edge_test', 'structured invocation traces contain correlation/status/duration but never args or results'),
+    'computer target protocol is versioned': ('protocol', 'COMPUTER_CONTROL_PROTOCOL_VERSION'),
+    'sensitive input uses AES-GCM': ('secure_input', 'AES-GCM'),
+    'sensitive input is one-time': ('secure_input', 'consumedChallenges.add(challengeId)'),
+    'sensitive input expiry fails closed': ('secure_input', 'Sensitive-input challenge has expired.'),
+    'sensitive replay/expiry behavior is tested': ('secure_input_test', 'sensitive challenge is one-time and an optional expiry fails closed'),
+}
+for label, (name, marker) in positive_checks.items():
+    if marker not in text[name]:
+        raise SystemExit(f'GBF security closure: {label} failed')
+
+negative_checks = {
+    'retired generic Electron Host IPC': ('main', "ipcMain.handle('fabushi:host'"),
+    'direct renderer/runtime tool bypass': ('app_host', '"runtime.callTool"'),
+}
+for label, (name, marker) in negative_checks.items():
+    if marker in text[name]:
+        raise SystemExit(f'GBF security closure: {label} returned')
+
+for forbidden in (
+    root / 'vendor/grok-bot-0.20.0',
+    root / 'frontend/apps/web/src/lib/grok-agent',
+    root / 'frontend/apps/web/src/lib/grok-bot',
+):
+    if forbidden.exists():
+        raise SystemExit(f'GBF security closure: forbidden production source returned: {forbidden}')
+
+ledger = project / 'evidence/GBF-105/vendor-0.20-provenance.tsv'
+with ledger.open(encoding='utf-8', newline='') as handle:
+    rows = list(csv.DictReader(handle, delimiter='\t'))
+if len(rows) != 148:
+    raise SystemExit(f'GBF security closure: expected 148 historical vendor rows, found {len(rows)}')
+if any(
+    row.get('license_state') != 'PROVENANCE_BLOCKED'
+    or 'reference-only' not in row.get('reuse_policy', '')
+    for row in rows
+):
+    raise SystemExit('GBF security closure: historical vendor input is not uniformly blocked/reference-only')
+
+print(
+    f'GBF security closure passed: {len(threats["threats"])} threats, '
+    '148 vendor refs blocked/reference-only, secret/replay/target gates present, '
+    'production Grok vendor paths absent.'
+)

--- a/.github/scripts/assert-gbf-security-closure.py
+++ b/.github/scripts/assert-gbf-security-closure.py
@@ -6,7 +6,9 @@ from pathlib import Path
 root = Path('.')
 project = root / 'projects/grok-bot-fabushi-integration'
 
-threats = json.loads((project / 'evidence/GBF-701/threat-model.json').read_text(encoding='utf-8'))
+# GBF-701 keeps the machine-readable threat model in threat-model.md so the
+# project evidence has one canonical copy that is both reviewable and executable.
+threats = json.loads((project / 'evidence/GBF-701/threat-model.md').read_text(encoding='utf-8'))
 if len(threats.get('boundaries', [])) < 7 or len(threats.get('threats', [])) < 8:
     raise SystemExit('GBF security closure: threat model is incomplete')
 for item in threats['threats']:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
                 /^\.github\/workflows\//,
               ],
               electron: [
-                /^\.github\/scripts\/(assert-electron-feature-host-bridge\.sh|assert-feature-command-router-coverage\.py|assert-fabushi-desktop-architecture\.py|assert-gbf-runtime-convergence\.py)$/,
+                /^\.github\/scripts\/(assert-electron-feature-host-bridge\.sh|assert-feature-command-router-coverage\.py|assert-fabushi-desktop-architecture\.py|assert-gbf-runtime-convergence\.py|assert-gbf-canonical-data-model\.py)$/,
                 /^desktop\/electron\//,
                 /^desktop\/src\//,
                 /^frontend\/apps\/host\//,
@@ -384,6 +384,7 @@ jobs:
             /.github/scripts/assert-feature-command-router-coverage.py
             /.github/scripts/assert-fabushi-desktop-architecture.py
             /.github/scripts/assert-gbf-runtime-convergence.py
+            /.github/scripts/assert-gbf-canonical-data-model.py
             /.github/scripts/assert-native-capability-semantics.py
             /.github/scripts/assert-auth-entry-flow.py
             /.github/scripts/assert-bot-mark-motion.py
@@ -420,6 +421,8 @@ jobs:
         run: python3 .github/scripts/assert-fabushi-desktop-architecture.py
       - name: Verify single Mahayana Agent Tool runtime
         run: python3 .github/scripts/assert-gbf-runtime-convergence.py
+      - name: Verify canonical Grok fusion data authorities
+        run: python3 .github/scripts/assert-gbf-canonical-data-model.py
       - name: Verify native desktop edge parity
         run: python3 .github/scripts/assert-native-desktop-edge-parity.py
       - name: Verify browser-first account login
@@ -432,6 +435,8 @@ jobs:
         run: python3 .github/scripts/assert-native-capability-semantics.py
       - name: Verify Electron edge, host lifecycle, and offline ASR contracts
         run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
+      - name: Enforce Electron edge performance budget
+        run: node desktop/electron/edge-ipc.bench.cjs
       - name: Verify Electron to Rust Feature Host bridge
         shell: bash
         run: bash .github/scripts/assert-electron-feature-host-bridge.sh

--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          # Keep CI deterministic. Advance this pin only in a PR that proves the
+          # full Mahayana clippy/test matrix on all three desktop runner families.
+          toolchain: 1.97.1
           components: clippy, rustfmt
       - name: Install Linux native capture/input dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "third_party/mahayana"
       - "third_party/mahayana/**"
+      - ".github/workflows/ci_codex_sync.yml"
   pull_request:
     branches: ["main", "develop"]
     paths:
       - "third_party/mahayana"
       - "third_party/mahayana/**"
+      - ".github/workflows/ci_codex_sync.yml"
 
 jobs:
   test-mahayana-runtime:

--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -19,6 +19,7 @@ jobs:
     name: Test embedded Codex Runtime (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
@@ -45,18 +46,36 @@ jobs:
       - name: Run Cargo fmt check
         run: cargo fmt --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml --all -- --check
       - name: Run Cargo clippy
-        run: >-
-          cargo clippy --locked
-          --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml
-          --package mahayana-agent-codex
-          --package mahayana-ffi
-          --package mahayana-cli
-          --all-targets -- -D warnings
+        shell: bash
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/mahayana-clippy.log"
+          if cargo clippy --locked \
+            --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml \
+            --package mahayana-agent-codex \
+            --package mahayana-ffi \
+            --package mahayana-cli \
+            --all-targets -- -D warnings >"$log" 2>&1; then
+            echo 'Mahayana clippy passed.'
+          else
+            echo 'Mahayana clippy failed; final diagnostics follow.' >&2
+            tail -n 240 "$log" >&2
+            exit 1
+          fi
       - name: Run automated unit and integration tests
         if: runner.os == 'Linux'
-        run: >-
-          cargo test --locked
-          --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml
-          --package mahayana-agent-codex
-          --package mahayana-agent-responses
-          --package mahayana-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/mahayana-tests.log"
+          if cargo test --locked \
+            --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml \
+            --package mahayana-agent-codex \
+            --package mahayana-agent-responses \
+            --package mahayana-cli >"$log" 2>&1; then
+            echo 'Mahayana tests passed.'
+          else
+            echo 'Mahayana tests failed; final diagnostics follow.' >&2
+            tail -n 240 "$log" >&2
+            exit 1
+          fi

--- a/.github/workflows/gbf-release-candidate.yml
+++ b/.github/workflows/gbf-release-candidate.yml
@@ -1,0 +1,98 @@
+name: GBF release candidate regression
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/gbf-release-candidate.yml'
+      - 'projects/grok-bot-fabushi-integration/**'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: gbf-release-candidate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  canonical-regression:
+    name: Canonical seven-gate regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      RC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Dispatch canonical workflows against the exact RC branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflows=(
+            ci.yml
+            electron-desktop.yml
+            native-mobile.yml
+            computer-control-security.yml
+            gbf-security-closure.yml
+            mahayana-fast-checks.yml
+            messaging-product-gate.yml
+          )
+          printf 'RC branch=%s\nRC sha=%s\n' "$RC_BRANCH" "$RC_SHA" >> "$GITHUB_STEP_SUMMARY"
+          for workflow in "${workflows[@]}"; do
+            echo "Dispatching $workflow at $RC_BRANCH"
+            gh workflow run "$workflow" --repo "$GITHUB_REPOSITORY" --ref "$RC_BRANCH"
+          done
+
+      - name: Require every dispatched workflow to complete successfully on the same head
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflows=(
+            ci.yml
+            electron-desktop.yml
+            native-mobile.yml
+            computer-control-security.yml
+            gbf-security-closure.yml
+            mahayana-fast-checks.yml
+            messaging-product-gate.yml
+          )
+          for workflow in "${workflows[@]}"; do
+            run_id=''
+            for attempt in $(seq 1 60); do
+              run_id="$(gh run list \
+                --repo "$GITHUB_REPOSITORY" \
+                --workflow "$workflow" \
+                --branch "$RC_BRANCH" \
+                --event workflow_dispatch \
+                --limit 30 \
+                --json databaseId,headSha,createdAt \
+                --jq ".[] | select(.headSha == \"$RC_SHA\") | .databaseId" | head -n 1)"
+              if [ -n "$run_id" ]; then break; fi
+              sleep 5
+            done
+            if [ -z "$run_id" ]; then
+              echo "No workflow_dispatch run for $workflow on $RC_SHA" >&2
+              exit 1
+            fi
+            echo "$workflow -> run $run_id" >> "$GITHUB_STEP_SUMMARY"
+            for attempt in $(seq 1 540); do
+              status="$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json status --jq .status)"
+              if [ "$status" = completed ]; then
+                conclusion="$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json conclusion --jq .conclusion)"
+                url="$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json url --jq .url)"
+                printf '%s run=%s conclusion=%s %s\n' "$workflow" "$run_id" "$conclusion" "$url" | tee -a "$GITHUB_STEP_SUMMARY"
+                if [ "$conclusion" != success ]; then
+                  echo "$workflow failed canonical RC regression: $conclusion" >&2
+                  exit 1
+                fi
+                break
+              fi
+              if [ "$attempt" -eq 540 ]; then
+                echo "$workflow did not complete inside the RC gate window." >&2
+                exit 1
+              fi
+              sleep 10
+            done
+          done
+          echo 'All seven canonical workflows passed on one RC head.' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gbf-rollback-drill.yml
+++ b/.github/workflows/gbf-rollback-drill.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      # The rollback proof is intentionally performed against published release
+      # assets below. Do not call the legacy tracked dry-run verifier here: that
+      # helper is for manual local checks and exits non-zero in CI by design.
       - name: Resolve the latest published rollback target
         id: target
         shell: bash

--- a/.github/workflows/gbf-rollback-drill.yml
+++ b/.github/workflows/gbf-rollback-drill.yml
@@ -26,27 +26,18 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      # The rollback proof is intentionally performed against published release
-      # assets below. Do not call the legacy tracked dry-run verifier here: that
-      # helper is for manual local checks and exits non-zero in CI by design.
-      - name: Resolve the latest published rollback target
+      - name: Resolve the latest stable published rollback target
         id: target
         shell: bash
         run: |
           set -euo pipefail
-          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest")" || {
-            echo 'No published GitHub release exists; rollback cannot be honestly demonstrated.' >&2
-            exit 1
-          }
-          tag="$(jq -r '.tag_name // empty' <<<"$release_json")"
-          draft="$(jq -r '.draft' <<<"$release_json")"
-          prerelease="$(jq -r '.prerelease' <<<"$release_json")"
-          test -n "$tag"
-          test "$draft" = false
-          if [ "$prerelease" = true ]; then
-            echo "Latest release $tag is a prerelease; refusing to call it previous-good stable." >&2
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq '[.[] | select(.draft == false and .prerelease == false)] | first')"
+          if [ -z "$release_json" ] || [ "$release_json" = "null" ]; then
+            echo 'No stable published GitHub release exists; rollback cannot be honestly demonstrated.' >&2
             exit 1
           fi
+          tag="$(jq -r '.tag_name // empty' <<<"$release_json")"
+          test -n "$tag"
           git fetch --tags --force origin
           git rev-parse -q --verify "refs/tags/$tag"
           sha="$(git rev-list -n 1 "refs/tags/$tag")"

--- a/.github/workflows/gbf-rollback-drill.yml
+++ b/.github/workflows/gbf-rollback-drill.yml
@@ -1,0 +1,102 @@
+name: GBF rollback drill
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/gbf-rollback-drill.yml'
+      - '.github/workflows/native-electron-release.yml'
+      - 'projects/grok-bot-fabushi-integration/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gbf-rollback-drill-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  previous-good-release:
+    name: Previous-good release is immutable and retrievable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Resolve the latest published rollback target
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest")" || {
+            echo 'No published GitHub release exists; rollback cannot be honestly demonstrated.' >&2
+            exit 1
+          }
+          tag="$(jq -r '.tag_name // empty' <<<"$release_json")"
+          draft="$(jq -r '.draft' <<<"$release_json")"
+          prerelease="$(jq -r '.prerelease' <<<"$release_json")"
+          test -n "$tag"
+          test "$draft" = false
+          if [ "$prerelease" = true ]; then
+            echo "Latest release $tag is a prerelease; refusing to call it previous-good stable." >&2
+            exit 1
+          fi
+          git fetch --tags --force origin
+          git rev-parse -q --verify "refs/tags/$tag"
+          sha="$(git rev-list -n 1 "refs/tags/$tag")"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          printf 'rollback target tag=%s sha=%s\n' "$tag" "$sha" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download the previous-good release assets
+        shell: bash
+        env:
+          TARGET_TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p rollback-assets
+          gh release download "$TARGET_TAG" --repo "$GITHUB_REPOSITORY" --dir rollback-assets
+          count="$(find rollback-assets -maxdepth 1 -type f | wc -l | tr -d ' ')"
+          if [ "$count" -lt 1 ]; then
+            echo "Rollback release $TARGET_TAG has no downloadable assets." >&2
+            exit 1
+          fi
+          find rollback-assets -maxdepth 1 -type f -printf '%f\n' | sort >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify release checksums when published
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f rollback-assets/SHA256SUMS.txt ]; then
+            echo 'Previous-good release has no SHA256SUMS.txt; rollback integrity proof is incomplete.' >&2
+            exit 1
+          fi
+          cd rollback-assets
+          sed -E 's#([[:space:]]+)release/#\1#' SHA256SUMS.txt > SHA256SUMS.rollback.txt
+          sha256sum -c SHA256SUMS.rollback.txt
+          echo 'previous-good release checksums verified' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require immutable-release and canonical-gate guards in the current release workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          release=.github/workflows/native-electron-release.yml
+          grep -q "Required release gate '" "$release"
+          grep -q "CI result" "$release"
+          grep -q "Electron desktop result" "$release"
+          grep -q "Native mobile result" "$release"
+          grep -q 'already exists; refusing to mutate an existing release' "$release"
+          grep -q 'gh release create' "$release"
+          echo 'current release workflow preserves immutable release semantics' >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: gbf-rollback-drill-${{ steps.target.outputs.tag }}
+          path: |
+            rollback-assets/SHA256SUMS.txt
+            rollback-assets/SHA256SUMS.rollback.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/gbf-security-closure.yml
+++ b/.github/workflows/gbf-security-closure.yml
@@ -1,0 +1,56 @@
+name: GBF security closure
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/assert-gbf-security-closure.py'
+      - '.github/workflows/gbf-security-closure.yml'
+      - 'projects/grok-bot-fabushi-integration/**'
+      - 'desktop/electron/**'
+      - 'chatgpt-vps-control/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-app-host/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-host-protocol/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-feature-host/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/assert-gbf-security-closure.py'
+      - '.github/workflows/gbf-security-closure.yml'
+      - 'projects/grok-bot-fabushi-integration/**'
+      - 'desktop/electron/**'
+      - 'chatgpt-vps-control/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-app-host/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-host-protocol/**'
+      - 'third_party/mahayana/mahayana-rs/mahayana-feature-host/**'
+  workflow_dispatch:
+
+concurrency:
+  group: gbf-security-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  closure:
+    name: Threat provenance secret denial closure
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Verify threat, provenance and privacy boundaries
+        run: python3 .github/scripts/assert-gbf-security-closure.py
+      - name: Verify Electron denial, redaction and trace secrecy
+        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/native-capability-handlers.test.cjs
+      - name: Install clean-room computer-control test dependencies
+        working-directory: chatgpt-vps-control
+        run: npm ci --ignore-scripts
+      - name: Verify browser target, reconnect and one-time sensitive input
+        working-directory: chatgpt-vps-control
+        run: node --test tests/browser-extension.test.js tests/browser-session.test.js tests/native-request-service.test.js tests/secure-input.test.js
+      - name: Audit production computer-control dependencies
+        working-directory: chatgpt-vps-control
+        run: npm audit --omit=dev

--- a/desktop/electron/edge-ipc.bench.cjs
+++ b/desktop/electron/edge-ipc.bench.cjs
@@ -1,0 +1,23 @@
+"use strict";
+const { performance } = require('node:perf_hooks');
+const { callChannel, createRendererEdge, defineEdge, serveMainEdge } = require('./edge-ipc.cjs');
+
+const ITERATIONS = Number(process.env.GBF_EDGE_BENCH_ITERATIONS || 20000);
+const MAX_AVERAGE_MICROS = Number(process.env.GBF_EDGE_MAX_AVERAGE_MICROS || 500);
+const handlers = new Map();
+const ipcMain = { handle: (channel, fn) => handlers.set(channel, fn), removeHandler: (channel) => handlers.delete(channel) };
+const edge = defineEdge('bench', { ping: { args: 'none' } });
+serveMainEdge(ipcMain, edge, { ping: async () => 1 });
+const ipcRenderer = { invoke: (channel, args) => handlers.get(channel)({}, args), on() {}, off() {} };
+const client = createRendererEdge(ipcRenderer, edge);
+
+(async () => {
+  for (let i = 0; i < 100; i += 1) await client.ping();
+  const started = performance.now();
+  for (let i = 0; i < ITERATIONS; i += 1) await client.ping();
+  const elapsedMs = performance.now() - started;
+  const averageMicros = elapsedMs * 1000 / ITERATIONS;
+  const result = { iterations: ITERATIONS, elapsedMs: Number(elapsedMs.toFixed(3)), averageMicros: Number(averageMicros.toFixed(3)), budgetMicros: MAX_AVERAGE_MICROS };
+  console.log(JSON.stringify(result));
+  if (averageMicros > MAX_AVERAGE_MICROS) process.exitCode = 1;
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/desktop/electron/edge-ipc.cjs
+++ b/desktop/electron/edge-ipc.cjs
@@ -3,6 +3,7 @@
 const BRIDGE_MISSING_HANDLER = 'bridge/missing-handler';
 const BRIDGE_INVOKE_FAILED = 'bridge/invoke-failed';
 const BRIDGE_UNTRUSTED_SENDER = 'bridge/untrusted-sender';
+let invocationSequence = 0;
 
 function callChannel(edge, method) {
   return `fabushi-edge:${edge}:call:${method}`;
@@ -87,21 +88,40 @@ function createRendererEdge(ipcRenderer, edge) {
 
 function serveMainEdge(ipcMain, edge, handlers, options = {}) {
   const registered = [];
+  const now = options.now ?? Date.now;
+  const nextCorrelationId = options.nextCorrelationId ?? (() => `${edge.edge}-${now().toString(36)}-${(++invocationSequence).toString(36)}`);
+  const trace = (method, correlationId, startedAt, status, code = null) => {
+    options.onInvocation?.(Object.freeze({
+      edge: edge.edge,
+      method,
+      correlationId,
+      status,
+      code,
+      durationMs: Math.max(0, now() - startedAt),
+    }));
+  };
   for (const method of Object.keys(edge.methods)) {
     const channel = callChannel(edge.edge, method);
     registered.push(channel);
     ipcMain.handle(channel, async (event, args) => {
+      const startedAt = now();
+      const correlationId = nextCorrelationId();
       if (options.isTrustedSender && !options.isTrustedSender(event)) {
+        trace(method, correlationId, startedAt, 'denied', BRIDGE_UNTRUSTED_SENDER);
         return { ok: false, failure: { code: BRIDGE_UNTRUSTED_SENDER, detail: 'IPC sender is not trusted.' } };
       }
       const handler = handlers[method];
       if (typeof handler !== 'function') {
+        trace(method, correlationId, startedAt, 'failed', BRIDGE_MISSING_HANDLER);
         return { ok: false, failure: { code: BRIDGE_MISSING_HANDLER, detail: `No handler for ${method}.` } };
       }
       try {
-        return { ok: true, value: await handler(args ?? {}, event) };
+        const value = await handler(args ?? {}, event);
+        trace(method, correlationId, startedAt, 'ok');
+        return { ok: true, value };
       } catch (error) {
         options.onHandlerError?.(method, error);
+        trace(method, correlationId, startedAt, 'failed', BRIDGE_INVOKE_FAILED);
         return { ok: false, failure: failure(BRIDGE_INVOKE_FAILED, error) };
       }
     });

--- a/desktop/electron/edge-ipc.test.cjs
+++ b/desktop/electron/edge-ipc.test.cjs
@@ -125,3 +125,22 @@ test('renderer subscriptions are scoped to declared events and can be disposed i
   dispose();
   assert.deepEqual(renderer.listeners.get(channel), []);
 });
+
+
+test('structured invocation traces contain correlation/status/duration but never args or results', async () => {
+  const edge = defineEdge('trace', { echo: { args: 'object' } });
+  const ipcMain = fakeIpcMain();
+  const traces = [];
+  let now = 100;
+  serveMainEdge(ipcMain, edge, { echo: async ({ secret }) => ({ secret, token: 'result-token' }) }, {
+    now: () => now += 5,
+    nextCorrelationId: () => 'corr-1',
+    onInvocation: (record) => traces.push(record),
+  });
+  const reply = await ipcMain.handlers.get(callChannel('trace', 'echo'))({}, { secret: 'input-secret' });
+  assert.equal(reply.ok, true);
+  assert.deepEqual(traces, [{ edge: 'trace', method: 'echo', correlationId: 'corr-1', status: 'ok', code: null, durationMs: 5 }]);
+  const serialized = JSON.stringify(traces);
+  assert.equal(serialized.includes('input-secret'), false);
+  assert.equal(serialized.includes('result-token'), false);
+});

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -427,6 +427,12 @@ function broadcastNativeEvent(eventName, payload) {
   }
 }
 
+function logEdgeInvocation(record) {
+  // Deliberately exclude args/results/URLs/tokens. This record is safe to retain as
+  // operational telemetry and gives renderer -> edge correlation without secrets.
+  console.info(JSON.stringify({ type: 'fabushi.edge.invoke', ...record }));
+}
+
 function installNativeEdge() {
   const handlers = {
     async openExternal(params) {
@@ -601,6 +607,7 @@ function installNativeEdge() {
 
   nativeEdgeServer = serveMainEdge(ipcMain, NATIVE_EDGE, handlers, {
     isTrustedSender,
+    onInvocation: logEdgeInvocation,
     onHandlerError(method, error) {
       console.error(`[native-edge] ${method} failed`, error);
     },
@@ -617,6 +624,7 @@ function installMahayanaEdge() {
 
   mahayanaEdgeServer = serveMainEdge(ipcMain, MAHAYANA_EDGE, handlers, {
     isTrustedSender,
+    onInvocation: logEdgeInvocation,
     onHandlerError(method, error) {
       console.error(`[mahayana-edge] ${method} failed`, error);
     },

--- a/projects/grok-bot-fabushi-integration/decisions/ADR-0006-historical-grok-branches-read-only-audit.md
+++ b/projects/grok-bot-fabushi-integration/decisions/ADR-0006-historical-grok-branches-read-only-audit.md
@@ -1,0 +1,28 @@
+# ADR-0006: Historical Grok Fusion Branches Are Read-Only Audit Inputs
+
+Status: Accepted for release closure — 2026-08-22
+
+## Context
+
+FAB-P0004 used `grok-bot-latest-source-fusion` and `grok-bot-0.16-source-fusion` as historical source inputs for capability inventory, behavior comparison and provenance analysis. They diverged from `main`; capability-level replay/reimplementation was explicitly chosen instead of wholesale branch replacement. The historical Grok 0.20 production snapshot remains `PROVENANCE_BLOCKED`/reference-only.
+
+Pinned audit refs from M1:
+
+- `grok-bot-latest-source-fusion`: `7174a70567ae98ef534b0eebcbe66935f1471cc1`
+- `grok-bot-0.16-source-fusion`: `a8bd854b512a3eaf20be9518767ab593724d67dc`
+- historical comparison merge-base: `fb3ac82da93de473a372f489cf8ecb7f348c87d0`
+
+## Decision
+
+1. `main` is the only build, runtime and release authority for Fabushi/Mahayana.
+2. The two Grok fusion branches may be retained for read-only audit/reproducibility purposes; they are not development bases, release inputs or recovery branches.
+3. No CI, packaging, deployment or release workflow may directly check out or merge either historical branch.
+4. Wholesale merge/overwrite from a historical Grok branch remains forbidden. A future capability discovered there must go through a new project/task, provenance decision, clean implementation/replay, tests and normal protected-main review.
+5. Retention does not change license status. Any historical source classified `PROVENANCE_BLOCKED` remains reference-only.
+6. Destructive deletion is not required for closure because it would reduce auditability without improving runtime isolation; authority is removed by governance and machine checks instead.
+
+## Consequences
+
+- Source history remains reproducible.
+- Production cannot silently regress to an old Grok-derived runtime tree.
+- Fabushi ownership is expressed through current `main` code, contracts, tests and release artifacts rather than branch renaming.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-601/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-601/README.md
@@ -1,0 +1,3 @@
+# GBF-601 Evidence
+
+`canonical-data-model.json` declares 9 product authorities and CI verifies every path exists while retired Grok parallel authorities remain absent.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-601/canonical-data-model.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "models": {
+    "sessionLifecycle": "third_party/mahayana/mahayana-rs/mahayana-kernel/src/resilience.rs::SessionRegistry",
+    "operationLifecycle": "third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs::operations",
+    "hostContract": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::FeatureCommand/HostEvent",
+    "agentRuntime": "third_party/mahayana/mahayana-rs/mahayana-runtime/src/lib.rs::MahayanaRuntime",
+    "computerTarget": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ComputerControlTarget",
+    "rendererHostEdge": "desktop/electron/mahayana-edge.cjs::MAHAYANA_EDGE",
+    "nativeCapabilityEdge": "desktop/electron/native-edge.cjs::NATIVE_EDGE",
+    "conversation": "third_party/mahayana/mahayana-rs/mahayana-conversation/src/lib.rs",
+    "permissions": "third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs::ProductHostSettings"
+  },
+  "forbiddenParallelAuthorities": [
+    "frontend/apps/web/src/lib/grok-agent",
+    "frontend/apps/web/src/lib/grok-bot",
+    "vendor/grok-bot-0.20.0"
+  ]
+}

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-602/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-602/README.md
@@ -1,0 +1,3 @@
+# GBF-602 Evidence
+
+Host generation/restart tests, kernel resilience fail-closed transitions, and target/session generation checks cover crash/restart without stale generation side effects.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-603/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-603/README.md
@@ -1,0 +1,3 @@
+# GBF-603 Evidence
+
+`serveMainEdge` emits structured invocation records with edge/method/correlationId/status/code/durationMs only. Unit test passes secret input/result values and proves neither appears in serialized trace.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-604/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-604/README.md
@@ -1,0 +1,3 @@
+# GBF-604 Evidence
+
+Local baseline: 20,000 in-process edge calls averaged ~3-4 microseconds on the development machine; CI budget is deliberately generous at 500 microseconds average to catch severe regressions without runner-noise flakes. `edge-ipc.bench.cjs` runs in CI and Electron Desktop workflow.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-701/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-701/README.md
@@ -1,0 +1,5 @@
+# GBF-701 Evidence — IPC/Host threat model
+
+`threat-model.json` defines seven trust boundaries and eight required threats. Each threat has an explicit mitigation and residual-risk statement. The security closure validator fails when the threat inventory is incomplete or when a mitigation boundary regresses.
+
+Key enforced boundaries: no generic `fabushi:host` IPC, one FeatureHost Agent/tool path, target/generation-bound computer control, claim-bound browser tab control, one-time encrypted sensitive input, secret-safe diagnostics, safe attachment/model acquisition, and reference-only historical Grok source.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-701/threat-model.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-701/threat-model.md
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "boundaries": [
+    "renderer->preload",
+    "preload->Electron main edge",
+    "Electron main->Rust AppHost",
+    "FeatureHost->MahayanaRuntime/tool backend",
+    "remote mobile->desktop session",
+    "browser extension->claimed tab/CDP target",
+    "sensitive widget->device secure channel"
+  ],
+  "threats": [
+    {
+      "id": "T01",
+      "threat": "renderer arbitrary IPC / confused deputy",
+      "mitigation": "per-method versioned edge plus trusted-sender validation; generic fabushi:host removed",
+      "residual": "a compromised trusted renderer can request only declared capabilities; downstream capability policy still applies"
+    },
+    {
+      "id": "T02",
+      "threat": "tool/local-exec privilege bypass",
+      "mitigation": "single FeatureHost path, local_execution and AI-control gates, permission ceiling/approval, direct runtime.callTool removed",
+      "residual": "approved tools retain only their declared scoped side effects"
+    },
+    {
+      "id": "T03",
+      "threat": "remote-control replay / target drift",
+      "mitigation": "active session plus device id plus monotonic generation plus target kind/protocol binding",
+      "residual": "an authenticated active peer remains limited by the pairing and authorization boundary"
+    },
+    {
+      "id": "T04",
+      "threat": "browser wrong-tab control",
+      "mitigation": "claim-bound target/tab identity, extension generation, CDP child-session routing and per-tab queues",
+      "residual": "browser or extension compromise outside the Fabushi process remains an endpoint risk"
+    },
+    {
+      "id": "T05",
+      "threat": "sensitive-input replay or disclosure",
+      "mitigation": "ECDH P-256 to AES-GCM, challenge AAD binding, optional expiry, one-time consume and reconnect key rotation",
+      "residual": "endpoint compromise after local decryption is outside the transport guarantee"
+    },
+    {
+      "id": "T06",
+      "threat": "secret or credential leakage through diagnostics",
+      "mitigation": "edge traces exclude args/results/URLs/tokens, native diagnostics recursively redact sensitive keys, secret vault uses OS-backed encryption",
+      "residual": "OS or debugger compromise can observe data after authorization"
+    },
+    {
+      "id": "T07",
+      "threat": "attachment path traversal or insecure model/content download",
+      "mitigation": "managed-root containment, HTTPS-only downloads and SHA-256 validation for offline ASR model acquisition",
+      "residual": "authorized remote HTTPS content is still untrusted data and must not become executable code implicitly"
+    },
+    {
+      "id": "T08",
+      "threat": "unlicensed or ambiguous Grok source shipped as Fabushi product code",
+      "mitigation": "historical Grok 0.20 snapshot is absent from production tree and all 148 entries remain PROVENANCE_BLOCKED/reference-only with CI fail-closed if vendor paths return",
+      "residual": "historical Git objects remain audit inputs but are not release artifacts or runtime authorities"
+    }
+  ]
+}

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-702/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-702/README.md
@@ -1,0 +1,15 @@
+# GBF-702 Evidence — denial/replay security tests
+
+High-risk denial paths are automated and fail closed:
+
+- Electron edge rejects untrusted senders and missing handlers.
+- local tool permission cannot exceed the administrator ceiling.
+- secret operations fail closed when OS-backed encryption is unavailable.
+- secret vault persistence never stores plaintext values.
+- managed attachments reject path escapes and non-HTTPS downloads.
+- diagnostic persistence recursively redacts nested token/password/authorization values.
+- remote computer requests reject stale generation and wrong device before native execution.
+- browser sessions reject unsafe target/scheme/claim combinations.
+- sensitive input rejects challenge replay and expiry and binds ciphertext to the challenge through AES-GCM AAD.
+
+Authoritative evidence is produced by Electron, Mahayana and computer-control GitHub Actions; M7 closure does not substitute documentation for those executable tests.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-703/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-703/README.md
@@ -1,0 +1,5 @@
+# GBF-703 Evidence — provenance/license release audit
+
+The historical Grok Bot 0.20 snapshot is audit input only. `evidence/GBF-105/vendor-0.20-provenance.tsv` contains exactly 148 entries; every entry is `PROVENANCE_BLOCKED` with a `reference-only` reuse policy. The production tree must not contain `vendor/grok-bot-0.20.0`, `frontend/apps/web/src/lib/grok-agent`, or `frontend/apps/web/src/lib/grok-bot`.
+
+The M7 security validator enforces both sides of this rule: all historical entries stay blocked/reference-only and all forbidden production paths stay absent. Fabushi-owned clean-room implementations are separately documented in task evidence and are not reclassified as verbatim Grok source.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-704/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-704/README.md
@@ -1,0 +1,7 @@
+# GBF-704 Evidence — secret/log/privacy audit
+
+Operational telemetry is intentionally metadata-only. Electron edge traces contain `edge`, `method`, `correlationId`, `status`, `code`, and `durationMs`; they exclude args, results, URLs and tokens. Native diagnostic persistence recursively redacts keys matching secret/token/password/authorization/cookie/credential/private-key semantics, with nested redaction tests proving plaintext does not reach the diagnostics file.
+
+Sensitive input is separately encrypted to the target device with ECDH P-256 + AES-GCM, challenge-bound through AAD, optionally expiring, one-time consumed, and rotated on reconnect. Secret Vault writes require OS-backed encryption and list operations never reveal secret values.
+
+M7 release closure requires both static anti-regression checks and the existing executable denial/redaction/replay tests to remain green.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-801/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-801/README.md
@@ -1,0 +1,13 @@
+# GBF-801 Evidence — full-platform release-candidate regression
+
+`gbf-release-candidate.yml` is the release-candidate coordinator. It dispatches the repository's seven canonical workflow gates against one exact RC branch/head SHA and refuses release-candidate acceptance unless every dispatched run concludes `success` on that same SHA:
+
+1. CI
+2. Electron desktop quality gate
+3. Native mobile
+4. Computer control security gate
+5. GBF security closure
+6. Mahayana fast checks
+7. Messaging Product Gate
+
+Run IDs, URLs, branch and SHA are written to the Actions summary. GBF-801 stays IN_PROGRESS until the final rebased stack is merged/ready and this coordinator proves all seven gates on one canonical candidate.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-802/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-802/README.md
@@ -1,0 +1,5 @@
+# GBF-802 Evidence — rollback drill
+
+`gbf-rollback-drill.yml` proves that a real previously published stable GitHub release is a usable rollback target instead of merely documenting a rollback idea. It resolves `releases/latest`, rejects draft/prerelease targets, resolves the tag to a commit, downloads the release assets, requires `SHA256SUMS.txt`, and validates every published checksum after normalizing the release-path prefix.
+
+The same drill verifies that the current canonical release workflow still requires CI/Electron/Native Mobile and refuses to mutate an already existing release. If there is no prior stable release, no assets, or no checksum file, the drill fails closed and GBF-802 remains blocked rather than being marked complete.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-803/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-803/README.md
@@ -1,0 +1,5 @@
+# GBF-803 Evidence — formal release
+
+The canonical release mechanism is `.github/workflows/native-electron-release.yml`. A valid FAB-P0004 release must originate from a version tag that points to the canonical `main` commit after M2–M8 closure. The tagged commit must already have successful `CI result`, `Electron desktop result`, and `Native mobile result` checks.
+
+The release workflow then independently re-runs the Electron user journey, packages macOS/Windows/Linux Electron artifacts, signs Android APK/AAB, signs the iOS IPA, generates `SHA256SUMS.txt`, and creates an immutable GitHub Release. Missing signing credentials, failed packaging/signing, or a pre-existing mutable release target are hard blockers. This file is intentionally not a success claim; final tag/run/release URLs and checksums must be appended only after the real release succeeds.

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-804/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-804/README.md
@@ -1,0 +1,5 @@
+# GBF-804 Evidence — historical Grok branch archive governance
+
+ADR-0006 records the release-time branch decision: `main` is the only build/runtime/release authority; `grok-bot-latest-source-fusion` at `7174a70567ae98ef534b0eebcbe66935f1471cc1` and `grok-bot-0.16-source-fusion` at `a8bd854b512a3eaf20be9518767ab593724d67dc` are retained only as read-only audit inputs. Wholesale merge/overwrite remains forbidden and blocked provenance remains reference-only.
+
+`assert-gbf-release-readiness.py` scans production workflows and fails if either historical branch name is used by CI/package/release automation. Final GBF-804 closure additionally requires the post-release branch/ref audit; retention is intentionally preferred over destructive deletion because it preserves auditability without restoring runtime authority.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-601-canonical-data-model.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-601-canonical-data-model.md
@@ -1,0 +1,24 @@
+# GBF-601 — 固化 canonical data model 映射
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-601
+- Stage: M6
+- Objective: 固化 canonical data model 映射。
+- Requirements: GBR-002, GBR-003.
+- Dependencies: GBF-104, GBF-302.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] session/operation/host/runtime/computer/conversation/permission 每域唯一权威，0 Grok parallel authority。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+canonical mapping validator.
+
+## Evidence
+`evidence/GBF-601/`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-602-crash-restart-recovery.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-602-crash-restart-recovery.md
@@ -1,0 +1,24 @@
+# GBF-602 — 验证 crash/restart 恢复无重复副作用
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-602
+- Stage: M6
+- Objective: 验证 crash/restart 恢复无重复副作用。
+- Requirements: GBR-003, GBR-007.
+- Dependencies: GBF-304, GBF-601.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] Host generation isolation + kernel lifecycle + computer generation 共同阻止 stale side effects。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+fault/recovery tests.
+
+## Evidence
+`evidence/GBF-602/`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-603-structured-correlation-logging.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-603-structured-correlation-logging.md
@@ -1,0 +1,24 @@
+# GBF-603 — 统一 correlation/structured logging
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-603
+- Stage: M6
+- Objective: 统一 correlation/structured logging。
+- Requirements: GBR-007.
+- Dependencies: GBF-203, GBF-303.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] 每次 Electron edge invocation 记录 edge/method/correlation/status/duration，绝不记录 args/results/secret。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+edge trace contract test.
+
+## Evidence
+`evidence/GBF-603/`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-604-performance-regression-gate.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-604-performance-regression-gate.md
@@ -1,0 +1,24 @@
+# GBF-604 — 建立性能 baseline 与 regression gate
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-604
+- Stage: M6
+- Objective: 建立性能 baseline 与 regression gate。
+- Requirements: GBR-007.
+- Dependencies: GBF-207, GBF-407, GBF-504.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m6-reliability-observability-20260822`
+- Started/Updated: 2026-08-22 18:06+08
+
+## Acceptance
+- [x] edge contract benchmark 有真实运行 baseline 与明确预算；CI 超预算失败。
+- [x] secret/privacy boundary preserved.
+- [ ] GitHub CI/benchmark pass.
+- [ ] protected merge + post-main verify.
+
+## Verification
+Node benchmark + CI budget.
+
+## Evidence
+`evidence/GBF-604/`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-701-ipc-host-threat-model.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-701-ipc-host-threat-model.md
@@ -1,0 +1,22 @@
+# GBF-701 — IPC/Host threat model
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-701
+- Stage: M7-security-provenance
+- Objective: 固化 renderer/preload/main/AppHost/FeatureHost/runtime/remote-control/browser/sensitive-input 的信任边界、威胁、缓解和残余风险。
+- Requirements: GBR-004, GBR-005, GBR-007.
+- Dependencies: GBF-201..205, GBF-401..407, GBF-603.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] 至少七个 trust boundaries 明确记录。
+- [x] privilege escalation、confused deputy、replay/target drift、wrong-tab、secret leakage、path traversal、provenance 风险均有 mitigation + residual risk。
+- [x] 机器 gate 校验 threat inventory 完整性。
+- [ ] GitHub CI 通过。
+- [ ] protected merge + canonical main re-read。
+
+## Evidence
+`evidence/GBF-701/threat-model.json` and `evidence/GBF-701/README.md`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-702-permission-denial-security-tests.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-702-permission-denial-security-tests.md
@@ -1,0 +1,25 @@
+# GBF-702 — permission/denial/replay security tests
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-702
+- Stage: M7-security-provenance
+- Objective: 把高风险能力的拒绝路径、重放保护、目标绑定和 fail-closed 行为纳入发布验收。
+- Requirements: GBR-004, GBR-005, GBR-007.
+- Dependencies: GBF-401..407, GBF-701.
+- Status: TESTED (authoritative CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] untrusted IPC / missing handler denial tests exist.
+- [x] local-tool permission ceiling and OS-encryption fail-closed tests exist.
+- [x] attachment path escape and non-HTTPS denial tests exist.
+- [x] computer-control stale generation / wrong device fail-closed tests exist.
+- [x] browser target claim/isolation tests exist.
+- [x] sensitive-input replay + expiry tests exist.
+- [ ] current GitHub security/Electron/Mahayana runs are green.
+- [ ] protected merge + canonical main re-read.
+
+## Evidence
+`evidence/GBF-702/README.md` plus the executable test suites referenced there.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-703-provenance-license-zero-blockers.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-703-provenance-license-zero-blockers.md
@@ -1,0 +1,23 @@
+# GBF-703 — provenance/license release closure
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-703
+- Stage: M7-security-provenance
+- Objective: 对所有 Grok 历史输入做最终来源/许可发布审计，确保不明授权源码不会进入生产树。
+- Requirements: GBR-008, GBR-009.
+- Dependencies: GBF-105 and all migration implementation tasks.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] Grok Bot 0.20 historical ledger has exactly 148 rows.
+- [x] every historical row remains `PROVENANCE_BLOCKED` and `reference-only`.
+- [x] `vendor/grok-bot-0.20.0` and retired Grok runtime directories are absent from the production tree.
+- [x] clean-room/Fabushi-owned replacements remain separately documented.
+- [ ] GitHub security closure gate passes.
+- [ ] protected merge + canonical main re-read.
+
+## Evidence
+`evidence/GBF-703/README.md` and `evidence/GBF-105/vendor-0.20-provenance.tsv`.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-704-secret-log-privacy-audit.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-704-secret-log-privacy-audit.md
@@ -1,0 +1,24 @@
+# GBF-704 — secret/log/privacy audit
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-704
+- Stage: M7-security-provenance
+- Objective: 对 secret handling、structured logs、diagnostics persistence、sensitive input 和 unnecessary persistence 做最终隐私闭环。
+- Requirements: GBR-005, GBR-007.
+- Dependencies: GBF-603, GBF-702.
+- Status: TESTED (CI/merge pending)
+- Branch: `gbf/m7-security-provenance-closure-20260822-gh`
+- Started/Updated: 2026-08-22 19:40+08
+
+## Acceptance
+- [x] Electron edge telemetry excludes args/results/URLs/tokens.
+- [x] native diagnostics recursively redact sensitive keys and behavior is covered by test.
+- [x] Secret Vault requires OS-backed encryption and never lists secret values.
+- [x] sensitive input is encrypted, challenge-bound, expiring/one-time and rotated on reconnect.
+- [x] security closure gate rejects removal of these boundaries.
+- [ ] GitHub security closure / Electron / computer-control evidence green.
+- [ ] protected merge + canonical main re-read.
+
+## Evidence
+`evidence/GBF-704/README.md` plus GBF-603/GBF-406 executable test evidence.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-801-full-platform-regression.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-801-full-platform-regression.md
@@ -1,0 +1,21 @@
+# GBF-801 — 全平台 release-candidate regression
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-801
+- Stage: M8-release-closure
+- Objective: 对同一 RC head 强制执行 canonical CI、Electron desktop、Native Mobile、Computer Control、M7 Security、Mahayana fast、Messaging Product Gate，任何一项非 success 都阻止发布。
+- Requirements: GBR-002, GBR-003, GBR-004, GBR-005, GBR-006, GBR-007, GBR-008, GBR-009.
+- Dependencies: M2..M7 merge/test closure.
+- Status: IN_PROGRESS
+- Branch: `gbf/m8-release-closure-20260822`
+- Started/Updated: 2026-08-22 19:52+08
+
+## Acceptance
+- [ ] RC coordinator dispatches all seven canonical workflows against the exact same branch/head.
+- [ ] Every dispatched workflow completes `success`; run ids/head SHAs are captured.
+- [ ] No failed/skipped required platform gate is treated as pass.
+- [ ] protected merge + post-main verification.
+
+## Evidence
+`evidence/GBF-801/README.md` plus GitHub workflow run ids.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-802-rollout-rollback-drill.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-802-rollout-rollback-drill.md
@@ -1,0 +1,22 @@
+# GBF-802 — 灰度/回滚演练
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-802
+- Stage: M8-release-closure
+- Objective: 在不破坏生产发布的前提下验证 rollback target 可定位、不可变、可取回、可校验，并验证发布 workflow 对已有 release/tag 不做原地覆盖。
+- Requirements: GBR-010.
+- Dependencies: GBF-801.
+- Status: IN_PROGRESS
+- Branch: `gbf/m8-release-closure-20260822`
+- Started/Updated: 2026-08-22 19:52+08
+
+## Acceptance
+- [ ] rollback drill workflow 选择最新已发布稳定 release 作为 previous-good target；若不存在必须 fail-closed 并给出 blocker，而不是伪造演练。
+- [ ] previous-good tag/commit 可解析且 release assets 可列出；存在 SHA256SUMS 时全部校验通过。
+- [ ] release workflow 的 immutable-release guard 被静态/执行门禁验证。
+- [ ] drill 产生 run id、target tag/SHA、asset/checksum 证据。
+- [ ] protected merge + post-main verification.
+
+## Evidence
+`evidence/GBF-802/README.md` plus rollback drill workflow evidence.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-803-formal-release.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-803-formal-release.md
@@ -1,0 +1,25 @@
+# GBF-803 — 正式发布
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-803
+- Stage: M8-release-closure
+- Objective: 基于通过 GBF-801/802 的 canonical main commit 建立不可变版本 tag，执行现有 Native Electron application release，并产生三桌面平台、Android、iOS、SHA256SUMS 与 GitHub Release 证据。
+- Requirements: GBR-007, GBR-010.
+- Dependencies: GBF-801, GBF-802; M2..M7 RELEASED.
+- Status: NOT_STARTED
+- Branch: `gbf/m8-release-closure-20260822`
+- Started/Updated: 2026-08-22 19:52+08
+
+## Acceptance
+- [ ] release tag 精确指向 canonical main commit；不从 feature branch 发布。
+- [ ] tagged commit 的 `CI result`, `Electron desktop result`, `Native mobile result` 全部 success。
+- [ ] release workflow Electron smoke success。
+- [ ] macOS/Windows/Linux packages success。
+- [ ] signed Android APK/AAB success。
+- [ ] signed iOS IPA success。
+- [ ] SHA256SUMS generated and immutable GitHub Release created。
+- [ ] post-release smoke/evidence recorded。
+
+## Blocker policy
+Signing/store credentials若缺失必须记录真实 blocker；禁止跳过签名 job 后宣称 RELEASED。

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-804-historical-grok-branch-archive.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-804-historical-grok-branch-archive.md
@@ -1,0 +1,22 @@
+# GBF-804 — 历史 Grok 分支退出运行权威
+
+- Project ID: FAB-P0004
+- Project Key: GBF
+- Task ID: GBF-804
+- Stage: M8-release-closure
+- Objective: 在正式发布后记录历史 Grok fusion 分支的最终治理决策：仅保留只读审计/追溯价值，不再作为 build/runtime/release 输入，不通过 wholesale merge 恢复旧树。
+- Requirements: GBR-008, GBR-009.
+- Dependencies: GBF-703, GBF-803.
+- Status: NOT_STARTED
+- Branch: `gbf/m8-release-closure-20260822`
+- Started/Updated: 2026-08-22 19:52+08
+
+## Acceptance
+- [ ] ADR 记录 `grok-bot-latest-source-fusion` 和 `grok-bot-0.16-source-fusion` 精确 refs 与 RETAIN_READ_ONLY_AUDIT 决策。
+- [ ] repository/project docs 明确 `main` 是唯一运行/发布权威。
+- [ ] CI/release workflow 不引用历史 Grok branches。
+- [ ] no-wholesale-merge rule 保持可机器审计。
+- [ ] post-release branch/ref audit recorded。
+
+## Evidence
+`evidence/GBF-804/README.md` and final ADR.


### PR DESCRIPTION
## FAB-P0004 / GBF — final clean M8 landing

This PR replaces superseded #2034 after M7 was rebuilt. It has exactly one parent commit (`8ffc597f`, final clean M7) and exactly the 12 M8 release/closure files from the validated M8 delta; no stale M5–M7 history is carried.

### M8 scope
- machine-enforced FAB-P0004 release-readiness validator
- exact-head seven-gate release-candidate coordinator
- previous-good immutable rollback drill
- GBF-801..804 evidence/task records
- ADR-0006: historical Grok branches are read-only audit provenance and never production/release authority

### Acceptance
Remain TESTED until M5→M7 reach protected main, this PR is retargeted to main, canonical RC/rollback/release gates pass on the final lineage, the formal release is produced from an immutable main tag, and post-release smoke/project-record closure are recorded.