### PR TITLE
ci(gbf): stabilize post-M6 desktop host gate

### DIFF
--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -19,6 +19,7 @@ jobs:
     name: Test embedded Codex Runtime (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
@@ -45,18 +46,36 @@ jobs:
       - name: Run Cargo fmt check
         run: cargo fmt --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml --all -- --check
       - name: Run Cargo clippy
-        run: >-
-          cargo clippy --locked
-          --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml
-          --package mahayana-agent-codex
-          --package mahayana-ffi
-          --package mahayana-cli
-          --all-targets -- -D warnings
+        shell: bash
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/mahayana-clippy.log"
+          if cargo clippy --locked \
+            --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml \
+            --package mahayana-agent-codex \
+            --package mahayana-ffi \
+            --package mahayana-cli \
+            --all-targets -- -D warnings >"$log" 2>&1; then
+            echo 'Mahayana clippy passed.'
+          else
+            echo 'Mahayana clippy failed; final diagnostics follow.' >&2
+            tail -n 240 "$log" >&2
+            exit 1
+          fi
       - name: Run automated unit and integration tests
         if: runner.os == 'Linux'
-        run: >-
-          cargo test --locked
-          --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml
-          --package mahayana-agent-codex
-          --package mahayana-agent-responses
-          --package mahayana-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/mahayana-tests.log"
+          if cargo test --locked \
+            --manifest-path third_party/mahayana/mahayana-rs/Cargo.toml \
+            --package mahayana-agent-codex \
+            --package mahayana-agent-responses \
+            --package mahayana-cli >"$log" 2>&1; then
+            echo 'Mahayana tests passed.'
+          else
+            echo 'Mahayana tests failed; final diagnostics follow.' >&2
+            tail -n 240 "$log" >&2
+            exit 1
+          fi

--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -139,18 +139,30 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v6-${{ steps.host-source-key.outputs.hash }}
+          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v7-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
 
       - name: Set up Rust on Host cache miss
         if: steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+
+      - name: Install Linux native Host dependencies on cache miss
+        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            pkg-config libclang-dev libxcb1-dev libxrandr-dev libxfixes-dev \
+            libdbus-1-dev libpipewire-0.3-dev libwayland-dev libxkbcommon-dev \
+            libegl1-mesa-dev libgbm-dev
 
       - name: Restore Rust compiler cache on Host cache miss
         if: steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: electron-desktop-host-ci-v5
+          shared-key: electron-desktop-host-ci-v6-rust-1.97.1
 
       - name: Build and stage CI Mahayana Host on cache miss
         if: steps.host-binary-cache.outputs.cache-hit != 'true'
@@ -162,7 +174,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v6-${{ steps.host-source-key.outputs.hash }}
+          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v7-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
 
       - name: Hand off Linux Host binary to package job in the same run
         uses: actions/upload-artifact@v7
@@ -255,18 +267,20 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v6-${{ steps.host-source-key.outputs.hash }}
+          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v7-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
 
       - name: Set up Rust on Host cache miss
         if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
 
       - name: Restore Rust compiler cache on Host cache miss
         if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: electron-package-ci-${{ runner.os }}-v5
+          shared-key: electron-package-ci-${{ runner.os }}-v6-rust-1.97.1
 
       - name: Build and stage CI native Host on cache miss
         if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
@@ -278,7 +292,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v6-${{ steps.host-source-key.outputs.hash }}
+          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v7-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
 
       - name: Build pinned offline ASR engine
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## FAB-P0004 post-M6 stabilization

This lands the Electron CI hardening that missed PR #2031's auto-merge race. It is intentionally isolated from M7.

- pins native Electron Host Rust builds to 1.97.1, matching the canonical embedded Runtime gate
- installs the full Linux native capture/input dependency baseline on Host cache miss
- rotates Host/compiler cache generations so stale binaries cannot make the gate pass
- preserves the full Electron simulated-user smoke and macOS/Windows/Linux package matrix

This PR does not claim FAB-P0004 release completion. M7/M8 remain gated on canonical-main CI and formal release evidence.