### PR TITLE
fix(governance): register DeepSeek Harness project

### DIFF
--- a/projects/PORTFOLIO.json
+++ b/projects/PORTFOLIO.json
@@ -5,7 +5,7 @@
   "project_id_regex": "^FAB-P[0-9]{4}$",
   "allocation_policy": "monotonic-no-reuse",
   "ordering_basis": "first-formal-project-folder-commit-on-canonical-main",
-  "next_sequence": 7,
+  "next_sequence": 8,
   "projects": [
     {
       "project_id": "FAB-P0001",
@@ -72,6 +72,17 @@
       "registered_at": "2026-08-23",
       "first_canonical_main_commit": "173e7f793987b6d0a9303b55e2060e2584552da9",
       "legacy_project_ids": []
+    },
+    {
+      "project_id": "FAB-P0007",
+      "project_key": "DHRF",
+      "slug": "deepseek-harness-rust-fusion",
+      "name": "DeepSeek Harness Rust Fusion",
+      "authoritative_path": "projects/deepseek-harness-rust-fusion",
+      "status": "active",
+      "registered_at": "2026-08-23",
+      "first_canonical_main_commit": "11fd9d32d5b7edf09882ff5308be55b566e1a6d4",
+      "legacy_project_ids": ["DHRF"]
     }
   ]
 }

--- a/projects/deepseek-harness-rust-fusion/PROJECT.yaml
+++ b/projects/deepseek-harness-rust-fusion/PROJECT.yaml
@@ -1,4 +1,5 @@
-project_id: DHRF
+project_id: FAB-P0007
+project_key: DHRF
 name: DeepSeek Harness Rust Fusion
 slug: deepseek-harness-rust-fusion
 status: active
@@ -9,7 +10,7 @@ owner: Fabushi engineering
 reviewers: []
 current_stage: M0-source-audit-and-gap-baseline
 created_at: 2026-08-22
-updated_at: 2026-08-22
+updated_at: 2026-08-23
 risk_tier: tier-1
 security_classification: public
 target_finish: null


### PR DESCRIPTION
Repairs the canonical project portfolio after #1995 introduced `projects/deepseek-harness-rust-fusion` without a permanent Fabushi Project ID.

- allocates immutable `FAB-P0007`
- adds `project_key: DHRF` to the project metadata
- records #1995 merge commit as the first canonical-main project commit
- advances `next_sequence` to 8

This unblocks project-portfolio validation for the remaining PR convergence/merge queue.