### PR TITLE
chore(fcm): close FCM-007 open-PR convergence

### DIFF
--- a/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
@@ -14,5 +14,6 @@
 | FCM-004 | Align Apple/Google store delivery with canonical release gates | yes | exact SHA is on protected main and required CI/platform gates are green before build/upload | passed |
 | FCM-005 | Add narrow sensitive-path ownership and governance contract | yes | CODEOWNERS covers Tier-3 paths without catch-all; contract validates invariants | passed |
 | FCM-006 | Close project records and verify canonical main | yes | full enterprise scaffold + PR/CI/merge evidence + post-merge main verification | passed |
+| FCM-007 | Converge all 2026-08-23 intake PRs into canonical main | yes | every intake PR merged or proven superseded; protected checks preserved; final open-PR verification clean | in-progress |
 
-All required FAB-P0003 tasks are passed. No hidden percentage-based work remains.
+FCM-007 is an active follow-up convergence task. Prior FCM tasks remain passed; project closure is temporarily reopened until FCM-007 acceptance evidence is complete.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-007-merge-open-prs.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-007-merge-open-prs.md
@@ -1,0 +1,67 @@
+# FCM-007 — Merge all current PRs into main
+
+- **Project ID:** FAB-P0003
+- **Project Key:** FCM
+- **Task ID:** FCM-007
+- **Status:** in-progress
+- **Started:** 2026-08-23
+- **Updated:** 2026-08-23
+
+## Objective
+
+Integrate all pull-request work from the 2026-08-23 intake into canonical `main` without duplicating superseded history, losing stacked changes, or bypassing protected-main checks and merge queue rules.
+
+## Source requirement
+
+User request: merge all current PRs into `main`, then continue until all effective work is fully dispositioned.
+
+## In scope
+
+- Inspect every intake PR and current open PR against live GitHub state.
+- Merge effective convergence PRs through required checks/merge queue.
+- Repair deterministic CI or merge-conflict blockers when necessary.
+- Close stacked/superseded PRs only after their effective changes are represented on canonical `main`.
+- Re-read canonical `main` and verify no stale intake PR remains open.
+
+## Out of scope
+
+- Bypassing required CI, branch protection, or merge queue.
+- Claiming a product release that its project-specific release acceptance has not proven.
+
+## Acceptance criteria
+
+1. Every intake PR is either merged or explicitly superseded by an effective merged replacement.
+2. No required effective code/docs changes are lost from the final canonical lineage.
+3. Stacked PRs are handled in dependency order or by a proven final convergence PR containing the stack.
+4. Required GitHub Actions and protected-main rules are not bypassed.
+5. Final verification shows canonical `main` contains the intended effective changes and no stale intake PR remains open.
+6. FCM WBS/status/changelog/evidence are synchronized with the final GitHub facts.
+
+## Verification
+
+- Live PR metadata, diff lineage, mergeability and changed-file comparisons.
+- GitHub Actions workflow/check evidence at each final landing point.
+- Merge commit SHA for each effective convergence PR.
+- Final `main` head SHA and final open-PR search.
+
+## Intake inventory
+
+Original open PRs: #1967, #1992, #1995, #2000, #2004, #2014, #2017, #2018, #2022, #2032, #2036, #2037, #2038.
+
+Verified before this round:
+
+- #1995 merged into `main`; registry repair #2040 also merged.
+- #2017 merged and is the effective Mahayana convergence; #1992/#2000/#2004/#2014 were closed as superseded.
+- #1967 was a reverse synchronization PR and was closed.
+- #2018 was already represented on `main` and was closed as duplicate.
+- Remaining effective work is Grok convergence #2036 and Telegram convergence stack #2022/#2037/#2038.
+
+## Current blockers / risks
+
+- `main` can advance while final PR checks run, requiring mergeability to be re-evaluated.
+- Telegram #2038 was temporarily closed while applying a deterministic Rust exhaustive-match repair and must be reopened only after its final head is valid.
+- Lower stacked PRs must not be closed until the final convergence lineage is verified on `main`.
+
+## Next action
+
+Finish Grok #2036 through protected merge, finish/reopen Telegram #2038 with its two exhaustive-match fixes, then close lower stacked PRs only after their effective changes are canonical. Finally update this task and merge the FCM-007 closure record.


### PR DESCRIPTION
## FAB-P0003 / FCM-007

Governed follow-up task to converge every PR from the 2026-08-23 intake into canonical `main` without bypassing protected-main CI/merge queue rules.

This PR carries only durable FCM-007 execution/evidence records. Feature PRs are landed separately through their own protected checks.

**Do not merge this closure record yet.** It remains in-progress until the intake PR set is fully dispositioned, canonical `main` is re-read, final CI/merge SHAs are recorded, and the final open-PR search is clean.