### PR TITLE
feat(tfi): unify Grok design with Telegram-class Messenger

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -349,3 +349,16 @@ jobs:
           test -s /tmp/production-health.json
           status=$(curl -sS -o /tmp/production-auth.json -w '%{http_code}' "$PRODUCTION_API_URL/api/auth/user-info")
           test "$status" = "401" -o "$status" = "403"
+
+          browser_start_status=$(curl -sS -o /tmp/production-browser-start.json -w '%{http_code}' \
+            -H 'content-type: application/json' \
+            --data '{"platform":"desktop"}' \
+            "$PRODUCTION_API_URL/api/auth/browser/start")
+          test "$browser_start_status" = "200"
+          jq -e '.attemptId and .pollSecret and .loginUrl' /tmp/production-browser-start.json >/dev/null
+          ! grep -Fq 'This Cloudflare Worker is an API backend only.' /tmp/production-browser-start.json
+          login_url=$(jq -er '.loginUrl' /tmp/production-browser-start.json)
+          case "$login_url" in
+            "$PRODUCTION_API_URL/api/auth/browser/portal"*) ;;
+            *) echo "Production browser login escaped canonical API origin: $login_url" >&2; exit 1 ;;
+          esac

--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -50,11 +50,9 @@ async function completeBrowserLogin(page: Page): Promise<void> {
 
 async function openMessenger(page: Page): Promise<void> {
   const workspace = page.getByTestId('messenger-workspace');
-  if (!await workspace.isVisible().catch(() => false)) {
-    await page.getByTestId('open-messenger').click();
-  }
   await expect(workspace).toBeVisible();
   await expect(page.getByTitle('聊天')).toBeVisible();
+  await expect(page.getByTestId('open-messenger')).toHaveCount(0);
 }
 
 async function getMessagingIdentity(page: Page): Promise<{ actorId: string; deviceId: string; sessionId: string }> {
@@ -107,7 +105,7 @@ async function executeMessagingCommand(
   );
 }
 
-test('desktop Messenger exposes Telegram-class navigation and preserves the real AI Host', async () => {
+test('desktop Messenger unifies Telegram-class navigation with Fabushi agent identity', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-e2e-'));
   const app = await launchDesktopApp(appDataDir);
 
@@ -135,6 +133,7 @@ test('desktop Messenger exposes Telegram-class navigation and preserves the real
 
     const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
     await expect(assistant).toBeVisible();
+    await expect(assistant.locator('[data-engine="fabushi-motion-v2"]')).toBeVisible();
     await assistant.click();
     await expect(page.getByTestId('messenger-input')).toBeVisible();
 

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -39,6 +39,7 @@ import {
 } from 'lucide-react';
 import React, { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import HostClient from '../../frontend/apps/web/src/app/host/host-client';
+import { BotMark, type BotMarkState } from '../../frontend/apps/web/src/app/host/bot-mark';
 import type {
   BotSummary,
   ConversationSummary,
@@ -75,7 +76,6 @@ import {
   type WebRtcCallStatus,
 } from './webrtc-call-controller';
 
-type RootSurface = 'ai' | 'messages';
 type MessengerSection =
   | 'chats'
   | 'contacts'
@@ -143,7 +143,6 @@ type EditDialogState = { conversationId: string; messageId: string; originalText
 type InvoiceDialogState = { conversationId: string; title: string; amount: string } | null;
 type InfoTab = 'media' | 'files' | 'links';
 
-const rootSurfaceKey = 'fabushi.desktop.root-surface.v2';
 const messengerSettingsKey = 'fabushi.desktop.messenger-settings.v2';
 const messengerDraftsKey = 'fabushi.desktop.messenger-drafts.v2';
 const initialPeerRenderCount = 120;
@@ -163,6 +162,34 @@ function createTransport(): MahayanaHostTransport {
 function avatarText(title: string): string {
   const value = title.trim();
   return value ? Array.from(value)[0] ?? '聊' : '聊';
+}
+
+
+function isAgentPeer(peer: PeerItem): boolean {
+  const identity = `${peer.kind} ${peer.id} ${peer.actorId ?? ''} ${peer.title}`.toLocaleLowerCase();
+  return peer.kind === 'bot' || /(agent|assistant|mahayana|codex|grok|大乘|智能体)/u.test(identity);
+}
+
+function botMarkStateForPeer(
+  peer: PeerItem,
+  executions: MessagingBotExecution[],
+  busy: boolean,
+  hostReady: boolean,
+): BotMarkState {
+  if (busy) return 'sending';
+  const identities = [peer.id, peer.actorId].filter((value): value is string => Boolean(value));
+  const execution = [...executions]
+    .sort((left, right) => (right.startedAtMs ?? 0) - (left.startedAtMs ?? 0))
+    .find((candidate) => identities.includes(candidate.botId));
+  if (!execution) return hostReady ? 'idle' : 'waking';
+  switch (execution.state) {
+    case 'queued': return 'waking';
+    case 'running': return 'working';
+    case 'waitingForApproval': return 'alerting';
+    case 'failed': return 'error';
+    case 'cancelled': return 'sleeping';
+    case 'completed': return 'result';
+  }
 }
 
 function formatTime(timestamp: number): string {
@@ -273,42 +300,40 @@ function upsertById<T extends { id: string }>(items: T[], item: T): T[] {
 }
 
 export default function DesktopShellV2() {
-  const [surface, setSurface] = useState<RootSurface>(() => {
-    try {
-      return window.localStorage.getItem(rootSurfaceKey) === 'messages' ? 'messages' : 'ai';
-    } catch {
-      return 'ai';
-    }
-  });
+  const authTransport = useMemo(() => createTransport(), []);
+  const [authenticated, setAuthenticated] = useState<boolean | null>(null);
 
   useEffect(() => {
-    try {
-      window.localStorage.setItem(rootSurfaceKey, surface);
-    } catch {
-      // The shell remains usable when storage is unavailable.
-    }
-  }, [surface]);
+    let closed = false;
+    let retryTimer: number | undefined;
+    const checkAuth = async () => {
+      try {
+        const state = await authTransport.authStatus();
+        if (closed) return;
+        setAuthenticated(state.loggedIn);
+        if (!state.loggedIn) retryTimer = window.setTimeout(() => void checkAuth(), 900);
+      } catch {
+        if (closed) return;
+        setAuthenticated(false);
+        retryTimer = window.setTimeout(() => void checkAuth(), 1_800);
+      }
+    };
+    void checkAuth();
+    return () => {
+      closed = true;
+      if (retryTimer) window.clearTimeout(retryTimer);
+      void authTransport.close();
+    };
+  }, [authTransport]);
 
   return (
     <div className={styles.desktopRoot} data-testid="desktop-shell">
-      <nav className={styles.productRail} aria-label="Fabushi 主视图">
-        <button type="button" data-active={surface === 'ai'} onClick={() => setSurface('ai')} title="AI 工作区">
-          <span className={styles.brandOrb}>法</span>
-          <small>AI</small>
-        </button>
-        <button data-testid="open-messenger" type="button" data-active={surface === 'messages'} onClick={() => setSurface('messages')} title="消息">
-          <MessageCircle size={21} />
-          <small>消息</small>
-        </button>
-      </nav>
-      <div className={styles.productSurface}>
-        {surface === 'ai' ? <HostClient /> : <MessengerWorkspace onOpenAi={() => setSurface('ai')} />}
-      </div>
+      {authenticated === true ? <MessengerWorkspace /> : <HostClient />}
     </div>
   );
 }
 
-function MessengerWorkspace({ onOpenAi }: { onOpenAi: () => void }) {
+function MessengerWorkspace() {
   const transport = useMemo(() => createTransport(), []);
   const selfHosted = useMemo(() => new SelfHostedMessagingClientV2(transport), [transport]);
   const [hostReady, setHostReady] = useState(false);
@@ -1508,9 +1533,9 @@ async function saveInvoiceDialog() {
   }
 
   return (
-    <main className={styles.messenger} data-testid="messenger-workspace" onClick={() => setMessageMenu(null)}>
+    <main className={`${styles.messenger} ${styles.fabushiUnified}`} data-testid="messenger-workspace" onClick={() => setMessageMenu(null)}>
       <aside className={styles.navRail}>
-        <button className={styles.railBrand} type="button" onClick={onOpenAi} title="返回 AI 工作区">法</button>
+        <button className={styles.railBrand} type="button" onClick={() => setSection('chats')} title="Fabushi">法</button>
         <RailButton icon={<MessageCircle />} label="聊天" active={section === 'chats'} onClick={() => setSection('chats')} />
         <RailButton icon={<Users />} label="联系人" active={section === 'contacts'} onClick={() => setSection('contacts')} />
         <RailButton icon={<Bot />} label="Bots" active={section === 'bots'} onClick={() => setSection('bots')} />
@@ -1558,7 +1583,15 @@ async function saveInvoiceDialog() {
             </div>
             {renderedPeers.map((peer) => (
               <button data-testid={`peer-${peer.key}`} key={peer.key} type="button" className={peer.key === activePeerKey ? styles.peerActive : styles.peer} onClick={() => void openPeer(peer)}>
-                <span className={styles.avatar}>{peer.avatar ? <img src={peer.avatar} alt="" /> : avatarText(peer.title)}<i data-kind={peer.kind} /></span>
+                {isAgentPeer(peer) ? (
+                  <BotMark
+                    botId={peer.actorId ?? peer.id}
+                    state={botMarkStateForPeer(peer, selfBotExecutions, peer.key === activePeerKey && pendingSend, hostReady)}
+                    size={48}
+                    className={styles.agentAvatarMark}
+                    label={peer.title}
+                  />
+                ) : <span className={styles.avatar}>{peer.avatar ? <img src={peer.avatar} alt="" /> : avatarText(peer.title)}<i data-kind={peer.kind} /></span>}
                 <span className={styles.peerCopy}>
                   <span><strong>{peer.title}</strong><time>{formatTime(peer.updatedAtMs)}</time></span>
                   <small>{peer.subtitle}</small>
@@ -1579,7 +1612,15 @@ async function saveInvoiceDialog() {
           <>
             <header className={styles.chatHeader}>
               <div className={styles.chatIdentity}>
-                <span className={styles.avatar}>{avatarText(activePeer.title)}<i data-kind={activePeer.kind} /></span>
+                {isAgentPeer(activePeer) ? (
+                  <BotMark
+                    botId={activePeer.actorId ?? activePeer.id}
+                    state={botMarkStateForPeer(activePeer, selfBotExecutions, pendingSend, hostReady)}
+                    size={40}
+                    className={styles.agentAvatarMark}
+                    label={activePeer.title}
+                  />
+                ) : <span className={styles.avatar}>{avatarText(activePeer.title)}<i data-kind={activePeer.kind} /></span>}
                 <div><strong>{activePeer.title}</strong><small data-testid="conversation-status">{activeTypingActors.length ? '正在输入…' : `${activePeer.subtitle}${hostReady ? ' · 在线' : ' · 正在连接'}`}</small></div>
               </div>
               <div className={styles.headerActions}>
@@ -1616,7 +1657,7 @@ async function saveInvoiceDialog() {
                   <small>{formatTime(message.createdAtMs)} {message.role === 'me' ? <Check size={12} /> : null}</small>
                 </article>
               ))}
-              {!matchingMessages.length ? <div className={styles.chatEmpty} data-testid="message-search-empty"><span className={styles.avatarLarge}>{avatarText(activePeer.title)}</span><strong>{conversationQuery ? '没有匹配消息' : activePeer.title}</strong><p>{conversationQuery ? '换一个关键词继续搜索。' : '联系人、AI Bot、群组和频道使用同一个 Fabushi 消息产品层。'}</p></div> : null}
+              {!matchingMessages.length ? <div className={styles.chatEmpty} data-testid="message-search-empty">{isAgentPeer(activePeer) ? <BotMark botId={activePeer.actorId ?? activePeer.id} state={botMarkStateForPeer(activePeer, selfBotExecutions, false, hostReady)} size={78} className={styles.agentAvatarMark} label={activePeer.title} /> : <span className={styles.avatarLarge}>{avatarText(activePeer.title)}</span>}<strong>{conversationQuery ? '没有匹配消息' : activePeer.title}</strong><p>{conversationQuery ? '换一个关键词继续搜索。' : '联系人、AI Bot、群组和频道使用同一个 Fabushi 消息产品层。'}</p></div> : null}
             </div>
             {replyTo ? <div className={extra.composerBanner}><Reply size={15} /><div><strong>回复</strong><span>{replyTo.text}</span></div><button type="button" onClick={() => setReplyTo(null)}><X size={14} /></button></div> : null}
             {scheduledAtMs ? <div className={extra.composerBanner}><span>⏱</span><div><strong>定时发送</strong><span>{new Date(scheduledAtMs).toLocaleString()}</span></div><button type="button" onClick={() => setScheduledAtMs(undefined)}><X size={14} /></button></div> : null}
@@ -1647,7 +1688,7 @@ async function saveInvoiceDialog() {
         <aside className={styles.infoPanel}>
           <header><strong>资料</strong><button type="button" onClick={() => setInfoOpen(false)}><X size={17} /></button></header>
           <div className={styles.profileCard}>
-            <span className={styles.avatarHuge}>{avatarText(activePeer.title)}</span>
+            {isAgentPeer(activePeer) ? <BotMark botId={activePeer.actorId ?? activePeer.id} state={botMarkStateForPeer(activePeer, selfBotExecutions, pendingSend, hostReady)} size={92} className={styles.agentProfileMark} label={activePeer.title} /> : <span className={styles.avatarHuge}>{avatarText(activePeer.title)}</span>}
             <strong>{activePeer.title}</strong><small>{activePeer.subtitle}</small>
             <div><button type="button" onClick={() => void startCall('voice')}><PhoneCall size={18} /><span>通话</span></button><button type="button" onClick={() => void startCall('video')}><Video size={18} /><span>视频</span></button><button type="button" onClick={() => setConversationSearchOpen(true)}><Search size={18} /><span>搜索</span></button></div>
           </div>

--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -4,7 +4,7 @@
   width: 100vw;
   height: 100vh;
   display: grid;
-  grid-template-columns: 54px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   overflow: hidden;
   background: #0d1117;
   color: #17212b;
@@ -297,8 +297,241 @@
 }
 
 @media (max-width: 900px) {
-  .desktopRoot { grid-template-columns: 48px minmax(0,1fr); }
+  .desktopRoot { grid-template-columns: minmax(0,1fr); }
   .messenger { grid-template-columns: 60px 280px minmax(360px,1fr); }
   .navRail > button small { display:none; }
   .navRail > button { min-height:44px; }
+}
+
+/* Fabushi unified Messenger: Telegram-class information density with the
+   motion, depth and dark material language inherited from Fabushi/Grok UX. */
+.fabushiUnified {
+  --fabushi-app: #0b0b11;
+  --fabushi-panel: rgba(18, 18, 27, .94);
+  --fabushi-panel-strong: rgba(24, 23, 35, .97);
+  --fabushi-line: rgba(255, 255, 255, .08);
+  --fabushi-muted: #9694a6;
+  --fabushi-accent: #8b5cf6;
+  --fabushi-accent-soft: rgba(139, 92, 246, .18);
+  color: #f7f5fb;
+  background: var(--fabushi-app);
+}
+
+.fabushiUnified .navRail {
+  background:
+    radial-gradient(circle at 50% 4%, rgba(139, 92, 246, .22), transparent 28%),
+    linear-gradient(180deg, #0c0c13 0%, #11101a 100%);
+  border-right: 1px solid var(--fabushi-line);
+  color: #918fa2;
+}
+
+.fabushiUnified .navRail > button:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, .07);
+}
+
+.fabushiUnified .navRail > button[data-active="true"] {
+  color: #fff;
+  background: linear-gradient(145deg, rgba(139, 92, 246, .96), rgba(92, 67, 205, .94));
+  box-shadow: 0 10px 28px rgba(91, 58, 204, .28), inset 0 1px rgba(255, 255, 255, .16);
+}
+
+.fabushiUnified .navRail .railBrand {
+  background: linear-gradient(145deg, #a78bfa, #6d4be8 58%, #4733a9);
+  box-shadow: 0 9px 30px rgba(109, 75, 232, .34), inset 0 1px rgba(255, 255, 255, .3);
+}
+
+.fabushiUnified .chatList,
+.fabushiUnified .infoPanel {
+  background: var(--fabushi-panel);
+  border-color: var(--fabushi-line);
+  backdrop-filter: blur(26px) saturate(1.18);
+}
+
+.fabushiUnified .listHeader,
+.fabushiUnified .chatHeader,
+.fabushiUnified .infoPanel > header,
+.fabushiUnified .inChatSearch {
+  background: rgba(18, 18, 27, .82);
+  border-color: var(--fabushi-line);
+  backdrop-filter: blur(24px) saturate(1.22);
+}
+
+.fabushiUnified .iconButton,
+.fabushiUnified .listHeader button,
+.fabushiUnified .headerActions button,
+.fabushiUnified .infoPanel > header button {
+  color: #aaa7ba;
+}
+
+.fabushiUnified .iconButton:hover,
+.fabushiUnified .listHeader button:hover,
+.fabushiUnified .headerActions button:hover,
+.fabushiUnified .headerActions button[data-active="true"] {
+  color: #fff;
+  background: var(--fabushi-accent-soft);
+}
+
+.fabushiUnified .searchBox {
+  background: rgba(255, 255, 255, .065);
+  color: #8f8c9f;
+  border: 1px solid transparent;
+}
+
+.fabushiUnified .searchBox:focus-within {
+  background: rgba(255, 255, 255, .085);
+  border-color: rgba(167, 139, 250, .56);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, .11);
+}
+
+.fabushiUnified .searchBox input,
+.fabushiUnified .inChatSearch input {
+  color: #f7f5fb;
+}
+
+.fabushiUnified .quickActions button {
+  color: #c8b9ff;
+  background: rgba(139, 92, 246, .09);
+  border: 1px solid rgba(167, 139, 250, .11);
+}
+
+.fabushiUnified .quickActions button:hover {
+  background: rgba(139, 92, 246, .17);
+}
+
+.fabushiUnified .peer,
+.fabushiUnified .peerActive {
+  color: #f4f2f8;
+  border-radius: 14px;
+  margin: 2px 7px;
+  width: calc(100% - 14px);
+}
+
+.fabushiUnified .peer:hover {
+  background: rgba(255, 255, 255, .055);
+}
+
+.fabushiUnified .peerActive,
+.fabushiUnified .peerActive:hover {
+  background: linear-gradient(100deg, rgba(139, 92, 246, .27), rgba(92, 67, 205, .14));
+  box-shadow: inset 0 0 0 1px rgba(167, 139, 250, .18), 0 8px 26px rgba(0, 0, 0, .14);
+}
+
+.fabushiUnified .peerCopy small,
+.fabushiUnified .peerCopy time,
+.fabushiUnified .peerMeta,
+.fabushiUnified .chatIdentity small,
+.fabushiUnified .profileCard > small {
+  color: var(--fabushi-muted);
+}
+
+.fabushiUnified .peerActive .peerCopy small,
+.fabushiUnified .peerActive .peerCopy time {
+  color: #c9c4d8;
+}
+
+.fabushiUnified .chatWorkspace {
+  background:
+    radial-gradient(circle at 78% 8%, rgba(127, 84, 235, .14), transparent 33%),
+    radial-gradient(circle at 18% 82%, rgba(52, 107, 255, .08), transparent 30%),
+    #0d0d14;
+}
+
+.fabushiUnified .chatWorkspace::before {
+  opacity: .13;
+  background-image: radial-gradient(circle at 12px 12px, rgba(201, 188, 255, .2) 1px, transparent 1.2px);
+}
+
+.fabushiUnified .messageMine,
+.fabushiUnified .messagePeer {
+  border: 1px solid rgba(255, 255, 255, .07);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, .18);
+}
+
+.fabushiUnified .messageMine {
+  color: #f9f7ff;
+  background: linear-gradient(145deg, rgba(110, 76, 220, .92), rgba(74, 55, 157, .96));
+}
+
+.fabushiUnified .messagePeer {
+  color: #f2f0f6;
+  background: rgba(31, 30, 42, .94);
+}
+
+.fabushiUnified .messageMine small,
+.fabushiUnified .messagePeer small {
+  color: #b9b3c9;
+}
+
+.fabushiUnified .composer {
+  background: rgba(27, 26, 38, .94);
+  border: 1px solid rgba(255, 255, 255, .08);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, .32), inset 0 1px rgba(255, 255, 255, .04);
+  backdrop-filter: blur(24px) saturate(1.2);
+}
+
+.fabushiUnified .composer textarea {
+  color: #f7f5fb;
+  background: transparent;
+}
+
+.fabushiUnified .composer > button {
+  color: #9e9bad;
+}
+
+.fabushiUnified .composer > button:hover {
+  color: #fff;
+  background: rgba(139, 92, 246, .14);
+}
+
+.fabushiUnified .composer .sendButton,
+.fabushiUnified .composer .sendButton:hover {
+  color: #fff;
+  background: linear-gradient(145deg, #9b72ff, #7350e8);
+  box-shadow: 0 6px 18px rgba(115, 80, 232, .32);
+}
+
+.fabushiUnified .profileCard,
+.fabushiUnified .profileActions,
+.fabushiUnified .infoTabs {
+  border-color: var(--fabushi-line);
+}
+
+.fabushiUnified .profileActions button {
+  color: #d8d4e2;
+}
+
+.fabushiUnified .profileActions button:hover {
+  background: rgba(139, 92, 246, .09);
+}
+
+.fabushiUnified .infoTabs button {
+  color: #908d9e;
+}
+
+.fabushiUnified .infoTabs button[data-active="true"] {
+  color: #c5b5ff;
+  border-bottom-color: #8b5cf6;
+}
+
+.fabushiUnified .infoContent,
+.fabushiUnified .infoContent strong {
+  color: #aaa6b7;
+}
+
+.agentAvatarMark,
+.agentProfileMark {
+  flex: none;
+  filter: drop-shadow(0 7px 16px rgba(82, 55, 186, .22));
+}
+
+.agentProfileMark {
+  margin: 2px 0 5px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agentAvatarMark,
+  .agentProfileMark {
+    filter: none;
+  }
 }

--- a/fabushi/web/tests/platform-control-plane.test.js
+++ b/fabushi/web/tests/platform-control-plane.test.js
@@ -75,10 +75,10 @@ assert.doesNotMatch(identityAuth, /offline_access/, 'sign-in gatekeepers must no
 const accountMigration = read('../../third_party/mahayana/mahayana-rs/mahayana-platform-worker/account-migrations/0005_principals_connections.sql');
 const workspaceMigration = read('../../third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0007_workspace_messaging.sql');
 for (const table of ['account_principals', 'account_contact_points', 'account_connections', 'account_connection_grants']) {
-  assert.match(accountMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\b`), `missing ${table}`);
+  assert.match(accountMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\b`), `missing ${table}`);
 }
 for (const table of ['platform_workspaces', 'platform_agents', 'platform_peers', 'platform_conversations', 'platform_messages']) {
-  assert.match(workspaceMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\b`), `missing ${table}`);
+  assert.match(workspaceMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\b`), `missing ${table}`);
 }
 assert.match(workspaceMigration, /UNIQUE \(conversation_id, seq\)/, 'messages need stable per-conversation ordering');
 assert.match(workspaceMigration, /UNIQUE \(conversation_id, client_nonce\)/, 'message retries need idempotency');

--- a/fabushi/web/tests/platform-control-plane.test.js
+++ b/fabushi/web/tests/platform-control-plane.test.js
@@ -29,8 +29,10 @@ assert.ok(
 
 const gateway = read('src/routes/platform-gateway-routes.js');
 assert.match(gateway, /https:\/\/mahayana-platform\.bhrumom\.workers\.dev/, 'gateway needs an explicit canonical upstream');
+assert.match(gateway, /pathname\.startsWith\('\/api\/auth\/browser\/'\)/, 'browser-first auth must always route through the Mahayana control plane');
 assert.match(gateway, /pathname\.startsWith\('\/v1\/'\)/, 'all v1 platform APIs must go to the Rust control plane');
 assert.match(gateway, /redirect: 'manual'/, 'OAuth redirects must be returned to the browser, not followed by the gateway');
+assert.match(gateway, /X-Fabushi-Control-Plane/, 'proxied browser auth must identify the canonical control plane');
 
 const requestGate = read('src/security/request-gate.js');
 assert.doesNotMatch(requestGate, /TRANSFER_RECEIPT_SECRET|leaderboard/i, 'retired leaderboard gate must stay removed');
@@ -73,10 +75,10 @@ assert.doesNotMatch(identityAuth, /offline_access/, 'sign-in gatekeepers must no
 const accountMigration = read('../../third_party/mahayana/mahayana-rs/mahayana-platform-worker/account-migrations/0005_principals_connections.sql');
 const workspaceMigration = read('../../third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0007_workspace_messaging.sql');
 for (const table of ['account_principals', 'account_contact_points', 'account_connections', 'account_connection_grants']) {
-  assert.match(accountMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\b`), `missing ${table}`);
+  assert.match(accountMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\b`), `missing ${table}`);
 }
 for (const table of ['platform_workspaces', 'platform_agents', 'platform_peers', 'platform_conversations', 'platform_messages']) {
-  assert.match(workspaceMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\b`), `missing ${table}`);
+  assert.match(workspaceMigration, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\b`), `missing ${table}`);
 }
 assert.match(workspaceMigration, /UNIQUE \(conversation_id, seq\)/, 'messages need stable per-conversation ordering');
 assert.match(workspaceMigration, /UNIQUE \(conversation_id, client_nonce\)/, 'message retries need idempotency');

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -24,7 +24,7 @@
 | 媒体 | media/blob_store + desktop attachment | M4 | IMPLEMENTED | 需大文件 resume/retry/permissions/cache 验收 |
 | 联系人/群组 | actor/conversation/community | M5 | IMPLEMENTED | 需 owner/admin/member/restricted 权限矩阵 |
 | 频道/Topic | conversation/community | M6 | IMPLEMENTED | 需广播/分页/Topic 状态规模验收 |
-| Bot/Agent | bot + Actor/Feature Host | M7 | IMPLEMENTED | 需统一联系人/Agent-to-Agent acceptance |
+| Bot/Agent | bot + Actor/Feature Host + unified Messenger | M7 | IN_PROGRESS | M7-DESKTOP-001：单一桌面壳、Motion v2 Agent identity、统一 composer；PR #2046 current-head CI/E2E pending |
 | Mini Apps | miniapp + Host bridge | M8 | IMPLEMENTED | 需授权/撤销/沙箱 E2E |
 | 支付 | payment/settlement/wallet | M9 | IMPLEMENTED | 需 sandbox E2E / webhook replay evidence |
 | 音视频 | realtime/signaling + desktop WebRTC | M10 | IMPLEMENTED | 需跨端/TURN/SFU/网络切换实测 |
@@ -47,3 +47,8 @@
 ## Active M3 acceptance
 
 M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded peer/message rendering, typing semantics and existing Messenger interactions with current GitHub typecheck/Playwright evidence before M3 closes.
+
+
+## Active M7 unified desktop acceptance — 2026-08-23
+
+`M7-DESKTOP-001` 将 Grok/Fabushi 已自研的 Motion v2 动态 Agent identity 与 Telegram-class Messenger 合并为一个产品界面。验收要求：认证后不存在第二套 `AI / 消息` product switcher；AI/Bot、人类、群组、频道共用 Messenger peer/conversation surface；生产 browser-first auth smoke 必须覆盖 `/api/auth/browser/start`。当前仅为 `IN_PROGRESS`，等待 PR #2046 current-head CI、E2E、protected merge、production deployment 与 canonical-main 验证。

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -57,3 +57,12 @@ M3 第一批 UI 改动已在 `feat/telegram-m3-desktop-ux` 实现，后续必须
 - GitHub `main:projects/telegram-fabushi-integration/` 为唯一工程权威源。
 - immutable identity = `FAB-P0001 / TFI`。
 - 任何阶段都必须 current-head CI + protected merge + canonical-main verification 才能关账。
+
+
+## 2026-08-23 — M7 Grok × Telegram unified UI started
+
+- 新任务 `M7-DESKTOP-001` 已启动：不再在 Fabushi 中并排维护“AI 工作区”和“消息工作区”，而是以 Telegram-class Messenger 为统一信息架构，吸收 Grok/Fabushi 的 Motion v2 动态 Agent identity、深色层次、状态反馈与交互质感。
+- 实现分支：`feat/tfi-m7-grok-telegram-unified-ui`；PR #2046。
+- 当前实现：预登录继续复用安全 browser-first 登录体验；认证后直接进入唯一 Messenger Shell；AI/Bot 与真人 peer 共用会话列表、聊天区和 composer；AI identity 使用 `BotMark` / `fabushi-motion-v2` 状态引擎。
+- 同轮修复生产登录回归防线：`deploy-production.yml` production smoke 将真实 POST `/api/auth/browser/start`，拒绝 legacy Worker 404 fallback。
+- 2026-08-23 实测生产 `https://api.ombhrum.com/api/auth/browser/start` 仍返回 HTTP 404 + `This Cloudflare Worker is an API backend only.`，因此任务保持 `IN_PROGRESS`，需 PR 合并后的 production CD/Cloudflare deployment 证据。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -52,3 +52,11 @@
 
 - OWNERS、dependency/blocker register、issue/action register 与 messaging/SQLite runbooks 持续维护。
 - 每轮工作必须同步 task/WBS/acceptance/status/changelog/evidence；未有客观证据不得标记完成。
+
+
+## 2026-08-23 — Grok design converges into the unified Messenger
+
+- 用户明确要求把 Grok Bot 融合进 Telegram UI，而不是保留两套视觉/产品 surface。
+- `M7-DESKTOP-001` 固化目标：Telegram 提供成熟 IM 信息架构和功能密度；Fabushi/Grok 已自研能力提供 Motion v2 动态 Agent identity、状态反馈、深色材质和交互质感；最终只保留一个 Fabushi Messenger Shell。
+- 禁止通过新增第二套 Agent runtime、Host runtime 或聊天状态机完成视觉融合。
+- 同步增加 production browser-first auth smoke，防止 `api.ombhrum.com/api/auth/browser/start` 再次落到 legacy 404。

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
@@ -8,6 +8,8 @@
 - **Started**: `2026-08-23`
 - **Updated**: `2026-08-23`
 - **Branch**: `feat/tfi-m7-grok-telegram-unified-ui`
+- **Implementation commit**: `9c31c73dde2cbe8c3dc2246ea9918f1f32409e87`
+- **PR**: `#2046`
 
 ## Objective
 
@@ -47,20 +49,28 @@
 6. GitHub Actions 的 desktop/typecheck/Playwright/Worker relevant gates 通过后才允许提升为 TESTED。
 7. 受保护 main 合并并 canonical readback 后才允许完成任务。
 
-## Verification plan
+## Implementation summary
 
-- GitHub Actions only；遵守仓库规则，不在本地构建或运行 E2E。
-- Desktop TypeScript/typecheck gate。
-- Messenger Playwright E2E。
-- Worker regression / production smoke workflow。
-- Project portfolio governance if project records change classification requires it.
+- DesktopShellV2 已移除外层 `AI / 消息` product rail；预登录阶段继续复用现有 browser-first Host 登录体验，认证成功后直接切入唯一 Messenger。
+- Messenger rail 成为唯一主导航，品牌按钮返回 Chats，不再返回独立 AI workspace。
+- AI/Bot peer 的列表头像、会话 header、空态和资料页复用 `BotMark` / `fabushi-motion-v2`；`MessagingBotExecution` 的 `queued/running/waitingForApproval/completed/failed/cancelled` 映射到动态视觉状态。
+- Messenger 新增 Fabushi/Grok 风格的深色、玻璃、紫色动态材质层，同时保留 Telegram-class 三栏布局、高密度操作和统一 composer。
+- Desktop E2E 新增“不存在 `open-messenger` 第二产品切换器”与 Assistant peer Motion v2 identity 断言。
+- Production smoke 新增真实 `/api/auth/browser/start` POST、payload/schema/origin/legacy-fallback 检查。
 
-## Risks
+## Verification / evidence
 
-- 当前 Messenger 仍含 legacy Host conversation adapter，需防止在 UI 融合时制造第二套状态机。
-- BotMark 当前位于 web Host 组件目录，桌面直接复用必须保持依赖边界可构建。
-- 生产 auth 失败可能来自 Cloudflare 自定义域实际绑定版本；代码 smoke 修复只能防止再次部署错误，最终仍需 deployment evidence。
+- Lightweight source gate: `git diff --check` — PASS on implementation branch.
+- Live production probe on 2026-08-23: `POST https://api.ombhrum.com/api/auth/browser/start` returned **HTTP 404** with `This Cloudflare Worker is an API backend only.`. This proves the user-visible login defect is still present in production before the repair is deployed.
+- PR #2046 current-head workflows started for commit `9c31c73d...`: `Messaging Product Gate`, `Fabushi self-hosted messaging`, `Electron desktop quality gate`, repository `CI`, and `Project portfolio governance`.
+- Heavy build/E2E verification remains GitHub Actions only per repository policy.
+
+## Risks / blockers
+
+- Current production custom domain is still serving the legacy 404 path for browser auth; completion is blocked until protected merge + production CD + endpoint readback.
+- Messenger still includes the intentional legacy Host conversation adapter during migration; this task must not create an additional state machine.
+- BotMark is reused from the canonical Fabushi Host UI module; CI must prove cross-surface import/build compatibility.
 
 ## Next action
 
-实现单壳 UI、BotMark 动态 Agent identity、production browser-auth smoke gate，并提交 PR 触发 GitHub Actions。
+Wait for PR #2046 current-head CI. Repair any failures on the same branch, then merge through protected main, let Worker production CD run, verify `/api/auth/browser/start` no longer returns the legacy 404, and only then close project records.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
@@ -1,0 +1,66 @@
+# M7-DESKTOP-001 — Grok Bot × Telegram unified desktop UI
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M7-DESKTOP-001`
+- **Stage**: `M7 Bot/Agent 统一联系人体系`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-23`
+- **Updated**: `2026-08-23`
+- **Branch**: `feat/tfi-m7-grok-telegram-unified-ui`
+
+## Objective
+
+将现有 Grok/Fabushi Agent 交互设计融合进 Telegram-class Messenger，而不是继续维持“AI 工作区”和“消息工作区”两套产品界面。最终桌面端只保留一套 Fabushi Messenger Shell：真人、Bot、AI Agent、群组、频道、Mini App、支付共用同一信息架构和视觉语言。
+
+同时修复当前桌面登录入口暴露的生产控制平面 404 回归：生产部署必须显式验证 `/api/auth/browser/start`，避免 `api.ombhrum.com` 回落到 legacy Worker 404。
+
+## Source requirements
+
+- `docs/02-产品需求-PRD.md`：AI Agent 是一等联系人，通信不是外挂 IM。
+- `docs/07-客户端架构与交互.md`：桌面端采用 Telegram 类成熟 IM 密度，但必须使用 Fabushi 设计语言。
+- `management/wbs/M7.md`：真人和 Agent 使用同一消息内核，UI 不再使用独立第二套聊天实现。
+- 用户 2026-08-23 明确要求：把 Grok Bot 融合进 Telegram UI，吸收 Grok Bot 的优秀设计，并修复当前登录错误与双侧边栏。
+
+## In scope
+
+- 移除 DesktopShellV2 最外层 `AI / 消息` 产品切换 rail，避免双侧边栏。
+- Messenger 成为唯一桌面主壳；AI/Bot 作为统一 peer/conversation 出现在同一会话系统。
+- 复用 Fabushi Motion v2 / BotMark 作为 AI Bot/Agent 的动态身份头像，并在列表、会话 header、资料页体现运行状态。
+- 调整 Messenger 视觉层：更接近 Grok/Fabushi 的深色、玻璃、动态层次，但保留 Telegram 的高密度信息架构与交互效率。
+- 为生产 Worker smoke 增加 `/api/auth/browser/start` 路由验证，防止 browser-first auth 404 回归。
+- 更新 Playwright/静态契约，明确只允许一套 desktop navigation shell。
+
+## Out of scope
+
+- 本任务不重写 Rust Messaging Core。
+- 不引入第二套 Agent runtime / Host runtime。
+- 不复制 Grok 商标、品牌资源或外部运行时；仅融合已经进入 Fabushi 的自研 Motion v2/Agent 交互能力。
+
+## Acceptance criteria
+
+1. Electron renderer 不再渲染 `productRail` 的 `AI / 消息` 双产品切换。
+2. Messenger 主导航只保留一套 rail；Bots/Agents 与真人联系人在同一会话列表/聊天区工作。
+3. AI/Bot peer 使用 `BotMark` 动态身份表现，运行中/等待审批/失败等状态能映射到视觉状态。
+4. Playwright 明确断言不存在第二层 `AI / 消息` rail，并继续覆盖 Telegram-class 导航与 AI peer 消息发送。
+5. `deploy-production.yml` 的 production smoke 对 `/api/auth/browser/start` 发起真实 POST，并拒绝 404/legacy fallback。
+6. GitHub Actions 的 desktop/typecheck/Playwright/Worker relevant gates 通过后才允许提升为 TESTED。
+7. 受保护 main 合并并 canonical readback 后才允许完成任务。
+
+## Verification plan
+
+- GitHub Actions only；遵守仓库规则，不在本地构建或运行 E2E。
+- Desktop TypeScript/typecheck gate。
+- Messenger Playwright E2E。
+- Worker regression / production smoke workflow。
+- Project portfolio governance if project records change classification requires it.
+
+## Risks
+
+- 当前 Messenger 仍含 legacy Host conversation adapter，需防止在 UI 融合时制造第二套状态机。
+- BotMark 当前位于 web Host 组件目录，桌面直接复用必须保持依赖边界可构建。
+- 生产 auth 失败可能来自 Cloudflare 自定义域实际绑定版本；代码 smoke 修复只能防止再次部署错误，最终仍需 deployment evidence。
+
+## Next action
+
+实现单壳 UI、BotMark 动态 Agent identity、production browser-auth smoke gate，并提交 PR 触发 GitHub Actions。

--- a/projects/telegram-fabushi-integration/management/wbs/M7.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M7.md
@@ -4,23 +4,23 @@
 
 - **交付物**：Participant::Agent/Bot
 - **验收标准**：真人和 Agent 使用同一消息内核；Agent-to-Agent 可通信；UI 不再使用独立第二套聊天实现
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
-- **来源**：源计划 M7
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **客观验证**：Messenger Playwright 断言单一 desktop shell，AI Assistant peer 使用 Fabushi Motion v2 BotMark 并可在统一 composer 发送消息。
+- **来源**：源计划 M7 + 用户 2026-08-23 Grok × Telegram UI 融合要求
+- **状态**：IN_PROGRESS
+- **阻塞**：PR #2046 current-head GitHub typecheck/Playwright pending
+- **证据位置**：`M7-DESKTOP-001`; `desktop/src/messaging-shell-v2.tsx`; `desktop/e2e/messenger.spec.ts`
+- **下一步**：PR current-head CI 后提升 TESTED。
 
 ### M7.T02 — Agent conversation
 
 - **交付物**：Agent conversation
 - **验收标准**：真人和 Agent 使用同一消息内核；Agent-to-Agent 可通信；UI 不再使用独立第二套聊天实现
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
-- **来源**：源计划 M7
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **客观验证**：Electron 不再渲染外层 `AI / 消息` product rail；认证后直接进入统一 Messenger，AI conversation 与真人 peer 共用同一列表/聊天区。
+- **来源**：源计划 M7 + 用户 2026-08-23 Grok × Telegram UI 融合要求
+- **状态**：IN_PROGRESS
+- **阻塞**：PR #2046 current-head GitHub desktop E2E pending
+- **证据位置**：`M7-DESKTOP-001`; `desktop/src/messaging-shell-v2.tsx`
+- **下一步**：完成 CI、protected merge 与 canonical-main readback。
 
 ### M7.T03 — group @Agent
 
@@ -76,4 +76,3 @@
 - **阻塞**：无/待执行时更新
 - **证据位置**：待填写（commit / PR / CI run / release / test report）
 - **下一步**：领取后补充实现路径与测试名称。
-


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: `M7-DESKTOP-001`

## What changes
- removes the outer `AI / 消息` product switcher so authenticated desktop users enter one Messenger shell;
- keeps the existing secure browser-first login surface before authentication;
- fuses Fabushi/Grok Motion v2 `BotMark` identity into Agent/Bot peers, headers, empty state and profile, mapped from bot execution state;
- applies Fabushi/Grok dark glass/motion visual language while preserving Telegram-class navigation density and messaging interaction model;
- strengthens desktop E2E to prove there is no second product switcher and that the Assistant peer renders Motion v2 identity;
- adds production CD smoke coverage for `POST /api/auth/browser/start` and explicitly rejects the legacy Worker 404 fallback.

## Current production defect confirmed
`POST https://api.ombhrum.com/api/auth/browser/start` currently returns HTTP 404 with `This Cloudflare Worker is an API backend only.`. This PR adds the missing deployment acceptance gate; production repair is not complete until merge/CD and endpoint readback succeed.

## Verification
Heavy build/E2E verification is GitHub Actions only per repository policy. Local work was limited to source inspection and `git diff --check`.