### PR TITLE
fix(tfi): restore final messaging product gate

### DIFF
--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -11078,7 +11078,7 @@ mod tests {
                 RemoteComputerLocalSession {
                     device_id: "desktop-a".into(),
                     client_id: "phone-a".into(),
-                    expires_at_seconds: now_seconds() + 60,
+                    expires_at_seconds: now_millis() / 1_000 + 60,
                     generation: 7,
                 },
             );


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: `M7-DESKTOP-001`
- Follow-up to merged #2046

## Why
The broader Messaging Product Gate exposed a pre-existing Feature Host test compile error after #2046: `now_seconds()` no longer exists. The canonical clock helper is `now_millis()`.

## Change
Use `now_millis() / 1_000 + 60` for the test-only remote-computer session expiry.

This clean PR is based directly on current `main` and contains only this one-line gate repair. Heavy verification is GitHub Actions only.