### PR TITLE
fix(tfi): use Cloudflare service binding for Mahayana auth gateway

### DIFF
--- a/fabushi/web/src/routes/platform-gateway-routes.js
+++ b/fabushi/web/src/routes/platform-gateway-routes.js
@@ -26,6 +26,17 @@ function platformOrigin(env) {
   return url.origin;
 }
 
+async function fetchPlatform(env, request) {
+  // Cloudflare can return a workers.dev placeholder when one Worker fetches
+  // another Worker in the same account through the public workers.dev hostname.
+  // The service binding keeps this hop on Cloudflare's internal Worker network
+  // and makes browser auth deterministic in staging and production.
+  if (env.MAHAYANA_PLATFORM && typeof env.MAHAYANA_PLATFORM.fetch === 'function') {
+    return env.MAHAYANA_PLATFORM.fetch(request);
+  }
+  return fetch(request, { redirect: 'manual' });
+}
+
 export async function routePlatformGateway({ pathname, request, env }) {
   if (!isCanonicalPlatformPath(pathname)) return null;
 
@@ -35,7 +46,7 @@ export async function routePlatformGateway({ pathname, request, env }) {
     // Manual redirect handling is essential for OAuth/browser-first auth: the
     // user's browser, not this gateway Worker, must follow provider redirects.
     const upstreamRequest = new Request(target.toString(), request);
-    const upstream = await fetch(upstreamRequest, { redirect: 'manual' });
+    const upstream = await fetchPlatform(env, upstreamRequest);
     const headers = new Headers(upstream.headers);
     headers.set('X-Fabushi-Control-Plane', 'mahayana-platform');
     return new Response(upstream.body, {

--- a/fabushi/web/tests/platform-control-plane.test.js
+++ b/fabushi/web/tests/platform-control-plane.test.js
@@ -33,6 +33,16 @@ assert.match(gateway, /pathname\.startsWith\('\/api\/auth\/browser\/'\)/, 'brows
 assert.match(gateway, /pathname\.startsWith\('\/v1\/'\)/, 'all v1 platform APIs must go to the Rust control plane');
 assert.match(gateway, /redirect: 'manual'/, 'OAuth redirects must be returned to the browser, not followed by the gateway');
 assert.match(gateway, /X-Fabushi-Control-Plane/, 'proxied browser auth must identify the canonical control plane');
+assert.match(gateway, /env\.MAHAYANA_PLATFORM\.fetch\(request\)/, 'same-account platform forwarding must prefer the Cloudflare service binding');
+
+const workerWrangler = read('wrangler.toml');
+for (const environment of ['production', 'development']) {
+  assert.match(
+    workerWrangler,
+    new RegExp(`\\[\\[env\\.${environment}\\.services\\]\\][\\s\\S]*?binding = "MAHAYANA_PLATFORM"[\\s\\S]*?service = "mahayana-platform"`),
+    `${environment} must bind the Mahayana platform Worker internally`,
+  );
+}
 
 const requestGate = read('src/security/request-gate.js');
 assert.doesNotMatch(requestGate, /TRANSFER_RECEIPT_SECRET|leaderboard/i, 'retired leaderboard gate must stay removed');

--- a/fabushi/web/wrangler.toml
+++ b/fabushi/web/wrangler.toml
@@ -2,6 +2,10 @@ name = "fabushi-flutter-web"
 main = "worker-modular.js"
 compatibility_date = "2024-08-01"
 
+[[services]]
+binding = "MAHAYANA_PLATFORM"
+service = "mahayana-platform"
+
 [[kv_namespaces]]
 binding = "USERS_KV"
 id = "20bc68276a0345ab9b5cbf17c1bd51c5"
@@ -64,6 +68,10 @@ routes = [
 ]
 workers_dev = false
 
+[[env.production.services]]
+binding = "MAHAYANA_PLATFORM"
+service = "mahayana-platform"
+
 [[env.production.kv_namespaces]]
 binding = "USERS_KV"
 id = "20bc68276a0345ab9b5cbf17c1bd51c5"
@@ -115,6 +123,10 @@ ALIPAY_RETURN_URL = "https://flutter.ombhrum.com/payment-success.html"
 
 [env.development]
 name = "fabushi-flutter-web-dev"
+
+[[env.development.services]]
+binding = "MAHAYANA_PLATFORM"
+service = "mahayana-platform"
 
 [[env.development.kv_namespaces]]
 binding = "USERS_KV"

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
@@ -7,70 +7,89 @@
 - **Status**: `IN_PROGRESS`
 - **Started**: `2026-08-23`
 - **Updated**: `2026-08-23`
-- **Branch**: `feat/tfi-m7-grok-telegram-unified-ui`
-- **Implementation commit**: `9c31c73dde2cbe8c3dc2246ea9918f1f32409e87`
-- **PR**: `#2046`
+- **Primary implementation PR**: `#2046`
+- **Product-gate repair PR**: `#2048`
+- **Auth gateway repair PR**: `#2049`
 
 ## Objective
 
-将现有 Grok/Fabushi Agent 交互设计融合进 Telegram-class Messenger，而不是继续维持“AI 工作区”和“消息工作区”两套产品界面。最终桌面端只保留一套 Fabushi Messenger Shell：真人、Bot、AI Agent、群组、频道、Mini App、支付共用同一信息架构和视觉语言。
+将 Grok/Fabushi Agent 的优秀交互设计融合进 Telegram-class Messenger，而不是继续维持“AI 工作区”和“消息工作区”两套产品界面。最终桌面端只保留一套 Fabushi Messenger Shell：真人、Bot、AI Agent、群组、频道、Mini App、支付共用同一信息架构和视觉语言。
 
-同时修复当前桌面登录入口暴露的生产控制平面 404 回归：生产部署必须显式验证 `/api/auth/browser/start`，避免 `api.ombhrum.com` 回落到 legacy Worker 404。
+同时修复用户当前看到的 browser-first 登录 404，确保 `api.ombhrum.com/api/auth/browser/start` 真实到达 Mahayana Platform，而不是落到 legacy Worker 或 Cloudflare workers.dev placeholder。
 
 ## Source requirements
 
 - `docs/02-产品需求-PRD.md`：AI Agent 是一等联系人，通信不是外挂 IM。
-- `docs/07-客户端架构与交互.md`：桌面端采用 Telegram 类成熟 IM 密度，但必须使用 Fabushi 设计语言。
+- `docs/07-客户端架构与交互.md`：桌面端采用 Telegram 类成熟 IM 密度，但使用 Fabushi 设计语言。
 - `management/wbs/M7.md`：真人和 Agent 使用同一消息内核，UI 不再使用独立第二套聊天实现。
 - 用户 2026-08-23 明确要求：把 Grok Bot 融合进 Telegram UI，吸收 Grok Bot 的优秀设计，并修复当前登录错误与双侧边栏。
 
 ## In scope
 
-- 移除 DesktopShellV2 最外层 `AI / 消息` 产品切换 rail，避免双侧边栏。
+- 删除 DesktopShellV2 最外层 `AI / 消息` 产品切换 rail，避免双侧边栏。
 - Messenger 成为唯一桌面主壳；AI/Bot 作为统一 peer/conversation 出现在同一会话系统。
-- 复用 Fabushi Motion v2 / BotMark 作为 AI Bot/Agent 的动态身份头像，并在列表、会话 header、资料页体现运行状态。
-- 调整 Messenger 视觉层：更接近 Grok/Fabushi 的深色、玻璃、动态层次，但保留 Telegram 的高密度信息架构与交互效率。
-- 为生产 Worker smoke 增加 `/api/auth/browser/start` 路由验证，防止 browser-first auth 404 回归。
-- 更新 Playwright/静态契约，明确只允许一套 desktop navigation shell。
+- 复用 Fabushi Motion v2 / BotMark 作为 AI Bot/Agent 动态身份头像，并把执行状态映射到视觉状态。
+- 将 Messenger 视觉层收敛为 Fabushi/Grok 深色、玻璃、动态层次，同时保留 Telegram 的高密度信息架构与成熟交互。
+- 修复生产 browser-first auth 网关并建立部署 smoke 防回归。
 
 ## Out of scope
 
-- 本任务不重写 Rust Messaging Core。
-- 不引入第二套 Agent runtime / Host runtime。
+- 不重写 Rust Messaging Core。
+- 不引入第二套 Agent runtime / Host runtime / messaging state machine。
 - 不复制 Grok 商标、品牌资源或外部运行时；仅融合已经进入 Fabushi 的自研 Motion v2/Agent 交互能力。
 
 ## Acceptance criteria
 
-1. Electron renderer 不再渲染 `productRail` 的 `AI / 消息` 双产品切换。
+1. Electron renderer 不再渲染外层 `AI / 消息` 双产品切换。
 2. Messenger 主导航只保留一套 rail；Bots/Agents 与真人联系人在同一会话列表/聊天区工作。
 3. AI/Bot peer 使用 `BotMark` 动态身份表现，运行中/等待审批/失败等状态能映射到视觉状态。
-4. Playwright 明确断言不存在第二层 `AI / 消息` rail，并继续覆盖 Telegram-class 导航与 AI peer 消息发送。
-5. `deploy-production.yml` 的 production smoke 对 `/api/auth/browser/start` 发起真实 POST，并拒绝 404/legacy fallback。
-6. GitHub Actions 的 desktop/typecheck/Playwright/Worker relevant gates 通过后才允许提升为 TESTED。
-7. 受保护 main 合并并 canonical readback 后才允许完成任务。
+4. Playwright 明确断言不存在第二层 `AI / 消息` rail，并覆盖 AI peer 在统一 composer 发送消息。
+5. 生产 `POST /api/auth/browser/start` 返回 200 且 payload 含 `attemptId` / `pollSecret` / `loginUrl`，不得返回 legacy/Cloudflare 404。
+6. Desktop/Messaging/Platform relevant GitHub Actions 通过。
+7. 受保护 main 合并、production CD 与 canonical/live readback 后才允许关闭任务。
 
 ## Implementation summary
 
-- DesktopShellV2 已移除外层 `AI / 消息` product rail；预登录阶段继续复用现有 browser-first Host 登录体验，认证成功后直接切入唯一 Messenger。
-- Messenger rail 成为唯一主导航，品牌按钮返回 Chats，不再返回独立 AI workspace。
-- AI/Bot peer 的列表头像、会话 header、空态和资料页复用 `BotMark` / `fabushi-motion-v2`；`MessagingBotExecution` 的 `queued/running/waitingForApproval/completed/failed/cancelled` 映射到动态视觉状态。
-- Messenger 新增 Fabushi/Grok 风格的深色、玻璃、紫色动态材质层，同时保留 Telegram-class 三栏布局、高密度操作和统一 composer。
-- Desktop E2E 新增“不存在 `open-messenger` 第二产品切换器”与 Assistant peer Motion v2 identity 断言。
-- Production smoke 新增真实 `/api/auth/browser/start` POST、payload/schema/origin/legacy-fallback 检查。
+### UI convergence — PR #2046
+
+- `DesktopShellV2` 已移除外层 `AI / 消息` product rail；未登录继续复用 browser-first 登录体验，认证后直接进入唯一 Messenger。
+- Messenger rail 成为唯一主导航；AI/Bot 与真人 peer 共用列表、聊天区和 composer。
+- 列表头像、会话 header、空态和资料页复用 `BotMark` / `fabushi-motion-v2`。
+- `MessagingBotExecution` 的 `queued/running/waitingForApproval/completed/failed/cancelled` 映射到动态视觉状态。
+- Messenger 吸收 Fabushi/Grok 的深色玻璃、紫色动态材质和状态反馈，同时保留 Telegram-class 三栏密度与交互效率。
+- E2E 新增“不存在 `open-messenger` 第二产品切换器”以及 Assistant Motion v2 identity 断言。
+- #2046 已通过受保护流程合并到 `main`，merge commit `fea29e5c7958c31461af555f4292bfbf9ee443cc`。
+
+### Final messaging product gate — PR #2048
+
+- 广义 Messaging Product Gate 暴露既有 Feature Host 测试使用已移除 `now_seconds()` 的编译错误。
+- #2048 将测试时钟改为 canonical `now_millis() / 1_000`，已合并到 `main`，merge commit `ccd84bf5f9533ca4938c01715431798a7645d254`。
+- Messaging Product Gate run `32623488713`：SUCCESS；Electron Messenger contract、TypeScript Messenger V2、Rust self-hosted messaging/Feature Host bridge 均通过。
+
+### Browser-auth root cause and service-binding repair — PR #2049
+
+- #2046 后 production CD run `32623442672`：staging Worker deploy 成功，但 staging API E2E 失败，因此 production deploy/smoke 被阻断。
+- 现场探测确认：staging `/api/auth/browser/start` 响应带 `X-Fabushi-Control-Plane: mahayana-platform`，证明 Fabushi gateway 已命中；但响应体是 Cloudflare workers.dev `There is nothing here yet` 404。
+- 同一时刻从外部直接调用 `https://mahayana-platform.bhrumom.workers.dev/api/auth/browser/start` 返回 200 和有效 browser-login attempt，证明 Mahayana Platform 本身健康。
+- 根因收敛为同 Cloudflare account 内 Worker 通过 public `workers.dev` hostname 再 fetch 另一个 Worker 的不可靠 upstream hop。
+- #2049 在 `fabushi/web/wrangler.toml` 为 default/development/production 增加 `MAHAYANA_PLATFORM -> mahayana-platform` Cloudflare Service Binding；gateway 优先使用 `env.MAHAYANA_PLATFORM.fetch()`，只保留 public HTTPS 作为 fallback。
+- `platform-control-plane.test.js` 新增 service-binding 与 production/development binding 静态契约，防止未来回退到 public workers.dev hop。
 
 ## Verification / evidence
 
-- Lightweight source gate: `git diff --check` — PASS on implementation branch.
-- Live production probe on 2026-08-23: `POST https://api.ombhrum.com/api/auth/browser/start` returned **HTTP 404** with `This Cloudflare Worker is an API backend only.`. This proves the user-visible login defect is still present in production before the repair is deployed.
-- PR #2046 current-head workflows started for commit `9c31c73d...`: `Messaging Product Gate`, `Fabushi self-hosted messaging`, `Electron desktop quality gate`, repository `CI`, and `Project portfolio governance`.
-- Heavy build/E2E verification remains GitHub Actions only per repository policy.
+- UI source + E2E: PR #2046 merged, `fea29e5c...`。
+- Messaging product gate: run `32623488713` SUCCESS。
+- Product-gate repair: PR #2048 merged, `ccd84bf5...`。
+- Failed deployment evidence exposing auth root cause: CD run `32623442672`，staging deploy passed, staging API E2E failed, production skipped。
+- Direct upstream probe: Mahayana Platform `/health` 200；direct browser auth start 200。
+- Public production probe before #2049 deployment: `POST https://api.ombhrum.com/api/auth/browser/start` still returns HTTP 404 legacy fallback。
+- Heavy build/E2E/deployment verification remains GitHub Actions only per repository policy。
 
 ## Risks / blockers
 
-- Current production custom domain is still serving the legacy 404 path for browser auth; completion is blocked until protected merge + production CD + endpoint readback.
-- Messenger still includes the intentional legacy Host conversation adapter during migration; this task must not create an additional state machine.
-- BotMark is reused from the canonical Fabushi Host UI module; CI must prove cross-surface import/build compatibility.
+- #2049 current-head CI、protected merge、production CD 和 live endpoint readback 尚未完成，因此登录修复仍不可宣称完成。
+- 当前用户安装的 Mac 客户端要看到新的统一 UI，还需要对应 Electron package/release 安装验证；源码合并不等于已安装版本自动变化。
 
 ## Next action
 
-Wait for PR #2046 current-head CI. Repair any failures on the same branch, then merge through protected main, let Worker production CD run, verify `/api/auth/browser/start` no longer returns the legacy 404, and only then close project records.
+等待 PR #2049 Platform Control Plane/CI 通过并合并；随后观察 Worker production CD，要求 staging E2E、production deploy、production smoke 全绿；再 live probe `api.ombhrum.com/api/auth/browser/start`。之后更新 WBS/验收矩阵/status/changelog/evidence 并决定是否触发最新 Electron macOS 安装包发布验证。


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: `M7-DESKTOP-001`
- Follow-up to merged #2046/#2048

## Root cause
The Fabushi staging Worker correctly entered `routePlatformGateway`, but Worker-to-Worker fetches to `https://mahayana-platform.bhrumom.workers.dev` returned Cloudflare's `There is nothing here yet` 404 page even though the Mahayana Platform Worker is healthy when called directly. The response carried `X-Fabushi-Control-Plane: mahayana-platform`, proving the 404 came from the upstream hop rather than the Fabushi router.

## Fix
- bind `MAHAYANA_PLATFORM` to the `mahayana-platform` Worker for default, development and production environments;
- prefer the service binding for canonical auth/v1 forwarding, keeping public HTTPS fetch only as an explicit fallback;
- preserve manual OAuth/browser redirect handling and the stable public `api.ombhrum.com` login URL.

## Expected deployment effect
The staging password/API gate and `/api/auth/browser/start` should stop receiving the Cloudflare workers.dev placeholder. Once staging E2E passes, production CD can finally deploy the browser-auth gateway to `api.ombhrum.com`, where the user-visible login 404 is still present.

Heavy verification/deployment remains GitHub Actions only.