### PR TITLE
fix(tfi): bind unified Messenger runtime to authenticated actor

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -39,13 +39,7 @@ async function completeBrowserLogin(page: Page): Promise<void> {
     await page.getByTestId('browser-login-start').click();
     await expect(loginGate).toBeHidden();
   }
-  await expect.poll(async () => {
-    if (await page.getByTestId('messenger-workspace').isVisible().catch(() => false)) return true;
-    if (await page.getByTestId('open-messenger').isVisible().catch(() => false)) return true;
-    const hostStatus = page.getByTestId('host-status');
-    if (!await hostStatus.isVisible().catch(() => false)) return false;
-    return await hostStatus.getAttribute('data-state').catch(() => null) === 'ready';
-  }, { timeout: 15_000 }).toBe(true);
+  await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
 }
 
 async function openMessenger(page: Page): Promise<void> {
@@ -133,7 +127,7 @@ test('desktop Messenger unifies Telegram-class navigation with Fabushi agent ide
 
     const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
     await expect(assistant).toBeVisible();
-    await expect(assistant.locator('[data-engine="fabushi-motion-v2"]')).toBeVisible();
+    await expect(assistant.locator('[data-engine="fabushi-motion-v2"]').first()).toBeVisible();
     await assistant.click();
     await expect(page.getByTestId('messenger-input')).toBeVisible();
 
@@ -247,12 +241,6 @@ test('installed Mini App opens from the unified Messenger surface', async () => 
     const page = await app.firstWindow();
     await completeBrowserLogin(page);
 
-    await page.getByTestId('open-marketplace').click();
-    const install = page.getByTestId('install-miniapp');
-    if (await install.isEnabled()) await install.click();
-    await expect(install).toBeDisabled();
-    await page.getByRole('button', { name: '关闭插件市场' }).click();
-
     await openMessenger(page);
     await page.getByTitle('Mini Apps').click();
     await page.getByRole('button', { name: /全球法布施/ }).last().click();
@@ -293,7 +281,8 @@ test('desktop Messenger persists per-peer drafts and performs real in-conversati
     await page.getByTitle('搜索当前会话').click();
     const search = page.getByTestId('conversation-search-input');
     await search.fill(marker);
-    await expect(page.locator('article').filter({ hasText: marker })).toHaveCount(1);
+    await expect(page.getByText(marker, { exact: true })).toHaveCount(1);
+    await expect(page.getByText('收到：' + marker, { exact: true })).toHaveCount(1);
 
     await search.fill('绝对不存在的会话内搜索结果-20260822');
     await expect(page.getByTestId('message-search-empty')).toBeVisible();
@@ -344,7 +333,7 @@ test('desktop Messenger rejects self-hosted actor impersonation at the real Host
     } catch (cause) {
       rejection = cause instanceof Error ? cause.message : String(cause);
     }
-    expect(rejection).toContain('profile actor id does not match authenticated actor');
+    expect(rejection).toContain('Messaging envelope actor does not match authenticated account');
   } finally {
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -614,11 +614,30 @@ function installNativeEdge() {
   });
 }
 
+async function authorizeMahayanaParams(method, params) {
+  const normalized = normalizeParams(params);
+  if (method !== 'feature.execute') return normalized;
+  const command = normalized.command;
+  if (!command || command.type !== 'messaging.execute') return normalized;
+  const context = command.envelope?.context;
+  const deviceId = String(context?.deviceId || '').trim();
+  const sessionId = String(context?.sessionId || '').trim();
+  const actorId = String(context?.actorId || '').trim();
+  if (!deviceId || !sessionId || !actorId) {
+    throw new Error('Messaging envelope requires account-bound actor, device, and session identity.');
+  }
+  const credential = await getOrIssueMessagingAccess({ deviceId, sessionId }, ['messaging']);
+  if (String(credential.actorId || '') !== actorId) {
+    throw new Error('Messaging envelope actor does not match authenticated account.');
+  }
+  return normalized;
+}
+
 function installMahayanaEdge() {
   const handlers = Object.fromEntries(
     Object.keys(MAHAYANA_EDGE.methods).map((method) => [
       method,
-      async (params) => host.request(method, normalizeParams(params)),
+      async (params) => host.request(method, await authorizeMahayanaParams(method, params)),
     ]),
   );
 

--- a/desktop/src/selfhosted-messaging-client-v2.ts
+++ b/desktop/src/selfhosted-messaging-client-v2.ts
@@ -456,6 +456,7 @@ export class SelfHostedMessagingClientV2 {
   }
 
   async ensureCurrentActor(displayName = '当前用户'): Promise<void> {
+    await this.ensureNativeIdentity();
     await this.ensureActor({
       id: this.actorId,
       kind: 'human',


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: `M7-DESKTOP-001`

## Root causes fixed
1. `ensureCurrentActor()` captured the bootstrap actor ID before Electron resolved the account-backed messaging identity. Rust then correctly rejected the profile as actor impersonation, producing the orange startup error banner in the unified Messenger.
2. The Electron Mahayana IPC edge forwarded arbitrary `messaging.execute` envelopes directly to the Host. A renderer could forge both the envelope actor and profile actor and bypass the intended account binding.
3. The Messenger E2E suite still waited on the retired Host surface, used a strict Motion-v2 selector that matched nested engine nodes, and opened Mini Apps through the old marketplace surface.

## Fix
- resolve native/account messaging identity before constructing the current-user profile payload;
- bind every `messaging.execute` IPC request to an account-issued actor/device/session credential before Host forwarding;
- update unified Messenger E2E to wait for the final Messenger shell, validate Motion v2 deterministically, open Mini Apps through the Messenger rail, and assert the account-bound impersonation rejection;
- correct in-conversation search assertions to account for both the user message and assistant echo.

## Verification
- `node --check desktop/electron/main.cjs` PASS
- `git diff --check` PASS
- heavy Electron build/E2E remains GitHub Actions only.

Once green, this branch is intended for the macOS hot-package path so the current installed 1.0.2 shell can receive the fixed `app.asar` without a full rebuild.