### PR TITLE
fix(tfi): restore Messenger composer and Mini App routing

### DIFF
--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -1,0 +1,171 @@
+import { _electron as electron, expect, test, type Page } from '@playwright/test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ElectronMahayanaHostTransport } from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
+import type { RuntimeEvent } from '../../frontend/apps/web/src/lib/mahayana-host/contracts';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
+
+async function launchDesktopApp(appDataDir: string) {
+  return electron.launch({
+    ...(packagedExecutable
+      ? { executablePath: packagedExecutable, args: [] }
+      : { args: [appRoot] }),
+    env: {
+      ...process.env,
+      FABUSHI_APP_DATA: appDataDir,
+      FABUSHI_FEATURE_HOST_MODE: process.env.FABUSHI_FEATURE_HOST_MODE || 'test',
+      MAHAYANA_APP_HOST_BIN: process.env.MAHAYANA_APP_HOST_BIN || '',
+    },
+  });
+}
+
+async function completeBrowserLogin(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect.poll(async () => {
+    for (const testId of ['onboarding-gate', 'login-gate', 'messenger-workspace']) {
+      if (await page.getByTestId(testId).isVisible().catch(() => false)) return true;
+    }
+    return false;
+  }, { timeout: 15_000 }).toBe(true);
+
+  while (await page.getByTestId('onboarding-gate').isVisible().catch(() => false)) {
+    await page.getByTestId('onboarding-next').click();
+  }
+  const loginGate = page.getByTestId('login-gate');
+  if (await loginGate.isVisible().catch(() => false)) {
+    await page.getByTestId('browser-login-start').click();
+    await expect(loginGate).toBeHidden();
+  }
+  await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
+}
+
+async function expectComposerInsideViewport(page: Page): Promise<void> {
+  const input = page.getByTestId('messenger-input');
+  await expect(input).toBeVisible();
+  const box = await input.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box, 'composer input must have a rendered bounding box').not.toBeNull();
+  expect(viewport, 'desktop page must expose a viewport').not.toBeNull();
+  if (!box || !viewport) return;
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.y).toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+  expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+}
+
+test('Electron transport keeps Mini Apps out of chat conversations and routes direct opens to miniapp.open', async () => {
+  let runtimeListener: ((event: RuntimeEvent) => void) | null = null;
+  const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const fakeWindow = {
+    mahayana: {
+      contractVersion: 1,
+      async invoke<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+        calls.push({ method, params });
+        if (method === 'feature.info') {
+          return {
+            runtimeVersion: 'test',
+            protocolVersion: '1',
+            platform: 'electron',
+          } as T;
+        }
+        return { requestId: String((params?.command as { requestId?: string } | undefined)?.requestId ?? 'test') } as T;
+      },
+      subscribe(listener: (event: RuntimeEvent) => void) {
+        runtimeListener = listener;
+        return () => { runtimeListener = null; };
+      },
+    },
+    fabushi: {
+      contractVersion: 1,
+      async notify() {},
+      async openExternal() {},
+      async openSystemSettings() {},
+      async windowFocused() { return true; },
+    },
+  };
+  const globalWithWindow = globalThis as unknown as { window?: typeof fakeWindow };
+  const previousWindow = globalWithWindow.window;
+  globalWithWindow.window = fakeWindow;
+
+  try {
+    const transport = new ElectronMahayanaHostTransport();
+    const observed: RuntimeEvent[] = [];
+    transport.subscribe((event) => observed.push(event));
+    await transport.initialize({ profileId: 'transport-regression', mode: 'test' });
+
+    const listedEvent: RuntimeEvent = {
+      type: 'conversation.listed',
+      timestamp: new Date().toISOString(),
+      conversations: [
+        {
+          id: 'official:bot-father',
+          title: 'Bot Father',
+          kind: 'miniapp',
+          pinned: false,
+          unreadCount: 0,
+          updatedAtMs: Date.now(),
+        },
+        {
+          id: 'mahayana:contact:alice',
+          title: 'Alice',
+          kind: 'contact',
+          pinned: false,
+          unreadCount: 0,
+          updatedAtMs: Date.now(),
+        },
+      ],
+    };
+    const emitRuntime = runtimeListener as ((event: RuntimeEvent) => void) | null;
+    expect(emitRuntime).not.toBeNull();
+    emitRuntime?.(listedEvent);
+
+    const normalized = observed.find((event) => event.type === 'conversation.listed');
+    expect(normalized?.type).toBe('conversation.listed');
+    if (normalized?.type === 'conversation.listed') {
+      expect(normalized.conversations.map((conversation) => conversation.id)).toEqual(['mahayana:contact:alice']);
+    }
+
+    await transport.execute({
+      type: 'conversation.open',
+      requestId: 'open-bot-father',
+      conversationId: 'official:bot-father',
+    });
+    const routed = calls.at(-1)?.params?.command as { type?: string; miniAppId?: string } | undefined;
+    expect(routed?.type).toBe('miniapp.open');
+    expect(routed?.miniAppId).toBe('bot-father');
+    await transport.close();
+  } finally {
+    if (previousWindow === undefined) delete globalWithWindow.window;
+    else globalWithWindow.window = previousWindow;
+  }
+});
+
+test('Messenger composer remains inside the desktop viewport for chat peers', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-composer-regression-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+    await completeBrowserLogin(page);
+
+    const peers = page.locator('[data-testid^="peer-"]');
+    await expect(peers.first()).toBeVisible();
+    const count = Math.min(await peers.count(), 12);
+    expect(count).toBeGreaterThan(0);
+
+    for (let index = 0; index < count; index += 1) {
+      const peer = peers.nth(index);
+      await peer.scrollIntoViewIfNeeded();
+      await peer.click();
+      await expectComposerInsideViewport(page);
+    }
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});

--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -48,10 +48,14 @@ async function expectComposerInsideViewport(page: Page): Promise<void> {
   const input = page.getByTestId('messenger-input');
   await expect(input).toBeVisible();
   const box = await input.boundingBox();
-  const viewport = page.viewportSize();
+  const viewport = await page.evaluate(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
   expect(box, 'composer input must have a rendered bounding box').not.toBeNull();
-  expect(viewport, 'desktop page must expose a viewport').not.toBeNull();
-  if (!box || !viewport) return;
+  if (!box) return;
+  expect(viewport.width).toBeGreaterThan(0);
+  expect(viewport.height).toBeGreaterThan(0);
   expect(box.x).toBeGreaterThanOrEqual(0);
   expect(box.y).toBeGreaterThanOrEqual(0);
   expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import DesktopShellV2 from './messaging-shell-v2';
+import './messenger-layout-regressions.css';
 
 const root = document.querySelector<HTMLDivElement>('#root');
 if (!root) {

--- a/desktop/src/messenger-layout-regressions.css
+++ b/desktop/src/messenger-layout-regressions.css
@@ -1,0 +1,24 @@
+/*
+ * Layout safety net for the unified Electron Messenger.
+ *
+ * The chat column is a clipped flex container. Flex items default to
+ * min-height:auto, which lets the scrolling message region keep its intrinsic
+ * minimum height and displace the composer below the clipped viewport. These
+ * rules make the chat column and its direct content shrinkable while keeping
+ * the composer itself non-shrinking.
+ */
+[data-testid="messenger-workspace"] > section {
+  min-height: 0;
+}
+
+[data-testid="messenger-workspace"] > section > div {
+  min-height: 0;
+}
+
+[data-testid="messenger-workspace"] form:has(textarea[data-testid="messenger-input"]) {
+  flex: 0 0 auto;
+}
+
+[data-testid="messenger-workspace"] textarea[data-testid="messenger-input"] {
+  min-width: 0;
+}

--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -45,6 +45,29 @@ const ELECTRON_EDGE_CONTRACT_VERSION = 1;
 const idle = (milliseconds = 10) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
+function isMiniAppConversation(kind: string): boolean {
+  return kind.trim().toLocaleLowerCase() === "miniapp";
+}
+
+function miniAppIdForConversation(conversation: { id: string; title: string }): string {
+  const exactTitle = conversation.title.trim().toLocaleLowerCase();
+  const knownByTitle: Record<string, string> = {
+    "bot father": "bot-father",
+    "chatgpt 自动确认": "chatgpt-auto-confirm",
+    "全球法布施": "global-dharma",
+    "法流记忆卡": "faliu-flashcards",
+    "平台发布": "platform-publish",
+    "hermes 安装器": "hermes-installer",
+    "大乘助手": "mahayana-assistant",
+  };
+  const known = knownByTitle[exactTitle];
+  if (known) return known;
+
+  const cleanId = conversation.id.trim();
+  const namespaced = cleanId.match(/(?:^|:)([a-z0-9][a-z0-9-]*)$/i)?.[1];
+  return namespaced || cleanId;
+}
+
 export function isElectronMahayanaHostAvailable(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -69,6 +92,7 @@ function shellBridge(): ElectronShellBridge {
 
 export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   private readonly listeners = new Set<RuntimeEventListener>();
+  private readonly miniAppConversations = new Map<string, string>();
   private closed = false;
   private pumping = false;
   private unsubscribeBridge: (() => void) | null = null;
@@ -96,6 +120,18 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   }
 
   execute(command: RuntimeCommand): Promise<CommandAccepted> {
+    if (command.type === "conversation.open") {
+      const miniAppId = this.miniAppConversations.get(command.conversationId);
+      if (miniAppId) {
+        return mahayanaBridge().invoke<CommandAccepted>("feature.execute", {
+          command: {
+            type: "miniapp.open",
+            requestId: command.requestId,
+            miniAppId,
+          },
+        });
+      }
+    }
     return mahayanaBridge().invoke<CommandAccepted>("feature.execute", { command });
   }
 
@@ -177,9 +213,26 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     this.closed = true;
     this.unsubscribeBridge?.();
     this.unsubscribeBridge = null;
+    this.miniAppConversations.clear();
   }
 
   private dispatchEvent(event: RuntimeEvent): void {
+    if (event.type === "conversation.listed") {
+      const messengerConversations = event.conversations.filter((conversation) => {
+        if (!isMiniAppConversation(conversation.kind)) return true;
+        this.miniAppConversations.set(
+          conversation.id,
+          miniAppIdForConversation(conversation),
+        );
+        return false;
+      });
+      const normalizedEvent: RuntimeEvent = {
+        ...event,
+        conversations: messengerConversations,
+      };
+      for (const listener of this.listeners) listener(normalizedEvent);
+      return;
+    }
     for (const listener of this.listeners) listener(event);
   }
 

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-002/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-002/README.md
@@ -1,0 +1,54 @@
+# M7-DESKTOP-002 evidence
+
+- **Project**: `FAB-P0001 / TFI`
+- **Task**: `M7-DESKTOP-002`
+- **PR**: `#2053`
+- **Status**: `TESTING`
+- **Date**: `2026-08-23`
+
+## User evidence
+
+The task was opened from a real Fabushi macOS screenshot showing:
+
+- Bot Father selected in the unified Messenger;
+- orange error banner: `agent backend is unavailable: plugin not found: bot-father`;
+- no visible bottom message composer/input for the selected messaging peer.
+
+Source intake: `../../source/2026-08-23-messenger-composer-miniapp-regression.md`.
+
+## Code evidence
+
+- `frontend/apps/web/src/lib/mahayana-host/electron-transport.ts`
+  - removes `kind=miniapp` summaries from ordinary conversation list delivery;
+  - stores canonical Mini App routing data;
+  - reroutes historical/direct `conversation.open` attempts to `miniapp.open`.
+- `desktop/src/messenger-layout-regressions.css`
+  - removes flex min-content displacement of the composer;
+  - keeps the composer non-shrinking inside the clipped chat workspace.
+- `desktop/e2e/messenger-regressions.spec.ts`
+  - verifies Mini App transport normalization and direct-open fallback;
+  - verifies each exercised chat peer's `messenger-input` bounding box is inside the Electron viewport.
+
+## GitHub evidence
+
+Initial implementation head: `46be6d7268962fe0f682d93efb69f3d29ade8b2a`.
+
+- Project portfolio governance run `32627390573`: SUCCESS.
+- Host fast E2E run `32627390610`: SUCCESS.
+- Messaging Product Gate run `32627390565`: was running when the evidence ledger was opened.
+- Electron desktop quality gate run `32627390618`: was running when the evidence ledger was opened.
+- CI run `32627390630`: was running when the evidence ledger was opened.
+
+The project-record synchronization commits after the initial implementation trigger a fresh latest-head CI set. Only that latest-head set plus protected merge and canonical-main readback can promote this task to `TESTED`.
+
+## Closure checklist
+
+- [x] User symptom recorded.
+- [x] Root-cause implementation added.
+- [x] Regression tests added.
+- [x] PR #2053 opened.
+- [x] Protected auto-merge enabled.
+- [ ] Latest-head required checks all SUCCESS.
+- [ ] Protected merge completed.
+- [ ] Canonical `main` readback completed.
+- [ ] Task/WBS/acceptance/status/evidence promoted to final `TESTED` state.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-03
-- **版本**：v1.3
+- **版本**：v1.4
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
@@ -24,8 +24,8 @@
 | 媒体 | media/blob_store + desktop attachment | M4 | IMPLEMENTED | 需大文件 resume/retry/permissions/cache 验收 |
 | 联系人/群组 | actor/conversation/community | M5 | IMPLEMENTED | 需 owner/admin/member/restricted 权限矩阵 |
 | 频道/Topic | conversation/community | M6 | IMPLEMENTED | 需广播/分页/Topic 状态规模验收 |
-| Bot/Agent | bot + Actor/Feature Host + unified Messenger | M7 | IN_PROGRESS | M7-DESKTOP-001：单一桌面壳、Motion v2 Agent identity、统一 composer；PR #2046 current-head CI/E2E pending |
-| Mini Apps | miniapp + Host bridge | M8 | IMPLEMENTED | 需授权/撤销/沙箱 E2E |
+| Bot/Agent | bot + Actor/Feature Host + unified Messenger | M7 | TESTING | M7-DESKTOP-002 / PR #2053：Mini App conversation edge normalization + composer viewport geometry；等待 latest-head required checks / protected merge / canonical-main readback |
+| Mini Apps | miniapp + Host bridge | M8 | IMPLEMENTED | M7-DESKTOP-002 已防止 Mini App 被误路由进 Agent conversation；M8 仍需授权/撤销/沙箱 E2E |
 | 支付 | payment/settlement/wallet | M9 | IMPLEMENTED | 需 sandbox E2E / webhook replay evidence |
 | 音视频 | realtime/signaling + desktop WebRTC | M10 | IMPLEMENTED | 需跨端/TURN/SFU/网络切换实测 |
 | 移动端共享 Core | native bridge / Host | M11 | IN_PROGRESS | 需 iOS/Android/Electron cross-device E2E |
@@ -48,7 +48,8 @@
 
 M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded peer/message rendering, typing semantics and existing Messenger interactions with current GitHub typecheck/Playwright evidence before M3 closes.
 
-
 ## Active M7 unified desktop acceptance — 2026-08-23
 
-`M7-DESKTOP-001` 将 Grok/Fabushi 已自研的 Motion v2 动态 Agent identity 与 Telegram-class Messenger 合并为一个产品界面。验收要求：认证后不存在第二套 `AI / 消息` product switcher；AI/Bot、人类、群组、频道共用 Messenger peer/conversation surface；生产 browser-first auth smoke 必须覆盖 `/api/auth/browser/start`。当前仅为 `IN_PROGRESS`，等待 PR #2046 current-head CI、E2E、protected merge、production deployment 与 canonical-main 验证。
+`M7-DESKTOP-001` 将 Grok/Fabushi 已自研的 Motion v2 动态 Agent identity 与 Telegram-class Messenger 合并为一个产品界面。`M7-DESKTOP-002` 处理统一界面落地后的真实回归：Mini App summary 不得进入普通 Agent conversation backend；所有普通 chat peer 的 composer 必须完整位于 Electron viewport 内。
+
+当前 `M7-DESKTOP-002` = `TESTING`。PR #2053 initial head 已获得 Project portfolio governance run `32627390573` SUCCESS 与 Host fast E2E run `32627390610` SUCCESS；其余 current-head required checks、protected merge 与 canonical-main verification 完成前不得标记 `TESTED`。

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -4,18 +4,18 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-05
-- **版本**：v1.5
+- **版本**：v1.6
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
 ## 当前状态
 
-- **整体阶段**：M3 桌面聊天完整交互 — `IN_PROGRESS`。
+- **整体阶段**：M3 桌面聊天完整交互 — `IN_PROGRESS`；M7 unified Messenger remediation 并行 `TESTING`。
 - **M0**：`TESTED`。
 - **M1**：`TESTED`，证据 `M1-ACCEPT-001`。
 - **M2**：`TESTED`，证据 `M2-ACCEPT-001`。
 - **Canonical Messaging Core**：`native/mahayana-messaging/`。
-- **当前产品任务**：`M3-DESKTOP-001`，分支 `feat/telegram-m3-desktop-ux`。
+- **当前 M7 产品任务**：`M7-DESKTOP-002`，分支 `fix/tfi-m7-messenger-composer-miniapp-routing`，PR #2053。
 - **旧 Telegram 栈**：继续 LEGACY/FROZEN；M14 前不得新增产品功能。
 
 ## M2 final landing
@@ -50,19 +50,21 @@
 4. Protocol v2 typing end-to-end；
 5. 对已有 interaction surface 补 Playwright acceptance。
 
-M3 第一批 UI 改动已在 `feat/telegram-m3-desktop-ux` 实现，后续必须在 M2 closure main 基线上 clean restack、通过 GitHub typecheck/Playwright 后才能合并。
+## 2026-08-23 — M7 Grok × Telegram unified UI
+
+- `M7-DESKTOP-001` 将产品收敛为唯一 Messenger Shell；AI/Bot 与真人 peer 共用会话列表、聊天区和 composer；AI identity 使用 `BotMark` / `fabushi-motion-v2` 状态引擎。
+- 用户随后通过真实 macOS 截图暴露两个回归：Bot Father `miniapp` 被误送 Agent backend，出现 `plugin not found: bot-father` 顶部错误；普通联系人 composer 被 flex minimum sizing 推出裁剪 viewport。
+
+## 2026-08-23 — M7-DESKTOP-002 remediation
+
+- PR #2053 已实现 Electron edge Mini App conversation normalization：`kind=miniapp` 不再进入普通 chat conversation list；历史直接 `conversation.open` fallback 改写到既有 `miniapp.open`。
+- 新增 `desktop/src/messenger-layout-regressions.css`，使聊天 flex column/direct children 可收缩，并让 composer 固定为 non-shrinking flex item。
+- 新增 `desktop/e2e/messenger-regressions.spec.ts`：验证 Mini App 路由改写与 chat peer composer viewport geometry。
+- initial implementation head `46be6d7268962fe0f682d93efb69f3d29ade8b2a` 已通过 Project portfolio governance `32627390573` 与 Host fast E2E `32627390610`；PR 后续文档提交会触发 latest-head gates，最终以 latest-head required checks 为准。
+- #2053 auto-merge 已启用；在 required checks、protected merge、canonical-main readback 完成前维持 `TESTING`。
 
 ## 治理事实
 
 - GitHub `main:projects/telegram-fabushi-integration/` 为唯一工程权威源。
 - immutable identity = `FAB-P0001 / TFI`。
 - 任何阶段都必须 current-head CI + protected merge + canonical-main verification 才能关账。
-
-
-## 2026-08-23 — M7 Grok × Telegram unified UI started
-
-- 新任务 `M7-DESKTOP-001` 已启动：不再在 Fabushi 中并排维护“AI 工作区”和“消息工作区”，而是以 Telegram-class Messenger 为统一信息架构，吸收 Grok/Fabushi 的 Motion v2 动态 Agent identity、深色层次、状态反馈与交互质感。
-- 实现分支：`feat/tfi-m7-grok-telegram-unified-ui`；PR #2046。
-- 当前实现：预登录继续复用安全 browser-first 登录体验；认证后直接进入唯一 Messenger Shell；AI/Bot 与真人 peer 共用会话列表、聊天区和 composer；AI identity 使用 `BotMark` / `fabushi-motion-v2` 状态引擎。
-- 同轮修复生产登录回归防线：`deploy-production.yml` production smoke 将真实 POST `/api/auth/browser/start`，拒绝 legacy Worker 404 fallback。
-- 2026-08-23 实测生产 `https://api.ombhrum.com/api/auth/browser/start` 仍返回 HTTP 404 + `This Cloudflare Worker is an API backend only.`，因此任务保持 `IN_PROGRESS`，需 PR 合并后的 production CD/Cloudflare deployment 证据。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-07
-- **版本**：v1.5
+- **版本**：v1.6
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
@@ -53,10 +53,19 @@
 - OWNERS、dependency/blocker register、issue/action register 与 messaging/SQLite runbooks 持续维护。
 - 每轮工作必须同步 task/WBS/acceptance/status/changelog/evidence；未有客观证据不得标记完成。
 
-
 ## 2026-08-23 — Grok design converges into the unified Messenger
 
 - 用户明确要求把 Grok Bot 融合进 Telegram UI，而不是保留两套视觉/产品 surface。
 - `M7-DESKTOP-001` 固化目标：Telegram 提供成熟 IM 信息架构和功能密度；Fabushi/Grok 已自研能力提供 Motion v2 动态 Agent identity、状态反馈、深色材质和交互质感；最终只保留一个 Fabushi Messenger Shell。
 - 禁止通过新增第二套 Agent runtime、Host runtime 或聊天状态机完成视觉融合。
 - 同步增加 production browser-first auth smoke，防止 `api.ombhrum.com/api/auth/browser/start` 再次落到 legacy 404。
+
+## 2026-08-23 — M7-DESKTOP-002 Messenger regression repair
+
+- 用户真实 macOS 截图确认 Bot Father 顶部出现 `agent backend is unavailable: plugin not found: bot-father`，并确认消息联系人底部 composer/input 不可见。
+- 根因一：Electron `conversation.listed` 中 `kind=miniapp` 被统一 Messenger 当成普通 conversation，最终错误进入 Agent backend。
+- 根因二：裁剪的聊天 flex column 中 scrolling message region 保留默认 `min-height:auto`，可将 composer 推出 viewport。
+- PR #2053：Electron Host edge 过滤普通 chat list 中的 Mini App summary，同时保存 conversation → Mini App canonical route，并为历史直接 open 提供 `miniapp.open` fallback。
+- PR #2053：增加布局 regression guard，让 workspace/direct flex content 可收缩、composer non-shrinking。
+- PR #2053：增加 Playwright transport routing + composer viewport geometry 回归测试。
+- initial implementation head 已通过 Project portfolio governance `32627390573` 与 Host fast E2E `32627390610`；latest-head required checks、protected merge 与 canonical-main readback 仍是 TESTED 晋级条件。

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-002-messenger-composer-miniapp-routing.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-002-messenger-composer-miniapp-routing.md
@@ -4,11 +4,11 @@
 - **Project Key**: `TFI`
 - **Task ID**: `M7-DESKTOP-002`
 - **Stage**: `M7 Bot/Agent 统一联系人体系`
-- **Status**: `IN_PROGRESS`
+- **Status**: `TESTING`
 - **Started**: `2026-08-23`
 - **Updated**: `2026-08-23`
 - **Branch**: `fix/tfi-m7-messenger-composer-miniapp-routing`
-- **Primary PR**: `TBD`
+- **Primary PR**: `#2053`
 
 ## Objective
 
@@ -49,8 +49,8 @@
 
 ## Acceptance criteria
 
-1. `conversation.kind === 'miniapp'` 不再被归类为普通 conversation 并调用 `conversation.open`。
-2. 点击 Bot Father 类 Mini App peer 使用既有 Mini App Host 路由；不会产生 `agent backend is unavailable: plugin not found` 错误横幅。
+1. `conversation.kind === 'miniapp'` 不再进入普通 Messenger conversation list；Electron edge 会记录其 canonical Mini App route。
+2. 若旧路径直接尝试 `conversation.open` 一个已识别 Mini App，会改写为既有 `miniapp.open`，不再送入 Agent backend。
 3. 普通联系人/Bot/Agent 会话的 `messenger-input` 位于 viewport 内且可输入。
 4. 空会话/长消息区都不能把 composer 挤出 `.chatWorkspace` 的裁剪边界。
 5. 新增自动化回归覆盖 Mini App 路由和 composer 几何可见性。
@@ -65,17 +65,34 @@
 
 ## Risks / blockers
 
-- 生产数据中的 Mini App conversation ID 可能带命名空间前缀；实现需避免只依赖一个硬编码 ID。
-- 当前安装中的 macOS 客户端不会因为源码合并自动更新；若用户要求现场验证，需要后续构建/发布/安装最新包。
+- 生产数据中的 Mini App conversation ID 可能带命名空间前缀；实现同时使用已知 title 映射和末段 ID 归一化，避免只依赖 `bot-father` 一个裸 ID。
+- 当前安装中的 macOS 客户端不会因为源码合并自动更新；现场验证需要安装包含本次修复的最新正式包。
 
 ## Implementation summary
 
-Pending.
+- `frontend/apps/web/src/lib/mahayana-host/electron-transport.ts`
+  - 捕获 `conversation.listed` 中 `kind=miniapp` 项并从普通聊天列表剥离；
+  - 缓存 conversation → Mini App route；
+  - 对历史/直接 `conversation.open` 调用提供 `miniapp.open` fallback，消除错误 Agent backend 路由。
+- `desktop/src/messenger-layout-regressions.css`
+  - 让 chat workspace 与直接 flex content 使用 `min-height: 0`；
+  - composer 使用 `flex: 0 0 auto`，保证不会被 message area 挤出裁剪 viewport。
+- `desktop/e2e/messenger-regressions.spec.ts`
+  - 使用 fake Electron bridge 验证 Mini App 过滤与 `miniapp.open` 改写；
+  - 启动真实 Electron test Host，逐个点击可见 chat peer 并验证 `messenger-input` bounding box 完整处于 viewport 内。
 
 ## Evidence
 
-Pending CI/PR evidence.
+- PR: `#2053`.
+- Initial implementation head: `46be6d7268962fe0f682d93efb69f3d29ade8b2a`.
+- Initial current-head GitHub Actions:
+  - Project portfolio governance `32627390573` — SUCCESS.
+  - Host fast E2E `32627390610` — SUCCESS.
+  - Messaging Product Gate `32627390565` — running at evidence update time.
+  - Electron desktop quality gate `32627390618` — running at evidence update time.
+  - CI `32627390630` — running at evidence update time.
+- PR #2053 auto-merge enabled; protected merge remains gated on required checks.
 
 ## Next action
 
-实现 Mini App peer 分类/路由、composer 布局约束和对应 E2E 回归，然后提交 PR 进入 GitHub Actions 验证。
+等待 #2053 最新 head 的 GitHub Actions 全绿；如有失败按失败日志修复。全部 required checks 通过后由 protected auto-merge 落 main，再执行 canonical-main readback 并将任务提升为 `TESTED`。

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-002-messenger-composer-miniapp-routing.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-002-messenger-composer-miniapp-routing.md
@@ -1,0 +1,81 @@
+# M7-DESKTOP-002 — Messenger composer visibility and Mini App routing repair
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M7-DESKTOP-002`
+- **Stage**: `M7 Bot/Agent 统一联系人体系`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-23`
+- **Updated**: `2026-08-23`
+- **Branch**: `fix/tfi-m7-messenger-composer-miniapp-routing`
+- **Primary PR**: `TBD`
+
+## Objective
+
+修复统一 Messenger 中两个用户可见回归：
+
+1. `Bot Father` 等 Mini App 会话被错误送入普通 Agent conversation backend，产生 `plugin not found` 顶部错误横幅；
+2. 联系人会话底部 composer/input 在实际桌面窗口中被布局挤出可视区域。
+
+修复必须保留单一 Messenger Shell、单一 Host/消息产品层，不新增第二套聊天 UI 或第二套运行时。
+
+## Source requirements
+
+- `../../source/2026-08-23-messenger-composer-miniapp-regression.md`
+- `../../source/完整telegram融合进fabushi.txt`
+- `../wbs/M7.md`：真人、Bot、Agent 使用同一消息产品层，UI 不再分裂。
+- 用户 2026-08-23 截图与明确要求：修复顶部错误，并恢复每个联系人会话的消息输入框。
+
+## In scope
+
+- 明确区分普通 conversation 与 `miniapp` conversation 的桌面路由。
+- Mini App peer 不得调用普通 `conversation.open`/Agent backend；使用现有 `miniapp.open` Host 能力。
+- 修正 Messenger flex/grid 收缩约束，保证 composer 固定保留在聊天区可视底部。
+- 增加 Electron Playwright 回归断言：composer 不仅 DOM 存在，而且边界位于 viewport 内；Mini App peer 不走错误的普通 conversation backend。
+- 同步 M7 WBS、验收追踪、状态、变更日志和 evidence。
+
+## Out of scope
+
+- 不重写 Rust Messaging Core。
+- 不通过隐藏 `operation.failed` 或吞掉错误来伪装修复。
+- 不把 Mini App 复制成第二套 Agent runtime。
+- 不在本地执行应用构建、Playwright 或重型测试；按仓库规则由 GitHub Actions 验证。
+
+## Dependencies
+
+- `M7-DESKTOP-001` 统一 Messenger 已落入 main。
+- `miniapp.open` / `miniapp.opened` Host contract 已存在。
+- Electron Messenger CI/E2E workflow 可运行。
+
+## Acceptance criteria
+
+1. `conversation.kind === 'miniapp'` 不再被归类为普通 conversation 并调用 `conversation.open`。
+2. 点击 Bot Father 类 Mini App peer 使用既有 Mini App Host 路由；不会产生 `agent backend is unavailable: plugin not found` 错误横幅。
+3. 普通联系人/Bot/Agent 会话的 `messenger-input` 位于 viewport 内且可输入。
+4. 空会话/长消息区都不能把 composer 挤出 `.chatWorkspace` 的裁剪边界。
+5. 新增自动化回归覆盖 Mini App 路由和 composer 几何可见性。
+6. 相关 GitHub Actions 通过，PR 经受保护流程合并，并在 canonical `main` 回读确认实现与项目记录一致。
+
+## Verification plan
+
+- Lightweight source/diff inspection only in development session.
+- GitHub Actions: Electron typecheck/build-renderer contract as configured by repository CI.
+- GitHub Actions: desktop Messenger Playwright/E2E relevant gate.
+- Protected merge and canonical-main readback.
+
+## Risks / blockers
+
+- 生产数据中的 Mini App conversation ID 可能带命名空间前缀；实现需避免只依赖一个硬编码 ID。
+- 当前安装中的 macOS 客户端不会因为源码合并自动更新；若用户要求现场验证，需要后续构建/发布/安装最新包。
+
+## Implementation summary
+
+Pending.
+
+## Evidence
+
+Pending CI/PR evidence.
+
+## Next action
+
+实现 Mini App peer 分类/路由、composer 布局约束和对应 E2E 回归，然后提交 PR 进入 GitHub Actions 验证。

--- a/projects/telegram-fabushi-integration/management/wbs/M7.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M7.md
@@ -4,22 +4,22 @@
 
 - **交付物**：Participant::Agent/Bot
 - **验收标准**：真人和 Agent 使用同一消息内核；Agent-to-Agent 可通信；UI 不再使用独立第二套聊天实现
-- **客观验证**：Messenger Playwright 断言单一 desktop shell，AI Assistant peer 使用 Fabushi Motion v2 BotMark 并可在统一 composer 发送消息。
-- **来源**：源计划 M7 + 用户 2026-08-23 Grok × Telegram UI 融合要求
-- **状态**：IN_PROGRESS
-- **阻塞**：PR #2046 current-head GitHub typecheck/Playwright pending
-- **证据位置**：`M7-DESKTOP-001`; `desktop/src/messaging-shell-v2.tsx`; `desktop/e2e/messenger.spec.ts`
-- **下一步**：PR current-head CI 后提升 TESTED。
+- **客观验证**：Messenger Playwright 断言单一 desktop shell，AI Assistant peer 使用 Fabushi Motion v2 BotMark 并可在统一 composer 发送消息；M7-DESKTOP-002 进一步验证所有可见 chat peer 的 composer bounding box 位于 Electron viewport 内。
+- **来源**：源计划 M7 + 用户 2026-08-23 Grok × Telegram UI 融合要求 + 2026-08-23 composer 回归截图
+- **状态**：TESTING
+- **阻塞**：PR #2053 latest-head GitHub required checks / protected merge
+- **证据位置**：`M7-DESKTOP-001`; `M7-DESKTOP-002`; `desktop/src/messaging-shell-v2.tsx`; `desktop/e2e/messenger.spec.ts`; `desktop/e2e/messenger-regressions.spec.ts`
+- **下一步**：PR #2053 全绿后 protected merge + canonical-main readback。
 
 ### M7.T02 — Agent conversation
 
 - **交付物**：Agent conversation
 - **验收标准**：真人和 Agent 使用同一消息内核；Agent-to-Agent 可通信；UI 不再使用独立第二套聊天实现
-- **客观验证**：Electron 不再渲染外层 `AI / 消息` product rail；认证后直接进入统一 Messenger，AI conversation 与真人 peer 共用同一列表/聊天区。
-- **来源**：源计划 M7 + 用户 2026-08-23 Grok × Telegram UI 融合要求
-- **状态**：IN_PROGRESS
-- **阻塞**：PR #2046 current-head GitHub desktop E2E pending
-- **证据位置**：`M7-DESKTOP-001`; `desktop/src/messaging-shell-v2.tsx`
+- **客观验证**：Electron 不再渲染外层 `AI / 消息` product rail；认证后直接进入统一 Messenger，AI conversation 与真人 peer 共用同一列表/聊天区。M7-DESKTOP-002 在 Electron transport edge 将 `kind=miniapp` 从普通 conversation list 剥离，并把历史直接 open 路径改写为 `miniapp.open`，避免误进 Agent backend。
+- **来源**：源计划 M7 + 用户 2026-08-23 Grok × Telegram UI 融合要求 + Bot Father `plugin not found` 回归截图
+- **状态**：TESTING
+- **阻塞**：PR #2053 latest-head GitHub required checks / protected merge
+- **证据位置**：`M7-DESKTOP-001`; `M7-DESKTOP-002`; `frontend/apps/web/src/lib/mahayana-host/electron-transport.ts`; `desktop/e2e/messenger-regressions.spec.ts`
 - **下一步**：完成 CI、protected merge 与 canonical-main readback。
 
 ### M7.T03 — group @Agent

--- a/projects/telegram-fabushi-integration/source/2026-08-23-messenger-composer-miniapp-regression.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-23-messenger-composer-miniapp-regression.md
@@ -1,0 +1,20 @@
+# 2026-08-23 Messenger composer / Mini App regression
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Reported**: `2026-08-23`
+- **Source**: user desktop screenshot and explicit repair request
+
+## User-observed behavior
+
+1. In the unified desktop Messenger, selecting **Bot Father** shows an orange top error banner:
+   `bridge/invoke-failed: host operation failed: provider failed: agent backend is unavailable: plugin not found: bot-father`.
+2. The message composer/input is not visible at the bottom of contact conversations.
+3. The requested result is to remove the erroneous failure state by repairing the routing problem, not by merely hiding the error, and to make the composer reliably visible for message contacts.
+
+## Engineering interpretation to verify
+
+- `Bot Father` is surfaced with conversation kind `miniapp`. Mini Apps already have a dedicated `miniapp.open` Host route and dedicated Messenger Mini Apps surface; treating a `miniapp` summary as a generic chat conversation incorrectly sends it through `conversation.open` / the agent backend.
+- The chat workspace is a vertical flex container with clipped overflow. The scrolling message region currently has no explicit `min-height: 0`, so its intrinsic minimum can displace the composer below the clipped viewport, especially on an empty conversation with the centered empty-state card.
+
+These interpretations are hypotheses until the task implementation and GitHub Actions regression checks confirm them.


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: M7-DESKTOP-002

## User-visible regressions
- Bot Father selected in unified Messenger emitted `agent backend is unavailable: plugin not found: bot-father`.
- Contact conversation composer could be displaced below the clipped desktop viewport.

## Root causes
- Electron delivered `conversation.kind === miniapp` into the generic conversation list, so the Messenger treated Mini Apps as ordinary Agent conversations and called `conversation.open`.
- The clipped flex chat column allowed direct flex children to retain `min-height:auto`, allowing the scrolling message region to displace the composer.

## Fix
- Normalize Mini App conversation summaries at the Electron Host edge: keep them out of ordinary chat conversations and remember their canonical Mini App route; direct legacy opens are rerouted to existing `miniapp.open` rather than the Agent backend.
- Add a desktop layout regression guard that makes the chat column/direct content shrinkable and keeps the composer non-shrinking inside the viewport.
- Add Playwright regression coverage for Mini App routing and composer geometry across visible chat peers.
- Add durable project source/task records under `projects/telegram-fabushi-integration`.

## Verification
Heavy verification is intentionally delegated to GitHub Actions per repository policy. This PR should pass the desktop renderer/typecheck and Messenger Playwright gates before merge.
