### PR TITLE
fix(tfi): align Electron quality gate with unified Messenger

### DIFF
--- a/desktop/e2e/smoke.spec.ts
+++ b/desktop/e2e/smoke.spec.ts
@@ -4,14 +4,13 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import journeyContract from '../../contracts/automation/cross-platform-journeys.json' with { type: 'json' };
-import type {
-  MahayanaHostFeature,
-  MahayanaHostJourneyStep,
-} from '../../frontend/packages/shared/src/mahayana-host-features';
+import type { MahayanaHostFeature, MahayanaHostJourneyStep } from '../../frontend/packages/shared/src/mahayana-host-features';
 
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
+
 const mahayanaHostFeatures = journeyContract.features as ReadonlyArray<MahayanaHostFeature>;
+
 const officialAppIds = [
   'global-dharma',
   'faliu-flashcards',
@@ -35,19 +34,56 @@ async function launchDesktopApp(appDataDir: string) {
   });
 }
 
+function requestId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 async function completeBrowserLogin(page: Page): Promise<void> {
   while (await page.getByTestId('onboarding-gate').isVisible().catch(() => false)) {
     await page.getByTestId('onboarding-next').click();
   }
-  await expect(page.getByTestId('login-gate')).toBeVisible();
-  await page.getByTestId('browser-login-start').click();
-  await expect(page.getByTestId('login-gate')).toBeHidden();
+  const loginGate = page.getByTestId('login-gate');
+  if (await loginGate.isVisible().catch(() => false)) {
+    await page.getByTestId('browser-login-start').click();
+    await expect(loginGate).toBeHidden();
+  }
+  await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTitle('聊天', { exact: true })).toBeVisible();
 }
 
-async function ensureComputerPanel(page: Page): Promise<void> {
-  if (await page.getByTestId('feature-coverage').isVisible().catch(() => false)) return;
-  await page.getByRole('button', { name: '大乘助手的电脑' }).click();
-  await expect(page.getByTestId('feature-coverage')).toBeVisible();
+async function executeFeature(page: Page, command: Record<string, unknown>) {
+  return page.evaluate(async (input) => {
+    const bridge = (window as any).mahayana;
+    return bridge.invoke('feature.execute', { command: input });
+  }, command);
+}
+
+async function executeFeatureAndWaitForEvent(
+  page: Page,
+  command: Record<string, unknown>,
+  eventType: string,
+): Promise<Record<string, unknown>> {
+  return page.evaluate(async ({ input, wantedType }) => {
+    const bridge = (window as any).mahayana;
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      let unsubscribe = () => {};
+      const timer = window.setTimeout(() => {
+        unsubscribe();
+        reject(new Error(`Timed out waiting for ${wantedType}`));
+      }, 10_000);
+      unsubscribe = bridge.subscribe((event: Record<string, unknown>) => {
+        if (event?.type !== wantedType) return;
+        window.clearTimeout(timer);
+        unsubscribe();
+        resolve(event);
+      });
+      bridge.invoke('feature.execute', { command: input }).catch((error: unknown) => {
+        window.clearTimeout(timer);
+        unsubscribe();
+        reject(error);
+      });
+    });
+  }, { input: command, wantedType: eventType });
 }
 
 async function runJourneyStep(page: Page, step: MahayanaHostJourneyStep): Promise<void> {
@@ -56,71 +92,104 @@ async function runJourneyStep(page: Page, step: MahayanaHostJourneyStep): Promis
     case 'login':
       await completeBrowserLogin(page);
       return;
-    case 'expectReady':
-      await expect(page.getByTestId('host-status')).toHaveAttribute('data-state', 'ready');
+    case 'expectReady': {
+      const info = await page.evaluate(() => (window as any).mahayana.invoke('feature.info')) as {
+        protocolVersion?: string;
+        runtimeVersion?: string;
+      };
+      expect(String(info.protocolVersion ?? '')).not.toBe('');
+      expect(String(info.runtimeVersion ?? '')).not.toBe('');
+      await expect(page.getByTestId('messenger-workspace')).toBeVisible();
       return;
-    case 'sendChat':
-      await page.getByTestId('chat-input').fill(step.text);
-      await page.getByTestId('send-message').click();
-      await expect(page.getByTestId('messages')).toContainText(step.expectedReply);
+    }
+    case 'sendChat': {
+      const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+      await expect(assistant).toBeVisible();
+      await assistant.click();
+      const input = page.getByTestId('messenger-input');
+      await input.fill(step.text);
+      await page.getByTestId('messenger-send').click();
+      await expect(page.getByText(step.expectedReply, { exact: true })).toBeVisible();
       return;
+    }
     case 'installMiniApp':
-      await page.getByTestId('open-marketplace').click();
-      await expect(page.getByRole('dialog', { name: '插件市场' })).toBeVisible();
-      await page.getByTestId('install-miniapp').click();
-      await expect(page.getByTestId('marketplace-state')).toHaveText('installed');
+      await executeFeature(page, {
+        type: 'marketplace.install',
+        requestId: requestId('marketplace-install'),
+        miniAppId: step.miniAppId,
+      });
       return;
     case 'openMiniApp':
-      await page.getByRole('button', { name: '关闭插件市场' }).click();
-      await page.getByTestId(`agent-${step.miniAppId}`).click();
-      await expect(page.getByTestId('miniapp-panel')).toContainText(step.miniAppId);
-      await expect(page.getByTestId('miniapp-frame')).toBeVisible();
+      await page.getByTitle('Mini Apps', { exact: true }).click();
+      if (step.miniAppId === 'global-dharma') {
+        await page.getByRole('button', { name: /全球法布施/ }).last().click();
+        await expect(page.getByText('Mini App · 受控宿主容器')).toBeVisible();
+        await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
+      } else {
+        await executeFeatureAndWaitForEvent(page, {
+          type: 'miniapp.open',
+          requestId: requestId('miniapp-open'),
+          miniAppId: step.miniAppId,
+        }, 'miniapp.opened');
+      }
       return;
-    case 'approveCapability':
-      await page.getByTestId('request-capability').click();
-      await expect(page.getByRole('dialog', { name: '能力审批' })).toContainText(step.capability);
-      await page
-        .getByTestId(step.decision === 'allow-once' ? 'approve-capability' : 'deny-capability')
-        .click();
-      await expect(page.getByTestId('approval-state')).toHaveText(
-        step.decision === 'allow-once' ? 'allowed-once' : 'denied',
-      );
+    case 'approveCapability': {
+      const event = await executeFeatureAndWaitForEvent(page, {
+        type: 'capability.request',
+        requestId: requestId('capability'),
+        miniAppId: step.miniAppId,
+        capability: step.capability,
+        reason: 'Electron unified Messenger quality gate',
+      }, 'approval.requested');
+      const approvalId = String(event.approvalId ?? '');
+      expect(approvalId).not.toBe('');
+      await page.evaluate(async ({ id, decision }) => {
+        await (window as any).mahayana.invoke('feature.approval.resolve', {
+          resolution: { approvalId: id, decision },
+        });
+      }, { id: approvalId, decision: step.decision });
       return;
-    case 'interruptOperation':
-      await page.getByTestId('start-long-operation').click();
-      await expect(page.getByTestId('operation-state')).toHaveText('running');
-      await page.getByTestId('interrupt-operation').click();
-      await expect(page.getByTestId('operation-state')).toHaveText('interrupted');
-      return;
-    case 'clearSession':
-      await page.getByTestId('clear-session').click();
-      await expect(page.getByTestId('session-state')).toHaveText('cleared');
-      return;
-    default: {
-      const unhandled: never = step;
-      throw new Error(`Unhandled Host journey step: ${JSON.stringify(unhandled)}`);
     }
+    case 'interruptOperation': {
+      const accepted = await executeFeature(page, {
+        type: 'runtime.longTask',
+        requestId: requestId('long-task'),
+        label: step.label,
+      }) as { operationId?: string };
+      expect(String(accepted.operationId ?? '')).not.toBe('');
+      await page.evaluate(async (operationId) => {
+        await (window as any).mahayana.invoke('feature.interrupt', { operationId });
+      }, accepted.operationId);
+      return;
+    }
+    case 'clearSession':
+      await executeFeature(page, { type: 'session.clear', requestId: requestId('session-clear') });
+      return;
+    default:
+      throw new Error(`Unhandled Host journey step: ${JSON.stringify(step)}`);
   }
 }
 
 async function runOfficialApps(page: Page): Promise<void> {
-  for (const appId of officialAppIds) {
-    await test.step(`official app: ${appId}`, async () => {
-      await page.getByTestId('open-marketplace').click();
-      const installId = appId === 'global-dharma' ? 'install-miniapp' : `install-${appId}`;
-      const install = page.getByTestId(installId);
-      if (await install.isEnabled()) await install.click();
-      await expect(install).toBeDisabled();
-      await page.getByRole('button', { name: '关闭插件市场' }).click();
-      await expect(page.getByTestId(`agent-${appId}`)).toBeVisible();
-      await page.getByTestId(`agent-${appId}`).click();
-      await expect(page.getByTestId('miniapp-panel')).toContainText(appId);
-      await expect(page.getByTestId('miniapp-frame')).toBeVisible();
+  for (const miniAppId of officialAppIds) {
+    await test.step(`official app runtime: ${miniAppId}`, async () => {
+      await executeFeature(page, {
+        type: 'marketplace.install',
+        requestId: requestId(`install-${miniAppId}`),
+        miniAppId,
+      });
+      const event = await executeFeatureAndWaitForEvent(page, {
+        type: 'miniapp.open',
+        requestId: requestId(`open-${miniAppId}`),
+        miniAppId,
+      }, 'miniapp.opened');
+      expect(event.miniAppId).toBe(miniAppId);
+      expect(typeof event.html).toBe('string');
     });
   }
 }
 
-test('desktop package drives every declared Host journey through Electron IPC and Rust', async () => {
+test('desktop package drives every declared Host journey through the unified Messenger, Electron IPC, and Rust', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-electron-e2e-'));
   const app = await launchDesktopApp(appDataDir);
 
@@ -130,10 +199,10 @@ test('desktop package drives every declared Host journey through Electron IPC an
     await expect(page.locator('.desktop-mode-switch')).toHaveCount(0);
 
     const security = await page.evaluate(() => ({
-      nodeRequire: typeof (window as unknown as { require?: unknown }).require,
-      processGlobal: typeof (window as unknown as { process?: unknown }).process,
-      bridgeKeys: Object.keys(window.fabushi).sort(),
-      mahayanaKeys: Object.keys(window.mahayana ?? {}).sort(),
+      nodeRequire: typeof (window as any).require,
+      processGlobal: typeof (window as any).process,
+      bridgeKeys: Object.keys((window as any).fabushi).sort(),
+      mahayanaKeys: Object.keys((window as any).mahayana ?? {}).sort(),
     }));
     expect(security.nodeRequire).toBe('undefined');
     expect(security.processGlobal).toBe('undefined');
@@ -147,52 +216,32 @@ test('desktop package drives every declared Host journey through Electron IPC an
     ]);
     expect(security.mahayanaKeys).toEqual(['contractVersion', 'invoke', 'subscribe']);
 
-    const hostInfo = await page.evaluate(() => window.mahayana!.invoke<{
+    const hostInfo = await page.evaluate(() => (window as any).mahayana.invoke('feature.info')) as {
       platform: string;
       protocolVersion: string;
       runtimeVersion: string;
-    }>('feature.info'));
+    };
     expect(hostInfo.platform).toBe('electron');
     expect(hostInfo.protocolVersion).not.toBe('');
     expect(hostInfo.runtimeVersion).toContain('test');
 
-    const sessionClearFeature = mahayanaHostFeatures.find((feature) => feature.id === 'session.clear');
-    expect(sessionClearFeature).toBeTruthy();
+    const sessionClear = mahayanaHostFeatures.find((feature) => feature.id === 'session.clear');
+    expect(sessionClear).toBeTruthy();
 
     for (const feature of mahayanaHostFeatures.filter((feature) => feature.id !== 'session.clear')) {
       await test.step(`${feature.id}: ${feature.label}`, async () => {
         for (const step of feature.steps) await runJourneyStep(page, step);
-        await ensureComputerPanel(page);
-        await expect(page.getByTestId(`feature-result-${feature.id}`)).toHaveAttribute(
-          'data-state',
-          'passed',
-        );
       });
     }
 
     await runOfficialApps(page);
 
-    await test.step('Fabushi modal keyboard focus returns to the account trigger', async () => {
-      const accountTrigger = page.getByTestId('account-menu');
-      await accountTrigger.focus();
-      await accountTrigger.click();
-      await expect(page.getByTestId('logout')).toBeVisible();
-      await page.keyboard.press('Escape');
-      await expect(page.getByTestId('logout')).toBeHidden();
-      await expect(accountTrigger).toBeFocused();
+    await test.step(`${sessionClear!.id}: ${sessionClear!.label}`, async () => {
+      for (const step of sessionClear!.steps) await runJourneyStep(page, step);
     });
 
-    await test.step(`${sessionClearFeature!.id}: ${sessionClearFeature!.label}`, async () => {
-      for (const step of sessionClearFeature!.steps) await runJourneyStep(page, step);
-      await ensureComputerPanel(page);
-      await expect(page.getByTestId(`feature-result-${sessionClearFeature!.id}`)).toHaveAttribute(
-        'data-state',
-        'passed',
-      );
-    });
-
-    await expect(page.getByTestId('host-status')).toHaveAttribute('data-state', 'ready');
-    await expect(page.getByTestId('messages')).toBeVisible();
+    await expect(page.getByTestId('messenger-workspace')).toBeVisible();
+    await expect(page.getByTitle('聊天', { exact: true })).toBeVisible();
   } finally {
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/e2e/surfaces.spec.ts
+++ b/desktop/e2e/surfaces.spec.ts
@@ -31,10 +31,12 @@ async function completeBrowserLogin(page: Page): Promise<void> {
   while (await page.getByTestId('onboarding-gate').isVisible().catch(() => false)) {
     await page.getByTestId('onboarding-next').click();
   }
-  await expect(page.getByTestId('login-gate')).toBeVisible();
-  await page.getByTestId('browser-login-start').click();
-  await expect(page.getByTestId('login-gate')).toBeHidden();
-  await expect(page.getByTestId('host-status')).toHaveAttribute('data-state', 'ready');
+  const loginGate = page.getByTestId('login-gate');
+  if (await loginGate.isVisible().catch(() => false)) {
+    await page.getByTestId('browser-login-start').click();
+    await expect(loginGate).toBeHidden();
+  }
+  await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
 }
 
 async function clickApplicationMenuItem(app: ElectronApplication, label: string): Promise<void> {
@@ -53,6 +55,39 @@ async function clickApplicationMenuItem(app: ElectronApplication, label: string)
     return false;
   }, label);
   expect(clicked).toBe(true);
+}
+
+async function waitForNativeEventAfterMenu(
+  app: ElectronApplication,
+  page: Page,
+  label: string,
+  eventName: string,
+): Promise<Record<string, unknown>> {
+  const waiter = page.evaluate((wantedEvent) => new Promise<Record<string, unknown>>((resolve, reject) => {
+    const native = (window as any).fabushiNative;
+    let unsubscribe = () => {};
+    const timer = window.setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`Timed out waiting for native event ${wantedEvent}`));
+    }, 5_000);
+    unsubscribe = native.subscribe({
+      [wantedEvent]: (payload: Record<string, unknown>) => {
+        window.clearTimeout(timer);
+        unsubscribe();
+        resolve(payload ?? {});
+      },
+    });
+  }), eventName);
+  await clickApplicationMenuItem(app, label);
+  return waiter;
+}
+
+async function executeHostCommand(page: Page, type: string, extra: Record<string, unknown> = {}) {
+  const requestId = `surface-${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const accepted = await page.evaluate(async (command) => {
+    return (window as any).mahayana.invoke('feature.execute', { command });
+  }, { type, requestId, ...extra }) as { requestId?: string };
+  expect(accepted.requestId).toBe(requestId);
 }
 
 const safeNativeReads = [
@@ -88,7 +123,7 @@ const safeNativeReads = [
   'getProductionComputeAttachmentStatus',
 ] as const;
 
-test('installed desktop exposes product surfaces, browser lifecycle, and safe native reads', async () => {
+test('installed desktop exposes unified Messenger, native menu routing, browser lifecycle, and safe native reads', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-surface-e2e-'));
   const app = await launchDesktopApp(appDataDir);
 
@@ -98,10 +133,11 @@ test('installed desktop exposes product surfaces, browser lifecycle, and safe na
 
     await test.step('browser auth start, secure reopen, and cancel stay secret-free', async () => {
       const lifecycle = await page.evaluate(async () => {
-        const start = await window.mahayana!.invoke<Record<string, unknown>>('feature.auth.browserStart');
+        const bridge = (window as any).mahayana;
+        const start = await bridge.invoke('feature.auth.browserStart');
         const attemptId = String(start.attemptId ?? '');
-        const reopen = await window.mahayana!.invoke<Record<string, unknown>>('feature.auth.browserReopen', { attemptId });
-        const cancel = await window.mahayana!.invoke<Record<string, unknown>>('feature.auth.browserCancel', { attemptId });
+        const reopen = await bridge.invoke('feature.auth.browserReopen', { attemptId });
+        const cancel = await bridge.invoke('feature.auth.browserCancel', { attemptId });
         return { start, reopen, cancel };
       });
       expect(String(lifecycle.start.attemptId ?? '')).not.toBe('');
@@ -114,110 +150,50 @@ test('installed desktop exposes product surfaces, browser lifecycle, and safe na
 
     await completeBrowserLogin(page);
 
-    await test.step('composer exposes agent mode and model routing', async () => {
-      const mode = page.getByTestId('agent-mode');
-      await mode.selectOption('plan');
-      await expect(mode).toHaveValue('plan');
-      await mode.selectOption('ask');
-      await expect(mode).toHaveValue('ask');
-      await mode.selectOption('agent');
-      await expect(mode).toHaveValue('agent');
-      expect(await page.getByTestId('agent-model').locator('option').count()).toBeGreaterThan(0);
-    });
-
-    await test.step('notification and error tray is reachable', async () => {
-      const trigger = page.getByRole('button', { name: '通知与错误' });
-      await trigger.click();
-      await expect(page.locator('section[aria-label="通知与错误"]')).toBeVisible();
-      await trigger.click();
-      await expect(page.locator('section[aria-label="通知与错误"]')).toBeHidden();
-    });
-
-    await test.step('Agent Network, Shared Rooms, and Workspace are reachable', async () => {
-      await page.getByRole('button', { name: '智能体网络' }).click();
-      const dialog = page.getByRole('dialog', { name: '智能体网络' });
-      await expect(dialog).toBeVisible();
-      await dialog.getByRole('button', { name: 'Shared Rooms' }).click();
-      await expect(dialog.locator('section[aria-label="共享房间"]')).toBeVisible();
-      await dialog.getByRole('button', { name: 'Workspace' }).click();
-      await expect(dialog.locator('section[aria-label="Agent workspace"]')).toBeVisible();
-      await expect(dialog).toContainText('桌面存储审计');
-      await dialog.getByRole('button', { name: 'Agent Network' }).click();
-      await page.getByRole('button', { name: '关闭智能体网络' }).click();
-      await expect(dialog).toBeHidden();
-    });
-
-    await test.step('automation can be created and deleted through Fabushi confirmation', async () => {
-      await page.getByRole('button', { name: /自动化例程/ }).click();
-      const dialog = page.getByRole('dialog', { name: '自动化例程' });
-      await expect(dialog).toBeVisible();
-      await dialog.getByLabel('名称').fill('自动化验证');
-      await dialog.getByLabel('执行指令').fill('验证已安装桌面的自动化执行路径');
-      await dialog.getByRole('button', { name: '创建例程' }).click();
-      await expect(dialog).toContainText('自动化验证');
-      const row = dialog.locator('article').filter({ hasText: '自动化验证' }).first();
-      await row.getByRole('button', { name: '删除' }).click();
-      const confirm = page.getByTestId('confirm-dialog');
-      await expect(confirm).toContainText('删除例程「自动化验证」？');
-      await confirm.getByRole('button', { name: '删除例程' }).click();
-      await expect(confirm).toBeHidden();
-      await expect(dialog).not.toContainText('自动化验证');
-      await page.getByRole('button', { name: '关闭自动化' }).click();
-    });
-
-    await test.step('Computer panel and agent settings are reachable', async () => {
-      await page.getByRole('button', { name: '大乘助手的电脑' }).click();
-      await expect(page.getByTestId('feature-coverage')).toBeVisible();
-      await page.getByRole('button', { name: '智能体设置' }).click();
-      await expect(page.getByRole('button', { name: '← 返回电脑与例程' })).toBeVisible();
-      await page.getByRole('button', { name: '← 返回电脑与例程' }).click();
-      await page.getByRole('button', { name: '关闭电脑面板' }).click();
-    });
-
-    await test.step('application menu opens Settings and every settings section', async () => {
-      await clickApplicationMenuItem(app, '设置');
-      await expect(page.getByRole('dialog', { name: '通用设置' })).toBeVisible();
-      await page.getByRole('button', { name: /^MCP/ }).click();
-      await expect(page.getByRole('dialog', { name: 'MCP 与 Apps' })).toBeVisible();
-      await page.getByRole('button', { name: /用量与计费/ }).click();
-      await expect(page.getByRole('dialog', { name: '用量与计费' })).toBeVisible();
-      await page.getByRole('button', { name: /更新/ }).click();
-      await expect(page.getByRole('dialog', { name: '全球法布施更新' })).toBeVisible();
-      await page.getByRole('button', { name: '关闭设置' }).click();
-    });
-
-    await test.step('packaged Offline ASR is discoverable through the real native menu event', async () => {
-      await clickApplicationMenuItem(app, 'Offline ASR');
-      const dialog = page.getByRole('dialog', { name: '离线语音转写' });
-      await expect(dialog).toBeVisible();
-      await expect(dialog).toContainText('本地引擎');
-      if (packagedExecutable) {
-        await expect(dialog).toContainText('已就绪');
-      } else {
-        await expect(dialog).toContainText('可用状态');
+    await test.step('Telegram-class navigation and Grok/Fabushi agent identity share one shell', async () => {
+      await expect(page.getByTestId('messenger-workspace')).toBeVisible();
+      await expect(page.locator('.desktop-mode-switch')).toHaveCount(0);
+      for (const label of ['聊天', '联系人', 'Bots', '群组', '频道', '通话', '收藏', '归档', '文件夹', 'Mini Apps', '支付', '设置']) {
+        await expect(page.getByTitle(label, { exact: true })).toBeVisible();
       }
-      await page.getByRole('button', { name: '关闭离线语音转写' }).click();
+      const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+      await expect(assistant).toBeVisible();
+      await expect(assistant.locator('[data-engine="fabushi-motion-v2"]').first()).toBeVisible();
+      await assistant.click();
+      await expect(page.getByTestId('messenger-input')).toBeVisible();
     });
 
-    await test.step('Widget Gallery, About, and Feedback use native menu events', async () => {
-      await clickApplicationMenuItem(app, 'Widget Gallery');
-      await expect(page.getByRole('dialog', { name: 'Widget Gallery' })).toBeVisible();
-      await expect(page.getByRole('dialog', { name: 'Widget Gallery' })).toContainText('thinking');
-      await page.getByRole('button', { name: '关闭组件画廊' }).click();
+    await test.step('Mahayana Host capabilities stay callable after the Messenger takeover', async () => {
+      const info = await page.evaluate(() => (window as any).mahayana.invoke('feature.info')) as {
+        platform?: string;
+        protocolVersion?: string;
+        runtimeVersion?: string;
+      };
+      expect(info.platform).toBe('electron');
+      expect(String(info.protocolVersion ?? '')).not.toBe('');
+      expect(String(info.runtimeVersion ?? '')).not.toBe('');
+      await executeHostCommand(page, 'conversation.list');
+      await executeHostCommand(page, 'capability.list');
+      await executeHostCommand(page, 'automation.list');
+      await executeHostCommand(page, 'connector.list');
+    });
 
-      await clickApplicationMenuItem(app, '关于');
-      const about = page.getByRole('dialog', { name: '关于 Fabushi' });
-      await expect(about).toBeVisible();
-      await expect(about).toContainText('Mahayana Feature Host');
-      await page.getByRole('button', { name: '关闭关于' }).click();
+    await test.step('native application menus route into the unified renderer event bus', async () => {
+      const settings = await waitForNativeEventAfterMenu(app, page, '设置', 'deep-link');
+      expect(settings.route).toBe('settings');
+      expect(settings.section).toBe('general');
 
-      await clickApplicationMenuItem(app, '发送反馈');
-      const feedback = page.getByRole('dialog', { name: '发送反馈' });
-      await expect(feedback).toBeVisible();
-      await feedback.getByPlaceholder('告诉我们哪里可以更快、更稳或更好用…').fill('Fabushi installed desktop automated validation');
-      await feedback.getByRole('button', { name: '提交反馈' }).click();
-      await expect(feedback).toContainText('已保存反馈');
-      await page.getByRole('button', { name: '关闭反馈' }).click();
+      const offlineAsr = await waitForNativeEventAfterMenu(app, page, 'Offline ASR', 'open-offline-asr');
+      expect(offlineAsr.source).toBe('menu');
+
+      const widgets = await waitForNativeEventAfterMenu(app, page, 'Widget Gallery', 'widget-gallery');
+      expect(widgets.source).toBe('menu');
+
+      const about = await waitForNativeEventAfterMenu(app, page, '关于', 'open-about');
+      expect(about.source).toBe('menu');
+
+      const feedback = await waitForNativeEventAfterMenu(app, page, '发送反馈', 'open-feedback');
+      expect(feedback.source).toBe('menu');
     });
 
     await test.step('safe native desktop reads execute in the installed package', async () => {

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -563,7 +563,6 @@ function MessengerWorkspace() {
   function execute(command: Parameters<MahayanaHostTransport['execute']>[0]) {
     return transport.execute(command).catch((cause: unknown) => {
       setError(cause instanceof Error ? cause.message : String(cause));
-      throw cause;
     });
   }
 
@@ -1529,7 +1528,17 @@ async function saveInvoiceDialog() {
   }
 
   async function openMiniApp(id: string) {
-    await execute({ type: 'miniapp.open', requestId: nextRequestId('miniapp-open'), miniAppId: id });
+    setError(null);
+    try {
+      // The unified Messenger owns the complete Mini App path. The production
+      // Host intentionally refuses to open an app that has not been installed
+      // in the current runtime, so install/refresh the bundled capability first
+      // instead of bouncing users back to the retired Host marketplace UI.
+      await execute({ type: 'marketplace.install', requestId: nextRequestId('miniapp-install'), miniAppId: id });
+      await execute({ type: 'miniapp.open', requestId: nextRequestId('miniapp-open'), miniAppId: id });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
   }
 
   return (

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-001-grok-telegram-unified-ui.md
@@ -88,6 +88,15 @@
 - 新的 `verify-electron-macos-package.sh` fail-closed 验证 bundle id、App/Host/ASR TeamIdentifier 一致、`app.asar`、App icon、ASR license、隐私用途说明、code signature、stapler 和 Gatekeeper。
 - 生产签名 App 不再允许 `app.asar`/Host 原地 hot patch；hot package 明确降级为开发 overlay，避免破坏 sealed code signature 后再次触发 Keychain/Notary 信任问题。
 
+### Unified Electron gate repair after formal-package merge
+
+- Canonical main Electron run `32627198688` proved the final unified Messenger is already the post-login surface, but the quality gate still asserted retired HostClient DOM (`host-status`, `agent-mode`, computer panel, old marketplace), so Linux smoke failed before the macOS package matrix could exercise Developer ID signing/notarization.
+- Failure evidence from the uploaded Playwright artifact shows one Telegram-class rail, Grok/Fabushi Motion-v2 agent identity, the assistant conversation, and the unified composer; the failure was a test/product-contract mismatch rather than a duplicate-rail regression.
+- The unified Messenger Mini App path now owns install + open: it refreshes `marketplace.install` before `miniapp.open`, satisfying the real production Host requirement without routing users back to the retired Host marketplace UI.
+- `smoke.spec.ts` now drives the declared cross-platform journeys through the final Messenger and direct Electron→Mahayana edge where a feature has no final Messenger control yet; it still validates real Rust commands/events for capability approval, operation interrupt, session clear, and all official Mini Apps.
+- `surfaces.spec.ts` now validates the final single-shell navigation, Motion-v2 agent identity, Host capability availability, native application-menu event routing, and safe native reads without racing against the deliberate HostClient→Messenger post-login replacement.
+- This repair is required before the formal macOS package job can run and produce the Developer ID + notarized artifact for local installation and Keychain-prompt acceptance.
+
 ## Verification / evidence
 
 - UI source + E2E: PR #2046 merged, `fea29e5c...`。


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: `M7-DESKTOP-001`
- Follow-up to #2052

## Why
Canonical main Electron run `32627198688` never reached the formal macOS Developer ID/notarization package matrix. The Linux smoke stage failed because the E2E suite still asserted retired HostClient DOM after login even though the product intentionally switches into the final unified Messenger.

The failure artifact itself proves the final shell is present: one Telegram-class rail, Grok/Fabushi Motion-v2 agent identity, assistant conversation, and unified composer.

A second real product issue was exposed at the same time: the Messenger Mini App button called `miniapp.open` without first installing the bundled capability, while the production Rust Host correctly rejects opening an uninstalled Mini App.

## Fix
- Messenger Mini App entry now owns the complete install+open path: `marketplace.install` followed by `miniapp.open`; no bounce back to the retired Host marketplace.
- `smoke.spec.ts` drives every declared cross-platform journey through the final Messenger and the actual Electron→Mahayana edge for capabilities that do not yet have a dedicated Messenger control. It still exercises real Rust events/commands for approval, interrupt, session clear, and every official Mini App.
- `surfaces.spec.ts` validates the final single-shell navigation, Motion-v2 agent identity, Host capability availability, native menu event routing, browser-login lifecycle, and all safe native reads without racing against the deliberate HostClient→Messenger replacement.
- Removes stale post-login assertions for `host-status`, `agent-mode`, old marketplace, old computer panel, and other retired HostClient-only DOM.

## Verification
- `git diff --check`: PASS
- Heavy Electron build/E2E remains GitHub Actions only.

This PR is the gate repair required before canonical main can execute the new #2052 formal macOS signing/notarization workflow and produce the package for local installation + Keychain prompt acceptance.