### PR TITLE
feat(tfi): make all Mini Apps online-installed

### DIFF
--- a/.github/scripts/assert-electron-feature-host-bridge.sh
+++ b/.github/scripts/assert-electron-feature-host-bridge.sh
@@ -34,13 +34,13 @@ methods=(
   feature.auth.oauthStart
   feature.auth.oauthPoll
   feature.auth.logout
-  marketplace.browse
-  marketplace.release
-  plugin.install
-  plugin.uninstall
-  plugin.active
-  plugin.listInstalled
-  plugin.uiDocument
+  feature.marketplace.browse
+  feature.marketplace.release
+  feature.plugin.install
+  feature.plugin.uninstall
+  feature.plugin.active
+  feature.plugin.listInstalled
+  feature.plugin.uiDocument
 )
 
 for method in "${methods[@]}"; do

--- a/.github/scripts/assert-electron-feature-host-bridge.sh
+++ b/.github/scripts/assert-electron-feature-host-bridge.sh
@@ -34,6 +34,13 @@ methods=(
   feature.auth.oauthStart
   feature.auth.oauthPoll
   feature.auth.logout
+  marketplace.browse
+  marketplace.release
+  plugin.install
+  plugin.uninstall
+  plugin.active
+  plugin.listInstalled
+  plugin.uiDocument
 )
 
 for method in "${methods[@]}"; do
@@ -99,6 +106,11 @@ if grep -Fq 'MahayanaProductClient::default()' "$app_host"; then
   echo "Electron Rust app host must not probe the shared Mahayana container during startup" >&2
   exit 1
 fi
+if test -n "$desktop_shell" && grep -Fq 'defaultMiniApps' "$desktop_shell"; then
+  echo "Unified Messenger must discover Mini Apps from the online marketplace, not a bundled defaultMiniApps registry" >&2
+  exit 1
+fi
+
 for file in "$desktop_renderer" ${desktop_shell:+"$desktop_shell"}; do
   if grep -Eq 'PluginRuntimeApp|desktop-mode-switch|open-plugin-runtime|open-agent-host' "$file"; then
     echo "Canonical Electron renderer must not expose the retired PluginRuntime surface: $file" >&2

--- a/desktop/electron/mahayana-edge.cjs
+++ b/desktop/electron/mahayana-edge.cjs
@@ -19,13 +19,13 @@ const methodNames = [
   'feature.auth.oauthStart',
   'feature.auth.oauthPoll',
   'feature.auth.logout',
-  'marketplace.browse',
-  'marketplace.release',
-  'plugin.install',
-  'plugin.uninstall',
-  'plugin.active',
-  'plugin.listInstalled',
-  'plugin.uiDocument',
+  'feature.marketplace.browse',
+  'feature.marketplace.release',
+  'feature.plugin.install',
+  'feature.plugin.uninstall',
+  'feature.plugin.active',
+  'feature.plugin.listInstalled',
+  'feature.plugin.uiDocument',
 ];
 
 const methods = Object.fromEntries(methodNames.map((name) => [name, { args: 'object' }]));

--- a/desktop/electron/mahayana-edge.cjs
+++ b/desktop/electron/mahayana-edge.cjs
@@ -19,6 +19,13 @@ const methodNames = [
   'feature.auth.oauthStart',
   'feature.auth.oauthPoll',
   'feature.auth.logout',
+  'marketplace.browse',
+  'marketplace.release',
+  'plugin.install',
+  'plugin.uninstall',
+  'plugin.active',
+  'plugin.listInstalled',
+  'plugin.uiDocument',
 ];
 
 const methods = Object.fromEntries(methodNames.map((name) => [name, { args: 'object' }]));

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -48,7 +48,7 @@ import type {
 } from '../../frontend/apps/web/src/lib/mahayana-host/contracts';
 import { ElectronMahayanaHostTransport, isElectronMahayanaHostAvailable } from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
 import { MockMahayanaHostTransport } from '../../frontend/apps/web/src/lib/mahayana-host/mock-transport';
-import type { MahayanaHostTransport } from '../../frontend/apps/web/src/lib/mahayana-host/transport';
+import type { InstalledPluginPointer, MahayanaHostTransport, MarketplacePluginSummary } from '../../frontend/apps/web/src/lib/mahayana-host/transport';
 import {
   SelfHostedMessagingClientV2,
   asMessagingHostEvent,
@@ -147,12 +147,6 @@ const messengerSettingsKey = 'fabushi.desktop.messenger-settings.v2';
 const messengerDraftsKey = 'fabushi.desktop.messenger-drafts.v2';
 const initialPeerRenderCount = 120;
 const initialMessageRenderCount = 240;
-const defaultMiniApps = [
-  { id: 'global-dharma', title: '全球法布施', description: '任务、日志与部署' },
-  { id: 'faliu-flashcards', title: '法流记忆卡', description: '经文牌组与复习' },
-  { id: 'platform-publish', title: '平台发布', description: '内容发布与自动化' },
-  { id: 'bot-father', title: 'Bot Father', description: '创建和管理机器人' },
-];
 
 function createTransport(): MahayanaHostTransport {
   if (isElectronMahayanaHostAvailable()) return new ElectronMahayanaHostTransport();
@@ -379,7 +373,12 @@ function MessengerWorkspace() {
   const [attachmentProgress, setAttachmentProgress] = useState<string | null>(null);
   const [localCall, setLocalCall] = useState<LocalCall | null>(null);
   const [incomingCall, setIncomingCall] = useState<IncomingFabushiCall | null>(null);
-  const [miniApp, setMiniApp] = useState<{ id: string; html?: string } | null>(null);
+  const [miniApp, setMiniApp] = useState<{ id: string; title: string; html: string } | null>(null);
+  const [marketplaceApps, setMarketplaceApps] = useState<MarketplacePluginSummary[]>([]);
+  const [installedMiniApps, setInstalledMiniApps] = useState<Record<string, InstalledPluginPointer>>({});
+  const [miniAppQuery, setMiniAppQuery] = useState('');
+  const [miniAppLoading, setMiniAppLoading] = useState(false);
+  const [miniAppBusy, setMiniAppBusy] = useState<Set<string>>(() => new Set());
   const [error, setError] = useState<string | null>(null);
   const [mutedPeerKeys, setMutedPeerKeys] = useState<Set<string>>(() => new Set());
   const [pinnedPeerKeys, setPinnedPeerKeys] = useState<Set<string>>(() => new Set());
@@ -534,6 +533,14 @@ function MessengerWorkspace() {
       void transport.close();
     };
   }, [transport, selfHosted]);
+
+  useEffect(() => {
+    if (!hostReady || section !== 'miniapps') return;
+    const timer = window.setTimeout(() => {
+      void refreshMiniApps(miniAppQuery);
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [hostReady, section, miniAppQuery]);
 
   useEffect(() => {
     if (!hostReady) return;
@@ -1527,17 +1534,77 @@ async function saveInvoiceDialog() {
     toggleLocalSet(setMutedPeerKeys, peer.key);
   }
 
-  async function openMiniApp(id: string) {
-    setError(null);
+  async function refreshMiniApps(query = miniAppQuery) {
+    setMiniAppLoading(true);
     try {
-      // The unified Messenger owns the complete Mini App path. The production
-      // Host intentionally refuses to open an app that has not been installed
-      // in the current runtime, so install/refresh the bundled capability first
-      // instead of bouncing users back to the retired Host marketplace UI.
-      await execute({ type: 'marketplace.install', requestId: nextRequestId('miniapp-install'), miniAppId: id });
-      await execute({ type: 'miniapp.open', requestId: nextRequestId('miniapp-open'), miniAppId: id });
+      const [catalog, installed] = await Promise.all([
+        transport.marketplaceBrowse(query),
+        transport.pluginListInstalled(),
+      ]);
+      setMarketplaceApps(catalog.plugins);
+      setInstalledMiniApps(Object.fromEntries(installed.plugins.map((plugin) => [plugin.pluginId, plugin])));
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setMiniAppLoading(false);
+    }
+  }
+
+  function setMiniAppBusyState(id: string, busy: boolean) {
+    setMiniAppBusy((current) => {
+      const next = new Set(current);
+      if (busy) next.add(id); else next.delete(id);
+      return next;
+    });
+  }
+
+  async function installMiniApp(app: MarketplacePluginSummary) {
+    setError(null);
+    setMiniAppBusyState(app.pluginId, true);
+    try {
+      const release = await transport.marketplaceRelease(app.pluginId, app.latestVersion);
+      if (release.releaseStatus && release.releaseStatus !== 'approved') {
+        throw new Error(`Mini App release is not approved: ${release.releaseStatus}`);
+      }
+      if (release.releaseManifest?.protocol !== 'mahayana.external-release.v1') {
+        throw new Error('Mini App release is missing a verified external release manifest');
+      }
+      await transport.pluginInstall(release.releaseManifest, 'desktop');
+      await refreshMiniApps(miniAppQuery);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setMiniAppBusyState(app.pluginId, false);
+    }
+  }
+
+  async function uninstallMiniApp(id: string) {
+    setError(null);
+    setMiniAppBusyState(id, true);
+    try {
+      await transport.pluginUninstall(id);
+      if (miniApp?.id === id) setMiniApp(null);
+      await refreshMiniApps(miniAppQuery);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setMiniAppBusyState(id, false);
+    }
+  }
+
+  async function openMiniApp(id: string) {
+    setError(null);
+    setMiniAppBusyState(id, true);
+    try {
+      const installed = installedMiniApps[id] ?? await transport.pluginActive(id);
+      if (!installed) throw new Error('请先从在线 Mini App 市场安装此应用');
+      const document = await transport.pluginUiDocument(id);
+      const title = marketplaceApps.find((app) => app.pluginId === id)?.displayName ?? id;
+      setMiniApp({ id, title, html: document.html });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setMiniAppBusyState(id, false);
     }
   }
 
@@ -1612,7 +1679,7 @@ async function saveInvoiceDialog() {
             {!visiblePeers.length ? <EmptyList section={section} /> : null}
           </div>
         ) : (
-          <SectionPanel section={section} onOpenMiniApp={openMiniApp} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} />
+          <SectionPanel section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} />
         )}
       </aside>
 
@@ -1689,7 +1756,7 @@ async function saveInvoiceDialog() {
             </form>
           </>
         ) : (
-          <FeatureWorkspace section={section} onOpenMiniApp={openMiniApp} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} />
+          <FeatureWorkspace section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} />
         )}
       </section>
 
@@ -1974,8 +2041,8 @@ function CallDialog({
   </section></div>;
 }
 
-function MiniAppDialog({ app, onClose }: { app: { id: string; html?: string }; onClose: () => void }) {
-  return <div className={styles.backdrop} onMouseDown={onClose}><section className={styles.miniAppDialog} onMouseDown={(event) => event.stopPropagation()}><header><div><strong>{defaultMiniApps.find((item) => item.id === app.id)?.title ?? app.id}</strong><small>Mini App · 受控宿主容器</small></div><button type="button" onClick={onClose}><X size={17} /></button></header>{app.html ? <iframe title={app.id} sandbox="allow-scripts allow-forms" srcDoc={app.html} /> : <div className={styles.miniAppEmpty}><AppWindow size={38} /><strong>Mini App 已由 Host 打开</strong><p>生产构建将使用受控页面/WebView 容器。</p></div>}</section></div>;
+function MiniAppDialog({ app, onClose }: { app: { id: string; title: string; html: string }; onClose: () => void }) {
+  return <div className={styles.backdrop} onMouseDown={onClose}><section className={styles.miniAppDialog} onMouseDown={(event) => event.stopPropagation()}><header><div><strong>{app.title}</strong><small>Mini App · 已安装线上包 · 受控宿主容器</small></div><button type="button" onClick={onClose}><X size={17} /></button></header><iframe title={app.id} sandbox="allow-scripts allow-forms" srcDoc={app.html} /></section></div>;
 }
 
 type PaymentUiState = {
@@ -2008,16 +2075,81 @@ function PaymentOverview({ payment, onInvoice, onRefund, compact = false }: { pa
   </div>;
 }
 
-function SectionPanel({ section, onOpenMiniApp, onInvoice, payment, onRefund }: { section: MessengerSection; onOpenMiniApp: (id: string) => Promise<void>; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void }) {
-  if (section === 'miniapps') return <div className={styles.sectionList}>{defaultMiniApps.map((app) => <button type="button" key={app.id} onClick={() => void onOpenMiniApp(app.id)}><span className={styles.appIcon}><AppWindow size={18} /></span><div><strong>{app.title}</strong><small>{app.description}</small></div></button>)}</div>;
+type MiniAppMarketplaceProps = {
+  miniApps: MarketplacePluginSummary[];
+  installedMiniApps: Record<string, InstalledPluginPointer>;
+  miniAppQuery: string;
+  onMiniAppQuery: (query: string) => void;
+  miniAppLoading: boolean;
+  miniAppBusy: Set<string>;
+  onOpenMiniApp: (id: string) => Promise<void>;
+  onInstallMiniApp: (app: MarketplacePluginSummary) => Promise<void>;
+  onUninstallMiniApp: (id: string) => Promise<void>;
+};
+
+function MiniAppMarketplaceSearch({ query, onChange }: { query: string; onChange: (query: string) => void }) {
+  return <label className={styles.marketplaceSearch}><Search size={15} /><input value={query} onChange={(event) => onChange(event.target.value)} placeholder="搜索线上 Mini App" />{query ? <button type="button" onClick={() => onChange('')}><X size={13} /></button> : null}</label>;
+}
+
+function MiniAppMarketplaceList(props: MiniAppMarketplaceProps) {
+  return <div className={styles.sectionList}>
+    <MiniAppMarketplaceSearch query={props.miniAppQuery} onChange={props.onMiniAppQuery} />
+    {props.miniAppLoading ? <div className={styles.marketplaceStatus}>正在搜索在线市场…</div> : null}
+    {!props.miniAppLoading && !props.miniApps.length ? <div className={styles.marketplaceStatus}>没有找到可安装的 Mini App</div> : null}
+    {props.miniApps.map((app) => {
+      const installed = props.installedMiniApps[app.pluginId];
+      const busy = props.miniAppBusy.has(app.pluginId);
+      const update = Boolean(installed && installed.version !== app.latestVersion);
+      return <div className={styles.marketplaceRow} key={app.pluginId} data-testid={`miniapp-market-${app.pluginId}`}>
+        <span className={styles.appIcon}><AppWindow size={18} /></span>
+        <div className={styles.marketplaceCopy}><strong>{app.displayName}</strong><small>{app.description}</small><em>{installed ? `已安装 ${installed.version}` : `在线 · ${app.latestVersion}`}</em></div>
+        <div className={styles.marketplaceActions}>
+          {installed ? <button type="button" disabled={busy} onClick={() => void props.onOpenMiniApp(app.pluginId)}>打开</button> : null}
+          {!installed || update ? <button type="button" disabled={busy} onClick={() => void props.onInstallMiniApp(app)}>{busy ? '处理中' : update ? '更新' : '安装'}</button> : null}
+          {installed ? <button type="button" disabled={busy} title="卸载" onClick={() => void props.onUninstallMiniApp(app.pluginId)}><Trash2 size={13} /></button> : null}
+        </div>
+      </div>;
+    })}
+  </div>;
+}
+
+function MiniAppMarketplaceWorkspace(props: MiniAppMarketplaceProps) {
+  return <div className={styles.featureWorkspace}>
+    <AppWindow size={54} />
+    <h2>Mini Apps</h2>
+    <p>所有官方与第三方 Mini App 都从线上市场搜索、验证并安装；Fabushi 主程序不预装应用。</p>
+    <MiniAppMarketplaceSearch query={props.miniAppQuery} onChange={props.onMiniAppQuery} />
+    {props.miniAppLoading ? <div className={styles.marketplaceStatus}>正在搜索在线市场…</div> : null}
+    <div className={styles.featureGrid}>{props.miniApps.map((app) => {
+      const installed = props.installedMiniApps[app.pluginId];
+      const busy = props.miniAppBusy.has(app.pluginId);
+      const update = Boolean(installed && installed.version !== app.latestVersion);
+      return <article className={styles.marketplaceCard} key={app.pluginId}>
+        <AppWindow size={24} />
+        <strong>{app.displayName}</strong>
+        <small>{app.description}</small>
+        <em>{installed ? `已安装 ${installed.version}` : `线上版本 ${app.latestVersion}`}</em>
+        <div>
+          {installed ? <button type="button" disabled={busy} onClick={() => void props.onOpenMiniApp(app.pluginId)}>打开</button> : null}
+          {!installed || update ? <button type="button" disabled={busy} onClick={() => void props.onInstallMiniApp(app)}>{busy ? '处理中…' : update ? '更新' : '安装'}</button> : null}
+          {installed ? <button type="button" disabled={busy} onClick={() => void props.onUninstallMiniApp(app.pluginId)}>卸载</button> : null}
+        </div>
+      </article>;
+    })}</div>
+    {!props.miniAppLoading && !props.miniApps.length ? <div className={styles.marketplaceStatus}>没有找到可安装的 Mini App</div> : null}
+  </div>;
+}
+
+function SectionPanel({ section, onInvoice, payment, onRefund, ...miniAppProps }: { section: MessengerSection; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void } & MiniAppMarketplaceProps) {
+  if (section === 'miniapps') return <MiniAppMarketplaceList {...miniAppProps} />;
   if (section === 'payments') return <div className={styles.sectionList}><PaymentOverview payment={payment} onInvoice={onInvoice} onRefund={onRefund} compact /></div>;
   if (section === 'folders') return <div className={styles.sectionList}><div className={styles.panelHint}><Folder size={24} /><strong>聊天文件夹</strong><p>按联系人、Bot、群组、频道、未读和静音状态组织。</p></div></div>;
   if (section === 'calls') return <div className={styles.sectionList}><div className={styles.panelHint}><Phone size={24} /><strong>最近通话</strong><p>从会话顶部发起语音/视频。</p></div></div>;
   return <div className={styles.sectionList}><div className={styles.panelHint}><Settings size={24} /><strong>{sectionTitle(section)}</strong><p>该功能入口已合并进统一 Messenger。</p></div></div>;
 }
 
-function FeatureWorkspace({ section, onOpenMiniApp, onInvoice, payment, onRefund }: { section: MessengerSection; onOpenMiniApp: (id: string) => Promise<void>; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void }) {
-  if (section === 'miniapps') return <div className={styles.featureWorkspace}><AppWindow size={54} /><h2>Mini Apps</h2><p>Mini App 与 Bot、会话、支付共享身份和权限上下文。</p><div className={styles.featureGrid}>{defaultMiniApps.map((app) => <button type="button" key={app.id} onClick={() => void onOpenMiniApp(app.id)}><AppWindow size={22} /><strong>{app.title}</strong><small>{app.description}</small></button>)}</div></div>;
+function FeatureWorkspace({ section, onInvoice, payment, onRefund, ...miniAppProps }: { section: MessengerSection; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void } & MiniAppMarketplaceProps) {
+  if (section === 'miniapps') return <MiniAppMarketplaceWorkspace {...miniAppProps} />;
   if (section === 'payments') return <div className={styles.featureWorkspace}><WalletCards size={54} /><h2>Fabushi Pay</h2><p>自建余额、Invoice、Order、退款与外部 settlement 都由 Rust 账本结算。</p><PaymentOverview payment={payment} onInvoice={onInvoice} onRefund={onRefund} /></div>;
   if (section === 'calls') return <div className={styles.featureWorkspace}><Phone size={54} /><h2>通话</h2><p>本机媒体已接通，Rust realtime 已具备一对一/群组通话信令状态。</p></div>;
   return <div className={styles.featureWorkspace}><MessageCircle size={54} /><h2>{sectionTitle(section)}</h2><p>联系人、Bot、群组和频道正在统一到同一个 Fabushi Actor/Conversation 模型。</p></div>;

--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -535,3 +535,24 @@
     filter: none;
   }
 }
+
+.marketplaceSearch { width:calc(100% - 8px); min-height:36px; margin:6px 4px 10px; padding:0 10px; border:1px solid #dfe7ec; border-radius:10px; background:#f7fafc; display:flex; align-items:center; gap:7px; color:#6e7f8b; }
+.marketplaceSearch input { min-width:0; flex:1; border:0; outline:0; background:transparent; color:#2c3d49; font:inherit; }
+.marketplaceSearch button { border:0; background:transparent; color:#7c8a94; display:grid; place-items:center; cursor:pointer; }
+.marketplaceStatus { padding:14px 10px; color:#7f8e98; font-size:12px; text-align:center; }
+.marketplaceRow { width:100%; min-height:70px; padding:9px; display:flex; align-items:center; gap:9px; border-radius:11px; }
+.marketplaceRow:hover { background:#f3f6f8; }
+.marketplaceCopy { min-width:0; flex:1; display:grid; gap:2px; text-align:left; }
+.marketplaceCopy strong { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.marketplaceCopy small { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.marketplaceCopy em { color:#2b91cd; font-size:10px; font-style:normal; }
+.marketplaceActions { display:flex; align-items:center; gap:4px; }
+.marketplaceActions button { min-height:28px; padding:0 8px; border:1px solid #d7e4eb; border-radius:8px; background:#fff; color:#258ecf; font-size:11px; cursor:pointer; }
+.marketplaceActions button:disabled { opacity:.55; cursor:default; }
+.marketplaceCard { min-height:150px; padding:15px 12px; border:1px solid #e2e8ec; border-radius:13px; background:#fff; display:grid; justify-items:center; align-content:center; gap:6px; color:#268fcf; }
+.marketplaceCard strong { color:#33434f; }
+.marketplaceCard small { color:#7e8d97; line-height:1.35; }
+.marketplaceCard em { color:#268fcf; font-size:10px; font-style:normal; }
+.marketplaceCard > div { display:flex; flex-wrap:wrap; justify-content:center; gap:5px; margin-top:3px; }
+.marketplaceCard > div button { min-height:30px; padding:0 10px; border:1px solid #d7e4eb; border-radius:8px; background:#fff; display:inline-flex; align-items:center; justify-content:center; color:#258ecf; font-size:11px; cursor:pointer; }
+.marketplaceCard > div button:disabled { opacity:.55; cursor:default; }

--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -15,7 +15,13 @@ import type {
   RuntimeEvent,
 } from "./contracts";
 import type {
+  InstalledPluginList,
+  InstalledPluginPointer,
   MahayanaHostTransport,
+  MarketplaceBrowseResult,
+  MarketplaceReleaseMetadata,
+  PluginUiDocument,
+  PluginUninstallResult,
   RuntimeEventListener,
 } from "./transport";
 
@@ -133,6 +139,40 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
       }
     }
     return mahayanaBridge().invoke<CommandAccepted>("feature.execute", { command });
+  }
+
+  marketplaceBrowse(query?: string): Promise<MarketplaceBrowseResult> {
+    return mahayanaBridge().invoke<MarketplaceBrowseResult>("marketplace.browse", {
+      query: query?.trim() || undefined,
+      platform: "desktop",
+    });
+  }
+
+  marketplaceRelease(pluginId: string, version: string): Promise<MarketplaceReleaseMetadata> {
+    return mahayanaBridge().invoke<MarketplaceReleaseMetadata>("marketplace.release", { pluginId, version });
+  }
+
+  pluginInstall(
+    release: Record<string, unknown>,
+    platform = "desktop",
+  ): Promise<InstalledPluginPointer> {
+    return mahayanaBridge().invoke<InstalledPluginPointer>("plugin.install", { release, platform });
+  }
+
+  pluginUninstall(pluginId: string): Promise<PluginUninstallResult> {
+    return mahayanaBridge().invoke<PluginUninstallResult>("plugin.uninstall", { pluginId });
+  }
+
+  pluginActive(pluginId: string): Promise<InstalledPluginPointer | null> {
+    return mahayanaBridge().invoke<InstalledPluginPointer | null>("plugin.active", { pluginId });
+  }
+
+  pluginListInstalled(): Promise<InstalledPluginList> {
+    return mahayanaBridge().invoke<InstalledPluginList>("plugin.listInstalled");
+  }
+
+  pluginUiDocument(pluginId: string): Promise<PluginUiDocument> {
+    return mahayanaBridge().invoke<PluginUiDocument>("plugin.uiDocument", { pluginId });
   }
 
   authStatus(): Promise<AuthState> {

--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -142,37 +142,37 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   }
 
   marketplaceBrowse(query?: string): Promise<MarketplaceBrowseResult> {
-    return mahayanaBridge().invoke<MarketplaceBrowseResult>("marketplace.browse", {
+    return mahayanaBridge().invoke<MarketplaceBrowseResult>("feature.marketplace.browse", {
       query: query?.trim() || undefined,
       platform: "desktop",
     });
   }
 
   marketplaceRelease(pluginId: string, version: string): Promise<MarketplaceReleaseMetadata> {
-    return mahayanaBridge().invoke<MarketplaceReleaseMetadata>("marketplace.release", { pluginId, version });
+    return mahayanaBridge().invoke<MarketplaceReleaseMetadata>("feature.marketplace.release", { pluginId, version });
   }
 
   pluginInstall(
     release: Record<string, unknown>,
     platform = "desktop",
   ): Promise<InstalledPluginPointer> {
-    return mahayanaBridge().invoke<InstalledPluginPointer>("plugin.install", { release, platform });
+    return mahayanaBridge().invoke<InstalledPluginPointer>("feature.plugin.install", { release, platform });
   }
 
   pluginUninstall(pluginId: string): Promise<PluginUninstallResult> {
-    return mahayanaBridge().invoke<PluginUninstallResult>("plugin.uninstall", { pluginId });
+    return mahayanaBridge().invoke<PluginUninstallResult>("feature.plugin.uninstall", { pluginId });
   }
 
   pluginActive(pluginId: string): Promise<InstalledPluginPointer | null> {
-    return mahayanaBridge().invoke<InstalledPluginPointer | null>("plugin.active", { pluginId });
+    return mahayanaBridge().invoke<InstalledPluginPointer | null>("feature.plugin.active", { pluginId });
   }
 
   pluginListInstalled(): Promise<InstalledPluginList> {
-    return mahayanaBridge().invoke<InstalledPluginList>("plugin.listInstalled");
+    return mahayanaBridge().invoke<InstalledPluginList>("feature.plugin.listInstalled");
   }
 
   pluginUiDocument(pluginId: string): Promise<PluginUiDocument> {
-    return mahayanaBridge().invoke<PluginUiDocument>("plugin.uiDocument", { pluginId });
+    return mahayanaBridge().invoke<PluginUiDocument>("feature.plugin.uiDocument", { pluginId });
   }
 
   authStatus(): Promise<AuthState> {

--- a/frontend/apps/web/src/lib/mahayana-host/mock-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/mock-transport.ts
@@ -35,7 +35,13 @@ import {
   isElectronMahayanaHostAvailable,
 } from "./electron-transport";
 import type {
+  InstalledPluginList,
+  InstalledPluginPointer,
   MahayanaHostTransport,
+  MarketplaceBrowseResult,
+  MarketplaceReleaseMetadata,
+  PluginUiDocument,
+  PluginUninstallResult,
   RuntimeEventListener,
 } from "./transport";
 import { makeMemoryId, memoryDedupeKey, normalizeMemoryContent } from "../fabushi-runtime/memory-store";
@@ -505,6 +511,7 @@ const richResultsCards = (): TranscriptCard[] => {
 export class MockMahayanaHostTransport implements MahayanaHostTransport {
   private readonly native: MahayanaHostTransport | null;
   private readonly listeners = new Set<RuntimeEventListener>();
+  private readonly installedPlugins = new Map<string, InstalledPluginPointer>();
   private readonly approvals = new Set<string>();
   private status: HostStatus = "idle";
   private sequence = 0;
@@ -573,6 +580,72 @@ export class MockMahayanaHostTransport implements MahayanaHostTransport {
     this.status = "ready";
     this.emit({ type: "host.ready", timestamp: now(), info: this.info });
     return this.info;
+  }
+
+  async marketplaceBrowse(query?: string): Promise<MarketplaceBrowseResult> {
+    if (this.native) return this.native.marketplaceBrowse(query);
+    const term = query?.trim().toLocaleLowerCase() ?? "";
+    const plugins = [
+      ["global-dharma", "全球法布施", "任务、日志与部署"],
+      ["faliu-flashcards", "法流记忆卡", "经文牌组与复习"],
+      ["platform-publish", "平台发布", "内容发布与自动化"],
+      ["bot-father", "Bot Father", "创建和管理机器人"],
+    ].map(([pluginId, displayName, description]) => ({
+      pluginId, displayName, description, latestVersion: "1.0.0",
+      platforms: ["desktop"], releaseStatus: "approved",
+    })).filter((plugin) => !term || `${plugin.pluginId} ${plugin.displayName} ${plugin.description}`.toLocaleLowerCase().includes(term));
+    return { plugins };
+  }
+
+  async marketplaceRelease(pluginId: string, version: string): Promise<MarketplaceReleaseMetadata> {
+    if (this.native) return this.native.marketplaceRelease(pluginId, version);
+    return {
+      pluginId,
+      version,
+      releaseStatus: "approved",
+      releaseManifest: {
+        schemaVersion: 1,
+        protocol: "mahayana.external-release.v1",
+        pluginId,
+        version,
+        permissions: [],
+        artifacts: [],
+      },
+    };
+  }
+
+  async pluginInstall(release: Record<string, unknown>, platform = "desktop"): Promise<InstalledPluginPointer> {
+    if (this.native) return this.native.pluginInstall(release, platform);
+    const pluginId = String(release.pluginId ?? "");
+    const version = String(release.version ?? "1.0.0");
+    if (!pluginId) throw new Error("release pluginId is required");
+    const pointer: InstalledPluginPointer = {
+      pluginId, version, artifactId: "mock-ui", artifactSha256: "0".repeat(64),
+      runtime: "local-web", entry: "index.html", installedPath: `/mock/plugins/${pluginId}/${version}`, requestedPermissions: [],
+    };
+    this.installedPlugins.set(pluginId, pointer);
+    return pointer;
+  }
+
+  async pluginUninstall(pluginId: string): Promise<PluginUninstallResult> {
+    if (this.native) return this.native.pluginUninstall(pluginId);
+    return { pluginId, removed: this.installedPlugins.delete(pluginId), permissionsRemoved: true };
+  }
+
+  async pluginActive(pluginId: string): Promise<InstalledPluginPointer | null> {
+    if (this.native) return this.native.pluginActive(pluginId);
+    return this.installedPlugins.get(pluginId) ?? null;
+  }
+
+  async pluginListInstalled(): Promise<InstalledPluginList> {
+    if (this.native) return this.native.pluginListInstalled();
+    return { plugins: [...this.installedPlugins.values()] };
+  }
+
+  async pluginUiDocument(pluginId: string): Promise<PluginUiDocument> {
+    if (this.native) return this.native.pluginUiDocument(pluginId);
+    if (!this.installedPlugins.has(pluginId)) throw new Error(`plugin ${pluginId} is not installed`);
+    return { pluginId, html: `<!doctype html><meta charset="utf-8"><title>${pluginId}</title><main style="font-family:system-ui;padding:32px"><h1>${pluginId}</h1><p>Installed from the online Mahayana Marketplace.</p></main>` };
   }
 
   async execute(command: RuntimeCommand): Promise<CommandAccepted> {

--- a/frontend/apps/web/src/lib/mahayana-host/transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/transport.ts
@@ -17,9 +17,64 @@ import type {
 
 export type RuntimeEventListener = (event: RuntimeEvent) => void;
 
+export type MarketplacePluginSummary = {
+  pluginId: string;
+  displayName: string;
+  description: string;
+  latestVersion: string;
+  platforms?: string[];
+  releaseStatus?: string;
+  releaseManifest?: Record<string, unknown>;
+  source?: Record<string, unknown>;
+};
+
+export type MarketplaceBrowseResult = {
+  plugins: MarketplacePluginSummary[];
+};
+
+export type MarketplaceReleaseMetadata = {
+  pluginId: string;
+  version: string;
+  releaseStatus?: string;
+  releaseManifest: Record<string, unknown>;
+};
+
+export type InstalledPluginPointer = {
+  pluginId: string;
+  version: string;
+  artifactId: string;
+  artifactSha256: string;
+  runtime: string;
+  entry?: string;
+  requestedPermissions?: string[];
+  installedPath: string;
+};
+
+export type InstalledPluginList = {
+  plugins: InstalledPluginPointer[];
+};
+
+export type PluginUninstallResult = {
+  pluginId: string;
+  removed: boolean;
+  permissionsRemoved?: boolean;
+};
+
+export type PluginUiDocument = {
+  pluginId: string;
+  html: string;
+};
+
 export interface MahayanaHostTransport {
   initialize(config: HostConfig): Promise<HostInfo>;
   execute(command: RuntimeCommand): Promise<CommandAccepted>;
+  marketplaceBrowse(query?: string): Promise<MarketplaceBrowseResult>;
+  marketplaceRelease(pluginId: string, version: string): Promise<MarketplaceReleaseMetadata>;
+  pluginInstall(release: Record<string, unknown>, platform?: string): Promise<InstalledPluginPointer>;
+  pluginUninstall(pluginId: string): Promise<PluginUninstallResult>;
+  pluginActive(pluginId: string): Promise<InstalledPluginPointer | null>;
+  pluginListInstalled(): Promise<InstalledPluginList>;
+  pluginUiDocument(pluginId: string): Promise<PluginUiDocument>;
   authStatus(): Promise<AuthState>;
   authProviders(): Promise<AuthProvider[]>;
   browserLoginStart(): Promise<BrowserLoginAttempt>;

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -68,3 +68,9 @@
 - GitHub `main:projects/telegram-fabushi-integration/` 为唯一工程权威源。
 - immutable identity = `FAB-P0001 / TFI`。
 - 任何阶段都必须 current-head CI + protected merge + canonical-main verification 才能关账。
+
+## 2026-08-23 — M7 Mini App online installation convergence
+
+- 当前 implementation head 将官方/第三方 Mini App 收敛为同一线上 Marketplace 安装模型。
+- unified Messenger 不再维护 bundled `defaultMiniApps`；搜索、安装、更新、打开、卸载全部基于 Marketplace + AppHost plugin store。
+- 本地 structural gates 已通过；状态保持 `TESTING`，待 GitHub current-head CI、protected merge 与 canonical-main readback 后晋级 `TESTED`。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -69,3 +69,11 @@
 - PR #2053：增加布局 regression guard，让 workspace/direct flex content 可收缩、composer non-shrinking。
 - PR #2053：增加 Playwright transport routing + composer viewport geometry 回归测试。
 - initial implementation head 已通过 Project portfolio governance `32627390573` 与 Host fast E2E `32627390610`；latest-head required checks、protected merge 与 canonical-main readback 仍是 TESTED 晋级条件。
+
+## 2026-08-23 — Mini Apps switched to online-install model
+
+- 用户要求官方 Mini App 也必须像 Telegram 一样在线搜索安装，禁止作为 Messenger 内置应用。
+- `defaultMiniApps` 从 unified Messenger 删除；Mini Apps 入口改为实时 Marketplace browse/search + installed state。
+- 安装读取 approved `mahayana.external-release.v1` release manifest，通过 Rust `PluginInstaller` 验证下载并写入版本化本地 plugin store。
+- Electron edge/transport 新增 Marketplace、install/list/active/uninstall/UI document 路径；未安装应用不能打开。
+- CI guard 新增 `defaultMiniApps` 回归禁令。

--- a/projects/telegram-fabushi-integration/source/2026-08-23-online-miniapp-marketplace.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-23-online-miniapp-marketplace.md
@@ -1,0 +1,21 @@
+# 2026-08-23 — Online Mini App Marketplace convergence
+
+## User requirement
+
+官方 Mini App 与第三方 Mini App 使用同一线上安装模型：不在 Messenger 中维护内置 `defaultMiniApps` 清单；用户在 Mini Apps 入口搜索线上 Marketplace，安装经过审核的 release，安装后才能打开、更新或卸载。
+
+## Implementation
+
+- Electron Mahayana edge 暴露 `marketplace.browse` / `marketplace.release` 与 plugin install/active/list/uninstall/UI document 方法。
+- Renderer `MahayanaHostTransport` 使用同一版本化 edge，不走退役 generic IPC。
+- Unified Messenger 删除 `defaultMiniApps`，Mini Apps 左栏与 workspace 都改为在线搜索结果。
+- 安装路径读取 approved `mahayana.external-release.v1` manifest，再交给 Rust `PluginInstaller` 下载、哈希验证、版本化落盘和 active pointer 切换。
+- Rust AppHost 新增 installed-plugin enumeration；Mini App UI 只从当前已安装版本目录读取，未安装应用禁止打开。
+- 增加 CI guard，禁止 unified Messenger 恢复 bundled `defaultMiniApps` registry。
+
+## Local evidence
+
+- `git diff --check` PASS。
+- `node --check desktop/electron/mahayana-edge.cjs` PASS。
+- `.github/scripts/assert-electron-feature-host-bridge.sh` PASS（补齐 sparse paths 后执行）。
+- GitHub required checks 与 protected merge 仍是最终 TESTED 条件。

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -142,6 +142,7 @@ impl AppHost {
             "plugin.install" => self.install_plugin(params),
             "plugin.uninstall" => self.uninstall_plugin(params),
             "plugin.active" => self.active_plugin(params),
+            "plugin.listInstalled" => self.list_installed_plugins(),
             "plugin.permissions" => self.plugin_permissions(params),
             "plugin.permission.grant" => self.set_permission(params, true),
             "plugin.permission.revoke" => self.set_permission(params, false),
@@ -386,6 +387,38 @@ impl AppHost {
         serde_json::to_value(pointer).map_err(|error| AppHostError::Operation(error.to_string()))
     }
 
+    fn list_installed_plugins(&self) -> Result<Value, AppHostError> {
+        let root = self.plugin_root();
+        let installer = self.installer()?;
+        let mut plugins = Vec::new();
+        let entries = match std::fs::read_dir(&root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(json!({"plugins": plugins}));
+            }
+            Err(error) => return Err(AppHostError::Operation(error.to_string())),
+        };
+        for entry in entries {
+            let entry = entry.map_err(|error| AppHostError::Operation(error.to_string()))?;
+            if !entry
+                .file_type()
+                .map_err(|error| AppHostError::Operation(error.to_string()))?
+                .is_dir()
+            {
+                continue;
+            }
+            let plugin_id = entry.file_name().to_string_lossy().into_owned();
+            if let Some(pointer) = installer
+                .active(&plugin_id)
+                .map_err(|error| AppHostError::Operation(error.to_string()))?
+            {
+                plugins.push(pointer);
+            }
+        }
+        plugins.sort_by(|left, right| left.plugin_id.cmp(&right.plugin_id));
+        Ok(json!({"plugins": plugins}))
+    }
+
     fn plugin_permissions(&self, params: Value) -> Result<Value, AppHostError> {
         let plugin_id = string_param(&params, "pluginId")?;
         let pointer = self
@@ -459,20 +492,24 @@ impl AppHost {
             .ok_or_else(|| {
                 AppHostError::Operation(format!("plugin {plugin_id} is not installed"))
             })?;
-        if pointer.runtime != "local-web" {
-            return Err(AppHostError::Operation(format!(
-                "plugin runtime {} does not expose a local Web document",
-                pointer.runtime
-            )));
-        }
         let root = std::fs::canonicalize(&pointer.installed_path)
             .map_err(|error| AppHostError::Operation(error.to_string()))?;
-        let entry = pointer
-            .entry
-            .as_deref()
-            .unwrap_or("index.html")
-            .trim_start_matches("./");
-        let relative = PathBuf::from(entry);
+        let requested_entry = pointer.entry.as_deref().map(|value| value.trim_start_matches("./"));
+        let entry = requested_entry
+            .filter(|value| value.to_ascii_lowercase().ends_with(".html"))
+            .map(str::to_string)
+            .or_else(|| {
+                ["ui/index.html", "web/index.html", "index.html"]
+                    .into_iter()
+                    .find(|candidate| root.join(candidate).is_file())
+                    .map(str::to_string)
+            })
+            .ok_or_else(|| {
+                AppHostError::Operation(format!(
+                    "installed plugin {plugin_id} does not expose an HTML Mini App entry"
+                ))
+            })?;
+        let relative = PathBuf::from(&entry);
         if relative.components().any(|component| {
             matches!(
                 component,

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -114,40 +114,14 @@ impl AppHost {
         match method {
             "host.platform" => Ok(json!({"platform": host_platform()})),
             method if method.starts_with("feature.") => self.handle_feature(method, params),
-            "marketplace.browse" => {
-                let query = params.get("query").and_then(Value::as_str);
-                let requested_platform = params
-                    .get("platform")
-                    .and_then(Value::as_str)
-                    .unwrap_or(host_platform());
-                let marketplace_platform = match requested_platform {
-                    "ios" | "android" => "mobile",
-                    other => other,
-                };
-                self.product
-                    .marketplace_browse(query, Some(marketplace_platform))
-                    .map_err(|error| AppHostError::Operation(error.to_string()))
-            }
-            "marketplace.release" => {
-                let plugin_id = string_param(&params, "pluginId")?;
-                let version = string_param(&params, "version")?;
-                self.product
-                    .marketplace_release_metadata(plugin_id, version)
-                    .map_err(|error| AppHostError::Operation(error.to_string()))
-            }
             "platform.request" => self
                 .product
                 .execute("mahayana.platform.request", &params)
                 .map_err(|error| AppHostError::Operation(error.to_string())),
-            "plugin.install" => self.install_plugin(params),
-            "plugin.uninstall" => self.uninstall_plugin(params),
-            "plugin.active" => self.active_plugin(params),
-            "plugin.listInstalled" => self.list_installed_plugins(),
             "plugin.permissions" => self.plugin_permissions(params),
             "plugin.permission.grant" => self.set_permission(params, true),
             "plugin.permission.revoke" => self.set_permission(params, false),
             "plugin.compatibility" => self.plugin_compatibility(params),
-            "plugin.uiDocument" => self.plugin_ui_document(params),
             "runtime.start" => self.start_runtime(params),
             "runtime.stop" => self.stop_runtime(params),
             "runtime.tools" => self.runtime_tools(),
@@ -187,6 +161,13 @@ impl AppHost {
                 .feature
                 .logout()
                 .map_err(|error| AppHostError::Operation(error.to_string())),
+            "feature.marketplace.browse" => self.marketplace_browse(params),
+            "feature.marketplace.release" => self.marketplace_release(params),
+            "feature.plugin.install" => self.install_plugin(params),
+            "feature.plugin.uninstall" => self.uninstall_plugin(params),
+            "feature.plugin.active" => self.active_plugin(params),
+            "feature.plugin.listInstalled" => self.list_installed_plugins(),
+            "feature.plugin.uiDocument" => self.plugin_ui_document(params),
             "feature.messaging.access.issue" => self.feature_messaging_access_issue(params),
             other => Err(AppHostError::InvalidRequest(format!(
                 "unknown feature method {other}"
@@ -296,6 +277,29 @@ impl AppHost {
     fn feature_oauth_poll(&self, params: Value) -> Result<Value, AppHostError> {
         self.feature
             .oauth_poll(string_param(&params, "attemptId")?.to_string())
+            .map_err(|error| AppHostError::Operation(error.to_string()))
+    }
+
+    fn marketplace_browse(&self, params: Value) -> Result<Value, AppHostError> {
+        let query = params.get("query").and_then(Value::as_str);
+        let requested_platform = params
+            .get("platform")
+            .and_then(Value::as_str)
+            .unwrap_or(host_platform());
+        let marketplace_platform = match requested_platform {
+            "ios" | "android" => "mobile",
+            other => other,
+        };
+        self.product
+            .marketplace_browse(query, Some(marketplace_platform))
+            .map_err(|error| AppHostError::Operation(error.to_string()))
+    }
+
+    fn marketplace_release(&self, params: Value) -> Result<Value, AppHostError> {
+        let plugin_id = string_param(&params, "pluginId")?;
+        let version = string_param(&params, "version")?;
+        self.product
+            .marketplace_release_metadata(plugin_id, version)
             .map_err(|error| AppHostError::Operation(error.to_string()))
     }
 
@@ -494,7 +498,10 @@ impl AppHost {
             })?;
         let root = std::fs::canonicalize(&pointer.installed_path)
             .map_err(|error| AppHostError::Operation(error.to_string()))?;
-        let requested_entry = pointer.entry.as_deref().map(|value| value.trim_start_matches("./"));
+        let requested_entry = pointer
+            .entry
+            .as_deref()
+            .map(|value| value.trim_start_matches("./"));
         let entry = requested_entry
             .filter(|value| value.to_ascii_lowercase().ends_with(".html"))
             .map(str::to_string)


### PR DESCRIPTION
## Summary

- remove the bundled `defaultMiniApps` registry from the unified Messenger
- browse/search approved Mini Apps from the online Mahayana Marketplace
- install/update/uninstall through verified `mahayana.external-release.v1` manifests and the Rust `PluginInstaller`
- expose Marketplace + plugin lifecycle methods through the versioned Electron Mahayana edge
- enumerate installed plugins in the Rust AppHost and open UI only from the active installed version
- add regression guard preventing bundled Mini App registries from returning
- update FAB-P0001 / TFI source and status records

## Local verification

- `git diff --check`
- `node --check desktop/electron/mahayana-edge.cjs`
- `.github/scripts/assert-electron-feature-host-bridge.sh`

Final acceptance requires current-head GitHub CI, protected merge, and canonical-main readback.