### PR TITLE
fix(tfi): repair Mini App legacy event typing

### DIFF
--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -857,7 +857,10 @@ function MessengerWorkspace() {
         });
         break;
       case 'miniapp.opened':
-        setMiniApp({ id: event.miniAppId, html: event.html });
+        if (event.html) {
+          const title = marketplaceApps.find((app) => app.pluginId === event.miniAppId)?.displayName ?? event.miniAppId;
+          setMiniApp({ id: event.miniAppId, title, html: event.html });
+        }
         break;
       case 'operation.failed':
         setPendingSend(false);


### PR DESCRIPTION
## Summary

Follow-up to #2055. The online Mini App marketplace landed in `main`, but the Messaging Product Gate caught one renderer-only TypeScript mismatch in the legacy `miniapp.opened` event path.

- require `event.html` before opening the legacy Mini App event
- resolve a display title from the online marketplace catalog, falling back to the plugin id
- populate the canonical installed Mini App dialog state shape

## Evidence

The prior gate failed only at `desktop/src/messaging-shell-v2.tsx` with TS2322 (`string | undefined` -> `string`). This patch removes that mismatch. `git diff --check` passes.