### PR TITLE
feat(tfi): unify desktop navigation, avatars and global search

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -45,7 +45,7 @@ async function completeBrowserLogin(page: Page): Promise<void> {
 async function openMessenger(page: Page): Promise<void> {
   const workspace = page.getByTestId('messenger-workspace');
   await expect(workspace).toBeVisible();
-  await expect(page.getByTitle('聊天')).toBeVisible();
+  await expect(page.getByTestId('profile-navigation-trigger')).toBeVisible();
   await expect(page.getByTestId('open-messenger')).toHaveCount(0);
 }
 
@@ -108,6 +108,8 @@ test('desktop Messenger unifies Telegram-class navigation with Fabushi agent ide
     await completeBrowserLogin(page);
     await openMessenger(page);
 
+    await page.getByTestId('profile-navigation-trigger').click();
+    await expect(page.getByTestId('profile-navigation-menu')).toBeVisible();
     for (const label of [
       '聊天',
       '联系人',
@@ -124,6 +126,24 @@ test('desktop Messenger unifies Telegram-class navigation with Fabushi agent ide
     ]) {
       await expect(page.getByTitle(label, { exact: true })).toBeVisible();
     }
+    await page.getByTestId('profile-navigation-trigger').click();
+
+    const sidebar = page.getByTestId('messenger-sidebar');
+    const expandedBox = await sidebar.boundingBox();
+    expect(expandedBox?.width ?? 0).toBeGreaterThan(200);
+    await page.getByTestId('sidebar-resizer').dblclick();
+    await expect(sidebar).toHaveAttribute('data-collapsed', 'true');
+    const collapsedBox = await sidebar.boundingBox();
+    expect(collapsedBox?.width ?? 999).toBeLessThanOrEqual(112);
+    await page.getByTestId('sidebar-resizer').dblclick();
+    await expect(sidebar).not.toHaveAttribute('data-collapsed', 'true');
+
+    await page.getByTestId('global-search-trigger').click();
+    await expect(page.getByTestId('global-search-surface')).toBeVisible();
+    for (const category of ['chats', 'channels', 'apps', 'posts', 'images', 'videos', 'downloads', 'links', 'files', 'music', 'audio']) {
+      await expect(page.getByTestId(`global-search-tab-${category}`)).toBeVisible();
+    }
+    await page.getByRole('button', { name: '关闭搜索' }).click();
 
     const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
     await expect(assistant).toBeVisible();
@@ -242,8 +262,12 @@ test('installed Mini App opens from the unified Messenger surface', async () => 
     await completeBrowserLogin(page);
 
     await openMessenger(page);
-    await page.getByTitle('Mini Apps').click();
-    await page.getByRole('button', { name: /全球法布施/ }).last().click();
+    await page.getByTestId('global-search-trigger').click();
+    await page.getByTestId('global-search-tab-apps').click();
+    await page.getByTestId('global-search-input').fill('全球法布施');
+    const appResult = page.getByTestId('global-search-app-global-dharma');
+    await expect(appResult).toBeVisible();
+    await appResult.getByRole('button', { name: '打开' }).click();
     await expect(page.getByText('Mini App · 受控宿主容器')).toBeVisible();
     await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
   } finally {

--- a/desktop/e2e/smoke.spec.ts
+++ b/desktop/e2e/smoke.spec.ts
@@ -48,7 +48,7 @@ async function completeBrowserLogin(page: Page): Promise<void> {
     await expect(loginGate).toBeHidden();
   }
   await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByTitle('聊天', { exact: true })).toBeVisible();
+  await expect(page.getByTestId('profile-navigation-trigger')).toBeVisible();
 }
 
 async function executeFeature(page: Page, command: Record<string, unknown>) {
@@ -120,6 +120,7 @@ async function runJourneyStep(page: Page, step: MahayanaHostJourneyStep): Promis
       });
       return;
     case 'openMiniApp':
+      await page.getByTestId('profile-navigation-trigger').click();
       await page.getByTitle('Mini Apps', { exact: true }).click();
       if (step.miniAppId === 'global-dharma') {
         await page.getByRole('button', { name: /全球法布施/ }).last().click();
@@ -241,7 +242,7 @@ test('desktop package drives every declared Host journey through the unified Mes
     });
 
     await expect(page.getByTestId('messenger-workspace')).toBeVisible();
-    await expect(page.getByTitle('聊天', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('profile-navigation-trigger')).toBeVisible();
   } finally {
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/e2e/surfaces.spec.ts
+++ b/desktop/e2e/surfaces.spec.ts
@@ -153,6 +153,8 @@ test('installed desktop exposes unified Messenger, native menu routing, browser 
     await test.step('Telegram-class navigation and Grok/Fabushi agent identity share one shell', async () => {
       await expect(page.getByTestId('messenger-workspace')).toBeVisible();
       await expect(page.locator('.desktop-mode-switch')).toHaveCount(0);
+      await page.getByTestId('profile-navigation-trigger').click();
+      await expect(page.getByTestId('profile-navigation-menu')).toBeVisible();
       for (const label of ['聊天', '联系人', 'Bots', '群组', '频道', '通话', '收藏', '归档', '文件夹', 'Mini Apps', '支付', '设置']) {
         await expect(page.getByTitle(label, { exact: true })).toBeVisible();
       }

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -13,7 +13,6 @@ import {
   Image,
   Link2,
   MapPin,
-  Menu,
   MessageCircle,
   Mic,
   MoreVertical,
@@ -142,20 +141,31 @@ type ForwardDialogState = { sourceConversationId: string; message: DisplayMessag
 type EditDialogState = { conversationId: string; messageId: string; originalText: string; text: string } | null;
 type InvoiceDialogState = { conversationId: string; title: string; amount: string } | null;
 type InfoTab = 'media' | 'files' | 'links';
+type SearchCategory = 'chats' | 'channels' | 'apps' | 'posts' | 'images' | 'videos' | 'downloads' | 'links' | 'files' | 'music' | 'audio';
+
+const searchCategories: ReadonlyArray<{ id: SearchCategory; label: string }> = [
+  { id: 'chats', label: '聊天' },
+  { id: 'channels', label: '频道' },
+  { id: 'apps', label: '应用' },
+  { id: 'posts', label: '贴文' },
+  { id: 'images', label: '图片' },
+  { id: 'videos', label: '视频' },
+  { id: 'downloads', label: '下载' },
+  { id: 'links', label: '链接' },
+  { id: 'files', label: '文件' },
+  { id: 'music', label: '音乐' },
+  { id: 'audio', label: '声音' },
+];
 
 const messengerSettingsKey = 'fabushi.desktop.messenger-settings.v2';
 const messengerDraftsKey = 'fabushi.desktop.messenger-drafts.v2';
+const messengerSidebarWidthKey = 'fabushi.desktop.sidebar-width.v3';
 const initialPeerRenderCount = 120;
 const initialMessageRenderCount = 240;
 
 function createTransport(): MahayanaHostTransport {
   if (isElectronMahayanaHostAvailable()) return new ElectronMahayanaHostTransport();
   return new MockMahayanaHostTransport({ authenticated: true });
-}
-
-function avatarText(title: string): string {
-  const value = title.trim();
-  return value ? Array.from(value)[0] ?? '聊' : '聊';
 }
 
 
@@ -356,6 +366,10 @@ function MessengerWorkspace() {
   const [silentSend, setSilentSend] = useState(false);
   const [scheduledAtMs, setScheduledAtMs] = useState<number | undefined>();
   const [search, setSearch] = useState('');
+  const [globalSearchOpen, setGlobalSearchOpen] = useState(false);
+  const [globalSearchCategory, setGlobalSearchCategory] = useState<SearchCategory>('chats');
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const [sidebarWidth, setSidebarWidth] = useState(330);
   const [conversationSearchOpen, setConversationSearchOpen] = useState(false);
   const [conversationSearch, setConversationSearch] = useState('');
   const [peerRenderCount, setPeerRenderCount] = useState(initialPeerRenderCount);
@@ -399,6 +413,15 @@ function MessengerWorkspace() {
   useEffect(() => {
     activePeerKeyRef.current = activePeerKey;
   }, [activePeerKey]);
+
+  useEffect(() => {
+    const stored = Number(window.localStorage.getItem(messengerSidebarWidthKey));
+    if (Number.isFinite(stored) && stored >= 84 && stored <= 460) setSidebarWidth(stored);
+  }, []);
+
+  useEffect(() => {
+    try { window.localStorage.setItem(messengerSidebarWidthKey, String(Math.round(sidebarWidth))); } catch { /* best effort */ }
+  }, [sidebarWidth]);
 
   useEffect(() => {
     try {
@@ -541,6 +564,12 @@ function MessengerWorkspace() {
     }, 250);
     return () => window.clearTimeout(timer);
   }, [hostReady, section, miniAppQuery]);
+
+  useEffect(() => {
+    if (!hostReady || !globalSearchOpen || globalSearchCategory !== 'apps') return;
+    const timer = window.setTimeout(() => { void refreshMiniApps(search); }, 250);
+    return () => window.clearTimeout(timer);
+  }, [hostReady, globalSearchOpen, globalSearchCategory, search]);
 
   useEffect(() => {
     if (!hostReady) return;
@@ -1611,45 +1640,63 @@ async function saveInvoiceDialog() {
     }
   }
 
-  return (
-    <main className={`${styles.messenger} ${styles.fabushiUnified}`} data-testid="messenger-workspace" onClick={() => setMessageMenu(null)}>
-      <aside className={styles.navRail}>
-        <button className={styles.railBrand} type="button" onClick={() => setSection('chats')} title="Fabushi">法</button>
-        <RailButton icon={<MessageCircle />} label="聊天" active={section === 'chats'} onClick={() => setSection('chats')} />
-        <RailButton icon={<Users />} label="联系人" active={section === 'contacts'} onClick={() => setSection('contacts')} />
-        <RailButton icon={<Bot />} label="Bots" active={section === 'bots'} onClick={() => setSection('bots')} />
-        <RailButton icon={<Users />} label="群组" active={section === 'groups'} onClick={() => setSection('groups')} />
-        <RailButton icon={<Radio />} label="频道" active={section === 'channels'} onClick={() => setSection('channels')} />
-        <RailButton icon={<Phone />} label="通话" active={section === 'calls'} onClick={() => setSection('calls')} />
-        <RailButton icon={<Bookmark />} label="收藏" active={section === 'saved'} onClick={() => void ensureSavedMessages()} />
-        <RailButton icon={<Archive />} label="归档" active={section === 'archive'} onClick={() => setSection('archive')} />
-        <RailButton icon={<Folder />} label="文件夹" active={section === 'folders'} onClick={() => setSection('folders')} />
-        <div className={styles.railSpacer} />
-        <RailButton icon={<AppWindow />} label="Mini Apps" active={section === 'miniapps'} onClick={() => setSection('miniapps')} />
-        <RailButton icon={<WalletCards />} label="支付" active={section === 'payments'} onClick={() => setSection('payments')} />
-        <RailButton icon={<Settings />} label="设置" active={section === 'settings'} onClick={() => setSection('settings')} />
-      </aside>
 
-      <aside className={styles.chatList}>
+  function startSidebarResize(event: React.PointerEvent<HTMLDivElement>) {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = sidebarWidth;
+    const onMove = (moveEvent: PointerEvent) => {
+      const next = Math.max(84, Math.min(460, startWidth + moveEvent.clientX - startX));
+      setSidebarWidth(next);
+    };
+    const onUp = (upEvent: PointerEvent) => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      const finalWidth = Math.max(84, Math.min(460, startWidth + upEvent.clientX - startX));
+      setSidebarWidth(finalWidth < 145 ? 88 : finalWidth);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }
+
+  function navigateFromProfile(next: MessengerSection) {
+    setProfileMenuOpen(false);
+    setGlobalSearchOpen(false);
+    if (next === 'saved') {
+      void ensureSavedMessages();
+      return;
+    }
+    setSection(next);
+  }
+
+  return (
+    <main
+      className={`${styles.messenger} ${styles.fabushiUnified}`}
+      data-testid="messenger-workspace"
+      data-sidebar-collapsed={sidebarWidth <= 112 || undefined}
+      style={{ gridTemplateColumns: !globalSearchOpen && infoOpen && activePeer && sectionIsPeerList ? `${sidebarWidth}px minmax(420px,1fr) 286px` : `${sidebarWidth}px minmax(420px,1fr)` }}
+      onClick={() => { setMessageMenu(null); setProfileMenuOpen(false); }}
+    >
+      <aside className={styles.chatList} data-testid="messenger-sidebar" data-collapsed={sidebarWidth <= 112 || undefined} onClick={(event) => event.stopPropagation()}>
         <header className={styles.listHeader}>
-          <button type="button" className={styles.iconButton} aria-label="菜单"><Menu size={19} /></button>
+          <span className={styles.sidebarBrand} title="Fabushi"><BotMark botId="fabushi:brand" state="idle" size={30} label="Fabushi" /></span>
           <strong>{sectionTitle(section)}</strong>
           <button type="button" className={styles.iconButton} aria-label="新建" onClick={() => setNewDialog({ type: 'group', name: '', selectedBotIds: new Set() })}><SquarePen size={18} /></button>
         </header>
-        <label className={styles.searchBox}>
+        <label className={styles.searchBox} data-testid="global-search-trigger" onClick={() => setGlobalSearchOpen(true)}>
           <Search size={16} />
-          <input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="搜索消息、联系人和 Bot" />
-          {search ? <button type="button" onClick={() => setSearch('')}><X size={14} /></button> : null}
+          <input value={search} onFocus={() => setGlobalSearchOpen(true)} onChange={(event) => setSearch(event.target.value)} placeholder="搜索" />
+          {search ? <button type="button" aria-label="清除搜索" onClick={(event) => { event.stopPropagation(); setSearch(''); }}><X size={14} /></button> : null}
         </label>
-        {['chats', 'contacts'].includes(section) ? <div className={extra.storyStrip}>
+        {['chats', 'contacts'].includes(section) && sidebarWidth > 112 ? <div className={extra.storyStrip}>
           <button type="button" className={extra.storyItem} onClick={() => storyInputRef.current?.click()} title="发布动态">
-            <span className={extra.storyRing} data-own="true">{avatarText('我')}<b>+</b></span><small>我的动态</small>
+            <span className={extra.storyRing} data-own="true"><BotMark botId={`story:self:${selfHosted.actorId || 'local'}`} state="idle" size={40} label="我的动态" /><b>+</b></span><small>我的动态</small>
           </button>
           {visibleStories.map((story) => {
             const actor = selfActors.find((item) => item.id === story.ownerId);
             const name = actor?.displayName ?? (story.ownerId === selfHosted.actorId ? '我' : story.ownerId);
             return <button type="button" className={extra.storyItem} key={story.id} onClick={() => void openStory(story)} title={name}>
-              <span className={extra.storyRing}>{actor?.avatarUrl ? <img src={actor.avatarUrl} alt="" /> : avatarText(name)}</span><small>{name}</small>
+              <span className={extra.storyRing}><BotMark botId={`story:${story.ownerId}`} state="idle" size={40} label={name} /></span><small>{name}</small>
             </button>;
           })}
           <input ref={storyInputRef} type="file" accept="image/*,video/*" hidden onChange={(event) => { const file = event.currentTarget.files?.[0]; event.currentTarget.value = ''; if (file) void publishStoryFile(file); }} />
@@ -1662,15 +1709,13 @@ async function saveInvoiceDialog() {
             </div>
             {renderedPeers.map((peer) => (
               <button data-testid={`peer-${peer.key}`} key={peer.key} type="button" className={peer.key === activePeerKey ? styles.peerActive : styles.peer} onClick={() => void openPeer(peer)}>
-                {isAgentPeer(peer) ? (
-                  <BotMark
-                    botId={peer.actorId ?? peer.id}
-                    state={botMarkStateForPeer(peer, selfBotExecutions, peer.key === activePeerKey && pendingSend, hostReady)}
-                    size={48}
-                    className={styles.agentAvatarMark}
-                    label={peer.title}
-                  />
-                ) : <span className={styles.avatar}>{peer.avatar ? <img src={peer.avatar} alt="" /> : avatarText(peer.title)}<i data-kind={peer.kind} /></span>}
+                <BotMark
+                  botId={`peer:${peer.kind}:${peer.actorId ?? peer.id}`}
+                  state={isAgentPeer(peer) ? botMarkStateForPeer(peer, selfBotExecutions, peer.key === activePeerKey && pendingSend, hostReady) : peer.unread ? 'notifying' : 'idle'}
+                  size={48}
+                  className={styles.agentAvatarMark}
+                  label={peer.title}
+                />
                 <span className={styles.peerCopy}>
                   <span><strong>{peer.title}</strong><time>{formatTime(peer.updatedAtMs)}</time></span>
                   <small>{peer.subtitle}</small>
@@ -1684,22 +1729,60 @@ async function saveInvoiceDialog() {
         ) : (
           <SectionPanel section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} />
         )}
+        <div className={styles.sidebarFooter}>
+          {profileMenuOpen ? <ProfileNavigationMenu section={section} onNavigate={navigateFromProfile} /> : null}
+          <button
+            type="button"
+            className={styles.profileNavigationTrigger}
+            data-testid="profile-navigation-trigger"
+            title="个人与导航"
+            onClick={(event) => { event.stopPropagation(); setProfileMenuOpen((value) => !value); }}
+          >
+            <BotMark botId={`self:${selfHosted.actorId || 'local'}`} state="idle" size={38} label="我的头像" />
+            <span><strong>我</strong><small>导航与设置</small></span>
+          </button>
+        </div>
+        <div
+          className={styles.sidebarResizer}
+          data-testid="sidebar-resizer"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="调整会话栏宽度"
+          onPointerDown={startSidebarResize}
+          onDoubleClick={() => setSidebarWidth((width) => width <= 112 ? 330 : 88)}
+        />
       </aside>
 
       <section className={styles.chatWorkspace}>
-        {activePeer && sectionIsPeerList ? (
+        {globalSearchOpen ? (
+          <GlobalSearchWorkspace
+            query={search}
+            onQuery={setSearch}
+            category={globalSearchCategory}
+            onCategory={setGlobalSearchCategory}
+            peers={peers}
+            messages={messages}
+            miniApps={marketplaceApps}
+            installedMiniApps={installedMiniApps}
+            miniAppBusy={miniAppBusy}
+            miniAppLoading={miniAppLoading}
+            onOpenPeer={(peer) => { setGlobalSearchOpen(false); setSearch(''); setSection(peer.kind === 'channel' ? 'channels' : 'chats'); void openPeer(peer); }}
+            onOpenMiniApp={openMiniApp}
+            onInstallMiniApp={installMiniApp}
+            onUninstallMiniApp={uninstallMiniApp}
+            onClose={() => { setGlobalSearchOpen(false); setSearch(''); }}
+          />
+        ) : activePeer && sectionIsPeerList ? (
           <>
             <header className={styles.chatHeader}>
               <div className={styles.chatIdentity}>
-                {isAgentPeer(activePeer) ? (
-                  <BotMark
-                    botId={activePeer.actorId ?? activePeer.id}
-                    state={botMarkStateForPeer(activePeer, selfBotExecutions, pendingSend, hostReady)}
-                    size={40}
-                    className={styles.agentAvatarMark}
-                    label={activePeer.title}
-                  />
-                ) : <span className={styles.avatar}>{avatarText(activePeer.title)}<i data-kind={activePeer.kind} /></span>}
+                <BotMark
+                  botId={`peer:${activePeer.kind}:${activePeer.actorId ?? activePeer.id}`}
+                  state={isAgentPeer(activePeer) ? botMarkStateForPeer(activePeer, selfBotExecutions, pendingSend, hostReady) : 'idle'}
+                  size={40}
+                  className={styles.agentAvatarMark}
+                  label={activePeer.title}
+                />
                 <div><strong>{activePeer.title}</strong><small data-testid="conversation-status">{activeTypingActors.length ? '正在输入…' : `${activePeer.subtitle}${hostReady ? ' · 在线' : ' · 正在连接'}`}</small></div>
               </div>
               <div className={styles.headerActions}>
@@ -1736,7 +1819,7 @@ async function saveInvoiceDialog() {
                   <small>{formatTime(message.createdAtMs)} {message.role === 'me' ? <Check size={12} /> : null}</small>
                 </article>
               ))}
-              {!matchingMessages.length ? <div className={styles.chatEmpty} data-testid="message-search-empty">{isAgentPeer(activePeer) ? <BotMark botId={activePeer.actorId ?? activePeer.id} state={botMarkStateForPeer(activePeer, selfBotExecutions, false, hostReady)} size={78} className={styles.agentAvatarMark} label={activePeer.title} /> : <span className={styles.avatarLarge}>{avatarText(activePeer.title)}</span>}<strong>{conversationQuery ? '没有匹配消息' : activePeer.title}</strong><p>{conversationQuery ? '换一个关键词继续搜索。' : '联系人、AI Bot、群组和频道使用同一个 Fabushi 消息产品层。'}</p></div> : null}
+              {!matchingMessages.length ? <div className={styles.chatEmpty} data-testid="message-search-empty"><BotMark botId={`peer:${activePeer.kind}:${activePeer.actorId ?? activePeer.id}`} state={isAgentPeer(activePeer) ? botMarkStateForPeer(activePeer, selfBotExecutions, false, hostReady) : 'idle'} size={78} className={styles.agentAvatarMark} label={activePeer.title} /><strong>{conversationQuery ? '没有匹配消息' : activePeer.title}</strong><p>{conversationQuery ? '换一个关键词继续搜索。' : '联系人、AI Bot、群组和频道使用同一个 Fabushi 消息产品层。'}</p></div> : null}
             </div>
             {replyTo ? <div className={extra.composerBanner}><Reply size={15} /><div><strong>回复</strong><span>{replyTo.text}</span></div><button type="button" onClick={() => setReplyTo(null)}><X size={14} /></button></div> : null}
             {scheduledAtMs ? <div className={extra.composerBanner}><span>⏱</span><div><strong>定时发送</strong><span>{new Date(scheduledAtMs).toLocaleString()}</span></div><button type="button" onClick={() => setScheduledAtMs(undefined)}><X size={14} /></button></div> : null}
@@ -1763,11 +1846,11 @@ async function saveInvoiceDialog() {
         )}
       </section>
 
-      {infoOpen && activePeer && sectionIsPeerList ? (
+      {!globalSearchOpen && infoOpen && activePeer && sectionIsPeerList ? (
         <aside className={styles.infoPanel}>
           <header><strong>资料</strong><button type="button" onClick={() => setInfoOpen(false)}><X size={17} /></button></header>
           <div className={styles.profileCard}>
-            {isAgentPeer(activePeer) ? <BotMark botId={activePeer.actorId ?? activePeer.id} state={botMarkStateForPeer(activePeer, selfBotExecutions, pendingSend, hostReady)} size={92} className={styles.agentProfileMark} label={activePeer.title} /> : <span className={styles.avatarHuge}>{avatarText(activePeer.title)}</span>}
+            <BotMark botId={`peer:${activePeer.kind}:${activePeer.actorId ?? activePeer.id}`} state={isAgentPeer(activePeer) ? botMarkStateForPeer(activePeer, selfBotExecutions, pendingSend, hostReady) : 'idle'} size={92} className={styles.agentProfileMark} label={activePeer.title} />
             <strong>{activePeer.title}</strong><small>{activePeer.subtitle}</small>
             <div><button type="button" onClick={() => void startCall('voice')}><PhoneCall size={18} /><span>通话</span></button><button type="button" onClick={() => void startCall('video')}><Video size={18} /><span>视频</span></button><button type="button" onClick={() => setConversationSearchOpen(true)}><Search size={18} /><span>搜索</span></button></div>
           </div>
@@ -1795,8 +1878,89 @@ async function saveInvoiceDialog() {
   );
 }
 
-function RailButton({ icon, label, active, onClick }: { icon: React.ReactNode; label: string; active: boolean; onClick: () => void }) {
-  return <button type="button" data-active={active} onClick={onClick} title={label}><span>{icon}</span><small>{label}</small></button>;
+function ProfileNavigationMenu({ section, onNavigate }: { section: MessengerSection; onNavigate: (section: MessengerSection) => void }) {
+  const items: Array<{ section: MessengerSection; label: string; icon: React.ReactNode }> = [
+    { section: 'chats', label: '聊天', icon: <MessageCircle size={17} /> },
+    { section: 'contacts', label: '联系人', icon: <Users size={17} /> },
+    { section: 'bots', label: 'Bots', icon: <Bot size={17} /> },
+    { section: 'groups', label: '群组', icon: <Users size={17} /> },
+    { section: 'channels', label: '频道', icon: <Radio size={17} /> },
+    { section: 'calls', label: '通话', icon: <Phone size={17} /> },
+    { section: 'saved', label: '收藏', icon: <Bookmark size={17} /> },
+    { section: 'archive', label: '归档', icon: <Archive size={17} /> },
+    { section: 'folders', label: '文件夹', icon: <Folder size={17} /> },
+    { section: 'miniapps', label: 'Mini Apps', icon: <AppWindow size={17} /> },
+    { section: 'payments', label: '支付', icon: <WalletCards size={17} /> },
+    { section: 'settings', label: '设置', icon: <Settings size={17} /> },
+  ];
+  return <div className={styles.profileNavigationMenu} data-testid="profile-navigation-menu" onClick={(event) => event.stopPropagation()}>
+    <header><BotMark botId="fabushi:navigation" state="idle" size={34} label="Fabushi" /><div><strong>Fabushi</strong><small>统一导航</small></div></header>
+    <div>{items.map((item) => <button key={item.section} type="button" title={item.label} data-active={section === item.section} onClick={() => onNavigate(item.section)}>{item.icon}<span>{item.label}</span></button>)}</div>
+  </div>;
+}
+
+type GlobalSearchWorkspaceProps = {
+  query: string;
+  onQuery: (value: string) => void;
+  category: SearchCategory;
+  onCategory: (value: SearchCategory) => void;
+  peers: PeerItem[];
+  messages: DisplayMessage[];
+  miniApps: MarketplacePluginSummary[];
+  installedMiniApps: Record<string, InstalledPluginPointer>;
+  miniAppBusy: Set<string>;
+  miniAppLoading: boolean;
+  onOpenPeer: (peer: PeerItem) => void;
+  onOpenMiniApp: (id: string) => Promise<void>;
+  onInstallMiniApp: (app: MarketplacePluginSummary) => Promise<void>;
+  onUninstallMiniApp: (id: string) => Promise<void>;
+  onClose: () => void;
+};
+
+function GlobalSearchWorkspace(props: GlobalSearchWorkspaceProps) {
+  const normalized = props.query.trim().toLocaleLowerCase();
+  const matches = (value: string) => !normalized || value.toLocaleLowerCase().includes(normalized);
+  const peerResults = props.peers.filter((peer) => matches(`${peer.title} ${peer.subtitle}`));
+  const messageResults = props.messages.filter((message) => matches(message.text));
+  const mediaResults = messageResults.filter((message) => {
+    if (props.category === 'images') return message.mediaType === 'photo';
+    if (props.category === 'videos') return message.mediaType === 'video';
+    if (props.category === 'files' || props.category === 'downloads') return message.mediaType === 'document';
+    if (props.category === 'links') return /https?:\/\//iu.test(message.text);
+    return props.category === 'posts';
+  });
+  const appResults = props.miniApps.filter((app) => matches(`${app.displayName} ${app.description} ${app.pluginId}`));
+  const unsupportedMediaCategory = props.category === 'music' || props.category === 'audio';
+
+  return <div className={styles.globalSearch} data-testid="global-search-surface">
+    <header className={styles.globalSearchHeader}>
+      <label><Search size={20} /><input data-testid="global-search-input" value={props.query} onChange={(event) => props.onQuery(event.target.value)} placeholder="搜索聊天、频道、应用、文件…" autoFocus />{props.query ? <button type="button" aria-label="清除搜索" onClick={() => props.onQuery('')}><X size={18} /></button> : null}</label>
+      <button type="button" aria-label="关闭搜索" onClick={props.onClose}><X size={20} /></button>
+    </header>
+    <nav className={styles.globalSearchTabs} aria-label="搜索分类">
+      {searchCategories.map((item) => <button key={item.id} type="button" data-testid={`global-search-tab-${item.id}`} data-active={props.category === item.id} onClick={() => props.onCategory(item.id)}>{item.label}</button>)}
+    </nav>
+    <div className={styles.globalSearchResults}>
+      {props.category === 'chats' ? peerResults.filter((peer) => peer.kind !== 'channel').map((peer) => <button key={peer.key} type="button" className={styles.searchResultRow} onClick={() => props.onOpenPeer(peer)}><BotMark botId={`peer:${peer.kind}:${peer.actorId ?? peer.id}`} state="idle" size={46} label={peer.title} /><span><strong>{peer.title}</strong><small>{peer.subtitle}</small></span><time>{formatTime(peer.updatedAtMs)}</time></button>) : null}
+      {props.category === 'channels' ? peerResults.filter((peer) => peer.kind === 'channel').map((peer) => <button key={peer.key} type="button" className={styles.searchResultRow} onClick={() => props.onOpenPeer(peer)}><BotMark botId={`peer:channel:${peer.id}`} state="idle" size={46} label={peer.title} /><span><strong>{peer.title}</strong><small>{peer.subtitle}</small></span><time>{formatTime(peer.updatedAtMs)}</time></button>) : null}
+      {props.category === 'apps' ? <div className={styles.searchAppResults}>{props.miniAppLoading ? <div className={styles.marketplaceStatus}>正在搜索在线应用市场…</div> : appResults.map((app) => {
+        const installed = props.installedMiniApps[app.pluginId];
+        const busy = props.miniAppBusy.has(app.pluginId);
+        const update = Boolean(installed && installed.version !== app.latestVersion);
+        return <article key={app.pluginId} className={styles.searchAppCard} data-testid={`global-search-app-${app.pluginId}`}><BotMark botId={`miniapp:${app.pluginId}`} state={installed ? 'idle' : 'sleeping'} size={52} label={app.displayName} /><div><strong>{app.displayName}</strong><small>{app.description}</small><em>{installed ? `已安装 ${installed.version}` : `在线 · ${app.latestVersion}`}</em></div><aside>{installed ? <button type="button" disabled={busy} onClick={() => void props.onOpenMiniApp(app.pluginId)}>打开</button> : null}{!installed || update ? <button type="button" disabled={busy} onClick={() => void props.onInstallMiniApp(app)}>{busy ? '处理中' : update ? '更新' : '安装'}</button> : null}{installed ? <button type="button" disabled={busy} onClick={() => void props.onUninstallMiniApp(app.pluginId)}>卸载</button> : null}</aside></article>;
+      })}</div> : null}
+      {['posts', 'images', 'videos', 'downloads', 'links', 'files'].includes(props.category) ? mediaResults.map((message) => <article key={message.id} className={styles.searchMessageResult}><BotMark botId={`search-message:${message.id}`} state="idle" size={38} label="消息" /><div><p>{message.text || (message.mediaType === 'photo' ? '图片' : message.mediaType === 'video' ? '视频' : '文件')}</p><small>{new Date(message.createdAtMs).toLocaleString()}</small></div></article>) : null}
+      {unsupportedMediaCategory ? <SearchEmptyState label="当前会话尚无可搜索的音频索引" /> : null}
+      {props.category === 'chats' && !peerResults.filter((peer) => peer.kind !== 'channel').length ? <SearchEmptyState label={normalized ? '没有匹配的聊天' : '最近搜索结果将显示在此处'} /> : null}
+      {props.category === 'channels' && !peerResults.filter((peer) => peer.kind === 'channel').length ? <SearchEmptyState label={normalized ? '没有匹配的频道' : '最近搜索结果将显示在此处'} /> : null}
+      {props.category === 'apps' && !props.miniAppLoading && !appResults.length ? <SearchEmptyState label="没有匹配的在线应用" /> : null}
+      {['posts', 'images', 'videos', 'downloads', 'links', 'files'].includes(props.category) && !mediaResults.length ? <SearchEmptyState label={normalized ? '当前已加载内容中没有匹配结果' : '最近搜索结果将显示在此处'} /> : null}
+    </div>
+  </div>;
+}
+
+function SearchEmptyState({ label }: { label: string }) {
+  return <div className={styles.globalSearchEmpty}><Search size={58} /><strong>{label}</strong><small>输入关键词或切换分类继续搜索。</small></div>;
 }
 
 function EmptyList({ section }: { section: MessengerSection }) {
@@ -1830,7 +1994,7 @@ function ForwardMessageDialog({ message, peers, onClose, onSelect }: { message: 
   return <div className={styles.backdrop} onMouseDown={onClose}><section className={styles.dialog} onMouseDown={(event) => event.stopPropagation()}>
     <header><div><strong>转发消息</strong><small>{message.text || '媒体消息'}</small></div><button type="button" onClick={onClose}><X size={17} /></button></header>
     <div className={extra.forwardList}>
-      {peers.length ? peers.map((peer) => <button key={peer.key} type="button" onClick={() => onSelect(peer)}><span className={styles.avatar}>{avatarText(peer.title)}</span><span><strong>{peer.title}</strong><small>{peer.subtitle}</small></span><Forward size={16} /></button>) : <p>暂无可转发的自建会话，请先创建群组、频道或收藏消息。</p>}
+      {peers.length ? peers.map((peer) => <button key={peer.key} type="button" onClick={() => onSelect(peer)}><BotMark botId={`peer:${peer.kind}:${peer.actorId ?? peer.id}`} state="idle" size={40} label={peer.title} /><span><strong>{peer.title}</strong><small>{peer.subtitle}</small></span><Forward size={16} /></button>) : <p>暂无可转发的自建会话，请先创建群组、频道或收藏消息。</p>}
     </div>
   </section></div>;
 }
@@ -1866,7 +2030,7 @@ function NewConversationDialog({ dialog, bots, onChange, onClose, onSave }: { di
         const selectedBotIds = new Set(current.selectedBotIds);
         if (selectedBotIds.has(bot.id)) selectedBotIds.delete(bot.id); else selectedBotIds.add(bot.id);
         return { ...current, selectedBotIds };
-      })}><span className={styles.avatarSmall}>{avatarText(bot.name)}</span><div><strong>{bot.name}</strong><small>{bot.description}</small></div>{selected ? <Check size={16} /> : <Plus size={16} />}</button>;
+      })}><BotMark botId={`bot:${bot.id}`} state="idle" size={34} label={bot.name} /><div><strong>{bot.name}</strong><small>{bot.description}</small></div>{selected ? <Check size={16} /> : <Plus size={16} />}</button>;
     })}</div> : null}
     <footer><button type="button" onClick={onClose}>取消</button><button type="button" className={styles.primaryButton} disabled={!dialog.name.trim() || (dialog.type === 'group' && dialog.selectedBotIds.size === 0)} onClick={onSave}>{dialog.type === 'group' ? '创建群组' : '创建频道'}</button></footer>
   </section></div>;
@@ -1988,7 +2152,7 @@ function StoryViewer({ story, owner, own, onClose, onReact, onDelete }: { story:
   const isVideo = story.media.mimeType?.startsWith('video/') === true;
   return <div className={extra.storyBackdrop} onMouseDown={onClose}>
     <section className={extra.storyViewer} onMouseDown={(event) => event.stopPropagation()}>
-      <header><span className={styles.avatar}>{owner?.avatarUrl ? <img src={owner.avatarUrl} alt="" /> : avatarText(owner?.displayName ?? story.ownerId)}</span><div><strong>{owner?.displayName ?? story.ownerId}</strong><small>{new Date(story.createdAtMs).toLocaleString()}</small></div><button type="button" onClick={onClose}><X size={18} /></button></header>
+      <header><BotMark botId={`story:${story.ownerId}`} state="idle" size={40} label={owner?.displayName ?? story.ownerId} /><div><strong>{owner?.displayName ?? story.ownerId}</strong><small>{new Date(story.createdAtMs).toLocaleString()}</small></div><button type="button" onClick={onClose}><X size={18} /></button></header>
       <div className={extra.storyMedia}>{source ? isVideo ? <video src={source} autoPlay controls playsInline /> : <img src={source} alt={story.caption.text || 'Story'} /> : <span>媒体不可用</span>}</div>
       {story.caption.text ? <p>{story.caption.text}</p> : null}
       <footer>{['👍', '❤️', '🔥', '🙏'].map((reaction) => <button key={reaction} type="button" onClick={() => onReact(reaction)}>{reaction}</button>)}{own ? <button type="button" onClick={onDelete}><Trash2 size={16} />删除</button> : null}</footer>
@@ -2031,7 +2195,7 @@ function CallDialog({
           ? '通话连接失败'
           : '通话已结束';
   return <div className={styles.backdrop}><section className={styles.callDialog}>
-    <header><span className={styles.avatarHuge}>{avatarText(call.title)}</span><strong>{call.title}</strong><small>{statusText}</small></header>
+    <header><BotMark botId={`call:${call.title}`} state={call.status === "connected" ? "speaking" : "listening"} size={78} label={call.title} /><strong>{call.title}</strong><small>{statusText}</small></header>
     {call.kind === 'video' ? <div className={extra.callVideoStage}><video ref={remoteVideoRef} autoPlay playsInline className={extra.remoteVideo} /><video ref={localVideoRef} autoPlay muted playsInline className={extra.localVideoPip} /></div> : <audio ref={remoteAudioRef} autoPlay />}
     {call.error ? <p>{call.error}</p> : null}
     {canAccept && call.incoming && call.status === 'ringing' ? <div className={styles.callActions}><button type="button" onClick={onDecline} className={styles.hangup}><Phone size={20} /></button><button type="button" onClick={onAccept}><PhoneCall size={20} /></button></div> : <div className={styles.callActions}>
@@ -2104,7 +2268,7 @@ function MiniAppMarketplaceList(props: MiniAppMarketplaceProps) {
       const busy = props.miniAppBusy.has(app.pluginId);
       const update = Boolean(installed && installed.version !== app.latestVersion);
       return <div className={styles.marketplaceRow} key={app.pluginId} data-testid={`miniapp-market-${app.pluginId}`}>
-        <span className={styles.appIcon}><AppWindow size={18} /></span>
+        <span className={styles.appIcon}><BotMark botId={`miniapp:${app.pluginId}`} state={installed ? "idle" : "sleeping"} size={34} label={app.displayName} /></span>
         <div className={styles.marketplaceCopy}><strong>{app.displayName}</strong><small>{app.description}</small><em>{installed ? `已安装 ${installed.version}` : `在线 · ${app.latestVersion}`}</em></div>
         <div className={styles.marketplaceActions}>
           {installed ? <button type="button" disabled={busy} onClick={() => void props.onOpenMiniApp(app.pluginId)}>打开</button> : null}
@@ -2128,7 +2292,7 @@ function MiniAppMarketplaceWorkspace(props: MiniAppMarketplaceProps) {
       const busy = props.miniAppBusy.has(app.pluginId);
       const update = Boolean(installed && installed.version !== app.latestVersion);
       return <article className={styles.marketplaceCard} key={app.pluginId}>
-        <AppWindow size={24} />
+        <BotMark botId={`miniapp:${app.pluginId}`} state={installed ? "idle" : "sleeping"} size={48} label={app.displayName} />
         <strong>{app.displayName}</strong>
         <small>{app.description}</small>
         <em>{installed ? `已安装 ${installed.version}` : `线上版本 ${app.latestVersion}`}</em>

--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -556,3 +556,329 @@
 .marketplaceCard > div { display:flex; flex-wrap:wrap; justify-content:center; gap:5px; margin-top:3px; }
 .marketplaceCard > div button { min-height:30px; padding:0 10px; border:1px solid #d7e4eb; border-radius:8px; background:#fff; display:inline-flex; align-items:center; justify-content:center; color:#258ecf; font-size:11px; cursor:pointer; }
 .marketplaceCard > div button:disabled { opacity:.55; cursor:default; }
+
+/* M7-DESKTOP-003: one navigation surface, resizable avatar rail and Grok/Fabushi search. */
+.fabushiUnified.chatList,
+.fabushiUnified .chatList {
+  position: relative;
+  min-width: 84px;
+  overflow: visible;
+}
+
+.sidebarBrand {
+  display: grid;
+  place-items: center;
+}
+
+.sidebarFooter {
+  position: relative;
+  flex: 0 0 auto;
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--fabushi-line, rgba(255,255,255,.08));
+  background: rgba(12, 12, 19, .86);
+  backdrop-filter: blur(24px) saturate(1.18);
+  z-index: 8;
+}
+
+.profileNavigationTrigger {
+  width: 100%;
+  min-height: 52px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #f5f2fb;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+.profileNavigationTrigger:hover { background: rgba(255,255,255,.065); }
+.profileNavigationTrigger > span:last-child { min-width: 0; display: grid; gap: 1px; }
+.profileNavigationTrigger strong { font-size: 13px; }
+.profileNavigationTrigger small { font-size: 10px; color: var(--fabushi-muted, #9694a6); }
+
+.profileNavigationMenu {
+  position: absolute;
+  left: 10px;
+  bottom: calc(100% + 8px);
+  width: min(286px, calc(100vw - 24px));
+  padding: 10px;
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: 18px;
+  background: rgba(20, 19, 30, .98);
+  box-shadow: 0 24px 70px rgba(0,0,0,.5), inset 0 1px rgba(255,255,255,.05);
+  backdrop-filter: blur(28px) saturate(1.22);
+  z-index: 30;
+}
+.profileNavigationMenu > header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 4px 5px 10px;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+.profileNavigationMenu > header > div { display: grid; gap: 1px; }
+.profileNavigationMenu > header strong { font-size: 13px; color: #fff; }
+.profileNavigationMenu > header small { font-size: 10px; color: #8f8c9f; }
+.profileNavigationMenu > div { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; padding-top: 8px; }
+.profileNavigationMenu button {
+  min-height: 38px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #c7c3d2;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+.profileNavigationMenu button:hover { color: #fff; background: rgba(255,255,255,.065); }
+.profileNavigationMenu button[data-active="true"] { color: #fff; background: rgba(139,92,246,.2); }
+
+.sidebarResizer {
+  position: absolute;
+  top: 0;
+  right: -5px;
+  bottom: 0;
+  width: 10px;
+  z-index: 25;
+  cursor: col-resize;
+  touch-action: none;
+}
+.sidebarResizer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 4px;
+  width: 1px;
+  background: transparent;
+  transition: background .16s ease, box-shadow .16s ease;
+}
+.sidebarResizer:hover::after {
+  background: rgba(167,139,250,.72);
+  box-shadow: 0 0 14px rgba(139,92,246,.7);
+}
+
+.chatList[data-collapsed="true"] .listHeader {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  padding-inline: 6px;
+}
+.chatList[data-collapsed="true"] .listHeader > strong,
+.chatList[data-collapsed="true"] .listHeader > button,
+.chatList[data-collapsed="true"] .searchBox input,
+.chatList[data-collapsed="true"] .searchBox button,
+.chatList[data-collapsed="true"] .peerCopy,
+.chatList[data-collapsed="true"] .peerMeta,
+.chatList[data-collapsed="true"] .quickActions,
+.chatList[data-collapsed="true"] .profileNavigationTrigger > span:last-child,
+.chatList[data-collapsed="true"] .sectionList {
+  display: none;
+}
+.chatList[data-collapsed="true"] .searchBox {
+  width: 48px;
+  height: 44px;
+  margin: 0 auto 8px;
+  padding: 0;
+  justify-content: center;
+  border-radius: 14px;
+  cursor: pointer;
+}
+.chatList[data-collapsed="true"] .peer,
+.chatList[data-collapsed="true"] .peerActive {
+  width: 64px;
+  min-height: 64px;
+  margin: 3px auto;
+  padding: 8px;
+  grid-template-columns: 48px;
+  justify-content: center;
+  border-radius: 16px;
+}
+.chatList[data-collapsed="true"] .peerList { padding: 2px 0 8px; }
+.chatList[data-collapsed="true"] .sidebarFooter { padding-inline: 8px; }
+.chatList[data-collapsed="true"] .profileNavigationTrigger { padding: 5px; justify-content: center; }
+.chatList[data-collapsed="true"] .profileNavigationMenu { left: 76px; bottom: 8px; }
+
+.globalSearch {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  color: #f4f1f8;
+  background:
+    radial-gradient(circle at 82% 4%, rgba(71,122,255,.14), transparent 32%),
+    radial-gradient(circle at 18% 88%, rgba(139,92,246,.12), transparent 30%),
+    #0d0d14;
+}
+.globalSearchHeader {
+  min-height: 72px;
+  padding: 14px 18px 8px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(13,13,20,.88);
+  backdrop-filter: blur(24px) saturate(1.2);
+}
+.globalSearchHeader > label {
+  min-width: 0;
+  flex: 1;
+  height: 44px;
+  padding: 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 16px;
+  color: #8f8c9f;
+  background: rgba(255,255,255,.07);
+  box-shadow: inset 0 1px rgba(255,255,255,.03);
+}
+.globalSearchHeader > label:focus-within {
+  border-color: rgba(167,139,250,.6);
+  box-shadow: 0 0 0 3px rgba(139,92,246,.12);
+}
+.globalSearchHeader input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  color: #fff;
+  background: transparent;
+  font: inherit;
+  font-size: 15px;
+}
+.globalSearchHeader button,
+.globalSearchTabs button {
+  border: 0;
+  color: #9995a8;
+  background: transparent;
+  cursor: pointer;
+}
+.globalSearchHeader > button { width: 40px; height: 40px; border-radius: 12px; display: grid; place-items: center; }
+.globalSearchHeader > button:hover { color: #fff; background: rgba(255,255,255,.07); }
+
+.globalSearchTabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 18px;
+  overflow-x: auto;
+  border-bottom: 1px solid rgba(255,255,255,.07);
+  background: rgba(13,13,20,.88);
+}
+.globalSearchTabs button {
+  position: relative;
+  flex: 0 0 auto;
+  min-height: 42px;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 12px;
+}
+.globalSearchTabs button:hover { color: #e9e5f2; }
+.globalSearchTabs button[data-active="true"] { color: #bca8ff; }
+.globalSearchTabs button[data-active="true"]::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 0;
+  height: 2px;
+  border-radius: 2px 2px 0 0;
+  background: linear-gradient(90deg,#7b61ff,#a78bfa);
+}
+.globalSearchResults { min-height: 0; overflow: auto; padding: 12px 18px 28px; }
+.searchResultRow {
+  width: 100%;
+  min-height: 68px;
+  padding: 9px 10px;
+  border: 0;
+  border-radius: 15px;
+  display: grid;
+  grid-template-columns: 48px minmax(0,1fr) auto;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+  color: #f3f0f7;
+  background: transparent;
+  cursor: pointer;
+}
+.searchResultRow:hover { background: rgba(255,255,255,.055); }
+.searchResultRow > span { min-width: 0; display: grid; gap: 3px; }
+.searchResultRow strong,
+.searchResultRow small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.searchResultRow small,
+.searchResultRow time { color: #8f8c9f; font-size: 11px; }
+.searchAppResults { display: grid; gap: 8px; }
+.searchAppCard {
+  min-height: 78px;
+  padding: 10px 12px;
+  display: grid;
+  grid-template-columns: 56px minmax(0,1fr) auto;
+  align-items: center;
+  gap: 11px;
+  border: 1px solid rgba(255,255,255,.07);
+  border-radius: 16px;
+  background: rgba(255,255,255,.035);
+}
+.searchAppCard > div { min-width: 0; display: grid; gap: 3px; }
+.searchAppCard strong { color: #f5f2fb; }
+.searchAppCard small { color: #a09cac; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.searchAppCard em { color: #ad9aff; font-size: 10px; font-style: normal; }
+.searchAppCard aside { display: flex; gap: 5px; }
+.searchAppCard button {
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid rgba(167,139,250,.22);
+  border-radius: 9px;
+  color: #d8ceff;
+  background: rgba(139,92,246,.11);
+  cursor: pointer;
+}
+.searchAppCard button:hover { color: #fff; background: rgba(139,92,246,.2); }
+.searchMessageResult {
+  min-height: 64px;
+  padding: 10px;
+  border-bottom: 1px solid rgba(255,255,255,.06);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.searchMessageResult > div { min-width: 0; display: grid; gap: 3px; }
+.searchMessageResult p { margin: 0; color: #eeeaf5; }
+.searchMessageResult small { color: #8f8c9f; font-size: 10px; }
+.globalSearchEmpty {
+  min-height: 52vh;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  color: #777384;
+  text-align: center;
+}
+.globalSearchEmpty svg { opacity: .55; filter: drop-shadow(0 8px 22px rgba(139,92,246,.16)); }
+.globalSearchEmpty strong { color: #a7a3b3; font-size: 14px; font-weight: 560; }
+.globalSearchEmpty small { color: #716d7d; font-size: 11px; }
+
+.fabushiUnified .marketplaceRow,
+.fabushiUnified .marketplaceCard {
+  color: #f2eef8;
+  border-color: rgba(255,255,255,.08);
+  background: rgba(255,255,255,.035);
+}
+.fabushiUnified .marketplaceRow:hover { background: rgba(255,255,255,.06); }
+.fabushiUnified .marketplaceCopy strong,
+.fabushiUnified .marketplaceCard strong { color: #f2eef8; }
+.fabushiUnified .marketplaceCopy small,
+.fabushiUnified .marketplaceCard small { color: #918d9e; }
+.fabushiUnified .marketplaceActions button,
+.fabushiUnified .marketplaceCard > div button {
+  border-color: rgba(167,139,250,.2);
+  color: #d7ceff;
+  background: rgba(139,92,246,.1);
+}

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
@@ -1,0 +1,40 @@
+# M7-DESKTOP-003 Evidence
+
+- Project: `FAB-P0001 / TFI`
+- Task: `M7-DESKTOP-003`
+- Branch: `feat/tfi-m7-unified-search-resizable-sidebar`
+- Status: `IMPLEMENTED` (GitHub CI / protected merge pending)
+- Date: 2026-08-23
+
+## Implementation evidence
+
+- `desktop/src/messaging-shell-v2.tsx`
+  - removed the permanent feature `navRail` from the authenticated Messenger;
+  - added bottom-left `profile-navigation-trigger` and menu for Chats/Contacts/Bots/Groups/Channels/Calls/Saved/Archive/Folders/Mini Apps/Payments/Settings;
+  - added persisted resizable sidebar with pointer drag and avatar-only collapse;
+  - converted peer/story/call/dialog/Mini App identities to canonical `BotMark` / `fabushi-motion-v2`;
+  - added `GlobalSearchWorkspace` with 11 category tabs;
+  - reused live Marketplace data/actions inside the “应用” search tab.
+- `desktop/src/messaging-shell.module.css`
+  - added Grok/Fabushi dark-glass personal menu, resizer, collapsed avatar rail, categorized search surface and dark Marketplace styling.
+- `desktop/e2e/messenger.spec.ts`
+  - asserts personal navigation contents;
+  - asserts collapsed/expanded sidebar geometry;
+  - asserts all 11 search tabs;
+  - opens the installed `global-dharma` Mini App through global Application search.
+- `desktop/e2e/smoke.spec.ts`, `desktop/e2e/surfaces.spec.ts`
+  - updated canonical navigation expectations to the personal-avatar menu.
+
+## Local lightweight verification
+
+Per repository policy, no local Electron build, Playwright, Cargo, package build or heavyweight test was executed.
+
+- `git diff --check` — PASS.
+- source marker inspection — PASS for `profile-navigation-trigger`, `sidebar-resizer`, global search tabs, unified `peer:*` BotMark and `miniapp:*` BotMark identities.
+
+## Pending objective evidence
+
+- GitHub Actions current-head relevant gates.
+- protected PR merge.
+- canonical `main` readback.
+- final packaged desktop visual acceptance.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -53,3 +53,8 @@ M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded 
 `M7-DESKTOP-001` 将 Grok/Fabushi 已自研的 Motion v2 动态 Agent identity 与 Telegram-class Messenger 合并为一个产品界面。`M7-DESKTOP-002` 处理统一界面落地后的真实回归：Mini App summary 不得进入普通 Agent conversation backend；所有普通 chat peer 的 composer 必须完整位于 Electron viewport 内。
 
 当前 `M7-DESKTOP-002` = `TESTING`。PR #2053 initial head 已获得 Project portfolio governance run `32627390573` SUCCESS 与 Host fast E2E run `32627390610` SUCCESS；其余 current-head required checks、protected merge 与 canonical-main verification 完成前不得标记 `TESTED`。
+
+
+## Active M7 desktop convergence — M7-DESKTOP-003
+
+`M7-DESKTOP-003` = `IMPLEMENTED`：单一 Messenger 当前源码已具备 personal-avatar navigation、resizable avatar-only sidebar、全身份 BotMark、11 类 global search 与 Marketplace-in-search。新增 Playwright assertions 已写入 desktop E2E，但在 current-head GitHub Actions、protected merge、canonical-main verification 完成前不得标记 `TESTED`。

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -74,3 +74,12 @@
 - 当前 implementation head 将官方/第三方 Mini App 收敛为同一线上 Marketplace 安装模型。
 - unified Messenger 不再维护 bundled `defaultMiniApps`；搜索、安装、更新、打开、卸载全部基于 Marketplace + AppHost plugin store。
 - 本地 structural gates 已通过；状态保持 `TESTING`，待 GitHub current-head CI、protected merge 与 canonical-main readback 后晋级 `TESTED`。
+
+
+## 2026-08-23 — M7-DESKTOP-003 unified identity/search/sidebar
+
+- 用户提供 6 张 UI 参考，要求将图 5 的常驻联系人/Bots/收藏等导航收进左下角个人头像，并采用图 2/3 可拖拽 avatar-only 左栏与图 6 分类搜索。
+- current implementation 已删除 authenticated Messenger 常驻 `navRail`，新增 personal BotMark navigation menu、persisted resizable/collapsible sidebar。
+- 真人/Agent/Bot/群组/频道/Story/Call/Mini App identity 已统一到 canonical `BotMark` / `fabushi-motion-v2`。
+- global search 新增聊天、频道、应用、贴文、图片、视频、下载、链接、文件、音乐、声音 11 分类；应用分类复用线上 Marketplace install/update/open/uninstall。
+- E2E source 已覆盖导航、sidebar collapse、search tabs 与通过应用搜索打开 Mini App。当前状态 `IMPLEMENTED`；GitHub current-head CI / protected merge / canonical-main readback 尚待完成。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -77,3 +77,12 @@
 - 安装读取 approved `mahayana.external-release.v1` release manifest，通过 Rust `PluginInstaller` 验证下载并写入版本化本地 plugin store。
 - Electron edge/transport 新增 Marketplace、install/list/active/uninstall/UI document 路径；未安装应用不能打开。
 - CI guard 新增 `defaultMiniApps` 回归禁令。
+
+
+## 2026-08-23 — M7-DESKTOP-003 navigation/search/avatar convergence
+
+- 常驻 feature rail 移入左下角个人 BotMark 菜单，避免 Messenger 再出现第二条功能侧栏。
+- 左侧 conversation rail 支持 pointer resize、持久化和 avatar-only collapse。
+- identity primitive 收敛为 BotMark，包括真人 peer 与 Mini App，不再保留 Agent-only avatar split。
+- 新增图 6 风格 global categorized search；线上 Mini App Marketplace 直接进入“应用”分类。
+- 添加/调整 desktop Playwright contracts；重型验证仍只在 GitHub Actions 执行。

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
@@ -8,7 +8,7 @@
 - **Started**: `2026-08-23`
 - **Updated**: `2026-08-23`
 - **Branch**: `feat/tfi-m7-unified-search-resizable-sidebar`
-- **Primary PR**: pending
+- **Primary PR**: `#2057`
 
 ## Objective
 

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
@@ -1,0 +1,82 @@
+# M7-DESKTOP-003 — Unified avatar, resizable sidebar and global categorized search
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M7-DESKTOP-003`
+- **Stage**: `M7 Bot/Agent 统一联系人体系`
+- **Status**: `IMPLEMENTED`
+- **Started**: `2026-08-23`
+- **Updated**: `2026-08-23`
+- **Branch**: `feat/tfi-m7-unified-search-resizable-sidebar`
+- **Primary PR**: pending
+
+## Objective
+
+按照用户 2026-08-23 提供的 6 张 UI 参考图，继续把桌面 Messenger 收敛成一套 Fabushi/Grok 风格产品界面：移除常驻功能 rail，把导航收进个人头像菜单；支持左侧会话栏拖拽到头像-only 窄态；所有身份和 Mini App 共用 BotMark；点击搜索进入分类全局搜索，并把线上 Mini App Marketplace 融合进应用搜索结果。
+
+## Source requirements
+
+- `../../source/2026-08-23-unified-avatar-search-resizable-sidebar.md`
+- `../../source/完整telegram融合进fabushi.txt`
+- `../../docs/07-客户端架构与交互.md`
+- `../wbs/M7.md`
+- `M7-DESKTOP-001`：单一 Messenger Shell 与 Motion v2 identity。
+- `M7-DESKTOP-002`：Mini App canonical routing 与 composer viewport regression guard。
+
+## In scope
+
+- 删除常驻 `navRail`，功能入口进入左下角个人 BotMark 菜单。
+- 会话栏宽度可拖拽并持久化；窄态隐藏标题/摘要等，只保留 BotMark 身份图标。
+- 真人、Agent/Bot、群组、频道、收藏/系统 peer 与 Mini App 全部使用统一 `BotMark` identity primitive。
+- 新增全局搜索 mode 与分类 tabs：聊天、频道、应用、贴文、图片、视频、下载、链接、文件、音乐、声音。
+- “应用”分类直接复用在线 Marketplace 数据与 install/update/open/uninstall actions。
+- 保持现有 Fabushi/Grok dark-glass material，并强化 sidebar/search 的统一视觉层级。
+- 增加 Electron Playwright 契约覆盖导航菜单、sidebar collapse、全局搜索与应用 marketplace 搜索。
+
+## Out of scope
+
+- 不新增第二套聊天、Agent、Host、Marketplace runtime。
+- 不恢复 Grok vendor runtime/品牌资产。
+- 不改写 Rust Messaging Core。
+- 不把 Mini App 重新打包进主程序。
+- 不在本地执行 Electron build、Playwright、Cargo 或其他重型测试。
+
+## Acceptance criteria
+
+1. Electron authenticated surface 不再渲染常驻联系人/Bots/收藏等功能 rail；这些入口可由左下角个人头像菜单打开。
+2. sidebar 可由 pointer drag 在宽/窄范围调整；窄态只显示身份头像，workspace 明显扩展；宽度刷新后保持。
+3. 所有 peer identity 和 Marketplace Mini App card/row 使用 `BotMark`，不存在 Agent-only avatar split。
+4. 搜索框 focus/click 打开 global search surface，并可在 11 个分类 tab 间切换。
+5. “应用”分类使用同一 `marketplaceApps` 数据，可搜索并执行安装/更新/打开/卸载。
+6. 聊天/频道分类基于当前 canonical peer 数据；贴文/链接/媒体分类基于当前已加载 message/media 数据，不伪造后端索引结果。
+7. Playwright 覆盖 personal navigation、sidebar resize/collapse、search tabs 与 Marketplace app result。
+8. GitHub Actions relevant desktop/Messaging/portfolio gates 通过，protected merge 完成，并在 canonical `main` 回读确认后才提升为 `TESTED`。
+
+## Verification plan
+
+- 本地仅做源码/diff/静态文本检查，不构建、不运行应用或 E2E。
+- GitHub Actions 运行 Electron typecheck/renderer、Messenger Playwright、Messaging Product Gate 与 Project portfolio governance（按 workflow path classifier 实际触发为准）。
+- protected merge + canonical-main readback。
+
+## Risks / blockers
+
+- 现有部分媒体分类只对已加载会话消息有数据，完整跨会话索引仍属于 M12 search domain；本任务只提供真实可用 UI 与当前数据结果，不制造虚假全库搜索。
+- 用户本机安装版本不会随源码合并自动升级；最终视觉验收仍需安装 canonical main 产出的最新正式包。
+
+## Implementation summary
+
+- authenticated Messenger 已删除常驻 `navRail`；所有原 rail 功能进入左下角个人 `BotMark` 菜单。
+- sidebar 新增 pointer drag、宽度 localStorage 持久化与 <=112px avatar-only collapse；双击 separator 可在 88/330px 快速切换。
+- peer list、chat header、empty/profile、Story、forward/new-dialog/call 与 Mini App marketplace identity 全部使用 `BotMark`。
+- 搜索框进入独立 `GlobalSearchWorkspace`，实现 11 个分类 tab；聊天/频道使用 canonical peer，贴文/媒体使用当前真实已加载 message 数据。
+- 应用 tab 直接复用 `marketplaceApps`、installed state 与 install/update/open/uninstall callbacks，不新增第二套插件市场。
+- Messenger/Smoke/Surfaces E2E 已切换到个人导航模型，并新增 sidebar collapse、global search tabs、应用搜索打开 Mini App 的回归覆盖。
+- 本地仅执行 `git diff --check` 与源码 marker inspection，均通过；按仓库策略未执行本地重型测试。
+
+## Evidence
+
+`../../evidence/M7-DESKTOP-003/README.md`.
+
+## Next action
+
+提交 branch/PR，等待 GitHub current-head relevant checks；失败则按 CI 证据修复，全部通过后 protected merge，并回读 canonical `main` 后再提升为 `TESTED`。

--- a/projects/telegram-fabushi-integration/management/wbs/M7.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M7.md
@@ -8,7 +8,7 @@
 - **来源**：源计划 M7 + 用户 2026-08-23 Grok × Telegram UI 融合要求 + 2026-08-23 composer 回归截图
 - **状态**：TESTING
 - **阻塞**：PR #2053 latest-head GitHub required checks / protected merge
-- **证据位置**：`M7-DESKTOP-001`; `M7-DESKTOP-002`; `desktop/src/messaging-shell-v2.tsx`; `desktop/e2e/messenger.spec.ts`; `desktop/e2e/messenger-regressions.spec.ts`
+- **证据位置**：`M7-DESKTOP-001`; `M7-DESKTOP-002`; `M7-DESKTOP-003`; `desktop/src/messaging-shell-v2.tsx`; `desktop/e2e/messenger.spec.ts`; `desktop/e2e/messenger-regressions.spec.ts`
 - **下一步**：PR #2053 全绿后 protected merge + canonical-main readback。
 
 ### M7.T02 — Agent conversation
@@ -76,3 +76,12 @@
 - **阻塞**：无/待执行时更新
 - **证据位置**：待填写（commit / PR / CI run / release / test report）
 - **下一步**：领取后补充实现路径与测试名称。
+
+
+### M7 desktop product convergence mapping — M7-DESKTOP-003
+
+- **交付物**：personal-avatar navigation + resizable avatar rail + unified BotMark identity + categorized global search + Marketplace-in-search。
+- **映射**：强化 M7.T01 Participant::Agent/Bot 与 M7.T02 Agent conversation 的“单一 UI/单一 identity/product layer”验收，不新增 protocol/domain 原子任务。
+- **状态**：IMPLEMENTED。
+- **证据位置**：`management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md`; `evidence/M7-DESKTOP-003/README.md`; desktop source/E2E。
+- **下一步**：current-head GitHub CI + protected merge + canonical-main readback。

--- a/projects/telegram-fabushi-integration/source/2026-08-23-unified-avatar-search-resizable-sidebar.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-23-unified-avatar-search-resizable-sidebar.md
@@ -1,0 +1,27 @@
+# 2026-08-23 — 统一头像、可伸缩侧栏与全局分类搜索
+
+## 用户原始要求
+
+基于用户提供的 6 张界面参考图，将 Fabushi 桌面 Messenger 继续收敛为单一 Grok/Fabushi 风格 UI：
+
+1. 将当前侧边栏中的联系人、Bots、群组、频道、通话、收藏、归档、文件夹、Mini Apps、支付、设置等入口收进左下角个人头像菜单，不再常驻第二条功能导航栏。
+2. 左侧会话栏支持像参考图 2/3 一样拖拽改变宽度；拖到窄宽度时只显示统一头像，右侧聊天区域自动扩大。
+3. 所有身份头像，包括真人联系人、Agent/Bot、群组/频道以及 Mini App，统一使用 Fabushi `BotMark` / `fabushi-motion-v2` 身份系统，不再混用圆形文字头像、应用图标和 Agent 专属头像系统。
+4. 整体采用现有 Fabushi/Grok 深色、玻璃、动态状态反馈视觉语言，但不恢复 Grok vendor 视觉 runtime 或品牌资产。
+5. 点击搜索框进入独立全局搜索界面，按“聊天、频道、应用、贴文、图片、视频、下载、链接、文件、音乐、声音”分类展示结果。
+6. 现有线上 Mini App / 插件市场必须融合进“应用”搜索结果，同一搜索入口即可发现、安装、更新、打开、卸载 Mini App。
+
+## 参考关系
+
+- 图 1：Grok Bot/FPU 深色材质、消息气泡、左侧头像 rail 的视觉质感。
+- 图 2/3：左栏宽窄拖拽、窄态仅头像、右侧内容随之扩大。
+- 图 4：Fabushi 现有三栏信息架构作为产品骨架。
+- 图 5：需要从常驻侧栏搬入个人头像菜单的导航项。
+- 图 6：全局搜索页面和分类 tab 的交互参考。
+
+## 架构约束
+
+- 继续使用唯一 `DesktopShellV2` / Messenger product surface。
+- 继续使用现有 `MahayanaHostTransport`、Rust Messaging Core 与 Marketplace contracts，不新增第二套 runtime/state machine。
+- Grok 视觉参考只用于 Fabushi 自研视觉语言；统一身份系统以当前 canonical `BotMark` / `fabushi-motion-v2` 为准。
+- Mini App 继续采用线上 Marketplace 安装模型，不回退为内置应用。


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: M7-DESKTOP-003

## User-visible changes
- Move Contacts/Bots/Groups/Channels/Calls/Saved/Archive/Folders/Mini Apps/Payments/Settings out of the permanent rail and into the bottom-left personal BotMark menu.
- Add a persisted resizable conversation sidebar; collapsing below the threshold becomes an avatar-only rail and expands the chat workspace.
- Make peer, Story, call/dialog and Mini App identities use the same canonical `BotMark` / `fabushi-motion-v2` primitive.
- Clicking the search field opens a dedicated categorized search surface with 11 tabs: 聊天、频道、应用、贴文、图片、视频、下载、链接、文件、音乐、声音.
- Merge the existing online Mini App Marketplace into the 应用 search category using the same install/update/open/uninstall state and actions.
- Keep the current Fabushi/Grok dark-glass visual language without restoring Grok vendor runtime or branded assets.

## Architecture
- No second Messenger, Agent, Host or Marketplace runtime.
- Reuses `DesktopShellV2`, current Mahayana Host transport, Rust Messaging Core and online Marketplace contracts.
- Search only shows data that is actually available: canonical peers, current loaded messages/media, and live Marketplace results.

## Verification
- Local lightweight only per repository policy: `git diff --check` PASS and source-marker inspection PASS.
- Updated Messenger/Smoke/Surfaces Playwright contracts for personal navigation.
- New E2E coverage for sidebar collapse/expand, all search tabs, and opening `global-dharma` via global Application search.
- Heavy build/E2E verification is delegated to GitHub Actions.

## Project records
- Source: `projects/telegram-fabushi-integration/source/2026-08-23-unified-avatar-search-resizable-sidebar.md`
- Task: `management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md`
- Evidence: `evidence/M7-DESKTOP-003/README.md`
- WBS / acceptance / status / changelog updated.

Do not mark TESTED until current-head CI is green, protected merge completes, and canonical main is read back.