### PR TITLE
fix(tfi): repair unified desktop call-state typecheck

### DIFF
--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -2195,7 +2195,7 @@ function CallDialog({
           ? '通话连接失败'
           : '通话已结束';
   return <div className={styles.backdrop}><section className={styles.callDialog}>
-    <header><BotMark botId={`call:${call.title}`} state={call.status === "connected" ? "speaking" : "listening"} size={78} label={call.title} /><strong>{call.title}</strong><small>{statusText}</small></header>
+    <header><BotMark botId={`call:${call.title}`} state={call.status === "active" ? "speaking" : "listening"} size={78} label={call.title} /><strong>{call.title}</strong><small>{statusText}</small></header>
     {call.kind === 'video' ? <div className={extra.callVideoStage}><video ref={remoteVideoRef} autoPlay playsInline className={extra.remoteVideo} /><video ref={localVideoRef} autoPlay muted playsInline className={extra.localVideoPip} /></div> : <audio ref={remoteAudioRef} autoPlay />}
     {call.error ? <p>{call.error}</p> : null}
     {canAccept && call.incoming && call.status === 'ringing' ? <div className={styles.callActions}><button type="button" onClick={onDecline} className={styles.hangup}><Phone size={20} /></button><button type="button" onClick={onAccept}><PhoneCall size={20} /></button></div> : <div className={styles.callActions}>

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
@@ -3,7 +3,7 @@
 - Project: `FAB-P0001 / TFI`
 - Task: `M7-DESKTOP-003`
 - Branch: `feat/tfi-m7-unified-search-resizable-sidebar`
-- Status: `IMPLEMENTED` (GitHub CI / protected merge pending)
+- Status: `TESTING` (post-merge CI repair in progress)
 - Date: 2026-08-23
 
 ## Implementation evidence
@@ -38,3 +38,11 @@ Per repository policy, no local Electron build, Playwright, Cargo, package build
 - protected PR merge.
 - canonical `main` readback.
 - final packaged desktop visual acceptance.
+
+
+## Post-merge gate evidence
+
+- #2057 merged: `ebfb1e090cb677b6d9d35edff3ad912819f3fba6`.
+- Electron desktop quality gate `32637615241` failed only at renderer typecheck: TS2367 comparing `WebRtcCallStatus` with unsupported literal `connected`.
+- Messaging Product Gate `32637615272` failed only at the same Electron typecheck; Rust self-hosted product passed.
+- Canonical `WebRtcCallStatus` = `idle | ringing | connecting | active | ended | failed`; repair maps live-call BotMark state from `active` to `speaking`.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
@@ -4,7 +4,7 @@
 - **Project Key**: `TFI`
 - **Task ID**: `M7-DESKTOP-003`
 - **Stage**: `M7 Bot/Agent 统一联系人体系`
-- **Status**: `IMPLEMENTED`
+- **Status**: `TESTING`
 - **Started**: `2026-08-23`
 - **Updated**: `2026-08-23`
 - **Branch**: `feat/tfi-m7-unified-search-resizable-sidebar`
@@ -80,3 +80,13 @@
 ## Next action
 
 提交 branch/PR，等待 GitHub current-head relevant checks；失败则按 CI 证据修复，全部通过后 protected merge，并回读 canonical `main` 后再提升为 `TESTED`。
+
+
+## Post-merge CI repair — 2026-08-23
+
+PR #2057 merged to `main` as `ebfb1e090cb677b6d9d35edff3ad912819f3fba6`, but two non-blocking product gates exposed the same TypeScript defect after merge: `WebRtcCallStatus` uses `active`, while the new call BotMark expression compared against nonexistent `connected`.
+
+- Electron desktop quality gate run `32637615241`: renderer typecheck failed at `messaging-shell-v2.tsx` with TS2367.
+- Messaging Product Gate run `32637615272`: Electron Messenger contract failed at the same TS2367; Rust self-hosted product passed.
+- Repair branch `fix/tfi-m7-unified-ui-ci` changes the visual call-state mapping from `connected` to canonical `active`; no protocol/runtime behavior changes.
+- Task remains `TESTING` until the repair PR is green, merged, and canonical main is re-read.


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: M7-DESKTOP-003 follow-up

## Root cause
PR #2057 merged successfully, but two post-merge product gates failed on the same TypeScript error. The new call-avatar visual mapping compared `WebRtcCallStatus` to `connected`, while the canonical union is `idle | ringing | connecting | active | ended | failed`.

## Fix
- Change the call BotMark live-state check from `connected` to canonical `active`.
- Record #2057 merge and the exact failed gate evidence in the project task/evidence files.
- No protocol, signaling, Host, Marketplace, or Rust messaging behavior changes.

## Failed evidence repaired
- Electron desktop quality gate `32637615241`: renderer typecheck TS2367.
- Messaging Product Gate `32637615272`: Electron Messenger typecheck TS2367; Rust self-hosted product passed.

## Verification
- Local lightweight only: `git diff --check` PASS.
- Heavy renderer/typecheck/E2E remains GitHub Actions only per repository policy.

Do not close M7-DESKTOP-003 as TESTED until this PR is green, merged, and canonical main is read back.