### PR TITLE
test(tfi): verify final unified desktop package path

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -108,7 +108,9 @@ test('desktop Messenger unifies Telegram-class navigation with Fabushi agent ide
     await completeBrowserLogin(page);
     await openMessenger(page);
 
-    await page.getByTestId('profile-navigation-trigger').click();
+    const profileNavigation = page.getByTestId('profile-navigation-trigger');
+    await expect(profileNavigation.locator('[data-engine="fabushi-motion-v2"]')).toBeVisible();
+    await profileNavigation.click();
     await expect(page.getByTestId('profile-navigation-menu')).toBeVisible();
     for (const label of [
       '聊天',

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
@@ -46,3 +46,11 @@ Per repository policy, no local Electron build, Playwright, Cargo, package build
 - Electron desktop quality gate `32637615241` failed only at renderer typecheck: TS2367 comparing `WebRtcCallStatus` with unsupported literal `connected`.
 - Messaging Product Gate `32637615272` failed only at the same Electron typecheck; Rust self-hosted product passed.
 - Canonical `WebRtcCallStatus` = `idle | ringing | connecting | active | ended | failed`; repair maps live-call BotMark state from `active` to `speaking`.
+
+
+## Final package-verification evidence
+
+- Repair PR #2058 merged: `947f537f8ebe4c762a09c6ac66150d50b5bda724`.
+- PR #2058 Electron Messenger contract reached successful TypeScript typecheck after switching to canonical `active`.
+- Follow-up E2E guard verifies `profile-navigation-trigger` contains a `data-engine="fabushi-motion-v2"` identity.
+- Because `desktop/e2e/**` is a canonical package-classifier path, the follow-up PR and its eventual main merge exercise the package matrix needed for macOS installation evidence.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -83,3 +83,10 @@
 - 真人/Agent/Bot/群组/频道/Story/Call/Mini App identity 已统一到 canonical `BotMark` / `fabushi-motion-v2`。
 - global search 新增聊天、频道、应用、贴文、图片、视频、下载、链接、文件、音乐、声音 11 分类；应用分类复用线上 Marketplace install/update/open/uninstall。
 - E2E source 已覆盖导航、sidebar collapse、search tabs 与通过应用搜索打开 Mini App。当前状态 `IMPLEMENTED`；GitHub current-head CI / protected merge / canonical-main readback 尚待完成。
+
+
+## 2026-08-23 — M7-DESKTOP-003 package verification
+
+- #2058 已修复 #2057 暴露的 `WebRtcCallStatus` typecheck 错误并合并到 main `947f537f8...`。
+- final package-verification follow-up 增加 personal-avatar Motion v2 E2E guard，并通过 `desktop/e2e/**` 触发 canonical Electron package matrix。
+- 下一验收事实：main signed/notarized macOS artifact 安装到用户 Mac 并实际打开；完成前 M7-DESKTOP-003 维持 `TESTING`。

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
@@ -90,3 +90,12 @@ PR #2057 merged to `main` as `ebfb1e090cb677b6d9d35edff3ad912819f3fba6`, but two
 - Messaging Product Gate run `32637615272`: Electron Messenger contract failed at the same TS2367; Rust self-hosted product passed.
 - Repair branch `fix/tfi-m7-unified-ui-ci` changes the visual call-state mapping from `connected` to canonical `active`; no protocol/runtime behavior changes.
 - Task remains `TESTING` until the repair PR is green, merged, and canonical main is re-read.
+
+
+## Final package-verification follow-up — 2026-08-23
+
+- CI repair PR #2058 merged to `main` as `947f537f8ebe4c762a09c6ac66150d50b5bda724`.
+- Electron Messenger typecheck on PR #2058 passed, confirming the `active` call-state repair.
+- A final E2E assertion now verifies the bottom-left personal navigation avatar itself is rendered by `fabushi-motion-v2`.
+- The E2E-file change deliberately enters the canonical Electron package matrix; after protected merge, the `main` push must produce the signed/notarized macOS package used for local installation acceptance.
+- Task remains `TESTING` until packaged-main macOS artifact is installed and opened on the user's Mac and canonical project evidence is updated.


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: M7-DESKTOP-003 final package verification

## Superseded while verifying
PR #2058 repaired the TypeScript call-state regression and landed on main as `947f537f8ebe4c762a09c6ac66150d50b5bda724`.

During the required Electron runtime-smoke readback, run `32638060949` exposed additional integration defects that would make this package-verification PR unsafe to merge unchanged:
- global Application search could not populate the deterministic test Marketplace;
- native capability handlers still called obsolete unprefixed `marketplace.*` / `plugin.*` Host methods instead of canonical `feature.*` methods;
- application-menu E2E had a subscription race that could miss `open-offline-asr`.

This PR is temporarily closed/dequeued so the branch can be repaired rather than knowingly merging a red package path. The existing personal BotMark E2E assertion is retained. After the integration repairs are pushed, this PR will be reopened and re-queued for full runtime + package verification.