### PR TITLE
fix(tfi): harden unified Marketplace runtime smoke

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -255,7 +255,7 @@ test('desktop Messenger creates a real Bot collaboration group and sends into it
   }
 });
 
-test('installed Mini App opens from the unified Messenger surface', async () => {
+test('online Mini App installs and opens from global Application search', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-miniapp-e2e-'));
   const app = await launchDesktopApp(appDataDir);
 
@@ -269,7 +269,13 @@ test('installed Mini App opens from the unified Messenger surface', async () => 
     await page.getByTestId('global-search-input').fill('全球法布施');
     const appResult = page.getByTestId('global-search-app-global-dharma');
     await expect(appResult).toBeVisible();
-    await appResult.getByRole('button', { name: '打开' }).click();
+    const install = appResult.getByRole('button', { name: '安装' });
+    if (await install.isVisible().catch(() => false)) {
+      await install.click();
+    }
+    const open = appResult.getByRole('button', { name: '打开' });
+    await expect(open).toBeVisible();
+    await open.click();
     await expect(page.getByText('Mini App · 受控宿主容器')).toBeVisible();
     await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
   } finally {

--- a/desktop/e2e/smoke.spec.ts
+++ b/desktop/e2e/smoke.spec.ts
@@ -120,10 +120,19 @@ async function runJourneyStep(page: Page, step: MahayanaHostJourneyStep): Promis
       });
       return;
     case 'openMiniApp':
-      await page.getByTestId('profile-navigation-trigger').click();
-      await page.getByTitle('Mini Apps', { exact: true }).click();
       if (step.miniAppId === 'global-dharma') {
-        await page.getByRole('button', { name: /全球法布施/ }).last().click();
+        await page.getByTestId('global-search-trigger').click();
+        await page.getByTestId('global-search-tab-apps').click();
+        await page.getByTestId('global-search-input').fill('全球法布施');
+        const appResult = page.getByTestId('global-search-app-global-dharma');
+        await expect(appResult).toBeVisible();
+        const install = appResult.getByRole('button', { name: '安装' });
+        if (await install.isVisible().catch(() => false)) {
+          await install.click();
+        }
+        const open = appResult.getByRole('button', { name: '打开' });
+        await expect(open).toBeVisible();
+        await open.click();
         await expect(page.getByText('Mini App · 受控宿主容器')).toBeVisible();
         await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
       } else {

--- a/desktop/e2e/surfaces.spec.ts
+++ b/desktop/e2e/surfaces.spec.ts
@@ -63,23 +63,30 @@ async function waitForNativeEventAfterMenu(
   label: string,
   eventName: string,
 ): Promise<Record<string, unknown>> {
-  const waiter = page.evaluate((wantedEvent) => new Promise<Record<string, unknown>>((resolve, reject) => {
-    const native = (window as any).fabushiNative;
+  const probeId = `native-menu-${eventName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  await page.evaluate(({ wantedEvent, id }) => {
+    const target = window as any;
+    const probes = target.__fabushiNativeMenuProbes ??= {};
+    probes[id] = { payload: null };
     let unsubscribe = () => {};
-    const timer = window.setTimeout(() => {
-      unsubscribe();
-      reject(new Error(`Timed out waiting for native event ${wantedEvent}`));
-    }, 5_000);
-    unsubscribe = native.subscribe({
+    unsubscribe = target.fabushiNative.subscribe({
       [wantedEvent]: (payload: Record<string, unknown>) => {
-        window.clearTimeout(timer);
+        probes[id].payload = payload ?? {};
         unsubscribe();
-        resolve(payload ?? {});
       },
     });
-  }), eventName);
+  }, { wantedEvent: eventName, id: probeId });
   await clickApplicationMenuItem(app, label);
-  return waiter;
+  await expect.poll(async () => page.evaluate((id) => {
+    return (window as any).__fabushiNativeMenuProbes?.[id]?.payload ?? null;
+  }, probeId), { timeout: 5_000 }).not.toBeNull();
+  const payload = await page.evaluate((id) => {
+    const target = window as any;
+    const value = target.__fabushiNativeMenuProbes?.[id]?.payload ?? {};
+    if (target.__fabushiNativeMenuProbes) delete target.__fabushiNativeMenuProbes[id];
+    return value;
+  }, probeId) as Record<string, unknown>;
+  return payload;
 }
 
 async function executeHostCommand(page: Page, type: string, extra: Record<string, unknown> = {}) {

--- a/desktop/electron/native-capability-handlers.cjs
+++ b/desktop/electron/native-capability-handlers.cjs
@@ -186,13 +186,13 @@ function createNativeCapabilityHandlers(deps) {
   }
 
   async function installedPluginPointers() {
-    const catalog = await host.request('marketplace.browse', { query: '', platform: 'desktop' }).catch(() => []);
+    const catalog = await host.request('feature.marketplace.browse', { query: '', platform: 'desktop' }).catch(() => []);
     const entries = Array.isArray(catalog) ? catalog : Array.isArray(catalog?.plugins) ? catalog.plugins : [];
     const pointers = [];
     for (const entry of entries.slice(0, 200)) {
       const pluginId = cleanString(entry?.id ?? entry?.pluginId, 200);
       if (!pluginId) continue;
-      const pointer = await host.request('plugin.active', { pluginId }).catch(() => null);
+      const pointer = await host.request('feature.plugin.active', { pluginId }).catch(() => null);
       if (pointer) pointers.push({ pluginId, ...pointer });
     }
     return pointers;
@@ -1246,12 +1246,12 @@ function createNativeCapabilityHandlers(deps) {
     },
 
     async getMcpCatalog() {
-      const catalog = await host.request('marketplace.browse', { query: 'mcp', platform: 'desktop' });
+      const catalog = await host.request('feature.marketplace.browse', { query: 'mcp', platform: 'desktop' });
       return Array.isArray(catalog) ? catalog : catalog?.plugins ?? catalog;
     },
 
     async getMcpTeamPopularity() {
-      const catalog = await host.request('marketplace.browse', { query: 'mcp', platform: 'desktop' }).catch(() => []);
+      const catalog = await host.request('feature.marketplace.browse', { query: 'mcp', platform: 'desktop' }).catch(() => []);
       const entries = Array.isArray(catalog) ? catalog : Array.isArray(catalog?.plugins) ? catalog.plugins : [];
       const items = entries
         .map((item) => ({
@@ -1268,7 +1268,7 @@ function createNativeCapabilityHandlers(deps) {
 
     async getMcpPluginLogo(params) {
       const pluginId = cleanString(params.pluginId ?? params.id, 200);
-      const catalog = await host.request('marketplace.browse', { query: pluginId, platform: 'desktop' }).catch(() => []);
+      const catalog = await host.request('feature.marketplace.browse', { query: pluginId, platform: 'desktop' }).catch(() => []);
       const entries = Array.isArray(catalog) ? catalog : catalog?.plugins ?? [];
       const match = entries.find((item) => cleanString(item?.id ?? item?.pluginId, 200) === pluginId) ?? entries[0];
       return match?.logo ?? match?.icon ?? null;
@@ -1278,8 +1278,8 @@ function createNativeCapabilityHandlers(deps) {
       const pluginId = cleanString(params.pluginId ?? params.id ?? params.entry?.id, 200);
       const version = cleanString(params.version ?? params.entry?.version, 100);
       if (!pluginId || !version) throw new Error('Plugin ID and version are required.');
-      const release = params.release ?? await host.request('marketplace.release', { pluginId, version });
-      return host.request('plugin.install', { release, platform: process.platform });
+      const release = params.release ?? await host.request('feature.marketplace.release', { pluginId, version });
+      return host.request('feature.plugin.install', { release, platform: 'desktop' });
     },
 
     updatePluginInstall(params) {
@@ -1296,7 +1296,7 @@ function createNativeCapabilityHandlers(deps) {
     async uninstallPlugin(params) {
       const pluginId = cleanString(params.pluginId ?? params.id, 200);
       if (!pluginId) throw new Error('Plugin ID is required.');
-      return host.request('plugin.uninstall', { pluginId });
+      return host.request('feature.plugin.uninstall', { pluginId });
     },
 
     async authenticateMcpServer(params) {

--- a/desktop/electron/native-capability-handlers.test.cjs
+++ b/desktop/electron/native-capability-handlers.test.cjs
@@ -48,6 +48,39 @@ async function harness(run, options = {}) {
   }
 }
 
+
+test('marketplace native capabilities use canonical Feature Host method names', async () => {
+  const calls = [];
+  const host = {
+    async request(method, params = {}) {
+      calls.push([method, params]);
+      if (method === 'feature.marketplace.browse') {
+        return { plugins: [{ pluginId: 'mcp-demo', displayName: 'MCP Demo', latestVersion: '1.0.0' }] };
+      }
+      if (method === 'feature.marketplace.release') {
+        return { pluginId: params.pluginId, version: params.version, releaseManifest: { pluginId: params.pluginId, version: params.version } };
+      }
+      if (method === 'feature.plugin.active') return null;
+      if (method === 'feature.plugin.install') return { pluginId: 'mcp-demo', version: '1.0.0' };
+      if (method === 'feature.plugin.uninstall') return { pluginId: params.pluginId, removed: true };
+      throw new Error(`unexpected Host method ${method}`);
+    },
+  };
+  await harness(async ({ handlers }) => {
+    const catalog = await handlers.getMcpCatalog({});
+    assert.equal(catalog[0].pluginId, 'mcp-demo');
+    await handlers.getEffectivePlugins({});
+    await handlers.installEntry({ pluginId: 'mcp-demo', version: '1.0.0' });
+    await handlers.uninstallPlugin({ pluginId: 'mcp-demo' });
+  }, { host });
+  assert.ok(calls.some(([method]) => method === 'feature.marketplace.browse'));
+  assert.ok(calls.some(([method]) => method === 'feature.marketplace.release'));
+  assert.ok(calls.some(([method]) => method === 'feature.plugin.active'));
+  assert.ok(calls.some(([method]) => method === 'feature.plugin.install'));
+  assert.ok(calls.some(([method]) => method === 'feature.plugin.uninstall'));
+  assert.equal(calls.some(([method]) => /^(marketplace|plugin)\./.test(method)), false);
+});
+
 test('local tool permission cannot exceed the administrator ceiling', async () => {
   const previous = process.env.FABUSHI_LOCAL_TOOL_PERMISSION_CEILING;
   process.env.FABUSHI_LOCAL_TOOL_PERMISSION_CEILING = 'ask';

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
@@ -54,3 +54,17 @@ Per repository policy, no local Electron build, Playwright, Cargo, package build
 - PR #2058 Electron Messenger contract reached successful TypeScript typecheck after switching to canonical `active`.
 - Follow-up E2E guard verifies `profile-navigation-trigger` contains a `data-engine="fabushi-motion-v2"` identity.
 - Because `desktop/e2e/**` is a canonical package-classifier path, the follow-up PR and its eventual main merge exercise the package matrix needed for macOS installation evidence.
+
+
+## Runtime-smoke failure and repair evidence
+
+- #2059 main merge: `ae70c06f4286097d2f90c43d047b77845173d9cf`.
+- Electron runtime smoke run `32638060949` failed with three concrete errors:
+  - Messenger Mini App global search: `global-search-app-global-dharma` not found.
+  - Smoke Mini App journey: legacy UI locator for `全球法布施` timed out after the permanent navigation/Marketplace convergence.
+  - Native surface: `getMcpCatalog` returned `bridge/invoke-failed: invalid request: unknown method marketplace.browse`; first attempt also demonstrated the native-menu event registration race on `open-offline-asr`.
+- Current repair:
+  - AppHost stores its explicit feature mode and exposes deterministic Marketplace browse/release/install behavior only in `Test`; Production remains backed by `MahayanaProductClient` and verified external releases.
+  - Native Electron capabilities call `feature.marketplace.*` / `feature.plugin.*` only, with desktop plugin platform normalization.
+  - Global search E2E performs visible online-app discovery, installation and opening through the same UI users see.
+  - Native-menu probe is fully registered before the main-process menu click.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -90,3 +90,11 @@
 - #2058 已修复 #2057 暴露的 `WebRtcCallStatus` typecheck 错误并合并到 main `947f537f8...`。
 - final package-verification follow-up 增加 personal-avatar Motion v2 E2E guard，并通过 `desktop/e2e/**` 触发 canonical Electron package matrix。
 - 下一验收事实：main signed/notarized macOS artifact 安装到用户 Mac 并实际打开；完成前 M7-DESKTOP-003 维持 `TESTING`。
+
+
+## 2026-08-23 — M7-DESKTOP-003 runtime-smoke repair
+
+- #2059 已落 main `ae70c06f4...`，但 deeper Electron runtime smoke 发现 Marketplace test seam、native Feature Host method prefix 与 menu-event registration race 三个真实缺口。
+- 当前 `fix/tfi-m7-marketplace-runtime-smoke` 只在 AppHost Test mode 提供 deterministic Marketplace；Production 仍严格走线上 Marketplace + verified external release。
+- desktop native capabilities 已统一调用 canonical `feature.marketplace.*` / `feature.plugin.*`；Mini App UI E2E 改为全局“应用”搜索 → 安装 → 打开；native-menu E2E 消除监听注册竞态。
+- 安装验收继续阻塞在 repaired Electron runtime/package 全绿与 main signed/notarized macOS artifact。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -86,3 +86,11 @@
 - identity primitive 收敛为 BotMark，包括真人 peer 与 Mini App，不再保留 Agent-only avatar split。
 - 新增图 6 风格 global categorized search；线上 Mini App Marketplace 直接进入“应用”分类。
 - 添加/调整 desktop Playwright contracts；重型验证仍只在 GitHub Actions 执行。
+
+
+## 2026-08-23 — Marketplace runtime-smoke hardening
+
+- 修复 Electron native capabilities 使用 retired unprefixed Marketplace/plugin Host method 的问题，统一到 `feature.*` contract。
+- AppHost Test mode 新增 deterministic online-marketplace seam，避免 E2E 依赖生产账号/网络，同时 Production 行为不变。
+- Mini App E2E 改为真实 global Application search/install/open user journey。
+- 修复 application-menu native event listener 与 main-process click 的跨通道竞态。

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
@@ -99,3 +99,15 @@ PR #2057 merged to `main` as `ebfb1e090cb677b6d9d35edff3ad912819f3fba6`, but two
 - A final E2E assertion now verifies the bottom-left personal navigation avatar itself is rendered by `fabushi-motion-v2`.
 - The E2E-file change deliberately enters the canonical Electron package matrix; after protected merge, the `main` push must produce the signed/notarized macOS package used for local installation acceptance.
 - Task remains `TESTING` until packaged-main macOS artifact is installed and opened on the user's Mac and canonical project evidence is updated.
+
+
+## Runtime-smoke integration repair — 2026-08-23
+
+- PR #2059 merged to `main` as `ae70c06f4286097d2f90c43d047b77845173d9cf` while deeper Electron runtime/package checks were still executing.
+- Electron runtime smoke from the preceding repair run `32638060949` exposed three integration defects that are now treated as blocking before installation:
+  1. Application global search had no deterministic Marketplace catalog in `FABUSHI_FEATURE_HOST_MODE=test`, so `global-search-app-global-dharma` never appeared.
+  2. native capability handlers still called obsolete unprefixed `marketplace.*` / `plugin.*` Host methods, causing `getMcpCatalog` to fail with `unknown method marketplace.browse`.
+  3. application-menu E2E armed its native-event listener and clicked the menu through independent Electron/renderer channels without a registration handshake, so `open-offline-asr` could be missed.
+- Repair branch `fix/tfi-m7-marketplace-runtime-smoke` adds a deterministic AppHost test Marketplace/install seam while production continues to use the real online Product API; native capability calls are normalized to canonical `feature.marketplace.*` / `feature.plugin.*`; menu E2E now confirms listener registration before the click.
+- Global Application-search tests now exercise the real search → install → open UI flow instead of assuming an already-installed Mini App.
+- Task remains `TESTING` until repaired runtime smoke, package matrix, protected merge, signed/notarized main artifact installation and local Mac open verification all pass.

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -24,9 +24,17 @@ const TEST_MARKETPLACE_PLUGINS: &[(&str, &str, &str)] = &[
     ("global-dharma", "全球法布施", "任务、日志与部署"),
     ("faliu-flashcards", "法流记忆卡", "经文牌组与复习"),
     ("platform-publish", "平台发布", "内容发布与自动化"),
-    ("hermes-installer", "Hermes Installer", "插件安装与运行时管理"),
+    (
+        "hermes-installer",
+        "Hermes Installer",
+        "插件安装与运行时管理",
+    ),
     ("bot-father", "Bot Father", "创建和管理机器人"),
-    ("chatgpt-auto-confirm", "ChatGPT Auto Confirm", "受控自动确认与任务协作"),
+    (
+        "chatgpt-auto-confirm",
+        "ChatGPT Auto Confirm",
+        "受控自动确认与任务协作",
+    ),
 ];
 
 impl From<AppHostFeatureMode> for HostMode {
@@ -300,7 +308,8 @@ impl AppHost {
             let plugins = TEST_MARKETPLACE_PLUGINS
                 .iter()
                 .filter_map(|(plugin_id, display_name, description)| {
-                    let searchable = format!("{plugin_id} {display_name} {description}").to_lowercase();
+                    let searchable =
+                        format!("{plugin_id} {display_name} {description}").to_lowercase();
                     if !term.is_empty() && !searchable.contains(&term) {
                         return None;
                     }

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -5,7 +5,9 @@ use mahayana_host_protocol::{
     ApprovalResolution, FeatureCommand, HostConfig, HostMode, SurfacePlatform,
 };
 use mahayana_js_runtime::{DeepSeekJsHost, scan_package_compatibility};
-use mahayana_plugin_runtime::{ExternalReleaseManifest, PermissionManager, PluginInstaller};
+use mahayana_plugin_runtime::{
+    ExternalReleaseManifest, InstalledPluginPointer, PermissionManager, PluginInstaller,
+};
 use mahayana_product::MahayanaProductClient;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -17,6 +19,15 @@ pub enum AppHostFeatureMode {
     Production,
     Test,
 }
+
+const TEST_MARKETPLACE_PLUGINS: &[(&str, &str, &str)] = &[
+    ("global-dharma", "全球法布施", "任务、日志与部署"),
+    ("faliu-flashcards", "法流记忆卡", "经文牌组与复习"),
+    ("platform-publish", "平台发布", "内容发布与自动化"),
+    ("hermes-installer", "Hermes Installer", "插件安装与运行时管理"),
+    ("bot-father", "Bot Father", "创建和管理机器人"),
+    ("chatgpt-auto-confirm", "ChatGPT Auto Confirm", "受控自动确认与任务协作"),
+];
 
 impl From<AppHostFeatureMode> for HostMode {
     fn from(value: AppHostFeatureMode) -> Self {
@@ -57,6 +68,7 @@ pub struct HostResponse {
 
 pub struct AppHost {
     app_data_dir: PathBuf,
+    feature_mode: AppHostFeatureMode,
     product: MahayanaProductClient,
     js: Mutex<DeepSeekJsHost>,
     feature: FeatureHostController,
@@ -83,6 +95,7 @@ impl AppHost {
         );
         Ok(Self {
             app_data_dir,
+            feature_mode,
             product,
             js: Mutex::new(
                 DeepSeekJsHost::new()
@@ -282,6 +295,27 @@ impl AppHost {
 
     fn marketplace_browse(&self, params: Value) -> Result<Value, AppHostError> {
         let query = params.get("query").and_then(Value::as_str);
+        if self.feature_mode == AppHostFeatureMode::Test {
+            let term = query.unwrap_or_default().trim().to_lowercase();
+            let plugins = TEST_MARKETPLACE_PLUGINS
+                .iter()
+                .filter_map(|(plugin_id, display_name, description)| {
+                    let searchable = format!("{plugin_id} {display_name} {description}").to_lowercase();
+                    if !term.is_empty() && !searchable.contains(&term) {
+                        return None;
+                    }
+                    Some(json!({
+                        "pluginId": plugin_id,
+                        "displayName": display_name,
+                        "description": description,
+                        "latestVersion": "1.0.0",
+                        "platforms": ["desktop"],
+                        "releaseStatus": "approved"
+                    }))
+                })
+                .collect::<Vec<_>>();
+            return Ok(json!({"plugins": plugins}));
+        }
         let requested_platform = params
             .get("platform")
             .and_then(Value::as_str)
@@ -298,6 +332,29 @@ impl AppHost {
     fn marketplace_release(&self, params: Value) -> Result<Value, AppHostError> {
         let plugin_id = string_param(&params, "pluginId")?;
         let version = string_param(&params, "version")?;
+        if self.feature_mode == AppHostFeatureMode::Test {
+            if !TEST_MARKETPLACE_PLUGINS
+                .iter()
+                .any(|(candidate, _, _)| *candidate == plugin_id)
+            {
+                return Err(AppHostError::Operation(format!(
+                    "test marketplace plugin {plugin_id} was not found"
+                )));
+            }
+            return Ok(json!({
+                "pluginId": plugin_id,
+                "version": version,
+                "releaseStatus": "approved",
+                "releaseManifest": {
+                    "schemaVersion": 1,
+                    "protocol": "mahayana.external-release.v1",
+                    "pluginId": plugin_id,
+                    "version": version,
+                    "permissions": [],
+                    "artifacts": []
+                }
+            }));
+        }
         self.product
             .marketplace_release_metadata(plugin_id, version)
             .map_err(|error| AppHostError::Operation(error.to_string()))
@@ -327,6 +384,52 @@ impl AppHost {
             .get("platform")
             .and_then(Value::as_str)
             .unwrap_or(host_platform());
+        if self.feature_mode == AppHostFeatureMode::Test {
+            if !TEST_MARKETPLACE_PLUGINS
+                .iter()
+                .any(|(candidate, _, _)| *candidate == release.plugin_id)
+            {
+                return Err(AppHostError::Operation(format!(
+                    "test marketplace plugin {} was not found",
+                    release.plugin_id
+                )));
+            }
+            let plugin_root = self.plugin_root().join(&release.plugin_id);
+            let installed_dir = plugin_root
+                .join("versions")
+                .join(&release.version)
+                .join("test-ui");
+            std::fs::create_dir_all(&installed_dir)
+                .map_err(|error| AppHostError::Operation(error.to_string()))?;
+            let display_name = TEST_MARKETPLACE_PLUGINS
+                .iter()
+                .find(|(candidate, _, _)| *candidate == release.plugin_id)
+                .map(|(_, display_name, _)| *display_name)
+                .unwrap_or(release.plugin_id.as_str());
+            let html = format!(
+                "<!doctype html><html><head><meta charset=\"utf-8\"><title>{display_name}</title></head><body><main><h1>{display_name}</h1><p>Installed from the deterministic Mahayana Marketplace test backend.</p></main></body></html>"
+            );
+            std::fs::write(installed_dir.join("index.html"), html)
+                .map_err(|error| AppHostError::Operation(error.to_string()))?;
+            let pointer = InstalledPluginPointer {
+                plugin_id: release.plugin_id.clone(),
+                version: release.version.clone(),
+                artifact_id: "test-ui".to_string(),
+                artifact_sha256: "0".repeat(64),
+                runtime: "local-web".to_string(),
+                entry: Some("index.html".to_string()),
+                requested_permissions: release.permissions.clone(),
+                installed_path: installed_dir.to_string_lossy().into_owned(),
+            };
+            std::fs::create_dir_all(&plugin_root)
+                .map_err(|error| AppHostError::Operation(error.to_string()))?;
+            let active = serde_json::to_vec_pretty(&pointer)
+                .map_err(|error| AppHostError::Operation(error.to_string()))?;
+            std::fs::write(plugin_root.join("active.json"), active)
+                .map_err(|error| AppHostError::Operation(error.to_string()))?;
+            return serde_json::to_value(pointer)
+                .map_err(|error| AppHostError::Operation(error.to_string()));
+        }
         let preferred: &[&str] = match platform {
             "ios" | "android" | "mobile" => &[
                 "deepseek-js",


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: M7-DESKTOP-003 runtime/package acceptance repair

## Evidence-driven root causes
Electron runtime smoke run `32638060949` exposed three blocking integration defects after #2057/#2058/#2059 landed:
1. global Application search had no deterministic Marketplace catalog in `FABUSHI_FEATURE_HOST_MODE=test`, so `global-search-app-global-dharma` never appeared;
2. Electron native capability handlers still called obsolete unprefixed `marketplace.*` / `plugin.*` Host methods, causing `getMcpCatalog` to fail with `unknown method marketplace.browse`;
3. application-menu E2E could miss `open-offline-asr` because renderer subscription registration and main-process click ran on independent channels without a handshake.

## Fix
- AppHost now retains explicit `AppHostFeatureMode` and exposes deterministic Marketplace browse/release/install behavior only in `Test` mode. Production continues to use `MahayanaProductClient` and verified external releases.
- Test-mode Marketplace install writes a local test-only active plugin pointer/UI document so the real Electron transport/plugin-store UI path can be exercised without production credentials/network.
- All native Marketplace/plugin capabilities now call canonical `feature.marketplace.*` / `feature.plugin.*` methods; desktop plugin installation normalizes to platform `desktop`.
- Native capability unit test locks those method names.
- Messenger and smoke E2E now exercise global `应用` search → visible app result → install → open, rather than assuming an already-installed/bundled Mini App.
- Native menu E2E registers and confirms the probe before clicking the application menu item, removing the race.
- Follow-up head `579c5edd4bda2e8f7b3758837c8d480013580e53` applies the exact rustfmt output from Mahayana fast run `32638640465`.

## Local lightweight verification
- `git diff --check` PASS.
- `node --check` for modified native capability files PASS.
- `node --test desktop/electron/native-capability-handlers.test.cjs` PASS: 7/7.
- No local Electron build, Playwright, Cargo build, package build or other heavyweight verification; GitHub Actions remains authoritative.

## Required acceptance before install
Electron runtime smoke + package matrix, Messaging Product Gate, self-hosted messaging, CI, Mahayana fast and project governance must be green; protected merge to main must complete; then canonical main must produce the signed/notarized `fabushi-electron-mac` artifact for installation on the user's Mac.