### PR TITLE
test(tfi): align final unified desktop E2E contracts

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -109,7 +109,7 @@ test('desktop Messenger unifies Telegram-class navigation with Fabushi agent ide
     await openMessenger(page);
 
     const profileNavigation = page.getByTestId('profile-navigation-trigger');
-    await expect(profileNavigation.locator('[data-engine="fabushi-motion-v2"]')).toBeVisible();
+    await expect(profileNavigation.locator('[data-engine="fabushi-motion-v2"]').first()).toBeVisible();
     await profileNavigation.click();
     await expect(page.getByTestId('profile-navigation-menu')).toBeVisible();
     for (const label of [
@@ -276,7 +276,7 @@ test('online Mini App installs and opens from global Application search', async 
     const open = appResult.getByRole('button', { name: '打开' });
     await expect(open).toBeVisible();
     await open.click();
-    await expect(page.getByText('Mini App · 受控宿主容器')).toBeVisible();
+    await expect(page.getByText('Mini App · 已安装线上包 · 受控宿主容器')).toBeVisible();
     await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
   } finally {
     await app.close();

--- a/desktop/e2e/smoke.spec.ts
+++ b/desktop/e2e/smoke.spec.ts
@@ -133,7 +133,7 @@ async function runJourneyStep(page: Page, step: MahayanaHostJourneyStep): Promis
         const open = appResult.getByRole('button', { name: '打开' });
         await expect(open).toBeVisible();
         await open.click();
-        await expect(page.getByText('Mini App · 受控宿主容器')).toBeVisible();
+        await expect(page.getByText('Mini App · 已安装线上包 · 受控宿主容器')).toBeVisible();
         await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
       } else {
         await executeFeatureAndWaitForEvent(page, {

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/README.md
@@ -68,3 +68,11 @@ Per repository policy, no local Electron build, Playwright, Cargo, package build
   - Native Electron capabilities call `feature.marketplace.*` / `feature.plugin.*` only, with desktop plugin platform normalization.
   - Global search E2E performs visible online-app discovery, installation and opening through the same UI users see.
   - Native-menu probe is fully registered before the main-process menu click.
+
+
+## Final E2E contract-alignment evidence
+
+- #2060 merge: `bcd0951396a7efe9f5f37aaa5b0ea38c35ec6220`.
+- Electron runtime run `32638779651` artifact `electron-runtime-smoke-failure-32638779651-1` shows the Mini App did open successfully: `全球法布施`, subtitle `Mini App · 已安装线上包 · 受控宿主容器`, and iframe are present in the failure snapshot.
+- Therefore the remaining Mini App failure was an obsolete expected string (`Mini App · 受控宿主容器`), not a Host/Marketplace/UI-open defect.
+- The personal navigation failure is a Playwright strict-mode ambiguity because the Motion-v2 wrapper and its SVG both expose `data-engine`; selecting `.first()` preserves the intended engine assertion.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-unified-avatar-search-resizable-sidebar.md
@@ -111,3 +111,12 @@ PR #2057 merged to `main` as `ebfb1e090cb677b6d9d35edff3ad912819f3fba6`, but two
 - Repair branch `fix/tfi-m7-marketplace-runtime-smoke` adds a deterministic AppHost test Marketplace/install seam while production continues to use the real online Product API; native capability calls are normalized to canonical `feature.marketplace.*` / `feature.plugin.*`; menu E2E now confirms listener registration before the click.
 - Global Application-search tests now exercise the real search → install → open UI flow instead of assuming an already-installed Mini App.
 - Task remains `TESTING` until repaired runtime smoke, package matrix, protected merge, signed/notarized main artifact installation and local Mac open verification all pass.
+
+
+## Final E2E contract alignment — 2026-08-23
+
+- Runtime repair PR #2060 merged to `main` as `bcd0951396a7efe9f5f37aaa5b0ea38c35ec6220`.
+- Electron runtime run `32638779651` proved the product path itself works: Marketplace discovery/install/open completed and the failure snapshot contains the installed `global-dharma` Mini App dialog/iframe. Two remaining failures are stale Playwright assertions, not product/runtime failures.
+- Personal BotMark assertion matched both the wrapper and SVG because both intentionally carry `data-engine="fabushi-motion-v2"`; the final contract selects the first matching engine node.
+- Mini App dialog canonical subtitle is `Mini App · 已安装线上包 · 受控宿主容器`; Messenger/smoke assertions now match that actual product text.
+- Task stays `TESTING` until this final contract repair is green/merged and the canonical main macOS package is installed and opened locally.


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: M7-DESKTOP-003 final acceptance

## Evidence
Runtime repair PR #2060 merged to main as `bcd0951396a7efe9f5f37aaa5b0ea38c35ec6220`. Electron runtime run `32638779651` proved the product path itself is working: its Playwright failure snapshot contains the installed `global-dharma` Mini App dialog and iframe.

The remaining failures are stale test contracts:
- personal navigation BotMark exposes `data-engine="fabushi-motion-v2"` on both wrapper and SVG, so the strict locator must select a single engine node;
- the canonical Mini App subtitle is `Mini App · 已安装线上包 · 受控宿主容器`, while Messenger/smoke still asserted the retired shorter copy.

## Fix
- select `.first()` for the personal Motion-v2 engine assertion;
- align Messenger and smoke Mini App assertions with the current product subtitle;
- record #2060 merge and the runtime-artifact evidence in the project task/evidence files.

## Verification
- `git diff --check` PASS locally.
- Heavy Electron runtime/package verification remains GitHub Actions only.

## Final acceptance after this PR
Current-head Electron runtime + package matrix and relevant product gates must pass, protected merge must land, then the canonical main signed/notarized macOS artifact will be installed and opened on the user's Mac.