### PR TITLE
fix(messenger): keep personal footer outside peer list

### DIFF
--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -119,7 +119,7 @@
 .searchBox input { min-width:0; flex:1; border:0; outline:0; background:transparent; color:#17212b; font:inherit; }
 .searchBox button { border:0; background:transparent; color:#8393a3; cursor:pointer; display:grid; place-items:center; }
 
-.peerList { flex:1; overflow:auto; padding-bottom:12px; }
+.peerList { min-height:0; flex:1 1 auto; overflow:auto; padding-bottom:12px; }
 .quickActions { display:grid; grid-template-columns:1fr 1fr; gap:6px; padding:0 9px 8px; }
 .quickActions button { min-height:42px; border:0; background:#f4f7fa; color:#338fd0; border-radius:10px; display:flex; align-items:center; justify-content:center; gap:7px; cursor:pointer; font-weight:700; }
 .quickActions button:hover { background:#e8f4fc; }
@@ -562,6 +562,8 @@
 .fabushiUnified .chatList {
   position: relative;
   min-width: 84px;
+  min-height: 0;
+  height: 100%;
   overflow: visible;
 }
 

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/2026-08-23-sidebar-footer-overlap.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/2026-08-23-sidebar-footer-overlap.md
@@ -1,0 +1,19 @@
+# M7-DESKTOP-003 packaged sidebar footer regression
+
+## Symptom
+
+Packaged Electron E2E on macOS and Windows reached the unified Messenger but the final surface test could not click the active assistant peer. Playwright reported that the bottom personal-navigation footer intercepted pointer events over the peer row.
+
+## Root cause
+
+The peer list was a flex child with the default automatic minimum height. In constrained packaged windows it could retain content height instead of shrinking to the remaining space above the fixed-size footer. The footer therefore painted over the last visible peer rows.
+
+## Repair
+
+- make `.peerList` explicitly shrinkable with `min-height: 0` and `flex: 1 1 auto`;
+- constrain the unified chat-list column to the shell height while retaining visible overflow for the personal navigation popover;
+- keep the existing real click in `surfaces.spec.ts` as the regression gate rather than forcing the click or weakening the test.
+
+## Required verification
+
+The repair is complete only when packaged Electron E2E passes on macOS and Windows, the canonical main macOS package passes Developer ID signing/notarization/verification, and the resulting signed package is installed and opened on the target Mac.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-sidebar-footer-regression.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-sidebar-footer-regression.md
@@ -1,0 +1,18 @@
+# M7-DESKTOP-003 — packaged sidebar footer regression follow-up
+
+- Status: IN PROGRESS
+- Parent: M7-DESKTOP-003 unified avatar/search/resizable sidebar
+- Scope: Electron packaged desktop only
+
+## Acceptance
+
+1. Bottom personal-navigation footer never overlaps or intercepts conversation peer rows.
+2. The peer list remains independently scrollable at constrained packaged-window heights.
+3. Personal navigation popover remains able to escape the sidebar bounds.
+4. Existing packaged Electron surface E2E performs a normal user click on the assistant peer and passes on macOS and Windows.
+5. After merge, canonical main macOS Developer ID signing, App Store Connect notarization, stapling and package verification pass.
+6. The resulting current-main macOS package is installed and opened on the target Mac, with bundle and nested code identities verified.
+
+## Evidence
+
+See `evidence/M7-DESKTOP-003/2026-08-23-sidebar-footer-overlap.md`.

--- a/projects/telegram-fabushi-integration/source/2026-08-23-packaged-sidebar-footer-regression.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-23-packaged-sidebar-footer-regression.md
@@ -1,0 +1,7 @@
+# Source — Packaged Messenger sidebar footer regression
+
+On 2026-08-23, the packaged Electron quality gate for the M7 unified desktop shell exposed the same cross-platform UI defect on macOS and Windows: the bottom personal-navigation footer intercepted pointer events intended for a visible assistant peer row. Linux packaging and the Host simulated-user smoke remained green.
+
+The product requirement is unchanged: the left conversation column must resize and collapse to avatar-only mode while the personal-navigation trigger stays at the bottom, without obscuring any conversation. The fix therefore preserves the UI design and corrects flex sizing rather than weakening the Playwright interaction.
+
+The direct-distribution macOS signing repair from PR #2064 is a separate layer. It has already merged to `main`; after this layout regression is green and merged, canonical main packaging must re-run so the fixed Developer ID/nested-identifier/notarization path can produce the package used for local installation.


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Follow-up: M7-DESKTOP-003

## Regression
Packaged Electron E2E on both macOS and Windows could see the active assistant peer but a normal click was intercepted by the bottom personal-navigation footer. Linux packaging and Host simulated-user smoke stayed green.

## Root cause
The conversation list remained a flex item with its automatic minimum height. In constrained packaged windows it could retain content height instead of shrinking to the remaining space above the footer, so the footer painted over the last peer rows.

## Fix
- make `.peerList` explicitly shrinkable with `min-height: 0` and `flex: 1 1 auto`;
- constrain the unified chat-list column to shell height with `min-height: 0; height: 100%`;
- retain `overflow: visible` so the personal-navigation popover is not clipped;
- keep the existing real Playwright click unchanged (no forced click / no test weakening).

## Evidence
- `projects/telegram-fabushi-integration/source/2026-08-23-packaged-sidebar-footer-regression.md`
- `projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-003-sidebar-footer-regression.md`
- `projects/telegram-fabushi-integration/evidence/M7-DESKTOP-003/2026-08-23-sidebar-footer-overlap.md`

After this merges, canonical main must run the formal Developer ID + App Store Connect notarization path introduced/fixed by #2064, and the resulting current-main macOS package will be installed and opened on the target Mac.