### PR TITLE
fix(ci): run packaged Electron E2E on every main merge

### DIFF
--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
-          FORCE_ALL: ${{ github.event_name == 'workflow_dispatch' }}
+          FORCE_ALL: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         run: |
           set -euo pipefail
           if [ "$FORCE_ALL" = "true" ] || [ -z "$BASE_SHA" ]; then


### PR DESCRIPTION
## Purpose
Restore the desktop delivery contract: pull requests stay on the minimum safe validation surface, while every merge/push to `main` performs the full packaged Electron matrix and packaged E2E.

## CI root cause
`electron-desktop.yml` classified a main push only by the files changed in that merge. A renderer-only change such as the M7 sidebar CSS repair therefore set `package=false`, which skipped macOS/Windows/Linux package jobs even though this was a canonical `main` merge.

## CI change
`FORCE_ALL` now becomes true for either:
- manual `workflow_dispatch`, or
- `push` to `refs/heads/main`.

That preserves fast PR classification but guarantees canonical main runs the full package/E2E matrix. On macOS main pushes this also reaches Developer ID signing, stable nested Host/ASR identity restoration, App Store Connect notarization, stapling, Gatekeeper verification and artifact upload.

## Packaged E2E follow-up
The previous packaged failure was traced more precisely: the test intentionally opened the new personal-navigation popover, verified all migrated navigation entries, and then tried to click a conversation peer *behind the still-open popover*. The intercepting `<header>` belonged to `ProfileNavigationMenu`, not the collapsed-footer layout itself. The test now closes the popover through the real profile trigger and confirms it is removed before clicking the assistant peer. This keeps normal user interaction semantics and does not use forced clicks or bypass hit-testing.

The earlier flex sizing hardening from #2065 remains in place and is harmless. This PR’s workflow-file change forces its own full packaged matrix, so macOS and Windows must pass the real packaged click flow before merge.

After merge, the resulting canonical main macOS artifact will be installed and opened on the target Mac.