### PR TITLE
test(messenger): close personal menu before peer interaction

### DIFF
--- a/desktop/e2e/surfaces.spec.ts
+++ b/desktop/e2e/surfaces.spec.ts
@@ -165,6 +165,8 @@ test('installed desktop exposes unified Messenger, native menu routing, browser 
       for (const label of ['聊天', '联系人', 'Bots', '群组', '频道', '通话', '收藏', '归档', '文件夹', 'Mini Apps', '支付', '设置']) {
         await expect(page.getByTitle(label, { exact: true })).toBeVisible();
       }
+      await page.getByTestId('profile-navigation-trigger').click();
+      await expect(page.getByTestId('profile-navigation-menu')).toHaveCount(0);
       const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
       await expect(assistant).toBeVisible();
       await expect(assistant.locator('[data-engine="fabushi-motion-v2"]').first()).toBeVisible();


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- M7-DESKTOP-003 follow-up

## Root cause confirmed by packaged macOS evidence
The packaged surface test opened `ProfileNavigationMenu`, verified the migrated entries, then attempted to click the assistant peer while the popover was still open. Playwright correctly reported that the popover `<header>` intercepted the click. This is expected hit-testing for an open menu, not a failure of the peer row.

## Fix
The E2E now uses the real personal-avatar trigger to close the menu, confirms `profile-navigation-menu` is removed from the DOM, and only then clicks the assistant peer. No `force: true`, no hit-testing bypass, and no weakening of the product assertion.

## Verification contract
Because this modifies `desktop/e2e/**`, the Electron PR classifier runs the full packaged macOS/Windows/Linux matrix. After merge, the newly fixed `main` workflow from #2066 also forces the full package matrix on every main push, including formal macOS Developer ID signing, nested Host/ASR identity restoration, App Store Connect notarization, stapling, Gatekeeper verification, packaged E2E and artifact upload.

The resulting canonical main macOS artifact will then be installed and opened on the target Mac.