### PR TITLE
fix(messaging): normalize authenticated account ids for desktop access

### DIFF
--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
@@ -1,0 +1,26 @@
+# M7-DESKTOP-004 evidence — authenticated messaging account identity
+
+## Production symptom
+
+The signed/notarized canonical-main macOS artifact at `25292d1c9f4640670612a2bf794d4e7df9b32d3a` was downloaded from GitHub Actions, its artifact SHA-256 matched GitHub, its DMG and app passed codesign/stapler/Gatekeeper, and it was installed and opened on the target arm64 Mac. The running app then showed:
+
+`bridge/invoke-failed: host operation failed: authenticated account has no stable user id`
+
+This proved the remaining defect was above the Apple signing boundary and inside authenticated messaging access issuance.
+
+## Root cause evidence
+
+Production account responses serialize `user.id`, `userId`, and `userNo` as JSON numbers. `issue_messaging_access` previously selected the first present field and then called `Value::as_str()` once. A present numeric `user.id` therefore stopped resolution and produced `None` even when later compatible identity fields existed.
+
+## Repair evidence required before TESTED
+
+- current-head Rust/Host/CI gates green;
+- protected merge to main;
+- canonical-main full Electron package matrix green;
+- macOS notarization final status `Accepted` and stapled;
+- downloaded artifact digest equals GitHub Actions artifact digest;
+- installed app, Host and ASR all validate with Developer ID Team `M4Q99K4UR4` and stable identifiers;
+- app opens on the target Mac using the restored authenticated session;
+- no stable-user-id banner is present and Messenger initialization succeeds without requiring a new login.
+
+Until those facts are recorded, M7-DESKTOP-004 remains `TESTING`.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-messaging-account-id-normalization.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-messaging-account-id-normalization.md
@@ -1,0 +1,35 @@
+# M7-DESKTOP-004 — messaging account identity normalization
+
+- Status: TESTING
+- Parent milestone: M7 — Bot/Agent unified contact system
+- Trigger: final signed/notarized macOS local-app smoke after M7-DESKTOP-003
+
+## Problem
+
+The installed canonical-main macOS build restored an authenticated account but failed to issue the local self-hosted messaging credential with `authenticated account has no stable user id`.
+
+The production account service emits numeric JSON `id` / `userId` values, while the Host assumed the first present identity field was a string. This rejected a valid authenticated account before the unified Messenger could finish establishing its messaging access boundary.
+
+## Implementation
+
+1. Normalize stable identity values from JSON strings or numbers.
+2. Prefer principal identifiers when present, then current/legacy user identifiers.
+3. Search both `auth.user` and the UI-safe session root for compatibility with restored historical sessions.
+4. Preserve the existing one-way SHA-256 account fingerprint before constructing the local `ActorId`.
+5. Add regression tests for numeric IDs, top-level legacy IDs, trimmed usernames and missing stable identity.
+
+## Acceptance
+
+- [ ] Feature Host tests pass on current head.
+- [ ] Existing authenticated desktop session can issue messaging access without re-login.
+- [ ] No account credential or raw messaging bearer token crosses the presentation boundary.
+- [ ] Missing stable account identity still fails closed.
+- [ ] Protected merge reaches canonical `main`.
+- [ ] Canonical-main Electron package matrix is green on macOS, Windows and Linux.
+- [ ] macOS package passes Developer ID signing, stable nested Host/ASR identifiers, App Store Connect notarization, stapling and Gatekeeper verification.
+- [ ] The exact canonical-main artifact is installed over `/Applications/fabushi.app` and opened on the target Mac.
+- [ ] Final visual/runtime smoke has no `authenticated account has no stable user id` banner.
+
+## Evidence
+
+See `evidence/M7-DESKTOP-004/README.md`.

--- a/projects/telegram-fabushi-integration/source/2026-08-23-messaging-account-id-normalization.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-23-messaging-account-id-normalization.md
@@ -1,0 +1,29 @@
+# Source — Authenticated messaging account identity normalization
+
+On 2026-08-23, final smoke testing of the signed and notarized canonical-main macOS package exposed a production-only messaging access regression after the app was installed and opened on the target Mac.
+
+The app restored the existing authenticated Fabushi session, but the unified Messenger displayed:
+
+`bridge/invoke-failed: host operation failed: authenticated account has no stable user id`
+
+## Root cause
+
+`mahayana-feature-host::issue_messaging_access` derived the local messaging actor from the UI-safe account object. It selected `user.id`, `user.userId`, or `user.username` with one `or_else` chain and then applied a single `Value::as_str()` to the selected value.
+
+The production account worker serializes `id`, `userId`, and `userNo` as JSON numbers. Because `user.id` exists first, the chain selected that numeric value; `as_str()` then returned `None`, and the code never continued to the valid later identity fields. The result was a false “no stable user id” contract failure even though the authenticated account had a stable numeric identity.
+
+## Repair direction
+
+Normalize stable account identity components instead of assuming every identifier is a JSON string. The Host now accepts non-empty strings and JSON numbers, checks canonical/future principal identifiers as well as current and legacy user identifiers, searches both the nested `user` object and the UI-safe session root, and still fails closed when no stable identifier exists.
+
+The resulting identifier is used only as input to the existing SHA-256 account fingerprint; raw account identifiers and account credentials are not exposed to the presentation layer or persisted in the messaging access registry.
+
+## Verification contract
+
+- numeric production `user.id` / `userId` values are accepted;
+- legacy string usernames and top-level session identifiers remain compatible;
+- missing stable identity still fails closed;
+- the existing authenticated desktop session issues self-hosted messaging access without requiring re-login;
+- current-head CI passes;
+- after protected merge, canonical main builds the full macOS Developer ID package, passes App Store Connect notarization/stapling/Gatekeeper verification and packaged E2E;
+- that exact artifact is installed and opened on the target Mac, and the stable-user-id runtime banner is absent.

--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -529,19 +529,9 @@ impl FeatureHostController {
                 "messaging access requires an authenticated Fabushi account session".into(),
             ));
         }
-        let user = auth.get("user").and_then(Value::as_object).ok_or_else(|| {
-            FeatureHostError::Contract("authenticated account has no user identity".into())
+        let user_id = stable_authenticated_account_id(&auth).ok_or_else(|| {
+            FeatureHostError::Contract("authenticated account has no stable user id".into())
         })?;
-        let user_id = user
-            .get("id")
-            .or_else(|| user.get("userId"))
-            .or_else(|| user.get("username"))
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                FeatureHostError::Contract("authenticated account has no stable user id".into())
-            })?;
         let digest = Sha256::digest(user_id.as_bytes());
         let account_fingerprint = digest[..16]
             .iter()
@@ -11025,6 +11015,48 @@ fn test_computer_snapshot() -> ComputerSnapshot {
     }
 }
 
+
+fn stable_identity_component(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => {
+            let value = value.trim();
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        }
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn stable_authenticated_account_id(auth: &Value) -> Option<String> {
+    const ID_KEYS: [&str; 8] = [
+        "principalId",
+        "principal_id",
+        "id",
+        "userId",
+        "user_id",
+        "userNo",
+        "user_no",
+        "username",
+    ];
+
+    auth.get("user")
+        .and_then(Value::as_object)
+        .and_then(|user| {
+            ID_KEYS
+                .iter()
+                .find_map(|key| stable_identity_component(user.get(*key)))
+        })
+        .or_else(|| {
+            ID_KEYS
+                .iter()
+                .find_map(|key| stable_identity_component(auth.get(*key)))
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -11945,6 +11977,43 @@ mod tests {
         assert!(kinds.contains(&"operation.interrupted"));
         assert!(kinds.contains(&"session.cleared"));
         assert!(kinds.contains(&"host.closed"));
+    }
+
+    #[test]
+    fn stable_messaging_account_identity_accepts_numeric_and_legacy_session_ids() {
+        assert_eq!(
+            stable_authenticated_account_id(&json!({
+                "loggedIn": true,
+                "user": {"id": 42, "username": "ignored"},
+            }))
+            .as_deref(),
+            Some("42")
+        );
+        assert_eq!(
+            stable_authenticated_account_id(&json!({
+                "loggedIn": true,
+                "user": {},
+                "userId": 77,
+                "username": "legacy-user",
+            }))
+            .as_deref(),
+            Some("77")
+        );
+        assert_eq!(
+            stable_authenticated_account_id(&json!({
+                "loggedIn": true,
+                "user": {"username": "  legacy-name  "},
+            }))
+            .as_deref(),
+            Some("legacy-name")
+        );
+        assert_eq!(
+            stable_authenticated_account_id(&json!({
+                "loggedIn": true,
+                "user": {"nickname": "No stable identifier"},
+            })),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Task: M7-DESKTOP-004

## Production regression
Final smoke testing of the signed/notarized canonical-main macOS package exposed a real runtime failure after installation and launch:

`bridge/invoke-failed: host operation failed: authenticated account has no stable user id`

The account session was already authenticated; this was not a login or Apple-signing failure.

## Root cause
The production account worker serializes `user.id`, `userId`, and `userNo` as JSON numbers. `issue_messaging_access` selected the first present identity field (`id` first) and then applied one `Value::as_str()` to that selected value. A valid numeric `id` therefore became `None`, and resolution never continued to compatible later fields.

## Fix
- normalize non-empty JSON strings and JSON numbers into the stable identity input;
- prefer principal identifiers when present, then current/legacy user identifiers;
- search both `auth.user` and the UI-safe restored session root;
- preserve the existing SHA-256 account fingerprint before constructing the local messaging `ActorId`;
- add regression tests for numeric IDs, top-level legacy IDs, trimmed usernames, and missing stable identity;
- keep the existing fail-closed unauthenticated behavior and bearer-token non-persistence test.

No account credential or raw account identifier is exposed to the renderer by this change.

## Local lightweight verification
- `rustfmt --edition 2021 --check` on the modified full source: PASS.
- Heavy Rust/Host/package/E2E verification remains delegated to GitHub Actions.

## Acceptance
After protected merge, canonical `main` must run the full package matrix. The resulting macOS Developer ID package must be notarized/stapled/verified, downloaded, digest-checked, installed on the target Mac, opened with the existing authenticated session, and the stable-user-id banner must be absent.

## Records
- Source: `projects/telegram-fabushi-integration/source/2026-08-23-messaging-account-id-normalization.md`
- Task: `projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-messaging-account-id-normalization.md`
- Evidence: `projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md`