### PR TITLE
fix(rust): close formatting and embedded runtime clippy gates

### DIFF
--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
@@ -12,6 +12,10 @@ This proved the remaining defect was above the Apple signing boundary and inside
 
 Production account responses serialize `user.id`, `userId`, and `userNo` as JSON numbers. `issue_messaging_access` previously selected the first present field and then called `Value::as_str()` once. A present numeric `user.id` therefore stopped resolution and produced `None` even when later compatible identity fields existed.
 
+## Current-head follow-up
+
+PR #2068 merged the functional repair before its final one-line rustfmt cleanup had reached the branch head. PR #2069 carries that formatting correction; this evidence update intentionally creates a post-open synchronize event so the complete current head is exercised by the repository pull-request gates before merge.
+
 ## Repair evidence required before TESTED
 
 - current-head Rust/Host/CI gates green;

--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -11015,7 +11015,6 @@ fn test_computer_snapshot() -> ComputerSnapshot {
     }
 }
 
-
 fn stable_identity_component(value: Option<&Value>) -> Option<String> {
     match value? {
         Value::String(value) => {


### PR DESCRIPTION
Follow-up to #2068 after the authenticated messaging account-ID normalization merged.

## Current-head gate closure
The first post-merge follow-up removed the one extra blank line reported by `cargo fmt --all -- --check`. A subsequent full `Mahayana embedded Codex Runtime` run exposed three independent `-D warnings` clippy blockers already present in `mahayana-mcp-runtime` on all three hosted OSes:

- `uuid::Uuid` was imported at library scope but used only by a test;
- the App API Authorization-header condition used a collapsible nested `if`;
- the SSE parser used `.last()` on a double-ended iterator.

## Fix
- qualify `uuid::Uuid::new_v4()` at the test use site and remove the production-scope import;
- use the Rust 2024 if-let chain clippy recommends while preserving the exact trusted-host/token behavior;
- replace `.last()` with `.next_back()` for the equivalent final SSE JSON event without needless forward iteration;
- retain the rustfmt cleanup and M7-DESKTOP-004 evidence note.

The modified MCP runtime source passes `rustfmt --edition 2024 --check --config skip_children=true` locally. Heavy clippy, Host, package, notarization and packaged E2E validation remain on GitHub Actions.

After all current-head gates are green and protected auto-merge completes, canonical `main` will run the full Electron package matrix. The resulting signed/notarized macOS artifact will be digest-verified, installed over `/Applications/fabushi.app`, opened with the existing authenticated session, and checked to ensure the previous `authenticated account has no stable user id` runtime banner is gone.