### PR TITLE
fix(ci): close final runtime and mac hot-package blockers

### DIFF
--- a/.github/workflows/electron-macos-hot-package.yml
+++ b/.github/workflows/electron-macos-hot-package.yml
@@ -191,6 +191,7 @@ jobs:
           sparse-checkout: |
             .github/scripts
             desktop
+            native/mahayana-messaging
             third_party/mahayana/codex-rs
             third_party/mahayana/mahayana-rs
 

--- a/third_party/mahayana/mahayana-rs/mahayana-runtime/src/kernel_conversation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-runtime/src/kernel_conversation.rs
@@ -10,15 +10,13 @@ use mahayana_core::{
 };
 use mahayana_kernel::{
     ApprovalResolution, Capability, CapabilitySet, EngineBackend, ExecutionPolicy, KernelError,
-    KernelEvent, KernelEventSink, OpenSessionRequest, OperationId as KernelOperationId, RiskLevel,
-    RunRequest, RuntimeProfile, SessionId, SharedKernelEventSink,
+    KernelEvent, KernelEventSink, OpenSessionRequest, OperationId as KernelOperationId, RunRequest,
+    RuntimeProfile, SessionId, SharedKernelEventSink,
 };
 use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex as AsyncMutex;
-
-pub const MAHAYANA_AI_CONVERSATION_ID: &str = "mahayana-ai:agent:assistant";
 
 pub struct KernelConversationProvider {
     backend: Arc<dyn EngineBackend>,

--- a/third_party/mahayana/mahayana-rs/mahayana-runtime/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-runtime/src/lib.rs
@@ -9,15 +9,8 @@ use fabushi_official_miniapps::OfficialMiniAppEngine;
 use fabushi_official_miniapps::app_definition;
 use fabushi_official_miniapps::home_html;
 use kernel_conversation::KernelConversationProvider;
-use mahayana_agent::AgentActivityStatus;
 use mahayana_agent::AgentBackend;
 use mahayana_agent::AgentError;
-use mahayana_agent::AgentEvent;
-use mahayana_agent::AgentEventSink;
-use mahayana_agent::AgentMessageRequest;
-use mahayana_agent::ApprovalResolution;
-use mahayana_agent::SharedAgentEventSink;
-use mahayana_agent::StartThreadRequest;
 use mahayana_agent_kernel_bridge::LegacyAgentKernelBridge;
 use mahayana_conversation::ConversationError;
 use mahayana_conversation::ConversationEventSink;
@@ -26,15 +19,12 @@ use mahayana_conversation::ProviderRegistry;
 use mahayana_conversation::ResolveApprovalRequest;
 use mahayana_conversation::SendMessageRequest;
 use mahayana_conversation::SharedConversationEventSink;
-use mahayana_core::AgentThreadId;
 use mahayana_core::ApprovalId;
 use mahayana_core::CONVERSATION_SCHEMA_VERSION;
 use mahayana_core::Conversation;
 use mahayana_core::ConversationId;
 use mahayana_core::MODEL_RUNTIME_VERSION;
 use mahayana_core::Message;
-use mahayana_core::MessageId;
-use mahayana_core::MessageRole;
 use mahayana_core::OperationId;
 use mahayana_core::PluginCommandDescriptor;
 use mahayana_core::RUNTIME_ABI_VERSION;
@@ -56,9 +46,6 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
-use tokio::sync::Mutex as AsyncMutex;
 
 pub struct RuntimeBuilder {
     config: RuntimeConfig,
@@ -713,220 +700,6 @@ impl ConversationEventSink for RuntimeEventSink {
     }
 }
 
-struct AgentConversationProvider {
-    backend: Arc<dyn AgentBackend>,
-    thread_id: AsyncMutex<Option<AgentThreadId>>,
-    history: Arc<Mutex<Vec<Message>>>,
-}
-
-impl AgentConversationProvider {
-    fn new(backend: Arc<dyn AgentBackend>) -> Self {
-        Self {
-            backend,
-            thread_id: AsyncMutex::new(None),
-            history: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    async fn thread_id(
-        &self,
-        conversation_id: &ConversationId,
-    ) -> Result<AgentThreadId, ConversationError> {
-        let mut thread_id = self.thread_id.lock().await;
-        if let Some(thread_id) = thread_id.as_ref() {
-            return Ok(thread_id.clone());
-        }
-        let created = self
-            .backend
-            .start_thread(StartThreadRequest {
-                conversation_id: conversation_id.clone(),
-            })
-            .await
-            .map_err(agent_error)?;
-        *thread_id = Some(created.clone());
-        Ok(created)
-    }
-}
-
-#[async_trait::async_trait]
-impl ConversationProvider for AgentConversationProvider {
-    fn key(&self) -> &'static str {
-        "codex"
-    }
-
-    async fn list_conversations(&self) -> Result<Vec<Conversation>, ConversationError> {
-        Ok(vec![Conversation::codex_assistant()])
-    }
-
-    async fn history(
-        &self,
-        conversation_id: &ConversationId,
-        limit: u32,
-    ) -> Result<Vec<Message>, ConversationError> {
-        let history = self
-            .history
-            .lock()
-            .map_err(|_| ConversationError::Provider("history mutex poisoned".to_string()))?;
-        let matching: Vec<_> = history
-            .iter()
-            .filter(|message| &message.conversation_id == conversation_id)
-            .cloned()
-            .collect();
-        let start = matching.len().saturating_sub(limit as usize);
-        Ok(matching[start..].to_vec())
-    }
-
-    async fn send_message(
-        &self,
-        request: SendMessageRequest,
-        events: SharedConversationEventSink,
-    ) -> Result<(), ConversationError> {
-        let thread_id = self.thread_id(&request.conversation_id).await?;
-        let user_message = Message {
-            id: request
-                .client_message_id
-                .as_deref()
-                .and_then(|id| MessageId::new(id).ok())
-                .unwrap_or_else(|| MessageId::generated("message")),
-            conversation_id: request.conversation_id.clone(),
-            role: MessageRole::User,
-            text: request.text.clone(),
-            created_at_ms: now_ms(),
-            metadata: Value::Null,
-        };
-        if !request.hidden {
-            self.history
-                .lock()
-                .map_err(|_| ConversationError::Provider("history mutex poisoned".to_string()))?
-                .push(user_message);
-        }
-        let agent_sink: SharedAgentEventSink = Arc::new(AgentEventBridge {
-            conversation_id: request.conversation_id.clone(),
-            operation_id: request.operation_id.clone(),
-            events,
-            history: Arc::clone(&self.history),
-        });
-        self.backend
-            .send_message(
-                AgentMessageRequest {
-                    thread_id,
-                    conversation_id: request.conversation_id,
-                    operation_id: request.operation_id,
-                    text: request.text,
-                    client_message_id: request.client_message_id,
-                },
-                agent_sink,
-            )
-            .await
-            .map_err(agent_error)
-    }
-
-    async fn interrupt(&self, operation_id: &OperationId) -> Result<(), ConversationError> {
-        self.backend
-            .interrupt(operation_id)
-            .await
-            .map_err(agent_error)
-    }
-
-    async fn resolve_approval(
-        &self,
-        request: ResolveApprovalRequest,
-    ) -> Result<(), ConversationError> {
-        self.backend
-            .resolve_approval(ApprovalResolution {
-                approval_id: request.approval_id,
-                decision: request.decision,
-                payload: request.payload,
-            })
-            .await
-            .map_err(agent_error)
-    }
-}
-
-struct AgentEventBridge {
-    conversation_id: ConversationId,
-    operation_id: OperationId,
-    events: SharedConversationEventSink,
-    history: Arc<Mutex<Vec<Message>>>,
-}
-
-impl AgentEventSink for AgentEventBridge {
-    fn emit(&self, event: AgentEvent) -> Result<(), AgentError> {
-        let event = match event {
-            AgentEvent::MessageDelta { delta } => RuntimeEvent::MessageDelta {
-                operation_id: self.operation_id.clone(),
-                conversation_id: self.conversation_id.clone(),
-                delta,
-            },
-            AgentEvent::MessageCompleted { mut message } => {
-                message.conversation_id = self.conversation_id.clone();
-                self.history
-                    .lock()
-                    .map_err(|_| AgentError::Backend("history mutex poisoned".to_string()))?
-                    .push(message.clone());
-                RuntimeEvent::MessageCompleted {
-                    operation_id: self.operation_id.clone(),
-                    message,
-                }
-            }
-            AgentEvent::TokenUsageUpdated { usage } => RuntimeEvent::ModelUsageUpdated {
-                operation_id: self.operation_id.clone(),
-                usage,
-            },
-            AgentEvent::ToolProgress { message } => RuntimeEvent::PluginProgress {
-                operation_id: self.operation_id.clone(),
-                plugin_id: "codex".into(),
-                tool: String::new(),
-                progress: 0,
-                total: 0,
-                message,
-            },
-            AgentEvent::Activity { activity } => RuntimeEvent::AgentActivity {
-                operation_id: self.operation_id.clone(),
-                step_id: activity.step_id,
-                kind: activity.kind,
-                title: activity.title,
-                detail: activity.detail,
-                status: match activity.status {
-                    AgentActivityStatus::Running => RuntimeActivityStatus::Running,
-                    AgentActivityStatus::Completed => RuntimeActivityStatus::Completed,
-                    AgentActivityStatus::Failed => RuntimeActivityStatus::Failed,
-                },
-                metadata: activity.metadata,
-            },
-            AgentEvent::ApprovalRequested {
-                approval_id,
-                title,
-                details,
-            } => RuntimeEvent::ApprovalRequested {
-                operation_id: self.operation_id.clone(),
-                approval_id,
-                title,
-                details,
-            },
-        };
-        self.events
-            .emit(event)
-            .map_err(|error| AgentError::Backend(error.to_string()))
-    }
-}
-
-fn agent_error(error: AgentError) -> ConversationError {
-    match error {
-        AgentError::UsageLimitExceeded(message) => ConversationError::UsageLimitExceeded(message),
-        error => ConversationError::Provider(error.to_string()),
-    }
-}
-
-fn now_ms() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .try_into()
-        .unwrap_or(i64::MAX)
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
     #[error("runtime initialization failed: {0}")]
@@ -1001,8 +774,16 @@ fn local_plugin_commands(plugin_id: Option<&str>) -> Vec<PluginCommandDescriptor
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use mahayana_agent::AgentEvent;
+    use mahayana_agent::AgentMessageRequest;
+    use mahayana_agent::ApprovalResolution;
+    use mahayana_agent::SharedAgentEventSink;
+    use mahayana_agent::StartThreadRequest;
+    use mahayana_core::AgentThreadId;
     use mahayana_core::ApprovalDecision;
     use mahayana_core::CODEX_ASSISTANT_CONVERSATION_ID;
+    use mahayana_core::MessageId;
+    use mahayana_core::MessageRole;
 
     struct EchoAgent;
 
@@ -1030,7 +811,7 @@ mod tests {
                     conversation_id: request.conversation_id,
                     role: MessageRole::Assistant,
                     text: format!("大乘：{}", request.text),
-                    created_at_ms: now_ms(),
+                    created_at_ms: 0,
                     metadata: Value::Null,
                 },
             })


### PR DESCRIPTION
## Project
- FAB-P0001 / TFI
- Completion follow-up for M7-DESKTOP-004

## Embedded Runtime gate
After #2070 removed the first `mahayana-mcp-runtime` clippy failures, the three-OS `Mahayana embedded Codex Runtime` gate exposed a superseded legacy conversation adapter in `mahayana-runtime` as dead code under `-D warnings`.

The active architecture already routes legacy Agent backends through `LegacyAgentKernelBridge` into `KernelConversationProvider`. The old `AgentConversationProvider` / `AgentEventBridge` path is no longer constructed.

This PR removes that dead adapter and its production-only imports/helper, moves the remaining EchoAgent-only types into the test module, replaces the test-only wall-clock timestamp with deterministic `0`, and removes the unused `RiskLevel` import plus the orphan `MAHAYANA_AI_CONVERSATION_ID` constant. No active runtime route is changed.

## Mac hot-package gate
The canonical-main hot-package native-delta job sparse-checks out the Mahayana Host workspace but omitted `native/mahayana-messaging`, even though the workspace references that path. Cargo metadata therefore failed before incremental Host build.

This PR adds `native/mahayana-messaging` to that sparse checkout, preserving the incremental/hot-build design while making the workspace complete.

## Local lightweight verification
- modified Rust sources pass Rust 2024 rustfmt check using the repository-compatible formatting surface;
- no full local Rust build/package was performed; heavy clippy, tests, Electron package/E2E, Developer ID signing and Apple notarization remain delegated to GitHub Actions.

## Completion contract
Before this work is considered complete:
1. embedded Runtime clippy/tests pass on Linux, macOS and Windows;
2. Electron packaged macOS/Windows/Linux E2E passes;
3. canonical-main Mac hot-package workflow passes;
4. macOS Developer ID package is notarized/stapled/Gatekeeper-verified;
5. the exact canonical-main artifact is digest-verified, installed over `/Applications/fabushi.app`, opened on the target Mac, and the prior `authenticated account has no stable user id` runtime banner is absent.