### PR TITLE
ci: revalidate protected queue commit for PR #2074

### DIFF
--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -359,7 +359,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
-        run: npx electron-builder --${{ matrix.target }}
+        run: npx electron-builder --${{ matrix.target }} --publish never
 
       - name: Notarize, staple, and verify canonical main macOS package
         if: matrix.target == 'mac' && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-005/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-005/README.md
@@ -11,3 +11,9 @@
 ## GitHub evidence
 
 Pending PR and GitHub Actions evidence.
+
+
+## Canonical-main package repair evidence
+
+- Main Electron run `32648194025`: runtime smoke passed; Linux package failed solely because `electron-builder` auto-detected CI publishing after the GitHub updater provider was configured, with `GitHub Personal Access Token is not set`.
+- The package matrix now explicitly uses `--publish never`; immutable publishing remains in the dedicated release workflow.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-005-left-search-updater-jellyfish.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-005-left-search-updater-jellyfish.md
@@ -30,3 +30,11 @@ Apply the 2026-08-23 Telegram/Grok UI correction: keep all search activity in th
 - Local lightweight checks only: `git diff --check`, BotMark static contract script, source marker checks, PNG alpha/dimension inspection.
 - GitHub Actions: Electron desktop quality gate and any repository-required checks selected for the PR.
 - After merge: canonical `main` readback. Release workflow validates immutable GitHub Release updater assets on the next tagged release.
+
+
+## Canonical-main package repair — 2026-08-23
+
+- PR #2073 merged through the protected merge queue as canonical main `ed1535aaeb835c2819a8cb8be77bf3519b349bd1`.
+- Main Electron run `32648194025` exposed a packaging-only regression after adding the GitHub updater provider: `electron-builder` implicitly attempted to publish from ordinary CI because the package matrix did not pass `--publish never`, then failed without `GH_TOKEN`.
+- Release publication remains exclusively owned by `native-electron-release.yml`; ordinary desktop quality/package CI must only build artifacts.
+- Repair: canonical Electron package matrix now invokes `electron-builder --<target> --publish never`, preventing CI from mutating GitHub Releases while still generating updater metadata/assets for later release publication.


### PR DESCRIPTION
Temporary CI-only revalidation branch for the exact protected merge-queue candidate SHA of PR #2074. The merge queue created the candidate but did not emit its expected `merge_group/checks_requested` CI run. This PR intentionally triggers the canonical CI workflow on that exact commit so the required `CI result` check can be recorded without bypassing branch protection. Do not merge this PR; close it after #2074 lands.