### PR TITLE
docs(governance): require PR merge to main before next task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,23 @@ If no matching project exists and the work is genuinely independent:
 5. If concurrent project creation causes a `PORTFOLIO.json` merge conflict, re-read canonical `main` and reallocate the later project from the new high-water mark. Do not force, duplicate, or reuse the losing sequence.
 6. Project/registry changes must pass the `Project portfolio governance` GitHub Actions validator before completion.
 
+### 1B. CRITICAL: PR-to-main serialization gate — finish and merge before the next PR task
+
+Fabushi repository work is **serial at the task/PR completion boundary by default**. An agent must not leave one independent task's PR unmerged and then start or advance the next independent PR task.
+
+For every repository task that uses a PR:
+
+1. Finish the current task's implementation, project records, and objective acceptance checks on the current task branch/PR.
+2. Wait for and inspect all required review, CI, branch-protection, and merge-queue gates for that PR.
+3. Resolve failures, conflicts, or requested changes on **that same task** until the PR is mergeable. If it cannot be merged, keep the task `in-progress`, `blocked`, or `failed`; do not treat it as complete.
+4. Merge the current PR into canonical `main` through the repository's required protected-main process.
+5. Re-read/verify the relevant files and engineering facts from canonical GitHub `main` after merge. A PR being open, approved, green, queued, or merely pushed is not enough.
+6. Only after the merge and canonical-main verification are complete may the agent begin or advance the next independent PR task.
+
+**Default prohibition:** while the current task has an unmerged PR, do not create, switch to, implement, or advance another independent PR task merely to keep work moving in parallel.
+
+**Narrow exception:** a truly urgent security/incident fix may run in parallel only when the user explicitly authorizes it or an existing higher-priority emergency policy requires it. Record the exception and reason in both tasks' durable project records. This exception must never be used as a convenience bypass for ordinary CI waits, review waits, conflicts, or merge queues.
+
 ### 2. If no project folder exists, create the enterprise standard before implementation
 
 If the request does not belong to an existing project, first allocate the portfolio Project ID under the gate above, then create a lowercase kebab-case folder under:
@@ -108,7 +125,7 @@ At minimum:
 - `docs/19-完成定义与验收.md`: objective project Definition of Done with evidence type for every required gate.
 - `management/`: roadmap, WBS, milestones, acceptance traceability, RAID/risk, append-only status, dependencies/blockers, append-only changelog, open issues/actions, per-task records.
 - `decisions/`: ADRs for expensive-to-reverse architecture/protocol/data/security/deployment/CI/CD/governance/vendor decisions.
-- `evidence/`: durable evidence indexes for commits, PRs, reviews, CI checks, tests, releases, deployments, migrations.
+- `evidence/`: durable evidence indexes for commits, PRs, reviews, CI checks, releases, deployments, migrations.
 - `runbooks/`: deploy/rollback/recovery/migration/incident/data-repair/key-rotation or other repeatable operational procedures when applicable.
 
 ### 4. Every substantial task must have a durable task record
@@ -147,6 +164,7 @@ The GitHub portfolio registry and project folder are the durable working context
 - Keep planned work and verified completed work clearly separated.
 - Prefer the same branch/PR for implementation and its project-record updates.
 - Never mutate an existing registered Project ID to make a registry conflict disappear.
+- Do not begin or advance a different independent PR task until the current task's PR has been merged and verified on canonical `main`, except for the narrow documented emergency exception in §1B.
 
 ### 6. Task completion is blocked until project records and evidence are current
 
@@ -166,8 +184,9 @@ Before saying a task is finished:
 10. Commit project-record changes to GitHub in the same task change stream when possible.
 11. Merge through required protected-main checks/merge queue.
 12. Verify canonical state on GitHub `main` after merge, including registry/project metadata parity when applicable.
+13. Do not begin or advance the next independent PR task until steps 11–12 for the current task are complete.
 
-If any required review/CI/merge/release/deployment/migration/acceptance gate is pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete.
+If any required review/CI/merge/release/deployment/migration/acceptance gate is pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete and do not use the pending state as a reason to advance the next independent PR task.
 
 ### 7. Source-of-truth precedence
 
@@ -197,7 +216,7 @@ and:
 
 When Task Orchestration is used, preserve the same immutable `FAB-Pxxxx` Project ID, Project Key, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links in external control views. Google Sheets is a portfolio/control-plane view; for Fabushi repository work the GitHub portfolio registry/project folder and live GitHub/CI facts remain authoritative.
 
-The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass portfolio Project ID allocation, project-folder creation/reuse, task records, acceptance evidence, or completion closure.
+The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass portfolio Project ID allocation, project-folder creation/reuse, task records, acceptance evidence, PR-to-main serialization, or completion closure.
 
 ## CRITICAL: Local Disk Safety — Never Build or Test the App Locally
 

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -21,6 +21,7 @@
 | FPG-004.5 | 将编号流程写入 AGENTS/governance Skill/lifecycle/standard | yes | 新项目必须先读取 registry 并原子分配 next_sequence | canonical main file review | passed |
 | FPG-004.6 | GitHub Actions portfolio governance gate | yes | PR 上 validator workflow success | run 32561929188 | passed |
 | FPG-004.7 | Protected merge + canonical main verification | yes | 合并后 registry、5 项目 metadata、控制规则均可从 main 验证 | PR #1996 / merge 87462b14 / main fetch | passed |
+| FPG-005 | 强制当前 PR 合并 main 后才能进入下一个 PR 任务 | yes | AGENTS 明确 PR->required gates->merge main->main verify->next task 串行门禁 | PR + required checks + protected merge + main readback | in-progress |
 
 ## Status rule
 

--- a/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
@@ -14,6 +14,7 @@
 | FPG-R10 Project ID 与 Project Key/Task ID 分层 | `project_id` + `project_key` + `legacy_project_ids` schema | 5 canonical PROJECT.yaml files on main | passed |
 | FPG-R11 编号规则自动阻止重复/改号/漏登记 | baseline-aware portfolio validator in GitHub Actions | Project portfolio governance run 32561929188 | passed |
 | FPG-R12 编号流程进入仓库 Agent/Skill/lifecycle 控制面 | AGENTS + governance Skill + project standard + task lifecycle | canonical main file review after #1996 | passed |
+| FPG-R13 当前 PR 必须合并并验证 main 后才能进入下一独立 PR 任务 | root `AGENTS.md` §1B + completion gate + FPG-005 task/source | pending PR/check/merge/main verification | in-progress |
 | Task Orchestration Skill validator | `quick_validate.py` | `Skill is valid!` | passed |
 | Task Orchestration Skill package | `package_skill.py` | `skill.zip`, 16128 bytes, SHA-256 `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61` | passed |
 | Root AGENTS enterprise scaffold | post-merge file review | main `AGENTS.md` | passed |

--- a/projects/fabushi-project-governance/management/tasks/FPG-005-pr-main-serialization.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-005-pr-main-serialization.md
@@ -1,0 +1,67 @@
+# FPG-005 — PR-to-main serialization gate
+
+- Project ID: `FAB-P0002`
+- Project Key: `FPG`
+- Task ID: `FPG-005`
+- Source: `source/2026-08-24-FPG-005-pr-main-serialization.md`
+- Status: `in-progress`
+- Started: `2026-08-24`
+- Updated: `2026-08-24`
+- Completed: pending
+
+## Objective
+
+Make repository task execution serial at the PR completion boundary: the current task PR must pass required gates, merge to canonical `main`, and be verified on `main` before another independent PR task may begin or advance.
+
+## In scope
+
+- root `AGENTS.md` hard gate;
+- durable source requirement;
+- WBS and acceptance traceability;
+- status/changelog evidence;
+- protected PR merge and canonical-main readback.
+
+## Out of scope
+
+- changing GitHub branch protection settings;
+- implementing a new CI bot to auto-block PR creation;
+- emergency incident policy redesign.
+
+## Acceptance criteria
+
+1. `AGENTS.md` explicitly prohibits starting/advancing the next independent PR task while the current task PR remains unmerged.
+2. Completion sequence is explicit: acceptance checks -> required review/CI -> protected merge -> canonical-main verification -> next PR task.
+3. Pending/failed current PR remains `in-progress`/`blocked`/`failed` rather than being bypassed.
+4. Narrow emergency exception requires explicit authorization/policy and durable record.
+5. This governance change itself is merged to `main` and verified there before FPG-005 is marked passed.
+
+## Verification
+
+- GitHub PR diff review;
+- required GitHub Actions checks;
+- protected merge result;
+- post-merge fetch of canonical `main` `AGENTS.md` and project records.
+
+## Branch / commit / PR
+
+- Branch: `governance/fpg-005-pr-main-serialization`
+- Initial source commit: `6209e77a50ebfc889a2234ec3fb53df3169e7d6b`
+- AGENTS commit: `de50a82a734d2fb49ec0538c46e8b409c29d41c6`
+- PR: pending
+
+## Implementation summary
+
+Added root `AGENTS.md` section `1B. CRITICAL: PR-to-main serialization gate` and reinforced the same constraint in implementation/completion rules. Captured the user requirement as a durable source record.
+
+## Evidence
+
+Pending PR/check/merge/main evidence.
+
+## Blockers / risks
+
+- Existing unrelated open PRs predate this rule and are not retroactively rewritten by this task.
+- This task itself must not be marked complete before merge + main verification.
+
+## Next action
+
+Update governance WBS/acceptance/status/changelog, open PR, inspect required checks, merge, and verify canonical `main`.

--- a/projects/fabushi-project-governance/source/2026-08-24-FPG-005-pr-main-serialization.md
+++ b/projects/fabushi-project-governance/source/2026-08-24-FPG-005-pr-main-serialization.md
@@ -1,0 +1,25 @@
+# FPG-005 原始需求：PR 必须先合并 main 才能进入下一任务
+
+日期：2026-08-24
+来源：用户明确要求
+项目：FAB-P0002 / FPG / Fabushi Project Governance
+
+## 用户要求
+
+在根 `AGENTS.md` 中加入仓库级硬性规则：每次任务结束之前，必须先把当前任务对应的 PR 合并到 `main`，确认合并成功之后，才能开始下一个 PR 任务。
+
+## 规范化解释
+
+1. 一个仓库任务在其 PR 尚未合并到 `main` 前，不得被视为完成。
+2. 当前任务存在未合并 PR 时，Agent 不得为了另一个独立任务创建或推进新的 PR 工作流。
+3. 必须先等待/检查 required CI、review、merge queue 或其他受保护分支门禁，并完成 merge。
+4. merge 后必须从 canonical `main` 回读关键结果，确认目标变更确实已进入 `main`。
+5. 只有完成上述闭环后，才允许切换到下一个独立 PR 任务。
+6. 若当前 PR 因 CI、review、冲突或保护规则无法合并，应把当前任务保持为 `in-progress` / `blocked` / `failed`，而不是绕过它开始下一个 PR。
+7. 紧急安全修复等真正需要并行处理的例外，只有在用户明确授权或仓库已有更高优先级紧急流程时才允许，并必须记录原因；默认规则仍是严格串行。
+
+## 验收
+
+- 根 `AGENTS.md` 明确出现 PR-to-main 串行门禁。
+- FPG WBS 与验收矩阵登记此规则。
+- 本治理变更自身必须通过 PR、required checks、合并 `main`、canonical-main 回读后才可标记 passed。


### PR DESCRIPTION
## FAB-P0002 / FPG-005

Adds a repository-wide PR-to-main serialization gate requested by the user.

### Rule
For every repository task using a PR, the agent must finish the current task, pass required review/CI/protected-branch gates, merge the PR into canonical `main`, and verify the result on `main` **before beginning or advancing the next independent PR task**.

Pending CI/review/conflict/merge-queue state keeps the current task `in-progress`/`blocked`/`failed`; it is not a reason to bypass the task with another PR.

A narrow emergency exception is allowed only when explicitly authorized by the user or required by an existing higher-priority emergency policy, and must be recorded durably.

### Durable records
- root `AGENTS.md` §1B
- `projects/fabushi-project-governance/source/2026-08-24-FPG-005-pr-main-serialization.md`
- `management/tasks/FPG-005-pr-main-serialization.md`
- WBS + acceptance matrix entries

### Acceptance
This task is not complete until required checks pass, this PR merges through the protected-main process, and canonical `main` is read back to verify the rule is present.