### PR TITLE
docs(governance): allow parallel PR work with strict task closure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,22 +39,22 @@ If no matching project exists and the work is genuinely independent:
 5. If concurrent project creation causes a `PORTFOLIO.json` merge conflict, re-read canonical `main` and reallocate the later project from the new high-water mark. Do not force, duplicate, or reuse the losing sequence.
 6. Project/registry changes must pass the `Project portfolio governance` GitHub Actions validator before completion.
 
-### 1B. CRITICAL: PR-to-main serialization gate — finish and merge before the next PR task
+### 1B. CRITICAL: PR-to-main completion gate — parallel work allowed, merge required before task closure
 
-Fabushi repository work is **serial at the task/PR completion boundary by default**. An agent must not leave one independent task's PR unmerged and then start or advance the next independent PR task.
+Fabushi repository work **may proceed in parallel across independent tasks and PRs**. Waiting for CI, review, branch protection, or a merge queue on one task must not prevent productive work on another independent task. The hard gate applies to **task completion**, not to task start.
 
 For every repository task that uses a PR:
 
-1. Finish the current task's implementation, project records, and objective acceptance checks on the current task branch/PR.
-2. Wait for and inspect all required review, CI, branch-protection, and merge-queue gates for that PR.
-3. Resolve failures, conflicts, or requested changes on **that same task** until the PR is mergeable. If it cannot be merged, keep the task `in-progress`, `blocked`, or `failed`; do not treat it as complete.
-4. Merge the current PR into canonical `main` through the repository's required protected-main process.
-5. Re-read/verify the relevant files and engineering facts from canonical GitHub `main` after merge. A PR being open, approved, green, queued, or merely pushed is not enough.
-6. Only after the merge and canonical-main verification are complete may the agent begin or advance the next independent PR task.
+1. Finish that task's implementation, project records, and objective acceptance checks on its own branch/PR.
+2. Open and manage the task PR. While that PR is waiting on required review, CI, branch protection, or merge queue state, the agent may create, switch to, implement, and advance other independent tasks/PRs in parallel.
+3. Keep tracking the pending PR and return to it to resolve failures, conflicts, or requested changes. Parallel work is not permission to abandon a pending PR or lose its durable task/evidence state.
+4. **Before declaring that task complete or ending it as finished**, actively drive its PR through all required review/CI/protected-main/merge-queue gates and merge it into canonical `main`. If it cannot yet merge, keep that task `in-progress`, `blocked`, or `failed` rather than calling it complete.
+5. Re-read/verify the relevant files and engineering facts from canonical GitHub `main` after merge. A PR being open, approved, green, queued, or merely pushed is not enough for task completion.
+6. Only after merge plus canonical-main verification may that individual task be marked `passed` / `completed` and reported as finished.
 
-**Default prohibition:** while the current task has an unmerged PR, do not create, switch to, implement, or advance another independent PR task merely to keep work moving in parallel.
+**Parallelism is explicitly allowed:** multiple independent tasks and PRs may be active at the same time, including while another PR is waiting on CI or the merge queue.
 
-**Narrow exception:** a truly urgent security/incident fix may run in parallel only when the user explicitly authorizes it or an existing higher-priority emergency policy requires it. Record the exception and reason in both tasks' durable project records. This exception must never be used as a convenience bypass for ordinary CI waits, review waits, conflicts, or merge queues.
+**Closure is still strict:** every active task owns its own PR-to-main closure gate. Before finishing a task, the agent must return to that task, push its PR toward merge, resolve merge blockers when possible, and verify the result on `main`. Pending PRs must remain visible in project/task records until closed.
 
 ### 2. If no project folder exists, create the enterprise standard before implementation
 
@@ -164,7 +164,7 @@ The GitHub portfolio registry and project folder are the durable working context
 - Keep planned work and verified completed work clearly separated.
 - Prefer the same branch/PR for implementation and its project-record updates.
 - Never mutate an existing registered Project ID to make a registry conflict disappear.
-- Do not begin or advance a different independent PR task until the current task's PR has been merged and verified on canonical `main`, except for the narrow documented emergency exception in §1B.
+- Parallel independent task/PR work is permitted. Keep each task separately tracked, and do not mark any task complete until that task's own PR satisfies the §1B merge-and-main-verification closure gate.
 
 ### 6. Task completion is blocked until project records and evidence are current
 
@@ -184,9 +184,9 @@ Before saying a task is finished:
 10. Commit project-record changes to GitHub in the same task change stream when possible.
 11. Merge through required protected-main checks/merge queue.
 12. Verify canonical state on GitHub `main` after merge, including registry/project metadata parity when applicable.
-13. Do not begin or advance the next independent PR task until steps 11–12 for the current task are complete.
+13. Do not mark or report that task as finished until steps 11–12 are complete. Other independent tasks may proceed in parallel while these gates are pending.
 
-If any required review/CI/merge/release/deployment/migration/acceptance gate is pending, keep the task `in-progress`, `blocked`, or `failed`; do not mark it complete and do not use the pending state as a reason to advance the next independent PR task.
+If any required review/CI/merge/release/deployment/migration/acceptance gate is pending, keep that task `in-progress`, `blocked`, or `failed` rather than marking it complete. This pending state does **not** prohibit work on other independently tracked tasks/PRs.
 
 ### 7. Source-of-truth precedence
 
@@ -216,7 +216,7 @@ and:
 
 When Task Orchestration is used, preserve the same immutable `FAB-Pxxxx` Project ID, Project Key, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links in external control views. Google Sheets is a portfolio/control-plane view; for Fabushi repository work the GitHub portfolio registry/project folder and live GitHub/CI facts remain authoritative.
 
-The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass portfolio Project ID allocation, project-folder creation/reuse, task records, acceptance evidence, PR-to-main serialization, or completion closure.
+The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass portfolio Project ID allocation, project-folder creation/reuse, task records, acceptance evidence, the PR-to-main completion gate, or completion closure.
 
 ## CRITICAL: Local Disk Safety — Never Build or Test the App Locally
 

--- a/projects/fabushi-project-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-project-governance/management/01-WBS原子任务.md
@@ -21,8 +21,8 @@
 | FPG-004.5 | 将编号流程写入 AGENTS/governance Skill/lifecycle/standard | yes | 新项目必须先读取 registry 并原子分配 next_sequence | canonical main file review | passed |
 | FPG-004.6 | GitHub Actions portfolio governance gate | yes | PR 上 validator workflow success | run 32561929188 | passed |
 | FPG-004.7 | Protected merge + canonical main verification | yes | 合并后 registry、5 项目 metadata、控制规则均可从 main 验证 | PR #1996 / merge 87462b14 / main fetch | passed |
-| FPG-005 | 强制当前 PR 合并 main 后才能进入下一个 PR 任务 | yes | AGENTS 明确 PR->required gates->merge main->main verify->next task 串行门禁 | PR + required checks + protected merge + main readback | in-progress |
+| FPG-005 | 允许并行 PR 工作，但每个任务结束前必须完成自身 PR-to-main 闭环 | yes | AGENTS 明确 parallel work allowed；每个任务在 `passed/completed` 前必须完成 required gates -> merge main -> canonical main verify | correction PR + required checks + protected merge + main readback | in-progress |
 
 ## Status rule
 
-`passed` 只用于 objective acceptance evidence 已存在的原子任务。`implemented` 仅表示 branch 上实现已存在但最终 CI/merge/main gate 尚未完成。后续治理改动继续遵守同一规则。
+`passed` 只用于 objective acceptance evidence 已存在的原子任务。`implemented` 仅表示 branch 上实现已存在但最终 CI/merge/main gate 尚未完成。一个任务等待 PR/CI/merge 时可以并行推进其他独立任务，但等待中的任务本身不得因此标记为完成。后续治理改动继续遵守同一规则。

--- a/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-project-governance/management/03-验收追踪矩阵.md
@@ -14,7 +14,7 @@
 | FPG-R10 Project ID 与 Project Key/Task ID 分层 | `project_id` + `project_key` + `legacy_project_ids` schema | 5 canonical PROJECT.yaml files on main | passed |
 | FPG-R11 编号规则自动阻止重复/改号/漏登记 | baseline-aware portfolio validator in GitHub Actions | Project portfolio governance run 32561929188 | passed |
 | FPG-R12 编号流程进入仓库 Agent/Skill/lifecycle 控制面 | AGENTS + governance Skill + project standard + task lifecycle | canonical main file review after #1996 | passed |
-| FPG-R13 当前 PR 必须合并并验证 main 后才能进入下一独立 PR 任务 | root `AGENTS.md` §1B + completion gate + FPG-005 task/source | pending PR/check/merge/main verification | in-progress |
+| FPG-R13 允许多个独立任务/PR 并行，但每个任务结束前必须把自身 PR 合并并验证 `main` | root `AGENTS.md` §1B + FPG-005 original/clarification sources + completion gate | correction PR/check/merge/main verification pending | in-progress |
 | Task Orchestration Skill validator | `quick_validate.py` | `Skill is valid!` | passed |
 | Task Orchestration Skill package | `package_skill.py` | `skill.zip`, 16128 bytes, SHA-256 `95385f836c2c10eaf6e5ae0e22a4b04a91b4924cfdc215e021e199b0154efd61` | passed |
 | Root AGENTS enterprise scaffold | post-merge file review | main `AGENTS.md` | passed |

--- a/projects/fabushi-project-governance/management/05-状态报告.md
+++ b/projects/fabushi-project-governance/management/05-状态报告.md
@@ -95,3 +95,23 @@
 - Acceptance: FPG-R08–FPG-R12、FPG-004.1–FPG-004.7 全部有客观证据并通过。
 - Blocker: none.
 - Next: FPG-004 closed. Future new projects must re-read live canonical registry; current `FAB-P0006` is next candidate, not a reservation.
+
+## 2026-08-24 — FPG-005 Round 1 — Initial interpretation
+
+- Work: 根据用户最初“任务结束之前把 PR 合并到 main，才能进行下一个 PR 任务”的要求，创建 FPG-005 并在 root `AGENTS.md` 加入严格串行 PR-to-main 门禁。
+- Evidence: branch `governance/fpg-005-pr-main-serialization`; PR #2076; merge commit `3ac9f841b4d5d1b2e9972c6ddbb661199260910b`.
+- Acceptance: PR #2076 已经通过仓库保护流程并进入 canonical `main`。
+- Finding: 用户随后明确澄清，等待 PR 合并期间**可以并行处理其他任务**；#2076 的“禁止并行”解释过严，因此 FPG-005 不能按该解释关闭。
+- Status: FPG-005 remains `in-progress` pending correction.
+- Next: 保留原始来源历史，新增澄清来源并把规则修正为 parallel execution + strict per-task completion gate。
+
+## 2026-08-24 — FPG-005 Round 2 — Parallel-work clarification
+
+- Work: 新增 `source/2026-08-24-FPG-005-parallel-pr-clarification.md`，明确最新用户要求优先于早先的严格串行解释。
+- Work: root `AGENTS.md` 改为允许多个独立任务/PR 并行；某个 PR 等待 CI/review/merge queue 时可继续其他任务。
+- Work: 保留严格的单任务完成门禁：某任务只有在自身 PR 通过 required gates、合并 canonical `main`、并完成 main 回读验证后，才可标记/报告 `passed` / `completed`。
+- Work: 同步更新 FPG-005 task、WBS 和验收矩阵。
+- Evidence: correction branch `governance/fpg-005-parallel-closure-gate`; AGENTS commit `20b8636e613c3f6918a99a8b2175e0c367a36130`; clarification source commit `6be18160f1c69402214bbef17a274ceca6507220`.
+- Acceptance: branch implementation complete; correction PR / required checks / protected merge / canonical-main verification pending.
+- Blocker: canonical `main` 仍暂时包含 #2076 的过严串行规则，直到 correction PR 合并。
+- Next: 创建 correction PR，推进 required checks 与 merge queue，合并后从 `main` 回读并关闭 FPG-005。

--- a/projects/fabushi-project-governance/management/07-变更日志.md
+++ b/projects/fabushi-project-governance/management/07-变更日志.md
@@ -26,7 +26,7 @@
 - PR #1980 required `CI result` 成功并通过 merge queue 合并到 `main`，合并提交 `e77e11d4cb4e96e59ae35859cc159874bb93180d`。
 - 合并后已验证 canonical `main` 的 root `AGENTS.md`、governance Skill 和 project-folder audit。
 - FPG-002 标记 passed，项目进入 adoption-and-measurement 阶段。
-- PR #1980 暴露的 `.agent/skills/**` CI 分类低效已分离到 CI/CD 项目 FCM-003，不与本治理任务耦合。
+- PR #1980 暴露的 `.agent/skills/**` CI 分类低效已分离到 CI/CD 项目 FCM-003，不与 FPG scope。
 
 ## 2026-08-22 — FPG-004 global project identifiers
 
@@ -40,3 +40,14 @@
 - PR #1996 的 Project portfolio governance run `32561929188` 与 repository CI run `32561929208` 全部成功。
 - PR #1996 通过 merge queue 合并到 `main`，merge commit `87462b14017b08f0f4dcd6f97fbea67b5c12d791`。
 - 合并后已回读 canonical `main` 的 registry、五个 `PROJECT.yaml`、root `AGENTS.md` 与 Project portfolio governance workflow；FPG-004 验收完成并关闭。
+
+## 2026-08-24 — FPG-005 parallel execution + per-task PR closure
+
+- 初始要求被解释为“当前 PR 未合并时禁止开始下一独立 PR 任务”，并通过 PR #2076 合并到 `main`，merge commit `3ac9f841b4d5d1b2e9972c6ddbb661199260910b`。
+- 用户随后明确澄清：多个任务/PR **可以并行**；某个 PR 等待 CI、review 或 merge queue 时，可以继续处理其他任务。
+- 新增 `source/2026-08-24-FPG-005-parallel-pr-clarification.md`，保留原来源历史并记录最新澄清，禁止静默改写过去要求。
+- FPG-005 的规范化语义改为：parallel execution is allowed；strict gate applies at each task's completion boundary。
+- 根 `AGENTS.md` 删除“等待未合并 PR 时禁止其他任务”的规则，明确允许并行创建/切换/实现/推进独立任务和 PR。
+- 每个任务结束前仍必须回到自身 PR：持续跟踪、处理失败/冲突/review，推进 required checks 和受保护 merge 流程，合并 canonical `main`，并从 `main` 回读验证；否则该任务保持 `in-progress` / `blocked` / `failed`。
+- 同步修正 FPG-005 task record、WBS、验收矩阵和状态报告。
+- correction branch: `governance/fpg-005-parallel-closure-gate`；correction PR / required checks / merge / main verification 待完成后关闭 FPG-005。

--- a/projects/fabushi-project-governance/management/tasks/FPG-005-pr-main-serialization.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-005-pr-main-serialization.md
@@ -1,9 +1,10 @@
-# FPG-005 — PR-to-main serialization gate
+# FPG-005 — Parallel PR execution with PR-to-main completion gate
 
 - Project ID: `FAB-P0002`
 - Project Key: `FPG`
 - Task ID: `FPG-005`
-- Source: `source/2026-08-24-FPG-005-pr-main-serialization.md`
+- Original source: `source/2026-08-24-FPG-005-pr-main-serialization.md`
+- Clarification source: `source/2026-08-24-FPG-005-parallel-pr-clarification.md`
 - Status: `in-progress`
 - Started: `2026-08-24`
 - Updated: `2026-08-24`
@@ -11,57 +12,75 @@
 
 ## Objective
 
-Make repository task execution serial at the PR completion boundary: the current task PR must pass required gates, merge to canonical `main`, and be verified on `main` before another independent PR task may begin or advance.
+Allow independent Fabushi repository tasks/PRs to proceed in parallel, including while another PR is waiting on CI/review/merge queue, while enforcing a strict **per-task completion gate**: before any individual task is marked or reported complete, that task's own PR must pass required gates, merge to canonical `main`, and be verified on `main`.
+
+## Requirement evolution
+
+The initial FPG-005 interpretation made task/PR execution strictly serial. The user then explicitly clarified that waiting on one PR must not block work on other tasks. The latest requirement therefore supersedes only the strict-serialization interpretation while preserving the original merge-before-task-completion requirement.
 
 ## In scope
 
-- root `AGENTS.md` hard gate;
-- durable source requirement;
+- root `AGENTS.md` parallel-work + per-task PR-to-main completion gate;
+- durable original requirement plus later clarification source;
 - WBS and acceptance traceability;
 - status/changelog evidence;
-- protected PR merge and canonical-main readback.
+- protected PR merge and canonical-main readback for this correction.
 
 ## Out of scope
 
 - changing GitHub branch protection settings;
-- implementing a new CI bot to auto-block PR creation;
-- emergency incident policy redesign.
+- limiting the number of simultaneously active PRs;
+- implementing a new CI bot for concurrency control;
+- redesigning project scheduling/priority policy.
 
 ## Acceptance criteria
 
-1. `AGENTS.md` explicitly prohibits starting/advancing the next independent PR task while the current task PR remains unmerged.
-2. Completion sequence is explicit: acceptance checks -> required review/CI -> protected merge -> canonical-main verification -> next PR task.
-3. Pending/failed current PR remains `in-progress`/`blocked`/`failed` rather than being bypassed.
-4. Narrow emergency exception requires explicit authorization/policy and durable record.
-5. This governance change itself is merged to `main` and verified there before FPG-005 is marked passed.
+1. `AGENTS.md` explicitly allows creating, switching to, implementing, and advancing independent tasks/PRs while another PR is waiting on CI/review/branch protection/merge queue.
+2. Parallel work does not allow a pending PR to be abandoned; every task retains its own durable status, PR/CI evidence, blockers, and next action.
+3. Before an individual task is marked `passed` / `completed` or reported finished, that task's own PR must be actively driven through required review/CI/protected merge, merged to canonical `main`, and verified by canonical-main readback.
+4. If a task's PR cannot yet merge, that task remains `in-progress`, `blocked`, or `failed`, but other independent tasks may continue in parallel.
+5. This FPG-005 correction itself must pass required checks, protected merge, and canonical-main verification before FPG-005 is marked passed.
 
 ## Verification
 
 - GitHub PR diff review;
 - required GitHub Actions checks;
-- protected merge result;
+- protected merge/merge-queue result;
 - post-merge fetch of canonical `main` `AGENTS.md` and project records.
 
-## Branch / commit / PR
+## Branch / commit / PR evidence
 
+### Initial interpretation
 - Branch: `governance/fpg-005-pr-main-serialization`
 - Initial source commit: `6209e77a50ebfc889a2234ec3fb53df3169e7d6b`
-- AGENTS commit: `de50a82a734d2fb49ec0538c46e8b409c29d41c6`
-- PR: pending
+- Initial AGENTS commit: `de50a82a734d2fb49ec0538c46e8b409c29d41c6`
+- PR: `#2076`
+- PR result: merged to `main`
+- Merge commit: `3ac9f841b4d5d1b2e9972c6ddbb661199260910b`
+- Finding: implementation was too strict because it prohibited parallel work while a PR waited.
+
+### Corrected interpretation
+- Branch: `governance/fpg-005-parallel-closure-gate`
+- Corrected AGENTS commit: `20b8636e613c3f6918a99a8b2175e0c367a36130`
+- Clarification source commit: `6be18160f1c69402214bbef17a274ceca6507220`
+- Correction PR: pending
 
 ## Implementation summary
 
-Added root `AGENTS.md` section `1B. CRITICAL: PR-to-main serialization gate` and reinforced the same constraint in implementation/completion rules. Captured the user requirement as a durable source record.
+Root `AGENTS.md` now defines parallelism as normal: multiple independent tasks/PRs may advance concurrently, especially during CI/review/merge waits. The strict rule is moved to the completion boundary: each task must return to its own PR, resolve blockers where possible, merge through protected `main`, and verify canonical `main` before that task can be declared finished.
 
 ## Evidence
 
-Pending PR/check/merge/main evidence.
+- Initial PR #2076 merged, proving the first interpretation reached `main`.
+- User clarification recorded separately without rewriting source history.
+- Corrected branch contains updated root `AGENTS.md` and project traceability.
+- Required CI / correction PR / final merge / canonical-main evidence: pending.
 
 ## Blockers / risks
 
-- Existing unrelated open PRs predate this rule and are not retroactively rewritten by this task.
-- This task itself must not be marked complete before merge + main verification.
+- Until the correction PR merges, canonical `main` still contains the over-serial interpretation from #2076.
+- Parallel work increases the need to keep each active task's branch/PR/evidence state distinct and current.
 
 ## Next action
 
-Update governance WBS/acceptance/status/changelog, open PR, inspect required checks, merge, and verify canonical `main`.
+Update WBS/acceptance/status/changelog to the clarified rule, open the correction PR, enable/enter the protected merge process, inspect required checks, merge, and verify canonical `main` before closing FPG-005.

--- a/projects/fabushi-project-governance/management/tasks/FPG-005-pr-main-serialization.md
+++ b/projects/fabushi-project-governance/management/tasks/FPG-005-pr-main-serialization.md
@@ -63,7 +63,10 @@ The initial FPG-005 interpretation made task/PR execution strictly serial. The u
 - Branch: `governance/fpg-005-parallel-closure-gate`
 - Corrected AGENTS commit: `20b8636e613c3f6918a99a8b2175e0c367a36130`
 - Clarification source commit: `6be18160f1c69402214bbef17a274ceca6507220`
-- Correction PR: pending
+- Correction PR: `#2077`
+- Required checks: pending
+- Protected merge: pending
+- Canonical-main readback: pending
 
 ## Implementation summary
 
@@ -74,13 +77,14 @@ Root `AGENTS.md` now defines parallelism as normal: multiple independent tasks/P
 - Initial PR #2076 merged, proving the first interpretation reached `main`.
 - User clarification recorded separately without rewriting source history.
 - Corrected branch contains updated root `AGENTS.md` and project traceability.
-- Required CI / correction PR / final merge / canonical-main evidence: pending.
+- Correction PR #2077 is open and targets `main`.
+- Required CI / final merge / canonical-main evidence: pending.
 
 ## Blockers / risks
 
-- Until the correction PR merges, canonical `main` still contains the over-serial interpretation from #2076.
+- Until PR #2077 merges, canonical `main` still contains the over-serial interpretation from #2076.
 - Parallel work increases the need to keep each active task's branch/PR/evidence state distinct and current.
 
 ## Next action
 
-Update WBS/acceptance/status/changelog to the clarified rule, open the correction PR, enable/enter the protected merge process, inspect required checks, merge, and verify canonical `main` before closing FPG-005.
+Drive PR #2077 through required checks and the protected merge queue, merge it to `main`, then verify canonical `main` before closing FPG-005.

--- a/projects/fabushi-project-governance/source/2026-08-24-FPG-005-parallel-pr-clarification.md
+++ b/projects/fabushi-project-governance/source/2026-08-24-FPG-005-parallel-pr-clarification.md
@@ -1,0 +1,30 @@
+# FPG-005 澄清：允许并行任务，PR 合并是任务完成门禁
+
+日期：2026-08-24
+来源：用户对 FPG-005 的明确澄清
+项目：FAB-P0002 / FPG / Fabushi Project Governance
+
+## 用户澄清
+
+可以并行处理多个任务。在某个 PR 等待 CI、review 或 merge queue 的过程中，可以继续处理其他任务。要求不是“上一 PR 未合并就不能开始下一任务”，而是：**每一个任务在结束/宣告完成之前，必须回到该任务，把它自己的 PR 推进并合并到 `main`，并确认 `main` 已经包含该结果。**
+
+## 对原 FPG-005 的修正
+
+1. 删除“当前存在未合并 PR 时禁止开始/推进其他独立 PR 任务”的串行限制。
+2. 明确允许多个独立任务、分支和 PR 并行推进。
+3. 某个 PR 等待 required CI、review、branch protection 或 merge queue 时，可以切换去处理其他任务。
+4. 并行不等于遗忘：每个任务必须保持独立 task record、PR/CI/阻塞状态和下一步动作。
+5. 在某个任务被标记 `passed` / `completed` 或对用户宣告“已完成”之前，必须主动回到该任务并推进它自己的 PR：处理失败/冲突/review，完成 required checks，进入受保护 merge 流程并合并到 canonical `main`。
+6. merge 后必须从 canonical `main` 回读验证关键结果。PR 只是 open/approved/green/queued/pushed 都不能作为任务完成证据。
+7. 如果该任务的 PR 仍无法合并，则该任务继续保持 `in-progress` / `blocked` / `failed`；这不阻止其他独立任务继续并行。
+
+## 生效关系
+
+本文件是用户对 `2026-08-24-FPG-005-pr-main-serialization.md` 中“严格串行”解释的后续澄清。按照项目 Source of Truth precedence，最新明确用户要求优先，因此 FPG-005 应实现“parallel execution + strict per-task PR-to-main closure gate”。
+
+## 验收
+
+- 根 `AGENTS.md` 明确允许等待 PR 期间推进其他任务。
+- 根 `AGENTS.md` 明确每个任务结束前仍必须将其 PR 推进合并到 `main` 并回读验证。
+- FPG-005 task/WBS/acceptance/status/changelog 与此澄清一致。
+- 修正 PR 通过 required checks、受保护合并并从 canonical `main` 验证后，FPG-005 才可关闭。


### PR DESCRIPTION
## FAB-P0002 / FPG-005 correction

This corrects the over-serial interpretation merged in #2076 after the user's explicit clarification.

### Correct rule
- Independent tasks and PRs may proceed in parallel.
- Waiting on CI, review, branch protection, or merge queue for one PR does **not** block work on other tasks.
- Parallel work does not mean abandoning pending PRs; each task keeps its own durable state/evidence.
- Before an individual task is marked or reported complete, that task's own PR must be actively driven through required gates, merged to canonical `main`, and verified by reading back `main`.
- If that PR is still blocked, that task remains `in-progress` / `blocked` / `failed`, while other independent tasks may continue.

### Durable records
- root `AGENTS.md` §1B corrected from serialization gate to per-task completion gate
- new clarification source preserving original history
- FPG-005 task/WBS/acceptance/status/changelog aligned to the corrected semantics

### Acceptance
This correction is not complete until required checks pass, the PR merges through protected-main/merge queue, and canonical `main` is read back to confirm the corrected rule.