### PR TITLE
feat(desktop): Telegram local-first startup and settings

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -176,6 +176,60 @@ test('desktop Messenger unifies Telegram-class navigation with Fabushi agent ide
   }
 });
 
+test('Telegram-inspired settings bind supported preferences and persist fast-start projection', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-settings-e2e-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    await openMessenger(page);
+
+    await page.getByTestId('profile-navigation-trigger').click();
+    await page.getByTitle('设置', { exact: true }).click();
+    await expect(page.getByTestId('telegram-settings-navigation')).toBeVisible();
+    await expect(page.getByTestId('telegram-settings-workspace')).toBeVisible();
+
+    for (const category of ['account', 'notifications', 'privacy', 'data', 'chat', 'folders', 'devices', 'calls', 'language', 'advanced', 'fabushi']) {
+      await expect(page.getByTestId(`settings-category-${category}`)).toBeVisible();
+    }
+
+    await page.getByTestId('settings-category-chat').click();
+    await expect(page.getByText('Enter 发送消息')).toBeVisible();
+    await expect(page.getByText('显示资料侧栏')).toBeVisible();
+    await expect(page.getByText('减少动态效果')).toBeVisible();
+    await page.getByTestId('settings-toggle-reduced-motion').check();
+    await expect(page.getByTestId('messenger-workspace')).toHaveAttribute('data-reduce-motion', 'true');
+
+    const preferences = await page.evaluate(() => JSON.parse(localStorage.getItem('fabushi.desktop.telegram-settings.v1') || '{}'));
+    expect(preferences.reducedMotion).toBe(true);
+
+    await page.getByTestId('profile-navigation-trigger').click();
+    await page.getByTitle('聊天', { exact: true }).click();
+    await page.getByRole('button', { name: '新建', exact: true }).click();
+    await page.getByRole('button', { name: '新建频道' }).click();
+    await page.getByPlaceholder('频道名称').fill('本地优先投影验收');
+    await page.getByPlaceholder('频道简介').fill('Telegram-style local-first');
+    await page.getByRole('button', { name: '创建频道' }).click();
+    const channelPeer = page.locator('[data-testid^="peer-selfhosted:channel:"]').filter({ hasText: '本地优先投影验收' }).first();
+    await expect(channelPeer).toBeVisible();
+    await channelPeer.click();
+
+    await expect.poll(async () => page.evaluate(() => {
+      const projection = JSON.parse(localStorage.getItem('fabushi.desktop.messenger-projection.v1') || 'null');
+      return Boolean(projection?.activePeerKey?.startsWith('selfhosted:') && projection?.selfConversations?.some((item: { title?: string }) => item.title === '本地优先投影验收'));
+    }), { timeout: 5_000 }).toBe(true);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('messenger-workspace')).toHaveAttribute('data-testid-ready-projection', 'true');
+    await expect(page.getByText('本地优先投影验收').first()).toBeVisible();
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});
+
 test('desktop Messenger creates a self-hosted channel and executes message mutation commands', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-channel-e2e-'));
   const app = await launchDesktopApp(appDataDir);

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -145,6 +145,26 @@ type EditDialogState = { conversationId: string; messageId: string; originalText
 type InvoiceDialogState = { conversationId: string; title: string; amount: string } | null;
 type InfoTab = 'media' | 'files' | 'links';
 type SearchCategory = 'chats' | 'channels' | 'apps' | 'posts' | 'images' | 'videos' | 'downloads' | 'links' | 'files' | 'music' | 'audio';
+type SettingsCategory = 'account' | 'notifications' | 'privacy' | 'data' | 'chat' | 'folders' | 'devices' | 'calls' | 'language' | 'advanced' | 'fabushi';
+
+type DesktopMessengerPreferences = {
+  showInfoPanel: boolean;
+  messagePreview: boolean;
+  autoPlayMedia: boolean;
+  enterToSend: boolean;
+  reducedMotion: boolean;
+};
+
+type MessengerProjection = {
+  version: 1;
+  savedAtMs: number;
+  actorId?: string;
+  cursor?: string | null;
+  activePeerKey?: string | null;
+  selfActors: MessagingActor[];
+  selfConversations: MessagingConversation[];
+  selfMessages: Record<string, MessagingMessage[]>;
+};
 
 const searchCategories: ReadonlyArray<{ id: SearchCategory; label: string }> = [
   { id: 'chats', label: '聊天' },
@@ -163,8 +183,51 @@ const searchCategories: ReadonlyArray<{ id: SearchCategory; label: string }> = [
 const messengerSettingsKey = 'fabushi.desktop.messenger-settings.v2';
 const messengerDraftsKey = 'fabushi.desktop.messenger-drafts.v2';
 const messengerSidebarWidthKey = 'fabushi.desktop.sidebar-width.v3';
+const messengerProjectionKey = 'fabushi.desktop.messenger-projection.v1';
+const messengerPreferencesKey = 'fabushi.desktop.telegram-settings.v1';
 const initialPeerRenderCount = 120;
 const initialMessageRenderCount = 240;
+const initialSyncLimit = 20;
+const backgroundSyncLimit = 100;
+const projectionConversationLimit = 80;
+const projectionMessageLimit = 80;
+
+const defaultDesktopMessengerPreferences: DesktopMessengerPreferences = {
+  showInfoPanel: true,
+  messagePreview: true,
+  autoPlayMedia: false,
+  enterToSend: true,
+  reducedMotion: false,
+};
+
+function readMessengerProjection(): MessengerProjection | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(messengerProjectionKey) || 'null') as MessengerProjection | null;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.selfConversations) || !parsed.selfMessages) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function readDesktopMessengerPreferences(): DesktopMessengerPreferences {
+  if (typeof window === 'undefined') return defaultDesktopMessengerPreferences;
+  try {
+    const stored = JSON.parse(window.localStorage.getItem(messengerPreferencesKey) || '{}') as Partial<DesktopMessengerPreferences>;
+    return { ...defaultDesktopMessengerPreferences, ...stored };
+  } catch {
+    return defaultDesktopMessengerPreferences;
+  }
+}
+
+function persistMessengerProjection(projection: MessengerProjection): void {
+  try {
+    window.localStorage.setItem(messengerProjectionKey, JSON.stringify(projection));
+  } catch {
+    // Fast-start projection is best effort; Rust SQLite remains authoritative.
+  }
+}
 
 function createTransport(): MahayanaHostTransport {
   if (isElectronMahayanaHostAvailable()) return new ElectronMahayanaHostTransport();
@@ -320,6 +383,7 @@ function upsertById<T extends { id: string }>(items: T[], item: T): T[] {
 
 export default function DesktopShellV2() {
   const authTransport = useMemo(() => createTransport(), []);
+  const [hasReturningProjection] = useState(() => Boolean(readMessengerProjection()));
   const [authenticated, setAuthenticated] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -345,24 +409,26 @@ export default function DesktopShellV2() {
     };
   }, [authTransport]);
 
+  const showMessenger = authenticated === true || (authenticated === null && hasReturningProjection);
   return (
-    <div className={styles.desktopRoot} data-testid="desktop-shell">
-      {authenticated === true ? <MessengerWorkspace /> : <HostClient />}
+    <div className={styles.desktopRoot} data-testid="desktop-shell" data-local-first={showMessenger && authenticated === null ? 'true' : undefined}>
+      {showMessenger ? <MessengerWorkspace /> : <HostClient />}
     </div>
   );
 }
 
 function MessengerWorkspace() {
   const transport = useMemo(() => createTransport(), []);
-  const selfHosted = useMemo(() => new SelfHostedMessagingClientV2(transport), [transport]);
+  const startupProjection = useMemo(() => readMessengerProjection(), []);
+  const selfHosted = useMemo(() => new SelfHostedMessagingClientV2(transport, { actorId: startupProjection?.actorId }), [transport, startupProjection]);
   const [hostReady, setHostReady] = useState(false);
   const [section, setSection] = useState<MessengerSection>('chats');
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [bots, setBots] = useState<BotSummary[]>([]);
   const [groups, setGroups] = useState<GroupSummary[]>([]);
-  const [selfActors, setSelfActors] = useState<MessagingActor[]>([]);
-  const [selfConversations, setSelfConversations] = useState<MessagingConversation[]>([]);
-  const [selfMessages, setSelfMessages] = useState<Record<string, MessagingMessage[]>>({});
+  const [selfActors, setSelfActors] = useState<MessagingActor[]>(startupProjection?.selfActors ?? []);
+  const [selfConversations, setSelfConversations] = useState<MessagingConversation[]>(startupProjection?.selfConversations ?? []);
+  const [selfMessages, setSelfMessages] = useState<Record<string, MessagingMessage[]>>(startupProjection?.selfMessages ?? {});
   const [selfStories, setSelfStories] = useState<MessagingStory[]>([]);
   const [selfCommunities, setSelfCommunities] = useState<MessagingCommunityState[]>([]);
   const [selfBotProfiles, setSelfBotProfiles] = useState<MessagingBotProfile[]>([]);
@@ -373,7 +439,7 @@ function MessengerWorkspace() {
   const [selfOrders, setSelfOrders] = useState<MessagingOrder[]>([]);
   const [walletAccount, setWalletAccount] = useState<MessagingWalletAccount | null>(null);
   const [walletEntries, setWalletEntries] = useState<MessagingLedgerEntry[]>([]);
-  const [activePeerKey, setActivePeerKey] = useState<string | null>(null);
+  const [activePeerKey, setActivePeerKey] = useState<string | null>(startupProjection?.activePeerKey ?? null);
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [composer, setComposer] = useState('');
   const [drafts, setDrafts] = useState<Record<string, string>>({});
@@ -391,7 +457,10 @@ function MessengerWorkspace() {
   const [desktopUpdateBusy, setDesktopUpdateBusy] = useState(false);
   const [peerRenderCount, setPeerRenderCount] = useState(initialPeerRenderCount);
   const [messageRenderCount, setMessageRenderCount] = useState(initialMessageRenderCount);
-  const [infoOpen, setInfoOpen] = useState(true);
+  const [desktopPreferences, setDesktopPreferences] = useState<DesktopMessengerPreferences>(() => readDesktopMessengerPreferences());
+  const [settingsCategory, setSettingsCategory] = useState<SettingsCategory>('account');
+  const [infoOpen, setInfoOpen] = useState(() => readDesktopMessengerPreferences().showInfoPanel);
+  const [wideInfoLayout, setWideInfoLayout] = useState(() => typeof window === 'undefined' ? true : window.innerWidth > 1280);
   const [infoTab, setInfoTab] = useState<InfoTab>('media');
   const [pendingSend, setPendingSend] = useState(false);
   const [typingByConversation, setTypingByConversation] = useState<Record<string, Record<string, number>>>({});
@@ -415,7 +484,7 @@ function MessengerWorkspace() {
   const [pinnedPeerKeys, setPinnedPeerKeys] = useState<Set<string>>(() => new Set());
   const [archivedPeerKeys, setArchivedPeerKeys] = useState<Set<string>>(() => new Set());
   const activePeerKeyRef = useRef<string | null>(null);
-  const messagingCursorRef = useRef<string | null>(null);
+  const messagingCursorRef = useRef<string | null>(startupProjection?.cursor ?? null);
   const syncInFlightRef = useRef(false);
   const typingStopTimerRef = useRef<number | null>(null);
   const peersRef = useRef<PeerItem[]>([]);
@@ -430,6 +499,63 @@ function MessengerWorkspace() {
   useEffect(() => {
     activePeerKeyRef.current = activePeerKey;
   }, [activePeerKey]);
+
+  useEffect(() => {
+    const onResize = () => setWideInfoLayout(window.innerWidth > 1280);
+    onResize();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(messengerPreferencesKey, JSON.stringify(desktopPreferences));
+    } catch {
+      // Desktop-only preferences are best effort.
+    }
+  }, [desktopPreferences]);
+
+  useEffect(() => {
+    if (!startupProjection?.activePeerKey?.startsWith('selfhosted:')) return;
+    const conversationId = startupProjection.activePeerKey.slice('selfhosted:'.length);
+    const cached = (startupProjection.selfMessages[conversationId] ?? []).filter((message) => !message.deleted);
+    setMessages(cached.map(displaySelfMessage));
+  }, [startupProjection]);
+
+  useEffect(() => {
+    if (!selfConversations.length && !selfActors.length) return;
+    const timer = window.setTimeout(() => {
+      const conversationIds = new Set(
+        [...selfConversations]
+          .sort((left, right) => right.updatedAtMs - left.updatedAtMs)
+          .slice(0, projectionConversationLimit)
+          .map((conversation) => conversation.id),
+      );
+      const boundedMessages = Object.fromEntries(
+        Object.entries(selfMessages)
+          .filter(([conversationId]) => conversationIds.has(conversationId))
+          .map(([conversationId, list]) => [conversationId, list.slice(-projectionMessageLimit)]),
+      );
+      persistMessengerProjection({
+        version: 1,
+        savedAtMs: Date.now(),
+        actorId: selfHosted.actorId,
+        cursor: messagingCursorRef.current,
+        activePeerKey,
+        selfActors,
+        selfConversations: [...selfConversations]
+          .sort((left, right) => right.updatedAtMs - left.updatedAtMs)
+          .slice(0, projectionConversationLimit),
+        selfMessages: boundedMessages,
+      });
+    }, 180);
+    return () => window.clearTimeout(timer);
+  }, [activePeerKey, selfActors, selfConversations, selfMessages, selfHosted.actorId]);
+
+  function updateDesktopPreference<K extends keyof DesktopMessengerPreferences>(key: K, value: DesktopMessengerPreferences[K]) {
+    setDesktopPreferences((current) => ({ ...current, [key]: value }));
+    if (key === 'showInfoPanel') setInfoOpen(Boolean(value));
+  }
 
   useEffect(() => {
     const stored = Number(window.localStorage.getItem(messengerSidebarWidthKey));
@@ -581,7 +707,7 @@ function MessengerWorkspace() {
         refreshLegacy();
         try {
           await selfHosted.ensureCurrentActor();
-          await selfHosted.sync();
+          await selfHosted.sync(initialSyncLimit, messagingCursorRef.current);
           void webRtcRef.current?.connect().catch(() => {});
         } catch (cause) {
           setError(cause instanceof Error ? cause.message : String(cause));
@@ -623,7 +749,7 @@ function MessengerWorkspace() {
       });
       if (syncInFlightRef.current) return;
       syncInFlightRef.current = true;
-      void selfHosted.sync(1000, messagingCursorRef.current)
+      void selfHosted.sync(backgroundSyncLimit, messagingCursorRef.current)
         .catch(() => {})
         .finally(() => { syncInFlightRef.current = false; });
     }, 2_000);
@@ -676,6 +802,7 @@ function MessengerWorkspace() {
   function handleSelfHostedEvent(runtimeEvent: RuntimeEvent): boolean {
     const hostEvent = asMessagingHostEvent(runtimeEvent);
     if (!hostEvent) return false;
+    const previousCursor = messagingCursorRef.current;
     if (hostEvent.envelope.cursor) messagingCursorRef.current = hostEvent.envelope.cursor;
     const event = hostEvent.envelope.event;
     switch (event.type) {
@@ -691,26 +818,32 @@ function MessengerWorkspace() {
           bots?: MessagingBotProfile[];
           botExecutions?: MessagingBotExecution[];
         };
-        const nextConversations = payload.conversations ?? [];
         const grouped: Record<string, MessagingMessage[]> = {};
         for (const message of payload.messages ?? []) {
           (grouped[message.conversationId] ??= []).push(message);
         }
         for (const list of Object.values(grouped)) list.sort((a, b) => a.createdAtMs - b.createdAtMs);
-        setSelfActors(payload.actors ?? []);
-        setSelfConversations(nextConversations);
-        setSelfMessages(grouped);
-        setSelfInvoices(payload.invoices ?? []);
-        setSelfOrders(payload.orders ?? []);
-        setSelfStories(payload.stories ?? []);
-        setSelfCommunities(payload.communities ?? []);
-        setSelfBotProfiles(payload.bots ?? []);
-        setSelfBotExecutions(payload.botExecutions ?? []);
-        const active = activePeerKeyRef.current;
-        if (active?.startsWith('selfhosted:')) {
-          const conversationId = active.slice('selfhosted:'.length);
-          setMessages((grouped[conversationId] ?? []).filter((message) => !message.deleted).map(displaySelfMessage));
-        }
+        setSelfActors((current) => (payload.actors ?? []).reduce((items, actor) => upsertById(items, actor), previousCursor ? current : []));
+        setSelfConversations((current) => (payload.conversations ?? []).reduce((items, conversation) => upsertById(items, conversation), previousCursor ? current : []));
+        setSelfMessages((current) => {
+          const next = previousCursor ? { ...current } : {};
+          for (const [conversationId, incoming] of Object.entries(grouped)) {
+            next[conversationId] = incoming.reduce((items, message) => upsertById(items, message), next[conversationId] ?? [])
+              .sort((a, b) => a.createdAtMs - b.createdAtMs);
+          }
+          const active = activePeerKeyRef.current;
+          if (active?.startsWith('selfhosted:')) {
+            const conversationId = active.slice('selfhosted:'.length);
+            setMessages((next[conversationId] ?? []).filter((message) => !message.deleted).map(displaySelfMessage));
+          }
+          return next;
+        });
+        setSelfInvoices((current) => (payload.invoices ?? []).reduce((items, item) => upsertById(items, item), previousCursor ? current : []));
+        setSelfOrders((current) => (payload.orders ?? []).reduce((items, item) => upsertById(items, item), previousCursor ? current : []));
+        setSelfStories((current) => (payload.stories ?? []).reduce((items, item) => upsertById(items, item), previousCursor ? current : []));
+        setSelfCommunities((current) => (payload.communities ?? []).reduce((items, item) => [...items.filter((existing) => existing.conversationId !== item.conversationId), item], previousCursor ? current : []));
+        setSelfBotProfiles((current) => (payload.bots ?? []).reduce((items, item) => [...items.filter((existing) => existing.actorId !== item.actorId), item], previousCursor ? current : []));
+        setSelfBotExecutions((current) => (payload.botExecutions ?? []).reduce((items, item) => upsertById(items, item), previousCursor ? current : []));
         break;
       }
       case 'conversationChanged': {
@@ -1031,6 +1164,8 @@ function MessengerWorkspace() {
     return !query || `${peer.title} ${peer.subtitle}`.toLowerCase().includes(query);
   });
   const sectionIsPeerList = ['chats', 'contacts', 'bots', 'groups', 'channels', 'saved', 'archive'].includes(section);
+  const infoPanelVisible = Boolean(infoOpen && wideInfoLayout && activePeer && sectionIsPeerList);
+  const currentActor = selfActors.find((actor) => actor.id === selfHosted.actorId);
   const renderedPeers = visiblePeers.slice(0, peerRenderCount);
   const matchingMessages = messages;
   const renderedMessages = matchingMessages.slice(Math.max(0, matchingMessages.length - messageRenderCount));
@@ -1692,7 +1827,9 @@ async function saveInvoiceDialog() {
       className={`${styles.messenger} ${styles.fabushiUnified}`}
       data-testid="messenger-workspace"
       data-sidebar-collapsed={sidebarWidth <= 112 || undefined}
-      style={{ gridTemplateColumns: infoOpen && activePeer && sectionIsPeerList ? `${sidebarWidth}px minmax(420px,1fr) 286px` : `${sidebarWidth}px minmax(420px,1fr)` }}
+      data-reduce-motion={desktopPreferences.reducedMotion || undefined}
+      data-testid-ready-projection={startupProjection ? 'true' : undefined}
+      style={{ gridTemplateColumns: infoPanelVisible ? `${sidebarWidth}px minmax(420px,1fr) 286px` : `${sidebarWidth}px minmax(420px,1fr)` }}
       onClick={() => { setMessageMenu(null); setProfileMenuOpen(false); setCreateMenuOpen(false); }}
     >
       <aside className={styles.chatList} data-testid="messenger-sidebar" data-collapsed={sidebarWidth <= 112 || undefined} onClick={(event) => event.stopPropagation()}>
@@ -1762,7 +1899,7 @@ async function saveInvoiceDialog() {
                 />
                 <span className={styles.peerCopy}>
                   <span><strong>{peer.title}</strong><time>{formatTime(peer.updatedAtMs)}</time></span>
-                  <small>{peer.subtitle}</small>
+                  <small>{desktopPreferences.messagePreview ? peer.subtitle : peer.unread ? '有新消息' : '消息预览已关闭'}</small>
                 </span>
                 <span className={styles.peerMeta}>{peer.pinned ? <Pin size={12} /> : null}{mutedPeerKeys.has(peer.key) ? <BellOff size={12} /> : null}{peer.unread ? <b>{peer.unread}</b> : null}</span>
               </button>
@@ -1771,7 +1908,7 @@ async function saveInvoiceDialog() {
             {!visiblePeers.length ? <EmptyList section={section} /> : null}
           </div>
         ) : (
-          <SectionPanel section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} />
+          <SectionPanel section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} settings={{ category: settingsCategory, onCategory: setSettingsCategory }} />
         )}
         <div className={styles.sidebarFooter}>
           {profileMenuOpen ? <ProfileNavigationMenu section={section} onNavigate={navigateFromProfile} /> : null}
@@ -1856,7 +1993,7 @@ async function saveInvoiceDialog() {
                 >
                   {message.pinned ? <Pin size={11} /> : null}
                   {message.mediaType === 'photo' && blobMediaUrl(message.media) ? <img className={extra.messageMedia} src={blobMediaUrl(message.media)} alt={message.media?.fileName ?? '图片'} /> : null}
-                  {message.mediaType === 'video' && blobMediaUrl(message.media) ? <video className={extra.messageMedia} controls playsInline src={blobMediaUrl(message.media)} /> : null}
+                  {message.mediaType === 'video' && blobMediaUrl(message.media) ? <video className={extra.messageMedia} controls playsInline autoPlay={desktopPreferences.autoPlayMedia} src={blobMediaUrl(message.media)} /> : null}
                   {message.mediaType === 'document' && blobMediaUrl(message.media) ? <a className={extra.messageFile} href={blobMediaUrl(message.media)} download={message.media?.fileName}><FileText size={17} />{message.media?.fileName ?? '文件'}</a> : null}
                   <p>{message.text}</p>
                   {message.reactions?.length ? <div className={extra.reactions}>{message.reactions.map((reaction) => <span key={reaction}>{reaction}</span>)}</div> : null}
@@ -1879,18 +2016,22 @@ async function saveInvoiceDialog() {
               <input ref={mediaInputRef} type="file" accept="image/*,video/*" hidden onChange={(event) => { const file = event.currentTarget.files?.[0]; event.currentTarget.value = ''; if (file) void sendAttachmentFile(file); }} />
               <input ref={fileInputRef} type="file" hidden onChange={(event) => { const file = event.currentTarget.files?.[0]; event.currentTarget.value = ''; if (file) void sendAttachmentFile(file); }} />
               {attachmentProgress ? <span className={extra.uploadProgress}>{attachmentProgress}</span> : null}
-              <textarea data-testid="messenger-input" value={composer} onChange={(event) => updateComposer(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); event.currentTarget.form?.requestSubmit(); } }} placeholder="消息" rows={1} />
+              <textarea data-testid="messenger-input" value={composer} onChange={(event) => updateComposer(event.target.value)} onKeyDown={(event) => {
+                const submitWithEnter = desktopPreferences.enterToSend && event.key === 'Enter' && !event.shiftKey;
+                const submitWithShortcut = !desktopPreferences.enterToSend && event.key === 'Enter' && (event.metaKey || event.ctrlKey);
+                if (submitWithEnter || submitWithShortcut) { event.preventDefault(); event.currentTarget.form?.requestSubmit(); }
+              }} placeholder="消息" rows={1} />
               <button type="button" title="表情"><Smile size={20} /></button>
               <button type="button" data-active={silentSend} title={silentSend ? '关闭静默发送' : '静默发送'} onClick={() => setSilentSend((value) => !value)}><BellOff size={19} /></button>
               {composer.trim() ? <button data-testid="messenger-send" className={styles.sendButton} type="submit" disabled={!hostReady || pendingSend}><Send size={19} /></button> : <button type="button" title="语音消息"><Mic size={20} /></button>}
             </form>
           </>
         ) : (
-          <FeatureWorkspace section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} />
+          <FeatureWorkspace section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} settings={{ category: settingsCategory, onCategory: setSettingsCategory, preferences: desktopPreferences, onPreference: updateDesktopPreference, actor: currentActor, actorId: selfHosted.actorId }} />
         )}
       </section>
 
-      {infoOpen && activePeer && sectionIsPeerList ? (
+      {infoPanelVisible && activePeer ? (
         <aside className={styles.infoPanel}>
           <header><strong>资料</strong><button type="button" onClick={() => setInfoOpen(false)}><X size={17} /></button></header>
           <div className={styles.profileCard}>
@@ -2349,17 +2490,102 @@ function MiniAppMarketplaceWorkspace(props: MiniAppMarketplaceProps) {
   </div>;
 }
 
-function SectionPanel({ section, onInvoice, payment, onRefund, ...miniAppProps }: { section: MessengerSection; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void } & MiniAppMarketplaceProps) {
+type SettingsNavigationProps = {
+  category: SettingsCategory;
+  onCategory: (category: SettingsCategory) => void;
+};
+
+type SettingsWorkspaceProps = SettingsNavigationProps & {
+  preferences: DesktopMessengerPreferences;
+  onPreference: <K extends keyof DesktopMessengerPreferences>(key: K, value: DesktopMessengerPreferences[K]) => void;
+  actor?: MessagingActor;
+  actorId: string;
+};
+
+const settingsNavigationItems: ReadonlyArray<{ id: SettingsCategory; label: string; subtitle: string; glyph: string }> = [
+  { id: 'account', label: '我的资料', subtitle: '头像、姓名、用户名', glyph: '👤' },
+  { id: 'notifications', label: '通知与声音', subtitle: '通知、预览与静音', glyph: '🔔' },
+  { id: 'privacy', label: '隐私与安全', subtitle: '屏蔽、密码、隐私控制', glyph: '🔒' },
+  { id: 'data', label: '数据与存储', subtitle: '下载、缓存与媒体', glyph: '💾' },
+  { id: 'chat', label: '聊天设置', subtitle: '外观、发送与动画', glyph: '💬' },
+  { id: 'folders', label: '聊天文件夹', subtitle: '组织会话', glyph: '📁' },
+  { id: 'devices', label: '设备', subtitle: '活动会话与登录设备', glyph: '💻' },
+  { id: 'calls', label: '通话', subtitle: '麦克风、摄像头与网络', glyph: '📞' },
+  { id: 'language', label: '语言', subtitle: '界面与翻译语言', glyph: '🌐' },
+  { id: 'advanced', label: '高级', subtitle: '网络、更新与系统集成', glyph: '⚙️' },
+  { id: 'fabushi', label: 'AI 与 Mini Apps', subtitle: 'Fabushi 原生能力', glyph: '✦' },
+];
+
+function SettingsNavigation({ category, onCategory }: SettingsNavigationProps) {
+  return <div className={styles.settingsNavigation} data-testid="telegram-settings-navigation">
+    {settingsNavigationItems.map((item) => <button key={item.id} type="button" data-testid={`settings-category-${item.id}`} data-active={category === item.id} onClick={() => onCategory(item.id)}>
+      <span>{item.glyph}</span><div><strong>{item.label}</strong><small>{item.subtitle}</small></div>
+    </button>)}
+  </div>;
+}
+
+function SettingsToggleRow({ title, description, checked, onChange, testId }: { title: string; description: string; checked: boolean; onChange: (checked: boolean) => void; testId?: string }) {
+  return <label className={styles.settingsRow}><div><strong>{title}</strong><small>{description}</small></div><input data-testid={testId} type="checkbox" role="switch" checked={checked} onChange={(event) => onChange(event.target.checked)} /></label>;
+}
+
+function SettingsPlannedRow({ title, description }: { title: string; description: string }) {
+  return <div className={`${styles.settingsRow} ${styles.settingsRowDisabled}`}><div><strong>{title}</strong><small>{description}</small></div><em>后端接入中</em></div>;
+}
+
+function SettingsWorkspace({ category, preferences, onPreference, actor, actorId }: SettingsWorkspaceProps) {
+  const meta = settingsNavigationItems.find((item) => item.id === category)!;
+  const profileName = actor?.displayName || '当前用户';
+  return <div className={styles.settingsWorkspace} data-testid="telegram-settings-workspace">
+    <header><span className={styles.settingsGlyph}>{meta.glyph}</span><div><h2>{meta.label}</h2><p>{meta.subtitle} · 参考 Telegram Desktop 的分组方式，并绑定 Fabushi 自建能力。</p></div></header>
+    {category === 'account' ? <section className={styles.settingsGroup}>
+      <div className={styles.settingsProfile}><BotMark botId={`self:${actorId}`} state="idle" size={72} label={profileName} /><div><strong>{profileName}</strong><small>{actor?.username ? `@${actor.username}` : actorId}</small><p>{actor?.bio || 'Fabushi 统一 Actor 资料由 Rust 消息核心管理。'}</p></div></div>
+      <SettingsPlannedRow title="编辑个人资料" description="姓名、用户名、简介与头像写回 Actor Profile。" />
+      <SettingsPlannedRow title="账号与手机号" description="账号身份与恢复渠道将在统一账户服务接入后开放。" />
+    </section> : null}
+    {category === 'notifications' ? <section className={styles.settingsGroup}>
+      <SettingsToggleRow testId="settings-toggle-message-preview" title="消息预览" description="在会话列表显示最近消息摘要。" checked={preferences.messagePreview} onChange={(value) => onPreference('messagePreview', value)} />
+      <SettingsPlannedRow title="桌面通知" description="按私聊、群组和频道分别控制系统通知。" />
+      <SettingsPlannedRow title="通知声音" description="选择提示音，并支持按会话覆盖。" />
+    </section> : null}
+    {category === 'privacy' ? <section className={styles.settingsGroup}>
+      <SettingsPlannedRow title="屏蔽用户" description="查看和管理已屏蔽 Actor。" />
+      <SettingsPlannedRow title="最后上线与在线状态" description="基于 Fabushi presence ACL 控制可见范围。" />
+      <SettingsPlannedRow title="两步验证与本地锁" description="接入统一账户安全策略后启用。" />
+    </section> : null}
+    {category === 'data' ? <section className={styles.settingsGroup}>
+      <SettingsToggleRow testId="settings-toggle-autoplay-media" title="自动播放视频" description="聊天内视频加载后自动播放；默认关闭以节省资源。" checked={preferences.autoPlayMedia} onChange={(value) => onPreference('autoPlayMedia', value)} />
+      <div className={styles.settingsInfoRow}><strong>本地消息数据库</strong><small>Rust SQLite 是权威本地存储；Renderer 只保存有界快速启动投影。</small><em>已启用</em></div>
+      <SettingsPlannedRow title="自动下载媒体" description="按网络类型、会话类型和文件大小设置策略。" />
+      <SettingsPlannedRow title="存储占用" description="按媒体类型查看缓存并执行安全清理。" />
+    </section> : null}
+    {category === 'chat' ? <section className={styles.settingsGroup}>
+      <SettingsToggleRow testId="settings-toggle-info-panel" title="显示资料侧栏" description="宽屏聊天时显示右侧资料栏；窄屏自动收起且不占布局宽度。" checked={preferences.showInfoPanel} onChange={(value) => onPreference('showInfoPanel', value)} />
+      <SettingsToggleRow testId="settings-toggle-enter-send" title="Enter 发送消息" description="关闭后使用 Command/Ctrl + Enter 发送，Enter 换行。" checked={preferences.enterToSend} onChange={(value) => onPreference('enterToSend', value)} />
+      <SettingsToggleRow testId="settings-toggle-reduced-motion" title="减少动态效果" description="关闭大部分界面过渡动画，适合低功耗或辅助功能场景。" checked={preferences.reducedMotion} onChange={(value) => onPreference('reducedMotion', value)} />
+      <SettingsPlannedRow title="聊天背景与气泡" description="主题、背景、字号与消息密度将在统一主题引擎中开放。" />
+    </section> : null}
+    {category === 'folders' ? <section className={styles.settingsGroup}><SettingsPlannedRow title="聊天文件夹" description="创建、排序并共享自定义会话过滤器。" /><SettingsPlannedRow title="归档行为" description="设置新消息到来时是否自动移出归档。" /></section> : null}
+    {category === 'devices' ? <section className={styles.settingsGroup}><SettingsPlannedRow title="活动会话" description="列出已授权设备、最近活动与远程退出操作。" /><SettingsPlannedRow title="新设备登录提醒" description="设备身份系统接入后开启安全提醒。" /></section> : null}
+    {category === 'calls' ? <section className={styles.settingsGroup}><div className={styles.settingsInfoRow}><strong>通话引擎</strong><small>Fabushi 自建信令 + WebRTC，支持语音、视频与屏幕共享。</small><em>可用</em></div><SettingsPlannedRow title="输入/输出设备" description="选择麦克风、摄像头和扬声器，并进行测试。" /><SettingsPlannedRow title="点对点与 TURN 策略" description="按隐私策略选择直连或中继。" /></section> : null}
+    {category === 'language' ? <section className={styles.settingsGroup}><div className={styles.settingsInfoRow}><strong>界面语言</strong><small>当前跟随系统语言。</small><em>跟随系统</em></div><SettingsPlannedRow title="翻译语言" description="为消息翻译和 AI 翻译指定首选语言。" /></section> : null}
+    {category === 'advanced' ? <section className={styles.settingsGroup}><div className={styles.settingsInfoRow}><strong>增量同步</strong><small>首轮最多 20 条；后续基于 cursor 每批最多 100 条，避免启动大同步。</small><em>已启用</em></div><div className={styles.settingsInfoRow}><strong>应用更新</strong><small>检测到 GitHub Release 新版本后可从头像旁云朵入口下载并安装。</small><em>自动检测</em></div><SettingsPlannedRow title="代理与网络" description="支持直连、系统代理与自建代理节点。" /></section> : null}
+    {category === 'fabushi' ? <section className={styles.settingsGroup}><div className={styles.settingsInfoRow}><strong>AI Bot / Agent</strong><small>联系人、Bot、群组与频道共用 Actor/Conversation 消息模型。</small><em>已融合</em></div><div className={styles.settingsInfoRow}><strong>Mini Apps</strong><small>从在线市场搜索、验证、安装，并在受控宿主容器运行。</small><em>已融合</em></div><SettingsPlannedRow title="AI 权限中心" description="统一管理电脑控制、敏感输入、Mini App 与 Bot 权限。" /></section> : null}
+  </div>;
+}
+
+function SectionPanel({ section, onInvoice, payment, onRefund, settings, ...miniAppProps }: { section: MessengerSection; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void; settings: SettingsNavigationProps } & MiniAppMarketplaceProps) {
   if (section === 'miniapps') return <MiniAppMarketplaceList {...miniAppProps} />;
   if (section === 'payments') return <div className={styles.sectionList}><PaymentOverview payment={payment} onInvoice={onInvoice} onRefund={onRefund} compact /></div>;
   if (section === 'folders') return <div className={styles.sectionList}><div className={styles.panelHint}><Folder size={24} /><strong>聊天文件夹</strong><p>按联系人、Bot、群组、频道、未读和静音状态组织。</p></div></div>;
   if (section === 'calls') return <div className={styles.sectionList}><div className={styles.panelHint}><Phone size={24} /><strong>最近通话</strong><p>从会话顶部发起语音/视频。</p></div></div>;
+  if (section === 'settings') return <div className={styles.sectionList}><SettingsNavigation {...settings} /></div>;
   return <div className={styles.sectionList}><div className={styles.panelHint}><Settings size={24} /><strong>{sectionTitle(section)}</strong><p>该功能入口已合并进统一 Messenger。</p></div></div>;
 }
 
-function FeatureWorkspace({ section, onInvoice, payment, onRefund, ...miniAppProps }: { section: MessengerSection; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void } & MiniAppMarketplaceProps) {
+function FeatureWorkspace({ section, onInvoice, payment, onRefund, settings, ...miniAppProps }: { section: MessengerSection; onInvoice: () => void; payment: PaymentUiState; onRefund: (orderId: string) => void; settings: SettingsWorkspaceProps } & MiniAppMarketplaceProps) {
   if (section === 'miniapps') return <MiniAppMarketplaceWorkspace {...miniAppProps} />;
   if (section === 'payments') return <div className={styles.featureWorkspace}><WalletCards size={54} /><h2>Fabushi Pay</h2><p>自建余额、Invoice、Order、退款与外部 settlement 都由 Rust 账本结算。</p><PaymentOverview payment={payment} onInvoice={onInvoice} onRefund={onRefund} /></div>;
   if (section === 'calls') return <div className={styles.featureWorkspace}><Phone size={54} /><h2>通话</h2><p>本机媒体已接通，Rust realtime 已具备一对一/群组通话信令状态。</p></div>;
+  if (section === 'settings') return <SettingsWorkspace {...settings} />;
   return <div className={styles.featureWorkspace}><MessageCircle size={54} /><h2>{sectionTitle(section)}</h2><p>联系人、Bot、群组和频道正在统一到同一个 Fabushi Actor/Conversation 模型。</p></div>;
 }

--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -1025,3 +1025,202 @@
 .fabushiUnified .createMenu {
   z-index: 80;
 }
+
+
+/* Telegram-inspired settings information architecture, rendered with Fabushi materials. */
+.settingsNavigation {
+  display: grid;
+  gap: 3px;
+  padding: 2px 0 14px;
+}
+
+.settingsNavigation > button {
+  width: 100%;
+  min-height: 58px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 12px;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 9px;
+  align-items: center;
+  text-align: left;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.settingsNavigation > button:hover,
+.settingsNavigation > button[data-active="true"] {
+  background: rgba(139, 92, 246, .14);
+}
+
+.settingsNavigation > button[data-active="true"] {
+  box-shadow: inset 2px 0 #8b5cf6;
+}
+
+.settingsNavigation > button > span {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, .065);
+  font-size: 16px;
+}
+
+.settingsNavigation > button > div {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.settingsNavigation strong { font-size: 13px; }
+.settingsNavigation small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #8f8c9f;
+  font-size: 10px;
+}
+
+.settingsWorkspace {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  min-height: 100%;
+  overflow: auto;
+  padding: 34px clamp(24px, 6vw, 88px) 54px;
+  background:
+    radial-gradient(circle at 82% 8%, rgba(139, 92, 246, .12), transparent 28%),
+    #0b0b11;
+  color: #f7f5fb;
+}
+
+.settingsWorkspace > header {
+  width: min(760px, 100%);
+  margin: 0 auto 22px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.settingsGlyph {
+  width: 48px;
+  height: 48px;
+  flex: 0 0 48px;
+  border-radius: 15px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, rgba(167, 139, 250, .24), rgba(91, 65, 190, .2));
+  box-shadow: inset 0 1px rgba(255, 255, 255, .12);
+  font-size: 23px;
+}
+
+.settingsWorkspace > header div { min-width: 0; }
+.settingsWorkspace h2 { margin: 0; font-size: 23px; font-weight: 760; letter-spacing: -.02em; }
+.settingsWorkspace > header p { margin: 4px 0 0; color: #9996a8; font-size: 12px; line-height: 1.45; }
+
+.settingsGroup {
+  width: min(760px, 100%);
+  margin: 0 auto 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, .075);
+  border-radius: 16px;
+  background: rgba(21, 20, 30, .82);
+  box-shadow: 0 18px 54px rgba(0, 0, 0, .16), inset 0 1px rgba(255, 255, 255, .035);
+  backdrop-filter: blur(22px) saturate(1.12);
+}
+
+.settingsRow,
+.settingsInfoRow {
+  min-height: 64px;
+  padding: 11px 15px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, .065);
+}
+
+.settingsGroup > :last-child { border-bottom: 0; }
+.settingsRow > div,
+.settingsInfoRow { min-width: 0; }
+.settingsRow > div { display: grid; gap: 3px; }
+.settingsRow strong,
+.settingsInfoRow strong { font-size: 13px; font-weight: 690; }
+.settingsRow small,
+.settingsInfoRow small { color: #9693a5; font-size: 11px; line-height: 1.42; }
+.settingsRow em,
+.settingsInfoRow em {
+  padding: 4px 7px;
+  border-radius: 8px;
+  background: rgba(139, 92, 246, .14);
+  color: #c4b5fd;
+  font-size: 10px;
+  font-style: normal;
+  white-space: nowrap;
+}
+
+.settingsRow input[role="switch"] {
+  width: 38px;
+  height: 22px;
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, .16);
+  cursor: pointer;
+  position: relative;
+  transition: background .16s ease;
+}
+
+.settingsRow input[role="switch"]::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, .3);
+  transition: transform .16s ease;
+}
+
+.settingsRow input[role="switch"]:checked { background: #8b5cf6; }
+.settingsRow input[role="switch"]:checked::after { transform: translateX(16px); }
+.settingsRowDisabled { opacity: .63; cursor: default; }
+
+.settingsInfoRow {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+.settingsInfoRow strong,
+.settingsInfoRow small { grid-column: 1; }
+.settingsInfoRow em { grid-column: 2; grid-row: 1 / span 2; }
+
+.settingsProfile {
+  padding: 18px 16px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 15px;
+  border-bottom: 1px solid rgba(255, 255, 255, .065);
+}
+.settingsProfile > div { min-width: 0; display: grid; gap: 3px; }
+.settingsProfile strong { font-size: 17px; }
+.settingsProfile small { color: #aaa7b8; font-size: 11px; overflow: hidden; text-overflow: ellipsis; }
+.settingsProfile p { margin: 3px 0 0; color: #8e8b9c; font-size: 11px; line-height: 1.4; }
+
+.fabushiUnified[data-reduce-motion="true"] *,
+.fabushiUnified[data-reduce-motion="true"] *::before,
+.fabushiUnified[data-reduce-motion="true"] *::after {
+  animation-duration: .001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: .001ms !important;
+  scroll-behavior: auto !important;
+}
+
+@media (max-width: 900px) {
+  .settingsWorkspace { padding: 24px 18px 40px; }
+  .settingsWorkspace > header { align-items: flex-start; }
+}

--- a/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
@@ -1,0 +1,19 @@
+# M3-DESKTOP-002 evidence
+
+- Project: `FAB-P0001 / TFI`
+- Task: `M3-DESKTOP-002`
+- Branch: `feat/telegram-local-first-settings`
+- Implementation commit: `cda0bbc37c7f8b2623384fc5a9c1542aef5fcffa`
+- Pull request: #2079
+- Local static hygiene: `git diff --check` passed before push.
+- Local build/test: not run, by repository disk-safety policy.
+- GitHub Actions current-head verification: pending.
+- Protected-main merge: pending.
+- Canonical-main verification: pending.
+
+## Expected CI evidence
+
+1. desktop TypeScript/typecheck or equivalent fast CI check;
+2. messaging product gate;
+3. relevant Messenger Playwright/E2E check where configured;
+4. merge SHA and canonical-main file readback after protected merge.

--- a/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
@@ -35,3 +35,7 @@
 - [项目治理任务](wbs/governance.md)
 
 状态变更必须同时更新对应分卷、验收追踪矩阵、状态报告与任务记录。
+
+## 2026-08-24 — M3-DESKTOP-002 Telegram local-first + Settings
+
+- `M3-DESKTOP-002` — `TESTING`: returning-user fast-start projection, first sync 20 / cursor background 100, responsive zero-width absent info panel, Telegram-inspired Settings IA, supported desktop preference bindings, and Playwright regression coverage implemented in PR #2079. GitHub Actions + protected merge + canonical-main verification remain the completion gate.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -58,3 +58,7 @@ M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded 
 ## Active M7 desktop convergence — M7-DESKTOP-003
 
 `M7-DESKTOP-003` = `IMPLEMENTED`：单一 Messenger 当前源码已具备 personal-avatar navigation、resizable avatar-only sidebar、全身份 BotMark、11 类 global search 与 Marketplace-in-search。新增 Playwright assertions 已写入 desktop E2E，但在 current-head GitHub Actions、protected merge、canonical-main verification 完成前不得标记 `TESTED`。
+
+## Active M3 local-first / Settings acceptance — 2026-08-24
+
+`M3-DESKTOP-002` = `TESTING`: implementation commit `cda0bbc37` on PR #2079 adds bounded fast-start projection, initial sync limit 20, cursor-based background batches of 100, responsive third-column zero-width behavior, Telegram-inspired settings categories and persisted real desktop preferences. Playwright coverage is committed. Required current-head GitHub Actions, protected merge, and canonical-main verification are pending; therefore this row is not yet `TESTED`.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -98,3 +98,12 @@
 - 当前 `fix/tfi-m7-marketplace-runtime-smoke` 只在 AppHost Test mode 提供 deterministic Marketplace；Production 仍严格走线上 Marketplace + verified external release。
 - desktop native capabilities 已统一调用 canonical `feature.marketplace.*` / `feature.plugin.*`；Mini App UI E2E 改为全局“应用”搜索 → 安装 → 打开；native-menu E2E 消除监听注册竞态。
 - 安装验收继续阻塞在 repaired Electron runtime/package 全绿与 main signed/notarized macOS artifact。
+
+## 2026-08-24 — M3-DESKTOP-002 local-first + Telegram Settings
+
+- 用户要求按照 Telegram Desktop/Unigram 的本地优先启动方式改造 Fabushi，并吸收 Telegram Settings 信息架构。
+- PR #2079 已提交实现：返回用户可从有界 projection 直接绘制 Messenger；Rust SQLite/Host 仍为权威状态；首轮 sync 20、后台 cursor sync 每批 100；delta batch 做 merge。
+- <=1280px 的资料栏不再出现“CSS 隐藏但 Grid 仍保留 286px”的黑色空栏。
+- 设置页增加资料、通知、隐私、安全、数据、聊天、文件夹、设备、通话、语言、高级、AI/Mini Apps 分类；已存在的客户端偏好真实绑定，未落地后端能力明确标记为“后端接入中”。
+- Playwright 新增设置持久化 + fast-start projection reload 验收；本地不跑构建/测试，等待 GitHub Actions。
+- 当前状态：`TESTING`，不可在 PR merge + canonical-main verification 前关闭。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -94,3 +94,12 @@
 - AppHost Test mode 新增 deterministic online-marketplace seam，避免 E2E 依赖生产账号/网络，同时 Production 行为不变。
 - Mini App E2E 改为真实 global Application search/install/open user journey。
 - 修复 application-menu native event listener 与 main-process click 的跨通道竞态。
+
+## 2026-08-24 — Telegram local-first startup + Settings absorbed
+
+- 新增 source requirement `2026-08-24-local-first-startup-and-settings.md` 与任务 `M3-DESKTOP-002`。
+- Electron Messenger 增加 non-authoritative bounded fast-start projection；首轮 self-hosted sync 从默认 1000 改为 20，后台 cursor batch 改为 100。
+- syncBatch 支持增量 merge，恢复最后活动 self-hosted conversation/recent messages。
+- 修复窄窗口 info panel 已隐藏但仍占 286px 的黑栏问题。
+- Settings 从 placeholder 升级为 Telegram-inspired grouped settings workspace，并新增真实 message preview / autoplay / info panel / Enter-to-send / reduced-motion 偏好。
+- 新增 Playwright settings/projection reload contract。实现 commit `cda0bbc37`，PR #2079；CI/merge 尚未完成。

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -1,0 +1,67 @@
+# M3-DESKTOP-002 — Telegram local-first startup and settings absorption
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M3-DESKTOP-002`
+- **Stage**: `M3 桌面聊天完整交互`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-24`
+- **Updated**: `2026-08-24`
+- **Branch**: `feat/telegram-local-first-settings`
+- **Source**: `source/2026-08-24-local-first-startup-and-settings.md`
+
+## Objective
+
+Adopt Telegram Desktop/Unigram's local-first, bounded-initial-load behavior in the canonical Electron Messenger and absorb Telegram's settings information architecture into Fabushi without creating a second messaging/settings state machine.
+
+## In scope
+
+- returning-user Messenger first paint without a HostClient → Messenger remount;
+- bounded initial self-hosted sync and cursor-based background deltas;
+- fast renderer projection restore reconciled against canonical Rust/Host state;
+- remember last active conversation and recent renderer projection for instant paint;
+- make absent third/info panel consume zero width at runtime;
+- Telegram-inspired grouped settings navigation inside Messenger;
+- bind supported settings to real local/runtime preferences and clearly label unavailable backend capabilities;
+- E2E/contract assertions for local-first shell and settings entry.
+
+## Out of scope
+
+- replacing the canonical Rust SQLite state store;
+- copying Telegram branding/assets verbatim;
+- pretending unsupported privacy/device/backend settings are already functional;
+- local application build/test (forbidden by repository policy).
+
+## Dependencies
+
+- M1 SQLite durable local-first storage landed in canonical messaging core.
+- M3-DESKTOP-001 desktop Messenger interaction work merged via PR #2021.
+- Electron Host authentication and native runtime bridge remain authoritative for live session validation.
+
+## Acceptance criteria
+
+1. Returning-user renderer can paint Messenger from a persisted projection before Host network/auth round trips finish.
+2. First self-hosted sync is a small bounded request; later synchronization uses cursor deltas.
+3. Persisted projection is non-authoritative and is replaced/reconciled by canonical Host/Rust events after initialization.
+4. Last selected peer restores when still present.
+5. Settings includes grouped sections for account, notifications, privacy/security, data/storage, chat appearance, folders, devices, calls, language, advanced, and Fabushi-native AI/Mini App controls.
+6. Supported toggles persist and affect their real UI behavior; unsupported server capabilities are shown disabled/planned.
+7. GitHub Actions typecheck/product gate and relevant Messenger Playwright coverage pass before completion.
+8. PR merges to protected `main` and canonical-main state is re-read before task is marked complete.
+
+## Verification plan
+
+- Electron TypeScript typecheck in GitHub Actions.
+- Messaging Product Gate in GitHub Actions.
+- Messenger Playwright assertions for instant shell projection/settings navigation.
+- PR/CI/merge evidence recorded under `evidence/M3-DESKTOP-002/`.
+
+## Risks
+
+- stale renderer projection could diverge from Rust state; mitigation: projection is display-only and canonical events overwrite it.
+- auth-invalid returning users must still land in login/HostClient path after validation.
+- settings breadth can imply functionality not present; mitigation: explicit availability metadata and disabled rows.
+
+## Next action
+
+Implement the shell/startup projection and settings surface, then open PR and drive GitHub Actions/merge gates.

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -4,11 +4,13 @@
 - **Project Key**: `TFI`
 - **Task ID**: `M3-DESKTOP-002`
 - **Stage**: `M3 桌面聊天完整交互`
-- **Status**: `IN_PROGRESS`
+- **Status**: `TESTING`
 - **Started**: `2026-08-24`
 - **Updated**: `2026-08-24`
 - **Branch**: `feat/telegram-local-first-settings`
 - **Source**: `source/2026-08-24-local-first-startup-and-settings.md`
+- **Implementation commit**: `cda0bbc37c7f8b2623384fc5a9c1542aef5fcffa`
+- **PR**: `#2079`
 
 ## Objective
 
@@ -62,6 +64,28 @@ Adopt Telegram Desktop/Unigram's local-first, bounded-initial-load behavior in t
 - auth-invalid returning users must still land in login/HostClient path after validation.
 - settings breadth can imply functionality not present; mitigation: explicit availability metadata and disabled rows.
 
+## Implementation summary
+
+- Added bounded renderer fast-start projection (`fabushi.desktop.messenger-projection.v1`) for returning-user first paint while Rust SQLite/Host remains authoritative.
+- Changed first self-hosted sync to 20 records and cursor-based background batches to 100; delta sync batches merge instead of replacing projected state.
+- Restores last active self-hosted conversation and bounded recent messages.
+- Fixed the <=1280 responsive third-column mismatch by allocating the 286px column only when the info panel is actually visible.
+- Added Telegram-inspired Settings navigation and detail workspace for account, notifications, privacy/security, data/storage, chat, folders, devices, calls, language, advanced, and Fabushi AI/Mini Apps.
+- Wired real desktop preferences for message preview, video autoplay, info-panel visibility, Enter-to-send and reduced motion; unsupported server-backed options are explicitly marked planned.
+- Added Playwright coverage for settings/preferences and reload-from-projection.
+
+## Verification / evidence
+
+- `git diff --check`: PASS before push.
+- Local application build/test: intentionally NOT RUN per repository disk-safety policy.
+- GitHub Actions: pending on PR #2079.
+- Protected merge + canonical-main verification: pending.
+- Evidence index: `evidence/M3-DESKTOP-002/README.md`.
+
+## Blockers
+
+- Required GitHub Actions / protected-main gates have not completed yet; task remains `TESTING`.
+
 ## Next action
 
-Implement the shell/startup projection and settings surface, then open PR and drive GitHub Actions/merge gates.
+Drive PR #2079 through current-head CI, fix any failures, merge through protected `main`, then re-read canonical main and update acceptance/project records before closure.

--- a/projects/telegram-fabushi-integration/source/2026-08-24-local-first-startup-and-settings.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-24-local-first-startup-and-settings.md
@@ -1,0 +1,54 @@
+# 2026-08-24 — Telegram local-first startup + settings absorption
+
+## User requirement
+
+Continue the Telegram → Fabushi integration by implementing the startup/data-flow behavior observed in Telegram Desktop/Unigram and by absorbing Telegram's settings surface into Fabushi's canonical Electron Messenger.
+
+## Source-derived implementation principles
+
+### Local-first startup
+
+Reference behavior audited from `telegramdesktop/tdesktop` and `UnigramDev/Unigram`:
+
+- restore account/session/local state before waiting for network synchronization;
+- render the chat shell from local data immediately;
+- first chat-list load is bounded (Telegram Desktop uses 20 dialogs for the first load; Unigram loads chat-list slices incrementally);
+- later network work is incremental/delta synchronization and must not block first interaction;
+- a hidden/absent third panel must consume zero layout width.
+
+Fabushi adaptation:
+
+- keep the canonical Rust `native/mahayana-messaging` state machine authoritative;
+- use its already-versioned SQLite durable store as the canonical local messaging persistence;
+- renderer projection caches are permitted only as a non-authoritative fast-start projection and must reconcile against Rust/Host state;
+- remove the HostClient-before-Messenger remount from the normal returning-user path;
+- reduce initial self-hosted sync from an unbounded 1000-event first pass to a small first slice, then continue delta sync in the background;
+- preserve explicit login/authentication when no valid returning-user projection/session exists.
+
+### Settings surface
+
+Reference surface audited from Telegram Desktop `Telegram/SourceFiles/settings/` and `settings/sections/` including active sessions, advanced, blocked peers, business, calls, chat, notification/privacy/data-related sections.
+
+Fabushi should absorb the information architecture and interaction quality, not copy Telegram branding or create a second settings state machine. Initial desktop settings categories:
+
+1. Profile / account
+2. Notifications & sounds
+3. Privacy & security
+4. Data & storage
+5. Chat settings / appearance
+6. Folders
+7. Devices / active sessions
+8. Calls
+9. Language
+10. Advanced
+11. Fabushi-native AI/Bot/Mini App controls where applicable
+
+Settings that already have a real Fabushi backend must bind to it. Settings whose backend is not yet implemented must be clearly identified as planned/disabled rather than pretending to work.
+
+## Acceptance direction
+
+- Returning-user first paint shows Messenger immediately from local projection instead of `HostClient` followed by remount.
+- Initial self-hosted synchronization requests a small bounded slice and subsequent sync uses the cursor incrementally.
+- Settings opens as a native Messenger section with Telegram-inspired grouped navigation and real toggles for currently supported desktop preferences.
+- Existing messaging, update, search, drafts, pin/mute/archive, and authentication flows remain compatible.
+- Verification is performed in GitHub Actions; local build/test is prohibited by repository instructions.


### PR DESCRIPTION
## FAB-P0001 / TFI — M3-DESKTOP-002

Implements the Telegram/Unigram-derived local-first desktop startup model and absorbs Telegram's settings information architecture into Fabushi's canonical Electron Messenger.

### Local-first startup
- returning users can paint Messenger from a bounded persisted projection while native auth validates in the background;
- canonical Rust/Host + SQLite state remains authoritative; the renderer projection is display-only and reconciled by runtime events;
- first self-hosted sync is capped at 20 items, matching Telegram's bounded first-dialog strategy;
- cursor-based background sync is capped at 100 per pass rather than blocking startup with `sync(1000)`;
- delta `syncBatch` payloads merge into the existing projected state instead of replacing it wholesale;
- last active self-hosted conversation and bounded recent messages are restored for immediate first paint.

### Responsive third column
- third/info panel width is now allocated only when the panel is actually visible at the current viewport width;
- <=1280px no longer hides the panel in CSS while retaining a 286px React grid column, eliminating the black blank strip.

### Telegram-inspired Settings
Adds grouped settings navigation for:
- account/profile
- notifications & sounds
- privacy & security
- data & storage
- chat settings
- folders
- devices / active sessions
- calls
- language
- advanced
- Fabushi-native AI & Mini Apps

Real supported preferences are wired now: message preview, video autoplay, info-panel visibility, Enter-to-send behavior, and reduced motion. Backend features not yet implemented are visibly marked as planned instead of pretending to work.

### Verification
- added Playwright coverage for settings navigation/preferences, persisted fast-start projection, and reload restore;
- `git diff --check` passes locally;
- per repository disk-safety policy, no local build/test suite was run. GitHub Actions is the required verification source.

Project record: `projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md`