### PR TITLE
test(tfi): gate Telegram local-first startup before Release

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -1,5 +1,5 @@
 import { _electron as electron, expect, test, type Page } from '@playwright/test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -226,6 +226,71 @@ test('Telegram-inspired settings bind supported preferences and persist fast-sta
     await expect(page.getByText('本地优先投影验收').first()).toBeVisible();
   } finally {
     await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});
+
+test('returning-user local-first conversation list is interactive within the one-second target', async ({}, testInfo) => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-startup-perf-e2e-'));
+  let app = await launchDesktopApp(appDataDir);
+
+  try {
+    let page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    await openMessenger(page);
+
+    await page.getByRole('button', { name: '新建', exact: true }).click();
+    await page.getByRole('button', { name: '新建频道' }).click();
+    await page.getByPlaceholder('频道名称').fill('首屏性能验收');
+    await page.getByPlaceholder('频道简介').fill('local-first startup timing');
+    await page.getByRole('button', { name: '创建频道' }).click();
+    const seededPeer = page.locator('[data-testid^="peer-selfhosted:channel:"]').filter({ hasText: '首屏性能验收' }).first();
+    await expect(seededPeer).toBeVisible();
+    await seededPeer.click();
+    await expect.poll(async () => page.evaluate(() => {
+      const projection = JSON.parse(localStorage.getItem('fabushi.desktop.messenger-projection.v1') || 'null');
+      return Boolean(projection?.activePeerKey?.startsWith('selfhosted:') && projection?.selfConversations?.some((item: { title?: string }) => item.title === '首屏性能验收'));
+    }), { timeout: 5_000 }).toBe(true);
+
+    await app.close();
+
+    const launchStartedAtMs = Date.now();
+    app = await launchDesktopApp(appDataDir);
+    page = await app.firstWindow();
+    const workspace = page.getByTestId('messenger-workspace');
+    const projectedPeer = page.locator('[data-testid^="peer-selfhosted:channel:"]').filter({ hasText: '首屏性能验收' }).first();
+
+    await expect(workspace).toBeVisible({ timeout: 5_000 });
+    await expect(workspace).toHaveAttribute('data-testid-ready-projection', 'true');
+    await expect(projectedPeer).toBeVisible({ timeout: 5_000 });
+
+    const rendererToConversationListMs = await page.evaluate(() => performance.now());
+    const launchToConversationListMs = Date.now() - launchStartedAtMs;
+    await projectedPeer.click();
+    await expect(page.getByTestId('messenger-input')).toBeVisible({ timeout: 2_000 });
+    const rendererToComposerInteractiveMs = await page.evaluate(() => performance.now());
+
+    const evidence = {
+      targetMs: 1_000,
+      metric: 'renderer-navigation-to-cached-conversation-list-interactive',
+      rendererToConversationListMs: Math.round(rendererToConversationListMs * 100) / 100,
+      rendererToComposerInteractiveMs: Math.round(rendererToComposerInteractiveMs * 100) / 100,
+      launchToConversationListMs,
+      packaged: Boolean(packagedExecutable),
+      platform: process.platform,
+      passed: rendererToConversationListMs < 1_000,
+    };
+    const evidenceJson = `${JSON.stringify(evidence, null, 2)}\n`;
+    console.log(`[startup-performance] ${JSON.stringify(evidence)}`);
+    await writeFile(testInfo.outputPath('startup-performance.json'), evidenceJson);
+    await testInfo.attach('startup-performance', { body: Buffer.from(evidenceJson), contentType: 'application/json' });
+
+    expect(
+      rendererToConversationListMs,
+      `cached conversation list must become interactive within 1000ms; measured ${rendererToConversationListMs.toFixed(2)}ms`,
+    ).toBeLessThan(1_000);
+  } finally {
+    await app.close().catch(() => undefined);
     await rm(appDataDir, { recursive: true, force: true });
   }
 });

--- a/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
@@ -7,13 +7,16 @@
 - Pull request: #2079
 - Local static hygiene: `git diff --check` passed before push.
 - Local build/test: not run, by repository disk-safety policy.
-- GitHub Actions current-head verification: pending.
-- Protected-main merge: pending.
-- Canonical-main verification: pending.
+- GitHub Actions current-head verification: PASS.
+  - CI: `32673731408`
+  - Messaging Product Gate: `32673731405`
+  - Fabushi self-hosted messaging: `32673731410`
+  - Electron desktop quality gate: `32673731418`
+- Electron Host simulated user smoke: PASS; renderer typecheck/build and Messenger E2E passed, including `Telegram-inspired settings bind supported preferences and persist fast-start projection`.
+- macOS package/E2E: initial run hit an unrelated pre-existing Mini App test worker-teardown flake; rerun job `97279437431` passed. Linux and Windows package journeys also passed.
+- Protected-main merge: PASS — PR #2079 merged through merge queue as `01b33d60f7d7d9add41a5fba84d21014094cb5dc`.
+- Canonical-main verification: PASS — `main` points to `01b33d60f7d7d9add41a5fba84d21014094cb5dc` and contains the implementation.
 
-## Expected CI evidence
+## Closure
 
-1. desktop TypeScript/typecheck or equivalent fast CI check;
-2. messaging product gate;
-3. relevant Messenger Playwright/E2E check where configured;
-4. merge SHA and canonical-main file readback after protected merge.
+All expected CI, merge-queue, and canonical-main evidence is present. M3-DESKTOP-002 is complete.

--- a/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
@@ -20,3 +20,7 @@
 ## Closure
 
 All expected CI, merge-queue, and canonical-main evidence is present. M3-DESKTOP-002 is complete.
+
+## 2026-08-24 performance / Release continuation
+
+The task is re-opened from administrative closure to `TESTING` under the newer repository post-main delivery rule. A packaged Playwright performance gate now records `startup-performance.json` and requires cached conversation-list first interaction in `< 1000 ms`. Final closure requires exact-main packaged E2E + mobile gates + GitHub Release/updater evidence.

--- a/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
@@ -39,3 +39,7 @@
 ## 2026-08-24 — M3-DESKTOP-002 Telegram local-first + Settings
 
 - `M3-DESKTOP-002` — `TESTING`: returning-user fast-start projection, first sync 20 / cursor background 100, responsive zero-width absent info panel, Telegram-inspired Settings IA, supported desktop preference bindings, and Playwright regression coverage implemented in PR #2079. GitHub Actions + protected merge + canonical-main verification remain the completion gate.
+
+## 2026-08-24 — M3-DESKTOP-002 closed
+
+- `M3-DESKTOP-002` — `COMPLETED`: PR #2079 passed CI, Messaging Product Gate, self-hosted messaging, and Electron desktop quality gate, then merged through the protected merge queue as `01b33d60f7d7d9add41a5fba84d21014094cb5dc`. Canonical `main` was re-read at the merge SHA.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -62,3 +62,7 @@ M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded 
 ## Active M3 local-first / Settings acceptance — 2026-08-24
 
 `M3-DESKTOP-002` = `TESTING`: implementation commit `cda0bbc37` on PR #2079 adds bounded fast-start projection, initial sync limit 20, cursor-based background batches of 100, responsive third-column zero-width behavior, Telegram-inspired settings categories and persisted real desktop preferences. Playwright coverage is committed. Required current-head GitHub Actions, protected merge, and canonical-main verification are pending; therefore this row is not yet `TESTED`.
+
+## M3-DESKTOP-002 final acceptance — 2026-08-24
+
+`M3-DESKTOP-002` = `TESTED / COMPLETED`: local-first projection restore, initial sync 20, cursor background sync 100, responsive third-column behavior, Telegram-inspired grouped Settings, persisted real desktop preferences, and reload-from-projection Playwright coverage all passed required product gates. PR #2079 merged through the protected queue as `01b33d60f7d7d9add41a5fba84d21014094cb5dc` and canonical `main` was re-verified.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -107,3 +107,11 @@
 - 设置页增加资料、通知、隐私、安全、数据、聊天、文件夹、设备、通话、语言、高级、AI/Mini Apps 分类；已存在的客户端偏好真实绑定，未落地后端能力明确标记为“后端接入中”。
 - Playwright 新增设置持久化 + fast-start projection reload 验收；本地不跑构建/测试，等待 GitHub Actions。
 - 当前状态：`TESTING`，不可在 PR merge + canonical-main verification 前关闭。
+
+## 2026-08-24 — M3-DESKTOP-002 completed
+
+- PR #2079 全部必要 gates 通过：CI、Messaging Product Gate、self-hosted messaging、Electron desktop quality gate。
+- Electron renderer typecheck/build 与 Messenger E2E 通过；新增 Telegram Settings + fast-start projection reload 用例通过。
+- macOS 首轮只有既有 Mini App 用例 worker teardown 抖动，重跑通过；Linux / Windows package journey 同样通过。
+- PR 经 merge queue 合并为 `01b33d60f7d7d9add41a5fba84d21014094cb5dc`，并已重新读取 canonical `main` 确认。
+- `M3-DESKTOP-002` 状态更新为 `COMPLETED`。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -103,3 +103,9 @@
 - 修复窄窗口 info panel 已隐藏但仍占 286px 的黑栏问题。
 - Settings 从 placeholder 升级为 Telegram-inspired grouped settings workspace，并新增真实 message preview / autoplay / info panel / Enter-to-send / reduced-motion 偏好。
 - 新增 Playwright settings/projection reload contract。实现 commit `cda0bbc37`，PR #2079；CI/merge 尚未完成。
+
+## 2026-08-24 — M3-DESKTOP-002 closure
+
+- PR #2079 (`Telegram local-first startup + Settings`) 通过全部当前 head product gates。
+- merge queue position 1 revalidation 通过并合并为 `01b33d60f7d7d9add41a5fba84d21014094cb5dc`。
+- canonical `main` readback 完成；任务记录与 evidence 从 `TESTING` 更新为 `COMPLETED`。

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -4,13 +4,14 @@
 - **Project Key**: `TFI`
 - **Task ID**: `M3-DESKTOP-002`
 - **Stage**: `M3 桌面聊天完整交互`
-- **Status**: `TESTING`
+- **Status**: `COMPLETED`
 - **Started**: `2026-08-24`
 - **Updated**: `2026-08-24`
 - **Branch**: `feat/telegram-local-first-settings`
 - **Source**: `source/2026-08-24-local-first-startup-and-settings.md`
 - **Implementation commit**: `cda0bbc37c7f8b2623384fc5a9c1542aef5fcffa`
 - **PR**: `#2079`
+- **Merge commit**: `01b33d60f7d7d9add41a5fba84d21014094cb5dc`
 
 ## Objective
 
@@ -78,14 +79,18 @@ Adopt Telegram Desktop/Unigram's local-first, bounded-initial-load behavior in t
 
 - `git diff --check`: PASS before push.
 - Local application build/test: intentionally NOT RUN per repository disk-safety policy.
-- GitHub Actions: pending on PR #2079.
-- Protected merge + canonical-main verification: pending.
+- GitHub Actions: PASS — CI `32673731408`, Messaging Product Gate `32673731405`, self-hosted messaging `32673731410`, Electron desktop quality gate `32673731418`.
+- Electron renderer `tsc --noEmit && vite build`: PASS in the quality gate.
+- Messenger Playwright: PASS, including the new Telegram Settings + fast-start projection reload test.
+- macOS packaged E2E had one unrelated Mini App flake on the first attempt; the job rerun passed fully.
+- Protected merge queue: PASS — PR #2079 merged as `01b33d60f7d7d9add41a5fba84d21014094cb5dc`.
+- Canonical-main verification: PASS — `main` re-read at `01b33d60f7d7d9add41a5fba84d21014094cb5dc`.
 - Evidence index: `evidence/M3-DESKTOP-002/README.md`.
 
 ## Blockers
 
-- Required GitHub Actions / protected-main gates have not completed yet; task remains `TESTING`.
+- None.
 
-## Next action
+## Closure
 
-Drive PR #2079 through current-head CI, fix any failures, merge through protected `main`, then re-read canonical main and update acceptance/project records before closure.
+All acceptance gates passed. PR #2079 entered the protected merge queue at position 1, passed merge-group revalidation, merged to `main`, and canonical `main` was re-read at `01b33d60f7d7d9add41a5fba84d21014094cb5dc`.

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -4,11 +4,12 @@
 - **Project Key**: `TFI`
 - **Task ID**: `M3-DESKTOP-002`
 - **Stage**: `M3 桌面聊天完整交互`
-- **Status**: `COMPLETED`
+- **Status**: `TESTING`
 - **Started**: `2026-08-24`
 - **Updated**: `2026-08-24`
 - **Branch**: `feat/telegram-local-first-settings`
 - **Source**: `source/2026-08-24-local-first-startup-and-settings.md`
+- **Performance/Release source**: `source/2026-08-24-startup-performance-release-gate.md`
 - **Implementation commit**: `cda0bbc37c7f8b2623384fc5a9c1542aef5fcffa`
 - **PR**: `#2079`
 - **Merge commit**: `01b33d60f7d7d9add41a5fba84d21014094cb5dc`
@@ -51,6 +52,8 @@ Adopt Telegram Desktop/Unigram's local-first, bounded-initial-load behavior in t
 6. Supported toggles persist and affect their real UI behavior; unsupported server capabilities are shown disabled/planned.
 7. GitHub Actions typecheck/product gate and relevant Messenger Playwright coverage pass before completion.
 8. PR merges to protected `main` and canonical-main state is re-read before task is marked complete.
+9. Returning-user cached conversation list first-interactive time is objectively measured in packaged E2E and is `< 1000 ms`.
+10. The exact accepted main SHA completes the post-main packaged E2E → Release → updater proof before final `COMPLETED`.
 
 ## Verification plan
 
@@ -87,10 +90,8 @@ Adopt Telegram Desktop/Unigram's local-first, bounded-initial-load behavior in t
 - Canonical-main verification: PASS — `main` re-read at `01b33d60f7d7d9add41a5fba84d21014094cb5dc`.
 - Evidence index: `evidence/M3-DESKTOP-002/README.md`.
 
-## Blockers
+## Current delivery gate
 
-- None.
-
-## Closure
-
-All acceptance gates passed. PR #2079 entered the protected merge queue at position 1, passed merge-group revalidation, merged to `main`, and canonical `main` was re-read at `01b33d60f7d7d9add41a5fba84d21014094cb5dc`.
+- Core implementation PR #2079 is merged and canonical-main readback passed.
+- A new packaged returning-user startup performance E2E now enforces the project `< 1 second` first-interactive target.
+- Final task closure remains pending until this measurement is green on canonical main and the same accepted SHA is published through the post-main Release/updater loop.

--- a/projects/telegram-fabushi-integration/source/2026-08-24-startup-performance-release-gate.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-24-startup-performance-release-gate.md
@@ -1,0 +1,22 @@
+# 2026-08-24 — Local-first startup performance and Release gate
+
+## User requirement
+
+After the Telegram local-first/settings implementation is merged, run packaged simulated-user E2E, collect the actual display/interaction time, compare it to the project performance target, and publish a new version only if the target is met. Continue until the full merge → E2E → timing → Release loop is complete.
+
+## Existing target
+
+`source/full-plan/part-05.txt` defines the returning-user client target as: conversation list first interactive **< 1 second** on reasonable hardware with an authenticated local cache.
+
+## Measurement contract
+
+- Seed a real self-hosted conversation and allow the production projection persistence path to write it.
+- Fully close and relaunch Electron with the same app-data directory.
+- Measure `performance.now()` from renderer navigation start until the cached conversation row is visible and clickable. This is the release-gating metric because it measures the local-first first-interaction path independently of GitHub runner process-scheduling noise.
+- Also record process-launch → conversation-list-visible and renderer → composer-interactive as diagnostic metrics.
+- Write JSON evidence into Playwright `test-results` and print the same evidence into the Actions log.
+- Gate at `< 1000 ms`; failure blocks the Electron main quality gate and therefore blocks post-main Release publication.
+
+## Delivery requirement
+
+The exact accepted main SHA must pass packaged Electron E2E plus the repository-required Android/iOS simulated-user gates. Only then may the post-main delivery workflow publish the tested artifacts with a monotonic version and updater metadata.


### PR DESCRIPTION
## FAB-P0001 / TFI — M3-DESKTOP-002 performance + delivery continuation

Core implementation PR #2079 is already merged. This PR keeps the task in `TESTING` and adds the missing objective performance/release gate required by the current repository delivery policy and the user request.

### Startup performance gate
- seeds a real self-hosted conversation through the production Messenger path;
- waits for the real `fabushi.desktop.messenger-projection.v1` fast-start projection;
- fully closes and relaunches Electron with the same app-data directory;
- measures renderer navigation → cached conversation list visible/clickable;
- records `startup-performance.json` plus Actions log evidence;
- also records process launch → list and renderer → composer interaction diagnostics;
- **hard release gate: cached conversation list first-interactive < 1000 ms**, matching the existing TFI performance target in `source/full-plan/part-05.txt`.

### Delivery rule
This PR is not a closure-only record anymore. After protected merge, the exact canonical-main SHA must pass:
1. packaged Electron E2E on the required desktop platforms, including this timing assertion;
2. Android/iOS simulated-user gates;
3. post-main exact-SHA Release publication using the already-tested artifacts;
4. previous-release updater proof.

Only after those objective results are recorded will M3-DESKTOP-002 be marked `COMPLETED`.

No local app build/test was run; repository policy requires GitHub Actions for build/E2E/package verification.