### PR TITLE
fix(runtime): bootstrap desktop provider workspace before first message

### DIFF
--- a/projects/mahayana-sovereign-runtime/management/tasks/MSR-105-desktop-provider-readiness.md
+++ b/projects/mahayana-sovereign-runtime/management/tasks/MSR-105-desktop-provider-readiness.md
@@ -1,0 +1,55 @@
+# MSR-105 — Desktop provider readiness and managed workspace bootstrap
+
+- **Project ID:** FAB-P0005
+- **Project Key:** MSR
+- **Task ID:** MSR-105
+- **Status:** in-progress
+- **Started:** 2026-08-24T08:11:00+08:00
+- **Updated:** 2026-08-24T08:11:00+08:00
+- **Completed:** null
+
+## Objective
+Eliminate the desktop Mahayana first-message failure that surfaced as `provider failed: backend failed: No such file or directory (os error 2)` by making product-owned runtime prerequisites explicit and deterministic before the provider is allowed to serve requests.
+
+## Reference implementation review
+Cloudflare OS was reviewed as an architecture reference. Its AI backend centralizes model/provider routing behind typed handles and keeps routing/auth details out of callers. Fabushi should adopt the same class of boundary: initialize and validate runtime-owned prerequisites once at the host boundary, keep provider internals behind product-owned contracts, and surface deterministic failures instead of raw operating-system errors. Cloudflare OS is service/Workers oriented, so its implementation is a design reference rather than a literal Electron sidecar template.
+
+## Root cause
+The desktop app host configures the native runtime data directory under `feature-host/runtime`. When no explicit workspace is selected, `mahayana-host` derives the product-owned fallback workspace as `feature-host/runtime/workspace`. The first native Agent session canonicalizes that path. A fresh app-data directory did not create the fallback workspace before the first message, so path canonicalization returned OS error 2 and the error propagated through the Agent/provider layers to the conversation UI.
+
+## In scope
+- Create the product-owned desktop fallback workspace before `UnifiedAppHost` initialization.
+- Never create arbitrary user-selected workspace paths implicitly.
+- Add a deterministic regression test for the managed runtime layout.
+- Verify the exact branch through CI before merge.
+- Record PR, CI, merge and canonical-main evidence before task closure.
+
+## Out of scope
+- Retrying filesystem/configuration errors as if they were transient provider failures.
+- Silently falling back to a test backend.
+- Creating missing user-selected workspaces.
+- Changing model credentials or provider routing.
+
+## Acceptance criteria
+1. A fresh desktop app-data directory creates `feature-host/runtime/workspace` before the native host starts.
+2. The first native Agent session no longer fails because the product-owned fallback workspace is absent.
+3. User-selected workspaces remain explicit inputs and are not auto-created by this bootstrap.
+4. Regression coverage runs in CI.
+5. The change is merged only after required checks pass and canonical `main` is verified.
+
+## Verification
+`cargo test -p mahayana-app-host-desktop --profile ci` plus repository fast checks on the exact PR head. Release/E2E packaging remains governed by the repository merge-to-main pipeline.
+
+## Branch / commit / PR
+Branch: `fix/msr-105-desktop-provider-readiness`
+Initial implementation commit: `4936c3c65869be9cbfc4411368115a0e06cddfaf`
+PR: pending
+
+## Implementation summary
+Desktop startup now explicitly creates the runtime-owned fallback workspace before constructing `UnifiedAppHost`. The bootstrap is intentionally limited to the application-owned runtime path. This moves filesystem readiness to the lifecycle boundary instead of allowing an OS-level `ENOENT` to escape during the user's first chat request.
+
+## Evidence
+Pending exact-head CI, PR review/merge, and canonical-main verification.
+
+## Next action
+Open the focused PR, run required CI on the exact head, inspect any failures, and merge only after the branch is green.

--- a/projects/mahayana-sovereign-runtime/management/tasks/MSR-105-desktop-provider-readiness.md
+++ b/projects/mahayana-sovereign-runtime/management/tasks/MSR-105-desktop-provider-readiness.md
@@ -5,7 +5,7 @@
 - **Task ID:** MSR-105
 - **Status:** in-progress
 - **Started:** 2026-08-24T08:11:00+08:00
-- **Updated:** 2026-08-24T08:11:00+08:00
+- **Updated:** 2026-08-24T08:14:00+08:00
 - **Completed:** null
 
 ## Objective
@@ -43,13 +43,13 @@ The desktop app host configures the native runtime data directory under `feature
 ## Branch / commit / PR
 Branch: `fix/msr-105-desktop-provider-readiness`
 Initial implementation commit: `4936c3c65869be9cbfc4411368115a0e06cddfaf`
-PR: pending
+PR: #2081
 
 ## Implementation summary
 Desktop startup now explicitly creates the runtime-owned fallback workspace before constructing `UnifiedAppHost`. The bootstrap is intentionally limited to the application-owned runtime path. This moves filesystem readiness to the lifecycle boundary instead of allowing an OS-level `ENOENT` to escape during the user's first chat request.
 
 ## Evidence
-Pending exact-head CI, PR review/merge, and canonical-main verification.
+PR #2081 is open and mergeable. Exact-head CI had not yet appeared at the first post-PR status read; merge remains blocked until required checks complete.
 
 ## Next action
-Open the focused PR, run required CI on the exact head, inspect any failures, and merge only after the branch is green.
+Run required CI on the exact #2081 head, inspect any failures, and merge only after the branch is green.

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host-desktop/src/main.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host-desktop/src/main.rs
@@ -1,8 +1,27 @@
 use mahayana_unified_app_host::{UnifiedAppHost, default_unified_app_data_dir, dispatch_json};
+use std::fs;
 use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+fn ensure_managed_runtime_layout(app_data_dir: &Path) -> io::Result<()> {
+    // The desktop product owns this fallback workspace.  It must exist before
+    // the native engine canonicalizes the path while opening the first Agent
+    // session.  User-selected workspace paths are validated elsewhere and are
+    // never created implicitly.
+    fs::create_dir_all(app_data_dir.join("feature-host/runtime/workspace"))
+}
 
 fn main() {
-    let host = match UnifiedAppHost::new(default_unified_app_data_dir()) {
+    let app_data_dir = default_unified_app_data_dir();
+    if let Err(error) = ensure_managed_runtime_layout(&app_data_dir) {
+        eprintln!(
+            "failed to initialize managed Mahayana runtime layout at {}: {error}",
+            app_data_dir.display()
+        );
+        std::process::exit(1);
+    }
+
+    let host = match UnifiedAppHost::new(app_data_dir) {
         Ok(host) => host,
         Err(error) => {
             eprintln!("failed to initialize unified Mahayana app host: {error}");
@@ -26,5 +45,29 @@ fn main() {
         if writeln!(stdout, "{response}").is_err() || stdout.flush().is_err() {
             break;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_managed_runtime_layout;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn creates_product_owned_fallback_workspace_before_host_startup() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "fabushi-mahayana-desktop-layout-{}-{suffix}",
+            std::process::id()
+        ));
+
+        ensure_managed_runtime_layout(&root).expect("initialize managed runtime layout");
+        assert!(root.join("feature-host/runtime/workspace").is_dir());
+
+        fs::remove_dir_all(root).expect("remove test layout");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the fresh-install desktop failure where the first Mahayana message could surface `provider failed: backend failed: No such file or directory (os error 2)`.

The desktop host previously derived its managed fallback workspace as `feature-host/runtime/workspace` but did not create it before the native Agent opened its first session. The native engine canonicalizes the workspace path, so a fresh app-data directory failed with `ENOENT` and the low-level error propagated through the provider boundary.

## Design

- Initialize only the **product-owned** fallback workspace at the desktop host lifecycle boundary, before `UnifiedAppHost` starts.
- Do **not** create arbitrary user-selected workspace paths.
- Do **not** retry deterministic filesystem/configuration failures as transient provider failures.
- Add a regression test for a clean app-data layout.
- Track the change under `MSR-105` in the existing Mahayana sovereign runtime project.

## Reference review

Cloudflare OS was reviewed as an architecture reference. Its AI backend centralizes provider/model routing behind typed handles and keeps routing/auth details behind a backend boundary. This PR applies the same class of lifecycle discipline to Fabushi rather than copying its Workers-specific implementation.

## Verification

Required CI must pass on the exact PR head before merge. The focused Rust check is:

`cargo test -p mahayana-app-host-desktop --profile ci`

Release/E2E packaging remains on the repository's merge-to-main pipeline.