### PR TITLE
ci(native): install Linux host dependencies for shared gate

### DIFF
--- a/.github/workflows/native-mobile.yml
+++ b/.github/workflows/native-mobile.yml
@@ -133,6 +133,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - name: Install Linux native host dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            pkg-config libclang-dev libxcb1-dev libxrandr-dev libxfixes-dev \
+            libdbus-1-dev libpipewire-0.3-dev libwayland-dev libxkbcommon-dev \
+            libegl1-mesa-dev libgbm-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt,clippy


### PR DESCRIPTION
## Summary

Fixes the canonical-main `Native mobile quality gate` failure observed after #2081 merged.

The `Shared Rust host contract` job runs `cargo clippy -p mahayana-app-host --all-targets -- -D warnings` on Ubuntu. That graph includes `wayland-sys`, but the job did not install the Linux native development packages required by pkg-config. The exact post-main failure was `Package 'wayland-client', required by 'virtual:world', not found`.

## Change

Install the same Linux native host dependency set already used by the Electron host build before running the shared Rust contract:

- pkg-config / libclang
- XCB/XRandR/XFixes
- D-Bus / PipeWire
- Wayland / xkbcommon
- EGL / GBM

This is a CI-environment correction only; there is no product runtime behavior change.

## Why this is required

The repository's post-main delivery flow requires canonical-main native Rust, Android, and iOS gates to succeed before release delivery. A missing runner system package must not block or falsely classify the product as failing.

## Verification

- `git diff --check` passes locally on the isolated worktree.
- PR fast checks must pass on the exact head.
- Merge through the protected main path, then rerun canonical-main Electron/native E2E and release delivery on the new exact main SHA.