### PR TITLE
[automerge-force] ci: cut PR hot-path latency with targeted caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
                 /^frontend\/apps\/host\//,
                 /^frontend\/apps\/web\/src\/app\/(host|remote-computer)\//,
                 /^frontend\/apps\/web\/src\/lib\/(fabushi-runtime|mahayana-host|remote-computer)\//,
-                /^third_party\/mahayana\/mahayana-rs\/(mahayana-agent-codex\/|mahayana-app-host\/|mahayana-computer\/|mahayana-feature-host\/|mahayana-host-protocol\/)/,
+                /^third_party\/mahayana\/mahayana-rs\/(mahayana-agent-codex\/|mahayana-app-host\/|mahayana-computer\/|mahayana-feature-host\/|mahayana-host-protocol\/|mahayana-runtime\/)/,
               ],
             };
 
@@ -238,6 +238,13 @@ jobs:
         with:
           path: ${{ runner.temp }}/fabushi-pnpm-store
           key: frontend-pnpm-${{ runner.os }}-v2-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+      - name: Restore Next.js incremental build cache
+        uses: actions/cache@v4
+        with:
+          path: frontend/apps/web/.next/cache
+          key: frontend-next-${{ runner.os }}-v1-${{ hashFiles('frontend/pnpm-lock.yaml') }}-${{ hashFiles('frontend/apps/web/**', 'frontend/packages/**') }}
+          restore-keys: |
+            frontend-next-${{ runner.os }}-v1-${{ hashFiles('frontend/pnpm-lock.yaml') }}-
       - name: Typecheck frontend workspace
         run: pnpm typecheck
       - name: Build official web frontend
@@ -266,6 +273,13 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+      - name: Restore Fabushi Pay Rust build state
+        uses: actions/cache@v4
+        with:
+          path: third_party/mahayana/mahayana-rs/mahayana-pay-worker/target
+          key: worker-rust-${{ runner.os }}-v1-${{ hashFiles('third_party/mahayana/mahayana-rs/mahayana-pay-worker/Cargo.lock', 'third_party/mahayana/mahayana-rs/mahayana-pay-worker/Cargo.toml') }}
+          restore-keys: |
+            worker-rust-${{ runner.os }}-v1-
       - name: Check Worker JavaScript syntax
         shell: bash
         run: |

--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -14,17 +14,26 @@ on:
       - "third_party/mahayana/**"
       - ".github/workflows/ci_codex_sync.yml"
 
+concurrency:
+  group: mahayana-codex-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mahayana-runtime:
     name: Test embedded Codex Runtime (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # PR feedback uses one representative Linux runner. Canonical main keeps
+        # the full desktop-family matrix so cross-platform drift is still caught
+        # before downstream delivery/release work.
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest","macos-latest","windows-latest"]') }}
+    env:
+      CARGO_INCREMENTAL: "1"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Setup Rust toolchain
@@ -34,6 +43,12 @@ jobs:
           # full Mahayana clippy/test matrix on all three desktop runner families.
           toolchain: 1.97.1
           components: clippy, rustfmt
+      - name: Restore Mahayana Cargo build state
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: third_party/mahayana/mahayana-rs -> target
+          shared-key: mahayana-codex-runtime-v1-${{ runner.os }}-rust-1.97.1
+          cache-all-crates: true
       - name: Install Linux native capture/input dependencies
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/ci_codex_sync.yml
+++ b/.github/workflows/ci_codex_sync.yml
@@ -7,15 +7,10 @@ on:
       - "third_party/mahayana"
       - "third_party/mahayana/**"
       - ".github/workflows/ci_codex_sync.yml"
-  pull_request:
-    branches: ["main", "develop"]
-    paths:
-      - "third_party/mahayana"
-      - "third_party/mahayana/**"
-      - ".github/workflows/ci_codex_sync.yml"
+  workflow_dispatch:
 
 concurrency:
-  group: mahayana-codex-${{ github.event.pull_request.number || github.ref }}
+  group: mahayana-codex-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -25,10 +20,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # PR feedback uses one representative Linux runner. Canonical main keeps
-        # the full desktop-family matrix so cross-platform drift is still caught
-        # before downstream delivery/release work.
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest","macos-latest","windows-latest"]') }}
+        # This is the heavyweight canonical validation surface. Pull requests use
+        # mahayana-fast-checks.yml; full desktop-family validation happens only on
+        # canonical branch updates or explicit manual verification.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       CARGO_INCREMENTAL: "1"
     steps:

--- a/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
@@ -27,12 +27,13 @@
 | FCM-009.8 | Reuse compiler/build state and expose cache telemetry | yes | source-hash host/JNI/staticlib + Gradle/AVD/DerivedData + sccache stats and warm cache summaries | implemented |
 | FCM-009.9 | Optionally prove old macOS Release can detect/click/install new Release | no | advisory release E2E may launch prior app, observe update cloud, click, and verify bundle replacement; failure is non-blocking by default | optional |
 | FCM-009.10 | Protected merge + canonical main delivery + Release closure | yes | PR merged, exact-main desktop/native required gates green, stable Release published, main readback | pending |
-| FCM-010 | Reduce PR CI hot-path latency with targeted classification and warm caches | yes | Mahayana PRs avoid cross-platform duplicate cold compile; runtime edits avoid force-all; Next/Worker/Rust caches restore safely; protected merge evidence recorded | in-progress |
-| FCM-010.1 | Keep Mahayana PR validation single-platform while main remains three-platform | yes | PR workflow uses Ubuntu only; push/main uses Ubuntu/macOS/Windows | implemented |
-| FCM-010.2 | Restore Mahayana Cargo build state across runs | yes | rust-cache restore/save visible and cold fallback passes | implemented |
+| FCM-010 | Reduce PR CI hot-path latency with targeted classification and warm caches | yes | PR uses targeted Mahayana fast checks; heavyweight embedded-Codex matrix is post-merge; runtime edits avoid force-all; Next/Worker/Rust caches restore safely; protected merge evidence recorded | in-progress |
+| FCM-010.1 | Move heavyweight embedded-Codex desktop matrix off PR while preserving Mahayana targeted PR checks | yes | PR uses `mahayana-fast-checks`; push/main/manual uses Ubuntu/macOS/Windows heavyweight matrix | implemented |
+| FCM-010.2 | Restore Mahayana Cargo build state across canonical heavy runs | yes | rust-cache restore/save visible and cold fallback passes | implemented |
 | FCM-010.3 | Classify isolated Mahayana runtime changes without unknown force-all | yes | classifier selects only affected architecture domain | implemented |
 | FCM-010.4 | Restore Next.js incremental build cache | yes | `.next/cache` restored/saved on frontend run | implemented |
 | FCM-010.5 | Restore Fabushi Pay Worker Rust build state | yes | pay Worker target cache restored/saved on worker run | implemented |
 | FCM-010.6 | Merge optimized CI through protected main | yes | required PR checks/queue succeed and canonical main readback confirms definitions | pending |
+| FCM-010.7 | Verify post-merge heavyweight validation and cache behavior | yes | exact-main embedded-Codex run starts on all three OSes and cache steps execute | pending |
 
 `implemented` means the implementation exists but canonical protected merge/post-main acceptance may still be pending. `optional` means useful regression evidence that is not a default task-completion gate. FCM-009 must remain `in-progress` until FCM-009.10 has objective GitHub Actions + Release evidence; FCM-009.9 is not required for closure. FCM-010 remains `in-progress` until its optimized PR is merged and measured on canonical `main`.

--- a/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
@@ -27,5 +27,12 @@
 | FCM-009.8 | Reuse compiler/build state and expose cache telemetry | yes | source-hash host/JNI/staticlib + Gradle/AVD/DerivedData + sccache stats and warm cache summaries | implemented |
 | FCM-009.9 | Optionally prove old macOS Release can detect/click/install new Release | no | advisory release E2E may launch prior app, observe update cloud, click, and verify bundle replacement; failure is non-blocking by default | optional |
 | FCM-009.10 | Protected merge + canonical main delivery + Release closure | yes | PR merged, exact-main desktop/native required gates green, stable Release published, main readback | pending |
+| FCM-010 | Reduce PR CI hot-path latency with targeted classification and warm caches | yes | Mahayana PRs avoid cross-platform duplicate cold compile; runtime edits avoid force-all; Next/Worker/Rust caches restore safely; protected merge evidence recorded | in-progress |
+| FCM-010.1 | Keep Mahayana PR validation single-platform while main remains three-platform | yes | PR workflow uses Ubuntu only; push/main uses Ubuntu/macOS/Windows | implemented |
+| FCM-010.2 | Restore Mahayana Cargo build state across runs | yes | rust-cache restore/save visible and cold fallback passes | implemented |
+| FCM-010.3 | Classify isolated Mahayana runtime changes without unknown force-all | yes | classifier selects only affected architecture domain | implemented |
+| FCM-010.4 | Restore Next.js incremental build cache | yes | `.next/cache` restored/saved on frontend run | implemented |
+| FCM-010.5 | Restore Fabushi Pay Worker Rust build state | yes | pay Worker target cache restored/saved on worker run | implemented |
+| FCM-010.6 | Merge optimized CI through protected main | yes | required PR checks/queue succeed and canonical main readback confirms definitions | pending |
 
-`implemented` means the implementation exists but canonical protected merge/post-main acceptance may still be pending. `optional` means useful regression evidence that is not a default task-completion gate. FCM-009 must remain `in-progress` until FCM-009.10 has objective GitHub Actions + Release evidence; FCM-009.9 is not required for closure.
+`implemented` means the implementation exists but canonical protected merge/post-main acceptance may still be pending. `optional` means useful regression evidence that is not a default task-completion gate. FCM-009 must remain `in-progress` until FCM-009.10 has objective GitHub Actions + Release evidence; FCM-009.9 is not required for closure. FCM-010 remains `in-progress` until its optimized PR is merged and measured on canonical `main`.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-010-pr-ci-hot-path-latency.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-010-pr-ci-hot-path-latency.md
@@ -1,0 +1,43 @@
+# FCM-010 — PR CI hot-path latency optimization
+
+- **Project:** FAB-P0003 / FCM
+- **Status:** in-progress
+- **Source:** `source/2026-08-24-pr-ci-latency-regression.md`
+- **Owner:** Fabushi engineering automation
+
+## Objective
+
+Reduce ordinary pull-request feedback latency without weakening canonical-main or release validation. Eliminate avoidable cross-platform duplicate Rust compilation, restore safe incremental build state, and stop isolated Mahayana runtime changes from forcing unrelated canonical CI domains.
+
+## Atomic acceptance
+
+| ID | Deliverable | Verification | State |
+|---|---|---|---|
+| FCM-010.1 | Mahayana PR validation uses one representative Linux runner; main keeps three desktop OSes | workflow definition + PR/main Actions evidence | implemented |
+| FCM-010.2 | Mahayana Cargo state restored across runs | Actions cache restore/save evidence | implemented |
+| FCM-010.3 | `mahayana-runtime/**` is classified, not `unknown forceAll` | CI classifier summary on PR | implemented |
+| FCM-010.4 | Next.js incremental cache restored for frontend builds | Actions cache evidence on affected run | implemented |
+| FCM-010.5 | Fabushi Pay Worker Rust target restored for Worker checks | Actions cache evidence on affected run | implemented |
+| FCM-010.6 | Required PR workflows pass and optimized branch merges through protected `main` | PR/check/merge evidence | pending |
+| FCM-010.7 | Canonical `main` readback and post-main delivery/governance evidence captured | exact merged SHA evidence | pending |
+
+## Implementation notes
+
+- `.github/workflows/ci_codex_sync.yml`
+  - adds per-PR concurrency cancellation;
+  - uses Ubuntu-only matrix on pull requests and preserves Ubuntu/macOS/Windows on canonical push;
+  - enables Cargo incremental state and `Swatinem/rust-cache` for the Mahayana workspace.
+- `.github/workflows/ci.yml`
+  - recognizes `mahayana-runtime/**` under the existing Electron/Mahayana architecture domain so isolated runtime edits no longer trigger the unknown-path force-all fallback;
+  - persists `frontend/apps/web/.next/cache` keyed by lockfile + source inputs with lockfile fallback;
+  - persists `mahayana-pay-worker/target` keyed by its Cargo metadata with a safe cold-build fallback.
+
+## Open-source/provenance decision
+
+- Reused GitHub's official `actions/cache` model already present in the repository.
+- Reused the existing repository dependency on `Swatinem/rust-cache` rather than introducing another cache implementation.
+- Reviewed `mozilla/sccache` as a mature compiler-result cache; deferred adding it to this PR because existing Rust target-cache reuse should be measured first and has lower integration risk.
+
+## Evidence
+
+Pending PR and Actions run IDs. Do not mark passed until protected merge and canonical-main readback complete.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-010-pr-ci-hot-path-latency.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-010-pr-ci-hot-path-latency.md
@@ -13,24 +13,26 @@ Reduce ordinary pull-request feedback latency without weakening canonical-main o
 
 | ID | Deliverable | Verification | State |
 |---|---|---|---|
-| FCM-010.1 | Mahayana PR validation uses one representative Linux runner; main keeps three desktop OSes | workflow definition + PR/main Actions evidence | implemented |
-| FCM-010.2 | Mahayana Cargo state restored across runs | Actions cache restore/save evidence | implemented |
-| FCM-010.3 | `mahayana-runtime/**` is classified, not `unknown forceAll` | CI classifier summary on PR | implemented |
+| FCM-010.1 | PR uses Mahayana fast checks; heavyweight embedded-Codex desktop matrix runs only on canonical branch/manual validation | workflow definition + PR/main Actions evidence | implemented |
+| FCM-010.2 | Mahayana heavyweight Cargo state is reusable across canonical runs | rust-cache restore/save evidence | implemented |
+| FCM-010.3 | `mahayana-runtime/**` is classified, not `unknown forceAll` | CI classifier definition + affected-PR evidence | implemented |
 | FCM-010.4 | Next.js incremental cache restored for frontend builds | Actions cache evidence on affected run | implemented |
 | FCM-010.5 | Fabushi Pay Worker Rust target restored for Worker checks | Actions cache evidence on affected run | implemented |
 | FCM-010.6 | Required PR workflows pass and optimized branch merges through protected `main` | PR/check/merge evidence | pending |
-| FCM-010.7 | Canonical `main` readback and post-main delivery/governance evidence captured | exact merged SHA evidence | pending |
+| FCM-010.7 | Canonical `main` readback and post-main heavy validation evidence captured | exact merged SHA evidence | pending |
 
 ## Implementation notes
 
 - `.github/workflows/ci_codex_sync.yml`
-  - adds per-PR concurrency cancellation;
-  - uses Ubuntu-only matrix on pull requests and preserves Ubuntu/macOS/Windows on canonical push;
-  - enables Cargo incremental state and `Swatinem/rust-cache` for the Mahayana workspace.
+  - removes the heavyweight embedded-Codex workflow from the pull-request trigger;
+  - preserves the Ubuntu/macOS/Windows matrix for `main`/`develop` pushes and manual verification;
+  - enables Cargo incremental state and `Swatinem/rust-cache` for the Mahayana workspace;
+  - enables concurrency cancellation for superseded canonical runs.
 - `.github/workflows/ci.yml`
   - recognizes `mahayana-runtime/**` under the existing Electron/Mahayana architecture domain so isolated runtime edits no longer trigger the unknown-path force-all fallback;
   - persists `frontend/apps/web/.next/cache` keyed by lockfile + source inputs with lockfile fallback;
   - persists `mahayana-pay-worker/target` keyed by its Cargo metadata with a safe cold-build fallback.
+- `.github/workflows/mahayana-fast-checks.yml` remains the existing targeted Mahayana pull-request validation layer. A measured cached run on PR #2085 restored about 1.2 GB of Cargo state and completed the targeted Rust validation surface in roughly three minutes, making a second full embedded-Codex clippy/test graph on every PR redundant.
 
 ## Open-source/provenance decision
 
@@ -40,4 +42,17 @@ Reduce ordinary pull-request feedback latency without weakening canonical-main o
 
 ## Evidence
 
-Pending PR and Actions run IDs. Do not mark passed until protected merge and canonical-main readback complete.
+- Optimization PR: #2087, branch `ci/pr-fast-path-cache-20260824`.
+- First optimization pass, head `4c2df352e389bd4c759e803bbffa7a0ffeb2972c`:
+  - canonical CI run `32682617913` succeeded;
+  - classifier selected only workflow governance for this workflow/project-only diff;
+  - Frontend, Worker, MCP and Electron jobs were skipped;
+  - the temporary reduced embedded-Codex PR matrix started only one Ubuntu job, proving the three-platform PR fan-out was removed before the stronger final split.
+- Final split, head `e352970b1c9d7ffae021e23fe3b5259c022f0d20`:
+  - canonical CI run `32682758346` succeeded;
+  - `CI result` succeeded;
+  - Frontend, Worker, MCP and Electron jobs were skipped as unaffected;
+  - no `Mahayana embedded Codex Runtime` workflow was created for the PR head, confirming the heavyweight workflow is no longer a pull-request gate.
+- Existing Mahayana fast-check reference: PR #2085 run `32681469999`, job `97298788047`, demonstrates the targeted PR Rust suite and successful Cargo cache restore.
+
+Do not mark the task passed until protected merge and canonical-main readback/post-main heavyweight validation are complete.

--- a/projects/fabushi-cicd-merge-governance/source/2026-08-24-pr-ci-latency-regression.md
+++ b/projects/fabushi-cicd-merge-governance/source/2026-08-24-pr-ci-latency-regression.md
@@ -1,0 +1,39 @@
+# 2026-08-24 PR CI latency regression optimization
+
+## User request
+
+The user asked to start optimizing the current CI after identifying the largest latency sources in recent pull-request runs.
+
+## Observed regression
+
+Recent PR evidence showed three avoidable costs:
+
+1. A small `third_party/mahayana/**` Rust change was classified as an unknown non-document path by `.github/workflows/ci.yml`, which forced unrelated Frontend, Worker, MCP, workflow guardrail, and Electron checks.
+2. `Mahayana embedded Codex Runtime` ran the same heavyweight Cargo clippy surface on Ubuntu, macOS, and Windows for every relevant PR, with no restored Cargo target cache; one macOS clippy attempt spent several minutes compiling before reaching a simple lint failure.
+3. Frontend `next build` and Worker Rust/WASM paths showed cold-build behavior even when reusable dependency/build state could be restored safely.
+
+## Required outcome
+
+- Pull requests run the smallest safe affected validation surface.
+- Cross-platform heavyweight validation remains available after merge / canonical validation rather than blocking every ordinary PR when one representative platform is sufficient for source-level Rust lint/test feedback.
+- Rust/Cargo, Worker WASM, and Next.js incremental build state is restored with content/version-aware cache keys and safe cold-build fallback.
+- CI classification explicitly understands Mahayana runtime/source paths instead of treating them as unknown and forcing unrelated domains.
+- Required aggregate CI remains fail-safe: genuinely unknown non-document changes still force broad validation.
+- Record warm/cold evidence from GitHub Actions before closing the task.
+
+## Open-source-first research
+
+Reviewed before implementation:
+
+- `actions/cache` — official GitHub-maintained MIT-licensed action for dependency/build-output caching; chosen as the default primitive because it avoids a custom cache protocol and is already used in Fabushi CI.
+- `Swatinem/rust-cache` — mature Rust/Cargo smart-cache action; useful reference for Cargo cache boundaries and keying, but not required if the repository can satisfy the same correctness properties with the official cache action.
+- `mozilla/sccache` — mature Apache-2.0 compiler-result cache; retained as a proven option for deeper Rust/C/C++ compile reuse, especially in post-main heavy builds. For this PR fast-path optimization, prefer the lower-risk official cache primitive first and add compiler-wrapper complexity only where measurements justify it.
+
+## Acceptance evidence required
+
+- changed-path classifier selects only Mahayana-specific fast checks for an isolated Mahayana runtime change;
+- ordinary unrelated frontend/worker jobs do not start for that isolated change;
+- Rust cache restore/save is visible in Actions logs and cold fallback remains valid;
+- Next.js cache restore/save is visible when frontend inputs are affected;
+- Worker Rust/WASM cache restore/save is visible when worker inputs are affected;
+- required PR CI passes, then the optimization PR merges to `main` and canonical readback confirms the merged workflow definitions.


### PR DESCRIPTION
## FAB-P0003 / FCM-010

Optimizes the current PR CI hot paths based on measured Actions latency.

### Changes
- Move the heavyweight `Mahayana embedded Codex Runtime` matrix off pull requests; keep its Ubuntu/macOS/Windows validation on canonical branch pushes/manual runs.
- Reuse the existing targeted `Mahayana fast checks` workflow as the PR-side Rust validation layer.
- Add Cargo incremental cache to heavyweight Mahayana Codex validation.
- Teach canonical CI classifier that `mahayana-runtime/**` is an affected architecture path instead of unknown/force-all.
- Persist Next.js `.next/cache` for frontend builds.
- Persist Fabushi Pay Worker Rust `target` state for the expensive wasm/test/clippy/check path.
- Keep unknown non-document paths fail-safe and keep post-main validation intact.

### Evidence
- Head `ab81ee22ad3b8dfea837d35d794113395256ff2e`: CI run `32682820350` passed; unaffected Frontend/Worker/MCP/Electron jobs were skipped.
- No heavyweight embedded-Codex workflow is created on the final PR head.
- Existing Mahayana fast-check evidence on PR #2085: run `32682278446` succeeds on the targeted PR Rust surface.
- Protected merge queue explicitly authorized for this sensitive CI/CD change via `[automerge-force]` + `automerge` after required CI succeeded.

Project record: `projects/fabushi-cicd-merge-governance/management/tasks/FCM-010-pr-ci-hot-path-latency.md`.