### PR TITLE
[automerge-force] fix(release): unblock cross-platform Mahayana gates

### DIFF
--- a/.github/scripts/assert-gbf-release-readiness.py
+++ b/.github/scripts/assert-gbf-release-readiness.py
@@ -44,7 +44,10 @@ release = (workflows / 'native-electron-release.yml').read_text(encoding='utf-8'
 for marker in (
     'CI result',
     'Electron desktop result',
+    'Electron macOS',
+    'Electron Windows',
     'Native mobile result',
+    'Native iOS',
     'already exists; refusing to mutate an existing release',
     'gh release create',
     'SHA256SUMS.txt',
@@ -82,4 +85,4 @@ for marker in (
     if marker not in adr:
         raise SystemExit(f'GBF release readiness: historical-branch ADR missing {marker}')
 
-print('GBF release readiness passed: canonical seven-gate RC, rollback integrity, immutable signed release and historical-branch isolation are all enforced.')
+print('GBF release readiness passed: canonical per-platform gates, rollback integrity, immutable signed release and historical-branch isolation are all enforced.')

--- a/.github/scripts/require-release-source-gates.sh
+++ b/.github/scripts/require-release-source-gates.sh
@@ -8,13 +8,16 @@ set -euo pipefail
 
 case "$RELEASE_TARGET" in
   macos)
-    required_checks=('CI result' 'Electron desktop result')
+    required_checks=('CI result' 'Electron desktop result' 'Electron macOS')
     ;;
-  ios|android)
+  ios)
+    required_checks=('CI result' 'Native iOS')
+    ;;
+  android)
     required_checks=('CI result' 'Native mobile result')
     ;;
   both)
-    required_checks=('CI result' 'Electron desktop result' 'Native mobile result')
+    required_checks=('CI result' 'Electron desktop result' 'Electron macOS' 'Electron Windows' 'Native mobile result' 'Native iOS')
     ;;
   *)
     echo "Unsupported RELEASE_TARGET '$RELEASE_TARGET'." >&2

--- a/.github/workflows/delivery-governance-contract.yml
+++ b/.github/workflows/delivery-governance-contract.yml
@@ -54,7 +54,7 @@ jobs:
           gate=.github/scripts/require-release-source-gates.sh
           test -s "$gate"
           grep -Fq "compare/main...\$SOURCE_SHA" "$gate"
-          for required in 'CI result' 'Electron desktop result' 'Native mobile result'; do
+          for required in 'CI result' 'Electron desktop result' 'Electron macOS' 'Electron Windows' 'Native mobile result' 'Native iOS'; do
             grep -Fq "$required" "$gate"
           done
 
@@ -105,6 +105,7 @@ jobs:
             echo '## FAB-P0003 delivery governance contract'
             echo
             echo '- Canonical release-source gates: present'
+            echo '- Per-platform desktop/mobile checks: present'
             echo '- Apple Store delivery gate: present'
             echo '- Google Play delivery gate: present'
             echo '- Sensitive CODEOWNERS coverage: present and narrow'

--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -36,134 +36,20 @@ permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Classify Electron changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    outputs:
-      host: ${{ steps.classify.outputs.host }}
-      renderer: ${{ steps.classify.outputs.renderer }}
-      package: ${{ steps.classify.outputs.package }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 1
-      - id: classify
-        name: Select the minimum safe test surface
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
-          FORCE_ALL: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-        run: |
-          set -euo pipefail
-          if [ "$FORCE_ALL" = "true" ] || [ -z "$BASE_SHA" ]; then
-            host=true
-            renderer=true
-            package=true
-          else
-            git fetch --no-tags --depth=1 origin "$BASE_SHA"
-            changed="$(git diff --name-only "$BASE_SHA" HEAD)"
-            printf '%s\n' "$changed" >> "$GITHUB_STEP_SUMMARY"
-            host=false
-            renderer=false
-            package=false
-            if printf '%s\n' "$changed" | grep -Eq '^third_party/mahayana/(codex-rs/|mahayana-rs/(Cargo\.toml|Cargo\.lock|mahayana-app-host/|mahayana-app-host-desktop/|mahayana-feature-host/|mahayana-host/|mahayana-host-protocol/|mahayana-product/))'; then
-              host=true
-            fi
-            if printf '%s\n' "$changed" | grep -Eq '^(desktop/|contracts/automation/cross-platform-journeys\.json$|frontend/apps/host/|frontend/apps/web/src/app/(host|remote-computer)/|frontend/apps/web/src/lib/(fabushi-runtime|mahayana-host|remote-computer)/|frontend/packages/shared/|\.github/scripts/(assert-native-electron-canonical\.sh|assert-electron-feature-host-bridge\.sh|assert-fabushi-desktop-architecture\.py|assert-native-desktop-edge-parity\.py)$)'; then
-              renderer=true
-            fi
-            if printf '%s\n' "$changed" | grep -Eq '^(contracts/automation/cross-platform-journeys\.json$|desktop/(electron/|resources/|scripts/|e2e/|playwright\.config\.ts$|package\.json$|package-lock\.json$)|\.github/workflows/electron-desktop\.yml$)'; then
-              package=true
-            fi
-          fi
-          echo "host=$host" >> "$GITHUB_OUTPUT"
-          echo "renderer=$renderer" >> "$GITHUB_OUTPUT"
-          echo "package=$package" >> "$GITHUB_OUTPUT"
-          printf 'host=%s renderer=%s package=%s\n' "$host" "$renderer" "$package" >> "$GITHUB_STEP_SUMMARY"
-
-  pr-fast:
-    name: Electron PR fast checks
-    needs: changes
-    if: >-
-      github.event_name == 'pull_request' &&
-      (needs.changes.outputs.host == 'true' || needs.changes.outputs.renderer == 'true' || needs.changes.outputs.package == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 12
-    steps:
-      - name: Checkout fast-check inputs
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: desktop/package-lock.json
-      - name: Install Electron dependencies from warm npm cache
-        working-directory: desktop
-        run: npm ci --prefer-offline
-      - name: Enforce canonical application architecture
-        run: bash .github/scripts/assert-native-electron-canonical.sh
-      - name: Verify Electron Feature Host bridge contract
-        run: bash .github/scripts/assert-electron-feature-host-bridge.sh
-      - name: Run lightweight architecture and UI contracts
-        run: |
-          python3 .github/scripts/assert-fabushi-desktop-architecture.py
-          python3 .github/scripts/assert-native-desktop-edge-parity.py
-          python3 .github/scripts/assert-auth-entry-flow.py
-          python3 .github/scripts/assert-bot-mark-motion.py
-          python3 .github/scripts/assert-product-ui-contracts.py
-          python3 .github/scripts/assert-native-capability-semantics.py
-      - name: Run Electron main-process contract tests without packaging/E2E
-        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
-      - name: Verify renderer TypeScript without installer/E2E
-        working-directory: desktop
-        run: npx tsc --noEmit
-
-  runtime-smoke:
-    name: Electron Host simulated user smoke
-    needs: changes
-    if: >-
-      github.event_name != 'pull_request' &&
-      (needs.changes.outputs.host == 'true' || needs.changes.outputs.renderer == 'true' || needs.changes.outputs.package == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+  platform:
+    name: ${{ matrix.check_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"os":"ubuntu-latest","label":"Linux","target":"linux","check_name":"Electron desktop result"}]' || '[{"os":"macos-15","label":"macOS","target":"mac","check_name":"Electron macOS"},{"os":"windows-latest","label":"Windows","target":"win","check_name":"Electron Windows"},{"os":"ubuntu-latest","label":"Linux","target":"linux","check_name":"Electron desktop result"}]') }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
     steps:
       - name: Checkout source
         uses: actions/checkout@v5
-
-      - id: host-source-key
-        name: Freeze Rust Host source cache key
-        shell: bash
-        env:
-          SOURCE_HASH: ${{ hashFiles('third_party/mahayana/mahayana-rs/Cargo.lock', 'third_party/mahayana/mahayana-rs/**/*.rs', 'third_party/mahayana/mahayana-rs/**/Cargo.toml', 'third_party/mahayana/codex-rs/**/*.rs', 'third_party/mahayana/codex-rs/**/Cargo.toml') }}
-        run: echo "hash=$SOURCE_HASH" >> "$GITHUB_OUTPUT"
-
-      - name: Enforce canonical application architecture
-        shell: bash
-        run: bash .github/scripts/assert-native-electron-canonical.sh
-
-      - name: Verify Electron Feature Host bridge contract
-        shell: bash
-        run: bash .github/scripts/assert-electron-feature-host-bridge.sh
-
-      - name: Guard the Fabushi desktop architecture
-        run: python3 .github/scripts/assert-fabushi-desktop-architecture.py
-      - name: Verify native desktop edge parity
-        run: python3 .github/scripts/assert-native-desktop-edge-parity.py
-      - name: Verify browser-first account login
-        run: python3 .github/scripts/assert-auth-entry-flow.py
-      - name: Verify living BotMark motion contracts
-        run: python3 .github/scripts/assert-bot-mark-motion.py
-      - name: Verify product UI capability surfaces
-        run: python3 .github/scripts/assert-product-ui-contracts.py
-      - name: Reject native capability stubs
-        run: python3 .github/scripts/assert-native-capability-semantics.py
-      - name: Verify Electron edge, host lifecycle, and offline ASR contracts
-        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -176,31 +62,77 @@ jobs:
         working-directory: desktop
         run: npm ci --prefer-offline
 
+      - name: Enforce canonical application architecture
+        if: matrix.target == 'linux'
+        shell: bash
+        run: bash .github/scripts/assert-native-electron-canonical.sh
+
+      - name: Verify Electron Feature Host bridge contract
+        if: matrix.target == 'linux'
+        shell: bash
+        run: bash .github/scripts/assert-electron-feature-host-bridge.sh
+
+      - name: Run lightweight architecture and UI contracts
+        if: matrix.target == 'linux'
+        shell: bash
+        run: |
+          python3 .github/scripts/assert-fabushi-desktop-architecture.py
+          python3 .github/scripts/assert-native-desktop-edge-parity.py
+          python3 .github/scripts/assert-auth-entry-flow.py
+          python3 .github/scripts/assert-bot-mark-motion.py
+          python3 .github/scripts/assert-product-ui-contracts.py
+          python3 .github/scripts/assert-native-capability-semantics.py
+
+      - name: Run Electron main-process contract tests
+        if: matrix.target == 'linux'
+        shell: bash
+        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
+
+      - name: Verify renderer TypeScript
+        if: matrix.target == 'linux'
+        working-directory: desktop
+        run: npx tsc --noEmit
+
+      - name: Record PR fast-path completion
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo 'Electron PR fast checks passed on the single Linux desktop runner; installer and packaged E2E remain post-main gates.' >> "$GITHUB_STEP_SUMMARY"
+
+      - id: host-source-key
+        name: Freeze Rust Host source cache key
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          SOURCE_HASH: ${{ hashFiles('third_party/mahayana/mahayana-rs/Cargo.lock', 'third_party/mahayana/mahayana-rs/**/*.rs', 'third_party/mahayana/mahayana-rs/**/Cargo.toml', 'third_party/mahayana/codex-rs/**/*.rs', 'third_party/mahayana/codex-rs/**/Cargo.toml') }}
+        run: echo "hash=$SOURCE_HASH" >> "$GITHUB_OUTPUT"
+
       - id: host-binary-cache
-        name: Restore reusable Linux Host binary
+        name: Restore reusable native Host binary
+        if: github.event_name != 'pull_request'
         uses: actions/cache/restore@v4
         with:
           path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v8-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
+          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v9-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
 
-      - name: Record Host binary cache result
+      - name: Record native Host cache result
+        if: github.event_name != 'pull_request'
         shell: bash
-        run: echo "Host binary cache hit=${{ steps.host-binary-cache.outputs.cache-hit }} key=electron-host-${{ runner.os }}-${{ runner.arch }}-v8-…" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "${{ matrix.label }} Host binary cache hit=${{ steps.host-binary-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Rust on Host cache miss
-        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
 
       - name: Enable compiler-result cache on Host cache miss
-        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: mozilla-actions/sccache-action@v0.0.11
         with:
           version: v0.16.0
 
       - name: Install Linux native Host dependencies on cache miss
-        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           sudo apt-get update
@@ -210,14 +142,14 @@ jobs:
             libegl1-mesa-dev libgbm-dev
 
       - name: Restore Rust dependency/target cache on Host cache miss
-        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: electron-desktop-host-ci-v7-rust-1.97.1
+          shared-key: electron-platform-${{ runner.os }}-v8-rust-1.97.1
 
-      - name: Build and stage CI Mahayana Host on cache miss
-        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+      - name: Build and stage CI native Host on cache miss
+        if: github.event_name != 'pull_request' && steps.host-binary-cache.outputs.cache-hit != 'true'
         working-directory: desktop
         env:
           SCCACHE_GHA_ENABLED: 'true'
@@ -225,91 +157,34 @@ jobs:
         run: npm run build:host:ci
 
       - name: Show Rust compiler cache stats
-        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && steps.host-binary-cache.outputs.cache-hit != 'true'
         shell: bash
         run: sccache --show-stats >> "$GITHUB_STEP_SUMMARY" || true
 
-      - name: Save reusable Linux Host binary immediately
-        if: steps.host-binary-cache.outputs.cache-hit != 'true'
+      - name: Save reusable native Host binary immediately
+        if: github.event_name != 'pull_request' && steps.host-binary-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v8-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
-
-      - name: Hand off Linux Host binary to package job in the same run
-        uses: actions/upload-artifact@v7
-        with:
-          name: electron-host-linux-ci
-          path: desktop/resources/bin/mahayana-app-host
-          if-no-files-found: error
-          retention-days: 1
+          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v9-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
 
       - name: Build Electron renderer
+        if: github.event_name != 'pull_request'
         working-directory: desktop
         run: npm run build:renderer
 
-      - name: Simulate a user in the Electron sandbox and real Rust Host
+      - name: Simulate a user against the real Linux Rust Host before packaging
+        if: github.event_name != 'pull_request' && matrix.target == 'linux'
         working-directory: desktop
         env:
           FABUSHI_FEATURE_HOST_MODE: test
           MAHAYANA_APP_HOST_BIN: ${{ github.workspace }}/desktop/resources/bin/mahayana-app-host
         run: xvfb-run -a npm run test:e2e
 
-      - name: Upload Electron E2E failure evidence
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: electron-runtime-smoke-failure-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            desktop/test-results
-            desktop/playwright-report
-          if-no-files-found: warn
-          retention-days: 7
-
-  package:
-    name: Package Electron (${{ matrix.label }})
-    needs: [changes, runtime-smoke]
-    if: >-
-      always() &&
-      github.event_name != 'pull_request' &&
-      needs.runtime-smoke.result == 'success' &&
-      (needs.changes.outputs.host == 'true' || needs.changes.outputs.package == 'true')
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-15
-            label: macOS
-            target: mac
-          - os: windows-latest
-            label: Windows
-            target: win
-          - os: ubuntu-latest
-            label: Linux
-            target: linux
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 180
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-
-      - id: host-source-key
-        name: Freeze Rust Host source cache key
-        shell: bash
-        env:
-          SOURCE_HASH: ${{ hashFiles('third_party/mahayana/mahayana-rs/Cargo.lock', 'third_party/mahayana/mahayana-rs/**/*.rs', 'third_party/mahayana/mahayana-rs/**/Cargo.toml', 'third_party/mahayana/codex-rs/**/*.rs', 'third_party/mahayana/codex-rs/**/Cargo.toml') }}
-        run: echo "hash=$SOURCE_HASH" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: desktop/package-lock.json
-
-      - name: Install Electron dependencies
-        working-directory: desktop
-        run: npm ci --prefer-offline
+      - name: Build pinned offline ASR engine
+        if: github.event_name != 'pull_request'
+        working-directory: ${{ github.workspace }}
+        run: node .github/scripts/build-offline-asr-engine.mjs
 
       - name: Assign monotonic desktop version for canonical main delivery
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -327,77 +202,6 @@ jobs:
           npm pkg set "version=$version"
           echo "FABUSHI_DELIVERY_VERSION=$version" >> "$GITHUB_ENV"
           echo "Canonical main desktop version: $version (source $GITHUB_SHA)" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Reuse Linux Host binary from runtime smoke in the same run
-        if: matrix.target == 'linux'
-        uses: actions/download-artifact@v8
-        with:
-          name: electron-host-linux-ci
-          path: desktop/resources/bin
-
-      - name: Restore Linux Host executable permission after artifact transfer
-        if: matrix.target == 'linux'
-        run: chmod +x desktop/resources/bin/mahayana-app-host
-
-      - id: host-binary-cache
-        name: Restore reusable native Host binary
-        if: matrix.target != 'linux'
-        uses: actions/cache/restore@v4
-        with:
-          path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v8-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
-
-      - name: Record native Host cache result
-        if: matrix.target != 'linux'
-        shell: bash
-        run: echo "${{ matrix.label }} Host binary cache hit=${{ steps.host-binary-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Set up Rust on Host cache miss
-        if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.97.1
-
-      - name: Enable compiler-result cache on Host cache miss
-        if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
-        uses: mozilla-actions/sccache-action@v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Restore Rust dependency/target cache on Host cache miss
-        if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: electron-package-ci-${{ runner.os }}-v7-rust-1.97.1
-
-      - name: Build and stage CI native Host on cache miss
-        if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
-        working-directory: desktop
-        env:
-          SCCACHE_GHA_ENABLED: 'true'
-          RUSTC_WRAPPER: sccache
-        run: npm run build:host:ci
-
-      - name: Show Rust compiler cache stats
-        if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: sccache --show-stats >> "$GITHUB_STEP_SUMMARY" || true
-
-      - name: Save reusable native Host binary immediately
-        if: matrix.target != 'linux' && steps.host-binary-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: desktop/resources/bin
-          key: electron-host-${{ runner.os }}-${{ runner.arch }}-v8-rust-1.97.1-${{ steps.host-source-key.outputs.hash }}
-
-      - name: Build pinned offline ASR engine
-        working-directory: ${{ github.workspace }}
-        run: node .github/scripts/build-offline-asr-engine.mjs
-
-      - name: Build renderer once without rebuilding the Host
-        working-directory: desktop
-        run: npm run build:renderer
 
       - name: Install Developer ID identity for canonical main macOS package
         if: matrix.target == 'mac' && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -446,6 +250,7 @@ jobs:
           codesign --verify --strict --verbose=2 "$host"
 
       - name: Package canonical Electron application from staged inputs
+        if: github.event_name != 'pull_request'
         working-directory: desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.target == 'mac' && github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}
@@ -492,6 +297,7 @@ jobs:
           bash .github/scripts/verify-electron-macos-package.sh "$app" "$dmg"
 
       - name: Locate runnable packaged Electron executable
+        if: github.event_name != 'pull_request'
         shell: pwsh
         run: |
           $release = Join-Path $env:GITHUB_WORKSPACE 'desktop/release'
@@ -521,21 +327,21 @@ jobs:
           "Packaged executable: $($candidate.FullName)" >> $env:GITHUB_STEP_SUMMARY
 
       - name: Simulate the complete user journey in packaged Linux Electron
-        if: matrix.target == 'linux'
+        if: github.event_name != 'pull_request' && matrix.target == 'linux'
         working-directory: desktop
         env:
           FABUSHI_FEATURE_HOST_MODE: test
         run: xvfb-run -a npm run test:e2e
 
       - name: Simulate the complete user journey in packaged macOS or Windows Electron
-        if: matrix.target != 'linux'
+        if: github.event_name != 'pull_request' && matrix.target != 'linux'
         working-directory: desktop
         env:
           FABUSHI_FEATURE_HOST_MODE: test
         run: npm run test:e2e
 
       - name: Upload packaged Electron user-journey diagnostics
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: fabushi-electron-${{ matrix.target }}-e2e-diagnostics
@@ -546,43 +352,10 @@ jobs:
           retention-days: 14
 
       - name: Upload Electron packages
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: fabushi-electron-${{ matrix.target }}
           path: desktop/release/**
           if-no-files-found: error
           retention-days: 14
-
-  result:
-    name: Electron desktop result
-    needs: [changes, pr-fast, runtime-smoke, package]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    steps:
-      - name: Require every selected Electron layer for this event
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_FAST: ${{ needs.pr-fast.result }}
-          RUNTIME: ${{ needs.runtime-smoke.result }}
-          PACKAGE: ${{ needs.package.result }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = pull_request ]; then
-            if [ "$PR_FAST" != success ] && [ "$PR_FAST" != skipped ]; then
-              echo "PR fast checks failed: $PR_FAST" >&2
-              exit 1
-            fi
-            echo 'Electron PR fast checks passed; installer/E2E deferred to post-main delivery.'
-            exit 0
-          fi
-          for pair in "runtime:$RUNTIME" "package:$PACKAGE"; do
-            name="${pair%%:*}"
-            result="${pair#*:}"
-            if [ "$result" != success ] && [ "$result" != skipped ]; then
-              echo "$name failed: $result" >&2
-              exit 1
-            fi
-          done
-          echo 'Electron post-main selected-surface package and user-journey checks passed.'

--- a/.github/workflows/global-dharma-rust.yml
+++ b/.github/workflows/global-dharma-rust.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Verify Mahayana source ownership boundary
         run: python3 scripts/check-mahayana-source-boundary.py
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux native host dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            pkg-config libclang-dev libxcb1-dev libxrandr-dev libxfixes-dev \
+            libdbus-1-dev libpipewire-0.3-dev libwayland-dev libxkbcommon-dev \
+            libegl1-mesa-dev libgbm-dev
       - name: Restore Mahayana Cargo cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/mahayana-cloud-marketplace-e2e.yml
+++ b/.github/workflows/mahayana-cloud-marketplace-e2e.yml
@@ -26,7 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      CARGO_INCREMENTAL: 1
+      # This job compiles both Worker and native Mahayana graphs. Incremental
+      # artifacts are not reused inside the immutable CI run and can consume
+      # several additional GiB on GitHub-hosted runners.
+      CARGO_INCREMENTAL: 0
       CARGO_PROFILE: ci
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
@@ -41,6 +44,22 @@ jobs:
       - name: Configure runner paths
         shell: bash
         run: echo "MAHAYANA_HOME=$RUNNER_TEMP/mahayana-home" >> "$GITHUB_ENV"
+
+      - name: Reclaim Ubuntu runner disk for marketplace E2E
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Disk before reclaim:"
+          df -h /
+          # Marketplace E2E uses Node, Rust, Wrangler and native Linux libs; it
+          # does not use the preinstalled Android, .NET or Haskell toolchains.
+          # Reclaim those hosted-runner images before restoring the Rust cache
+          # so the native host build cannot fail with ENOSPC late in the run.
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          docker system prune -af >/dev/null 2>&1 || true
+          sudo apt-get clean
+          echo "Disk after reclaim:"
+          df -h /
 
       - name: Require deployment credentials
         shell: bash

--- a/.github/workflows/native-electron-release.yml
+++ b/.github/workflows/native-electron-release.yml
@@ -21,115 +21,133 @@ env:
   RELEASE_TAG: ${{ inputs.tag }}
 
 jobs:
-  verify:
-    name: Verify canonical release source
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Verify tag and canonical architecture
-        shell: bash
-        run: |
-          set -euo pipefail
-          git rev-parse -q --verify "refs/tags/$RELEASE_TAG"
-          bash .github/scripts/assert-native-electron-canonical.sh
-      - name: Require green CI, Electron and native-mobile gates for the tagged commit
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          tagged_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
-          checks_json="$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/commits/$tagged_sha/check-runs?per_page=100")"
-          for required in 'CI result' 'Electron desktop result' 'Native mobile result'; do
-            conclusion="$(printf '%s' "$checks_json" | jq -r --arg required "$required" '[.[].check_runs[] | select(.name == $required)] | last | .conclusion // "missing"')"
-            if [ "$conclusion" != "success" ]; then
-              echo "Required release gate '$required' is $conclusion for $tagged_sha." >&2
-              exit 1
-            fi
-          done
-          echo "Tagged commit $tagged_sha has all canonical platform gates green."
-      - id: version
-        shell: bash
-        run: echo "version=$(jq -r '.version' app-version.json)" >> "$GITHUB_OUTPUT"
-
-  electron-quality:
-    name: Electron release smoke
-    needs: verify
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          submodules: recursive
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: desktop/package-lock.json
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: release-electron-${{ runner.os }}-v2
-      - working-directory: desktop
-        run: npm ci --prefer-offline
-      - working-directory: desktop
-        run: npm run build
-      - name: Playwright Electron smoke
-        working-directory: desktop
-        run: xvfb-run -a npm run test:e2e
-
-  electron-package:
-    name: Electron package (${{ matrix.label }})
-    needs: [verify, electron-quality]
+  platform:
+    name: Release platform (${{ matrix.label }})
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: macos-15
-            label: macOS
+            label: macOS desktop
+            kind: electron
             target: mac
           - os: windows-latest
-            label: Windows
+            label: Windows desktop
+            kind: electron
             target: win
           - os: ubuntu-latest
-            label: Linux
+            label: Linux desktop
+            kind: electron
             target: linux
+          - os: ubuntu-latest
+            label: Android
+            kind: android
+            target: android
+          - os: macos-15
+            label: iOS
+            kind: ios
+            target: ios
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout immutable release source
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
           submodules: recursive
-      - uses: actions/setup-node@v6
+          persist-credentials: false
+
+      - name: Verify tag, canonical architecture, and exact-SHA platform gates
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git rev-parse -q --verify "refs/tags/$RELEASE_TAG"
+          bash .github/scripts/assert-native-electron-canonical.sh
+          tagged_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          checks_json="$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/commits/$tagged_sha/check-runs?per_page=100")"
+          for required in 'CI result' 'Electron desktop result' 'Electron macOS' 'Electron Windows' 'Native mobile result' 'Native iOS'; do
+            conclusion="$(printf '%s' "$checks_json" | jq -r --arg required "$required" '[.[].check_runs[] | select(.name == $required)] | last | .conclusion // "missing"')"
+            if [ "$conclusion" != success ]; then
+              echo "Required release gate '$required' is $conclusion for $tagged_sha." >&2
+              exit 1
+            fi
+          done
+          echo "Tagged commit $tagged_sha has all canonical platform gates green." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Load release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(jq -r '.version' app-version.json)"
+          test -n "$version"
+          test "$version" != null
+          echo "FABUSHI_RELEASE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "Release version: $version" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set up Node.js for Electron
+        if: matrix.kind == 'electron'
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: desktop/package-lock.json
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+
+      - name: Set up Rust for Electron
+        if: matrix.kind == 'electron'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+
+      - name: Restore Electron Rust cache
+        if: matrix.kind == 'electron'
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: release-electron-${{ runner.os }}-v2
-      - working-directory: desktop
+          shared-key: release-electron-${{ runner.os }}-v3
+
+      - name: Install Linux Electron native dependencies
+        if: matrix.kind == 'electron' && matrix.target == 'linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            pkg-config libclang-dev libxcb1-dev libxrandr-dev libxfixes-dev \
+            libdbus-1-dev libpipewire-0.3-dev libwayland-dev libxkbcommon-dev \
+            libegl1-mesa-dev libgbm-dev
+
+      - name: Install Electron dependencies
+        if: matrix.kind == 'electron'
+        working-directory: desktop
         run: npm ci --prefer-offline
+
       - name: Build and stage release Mahayana Host
+        if: matrix.kind == 'electron'
         working-directory: desktop
         run: npm run build:host
+
       - name: Build pinned offline ASR engine
+        if: matrix.kind == 'electron'
         working-directory: ${{ github.workspace }}
         run: node .github/scripts/build-offline-asr-engine.mjs
+
       - name: Build release renderer
+        if: matrix.kind == 'electron'
         working-directory: desktop
         run: npm run build:renderer
+
+      - name: Run release Electron user smoke on the Linux platform runner
+        if: matrix.kind == 'electron' && matrix.target == 'linux'
+        working-directory: desktop
+        env:
+          FABUSHI_FEATURE_HOST_MODE: test
+          MAHAYANA_APP_HOST_BIN: ${{ github.workspace }}/desktop/resources/bin/mahayana-app-host
+        run: xvfb-run -a npm run test:e2e
+
       - name: Install Developer ID Application identity
-        if: matrix.target == 'mac'
+        if: matrix.kind == 'electron' && matrix.target == 'mac'
         shell: bash
         env:
           MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
@@ -160,8 +178,9 @@ jobs:
           esac
           security find-identity -v -p codesigning "$keychain" | grep -F -- "$identity" >/dev/null
           echo "MACOS_CODESIGN_IDENTITY=$identity" >> "$GITHUB_ENV"
+
       - name: Sign bundled native macOS executables before app sealing
-        if: matrix.target == 'mac'
+        if: matrix.kind == 'electron' && matrix.target == 'mac'
         shell: bash
         run: |
           set -euo pipefail
@@ -174,6 +193,7 @@ jobs:
           codesign --verify --strict --verbose=2 "$host"
 
       - name: Package canonical Electron application
+        if: matrix.kind == 'electron'
         working-directory: desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.target == 'mac' && 'true' || 'false' }}
@@ -185,8 +205,9 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         run: npx electron-builder --${{ matrix.target }} --publish never
+
       - name: Notarize and staple macOS DMG
-        if: matrix.target == 'mac'
+        if: matrix.kind == 'electron' && matrix.target == 'mac'
         shell: bash
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -200,38 +221,38 @@ jobs:
         run: |
           set -euo pipefail
           dmg="$(find desktop/release -maxdepth 1 -type f -name '*.dmg' -print -quit)"
-          test -n "$dmg"
-          bash .github/scripts/notarize-macos-dmg.sh "$dmg"
           app="$(find desktop/release -maxdepth 3 -type d -name '*.app' -print -quit)"
+          test -n "$dmg"
           test -n "$app"
+          bash .github/scripts/notarize-macos-dmg.sh "$dmg"
           chmod +x .github/scripts/verify-electron-macos-package.sh
           bash .github/scripts/verify-electron-macos-package.sh "$app" "$dmg"
-      - uses: actions/upload-artifact@v7
+
+      - name: Upload Electron package
+        if: matrix.kind == 'electron'
+        uses: actions/upload-artifact@v7
         with:
           name: electron-${{ matrix.target }}
           path: desktop/release/**
           if-no-files-found: error
           retention-days: 14
 
-  android-release:
-    name: Signed native Android APK/AAB
-    needs: verify
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          submodules: recursive
-      - uses: actions/setup-java@v5
+      - name: Set up Java for Android
+        if: matrix.kind == 'android'
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: android-actions/setup-android@v4
+
+      - name: Set up Android SDK
+        if: matrix.kind == 'android'
+        uses: android-actions/setup-android@v4
         with:
           cmdline-tools-version: '14742923'
           packages: 'platform-tools'
+
       - name: Install Android 17 SDK and NDK
+        if: matrix.kind == 'android'
         shell: bash
         run: |
           set -euo pipefail
@@ -245,22 +266,49 @@ jobs:
             test -n "$installed_platform"
             ln -s "$installed_platform" "$ANDROID_HOME/platforms/android-37"
           fi
-      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Rust for Android
+        if: matrix.kind == 'android'
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android,x86_64-linux-android
-      - uses: Swatinem/rust-cache@v2
+
+      - name: Restore Android release Rust cache
+        if: matrix.kind == 'android'
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: release-android-v2
-      - name: Install cargo-ndk
+          shared-key: release-android-v3
+
+      - name: Restore cargo-ndk
+        if: matrix.kind == 'android'
+        id: release-cargo-ndk
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cargo/bin/cargo-ndk
+          key: release-cargo-ndk-${{ runner.os }}-${{ runner.arch }}-v1
+
+      - name: Install cargo-ndk on cache miss
+        if: matrix.kind == 'android' && steps.release-cargo-ndk.outputs.cache-hit != 'true'
         run: cargo install cargo-ndk --locked
+
+      - name: Save cargo-ndk on cache miss
+        if: matrix.kind == 'android' && steps.release-cargo-ndk.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cargo/bin/cargo-ndk
+          key: release-cargo-ndk-${{ runner.os }}-${{ runner.arch }}-v1
+
       - name: Build native Rust JNI libraries
+        if: matrix.kind == 'android'
         working-directory: third_party/mahayana/mahayana-rs
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
           ANDROID_NDK_ROOT: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
         run: cargo ndk -t arm64-v8a -t x86_64 -o ../../../mobile/android/app/src/main/jniLibs build --release -p mahayana-app-host-mobile
+
       - name: Install Android signing key
+        if: matrix.kind == 'android'
         shell: bash
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -268,17 +316,25 @@ jobs:
           set -euo pipefail
           test -n "$ANDROID_KEYSTORE_BASE64"
           printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/fabushi-release.jks"
+
       - name: Restore Gradle dependency and build cache
+        if: matrix.kind == 'android'
         uses: gradle/actions/setup-gradle@v4
+
       - name: Build signed Android release
+        if: matrix.kind == 'android'
         working-directory: mobile/android
         env:
           ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/fabushi-release.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        run: ./gradlew --no-daemon --build-cache bundleRelease assembleRelease -PversionName=${{ needs.verify.outputs.version }}
-      - uses: actions/upload-artifact@v7
+        shell: bash
+        run: ./gradlew --no-daemon --build-cache bundleRelease assembleRelease -PversionName="$FABUSHI_RELEASE_VERSION"
+
+      - name: Upload Android release
+        if: matrix.kind == 'android'
+        uses: actions/upload-artifact@v7
         with:
           name: android-release
           path: |
@@ -287,34 +343,37 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  ios-release:
-    name: Signed native iOS IPA
-    needs: verify
-    runs-on: macos-15
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust for iOS
+        if: matrix.kind == 'ios'
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-ios
-      - uses: Swatinem/rust-cache@v2
+
+      - name: Restore iOS release Rust cache
+        if: matrix.kind == 'ios'
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: release-ios-v2
+          shared-key: release-ios-v3
+
       - name: Install XcodeGen
+        if: matrix.kind == 'ios'
         run: command -v xcodegen >/dev/null 2>&1 || brew install xcodegen
+
       - name: Build Rust static library for iOS device
+        if: matrix.kind == 'ios'
         working-directory: third_party/mahayana/mahayana-rs
         run: cargo build --release -p mahayana-app-host-mobile --target aarch64-apple-ios
+
       - name: Stage Rust static library
+        if: matrix.kind == 'ios'
         shell: bash
         run: |
           mkdir -p mobile/ios/Frameworks
           cp third_party/mahayana/mahayana-rs/target/aarch64-apple-ios/release/libmahayana_app_host.a mobile/ios/Frameworks/
+
       - name: Install iOS signing identity and profile
+        if: matrix.kind == 'ios'
         shell: bash
         env:
           IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64 }}
@@ -341,10 +400,14 @@ jobs:
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$profile" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
           echo "PROFILE_NAME=$profile_name" >> "$GITHUB_ENV"
+
       - name: Generate Xcode project
+        if: matrix.kind == 'ios'
         working-directory: mobile/ios
         run: xcodegen generate
+
       - name: Archive native iOS application
+        if: matrix.kind == 'ios'
         working-directory: mobile/ios
         env:
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
@@ -359,7 +422,9 @@ jobs:
           CODE_SIGN_STYLE=Manual
           CODE_SIGN_IDENTITY='Apple Distribution'
           PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME"
+
       - name: Export signed iOS IPA
+        if: matrix.kind == 'ios'
         shell: bash
         env:
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
@@ -380,7 +445,10 @@ jobs:
             -archivePath "$RUNNER_TEMP/Fabushi.xcarchive" \
             -exportPath "$RUNNER_TEMP/ios-export" \
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
-      - uses: actions/upload-artifact@v7
+
+      - name: Upload iOS release
+        if: matrix.kind == 'ios'
+        uses: actions/upload-artifact@v7
         with:
           name: ios-release
           path: ${{ runner.temp }}/ios-export/*.ipa
@@ -388,18 +456,23 @@ jobs:
           retention-days: 14
 
   publish:
-    name: Publish native Electron GitHub Release
-    needs: [verify, electron-package, android-release, ios-release]
+    name: Release control plane (no platform build)
+    needs: platform
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          persist-credentials: false
+
       - uses: actions/download-artifact@v8
         with:
           path: release
           merge-multiple: true
-      - name: Verify desktop install and auto-update assets
+
+      - name: Verify complete cross-platform asset set
         shell: bash
         run: |
           set -euo pipefail
@@ -407,12 +480,19 @@ jobs:
           test -n "$(find release -type f -name 'fabushi-*-macos-*.zip' -print -quit)"
           test -n "$(find release -type f -name 'latest-mac.yml' -print -quit)"
           test -n "$(find release -type f -name '*.zip.blockmap' -print -quit)"
-          echo 'Verified GitHub Release contains DMG plus electron-updater macOS feed assets.' >> "$GITHUB_STEP_SUMMARY"
+          test -n "$(find release -type f -name '*.exe' -print -quit)"
+          test -n "$(find release -type f -name '*.AppImage' -print -quit)"
+          test -n "$(find release -type f -name '*.apk' -print -quit)"
+          test -n "$(find release -type f -name '*.aab' -print -quit)"
+          test -n "$(find release -type f -name '*.ipa' -print -quit)"
+          echo 'Verified complete desktop + Android + iOS release asset set.' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Generate release checksums
         shell: bash
         run: |
           set -euo pipefail
           find release -type f ! -name SHA256SUMS.txt -print0 | sort -z | xargs -0 sha256sum > release/SHA256SUMS.txt
+
       - name: Publish immutable release assets
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/native-mobile.yml
+++ b/.github/workflows/native-mobile.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Reject whitespace and conflict-marker regressions on PR

--- a/.github/workflows/native-mobile.yml
+++ b/.github/workflows/native-mobile.yml
@@ -30,72 +30,24 @@ permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Classify native changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    outputs:
-      shared: ${{ steps.classify.outputs.shared }}
-      android: ${{ steps.classify.outputs.android }}
-      ios: ${{ steps.classify.outputs.ios }}
+  platform:
+    name: ${{ matrix.check_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"os":"ubuntu-latest","target":"android","check_name":"Native mobile result"}]' || '[{"os":"ubuntu-latest","target":"android","check_name":"Native mobile result"},{"os":"macos-15","target":"ios","check_name":"Native iOS"}]') }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout source
+        uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 1
-      - id: classify
-        name: Select affected PR surface and full canonical main surface
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
-          FORCE_ALL: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-        run: |
-          set -euo pipefail
-          if [ "$FORCE_ALL" = "true" ] || [ -z "$BASE_SHA" ]; then
-            shared=true
-            android=true
-            ios=true
-          else
-            git fetch --no-tags --depth=1 origin "$BASE_SHA"
-            changed="$(git diff --name-only "$BASE_SHA" HEAD)"
-            printf '%s\n' "$changed" >> "$GITHUB_STEP_SUMMARY"
-            shared=false
-            android=false
-            ios=false
-            if printf '%s\n' "$changed" | grep -Eq '^third_party/mahayana/(codex-rs/|mahayana-rs/(Cargo\.toml|Cargo\.lock|mahayana-app-host/|mahayana-app-host-mobile/|mahayana-host-protocol/|mahayana-product/|mahayana-plugin-runtime/|mahayana-js-runtime/))'; then
-              shared=true
-            fi
-            if printf '%s\n' "$changed" | grep -Eq '^(mobile/android/|app-version\.json$)'; then
-              android=true
-            fi
-            if printf '%s\n' "$changed" | grep -Eq '^(mobile/ios/|app-version\.json$)'; then
-              ios=true
-            fi
-            if printf '%s\n' "$changed" | grep -Eq '^(contracts/automation/cross-platform-journeys\.json$|\.github/workflows/native-mobile\.yml$)'; then
-              shared=true
-              android=true
-              ios=true
-            fi
-          fi
-          echo "shared=$shared" >> "$GITHUB_OUTPUT"
-          echo "android=$android" >> "$GITHUB_OUTPUT"
-          echo "ios=$ios" >> "$GITHUB_OUTPUT"
-          printf 'shared=%s android=%s ios=%s\n' "$shared" "$android" "$ios" >> "$GITHUB_STEP_SUMMARY"
-
-  pr-fast:
-    name: Native PR fast checks
-    needs: changes
-    if: >-
-      github.event_name == 'pull_request' &&
-      (needs.changes.outputs.shared == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.ios == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
+          submodules: recursive
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           persist-credentials: false
-      - name: Reject whitespace and conflict-marker regressions
+
+      - name: Reject whitespace and conflict-marker regressions on PR
+        if: github.event_name == 'pull_request'
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -106,34 +58,29 @@ jobs:
             echo 'Unresolved merge markers found in native inputs.' >&2
             exit 1
           fi
-      - name: Rust formatting only when shared Rust changed
-        if: needs.changes.outputs.shared == 'true'
+
+      - name: Set up Rust formatting for PR fast path
+        if: github.event_name == 'pull_request'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - name: Check shared Rust formatting without compiling
-        if: needs.changes.outputs.shared == 'true'
+
+      - name: Check shared Rust formatting without compiling on PR
+        if: github.event_name == 'pull_request'
         working-directory: third_party/mahayana/mahayana-rs
         run: cargo fmt -p mahayana-app-host -p mahayana-app-host-mobile -p mahayana-plugin-runtime -p mahayana-js-runtime -- --check
-      - name: Confirm native project manifests exist
+
+      - name: Confirm native project manifests exist on PR
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
           test -f mobile/android/settings.gradle.kts || test -f mobile/android/settings.gradle
           test -f mobile/ios/project.yml
-          echo 'Native PR fast checks passed; package/emulator/simulator E2E is deferred to canonical main.'
+          echo 'Native PR fast checks passed on the single Android/Linux runner; emulator, simulator, and release packaging remain post-main gates.' >> "$GITHUB_STEP_SUMMARY"
 
-  rust-contract:
-    name: Shared Rust host contract
-    needs: changes
-    if: github.event_name != 'pull_request' && needs.changes.outputs.shared == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
       - name: Install Linux native host dependencies
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         shell: bash
         run: |
           sudo apt-get update
@@ -141,71 +88,72 @@ jobs:
             pkg-config libclang-dev libxcb1-dev libxrandr-dev libxfixes-dev \
             libdbus-1-dev libpipewire-0.3-dev libwayland-dev libxkbcommon-dev \
             libegl1-mesa-dev libgbm-dev
-      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Rust for Android and shared host contract
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt,clippy
-      - uses: mozilla-actions/sccache-action@v0.0.11
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Enable Android/shared compiler-result cache
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
+        uses: mozilla-actions/sccache-action@v0.0.11
         with:
           version: v0.16.0
-      - name: Install Linux native Host dependencies
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            pkg-config libclang-dev libxcb1-dev libxrandr-dev libxfixes-dev \
-            libdbus-1-dev libpipewire-0.3-dev libwayland-dev libxkbcommon-dev \
-            libegl1-mesa-dev libgbm-dev
-      - uses: Swatinem/rust-cache@v2
+
+      - name: Restore Android/shared Rust dependency cache
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: native-shared-contract-v5
+          shared-key: native-mobile-android-platform-v7
+
       - name: Format shared host
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         working-directory: third_party/mahayana/mahayana-rs
         run: cargo fmt -p mahayana-app-host -p mahayana-app-host-mobile -p mahayana-plugin-runtime -p mahayana-js-runtime -- --check
+
       - name: Lint shared host
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         working-directory: third_party/mahayana/mahayana-rs
         env:
           SCCACHE_GHA_ENABLED: 'true'
           RUSTC_WRAPPER: sccache
         run: cargo clippy -p mahayana-app-host --all-targets -- -D warnings
+
       - name: Test shared host dependencies
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         working-directory: third_party/mahayana/mahayana-rs
         env:
           SCCACHE_GHA_ENABLED: 'true'
           RUSTC_WRAPPER: sccache
         run: cargo test -p mahayana-app-host -p mahayana-plugin-runtime -p mahayana-js-runtime
-      - name: Record compiler cache statistics
-        run: sccache --show-stats >> "$GITHUB_STEP_SUMMARY" || true
-
-  android:
-    name: Android Compose simulated user gate
-    needs: changes
-    if: >-
-      github.event_name != 'pull_request' &&
-      (needs.changes.outputs.android == 'true' || needs.changes.outputs.shared == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 75
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
 
       - id: jni-source-key
         name: Freeze Android Rust JNI source cache key
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         shell: bash
         env:
           SOURCE_HASH: ${{ hashFiles('third_party/mahayana/mahayana-rs/Cargo.lock', 'third_party/mahayana/mahayana-rs/**/*.rs', 'third_party/mahayana/mahayana-rs/**/Cargo.toml', 'third_party/mahayana/codex-rs/**/*.rs', 'third_party/mahayana/codex-rs/**/Cargo.toml') }}
         run: echo "hash=$SOURCE_HASH" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-java@v5
+      - name: Set up Java
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: android-actions/setup-android@v4
+
+      - name: Set up Android SDK
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
+        uses: android-actions/setup-android@v4
         with:
           cmdline-tools-version: '14742923'
           packages: 'platform-tools'
+
       - name: Install Android 17 preview SDK without the NDK hot path
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         shell: bash
         run: |
           set -euo pipefail
@@ -240,63 +188,42 @@ jobs:
 
       - id: jni-cache
         name: Restore reusable Android Rust JNI libraries
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         uses: actions/cache/restore@v4
         with:
           path: mobile/android/app/src/main/jniLibs
-          key: native-host-android-v7-${{ steps.jni-source-key.outputs.hash }}
+          key: native-host-android-v8-${{ steps.jni-source-key.outputs.hash }}
 
       - name: Record JNI cache result
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         run: echo "Android JNI cache hit=${{ steps.jni-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install Android NDK on JNI cache miss
-        if: steps.jni-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true'
         run: sdkmanager --channel=3 'ndk;28.2.13676358'
-
-      - name: Set up Rust targets on JNI cache miss
-        if: steps.jni-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android,x86_64-linux-android
-
-      - name: Enable compiler-result cache on JNI cache miss
-        if: steps.jni-cache.outputs.cache-hit != 'true'
-        uses: mozilla-actions/sccache-action@v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Restore Rust dependency/target cache on JNI cache miss
-        if: steps.jni-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: native-mobile-android-ci-v6
 
       - id: cargo-ndk-cache
         name: Restore cargo-ndk on JNI cache miss
-        if: steps.jni-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true'
         uses: actions/cache/restore@v4
         with:
           path: ~/.cargo/bin/cargo-ndk
           key: cargo-ndk-${{ runner.os }}-${{ runner.arch }}-v4
 
       - name: Install cargo-ndk only when needed
-        if: steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'
         shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v cargo-ndk >/dev/null 2>&1; then
-            cargo install cargo-ndk --locked
-          fi
+        run: cargo install cargo-ndk --locked
 
       - name: Save cargo-ndk immediately
-        if: steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/.cargo/bin/cargo-ndk
           key: cargo-ndk-${{ runner.os }}-${{ runner.arch }}-v4
 
-      - name: Build Rust JNI libraries only when Rust changed
-        if: steps.jni-cache.outputs.cache-hit != 'true'
+      - name: Build Rust JNI libraries on cache miss
+        if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true'
         working-directory: third_party/mahayana/mahayana-rs
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
@@ -305,25 +232,28 @@ jobs:
           RUSTC_WRAPPER: sccache
         run: cargo ndk -t arm64-v8a -t x86_64 -o ../../../mobile/android/app/src/main/jniLibs build --profile ci -p mahayana-app-host-mobile
 
-      - name: Show JNI compiler cache statistics
-        if: steps.jni-cache.outputs.cache-hit != 'true'
-        run: sccache --show-stats >> "$GITHUB_STEP_SUMMARY" || true
-
       - name: Save reusable JNI libraries before UI tests
-        if: steps.jni-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: mobile/android/app/src/main/jniLibs
-          key: native-host-android-v7-${{ steps.jni-source-key.outputs.hash }}
+          key: native-host-android-v8-${{ steps.jni-source-key.outputs.hash }}
+
+      - name: Record Android compiler cache statistics
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
+        run: sccache --show-stats >> "$GITHUB_STEP_SUMMARY" || true
 
       - name: Restore Gradle dependency and build cache
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         uses: gradle/actions/setup-gradle@v4
 
       - name: Android unit, lint and debug package with incremental build cache
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         working-directory: mobile/android
         run: ./gradlew --no-daemon --build-cache testDebugUnitTest lintDebug assembleDebug
 
       - name: Enable KVM acceleration for the Android emulator
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         shell: bash
         run: |
           set -euo pipefail
@@ -332,12 +262,12 @@ jobs:
             exit 1
           fi
           sudo chmod a+rw /dev/kvm
-          ls -l /dev/kvm
           test -r /dev/kvm
           test -w /dev/kvm
 
       - id: avd-cache
         name: Restore reusable Pixel 7 emulator snapshot
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         uses: actions/cache@v5
         with:
           path: |
@@ -345,11 +275,8 @@ jobs:
             ~/.android/adb*
           key: android-avd-api35-x86_64-pixel7-kvm-v2
 
-      - name: Record Android emulator cache result
-        run: echo "Android AVD cache hit=${{ steps.avd-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
-
       - name: Generate clean Pixel 7 snapshot once
-        if: steps.avd-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
@@ -362,6 +289,7 @@ jobs:
           script: echo 'Generated reusable Pixel 7 AVD snapshot.'
 
       - name: Emulator Compose simulated user tests
+        if: github.event_name != 'pull_request' && matrix.target == 'android'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
@@ -374,7 +302,7 @@ jobs:
           script: cd mobile/android && ./gradlew --no-daemon --build-cache connectedDebugAndroidTest
 
       - name: Upload Android reports
-        if: always()
+        if: always() && github.event_name != 'pull_request' && matrix.target == 'android'
         uses: actions/upload-artifact@v7
         with:
           name: android-native-reports
@@ -385,21 +313,9 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-  ios:
-    name: iOS SwiftUI simulated user gate
-    needs: changes
-    if: >-
-      github.event_name != 'pull_request' &&
-      (needs.changes.outputs.ios == 'true' || needs.changes.outputs.shared == 'true')
-    runs-on: macos-15
-    timeout-minutes: 75
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
-
       - id: staticlib-source-key
         name: Freeze iOS Rust static-library source cache key
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         shell: bash
         env:
           SOURCE_HASH: ${{ hashFiles('third_party/mahayana/mahayana-rs/Cargo.lock', 'third_party/mahayana/mahayana-rs/**/*.rs', 'third_party/mahayana/mahayana-rs/**/Cargo.toml', 'third_party/mahayana/codex-rs/**/*.rs', 'third_party/mahayana/codex-rs/**/Cargo.toml') }}
@@ -407,67 +323,68 @@ jobs:
 
       - id: staticlib-cache
         name: Restore reusable iOS simulator Rust static library
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         uses: actions/cache/restore@v4
         with:
           path: mobile/ios/Frameworks/libmahayana_app_host.a
-          key: native-host-ios-sim-v7-${{ steps.staticlib-source-key.outputs.hash }}
+          key: native-host-ios-sim-v8-${{ steps.staticlib-source-key.outputs.hash }}
 
       - name: Record iOS Rust static-library cache result
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         run: echo "iOS staticlib cache hit=${{ steps.staticlib-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Rust target on static library cache miss
-        if: steps.staticlib-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'ios' && steps.staticlib-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-ios-sim
 
-      - name: Enable compiler-result cache on static library cache miss
-        if: steps.staticlib-cache.outputs.cache-hit != 'true'
+      - name: Enable iOS compiler-result cache on static library cache miss
+        if: github.event_name != 'pull_request' && matrix.target == 'ios' && steps.staticlib-cache.outputs.cache-hit != 'true'
         uses: mozilla-actions/sccache-action@v0.0.11
         with:
           version: v0.16.0
 
-      - name: Restore Rust dependency/target cache on static library cache miss
-        if: steps.staticlib-cache.outputs.cache-hit != 'true'
+      - name: Restore iOS Rust dependency/target cache on static library cache miss
+        if: github.event_name != 'pull_request' && matrix.target == 'ios' && steps.staticlib-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: third_party/mahayana/mahayana-rs -> target
-          shared-key: native-mobile-ios-ci-v6
+          shared-key: native-mobile-ios-platform-v7
 
-      - name: Build Rust static library only when Rust changed
-        if: steps.staticlib-cache.outputs.cache-hit != 'true'
+      - name: Build Rust static library on cache miss
+        if: github.event_name != 'pull_request' && matrix.target == 'ios' && steps.staticlib-cache.outputs.cache-hit != 'true'
         working-directory: third_party/mahayana/mahayana-rs
         env:
           SCCACHE_GHA_ENABLED: 'true'
           RUSTC_WRAPPER: sccache
         run: cargo build --profile ci -p mahayana-app-host-mobile --target aarch64-apple-ios-sim
 
-      - name: Show iOS compiler cache statistics
-        if: steps.staticlib-cache.outputs.cache-hit != 'true'
-        run: sccache --show-stats >> "$GITHUB_STEP_SUMMARY" || true
-
       - name: Stage Rust static library on cache miss
-        if: steps.staticlib-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'ios' && steps.staticlib-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           mkdir -p mobile/ios/Frameworks
           cp third_party/mahayana/mahayana-rs/target/aarch64-apple-ios-sim/ci/libmahayana_app_host.a mobile/ios/Frameworks/
 
       - name: Save reusable iOS static library before UI tests
-        if: steps.staticlib-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && matrix.target == 'ios' && steps.staticlib-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: mobile/ios/Frameworks/libmahayana_app_host.a
-          key: native-host-ios-sim-v7-${{ steps.staticlib-source-key.outputs.hash }}
+          key: native-host-ios-sim-v8-${{ steps.staticlib-source-key.outputs.hash }}
 
-      - name: Install XcodeGen only when the runner does not have it
+      - name: Install XcodeGen only when needed
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         run: command -v xcodegen >/dev/null 2>&1 || brew install xcodegen
 
       - name: Generate Xcode project
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         working-directory: mobile/ios
         run: xcodegen generate
 
       - name: Select an available iPhone simulator
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         id: simulator
         shell: bash
         run: |
@@ -478,17 +395,16 @@ jobs:
 
       - id: derived-cache
         name: Restore incremental Xcode DerivedData
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/FabushiDerivedData
-          key: ios-derived-v5-${{ hashFiles('mobile/ios/project.yml') }}-${{ github.sha }}
+          key: ios-derived-v6-${{ hashFiles('mobile/ios/project.yml') }}-${{ github.sha }}
           restore-keys: |
-            ios-derived-v5-${{ hashFiles('mobile/ios/project.yml') }}-
-
-      - name: Record Xcode DerivedData cache result
-        run: echo "iOS DerivedData exact cache hit=${{ steps.derived-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
+            ios-derived-v6-${{ hashFiles('mobile/ios/project.yml') }}-
 
       - name: SwiftUI unit and simulated user UI tests
+        if: github.event_name != 'pull_request' && matrix.target == 'ios'
         working-directory: mobile/ios
         run: >-
           xcodebuild test
@@ -502,52 +418,17 @@ jobs:
           -resultBundlePath "$RUNNER_TEMP/FabushiTests.xcresult"
 
       - name: Save incremental Xcode DerivedData after compilation
-        if: always() && steps.derived-cache.outputs.cache-hit != 'true'
+        if: always() && github.event_name != 'pull_request' && matrix.target == 'ios' && steps.derived-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/FabushiDerivedData
-          key: ios-derived-v5-${{ hashFiles('mobile/ios/project.yml') }}-${{ github.sha }}
+          key: ios-derived-v6-${{ hashFiles('mobile/ios/project.yml') }}-${{ github.sha }}
 
       - name: Upload iOS result bundle
-        if: always()
+        if: always() && github.event_name != 'pull_request' && matrix.target == 'ios'
         uses: actions/upload-artifact@v7
         with:
           name: ios-native-xcresult
           path: ${{ runner.temp }}/FabushiTests.xcresult
           if-no-files-found: warn
           retention-days: 14
-
-  result:
-    name: Native mobile result
-    needs: [changes, pr-fast, rust-contract, android, ios]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    steps:
-      - name: Require the correct native surface for this event
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_FAST: ${{ needs.pr-fast.result }}
-          SHARED: ${{ needs.rust-contract.result }}
-          ANDROID: ${{ needs.android.result }}
-          IOS: ${{ needs.ios.result }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = pull_request ]; then
-            if [ "$PR_FAST" != success ] && [ "$PR_FAST" != skipped ]; then
-              echo "Native PR fast checks failed: $PR_FAST" >&2
-              exit 1
-            fi
-            echo 'Native PR fast checks passed; emulator/simulator/package gates are deferred to canonical main.'
-            exit 0
-          fi
-          for pair in "shared:$SHARED" "android:$ANDROID" "ios:$IOS"; do
-            name="${pair%%:*}"
-            result="${pair#*:}"
-            if [ "$result" != success ] && [ "$result" != skipped ]; then
-              echo "$name failed: $result" >&2
-              exit 1
-            fi
-          done
-          echo 'Native canonical-main Rust, Android and iOS simulated-user gates passed.'

--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -49,6 +49,7 @@ jobs:
           set -euo pipefail
           grep -F 'github.event.workflow_run.head_sha' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'Native mobile result' .github/workflows/post-main-delivery.yml >/dev/null
+          grep -F 'Native iOS' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'run-id:' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'needs.gate.outputs.electron_run_id' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'fabushi-delivery-mac.json' .github/workflows/post-main-delivery.yml >/dev/null
@@ -92,7 +93,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - id: wait-native
-        name: Wait for Native mobile result on the same main SHA
+        name: Wait for Android and iOS platform checks on the same main SHA
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -101,27 +102,37 @@ jobs:
           set -euo pipefail
           deadline=$((SECONDS + 7200))
           native_run_id=''
+          required_checks=('Native mobile result' 'Native iOS')
           while [ "$SECONDS" -lt "$deadline" ]; do
             checks="$(gh api -H 'Accept: application/vnd.github+json' "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA/check-runs?per_page=100")"
-            status="$(jq -r '[.check_runs[] | select(.name == "Native mobile result")] | sort_by(.started_at) | last | .status // "missing"' <<<"$checks")"
-            conclusion="$(jq -r '[.check_runs[] | select(.name == "Native mobile result")] | sort_by(.started_at) | last | .conclusion // ""' <<<"$checks")"
-            details_url="$(jq -r '[.check_runs[] | select(.name == "Native mobile result")] | sort_by(.started_at) | last | .details_url // ""' <<<"$checks")"
-            if [ "$status" = completed ]; then
-              if [ "$conclusion" != success ]; then
-                echo "Native mobile result for $SOURCE_SHA concluded $conclusion" >&2
-                exit 1
+            all_done=true
+            for required in "${required_checks[@]}"; do
+              status="$(jq -r --arg required "$required" '[.check_runs[] | select(.name == $required)] | sort_by(.started_at) | last | .status // "missing"' <<<"$checks")"
+              conclusion="$(jq -r --arg required "$required" '[.check_runs[] | select(.name == $required)] | sort_by(.started_at) | last | .conclusion // ""' <<<"$checks")"
+              details_url="$(jq -r --arg required "$required" '[.check_runs[] | select(.name == $required)] | sort_by(.started_at) | last | .details_url // ""' <<<"$checks")"
+              if [ "$status" = completed ]; then
+                if [ "$conclusion" != success ]; then
+                  echo "$required for $SOURCE_SHA concluded $conclusion" >&2
+                  exit 1
+                fi
+                if [ -z "$native_run_id" ] && [ -n "$details_url" ]; then
+                  native_run_id="$(sed -nE 's#.*actions/runs/([0-9]+).*#\1#p' <<<"$details_url" | head -1)"
+                fi
+              else
+                all_done=false
               fi
-              if [ -n "$details_url" ]; then
-                native_run_id="$(sed -nE 's#.*actions/runs/([0-9]+).*#\1#p' <<<"$details_url" | head -1)"
-              fi
+              echo "Native check $required: status=$status conclusion=${conclusion:-pending}"
+            done
+            if [ "$all_done" = true ]; then
               echo "native_run_id=$native_run_id" >> "$GITHUB_OUTPUT"
-              echo "- Native mobile result: success (run ${native_run_id:-unknown})" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Native mobile result: success" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Native iOS: success" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Native workflow run: ${native_run_id:-unknown}" >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
-            echo "Waiting for Native mobile result on $SOURCE_SHA: status=$status conclusion=${conclusion:-pending}"
             sleep 20
           done
-          echo "Timed out waiting for Native mobile result on $SOURCE_SHA" >&2
+          echo "Timed out waiting for Android and iOS native checks on $SOURCE_SHA" >&2
           exit 1
 
   publish:

--- a/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
+++ b/projects/fabushi-cicd-merge-governance/management/01-WBS原子任务.md
@@ -35,5 +35,6 @@
 | FCM-010.5 | Restore Fabushi Pay Worker Rust build state | yes | pay Worker target cache restored/saved on worker run | implemented |
 | FCM-010.6 | Merge optimized CI through protected main | yes | required PR checks/queue succeed and canonical main readback confirms definitions | pending |
 | FCM-010.7 | Verify post-merge heavyweight validation and cache behavior | yes | exact-main embedded-Codex run starts on all three OSes and cache steps execute | pending |
+| FCM-010.8 | Enforce one product platform per runner allocation | yes | Electron PR uses one Linux runner; main uses one macOS, one Windows, one Linux runner; native main uses one Android and one iOS runner; release packaging uses one runner per product platform with only a non-build control-plane publisher | implemented |
 
 `implemented` means the implementation exists but canonical protected merge/post-main acceptance may still be pending. `optional` means useful regression evidence that is not a default task-completion gate. FCM-009 must remain `in-progress` until FCM-009.10 has objective GitHub Actions + Release evidence; FCM-009.9 is not required for closure. FCM-010 remains `in-progress` until its optimized PR is merged and measured on canonical `main`.

--- a/third_party/mahayana/codex-rs/utils/pty/src/win/conpty.rs
+++ b/third_party/mahayana/codex-rs/utils/pty/src/win/conpty.rs
@@ -79,7 +79,7 @@ impl RawConPty {
     }
 
     pub fn pseudoconsole_handle(&self) -> RawHandle {
-        self.con.raw_handle()
+        self.con.raw_handle().cast::<std::ffi::c_void>()
     }
 
     pub fn into_handles(self) -> (PsuedoCon, FileDescriptor, FileDescriptor) {

--- a/third_party/mahayana/mahayana-rs/mahayana-cli/src/main.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-cli/src/main.rs
@@ -511,6 +511,7 @@ fn main() {
     }
 }
 
+#[cfg(any(feature = "codex-compat", test))]
 fn should_run_embedded_agent_cli(args: &[OsString]) -> bool {
     let Some(command) = args.first().and_then(|value| value.to_str()) else {
         return false;
@@ -524,6 +525,7 @@ fn should_run_embedded_agent_cli(args: &[OsString]) -> bool {
     !matches!(command, "-h" | "--help" | "-V" | "--version") && !is_product_command(command)
 }
 
+#[cfg(any(feature = "codex-compat", test))]
 fn is_product_command(command: &str) -> bool {
     matches!(
         command,
@@ -1930,6 +1932,7 @@ fn should_print_completed_text(print_stream: bool, streamed_output: bool, comple
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
+    #[cfg(feature = "codex-compat")]
     use super::Cli;
     use super::merge_completed_text;
     use super::should_print_completed_text;

--- a/third_party/mahayana/mahayana-rs/mahayana-cli/src/plugin_dev_tests.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-cli/src/plugin_dev_tests.rs
@@ -206,7 +206,7 @@ fn marketplace_install_extracts_a_verified_pages_bundle_into_the_repository() {
     )
     .expect("initialize source plugin");
     let source_plugin = source_repository.join(".agents/plugins/plugins/market-plugin");
-    let archive = codex_core_plugins::plugin_bundle_archive::pack_plugin_bundle_tar_gz(
+    let archive = pack_plugin_bundle_tar_gz(
         &source_plugin,
         50 * 1024 * 1024,
     )
@@ -241,7 +241,7 @@ fn marketplace_install_rejects_manifest_version_mismatch() {
     )
     .expect("initialize source plugin");
     let source_plugin = source_repository.join(".agents/plugins/plugins/versioned-plugin");
-    let archive = codex_core_plugins::plugin_bundle_archive::pack_plugin_bundle_tar_gz(
+    let archive = pack_plugin_bundle_tar_gz(
         &source_plugin,
         50 * 1024 * 1024,
     )

--- a/third_party/mahayana/mahayana-rs/mahayana-cli/src/plugin_dev_tests.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-cli/src/plugin_dev_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::pack_plugin_bundle_tar_gz;
 
 fn temporary_repository(label: &str) -> PathBuf {
     std::env::temp_dir().join(format!("mahayana-cli-{label}-{}", uuid::Uuid::new_v4()))

--- a/third_party/mahayana/mahayana-rs/mahayana-cli/src/plugin_dev_tests.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-cli/src/plugin_dev_tests.rs
@@ -206,11 +206,7 @@ fn marketplace_install_extracts_a_verified_pages_bundle_into_the_repository() {
     )
     .expect("initialize source plugin");
     let source_plugin = source_repository.join(".agents/plugins/plugins/market-plugin");
-    let archive = pack_plugin_bundle_tar_gz(
-        &source_plugin,
-        50 * 1024 * 1024,
-    )
-    .expect("pack plugin");
+    let archive = pack_plugin_bundle_tar_gz(&source_plugin, 50 * 1024 * 1024).expect("pack plugin");
 
     let destination_repository = temporary_repository("market-destination");
     fs::create_dir_all(&destination_repository).expect("create destination repository");
@@ -241,11 +237,7 @@ fn marketplace_install_rejects_manifest_version_mismatch() {
     )
     .expect("initialize source plugin");
     let source_plugin = source_repository.join(".agents/plugins/plugins/versioned-plugin");
-    let archive = pack_plugin_bundle_tar_gz(
-        &source_plugin,
-        50 * 1024 * 1024,
-    )
-    .expect("pack plugin");
+    let archive = pack_plugin_bundle_tar_gz(&source_plugin, 50 * 1024 * 1024).expect("pack plugin");
     let destination_repository = temporary_repository("market-version-destination");
     fs::create_dir_all(&destination_repository).expect("create destination repository");
 


### PR DESCRIPTION
## Summary

Follow-up release-gate fix after #2085 merged while its long-running platform jobs exposed additional deterministic failures, plus the CI allocation refactor requested for one product platform per runner.

This PR fixes the observed release-path failures:

- Global Dharma `mahayana-test` on Ubuntu installs the Linux Wayland/PipeWire/X11 development dependencies required by the embedded runtime gate.
- `mahayana-cli` tests use the product-owned `pack_plugin_bundle_tar_gz` directly and native-only builds no longer retain compatibility-only routing/import dead code.
- Windows embedded Codex Runtime explicitly casts the ConPTY `HPCON` raw pointer type at the `RawHandle` boundary.
- Marketplace E2E frees runner disk before the heavy browser/runtime path.

It also enforces **one product platform = one runner allocation** for the platform pipelines:

- Electron PR fast path: one Linux runner.
- Canonical-main Electron: one macOS runner, one Windows runner, one Linux runner; each runner owns that platform's Host build/cache, package, and packaged E2E.
- Canonical-main native: one Android/Linux runner and one iOS/macOS runner; shared Rust validation is folded into Android instead of consuming a third runner.
- Tagged release packaging: exactly one runner for macOS desktop, Windows desktop, Linux desktop, Android, and iOS. The remaining Ubuntu `publish` job is control-plane only and performs no platform build.
- Release-source governance now requires the per-platform checks `Electron macOS`, `Electron Windows`, `Native mobile result`, and `Native iOS` in addition to the canonical CI/Linux Electron check.
- Post-main publication waits for both Android and iOS exact-SHA checks before publishing tested desktop artifacts.

## Verification

- Branch synchronized with current `main` (`bb582228cb1746808658834b2712f48c2b9351ec`) without overlapping source conflicts.
- GitHub Actions successfully parsed the new dynamic PR matrices: the Electron PR workflow materialized exactly one job named `Electron desktop result`, and the native PR workflow materialized exactly one job named `Native mobile result` on the prior exact head.
- Exact-head GitHub Actions for the current head must pass before merge.
- After merge, canonical-main evidence must show exactly three Electron platform jobs and two native platform jobs on the same SHA before Release publication.

Tracking: FAB-P0005 / MSR-105 release verification follow-up; FAB-P0003 / FCM-010.8 one-runner-per-platform allocation.