### PR TITLE
fix(desktop): make Telegram fast-start projection durable

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -251,6 +251,18 @@ test('returning-user local-first conversation list is interactive within the one
       const projection = JSON.parse(localStorage.getItem('fabushi.desktop.messenger-projection.v1') || 'null');
       return Boolean(projection?.activePeerKey?.startsWith('selfhosted:') && projection?.selfConversations?.some((item: { title?: string }) => item.title === '首屏性能验收'));
     }), { timeout: 5_000 }).toBe(true);
+    await expect.poll(async () => page.evaluate(async () => {
+      const bridge = (window as unknown as {
+        fabushiNative?: { invoke<T>(method: string, params?: Record<string, unknown>): Promise<T> };
+      }).fabushiNative;
+      if (!bridge) return false;
+      const projection = await bridge.invoke<{ activePeerKey?: string; selfConversations?: Array<{ title?: string }> } | null>(
+        'readClientPersistence',
+        { key: 'fabushi.desktop.messenger-projection.v1' },
+      );
+      return Boolean(projection?.activePeerKey?.startsWith('selfhosted:')
+        && projection?.selfConversations?.some((item) => item.title === '首屏性能验收'));
+    }), { timeout: 5_000 }).toBe(true);
 
     await app.close();
 
@@ -262,6 +274,10 @@ test('returning-user local-first conversation list is interactive within the one
 
     await expect(workspace).toBeVisible({ timeout: 5_000 });
     await expect(workspace).toHaveAttribute('data-testid-ready-projection', 'true');
+    await expect.poll(async () => page.evaluate(() => {
+      const projection = JSON.parse(localStorage.getItem('fabushi.desktop.messenger-projection.v1') || 'null');
+      return Boolean(projection?.selfConversations?.some((item: { title?: string }) => item.title === '首屏性能验收'));
+    }), { timeout: 2_000 }).toBe(true);
     await expect(projectedPeer).toBeVisible({ timeout: 5_000 });
 
     const rendererToConversationListMs = await page.evaluate(() => performance.now());

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -200,12 +200,35 @@ const defaultDesktopMessengerPreferences: DesktopMessengerPreferences = {
   reducedMotion: false,
 };
 
+function asMessengerProjection(value: unknown): MessengerProjection | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const parsed = value as Partial<MessengerProjection>;
+  if (parsed.version !== 1 || !Array.isArray(parsed.selfConversations) || !Array.isArray(parsed.selfActors)) return null;
+  if (!parsed.selfMessages || typeof parsed.selfMessages !== 'object' || Array.isArray(parsed.selfMessages)) return null;
+  return parsed as MessengerProjection;
+}
+
 function readMessengerProjection(): MessengerProjection | null {
   if (typeof window === 'undefined') return null;
   try {
-    const parsed = JSON.parse(window.localStorage.getItem(messengerProjectionKey) || 'null') as MessengerProjection | null;
-    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.selfConversations) || !parsed.selfMessages) return null;
-    return parsed;
+    return asMessengerProjection(JSON.parse(window.localStorage.getItem(messengerProjectionKey) || 'null'));
+  } catch {
+    return null;
+  }
+}
+
+async function readDurableMessengerProjection(): Promise<MessengerProjection | null> {
+  const local = readMessengerProjection();
+  if (local) return local;
+  try {
+    const durable = asMessengerProjection(await invokeNativeDesktop<unknown>('readClientPersistence', { key: messengerProjectionKey }));
+    if (!durable) return null;
+    try {
+      window.localStorage.setItem(messengerProjectionKey, JSON.stringify(durable));
+    } catch {
+      // The native client-persistence mirror remains available for the next launch.
+    }
+    return durable;
   } catch {
     return null;
   }
@@ -227,6 +250,12 @@ function persistMessengerProjection(projection: MessengerProjection): void {
   } catch {
     // Fast-start projection is best effort; Rust SQLite remains authoritative.
   }
+  void invokeNativeDesktop<boolean>('writeClientPersistence', {
+    key: messengerProjectionKey,
+    value: projection,
+  }).catch(() => {
+    // Native persistence is a durability mirror only; canonical Rust SQLite remains authoritative.
+  });
 }
 
 function createTransport(): MahayanaHostTransport {
@@ -383,8 +412,21 @@ function upsertById<T extends { id: string }>(items: T[], item: T): T[] {
 
 export default function DesktopShellV2() {
   const authTransport = useMemo(() => createTransport(), []);
-  const [hasReturningProjection] = useState(() => Boolean(readMessengerProjection()));
+  const localProjection = useMemo(() => readMessengerProjection(), []);
+  const [startupProjection, setStartupProjection] = useState<MessengerProjection | null>(localProjection);
+  const [projectionLookupComplete, setProjectionLookupComplete] = useState(Boolean(localProjection));
   const [authenticated, setAuthenticated] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (localProjection) return;
+    let closed = false;
+    void readDurableMessengerProjection().then((projection) => {
+      if (closed) return;
+      setStartupProjection(projection);
+      setProjectionLookupComplete(true);
+    });
+    return () => { closed = true; };
+  }, [localProjection]);
 
   useEffect(() => {
     let closed = false;
@@ -409,17 +451,22 @@ export default function DesktopShellV2() {
     };
   }, [authTransport]);
 
-  const showMessenger = authenticated === true || (authenticated === null && hasReturningProjection);
+  const showMessenger = projectionLookupComplete
+    && (authenticated === true || (authenticated === null && Boolean(startupProjection)));
   return (
     <div className={styles.desktopRoot} data-testid="desktop-shell" data-local-first={showMessenger && authenticated === null ? 'true' : undefined}>
-      {showMessenger ? <MessengerWorkspace /> : <HostClient />}
+      {showMessenger
+        ? <MessengerWorkspace initialProjection={startupProjection} />
+        : projectionLookupComplete
+          ? <HostClient />
+          : <div className={styles.desktopRoot} data-testid="desktop-fast-start-bootstrap" aria-hidden="true" />}
     </div>
   );
 }
 
-function MessengerWorkspace() {
+function MessengerWorkspace({ initialProjection }: { initialProjection?: MessengerProjection | null }) {
   const transport = useMemo(() => createTransport(), []);
-  const startupProjection = useMemo(() => readMessengerProjection(), []);
+  const startupProjection = useMemo(() => initialProjection ?? readMessengerProjection(), [initialProjection]);
   const selfHosted = useMemo(() => new SelfHostedMessagingClientV2(transport, { actorId: startupProjection?.actorId }), [transport, startupProjection]);
   const [hostReady, setHostReady] = useState(false);
   const [section, setSection] = useState<MessengerSection>('chats');
@@ -548,7 +595,7 @@ function MessengerWorkspace() {
           .slice(0, projectionConversationLimit),
         selfMessages: boundedMessages,
       });
-    }, 180);
+    }, 60);
     return () => window.clearTimeout(timer);
   }, [activePeerKey, selfActors, selfConversations, selfMessages, selfHosted.actorId]);
 

--- a/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
@@ -24,3 +24,12 @@ All expected CI, merge-queue, and canonical-main evidence is present. M3-DESKTOP
 ## 2026-08-24 performance / Release continuation
 
 The task is re-opened from administrative closure to `TESTING` under the newer repository post-main delivery rule. A packaged Playwright performance gate now records `startup-performance.json` and requires cached conversation-list first interaction in `< 1000 ms`. Final closure requires exact-main packaged E2E + mobile gates + GitHub Release/updater evidence.
+
+## Canonical-main performance failure evidence
+
+- Main SHA: `ace59b487bb8b1838508d08acbea5f4e7e4fa775`.
+- Electron desktop quality gate: `32681842813` — failed only after the new full-relaunch performance case reached the expected seeded conversation assertion.
+- Messenger E2E summary: 11 passed, 1 failed.
+- Failure mode: the seeded `首屏性能验收` projection existed before shutdown, but `[data-testid^="peer-selfhosted:channel:"]` with that title was absent after full process relaunch.
+- No timing value is accepted from this run because the release-gating row did not become interactive.
+- Follow-up evidence must include durable native projection verification, `startup-performance.json`, exact-main desktop/native success, and the resulting Release tag.

--- a/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
@@ -43,3 +43,7 @@
 ## 2026-08-24 — M3-DESKTOP-002 closed
 
 - `M3-DESKTOP-002` — `COMPLETED`: PR #2079 passed CI, Messaging Product Gate, self-hosted messaging, and Electron desktop quality gate, then merged through the protected merge queue as `01b33d60f7d7d9add41a5fba84d21014094cb5dc`. Canonical `main` was re-read at the merge SHA.
+
+## 2026-08-24 — M3-DESKTOP-002 performance continuation
+
+- `M3-DESKTOP-002` — `TESTING`: canonical-main full-relaunch E2E exposed a renderer-projection durability gap. Follow-up adds an existing native client-persistence mirror/fallback and durable-preclose assertion; `< 1000 ms` packaged timing + exact-main Release remain blocking.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -66,3 +66,7 @@ M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded 
 ## M3-DESKTOP-002 final acceptance — 2026-08-24
 
 `M3-DESKTOP-002` = `TESTED / COMPLETED`: local-first projection restore, initial sync 20, cursor background sync 100, responsive third-column behavior, Telegram-inspired grouped Settings, persisted real desktop preferences, and reload-from-projection Playwright coverage all passed required product gates. PR #2079 merged through the protected queue as `01b33d60f7d7d9add41a5fba84d21014094cb5dc` and canonical `main` was re-verified.
+
+## M3-DESKTOP-002 performance-gate continuation — 2026-08-24
+
+`M3-DESKTOP-002` = `TESTING`: the original functional acceptance remains valid, but canonical-main full-process relaunch did not restore the seeded fast-start row from renderer-only persistence, so acceptance criterion 9 has no valid timing result yet and criterion 10 has not published a Release. The follow-up must pass durable projection-mirror verification, packaged `< 1000 ms` first-interactive timing, exact-main desktop/mobile gates, and E2E-gated Release publication.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -115,3 +115,10 @@
 - macOS 首轮只有既有 Mini App 用例 worker teardown 抖动，重跑通过；Linux / Windows package journey 同样通过。
 - PR 经 merge queue 合并为 `01b33d60f7d7d9add41a5fba84d21014094cb5dc`，并已重新读取 canonical `main` 确认。
 - `M3-DESKTOP-002` 状态更新为 `COMPLETED`。
+
+## 2026-08-24 — M3-DESKTOP-002 performance gate reopened
+
+- `main@ace59b487bb8b1838508d08acbea5f4e7e4fa775` Electron E2E reached the new full-relaunch performance case; 11/12 tests passed, but the seeded `首屏性能验收` row was absent after process relaunch.
+- Because the row never became visible, the run cannot claim a valid `< 1000 ms` result; Release remains correctly blocked.
+- Follow-up `fix/tfi-m3-durable-fast-start` keeps the localStorage hot path and adds the existing Electron native client-persistence store as a non-authoritative durable projection mirror/fallback.
+- The task remains `TESTING` until exact-main packaged timing, native/mobile gates, and Release publication all pass.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -109,3 +109,10 @@
 - PR #2079 (`Telegram local-first startup + Settings`) 通过全部当前 head product gates。
 - merge queue position 1 revalidation 通过并合并为 `01b33d60f7d7d9add41a5fba84d21014094cb5dc`。
 - canonical `main` readback 完成；任务记录与 evidence 从 `TESTING` 更新为 `COMPLETED`。
+
+## 2026-08-24 — durable Telegram-style fast-start fallback
+
+- Canonical-main startup performance E2E exposed that an in-memory renderer projection was not sufficient evidence of full-process durability.
+- Fast-start projection now mirrors into existing Electron native client persistence while Rust SQLite/Host remains authoritative.
+- Startup can recover the native mirror before the HostClient/login route and repopulates localStorage for subsequent zero-round-trip launches.
+- Performance E2E now requires durable pre-close projection evidence before measuring full relaunch; Release remains gated at `< 1000 ms`.

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -95,3 +95,11 @@ Adopt Telegram Desktop/Unigram's local-first, bounded-initial-load behavior in t
 - Core implementation PR #2079 is merged and canonical-main readback passed.
 - A new packaged returning-user startup performance E2E now enforces the project `< 1 second` first-interactive target.
 - Final task closure remains pending until this measurement is green on canonical main and the same accepted SHA is published through the post-main Release/updater loop.
+
+## 2026-08-24 durability/performance continuation
+
+Canonical `main@ace59b487bb8b1838508d08acbea5f4e7e4fa775` ran the new startup-performance E2E. The projection contained `首屏性能验收` before shutdown, but the row was missing after a full Electron relaunch; therefore the run produced no acceptable first-interactive measurement and Release stayed blocked.
+
+The follow-up fix on branch `fix/tfi-m3-durable-fast-start` mirrors the bounded renderer projection into the existing Electron native client-persistence store while preserving Rust SQLite/Host as authoritative. Startup prefers synchronous `localStorage`, falls back to the native mirror before routing to HostClient, and mirrors recovered data back into local storage. The E2E now verifies the durable mirror before closing the first process.
+
+Status remains `TESTING` until the protected-main packaged E2E records `< 1000 ms`, all required exact-main desktop/mobile gates pass, and the tested artifacts are published as a new Release.

--- a/projects/telegram-fabushi-integration/source/2026-08-24-startup-performance-release-gate.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-24-startup-performance-release-gate.md
@@ -20,3 +20,18 @@ After the Telegram local-first/settings implementation is merged, run packaged s
 ## Delivery requirement
 
 The exact accepted main SHA must pass packaged Electron E2E plus the repository-required Android/iOS simulated-user gates. Only then may the post-main delivery workflow publish the tested artifacts with a monotonic version and updater metadata.
+
+## Canonical-main failure observed and durability repair
+
+Canonical `main@ace59b487bb8b1838508d08acbea5f4e7e4fa775` reached the new performance E2E. The seeded conversation was present in the in-renderer projection before shutdown, but after a full Electron process close/relaunch the expected cached row was absent, so no valid `< 1000 ms` timing result could be accepted. This exposes a durability gap in relying on Chromium `localStorage` alone for the non-authoritative fast-start projection across abrupt/full process teardown.
+
+Repair direction:
+
+- keep Rust SQLite/Host as the only authoritative messaging state;
+- keep `localStorage` as the zero-round-trip hot path when it is present;
+- mirror the bounded projection through the existing Electron native `clientPersistence` store (`fabushi-native-state.json`) so full-process restart has a durable fallback;
+- on startup, check local projection synchronously first, then recover the native mirror before choosing the login/HostClient path;
+- mirror a recovered native projection back into `localStorage` and continue canonical Host reconciliation normally;
+- require the performance E2E to prove the native mirror contains the seeded conversation before shutting down, then measure the real full relaunch.
+
+The release gate remains `< 1000 ms` and remains blocking until the canonical-main packaged run records a passing timing artifact.


### PR DESCRIPTION
## FAB-P0001 / TFI — M3-DESKTOP-002 durability/performance continuation

Canonical main run `32681842813` proved the in-renderer projection before shutdown but lost the seeded cached row after a full Electron relaunch, so no valid `<1000 ms` timing could be accepted and Release correctly stayed blocked.

### Fix
- keep `localStorage` as the zero-round-trip hot path;
- mirror the bounded non-authoritative Messenger projection through existing native `clientPersistence`;
- recover the native mirror before choosing HostClient/login when local projection is absent;
- mirror recovered projection back into `localStorage`;
- keep Rust SQLite/Host as canonical authority;
- shorten projection persistence debounce to 60 ms;
- require the performance E2E to prove the durable mirror exists before the full relaunch.

### Release gate
No local app build/test was run. GitHub Actions must pass. After protected merge, the exact canonical-main packaged Electron E2E must record renderer-to-cached-list `<1000 ms`; required native/mobile gates must pass; only then may the already-tested artifacts be published as a new Release.

Tracking: `projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md`.