### PR TITLE
fix(auth): persist returning test session across restart

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -286,6 +286,14 @@ test('returning-user local-first conversation list is interactive within the one
     await expect(page.getByTestId('messenger-input')).toBeVisible({ timeout: 2_000 });
     const rendererToComposerInteractiveMs = await page.evaluate(() => performance.now());
 
+    // The async account-status poll must not replace the locally restored Messenger
+    // with the login shell after first paint. Waiting longer than the retry cadence
+    // turns the previous transient failure into an explicit returning-session gate.
+    await page.waitForTimeout(1_100);
+    await expect(page.getByTestId('login-gate')).toHaveCount(0);
+    await expect(workspace).toBeVisible();
+    await expect(projectedPeer).toBeVisible();
+
     const evidence = {
       targetMs: 1_000,
       metric: 'renderer-navigation-to-cached-conversation-list-interactive',

--- a/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M3-DESKTOP-002/README.md
@@ -33,3 +33,11 @@ The task is re-opened from administrative closure to `TESTING` under the newer r
 - Failure mode: the seeded `首屏性能验收` projection existed before shutdown, but `[data-testid^="peer-selfhosted:channel:"]` with that title was absent after full process relaunch.
 - No timing value is accepted from this run because the release-gating row did not become interactive.
 - Follow-up evidence must include durable native projection verification, `startup-performance.json`, exact-main desktop/native success, and the resulting Release tag.
+
+## Exact-main durable-projection / auth-session evidence
+
+- Canonical main SHA: `197dc768b972974aea3603eae8f80a46df4714a4`.
+- Electron desktop quality run: `32683544762`; Host simulated user smoke job `97304464629`.
+- Result: 11/12 E2E passed. The performance case recovered `首屏性能验收` into `localStorage` after full relaunch, proving the native projection mirror worked, then failed because the UI changed to the login shell before the projected peer assertion.
+- Root cause: deterministic Rust test Feature Host `auth_user` was process-local; production's Rust-owned session restore path is already durable.
+- Follow-up must prove persisted test account restore, logout clearing, no credential fields in persisted state, no login-shell replacement after the auth retry window, and then produce the real `< 1000 ms` timing artifact.

--- a/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
@@ -47,3 +47,7 @@
 ## 2026-08-24 — M3-DESKTOP-002 performance continuation
 
 - `M3-DESKTOP-002` — `TESTING`: canonical-main full-relaunch E2E exposed a renderer-projection durability gap. Follow-up adds an existing native client-persistence mirror/fallback and durable-preclose assertion; `< 1000 ms` packaged timing + exact-main Release remain blocking.
+
+## 2026-08-24 — M3-DESKTOP-002 returning-session continuation
+
+- `M3-DESKTOP-002` — `TESTING`: durable projection restore is proven on canonical main; deterministic Rust test account persistence is the remaining full-restart blocker. Follow-up persists only UI-safe test identity in configured Host runtime data, deletes it on logout, and adds a post-auth-poll Messenger-stability E2E assertion. `< 1000 ms` exact-main packaged timing and Release remain blocking.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -70,3 +70,7 @@ M3-DESKTOP-001 must prove true in-conversation search, per-peer drafts, bounded 
 ## M3-DESKTOP-002 performance-gate continuation — 2026-08-24
 
 `M3-DESKTOP-002` = `TESTING`: the original functional acceptance remains valid, but canonical-main full-process relaunch did not restore the seeded fast-start row from renderer-only persistence, so acceptance criterion 9 has no valid timing result yet and criterion 10 has not published a Release. The follow-up must pass durable projection-mirror verification, packaged `< 1000 ms` first-interactive timing, exact-main desktop/mobile gates, and E2E-gated Release publication.
+
+## M3-DESKTOP-002 returning-session continuation — 2026-08-24
+
+`M3-DESKTOP-002` remains `TESTING`: canonical `197dc768` proves durable projection recovery but exposes process-local deterministic test authentication. Acceptance now also requires test-mode returning session restore from configured durable Host data, explicit logout clearing, no secret persistence, no asynchronous fallback to login after Messenger first paint, then packaged `< 1000 ms` timing and exact-main Release publication.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -122,3 +122,9 @@
 - Because the row never became visible, the run cannot claim a valid `< 1000 ms` result; Release remains correctly blocked.
 - Follow-up `fix/tfi-m3-durable-fast-start` keeps the localStorage hot path and adds the existing Electron native client-persistence store as a non-authoritative durable projection mirror/fallback.
 - The task remains `TESTING` until exact-main packaged timing, native/mobile gates, and Release publication all pass.
+
+## 2026-08-24 — M3-DESKTOP-002 returning-session root cause
+
+- `main@197dc768b972974aea3603eae8f80a46df4714a4`, Electron run `32683544762`: durable projection recovery succeeded, but the deterministic Rust test account was process-local and `feature.auth.status` switched the restored Messenger back to login.
+- The next fix makes test-mode account state durable only when a real Host data directory is supplied, mirrors production's local returning-session contract, persists no secrets, and deletes the state on logout.
+- Release remains blocked until exact-main packaged `< 1000 ms` evidence and all delivery gates are green.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -116,3 +116,10 @@
 - Fast-start projection now mirrors into existing Electron native client persistence while Rust SQLite/Host remains authoritative.
 - Startup can recover the native mirror before the HostClient/login route and repopulates localStorage for subsequent zero-round-trip launches.
 - Performance E2E now requires durable pre-close projection evidence before measuring full relaunch; Release remains gated at `< 1000 ms`.
+
+## 2026-08-24 — returning account survives deterministic Host restart
+
+- Root cause refined after the projection durability fix: renderer projection survives full restart, but test-mode Rust `auth_user` did not.
+- Durable test Host instances now persist/restore only UI-safe deterministic account identity in their configured runtime data directory.
+- Explicit logout removes that persisted test account, preserving sign-out semantics.
+- Startup E2E now guards against post-first-paint fallback to the login shell after the auth polling window.

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -103,3 +103,11 @@ Canonical `main@ace59b487bb8b1838508d08acbea5f4e7e4fa775` ran the new startup-pe
 The follow-up fix on branch `fix/tfi-m3-durable-fast-start` mirrors the bounded renderer projection into the existing Electron native client-persistence store while preserving Rust SQLite/Host as authoritative. Startup prefers synchronous `localStorage`, falls back to the native mirror before routing to HostClient, and mirrors recovered data back into local storage. The E2E now verifies the durable mirror before closing the first process.
 
 Status remains `TESTING` until the protected-main packaged E2E records `< 1000 ms`, all required exact-main desktop/mobile gates pass, and the tested artifacts are published as a new Release.
+
+## 2026-08-24 returning-account session persistence continuation
+
+Exact-main Electron run `32683544762` on `main@197dc768b972974aea3603eae8f80a46df4714a4` confirmed the durable projection fallback itself succeeds: the seeded conversation is recovered into renderer storage after a full process restart. The test still fails because the deterministic Rust Feature Host keeps `auth_user` only in process memory; its first asynchronous `feature.auth.status` after relaunch returns signed-out and unmounts the restored Messenger.
+
+The follow-up persists only the deterministic UI-safe test user when the test Host is created with the app's durable runtime data directory, restores it across Host process restart, and deletes it on explicit logout. No credentials or tokens cross into this file. The E2E also waits beyond the auth retry interval after first interaction and requires the login shell to remain absent.
+
+Status remains `TESTING` until the exact canonical-main packaged run emits a passing `startup-performance.json` under 1000 ms, all required desktop/mobile gates pass, and the tested artifacts are published as the new Release.

--- a/projects/telegram-fabushi-integration/source/2026-08-24-startup-performance-release-gate.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-24-startup-performance-release-gate.md
@@ -35,3 +35,19 @@ Repair direction:
 - require the performance E2E to prove the native mirror contains the seeded conversation before shutting down, then measure the real full relaunch.
 
 The release gate remains `< 1000 ms` and remains blocking until the canonical-main packaged run records a passing timing artifact.
+
+## Returning-account session persistence blocker — canonical main `197dc768`
+
+The durable projection repair reached canonical `main@197dc768b972974aea3603eae8f80a46df4714a4`. Exact-main Electron run `32683544762` proved the native projection mirror works: after full relaunch the E2E recovered `首屏性能验收` into `localStorage`. The row still disappeared because the deterministic Rust test Feature Host reset `auth_user` on every host process start; the asynchronous `feature.auth.status` poll therefore returned signed-out and replaced Messenger with the login shell.
+
+This is an authentication-fixture persistence defect, not a renderer projection defect. Production already restores the Rust-owned account session locally before remote validation. The deterministic test backend must model the same returning-account lifecycle so packaged E2E exercises the production contract instead of a process-local fake session.
+
+Follow-up requirements:
+
+- when `FeatureHostController::create_with_host_config` runs in test mode with a real runtime data directory, persist only the UI-safe deterministic test user under that data directory;
+- restore that user on the next Host process so `feature.auth.status` remains logged in across a full Electron restart;
+- never persist access tokens, refresh tokens, passwords, or browser polling secrets in this test session file;
+- explicit `feature.auth.logout` must delete the persisted test session and a subsequent Host process must return signed-out;
+- keep the existing process-local `FeatureHostController::create(..., HostMode::Test)` behavior isolated for unit tests that do not provide a durable data directory;
+- the startup E2E must additionally prove the login shell does not replace Messenger after the asynchronous auth retry window;
+- `< 1000 ms` remains the blocking release target and no Release may publish until exact-main packaged evidence passes.

--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -298,6 +298,7 @@ pub struct FeatureHostController {
     peer_messages_path: Option<PathBuf>,
     settings_path: Option<PathBuf>,
     remote_device_state_path: Option<PathBuf>,
+    test_auth_state_path: Option<PathBuf>,
     memory_root_path: Option<PathBuf>,
     workflow_root_path: Option<PathBuf>,
     teach_recording: Mutex<Option<TeachCaptureProcess>>,
@@ -308,7 +309,7 @@ impl FeatureHostController {
     pub fn create(config: HostConfig, platform: SurfacePlatform) -> Result<Self, FeatureHostError> {
         validate_config(&config)?;
         match config.mode {
-            HostMode::Test => Ok(Self::create_test_backend(config, platform)),
+            HostMode::Test => Ok(Self::create_test_backend(config, platform, None)),
             HostMode::Production => {
                 #[cfg(feature = "production")]
                 {
@@ -322,7 +323,13 @@ impl FeatureHostController {
         }
     }
 
-    fn create_test_backend(config: HostConfig, platform: SurfacePlatform) -> Self {
+    fn create_test_backend(
+        config: HostConfig,
+        platform: SurfacePlatform,
+        test_data_dir: Option<&Path>,
+    ) -> Self {
+        let test_auth_state_path =
+            test_data_dir.map(|data_dir| data_dir.join("test-auth-session.json"));
         let memory_root_path = Some(std::env::temp_dir().join(format!(
             "fabushi-feature-host-memory-{}-{}",
             config.profile_id,
@@ -339,6 +346,9 @@ impl FeatureHostController {
             platform,
         };
         let mut state = FeatureState::default();
+        if let Some(path) = test_auth_state_path.as_deref() {
+            state.auth_user = load_test_auth_user(path);
+        }
         sync_computer_control_policy(&state.settings);
         state.events.push_back(HostEvent::HostReady {
             timestamp: timestamp(),
@@ -355,6 +365,7 @@ impl FeatureHostController {
             peer_messages_path: None,
             settings_path: None,
             remote_device_state_path: None,
+            test_auth_state_path,
             memory_root_path,
             workflow_root_path,
             teach_recording: Mutex::new(None),
@@ -370,7 +381,12 @@ impl FeatureHostController {
     ) -> Result<Self, FeatureHostError> {
         validate_config(&config)?;
         if config.mode == HostMode::Test {
-            return Ok(Self::create_test_backend(config, platform));
+            let test_data_dir = host_config.runtime.data_dir.clone();
+            return Ok(Self::create_test_backend(
+                config,
+                platform,
+                test_data_dir.as_deref(),
+            ));
         }
         let automation_path = host_config.automation_path.clone().or_else(|| {
             host_config
@@ -456,6 +472,7 @@ impl FeatureHostController {
             peer_messages_path,
             settings_path,
             remote_device_state_path,
+            test_auth_state_path: None,
             memory_root_path,
             workflow_root_path,
             teach_recording: Mutex::new(None),
@@ -612,7 +629,10 @@ impl FeatureHostController {
                     "username": username,
                     "nickname": "本地测试用户",
                 });
-                self.state()?.auth_user = Some(user.clone());
+                {
+                    self.state()?.auth_user = Some(user.clone());
+                }
+                self.persist_test_auth_user(Some(&user))?;
                 Ok(json!({
                     "@type": "mahayana.auth.session",
                     "loggedIn": true,
@@ -714,7 +734,10 @@ impl FeatureHostController {
                     "email": "browser@example.test",
                     "nickname": "Browser 测试用户",
                 });
-                self.state()?.auth_user = Some(user.clone());
+                {
+                    self.state()?.auth_user = Some(user.clone());
+                }
+                self.persist_test_auth_user(Some(&user))?;
                 Ok(json!({
                     "status": "completed",
                     "provider": "browser",
@@ -792,7 +815,10 @@ impl FeatureHostController {
                     "email": "oauth@example.test",
                     "nickname": "OAuth 测试用户",
                 });
-                self.state()?.auth_user = Some(user.clone());
+                {
+                    self.state()?.auth_user = Some(user.clone());
+                }
+                self.persist_test_auth_user(Some(&user))?;
                 Ok(json!({
                     "attemptId": attempt_id,
                     "status": "completed",
@@ -821,7 +847,10 @@ impl FeatureHostController {
     pub fn logout(&self) -> Result<Value, FeatureHostError> {
         match self.config.mode {
             HostMode::Test => {
-                self.state()?.auth_user = None;
+                {
+                    self.state()?.auth_user = None;
+                }
+                self.persist_test_auth_user(None)?;
                 Ok(json!({
                     "@type": "mahayana.auth.session",
                     "loggedIn": false,
@@ -5399,6 +5428,13 @@ impl FeatureHostController {
             })?;
         }
         Ok(())
+    }
+
+    fn persist_test_auth_user(&self, user: Option<&Value>) -> Result<(), FeatureHostError> {
+        let Some(path) = self.test_auth_state_path.as_deref() else {
+            return Ok(());
+        };
+        persist_test_auth_user(path, user)
     }
 
     fn persist_automations(
@@ -10781,6 +10817,52 @@ fn persist_groups(
     Ok(())
 }
 
+fn load_test_auth_user(path: &Path) -> Option<Value> {
+    let bytes = std::fs::read(path).ok()?;
+    let stored = serde_json::from_slice::<Value>(&bytes).ok()?;
+    if stored.get("version").and_then(Value::as_u64) != Some(1) {
+        return None;
+    }
+    stored.get("user").filter(|user| user.is_object()).cloned()
+}
+
+fn persist_test_auth_user(path: &Path, user: Option<&Value>) -> Result<(), FeatureHostError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            FeatureHostError::Contract(format!("create test auth directory: {error}"))
+        })?;
+    }
+    let temp = path.with_extension("json.tmp");
+    if let Some(user) = user {
+        let data = serde_json::to_vec_pretty(&json!({
+            "version": 1,
+            "user": user,
+        }))
+        .map_err(|error| {
+            FeatureHostError::Contract(format!("serialize test auth state: {error}"))
+        })?;
+        std::fs::write(&temp, data).map_err(|error| {
+            FeatureHostError::Contract(format!("write test auth state: {error}"))
+        })?;
+        std::fs::rename(&temp, path).map_err(|error| {
+            FeatureHostError::Contract(format!("commit test auth state: {error}"))
+        })?;
+        return Ok(());
+    }
+
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(FeatureHostError::Contract(format!(
+                "clear test auth state: {error}"
+            )));
+        }
+    }
+    let _ = std::fs::remove_file(temp);
+    Ok(())
+}
+
 fn load_bots(path: &Path) -> BTreeMap<String, BotSummary> {
     let Ok(bytes) = std::fs::read(path) else {
         return BTreeMap::new();
@@ -12134,6 +12216,74 @@ mod tests {
             cancelled_controller.auth_status().unwrap()["loggedIn"],
             false
         );
+    }
+
+    #[cfg(feature = "production")]
+    #[test]
+    fn test_backend_restores_browser_session_across_controller_restart_and_logout_clears_it() {
+        let root = std::env::temp_dir().join(format!(
+            "fabushi-feature-host-returning-auth-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("create returning auth root");
+        let host_config = || HostCreateConfig {
+            runtime: mahayana_core::RuntimeConfig {
+                data_dir: Some(root.join("runtime")),
+                ..Default::default()
+            },
+            product_session_path: Some(root.join("product-session.json")),
+            inherit_installed_plugins: Some(false),
+            ..Default::default()
+        };
+        let config = || HostConfig {
+            profile_id: "returning-auth".into(),
+            mode: HostMode::Test,
+        };
+
+        let first = FeatureHostController::create_with_host_config(
+            config(),
+            SurfacePlatform::Electron,
+            host_config(),
+        )
+        .expect("create first test Host");
+        let attempt = first.browser_login_start().expect("start browser login");
+        first
+            .browser_login_poll(
+                attempt["attemptId"]
+                    .as_str()
+                    .expect("attempt id")
+                    .to_string(),
+            )
+            .expect("complete browser login");
+        assert_eq!(first.auth_status().unwrap()["loggedIn"], true);
+        drop(first);
+
+        let reopened = FeatureHostController::create_with_host_config(
+            config(),
+            SurfacePlatform::Electron,
+            host_config(),
+        )
+        .expect("reopen test Host");
+        let restored = reopened.auth_status().expect("restore browser session");
+        assert_eq!(restored["loggedIn"], true);
+        assert_eq!(restored["user"]["id"], "fast-e2e-browser-user");
+        let persisted = std::fs::read_to_string(root.join("runtime/test-auth-session.json"))
+            .expect("read persisted test auth state");
+        assert!(!persisted.contains("accessToken"));
+        assert!(!persisted.contains("refreshToken"));
+
+        reopened.logout().expect("logout returning account");
+        drop(reopened);
+        let after_logout = FeatureHostController::create_with_host_config(
+            config(),
+            SurfacePlatform::Electron,
+            host_config(),
+        )
+        .expect("reopen after logout");
+        assert_eq!(after_logout.auth_status().unwrap()["loggedIn"], false);
+        assert!(!root.join("runtime/test-auth-session.json").exists());
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
## FAB-P0001 / TFI — M3-DESKTOP-002 returning-session continuation

Exact canonical main `197dc768b972974aea3603eae8f80a46df4714a4` proved the durable Messenger projection is recovered after a full Electron process restart, but exact-main Electron run `32683544762` still failed because deterministic Rust test-mode `auth_user` was process-local. The async `feature.auth.status` poll returned signed-out and replaced the restored Messenger with the login shell before the cached row could be accepted.

### Fix
- persist only the UI-safe deterministic test user when `FeatureHostController::create_with_host_config` receives a durable runtime data directory;
- restore that user in the next Host process so returning-session E2E matches production's Rust-owned local session contract;
- persist no password, access token, refresh token, or browser poll secret;
- explicit logout deletes the durable test session and a subsequent Host is signed out;
- keep plain `FeatureHostController::create(... HostMode::Test)` process-isolated for unit tests without a data directory;
- extend the startup E2E to verify the login shell does not replace Messenger after the auth retry window.

### Delivery gate
No local application build/test was run. The repository Actions must verify formatting, Rust contracts, Electron E2E and package gates. After protected merge, the exact canonical-main packaged run must emit `startup-performance.json` with renderer-to-cached-conversation-list first-interactive `< 1000 ms`; required native/mobile gates must pass; only then may the exact tested artifacts be published as a new Release.