### PR TITLE
fix(desktop): repair updater, startup UX and idle energy

### DIFF
--- a/.github/scripts/assert-electron-feature-host-bridge.sh
+++ b/.github/scripts/assert-electron-feature-host-bridge.sh
@@ -57,7 +57,8 @@ if grep -Fq "ipcMain.handle('fabushi:host'" "$main"; then
 fi
 grep -Fq 'Object.keys(MAHAYANA_EDGE.methods).map((method)' "$main" || { echo "Electron main does not derive edge handlers from MAHAYANA_EDGE" >&2; exit 1; }
 grep -Fq 'serveMainEdge(ipcMain, MAHAYANA_EDGE, handlers' "$main" || { echo "Electron main does not serve MAHAYANA_EDGE through the shared edge runtime" >&2; exit 1; }
-grep -Fq "host.request('feature.receive', {})" "$main" || { echo "Electron main runtime event pump is missing" >&2; exit 1; }
+grep -Fq "host.request('feature.receive', { timeoutMs: 500 })" "$main" || { echo "Electron main runtime event pump must use a bounded long poll" >&2; exit 1; }
+grep -Fq 'receive_with_timeout(Duration::from_millis(timeout_ms))' "$app_host" || { echo "Rust app host must forward bounded feature.receive timeoutMs" >&2; exit 1; }
 grep -Fq "mahayanaEdgeServer.emit(win.webContents, 'runtime-event', event)" "$main" || { echo "Electron main runtime event push is missing" >&2; exit 1; }
 
 if grep -Eq "require\(['\"]\./" "$preload"; then

--- a/.github/scripts/assert-fabushi-desktop-architecture.py
+++ b/.github/scripts/assert-fabushi-desktop-architecture.py
@@ -47,6 +47,12 @@ REQUIRED_SNIPPETS = {
         "native-desktop",
         "runtime-event",
     ),
+    "desktop/electron/main.cjs": (
+        "installAutomaticDesktopUpdateChecks",
+        "browser-window-focus",
+        "DESKTOP_UPDATE_FOREGROUND_INTERVAL_MS",
+        "checkForDesktopUpdateAutomatically",
+    ),
     "frontend/apps/web/src/lib/mahayana-host/coordinator.ts": (
         "class MahayanaCoordinator",
         "getAgentTranscriptTail",

--- a/.github/workflows/apple-store-delivery.yml
+++ b/.github/workflows/apple-store-delivery.yml
@@ -571,5 +571,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --target "$SOURCE_SHA" \
             --title "Fabushi Apple $APP_VERSION ($BUILD_NUMBER)" \
-            --notes "Signed store-distribution packages accepted by App Store Connect from $SOURCE_SHA. These assets are also retained here exactly as delivered; Apple review/public availability remains controlled in App Store Connect."
+            --notes "Signed store-distribution packages accepted by App Store Connect from $SOURCE_SHA. These assets are also retained here exactly as delivered; Apple review/public availability remains controlled in App Store Connect." \
+            --latest=false
           echo "- GitHub Release: $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/delivery-governance-contract.yml
+++ b/.github/workflows/delivery-governance-contract.yml
@@ -9,6 +9,9 @@ on:
       - '.github/scripts/require-release-source-gates.sh'
       - '.github/workflows/apple-store-delivery.yml'
       - '.github/workflows/google-play-delivery.yml'
+      - '.github/workflows/native-electron-release.yml'
+      - '.github/workflows/global-dharma-rust.yml'
+      - '.github/workflows/important-release-gate.yml'
       - '.github/workflows/delivery-governance-contract.yml'
       - '.github/workflows/automerge.yml'
       - 'projects/fabushi-cicd-merge-governance/**'
@@ -20,6 +23,9 @@ on:
       - '.github/scripts/require-release-source-gates.sh'
       - '.github/workflows/apple-store-delivery.yml'
       - '.github/workflows/google-play-delivery.yml'
+      - '.github/workflows/native-electron-release.yml'
+      - '.github/workflows/global-dharma-rust.yml'
+      - '.github/workflows/important-release-gate.yml'
       - '.github/workflows/delivery-governance-contract.yml'
       - '.github/workflows/automerge.yml'
       - 'projects/fabushi-cicd-merge-governance/**'
@@ -45,6 +51,9 @@ jobs:
             /.github/scripts/require-release-source-gates.sh
             /.github/workflows/apple-store-delivery.yml
             /.github/workflows/google-play-delivery.yml
+            /.github/workflows/native-electron-release.yml
+            /.github/workflows/global-dharma-rust.yml
+            /.github/workflows/important-release-gate.yml
             /.github/workflows/automerge.yml
 
       - name: Validate release source gates
@@ -63,10 +72,17 @@ jobs:
             grep -Fq 'actions: read' "$workflow"
             grep -Fq 'Require canonical release source gates' "$workflow"
             grep -Fq 'require-release-source-gates.sh' "$workflow"
+            grep -Fq -- '--latest=false' "$workflow"
           done
 
           grep -Fq 'RELEASE_TARGET: android' .github/workflows/google-play-delivery.yml
           grep -Fq 'RELEASE_TARGET: ${{ inputs.target }}' .github/workflows/apple-store-delivery.yml
+          for workflow in \
+            .github/workflows/native-electron-release.yml \
+            .github/workflows/global-dharma-rust.yml \
+            .github/workflows/important-release-gate.yml; do
+            grep -Fq -- '--latest=false' "$workflow"
+          done
 
       - name: Validate narrow CODEOWNERS coverage
         shell: bash

--- a/.github/workflows/gbf-rollback-drill.yml
+++ b/.github/workflows/gbf-rollback-drill.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/gbf-rollback-drill.yml'
       - '.github/workflows/native-electron-release.yml'
+      - '.github/workflows/post-main-delivery.yml'
       - 'projects/grok-bot-fabushi-integration/**'
   workflow_dispatch:
 
@@ -31,9 +32,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq '[.[] | select(.draft == false and .prerelease == false)] | first')"
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq '[.[] | select(.draft == false and .prerelease == false and (.tag_name | test("^desktop-[0-9]+\\.[0-9]+\\.[0-9]+$")))] | first')"
           if [ -z "$release_json" ] || [ "$release_json" = "null" ]; then
-            echo 'No stable published GitHub release exists; rollback cannot be honestly demonstrated.' >&2
+            echo 'No canonical stable desktop GitHub release exists; desktop rollback cannot be honestly demonstrated.' >&2
             exit 1
           fi
           tag="$(jq -r '.tag_name // empty' <<<"$release_json")"
@@ -59,6 +60,9 @@ jobs:
             exit 1
           fi
           find rollback-assets -maxdepth 1 -type f -printf '%f\n' | sort >> "$GITHUB_STEP_SUMMARY"
+          test -f rollback-assets/latest-mac.yml
+          test -n "$(find rollback-assets -maxdepth 1 -type f -name '*.dmg' -print -quit)"
+          test -n "$(find rollback-assets -maxdepth 1 -type f -name '*macos-*.zip' -print -quit)"
 
       - name: Verify release checksums when published
         shell: bash

--- a/.github/workflows/global-dharma-rust.yml
+++ b/.github/workflows/global-dharma-rust.yml
@@ -158,4 +158,4 @@ jobs:
           done
       - env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" release/* --generate-notes
+        run: gh release create "${GITHUB_REF_NAME}" release/* --generate-notes --latest=false

--- a/.github/workflows/google-play-delivery.yml
+++ b/.github/workflows/google-play-delivery.yml
@@ -276,5 +276,6 @@ jobs:
           gh release create "$release_tag" "${assets[@]}" \
             --target "${{ steps.release.outputs.source_sha }}" \
             --title "Fabushi Android ${{ steps.release.outputs.version_name }} (${{ steps.release.outputs.version_code }})" \
-            --notes "Native Android package delivered to Google Play track '${{ inputs.track }}' from ${{ steps.release.outputs.short_sha }}."
+            --notes "Native Android package delivered to Google Play track '${{ inputs.track }}' from ${{ steps.release.outputs.short_sha }}." \
+            --latest=false
           echo "- GitHub Release: $release_tag" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/important-release-gate.yml
+++ b/.github/workflows/important-release-gate.yml
@@ -63,7 +63,7 @@ jobs:
             exit 0
           fi
           if [ "$PRERELEASE" = "true" ]; then
-            gh release create "$RELEASE_TAG" --verify-tag --generate-notes --prerelease
+            gh release create "$RELEASE_TAG" --verify-tag --generate-notes --prerelease --latest=false
           else
-            gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+            gh release create "$RELEASE_TAG" --verify-tag --generate-notes --latest=false
           fi

--- a/.github/workflows/native-electron-release.yml
+++ b/.github/workflows/native-electron-release.yml
@@ -504,4 +504,4 @@ jobs:
             exit 1
           fi
           mapfile -d '' assets < <(find release -type f -print0)
-          gh release create "$RELEASE_TAG" "${assets[@]}" --verify-tag --generate-notes
+          gh release create "$RELEASE_TAG" "${assets[@]}" --verify-tag --generate-notes --latest=false

--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -54,6 +54,8 @@ jobs:
           grep -F 'needs.gate.outputs.electron_run_id' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'fabushi-delivery-mac.json' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'latest-mac.yml' .github/workflows/post-main-delivery.yml >/dev/null
+          grep -F 'gh release create "$tag" "${assets[@]}"' .github/workflows/post-main-delivery.yml >/dev/null
+          grep -F 'latest_args=(--latest)' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'desktop-update-cloud' .github/scripts/verify-release-updater-ui.mjs >/dev/null
           grep -F 'github.sha' .github/workflows/electron-desktop.yml >/dev/null
           grep -F 'github.sha' .github/workflows/native-mobile.yml >/dev/null
@@ -259,7 +261,7 @@ jobs:
           The macOS DMG/ZIP/updater metadata and Windows/Linux installers are the same artifacts that passed the Electron packaged-user gate for this source SHA.
           EOF
 
-          existing="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>/dev/null || true)"
+          existing="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\")" 2>/dev/null || true)"
           if [ -n "$existing" ]; then
             release_id="$(jq -r '.id' <<<"$existing")"
             existing_target="$(jq -r '.target_commitish' <<<"$existing")"
@@ -270,28 +272,28 @@ jobs:
               echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-          else
-            created="$(gh api --method POST "repos/$GITHUB_REPOSITORY/releases" \
-              -f tag_name="$tag" \
-              -f target_commitish="$SOURCE_SHA" \
-              -f name="Fabushi Desktop $VERSION" \
-              -f body="$(cat "$notes")" \
-              -F draft=true \
-              -F prerelease=false \
-              -f make_latest=false)"
-            release_id="$(jq -r '.id' <<<"$created")"
+            echo "Removing stale draft Release $tag before retrying atomic publication."
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"
           fi
 
           mapfile -t assets < <(find release-assets -maxdepth 1 -type f -print | sort)
           test "${#assets[@]}" -gt 0
-          gh release upload "$tag" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
+          latest_args=(--latest)
+          if [ "$make_latest" != true ]; then
+            latest_args=(--latest=false)
+          fi
+          gh release create "$tag" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$SOURCE_SHA" \
+            --title "Fabushi Desktop $VERSION" \
+            --notes-file "$notes" \
+            "${latest_args[@]}"
 
-          published="$(gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" \
-            -F draft=false \
-            -F prerelease=false \
-            -f make_latest="$make_latest")"
+          published="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag")"
           test "$(jq -r '.draft' <<<"$published")" = false
+          test "$(jq -r '.prerelease' <<<"$published")" = false
           test "$(jq -r '.tag_name' <<<"$published")" = "$tag"
+          test "$(jq -r '.target_commitish' <<<"$published")" = "$SOURCE_SHA"
           echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
           {
             echo '## Published Release'

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -34,6 +34,11 @@ let hostEventPump = null;
 const messagingAccessCache = new Map();
 let messagingSignalingClient = null;
 let availableDesktopUpdateVersion = null;
+const DESKTOP_UPDATE_CHECK_MIN_INTERVAL_MS = 60_000;
+const DESKTOP_UPDATE_FOREGROUND_INTERVAL_MS = 5 * 60_000;
+let lastAutomaticDesktopUpdateCheckAt = 0;
+let automaticDesktopUpdateCheckTimer = null;
+let automaticDesktopUpdateCheckPromise = null;
 
 function normalizeMessagingAccessParams(params) {
   const deviceId = String(params?.deviceId || 'desktop:electron').trim();
@@ -690,7 +695,7 @@ function startHostEventPump() {
   hostEventPump = (async () => {
     while (!hostEventPumpStopped) {
       try {
-        const event = await host.request('feature.receive', {});
+        const event = await host.request('feature.receive', { timeoutMs: 500 });
         if (event) broadcastMahayanaEvent(event);
         else await sleep(10);
       } catch (error) {
@@ -842,6 +847,33 @@ function installAutoUpdaterEvents() {
     void mutateNativeState((state) => ({ ...state, updateStatus: status }));
     broadcastNativeEvent('update-status', status);
   });
+}
+
+async function checkForDesktopUpdateAutomatically({ force = false } = {}) {
+  if (!app.isPackaged || !autoUpdater?.checkForUpdates) return null;
+  const now = Date.now();
+  if (!force && now - lastAutomaticDesktopUpdateCheckAt < DESKTOP_UPDATE_CHECK_MIN_INTERVAL_MS) return null;
+  if (automaticDesktopUpdateCheckPromise) return automaticDesktopUpdateCheckPromise;
+  lastAutomaticDesktopUpdateCheckAt = now;
+  automaticDesktopUpdateCheckPromise = autoUpdater.checkForUpdates()
+    .catch((error) => {
+      console.warn('[updater] automatic update check failed', error instanceof Error ? error.message : String(error));
+      return null;
+    })
+    .finally(() => { automaticDesktopUpdateCheckPromise = null; });
+  return automaticDesktopUpdateCheckPromise;
+}
+
+function installAutomaticDesktopUpdateChecks() {
+  if (!app.isPackaged) return;
+  const startupTimer = setTimeout(() => { void checkForDesktopUpdateAutomatically({ force: true }); }, 4_000);
+  startupTimer.unref?.();
+  app.on('browser-window-focus', () => { void checkForDesktopUpdateAutomatically(); });
+  automaticDesktopUpdateCheckTimer = setInterval(() => {
+    const hasFocusedWindow = BrowserWindow.getAllWindows().some((win) => !win.isDestroyed() && win.isFocused());
+    if (hasFocusedWindow) void checkForDesktopUpdateAutomatically();
+  }, DESKTOP_UPDATE_FOREGROUND_INTERVAL_MS);
+  automaticDesktopUpdateCheckTimer.unref?.();
 }
 
 function installApplicationMenu() {
@@ -1009,14 +1041,17 @@ app.whenReady().then(() => {
   host.start();
   createWindow();
   startHostEventPump();
-  if (app.isPackaged) {
-    setTimeout(() => { void autoUpdater.checkForUpdates().catch(() => undefined); }, 4_000);
-  }
-  app.on('activate', () => { if (BrowserWindow.getAllWindows().length === 0) createWindow(); });
+  installAutomaticDesktopUpdateChecks();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    void checkForDesktopUpdateAutomatically();
+  });
 });
 
 app.on('window-all-closed', () => { deepLinkRouter.markNotReady(); if (process.platform !== 'darwin') app.quit(); });
 app.on('before-quit', () => {
+  if (automaticDesktopUpdateCheckTimer) clearInterval(automaticDesktopUpdateCheckTimer);
+  automaticDesktopUpdateCheckTimer = null;
   hostEventPumpStopped = true;
   mahayanaEdgeServer?.dispose();
   mahayanaEdgeServer = null;

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -139,3 +139,11 @@
 - 该旅程改为 optional/non-blocking 回归；现有自动化可以继续运行并产出诊断证据，但默认失败不会单独阻塞普通任务或 FCM-009 关闭。
 - required exact-main packaged E2E、Release、签名/公证、updater-compatible assets/versioning、open-source-first 与 warm-build/cache 完整性保持强制。
 - updater 自身发生修改的任务可以根据风险在自己的 acceptance criteria 中显式把该旅程提升为 required gate。
+
+## 2026-08-24 — FCM-011 Round 1 — desktop updater channel diagnosis
+
+- Target Mac 1.0.2 persisted updater failure because GitHub repository Latest was `android-v1.0.2-262331106`, which has no `latest-mac.yml`; the updater therefore fetched the Android Release path and received HTTP 404.
+- After `desktop-1.0.798` became Latest, a real process restart immediately produced `updateStatus=available` for 1.0.798 and rendered the profile update control, proving the desktop updater assets themselves are valid.
+- Diagnosed a second reliability gap: the packaged desktop only checked once four seconds after process start. The repair adds a throttled focus/foreground recheck and reserves GitHub Latest for canonical desktop Releases while making all non-desktop release workflows `--latest=false`.
+- Canonical post-main publication is also switched from the failed draft/upload/patch sequence to the create-with-assets path already proven by recovery run `32694503412`.
+- Task remains in-progress pending protected PR/main delivery evidence.

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -147,3 +147,7 @@
 - Diagnosed a second reliability gap: the packaged desktop only checked once four seconds after process start. The repair adds a throttled focus/foreground recheck and reserves GitHub Latest for canonical desktop Releases while making all non-desktop release workflows `--latest=false`.
 - Canonical post-main publication is also switched from the failed draft/upload/patch sequence to the create-with-assets path already proven by recovery run `32694503412`.
 - Task remains in-progress pending protected PR/main delivery evidence.
+
+### PR #2092 CI follow-up
+- `GBF rollback drill` exposed one more cross-platform Release assumption: it selected the first stable Release regardless of platform, then expected desktop checksum/update assets.
+- The drill is corrected to accept only canonical `desktop-x.y.z` Releases and to require macOS updater/install assets before using that Release as a rollback target.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -82,3 +82,7 @@
 - Kept updater-compatible Release assets and monotonic update-comparable versions mandatory; only the old-client journey proof changed from required to optional/non-blocking by default.
 - Updated FCM-009 task/WBS/acceptance semantics so optional updater E2E can continue as advisory regression evidence without blocking ordinary Release/task closure.
 - Updater-specific changes may still explicitly require this journey in their own task acceptance criteria when risk warrants it.
+
+## 2026-08-24 — FCM-011 in progress
+- Diagnosed GitHub Latest cross-platform release collision and single-startup-check updater staleness.
+- Added desktop Latest ownership, atomic post-main publication, foreground-throttled update checks, and governance contracts.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -44,5 +44,9 @@ Make a running Fabushi macOS client reliably discover the canonical desktop GitH
 - `bash .github/scripts/assert-electron-feature-host-bridge.sh` — pass.
 - Release ownership source checks: Apple / Google Play / native-electron / Global Dharma / important release paths all contain `--latest=false`; canonical post-main retains `--latest`.
 
+## PR CI finding
+- PR #2092 rollback drill initially failed because `.github/workflows/gbf-rollback-drill.yml` selected the first stable Release across every platform. A mobile/non-canonical Release can therefore be treated as the desktop rollback image.
+- The drill now selects only canonical `desktop-x.y.z` stable Releases and requires `latest-mac.yml`, a DMG, a macOS ZIP and checksums before accepting the rollback target.
+
 ## Current evidence / next gate
-Implementation pending PR CI, protected merge, exact-main packaged delivery and Release verification.
+Implementation pending refreshed PR CI, protected merge, exact-main packaged delivery and Release verification.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -1,0 +1,48 @@
+# FCM-011 — Desktop updater channel reliability
+
+- **Project ID:** FAB-P0003
+- **Project Key:** FCM
+- **Task ID:** FCM-011
+- **Status:** in-progress
+- **Started:** 2026-08-24T13:52:00+08:00
+- **Updated:** 2026-08-24T14:00:00+08:00
+- **Branch:** `fix/desktop-updater-idle-energy`
+
+## Objective
+Make a running Fabushi macOS client reliably discover the canonical desktop GitHub Release without requiring a process restart, while preventing Android/iOS/other repository releases from stealing GitHub's `Latest` pointer used by `electron-updater`. Repair the canonical post-main publication path so future desktop Releases publish atomically with updater assets.
+
+## Diagnosed evidence
+- Installed macOS app `1.0.2` persisted updater error: `Cannot find latest-mac.yml` under `android-v1.0.2-262331106`; GitHub `Latest` pointed at an Android delivery with no macOS metadata.
+- After canonical `desktop-1.0.798` became GitHub Latest, a real process restart changed persisted `updateStatus` to `available / 1.0.798` and the UI displayed `更新 1.0.798`.
+- The desktop main process only performed one automatic check four seconds after startup, so a long-running macOS process never revisited a corrected/new Release until restart/manual action.
+- Post-main run `32693968757` validated exact-SHA updater assets but failed in the old draft/create/upload mutation sequence; recovery run `32694503412` proved `gh release create <tag> <assets...>` works.
+
+## Open-source-first baseline
+- `electron-userland/electron-builder` / `electron-updater` (MIT): retain its GitHub provider and generated `latest-mac.yml`; upstream troubleshooting confirms draft/missing-channel metadata causes update discovery failures.
+- `electron-updater` already deduplicates concurrent `checkForUpdates()` calls, so Fabushi can safely add a throttled foreground/focus scheduler instead of inventing a new updater.
+- Decision: adapt proven upstream behavior; no new updater protocol or dependency.
+
+## Atomic work
+1. Reserve repository GitHub `Latest` for canonical desktop Releases; non-desktop/store workflows publish with `--latest=false`.
+2. Add delivery-governance contract coverage for Apple/Google store release latest-pointer safety.
+3. Replace fragile draft + upload + patch post-main publication with atomic create-with-assets, including stale draft cleanup and exact-SHA verification.
+4. Recheck updates on app/window focus after a throttle window and every five minutes only while a Fabushi window is focused; keep the initial startup check.
+5. Preserve updater compatibility and run the already-available old-client discovery proof for this release; a two-release no-restart focus journey remains sampled/non-blocking unless a later updater change explicitly promotes it.
+
+## Acceptance
+- Scheduler/contract coverage proves a running packaged macOS client rechecks on focus/foreground cadence without background polling; the existing 1.0.2 client already proves canonical desktop metadata discovery after a real restart.
+- Android/iOS/other non-desktop Release workflows cannot become repository Latest.
+- Canonical post-main desktop publication is atomic and leaves `latest-mac.yml`, ZIP, DMG and blockmaps on the Release.
+- Automatic checks are throttled and do not create background network polling.
+- PR passes required CI, merge queue, canonical-main post-merge package/E2E/Release gates, and exact main readback.
+
+## Local verification before PR
+- `node --check desktop/electron/main.cjs` — pass.
+- Changed GitHub Actions YAML parsed successfully with PyYAML.
+- `node --test desktop/electron/host-process.test.cjs` — 5/5 pass.
+- `python3 .github/scripts/assert-fabushi-desktop-architecture.py` — pass.
+- `bash .github/scripts/assert-electron-feature-host-bridge.sh` — pass.
+- Release ownership source checks: Apple / Google Play / native-electron / Global Dharma / important release paths all contain `--latest=false`; canonical post-main retains `--latest`.
+
+## Current evidence / next gate
+Implementation pending PR CI, protected merge, exact-main packaged delivery and Release verification.

--- a/projects/mahayana-sovereign-runtime/management/05-状态报告.md
+++ b/projects/mahayana-sovereign-runtime/management/05-状态报告.md
@@ -22,3 +22,10 @@
 - CI/merge evidence for MSR-101/102/103 is pending; none of those tasks is represented as passed yet.
 
 Next: open the implementation PR, repair all Actions failures, merge/re-verify; then execute the remaining matrix gaps in MSR-201/202/301/302/401/501/601.
+
+## 2026-08-24 — MSR-106 Round 1 — desktop idle energy diagnosis
+
+- Target Mac hidden/background baseline isolated the main drain: GPU/renderer fell near zero, while `mahayana-app-host` remained around 21.6% CPU and the Electron main process around 0.9%.
+- `sample` captured `feature_receive -> crossbeam_channel::Receiver::recv_timeout`; source inspection found a 1 ms production receive timeout followed by the Electron 10 ms retry loop, creating continuous idle wakeups.
+- Repair keeps existing `crossbeam-channel` and adds an explicit bounded `timeoutMs` boundary: Electron requests a 500 ms long poll, direct/test callers remain non-blocking, and queued events drain with zero additional wait after wakeup.
+- Task remains in-progress pending CI, protected merge, exact-main package and target-Mac post-fix energy measurement.

--- a/projects/mahayana-sovereign-runtime/management/07-变更日志.md
+++ b/projects/mahayana-sovereign-runtime/management/07-变更日志.md
@@ -8,3 +8,7 @@
 - Advanced reviewed Codex baseline from `970b7f2d...` to `343074d4207d572809bd8cea15f4be1d09d98e0b`; retained Grok Build `19d42e35...` as the current reviewed baseline.
 - Added `docs/08-upstream-capability-matrix.md` and routed explicit remaining gaps to MSR-103/201/202/301/302/401/501/601.
 - Began MSR-103: introduced Mahayana-owned auth and encrypted-secrets crates, product dependency cutover, migration compatibility, source-boundary enforcement, and Actions coverage.
+
+## 2026-08-24 — MSR-106 in progress
+- Diagnosed background CPU drain to 1 ms Feature Host event polling.
+- Added explicit bounded event long-poll while preserving non-blocking direct/test receive semantics.

--- a/projects/mahayana-sovereign-runtime/management/tasks/MSR-106-desktop-idle-energy.md
+++ b/projects/mahayana-sovereign-runtime/management/tasks/MSR-106-desktop-idle-energy.md
@@ -1,0 +1,45 @@
+# MSR-106 — Desktop idle/background energy
+
+- **Project ID:** FAB-P0005
+- **Project Key:** MSR
+- **Task ID:** MSR-106
+- **Status:** in-progress
+- **Started:** 2026-08-24T13:52:00+08:00
+- **Updated:** 2026-08-24T14:00:00+08:00
+- **Branch:** `fix/desktop-updater-idle-energy`
+
+## Objective
+Eliminate the Mahayana desktop runtime busy-poll that keeps Fabushi near the top of macOS battery usage while the app is idle/backgrounded, without adding latency to real runtime events.
+
+## Diagnosed evidence
+- The installed Fabushi `1.0.2` process had remained alive for over five hours on macOS.
+- With the app hidden, renderer/GPU usage fell to approximately zero, but `mahayana-app-host` remained about `21.6% CPU` and the Electron main process about `0.9% CPU`.
+- `desktop/electron/main.cjs` repeatedly calls `feature.receive`; when no event is returned it sleeps only 10 ms.
+- Production `mahayana-feature-host::receive_production` waits only 1 ms on `crossbeam_channel::recv_timeout`, causing roughly tens of IPC wakeups per second while completely idle.
+- A process sample captured `feature_receive -> crossbeam_channel::Receiver::recv_timeout` as the active host stack.
+
+## Open-source-first baseline
+- Existing `crossbeam-channel` (MIT/Apache-2.0) is already the runtime event primitive and natively supports blocking `recv_timeout`; no polling framework is needed.
+- Proven event-loop pattern: block the first receive with a bounded timeout, wake immediately when data arrives, then drain already queued events without another long wait.
+- Decision: reuse the existing channel's blocking semantics; no new dependency.
+
+## Implementation
+- `feature.receive` now accepts a bounded `timeoutMs`; the Electron event pump requests a 500 ms long poll, while existing direct/test callers remain non-blocking by default.
+- The production controller blocks only for the first runtime event, returning immediately when data arrives; subsequent iterations use a zero timeout to drain queued/translatable events without adding streaming latency.
+- Electron remains responsive to runtime events while idle wakeups collapse from approximately ~90 polls/sec to about ~2 polls/sec.
+
+## Acceptance
+- Hidden/background idle `mahayana-app-host` no longer burns double-digit CPU.
+- Runtime events still wake immediately rather than waiting for the full timeout.
+- Existing feature-host/runtime tests pass.
+- PR passes required CI, protected merge queue, post-main packaged E2E/Release, and canonical-main readback.
+
+## Local verification before PR
+- Hidden installed 1.0.2 baseline: `mahayana-app-host` approximately 21.6% CPU while renderer/GPU fell near zero.
+- Process sample showed the host active in `feature_receive -> crossbeam_channel::Receiver::recv_timeout`.
+- `node --test desktop/electron/host-process.test.cjs` — 5/5 pass.
+- Electron Feature Host bridge contract — pass with explicit `{ timeoutMs: 500 }` and Rust `receive_with_timeout` forwarding.
+- Rust formatting/build validation is intentionally delegated to GitHub Actions because the repository's canonical native toolchain/build evidence is CI-hosted.
+
+## Current evidence / next gate
+Implementation pending exact-head CI, protected merge, exact-main packaged delivery, then target-Mac hidden-idle CPU remeasurement.

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppHostFeatureMode {
@@ -157,7 +158,7 @@ impl AppHost {
             "feature.info" => serde_json::to_value(self.feature.info())
                 .map_err(|error| AppHostError::Operation(error.to_string())),
             "feature.execute" => self.feature_execute(params),
-            "feature.receive" => self.feature_receive(),
+            "feature.receive" => self.feature_receive(params),
             "feature.approval.resolve" => self.feature_resolve_approval(params),
             "feature.interrupt" => self.feature_interrupt(params),
             "feature.auth.status" => self
@@ -208,10 +209,15 @@ impl AppHost {
         serde_json::to_value(accepted).map_err(|error| AppHostError::Operation(error.to_string()))
     }
 
-    fn feature_receive(&self) -> Result<Value, AppHostError> {
+    fn feature_receive(&self, params: Value) -> Result<Value, AppHostError> {
+        let timeout_ms = params
+            .get("timeoutMs")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            .min(30_000);
         let event = self
             .feature
-            .receive()
+            .receive_with_timeout(Duration::from_millis(timeout_ms))
             .map_err(|error| AppHostError::Operation(error.to_string()))?;
         serde_json::to_value(event).map_err(|error| AppHostError::Operation(error.to_string()))
     }

--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -5400,13 +5400,20 @@ impl FeatureHostController {
     }
 
     pub fn receive(&self) -> Result<Option<HostEvent>, FeatureHostError> {
+        self.receive_with_timeout(Duration::ZERO)
+    }
+
+    pub fn receive_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<Option<HostEvent>, FeatureHostError> {
         self.fire_due_automation()?;
         if let Some(event) = self.state()?.events.pop_front() {
             return Ok(Some(event));
         }
         match self.config.mode {
             HostMode::Test => Ok(None),
-            HostMode::Production => self.receive_production(),
+            HostMode::Production => self.receive_production(timeout),
         }
     }
 
@@ -5620,7 +5627,10 @@ impl FeatureHostController {
     }
 
     #[cfg(not(feature = "production"))]
-    fn receive_production(&self) -> Result<Option<HostEvent>, FeatureHostError> {
+    fn receive_production(
+        &self,
+        _timeout: Duration,
+    ) -> Result<Option<HostEvent>, FeatureHostError> {
         Err(FeatureHostError::ProductionUnavailable)
     }
 
@@ -6430,9 +6440,15 @@ impl FeatureHostController {
     }
 
     #[cfg(feature = "production")]
-    fn receive_production(&self) -> Result<Option<HostEvent>, FeatureHostError> {
-        for _ in 0..16 {
-            let Some(event) = self.runtime()?.receive(Duration::from_millis(1))? else {
+    fn receive_production(
+        &self,
+        timeout: Duration,
+    ) -> Result<Option<HostEvent>, FeatureHostError> {
+        for index in 0..16 {
+            // Block only for the first runtime event. Once awakened, drain already-queued
+            // events without adding latency between streamed events.
+            let receive_timeout = if index == 0 { timeout } else { Duration::ZERO };
+            let Some(event) = self.runtime()?.receive(receive_timeout)? else {
                 return Ok(None);
             };
             if let Some(event) = self.translate_runtime_event(event)? {


### PR DESCRIPTION
## Summary

Fixes the macOS issues reproduced on the installed Fabushi client and aligns the interaction model with the user-requested ChatGPT desktop behavior while retaining Fabushi's Electron/Rust architecture.

### Updater reliability / FCM-011
- Root cause of the restart-only discovery: GitHub `Latest` had previously been an Android Release with no `latest-mac.yml`, and the packaged client only performed one-shot startup checks.
- Reserve repository `Latest` for canonical desktop Releases; non-desktop/store releases use `--latest=false`.
- Re-check updates on startup, window focus, and a throttled five-minute interval only while Fabushi is focused; no background polling.
- Repair canonical post-main publication with the proven atomic `gh release create <tag> <assets...>` path and validate updater metadata references/checksums.
- One click now owns the whole update transaction: download -> real `update-downloaded` event -> staging -> `quitAndInstall` -> relaunch.
- Render the real `download-progress.percent` as percentage text plus a progress rail; keep the control busy so there is no misleading second `安装更新` click.
- Set `autoInstallOnAppQuit=true` as a fallback.
- Updater E2E now requires progress UI and automatic app close/replacement from the single click.

### ChatGPT-style nonblocking startup / TFI M3-DESKTOP-002
- `正在恢复你的工作空间` was not a real workspace restore; it was the `authResolved=false` account-validation gate.
- Returning/startup UI now paints the normal Fabushi Messenger shell/projection first while auth and Host readiness reconcile in the background.
- Only an explicit successful `loggedIn=false` response routes to login; transient Host/auth transport failures retry without evicting a valid cached shell.
- HostClient resolves auth before expensive conversations/connectors/skills/agents/settings hydration and uses accurate account-verification copy instead of workspace-restore copy.

### Idle/background energy / MSR-106
- Earlier hidden-app measurement isolated `mahayana-app-host` around 21.6% CPU from a 1 ms receive poll; the Host path now uses a bounded 500 ms blocking receive and immediate queue drain.
- A second target-Mac measurement on packaged `1.0.798` with Fabushi merely unfocused showed the larger remaining drain: GPU about 60.9% CPU and renderer about 22.5% CPU.
- Root cause: the global BotMark `requestAnimationFrame` clock and CSS aura/breathe/orbit animations kept running when the Fabushi window lost focus.
- Suspend shared JS + CSS BotMark motion when the document is hidden/unfocused, resume immediately on focus, and cap focused organic motion dispatch to 30 FPS.

## ChatGPT / open-source reference
- Target Mac ChatGPT app was inspected as the requested UX benchmark: it paints its normal shell immediately and bundles Sparkle with automatic checks/updates enabled.
- Reuse public/proven updater concepts only; Fabushi remains on `electron-updater` and does not copy proprietary ChatGPT implementation.
- Reuse existing `crossbeam-channel` blocking semantics for runtime events; no new polling dependency.

## Local lightweight verification
- `node --check` on modified Electron/update automation files — pass
- `node --test desktop/electron/native-capability-handlers.test.cjs desktop/electron/host-process.test.cjs` — 13/13 pass
- BotMark low-power motion contract — pass
- desktop architecture contract — pass
- Electron Feature Host bridge contract — pass
- changed workflow YAML parse — pass
- `git diff --check` — pass

## Required completion gates
This PR is **not complete** until required CI passes, it merges through protected merge queue, the exact main SHA completes packaged desktop/native E2E and publishes a newer signed/notarized Release, the updater-specific old-client journey proves one-click progress/install/relaunch, startup no longer shows the misleading restore screen, and the target Mac background energy measurement settles near idle.