### PR TITLE
fix(desktop): one-click updates, nonblocking startup and low-power background

### DIFF
--- a/.github/scripts/assert-bot-mark-motion.py
+++ b/.github/scripts/assert-bot-mark-motion.py
@@ -20,6 +20,10 @@ for marker in required_component:
 required_engine = [
     'const frameListeners = new Set<FrameListener>()',
     'window.requestAnimationFrame(runMotionFrame)',
+    'MOTION_FRAME_INTERVAL_MS',
+    'document.visibilityState',
+    'document.hasFocus()',
+    'dataset.fabushiMotion',
     'function springStep(',
     'function eyeLensPath(',
     'function profileForState(',

--- a/.github/scripts/assert-fabushi-desktop-architecture.py
+++ b/.github/scripts/assert-fabushi-desktop-architecture.py
@@ -53,6 +53,11 @@ REQUIRED_SNIPPETS = {
         "DESKTOP_UPDATE_FOREGROUND_INTERVAL_MS",
         "checkForDesktopUpdateAutomatically",
     ),
+    "desktop/package.json": (
+        '"artifactName": "fabushi-${version}-setup.${ext}"',
+        '"artifactName": "fabushi-${version}-${arch}.${ext}"',
+        '"artifactName": "fabushi-${version}-macos-${arch}.${ext}"',
+    ),
     "frontend/apps/web/src/lib/mahayana-host/coordinator.ts": (
         "class MahayanaCoordinator",
         "getAgentTranscriptTail",

--- a/.github/scripts/verify-release-updater-ui.mjs
+++ b/.github/scripts/verify-release-updater-ui.mjs
@@ -23,6 +23,7 @@ let applicationClosed = false;
 app.on('close', () => { applicationClosed = true; });
 const observedStates = [];
 let buttonText = '';
+let sawProgressIndicator = false;
 
 async function completeBrowserLogin(page) {
   await page.waitForLoadState('domcontentloaded');
@@ -64,6 +65,7 @@ try {
     try {
       const state = await update.getAttribute('data-state');
       if (state && observedStates.at(-1) !== state) observedStates.push(state);
+      if (await page.getByTestId('desktop-update-progress').isVisible().catch(() => false)) sawProgressIndicator = true;
     } catch {
       if (applicationClosed) break;
     }
@@ -73,12 +75,20 @@ try {
     throw new Error(`Clicking the update control did not start an updater transition; states=${observedStates.join(',')}`);
   }
 
+  if (observedStates.includes('downloading') && !sawProgressIndicator) {
+    throw new Error(`Updater entered downloading state without exposing progress UI; states=${observedStates.join(',')}`);
+  }
+  if (!applicationClosed) {
+    throw new Error(`One update click did not automatically close the previous app for installation; states=${observedStates.join(',')}`);
+  }
+
   await writeFile(evidencePath, `${JSON.stringify({
     expectedVersion,
     executablePath,
     buttonText,
     observedStates,
     applicationClosed,
+    sawProgressIndicator,
     clicked: true,
     timestamp: new Date().toISOString(),
   }, null, 2)}\n`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,7 @@ jobs:
             /desktop/electron/offline-asr.cjs
             /.github/scripts/assert-native-desktop-edge-parity.py
             /desktop/electron/**
+            /desktop/package.json
             /desktop/src/edge/**
             /desktop/src/main.tsx
             /desktop/src/messaging-shell-v2.tsx

--- a/.github/workflows/gbf-rollback-drill.yml
+++ b/.github/workflows/gbf-rollback-drill.yml
@@ -73,9 +73,24 @@ jobs:
             exit 1
           fi
           cd rollback-assets
-          sed -E 's#([[:space:]]+)release/#\1#' SHA256SUMS.txt > SHA256SUMS.rollback.txt
+          : > SHA256SUMS.rollback.txt
+          manifest_digests="$(awk '{print $1}' SHA256SUMS.txt | grep -E '^[0-9a-fA-F]{64}$' | tr 'A-F' 'a-f' | sort -u)"
+          verified=0
+          while IFS= read -r -d '' asset; do
+            case "$asset" in
+              ./SHA256SUMS.txt|./SHA256SUMS.rollback.txt) continue ;;
+            esac
+            digest="$(sha256sum "$asset" | awk '{print tolower($1)}')"
+            if ! grep -Fxq "$digest" <<<"$manifest_digests"; then
+              echo "Downloaded rollback asset has no matching published checksum: $asset ($digest)" >&2
+              exit 1
+            fi
+            printf '%s  %s\n' "$digest" "$asset" >> SHA256SUMS.rollback.txt
+            verified=$((verified + 1))
+          done < <(find . -maxdepth 1 -type f -print0 | sort -z)
+          test "$verified" -gt 0
           sha256sum -c SHA256SUMS.rollback.txt
-          echo 'previous-good release checksums verified' >> "$GITHUB_STEP_SUMMARY"
+          echo "previous-good release checksums verified by content digest for $verified assets" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Require immutable-release and canonical-gate guards in the current release workflow
         shell: bash

--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -56,6 +56,8 @@ jobs:
           grep -F 'latest-mac.yml' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'gh release create "$tag" "${assets[@]}"' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'latest_args=(--latest)' .github/workflows/post-main-delivery.yml >/dev/null
+          grep -F 'Checksum manifest must never contain itself.' .github/workflows/post-main-delivery.yml >/dev/null
+          grep -F 'references missing release asset' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'desktop-update-cloud' .github/scripts/verify-release-updater-ui.mjs >/dev/null
           grep -F 'github.sha' .github/workflows/electron-desktop.yml >/dev/null
           grep -F 'github.sha' .github/workflows/native-mobile.yml >/dev/null
@@ -222,7 +224,28 @@ jobs:
           metadata_version="$(awk -F': ' '/^version:/ {gsub(/[[:space:]\r]/, "", $2); print $2; exit}' release-assets/latest-mac.yml)"
           test "$metadata_version" = "$version"
 
-          (cd release-assets && find . -maxdepth 1 -type f ! -name SHA256SUMS.txt -print0 | sort -z | xargs -0 shasum -a 256 > SHA256SUMS.txt)
+          # electron-updater follows the URLs encoded in these channel files. Refuse to
+          # publish if a generated metadata URL does not resolve to an exact asset name.
+          for metadata in latest-mac.yml latest.yml latest-linux.yml; do
+            test -f "release-assets/$metadata"
+            while IFS= read -r referenced; do
+              test -n "$referenced"
+              if [ ! -f "release-assets/$referenced" ]; then
+                echo "$metadata references missing release asset: $referenced" >&2
+                exit 1
+              fi
+            done < <(awk '$1 == "-" && $2 == "url:" { value=$3; gsub(/^['\"']|['\"']$/, "", value); print value }' "release-assets/$metadata")
+          done
+
+          # Write outside release-assets first. Creating the destination in-place before
+          # `find` can make the checksum file hash itself as an empty file.
+          checksum_file="$RUNNER_TEMP/SHA256SUMS.txt"
+          (cd release-assets && find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 shasum -a 256 > "$checksum_file")
+          mv "$checksum_file" release-assets/SHA256SUMS.txt
+          if grep -Fq 'SHA256SUMS.txt' release-assets/SHA256SUMS.txt; then
+            echo 'Checksum manifest must never contain itself.' >&2
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Validated exact-SHA updater assets for version $version / $SOURCE_SHA" >> "$GITHUB_STEP_SUMMARY"
           find release-assets -maxdepth 1 -type f -printf '%f\n' | sort >> "$GITHUB_STEP_SUMMARY"

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -812,7 +812,7 @@ function createWindow() {
 function installAutoUpdaterEvents() {
   if (!autoUpdater?.on) return;
   autoUpdater.autoDownload = false;
-  autoUpdater.autoInstallOnAppQuit = false;
+  autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.allowPrerelease = false;
   autoUpdater.on('checking-for-update', () => {
     const status = { type: 'checking', version: app.getVersion() };

--- a/desktop/electron/native-capability-handlers.cjs
+++ b/desktop/electron/native-capability-handlers.cjs
@@ -213,6 +213,27 @@ function createNativeCapabilityHandlers(deps) {
     return status;
   }
 
+  function waitForUpdateDownloaded(timeoutMs = 180_000) {
+    if (!autoUpdater?.once) return Promise.resolve(null);
+    return new Promise((resolve, reject) => {
+      let timer = null;
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        autoUpdater.removeListener?.('update-downloaded', onDownloaded);
+        autoUpdater.removeListener?.('error', onError);
+      };
+      const onDownloaded = (info) => { cleanup(); resolve(info ?? null); };
+      const onError = (error) => { cleanup(); reject(error instanceof Error ? error : new Error(String(error))); };
+      autoUpdater.once('update-downloaded', onDownloaded);
+      autoUpdater.once('error', onError);
+      timer = setTimeout(() => {
+        cleanup();
+        reject(new Error('Timed out waiting for the desktop update to finish downloading.'));
+      }, timeoutMs);
+      timer.unref?.();
+    });
+  }
+
   const handlers = {
     async submitFeedback(params) {
       const id = crypto.randomUUID();
@@ -371,15 +392,21 @@ function createNativeCapabilityHandlers(deps) {
         if (!autoUpdater?.downloadUpdate) {
           return { installed: false, reason: 'Desktop updater cannot download this release.' };
         }
-        await writeUpdateStatus({ type: 'downloading', version: status.version ?? expected ?? null, progress: 0 });
-        await autoUpdater.downloadUpdate();
-        status = await writeUpdateStatus({ type: 'ready', version: status.version ?? expected ?? null });
+        const version = status.version ?? expected ?? app.getVersion();
+        const downloaded = waitForUpdateDownloaded();
+        await writeUpdateStatus({ type: 'downloading', version, progress: 0 });
+        await Promise.all([autoUpdater.downloadUpdate(), downloaded]);
+        status = await currentUpdateStatus();
+        if (status.type !== 'ready') status = await writeUpdateStatus({ type: 'ready', version });
       }
       if (status.type !== 'ready') {
         return { installed: false, reason: 'No downloaded desktop update is ready.' };
       }
-      setImmediate(() => autoUpdater.quitAndInstall(false, true));
-      return { installed: true, version: status.version ?? null };
+      const version = status.version ?? expected ?? app.getVersion();
+      await writeUpdateStatus({ type: 'staging', version });
+      const installTimer = setTimeout(() => autoUpdater.quitAndInstall(false, true), 120);
+      installTimer.unref?.();
+      return { installed: true, version };
     },
 
     async setAutoUpdateWhenIdleOptIn(params) {

--- a/desktop/electron/native-capability-handlers.test.cjs
+++ b/desktop/electron/native-capability-handlers.test.cjs
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
+const { EventEmitter } = require('node:events');
 const test = require('node:test');
 
 const { createNativeCapabilityHandlers } = require('./native-capability-handlers.cjs');
@@ -154,16 +155,19 @@ test('diagnostic reports redact nested secrets before persistence', async () => 
 
 test('desktop update click downloads a GitHub release and schedules replacement restart', async () => {
   const calls = [];
-  const autoUpdater = {
-    async downloadUpdate() { calls.push('download'); return ['/tmp/fabushi-update.zip']; },
-    quitAndInstall(silent, forceRunAfter) { calls.push(['install', silent, forceRunAfter]); },
+  const autoUpdater = new EventEmitter();
+  autoUpdater.downloadUpdate = async () => {
+    calls.push('download');
+    setImmediate(() => autoUpdater.emit('update-downloaded', { version: '1.0.3' }));
+    return ['/tmp/fabushi-update.zip'];
   };
+  autoUpdater.quitAndInstall = (silent, forceRunAfter) => { calls.push(['install', silent, forceRunAfter]); };
   await harness(async ({ handlers, getState }) => {
     const result = await handlers.quitAndInstallUpdate({ expectedVersion: '1.0.3' });
     assert.equal(result.installed, true);
     assert.equal(result.version, '1.0.3');
-    assert.equal(getState().updateStatus.type, 'ready');
-    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(getState().updateStatus.type, 'staging');
+    await new Promise((resolve) => setTimeout(resolve, 180));
     assert.deepEqual(calls, ['download', ['install', false, true]]);
   }, {
     isPackaged: true,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -81,7 +81,8 @@
     "win": {
       "target": [
         "nsis"
-      ]
+      ],
+      "artifactName": "fabushi-${version}-setup.${ext}"
     },
     "linux": {
       "category": "Utility",
@@ -90,7 +91,8 @@
       "target": [
         "AppImage",
         "deb"
-      ]
+      ],
+      "artifactName": "fabushi-${version}-${arch}.${ext}"
     },
     "deb": {
       "packageName": "fabushi",

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -439,7 +439,8 @@ export default function DesktopShellV2() {
         if (!state.loggedIn) retryTimer = window.setTimeout(() => void checkAuth(), 900);
       } catch {
         if (closed) return;
-        setAuthenticated(false);
+        // A transient Host/network failure must not replace a valid local-first shell
+        // with a login/restore screen. Only an explicit loggedIn=false response signs out.
         retryTimer = window.setTimeout(() => void checkAuth(), 1_800);
       }
     };
@@ -452,15 +453,53 @@ export default function DesktopShellV2() {
   }, [authTransport]);
 
   const showMessenger = projectionLookupComplete
-    && (authenticated === true || (authenticated === null && Boolean(startupProjection)));
+    && (authenticated === true || Boolean(startupProjection));
+  const showLogin = projectionLookupComplete && authenticated === false;
   return (
-    <div className={styles.desktopRoot} data-testid="desktop-shell" data-local-first={showMessenger && authenticated === null ? 'true' : undefined}>
+    <div className={styles.desktopRoot} data-testid="desktop-shell" data-local-first={showMessenger && authenticated !== true ? 'true' : undefined}>
       {showMessenger
         ? <MessengerWorkspace initialProjection={startupProjection} />
-        : projectionLookupComplete
+        : showLogin
           ? <HostClient />
-          : <div className={styles.desktopRoot} data-testid="desktop-fast-start-bootstrap" aria-hidden="true" />}
+          : <DesktopFastStartBootstrap />}
     </div>
+  );
+}
+
+function DesktopFastStartBootstrap() {
+  return (
+    <main
+      className={`${styles.messenger} ${styles.fabushiUnified}`}
+      data-testid="desktop-fast-start-bootstrap"
+      aria-busy="true"
+      aria-label="Fabushi 正在连接"
+      style={{ gridTemplateColumns: '330px minmax(420px,1fr)' }}
+    >
+      <aside className={styles.chatList}>
+        <header className={styles.listHeader}>
+          <span className={styles.sidebarBrand} title="Fabushi"><BotMark botId="fabushi:bootstrap" state="idle" size={30} paused label="Fabushi" /></span>
+          <strong>聊天</strong>
+        </header>
+        <label className={styles.searchBox}>
+          <Search size={16} />
+          <input disabled placeholder="搜索" aria-label="搜索" />
+        </label>
+        <div className={styles.peerList} aria-hidden="true" />
+        <div className={styles.sidebarFooter}>
+          <button type="button" className={styles.profileNavigationTrigger} disabled>
+            <BotMark botId="fabushi:bootstrap:self" state="idle" size={38} paused label="我的头像" />
+            <span><strong>我</strong><small>正在连接</small></span>
+          </button>
+        </div>
+      </aside>
+      <section className={styles.chatWorkspace}>
+        <div className={styles.chatEmpty}>
+          <BotMark botId="fabushi:bootstrap:workspace" state="idle" size={72} paused label="Fabushi" />
+          <strong>Fabushi</strong>
+          <p>界面已经就绪，正在后台连接本机服务。</p>
+        </div>
+      </section>
+    </main>
   );
 }
 
@@ -618,7 +657,9 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
     const acceptUpdateState = (payload: unknown) => {
       if (disposed || !isDesktopUpdateState(payload)) return;
       setDesktopUpdateState(payload);
-      if (payload.type !== 'ready') setDesktopUpdateBusy(false);
+      if (payload.type === 'available' || payload.type === 'upToDate' || payload.type === 'error') {
+        setDesktopUpdateBusy(false);
+      }
     };
     const unsubscribe = subscribeNativeDesktopEvents({ 'update-status': acceptUpdateState });
     void invokeNativeDesktop<UpdateState>('getUpdateStatus').then(acceptUpdateState).catch(() => {});
@@ -1832,9 +1873,10 @@ async function saveInvoiceDialog() {
     if (!['available', 'downloading', 'staging', 'ready'].includes(state.type)) return;
     setDesktopUpdateBusy(true);
     try {
-      await invokeNativeDesktop('quitAndInstallUpdate', {
+      const result = await invokeNativeDesktop<{ installed?: boolean; reason?: string }>('quitAndInstallUpdate', {
         expectedVersion: 'version' in state ? state.version : undefined,
       });
+      if (result?.installed === false) throw new Error(result.reason || '无法开始桌面更新');
     } catch (cause) {
       setDesktopUpdateBusy(false);
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -1965,11 +2007,33 @@ async function saveInvoiceDialog() {
             data-testid="desktop-update-cloud"
             data-state={desktopUpdateState.type}
             disabled={desktopUpdateBusy}
-            title={desktopUpdateState.type === 'ready' ? '更新已下载，点击安装并重启' : '发现新版本，点击下载、替换并重启'}
+            title={desktopUpdateState.type === 'ready' ? '更新已下载，点击后立即安装并重启' : '点击一次即可下载、安装并自动重启'}
             onClick={() => void installDesktopUpdate(desktopUpdateState)}
           >
             <CloudDownload size={18} />
-            <span>{desktopUpdateState.type === 'ready' ? '安装更新' : desktopUpdateState.type === 'downloading' || desktopUpdateState.type === 'staging' ? '正在更新' : `更新 ${desktopUpdateState.version}`}</span>
+            <span>{desktopUpdateState.type === 'ready'
+              ? '重启并更新'
+              : desktopUpdateState.type === 'downloading'
+                ? `下载更新 ${Math.max(0, Math.min(100, Math.round(desktopUpdateState.progress ?? 0)))}%`
+                : desktopUpdateState.type === 'staging'
+                  ? '正在安装并重启…'
+                  : `更新 ${desktopUpdateState.version}`}</span>
+            {desktopUpdateState.type === 'downloading' || desktopUpdateState.type === 'staging' ? (
+              <span
+                className={styles.updateProgressTrack}
+                data-testid="desktop-update-progress"
+                data-indeterminate={desktopUpdateState.type === 'staging' || undefined}
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={desktopUpdateState.type === 'downloading' ? Math.max(0, Math.min(100, Math.round(desktopUpdateState.progress ?? 0))) : undefined}
+              >
+                <i
+                  className={styles.updateProgressFill}
+                  style={desktopUpdateState.type === 'downloading' ? { width: `${Math.max(0, Math.min(100, desktopUpdateState.progress ?? 0))}%` } : undefined}
+                />
+              </span>
+            ) : null}
           </button> : null}
           <button
             type="button"

--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -960,12 +960,40 @@
   font: inherit;
   font-size: 10px;
   font-weight: 680;
+  position: relative;
+  overflow: hidden;
 }
 .updateCloudButton:hover { color: #fff; background: rgba(45,146,224,.17); border-color: rgba(112,193,255,.34); }
 .updateCloudButton:disabled { cursor: progress; opacity: .72; }
 .updateCloudButton[data-state="downloading"] svg,
 .updateCloudButton[data-state="staging"] svg { animation: updateCloudPulse 1.25s ease-in-out infinite; }
 @keyframes updateCloudPulse { 50% { transform: translateY(1px) scale(.92); opacity: .55; } }
+
+.updateProgressTrack {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 2px;
+  height: 2px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(191,229,255,.16);
+}
+.updateProgressFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: currentColor;
+  transition: width .18s linear;
+}
+.updateProgressTrack[data-indeterminate="true"] .updateProgressFill {
+  width: 34%;
+  animation: updateProgressIndeterminate 1s ease-in-out infinite;
+}
+@keyframes updateProgressIndeterminate {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(360%); }
+}
 
 .chatList[data-collapsed="true"] .createMenuWrap,
 .chatList[data-collapsed="true"] .searchScope { display: none; }

--- a/frontend/apps/web/src/app/host/fabushi-bot-mark-engine.tsx
+++ b/frontend/apps/web/src/app/host/fabushi-bot-mark-engine.tsx
@@ -86,31 +86,69 @@ type FrameListener = (timeMs: number, deltaSeconds: number) => void;
 // One animation clock drives every mark. The engine writes SVG attributes directly,
 // so a sidebar full of agents does not cause a React render on every animation frame.
 const frameListeners = new Set<FrameListener>();
+const MOTION_FRAME_INTERVAL_MS = 1000 / 30;
 let motionFrameId: number | null = null;
 let lastMotionFrameMs = 0;
+let lastMotionDispatchMs = 0;
+let motionDocumentActive = true;
+let motionLifecycleInstalled = false;
+
+function updateMotionDocumentState(): void {
+  motionDocumentActive = document.visibilityState === "visible" && document.hasFocus();
+  document.documentElement.dataset.fabushiMotion = motionDocumentActive ? "active" : "paused";
+  if (!motionDocumentActive && motionFrameId !== null) {
+    window.cancelAnimationFrame(motionFrameId);
+    motionFrameId = null;
+    lastMotionFrameMs = 0;
+    lastMotionDispatchMs = 0;
+  } else if (motionDocumentActive && frameListeners.size > 0 && motionFrameId === null) {
+    motionFrameId = window.requestAnimationFrame(runMotionFrame);
+  }
+}
+
+function ensureMotionLifecycle(): void {
+  if (motionLifecycleInstalled) return;
+  motionLifecycleInstalled = true;
+  document.addEventListener("visibilitychange", updateMotionDocumentState);
+  window.addEventListener("focus", updateMotionDocumentState);
+  window.addEventListener("blur", updateMotionDocumentState);
+  updateMotionDocumentState();
+}
 
 function runMotionFrame(timeMs: number): void {
-  const rawDelta = lastMotionFrameMs ? (timeMs - lastMotionFrameMs) / 1000 : 1 / 60;
-  const deltaSeconds = Math.min(0.033, Math.max(1 / 240, rawDelta));
+  if (!motionDocumentActive) {
+    motionFrameId = null;
+    return;
+  }
+  if (lastMotionDispatchMs && timeMs - lastMotionDispatchMs < MOTION_FRAME_INTERVAL_MS) {
+    motionFrameId = window.requestAnimationFrame(runMotionFrame);
+    return;
+  }
+  const rawDelta = lastMotionFrameMs ? (timeMs - lastMotionFrameMs) / 1000 : 1 / 30;
+  const deltaSeconds = Math.min(0.05, Math.max(1 / 120, rawDelta));
   lastMotionFrameMs = timeMs;
+  lastMotionDispatchMs = timeMs;
   for (const listener of frameListeners) listener(timeMs, deltaSeconds);
   if (frameListeners.size > 0) {
     motionFrameId = window.requestAnimationFrame(runMotionFrame);
   } else {
     motionFrameId = null;
     lastMotionFrameMs = 0;
+    lastMotionDispatchMs = 0;
   }
 }
 
 function subscribeMotionFrame(listener: FrameListener): () => void {
+  ensureMotionLifecycle();
   frameListeners.add(listener);
-  if (motionFrameId === null) motionFrameId = window.requestAnimationFrame(runMotionFrame);
+  if (motionDocumentActive && motionFrameId === null) motionFrameId = window.requestAnimationFrame(runMotionFrame);
   return () => {
     frameListeners.delete(listener);
     if (frameListeners.size === 0 && motionFrameId !== null) {
       window.cancelAnimationFrame(motionFrameId);
       motionFrameId = null;
       lastMotionFrameMs = 0;
+      lastMotionDispatchMs = 0;
     }
   };
 }

--- a/frontend/apps/web/src/app/host/host-client.tsx
+++ b/frontend/apps/web/src/app/host/host-client.tsx
@@ -1702,6 +1702,30 @@ export default function HostClient() {
     void transport
       .initialize({ profileId: "default", mode })
       .then(async () => {
+        // Resolve authentication first. Conversation/tool/workspace hydration is background
+        // work and must never hold a full-screen returning-user gate.
+        try {
+          const authState = await Promise.race([
+            transport.authStatus(),
+            new Promise<never>((_, reject) =>
+              window.setTimeout(
+                () => reject(new Error("账号服务响应超时，请重新登录")),
+                8_000,
+              ),
+            ),
+          ]);
+          setAuth(authState);
+          if (authState.loggedIn) {
+            setFeatureStates((current) => ({ ...current, "auth.login": "passed" }));
+          }
+        } catch (cause: unknown) {
+          setAuth({ loggedIn: false });
+          setLoginError(
+            `无法恢复账号会话：${cause instanceof Error ? cause.message : String(cause)}`,
+          );
+        } finally {
+          setAuthResolved(true);
+        }
         await transport.execute({
           type: "conversation.list",
           requestId: "conversation-list-initial",
@@ -1730,28 +1754,6 @@ export default function HostClient() {
             requestId: "update-status-initial",
           }),
         ]);
-        try {
-          const authState = await Promise.race([
-            transport.authStatus(),
-            new Promise<never>((_, reject) =>
-              window.setTimeout(
-                () => reject(new Error("账号服务响应超时，请重新登录")),
-                8_000,
-              ),
-            ),
-          ]);
-          setAuth(authState);
-          if (authState.loggedIn) {
-            setFeatureStates((current) => ({ ...current, "auth.login": "passed" }));
-          }
-        } catch (cause: unknown) {
-          setAuth({ loggedIn: false });
-          setLoginError(
-            `无法恢复账号会话：${cause instanceof Error ? cause.message : String(cause)}`,
-          );
-        } finally {
-          setAuthResolved(true);
-        }
         const stored = JSON.parse(
           window.localStorage.getItem("fabushi.installed-miniapps") ?? "[]",
         ) as unknown;
@@ -4868,8 +4870,8 @@ export default function HostClient() {
             <section className={`${styles.fabushiWelcome} ${styles.loginExperience}`} role="status" aria-live="polite">
               <BotMark botId="fabushi-account" state="waking" size={96} className={styles.loginHeroMark} paused={false} />
               <p className={styles.loginEyebrow}>FABUSHI ACCOUNT</p>
-              <h2>正在恢复你的工作空间</h2>
-              <p>安全会话保存在本机；不会把登录凭据暴露给界面层。</p>
+              <h2>正在验证账号</h2>
+              <p>界面不会等待工作空间同步；这里只确认本机安全会话是否仍有效。</p>
               <div className={styles.loginLoadingRail}><i /><i /><i /></div>
             </section>
           ) : browserLoginAttempt ? (

--- a/frontend/apps/web/src/app/host/host.module.css
+++ b/frontend/apps/web/src/app/host/host.module.css
@@ -5617,6 +5617,13 @@
   animation-play-state: paused !important;
 }
 
+:global(html[data-fabushi-motion="paused"]) .botMark > svg,
+:global(html[data-fabushi-motion="paused"]) .botMarkAura,
+:global(html[data-fabushi-motion="paused"]) .botMarkAuraSecondary,
+:global(html[data-fabushi-motion="paused"]) .botMarkParticles i {
+  animation-play-state: paused !important;
+}
+
 @keyframes botMarkBreathe {
   0%, 100% { transform: translateY(0) rotate(-.35deg) scale(1); }
   34% { transform: translateY(-.9%) rotate(.65deg) scale(1.012, .995); }

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -151,3 +151,16 @@
 ### PR #2092 CI follow-up
 - `GBF rollback drill` exposed one more cross-platform Release assumption: it selected the first stable Release regardless of platform, then expected desktop checksum/update assets.
 - The drill is corrected to accept only canonical `desktop-x.y.z` Releases and to require macOS updater/install assets before using that Release as a rollback target.
+
+### PR #2092 CI follow-up 2 — updater metadata and checksum producer
+- Public `desktop-1.0.798/latest.yml` points at `@fabushi/desktop-setup-1.0.798.exe`, while the actual Release asset is `Setup.1.0.798.exe`; `latest-linux.yml` has the analogous AppImage mismatch. macOS metadata is correct.
+- Published `SHA256SUMS.txt` also contains an empty self-hash and original Unicode artifact filenames that differ from GitHub's final sanitized names.
+- Producer repair sets explicit ASCII Windows/Linux `artifactName` values, validates all updater metadata URLs against collected assets before publication, and generates checksums outside the release asset directory before moving the final manifest in.
+- Legacy rollback verification remains strict by matching every downloaded asset's byte digest against the published checksum digest set, independent of stale legacy filenames.
+
+## 2026-08-24 — FCM-011 Round 2 — one-click updater UX
+
+- Packaged `1.0.798` confirmed update discovery after restart but exposed no visual download percentage and could leave the user at a second `安装更新` click.
+- Target-Mac ChatGPT inspection confirmed Sparkle automatic checks/updates are enabled; Fabushi keeps electron-updater but now exposes real `download-progress` and binds one click through downloaded -> staging -> quit/install/relaunch.
+- Updater Release E2E is tightened for this updater-specific task: progress UI and automatic app close after the single click are required.
+- FCM-011 remains in-progress until protected merge, exact-main Release, and updater regression evidence pass.

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -164,3 +164,8 @@
 - Target-Mac ChatGPT inspection confirmed Sparkle automatic checks/updates are enabled; Fabushi keeps electron-updater but now exposes real `download-progress` and binds one click through downloaded -> staging -> quit/install/relaunch.
 - Updater Release E2E is tightened for this updater-specific task: progress UI and automatic app close after the single click are required.
 - FCM-011 remains in-progress until protected merge, exact-main Release, and updater regression evidence pass.
+
+## 2026-08-24 — FCM-011 Round 3 — PR #2093 contract checkout repair
+
+- Exact-head CI surfaced a deterministic sparse-checkout defect: the desktop architecture guard reads `desktop/package.json`, but the Electron Feature Host contract job had not checked that file out.
+- Added the package manifest to that job's sparse inputs; the guard remains strict.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -86,3 +86,10 @@
 ## 2026-08-24 — FCM-011 in progress
 - Diagnosed GitHub Latest cross-platform release collision and single-startup-check updater staleness.
 - Added desktop Latest ownership, atomic post-main publication, foreground-throttled update checks, and governance contracts.
+
+## 2026-08-24 — FCM-011 one-click updater continuation
+
+- Added visible update percentage/progress rail.
+- Changed install coordination to wait for the real `update-downloaded` event before staging and `quitAndInstall`.
+- Kept renderer busy through the transaction and added `autoInstallOnAppQuit` fallback.
+- Strengthened macOS updater E2E to reject missing progress or a required second click.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -65,3 +65,7 @@ The user validated `1.0.798` and reported two remaining UX regressions: the upda
 - release updater E2E fails if a downloading state has no progress UI or if the old app does not close automatically after the single click.
 
 This task now treats the old-client updater journey as required because FCM-011 directly changes updater behavior.
+
+## 2026-08-24 PR #2093 Round 1 CI sparse-checkout blocker
+
+PR #2093 exact-head CI correctly failed the `Electron Feature Host contract` before product tests because `assert-fabushi-desktop-architecture.py` now validates updater artifact naming in `desktop/package.json`, but that job's sparse checkout did not include the file. The repair adds only `desktop/package.json` to the existing contract job checkout; no validation is weakened or skipped.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -47,6 +47,21 @@ Make a running Fabushi macOS client reliably discover the canonical desktop GitH
 ## PR CI finding
 - PR #2092 rollback drill initially failed because `.github/workflows/gbf-rollback-drill.yml` selected the first stable Release across every platform. A mobile/non-canonical Release can therefore be treated as the desktop rollback image.
 - The drill now selects only canonical `desktop-x.y.z` stable Releases and requires `latest-mac.yml`, a DMG, a macOS ZIP and checksums before accepting the rollback target.
+- The refreshed drill then exposed a producer defect in `desktop-1.0.798`: Windows/Linux channel metadata referenced non-ASCII/default builder names that did not equal the GitHub-published asset names, and `SHA256SUMS.txt` also contained a self-entry for an empty checksum file.
+- Electron Builder now emits deterministic ASCII artifact names for Windows/Linux at source; post-main publication validates every `url:` in all `latest*.yml` files against a collected asset before release and builds `SHA256SUMS.txt` in `$RUNNER_TEMP` before moving it into the asset directory.
+- The rollback drill verifies legacy 1.0.798 by content digest rather than stale filename, preserving full byte-integrity proof while future releases use exact canonical filenames.
 
 ## Current evidence / next gate
 Implementation pending refreshed PR CI, protected merge, exact-main packaged delivery and Release verification.
+
+## 2026-08-24 updater interaction continuation
+
+The user validated `1.0.798` and reported two remaining UX regressions: the update control exposed no download progress and the first click could stop at `ready`, requiring a second `安装更新` click. The installed ChatGPT app on the same Mac bundles Sparkle and has automatic checking/updating enabled; Sparkle's public API explicitly models download, extraction, ready-to-install and relaunch states. Fabushi keeps `electron-updater` but adopts the same state-machine quality:
+
+- `download-progress.percent` is rendered as a visible progress rail plus percentage text;
+- one click attaches to the real `update-downloaded` event before download begins, then transitions to staging and schedules `quitAndInstall`;
+- `autoInstallOnAppQuit=true` is a fallback if the process exits normally after download;
+- the renderer stays busy through downloading/staging instead of re-enabling a misleading second click;
+- release updater E2E fails if a downloading state has no progress UI or if the old app does not close automatically after the single click.
+
+This task now treats the old-client updater journey as required because FCM-011 directly changes updater behavior.

--- a/projects/mahayana-sovereign-runtime/management/05-状态报告.md
+++ b/projects/mahayana-sovereign-runtime/management/05-状态报告.md
@@ -29,3 +29,10 @@ Next: open the implementation PR, repair all Actions failures, merge/re-verify; 
 - `sample` captured `feature_receive -> crossbeam_channel::Receiver::recv_timeout`; source inspection found a 1 ms production receive timeout followed by the Electron 10 ms retry loop, creating continuous idle wakeups.
 - Repair keeps existing `crossbeam-channel` and adds an explicit bounded `timeoutMs` boundary: Electron requests a 500 ms long poll, direct/test callers remain non-blocking, and queued events drain with zero additional wait after wakeup.
 - Task remains in-progress pending CI, protected merge, exact-main package and target-Mac post-fix energy measurement.
+
+## 2026-08-24 — MSR-106 Round 2 — renderer/GPU background energy
+
+- Target-Mac packaged `1.0.798` with Fabushi unfocused but still open isolated a second energy source: GPU about 60.9% CPU and renderer about 22.5%, while ChatGPT on the same machine sampled near idle.
+- Root cause is continuous BotMark JS/CSS motion surviving application blur because intersection visibility is not equivalent to foreground focus.
+- Shared motion now suspends on hidden/unfocused documents, resumes on focus, and dispatches focused organic motion at 30 FPS; CSS BotMark animations follow the same lifecycle.
+- MSR-106 remains in-progress until the packaged post-merge build is re-measured on the target Mac.

--- a/projects/mahayana-sovereign-runtime/management/07-变更日志.md
+++ b/projects/mahayana-sovereign-runtime/management/07-变更日志.md
@@ -12,3 +12,9 @@
 ## 2026-08-24 — MSR-106 in progress
 - Diagnosed background CPU drain to 1 ms Feature Host event polling.
 - Added explicit bounded event long-poll while preserving non-blocking direct/test receive semantics.
+
+## 2026-08-24 — MSR-106 renderer/GPU continuation
+
+- Paused BotMark requestAnimationFrame and compositor CSS motion when Fabushi is hidden or unfocused.
+- Capped focused shared BotMark motion dispatch to 30 FPS.
+- Preserved reduced-motion and explicit per-mark pause behavior.

--- a/projects/mahayana-sovereign-runtime/management/tasks/MSR-106-desktop-idle-energy.md
+++ b/projects/mahayana-sovereign-runtime/management/tasks/MSR-106-desktop-idle-energy.md
@@ -43,3 +43,17 @@ Eliminate the Mahayana desktop runtime busy-poll that keeps Fabushi near the top
 
 ## Current evidence / next gate
 Implementation pending exact-head CI, protected merge, exact-main packaged delivery, then target-Mac hidden-idle CPU remeasurement.
+
+## 2026-08-24 renderer/GPU continuation
+
+A second target-Mac measurement with packaged `1.0.798` while ChatGPT was foreground and Fabushi merely sat behind it showed the remaining dominant drain: Fabushi GPU process about `60.9% CPU` and renderer about `22.5% CPU`, while the local ChatGPT benchmark was near-idle (main about `0.2%`, GPU service about `1.3%` in the sampled process view).
+
+Root cause: the shared BotMark engine kept its global `requestAnimationFrame` clock alive whenever marks were intersection-visible, even when the Fabushi document had lost focus; CSS aura/breathe/orbit animations also continued. The energy fix therefore extends beyond Host long-polling:
+
+- suspend the shared JS motion clock whenever the document is hidden or the Fabushi window is unfocused;
+- set a document motion lifecycle marker so CSS BotMark compositor animations pause at the same boundary;
+- resume immediately on focus/visibility return;
+- cap focused shared motion dispatch to 30 FPS (slow organic avatar motion does not need 60+ attribute writes/sec);
+- preserve `prefers-reduced-motion` and per-mark pause semantics.
+
+Acceptance adds target-Mac background measurement after the packaged fix: renderer/GPU and `mahayana-app-host` must settle near idle rather than sustained double-digit CPU.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -128,3 +128,11 @@
 - `main@197dc768b972974aea3603eae8f80a46df4714a4`, Electron run `32683544762`: durable projection recovery succeeded, but the deterministic Rust test account was process-local and `feature.auth.status` switched the restored Messenger back to login.
 - The next fix makes test-mode account state durable only when a real Host data directory is supplied, mirrors production's local returning-session contract, persists no secrets, and deletes the state on logout.
 - Release remains blocked until exact-main packaged `< 1000 ms` evidence and all delivery gates are green.
+
+## 2026-08-24 — M3-DESKTOP-002 Round 5 — ChatGPT-style nonblocking startup
+
+- Target-Mac packaged `1.0.798` still showed `正在恢复你的工作空间`, but source tracing proved this was an `authResolved=false` account-validation gate rather than workspace restore.
+- The installed ChatGPT macOS app was inspected as the requested UX reference: normal shell first, background readiness work second.
+- Fabushi now keeps the normal Messenger shell/projection visible while auth is unknown or transport retries; only an explicit `loggedIn=false` result routes to login.
+- HostClient resolves auth before expensive conversation/connector/agent/settings hydration, and the fallback copy is renamed to accurate account verification.
+- Acceptance remains pending protected merge plus exact-main packaged startup measurement and Release validation.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -123,3 +123,9 @@
 - Durable test Host instances now persist/restore only UI-safe deterministic account identity in their configured runtime data directory.
 - Explicit logout removes that persisted test account, preserving sign-out semantics.
 - Startup E2E now guards against post-first-paint fallback to the login shell after the auth polling window.
+
+## 2026-08-24 — M3-DESKTOP-002 startup gate correction
+
+- Removed misleading full-screen workspace-restore semantics from returning-user startup.
+- Added normal-shell bootstrap while local projection/auth is unresolved.
+- Transient auth transport failures no longer force a signed-out remount; explicit signed-out state still does.

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -111,3 +111,17 @@ Exact-main Electron run `32683544762` on `main@197dc768b972974aea3603eae8f80a46d
 The follow-up persists only the deterministic UI-safe test user when the test Host is created with the app's durable runtime data directory, restores it across Host process restart, and deletes it on explicit logout. No credentials or tokens cross into this file. The E2E also waits beyond the auth retry interval after first interaction and requires the login shell to remain absent.
 
 Status remains `TESTING` until the exact canonical-main packaged run emits a passing `startup-performance.json` under 1000 ms, all required desktop/mobile gates pass, and the tested artifacts are published as the new Release.
+
+## 2026-08-24 ChatGPT-style nonblocking startup continuation
+
+Target-Mac validation of packaged desktop `1.0.798` still exposed the full-screen copy `正在恢复你的工作空间`. The screen was misleading: it was `HostClient`'s `authResolved=false` gate, not a real workspace restore. `DesktopShellV2` routed `no projection + auth still unknown` into that HostClient path, and a transient auth transport error also forced an immediate signed-out remount.
+
+The installed ChatGPT desktop app on the same Mac was inspected as the user-requested UX reference: it paints its normal shell immediately instead of blocking the app behind a workspace-restore page. Fabushi follows the same product principle without copying proprietary implementation:
+
+- durable/local projection still paints immediately when present;
+- while projection/auth is genuinely unresolved, render the normal Fabushi Messenger shell bootstrap instead of the HostClient restore screen;
+- only an explicit successful `loggedIn=false` auth result may route to login; transport/network exceptions keep the local-first shell and retry;
+- HostClient resolves auth before conversations/connectors/skills/agents/settings hydration and labels its fallback accurately as account verification;
+- returning-user synchronization remains background reconciliation against canonical Rust/Host state.
+
+Acceptance for this continuation: a returning signed-in packaged client must never show `正在恢复你的工作空间`; transient auth/Host startup failure must not evict a valid cached Messenger; an explicitly signed-out client still reaches the login surface; exact-main packaged startup E2E remains under the existing `<1000 ms` target.


### PR DESCRIPTION
## Summary
Follow-up to #2092 for the issues reproduced on the target Mac after `desktop-1.0.798` was installed.

### One-click updater / FCM-011
- Render real `download-progress.percent` as percentage text and a visible progress rail.
- Keep the updater control busy through downloading/staging instead of exposing a misleading second click.
- Attach to the real `update-downloaded` event before starting the download, then transition to staging and schedule `quitAndInstall(false, true)` automatically.
- Enable `autoInstallOnAppQuit` as a fallback.
- Tighten macOS release updater E2E: downloading must expose progress UI and the old app must close automatically after the single click.
- Preserve #2092's startup/focus/throttled foreground re-check and desktop-only GitHub Latest policy.

### ChatGPT-style nonblocking startup / TFI M3-DESKTOP-002
- `正在恢复你的工作空间` was an account/auth wait screen, not a real workspace restore.
- Paint the normal Messenger shell/projection first while auth/Host readiness resolves in the background.
- A transient auth transport error now retries without forcing a signed-out remount; only explicit `loggedIn=false` routes to login.
- Resolve auth before expensive conversation/connector/skills/agents/settings hydration and use accurate account-verification copy.

### Background energy / MSR-106
- #2092 already removes the 1 ms Feature Host busy poll via bounded long-polling.
- Target-Mac packaged `1.0.798` still showed about 60.9% CPU in the Fabushi GPU process and 22.5% in renderer when Fabushi was merely unfocused.
- Suspend the shared BotMark JS animation clock and CSS motion when the document is hidden/unfocused; resume on focus.
- Cap focused organic BotMark motion dispatch to 30 FPS while preserving reduced-motion/per-mark pause behavior.

### Release integrity follow-up
- Validate generated updater metadata references real release asset names.
- Prevent SHA256SUMS from hashing itself and verify rollback artifacts by content digest.
- Stabilize Windows/Linux artifact naming used by updater metadata.

## Reference
The installed ChatGPT macOS app was inspected as the user-requested UX benchmark: normal shell first and Sparkle automatic update checks/updates enabled. Fabushi keeps its own Electron/Rust implementation and `electron-updater`; no proprietary ChatGPT code is copied.

## Local lightweight verification
- `node --check` Electron/update automation files — pass
- `node --test desktop/electron/native-capability-handlers.test.cjs desktop/electron/host-process.test.cjs` — 13/13 pass
- BotMark low-power motion contract — pass
- desktop architecture contract — pass
- Electron Feature Host bridge contract — pass
- changed workflow YAML parse — pass
- `git diff --check` — pass

## Completion gate
Do not mark complete until required CI + protected merge queue pass, exact-main packaged desktop/native E2E publishes a newer signed/notarized Release, the updater-specific old-client regression proves visible progress + one-click install/relaunch, startup no longer shows the misleading restore screen, and target-Mac background CPU is re-measured near idle.