### PR TITLE
fix(release): make updater metadata parser shell-safe

### DIFF
--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -234,7 +234,7 @@ jobs:
                 echo "$metadata references missing release asset: $referenced" >&2
                 exit 1
               fi
-            done < <(awk '$1 == "-" && $2 == "url:" { value=$3; gsub(/^['\"']|['\"']$/, "", value); print value }' "release-assets/$metadata")
+            done < <(awk '$1 == "-" && $2 == "url:" { print $3 }' "release-assets/$metadata" | tr -d "\"'")
           done
 
           # Write outside release-assets first. Creating the destination in-place before

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -69,3 +69,7 @@ This task now treats the old-client updater journey as required because FCM-011 
 ## 2026-08-24 PR #2093 Round 1 CI sparse-checkout blocker
 
 PR #2093 exact-head CI correctly failed the `Electron Feature Host contract` before product tests because `assert-fabushi-desktop-architecture.py` now validates updater artifact naming in `desktop/package.json`, but that job's sparse checkout did not include the file. The repair adds only `desktop/package.json` to the existing contract job checkout; no validation is weakened or skipped.
+
+## 2026-08-24 post-main metadata parser quote repair
+
+After #2093 merged, comparison against the parallel #2094 branch found one valid unique delta: the updater metadata asset-name parser embedded a single quote inside a shell single-quoted awk program. Preserve the #2093 startup/updater/energy behavior and replace only that parser with `awk ... | tr -d` so the canonical post-main Bash step is syntactically safe. #2094 otherwise reverts the user-requested nonblocking startup and must not be merged wholesale.


### PR DESCRIPTION
## Summary
- preserve all user-requested startup/updater/energy fixes already merged in #2093
- extract the one valid unique delta found in parallel #2094
- replace a single-quote-containing awk regexp inside the shell single-quoted awk program with `awk ... | tr -d`, avoiding a deterministic Bash quoting failure in canonical post-main Release validation
- record why #2094 must not be merged wholesale: against current main it primarily reverts the nonblocking startup work

## Verification
- workflow YAML parse: pass
- corrected shell fragment `bash -n`: pass
- corrected fragment parses a quoted `url:` value to `foo.zip`: pass
- `git diff --check`: pass

## Governance
FCM-011 remains in progress. This is a narrow Release-pipeline correctness follow-up needed before exact-main updater publication can be accepted.