### PR TITLE
fix(release): advance canonical desktop Latest

### DIFF
--- a/.github/workflows/delivery-governance-contract.yml
+++ b/.github/workflows/delivery-governance-contract.yml
@@ -9,6 +9,7 @@ on:
       - '.github/scripts/require-release-source-gates.sh'
       - '.github/workflows/apple-store-delivery.yml'
       - '.github/workflows/google-play-delivery.yml'
+      - '.github/workflows/post-main-delivery.yml'
       - '.github/workflows/native-electron-release.yml'
       - '.github/workflows/global-dharma-rust.yml'
       - '.github/workflows/important-release-gate.yml'
@@ -23,6 +24,7 @@ on:
       - '.github/scripts/require-release-source-gates.sh'
       - '.github/workflows/apple-store-delivery.yml'
       - '.github/workflows/google-play-delivery.yml'
+      - '.github/workflows/post-main-delivery.yml'
       - '.github/workflows/native-electron-release.yml'
       - '.github/workflows/global-dharma-rust.yml'
       - '.github/workflows/important-release-gate.yml'
@@ -51,6 +53,7 @@ jobs:
             /.github/scripts/require-release-source-gates.sh
             /.github/workflows/apple-store-delivery.yml
             /.github/workflows/google-play-delivery.yml
+            /.github/workflows/post-main-delivery.yml
             /.github/workflows/native-electron-release.yml
             /.github/workflows/global-dharma-rust.yml
             /.github/workflows/important-release-gate.yml

--- a/.github/workflows/delivery-governance-contract.yml
+++ b/.github/workflows/delivery-governance-contract.yml
@@ -77,6 +77,12 @@ jobs:
 
           grep -Fq 'RELEASE_TARGET: android' .github/workflows/google-play-delivery.yml
           grep -Fq 'RELEASE_TARGET: ${{ inputs.target }}' .github/workflows/apple-store-delivery.yml
+
+          post_main=.github/workflows/post-main-delivery.yml
+          grep -Fq 'test("^desktop-[0-9]+[.][0-9]+[.][0-9]+$")' "$post_main"
+          grep -Fq 'releases/latest' "$post_main"
+          grep -Fq 'make_latest=true' "$post_main"
+          grep -Fq 'GitHub Latest pointer did not advance' "$post_main"
           for workflow in \
             .github/workflows/native-electron-release.yml \
             .github/workflows/global-dharma-rust.yml \

--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -262,11 +262,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="desktop-$VERSION"
-          highest_version="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isDraft,isPrerelease --jq '.[] | select(.isDraft == false and .isPrerelease == false and (.tagName | startswith("desktop-"))) | .tagName' | sed 's/^desktop-//' | sort -V | tail -1)"
+          # Only canonical desktop-X.Y.Z releases participate in updater ordering.
+          # Legacy desktop-v1.0.1-* tags sort after numeric SemVer under sort -V and
+          # previously caused every new desktop Release to be published with make_latest=false.
+          highest_version="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isDraft,isPrerelease --jq '.[] | select(.isDraft == false and .isPrerelease == false and (.tagName | test("^desktop-[0-9]+[.][0-9]+[.][0-9]+$"))) | .tagName' | sed 's/^desktop-//' | sort -V | tail -1)"
           make_latest=true
           if [ -n "$highest_version" ]; then
             newest="$(printf '%s\n%s\n' "$highest_version" "$VERSION" | sort -V | tail -1)"
-            if [ "$newest" != "$VERSION" ] || [ "$highest_version" = "$VERSION" ]; then
+            if [ "$newest" != "$VERSION" ]; then
               make_latest=false
             fi
           fi
@@ -292,6 +295,14 @@ jobs:
             test "$existing_target" = "$SOURCE_SHA"
             if [ "$existing_draft" != true ]; then
               echo "Release $tag is already published for $SOURCE_SHA; refusing to mutate published assets."
+              if [ "$make_latest" = true ]; then
+                gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" -f make_latest=true >/dev/null
+                latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')"
+                if [ "$latest_tag" != "$tag" ]; then
+                  echo "GitHub Latest pointer did not advance to $tag; observed $latest_tag" >&2
+                  exit 1
+                fi
+              fi
               echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -317,6 +328,18 @@ jobs:
           test "$(jq -r '.prerelease' <<<"$published")" = false
           test "$(jq -r '.tag_name' <<<"$published")" = "$tag"
           test "$(jq -r '.target_commitish' <<<"$published")" = "$SOURCE_SHA"
+          if [ "$make_latest" = true ]; then
+            release_id="$(jq -r '.id' <<<"$published")"
+            # GitHub exposes make_latest directly on the Release REST API. Patch and
+            # read it back instead of trusting the CLI flag silently. electron-updater
+            # follows /releases/latest, so a stale pointer is a delivery failure.
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" -f make_latest=true >/dev/null
+            latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')"
+            if [ "$latest_tag" != "$tag" ]; then
+              echo "GitHub Latest pointer did not advance to $tag; observed $latest_tag" >&2
+              exit 1
+            fi
+          fi
           echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
           {
             echo '## Published Release'

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -169,3 +169,10 @@
 
 - Exact-head CI surfaced a deterministic sparse-checkout defect: the desktop architecture guard reads `desktop/package.json`, but the Electron Feature Host contract job had not checked that file out.
 - Added the package manifest to that job's sparse inputs; the guard remains strict.
+
+## 2026-08-24 — FCM-011 Round 4 — GitHub Latest pointer regression
+
+- `desktop-1.0.806` / `.807` / `.808` all published successfully, but GitHub Latest remained `.798`; all newer Release bodies recorded `make_latest=false`.
+- Root cause: the ordering query accepted legacy `desktop-v1.0.1-*` tags, whose post-prefix `v...` values outrank numeric SemVer under the existing `sort -V` comparison.
+- Repair narrows ordering to strict `desktop-X.Y.Z`, allows equal-highest retries to re-promote, explicitly PATCHes `make_latest=true`, and fails delivery unless `/releases/latest` reads back the expected tag.
+- FCM-011 remains in progress pending fixed Release + live old-to-new updater proof.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -93,3 +93,10 @@
 - Changed install coordination to wait for the real `update-downloaded` event before staging and `quitAndInstall`.
 - Kept renderer busy through the transaction and added `autoInstallOnAppQuit` fallback.
 - Strengthened macOS updater E2E to reject missing progress or a required second click.
+
+## 2026-08-24 — FCM-011 strict desktop Latest ordering
+
+- Excluded legacy `desktop-v*` tags from canonical desktop updater ordering.
+- Made same-version exact-SHA retries eligible to repair the Latest pointer.
+- Added explicit GitHub Release `make_latest=true` PATCH plus `/releases/latest` readback gate.
+- Added delivery governance contract coverage for the Latest-pointer invariant.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -73,3 +73,20 @@ PR #2093 exact-head CI correctly failed the `Electron Feature Host contract` bef
 ## 2026-08-24 post-main metadata parser quote repair
 
 After #2093 merged, comparison against the parallel #2094 branch found one valid unique delta: the updater metadata asset-name parser embedded a single quote inside a shell single-quoted awk program. Preserve the #2093 startup/updater/energy behavior and replace only that parser with `awk ... | tr -d` so the canonical post-main Bash step is syntactically safe. #2094 otherwise reverts the user-requested nonblocking startup and must not be merged wholesale.
+
+## 2026-08-24 Round 4 — GitHub Latest pointer ordering defect
+
+After `desktop-1.0.806`, `desktop-1.0.807`, and `desktop-1.0.808` all passed exact-main package/E2E and were published, GitHub `/releases/latest` still returned `desktop-1.0.798`. Release bodies proved all three newer releases had `Publication ordering: make_latest=false`.
+
+Root cause is deterministic: the ordering query accepted every tag beginning with `desktop-`, including historical tags such as `desktop-v1.0.1-1250-...`. After stripping only `desktop-`, GNU `sort -V` can rank the legacy `v...` strings after numeric `1.0.808`, so the guard incorrectly classified every modern Release as older.
+
+Repair:
+
+1. Only strict canonical tags matching `^desktop-[0-9]+[.][0-9]+[.][0-9]+$` participate in updater ordering.
+2. Equality with the currently highest version remains eligible for `make_latest=true`; this lets duplicate/retried exact-SHA delivery runs repair a stale Latest pointer without mutating assets.
+3. When a Release should be latest, explicitly PATCH the GitHub Release REST field `make_latest=true` after creation (or on an existing immutable Release), then read `/releases/latest` back and require its tag to equal the expected desktop tag.
+4. Delivery governance now statically requires the strict tag filter, explicit latest promotion, and readback failure message.
+
+Open-source/official reference: GitHub Release REST documents `make_latest` as `true|false|legacy`; GitHub CLI documents `--latest`, but Fabushi now verifies the authoritative REST readback instead of trusting a fire-and-forget flag.
+
+Acceptance is not complete until a newer fixed Release becomes `/releases/latest`, a running fixed client discovers the following Release without restart, and one-click progress/install/relaunch is proven on the target Mac.


### PR DESCRIPTION
## Summary
- fix the deterministic GitHub Latest-pointer bug that left `/releases/latest` pinned to `desktop-1.0.798` even after `desktop-1.0.806`, `.807`, and `.808` were published
- only strict canonical `desktop-X.Y.Z` tags participate in desktop updater ordering; legacy `desktop-v1.0.1-*` tags no longer poison GNU `sort -V` ordering
- allow an exact same-version retry to repair a stale Latest pointer without mutating immutable assets
- explicitly PATCH the GitHub Release REST field `make_latest=true` when the release should be Latest, then read `/releases/latest` back and fail delivery if it is not the expected tag
- extend delivery governance contract coverage for the strict desktop-tag filter and Latest readback invariant
- record FCM-011 Round 4 diagnosis and acceptance state

## Reproduced evidence
- `desktop-1.0.806`, `.807`, `.808` all published successfully
- every newer Release body recorded `Publication ordering: make_latest=false`
- public GitHub `/releases/latest` still returned `desktop-1.0.798`
- historical `desktop-v1.0.1-*` tags were included by the old `startsWith("desktop-")` filter and can rank after numeric SemVer once the prefix is stripped

## Local verification
- strict filter smoke over mixed legacy/current tags selects `1.0.808`
- both changed workflow YAML files parse successfully
- required release-governance markers present
- `git diff --check` passes

## Completion gate
FCM-011 remains in progress until this goes through protected CI/merge queue, the resulting exact-main Release becomes `/releases/latest`, and a running fixed Mac client proves no-restart discovery plus visible progress and one-click install/relaunch.