### PR TITLE
fix(messaging): paint complete contact rail immediately

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -185,6 +185,13 @@ test('Telegram-inspired settings bind supported preferences and persist fast-sta
     await completeBrowserLogin(page);
     await openMessenger(page);
 
+    const cachedLegacyPeer = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+    await expect(cachedLegacyPeer).toBeVisible();
+    await expect.poll(async () => page.evaluate(() => {
+      const projection = JSON.parse(localStorage.getItem('fabushi.desktop.messenger-projection.v1') || 'null');
+      return Boolean(projection?.legacyConversations?.some((item: { id?: string }) => item.id === 'codex:agent:assistant'));
+    }), { timeout: 5_000 }).toBe(true);
+
     await page.getByTestId('profile-navigation-trigger').click();
     await page.getByTitle('设置', { exact: true }).click();
     await expect(page.getByTestId('telegram-settings-navigation')).toBeVisible();
@@ -224,6 +231,7 @@ test('Telegram-inspired settings bind supported preferences and persist fast-sta
     await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId('messenger-workspace')).toHaveAttribute('data-testid-ready-projection', 'true');
     await expect(page.getByText('本地优先投影验收').first()).toBeVisible();
+    await expect(page.getByTestId('peer-legacy:conversation:codex:agent:assistant')).toBeVisible();
   } finally {
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -161,6 +161,11 @@ type MessengerProjection = {
   actorId?: string;
   cursor?: string | null;
   activePeerKey?: string | null;
+  // The complete lightweight left-rail model is persisted for first-frame paint.
+  // Rust/Host remains authoritative and reconciles these display-only summaries in background.
+  legacyConversations?: ConversationSummary[];
+  legacyBots?: BotSummary[];
+  legacyGroups?: GroupSummary[];
   selfActors: MessagingActor[];
   selfConversations: MessagingConversation[];
   selfMessages: Record<string, MessagingMessage[]>;
@@ -205,6 +210,9 @@ function asMessengerProjection(value: unknown): MessengerProjection | null {
   const parsed = value as Partial<MessengerProjection>;
   if (parsed.version !== 1 || !Array.isArray(parsed.selfConversations) || !Array.isArray(parsed.selfActors)) return null;
   if (!parsed.selfMessages || typeof parsed.selfMessages !== 'object' || Array.isArray(parsed.selfMessages)) return null;
+  if (parsed.legacyConversations !== undefined && !Array.isArray(parsed.legacyConversations)) return null;
+  if (parsed.legacyBots !== undefined && !Array.isArray(parsed.legacyBots)) return null;
+  if (parsed.legacyGroups !== undefined && !Array.isArray(parsed.legacyGroups)) return null;
   return parsed as MessengerProjection;
 }
 
@@ -509,9 +517,9 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
   const selfHosted = useMemo(() => new SelfHostedMessagingClientV2(transport, { actorId: startupProjection?.actorId }), [transport, startupProjection]);
   const [hostReady, setHostReady] = useState(false);
   const [section, setSection] = useState<MessengerSection>('chats');
-  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
-  const [bots, setBots] = useState<BotSummary[]>([]);
-  const [groups, setGroups] = useState<GroupSummary[]>([]);
+  const [conversations, setConversations] = useState<ConversationSummary[]>(startupProjection?.legacyConversations ?? []);
+  const [bots, setBots] = useState<BotSummary[]>(startupProjection?.legacyBots ?? []);
+  const [groups, setGroups] = useState<GroupSummary[]>(startupProjection?.legacyGroups ?? []);
   const [selfActors, setSelfActors] = useState<MessagingActor[]>(startupProjection?.selfActors ?? []);
   const [selfConversations, setSelfConversations] = useState<MessagingConversation[]>(startupProjection?.selfConversations ?? []);
   const [selfMessages, setSelfMessages] = useState<Record<string, MessagingMessage[]>>(startupProjection?.selfMessages ?? {});
@@ -609,7 +617,7 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
   }, [startupProjection]);
 
   useEffect(() => {
-    if (!selfConversations.length && !selfActors.length) return;
+    if (!selfConversations.length && !selfActors.length && !conversations.length && !bots.length && !groups.length) return;
     const timer = window.setTimeout(() => {
       const conversationIds = new Set(
         [...selfConversations]
@@ -628,6 +636,9 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
         actorId: selfHosted.actorId,
         cursor: messagingCursorRef.current,
         activePeerKey,
+        legacyConversations: conversations,
+        legacyBots: bots,
+        legacyGroups: groups,
         selfActors,
         selfConversations: [...selfConversations]
           .sort((left, right) => right.updatedAtMs - left.updatedAtMs)
@@ -636,7 +647,7 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
       });
     }, 60);
     return () => window.clearTimeout(timer);
-  }, [activePeerKey, selfActors, selfConversations, selfMessages, selfHosted.actorId]);
+  }, [activePeerKey, bots, conversations, groups, selfActors, selfConversations, selfMessages, selfHosted.actorId]);
 
   function updateDesktopPreference<K extends keyof DesktopMessengerPreferences>(key: K, value: DesktopMessengerPreferences[K]) {
     setDesktopPreferences((current) => ({ ...current, [key]: value }));

--- a/native/mahayana-messaging/src/service.rs
+++ b/native/mahayana-messaging/src/service.rs
@@ -780,16 +780,19 @@ impl<S: MessagingStateStore> MessagingService<S> {
             cursor: Some(self.cursor.to_string()),
             server_time_ms,
             event: ServerEvent::SyncBatch {
+                // Actor/conversation metadata is the lightweight navigation index and must
+                // be complete in a snapshot. Applying the message/event limit here used to
+                // return only the first N contacts/conversations and then advance next_cursor
+                // to the current journal position, so the omitted rows could never arrive via
+                // later delta sync. Keep heavy collections bounded below, not the left-rail index.
                 actors: visible_actor_ids
                     .iter()
                     .filter_map(|id| state.actors.get(id))
-                    .take(max_items)
                     .cloned()
                     .collect(),
                 conversations: visible_conversation_ids
                     .iter()
                     .filter_map(|id| state.conversations.get(id))
-                    .take(max_items)
                     .map(|conversation| {
                         self.project_conversation_for_actor(actor_id, conversation, server_time_ms)
                     })

--- a/native/mahayana-messaging/tests/delta_sync_contract.rs
+++ b/native/mahayana-messaging/tests/delta_sync_contract.rs
@@ -159,6 +159,93 @@ fn remove_db(path: &PathBuf) {
 }
 
 #[test]
+fn initial_snapshot_limit_keeps_complete_navigation_metadata() {
+    let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
+    setup_direct_conversation(&mut service);
+
+    service
+        .handle(
+            envelope(
+                "human:carol",
+                "actor:carol",
+                ClientCommand::UpsertProfile {
+                    actor: Actor::human("human:carol", "Carol"),
+                },
+            ),
+            14,
+        )
+        .expect("upsert carol");
+    service
+        .handle(
+            envelope(
+                "human:alice",
+                "conversation:second",
+                ClientCommand::CreateConversation {
+                    conversation: Conversation::direct(
+                        "chat:second",
+                        "Alice and Carol",
+                        vec![
+                            participant("human:alice", ParticipantRole::Owner),
+                            participant("human:carol", ParticipantRole::Member),
+                        ],
+                        15,
+                    ),
+                },
+            ),
+            15,
+        )
+        .expect("create second conversation");
+
+    for (request_id, client_id, text, now) in [
+        ("send:snapshot:one", "client:snapshot:one", "one", 20),
+        ("send:snapshot:two", "client:snapshot:two", "two", 21),
+    ] {
+        service
+            .handle(
+                envelope("human:alice", request_id, send_text(client_id, text)),
+                now,
+            )
+            .expect("seed snapshot message");
+    }
+
+    let events = service
+        .handle(
+            envelope(
+                "human:alice",
+                "sync:small-snapshot",
+                ClientCommand::Sync {
+                    cursor: None,
+                    limit: 1,
+                },
+            ),
+            30,
+        )
+        .expect("initial snapshot");
+
+    let (actors, conversations, messages) = events
+        .iter()
+        .find_map(|envelope| match &envelope.event {
+            ServerEvent::SyncBatch {
+                actors,
+                conversations,
+                messages,
+                ..
+            } => Some((actors, conversations, messages)),
+            _ => None,
+        })
+        .expect("sync batch");
+
+    assert_eq!(conversations.len(), 2, "all visible conversation summaries must be present");
+    assert!(conversations.iter().any(|item| item.id == ConversationId::new("chat:direct")));
+    assert!(conversations.iter().any(|item| item.id == ConversationId::new("chat:second")));
+    assert_eq!(actors.len(), 3, "all actors visible through those conversations must be present");
+    assert!(actors.iter().any(|item| item.id == ActorId::new("human:alice")));
+    assert!(actors.iter().any(|item| item.id == ActorId::new("human:bob")));
+    assert!(actors.iter().any(|item| item.id == ActorId::new("human:carol")));
+    assert_eq!(messages.len(), 1, "heavy message payload must still honor the requested limit");
+}
+
+#[test]
 fn send_message_is_idempotent_and_server_acknowledged() {
     let mut service = MessagingService::load(MemoryStateStore::default()).expect("load service");
     setup_direct_conversation(&mut service);

--- a/native/mahayana-messaging/tests/delta_sync_contract.rs
+++ b/native/mahayana-messaging/tests/delta_sync_contract.rs
@@ -235,14 +235,36 @@ fn initial_snapshot_limit_keeps_complete_navigation_metadata() {
         })
         .expect("sync batch");
 
-    assert_eq!(conversations.len(), 2, "all visible conversation summaries must be present");
-    assert!(conversations.iter().any(|item| item.id == ConversationId::new("chat:direct")));
-    assert!(conversations.iter().any(|item| item.id == ConversationId::new("chat:second")));
-    assert_eq!(actors.len(), 3, "all actors visible through those conversations must be present");
-    assert!(actors.iter().any(|item| item.id == ActorId::new("human:alice")));
-    assert!(actors.iter().any(|item| item.id == ActorId::new("human:bob")));
-    assert!(actors.iter().any(|item| item.id == ActorId::new("human:carol")));
-    assert_eq!(messages.len(), 1, "heavy message payload must still honor the requested limit");
+    assert_eq!(
+        conversations.len(),
+        2,
+        "all visible conversation summaries must be present"
+    );
+    assert!(conversations
+        .iter()
+        .any(|item| item.id == ConversationId::new("chat:direct")));
+    assert!(conversations
+        .iter()
+        .any(|item| item.id == ConversationId::new("chat:second")));
+    assert_eq!(
+        actors.len(),
+        3,
+        "all actors visible through those conversations must be present"
+    );
+    assert!(actors
+        .iter()
+        .any(|item| item.id == ActorId::new("human:alice")));
+    assert!(actors
+        .iter()
+        .any(|item| item.id == ActorId::new("human:bob")));
+    assert!(actors
+        .iter()
+        .any(|item| item.id == ActorId::new("human:carol")));
+    assert_eq!(
+        messages.len(),
+        1,
+        "heavy message payload must still honor the requested limit"
+    );
 }
 
 #[test]

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -136,3 +136,11 @@
 - Fabushi now keeps the normal Messenger shell/projection visible while auth is unknown or transport retries; only an explicit `loggedIn=false` result routes to login.
 - HostClient resolves auth before expensive conversation/connector/agent/settings hydration, and the fallback copy is renamed to accurate account verification.
 - Acceptance remains pending protected merge plus exact-main packaged startup measurement and Release validation.
+
+## 2026-08-24 — M3-DESKTOP-002 complete-contact first frame
+
+- Target Mac reproduced left-rail staged appearance: a few rows rendered immediately, remaining contacts/conversations appeared seconds later.
+- Root causes: legacy peer summaries were omitted from the durable renderer projection, and self-hosted `Sync { cursor: None, limit: 20 }` incorrectly truncated actor/conversation metadata while still advancing the journal cursor.
+- Follow-up persists legacy conversation/Bot/group summaries for instant returning-user paint and makes initial Rust snapshot metadata complete while preserving bounded message payloads.
+- New Rust contract uses `limit=1` to prove complete visible actors/conversations + one bounded message; Messenger E2E requires the legacy assistant peer to be persisted and restored.
+- Status remains `TESTING` pending PR/main/package/target-Mac proof.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -129,3 +129,9 @@
 - Removed misleading full-screen workspace-restore semantics from returning-user startup.
 - Added normal-shell bootstrap while local projection/auth is unresolved.
 - Transient auth transport failures no longer force a signed-out remount; explicit signed-out state still does.
+
+## 2026-08-24 — complete local-first contact/conversation rail
+
+- Persisted legacy conversation/Bot/group summaries in the Messenger fast-start projection.
+- Removed snapshot `limit` truncation from visible actor and conversation metadata; heavy message payload remains limited.
+- Added protocol and packaged-Messenger regression coverage for complete first-frame navigation data.

--- a/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M3-DESKTOP-002-local-first-settings.md
@@ -125,3 +125,16 @@ The installed ChatGPT desktop app on the same Mac was inspected as the user-requ
 - returning-user synchronization remains background reconciliation against canonical Rust/Host state.
 
 Acceptance for this continuation: a returning signed-in packaged client must never show `正在恢复你的工作空间`; transient auth/Host startup failure must not evict a valid cached Messenger; an explicitly signed-out client still reaches the login surface; exact-main packaged startup E2E remains under the existing `<1000 ms` target.
+
+## 2026-08-24 complete-contact first-frame continuation
+
+Target-Mac validation found another local-first defect: the left rail could paint only a few rows and then add the remaining contacts/conversations several seconds later. Source tracing identified two independent causes. First, the renderer projection persisted only self-hosted conversations/messages; legacy `conversation.list` / `bot.list` / `group.list` state always started empty and waited for Electron -> Rust Host initialization. Second, an initial self-hosted snapshot with `limit=20` applied that limit to actors and conversations as well as messages, then advanced `next_cursor` to the current journal cursor; rows after the first 20 had no later pagination path because background sync is cursor-delta-only.
+
+Repair contract:
+
+- the fast-start projection now persists the complete lightweight legacy conversation/Bot/group summaries so returning users paint the whole known left rail on the first frame;
+- Rust initial snapshot sync returns all visible actor + conversation metadata regardless of the heavy payload limit, while messages and other heavy collections remain bounded;
+- delta cursor behavior is unchanged; Rust remains authoritative and renderer projection is still display-only;
+- protocol coverage proves `limit=1` still returns every visible actor/conversation but only one message; packaged Messenger coverage proves a legacy peer is present in the persisted projection and survives reload.
+
+Task remains `TESTING` until protected merge, exact-main package gates, target-Mac no-delay observation, and the Release/updater loop are all green.

--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -6440,10 +6440,7 @@ impl FeatureHostController {
     }
 
     #[cfg(feature = "production")]
-    fn receive_production(
-        &self,
-        timeout: Duration,
-    ) -> Result<Option<HostEvent>, FeatureHostError> {
+    fn receive_production(&self, timeout: Duration) -> Result<Option<HostEvent>, FeatureHostError> {
         for index in 0..16 {
             // Block only for the first runtime event. Once awakened, drain already-queued
             // events without adding latency between streamed events.


### PR DESCRIPTION
## Summary
- persist the complete lightweight legacy conversation / Bot / group summaries in the Messenger fast-start projection so returning users paint the whole known left rail on the first frame
- fix self-hosted initial snapshot semantics: actor + conversation navigation metadata is complete even when `Sync.limit` keeps messages/heavy collections bounded
- preserve cursor-delta behavior and Rust/Host authority; renderer projection remains display-only
- add a Rust regression proving `limit=1` returns all visible actors/conversations but only one message
- extend packaged Messenger coverage so a legacy peer is persisted and survives reload
- record the target-Mac staged-contact diagnosis under M3-DESKTOP-002

## Root cause
Two delays were stacked:
1. the durable renderer projection omitted legacy `conversation.list` / `bot.list` / `group.list` state, so those rows waited for Electron -> Rust Host cold start;
2. initial `Sync { cursor: None, limit: 20 }` truncated actors/conversations as well as messages, then advanced `next_cursor` to the current journal position. Rows after the first 20 had no later pagination path because background sync is cursor-delta-only.

## Verification
- `git diff --check` passes
- no local application build/test was run; repository policy keeps compile/package/E2E in GitHub Actions

## Completion gate
Keep M3-DESKTOP-002 in TESTING until required CI passes, protected merge completes, exact-main packaged artifacts publish, and the target Mac confirms no staged left-rail appearance after the new projection has been populated.