### PR TITLE
feat(gbf): begin Grok parity UI and Host lifecycle convergence

### DIFF
--- a/desktop/e2e/grok-parity.spec.ts
+++ b/desktop/e2e/grok-parity.spec.ts
@@ -1,0 +1,98 @@
+import { _electron as electron, expect, test, type Page } from '@playwright/test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
+
+async function launchDesktopApp(appDataDir: string) {
+  return electron.launch({
+    ...(packagedExecutable
+      ? { executablePath: packagedExecutable, args: [] }
+      : { args: [appRoot] }),
+    env: {
+      ...process.env,
+      FABUSHI_APP_DATA: appDataDir,
+      FABUSHI_FEATURE_HOST_MODE: process.env.FABUSHI_FEATURE_HOST_MODE || 'test',
+      MAHAYANA_APP_HOST_BIN: process.env.MAHAYANA_APP_HOST_BIN || '',
+    },
+  });
+}
+
+async function completeBrowserLogin(page: Page): Promise<void> {
+  while (await page.getByTestId('onboarding-gate').isVisible().catch(() => false)) {
+    await page.getByTestId('onboarding-next').click();
+  }
+  const loginGate = page.getByTestId('login-gate');
+  if (await loginGate.isVisible().catch(() => false)) {
+    await page.getByTestId('browser-login-start').click();
+    await expect(loginGate).toBeHidden();
+  }
+  await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
+}
+
+function rgbLuma(value: string): number {
+  const components = value.match(/[\d.]+/g)?.slice(0, 3).map(Number) ?? [];
+  if (components.length !== 3) return 255;
+  return components[0] * 0.2126 + components[1] * 0.7152 + components[2] * 0.0722;
+}
+
+test('desktop uses the Fabushi-owned Grok parity surface without a parallel Messenger', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-grok-parity-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+
+    await test.step('parity stylesheet and surface marker load before authentication', async () => {
+      await expect(page.locator('body')).toHaveAttribute('data-fabushi-surface', 'grok-parity-v1');
+      const parityLoaded = await page.evaluate(() => Array.from(document.styleSheets).some((sheet) =>
+        String(sheet.href ?? '').includes('grok-parity.css')));
+      expect(parityLoaded).toBe(true);
+      const bodyBackground = await page.locator('body').evaluate((element) => getComputedStyle(element).backgroundColor);
+      expect(rgbLuma(bodyBackground)).toBeLessThan(40);
+    });
+
+    await completeBrowserLogin(page);
+
+    await test.step('canonical Messenger remains the only product shell', async () => {
+      await expect(page.getByTestId('messenger-workspace')).toHaveCount(1);
+      await expect(page.locator('.desktop-mode-switch')).toHaveCount(0);
+      await expect(page.getByTestId('profile-navigation-trigger').locator('[data-engine="fabushi-motion-v2"]').first()).toBeVisible();
+    });
+
+    await test.step('conversation and composer expose dark low-contrast material', async () => {
+      const peer = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+      await expect(peer).toBeVisible();
+      await peer.click();
+      const input = page.getByTestId('messenger-input');
+      await expect(input).toBeVisible();
+
+      const material = await page.evaluate(() => {
+        const inputElement = document.querySelector('[data-testid="messenger-input"]');
+        const composer = inputElement?.parentElement;
+        const peerElement = document.querySelector('[data-testid="peer-legacy:conversation:codex:agent:assistant"]');
+        if (!composer || !peerElement) return null;
+        const composerStyle = getComputedStyle(composer);
+        const peerStyle = getComputedStyle(peerElement);
+        return {
+          composerBackground: composerStyle.backgroundColor,
+          composerRadius: composerStyle.borderRadius,
+          peerBackground: peerStyle.backgroundColor,
+          peerRadius: peerStyle.borderRadius,
+        };
+      });
+
+      expect(material).not.toBeNull();
+      expect(rgbLuma(material!.composerBackground)).toBeLessThan(70);
+      expect(parseFloat(material!.composerRadius)).toBeGreaterThanOrEqual(14);
+      expect(rgbLuma(material!.peerBackground)).toBeLessThan(80);
+      expect(parseFloat(material!.peerRadius)).toBeGreaterThanOrEqual(10);
+    });
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});

--- a/desktop/electron/host-process.cjs
+++ b/desktop/electron/host-process.cjs
@@ -1,5 +1,6 @@
 const { app } = require('electron');
 const { spawn } = require('node:child_process');
+const { EventEmitter } = require('node:events');
 const path = require('node:path');
 const readline = require('node:readline');
 
@@ -37,6 +38,10 @@ class MahayanaHostProcess {
     this.startedAt = null;
     this.lastExit = null;
     this.unexpectedExitCount = 0;
+    this.lifecycleSequence = 0;
+    this.lastLifecycleEvent = null;
+    this.events = new EventEmitter();
+    this.events.setMaxListeners(32);
   }
 
   executablePath() {
@@ -58,7 +63,32 @@ class MahayanaHostProcess {
       startedAt: this.startedAt,
       lastExit: this.lastExit ? { ...this.lastExit } : null,
       unexpectedExitCount: this.unexpectedExitCount,
+      lifecycleSequence: this.lifecycleSequence,
+      lastLifecycleEvent: this.lastLifecycleEvent ? { ...this.lastLifecycleEvent } : null,
     });
+  }
+
+  onLifecycle(listener) {
+    if (typeof listener !== 'function') throw new TypeError('Mahayana host lifecycle listener must be a function.');
+    this.events.on('lifecycle', listener);
+    return () => this.events.off('lifecycle', listener);
+  }
+
+  emitLifecycle(type, detail = {}) {
+    const event = Object.freeze({
+      type,
+      sequence: ++this.lifecycleSequence,
+      at: this.now(),
+      state: this.state,
+      generation: this.currentGeneration,
+      pid: this.child?.pid ?? null,
+      pending: this.pending.size,
+      unexpectedExitCount: this.unexpectedExitCount,
+      ...detail,
+    });
+    this.lastLifecycleEvent = event;
+    this.events.emit('lifecycle', event);
+    return event;
   }
 
   start() {
@@ -66,21 +96,35 @@ class MahayanaHostProcess {
     if (this.child) return this.child;
 
     const generation = this.currentGeneration + 1;
-    const child = this.spawn(this.executablePath(), [], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...this.env,
-        MAHAYANA_API_BASE_URL: productApiBaseUrl(this.app, this.env),
-        MAHAYANA_AUTH_STORAGE_NAMESPACE: this.env.MAHAYANA_AUTH_STORAGE_NAMESPACE || 'fabushi-desktop-v2',
-        FABUSHI_APP_DATA: this.app.getPath('userData'),
-      },
-      windowsHide: true,
-    });
-
     this.currentGeneration = generation;
+    this.state = 'starting';
+    this.emitLifecycle('starting');
+
+    let child;
+    try {
+      child = this.spawn(this.executablePath(), [], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...this.env,
+          MAHAYANA_API_BASE_URL: productApiBaseUrl(this.app, this.env),
+          MAHAYANA_AUTH_STORAGE_NAMESPACE: this.env.MAHAYANA_AUTH_STORAGE_NAMESPACE || 'fabushi-desktop-v2',
+          FABUSHI_APP_DATA: this.app.getPath('userData'),
+        },
+        windowsHide: true,
+      });
+    } catch (error) {
+      this.state = 'stopped';
+      this.startedAt = null;
+      this.unexpectedExitCount += 1;
+      this.lastExit = Object.freeze({ error: error instanceof Error ? error.message : String(error), at: this.now() });
+      this.emitLifecycle('spawn-failed', { error: this.lastExit.error });
+      throw error;
+    }
+
     this.child = child;
     this.state = 'running';
     this.startedAt = this.now();
+    this.emitLifecycle('running');
 
     const lines = this.readline.createInterface({ input: child.stdout });
     lines.on('line', (line) => {
@@ -89,6 +133,7 @@ class MahayanaHostProcess {
         message = JSON.parse(line);
       } catch (error) {
         this.rejectGeneration(generation, new Error(`Invalid Mahayana host response: ${error}`));
+        this.emitLifecycle('protocol-error', { error: error instanceof Error ? error.message : String(error) });
         return;
       }
       const key = String(message.id ?? '');
@@ -125,6 +170,7 @@ class MahayanaHostProcess {
         this.state = 'stopped';
         this.unexpectedExitCount += 1;
         this.lastExit = Object.freeze({ ...metadata, at: this.now() });
+        this.emitLifecycle('stopped', { ...metadata, recoverable: true });
       }
     }
     this.rejectGeneration(generation, error);
@@ -145,6 +191,7 @@ class MahayanaHostProcess {
         const pending = this.pending.get(key);
         if (!pending || pending.generation !== generation) return;
         this.pending.delete(key);
+        this.emitLifecycle('request-timeout', { method: String(method), requestId: id });
         reject(new Error(`Mahayana host request timed out: ${method}`));
       }, timeoutMs);
       timer.unref?.();
@@ -176,10 +223,11 @@ class MahayanaHostProcess {
     if (this.closed) throw new Error('Mahayana host is closed.');
     const child = this.child;
     const generation = this.currentGeneration;
+    this.state = 'restarting';
+    this.emitLifecycle('restarting', { reason: String(reason) });
     if (child) {
       this.child = null;
       this.startedAt = null;
-      this.state = 'stopped';
       this.rejectGeneration(generation, new Error(`Mahayana host restarted: ${reason}`));
       child.kill();
     }
@@ -195,7 +243,9 @@ class MahayanaHostProcess {
     this.child = null;
     this.startedAt = null;
     this.rejectGeneration(generation, new Error('Mahayana host closed.'));
+    this.emitLifecycle('closed');
     child?.kill();
+    this.events.removeAllListeners();
   }
 }
 

--- a/desktop/electron/host-process.test.cjs
+++ b/desktop/electron/host-process.test.cjs
@@ -105,7 +105,39 @@ test('host resolves structured requests and reports health for the active genera
   assert.equal(health.pid, 7000);
   assert.equal(health.pending, 0);
   assert.equal(health.unexpectedExitCount, 0);
+  assert.equal(health.lastLifecycleEvent.type, 'running');
   host.close();
+});
+
+test('lifecycle stream exposes start, crash recovery generation, restart, and terminal close', async () => {
+  const { host, children } = harness();
+  const events = [];
+  const unsubscribe = host.onLifecycle((event) => events.push(event));
+
+  const first = host.request('feature.receive', {});
+  assert.deepEqual(events.slice(0, 2).map((event) => event.type), ['starting', 'running']);
+  assert.equal(events[1].generation, 1);
+  children[0].emit('error', new Error('crash'));
+  await assert.rejects(first, /crash/);
+  assert.equal(events.at(-1).type, 'stopped');
+  assert.equal(events.at(-1).recoverable, true);
+
+  const second = host.request('feature.info', {});
+  assert.deepEqual(events.slice(-2).map((event) => event.type), ['starting', 'running']);
+  assert.equal(events.at(-1).generation, 2);
+  const request = children[1].requestAt();
+  children[1].respond(request.id, { ok: true });
+  await second;
+
+  host.restart('test restart');
+  assert.ok(events.some((event) => event.type === 'restarting' && event.reason === 'test restart'));
+  assert.equal(events.at(-1).type, 'running');
+  assert.equal(events.at(-1).generation, 3);
+
+  host.close();
+  assert.equal(events.at(-1).type, 'closed');
+  assert.equal(host.health().closed, true);
+  unsubscribe();
 });
 
 test('stale process termination cannot reject requests from a newer generation', async () => {

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+    <link rel="stylesheet" href="./grok-parity.css" />
     <title>全球法布施</title>
   </head>
-  <body>
+  <body data-fabushi-surface="grok-parity-v1">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/desktop/public/grok-parity.css
+++ b/desktop/public/grok-parity.css
@@ -1,0 +1,451 @@
+/*
+ * Fabushi Grok parity surface v1.
+ *
+ * This is a product-owned behavior/visual reimplementation layer. It intentionally
+ * keeps the existing Messenger component tree and runtime contracts intact while
+ * converging the visible desktop surface on one dark Fabushi/Grok material system.
+ */
+
+:root {
+  color-scheme: dark;
+  --gbf-app: #070707;
+  --gbf-panel: #101010;
+  --gbf-panel-raised: #171717;
+  --gbf-card: #1d1d1d;
+  --gbf-card-hover: #252525;
+  --gbf-card-active: #2c2c2c;
+  --gbf-inset: #0c0c0c;
+  --gbf-line: rgb(255 255 255 / 8%);
+  --gbf-line-strong: rgb(255 255 255 / 13%);
+  --gbf-text: #f7f7f5;
+  --gbf-muted: rgb(247 247 245 / 61%);
+  --gbf-faint: rgb(247 247 245 / 39%);
+  --gbf-accent: #1687ff;
+  --gbf-accent-soft: rgb(22 135 255 / 15%);
+  --gbf-success: #38d591;
+  --gbf-danger: #ff6174;
+  --gbf-shadow: 0 20px 70px rgb(0 0 0 / 42%);
+  --gbf-radius-xs: 8px;
+  --gbf-radius-sm: 10px;
+  --gbf-radius-md: 14px;
+  --gbf-radius-lg: 18px;
+}
+
+html,
+body[data-fabushi-surface="grok-parity-v1"],
+body[data-fabushi-surface="grok-parity-v1"] #root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--gbf-app);
+  color: var(--gbf-text);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] ::selection {
+  background: rgb(22 135 255 / 36%);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] button,
+body[data-fabushi-surface="grok-parity-v1"] input,
+body[data-fabushi-surface="grok-parity-v1"] textarea,
+body[data-fabushi-surface="grok-parity-v1"] select {
+  font: inherit;
+}
+
+/* Desktop/Messenger shell */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_desktopRoot_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messenger_"] {
+  background:
+    radial-gradient(circle at 48% -18%, rgb(70 51 113 / 17%), transparent 36%),
+    var(--gbf-app) !important;
+  color: var(--gbf-text) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messenger_"] {
+  --fabushi-panel-width: 286px;
+  border: 0 !important;
+}
+
+/* Conversation sidebar */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_chatList_"] {
+  background: rgb(16 16 16 / 96%) !important;
+  color: var(--gbf-text) !important;
+  border-right: 1px solid var(--gbf-line) !important;
+  backdrop-filter: blur(24px) saturate(118%);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_listHeader_"] {
+  min-height: 58px;
+  color: var(--gbf-text) !important;
+  border-color: var(--gbf-line) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_listHeader_"] strong {
+  color: var(--gbf-text) !important;
+  font-size: 15px !important;
+  font-weight: 650 !important;
+  letter-spacing: -0.01em;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_iconButton_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_listHeader_"] button,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_headerActions_"] button {
+  color: var(--gbf-muted) !important;
+  background: transparent !important;
+  border-radius: var(--gbf-radius-sm) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_iconButton_"]:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_listHeader_"] button:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_headerActions_"] button:hover {
+  background: var(--gbf-card-hover) !important;
+  color: var(--gbf-text) !important;
+}
+
+/* Search */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_searchBox_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceSearch_"] {
+  color: var(--gbf-muted) !important;
+  background: rgb(255 255 255 / 7%) !important;
+  border: 1px solid transparent !important;
+  border-radius: 11px !important;
+  box-shadow: none !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_searchBox_"]:focus-within,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceSearch_"]:focus-within {
+  background: rgb(255 255 255 / 9%) !important;
+  border-color: rgb(255 255 255 / 12%) !important;
+  box-shadow: 0 0 0 3px rgb(22 135 255 / 10%) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_searchBox_"] input,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceSearch_"] input,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_inChatSearch_"] input {
+  color: var(--gbf-text) !important;
+  caret-color: var(--gbf-accent);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] input::placeholder,
+body[data-fabushi-surface="grok-parity-v1"] textarea::placeholder {
+  color: var(--gbf-faint) !important;
+}
+
+/* Peer rows */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peer_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peerActive_"] {
+  min-height: 64px !important;
+  margin: 1px 6px !important;
+  width: calc(100% - 12px) !important;
+  border-radius: 12px !important;
+  color: var(--gbf-text) !important;
+  transition: background-color 120ms ease, transform 120ms ease;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peer_"]:hover {
+  background: rgb(255 255 255 / 5%) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peerActive_"] {
+  background: var(--gbf-card-active) !important;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 4%);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peerCopy_"] strong {
+  color: var(--gbf-text) !important;
+  font-weight: 610 !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peerCopy_"] small,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peerCopy_"] time,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peerMeta_"] {
+  color: var(--gbf-muted) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_peerMeta_"] b {
+  background: var(--gbf-accent) !important;
+  color: white !important;
+}
+
+/* Workspace */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_chatWorkspace_"] {
+  background:
+    radial-gradient(circle at 50% 0%, rgb(91 65 151 / 11%), transparent 38%),
+    #090909 !important;
+  color: var(--gbf-text) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_chatWorkspace_"]::before {
+  opacity: 0 !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_chatHeader_"] {
+  min-height: 62px !important;
+  background: rgb(9 9 9 / 84%) !important;
+  color: var(--gbf-text) !important;
+  border-bottom: 1px solid var(--gbf-line) !important;
+  backdrop-filter: blur(22px) saturate(120%);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_chatIdentity_"] strong {
+  color: var(--gbf-text) !important;
+  font-weight: 620 !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_chatIdentity_"] small {
+  color: var(--gbf-muted) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_inChatSearch_"] {
+  background: rgb(14 14 14 / 96%) !important;
+  color: var(--gbf-muted) !important;
+  border-bottom: 1px solid var(--gbf-line) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messageArea_"] {
+  padding-top: 24px !important;
+  gap: 8px !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_dayDivider_"] {
+  background: rgb(255 255 255 / 7%) !important;
+  color: var(--gbf-muted) !important;
+  border: 1px solid var(--gbf-line) !important;
+  backdrop-filter: blur(12px);
+}
+
+/* Message material: quieter than Telegram bubbles, closer to Grok conversation density. */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messageMine_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messagePeer_"] {
+  border-radius: 15px !important;
+  box-shadow: none !important;
+  color: var(--gbf-text) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messageMine_"] {
+  background: #303030 !important;
+  border-bottom-right-radius: 5px !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messagePeer_"] {
+  background: transparent !important;
+  border: 1px solid transparent !important;
+  padding-left: 0 !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messageMine_"] p,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messagePeer_"] p {
+  color: var(--gbf-text) !important;
+  line-height: 1.52 !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messageMine_"] small,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_messagePeer_"] small {
+  color: var(--gbf-faint) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_reactions_"] span {
+  color: #9fcaff !important;
+  background: var(--gbf-accent-soft) !important;
+  border: 1px solid rgb(22 135 255 / 16%);
+}
+
+/* Composer */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composer_"] {
+  min-height: 58px !important;
+  padding: 8px 9px !important;
+  background: #1b1b1b !important;
+  color: var(--gbf-text) !important;
+  border: 1px solid var(--gbf-line-strong) !important;
+  border-radius: 17px !important;
+  box-shadow: 0 18px 45px rgb(0 0 0 / 28%) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composer_"]:focus-within {
+  border-color: rgb(255 255 255 / 20%) !important;
+  box-shadow: 0 18px 50px rgb(0 0 0 / 34%), 0 0 0 3px rgb(22 135 255 / 7%) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composer_"] textarea {
+  color: var(--gbf-text) !important;
+  background: transparent !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composer_"] > button,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_attachmentAnchor_"] > button {
+  color: var(--gbf-muted) !important;
+  background: transparent !important;
+  border-radius: 10px !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composer_"] > button:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_attachmentAnchor_"] > button:hover {
+  color: var(--gbf-text) !important;
+  background: var(--gbf-card-hover) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composer_"] [class*="_sendButton_"] {
+  color: #111 !important;
+  background: #f4f4f2 !important;
+  border-radius: 11px !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composerBanner_"] {
+  background: #171717 !important;
+  color: #9fcaff !important;
+  border: 1px solid var(--gbf-line) !important;
+  border-left: 2px solid var(--gbf-accent) !important;
+  box-shadow: none !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_composerBanner_"] span {
+  color: var(--gbf-muted) !important;
+}
+
+/* Right context/info column */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_infoPanel_"] {
+  background: #0f0f0f !important;
+  color: var(--gbf-text) !important;
+  border-left: 1px solid var(--gbf-line) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_infoPanel_"] > header,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_profileCard_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_profileActions_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_infoTabs_"] {
+  border-color: var(--gbf-line) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_profileCard_"] small,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_infoContent_"] {
+  color: var(--gbf-muted) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_profileActions_"] button,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_profileCard_"] button,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_infoTabs_"] button {
+  color: var(--gbf-muted) !important;
+  background: transparent !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_profileActions_"] button:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_profileCard_"] button:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_infoTabs_"] button:hover {
+  color: var(--gbf-text) !important;
+  background: rgb(255 255 255 / 5%) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_infoTabs_"] button[data-active="true"] {
+  color: #a7d0ff !important;
+  border-bottom-color: var(--gbf-accent) !important;
+}
+
+/* Feature/search/settings/marketplace workspaces */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_featureWorkspace_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_settingsWorkspace_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_globalSearch_"] {
+  background: transparent !important;
+  color: var(--gbf-text) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_settingsNavigation_"] button,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_settingsRow_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceRow_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceCard_"] {
+  color: var(--gbf-text) !important;
+  background: transparent !important;
+  border-color: var(--gbf-line) !important;
+  border-radius: 12px !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_settingsNavigation_"] button:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_settingsNavigation_"] button[data-active="true"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceRow_"]:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceCard_"]:hover {
+  background: rgb(255 255 255 / 5%) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_settingsRow_"] small,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_settingsNavigation_"] small,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceCopy_"] small,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_marketplaceCopy_"] em {
+  color: var(--gbf-muted) !important;
+}
+
+/* Popovers / dialogs */
+body[data-fabushi-surface="grok-parity-v1"] [class*="_popover_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_contextMenu_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_dialog_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_Dialog_"],
+body[data-fabushi-surface="grok-parity-v1"] [class*="_communityDialog_"] {
+  color: var(--gbf-text) !important;
+  background: rgb(28 28 28 / 96%) !important;
+  border: 1px solid var(--gbf-line-strong) !important;
+  box-shadow: var(--gbf-shadow) !important;
+  backdrop-filter: blur(26px) saturate(120%);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_popover_"] button,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_contextMenu_"] button {
+  color: var(--gbf-text) !important;
+  background: transparent !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_popover_"] button:hover,
+body[data-fabushi-surface="grok-parity-v1"] [class*="_contextMenu_"] button:hover:not(:disabled) {
+  color: var(--gbf-text) !important;
+  background: rgb(255 255 255 / 7%) !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [class*="_backdrop_"] {
+  background: rgb(0 0 0 / 68%) !important;
+  backdrop-filter: blur(12px);
+}
+
+/* BotMark integration: preserve engine motion; visually seat it in the dark surface. */
+body[data-fabushi-surface="grok-parity-v1"] [data-engine="fabushi-motion-v2"] {
+  isolation: isolate;
+  filter: saturate(1.04) contrast(1.03);
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [data-engine="fabushi-motion-v2"][data-agent-state="thinking"],
+body[data-fabushi-surface="grok-parity-v1"] [data-engine="fabushi-motion-v2"][data-agent-state="working"],
+body[data-fabushi-surface="grok-parity-v1"] [data-engine="fabushi-motion-v2"][data-agent-state="tool-running"] {
+  filter: saturate(1.13) contrast(1.04) drop-shadow(0 8px 18px rgb(22 135 255 / 14%));
+}
+
+body[data-fabushi-surface="grok-parity-v1"] [data-engine="fabushi-motion-v2"][data-agent-state="error"],
+body[data-fabushi-surface="grok-parity-v1"] [data-engine="fabushi-motion-v2"][data-agent-state="alerting"] {
+  filter: saturate(1.13) contrast(1.05) drop-shadow(0 8px 18px rgb(255 97 116 / 13%));
+}
+
+/* Scrollbars */
+body[data-fabushi-surface="grok-parity-v1"] * {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(255 255 255 / 16%) transparent;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] *::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+body[data-fabushi-surface="grok-parity-v1"] *::-webkit-scrollbar-thumb {
+  background: rgb(255 255 255 / 14%);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-fabushi-surface="grok-parity-v1"] [class*="_peer_"],
+  body[data-fabushi-surface="grok-parity-v1"] [class*="_peerActive_"] {
+    transition: none !important;
+  }
+}

--- a/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
@@ -17,12 +17,12 @@
 | GBF-205 | M2 | 收敛 native/edge IPC | GBF-202 | schema/error contract 唯一 | schema/version/sender tests | evidence/GBF-205 | RELEASED | none | GBF-301 runtime convergence |
 | GBF-206 | M2 | 评估并迁移 Offline ASR | GBF-104 | 产品归属、资源/性能证据清晰 | unit + CI contract | evidence/GBF-206 | RELEASED | none | GBF-604 perf closure |
 | GBF-207 | M2 | 迁移有效 Electron E2E | GBF-201..206 | 当前 main 架构可运行 | Host smoke + macOS/Windows/Linux packaged E2E | evidence/GBF-207 | RELEASED | none | GBF-801 final RC |
-| GBF-301 | M3 | 盘点 coordinator/supervisor/host 行为 | GBF-103,104 | 重复执行链全部识别 | architecture walk + call graph | evidence/GBF-301 | TESTED | GitHub CI/merge pending | PR #2007 + Mahayana/CI gates |
-| GBF-302 | M3 | 统一 Agent loop 到 Mahayana | GBF-301 | 唯一正式 agent runtime | integration/call-path tests | evidence/GBF-302 | TESTED | GitHub CI/merge pending | PR #2007 + Mahayana/CI gates |
-| GBF-303 | M3 | 统一 tool/MCP/extension dispatch | GBF-302 | 同一 policy/result contract | contract + integration tests | evidence/GBF-303 | TESTED | GitHub CI/merge pending | PR #2007 + Mahayana/CI gates |
-| GBF-304 | M3 | 统一 session/checkpoint/resume/cancel | GBF-302 | crash/resume/cancel 语义唯一 | fault/recovery integration | evidence/GBF-304 | TESTED | GitHub CI/merge pending | PR #2007 + Mahayana/CI gates |
-| GBF-305 | M3 | 统一 local exec | GBF-303 | 无绕过 capability gate 的执行口 | deny-path + code-path audit | evidence/GBF-305 | TESTED | GitHub CI/merge pending | PR #2007 + Mahayana/CI gates |
-| GBF-306 | M3 | 统一错误/重试/超时/并发 | GBF-303..305 | 行为确定且可取消 | deterministic integration suite | evidence/GBF-306 | TESTED | GitHub CI/merge pending | PR #2007 + Mahayana/CI gates |
+| GBF-301 | M3 | 盘点 coordinator/supervisor/host 行为 | GBF-103,104 | 重复执行链全部识别 | architecture walk + call graph | evidence/GBF-301 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
+| GBF-302 | M3 | 统一 Agent loop 到 Mahayana | GBF-301 | 唯一正式 agent runtime | integration/call-path tests | evidence/GBF-302 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
+| GBF-303 | M3 | 统一 tool/MCP/extension dispatch | GBF-302 | 同一 policy/result contract | contract + integration tests | evidence/GBF-303 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
+| GBF-304 | M3 | 统一 session/checkpoint/resume/cancel | GBF-302 | crash/resume/cancel 语义唯一 | fault/recovery integration | evidence/GBF-304 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
+| GBF-305 | M3 | 统一 local exec | GBF-303 | 无绕过 capability gate 的执行口 | deny-path + code-path audit | evidence/GBF-305 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
+| GBF-306 | M3 | 统一错误/重试/超时/并发 | GBF-303..305 | 行为确定且可取消 | deterministic integration suite | evidence/GBF-306 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
 | GBF-401 | M4 | 定义 computer-control capability schema | GBF-204,305 | versioned target-bound contract | schema/threat review | evidence/GBF-401 | NOT_STARTED | M3 | 定义 capability IDs |
 | GBF-402 | M4 | 实现/验证 macOS adapter | GBF-401 | observe/input/window 能力受控 | macOS E2E | evidence/GBF-402 | NOT_STARTED | GBF-401 | 对齐平台 API |
 | GBF-403 | M4 | 实现/验证 Windows adapter | GBF-401 | observe/input/window 能力受控 | Windows E2E | evidence/GBF-403 | NOT_STARTED | GBF-401 | 对齐平台 API |
@@ -30,7 +30,7 @@
 | GBF-405 | M4 | 浏览器标签页级控制 | GBF-401 | 控制目标 tab 不干扰其它 tab | browser isolation E2E | evidence/GBF-405 | NOT_STARTED | GBF-401 | 建 target identity |
 | GBF-406 | M4 | 敏感输入一次性安全通道 | GBF-401 | approve/deny/expire/replay 安全 | security E2E | evidence/GBF-406 | NOT_STARTED | GBF-401 | 统一 sensitive-input contract |
 | GBF-407 | M4 | computer-control crash/reconnect | GBF-402..406 | 恢复无重复副作用 | fault/idempotency E2E | evidence/GBF-407 | NOT_STARTED | adapters | 建故障注入用例 |
-| GBF-501 | M5 | Grok UI/交互能力盘点 | GBF-103 | UI 能力 100% 有保留/重写/废弃决策 | parity table review | evidence/GBF-501 | NOT_STARTED | M1 | 建视觉/交互矩阵 |
+| GBF-501 | M5 | Grok UI/交互能力盘点 | GBF-103 | UI 能力 100% 有保留/重写/废弃决策 | parity table review + packaged UI contract | evidence/GBF-501 | IN_PROGRESS | PR #2098 CI/merge/package pending | 完成 parity matrix、截图基线与 protected delivery |
 | GBF-502 | M5 | Fabushi 动态头像语义状态机 | GBF-501 | idle/listening/thinking/tool/speaking/result/error | state contract tests | evidence/GBF-502 | NOT_STARTED | GBF-501 | 定义状态事件 |
 | GBF-503 | M5 | 动画 timeline/composition engine | GBF-502 | 可组合可确定渲染 | deterministic animation tests | evidence/GBF-503 | NOT_STARTED | GBF-502 | 实现时间线/曲线 |
 | GBF-504 | M5 | 动画性能与无障碍 | GBF-503 | offscreen/reduced-motion/预算可验证 | perf + accessibility tests | evidence/GBF-504 | NOT_STARTED | GBF-503 | 测量 frame baseline |

--- a/projects/grok-bot-fabushi-integration/management/05-状态报告.md
+++ b/projects/grok-bot-fabushi-integration/management/05-状态报告.md
@@ -63,10 +63,10 @@
 ## 2026-08-22 17:51+08 / Round 9
 
 - Task/Stage: GBF-207 / M2 E2E closure.
-- Evidence: Electron run #509 failure artifact 9473924227 downloaded and inspected. Root causes were Messenger native `prompt()` edit UI and zero-Bot group submission; Host security/validation behavior was correct.
-- Fixed: in-app edit dialog；group create requires selected Bot；stable `group-bot-*` selector；E2E verifies Bot selected；browser-login helper tolerates already-ready authenticated state.
-- Acceptance: implementation repaired；authoritative Electron smoke rerun still required, so GBF-207/M2 remain IN_PROGRESS.
-- Next: push PR #2009 update and require Electron desktop green before M2 release.
+- Evidence: Electron run #509 failure artifact 9473924227 downloaded and inspected. Root causes were Messenger native `prompt()` edit UI and zero-Bot group submission；Host security/validation behavior was correct。
+- Fixed: in-app edit dialog；group create requires selected Bot；stable `group-bot-*` selector；E2E verifies Bot selected；browser-login helper tolerates already-ready authenticated state。
+- Acceptance: implementation repaired；authoritative Electron smoke rerun still required, so GBF-207/M2 remain IN_PROGRESS。
+- Next: push PR #2009 update and require Electron desktop green before M2 release。
 
 ## 2026-08-22 20:12+08 / Round 10
 
@@ -84,3 +84,15 @@
 - Implemented: renderer Mahayana edge restricted to Host/FeatureHost contract; direct `runtime.callTool` bypass removed; canonical call path guarded as Coordinator -> transport -> feature.execute -> AppHost -> FeatureHost -> MahayanaRuntime/provider -> HostEvent; local process execution restricted to controlled Host/ASR surfaces; kernel session resume/cancel and interrupt ownership remain canonical.
 - Acceptance: GBF-301..306 TESTED; authoritative post-rebase GitHub CI/merge/post-main still pending, so M3 remains IN_PROGRESS.
 - Next: push rebased #2007, require runtime-convergence + Mahayana fast/Host/CI green, then merge and post-main verify.
+
+## 2026-08-24 15:34+08 / Round 12
+
+- Task/Stage: GBF-501 / M5 + Host lifecycle parity follow-up.
+- User source: `source/2026-08-24-grok-parity-reimplementation.md` records the request to begin full observable Grok Bot parity while keeping Fabushi/Mahayana as the product implementation.
+- Open-source-first: reviewed official `xai-org/grok-build` (Apache-2.0, Rust) as a current xAI agent reference; it is not a drop-in desktop Messenger implementation, so the task keeps existing Electron + Rust Mahayana Host and does not vendor a second runtime.
+- Implemented: added `desktop/public/grok-parity.css` + root surface marker to move the canonical Messenger from mixed Telegram light styling to one dark Grok/Fabushi material across sidebar, peer list, workspace, messages, composer, context panel, search/settings/Marketplace, dialogs and BotMark integration. Added packaged Playwright parity contract.
+- Runtime follow-up: `MahayanaHostProcess` now exposes structured lifecycle events/sequence for starting/running/stopped/restarting/closed/protocol-timeout conditions while preserving generation-bound request isolation; fault tests cover crash -> new generation -> restart -> close. The existing `feature.receive` pump remains the sole runtime event path and re-enters `host.request()` after failure, naturally starting a fresh generation without introducing a second daemon.
+- GitHub: PR #2098 opened from `feat/gbf-grok-parity-v1`; initial diff 7 files / +723 -13 before project-record follow-up commits.
+- Acceptance: GBF-501 = IN_PROGRESS. No completion claim: PR CI, protected merge, canonical-main packaged E2E, screenshot-level visual tuning, BotMark state integration and Release evidence remain required.
+- M3 correction: PR #2007 is verified merged (`c9bfa320...`), and its head had CI/Mahayana fast/Electron/Self-hosted Messaging/portfolio successes; historical Native mobile / embedded Codex runs on that head also had failures, so GBF-301..306 remain TESTED pending explicit post-main closure evidence rather than being falsely marked RELEASED.
+- Next: drive #2098 through CI; fix any contract regressions, then merge and continue GBF-501/502 visual-state parity plus GBF-401..407 computer-control parity.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-501-grok-ui-parity.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-501-grok-ui-parity.md
@@ -1,0 +1,58 @@
+# GBF-501 — Grok UI / interaction parity
+
+- **Project ID**: `FAB-P0004`
+- **Project Key**: `GBF`
+- **Task ID**: `GBF-501`
+- **Stage**: `M5 UI 与动画引擎`
+- **Status**: `IN_PROGRESS`
+- **Started**: `2026-08-24`
+- **Updated**: `2026-08-24`
+- **Branch**: `feat/gbf-grok-parity-v1`
+
+## Objective
+
+把当前混合 Telegram 亮色视觉的 Desktop Messenger 收敛为 Grok/Fabushi 单一视觉语言，在不删除现有消息、支付、Mini App、通话、搜索、设置能力的前提下，实现 Grok Bot 可观察的深色层级、紧凑密度、浮层、composer、侧栏和动态身份表现。
+
+## Source
+
+- `../../source/2026-08-24-grok-parity-reimplementation.md`
+- `../../source/grok-bot融合优化.txt`
+- pinned historical Grok inputs/evidence under `evidence/GBF-101..105`
+- existing Fabushi BotMark engine and canonical Electron Messenger on `main`
+
+## Open-source-first review
+
+- `xai-org/grok-build` (Apache-2.0, Rust): reviewed as a current official xAI open-source agent implementation and evidence that Rust remains compatible with the product direction. It is not a drop-in desktop Messenger/UI implementation, so this task does not vendor it.
+- Existing Fabushi React/Electron/CSS Modules and Rust Mahayana Host are reused rather than introducing a second UI/runtime framework.
+- Grok Bot production/reference assets with unclear provenance remain behavior/reference-only; production code is rewritten in Fabushi-owned files.
+
+## Acceptance criteria
+
+1. Authenticated desktop shell defaults to a coherent dark Grok/Fabushi material instead of Telegram white/bright-blue primary styling.
+2. Sidebar, peer list, workspace, chat header, message bubbles, composer, info panel, popovers/dialogs, search/settings and marketplace surfaces share the same color/material/spacing system.
+3. Existing BotMark motion remains the only animated identity primitive and is visually integrated into the new surface.
+4. Existing functional selectors and product behavior remain intact; styling changes do not create a parallel Messenger implementation.
+5. Electron typecheck/build, Messenger/packaged Playwright and relevant governance checks pass on GitHub Actions before task closure.
+6. Task remains `IN_PROGRESS` until protected merge, canonical-main readback, packaged E2E and Release evidence are complete.
+
+## Implementation round 1
+
+- Add a dedicated, product-owned `grok-parity.css` surface layer loaded by Electron/Vite.
+- Scope it with a root `data-fabushi-surface="grok-parity-v1"` marker so parity styling can be audited/removed independently.
+- Convert the visible Telegram light palette to a dark graphite/black material with low-contrast borders and restrained blue accent.
+- Preserve existing React components and selectors so runtime behavior is unchanged in this first visual convergence round.
+
+## Verification
+
+- Static HTML/CSS contract check: parity stylesheet is bundled from `public/` and explicitly linked from `index.html`.
+- Existing Electron/Messaging CI must typecheck/build and run packaged journeys.
+- Visual screenshot/E2E comparison will be added in follow-up GBF-501/502 rounds.
+
+## Blockers / risks
+
+- This round establishes the common visual substrate; exact pixel/animation parity still requires follow-up screenshot-driven tuning and BotMark state integration.
+- Grok proprietary/vendored reference code must not become a production dependency.
+
+## Next action
+
+Land the parity theme layer, then add screenshot contracts and state-driven BotMark/UI transitions before promoting GBF-501 beyond `IN_PROGRESS`.

--- a/projects/grok-bot-fabushi-integration/source/2026-08-24-grok-parity-reimplementation.md
+++ b/projects/grok-bot-fabushi-integration/source/2026-08-24-grok-parity-reimplementation.md
@@ -1,0 +1,20 @@
+# 2026-08-24 — Grok Bot parity reimplementation requirement
+
+## User requirement
+
+用户要求开始把 Grok Bot 的整体体验完整复刻进 Fabushi：在功能、交互、动画、UI 视觉和运行行为上达到一比一的可观察效果，同时保持 Fabushi 为自己的产品，最终实现不能呈现为一个平行的 Grok Bot 子产品。
+
+## Normalized engineering interpretation
+
+- Grok Bot 0.20 / 历史可观察实现作为行为、布局、动效与交互验收基准。
+- Fabushi/Mahayana 保持自己的 Electron + Rust Host + Mahayana sovereign runtime；不为了相似度退回第二套 Node/Grok runtime。
+- 对来源许可不明确或生产 bundle 反推得到的实现采用 clean-room behavior/spec reimplementation，不原样复制专有源码或品牌资产。
+- 目标是 observable parity：布局层级、密度、深色材质、composer、搜索/菜单、BotMark 状态表现、Host/Computer-Control 行为与恢复语义达到等效或更优。
+- Telegram/Fabushi 已有消息、支付、Mini App、通话、搜索等能力必须保留，不因 Grok 风格重构而退化。
+
+## Acceptance direction
+
+1. Desktop shell 不再呈现 Telegram 白底/亮蓝作为主视觉，而统一为 Grok/Fabushi 深色、低对比层级、浮层材质。
+2. Bot/User/Group/Channel/Mini App 共用 Fabushi BotMark/Identity 体系，AI 状态直接驱动动态表现。
+3. Rust Host / Mahayana 仍是唯一正式 Agent/Tool/Computer runtime，吸收 Grok coordinator/supervisor 的恢复、取消、事件流语义。
+4. 所有变化需通过现有 Electron/Messaging/Host/portfolio gates，并按 canonical main 的 packaged E2E + Release 规则完成交付。


### PR DESCRIPTION
## FAB-P0004 / GBF — Grok parity reimplementation round 1

Starts the user-requested full Grok Bot parity effort as a Fabushi-owned clean-room reimplementation rather than a parallel Grok runtime.

### UI parity substrate
- add `desktop/public/grok-parity.css` and activate it with `data-fabushi-surface="grok-parity-v1"`
- converge the existing canonical Messenger from Telegram light/bright-blue styling to one dark graphite Grok/Fabushi material system
- cover sidebar, peer rows, workspace, messages, composer, info panel, search/settings/marketplace, dialogs/popovers and BotMark integration
- preserve the existing single Messenger/Telegram feature tree; no second UI/runtime is introduced
- add `desktop/e2e/grok-parity.spec.ts` to assert the parity stylesheet loads, canonical Messenger remains unique, BotMark remains the identity engine, and conversation/composer computed styles are dark low-contrast material

### Host lifecycle convergence
- extend `MahayanaHostProcess` with a structured lifecycle stream (`starting`, `running`, `stopped`, `restarting`, `closed`, timeout/protocol failures)
- retain generation-bound request isolation and expose lifecycle sequence/health metadata
- add crash -> new generation -> explicit restart -> terminal close coverage
- existing `feature.receive` pump remains the single event path and naturally re-enters `host.request()` after failure, so the next loop iteration starts a fresh Host generation without a parallel daemon

### Provenance / architecture
- record the dated user requirement under the existing FAB-P0004 source tree
- Grok production/reference code remains behavior/reference-only when provenance is unclear
- `xai-org/grok-build` (Apache-2.0, Rust) was reviewed as an official current open-source reference; it is not vendored as a desktop UI replacement
- Fabushi keeps Electron + Rust Mahayana Host as the canonical implementation

### Verification gate
This PR is not task completion. Required GitHub CI/Electron/Messaging gates must pass, then protected merge and canonical-main packaged E2E/Release evidence must complete before GBF-501 is promoted beyond in-progress.