### PR TITLE
fix(desktop): make updater atomic and idle motion efficient

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -109,7 +109,9 @@ test('desktop Messenger unifies Telegram-class navigation with Fabushi agent ide
     await openMessenger(page);
 
     const profileNavigation = page.getByTestId('profile-navigation-trigger');
-    await expect(profileNavigation.locator('[data-engine="fabushi-motion-v2"]').first()).toBeVisible();
+    const profileMark = profileNavigation.locator('[data-engine="fabushi-motion-v2"]').first();
+    await expect(profileMark).toBeVisible();
+    await expect(profileMark).toHaveAttribute('data-motion-tier', 'ambient');
     await profileNavigation.click();
     await expect(page.getByTestId('profile-navigation-menu')).toBeVisible();
     for (const label of [

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -34,6 +34,7 @@ let hostEventPump = null;
 const messagingAccessCache = new Map();
 let messagingSignalingClient = null;
 let availableDesktopUpdateVersion = null;
+let runtimeDesktopUpdateStatus = null;
 const DESKTOP_UPDATE_CHECK_MIN_INTERVAL_MS = 60_000;
 const DESKTOP_UPDATE_FOREGROUND_INTERVAL_MS = 5 * 60_000;
 let lastAutomaticDesktopUpdateCheckAt = 0;
@@ -313,6 +314,36 @@ async function mutateNativeState(mutator) {
     await fs.rename(temp, file);
   });
   return nativeStateWrite;
+}
+
+function normalizePersistedDesktopUpdateStatus(status) {
+  const currentVersion = app.getVersion();
+  if (!status || typeof status !== 'object') return { type: 'upToDate', version: currentVersion };
+  const version = typeof status.version === 'string' && status.version ? status.version : currentVersion;
+  if (status.type === 'upToDate') return { ...status, version: currentVersion };
+  if (version === currentVersion && ['available', 'downloading', 'ready', 'staging'].includes(status.type)) {
+    return { type: 'upToDate', version: currentVersion };
+  }
+  return { ...status, version };
+}
+
+async function getDesktopUpdateStatus() {
+  if (runtimeDesktopUpdateStatus) return runtimeDesktopUpdateStatus;
+  const state = await readNativeState();
+  runtimeDesktopUpdateStatus = normalizePersistedDesktopUpdateStatus(state.updateStatus);
+  return runtimeDesktopUpdateStatus;
+}
+
+function setDesktopUpdateStatus(status, { broadcast = true } = {}) {
+  // The updater is a live process state machine. Set memory before broadcasting so
+  // a renderer click triggered by this exact event can never read stale disk state.
+  runtimeDesktopUpdateStatus = status;
+  if (broadcast) broadcastNativeEvent('update-status', status);
+  return mutateNativeState((state) => ({ ...state, updateStatus: status }))
+    .catch((error) => {
+      console.warn('[updater] unable to persist live update status', error instanceof Error ? error.message : String(error));
+    })
+    .then(() => status);
 }
 
 function persistenceKey(value) {
@@ -607,6 +638,8 @@ function installNativeEdge() {
     host,
     readNativeState,
     mutateNativeState,
+    getDesktopUpdateStatus,
+    setDesktopUpdateStatus,
     windowForEvent,
     broadcastNativeEvent,
     markDeepLinksReady: () => deepLinkRouter.markReady(),
@@ -816,36 +849,30 @@ function installAutoUpdaterEvents() {
   autoUpdater.allowPrerelease = false;
   autoUpdater.on('checking-for-update', () => {
     const status = { type: 'checking', version: app.getVersion() };
-    void mutateNativeState((state) => ({ ...state, updateStatus: status }));
-    broadcastNativeEvent('update-status', status);
+    void setDesktopUpdateStatus(status);
   });
   autoUpdater.on('update-not-available', (info) => {
     availableDesktopUpdateVersion = null;
     const status = { type: 'upToDate', version: info?.version ?? app.getVersion() };
-    void mutateNativeState((state) => ({ ...state, updateStatus: status }));
-    broadcastNativeEvent('update-status', status);
+    void setDesktopUpdateStatus(status);
   });
   autoUpdater.on('update-available', (info) => {
     availableDesktopUpdateVersion = info?.version ?? app.getVersion();
     const status = { type: 'available', version: availableDesktopUpdateVersion, notes: typeof info?.releaseNotes === 'string' ? info.releaseNotes : undefined };
-    void mutateNativeState((state) => ({ ...state, updateStatus: status }));
-    broadcastNativeEvent('update-status', status);
+    void setDesktopUpdateStatus(status);
   });
   autoUpdater.on('download-progress', (progress) => {
     const status = { type: 'downloading', version: availableDesktopUpdateVersion ?? app.getVersion(), progress: Number.isFinite(progress?.percent) ? Math.round(progress.percent) : undefined };
-    void mutateNativeState((state) => ({ ...state, updateStatus: status }));
-    broadcastNativeEvent('update-status', status);
+    void setDesktopUpdateStatus(status);
   });
   autoUpdater.on('update-downloaded', (info) => {
     availableDesktopUpdateVersion = info?.version ?? availableDesktopUpdateVersion ?? app.getVersion();
     const status = { type: 'ready', version: availableDesktopUpdateVersion };
-    void mutateNativeState((state) => ({ ...state, updateStatus: status }));
-    broadcastNativeEvent('update-status', status);
+    void setDesktopUpdateStatus(status);
   });
   autoUpdater.on('error', (error) => {
     const status = { type: 'error', message: error instanceof Error ? error.message : String(error) };
-    void mutateNativeState((state) => ({ ...state, updateStatus: status }));
-    broadcastNativeEvent('update-status', status);
+    void setDesktopUpdateStatus(status);
   });
 }
 

--- a/desktop/electron/native-capability-handlers.cjs
+++ b/desktop/electron/native-capability-handlers.cjs
@@ -97,6 +97,8 @@ function createNativeCapabilityHandlers(deps) {
     host,
     readNativeState,
     mutateNativeState,
+    getDesktopUpdateStatus,
+    setDesktopUpdateStatus,
     windowForEvent,
     broadcastNativeEvent,
   } = deps;
@@ -199,6 +201,7 @@ function createNativeCapabilityHandlers(deps) {
   }
 
   async function currentUpdateStatus() {
+    if (typeof getDesktopUpdateStatus === 'function') return getDesktopUpdateStatus();
     const state = await readNativeState();
     return state.updateStatus ?? {
       type: 'upToDate',
@@ -208,6 +211,7 @@ function createNativeCapabilityHandlers(deps) {
   }
 
   async function writeUpdateStatus(status) {
+    if (typeof setDesktopUpdateStatus === 'function') return setDesktopUpdateStatus(status);
     await mutateNativeState((state) => ({ ...state, updateStatus: status }));
     broadcastNativeEvent('update-status', status);
     return status;

--- a/desktop/electron/native-capability-handlers.test.cjs
+++ b/desktop/electron/native-capability-handlers.test.cjs
@@ -39,6 +39,8 @@ async function harness(run, options = {}) {
     host: options.host ?? { request: async () => ({ ok: true, data: null }) },
     readNativeState: async () => state,
     mutateNativeState: async (mutator) => { state = await mutator(state); return state; },
+    getDesktopUpdateStatus: options.getDesktopUpdateStatus,
+    setDesktopUpdateStatus: options.setDesktopUpdateStatus,
     windowForEvent: () => ({}),
     broadcastNativeEvent: () => {},
   });
@@ -152,6 +154,32 @@ test('diagnostic reports redact nested secrets before persistence', async () => 
   });
 });
 
+
+test('desktop update click uses live status even while persisted state is stale', async () => {
+  const calls = [];
+  let liveStatus = { type: 'available', version: '1.0.9' };
+  const autoUpdater = new EventEmitter();
+  autoUpdater.downloadUpdate = async () => {
+    calls.push('download');
+    setImmediate(() => autoUpdater.emit('update-downloaded', { version: '1.0.9' }));
+    return ['/tmp/fabushi-update.zip'];
+  };
+  autoUpdater.quitAndInstall = (silent, forceRunAfter) => { calls.push(['install', silent, forceRunAfter]); };
+  await harness(async ({ handlers, getState }) => {
+    assert.equal(getState().updateStatus.version, '1.0.798', 'disk intentionally begins stale');
+    const result = await handlers.quitAndInstallUpdate({ expectedVersion: '1.0.9' });
+    assert.equal(result.installed, true);
+    assert.equal(result.version, '1.0.9');
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    assert.deepEqual(calls, ['download', ['install', false, true]]);
+  }, {
+    isPackaged: true,
+    autoUpdater,
+    initialState: { preferences: {}, clientPersistence: {}, updateStatus: { type: 'upToDate', version: '1.0.798' } },
+    getDesktopUpdateStatus: async () => liveStatus,
+    setDesktopUpdateStatus: async (status) => { liveStatus = status; return status; },
+  });
+});
 
 test('desktop update click downloads a GitHub release and schedules replacement restart', async () => {
   const calls = [];

--- a/frontend/apps/web/src/app/host/bot-mark.tsx
+++ b/frontend/apps/web/src/app/host/bot-mark.tsx
@@ -146,6 +146,18 @@ const COLORS: readonly BotMarkColor[] = [
   "brown", "red", "orange", "yellow", "green", "cyan", "blue", "violet", "magenta", "gray",
 ];
 
+const AMBIENT_MOTION_STATES = new Set<BotMarkState>([
+  "idle", "sleeping", "drowsy", "bored", "powering-down",
+]);
+
+export function botMarkMotionTier(
+  state: BotMarkState,
+  emphasis = false,
+  followPointer = false,
+): "ambient" | "active" {
+  return !emphasis && !followPointer && AMBIENT_MOTION_STATES.has(state) ? "ambient" : "active";
+}
+
 const COLOR_VALUES: Record<BotMarkColor, { light: string; dark: string }> = {
   black: { light: "#000000", dark: "#FFFFFF" },
   brown: { light: "#A27952", dark: "#855C36" },
@@ -274,6 +286,7 @@ export const BotMark = forwardRef<BotMarkHandle, BotMarkProps>(function BotMark(
       data-shape={shape}
       data-color={color}
       data-accent={accent}
+      data-motion-tier={botMarkMotionTier(state, emphasis, followPointer)}
       data-engine="fabushi-motion-v2"
       style={style}
       aria-label={label}

--- a/frontend/apps/web/src/app/host/fabushi-bot-mark-engine.tsx
+++ b/frontend/apps/web/src/app/host/fabushi-bot-mark-engine.tsx
@@ -87,6 +87,8 @@ type FrameListener = (timeMs: number, deltaSeconds: number) => void;
 // so a sidebar full of agents does not cause a React render on every animation frame.
 const frameListeners = new Set<FrameListener>();
 const MOTION_FRAME_INTERVAL_MS = 1000 / 30;
+const AMBIENT_MOTION_FRAME_INTERVAL_MS = 1000 / 8;
+const AMBIENT_MOTION_STATES = new Set(["idle", "sleeping", "drowsy", "bored", "powering-down"]);
 let motionFrameId: number | null = null;
 let lastMotionFrameMs = 0;
 let lastMotionDispatchMs = 0;
@@ -481,17 +483,27 @@ export const FabushiBotMarkEngine = forwardRef<FabushiBotMarkEngineHandle, Fabus
       const phaseB = seededUnit(seed, 11) * Math.PI * 2;
       const phaseC = seededUnit(seed, 12) * Math.PI * 2;
       const phaseD = seededUnit(seed, 13) * Math.PI * 2;
+      let lastEngineFrameMs = 0;
 
       return subscribeMotionFrame((timeMs, deltaSeconds) => {
         if (!visibleRef.current) return;
 
         const currentProps = propsRef.current;
+        if (currentProps.paused) return;
+        const ambient = !currentProps.emphasis && !followPointer && AMBIENT_MOTION_STATES.has(currentProps.state);
+        const minimumIntervalMs = ambient ? AMBIENT_MOTION_FRAME_INTERVAL_MS : MOTION_FRAME_INTERVAL_MS;
+        if (lastEngineFrameMs && timeMs - lastEngineFrameMs < minimumIntervalMs) return;
+        const localDeltaSeconds = lastEngineFrameMs
+          ? Math.min(0.14, Math.max(1 / 120, (timeMs - lastEngineFrameMs) / 1000))
+          : deltaSeconds;
+        lastEngineFrameMs = timeMs;
+
         const profileValue = profileForState(currentProps.state);
         const physics = physicsRef.current;
         const timeSeconds = timeMs / 1000;
         const reduced = reducedMotionRef.current;
-        const continuousMotion = currentProps.paused || reduced ? 0 : 1;
-        const springDelta = currentProps.paused ? 0 : deltaSeconds;
+        const continuousMotion = reduced ? 0 : 1;
+        const springDelta = localDeltaSeconds;
 
         const baseWave = Math.sin(timeSeconds * (0.86 + profileValue.pace * 0.12) + phaseA);
         const secondaryWave = Math.sin(timeSeconds * (1.37 + profileValue.pace * 0.22) + phaseB);

--- a/frontend/apps/web/src/app/host/host.module.css
+++ b/frontend/apps/web/src/app/host/host.module.css
@@ -5504,8 +5504,11 @@
   position: relative;
   z-index: 2;
   transform-origin: 50% 54%;
-  animation: botMarkBreathe var(--bot-mark-breathe-duration) cubic-bezier(.46, 0, .54, 1) var(--bot-mark-motion-delay) infinite;
   filter: drop-shadow(0 4px 8px rgb(0 0 0 / 12%));
+}
+
+.botMark[data-motion-tier="active"] > svg {
+  animation: botMarkBreathe var(--bot-mark-breathe-duration) cubic-bezier(.46, 0, .54, 1) var(--bot-mark-motion-delay) infinite;
 }
 
 .botMarkAura,
@@ -5530,6 +5533,9 @@
   filter: blur(calc(var(--bot-mark-size) * .14));
   opacity: .16;
   transform: scale(.72);
+}
+
+.botMark[data-motion-tier="active"] .botMarkAuraSecondary {
   animation: botMarkGlow var(--bot-mark-breathe-duration) ease-in-out var(--bot-mark-motion-delay) infinite;
 }
 

--- a/frontend/apps/web/src/app/host/host.module.css
+++ b/frontend/apps/web/src/app/host/host.module.css
@@ -4085,6 +4085,7 @@
   height: 100%;
   display: block;
   overflow: visible;
+  pointer-events: none;
 }
 
 .sidebarBotMark { margin: 0; }

--- a/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
+++ b/projects/fabushi-cicd-merge-governance/management/05-状态报告.md
@@ -176,3 +176,10 @@
 - Root cause: the ordering query accepted legacy `desktop-v1.0.1-*` tags, whose post-prefix `v...` values outrank numeric SemVer under the existing `sort -V` comparison.
 - Repair narrows ordering to strict `desktop-X.Y.Z`, allows equal-highest retries to re-promote, explicitly PATCHes `make_latest=true`, and fails delivery unless `/releases/latest` reads back the expected tag.
 - FCM-011 remains in progress pending fixed Release + live old-to-new updater proof.
+
+## 2026-08-24 — FCM-011 Round 5 — first-click updater + energy closure
+
+- Running `1.0.808` discovered GitHub-Latest `1.0.809` after focus without restart: scheduler/latest-pointer repair is proven on the target Mac.
+- First-click failure was a disk/live-state race: UI had `available / 1.0.809` while persisted native state still reported `upToDate / 1.0.798`; installer reread stale disk. Electron now owns synchronous live updater state and persists after broadcast-safe memory update.
+- Target-Mac background CPU reaches ~0% after focus loss, but foreground-idle baseline remains ~76% GPU + ~21% renderer due to double JS + CSS avatar animation. Ambient avatar motion is reduced to 8 fps and duplicate CSS breathe/glow is disabled for ambient states; active states stay rich/full-rate.
+- Pending: PR CI/merge, exact-main Release, target-Mac progress/one-click auto-relaunch proof, then energy delta measurement.

--- a/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
+++ b/projects/fabushi-cicd-merge-governance/management/07-变更日志.md
@@ -100,3 +100,10 @@
 - Made same-version exact-SHA retries eligible to repair the Latest pointer.
 - Added explicit GitHub Release `make_latest=true` PATCH plus `/releases/latest` readback gate.
 - Added delivery governance contract coverage for the Latest-pointer invariant.
+
+## 2026-08-24 — live updater state and adaptive avatar energy
+
+- Made Electron in-memory update state authoritative for real-time updater actions, with serialized native-state persistence behind it.
+- Added stale-disk/first-click regression coverage.
+- Added ambient vs active avatar motion tiers; ambient marks use low-cadence JS and no duplicate CSS breathe/glow while active marks retain full animation.
+- Added packaged Messenger assertion for ambient idle avatar tier.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -100,3 +100,7 @@ Repair: Electron main now owns one synchronous in-memory desktop-update state. E
 The same target Mac showed why historical Energy Impact was extreme: background focus loss now correctly drives Fabushi processes to ~0% CPU, but foreground-idle `1.0.808` still measured roughly 76% GPU helper + 21% renderer. The avatar system was double-driving every idle mark: a 30-fps SVG JavaScript physics loop plus continuous CSS breathe/glow compositor animations. Ambient states now keep the living effect at an 8-fps JS cadence with no duplicate CSS breathe/glow; thinking/working/speaking/emphasized/pointer-follow states retain full 30-fps + active ambience. Background focus/visibility suspension remains unchanged.
 
 Acceptance remains open until exact-main Release on the target Mac proves visible download progress, one click -> download -> automatic install/relaunch, and post-relaunch version/readiness; energy proof must show background near-zero and substantially lower foreground-idle GPU/renderer CPU than the `1.0.808` baseline.
+
+### Round 5 CI interaction finding
+
+Host fast E2E found animated BotMark SVG paths intercepting pointer input intended for surrounding Host controls (`open-marketplace`, `大乘助手的电脑`). BotMark SVG is visual content inside parent controls, not its own input target, so the SVG layer now has `pointer-events: none`; parent buttons/list items remain the interactive hit target. This also removes needless per-path hit testing from animated avatars.

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-011-desktop-updater-channel-reliability.md
@@ -5,8 +5,8 @@
 - **Task ID:** FCM-011
 - **Status:** in-progress
 - **Started:** 2026-08-24T13:52:00+08:00
-- **Updated:** 2026-08-24T14:00:00+08:00
-- **Branch:** `fix/desktop-updater-idle-energy`
+- **Updated:** 2026-08-24T15:36:00+08:00
+- **Branch:** `fix/desktop-updater-energy-closure`
 
 ## Objective
 Make a running Fabushi macOS client reliably discover the canonical desktop GitHub Release without requiring a process restart, while preventing Android/iOS/other repository releases from stealing GitHub's `Latest` pointer used by `electron-updater`. Repair the canonical post-main publication path so future desktop Releases publish atomically with updater assets.
@@ -90,3 +90,13 @@ Repair:
 Open-source/official reference: GitHub Release REST documents `make_latest` as `true|false|legacy`; GitHub CLI documents `--latest`, but Fabushi now verifies the authoritative REST readback instead of trusting a fire-and-forget flag.
 
 Acceptance is not complete until a newer fixed Release becomes `/releases/latest`, a running fixed client discovers the following Release without restart, and one-click progress/install/relaunch is proven on the target Mac.
+
+## 2026-08-24 Round 5 — live updater state race + foreground idle energy
+
+Target-Mac proof reached the fixed no-restart discovery gate: a running `1.0.808` process was merely refocused and immediately exposed `更新 1.0.809` after `desktop-1.0.809` became GitHub Latest. The first click then exposed a separate race: renderer UI had received `update-available / 1.0.809`, while `fabushi-native-state.json` still held `upToDate / 1.0.798`. `quitAndInstallUpdate` reread disk, so an immediate click could observe the stale value and exit without downloading.
+
+Repair: Electron main now owns one synchronous in-memory desktop-update state. Every updater event updates memory before renderer broadcast and then serially persists it; native capability handlers read/write that same live state when hosted by Electron. Disk remains restart persistence, not the real-time state machine. A regression intentionally starts disk at `1.0.798`, live state at `available / 1.0.9`, and requires the first click to download and schedule replacement restart.
+
+The same target Mac showed why historical Energy Impact was extreme: background focus loss now correctly drives Fabushi processes to ~0% CPU, but foreground-idle `1.0.808` still measured roughly 76% GPU helper + 21% renderer. The avatar system was double-driving every idle mark: a 30-fps SVG JavaScript physics loop plus continuous CSS breathe/glow compositor animations. Ambient states now keep the living effect at an 8-fps JS cadence with no duplicate CSS breathe/glow; thinking/working/speaking/emphasized/pointer-follow states retain full 30-fps + active ambience. Background focus/visibility suspension remains unchanged.
+
+Acceptance remains open until exact-main Release on the target Mac proves visible download progress, one click -> download -> automatic install/relaunch, and post-relaunch version/readiness; energy proof must show background near-zero and substantially lower foreground-idle GPU/renderer CPU than the `1.0.808` baseline.


### PR DESCRIPTION
## Summary
- make Electron's in-memory desktop update status authoritative for real-time actions, while persisting it asynchronously for restart recovery
- remove the race where the renderer could receive `update-available` but the first install click reread an older `fabushi-native-state.json` value and did nothing
- add a stale-disk regression that requires the first click to download and schedule replacement restart from the live version
- introduce adaptive avatar motion tiers: idle/sleeping ambient marks update at 8 fps and do not duplicate JavaScript motion with CSS breathe/glow animations; active thinking/working/speaking/emphasized marks retain full-rate rich motion
- preserve existing full suspension on window blur/hidden state
- record target-Mac updater and energy evidence in FCM-011

## Target-Mac evidence before this PR
- running Fabushi `1.0.808` discovered GitHub-Latest `1.0.809` after window refocus without restarting, proving the foreground updater scheduler and Latest-pointer repairs
- first click then exposed the live/disk race: UI showed `1.0.809` while persisted native state still said `upToDate / 1.0.798`
- background after focus loss is already ~0% CPU for Fabushi processes
- foreground-idle `1.0.808` measured approximately 75.9% GPU helper + 21.4% renderer, traced to every idle avatar being driven both by a 30-fps SVG physics loop and continuous CSS compositor animations

## Verification before PR
- `node --check desktop/electron/main.cjs` passes
- `node --check desktop/electron/native-capability-handlers.cjs` passes
- `git diff --check` passes
- no local app build/package/E2E was run; those remain GitHub Actions responsibilities

## Completion gate
FCM-011 remains in progress until protected CI/merge, exact-main signed/notarized Release, target-Mac visible download progress + one-click automatic install/relaunch, post-relaunch version proof, and foreground/background energy delta measurements all pass.