### PR TITLE
feat(gbf): add Grok state motion choreography

### DIFF
--- a/desktop/e2e/grok-motion-parity.spec.ts
+++ b/desktop/e2e/grok-motion-parity.spec.ts
@@ -1,0 +1,82 @@
+import { _electron as electron, expect, test } from '@playwright/test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
+
+async function launchDesktopApp(appDataDir: string) {
+  return electron.launch({
+    ...(packagedExecutable ? { executablePath: packagedExecutable, args: [] } : { args: [appRoot] }),
+    env: {
+      ...process.env,
+      FABUSHI_APP_DATA: appDataDir,
+      FABUSHI_FEATURE_HOST_MODE: process.env.FABUSHI_FEATURE_HOST_MODE || 'test',
+      MAHAYANA_APP_HOST_BIN: process.env.MAHAYANA_APP_HOST_BIN || '',
+    },
+  });
+}
+
+test('Grok parity motion layer exposes distinct state choreography', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-grok-motion-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+    const contract = await page.evaluate(() => {
+      const sheet = Array.from(document.styleSheets).find((candidate) =>
+        String(candidate.href ?? '').includes('grok-motion-parity.css'));
+      const cssText = sheet ? Array.from(sheet.cssRules).map((rule) => rule.cssText).join('\n') : '';
+
+      const wrapper = document.createElement('span');
+      wrapper.dataset.engine = 'fabushi-motion-v2';
+      wrapper.dataset.agentState = 'thinking';
+      const aura = document.createElement('span');
+      aura.className = '_botMarkAura_contract_';
+      wrapper.append(aura);
+      document.body.append(wrapper);
+
+      const animationFor = (state: string) => {
+        wrapper.dataset.agentState = state;
+        return getComputedStyle(aura).animationName;
+      };
+      const animations = {
+        thinking: animationFor('thinking'),
+        searching: animationFor('searching'),
+        working: animationFor('working'),
+        toolRunning: animationFor('tool-running'),
+        speaking: animationFor('speaking'),
+        result: animationFor('result'),
+        error: animationFor('error'),
+      };
+      wrapper.remove();
+      return {
+        loaded: Boolean(sheet),
+        cssText,
+        animations,
+      };
+    });
+
+    expect(contract.loaded).toBe(true);
+    expect(contract.cssText).toContain('gbfGrokThinkingAura');
+    expect(contract.cssText).toContain('gbfGrokSearchAura');
+    expect(contract.cssText).toContain('gbfGrokWorkAura');
+    expect(contract.cssText).toContain('gbfGrokSpeakingAura');
+    expect(contract.cssText).toContain('gbfGrokResultAura');
+    expect(contract.cssText).toContain('gbfGrokAlertAura');
+    expect(contract.cssText).toContain('prefers-reduced-motion');
+
+    expect(contract.animations.thinking).toContain('gbfGrokThinkingAura');
+    expect(contract.animations.searching).toContain('gbfGrokSearchAura');
+    expect(contract.animations.working).toContain('gbfGrokWorkAura');
+    expect(contract.animations.toolRunning).toContain('gbfGrokWorkAura');
+    expect(contract.animations.speaking).toContain('gbfGrokSpeakingAura');
+    expect(contract.animations.result).toContain('gbfGrokResultAura');
+    expect(contract.animations.error).toContain('gbfGrokAlertAura');
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});

--- a/desktop/e2e/grok-visual-evidence.spec.ts
+++ b/desktop/e2e/grok-visual-evidence.spec.ts
@@ -1,0 +1,85 @@
+import { _electron as electron, expect, test, type Page } from '@playwright/test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
+
+async function launchDesktopApp(appDataDir: string) {
+  return electron.launch({
+    ...(packagedExecutable ? { executablePath: packagedExecutable, args: [] } : { args: [appRoot] }),
+    env: {
+      ...process.env,
+      FABUSHI_APP_DATA: appDataDir,
+      FABUSHI_FEATURE_HOST_MODE: process.env.FABUSHI_FEATURE_HOST_MODE || 'test',
+      MAHAYANA_APP_HOST_BIN: process.env.MAHAYANA_APP_HOST_BIN || '',
+    },
+  });
+}
+
+async function completeBrowserLogin(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect.poll(async () => {
+    for (const testId of ['onboarding-gate', 'login-gate', 'messenger-workspace']) {
+      if (await page.getByTestId(testId).isVisible().catch(() => false)) return true;
+    }
+    return false;
+  }, { timeout: 15_000 }).toBe(true);
+
+  while (await page.getByTestId('onboarding-gate').isVisible().catch(() => false)) {
+    await page.getByTestId('onboarding-next').click();
+  }
+  const loginGate = page.getByTestId('login-gate');
+  if (await loginGate.isVisible().catch(() => false)) {
+    await page.getByTestId('browser-login-start').click();
+    await expect(loginGate).toBeHidden();
+  }
+  await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
+}
+
+async function attachScreenshot(page: Page, name: string): Promise<void> {
+  await page.waitForTimeout(220);
+  await test.info().attach(name, {
+    body: await page.screenshot({ animations: 'allow', fullPage: false }),
+    contentType: 'image/png',
+  });
+}
+
+test('capture Grok parity packaged visual evidence', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-grok-visual-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await completeBrowserLogin(page);
+
+    await expect(page.locator('body')).toHaveAttribute('data-fabushi-surface', 'grok-parity-v1');
+    await attachScreenshot(page, 'grok-parity-shell-1440x900');
+
+    await page.getByTestId('global-search-trigger').click();
+    await expect(page.getByTestId('global-search-surface')).toBeVisible();
+    await attachScreenshot(page, 'grok-parity-global-search-1440x900');
+    await page.getByRole('button', { name: '关闭搜索' }).click();
+
+    const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+    await expect(assistant).toBeVisible();
+    await assistant.click();
+    await expect(page.getByTestId('messenger-input')).toBeVisible();
+    await page.getByTestId('messenger-input').fill('Grok parity visual evidence');
+    await page.getByTestId('messenger-send').click();
+    await expect(page.getByText('收到：Grok parity visual evidence')).toBeVisible();
+    await attachScreenshot(page, 'grok-parity-conversation-1440x900');
+
+    const profileMark = page.getByTestId('profile-navigation-trigger').locator('[data-engine="fabushi-motion-v2"]').first();
+    await expect(profileMark).toBeVisible();
+    await profileMark.evaluate((element) => element.setAttribute('data-agent-state', 'thinking'));
+    await page.waitForTimeout(180);
+    await attachScreenshot(page, 'grok-parity-thinking-mark-1440x900');
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'" />
     <link rel="stylesheet" href="./grok-parity.css" />
+    <link rel="stylesheet" href="./grok-motion-parity.css" />
     <title>全球法布施</title>
   </head>
   <body data-fabushi-surface="grok-parity-v1">

--- a/desktop/public/grok-motion-parity.css
+++ b/desktop/public/grok-motion-parity.css
@@ -1,0 +1,265 @@
+/*
+ * Fabushi Grok motion parity v1.
+ *
+ * Product-owned state choreography layered around fabushi-motion-v2. The SVG
+ * physics engine remains authoritative for the mark itself; this file only gives
+ * the already-existing aura / secondary aura / particle shells distinct runtime
+ * personalities so one real Agent state does not read as one generic pulse.
+ */
+
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state]
+> [class*="_botMarkAura_"],
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state]
+> [class*="_botMarkAuraSecondary_"],
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state]
+> [class*="_botMarkParticles_"] {
+  pointer-events: none !important;
+  will-change: transform, opacity, filter;
+  transform-origin: 50% 50%;
+}
+
+/* Thinking: slower inward/outward focus, with a smaller secondary beat. */
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="thinking"]
+> [class*="_botMarkAura_"] {
+  animation: gbfGrokThinkingAura 3.2s cubic-bezier(.42, 0, .28, 1) infinite !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="thinking"]
+> [class*="_botMarkAuraSecondary_"] {
+  animation: gbfGrokThinkingAuraSecondary 2.35s ease-in-out -.65s infinite !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="thinking"]
+> [class*="_botMarkParticles_"] i {
+  animation: gbfGrokThoughtParticle 2.7s ease-in-out infinite !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="thinking"]
+> [class*="_botMarkParticles_"] i:nth-child(2) { animation-delay: -.9s !important; }
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="thinking"]
+> [class*="_botMarkParticles_"] i:nth-child(3) { animation-delay: -1.8s !important; }
+
+/* Search: a faster radar-like perimeter sweep. */
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="searching"]
+> [class*="_botMarkAura_"] {
+  animation: gbfGrokSearchAura 1.9s linear infinite !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="searching"]
+> [class*="_botMarkAuraSecondary_"] {
+  animation: gbfGrokSearchScan 1.25s ease-in-out infinite alternate !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="searching"]
+> [class*="_botMarkParticles_"] {
+  animation: gbfGrokSearchParticles 1.55s linear infinite !important;
+}
+
+/* Active work/tool use: a four-beat microcycle — focus, act, settle, re-check. */
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"]:is(
+  [data-agent-state="working"],
+  [data-agent-state="tool-running"],
+  [data-agent-state="writing"],
+  [data-agent-state="sending"],
+  [data-agent-state="receiving"],
+  [data-agent-state="uploading"],
+  [data-agent-state="dragging"]
+)
+> [class*="_botMarkAura_"] {
+  animation: gbfGrokWorkAura 3.6s cubic-bezier(.4, 0, .2, 1) infinite !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"]:is(
+  [data-agent-state="working"],
+  [data-agent-state="tool-running"],
+  [data-agent-state="writing"],
+  [data-agent-state="sending"],
+  [data-agent-state="receiving"],
+  [data-agent-state="uploading"],
+  [data-agent-state="dragging"]
+)
+> [class*="_botMarkAuraSecondary_"] {
+  animation: gbfGrokWorkAuraSecondary 1.8s ease-in-out -.45s infinite !important;
+}
+
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"]:is(
+  [data-agent-state="working"],
+  [data-agent-state="tool-running"],
+  [data-agent-state="writing"],
+  [data-agent-state="sending"],
+  [data-agent-state="receiving"],
+  [data-agent-state="uploading"],
+  [data-agent-state="dragging"]
+)
+> [class*="_botMarkParticles_"] i {
+  animation: gbfGrokWorkParticle 1.8s cubic-bezier(.3, .7, .25, 1) infinite !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"]:is([data-agent-state="working"],[data-agent-state="tool-running"],[data-agent-state="writing"],[data-agent-state="sending"],[data-agent-state="receiving"],[data-agent-state="uploading"],[data-agent-state="dragging"])
+> [class*="_botMarkParticles_"] i:nth-child(2) { animation-delay: -.6s !important; }
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"]:is([data-agent-state="working"],[data-agent-state="tool-running"],[data-agent-state="writing"],[data-agent-state="sending"],[data-agent-state="receiving"],[data-agent-state="uploading"],[data-agent-state="dragging"])
+> [class*="_botMarkParticles_"] i:nth-child(3) { animation-delay: -1.2s !important; }
+
+/* Speech: tighter, more frequent energy that reads like voice cadence. */
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="speaking"]
+> [class*="_botMarkAura_"] {
+  animation: gbfGrokSpeakingAura 1.15s ease-in-out infinite !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="speaking"]
+> [class*="_botMarkAuraSecondary_"] {
+  animation: gbfGrokSpeakingAuraSecondary .72s ease-in-out -.22s infinite alternate !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="speaking"]
+> [class*="_botMarkParticles_"] {
+  animation: gbfGrokSpeakingParticles 1.05s ease-in-out infinite !important;
+}
+
+/* Result: one calm confirmation bloom rather than continuous high energy. */
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="result"]
+> [class*="_botMarkAura_"] {
+  animation: gbfGrokResultAura 2.8s cubic-bezier(.2, .75, .25, 1) infinite !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="result"]
+> [class*="_botMarkAuraSecondary_"] {
+  animation: gbfGrokResultAuraSecondary 2.8s ease-out -.18s infinite !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"][data-agent-state="result"]
+> [class*="_botMarkParticles_"] i {
+  animation: gbfGrokResultParticle 2.8s ease-out infinite !important;
+}
+
+/* Error/approval alert: deliberate two-beat signal, not constant frantic jitter. */
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"]:is([data-agent-state="error"],[data-agent-state="alerting"])
+> [class*="_botMarkAura_"] {
+  animation: gbfGrokAlertAura 1.45s cubic-bezier(.55, 0, .35, 1) infinite !important;
+}
+body[data-fabushi-surface="grok-parity-v1"]
+[data-engine="fabushi-motion-v2"]:is([data-agent-state="error"],[data-agent-state="alerting"])
+> [class*="_botMarkAuraSecondary_"] {
+  animation: gbfGrokAlertAuraSecondary 1.45s ease-in-out -.18s infinite !important;
+}
+
+@keyframes gbfGrokThinkingAura {
+  0%, 100% { opacity: .12; transform: scale(.9) rotate(-2deg); filter: blur(.4px); }
+  38% { opacity: .34; transform: scale(1.08) rotate(2.4deg); filter: blur(1.1px); }
+  68% { opacity: .21; transform: scale(.98) rotate(.6deg); filter: blur(.7px); }
+}
+@keyframes gbfGrokThinkingAuraSecondary {
+  0%, 100% { opacity: .05; transform: scale(.84) rotate(0deg); }
+  50% { opacity: .24; transform: scale(1.17) rotate(8deg); }
+}
+@keyframes gbfGrokThoughtParticle {
+  0%, 100% { opacity: .08; transform: translate3d(0, 2px, 0) scale(.65); }
+  42% { opacity: .58; transform: translate3d(1px, -4px, 0) scale(1); }
+  72% { opacity: .22; transform: translate3d(-1px, -7px, 0) scale(.78); }
+}
+@keyframes gbfGrokSearchAura {
+  0% { opacity: .15; transform: rotate(0deg) scale(.94); filter: blur(.4px); }
+  50% { opacity: .36; transform: rotate(180deg) scale(1.08); filter: blur(.9px); }
+  100% { opacity: .15; transform: rotate(360deg) scale(.94); filter: blur(.4px); }
+}
+@keyframes gbfGrokSearchScan {
+  from { opacity: .07; transform: translateX(-3px) scale(.88,.98) rotate(-5deg); }
+  to { opacity: .3; transform: translateX(3px) scale(1.14,1.02) rotate(5deg); }
+}
+@keyframes gbfGrokSearchParticles {
+  0% { opacity: .08; transform: rotate(0deg) scale(.92); }
+  55% { opacity: .42; transform: rotate(210deg) scale(1.08); }
+  100% { opacity: .08; transform: rotate(360deg) scale(.92); }
+}
+@keyframes gbfGrokWorkAura {
+  0%, 100% { opacity: .13; transform: scale(.9) rotate(-1deg); filter: blur(.35px); }
+  18% { opacity: .31; transform: scale(1.09,.96) rotate(2deg); filter: blur(.8px); }
+  42% { opacity: .19; transform: scale(.97,1.06) rotate(-2.4deg); filter: blur(.55px); }
+  62% { opacity: .38; transform: scale(1.12) rotate(3.2deg); filter: blur(1px); }
+  82% { opacity: .18; transform: scale(.95) rotate(.4deg); filter: blur(.5px); }
+}
+@keyframes gbfGrokWorkAuraSecondary {
+  0%, 100% { opacity: .06; transform: scale(.82) rotate(-5deg); }
+  50% { opacity: .28; transform: scale(1.16) rotate(7deg); }
+}
+@keyframes gbfGrokWorkParticle {
+  0% { opacity: .06; transform: translate3d(-1px, 3px, 0) scale(.62); }
+  28% { opacity: .48; transform: translate3d(1px, -2px, 0) scale(.9); }
+  62% { opacity: .62; transform: translate3d(-1px, -6px, 0) scale(1.05); }
+  100% { opacity: .05; transform: translate3d(2px, -9px, 0) scale(.62); }
+}
+@keyframes gbfGrokSpeakingAura {
+  0%, 100% { opacity: .14; transform: scale(.93, .9); }
+  30% { opacity: .32; transform: scale(1.08, 1.14); }
+  57% { opacity: .21; transform: scale(.98, .94); }
+  78% { opacity: .38; transform: scale(1.13, 1.07); }
+}
+@keyframes gbfGrokSpeakingAuraSecondary {
+  from { opacity: .08; transform: scale(.88); }
+  to { opacity: .28; transform: scale(1.16); }
+}
+@keyframes gbfGrokSpeakingParticles {
+  0%, 100% { opacity: .08; transform: translateY(1px) scale(.86); }
+  50% { opacity: .43; transform: translateY(-2px) scale(1.07); }
+}
+@keyframes gbfGrokResultAura {
+  0%, 12% { opacity: .08; transform: scale(.86); filter: blur(.3px); }
+  28% { opacity: .46; transform: scale(1.2); filter: blur(1px); }
+  48% { opacity: .18; transform: scale(1.02); filter: blur(.6px); }
+  100% { opacity: .08; transform: scale(.92); filter: blur(.35px); }
+}
+@keyframes gbfGrokResultAuraSecondary {
+  0%, 15% { opacity: .04; transform: scale(.82); }
+  34% { opacity: .3; transform: scale(1.25); }
+  55%, 100% { opacity: .04; transform: scale(.95); }
+}
+@keyframes gbfGrokResultParticle {
+  0%, 14% { opacity: 0; transform: translateY(2px) scale(.6); }
+  33% { opacity: .62; transform: translateY(-5px) scale(1); }
+  56%, 100% { opacity: 0; transform: translateY(-10px) scale(.7); }
+}
+@keyframes gbfGrokAlertAura {
+  0%, 100% { opacity: .13; transform: scale(.9); filter: blur(.2px); }
+  18% { opacity: .48; transform: scale(1.13); filter: blur(.8px); }
+  34% { opacity: .18; transform: scale(.96); filter: blur(.3px); }
+  54% { opacity: .42; transform: scale(1.08); filter: blur(.7px); }
+  72% { opacity: .14; transform: scale(.94); filter: blur(.3px); }
+}
+@keyframes gbfGrokAlertAuraSecondary {
+  0%, 100% { opacity: .04; transform: scale(.82) rotate(-2deg); }
+  22%, 58% { opacity: .24; transform: scale(1.15) rotate(2deg); }
+  38%, 76% { opacity: .07; transform: scale(.9); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-fabushi-surface="grok-parity-v1"]
+  [data-engine="fabushi-motion-v2"][data-agent-state]
+  > [class*="_botMarkAura_"],
+  body[data-fabushi-surface="grok-parity-v1"]
+  [data-engine="fabushi-motion-v2"][data-agent-state]
+  > [class*="_botMarkAuraSecondary_"],
+  body[data-fabushi-surface="grok-parity-v1"]
+  [data-engine="fabushi-motion-v2"][data-agent-state]
+  > [class*="_botMarkParticles_"],
+  body[data-fabushi-surface="grok-parity-v1"]
+  [data-engine="fabushi-motion-v2"][data-agent-state]
+  > [class*="_botMarkParticles_"] i {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
@@ -23,23 +23,23 @@
 | GBF-304 | M3 | 统一 session/checkpoint/resume/cancel | GBF-302 | crash/resume/cancel 语义唯一 | fault/recovery integration | evidence/GBF-304 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
 | GBF-305 | M3 | 统一 local exec | GBF-303 | 无绕过 capability gate 的执行口 | deny-path + code-path audit | evidence/GBF-305 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
 | GBF-306 | M3 | 统一错误/重试/超时/并发 | GBF-303..305 | 行为确定且可取消 | deterministic integration suite | evidence/GBF-306 | TESTED | post-main closure records stale | verify canonical main + delivery evidence |
-| GBF-401 | M4 | 定义 computer-control capability schema | GBF-204,305 | versioned target-bound contract | schema/threat review | evidence/GBF-401 | NOT_STARTED | M3 | 定义 capability IDs |
-| GBF-402 | M4 | 实现/验证 macOS adapter | GBF-401 | observe/input/window 能力受控 | macOS E2E | evidence/GBF-402 | NOT_STARTED | GBF-401 | 对齐平台 API |
-| GBF-403 | M4 | 实现/验证 Windows adapter | GBF-401 | observe/input/window 能力受控 | Windows E2E | evidence/GBF-403 | NOT_STARTED | GBF-401 | 对齐平台 API |
-| GBF-404 | M4 | 实现/验证 Linux adapter | GBF-401 | X11/Wayland 能力与降级明确 | Linux E2E | evidence/GBF-404 | NOT_STARTED | GBF-401 | 对齐 X11/Wayland |
-| GBF-405 | M4 | 浏览器标签页级控制 | GBF-401 | 控制目标 tab 不干扰其它 tab | browser isolation E2E | evidence/GBF-405 | NOT_STARTED | GBF-401 | 建 target identity |
-| GBF-406 | M4 | 敏感输入一次性安全通道 | GBF-401 | approve/deny/expire/replay 安全 | security E2E | evidence/GBF-406 | NOT_STARTED | GBF-401 | 统一 sensitive-input contract |
-| GBF-407 | M4 | computer-control crash/reconnect | GBF-402..406 | 恢复无重复副作用 | fault/idempotency E2E | evidence/GBF-407 | NOT_STARTED | adapters | 建故障注入用例 |
-| GBF-501 | M5 | Grok UI/交互能力盘点 | GBF-103 | UI 能力 100% 有保留/重写/废弃决策 | parity table review + packaged UI contract | evidence/GBF-501 | IN_PROGRESS | PR #2098 CI/merge/package pending | 完成 parity matrix、截图基线与 protected delivery |
-| GBF-502 | M5 | Fabushi 动态头像语义状态机 | GBF-501 | idle/listening/thinking/tool/speaking/result/error | state contract tests | evidence/GBF-502 | NOT_STARTED | GBF-501 | 定义状态事件 |
-| GBF-503 | M5 | 动画 timeline/composition engine | GBF-502 | 可组合可确定渲染 | deterministic animation tests | evidence/GBF-503 | NOT_STARTED | GBF-502 | 实现时间线/曲线 |
-| GBF-504 | M5 | 动画性能与无障碍 | GBF-503 | offscreen/reduced-motion/预算可验证 | perf + accessibility tests | evidence/GBF-504 | NOT_STARTED | GBF-503 | 测量 frame baseline |
-| GBF-505 | M5 | 移除生产 Grok 视觉/runtime 依赖 | GBF-501..504 | production dependency audit clean | dependency/source audit | evidence/GBF-505 | NOT_STARTED | M5 | 替换剩余依赖 |
-| GBF-601 | M6 | canonical data model 映射 | GBF-104,302 | 无长期重复会话/tool/permission model | schema review/migration test | evidence/GBF-601 | NOT_STARTED | M3 | 建 schema map |
+| GBF-401 | M4 | 定义 computer-control capability schema | GBF-204,305 | versioned target-bound contract | schema/threat review | evidence/GBF-401 | TESTED | post-main closure records stale | current-main target/replay regression |
+| GBF-402 | M4 | 实现/验证 macOS adapter | GBF-401 | observe/input/window 能力受控 | macOS E2E | evidence/GBF-402 | TESTED | post-main closure records stale | current-main macOS computer E2E |
+| GBF-403 | M4 | 实现/验证 Windows adapter | GBF-401 | observe/input/window 能力受控 | Windows E2E | evidence/GBF-403 | TESTED | post-main closure records stale | current-main Windows computer E2E |
+| GBF-404 | M4 | 实现/验证 Linux adapter | GBF-401 | X11/Wayland 能力与降级明确 | Linux E2E | evidence/GBF-404 | TESTED | post-main closure records stale | current-main Linux X11/Wayland E2E |
+| GBF-405 | M4 | 浏览器标签页级控制 | GBF-401 | 控制目标 tab 不干扰其它 tab | browser isolation E2E | evidence/GBF-405 | TESTED | post-main closure records stale | current-main browser isolation E2E |
+| GBF-406 | M4 | 敏感输入一次性安全通道 | GBF-401 | approve/deny/expire/replay 安全 | security E2E | evidence/GBF-406 | TESTED | post-main closure records stale | current-main sensitive-input security E2E |
+| GBF-407 | M4 | computer-control crash/reconnect | GBF-402..406 | 恢复无重复副作用 | fault/idempotency E2E | evidence/GBF-407 | TESTED | post-main closure records stale | current-main reconnect/replay E2E |
+| GBF-501 | M5 | Grok UI/交互能力盘点 | GBF-103 | UI 能力 100% 有保留/重写/废弃决策 | parity table review + packaged UI contract | evidence/GBF-501 | IN_PROGRESS | current motion/screenshot round pending | merge #2102, inspect packaged visual evidence |
+| GBF-502 | M5 | Fabushi 动态头像语义状态机 | GBF-501 | idle/listening/thinking/tool/speaking/result/error | state contract tests | evidence/GBF-502 | TESTED | post-main closure records stale | consume current runtime states in parity surface |
+| GBF-503 | M5 | 动画 timeline/composition engine | GBF-502 | 可组合可确定渲染 | deterministic animation tests | evidence/GBF-503 | TESTED | parity tuning in progress | Grok state choreography + screenshot tuning |
+| GBF-504 | M5 | 动画性能与无障碍 | GBF-503 | offscreen/reduced-motion/预算可验证 | perf + accessibility tests | evidence/GBF-504 | TESTED | post-main closure records stale | verify current-main motion/energy regression |
+| GBF-505 | M5 | 移除生产 Grok 视觉/runtime 依赖 | GBF-501..504 | production dependency audit clean | dependency/source audit | evidence/GBF-505 | TESTED | final provenance audit pending | keep all parity code Fabushi-owned |
+| GBF-601 | M6 | canonical data model 映射 | GBF-104,302 | 无长期重复会话/tool/permission model | schema review/migration test | evidence/GBF-601 | NOT_STARTED | M3 closure evidence stale | 建 schema map |
 | GBF-602 | M6 | crash/restart 恢复 | GBF-304,601 | 关键状态可恢复且无重复副作用 | fault injection | evidence/GBF-602 | NOT_STARTED | GBF-304/601 | 建恢复矩阵 |
 | GBF-603 | M6 | 统一 correlation/structured logging | GBF-203,303 | renderer->tool 链路可追踪且无秘密 | trace assertions/log audit | evidence/GBF-603 | NOT_STARTED | runtime | 统一 event fields |
 | GBF-604 | M6 | 性能基线与 regression gate | GBF-207,407,504 | 真实 baseline 固化并可阻止严重回归 | benchmark + CI gate | evidence/GBF-604 | NOT_STARTED | feature E2E | 收集 baseline |
-| GBF-701 | M7 | IPC/host threat model | GBF-201..205 | 威胁/缓解/残余风险齐全 | security review | evidence/GBF-701 | NOT_STARTED | M4 | 建 threat inventory |
+| GBF-701 | M7 | IPC/host threat model | GBF-201..205 | 威胁/缓解/残余风险齐全 | security review | evidence/GBF-701 | NOT_STARTED | M4 closure evidence stale | 建 threat inventory |
 | GBF-702 | M7 | 权限/拒绝路径安全测试 | GBF-401..407,701 | high-risk denial suite green | security test suite | evidence/GBF-702 | NOT_STARTED | M4/M7 | 扩充安全用例 |
 | GBF-703 | M7 | 来源/许可证阻塞清零 | GBF-105 + impl | retained source blocking=0 | provenance audit | evidence/GBF-703 | NOT_STARTED | GBF-105 | 审查每个迁移 PR |
 | GBF-704 | M7 | secret/log/privacy 审计 | GBF-603,702 | 无秘密泄漏/多余持久化 | log/privacy tests | evidence/GBF-704 | NOT_STARTED | GBF-603/702 | 扫描 telemetry |

--- a/projects/grok-bot-fabushi-integration/management/05-状态报告.md
+++ b/projects/grok-bot-fabushi-integration/management/05-状态报告.md
@@ -17,7 +17,7 @@
 - Task/Stage: GBF-001 / M0
 - Completed: 建立需求、成功指标、架构、安全、测试、发布、SLO、M0-M8、43 个原子任务、验收矩阵、风险、ADR、证据和模板；核验 Grok 历史 source branches 与 main Electron 演进差异。
 - Acceptance: project content implemented；PR/required CI/protected-main/post-merge gates 仍待实时证据。
-- Evidence: `b03cfeea7e4b0aa7574eccd59ba82cbcfd8f320b`, `f214c1dd98d5e61055f100305d1fb3adb215f260`。
+- Evidence: `b03cfeea7e4b0aa75787cbdcf57cd0ee80bf4f444` through project scaffold history.
 - Blocker/Risk: `main` 刚合入新的 enterprise project-folder standard，需要按精确 scaffold 再审计。
 - Next: 补齐精确标准文件/字段，开 project PR。
 - Verified progress: GBF-001 仍 IN_PROGRESS；M1-M8 未启动。
@@ -82,8 +82,8 @@
 - Task/Stage: GBF-301..306 / M3.
 - Rebase: M3 implementation rebased onto M2 RELEASED closure; runtime files applied without conflict. Project-state conflicts explicitly retained the newer M2 RELEASED baseline; M3 task/evidence files remained intact.
 - Implemented: renderer Mahayana edge restricted to Host/FeatureHost contract; direct `runtime.callTool` bypass removed; canonical call path guarded as Coordinator -> transport -> feature.execute -> AppHost -> FeatureHost -> MahayanaRuntime/provider -> HostEvent; local process execution restricted to controlled Host/ASR surfaces; kernel session resume/cancel and interrupt ownership remain canonical.
-- Acceptance: GBF-301..306 TESTED; authoritative post-rebase GitHub CI/merge/post-main still pending, so M3 remains IN_PROGRESS.
-- Next: push rebased #2007, require runtime-convergence + Mahayana fast/Host/CI green, then merge and post-main verify.
+- Acceptance: GBF-301..306 TESTED; authoritative post-rebase GitHub CI/merge/post-main still pending, so M3 remains IN_PROGRESS。
+- Next: push rebased #2007, require runtime-convergence + Mahayana fast/Host/CI green, then merge and post-main verify。
 
 ## 2026-08-24 15:34+08 / Round 12
 
@@ -92,7 +92,20 @@
 - Open-source-first: reviewed official `xai-org/grok-build` (Apache-2.0, Rust) as a current xAI agent reference; it is not a drop-in desktop Messenger implementation, so the task keeps existing Electron + Rust Mahayana Host and does not vendor a second runtime.
 - Implemented: added `desktop/public/grok-parity.css` + root surface marker to move the canonical Messenger from mixed Telegram light styling to one dark Grok/Fabushi material across sidebar, peer list, workspace, messages, composer, context panel, search/settings/Marketplace, dialogs and BotMark integration. Added packaged Playwright parity contract.
 - Runtime follow-up: `MahayanaHostProcess` now exposes structured lifecycle events/sequence for starting/running/stopped/restarting/closed/protocol-timeout conditions while preserving generation-bound request isolation; fault tests cover crash -> new generation -> restart -> close. The existing `feature.receive` pump remains the sole runtime event path and re-enters `host.request()` after failure, naturally starting a fresh generation without introducing a second daemon.
-- GitHub: PR #2098 opened from `feat/gbf-grok-parity-v1`; initial diff 7 files / +723 -13 before project-record follow-up commits.
-- Acceptance: GBF-501 = IN_PROGRESS. No completion claim: PR CI, protected merge, canonical-main packaged E2E, screenshot-level visual tuning, BotMark state integration and Release evidence remain required.
-- M3 correction: PR #2007 is verified merged (`c9bfa320...`), and its head had CI/Mahayana fast/Electron/Self-hosted Messaging/portfolio successes; historical Native mobile / embedded Codex runs on that head also had failures, so GBF-301..306 remain TESTED pending explicit post-main closure evidence rather than being falsely marked RELEASED.
-- Next: drive #2098 through CI; fix any contract regressions, then merge and continue GBF-501/502 visual-state parity plus GBF-401..407 computer-control parity.
+- GitHub: PR #2098 opened from `feat/gbf-grok-parity-v1`; initial diff 7 files / +723 -13 before project-record follow-up commits。
+- Acceptance: GBF-501 = IN_PROGRESS. No completion claim: PR CI, protected merge, canonical-main packaged E2E, screenshot-level visual tuning, BotMark state integration and Release evidence remain required。
+- M3 correction: PR #2007 is verified merged (`c9bfa320...`), and its head had CI/Mahayana fast/Electron/Self-hosted Messaging/portfolio successes; historical Native mobile / embedded Codex runs on that head also had failures, so GBF-301..306 remain TESTED pending explicit post-main closure evidence rather than being falsely marked RELEASED。
+- Next: drive #2098 through CI; fix any contract regressions, then merge and continue GBF-501/502 visual-state parity plus GBF-401..407 computer-control parity。
+
+## 2026-08-24 15:55+08 / Round 13
+
+- Task/Stage: GBF-501 / M5 visual + motion parity continuation; project-state reconciliation.
+- Merged evidence: PR #2098 merged to `main` as `eae1503d0ca06fd099535bba34b96849874ffe04`; the one-file renderer-metric calibration PR #2101 passed CI/Electron and merged as `14d79649ff1c5d45382a4046c7c42882432321c8`.
+- Visual calibration: canonical parity surface now uses the historical Grok renderer's observable material/geometry metrics rather than approximate values: `#070707/#111111/#242424/#2f2f2f/#3b3b3b`, 54px sidebar header, 68px chat header, raised active rows, 760px `#1c1c1c` composer, `#4a4a4a` user bubble and unboxed assistant content.
+- Motion implementation: branch `feat/gbf-grok-motion-parity-v1` adds a product-owned `grok-motion-parity.css` around the existing `fabushi-motion-v2` engine. Real states now have distinct outer aura/particle choreography: thinking focus, searching sweep, working/tool four-beat microcycle, speaking cadence, result confirmation bloom, error/alert two-beat warning; reduced-motion disables the additions.
+- Verification additions: `grok-motion-parity.spec.ts` asserts stylesheet/keyframe/computed-animation contract; `grok-visual-evidence.spec.ts` captures packaged 1440x900 screenshots for shell, global search, conversation and thinking BotMark into Playwright evidence so subsequent rounds can visually tune the real packaged product.
+- Existing capability reconciliation: live GitHub task/evidence and merged PRs prove M4 `GBF-401..407` were already implemented/tested via PR #2019 and M5 `GBF-502..505` via PR #2029. The WBS was stale; it is corrected to `TESTED` with current-main/post-main closure evidence explicitly still pending rather than duplicating implementations.
+- Active GitHub: PR #2102 opened with auto-merge enabled. Current head includes motion choreography, screenshot evidence and WBS/task updates; full GBF/CI/Electron/governance workflows are running.
+- Acceptance: GBF-501 remains IN_PROGRESS. Exact packaged screenshot inspection, protected merge, canonical-main package/E2E and Release proof are still required before closure.
+- Tooling blocker: DevSpace local coding connector still returns HTTP 502. Large 37KB `fabushi-motion-v2` internal edits are intentionally not performed through unsafe whole-file replacement; current safe outer choreography preserves the proven engine and keeps the path open for true fine-grained Agent phase events later.
+- Next: merge #2102 after green gates, retrieve packaged Playwright visual artifacts, inspect the actual screenshots, tune remaining visual differences, then validate current-main M4 control/reconnect/security paths and post-main Release evidence.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-501-grok-ui-parity.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-501-grok-ui-parity.md
@@ -7,7 +7,8 @@
 - **Status**: `IN_PROGRESS`
 - **Started**: `2026-08-24`
 - **Updated**: `2026-08-24`
-- **Branch**: `feat/gbf-grok-parity-v1`
+- **Active branch**: `feat/gbf-grok-motion-parity-v1`
+- **Merged rounds**: PR #2098, PR #2101
 
 ## Objective
 
@@ -32,27 +33,49 @@
 2. Sidebar, peer list, workspace, chat header, message bubbles, composer, info panel, popovers/dialogs, search/settings and marketplace surfaces share the same color/material/spacing system.
 3. Existing BotMark motion remains the only animated identity primitive and is visually integrated into the new surface.
 4. Existing functional selectors and product behavior remain intact; styling changes do not create a parallel Messenger implementation.
-5. Electron typecheck/build, Messenger/packaged Playwright and relevant governance checks pass on GitHub Actions before task closure.
-6. Task remains `IN_PROGRESS` until protected merge, canonical-main readback, packaged E2E and Release evidence are complete.
+5. Agent states `thinking/searching/working/tool-running/speaking/result/error/alerting` have visibly distinct motion choreography without replacing the authoritative `fabushi-motion-v2` SVG engine.
+6. Electron typecheck/build, Messenger/packaged Playwright and relevant governance checks pass on GitHub Actions before task closure.
+7. Task remains `IN_PROGRESS` until protected merge, canonical-main readback, packaged E2E, screenshot-level comparison and Release evidence are complete.
 
-## Implementation round 1
+## Implementation round 1 — merged PR #2098
 
-- Add a dedicated, product-owned `grok-parity.css` surface layer loaded by Electron/Vite.
-- Scope it with a root `data-fabushi-surface="grok-parity-v1"` marker so parity styling can be audited/removed independently.
-- Convert the visible Telegram light palette to a dark graphite/black material with low-contrast borders and restrained blue accent.
-- Preserve existing React components and selectors so runtime behavior is unchanged in this first visual convergence round.
+- Added dedicated product-owned `desktop/public/grok-parity.css` loaded by Electron/Vite.
+- Scoped with root `data-fabushi-surface="grok-parity-v1"` marker so parity styling can be audited/removed independently.
+- Converted visible Telegram light palette to dark graphite/black material while preserving current React/runtime behavior.
+- Added `desktop/e2e/grok-parity.spec.ts` and structured Mahayana Host lifecycle events/fault coverage in the same convergence round.
+- PR #2098 merged to canonical `main` as `eae1503d0ca06fd099535bba34b96849874ffe04`.
+
+## Implementation round 2 — merged PR #2101
+
+- Calibrated the surface to the historical Grok renderer's observable metrics rather than approximate values: `#070707/#111111/#242424/#2f2f2f/#3b3b3b`, 54px sidebar header, 68px chat header, raised active rows, 760px composer, `#1c1c1c` composer material, user `#4a4a4a` bubble and unboxed assistant content.
+- Only the Fabushi-owned parity stylesheet changed; no Grok runtime/vendor dependency was introduced.
+- PR #2101 passed PR CI/Electron gates and merged through repository automation as `14d79649ff1c5d45382a4046c7c42882432321c8`.
+
+## Implementation round 3 — active
+
+- Add `desktop/public/grok-motion-parity.css` as an outer choreography layer around the existing `fabushi-motion-v2` engine.
+- `thinking`: slow focus/breath + staggered thought particles.
+- `searching`: radar/sweep cadence.
+- `working/tool-running/writing/sending/receiving/uploading/dragging`: four-beat focus → act → settle → re-check microcycle so a long-running task is not a generic repeated pulse.
+- `speaking`: tighter voice cadence.
+- `result`: calm confirmation bloom.
+- `error/alerting`: deliberate two-beat signal instead of constant frantic motion.
+- Reduced-motion disables all added choreography.
+- Add packaged Electron Playwright CSSOM/computed-style contract proving the state selectors and keyframes are actually loaded/applied.
 
 ## Verification
 
-- Static HTML/CSS contract check: parity stylesheet is bundled from `public/` and explicitly linked from `index.html`.
-- Existing Electron/Messaging CI must typecheck/build and run packaged journeys.
-- Visual screenshot/E2E comparison will be added in follow-up GBF-501/502 rounds.
+- PR #2098: required PR CI/Electron/security/governance gates passed before merge.
+- PR #2101: CI and Electron desktop quality gate passed on head `802e8472...` before merge.
+- Round 3: GitHub Actions pending; no local heavy build is substituted for repository evidence.
+- Packaged screenshot-level comparison and exact-main Release evidence are still required for task closure.
 
 ## Blockers / risks
 
-- This round establishes the common visual substrate; exact pixel/animation parity still requires follow-up screenshot-driven tuning and BotMark state integration.
+- Current Messaging Bot execution state is coarse (`queued/running/waitingForApproval/completed/failed/cancelled`), so `running` still maps to `working`; the outer microcycle improves continuous-work expression without inventing fake backend phases. Fine-grained true Agent phase events remain a later protocol/runtime improvement.
 - Grok proprietary/vendored reference code must not become a production dependency.
+- DevSpace local editing connection returned 502 during this round, so large-engine internal edits are intentionally deferred rather than replacing a 37KB production file through an unsafe whole-file API operation.
 
 ## Next action
 
-Land the parity theme layer, then add screenshot contracts and state-driven BotMark/UI transitions before promoting GBF-501 beyond `IN_PROGRESS`.
+Merge round 3 after CI, then use canonical packaged Electron screenshots/E2E to tune any remaining layout/state differences and add true fine-grained Agent presence only from authoritative runtime events.


### PR DESCRIPTION
## FAB-P0004 / GBF — Grok parity motion round

Continues the user-requested observable Grok parity work after #2098 and #2101, while keeping Fabushi's existing `fabushi-motion-v2` SVG/spring engine and Rust Mahayana runtime canonical.

### Product changes
- add `desktop/public/grok-motion-parity.css` and load it after the calibrated `grok-parity.css`
- choreograph the already-existing BotMark aura / secondary aura / particle layers by real `data-agent-state`
- `thinking`: slow focus/breath + staggered thought particles
- `searching`: radar/sweep cadence
- `working/tool-running/writing/sending/receiving/uploading/dragging`: four-beat focus -> act -> settle -> re-check microcycle
- `speaking`: tighter voice cadence
- `result`: calm confirmation bloom
- `error/alerting`: deliberate two-beat warning
- preserve `prefers-reduced-motion` by disabling the added choreography

### Architecture / provenance
- no Grok vendor runtime/source is imported
- no second animation engine is introduced
- the existing `fabushi-motion-v2` still owns SVG physics, gaze, blink, face and accent behavior
- this layer only gives the pre-existing outer visual shells distinct state personalities

### Verification
- add packaged Electron Playwright `grok-motion-parity.spec.ts`
- assert the stylesheet/keyframes load and CSSOM/computed animation selects distinct choreography for thinking/searching/working/tool-running/speaking/result/error
- add `grok-visual-evidence.spec.ts` to attach deterministic 1440x900 packaged screenshots for shell, global search, conversation and thinking BotMark into the Playwright report/artifact
- update the canonical GBF-501 task record with merged rounds and remaining closure gates

GBF-501 remains IN_PROGRESS until protected merge, canonical-main packaged E2E, screenshot comparison and Release evidence complete.