### PR TITLE
docs(fcm-009): require main E2E screenshots and videos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,18 @@ After the task PR merges:
 6. Desktop Release assets must remain compatible with `electron-updater`. For macOS this includes the signed/notarized DMG, macOS ZIP, `latest-mac.yml`, and required blockmap/update metadata from the same build lineage. Windows/Linux updater/installable assets must likewise come from the accepted build.
 7. Every automatically published desktop build must have a monotonically increasing update-comparable version. Do not publish a changed binary under the same app version and expect installed clients to detect it.
 8. **Optional / recommended updater regression:** when useful, validate the update channel from a previous installed Release by checking that the old packaged app can discover a strictly newer stable GitHub Release, expose the update affordance beside the profile/avatar, download it, and exercise the install/relaunch path. This old-client journey is **not a default per-task or per-Release completion gate**. Run it as advisory regression, sampled release validation, or a task-specific required gate when the task itself changes updater behavior and its acceptance criteria explicitly require it.
-9. Record build run IDs, package artifacts, required E2E reports/screenshots, and Release tag/target SHA/assets in the originating task record. Record updater/upgrade evidence when that optional journey is run or when the task explicitly requires it.
+9. Record build run IDs, package artifacts, required E2E screenshots/videos/traces/reports/logs, and Release tag/target SHA/assets in the originating task record. Record updater/upgrade evidence when that optional journey is run or when the task explicitly requires it.
 10. Only after merge + canonical-main readback + required post-main E2E + verified Release evidence may that application-affecting task be marked `passed` / `completed` and reported as finished. Failure or absence of the optional old-client updater journey alone must not block an otherwise accepted task unless that task explicitly promoted the journey to a required acceptance gate.
+
+**Mandatory canonical-main E2E visual evidence contract:** every required E2E execution for a change accepted into canonical `main` must retain enough evidence to reconstruct the actual user journey, regardless of whether the test passed or failed. Failure-only evidence retention is not sufficient.
+
+- Capture detailed, step-labelled screenshots at meaningful checkpoints, including the relevant startup/onboarding/login/navigation/search/messaging/MiniApp/task-specific surfaces exercised by the journey. Do not rely on a single final screenshot when multiple meaningful actions occurred.
+- Retain a complete operation video covering the entire tested user journey. If a platform recorder imposes a duration limit, sequential segments are allowed, but together they must cover the full journey without an unexplained evidence gap.
+- Retain action/trace evidence and platform-native reports/logs where supported: Electron should keep Playwright video + screenshots + trace + HTML/test results; Android should keep emulator recording + screenshots + instrumentation results + relevant logcat/debug evidence; iOS should keep Simulator recording + screenshots + `.xcresult` + relevant crash/debug evidence.
+- Tie every evidence bundle to the exact canonical `main` SHA, app version, platform, workflow run/job, journey/test identifier, and timestamp. Artifact names must make the originating SHA/platform/run unambiguous.
+- Upload evidence on an `always()`-equivalent path so passing and failing executions both preserve evidence. Evidence capture/upload must not be skipped merely because test assertions passed.
+- Canonical-main E2E evidence should target **90-day retention** where GitHub repository/organization policy permits. If policy imposes a lower maximum, use the maximum permitted retention and record the constraint rather than silently dropping evidence early.
+- A required E2E assertion pass **without the required screenshot/video/trace/report evidence bundle is not evidentially complete** and must not satisfy the post-main completion gate. Fix the evidence pipeline and rerun against the applicable canonical `main` SHA.
 
 Build/test work for multiple accepted main SHAs may execute in parallel. Publication must be ordered safely so an older/slower run cannot replace a newer accepted Release. A newer commit must not silently erase the evidence/status of an earlier merged task; every merged task keeps an explicit post-main delivery result (`passed`, `failed`, `blocked`, or explicitly superseded with evidence).
 
@@ -202,7 +212,7 @@ The task record must include at least:
 - status;
 - implementation summary;
 - CI / E2E / security / performance / release / deployment / migration evidence when applicable;
-- post-main build/package/required-E2E/Release evidence or an objective N/A reason; optional updater journey evidence when run or when explicitly required by the task;
+- post-main build/package/required-E2E/Release evidence, including mandatory canonical-main E2E screenshots/videos/traces/reports/logs for application-affecting work, or an objective N/A reason; optional updater journey evidence when run or when explicitly required by the task;
 - blockers and risks;
 - next action;
 - started, updated, and completed timestamps.
@@ -240,12 +250,12 @@ Before saying a task is finished:
 10. Commit project-record changes to GitHub in the same task change stream when possible.
 11. Merge through required protected-main checks/merge queue.
 12. Verify canonical state on GitHub `main` after merge, including registry/project metadata parity when applicable.
-13. For application-affecting work, inspect the exact merged SHA's post-main packaged build and simulated-user E2E results. Do not reuse a different SHA's green result.
-14. If any required post-main E2E fails, keep the task `in-progress` / `blocked` / `failed`, fix it through a governed follow-up PR, merge, and repeat the post-main loop until green.
+13. For application-affecting work, inspect the exact merged SHA's post-main packaged build and simulated-user E2E results **and the required visual/debug evidence bundle**. Do not reuse a different SHA's green result or a different run's screenshots/video.
+14. If any required post-main E2E fails **or its required screenshots/video/trace/report evidence is missing**, keep the task `in-progress` / `blocked` / `failed`, fix it through a governed follow-up PR, merge, and repeat the post-main loop until green and evidentially complete.
 15. After required E2E is green, verify the GitHub Release is bound to the accepted `main` SHA, contains the required updater/installable assets, and has a strictly update-comparable version. Previous-installed-App discovery/button/download/install/relaunch evidence is optional by default and is required only when the task's own acceptance criteria explicitly promote it to a required gate.
 16. Only then mark or report that task as `passed` / `completed`. Other independently tracked tasks may proceed in parallel while any required gate is pending.
 
-If any required review/CI/merge/post-main build/E2E/release/deployment/migration/acceptance gate is pending, keep that task `in-progress`, `blocked`, or `failed` rather than marking it complete. This pending state does **not** prohibit work on other independently tracked tasks/PRs. Failure or absence of an optional updater journey does not by itself create a blocker.
+If any required review/CI/merge/post-main build/E2E/evidence/release/deployment/migration/acceptance gate is pending, keep that task `in-progress`, `blocked`, or `failed` rather than marking it complete. This pending state does **not** prohibit work on other independently tracked tasks/PRs. Failure or absence of an optional updater journey does not by itself create a blocker.
 
 ### 7. Source-of-truth precedence
 
@@ -275,7 +285,7 @@ and:
 
 When Task Orchestration is used, preserve the same immutable `FAB-Pxxxx` Project ID, Project Key, Stage ID, Task ID, requirement IDs, acceptance criteria, and evidence links in external control views. Google Sheets is a portfolio/control-plane view; for Fabushi repository work the GitHub portfolio registry/project folder and live GitHub/CI facts remain authoritative.
 
-The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass portfolio Project ID allocation, project-folder creation/reuse, task records, open-source-first research, acceptance evidence, the PR-to-main completion gate, the required post-main packaged E2E/Release gate, the optional-by-default updater-proof policy, warm-build integrity, or completion closure.
+The root `AGENTS.md` rule is repository-wide. More specific nested instructions may add requirements, but must not bypass portfolio Project ID allocation, project-folder creation/reuse, task records, open-source-first research, acceptance evidence, the PR-to-main completion gate, the required post-main packaged E2E/Release gate, the mandatory canonical-main E2E visual evidence contract, the optional-by-default updater-proof policy, warm-build integrity, or completion closure.
 
 ## CRITICAL: Local Disk Safety — Never Build or Test the App Locally
 

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009-main-e2e-release-loop.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009-main-e2e-release-loop.md
@@ -6,12 +6,14 @@
 - **Status:** in-progress
 - **Started:** 2026-08-24
 - **Updated:** 2026-08-24
-- **Branch:** `project/fcm-009-main-e2e-release-loop`
+- **Branch:** `project/fcm-009-e2e-evidence`
 - **Supersedes stale setup PR:** #2062 (same objective, older baseline)
 
 ## Objective
 
 建立仓库级持续交付闭环：每个 PR 合并到 `main` 后，立即以跨 run 缓存和同 run 产物复用进行最快安装包构建与真实用户 E2E；全部 required E2E 通过后发布绑定该 `main` SHA 的 GitHub Release，并保持 Electron Release 的版本和 updater 资产可供已安装客户端正常更新。
+
+所有 canonical `main` required E2E 必须同时产出可回溯的视觉与调试证据：详细分步骤截图、覆盖完整测试旅程的操作视频（平台有时长限制时允许分段但必须连续覆盖完整旅程）、trace/action evidence、平台原生测试报告/日志以及精确 SHA/run/platform/version 元数据。成功和失败都必须留证，不能只在失败时保留视频或截图。
 
 “上一版已安装 App 必须发现新版、显示头像旁更新按钮、点击下载/替换/重启”的真实升级旅程不再是默认强制完成门禁；它保留为可选/建议性回归，或在修改 updater 本身的高风险任务中由该任务单独提升为 required gate。
 
@@ -21,6 +23,7 @@
 
 - `source/2026-08-24-main-e2e-release-open-source-first.md`
 - `source/2026-08-24-updater-proof-optional-clarification.md` — latest clarification; supersedes only the previous mandatory old-client updater-proof interpretation.
+- `source/2026-08-24-main-e2e-visual-evidence.md` — every required canonical-main E2E must retain detailed screenshots + complete operation video + trace/report/log evidence for both pass and failure.
 - 历史相关需求：PR fast / post-main heavy、跨运行增量缓存、GitHub Release updater。
 
 ## Existing implementation reused
@@ -51,17 +54,22 @@
 8. `FCM-009.8` Add cache telemetry and warm/cold timing evidence; extend Rust hot path with compiler-result cache where safe.
 9. `FCM-009.9` Optional regression: validate update path from a previous release to the new release in automated macOS E2E. This is non-blocking by default.
 10. `FCM-009.10` Protected PR merge + required main delivery run + Release + canonical-main readback + closure records.
+11. `FCM-009.11` Mandatory visual evidence: every canonical-main required E2E retains detailed step screenshots, complete operation video, trace/action evidence, native reports/logs, and exact-SHA metadata for pass and failure; missing evidence keeps the gate incomplete.
 
 ## Acceptance criteria
 
 - Every merged PR produces a post-main delivery record for its exact SHA; no silent cancellation because a newer commit arrived.
 - Desktop + Android + iOS required simulated-user gates are green before publication.
+- Every required canonical-main E2E run, including successful runs, produces detailed step-labelled screenshots and a complete operation video. Platform recorder duration limits may be handled with sequential video segments only when the full journey remains reconstructable.
+- Electron evidence includes Playwright video + screenshots + trace + HTML/test results; Android includes emulator recording + screenshots + instrumentation results + relevant logcat/debug output; iOS includes Simulator recording + screenshots + `.xcresult` + relevant debug/crash evidence.
+- Evidence artifacts identify the exact canonical `main` SHA, app version, platform, workflow run/job and test/journey, are uploaded even on failure, and target 90-day retention where repository/organization policy permits (otherwise maximum permitted retention is used and recorded).
+- A required E2E assertion pass without its mandatory evidence bundle is not evidentially complete and must not satisfy the post-main closure gate.
 - Failed required E2E blocks Release and leaves the originating task in-progress/blocked/failed.
 - Successful required run publishes installable artifacts to GitHub Release.
 - Published desktop version is greater than the previous published desktop version and updater metadata is from the same build as the binaries.
 - Release keeps updater-compatible assets/versioning. A previous-installed-App discovery/button/download/install/relaunch journey may be run as optional regression evidence, but is not required for ordinary task/Release closure unless that task explicitly promotes it to a required risk gate.
 - Cross-run cache miss clean fallback remains correct; warm small-change runs reuse prior compile/build state.
-- Root `AGENTS.md` explicitly requires open-source-first startup and required post-main build/E2E/Release evidence before task completion, while marking old-client updater journey proof optional by default.
+- Root `AGENTS.md` explicitly requires open-source-first startup, required post-main build/E2E/Release evidence, and mandatory pass/fail visual E2E evidence before task completion, while marking old-client updater journey proof optional by default.
 - FCM-009 is not marked passed until its required work is merged and the new post-main delivery loop succeeds on canonical `main`; optional updater E2E does not block FCM-009 closure.
 
 ## Verification / evidence
@@ -69,7 +77,7 @@
 - GitHub PR / protected checks / merge queue.
 - Main SHA and workflow run IDs.
 - Electron desktop result + Native mobile result.
-- package/E2E artifacts and screenshots/reports.
+- package/E2E artifacts, detailed screenshots, full/segmented operation recordings, traces, reports, logs and exact-SHA metadata.
 - cache hit/miss + duration summaries.
 - GitHub Release tag/assets/target commit.
 - optional macOS previous-release upgrade/update evidence when run.
@@ -83,10 +91,11 @@
 - GitHub-hosted runners are ephemeral; “热重载式” means persisted content-addressed cache and artifact reuse, not an actually persistent runner process.
 - Signing/notarization secrets may block Release even when tests pass; task remains blocked rather than publishing unsigned substitutes.
 - Optional updater-journey coverage can miss a regression between dedicated updater changes; updater-specific tasks should explicitly promote that journey to required when risk warrants it.
+- Always-retained main E2E video increases artifact storage; use platform-native compression/segmentation and bounded retention without weakening replay completeness.
 
 ## Next action
 
-Continue protected-main delivery repair/optimization until required exact-main desktop/native packaged E2E and Release evidence are green; updater journey proof may run independently as optional regression and does not block closure by default.
+Implement the canonical-main visual evidence contract in root `AGENTS.md` and post-main desktop/Android/iOS workflows, then drive the protected PR to `main` and verify that a real canonical-main run retains screenshots/video/trace/report artifacts for both pass/failure paths.
 
 ## 2026-08-24 — Round 2 native shared-host blocker
 
@@ -118,3 +127,11 @@ Continue protected-main delivery repair/optimization until required exact-main d
 - This journey is therefore optional/non-blocking by default. It may still run automatically or manually for regression evidence.
 - Required post-main packaged E2E, Release publication, updater-compatible metadata/assets/versioning, signing/notarization, open-source-first, and warm-build integrity remain unchanged.
 - When a task directly changes updater behavior, that task may explicitly promote the updater journey to a required acceptance gate based on risk.
+
+## 2026-08-24 — Round 6 mandatory visual evidence clarification
+
+- User requires every E2E associated with a change merged into `main` to produce detailed screenshots and operation video for retrospective debugging.
+- Requirement persisted in `source/2026-08-24-main-e2e-visual-evidence.md`.
+- Pass/fail parity is explicit: successful E2E must keep the visual evidence too; failure-only retention is insufficient.
+- Missing required screenshots/video/trace/report evidence means the post-main E2E delivery is incomplete even if assertions passed.
+- Active implementation branch is `project/fcm-009-e2e-evidence` from current `main`.

--- a/projects/fabushi-cicd-merge-governance/source/2026-08-24-main-e2e-visual-evidence.md
+++ b/projects/fabushi-cicd-merge-governance/source/2026-08-24-main-e2e-visual-evidence.md
@@ -1,0 +1,37 @@
+# 2026-08-24 — Main post-merge E2E visual evidence requirement
+
+## Source
+
+User requirement, 2026-08-24:
+
+> 要求合并进main的E2E测试需要产出详细的截图和操作视频，方便回溯。
+
+Follow-up clarification asked whether this requirement had been written into root `AGENTS.md`.
+
+## Durable requirement
+
+For every required E2E execution associated with a change accepted into canonical `main`, visual/debug evidence is mandatory for both passing and failing journeys, not failure-only diagnostics.
+
+Required evidence:
+
+1. Detailed, step-labelled screenshots at meaningful user-journey checkpoints.
+2. A complete operation recording covering the tested journey; segmented recordings are acceptable when the platform recorder has a duration limit, but the segments together must cover the full journey.
+3. Action/trace evidence and platform-native test reports/logs where supported (for example Playwright trace/report, Android instrumentation report/logcat, iOS `.xcresult`).
+4. Metadata tying the evidence to the exact canonical `main` SHA, application version, platform, workflow run/job, test/journey name, and timestamp.
+5. Upload evidence with an `always()`-equivalent path so diagnostics survive failures as well as successes.
+6. Evidence must be retained as GitHub Actions artifacts for retrospective debugging; target 90-day retention for canonical-main E2E evidence where repository/organization retention policy permits, otherwise use the maximum permitted retention and record that constraint.
+
+A required post-main E2E gate is not considered evidentially complete if the required screenshots/video/report bundle is missing, even when the test assertions themselves passed.
+
+## Platform expectations
+
+- Electron/Desktop: retain video for every canonical-main E2E journey, detailed screenshots, Playwright trace, and HTML/test result report.
+- Android: retain emulator operation recording (segment if needed), step screenshots, instrumentation results, and relevant logcat/debug evidence.
+- iOS: retain Simulator operation recording, step screenshots, `.xcresult`, and relevant crash/debug logs.
+
+## Project mapping
+
+- Project: `FAB-P0003`
+- Project key: `FCM`
+- Task: `FCM-009`
+- This source extends the post-main delivery evidence requirements; it does not make the optional previous-installed-client updater journey mandatory.


### PR DESCRIPTION
## FAB-P0003 / FCM-009

Persist the user's post-main evidence requirement at repository scope before implementing the workflow changes.

### Changes
- Root `AGENTS.md`: every required canonical-main E2E must retain detailed step screenshots, complete operation video (segmented only when platform recorder limits require it), trace/action evidence, native reports/logs, and exact-SHA metadata for both passing and failing runs.
- Missing required visual/debug evidence keeps the post-main gate evidentially incomplete even if assertions passed.
- Target 90-day artifact retention where GitHub policy permits.
- Durable source requirement added under the FCM project.
- FCM-009 task/acceptance updated with `FCM-009.11`.

This PR intentionally establishes governance/source-of-truth first. Workflow implementation for Electron/Android/iOS evidence follows under FCM-009 and remains in-progress.