### PR TITLE
test(gbf): stabilize packaged Grok visual evidence

### DIFF
--- a/desktop/e2e/grok-visual-evidence.spec.ts
+++ b/desktop/e2e/grok-visual-evidence.spec.ts
@@ -40,9 +40,12 @@ async function completeBrowserLogin(page: Page): Promise<void> {
 }
 
 async function attachScreenshot(page: Page, name: string): Promise<void> {
-  await page.waitForTimeout(220);
+  // Visual evidence is intentionally deterministic. Motion behavior is verified
+  // separately by grok-motion-parity.spec.ts; screenshots freeze CSS animations so
+  // Xvfb/Chromium never captures an arbitrary transition frame or waits forever on
+  // continuously animated BotMark aura layers.
   await test.info().attach(name, {
-    body: await page.screenshot({ animations: 'allow', fullPage: false }),
+    body: await page.screenshot({ animations: 'disabled', fullPage: false }),
     contentType: 'image/png',
   });
 }
@@ -72,12 +75,6 @@ test('capture Grok parity packaged visual evidence', async () => {
     await page.getByTestId('messenger-send').click();
     await expect(page.getByText('收到：Grok parity visual evidence')).toBeVisible();
     await attachScreenshot(page, 'grok-parity-conversation-1440x900');
-
-    const profileMark = page.getByTestId('profile-navigation-trigger').locator('[data-engine="fabushi-motion-v2"]').first();
-    await expect(profileMark).toBeVisible();
-    await profileMark.evaluate((element) => element.setAttribute('data-agent-state', 'thinking'));
-    await page.waitForTimeout(180);
-    await attachScreenshot(page, 'grok-parity-thinking-mark-1440x900');
   } finally {
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-501-grok-ui-parity.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-501-grok-ui-parity.md
@@ -7,8 +7,9 @@
 - **Status**: `IN_PROGRESS`
 - **Started**: `2026-08-24`
 - **Updated**: `2026-08-24`
-- **Active branch**: `feat/gbf-grok-motion-parity-v1`
-- **Merged rounds**: PR #2098, PR #2101
+- **Active branch**: `fix/gbf-grok-visual-evidence`
+- **Merged rounds**: PR #2098, PR #2101, PR #2102
+- **Active repair PR**: #2104
 
 ## Objective
 
@@ -26,6 +27,7 @@
 - `xai-org/grok-build` (Apache-2.0, Rust): reviewed as a current official xAI open-source agent implementation and evidence that Rust remains compatible with the product direction. It is not a drop-in desktop Messenger/UI implementation, so this task does not vendor it.
 - Existing Fabushi React/Electron/CSS Modules and Rust Mahayana Host are reused rather than introducing a second UI/runtime framework.
 - Grok Bot production/reference assets with unclear provenance remain behavior/reference-only; production code is rewritten in Fabushi-owned files.
+- Packaged visual evidence uses Playwright's built-in deterministic animation suppression rather than custom screenshot polling/timeouts.
 
 ## Acceptance criteria
 
@@ -35,7 +37,8 @@
 4. Existing functional selectors and product behavior remain intact; styling changes do not create a parallel Messenger implementation.
 5. Agent states `thinking/searching/working/tool-running/speaking/result/error/alerting` have visibly distinct motion choreography without replacing the authoritative `fabushi-motion-v2` SVG engine.
 6. Electron typecheck/build, Messenger/packaged Playwright and relevant governance checks pass on GitHub Actions before task closure.
-7. Task remains `IN_PROGRESS` until protected merge, canonical-main readback, packaged E2E, screenshot-level comparison and Release evidence are complete.
+7. Stable packaged screenshots are produced with animations frozen for layout/material comparison; motion correctness is verified separately by the motion contract.
+8. Task remains `IN_PROGRESS` until protected merge, canonical-main readback, packaged E2E, screenshot-level comparison and Release evidence are complete.
 
 ## Implementation round 1 — merged PR #2098
 
@@ -51,9 +54,9 @@
 - Only the Fabushi-owned parity stylesheet changed; no Grok runtime/vendor dependency was introduced.
 - PR #2101 passed PR CI/Electron gates and merged through repository automation as `14d79649ff1c5d45382a4046c7c42882432321c8`.
 
-## Implementation round 3 — active
+## Implementation round 3 — merged PR #2102
 
-- Add `desktop/public/grok-motion-parity.css` as an outer choreography layer around the existing `fabushi-motion-v2` engine.
+- Added `desktop/public/grok-motion-parity.css` as an outer choreography layer around the existing `fabushi-motion-v2` engine.
 - `thinking`: slow focus/breath + staggered thought particles.
 - `searching`: radar/sweep cadence.
 - `working/tool-running/writing/sending/receiving/uploading/dragging`: four-beat focus → act → settle → re-check microcycle so a long-running task is not a generic repeated pulse.
@@ -61,21 +64,40 @@
 - `result`: calm confirmation bloom.
 - `error/alerting`: deliberate two-beat signal instead of constant frantic motion.
 - Reduced-motion disables all added choreography.
-- Add packaged Electron Playwright CSSOM/computed-style contract proving the state selectors and keyframes are actually loaded/applied.
+- Added packaged Electron CSSOM/computed-style motion contract and packaged visual-evidence test.
+- PR #2102 merged to canonical `main` as `78d6b77f67db3a96957aa91b52717e2106bed7f5`.
+
+## RC regression found after round 3
+
+The additional seven-gate RC workflow exposed a real post-merge blocker rather than allowing a false closure:
+
+- Seven-gate parent run: `32703807018`.
+- Electron workflow_dispatch child: `32703844541`.
+- Linux: the new visual-evidence screenshot timed out twice because `page.screenshot({ animations: 'allow' })` waited on continuously animated BotMark aura/particles; a separate channel-mutation journey also timed out and must be judged again after the deterministic blocker is removed.
+- Windows: the same visual-evidence screenshot timeout was the true failure; Mini App startup was flaky but passed on retry.
+- Linux diagnostics artifact `9511634437` captured arbitrary extreme motion frames, proving that increasing screenshot timeout would create poor visual evidence instead of fixing the test.
+
+## Repair round — PR #2104 active
+
+- Switch packaged visual screenshots to Playwright `animations: 'disabled'` so layout/material evidence is deterministic and cannot stall on infinite CSS animations.
+- Remove the test-only DOM mutation that forced the profile mark to `thinking`; state choreography is already verified by `grok-motion-parity.spec.ts` and should not be fabricated inside the screenshot baseline.
+- Keep shell/global-search/conversation screenshots as the stable visual comparison set.
+- Rerun full Electron/seven-gate validation; only after the introduced deterministic failure is removed will any remaining independent channel/Mini App failure be treated as a separate product/test defect.
 
 ## Verification
 
 - PR #2098: required PR CI/Electron/security/governance gates passed before merge.
 - PR #2101: CI and Electron desktop quality gate passed on head `802e8472...` before merge.
-- Round 3: GitHub Actions pending; no local heavy build is substituted for repository evidence.
+- PR #2102: merged after repository required checks, but the extra RC regression later failed as documented above; therefore GBF-501 remains explicitly open.
+- PR #2104: pending current-head CI/Electron/RC evidence.
 - Packaged screenshot-level comparison and exact-main Release evidence are still required for task closure.
 
 ## Blockers / risks
 
 - Current Messaging Bot execution state is coarse (`queued/running/waitingForApproval/completed/failed/cancelled`), so `running` still maps to `working`; the outer microcycle improves continuous-work expression without inventing fake backend phases. Fine-grained true Agent phase events remain a later protocol/runtime improvement.
 - Grok proprietary/vendored reference code must not become a production dependency.
-- DevSpace local editing connection returned 502 during this round, so large-engine internal edits are intentionally deferred rather than replacing a 37KB production file through an unsafe whole-file API operation.
+- DevSpace local editing connection returned 502 during this round, so large-engine/internal Messenger edits are intentionally deferred rather than replacing large production files through unsafe whole-file API operations.
 
 ## Next action
 
-Merge round 3 after CI, then use canonical packaged Electron screenshots/E2E to tune any remaining layout/state differences and add true fine-grained Agent presence only from authoritative runtime events.
+Drive #2104 through the full rerun. Then inspect stable packaged screenshots, tune structural/product-language differences, and only add finer Agent presence when it comes from authoritative Rust/Mahayana runtime events.


### PR DESCRIPTION
## FAB-P0004 / GBF-501 — packaged visual evidence repair

The extra seven-gate regression triggered from #2102 exposed a deterministic failure in the new visual-evidence test on both Linux/Xvfb and Windows: `page.screenshot({ animations: 'allow' })` waited 30 seconds while the page had continuously animated BotMark aura/particle layers. The Linux diagnostic artifact also captured arbitrary extreme transition frames, so extending timeouts would produce bad evidence rather than fixing the test.

### Fix
- visual evidence now uses Playwright's deterministic `animations: 'disabled'` screenshot mode
- remove the test-only DOM mutation that forced the profile mark to `thinking`; motion behavior is already covered by `grok-motion-parity.spec.ts`
- keep shell/global-search/conversation screenshots as the stable packaged visual baseline

### Evidence from failed RC run
- parent seven-gate regression: `32703807018`
- Electron workflow_dispatch child: `32703844541`
- Linux true failures: visual screenshot timeout + one channel mutation timeout; Linux diagnostics artifact `9511634437`
- Windows true failure: the same visual screenshot timeout; Mini App journey was flaky but passed on retry
- the screenshot timeout consumed ~60s with retry, so this PR fixes the introduced deterministic blocker first; remaining independent failures will be judged on the rerun rather than masked by timeout increases

GBF-501 remains IN_PROGRESS until the rerun and post-main packaged evidence are green.