### PR TITLE
feat(gbf): fuse Mahayana multi-step agent workbench into Messenger

### DIFF
--- a/desktop/e2e/mahayana-agent-workbench.spec.ts
+++ b/desktop/e2e/mahayana-agent-workbench.spec.ts
@@ -75,9 +75,7 @@ test('bot runs through Mahayana as a visible multi-step task and restores its ru
     const restoredRun = page.locator(`[data-testid="agent-run"][data-run-id="${persistedRunId}"]`);
     await expect(restoredRun).toBeVisible({ timeout: 15_000 });
     await expect(restoredRun).toHaveAttribute('data-status', 'completed');
-    await expect(restoredRun.getByTestId('agent-step')).toHaveCount(3, { timeout: 15_000 }).catch(async () => {
-      await expect.poll(async () => restoredRun.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
-    });
+    await expect.poll(async () => restoredRun.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
     await expect(restoredRun.getByTestId('agent-output')).toContainText('收到：');
   } finally {
     await app?.close().catch(() => undefined);

--- a/desktop/e2e/mahayana-agent-workbench.spec.ts
+++ b/desktop/e2e/mahayana-agent-workbench.spec.ts
@@ -1,0 +1,86 @@
+import { _electron as electron, expect, test, type ElectronApplication, type Page } from '@playwright/test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
+
+async function launchDesktopApp(appDataDir: string): Promise<ElectronApplication> {
+  return electron.launch({
+    ...(packagedExecutable
+      ? { executablePath: packagedExecutable, args: [] }
+      : { args: [appRoot] }),
+    env: {
+      ...process.env,
+      FABUSHI_APP_DATA: appDataDir,
+      FABUSHI_FEATURE_HOST_MODE: process.env.FABUSHI_FEATURE_HOST_MODE || 'test',
+      MAHAYANA_APP_HOST_BIN: process.env.MAHAYANA_APP_HOST_BIN || '',
+    },
+  });
+}
+
+async function completeBrowserLogin(page: Page): Promise<void> {
+  while (await page.getByTestId('onboarding-gate').isVisible().catch(() => false)) {
+    await page.getByTestId('onboarding-next').click();
+  }
+  const loginGate = page.getByTestId('login-gate');
+  if (await loginGate.isVisible().catch(() => false)) {
+    await page.getByTestId('browser-login-start').click();
+    await expect(loginGate).toBeHidden();
+  }
+  await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
+}
+
+async function openMahayanaConversation(page: Page): Promise<void> {
+  const peer = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+  await expect(peer).toBeVisible({ timeout: 15_000 });
+  await peer.click();
+  await expect(page.getByTestId('messenger-input')).toBeVisible();
+}
+
+test('bot runs through Mahayana as a visible multi-step task and restores its run journal', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-mahayana-workbench-'));
+  let app: ElectronApplication | null = null;
+
+  try {
+    app = await launchDesktopApp(appDataDir);
+    let page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    await openMahayanaConversation(page);
+
+    await page.getByTestId('messenger-input').fill('请分析这个任务，规划步骤，调用工具并给出最终结果。');
+    await page.getByTestId('messenger-send').click();
+
+    const workbench = page.getByTestId('agent-workbench');
+    await expect(workbench).toBeVisible({ timeout: 15_000 });
+    const run = page.getByTestId('agent-run').last();
+    await expect(run).toHaveAttribute('data-status', 'completed', { timeout: 15_000 });
+    await expect.poll(async () => run.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
+    await expect(run.getByTestId('agent-output')).toContainText('收到：');
+    await expect(page.locator('#mahayana-agent-header-avatar [data-agent-state="result"]')).toBeVisible();
+
+    const persistedRunId = await run.getAttribute('data-run-id');
+    expect(persistedRunId).toBeTruthy();
+
+    await app.close();
+    app = null;
+
+    app = await launchDesktopApp(appDataDir);
+    page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    await openMahayanaConversation(page);
+
+    const restoredRun = page.locator(`[data-testid="agent-run"][data-run-id="${persistedRunId}"]`);
+    await expect(restoredRun).toBeVisible({ timeout: 15_000 });
+    await expect(restoredRun).toHaveAttribute('data-status', 'completed');
+    await expect(restoredRun.getByTestId('agent-step')).toHaveCount(3, { timeout: 15_000 }).catch(async () => {
+      await expect.poll(async () => restoredRun.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
+    });
+    await expect(restoredRun.getByTestId('agent-output')).toContainText('收到：');
+  } finally {
+    await app?.close().catch(() => undefined);
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});

--- a/desktop/src/grok-agent-ui-parity.css
+++ b/desktop/src/grok-agent-ui-parity.css
@@ -1,0 +1,128 @@
+/* Fabushi-owned Grok-style agent workspace. No upstream renderer assets are embedded. */
+[data-testid='messenger-workspace'] {
+  --agent-surface: rgba(15, 16, 21, 0.96);
+  --agent-surface-raised: rgba(24, 25, 31, 0.9);
+  --agent-stroke: rgba(255, 255, 255, 0.075);
+  --agent-text-muted: rgba(255, 255, 255, 0.46);
+}
+
+[data-testid='messenger-workspace'] [class*='chatWorkspace'] {
+  background:
+    radial-gradient(900px 560px at 58% -16%, rgba(117, 143, 197, 0.075), transparent 62%),
+    linear-gradient(180deg, rgba(13, 14, 18, 0.995), rgba(10, 11, 14, 0.995));
+}
+
+[data-testid='messenger-workspace'] [class*='chatHeader'] {
+  min-height: 68px;
+  border-bottom-color: var(--agent-stroke);
+  background: color-mix(in srgb, var(--agent-surface) 88%, transparent);
+  backdrop-filter: blur(24px) saturate(130%);
+}
+
+[data-testid='messenger-workspace'] [class*='chatIdentity'] {
+  gap: 11px;
+}
+
+[data-testid='conversation-status'][data-mahayana-state] {
+  color: rgba(190, 213, 255, 0.7) !important;
+}
+
+[data-testid='conversation-status'][data-mahayana-state='alerting'],
+[data-testid='conversation-status'][data-mahayana-state='error'] {
+  color: rgba(255, 194, 169, 0.86) !important;
+}
+
+[data-testid='conversation-status'][data-mahayana-state='result'] {
+  color: rgba(169, 237, 198, 0.76) !important;
+}
+
+[data-testid='messenger-workspace'] [class*='messageArea'] {
+  padding: 24px clamp(14px, 3.2vw, 48px) 30px;
+  scroll-padding-bottom: 220px;
+}
+
+[data-testid='messenger-workspace'] [class*='dayDivider'] {
+  border: 1px solid rgba(255, 255, 255, 0.055);
+  background: rgba(255, 255, 255, 0.035);
+  color: rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(18px);
+}
+
+[data-testid='messenger-workspace'] [class*='messagePeer'],
+[data-testid='messenger-workspace'] [class*='messageMine'] {
+  max-width: min(760px, 86%);
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.16);
+  backdrop-filter: blur(18px);
+}
+
+[data-testid='messenger-workspace'] [class*='messagePeer'] {
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent 56%),
+    rgba(23, 24, 30, 0.78);
+}
+
+[data-testid='messenger-workspace'] [class*='messageMine'] {
+  background:
+    linear-gradient(145deg, rgba(172, 201, 255, 0.11), transparent 58%),
+    rgba(37, 43, 55, 0.82);
+}
+
+[data-testid='messenger-workspace'] [class*='messagePeer'] p,
+[data-testid='messenger-workspace'] [class*='messageMine'] p {
+  font-size: 13.5px;
+  line-height: 1.62;
+  white-space: pre-wrap;
+}
+
+[data-testid='messenger-workspace'] [class*='composer'] {
+  width: min(860px, calc(100% - 30px));
+  margin: 0 auto 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent 48%),
+    rgba(24, 25, 31, 0.92);
+  box-shadow:
+    0 22px 58px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.045);
+  backdrop-filter: blur(28px) saturate(135%);
+}
+
+[data-testid='messenger-input'] {
+  min-height: 28px;
+  max-height: 160px;
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1.5;
+}
+
+[data-testid='messenger-send'] {
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.26);
+}
+
+#mahayana-agent-header-avatar,
+#mahayana-agent-peer-avatar,
+#mahayana-agent-info-avatar {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+}
+
+#mahayana-agent-info-avatar {
+  margin: 0 auto;
+}
+
+#mahayana-agent-workbench-portal {
+  width: 100%;
+  display: block;
+}
+
+@media (max-width: 760px) {
+  [data-testid='messenger-workspace'] [class*='messageArea'] {
+    padding-inline: 10px;
+  }
+
+  [data-testid='messenger-workspace'] [class*='composer'] {
+    width: calc(100% - 18px);
+    margin-bottom: 9px;
+  }
+}

--- a/desktop/src/mahayana-agent-workbench.module.css
+++ b/desktop/src/mahayana-agent-workbench.module.css
@@ -1,0 +1,493 @@
+.portalRoot {
+  display: contents;
+}
+
+.portalAvatar {
+  flex: 0 0 auto;
+}
+
+.workbench {
+  width: min(820px, calc(100% - 36px));
+  margin: 10px auto 18px;
+  display: grid;
+  gap: 10px;
+  position: relative;
+  z-index: 2;
+}
+
+.workbench[data-empty='true'] {
+  display: none;
+}
+
+.runCard {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #ffffff 10%, transparent);
+  border-radius: 18px;
+  background:
+    linear-gradient(145deg, color-mix(in srgb, #ffffff 5%, transparent), transparent 42%),
+    color-mix(in srgb, #101116 94%, transparent);
+  box-shadow:
+    0 18px 50px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(28px) saturate(130%);
+  color: rgba(255, 255, 255, 0.92);
+  transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.runCard:hover,
+.runCard[open] {
+  border-color: color-mix(in srgb, #ffffff 18%, transparent);
+  box-shadow:
+    0 22px 66px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.runSummary {
+  min-height: 62px;
+  padding: 10px 13px;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto 18px;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.runSummary::-webkit-details-marker {
+  display: none;
+}
+
+.runAvatar {
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.32));
+}
+
+.runIdentity {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.runIdentity strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13.5px;
+  letter-spacing: -0.01em;
+}
+
+.runIdentity small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.54);
+  font-size: 11.5px;
+}
+
+.runStatus {
+  min-width: 58px;
+  padding: 5px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(255, 255, 255, 0.68);
+  text-align: center;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.runStatus[data-status='running'],
+.runStatus[data-status='queued'] {
+  border-color: color-mix(in srgb, #9cc7ff 34%, transparent);
+  color: #cfe3ff;
+}
+
+.runStatus[data-status='waiting-for-approval'] {
+  border-color: color-mix(in srgb, #ffc76b 42%, transparent);
+  color: #ffe0a8;
+}
+
+.runStatus[data-status='completed'] {
+  border-color: color-mix(in srgb, #80e2ae 34%, transparent);
+  color: #baf5d2;
+}
+
+.runStatus[data-status='failed'] {
+  border-color: color-mix(in srgb, #ff7f8d 36%, transparent);
+  color: #ffbbc2;
+}
+
+.chevron {
+  color: rgba(255, 255, 255, 0.34);
+  transition: transform 180ms ease;
+}
+
+.runCard[open] .chevron {
+  transform: rotate(180deg);
+}
+
+.runBody {
+  padding: 0 14px 13px;
+  display: grid;
+  gap: 11px;
+  border-top: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+.runMeta {
+  padding-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.runMeta span {
+  min-height: 24px;
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 10.5px;
+}
+
+.prompt,
+.agentOutput {
+  padding: 10px 11px;
+  display: grid;
+  gap: 5px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.prompt span,
+.agentOutput > strong {
+  color: rgba(255, 255, 255, 0.44);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.prompt p,
+.agentOutput p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.timeline {
+  display: grid;
+  padding: 3px 0;
+}
+
+.step {
+  min-height: 44px;
+  display: grid;
+  grid-template-columns: 23px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: start;
+  position: relative;
+}
+
+.stepRail {
+  min-height: 44px;
+  display: grid;
+  justify-items: center;
+  color: rgba(255, 255, 255, 0.48);
+  position: relative;
+}
+
+.stepRail::after {
+  width: 1px;
+  height: calc(100% - 19px);
+  content: '';
+  position: absolute;
+  top: 19px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.step:last-child .stepRail::after {
+  display: none;
+}
+
+.step[data-status='completed'] .stepRail {
+  color: #89deb0;
+}
+
+.step[data-status='failed'] .stepRail {
+  color: #ff8f9a;
+}
+
+.stepCopy {
+  min-width: 0;
+  padding-bottom: 10px;
+  display: grid;
+  gap: 3px;
+}
+
+.stepCopy strong {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.stepCopy small {
+  overflow-wrap: anywhere;
+  color: rgba(255, 255, 255, 0.44);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.step time {
+  padding-top: 1px;
+  color: rgba(255, 255, 255, 0.26);
+  font-size: 9px;
+}
+
+.progress {
+  width: min(240px, 100%);
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.progress i {
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+  background: currentColor;
+  transition: width 180ms ease;
+}
+
+.approval {
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  gap: 9px;
+  border: 1px solid color-mix(in srgb, #ffc76b 26%, transparent);
+  border-radius: 13px;
+  background: color-mix(in srgb, #6f4e14 15%, transparent);
+  color: #ffe1ac;
+}
+
+.approval > div {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.approval strong {
+  font-size: 12px;
+}
+
+.approval p,
+.approval small {
+  margin: 0;
+  color: rgba(255, 232, 190, 0.68);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.approval code {
+  padding: 6px 8px;
+  overflow-wrap: anywhere;
+  border-radius: 7px;
+  background: rgba(0, 0, 0, 0.2);
+  color: rgba(255, 238, 207, 0.82);
+  font-size: 10px;
+}
+
+.approvalActions,
+.runActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.approvalActions button,
+.runActions button,
+.clearHistory {
+  min-height: 28px;
+  padding: 5px 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.76);
+  font: inherit;
+  font-size: 10.5px;
+  cursor: pointer;
+}
+
+.approvalActions button:hover,
+.runActions button:hover,
+.clearHistory:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.observations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.observations > span {
+  min-height: 28px;
+  padding: 5px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.035);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 10px;
+}
+
+.observations b {
+  font-weight: 600;
+}
+
+.observations small {
+  color: rgba(255, 255, 255, 0.34);
+}
+
+.artifact {
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.artifact > div {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.artifact strong {
+  font-size: 11.5px;
+}
+
+.artifact pre,
+.toolResult pre {
+  max-height: 240px;
+  margin: 0;
+  padding: 8px;
+  overflow: auto;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.2);
+  color: rgba(255, 255, 255, 0.56);
+  font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  white-space: pre-wrap;
+}
+
+.toolResult {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.toolResult summary {
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: rgba(255, 255, 255, 0.68);
+  cursor: pointer;
+}
+
+.toolResult summary strong {
+  font-size: 10.5px;
+}
+
+.toolResult summary span {
+  color: rgba(255, 255, 255, 0.38);
+  font-size: 10px;
+}
+
+.toolResult pre {
+  border-radius: 0 0 10px 10px;
+}
+
+.runError,
+.bridgeError {
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid color-mix(in srgb, #ff7f8d 24%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, #762733 14%, transparent);
+  color: #ffc0c6;
+  font-size: 10.5px;
+}
+
+.runFooter {
+  padding-top: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 9.5px;
+}
+
+.clearHistory {
+  width: max-content;
+  margin-left: auto;
+  opacity: 0.62;
+}
+
+.spin {
+  animation: mahayana-agent-spin 900ms linear infinite;
+}
+
+@keyframes mahayana-agent-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 760px) {
+  .workbench {
+    width: calc(100% - 20px);
+    margin-bottom: 12px;
+  }
+
+  .runSummary {
+    grid-template-columns: 40px minmax(0, 1fr) auto;
+  }
+
+  .chevron {
+    display: none;
+  }
+
+  .runMeta {
+    gap: 4px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .runCard,
+  .chevron,
+  .progress i,
+  .spin {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/desktop/src/mahayana-agent-workbench.tsx
+++ b/desktop/src/mahayana-agent-workbench.tsx
@@ -1,0 +1,1351 @@
+import {
+  Bot,
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  Clock3,
+  Cpu,
+  FileText,
+  LoaderCircle,
+  PauseCircle,
+  Play,
+  RotateCcw,
+  ShieldAlert,
+  Square,
+  Terminal,
+  XCircle,
+} from 'lucide-react';
+import React, { useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  BotMark,
+  botMarkStateFromActivity,
+  type BotMarkState,
+} from '../../frontend/apps/web/src/app/host/bot-mark';
+import type {
+  ApprovalResolution,
+  CommandAccepted,
+  RuntimeCommand,
+  RuntimeEvent,
+  TranscriptCard,
+} from '../../frontend/apps/web/src/lib/mahayana-host/contracts';
+import {
+  MAHAYANA_COMMAND_EVENT_NAME,
+  MAHAYANA_RUNTIME_EVENT_NAME,
+  type MahayanaCommandBridgeContext,
+  type MahayanaCommandBridgeDetail,
+} from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
+import styles from './mahayana-agent-workbench.module.css';
+
+const STORAGE_KEY = 'fabushi.desktop.mahayana-agent-workbench.v1';
+const SNAPSHOT_VERSION = 1;
+const MAX_RUNS = 64;
+const MAX_STEPS_PER_RUN = 160;
+const MAX_MESSAGES_PER_RUN = 80;
+const MAX_CARDS_PER_RUN = 32;
+const MAX_OBSERVATIONS_PER_RUN = 40;
+const MAX_TOOL_RESULTS_PER_RUN = 24;
+
+export type AgentRunStatus =
+  | 'queued'
+  | 'running'
+  | 'waiting-for-approval'
+  | 'completed'
+  | 'failed'
+  | 'interrupted';
+
+export type AgentStepProjection = {
+  id: string;
+  kind: string;
+  title: string;
+  detail?: string;
+  status: 'running' | 'completed' | 'failed';
+  progress?: number;
+  total?: number;
+  startedAtMs: number;
+  updatedAtMs: number;
+};
+
+export type AgentMessageProjection = {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+  operationId?: string;
+  streaming?: boolean;
+  createdAtMs: number;
+};
+
+export type AgentApprovalProjection = {
+  approvalId: string;
+  miniAppId: string;
+  capability: string;
+  reason: string;
+  kind?: string;
+  subject?: string;
+  detail?: string;
+  proposedRule?: string;
+  location?: string;
+  decision?: ApprovalResolution['decision'];
+  requestedAtMs: number;
+};
+
+export type AgentCardProjection = {
+  id: string;
+  card: TranscriptCard;
+  createdAtMs: number;
+};
+
+export type AgentObservationProjection = {
+  id: string;
+  label: string;
+  status?: string;
+  detail?: string;
+  kind: 'subagent' | 'async-task' | 'background';
+};
+
+export type AgentToolResultProjection = {
+  id: string;
+  server: string;
+  tool: string;
+  result: unknown;
+  createdAtMs: number;
+};
+
+export type AgentUsageProjection = {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+  contextWindow?: number;
+};
+
+export type AgentRunProjection = {
+  id: string;
+  requestId?: string;
+  operationId?: string;
+  conversationKey: string;
+  conversationId?: string;
+  agentId: string;
+  prompt: string;
+  label: string;
+  status: AgentRunStatus;
+  interruptible: boolean;
+  visualState: BotMarkState;
+  provider?: string;
+  model?: string;
+  mode?: string;
+  steps: AgentStepProjection[];
+  messages: AgentMessageProjection[];
+  approvals: AgentApprovalProjection[];
+  cards: AgentCardProjection[];
+  observations: AgentObservationProjection[];
+  toolResults: AgentToolResultProjection[];
+  usage?: AgentUsageProjection;
+  error?: string;
+  startedAtMs: number;
+  updatedAtMs: number;
+  completedAtMs?: number;
+};
+
+export type AgentWorkbenchSnapshot = {
+  version: 1;
+  activeConversationKey: string;
+  knownBotIds: string[];
+  runs: AgentRunProjection[];
+};
+
+type WorkbenchAction =
+  | { type: 'bridge-command'; detail: MahayanaCommandBridgeDetail }
+  | { type: 'runtime-event'; event: RuntimeEvent }
+  | { type: 'set-active-conversation'; conversationKey: string }
+  | { type: 'clear-history' };
+
+type PortalTargets = {
+  timeline: HTMLElement | null;
+  headerAvatar: HTMLElement | null;
+  peerAvatar: HTMLElement | null;
+  infoAvatar: HTMLElement | null;
+};
+
+const EMPTY_TARGETS: PortalTargets = {
+  timeline: null,
+  headerAvatar: null,
+  peerAvatar: null,
+  infoAvatar: null,
+};
+
+function nowFromTimestamp(timestamp?: string): number {
+  if (!timestamp) return Date.now();
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function bounded<T>(items: T[], limit: number): T[] {
+  return items.length > limit ? items.slice(items.length - limit) : items;
+}
+
+function cloneRun(run: AgentRunProjection): AgentRunProjection {
+  return {
+    ...run,
+    steps: run.steps.map((step) => ({ ...step })),
+    messages: run.messages.map((message) => ({ ...message })),
+    approvals: run.approvals.map((approval) => ({ ...approval })),
+    cards: run.cards.map((card) => ({ ...card })),
+    observations: run.observations.map((item) => ({ ...item })),
+    toolResults: run.toolResults.map((item) => ({ ...item })),
+    usage: run.usage ? { ...run.usage } : undefined,
+  };
+}
+
+function cloneSnapshot(snapshot: AgentWorkbenchSnapshot): AgentWorkbenchSnapshot {
+  return {
+    ...snapshot,
+    knownBotIds: [...snapshot.knownBotIds],
+    runs: snapshot.runs.map(cloneRun),
+  };
+}
+
+function emptySnapshot(): AgentWorkbenchSnapshot {
+  return {
+    version: SNAPSHOT_VERSION,
+    activeConversationKey: 'mahayana-assistant',
+    knownBotIds: ['mahayana-assistant'],
+    runs: [],
+  };
+}
+
+function normalizeLoadedSnapshot(value: unknown): AgentWorkbenchSnapshot {
+  if (!value || typeof value !== 'object') return emptySnapshot();
+  const candidate = value as Partial<AgentWorkbenchSnapshot>;
+  if (candidate.version !== SNAPSHOT_VERSION || !Array.isArray(candidate.runs)) {
+    return emptySnapshot();
+  }
+
+  const loadedAt = Date.now();
+  const runs = candidate.runs
+    .filter((run): run is AgentRunProjection => Boolean(run && typeof run === 'object' && run.id))
+    .map((run) => {
+      const copied = cloneRun({
+        ...run,
+        steps: Array.isArray(run.steps) ? run.steps : [],
+        messages: Array.isArray(run.messages) ? run.messages : [],
+        approvals: Array.isArray(run.approvals) ? run.approvals : [],
+        cards: Array.isArray(run.cards) ? run.cards : [],
+        observations: Array.isArray(run.observations) ? run.observations : [],
+        toolResults: Array.isArray(run.toolResults) ? run.toolResults : [],
+      });
+      if (['queued', 'running', 'waiting-for-approval'].includes(copied.status)) {
+        copied.status = 'interrupted';
+        copied.visualState = 'idle';
+        copied.interruptible = false;
+        copied.error = copied.error || '应用重新启动后任务已暂停，可从运行卡片继续。';
+        copied.updatedAtMs = loadedAt;
+        copied.steps = copied.steps.map((step) =>
+          step.status === 'running'
+            ? { ...step, status: 'failed', updatedAtMs: loadedAt }
+            : step,
+        );
+      }
+      return copied;
+    });
+
+  return {
+    version: SNAPSHOT_VERSION,
+    activeConversationKey:
+      typeof candidate.activeConversationKey === 'string' && candidate.activeConversationKey
+        ? candidate.activeConversationKey
+        : 'mahayana-assistant',
+    knownBotIds: Array.isArray(candidate.knownBotIds)
+      ? Array.from(new Set(['mahayana-assistant', ...candidate.knownBotIds.filter((id): id is string => typeof id === 'string')]))
+      : ['mahayana-assistant'],
+    runs: bounded(runs, MAX_RUNS),
+  };
+}
+
+function loadSnapshot(): AgentWorkbenchSnapshot {
+  if (typeof window === 'undefined') return emptySnapshot();
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return value ? normalizeLoadedSnapshot(JSON.parse(value)) : emptySnapshot();
+  } catch {
+    return emptySnapshot();
+  }
+}
+
+function conversationKeyFromContext(
+  command: RuntimeCommand,
+  context?: MahayanaCommandBridgeContext,
+): string {
+  if (context?.conversationKey) return context.conversationKey;
+  if (command.type === 'chat.send') {
+    return command.conversationId || command.agentId || 'mahayana-assistant';
+  }
+  if (command.type === 'conversation.open') return command.conversationId;
+  return 'mahayana-assistant';
+}
+
+function createRunFromCommand(
+  command: Extract<RuntimeCommand, { type: 'chat.send' }>,
+  context?: MahayanaCommandBridgeContext,
+): AgentRunProjection {
+  const now = Date.now();
+  const conversationKey = conversationKeyFromContext(command, context);
+  return {
+    id: `request:${command.requestId}`,
+    requestId: command.requestId,
+    conversationKey,
+    conversationId: command.conversationId || context?.conversationId,
+    agentId: command.agentId || context?.agentId || 'mahayana-assistant',
+    prompt: command.text,
+    label: 'Mahayana Agent 运行',
+    status: 'queued',
+    interruptible: false,
+    visualState: 'waking',
+    provider: undefined,
+    model: command.model,
+    mode: command.mode || 'agent',
+    steps: [
+      {
+        id: `request:${command.requestId}:accepted`,
+        kind: 'plan',
+        title: 'Mahayana 已接管任务',
+        detail: '正在建立上下文并规划执行步骤',
+        status: 'running',
+        startedAtMs: now,
+        updatedAtMs: now,
+      },
+    ],
+    messages: [
+      {
+        id: `request:${command.requestId}:user`,
+        role: 'user',
+        text: command.text,
+        createdAtMs: now,
+      },
+    ],
+    approvals: [],
+    cards: [],
+    observations: [],
+    toolResults: [],
+    startedAtMs: now,
+    updatedAtMs: now,
+  };
+}
+
+function activeStatuses(status: AgentRunStatus): boolean {
+  return status === 'queued' || status === 'running' || status === 'waiting-for-approval';
+}
+
+function findRunIndex(
+  snapshot: AgentWorkbenchSnapshot,
+  operationId?: string,
+  requestId?: string,
+): number {
+  if (operationId) {
+    const exact = snapshot.runs.findIndex((run) => run.operationId === operationId);
+    if (exact >= 0) return exact;
+  }
+  if (requestId) {
+    const exact = snapshot.runs.findIndex((run) => run.requestId === requestId);
+    if (exact >= 0) return exact;
+  }
+  for (let index = snapshot.runs.length - 1; index >= 0; index -= 1) {
+    const run = snapshot.runs[index];
+    if (run.conversationKey === snapshot.activeConversationKey && activeStatuses(run.status)) return index;
+  }
+  for (let index = snapshot.runs.length - 1; index >= 0; index -= 1) {
+    if (activeStatuses(snapshot.runs[index].status)) return index;
+  }
+  return -1;
+}
+
+function ensureRunForOperation(
+  snapshot: AgentWorkbenchSnapshot,
+  operationId: string | undefined,
+  timestampMs: number,
+): number {
+  const existing = findRunIndex(snapshot, operationId);
+  if (existing >= 0) {
+    if (operationId && !snapshot.runs[existing].operationId) {
+      snapshot.runs[existing].operationId = operationId;
+    }
+    return existing;
+  }
+
+  const run: AgentRunProjection = {
+    id: operationId ? `operation:${operationId}` : `orphan:${timestampMs}`,
+    operationId,
+    conversationKey: snapshot.activeConversationKey || 'mahayana-assistant',
+    agentId: 'mahayana-assistant',
+    prompt: '',
+    label: 'Mahayana Agent 运行',
+    status: 'running',
+    interruptible: true,
+    visualState: 'thinking',
+    steps: [],
+    messages: [],
+    approvals: [],
+    cards: [],
+    observations: [],
+    toolResults: [],
+    startedAtMs: timestampMs,
+    updatedAtMs: timestampMs,
+  };
+  snapshot.runs.push(run);
+  return snapshot.runs.length - 1;
+}
+
+function upsertStep(
+  run: AgentRunProjection,
+  step: Omit<AgentStepProjection, 'startedAtMs' | 'updatedAtMs'>,
+  timestampMs: number,
+): void {
+  const existing = run.steps.findIndex((item) => item.id === step.id);
+  if (existing >= 0) {
+    run.steps[existing] = {
+      ...run.steps[existing],
+      ...step,
+      updatedAtMs: timestampMs,
+    };
+  } else {
+    run.steps.push({
+      ...step,
+      startedAtMs: timestampMs,
+      updatedAtMs: timestampMs,
+    });
+  }
+  run.steps = bounded(run.steps, MAX_STEPS_PER_RUN);
+}
+
+function completeBootstrapStep(run: AgentRunProjection, timestampMs: number): void {
+  const bootstrap = run.steps.find((step) => step.id.endsWith(':accepted'));
+  if (bootstrap?.status === 'running') {
+    bootstrap.status = 'completed';
+    bootstrap.updatedAtMs = timestampMs;
+  }
+}
+
+function observationFromUnknown(
+  value: unknown,
+  index: number,
+  kind: AgentObservationProjection['kind'],
+): AgentObservationProjection {
+  const record = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+  const id = String(record.id || record.operationId || record.taskId || `${kind}:${index}`);
+  const label = String(record.name || record.label || record.title || record.agentName || id);
+  const status = typeof record.status === 'string' ? record.status : undefined;
+  const detailValue = record.detail || record.description || record.source;
+  return {
+    id,
+    label,
+    status,
+    detail: typeof detailValue === 'string' ? detailValue : undefined,
+    kind,
+  };
+}
+
+function updateAssistantDelta(run: AgentRunProjection, operationId: string, delta: string, timestampMs: number): void {
+  let message = [...run.messages]
+    .reverse()
+    .find((item) => item.role === 'assistant' && item.operationId === operationId && item.streaming);
+  if (!message) {
+    message = {
+      id: `stream:${operationId}`,
+      role: 'assistant',
+      text: '',
+      operationId,
+      streaming: true,
+      createdAtMs: timestampMs,
+    };
+    run.messages.push(message);
+  }
+  message.text += delta;
+  run.messages = bounded(run.messages, MAX_MESSAGES_PER_RUN);
+}
+
+function appendChatMessage(
+  run: AgentRunProjection,
+  event: Extract<RuntimeEvent, { type: 'chat.message' }>,
+  timestampMs: number,
+): void {
+  if (event.role === 'user') {
+    if (run.messages.some((item) => item.role === 'user' && item.text === event.text)) return;
+    run.messages.push({
+      id: `message:user:${timestampMs}`,
+      role: 'user',
+      text: event.text,
+      operationId: event.operationId,
+      createdAtMs: timestampMs,
+    });
+  } else {
+    const streaming = [...run.messages]
+      .reverse()
+      .find((item) => item.role === 'assistant' && item.operationId === event.operationId && item.streaming);
+    if (streaming) {
+      streaming.text = event.text || streaming.text;
+      streaming.streaming = false;
+    } else if (!run.messages.some((item) => item.role === 'assistant' && item.text === event.text)) {
+      run.messages.push({
+        id: `message:assistant:${event.operationId || timestampMs}`,
+        role: 'assistant',
+        text: event.text,
+        operationId: event.operationId,
+        createdAtMs: timestampMs,
+      });
+    }
+  }
+  run.messages = bounded(run.messages, MAX_MESSAGES_PER_RUN);
+}
+
+function projectCommand(
+  snapshot: AgentWorkbenchSnapshot,
+  detail: MahayanaCommandBridgeDetail,
+): AgentWorkbenchSnapshot {
+  const next = cloneSnapshot(snapshot);
+  const command = detail.command;
+  const conversationKey = conversationKeyFromContext(command, detail.context);
+  if (command.type === 'conversation.open') {
+    next.activeConversationKey = conversationKey;
+    return next;
+  }
+  if (command.type !== 'chat.send') return next;
+
+  next.activeConversationKey = conversationKey;
+  if (detail.phase === 'dispatch') {
+    const existing = findRunIndex(next, undefined, command.requestId);
+    if (existing < 0) next.runs.push(createRunFromCommand(command, detail.context));
+  } else if (detail.phase === 'accepted') {
+    const index = findRunIndex(next, detail.accepted.operationId, command.requestId);
+    const target = index >= 0 ? index : ensureRunForOperation(next, detail.accepted.operationId, Date.now());
+    const run = next.runs[target];
+    run.operationId = detail.accepted.operationId || run.operationId;
+    run.status = detail.accepted.operationId ? 'running' : run.status;
+    run.interruptible = Boolean(detail.accepted.operationId);
+    run.visualState = 'thinking';
+    run.updatedAtMs = Date.now();
+    completeBootstrapStep(run, run.updatedAtMs);
+  } else {
+    const index = findRunIndex(next, undefined, command.requestId);
+    if (index >= 0) {
+      const run = next.runs[index];
+      run.status = 'failed';
+      run.visualState = 'error';
+      run.error = detail.error;
+      run.interruptible = false;
+      run.updatedAtMs = Date.now();
+      run.completedAtMs = run.updatedAtMs;
+      completeBootstrapStep(run, run.updatedAtMs);
+    }
+  }
+  next.runs = bounded(next.runs, MAX_RUNS);
+  return next;
+}
+
+function projectRuntimeEvent(
+  snapshot: AgentWorkbenchSnapshot,
+  event: RuntimeEvent,
+): AgentWorkbenchSnapshot {
+  const next = cloneSnapshot(snapshot);
+  const timestampMs = nowFromTimestamp(event.timestamp);
+
+  if (event.type === 'conversation.opened') {
+    next.activeConversationKey = event.conversationId;
+    return next;
+  }
+  if (event.type === 'bot.listed') {
+    next.knownBotIds = Array.from(new Set(['mahayana-assistant', ...event.bots.map((bot) => bot.id)]));
+    return next;
+  }
+  if (event.type === 'bot.changed') {
+    const ids = new Set(next.knownBotIds);
+    if (event.action === 'deleted') ids.delete(event.bot.id);
+    else ids.add(event.bot.id);
+    next.knownBotIds = Array.from(ids);
+    return next;
+  }
+  if (event.type === 'host.closed') {
+    next.runs.forEach((run) => {
+      if (!activeStatuses(run.status)) return;
+      run.status = 'interrupted';
+      run.visualState = 'idle';
+      run.interruptible = false;
+      run.error = run.error || 'Mahayana Host 已关闭，任务可以恢复。';
+      run.updatedAtMs = timestampMs;
+    });
+    return next;
+  }
+
+  if (event.type === 'operation.started') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.operationId = event.operationId;
+    run.label = event.label || run.label;
+    run.status = 'running';
+    run.interruptible = event.interruptible;
+    run.visualState = 'thinking';
+    run.updatedAtMs = timestampMs;
+    completeBootstrapStep(run, timestampMs);
+    upsertStep(run, {
+      id: `${event.operationId}:runtime-start`,
+      kind: 'runtime',
+      title: '运行已启动',
+      detail: event.label,
+      status: 'running',
+    }, timestampMs);
+  } else if (event.type === 'model.routed') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.provider = event.provider;
+    run.model = event.model;
+    run.mode = event.mode;
+    run.status = 'running';
+    run.visualState = 'thinking';
+    run.updatedAtMs = timestampMs;
+    completeBootstrapStep(run, timestampMs);
+    upsertStep(run, {
+      id: `${event.operationId}:model-route`,
+      kind: 'model',
+      title: `模型路由 · ${event.provider}`,
+      detail: `${event.model} · ${event.mode}`,
+      status: 'completed',
+    }, timestampMs);
+  } else if (event.type === 'agent.step') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.status = event.status === 'failed' ? 'failed' : 'running';
+    run.visualState = event.status === 'failed'
+      ? 'error'
+      : botMarkStateFromActivity({ kind: event.kind, title: event.title, detail: event.detail });
+    run.updatedAtMs = timestampMs;
+    if (event.status === 'failed') run.error = event.detail || event.title;
+    completeBootstrapStep(run, timestampMs);
+    const runtimeStart = run.steps.find((step) => step.id.endsWith(':runtime-start'));
+    if (runtimeStart?.status === 'running') {
+      runtimeStart.status = 'completed';
+      runtimeStart.updatedAtMs = timestampMs;
+    }
+    upsertStep(run, {
+      id: event.stepId,
+      kind: event.kind,
+      title: event.title,
+      detail: event.detail,
+      status: event.status,
+      progress: event.progress,
+      total: event.total,
+    }, timestampMs);
+  } else if (event.type === 'chat.delta') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.status = 'running';
+    run.visualState = 'speaking';
+    run.updatedAtMs = timestampMs;
+    updateAssistantDelta(run, event.operationId, event.delta, timestampMs);
+  } else if (event.type === 'chat.message') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    appendChatMessage(run, event, timestampMs);
+    run.updatedAtMs = timestampMs;
+    if (event.role === 'assistant') run.visualState = 'speaking';
+  } else if (event.type === 'transcript.card') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    if (!run.cards.some((item) => item.id === event.entryId)) {
+      run.cards.push({ id: event.entryId, card: event.card, createdAtMs: timestampMs });
+      run.cards = bounded(run.cards, MAX_CARDS_PER_RUN);
+    }
+    run.visualState = botMarkStateFromActivity({ kind: event.card.kind, title: event.card.kind });
+    run.updatedAtMs = timestampMs;
+  } else if (event.type === 'mcp.toolResult') {
+    const index = ensureRunForOperation(next, undefined, timestampMs);
+    const run = next.runs[index];
+    run.toolResults.push({
+      id: `mcp:${event.server}:${event.tool}:${timestampMs}`,
+      server: event.server,
+      tool: event.tool,
+      result: event.result,
+      createdAtMs: timestampMs,
+    });
+    run.toolResults = bounded(run.toolResults, MAX_TOOL_RESULTS_PER_RUN);
+    run.visualState = 'tool-running';
+    run.updatedAtMs = timestampMs;
+  } else if (event.type === 'approval.requested') {
+    const index = ensureRunForOperation(next, undefined, timestampMs);
+    const run = next.runs[index];
+    if (!run.approvals.some((item) => item.approvalId === event.approvalId)) {
+      run.approvals.push({
+        approvalId: event.approvalId,
+        miniAppId: event.miniAppId,
+        capability: event.capability,
+        reason: event.reason,
+        kind: event.kind,
+        subject: event.subject,
+        detail: event.detail,
+        proposedRule: event.proposedRule,
+        location: event.location,
+        requestedAtMs: timestampMs,
+      });
+    }
+    run.status = 'waiting-for-approval';
+    run.visualState = 'alerting';
+    run.updatedAtMs = timestampMs;
+  } else if (event.type === 'approval.resolved') {
+    const run = next.runs.find((item) => item.approvals.some((approval) => approval.approvalId === event.approvalId));
+    if (run) {
+      const approval = run.approvals.find((item) => item.approvalId === event.approvalId);
+      if (approval) approval.decision = event.decision;
+      const pending = run.approvals.some((item) => !item.decision);
+      run.status = pending ? 'waiting-for-approval' : 'running';
+      run.visualState = pending ? 'alerting' : 'thinking';
+      run.updatedAtMs = timestampMs;
+    }
+  } else if (event.type === 'usage.updated') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.usage = {
+      inputTokens: event.inputTokens,
+      cachedInputTokens: event.cachedInputTokens,
+      outputTokens: event.outputTokens,
+      reasoningTokens: event.reasoningTokens,
+      totalTokens: event.totalTokens,
+      contextWindow: event.contextWindow,
+    };
+    run.updatedAtMs = timestampMs;
+    if (run.provider === 'mahayana-test' && run.messages.some((message) => message.role === 'assistant')) {
+      run.status = 'completed';
+      run.visualState = 'result';
+      run.interruptible = false;
+      run.completedAtMs = timestampMs;
+      run.steps.forEach((step) => {
+        if (step.status === 'running') {
+          step.status = 'completed';
+          step.updatedAtMs = timestampMs;
+        }
+      });
+    }
+  } else if (event.type === 'subagent.listed' || event.type === 'subagent.changed') {
+    const index = ensureRunForOperation(next, undefined, timestampMs);
+    const run = next.runs[index];
+    const values = event.type === 'subagent.listed' ? event.subagents : [event.subagent];
+    const incoming = values.map((value, itemIndex) => observationFromUnknown(value, itemIndex, 'subagent'));
+    const byId = new Map(run.observations.map((item) => [item.id, item]));
+    incoming.forEach((item) => byId.set(item.id, item));
+    run.observations = bounded(Array.from(byId.values()), MAX_OBSERVATIONS_PER_RUN);
+    run.visualState = 'spawning';
+    run.updatedAtMs = timestampMs;
+  } else if (event.type === 'asyncTask.listed' || event.type === 'asyncTask.changed') {
+    const index = ensureRunForOperation(next, undefined, timestampMs);
+    const run = next.runs[index];
+    const incoming = event.tasks.map((value, itemIndex) => observationFromUnknown(value, itemIndex, 'async-task'));
+    const retained = run.observations.filter((item) => item.kind !== 'async-task');
+    run.observations = bounded([...retained, ...incoming], MAX_OBSERVATIONS_PER_RUN);
+    run.visualState = incoming.length ? 'orbit' : run.visualState;
+    run.updatedAtMs = timestampMs;
+  } else if (event.type === 'agent.backgroundStarted') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.agentId = event.agentId;
+    run.status = 'running';
+    run.visualState = 'orbit';
+    run.observations.push({
+      id: `background:${event.operationId}`,
+      label: event.agentName,
+      status: 'running',
+      detail: event.source,
+      kind: 'background',
+    });
+    run.observations = bounded(run.observations, MAX_OBSERVATIONS_PER_RUN);
+    run.updatedAtMs = timestampMs;
+  } else if (event.type === 'agent.backgroundDelta' || event.type === 'agent.backgroundMessage') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    const text = event.type === 'agent.backgroundDelta' ? event.delta : event.text;
+    updateAssistantDelta(run, event.operationId, text, timestampMs);
+    run.visualState = 'receiving';
+    run.updatedAtMs = timestampMs;
+  } else if (event.type === 'agent.backgroundFinished') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    const observation = run.observations.find((item) => item.id === `background:${event.operationId}`);
+    if (observation) observation.status = event.error ? 'failed' : 'completed';
+    run.updatedAtMs = timestampMs;
+    if (event.error) {
+      run.status = 'failed';
+      run.visualState = 'error';
+      run.error = event.error;
+    }
+  } else if (event.type === 'operation.completed') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.status = 'completed';
+    run.visualState = 'result';
+    run.interruptible = false;
+    run.completedAtMs = timestampMs;
+    run.updatedAtMs = timestampMs;
+    run.steps.forEach((step) => {
+      if (step.status === 'running') {
+        step.status = 'completed';
+        step.updatedAtMs = timestampMs;
+      }
+    });
+  } else if (event.type === 'operation.failed') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.status = 'failed';
+    run.visualState = 'error';
+    run.interruptible = false;
+    run.error = `${event.code}: ${event.message}`;
+    run.completedAtMs = timestampMs;
+    run.updatedAtMs = timestampMs;
+    run.steps.forEach((step) => {
+      if (step.status === 'running') {
+        step.status = 'failed';
+        step.updatedAtMs = timestampMs;
+      }
+    });
+  } else if (event.type === 'operation.interrupted') {
+    const index = ensureRunForOperation(next, event.operationId, timestampMs);
+    const run = next.runs[index];
+    run.status = 'interrupted';
+    run.visualState = 'idle';
+    run.interruptible = false;
+    run.completedAtMs = timestampMs;
+    run.updatedAtMs = timestampMs;
+    run.steps.forEach((step) => {
+      if (step.status === 'running') {
+        step.status = 'failed';
+        step.updatedAtMs = timestampMs;
+      }
+    });
+  }
+
+  next.runs = bounded(next.runs, MAX_RUNS);
+  return next;
+}
+
+export function agentWorkbenchReducer(
+  snapshot: AgentWorkbenchSnapshot,
+  action: WorkbenchAction,
+): AgentWorkbenchSnapshot {
+  if (action.type === 'bridge-command') return projectCommand(snapshot, action.detail);
+  if (action.type === 'runtime-event') return projectRuntimeEvent(snapshot, action.event);
+  if (action.type === 'set-active-conversation') {
+    if (!action.conversationKey || action.conversationKey === snapshot.activeConversationKey) return snapshot;
+    return { ...snapshot, activeConversationKey: action.conversationKey };
+  }
+  return { ...emptySnapshot(), knownBotIds: snapshot.knownBotIds };
+}
+
+function conversationKeyFromPeerTestId(testId: string): string {
+  const key = testId.replace(/^peer-/, '');
+  if (key.startsWith('legacy:conversation:')) return key.slice('legacy:conversation:'.length);
+  return key;
+}
+
+function activePeerButton(): HTMLButtonElement | null {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('button[data-testid^="peer-"]'))
+    .find((button) => button.className.includes('peerActive')) || null;
+}
+
+function activePeerContext(): { peerKey: string; kind: string; actorId: string } | null {
+  const button = activePeerButton();
+  const testId = button?.getAttribute('data-testid');
+  if (!button || !testId) return null;
+  const status = document.querySelector<HTMLElement>('[data-testid="conversation-status"]');
+  const identity = status?.parentElement?.parentElement;
+  const mark = identity?.querySelector<HTMLElement>('[data-bot-id^="peer:"]');
+  const botId = mark?.dataset.botId;
+  if (!botId) return null;
+  const parts = botId.split(':');
+  return {
+    peerKey: conversationKeyFromPeerTestId(testId),
+    kind: parts[1] || '',
+    actorId: parts.slice(2).join(':') || 'mahayana-assistant',
+  };
+}
+
+function emitCommandDetail(detail: MahayanaCommandBridgeDetail): void {
+  window.dispatchEvent(new CustomEvent<MahayanaCommandBridgeDetail>(MAHAYANA_COMMAND_EVENT_NAME, { detail }));
+}
+
+async function executeAgentCommand(
+  command: Extract<RuntimeCommand, { type: 'chat.send' }>,
+  context: MahayanaCommandBridgeContext,
+): Promise<CommandAccepted> {
+  if (!window.mahayana?.invoke) throw new Error('Mahayana Electron bridge is unavailable');
+  const normalized: Extract<RuntimeCommand, { type: 'chat.send' }> = {
+    ...command,
+    mode: 'agent',
+  };
+  emitCommandDetail({ phase: 'dispatch', command: normalized, context });
+  try {
+    const accepted = await window.mahayana.invoke<CommandAccepted>('feature.execute', { command: normalized });
+    emitCommandDetail({ phase: 'accepted', command: normalized, accepted, context });
+    return accepted;
+  } catch (error) {
+    emitCommandDetail({
+      phase: 'failed',
+      command: normalized,
+      error: error instanceof Error ? error.message : String(error),
+      context,
+    });
+    throw error;
+  }
+}
+
+function requestId(prefix: string): string {
+  const random = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `${prefix}-${random}`;
+}
+
+function statusLabel(status: AgentRunStatus): string {
+  const labels: Record<AgentRunStatus, string> = {
+    queued: '准备中',
+    running: '执行中',
+    'waiting-for-approval': '等待批准',
+    completed: '已完成',
+    failed: '失败',
+    interrupted: '已暂停',
+  };
+  return labels[status];
+}
+
+function statusLine(run: AgentRunProjection): string {
+  const running = [...run.steps].reverse().find((step) => step.status === 'running');
+  if (run.status === 'waiting-for-approval') return '等待你批准下一步';
+  if (run.status === 'completed') return '任务已完成';
+  if (run.status === 'failed') return run.error || '任务执行失败';
+  if (run.status === 'interrupted') return '任务已暂停，可继续';
+  return running?.title || 'Mahayana 正在规划和执行';
+}
+
+function formatDuration(run: AgentRunProjection): string {
+  const end = run.completedAtMs || Date.now();
+  const seconds = Math.max(0, Math.round((end - run.startedAtMs) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function jsonPreview(value: unknown): string {
+  try {
+    const text = JSON.stringify(value, null, 2);
+    return text.length > 1800 ? `${text.slice(0, 1800)}\n…` : text;
+  } catch {
+    return String(value);
+  }
+}
+
+function transcriptCardTitle(card: TranscriptCard): string {
+  switch (card.kind) {
+    case 'emailDraft': return '邮件草稿';
+    case 'slackDraft': return 'Slack 草稿';
+    case 'secretRequest': return card.label;
+    case 'listenerConnect': return `连接 ${card.platform}`;
+    case 'event': return card.event.title;
+    case 'pdf': return card.name;
+    case 'spreadsheet': return card.name;
+  }
+}
+
+function StepIcon({ status }: { status: AgentStepProjection['status'] }) {
+  if (status === 'completed') return <CheckCircle2 size={15} />;
+  if (status === 'failed') return <XCircle size={15} />;
+  return <LoaderCircle className={styles.spin} size={15} />;
+}
+
+function RunCard({
+  run,
+  latest,
+  onInterrupt,
+  onResolveApproval,
+  onResume,
+}: {
+  run: AgentRunProjection;
+  latest: boolean;
+  onInterrupt: (run: AgentRunProjection) => void;
+  onResolveApproval: (approvalId: string, decision: ApprovalResolution['decision']) => void;
+  onResume: (run: AgentRunProjection) => void;
+}) {
+  const assistantMessages = run.messages.filter((message) => message.role === 'assistant' && message.text.trim());
+  const canResume = Boolean(run.prompt && (run.status === 'failed' || run.status === 'interrupted'));
+  return (
+    <details
+      className={styles.runCard}
+      data-testid="agent-run"
+      data-run-id={run.id}
+      data-status={run.status}
+      open={latest || activeStatuses(run.status)}
+    >
+      <summary className={styles.runSummary}>
+        <BotMark
+          botId={`workbench:${run.agentId}`}
+          state={run.visualState}
+          size={38}
+          className={styles.runAvatar}
+          label={run.agentId}
+        />
+        <span className={styles.runIdentity}>
+          <strong>{run.label}</strong>
+          <small>{statusLine(run)}</small>
+        </span>
+        <span className={styles.runStatus} data-status={run.status}>{statusLabel(run.status)}</span>
+        <ChevronDown className={styles.chevron} size={16} />
+      </summary>
+
+      <div className={styles.runBody}>
+        <div className={styles.runMeta}>
+          <span><Cpu size={13} />{run.provider || 'mahayana'}{run.model ? ` / ${run.model}` : ''}</span>
+          <span><Clock3 size={13} />{formatDuration(run)}</span>
+          <span><Bot size={13} />{run.mode || 'agent'}</span>
+        </div>
+
+        {run.prompt ? <div className={styles.prompt}><span>任务</span><p>{run.prompt}</p></div> : null}
+
+        {run.steps.length ? (
+          <div className={styles.timeline} data-testid="agent-step-timeline">
+            {run.steps.map((step) => (
+              <div className={styles.step} data-testid="agent-step" data-status={step.status} data-kind={step.kind} key={step.id}>
+                <span className={styles.stepRail}><StepIcon status={step.status} /></span>
+                <span className={styles.stepCopy}>
+                  <strong>{step.title}</strong>
+                  {step.detail ? <small>{step.detail}</small> : null}
+                  {typeof step.progress === 'number' && typeof step.total === 'number' && step.total > 0 ? (
+                    <span className={styles.progress} aria-label={`${step.progress}/${step.total}`}>
+                      <i style={{ width: `${Math.min(100, Math.max(0, (step.progress / step.total) * 100))}%` }} />
+                    </span>
+                  ) : null}
+                </span>
+                <time>{new Date(step.updatedAtMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        {run.approvals.map((approval) => (
+          <section className={styles.approval} data-testid="agent-approval" key={approval.approvalId}>
+            <ShieldAlert size={20} />
+            <div>
+              <strong>{approval.subject || approval.capability}</strong>
+              <p>{approval.detail || approval.reason}</p>
+              {approval.proposedRule ? <code>{approval.proposedRule}</code> : null}
+              {approval.decision ? <small>已处理：{approval.decision}</small> : (
+                <span className={styles.approvalActions}>
+                  <button type="button" onClick={() => onResolveApproval(approval.approvalId, 'allow-once')}>仅本次允许</button>
+                  <button type="button" onClick={() => onResolveApproval(approval.approvalId, 'allow-session')}>本次会话允许</button>
+                  <button type="button" onClick={() => onResolveApproval(approval.approvalId, 'deny')}>拒绝</button>
+                </span>
+              )}
+            </div>
+          </section>
+        ))}
+
+        {run.observations.length ? (
+          <div className={styles.observations}>
+            {run.observations.map((item) => (
+              <span key={`${item.kind}:${item.id}`} data-kind={item.kind}>
+                {item.kind === 'subagent' ? <Bot size={14} /> : item.kind === 'async-task' ? <Terminal size={14} /> : <Circle size={12} />}
+                <b>{item.label}</b>
+                {item.status ? <small>{item.status}</small> : null}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {run.cards.map((item) => (
+          <section className={styles.artifact} data-testid="agent-artifact" key={item.id}>
+            <FileText size={18} />
+            <div><strong>{transcriptCardTitle(item.card)}</strong><pre>{jsonPreview(item.card)}</pre></div>
+          </section>
+        ))}
+
+        {run.toolResults.map((item) => (
+          <details className={styles.toolResult} data-testid="agent-tool-result" key={item.id}>
+            <summary><Terminal size={15} /><strong>{item.server}</strong><span>{item.tool}</span></summary>
+            <pre>{jsonPreview(item.result)}</pre>
+          </details>
+        ))}
+
+        {assistantMessages.length ? (
+          <div className={styles.agentOutput} data-testid="agent-output">
+            <strong>结果</strong>
+            {assistantMessages.map((message) => <p key={message.id}>{message.text}</p>)}
+          </div>
+        ) : null}
+
+        {run.error ? <div className={styles.runError}><XCircle size={16} /><span>{run.error}</span></div> : null}
+
+        <footer className={styles.runFooter}>
+          <span>{run.usage ? `${run.usage.totalTokens.toLocaleString()} tokens` : 'Mahayana runtime'}</span>
+          <span className={styles.runActions}>
+            {run.interruptible && run.operationId && activeStatuses(run.status) ? (
+              <button type="button" data-testid="agent-stop" onClick={() => onInterrupt(run)}><Square size={13} />停止</button>
+            ) : null}
+            {canResume ? (
+              <button type="button" data-testid="agent-resume" onClick={() => onResume(run)}><RotateCcw size={13} />继续任务</button>
+            ) : null}
+          </span>
+        </footer>
+      </div>
+    </details>
+  );
+}
+
+function ensurePortalRoot(id: string, parent: HTMLElement | null, before?: Element | null): HTMLElement | null {
+  const existing = document.getElementById(id);
+  if (!parent) {
+    existing?.remove();
+    return null;
+  }
+  const root = existing || document.createElement('div');
+  root.id = id;
+  root.className = styles.portalRoot;
+  if (root.parentElement !== parent) {
+    if (before) parent.insertBefore(root, before);
+    else parent.appendChild(root);
+  }
+  return root;
+}
+
+function directChildBotMark(parent: HTMLElement): HTMLElement | null {
+  return Array.from(parent.children).find((child) =>
+    child instanceof HTMLElement && child.dataset.engine === 'fabushi-motion-v2',
+  ) as HTMLElement | null;
+}
+
+export default function MahayanaAgentWorkbench() {
+  const [snapshot, dispatch] = useReducer(agentWorkbenchReducer, undefined, loadSnapshot);
+  const [targets, setTargets] = useState<PortalTargets>(EMPTY_TARGETS);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const snapshotRef = useRef(snapshot);
+  const hiddenMarksRef = useRef(new Map<HTMLElement, string>());
+  snapshotRef.current = snapshot;
+
+  useEffect(() => {
+    const onCommand = (event: Event) => {
+      const detail = (event as CustomEvent<MahayanaCommandBridgeDetail>).detail;
+      if (detail) dispatch({ type: 'bridge-command', detail });
+    };
+    const onRuntime = (event: Event) => {
+      const detail = (event as CustomEvent<RuntimeEvent>).detail;
+      if (detail) dispatch({ type: 'runtime-event', event: detail });
+    };
+    window.addEventListener(MAHAYANA_COMMAND_EVENT_NAME, onCommand);
+    window.addEventListener(MAHAYANA_RUNTIME_EVENT_NAME, onRuntime);
+    return () => {
+      window.removeEventListener(MAHAYANA_COMMAND_EVENT_NAME, onCommand);
+      window.removeEventListener(MAHAYANA_RUNTIME_EVENT_NAME, onRuntime);
+    };
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+    } catch (error) {
+      console.warn('Failed to persist Mahayana agent workbench', error);
+    }
+  }, [snapshot]);
+
+  useEffect(() => {
+    let disposed = false;
+    const hideOriginal = (element: HTMLElement | null) => {
+      if (!element || hiddenMarksRef.current.has(element)) return;
+      hiddenMarksRef.current.set(element, element.style.display);
+      element.style.display = 'none';
+      element.dataset.mahayanaAvatarReplaced = 'true';
+    };
+
+    const refresh = () => {
+      if (disposed) return;
+      const workspace = document.querySelector<HTMLElement>('[data-testid="messenger-workspace"]');
+      const messageArea = workspace?.querySelector<HTMLElement>('[class*="messageArea"]') || null;
+      const timeline = ensurePortalRoot('mahayana-agent-workbench-portal', messageArea);
+
+      const status = workspace?.querySelector<HTMLElement>('[data-testid="conversation-status"]') || null;
+      const identity = status?.parentElement?.parentElement instanceof HTMLElement
+        ? status.parentElement.parentElement
+        : null;
+      const identityOriginal = identity ? directChildBotMark(identity) : null;
+      const headerAvatar = ensurePortalRoot('mahayana-agent-header-avatar', identity, identityOriginal);
+      hideOriginal(identityOriginal);
+
+      const activeButton = activePeerButton();
+      const peerOriginal = activeButton ? directChildBotMark(activeButton) : null;
+      const peerAvatar = ensurePortalRoot('mahayana-agent-peer-avatar', activeButton, peerOriginal);
+      hideOriginal(peerOriginal);
+
+      const profileCard = workspace?.querySelector<HTMLElement>('aside [class*="profileCard"]') || null;
+      const infoOriginal = profileCard ? directChildBotMark(profileCard) : null;
+      const infoAvatar = ensurePortalRoot('mahayana-agent-info-avatar', profileCard, infoOriginal);
+      hideOriginal(infoOriginal);
+
+      const peerTestId = activeButton?.getAttribute('data-testid');
+      if (peerTestId) {
+        const conversationKey = conversationKeyFromPeerTestId(peerTestId);
+        if (conversationKey && snapshotRef.current.activeConversationKey !== conversationKey) {
+          dispatch({ type: 'set-active-conversation', conversationKey });
+        }
+      }
+
+      setTargets((current) =>
+        current.timeline === timeline &&
+        current.headerAvatar === headerAvatar &&
+        current.peerAvatar === peerAvatar &&
+        current.infoAvatar === infoAvatar
+          ? current
+          : { timeline, headerAvatar, peerAvatar, infoAvatar },
+      );
+    };
+
+    const observer = new MutationObserver(refresh);
+    observer.observe(document.body, { childList: true, subtree: true });
+    const interval = window.setInterval(refresh, 500);
+    refresh();
+    return () => {
+      disposed = true;
+      observer.disconnect();
+      window.clearInterval(interval);
+      ['mahayana-agent-workbench-portal', 'mahayana-agent-header-avatar', 'mahayana-agent-peer-avatar', 'mahayana-agent-info-avatar']
+        .forEach((id) => document.getElementById(id)?.remove());
+      hiddenMarksRef.current.forEach((display, element) => {
+        element.style.display = display;
+        delete element.dataset.mahayanaAvatarReplaced;
+      });
+      hiddenMarksRef.current.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    const onSubmitCapture = (event: Event) => {
+      const form = event.target instanceof HTMLFormElement ? event.target : null;
+      const input = form?.querySelector<HTMLTextAreaElement>('[data-testid="messenger-input"]');
+      if (!form || !input) return;
+      const peer = activePeerContext();
+      const activeButton = activePeerButton();
+      const activeTestId = activeButton?.getAttribute('data-testid') || '';
+      if (!peer || !activeTestId.startsWith('peer-selfhosted:')) return;
+      if (!['bot', 'agent'].includes(peer.kind.toLowerCase())) return;
+      const text = input.value.trim();
+      if (!text) return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      setter?.call(input, '');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      const knownBotIds = snapshotRef.current.knownBotIds;
+      const agentId = knownBotIds.includes(peer.actorId) ? peer.actorId : 'mahayana-assistant';
+      const command: Extract<RuntimeCommand, { type: 'chat.send' }> = {
+        type: 'chat.send',
+        requestId: requestId('selfhosted-agent'),
+        text,
+        agentId,
+        mode: 'agent',
+      };
+      void executeAgentCommand(command, {
+        conversationKey: peer.peerKey,
+        agentId,
+      }).catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+    };
+
+    document.addEventListener('submit', onSubmitCapture, true);
+    return () => document.removeEventListener('submit', onSubmitCapture, true);
+  }, []);
+
+  const visibleRuns = useMemo(() => {
+    const exact = snapshot.runs.filter((run) => run.conversationKey === snapshot.activeConversationKey);
+    return bounded(exact, 6);
+  }, [snapshot.activeConversationKey, snapshot.runs]);
+
+  const activeRun = visibleRuns.length
+    ? visibleRuns[visibleRuns.length - 1]
+    : [...snapshot.runs].reverse().find((run) => activeStatuses(run.status));
+  const avatarState = activeRun?.visualState || 'idle';
+  const avatarBotId = activeRun?.agentId || 'mahayana-assistant';
+
+  useEffect(() => {
+    const status = document.querySelector<HTMLElement>('[data-testid="conversation-status"]');
+    if (!status) return;
+    if (!status.dataset.mahayanaOriginalText) status.dataset.mahayanaOriginalText = status.textContent || '';
+    if (activeRun) {
+      status.textContent = statusLine(activeRun);
+      status.dataset.mahayanaState = avatarState;
+    } else if (status.dataset.mahayanaOriginalText) {
+      status.textContent = status.dataset.mahayanaOriginalText;
+      delete status.dataset.mahayanaState;
+    }
+  }, [activeRun, avatarState]);
+
+  const interrupt = (run: AgentRunProjection) => {
+    if (!run.operationId || !window.mahayana?.invoke) return;
+    setActionError(null);
+    void window.mahayana.invoke<void>('feature.interrupt', { operationId: run.operationId })
+      .catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+  };
+
+  const resolveApproval = (approvalId: string, decision: ApprovalResolution['decision']) => {
+    if (!window.mahayana?.invoke) return;
+    setActionError(null);
+    void window.mahayana.invoke<void>('feature.approval.resolve', {
+      resolution: { approvalId, decision },
+    }).catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+  };
+
+  const resume = (run: AgentRunProjection) => {
+    setActionError(null);
+    const command: Extract<RuntimeCommand, { type: 'chat.send' }> = {
+      type: 'chat.send',
+      requestId: requestId('resume-agent'),
+      text: run.prompt,
+      agentId: run.agentId,
+      conversationId: run.conversationId,
+      mode: 'agent',
+    };
+    void executeAgentCommand(command, {
+      conversationKey: run.conversationKey,
+      conversationId: run.conversationId,
+      agentId: run.agentId,
+    }).catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+  };
+
+  const panel = (
+    <section className={styles.workbench} data-testid="agent-workbench" data-empty={!visibleRuns.length || undefined}>
+      {actionError ? <div className={styles.bridgeError}><XCircle size={14} />{actionError}</div> : null}
+      {visibleRuns.map((run, index) => (
+        <RunCard
+          key={run.id}
+          run={run}
+          latest={index === visibleRuns.length - 1}
+          onInterrupt={interrupt}
+          onResolveApproval={resolveApproval}
+          onResume={resume}
+        />
+      ))}
+      {visibleRuns.length > 1 ? (
+        <button className={styles.clearHistory} type="button" onClick={() => dispatch({ type: 'clear-history' })}>
+          <PauseCircle size={13} />清理运行历史
+        </button>
+      ) : null}
+    </section>
+  );
+
+  return (
+    <>
+      {targets.timeline && visibleRuns.length ? createPortal(panel, targets.timeline) : null}
+      {targets.headerAvatar ? createPortal(
+        <BotMark botId={`header:${avatarBotId}`} state={avatarState} size={40} className={styles.portalAvatar} label={avatarBotId} />,
+        targets.headerAvatar,
+      ) : null}
+      {targets.peerAvatar ? createPortal(
+        <BotMark botId={`peer-active:${avatarBotId}`} state={avatarState} size={48} className={styles.portalAvatar} label={avatarBotId} />,
+        targets.peerAvatar,
+      ) : null}
+      {targets.infoAvatar ? createPortal(
+        <BotMark botId={`info:${avatarBotId}`} state={avatarState} size={92} className={styles.portalAvatar} label={avatarBotId} />,
+        targets.infoAvatar,
+      ) : null}
+    </>
+  );
+}

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,7 +1,9 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import DesktopShellV2 from './messaging-shell-v2';
+import MahayanaAgentWorkbench from './mahayana-agent-workbench';
 import './messenger-layout-regressions.css';
+import './grok-agent-ui-parity.css';
 
 const root = document.querySelector<HTMLDivElement>('#root');
 if (!root) {
@@ -11,5 +13,6 @@ if (!root) {
 createRoot(root).render(
   <StrictMode>
     <DesktopShellV2 />
+    <MahayanaAgentWorkbench />
   </StrictMode>,
 );

--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -48,6 +48,34 @@ declare global {
 
 const ELECTRON_EDGE_CONTRACT_VERSION = 1;
 
+export const MAHAYANA_RUNTIME_EVENT_NAME = "fabushi:mahayana-runtime-event";
+export const MAHAYANA_COMMAND_EVENT_NAME = "fabushi:mahayana-command";
+
+export type MahayanaCommandBridgeContext = {
+  conversationKey?: string;
+  conversationId?: string;
+  agentId?: string;
+};
+
+export type MahayanaCommandBridgeDetail =
+  | {
+      phase: "dispatch";
+      command: RuntimeCommand;
+      context?: MahayanaCommandBridgeContext;
+    }
+  | {
+      phase: "accepted";
+      command: RuntimeCommand;
+      accepted: CommandAccepted;
+      context?: MahayanaCommandBridgeContext;
+    }
+  | {
+      phase: "failed";
+      command: RuntimeCommand;
+      error: string;
+      context?: MahayanaCommandBridgeContext;
+    };
+
 const idle = (milliseconds = 10) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
@@ -72,6 +100,41 @@ function miniAppIdForConversation(conversation: { id: string; title: string }): 
   const cleanId = conversation.id.trim();
   const namespaced = cleanId.match(/(?:^|:)([a-z0-9][a-z0-9-]*)$/i)?.[1];
   return namespaced || cleanId;
+}
+
+function bridgeContextForCommand(command: RuntimeCommand): MahayanaCommandBridgeContext | undefined {
+  if (command.type === "chat.send") {
+    const conversationKey = command.conversationId || command.agentId || "mahayana-assistant";
+    return {
+      conversationKey,
+      conversationId: command.conversationId,
+      agentId: command.agentId || "mahayana-assistant",
+    };
+  }
+  if (command.type === "conversation.open") {
+    return {
+      conversationKey: command.conversationId,
+      conversationId: command.conversationId,
+    };
+  }
+  return undefined;
+}
+
+function normalizeAgentCommand(command: RuntimeCommand): RuntimeCommand {
+  if (command.type !== "chat.send") return command;
+  return {
+    ...command,
+    mode: "agent",
+  };
+}
+
+function dispatchWindowBridgeEvent<T>(name: string, detail: T): void {
+  if (typeof window === "undefined" || typeof window.dispatchEvent !== "function") return;
+  window.dispatchEvent(new CustomEvent<T>(name, { detail }));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function isElectronMahayanaHostAvailable(): boolean {
@@ -125,20 +188,54 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     return info;
   }
 
-  execute(command: RuntimeCommand): Promise<CommandAccepted> {
-    if (command.type === "conversation.open") {
-      const miniAppId = this.miniAppConversations.get(command.conversationId);
-      if (miniAppId) {
-        return mahayanaBridge().invoke<CommandAccepted>("feature.execute", {
-          command: {
-            type: "miniapp.open",
-            requestId: command.requestId,
-            miniAppId,
-          },
+  async execute(command: RuntimeCommand): Promise<CommandAccepted> {
+    const normalizedCommand = normalizeAgentCommand(command);
+    const context = bridgeContextForCommand(normalizedCommand);
+    dispatchWindowBridgeEvent<MahayanaCommandBridgeDetail>(MAHAYANA_COMMAND_EVENT_NAME, {
+      phase: "dispatch",
+      command: normalizedCommand,
+      context,
+    });
+
+    try {
+      let accepted: CommandAccepted;
+      if (normalizedCommand.type === "conversation.open") {
+        const miniAppId = this.miniAppConversations.get(normalizedCommand.conversationId);
+        if (miniAppId) {
+          accepted = await mahayanaBridge().invoke<CommandAccepted>("feature.execute", {
+            command: {
+              type: "miniapp.open",
+              requestId: normalizedCommand.requestId,
+              miniAppId,
+            },
+          });
+        } else {
+          accepted = await mahayanaBridge().invoke<CommandAccepted>("feature.execute", {
+            command: normalizedCommand,
+          });
+        }
+      } else {
+        accepted = await mahayanaBridge().invoke<CommandAccepted>("feature.execute", {
+          command: normalizedCommand,
         });
       }
+
+      dispatchWindowBridgeEvent<MahayanaCommandBridgeDetail>(MAHAYANA_COMMAND_EVENT_NAME, {
+        phase: "accepted",
+        command: normalizedCommand,
+        accepted,
+        context,
+      });
+      return accepted;
+    } catch (error) {
+      dispatchWindowBridgeEvent<MahayanaCommandBridgeDetail>(MAHAYANA_COMMAND_EVENT_NAME, {
+        phase: "failed",
+        command: normalizedCommand,
+        error: errorMessage(error),
+        context,
+      });
+      throw error;
     }
-    return mahayanaBridge().invoke<CommandAccepted>("feature.execute", { command });
   }
 
   marketplaceBrowse(query?: string): Promise<MarketplaceBrowseResult> {
@@ -256,6 +353,11 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     this.miniAppConversations.clear();
   }
 
+  private dispatchToListeners(event: RuntimeEvent): void {
+    dispatchWindowBridgeEvent<RuntimeEvent>(MAHAYANA_RUNTIME_EVENT_NAME, event);
+    for (const listener of this.listeners) listener(event);
+  }
+
   private dispatchEvent(event: RuntimeEvent): void {
     if (event.type === "conversation.listed") {
       const messengerConversations = event.conversations.filter((conversation) => {
@@ -270,10 +372,10 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
         ...event,
         conversations: messengerConversations,
       };
-      for (const listener of this.listeners) listener(normalizedEvent);
+      this.dispatchToListeners(normalizedEvent);
       return;
     }
-    for (const listener of this.listeners) listener(event);
+    this.dispatchToListeners(event);
   }
 
   private attachRuntimeEvents(): void {

--- a/projects/grok-bot-fabushi-integration/evidence/GBF-507/README.md
+++ b/projects/grok-bot-fabushi-integration/evidence/GBF-507/README.md
@@ -1,0 +1,57 @@
+# GBF-507 Evidence Index
+
+## Source requirement
+
+- `projects/grok-bot-fabushi-integration/source/grok-bot融合优化.txt`
+- `projects/grok-bot-fabushi-integration/source/完整telegram融合进fabushi.txt`
+- User continuation on 2026-08-25: complete Grok-style UI/behavior fusion, route Bot work through Mahayana multi-step runtime, persist conversations/runs, and drive the dynamic avatar from real execution state.
+
+## Reference and provenance
+
+- Reference repository: `bhrum/grok-bot-0.18-reconstructed`
+- Pinned reference commit: `a9f633e09d49a85829b8236331b9e21f7e612634`
+- Reuse decision: clean-room observable behavior / API adaptation only. No production renderer, installer payload, vendor visual asset, trademarked product identity, or unlicensed source is copied into Fabushi.
+
+## Branch and pull request
+
+- Branch: `feat/gbf-mahayana-agent-workbench-v1`
+- PR: `#2108` — `feat(gbf): fuse Mahayana multi-step agent workbench into Messenger`
+
+## Implementation commits
+
+| Commit | Evidence |
+|---|---|
+| `01071e5519ea58940c431f1e658c158f39f4a8ec` | Mahayana command/runtime event bridge and forced Agent mode |
+| `4a4c0e42c315dc8fc4e31bb842ec46b6025416c4` | Persistent Agent Workbench reducer, actions, runtime projection and dynamic avatar wiring |
+| `cae27b7b4672513ed8ed8d94701e2ac328f1caef` | Workbench timeline/approval/tool/artifact UI |
+| `4cf3fdff56402e1e27de5a0888861e22fde2875a` | Fabushi-owned Grok-style conversation material |
+| `006a84583e9e75c056070aa07338d0c891c6cc47` | Canonical desktop mount |
+| `9b119a853ddf89223de4cb55ad5b5d98aa2d5f97` | Multi-step and restart Playwright journey |
+| `1ceca38d8e33c7f30480491bb274f7a4c34dd3fc` | Stable restored-run assertion |
+
+## Acceptance evidence captured so far
+
+Initial code head `9b119a853ddf89223de4cb55ad5b5d98aa2d5f97`:
+
+- Electron desktop quality gate run `32797695610`: **success**.
+  - canonical application architecture: success
+  - Feature Host bridge contract: success
+  - lightweight architecture/UI contracts: success
+  - Electron main-process contracts: success
+  - Renderer TypeScript: success
+- Host fast E2E run `32797695647`: **success**.
+- Messaging Product Gate Electron Messenger contract: **success**.
+- Final branch head and canonical-main acceptance remain pending because task/project evidence commits changed the head after the initial checks.
+
+## Required final evidence
+
+- [ ] Required PR checks successful on exact final head
+- [ ] Protected merge commit
+- [ ] Canonical-main `mahayana-agent-workbench.spec.ts`
+- [ ] Packaged macOS/Windows/Linux Electron journey where required by release pipeline
+- [ ] Screenshot/video/trace artifacts showing planning, multiple steps, final result and avatar state changes
+- [ ] Post-main file/behavior verification
+
+## Truthfulness note
+
+This index records implementation and currently observed checks only. It is not a release-completion claim. `GBF-507` remains `IN_PROGRESS` until the final evidence checklist is complete.

--- a/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md
@@ -40,8 +40,9 @@
 | GBF-504 | M5 | 动画性能与无障碍 | GBF-503 | offscreen/reduced-motion/预算可验证 | perf + accessibility tests | evidence/GBF-504 | TESTED | post-main closure records stale | verify current-main motion/energy regression |
 | GBF-505 | M5 | 移除生产 Grok 视觉/runtime 依赖 | GBF-501..504 | production dependency audit clean | dependency/source audit | evidence/GBF-505 | TESTED | final provenance audit pending | keep all parity code Fabushi-owned |
 | GBF-506 | M5 | Router/usage/local sandbox 设置 parity | GBF-106,307,308,408 | 设置布局、持久化、状态和错误反馈与基准等效 | packaged screenshot/video/trace E2E | evidence/GBF-506 | RELEASED | none | GBF-805 final parity closure |
-| GBF-601 | M6 | canonical data model 映射 | GBF-104,302 | 无长期重复会话/tool/permission model | schema review/migration test | evidence/GBF-601 | NOT_STARTED | M3 closure evidence stale | 建 schema map |
-| GBF-602 | M6 | crash/restart 恢复 | GBF-304,601 | 关键状态可恢复且无重复副作用 | fault injection | evidence/GBF-602 | NOT_STARTED | GBF-304/601 | 建恢复矩阵 |
+| GBF-507 | M5 | Mahayana Agent Workbench 与实时动态头像 | GBF-302,501,502 | Bot 多步骤、步骤/工具/审批/结果可见；头像随真实运行状态变化；运行日志重启可恢复 | renderer contract + Playwright restart journey + packaged visual E2E | evidence/GBF-507 | IN_PROGRESS | final-head CI/main E2E/package evidence pending | merge #2108 then verify canonical-main artifacts |
+| GBF-601 | M6 | canonical data model 映射 | GBF-104,302 | 无长期重复会话/tool/permission model | schema review/migration test | evidence/GBF-601 | IN_PROGRESS | GBF-507 adds renderer projection; Rust canonical store migration pending | map Workbench run projection to Rust store |
+| GBF-602 | M6 | crash/restart 恢复 | GBF-304,601 | 关键状态可恢复且无重复副作用 | fault injection | evidence/GBF-602 | IN_PROGRESS | local journal is conservative cache, not canonical runtime recovery | implement Rust checkpoint/resume matrix |
 | GBF-603 | M6 | 统一 correlation/structured logging | GBF-203,303 | renderer->tool 链路可追踪且无秘密 | trace assertions/log audit | evidence/GBF-603 | NOT_STARTED | runtime | 统一 event fields |
 | GBF-604 | M6 | 性能基线与 regression gate | GBF-207,407,504 | 真实 baseline 固化并可阻止严重回归 | benchmark + CI gate | evidence/GBF-604 | NOT_STARTED | feature E2E | 收集 baseline |
 | GBF-701 | M7 | IPC/host threat model | GBF-201..205 | 威胁/缓解/残余风险齐全 | security review | evidence/GBF-701 | NOT_STARTED | M4 closure evidence stale | 建 threat inventory |

--- a/projects/grok-bot-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/grok-bot-fabushi-integration/management/03-验收追踪矩阵.md
@@ -16,3 +16,4 @@
 | GBR-012 多 provider Router | GBF-307,506 | provider contract + readiness + packaged E2E | RELEASED (`f81588d3...`; Electron `32733627050`; Release `desktop-1.0.867`) |
 | GBR-013 routed MCP/transcript/usage | GBF-308 | provider matrix integration + evidence | RELEASED (seven-gate `32731980249`; exact-main delivery `32734915241`) |
 | GBR-014 本地容器执行环境 | GBF-408,506 | lifecycle security + packaged E2E | RELEASED (Windows Docker-ready and macOS/Linux fail-closed journeys passed) |
+| GBR-015 Mahayana 多步骤 Agent 工作台 | GBF-507,601,602 | Agent-mode command path + step/tool/approval/result UI + live avatar state + restart journey + canonical store/recovery evidence | IN_PROGRESS (PR #2108 implementation present; final-head CI, main E2E, packaged visual evidence and Rust canonical recovery pending) |

--- a/projects/grok-bot-fabushi-integration/management/05-状态报告.md
+++ b/projects/grok-bot-fabushi-integration/management/05-状态报告.md
@@ -105,58 +105,69 @@
 - Motion implementation: branch `feat/gbf-grok-motion-parity-v1` adds a product-owned `grok-motion-parity.css` around the existing `fabushi-motion-v2` engine. Real states now have distinct outer aura/particle choreography: thinking focus, searching sweep, working/tool four-beat microcycle, speaking cadence, result confirmation bloom, error/alert two-beat warning; reduced-motion disables the additions.
 - Verification additions: `grok-motion-parity.spec.ts` asserts stylesheet/keyframe/computed-animation contract; `grok-visual-evidence.spec.ts` captures packaged 1440x900 screenshots for shell, global search, conversation and thinking BotMark into Playwright evidence so subsequent rounds can visually tune the real packaged product.
 - Existing capability reconciliation: live GitHub task/evidence and merged PRs prove M4 `GBF-401..407` were already implemented/tested via PR #2019 and M5 `GBF-502..505` via PR #2029. The WBS was stale; it is corrected to `TESTED` with current-main/post-main closure evidence explicitly still pending rather than duplicating implementations.
-- Active GitHub: PR #2102 opened with auto-merge enabled. Current head includes motion choreography, screenshot evidence and WBS/task updates; full GBF/CI/Electron/governance workflows are running.
+- Active GitHub: PR #2102 opened with auto-merge enabled. Current head includes motion choreography, screenshot evidence and WBS/task updates；full GBF/CI/Electron/governance workflows are running.
 - Acceptance: GBF-501 remains IN_PROGRESS. Exact packaged screenshot inspection, protected merge, canonical-main package/E2E and Release proof are still required before closure.
-- Tooling blocker: DevSpace local coding connector still returns HTTP 502. Large 37KB `fabushi-motion-v2` internal edits are intentionally not performed through unsafe whole-file replacement; current safe outer choreography preserves the proven engine and keeps the path open for true fine-grained Agent phase events later.
+- Tooling blocker: DevSpace local coding connector still returns HTTP 502. Large 37KB `fabushi-motion-v2` internal edits are intentionally not performed through unsafe whole-file replacement；current safe outer choreography preserves the proven engine and keeps the path open for true fine-grained Agent phase events later.
 - Next: merge #2102 after green gates, retrieve packaged Playwright visual artifacts, inspect the actual screenshots, tune remaining visual differences, then validate current-main M4 control/reconnect/security paths and post-main Release evidence.
 
 ## 2026-08-24 17:49+08 / Round 14
 
 - Task/Stage: GBF-106 / M1 source-baseline extension.
 - User source: `bhrum/grok-bot-0.18-reconstructed`; pinned commit `a9f633e09d49a85829b8236331b9e21f7e612634`, tree `b68f24972427952c4934e4364736fec62661044f`.
-- Open-source/provenance gate: inspected README, NOTICE, PROVENANCE, architecture and focused tests. The reference does not grant an upstream source-code license and preserves original installer LFS pointers/checksum-pinned renderer; direct import is rejected. ADR-0007 requires clean-room behavior/API fusion through the single Mahayana runtime.
-- Completed locally: deterministic 2,111-row manifest with capability domain and per-path decision; 29 `ADAPT_DESIGN`, 1,693 `CLEAN_ROOM_SPEC`, 347 `LEARN`, 42 `REJECT`; exact commit/tree, full classification, complete decisions and zero COPY assertions all passed.
-- Delta: registered GBF-307 provider Router, GBF-308 routed transcript/MCP/usage, GBF-408 local container sandbox, GBF-506 settings parity and GBF-805 final 0.18 parity closure; normalized GBR-011..014.
-- Acceptance: local lightweight audit passed; GBF-106 remains IN_PROGRESS until PR/CI/protected-main/canonical readback.
+- Open-source/provenance gate: inspected README, NOTICE, PROVENANCE, architecture and focused tests. The reference does not grant an upstream source-code license and preserves original installer LFS pointers/checksum-pinned renderer；direct import is rejected. ADR-0007 requires clean-room behavior/API fusion through the single Mahayana runtime.
+- Completed locally: deterministic 2,111-row manifest with capability domain and per-path decision；29 `ADAPT_DESIGN`, 1,693 `CLEAN_ROOM_SPEC`, 347 `LEARN`, 42 `REJECT`; exact commit/tree, full classification, complete decisions and zero COPY assertions all passed.
+- Delta: registered GBF-307 provider Router, GBF-308 routed transcript/MCP/usage, GBF-408 local container sandbox, GBF-506 settings parity and GBF-805 final 0.18 parity closure；normalized GBR-011..014.
+- Acceptance: local lightweight audit passed；GBF-106 remains IN_PROGRESS until PR/CI/protected-main/canonical readback.
 - Build/test: no local application build or test was run, per disk-safety policy.
 - Next: merge the audit/evidence PR, then implement GBF-307/506 vertical slice via GitHub Actions.
 
 ## 2026-08-24 17:57+08 / Round 15
 
-- GBF-106 closure: PR #2105 merged as canonical `main` SHA `4520415a8a7e6beb6e5906ad547c692ad2dde0f3`; CI `32713096020`, portfolio `32713095842`, security `32713095963` and rollback `32713095954` passed; canonical audit summary readback matched. Audit-only post-main product delivery is N/A.
+- GBF-106 closure: PR #2105 merged as canonical `main` SHA `4520415a8a7e6beb6e5906ad547c692ad2dde0f3`; CI `32713096020`, portfolio `32713095842`, security `32713095963` and rollback `32713095954` passed；canonical audit summary readback matched. Audit-only post-main product delivery is N/A.
 - Task/Stage: GBF-307 + first GBF-506 vertical slice / M3+M5.
-- Implemented on `codex/gbf-provider-router`: backwards-compatible provider/sandbox contracts; native readiness with secret-free status; Fabushi/Codex Host generation routing using the existing Codex backend; fail-closed Claude/OpenRouter/Docker placeholders; Router settings, usage and packaged visual checkpoint.
-- Security: no reconstructed code copied; no secrets returned; unsupported adapters remain disabled and throw before process spawn if persisted out of band.
-- Acceptance: IN_PROGRESS. GitHub PR/CI/protected-main/canonical packaged E2E visual bundle/Release are pending; Claude Code, OpenRouter, routed continuity and Docker remain separately tracked.
-- Build/test: no local application build/test; only lightweight syntax/diff inspection is allowed before GitHub Actions.
+- Implemented on `codex/gbf-provider-router`: backwards-compatible provider/sandbox contracts；native readiness with secret-free status；Fabushi/Codex Host generation routing using the existing Codex backend；fail-closed Claude/OpenRouter/Docker placeholders；Router settings, usage and packaged visual checkpoint.
+- Security: no reconstructed code copied；no secrets returned；unsupported adapters remain disabled and throw before process spawn if persisted out of band.
+- Acceptance: IN_PROGRESS. GitHub PR/CI/protected-main/canonical packaged E2E visual bundle/Release are pending；Claude Code, OpenRouter, routed continuity and Docker remain separately tracked.
+- Build/test: no local application build/test；only lightweight syntax/diff inspection is allowed before GitHub Actions.
 - GitHub: implementation commit `c237f0120`; PR #2106 opened and CI is running.
 - Next: resolve CI, merge, then execute exact-main packaged delivery loop.
 
 ## 2026-08-24 19:07+08 / Round 16
 
-- User sequencing: all remaining 0.18 Router delta is being fused on `codex/gbf-provider-router` before one consolidated submission; no incremental push/merge during implementation.
-- GBF-307: implemented real OpenRouter Chat Completions and Claude Messages adapters inside the existing Mahayana native Agent/tool/MCP/approval loop. Claude Code local-session auth is diagnostic only; API inference requires a separately scoped Claude key.
+- User sequencing: all remaining 0.18 Router delta is being fused on `codex/gbf-provider-router` before one consolidated submission；no incremental push/merge during implementation.
+- GBF-307: implemented real OpenRouter Chat Completions and Claude Messages adapters inside the existing Mahayana native Agent/tool/MCP/approval loop. Claude Code local-session auth is diagnostic only；API inference requires a separately scoped Claude key.
 - GBF-308: added provider-neutral transcript persistence, exact native session snapshots, stale-snapshot resolution, bounded one-time Codex bootstrap and per-provider usage aggregation.
 - GBF-408: added digest-pinned disposable Local Docker process execution under the existing capability/approval gate with network-none, read-only root, dropped capabilities, no-new-privileges and resource/mount limits.
-- GBF-506: replaced the split settings page with a reconstructed-style centered dark modal and General/Router/Usage & Billing/Updates navigation while retaining Fabushi settings; packaged E2E now captures Router screenshot evidence.
-- Provenance: Cursor's private backend/auth protocol is not copied; Fabushi/Mahayana is the first-party equivalent. Official OpenRouter, Anthropic and Microsoft Dev Container contracts were used as primary implementation references.
-- Verification: local checks are limited to CJS syntax and diff inspection; `rustfmt` is unavailable locally and repository policy forbids local build/test. GitHub Mahayana fast checks, Electron contracts, protected-main package/E2E and Release remain pending.
+- GBF-506: replaced the split settings page with a reconstructed-style centered dark modal and General/Router/Usage & Billing/Updates navigation while retaining Fabushi settings；packaged E2E now captures Router screenshot evidence.
+- Provenance: Cursor's private backend/auth protocol is not copied；Fabushi/Mahayana is the first-party equivalent. Official OpenRouter, Anthropic and Microsoft Dev Container contracts were used as primary implementation references.
+- Verification: local checks are limited to CJS syntax and diff inspection；`rustfmt` is unavailable locally and repository policy forbids local build/test. GitHub Mahayana fast checks, Electron contracts, protected-main package/E2E and Release remain pending.
 - Next: finish documentation/static audit, create one consolidated commit, push PR #2106, fix all GitHub failures, then merge and run exact-main Windows/macOS/Linux packaged delivery.
 
 ## 2026-08-24 20:07+08 / Round 17
 
 - Unified PR: #2106 code head completed CI `32725104017`, Host journey `32725104003`, Electron contract `32725103923`, security `32725103937`, native-mobile `32725103902`, messaging `32725103886`, multi-platform contracts `32725103959` and portfolio `32725103915` successfully.
-- Host repair: repeated CI traces proved the shared BotMark spring was numerically unstable when an 8fps ambient frame supplied a 125ms integration step. Bounded 1/60 substeps and complete reduced-motion gating removed the exploding SVG transform; Host run `32725104003` then passed in 61 seconds.
-- Rust repair: fast run `32725103949` found `Duration` was incorrectly imported only under `production` while the no-default-feature receive stub also used it; the guard was removed and rerun `32725865616` passed all stages. Full combination runs then exposed a test-only missing `Message` import, a Codex-protocol/Mahayana plugin-host runtime-variant type mismatch, and a stale assertion that the documented legacy helper returned `CodexAi` instead of the sovereign `MahayanaAi`. The final unified head adds the exact test import, explicit field-by-field boundary conversion, and aligns the assertion with the established sovereign conversation contract.
-- Evidence contract: packaged Electron Playwright now retains trace and full video on both success and failure; packaged diagnostics/installers target 90-day artifact retention.
+- Host repair: repeated CI traces proved the shared BotMark spring was numerically unstable when an 8fps ambient frame supplied a 125ms integration step. Bounded 1/60 substeps and complete reduced-motion gating removed the exploding SVG transform；Host run `32725104003` then passed in 61 seconds.
+- Rust repair: fast run `32725103949` found `Duration` was incorrectly imported only under `production` while the no-default-feature receive stub also used it；the guard was removed and rerun `32725865616` passed all stages. Full combination runs then exposed a test-only missing `Message` import, a Codex-protocol/Mahayana plugin-host runtime-variant type mismatch, and a stale assertion that the documented legacy helper returned `CodexAi` instead of the sovereign `MahayanaAi`. The final unified head adds the exact test import, explicit field-by-field boundary conversion, and aligns the assertion with the established sovereign conversation contract.
+- Evidence contract: packaged Electron Playwright now retains trace and full video on both success and failure；packaged diagnostics/installers target 90-day artifact retention.
 - Acceptance: GBF-307/308/408/506 remain IN_PROGRESS until final PR checks, protected merge, canonical-main three-platform packaged journeys, exact-SHA visual/debug evidence and Release are complete.
 
 ## 2026-08-24 21:56 +08:00 — Round 18
 
 - Unified delivery: PR #2106 retained one implementation commit and passed canonical seven-gate `32731980249` on head `4d8d3a6a...`.
-- Protected main: merge queue CI `32733468063` passed; canonical SHA is `f81588d33c1f10610ed0d0e4b147ae239b72b3a3`.
-- Packaged E2E: exact-main Electron `32733627050` built, launched and passed Windows/macOS/Linux journeys with screenshots/video/trace/report; native mobile `32733627056` passed Android/iOS simulated-user journeys.
+- Protected main: merge queue CI `32733468063` passed；canonical SHA is `f81588d33c1f10610ed0d0e4b147ae239b72b3a3`.
+- Packaged E2E: exact-main Electron `32733627050` built, launched and passed Windows/macOS/Linux journeys with screenshots/video/trace/report；native mobile `32733627056` passed Android/iOS simulated-user journeys.
 - Release: post-main delivery `32734915241` published `desktop-1.0.867` with Windows installer/blockmap/`latest.yml`, macOS DMG/ZIP/updater metadata and Linux packages, all targeting the exact main SHA.
-- Acceptance: GBF-307, GBF-308, GBF-408 and GBF-506 are RELEASED. M3/M4/M5 remain open for their separately tracked tasks; GBF-805 owns final reconstructed-source parity closure.
-- Build/test: no local application build/test was run; all heavy verification remains in GitHub Actions.
+- Acceptance: GBF-307, GBF-308, GBF-408 and GBF-506 are RELEASED. M3/M4/M5 remain open for their separately tracked tasks；GBF-805 owns final reconstructed-source parity closure.
+- Build/test: no local application build/test was run；all heavy verification remains in GitHub Actions.
 - Next: amend all repairs/evidence into the one consolidated commit, rerun checks, merge, then execute exact-main Windows package build and launch journey.
+
+## 2026-08-25 09:35+08 / Round 19
+
+- Task/Stage: GBF-507 / M5, with GBF-601/602 follow-up dependencies.
+- User source: `grok-bot融合优化.txt`, `完整telegram融合进fabushi.txt`, and the 2026-08-25 continuation requiring a complete Grok-style Agent UI, Mahayana multi-step Bot execution, real-state dynamic avatars and persistent conversations/runs.
+- Implemented: forced desktop `chat.send` to Mahayana `agent` mode；added a renderer command/runtime event bridge；projected operation/model/step/message/card/MCP/approval/subagent/async/background/usage events into one persistent Agent Workbench；added stop/approval/resume controls；wired list/Header/profile BotMark instances to live runtime activity；routed self-hosted Bot composer submissions to Mahayana；added Fabushi-owned Grok-style conversation/workbench material and a close/relaunch Playwright journey.
+- Project records: registered GBF-507, changed GBF-601/602 to IN_PROGRESS without claiming canonical Rust recovery completion, added GBR-015, task/acceptance/evidence/status/change records and PR #2108.
+- Verification: initial head `9b119a85...` passed Electron desktop quality gate `32797695610`, Host fast E2E `32797695647`, Messenger TypeScript/contracts and renderer TypeScript. Final-head checks are rerunning after project-record commits.
+- Acceptance: GBF-507 remains IN_PROGRESS. Protected merge, canonical-main Playwright restart journey, packaged Windows/macOS/Linux journey, screenshot/video inspection and Rust canonical conversation/run recovery are still required.
+- Risk/provenance: localStorage is a bounded UI recovery journal, not the final source of truth；in-flight runs are marked interrupted and never automatically replayed；no vendor production renderer, installer payload or visual asset is copied.
+- Next: finish exact-head gates, merge #2108 through protected main, collect canonical-main E2E/package artifacts and update the evidence index before closing any acceptance row.

--- a/projects/grok-bot-fabushi-integration/management/07-变更日志.md
+++ b/projects/grok-bot-fabushi-integration/management/07-变更日志.md
@@ -20,3 +20,7 @@
 - 2026-08-24 19:07+08：按用户要求将剩余 Router delta 合并到同一提交流：实现 OpenRouter/Claude wire adapters、provider-neutral transcript/native snapshot/usage 连续性、受 Mahayana gate 约束的 digest-pinned Local Docker，以及居中 Router/Usage/Updates 设置 modal；原先 fail-closed placeholder 状态由真实适配替代，任务仍等待统一 CI/main/post-main closure。
 - 2026-08-24 21:56+08：统一 PR #2106 经 seven-gate `32731980249` 与 merge queue 合入 `main` 为 `f81588d3...`；exact-main Electron `32733627050`、native mobile `32733627056`、post-main delivery `32734915241` 全绿并发布 `desktop-1.0.867`，GBF-307/308/408/506 转为 RELEASED。
 - 2026-08-24 20:07+08：统一 PR 首轮主要 gates 通过；依据 Host trace 修复 BotMark 低帧率弹簧数值发散并完善 reduced-motion，依据 no-default-features/full-combination Rust gates 修复 `Duration` 条件 import、runtime test `Message` import、Codex/Mahayana plugin runtime variant 显式转换及 legacy helper 的 sovereign peer 断言；Electron packaged E2E 改为成功/失败均保留完整视频与 trace，诊断/安装包证据保留目标提升至 90 天。
+
+## 2026-08-25
+
+- 2026-08-25 09:35+08：新增 GBF-507 Mahayana Agent Workbench。桌面 `chat.send` 统一到 Mahayana `agent` 模式；Electron transport 发布命令/运行事件；Messenger 投影 operation/model/step/message/card/MCP/approval/subagent/async/background/usage；新增停止、审批、继续与重启恢复日志；列表、Header、资料页动态头像读取真实运行状态；自建 Bot 通过兼容提交桥进入 Mahayana；新增 Fabushi 自有 Grok 风格运行时间线和 Playwright 多步骤/重启旅程。同步 WBS、GBR-015、任务、验收、证据和状态记录；GBF-507/601/602 保持 IN_PROGRESS，等待 final-head CI、protected main、canonical-main E2E/安装包证据与 Rust 权威恢复模型。

--- a/projects/grok-bot-fabushi-integration/management/acceptance/GBF-507-mahayana-agent-workbench.md
+++ b/projects/grok-bot-fabushi-integration/management/acceptance/GBF-507-mahayana-agent-workbench.md
@@ -1,0 +1,18 @@
+# GBF-507 Acceptance Traceability
+
+| Requirement | Source | Implementation | Verification | Evidence | State |
+|---|---|---|---|---|---|
+| Bot 不能只做单轮对话，必须多步骤工作 | 2026-08-25 user continuation | `ElectronMahayanaHostTransport.execute` normalizes `chat.send` to `mode=agent`; self-hosted Bot submit bridge invokes `feature.execute` | renderer typecheck; Playwright Agent journey | PR #2108; `desktop/e2e/mahayana-agent-workbench.spec.ts` | IMPLEMENTED; main E2E pending |
+| 使用现有 Mahayana，不建立第二 runtime | original Grok fusion requirement | all commands use Electron Mahayana edge / Rust AppHost | architecture contract + Host fast E2E | runs `32797695610`, `32797695647` | PASSED on initial head |
+| 展示规划、步骤、工具和结果 | 2026-08-25 user continuation | Agent Workbench projects runtime lifecycle, steps, tools, cards and output | selector assertions for run/step/output | `mahayana-agent-workbench.tsx` + spec | IMPLEMENTED; main E2E pending |
+| 会话内完成审批并继续 | Grok observable behavior | approval cards invoke `feature.approval.resolve` | approval UI/runtime journey | task record A6 | IMPLEMENTED; E2E pending |
+| 子智能体与后台任务可观察 | Grok observable behavior | `subagent.*`, `asyncTask.*`, `agent.background*` projections | reducer/event contract + runtime journey | task record A4 | IMPLEMENTED; E2E pending |
+| 动态头像随真实运行状态变化 | original dynamic avatar requirement | runtime events map to `BotMarkState`; active peer/Header/profile share current run state | Playwright result-state assertion and screenshot evidence | `#mahayana-agent-header-avatar [data-agent-state=result]` | IMPLEMENTED; main E2E pending |
+| 会话/运行重启后不消失 | 2026-08-25 user continuation | bounded persistent run journal; in-flight runs become interrupted/resumable | close/relaunch same app-data journey | restart section in spec | IMPLEMENTED; main E2E pending |
+| 可停止、恢复失败或中断任务 | Grok observable behavior | interrupt and resume actions | `feature.interrupt`/`feature.execute` journey | task record A6 | IMPLEMENTED; E2E pending |
+| 视觉接近 Grok 运行工作台，同时保持 Fabushi 所有权 | original UI fusion requirement + provenance policy | new React/CSS UI and existing Fabushi motion engine; no vendor renderer/assets | source/provenance audit + packaged screenshots | `grok-agent-ui-parity.css`, workbench CSS | IMPLEMENTED; visual artifact review pending |
+| 最终变更进入 main 并由安装包旅程验证 | repository completion gate | protected PR/merge/main Actions | exact main SHA checks, packaged journeys | evidence/GBF-507 | PENDING |
+
+## Acceptance decision
+
+`GBF-507` is **IN_PROGRESS**. Static/contract evidence has passed on an earlier exact head. The final decision requires final-head required checks, protected merge, canonical-main E2E and packaged visual evidence.

--- a/projects/grok-bot-fabushi-integration/management/change-entries/2026-08-25-GBF-507-mahayana-agent-workbench.md
+++ b/projects/grok-bot-fabushi-integration/management/change-entries/2026-08-25-GBF-507-mahayana-agent-workbench.md
@@ -1,0 +1,29 @@
+# 2026-08-25 — GBF-507 Mahayana Agent Workbench
+
+## Added
+
+- Fabushi-owned Mahayana Agent Workbench inside the canonical Messenger.
+- Runtime projections for operation lifecycle, model route, Agent steps, streaming messages, transcript cards, MCP results, approvals, subagents, asynchronous tasks, background agents and usage.
+- Real runtime-state-driven BotMark avatars in the active peer row, conversation Header and profile panel.
+- Persistent bounded run journal with conservative restart interruption and explicit resume.
+- In-conversation stop, approval and resume actions.
+- Grok-style dark translucent run timeline and conversation material implemented with Fabushi React/CSS/Motion code.
+- Playwright journey covering multi-step visibility, final avatar state and close/relaunch run restoration.
+
+## Changed
+
+- Electron Mahayana `chat.send` commands are normalized to `mode=agent`.
+- Self-hosted Bot composer submissions route to Mahayana rather than remaining a messaging-only exchange.
+- Messenger conversation status reflects the current Mahayana step/result/error/approval state.
+
+## Security and provenance
+
+- Mahayana remains the only execution and permission authority.
+- Unfinished runs are not automatically replayed after restart.
+- No Grok production renderer, installer payload or vendor visual asset is copied into Fabushi.
+
+## Delivery
+
+- Branch: `feat/gbf-mahayana-agent-workbench-v1`
+- PR: `#2108`
+- State: implementation present; final-head CI, protected merge and canonical-main package/E2E evidence pending.

--- a/projects/grok-bot-fabushi-integration/management/status-rounds/2026-08-25-GBF-507-round-1.md
+++ b/projects/grok-bot-fabushi-integration/management/status-rounds/2026-08-25-GBF-507-round-1.md
@@ -1,0 +1,19 @@
+# 2026-08-25 / GBF-507 Round 1
+
+- **Task/Stage:** GBF-507 / M5, with GBF-601/602 follow-up dependencies.
+- **User requirement:** fully integrate Grok-style Agent UI/behavior into Fabushi; route Bot work to Mahayana multi-step execution; make live dynamic avatars reflect real work; retain conversations and runs.
+- **Completed this round:**
+  - forced desktop `chat.send` through Mahayana Agent mode;
+  - added a renderer command/runtime event bridge;
+  - implemented persistent run/step/tool/approval/artifact/subagent/background-task/usage projections;
+  - added stop, approval and resume controls;
+  - wired active Bot avatars to real runtime state in list, Header and profile surfaces;
+  - routed self-hosted Bot composer submissions into Mahayana;
+  - added a Grok-style Fabushi-owned workbench/conversation visual layer;
+  - added a close/relaunch Playwright journey for multi-step visibility and run-journal restoration;
+  - opened draft PR #2108 and created task/acceptance/evidence records.
+- **Acceptance:** implementation and initial exact-head static contracts are passing. GBF-507 remains `IN_PROGRESS` because final-head required checks, protected merge, canonical-main E2E, packaged journey, screenshot/video inspection and post-main verification are pending.
+- **Evidence:** commits `01071e55`, `4a4c0e42`, `cae27b7b`, `4cf3fdff`, `006a8458`, `9b119a85`, `1ceca38d`; PR #2108; Electron quality run `32797695610` success; Host fast E2E run `32797695647` success; Messenger contract success.
+- **Risk:** localStorage is a bounded UI recovery journal, not the final Rust canonical store. In-flight runs are marked interrupted, never automatically replayed, to prevent duplicate side effects. GBF-601/602 must move the authoritative model/recovery into the Rust store.
+- **Provenance:** observable behavior and layout are reimplemented in Fabushi-owned code. No vendor production renderer or installer asset is included.
+- **Next action:** finish exact-head CI, merge through protected main, collect canonical-main E2E/package artifacts, then update aggregate WBS/status/changelog and close only the evidence-backed acceptance rows.

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-507-mahayana-agent-workbench.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-507-mahayana-agent-workbench.md
@@ -1,0 +1,90 @@
+# GBF-507 — Mahayana Agent Workbench 与实时动态头像
+
+- **Project:** `grok-bot-fabushi-integration`
+- **Stage:** M5 / UI 与可观察 Agent 行为融合
+- **Owner:** Fabushi desktop + Mahayana runtime
+- **Status:** IN_PROGRESS
+- **Branch:** `feat/gbf-mahayana-agent-workbench-v1`
+- **Pull request:** `#2108`
+- **Source requirement:** `grok-bot融合优化.txt`、`完整telegram融合进fabushi.txt`，以及 2026-08-25 用户要求“Bot 必须调用 Mahayana 多步骤工作、会话保存、动态头像和 Grok 类运行 UI 完整融合”。
+- **Reference baseline:** `bhrum/grok-bot-0.18-reconstructed@a9f633e09d49a85829b8236331b9e21f7e612634`
+
+## Objective
+
+把当前“普通聊天气泡 + 粗粒度 busy 状态”升级为 Fabushi 自有实现的 Agent 工作台：所有 Bot 通过单一 Mahayana Runtime 执行，用户能在同一个 Messenger 会话里看到规划、模型路由、步骤、工具、审批、子智能体、后台任务、结果、Usage 与中断/恢复；动态头像必须读取同一条真实运行事件流。
+
+## Scope
+
+1. `chat.send` 统一为 Mahayana `agent` 模式，不增加第二套 Agent runtime。
+2. 通过 Electron Mahayana transport 发布命令与 runtime event 总线。
+3. 将 `operation.*`、`agent.step`、`model.routed`、`chat.*`、`transcript.card`、`mcp.toolResult`、`approval.*`、`subagent.*`、`asyncTask.*`、background agent 与 `usage.updated` 投影为同一运行日志。
+4. 在现有 Messenger 中展示可折叠运行卡、步骤时间线、审批、工具结果、Artifact、最终结果、停止与继续操作。
+5. 活跃会话列表、Header、资料页头像读取运行投影状态，而不是仅依赖发送按钮 busy 状态。
+6. 本地保存运行日志；应用重启后已完成运行保持可见，未完成运行进入 `interrupted/resumable`。
+7. 自建 Bot 与 legacy Mahayana Bot 最终都进入 Mahayana 执行路径。
+8. 以 Fabushi 自有 React/CSS/Motion 代码重建可观察行为和视觉，不嵌入供应商生产 renderer、安装包资产或品牌文件。
+
+## Non-goals
+
+- 不把 Grok Bot 的闭源生产 renderer 或安装包资源直接打入 Fabushi。
+- 不建立独立于 Mahayana 的第二套工具循环、权限系统或会话权威数据库。
+- 本任务的 localStorage journal 是首屏/恢复投影；最终 Rust canonical conversation/run store 仍由 GBF-601/602 完成。
+
+## Architecture
+
+```text
+Messenger composer
+  -> ElectronMahayanaHostTransport.execute(chat.send, mode=agent)
+  -> Electron preload / feature.execute
+  -> Rust Mahayana AppHost / Runtime / tools
+  -> RuntimeEvent stream
+  -> Mahayana Agent Workbench reducer
+       -> run/step/tool/approval/output projection
+       -> BotMark real activity state
+       -> local recovery journal
+  -> existing Messenger message area + avatar slots
+```
+
+`operationId` 是运行主关联键；发送接受前以 `requestId` 建立临时运行，Host 返回后将其绑定到 `operationId`。会话使用 `conversationId` 或稳定的 Messenger peer key 关联。
+
+## Acceptance criteria
+
+| ID | Criterion | Objective verification | Status |
+|---|---|---|---|
+| GBF-507-A1 | Legacy Mahayana Bot 的 `chat.send` 必须使用 `mode=agent` | transport contract + renderer typecheck | PASSED |
+| GBF-507-A2 | 自建 Bot 提交必须进入 Mahayana，而不是只回普通对话 | Electron journey sends from Bot peer and observes runtime run | IMPLEMENTED; E2E pending |
+| GBF-507-A3 | 一次任务至少显示 3 个真实步骤/生命周期节点 | `mahayana-agent-workbench.spec.ts` | IMPLEMENTED; main E2E pending |
+| GBF-507-A4 | 模型、工具、审批、子智能体、后台任务、Usage 有独立投影 | reducer event coverage + UI selectors | PASSED by typecheck/contracts; runtime journey pending |
+| GBF-507-A5 | 动态头像随 `thinking/searching/working/speaking/result/error/alerting` 等事件变化 | live event state + Playwright result-state assertion | IMPLEMENTED; main E2E pending |
+| GBF-507-A6 | 用户可停止可中断任务、批准/拒绝权限、继续失败/中断任务 | UI controls invoke `feature.interrupt` / `feature.approval.resolve` / `feature.execute` | IMPLEMENTED; runtime E2E pending |
+| GBF-507-A7 | 应用重启后完整运行日志和结果仍可查看 | same app-data close/relaunch Playwright journey | IMPLEMENTED; main E2E pending |
+| GBF-507-A8 | Renderer TypeScript、Messenger、Host fast gates 全绿 | GitHub Actions exact-head evidence | PASSED for initial head; final-head pending |
+| GBF-507-A9 | protected-main merge 后主分支运行 E2E、截图/视频和安装包旅程通过 | main GitHub Actions and artifacts | PENDING |
+
+## Implementation evidence
+
+- `frontend/apps/web/src/lib/mahayana-host/electron-transport.ts`
+- `desktop/src/mahayana-agent-workbench.tsx`
+- `desktop/src/mahayana-agent-workbench.module.css`
+- `desktop/src/grok-agent-ui-parity.css`
+- `desktop/src/main.tsx`
+- `desktop/e2e/mahayana-agent-workbench.spec.ts`
+- Draft PR `#2108`
+- Initial exact-head checks: Electron desktop quality gate and Host fast E2E succeeded on `9b119a853ddf89223de4cb55ad5b5d98aa2d5f97`; final-head checks remain required.
+
+## Risks and controls
+
+- **R-507-1 — duplicate UI/runtime state:** Workbench is a projection only; Mahayana remains the sole executor and permission authority.
+- **R-507-2 — selector/portal drift:** Existing Messenger remains canonical. Playwright selectors and UI contracts must catch layout changes; a later direct component integration may replace the compatibility portal without changing the event model.
+- **R-507-3 — local journal is not canonical:** unfinished runs are conservatively marked interrupted on restart; no automatic side-effect replay occurs.
+- **R-507-4 — vendor provenance:** only observable behavior and design metrics are reimplemented; no vendor renderer/assets are copied.
+
+## Completion gate
+
+Keep this task `IN_PROGRESS` until:
+
+1. PR final head passes required CI;
+2. PR is merged through the repository's protected flow;
+3. canonical `main` runs the new Playwright restart journey and packaged Electron journey;
+4. screenshot/video artifacts are inspected;
+5. WBS, acceptance traceability, append-only status/changelog and evidence index are updated with exact merge/run/artifact references.


### PR DESCRIPTION
## 目标

把 Fabushi Bot 从普通对话升级为由 Mahayana 驱动的多步骤 Agent，并把 Grok 风格的运行时间线、真实状态动态头像、审批、工具结果、子智能体与运行恢复统一放进现有 Messenger。

## 已实现

- Electron Mahayana Transport 强制 `chat.send` 使用 `agent` 模式，并发布命令/运行事件总线。
- 新增持久化 Agent Workbench，投影 `operation.*`、`agent.step`、`model.routed`、`usage.updated`、`approval.*`、`transcript.card`、MCP、子智能体、异步任务和后台 Agent。
- Mahayana Bot 与自建 Bot 都进入 Mahayana 执行路径；自建 Bot 通过 Messenger 提交兼容桥路由。
- 动态头像读取真实运行活动，并同步会话列表、Header 与资料页当前 Bot 状态。
- 会话内提供停止、批准/拒绝、继续任务；运行日志、步骤、结果和审批投影持久化，重启后可查看，未完成运行进入可恢复中断态。
- 新增 Fabushi 自有 Grok 风格会话材料、运行卡和 Playwright 多步骤/重启恢复验收；不嵌入供应商生产 renderer 或安装包资产。
- 已同步 GBF-507 WBS、GBR-015 验收矩阵、任务记录、状态报告、变更日志和证据索引；GBF-601/602 明确保持进行中，不把本地 journal 冒充 Rust 权威存储。

## 验收状态

- [x] Renderer TypeScript / Messenger contract（初始代码 head 已通过）
- [x] Electron main / Feature Host contract（初始代码 head 已通过）
- [x] Host fast E2E（初始代码 head 已通过）
- [x] 项目 WBS、验收矩阵、状态报告、变更日志、任务和证据同步
- [ ] 最终 head required CI 全绿
- [ ] 转 Ready 并经 protected main 合并
- [ ] canonical-main 运行 `mahayana-agent-workbench.spec.ts`、安装包旅程与截图/视频/trace 验收

## 当前任务状态

`GBF-507 = IN_PROGRESS`。在最终 head、protected merge、主分支 E2E/安装包证据完成前不标记 RELEASED。