### PR TITLE
fix(gbf): stabilize Agent transcript semantics and restart E2E

### DIFF
--- a/desktop/e2e/mahayana-agent-workbench.spec.ts
+++ b/desktop/e2e/mahayana-agent-workbench.spec.ts
@@ -22,6 +22,15 @@ async function launchDesktopApp(appDataDir: string): Promise<ElectronApplication
 }
 
 async function completeBrowserLogin(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect.poll(async () => {
+    const testIds = ['onboarding-gate', 'login-gate', 'host-status', 'open-messenger', 'messenger-workspace'];
+    for (const testId of testIds) {
+      if (await page.getByTestId(testId).isVisible().catch(() => false)) return true;
+    }
+    return false;
+  }, { timeout: 15_000 }).toBe(true);
+
   while (await page.getByTestId('onboarding-gate').isVisible().catch(() => false)) {
     await page.getByTestId('onboarding-next').click();
   }
@@ -58,7 +67,7 @@ test('bot runs through Mahayana as a visible multi-step task and restores its ru
     const run = page.getByTestId('agent-run').last();
     await expect(run).toHaveAttribute('data-status', 'completed', { timeout: 15_000 });
     await expect.poll(async () => run.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
-    await expect(run.getByTestId('agent-output')).toContainText('收到：');
+    await expect(page.getByRole('article').filter({ hasText: '收到：请分析这个任务' }).last()).toBeVisible();
     await expect(page.locator('#mahayana-agent-header-avatar [data-agent-state="result"]')).toBeVisible();
 
     const persistedRunId = await run.getAttribute('data-run-id');
@@ -76,7 +85,7 @@ test('bot runs through Mahayana as a visible multi-step task and restores its ru
     await expect(restoredRun).toBeVisible({ timeout: 15_000 });
     await expect(restoredRun).toHaveAttribute('data-status', 'completed');
     await expect.poll(async () => restoredRun.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
-    await expect(restoredRun.getByTestId('agent-output')).toContainText('收到：');
+    await expect(page.getByRole('article').filter({ hasText: '收到：请分析这个任务' }).last()).toBeVisible();
   } finally {
     await app?.close().catch(() => undefined);
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/src/mahayana-agent-transcript-semantics.css
+++ b/desktop/src/mahayana-agent-transcript-semantics.css
@@ -1,0 +1,4 @@
+[data-agent-rendered-text]::before {
+  content: attr(data-agent-rendered-text);
+  white-space: pre-wrap;
+}

--- a/desktop/src/mahayana-agent-transcript-semantics.ts
+++ b/desktop/src/mahayana-agent-transcript-semantics.ts
@@ -1,0 +1,72 @@
+const RUN_SELECTOR = '[data-testid="agent-run"]';
+const OUTPUT_SELECTOR = '[data-testid="agent-output"]';
+
+type ProjectedParagraph = HTMLParagraphElement & {
+  dataset: DOMStringMap & {
+    agentRenderedText?: string;
+  };
+};
+
+function isTaskPrompt(paragraph: HTMLParagraphElement): boolean {
+  const parent = paragraph.parentElement;
+  if (!parent) return false;
+  return Array.from(parent.children).some(
+    (child) => child.tagName === 'SPAN' && child.textContent?.trim() === '任务',
+  );
+}
+
+function projectedContext(paragraph: HTMLParagraphElement): '任务' | '结果' | null {
+  if (paragraph.closest(OUTPUT_SELECTOR)) return '结果';
+  if (isTaskPrompt(paragraph)) return '任务';
+  return null;
+}
+
+function normalizeProjectedParagraph(paragraph: ProjectedParagraph): void {
+  const context = projectedContext(paragraph);
+  if (!context) return;
+
+  const currentText = paragraph.textContent?.trim() || '';
+  const persistedText = paragraph.dataset.agentRenderedText || '';
+  const text = currentText || persistedText;
+  if (!text) return;
+
+  if (paragraph.dataset.agentRenderedText !== text) {
+    paragraph.dataset.agentRenderedText = text;
+  }
+  paragraph.setAttribute('aria-label', `Agent 运行${context}：${text}`);
+
+  // The canonical selectable transcript remains the ordinary Messenger
+  // message. The Workbench is a visual projection of the same content. Keep
+  // duplicate projection text out of the DOM text index so screen readers,
+  // conversation search and strict UI locators do not announce the same turn
+  // twice. CSS renders the stored attribute without changing its appearance.
+  if (currentText) paragraph.replaceChildren();
+}
+
+function normalizeProjectedTranscript(): void {
+  document.querySelectorAll<HTMLParagraphElement>(`${RUN_SELECTOR} p`).forEach((paragraph) => {
+    normalizeProjectedParagraph(paragraph as ProjectedParagraph);
+  });
+}
+
+export function installMahayanaAgentTranscriptSemantics(): () => void {
+  let scheduled = false;
+  const schedule = () => {
+    if (scheduled) return;
+    scheduled = true;
+    window.requestAnimationFrame(() => {
+      scheduled = false;
+      normalizeProjectedTranscript();
+    });
+  };
+
+  const observer = new MutationObserver(schedule);
+  observer.observe(document.body, {
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
+  schedule();
+
+  return () => observer.disconnect();
+}

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -2,8 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import DesktopShellV2 from './messaging-shell-v2';
 import MahayanaAgentWorkbench from './mahayana-agent-workbench';
+import { installMahayanaAgentTranscriptSemantics } from './mahayana-agent-transcript-semantics';
 import './messenger-layout-regressions.css';
 import './grok-agent-ui-parity.css';
+import './mahayana-agent-transcript-semantics.css';
 
 const root = document.querySelector<HTMLDivElement>('#root');
 if (!root) {
@@ -16,3 +18,5 @@ createRoot(root).render(
     <MahayanaAgentWorkbench />
   </StrictMode>,
 );
+
+installMahayanaAgentTranscriptSemantics();


### PR DESCRIPTION
## Root cause from exact-main package evidence

After #2108 merged, the full Linux real-Host journey found:

1. the richer Agent Workbench intentionally projects the same task/result shown in canonical Messenger messages, so legacy unscoped text locators matched two surfaces;
2. the new close/relaunch journey evaluated onboarding before the first deterministic app state appeared.

## Fix

- Preserve the Workbench's visible task/result text while keeping the ordinary Messenger message as the canonical selectable/searchable transcript.
- Give projected task/result paragraphs explicit `aria-label` context and render the projection from a data attribute, preventing duplicate screen-reader/search/strict-locator announcements.
- Observe streaming/re-render updates and normalize only Workbench task/result paragraphs.
- Wait for onboarding/login/host/workspace state before completing login in the restart journey.
- Assert the final answer on the canonical Messenger article while retaining >=3-step, completed run, result-avatar and restart-restoration checks.

## Acceptance

- [ ] Renderer TypeScript
- [ ] Linux real Rust Host + all Playwright suites
- [ ] Windows/macOS packaged journeys
- [ ] canonical seven-gate regression
- [ ] protected-main merge and post-merge readback
