### PR TITLE
fix(gbf): restore Mahayana conversations and eliminate duplicate Agent text

### DIFF
--- a/desktop/src/mahayana-agent-transcript-semantics.ts
+++ b/desktop/src/mahayana-agent-transcript-semantics.ts
@@ -50,23 +50,28 @@ function normalizeProjectedTranscript(): void {
 }
 
 export function installMahayanaAgentTranscriptSemantics(): () => void {
-  let scheduled = false;
-  const schedule = () => {
-    if (scheduled) return;
-    scheduled = true;
-    window.requestAnimationFrame(() => {
-      scheduled = false;
+  let normalizing = false;
+  const normalize = () => {
+    if (normalizing) return;
+    normalizing = true;
+    try {
+      // MutationObserver callbacks run in the same microtask checkpoint as the
+      // React commit. Normalize immediately rather than waiting for the next
+      // animation frame; accessibility/search consumers and Playwright can
+      // inspect the DOM before that later frame.
       normalizeProjectedTranscript();
-    });
+    } finally {
+      normalizing = false;
+    }
   };
 
-  const observer = new MutationObserver(schedule);
+  const observer = new MutationObserver(normalize);
   observer.observe(document.body, {
     childList: true,
     characterData: true,
     subtree: true,
   });
-  schedule();
+  normalize();
 
   return () => observer.disconnect();
 }

--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -47,6 +47,11 @@ declare global {
 }
 
 const ELECTRON_EDGE_CONTRACT_VERSION = 1;
+const CONVERSATION_JOURNAL_KEY = "fabushi.desktop.mahayana-conversation-journal.v1";
+const CONVERSATION_JOURNAL_VERSION = 1;
+const CONVERSATION_JOURNAL_LIMIT = 80;
+const CONVERSATION_MESSAGE_LIMIT = 240;
+const CONVERSATION_EQUIVALENCE_WINDOW_MS = 60_000;
 
 export const MAHAYANA_RUNTIME_EVENT_NAME = "fabushi:mahayana-runtime-event";
 export const MAHAYANA_COMMAND_EVENT_NAME = "fabushi:mahayana-command";
@@ -75,6 +80,18 @@ export type MahayanaCommandBridgeDetail =
       error: string;
       context?: MahayanaCommandBridgeContext;
     };
+
+type ConversationJournalMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  createdAtMs: number;
+};
+
+type ConversationJournal = {
+  version: 1;
+  conversations: Record<string, ConversationJournalMessage[]>;
+};
 
 const idle = (milliseconds = 10) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
@@ -137,6 +154,123 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function eventTimestampMs(timestamp: string): number {
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function isConversationJournalMessage(value: unknown): value is ConversationJournalMessage {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Partial<ConversationJournalMessage>;
+  return (
+    typeof candidate.id === "string" &&
+    (candidate.role === "user" || candidate.role === "assistant") &&
+    typeof candidate.text === "string" &&
+    typeof candidate.createdAtMs === "number" &&
+    Number.isFinite(candidate.createdAtMs)
+  );
+}
+
+function emptyConversationJournal(): ConversationJournal {
+  return { version: CONVERSATION_JOURNAL_VERSION, conversations: {} };
+}
+
+function readConversationJournal(): ConversationJournal {
+  if (typeof window === "undefined") return emptyConversationJournal();
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(CONVERSATION_JOURNAL_KEY) || "null") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return emptyConversationJournal();
+    const candidate = parsed as Partial<ConversationJournal>;
+    if (
+      candidate.version !== CONVERSATION_JOURNAL_VERSION ||
+      !candidate.conversations ||
+      typeof candidate.conversations !== "object" ||
+      Array.isArray(candidate.conversations)
+    ) {
+      return emptyConversationJournal();
+    }
+
+    const conversations = Object.fromEntries(
+      Object.entries(candidate.conversations)
+        .filter(([conversationId, messages]) => Boolean(conversationId) && Array.isArray(messages))
+        .map(([conversationId, messages]) => [
+          conversationId,
+          (messages as unknown[])
+            .filter(isConversationJournalMessage)
+            .sort((left, right) => left.createdAtMs - right.createdAtMs)
+            .slice(-CONVERSATION_MESSAGE_LIMIT),
+        ])
+        .filter(([, messages]) => (messages as ConversationJournalMessage[]).length > 0)
+        .slice(-CONVERSATION_JOURNAL_LIMIT),
+    );
+    return { version: CONVERSATION_JOURNAL_VERSION, conversations };
+  } catch {
+    return emptyConversationJournal();
+  }
+}
+
+function persistConversationJournal(journal: ConversationJournal): void {
+  if (typeof window === "undefined") return;
+  try {
+    const conversations = Object.fromEntries(
+      Object.entries(journal.conversations)
+        .filter(([, messages]) => messages.length > 0)
+        .sort(([, left], [, right]) =>
+          (right.at(-1)?.createdAtMs ?? 0) - (left.at(-1)?.createdAtMs ?? 0),
+        )
+        .slice(0, CONVERSATION_JOURNAL_LIMIT)
+        .map(([conversationId, messages]) => [
+          conversationId,
+          messages
+            .slice(-CONVERSATION_MESSAGE_LIMIT)
+            .map((message) => ({ ...message })),
+        ]),
+    );
+    window.localStorage.setItem(
+      CONVERSATION_JOURNAL_KEY,
+      JSON.stringify({ version: CONVERSATION_JOURNAL_VERSION, conversations }),
+    );
+  } catch {
+    // Conversation recovery is a local-first cache. Host persistence remains
+    // authoritative and storage pressure must never block a live Agent turn.
+  }
+}
+
+function equivalentConversationMessage(
+  left: ConversationJournalMessage,
+  right: ConversationJournalMessage,
+): boolean {
+  if (left.id === right.id) return true;
+  return (
+    left.role === right.role &&
+    left.text === right.text &&
+    Math.abs(left.createdAtMs - right.createdAtMs) <= CONVERSATION_EQUIVALENCE_WINDOW_MS
+  );
+}
+
+function mergeConversationMessages(
+  current: ConversationJournalMessage[],
+  incoming: ConversationJournalMessage[],
+): ConversationJournalMessage[] {
+  const merged = current.map((message) => ({ ...message }));
+  for (const message of incoming) {
+    const index = merged.findIndex((candidate) => equivalentConversationMessage(candidate, message));
+    if (index >= 0) {
+      merged[index] = {
+        ...merged[index],
+        ...message,
+        id: merged[index].id || message.id,
+        createdAtMs: Math.min(merged[index].createdAtMs, message.createdAtMs),
+      };
+    } else {
+      merged.push({ ...message });
+    }
+  }
+  return merged
+    .sort((left, right) => left.createdAtMs - right.createdAtMs)
+    .slice(-CONVERSATION_MESSAGE_LIMIT);
+}
+
 export function isElectronMahayanaHostAvailable(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -162,9 +296,18 @@ function shellBridge(): ElectronShellBridge {
 export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   private readonly listeners = new Set<RuntimeEventListener>();
   private readonly miniAppConversations = new Map<string, string>();
+  private readonly conversationJournal = readConversationJournal();
+  private readonly requestConversations = new Map<string, string>();
+  private readonly operationConversations = new Map<string, string>();
+  private readonly ignoredRequests = new Set<string>();
+  private readonly ignoredOperations = new Set<string>();
+  private activeConversationId: string | null = null;
+  private suppressUnscopedRuntime = false;
   private closed = false;
   private pumping = false;
   private unsubscribeBridge: (() => void) | null = null;
+  private unsubscribeCommandObserver: (() => void) | null = null;
+  private journalPersistTimer: ReturnType<typeof setTimeout> | null = null;
 
   subscribe(listener: RuntimeEventListener): () => void {
     this.listeners.add(listener);
@@ -174,6 +317,7 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   async initialize(_config: HostConfig): Promise<HostInfo> {
     const info = await mahayanaBridge().invoke<HostInfo>("feature.info");
     this.closed = false;
+    this.attachCommandObserver();
     this.attachRuntimeEvents();
     // The main process owns the long-lived event pump and may observe the
     // one-shot host.ready event before the renderer subscribes. A successful
@@ -350,7 +494,10 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     this.closed = true;
     this.unsubscribeBridge?.();
     this.unsubscribeBridge = null;
+    this.unsubscribeCommandObserver?.();
+    this.unsubscribeCommandObserver = null;
     this.miniAppConversations.clear();
+    this.flushConversationJournal();
   }
 
   private dispatchToListeners(event: RuntimeEvent): void {
@@ -375,7 +522,54 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
       this.dispatchToListeners(normalizedEvent);
       return;
     }
+
+    if (event.type === "conversation.opened") {
+      this.activeConversationId = event.conversationId;
+      const cached = this.conversationJournal.conversations[event.conversationId] ?? [];
+      const merged = mergeConversationMessages(cached, event.messages);
+      this.setConversationMessages(event.conversationId, merged, true);
+      this.dispatchToListeners({ ...event, messages: merged });
+      return;
+    }
+
+    if (event.type === "chat.message") {
+      const conversationId = this.conversationIdForEvent(event.operationId);
+      if (conversationId) {
+        const createdAtMs = eventTimestampMs(event.timestamp);
+        this.appendConversationMessage(conversationId, {
+          id: event.operationId
+            ? `${event.operationId}:${event.role}`
+            : `${event.role}:${createdAtMs}:${Math.random().toString(16).slice(2)}`,
+          role: event.role,
+          text: event.text,
+          createdAtMs,
+        }, true);
+      }
+    } else if (event.type === "chat.delta") {
+      const conversationId = this.conversationIdForEvent(event.operationId);
+      if (conversationId) {
+        const createdAtMs = eventTimestampMs(event.timestamp);
+        const id = `${event.operationId}:assistant`;
+        const current = this.conversationJournal.conversations[conversationId] ?? [];
+        const existing = current.find((message) => message.id === id);
+        this.appendConversationMessage(conversationId, {
+          id,
+          role: "assistant",
+          text: `${existing?.text ?? ""}${event.delta}`,
+          createdAtMs: existing?.createdAtMs ?? createdAtMs,
+        }, false);
+      }
+    }
+
     this.dispatchToListeners(event);
+
+    if (
+      event.type === "operation.completed" ||
+      event.type === "operation.failed" ||
+      event.type === "operation.interrupted"
+    ) {
+      if (this.ignoredOperations.delete(event.operationId)) this.refreshUnscopedSuppression();
+    }
   }
 
   private attachRuntimeEvents(): void {
@@ -391,6 +585,125 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     // Compatibility fallback for older Tauri/Electron bundles which have not
     // yet adopted the native edge event channel.
     this.startEventPump();
+  }
+
+  private attachCommandObserver(): void {
+    this.unsubscribeCommandObserver?.();
+    if (typeof window === "undefined") return;
+    const listener = (event: Event) => {
+      const detail = (event as CustomEvent<MahayanaCommandBridgeDetail>).detail;
+      if (detail) this.observeCommand(detail);
+    };
+    window.addEventListener(MAHAYANA_COMMAND_EVENT_NAME, listener);
+    this.unsubscribeCommandObserver = () => window.removeEventListener(MAHAYANA_COMMAND_EVENT_NAME, listener);
+  }
+
+  private observeCommand(detail: MahayanaCommandBridgeDetail): void {
+    const command = detail.command;
+    if (command.type === "conversation.open") {
+      if (detail.phase === "dispatch") this.activeConversationId = command.conversationId;
+      return;
+    }
+    if (command.type !== "chat.send") return;
+
+    const requestId = command.requestId;
+    const isSelfHostedProjection = detail.context?.conversationKey?.startsWith("selfhosted:") ?? false;
+    const conversationId = command.conversationId || detail.context?.conversationId || this.activeConversationId;
+
+    if (detail.phase === "dispatch") {
+      if (isSelfHostedProjection || !conversationId) {
+        this.ignoredRequests.add(requestId);
+        this.refreshUnscopedSuppression();
+        return;
+      }
+      this.activeConversationId = conversationId;
+      this.requestConversations.set(requestId, conversationId);
+      this.appendConversationMessage(conversationId, {
+        id: `request:${requestId}:user`,
+        role: "user",
+        text: command.text,
+        createdAtMs: Date.now(),
+      }, true);
+      return;
+    }
+
+    if (detail.phase === "accepted") {
+      const operationId = detail.accepted.operationId;
+      if (this.ignoredRequests.delete(requestId)) {
+        if (operationId) this.ignoredOperations.add(operationId);
+        this.refreshUnscopedSuppression();
+        return;
+      }
+      const mappedConversationId = this.requestConversations.get(requestId) || conversationId;
+      this.requestConversations.delete(requestId);
+      if (operationId && mappedConversationId) {
+        this.operationConversations.set(operationId, mappedConversationId);
+        this.trimOperationMappings();
+      }
+      return;
+    }
+
+    this.requestConversations.delete(requestId);
+    this.ignoredRequests.delete(requestId);
+    this.refreshUnscopedSuppression();
+  }
+
+  private conversationIdForEvent(operationId?: string): string | null {
+    if (operationId) {
+      if (this.ignoredOperations.has(operationId)) return null;
+      const mapped = this.operationConversations.get(operationId);
+      if (mapped) return mapped;
+    }
+    if (this.suppressUnscopedRuntime) return null;
+    return this.activeConversationId;
+  }
+
+  private appendConversationMessage(
+    conversationId: string,
+    message: ConversationJournalMessage,
+    persistImmediately: boolean,
+  ): void {
+    const current = this.conversationJournal.conversations[conversationId] ?? [];
+    const merged = mergeConversationMessages(current, [message]);
+    this.setConversationMessages(conversationId, merged, persistImmediately);
+  }
+
+  private setConversationMessages(
+    conversationId: string,
+    messages: ConversationJournalMessage[],
+    persistImmediately: boolean,
+  ): void {
+    this.conversationJournal.conversations[conversationId] = messages.slice(-CONVERSATION_MESSAGE_LIMIT);
+    if (persistImmediately) this.flushConversationJournal();
+    else this.scheduleConversationJournalPersist();
+  }
+
+  private scheduleConversationJournalPersist(): void {
+    if (this.journalPersistTimer) return;
+    this.journalPersistTimer = setTimeout(() => {
+      this.journalPersistTimer = null;
+      persistConversationJournal(this.conversationJournal);
+    }, 120);
+  }
+
+  private flushConversationJournal(): void {
+    if (this.journalPersistTimer) {
+      clearTimeout(this.journalPersistTimer);
+      this.journalPersistTimer = null;
+    }
+    persistConversationJournal(this.conversationJournal);
+  }
+
+  private refreshUnscopedSuppression(): void {
+    this.suppressUnscopedRuntime = this.ignoredRequests.size > 0 || this.ignoredOperations.size > 0;
+  }
+
+  private trimOperationMappings(): void {
+    while (this.operationConversations.size > 256) {
+      const oldest = this.operationConversations.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.operationConversations.delete(oldest);
+    }
   }
 
   private startEventPump(): void {


### PR DESCRIPTION
## 根因（来自 exact-main real Rust Host E2E）

主分支 `75a7d5e94e6f…` 的完整 Linux Electron 旅程证明：

1. Agent Workbench 的语义归一等待下一动画帧，Playwright/无障碍/搜索可在此之前读到重复任务与结果文本；
2. Workbench 运行日志能恢复，但 Rust test Host 重启后 `conversation.opened` 为空，普通 Messenger 会话正文没有 UI 级恢复缓存，因此用户看到“运行还在、会话没了”。

## 修复

- Workbench 任务/结果投影在 React DOM commit 后的同一 MutationObserver microtask 立即归一，不再等待 `requestAnimationFrame`。
- Electron Mahayana Transport 新增有界本地会话日志（80 会话、每会话 240 条），仅保存 user/assistant 文本和时间，不保存工具秘密。
- `chat.send`、`chat.message`、`chat.delta` 与 operation/conversation 映射统一记录。
- `conversation.opened` 将 Host 权威历史与本地日志去重合并后再交给 Messenger；Host 有数据时继续以其历史为准，测试 Host/离线重启为空时恢复本地正文。
- 自建 self-hosted Bot 的 Mahayana 事件明确排除在 legacy journal 外，避免污染旧会话；其消息仍由现有 self-hosted store 持久化。
- 本地日志写入失败永不阻断 Agent 执行；流式 delta 节流写入，最终 message/打开会话同步落盘。

## 验收

- [ ] Renderer TypeScript / Electron contract
- [ ] real Linux Rust Host：全部 Playwright（含旧 smoke、Grok visual、Agent 多步骤与重启恢复）
- [ ] Windows/macOS packaged journeys
- [ ] protected-main merge + exact-main readback
- [ ] 非默认 Research Bot 的 Mahayana 多步骤旅程补充验证

GBF-507/601/602 仍保持 `IN_PROGRESS`，本 PR 不把本地恢复日志冒充最终 Rust canonical store。