### PR TITLE
fix(gbf): route self-hosted Bots through Mahayana and repair delivery gate

### DIFF
--- a/desktop/e2e/mahayana-agent-workbench.spec.ts
+++ b/desktop/e2e/mahayana-agent-workbench.spec.ts
@@ -49,6 +49,63 @@ async function openMahayanaConversation(page: Page): Promise<void> {
   await expect(page.getByTestId('messenger-input')).toBeVisible();
 }
 
+async function createSelfHostedBotAcceptanceChannel(page: Page): Promise<{ conversationId: string; peerTestId: string }> {
+  await page.getByTestId('profile-navigation-trigger').click();
+  const chats = page.getByTitle('聊天', { exact: true });
+  if (await chats.isVisible().catch(() => false)) await chats.click();
+  await page.getByRole('button', { name: '新建', exact: true }).click();
+  await page.getByRole('button', { name: '新建频道' }).click();
+  await page.getByPlaceholder('频道名称').fill('自建 Bot Mahayana 验收');
+  await page.getByPlaceholder('频道简介').fill('Rust messaging → Mahayana multi-step runtime');
+  await page.getByRole('button', { name: '创建频道' }).click();
+
+  const peer = page.locator('[data-testid^="peer-selfhosted:channel:"]').filter({ hasText: '自建 Bot Mahayana 验收' }).first();
+  await expect(peer).toBeVisible({ timeout: 10_000 });
+  const peerTestId = await peer.getAttribute('data-testid');
+  expect(peerTestId).toBeTruthy();
+  await peer.click();
+  await expect(page.getByTestId('messenger-input')).toBeVisible();
+  return {
+    peerTestId: peerTestId!,
+    conversationId: peerTestId!.replace(/^peer-selfhosted:/, ''),
+  };
+}
+
+async function emitBotInvocationRequested(
+  page: Page,
+  conversationId: string,
+  text: string,
+): Promise<string> {
+  return page.evaluate(({ conversationId: id, text: prompt }) => {
+    const invocationId = `invocation:e2e:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+    window.dispatchEvent(new CustomEvent('fabushi:mahayana-runtime-event', {
+      detail: {
+        type: 'messaging.event',
+        timestamp: new Date().toISOString(),
+        requestId: `messaging:e2e:${Date.now()}`,
+        envelope: {
+          protocolVersion: 2,
+          cursor: String(Date.now()),
+          serverTimeMs: Date.now(),
+          event: {
+            type: 'botInvocationRequested',
+            invocation: {
+              id: invocationId,
+              botId: 'bot:e2e:helper',
+              senderId: 'human:e2e',
+              conversationId: id,
+              text: { text: prompt, entities: [] },
+              metadata: { source: 'messaging-service' },
+              createdAtMs: Date.now(),
+            },
+          },
+        },
+      },
+    }));
+    return invocationId;
+  }, { conversationId, text });
+}
+
 test('bot runs through Mahayana as a visible multi-step task and restores its run journal', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-mahayana-workbench-'));
   let app: ElectronApplication | null = null;
@@ -86,6 +143,64 @@ test('bot runs through Mahayana as a visible multi-step task and restores its ru
     await expect(restoredRun).toHaveAttribute('data-status', 'completed');
     await expect.poll(async () => restoredRun.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
     await expect(page.getByRole('article').filter({ hasText: '收到：请分析这个任务' }).last()).toBeVisible();
+  } finally {
+    await app?.close().catch(() => undefined);
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});
+
+test('self-hosted Bot invocation is consumed by Mahayana multi-step runtime without actor impersonation and restores after restart', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-selfhosted-bot-mahayana-'));
+  let app: ElectronApplication | null = null;
+  const prompt = '自建 Bot 请规划步骤，调用 Mahayana 工具并完成这个任务。';
+
+  try {
+    app = await launchDesktopApp(appDataDir);
+    let page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    const { conversationId, peerTestId } = await createSelfHostedBotAcceptanceChannel(page);
+
+    // The authenticated human turn first goes through the canonical Rust messaging store.
+    await page.getByTestId('messenger-input').fill(prompt);
+    await page.getByTestId('messenger-send').click();
+    await expect(page.getByRole('article').filter({ hasText: prompt }).last()).toBeVisible({ timeout: 10_000 });
+
+    // The Rust messaging service has a separate contract test proving that a
+    // human message to a Bot produces this exact BotInvocationRequested event.
+    // Here we verify the Electron consumer half: event -> Mahayana -> visible run.
+    const invocationId = await emitBotInvocationRequested(page, conversationId, prompt);
+    expect(invocationId).toContain('invocation:e2e:');
+
+    const run = page.getByTestId('agent-run').last();
+    await expect(run).toBeVisible({ timeout: 15_000 });
+    await expect(run).toHaveAttribute('data-status', 'completed', { timeout: 15_000 });
+    await expect.poll(async () => run.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
+    await expect(run).toContainText('Mahayana');
+    await expect(page.locator('#mahayana-agent-header-avatar [data-agent-state="result"]')).toBeVisible();
+
+    const persistedRunId = await run.getAttribute('data-run-id');
+    expect(persistedRunId).toBeTruthy();
+    await expect.poll(async () => page.evaluate(() => {
+      const journal = JSON.parse(localStorage.getItem('fabushi.desktop.selfhosted-mahayana-invocations.v1') || 'null');
+      return Object.values(journal?.claims || {}).some((claim: unknown) =>
+        Boolean(claim && typeof claim === 'object' && (claim as { state?: string }).state === 'accepted'));
+    })).toBe(true);
+
+    await app.close();
+    app = null;
+
+    app = await launchDesktopApp(appDataDir);
+    page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    const restoredPeer = page.getByTestId(peerTestId);
+    await expect(restoredPeer).toBeVisible({ timeout: 15_000 });
+    await restoredPeer.click();
+    await expect(page.getByRole('article').filter({ hasText: prompt }).last()).toBeVisible({ timeout: 10_000 });
+
+    const restoredRun = page.locator(`[data-testid="agent-run"][data-run-id="${persistedRunId}"]`);
+    await expect(restoredRun).toBeVisible({ timeout: 15_000 });
+    await expect(restoredRun).toHaveAttribute('data-status', 'completed');
+    await expect.poll(async () => restoredRun.getByTestId('agent-step').count()).toBeGreaterThanOrEqual(3);
   } finally {
     await app?.close().catch(() => undefined);
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -91,6 +91,12 @@ test('Electron transport keeps Mini Apps out of chat conversations and routes di
       async openSystemSettings() {},
       async windowFocused() { return true; },
     },
+    // ElectronMahayanaHostTransport is renderer-only and installs a command
+    // observer on the browser Window EventTarget. This direct Node regression
+    // substitutes a minimal window object, so model that EventTarget contract
+    // instead of accidentally testing an impossible partial browser Window.
+    addEventListener() {},
+    removeEventListener() {},
   };
   const globalWithWindow = globalThis as unknown as { window?: typeof fakeWindow };
   const previousWindow = globalWithWindow.window;

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import DesktopShellV2 from './messaging-shell-v2';
 import MahayanaAgentWorkbench from './mahayana-agent-workbench';
 import { installMahayanaAgentTranscriptSemantics } from './mahayana-agent-transcript-semantics';
+import { installSelfHostedMahayanaInvocationBridge } from './selfhosted-mahayana-invocation-bridge';
 import './messenger-layout-regressions.css';
 import './grok-agent-ui-parity.css';
 import './mahayana-agent-transcript-semantics.css';
@@ -20,3 +21,4 @@ createRoot(root).render(
 );
 
 installMahayanaAgentTranscriptSemantics();
+installSelfHostedMahayanaInvocationBridge();

--- a/desktop/src/selfhosted-mahayana-invocation-bridge.ts
+++ b/desktop/src/selfhosted-mahayana-invocation-bridge.ts
@@ -1,0 +1,225 @@
+import type { CommandAccepted, RuntimeCommand } from '../../frontend/apps/web/src/lib/mahayana-host/contracts';
+import {
+  MAHAYANA_COMMAND_EVENT_NAME,
+  MAHAYANA_RUNTIME_EVENT_NAME,
+  type MahayanaCommandBridgeContext,
+  type MahayanaCommandBridgeDetail,
+} from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
+
+const CLAIMS_KEY = 'fabushi.desktop.selfhosted-mahayana-invocations.v1';
+const CLAIMS_VERSION = 1;
+const MAX_CLAIMS = 256;
+const INFLIGHT_TTL_MS = 5 * 60_000;
+const RUNTIME_AGENT_ID = 'mahayana-assistant';
+
+type ChatSendCommand = Extract<RuntimeCommand, { type: 'chat.send' }>;
+
+type SelfHostedBotInvocation = {
+  id: string;
+  botId: string;
+  senderId: string;
+  conversationId: string;
+  text: string;
+  command?: string;
+  createdAtMs: number;
+};
+
+type InvocationClaim = {
+  state: 'inflight' | 'accepted' | 'failed';
+  updatedAtMs: number;
+};
+
+type InvocationClaimJournal = {
+  version: 1;
+  claims: Record<string, InvocationClaim>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function parseInvocation(detail: unknown): SelfHostedBotInvocation | null {
+  const runtimeEvent = asRecord(detail);
+  if (runtimeEvent?.type !== 'messaging.event') return null;
+  const envelope = asRecord(runtimeEvent.envelope);
+  const event = asRecord(envelope?.event);
+  if (event?.type !== 'botInvocationRequested') return null;
+  const invocation = asRecord(event.invocation);
+  const formattedText = asRecord(invocation?.text);
+  const id = asNonEmptyString(invocation?.id);
+  const botId = asNonEmptyString(invocation?.botId);
+  const senderId = asNonEmptyString(invocation?.senderId);
+  const conversationId = asNonEmptyString(invocation?.conversationId);
+  const text = asNonEmptyString(formattedText?.text);
+  if (!id || !botId || !senderId || !conversationId || !text) return null;
+  return {
+    id,
+    botId,
+    senderId,
+    conversationId,
+    text,
+    command: asNonEmptyString(invocation?.command) ?? undefined,
+    createdAtMs: typeof invocation?.createdAtMs === 'number' && Number.isFinite(invocation.createdAtMs)
+      ? invocation.createdAtMs
+      : Date.now(),
+  };
+}
+
+function emptyJournal(): InvocationClaimJournal {
+  return { version: CLAIMS_VERSION, claims: {} };
+}
+
+function readJournal(): InvocationClaimJournal {
+  if (typeof window === 'undefined') return emptyJournal();
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(CLAIMS_KEY) || 'null') as unknown;
+    const record = asRecord(parsed);
+    const rawClaims = asRecord(record?.claims);
+    if (record?.version !== CLAIMS_VERSION || !rawClaims) return emptyJournal();
+    const claims = Object.fromEntries(
+      Object.entries(rawClaims)
+        .map(([id, value]) => {
+          const claim = asRecord(value);
+          const state = claim?.state;
+          const updatedAtMs = claim?.updatedAtMs;
+          if (
+            !id ||
+            (state !== 'inflight' && state !== 'accepted' && state !== 'failed') ||
+            typeof updatedAtMs !== 'number' ||
+            !Number.isFinite(updatedAtMs)
+          ) return null;
+          return [id, { state, updatedAtMs } satisfies InvocationClaim] as const;
+        })
+        .filter((entry): entry is readonly [string, InvocationClaim] => Boolean(entry))
+        .sort((left, right) => right[1].updatedAtMs - left[1].updatedAtMs)
+        .slice(0, MAX_CLAIMS),
+    );
+    return { version: CLAIMS_VERSION, claims };
+  } catch {
+    return emptyJournal();
+  }
+}
+
+function persistJournal(journal: InvocationClaimJournal): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const claims = Object.fromEntries(
+      Object.entries(journal.claims)
+        .sort((left, right) => right[1].updatedAtMs - left[1].updatedAtMs)
+        .slice(0, MAX_CLAIMS),
+    );
+    window.localStorage.setItem(CLAIMS_KEY, JSON.stringify({ version: CLAIMS_VERSION, claims }));
+  } catch {
+    // This journal is only an idempotency aid. Storage pressure must never block a live task.
+  }
+}
+
+function shouldSkipClaim(claim: InvocationClaim | undefined, nowMs: number): boolean {
+  if (!claim) return false;
+  if (claim.state === 'accepted') return true;
+  return claim.state === 'inflight' && nowMs - claim.updatedAtMs < INFLIGHT_TTL_MS;
+}
+
+function dispatchBridgeDetail(detail: MahayanaCommandBridgeDetail): void {
+  window.dispatchEvent(new CustomEvent<MahayanaCommandBridgeDetail>(MAHAYANA_COMMAND_EVENT_NAME, { detail }));
+}
+
+function messageForInvocation(invocation: SelfHostedBotInvocation): string {
+  if (!invocation.command) return invocation.text;
+  return invocation.text.startsWith('/') ? invocation.text : `/${invocation.command} ${invocation.text}`.trim();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Bridges the Rust-native self-hosted messaging BotInvocationRequested event into
+ * the single Mahayana Agent runtime. The authenticated human message remains in
+ * the Rust messaging store; this bridge never impersonates a Bot to write back
+ * into messaging. Workbench projection identity is the self-hosted Bot while the
+ * actual executor stays the canonical Mahayana runtime agent.
+ */
+export function installSelfHostedMahayanaInvocationBridge(): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const journal = readJournal();
+  let disposed = false;
+
+  const mark = (id: string, state: InvocationClaim['state']) => {
+    journal.claims[id] = { state, updatedAtMs: Date.now() };
+    persistJournal(journal);
+  };
+
+  const executeInvocation = async (invocation: SelfHostedBotInvocation) => {
+    const bridge = window.mahayana;
+    if (!bridge?.invoke || disposed) return;
+
+    const nowMs = Date.now();
+    if (shouldSkipClaim(journal.claims[invocation.id], nowMs)) return;
+    mark(invocation.id, 'inflight');
+
+    const requestId = `selfhosted-bot:${invocation.id}`;
+    const projectionCommand: ChatSendCommand = {
+      type: 'chat.send',
+      requestId,
+      text: messageForInvocation(invocation),
+      agentId: invocation.botId,
+      mode: 'agent',
+      modeStatement: [
+        `Execute as the Fabushi self-hosted Bot ${invocation.botId}.`,
+        `The authenticated sender is ${invocation.senderId}.`,
+        `The source Messenger conversation is ${invocation.conversationId}.`,
+        'Use Mahayana planning, tools, approvals and multiple steps when the task requires them.',
+        'Return the final result to the active Messenger Agent Workbench surface.',
+      ].join(' '),
+    };
+    const context: MahayanaCommandBridgeContext = {
+      conversationKey: `selfhosted:${invocation.conversationId}`,
+      conversationId: invocation.conversationId,
+      agentId: invocation.botId,
+    };
+
+    dispatchBridgeDetail({ phase: 'dispatch', command: projectionCommand, context });
+
+    // The self-hosted Bot id is a messaging identity, not permission to invent a
+    // second runtime agent. Execute on Mahayana's canonical agent while keeping
+    // the Bot identity in the projection context above.
+    const runtimeCommand: ChatSendCommand = {
+      ...projectionCommand,
+      agentId: RUNTIME_AGENT_ID,
+      conversationId: undefined,
+    };
+
+    try {
+      const accepted = await bridge.invoke<CommandAccepted>('feature.execute', { command: runtimeCommand });
+      mark(invocation.id, 'accepted');
+      dispatchBridgeDetail({ phase: 'accepted', command: projectionCommand, accepted, context });
+    } catch (error) {
+      mark(invocation.id, 'failed');
+      dispatchBridgeDetail({
+        phase: 'failed',
+        command: projectionCommand,
+        error: errorMessage(error),
+        context,
+      });
+    }
+  };
+
+  const onRuntimeEvent = (event: Event) => {
+    const invocation = parseInvocation((event as CustomEvent<unknown>).detail);
+    if (!invocation) return;
+    void executeInvocation(invocation);
+  };
+
+  window.addEventListener(MAHAYANA_RUNTIME_EVENT_NAME, onRuntimeEvent);
+  return () => {
+    disposed = true;
+    window.removeEventListener(MAHAYANA_RUNTIME_EVENT_NAME, onRuntimeEvent);
+  };
+}


### PR DESCRIPTION
## Context

Exact-main delivery for `GBF-507` at `7fb1cd1f5749bb206dd3cf04da5c78612d6e6d25` correctly stopped before Release in Electron run `32803828364`. That run exposed two issues which must be fixed before publishing:

1. the direct Node regression fixture supplied a partial synthetic `window` without the browser EventTarget methods now legitimately used by `ElectronMahayanaHostTransport`;
2. audit of `GBF-507-A2` found the compatibility submit interception could not match normal self-hosted direct peers because Messenger classifies them as `conversation`, so a self-hosted Bot event was not reliably entering Mahayana.

## Fix

- Repair the direct transport regression fixture by modeling `addEventListener/removeEventListener`; production transport behavior is unchanged.
- Add `selfhosted-mahayana-invocation-bridge.ts`, consuming the Rust messaging protocol `botInvocationRequested` event.
- Preserve the security boundary: the renderer never impersonates a Bot actor. The authenticated human message stays in the Rust messaging store; the invocation executes on the single canonical `mahayana-assistant` runtime while the self-hosted Bot identity/conversation is retained in Workbench projection context.
- Dispatch the normal Mahayana command lifecycle so operation IDs, multi-step events, tools, approvals, Usage and BotMark state all bind to the self-hosted Messenger conversation.
- Persist a bounded invocation idempotency journal so replayed accepted invocations do not duplicate execution.
- Add Electron E2E proving a self-hosted messaging turn + `botInvocationRequested` consumer produces a completed Mahayana run with >=3 lifecycle/step nodes, result avatar state, and survives application restart. The Rust producer half is already covered by `human_group_message_requests_bot_execution_inside_messaging_service` in `native/mahayana-messaging/tests/service_contract.rs`.

## Acceptance

- [ ] final-head Renderer TypeScript / Electron / CI / Host gates green
- [ ] self-hosted Bot E2E shows Mahayana multi-step run and restart recovery
- [ ] merge through required merge queue
- [ ] exact-main Electron packaged-user E2E green
- [ ] same exact-main SHA Native iOS + Android gates green
- [ ] automatic post-main Release created from the tested exact SHA with updater metadata/assets
- [ ] GBF project task/WBS/status/evidence records closed against exact merge/run/release facts

Project: `FAB-P0004 / GBF-507`. No failing E2E is waived and the self-hosted messaging actor-impersonation guard remains intact.