### PR TITLE
fix(tfi): stabilize Motion v2 avatar portal lifecycle

### DIFF
--- a/desktop/src/mahayana-agent-workbench.module.css
+++ b/desktop/src/mahayana-agent-workbench.module.css
@@ -2,6 +2,14 @@
   display: contents;
 }
 
+:global([data-mahayana-avatar-portal="true"]) > :global([data-engine="fabushi-motion-v2"]) {
+  display: none !important;
+}
+
+:global([data-mahayana-avatar-portal="true"]) > .portalRoot :global([data-engine="fabushi-motion-v2"]) {
+  display: inline-flex !important;
+}
+
 .portalAvatar {
   flex: 0 0 auto;
 }

--- a/desktop/src/mahayana-agent-workbench.tsx
+++ b/desktop/src/mahayana-agent-workbench.tsx
@@ -1094,7 +1094,9 @@ function RunCard({
 
 function ensurePortalRoot(id: string, parent: HTMLElement | null, before?: Element | null): HTMLElement | null {
   const existing = document.getElementById(id);
+  const previousParent = existing?.parentElement instanceof HTMLElement ? existing.parentElement : null;
   if (!parent) {
+    if (previousParent) delete previousParent.dataset.mahayanaAvatarPortal;
     existing?.remove();
     return null;
   }
@@ -1105,10 +1107,12 @@ function ensurePortalRoot(id: string, parent: HTMLElement | null, before?: Eleme
     root.dataset.sourceBotId = before.dataset.botId || '';
     root.dataset.sourceLabel = before.getAttribute('aria-label') || '';
   }
+  if (previousParent && previousParent !== parent) delete previousParent.dataset.mahayanaAvatarPortal;
   if (root.parentElement !== parent) {
     if (before) parent.insertBefore(root, before);
     else parent.appendChild(root);
   }
+  parent.dataset.mahayanaAvatarPortal = 'true';
   return root;
 }
 

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -153,3 +153,10 @@
 - 根因三：`infoPanelVisible` 强依赖 `window.innerWidth > 1280`，Retina/缩放后的 CSS viewport 会直接禁用右栏。
 - 当前 branch `fix/tfi-bot-avatar-info-panel` 已实现 stale avatar restore、identity preservation、conversation-scoped animation state、wide dock / narrow overlay info panel 与 Playwright 回归。
 - 状态 `IMPLEMENTED`；等待 GitHub current-head CI、protected merge、exact-main packaged E2E，随后与 M8 marketplace 一起发布。
+
+## 2026-08-25 — M7-DESKTOP-004 exact-main portal lifecycle follow-up
+
+- Exact-main Electron run `32812505326` blocked Release on the new avatar regression: active peer had two visible Motion v2 marks after React re-render restored the original inline display.
+- Fix moves hiding authority to `data-mahayana-avatar-portal` + CSS direct-child suppression, so React-owned style reconciliation cannot resurrect the replaced original.
+- Portal relocation clears the prior parent marker, preserving the already-fixed peer-switch restore behavior.
+- Release remains blocked pending protected follow-up merge and a fully green new exact-main delivery.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -143,3 +143,10 @@
 - workbench avatar activity 不再跨会话借用另一 Bot 的 active run。
 - 右资料栏移除 `<=1280px` 禁渲染行为：宽屏保持第三列，窄屏改为右侧 overlay drawer。
 - 新增 Messenger Playwright 回归覆盖连续 peer switch、Motion v2 可见性/identity 与 1100px viewport 资料栏打开。
+
+## 2026-08-25 — M7-DESKTOP-004 exact-main portal lifecycle follow-up
+
+- Exact-main Electron run `32812505326` blocked Release on the new avatar regression: active peer had two visible Motion v2 marks after React re-render restored the original inline display.
+- Fix moves hiding authority to `data-mahayana-avatar-portal` + CSS direct-child suppression, so React-owned style reconciliation cannot resurrect the replaced original.
+- Portal relocation clears the prior parent marker, preserving the already-fixed peer-switch restore behavior.
+- Release remains blocked pending protected follow-up merge and a fully green new exact-main delivery.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
@@ -35,3 +35,11 @@
 ## Completion gate
 
 Keep below `RELEASED` until required current-head CI, protected merge, canonical-main readback, exact-main packaged E2E and the new GitHub Release all exist.
+
+## Exact-main delivery retry — 2026-08-25
+
+- Product main `3dd5e2e8122f0ac142a33002c969930ab4c05bf8` reached Electron run `32812505326`.
+- Linux real-Host E2E retained diagnostics artifact `9550324929` and correctly blocked publication.
+- New regression failed because the active peer contained two visible Motion v2 marks after Messenger re-render: the React-owned original mark had its external inline `display:none` overwritten while the Workbench portal mark remained.
+- Follow-up branch `fix/tfi-avatar-portal-e2e` replaces fragile inline-only hiding with a parent portal marker and CSS-enforced direct-child suppression, while clearing the marker whenever the portal moves.
+- Status remains `IMPLEMENTED`; Release is blocked until the follow-up merges and a new exact-main delivery is green.


### PR DESCRIPTION
## FAB-P0001 / TFI — M7-DESKTOP-004 exact-main follow-up

The first exact-main delivery attempt (`3dd5e2e8122f0ac142a33002c969930ab4c05bf8`, Electron run `32812505326`) correctly blocked Release because the new avatar regression observed two visible Motion v2 marks in the active peer after Messenger re-render.

### Root cause
The Workbench hid the React-owned original BotMark via external inline `display:none`. Clicking a peer changes Messenger state; React reconciled the BotMark and restored its own style while the Workbench portal replacement remained visible.

### Fix
- mark only the current portal parent with `data-mahayana-avatar-portal=true`;
- CSS-enforce suppression of that parent's direct React-owned Motion v2 child, so React style reconciliation cannot resurrect it;
- clear the marker from the previous parent whenever the portal moves or is removed;
- preserve the existing stale-mark restoration and deterministic identity preservation from #2115.

### Evidence
- failed exact-main run retained diagnostics artifact `9550324929` (screenshots/trace/report), proving the failure instead of waiving it;
- existing regression `switching peers keeps dynamic avatars visible and narrow layouts can open the info panel` remains the acceptance test and must pass on this PR/current main.

Release remains blocked until this PR passes required checks, protected merge completes, and the resulting exact `main` SHA passes packaged Electron + native mobile delivery and publishes a newer GitHub Release.