### PR TITLE
fix(project): restore immutable FAB-P0008 registry history

### DIFF
--- a/projects/PORTFOLIO.json
+++ b/projects/PORTFOLIO.json
@@ -104,7 +104,7 @@
       "authoritative_path": "projects/fabushi-account-access-control",
       "status": "active",
       "registered_at": "2026-08-25",
-      "first_canonical_main_commit": "52b7c10889e585660b7d2a22a40781c22f31b7a1",
+      "first_canonical_main_commit": "039e18269280cffb5749bd41a719d61dfa5761d6",
       "legacy_project_ids": []
     }
   ]


### PR DESCRIPTION
## Closed as not applicable after validator review

This attempted to restore the pre-merge-queue registry SHA, but `Project portfolio governance` correctly rejected *any* mutation of an already-registered `first_canonical_main_commit` relative to the current protected-main baseline. The main registry now records the actual canonical merge-queue SHA `52b7c10889e585660b7d2a22a40781c22f31b7a1`, and no runtime code is involved here.

The PR is intentionally closed rather than bypassing or weakening the governance validator. Runtime implementation remains on `main` from #2117.