### PR TITLE
test(tfi): count semantic Motion v2 BotMark identities

### DIFF
--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -91,10 +91,6 @@ test('Electron transport keeps Mini Apps out of chat conversations and routes di
       async openSystemSettings() {},
       async windowFocused() { return true; },
     },
-    // ElectronMahayanaHostTransport is renderer-only and installs a command
-    // observer on the browser Window EventTarget. This direct Node regression
-    // substitutes a minimal window object, so model that EventTarget contract
-    // instead of accidentally testing an impossible partial browser Window.
     addEventListener() {},
     removeEventListener() {},
   };
@@ -194,7 +190,9 @@ test('switching peers keeps dynamic avatars visible and narrow layouts can open 
 
     const first = peers.nth(0);
     const second = peers.nth(1);
-    const visibleMark = '[data-engine="fabushi-motion-v2"]:visible';
+    // BotMark intentionally exposes the engine marker on both its semantic wrapper and inner SVG.
+    // Count only the semantic outer mark carrying data-bot-id, so one avatar equals one identity.
+    const visibleMark = '[data-engine="fabushi-motion-v2"][data-bot-id]:visible';
 
     await first.click();
     await expect(first.locator(visibleMark)).toHaveCount(1);

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
@@ -43,3 +43,11 @@ Keep below `RELEASED` until required current-head CI, protected merge, canonical
 - New regression failed because the active peer contained two visible Motion v2 marks after Messenger re-render: the React-owned original mark had its external inline `display:none` overwritten while the Workbench portal mark remained.
 - Follow-up branch `fix/tfi-avatar-portal-e2e` replaces fragile inline-only hiding with a parent portal marker and CSS-enforced direct-child suppression, while clearing the marker whenever the portal moves.
 - Status remains `IMPLEMENTED`; Release is blocked until the follow-up merges and a new exact-main delivery is green.
+
+## Exact-main selector correction — 2026-08-25
+
+- Follow-up product main `c0b5534d0c0e1b6fb916819c499adbdd5b855b46` reached Electron run `32812950533`; the real-Host journey retained diagnostics artifact `9550478342` and again blocked publication.
+- The retained screenshot shows one rendered BotMark. Source inspection proves the semantic BotMark wrapper and its inner SVG both intentionally carry `data-engine="fabushi-motion-v2"`, so the original regression locator counted two DOM nodes for one visible avatar identity.
+- Acceptance is corrected, not weakened: only the semantic outer BotMark carrying `data-bot-id` is counted via `[data-engine="fabushi-motion-v2"][data-bot-id]:visible`.
+- Peer switching, stable `data-bot-id` identity, and the 1100px right info drawer remain mandatory assertions.
+- Branch `fix/tfi-avatar-regression-selector-v2` is based on the current canonical main `54eeb8ad3caf64c02ef834142cb63d38b12033a9`; Release remains blocked until this correction passes protected merge and a later exact-main product delivery is fully green.


### PR DESCRIPTION
## FAB-P0001 / TFI — M7-DESKTOP-004 exact-main acceptance correction

The exact-main delivery for `c0b5534d0c0e1b6fb916819c499adbdd5b855b46` correctly blocked publication in Electron run `32812950533` and retained diagnostics artifact `9550478342`.

The retained screenshot shows one rendered avatar. Source inspection proves one `BotMark` intentionally exposes `data-engine="fabushi-motion-v2"` on both the semantic wrapper and its internal SVG, so the regression locator counted two DOM nodes for one avatar.

### Correction
- change the visible avatar locator to `[data-engine="fabushi-motion-v2"][data-bot-id]:visible`;
- this counts only the semantic outer BotMark identity;
- keep all product acceptance unchanged: switch two peers, require one visible semantic avatar for each, preserve `data-bot-id` in the active header, and open the right info drawer at 1100px.

This is test precision, not a waiver. The product will remain unreleased until this PR merges and the resulting latest-main SHA passes the complete packaged Electron + native mobile delivery gates.