### PR TITLE
fix(tfi): bind Motion v2 portals to selected peer identity

### DIFF
--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -193,16 +193,17 @@ test('switching peers keeps dynamic avatars visible and narrow layouts can open 
     // BotMark intentionally exposes the engine marker on both its semantic wrapper and inner SVG.
     // Count only the semantic outer mark carrying data-bot-id, so one avatar equals one identity.
     const visibleMark = '[data-engine="fabushi-motion-v2"][data-bot-id]:visible';
+    const headerIdentity = page.getByTestId('conversation-status').locator('xpath=../..');
+    const headerMark = headerIdentity.locator(visibleMark);
 
     await first.click();
     await expect(first.locator(visibleMark)).toHaveCount(1);
+    await expect(headerMark).toHaveCount(1);
+    expect(await headerMark.getAttribute('data-bot-id')).toBe(await first.locator(visibleMark).getAttribute('data-bot-id'));
 
     await second.click();
     await expect(second.locator(visibleMark)).toHaveCount(1);
     await expect(first.locator(visibleMark)).toHaveCount(1);
-
-    const headerIdentity = page.getByTestId('conversation-status').locator('xpath=../..');
-    const headerMark = headerIdentity.locator(visibleMark);
     await expect(headerMark).toHaveCount(1);
     expect(await headerMark.getAttribute('data-bot-id')).toBe(await second.locator(visibleMark).getAttribute('data-bot-id'));
 
@@ -218,6 +219,15 @@ test('switching peers keeps dynamic avatars visible and narrow layouts can open 
     await toggle.click();
     await expect(infoPanel).toBeVisible();
     await expect(infoPanel).toHaveAttribute('data-overlay', 'true');
+    const infoMark = infoPanel.locator(visibleMark);
+    await expect(infoMark).toHaveCount(1);
+    expect(await infoMark.getAttribute('data-bot-id')).toBe(await second.locator(visibleMark).getAttribute('data-bot-id'));
+
+    await first.click();
+    await expect(headerMark).toHaveCount(1);
+    expect(await headerMark.getAttribute('data-bot-id')).toBe(await first.locator(visibleMark).getAttribute('data-bot-id'));
+    await expect(infoMark).toHaveCount(1);
+    expect(await infoMark.getAttribute('data-bot-id')).toBe(await first.locator(visibleMark).getAttribute('data-bot-id'));
   } finally {
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });

--- a/desktop/src/mahayana-agent-workbench.tsx
+++ b/desktop/src/mahayana-agent-workbench.tsx
@@ -166,6 +166,8 @@ type PortalTargets = {
   headerAvatar: HTMLElement | null;
   peerAvatar: HTMLElement | null;
   infoAvatar: HTMLElement | null;
+  activeBotId: string;
+  activeLabel: string;
 };
 
 const EMPTY_TARGETS: PortalTargets = {
@@ -173,6 +175,8 @@ const EMPTY_TARGETS: PortalTargets = {
   headerAvatar: null,
   peerAvatar: null,
   infoAvatar: null,
+  activeBotId: '',
+  activeLabel: '',
 };
 
 function nowFromTimestamp(timestamp?: string): number {
@@ -851,9 +855,10 @@ function activePeerContext(): { peerKey: string; kind: string; actorId: string }
   const button = activePeerButton();
   const testId = button?.getAttribute('data-testid');
   if (!button || !testId) return null;
-  const status = document.querySelector<HTMLElement>('[data-testid="conversation-status"]');
-  const identity = status?.parentElement?.parentElement;
-  const mark = identity?.querySelector<HTMLElement>('[data-bot-id^="peer:"]');
+  // The selected peer row is the canonical identity source. Never read the
+  // Workbench-owned header portal here: after a peer switch that portal can
+  // still contain the previous BotMark until React commits the next render.
+  const mark = directChildBotMark(button);
   const botId = mark?.dataset.botId;
   if (!botId) return null;
   const parts = botId.split(':');
@@ -1189,6 +1194,8 @@ export default function MahayanaAgentWorkbench() {
       const peerOriginal = activeButton ? directChildBotMark(activeButton) : null;
       const peerAvatar = ensurePortalRoot('mahayana-agent-peer-avatar', activeButton, peerOriginal);
       hideOriginal(peerOriginal);
+      const activeBotId = peerOriginal?.dataset.botId || identityOriginal?.dataset.botId || '';
+      const activeLabel = peerOriginal?.getAttribute('aria-label') || identityOriginal?.getAttribute('aria-label') || '';
 
       const profileCard = workspace?.querySelector<HTMLElement>('aside [class*="profileCard"]') || null;
       const infoOriginal = profileCard ? directChildBotMark(profileCard) : null;
@@ -1214,9 +1221,11 @@ export default function MahayanaAgentWorkbench() {
         current.timeline === timeline &&
         current.headerAvatar === headerAvatar &&
         current.peerAvatar === peerAvatar &&
-        current.infoAvatar === infoAvatar
+        current.infoAvatar === infoAvatar &&
+        current.activeBotId === activeBotId &&
+        current.activeLabel === activeLabel
           ? current
-          : { timeline, headerAvatar, peerAvatar, infoAvatar },
+          : { timeline, headerAvatar, peerAvatar, infoAvatar, activeBotId, activeLabel },
       );
     };
 
@@ -1283,14 +1292,18 @@ export default function MahayanaAgentWorkbench() {
 
   const activeRun = visibleRuns.length ? visibleRuns[visibleRuns.length - 1] : undefined;
   const avatarState = activeRun?.visualState || 'idle';
-  const avatarBotId = activeRun?.agentId || activePeerContext()?.actorId || 'mahayana-assistant';
-  const portalIdentity = (target: HTMLElement | null, fallback: string) => ({
-    botId: target?.dataset.sourceBotId || fallback,
-    label: target?.dataset.sourceLabel || avatarBotId,
-  });
-  const headerIdentity = portalIdentity(targets.headerAvatar, `peer:bot:${avatarBotId}`);
-  const peerIdentity = portalIdentity(targets.peerAvatar, `peer:bot:${avatarBotId}`);
-  const infoIdentity = portalIdentity(targets.infoAvatar, `peer:bot:${avatarBotId}`);
+  const fallbackAgentId = activeRun?.agentId || 'mahayana-assistant';
+  // Identity belongs to the selected Messenger peer, while animation state
+  // belongs to the selected conversation's Mahayana run. Keeping those two
+  // concerns separate prevents a stale portal BotMark from becoming the next
+  // peer's identity source.
+  const activeIdentity = {
+    botId: targets.activeBotId || `peer:bot:${fallbackAgentId}`,
+    label: targets.activeLabel || fallbackAgentId,
+  };
+  const headerIdentity = activeIdentity;
+  const peerIdentity = activeIdentity;
+  const infoIdentity = activeIdentity;
 
   useEffect(() => {
     const status = document.querySelector<HTMLElement>('[data-testid="conversation-status"]');

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
@@ -10,3 +10,24 @@
 ## Pending release evidence
 
 Record final PR/head checks, protected merge SHA, canonical-main packaged E2E visual artifacts and the new Release tag/target/assets after they are produced.
+
+
+## Exact-main failure evidence — selected-peer identity
+
+- Canonical main: `6ae21cba7878d113ac2902df94d867e7d3b7cd34`.
+- Electron delivery: `32813752100`.
+- Linux real-Host diagnostics: artifact `9550721736`.
+- Failure: selected peer `peer:bot:incident-bot`; Header semantic Motion v2 identity `peer:conversation:codex:agent:assistant`.
+- This evidence blocks Release and is treated as a product failure, not a waived assertion.
+
+## Follow-up implementation
+
+- Branch: `fix/tfi-selected-peer-avatar-identity`.
+- Identity authority: active peer row direct semantic BotMark.
+- React portal state now includes selected `activeBotId` + label; runtime task state remains independent.
+- Regression covers first → second → first peer Header identity and 1100px overlay info-panel identity.
+- Open-source-first reference: official `facebook/react` (MIT) portal/reconciliation design; architectural principle adapted, no source copied.
+
+## Pending closure
+
+Record protected merge SHA, final exact-main Electron/native runs, retained screenshot/video/trace/report artifact IDs, Release tag, target commit and updater assets only after they exist.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -91,3 +91,8 @@ Acceptance traceability:
 - Verification contracts: `ai-backend/test/miniapp_marketplace.test.js`, `ai-backend/test/miniapp_marketplace_http.test.js`.
 - Package distribution: external immutable GitHub source URLs + SHA-256/size in `mahayana.external-release.v1`; marketplace API declares `marketplaceHostsPackage: false` and does not proxy package bytes.
 - Remaining gate for this task: protected canonical-main readback, exact-main packaged/E2E and a strictly newer GitHub Release. Full M8 authorization/revocation/sandbox closure remains a separate broader-stage requirement.
+
+
+## M7-DESKTOP-004 selected-peer identity acceptance — 2026-08-25
+
+`main@6ae21cba7878d113ac2902df94d867e7d3b7cd34` / Electron `32813752100` 证明头像“可见”之外仍存在身份一致性缺口：选择 `Incident Bot` 后 Header 仍保留上一 Agent 的 Motion v2 `data-bot-id`。因此 M7-DESKTOP-004 继续为 `IMPLEMENTED / RELEASE_BLOCKED`。验收现在明确要求：连续 peer 切换时 selected row、Header、窄屏 info drawer 的 semantic BotMark `data-bot-id` 必须始终等于当前 peer，并在切回前一个 peer 后再次成立；随后才允许 exact-main Release。

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -160,3 +160,11 @@
 - Fix moves hiding authority to `data-mahayana-avatar-portal` + CSS direct-child suppression, so React-owned style reconciliation cannot resurrect the replaced original.
 - Portal relocation clears the prior parent marker, preserving the already-fixed peer-switch restore behavior.
 - Release remains blocked pending protected follow-up merge and a fully green new exact-main delivery.
+
+
+## 2026-08-25 — M7-DESKTOP-004 selected-peer identity delivery block
+
+- Latest canonical delivery `main@6ae21cba7878d113ac2902df94d867e7d3b7cd34`, Electron run `32813752100`, remains blocked.
+- 17/18 Linux real-Host E2E cases passed; task-specific peer-switch regression exposed Header identity staying on the previous Agent after selecting Incident Bot. Evidence artifact: `9550721736`.
+- Follow-up `fix/tfi-selected-peer-avatar-identity` removes the Header portal as an identity authority, uses the active peer row direct BotMark, and makes active identity an explicit React state input so a stable portal node cannot retain stale identity.
+- No desktop Release is allowed until this branch merges and a later exact-main desktop/mobile delivery is fully green.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -150,3 +150,11 @@
 - Fix moves hiding authority to `data-mahayana-avatar-portal` + CSS direct-child suppression, so React-owned style reconciliation cannot resurrect the replaced original.
 - Portal relocation clears the prior parent marker, preserving the already-fixed peer-switch restore behavior.
 - Release remains blocked pending protected follow-up merge and a fully green new exact-main delivery.
+
+
+## 2026-08-25 — M7-DESKTOP-004 exact-main identity follow-up
+
+- Recorded failed Electron delivery run `32813752100` / artifact `9550721736` for `main@6ae21cba...`.
+- Fixed stale Header portal identity by making the selected peer row direct Motion v2 BotMark canonical and carrying `activeBotId/activeLabel` through React state.
+- Strengthened Playwright to validate Header + info drawer identity across second-peer selection and switch-back.
+- Recorded official React (MIT) portal/reconciliation review; adopted state-ownership principle only, with no copied upstream code.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
@@ -51,3 +51,18 @@ Keep below `RELEASED` until required current-head CI, protected merge, canonical
 - Acceptance is corrected, not weakened: only the semantic outer BotMark carrying `data-bot-id` is counted via `[data-engine="fabushi-motion-v2"][data-bot-id]:visible`.
 - Peer switching, stable `data-bot-id` identity, and the 1100px right info drawer remain mandatory assertions.
 - Branch `fix/tfi-avatar-regression-selector-v2` is based on the current canonical main `54eeb8ad3caf64c02ef834142cb63d38b12033a9`; Release remains blocked until this correction passes protected merge and a later exact-main product delivery is fully green.
+
+## Exact-main selected-peer identity follow-up — 2026-08-25
+
+- Canonical `main@6ae21cba7878d113ac2902df94d867e7d3b7cd34` entered Electron delivery run `32813752100`.
+- The real Linux Rust Host journey failed only the task-specific avatar regression after 17/18 E2E cases passed; diagnostics artifact `9550721736` was retained. Windows and signed/notarized macOS packages were also blocked by packaged-user E2E rather than published.
+- The failure is a real identity mismatch: after selecting `Incident Bot`, the selected peer row exposed `peer:bot:incident-bot` while the Header portal still rendered `peer:conversation:codex:agent:assistant`.
+- Root cause: `activePeerContext()` queried the Header identity subtree, where the Workbench-owned portal can still be the first matching `peer:*` BotMark after a switch. In parallel, `ensurePortalRoot()` mutated `dataset.sourceBotId` on a stable portal DOM node, but mutable DOM metadata is not React state and therefore did not itself trigger a render.
+- Follow-up branch `fix/tfi-selected-peer-avatar-identity` makes the selected peer row's direct semantic BotMark the canonical identity source, stores active `botId`/label in React portal target state, and keeps Mahayana run state separate from Messenger peer identity. Header, selected row and info-panel portal marks now render from the same selected-peer identity.
+- Acceptance is strengthened to assert identity equality on the first peer, second peer, the 1100px info drawer, and a switch back to the first peer.
+
+### Open-source-first decision
+
+- Reviewed the official `facebook/react` portal/reconciliation design (MIT). The relevant architectural lesson is ownership, not code reuse: portal rendering must be driven by React props/state; external DOM `dataset` mutation is not a reliable reactive source.
+- Fabushi keeps its custom Motion v2 / Messenger integration because upstream React does not provide product identity semantics. No upstream code is copied.
+- Status remains `IMPLEMENTED`; Release is blocked until this follow-up passes protected merge and the resulting latest-main exact delivery is green.

--- a/projects/telegram-fabushi-integration/management/wbs/M7.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M7.md
@@ -95,3 +95,12 @@
 - **客观验证**：`desktop/e2e/messenger-regressions.spec.ts` 新增 peer-switch avatar + narrow info panel 回归；PR current-head Actions + protected merge + exact-main package E2E。
 - **证据位置**：`management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md`; `evidence/M7-DESKTOP-004/README.md`。
 - **下一步**：GitHub Actions 全绿后合并 main，与 M8 marketplace 一起进入新版 Release。
+
+
+### M7-DESKTOP-004 delivery follow-up — selected-peer identity
+
+- **状态**：IMPLEMENTED / RELEASE_BLOCKED。
+- **失败证据**：`main@6ae21cba7878d113ac2902df94d867e7d3b7cd34`，Electron run `32813752100`，Linux diagnostics artifact `9550721736`。
+- **真实缺口**：切到 `Incident Bot` 后 peer row 为 `peer:bot:incident-bot`，Header portal 仍为 `peer:conversation:codex:agent:assistant`。
+- **修复**：selected peer row direct BotMark 成为 canonical identity；React state 显式携带 `activeBotId/activeLabel`；Header/peer/info 三处 portal 共用 selected-peer identity，Mahayana runtime 仅提供 animation state。
+- **下一步**：current-head PR gates → protected merge → latest canonical-main exact package/E2E → Release。


### PR DESCRIPTION
## FAB-P0001 / TFI — M7-DESKTOP-004 delivery follow-up

Canonical `main@6ae21cba7878d113ac2902df94d867e7d3b7cd34` failed Electron delivery run `32813752100` in the real Linux Rust Host path after 17/18 E2E cases passed. The retained artifact is `9550721736`.

The failure is real: selecting Incident Bot changed the peer row to `peer:bot:incident-bot`, while the Header portal still rendered the previous `peer:conversation:codex:agent:assistant` identity.

### Root cause
- `activePeerContext()` read identity from the Header subtree, which also contains the Workbench-owned portal and can therefore return a stale portal BotMark after a peer switch.
- `ensurePortalRoot()` mutated `dataset.sourceBotId` on a stable portal DOM node, but external DOM metadata is not React render state, so the portal could retain the previous identity.

### Fix
- Make the selected peer row direct semantic BotMark the canonical identity source.
- Carry selected `activeBotId` / label through React portal-target state so identity changes force a render even when the portal DOM node is reused.
- Separate Messenger peer identity from Mahayana run animation state.
- Render Header, selected peer and info-panel portal BotMarks from the same selected-peer identity.
- Strengthen Playwright to verify first peer -> second peer -> first peer identity, plus the 1100px overlay info panel identity.

### Provenance
Reviewed official `facebook/react` portal/reconciliation design (MIT) and adapted the state-ownership principle only; no upstream source code copied.

Release remains blocked until this PR passes current-head gates, protected merge, and a later exact-main desktop/mobile packaged delivery is fully green.