### PR TITLE
test(electron): drive narrow info panel from explicit state

### DIFF
--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -235,11 +235,13 @@ test('switching peers keeps dynamic avatars visible and narrow layouts can open 
     const infoPanel = page.getByTestId('messenger-info-panel');
     await expect(toggle).toBeVisible();
 
-    if (await infoPanel.isVisible().catch(() => false)) {
+    // The panel DOM can disappear for a render while the responsive grid switches from
+    // docked to overlay. Drive the action from React's explicit toggle state instead of
+    // sampling panel visibility at that transition boundary and accidentally closing it.
+    if (await toggle.getAttribute('data-active') !== 'true') {
       await toggle.click();
-      await expect(infoPanel).toBeHidden();
     }
-    await toggle.click();
+    await expect(toggle).toHaveAttribute('data-active', 'true');
     await expect(infoPanel).toBeVisible();
     await expect(infoPanel).toHaveAttribute('data-overlay', 'true');
     const infoMark = infoPanel.locator(visibleMark);

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
@@ -6,8 +6,9 @@
 - **Task ID:** FCM-009.12
 - **Status:** in-progress
 - **Started:** 2026-08-25
-- **Branch:** `fix/fcm-009-peer-switch-e2e-stability-v2`
-- **Supersedes branch/PR:** `fix/fcm-009-peer-switch-e2e-stability` / #2123, which became merge-conflicted after concurrent #2122 landed first.
+- **Current branch:** `fix/fcm-009-info-panel-state-contract`
+- **Prior repair:** PR #2124 merged through merge queue as canonical main `6ef9358e440f79df549e8d81bd2ef3c60a799453`.
+- **Superseded branch/PR:** `fix/fcm-009-peer-switch-e2e-stability` / #2123, which became merge-conflicted after concurrent #2122 landed first.
 
 ## Objective
 
@@ -22,9 +23,12 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 ## Failure evidence
 
 - Exact-main Electron run `32813081929` (`52b7c10889e585660b7d2a22a40781c22f31b7a1`): Linux E2E 17/18; earlier avatar selector resolved two engine markers.
-- Exact-main Electron run `32813752100` (`6ae21cba7878d113ac2902df94d867e7d3b7cd34`): Linux E2E 17/18; current failure expected `peer:bot:incident-bot` but header was `peer:conversation:codex:agent:assistant` after a live `nth(1)` locator retargeted on list reorder.
+- Exact-main Electron run `32813752100` (`6ae21cba7878d113ac2902df94d867e7d3b7cd34`): Linux E2E 17/18; expected `peer:bot:incident-bot` but header was `peer:conversation:codex:agent:assistant` after a live `nth(1)` locator retargeted on list reorder.
 - #2122 (`eb4b340ce4d9d18cc69b4e60ec97037cbcb2c878`) strengthened product/test identity coverage by adding header identity checks after the first click, info-panel identity checks, and switching back to the first peer.
-- The product uses stable peer keys for `activePeerKey` and renders `data-testid="peer-${peer.key}"`; the remaining failure is test locator identity drift.
+- PR #2124 replaced dynamic positional peer locators with stable `data-testid` identities and merged as `6ef9358e440f79df549e8d81bd2ef3c60a799453`.
+- Exact-main Electron run `32823269733`, Linux job `97725765855`, proved the identity repair: all first/second peer and header identity assertions passed. The only remaining failure was the narrow info-panel open step; suite result was 17/18 passed.
+- Failure artifact `fabushi-electron-linux-e2e-diagnostics`, artifact ID `9553968229`, digest `sha256:3e6139bd190a40c02913db6460d0946f112c37cf9ced1f45ced0a90256c82a9e`, retained screenshot, error context and traces for the failure and retry.
+- Trace timing shows `getByTestId('messenger-info-panel').isVisible()` returned false in roughly 1 ms immediately after `setViewportSize(1100x800)`, so the old test skipped its close branch and then unconditionally clicked the toggle. Product state exposes `data-active={infoOpen}` on `conversation-info-toggle`; DOM visibility is not a reliable state source during the docked-to-overlay responsive render boundary.
 
 ## Implementation
 
@@ -35,6 +39,7 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 5. Preserve all #2122 header/info-panel/switch-back identity assertions, using retryable `toHaveAttribute('data-bot-id', expectedPeerBotId)`.
 6. Preserve the narrow-layout info-panel assertion.
 7. Apply the same stable-ID snapshot to the multi-peer composer viewport loop, which had the same positional-locator risk.
+8. At the responsive panel transition, drive opening from the toggle's explicit `data-active` state instead of instantaneous panel DOM visibility. Click only when `data-active != true`, then require `data-active=true`, visible overlay panel, and correct peer identity.
 
 ## Acceptance
 
@@ -47,4 +52,4 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 
 ## Completion evidence
 
-Pending.
+Pending the state-contract repair PR, protected merge, and exact-main post-merge gates.


### PR DESCRIPTION
Superseded by the v2 branch/PR built directly from canonical main `adcd73d0b68ddff403d5804d1b8d10f9b5e6c202`. While #2126 was being created, concurrent main added two stronger `peerActive` assertions to the same regression. The replacement preserves those assertions and the info-panel state-contract repair. #2126 is intentionally closed rather than force-merging over concurrent accepted work.