### PR TITLE
test(electron): stabilize narrow info-panel open state

### DIFF
--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -236,11 +236,13 @@ test('switching peers keeps dynamic avatars visible and narrow layouts can open 
     const infoPanel = page.getByTestId('messenger-info-panel');
     await expect(toggle).toBeVisible();
 
-    if (await infoPanel.isVisible().catch(() => false)) {
+    // The panel DOM can disappear for a render while the responsive grid switches from
+    // docked to overlay. Drive the action from React's explicit toggle state instead of
+    // sampling panel visibility at that transition boundary and accidentally closing it.
+    if (await toggle.getAttribute('data-active') !== 'true') {
       await toggle.click();
-      await expect(infoPanel).toBeHidden();
     }
-    await toggle.click();
+    await expect(toggle).toHaveAttribute('data-active', 'true');
     await expect(infoPanel).toBeVisible();
     await expect(infoPanel).toHaveAttribute('data-overlay', 'true');
     const infoMark = infoPanel.locator(visibleMark);

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
@@ -6,12 +6,13 @@
 - **Task ID:** FCM-009.12
 - **Status:** in-progress
 - **Started:** 2026-08-25
-- **Branch:** `fix/fcm-009-peer-switch-e2e-stability-v2`
-- **Supersedes branch/PR:** `fix/fcm-009-peer-switch-e2e-stability` / #2123, which became merge-conflicted after concurrent #2122 landed first.
+- **Current branch:** `fix/fcm-009-info-panel-state-contract-v2`
+- **Prior repair:** PR #2124 merged through merge queue as canonical main `6ef9358e440f79df549e8d81bd2ef3c60a799453`.
+- **Superseded work:** #2123 was superseded after concurrent #2122; #2126 was superseded after concurrent main `adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` strengthened the same regression with `peerActive` assertions.
 
 ## Objective
 
-Repair the canonical-main Electron peer-switch simulated-user journey without weakening product assertions. The test must remain correct when opening/reading a conversation causes the left peer list to re-render or reorder, while preserving #2122's stronger header and info-panel avatar identity checks.
+Repair the canonical-main Electron peer-switch simulated-user journey without weakening product assertions. The test must remain correct when opening/reading a conversation causes the left peer list to re-render or reorder, preserve active-peer identity, and reliably exercise the narrow-layout info panel.
 
 ## Source / upstream gate
 
@@ -22,19 +23,21 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 ## Failure evidence
 
 - Exact-main Electron run `32813081929` (`52b7c10889e585660b7d2a22a40781c22f31b7a1`): Linux E2E 17/18; earlier avatar selector resolved two engine markers.
-- Exact-main Electron run `32813752100` (`6ae21cba7878d113ac2902df94d867e7d3b7cd34`): Linux E2E 17/18; current failure expected `peer:bot:incident-bot` but header was `peer:conversation:codex:agent:assistant` after a live `nth(1)` locator retargeted on list reorder.
-- #2122 (`eb4b340ce4d9d18cc69b4e60ec97037cbcb2c878`) strengthened product/test identity coverage by adding header identity checks after the first click, info-panel identity checks, and switching back to the first peer.
-- The product uses stable peer keys for `activePeerKey` and renders `data-testid="peer-${peer.key}"`; the remaining failure is test locator identity drift.
+- Exact-main Electron run `32813752100` (`6ae21cba7878d113ac2902df94d867e7d3b7cd34`): Linux E2E 17/18; expected `peer:bot:incident-bot` but header was `peer:conversation:codex:agent:assistant` after a live `nth(1)` locator retargeted on list reorder.
+- #2122 (`eb4b340ce4d9d18cc69b4e60ec97037cbcb2c878`) strengthened header/info-panel/switch-back identity coverage.
+- PR #2124 replaced dynamic positional peer locators with stable `data-testid` identities and merged as `6ef9358e440f79df549e8d81bd2ef3c60a799453`.
+- Exact-main Electron run `32823269733`, Linux job `97725765855`, proved the identity repair: all first/second peer and header identity assertions passed. The only remaining failure was the narrow info-panel open step; suite result was 17/18 passed.
+- Failure artifact `fabushi-electron-linux-e2e-diagnostics`, artifact ID `9553968229`, digest `sha256:3e6139bd190a40c02913db6460d0946f112c37cf9ced1f45ced0a90256c82a9e`, retained screenshot, error context and traces for the failure and retry.
+- Trace timing shows `getByTestId('messenger-info-panel').isVisible()` returned false immediately after `setViewportSize(1100x800)`, so the test sampled the docked-to-overlay transition and then unconditionally clicked the toggle. Product state already exposes `data-active={infoOpen}` on `conversation-info-toggle`, which is the deterministic state contract.
+- Concurrent main `adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` added `peerActive` assertions for the second peer and switch-back peer. This branch is rebuilt from that SHA and preserves those checks.
 
 ## Implementation
 
-1. Capture peer `data-testid` values before any click.
-2. Re-bind to those peers via `page.getByTestId(stableId)`.
-3. Capture each stable peer's semantic BotMark `data-bot-id` before state changes.
-4. Keep the existing visible-avatar assertions.
-5. Preserve all #2122 header/info-panel/switch-back identity assertions, using retryable `toHaveAttribute('data-bot-id', expectedPeerBotId)`.
-6. Preserve the narrow-layout info-panel assertion.
-7. Apply the same stable-ID snapshot to the multi-peer composer viewport loop, which had the same positional-locator risk.
+1. Capture peer `data-testid` values before any click and re-bind through `page.getByTestId(stableId)`.
+2. Capture each stable peer's semantic BotMark `data-bot-id` before state changes.
+3. Preserve peer/avatar/header/info-panel/switch-back identity assertions and the concurrent `peerActive` assertions.
+4. Apply the same stable-ID snapshot to the multi-peer composer viewport loop.
+5. At the responsive panel transition, drive opening from `conversation-info-toggle[data-active]` instead of instantaneous panel DOM visibility: click only when `data-active != true`, require retryable `data-active=true`, then require the visible overlay panel and matching peer identity.
 
 ## Acceptance
 
@@ -47,4 +50,4 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 
 ## Completion evidence
 
-Pending.
+Pending the state-contract repair PR, protected merge, and exact-main post-merge gates.


### PR DESCRIPTION
## FAB-P0003 / FCM-009.12

Rebuilt directly from canonical main `adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` so concurrent stronger `peerActive` assertions are preserved.

Exact-main Electron run `32823269733` for prior repair SHA `6ef9358e440f79df549e8d81bd2ef3c60a799453` passed every peer/header identity assertion and failed only at the responsive info-panel open step (Linux 17/18).

### Evidence
- Linux job `97725765855`
- diagnostics artifact `9553968229`
- trace captured `messenger-info-panel.isVisible()` as false immediately after `setViewportSize(1100x800)`, at the docked→overlay render boundary

### Repair
- preserve stable peer test IDs and semantic BotMark IDs
- preserve concurrent `peerActive`, header, info-panel, and switch-back assertions
- drive panel opening from `conversation-info-toggle[data-active]`, the React state contract
- click only if state is not active, then require retryable `data-active=true`, visible overlay, and correct peer identity

No product behavior or acceptance criterion is weakened. Completion still requires protected merge plus exact-main Linux/macOS/Windows packaged-user journeys, native gates, retained visual evidence, and post-main Release.