### PR TITLE
fix(tfi): keep narrow info drawer visible

### DIFF
--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -295,7 +295,10 @@
 
 @media (max-width: 1280px) {
   .messenger { grid-template-columns: 66px 300px minmax(390px,1fr); }
-  .infoPanel { display:none; }
+  /* Narrow layouts use the JS-controlled overlay drawer. Keep the legacy docked
+     panel hidden during resize state convergence, but never hide an explicit overlay. */
+  .infoPanel:not([data-overlay="true"]) { display:none; }
+  .infoPanel[data-overlay="true"] { display:flex; }
 }
 
 @media (max-width: 900px) {

--- a/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M7-DESKTOP-004/README.md
@@ -41,3 +41,14 @@ Record protected merge SHA, final exact-main Electron/native runs, retained scre
 - Result: 17/18 E2E passed; selected peer row switched to Incident Bot but Header portal identity remained the previous assistant at assertion time.
 - Root cause: peer selection is a CSS class mutation on reused DOM rows; the existing portal MutationObserver watched only child-list mutations.
 - Follow-up: observer now includes `attributes: true`, `attributeFilter: ['class']`, and refreshes only when a changed class belongs to a Messenger peer button; recovery polling is retained but no longer the normal switch path.
+
+
+## Exact-main failure evidence — narrow right info drawer
+
+- Canonical main: `adcd73d0b68ddff403d5804d1b8d10f9b5e6c202`.
+- Electron delivery: `32823782495`.
+- Linux real-Host diagnostics: artifact `9554164364`.
+- Result: 17/18 E2E passed. Selected Incident Bot and Header identities were correct; the failure occurred only at `expect(getByTestId('messenger-info-panel')).toBeVisible()` after clicking `资料` at 1100px.
+- Screenshot/accessibility evidence shows the toggle is present and the selected Bot is correct, with no right drawer visible.
+- Root cause: legacy responsive CSS hid all `.infoPanel` elements at `<=1280px`, including the newer `data-overlay=true` drawer.
+- Follow-up: `fix/tfi-narrow-info-panel-toggle` hides only non-overlay info panels and keeps overlay panels flex-visible. No third-party code is required.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -101,3 +101,8 @@ Acceptance traceability:
 ## M7-DESKTOP-004 observer-driven peer identity — 2026-08-25
 
 Exact-main `eb4b340ce...` / Electron `32822744019` / artifact `9553768019` 证明 selected-row identity authority已正确，但 peer switch 的 class-only DOM update 没有被 Workbench observer 监听。验收继续要求 Header/info semantic `data-bot-id` 最终与 `peerActive` 行一致；实现改为 class mutation event-driven refresh，轮询只作恢复兜底。Release 继续阻断。
+
+
+## M7-DESKTOP-004 narrow info drawer acceptance — 2026-08-25
+
+`main@adcd73d0...` / Electron `32823782495` / artifact `9554164364` confirms the avatar identity portion now passes in the real Linux Host path. The only task-specific failure moved to the 1100px info drawer: the React state/layout emits overlay semantics, while a legacy responsive CSS rule hides `.infoPanel` unconditionally. Acceptance remains unchanged: the `资料` button must open a visible `data-overlay="true"` panel and the panel avatar identity must equal the selected peer before and after peer switching.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -176,3 +176,11 @@
 - 17/18 cases pass. Remaining gap is immediate selected-peer propagation: Messenger changes `peerActive` class on stable row nodes, but Workbench observed only child-node mutations.
 - `fix/tfi-peer-selection-observer` adds filtered `class` observation for peer buttons and keeps the 500 ms interval as recovery-only.
 - Release remains blocked until protected merge + later exact-main Electron/native delivery are green.
+
+
+## 2026-08-25 — M7-DESKTOP-004 right drawer exact-main block
+
+- `main@adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` / Electron `32823782495` retained diagnostics `9554164364`; 17/18 real-Host E2E cases passed.
+- Header/peer Motion v2 identity is no longer the failing point. The remaining user-visible defect is the narrow right `资料` drawer.
+- Root cause is the old `max-width:1280px` CSS `display:none` rule masking the newer overlay drawer even when React renders it.
+- `fix/tfi-narrow-info-panel-toggle` preserves the docked-panel hide only for non-overlay state and allows `data-overlay=true` to render. Release stays blocked until the next exact-main delivery is green.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -166,3 +166,11 @@
 - Added filtered MutationObserver handling for `peerActive` class changes on Messenger peer buttons.
 - Kept 500 ms target refresh interval as recovery-only fallback.
 - Updated regression to wait for committed `peerActive` selection and then require Header semantic Motion v2 identity convergence.
+
+
+## 2026-08-25 — M7-DESKTOP-004 narrow info drawer CSS repair
+
+- Recorded exact-main failure `adcd73d0...` / Electron `32823782495` / diagnostics `9554164364`.
+- Confirmed selected-peer/Header avatar identity now passes; failure moved to 1100px info-panel visibility.
+- Replaced unconditional narrow `.infoPanel { display:none; }` with non-overlay-only hiding and explicit overlay `display:flex`.
+- Existing real Host E2E continues to require right drawer visibility, `data-overlay=true`, and selected-peer Motion v2 identity.

--- a/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M7-DESKTOP-004-bot-avatar-info-panel-regression.md
@@ -74,3 +74,12 @@ Keep below `RELEASED` until required current-head CI, protected merge, canonical
 - Follow-up branch `fix/tfi-peer-selection-observer` observes peer-button `class` mutations (filtered to `button[data-testid^="peer-"]`) and refreshes portal identity immediately after the React commit; the 500 ms interval remains recovery-only.
 - E2E now waits for the selected peer's `peerActive` class and then polls Header semantic identity equality, so the assertion models the asynchronous React portal commit without accepting a permanently stale identity.
 - Status remains `IMPLEMENTED / RELEASE_BLOCKED` pending protected merge and a green exact-main delivery.
+
+## Exact-main narrow info drawer follow-up — 2026-08-25
+
+- Canonical `main@adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` reached Electron run `32823782495`; the real Linux Rust Host journey advanced past the selected-peer/Header identity assertions and failed only when opening the 1100px info drawer. Diagnostics artifact: `9554164364`; 17/18 E2E cases passed.
+- Retained screenshot and accessibility context show the selected `Incident Bot` identity is correct and the `资料` toggle is reachable, but `messenger-info-panel` is absent after the click.
+- Root cause is a stale responsive CSS rule: the new JS layout already renders `data-overlay="true"` for widths `<=1280`, but legacy `@media (max-width: 1280px) { .infoPanel { display:none; } }` still hides every info panel. When `infoOpen` is already true, the drawer exists in state but is visually suppressed; clicking the toggle can then close the state rather than reveal anything.
+- Follow-up branch `fix/tfi-narrow-info-panel-toggle` scopes the legacy hide rule to non-overlay panels and explicitly keeps `[data-overlay="true"]` at `display:flex`. Existing Playwright acceptance remains unchanged and must now prove the real 1100px drawer opens and follows the selected Bot identity.
+- No external dependency is needed: the product already has the correct overlay state/layout model; this is removal of a stale internal CSS override.
+- Status remains `IMPLEMENTED / RELEASE_BLOCKED` until protected merge and a later exact-main desktop/mobile delivery are fully green.

--- a/projects/telegram-fabushi-integration/management/wbs/M7.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M7.md
@@ -112,3 +112,12 @@
 - **失败证据**：`main@eb4b340ce4d9d18cc69b4e60ec97037cbcb2c878`, Electron `32822744019`, diagnostics `9553768019`, 17/18 E2E passed.
 - **根因**：Messenger peer switch 只更新 `peerActive` class；Workbench observer 只监听 `childList`，导致 portal identity 依赖 500 ms fallback polling。
 - **修复**：监听 peer button `class` attribute mutation 并即时 refresh；500 ms interval 仅保留异常 DOM 恢复。
+
+
+### M7-DESKTOP-004 delivery follow-up — narrow info drawer CSS
+
+- **状态**：IMPLEMENTED / RELEASE_BLOCKED。
+- **失败证据**：`main@adcd73d0b68ddff403d5804d1b8d10f9b5e6c202`, Electron `32823782495`, diagnostics artifact `9554164364`, 17/18 E2E passed.
+- **进展**：peer/Header Motion v2 identity assertions now pass; remaining failure is the 1100px `资料` drawer.
+- **根因**：legacy `@media (max-width:1280px) .infoPanel { display:none; }` overrides the newer `data-overlay="true"` drawer rendering.
+- **修复**：only non-overlay panels are hidden at narrow width; explicit overlay panels retain `display:flex`.


### PR DESCRIPTION
## FAB-P0001 / TFI — M7-DESKTOP-004 right drawer follow-up

Canonical `main@adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` failed Electron delivery `32823782495`; Linux real-Host diagnostics artifact `9554164364` was retained and 17/18 E2E cases passed.

This run advanced past the selected-peer/Header Motion v2 identity assertions. The remaining task-specific failure is exactly the user-visible right-sidebar issue: at 1100px the `资料` toggle is reachable but `messenger-info-panel` never becomes visible.

### Root cause
The React layout already renders narrow panels with `data-overlay="true"`, but a legacy responsive CSS rule still applies `@media (max-width: 1280px) { .infoPanel { display:none; } }` to every info panel. That masks the new overlay drawer. If `infoOpen` is already true, the state says open while CSS hides it, so another click can actually close the state.

### Fix
- At `<=1280px`, hide only non-overlay info panels during responsive state convergence.
- Explicit `[data-overlay="true"]` panels remain `display:flex`.
- Preserve #2127's test stabilization that drives the action from the toggle's explicit `data-active` state.
- Keep the existing real-Host acceptance: drawer visible at 1100px, `data-overlay=true`, and info-panel Motion v2 identity equals the selected peer across switching.

No external dependency is required; the product already has the overlay model and this removes a stale internal CSS override.

Release remains blocked until this PR passes current-head checks, protected merge, and the resulting latest-main desktop/mobile packaged delivery is fully green.