### PR TITLE
fix(electron): show narrow info panel overlay

### DIFF
--- a/desktop/src/messenger-layout-regressions.css
+++ b/desktop/src/messenger-layout-regressions.css
@@ -22,3 +22,15 @@
 [data-testid="messenger-workspace"] textarea[data-testid="messenger-input"] {
   min-width: 0;
 }
+
+/*
+ * The CSS module intentionally removes the docked info column at <=1280px.
+ * When React marks that same panel as an overlay, keep it rendered as flex:
+ * absolute positioning removes it from the grid while the header toggle still
+ * gives narrow layouts access to the profile/info surface.
+ */
+@media (max-width: 1280px) {
+  [data-testid="messenger-info-panel"][data-overlay="true"] {
+    display: flex;
+  }
+}

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
@@ -6,13 +6,13 @@
 - **Task ID:** FCM-009.12
 - **Status:** in-progress
 - **Started:** 2026-08-25
-- **Current branch:** `fix/fcm-009-info-panel-state-contract-v2`
-- **Prior repair:** PR #2124 merged through merge queue as canonical main `6ef9358e440f79df549e8d81bd2ef3c60a799453`.
-- **Superseded work:** #2123 was superseded after concurrent #2122; #2126 was superseded after concurrent main `adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` strengthened the same regression with `peerActive` assertions.
+- **Current branch:** `fix/fcm-009-info-panel-overlay-layout`
+- **Prior repairs:** #2124 merged as `6ef9358e440f79df549e8d81bd2ef3c60a799453`; #2127 merged as `2faa0cd815ef0a7032b25486c3404f9f3d4cad5e`.
+- **Superseded work:** #2123 and #2126 were closed rather than overwriting concurrent accepted main changes.
 
 ## Objective
 
-Repair the canonical-main Electron peer-switch simulated-user journey without weakening product assertions. The test must remain correct when opening/reading a conversation causes the left peer list to re-render or reorder, preserve active-peer identity, and reliably exercise the narrow-layout info panel.
+Repair the canonical-main Electron peer-switch simulated-user journey without weakening product assertions. The test must remain correct when opening/reading a conversation changes list order, preserve active-peer identity, and expose the requested info panel as a visible narrow-layout overlay.
 
 ## Source / upstream gate
 
@@ -22,32 +22,31 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 
 ## Failure evidence
 
-- Exact-main Electron run `32813081929` (`52b7c10889e585660b7d2a22a40781c22f31b7a1`): Linux E2E 17/18; earlier avatar selector resolved two engine markers.
-- Exact-main Electron run `32813752100` (`6ae21cba7878d113ac2902df94d867e7d3b7cd34`): Linux E2E 17/18; expected `peer:bot:incident-bot` but header was `peer:conversation:codex:agent:assistant` after a live `nth(1)` locator retargeted on list reorder.
-- #2122 (`eb4b340ce4d9d18cc69b4e60ec97037cbcb2c878`) strengthened header/info-panel/switch-back identity coverage.
-- PR #2124 replaced dynamic positional peer locators with stable `data-testid` identities and merged as `6ef9358e440f79df549e8d81bd2ef3c60a799453`.
-- Exact-main Electron run `32823269733`, Linux job `97725765855`, proved the identity repair: all first/second peer and header identity assertions passed. The only remaining failure was the narrow info-panel open step; suite result was 17/18 passed.
-- Failure artifact `fabushi-electron-linux-e2e-diagnostics`, artifact ID `9553968229`, digest `sha256:3e6139bd190a40c02913db6460d0946f112c37cf9ced1f45ced0a90256c82a9e`, retained screenshot, error context and traces for the failure and retry.
-- Trace timing shows `getByTestId('messenger-info-panel').isVisible()` returned false immediately after `setViewportSize(1100x800)`, so the test sampled the docked-to-overlay transition and then unconditionally clicked the toggle. Product state already exposes `data-active={infoOpen}` on `conversation-info-toggle`, which is the deterministic state contract.
-- Concurrent main `adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` added `peerActive` assertions for the second peer and switch-back peer. This branch is rebuilt from that SHA and preserves those checks.
+- Run `32813081929` / main `52b7c10889e585660b7d2a22a40781c22f31b7a1`: Linux E2E 17/18; avatar selector ambiguity.
+- Run `32813752100` / main `6ae21cba7878d113ac2902df94d867e7d3b7cd34`: Linux E2E 17/18; live `nth(1)` peer locator retargeted after list reorder.
+- #2122 strengthened `peerActive`, header, info-panel and switch-back identity coverage; #2124 preserved those checks and replaced dynamic positional peer locators with stable test IDs.
+- Run `32823269733`, Linux job `97725765855`: identity repair passed; only responsive info-panel open remained; diagnostics artifact `9553968229`, digest `sha256:3e6139bd190a40c02913db6460d0946f112c37cf9ced1f45ced0a90256c82a9e`.
+- #2127 replaced instantaneous DOM-state sampling with the product's `conversation-info-toggle[data-active]` React state contract.
+- Run `32824218692` / exact main `2faa0cd815ef0a7032b25486c3404f9f3d4cad5e`, Linux job `97728625316`: `data-active=true` passes and the panel exists for the full 10-second assertion window as `<aside data-overlay="true" ... data-testid="messenger-info-panel">`, but Playwright reports it hidden on every resolution. Suite remains 17/18. Diagnostics artifact `9554317988`, digest `sha256:0c6e6e152ed0be57ac8a5b2eba5f5772dfcd3909b86532e0647d2d555bf8b14a`.
+- Product CSS root cause is now proven: base `.infoPanel` declares `display:flex`; the responsive `@media (max-width: 1280px)` later declares `.infoPanel { display:none; }`. The overlay rule `.infoPanel[data-overlay="true"]` sets position/geometry but does not restore `display`, so at 1100px an open overlay is intentionally rendered by React yet hidden by CSS.
 
 ## Implementation
 
-1. Capture peer `data-testid` values before any click and re-bind through `page.getByTestId(stableId)`.
-2. Capture each stable peer's semantic BotMark `data-bot-id` before state changes.
-3. Preserve peer/avatar/header/info-panel/switch-back identity assertions and the concurrent `peerActive` assertions.
-4. Apply the same stable-ID snapshot to the multi-peer composer viewport loop.
-5. At the responsive panel transition, drive opening from `conversation-info-toggle[data-active]` instead of instantaneous panel DOM visibility: click only when `data-active != true`, require retryable `data-active=true`, then require the visible overlay panel and matching peer identity.
+1. Stable peer identity: snapshot peer `data-testid` and semantic `data-bot-id`, then re-bind via `getByTestId`.
+2. Preserve all `peerActive`, avatar, header, info-panel and switch-back identity assertions.
+3. Preserve the stable-ID composer viewport loop.
+4. Drive responsive panel opening from `conversation-info-toggle[data-active]`.
+5. Fix the actual responsive product contract: at `max-width:1280px`, hide only non-overlay info panels; when `data-overlay=true`, retain the base flex display so the absolute overlay is visible without occupying a grid column.
 
 ## Acceptance
 
-- Targeted peer-switch regression passes without retry-dependent flakiness.
-- Full Electron source E2E passes.
-- PR fast checks pass and PR merges through protected `main` / merge queue.
-- Exact canonical-main Electron desktop quality gate is green for Linux, macOS, and Windows packaged/user journeys.
+- Full source Electron E2E passes without retry-dependent flakiness.
+- PR fast checks pass and changes merge through protected `main` / merge queue.
+- Exact canonical-main Electron desktop quality gate is green for Linux, macOS and Windows packaged/user journeys.
 - Required screenshot/video/trace/report evidence remains retained by the canonical workflow.
+- Exact same main SHA native Android/iOS gates are green and post-main Release succeeds.
 - FCM-009 delivery evidence and originating AAC-001 closure record are updated only after objective post-main success.
 
 ## Completion evidence
 
-Pending the state-contract repair PR, protected merge, and exact-main post-merge gates.
+Pending product CSS repair, protected merge, and exact-main post-merge gates.


### PR DESCRIPTION
## FAB-P0003 / FCM-009.12 product fix

Exact-main Electron run `32824218692` for `2faa0cd815ef0a7032b25486c3404f9f3d4cad5e` proves this is now a product CSS bug rather than a test race:

- the info toggle reaches `data-active=true`
- React continuously renders `<aside data-overlay="true" data-testid="messenger-info-panel">`
- Playwright resolves that exact element for 10 seconds but reports it hidden
- Linux source E2E remains 17/18; all peer/header identity checks pass

### Root cause
The CSS module declares `.infoPanel { display:flex }`, then `@media (max-width:1280px) { .infoPanel { display:none } }`. The overlay rule sets absolute geometry but never restores display, so the requested narrow overlay exists in DOM and state yet remains hidden.

### Fix
Extend the existing global Messenger layout safety net:

```css
@media (max-width: 1280px) {
  [data-testid="messenger-info-panel"][data-overlay="true"] {
    display: flex;
  }
}
```

This preserves the intended behavior: no docked grid column on narrow layouts, but the header toggle can show the panel as an absolute overlay.

### Evidence
- Linux job `97728625316`
- diagnostics artifact `9554317988`
- digest `sha256:0c6e6e152ed0be57ac8a5b2eba5f5772dfcd3909b86532e0647d2d555bf8b14a`

No assertions are removed or weakened. Closure still requires protected merge, exact-main Electron Linux/macOS/Windows packaged E2E, exact-SHA native gates, retained visual evidence, and post-main Release.