### PR TITLE
fix(electron): separate narrow info overlay state

### DIFF
--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -235,6 +235,8 @@ test('switching peers keeps dynamic avatars visible and narrow layouts can open 
     const toggle = page.getByTestId('conversation-info-toggle');
     const infoPanel = page.getByTestId('messenger-info-panel');
     await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('data-active', 'false');
+    await expect(infoPanel).toHaveCount(0);
 
     // The panel DOM can disappear for a render while the responsive grid switches from
     // docked to overlay. Drive the action from React's explicit toggle state instead of

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -585,6 +585,7 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
   const [routerStatus, setRouterStatus] = useState<InferenceRouterStatus | null>(null);
   const [usageSummary, setUsageSummary] = useState<UsageSummary | null>(null);
   const [infoOpen, setInfoOpen] = useState(() => readDesktopMessengerPreferences().showInfoPanel);
+  const [narrowInfoOpen, setNarrowInfoOpen] = useState(false);
   const [wideInfoLayout, setWideInfoLayout] = useState(() => typeof window === 'undefined' ? true : window.innerWidth > 1280);
   const [infoTab, setInfoTab] = useState<InfoTab>('media');
   const [pendingSend, setPendingSend] = useState(false);
@@ -626,7 +627,11 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
   }, [activePeerKey]);
 
   useEffect(() => {
-    const onResize = () => setWideInfoLayout(window.innerWidth > 1280);
+    const onResize = () => {
+      const nextWide = window.innerWidth > 1280;
+      setWideInfoLayout(nextWide);
+      if (nextWide) setNarrowInfoOpen(false);
+    };
     onResize();
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
@@ -1373,7 +1378,8 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
     return !query || `${peer.title} ${peer.subtitle}`.toLowerCase().includes(query);
   });
   const sectionIsPeerList = ['chats', 'contacts', 'bots', 'groups', 'channels', 'saved', 'archive'].includes(section);
-  const infoPanelVisible = Boolean(infoOpen && activePeer && sectionIsPeerList);
+  const layoutInfoOpen = wideInfoLayout ? infoOpen : narrowInfoOpen;
+  const infoPanelVisible = Boolean(layoutInfoOpen && activePeer && sectionIsPeerList);
   const infoPanelDocked = Boolean(infoPanelVisible && wideInfoLayout);
   const currentActor = selfActors.find((actor) => actor.id === selfHosted.actorId);
   const renderedPeers = visiblePeers.slice(0, peerRenderCount);
@@ -2212,7 +2218,7 @@ async function saveInvoiceDialog() {
                 }}><Search size={18} /></button>
                 <button type="button" title={activePeer.pinned ? '取消置顶' : '置顶'} onClick={() => void togglePinConversation(activePeer)}><Pin size={18} /></button>
                 <button type="button" title={mutedPeerKeys.has(activePeer.key) ? '开启通知' : '静音'} onClick={() => void toggleMuteConversation(activePeer)}><BellOff size={18} /></button>
-                <button type="button" title="资料" data-testid="conversation-info-toggle" data-active={infoOpen} onClick={() => setInfoOpen((value) => !value)}><MoreVertical size={18} /></button>
+                <button type="button" title="资料" data-testid="conversation-info-toggle" data-active={layoutInfoOpen} onClick={() => wideInfoLayout ? setInfoOpen((value) => !value) : setNarrowInfoOpen((value) => !value)}><MoreVertical size={18} /></button>
               </div>
             </header>
             {error ? <div className={styles.errorBanner} role="alert"><span>{error}</span><button type="button" onClick={() => setError(null)}><X size={14} /></button></div> : null}
@@ -2271,7 +2277,7 @@ async function saveInvoiceDialog() {
 
       {infoPanelVisible && activePeer ? (
         <aside className={styles.infoPanel} data-testid="messenger-info-panel" data-overlay={!wideInfoLayout || undefined}>
-          <header><strong>资料</strong><button type="button" onClick={() => setInfoOpen(false)}><X size={17} /></button></header>
+          <header><strong>资料</strong><button type="button" onClick={() => wideInfoLayout ? setInfoOpen(false) : setNarrowInfoOpen(false)}><X size={17} /></button></header>
           <div className={styles.profileCard}>
             <BotMark botId={`peer:${activePeer.kind}:${activePeer.actorId ?? activePeer.id}`} state={isAgentPeer(activePeer) ? botMarkStateForPeer(activePeer, selfBotExecutions, pendingSend, hostReady) : 'idle'} size={92} className={styles.agentProfileMark} label={activePeer.title} />
             <strong>{activePeer.title}</strong><small>{activePeer.subtitle}</small>

--- a/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
+++ b/projects/fabushi-cicd-merge-governance/management/tasks/FCM-009.12-peer-switch-e2e-stability.md
@@ -6,13 +6,13 @@
 - **Task ID:** FCM-009.12
 - **Status:** in-progress
 - **Started:** 2026-08-25
-- **Current branch:** `fix/fcm-009-info-panel-overlay-layout`
-- **Prior repairs:** #2124 merged as `6ef9358e440f79df549e8d81bd2ef3c60a799453`; #2127 merged as `2faa0cd815ef0a7032b25486c3404f9f3d4cad5e`.
+- **Current branch:** `fix/fcm-009-responsive-info-state`
+- **Prior repairs:** #2124 merged as `6ef9358e440f79df549e8d81bd2ef3c60a799453`; #2127 merged as `2faa0cd815ef0a7032b25486c3404f9f3d4cad5e`; #2129 merged as `13c1691d4fd9a5ef1734f5a74219b8f647d36d92`.
 - **Superseded work:** #2123 and #2126 were closed rather than overwriting concurrent accepted main changes.
 
 ## Objective
 
-Repair the canonical-main Electron peer-switch simulated-user journey without weakening product assertions. The test must remain correct when opening/reading a conversation changes list order, preserve active-peer identity, and expose the requested info panel as a visible narrow-layout overlay.
+Repair the canonical-main Electron peer-switch simulated-user journey without weakening product assertions. The test must remain correct when opening/reading a conversation changes list order, preserve active-peer identity, and expose the requested info panel as a visible narrow-layout overlay **only after the user asks for it**.
 
 ## Source / upstream gate
 
@@ -27,20 +27,28 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 - #2122 strengthened `peerActive`, header, info-panel and switch-back identity coverage; #2124 preserved those checks and replaced dynamic positional peer locators with stable test IDs.
 - Run `32823269733`, Linux job `97725765855`: identity repair passed; only responsive info-panel open remained; diagnostics artifact `9553968229`, digest `sha256:3e6139bd190a40c02913db6460d0946f112c37cf9ced1f45ced0a90256c82a9e`.
 - #2127 replaced instantaneous DOM-state sampling with the product's `conversation-info-toggle[data-active]` React state contract.
-- Run `32824218692` / exact main `2faa0cd815ef0a7032b25486c3404f9f3d4cad5e`, Linux job `97728625316`: `data-active=true` passes and the panel exists for the full 10-second assertion window as `<aside data-overlay="true" ... data-testid="messenger-info-panel">`, but Playwright reports it hidden on every resolution. Suite remains 17/18. Diagnostics artifact `9554317988`, digest `sha256:0c6e6e152ed0be57ac8a5b2eba5f5772dfcd3909b86532e0647d2d555bf8b14a`.
-- Product CSS root cause is now proven: base `.infoPanel` declares `display:flex`; the responsive `@media (max-width: 1280px)` later declares `.infoPanel { display:none; }`. The overlay rule `.infoPanel[data-overlay="true"]` sets position/geometry but does not restore `display`, so at 1100px an open overlay is intentionally rendered by React yet hidden by CSS.
+- Run `32824218692` / exact main `2faa0cd815ef0a7032b25486c3404f9f3d4cad5e`, Linux job `97728625316`: `data-active=true` passed and React rendered the overlay, but CSS kept it hidden; diagnostics artifact `9554317988`, digest `sha256:0c6e6e152ed0be57ac8a5b2eba5f5772dfcd3909b86532e0647d2d555bf8b14a`.
+- #2129 restored `display:flex` for the requested `data-overlay=true` panel at `max-width:1280px`, proving the CSS visibility issue was fixed.
+- Exact-main run `32824737447` / main `13c1691d4fd9a5ef1734f5a74219b8f647d36d92`, Linux job `97730168229`, then exposed the remaining state-model bug: suite moved from the single hidden-overlay failure to **7 failures / 11 passes**, and every failing message-send click was intercepted by the now-visible `messenger-info-panel`. Diagnostics artifact `9554706397`, digest `sha256:040764804a1ae9e85baac0aa4c5fd7e00b4d5d53e3ef088801507992ce566795`.
+- Root cause: one `infoOpen` state currently represents two different concepts. It is initialized from persisted `showInfoPanel=true` for the wide three-column desktop layout; at the default/narrow `<=1280px` layout the same true state becomes an absolute overlay. Before #2129 CSS accidentally hid that overlay; after #2129 it correctly became visible, revealing that narrow layouts were opening it by default and covering the composer.
 
 ## Implementation
 
 1. Stable peer identity: snapshot peer `data-testid` and semantic `data-bot-id`, then re-bind via `getByTestId`.
 2. Preserve all `peerActive`, avatar, header, info-panel and switch-back identity assertions.
 3. Preserve the stable-ID composer viewport loop.
-4. Drive responsive panel opening from `conversation-info-toggle[data-active]`.
-5. Fix the actual responsive product contract: at `max-width:1280px`, hide only non-overlay info panels; when `data-overlay=true`, retain the base flex display so the absolute overlay is visible without occupying a grid column.
+4. Drive responsive panel opening from the explicit toggle state.
+5. Keep the #2129 CSS contract: an explicitly opened narrow overlay is visible as flex.
+6. Split the product state model:
+   - persisted `infoOpen` continues to control the wide docked info column and `showInfoPanel` preference;
+   - new session-only `narrowInfoOpen` defaults to false and controls only the `<=1280px` overlay;
+   - header toggle and close button update the state for the current layout;
+   - switching back to wide clears the transient narrow overlay state so a later shrink does not unexpectedly reopen it.
+7. Strengthen the regression to require that after entering 1100px layout the info toggle is inactive and no overlay exists before the user clicks it, then require the visible overlay and peer identity after the click.
 
 ## Acceptance
 
-- Full source Electron E2E passes without retry-dependent flakiness.
+- Full source Electron E2E passes without retry-dependent flakiness and message composer clicks are never blocked by an unsolicited overlay.
 - PR fast checks pass and changes merge through protected `main` / merge queue.
 - Exact canonical-main Electron desktop quality gate is green for Linux, macOS and Windows packaged/user journeys.
 - Required screenshot/video/trace/report evidence remains retained by the canonical workflow.
@@ -49,4 +57,4 @@ Repair the canonical-main Electron peer-switch simulated-user journey without we
 
 ## Completion evidence
 
-Pending product CSS repair, protected merge, and exact-main post-merge gates.
+Pending responsive state split, protected merge, and exact-main post-merge gates.


### PR DESCRIPTION
## FAB-P0003 / FCM-009.12 state-model repair

Exact-main Electron run `32824737447` for `13c1691d4fd9a5ef1734f5a74219b8f647d36d92` proved #2129 made the narrow overlay visible, but also exposed the remaining product-state bug: the persisted wide-layout `showInfoPanel=true` state was reused as a narrow overlay state, so the overlay opened by default and intercepted message composer clicks. Linux source E2E moved to 11/18 with 7 send-button clicks blocked by `messenger-info-panel`.

### Evidence
- Linux job `97730168229`
- diagnostics artifact `9554706397`
- digest `sha256:040764804a1ae9e85baac0aa4c5fd7e00b4d5d53e3ef088801507992ce566795`

### Product fix
- keep persisted `infoOpen` for wide docked info-column preference
- add session-only `narrowInfoOpen=false` for `<=1280px` overlay
- derive the header toggle state from the active layout
- toggle/close only the state belonging to the active layout
- clear transient narrow state when returning to wide layout so a later shrink cannot unexpectedly reopen it
- preserve #2129 CSS: when the user explicitly opens the narrow overlay, it is visible

### Regression
At 1100px the peer-switch E2E now requires `conversation-info-toggle[data-active=false]` and zero `messenger-info-panel` nodes before clicking the toggle, then preserves the existing visible overlay / peer identity / switch-back assertions after opening it.

No product acceptance assertion is removed or weakened. Closure still requires protected merge, exact-main Electron Linux/macOS/Windows packaged user journeys, exact-SHA Native Android/iOS, retained visual evidence, and automatic exact-SHA Release.