### PR TITLE
feat(monetization): establish unified ledger core

### DIFF
--- a/fabushi/web/migrations/20260825_monetization_platform_v1.sql
+++ b/fabushi/web/migrations/20260825_monetization_platform_v1.sql
@@ -1,0 +1,158 @@
+-- Fabushi Monetization Platform v1
+-- Immutable money movements are recorded in monetization_journals + monetization_entries.
+-- Amounts are integer minor units (fen/cents) to avoid floating point money arithmetic.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS monetization_accounts (
+  account_id TEXT PRIMARY KEY,
+  owner_type TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(owner_type, owner_id, bucket, currency)
+);
+
+CREATE TABLE IF NOT EXISTS monetization_revenue_events (
+  event_id TEXT PRIMARY KEY,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  source TEXT NOT NULL,
+  source_id TEXT,
+  scope_type TEXT NOT NULL,
+  scope_id TEXT NOT NULL,
+  gross_amount_minor INTEGER NOT NULL CHECK(gross_amount_minor >= 0),
+  currency TEXT NOT NULL,
+  developer_id TEXT,
+  miniapp_id TEXT,
+  bot_id TEXT,
+  customer_id TEXT,
+  status TEXT NOT NULL DEFAULT 'recorded',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  occurred_at TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS monetization_split_rules (
+  rule_id TEXT PRIMARY KEY,
+  scope_type TEXT NOT NULL,
+  scope_id TEXT NOT NULL,
+  revenue_source TEXT NOT NULL,
+  version INTEGER NOT NULL CHECK(version > 0),
+  effective_from TEXT NOT NULL,
+  effective_to TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  rule_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(scope_type, scope_id, revenue_source, version)
+);
+CREATE INDEX IF NOT EXISTS idx_monetization_split_rules_active
+  ON monetization_split_rules(scope_type, scope_id, revenue_source, status, effective_from);
+
+CREATE TABLE IF NOT EXISTS monetization_journals (
+  journal_id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL UNIQUE,
+  event_type TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  total_debits_minor INTEGER NOT NULL CHECK(total_debits_minor >= 0),
+  total_credits_minor INTEGER NOT NULL CHECK(total_credits_minor >= 0),
+  status TEXT NOT NULL DEFAULT 'posted',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(event_id) REFERENCES monetization_revenue_events(event_id)
+);
+
+CREATE TABLE IF NOT EXISTS monetization_entries (
+  entry_id TEXT PRIMARY KEY,
+  journal_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK(direction IN ('debit', 'credit')),
+  amount_minor INTEGER NOT NULL CHECK(amount_minor >= 0),
+  currency TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(journal_id) REFERENCES monetization_journals(journal_id),
+  FOREIGN KEY(account_id) REFERENCES monetization_accounts(account_id)
+);
+CREATE INDEX IF NOT EXISTS idx_monetization_entries_journal ON monetization_entries(journal_id);
+CREATE INDEX IF NOT EXISTS idx_monetization_entries_account ON monetization_entries(account_id, created_at);
+
+CREATE TABLE IF NOT EXISTS monetization_balances (
+  account_id TEXT PRIMARY KEY,
+  pending_minor INTEGER NOT NULL DEFAULT 0 CHECK(pending_minor >= 0),
+  available_minor INTEGER NOT NULL DEFAULT 0 CHECK(available_minor >= 0),
+  reserved_minor INTEGER NOT NULL DEFAULT 0 CHECK(reserved_minor >= 0),
+  paid_minor INTEGER NOT NULL DEFAULT 0 CHECK(paid_minor >= 0),
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(account_id) REFERENCES monetization_accounts(account_id)
+);
+
+CREATE TABLE IF NOT EXISTS monetization_subscriptions (
+  subscription_id TEXT PRIMARY KEY,
+  customer_id TEXT NOT NULL,
+  merchant_id TEXT NOT NULL,
+  product_id TEXT NOT NULL,
+  price_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  provider_subscription_id TEXT,
+  status TEXT NOT NULL,
+  current_period_start TEXT,
+  current_period_end TEXT,
+  cancel_at_period_end INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(provider, provider_subscription_id)
+);
+
+CREATE TABLE IF NOT EXISTS monetization_entitlements (
+  entitlement_id TEXT PRIMARY KEY,
+  subject_type TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  capability TEXT NOT NULL,
+  source_type TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  valid_from TEXT NOT NULL,
+  valid_to TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(subject_type, subject_id, capability, source_type, source_id)
+);
+CREATE INDEX IF NOT EXISTS idx_monetization_entitlements_subject
+  ON monetization_entitlements(subject_type, subject_id, status, valid_to);
+
+CREATE TABLE IF NOT EXISTS monetization_payouts (
+  payout_id TEXT PRIMARY KEY,
+  developer_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  amount_minor INTEGER NOT NULL CHECK(amount_minor > 0),
+  currency TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  provider_payout_id TEXT,
+  status TEXT NOT NULL DEFAULT 'requested',
+  failure_code TEXT,
+  failure_message TEXT,
+  requested_at TEXT NOT NULL,
+  completed_at TEXT,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(account_id) REFERENCES monetization_accounts(account_id),
+  UNIQUE(provider, provider_payout_id)
+);
+
+CREATE TABLE IF NOT EXISTS monetization_ad_events (
+  ad_event_id TEXT PRIMARY KEY,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  placement_id TEXT NOT NULL,
+  miniapp_id TEXT NOT NULL,
+  developer_id TEXT NOT NULL,
+  campaign_id TEXT,
+  event_type TEXT NOT NULL,
+  billable_amount_minor INTEGER NOT NULL DEFAULT 0 CHECK(billable_amount_minor >= 0),
+  currency TEXT NOT NULL,
+  verification_status TEXT NOT NULL DEFAULT 'pending',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  occurred_at TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);

--- a/fabushi/web/migrations/20260825_monetization_platform_v1.sql
+++ b/fabushi/web/migrations/20260825_monetization_platform_v1.sql
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS monetization_journals (
   status TEXT NOT NULL DEFAULT 'posted',
   metadata_json TEXT NOT NULL DEFAULT '{}',
   created_at TEXT NOT NULL,
+  CHECK(total_debits_minor = total_credits_minor),
   FOREIGN KEY(event_id) REFERENCES monetization_revenue_events(event_id)
 );
 

--- a/fabushi/web/src/services/monetization-store.js
+++ b/fabushi/web/src/services/monetization-store.js
@@ -1,0 +1,151 @@
+import {
+  buildBalancedRevenueJournal,
+  normalizeRevenueEvent,
+} from './monetization.js';
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+export async function findRevenueEventByIdempotency(db, idempotencyKey) {
+  return await db.prepare(`
+    SELECT event_id, idempotency_key, source, source_id, scope_type, scope_id,
+           gross_amount_minor, currency, developer_id, miniapp_id, bot_id,
+           customer_id, status, metadata_json, occurred_at, created_at
+      FROM monetization_revenue_events
+     WHERE idempotency_key = ?
+  `).bind(idempotencyKey).first();
+}
+
+export async function recordRevenueEvent({
+  db,
+  input,
+  clearingAccount,
+  allocations,
+}) {
+  if (!db?.prepare || !db?.batch) throw new TypeError('D1-compatible db binding is required');
+  const event = normalizeRevenueEvent(input);
+  const existing = await findRevenueEventByIdempotency(db, event.idempotencyKey);
+  if (existing) return { eventId: existing.event_id, duplicate: true };
+
+  if (!clearingAccount?.accountId) throw new TypeError('clearingAccount.accountId is required');
+  if (!Array.isArray(allocations) || allocations.length === 0) throw new TypeError('allocations are required');
+
+  const journalId = `journal_${event.eventId}`;
+  const journal = buildBalancedRevenueJournal({
+    eventId: event.eventId,
+    source: event.source,
+    grossAmountMinor: event.grossAmountMinor,
+    currency: event.currency,
+    clearingAccountId: clearingAccount.accountId,
+    allocations: allocations.map((item) => ({
+      accountId: item.account.accountId,
+      amountMinor: item.amountMinor,
+    })),
+  });
+  const createdAt = nowIso();
+  const accounts = [clearingAccount, ...allocations.map((item) => item.account)];
+  const statements = [];
+
+  for (const account of accounts) {
+    if (!account?.accountId || !account?.ownerType || !account?.ownerId || !account?.bucket) {
+      throw new TypeError('each account requires accountId, ownerType, ownerId, and bucket');
+    }
+    statements.push(
+      db.prepare(`
+        INSERT OR IGNORE INTO monetization_accounts
+          (account_id, owner_type, owner_id, bucket, currency, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, 'active', ?, ?)
+      `).bind(
+        account.accountId,
+        account.ownerType,
+        account.ownerId,
+        account.bucket,
+        event.currency,
+        createdAt,
+        createdAt,
+      ),
+    );
+  }
+
+  statements.push(
+    db.prepare(`
+      INSERT INTO monetization_revenue_events
+        (event_id, idempotency_key, source, source_id, scope_type, scope_id,
+         gross_amount_minor, currency, developer_id, miniapp_id, bot_id, customer_id,
+         status, metadata_json, occurred_at, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'recorded', ?, ?, ?)
+    `).bind(
+      event.eventId,
+      event.idempotencyKey,
+      event.source,
+      event.sourceId,
+      event.scopeType,
+      event.scopeId,
+      event.grossAmountMinor,
+      event.currency,
+      event.developerId,
+      event.miniappId,
+      event.botId,
+      event.customerId,
+      JSON.stringify(event.metadata),
+      event.occurredAt,
+      createdAt,
+    ),
+    db.prepare(`
+      INSERT INTO monetization_journals
+        (journal_id, event_id, event_type, currency, total_debits_minor, total_credits_minor,
+         status, metadata_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, 'posted', '{}', ?)
+    `).bind(
+      journalId,
+      event.eventId,
+      journal.eventType,
+      journal.currency,
+      journal.totalDebitsMinor,
+      journal.totalCreditsMinor,
+      createdAt,
+    ),
+  );
+
+  for (const [index, entry] of journal.entries.entries()) {
+    statements.push(
+      db.prepare(`
+        INSERT INTO monetization_entries
+          (entry_id, journal_id, account_id, direction, amount_minor, currency, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).bind(
+        `${journalId}:entry:${index + 1}`,
+        journalId,
+        entry.accountId,
+        entry.direction,
+        entry.amountMinor,
+        entry.currency,
+        createdAt,
+      ),
+    );
+  }
+
+  for (const allocation of allocations) {
+    if (allocation.account.bucket !== 'pending') continue;
+    statements.push(
+      db.prepare(`
+        INSERT INTO monetization_balances
+          (account_id, pending_minor, available_minor, reserved_minor, paid_minor, updated_at)
+        VALUES (?, ?, 0, 0, 0, ?)
+        ON CONFLICT(account_id) DO UPDATE SET
+          pending_minor = pending_minor + excluded.pending_minor,
+          updated_at = excluded.updated_at
+      `).bind(allocation.account.accountId, allocation.amountMinor, createdAt),
+    );
+  }
+
+  try {
+    await db.batch(statements);
+    return { eventId: event.eventId, journalId, duplicate: false };
+  } catch (error) {
+    const raced = await findRevenueEventByIdempotency(db, event.idempotencyKey);
+    if (raced) return { eventId: raced.event_id, duplicate: true };
+    throw error;
+  }
+}

--- a/fabushi/web/src/services/monetization.js
+++ b/fabushi/web/src/services/monetization.js
@@ -1,0 +1,168 @@
+const BALANCE_BUCKETS = new Set(['pending', 'available', 'reserved', 'paid']);
+
+export function assertMinorUnits(value, name = 'amountMinor') {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${name} must be a non-negative safe integer minor-unit amount`);
+  }
+  return value;
+}
+
+export function normalizeCurrency(value) {
+  const currency = String(value || '').trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(currency)) throw new TypeError('currency must be an ISO-4217 style 3-letter code');
+  return currency;
+}
+
+export function validateSplitRule(rule) {
+  if (!rule || !Array.isArray(rule.splits) || rule.splits.length === 0) {
+    throw new TypeError('split rule must include at least one split');
+  }
+
+  let totalBps = 0;
+  const seen = new Set();
+  for (const split of rule.splits) {
+    const accountKey = String(split?.accountKey || '').trim();
+    if (!accountKey) throw new TypeError('split accountKey is required');
+    if (seen.has(accountKey)) throw new TypeError(`duplicate split accountKey: ${accountKey}`);
+    seen.add(accountKey);
+
+    const basisPoints = Number(split.basisPoints);
+    if (!Number.isInteger(basisPoints) || basisPoints < 0 || basisPoints > 10000) {
+      throw new TypeError('split basisPoints must be an integer between 0 and 10000');
+    }
+    totalBps += basisPoints;
+  }
+
+  if (totalBps !== 10000) throw new RangeError(`split basis points must total 10000; got ${totalBps}`);
+  return rule;
+}
+
+export function allocateSplit(amountMinor, rule) {
+  assertMinorUnits(amountMinor);
+  validateSplitRule(rule);
+
+  const allocations = rule.splits.map((split, index) => {
+    const raw = amountMinor * split.basisPoints;
+    const floor = Math.floor(raw / 10000);
+    const remainder = raw % 10000;
+    return {
+      accountKey: split.accountKey,
+      basisPoints: split.basisPoints,
+      amountMinor: floor,
+      remainder,
+      index,
+    };
+  });
+
+  let allocated = allocations.reduce((sum, item) => sum + item.amountMinor, 0);
+  let remainderUnits = amountMinor - allocated;
+  const remainderOrder = [...allocations].sort((a, b) => b.remainder - a.remainder || a.index - b.index);
+  for (let index = 0; index < remainderUnits; index += 1) {
+    remainderOrder[index % remainderOrder.length].amountMinor += 1;
+  }
+
+  return allocations.map(({ remainder, index, ...item }) => item);
+}
+
+export function buildBalancedRevenueJournal({
+  eventId,
+  source,
+  grossAmountMinor,
+  currency,
+  clearingAccountId,
+  allocations,
+}) {
+  assertMinorUnits(grossAmountMinor, 'grossAmountMinor');
+  const normalizedCurrency = normalizeCurrency(currency);
+  if (!eventId) throw new TypeError('eventId is required');
+  if (!source) throw new TypeError('source is required');
+  if (!clearingAccountId) throw new TypeError('clearingAccountId is required');
+  if (!Array.isArray(allocations) || allocations.length === 0) throw new TypeError('allocations are required');
+
+  const creditTotal = allocations.reduce((sum, item) => sum + assertMinorUnits(item.amountMinor), 0);
+  if (creditTotal !== grossAmountMinor) {
+    throw new RangeError(`journal allocations must equal gross amount: ${creditTotal} != ${grossAmountMinor}`);
+  }
+
+  const entries = [
+    {
+      accountId: clearingAccountId,
+      direction: 'debit',
+      amountMinor: grossAmountMinor,
+      currency: normalizedCurrency,
+    },
+    ...allocations.map((item) => ({
+      accountId: item.accountId,
+      direction: 'credit',
+      amountMinor: item.amountMinor,
+      currency: normalizedCurrency,
+    })),
+  ];
+
+  return {
+    eventId,
+    eventType: source,
+    currency: normalizedCurrency,
+    totalDebitsMinor: grossAmountMinor,
+    totalCreditsMinor: creditTotal,
+    entries,
+  };
+}
+
+export function transitionBalance(balance, transition) {
+  const next = {
+    pending: assertMinorUnits(balance?.pending ?? 0, 'pending'),
+    available: assertMinorUnits(balance?.available ?? 0, 'available'),
+    reserved: assertMinorUnits(balance?.reserved ?? 0, 'reserved'),
+    paid: assertMinorUnits(balance?.paid ?? 0, 'paid'),
+  };
+  const amountMinor = assertMinorUnits(transition?.amountMinor, 'amountMinor');
+  const from = transition?.from ?? null;
+  const to = transition?.to ?? null;
+
+  if (from !== null && !BALANCE_BUCKETS.has(from)) throw new TypeError(`invalid source balance bucket: ${from}`);
+  if (to !== null && !BALANCE_BUCKETS.has(to)) throw new TypeError(`invalid destination balance bucket: ${to}`);
+  if (from === null && to === null) throw new TypeError('a balance transition needs a source or destination bucket');
+  if (from === to && from !== null) return next;
+
+  if (from !== null) {
+    if (next[from] < amountMinor) throw new RangeError(`insufficient ${from} balance`);
+    next[from] -= amountMinor;
+  }
+  if (to !== null) next[to] += amountMinor;
+  return next;
+}
+
+export function canTransitionPayout(from, to) {
+  const transitions = {
+    requested: new Set(['reviewing', 'cancelled', 'failed']),
+    reviewing: new Set(['processing', 'cancelled', 'failed']),
+    processing: new Set(['paid', 'failed']),
+    paid: new Set(),
+    failed: new Set(),
+    cancelled: new Set(),
+  };
+  return Boolean(transitions[from]?.has(to));
+}
+
+export function normalizeRevenueEvent(input) {
+  if (!input?.idempotencyKey) throw new TypeError('idempotencyKey is required');
+  if (!input?.source) throw new TypeError('source is required');
+  if (!input?.scopeType || !input?.scopeId) throw new TypeError('scopeType and scopeId are required');
+  return {
+    eventId: input.eventId || crypto.randomUUID(),
+    idempotencyKey: String(input.idempotencyKey),
+    source: String(input.source).toUpperCase(),
+    sourceId: input.sourceId ?? null,
+    scopeType: String(input.scopeType),
+    scopeId: String(input.scopeId),
+    grossAmountMinor: assertMinorUnits(input.grossAmountMinor, 'grossAmountMinor'),
+    currency: normalizeCurrency(input.currency),
+    developerId: input.developerId ?? null,
+    miniappId: input.miniappId ?? null,
+    botId: input.botId ?? null,
+    customerId: input.customerId ?? null,
+    metadata: input.metadata && typeof input.metadata === 'object' ? input.metadata : {},
+    occurredAt: input.occurredAt || new Date().toISOString(),
+  };
+}

--- a/fabushi/web/tests/monetization.test.js
+++ b/fabushi/web/tests/monetization.test.js
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  allocateSplit,
+  buildBalancedRevenueJournal,
+  canTransitionPayout,
+  normalizeRevenueEvent,
+  transitionBalance,
+  validateSplitRule,
+} from '../src/services/monetization.js';
+
+const standardRule = {
+  splits: [
+    { accountKey: 'platform', basisPoints: 2000 },
+    { accountKey: 'developer', basisPoints: 7500 },
+    { accountKey: 'affiliate', basisPoints: 500 },
+  ],
+};
+
+test('split rules must total exactly 10000 basis points', () => {
+  assert.equal(validateSplitRule(standardRule), standardRule);
+  assert.throws(
+    () => validateSplitRule({ splits: [{ accountKey: 'platform', basisPoints: 9999 }] }),
+    /total 10000/,
+  );
+});
+
+test('split allocation preserves every minor unit deterministically', () => {
+  const result = allocateSplit(101, {
+    splits: [
+      { accountKey: 'platform', basisPoints: 5000 },
+      { accountKey: 'developer', basisPoints: 5000 },
+    ],
+  });
+
+  assert.deepEqual(result, [
+    { accountKey: 'platform', basisPoints: 5000, amountMinor: 51 },
+    { accountKey: 'developer', basisPoints: 5000, amountMinor: 50 },
+  ]);
+  assert.equal(result.reduce((sum, item) => sum + item.amountMinor, 0), 101);
+});
+
+test('revenue journal is balanced and rejects mismatched allocations', () => {
+  const journal = buildBalancedRevenueJournal({
+    eventId: 'evt_1',
+    source: 'SUBSCRIPTION',
+    grossAmountMinor: 3000,
+    currency: 'cny',
+    clearingAccountId: 'psp:clearing:cny',
+    allocations: [
+      { accountId: 'platform:revenue:cny', amountMinor: 600 },
+      { accountId: 'developer:42:pending:cny', amountMinor: 2400 },
+    ],
+  });
+
+  assert.equal(journal.totalDebitsMinor, 3000);
+  assert.equal(journal.totalCreditsMinor, 3000);
+  assert.equal(journal.currency, 'CNY');
+  assert.equal(journal.entries.filter((entry) => entry.direction === 'debit').length, 1);
+  assert.equal(journal.entries.filter((entry) => entry.direction === 'credit').length, 2);
+
+  assert.throws(
+    () => buildBalancedRevenueJournal({
+      eventId: 'evt_bad',
+      source: 'PURCHASE',
+      grossAmountMinor: 100,
+      currency: 'USD',
+      clearingAccountId: 'psp:clearing:usd',
+      allocations: [{ accountId: 'developer:1:pending:usd', amountMinor: 99 }],
+    }),
+    /must equal gross amount/,
+  );
+});
+
+test('balance lifecycle supports pending to available to reserved to paid without overdraft', () => {
+  let balance = transitionBalance(
+    { pending: 0, available: 0, reserved: 0, paid: 0 },
+    { from: null, to: 'pending', amountMinor: 10000 },
+  );
+  balance = transitionBalance(balance, { from: 'pending', to: 'available', amountMinor: 10000 });
+  balance = transitionBalance(balance, { from: 'available', to: 'reserved', amountMinor: 8000 });
+  balance = transitionBalance(balance, { from: 'reserved', to: 'paid', amountMinor: 8000 });
+
+  assert.deepEqual(balance, { pending: 0, available: 2000, reserved: 0, paid: 8000 });
+  assert.throws(
+    () => transitionBalance(balance, { from: 'available', to: 'reserved', amountMinor: 2001 }),
+    /insufficient available balance/,
+  );
+});
+
+test('payout state machine prevents unsafe state skipping', () => {
+  assert.equal(canTransitionPayout('requested', 'reviewing'), true);
+  assert.equal(canTransitionPayout('reviewing', 'processing'), true);
+  assert.equal(canTransitionPayout('processing', 'paid'), true);
+  assert.equal(canTransitionPayout('requested', 'paid'), false);
+  assert.equal(canTransitionPayout('paid', 'processing'), false);
+});
+
+test('revenue events normalize source, currency, and require idempotency', () => {
+  const event = normalizeRevenueEvent({
+    eventId: 'evt_demo',
+    idempotencyKey: 'alipay:trade:abc',
+    source: 'subscription',
+    scopeType: 'miniapp',
+    scopeId: 'global-donation',
+    grossAmountMinor: 3000,
+    currency: 'cny',
+    developerId: 'developer-1',
+  });
+
+  assert.equal(event.source, 'SUBSCRIPTION');
+  assert.equal(event.currency, 'CNY');
+  assert.equal(event.grossAmountMinor, 3000);
+  assert.throws(
+    () => normalizeRevenueEvent({ source: 'AD_CLICK', scopeType: 'miniapp', scopeId: 'x', grossAmountMinor: 1, currency: 'USD' }),
+    /idempotencyKey is required/,
+  );
+});

--- a/projects/telegram-fabushi-integration/docs/11-Fabushi-Pay.md
+++ b/projects/telegram-fabushi-integration/docs/11-Fabushi-Pay.md
@@ -1,62 +1,129 @@
-# Fabushi Pay
+# Fabushi Pay / Monetization Platform
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：DOC-11
-- **版本**：v1.0
-- **状态**：BASELINE
+- **版本**：v1.1
+- **状态**：ACTIVE_DESIGN
 - **基线日期**：2026-08-22
+- **扩展日期**：2026-08-25
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
 
-> 本文档由源计划结构化拆分而来。源计划未明确的管理字段会标记为“项目管理补充/待确认”，避免把推导内容冒充既有事实。
+目标：Mini App、Bot、Agent、聊天内商品、订阅和广告统一走 Fabushi Monetization Platform；支付只是收入来源之一。
 
-目标：Mini App、Bot、Agent、聊天内商品统一走 Fabushi Pay。
+## 统一领域模型
 
-核心模型：
-- Merchant
-- Product
-- Order
-- PaymentIntent
-- PaymentMethod
-- Provider
-- Refund
-- Settlement
-- Ledger
+- Merchant / Developer
+- Product / Price
+- Order / PaymentIntent / PaymentMethod / Provider
+- Subscription
+- Entitlement
+- RevenueEvent
+- Versioned SplitRule
+- Ledger Journal / Ledger Entry
+- Developer Balance: Pending / Available / Reserved / Paid
+- Settlement / Payout
+- Refund / Chargeback reversal
+- Ad Placement / Ad Event
 - WebhookEvent
 
-统一支付流程：
-1. Mini App/Bot/Agent 创建 Order
-2. Fabushi Pay 创建 PaymentIntent
-3. 根据平台/地区选择 Provider
-4. 用户确认支付
-5. Provider 返回结果
-6. Payment Service 验签
-7. Ledger 记账
-8. 更新 Order
-9. Webhook 通知商户
-10. Chat/Mini App 收到统一支付结果事件
+## 总体资金流
 
-必须支持 Provider Adapter：
+```text
+Payment / Subscription / Verified Ad Event / Future Revenue Source
+                         |
+                         v
+                   Revenue Event
+                         |
+                 Versioned Split Rule
+                         |
+                         v
+              Immutable Double-entry Ledger
+                         |
+                         v
+        Pending -> Available -> Reserved -> Paid
+                         |
+                         v
+                    PSP Payout
+```
+
+所有金额使用最小货币单位整数（fen/cents），禁止用浮点数进行账务计算。每个 journal 必须满足 `total_debits_minor == total_credits_minor`，数据库与领域服务同时保护该不变量。
+
+## Revenue Event
+
+Revenue Event 是广告、支付、订阅等商业化来源进入账本的唯一标准入口。最少包含：
+
+- event id + idempotency key
+- source/source id
+- scope type/scope id
+- gross amount minor + currency
+- customer/developer/miniapp/bot attribution
+- occurred at + metadata
+
+Provider webhook 重试、广告事件重试或网络重复投递必须复用同一个 idempotency key，不得重复形成收入。
+
+## 分账
+
+分账规则按 `scope + revenue source + version + effective window` 版本化。每个规则严格等于 `10000 bps`，历史事件固定使用事件发生时对应的规则版本。最小货币单位不能整除时采用确定性余数分配，保证逐分守恒。
+
+示例：
+
+```text
+100 CNY gross
+platform 20% + developer 75% + affiliate 5%
+```
+
+未来支付处理费、税费、渠道成本应通过明确 ledger account / split component 表达，不允许通过修改历史余额模拟。
+
+## 订阅与权益
+
+`Payment != Entitlement`。StoreKit、Play Billing、支付宝、Stripe、兑换码、管理员赠送最终都写入独立 Entitlement 模型，客户端只根据 Entitlement 判断是否解锁功能。订阅负责生命周期，支付负责资金确认，权益负责产品访问能力。
+
+## 广告
+
+广告事件先进入 `monetization_ad_events` staging 层。只有经过验证/反作弊并成为 billable event 后，才能转换为 Revenue Event，随后与支付收入共用同一分账、账本和开发者余额体系。
+
+首期事件类型面向 impression/click/conversion/rewarded-complete 扩展，不允许未经验证的客户端事件直接产生可提现余额。
+
+## 开发者余额与提现
+
+开发者收益四个状态：
+
+1. Pending：已记账但仍处退款/反作弊/结算等待期。
+2. Available：可申请提现。
+3. Reserved：已提交 payout，资金被锁定。
+4. Paid：PSP 已确认打款完成。
+
+提现状态机：`requested -> reviewing -> processing -> paid`，允许明确的 failed/cancelled 退出，但禁止 `requested -> paid` 直接跳转。
+
+第一阶段由持牌 PSP/marketplace payout provider 托管实际资金并执行 KYC/KYB/payout；Fabushi 负责商业规则、账本、余额和结算编排，不自行充当资金托管机构。
+
+## Provider Adapter
+
+必须支持：
+
 - Apple In-App Purchase / StoreKit（虚拟商品场景遵循平台规则）
 - Google Play Billing（虚拟商品场景遵循平台规则）
-- Stripe 等外部支付渠道（适用场景）
-- 地区支付渠道扩展
+- Stripe/Adyen/其他 marketplace provider（适用场景）
+- 支付宝及地区支付渠道
 
-虚拟商品：
-- Credits/Stars 类平台余额（如启用）
-- 数字内容
-- Mini App 虚拟服务
-- Bot/Agent 服务
+Adapter 的职责是验证外部事实并产生标准事件，而不是各自维护余额或权益真相。
 
-需要提前设计：
-- 平台规则
-- 税务/退款
-- 余额监管风险
-- KYC/KYB（如进入商户结算）
-- 对账
-- 风控
+## Refund / Chargeback
 
-重要原则：
-支付系统不要和聊天 UI 直接耦合；聊天只消费 PaymentIntent/PaymentResult 事件。
+退款和拒付不得删除或修改历史 journal。必须生成引用原事件的 reversal Revenue Event / reversal journal，通过相反账务分录恢复正确状态，并保持 webhook 幂等。
 
+## 合规与风险边界
 
-============================================================
+需要长期覆盖：平台规则、KYC/KYB、税务、退款/chargeback、对账、广告审核、广告反作弊、隐私同意、未成年人保护与 payout 风控。通用可转让/可提现用户储值余额不属于 V1 范围；如未来启用，必须先做对应支付/电子货币监管评估。
+
+## 当前 V1 落地
+
+- migration: `fabushi/web/migrations/20260825_monetization_platform_v1.sql`
+- domain core: `fabushi/web/src/services/monetization.js`
+- D1 persistence: `fabushi/web/src/services/monetization-store.js`
+- invariant tests: `fabushi/web/tests/monetization.test.js`
+- task record: `../management/tasks/M9-T06-monetization-core.md`
+
+下一阶段：active split-rule resolver -> 现有支付 provider Revenue Event adapter -> refund reversal -> entitlement migration -> verified ads -> PSP payout。
+
+重要原则：支付/商业化系统不要和聊天 UI 直接耦合；Chat/MiniApp 只消费 Payment/Entitlement/Monetization 领域事件。

--- a/projects/telegram-fabushi-integration/management/tasks/M9-T06-monetization-core.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M9-T06-monetization-core.md
@@ -2,8 +2,10 @@
 
 - **Project**: FAB-P0001 / TFI / Fabushi Telegram 全量融合
 - **Task ID**: M9.T06
-- **Status**: IMPLEMENTED_PENDING_CI
+- **Status**: TESTING
 - **Branch**: `feat/fabushi-monetization-core`
+- **PR**: `#2131`
+- **PR head**: `36de89b2c645eedff048acc1e2c5c912f262ef1b` at PR creation; later task-record commits may advance the head.
 - **Source requirement**: 2026-08-25 user request to implement a unified Monetization Platform spanning advertising, payments, subscriptions, developer revenue sharing, settlement and payout.
 
 ## Objective
@@ -14,7 +16,7 @@ Build the shared financial core so payment providers, subscriptions, advertising
 
 1. All money is represented as integer minor units; floating point is rejected for ledger arithmetic.
 2. Every split rule totals exactly 10,000 basis points and every minor unit is allocated deterministically.
-3. Every posted revenue journal has equal total debit and total credit.
+3. Every posted revenue journal has equal total debit and total credit; the D1 schema also rejects an unbalanced journal header.
 4. Revenue events are idempotent by external/provider key and duplicate delivery does not create duplicate revenue.
 5. Developer earnings expose Pending, Available, Reserved and Paid lifecycle buckets and cannot overdraw.
 6. Payout lifecycle cannot jump directly from requested to paid.
@@ -24,7 +26,7 @@ Build the shared financial core so payment providers, subscriptions, advertising
 ## Implementation
 
 - `fabushi/web/migrations/20260825_monetization_platform_v1.sql`
-  - accounts, revenue events, versioned split rules, journals/entries, balances, subscriptions, entitlements, payouts, advertising events.
+  - accounts, revenue events, versioned split rules, balanced journals/entries, balances, subscriptions, entitlements, payouts, advertising events.
 - `fabushi/web/src/services/monetization.js`
   - integer-money validation, split rule validation, deterministic split allocation, balanced journal construction, balance transitions, payout state machine, Revenue Event normalization.
 - `fabushi/web/src/services/monetization-store.js`
@@ -50,14 +52,17 @@ Decision: adapt the proven separation-of-concerns and double-entry concepts into
 - Invariant tests commit: `0d716c8ee89daf8d9949612362d65058e7d7b638`
 - Persistence commit: `a6d9c8d19dab68899966b8814d82fd3d21de75d3`
 - WBS update commit: `20ec91258948948a0c31a463faee6feee7c9ee3d`
+- DB balance invariant hardening: `8ad4fbbd8a607c997f30a8f3b52ff22ba068ab1d`
+- Architecture update: `36de89b2c645eedff048acc1e2c5c912f262ef1b`
+- PR: `#2131`; auto-merge enabled, subject to protected required checks.
 
 ## Verification
 
-Planned required check: `node --test fabushi/web/tests/monetization.test.js` plus repository CI. PR, CI, protected-main merge, canonical-main readback and applicable post-main delivery evidence are still pending; therefore this task is not complete.
+Required focused check: `node --test fabushi/web/tests/monetization.test.js` plus repository CI. At the first post-PR inspection no workflow/status result had been published yet. Protected-main merge, canonical-main readback and applicable post-main delivery evidence remain mandatory; therefore this task is not complete.
 
 ## Next actions
 
-1. Run repository CI through a PR and fix failures.
+1. Drive PR #2131 through CI and fix any failures.
 2. Add active split-rule resolver and persistence integration coverage.
 3. Migrate existing Alipay/StoreKit/Play/Stripe events through a feature-gated Revenue Event adapter.
 4. Implement reversal journals for refunds/chargebacks.

--- a/projects/telegram-fabushi-integration/management/tasks/M9-T06-monetization-core.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M9-T06-monetization-core.md
@@ -1,0 +1,64 @@
+# M9.T06 — Unified Monetization Core
+
+- **Project**: FAB-P0001 / TFI / Fabushi Telegram 全量融合
+- **Task ID**: M9.T06
+- **Status**: IMPLEMENTED_PENDING_CI
+- **Branch**: `feat/fabushi-monetization-core`
+- **Source requirement**: 2026-08-25 user request to implement a unified Monetization Platform spanning advertising, payments, subscriptions, developer revenue sharing, settlement and payout.
+
+## Objective
+
+Build the shared financial core so payment providers, subscriptions, advertising and future MiniApp/Bot/Agent revenue sources emit one normalized Revenue Event into one auditable ledger instead of maintaining independent balances.
+
+## Acceptance criteria
+
+1. All money is represented as integer minor units; floating point is rejected for ledger arithmetic.
+2. Every split rule totals exactly 10,000 basis points and every minor unit is allocated deterministically.
+3. Every posted revenue journal has equal total debit and total credit.
+4. Revenue events are idempotent by external/provider key and duplicate delivery does not create duplicate revenue.
+5. Developer earnings expose Pending, Available, Reserved and Paid lifecycle buckets and cannot overdraw.
+6. Payout lifecycle cannot jump directly from requested to paid.
+7. Subscription and entitlement records are separate from raw payment state.
+8. Advertising has a verified-event staging model before a billable Revenue Event is produced.
+
+## Implementation
+
+- `fabushi/web/migrations/20260825_monetization_platform_v1.sql`
+  - accounts, revenue events, versioned split rules, journals/entries, balances, subscriptions, entitlements, payouts, advertising events.
+- `fabushi/web/src/services/monetization.js`
+  - integer-money validation, split rule validation, deterministic split allocation, balanced journal construction, balance transitions, payout state machine, Revenue Event normalization.
+- `fabushi/web/src/services/monetization-store.js`
+  - D1-compatible idempotent Revenue Event persistence and atomic journal/entry posting.
+- `fabushi/web/tests/monetization.test.js`
+  - invariant tests for split conservation, journal balance, balance overdraft prevention, payout transitions and event idempotency requirements.
+
+## Open-source-first research
+
+Before implementation, proven designs were reviewed for concepts rather than copied code:
+
+- Formance Ledger: immutable/double-entry financial ledger concepts and transaction-oriented money movement.
+- Lago: separation of billing/metering concerns from payment collection.
+- Kill Bill: subscription/billing domain separation and provider-oriented architecture.
+- Medusa commerce architecture: provider abstraction and modular commerce boundaries.
+
+Decision: adapt the proven separation-of-concerns and double-entry concepts into Fabushi's existing Cloudflare D1/JavaScript backend. No upstream source code is copied into this task; the implementation remains within Fabushi domain boundaries. External PSP custody/payout remains a later provider-adapter task rather than making Fabushi a funds custodian.
+
+## Evidence
+
+- Schema commit: `108e190fef30a869c68309af15f3610a93cd4f84`
+- Domain core commit: `628809cb1e5afbbafb505f4a93dd925678615a7a`
+- Invariant tests commit: `0d716c8ee89daf8d9949612362d65058e7d7b638`
+- Persistence commit: `a6d9c8d19dab68899966b8814d82fd3d21de75d3`
+- WBS update commit: `20ec91258948948a0c31a463faee6feee7c9ee3d`
+
+## Verification
+
+Planned required check: `node --test fabushi/web/tests/monetization.test.js` plus repository CI. PR, CI, protected-main merge, canonical-main readback and applicable post-main delivery evidence are still pending; therefore this task is not complete.
+
+## Next actions
+
+1. Run repository CI through a PR and fix failures.
+2. Add active split-rule resolver and persistence integration coverage.
+3. Migrate existing Alipay/StoreKit/Play/Stripe events through a feature-gated Revenue Event adapter.
+4. Implement reversal journals for refunds/chargebacks.
+5. Implement verified advertising event -> Revenue Event adapter and PSP-backed developer payout adapter.

--- a/projects/telegram-fabushi-integration/management/wbs/M9.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M9.md
@@ -55,25 +55,68 @@
 - **证据位置**：待填写（commit / PR / CI run / release / test report）
 - **下一步**：领取后补充实现路径与测试名称。
 
-### M9.T06 — ledger
+### M9.T06 — universal ledger + revenue event core
 
-- **交付物**：ledger
-- **验收标准**：Mini App/Bot/Agent 可以创建支付意图；沙盒支付端到端完成；重复 webhook 不重复记账
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
-- **来源**：源计划 M9
-- **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **交付物**：不可变复式账本、Revenue Event、幂等记账、整数最小货币单位模型。
+- **验收标准**：任意收入事件只记账一次；每个 journal 借贷相等；分账金额逐分守恒；重复 idempotency key 不重复产生收入。
+- **客观验证**：`node --test fabushi/web/tests/monetization.test.js` + CI。
+- **来源**：源计划 M9 + 2026-08-25 用户要求统一广告联盟/支付/订阅/分账/提现。
+- **状态**：IMPLEMENTED_PENDING_CI
+- **阻塞**：PR/CI/merge/canonical-main delivery gate 尚未完成。
+- **证据位置**：branch `feat/fabushi-monetization-core`；migration `20260825_monetization_platform_v1.sql`；services `monetization.js` / `monetization-store.js`。
+- **下一步**：通过 PR CI 后接入现有支付宝、StoreKit、Play Billing/provider adapter 的标准 Revenue Event。
 
 ### M9.T07 — refund basic flow
 
 - **交付物**：refund basic flow
-- **验收标准**：Mini App/Bot/Agent 可以创建支付意图；沙盒支付端到端完成；重复 webhook 不重复记账
-- **客观验证**：对应单元/集成/E2E/CI 检查，具体 test/check 名称在执行 PR 中补齐。
+- **验收标准**：退款生成反向账本事件，不删除或改写历史 journal；重复退款 webhook 幂等。
+- **客观验证**：退款集成测试 + journal balance assertion。
 - **来源**：源计划 M9
 - **状态**：NOT_STARTED
-- **阻塞**：无/待执行时更新
-- **证据位置**：待填写（commit / PR / CI run / release / test report）
-- **下一步**：领取后补充实现路径与测试名称。
+- **阻塞**：依赖 M9.T06 canonical main。
+- **证据位置**：待填写。
+- **下一步**：在统一账本落主干后实现 reversal journal。
 
+### M9.T08 — versioned revenue split engine
+
+- **交付物**：按 source/scope/version/effective window 的分账规则。
+- **验收标准**：规则总和必须 10000 bps；历史收入锁定发生时的规则版本；最小货币单位余数确定性分配。
+- **客观验证**：`monetization.test.js` split tests + persistence integration test。
+- **来源**：2026-08-25 Monetization Platform 扩展。
+- **状态**：IMPLEMENTED_PENDING_CI
+- **阻塞**：持久化规则读取与历史版本选择尚需下一轮接线。
+- **证据位置**：`monetization_split_rules` schema + `validateSplitRule` / `allocateSplit`。
+- **下一步**：实现规则管理 API 与 effective-at resolver。
+
+### M9.T09 — subscription + entitlement unification
+
+- **交付物**：订阅状态与 entitlement 独立模型。
+- **验收标准**：Stripe/支付宝/StoreKit/Play/兑换/管理员赠送均通过 entitlement 决定权限，支付状态不直接作为 UI 权限源。
+- **客观验证**：provider contract tests + entitlement E2E。
+- **来源**：2026-08-25 Monetization Platform 扩展。
+- **状态**：SCHEMA_IMPLEMENTED
+- **阻塞**：现有 membership 字段迁移策略待实现。
+- **证据位置**：`monetization_subscriptions` / `monetization_entitlements`。
+- **下一步**：建立兼容读路径并迁移现有 membership。
+
+### M9.T10 — developer balances + settlement + payout
+
+- **交付物**：Pending/Available/Reserved/Paid 四桶余额与 payout 状态机。
+- **验收标准**：不可透支；只有 Available 可进入 Reserved；payout 不允许 requested 直接跳 paid；最终资金由持牌 PSP 执行。
+- **客观验证**：余额状态机单测 + PSP sandbox payout contract test。
+- **来源**：2026-08-25 Monetization Platform 扩展。
+- **状态**：CORE_IMPLEMENTED_PENDING_CI
+- **阻塞**：PSP Connect/marketplace provider 尚未接入。
+- **证据位置**：`monetization_balances` / `monetization_payouts` + `transitionBalance` / `canTransitionPayout`。
+- **下一步**：接入首个 marketplace payout provider。
+
+### M9.T11 — advertising revenue producer
+
+- **交付物**：广告 placement/event 进入统一 Revenue Event/ledger 的入口。
+- **验收标准**：曝光/点击/转化/激励广告经 verification 后才能形成 billable event；广告收入与支付收入共用账本和开发者余额。
+- **客观验证**：ad event idempotency/fraud-status integration tests。
+- **来源**：2026-08-25 Monetization Platform 扩展。
+- **状态**：SCHEMA_IMPLEMENTED
+- **阻塞**：广告服务、审核、反作弊和 campaign auction 尚未实现。
+- **证据位置**：`monetization_ad_events`。
+- **下一步**：实现 verified ad event -> revenue event adapter。


### PR DESCRIPTION
## Summary

Starts the FAB-P0001 / M9 unified Monetization Platform foundation for advertising + payments + subscriptions + developer revenue sharing + settlement/payout.

### Included
- D1 schema for accounts, Revenue Events, versioned split rules, immutable journals/entries, four-state developer balances, subscriptions, entitlements, payouts and ad event staging
- integer minor-unit money arithmetic
- deterministic 10,000-bps split allocator
- balanced double-entry journal builder with DB-level balance invariant
- idempotent D1 Revenue Event persistence
- payout and balance state-machine invariants
- Node tests for money conservation, journal balance, overdraft prevention and payout transition safety
- FAB-P0001 M9 WBS/task/architecture documentation

### Intentionally not wired yet
Existing Alipay/StoreKit/Play/Stripe flows remain unchanged in this PR. Provider adapters will be migrated behind the unified Revenue Event boundary after this core passes CI, so a schema rollout cannot accidentally interrupt live payment callbacks.

## Verification

Required focused check: `node --test fabushi/web/tests/monetization.test.js`

Repository CI / protected merge / canonical-main verification remain required before M9.T06 can be considered complete.

## Open-source-first
Reviewed proven ledger/billing/provider designs (Formance Ledger, Lago, Kill Bill, Medusa) for architecture and invariants; no upstream source code was copied.