### PR TITLE
docs(pay): close M9 developer commerce and global CN payouts

### DIFF
--- a/projects/telegram-fabushi-integration/evidence/M9-PAY-002-003-current-main/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M9-PAY-002-003-current-main/README.md
@@ -1,0 +1,48 @@
+# M9-PAY-002 / M9-PAY-003 exact-main closure evidence
+
+- Project: `FAB-P0001 / TFI`
+- Canonical main SHA: `573c140f7007ad98230c90f3c24bc99e1f36a88f`
+- Implementation PR: `#2133`
+- Final feature head: `4d0687fed9b54793cb1237c39718b51b8d32b669`
+- Merge method: protected GitHub Merge Queue
+- Merged at: `2026-08-25T16:01:48Z`
+
+## Feature-head evidence
+
+- Developer Fiat Commerce `32868752808`: 5/5 success.
+- Developer Fiat Commerce UI `32868752819`: native contract + production web build success.
+- Platform Control Plane `32868752821`: schema/account invariants, production Worker compile and one-control-plane guard success.
+- Repository CI `32868752829`: success.
+- Electron desktop quality gate `32868752823`: success.
+- Messaging Product Gate `32868752779`: success.
+
+## Merge Queue evidence
+
+- Explicit sensitive-path authorization was recorded through repository governance using the `automerge` label and `[automerge-force]` title marker after the user explicitly required merge to `main`.
+- Merge Queue reported PR #2133 at position 1.
+- Authoritative merge-group CI `32869281732`: success.
+- The successful merge-group SHA became canonical `main` as `573c140f7007ad98230c90f3c24bc99e1f36a88f`.
+
+## Exact-main evidence
+
+All checks below ran against `main@573c140f7007ad98230c90f3c24bc99e1f36a88f`:
+
+- Developer Fiat Commerce `32869457305`: control-plane unit/fmt, commerce-control wasm32, platform-worker wasm32/fmt, pay-worker wasm32/fmt, schema/security/accounting contract — all success.
+- Developer Fiat Commerce UI `32869457162`: native bridge authority contract + production Web build — both success.
+- Platform Control Plane `32869457301`: schema/account invariants + production Worker compile + one-control-plane architecture guard — success.
+- Merge Queue CI `32869281732` already validated the exact merge-group/main SHA before protected merge.
+
+## Accepted architecture
+
+- One canonical Rust Fabushi Pay / double-entry ledger remains the writable money authority.
+- Developer Commerce prices are server-authoritative integer minor units.
+- Apple Advanced Commerce uses generic products plus persisted dynamic Mini App SKU/JWS integrity binding.
+- Google Play uses global `convertRegionPrices` plus catalog synchronization and fail-closed rail activation.
+- Mainland-China settlement routing distinguishes source-order WeChat/Alipay split from LianLian/Huifu external-proceeds payout.
+- Global payout routing supports Stripe Connect, Adyen Platform, PayPal Multiparty and PayPal Payouts through provider-neutral orchestration.
+- KYC/KYB/provider capability/route state is server-owned; renderer cannot self-approve payout eligibility or set provider secrets/platform fees.
+- Settlement fee calculation is based on reconciled net receipts, with explicit reserve, refund/chargeback and payout-clearing accounting.
+
+## External production activation gates
+
+Engineering implementation, protected merge and exact-main automated verification are complete. This evidence does **not** claim that every external payment provider is already production-enabled. Real money movement remains fail-closed until the relevant provider approval, merchant/platform agreement, business-category eligibility, KYC/KYB, production credentials, webhook configuration and settlement account are verified for Apple, Google, WeChat Pay, Alipay, LianLian, Huifu, Stripe, Adyen and/or PayPal as applicable.

--- a/projects/telegram-fabushi-integration/management/tasks/M9-PAY-002-dynamic-fiat-developer-commerce.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M9-PAY-002-dynamic-fiat-developer-commerce.md
@@ -2,7 +2,7 @@
 
 - Project: FAB-P0001 / TFI
 - Stage: M9 支付
-- Status: IN_PROGRESS
+- Status: COMPLETE
 - Owner surface: Developer Commerce / Bot Father / Fabushi Pay
 
 ## 目标
@@ -13,25 +13,35 @@
 
 | ID | 验收条件 | 客观测试 | 状态 |
 |---|---|---|---|
-| M9-PAY-002-A | Developer Commerce 按登录用户/角色授权，客户端不能指定 developerId/owner/platform fee | schema-contract + Rust tests + desktop bridge contract | IMPLEMENTED / VERIFYING |
-| M9-PAY-002-B | 商品使用 ISO 法币 + integer minor units；价格修改产生新 price revision | Rust + schema contract + HTTP contract | IMPLEMENTED / VERIFYING |
-| M9-PAY-002-C | Apple Advanced Commerce 使用 generic product + 动态 SKU + server ES256 JWS；未配置 entitlement/key/tax code 时 fail closed | Rust + wasm compile + JWS contract | IMPLEMENTED / VERIFYING |
-| M9-PAY-002-D | Google Play 先通过 `pricing:convertRegionPrices` 生成全球地区价格，再用 Publisher API 同步商品；失败进入 error，不伪装 active | Rust + wasm compile + adapter contract | IMPLEMENTED / VERIFYING |
-| M9-PAY-002-E | PaymentIntent 仍只从服务端 catalog 取价格，Mini App 不提交可信 amount/currency；只有 active provider binding 可进入 allowed rails | existing Fabushi Pay tests + contract test | VERIFYING |
-| M9-PAY-002-F | global-dharma 只作为 official.fabushi 名下普通 Mini App 使用同一 catalog/owner/provider binding | migration contract | IMPLEMENTED / VERIFYING |
-| M9-PAY-002-G | Bot Father 可创建开发者身份、注册 Mini App、创建/改价法币 SKU、查看/触发商店同步，renderer 不持有支付服务凭据 | web build + native bridge contract | IMPLEMENTED / VERIFYING |
-| M9-PAY-002-H | CI 绿后通过 PR 合并 canonical main，并在 exact-main SHA 再跑门禁 | GitHub Actions + exact-main verification | PENDING |
+| M9-PAY-002-A | Developer Commerce 按登录用户/角色授权，客户端不能指定 developerId/owner/platform fee | schema-contract + Rust tests + desktop bridge contract | COMPLETE |
+| M9-PAY-002-B | 商品使用 ISO 法币 + integer minor units；价格修改产生新 price revision | Rust + schema contract + HTTP contract | COMPLETE |
+| M9-PAY-002-C | Apple Advanced Commerce 使用 generic product + 动态 SKU + server ES256 JWS；未配置 entitlement/key/tax code 时 fail closed | Rust + wasm compile + JWS contract | COMPLETE |
+| M9-PAY-002-D | Google Play 先通过 `pricing:convertRegionPrices` 生成全球地区价格，再用 Publisher API 同步商品；失败进入 error，不伪装 active | Rust + wasm compile + adapter contract | COMPLETE |
+| M9-PAY-002-E | PaymentIntent 仍只从服务端 catalog 取价格，Mini App 不提交可信 amount/currency；只有 active provider binding 可进入 allowed rails | existing Fabushi Pay tests + contract test | COMPLETE |
+| M9-PAY-002-F | global-dharma 只作为 official.fabushi 名下普通 Mini App 使用同一 catalog/owner/provider binding | migration contract | COMPLETE |
+| M9-PAY-002-G | Bot Father 可创建开发者身份、注册 Mini App、创建/改价法币 SKU、查看/触发商店同步，renderer 不持有支付服务凭据 | web build + native bridge contract | COMPLETE |
+| M9-PAY-002-H | CI 绿后通过 PR 合并 canonical main，并在 exact-main SHA 再跑门禁 | GitHub Actions + exact-main verification | COMPLETE |
 
 ## 已落代码面
 
 - `0008_dynamic_fiat_developer_commerce.sql`：owner/member/catalog/price revision/provider binding/audit schema。
-- `0009_global_dharma_dynamic_fiat_seed.sql`：¥30/30 天、¥1080 永久版作为普通 canonical SKU 种子。
+- `0009_global_dharma_dynamic_fiat_seed.sql`：¥30/月、¥1080 永久版作为普通 canonical SKU 种子。
 - `mahayana-commerce-control-worker`：owner-scoped Developer Commerce API、Apple Advanced Commerce JWS、Google Publisher catalog sync。
 - Google 同步采用 `convertRegionPrices -> convertedRegionPrices/otherRegions/regionVersion -> catalog write`，不再只写单地区价格。
 - Provider purchase rail 采用 fail-closed：`payment_product_config.allowed_rails_json` 只包含 `sync_state=active` 的绑定；Google 同步成功后才激活 `google_play_billing`。
 - `api.ombhrum.com` 平台 Worker 只代理白名单 Developer Commerce 路由，拒绝 admin pay surface。
 - Bot Father `/miniapps/bot-father/commerce` 管理面使用 `window.fabushiNative.invoke`，宿主注入登录态；前端请求无法指定 developerId / ownerUserId / platformFeeBps。
+- Apple Advanced Commerce 校验同时绑定 generic product ID、persisted dynamic Mini App SKU、request reference、appAccountToken、currency、tax code 与 item price；结算收入仍以 provider reconciliation 为财务权威。
+
+## 完成证据
+
+- 主实现 PR：`#2133` — `[automerge-force] feat(pay): dynamic fiat commerce with global and mainland China payouts`。
+- 最终 feature head：`4d0687fed9b54793cb1237c39718b51b8d32b669`。
+- feature-head 验证：Developer Fiat Commerce run `32868752808` 5/5 success；Developer Fiat Commerce UI run `32868752819` 2/2 success；Platform Control Plane run `32868752821` success；CI run `32868752829` success；Electron desktop quality gate run `32868752823` success。
+- Protected Merge Queue：merge-group CI run `32869281732` success。
+- canonical `main` 合并 SHA：`573c140f7007ad98230c90f3c24bc99e1f36a88f`，PR #2133 merged at 2026-08-25T16:01:48Z。
+- exact-main 验证：Developer Fiat Commerce run `32869457305` 5/5 success；Developer Fiat Commerce UI run `32869457162` 2/2 success；Platform Control Plane run `32869457301` success。Merge Queue CI 已在同一 exact SHA `573c140f...` 上 success。
 
 ## 外部资格门禁
 
-Apple Mini Apps Partner Program / Advanced Commerce entitlement、generic product IDs、IAP signing key，以及 Google Play service-account 权限属于外部平台配置。代码必须实现完整适配并在缺失时 fail closed；没有外部批准/凭据不得把 provider 状态报告为可用。
+工程实现与 canonical-main 验收已完成；这不等于第三方支付渠道已经取得生产资格。Apple Mini Apps Partner Program / Advanced Commerce entitlement、generic product IDs、IAP signing key，以及 Google Play service-account 权限仍属于外部平台激活条件。缺失批准/凭据时 provider 必须保持 fail closed，不得报告为生产可用。

--- a/projects/telegram-fabushi-integration/management/tasks/M9-PAY-003-global-cn-developer-payouts.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M9-PAY-003-global-cn-developer-payouts.md
@@ -2,7 +2,7 @@
 
 - Project: FAB-P0001 / TFI
 - Stage: M9 支付
-- Status: IN_PROGRESS
+- Status: COMPLETE
 - Owner surface: Fabushi Pay / Developer Ledger / Developer Commerce / Bot Father
 - Depends on: M9-PAY-002 Dynamic Fiat Developer Commerce
 
@@ -14,21 +14,21 @@ Turn the existing developer settlement/payout primitives into a provider-neutral
 
 | ID | Acceptance | Objective test | Status |
 |---|---|---|---|
-| M9-PAY-003-A | Payout account models legal region, entity/KYC/KYB state, provider capability, supported currencies and external account reference; renderer cannot set provider secrets or verification state | migration + schema/security contract | VERIFYING |
-| M9-PAY-003-B | Server routing covers CN WeChat/Alipay original-order split, CN external-store proceeds via LianLian/Huifu, and global Stripe/Adyen/PayPal priorities; unavailable routes fail closed | Rust unit tests | VERIFYING |
-| M9-PAY-003-C | Settlement waterfall uses integer minor units and calculates platform fee from reconciled net receipts after tax/provider/store fees/refunds/chargebacks, then reserve/developer payable | Rust unit tests + ledger contract | VERIFYING |
-| M9-PAY-003-D | Payout reservation and provider execution are separate states with idempotent attempts, provider reference/error metadata, webhook reconciliation and failed-payout reversal | migration + Rust/contract tests | VERIFYING |
-| M9-PAY-003-E | Developer APIs are owner-scoped and expose balance breakdown, payout accounts, onboarding/capability state, settlement history and payout request without client authority over developer id, fee policy or ineligible provider routing | HTTP/auth contract + wasm compile | VERIFYING |
-| M9-PAY-003-F | Bot Father “收益与结算” surface shows pending/available/reserved/paid balances, onboarding/account status, settlement breakdown and payout history/request; native bridge keeps bearer/provider secrets outside renderer | web build + native bridge contract | VERIFYING |
-| M9-PAY-003-G | Existing M9-PAY-002 pay-in CI regression is green, including platform-worker wasm compile fix | GitHub Actions | VERIFYING |
-| M9-PAY-003-H | Final branch CI green, PR merged into canonical `main`, exact-main verification and required post-main delivery evidence completed | PR + Actions + evidence | PENDING |
+| M9-PAY-003-A | Payout account models legal region, entity/KYC/KYB state, provider capability, supported currencies and external account reference; renderer cannot set provider secrets or verification state | migration + schema/security contract | COMPLETE |
+| M9-PAY-003-B | Server routing covers CN WeChat/Alipay original-order split, CN external-store proceeds via LianLian/Huifu, and global Stripe/Adyen/PayPal priorities; unavailable routes fail closed | Rust unit tests | COMPLETE |
+| M9-PAY-003-C | Settlement waterfall uses integer minor units and calculates platform fee from reconciled net receipts after tax/provider/store fees/refunds/chargebacks, then reserve/developer payable | Rust unit tests + ledger contract | COMPLETE |
+| M9-PAY-003-D | Payout reservation and provider execution are separate states with idempotent attempts, provider reference/error metadata, webhook reconciliation and failed-payout reversal | migration + Rust/contract tests | COMPLETE |
+| M9-PAY-003-E | Developer APIs are owner-scoped and expose balance breakdown, payout accounts, onboarding/capability state, settlement history and payout request without client authority over developer id, fee policy or ineligible provider routing | HTTP/auth contract + wasm compile | COMPLETE |
+| M9-PAY-003-F | Bot Father “收益与结算” surface shows pending/available/reserved/paid balances, onboarding/account status, settlement breakdown and payout history/request; native bridge keeps bearer/provider secrets outside renderer | web build + native bridge contract | COMPLETE |
+| M9-PAY-003-G | Existing M9-PAY-002 pay-in CI regression is green, including platform-worker wasm compile fix | GitHub Actions | COMPLETE |
+| M9-PAY-003-H | Final branch CI green, PR merged into canonical `main`, exact-main verification and required post-main delivery evidence completed | PR + Actions + evidence | COMPLETE |
 
 ## Provider policy
 
 ### Mainland China
 - `wechat_platform`: WeChat-origin marketplace order split only after Platform Collection & Payment eligibility/configuration.
 - `alipay_platform`: Alipay-origin marketplace order split only after approved platform product configuration.
-- `lianlian_account_plus`: preferred payout for reconciled external store proceeds when provider/business approval is active.
+- `lianlian_account_plus`: preferred payout for reconciled external-store proceeds when provider/business approval is active.
 - `huifu_dougong`: fallback mainland-China payout provider when approved/configured.
 
 ### Global
@@ -47,10 +47,16 @@ Turn the existing developer settlement/payout primitives into a provider-neutral
 - China original-order split remains source-transaction-bound and separate from ordinary developer withdrawal.
 - Apple Advanced Commerce verification binds the generic product ID to the persisted dynamic Mini App SKU, request reference, app-account token, currency, tax code and item price. Financial settlement remains reconciliation-authoritative.
 
-## Final validation mode
+## 完成证据
 
-As of the final feature-head validation round, both Developer Fiat Commerce workflows are read-only: they use the exact committed GitHub SHA and no longer auto-edit or push source during CI. This task document update intentionally triggers both backend and UI/native workflows on the same candidate head. A-G may become `COMPLETE` only after those exact-head checks pass; H may become `COMPLETE` only after PR merge and exact-main checks pass.
+- 主实现 PR：`#2133` — `[automerge-force] feat(pay): dynamic fiat commerce with global and mainland China payouts`。
+- 最终 feature head：`4d0687fed9b54793cb1237c39718b51b8d32b669`。
+- feature-head 门禁：Developer Fiat Commerce run `32868752808` 5/5 success；Developer Fiat Commerce UI run `32868752819` 2/2 success；Platform Control Plane run `32868752821` success；CI run `32868752829` success；Electron desktop quality gate run `32868752823` success；Messaging Product Gate run `32868752779` success。
+- Protected Merge Queue：PR #2133 经 `automerge` + explicit `[automerge-force]` 授权进入队列第 1 位；merge-group CI run `32869281732` success。
+- canonical `main` 合并 SHA：`573c140f7007ad98230c90f3c24bc99e1f36a88f`，PR #2133 merged at 2026-08-25T16:01:48Z。
+- exact-main 门禁：Developer Fiat Commerce run `32869457305` 5/5 success；Developer Fiat Commerce UI run `32869457162` 2/2 success；Platform Control Plane run `32869457301` success；Merge Queue CI 已在同一 SHA 上 success。
+- exact-main Commerce 具体覆盖：control-plane unit/fmt、commerce-control wasm32、platform-worker wasm32/fmt、pay-worker wasm32/fmt、schema/security/accounting contract 全部 success。
 
 ## External activation gates
 
-Source code cannot grant provider approval. Production-live payout remains blocked per provider until the corresponding merchant/platform agreement, business-category approval, KYC/KYB flow, production credentials/webhook configuration and supported settlement account are present. Provider state must remain fail-closed until those facts are verified.
+工程实现、自动化验证、Protected Merge Queue 合并和 exact-main 验收已经完成。生产实际资金分发仍受第三方机构外部条件约束：微信/支付宝平台商户及业务类目/分账资格、连连/汇付合同与生产凭据、Stripe/Adyen/PayPal marketplace 账户与 KYC/KYB、Apple/Google 商店资格与结算账户、Webhook/生产密钥等。任何未验证的 provider route 必须继续保持 fail closed；本任务不把外部机构尚未批准的通道声明为已生产启用。


### PR DESCRIPTION
## FAB-P0001 / M9 closure

Synchronizes the authoritative project tasks and evidence after implementation PR #2133 merged through the protected Merge Queue.

- marks `M9-PAY-002` Dynamic Fiat Developer Commerce COMPLETE
- marks `M9-PAY-003` Global + China Developer Payout Orchestration COMPLETE
- records feature-head, merge-group and exact-main CI evidence
- records canonical main SHA `573c140f7007ad98230c90f3c24bc99e1f36a88f`
- keeps Apple/Google/WeChat/Alipay/LianLian/Huifu/Stripe/Adyen/PayPal production activation as explicit external fail-closed gates rather than claiming provider approval

Docs/evidence only; no runtime or financial source changes.