### PR TITLE
fix(desktop): restore login and unify Windows/macOS branding

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "androidVersionCode": 1,
   "iosBuildNumber": 1
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.0.2",
-  "description": "全球法布施 Electron desktop client",
+  "version": "1.0.3",
+  "description": "Fabushi Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",
   "desktopName": "com.ombhrum.fabushi",
@@ -10,6 +10,7 @@
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "vite --host 127.0.0.1 --port 1420",
+    "prebuild:renderer": "node scripts/prepare-desktop-window-branding.mjs",
     "build:renderer": "tsc --noEmit && vite build",
     "build:host": "cargo build --release -p mahayana-app-host-desktop --bin mahayana-app-host --manifest-path ../third_party/mahayana/mahayana-rs/Cargo.toml && node scripts/stage-host.mjs",
     "build:host:ci": "cargo build --profile ci -p mahayana-app-host-desktop --bin mahayana-app-host --manifest-path ../third_party/mahayana/mahayana-rs/Cargo.toml && node scripts/stage-host.mjs ci",
@@ -37,7 +38,7 @@
   },
   "build": {
     "appId": "com.ombhrum.fabushi",
-    "productName": "全球法布施",
+    "productName": "Fabushi",
     "executableName": "fabushi",
     "asar": true,
     "directories": {
@@ -82,7 +83,8 @@
       "target": [
         "nsis"
       ],
-      "artifactName": "fabushi-${version}-setup.${ext}"
+      "artifactName": "fabushi-${version}-setup.${ext}",
+      "icon": "resources/icon.png"
     },
     "linux": {
       "category": "Utility",

--- a/desktop/scripts/prepare-desktop-window-branding.mjs
+++ b/desktop/scripts/prepare-desktop-window-branding.mjs
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const mainPath = path.resolve(here, '..', 'electron', 'main.cjs');
+const source = fs.readFileSync(mainPath, 'utf8');
+
+const legacy = `function createWindow() {\n  const win = new BrowserWindow({\n    title: '全球法布施',`;
+const branded = `function createWindow() {\n  const frameOptions = process.platform === 'darwin'\n    ? { titleBarStyle: 'hiddenInset' }\n    : process.platform === 'win32'\n      ? {\n          titleBarStyle: 'hidden',\n          titleBarOverlay: { color: '#111111', symbolColor: '#ffffff', height: 54 },\n        }\n      : {};\n  const win = new BrowserWindow({\n    title: 'Fabushi',\n    ...frameOptions,`;
+
+if (source.includes(branded)) {
+  process.exit(0);
+}
+if (!source.includes(legacy)) {
+  throw new Error('Desktop window branding anchor changed; update prepare-desktop-window-branding.mjs instead of shipping a native title bar.');
+}
+
+fs.writeFileSync(mainPath, source.replace(legacy, branded));
+console.log('Prepared Fabushi desktop window branding.');

--- a/fabushi/web/src/routes/platform-gateway-routes.js
+++ b/fabushi/web/src/routes/platform-gateway-routes.js
@@ -27,12 +27,20 @@ function platformOrigin(env) {
 }
 
 async function fetchPlatform(env, request) {
-  // Cloudflare can return a workers.dev placeholder when one Worker fetches
-  // another Worker in the same account through the public workers.dev hostname.
-  // The service binding keeps this hop on Cloudflare's internal Worker network
-  // and makes browser auth deterministic in staging and production.
+  // Prefer Cloudflare's internal service binding. If that binding is temporarily
+  // unavailable, retry the same request against the canonical HTTPS origin so
+  // browser login does not fail closed with a gateway-generated 502.
   if (env.MAHAYANA_PLATFORM && typeof env.MAHAYANA_PLATFORM.fetch === 'function') {
-    return env.MAHAYANA_PLATFORM.fetch(request);
+    const directRequest = request.clone();
+    try {
+      return await env.MAHAYANA_PLATFORM.fetch(request);
+    } catch (error) {
+      console.warn(
+        'Mahayana platform service binding failed; retrying canonical HTTPS origin:',
+        error?.message || error,
+      );
+    }
+    return fetch(directRequest, { redirect: 'manual' });
   }
   return fetch(request, { redirect: 'manual' });
 }

--- a/fabushi/web/tests/platform-control-plane.test.js
+++ b/fabushi/web/tests/platform-control-plane.test.js
@@ -34,6 +34,9 @@ assert.match(gateway, /pathname\.startsWith\('\/v1\/'\)/, 'all v1 platform APIs 
 assert.match(gateway, /redirect: 'manual'/, 'OAuth redirects must be returned to the browser, not followed by the gateway');
 assert.match(gateway, /X-Fabushi-Control-Plane/, 'proxied browser auth must identify the canonical control plane');
 assert.match(gateway, /env\.MAHAYANA_PLATFORM\.fetch\(request\)/, 'same-account platform forwarding must prefer the Cloudflare service binding');
+assert.match(gateway, /request\.clone\(\)/, 'service-binding fallback must preserve the original request body');
+assert.match(gateway, /retrying canonical HTTPS origin/, 'service-binding failure must retry the canonical public origin instead of immediately returning 502');
+assert.match(gateway, /fetch\(directRequest, \{ redirect: 'manual' \}\)/, 'fallback must preserve browser-managed OAuth redirects');
 
 const workerWrangler = read('wrangler.toml');
 for (const environment of ['production', 'development']) {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
修复 Windows/macOS 桌面发布回归：

- Windows NSIS 显式使用 Fabushi 应用图标
- Windows/macOS 统一产品名为 Fabushi
- 构建阶段隐藏原生标题文字栏，同时保留 Windows/macOS 原生窗口控制
- Mahayana 平台 service binding 异常时回退 canonical HTTPS origin，避免浏览器登录直接返回 platform_control_plane_unavailable 502
- 增加控制面 fallback 架构守卫
- 发布版本提升到 1.0.3

当前 main 已包含账户弹窗中的“退出登录”按钮和 logout transport，本次新构建会将该入口正式带入发布包。