### PR TITLE
fix(desktop): make Windows branding build CRLF-safe

### DIFF
--- a/desktop/scripts/prepare-desktop-window-branding.mjs
+++ b/desktop/scripts/prepare-desktop-window-branding.mjs
@@ -5,16 +5,19 @@ import { fileURLToPath } from 'node:url';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const mainPath = path.resolve(here, '..', 'electron', 'main.cjs');
 const source = fs.readFileSync(mainPath, 'utf8');
+const eol = source.includes('\r\n') ? '\r\n' : '\n';
+const normalized = source.replace(/\r\n/g, '\n');
 
 const legacy = `function createWindow() {\n  const win = new BrowserWindow({\n    title: '全球法布施',`;
 const branded = `function createWindow() {\n  const frameOptions = process.platform === 'darwin'\n    ? { titleBarStyle: 'hiddenInset' }\n    : process.platform === 'win32'\n      ? {\n          titleBarStyle: 'hidden',\n          titleBarOverlay: { color: '#111111', symbolColor: '#ffffff', height: 54 },\n        }\n      : {};\n  const win = new BrowserWindow({\n    title: 'Fabushi',\n    ...frameOptions,`;
 
-if (source.includes(branded)) {
+if (normalized.includes(branded)) {
   process.exit(0);
 }
-if (!source.includes(legacy)) {
+if (!normalized.includes(legacy)) {
   throw new Error('Desktop window branding anchor changed; update prepare-desktop-window-branding.mjs instead of shipping a native title bar.');
 }
 
-fs.writeFileSync(mainPath, source.replace(legacy, branded));
+const updated = normalized.replace(legacy, branded);
+fs.writeFileSync(mainPath, eol === '\r\n' ? updated.replace(/\n/g, '\r\n') : updated);
 console.log('Prepared Fabushi desktop window branding.');


### PR DESCRIPTION
主干发布 run 944 的 Windows job 暴露出 Windows checkout 使用 CRLF，导致 branding 预处理脚本按 LF 精确匹配失败。此修复在匹配前统一换行符，并在写回时保留原始 EOL，因此 Windows/macOS/Linux 都能执行同一构建逻辑。用于恢复 #2137 的 Windows 正式发布。