### PR TITLE
[automerge-force] fix(auth): restore Mahayana platform deployment automatically

### DIFF
--- a/.github/workflows/mahayana-staging-auth-repair.yml
+++ b/.github/workflows/mahayana-staging-auth-repair.yml
@@ -2,6 +2,15 @@ name: Mahayana staging auth repair
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/mahayana-staging-auth-repair.yml'
+      - '.github/scripts/deploy-auth-provider-bridge.sh'
+      - 'third_party/mahayana/mahayana-rs/Cargo.toml'
+      - 'third_party/mahayana/mahayana-rs/Cargo.lock'
+      - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
恢复桌面浏览器登录所依赖的 Mahayana 平台 Worker。当前生产 CD 在 staging E2E 的 `/api/auth/browser/start` 收到 404，导致生产部署被跳过；这个工作流原来只能手动触发，因此平台 Worker 缺失时无法自愈。

本变更保留 `workflow_dispatch`，并在 main 上与 Mahayana 平台 Worker/身份桥相关文件发生变化时自动执行。工作流会编译、应用账户迁移、部署 `mahayana-platform`、配置测试账号并验证 health、浏览器登录、注册和支付宝跳转生命周期。工作流自身加入 paths，因此该修复合并后会立即执行一次恢复部署。