### PR TITLE
fix(desktop): make Windows branding build CRLF-safe

### DIFF
--- a/desktop/scripts/prepare-desktop-window-branding.mjs
+++ b/desktop/scripts/prepare-desktop-window-branding.mjs
@@ -5,16 +5,19 @@ import { fileURLToPath } from 'node:url';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const mainPath = path.resolve(here, '..', 'electron', 'main.cjs');
 const source = fs.readFileSync(mainPath, 'utf8');
+const eol = source.includes('\r\n') ? '\r\n' : '\n';
+const normalized = source.replace(/\r\n/g, '\n');
 
 const legacy = `function createWindow() {\n  const win = new BrowserWindow({\n    title: '全球法布施',`;
 const branded = `function createWindow() {\n  const frameOptions = process.platform === 'darwin'\n    ? { titleBarStyle: 'hiddenInset' }\n    : process.platform === 'win32'\n      ? {\n          titleBarStyle: 'hidden',\n          titleBarOverlay: { color: '#111111', symbolColor: '#ffffff', height: 54 },\n        }\n      : {};\n  const win = new BrowserWindow({\n    title: 'Fabushi',\n    ...frameOptions,`;
 
-if (source.includes(branded)) {
+if (normalized.includes(branded)) {
   process.exit(0);
 }
-if (!source.includes(legacy)) {
+if (!normalized.includes(legacy)) {
   throw new Error('Desktop window branding anchor changed; update prepare-desktop-window-branding.mjs instead of shipping a native title bar.');
 }
 
-fs.writeFileSync(mainPath, source.replace(legacy, branded));
+const updated = normalized.replace(legacy, branded);
+fs.writeFileSync(mainPath, eol === '\r\n' ? updated.replace(/\n/g, '\r\n') : updated);
 console.log('Prepared Fabushi desktop window branding.');


### PR DESCRIPTION
#2138 在主干发生新合并后被 GitHub merge queue 卡在旧基线，并报告 required `CI result` expected。此 PR 基于当前 main 重新落同一个 Windows CRLF 修复：构建前规范化换行匹配、写回保持原始 EOL，避免 Windows checkout 导致桌面品牌预处理失败。