### PR TITLE
ci(platform): deploy control-plane migrations on main

### DIFF
--- a/.github/workflows/platform-control-plane.yml
+++ b/.github/workflows/platform-control-plane.yml
@@ -61,3 +61,37 @@ jobs:
       - name: Guard one-control-plane architecture
         working-directory: fabushi/web
         run: node tests/platform-control-plane.test.js
+
+  deploy-production:
+    name: Deploy production control plane
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: architecture
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.WRANGLER_API_TOKEN || secrets.CLOUDFLARE_TOKEN || secrets.CF_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN || vars.WRANGLER_API_TOKEN || vars.CLOUDFLARE_TOKEN || vars.CF_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.CF_ACCOUNT || secrets.CLOUDFLARE_ACCOUNT || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID || vars.CF_ACCOUNT || vars.CLOUDFLARE_ACCOUNT }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Require Cloudflare deployment credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -n "${CLOUDFLARE_API_TOKEN:-}" ] || { echo "Cloudflare API token is not configured." >&2; exit 1; }
+          [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || { echo "Cloudflare account id is not configured." >&2; exit 1; }
+      - uses: dtolnay/rust-toolchain@1.98.0
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install Cloudflare Worker build tool
+        run: cargo install worker-build --locked
+      - name: Apply production platform migrations
+        working-directory: third_party/mahayana/mahayana-rs/mahayana-platform-worker
+        shell: bash
+        run: npx --yes wrangler@4 d1 migrations apply PLATFORM_DB --remote
+      - name: Deploy production Mahayana platform Worker
+        working-directory: third_party/mahayana/mahayana-rs/mahayana-platform-worker
+        shell: bash
+        run: npx --yes wrangler@4 deploy


### PR DESCRIPTION
## Why
The Platform Control Plane workflow currently validates pull requests and main pushes, but it does not apply D1 migrations or deploy `mahayana-platform`. This allowed marketplace catalog code/migrations to exist in the repository while production kept stale D1 data.

## Change
On protected `main` pushes, after the existing architecture checks pass:
- require configured Cloudflare credentials;
- apply `PLATFORM_DB` migrations remotely;
- deploy the production `mahayana-platform` Worker.

Pull requests remain validation-only; production writes happen only after protected-main merge.
