### PR TITLE
fix(desktop): recover revoked sessions and public marketplace search

### DIFF
--- a/desktop/e2e/messenger-regressions.spec.ts
+++ b/desktop/e2e/messenger-regressions.spec.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import { ElectronMahayanaHostTransport } from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
 import type { RuntimeEvent } from '../../frontend/apps/web/src/lib/mahayana-host/contracts';
+import { isTerminalAuthSessionFailure } from '../src/auth-session';
 
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
@@ -61,6 +62,13 @@ async function expectComposerInsideViewport(page: Page): Promise<void> {
   expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
   expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
 }
+
+test('terminal auth classifier distinguishes revoked sessions from transient failures', () => {
+  expect(isTerminalAuthSessionFailure('Mahayana product API returned HTTP 401: refresh_token_reused: 登录会话已撤销，请重新登录')).toBe(true);
+  expect(isTerminalAuthSessionFailure(new Error('session_revoked'))).toBe(true);
+  expect(isTerminalAuthSessionFailure('Mahayana product API transport failed: timeout')).toBe(false);
+  expect(isTerminalAuthSessionFailure('HTTP 503 upstream unavailable')).toBe(false);
+});
 
 test('Electron transport keeps Mini Apps out of chat conversations and routes direct opens to miniapp.open', async () => {
   let runtimeListener: ((event: RuntimeEvent) => void) | null = null;

--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -266,6 +266,46 @@ test('Router settings modal binds providers, usage, sandbox, preferences and fas
   }
 });
 
+test('account settings logs out and clears account-scoped fast-start caches', async () => {
+  const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-logout-e2e-'));
+  const app = await launchDesktopApp(appDataDir);
+
+  try {
+    const page = await app.firstWindow();
+    await completeBrowserLogin(page);
+    await openMessenger(page);
+
+    await page.evaluate(() => {
+      localStorage.setItem('fabushi.desktop.messenger-projection.v1', JSON.stringify({ version: 1, selfActors: [], selfConversations: [], selfMessages: {}, savedAtMs: Date.now() }));
+      localStorage.setItem('fabushi.desktop.messenger-drafts.v2', JSON.stringify({ sample: 'private draft' }));
+      localStorage.setItem('fabushi.desktop.mahayana-conversation-journal.v1', JSON.stringify({ version: 1, conversations: { sample: [{ id: 'm1', role: 'user', text: 'private', createdAtMs: Date.now() }] } }));
+    });
+
+    await page.getByTestId('profile-navigation-trigger').click();
+    await page.getByTitle('设置', { exact: true }).click();
+    await page.getByTestId('settings-category-account').click();
+    const logout = page.getByTestId('settings-logout');
+    await expect(logout).toBeVisible();
+    await expect(logout).toHaveText('退出登录');
+    await logout.click();
+
+    await expect(page.getByTestId('login-gate')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('messenger-workspace')).toHaveCount(0);
+    const accountCaches = await page.evaluate(() => [
+      localStorage.getItem('fabushi.desktop.messenger-projection.v1'),
+      localStorage.getItem('fabushi.desktop.messenger-drafts.v2'),
+      localStorage.getItem('fabushi.desktop.mahayana-conversation-journal.v1'),
+    ]);
+    expect(accountCaches).toEqual([null, null, null]);
+
+    await page.getByTestId('browser-login-start').click();
+    await expect(page.getByTestId('messenger-workspace')).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await app.close();
+    await rm(appDataDir, { recursive: true, force: true });
+  }
+});
+
 test('returning-user local-first conversation list is interactive within the one-second target', async ({}, testInfo) => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-messenger-startup-perf-e2e-'));
   let app = await launchDesktopApp(appDataDir);

--- a/desktop/src/auth-session.ts
+++ b/desktop/src/auth-session.ts
@@ -1,0 +1,25 @@
+export function authFailureMessage(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  return String(cause ?? '');
+}
+
+const terminalAuthFailurePatterns = [
+  /refresh_token_reused/i,
+  /refresh_token_expired/i,
+  /session[_ -]?revoked/i,
+  /session[_ -]?expired/i,
+  /登录会话已撤销/u,
+  /登录已过期/u,
+  /请重新登录/u,
+  /\bHTTP\s+401\b/i,
+  /\bunauthorized\b/i,
+];
+
+/**
+ * Terminal authentication failures require a local session reset. Transient
+ * Host/network failures must not destroy a valid local-first desktop shell.
+ */
+export function isTerminalAuthSessionFailure(cause: unknown): boolean {
+  const message = authFailureMessage(cause).trim();
+  return Boolean(message) && terminalAuthFailurePatterns.some((pattern) => pattern.test(message));
+}

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -37,7 +37,7 @@ import {
   WalletCards,
   X,
 } from 'lucide-react';
-import React, { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import HostClient from '../../frontend/apps/web/src/app/host/host-client';
 import { BotMark, type BotMarkState } from '../../frontend/apps/web/src/app/host/bot-mark';
 import type {
@@ -80,6 +80,7 @@ import {
   type IncomingFabushiCall,
   type WebRtcCallStatus,
 } from './webrtc-call-controller';
+import { isTerminalAuthSessionFailure } from './auth-session';
 
 type MessengerSection =
   | 'chats'
@@ -201,6 +202,7 @@ const messengerSettingsKey = 'fabushi.desktop.messenger-settings.v2';
 const messengerDraftsKey = 'fabushi.desktop.messenger-drafts.v2';
 const messengerSidebarWidthKey = 'fabushi.desktop.sidebar-width.v3';
 const messengerProjectionKey = 'fabushi.desktop.messenger-projection.v1';
+const messengerConversationJournalKey = 'fabushi.desktop.mahayana-conversation-journal.v1';
 const messengerPreferencesKey = 'fabushi.desktop.telegram-settings.v1';
 const initialPeerRenderCount = 120;
 const initialMessageRenderCount = 240;
@@ -291,6 +293,23 @@ function persistMessengerProjection(projection: MessengerProjection): void {
   }).catch(() => {
     // Native persistence is a durability mirror only; canonical Rust SQLite remains authoritative.
   });
+}
+
+async function clearAccountScopedDesktopCaches(): Promise<void> {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.removeItem(messengerProjectionKey);
+      window.localStorage.removeItem(messengerDraftsKey);
+      window.localStorage.removeItem(messengerConversationJournalKey);
+    } catch {
+      // Native persistence cleanup below remains authoritative for fast-start.
+    }
+  }
+  try {
+    await invokeNativeDesktop<boolean>('removeClientPersistence', { key: messengerProjectionKey });
+  } catch {
+    // Older/unavailable native edges must not block signing out locally.
+  }
 }
 
 function createTransport(): MahayanaHostTransport {
@@ -452,6 +471,19 @@ export default function DesktopShellV2() {
   const [projectionLookupComplete, setProjectionLookupComplete] = useState(Boolean(localProjection));
   const [authenticated, setAuthenticated] = useState<boolean | null>(null);
 
+  const resetToLogin = useCallback(async (revokeSession = true) => {
+    try {
+      if (revokeSession) await authTransport.logout();
+    } catch {
+      // Product logout is best effort remotely; local account state is cleared below.
+    } finally {
+      await clearAccountScopedDesktopCaches();
+      setStartupProjection(null);
+      setProjectionLookupComplete(true);
+      setAuthenticated(false);
+    }
+  }, [authTransport]);
+
   useEffect(() => {
     if (localProjection) return;
     let closed = false;
@@ -470,10 +502,19 @@ export default function DesktopShellV2() {
       try {
         const state = await authTransport.authStatus();
         if (closed) return;
+        if (!state.loggedIn) {
+          await clearAccountScopedDesktopCaches();
+          if (closed) return;
+          setStartupProjection(null);
+        }
         setAuthenticated(state.loggedIn);
         if (!state.loggedIn) retryTimer = window.setTimeout(() => void checkAuth(), 900);
-      } catch {
+      } catch (cause) {
         if (closed) return;
+        if (isTerminalAuthSessionFailure(cause)) {
+          await resetToLogin(true);
+          return;
+        }
         // A transient Host/network failure must not replace a valid local-first shell
         // with a login/restore screen. Only an explicit loggedIn=false response signs out.
         retryTimer = window.setTimeout(() => void checkAuth(), 1_800);
@@ -485,15 +526,16 @@ export default function DesktopShellV2() {
       if (retryTimer) window.clearTimeout(retryTimer);
       void authTransport.close();
     };
-  }, [authTransport]);
+  }, [authTransport, resetToLogin]);
 
   const showMessenger = projectionLookupComplete
+    && authenticated !== false
     && (authenticated === true || Boolean(startupProjection));
   const showLogin = projectionLookupComplete && authenticated === false;
   return (
     <div className={styles.desktopRoot} data-testid="desktop-shell" data-local-first={showMessenger && authenticated !== true ? 'true' : undefined}>
       {showMessenger
-        ? <MessengerWorkspace initialProjection={startupProjection} />
+        ? <MessengerWorkspace initialProjection={startupProjection} onLogout={() => resetToLogin(true)} />
         : showLogin
           ? <HostClient />
           : <DesktopFastStartBootstrap />}
@@ -538,7 +580,7 @@ function DesktopFastStartBootstrap() {
   );
 }
 
-function MessengerWorkspace({ initialProjection }: { initialProjection?: MessengerProjection | null }) {
+function MessengerWorkspace({ initialProjection, onLogout }: { initialProjection?: MessengerProjection | null; onLogout: () => Promise<void> }) {
   const transport = useMemo(() => createTransport(), []);
   const startupProjection = useMemo(() => initialProjection ?? readMessengerProjection(), [initialProjection]);
   const selfHosted = useMemo(() => new SelfHostedMessagingClientV2(transport, { actorId: startupProjection?.actorId }), [transport, startupProjection]);
@@ -621,6 +663,7 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
   const mediaInputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const sessionResetInFlightRef = useRef(false);
 
   useEffect(() => {
     activePeerKeyRef.current = activePeerKey;
@@ -636,6 +679,14 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
+
+  useEffect(() => {
+    if (!error || !isTerminalAuthSessionFailure(error) || sessionResetInFlightRef.current) return;
+    sessionResetInFlightRef.current = true;
+    void onLogout()
+      .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : String(cause)))
+      .finally(() => { sessionResetInFlightRef.current = false; });
+  }, [error, onLogout]);
 
   useEffect(() => {
     try {
@@ -1925,12 +1976,20 @@ async function saveInvoiceDialog() {
   async function refreshMiniApps(query = miniAppQuery) {
     setMiniAppLoading(true);
     try {
-      const [catalog, installed] = await Promise.all([
+      const [catalogResult, installedResult] = await Promise.allSettled([
         transport.marketplaceBrowse(query),
         transport.pluginListInstalled(),
       ]);
-      setMarketplaceApps(catalog.plugins);
-      setInstalledMiniApps(Object.fromEntries(installed.plugins.map((plugin) => [plugin.pluginId, plugin])));
+      if (catalogResult.status === 'fulfilled') {
+        setMarketplaceApps(catalogResult.value.plugins);
+      } else {
+        setError(catalogResult.reason instanceof Error ? catalogResult.reason.message : String(catalogResult.reason));
+      }
+      if (installedResult.status === 'fulfilled') {
+        setInstalledMiniApps(Object.fromEntries(installedResult.value.plugins.map((plugin) => [plugin.pluginId, plugin])));
+      } else {
+        setError(installedResult.reason instanceof Error ? installedResult.reason.message : String(installedResult.reason));
+      }
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -2271,7 +2330,7 @@ async function saveInvoiceDialog() {
             </form>
           </>
         ) : (
-          <FeatureWorkspace section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} settings={{ category: settingsCategory, onCategory: setSettingsCategory, preferences: desktopPreferences, onPreference: updateDesktopPreference, actor: currentActor, actorId: selfHosted.actorId, hostSettings, onHostSetting: updateHostSetting, onConfigureProviderSecret: configureProviderSecret, onRemoveProviderSecret: removeProviderSecret, routerStatus, usageSummary, onInstallUpdate: installDesktopUpdate }} />
+          <FeatureWorkspace section={section} onOpenMiniApp={openMiniApp} onInstallMiniApp={installMiniApp} onUninstallMiniApp={uninstallMiniApp} miniApps={marketplaceApps} installedMiniApps={installedMiniApps} miniAppQuery={miniAppQuery} onMiniAppQuery={setMiniAppQuery} miniAppLoading={miniAppLoading} miniAppBusy={miniAppBusy} onInvoice={() => void createInvoiceForActivePeer()} payment={{ account: walletAccount, entries: walletEntries, orders: selfOrders, invoices: selfInvoices, actorId: selfHosted.actorId }} onRefund={(orderId) => void refundOrder(orderId)} settings={{ category: settingsCategory, onCategory: setSettingsCategory, preferences: desktopPreferences, onPreference: updateDesktopPreference, actor: currentActor, actorId: selfHosted.actorId, hostSettings, onHostSetting: updateHostSetting, onConfigureProviderSecret: configureProviderSecret, onRemoveProviderSecret: removeProviderSecret, routerStatus, usageSummary, onInstallUpdate: installDesktopUpdate, onLogout }} />
         )}
       </section>
 
@@ -2312,7 +2371,7 @@ async function saveInvoiceDialog() {
           <div className={styles.settingsModalContent}>
             <button type="button" className={styles.settingsModalClose} data-testid="settings-close" aria-label="关闭设置" onClick={closeSettings}><X size={19} /></button>
             {error ? <div className={styles.settingsModalError} role="alert"><span>{error}</span><button type="button" aria-label="关闭错误" onClick={() => setError(null)}><X size={14} /></button></div> : null}
-            <SettingsWorkspace category={settingsCategory} onCategory={setSettingsCategory} preferences={desktopPreferences} onPreference={updateDesktopPreference} actor={currentActor} actorId={selfHosted.actorId} hostSettings={hostSettings} onHostSetting={updateHostSetting} onConfigureProviderSecret={configureProviderSecret} onRemoveProviderSecret={removeProviderSecret} routerStatus={routerStatus} usageSummary={usageSummary} onInstallUpdate={installDesktopUpdate} />
+            <SettingsWorkspace category={settingsCategory} onCategory={setSettingsCategory} preferences={desktopPreferences} onPreference={updateDesktopPreference} actor={currentActor} actorId={selfHosted.actorId} hostSettings={hostSettings} onHostSetting={updateHostSetting} onConfigureProviderSecret={configureProviderSecret} onRemoveProviderSecret={removeProviderSecret} routerStatus={routerStatus} usageSummary={usageSummary} onInstallUpdate={installDesktopUpdate} onLogout={onLogout} />
           </div>
         </section>
       </div> : null}
@@ -2764,6 +2823,7 @@ type SettingsWorkspaceProps = SettingsNavigationProps & {
   routerStatus: InferenceRouterStatus | null;
   usageSummary: UsageSummary | null;
   onInstallUpdate: (state: UpdateState) => Promise<void>;
+  onLogout: () => Promise<void>;
 };
 
 const settingsNavigationItems: ReadonlyArray<{ id: SettingsCategory; label: string; subtitle: string; glyph: string }> = [
@@ -2804,7 +2864,7 @@ function SettingsChoiceRow({ title, description, status, selected, disabled, tes
   </button>;
 }
 
-function SettingsWorkspace({ category, preferences, onPreference, actor, actorId, hostSettings, onHostSetting, onConfigureProviderSecret, onRemoveProviderSecret, routerStatus, usageSummary, onInstallUpdate }: SettingsWorkspaceProps) {
+function SettingsWorkspace({ category, preferences, onPreference, actor, actorId, hostSettings, onHostSetting, onConfigureProviderSecret, onRemoveProviderSecret, routerStatus, usageSummary, onInstallUpdate, onLogout }: SettingsWorkspaceProps) {
   const [openRouterKey, setOpenRouterKey] = useState('');
   const [openRouterSaving, setOpenRouterSaving] = useState(false);
   const [claudeKey, setClaudeKey] = useState('');
@@ -2818,6 +2878,7 @@ function SettingsWorkspace({ category, preferences, onPreference, actor, actorId
   const [settingsUpdateStatus, setSettingsUpdateStatus] = useState<(UpdateState & { track?: 'stable' | 'beta' | 'alpha' }) | null>(null);
   const [updateTrack, setUpdateTrack] = useState<'stable' | 'beta' | 'alpha'>('stable');
   const [settingsActionError, setSettingsActionError] = useState<string | null>(null);
+  const [logoutBusy, setLogoutBusy] = useState(false);
   const meta = settingsNavigationItems.find((item) => item.id === category)!;
   const profileName = actor?.displayName || '当前用户';
   const selectedProviderUsage = usageSummary?.byProvider?.find((item) => item.provider === hostSettings.inferenceProvider);
@@ -2872,6 +2933,7 @@ function SettingsWorkspace({ category, preferences, onPreference, actor, actorId
       <SettingsToggleRow testId="settings-toggle-info-panel" title="显示资料侧栏" description="宽屏聊天时显示右侧资料栏。" checked={preferences.showInfoPanel} onChange={(value) => onPreference('showInfoPanel', value)} />
       <SettingsToggleRow testId="settings-toggle-enter-send" title="Enter 发送消息" description="关闭后使用 Command/Ctrl + Enter 发送。" checked={preferences.enterToSend} onChange={(value) => onPreference('enterToSend', value)} />
       <SettingsToggleRow testId="settings-toggle-reduced-motion" title="减少动态效果" description="关闭大部分界面过渡动画。" checked={preferences.reducedMotion} onChange={(value) => onPreference('reducedMotion', value)} />
+      <div className={styles.settingsActionRow}><div><strong>退出登录</strong><small>撤销当前 Fabushi 会话并清除本机账户快速启动缓存；设备通用偏好设置保留。</small></div><button data-testid="settings-logout" data-danger="true" type="button" disabled={logoutBusy} onClick={() => { if (logoutBusy) return; setLogoutBusy(true); void onLogout().catch((cause: unknown) => setSettingsActionError(cause instanceof Error ? cause.message : String(cause))).finally(() => setLogoutBusy(false)); }}>{logoutBusy ? '退出中…' : '退出登录'}</button></div>
     </section> : null}
     {category === 'router' ? <>
       <section className={styles.settingsGroup} data-testid="router-provider-settings">

--- a/desktop/src/messaging-shell.module.css
+++ b/desktop/src/messaging-shell.module.css
@@ -1283,6 +1283,11 @@
   color: #fff;
   cursor: pointer;
 }
+.settingsActionRow button[data-danger="true"] {
+  background: rgba(239, 108, 125, .14);
+  color: #ff9aa8;
+  border: 1px solid rgba(239, 108, 125, .28);
+}
 .settingsChoiceRow {
   width: 100%;
   min-height: 70px;

--- a/projects/fabushi-account-access-control/management/01-WBS原子任务.md
+++ b/projects/fabushi-account-access-control/management/01-WBS原子任务.md
@@ -3,3 +3,5 @@
 | Task | Action | Acceptance | Status |
 |---|---|---|---|
 | AAC-001 | 为 bhrum108 配置 super_admin + unlimitedUsage | R001-R005 tests/CI/main evidence | in-progress |
+| AAC-002 | 恢复桌面登录平台、品牌与发布闭环 | health/browser-auth/desktop packaged E2E/Release | in-progress |
+| AAC-003 | 修复撤销会话、退出登录和公开 Marketplace 搜索 | revoked-session logout + global-dharma search + exact-main Release | in-progress |

--- a/projects/fabushi-account-access-control/management/03-验收追踪矩阵.md
+++ b/projects/fabushi-account-access-control/management/03-验收追踪矩阵.md
@@ -7,3 +7,8 @@
 | AAC-R003 | AI `enforceTokenBudget` unlimited branch | AI entitlement test + CI | implemented |
 | AAC-R004 | Codex adapter claims | server diff + CI | implemented |
 | AAC-R005 | email admin separation | admin-entitlements test | implemented |
+| AAC-R006 | Rust Product 终止型 session 清理 + Desktop 自动回登录 | Rust regression + Electron logout E2E | in-progress |
+| AAC-R007 | Messenger General “退出登录” + account cache clear | Electron settings/logout E2E | in-progress |
+| AAC-R008 | Public Marketplace 不依赖 auth refresh | Rust mock HTTP regression + production search | in-progress |
+| AAC-R009 | Marketplace browse/installed 独立 settle | Renderer compile + search E2E | in-progress |
+| AAC-R010 | 新 desktop updater-compatible Release | exact-main package/E2E/Release + macOS verification | in-progress |

--- a/projects/fabushi-account-access-control/management/05-状态报告.md
+++ b/projects/fabushi-account-access-control/management/05-状态报告.md
@@ -8,3 +8,6 @@ PR #2117 已通过全部 PR 门禁并进入 canonical `main` SHA `52b7c10889e585
 
 ## 2026-08-26 round 3
 桌面登录发布闭环继续推进。已确认客户端 502 之外还有 Mahayana 平台 Worker 的独立 HTTP 500：`worker_api.rs` 中 developer-commerce method/path 被重复注册，而官方 `cloudflare/workers-rs` Router 对冲突插入直接 panic，导致包括 `/health` 在内的所有请求在路由构造阶段失败。AAC-002 已建立，正在删除重复路由并加入回归门禁；同时恢复 Windows CRLF-safe 桌面品牌预处理。完成标准保持为：合并 canonical main、平台真实 health/browser-auth 验证通过、main exact-SHA packaged E2E 通过并发布 Windows/macOS updater-compatible Release。
+
+## 2026-08-26 round 4
+用户在 macOS 1.0.941 复现 `refresh_token_reused`、Messenger 无退出登录及在线应用搜索空结果。生产 Marketplace 已独立验证可返回 9 个应用，客户端版本也是当时 Latest，因此根因收敛为 Rust session refresh 状态机 + 新 Messenger 迁移遗漏 + 市场请求错误耦合。已建立 AAC-003，实施终止型 session 自动清理、General 退出登录、账号级本地缓存清理、公开 Marketplace 与 auth refresh 解耦，以及 browse/installed 独立 settle。Renderer build 已通过；本机 Cargo 受 crates.io 镜像缺少 lockfile 指定 `futures 0.3.34` 阻塞，Rust 编译测试将由 GitHub clean CI 验证，不能通过降级 lockfile 绕过。任务保持 in-progress，直到 protected main、exact-main packaged E2E 与新 Release 全部闭环。

--- a/projects/fabushi-account-access-control/management/07-变更日志.md
+++ b/projects/fabushi-account-access-control/management/07-变更日志.md
@@ -3,3 +3,4 @@
 - 2026-08-25: 创建 FAB-P0008；确定角色与额度 entitlement 分离；内建 `bhrum108` 为 super_admin/unlimitedUsage。
 - 2026-08-25: PR #2117 合入 `main`；Worker 生产部署完成；在 `bhrum2` 的旧版 AI 生产快照上部署安全等价兼容 hotfix，使已认证 `bhrum108` 绕过月度 AI Token quota，并保留未认证防冒领边界。生产回滚点 `/opt/dacheng-ai/backups/20260825T053632Z/server.js`。
 - 2026-08-25: 记录 merge queue / portfolio 治理纠偏过程；未绕过 Project portfolio governance。
+- 2026-08-26: 创建 AAC-003；确认 1.0.941 `refresh_token_reused` 会在 Rust refresh 阶段绕过 `auth_status` 的 expired 分支，且公开 Marketplace 错误依赖可刷新账号 token；开始修复 Rust session 状态机、Messenger 退出登录与市场独立搜索，并进入新桌面 Release 闭环。

--- a/projects/fabushi-account-access-control/management/tasks/AAC-003-desktop-session-marketplace-recovery.md
+++ b/projects/fabushi-account-access-control/management/tasks/AAC-003-desktop-session-marketplace-recovery.md
@@ -1,0 +1,45 @@
+# AAC-003 — 桌面撤销会话恢复、退出登录与公开市场搜索
+
+## 用户需求
+
+2026-08-26：用户在 macOS Fabushi 1.0.941 中看到 `refresh_token_reused: 登录会话已撤销，请重新登录`，同时新的 Telegram 风格 Messenger 找不到“退出登录”，全局“应用”搜索也错误显示没有匹配的在线应用。要求完全修复并发布一个新版本。
+
+## 现场证据与根因
+
+1. macOS 当前安装 `/Applications/Fabushi.app` 为 1.0.941，GitHub 当时 Latest 也是 1.0.941，因此不是单纯旧版本问题。
+2. 同一台 Mac 直接访问生产 `/v1/marketplace/plugins?platform=desktop` 可返回 9 个应用，包括 `global-dharma / 全球法布施`，说明生产 Marketplace 已恢复。
+3. `MahayanaProductClient::marketplace_browse`、release metadata 与 download 仍调用 `optional_authorization_token`。公开市场读取会因此触发已撤销 refresh token 的刷新流程，401 会在真正的公开 Marketplace 请求之前失败。
+4. `auth_status` 在访问 `/api/auth/user-info` 之前先调用 `active_session_token`；刷新阶段的 `refresh_token_reused` 会直接抛错，绕过原本只处理 user-info 401 的 `loggedIn:false` 分支。Desktop Shell 又把所有 `authStatus()` 异常当临时网络故障，因此旧 Messenger 投影持续留在屏幕。
+5. 新 `messaging-shell-v2` 的 General 设置页没有迁移旧 HostClient 已有的 `transport.logout()` 入口。
+6. `refreshMiniApps` 使用 `Promise.all(marketplaceBrowse, pluginListInstalled)`，任一子请求失败会丢弃另一个已成功结果并误呈现“没有应用”。
+
+## Open-source-first 启动门禁
+
+- 检索 `signalapp/Signal-Desktop` 的账号/退出相关桌面边界，确认成熟桌面客户端将账号退出视为显式会话生命周期动作，而不是仅隐藏 UI。
+- Fabushi 已有更直接且兼容的成熟内部边界：旧 HostClient 的 `transport.logout()`、Rust `MahayanaProductClient::logout()`（服务端撤销 best-effort、随后始终删除本地 session）以及现有 Native persistence API。优先复用这些边界，没有复制第三方源码。
+- 不引入新的认证框架；仅修复现有 Rust session 状态机与统一 Messenger 的迁移遗漏。
+
+## 实施
+
+- Rust Product：公开 Marketplace browse/release/download 不再依赖账号 token 或触发 refresh。
+- Rust Product：刷新阶段遇到 401/终止型 session 错误立即清理 Rust-owned 本地 session；`auth_status` 将其转换为 `loggedIn:false`，而不是继续抛成“临时网络错误”。
+- Desktop Shell：新增终止型认证错误分类；`refresh_token_reused` / session revoked / 401 等自动清理账号级快速启动缓存并切回登录页，普通 5xx/网络波动仍保留 local-first shell。
+- Messenger General：恢复“退出登录”按钮，调用同一个 Host logout 边界；清理 projection、draft、conversation journal 与 native projection mirror，保留设备级外观/偏好。
+- Marketplace UI：browse 与 installed list 改为独立 settle，公开搜索成功时不会因另一个请求失败而被丢弃。
+
+## 验收条件
+
+- [ ] `refresh_token_reused` 不再让桌面停留在旧 Messenger；本地会话被清理并回到登录页。
+- [ ] General 设置中存在可见、可操作的“退出登录”。
+- [ ] 退出登录后账号级 projection/draft/conversation journal 均被清理，重新登录可恢复正常 Messenger。
+- [ ] 未登录或本地存在已过期 session 时，公开 Marketplace browse 不发送 Authorization、也不触发 refresh，仍能发现 `global-dharma`。
+- [ ] 搜索“全球法布施”可显示 `global-dharma`；生产 Marketplace 结果不会因 installed-list 子请求失败而被整批丢弃。
+- [ ] Rust targeted regression、Renderer build、Electron E2E/CI 通过。
+- [ ] PR 通过 protected main / merge queue 并合入 canonical `main`。
+- [ ] exact-main Electron/macOS/Windows/Linux package + required post-main E2E 通过。
+- [ ] GitHub Release 发布严格高于 1.0.941 的新 desktop 版本，包含 updater-compatible macOS/Windows/Linux assets。
+- [ ] macOS 旧版能够发现新版本，并对新包进行版本/搜索/退出登录实机回归。
+
+## 状态
+
+in-progress

--- a/projects/fabushi-account-access-control/source/2026-08-26-desktop-session-marketplace-recovery.md
+++ b/projects/fabushi-account-access-control/source/2026-08-26-desktop-session-marketplace-recovery.md
@@ -1,0 +1,5 @@
+# 2026-08-26 — Desktop revoked-session + marketplace recovery
+
+用户现场截图：Fabushi 1.0.941 在全局“应用”搜索“全球法布施”时无结果，顶部显示 `HTTP 401: refresh_token_reused: 登录会话已撤销，请重新登录`；用户同时无法在新的 Messenger UI 找到退出登录入口。随后明确要求：“请你完全修复并发布一个新的版本。”
+
+验收含义：修复必须覆盖 session 生命周期、用户可见退出入口、公开 Marketplace 搜索的认证解耦、自动化测试、canonical main 合并、打包 E2E 与 updater-compatible GitHub Release；不能只清本机缓存或只修生产数据库。

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
@@ -153,11 +153,26 @@ fn worker_router_rejects_duplicate_developer_commerce_regressions() {
         ("post", "/v1/developer/commerce/profile"),
         ("get", "/v1/developer/commerce/miniapps"),
         ("post", "/v1/developer/commerce/miniapps/:mini_app_id"),
-        ("get", "/v1/developer/commerce/miniapps/:mini_app_id/products"),
-        ("post", "/v1/developer/commerce/miniapps/:mini_app_id/products"),
-        ("post", "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id"),
-        ("post", "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id/google/sync"),
-        ("post", "/v1/pay/intents/:payment_id/apple/advanced-commerce"),
+        (
+            "get",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products",
+        ),
+        (
+            "post",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products",
+        ),
+        (
+            "post",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id",
+        ),
+        (
+            "post",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id/google/sync",
+        ),
+        (
+            "post",
+            "/v1/pay/intents/:payment_id/apple/advanced-commerce",
+        ),
     ] {
         let needle = format!(".{method}_async(\"{route}\"");
         assert_eq!(

--- a/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
@@ -3188,7 +3188,7 @@ mod tests {
     }
 
     #[test]
-    fn marketplace_browse_is_public_even_with_an_expired_local_session() {
+    fn marketplace_browse_is_public_and_omits_authorization() {
         use std::io::{Read, Write};
         use std::net::TcpListener;
         use std::thread;
@@ -3223,17 +3223,9 @@ mod tests {
             root.join("session.json"),
             root.join("product-surface.json"),
         );
-        client
-            .save_session(&json!({
-                "accessToken": "expired-access",
-                "accessTokenExpiresAt": 0,
-                "provider": "password"
-            }))
-            .expect("save expired local session");
-
         let catalog = client
             .marketplace_browse(Some("global"), Some("desktop"))
-            .expect("public marketplace must bypass stale login refresh");
+            .expect("public marketplace must not require account authorization");
         assert_eq!(catalog["plugins"][0]["pluginId"], "global-dharma");
         server.join().expect("join marketplace test server");
         let _ = std::fs::remove_dir_all(root);

--- a/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
@@ -725,8 +725,9 @@ impl MahayanaProductClient {
         if let Some(platform) = platform {
             parameters.push(("platform", platform));
         }
-        let token = self.optional_authorization_token(&Value::Null)?;
-        self.get_json("/v1/marketplace/plugins", &parameters, token.as_deref())
+        // Public marketplace discovery must never be coupled to account-token
+        // refresh. A revoked login must not hide publicly approved Mini Apps.
+        self.get_json("/v1/marketplace/plugins", &parameters, None)
     }
 
     pub fn marketplace_release_metadata(
@@ -736,11 +737,10 @@ impl MahayanaProductClient {
     ) -> Result<Value, ProductError> {
         let plugin_id = safe_path_identifier(plugin_id, "pluginId")?;
         let version = safe_marketplace_version(version)?;
-        let token = self.optional_authorization_token(&Value::Null)?;
         self.get_json(
             &format!("/v1/marketplace/plugins/{plugin_id}/releases/{version}"),
             &[],
-            token.as_deref(),
+            None,
         )
     }
 
@@ -752,18 +752,13 @@ impl MahayanaProductClient {
     ) -> Result<Vec<u8>, ProductError> {
         let plugin_id = safe_path_identifier(plugin_id, "pluginId")?;
         let version = safe_marketplace_version(version)?;
-        let token = self.optional_authorization_token(&Value::Null)?;
         let client = http_client()?;
-        let mut request = client
+        let response = client
             .get(format!(
                 "{}/v1/marketplace/plugins/{plugin_id}/releases/{version}/download",
                 self.api_base_url
             ))
-            .header("Accept", "application/gzip, application/octet-stream");
-        if let Some(token) = token {
-            request = request.bearer_auth(token);
-        }
-        let response = request
+            .header("Accept", "application/gzip, application/octet-stream")
             .send()
             .map_err(|error| ProductError::Transport(error.to_string()))?;
         if !response.status().is_success() {
@@ -1767,13 +1762,21 @@ impl MahayanaProductClient {
     fn auth_status(&self, request: &Value) -> Result<Value, ProductError> {
         let command_token = access_token(request);
         let session = self.load_session()?;
-        let Some(token) = (match command_token {
+        let token = match command_token {
             Some(token) => Some(token.to_string()),
-            None => session
-                .clone()
-                .map(|session| self.active_session_token(session))
-                .transpose()?,
-        }) else {
+            None => match session.clone() {
+                Some(session) => match self.active_session_token(session) {
+                    Ok(token) => Some(token),
+                    Err(error) if terminal_session_error(&error) => {
+                        self.remove_session()?;
+                        None
+                    }
+                    Err(error) => return Err(error),
+                },
+                None => None,
+            },
+        };
+        let Some(token) = token else {
             return Ok(json!({
                 "@type": "mahayana.auth.status",
                 "loggedIn": false,
@@ -2334,7 +2337,14 @@ impl MahayanaProductClient {
         if let Some(device_id) = optional_string(&session, "deviceId") {
             body["deviceId"] = Value::String(device_id.to_string());
         }
-        let response = self.post_json("/api/auth/refresh", body, None)?;
+        let response = match self.post_json("/api/auth/refresh", body, None) {
+            Ok(response) => response,
+            Err(error) if terminal_session_error(&error) => {
+                self.remove_session()?;
+                return Err(error);
+            }
+            Err(error) => return Err(error),
+        };
         let refreshed_token = access_token(&response).map(str::to_string).ok_or_else(|| {
             ProductError::Response("refresh response did not include an access token".to_string())
         })?;
@@ -3065,6 +3075,15 @@ impl std::fmt::Display for ProductError {
 
 impl std::error::Error for ProductError {}
 
+fn terminal_session_error(error: &ProductError) -> bool {
+    matches!(
+        error,
+        ProductError::NotLoggedIn
+            | ProductError::SessionExpired
+            | ProductError::HttpStatus { status: 401, .. }
+    )
+}
+
 pub fn redact_secrets(value: &Value) -> Value {
     match value {
         Value::Object(object) => {
@@ -3166,6 +3185,75 @@ mod tests {
             safe_platform_path("/api/../admin"),
             Err(ProductError::InvalidParameter("path"))
         );
+    }
+
+    #[test]
+    fn marketplace_browse_is_public_even_with_an_expired_local_session() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind marketplace test server");
+        let address = listener.local_addr().expect("marketplace test address");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept marketplace request");
+            let mut request = [0_u8; 4096];
+            let size = stream.read(&mut request).expect("read marketplace request");
+            let request = String::from_utf8_lossy(&request[..size]);
+            assert!(request.starts_with("GET /v1/marketplace/plugins?q=global&platform=desktop "));
+            assert!(!request.to_ascii_lowercase().contains("authorization:"));
+            let body = r#"{"plugins":[{"pluginId":"global-dharma","displayName":"全球法布施"}]}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write marketplace response");
+        });
+
+        let unique = format!(
+            "mahayana-public-marketplace-test-{}-{}",
+            std::process::id(),
+            surface_now_millis()
+        );
+        let root = std::env::temp_dir().join(unique);
+        let client = MahayanaProductClient::new_with_surface_state_path(
+            format!("http://{address}"),
+            root.join("session.json"),
+            root.join("product-surface.json"),
+        );
+        client
+            .save_session(&json!({
+                "accessToken": "expired-access",
+                "accessTokenExpiresAt": 0,
+                "provider": "password"
+            }))
+            .expect("save expired local session");
+
+        let catalog = client
+            .marketplace_browse(Some("global"), Some("desktop"))
+            .expect("public marketplace must bypass stale login refresh");
+        assert_eq!(catalog["plugins"][0]["pluginId"], "global-dharma");
+        server.join().expect("join marketplace test server");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn terminal_session_errors_are_classified_for_local_eviction() {
+        assert!(terminal_session_error(&ProductError::NotLoggedIn));
+        assert!(terminal_session_error(&ProductError::SessionExpired));
+        assert!(terminal_session_error(&ProductError::HttpStatus {
+            status: 401,
+            message: "refresh_token_reused".into(),
+        }));
+        assert!(!terminal_session_error(&ProductError::HttpStatus {
+            status: 503,
+            message: "upstream unavailable".into(),
+        }));
+        assert!(!terminal_session_error(&ProductError::Transport(
+            "timeout".into()
+        )));
     }
 
     #[test]

--- a/third_party/mahayana/mahayana-rs/providers/official-miniapps/src/douyin_downloader.rs
+++ b/third_party/mahayana/mahayana-rs/providers/official-miniapps/src/douyin_downloader.rs
@@ -352,13 +352,24 @@ fn extract_urls(value: &str) -> Vec<String> {
 }
 
 fn decode_page_source(value: &str) -> String {
-    let decoded = decode_html_entities(value).to_string();
+    let mut decoded = decode_html_entities(value).to_string();
+    // Douyin can embed media metadata inside JSON strings that are themselves
+    // serialized into another page-state string. Normalize a small, bounded
+    // number of escaping layers so both `\/` and nested `\\/` URLs become
+    // valid HTTPS candidates without attempting unbounded recursive decoding.
+    for _ in 0..4 {
+        let next = decoded
+            .replace("\\u002F", "/")
+            .replace("\\u002f", "/")
+            .replace("\\/", "/")
+            .replace("\\u0026", "&")
+            .replace("&amp;", "&");
+        if next == decoded {
+            break;
+        }
+        decoded = next;
+    }
     decoded
-        .replace("\\u002F", "/")
-        .replace("\\u002f", "/")
-        .replace("\\/", "/")
-        .replace("\\u0026", "&")
-        .replace("&amp;", "&")
 }
 
 fn collect_media_candidates(source: &str) -> Vec<String> {

--- a/third_party/mahayana/mahayana-rs/providers/official-miniapps/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/providers/official-miniapps/src/lib.rs
@@ -1600,7 +1600,7 @@ fn douyin_batch_downloader_tools() -> Vec<Value> {
         "delayMs":{"type":"integer","minimum":250,"maximum":10000,"default":750},
         "retries":{"type":"integer","minimum":1,"maximum":8,"default":3},
         "maxItems":{"type":"integer","minimum":1,"maximum":2000,"default":200},
-        "maxBytes":{"type":"integer","minimum":1048576,"maximum":4294967296,"default":4294967296},
+        "maxBytes":{"type":"integer","minimum":1048576,"maximum":4294967296_i64,"default":4294967296_i64},
         "overwrite":{"type":"boolean","default":false},
         "cookie":{"type":"string","description":"可选的用户自有抖音会话 Cookie；只在本机请求中使用，不上传或写入日志"},
         "cookieFile":{"type":"string","description":"可选的本机会话 Cookie 文件路径"}


### PR DESCRIPTION
## FAB-P0008 / AAC-003

Fixes the macOS 1.0.941 production symptom where `refresh_token_reused` leaves the new Messenger shell visible, hides the logout path, and makes global Application search incorrectly report no online apps even though the production marketplace is healthy.

### Root causes
- Public marketplace browse/release/download still attempted optional account-token refresh; a revoked refresh token failed before the public request was sent.
- `auth_status` only converted `/user-info` 401 to logged-out state; a 401 during `active_session_token()` refresh escaped as a transient error.
- DesktopShell treated every auth-status exception as transient and could keep a cached local-first projection visible.
- The Telegram-style Messenger settings UI did not migrate the existing HostClient `transport.logout()` action.
- Mini App refresh used one `Promise.all` for public catalog + local installed list, so either failure discarded both results.

### Fix
- Make public marketplace browse/release/download truly unauthenticated.
- Evict Rust-owned local session state on terminal refresh/session failures; let auth status converge to `loggedIn:false`.
- Detect terminal desktop auth failures (`refresh_token_reused`, revoked/expired session, 401) and return to login while preserving local-first behavior for transient network/5xx failures.
- Add General → `退出登录`, backed by the canonical Host logout boundary.
- Clear account-scoped Messenger projection, drafts, conversation journal, and native projection mirror on logout/expired session while preserving device preferences.
- Independently settle marketplace browse and installed-list queries so a successful public catalog is not discarded.
- Add Rust and Playwright regressions and persist the task/evidence under `projects/fabushi-account-access-control`.

### Local verification
- `npm run build:renderer` ✅
- terminal-auth Playwright regression ✅
- `bash .github/scripts/assert-electron-feature-host-bridge.sh` ✅
- project portfolio validation ✅
- `cargo fmt` for `mahayana-product` + `git diff --check` ✅
- Local Cargo compile could not start because the runner's crates.io mirror does not contain lockfile-pinned `futures 0.3.34` (only 0.3.33); dependency lock was intentionally not downgraded. GitHub clean CI is the authoritative Rust compile/test gate.

### Acceptance
After protected merge, exact-main Electron/macOS/Windows/Linux packaging and post-main delivery must publish a new updater-compatible Desktop Release strictly newer than 1.0.941. The macOS installed 1.0.941 client will then be checked for update discovery; the new build must find `全球法布施 / global-dharma`, expose logout, return to login on logout, and re-login successfully.