### PR TITLE
fix(auth): bind bhrum108 entitlements to stable account id

### DIFF
--- a/ai-backend/src/account_entitlements.js
+++ b/ai-backend/src/account_entitlements.js
@@ -1,4 +1,5 @@
 const BUILTIN_SUPER_ADMIN_USERNAMES = Object.freeze(['bhrum108']);
+const BUILTIN_SUPER_ADMIN_ACCOUNT_IDS = Object.freeze(['22']);
 
 function normalizedUsernames(env = process.env) {
   const configured = String(env?.SUPER_ADMIN_USERNAMES || env?.ADMIN_USERNAMES || '')
@@ -8,9 +9,25 @@ function normalizedUsernames(env = process.env) {
   return new Set([...BUILTIN_SUPER_ADMIN_USERNAMES, ...configured]);
 }
 
+function normalizedAccountIds(env = process.env) {
+  const configured = String(env?.SUPER_ADMIN_ACCOUNT_IDS || env?.ADMIN_ACCOUNT_IDS || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return new Set([...BUILTIN_SUPER_ADMIN_ACCOUNT_IDS, ...configured]);
+}
+
+function accountId(account) {
+  return String(account?.id ?? account?.userId ?? account?.user_id ?? '').trim();
+}
+
 export function resolveAccountEntitlements(account, env = process.env) {
   const username = String(account?.username || '').trim().toLowerCase();
-  const superAdmin = Boolean(username && normalizedUsernames(env).has(username));
+  const stableId = accountId(account);
+  const superAdmin = Boolean(
+    (username && normalizedUsernames(env).has(username)) ||
+    (stableId && normalizedAccountIds(env).has(stableId)),
+  );
   return {
     role: superAdmin ? 'super_admin' : 'user',
     isAdmin: superAdmin,

--- a/ai-backend/test/account_entitlements.test.js
+++ b/ai-backend/test/account_entitlements.test.js
@@ -12,6 +12,15 @@ test('bhrum108 is a built-in super admin with unlimited usage', () => {
   assert.equal(hasUnlimitedUsage({ username: 'BHRUM108' }, {}), true);
 });
 
+test('bhrum108 keeps super-admin entitlement when only stable account id is available', () => {
+  assert.deepEqual(resolveAccountEntitlements({ id: 22 }, {}), {
+    role: 'super_admin',
+    isAdmin: true,
+    unlimitedUsage: true,
+  });
+  assert.equal(hasUnlimitedUsage({ userId: '22' }, {}), true);
+});
+
 test('ordinary accounts are not implicitly privileged', () => {
   assert.deepEqual(resolveAccountEntitlements({ username: 'ordinary-user' }, {}), {
     role: 'user',
@@ -21,7 +30,9 @@ test('ordinary accounts are not implicitly privileged', () => {
 });
 
 test('additional super admins may be configured without removing bhrum108', () => {
-  const env = { SUPER_ADMIN_USERNAMES: 'ops-admin' };
+  const env = { SUPER_ADMIN_USERNAMES: 'ops-admin', SUPER_ADMIN_ACCOUNT_IDS: '73' };
   assert.equal(hasUnlimitedUsage({ username: 'ops-admin' }, env), true);
+  assert.equal(hasUnlimitedUsage({ id: 73 }, env), true);
   assert.equal(hasUnlimitedUsage({ username: 'bhrum108' }, env), true);
+  assert.equal(hasUnlimitedUsage({ id: 22 }, env), true);
 });

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -874,7 +874,15 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
         void execute({ type: 'settings.get', requestId: nextRequestId('settings-get') });
         refreshLegacy();
         try {
-          await selfHosted.ensureCurrentActor();
+          const account = await transport.authStatus().catch(() => null);
+          const cachedActor = startupProjection?.selfActors.find((actor) => actor.id === selfHosted.actorId);
+          const username = account?.user?.username?.trim() || cachedActor?.username;
+          const displayName = account?.user?.nickname?.trim()
+            || username
+            || account?.user?.email?.trim()
+            || cachedActor?.displayName
+            || '当前用户';
+          await selfHosted.ensureCurrentActor(displayName, username);
           await selfHosted.sync(initialSyncLimit, messagingCursorRef.current);
           void webRtcRef.current?.connect().catch(() => {});
         } catch (cause) {
@@ -887,7 +895,7 @@ function MessengerWorkspace({ initialProjection }: { initialProjection?: Messeng
       unsubscribe();
       void transport.close();
     };
-  }, [transport, selfHosted]);
+  }, [transport, selfHosted, startupProjection]);
 
   useEffect(() => {
     if (!hostReady || section !== 'settings' || !['router', 'usage'].includes(settingsCategory)) return;

--- a/desktop/src/selfhosted-messaging-client-v2.ts
+++ b/desktop/src/selfhosted-messaging-client-v2.ts
@@ -401,6 +401,8 @@ export class SelfHostedMessagingClientV2 {
   private identityResolved = false;
   private identityPromise: Promise<void> | null = null;
   private lastIdentityFailureAtMs = 0;
+  private currentActorDisplayName = '当前用户';
+  private currentActorUsername: string | undefined;
 
   constructor(transport: MahayanaHostTransport, options: { actorId?: string; deviceId?: string; sessionId?: string } = {}) {
     this.transport = transport;
@@ -455,12 +457,16 @@ export class SelfHostedMessagingClientV2 {
     await this.execute({ type: 'upsertProfile', actor });
   }
 
-  async ensureCurrentActor(displayName = '当前用户'): Promise<void> {
+  async ensureCurrentActor(displayName?: string, username?: string): Promise<void> {
+    const normalizedDisplayName = displayName?.trim();
+    if (normalizedDisplayName) this.currentActorDisplayName = normalizedDisplayName;
+    if (username !== undefined) this.currentActorUsername = username.trim() || undefined;
     await this.ensureNativeIdentity();
     await this.ensureActor({
       id: this.actorId,
       kind: 'human',
-      displayName,
+      displayName: this.currentActorDisplayName,
+      ...(this.currentActorUsername ? { username: this.currentActorUsername } : {}),
       capabilities: ['messages', 'groups', 'channels', 'calls', 'payments', 'miniApps'],
       presence: { status: 'online', lastSeenAtMs: Date.now() },
       verified: false,

--- a/fabushi/web/src/utils/helpers.js
+++ b/fabushi/web/src/utils/helpers.js
@@ -1,7 +1,9 @@
 const BUILTIN_SUPER_ADMIN_USERNAMES = Object.freeze(["bhrum108"]);
+const BUILTIN_SUPER_ADMIN_ACCOUNT_IDS = Object.freeze(["22"]);
 
 let runtimeAdminEmails = Object.freeze([]);
 let runtimeAdminUsernames = BUILTIN_SUPER_ADMIN_USERNAMES;
+let runtimeAdminAccountIds = BUILTIN_SUPER_ADMIN_ACCOUNT_IDS;
 
 function parseAdminUsernames(env) {
   const configured = String(env?.ADMIN_USERNAMES || "")
@@ -20,9 +22,22 @@ function parseAdminEmails(env) {
   );
 }
 
+function parseAdminAccountIds(env) {
+  const configured = String(env?.SUPER_ADMIN_ACCOUNT_IDS || env?.ADMIN_ACCOUNT_IDS || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return Object.freeze([...new Set([...BUILTIN_SUPER_ADMIN_ACCOUNT_IDS, ...configured])]);
+}
+
+function userAccountId(user) {
+  return String(user?.id ?? user?.userId ?? user?.user_id ?? "").trim();
+}
+
 export function configureRuntimeAdminEmails(env) {
   runtimeAdminEmails = parseAdminEmails(env);
   runtimeAdminUsernames = parseAdminUsernames(env);
+  runtimeAdminAccountIds = parseAdminAccountIds(env);
   return runtimeAdminEmails.length;
 }
 
@@ -36,6 +51,9 @@ export function isAdmin(email, env) {
 export function isAdminUser(user, env) {
   if (!user || typeof user !== 'object') return false;
   if (isAdmin(user.email, env)) return true;
+  const stableId = userAccountId(user);
+  const configuredIds = env ? parseAdminAccountIds(env) : runtimeAdminAccountIds;
+  if (stableId && configuredIds.includes(stableId)) return true;
   const username = String(user.username || '').trim().toLowerCase();
   if (!username) return false;
   const configured = env ? parseAdminUsernames(env) : runtimeAdminUsernames;
@@ -43,6 +61,9 @@ export function isAdminUser(user, env) {
 }
 
 export function hasUnlimitedUsage(user, env) {
+  const stableId = userAccountId(user);
+  const configuredIds = env ? parseAdminAccountIds(env) : runtimeAdminAccountIds;
+  if (stableId && configuredIds.includes(stableId)) return true;
   const username = String(user?.username || '').trim().toLowerCase();
   if (!username) return false;
   const configured = env ? parseAdminUsernames(env) : runtimeAdminUsernames;

--- a/fabushi/web/tests/admin-entitlements.test.js
+++ b/fabushi/web/tests/admin-entitlements.test.js
@@ -9,6 +9,12 @@ test('bhrum108 is always a super administrator by username', () => {
   assert.equal(hasUnlimitedUsage(user, {}), true);
 });
 
+test('bhrum108 is recognized by stable account id when profile names are absent', () => {
+  const user = { id: 22, email: '' };
+  assert.equal(isAdminUser(user, {}), true);
+  assert.equal(hasUnlimitedUsage(user, {}), true);
+});
+
 test('configured email admins keep admin access but do not gain unlimited quota', () => {
   const env = { ADMIN_EMAILS: 'ops@example.com' };
   const user = { username: 'ops', email: 'ops@example.com' };
@@ -19,6 +25,13 @@ test('configured email admins keep admin access but do not gain unlimited quota'
 test('configured admin usernames gain the same super-admin entitlement', () => {
   const env = { ADMIN_USERNAMES: 'release-admin' };
   const user = { username: 'release-admin', email: 'release@example.com' };
+  assert.equal(isAdminUser(user, env), true);
+  assert.equal(hasUnlimitedUsage(user, env), true);
+});
+
+test('configured stable account ids gain the same super-admin entitlement', () => {
+  const env = { SUPER_ADMIN_ACCOUNT_IDS: '73' };
+  const user = { userId: '73', email: '' };
   assert.equal(isAdminUser(user, env), true);
   assert.equal(hasUnlimitedUsage(user, env), true);
 });

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-core/src/usage.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-core/src/usage.rs
@@ -38,4 +38,6 @@ pub struct AccountUsageStatus {
     pub used_tokens: i64,
     pub reserved_tokens: i64,
     pub remaining_tokens: i64,
+    #[serde(default)]
+    pub unlimited: bool,
 }

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
@@ -153,11 +153,26 @@ fn worker_router_rejects_duplicate_developer_commerce_regressions() {
         ("post", "/v1/developer/commerce/profile"),
         ("get", "/v1/developer/commerce/miniapps"),
         ("post", "/v1/developer/commerce/miniapps/:mini_app_id"),
-        ("get", "/v1/developer/commerce/miniapps/:mini_app_id/products"),
-        ("post", "/v1/developer/commerce/miniapps/:mini_app_id/products"),
-        ("post", "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id"),
-        ("post", "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id/google/sync"),
-        ("post", "/v1/pay/intents/:payment_id/apple/advanced-commerce"),
+        (
+            "get",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products",
+        ),
+        (
+            "post",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products",
+        ),
+        (
+            "post",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id",
+        ),
+        (
+            "post",
+            "/v1/developer/commerce/miniapps/:mini_app_id/products/:product_id/google/sync",
+        ),
+        (
+            "post",
+            "/v1/pay/intents/:payment_id/apple/advanced-commerce",
+        ),
     ] {
         let needle = format!(".{method}_async(\"{route}\"");
         assert_eq!(

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api.rs
@@ -70,8 +70,14 @@ const OAUTH_ATTEMPT_SECONDS: i64 = 10 * 60;
 const USAGE_WINDOW_SECONDS: i64 = 30 * 24 * 60 * 60;
 const USAGE_RESERVATION_SECONDS: i64 = 10 * 60;
 const MAX_TOKENS_PER_RESERVATION: i64 = 2_000_000;
+const UNLIMITED_AI_TOKEN_LIMIT: i64 = 9_007_199_254_740_991;
+const BUILTIN_SUPER_ADMIN_ACCOUNT_IDS: &[&str] = &["22"];
 const MARKETPLACE_DEPLOYMENT_VERIFY_ATTEMPTS: usize = 6;
 const MARKETPLACE_DEPLOYMENT_VERIFY_DELAY_SECONDS: u64 = 3;
+
+fn is_builtin_super_admin_account_id(user_id: &str) -> bool {
+    BUILTIN_SUPER_ADMIN_ACCOUNT_IDS.contains(&user_id.trim())
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 struct MarketplacePluginRow {

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/account.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/account.rs
@@ -2006,6 +2006,7 @@ fn issue_account_access_token(
 }
 
 fn serialize_account_user(user: &AccountUserRow) -> serde_json::Value {
+    let super_admin = is_builtin_super_admin_account_id(&user.id.to_string());
     let avatar = user
         .avatar
         .as_ref()
@@ -2018,6 +2019,19 @@ fn serialize_account_user(user: &AccountUserRow) -> serde_json::Value {
             "selectedAt": user.main_practice_selected_at,
         })
     });
+    let membership = if super_admin {
+        json!({
+            "type": "lifetime",
+            "expiresAt": null,
+            "isActive": true,
+            "active": true,
+        })
+    } else {
+        json!({
+            "type": user.membership_type.as_deref().unwrap_or("expired"),
+            "expiresAt": user.membership_expires_at.as_ref().or(user.free_trial_end_date.as_ref()),
+        })
+    };
     json!({
         "id": user.id,
         "userId": user.id,
@@ -2037,10 +2051,10 @@ fn serialize_account_user(user: &AccountUserRow) -> serde_json::Value {
         "mainPractice": main_practice,
         "createdAt": user.created_at,
         "emailVerified": user.email_verified == Some(1),
-        "membership": {
-            "type": user.membership_type.as_deref().unwrap_or("expired"),
-            "expiresAt": user.membership_expires_at.as_ref().or(user.free_trial_end_date.as_ref()),
-        },
+        "isAdmin": super_admin,
+        "role": if super_admin { "super_admin" } else { "user" },
+        "unlimitedUsage": super_admin,
+        "membership": membership,
     })
 }
 

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/ai_usage.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/ai_usage.rs
@@ -48,7 +48,20 @@ pub(super) async fn ai_usage_reserve(
 
     let window_start = usage_window_start(now);
     let window_end = window_start + USAGE_WINDOW_SECONDS;
-    let default_limit = default_usage_limit(&context.env)?;
+    let (token_limit, unlimited) = account_usage_limit(&context.env, &user_id)?;
+    if unlimited {
+        worker::query!(
+            &database,
+            "UPDATE ai_usage_budgets SET token_limit = ?1, updated_at = ?2
+             WHERE user_id = ?3 AND window_start = ?4",
+            token_limit,
+            now,
+            &user_id,
+            window_start
+        )?
+        .run()
+        .await?;
+    }
     worker::query!(
         &database,
         "INSERT OR IGNORE INTO ai_usage_budgets
@@ -57,7 +70,7 @@ pub(super) async fn ai_usage_reserve(
         &user_id,
         window_start,
         window_end,
-        default_limit,
+        token_limit,
         now
     )?
     .run()
@@ -341,6 +354,7 @@ async fn current_usage_status(
 ) -> Result<AccountUsageStatus> {
     let window_start = usage_window_start(now);
     let window_end = window_start + USAGE_WINDOW_SECONDS;
+    let (entitled_limit, unlimited) = account_usage_limit(env, user_id)?;
     let row = worker::query!(
         database,
         "SELECT window_start, window_end, token_limit, used_tokens, reserved_tokens
@@ -354,9 +368,17 @@ async fn current_usage_status(
         Some(row) => {
             debug_assert_eq!(row.window_start, window_start);
             debug_assert_eq!(row.window_end, window_end);
-            (row.token_limit, row.used_tokens, row.reserved_tokens)
+            (
+                if unlimited {
+                    entitled_limit
+                } else {
+                    row.token_limit
+                },
+                row.used_tokens,
+                row.reserved_tokens,
+            )
         }
-        None => (default_usage_limit(env)?, 0, 0),
+        None => (entitled_limit, 0, 0),
     };
     Ok(AccountUsageStatus {
         window_start,
@@ -367,6 +389,7 @@ async fn current_usage_status(
         remaining_tokens: token_limit
             .saturating_sub(used_tokens)
             .saturating_sub(reserved_tokens),
+        unlimited,
     })
 }
 
@@ -474,6 +497,27 @@ fn default_usage_limit(env: &Env) -> Result<i64> {
         .ok()
         .filter(|limit| *limit >= 0)
         .ok_or_else(|| worker::Error::RustError("DEFAULT_AI_TOKEN_LIMIT is invalid".into()))
+}
+
+fn account_usage_limit(env: &Env, user_id: &str) -> Result<(i64, bool)> {
+    let configured = ["SUPER_ADMIN_ACCOUNT_IDS", "ADMIN_ACCOUNT_IDS"]
+        .into_iter()
+        .filter_map(|name| env.var(name).ok())
+        .any(|value| {
+            value
+                .to_string()
+                .split(',')
+                .any(|candidate| candidate.trim() == user_id.trim())
+        });
+    let unlimited = is_builtin_super_admin_account_id(user_id) || configured;
+    Ok((
+        if unlimited {
+            UNLIMITED_AI_TOKEN_LIMIT
+        } else {
+            default_usage_limit(env)?
+        },
+        unlimited,
+    ))
 }
 
 fn require_model_gateway(request: &Request, env: &Env) -> Result<()> {


### PR DESCRIPTION
## 问题

PR #2117 只按用户名 `bhrum108` 判断超级管理员和无限额度。桌面实际会话稳定身份是账号 ID `22`（Actor 指纹为 `human:account:785f3ec7eb32f30b90cd0fcf3657d388`）；当账户资料链路没有用户名时，管理员和额度判断失效。消息 Actor 初始化也一直使用“当前用户”，没有读取登录账户名称。

此外，桌面读取的 Rust 平台 `/api/auth/user-info` 与 `/v1/ai/usage` 没有包含 #2117 的 entitlement 逻辑。

## 修复

- 将账号 ID `22` 作为 `bhrum108` 的稳定 super-admin entitlement，同时保留用户名和环境变量配置。
- Web 管理入口、AI 后端以及 Rust 平台账户/额度入口统一返回管理员、lifetime 和 unlimited 状态。
- Rust AI 使用预算对该账户返回 `unlimited: true`，并把月度预算提升到安全整数上限，不再因有限预算阻断。
- 桌面消息 Actor 从已认证账户读取昵称/用户名，并在后续 upsert 中保留，不再回退覆盖为“当前用户”。

## 验证

- `node --test ai-backend/test/account_entitlements.test.js fabushi/web/tests/admin-entitlements.test.js`：9/9 通过。
- `rustfmt --check`（4 个相关 Rust 文件）：通过。
- `git diff --check`：通过。
- 遵守仓库磁盘安全规则，未在本机执行构建、Rust 测试或桌面/E2E；完整验证交由 GitHub Actions。