### PR TITLE
feat(web): match Grok bot avatar motion

### DIFF
--- a/.github/scripts/assert-bot-mark-motion.py
+++ b/.github/scripts/assert-bot-mark-motion.py
@@ -8,54 +8,47 @@ host = Path('frontend/apps/web/src/app/host/host-client.tsx').read_text(encoding
 
 required_component = [
     'FabushiBotMarkEngine',
-    'data-engine="fabushi-motion-v2"',
-    'fabushiRhythmForBot',
-    'botMarkAura',
-    'botMarkParticles',
+    'data-engine="grok-mark"',
+    '"blob", "pebble", "squircle", "tablet", "wedge", "hex", "cloud", "teardrop"',
 ]
 for marker in required_component:
     if marker not in component:
-        raise SystemExit(f'BotMark motion gate: missing Fabushi v2 integration: {marker}')
+        raise SystemExit(f'BotMark motion gate: missing Grok mark integration: {marker}')
 
 required_engine = [
-    'const frameListeners = new Set<FrameListener>()',
-    'window.requestAnimationFrame(runMotionFrame)',
-    'MOTION_FRAME_INTERVAL_MS',
-    'document.visibilityState',
-    'document.hasFocus()',
-    'dataset.fabushiMotion',
-    'function springStep(',
-    'function eyeLensPath(',
-    'function profileForState(',
-    'IntersectionObserver',
+    'const VIEWBOX = "-15 -15 259 259"',
+    'const CENTER = 114.2705',
+    'normalizeArtifactPath',
+    'roundedPolygon',
+    'const MOTION:',
+    'requestAnimationFrame(tick)',
     'prefers-reduced-motion: reduce',
-    'queuedSecondBlink',
-    'data-engine="fabushi-motion-v2"',
-    'surfaceGradientRef',
-    'radarSweepRef',
+    'scale(1 ${motion.eye})',
+    '<ellipse cx={CENTER - 29}',
+    '<ellipse cx={CENTER + 29}',
 ]
 for marker in required_engine:
     if marker not in engine:
-        raise SystemExit(f'BotMark motion gate: missing Fabushi engine capability: {marker}')
+        raise SystemExit(f'BotMark motion gate: missing Grok mark behavior: {marker}')
 
 for semantic_state in ['tool-running', 'speaking', 'result', 'error']:
-    if f'\"{semantic_state}\"' not in component or f'\"{semantic_state}\"' not in engine:
+    if f'"{semantic_state}"' not in component or f'"{semantic_state}"' not in engine:
         raise SystemExit(f'BotMark motion gate: missing Agent lifecycle state: {semantic_state}')
 
-for forbidden in ['GrokBotMarkEngine', 'grok-bot-mark-engine', 'setInterval(() =>']:
+for forbidden in ['setInterval(() =>', 'surfaceGradientRef', 'radarSweepRef', 'botMarkParticles']:
     if forbidden in component or forbidden in engine:
-        raise SystemExit(f'BotMark motion gate: legacy/copied motion engine returned: {forbidden}')
+        raise SystemExit(f'BotMark motion gate: non-Grok visual effect returned: {forbidden}')
 
 required_styles = [
-    '.botMark[data-accent="pulse"]',
-    '@keyframes botMarkOrbit',
-    '@keyframes botMarkGlow',
+    '.botMark > svg',
+    'filter: none;',
+    '.onboardingMarkStage > span:not(.onboardingBotMark)',
     '@media (prefers-reduced-motion: reduce)',
     'animation: none !important;',
 ]
 for marker in required_styles:
     if marker not in styles:
-        raise SystemExit(f'BotMark motion gate: missing ambient CSS contract: {marker}')
+        raise SystemExit(f'BotMark motion gate: missing Grok-compatible CSS contract: {marker}')
 
 # Pointer-follow is intentionally reserved for large hero/profile marks. Keeping
 # it out of agent-list rows avoids N pointer listeners for a long sidebar.
@@ -64,4 +57,4 @@ if 'className={styles.sidebarBotMark}' in host:
     if 'followPointer' in sidebar_region:
         raise SystemExit('BotMark motion gate: sidebar list marks must not attach pointer-follow listeners')
 
-print('BotMark motion gate passed: Fabushi v2 shared clock, spring physics, expressive eyes, and reduced-motion support.')
+print('BotMark motion gate passed: Grok geometry, eyes, state motion, pointer gaze, and reduced-motion support.')

--- a/frontend/apps/web/src/app/host/bot-mark.tsx
+++ b/frontend/apps/web/src/app/host/bot-mark.tsx
@@ -1,14 +1,9 @@
 import {
   forwardRef,
-  useMemo,
   type CSSProperties,
   type ReactNode,
 } from "react";
-import {
-  FabushiBotMarkEngine,
-  fabushiAccentForState,
-  fabushiRhythmForBot,
-} from "./fabushi-bot-mark-engine";
+import { FabushiBotMarkEngine } from "./fabushi-bot-mark-engine";
 import styles from "./host.module.css";
 
 export type BotMarkState =
@@ -59,23 +54,12 @@ export type BotMarkState =
 export type BotMarkShape =
   | "blob"
   | "pebble"
-  | "bean"
-  | "egg"
   | "squircle"
   | "tablet"
-  | "capsule"
-  | "cylinder"
-  | "hex"
-  | "gem"
-  | "crystal"
   | "wedge"
-  | "shield"
-  | "dome"
-  | "arch"
+  | "hex"
   | "cloud"
-  | "teardrop"
-  | "leaf"
-  | "jelly";
+  | "teardrop";
 
 export type BotMarkColor =
   | "black"
@@ -97,21 +81,6 @@ export type BotMarkHandle = {
 };
 
 type GazePoint = { x: number; y: number };
-type BotMarkPose = { turn?: number; tilt?: number; roll?: number; scale?: number };
-type BotMarkFaceTune = {
-  size?: number;
-  gap?: number;
-  height?: number;
-  eyeWidth?: number;
-  eyeHeight?: number;
-};
-type BotMarkInkGradient = {
-  from: string;
-  to: string;
-  angle?: number;
-  fromPos?: number;
-  toPos?: number;
-};
 
 type BotMarkProps = {
   botId: string;
@@ -129,34 +98,15 @@ type BotMarkProps = {
   shape?: BotMarkShape;
   color?: BotMarkColor;
   eyeColor?: string;
-  pose?: BotMarkPose;
-  poseHome?: BotMarkPose;
-  faceTune?: BotMarkFaceTune;
-  eyeScale?: number;
-  uniformEyes?: boolean;
-  eyeTopology?: boolean;
-  inkGradient?: BotMarkInkGradient | null;
 };
 
 const IDENTITY_SHAPES: readonly BotMarkShape[] = [
-  "blob", "pebble", "bean", "egg", "squircle", "capsule", "cloud", "teardrop", "leaf", "jelly",
+  "blob", "pebble", "squircle", "tablet", "wedge", "hex", "cloud", "teardrop",
 ];
 
 const COLORS: readonly BotMarkColor[] = [
   "brown", "red", "orange", "yellow", "green", "cyan", "blue", "violet", "magenta", "gray",
 ];
-
-const AMBIENT_MOTION_STATES = new Set<BotMarkState>([
-  "idle", "sleeping", "drowsy", "bored", "powering-down",
-]);
-
-export function botMarkMotionTier(
-  state: BotMarkState,
-  emphasis = false,
-  followPointer = false,
-): "ambient" | "active" {
-  return !emphasis && !followPointer && AMBIENT_MOTION_STATES.has(state) ? "ambient" : "active";
-}
 
 const COLOR_VALUES: Record<BotMarkColor, { light: string; dark: string }> = {
   black: { light: "#000000", dark: "#FFFFFF" },
@@ -172,58 +122,43 @@ const COLOR_VALUES: Record<BotMarkColor, { light: string; dark: string }> = {
   gray: { light: "#959595", dark: "#777777" },
 };
 
-const SHAPE_PATHS: Record<BotMarkShape, string> = {
-  blob: "M50 9C68 8 88 20 91 39C95 59 85 82 65 90C43 99 18 88 10 67C3 48 10 25 28 15C35 11 42 9 50 9Z",
-  pebble: "M31 11H69C82 11 91 23 91 37V63C91 78 80 90 65 92H35C20 91 9 79 9 64V36C9 23 18 13 31 11Z",
-  bean: "M22 18C33 7 51 8 64 16C80 25 91 41 90 58C89 76 75 90 57 92C39 94 22 85 13 70C2 52 7 33 22 18Z",
-  egg: "M50 7C67 7 82 24 88 43C95 66 82 91 55 94C29 97 10 80 12 56C13 35 30 8 50 7Z",
-  squircle: "M29 9H71C84 9 91 16 91 29V71C91 84 84 91 71 91H29C16 91 9 84 9 71V29C9 16 16 9 29 9Z",
-  tablet: "M24 12H76C85 12 91 20 91 29V71C91 81 84 88 74 88H26C16 88 9 81 9 71V29C9 20 15 12 24 12Z",
-  capsule: "M28 15H72C86 15 94 27 94 42V58C94 73 85 85 70 85H30C15 85 6 73 6 58V42C6 27 14 15 28 15Z",
-  cylinder: "M22 19C22 11 78 11 78 19V81C78 89 22 89 22 81V19Z",
-  hex: "M27 10H73L94 50L73 90H27L6 50L27 10Z",
-  gem: "M50 5L88 28L82 72L50 95L18 72L12 28L50 5Z",
-  crystal: "M50 4L82 20L94 55L70 93H30L6 55L18 20L50 4Z",
-  wedge: "M16 18L91 32L78 88L10 72L16 18Z",
-  shield: "M50 6L88 18V49C88 73 73 88 50 95C27 88 12 73 12 49V18L50 6Z",
-  dome: "M11 55C11 31 28 11 50 11C72 11 89 31 89 55V89H11V55Z",
-  arch: "M13 91V48C13 25 29 9 50 9C71 9 87 25 87 48V91H67V49C67 38 60 30 50 30C40 30 33 38 33 49V91H13Z",
-  cloud: "M21 80C9 80 4 67 9 57C12 50 18 47 25 47C24 31 35 19 49 19C61 19 71 27 74 39C88 39 96 50 94 63C93 73 85 80 75 80H21Z",
-  teardrop: "M50 5C50 5 88 47 88 66C88 84 72 95 50 95C28 95 12 84 12 66C12 47 50 5 50 5Z",
-  leaf: "M91 9C63 10 26 17 13 42C1 66 18 89 42 91C70 93 89 62 91 9Z",
-  jelly: "M12 56C12 29 29 10 50 10C71 10 88 29 88 56V64C88 73 83 79 76 80C70 81 66 77 62 71C59 78 55 83 49 83C43 83 39 78 36 71C32 77 27 81 21 79C15 77 12 71 12 63V56Z",
-};
-
-const SHAPE_SCALE: Record<BotMarkShape, number> = {
-  blob: 0.94, pebble: 0.97, bean: 0.98, egg: 0.96, squircle: 0.9, tablet: 1,
-  capsule: 0.98, cylinder: 0.96, hex: 0.93, gem: 0.94, crystal: 0.92, wedge: 0.94,
-  shield: 0.95, dome: 0.95, arch: 0.95, cloud: 0.96, teardrop: 0.94, leaf: 0.94, jelly: 0.98,
-};
-
-const DEFAULT_POSE: BotMarkPose = { turn: 10, tilt: -6, roll: 4, scale: 1 };
-const DEFAULT_HOME_POSE: BotMarkPose = { turn: 16, tilt: -8, roll: 6, scale: 1 };
-const DEFAULT_FACE_TUNE: BotMarkFaceTune = { size: 0.9, gap: 1.12, height: 1, eyeWidth: 0.98, eyeHeight: 0.94 };
-
 function hashIdentity(value: string): number {
-  let hash = 0x811c9dc5;
-  for (const char of value) {
-    hash ^= char.codePointAt(0) ?? 0;
-    hash = Math.imul(hash, 0x01000193);
-    hash ^= hash >>> 13;
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = Math.imul(hash ^ value.charCodeAt(index), 16777619);
   }
   return hash >>> 0;
 }
 
+function identityRandom(seed: number): () => number {
+  let value = seed >>> 0;
+  return () => {
+    value = value + 1831565813 | 0;
+    let next = Math.imul(value ^ value >>> 15, 1 | value);
+    next = next + Math.imul(next ^ next >>> 7, 61 | next) ^ next;
+    return ((next ^ next >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+function shapeHash(value: string): number {
+  let hash = hashIdentity(value);
+  hash = Math.imul(hash ^ hash >>> 16, 73244475);
+  hash = Math.imul(hash ^ hash >>> 13, 3266489909);
+  return (hash ^ hash >>> 16) >>> 0;
+}
+
 export function botMarkShape(botId: string): BotMarkShape {
-  return IDENTITY_SHAPES[hashIdentity(`shape:${botId}`) % IDENTITY_SHAPES.length] ?? "blob";
+  return IDENTITY_SHAPES[shapeHash(botId) % IDENTITY_SHAPES.length] ?? "blob";
 }
 
 export function botMarkShapeIndex(botId: string): number {
-  return hashIdentity(`shape:${botId}`) % IDENTITY_SHAPES.length;
+  return shapeHash(botId) % IDENTITY_SHAPES.length;
 }
 
 export function botMarkColorId(botId: string): BotMarkColor {
-  return COLORS[hashIdentity(`color:${botId}`) % COLORS.length] ?? "brown";
+  const seed = (hashIdentity(botId) ^ Math.imul(1, 2654435769)) >>> 0;
+  const index = Math.floor(identityRandom((seed ^ 2654435769) >>> 0)() * COLORS.length);
+  return COLORS[index] ?? "gray";
 }
 
 export function botMarkColor(botId: string): string {
@@ -248,33 +183,16 @@ export const BotMark = forwardRef<BotMarkHandle, BotMarkProps>(function BotMark(
     shape: shapeOverride,
     color: colorOverride,
     eyeColor,
-    pose,
-    poseHome,
-    faceTune,
-    eyeScale = 1,
-    uniformEyes = true,
-    eyeTopology = true,
-    inkGradient = null,
   },
   ref,
 ) {
   const shape = shapeOverride ?? botMarkShape(botId);
   const color = colorOverride ?? botMarkColorId(botId);
-  const colorValue = COLOR_VALUES[color];
-  const rhythm = useMemo(() => fabushiRhythmForBot(botId), [botId]);
-  const accent = fabushiAccentForState(state);
-  const shapeScale = SHAPE_SCALE[shape];
-  const effectiveEyeScale = eyeScale * Math.max(0.9, Math.min(1.08, 0.95 / shapeScale));
   const style = {
     width: size,
     height: size,
     "--bot-mark-size": `${size}px`,
-    "--fg": `light-dark(${colorValue.light}, ${colorValue.dark})`,
-    "--bg": eyeColor ?? "var(--bot-mark-eye-color, var(--app, #0b0b0b))",
-    "--bot-mark-breathe-duration": `${rhythm.breatheMs}ms`,
-    "--bot-mark-orbit-duration": `${rhythm.orbitMs}ms`,
-    "--bot-mark-pulse-duration": `${rhythm.pulseMs}ms`,
-    "--bot-mark-motion-delay": `${rhythm.delayMs}ms`,
+    "--bot-mark-eye-color": eyeColor ?? "var(--app, #fff)",
   } as CSSProperties;
 
   return (
@@ -285,37 +203,26 @@ export const BotMark = forwardRef<BotMarkHandle, BotMarkProps>(function BotMark(
       data-paused={paused || undefined}
       data-shape={shape}
       data-color={color}
-      data-accent={accent}
-      data-motion-tier={botMarkMotionTier(state, emphasis, followPointer)}
-      data-engine="fabushi-motion-v2"
+      data-engine="grok-mark"
       style={style}
       aria-label={label}
       aria-hidden={label ? undefined : true}
       role={label ? "img" : undefined}
     >
-      <span className={styles.botMarkAura} aria-hidden="true" />
-      <span className={styles.botMarkAuraSecondary} aria-hidden="true" />
-      <span className={styles.botMarkParticles} aria-hidden="true"><i /><i /><i /></span>
       <FabushiBotMarkEngine
         ref={ref}
         botId={botId}
         state={state}
         size={size}
-        shapePath={SHAPE_PATHS[shape]}
-        shapeScale={shapeScale}
+        shape={shape}
+        color={color}
         gazeTarget={gazeTarget}
         followPointer={followPointer}
         emphasis={emphasis}
         spinSignal={spinSignal}
         badgeColor={badgeColor}
         paused={paused}
-        pose={{ ...DEFAULT_POSE, ...pose }}
-        poseHome={{ ...DEFAULT_HOME_POSE, ...poseHome }}
-        faceTune={{ ...DEFAULT_FACE_TUNE, ...faceTune }}
-        eyeScale={effectiveEyeScale}
-        uniformEyes={uniformEyes}
-        eyeTopology={eyeTopology}
-        inkGradient={inkGradient}
+        eyeColor={eyeColor}
       />
       {children}
     </span>

--- a/frontend/apps/web/src/app/host/extension-studio.tsx
+++ b/frontend/apps/web/src/app/host/extension-studio.tsx
@@ -389,8 +389,7 @@ const emptyBotDraft: BotDraft = {
 };
 
 const botShapeOptions: BotMarkShape[] = [
-  "blob", "pebble", "bean", "egg", "squircle", "tablet", "capsule", "cylinder",
-  "hex", "gem", "crystal", "wedge", "shield", "dome", "arch", "cloud", "teardrop", "leaf",
+  "blob", "pebble", "squircle", "tablet", "wedge", "hex", "cloud", "teardrop",
 ];
 const botColorOptions: BotMarkColor[] = [
   "black", "brown", "red", "orange", "yellow", "green", "cyan", "blue", "violet", "magenta", "gray",

--- a/frontend/apps/web/src/app/host/fabushi-bot-mark-engine.tsx
+++ b/frontend/apps/web/src/app/host/fabushi-bot-mark-engine.tsx
@@ -1,782 +1,293 @@
-import {
-  forwardRef,
-  useEffect,
-  useId,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-} from "react";
+import { forwardRef, useEffect, useId, useImperativeHandle, useRef, type CSSProperties } from "react";
 
-export type FabushiBotMarkEngineHandle = {
-  spin: (turns?: number) => void;
-  bounce: () => void;
-  burst: () => void;
-};
+import type { BotMarkColor, BotMarkHandle, BotMarkShape, BotMarkState } from "./bot-mark";
 
-type Point = { x: number; y: number };
-type Pose = { turn?: number; tilt?: number; roll?: number; scale?: number };
-type FaceTune = {
-  size?: number;
-  gap?: number;
-  height?: number;
-  eyeWidth?: number;
-  eyeHeight?: number;
-};
-type InkGradient = {
-  from: string;
-  to: string;
-  angle?: number;
-  fromPos?: number;
-  toPos?: number;
-};
-type AccentMode = "none" | "pulse" | "orbit" | "alert" | "radar" | "progress";
+// Port of the reconstructed Grok Bot 0.18 persona mark. Geometry, palette,
+// state timings, eye proportions, and pointer-gaze behavior stay source-aligned.
 
-type MotionProfile = {
-  energy: number;
-  pace: number;
-  breath: number;
-  swayX: number;
-  swayY: number;
-  roll: number;
-  bounce: number;
-  eyeOpen: number;
-  eyeWidth: number;
-  eyeY: number;
-  eyeTilt: number;
-  eyeSmile: number;
-  gazeWander: number;
-  mouth: number;
-  roundMouth: number;
-  cheek: number;
-  blinkRate: number;
-  accent: AccentMode;
-};
+type Point = [number, number];
+type GazePoint = { x: number; y: number };
 
 export type FabushiBotMarkEngineProps = {
   botId: string;
-  state: string;
+  state: BotMarkState;
   size: number;
-  shapePath: string;
-  shapeScale?: number;
-  gazeTarget?: Point | null;
+  shape: BotMarkShape;
+  color: BotMarkColor;
+  gazeTarget?: GazePoint | null;
   followPointer?: boolean;
   emphasis?: boolean;
   spinSignal?: number;
   badgeColor?: string;
   paused?: boolean;
-  pose?: Pose;
-  poseHome?: Pose;
-  faceTune?: FaceTune;
-  eyeScale?: number;
-  uniformEyes?: boolean;
-  eyeTopology?: boolean;
-  inkGradient?: InkGradient | null;
+  eyeColor?: string;
 };
 
-export type FabushiBotMarkRhythm = {
-  breatheMs: number;
-  orbitMs: number;
-  pulseMs: number;
-  blinkMs: number;
-  delayMs: number;
+const VIEWBOX = "-15 -15 259 259";
+const CENTER = 114.2705;
+const TAU = Math.PI * 2;
+const BLOB_PATH = "M228.541 114.228C228.541 130.133 225.184 145.994 218.738 160.534C212.674 174.217 203.904 186.669 193.065 196.988C155.933 232.34 99.497 238.596 55.5255 212.24C45.097 205.99 35.6851 198.072 27.7451 188.866C19.1926 178.953 12.3686 167.569 7.65781 155.351C2.60712 142.264 0 128.257 0 114.228C0 98.3219 3.35751 82.4611 9.80315 67.9215C15.8672 54.2382 24.6377 41.7862 35.4767 31.4668C72.6081 -3.88483 129.044 -10.1413 173.016 16.2153C183.444 22.4653 192.856 30.3829 200.796 39.5896C209.349 49.5018 216.173 60.8859 220.883 73.1037C225.934 86.1906 228.541 100.198 228.541 114.228Z";
+
+const COLORS: Record<BotMarkColor, { light: string; dark: string }> = {
+  black: { light: "#000000", dark: "#FFFFFF" }, brown: { light: "#A27952", dark: "#855C36" },
+  red: { light: "#FF3E51", dark: "#E02135" }, orange: { light: "#FF781C", dark: "#FF6700" },
+  yellow: { light: "#FFAF38", dark: "#FF9800" }, green: { light: "#00C972", dark: "#009957" },
+  cyan: { light: "#1CC3B0", dark: "#00A592" }, blue: { light: "#2A92FE", dark: "#0E74E0" },
+  violet: { light: "#A97EFE", dark: "#804EE0" }, magenta: { light: "#FF5EB1", dark: "#E02A88" },
+  gray: { light: "#959595", dark: "#777777" },
 };
 
-type FrameListener = (timeMs: number, deltaSeconds: number) => void;
+const round2 = (value: number) => Math.round(value * 100) / 100;
+const clamp = (value: number, minimum: number, maximum: number) => value < minimum ? minimum : value > maximum ? maximum : value;
 
-// One animation clock drives every mark. The engine writes SVG attributes directly,
-// so a sidebar full of agents does not cause a React render on every animation frame.
-const frameListeners = new Set<FrameListener>();
-const MOTION_FRAME_INTERVAL_MS = 1000 / 30;
-const AMBIENT_MOTION_FRAME_INTERVAL_MS = 1000 / 8;
-const AMBIENT_MOTION_STATES = new Set(["idle", "sleeping", "drowsy", "bored", "powering-down"]);
-let motionFrameId: number | null = null;
-let lastMotionFrameMs = 0;
-let lastMotionDispatchMs = 0;
-let motionDocumentActive = true;
-let motionLifecycleInstalled = false;
-
-function updateMotionDocumentState(): void {
-  motionDocumentActive = document.visibilityState === "visible" && document.hasFocus();
-  document.documentElement.dataset.fabushiMotion = motionDocumentActive ? "active" : "paused";
-  if (!motionDocumentActive && motionFrameId !== null) {
-    window.cancelAnimationFrame(motionFrameId);
-    motionFrameId = null;
-    lastMotionFrameMs = 0;
-    lastMotionDispatchMs = 0;
-  } else if (motionDocumentActive && frameListeners.size > 0 && motionFrameId === null) {
-    motionFrameId = window.requestAnimationFrame(runMotionFrame);
+function smoothPath(points: readonly Point[]): string {
+  const path = [`M${round2(points[0][0])} ${round2(points[0][1])}`];
+  for (let index = 0; index < points.length; index += 1) {
+    const previous = points[(index - 1 + points.length) % points.length];
+    const current = points[index];
+    const next = points[(index + 1) % points.length];
+    const afterNext = points[(index + 2) % points.length];
+    path.push(`C${round2(current[0] + (next[0] - previous[0]) / 6)} ${round2(current[1] + (next[1] - previous[1]) / 6)} ${round2(next[0] - (afterNext[0] - current[0]) / 6)} ${round2(next[1] - (afterNext[1] - current[1]) / 6)} ${round2(next[0])} ${round2(next[1])}`);
   }
+  return `${path.join("")}Z`;
 }
 
-function ensureMotionLifecycle(): void {
-  if (motionLifecycleInstalled) return;
-  motionLifecycleInstalled = true;
-  document.addEventListener("visibilitychange", updateMotionDocumentState);
-  window.addEventListener("focus", updateMotionDocumentState);
-  window.addEventListener("blur", updateMotionDocumentState);
-  updateMotionDocumentState();
-}
-
-function runMotionFrame(timeMs: number): void {
-  if (!motionDocumentActive) {
-    motionFrameId = null;
-    return;
+class ArtifactPath {
+  d = "";
+  x = 0;
+  y = 0;
+  move(x: number, y: number) { this.d += `M${round2(x)} ${round2(y)}`; this.x = x; this.y = y; return this; }
+  line(x: number, y: number) { this.d += `L${round2(x)} ${round2(y)}`; this.x = x; this.y = y; return this; }
+  curve(x1: number, y1: number, x2: number, y2: number, x: number, y: number) {
+    this.d += `C${round2(x1)} ${round2(y1)} ${round2(x2)} ${round2(y2)} ${round2(x)} ${round2(y)}`;
+    this.x = x; this.y = y; return this;
   }
-  if (lastMotionDispatchMs && timeMs - lastMotionDispatchMs < MOTION_FRAME_INTERVAL_MS) {
-    motionFrameId = window.requestAnimationFrame(runMotionFrame);
-    return;
-  }
-  const rawDelta = lastMotionFrameMs ? (timeMs - lastMotionFrameMs) / 1000 : 1 / 30;
-  const deltaSeconds = Math.min(0.05, Math.max(1 / 120, rawDelta));
-  lastMotionFrameMs = timeMs;
-  lastMotionDispatchMs = timeMs;
-  for (const listener of frameListeners) listener(timeMs, deltaSeconds);
-  if (frameListeners.size > 0) {
-    motionFrameId = window.requestAnimationFrame(runMotionFrame);
-  } else {
-    motionFrameId = null;
-    lastMotionFrameMs = 0;
-    lastMotionDispatchMs = 0;
-  }
-}
-
-function subscribeMotionFrame(listener: FrameListener): () => void {
-  ensureMotionLifecycle();
-  frameListeners.add(listener);
-  if (motionDocumentActive && motionFrameId === null) motionFrameId = window.requestAnimationFrame(runMotionFrame);
-  return () => {
-    frameListeners.delete(listener);
-    if (frameListeners.size === 0 && motionFrameId !== null) {
-      window.cancelAnimationFrame(motionFrameId);
-      motionFrameId = null;
-      lastMotionFrameMs = 0;
-      lastMotionDispatchMs = 0;
-    }
-  };
-}
-
-function clamp(value: number, minimum: number, maximum: number): number {
-  return Math.max(minimum, Math.min(maximum, value));
-}
-
-function hashMotionIdentity(value: string): number {
-  let hash = 0x6d2b79f5 ^ value.length;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = Math.imul(hash ^ value.charCodeAt(index), 0x45d9f3b);
-    hash = (hash << 13) | (hash >>> 19);
-  }
-  hash ^= hash >>> 16;
-  hash = Math.imul(hash, 0x27d4eb2d);
-  hash ^= hash >>> 15;
-  return hash >>> 0;
-}
-
-function seededUnit(seed: number, salt: number): number {
-  let value = (seed ^ Math.imul(salt + 1, 0x9e3779b1)) >>> 0;
-  value ^= value >>> 16;
-  value = Math.imul(value, 0x21f0aaad);
-  value ^= value >>> 15;
-  value = Math.imul(value, 0x735a2d97);
-  value ^= value >>> 15;
-  return (value >>> 0) / 0x100000000;
-}
-
-export function fabushiRhythmForBot(botId: string): FabushiBotMarkRhythm {
-  const seed = hashMotionIdentity(`rhythm:${botId}`);
-  const breatheMs = Math.round(4_400 + seededUnit(seed, 1) * 2_300);
-  return {
-    breatheMs,
-    orbitMs: Math.round(breatheMs * (1.26 + seededUnit(seed, 2) * 0.34)),
-    pulseMs: Math.round(breatheMs * (0.54 + seededUnit(seed, 3) * 0.2)),
-    blinkMs: Math.round(2_700 + seededUnit(seed, 4) * 3_900),
-    delayMs: -Math.round(seededUnit(seed, 5) * 3_400),
-  };
-}
-
-const BASE: MotionProfile = {
-  energy: 0.38, pace: 0.68, breath: 0.75, swayX: 0.65, swayY: 0.48,
-  roll: 0.8, bounce: 0, eyeOpen: 0.9, eyeWidth: 1, eyeY: 0, eyeTilt: 0,
-  eyeSmile: 0, gazeWander: 0.18, mouth: 0, roundMouth: 0, cheek: 0,
-  blinkRate: 1, accent: "none",
-};
-
-function p(overrides: Partial<MotionProfile>): MotionProfile {
-  return { ...BASE, ...overrides };
-}
-
-const SLEEP = p({ energy: 0.08, pace: 0.22, breath: 1, swayX: 0.12, swayY: 0.2, roll: 0.25, eyeOpen: 0.08, eyeWidth: 1.08, eyeY: 1.4, gazeWander: 0, blinkRate: 0 });
-const WAKE = p({ energy: 0.72, pace: 0.72, breath: 0.7, swayY: 0.8, eyeOpen: 1.22, eyeWidth: 0.94, gazeWander: 0.12, blinkRate: 0.72 });
-const LISTEN = p({ energy: 0.55, pace: 0.88, breath: 0.9, swayX: 0.2, swayY: 0.76, roll: 0.34, eyeOpen: 1.02, eyeWidth: 0.94, gazeWander: 0.05, blinkRate: 0.86 });
-const THINK = p({ energy: 0.46, pace: 0.56, breath: 0.62, swayX: 0.46, swayY: 0.34, roll: 0.52, eyeOpen: 0.76, eyeWidth: 0.98, eyeY: -0.5, eyeTilt: -2.5, gazeWander: 0.62, blinkRate: 0.82, accent: "pulse" });
-const SEARCH = p({ energy: 0.76, pace: 1.18, breath: 0.48, swayX: 0.92, swayY: 0.62, roll: 1.8, eyeOpen: 0.9, eyeWidth: 0.92, gazeWander: 0.82, blinkRate: 0.72, accent: "orbit" });
-const WORK = p({ energy: 0.84, pace: 1.36, breath: 0.5, swayX: 0.9, swayY: 0.5, roll: 1.3, eyeOpen: 0.84, eyeWidth: 0.96, gazeWander: 0.12, blinkRate: 0.7, accent: "pulse" });
-const JOY = p({ energy: 1.08, pace: 1.34, breath: 0.72, swayX: 0.64, swayY: 1.05, roll: 1.8, bounce: 0.86, eyeOpen: 0.46, eyeWidth: 1.08, eyeSmile: 0.96, gazeWander: 0.1, mouth: 0.88, cheek: 0.2, blinkRate: 0.92 });
-const EXCITED = p({ ...JOY, energy: 1.24, pace: 1.5, bounce: 1.08, eyeOpen: 1.08, eyeSmile: 0.2, mouth: 0.55 });
-const SURPRISED = p({ energy: 0.94, pace: 1.04, breath: 0.46, swayX: 0.36, swayY: 0.62, roll: 0.9, eyeOpen: 1.38, eyeWidth: 0.9, gazeWander: 0.04, roundMouth: 0.88, blinkRate: 0.58 });
-const LOW = p({ energy: 0.16, pace: 0.28, breath: 0.94, swayX: 0.18, swayY: 0.25, roll: 0.3, eyeOpen: 0.36, eyeWidth: 1.07, eyeY: 1, gazeWander: 0.06, mouth: -0.14, blinkRate: 1.25 });
-const CURIOUS = p({ energy: 0.52, pace: 0.54, breath: 0.62, swayX: 0.48, swayY: 0.38, roll: 0.58, eyeOpen: 1.04, eyeWidth: 0.95, eyeY: -0.4, eyeTilt: 2.5, gazeWander: 0.72, roundMouth: 0.42, blinkRate: 0.94 });
-const SUSPICIOUS = p({ energy: 0.36, pace: 0.42, breath: 0.42, swayX: 0.34, swayY: 0.18, roll: 0.42, eyeOpen: 0.46, eyeWidth: 1.08, eyeY: 0.4, eyeTilt: -7, gazeWander: 0.48, mouth: -0.12, blinkRate: 0.62 });
-const SAD = p({ energy: 0.22, pace: 0.34, breath: 0.9, swayX: 0.18, swayY: 0.28, roll: 0.32, eyeOpen: 0.56, eyeWidth: 0.96, eyeY: 0.9, eyeTilt: 7.5, gazeWander: 0.12, mouth: -0.66, blinkRate: 0.96 });
-const SHY = p({ ...SAD, energy: 0.34, eyeOpen: 0.62, eyeTilt: 6, gazeWander: 0.28, mouth: 0.2, cheek: 0.92, blinkRate: 1.14 });
-const ANGRY = p({ energy: 1.06, pace: 1.82, breath: 0.32, swayX: 1.25, swayY: 0.2, roll: 3.6, eyeOpen: 0.56, eyeWidth: 1.08, eyeTilt: -12, gazeWander: 0.02, mouth: -0.3, blinkRate: 0.54, accent: "alert" });
-const ALERT = p({ ...ANGRY, energy: 1.12, eyeOpen: 0.72, eyeTilt: -10 });
-const SCARED = p({ energy: 1.16, pace: 1.92, breath: 0.28, swayX: 1.42, swayY: 0.5, roll: 4.4, eyeOpen: 1.32, eyeWidth: 0.92, gazeWander: 0.12, roundMouth: 0.58, blinkRate: 0.5, accent: "alert" });
-const ORBIT = p({ energy: 0.68, pace: 1.06, breath: 0.48, swayX: 0.74, swayY: 0.62, roll: 1.7, eyeOpen: 0.82, gazeWander: 0.66, blinkRate: 0.68, accent: "orbit" });
-const RADAR = p({ energy: 0.76, pace: 1.28, breath: 0.4, swayX: 0.36, swayY: 0.3, roll: 0.8, eyeOpen: 0.9, gazeWander: 0.84, blinkRate: 0.58, accent: "radar" });
-const PROGRESS = p({ energy: 0.58, pace: 0.94, breath: 0.44, swayX: 0.28, swayY: 0.32, roll: 0.65, eyeOpen: 0.78, gazeWander: 0.1, blinkRate: 0.64, accent: "progress" });
-const POWER_DOWN = p({ ...SLEEP, energy: 0.04, pace: 0.16, eyeOpen: 0.05, eyeY: 1.6 });
-
-function profileForState(state: string): MotionProfile {
-  switch (state) {
-    case "sleeping": return SLEEP;
-    case "waking": case "spawning": return WAKE;
-    case "listening": case "dictating": case "humming": return LISTEN;
-    case "thinking": return THINK;
-    case "searching": case "loading": return SEARCH;
-    case "working": case "tool-running": case "writing": case "sending": case "receiving": case "uploading": case "notifying": case "dragging": return WORK;
-    case "speaking": return p({ ...LISTEN, energy: 0.72, pace: 1.18, mouth: 0.72, eyeSmile: 0.18 });
-    case "result": return p({ ...JOY, energy: 0.74, pace: 0.82, bounce: 0.28, mouth: 0.42 });
-    case "error": return p({ ...ALERT, energy: 0.96, pace: 1.42, eyeTilt: -8, mouth: -0.46 });
-    case "happy": case "laughing": case "celebrate": case "proud": return JOY;
-    case "excited": case "playful": case "bouncing": return EXCITED;
-    case "surprised": return SURPRISED;
-    case "drowsy": case "bored": return LOW;
-    case "curious": return CURIOUS;
-    case "suspicious": case "confused": return SUSPICIOUS;
-    case "sad": return SAD;
-    case "shy": return SHY;
-    case "angry": return ANGRY;
-    case "alerting": return ALERT;
-    case "scared": return SCARED;
-    case "orbit": return ORBIT;
-    case "radar": return RADAR;
-    case "progress": return PROGRESS;
-    case "powering-down": return POWER_DOWN;
-    default: return BASE;
-  }
-}
-
-export function fabushiAccentForState(state: string): "none" | "orbit" | "pulse" | "alert" {
-  const accent = profileForState(state).accent;
-  if (accent === "radar" || accent === "progress") return "orbit";
-  return accent;
-}
-
-type SpringChannel = { value: number; velocity: number };
-const channel = (value: number): SpringChannel => ({ value, velocity: 0 });
-
-function springStep(spring: SpringChannel, target: number, dt: number, stiffness = 92, damping = 17): void {
-  // Ambient marks are intentionally dispatched as slowly as 8 fps. Feeding
-  // that entire frame gap into a semi-implicit spring makes the high-energy
-  // profiles numerically unstable after a busy or throttled browser frame.
-  // Integrate bounded substeps so a delayed frame converges instead of
-  // producing an ever-growing SVG transform.
-  const steps = Math.max(1, Math.ceil(dt / (1 / 60)));
-  const stepSeconds = dt / steps;
-  for (let step = 0; step < steps; step += 1) {
-    const acceleration = (target - spring.value) * stiffness - spring.velocity * damping;
-    spring.velocity += acceleration * stepSeconds;
-    spring.value += spring.velocity * stepSeconds;
-  }
-}
-
-function eyeLensPath(cx: number, cy: number, width: number, height: number, smile: number): string {
-  const hw = Math.max(0.8, width / 2);
-  const hh = Math.max(0.42, height / 2);
-  const left = cx - hw;
-  const right = cx + hw;
-  const top = hh * (1 - smile * 0.12);
-  const bottom = Math.max(0.36, hh * (1 - smile * 0.58));
-  const lift = smile * hh * 0.72;
-  return `M${left.toFixed(2)} ${cy.toFixed(2)} C${(left + hw * 0.28).toFixed(2)} ${(cy - top).toFixed(2)} ${(right - hw * 0.28).toFixed(2)} ${(cy - top + lift * 0.12).toFixed(2)} ${right.toFixed(2)} ${cy.toFixed(2)} C${(right - hw * 0.28).toFixed(2)} ${(cy + bottom - lift).toFixed(2)} ${(left + hw * 0.28).toFixed(2)} ${(cy + bottom - lift).toFixed(2)} ${left.toFixed(2)} ${cy.toFixed(2)}Z`;
-}
-
-function normalizedGazeForPoint(element: SVGSVGElement, point: Point): Point {
-  const rect = element.getBoundingClientRect();
-  const halfWidth = Math.max(1, rect.width / 2);
-  const halfHeight = Math.max(1, rect.height / 2);
-  return {
-    x: clamp((point.x - (rect.left + halfWidth)) / halfWidth, -1, 1),
-    y: clamp((point.y - (rect.top + halfHeight)) / halfHeight, -1, 1),
-  };
-}
-
-function blinkAmountForTime(startedAt: number, timeMs: number): number {
-  if (startedAt <= 0) return 0;
-  const progress = (timeMs - startedAt) / 118;
-  if (progress <= 0 || progress >= 1) return 0;
-  if (progress < 0.38) {
-    const close = progress / 0.38;
-    return 1 - (1 - close) * (1 - close);
-  }
-  const open = (progress - 0.38) / 0.62;
-  return 1 - open * open;
-}
-
-type PhysicsState = {
-  x: SpringChannel; y: SpringChannel; roll: SpringChannel;
-  scaleX: SpringChannel; scaleY: SpringChannel;
-  gazeX: SpringChannel; gazeY: SpringChannel;
-  eyeOpen: SpringChannel; eyeWidth: SpringChannel; eyeY: SpringChannel;
-  eyeTilt: SpringChannel; eyeSmile: SpringChannel;
-  mouth: SpringChannel; roundMouth: SpringChannel; cheek: SpringChannel;
-  spin: SpringChannel; spinTarget: number;
-  bounceY: SpringChannel; burst: SpringChannel;
-  nextBlinkAt: number; blinkStartedAt: number;
-  queuedSecondBlink: boolean; forceSecondBlink: boolean; randomCounter: number;
-};
-
-function createPhysics(): PhysicsState {
-  return {
-    x: channel(0), y: channel(0), roll: channel(0), scaleX: channel(1), scaleY: channel(1),
-    gazeX: channel(0), gazeY: channel(0), eyeOpen: channel(BASE.eyeOpen), eyeWidth: channel(1),
-    eyeY: channel(0), eyeTilt: channel(0), eyeSmile: channel(0), mouth: channel(0),
-    roundMouth: channel(0), cheek: channel(0), spin: channel(0), spinTarget: 0,
-    bounceY: channel(0), burst: channel(0), nextBlinkAt: 0, blinkStartedAt: 0,
-    queuedSecondBlink: false, forceSecondBlink: false, randomCounter: 0,
-  };
-}
-
-export const FabushiBotMarkEngine = forwardRef<FabushiBotMarkEngineHandle, FabushiBotMarkEngineProps>(
-  function FabushiBotMarkEngine(
-    {
-      botId,
-      state,
-      size,
-      shapePath,
-      shapeScale = 1,
-      gazeTarget = null,
-      followPointer = false,
-      emphasis = false,
-      spinSignal = 0,
-      badgeColor,
-      paused = false,
-      pose,
-      poseHome,
-      faceTune,
-      eyeScale = 1,
-      uniformEyes = true,
-      eyeTopology = true,
-      inkGradient = null,
-    },
-    ref,
-  ) {
-    const svgRef = useRef<SVGSVGElement | null>(null);
-    const bodyRef = useRef<SVGGElement | null>(null);
-    const leftEyeRef = useRef<SVGPathElement | null>(null);
-    const rightEyeRef = useRef<SVGPathElement | null>(null);
-    const topologyRef = useRef<SVGPathElement | null>(null);
-    const mouthRef = useRef<SVGPathElement | null>(null);
-    const roundMouthRef = useRef<SVGCircleElement | null>(null);
-    const leftCheekRef = useRef<SVGCircleElement | null>(null);
-    const rightCheekRef = useRef<SVGCircleElement | null>(null);
-    const accentRingRef = useRef<SVGCircleElement | null>(null);
-    const radarSweepRef = useRef<SVGLineElement | null>(null);
-    const burstRingRef = useRef<SVGCircleElement | null>(null);
-    const surfaceGradientRef = useRef<SVGRadialGradientElement | null>(null);
-    const thoughtDotsRef = useRef<Array<SVGCircleElement | null>>([]);
-    const physicsRef = useRef<PhysicsState>(createPhysics());
-    const pointerGazeRef = useRef<Point | null>(null);
-    const externalGazeRef = useRef<Point | null>(null);
-    const visibleRef = useRef(true);
-    const reducedMotionRef = useRef(false);
-    const lastSpinSignalRef = useRef(spinSignal);
-    const seed = useMemo(() => hashMotionIdentity(`motion:${botId}`), [botId]);
-    const rhythm = useMemo(() => fabushiRhythmForBot(botId), [botId]);
-    const uniqueId = useId().replace(/:/g, "");
-    const clipId = `fabushi-mark-clip-${uniqueId}`;
-    const surfaceId = `fabushi-mark-surface-${uniqueId}`;
-    const shadeId = `fabushi-mark-shade-${uniqueId}`;
-    const inkId = `fabushi-mark-ink-${uniqueId}`;
-    const depthId = `fabushi-mark-depth-${uniqueId}`;
-
-    const propsRef = useRef({
-      state,
-      shapeScale,
-      emphasis,
-      paused,
-      pose,
-      poseHome,
-      faceTune,
-      eyeScale,
-      uniformEyes,
-      eyeTopology,
-    });
-    propsRef.current = {
-      state,
-      shapeScale,
-      emphasis,
-      paused,
-      pose,
-      poseHome,
-      faceTune,
-      eyeScale,
-      uniformEyes,
-      eyeTopology,
+  corner(previous: Point, current: Point, next: Point, radius: number) {
+    const unit = (from: Point, to: Point): Point => {
+      const x = from[0] - to[0], y = from[1] - to[1], length = Math.hypot(x, y) || 1;
+      return [x / length, y / length];
     };
+    const before = unit(previous, current), after = unit(next, current);
+    const start: Point = [current[0] + before[0] * radius, current[1] + before[1] * radius];
+    const end: Point = [current[0] + after[0] * radius, current[1] + after[1] * radius];
+    if (this.d) this.line(start[0], start[1]); else this.move(start[0], start[1]);
+    this.d += `Q${round2(current[0])} ${round2(current[1])} ${round2(end[0])} ${round2(end[1])}`;
+    this.x = end[0]; this.y = end[1]; return this;
+  }
+  arc(cx: number, cy: number, rx: number, ry: number, start: number, end: number) {
+    const segments = Math.max(1, Math.ceil(Math.abs(end - start) / (Math.PI / 2)));
+    const step = (end - start) / segments;
+    const control = 4 / 3 * Math.tan(step / 4);
+    let angle = start;
+    for (let index = 0; index < segments; index += 1) {
+      const nextAngle = angle + step;
+      const from: Point = [cx + rx * Math.cos(angle), cy + ry * Math.sin(angle)];
+      const to: Point = [cx + rx * Math.cos(nextAngle), cy + ry * Math.sin(nextAngle)];
+      this.curve(from[0] - control * rx * Math.sin(angle), from[1] + control * ry * Math.cos(angle), to[0] + control * rx * Math.sin(nextAngle), to[1] - control * ry * Math.cos(nextAngle), to[0], to[1]);
+      angle = nextAngle;
+    }
+    return this;
+  }
+  close() { return `${this.d}Z`; }
+}
 
-    useImperativeHandle(ref, () => ({
-      spin(turns = 1) {
-        physicsRef.current.spinTarget += clamp(turns, -4, 4) * 360;
-      },
-      bounce() {
-        const physics = physicsRef.current;
-        physics.bounceY.velocity -= 26;
-        physics.burst.value = Math.max(physics.burst.value, 0.24);
-      },
-      burst() {
-        const physics = physicsRef.current;
-        physics.burst.value = 1;
-        physics.burst.velocity = 0;
-      },
-    }), []);
+function sampledPath(generator: (angle: number) => Point, count = 128): string {
+  const points: Point[] = [];
+  for (let index = 0; index < count; index += 1) points.push(generator(index / count * TAU));
+  return smoothPath(points);
+}
 
-    useEffect(() => {
-      if (lastSpinSignalRef.current !== spinSignal) {
-        if (spinSignal !== 0) physicsRef.current.spinTarget += 360;
-        lastSpinSignalRef.current = spinSignal;
-      }
-    }, [spinSignal]);
+function roundedPolygon(radius: number, sides: number, cornerRadius: number, start = 0): string {
+  const points = Array.from({ length: sides }, (_, index): Point => {
+    const angle = start + index / sides * TAU;
+    return [CENTER + Math.cos(angle) * radius, CENTER + Math.sin(angle) * radius];
+  });
+  const path = new ArtifactPath();
+  for (let index = 0; index < sides; index += 1) path.corner(points[(index - 1 + sides) % sides], points[index], points[(index + 1) % sides], cornerRadius);
+  return path.close();
+}
 
-    useEffect(() => {
-      const media = window.matchMedia?.("(prefers-reduced-motion: reduce)");
-      if (!media) return undefined;
-      const sync = () => { reducedMotionRef.current = media.matches; };
-      sync();
-      media.addEventListener?.("change", sync);
-      return () => media.removeEventListener?.("change", sync);
-    }, []);
+function cloudPath(points: readonly [number, number, number][], count = 160): string {
+  return sampledPath((angle) => {
+    const cos = Math.cos(angle), sin = Math.sin(angle);
+    let radius = 0;
+    for (const [x, y, circleRadius] of points) {
+      const dx = x - CENTER, dy = y - CENTER, projection = cos * dx + sin * dy;
+      const discriminant = projection * projection - (dx * dx + dy * dy) + circleRadius * circleRadius;
+      if (discriminant > 0) radius = Math.max(radius, projection + Math.sqrt(discriminant));
+    }
+    return [CENTER + cos * radius, CENTER + sin * radius];
+  }, count);
+}
 
-    useEffect(() => {
-      const element = svgRef.current;
-      if (!element || typeof IntersectionObserver === "undefined") return undefined;
-      const observer = new IntersectionObserver((entries) => {
-        visibleRef.current = entries.some((entry) => entry.isIntersecting);
-      }, { rootMargin: "120px" });
-      observer.observe(element);
-      return () => observer.disconnect();
-    }, []);
+function squirclePath(width: number, height: number, exponent: number): string {
+  return sampledPath((angle) => {
+    const cos = Math.cos(angle), sin = Math.sin(angle);
+    return [CENTER + Math.sign(cos) * Math.pow(Math.abs(cos), 2 / exponent) * width, CENTER + Math.sign(sin) * Math.pow(Math.abs(sin), 2 / exponent) * height];
+  });
+}
 
-    useEffect(() => {
-      if (followPointer) return undefined;
-      const element = svgRef.current;
-      if (!element || !gazeTarget) {
-        externalGazeRef.current = null;
-        return undefined;
-      }
-      externalGazeRef.current = normalizedGazeForPoint(element, gazeTarget);
-      return undefined;
-    }, [followPointer, gazeTarget]);
+function tabletPath(width: number, height: number): string {
+  return new ArtifactPath().move(CENTER - width + height, CENTER - height).line(CENTER + width - height, CENTER - height)
+    .arc(CENTER + width - height, CENTER, height, height, -Math.PI / 2, Math.PI / 2).line(CENTER - width + height, CENTER + height)
+    .arc(CENTER - width + height, CENTER, height, height, Math.PI / 2, Math.PI * 3 / 2).close();
+}
 
-    useEffect(() => {
-      if (!followPointer) {
-        pointerGazeRef.current = null;
-        return undefined;
-      }
-      const onPointerMove = (event: PointerEvent) => {
-        const element = svgRef.current;
-        if (!element) return;
-        pointerGazeRef.current = normalizedGazeForPoint(element, { x: event.clientX, y: event.clientY });
+function teardropPath(width: number, top: number, bottom: number, cornerRadius: number): string {
+  const ratio = clamp(width / (bottom - top), -1, 1), height = Math.sqrt(1 - ratio * ratio);
+  const right: Point = [CENTER + width * height, bottom - width * ratio];
+  const left: Point = [CENTER - width * height, bottom - width * ratio];
+  const angle = Math.atan2(right[1] - bottom, right[0] - CENTER);
+  return new ArtifactPath().corner(right, [CENTER, top], left, cornerRadius).line(left[0], left[1]).arc(CENTER, bottom, width, width, Math.PI - angle, angle).close();
+}
+
+function pathSamples(path: string): Point[] {
+  const tokens = path.match(/[MLCQZmlcqz]|-?\d*\.?\d+(?:e[-+]?\d+)?/gi) ?? [];
+  const samples: Point[] = [];
+  let index = 0, command = "", startX = 0, startY = 0, x = 0, y = 0;
+  const number = () => Number(tokens[index++]);
+  const addLine = (toX: number, toY: number) => {
+    const length = Math.hypot(toX - x, toY - y), count = Math.max(2, Math.ceil(length / 4));
+    for (let step = 1; step <= count; step += 1) samples.push([x + (toX - x) * step / count, y + (toY - y) * step / count]);
+    x = toX; y = toY;
+  };
+  while (index < tokens.length) {
+    if (/^[a-z]$/i.test(tokens[index])) command = tokens[index++].toUpperCase();
+    if (command === "Z") { addLine(startX, startY); continue; }
+    if (command === "M") { x = number(); y = number(); startX = x; startY = y; samples.push([x, y]); command = "L"; continue; }
+    if (command === "L") { addLine(number(), number()); continue; }
+    if (command === "Q") {
+      const x1 = number(), y1 = number(), endX = number(), endY = number(), fromX = x, fromY = y;
+      const count = Math.max(2, Math.ceil((Math.hypot(x1 - x, y1 - y) + Math.hypot(endX - x1, endY - y1)) / 4));
+      for (let step = 1; step <= count; step += 1) { const t = step / count, inverse = 1 - t; samples.push([inverse * inverse * fromX + 2 * inverse * t * x1 + t * t * endX, inverse * inverse * fromY + 2 * inverse * t * y1 + t * t * endY]); }
+      x = endX; y = endY; continue;
+    }
+    if (command === "C") {
+      const x1 = number(), y1 = number(), x2 = number(), y2 = number(), endX = number(), endY = number(), fromX = x, fromY = y;
+      const count = Math.max(2, Math.ceil((Math.hypot(x1 - x, y1 - y) + Math.hypot(x2 - x1, y2 - y1) + Math.hypot(endX - x2, endY - y2)) / 4));
+      for (let step = 1; step <= count; step += 1) { const t = step / count, inverse = 1 - t; samples.push([inverse ** 3 * fromX + 3 * inverse ** 2 * t * x1 + 3 * inverse * t ** 2 * x2 + t ** 3 * endX, inverse ** 3 * fromY + 3 * inverse ** 2 * t * y1 + 3 * inverse * t ** 2 * y2 + t ** 3 * endY]); }
+      x = endX; y = endY; continue;
+    }
+    index += 1;
+  }
+  return samples;
+}
+
+function normalizeArtifactPath(path: string): string {
+  const samples = pathSamples(path);
+  const xs = samples.map(([x]) => x), ys = samples.map(([, y]) => y);
+  const minX = Math.min(...xs), maxX = Math.max(...xs), minY = Math.min(...ys), maxY = Math.max(...ys);
+  const offsetX = CENTER - (minX + maxX) / 2, offsetY = CENTER - (minY + maxY) / 2;
+  const scale = clamp(228.44 / Math.max(maxX - minX, maxY - minY), 0.9, 1.35);
+  if (Math.abs(scale - 1) < 0.005 && Math.abs(offsetX) < 0.5 && Math.abs(offsetY) < 0.5) return path;
+  let numberIndex = 0;
+  return path.replace(/-?\d*\.?\d+(?:e[-+]?\d+)?/gi, (value) => {
+    const coordinate = Number(value) + (numberIndex++ % 2 === 0 ? offsetX : offsetY);
+    return String(round2(CENTER + (coordinate - CENTER) * scale));
+  });
+}
+
+const SHAPE_PATHS: Record<BotMarkShape, string> = {
+  blob: normalizeArtifactPath(BLOB_PATH),
+  pebble: normalizeArtifactPath(sampledPath((angle) => { const radius = 108 * (1 + 0.075 * (Math.sin(angle * 2 + 1.1) * 0.6 + Math.sin(angle * 3 - 1.1) * 0.4)); return [CENTER + Math.cos(angle) * radius, CENTER + Math.sin(angle) * radius * 0.98]; })),
+  squircle: normalizeArtifactPath(squirclePath(107, 107, 4.2)),
+  tablet: normalizeArtifactPath(tabletPath(114, 74)),
+  wedge: normalizeArtifactPath(roundedPolygon(130, 3, 60, -Math.PI / 2)),
+  hex: normalizeArtifactPath(roundedPolygon(114, 6, 20, Math.PI / 6)),
+  cloud: normalizeArtifactPath(cloudPath([[CENTER - 62, CENTER + 26, 56], [CENTER + 62, CENTER + 26, 54], [CENTER, CENTER + 34, 62], [CENTER - 24, CENTER - 30, 62], [CENTER + 38, CENTER - 26, 54]])),
+  teardrop: normalizeArtifactPath(teardropPath(88, CENTER - 114, CENTER + 26, 18)),
+};
+
+const MOTION: Record<BotMarkState, { amplitude: number; period: number; tilt: number; eye: number }> = {
+  sleeping: { amplitude: 0, period: 6000, tilt: 0, eye: 0.12 }, waking: { amplitude: 2, period: 800, tilt: 0, eye: 0.35 }, idle: { amplitude: 1.5, period: 9000, tilt: 0, eye: 1 }, listening: { amplitude: 1.8, period: 2800, tilt: -2, eye: 1 },
+  thinking: { amplitude: 1, period: 2000, tilt: 3, eye: 0.75 }, searching: { amplitude: 2, period: 1000, tilt: -4, eye: 0.9 }, working: { amplitude: 2, period: 1800, tilt: -3, eye: 1 }, loading: { amplitude: 2, period: 6000, tilt: 3, eye: 0.9 },
+  "tool-running": { amplitude: 2, period: 1800, tilt: -3, eye: 1 }, "speaking": { amplitude: 2, period: 4000, tilt: 0, eye: 1 }, "result": { amplitude: 3, period: 2500, tilt: 0, eye: 1.08 }, "error": { amplitude: 2, period: 2000, tilt: 0, eye: 1.1 },
+  excited: { amplitude: 5, period: 1100, tilt: 0, eye: 1.08 }, surprised: { amplitude: 3, period: 2500, tilt: 0, eye: 1.18 }, suspicious: { amplitude: 1, period: 2600, tilt: 7, eye: 0.75 }, angry: { amplitude: 1, period: 2200, tilt: -7, eye: 0.65 }, drowsy: { amplitude: 0.5, period: 4000, tilt: 0, eye: 0.25 },
+  happy: { amplitude: 3, period: 2500, tilt: 0, eye: 1.08 }, curious: { amplitude: 2, period: 1800, tilt: 6, eye: 1 }, confused: { amplitude: 1, period: 2200, tilt: -5, eye: 0.8 }, bored: { amplitude: 0.4, period: 3500, tilt: -8, eye: 0.45 }, proud: { amplitude: 2, period: 3500, tilt: 4, eye: 1 }, shy: { amplitude: 1, period: 3000, tilt: -8, eye: 0.55 }, sad: { amplitude: 1, period: 4000, tilt: -4, eye: 0.6 }, laughing: { amplitude: 4, period: 1200, tilt: 0, eye: 0.8 }, scared: { amplitude: 3, period: 900, tilt: 0, eye: 1.1 }, playful: { amplitude: 4, period: 1500, tilt: 8, eye: 1.05 }, celebrate: { amplitude: 7, period: 1400, tilt: 0, eye: 1.12 },
+  orbit: { amplitude: 2, period: 4000, tilt: 12, eye: 1 }, radar: { amplitude: 2, period: 4000, tilt: -12, eye: 1 }, progress: { amplitude: 2, period: 4000, tilt: 0, eye: 1 }, spawning: { amplitude: 5, period: 1200, tilt: 0, eye: 1 }, humming: { amplitude: 1.5, period: 5000, tilt: 0, eye: 0.9 }, dictating: { amplitude: 2, period: 4000, tilt: 0, eye: 1 }, writing: { amplitude: 2, period: 4000, tilt: -4, eye: 1 }, sending: { amplitude: 2, period: 4000, tilt: 0, eye: 1 }, receiving: { amplitude: 2, period: 4000, tilt: 0, eye: 1 }, uploading: { amplitude: 2, period: 4000, tilt: 0, eye: 1 }, notifying: { amplitude: 3, period: 1500, tilt: 0, eye: 1.1 }, alerting: { amplitude: 2, period: 2000, tilt: 0, eye: 1.1 }, dragging: { amplitude: 3, period: 1600, tilt: 5, eye: 1 }, bouncing: { amplitude: 7, period: 3000, tilt: 0, eye: 1 }, "powering-down": { amplitude: 0, period: 6000, tilt: 0, eye: 0.12 },
+};
+
+function reducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+}
+
+export const FabushiBotMarkEngine = forwardRef<BotMarkHandle, FabushiBotMarkEngineProps>(function FabushiBotMarkEngine({ botId, state, size, shape, color, gazeTarget = null, followPointer = false, emphasis = false, spinSignal = 0, badgeColor, paused = false, eyeColor }, ref) {
+  const id = useId().replace(/:/g, "");
+  const faceRef = useRef<SVGGElement>(null);
+  const eyesRef = useRef<SVGGElement>(null);
+  const gazeRef = useRef({ x: 0, y: 0 });
+  const actionRef = useRef<"spin" | "bounce" | "burst" | null>(null);
+  const motion = MOTION[state] ?? MOTION.idle;
+  const colors = COLORS[color] ?? COLORS.black;
+
+  useImperativeHandle(ref, () => ({
+    spin: () => { actionRef.current = "spin"; },
+    bounce: () => { actionRef.current = "bounce"; },
+    burst: () => { actionRef.current = "burst"; },
+  }), []);
+
+  useEffect(() => {
+    if ((!followPointer && gazeTarget == null) || typeof window === "undefined") return;
+    const updateGaze = (point: GazePoint) => {
+      const node = faceRef.current?.ownerSVGElement;
+      const rect = node?.getBoundingClientRect();
+      if (rect == null || rect.width === 0 || rect.height === 0) return;
+      gazeRef.current = {
+        x: clamp((point.x - (rect.left + rect.width / 2)) / (rect.width / 2), -1, 1),
+        y: clamp((point.y - (rect.top + rect.height / 2)) / (rect.height / 2), -1, 1),
       };
-      const onPointerLeave = () => { pointerGazeRef.current = null; };
+    };
+    const onPointerMove = (event: PointerEvent) => updateGaze({ x: event.clientX, y: event.clientY });
+    const clearPointer = () => { gazeRef.current = { x: 0, y: 0 }; };
+    if (followPointer) {
       window.addEventListener("pointermove", onPointerMove, { passive: true });
-      document.documentElement.addEventListener("pointerleave", onPointerLeave);
-      return () => {
-        window.removeEventListener("pointermove", onPointerMove);
-        document.documentElement.removeEventListener("pointerleave", onPointerLeave);
-      };
-    }, [followPointer]);
+      document.documentElement.addEventListener("pointerleave", clearPointer);
+    }
+    if (gazeTarget != null) updateGaze(gazeTarget);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      document.documentElement.removeEventListener("pointerleave", clearPointer);
+      clearPointer();
+    };
+  }, [followPointer, gazeTarget]);
 
-    useEffect(() => {
-      const phaseA = seededUnit(seed, 10) * Math.PI * 2;
-      const phaseB = seededUnit(seed, 11) * Math.PI * 2;
-      const phaseC = seededUnit(seed, 12) * Math.PI * 2;
-      const phaseD = seededUnit(seed, 13) * Math.PI * 2;
-      let lastEngineFrameMs = 0;
+  useEffect(() => {
+    const face = faceRef.current, eyes = eyesRef.current;
+    if (spinSignal > 0) actionRef.current = "spin";
+    if (face == null || eyes == null || reducedMotion() || paused) return;
+    let frame = 0;
+    const started = performance.now();
+    const tick = (time: number) => {
+      const elapsed = time - started;
+      const action = actionRef.current;
+      const phase = elapsed / motion.period * Math.PI * 2;
+      const bounce = action === "bounce" ? Math.max(0, 1 - (elapsed % 700) / 700) * 8 : 0;
+      const spin = action === "spin" ? (elapsed % 1000) / 1000 * 360 : 0;
+      const bob = Math.sin(phase) * motion.amplitude;
+      const gaze = gazeRef.current;
+      face.setAttribute("transform", `translate(0 ${-bob - bounce}) rotate(${motion.tilt + spin} ${CENTER} ${CENTER})`);
+      eyes.setAttribute("transform", `translate(${gaze.x * 4} ${gaze.y * 3}) scale(1 ${motion.eye})`);
+      if (action === "bounce" && bounce === 0) actionRef.current = null;
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [motion, paused, spinSignal, state]);
 
-      return subscribeMotionFrame((timeMs, deltaSeconds) => {
-        if (!visibleRef.current) return;
+  const background = eyeColor ?? "var(--bot-mark-eye-color, var(--app, #fff))";
+  const rootStyle: CSSProperties = { display: "block", height: size, overflow: "visible", userSelect: "none", WebkitUserSelect: "none", width: size };
+  const eyeHeight = state === "sleeping" ? 2 : 7;
 
-        const currentProps = propsRef.current;
-        if (currentProps.paused) return;
-        const ambient = !currentProps.emphasis && !followPointer && AMBIENT_MOTION_STATES.has(currentProps.state);
-        const minimumIntervalMs = ambient ? AMBIENT_MOTION_FRAME_INTERVAL_MS : MOTION_FRAME_INTERVAL_MS;
-        if (lastEngineFrameMs && timeMs - lastEngineFrameMs < minimumIntervalMs) return;
-        const localDeltaSeconds = lastEngineFrameMs
-          ? Math.min(0.14, Math.max(1 / 120, (timeMs - lastEngineFrameMs) / 1000))
-          : deltaSeconds;
-        lastEngineFrameMs = timeMs;
-
-        const profileValue = profileForState(currentProps.state);
-        const physics = physicsRef.current;
-        const timeSeconds = timeMs / 1000;
-        const reduced = reducedMotionRef.current;
-        const continuousMotion = reduced ? 0 : 1;
-        const springDelta = localDeltaSeconds;
-
-        const baseWave = Math.sin(timeSeconds * (0.86 + profileValue.pace * 0.12) + phaseA);
-        const secondaryWave = Math.sin(timeSeconds * (1.37 + profileValue.pace * 0.22) + phaseB);
-        const taskWave = Math.sin(timeSeconds * (2.1 + profileValue.pace * 1.14) + phaseC);
-        const organic = baseWave * 0.62 + secondaryWave * 0.26 + Math.sin(timeSeconds * 0.43 + phaseD) * 0.12;
-        const alertJitter = profileValue.accent === "alert" ? Math.sin(timeSeconds * 21 + phaseB) : 0;
-        const joyLift = profileValue.bounce > 0
-          ? Math.max(0, Math.sin(timeSeconds * (2.5 + profileValue.pace * 1.4) + phaseC)) * profileValue.bounce
-          : 0;
-
-        springStep(
-          physics.x,
-          continuousMotion * (organic * profileValue.swayX * profileValue.energy + taskWave * profileValue.swayX * 0.3 + alertJitter * 1.35),
-          springDelta,
-          72 + profileValue.energy * 34,
-          15,
-        );
-        springStep(
-          physics.y,
-          continuousMotion * (-profileValue.breath * (0.35 + baseWave * 0.28) + secondaryWave * profileValue.swayY * 0.42 - joyLift * 2.6),
-          springDelta,
-          78 + profileValue.energy * 30,
-          15,
-        );
-        springStep(
-          physics.roll,
-          continuousMotion * (organic * profileValue.roll + taskWave * profileValue.roll * 0.36 + alertJitter * 2.2),
-          springDelta,
-          74 + profileValue.energy * 42,
-          16,
-        );
-        springStep(physics.bounceY, 0, springDelta, 126, 15.5);
-        springStep(physics.burst, 0, springDelta, 78, 19);
-        physics.burst.value = clamp(physics.burst.value, -0.03, 1.2);
-
-        const homePose = ["idle", "sleeping", "drowsy", "powering-down"].includes(currentProps.state)
-          ? currentProps.poseHome
-          : currentProps.pose;
-        const poseScale = clamp((homePose?.scale ?? 1) * currentProps.shapeScale, 0.76, 1.28);
-        const turn = clamp(homePose?.turn ?? 0, -70, 70);
-        const tilt = clamp(homePose?.tilt ?? 0, -50, 50);
-        const staticRoll = (homePose?.roll ?? 0) * 0.16;
-        const perspectiveX = 1 - Math.abs(turn) / 420;
-        const perspectiveY = 1 - Math.abs(tilt) / 680;
-        const breathingScale = continuousMotion * baseWave * profileValue.breath * 0.008;
-        const taskSquash = continuousMotion * taskWave * profileValue.bounce * 0.012;
-        const burstScale = Math.max(0, physics.burst.value) * 0.075;
-        springStep(physics.scaleX, poseScale * perspectiveX * (1 + breathingScale + taskSquash + burstScale), springDelta, 96, 18);
-        springStep(physics.scaleY, poseScale * perspectiveY * (1 - breathingScale * 0.72 - taskSquash * 0.56 + burstScale), springDelta, 96, 18);
-        springStep(physics.spin, physics.spinTarget, springDelta, 48, 13.5);
-
-        const directGaze = followPointer ? pointerGazeRef.current : externalGazeRef.current;
-        const wander = continuousMotion * profileValue.gazeWander;
-        const gazeTargetX = directGaze?.x
-          ?? (Math.sin(timeSeconds * 0.54 + phaseB) * 0.62 + Math.sin(timeSeconds * 0.23 + phaseD) * 0.38) * wander;
-        const gazeTargetY = directGaze?.y
-          ?? (Math.sin(timeSeconds * 0.41 + phaseC) * 0.72 + Math.cos(timeSeconds * 0.19 + phaseA) * 0.28) * wander * 0.7;
-        springStep(physics.gazeX, clamp(gazeTargetX, -1, 1), springDelta, directGaze ? 118 : 46, directGaze ? 20 : 13);
-        springStep(physics.gazeY, clamp(gazeTargetY, -1, 1), springDelta, directGaze ? 118 : 46, directGaze ? 20 : 13);
-
-        springStep(physics.eyeOpen, profileValue.eyeOpen, springDelta, 118, 20);
-        springStep(physics.eyeWidth, profileValue.eyeWidth, springDelta, 104, 19);
-        springStep(physics.eyeY, profileValue.eyeY, springDelta, 94, 18);
-        springStep(physics.eyeTilt, profileValue.eyeTilt, springDelta, 104, 18);
-        springStep(physics.eyeSmile, profileValue.eyeSmile, springDelta, 104, 19);
-        springStep(physics.mouth, profileValue.mouth, springDelta, 96, 18);
-        springStep(physics.roundMouth, profileValue.roundMouth, springDelta, 96, 18);
-        springStep(physics.cheek, profileValue.cheek, springDelta, 88, 17);
-
-        if (!currentProps.paused && !reduced && profileValue.blinkRate > 0) {
-          if (physics.nextBlinkAt === 0) {
-            physics.randomCounter += 1;
-            physics.nextBlinkAt = timeMs + rhythm.blinkMs * (0.72 + seededUnit(seed, physics.randomCounter) * 0.62) / profileValue.blinkRate;
-          }
-          if (physics.blinkStartedAt === 0 && timeMs >= physics.nextBlinkAt) {
-            physics.blinkStartedAt = timeMs;
-            if (!physics.forceSecondBlink) {
-              physics.randomCounter += 1;
-              physics.queuedSecondBlink = seededUnit(seed, physics.randomCounter) > 0.84;
-            }
-          }
-          if (physics.blinkStartedAt > 0 && timeMs - physics.blinkStartedAt > 118) {
-            physics.blinkStartedAt = 0;
-            if (physics.queuedSecondBlink) {
-              physics.queuedSecondBlink = false;
-              physics.forceSecondBlink = true;
-              physics.nextBlinkAt = timeMs + 150;
-            } else {
-              physics.forceSecondBlink = false;
-              physics.randomCounter += 1;
-              physics.nextBlinkAt = timeMs + rhythm.blinkMs * (0.68 + seededUnit(seed, physics.randomCounter) * 0.74) / profileValue.blinkRate;
-            }
-          }
-        } else {
-          physics.blinkStartedAt = 0;
-          physics.nextBlinkAt = 0;
-          physics.queuedSecondBlink = false;
-          physics.forceSecondBlink = false;
-        }
-
-        const blink = blinkAmountForTime(physics.blinkStartedAt, timeMs);
-        const faceScale = clamp((currentProps.faceTune?.size ?? 1) * currentProps.eyeScale, 0.66, 1.42);
-        const eyeGap = 17.2 * (currentProps.faceTune?.gap ?? 1) * faceScale;
-        const eyeWidth = 8.3 * physics.eyeWidth.value * (currentProps.faceTune?.eyeWidth ?? 1) * faceScale;
-        const eyeHeight = Math.max(0.72, 7.8 * physics.eyeOpen.value * (1 - blink * 0.9) * (currentProps.faceTune?.eyeHeight ?? 1) * (currentProps.faceTune?.height ?? 1) * faceScale);
-        const faceShiftX = turn * 0.035 + physics.gazeX.value * 3.2;
-        const eyeCenterY = 49 + tilt * 0.022 + physics.eyeY.value + physics.gazeY.value * 2.55;
-        const leftX = 50 - eyeGap / 2 + faceShiftX;
-        const rightX = 50 + eyeGap / 2 + faceShiftX;
-        const rightEyeScale = currentProps.uniformEyes ? 1 : 0.92;
-        const rightEyeHeightScale = currentProps.uniformEyes ? 1 : 1.07;
-
-        if (bodyRef.current) {
-          const centerX = 50 + physics.x.value;
-          const centerY = 50 + physics.y.value + physics.bounceY.value;
-          bodyRef.current.setAttribute(
-            "transform",
-            `translate(${centerX.toFixed(2)} ${centerY.toFixed(2)}) rotate(${(staticRoll + physics.roll.value + physics.spin.value).toFixed(2)}) skewY(${(turn * 0.052).toFixed(2)}) scale(${physics.scaleX.value.toFixed(4)} ${physics.scaleY.value.toFixed(4)}) translate(-50 -50)`,
-          );
-        }
-
-        if (leftEyeRef.current) {
-          leftEyeRef.current.setAttribute("d", eyeLensPath(leftX, eyeCenterY, eyeWidth, eyeHeight, physics.eyeSmile.value));
-          leftEyeRef.current.setAttribute("transform", `rotate(${physics.eyeTilt.value.toFixed(2)} ${leftX.toFixed(2)} ${eyeCenterY.toFixed(2)})`);
-        }
-        if (rightEyeRef.current) {
-          rightEyeRef.current.setAttribute("d", eyeLensPath(rightX, eyeCenterY, eyeWidth * rightEyeScale, eyeHeight * rightEyeHeightScale, physics.eyeSmile.value));
-          rightEyeRef.current.setAttribute("transform", `rotate(${physics.eyeTilt.value.toFixed(2)} ${rightX.toFixed(2)} ${eyeCenterY.toFixed(2)})`);
-        }
-        if (topologyRef.current) {
-          topologyRef.current.setAttribute("d", `M${(leftX + eyeWidth * 0.54).toFixed(2)} ${eyeCenterY.toFixed(2)} Q50 ${(eyeCenterY + 1.2 - physics.eyeSmile.value * 2.2).toFixed(2)} ${(rightX - eyeWidth * 0.54).toFixed(2)} ${eyeCenterY.toFixed(2)}`);
-          topologyRef.current.setAttribute("opacity", currentProps.eyeTopology ? (0.075 + profileValue.energy * 0.035).toFixed(3) : "0");
-        }
-        if (mouthRef.current) {
-          const amount = physics.mouth.value;
-          mouthRef.current.setAttribute("d", `M40.5 65.5 Q50 ${(66.5 + amount * 5.2).toFixed(2)} 59.5 65.5`);
-          mouthRef.current.setAttribute("opacity", clamp(Math.abs(amount) * 0.74, 0, 0.78).toFixed(3));
-        }
-        if (roundMouthRef.current) {
-          roundMouthRef.current.setAttribute("r", (1.3 + physics.roundMouth.value * 2.1).toFixed(2));
-          roundMouthRef.current.setAttribute("opacity", clamp(physics.roundMouth.value * 0.78, 0, 0.78).toFixed(3));
-        }
-        const cheekOpacity = clamp(physics.cheek.value * 0.52, 0, 0.52).toFixed(3);
-        leftCheekRef.current?.setAttribute("opacity", cheekOpacity);
-        rightCheekRef.current?.setAttribute("opacity", cheekOpacity);
-
-        const accent = profileValue.accent;
-        if (accentRingRef.current) {
-          const orbitPhase = timeSeconds * (1.4 + profileValue.pace * 0.38) + phaseA;
-          let radius = 43;
-          let opacity = currentProps.emphasis ? 0.22 : 0;
-          let dashArray = "none";
-          let dashOffset = 0;
-          let stroke = "var(--fg)";
-          if (accent === "pulse") {
-            radius = 42.5 + continuousMotion * Math.sin(orbitPhase * 1.55) * 2.5;
-            opacity = 0.29 + continuousMotion * Math.sin(orbitPhase * 1.55) * 0.11;
-          } else if (accent === "orbit") {
-            radius = 44; opacity = 0.34; dashArray = "6 7"; dashOffset = -timeSeconds * 15 * continuousMotion;
-          } else if (accent === "radar") {
-            radius = 44; opacity = 0.3; dashArray = "2 6"; dashOffset = -timeSeconds * 10 * continuousMotion;
-          } else if (accent === "progress") {
-            radius = 44; opacity = 0.38; dashArray = "72 205"; dashOffset = -timeSeconds * 38 * continuousMotion;
-          } else if (accent === "alert") {
-            radius = 43 + continuousMotion * Math.sin(timeSeconds * 7.2) * 2.2;
-            opacity = 0.52 + continuousMotion * Math.sin(timeSeconds * 7.2) * 0.17;
-            stroke = "#ff5c6f";
-          }
-          accentRingRef.current.setAttribute("r", radius.toFixed(2));
-          accentRingRef.current.setAttribute("opacity", clamp(opacity, 0, 0.72).toFixed(3));
-          accentRingRef.current.setAttribute("stroke-dasharray", dashArray);
-          accentRingRef.current.setAttribute("stroke-dashoffset", dashOffset.toFixed(2));
-          accentRingRef.current.setAttribute("stroke", stroke);
-        }
-        if (radarSweepRef.current) {
-          const showSweep = accent === "radar" || currentProps.state === "searching";
-          radarSweepRef.current.setAttribute("opacity", showSweep ? "0.38" : "0");
-          radarSweepRef.current.setAttribute("transform", `rotate(${((timeSeconds * 92 * continuousMotion + seededUnit(seed, 22) * 360) % 360).toFixed(2)} 50 50)`);
-        }
-        if (burstRingRef.current) {
-          const burst = clamp(physics.burst.value, 0, 1);
-          burstRingRef.current.setAttribute("r", (42 + (1 - burst) * 10).toFixed(2));
-          burstRingRef.current.setAttribute("opacity", (burst * 0.54).toFixed(3));
-        }
-        if (surfaceGradientRef.current) {
-          const lightX = clamp(31 + physics.gazeX.value * 5 - turn * 0.08 + organic * 1.8 * continuousMotion, 18, 46);
-          const lightY = clamp(21 + physics.gazeY.value * 4 - tilt * 0.08 + baseWave * 1.4 * continuousMotion, 12, 38);
-          surfaceGradientRef.current.setAttribute("fx", `${lightX.toFixed(1)}%`);
-          surfaceGradientRef.current.setAttribute("fy", `${lightY.toFixed(1)}%`);
-        }
-
-        const thinking = currentProps.state === "thinking" ? 1 : 0;
-        thoughtDotsRef.current.forEach((dot, index) => {
-          if (!dot) return;
-          const wave = reduced ? 0.5 : (Math.sin(timeSeconds * 2.3 + index * 1.15 + phaseD) + 1) / 2;
-          dot.setAttribute("opacity", (thinking * (0.1 + wave * 0.38)).toFixed(3));
-          dot.setAttribute("transform", `translate(0 ${(-wave * (1.2 + index * 0.45)).toFixed(2)})`);
-        });
-      });
-    }, [followPointer, rhythm.blinkMs, seed]);
-
-    const bodyFill = inkGradient ? `url(#${inkId})` : "var(--fg)";
-
-    return (
-      <svg
-        ref={svgRef}
-        viewBox="0 0 100 100"
-        width={size}
-        height={size}
-        focusable="false"
-        aria-hidden="true"
-        data-engine="fabushi-motion-v2"
-        style={{ overflow: "visible", display: "block" }}
-      >
-        <defs>
-          <clipPath id={clipId}><path d={shapePath} /></clipPath>
-          <radialGradient ref={surfaceGradientRef} id={surfaceId} cx="34%" cy="26%" r="72%" fx="31%" fy="21%">
-            <stop offset="0%" stopColor="#ffffff" stopOpacity="0.46" />
-            <stop offset="22%" stopColor="#ffffff" stopOpacity="0.16" />
-            <stop offset="62%" stopColor="#ffffff" stopOpacity="0.025" />
-            <stop offset="100%" stopColor="#ffffff" stopOpacity="0" />
-          </radialGradient>
-          <linearGradient id={shadeId} x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stopColor="#000000" stopOpacity="0" />
-            <stop offset="58%" stopColor="#000000" stopOpacity="0.015" />
-            <stop offset="100%" stopColor="#000000" stopOpacity="0.22" />
-          </linearGradient>
-          <filter id={depthId} x="-28%" y="-28%" width="156%" height="164%" colorInterpolationFilters="sRGB">
-            <feDropShadow dx="0.8" dy="2.6" stdDeviation="2.6" floodColor="#000000" floodOpacity="0.28" />
-            <feDropShadow dx="-0.7" dy="-0.8" stdDeviation="1.1" floodColor="#ffffff" floodOpacity="0.08" />
-          </filter>
-          {inkGradient ? (
-            <linearGradient id={inkId} x1="0" y1="0" x2="1" y2="1" gradientTransform={`rotate(${inkGradient.angle ?? 45} .5 .5)`}>
-              <stop offset={`${inkGradient.fromPos ?? 0}%`} stopColor={inkGradient.from} />
-              <stop offset={`${inkGradient.toPos ?? 100}%`} stopColor={inkGradient.to} />
-            </linearGradient>
-          ) : null}
-        </defs>
-
-        <circle ref={accentRingRef} cx="50" cy="50" r="43" fill="none" stroke="var(--fg)" strokeWidth="1.35" opacity="0" />
-        <line ref={radarSweepRef} x1="50" y1="50" x2="50" y2="8" stroke="var(--fg)" strokeWidth="1.2" strokeLinecap="round" opacity="0" />
-
-        <g ref={bodyRef} filter={`url(#${depthId})`}>
-          <path d={shapePath} fill="var(--fg)" opacity="0.12" transform="translate(2.2 3.2) scale(.982)" />
-          <path d={shapePath} fill={bodyFill} />
-          <path d={shapePath} fill={`url(#${surfaceId})`} clipPath={`url(#${clipId})`} opacity={emphasis ? 0.82 : 0.64} />
-          <path d={shapePath} fill={`url(#${shadeId})`} clipPath={`url(#${clipId})`} opacity="0.55" />
-          <path d={shapePath} fill="none" stroke="#ffffff" strokeWidth="0.72" strokeOpacity="0.18" />
-
-          <path ref={topologyRef} d="" fill="none" stroke="var(--bg)" strokeWidth="1.15" strokeLinecap="round" opacity="0.08" />
-          <path ref={leftEyeRef} d="M37 49h7v4h-7z" fill="var(--bg)" />
-          <path ref={rightEyeRef} d="M56 49h7v4h-7z" fill="var(--bg)" />
-          <circle ref={leftCheekRef} cx="31" cy="60" r="2.7" fill="#ff7d9c" opacity="0" />
-          <circle ref={rightCheekRef} cx="69" cy="60" r="2.7" fill="#ff7d9c" opacity="0" />
-          <path ref={mouthRef} d="M40.5 65.5 Q50 65.5 59.5 65.5" fill="none" stroke="var(--bg)" strokeWidth="2.2" strokeLinecap="round" opacity="0" />
-          <circle ref={roundMouthRef} cx="50" cy="66.5" r="1.3" fill="var(--bg)" opacity="0" />
-          <circle ref={(node) => { thoughtDotsRef.current[0] = node; }} cx="69" cy="31" r="1.8" fill="var(--bg)" opacity="0" />
-          <circle ref={(node) => { thoughtDotsRef.current[1] = node; }} cx="74.5" cy="25" r="1.35" fill="var(--bg)" opacity="0" />
-          <circle ref={(node) => { thoughtDotsRef.current[2] = node; }} cx="78.5" cy="19.5" r="0.9" fill="var(--bg)" opacity="0" />
-        </g>
-
-        <circle ref={burstRingRef} cx="50" cy="50" r="42" fill="none" stroke="var(--fg)" strokeWidth="1.6" opacity="0" />
-        {badgeColor ? <circle cx="82" cy="80" r="7" fill={badgeColor} stroke="var(--bg)" strokeWidth="2" /> : null}
-      </svg>
-    );
-  },
-);
+  return <svg aria-hidden="true" data-emphasis={emphasis || undefined} data-grok-state={state} data-paused={paused || undefined} data-reduced-motion={reducedMotion() ? "true" : "false"} data-source-id={botId} height={size} style={rootStyle} viewBox={VIEWBOX} width={size} xmlns="http://www.w3.org/2000/svg">
+    <defs><linearGradient id={`${id}-ink`} x1="0" x2="1" y1="0" y2="1"><stop offset="0" stopColor={colors.light} /><stop offset="1" stopColor={colors.dark} /></linearGradient></defs>
+    <g ref={faceRef} transform="translate(0 0)">
+      <path d={SHAPE_PATHS[shape] ?? SHAPE_PATHS.blob} fill={`url(#${id}-ink)`} />
+      <g ref={eyesRef} fill={background} transform="translate(0 0)">
+        <ellipse cx={CENTER - 29} cy={CENTER - 8} rx="10" ry={eyeHeight} />
+        <ellipse cx={CENTER + 29} cy={CENTER - 8} rx="10" ry={eyeHeight} />
+      </g>
+      {state === "excited" || state === "happy" || state === "celebrate" ? <path d={`M${CENTER - 20} ${CENTER + 24} Q${CENTER} ${CENTER + 38} ${CENTER + 20} ${CENTER + 24}`} fill="none" stroke={background} strokeLinecap="round" strokeWidth="5" /> : null}
+    </g>
+    {badgeColor ? <circle cx="200" cy="200" r="18" fill={badgeColor} stroke={background} strokeWidth="6" /> : null}
+  </svg>;
+});

--- a/frontend/apps/web/src/app/host/host.module.css
+++ b/frontend/apps/web/src/app/host/host.module.css
@@ -5256,7 +5256,7 @@
 }
 
 .loginHeroMark {
-  filter: drop-shadow(0 22px 36px rgb(0 0 0 / 36%));
+  filter: none;
 }
 
 .loginPresenceHalo {
@@ -5493,8 +5493,8 @@
   .loginLoadingRail i { animation: none !important; }
 }
 
-/* Living Fabushi marks: asynchronous breathing and state ambience stay in CSS
-   so lists of agents do not require per-frame JavaScript. */
+/* Grok-style marks animate their inner SVG group directly. The wrapper must
+   not add a second transform, shadow, or surface effect. */
 .botMark {
   isolation: isolate;
   --bot-mark-breathe-duration: 5200ms;
@@ -5505,7 +5505,8 @@
   position: relative;
   z-index: 2;
   transform-origin: 50% 54%;
-  filter: drop-shadow(0 4px 8px rgb(0 0 0 / 12%));
+  animation: none !important;
+  filter: none;
 }
 
 .botMark[data-motion-tier="active"] > svg {
@@ -6090,7 +6091,7 @@
   place-items: center;
   margin: -4px 0 6px;
 }
-.onboardingMarkStage > span {
+.onboardingMarkStage > span:not(.onboardingBotMark) {
   position: absolute;
   inset: 10px 3px 4px;
   z-index: -1;
@@ -6098,7 +6099,7 @@
   border-radius: 48% 52% 55% 45% / 52% 46% 54% 48%;
   animation: onboardingHalo 7s linear infinite;
 }
-.onboardingBotMark { margin: 0; filter: drop-shadow(0 24px 42px rgb(0 0 0 / 28%)); }
+.onboardingBotMark { margin: 0; filter: none; }
 .onboardingEyebrow {
   margin: 0 0 12px;
   color: #9484e9;
@@ -6404,7 +6405,7 @@
   .iconButton,
   .onboardingProgress i,
   .onboardingBots > article,
-  .onboardingMarkStage > span,
+  .onboardingMarkStage > span:not(.onboardingBotMark),
   .accountAvatarStage > i {
     animation: none !important;
     transition: none !important;


### PR DESCRIPTION
## Summary\n- port the reconstructed Grok Bot 0.18 avatar geometry and motion model\n- remove layered 3D, glow, particle, and shadow effects from BotMark\n- preserve current Agent lifecycle states and map them to the Grok-style motion vocabulary\n- restrict the Bot editor to the eight source-aligned avatar shapes\n\n## Verification\n- `python3 .github/scripts/assert-bot-mark-motion.py`\n- `git diff --check`\n\nHeavy build and test verification is delegated to GitHub Actions per repository policy.