### PR TITLE
fix(desktop): keep account caches empty after logout

### DIFF
--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -226,6 +226,10 @@ function persistConversationJournal(journal: ConversationJournal): void {
             .map((message) => ({ ...message })),
         ]),
     );
+    if (Object.keys(conversations).length === 0) {
+      window.localStorage.removeItem(CONVERSATION_JOURNAL_KEY);
+      return;
+    }
     window.localStorage.setItem(
       CONVERSATION_JOURNAL_KEY,
       JSON.stringify({ version: CONVERSATION_JOURNAL_VERSION, conversations }),

--- a/projects/fabushi-account-access-control/management/05-状态报告.md
+++ b/projects/fabushi-account-access-control/management/05-状态报告.md
@@ -11,3 +11,6 @@ PR #2117 已通过全部 PR 门禁并进入 canonical `main` SHA `52b7c10889e585
 
 ## 2026-08-26 round 4
 用户在 macOS 1.0.941 复现 `refresh_token_reused`、Messenger 无退出登录及在线应用搜索空结果。生产 Marketplace 已独立验证可返回 9 个应用，客户端版本也是当时 Latest，因此根因收敛为 Rust session refresh 状态机 + 新 Messenger 迁移遗漏 + 市场请求错误耦合。已建立 AAC-003，实施终止型 session 自动清理、General 退出登录、账号级本地缓存清理、公开 Marketplace 与 auth refresh 解耦，以及 browse/installed 独立 settle。Renderer build 已通过；本机 Cargo 受 crates.io 镜像缺少 lockfile 指定 `futures 0.3.34` 阻塞，Rust 编译测试将由 GitHub clean CI 验证，不能通过降级 lockfile 绕过。任务保持 in-progress，直到 protected main、exact-main packaged E2E 与新 Release 全部闭环。
+
+## 2026-08-26 round 5
+AAC-003 已通过 PR #2147 并合入 main（a10079f3cd315ddfc55a4698652a91469a6978e7）。exact-main Electron run 32962607644 的 Linux 打包前真实 Host 用户旅程发现退出后 `ElectronMahayanaHostTransport::close()` 会把已经清空的 conversation journal 重新持久化为空壳 `{version:1,conversations:{}}`。Projection 与 Draft 均已正确清空且 UI 已回登录页，但严格账号缓存清理验收未满足。跟进修复将空 conversation journal 视为无缓存并删除 key，而不是在 transport close 时重建空壳；原 E2E 断言保持严格，不放宽。

--- a/projects/fabushi-account-access-control/management/07-变更日志.md
+++ b/projects/fabushi-account-access-control/management/07-变更日志.md
@@ -4,3 +4,4 @@
 - 2026-08-25: PR #2117 合入 `main`；Worker 生产部署完成；在 `bhrum2` 的旧版 AI 生产快照上部署安全等价兼容 hotfix，使已认证 `bhrum108` 绕过月度 AI Token quota，并保留未认证防冒领边界。生产回滚点 `/opt/dacheng-ai/backups/20260825T053632Z/server.js`。
 - 2026-08-25: 记录 merge queue / portfolio 治理纠偏过程；未绕过 Project portfolio governance。
 - 2026-08-26: 创建 AAC-003；确认 1.0.941 `refresh_token_reused` 会在 Rust refresh 阶段绕过 `auth_status` 的 expired 分支，且公开 Marketplace 错误依赖可刷新账号 token；开始修复 Rust session 状态机、Messenger 退出登录与市场独立搜索，并进入新桌面 Release 闭环。
+- 2026-08-26: #2147 合入 main 后 exact-main Electron 用户旅程发现空 conversation journal 在 transport close 时被重新写回；跟进调整 journal persistence，使空 journal 删除 localStorage key，继续保持退出后的账号级缓存零残留验收。


### PR DESCRIPTION
## FAB-P0008 / AAC-003 release follow-up

The first exact-main Electron delivery run for #2147 (`32962607644`) caught a strict logout lifecycle regression before packaging: the UI returned to login and projection/drafts were cleared, but `ElectronMahayanaHostTransport::close()` flushed an empty conversation journal back into localStorage as `{version:1,conversations:{}}`.

### Fix
- Treat an empty conversation journal as no cache: remove `fabushi.desktop.mahayana-conversation-journal.v1` instead of writing an empty shell.
- Keep the existing strict packaged-user E2E unchanged; it must continue to require all three account-scoped cache keys to be absent after logout.
- Record the exact-main release blocker in the canonical AAC project status/changelog.

### Verification
- `git diff --check` ✅
- desktop TypeScript `tsc -p tsconfig.json --noEmit` ✅
- Authoritative acceptance remains the existing `account settings logs out and clears account-scoped fast-start caches` Electron E2E in the protected CI/release path.

After merge, the failed 1.0.963 candidate must not be promoted. A new exact-main Electron run must pass Linux/macOS/Windows packaged user journeys and publish a version strictly newer than 1.0.963.