### PR TITLE
fix(desktop): discard live account journal on session reset

### DIFF
--- a/desktop/e2e/messenger.spec.ts
+++ b/desktop/e2e/messenger.spec.ts
@@ -275,10 +275,20 @@ test('account settings logs out and clears account-scoped fast-start caches', as
     await completeBrowserLogin(page);
     await openMessenger(page);
 
+    const assistant = page.getByTestId('peer-legacy:conversation:codex:agent:assistant');
+    await expect(assistant).toBeVisible();
+    await assistant.click();
+    await page.getByTestId('messenger-input').fill('退出登录缓存清理验收');
+    await page.getByTestId('messenger-send').click();
+    await expect(page.getByText('收到：退出登录缓存清理验收')).toBeVisible();
+    await expect.poll(async () => page.evaluate(() => {
+      const journal = JSON.parse(localStorage.getItem('fabushi.desktop.mahayana-conversation-journal.v1') || 'null');
+      return Object.keys(journal?.conversations ?? {}).length;
+    })).toBeGreaterThan(0);
+
     await page.evaluate(() => {
       localStorage.setItem('fabushi.desktop.messenger-projection.v1', JSON.stringify({ version: 1, selfActors: [], selfConversations: [], selfMessages: {}, savedAtMs: Date.now() }));
       localStorage.setItem('fabushi.desktop.messenger-drafts.v2', JSON.stringify({ sample: 'private draft' }));
-      localStorage.setItem('fabushi.desktop.mahayana-conversation-journal.v1', JSON.stringify({ version: 1, conversations: { sample: [{ id: 'm1', role: 'user', text: 'private', createdAtMs: Date.now() }] } }));
     });
 
     await page.getByTestId('profile-navigation-trigger').click();

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -50,7 +50,7 @@ import type {
   SandboxRuntime,
   UpdateState,
 } from '../../frontend/apps/web/src/lib/mahayana-host/contracts';
-import { ElectronMahayanaHostTransport, isElectronMahayanaHostAvailable } from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
+import { ElectronMahayanaHostTransport, isElectronMahayanaHostAvailable, MAHAYANA_ACCOUNT_SESSION_RESET_EVENT } from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
 import { MockMahayanaHostTransport } from '../../frontend/apps/web/src/lib/mahayana-host/mock-transport';
 import { invokeNativeDesktop, subscribeNativeDesktopEvents } from '../../frontend/apps/web/src/lib/fabushi-runtime/native-desktop';
 import type { InstalledPluginPointer, MahayanaHostTransport, MarketplacePluginSummary } from '../../frontend/apps/web/src/lib/mahayana-host/transport';
@@ -297,6 +297,9 @@ function persistMessengerProjection(projection: MessengerProjection): void {
 
 async function clearAccountScopedDesktopCaches(): Promise<void> {
   if (typeof window !== 'undefined') {
+    // Tell every live Mahayana renderer transport to discard its in-memory
+    // account journal before React unmount cleanup can flush it back to disk.
+    window.dispatchEvent(new Event(MAHAYANA_ACCOUNT_SESSION_RESET_EVENT));
     try {
       window.localStorage.removeItem(messengerProjectionKey);
       window.localStorage.removeItem(messengerDraftsKey);

--- a/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/electron-transport.ts
@@ -55,6 +55,7 @@ const CONVERSATION_EQUIVALENCE_WINDOW_MS = 60_000;
 
 export const MAHAYANA_RUNTIME_EVENT_NAME = "fabushi:mahayana-runtime-event";
 export const MAHAYANA_COMMAND_EVENT_NAME = "fabushi:mahayana-command";
+export const MAHAYANA_ACCOUNT_SESSION_RESET_EVENT = "fabushi:mahayana-account-session-reset";
 
 export type MahayanaCommandBridgeContext = {
   conversationKey?: string;
@@ -311,7 +312,22 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
   private pumping = false;
   private unsubscribeBridge: (() => void) | null = null;
   private unsubscribeCommandObserver: (() => void) | null = null;
+  private unsubscribeAccountSessionReset: (() => void) | null = null;
   private journalPersistTimer: ReturnType<typeof setTimeout> | null = null;
+  private discardJournalOnClose = false;
+
+  constructor() {
+    if (typeof window !== "undefined") {
+      const onAccountSessionReset = () => {
+        this.discardJournalOnClose = true;
+        this.discardConversationJournal();
+      };
+      window.addEventListener(MAHAYANA_ACCOUNT_SESSION_RESET_EVENT, onAccountSessionReset);
+      this.unsubscribeAccountSessionReset = () => {
+        window.removeEventListener(MAHAYANA_ACCOUNT_SESSION_RESET_EVENT, onAccountSessionReset);
+      };
+    }
+  }
 
   subscribe(listener: RuntimeEventListener): () => void {
     this.listeners.add(listener);
@@ -500,8 +516,11 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
     this.unsubscribeBridge = null;
     this.unsubscribeCommandObserver?.();
     this.unsubscribeCommandObserver = null;
+    this.unsubscribeAccountSessionReset?.();
+    this.unsubscribeAccountSessionReset = null;
     this.miniAppConversations.clear();
-    this.flushConversationJournal();
+    if (this.discardJournalOnClose) this.discardConversationJournal();
+    else this.flushConversationJournal();
   }
 
   private dispatchToListeners(event: RuntimeEvent): void {
@@ -696,6 +715,21 @@ export class ElectronMahayanaHostTransport implements MahayanaHostTransport {
       this.journalPersistTimer = null;
     }
     persistConversationJournal(this.conversationJournal);
+  }
+
+  private discardConversationJournal(): void {
+    if (this.journalPersistTimer) {
+      clearTimeout(this.journalPersistTimer);
+      this.journalPersistTimer = null;
+    }
+    this.conversationJournal.conversations = {};
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.removeItem(CONVERSATION_JOURNAL_KEY);
+      } catch {
+        // Logout/session revocation must still clear in-memory account data.
+      }
+    }
   }
 
   private refreshUnscopedSuppression(): void {

--- a/projects/fabushi-account-access-control/management/05-状态报告.md
+++ b/projects/fabushi-account-access-control/management/05-状态报告.md
@@ -14,3 +14,6 @@ PR #2117 已通过全部 PR 门禁并进入 canonical `main` SHA `52b7c10889e585
 
 ## 2026-08-26 round 5
 AAC-003 已通过 PR #2147 并合入 main（a10079f3cd315ddfc55a4698652a91469a6978e7）。exact-main Electron run 32962607644 的 Linux 打包前真实 Host 用户旅程发现退出后 `ElectronMahayanaHostTransport::close()` 会把已经清空的 conversation journal 重新持久化为空壳 `{version:1,conversations:{}}`。Projection 与 Draft 均已正确清空且 UI 已回登录页，但严格账号缓存清理验收未满足。跟进修复将空 conversation journal 视为无缓存并删除 key，而不是在 transport close 时重建空壳；原 E2E 断言保持严格，不放宽。
+
+## 2026-08-26 round 6
+对 #2150 后的 logout 生命周期继续做真实数据审计：仅“空 journal 不落盘”仍不足以覆盖已有历史对话的用户。新增显式 `MAHAYANA_ACCOUNT_SESSION_RESET_EVENT`：Desktop 在 logout/terminal revoked-session 清理前通知所有活跃 Electron Mahayana transports，transport 立即取消待持久化 timer、清空内存 journal、删除 localStorage，并在随后 React unmount/`close()` 时禁止重新 flush 旧账号 journal。E2E 不再手工伪造 journal，而是先向真实 Messenger 会话发送消息并确认 journal 非空，再退出并要求 projection/draft/journal 三项全部不存在。


### PR DESCRIPTION
## FAB-P0008 / AAC-003 final logout lifecycle hardening

After #2150 fixed the empty-journal shell, a deeper lifecycle audit showed that a real user may still have a non-empty in-memory Mahayana conversation journal. React unmount/`transport.close()` could otherwise flush those old account messages back after logout.

### Fix
- Add an explicit renderer account-session-reset event shared by DesktopShell and Electron Mahayana transports.
- Before logout/revoked-session cache cleanup, DesktopShell broadcasts the reset event.
- Every live transport immediately cancels pending journal persistence, clears its in-memory journal, removes the journal key, and marks close/unmount as discard-only.
- Keep normal app-close behavior unchanged: without a session reset, pending conversation journal data is still flushed for local-first recovery.
- Strengthen the existing logout E2E: it now sends a real Messenger message, waits for a non-empty conversation journal, then logs out and requires projection, drafts, and journal keys all to be absent.

### Local verification
- `git diff --check` ✅
- `tsc -p desktop/tsconfig.json --noEmit` ✅

### Release acceptance
The exact-main Electron user journey must run the strengthened non-empty-journal logout test successfully before any new Desktop Release is promoted. The currently running 1.0.968 candidate is not the final release target; this PR must merge first and produce a newer exact-main build.