### PR TITLE
docs(tfi): close M8-CALL-001 after protected merge

### DIFF
--- a/projects/telegram-fabushi-integration/evidence/M8-CALL-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M8-CALL-001/README.md
@@ -3,7 +3,7 @@
 - Project: `FAB-P0001` / `TFI`
 - Task: `M8-CALL-001`
 - Branch: `feat/tfi-miniapp-ai-service-calls`
-- Status: `IN_PROGRESS`
+- Status: `TESTED / COMPLETED`
 
 ## Implementation evidence
 
@@ -23,32 +23,39 @@
 - `a0f82ed050a8d50c8077b95a4af1d25255021244` — ADR-0008 updated with MCP-only invariant and no-fallback rule。
 - `11b2c981ee61f853534915518032fec74872cf9a` — product/architecture spec updated for MCP-driven service calls。
 - `a6948a8ad40a78c5c15d33adeb88e5f04b0f7b73` — WBS expanded for STT, constrained MCP resolver/executor, composer routing。
+- `1c1a479eb93be7e21becaa2211463cb6f97b8a06` — latest-main conflict-resolution integration head used for final current-head checks。
 
-## Required acceptance evidence
+## Acceptance evidence
 
-M8-CALL-001 is not complete until current-head GitHub Actions proves at least:
+All M8-CALL-001 acceptance gates are satisfied for the atomic core-contract slice:
 
 1. Rustfmt success for `native/mahayana-messaging`。
-2. Unit/contract tests success, including:
-   - DTMF → exposed MCP Tool；
-   - chat numeric input → same DTMF/MCP route；
-   - final speech/chat natural language → `ResolveMcpTool`；
-   - resolver cannot select unexposed Tool；
-   - no matching Tool → `McpCapabilityUnavailable`；
-   - unmapped DTMF does not execute anything；
-   - ended session rejects input；
-   - MCP result audit；
-   - DTMF route cannot reference unexposed Tool；
-   - MiniApp `ServiceCall + Microphone` permission mapping。
+2. Unit/contract tests success, including DTMF → exposed MCP Tool、chat numeric parity、speech/chat resolver、unexposed Tool rejection、no-match unavailable、terminal-state rejection、MCP result audit and permission mapping。
 3. Clippy success。
 4. Required repository/product/governance checks success。
-5. Protected merge and canonical `main` readback before task closure。
+5. Protected merge and canonical `main` readback completed。
 
-## Verification evidence
+## Final GitHub Actions evidence
 
-- Local application build/test: **not run**, prohibited by repository disk-safety policy。
-- PR: #2063。
-- GitHub Actions current-head CI: pending after MCP-only refactor/doc commits。
-- Protected merge / canonical-main verification: pending。
+Final PR head: `1c1a479eb93be7e21becaa2211463cb6f97b8a06`.
 
-This index must be updated with latest-head workflow run/check IDs and merge SHA before the task can advance to `TESTED`/complete。
+- Mahayana fast checks `32969707544` — SUCCESS
+- Fabushi self-hosted messaging `32969707602` — SUCCESS
+- Messaging Product Gate `32969707606` — SUCCESS
+- CI `32969707626` — SUCCESS
+- Developer Fiat Commerce `32969707538` — SUCCESS
+- Project portfolio governance `32969707591` — SUCCESS
+- Explicit automerge `32969707671` — SUCCESS
+
+## Merge and canonical-main verification
+
+- PR: #2063
+- Protected merge SHA: `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`
+- Merge timestamp: `2026-08-26T12:42:42Z`
+- Canonical `main` HEAD readback: `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`
+- Canonical source readback: `native/mahayana-messaging/src/miniapp_service_call.rs`
+- Canonical source blob: `d6f3f503c1bccde38408ce507b9342717813b3ec`
+- WBS readback includes M8.T08–T11 without rolling back later M8 marketplace/project-state work.
+- Local application build/test: **not run**, per repository disk-safety policy; GitHub Actions current-head checks are the authoritative verification source.
+
+M8-CALL-001 may therefore advance to `TESTED / COMPLETED`. STT、real MCP Host resolver/executor、composer routing、media transport and UI remain separate follow-up tasks and are not implied complete by this closure.

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-03
-- **版本**：v1.4
+- **版本**：v1.5
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
@@ -25,7 +25,7 @@
 | 联系人/群组 | actor/conversation/community | M5 | IMPLEMENTED | 需 owner/admin/member/restricted 权限矩阵 |
 | 频道/Topic | conversation/community | M6 | IMPLEMENTED | 需广播/分页/Topic 状态规模验收 |
 | Bot/Agent | bot + Actor/Feature Host + unified Messenger | M7 | TESTING | M7-DESKTOP-002 / PR #2053：Mini App conversation edge normalization + composer viewport geometry；等待 latest-head required checks / protected merge / canonical-main readback |
-| Mini Apps | miniapp + Host bridge | M8 | IMPLEMENTED | M8-MARKET-001 已实现 marketplace registry/developer flow；完整 M8 仍需授权/撤销/沙箱 E2E |
+| Mini Apps | miniapp + Host bridge | M8 | IMPLEMENTED | M8-CALL-001 core contract 已 TESTED；M8-MARKET-001 已实现；完整 M8 仍需 STT/MCP Host wiring、授权/撤销/沙箱与跨端 E2E |
 | 支付 | payment/settlement/wallet | M9 | IMPLEMENTED | 需 sandbox E2E / webhook replay evidence |
 | 音视频 | realtime/signaling + desktop WebRTC | M10 | IMPLEMENTED | 需跨端/TURN/SFU/网络切换实测 |
 | 移动端共享 Core | native bridge / Host | M11 | IN_PROGRESS | 需 iOS/Android/Electron cross-device E2E |
@@ -92,17 +92,24 @@ Acceptance traceability:
 - Package distribution: external immutable GitHub source URLs + SHA-256/size in `mahayana.external-release.v1`; marketplace API declares `marketplaceHostsPackage: false` and does not proxy package bytes.
 - Remaining gate for this task: protected canonical-main readback, exact-main packaged/E2E and a strictly newer GitHub Release. Full M8 authorization/revocation/sandbox closure remains a separate broader-stage requirement.
 
-
 ## M7-DESKTOP-004 selected-peer identity acceptance — 2026-08-25
 
 `main@6ae21cba7878d113ac2902df94d867e7d3b7cd34` / Electron `32813752100` 证明头像“可见”之外仍存在身份一致性缺口：选择 `Incident Bot` 后 Header 仍保留上一 Agent 的 Motion v2 `data-bot-id`。因此 M7-DESKTOP-004 继续为 `IMPLEMENTED / RELEASE_BLOCKED`。验收现在明确要求：连续 peer 切换时 selected row、Header、窄屏 info drawer 的 semantic BotMark `data-bot-id` 必须始终等于当前 peer，并在切回前一个 peer 后再次成立；随后才允许 exact-main Release。
-
 
 ## M7-DESKTOP-004 observer-driven peer identity — 2026-08-25
 
 Exact-main `eb4b340ce...` / Electron `32822744019` / artifact `9553768019` 证明 selected-row identity authority已正确，但 peer switch 的 class-only DOM update 没有被 Workbench observer 监听。验收继续要求 Header/info semantic `data-bot-id` 最终与 `peerActive` 行一致；实现改为 class mutation event-driven refresh，轮询只作恢复兜底。Release 继续阻断。
 
-
 ## M7-DESKTOP-004 narrow info drawer acceptance — 2026-08-25
 
 `main@adcd73d0...` / Electron `32823782495` / artifact `9554164364` confirms the avatar identity portion now passes in the real Linux Host path. The only task-specific failure moved to the 1100px info drawer: the React state/layout emits overlay semantics, while a legacy responsive CSS rule hides `.infoPanel` unconditionally. Acceptance remains unchanged: the `资料` button must open a visible `data-overlay="true"` panel and the panel avatar identity must equal the selected peer before and after peer switching.
+
+## M8-CALL-001 final acceptance — 2026-08-26
+
+`M8-CALL-001` = `TESTED / COMPLETED` for the MiniApp MCP-only service-call core contract.
+
+- Final PR head: `1c1a479eb93be7e21becaa2211463cb6f97b8a06`.
+- Current-head gates all SUCCESS: Mahayana fast `32969707544`; self-hosted messaging `32969707602`; Messaging Product Gate `32969707606`; CI `32969707626`; Developer Fiat Commerce `32969707538`; portfolio governance `32969707591`; Explicit automerge `32969707671`.
+- Protected PR #2063 merged as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`.
+- Canonical `main` readback confirmed the same merge SHA and `native/mahayana-messaging/src/miniapp_service_call.rs` blob `d6f3f503c1bccde38408ce507b9342717813b3ec`.
+- This closure covers the atomic MCP-only domain/permission/bridge contract. STT、real `tools/list` resolver/`tools/call` Host execution、composer routing、media and cross-platform UI/E2E remain M8-CALL-002/003/004 and later tasks; full M8 therefore remains broader `IMPLEMENTED` rather than stage-closed.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -4,13 +4,13 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-05
-- **版本**：v1.6
+- **版本**：v1.7
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
 ## 当前状态
 
-- **整体阶段**：M3 桌面聊天完整交互 — `IN_PROGRESS`；M7 unified Messenger remediation 并行 `TESTING`。
+- **整体阶段**：M3 桌面聊天完整交互 — `IN_PROGRESS`；M7 unified Messenger remediation 并行 `TESTING`；M8-CALL-001 core contract 已 `TESTED / COMPLETED`。
 - **M0**：`TESTED`。
 - **M1**：`TESTED`，证据 `M1-ACCEPT-001`。
 - **M2**：`TESTED`，证据 `M2-ACCEPT-001`。
@@ -75,7 +75,6 @@
 - unified Messenger 不再维护 bundled `defaultMiniApps`；搜索、安装、更新、打开、卸载全部基于 Marketplace + AppHost plugin store。
 - 本地 structural gates 已通过；状态保持 `TESTING`，待 GitHub current-head CI、protected merge 与 canonical-main readback 后晋级 `TESTED`。
 
-
 ## 2026-08-23 — M7-DESKTOP-003 unified identity/search/sidebar
 
 - 用户提供 6 张 UI 参考，要求将图 5 的常驻联系人/Bots/收藏等导航收进左下角个人头像，并采用图 2/3 可拖拽 avatar-only 左栏与图 6 分类搜索。
@@ -84,13 +83,11 @@
 - global search 新增聊天、频道、应用、贴文、图片、视频、下载、链接、文件、音乐、声音 11 分类；应用分类复用线上 Marketplace install/update/open/uninstall。
 - E2E source 已覆盖导航、sidebar collapse、search tabs 与通过应用搜索打开 Mini App。当前状态 `IMPLEMENTED`；GitHub current-head CI / protected merge / canonical-main readback 尚待完成。
 
-
 ## 2026-08-23 — M7-DESKTOP-003 package verification
 
 - #2058 已修复 #2057 暴露的 `WebRtcCallStatus` typecheck 错误并合并到 main `947f537f8...`。
 - final package-verification follow-up 增加 personal-avatar Motion v2 E2E guard，并通过 `desktop/e2e/**` 触发 canonical Electron package matrix。
-- 下一验收事实：main signed/notarized macOS artifact 安装到用户 Mac 并实际打开；完成前 M7-DESKTOP-003 维持 `TESTING`。
-
+- 下一验收事实：main signed/notarized macOS artifact 安装到用户 Mac并实际打开；完成前 M7-DESKTOP-003 维持 `TESTING`。
 
 ## 2026-08-23 — M7-DESKTOP-003 runtime-smoke repair
 
@@ -139,11 +136,11 @@
 
 ## 2026-08-24 — M3-DESKTOP-002 complete-contact first frame
 
-- Target Mac reproduced left-rail staged appearance: a few rows rendered immediately, remaining contacts/conversations appeared seconds later.
-- Root causes: legacy peer summaries were omitted from the durable renderer projection, and self-hosted `Sync { cursor: None, limit: 20 }` incorrectly truncated actor/conversation metadata while still advancing the journal cursor.
-- Follow-up persists legacy conversation/Bot/group summaries for instant returning-user paint and makes initial Rust snapshot metadata complete while preserving bounded message payloads.
-- New Rust contract uses `limit=1` to prove complete visible actors/conversations + one bounded message; Messenger E2E requires the legacy assistant peer to be persisted and restored.
-- Status remains `TESTING` pending PR/main/package/target-Mac proof.
+- Target Mac reproduced left-rail staged appearance: a few rows rendered immediately, remaining contacts/conversations appeared seconds later。
+- Root causes: legacy peer summaries were omitted from the durable renderer projection, and self-hosted `Sync { cursor: None, limit: 20 }` incorrectly truncated actor/conversation metadata while still advancing the journal cursor。
+- Follow-up persists legacy conversation/Bot/group summaries for instant returning-user paint and makes initial Rust snapshot metadata complete while preserving bounded message payloads。
+- New Rust contract uses `limit=1` to prove complete visible actors/conversations + one bounded message; Messenger E2E requires the legacy assistant peer to be persisted and restored。
+- Status remains `TESTING` pending PR/main/package/target-Mac proof。
 
 ## 2026-08-25 — M7-DESKTOP-004 Bot avatar / info panel remediation
 
@@ -161,14 +158,12 @@
 - Portal relocation clears the prior parent marker, preserving the already-fixed peer-switch restore behavior.
 - Release remains blocked pending protected follow-up merge and a fully green new exact-main delivery.
 
-
 ## 2026-08-25 — M7-DESKTOP-004 selected-peer identity delivery block
 
 - Latest canonical delivery `main@6ae21cba7878d113ac2902df94d867e7d3b7cd34`, Electron run `32813752100`, remains blocked.
 - 17/18 Linux real-Host E2E cases passed; task-specific peer-switch regression exposed Header identity staying on the previous Agent after selecting Incident Bot. Evidence artifact: `9550721736`.
 - Follow-up `fix/tfi-selected-peer-avatar-identity` removes the Header portal as an identity authority, uses the active peer row direct BotMark, and makes active identity an explicit React state input so a stable portal node cannot retain stale identity.
 - No desktop Release is allowed until this branch merges and a later exact-main desktop/mobile delivery is fully green.
-
 
 ## 2026-08-25 — M7-DESKTOP-004 class-only selection propagation
 
@@ -177,10 +172,16 @@
 - `fix/tfi-peer-selection-observer` adds filtered `class` observation for peer buttons and keeps the 500 ms interval as recovery-only.
 - Release remains blocked until protected merge + later exact-main Electron/native delivery are green.
 
-
 ## 2026-08-25 — M7-DESKTOP-004 right drawer exact-main block
 
 - `main@adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` / Electron `32823782495` retained diagnostics `9554164364`; 17/18 real-Host E2E cases passed.
 - Header/peer Motion v2 identity is no longer the failing point. The remaining user-visible defect is the narrow right `资料` drawer.
 - Root cause is the old `max-width:1280px` CSS `display:none` rule masking the newer overlay drawer even when React renders it.
 - `fix/tfi-narrow-info-panel-toggle` preserves the docked-panel hide only for non-overlay state and allows `data-overlay=true` to render. Release stays blocked until the next exact-main delivery is green.
+
+## 2026-08-26 — M8-CALL-001 core contract closed
+
+- #2063 final head `1c1a479eb93be7e21becaa2211463cb6f97b8a06` passed Mahayana fast `32969707544`, self-hosted messaging `32969707602`, Messaging Product Gate `32969707606`, repository CI `32969707626`, Developer Fiat Commerce `32969707538`, portfolio governance `32969707591`, and Explicit automerge `32969707671`.
+- PR #2063 merged through protected GitHub flow as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`.
+- Canonical `main` readback confirmed HEAD `1f406461...` and service-call core blob `d6f3f503c1bccde38408ce507b9342717813b3ec`.
+- `M8-CALL-001` is now `TESTED / COMPLETED`. It closes only the MCP-only Rust domain/permission/bridge contract; STT、real MCP Host resolver/executor、composer routing、media/UI/E2E remain follow-up scope, so the wider M8 stage remains open.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-07
-- **版本**：v1.6
+- **版本**：v1.7
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
@@ -78,7 +78,6 @@
 - Electron edge/transport 新增 Marketplace、install/list/active/uninstall/UI document 路径；未安装应用不能打开。
 - CI guard 新增 `defaultMiniApps` 回归禁令。
 
-
 ## 2026-08-23 — M7-DESKTOP-003 navigation/search/avatar convergence
 
 - 常驻 feature rail 移入左下角个人 BotMark 菜单，避免 Messenger 再出现第二条功能侧栏。
@@ -86,7 +85,6 @@
 - identity primitive 收敛为 BotMark，包括真人 peer 与 Mini App，不再保留 Agent-only avatar split。
 - 新增图 6 风格 global categorized search；线上 Mini App Marketplace 直接进入“应用”分类。
 - 添加/调整 desktop Playwright contracts；重型验证仍只在 GitHub Actions 执行。
-
 
 ## 2026-08-23 — Marketplace runtime-smoke hardening
 
@@ -151,14 +149,12 @@
 - Portal relocation clears the prior parent marker, preserving the already-fixed peer-switch restore behavior.
 - Release remains blocked pending protected follow-up merge and a fully green new exact-main delivery.
 
-
 ## 2026-08-25 — M7-DESKTOP-004 exact-main identity follow-up
 
 - Recorded failed Electron delivery run `32813752100` / artifact `9550721736` for `main@6ae21cba...`.
 - Fixed stale Header portal identity by making the selected peer row direct Motion v2 BotMark canonical and carrying `activeBotId/activeLabel` through React state.
 - Strengthened Playwright to validate Header + info drawer identity across second-peer selection and switch-back.
 - Recorded official React (MIT) portal/reconciliation review; adopted state-ownership principle only, with no copied upstream code.
-
 
 ## 2026-08-25 — M7-DESKTOP-004 peer class observer
 
@@ -167,10 +163,16 @@
 - Kept 500 ms target refresh interval as recovery-only fallback.
 - Updated regression to wait for committed `peerActive` selection and then require Header semantic Motion v2 identity convergence.
 
-
 ## 2026-08-25 — M7-DESKTOP-004 narrow info drawer CSS repair
 
 - Recorded exact-main failure `adcd73d0...` / Electron `32823782495` / diagnostics `9554164364`.
 - Confirmed selected-peer/Header avatar identity now passes; failure moved to 1100px info-panel visibility.
 - Replaced unconditional narrow `.infoPanel { display:none; }` with non-overlay-only hiding and explicit overlay `display:flex`.
 - Existing real Host E2E continues to require right drawer visibility, `data-overlay=true`, and selected-peer Motion v2 identity.
+
+## 2026-08-26 — M8-CALL-001 protected merge closure
+
+- Resolved #2063 against latest `main` without rolling back later FAB-P0001 shared project-state changes: core Rust + dedicated ADR/spec/task/evidence were retained, while M8.T08–T11 were merged into the latest WBS.
+- Final PR head `1c1a479eb93be7e21becaa2211463cb6f97b8a06` passed all seven observed current-head GitHub Actions workflows: Mahayana fast `32969707544`, self-hosted messaging `32969707602`, Messaging Product Gate `32969707606`, CI `32969707626`, Developer Fiat Commerce `32969707538`, portfolio governance `32969707591`, Explicit automerge `32969707671`.
+- PR #2063 merged as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`; canonical `main` readback confirmed the same HEAD and service-call blob `d6f3f503c1bccde38408ce507b9342717813b3ec`.
+- `M8-CALL-001` advanced to `TESTED / COMPLETED`. Follow-up work remains explicitly split into M8-CALL-002/003/004 and later media/UI/E2E tasks; this closure does not overstate full M8 completion.

--- a/projects/telegram-fabushi-integration/management/tasks/M8-CALL-001-miniapp-ai-service-call-contract.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M8-CALL-001-miniapp-ai-service-call-contract.md
@@ -3,11 +3,11 @@
 - Project ID: `FAB-P0001`
 - Project Key: `TFI`
 - Task ID: `M8-CALL-001`
-- Status: `IN_PROGRESS`
+- Status: `TESTED / COMPLETED`
 - Branch: `feat/tfi-miniapp-ai-service-calls`
 - Started: `2026-08-23`
-- Updated: `2026-08-23`
-- Completed: N/A
+- Updated: `2026-08-26`
+- Completed: `2026-08-26`
 
 ## Objective
 
@@ -68,23 +68,32 @@
 
 ## Verification
 
-- GitHub Actions Rust/CI workflow 编译并运行 `mahayana-messaging` 测试。
-- 本机仅做源码/差异轻量检查；依据根 `AGENTS.md` 禁止本地 build/test。
+- GitHub Actions final PR head `1c1a479eb93be7e21becaa2211463cb6f97b8a06`：
+  - Mahayana fast checks `32969707544` — SUCCESS
+  - Fabushi self-hosted messaging `32969707602` — SUCCESS
+  - Messaging Product Gate `32969707606` — SUCCESS
+  - CI `32969707626` — SUCCESS
+  - Developer Fiat Commerce `32969707538` — SUCCESS
+  - Project portfolio governance `32969707591` — SUCCESS
+  - Explicit automerge `32969707671` — SUCCESS
+- 本机未运行 application build/test；依据根 `AGENTS.md`，GitHub Actions current-head evidence 为验证权威。
+- PR #2063 通过 protected merge，merge SHA `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`。
+- canonical `main` 回读确认 `native/mahayana-messaging/src/miniapp_service_call.rs` blob `d6f3f503c1bccde38408ce507b9342717813b3ec` 已落地。
 
 ## Evidence
 
 - Core MCP-only refactor commit: `89cad5682e6abcb3bb9e23c132bb772db9ea0bba`
 - Source requirement update: `fa2a96e953643b49465a2a5de34db9283ead048e`
-- PR: #2063
-- CI: latest-head pending
+- Conflict-resolution integration head: `1c1a479eb93be7e21becaa2211463cb6f97b8a06`
+- Protected merge: PR #2063 → `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`
 - Evidence index: `evidence/M8-CALL-001/README.md`
 
-## Risks / blockers
+## Risks / follow-up scope
 
-- 实际 STT、AI MCP resolver、MCP Host executor、媒体 transport 尚未在本任务内接线；本任务完成后仍需后续原子任务。
+- 实际 STT、AI MCP resolver、MCP Host executor、媒体 transport 不属于本原子任务，继续由 `M8-CALL-002`、`M8-CALL-003`、`M8-CALL-004` 与 M10/M11 后续任务承接。
 - MCP Tool catalog 必须来自该 MiniApp 的真实 `tools/list`，不能由模型自行生成；Host 接线任务需要保留现有 MCP 审批/高风险工具确认语义。
-- 新增协议字段需确认向后兼容策略；当前先保持 protocol version 2，仅扩展 serde 枚举/结构，若跨版本兼容测试要求升级则另立 ADR/任务。
+- 新增协议字段保持 protocol version 2；若后续跨版本兼容测试要求升级，另立 ADR/任务。
 
 ## Next action
 
-通过 GitHub Actions 验证 MCP-only Rust contract；随后落地 host-side `tools/list` catalog snapshot、AI constrained tool selection、`tools/call` executor、Conversation result projection，并继续拆分 STT/desktop-mobile UI/E2E。
+推进 `M8-CALL-002` streaming STT + Conversation projection、`M8-CALL-003` real `tools/list` constrained resolver + `tools/call` Host executor，以及 `M8-CALL-004` unified composer routing；本任务本身已完成并通过 current-head CI、protected merge 与 canonical-main verification。

--- a/projects/telegram-fabushi-integration/management/wbs/M8.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M8.md
@@ -81,12 +81,12 @@
 
 - **交付物**：统一 MiniApp Service Call Rust 领域契约、MiniApp permission/bridge 请求模型，以及 MCP-only Tool catalog / routing / invocation contract。
 - **验收标准**：同一个 `ConversationId` 下支持 DTMF、speech transcript、chat text；DTMF 和聊天纯数字只能映射到当前 MiniApp 已暴露 MCP Tool；最终语音与自然语言文字只在真实 MCP Tool catalog 中解析；catalog 外 Tool 选择被拒绝；无匹配 Tool 返回 unavailable；实际业务 effect 只能为 `InvokeMcpTool`；voice/hybrid bridge 声明 `ServiceCall + Microphone` 权限；结束会话后拒绝新输入。
-- **客观验证**：`mahayana-messaging` Rust 单元测试 + GitHub Actions current-head CI。
+- **客观验证**：`mahayana-messaging` Rust 单元/contract tests、Clippy、Mahayana fast、Messaging Product Gate、repository CI、project governance + protected merge + canonical-main readback。
 - **来源**：`../source/2026-08-23-miniapp-ai-service-calls.md`
-- **状态**：IN_PROGRESS
-- **阻塞**：等待 MCP-only latest-head GitHub Actions；实际 STT/constrained MCP resolver/Host `tools/call` executor/media transport/UI 为后续任务。
-- **证据位置**：`../evidence/M8-CALL-001/README.md`
-- **下一步**：完成 MCP-only contract CI 验证，再推进 `M8-CALL-002` STT/投影、`M8-CALL-003` real `tools/list` catalog + constrained resolver + `tools/call` executor、`M8-CALL-004` composer routing、desktop/mobile UI 与 E2E。
+- **状态**：TESTED / COMPLETED
+- **阻塞**：本原子任务无阻塞；STT、real MCP resolver/executor、media/UI 属于后续任务。
+- **证据位置**：`../evidence/M8-CALL-001/README.md`; PR #2063; final head `1c1a479eb93be7e21becaa2211463cb6f97b8a06`; protected merge `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`。
+- **下一步**：推进 `M8-CALL-002` STT/投影、`M8-CALL-003` real `tools/list` catalog + constrained resolver + `tools/call` executor、`M8-CALL-004` composer routing、desktop/mobile UI 与 E2E。
 
 ### M8.T09 / M8-CALL-002 — streaming STT + Conversation transcript projection
 
@@ -95,9 +95,9 @@
 - **客观验证**：Host contract tests + Rust projection tests + current-head CI。
 - **来源**：`../docs/20-MiniApp-AI客服电话.md`
 - **状态**：NOT_STARTED
-- **阻塞**：依赖 M8-CALL-001 contract 稳定。
+- **阻塞**：依赖 M8-CALL-001 contract 稳定；该依赖已于 2026-08-26 关闭。
 - **证据位置**：待创建 `../evidence/M8-CALL-002/README.md`。
-- **下一步**：M8-CALL-001 current-head CI 后开始。
+- **下一步**：开始 streaming STT + canonical Conversation projection。
 
 ### M8.T10 / M8-CALL-003 — constrained MCP resolver + tools/call Host executor
 
@@ -106,9 +106,9 @@
 - **客观验证**：MCP contract/integration tests + unavailable/unauthorized/destructive cases + current-head CI。
 - **来源**：`../source/2026-08-23-miniapp-ai-service-calls.md`; ADR-0008。
 - **状态**：NOT_STARTED
-- **阻塞**：依赖 M8-CALL-001；复用 `frontend/packages/mcp-app-sdk` /现有 MCP Apps Host runtime。
+- **阻塞**：依赖 M8-CALL-001；该依赖已关闭；复用 `frontend/packages/mcp-app-sdk` /现有 MCP Apps Host runtime。
 - **证据位置**：待创建 `../evidence/M8-CALL-003/README.md`。
-- **下一步**：先从现有 MCP Host 找到 canonical `tools/list`/`tools/call` production seam，再接 service-call effect。
+- **下一步**：从现有 MCP Host canonical `tools/list`/`tools/call` production seam 接 service-call effect。
 
 ### M8.T11 / M8-CALL-004 — composer → MiniApp service-call MCP routing
 
@@ -117,6 +117,6 @@
 - **客观验证**：Electron/Host routing tests + Playwright acceptance。
 - **来源**：`../source/2026-08-23-miniapp-ai-service-calls.md`。
 - **状态**：NOT_STARTED
-- **阻塞**：依赖 M8-CALL-001 和 M8-CALL-003。
+- **阻塞**：依赖 M8-CALL-001 和 M8-CALL-003；其中 M8-CALL-001 已关闭。
 - **证据位置**：待创建 `../evidence/M8-CALL-004/README.md`。
 - **下一步**：在 unified Messenger composer 上接 service-call context routing。


### PR DESCRIPTION
## FAB-P0001 / TFI — M8-CALL-001 closure

Records the already-completed #2063 protected merge and canonical-main verification without changing product code.

### Evidence recorded
- final implementation head `1c1a479eb93be7e21becaa2211463cb6f97b8a06`
- seven current-head GitHub Actions workflows SUCCESS
- protected merge #2063 -> `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`
- canonical `main` readback confirms service-call core blob `d6f3f503c1bccde38408ce507b9342717813b3ec`

### Project records synchronized
- task
- WBS
- acceptance matrix
- status report
- changelog
- evidence index

This PR is documentation/governance only. It marks the atomic MCP-only core-contract slice `TESTED / COMPLETED`; STT, real MCP Host resolver/executor, composer routing, media, UI and E2E remain separate follow-up tasks.