### PR TITLE
fix(desktop): stop first-login reload and restore motion tier

### DIFF
--- a/.github/scripts/assert-bot-mark-motion.py
+++ b/.github/scripts/assert-bot-mark-motion.py
@@ -10,6 +10,8 @@ required_component = [
     'FabushiBotMarkEngine',
     'data-engine="fabushi-motion-v2"',
     'data-renderer="grok-mark"',
+    'data-motion-tier={botMarkMotionTier(state, emphasis, followPointer)}',
+    'AMBIENT_MOTION_STATES',
     '"blob", "pebble", "squircle", "tablet", "wedge", "hex", "cloud", "teardrop"',
 ]
 for marker in required_component:
@@ -58,4 +60,4 @@ if 'className={styles.sidebarBotMark}' in host:
     if 'followPointer' in sidebar_region:
         raise SystemExit('BotMark motion gate: sidebar list marks must not attach pointer-follow listeners')
 
-print('BotMark motion gate passed: stable Fabushi semantics with Grok geometry, eyes, state motion, pointer gaze, and reduced-motion support.')
+print('BotMark motion gate passed: stable Fabushi semantics and motion tiers with Grok geometry, eyes, state motion, pointer gaze, and reduced-motion support.')

--- a/desktop/src/account-session-sync.ts
+++ b/desktop/src/account-session-sync.ts
@@ -5,19 +5,19 @@ import {
 } from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
 
 const REAUTH_POLL_MS = 350;
+const MESSENGER_WORKSPACE_SELECTOR = '[data-testid="messenger-workspace"]';
 
 let installed = false;
 
 /**
  * Keep the top-level DesktopShell auth gate synchronized with browser login
- * completions that happen inside HostClient after an explicit logout or a
- * terminal/revoked session.
+ * completions that happen after an explicit logout or terminal/revoked session.
  *
- * DesktopShell deliberately stops polling while a valid session is active.
- * When account-scoped state is reset it emits MAHAYANA_ACCOUNT_SESSION_RESET_EVENT;
- * from that point we poll only until the Rust Host reports a new authenticated
- * session, then reload once so every account-scoped transport/cache is rebuilt
- * from the new identity.
+ * The same account-reset event is also emitted during the normal first-login
+ * bootstrap when no Messenger workspace has existed yet. That path is already
+ * handled by DesktopShell's own auth probe and must never trigger a renderer
+ * reload. We therefore arm this synchronizer only when the reset is observed
+ * while a real Messenger workspace is mounted.
  */
 export function installDesktopAccountSessionSync(): () => void {
   if (installed || typeof window === 'undefined' || !isElectronMahayanaHostAvailable()) {
@@ -52,7 +52,12 @@ export function installDesktopAccountSessionSync(): () => void {
       if (state.loggedIn) {
         waitingForLogin = false;
         clearTimer();
-        window.location.reload();
+        // If DesktopShell has already restored the workspace itself, there is
+        // nothing to rebuild. Only the post-logout HostClient path needs one
+        // reload to re-enter the authenticated top-level shell.
+        if (!document.querySelector(MESSENGER_WORKSPACE_SELECTOR)) {
+          window.location.reload();
+        }
         return;
       }
     } catch {
@@ -63,6 +68,14 @@ export function installDesktopAccountSessionSync(): () => void {
   };
 
   const onAccountSessionReset = () => {
+    // Initial unauthenticated bootstrap emits the same cache-reset event. Do not
+    // arm in that state; otherwise the first successful login races DesktopShell
+    // and causes an unnecessary reload that detaches active controls.
+    if (!document.querySelector(MESSENGER_WORKSPACE_SELECTOR)) {
+      waitingForLogin = false;
+      clearTimer();
+      return;
+    }
     waitingForLogin = true;
     clearTimer();
     schedule(0);

--- a/frontend/apps/web/src/app/host/bot-mark.tsx
+++ b/frontend/apps/web/src/app/host/bot-mark.tsx
@@ -108,6 +108,18 @@ const COLORS: readonly BotMarkColor[] = [
   "brown", "red", "orange", "yellow", "green", "cyan", "blue", "violet", "magenta", "gray",
 ];
 
+const AMBIENT_MOTION_STATES = new Set<BotMarkState>([
+  "idle", "sleeping", "drowsy", "bored", "powering-down",
+]);
+
+export function botMarkMotionTier(
+  state: BotMarkState,
+  emphasis = false,
+  followPointer = false,
+): "ambient" | "active" {
+  return !emphasis && !followPointer && AMBIENT_MOTION_STATES.has(state) ? "ambient" : "active";
+}
+
 const COLOR_VALUES: Record<BotMarkColor, { light: string; dark: string }> = {
   black: { light: "#000000", dark: "#FFFFFF" },
   brown: { light: "#A27952", dark: "#855C36" },
@@ -203,6 +215,7 @@ export const BotMark = forwardRef<BotMarkHandle, BotMarkProps>(function BotMark(
       data-paused={paused || undefined}
       data-shape={shape}
       data-color={color}
+      data-motion-tier={botMarkMotionTier(state, emphasis, followPointer)}
       data-engine="fabushi-motion-v2"
       data-renderer="grok-mark"
       style={style}

--- a/projects/fabushi-account-access-control/source/2026-08-26-aac003-run977-root-cause.md
+++ b/projects/fabushi-account-access-control/source/2026-08-26-aac003-run977-root-cause.md
@@ -1,0 +1,17 @@
+# AAC-003 exact-main run #977 root-cause follow-up
+
+Exact-main Electron run `32973176951` (run number 977, SHA `9699ba5c0400f93d235f0853be9003e6ea7977b2`) proved the first #2153 repair partially successful: the stable `fabushi-motion-v2` BotMark nodes were visible again and marketplace search/install E2E passed. The run still failed the Linux pre-package user journey for two independent reasons.
+
+## 1. First-login reset incorrectly armed the reauthentication reload
+
+`clearAccountScopedDesktopCaches()` is intentionally called when the initial auth probe reports `loggedIn=false`, so `MAHAYANA_ACCOUNT_SESSION_RESET_EVENT` is not exclusive to logout. The first version of `account-session-sync.ts` armed on every reset. During normal first login it raced DesktopShell's own 900 ms auth probe and reloaded `app://bundle/index.html` after the Messenger had already become interactive. Playwright correctly observed controls detaching during send/create/scroll actions.
+
+The synchronizer is now armed only when the reset event is observed while `messenger-workspace` is actually mounted. That distinguishes manual logout / terminal session revocation from first-login bootstrap without introducing another global state flag. Once reauthenticated, it reloads only if DesktopShell has not already restored the workspace.
+
+## 2. Grok renderer migration also removed the stable motion-tier attribute
+
+Run #977 found the profile BotMark itself, but the existing contract expected `data-motion-tier="ambient"` for an idle, non-emphasized, non-pointer-follow mark. The pre-Grok implementation derived this from `idle`, `sleeping`, `drowsy`, `bored`, and `powering-down` states.
+
+That exact semantic tier function is restored while the Grok renderer remains unchanged. The BotMark architecture gate now requires the semantic motion-tier binding in addition to `data-engine="fabushi-motion-v2"` and `data-renderer="grok-mark"`.
+
+AAC-003 remains `in-progress` until a later exact-main run passes Linux/macOS/Windows packaged user journeys and publishes a desktop GitHub Release newer than 1.0.941.


### PR DESCRIPTION
## FAB-P0008 / AAC-003 exact-main #977 follow-up

Exact-main Electron run #977 proved that the first #2153 repair restored the BotMark nodes and marketplace E2E, but it exposed two remaining release blockers.

### 1. Scope reauthentication reload to a real logged-out workspace
`MAHAYANA_ACCOUNT_SESSION_RESET_EVENT` is also emitted during first-login bootstrap when the initial auth probe returns `loggedIn=false`. The first synchronizer armed on every reset and raced DesktopShell's own auth probe, causing repeated `app://bundle/index.html` reloads and detached DOM controls across the Linux E2E suite.

The synchronizer now arms only if `messenger-workspace` is mounted at reset time, which is true for manual logout/terminal revoked-session and false for first-login bootstrap. After a new authenticated Host session is observed, it reloads only if DesktopShell has not already restored the workspace.

### 2. Restore the stable BotMark motion-tier contract
The pre-Grok BotMark exposed `data-motion-tier=ambient|active`. Idle/sleeping/drowsy/bored/powering-down marks are ambient unless emphasized or pointer-following. That exact semantic function is restored without changing the Grok renderer. The motion gate now protects `data-engine`, `data-renderer`, and the motion-tier binding together.

### Durable evidence
`projects/fabushi-account-access-control/source/2026-08-26-aac003-run977-root-cause.md` records the #977 evidence and keeps AAC-003 in-progress.

### Acceptance
Do not weaken E2E. Merge only after PR gates pass, then require a new exact-main Electron run to pass Linux pre-package and packaged macOS/Windows user journeys and publish a GitHub Release newer than 1.0.941.