### PR TITLE
chore(gbf): start continuous GBF-805 product parity closure

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json
@@ -1,11 +1,48 @@
 {
   "schemaVersion": 3,
-  "revision": "2026-08-10.20",
+  "revision": "2026-08-26.805",
   "keepAlive": true,
   "authoritative": true,
   "maxConcurrent": 2,
   "reviewGate": false,
   "tasks": [
+    {
+      "id": "GBF-805-GROK-PARITY-20260826",
+      "goalVersion": 1,
+      "revision": 1,
+      "applyMode": "interrupt",
+      "title": "GBF-805 Grok Bot 0.18 可观察效果完整收敛",
+      "promptTemplate": "continue-to-complete",
+      "directive": "从 canonical main 开始持续推进 FAB-P0004 / GBF-805，直到用户实际安装的产品达到 Grok Bot 0.18 reconstructed 的可观察行为与体验标准，而不是只以代码存在或单元测试通过作为完成。每轮先读取 projects/grok-bot-fabushi-integration 全部管理/验收/来源文档与 issue #2155，再读取 bhrum/grok-bot-0.18-reconstructed@a9f633e09d49a85829b8236331b9e21f7e612634 中与 Bot、Agent、conversation、renderer、avatar、storage、settings 相关的可用源码/证据。必须遵守 provenance：可以复刻可观察行为、交互、数据模型、状态机和架构；未经许可不要整包复制生产 renderer、品牌资源或不明许可资产。所有 Bot 必须进入唯一 Mahayana Agent runtime。不要新建第二套执行器。不要弱化现有 E2E selector、assertion、security gate。必须持续实际实现、测试、合并、exact-main packaged E2E、发布和旧客户端更新验证，所有客观验收项完成后才把 GBF-805 标记 RELEASED。",
+      "connector": "GitHub",
+      "repository": "bhrumom/fabushi",
+      "codeDirectory": ".",
+      "priority": 1000,
+      "timeout": 21600,
+      "maxTaskContinuations": 0,
+      "maxRuntimeRetries": 5,
+      "dependsOn": [],
+      "resourceLocks": [
+        "worktree:fabushi",
+        "program:FAB-P0004",
+        "task:GBF-805",
+        "runtime:mahayana-agent",
+        "surface:desktop-messenger",
+        "service:mahayana-platform",
+        "release:desktop"
+      ],
+      "documentDirectory": "projects/grok-bot-fabushi-integration",
+      "specSources": [
+        "projects/grok-bot-fabushi-integration/management/01-WBS原子任务.md",
+        "projects/grok-bot-fabushi-integration/management/03-验收追踪矩阵.md",
+        "projects/grok-bot-fabushi-integration/management/05-状态报告.md",
+        "projects/grok-bot-fabushi-integration/management/07-变更日志.md",
+        "projects/grok-bot-fabushi-integration/management/tasks/GBF-507-mahayana-agent-workbench.md",
+        "projects/grok-bot-fabushi-integration/management/tasks/GBF-805-observable-parity-closure.md",
+        "projects/grok-bot-fabushi-integration/decisions/ADR-0003-single-agent-runtime.md"
+      ],
+      "prompt": "完成 FAB-P0004 / GBF-805 的全部剩余工作。第一，修复账号与设置：已认证用户的 General 首屏必须稳定显示并可操作‘退出登录’，logout 必须经过 canonical Host 边界并清除账号级 projection/draft/journal/native mirror，重新浏览器登录后恢复 workspace；以真实 /api/auth/user-info 和稳定 account id 22 作为身份事实，统一 Web、Rust platform、AI backend、provider router、usage/billing 的 super-admin + unlimited entitlement，任何模型路由都不得再为该账号报‘本月 AI token 额度不足’。第二，实现真正的 Grok 风格多步骤回复：唯一 Mahayana Agent runtime 产生真实 planning/reasoning/model route/ordered steps/tool calls/results/approvals/subagents/background tasks/artifacts/usage/failure/interrupted/resume/final answer 事件，Messenger 逐步流式显示，不能退化成普通气泡或单个失败卡。第三，收敛 Bot identity/avatar：Bot 使用稳定 canonical cloud bot id，联系人列表、Header、资料页、消息和 Workbench 共享同一 identity；头像 shape/color/eyes/motion choreography 必须基于稳定 Bot id，在 app restart、切换联系人、消息发送、多客户端后保持一致，不得把 conversationId/requestId/operationId 当 Bot identity。第四，把 Bot 创建/编辑/删除、avatar metadata、Conversation、Message、Run、Step、ToolResult、Approval、Artifact 迁移到 Rust/cloud canonical authoritative store；localStorage 只允许 bounded projection/cache；完成 GBF-601/602 的 crash/restart、operationId/requestId 幂等和无重复副作用 resume。第五，按照固定参考 bhrum/grok-bot-0.18-reconstructed@a9f633e09d49a85829b8236331b9e21f7e612634 逐屏收敛 Messenger typography、spacing、card hierarchy、streaming、tool/approval/error/result transition、avatar slots 和动态效果，用 screenshot/video/trace 做视觉证据。第六，完善而非削弱 TypeScript/Rust/unit/integration/architecture/security/E2E；exact-main macOS/Windows/Linux packaged journey 全绿，共享协议影响到 Android/iOS 时相应 gate 也必须绿；从同一个 tested main SHA 发布 updater-compatible immutable GitHub Release，并验证当前安装的旧 macOS Fabushi 能发现并安装新版本。最后更新 GBF-501/601/602/703/801/802/803/804/805 的 WBS、验收矩阵、状态、变更日志、evidence；任何一项缺少客观证据都不得声称全部完成。"
+    },
     {
       "id": "ios-external-miniapp-e2e-20260810",
       "goalVersion": 1,
@@ -40,7 +77,7 @@
         ".agents/plugins/plugins/chatgpt-auto-confirm/tasks/ios-external-miniapp-e2e-20260810/UI_UX.md",
         ".agents/plugins/plugins/chatgpt-auto-confirm/tasks/ios-external-miniapp-e2e-20260810/ACCEPTANCE.md"
       ],
-      "prompt": "实现 iOS 端从零插件的新用户状态开始的真实外部小程序全链路自动化：为 CLI 核心和 iOS/Flutter 薄 UI 建立业界标准、可快速驱动的测试接口；在构建安装包前后可自动启动、重置、查询、执行和读取结构化事件；搜索线上官方已发布的“全球法布施”小程序，验证它不是内置功能，下载并校验远端构件后安装；验证更新版本可热更新且无需重新打包 App；进入该插件机器人会话发送确定性测试消息；最终不能依据 UI 文案判断成功，必须根据 CLI/runtime 日志、安装回执、来源与版本、tool call、correlation id 和插件真实返回完成断言。覆盖所有可发现 action 的契约自动化、失败恢复、进程重启后的安装持久化、安全边界，以及 iOS Simulator 的 CI 自动执行；真机只保留少量签名/系统能力烟雾测试，不再作为核心功能验证的唯一手段。"
+      "prompt": "实现 iOS 端从零插件的新用户状态开始的真实外部小程序全链路自动化：为 CLI 核心和 iOS/Flutter 薄 UI 建立业界标准、可快速驱动的测试接口；在构建安装包前后可自动启动、重置、查询、执行和读取结构化事件；搜索线上官方已发布的‘全球法布施’小程序，验证它不是内置功能，下载并校验远端构件后安装；验证更新版本可热更新且无需重新打包 App；进入该插件机器人会话发送确定性测试消息；最终不能依据 UI 文案判断成功，必须根据 CLI/runtime 日志、安装回执、来源与版本、tool call、correlation id 和插件真实返回完成断言。覆盖所有可发现 action 的契约自动化、失败恢复、进程重启后的安装持久化、安全边界，以及 iOS Simulator 的 CI 自动执行；真机只保留少量签名/系统能力烟雾测试，不再作为核心功能验证的唯一手段。"
     }
   ]
 }

--- a/.github/workflows/chatgpt-auto-confirm-task-dispatch.yml
+++ b/.github/workflows/chatgpt-auto-confirm-task-dispatch.yml
@@ -1,0 +1,34 @@
+name: ChatGPT auto-confirm task dispatcher
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.agents/plugins/plugins/chatgpt-auto-confirm/tasks/actions-inbox.json'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: chatgpt-auto-confirm-task-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start continuous runner
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            -H 'Accept: application/vnd.github+json' \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/chatgpt-auto-confirm-runner.yml/dispatches" \
+            -f ref=main
+          echo 'Dispatched chatgpt-auto-confirm-runner.yml on main.'

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-805-observable-parity-closure.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-805-observable-parity-closure.md
@@ -1,0 +1,82 @@
+# GBF-805 — Grok Bot 0.18 observable parity closure
+
+- Project ID: `FAB-P0004`
+- Task ID: `GBF-805`
+- Status: `IN_PROGRESS`
+- Opened: `2026-08-26`
+- Tracking issue: `#2155`
+- Reference baseline: `bhrum/grok-bot-0.18-reconstructed@a9f633e09d49a85829b8236331b9e21f7e612634`
+- Canonical implementation: `bhrumom/fabushi`
+
+## Objective
+
+Close the remaining product gap between the current Fabushi Messenger/Bot experience and the observable Grok Bot 0.18 reconstructed baseline. Completion is defined by what an installed user can observe and operate in packaged builds, not by the existence of isolated implementation files.
+
+The sole execution runtime remains Mahayana. This task does not create a second agent loop.
+
+## Required closure
+
+### 1. Account, logout and unlimited entitlement
+
+- General settings exposes a visible `退出登录` action for every authenticated desktop session.
+- Logout uses the canonical Host boundary, clears account-scoped projection/draft/conversation/run caches and native mirrors, and allows browser reauthentication to rebuild the workspace.
+- Stable account identity `22` and the authenticated profile are authoritative for the `bhrum108` entitlement. Web, Rust platform, AI backend, provider router and usage/billing surfaces agree on `super-admin + unlimited`.
+- No Mahayana/provider path may reject this entitled account with `本月 AI token 额度已不足`.
+
+### 2. True multi-step Agent transcript
+
+A Bot reply is a real Mahayana run and exposes the real runtime lifecycle in Messenger:
+
+1. request accepted / planning / reasoning;
+2. model/provider route;
+3. ordered steps with status and timing;
+4. tool/MCP calls and tool results;
+5. approvals and denial/acceptance;
+6. subagents/background/async tasks;
+7. artifacts and generated outputs;
+8. token/context usage;
+9. interruption/error/retry/resume;
+10. streaming and final answer.
+
+The UI must not collapse the above into a normal assistant bubble or one coarse failure card.
+
+### 3. Stable Bot identity and Grok-style motion
+
+- Every Bot has a stable canonical cloud Bot ID.
+- Conversation list, header, profile, message author and Workbench resolve the same Bot ID.
+- Shape, color, eyes and motion choreography are deterministic from canonical identity and real runtime state.
+- App restart, contact switching, sending messages and another client must not silently generate a different avatar for the same Bot.
+- Transient `conversationId`, `requestId` or `operationId` must never become visual identity seeds.
+
+### 4. Canonical cloud/Rust persistence
+
+Canonical authoritative records cover at least:
+
+- Bot and avatar metadata;
+- Conversation and Message;
+- Agent Run and Step;
+- ToolResult;
+- Approval;
+- Artifact;
+- correlation/idempotency metadata required for recovery.
+
+Renderer local storage is a bounded cache/projection only. `GBF-601` and `GBF-602` must close with side-effect-safe restart/resume keyed by stable request/operation identifiers.
+
+### 5. Observable visual parity
+
+Use the pinned reconstructed baseline as an observable reference for Messenger typography, spacing, hierarchy, streaming transitions, run cards, steps, tools, approvals, errors, final results and Bot motion. Produce representative screenshots/video/trace for idle, thinking, tool-running, approval, error and result states.
+
+Provenance stays explicit: reimplement observable behavior and architecture in Fabushi-owned source. Do not wholesale vendor an unlicensed production renderer, brand assets or unknown-license resources.
+
+## Acceptance gates
+
+- Existing selectors/assertions/security gates are not weakened to obtain green CI.
+- Relevant TypeScript, Rust, unit, integration, architecture and security suites pass.
+- Exact-main packaged journeys pass on macOS, Windows and Linux; Android/iOS gates pass when shared contracts or surfaces are affected.
+- Release assets come from the exact tested main SHA and include updater-compatible metadata.
+- An already-installed older macOS client is proven to discover the new release.
+- Project records for `GBF-501/601/602/703/801/802/803/804/805` are updated from objective evidence.
+
+## Completion rule
+
+`GBF-805` may be marked `RELEASED` only after every required closure above has objective evidence on canonical `main` and the exact tested release. Missing visual, persistence, entitlement, packaged E2E, update-discovery or provenance evidence is a blocker, not a documentation exception.


### PR DESCRIPTION
Implements the durable execution entrypoint for #2155 / FAB-P0004 / GBF-805.

- prioritizes GBF-805 in the authoritative continuous-runner inbox
- records objective completion criteria for logout, unlimited entitlement, true Mahayana multi-step transcript, stable cloud Bot identity/avatar, canonical Rust/cloud persistence, restart-safe recovery and visual parity
- adds a main-push dispatcher so task-inbox changes automatically start the existing ChatGPT continuous runner
- explicitly forbids weakening E2E/security gates or falsely declaring completion without exact-main packaged/release evidence

This PR intentionally starts the long-running implementation/release closure using the repository's existing continuous execution infrastructure; the task may only be marked RELEASED after the objective acceptance gates in GBF-805 are proven.