### PR TITLE
test(tfi): close packaged Mini App sync recovery acceptance

### DIFF
--- a/desktop/e2e/miniapp-bot-parity.spec.ts
+++ b/desktop/e2e/miniapp-bot-parity.spec.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
+const syncProbeKey = 'm2_sync_packaged_probe';
 
 async function launchDesktopApp(appDataDir: string) {
   return electron.launch({
@@ -37,11 +38,41 @@ async function navigate(page: Page, title: string): Promise<void> {
   await page.getByTitle(title, { exact: true }).click();
 }
 
-test('installed Mini App projects its Bot into Contacts and Bots and keeps Bot chat as the launch center', async () => {
+async function waitForGlobalDharmaBot(page: Page) {
+  await navigate(page, 'Bots');
+  const botPeer = page.getByTestId('peer-miniapp:bot:global-dharma');
+  await expect(botPeer).toBeVisible({ timeout: 15_000 });
+  return botPeer;
+}
+
+async function writeCloudProbe(page: Page, value: string): Promise<void> {
+  const frame = page.frameLocator('iframe[title="global-dharma"]');
+  const stored = await frame.locator('body').evaluate(async (_body, probe) => {
+    const api = (window as any).FabushiMiniApp?.CloudStorage;
+    if (!api) throw new Error('FabushiMiniApp.CloudStorage is unavailable');
+    await api.setItem('m2_sync_packaged_probe', probe);
+    return api.getItem('m2_sync_packaged_probe');
+  }, value);
+  expect(stored).toBe(value);
+}
+
+async function readCloudProbe(page: Page): Promise<string | null> {
+  const frame = page.frameLocator('iframe[title="global-dharma"]');
+  return frame.locator('body').evaluate(async () => {
+    const api = (window as any).FabushiMiniApp?.CloudStorage;
+    if (!api) throw new Error('FabushiMiniApp.CloudStorage is unavailable');
+    return api.getItem('m2_sync_packaged_probe');
+  });
+}
+
+test('installed Mini App projects its Bot into Contacts/Bots and recovers Bot history plus CloudStorage', async ({}, testInfo) => {
+  test.setTimeout(90_000);
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-miniapp-bot-e2e-'));
-  const app = await launchDesktopApp(appDataDir);
+  const probeValue = `packaged-sync-${Date.now()}`;
+  const firstApp = await launchDesktopApp(appDataDir);
+  let restartedApp: Awaited<ReturnType<typeof launchDesktopApp>> | null = null;
   try {
-    const page = await app.firstWindow();
+    const page = await firstApp.firstWindow();
     await completeBrowserLogin(page);
 
     await page.getByTestId('global-search-trigger').click();
@@ -54,12 +85,11 @@ test('installed Mini App projects its Bot into Contacts and Bots and keeps Bot c
     await expect(appResult.getByRole('button', { name: '打开' })).toBeVisible();
 
     await navigate(page, '联系人');
-    const botPeer = page.getByTestId('peer-miniapp:bot:global-dharma');
-    await expect(botPeer).toBeVisible();
-    await expect(botPeer).toContainText('全球法布施');
+    const contactBot = page.getByTestId('peer-miniapp:bot:global-dharma');
+    await expect(contactBot).toBeVisible();
+    await expect(contactBot).toContainText('全球法布施');
 
-    await navigate(page, 'Bots');
-    await expect(botPeer).toBeVisible();
+    const botPeer = await waitForGlobalDharmaBot(page);
     await botPeer.click();
     await expect(page.getByTestId('miniapp-bot-open')).toBeVisible();
 
@@ -68,19 +98,39 @@ test('installed Mini App projects its Bot into Contacts and Bots and keeps Bot c
     await expect(page.getByTestId('miniapp-bot-commands')).toBeVisible();
     await expect(page.getByTestId('miniapp-bot-commands')).toContainText('/status');
 
-    await input.fill('/global-dharma:status {"detail":true}');
+    const commandText = '/global-dharma:status {"detail":true}';
+    const naturalText = 'please show status now';
+    await input.fill(commandText);
     await page.getByTestId('messenger-send').click();
     await expect(page.getByText('command', { exact: true })).toBeVisible();
 
-    await input.fill('please show status now');
+    await input.fill(naturalText);
     await page.getByTestId('messenger-send').click();
     await expect(page.getByText('natural-language', { exact: true })).toBeVisible();
 
     await page.getByTestId('miniapp-bot-open').click();
     await expect(page.getByText('Mini App · 已安装线上包 · 受控宿主容器')).toBeVisible();
     await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
+    await writeCloudProbe(page, probeValue);
+    await page.screenshot({ path: testInfo.outputPath('miniapp-sync-before-restart.png'), fullPage: true });
+
+    await firstApp.close();
+    restartedApp = await launchDesktopApp(appDataDir);
+    const restartedPage = await restartedApp.firstWindow();
+    await completeBrowserLogin(restartedPage);
+
+    const recoveredBot = await waitForGlobalDharmaBot(restartedPage);
+    await recoveredBot.click();
+    await expect(restartedPage.getByText(commandText, { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(restartedPage.getByText(naturalText, { exact: true })).toBeVisible();
+
+    await restartedPage.getByTestId('miniapp-bot-open').click();
+    await expect(restartedPage.locator('iframe[title="global-dharma"]')).toBeVisible();
+    await expect.poll(() => readCloudProbe(restartedPage), { timeout: 15_000 }).toBe(probeValue);
+    await restartedPage.screenshot({ path: testInfo.outputPath('miniapp-sync-after-restart.png'), fullPage: true });
   } finally {
-    await app.close();
+    await restartedApp?.close().catch(() => {});
+    await firstApp.close().catch(() => {});
     await rm(appDataDir, { recursive: true, force: true });
   }
 });

--- a/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-002-telegram-multidevice-account-sync.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-002-telegram-multidevice-account-sync.md
@@ -6,7 +6,8 @@
 - **Stages**: `M2 realtime sync + M7 Bot identity + M8 Mini Apps`
 - **Status**: `TESTING`
 - **Started**: `2026-08-27`
-- **Branch**: `feat/tfi-multidevice-account-sync`
+- **Implementation PR**: `#2159` — merged as `18042e968f80c97efba6f8bc6878579348c21d3a`
+- **Acceptance follow-up branch**: `test/tfi-m2-sync-packaged-recovery`
 - **Source**: `../../source/2026-08-27-telegram-multidevice-account-sync.md`
 - **Depends on**: `M2-SYNC-001`, `M8-MARKET-002`
 
@@ -25,45 +26,45 @@ The implementation intentionally keeps two durable synchronization domains inste
 - Replace token-hash Marketplace ownership with a canonical account scope resolved from authenticated account identity.
 - Different device/session access tokens for the same account map to one account key.
 - Device/session identity remains separate and auditable.
-- **State**: IMPLEMENTED + branch-tested.
+- **State**: IMPLEMENTED + branch-tested + merged.
 
 ### M2-SYNC-002.B — account sync state / difference protocol
 - Add explicit account sync state and snapshot/delta response metadata around a durable account event journal.
 - Detect ahead/expired/missing cursor and perform account-scoped snapshot recovery.
 - Preserve pagination, idempotent projection and account isolation.
-- **State**: IMPLEMENTED + branch-tested.
+- **State**: IMPLEMENTED + branch-tested + merged.
 
 ### M2-SYNC-002.C — Bot add/remove synchronization
 - Persist account-level added-Bot membership independently from global Bot registry/profile data.
 - Add/remove operations emit durable account-scoped events.
 - Snapshot/delta sync reconstructs added Bots on a new device.
 - Manual Bot membership remains independent from a Mini App-owned Bot source.
-- **State**: IMPLEMENTED + branch-tested.
+- **State**: IMPLEMENTED + branch-tested + merged.
 
 ### M2-SYNC-002.D — Mini App install/uninstall synchronization
 - Make installed Mini Apps account-scoped and durable.
 - Installation/uninstallation emits the account sync stream and projects the manifest Bot identity into Contacts/Bots.
 - New devices restore the account install list and reconcile missing local package bytes automatically.
-- **State**: IMPLEMENTED + branch-tested.
+- **State**: IMPLEMENTED + branch-tested + merged.
 
 ### M2-SYNC-002.E — Mini App cloud storage
 - Add account + MiniApp scoped cloud key/value storage with revision/update events.
 - Keep device-local and secure-device storage explicitly outside cloud sync.
 - Expose list/get/set/delete through the authenticated native bridge and a Mini App iframe `FabushiMiniApp.CloudStorage` host API bound to the current app id.
-- **State**: IMPLEMENTED + branch-tested.
+- **State**: IMPLEMENTED + branch-tested + merged.
 
 ### M2-SYNC-002.F — Bot conversation/history convergence
 - Normal/self-hosted Bot conversations remain on canonical Messaging v2 and inherit its durable message/read-state cursor.
 - Mini App Bot messages no longer use renderer memory as authority; they persist in the existing central `user_id + plugin_instance_id` message store.
 - Mini App message writes emit account-sync invalidation events so another device reloads canonical history.
-- **State**: IMPLEMENTED + branch-tested.
+- **State**: IMPLEMENTED + branch-tested + merged.
 
 ### M2-SYNC-002.G — desktop sync coordinator
 - Persist the account sync cursor in renderer + native client persistence.
 - Startup: restore local projection immediately, run Messaging v2 catch-up, then account catch-up.
 - Online: account changes converge on the active 2-second foreground/background synchronization cadence; cursor gaps use difference recovery.
 - Account switch/logout clears account-bound cursors/projections.
-- **State**: IMPLEMENTED + renderer build-tested.
+- **State**: IMPLEMENTED + renderer build-tested + merged.
 
 ### M2-SYNC-002.H — objective verification
 - Existing Messaging v2 tests cover two-device actor/session cursor resume, restart and pruned-cursor snapshot recovery for canonical chat data.
@@ -71,7 +72,7 @@ The implementation intentionally keeps two durable synchronization domains inste
 - Electron native bridge tests cover account sync, account Bot and Mini App package reconciliation APIs.
 - Renderer TypeScript + Vite build proves the desktop coordinator/CloudStorage bridge compiles in the shipping renderer.
 - Protected PR gates, merge queue, canonical-main packaged E2E screenshots/video/trace and Release evidence remain mandatory before completion.
-- **State**: BRANCH VERIFIED; canonical-main acceptance pending.
+- **State**: IMPLEMENTATION MERGED; packaged recovery acceptance follow-up in progress.
 
 ## Open-source-first decision
 
@@ -87,11 +88,15 @@ The implementation intentionally keeps two durable synchronization domains inste
 - Mini App package bytes/runtime caches remain device-local, while installation entitlement/configuration is account-level.
 - Secure device storage remains intentionally device-local and never enters general account sync.
 - Account logout/switch cannot expose the previous account's cursor or projection.
+- Exact-main packaged Electron acceptance must demonstrate install → Contacts/Bots → Bot chat → restart/history recovery → Mini App CloudStorage recovery and retain screenshot/video/trace evidence.
 
 ## Evidence
 
 - Evidence index: `../../evidence/M2-SYNC-002/README.md`.
 - Renderer integration gate: GitHub Actions run `33022386381` — SUCCESS (`git diff --check`, Native tests, Electron TypeScript + Vite renderer build).
 - Two-device integration gate: GitHub Actions run `33022543329` — SUCCESS. Verified different session tokens for one account, Mini App install/Bot projection, Mini App Bot history, CloudStorage, content state, cursor difference replay, uninstall propagation and cross-account isolation.
+- Implementation PR `#2159` merged through repository protection as exact main SHA `18042e968f80c97efba6f8bc6878579348c21d3a`.
+- Exact-main Electron run `33024284365` and Native mobile run `33024284539` started from that SHA; their final outcome is not used as completion evidence until they finish.
+- Acceptance follow-up commit `fa6c0d5802ff053e719bc77e1dec21d33086271f` strengthens `desktop/e2e/miniapp-bot-parity.spec.ts` with deterministic Bot history + `FabushiMiniApp.CloudStorage` restart recovery and explicit before/after screenshots; Playwright already records video + trace.
 - Persistent regression tests: `ai-backend/test/account_sync_store.test.js`, `ai-backend/test/miniapp_marketplace_http.test.js`, `ai-backend/test/multidevice_account_sync_integration.test.js`, `desktop/electron/native-capability-handlers.test.cjs`.
-- Completion remains blocked on protected PR current-head gates, merge queue, canonical-main package/E2E and newer Release evidence.
+- Completion remains blocked on the acceptance follow-up protected PR, its canonical-main packaged E2E, Native mobile success and the corresponding exact-SHA Release.


### PR DESCRIPTION
## Scope

Follow-up for `FAB-P0001 / TFI / M2-SYNC-002` after implementation PR #2159 merged.

The product implementation is already on `main`; this PR strengthens the mandatory packaged acceptance path instead of weakening the task's completion criteria.

### Added packaged acceptance
- install `global-dharma`
- verify its Bot appears in Contacts and Bots
- persist Bot command + natural-language conversation history
- open the Mini App and write through `FabushiMiniApp.CloudStorage`
- capture a before-restart screenshot
- restart the packaged app against the same account state
- verify the installed Bot is restored
- verify Bot chat history is restored from canonical account storage
- verify Mini App CloudStorage is restored
- capture an after-restart screenshot
- Playwright configuration already records full video + trace

The separate two-device backend integration run `33022543329` remains the objective proof that distinct session tokens for the same account converge across devices; this packaged journey proves the shipping Electron surface consumes and recovers that account state correctly.

## Governance

The existing `M2-SYNC-002` task record is updated in the same branch and remains `TESTING`. Completion still requires protected merge, exact-main packaged E2E, Native mobile success and the corresponding exact-SHA Release.
