### PR TITLE
test(tfi): assert Mini App Bot by canonical identity

### DIFF
--- a/desktop/e2e/miniapp-bot-parity.spec.ts
+++ b/desktop/e2e/miniapp-bot-parity.spec.ts
@@ -47,10 +47,15 @@ async function navigate(page: Page, title: string): Promise<void> {
   await page.getByTitle(title, { exact: true }).click();
 }
 
+function globalDharmaBotPeer(page: Page) {
+  return page.getByRole('button', { name: /@global_dharma_bot\b/ }).first();
+}
+
 async function waitForGlobalDharmaBot(page: Page) {
   await navigate(page, 'Bots');
-  const botPeer = page.getByTestId('peer-miniapp:bot:global-dharma');
+  const botPeer = globalDharmaBotPeer(page);
   await expect(botPeer).toBeVisible({ timeout: 15_000 });
+  await expect(botPeer).toContainText('全球法布施');
   return botPeer;
 }
 
@@ -94,8 +99,8 @@ test('installed Mini App projects its Bot into Contacts/Bots and recovers Bot hi
     await expect(appResult.getByRole('button', { name: '打开' })).toBeVisible();
 
     await navigate(page, '联系人');
-    const contactBot = page.getByTestId('peer-miniapp:bot:global-dharma');
-    await expect(contactBot).toBeVisible();
+    const contactBot = globalDharmaBotPeer(page);
+    await expect(contactBot).toBeVisible({ timeout: 15_000 });
     await expect(contactBot).toContainText('全球法布施');
 
     const botPeer = await waitForGlobalDharmaBot(page);

--- a/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-002-telegram-multidevice-account-sync.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M2-SYNC-002-telegram-multidevice-account-sync.md
@@ -8,7 +8,9 @@
 - **Started**: `2026-08-27`
 - **Implementation PR**: `#2159` — merged as `18042e968f80c97efba6f8bc6878579348c21d3a`
 - **Packaged acceptance PR**: `#2160` — merged as `69bafdbd726ba78e99f3dd69700183f00851a970`
-- **Active repair branch**: `fix/tfi-m2-sync-product-edge`
+- **Native product-edge repair PR**: `#2161` — merged as `ab6e3eb4787f9570aaff00342362000e1e960973`
+- **E2E shell-contract repair PR**: `#2162` — merged as `f565e46d070ce6f23183d861fee6cda589eca460`
+- **Active acceptance branch**: `fix/tfi-m2-sync-e2e-peer-identity`
 - **Source**: `../../source/2026-08-27-telegram-multidevice-account-sync.md`
 - **Depends on**: `M2-SYNC-001`, `M8-MARKET-002`
 
@@ -46,26 +48,26 @@ The implementation intentionally keeps two durable synchronization domains inste
 - Make installed Mini Apps account-scoped and durable.
 - Installation/uninstallation emits the account sync stream and projects the manifest Bot identity into Contacts/Bots.
 - New devices restore the account install list and reconcile missing local package bytes automatically.
-- **State**: IMPLEMENTED + branch-tested + merged; Electron edge repair pending protected merge.
+- **State**: IMPLEMENTED + branch-tested + merged; final packaged acceptance pending.
 
 ### M2-SYNC-002.E — Mini App cloud storage
 - Add account + MiniApp scoped cloud key/value storage with revision/update events.
 - Keep device-local and secure-device storage explicitly outside cloud sync.
 - Expose list/get/set/delete through the authenticated native bridge and a Mini App iframe `FabushiMiniApp.CloudStorage` host API bound to the current app id.
-- **State**: IMPLEMENTED + branch-tested + merged; packaged recovery proof pending repair merge.
+- **State**: IMPLEMENTED + branch-tested + merged; final packaged recovery proof pending.
 
 ### M2-SYNC-002.F — Bot conversation/history convergence
 - Normal/self-hosted Bot conversations remain on canonical Messaging v2 and inherit its durable message/read-state cursor.
 - Mini App Bot messages no longer use renderer memory as authority; they persist in the existing central `user_id + plugin_instance_id` message store.
 - Mini App message writes emit account-sync invalidation events so another device reloads canonical history.
-- **State**: IMPLEMENTED + branch-tested + merged; packaged recovery proof pending repair merge.
+- **State**: IMPLEMENTED + branch-tested + merged; final packaged recovery proof pending.
 
 ### M2-SYNC-002.G — desktop sync coordinator
 - Persist the account sync cursor in renderer + native client persistence.
 - Startup: restore local projection immediately, run Messaging v2 catch-up, then account catch-up.
 - Online: account changes converge on the active 2-second foreground/background synchronization cadence; cursor gaps use difference recovery.
 - Account switch/logout clears account-bound cursors/projections.
-- **State**: IMPLEMENTED + renderer build-tested + merged; native IPC exposure repair in progress.
+- **State**: IMPLEMENTED + renderer build-tested + merged; shipping IPC contract repaired and verified.
 
 ### M2-SYNC-002.H — objective verification
 - Existing Messaging v2 tests cover two-device actor/session cursor resume, restart and pruned-cursor snapshot recovery for canonical chat data.
@@ -74,7 +76,7 @@ The implementation intentionally keeps two durable synchronization domains inste
 - Renderer TypeScript + Vite build proves the desktop coordinator/CloudStorage bridge compiles in the shipping renderer.
 - Exact-main packaged Electron acceptance covers install → Contacts/Bots → Bot chat → restart/history recovery → Mini App CloudStorage recovery and retains screenshot/video/trace evidence.
 - Protected PR gates, merge queue, canonical-main packaged E2E and exact-SHA Release remain mandatory before completion.
-- **State**: TESTING — first exact-main delivery exposed a real native-edge regression; repair is implemented and awaiting protected verification.
+- **State**: TESTING — product projection is visible; final E2E locator now being aligned to canonical user-facing Bot identity.
 
 ## Exact-main regression found during acceptance
 
@@ -97,7 +99,13 @@ Electron exact-main run `33025670225` against `ab6e3eb4787f9570aaff00342362000e1
 - the real UI successfully opened the Global Dharma iframe and displayed `Mini App · 已安装线上包 · 账号云同步`, while two older E2E assertions still expected the historical `受控宿主容器` copy;
 - `miniapp-bot-parity.spec.ts` checked onboarding/login selectors before the first DOM surface had stabilized, so the onboarding dialog could mount after the helper had already moved on to waiting for Messenger. Other long-lived E2E helpers already guard this race with an initial surface poll.
 
-Diagnostic artifact `9628343898` (`fabushi-electron-linux-e2e-diagnostics`) contains screenshots, traces and error contexts. The follow-up synchronizes assertions to the current product copy and uses the established deterministic first-surface wait before onboarding/login handling. Product sync semantics are unchanged.
+Diagnostic artifact `9628343898` (`fabushi-electron-linux-e2e-diagnostics`) contains screenshots, traces and error contexts. PR `#2162` synchronized assertions to the current product copy and adopted the established deterministic first-surface wait before onboarding/login handling. Product sync semantics were unchanged.
+
+## Third exact-main acceptance result
+
+Electron exact-main run `33026283621` against `f565e46d070ce6f23183d861fee6cda589eca460` reduced the real-Host suite to a single failure. Diagnostic artifact `9628549449` proves the product requirement itself is already satisfied: after installation, the Contacts rail visibly contains a button named `全球法布施 … @global_dharma_bot` while the failing assertion waits for the internal test id `peer-miniapp:bot:global-dharma`.
+
+This is expected after account-level Bot convergence. Messenger deduplicates a Mini App-owned Bot against an existing canonical Bot identity; therefore the same visible Bot may be backed by a canonical Bot peer key instead of the temporary `miniapp:bot:*` projection key. The internal peer key is not a product contract. The acceptance test is being repaired to assert and open the Bot by its stable user-facing identity `@global_dharma_bot`, in both Contacts and Bots, while retaining all downstream history/CloudStorage restart assertions.
 
 ## Open-source-first decision
 
@@ -122,7 +130,10 @@ Diagnostic artifact `9628343898` (`fabushi-electron-linux-e2e-diagnostics`) cont
 - Two-device integration gate: GitHub Actions run `33022543329` — SUCCESS. Verified different session tokens for one account, Mini App install/Bot projection, Mini App Bot history, CloudStorage, content state, cursor difference replay, uninstall propagation and cross-account isolation.
 - Implementation PR `#2159` merged as exact main SHA `18042e968f80c97efba6f8bc6878579348c21d3a`.
 - Packaged acceptance PR `#2160` merged as `69bafdbd726ba78e99f3dd69700183f00851a970`, strengthening `desktop/e2e/miniapp-bot-parity.spec.ts` with Bot history + `FabushiMiniApp.CloudStorage` restart recovery, before/after screenshots, and existing Playwright video + trace capture.
-- First exact-main Electron run `33024284365` failed before packaging as intended by the release gate; Linux diagnostic artifact `fabushi-electron-linux-e2e-diagnostics` / artifact id `9627834782` captured the missing `addMiniAppToAccount` native-edge handler. This failed run is regression evidence, not completion evidence.
-- Repair implementation commit `aceff580f68c5bba7cb0ccd8658dc668b9254eab` plus this task-record commit adds native-edge coverage and deterministic test-platform persistence. Protected PR/current-head evidence is still pending.
+- Native product-edge PR `#2161` merged as `ab6e3eb4787f9570aaff00342362000e1e960973`; its current-head protected gates all passed.
+- E2E shell-contract PR `#2162` merged as `f565e46d070ce6f23183d861fee6cda589eca460`; all protected gates passed.
+- First exact-main Electron run `33024284365` failed before packaging; artifact id `9627834782` captured the missing native-edge handler.
+- Second exact-main Electron run `33025670225` failed after native-edge repair; artifact id `9628343898` proved product UI success plus stale copy/first-surface test drift. Exact-main Native mobile run `33025670242` succeeded on iOS SwiftUI and Android Compose simulated user tests.
+- Third exact-main Electron run `33026283621` has a single real-Host failure; artifact id `9628549449` proves the Global Dharma Bot is present in Contacts under canonical visible identity while the test still expected a projection-specific peer key. This run is regression evidence, not completion evidence.
 - Persistent regression tests include `ai-backend/test/account_sync_store.test.js`, `ai-backend/test/miniapp_marketplace_http.test.js`, `ai-backend/test/multidevice_account_sync_integration.test.js`, `desktop/electron/native-capability-handlers.test.cjs`, and `desktop/electron/edge-ipc.test.cjs`.
-- **Completion remains blocked** until the repair is merged, the new exact-main Electron/Native mobile delivery succeeds, packaged E2E evidence is archived, and the matching exact-SHA Release is published.
+- **Completion remains blocked** until the canonical Bot-identity E2E repair is protected/merged, the next exact-main Electron + Native delivery succeeds, packaged E2E evidence is archived, and the matching exact-SHA Release is published.


### PR DESCRIPTION
## Exact-main acceptance blocker

Electron exact-main run `33026283621` on `f565e46d070ce6f23183d861fee6cda589eca460` reduced the real Rust Host suite to one failing assertion. Diagnostic artifact `9628549449` shows the product is already correct: after installing Global Dharma, the Contacts rail visibly contains `全球法布施 … @global_dharma_bot`.

The remaining test was coupled to `data-testid="peer-miniapp:bot:global-dharma"`. After account-level Bot convergence, Messenger can deduplicate the Mini App-owned identity against an existing canonical Bot peer; the visible Bot remains the same, but the internal peer key no longer has to use the temporary `miniapp:bot:*` projection namespace.

## Change

- locate the Mini App Bot by stable user-facing identity `@global_dharma_bot` in Contacts and Bots
- keep the visible display-name assertion `全球法布施`
- keep all downstream acceptance unchanged: slash commands, natural-language routing, Mini App open, process restart, Bot history recovery, `FabushiMiniApp.CloudStorage` recovery, screenshots/video/trace
- record the third exact-main diagnostic in `M2-SYNC-002`

This does not weaken product behavior. It removes coupling to a non-product internal peer key while asserting the same identity the user sees across synchronized devices.
