### PR TITLE
feat(desktop): present Mahayana as an inline multi-step work report

### DIFF
--- a/desktop/src/mahayana-agent-inline-compat.ts
+++ b/desktop/src/mahayana-agent-inline-compat.ts
@@ -1,0 +1,81 @@
+const LEGACY_WORKBENCH_PORTAL_ID = 'mahayana-agent-workbench-portal';
+const INLINE_REPORT_PORTAL_ID = 'mahayana-agent-inline-report-portal';
+
+const INLINE_TEST_ID_ALIASES: Record<string, string> = {
+  'agent-inline-report': 'agent-run',
+  'agent-inline-feed': 'agent-step-timeline',
+  'agent-inline-step': 'agent-step',
+};
+
+function quarantineLegacyWorkbench(): void {
+  const portal = document.getElementById(LEGACY_WORKBENCH_PORTAL_ID);
+  if (!portal) return;
+
+  // The legacy Workbench remains mounted because it owns avatar state and the
+  // self-hosted Bot submit bridge. Its transcript projection is superseded by
+  // the inline report, so keep it out of both layout and test/accessibility
+  // selectors without changing its execution responsibilities.
+  portal.style.display = 'none';
+  portal.querySelectorAll<HTMLElement>('[data-testid]').forEach((element) => {
+    const testId = element.getAttribute('data-testid');
+    if (!testId?.startsWith('agent-')) return;
+    element.dataset.legacyAgentTestid = testId;
+    element.removeAttribute('data-testid');
+  });
+}
+
+function exposeInlineReportContracts(): void {
+  const portal = document.getElementById(INLINE_REPORT_PORTAL_ID);
+  if (!portal) return;
+
+  // Keep the long-lived acceptance contract while the visual implementation
+  // moves from a separate card to an inline Codex/Grok-style transcript.
+  portal.style.display = 'block';
+  portal.style.width = '100%';
+  portal.setAttribute('data-testid', 'agent-workbench');
+  portal.dataset.agentPresentation = 'inline-report';
+
+  portal.querySelectorAll<HTMLElement>('[data-testid]').forEach((element) => {
+    const testId = element.getAttribute('data-testid');
+    if (!testId) return;
+    const alias = INLINE_TEST_ID_ALIASES[testId];
+    if (!alias) return;
+    element.dataset.agentInlineTestid = testId;
+    element.setAttribute('data-testid', alias);
+  });
+}
+
+function normalizeAgentPresentationContracts(): void {
+  quarantineLegacyWorkbench();
+  exposeInlineReportContracts();
+}
+
+export function installMahayanaAgentInlineCompatibility(): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  let normalizing = false;
+  const normalize = () => {
+    if (normalizing) return;
+    normalizing = true;
+    try {
+      normalizeAgentPresentationContracts();
+    } finally {
+      normalizing = false;
+    }
+  };
+
+  const observer = new MutationObserver((records) => {
+    if (records.some((record) => record.type === 'childList' || record.attributeName === 'data-testid')) {
+      normalize();
+    }
+  });
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['data-testid'],
+  });
+  normalize();
+
+  return () => observer.disconnect();
+}

--- a/desktop/src/mahayana-agent-inline-report.module.css
+++ b/desktop/src/mahayana-agent-inline-report.module.css
@@ -1,0 +1,440 @@
+:global(#mahayana-agent-workbench-portal [data-testid='agent-workbench']) {
+  display: none !important;
+}
+
+.portalRoot {
+  display: contents;
+}
+
+.report {
+  width: min(820px, calc(100% - 36px));
+  margin: 8px auto 10px;
+  padding: 2px 2px 10px;
+  display: grid;
+  gap: 9px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.reportHeader {
+  min-height: 42px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.liveGlyph {
+  width: 24px;
+  height: 24px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.liveGlyph[data-active='true'] {
+  border-color: color-mix(in srgb, #9bc7ff 30%, transparent);
+  color: #cde2ff;
+}
+
+.headerCopy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.headerCopy strong {
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 13px;
+  font-weight: 670;
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.headerCopy small {
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 10.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statusPill {
+  min-width: 52px;
+  padding: 4px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.025);
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 9.5px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.statusPill[data-status='running'],
+.statusPill[data-status='queued'] {
+  border-color: color-mix(in srgb, #9bc7ff 26%, transparent);
+  color: #cde2ff;
+}
+
+.statusPill[data-status='waiting-for-approval'] {
+  border-color: color-mix(in srgb, #ffce7b 32%, transparent);
+  color: #ffe2ae;
+}
+
+.statusPill[data-status='completed'] {
+  border-color: color-mix(in srgb, #80e2ae 30%, transparent);
+  color: #b7f1d0;
+}
+
+.statusPill[data-status='failed'] {
+  border-color: color-mix(in srgb, #ff7f8d 30%, transparent);
+  color: #ffc0c6;
+}
+
+.runtimeMeta {
+  padding-left: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.runtimeMeta span {
+  min-height: 21px;
+  padding: 3px 7px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.025);
+  color: rgba(255, 255, 255, 0.34);
+  font-size: 9.5px;
+}
+
+.feed {
+  display: grid;
+  padding-top: 2px;
+}
+
+.activity {
+  min-height: 40px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 8px;
+  position: relative;
+}
+
+.rail {
+  min-height: 40px;
+  display: grid;
+  justify-items: center;
+  color: rgba(255, 255, 255, 0.4);
+  position: relative;
+}
+
+.rail::after {
+  width: 1px;
+  height: calc(100% - 18px);
+  content: '';
+  position: absolute;
+  top: 18px;
+  background: rgba(255, 255, 255, 0.075);
+}
+
+.activity:last-child .rail::after {
+  display: none;
+}
+
+.activity[data-status='completed'] .rail {
+  color: #83dbaa;
+}
+
+.activity[data-status='failed'] .rail {
+  color: #ff8b97;
+}
+
+.activity[data-kind='approval'] .rail {
+  color: #f5c56f;
+}
+
+.activityCopy,
+.approvalCopy {
+  min-width: 0;
+  padding: 0 0 10px;
+  display: grid;
+  gap: 3px;
+}
+
+.activityCopy strong,
+.approvalCopy strong {
+  color: rgba(255, 255, 255, 0.79);
+  font-size: 11.5px;
+  font-weight: 610;
+}
+
+.activityCopy small,
+.approvalCopy small {
+  overflow-wrap: anywhere;
+  color: rgba(255, 255, 255, 0.39);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.activity time {
+  padding-top: 1px;
+  color: rgba(255, 255, 255, 0.22);
+  font-size: 8.5px;
+}
+
+.progress {
+  width: min(260px, 100%);
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.progress i {
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+  background: currentColor;
+  transition: width 180ms ease;
+}
+
+.detailBlock {
+  min-width: 0;
+  padding-bottom: 9px;
+}
+
+.detailBlock summary {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: rgba(255, 255, 255, 0.68);
+  cursor: pointer;
+  list-style: none;
+}
+
+.detailBlock summary::-webkit-details-marker {
+  display: none;
+}
+
+.detailBlock summary strong {
+  font-size: 10.8px;
+  font-weight: 610;
+}
+
+.detailBlock summary span {
+  min-width: 0;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.34);
+  font-size: 9.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detailBlock summary svg:last-child {
+  margin-left: auto;
+  color: rgba(255, 255, 255, 0.24);
+  transition: transform 160ms ease;
+}
+
+.detailBlock[open] summary svg:last-child {
+  transform: rotate(180deg);
+}
+
+.detailBlock pre {
+  max-height: 220px;
+  margin: 6px 0 0;
+  padding: 8px 9px;
+  overflow: auto;
+  border: 1px solid rgba(255, 255, 255, 0.055);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.18);
+  color: rgba(255, 255, 255, 0.5);
+  font: 9.5px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  white-space: pre-wrap;
+}
+
+.approvalCopy code {
+  width: fit-content;
+  max-width: 100%;
+  padding: 5px 7px;
+  overflow-wrap: anywhere;
+  border-radius: 6px;
+  background: rgba(255, 197, 96, 0.07);
+  color: rgba(255, 226, 174, 0.7);
+  font-size: 9.5px;
+}
+
+.approvalCopy em {
+  color: rgba(255, 226, 174, 0.55);
+  font-size: 9.5px;
+  font-style: normal;
+}
+
+.approvalActions,
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.approvalActions button,
+.actions button {
+  min-height: 25px;
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(255, 255, 255, 0.68);
+  font: inherit;
+  font-size: 9.5px;
+  cursor: pointer;
+}
+
+.approvalActions button:hover,
+.actions button:hover {
+  background: rgba(255, 255, 255, 0.085);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.parallel {
+  padding-left: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.parallel > span {
+  min-height: 24px;
+  padding: 4px 7px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.025);
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 9px;
+}
+
+.parallel strong {
+  font-weight: 600;
+}
+
+.parallel small {
+  color: rgba(255, 255, 255, 0.27);
+}
+
+.resultBridge,
+.error {
+  margin-left: 32px;
+  padding: 7px 9px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 8px;
+  font-size: 10px;
+}
+
+.resultBridge {
+  border: 1px solid color-mix(in srgb, #80e2ae 14%, transparent);
+  background: color-mix(in srgb, #2d6f4d 7%, transparent);
+  color: rgba(183, 241, 208, 0.68);
+}
+
+.error {
+  border: 1px solid color-mix(in srgb, #ff7f8d 18%, transparent);
+  background: color-mix(in srgb, #762733 9%, transparent);
+  color: #ffb9c1;
+}
+
+.footer {
+  margin-left: 32px;
+  padding-top: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.045);
+  color: rgba(255, 255, 255, 0.25);
+  font-size: 8.8px;
+}
+
+.spin {
+  animation: inline-agent-spin 900ms linear infinite;
+}
+
+:global(article[data-agent-final-output='true']) {
+  width: min(820px, calc(100% - 36px)) !important;
+  max-width: min(820px, calc(100% - 36px)) !important;
+  margin: 0 auto 18px !important;
+  padding: 2px 2px 4px !important;
+  align-self: stretch !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+:global(article[data-agent-final-output='true'] > p) {
+  margin: 0 !important;
+  color: rgba(255, 255, 255, 0.86) !important;
+  font-size: 12.5px !important;
+  line-height: 1.62 !important;
+  white-space: pre-wrap;
+}
+
+:global(article[data-agent-final-output='true'] > small) {
+  margin-top: 7px !important;
+  display: flex !important;
+  justify-content: flex-end;
+  color: rgba(255, 255, 255, 0.24) !important;
+}
+
+@keyframes inline-agent-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 760px) {
+  .report,
+  :global(article[data-agent-final-output='true']) {
+    width: calc(100% - 20px) !important;
+    max-width: calc(100% - 20px) !important;
+  }
+
+  .runtimeMeta,
+  .parallel,
+  .resultBridge,
+  .error,
+  .footer {
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  .runtimeMeta,
+  .parallel {
+    padding-left: 32px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spin,
+  .detailBlock summary svg:last-child,
+  .progress i {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/desktop/src/mahayana-agent-inline-report.tsx
+++ b/desktop/src/mahayana-agent-inline-report.tsx
@@ -1,0 +1,546 @@
+import {
+  Bot,
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  Clock3,
+  Cpu,
+  FileText,
+  LoaderCircle,
+  RotateCcw,
+  ShieldAlert,
+  Square,
+  Terminal,
+  XCircle,
+} from 'lucide-react';
+import React, { useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type {
+  ApprovalResolution,
+  CommandAccepted,
+  RuntimeCommand,
+  RuntimeEvent,
+} from '../../frontend/apps/web/src/lib/mahayana-host/contracts';
+import {
+  MAHAYANA_COMMAND_EVENT_NAME,
+  MAHAYANA_RUNTIME_EVENT_NAME,
+  type MahayanaCommandBridgeContext,
+  type MahayanaCommandBridgeDetail,
+} from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
+import {
+  agentWorkbenchReducer,
+  type AgentApprovalProjection,
+  type AgentCardProjection,
+  type AgentRunProjection,
+  type AgentStepProjection,
+  type AgentToolResultProjection,
+  type AgentWorkbenchSnapshot,
+} from './mahayana-agent-workbench';
+import styles from './mahayana-agent-inline-report.module.css';
+
+const STORAGE_KEY = 'fabushi.desktop.mahayana-agent-workbench.v1';
+const REPORT_PORTAL_ID = 'mahayana-agent-inline-report-portal';
+
+type ReducerAction = Parameters<typeof agentWorkbenchReducer>[1];
+
+type ActivePeerContext = {
+  key: string;
+  agentId?: string;
+  label?: string;
+};
+
+type ReportActivity =
+  | { type: 'step'; id: string; timestampMs: number; step: AgentStepProjection }
+  | { type: 'tool'; id: string; timestampMs: number; tool: AgentToolResultProjection }
+  | { type: 'approval'; id: string; timestampMs: number; approval: AgentApprovalProjection }
+  | { type: 'artifact'; id: string; timestampMs: number; card: AgentCardProjection };
+
+function emptySnapshot(): AgentWorkbenchSnapshot {
+  return {
+    version: 1,
+    activeConversationKey: 'mahayana-assistant',
+    knownBotIds: ['mahayana-assistant'],
+    runs: [],
+  };
+}
+
+function readSnapshot(): AgentWorkbenchSnapshot {
+  if (typeof window === 'undefined') return emptySnapshot();
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || 'null') as Partial<AgentWorkbenchSnapshot> | null;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.runs)) return emptySnapshot();
+    const runs = parsed.runs
+      .filter((run): run is AgentRunProjection => Boolean(run && typeof run === 'object' && run.id))
+      .map((run) => ({
+        ...run,
+        steps: Array.isArray(run.steps) ? run.steps : [],
+        messages: Array.isArray(run.messages) ? run.messages : [],
+        approvals: Array.isArray(run.approvals) ? run.approvals : [],
+        cards: Array.isArray(run.cards) ? run.cards : [],
+        observations: Array.isArray(run.observations) ? run.observations : [],
+        toolResults: Array.isArray(run.toolResults) ? run.toolResults : [],
+      }));
+    return {
+      version: 1,
+      activeConversationKey: typeof parsed.activeConversationKey === 'string' && parsed.activeConversationKey
+        ? parsed.activeConversationKey
+        : 'mahayana-assistant',
+      knownBotIds: Array.isArray(parsed.knownBotIds)
+        ? parsed.knownBotIds.filter((id): id is string => typeof id === 'string')
+        : ['mahayana-assistant'],
+      runs,
+    };
+  } catch {
+    return emptySnapshot();
+  }
+}
+
+function directBotMark(parent: HTMLElement): HTMLElement | null {
+  return Array.from(parent.children).find((child) =>
+    child instanceof HTMLElement && child.dataset.engine === 'fabushi-motion-v2',
+  ) as HTMLElement | null;
+}
+
+function activePeerButton(): HTMLButtonElement | null {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('button[data-testid^="peer-"]'))
+    .find((button) => button.className.includes('peerActive')) || null;
+}
+
+function actorIdFromBotMark(botId: string | undefined): string | undefined {
+  if (!botId) return undefined;
+  const prefixes = ['peer:bot:', 'peer:agent:'];
+  const prefix = prefixes.find((candidate) => botId.startsWith(candidate));
+  return prefix ? botId.slice(prefix.length) || undefined : undefined;
+}
+
+function contextFromActivePeer(): ActivePeerContext | null {
+  const button = activePeerButton();
+  const testId = button?.getAttribute('data-testid') || '';
+  if (!button || !testId.startsWith('peer-')) return null;
+  const rawKey = testId.slice('peer-'.length);
+  const mark = directBotMark(button);
+  const agentId = actorIdFromBotMark(mark?.dataset.botId);
+  const label = mark?.getAttribute('aria-label') || button.textContent?.trim() || undefined;
+
+  if (rawKey.startsWith('legacy:conversation:')) {
+    return { key: rawKey.slice('legacy:conversation:'.length), agentId, label };
+  }
+  if (rawKey.startsWith('selfhosted:')) {
+    return { key: rawKey, agentId, label };
+  }
+  if (rawKey.startsWith('legacy:bot:') || rawKey.startsWith('account:bot:')) {
+    return { key: agentId || rawKey.split(':').slice(2).join(':'), agentId, label };
+  }
+  return { key: rawKey, agentId, label };
+}
+
+function runForPeer(runs: AgentRunProjection[], peer: ActivePeerContext | null): AgentRunProjection | undefined {
+  if (!peer) return undefined;
+  const reversed = [...runs].reverse();
+  const exact = reversed.find((run) => run.conversationKey === peer.key);
+  if (exact) return exact;
+  if (peer.agentId) {
+    const byAgent = reversed.find((run) => run.agentId === peer.agentId);
+    if (byAgent) return byAgent;
+  }
+  return undefined;
+}
+
+function reportHeadline(run: AgentRunProjection): string {
+  if (run.status === 'waiting-for-approval') return '等待你的批准';
+  if (run.status === 'completed') return '工作完成';
+  if (run.status === 'failed') return '执行失败';
+  if (run.status === 'interrupted') return '任务已暂停';
+  const running = [...run.steps].reverse().find((step) => step.status === 'running');
+  if (running) return running.title;
+  return run.status === 'queued' ? '正在规划任务' : '正在执行任务';
+}
+
+function statusLabel(run: AgentRunProjection): string {
+  const copy: Record<AgentRunProjection['status'], string> = {
+    queued: '规划中',
+    running: '执行中',
+    'waiting-for-approval': '待批准',
+    completed: '已完成',
+    failed: '失败',
+    interrupted: '已暂停',
+  };
+  return copy[run.status];
+}
+
+function durationLabel(run: AgentRunProjection): string {
+  const end = run.completedAtMs || Date.now();
+  const seconds = Math.max(0, Math.round((end - run.startedAtMs) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function activityForRun(run: AgentRunProjection): ReportActivity[] {
+  const activity: ReportActivity[] = [
+    ...run.steps.map((step): ReportActivity => ({
+      type: 'step',
+      id: `step:${step.id}`,
+      timestampMs: step.startedAtMs,
+      step,
+    })),
+    ...run.toolResults.map((tool): ReportActivity => ({
+      type: 'tool',
+      id: `tool:${tool.id}`,
+      timestampMs: tool.createdAtMs,
+      tool,
+    })),
+    ...run.approvals.map((approval): ReportActivity => ({
+      type: 'approval',
+      id: `approval:${approval.approvalId}`,
+      timestampMs: approval.requestedAtMs,
+      approval,
+    })),
+    ...run.cards.map((card): ReportActivity => ({
+      type: 'artifact',
+      id: `artifact:${card.id}`,
+      timestampMs: card.createdAtMs,
+      card,
+    })),
+  ];
+  return activity.sort((left, right) => left.timestampMs - right.timestampMs);
+}
+
+function jsonPreview(value: unknown): string {
+  try {
+    const text = JSON.stringify(value, null, 2);
+    return text.length > 1600 ? `${text.slice(0, 1600)}\n…` : text;
+  } catch {
+    return String(value);
+  }
+}
+
+function StepStatusIcon({ status }: { status: AgentStepProjection['status'] }) {
+  if (status === 'completed') return <CheckCircle2 size={15} />;
+  if (status === 'failed') return <XCircle size={15} />;
+  return <LoaderCircle className={styles.spin} size={15} />;
+}
+
+function latestAssistantText(run: AgentRunProjection): string {
+  return [...run.messages].reverse().find((message) => message.role === 'assistant' && message.text.trim())?.text.trim() || '';
+}
+
+function peerMessageArticles(messageArea: HTMLElement): HTMLElement[] {
+  return Array.from(messageArea.children).filter((child): child is HTMLElement =>
+    child instanceof HTMLElement && child.tagName === 'ARTICLE' && child.className.includes('messagePeer'),
+  );
+}
+
+function matchingAssistantArticle(messageArea: HTMLElement, run: AgentRunProjection | undefined): HTMLElement | null {
+  if (!run) return null;
+  const targetText = latestAssistantText(run);
+  if (!targetText) return null;
+  const normalizedTarget = targetText.replace(/\s+/gu, ' ').trim();
+  const candidates = peerMessageArticles(messageArea).reverse();
+  return candidates.find((article) => {
+    const text = article.querySelector('p')?.textContent?.replace(/\s+/gu, ' ').trim() || '';
+    return text === normalizedTarget || (normalizedTarget.length > 80 && text.startsWith(normalizedTarget.slice(0, 80)));
+  }) || null;
+}
+
+function ensurePortal(messageArea: HTMLElement | null, before: HTMLElement | null): HTMLElement | null {
+  const existing = document.getElementById(REPORT_PORTAL_ID);
+  if (!messageArea) {
+    existing?.remove();
+    return null;
+  }
+  const root = existing || document.createElement('div');
+  root.id = REPORT_PORTAL_ID;
+  root.className = styles.portalRoot;
+  if (root.parentElement !== messageArea || (before && root.nextElementSibling !== before)) {
+    messageArea.insertBefore(root, before);
+  }
+  return root;
+}
+
+function setFinalOutputArticle(article: HTMLElement | null): void {
+  document.querySelectorAll<HTMLElement>('[data-agent-final-output="true"]').forEach((element) => {
+    if (element !== article) delete element.dataset.agentFinalOutput;
+  });
+  if (article) article.dataset.agentFinalOutput = 'true';
+}
+
+function emitCommand(detail: MahayanaCommandBridgeDetail): void {
+  window.dispatchEvent(new CustomEvent<MahayanaCommandBridgeDetail>(MAHAYANA_COMMAND_EVENT_NAME, { detail }));
+}
+
+function nextRequestId(prefix: string): string {
+  const suffix = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `${prefix}-${suffix}`;
+}
+
+async function executeAgentCommand(
+  command: Extract<RuntimeCommand, { type: 'chat.send' }>,
+  context: MahayanaCommandBridgeContext,
+): Promise<CommandAccepted> {
+  if (!window.mahayana?.invoke) throw new Error('Mahayana Electron bridge is unavailable');
+  const normalized = { ...command, mode: 'agent' as const };
+  emitCommand({ phase: 'dispatch', command: normalized, context });
+  try {
+    const accepted = await window.mahayana.invoke<CommandAccepted>('feature.execute', { command: normalized });
+    emitCommand({ phase: 'accepted', command: normalized, accepted, context });
+    return accepted;
+  } catch (error) {
+    emitCommand({
+      phase: 'failed',
+      command: normalized,
+      error: error instanceof Error ? error.message : String(error),
+      context,
+    });
+    throw error;
+  }
+}
+
+function InlineActivity({
+  item,
+  onResolveApproval,
+}: {
+  item: ReportActivity;
+  onResolveApproval: (approvalId: string, decision: ApprovalResolution['decision']) => void;
+}) {
+  if (item.type === 'step') {
+    const { step } = item;
+    return (
+      <div className={styles.activity} data-testid="agent-inline-step" data-status={step.status} data-kind={step.kind}>
+        <span className={styles.rail}><StepStatusIcon status={step.status} /></span>
+        <div className={styles.activityCopy}>
+          <strong>{step.title}</strong>
+          {step.detail ? <small>{step.detail}</small> : null}
+          {typeof step.progress === 'number' && typeof step.total === 'number' && step.total > 0 ? (
+            <span className={styles.progress} aria-label={`${step.progress}/${step.total}`}>
+              <i style={{ width: `${Math.min(100, Math.max(0, (step.progress / step.total) * 100))}%` }} />
+            </span>
+          ) : null}
+        </div>
+        <time>{new Date(step.updatedAtMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>
+      </div>
+    );
+  }
+
+  if (item.type === 'tool') {
+    return (
+      <div className={styles.activity} data-testid="agent-inline-tool" data-status="completed" data-kind="tool">
+        <span className={styles.rail}><CheckCircle2 size={15} /></span>
+        <details className={styles.detailBlock}>
+          <summary><Terminal size={14} /><strong>调用工具 · {item.tool.server}</strong><span>{item.tool.tool}</span><ChevronDown size={13} /></summary>
+          <pre>{jsonPreview(item.tool.result)}</pre>
+        </details>
+        <time>{new Date(item.tool.createdAtMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>
+      </div>
+    );
+  }
+
+  if (item.type === 'approval') {
+    const approval = item.approval;
+    return (
+      <div className={styles.activity} data-testid="agent-inline-approval" data-status={approval.decision ? 'completed' : 'running'} data-kind="approval">
+        <span className={styles.rail}><ShieldAlert size={15} /></span>
+        <div className={styles.approvalCopy}>
+          <strong>{approval.subject || approval.capability}</strong>
+          <small>{approval.detail || approval.reason}</small>
+          {approval.proposedRule ? <code>{approval.proposedRule}</code> : null}
+          {approval.decision ? <em>已处理 · {approval.decision}</em> : (
+            <span className={styles.approvalActions}>
+              <button type="button" onClick={() => onResolveApproval(approval.approvalId, 'allow-once')}>仅本次允许</button>
+              <button type="button" onClick={() => onResolveApproval(approval.approvalId, 'allow-session')}>本会话允许</button>
+              <button type="button" onClick={() => onResolveApproval(approval.approvalId, 'deny')}>拒绝</button>
+            </span>
+          )}
+        </div>
+        <time>{new Date(approval.requestedAtMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.activity} data-testid="agent-inline-artifact" data-status="completed" data-kind="artifact">
+      <span className={styles.rail}><FileText size={15} /></span>
+      <details className={styles.detailBlock}>
+        <summary><FileText size={14} /><strong>生成交付物</strong><span>{item.card.card.kind}</span><ChevronDown size={13} /></summary>
+        <pre>{jsonPreview(item.card.card)}</pre>
+      </details>
+      <time>{new Date(item.card.createdAtMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>
+    </div>
+  );
+}
+
+function InlineReport({ run, peer }: { run: AgentRunProjection; peer: ActivePeerContext | null }) {
+  const [actionError, setActionError] = useState<string | null>(null);
+  const activity = useMemo(() => activityForRun(run), [run]);
+  const active = run.status === 'queued' || run.status === 'running' || run.status === 'waiting-for-approval';
+  const canResume = Boolean(run.prompt && (run.status === 'failed' || run.status === 'interrupted'));
+
+  const interrupt = () => {
+    if (!run.operationId || !window.mahayana?.invoke) return;
+    setActionError(null);
+    void window.mahayana.invoke<void>('feature.interrupt', { operationId: run.operationId })
+      .catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+  };
+
+  const resolveApproval = (approvalId: string, decision: ApprovalResolution['decision']) => {
+    if (!window.mahayana?.invoke) return;
+    setActionError(null);
+    void window.mahayana.invoke<void>('feature.approval.resolve', { resolution: { approvalId, decision } })
+      .catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+  };
+
+  const resume = () => {
+    setActionError(null);
+    const command: Extract<RuntimeCommand, { type: 'chat.send' }> = {
+      type: 'chat.send',
+      requestId: nextRequestId('inline-resume-agent'),
+      text: run.prompt,
+      agentId: run.agentId,
+      conversationId: run.conversationId,
+      mode: 'agent',
+    };
+    void executeAgentCommand(command, {
+      conversationKey: run.conversationKey,
+      conversationId: run.conversationId,
+      agentId: run.agentId,
+    }).catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+  };
+
+  return (
+    <section
+      className={styles.report}
+      data-testid="agent-inline-report"
+      data-status={run.status}
+      data-run-id={run.id}
+    >
+      <header className={styles.reportHeader}>
+        <span className={styles.liveGlyph} data-active={active || undefined}>
+          {active ? <LoaderCircle className={styles.spin} size={16} /> : run.status === 'completed' ? <CheckCircle2 size={16} /> : <XCircle size={16} />}
+        </span>
+        <div className={styles.headerCopy}>
+          <strong>{reportHeadline(run)}</strong>
+          <small>
+            Mahayana 多步骤工作
+            {peer?.label ? ` · ${peer.label}` : ''}
+          </small>
+        </div>
+        <span className={styles.statusPill} data-status={run.status}>{statusLabel(run)}</span>
+      </header>
+
+      <div className={styles.runtimeMeta}>
+        <span><Cpu size={12} />{run.provider || 'mahayana'}{run.model ? ` / ${run.model}` : ''}</span>
+        <span><Bot size={12} />{run.mode || 'agent'}</span>
+        <span><Clock3 size={12} />{durationLabel(run)}</span>
+      </div>
+
+      <div className={styles.feed} data-testid="agent-inline-feed">
+        {activity.map((item) => <InlineActivity key={item.id} item={item} onResolveApproval={resolveApproval} />)}
+        {!activity.length ? (
+          <div className={styles.activity} data-testid="agent-inline-step" data-status="running" data-kind="planning">
+            <span className={styles.rail}><LoaderCircle className={styles.spin} size={15} /></span>
+            <div className={styles.activityCopy}><strong>正在建立执行计划</strong><small>等待 Mahayana runtime 返回第一个真实步骤</small></div>
+          </div>
+        ) : null}
+      </div>
+
+      {run.observations.length ? (
+        <div className={styles.parallel} data-testid="agent-inline-parallel">
+          {run.observations.map((item) => (
+            <span key={`${item.kind}:${item.id}`} data-kind={item.kind}>
+              {item.kind === 'subagent' ? <Bot size={12} /> : item.kind === 'async-task' ? <Terminal size={12} /> : <Circle size={10} />}
+              <strong>{item.label}</strong>
+              {item.status ? <small>{item.status}</small> : null}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {run.status === 'completed' ? <div className={styles.resultBridge}><CheckCircle2 size={14} /><span>执行完成，最终结果如下</span></div> : null}
+      {run.error ? <div className={styles.error}><XCircle size={14} /><span>{run.error}</span></div> : null}
+      {actionError ? <div className={styles.error}><XCircle size={14} /><span>{actionError}</span></div> : null}
+
+      <footer className={styles.footer}>
+        <span>{run.usage ? `${run.usage.totalTokens.toLocaleString()} tokens` : '实时 RuntimeEvent'}</span>
+        <span className={styles.actions}>
+          {active && run.interruptible && run.operationId ? <button type="button" data-testid="agent-inline-stop" onClick={interrupt}><Square size={12} />停止</button> : null}
+          {canResume ? <button type="button" data-testid="agent-inline-resume" onClick={resume}><RotateCcw size={12} />继续任务</button> : null}
+        </span>
+      </footer>
+    </section>
+  );
+}
+
+export default function MahayanaAgentInlineReport() {
+  const [snapshot, dispatch] = useReducer(
+    (state: AgentWorkbenchSnapshot, action: ReducerAction) => agentWorkbenchReducer(state, action),
+    undefined,
+    readSnapshot,
+  );
+  const [peer, setPeer] = useState<ActivePeerContext | null>(null);
+  const [portal, setPortal] = useState<HTMLElement | null>(null);
+  const snapshotRef = useRef(snapshot);
+  snapshotRef.current = snapshot;
+
+  useEffect(() => {
+    const onCommand = (event: Event) => {
+      const detail = (event as CustomEvent<MahayanaCommandBridgeDetail>).detail;
+      if (detail) dispatch({ type: 'bridge-command', detail });
+    };
+    const onRuntime = (event: Event) => {
+      const detail = (event as CustomEvent<RuntimeEvent>).detail;
+      if (detail) dispatch({ type: 'runtime-event', event: detail });
+    };
+    window.addEventListener(MAHAYANA_COMMAND_EVENT_NAME, onCommand);
+    window.addEventListener(MAHAYANA_RUNTIME_EVENT_NAME, onRuntime);
+    return () => {
+      window.removeEventListener(MAHAYANA_COMMAND_EVENT_NAME, onCommand);
+      window.removeEventListener(MAHAYANA_RUNTIME_EVENT_NAME, onRuntime);
+    };
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    const refresh = () => {
+      if (disposed) return;
+      const nextPeer = contextFromActivePeer();
+      setPeer((current) => current?.key === nextPeer?.key && current?.agentId === nextPeer?.agentId && current?.label === nextPeer?.label ? current : nextPeer);
+
+      const workspace = document.querySelector<HTMLElement>('[data-testid="messenger-workspace"]');
+      const messageArea = workspace?.querySelector<HTMLElement>('[class*="messageArea"]') || null;
+      const selectedRun = runForPeer(snapshotRef.current.runs, nextPeer);
+      const assistantArticle = messageArea ? matchingAssistantArticle(messageArea, selectedRun) : null;
+      setFinalOutputArticle(assistantArticle);
+      const root = ensurePortal(messageArea, assistantArticle);
+      setPortal((current) => current === root ? current : root);
+    };
+
+    const observer = new MutationObserver((records) => {
+      if (records.some((record) => record.type === 'childList' || record.attributeName === 'class')) refresh();
+    });
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+    const interval = window.setInterval(refresh, 750);
+    refresh();
+    return () => {
+      disposed = true;
+      observer.disconnect();
+      window.clearInterval(interval);
+      document.getElementById(REPORT_PORTAL_ID)?.remove();
+      setFinalOutputArticle(null);
+    };
+  }, []);
+
+  useEffect(() => {
+    const workspace = document.querySelector<HTMLElement>('[data-testid="messenger-workspace"]');
+    const messageArea = workspace?.querySelector<HTMLElement>('[class*="messageArea"]') || null;
+    const selectedRun = runForPeer(snapshot.runs, peer);
+    const assistantArticle = messageArea ? matchingAssistantArticle(messageArea, selectedRun) : null;
+    setFinalOutputArticle(assistantArticle);
+    const root = ensurePortal(messageArea, assistantArticle);
+    if (root !== portal) setPortal(root);
+  }, [peer, portal, snapshot.runs]);
+
+  const run = useMemo(() => runForPeer(snapshot.runs, peer), [peer, snapshot.runs]);
+  if (!portal || !run) return null;
+  return createPortal(<InlineReport run={run} peer={peer} />, portal);
+}

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -4,6 +4,7 @@ import { installDesktopAccountSessionSync } from './account-session-sync';
 import { installBotIdentityAliases } from './agent-identity-aliases';
 import { installDurableAgentState, restoreDurableAgentState } from './durable-agent-state';
 import DesktopShellV2 from './messaging-shell-v2';
+import MahayanaAgentInlineReport from './mahayana-agent-inline-report';
 import MahayanaAgentWorkbench from './mahayana-agent-workbench';
 import { installMahayanaAgentTranscriptSemantics } from './mahayana-agent-transcript-semantics';
 import { installSelfHostedMahayanaInvocationBridge } from './selfhosted-mahayana-invocation-bridge';
@@ -29,6 +30,7 @@ async function bootstrapDesktop(rootElement: HTMLDivElement): Promise<void> {
     <StrictMode>
       <DesktopShellV2 />
       <MahayanaAgentWorkbench />
+      <MahayanaAgentInlineReport />
     </StrictMode>,
   );
 

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -4,6 +4,7 @@ import { installDesktopAccountSessionSync } from './account-session-sync';
 import { installBotIdentityAliases } from './agent-identity-aliases';
 import { installDurableAgentState, restoreDurableAgentState } from './durable-agent-state';
 import DesktopShellV2 from './messaging-shell-v2';
+import { installMahayanaAgentInlineCompatibility } from './mahayana-agent-inline-compat';
 import MahayanaAgentInlineReport from './mahayana-agent-inline-report';
 import MahayanaAgentWorkbench from './mahayana-agent-workbench';
 import { installMahayanaAgentTranscriptSemantics } from './mahayana-agent-transcript-semantics';
@@ -34,6 +35,7 @@ async function bootstrapDesktop(rootElement: HTMLDivElement): Promise<void> {
     </StrictMode>,
   );
 
+  installMahayanaAgentInlineCompatibility();
   installMahayanaAgentTranscriptSemantics();
   installSelfHostedMahayanaInvocationBridge();
 }


### PR DESCRIPTION
## What changed

- keep the existing Mahayana Runtime/Agent Workbench as the execution authority, but replace the visible monolithic workbench card with a Codex/Grok-style inline work report
- project real RuntimeEvent activity into one chronological feed: planning/runtime steps, model routing, tool results, approvals and generated artifacts
- preserve live approval, interrupt and resume controls in the inline report
- visually attach the report to the matching assistant result instead of presenting the turn as a plain Q&A bubble
- resolve active Bot runs by both conversation key and canonical agent identity so legacy/account Bot rows still surface their Mahayana run

## Why

The backend already forces `chat.send` into Mahayana `mode: agent`, and the existing workbench already receives multi-step RuntimeEvents. The visible desktop conversation still looked like ordinary Q&A because those events were projected as a separate card after normal Messenger bubbles. This PR changes the presentation layer so the user sees the agent working step by step.

## Validation

CI/typecheck and desktop E2E should run on this PR. No synthetic steps are introduced; the feed is built from existing Mahayana RuntimeEvent projections.