### PR TITLE
fix(desktop): stop inline agent compatibility observer from starving Messenger

### DIFF
--- a/desktop/src/mahayana-agent-inline-compat.ts
+++ b/desktop/src/mahayana-agent-inline-compat.ts
@@ -15,11 +15,11 @@ function quarantineLegacyWorkbench(): void {
   // self-hosted Bot submit bridge. Its transcript projection is superseded by
   // the inline report, so keep it out of both layout and test/accessibility
   // selectors without changing its execution responsibilities.
-  portal.style.display = 'none';
+  if (portal.style.display !== 'none') portal.style.display = 'none';
   portal.querySelectorAll<HTMLElement>('[data-testid]').forEach((element) => {
     const testId = element.getAttribute('data-testid');
     if (!testId?.startsWith('agent-')) return;
-    element.dataset.legacyAgentTestid = testId;
+    if (element.dataset.legacyAgentTestid !== testId) element.dataset.legacyAgentTestid = testId;
     element.removeAttribute('data-testid');
   });
 }
@@ -30,18 +30,26 @@ function exposeInlineReportContracts(): void {
 
   // Keep the long-lived acceptance contract while the visual implementation
   // moves from a separate card to an inline Codex/Grok-style transcript.
-  portal.style.display = 'block';
-  portal.style.width = '100%';
-  portal.setAttribute('data-testid', 'agent-workbench');
-  portal.dataset.agentPresentation = 'inline-report';
+  if (portal.style.display !== 'block') portal.style.display = 'block';
+  if (portal.style.width !== '100%') portal.style.width = '100%';
+  // MutationObserver below watches data-testid changes. Never write an
+  // identical value here: setAttribute() still queues an attribute mutation in
+  // Chromium, which would otherwise keep this observer in a microtask loop and
+  // starve the Messenger login/workspace transition.
+  if (portal.getAttribute('data-testid') !== 'agent-workbench') {
+    portal.setAttribute('data-testid', 'agent-workbench');
+  }
+  if (portal.dataset.agentPresentation !== 'inline-report') {
+    portal.dataset.agentPresentation = 'inline-report';
+  }
 
   portal.querySelectorAll<HTMLElement>('[data-testid]').forEach((element) => {
     const testId = element.getAttribute('data-testid');
     if (!testId) return;
     const alias = INLINE_TEST_ID_ALIASES[testId];
     if (!alias) return;
-    element.dataset.agentInlineTestid = testId;
-    element.setAttribute('data-testid', alias);
+    if (element.dataset.agentInlineTestid !== testId) element.dataset.agentInlineTestid = testId;
+    if (element.getAttribute('data-testid') !== alias) element.setAttribute('data-testid', alias);
   });
 }
 


### PR DESCRIPTION
## Fix

The inline Mahayana compatibility layer watched `data-testid` mutations and unconditionally rewrote the inline portal's `data-testid` on every normalization. Chromium queues an attribute mutation even when `setAttribute()` writes the same value, so the observer could feed itself indefinitely and starve the renderer microtask/event loop. That blocked the normal login → `messenger-workspace` transition in the post-merge real-host E2E gate.

This change makes every watched attribute write idempotent and documents why the guard is required. Legacy workbench test IDs are still quarantined and the inline Codex/Grok-style report keeps the long-lived `agent-*` acceptance contract.

## Evidence

- Before #2166, the prior main Electron gate had 19/21 Linux tests passing (one product regression plus one flaky motion assertion).
- After #2166, the Linux error snapshots consistently froze at the pre-Messenger shell, matching a renderer event-loop starvation symptom.
- This PR is intentionally narrow: no Mahayana runtime or presentation semantics are changed, only observer convergence.