### PR TITLE
feat(miniapp): make WebMCP the foreground agent interface

### DIFF
--- a/ai-backend/src/miniapp_marketplace_bootstrap.js
+++ b/ai-backend/src/miniapp_marketplace_bootstrap.js
@@ -4,10 +4,14 @@ import { fileURLToPath } from 'node:url';
 
 import express from 'express';
 
+import { MiniAppMarketplace } from './miniapp_marketplace.js';
 import { registerMiniAppMarketplaceRoutes } from './miniapp_marketplace_http.js';
+import { installWebMcpMarketplacePolicy } from './miniapp_webmcp_policy.js';
 
 const patchFlag = Symbol.for('fabushi.miniapp.marketplace.bootstrap.v2');
 const registrationFlag = Symbol.for('fabushi.miniapp.marketplace.routes.v2');
+
+installWebMcpMarketplacePolicy(MiniAppMarketplace);
 
 if (!express.application[patchFlag]) {
   const originalListen = express.application.listen;

--- a/ai-backend/src/miniapp_webmcp_policy.js
+++ b/ai-backend/src/miniapp_webmcp_policy.js
@@ -1,0 +1,84 @@
+export const FABUSHI_WEBMCP_CONTRACT = 'fabushi.webmcp.v1';
+
+function webMcpError(message) {
+  const error = new Error(message);
+  error.code = 'WEBMCP_CONTRACT_REQUIRED';
+  return error;
+}
+
+export function assertMiniAppWebMcpReady(manifest) {
+  if (!manifest || typeof manifest !== 'object') throw webMcpError('MiniApp manifest is required');
+  if (!Array.isArray(manifest.commands) || manifest.commands.length === 0) {
+    throw webMcpError(`MiniApp ${manifest.id ?? '<unknown>'} must expose at least one Tool for WebMCP`);
+  }
+  const seen = new Set();
+  for (const command of manifest.commands) {
+    const tool = String(command?.tool ?? command?.name ?? '').trim();
+    if (!tool) throw webMcpError(`MiniApp ${manifest.id ?? '<unknown>'} has a command without a Tool`);
+    if (seen.has(tool)) continue;
+    seen.add(tool);
+  }
+  return {
+    protocol: FABUSHI_WEBMCP_CONTRACT,
+    required: true,
+    toolSource: 'runtime-tool-catalog',
+    foreground: 'document.modelContext',
+    fallback: 'window.__fabushiWebMcp',
+    tools: [...seen],
+  };
+}
+
+export function webMcpMarketplaceProjection(manifest) {
+  return {
+    ...manifest,
+    webmcp: assertMiniAppWebMcpReady(manifest),
+  };
+}
+
+export function installWebMcpMarketplacePolicy(MarketplaceClass) {
+  if (!MarketplaceClass?.prototype) return;
+  const marker = Symbol.for('fabushi.webmcp.marketplace-policy.v1');
+  if (MarketplaceClass.prototype[marker]) return;
+  Object.defineProperty(MarketplaceClass.prototype, marker, { value: true });
+
+  const originalCreateDraft = MarketplaceClass.prototype.createDraft;
+  MarketplaceClass.prototype.createDraft = function createWebMcpDraft(input) {
+    const draft = originalCreateDraft.call(this, input);
+    assertMiniAppWebMcpReady(draft);
+    return draft;
+  };
+
+  const originalSubmit = MarketplaceClass.prototype.submit;
+  MarketplaceClass.prototype.submit = function submitWebMcpMiniApp(id, publisherId) {
+    const manifest = this.get(id, { includeUnapproved: true });
+    assertMiniAppWebMcpReady(manifest);
+    return originalSubmit.call(this, id, publisherId);
+  };
+
+  const originalReview = MarketplaceClass.prototype.review;
+  MarketplaceClass.prototype.review = function reviewWebMcpMiniApp(id, options = {}) {
+    if (options?.approved === true) {
+      const manifest = this.get(id, { includeUnapproved: true });
+      assertMiniAppWebMcpReady(manifest);
+    }
+    return originalReview.call(this, id, options);
+  };
+
+  const originalGenerationWorkflow = MarketplaceClass.prototype.generationWorkflow;
+  MarketplaceClass.prototype.generationWorkflow = function generationWorkflowWithWebMcp(input = {}) {
+    const workflow = originalGenerationWorkflow.call(this, input);
+    return {
+      ...workflow,
+      webmcp: {
+        protocol: FABUSHI_WEBMCP_CONTRACT,
+        required: true,
+        toolSource: 'runtime-tool-catalog',
+      },
+      acceptance: [
+        ...(workflow.acceptance ?? []),
+        'every MiniApp exposes its runtime Tool catalog through WebMCP when its page is open',
+        'WebMCP teardown never terminates an already-started Rust/native background job',
+      ],
+    };
+  };
+}

--- a/ai-backend/test/miniapp_webmcp_policy.test.js
+++ b/ai-backend/test/miniapp_webmcp_policy.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MiniAppMarketplace, officialMiniAppManifests } from '../src/miniapp_marketplace.js';
+import {
+  FABUSHI_WEBMCP_CONTRACT,
+  assertMiniAppWebMcpReady,
+  installWebMcpMarketplacePolicy,
+} from '../src/miniapp_webmcp_policy.js';
+
+test('every official MiniApp has a WebMCP-ready Tool contract', () => {
+  for (const manifest of officialMiniAppManifests()) {
+    const contract = assertMiniAppWebMcpReady(manifest);
+    assert.equal(contract.protocol, FABUSHI_WEBMCP_CONTRACT);
+    assert.equal(contract.required, true);
+    assert.ok(contract.tools.length > 0, `${manifest.id} has no WebMCP tools`);
+  }
+});
+
+test('marketplace policy rejects drafts without a Tool contract', () => {
+  class PolicyMarketplace extends MiniAppMarketplace {}
+  installWebMcpMarketplacePolicy(PolicyMarketplace);
+  const marketplace = Object.create(PolicyMarketplace.prototype);
+  marketplace.get = () => null;
+  const original = PolicyMarketplace.prototype.createDraft;
+  assert.throws(() => original.call({
+    now: () => Date.now(),
+    document: { apps: [], sequence: 0 },
+    seed: [],
+    storagePath: '/tmp/unused-webmcp-policy.json',
+  }, {}));
+});
+
+test('WebMCP policy rejects manifests with no tools', () => {
+  assert.throws(
+    () => assertMiniAppWebMcpReady({ id: 'empty-miniapp', commands: [] }),
+    /must expose at least one Tool/,
+  );
+});

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
-  "androidVersionCode": 1,
-  "iosBuildNumber": 1
+  "version": "1.0.4",
+  "androidVersionCode": 2,
+  "iosBuildNumber": 2
 }

--- a/desktop/e2e/miniapp-bot-parity.spec.ts
+++ b/desktop/e2e/miniapp-bot-parity.spec.ts
@@ -79,6 +79,15 @@ async function readCloudProbe(page: Page): Promise<string | null> {
   });
 }
 
+async function readWebMcpTools(page: Page): Promise<string[]> {
+  const frame = page.frameLocator('iframe[title="global-dharma"]');
+  return frame.locator('body').evaluate(() => {
+    const registry = (window as any).__fabushiWebMcp;
+    if (!registry?.list) throw new Error('Fabushi WebMCP registry is unavailable');
+    return registry.list().map((tool: { name?: unknown }) => String(tool.name ?? '')).filter(Boolean);
+  });
+}
+
 test('installed Mini App projects its Bot into Contacts/Bots and recovers Bot history plus CloudStorage', async ({}, testInfo) => {
   test.setTimeout(90_000);
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-miniapp-bot-e2e-'));
@@ -125,8 +134,11 @@ test('installed Mini App projects its Bot into Contacts/Bots and recovers Bot hi
     await page.getByTestId('miniapp-bot-open').click();
     await expect(page.getByText('Mini App · 已安装线上包 · 账号云同步')).toBeVisible();
     await expect(page.locator('iframe[title="global-dharma"]')).toBeVisible();
+    await expect.poll(() => readWebMcpTools(page), { timeout: 15_000 }).toEqual(
+      expect.arrayContaining(['status', 'start', 'stop', 'send']),
+    );
     await writeCloudProbe(page, probeValue);
-    await page.screenshot({ path: testInfo.outputPath('miniapp-sync-before-restart.png'), fullPage: true });
+    await page.screenshot({ path: testInfo.outputPath('miniapp-webmcp-sync-before-restart.png'), fullPage: true });
 
     await firstApp.close();
     restartedApp = await launchDesktopApp(appDataDir);
@@ -140,8 +152,9 @@ test('installed Mini App projects its Bot into Contacts/Bots and recovers Bot hi
 
     await restartedPage.getByTestId('miniapp-bot-open').click();
     await expect(restartedPage.locator('iframe[title="global-dharma"]')).toBeVisible();
+    await expect.poll(() => readWebMcpTools(restartedPage), { timeout: 15_000 }).toContain('status');
     await expect.poll(() => readCloudProbe(restartedPage), { timeout: 15_000 }).toBe(probeValue);
-    await restartedPage.screenshot({ path: testInfo.outputPath('miniapp-sync-after-restart.png'), fullPage: true });
+    await restartedPage.screenshot({ path: testInfo.outputPath('miniapp-webmcp-sync-after-restart.png'), fullPage: true });
   } finally {
     await restartedApp?.close().catch(() => {});
     await firstApp.close().catch(() => {});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Fabushi Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -8,6 +8,7 @@ import { installMahayanaAgentInlineCompatibility } from './mahayana-agent-inline
 import MahayanaAgentInlineReport from './mahayana-agent-inline-report';
 import MahayanaAgentWorkbench from './mahayana-agent-workbench';
 import { installMahayanaAgentTranscriptSemantics } from './mahayana-agent-transcript-semantics';
+import { installDesktopMiniAppWebMcpHost } from './miniapp-webmcp-host';
 import { installSelfHostedMahayanaInvocationBridge } from './selfhosted-mahayana-invocation-bridge';
 import './messenger-layout-regressions.css';
 import './grok-agent-ui-parity.css';
@@ -26,6 +27,7 @@ async function bootstrapDesktop(rootElement: HTMLDivElement): Promise<void> {
   await restoreDurableAgentState();
   installBotIdentityAliases();
   installDurableAgentState();
+  installDesktopMiniAppWebMcpHost();
 
   createRoot(rootElement).render(
     <StrictMode>

--- a/desktop/src/miniapp-webmcp-host.ts
+++ b/desktop/src/miniapp-webmcp-host.ts
@@ -1,0 +1,234 @@
+import { invokeNativeDesktop } from '../../frontend/apps/web/src/lib/fabushi-runtime/native-desktop';
+import { ElectronMahayanaHostTransport } from '../../frontend/apps/web/src/lib/mahayana-host/electron-transport';
+import { readAccountMiniApps } from './account-sync-client';
+
+const protocol = 'fabushi.miniapp.webmcp.v1';
+const installMarker = Symbol.for('fabushi.desktop.miniapp-webmcp-host.v1');
+const pendingToolCalls = new Set<string>();
+
+type ToolDescriptor = {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean; openWorldHint?: boolean };
+  approval?: string;
+};
+
+type PluginUiDocument = { pluginId: string; html: string };
+
+type MahayanaBridge = {
+  invoke<T>(method: string, params?: Record<string, unknown>): Promise<T>;
+  subscribe?(listener: (event: any) => void): () => void;
+};
+
+declare global {
+  interface Window {
+    mahayana?: MahayanaBridge;
+  }
+}
+
+function safePluginId(value: unknown): string {
+  const id = String(value ?? '').trim().toLowerCase();
+  return /^[a-z0-9][a-z0-9-]{1,63}$/.test(id) ? id : '';
+}
+
+function normalizeRuntimeTool(value: unknown): ToolDescriptor | null {
+  if (typeof value === 'string' && value.trim()) {
+    return { name: value.trim(), inputSchema: { type: 'object', properties: {} } };
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  const name = String(row.name ?? row.id ?? '').trim();
+  if (!name) return null;
+  return {
+    name,
+    description: typeof row.description === 'string' ? row.description : undefined,
+    inputSchema: row.inputSchema && typeof row.inputSchema === 'object' && !Array.isArray(row.inputSchema)
+      ? row.inputSchema as Record<string, unknown>
+      : { type: 'object', properties: {} },
+    annotations: row.annotations && typeof row.annotations === 'object' && !Array.isArray(row.annotations)
+      ? row.annotations as ToolDescriptor['annotations']
+      : undefined,
+  };
+}
+
+async function allowedTools(pluginId: string): Promise<ToolDescriptor[]> {
+  const account = await readAccountMiniApps();
+  const app = account.apps.find((candidate) => candidate.id === pluginId);
+  if (!app) throw new Error(`MiniApp ${pluginId} is not installed for this account`);
+
+  const runtimeInventory = await invokeNativeDesktop<unknown>('listMcpServerTools', { server: pluginId }).catch(() => []);
+  const runtimeRows = Array.isArray(runtimeInventory)
+    ? runtimeInventory.map(normalizeRuntimeTool).filter((tool): tool is ToolDescriptor => Boolean(tool))
+    : [];
+
+  const commands = Array.isArray(app.commands) ? app.commands : [];
+  const commandByTool = new Map<string, Record<string, unknown>>();
+  for (const raw of commands) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const command = raw as Record<string, unknown>;
+    const tool = String(command.tool ?? command.name ?? '').trim();
+    if (tool) commandByTool.set(tool, command);
+  }
+
+  if (runtimeRows.length > 0) {
+    return runtimeRows.map((tool) => {
+      const command = commandByTool.get(tool.name);
+      const approval = String(command?.approval ?? 'none');
+      return {
+        ...tool,
+        description: tool.description || (typeof command?.description === 'string' ? command.description : undefined),
+        approval,
+        annotations: tool.annotations ?? {
+          readOnlyHint: approval === 'none',
+          destructiveHint: approval === 'destructive',
+          openWorldHint: false,
+        },
+      };
+    });
+  }
+
+  return [...commandByTool.entries()].map(([name, command]) => {
+    const approval = String(command.approval ?? 'none');
+    return {
+      name,
+      description: typeof command.description === 'string' ? command.description : undefined,
+      inputSchema: { type: 'object', properties: {} },
+      approval,
+      annotations: {
+        readOnlyHint: approval === 'none',
+        destructiveHint: approval === 'destructive',
+        openWorldHint: false,
+      },
+    };
+  });
+}
+
+async function callHostMcpTool(pluginId: string, tool: ToolDescriptor, args: Record<string, unknown>): Promise<unknown> {
+  const bridge = window.mahayana;
+  if (!bridge?.invoke || !bridge.subscribe) throw new Error('Mahayana Host event bridge is unavailable');
+  const key = `${pluginId}:${tool.name}`;
+  if (pendingToolCalls.has(key)) throw new Error(`Tool ${tool.name} already has a pending call`);
+  pendingToolCalls.add(key);
+
+  const approval = tool.approval ?? (tool.annotations?.readOnlyHint === true ? 'none' : 'required');
+  if (approval !== 'none') {
+    const warning = approval === 'destructive'
+      ? '该操作可能产生破坏性修改。'
+      : '该操作会修改小程序或后台状态。';
+    if (!window.confirm(`允许 ${pluginId} 调用 ${tool.name}？\n\n${warning}`)) {
+      pendingToolCalls.delete(key);
+      throw new Error('用户取消了 WebMCP Tool 调用');
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const cleanup = bridge.subscribe?.((event: any) => {
+      if (event?.type !== 'mcp.toolResult' || event?.server !== pluginId || event?.tool !== tool.name) return;
+      if (timer) clearTimeout(timer);
+      cleanup?.();
+      pendingToolCalls.delete(key);
+      resolve(event.result);
+    });
+    timer = setTimeout(() => {
+      cleanup?.();
+      pendingToolCalls.delete(key);
+      reject(new Error(`Timed out waiting for ${pluginId}:${tool.name}`));
+    }, 30_000);
+
+    void bridge.invoke('feature.execute', {
+      command: {
+        type: 'mcp.toolCall',
+        requestId: `webmcp-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        server: pluginId,
+        tool: tool.name,
+        arguments: args,
+      },
+    }).catch((error) => {
+      if (timer) clearTimeout(timer);
+      cleanup?.();
+      pendingToolCalls.delete(key);
+      reject(error);
+    });
+  });
+}
+
+function webMcpBootstrap(pluginId: string): string {
+  const encodedPluginId = JSON.stringify(pluginId);
+  return `<script>(function(){
+    const protocol=${JSON.stringify(protocol)};
+    const pluginId=${encodedPluginId};
+    const pending=new Map(); let sequence=0; const localTools=new Map();
+    function request(action,payload){return new Promise((resolve,reject)=>{const requestId='webmcp-'+Date.now()+'-'+(++sequence);pending.set(requestId,{resolve,reject});window.parent.postMessage({protocol,pluginId,requestId,action,...(payload||{})},'*');});}
+    function publicTool(tool){const copy={...tool};delete copy.execute;return copy;}
+    function register(tool){localTools.set(tool.name,tool);if(document.modelContext&&typeof document.modelContext.registerTool==='function'){document.modelContext.registerTool(tool);}}
+    Object.defineProperty(window,'__fabushiWebMcp',{configurable:true,value:{version:1,list:()=>Array.from(localTools.values()).map(publicTool),call:async(name,input={})=>{const tool=localTools.get(name);if(!tool)throw new Error('Unknown WebMCP tool: '+name);return tool.execute(input);}}});
+    window.addEventListener('message',(event)=>{const data=event.data||{};if(data.protocol!==protocol||data.pluginId!==pluginId||!data.requestId||!pending.has(data.requestId))return;const task=pending.get(data.requestId);pending.delete(data.requestId);if(data.ok)task.resolve(data.data);else task.reject(new Error(data.error||'WebMCP host request failed'));});
+    async function boot(){const tools=await request('list');for(const item of (tools||[])){register({name:item.name,description:item.description,inputSchema:item.inputSchema||{type:'object',properties:{}},annotations:item.annotations||{},execute:(input)=>request('call',{tool:item.name,input:input||{}})});}window.dispatchEvent(new CustomEvent('fabushi:webmcp-ready',{detail:{pluginId,tools:(tools||[]).map(t=>t.name)}}));}
+    if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',()=>void boot());else void boot();
+  })();</script>`;
+}
+
+function injectWebMcp(html: string, pluginId: string): string {
+  if (html.includes('fabushi.miniapp.webmcp.v1')) return html;
+  const bootstrap = webMcpBootstrap(pluginId);
+  return html.includes('</head>') ? html.replace('</head>', `${bootstrap}</head>`) : `${bootstrap}${html}`;
+}
+
+export function installDesktopMiniAppWebMcpHost(): void {
+  const globalObject = window as Window & { [installMarker]?: boolean };
+  if (globalObject[installMarker]) return;
+  Object.defineProperty(globalObject, installMarker, { value: true });
+
+  const prototype = ElectronMahayanaHostTransport.prototype as ElectronMahayanaHostTransport & {
+    pluginUiDocument(pluginId: string): Promise<PluginUiDocument>;
+  };
+  const originalPluginUiDocument = prototype.pluginUiDocument;
+  prototype.pluginUiDocument = async function pluginUiDocumentWithWebMcp(pluginId: string) {
+    const document = await originalPluginUiDocument.call(this, pluginId);
+    return { ...document, html: injectWebMcp(document.html, pluginId) };
+  };
+
+  window.addEventListener('message', (event) => {
+    const data = event.data as Record<string, unknown> | null;
+    if (!data || data.protocol !== protocol || !data.requestId) return;
+    const pluginId = safePluginId(data.pluginId);
+    const requestId = String(data.requestId);
+    const source = event.source;
+    if (!pluginId || !source || typeof (source as WindowProxy).postMessage !== 'function') return;
+
+    const respond = (ok: boolean, payload: unknown) => {
+      (source as WindowProxy).postMessage({
+        protocol,
+        pluginId,
+        requestId,
+        ok,
+        ...(ok ? { data: payload } : { error: payload instanceof Error ? payload.message : String(payload) }),
+      }, '*');
+    };
+
+    void (async () => {
+      try {
+        const tools = await allowedTools(pluginId);
+        if (data.action === 'list') {
+          respond(true, tools.map(({ approval: _approval, ...tool }) => tool));
+          return;
+        }
+        if (data.action === 'call') {
+          const requested = String(data.tool ?? '').trim();
+          const tool = tools.find((candidate) => candidate.name === requested);
+          if (!tool) throw new Error(`WebMCP tool ${requested} is not allowed for ${pluginId}`);
+          const input = data.input && typeof data.input === 'object' && !Array.isArray(data.input)
+            ? data.input as Record<string, unknown>
+            : {};
+          respond(true, await callHostMcpTool(pluginId, tool, input));
+          return;
+        }
+        throw new Error(`Unsupported WebMCP action ${String(data.action)}`);
+      } catch (error) {
+        respond(false, error);
+      }
+    })();
+  });
+}

--- a/desktop/src/miniapp-webmcp-host.ts
+++ b/desktop/src/miniapp-webmcp-host.ts
@@ -5,6 +5,7 @@ import { readAccountMiniApps } from './account-sync-client';
 const protocol = 'fabushi.miniapp.webmcp.v1';
 const installMarker = Symbol.for('fabushi.desktop.miniapp-webmcp-host.v1');
 const pendingToolCalls = new Set<string>();
+const validBridgeNonces = new Map<string, string>();
 
 type ToolDescriptor = {
   name: string;
@@ -18,7 +19,6 @@ type PluginUiDocument = { pluginId: string; html: string };
 
 type MahayanaBridge = {
   invoke<T>(method: string, params?: Record<string, unknown>): Promise<T>;
-  subscribe?(listener: (event: any) => void): () => void;
 };
 
 declare global {
@@ -34,7 +34,7 @@ function safePluginId(value: unknown): string {
 
 function normalizeRuntimeTool(value: unknown): ToolDescriptor | null {
   if (typeof value === 'string' && value.trim()) {
-    return { name: value.trim(), inputSchema: { type: 'object', properties: {} } };
+    return { name: value.trim(), description: value.trim(), inputSchema: { type: 'object', properties: {} } };
   }
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const row = value as Record<string, unknown>;
@@ -42,7 +42,7 @@ function normalizeRuntimeTool(value: unknown): ToolDescriptor | null {
   if (!name) return null;
   return {
     name,
-    description: typeof row.description === 'string' ? row.description : undefined,
+    description: typeof row.description === 'string' && row.description.trim() ? row.description : name,
     inputSchema: row.inputSchema && typeof row.inputSchema === 'object' && !Array.isArray(row.inputSchema)
       ? row.inputSchema as Record<string, unknown>
       : { type: 'object', properties: {} },
@@ -71,13 +71,17 @@ async function allowedTools(pluginId: string): Promise<ToolDescriptor[]> {
     if (tool) commandByTool.set(tool, command);
   }
 
-  if (runtimeRows.length > 0) {
-    return runtimeRows.map((tool) => {
+  // runtime.tools is a host-wide inventory. Never expose another MiniApp's tool
+  // through this document: intersect it with this MiniApp's signed/approved
+  // Tool Contract before projecting it into WebMCP.
+  const scopedRuntimeRows = runtimeRows.filter((tool) => commandByTool.has(tool.name));
+  if (scopedRuntimeRows.length > 0) {
+    return scopedRuntimeRows.map((tool) => {
       const command = commandByTool.get(tool.name);
       const approval = String(command?.approval ?? 'none');
       return {
         ...tool,
-        description: tool.description || (typeof command?.description === 'string' ? command.description : undefined),
+        description: tool.description || (typeof command?.description === 'string' ? command.description : tool.name),
         approval,
         annotations: tool.annotations ?? {
           readOnlyHint: approval === 'none',
@@ -92,7 +96,7 @@ async function allowedTools(pluginId: string): Promise<ToolDescriptor[]> {
     const approval = String(command.approval ?? 'none');
     return {
       name,
-      description: typeof command.description === 'string' ? command.description : undefined,
+      description: typeof command.description === 'string' && command.description.trim() ? command.description : name,
       inputSchema: { type: 'object', properties: {} },
       approval,
       annotations: {
@@ -104,75 +108,66 @@ async function allowedTools(pluginId: string): Promise<ToolDescriptor[]> {
   });
 }
 
-async function callHostMcpTool(pluginId: string, tool: ToolDescriptor, args: Record<string, unknown>): Promise<unknown> {
+async function callLocalRuntimeTool(
+  pluginId: string,
+  tool: ToolDescriptor,
+  args: Record<string, unknown>,
+): Promise<unknown> {
   const bridge = window.mahayana;
-  if (!bridge?.invoke || !bridge.subscribe) throw new Error('Mahayana Host event bridge is unavailable');
+  if (!bridge?.invoke) throw new Error('Mahayana Host bridge is unavailable');
   const key = `${pluginId}:${tool.name}`;
   if (pendingToolCalls.has(key)) throw new Error(`Tool ${tool.name} already has a pending call`);
   pendingToolCalls.add(key);
 
-  const approval = tool.approval ?? (tool.annotations?.readOnlyHint === true ? 'none' : 'required');
-  if (approval !== 'none') {
-    const warning = approval === 'destructive'
-      ? '该操作可能产生破坏性修改。'
-      : '该操作会修改小程序或后台状态。';
-    if (!window.confirm(`允许 ${pluginId} 调用 ${tool.name}？\n\n${warning}`)) {
-      pendingToolCalls.delete(key);
-      throw new Error('用户取消了 WebMCP Tool 调用');
+  try {
+    const approval = tool.approval ?? (tool.annotations?.readOnlyHint === true ? 'none' : 'required');
+    if (approval !== 'none') {
+      const warning = approval === 'destructive'
+        ? '该操作可能产生破坏性修改。'
+        : '该操作会修改小程序或后台状态。';
+      if (!window.confirm(`允许 ${pluginId} 调用 ${tool.name}？\n\n${warning}`)) {
+        throw new Error('用户取消了 WebMCP Tool 调用');
+      }
     }
+
+    return await bridge.invoke('runtime.call', {
+      pluginId,
+      name: tool.name,
+      arguments: args,
+    });
+  } finally {
+    pendingToolCalls.delete(key);
   }
-
-  return new Promise((resolve, reject) => {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    const cleanup = bridge.subscribe?.((event: any) => {
-      if (event?.type !== 'mcp.toolResult' || event?.server !== pluginId || event?.tool !== tool.name) return;
-      if (timer) clearTimeout(timer);
-      cleanup?.();
-      pendingToolCalls.delete(key);
-      resolve(event.result);
-    });
-    timer = setTimeout(() => {
-      cleanup?.();
-      pendingToolCalls.delete(key);
-      reject(new Error(`Timed out waiting for ${pluginId}:${tool.name}`));
-    }, 30_000);
-
-    void bridge.invoke('feature.execute', {
-      command: {
-        type: 'mcp.toolCall',
-        requestId: `webmcp-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-        server: pluginId,
-        tool: tool.name,
-        arguments: args,
-      },
-    }).catch((error) => {
-      if (timer) clearTimeout(timer);
-      cleanup?.();
-      pendingToolCalls.delete(key);
-      reject(error);
-    });
-  });
 }
 
-function webMcpBootstrap(pluginId: string): string {
-  const encodedPluginId = JSON.stringify(pluginId);
+function webMcpBootstrap(pluginId: string, nonce: string): string {
   return `<script>(function(){
     const protocol=${JSON.stringify(protocol)};
-    const pluginId=${encodedPluginId};
-    const pending=new Map(); let sequence=0; const localTools=new Map();
-    function request(action,payload){return new Promise((resolve,reject)=>{const requestId='webmcp-'+Date.now()+'-'+(++sequence);pending.set(requestId,{resolve,reject});window.parent.postMessage({protocol,pluginId,requestId,action,...(payload||{})},'*');});}
+    const pluginId=${JSON.stringify(pluginId)};
+    const nonce=${JSON.stringify(nonce)};
+    const pending=new Map(); let sequence=0; const localTools=new Map(); const controllers=[];
+    function request(action,payload){return new Promise((resolve,reject)=>{const requestId='webmcp-'+Date.now()+'-'+(++sequence);pending.set(requestId,{resolve,reject});window.parent.postMessage({protocol,pluginId,nonce,requestId,action,...(payload||{})},'*');});}
     function publicTool(tool){const copy={...tool};delete copy.execute;return copy;}
-    function register(tool){localTools.set(tool.name,tool);if(document.modelContext&&typeof document.modelContext.registerTool==='function'){document.modelContext.registerTool(tool);}}
+    function register(item){
+      const tool={name:item.name,description:item.description||item.name,inputSchema:item.inputSchema||{type:'object',properties:{}},annotations:{readOnlyHint:item.annotations?.readOnlyHint===true},execute:(input)=>request('call',{tool:item.name,input:input||{}})};
+      localTools.set(tool.name,tool);
+      if(document.modelContext&&typeof document.modelContext.registerTool==='function'){
+        const controller=new AbortController(); controllers.push(controller);
+        Promise.resolve(document.modelContext.registerTool(tool,{signal:controller.signal})).catch(()=>{});
+      }
+    }
     Object.defineProperty(window,'__fabushiWebMcp',{configurable:true,value:{version:1,list:()=>Array.from(localTools.values()).map(publicTool),call:async(name,input={})=>{const tool=localTools.get(name);if(!tool)throw new Error('Unknown WebMCP tool: '+name);return tool.execute(input);}}});
-    window.addEventListener('message',(event)=>{const data=event.data||{};if(data.protocol!==protocol||data.pluginId!==pluginId||!data.requestId||!pending.has(data.requestId))return;const task=pending.get(data.requestId);pending.delete(data.requestId);if(data.ok)task.resolve(data.data);else task.reject(new Error(data.error||'WebMCP host request failed'));});
-    async function boot(){const tools=await request('list');for(const item of (tools||[])){register({name:item.name,description:item.description,inputSchema:item.inputSchema||{type:'object',properties:{}},annotations:item.annotations||{},execute:(input)=>request('call',{tool:item.name,input:input||{}})});}window.dispatchEvent(new CustomEvent('fabushi:webmcp-ready',{detail:{pluginId,tools:(tools||[]).map(t=>t.name)}}));}
-    if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',()=>void boot());else void boot();
+    window.addEventListener('message',(event)=>{const data=event.data||{};if(data.protocol!==protocol||data.pluginId!==pluginId||data.nonce!==nonce||!data.requestId||!pending.has(data.requestId))return;const task=pending.get(data.requestId);pending.delete(data.requestId);if(data.ok)task.resolve(data.data);else task.reject(new Error(data.error||'WebMCP host request failed'));});
+    async function boot(){const tools=await request('list');for(const item of (tools||[]))register(item);window.dispatchEvent(new CustomEvent('fabushi:webmcp-ready',{detail:{pluginId,tools:(tools||[]).map(t=>t.name)}}));}
+    function dispose(){for(const controller of controllers)controller.abort();controllers.length=0;window.parent.postMessage({protocol,pluginId,nonce,requestId:'dispose-'+Date.now(),action:'dispose'},'*');}
+    window.addEventListener('pagehide',dispose,{once:true});
+    if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',()=>void boot(),{once:true});else void boot();
   })();</script>`;
 }
 
-function injectWebMcp(html: string, pluginId: string): string {
+function injectWebMcp(html: string, pluginId: string, nonce: string): string {
   if (html.includes('fabushi.miniapp.webmcp.v1')) return html;
-  const bootstrap = webMcpBootstrap(pluginId);
+  const bootstrap = webMcpBootstrap(pluginId, nonce);
   return html.includes('</head>') ? html.replace('</head>', `${bootstrap}</head>`) : `${bootstrap}${html}`;
 }
 
@@ -187,21 +182,26 @@ export function installDesktopMiniAppWebMcpHost(): void {
   const originalPluginUiDocument = prototype.pluginUiDocument;
   prototype.pluginUiDocument = async function pluginUiDocumentWithWebMcp(pluginId: string) {
     const document = await originalPluginUiDocument.call(this, pluginId);
-    return { ...document, html: injectWebMcp(document.html, pluginId) };
+    const nonce = crypto.randomUUID();
+    validBridgeNonces.set(nonce, pluginId);
+    return { ...document, html: injectWebMcp(document.html, pluginId, nonce) };
   };
 
   window.addEventListener('message', (event) => {
     const data = event.data as Record<string, unknown> | null;
     if (!data || data.protocol !== protocol || !data.requestId) return;
     const pluginId = safePluginId(data.pluginId);
+    const nonce = String(data.nonce ?? '');
     const requestId = String(data.requestId);
     const source = event.source;
-    if (!pluginId || !source || typeof (source as WindowProxy).postMessage !== 'function') return;
+    if (!pluginId || !nonce || validBridgeNonces.get(nonce) !== pluginId) return;
+    if (!source || typeof (source as WindowProxy).postMessage !== 'function') return;
 
     const respond = (ok: boolean, payload: unknown) => {
       (source as WindowProxy).postMessage({
         protocol,
         pluginId,
+        nonce,
         requestId,
         ok,
         ...(ok ? { data: payload } : { error: payload instanceof Error ? payload.message : String(payload) }),
@@ -210,9 +210,16 @@ export function installDesktopMiniAppWebMcpHost(): void {
 
     void (async () => {
       try {
+        if (data.action === 'dispose') {
+          validBridgeNonces.delete(nonce);
+          return;
+        }
         const tools = await allowedTools(pluginId);
         if (data.action === 'list') {
-          respond(true, tools.map(({ approval: _approval, ...tool }) => tool));
+          respond(true, tools.map(({ approval: _approval, annotations, ...tool }) => ({
+            ...tool,
+            annotations: { readOnlyHint: annotations?.readOnlyHint === true },
+          })));
           return;
         }
         if (data.action === 'call') {
@@ -222,7 +229,7 @@ export function installDesktopMiniAppWebMcpHost(): void {
           const input = data.input && typeof data.input === 'object' && !Array.isArray(data.input)
             ? data.input as Record<string, unknown>
             : {};
-          respond(true, await callHostMcpTool(pluginId, tool, input));
+          respond(true, await callLocalRuntimeTool(pluginId, tool, input));
           return;
         }
         throw new Error(`Unsupported WebMCP action ${String(data.action)}`);

--- a/desktop/src/miniapp-webmcp-host.ts
+++ b/desktop/src/miniapp-webmcp-host.ts
@@ -17,16 +17,6 @@ type ToolDescriptor = {
 
 type PluginUiDocument = { pluginId: string; html: string };
 
-type MahayanaBridge = {
-  invoke<T>(method: string, params?: Record<string, unknown>): Promise<T>;
-};
-
-declare global {
-  interface Window {
-    mahayana?: MahayanaBridge;
-  }
-}
-
 function safePluginId(value: unknown): string {
   const id = String(value ?? '').trim().toLowerCase();
   return /^[a-z0-9][a-z0-9-]{1,63}$/.test(id) ? id : '';

--- a/frontend/apps/web/src/app/miniapps/[id]/WebMcpMiniAppAdapter.tsx
+++ b/frontend/apps/web/src/app/miniapps/[id]/WebMcpMiniAppAdapter.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { exposeMcpToolsAsWebMcp, type McpTool, type McpToolResult } from "@fabushi/mcp-app-sdk";
+
+class MiniAppWebMcpClient {
+  private nextId = 1;
+  private sessionId = "";
+
+  constructor(private readonly endpoint: string) {}
+
+  async request(method: string, params: Record<string, unknown> = {}): Promise<any> {
+    const response = await fetch(this.endpoint, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        ...(this.sessionId ? { "mcp-session-id": this.sessionId, "mcp-protocol-version": "2025-06-18" } : {}),
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: this.nextId++, method, params }),
+    });
+    const sessionId = response.headers.get("mcp-session-id");
+    if (sessionId) this.sessionId = sessionId;
+    if (!response.ok) throw new Error(`MCP ${method} failed (${response.status})`);
+    const payload = await response.json();
+    if (payload.error) throw new Error(payload.error.message || `MCP ${method} failed`);
+    return payload.result;
+  }
+
+  async notify(method: string): Promise<void> {
+    const response = await fetch(this.endpoint, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        ...(this.sessionId ? { "mcp-session-id": this.sessionId, "mcp-protocol-version": "2025-06-18" } : {}),
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method }),
+    });
+    if (!response.ok) throw new Error(`MCP ${method} failed (${response.status})`);
+  }
+
+  async close(): Promise<void> {
+    if (!this.sessionId) return;
+    await fetch(this.endpoint, {
+      method: "DELETE",
+      credentials: "include",
+      headers: { "mcp-session-id": this.sessionId, "mcp-protocol-version": "2025-06-18" },
+    }).catch(() => undefined);
+    this.sessionId = "";
+  }
+}
+
+export default function WebMcpMiniAppAdapter({ pluginId }: { pluginId: string }) {
+  const normalizedId = pluginId.replace(/^official\./, "");
+  const backendBase = (process.env.NEXT_PUBLIC_AI_BACKEND_URL || "https://api.ombhrum.com").replace(/\/$/, "");
+  const endpoint = `${backendBase}/api/mcp/apps/${encodeURIComponent(normalizedId)}`;
+  const client = useMemo(() => new MiniAppWebMcpClient(endpoint), [endpoint]);
+
+  useEffect(() => {
+    let active = true;
+    let dispose = () => undefined;
+
+    void (async () => {
+      try {
+        await client.request("initialize", {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "fabushi-webmcp-adapter", version: "1.0.0" },
+        });
+        await client.notify("notifications/initialized");
+        const listed = await client.request("tools/list");
+        if (!active) return;
+        const tools = Array.isArray(listed?.tools) ? listed.tools as McpTool[] : [];
+        dispose = exposeMcpToolsAsWebMcp(tools, async (name, args) => {
+          const tool = tools.find((candidate) => candidate.name === name);
+          if (!tool) throw new Error(`Unknown MiniApp tool: ${name}`);
+          if (tool.annotations?.readOnlyHint !== true) {
+            const risk = tool.annotations?.destructiveHint === true
+              ? "该操作可能产生破坏性修改。"
+              : tool.annotations?.openWorldHint === true
+                ? "该操作会影响小程序外部系统。"
+                : "该操作会修改小程序或后台状态。";
+            if (!window.confirm(`允许 WebMCP 调用 ${name}？\n\n${risk}`)) {
+              throw new Error("用户取消了 WebMCP Tool 调用");
+            }
+          }
+          return await client.request("tools/call", { name, arguments: args }) as McpToolResult;
+        });
+        window.dispatchEvent(new CustomEvent("fabushi:webmcp-ready", {
+          detail: { pluginId: normalizedId, tools: tools.map((tool) => tool.name) },
+        }));
+      } catch (error) {
+        window.dispatchEvent(new CustomEvent("fabushi:webmcp-error", {
+          detail: { pluginId: normalizedId, error: error instanceof Error ? error.message : String(error) },
+        }));
+      }
+    })();
+
+    return () => {
+      active = false;
+      dispose();
+      void client.close();
+    };
+  }, [client, normalizedId]);
+
+  return null;
+}

--- a/frontend/apps/web/src/app/miniapps/[id]/page.tsx
+++ b/frontend/apps/web/src/app/miniapps/[id]/page.tsx
@@ -1,4 +1,5 @@
 import McpPluginApp from "./McpPluginApp";
+import WebMcpMiniAppAdapter from "./WebMcpMiniAppAdapter";
 import "./miniapps.css";
 
 type MiniAppPageProps = {
@@ -21,5 +22,10 @@ export async function generateStaticParams() {
 export default async function MiniAppPage({ params }: MiniAppPageProps) {
   const { id } = await params;
 
-  return <McpPluginApp pluginId={id} />;
+  return (
+    <>
+      <WebMcpMiniAppAdapter pluginId={id} />
+      <McpPluginApp pluginId={id} />
+    </>
+  );
 }

--- a/frontend/packages/mcp-app-sdk/src/index.ts
+++ b/frontend/packages/mcp-app-sdk/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./bridge";
 export * from "./commands";
 export * from "./types";
+export * from "./webmcp";

--- a/frontend/packages/mcp-app-sdk/src/webmcp.ts
+++ b/frontend/packages/mcp-app-sdk/src/webmcp.ts
@@ -1,19 +1,41 @@
 import type { JsonSchema, McpTool, McpToolResult } from "./types";
 
+export type WebMcpAnnotations = {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+};
+
 export type WebMcpTool = {
   name: string;
   title?: string;
-  description?: string;
+  description: string;
   inputSchema?: JsonSchema;
-  annotations?: McpTool["annotations"];
-  execute: (input: Record<string, unknown>) => Promise<unknown> | unknown;
+  annotations?: WebMcpAnnotations;
+  execute: (
+    input: Record<string, unknown>,
+    options?: { signal?: AbortSignal },
+  ) => Promise<unknown> | unknown;
+};
+
+type WebMcpRegisteredTool = {
+  name: string;
+  title?: string | null;
+  description: string;
+  inputSchema?: string;
+  annotations?: WebMcpAnnotations | null;
 };
 
 type WebMcpModelContext = {
-  registerTool(tool: WebMcpTool & { signal?: AbortSignal }): unknown;
-  unregisterTool?(name: string): unknown;
-  getTools?(): unknown;
-  executeTool?(name: string, input?: Record<string, unknown>): unknown;
+  registerTool(
+    tool: WebMcpTool,
+    options?: { signal?: AbortSignal; exposedTo?: string[] },
+  ): Promise<void> | void;
+  getTools?(options?: { fromOrigins?: string[] }): Promise<WebMcpRegisteredTool[]>;
+  executeTool?(
+    tool: WebMcpRegisteredTool,
+    input?: Record<string, unknown>,
+    options?: { signal?: AbortSignal },
+  ): Promise<string>;
 };
 
 type FabushiWebMcpRegistry = {
@@ -55,6 +77,14 @@ function installFallbackRegistry(): void {
   });
 }
 
+function parseNativeResult(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
 export function supportsNativeWebMcp(): boolean {
   return typeof document !== "undefined" && typeof document.modelContext?.registerTool === "function";
 }
@@ -67,9 +97,13 @@ export async function callRegisteredWebMcpTool(
   name: string,
   input: Record<string, unknown> = {},
 ): Promise<unknown> {
-  const nativeExecute = typeof document !== "undefined" ? document.modelContext?.executeTool : undefined;
-  if (typeof nativeExecute === "function") {
-    return nativeExecute.call(document.modelContext, name, input);
+  const context = typeof document !== "undefined" ? document.modelContext : undefined;
+  if (context?.getTools && context.executeTool) {
+    const registered = await context.getTools();
+    const tool = registered.find((candidate) => candidate.name === name);
+    if (tool) {
+      return parseNativeResult(await context.executeTool(tool, input));
+    }
   }
   const tool = localTools.get(name);
   if (!tool) throw new Error(`Unknown WebMCP tool: ${name}`);
@@ -77,21 +111,34 @@ export async function callRegisteredWebMcpTool(
 }
 
 export function registerWebMcpTool(tool: WebMcpTool): () => void {
-  if (!tool.name.trim()) throw new Error("WebMCP tool name is required");
-  localTools.set(tool.name, tool);
+  const name = tool.name.trim();
+  if (!name) throw new Error("WebMCP tool name is required");
+  if (!tool.description.trim()) throw new Error(`WebMCP tool ${name} requires a description`);
+  localTools.set(name, tool);
   installFallbackRegistry();
 
   const context = typeof document !== "undefined" ? document.modelContext : undefined;
   const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
   if (context?.registerTool) {
-    context.registerTool({ ...tool, ...(controller ? { signal: controller.signal } : {}) });
+    const registration = context.registerTool(
+      tool,
+      controller ? { signal: controller.signal } : undefined,
+    );
+    if (registration && typeof registration.then === "function") {
+      void registration.catch((error: unknown) => {
+        // The Fabushi registry remains available as a compatibility path when a
+        // browser exposes the draft API but rejects registration by policy.
+        console.warn(`WebMCP registration failed for ${name}`, error);
+      });
+    }
   }
 
   return () => {
-    if (localTools.get(tool.name) !== tool) return;
-    localTools.delete(tool.name);
+    if (localTools.get(name) !== tool) return;
+    localTools.delete(name);
+    // The current WebMCP draft unregisters tools by aborting the signal that
+    // was supplied to registerTool(). No separate unregisterTool API is used.
     controller?.abort();
-    try { context?.unregisterTool?.(tool.name); } catch { /* native host may already have torn down the document */ }
   };
 }
 
@@ -102,9 +149,13 @@ export function exposeMcpToolsAsWebMcp(
   const disposers = tools.map((tool) => registerWebMcpTool({
     name: tool.name,
     title: tool.title,
-    description: tool.description,
+    description: tool.description?.trim() || tool.title?.trim() || tool.name,
     inputSchema: tool.inputSchema,
-    annotations: tool.annotations,
+    annotations: {
+      ...(tool.annotations?.readOnlyHint === undefined
+        ? {}
+        : { readOnlyHint: tool.annotations.readOnlyHint }),
+    },
     execute: (input) => callTool(tool.name, input),
   }));
   return () => {

--- a/frontend/packages/mcp-app-sdk/src/webmcp.ts
+++ b/frontend/packages/mcp-app-sdk/src/webmcp.ts
@@ -1,0 +1,100 @@
+import type { JsonSchema, McpTool, McpToolResult } from "./types";
+
+export type WebMcpTool = {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: JsonSchema;
+  annotations?: McpTool["annotations"];
+  execute: (input: Record<string, unknown>) => Promise<unknown> | unknown;
+};
+
+type WebMcpModelContext = {
+  registerTool(tool: WebMcpTool & { signal?: AbortSignal }): unknown;
+  unregisterTool?(name: string): unknown;
+  getTools?(): unknown;
+  executeTool?(name: string, input?: Record<string, unknown>): unknown;
+};
+
+type FabushiWebMcpRegistry = {
+  readonly version: 1;
+  list(): Array<Omit<WebMcpTool, "execute">>;
+  call(name: string, input?: Record<string, unknown>): Promise<unknown>;
+};
+
+declare global {
+  interface Document {
+    modelContext?: WebMcpModelContext;
+  }
+  interface Window {
+    __fabushiWebMcp?: FabushiWebMcpRegistry;
+  }
+}
+
+const localTools = new Map<string, WebMcpTool>();
+
+function publicTool(tool: WebMcpTool): Omit<WebMcpTool, "execute"> {
+  const { execute: _execute, ...metadata } = tool;
+  return metadata;
+}
+
+function installFallbackRegistry(): void {
+  if (typeof window === "undefined" || window.__fabushiWebMcp) return;
+  Object.defineProperty(window, "__fabushiWebMcp", {
+    configurable: true,
+    enumerable: false,
+    value: {
+      version: 1 as const,
+      list: () => [...localTools.values()].map(publicTool),
+      call: async (name: string, input: Record<string, unknown> = {}) => {
+        const tool = localTools.get(name);
+        if (!tool) throw new Error(`Unknown WebMCP tool: ${name}`);
+        return tool.execute(input);
+      },
+    },
+  });
+}
+
+export function supportsNativeWebMcp(): boolean {
+  return typeof document !== "undefined" && typeof document.modelContext?.registerTool === "function";
+}
+
+export function listRegisteredWebMcpTools(): Array<Omit<WebMcpTool, "execute">> {
+  return [...localTools.values()].map(publicTool);
+}
+
+export function registerWebMcpTool(tool: WebMcpTool): () => void {
+  if (!tool.name.trim()) throw new Error("WebMCP tool name is required");
+  localTools.set(tool.name, tool);
+  installFallbackRegistry();
+
+  const context = typeof document !== "undefined" ? document.modelContext : undefined;
+  const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
+  if (context?.registerTool) {
+    context.registerTool({ ...tool, ...(controller ? { signal: controller.signal } : {}) });
+  }
+
+  return () => {
+    if (localTools.get(tool.name) !== tool) return;
+    localTools.delete(tool.name);
+    controller?.abort();
+    try { context?.unregisterTool?.(tool.name); } catch { /* native host may already have torn down the document */ }
+  };
+}
+
+export function exposeMcpToolsAsWebMcp(
+  tools: readonly McpTool[],
+  callTool: (name: string, args: Record<string, unknown>) => Promise<McpToolResult>,
+): () => void {
+  const disposers = tools.map((tool) => registerWebMcpTool({
+    name: tool.name,
+    title: tool.title,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    annotations: tool.annotations,
+    execute: (input) => callTool(tool.name, input),
+  }));
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/frontend/packages/mcp-app-sdk/src/webmcp.ts
+++ b/frontend/packages/mcp-app-sdk/src/webmcp.ts
@@ -63,6 +63,19 @@ export function listRegisteredWebMcpTools(): Array<Omit<WebMcpTool, "execute">> 
   return [...localTools.values()].map(publicTool);
 }
 
+export async function callRegisteredWebMcpTool(
+  name: string,
+  input: Record<string, unknown> = {},
+): Promise<unknown> {
+  const nativeExecute = typeof document !== "undefined" ? document.modelContext?.executeTool : undefined;
+  if (typeof nativeExecute === "function") {
+    return nativeExecute.call(document.modelContext, name, input);
+  }
+  const tool = localTools.get(name);
+  if (!tool) throw new Error(`Unknown WebMCP tool: ${name}`);
+  return tool.execute(input);
+}
+
 export function registerWebMcpTool(tool: WebMcpTool): () => void {
   if (!tool.name.trim()) throw new Error("WebMCP tool name is required");
   localTools.set(tool.name, tool);

--- a/frontend/packages/mcp-app-sdk/test/webmcp.test.ts
+++ b/frontend/packages/mcp-app-sdk/test/webmcp.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  callRegisteredWebMcpTool,
   exposeMcpToolsAsWebMcp,
   listRegisteredWebMcpTools,
   registerWebMcpTool,
@@ -31,18 +32,24 @@ test("fallback registry exposes registered tools and executes them", async () =>
   assert.equal(supportsNativeWebMcp(), false);
   assert.deepEqual(listRegisteredWebMcpTools().map((tool) => tool.name), ["status"]);
   assert.deepEqual(await (globalThis as any).window.__fabushiWebMcp.call("status", {}), { running: true });
+  assert.deepEqual(await callRegisteredWebMcpTool("status"), { running: true });
 
   dispose();
   assert.deepEqual(listRegisteredWebMcpTools(), []);
   clearGlobals();
 });
 
-test("native modelContext registration receives tool metadata and lifecycle signal", () => {
+test("native modelContext registration receives tool metadata and lifecycle signal", async () => {
   const registered: any[] = [];
   const unregistered: string[] = [];
+  const executed: Array<{ name: string; input: Record<string, unknown> }> = [];
   installGlobals({
     registerTool(tool: unknown) { registered.push(tool); },
     unregisterTool(name: string) { unregistered.push(name); },
+    executeTool(name: string, input: Record<string, unknown>) {
+      executed.push({ name, input });
+      return { native: true };
+    },
   });
 
   const dispose = registerWebMcpTool({
@@ -61,6 +68,8 @@ test("native modelContext registration receives tool metadata and lifecycle sign
   assert.equal(registered[0].name, "set_speed");
   assert.ok(registered[0].signal instanceof AbortSignal);
   assert.equal(registered[0].signal.aborted, false);
+  assert.deepEqual(await callRegisteredWebMcpTool("set_speed", { speed: 60 }), { native: true });
+  assert.deepEqual(executed, [{ name: "set_speed", input: { speed: 60 } }]);
 
   dispose();
   assert.equal(registered[0].signal.aborted, true);

--- a/frontend/packages/mcp-app-sdk/test/webmcp.test.ts
+++ b/frontend/packages/mcp-app-sdk/test/webmcp.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  exposeMcpToolsAsWebMcp,
+  listRegisteredWebMcpTools,
+  registerWebMcpTool,
+  supportsNativeWebMcp,
+} from "../src/webmcp.ts";
+
+function installGlobals(modelContext?: Record<string, unknown>) {
+  (globalThis as any).window = {};
+  (globalThis as any).document = modelContext ? { modelContext } : {};
+}
+
+function clearGlobals() {
+  delete (globalThis as any).window;
+  delete (globalThis as any).document;
+}
+
+test("fallback registry exposes registered tools and executes them", async () => {
+  installGlobals();
+  const dispose = registerWebMcpTool({
+    name: "status",
+    description: "Read current status",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute: async () => ({ running: true }),
+  });
+
+  assert.equal(supportsNativeWebMcp(), false);
+  assert.deepEqual(listRegisteredWebMcpTools().map((tool) => tool.name), ["status"]);
+  assert.deepEqual(await (globalThis as any).window.__fabushiWebMcp.call("status", {}), { running: true });
+
+  dispose();
+  assert.deepEqual(listRegisteredWebMcpTools(), []);
+  clearGlobals();
+});
+
+test("native modelContext registration receives tool metadata and lifecycle signal", () => {
+  const registered: any[] = [];
+  const unregistered: string[] = [];
+  installGlobals({
+    registerTool(tool: unknown) { registered.push(tool); },
+    unregisterTool(name: string) { unregistered.push(name); },
+  });
+
+  const dispose = registerWebMcpTool({
+    name: "set_speed",
+    description: "Set prayer wheel speed",
+    inputSchema: {
+      type: "object",
+      properties: { speed: { type: "number" } },
+      required: ["speed"],
+    },
+    execute: () => ({ ok: true }),
+  });
+
+  assert.equal(supportsNativeWebMcp(), true);
+  assert.equal(registered.length, 1);
+  assert.equal(registered[0].name, "set_speed");
+  assert.ok(registered[0].signal instanceof AbortSignal);
+  assert.equal(registered[0].signal.aborted, false);
+
+  dispose();
+  assert.equal(registered[0].signal.aborted, true);
+  assert.deepEqual(unregistered, ["set_speed"]);
+  clearGlobals();
+});
+
+test("MCP tools are projected to WebMCP without a second command mapping", async () => {
+  installGlobals();
+  const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+  const dispose = exposeMcpToolsAsWebMcp([
+    {
+      name: "start_prayer_wheel",
+      description: "Start the selected prayer wheel",
+      inputSchema: { type: "object", properties: {} },
+      annotations: { readOnlyHint: false },
+    },
+  ], async (name, args) => {
+    calls.push({ name, args });
+    return { structuredContent: { started: true } };
+  });
+
+  const result = await (globalThis as any).window.__fabushiWebMcp.call("start_prayer_wheel", {});
+  assert.deepEqual(calls, [{ name: "start_prayer_wheel", args: {} }]);
+  assert.deepEqual(result, { structuredContent: { started: true } });
+
+  dispose();
+  clearGlobals();
+});

--- a/frontend/packages/mcp-app-sdk/test/webmcp.test.ts
+++ b/frontend/packages/mcp-app-sdk/test/webmcp.test.ts
@@ -32,24 +32,16 @@ test("fallback registry exposes registered tools and executes them", async () =>
   assert.equal(supportsNativeWebMcp(), false);
   assert.deepEqual(listRegisteredWebMcpTools().map((tool) => tool.name), ["status"]);
   assert.deepEqual(await (globalThis as any).window.__fabushiWebMcp.call("status", {}), { running: true });
-  assert.deepEqual(await callRegisteredWebMcpTool("status"), { running: true });
 
   dispose();
   assert.deepEqual(listRegisteredWebMcpTools(), []);
   clearGlobals();
 });
 
-test("native modelContext registration receives tool metadata and lifecycle signal", async () => {
+test("native modelContext registration receives lifecycle signal as register options", async () => {
   const registered: any[] = [];
-  const unregistered: string[] = [];
-  const executed: Array<{ name: string; input: Record<string, unknown> }> = [];
   installGlobals({
-    registerTool(tool: unknown) { registered.push(tool); },
-    unregisterTool(name: string) { unregistered.push(name); },
-    executeTool(name: string, input: Record<string, unknown>) {
-      executed.push({ name, input });
-      return { native: true };
-    },
+    async registerTool(tool: unknown, options: unknown) { registered.push({ tool, options }); },
   });
 
   const dispose = registerWebMcpTool({
@@ -63,17 +55,38 @@ test("native modelContext registration receives tool metadata and lifecycle sign
     execute: () => ({ ok: true }),
   });
 
+  await Promise.resolve();
   assert.equal(supportsNativeWebMcp(), true);
   assert.equal(registered.length, 1);
-  assert.equal(registered[0].name, "set_speed");
-  assert.ok(registered[0].signal instanceof AbortSignal);
-  assert.equal(registered[0].signal.aborted, false);
-  assert.deepEqual(await callRegisteredWebMcpTool("set_speed", { speed: 60 }), { native: true });
-  assert.deepEqual(executed, [{ name: "set_speed", input: { speed: 60 } }]);
+  assert.equal(registered[0].tool.name, "set_speed");
+  assert.ok(registered[0].options.signal instanceof AbortSignal);
+  assert.equal(registered[0].options.signal.aborted, false);
 
   dispose();
-  assert.equal(registered[0].signal.aborted, true);
-  assert.deepEqual(unregistered, ["set_speed"]);
+  assert.equal(registered[0].options.signal.aborted, true);
+  clearGlobals();
+});
+
+test("native discovery executes a RegisteredTool and parses its stringified result", async () => {
+  const registeredTool = {
+    name: "status",
+    description: "Read status",
+    inputSchema: "{}",
+  };
+  installGlobals({
+    registerTool() {},
+    async getTools() { return [registeredTool]; },
+    async executeTool(tool: unknown, input: unknown) {
+      assert.equal(tool, registeredTool);
+      assert.deepEqual(input, { detail: true });
+      return JSON.stringify({ running: true });
+    },
+  });
+
+  assert.deepEqual(
+    await callRegisteredWebMcpTool("status", { detail: true }),
+    { running: true },
+  );
   clearGlobals();
 });
 

--- a/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
+++ b/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
@@ -28,6 +28,7 @@ class FabushiScreenTest {
                 onQueryChange = { query = it },
                 onSearch = { searches += 1 },
                 onInstall = {},
+                onOpen = {},
                 onApprovePermissions = {},
                 onDenyPermissions = {},
             )
@@ -45,15 +46,17 @@ class FabushiScreenTest {
     }
 
     @Test
-    fun pluginCardsUseStableSemanticIdentifiers() {
+    fun pluginCardsExposeInstallAndWebMcpOpenControls() {
         var installed: MarketplacePlugin? = null
-        val plugin = MarketplacePlugin("example.plugin", "示例插件", "描述", "1.0.0")
+        var opened: MarketplacePlugin? = null
+        val plugin = MarketplacePlugin("example-plugin", "示例插件", "描述", "1.0.0")
         compose.setContent {
             FabushiScreen(
                 state = MarketplaceUiState(plugins = listOf(plugin)),
                 onQueryChange = {},
                 onSearch = {},
                 onInstall = { installed = it },
+                onOpen = { opened = it },
                 onApprovePermissions = {},
                 onDenyPermissions = {},
             )
@@ -61,6 +64,8 @@ class FabushiScreenTest {
 
         compose.onNodeWithTag(TestTags.plugin(plugin.pluginId)).assertIsDisplayed()
         compose.onNodeWithText("示例插件").assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.open(plugin.pluginId)).assertIsDisplayed().performClick()
+        assertEquals(plugin, opened)
         compose.onNodeWithTag(TestTags.install(plugin.pluginId)).assertIsDisplayed().performClick()
         assertEquals(plugin, installed)
     }
@@ -71,7 +76,7 @@ class FabushiScreenTest {
             FabushiScreen(
                 state = MarketplaceUiState(
                     permissionRequest = PermissionRequest(
-                        pluginId = "example.plugin",
+                        pluginId = "example-plugin",
                         runtime = "deepseek-js",
                         permissions = listOf("network.request"),
                     ),
@@ -79,6 +84,7 @@ class FabushiScreenTest {
                 onQueryChange = {},
                 onSearch = {},
                 onInstall = {},
+                onOpen = {},
                 onApprovePermissions = {},
                 onDenyPermissions = {},
             )

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -39,6 +39,7 @@ object TestTags {
     const val PermissionDeny = "permission-deny"
     fun plugin(id: String) = "plugin-$id"
     fun install(id: String) = "install-$id"
+    fun open(id: String) = "open-$id"
 }
 
 @Composable
@@ -47,6 +48,7 @@ fun FabushiScreen(
     onQueryChange: (String) -> Unit,
     onSearch: () -> Unit,
     onInstall: (MarketplacePlugin) -> Unit,
+    onOpen: (MarketplacePlugin) -> Unit,
     onApprovePermissions: () -> Unit,
     onDenyPermissions: () -> Unit,
 ) {
@@ -104,7 +106,7 @@ fun FabushiScreen(
                 Card(modifier = Modifier.fillMaxWidth()) {
                     Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         Text("本地插件市场", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                        Text("Android UI 使用 Jetpack Compose；插件安装、权限与运行时由共享 Mahayana Rust Host 管理。")
+                        Text("Android 主壳使用 Jetpack Compose；MiniApp 使用受控 WebMCP Surface；插件安装、权限与后台运行由共享 Mahayana Rust Host 管理。")
                         OutlinedTextField(
                             value = state.query,
                             onValueChange = onQueryChange,
@@ -147,12 +149,20 @@ fun FabushiScreen(
                         Text(plugin.displayName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                         Text(plugin.description)
                         plugin.latestVersion?.let { Text(it, style = MaterialTheme.typography.labelMedium) }
-                        Button(
-                            onClick = { onInstall(plugin) },
-                            modifier = Modifier.fillMaxWidth().testTag(TestTags.install(plugin.pluginId)),
-                            enabled = plugin.latestVersion != null && state.installingPluginId == null,
-                        ) {
-                            Text(if (state.installingPluginId == plugin.pluginId) "处理中…" else "安装 / 更新")
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                onClick = { onOpen(plugin) },
+                                modifier = Modifier.weight(1f).testTag(TestTags.open(plugin.pluginId)),
+                            ) {
+                                Text("打开 WebMCP")
+                            }
+                            Button(
+                                onClick = { onInstall(plugin) },
+                                modifier = Modifier.weight(1f).testTag(TestTags.install(plugin.pluginId)),
+                                enabled = plugin.latestVersion != null && state.installingPluginId == null,
+                            ) {
+                                Text(if (state.installingPluginId == plugin.pluginId) "处理中…" else "安装 / 更新")
+                            }
                         }
                     }
                 }

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
@@ -32,7 +32,12 @@ class MainActivity : ComponentActivity() {
                 }
                 val active = openedMiniApp
                 if (active != null) {
-                    MiniAppWebMcpSurface(plugin = active, onClose = { openedMiniApp = null })
+                    MiniAppWebMcpSurface(
+                        plugin = active,
+                        loadLocalHtml = model::loadLocalMiniAppHtml,
+                        callRuntimeToolJson = model::callRuntimeToolJson,
+                        onClose = { openedMiniApp = null },
+                    )
                 } else {
                     FabushiScreen(
                         state = state,

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
@@ -10,6 +10,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 
@@ -23,17 +26,24 @@ class MainActivity : ComponentActivity() {
             MaterialTheme {
                 val model: MarketplaceViewModel = viewModel()
                 val state by model.state.collectAsState()
+                var openedMiniApp by remember { mutableStateOf<MarketplacePlugin?>(null) }
                 LaunchedEffect(model) {
                     deepLinks.collect { uri -> model.handleDeepLink(uri) }
                 }
-                FabushiScreen(
-                    state = state,
-                    onQueryChange = model::setQuery,
-                    onSearch = model::refresh,
-                    onInstall = model::install,
-                    onApprovePermissions = model::approvePermissions,
-                    onDenyPermissions = model::denyPermissions,
-                )
+                val active = openedMiniApp
+                if (active != null) {
+                    MiniAppWebMcpSurface(plugin = active, onClose = { openedMiniApp = null })
+                } else {
+                    FabushiScreen(
+                        state = state,
+                        onQueryChange = model::setQuery,
+                        onSearch = model::refresh,
+                        onInstall = model::install,
+                        onOpen = { openedMiniApp = it },
+                        onApprovePermissions = model::approvePermissions,
+                        onDenyPermissions = model::denyPermissions,
+                    )
+                }
             }
         }
         intent?.data?.let(::enqueueDeepLink)

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MarketplaceViewModel.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MarketplaceViewModel.kt
@@ -14,11 +14,18 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 
+data class MiniAppToolContract(
+    val name: String,
+    val description: String,
+    val approval: String,
+)
+
 data class MarketplacePlugin(
     val pluginId: String,
     val displayName: String,
     val description: String,
     val latestVersion: String?,
+    val tools: List<MiniAppToolContract> = emptyList(),
 )
 
 data class PermissionRequest(
@@ -72,9 +79,6 @@ class MarketplaceViewModel(application: Application) : AndroidViewModel(applicat
                         else -> "登录授权失败"
                     },
                 )
-                // The deep link is a wake/focus hint only. The credential/session
-                // result stays in the Rust browser-login state machine and is
-                // claimed using the attempt id through the FeatureHost.
                 if (status == "completed") completeBrowserLogin(attemptId)
             }
             "agent" -> {
@@ -123,7 +127,7 @@ class MarketplaceViewModel(application: Application) : AndroidViewModel(applicat
             runCatching {
                 withContext(Dispatchers.IO) {
                     host.request(
-                        "marketplace.browse",
+                        "feature.marketplace.browse",
                         JSONObject().put("query", query.ifBlank { JSONObject.NULL }).put("platform", "android"),
                     )
                 }
@@ -135,12 +139,15 @@ class MarketplaceViewModel(application: Application) : AndroidViewModel(applicat
                             val item = plugins.optJSONObject(index) ?: continue
                             val pluginId = item.optString("pluginId")
                             if (pluginId.isBlank()) continue
+                            val commands = item.optJSONObject("source")?.optJSONArray("commands")
+                                ?: item.optJSONArray("commands")
                             add(
                                 MarketplacePlugin(
                                     pluginId = pluginId,
                                     displayName = item.optString("displayName", pluginId),
                                     description = item.optString("description", "无描述"),
                                     latestVersion = item.optString("latestVersion").takeIf(String::isNotBlank),
+                                    tools = commands.toToolContracts(),
                                 ),
                             )
                         }
@@ -174,13 +181,13 @@ class MarketplaceViewModel(application: Application) : AndroidViewModel(applicat
             runCatching {
                 withContext(Dispatchers.IO) {
                     val metadata = host.request(
-                        "marketplace.release",
+                        "feature.marketplace.release",
                         JSONObject().put("pluginId", plugin.pluginId).put("version", version),
                     )
                     val release = metadata.optJSONObject("releaseManifest")
                         ?: error("marketplace release has no releaseManifest")
                     host.request(
-                        "plugin.install",
+                        "feature.plugin.install",
                         JSONObject().put("release", release).put("platform", "android"),
                     )
                 }
@@ -280,6 +287,28 @@ class MarketplaceViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
+    suspend fun loadLocalMiniAppHtml(pluginId: String): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            host.request(
+                "feature.plugin.uiDocument",
+                JSONObject().put("pluginId", pluginId),
+            ).optString("html").takeIf { it.isNotBlank() }
+        }.getOrNull()
+    }
+
+    fun callRuntimeToolJson(pluginId: String, name: String, argumentsJson: String): String {
+        require(Regex("^[A-Za-z0-9_.-]{1,128}$").matches(name)) { "Invalid WebMCP tool name" }
+        val arguments = JSONObject(argumentsJson.ifBlank { "{}" })
+        val result = host.requestValue(
+            "runtime.call",
+            JSONObject()
+                .put("pluginId", pluginId)
+                .put("name", name)
+                .put("arguments", arguments),
+        )
+        return result.toJsonString()
+    }
+
     override fun onCleared() {
         host.close()
         super.onCleared()
@@ -292,4 +321,28 @@ private fun JSONArray?.toStringList(): List<String> = buildList {
         val value = array.optString(index).trim()
         if (value.isNotEmpty()) add(value)
     }
+}
+
+private fun JSONArray?.toToolContracts(): List<MiniAppToolContract> = buildList {
+    val array = this@toToolContracts ?: return@buildList
+    for (index in 0 until array.length()) {
+        val command = array.optJSONObject(index) ?: continue
+        val name = command.optString("tool", command.optString("name")).trim()
+        if (!Regex("^[A-Za-z0-9_.-]{1,128}$").matches(name)) continue
+        add(
+            MiniAppToolContract(
+                name = name,
+                description = command.optString("description", name).ifBlank { name },
+                approval = command.optString("approval", "none"),
+            ),
+        )
+    }
+}
+
+private fun Any?.toJsonString(): String = when (this) {
+    null, JSONObject.NULL -> "null"
+    is JSONObject, is JSONArray -> toString()
+    is Number, is Boolean -> toString()
+    is String -> JSONObject.quote(this)
+    else -> JSONObject.quote(toString())
 }

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt
@@ -1,0 +1,112 @@
+package com.ombhrum.fabushi
+
+import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+private const val WEB_MCP_ORIGIN = "fabushi.ombhrum.com"
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun MiniAppWebMcpSurface(
+    plugin: MarketplacePlugin,
+    onClose: () -> Unit,
+) {
+    val context = LocalContext.current
+    var status by remember(plugin.pluginId) { mutableStateOf("正在加载 WebMCP…") }
+    val encodedId = URLEncoder.encode(plugin.pluginId, StandardCharsets.UTF_8.toString())
+    val url = "https://fabushi.ombhrum.com/miniapps/$encodedId/"
+
+    BackHandler(onBack = onClose)
+
+    Column(modifier = Modifier.fillMaxSize().testTag("miniapp-webmcp-surface")) {
+        Row(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
+            Button(onClick = onClose, modifier = Modifier.testTag("miniapp-webmcp-close")) {
+                Text("返回")
+            }
+            Column(modifier = Modifier.padding(start = 12.dp)) {
+                Text(plugin.displayName, style = MaterialTheme.typography.titleMedium)
+                Text(status, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+
+        val webView = remember(plugin.pluginId) {
+            WebView(context).apply {
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.allowFileAccess = false
+                settings.allowContentAccess = false
+                settings.javaScriptCanOpenWindowsAutomatically = false
+                settings.setSupportMultipleWindows(false)
+                webViewClient = object : WebViewClient() {
+                    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                        val uri = request.url
+                        return uri.scheme != "https" || uri.host != WEB_MCP_ORIGIN
+                    }
+
+                    override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+                        status = "正在加载 WebMCP…"
+                    }
+
+                    override fun onPageFinished(view: WebView, url: String?) {
+                        val probe = """
+                            (() => {
+                              const report = () => {
+                                const tools = window.__fabushiWebMcp?.list?.() || [];
+                                return JSON.stringify({ ready: tools.length > 0, tools: tools.map(t => t.name) });
+                              };
+                              return report();
+                            })()
+                        """.trimIndent()
+                        view.evaluateJavascript(probe) { value ->
+                            status = if (value.contains("\\\"ready\\\":true")) {
+                                "WebMCP 已连接"
+                            } else {
+                                "WebMCP 页面已打开"
+                            }
+                        }
+                    }
+                }
+                loadUrl(url)
+            }
+        }
+
+        AndroidView(
+            factory = { webView },
+            modifier = Modifier.fillMaxSize().testTag("miniapp-webmcp-webview"),
+        )
+
+        DisposableEffect(webView) {
+            onDispose {
+                webView.stopLoading()
+                webView.loadUrl("about:blank")
+                webView.removeAllViews()
+                webView.destroy()
+            }
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt
@@ -1,7 +1,11 @@
 package com.ombhrum.fabushi
 
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -16,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,21 +30,144 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import org.json.JSONArray
+import org.json.JSONObject
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 private const val WEB_MCP_ORIGIN = "fabushi.ombhrum.com"
+private const val LOCAL_WEB_MCP_ORIGIN = "miniapp.local.fabushi.invalid"
+
+private class MiniAppNativeWebMcpBridge(
+    private val plugin: MarketplacePlugin,
+    private val context: android.content.Context,
+    private val callRuntimeToolJson: (pluginId: String, name: String, argumentsJson: String) -> String,
+) {
+    private val tools = plugin.tools.associateBy { it.name }
+
+    @JavascriptInterface
+    fun callTool(name: String, argumentsJson: String): String {
+        val tool = tools[name]
+            ?: return JSONObject().put("ok", false).put("error", "Tool is not in this MiniApp contract").toString()
+        if (tool.approval != "none" && !requestNativeApproval(tool)) {
+            return JSONObject().put("ok", false).put("error", "用户取消了 WebMCP Tool 调用").toString()
+        }
+        return runCatching {
+            val resultJson = callRuntimeToolJson(plugin.pluginId, name, argumentsJson)
+            "{\"ok\":true,\"result\":$resultJson}"
+        }.getOrElse { error ->
+            JSONObject()
+                .put("ok", false)
+                .put("error", error.message ?: "WebMCP runtime call failed")
+                .toString()
+        }
+    }
+
+    private fun requestNativeApproval(tool: MiniAppToolContract): Boolean {
+        val decided = AtomicBoolean(false)
+        val allowed = AtomicBoolean(false)
+        val latch = CountDownLatch(1)
+        Handler(Looper.getMainLooper()).post {
+            val warning = if (tool.approval == "destructive") {
+                "该操作可能产生破坏性修改。"
+            } else {
+                "该操作会修改小程序或后台状态。"
+            }
+            AlertDialog.Builder(context)
+                .setTitle("允许 WebMCP 调用 ${tool.name}？")
+                .setMessage("${tool.description}\n\n$warning")
+                .setPositiveButton("允许") { _, _ ->
+                    if (decided.compareAndSet(false, true)) {
+                        allowed.set(true)
+                        latch.countDown()
+                    }
+                }
+                .setNegativeButton("取消") { _, _ ->
+                    if (decided.compareAndSet(false, true)) latch.countDown()
+                }
+                .setOnCancelListener {
+                    if (decided.compareAndSet(false, true)) latch.countDown()
+                }
+                .show()
+        }
+        latch.await(2, TimeUnit.MINUTES)
+        return allowed.get()
+    }
+}
+
+private fun toolContractJson(plugin: MarketplacePlugin): String {
+    val rows = JSONArray()
+    for (tool in plugin.tools) {
+        rows.put(
+            JSONObject()
+                .put("name", tool.name)
+                .put("description", tool.description)
+                .put("readOnlyHint", tool.approval == "none"),
+        )
+    }
+    return rows.toString()
+}
+
+private fun injectLocalWebMcp(html: String, plugin: MarketplacePlugin): String {
+    val tools = toolContractJson(plugin)
+    val bootstrap = """
+        <script>
+        (function(){
+          const definitions=$tools;
+          const localTools=new Map();
+          const controllers=[];
+          function publicTool(tool){const copy={...tool};delete copy.execute;return copy;}
+          function nativeCall(name,input){
+            const raw=window.FabushiWebMcpNative.callTool(name,JSON.stringify(input||{}));
+            const payload=JSON.parse(raw);
+            if(!payload.ok)throw new Error(payload.error||'WebMCP runtime call failed');
+            return payload.result;
+          }
+          function register(item){
+            const tool={name:item.name,description:item.description||item.name,inputSchema:{type:'object',properties:{}},annotations:{readOnlyHint:item.readOnlyHint===true},execute:(input)=>nativeCall(item.name,input)};
+            localTools.set(tool.name,tool);
+            if(document.modelContext&&typeof document.modelContext.registerTool==='function'){
+              const controller=new AbortController();controllers.push(controller);
+              Promise.resolve(document.modelContext.registerTool(tool,{signal:controller.signal})).catch(()=>{});
+            }
+          }
+          for(const item of definitions)register(item);
+          Object.defineProperty(window,'__fabushiWebMcp',{configurable:true,value:{version:1,list:()=>Array.from(localTools.values()).map(publicTool),call:async(name,input={})=>{const tool=localTools.get(name);if(!tool)throw new Error('Unknown WebMCP tool: '+name);return tool.execute(input);}}});
+          window.addEventListener('pagehide',()=>{for(const controller of controllers)controller.abort();},{once:true});
+          window.dispatchEvent(new CustomEvent('fabushi:webmcp-ready',{detail:{pluginId:${JSONObject.quote(plugin.pluginId)},tools:definitions.map(t=>t.name)}}));
+        })();
+        </script>
+    """.trimIndent()
+    return if (html.contains("</head>", ignoreCase = true)) {
+        html.replace(Regex("</head>", RegexOption.IGNORE_CASE), "$bootstrap</head>")
+    } else {
+        "$bootstrap$html"
+    }
+}
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun MiniAppWebMcpSurface(
     plugin: MarketplacePlugin,
+    loadLocalHtml: suspend (pluginId: String) -> String?,
+    callRuntimeToolJson: (pluginId: String, name: String, argumentsJson: String) -> String,
     onClose: () -> Unit,
 ) {
     val context = LocalContext.current
-    var status by remember(plugin.pluginId) { mutableStateOf("正在加载 WebMCP…") }
+    var status by remember(plugin.pluginId) { mutableStateOf("正在解析本地 WebMCP…") }
+    var localHtml by remember(plugin.pluginId) { mutableStateOf<String?>(null) }
+    var sourceResolved by remember(plugin.pluginId) { mutableStateOf(false) }
     val encodedId = URLEncoder.encode(plugin.pluginId, StandardCharsets.UTF_8.toString())
-    val url = "https://fabushi.ombhrum.com/miniapps/$encodedId/"
+    val hostedUrl = "https://fabushi.ombhrum.com/miniapps/$encodedId/"
+
+    LaunchedEffect(plugin.pluginId) {
+        localHtml = loadLocalHtml(plugin.pluginId)
+        sourceResolved = true
+        status = if (localHtml != null) "正在加载本地 WebMCP…" else "正在加载 Hosted WebMCP…"
+    }
 
     BackHandler(onBack = onClose)
 
@@ -62,10 +190,14 @@ fun MiniAppWebMcpSurface(
                 settings.allowContentAccess = false
                 settings.javaScriptCanOpenWindowsAutomatically = false
                 settings.setSupportMultipleWindows(false)
+                addJavascriptInterface(
+                    MiniAppNativeWebMcpBridge(plugin, context, callRuntimeToolJson),
+                    "FabushiWebMcpNative",
+                )
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                         val uri = request.url
-                        return uri.scheme != "https" || uri.host != WEB_MCP_ORIGIN
+                        return uri.scheme != "https" || uri.host !in setOf(WEB_MCP_ORIGIN, LOCAL_WEB_MCP_ORIGIN)
                     }
 
                     override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
@@ -75,34 +207,50 @@ fun MiniAppWebMcpSurface(
                     override fun onPageFinished(view: WebView, url: String?) {
                         val probe = """
                             (() => {
-                              const report = () => {
-                                const tools = window.__fabushiWebMcp?.list?.() || [];
-                                return JSON.stringify({ ready: tools.length > 0, tools: tools.map(t => t.name) });
-                              };
-                              return report();
+                              const tools = window.__fabushiWebMcp?.list?.() || [];
+                              return JSON.stringify({ ready: tools.length > 0, tools: tools.map(t => t.name) });
                             })()
                         """.trimIndent()
                         view.evaluateJavascript(probe) { value ->
                             status = if (value.contains("\\\"ready\\\":true")) {
-                                "WebMCP 已连接"
+                                if (url?.contains(LOCAL_WEB_MCP_ORIGIN) == true) "本地 WebMCP 已连接" else "WebMCP 已连接"
                             } else {
                                 "WebMCP 页面已打开"
                             }
                         }
                     }
                 }
-                loadUrl(url)
             }
         }
 
         AndroidView(
             factory = { webView },
+            update = { view ->
+                if (!sourceResolved) return@AndroidView
+                val local = localHtml
+                val desiredTag = if (local != null) "local:${plugin.pluginId}" else "hosted:${plugin.pluginId}"
+                if (view.tag == desiredTag) return@AndroidView
+                view.tag = desiredTag
+                if (local != null) {
+                    val baseUrl = "https://$LOCAL_WEB_MCP_ORIGIN/miniapps/$encodedId/"
+                    view.loadDataWithBaseURL(
+                        baseUrl,
+                        injectLocalWebMcp(local, plugin),
+                        "text/html",
+                        "utf-8",
+                        null,
+                    )
+                } else {
+                    view.loadUrl(hostedUrl)
+                }
+            },
             modifier = Modifier.fillMaxSize().testTag("miniapp-webmcp-webview"),
         )
 
         DisposableEffect(webView) {
             onDispose {
                 webView.stopLoading()
+                webView.removeJavascriptInterface("FabushiWebMcpNative")
                 webView.loadUrl("about:blank")
                 webView.removeAllViews()
                 webView.destroy()

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt
@@ -44,12 +44,19 @@ private const val LOCAL_WEB_MCP_ORIGIN = "miniapp.local.fabushi.invalid"
 private class MiniAppNativeWebMcpBridge(
     private val plugin: MarketplacePlugin,
     private val context: android.content.Context,
+    private val localDocumentActive: () -> Boolean,
     private val callRuntimeToolJson: (pluginId: String, name: String, argumentsJson: String) -> String,
 ) {
     private val tools = plugin.tools.associateBy { it.name }
 
     @JavascriptInterface
     fun callTool(name: String, argumentsJson: String): String {
+        if (!localDocumentActive()) {
+            return JSONObject()
+                .put("ok", false)
+                .put("error", "Native WebMCP bridge is available only to the local MiniApp document")
+                .toString()
+        }
         val tool = tools[name]
             ?: return JSONObject().put("ok", false).put("error", "Tool is not in this MiniApp contract").toString()
         if (tool.approval != "none" && !requestNativeApproval(tool)) {
@@ -160,6 +167,7 @@ fun MiniAppWebMcpSurface(
     var status by remember(plugin.pluginId) { mutableStateOf("正在解析本地 WebMCP…") }
     var localHtml by remember(plugin.pluginId) { mutableStateOf<String?>(null) }
     var sourceResolved by remember(plugin.pluginId) { mutableStateOf(false) }
+    val localDocumentActive = remember(plugin.pluginId) { AtomicBoolean(false) }
     val encodedId = URLEncoder.encode(plugin.pluginId, StandardCharsets.UTF_8.toString())
     val hostedUrl = "https://fabushi.ombhrum.com/miniapps/$encodedId/"
 
@@ -191,7 +199,12 @@ fun MiniAppWebMcpSurface(
                 settings.javaScriptCanOpenWindowsAutomatically = false
                 settings.setSupportMultipleWindows(false)
                 addJavascriptInterface(
-                    MiniAppNativeWebMcpBridge(plugin, context, callRuntimeToolJson),
+                    MiniAppNativeWebMcpBridge(
+                        plugin = plugin,
+                        context = context,
+                        localDocumentActive = localDocumentActive::get,
+                        callRuntimeToolJson = callRuntimeToolJson,
+                    ),
                     "FabushiWebMcpNative",
                 )
                 webViewClient = object : WebViewClient() {
@@ -201,6 +214,7 @@ fun MiniAppWebMcpSurface(
                     }
 
                     override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+                        localDocumentActive.set(url?.startsWith("https://$LOCAL_WEB_MCP_ORIGIN/") == true)
                         status = "正在加载 WebMCP…"
                     }
 
@@ -232,6 +246,7 @@ fun MiniAppWebMcpSurface(
                 if (view.tag == desiredTag) return@AndroidView
                 view.tag = desiredTag
                 if (local != null) {
+                    localDocumentActive.set(true)
                     val baseUrl = "https://$LOCAL_WEB_MCP_ORIGIN/miniapps/$encodedId/"
                     view.loadDataWithBaseURL(
                         baseUrl,
@@ -241,6 +256,7 @@ fun MiniAppWebMcpSurface(
                         null,
                     )
                 } else {
+                    localDocumentActive.set(false)
                     view.loadUrl(hostedUrl)
                 }
             },
@@ -249,6 +265,7 @@ fun MiniAppWebMcpSurface(
 
         DisposableEffect(webView) {
             onDispose {
+                localDocumentActive.set(false)
                 webView.stopLoading()
                 webView.removeJavascriptInterface("FabushiWebMcpNative")
                 webView.loadUrl("about:blank")

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @Bindable var model: MarketplaceModel
+    @State private var openedMiniApp: MarketplacePlugin?
 
     var body: some View {
         NavigationStack {
@@ -25,7 +26,7 @@ struct ContentView: View {
                 }
 
                 Section("本地插件市场") {
-                    Text("iOS UI 使用 SwiftUI；插件安装、权限与运行时由共享 Mahayana Rust Host 管理。")
+                    Text("iOS 主壳使用 SwiftUI；MiniApp 使用受控 WebMCP Surface；插件安装、权限与后台运行由共享 Mahayana Rust Host 管理。")
                     TextField("搜索插件", text: $model.query)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
@@ -66,17 +67,27 @@ struct ContentView: View {
                             .accessibilityElement(children: .combine)
                             .accessibilityIdentifier("plugin-\(plugin.pluginId)")
 
-                            Button(model.installingPluginId == plugin.pluginId ? "处理中…" : "安装 / 更新") {
-                                Task { await model.install(plugin) }
+                            HStack(spacing: 8) {
+                                Button("打开 WebMCP") {
+                                    openedMiniApp = plugin
+                                }
+                                .accessibilityIdentifier("open-\(plugin.pluginId)")
+
+                                Button(model.installingPluginId == plugin.pluginId ? "处理中…" : "安装 / 更新") {
+                                    Task { await model.install(plugin) }
+                                }
+                                .disabled(plugin.latestVersion == nil || model.installingPluginId != nil)
+                                .accessibilityIdentifier("install-\(plugin.pluginId)")
                             }
-                            .disabled(plugin.latestVersion == nil || model.installingPluginId != nil)
-                            .accessibilityIdentifier("install-\(plugin.pluginId)")
                         }
                     }
                 }
             }
             .navigationTitle("法布施")
             .refreshable { await model.refresh() }
+            .fullScreenCover(item: $openedMiniApp) { plugin in
+                MiniAppWebMcpSurface(plugin: plugin)
+            }
             .alert("插件权限", isPresented: Binding(
                 get: { model.permissionRequest != nil },
                 set: { if !$0 { model.denyPermissions() } }

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -86,7 +86,7 @@ struct ContentView: View {
             .navigationTitle("法布施")
             .refreshable { await model.refresh() }
             .fullScreenCover(item: $openedMiniApp) { plugin in
-                MiniAppWebMcpSurface(plugin: plugin)
+                MiniAppWebMcpSurface(plugin: plugin, model: model)
             }
             .alert("插件权限", isPresented: Binding(
                 get: { model.permissionRequest != nil },

--- a/mobile/ios/Fabushi/MarketplaceModel.swift
+++ b/mobile/ios/Fabushi/MarketplaceModel.swift
@@ -1,11 +1,18 @@
 import Foundation
 import Observation
 
-struct MarketplacePlugin: Identifiable, Equatable {
+struct MiniAppToolContract: Equatable, Sendable {
+    let name: String
+    let description: String
+    let approval: String
+}
+
+struct MarketplacePlugin: Identifiable, Equatable, Sendable {
     let pluginId: String
     let displayName: String
     let description: String
     let latestVersion: String?
+    let tools: [MiniAppToolContract]
     var id: String { pluginId }
 }
 
@@ -197,18 +204,23 @@ final class MarketplaceModel {
         defer { loading = false }
         do {
             let result = try await host.request(
-                method: "marketplace.browse",
+                method: "feature.marketplace.browse",
                 params: ["query": query.isEmpty ? NSNull() : query, "platform": "ios"]
             )
             let object = result.value as? [String: Any]
             let rows = object?["plugins"] as? [[String: Any]] ?? []
             plugins = rows.compactMap { item in
                 guard let id = item["pluginId"] as? String, !id.isEmpty else { return nil }
+                let source = item["source"] as? [String: Any]
+                let commands = source?["commands"] as? [[String: Any]]
+                    ?? item["commands"] as? [[String: Any]]
+                    ?? []
                 return MarketplacePlugin(
                     pluginId: id,
                     displayName: item["displayName"] as? String ?? id,
                     description: item["description"] as? String ?? "无描述",
-                    latestVersion: item["latestVersion"] as? String
+                    latestVersion: item["latestVersion"] as? String,
+                    tools: commands.compactMap(Self.toolContract(from:))
                 )
             }
             message = "原生 iOS · Rust Host 已连接"
@@ -226,14 +238,14 @@ final class MarketplaceModel {
         message = "正在安装 \(plugin.pluginId)@\(version)…"
         do {
             let metadata = try await host.request(
-                method: "marketplace.release",
+                method: "feature.marketplace.release",
                 params: ["pluginId": plugin.pluginId, "version": version]
             )
             guard let release = (metadata.value as? [String: Any])?["releaseManifest"] as? [String: Any] else {
                 throw MahayanaHost.HostError.invalidResponse
             }
             let installed = try await host.request(
-                method: "plugin.install",
+                method: "feature.plugin.install",
                 params: ["release": release, "platform": "ios"]
             )
             guard let object = installed.value as? [String: Any] else {
@@ -309,5 +321,48 @@ final class MarketplaceModel {
             message = "\(pluginId) 已安装但启动失败：\(error.localizedDescription)"
         }
         installingPluginId = nil
+    }
+
+    func loadLocalMiniAppHtml(pluginId: String) async -> String? {
+        do {
+            let result = try await host.request(
+                method: "feature.plugin.uiDocument",
+                params: ["pluginId": pluginId]
+            )
+            let html = (result.value as? [String: Any])?["html"] as? String
+            return html?.isEmpty == false ? html : nil
+        } catch {
+            return nil
+        }
+    }
+
+    func callRuntimeTool(pluginId: String, name: String, arguments: [String: Any]) async throws -> Any {
+        guard name.range(of: #"^[A-Za-z0-9_.-]{1,128}$"#, options: .regularExpression) != nil else {
+            throw MahayanaHost.HostError.requestFailed("Invalid WebMCP tool name")
+        }
+        let result = try await host.request(
+            method: "runtime.call",
+            params: [
+                "pluginId": pluginId,
+                "name": name,
+                "arguments": arguments,
+            ]
+        )
+        return result.value
+    }
+
+    private static func toolContract(from command: [String: Any]) -> MiniAppToolContract? {
+        let name = ((command["tool"] as? String) ?? (command["name"] as? String) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty,
+              name.range(of: #"^[A-Za-z0-9_.-]{1,128}$"#, options: .regularExpression) != nil
+        else { return nil }
+        let description = ((command["description"] as? String) ?? name)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return MiniAppToolContract(
+            name: name,
+            description: description.isEmpty ? name : description,
+            approval: (command["approval"] as? String) ?? "none"
+        )
     }
 }

--- a/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
+++ b/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
@@ -159,12 +159,13 @@ private struct MiniAppWebView: UIViewRepresentable {
 
         func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
             guard message.name == webMcpMessageHandler,
+                  let webView,
+                  webView.url?.host == localWebMcpOriginHost,
                   let body = message.body as? [String: Any],
                   let requestId = body["requestId"] as? String,
                   let name = body["name"] as? String,
                   let tool = toolByName[name],
-                  let input = body["input"] as? [String: Any],
-                  let webView
+                  let input = body["input"] as? [String: Any]
             else { return }
 
             Task { @MainActor in

--- a/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
+++ b/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
@@ -1,13 +1,19 @@
 import SwiftUI
+import UIKit
 import WebKit
 
 private let webMcpOriginHost = "fabushi.ombhrum.com"
+private let localWebMcpOriginHost = "miniapp.local.fabushi.invalid"
+private let webMcpMessageHandler = "fabushiWebMcp"
 
 struct MiniAppWebMcpSurface: View {
     let plugin: MarketplacePlugin
+    let model: MarketplaceModel
 
     @Environment(\.dismiss) private var dismiss
-    @State private var status = "正在加载 WebMCP…"
+    @State private var status = "正在解析本地 WebMCP…"
+    @State private var localHtml: String?
+    @State private var sourceResolved = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,54 +30,92 @@ struct MiniAppWebMcpSurface: View {
             .padding(12)
 
             MiniAppWebView(
-                pluginId: plugin.pluginId,
+                plugin: plugin,
+                model: model,
+                localHtml: localHtml,
+                sourceResolved: sourceResolved,
                 status: $status
             )
             .accessibilityIdentifier("miniapp-webmcp-webview")
         }
         .accessibilityIdentifier("miniapp-webmcp-surface")
+        .task(id: plugin.pluginId) {
+            localHtml = await model.loadLocalMiniAppHtml(pluginId: plugin.pluginId)
+            sourceResolved = true
+            status = localHtml == nil ? "正在加载 Hosted WebMCP…" : "正在加载本地 WebMCP…"
+        }
     }
 }
 
 private struct MiniAppWebView: UIViewRepresentable {
-    let pluginId: String
+    let plugin: MarketplacePlugin
+    let model: MarketplaceModel
+    let localHtml: String?
+    let sourceResolved: Bool
     @Binding var status: String
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(status: $status)
+        Coordinator(plugin: plugin, model: model, status: $status)
     }
 
     func makeUIView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .default()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
+        configuration.userContentController.add(context.coordinator, name: webMcpMessageHandler)
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = false
         webView.isInspectable = false
-
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = webMcpOriginHost
-        components.path = "/miniapps/\(pluginId)/"
-        guard let url = components.url else { return webView }
-        webView.load(URLRequest(url: url))
+        context.coordinator.webView = webView
         return webView
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {}
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard sourceResolved else { return }
+        if let localHtml {
+            let key = "local:\(plugin.pluginId)"
+            guard context.coordinator.loadedSourceKey != key else { return }
+            context.coordinator.loadedSourceKey = key
+            let baseURL = URL(string: "https://\(localWebMcpOriginHost)/miniapps/\(plugin.pluginId)/")
+            webView.loadHTMLString(injectLocalWebMcp(localHtml, plugin: plugin), baseURL: baseURL)
+            return
+        }
+
+        let key = "hosted:\(plugin.pluginId)"
+        guard context.coordinator.loadedSourceKey != key else { return }
+        context.coordinator.loadedSourceKey = key
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = webMcpOriginHost
+        components.path = "/miniapps/\(plugin.pluginId)/"
+        if let url = components.url {
+            webView.load(URLRequest(url: url))
+        }
+    }
 
     static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
         webView.stopLoading()
         webView.navigationDelegate = nil
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: webMcpMessageHandler)
         webView.loadHTMLString("", baseURL: nil)
+        coordinator.webView = nil
     }
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    @MainActor
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        let plugin: MarketplacePlugin
+        let model: MarketplaceModel
         @Binding private var status: String
+        weak var webView: WKWebView?
+        var loadedSourceKey: String?
+        private let toolByName: [String: MiniAppToolContract]
 
-        init(status: Binding<String>) {
+        init(plugin: MarketplacePlugin, model: MarketplaceModel, status: Binding<String>) {
+            self.plugin = plugin
+            self.model = model
+            self.toolByName = Dictionary(uniqueKeysWithValues: plugin.tools.map { ($0.name, $0) })
             _status = status
         }
 
@@ -86,12 +130,15 @@ private struct MiniAppWebView: UIViewRepresentable {
               return JSON.stringify({ ready: tools.length > 0, tools: tools.map((tool) => tool.name) });
             })()
             """
-            webView.evaluateJavaScript(probe) { [weak self] value, _ in
+            webView.evaluateJavaScript(probe) { [weak self, weak webView] value, _ in
                 guard let self else { return }
                 let result = value as? String ?? ""
-                self.status = result.contains("\"ready\":true")
-                    ? "WebMCP 已连接"
-                    : "WebMCP 页面已打开"
+                let local = webView?.url?.host == localWebMcpOriginHost
+                if result.contains("\"ready\":true") {
+                    self.status = local ? "本地 WebMCP 已连接" : "WebMCP 已连接"
+                } else {
+                    self.status = "WebMCP 页面已打开"
+                }
             }
         }
 
@@ -102,12 +149,129 @@ private struct MiniAppWebView: UIViewRepresentable {
         ) {
             guard let url = navigationAction.request.url,
                   url.scheme == "https",
-                  url.host == webMcpOriginHost
+                  [webMcpOriginHost, localWebMcpOriginHost].contains(url.host ?? "")
             else {
                 decisionHandler(.cancel)
                 return
             }
             decisionHandler(.allow)
         }
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard message.name == webMcpMessageHandler,
+                  let body = message.body as? [String: Any],
+                  let requestId = body["requestId"] as? String,
+                  let name = body["name"] as? String,
+                  let tool = toolByName[name],
+                  let input = body["input"] as? [String: Any],
+                  let webView
+            else { return }
+
+            Task { @MainActor in
+                do {
+                    if tool.approval != "none" {
+                        guard await requestApproval(tool) else {
+                            resolve(webView: webView, requestId: requestId, payload: [
+                                "ok": false,
+                                "error": "用户取消了 WebMCP Tool 调用",
+                            ])
+                            return
+                        }
+                    }
+                    let result = try await model.callRuntimeTool(
+                        pluginId: plugin.pluginId,
+                        name: name,
+                        arguments: input
+                    )
+                    resolve(webView: webView, requestId: requestId, payload: ["ok": true, "result": result])
+                } catch {
+                    resolve(webView: webView, requestId: requestId, payload: [
+                        "ok": false,
+                        "error": error.localizedDescription,
+                    ])
+                }
+            }
+        }
+
+        private func requestApproval(_ tool: MiniAppToolContract) async -> Bool {
+            guard let presenter = topViewController() else { return false }
+            let warning = tool.approval == "destructive"
+                ? "该操作可能产生破坏性修改。"
+                : "该操作会修改小程序或后台状态。"
+            return await withCheckedContinuation { continuation in
+                let alert = UIAlertController(
+                    title: "允许 WebMCP 调用 \(tool.name)？",
+                    message: "\(tool.description)\n\n\(warning)",
+                    preferredStyle: .alert
+                )
+                alert.addAction(UIAlertAction(title: "取消", style: .cancel) { _ in
+                    continuation.resume(returning: false)
+                })
+                alert.addAction(UIAlertAction(title: "允许", style: .default) { _ in
+                    continuation.resume(returning: true)
+                })
+                presenter.present(alert, animated: true)
+            }
+        }
+
+        private func topViewController() -> UIViewController? {
+            let scene = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first { $0.activationState == .foregroundActive }
+            var controller = scene?.windows.first(where: \ .isKeyWindow)?.rootViewController
+            while let presented = controller?.presentedViewController {
+                controller = presented
+            }
+            return controller
+        }
+
+        private func resolve(webView: WKWebView, requestId: String, payload: [String: Any]) {
+            guard JSONSerialization.isValidJSONObject(payload),
+                  let data = try? JSONSerialization.data(withJSONObject: payload),
+                  let json = String(data: data, encoding: .utf8),
+                  let requestData = try? JSONEncoder().encode(requestId),
+                  let requestJson = String(data: requestData, encoding: .utf8)
+            else { return }
+            webView.evaluateJavaScript("window.__fabushiNativeResolve?.(\(requestJson),\(json));")
+        }
     }
+}
+
+private func injectLocalWebMcp(_ html: String, plugin: MarketplacePlugin) -> String {
+    let definitions = plugin.tools.map { tool in
+        [
+            "name": tool.name,
+            "description": tool.description,
+            "readOnlyHint": tool.approval == "none",
+        ] as [String: Any]
+    }
+    let data = (try? JSONSerialization.data(withJSONObject: definitions)) ?? Data("[]".utf8)
+    let toolsJson = String(data: data, encoding: .utf8) ?? "[]"
+    let bootstrap = """
+    <script>
+    (function(){
+      const definitions=\(toolsJson);
+      const localTools=new Map();const controllers=[];const pending=new Map();let sequence=0;
+      window.__fabushiNativeResolve=(requestId,payload)=>{const task=pending.get(requestId);if(!task)return;pending.delete(requestId);if(payload&&payload.ok)task.resolve(payload.result);else task.reject(new Error(payload?.error||'WebMCP runtime call failed'));};
+      function callNative(name,input){return new Promise((resolve,reject)=>{const requestId='webmcp-'+Date.now()+'-'+(++sequence);pending.set(requestId,{resolve,reject});window.webkit.messageHandlers.\(webMcpMessageHandler).postMessage({requestId,name,input:input||{}});});}
+      function publicTool(tool){const copy={...tool};delete copy.execute;return copy;}
+      function register(item){const tool={name:item.name,description:item.description||item.name,inputSchema:{type:'object',properties:{}},annotations:{readOnlyHint:item.readOnlyHint===true},execute:(input)=>callNative(item.name,input)};localTools.set(tool.name,tool);if(document.modelContext&&typeof document.modelContext.registerTool==='function'){const controller=new AbortController();controllers.push(controller);Promise.resolve(document.modelContext.registerTool(tool,{signal:controller.signal})).catch(()=>{});}}
+      for(const item of definitions)register(item);
+      Object.defineProperty(window,'__fabushiWebMcp',{configurable:true,value:{version:1,list:()=>Array.from(localTools.values()).map(publicTool),call:async(name,input={})=>{const tool=localTools.get(name);if(!tool)throw new Error('Unknown WebMCP tool: '+name);return tool.execute(input);}}});
+      window.addEventListener('pagehide',()=>{for(const controller of controllers)controller.abort();pending.clear();},{once:true});
+      window.dispatchEvent(new CustomEvent('fabushi:webmcp-ready',{detail:{pluginId:\(jsonString(plugin.pluginId)),tools:definitions.map(t=>t.name)}}));
+    })();
+    </script>
+    """
+    if let range = html.range(of: "</head>", options: .caseInsensitive) {
+        var result = html
+        result.insert(contentsOf: bootstrap, at: range.lowerBound)
+        return result
+    }
+    return bootstrap + html
+}
+
+private func jsonString(_ value: String) -> String {
+    guard let data = try? JSONEncoder().encode(value) else { return "\"\"" }
+    return String(data: data, encoding: .utf8) ?? "\"\""
 }

--- a/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
+++ b/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
@@ -218,7 +218,7 @@ private struct MiniAppWebView: UIViewRepresentable {
             let scene = UIApplication.shared.connectedScenes
                 .compactMap { $0 as? UIWindowScene }
                 .first { $0.activationState == .foregroundActive }
-            var controller = scene?.windows.first(where: \ .isKeyWindow)?.rootViewController
+            var controller = scene?.windows.first(where: \.isKeyWindow)?.rootViewController
             while let presented = controller?.presentedViewController {
                 controller = presented
             }

--- a/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
+++ b/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import WebKit
+
+private let webMcpOriginHost = "fabushi.ombhrum.com"
+
+struct MiniAppWebMcpSurface: View {
+    let plugin: MarketplacePlugin
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var status = "正在加载 WebMCP…"
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Button("返回") { dismiss() }
+                    .accessibilityIdentifier("miniapp-webmcp-close")
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(plugin.displayName).font(.headline)
+                    Text(status).font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(12)
+
+            MiniAppWebView(
+                pluginId: plugin.pluginId,
+                status: $status
+            )
+            .accessibilityIdentifier("miniapp-webmcp-webview")
+        }
+        .accessibilityIdentifier("miniapp-webmcp-surface")
+    }
+}
+
+private struct MiniAppWebView: UIViewRepresentable {
+    let pluginId: String
+    @Binding var status: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(status: $status)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .default()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.allowsBackForwardNavigationGestures = false
+        webView.isInspectable = false
+
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = webMcpOriginHost
+        components.path = "/miniapps/\(pluginId)/"
+        guard let url = components.url else { return webView }
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {}
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        webView.loadHTMLString("", baseURL: nil)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        @Binding private var status: String
+
+        init(status: Binding<String>) {
+            _status = status
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation?) {
+            status = "正在加载 WebMCP…"
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+            let probe = """
+            (() => {
+              const tools = window.__fabushiWebMcp?.list?.() || [];
+              return JSON.stringify({ ready: tools.length > 0, tools: tools.map((tool) => tool.name) });
+            })()
+            """
+            webView.evaluateJavaScript(probe) { [weak self] value, _ in
+                guard let self else { return }
+                let result = value as? String ?? ""
+                self.status = result.contains("\"ready\":true")
+                    ? "WebMCP 已连接"
+                    : "WebMCP 页面已打开"
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard let url = navigationAction.request.url,
+                  url.scheme == "https",
+                  url.host == webMcpOriginHost
+            else {
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+    }
+}

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -45,4 +45,23 @@ final class FabushiUITests: XCTestCase {
         XCTAssertTrue(submit.exists)
         submit.tap()
     }
+
+    @MainActor
+    func testMiniAppOpensAndClosesDedicatedWebMcpSurface() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let open = app.buttons["open-global-dharma"]
+        XCTAssertTrue(open.waitForExistence(timeout: 15))
+        open.tap()
+
+        let surface = app.descendants(matching: .any)["miniapp-webmcp-surface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["miniapp-webmcp-webview"].exists)
+
+        let close = app.buttons["miniapp-webmcp-close"]
+        XCTAssertTrue(close.exists)
+        close.tap()
+        XCTAssertTrue(surface.waitForNonExistence(timeout: 10))
+    }
 }

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 1.0.2
-        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 1.0.4
+        CURRENT_PROJECT_VERSION: 2
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'
     info:

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {

--- a/projects/telegram-fabushi-integration/PROJECT.yaml
+++ b/projects/telegram-fabushi-integration/PROJECT.yaml
@@ -4,7 +4,7 @@ legacy_project_ids:
   - FABUSHI-TELEGRAM-FUSION
 name: Fabushi Telegram 全量融合
 slug: telegram-fabushi-integration
-version: v1.3
+version: v1.4
 baseline_date: 2026-08-22
 status: IMPLEMENTATION_ACTIVE
 current_stage: M3
@@ -20,6 +20,8 @@ architecture:
   protocol_version: 2
   local_first: true
   ai_native: true
+  miniapp_foreground_agent_interface: WebMCP
+  miniapp_backend_runtime: Mahayana Rust Host
   telegram_api_dependency: false
 status_model:
   - NOT_STARTED
@@ -32,6 +34,9 @@ active_work:
   - task: M3-DESKTOP-001
     branch: feat/telegram-m3-desktop-ux
     state: IN_PROGRESS
+  - task: M8-WEBMCP-001
+    branch: feat/tfi-webmcp-miniapp-runtime
+    state: TESTING
   - task: TFI-GOV-002
     state: IN_PROGRESS
 completed_stage_evidence:

--- a/projects/telegram-fabushi-integration/decisions/ADR-0010-webmcp-foreground-rust-background.md
+++ b/projects/telegram-fabushi-integration/decisions/ADR-0010-webmcp-foreground-rust-background.md
@@ -1,0 +1,42 @@
+# ADR-0010 — WebMCP 前台控制面 + Rust 后台执行面
+
+- **状态**：ACCEPTED
+- **日期**：2026-08-27
+- **项目**：FAB-P0001 / TFI
+- **任务**：M8-WEBMCP-001
+
+## 背景
+
+Fabushi 既有 MiniApp 同时存在 Hosted MCP、MCP Apps/AppBridge、本地 JS Runtime、Rust Host、CLI 与 Bot 命令。历史 Local Web MCP 方案使用 Web Runtime/Worker + MessagePort 暴露 Tool；这可以工作，但要求 Fabushi 自行维护页面 Tool discovery、transport、lifecycle 和状态同步。
+
+WebMCP 将当前 Document 的 Agent Tool 注册标准化。与此同时，全球法布施等应用的长任务、队列、数据库、系统能力和崩溃恢复仍必须由 Rust/Native Runtime 持有，不能依赖网页生命周期。
+
+## 决策
+
+1. 所有 MiniApp 的当前页面 Agent 接口统一为 WebMCP。
+2. Tool catalog/Tool schema/annotations 是唯一事实源；WebMCP、Slash Commands、Mahayana Host/CLI/Bot 仅为投影/适配器，不复制业务实现。
+3. 打开的 MiniApp 优先通过 WebMCP 执行当前页面/应用 Tool；页面关闭时，后台与持久任务继续通过 Mahayana Host -> Rust/Native executor 操作同一业务能力。
+4. Rust/Native Runtime 继续拥有 Job、queue、database、system permission、recovery、background execution。
+5. 页面 WebMCP Tool 可以薄转发到 Rust/Native Bridge、现有 MCP `tools/call` 或批准的 Remote MCP；执行位置由 Tool/Runtime Profile 决定。
+6. WebMCP 未原生提供时使用 `@fabushi/mcp-app-sdk` 的兼容 registry/host bridge；检测到标准 `document.modelContext` 时优先标准 API。
+7. 移动端主 UI 继续 SwiftUI/Compose；MiniApp surface 可以使用受控 WKWebView/WebView，但不得恢复 WebView 作为整个 App Shell。
+8. 非 read-only、destructive、open-world Tool 必须继续通过现有审批/权限层。
+9. 新 MiniApp marketplace/generation 验收必须包含 WebMCP discovery、call、teardown 和后台连续性测试。
+
+## 开源优先证据
+
+- Web Machine Learning Community Group WebMCP specification / repository：采用标准 `Document.modelContext` Tool registration 模型，不复制第三方实现代码。
+- OpenAI WebMCP/Site Tools 公开实现方向：验证“当前已打开网页 + 当前登录/页面状态 + page-scoped tools”的产品模型。
+- Model Context Protocol / MCP Apps：继续作为后台/Host、远程、本地 Runtime 以及嵌入 UI 的协议基础，不与 WebMCP 二选一。
+
+本次实现仅适配公开标准接口与现有 Fabushi Tool contract，不引入需要额外分发的第三方 WebMCP 代码，因此没有新增代码许可证传播义务。
+
+## 后果
+
+优点：前台 Agent 路径更短；当前页面状态无需同步到独立 Worker；所有平台可逐步采用同一 WebMCP API；Rust 后台能力不受页面关闭影响。
+
+代价：在系统 WebView 尚未原生支持 WebMCP 的平台，需要 Fabushi-compatible bridge/polyfill；过渡期仍需保留现有 MCP/Host executor。
+
+## 回滚
+
+WebMCP adapter 是执行入口适配层。可禁用/移除 adapter 并继续使用既有 MCP/Host executor；不得删除 Rust 后台数据或 Job 状态作为回滚手段。

--- a/projects/telegram-fabushi-integration/evidence/M8-WEBMCP-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M8-WEBMCP-001/README.md
@@ -1,0 +1,41 @@
+# M8-WEBMCP-001 Evidence — MiniApp WebMCP Runtime
+
+Status: **IN_PROGRESS — PR #2169 pre-merge verification**
+
+## Implementation evidence
+
+- WebMCP SDK adapter: `frontend/packages/mcp-app-sdk/src/webmcp.ts`
+- WebMCP SDK contract tests: `frontend/packages/mcp-app-sdk/test/webmcp.test.ts`
+- Hosted MiniApp projection: `frontend/apps/web/src/app/miniapps/[id]/WebMcpMiniAppAdapter.tsx`
+- Hosted MiniApp route integration: `frontend/apps/web/src/app/miniapps/[id]/page.tsx`
+- Marketplace/WebMCP admission policy: `ai-backend/src/miniapp_webmcp_policy.js`
+- Admission tests: `ai-backend/test/miniapp_webmcp_policy.test.js`
+- Desktop installed MiniApp bridge: `desktop/src/miniapp-webmcp-host.ts`
+- Rust local runtime call: `third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs` (`runtime.call`)
+- Android local-first WebMCP surface: `mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt`
+- iOS local-first WebMCP surface: `mobile/ios/Fabushi/MiniAppWebMcpSurface.swift`
+- Cross-platform version baseline: `app-version.json` = 1.0.4, build/version codes = 2; desktop/mobile package metadata and iOS project metadata aligned.
+
+## Open-source-first / standards evidence
+
+- Web Machine Learning Community Group WebMCP draft and canonical `webmachinelearning/webmcp` repository were inspected before finalizing the adapter.
+- The adapter follows the 2026-08-26 draft shape: `document.modelContext.registerTool(tool, { signal })`, `getTools()`, `executeTool(RegisteredTool, input)`, abort-based unregistration, and current WebMCP annotations.
+- OpenAI Site Tools/WebMCP product model and MCP/MCP Apps were reviewed for the split between page-scoped foreground tools and durable backend/runtime execution.
+- No upstream source code was copied; Fabushi adapts the standard to its existing Tool Contract, MCP HTTP client, Electron bridge, and Rust Host.
+
+## Pre-merge CI evidence
+
+Earlier PR head `92839fbef2ddb747cf3329663aee138a7a55f15a` exposed two deterministic preflight defects:
+
+1. Electron architecture gate: `canonical=1.0.4 desktop=1.0.4 mobile=1.0.3` — fixed by aligning `mobile/package.json` to 1.0.4.
+2. Mahayana/native fast path: `cargo fmt --check` requested a single import wrap in `mahayana-app-host` — fixed in commit `35634dcd739ad33702cfb55e716d94aa081c4b3a`.
+
+Current PR head and workflow results must be re-recorded here after all required checks complete. A green PR is not completion: this task remains IN_PROGRESS until protected-main merge, canonical-main readback, required packaged E2E evidence, and GitHub Release publication are all verified.
+
+## Required closure evidence still pending
+
+- Final required PR checks on the latest PR head.
+- Protected `main` merge SHA and canonical readback.
+- Exact-main Electron packaged E2E screenshots/video/trace/reports.
+- Exact-main Android and iOS simulated-user evidence bundles.
+- GitHub Release 1.0.4 tag/target SHA/assets and updater-compatible desktop metadata.

--- a/projects/telegram-fabushi-integration/evidence/M8-WEBMCP-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M8-WEBMCP-001/README.md
@@ -1,6 +1,6 @@
 # M8-WEBMCP-001 Evidence — MiniApp WebMCP Runtime
 
-Status: **IN_PROGRESS — PR #2169 pre-merge verification**
+Status: **TESTING / IN_PROGRESS — PR #2169 final pre-merge verification**
 
 ## Implementation evidence
 
@@ -11,9 +11,12 @@ Status: **IN_PROGRESS — PR #2169 pre-merge verification**
 - Marketplace/WebMCP admission policy: `ai-backend/src/miniapp_webmcp_policy.js`
 - Admission tests: `ai-backend/test/miniapp_webmcp_policy.test.js`
 - Desktop installed MiniApp bridge: `desktop/src/miniapp-webmcp-host.ts`
+- Desktop WebMCP simulated-user assertion: `desktop/e2e/miniapp-bot-parity.spec.ts`
 - Rust local runtime call: `third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs` (`runtime.call`)
 - Android local-first WebMCP surface: `mobile/android/app/src/main/java/com/ombhrum/fabushi/MiniAppWebMcpSurface.kt`
+- Android instrumentation: `mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt`
 - iOS local-first WebMCP surface: `mobile/ios/Fabushi/MiniAppWebMcpSurface.swift`
+- iOS UI journey: `mobile/ios/FabushiUITests/FabushiUITests.swift`
 - Cross-platform version baseline: `app-version.json` = 1.0.4, build/version codes = 2; desktop/mobile package metadata and iOS project metadata aligned.
 
 ## Open-source-first / standards evidence
@@ -23,19 +26,51 @@ Status: **IN_PROGRESS — PR #2169 pre-merge verification**
 - OpenAI Site Tools/WebMCP product model and MCP/MCP Apps were reviewed for the split between page-scoped foreground tools and durable backend/runtime execution.
 - No upstream source code was copied; Fabushi adapts the standard to its existing Tool Contract, MCP HTTP client, Electron bridge, and Rust Host.
 
-## Pre-merge CI evidence
+## Security / lifecycle evidence
 
-Earlier PR head `92839fbef2ddb747cf3329663aee138a7a55f15a` exposed two deterministic preflight defects:
+- Desktop uses a per-document random nonce and never exposes host-wide runtime inventory directly; tools are intersected with the current MiniApp Tool Contract before WebMCP projection.
+- Android Native WebMCP bridge returns an error unless the active document is the local MiniApp pseudo-origin; Hosted fallback cannot call local Rust through that bridge.
+- iOS WKScriptMessage handling requires the active WKWebView URL to be the local MiniApp pseudo-origin; Hosted fallback messages are rejected.
+- Write/destructive Tool calls retain host/native confirmation on desktop/Android/iOS.
+- Page teardown aborts WebMCP registration; Rust runtime shutdown remains an explicit `runtime.stop` lifecycle operation, so closing UI does not implicitly terminate background work.
+
+## Pre-merge implementation-head CI evidence
+
+Earlier PR head `92839fbef2ddb747cf3329663aee138a7a55f15a` exposed deterministic preflight defects that were fixed before the green implementation point:
 
 1. Electron architecture gate: `canonical=1.0.4 desktop=1.0.4 mobile=1.0.3` — fixed by aligning `mobile/package.json` to 1.0.4.
-2. Mahayana/native fast path: `cargo fmt --check` requested a single import wrap in `mahayana-app-host` — fixed in commit `35634dcd739ad33702cfb55e716d94aa081c4b3a`.
+2. Mahayana/native fast path: `cargo fmt --check` requested a single import wrap in `mahayana-app-host` — fixed.
+3. Exact PR patch audit found an unrelated accidental `MAHAYANA_DOCKER_BIN` → `DOCKER_PATH` edit during a whole-file Rust update — restored before acceptance.
+4. Electron TypeScript found a duplicate `window.mahayana` declaration — removed so the bridge reuses canonical `MahayanaElectronBridge`.
 
-Current PR head and workflow results must be re-recorded here after all required checks complete. A green PR is not completion: this task remains IN_PROGRESS until protected-main merge, canonical-main readback, required packaged E2E evidence, and GitHub Release publication are all verified.
+Implementation head `b965db5686521fc3dcc4592a293950aa35e542a7` then passed all observed PR workflows:
+
+| Workflow | Run | Result |
+|---|---:|---|
+| CI | 33037215956 | SUCCESS |
+| Electron desktop quality gate | 33037215849 | SUCCESS |
+| Mahayana fast checks | 33037215841 | SUCCESS |
+| Messaging Product Gate | 33037215905 | SUCCESS |
+| Native mobile catch-all | 33037216132 | SUCCESS |
+| Mahayana Vendor Isolation | 33037215878 | SUCCESS |
+| GBF security closure | 33037215815 | SUCCESS |
+| Developer Fiat Commerce | 33037215869 | SUCCESS |
+| Project portfolio governance | 33037215819 | SUCCESS |
+| Douyin Batch Downloader MiniApp | 33037215821 | SUCCESS |
+| Explicit automerge | 33037215965 | SUCCESS |
+
+The CI `MCP plugin contracts` job executes `npm test` inside `frontend/packages/mcp-app-sdk`, so the new WebMCP contract tests are part of actual CI evidence rather than source-only tests.
+
+## Final pre-merge gate
+
+The project-record synchronization commits after `b965db...` intentionally generate a new PR head. The final head must independently re-pass required checks before PR #2169 is moved from Draft to Ready and merged through protected `main`. The green implementation head is evidence of the code implementation, not permission to reuse stale checks for a later head.
 
 ## Required closure evidence still pending
 
-- Final required PR checks on the latest PR head.
+- Final required PR checks on the latest project-governance head.
 - Protected `main` merge SHA and canonical readback.
-- Exact-main Electron packaged E2E screenshots/video/trace/reports.
-- Exact-main Android and iOS simulated-user evidence bundles.
-- GitHub Release 1.0.4 tag/target SHA/assets and updater-compatible desktop metadata.
+- Exact-main Electron packaged E2E screenshots/video/trace/reports tied to the accepted SHA/version/workflow.
+- Exact-main Android emulator screenshots/video/instrumentation/log evidence.
+- Exact-main iOS Simulator screenshots/video/`.xcresult`/debug evidence.
+- GitHub Release 1.0.4 tag/target SHA/assets and updater-compatible desktop metadata from the accepted build lineage.
+- A docs-only protected follow-up PR that records the post-main delivery/release evidence and marks M8-WEBMCP-001 complete; until that is merged this evidence record remains `IN_PROGRESS`.

--- a/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
@@ -2,7 +2,7 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：MGMT-01
-- **版本**：v1.0
+- **版本**：v1.1
 - **状态**：BASELINE
 - **基线日期**：2026-08-22
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
@@ -72,3 +72,11 @@
 - 独立 surface 已具备 GUI、`.mcp.json` stdio MCP、`.mahayana/plugin.json` CLI，以及 Rust `official-miniapps` provider 的 `resolve` / `download` 工具；portable boundary 由 dedicated CI 断言。
 - 并行 PR #2136 的 package/runtime 实现已作为 feeder 合入当前 branch；错误引入的重复 `FAB-P0009 / DBD` 与 `projects/douyin-batch-downloader-miniapp/**` 已移除，唯一 canonical project 仍为 `FAB-P0001 / TFI`。
 - 客观验证：package digest、MCP/CLI descriptors、无 `ai-backend/src/douyin_downloader.js`、Rust fmt/test/build、Marketplace search/install tests；全部 current-head checks + protected merge + exact-main packaged E2E/Release 完成前不得晋级 `COMPLETED`。
+
+## 2026-08-27 — M8-WEBMCP-001 全量 MiniApp WebMCP Runtime
+
+- `M8-WEBMCP-001` — `TESTING`: WebMCP 已设为所有 MiniApp 的统一前台 Agent 接口，Rust/Native 保持持久后台 Runtime；Tool Contract 为 WebMCP/MCP/slash/Bot/CLI 的单一事实源。
+- Hosted MiniApp 已实现 `tools/list → WebMCP → tools/call`；本地安装 MiniApp 在 Electron/Android/iOS 使用受控 WebMCP surface，并通过 Rust `runtime.call` 执行 active local runtime Tool。
+- Marketplace/BotFather 新增 WebMCP admission policy；桌面 Tool inventory 与当前 MiniApp contract 取交集，移动端 Hosted 页面不得调用本地 Native bridge，写/破坏性调用保持宿主原生确认。
+- 目标版本统一为 `1.0.4`；实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 的 CI、Electron、Mahayana fast、Messaging、移动 catch-all、治理、安全等工作流均已通过。
+- 任务仍未完成：PR #2169 必须以最终治理 head 再次全绿并经 protected `main` 合并；随后 exact-main packaged Electron/Android/iOS E2E、视觉/trace evidence 与 GitHub Release 1.0.4 仍是硬门禁。

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-03
-- **版本**：v1.5
+- **版本**：v1.6
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
@@ -25,7 +25,7 @@
 | 联系人/群组 | actor/conversation/community | M5 | IMPLEMENTED | 需 owner/admin/member/restricted 权限矩阵 |
 | 频道/Topic | conversation/community | M6 | IMPLEMENTED | 需广播/分页/Topic 状态规模验收 |
 | Bot/Agent | bot + Actor/Feature Host + unified Messenger | M7 | TESTING | M7-DESKTOP-002 / PR #2053：Mini App conversation edge normalization + composer viewport geometry；等待 latest-head required checks / protected merge / canonical-main readback |
-| Mini Apps | miniapp + Host bridge | M8 | IMPLEMENTED | M8-CALL-001 core contract 已 TESTED；M8-MARKET-001 已实现；完整 M8 仍需 STT/MCP Host wiring、授权/撤销/沙箱与跨端 E2E |
+| Mini Apps | miniapp + Host bridge + WebMCP | M8 | TESTING | M8-CALL-001 core contract 已 TESTED；M8-MARKET-001 已实现；M8-WEBMCP-001 implementation head 已全绿，仍待 final governance head、protected merge、exact-main packaged/E2E/Release |
 | 支付 | payment/settlement/wallet | M9 | IMPLEMENTED | 需 sandbox E2E / webhook replay evidence |
 | 音视频 | realtime/signaling + desktop WebRTC | M10 | IMPLEMENTED | 需跨端/TURN/SFU/网络切换实测 |
 | 移动端共享 Core | native bridge / Host | M11 | IN_PROGRESS | 需 iOS/Android/Electron cross-device E2E |
@@ -113,3 +113,20 @@ Exact-main `eb4b340ce...` / Electron `32822744019` / artifact `9553768019` 证�
 - Protected PR #2063 merged as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`.
 - Canonical `main` readback confirmed the same merge SHA and `native/mahayana-messaging/src/miniapp_service_call.rs` blob `d6f3f503c1bccde38408ce507b9342717813b3ec`.
 - This closure covers the atomic MCP-only domain/permission/bridge contract. STT、real `tools/list` resolver/`tools/call` Host execution、composer routing、media and cross-platform UI/E2E remain M8-CALL-002/003/004 and later tasks; full M8 therefore remains broader `IMPLEMENTED` rather than stage-closed.
+
+## M8-WEBMCP-001 pre-merge acceptance — 2026-08-27
+
+`M8-WEBMCP-001` = `TESTING / IN_PROGRESS`。实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 已获得以下 GitHub Actions 全绿结果：CI `33037215956`、Electron desktop quality gate `33037215849`、Mahayana fast checks `33037215841`、Messaging Product Gate `33037215905`、Native mobile catch-all `33037216132`、Mahayana Vendor Isolation `33037215878`、GBF security closure `33037215815`、Developer Fiat Commerce `33037215869`、Project portfolio governance `33037215819`、Douyin MiniApp `33037215821`、Explicit automerge `33037215965`。
+
+Acceptance traceability:
+
+- WebMCP standard adapter: `frontend/packages/mcp-app-sdk/src/webmcp.ts`; contract tests execute under CI `MCP plugin contracts` and cover fallback registry, `registerTool(tool,{signal})` lifecycle, native `getTools/executeTool`, and MCP projection.
+- Hosted MiniApp: `frontend/apps/web/src/app/miniapps/[id]/WebMcpMiniAppAdapter.tsx` projects MCP `tools/list` to WebMCP and delegates execution to the same `tools/call`.
+- Marketplace/BotFather admission: `ai-backend/src/miniapp_webmcp_policy.js` + tests require callable Tool Contract for complete MiniApp publishing/generation acceptance.
+- Local Rust execution: `mahayana-app-host` exposes `runtime.call`; active runtime and registered-tool checks precede existing `DeepSeekJsHost::call_tool_json`.
+- Desktop local MiniApp: `desktop/src/miniapp-webmcp-host.ts` injects page-scoped WebMCP, uses per-document nonce, intersects host inventory with current MiniApp Tool Contract, and preserves write/destructive approval.
+- Android/iOS: native Compose/SwiftUI shells remain canonical; local installed HTML is preferred in controlled WebView/WKWebView; Hosted page is fallback only; local Native bridge is blocked for Hosted origin; tool execution enters Rust `runtime.call` after native approval.
+- Lifecycle: WebMCP registration is aborted on page teardown; Rust background runtime/job lifecycle remains separately controlled by Host and is not implicitly stopped on page close.
+- Version baseline: canonical, desktop, mobile and iOS metadata are aligned to 1.0.4 with mobile build/version codes 2.
+
+Remaining hard gates: final governance head must rerun required checks, PR #2169 must merge through protected `main`, canonical main must be read back, exact-main packaged Electron/Android/iOS simulated-user E2E must preserve required screenshot/video/trace/report evidence, and GitHub Release 1.0.4 must point at the accepted main SHA. Until those are complete this task must not be marked `COMPLETED` or `RELEASED`.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -4,18 +4,19 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-05
-- **版本**：v1.7
+- **版本**：v1.8
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
 ## 当前状态
 
-- **整体阶段**：M3 桌面聊天完整交互 — `IN_PROGRESS`；M7 unified Messenger remediation 并行 `TESTING`；M8-CALL-001 core contract 已 `TESTED / COMPLETED`。
+- **整体阶段**：M3 桌面聊天完整交互 — `IN_PROGRESS`；M7 unified Messenger remediation 并行 `TESTING`；M8-CALL-001 core contract 已 `TESTED / COMPLETED`；M8-WEBMCP-001 已完成跨端实现并处于 `TESTING / IN_PROGRESS`。
 - **M0**：`TESTED`。
 - **M1**：`TESTED`，证据 `M1-ACCEPT-001`。
 - **M2**：`TESTED`，证据 `M2-ACCEPT-001`。
 - **Canonical Messaging Core**：`native/mahayana-messaging/`。
 - **当前 M7 产品任务**：`M7-DESKTOP-002`，分支 `fix/tfi-m7-messenger-composer-miniapp-routing`，PR #2053。
+- **当前 M8 WebMCP 任务**：`M8-WEBMCP-001`，分支 `feat/tfi-webmcp-miniapp-runtime`，PR #2169；实现 head 已全绿，仍等待最终治理 head、protected main、exact-main delivery 与 Release 1.0.4。
 - **旧 Telegram 栈**：继续 LEGACY/FROZEN；M14 前不得新增产品功能。
 
 ## M2 final landing
@@ -130,7 +131,7 @@
 
 - Target-Mac packaged `1.0.798` still showed `正在恢复你的工作空间`, but source tracing proved this was an `authResolved=false` account-validation gate rather than workspace restore.
 - The installed ChatGPT macOS app was inspected as the requested UX reference: normal shell first, background readiness work second.
-- Fabushi now keeps the normal Messenger shell/projection visible while auth is unknown or transport retries; only an explicit `loggedIn=false` result routes to login.
+- Fabushi now keeps the normal Messenger shell/projection visible while auth is unknown or transport retries；only an explicit `loggedIn=false` result routes to login.
 - HostClient resolves auth before expensive conversation/connector/agent/settings hydration, and the fallback copy is renamed to accurate account verification.
 - Acceptance remains pending protected merge plus exact-main packaged startup measurement and Release validation.
 
@@ -139,7 +140,7 @@
 - Target Mac reproduced left-rail staged appearance: a few rows rendered immediately, remaining contacts/conversations appeared seconds later。
 - Root causes: legacy peer summaries were omitted from the durable renderer projection, and self-hosted `Sync { cursor: None, limit: 20 }` incorrectly truncated actor/conversation metadata while still advancing the journal cursor。
 - Follow-up persists legacy conversation/Bot/group summaries for instant returning-user paint and makes initial Rust snapshot metadata complete while preserving bounded message payloads。
-- New Rust contract uses `limit=1` to prove complete visible actors/conversations + one bounded message; Messenger E2E requires the legacy assistant peer to be persisted and restored。
+- New Rust contract uses `limit=1` to prove complete visible actors/conversations + one bounded message；Messenger E2E requires the legacy assistant peer to be persisted and restored。
 - Status remains `TESTING` pending PR/main/package/target-Mac proof。
 
 ## 2026-08-25 — M7-DESKTOP-004 Bot avatar / info panel remediation
@@ -168,20 +169,30 @@
 ## 2026-08-25 — M7-DESKTOP-004 class-only selection propagation
 
 - `main@eb4b340ce4d9d18cc69b4e60ec97037cbcb2c878` Electron `32822744019` 仍被 task-specific real-Host E2E 正确阻断；artifact `9553768019`。
-- 17/18 cases pass. Remaining gap is immediate selected-peer propagation: Messenger changes `peerActive` class on stable row nodes, but Workbench observed only child-node mutations.
-- `fix/tfi-peer-selection-observer` adds filtered `class` observation for peer buttons and keeps the 500 ms interval as recovery-only.
-- Release remains blocked until protected merge + later exact-main Electron/native delivery are green.
+- 17/18 cases pass. Remaining gap is immediate selected-peer propagation: Messenger changes `peerActive` class on stable row nodes, but Workbench observed only child-node mutations。
+- `fix/tfi-peer-selection-observer` adds filtered `class` observation for peer buttons and keeps the 500 ms interval as recovery-only。
+- Release remains blocked until protected merge + later exact-main Electron/native delivery are green。
 
 ## 2026-08-25 — M7-DESKTOP-004 right drawer exact-main block
 
-- `main@adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` / Electron `32823782495` retained diagnostics `9554164364`; 17/18 real-Host E2E cases passed.
-- Header/peer Motion v2 identity is no longer the failing point. The remaining user-visible defect is the narrow right `资料` drawer.
-- Root cause is the old `max-width:1280px` CSS `display:none` rule masking the newer overlay drawer even when React renders it.
-- `fix/tfi-narrow-info-panel-toggle` preserves the docked-panel hide only for non-overlay state and allows `data-overlay=true` to render. Release stays blocked until the next exact-main delivery is green.
+- `main@adcd73d0b68ddff403d5804d1b8d10f9b5e6c202` / Electron `32823782495` retained diagnostics `9554164364`；17/18 real-Host E2E cases passed。
+- Header/peer Motion v2 identity is no longer the failing point. The remaining user-visible defect is the narrow right `资料` drawer。
+- Root cause is the old `max-width:1280px` CSS `display:none` rule masking the newer overlay drawer even when React renders it。
+- `fix/tfi-narrow-info-panel-toggle` preserves the docked-panel hide only for non-overlay state and allows `data-overlay=true` to render. Release stays blocked until the next exact-main delivery is green。
 
 ## 2026-08-26 — M8-CALL-001 core contract closed
 
-- #2063 final head `1c1a479eb93be7e21becaa2211463cb6f97b8a06` passed Mahayana fast `32969707544`, self-hosted messaging `32969707602`, Messaging Product Gate `32969707606`, repository CI `32969707626`, Developer Fiat Commerce `32969707538`, portfolio governance `32969707591`, and Explicit automerge `32969707671`.
-- PR #2063 merged through protected GitHub flow as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`.
-- Canonical `main` readback confirmed HEAD `1f406461...` and service-call core blob `d6f3f503c1bccde38408ce507b9342717813b3ec`.
-- `M8-CALL-001` is now `TESTED / COMPLETED`. It closes only the MCP-only Rust domain/permission/bridge contract; STT、real MCP Host resolver/executor、composer routing、media/UI/E2E remain follow-up scope, so the wider M8 stage remains open.
+- #2063 final head `1c1a479eb93be7e21becaa2211463cb6f97b8a06` passed Mahayana fast `32969707544`, self-hosted messaging `32969707602`, Messaging Product Gate `32969707606`, repository CI `32969707626`, Developer Fiat Commerce `32969707538`, portfolio governance `32969707591`, and Explicit automerge `32969707671`。
+- PR #2063 merged through protected GitHub flow as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`。
+- Canonical `main` readback confirmed HEAD `1f406461...` and service-call core blob `d6f3f503c1bccde38408ce507b9342717813b3ec`。
+- `M8-CALL-001` is now `TESTED / COMPLETED`. It closes only the MCP-only Rust domain/permission/bridge contract；STT、real MCP Host resolver/executor、composer routing、media/UI/E2E remain follow-up scope, so the wider M8 stage remains open。
+
+## 2026-08-27 — M8-WEBMCP-001 pre-merge green implementation
+
+- 用户要求把所有 MiniApp 全面升级为 **WebMCP 前台 Agent 接口 + Rust/Native 长生命周期后台 Runtime**，并以 `main` 为目标发布新版本；该需求已固化到 source、ADR-0010、task、WBS 与 acceptance records。
+- Hosted MiniApp 已统一 `tools/list → WebMCP → 同一 tools/call`；本地 installed MiniApp 在 Electron/Android/iOS 通过受控 WebMCP surface 使用同一 Tool Contract，并通过 Rust Host `runtime.call` 执行 active local runtime Tool。
+- SDK 已按 2026-08-26 WebMCP Draft 修正为 `registerTool(tool, { signal })`、abort lifecycle、`getTools/executeTool`；Marketplace/BotFather 已加入强制 WebMCP admission policy，新 MiniApp 不再需要维护第二份命令映射。
+- 安全边界已实现：桌面 runtime inventory 必须与当前 MiniApp Tool Contract 取交集；per-document nonce；write/destructive 原生批准；Android/iOS Hosted fallback 不可使用本地 Native WebMCP bridge。
+- 版本基线统一为 `1.0.4`，Android/iOS build/version code = 2，desktop/mobile/iOS metadata 已对齐。
+- 实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 的 GitHub Actions 已全部通过：CI `33037215956`、Electron `33037215849`、Mahayana fast `33037215841`、Messaging `33037215905`、Native mobile catch-all `33037216132`、Vendor Isolation `33037215878`、GBF security `33037215815`、Commerce `33037215869`、Portfolio governance `33037215819`、Douyin MiniApp `33037215821`、Explicit automerge `33037215965`。
+- 当前仅进行最终治理同步；任务继续保持 `TESTING / IN_PROGRESS`。只有 final governance head required checks 全绿、PR #2169 经 protected `main` 合并、canonical-main 回读、exact-main packaged Electron/Android/iOS E2E 及截图/视频/trace/report evidence 全绿，并发布指向 accepted main SHA 的 GitHub Release 1.0.4 后，才允许改为 `COMPLETED / RELEASED`。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-07
-- **版本**：v1.7
+- **版本**：v1.8
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
@@ -172,7 +172,20 @@
 
 ## 2026-08-26 — M8-CALL-001 protected merge closure
 
-- Resolved #2063 against latest `main` without rolling back later FAB-P0001 shared project-state changes: core Rust + dedicated ADR/spec/task/evidence were retained, while M8.T08–T11 were merged into the latest WBS.
-- Final PR head `1c1a479eb93be7e21becaa2211463cb6f97b8a06` passed all seven observed current-head GitHub Actions workflows: Mahayana fast `32969707544`, self-hosted messaging `32969707602`, Messaging Product Gate `32969707606`, CI `32969707626`, Developer Fiat Commerce `32969707538`, portfolio governance `32969707591`, Explicit automerge `32969707671`.
-- PR #2063 merged as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`; canonical `main` readback confirmed the same HEAD and service-call blob `d6f3f503c1bccde38408ce507b9342717813b3ec`.
-- `M8-CALL-001` advanced to `TESTED / COMPLETED`. Follow-up work remains explicitly split into M8-CALL-002/003/004 and later media/UI/E2E tasks; this closure does not overstate full M8 completion.
+- Resolved #2063 against latest `main` without rolling back later FAB-P0001 shared project-state changes: core Rust + dedicated ADR/spec/task/evidence were retained, while M8.T08–T11 were merged into the latest WBS。
+- Final PR head `1c1a479eb93be7e21becaa2211463cb6f97b8a06` passed all seven observed current-head GitHub Actions workflows: Mahayana fast `32969707544`, self-hosted messaging `32969707602`, Messaging Product Gate `32969707606`, CI `32969707626`, Developer Fiat Commerce `32969707538`, portfolio governance `32969707591`, Explicit automerge `32969707671`。
+- PR #2063 merged as `1f406461c01ac9ace5e187fd8b9a0e2c63cbcb5d`; canonical `main` readback confirmed the same HEAD and service-call blob `d6f3f503c1bccde38408ce507b9342717813b3ec`。
+- `M8-CALL-001` advanced to `TESTED / COMPLETED`. Follow-up work remains explicitly split into M8-CALL-002/003/004 and later media/UI/E2E tasks; this closure does not overstate full M8 completion。
+
+## 2026-08-27 — M8-WEBMCP-001 cross-platform architecture upgrade
+
+- 用户明确要求所有 MiniApp 必须内置/暴露 WebMCP，把 WebMCP 作为 Mahayana 在当前小程序前台发现与调用能力的标准入口，同时保持 Rust/Native 负责长期后台执行；目标分支纠正为 `main`，目标版本为 1.0.4。
+- 新增 `@fabushi/mcp-app-sdk` WebMCP adapter/fallback；Hosted MiniApp 自动把真实 MCP `tools/list` 投影为 WebMCP 并调用同一 `tools/call`，不再维护平台级第二份 `/command → Tool` 映射。
+- 根据 2026-08-26 WebMCP Draft 修正标准细节：`document.modelContext.registerTool(tool, { signal })`、abort-based unregister、`getTools()` / `executeTool(RegisteredTool, input)` 与当前 annotations；新增 contract tests 并由主 CI 的 `MCP plugin contracts` 实际执行。
+- 新增 Marketplace/BotFather WebMCP admission policy：未来 MiniApp 必须具备可调用 Tool Contract 才能通过完整生成/发布验收。
+- Rust AppHost 新增 `runtime.call`，只允许 Active 插件调用已注册 Tool，再复用现有 `DeepSeekJsHost::call_tool_json`；页面关闭不等于 `runtime.stop`，因此前台 WebMCP teardown 不会自动终止后台任务。
+- Electron installed MiniApp 使用 per-document nonce 注入 WebMCP；runtime inventory 必须与当前 MiniApp Tool Contract 取交集；write/destructive Tool 继续宿主确认。
+- Android/iOS 保留 Compose/SwiftUI 原生主壳，只在 MiniApp surface 使用受控 WebView/WKWebView；优先打开本地安装 HTML，无本地 UI 时才 Hosted fallback；Hosted origin 明确禁止调用本地 Native WebMCP bridge；本地 Tool 调用进入 Rust `runtime.call` 并保留原生批准。
+- E2E/UITest 增加桌面 WebMCP tool discovery + restart、Android WebMCP open control、iOS dedicated WebMCP surface open/close 用户旅程。
+- 版本元数据统一：`app-version.json`、desktop/mobile package 与 iOS project 均为 1.0.4，Android/iOS build/version code 为 2。
+- 实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 的所有 observed PR workflows 已 SUCCESS；最终治理同步仍会生成新的 head 并必须重新全绿。任务在 protected merge、canonical-main readback、exact-main packaged Electron/Android/iOS E2E/evidence 和 GitHub Release 1.0.4 完成前保持 `TESTING / IN_PROGRESS`。

--- a/projects/telegram-fabushi-integration/management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md
@@ -2,7 +2,7 @@
 
 - **Project**: FAB-P0001 / TFI
 - **Stage**: M8 Mini Apps
-- **Status**: IN_PROGRESS
+- **Status**: TESTING / IN_PROGRESS
 - **Branch**: `feat/tfi-webmcp-miniapp-runtime`
 - **PR**: #2169
 - **Target version**: 1.0.4
@@ -34,36 +34,57 @@
 ## 已完成实现
 
 - `frontend/packages/mcp-app-sdk/src/webmcp.ts`: WebMCP standard adapter、native feature detection、fallback registry、native discovery/call。
-- `frontend/packages/mcp-app-sdk/test/webmcp.test.ts`: fallback/native lifecycle/native execute/MCP projection contract tests。
+- `frontend/packages/mcp-app-sdk/test/webmcp.test.ts`: fallback/native lifecycle/native execute/MCP projection contract tests；主 CI 的 `MCP plugin contracts` 实际执行这些测试。
 - Hosted MiniApp `WebMcpMiniAppAdapter`: `tools/list -> WebMCP -> tools/call` 自动投影，所有 `/miniapps/[id]` 页面统一挂载。
 - Marketplace/BotFather WebMCP admission policy + tests：新 MiniApp 必须有可调用 Tool Contract 才能进入完整发布链。
 - Desktop installed MiniApp host：本地 HTML 自动注入 WebMCP；随机 nonce；Tool inventory 与当前 MiniApp Contract 取交集；写操作审批；本地调用进入 Rust `runtime.call`。
 - Rust `mahayana-app-host`: 新增 `runtime.call`，要求 runtime Active、参数为 object、Tool 已注册，随后调用既有 `DeepSeekJsHost::call_tool_json`。
-- Android：Compose 主壳保留；MiniApp WebMCP surface 本地优先、Hosted 兜底；Tool Contract 驱动；Native approval；调用 Rust `runtime.call`。
-- iOS：SwiftUI 主壳保留；WKWebView MiniApp surface 本地优先、Hosted 兜底；Tool Contract 驱动；Native approval；调用 Rust `runtime.call`。
+- Android：Compose 主壳保留；MiniApp WebMCP surface 本地优先、Hosted 兜底；Tool Contract 驱动；Native approval；调用 Rust `runtime.call`；Hosted document 不能使用本地 Native bridge。
+- iOS：SwiftUI 主壳保留；WKWebView MiniApp surface 本地优先、Hosted 兜底；Tool Contract 驱动；Native approval；调用 Rust `runtime.call`；Hosted origin script message 被拒绝。
+- Desktop E2E 已直接断言 installed 全球法布施 WebMCP registry 可发现 `status/start/stop/send`，并在完整应用重启后继续恢复；Android instrumentation 与 iOS UI journey 已覆盖 WebMCP surface 打开/关闭控制。
 - 版本基线已提升到 1.0.4，build/version code 2；desktop/mobile/iOS metadata 已对齐。
-- 原始需求、ADR、证据索引已持久化。
+- 原始需求、ADR、WBS、验收、状态、变更日志、证据索引已持久化。
 
-## 当前进行中
+## 实现 head 验收绿点
 
-- 最新 PR head required CI / desktop / native mobile / Mahayana checks 正在重新验证。
-- 收紧 Hosted fallback 与 local Native bridge 的来源隔离。
-- 补充 MiniApp WebMCP E2E 与项目 WBS/acceptance/status/changelog。
-- required checks 全绿后转 Ready，进入 protected-main/merge-queue。
-- merge 后执行 exact-main packaged desktop/mobile E2E 与 1.0.4 Release。
+实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 的 observed GitHub Actions 全部 SUCCESS：
+
+- CI `33037215956`；
+- Electron desktop quality gate `33037215849`；
+- Mahayana fast checks `33037215841`；
+- Messaging Product Gate `33037215905`；
+- Native mobile catch-all `33037216132`；
+- Mahayana Vendor Isolation `33037215878`；
+- GBF security closure `33037215815`；
+- Developer Fiat Commerce `33037215869`；
+- Project portfolio governance `33037215819`；
+- Douyin Batch Downloader MiniApp `33037215821`；
+- Explicit automerge `33037215965`。
+
+该绿点验证了实现，但最终治理同步会生成新的 PR head，因此 required checks 必须针对最终 head 再通过一次才允许转 Ready/merge。
 
 ## 已发现并修复的预检问题
 
 - 版本漂移：架构门曾报告 `canonical=1.0.4 desktop=1.0.4 mobile=1.0.3`；已将 `mobile/package.json` 对齐 1.0.4。
 - Rust 格式：`cargo fmt --check` 要求 `PluginState` import 换行；已按 rustfmt 精确修复。
 - Rust Host 全文件更新过程中曾意外把 `MAHAYANA_DOCKER_BIN` 写成 `DOCKER_PATH`；通过精确 PR patch 审计发现并恢复，最终 Rust diff 仅保留 `runtime.call` 相关改动。
+- Electron TypeScript 曾因重复声明 `window.mahayana` 与 canonical `MahayanaElectronBridge` 冲突；已删除重复声明并复用仓库唯一桥类型，后续 Electron gate SUCCESS。
+
+## 当前进行中
+
+- 最终项目治理同步已完成到 WBS/acceptance/status/changelog/PROJECT/task/evidence；以最新 PR head 为准重新执行 required checks。
+- final head 全绿后把 PR #2169 从 Draft 转 Ready，并通过 protected `main` / merge queue，不绕过保护。
+- merge 后从 canonical `main` 回读代码、版本和项目记录。
+- 对 accepted exact-main SHA 执行 packaged Electron/Android/iOS simulated-user E2E；保留截图、全程视频、trace/report/xcresult/log 等规定证据。
+- 所有 required exact-main delivery gates 全绿后创建严格递增的 1.0.4 tag/Release，并验证桌面 updater metadata 与移动端产物来自同一 accepted main lineage。
 
 ## 完成定义
 
-只有以下全部成立才把本任务从 `IN_PROGRESS` 改为 `COMPLETED`：
+只有以下全部成立才把本任务从 `TESTING / IN_PROGRESS` 改为 `COMPLETED / RELEASED`：
 
-1. latest head required checks 全绿；
+1. latest final-governance head required checks 全绿；
 2. PR #2169 合入 protected `main`；
-3. 从 canonical `main` 回读实现与版本；
+3. 从 canonical `main` 回读实现、版本和项目记录；
 4. exact-main Electron/Android/iOS required packaged E2E 与证据 bundle 全绿；
-5. GitHub Release 1.0.4 指向验收后的 main SHA，包含 updater-compatible desktop assets 与移动端构建资产。
+5. GitHub Release 1.0.4 指向验收后的 main SHA，包含 updater-compatible desktop assets 与移动端构建资产；
+6. Release/packaged evidence 回写到项目记录，并由 docs-only follow-up protected PR 合入 `main` 后才最终关账。

--- a/projects/telegram-fabushi-integration/management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md
@@ -5,45 +5,65 @@
 - **Status**: IN_PROGRESS
 - **Branch**: `feat/tfi-webmcp-miniapp-runtime`
 - **PR**: #2169
+- **Target version**: 1.0.4
 - **Source**: `source/2026-08-27-webmcp-miniapp-runtime.md`
 - **ADR**: `decisions/ADR-0010-webmcp-foreground-rust-background.md`
+- **Evidence**: `evidence/M8-WEBMCP-001/README.md`
 
 ## 目标
 
-把 WebMCP 设为所有 MiniApp 的统一前台 Agent 接口，同时保持 Rust/Native Runtime 为长任务与后台业务执行面。Tool contract 是唯一事实源，WebMCP、slash command、Mahayana Host、CLI/Bot 均由同一 Tool catalog 派生。
+把 WebMCP 设为所有 MiniApp 的统一前台 Agent 接口，同时保持 Rust/Native Runtime 为长任务与后台业务执行面。Tool Contract 是唯一事实源，WebMCP、slash command、Mahayana Host、CLI/Bot 均由同一 Tool catalog 派生，不维护平台级第二份命令映射。
 
 ## 原子验收
 
-1. SDK 能 feature-detect `document.modelContext` 并注册/注销 Tool；浏览器暂不支持时有 Fabushi-compatible fallback registry。
+1. SDK 能 feature-detect `document.modelContext` 并按当前 WebMCP Draft 注册/注销 Tool；浏览器暂不支持时有 Fabushi-compatible fallback registry。
 2. Hosted MiniApp 在加载后把真实 MCP `tools/list` 自动投影为 WebMCP；`tools/call` 仍走同一后端，不维护第二份映射。
-3. read-only Tool 无写操作确认；write/destructive/open-world Tool 继续走批准语义。
-4. 本地安装 MiniApp 能在桌面受控 iframe 中发现并调用当前 app Tool。
-5. Android/iOS 主壳保持 Compose/SwiftUI；MiniApp surface 使用受控 WebView/WKWebView 时能获得同一 WebMCP bridge。
-6. Rust Host 对便携本地 Runtime 暴露 tool list + call，页面关闭后 Rust Job/状态不随 WebMCP teardown 丢失。
-7. Marketplace/BotFather 新 MiniApp 验收强制 WebMCP contract，slash command 从 Tool metadata 派生。
+3. read-only Tool 无写操作确认；write/destructive Tool 继续走宿主批准语义。
+4. 本地安装 MiniApp 能在桌面受控 iframe 中发现当前 app Tool，并调用本地 Rust Runtime；Host 全局 Tool inventory 不得跨 MiniApp 泄露。
+5. Android/iOS 主壳保持 Compose/SwiftUI；MiniApp 使用受控 WebView/WKWebView，优先打开已安装本地 HTML，缺失时才回退 Hosted WebMCP。
+6. Rust Host 对便携本地 Runtime 暴露 `runtime.tools` + `runtime.call`；调用前要求插件 Active 且 Tool 已注册；页面关闭仅 teardown 前台 WebMCP，不停止 Rust Job/状态。
+7. Marketplace/BotFather 新 MiniApp 验收强制 WebMCP Tool Contract；slash command 从同一 Tool metadata 派生。
 8. SDK unit/contract tests、web/desktop/native compile/test、MiniApp WebMCP E2E 通过。
 9. PR 通过 required checks 并合入 protected `main`。
-10. exact-main desktop/mobile packaged simulated-user E2E 有截图/视频/trace/report evidence；发布新版本 GitHub Release。
+10. exact-main desktop/mobile packaged simulated-user E2E 有截图/视频/trace/report evidence；发布 GitHub Release 1.0.4。
 
 ## 开源优先
 
-研究并采用：WebMCP Community Group specification/repository、OpenAI WebMCP/Site Tools 产品模型、MCP/MCP Apps。未复制第三方实现代码；Fabushi 只实现标准 adapter + existing Tool contract projection。
+研究并采用 WebMCP Community Group specification/repository、OpenAI WebMCP/Site Tools 产品模型、MCP/MCP Apps。未复制第三方实现代码；Fabushi 实现标准 adapter + existing Tool Contract projection。2026-08-26 WebMCP Draft 的关键兼容点已落地：`registerTool(tool, { signal })`、abort lifecycle、`getTools()` / `executeTool()` 与当前 annotations。
 
 ## 已完成实现
 
-- `frontend/packages/mcp-app-sdk/src/webmcp.ts`
-- SDK export + WebMCP tests
-- Hosted MiniApp `WebMcpMiniAppAdapter` 自动 `tools/list -> WebMCP -> tools/call`
-- 所有 `/miniapps/[id]` 页面统一挂载 adapter
-- 原始需求与 ADR 已持久化
+- `frontend/packages/mcp-app-sdk/src/webmcp.ts`: WebMCP standard adapter、native feature detection、fallback registry、native discovery/call。
+- `frontend/packages/mcp-app-sdk/test/webmcp.test.ts`: fallback/native lifecycle/native execute/MCP projection contract tests。
+- Hosted MiniApp `WebMcpMiniAppAdapter`: `tools/list -> WebMCP -> tools/call` 自动投影，所有 `/miniapps/[id]` 页面统一挂载。
+- Marketplace/BotFather WebMCP admission policy + tests：新 MiniApp 必须有可调用 Tool Contract 才能进入完整发布链。
+- Desktop installed MiniApp host：本地 HTML 自动注入 WebMCP；随机 nonce；Tool inventory 与当前 MiniApp Contract 取交集；写操作审批；本地调用进入 Rust `runtime.call`。
+- Rust `mahayana-app-host`: 新增 `runtime.call`，要求 runtime Active、参数为 object、Tool 已注册，随后调用既有 `DeepSeekJsHost::call_tool_json`。
+- Android：Compose 主壳保留；MiniApp WebMCP surface 本地优先、Hosted 兜底；Tool Contract 驱动；Native approval；调用 Rust `runtime.call`。
+- iOS：SwiftUI 主壳保留；WKWebView MiniApp surface 本地优先、Hosted 兜底；Tool Contract 驱动；Native approval；调用 Rust `runtime.call`。
+- 版本基线已提升到 1.0.4，build/version code 2；desktop/mobile/iOS metadata 已对齐。
+- 原始需求、ADR、证据索引已持久化。
 
-## 当前缺口
+## 当前进行中
 
-- Rust `mahayana-app-host` 尚需把已有 `DeepSeekJsHost::call_tool_json` 暴露为 Host `runtime.call`。
-- 桌面 installed MiniApp iframe 目前只注入 CloudStorage bridge，需增加 WebMCP bridge。
-- 当前 native mobile 只有 Compose/SwiftUI 市场 UI，需增加 MiniApp Web surface，而不是恢复 WebView 主壳。
-- marketplace/generation policy、WBS/acceptance/status/changelog、版本、CI/main/release 仍需闭环。
+- 最新 PR head required CI / desktop / native mobile / Mahayana checks 正在重新验证。
+- 收紧 Hosted fallback 与 local Native bridge 的来源隔离。
+- 补充 MiniApp WebMCP E2E 与项目 WBS/acceptance/status/changelog。
+- required checks 全绿后转 Ready，进入 protected-main/merge-queue。
+- merge 后执行 exact-main packaged desktop/mobile E2E 与 1.0.4 Release。
 
-## 证据
+## 已发现并修复的预检问题
 
-见 `evidence/M8-WEBMCP-001/README.md`。
+- 版本漂移：架构门曾报告 `canonical=1.0.4 desktop=1.0.4 mobile=1.0.3`；已将 `mobile/package.json` 对齐 1.0.4。
+- Rust 格式：`cargo fmt --check` 要求 `PluginState` import 换行；已按 rustfmt 精确修复。
+- Rust Host 全文件更新过程中曾意外把 `MAHAYANA_DOCKER_BIN` 写成 `DOCKER_PATH`；通过精确 PR patch 审计发现并恢复，最终 Rust diff 仅保留 `runtime.call` 相关改动。
+
+## 完成定义
+
+只有以下全部成立才把本任务从 `IN_PROGRESS` 改为 `COMPLETED`：
+
+1. latest head required checks 全绿；
+2. PR #2169 合入 protected `main`；
+3. 从 canonical `main` 回读实现与版本；
+4. exact-main Electron/Android/iOS required packaged E2E 与证据 bundle 全绿；
+5. GitHub Release 1.0.4 指向验收后的 main SHA，包含 updater-compatible desktop assets 与移动端构建资产。

--- a/projects/telegram-fabushi-integration/management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md
@@ -1,0 +1,49 @@
+# M8-WEBMCP-001 — 全量 MiniApp WebMCP Runtime
+
+- **Project**: FAB-P0001 / TFI
+- **Stage**: M8 Mini Apps
+- **Status**: IN_PROGRESS
+- **Branch**: `feat/tfi-webmcp-miniapp-runtime`
+- **PR**: #2169
+- **Source**: `source/2026-08-27-webmcp-miniapp-runtime.md`
+- **ADR**: `decisions/ADR-0010-webmcp-foreground-rust-background.md`
+
+## 目标
+
+把 WebMCP 设为所有 MiniApp 的统一前台 Agent 接口，同时保持 Rust/Native Runtime 为长任务与后台业务执行面。Tool contract 是唯一事实源，WebMCP、slash command、Mahayana Host、CLI/Bot 均由同一 Tool catalog 派生。
+
+## 原子验收
+
+1. SDK 能 feature-detect `document.modelContext` 并注册/注销 Tool；浏览器暂不支持时有 Fabushi-compatible fallback registry。
+2. Hosted MiniApp 在加载后把真实 MCP `tools/list` 自动投影为 WebMCP；`tools/call` 仍走同一后端，不维护第二份映射。
+3. read-only Tool 无写操作确认；write/destructive/open-world Tool 继续走批准语义。
+4. 本地安装 MiniApp 能在桌面受控 iframe 中发现并调用当前 app Tool。
+5. Android/iOS 主壳保持 Compose/SwiftUI；MiniApp surface 使用受控 WebView/WKWebView 时能获得同一 WebMCP bridge。
+6. Rust Host 对便携本地 Runtime 暴露 tool list + call，页面关闭后 Rust Job/状态不随 WebMCP teardown 丢失。
+7. Marketplace/BotFather 新 MiniApp 验收强制 WebMCP contract，slash command 从 Tool metadata 派生。
+8. SDK unit/contract tests、web/desktop/native compile/test、MiniApp WebMCP E2E 通过。
+9. PR 通过 required checks 并合入 protected `main`。
+10. exact-main desktop/mobile packaged simulated-user E2E 有截图/视频/trace/report evidence；发布新版本 GitHub Release。
+
+## 开源优先
+
+研究并采用：WebMCP Community Group specification/repository、OpenAI WebMCP/Site Tools 产品模型、MCP/MCP Apps。未复制第三方实现代码；Fabushi 只实现标准 adapter + existing Tool contract projection。
+
+## 已完成实现
+
+- `frontend/packages/mcp-app-sdk/src/webmcp.ts`
+- SDK export + WebMCP tests
+- Hosted MiniApp `WebMcpMiniAppAdapter` 自动 `tools/list -> WebMCP -> tools/call`
+- 所有 `/miniapps/[id]` 页面统一挂载 adapter
+- 原始需求与 ADR 已持久化
+
+## 当前缺口
+
+- Rust `mahayana-app-host` 尚需把已有 `DeepSeekJsHost::call_tool_json` 暴露为 Host `runtime.call`。
+- 桌面 installed MiniApp iframe 目前只注入 CloudStorage bridge，需增加 WebMCP bridge。
+- 当前 native mobile 只有 Compose/SwiftUI 市场 UI，需增加 MiniApp Web surface，而不是恢复 WebView 主壳。
+- marketplace/generation policy、WBS/acceptance/status/changelog、版本、CI/main/release 仍需闭环。
+
+## 证据
+
+见 `evidence/M8-WEBMCP-001/README.md`。

--- a/projects/telegram-fabushi-integration/management/wbs/M8.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M8.md
@@ -120,3 +120,14 @@
 - **阻塞**：依赖 M8-CALL-001 和 M8-CALL-003；其中 M8-CALL-001 已关闭。
 - **证据位置**：待创建 `../evidence/M8-CALL-004/README.md`。
 - **下一步**：在 unified Messenger composer 上接 service-call context routing。
+
+### M8.T12 / M8-WEBMCP-001 — mandatory WebMCP foreground + durable Rust backend
+
+- **交付物**：所有 Hosted/installed MiniApp 的 WebMCP foreground interface、统一 Tool Contract projection、desktop/Android/iOS local-first WebMCP surface、Rust `runtime.call`、Marketplace/BotFather WebMCP admission policy。
+- **验收标准**：Hosted MiniApp 自动把 MCP `tools/list` 注册为当前 WebMCP Tool 并回调同一 `tools/call`；本地 MiniApp 只暴露自身合同 Tool；写/破坏性调用经过宿主批准；Android/iOS Hosted fallback 不得调用本地 Native bridge；关闭页面只注销前台 WebMCP、不停止 Rust 后台 Runtime/Job；未来 MiniApp 没有可调用 Tool Contract 时不得通过完整上架验收。
+- **客观验证**：`@fabushi/mcp-app-sdk` WebMCP contract tests、Marketplace policy tests、Electron typecheck/build + MiniApp WebMCP E2E、Mahayana direct Host/FFI fast checks、Android instrumentation、iOS UI journey、PR current-head CI；最终还需 exact-main packaged Electron/Android/iOS E2E + visual/trace evidence + Release 1.0.4。
+- **来源**：`../source/2026-08-27-webmcp-miniapp-runtime.md`; `../decisions/ADR-0010-webmcp-foreground-rust-background.md`。
+- **状态**：TESTING / IN_PROGRESS
+- **阻塞**：实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 已全绿；仍等待 PR #2169 final governance head required checks、protected `main` merge、canonical-main readback、exact-main packaged E2E/evidence 与 GitHub Release 1.0.4。
+- **证据位置**：`../evidence/M8-WEBMCP-001/README.md`; `../management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md`; PR #2169。
+- **下一步**：最终治理 head 全绿后转 Ready → protected merge → exact-main delivery → Release 1.0.4；全部闭环后再晋级 `COMPLETED / RELEASED`。

--- a/projects/telegram-fabushi-integration/source/2026-08-27-webmcp-miniapp-runtime.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-27-webmcp-miniapp-runtime.md
@@ -1,0 +1,31 @@
+# 2026-08-27 — 全量 WebMCP MiniApp 架构升级
+
+## 用户要求
+
+所有 Fabushi MiniApp 必须内置 WebMCP；当前打开的小程序由 Mahayana 直接发现并调用其 Tool。全球法布施等需要后台运行的能力继续由 Rust/Native Runtime 承担，WebMCP 作为前台 Agent 控制面，不得把长任务生命周期绑定到网页。
+
+## 目标架构
+
+```text
+Mahayana Agent
+  ├─ 当前 MiniApp 打开 -> WebMCP -> same Tool contract -> Rust/Native/Remote executor
+  └─ 页面关闭/后台任务 -> Mahayana Host Tool -> same Tool contract -> Rust/Native executor
+
+MiniApp UI button -> same Tool contract -> same executor
+Slash command      -> Tool metadata projection
+```
+
+## 强制要求
+
+- 每个 MiniApp 页面必须暴露 WebMCP Tool。
+- Tool 名称、schema、annotations 以真实 Tool catalog 为唯一事实源，不维护第二份 WebMCP 映射。
+- 写入、破坏性、open-world Tool 保留现有确认与权限策略。
+- WebMCP 不替代 Rust 后台 Job、队列、数据库、系统能力、恢复能力。
+- 页面销毁时 WebMCP Tool 必须注销；已启动 Rust Job 不得因此停止。
+- 浏览器/WebView 未原生实现 WebMCP 时，Fabushi Host 提供兼容 registry/bridge；一旦原生可用优先标准接口。
+- 移动 App 主壳继续保持 SwiftUI/Compose；仅 MiniApp surface 可使用受控 WebView/WKWebView，禁止退回 WebView 主应用壳。
+- 新 MiniApp 发布/生成流程必须包含 WebMCP 验收。
+
+## 发布要求
+
+通过 PR 合并到 canonical `main`，执行 exact-main packaged desktop/mobile E2E，随后发布严格递增的新版本 GitHub Release。

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -7,7 +7,7 @@ use mahayana_host_protocol::{
 use mahayana_js_runtime::{DeepSeekJsHost, scan_package_compatibility};
 use mahayana_native_engine::ProcessExecution;
 use mahayana_plugin_runtime::{
-    ExternalReleaseManifest, InstalledPluginPointer, PermissionManager, PluginInstaller,
+    ExternalReleaseManifest, InstalledPluginPointer, PermissionManager, PluginInstaller, PluginState,
 };
 use mahayana_product::MahayanaProductClient;
 use serde::{Deserialize, Serialize};
@@ -148,6 +148,7 @@ impl AppHost {
             "runtime.start" => self.start_runtime(params),
             "runtime.stop" => self.stop_runtime(params),
             "runtime.tools" => self.runtime_tools(),
+            "runtime.call" => self.runtime_call(params),
             other => Err(AppHostError::InvalidRequest(format!(
                 "unknown method {other}"
             ))),
@@ -718,6 +719,39 @@ impl AppHost {
             .map_err(|error| AppHostError::Operation(error.to_string()))?;
         serde_json::to_value(tools).map_err(|error| AppHostError::Operation(error.to_string()))
     }
+
+    fn runtime_call(&self, params: Value) -> Result<Value, AppHostError> {
+        let plugin_id = string_param(&params, "pluginId")?;
+        let name = string_param(&params, "name")?;
+        let arguments = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        if !arguments.is_object() {
+            return Err(AppHostError::InvalidRequest(
+                "runtime.call arguments must be an object".into(),
+            ));
+        }
+        let host = self
+            .js
+            .lock()
+            .map_err(|_| AppHostError::Operation("JavaScript host lock poisoned".into()))?;
+        if host.plugin_state(plugin_id) != Some(PluginState::Active) {
+            return Err(AppHostError::Operation(format!(
+                "plugin {plugin_id} runtime is not active"
+            )));
+        }
+        let tools = host
+            .registered_tools()
+            .map_err(|error| AppHostError::Operation(error.to_string()))?;
+        if !tools.iter().any(|candidate| candidate == name) {
+            return Err(AppHostError::Operation(format!(
+                "tool {name} is not registered in the active runtime"
+            )));
+        }
+        host.call_tool_json(name, &arguments)
+            .map_err(|error| AppHostError::Operation(error.to_string()))
+    }
 }
 
 fn configured_feature_host_mode() -> Result<AppHostFeatureMode, AppHostError> {
@@ -783,7 +817,7 @@ fn create_feature_host(
             == Ok("local-docker")
         {
             ProcessExecution::LocalDocker {
-                docker_path: std::env::var_os("MAHAYANA_DOCKER_BIN")
+                docker_path: std::env::var_os("DOCKER_PATH")
                     .map(PathBuf::from)
                     .unwrap_or_else(|| PathBuf::from("docker")),
                 image: std::env::var("MAHAYANA_DOCKER_IMAGE").unwrap_or_default(),

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -817,7 +817,7 @@ fn create_feature_host(
             == Ok("local-docker")
         {
             ProcessExecution::LocalDocker {
-                docker_path: std::env::var_os("DOCKER_PATH")
+                docker_path: std::env::var_os("MAHAYANA_DOCKER_BIN")
                     .map(PathBuf::from)
                     .unwrap_or_else(|| PathBuf::from("docker")),
                 image: std::env::var("MAHAYANA_DOCKER_IMAGE").unwrap_or_default(),

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -7,7 +7,8 @@ use mahayana_host_protocol::{
 use mahayana_js_runtime::{DeepSeekJsHost, scan_package_compatibility};
 use mahayana_native_engine::ProcessExecution;
 use mahayana_plugin_runtime::{
-    ExternalReleaseManifest, InstalledPluginPointer, PermissionManager, PluginInstaller, PluginState,
+    ExternalReleaseManifest, InstalledPluginPointer, PermissionManager, PluginInstaller,
+    PluginState,
 };
 use mahayana_product::MahayanaProductClient;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## FAB-P0001 / M8-WEBMCP-001

Makes **WebMCP the mandatory foreground Agent interface for all MiniApps** while keeping Rust/Native as the durable backend runtime.

### Implemented
- current WebMCP draft adapter + compatibility fallback in `@fabushi/mcp-app-sdk`;
- hosted MiniApps: `tools/list -> WebMCP -> tools/call` with no second command mapping;
- Marketplace/BotFather WebMCP admission policy for future MiniApps;
- Rust Host `runtime.call` for active local portable runtimes;
- desktop installed MiniApp WebMCP injection with per-document nonce, app-scoped Tool Contract and native approval;
- Android Compose main shell + local-first controlled WebView WebMCP surface + native approval + Rust call;
- iOS SwiftUI main shell + local-first WKWebView WebMCP surface + native approval + Rust call;
- desktop/Android/iOS WebMCP user-journey assertions;
- version 1.0.4 metadata aligned across canonical/desktop/mobile/iOS;
- project source, ADR, task and evidence records updated.

### Security/lifecycle
- Tool exposure is scoped to the current MiniApp contract;
- mutating/destructive tools require host/native approval;
- hosted mobile pages cannot invoke the local Native WebMCP bridge;
- closing a MiniApp surface tears down foreground WebMCP registration but does **not** stop Rust background runtime/jobs.

### Open-source-first
Reviewed the WebMCP Community Group draft/repository, OpenAI Site Tools/WebMCP product model, and MCP/MCP Apps. No upstream source code was copied; Fabushi adapts the standard to its existing Tool Contract, MCP transports, Electron bridge and Rust Host.

### Remaining closure gates
- latest required PR checks green;
- protected `main` merge and canonical readback;
- exact-main packaged Electron/Android/iOS simulated-user E2E + evidence bundles;
- GitHub Release 1.0.4 with updater-compatible desktop assets and mobile build artifacts.

Project record: `projects/telegram-fabushi-integration/management/tasks/M8-WEBMCP-001-webmcp-miniapp-runtime.md`