### PR TITLE
fix(desktop): isolate Mahayana observers from Messenger DOM

### DIFF
--- a/desktop/src/mahayana-agent-inline-compat.ts
+++ b/desktop/src/mahayana-agent-inline-compat.ts
@@ -7,10 +7,7 @@ const INLINE_TEST_ID_ALIASES: Record<string, string> = {
   'agent-inline-step': 'agent-step',
 };
 
-function quarantineLegacyWorkbench(): void {
-  const portal = document.getElementById(LEGACY_WORKBENCH_PORTAL_ID);
-  if (!portal) return;
-
+function quarantineLegacyWorkbench(portal: HTMLElement): void {
   // The legacy Workbench remains mounted because it owns avatar state and the
   // self-hosted Bot submit bridge. Its transcript projection is superseded by
   // the inline report, so keep it out of both layout and test/accessibility
@@ -24,18 +21,11 @@ function quarantineLegacyWorkbench(): void {
   });
 }
 
-function exposeInlineReportContracts(): void {
-  const portal = document.getElementById(INLINE_REPORT_PORTAL_ID);
-  if (!portal) return;
-
+function exposeInlineReportContracts(portal: HTMLElement): void {
   // Keep the long-lived acceptance contract while the visual implementation
   // moves from a separate card to an inline Codex/Grok-style transcript.
   if (portal.style.display !== 'block') portal.style.display = 'block';
   if (portal.style.width !== '100%') portal.style.width = '100%';
-  // MutationObserver below watches data-testid changes. Never write an
-  // identical value here: setAttribute() still queues an attribute mutation in
-  // Chromium, which would otherwise keep this observer in a microtask loop and
-  // starve the Messenger login/workspace transition.
   if (portal.getAttribute('data-testid') !== 'agent-workbench') {
     portal.setAttribute('data-testid', 'agent-workbench');
   }
@@ -53,37 +43,75 @@ function exposeInlineReportContracts(): void {
   });
 }
 
-function normalizeAgentPresentationContracts(): void {
-  quarantineLegacyWorkbench();
-  exposeInlineReportContracts();
-}
-
 export function installMahayanaAgentInlineCompatibility(): () => void {
-  if (typeof window === 'undefined') return () => {};
+  if (typeof window === 'undefined' || typeof document === 'undefined') return () => {};
 
-  let normalizing = false;
-  const normalize = () => {
-    if (normalizing) return;
-    normalizing = true;
-    try {
-      normalizeAgentPresentationContracts();
-    } finally {
-      normalizing = false;
-    }
+  let legacyPortal: HTMLElement | null = null;
+  let inlinePortal: HTMLElement | null = null;
+  let legacyObserver: MutationObserver | null = null;
+  let inlineObserver: MutationObserver | null = null;
+
+  const bindLegacyPortal = () => {
+    const next = document.getElementById(LEGACY_WORKBENCH_PORTAL_ID);
+    if (next === legacyPortal) return;
+    legacyObserver?.disconnect();
+    legacyObserver = null;
+    legacyPortal = next;
+    if (!legacyPortal) return;
+
+    quarantineLegacyWorkbench(legacyPortal);
+    legacyObserver = new MutationObserver(() => {
+      if (legacyPortal?.isConnected) quarantineLegacyWorkbench(legacyPortal);
+    });
+    legacyObserver.observe(legacyPortal, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-testid'],
+    });
   };
 
-  const observer = new MutationObserver((records) => {
-    if (records.some((record) => record.type === 'childList' || record.attributeName === 'data-testid')) {
-      normalize();
-    }
-  });
-  observer.observe(document.body, {
+  const bindInlinePortal = () => {
+    const next = document.getElementById(INLINE_REPORT_PORTAL_ID);
+    if (next === inlinePortal) return;
+    inlineObserver?.disconnect();
+    inlineObserver = null;
+    inlinePortal = next;
+    if (!inlinePortal) return;
+
+    exposeInlineReportContracts(inlinePortal);
+    inlineObserver = new MutationObserver(() => {
+      if (inlinePortal?.isConnected) exposeInlineReportContracts(inlinePortal);
+    });
+    inlineObserver.observe(inlinePortal, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-testid'],
+    });
+  };
+
+  const bindPortals = () => {
+    bindLegacyPortal();
+    bindInlinePortal();
+  };
+
+  // Portal nodes are created by the React projections after the Messenger has
+  // committed. Keep one deliberately cheap discovery observer on the document:
+  // it watches only node insertion/removal and never scans or rewrites ordinary
+  // Messenger test IDs. All compatibility mutations are handled by observers
+  // scoped to the two Mahayana portals. This prevents chat/message churn from
+  // monopolising Chromium's mutation microtask checkpoint.
+  const discoveryObserver = new MutationObserver(bindPortals);
+  discoveryObserver.observe(document.body, {
     childList: true,
     subtree: true,
-    attributes: true,
-    attributeFilter: ['data-testid'],
   });
-  normalize();
+  bindPortals();
 
-  return () => observer.disconnect();
+  return () => {
+    discoveryObserver.disconnect();
+    legacyObserver?.disconnect();
+    inlineObserver?.disconnect();
+  };
 }

--- a/desktop/src/mahayana-agent-transcript-semantics.ts
+++ b/desktop/src/mahayana-agent-transcript-semantics.ts
@@ -1,3 +1,4 @@
+const REPORT_PORTAL_ID = 'mahayana-agent-inline-report-portal';
 const RUN_SELECTOR = '[data-testid="agent-run"]';
 const OUTPUT_SELECTOR = '[data-testid="agent-output"]';
 
@@ -33,7 +34,9 @@ function normalizeProjectedParagraph(paragraph: ProjectedParagraph): void {
   if (paragraph.dataset.agentRenderedText !== text) {
     paragraph.dataset.agentRenderedText = text;
   }
-  paragraph.setAttribute('aria-label', `Agent 运行${context}：${text}`);
+  if (paragraph.getAttribute('aria-label') !== `Agent 运行${context}：${text}`) {
+    paragraph.setAttribute('aria-label', `Agent 运行${context}：${text}`);
+  }
 
   // The canonical selectable transcript remains the ordinary Messenger
   // message. The Workbench is a visual projection of the same content. Keep
@@ -43,35 +46,60 @@ function normalizeProjectedParagraph(paragraph: ProjectedParagraph): void {
   if (currentText) paragraph.replaceChildren();
 }
 
-function normalizeProjectedTranscript(): void {
-  document.querySelectorAll<HTMLParagraphElement>(`${RUN_SELECTOR} p`).forEach((paragraph) => {
+function normalizeProjectedTranscript(portal: HTMLElement): void {
+  portal.querySelectorAll<HTMLParagraphElement>(`${RUN_SELECTOR} p`).forEach((paragraph) => {
     normalizeProjectedParagraph(paragraph as ProjectedParagraph);
   });
 }
 
 export function installMahayanaAgentTranscriptSemantics(): () => void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return () => {};
+
+  let portal: HTMLElement | null = null;
+  let portalObserver: MutationObserver | null = null;
   let normalizing = false;
+
   const normalize = () => {
-    if (normalizing) return;
+    if (normalizing || !portal?.isConnected) return;
     normalizing = true;
     try {
-      // MutationObserver callbacks run in the same microtask checkpoint as the
-      // React commit. Normalize immediately rather than waiting for the next
-      // animation frame; accessibility/search consumers and Playwright can
-      // inspect the DOM before that later frame.
-      normalizeProjectedTranscript();
+      normalizeProjectedTranscript(portal);
     } finally {
       normalizing = false;
     }
   };
 
-  const observer = new MutationObserver(normalize);
-  observer.observe(document.body, {
+  const bindPortal = () => {
+    const next = document.getElementById(REPORT_PORTAL_ID);
+    if (next === portal) return;
+    portalObserver?.disconnect();
+    portalObserver = null;
+    portal = next;
+    if (!portal) return;
+
+    normalize();
+    portalObserver = new MutationObserver(normalize);
+    portalObserver.observe(portal, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+  };
+
+  // The report portal is inserted beside the matching assistant message after
+  // React commits the Messenger. Discover only portal creation/removal at the
+  // document level; all transcript normalization stays inside that portal so
+  // unrelated messages, search results and navigation updates do not trigger a
+  // full agent transcript scan.
+  const discoveryObserver = new MutationObserver(bindPortal);
+  discoveryObserver.observe(document.body, {
     childList: true,
-    characterData: true,
     subtree: true,
   });
-  normalize();
+  bindPortal();
 
-  return () => observer.disconnect();
+  return () => {
+    discoveryObserver.disconnect();
+    portalObserver?.disconnect();
+  };
 }


### PR DESCRIPTION
## Fix

The release-grade Electron E2E on main showed the Messenger visibly rendered while Playwright could no longer resolve stable Messenger contracts such as `messenger-workspace`, `peer-*`, or even complete screenshots/interactions. The remaining Mahayana compatibility and transcript observers were still attached to the entire `document.body`, so every chat/navigation mutation synchronously rescanned the agent projection during Chromium's mutation microtask checkpoint.

This change:

- keeps a cheap document-level child-list observer only to discover/rebind the two Mahayana portal nodes;
- moves compatibility `data-testid` normalization onto observers scoped to the legacy Workbench and inline-report portals;
- moves projected transcript normalization onto the inline-report portal only;
- preserves the existing Codex/Grok-style agent test contracts, approval/interrupt/resume behavior, and canonical Messenger transcript semantics;
- prevents unrelated Messenger messages, navigation, search, and dynamic avatar updates from triggering agent subtree scans.

## Release blocker addressed

Main run #1025 built/sign/notarized successfully but failed the real-host and packaged user-journey E2E with 18/21 Linux tests failing and equivalent Windows/macOS interaction timeouts. Diagnostics showed the full Messenger UI rendered, indicating renderer starvation/DOM observer churn rather than a missing Messenger shell.

## Validation

PR CI should run TypeScript, renderer, architecture/UI contracts, and the desktop fast path. After merge, the canonical main delivery gate will rerun the real Host and packaged E2E before publishing the next Desktop release.