### PR TITLE
feat(android): add manual GitHub Release updater

### DIFF
--- a/.github/workflows/native-android-release.yml
+++ b/.github/workflows/native-android-release.yml
@@ -1,0 +1,254 @@
+name: Native Android GitHub release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+  checks: read
+
+concurrency:
+  group: native-android-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish signed Android APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+    steps:
+      - name: Require manual dispatch from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != 'refs/heads/main' ]; then
+            echo 'Android GitHub releases may only be dispatched from main.' >&2
+            exit 1
+          fi
+
+      - name: Checkout immutable main source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Verify canonical architecture
+        run: bash .github/scripts/assert-native-electron-canonical.sh
+
+      - id: source
+        name: Require all Android release gates on this main SHA
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ github.sha }}
+          RELEASE_TARGET: android
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          bash .github/scripts/require-release-source-gates.sh
+          echo "sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - id: release
+        name: Resolve Android release identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_name="$(jq -r '.version' app-version.json)"
+          if ! [[ "$version_name" =~ ^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$ ]]; then
+            echo "Invalid app-version.json version: '$version_name'." >&2
+            exit 1
+          fi
+
+          # Keep Android versionCode monotonic without requiring a manual input.
+          # YYDDDHHMM remains below Android's 2.1B ceiling through 2099.
+          version_code="$(date -u +%y%j%H%M)"
+          if ! [[ "$version_code" =~ ^[1-9][0-9]*$ ]] || [ "$version_code" -gt 2100000000 ]; then
+            echo "Resolved Android versionCode is invalid: $version_code" >&2
+            exit 1
+          fi
+
+          release_tag="android-v${version_name}-${version_code}"
+          apk_name="fabushi-android-${version_name}-${version_code}.apk"
+          echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
+          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "apk_name=$apk_name" >> "$GITHUB_OUTPUT"
+          {
+            echo '## Native Android GitHub release'
+            echo
+            echo "- Source: ${{ steps.source.outputs.short_sha }}"
+            echo "- Version: $version_name ($version_code)"
+            echo "- Tag: $release_tag"
+            echo '- Required gates: CI result + Native mobile result'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Refuse to replace an existing immutable release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag='${{ steps.release.outputs.release_tag }}'
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists; refusing to mutate it." >&2
+            exit 1
+          fi
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          cmdline-tools-version: '14742923'
+          packages: 'platform-tools'
+
+      - name: Install Android 17 SDK and NDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          available_packages="$(sdkmanager --list --channel=3)"
+          platform_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/platforms;android-(37([.]0)?|CinnamonBun)/ && !found {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; found=1}')"
+          build_tools_package="$(printf '%s\n' "$available_packages" | awk -F'|' '/build-tools;37[.]/ && !found {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; found=1}')"
+          test -n "$platform_package" && test -n "$build_tools_package"
+          sdkmanager --channel=3 "$platform_package" "$build_tools_package" 'ndk;28.2.13676358'
+          if [ ! -e "$ANDROID_HOME/platforms/android-37" ]; then
+            installed_platform="$(find "$ANDROID_HOME/platforms" -maxdepth 1 -type d \( -name 'android-37*' -o -name 'android-CinnamonBun*' \) -print -quit)"
+            test -n "$installed_platform"
+            ln -s "$installed_platform" "$ANDROID_HOME/platforms/android-37"
+          fi
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Restore Android release Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: third_party/mahayana/mahayana-rs -> target
+          shared-key: github-release-android-v1
+
+      - id: cargo-ndk-cache
+        name: Restore cargo-ndk
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cargo/bin/cargo-ndk
+          key: github-release-cargo-ndk-${{ runner.os }}-${{ runner.arch }}-v1
+
+      - name: Install cargo-ndk on cache miss
+        if: steps.cargo-ndk-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-ndk --locked
+
+      - name: Save cargo-ndk on cache miss
+        if: steps.cargo-ndk-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cargo/bin/cargo-ndk
+          key: github-release-cargo-ndk-${{ runner.os }}-${{ runner.arch }}-v1
+
+      - name: Build native Rust JNI libraries
+        working-directory: third_party/mahayana/mahayana-rs
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
+          ANDROID_NDK_ROOT: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
+        run: cargo ndk -t arm64-v8a -t x86_64 -o ../../../mobile/android/app/src/main/jniLibs build --release -p mahayana-app-host-mobile
+
+      - name: Install Android signing key
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!name:-}" ]; then
+              echo "$name is required for a GitHub release APK." >&2
+              exit 1
+            fi
+          done
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/fabushi-release.jks"
+
+      - name: Restore Gradle dependency and build cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build signed GitHub self-updating APK
+        working-directory: mobile/android
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/fabushi-release.jks
+        run: >-
+          ./gradlew --no-daemon --build-cache assembleGithubRelease
+          -PversionName=${{ steps.release.outputs.version_name }}
+          -PversionCode=${{ steps.release.outputs.version_code }}
+
+      - id: package
+        name: Verify, checksum and stage Android update package
+        shell: bash
+        run: |
+          set -euo pipefail
+          apk='mobile/android/app/build/outputs/apk/githubRelease/app-githubRelease.apk'
+          test -s "$apk"
+
+          build_tools="$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d -print | sort -V | tail -n 1)"
+          test -x "$build_tools/aapt"
+          test -x "$build_tools/apksigner"
+          badging="$($build_tools/aapt dump badging "$apk")"
+          printf '%s\n' "$badging" | grep -F "package: name='com.ombhrum.fabushi'" >/dev/null
+          printf '%s\n' "$badging" | grep -F "versionCode='${{ steps.release.outputs.version_code }}'" >/dev/null
+          printf '%s\n' "$badging" | grep -F "versionName='${{ steps.release.outputs.version_name }}'" >/dev/null
+          "$build_tools/apksigner" verify --verbose --print-certs "$apk" > "$RUNNER_TEMP/apksigner.txt"
+
+          out="$RUNNER_TEMP/android-github-release"
+          mkdir -p "$out"
+          apk_name='${{ steps.release.outputs.apk_name }}'
+          cp "$apk" "$out/$apk_name"
+          apk_sha256="$(sha256sum "$out/$apk_name" | awk '{print $1}')"
+          apk_size="$(stat -c '%s' "$out/$apk_name")"
+
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag '${{ steps.release.outputs.release_tag }}' \
+            --arg version '${{ steps.release.outputs.version_name }}' \
+            --argjson versionCode '${{ steps.release.outputs.version_code }}' \
+            --arg sourceSha '${{ steps.source.outputs.sha }}' \
+            --arg apk "$apk_name" \
+            --arg sha256 "$apk_sha256" \
+            --argjson size "$apk_size" \
+            '{schemaVersion:1,repository:$repository,tag:$tag,version:$version,versionCode:$versionCode,sourceSha:$sourceSha,apk:$apk,sha256:$sha256,size:$size}' \
+            > "$out/fabushi-android-update.json"
+
+          (cd "$out" && sha256sum "$apk_name" fabushi-android-update.json > SHA256SUMS.txt)
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      - name: Preserve signed Android package as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-android-github-${{ steps.release.outputs.version_name }}-${{ steps.release.outputs.version_code }}
+          path: ${{ steps.package.outputs.out }}
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 6
+
+      - name: Publish immutable Android GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag='${{ steps.release.outputs.release_tag }}'
+          out='${{ steps.package.outputs.out }}'
+          mapfile -d '' assets < <(find "$out" -type f -print0 | sort -z)
+          gh release create "$tag" "${assets[@]}" \
+            --target '${{ steps.source.outputs.sha }}' \
+            --title 'Fabushi Android ${{ steps.release.outputs.version_name }} (${{ steps.release.outputs.version_code }})' \
+            --notes 'Manual GitHub Android release from main after CI result and Native mobile result passed for the exact source SHA. The APK includes the GitHub self-update channel.' \
+            --latest=false

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -15,6 +15,7 @@ android {
         versionName = (project.findProperty('versionName') ?: '0.1.0').toString()
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables { useSupportLibrary true }
+        buildConfigField 'boolean', 'GITHUB_UPDATES_ENABLED', 'false'
     }
 
     buildFeatures {
@@ -51,6 +52,12 @@ android {
             if (releaseKeystore) signingConfig signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+        githubRelease {
+            initWith release
+            matchingFallbacks = ['release']
+            buildConfigField 'boolean', 'GITHUB_UPDATES_ENABLED', 'true'
+            if (releaseKeystore) signingConfig signingConfigs.release
+        }
     }
 
     testOptions {
@@ -68,6 +75,7 @@ dependencies {
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.core:core-ktx:1.17.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.10.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.10.0'

--- a/mobile/android/app/src/githubRelease/AndroidManifest.xml
+++ b/mobile/android/app/src/githubRelease/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <application>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.updates"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/update_file_paths" />
+        </provider>
+    </application>
+</manifest>

--- a/mobile/android/app/src/githubRelease/res/xml/update_file_paths.xml
+++ b/mobile/android/app/src/githubRelease/res/xml/update_file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="updates" path="updates/" />
+</paths>

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/AndroidUpdateViewModel.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/AndroidUpdateViewModel.kt
@@ -1,0 +1,535 @@
+package com.ombhrum.fabushi
+
+import android.app.Application
+import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.core.content.FileProvider
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+enum class AndroidUpdatePhase {
+    DISABLED,
+    CHECKING,
+    UP_TO_DATE,
+    AVAILABLE,
+    DOWNLOADING,
+    WAITING_FOR_PERMISSION,
+    INSTALLING,
+    ERROR,
+}
+
+data class AndroidUpdateUiState(
+    val phase: AndroidUpdatePhase,
+    val currentVersion: String,
+    val currentVersionCode: Long = BuildConfig.VERSION_CODE.toLong(),
+    val availableVersion: String? = null,
+    val availableVersionCode: Long? = null,
+    val progressPercent: Int? = null,
+    val message: String? = null,
+)
+
+internal data class AndroidUpdateCandidate(
+    val version: String,
+    val versionCode: Long,
+    val tag: String,
+    val apkName: String,
+    val apkUrl: String,
+    val sha256: String,
+    val size: Long,
+    val notes: String?,
+)
+
+object AndroidVersion {
+    private data class Parsed(val core: List<Long>, val preRelease: List<String>)
+
+    fun compare(left: String, right: String): Int {
+        val leftParsed = parse(left)
+        val rightParsed = parse(right)
+        val count = maxOf(leftParsed.core.size, rightParsed.core.size)
+        repeat(count) { index ->
+            val lhs = leftParsed.core.getOrElse(index) { 0L }
+            val rhs = rightParsed.core.getOrElse(index) { 0L }
+            if (lhs != rhs) return lhs.compareTo(rhs)
+        }
+
+        if (leftParsed.preRelease.isEmpty() && rightParsed.preRelease.isNotEmpty()) return 1
+        if (leftParsed.preRelease.isNotEmpty() && rightParsed.preRelease.isEmpty()) return -1
+        val preCount = maxOf(leftParsed.preRelease.size, rightParsed.preRelease.size)
+        repeat(preCount) { index ->
+            val lhs = leftParsed.preRelease.getOrNull(index) ?: return -1
+            val rhs = rightParsed.preRelease.getOrNull(index) ?: return 1
+            val lhsNumber = lhs.toLongOrNull()
+            val rhsNumber = rhs.toLongOrNull()
+            val result = when {
+                lhsNumber != null && rhsNumber != null -> lhsNumber.compareTo(rhsNumber)
+                lhsNumber != null -> -1
+                rhsNumber != null -> 1
+                else -> lhs.compareTo(rhs, ignoreCase = true)
+            }
+            if (result != 0) return result
+        }
+        return 0
+    }
+
+    fun isNewer(
+        remoteVersion: String,
+        remoteVersionCode: Long,
+        currentVersion: String,
+        currentVersionCode: Long,
+    ): Boolean {
+        val versionResult = compare(remoteVersion, currentVersion)
+        return versionResult > 0 || (versionResult == 0 && remoteVersionCode > currentVersionCode)
+    }
+
+    private fun parse(value: String): Parsed {
+        val normalized = value.trim().removePrefix("v").substringBefore('+')
+        val pieces = normalized.split('-', limit = 2)
+        val core = pieces.firstOrNull().orEmpty().split('.')
+            .filter { it.isNotBlank() }
+            .map { it.toLongOrNull() ?: 0L }
+            .ifEmpty { listOf(0L) }
+        val preRelease = pieces.getOrNull(1)?.split('.')?.filter { it.isNotBlank() }.orEmpty()
+        return Parsed(core, preRelease)
+    }
+}
+
+class AndroidUpdateViewModel(application: Application) : AndroidViewModel(application) {
+    companion object {
+        private const val RELEASES_API = "https://api.github.com/repos/bhrumom/fabushi/releases?per_page=100"
+        private const val UPDATE_MANIFEST_NAME = "fabushi-android-update.json"
+        private const val REPOSITORY = "bhrumom/fabushi"
+        private const val UPDATE_CHECK_MIN_INTERVAL_MS = 60_000L
+        private const val UPDATE_FOREGROUND_INTERVAL_MS = 5 * 60_000L
+        private const val STARTUP_DELAY_MS = 4_000L
+        private const val MAX_METADATA_BYTES = 2 * 1024 * 1024
+        private const val MAX_MANIFEST_BYTES = 128 * 1024
+        private const val MAX_APK_BYTES = 768L * 1024L * 1024L
+        private val APK_NAME = Regex("^[A-Za-z0-9._-]+[.]apk$")
+        private val SHA256 = Regex("^[a-f0-9]{64}$")
+    }
+
+    private val applicationContext = getApplication<Application>()
+    private val updatesEnabled = BuildConfig.GITHUB_UPDATES_ENABLED && !BuildConfig.DEBUG
+    private val currentVersion = BuildConfig.VERSION_NAME
+    private val currentVersionCode = BuildConfig.VERSION_CODE.toLong()
+    private val _state = MutableStateFlow(
+        AndroidUpdateUiState(
+            phase = if (updatesEnabled) AndroidUpdatePhase.CHECKING else AndroidUpdatePhase.DISABLED,
+            currentVersion = currentVersion,
+            currentVersionCode = currentVersionCode,
+            message = if (updatesEnabled) "准备检查 GitHub Release…" else null,
+        ),
+    )
+    val state: StateFlow<AndroidUpdateUiState> = _state.asStateFlow()
+
+    private var candidate: AndroidUpdateCandidate? = null
+    private var pendingApk: File? = null
+    private var awaitingInstallPermission = false
+    private var checkJob: Job? = null
+    private var downloadJob: Job? = null
+    private var foregroundJob: Job? = null
+    private var lastCheckAtMs = 0L
+
+    fun setForeground(foreground: Boolean) {
+        if (!updatesEnabled) return
+        if (!foreground) {
+            foregroundJob?.cancel()
+            foregroundJob = null
+            return
+        }
+        if (awaitingInstallPermission && canInstallPackages()) {
+            pendingApk?.takeIf(File::exists)?.let(::requestPackageInstall)
+        }
+        if (foregroundJob?.isActive == true) return
+        foregroundJob = viewModelScope.launch {
+            if (lastCheckAtMs == 0L) delay(STARTUP_DELAY_MS)
+            while (isActive) {
+                checkForUpdates()
+                delay(UPDATE_FOREGROUND_INTERVAL_MS)
+            }
+        }
+    }
+
+    fun checkForUpdates(force: Boolean = false) {
+        if (!updatesEnabled || awaitingInstallPermission || pendingApk != null) return
+        if (downloadJob?.isActive == true || checkJob?.isActive == true) return
+        val now = System.currentTimeMillis()
+        if (!force && now - lastCheckAtMs < UPDATE_CHECK_MIN_INTERVAL_MS) return
+        lastCheckAtMs = now
+        checkJob = viewModelScope.launch {
+            _state.value = AndroidUpdateUiState(
+                phase = AndroidUpdatePhase.CHECKING,
+                currentVersion = currentVersion,
+                currentVersionCode = currentVersionCode,
+                message = "正在检查 Android GitHub Release…",
+            )
+            try {
+                val found = withContext(Dispatchers.IO) { findLatestUpdate() }
+                candidate = found
+                _state.value = if (found == null) {
+                    AndroidUpdateUiState(
+                        phase = AndroidUpdatePhase.UP_TO_DATE,
+                        currentVersion = currentVersion,
+                        currentVersionCode = currentVersionCode,
+                        message = "当前已是最新版本。",
+                    )
+                } else {
+                    AndroidUpdateUiState(
+                        phase = AndroidUpdatePhase.AVAILABLE,
+                        currentVersion = currentVersion,
+                        currentVersionCode = currentVersionCode,
+                        availableVersion = found.version,
+                        availableVersionCode = found.versionCode,
+                        message = found.notes?.takeIf { it.isNotBlank() },
+                    )
+                }
+            } catch (error: Exception) {
+                _state.value = AndroidUpdateUiState(
+                    phase = AndroidUpdatePhase.ERROR,
+                    currentVersion = currentVersion,
+                    currentVersionCode = currentVersionCode,
+                    message = "检查更新失败：${error.message ?: error.javaClass.simpleName}",
+                )
+            }
+        }
+    }
+
+    fun downloadAndInstall() {
+        if (!updatesEnabled || downloadJob?.isActive == true) return
+        val staged = pendingApk
+        if (staged != null && staged.exists()) {
+            requestPackageInstall(staged)
+            return
+        }
+        val release = candidate
+        if (release == null) {
+            checkForUpdates(force = true)
+            return
+        }
+
+        downloadJob = viewModelScope.launch {
+            try {
+                _state.value = AndroidUpdateUiState(
+                    phase = AndroidUpdatePhase.DOWNLOADING,
+                    currentVersion = currentVersion,
+                    currentVersionCode = currentVersionCode,
+                    availableVersion = release.version,
+                    availableVersionCode = release.versionCode,
+                    progressPercent = 0,
+                    message = "正在从 GitHub 下载已签名 APK…",
+                )
+                val apk = withContext(Dispatchers.IO) { downloadAndVerify(release) }
+                pendingApk = apk
+                requestPackageInstall(apk)
+            } catch (error: Exception) {
+                _state.value = AndroidUpdateUiState(
+                    phase = AndroidUpdatePhase.ERROR,
+                    currentVersion = currentVersion,
+                    currentVersionCode = currentVersionCode,
+                    availableVersion = release.version,
+                    availableVersionCode = release.versionCode,
+                    message = "更新失败：${error.message ?: error.javaClass.simpleName}",
+                )
+            }
+        }
+    }
+
+    private fun findLatestUpdate(): AndroidUpdateCandidate? {
+        val releases = JSONArray(httpGetText(RELEASES_API, MAX_METADATA_BYTES))
+        var best: AndroidUpdateCandidate? = null
+        for (index in 0 until releases.length()) {
+            val release = releases.optJSONObject(index) ?: continue
+            if (release.optBoolean("draft") || release.optBoolean("prerelease")) continue
+            val tag = release.optString("tag_name")
+            if (!tag.startsWith("android-v")) continue
+            val assets = release.optJSONArray("assets") ?: continue
+            val manifestAsset = assetNamed(assets, UPDATE_MANIFEST_NAME) ?: continue
+            val manifestUrl = trustedReleaseDownloadUrl(manifestAsset.optString("browser_download_url"))
+            val manifest = JSONObject(httpGetText(manifestUrl, MAX_MANIFEST_BYTES))
+            if (manifest.optInt("schemaVersion") != 1 || manifest.optString("repository") != REPOSITORY) continue
+            if (manifest.optString("tag") != tag) continue
+
+            val version = manifest.optString("version").trim()
+            val versionCode = manifest.optLong("versionCode", -1L)
+            val apkName = manifest.optString("apk").trim()
+            val sha256 = manifest.optString("sha256").trim().lowercase()
+            val manifestSize = manifest.optLong("size", -1L)
+            if (version.isEmpty() || versionCode <= 0L || !APK_NAME.matches(apkName) || !SHA256.matches(sha256)) continue
+            if (!AndroidVersion.isNewer(version, versionCode, currentVersion, currentVersionCode)) continue
+
+            val apkAsset = assetNamed(assets, apkName) ?: continue
+            val apkUrl = trustedReleaseDownloadUrl(apkAsset.optString("browser_download_url"))
+            val assetSize = apkAsset.optLong("size", -1L)
+            val size = if (manifestSize > 0L) manifestSize else assetSize
+            if (size <= 0L || size > MAX_APK_BYTES || (assetSize > 0L && assetSize != size)) continue
+
+            val candidate = AndroidUpdateCandidate(
+                version = version,
+                versionCode = versionCode,
+                tag = tag,
+                apkName = apkName,
+                apkUrl = apkUrl,
+                sha256 = sha256,
+                size = size,
+                notes = release.optString("body").trim().take(1200).ifEmpty { null },
+            )
+            if (best == null || AndroidVersion.isNewer(
+                    candidate.version,
+                    candidate.versionCode,
+                    best.version,
+                    best.versionCode,
+                )
+            ) {
+                best = candidate
+            }
+        }
+        return best
+    }
+
+    private fun assetNamed(assets: JSONArray, name: String): JSONObject? {
+        for (index in 0 until assets.length()) {
+            val asset = assets.optJSONObject(index) ?: continue
+            if (asset.optString("name") == name) return asset
+        }
+        return null
+    }
+
+    private fun trustedReleaseDownloadUrl(value: String): String {
+        val url = URL(value)
+        require(url.protocol == "https" && url.host == "github.com") { "Untrusted GitHub release URL." }
+        require(url.path.startsWith("/bhrumom/fabushi/releases/download/")) { "Unexpected GitHub release path." }
+        return url.toString()
+    }
+
+    private fun httpGetText(urlValue: String, maxBytes: Int): String {
+        val connection = openConnection(urlValue, "application/vnd.github+json, application/json")
+        try {
+            val status = connection.responseCode
+            require(status in 200..299) { "HTTP $status while reading update metadata." }
+            val declared = connection.contentLengthLong
+            require(declared < 0L || declared <= maxBytes.toLong()) { "Update metadata is too large." }
+            val output = ByteArrayOutputStream()
+            connection.inputStream.use { input ->
+                val buffer = ByteArray(16 * 1024)
+                var total = 0
+                while (true) {
+                    val count = input.read(buffer)
+                    if (count < 0) break
+                    total += count
+                    require(total <= maxBytes) { "Update metadata exceeded its size limit." }
+                    output.write(buffer, 0, count)
+                }
+            }
+            return output.toString(Charsets.UTF_8.name())
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun downloadAndVerify(release: AndroidUpdateCandidate): File {
+        val directory = File(applicationContext.cacheDir, "updates").apply { mkdirs() }
+        require(directory.isDirectory) { "Unable to create update cache directory." }
+        val target = File(directory, release.apkName)
+        if (target.exists() && target.length() == release.size && sha256File(target) == release.sha256) {
+            verifyDownloadedPackage(target, release)
+            return target
+        }
+        target.delete()
+        val temporary = File(directory, "${release.apkName}.download")
+        temporary.delete()
+
+        val connection = openConnection(release.apkUrl, "application/vnd.android.package-archive, application/octet-stream")
+        try {
+            val status = connection.responseCode
+            require(status in 200..299) { "HTTP $status while downloading the APK." }
+            val declared = connection.contentLengthLong
+            require(declared < 0L || declared == release.size) { "APK size changed before download." }
+            require(release.size <= MAX_APK_BYTES) { "APK exceeds the download size limit." }
+
+            val digest = MessageDigest.getInstance("SHA-256")
+            var copied = 0L
+            var lastPercent = -1
+            temporary.outputStream().buffered().use { output ->
+                connection.inputStream.buffered().use { input ->
+                    val buffer = ByteArray(64 * 1024)
+                    while (true) {
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        copied += count
+                        require(copied <= MAX_APK_BYTES && copied <= release.size) { "APK download exceeded its declared size." }
+                        digest.update(buffer, 0, count)
+                        output.write(buffer, 0, count)
+                        val percent = ((copied * 100L) / release.size).toInt().coerceIn(0, 100)
+                        if (percent != lastPercent) {
+                            lastPercent = percent
+                            _state.value = _state.value.copy(progressPercent = percent)
+                        }
+                    }
+                }
+            }
+            require(copied == release.size) { "APK download was incomplete." }
+            val actualSha256 = digest.digest().toHex()
+            require(actualSha256 == release.sha256) { "APK checksum verification failed." }
+            if (!temporary.renameTo(target)) {
+                temporary.copyTo(target, overwrite = true)
+                temporary.delete()
+            }
+            verifyDownloadedPackage(target, release)
+            return target
+        } catch (error: Exception) {
+            temporary.delete()
+            throw error
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun openConnection(urlValue: String, accept: String): HttpURLConnection {
+        return (URL(urlValue).openConnection() as HttpURLConnection).apply {
+            instanceFollowRedirects = true
+            connectTimeout = 15_000
+            readTimeout = 30_000
+            requestMethod = "GET"
+            setRequestProperty("Accept", accept)
+            setRequestProperty("User-Agent", "Fabushi-Android/${BuildConfig.VERSION_NAME}")
+        }
+    }
+
+    private fun sha256File(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().buffered().use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) break
+                digest.update(buffer, 0, count)
+            }
+        }
+        return digest.digest().toHex()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun verifyDownloadedPackage(file: File, release: AndroidUpdateCandidate) {
+        val packageManager = applicationContext.packageManager
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            PackageManager.GET_SIGNATURES
+        }
+        val archive = packageManager.getPackageArchiveInfo(file.absolutePath, flags)
+            ?: error("Downloaded APK is not a readable Android package.")
+        require(archive.packageName == applicationContext.packageName) { "Downloaded APK has the wrong package name." }
+        require(archive.versionName == release.version) { "Downloaded APK versionName does not match the release manifest." }
+        require(packageVersionCode(archive) == release.versionCode) { "Downloaded APK versionCode does not match the release manifest." }
+
+        val installed = packageManager.getPackageInfo(applicationContext.packageName, flags)
+        val installedSigners = signerDigests(installed)
+        val archiveSigners = signerDigests(archive)
+        require(installedSigners.isNotEmpty() && archiveSigners == installedSigners) {
+            "Downloaded APK signing identity does not match the installed app."
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun packageVersionCode(info: PackageInfo): Long {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) info.longVersionCode else info.versionCode.toLong()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun signerDigests(info: PackageInfo): Set<String> {
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.signingInfo?.apkContentsSigners.orEmpty()
+        } else {
+            info.signatures.orEmpty()
+        }
+        return signatures.map { signature ->
+            MessageDigest.getInstance("SHA-256").digest(signature.toByteArray()).toHex()
+        }.toSet()
+    }
+
+    private fun canInstallPackages(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.O || applicationContext.packageManager.canRequestPackageInstalls()
+    }
+
+    private fun requestPackageInstall(apk: File) {
+        val release = candidate ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !canInstallPackages()) {
+            awaitingInstallPermission = true
+            _state.value = AndroidUpdateUiState(
+                phase = AndroidUpdatePhase.WAITING_FOR_PERMISSION,
+                currentVersion = currentVersion,
+                currentVersionCode = currentVersionCode,
+                availableVersion = release.version,
+                availableVersionCode = release.versionCode,
+                message = "安装包已下载并验证。请允许全球法布施安装未知应用，返回后会自动继续。",
+            )
+            try {
+                applicationContext.startActivity(
+                    Intent(
+                        Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                        Uri.parse("package:${applicationContext.packageName}"),
+                    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                )
+            } catch (error: Exception) {
+                _state.value = _state.value.copy(
+                    phase = AndroidUpdatePhase.ERROR,
+                    message = "无法打开安装权限设置：${error.message ?: error.javaClass.simpleName}",
+                )
+            }
+            return
+        }
+
+        awaitingInstallPermission = false
+        val uri = FileProvider.getUriForFile(
+            applicationContext,
+            "${applicationContext.packageName}.updates",
+            apk,
+        )
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        try {
+            applicationContext.startActivity(intent)
+            _state.value = AndroidUpdateUiState(
+                phase = AndroidUpdatePhase.INSTALLING,
+                currentVersion = currentVersion,
+                currentVersionCode = currentVersionCode,
+                availableVersion = release.version,
+                availableVersionCode = release.versionCode,
+                message = "安装包已验证，系统安装器已打开。确认安装后 Android 会完成升级。",
+            )
+        } catch (error: Exception) {
+            _state.value = AndroidUpdateUiState(
+                phase = AndroidUpdatePhase.ERROR,
+                currentVersion = currentVersion,
+                currentVersionCode = currentVersionCode,
+                availableVersion = release.version,
+                availableVersionCode = release.versionCode,
+                message = "无法打开系统安装器：${error.message ?: error.javaClass.simpleName}",
+            )
+        }
+    }
+
+    private fun ByteArray.toHex(): String = joinToString("") { byte -> "%02x".format(byte) }
+}

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -37,6 +38,8 @@ object TestTags {
     const val PermissionDialog = "permission-dialog"
     const val PermissionApprove = "permission-approve"
     const val PermissionDeny = "permission-deny"
+    const val UpdateCard = "android-update-card"
+    const val UpdateAction = "android-update-action"
     fun plugin(id: String) = "plugin-$id"
     fun install(id: String) = "install-$id"
     fun open(id: String) = "open-$id"
@@ -51,6 +54,12 @@ fun FabushiScreen(
     onOpen: (MarketplacePlugin) -> Unit,
     onApprovePermissions: () -> Unit,
     onDenyPermissions: () -> Unit,
+    updateState: AndroidUpdateUiState = AndroidUpdateUiState(
+        phase = AndroidUpdatePhase.DISABLED,
+        currentVersion = BuildConfig.VERSION_NAME,
+    ),
+    onCheckUpdate: () -> Unit = {},
+    onInstallUpdate: () -> Unit = {},
 ) {
     state.permissionRequest?.let { request ->
         AlertDialog(
@@ -99,6 +108,54 @@ fun FabushiScreen(
                         modifier = Modifier.testTag(TestTags.RuntimeBadge).semantics { contentDescription = "Android native runtime" },
                         style = MaterialTheme.typography.labelMedium,
                     )
+                }
+            }
+
+            if (updateState.phase != AndroidUpdatePhase.DISABLED) {
+                item {
+                    Card(modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateCard)) {
+                        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            Text("应用更新", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                            Text(
+                                "当前版本 ${updateState.currentVersion} (${updateState.currentVersionCode})",
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                            val statusText = when (updateState.phase) {
+                                AndroidUpdatePhase.CHECKING -> "正在检查 GitHub Release…"
+                                AndroidUpdatePhase.UP_TO_DATE -> "已是最新版本"
+                                AndroidUpdatePhase.AVAILABLE -> "发现新版本 ${updateState.availableVersion} (${updateState.availableVersionCode})"
+                                AndroidUpdatePhase.DOWNLOADING -> "正在下载 ${updateState.progressPercent ?: 0}%"
+                                AndroidUpdatePhase.WAITING_FOR_PERMISSION -> "安装包已下载，等待安装权限"
+                                AndroidUpdatePhase.INSTALLING -> "系统安装器已打开"
+                                AndroidUpdatePhase.ERROR -> "更新检查或安装失败"
+                                AndroidUpdatePhase.DISABLED -> ""
+                            }
+                            if (statusText.isNotEmpty()) Text(statusText)
+                            updateState.message?.takeIf { it.isNotBlank() }?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+                            if (updateState.phase == AndroidUpdatePhase.DOWNLOADING) {
+                                val progress = (updateState.progressPercent ?: 0).coerceIn(0, 100) / 100f
+                                LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
+                            }
+                            when (updateState.phase) {
+                                AndroidUpdatePhase.AVAILABLE,
+                                AndroidUpdatePhase.WAITING_FOR_PERMISSION,
+                                AndroidUpdatePhase.INSTALLING,
+                                -> Button(
+                                    onClick = onInstallUpdate,
+                                    modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateAction),
+                                ) {
+                                    Text(if (updateState.phase == AndroidUpdatePhase.AVAILABLE) "下载并安装" else "继续安装")
+                                }
+                                AndroidUpdatePhase.UP_TO_DATE,
+                                AndroidUpdatePhase.ERROR,
+                                -> OutlinedButton(
+                                    onClick = onCheckUpdate,
+                                    modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateAction),
+                                ) { Text("检查更新") }
+                                else -> Unit
+                            }
+                        }
+                    }
                 }
             }
 

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 
 class MainActivity : ComponentActivity() {
     private val deepLinks = MutableSharedFlow<Uri>(replay = 1, extraBufferCapacity = 31)
+    private val updateModel: AndroidUpdateViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,6 +28,7 @@ class MainActivity : ComponentActivity() {
             MaterialTheme {
                 val model: MarketplaceViewModel = viewModel()
                 val state by model.state.collectAsState()
+                val updateState by updateModel.state.collectAsState()
                 var openedMiniApp by remember { mutableStateOf<MarketplacePlugin?>(null) }
                 LaunchedEffect(model) {
                     deepLinks.collect { uri -> model.handleDeepLink(uri) }
@@ -47,11 +50,24 @@ class MainActivity : ComponentActivity() {
                         onOpen = { openedMiniApp = it },
                         onApprovePermissions = model::approvePermissions,
                         onDenyPermissions = model::denyPermissions,
+                        updateState = updateState,
+                        onCheckUpdate = { updateModel.checkForUpdates(force = true) },
+                        onInstallUpdate = updateModel::downloadAndInstall,
                     )
                 }
             }
         }
         intent?.data?.let(::enqueueDeepLink)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        updateModel.setForeground(true)
+    }
+
+    override fun onStop() {
+        updateModel.setForeground(false)
+        super.onStop()
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/mobile/android/app/src/test/java/com/ombhrum/fabushi/AndroidVersionTest.kt
+++ b/mobile/android/app/src/test/java/com/ombhrum/fabushi/AndroidVersionTest.kt
@@ -1,0 +1,25 @@
+package com.ombhrum.fabushi
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidVersionTest {
+    @Test
+    fun newerSemanticVersionWinsEvenWithLowerBuildCode() {
+        assertTrue(AndroidVersion.isNewer("1.0.5", 1, "1.0.4", 999_999))
+        assertFalse(AndroidVersion.isNewer("1.0.3", 2_000_000, "1.0.4", 1))
+    }
+
+    @Test
+    fun sameVersionUsesMonotonicAndroidVersionCode() {
+        assertTrue(AndroidVersion.isNewer("1.0.4", 101, "1.0.4", 100))
+        assertFalse(AndroidVersion.isNewer("1.0.4", 100, "1.0.4", 100))
+    }
+
+    @Test
+    fun stableVersionSortsAfterPrerelease() {
+        assertTrue(AndroidVersion.compare("2.0.0", "2.0.0-beta.4") > 0)
+        assertTrue(AndroidVersion.compare("2.0.0-beta.10", "2.0.0-beta.2") > 0)
+    }
+}


### PR DESCRIPTION
## Summary
- add a manual `Native Android GitHub release` workflow that only runs from `main`
- require the exact source SHA to have both `CI result` and `Native mobile result` green before packaging
- build a separately signed `githubRelease` APK, emit a version/checksum manifest, and publish an immutable `android-v<version>-<versionCode>` GitHub Release
- add Android foreground/startup update checks matching the desktop cadence (startup + focus/foreground checks; no automatic download)
- when the user clicks update, download the APK, verify size/SHA-256/package/version/signing identity, then launch the Android system installer
- isolate `REQUEST_INSTALL_PACKAGES` and FileProvider to the GitHub-release build type so the Google Play build remains unaffected

## Notes
Android does not allow a normal third-party app to silently install an APK. The GitHub build automates download and verification and opens the system installer; Android still requires the platform-mandated user confirmation/unknown-source permission when applicable.

## Validation added
- unit coverage for Android version ordering
- release workflow validates package name/version and APK signature before publication
- runtime validates the downloaded APK against the installed signing identity before installation