### PR TITLE
feat(web): 全新 Mini App 应用市场与内容级搜索

### DIFF
--- a/frontend/apps/web/src/app/apps/[slug]/content/[contentId]/page.tsx
+++ b/frontend/apps/web/src/app/apps/[slug]/content/[contentId]/page.tsx
@@ -1,0 +1,278 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import {
+  ArrowRight,
+  BookOpen,
+  CalendarDays,
+  ChevronRight,
+  Clock3,
+  ExternalLink,
+  Search,
+} from "lucide-react";
+import { AppIcon } from "../../../../../components/marketplace/app-icon";
+import { AppInstallActions } from "../../../../../components/marketplace/app-install-actions";
+import styles from "../../../../../components/marketplace/marketplace.module.css";
+import {
+  getMarketplaceContent,
+  marketplaceContent,
+  type MarketplaceContentItem,
+} from "../../../../../lib/marketplace";
+import { siteHref, siteUrl } from "../../../../../lib/site-url";
+
+type ContentPageProps = {
+  params: Promise<{ slug: string; contentId: string }>;
+};
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return marketplaceContent.map(({ app, item }) => ({
+    slug: app.slug,
+    contentId: item.id,
+  }));
+}
+
+function contentTypeLabel(type: MarketplaceContentItem["type"]) {
+  switch (type) {
+    case "guide":
+      return "指南";
+    case "template":
+      return "模板";
+    case "collection":
+      return "内容集";
+    case "workflow":
+      return "工作流";
+    case "release":
+      return "版本说明";
+  }
+}
+
+export async function generateMetadata({ params }: ContentPageProps): Promise<Metadata> {
+  const { slug, contentId } = await params;
+  const result = getMarketplaceContent(slug, contentId);
+  if (!result) return {};
+
+  const { app, item } = result;
+  const title = `${item.title} | ${app.name} | Fabushi`;
+  const url = siteUrl(`/apps/${app.slug}/content/${item.id}`);
+
+  return {
+    title,
+    description: item.summary,
+    alternates: { canonical: url },
+    keywords: [app.name, contentTypeLabel(item.type), ...item.keywords],
+    openGraph: {
+      title,
+      description: item.summary,
+      url,
+      siteName: "Fabushi 应用市场",
+      locale: "zh_CN",
+      type: "article",
+      publishedTime: item.updatedAt,
+      modifiedTime: item.updatedAt,
+      tags: [...item.keywords],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: item.summary,
+    },
+  };
+}
+
+export default async function ContentPage({ params }: ContentPageProps) {
+  const { slug, contentId } = await params;
+  const result = getMarketplaceContent(slug, contentId);
+  if (!result) notFound();
+
+  const { app, item } = result;
+  const url = siteUrl(`/apps/${app.slug}/content/${item.id}`);
+  const relatedContent = [
+    ...app.content.filter((candidate) => candidate.id !== item.id).map((candidate) => ({ app, item: candidate })),
+    ...marketplaceContent.filter(
+      (candidate) => candidate.app.id !== app.id && candidate.item.keywords.some((keyword) => item.keywords.includes(keyword)),
+    ),
+    ...marketplaceContent.filter((candidate) => candidate.app.id !== app.id),
+  ]
+    .filter(
+      (candidate, index, values) =>
+        values.findIndex(
+          (value) => value.app.id === candidate.app.id && value.item.id === candidate.item.id,
+        ) === index,
+    )
+    .slice(0, 4);
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": item.type === "release" ? "TechArticle" : "Article",
+        "@id": `${url}#article`,
+        headline: item.title,
+        description: item.summary,
+        url,
+        datePublished: item.updatedAt,
+        dateModified: item.updatedAt,
+        articleSection: contentTypeLabel(item.type),
+        keywords: item.keywords.join(", "),
+        wordCount: item.body.join("").length,
+        author: {
+          "@type": "Organization",
+          name: app.developer,
+          url: siteUrl(`/apps/${app.slug}`),
+        },
+        publisher: {
+          "@type": "Organization",
+          name: "Fabushi",
+          url: siteUrl("/"),
+        },
+        isPartOf: {
+          "@type": "SoftwareApplication",
+          name: app.name,
+          url: siteUrl(`/apps/${app.slug}`),
+        },
+        mainEntityOfPage: url,
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "应用市场", item: siteUrl("/") },
+          { "@type": "ListItem", position: 2, name: app.name, item: siteUrl(`/apps/${app.slug}`) },
+          { "@type": "ListItem", position: 3, name: item.title, item: url },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <div className={styles.detailShell}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <header className={styles.detailHeader}>
+        <div className={styles.detailHeaderInner}>
+          <a className={styles.detailBrand} href={siteHref("/")}>
+            <span className={styles.brandMark}>法</span>
+            <span>Fabushi 内容搜索</span>
+          </a>
+          <nav className={styles.detailNav}>
+            <a href={siteHref("/")}>应用市场</a>
+            <a href={siteHref("/search")}>搜索内容</a>
+            <a href={siteHref(`/apps/${app.slug}`)}>{app.name}</a>
+            <a href={siteHref(`/miniapps/${app.id}`)}>打开应用</a>
+          </nav>
+        </div>
+      </header>
+
+      <main className={styles.detailMain}>
+        <nav className={styles.breadcrumbs} aria-label="面包屑">
+          <a href={siteHref("/")}>应用市场</a>
+          <ChevronRight />
+          <a href={siteHref(`/apps/${app.slug}`)}>{app.name}</a>
+          <ChevronRight />
+          <span>{item.title}</span>
+        </nav>
+
+        <div className={styles.articleLayout}>
+          <article className={styles.articleCard}>
+            <p className={styles.articleEyebrow}>
+              {app.name} · {contentTypeLabel(item.type)}
+            </p>
+            <h1>{item.title}</h1>
+            <p className={styles.articleSummary}>{item.summary}</p>
+            <div className={styles.articleMeta}>
+              <span><CalendarDays /> 更新于 {item.updatedAt}</span>
+              <span><Clock3 /> 阅读约 {item.readingMinutes} 分钟</span>
+              <span><BookOpen /> 内容 ID：{item.id}</span>
+            </div>
+
+            <div className={styles.articleBody}>
+              {item.body.map((paragraph, index) => (
+                <p key={`${item.id}:${index}`}>{paragraph}</p>
+              ))}
+            </div>
+
+            <aside className={styles.articleCallout}>
+              <strong>这是一个可直接搜索的内容入口</strong>
+              <p>
+                该页面使用稳定内容 ID、永久 URL、独立标题与摘要。用户可以从搜索结果直达这里，不必先进入应用首页逐层寻找。
+              </p>
+            </aside>
+
+            <div className={styles.tagList}>
+              {item.keywords.map((keyword) => (
+                <a
+                  key={keyword}
+                  className={styles.detailTag}
+                  href={siteHref(`/search?q=${encodeURIComponent(keyword)}`)}
+                >
+                  {keyword}
+                </a>
+              ))}
+            </div>
+          </article>
+
+          <aside className={styles.articleAside}>
+            <section className={styles.articleAppCard}>
+              <div className={styles.articleAppTop}>
+                <AppIcon label={app.icon} tone={app.tone} size="small" />
+                <div>
+                  <h2>{app.name}</h2>
+                  <p>{app.subtitle}</p>
+                </div>
+              </div>
+              <p>{app.description}</p>
+              <div className={styles.articleAppActions}>
+                <AppInstallActions appId={app.id} appName={app.name} />
+                <a className={styles.detailSecondary} href={siteHref(`/apps/${app.slug}`)}>
+                  查看应用详情 <ArrowRight />
+                </a>
+              </div>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>继续搜索</h3>
+              <p>搜索应用、功能、指南、模板和工作流，并直接打开对应内容。</p>
+              <div className={styles.articleAppActions}>
+                <a className={styles.detailPrimary} href={siteHref(`/search?q=${encodeURIComponent(item.keywords[0] ?? app.name)}`)}>
+                  搜索相关内容 <Search />
+                </a>
+              </div>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>相关内容</h3>
+              <div className={styles.contentList}>
+                {relatedContent.map(({ app: relatedApp, item: relatedItem }) => (
+                  <a
+                    key={`${relatedApp.id}:${relatedItem.id}`}
+                    className={styles.contentListItem}
+                    href={siteHref(`/apps/${relatedApp.slug}/content/${relatedItem.id}`)}
+                  >
+                    <span>
+                      <h3>{relatedItem.title}</h3>
+                      <p>{relatedApp.name} · {contentTypeLabel(relatedItem.type)}</p>
+                    </span>
+                    <ChevronRight />
+                  </a>
+                ))}
+              </div>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>机器可读入口</h3>
+              <p>公开搜索索引提供应用、内容 ID、关键词与永久链接，便于搜索引擎和 AI Agent 发现。</p>
+              <div className={styles.articleAppActions}>
+                <a className={styles.detailSecondary} href={siteHref("/search-index.json")}>
+                  打开 JSON 索引 <ExternalLink />
+                </a>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/apps/web/src/app/apps/[slug]/page.tsx
+++ b/frontend/apps/web/src/app/apps/[slug]/page.tsx
@@ -1,0 +1,334 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import {
+  ArrowRight,
+  Check,
+  ChevronRight,
+  LockKeyhole,
+  Search,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import { AppIcon } from "../../../components/marketplace/app-icon";
+import { AppInstallActions } from "../../../components/marketplace/app-install-actions";
+import styles from "../../../components/marketplace/marketplace.module.css";
+import {
+  MARKETPLACE_CATEGORY_LABELS,
+  getMarketplaceApp,
+  marketplaceApps,
+} from "../../../lib/marketplace";
+import { siteHref, siteUrl } from "../../../lib/site-url";
+
+type AppDetailsPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return marketplaceApps.map((app) => ({ slug: app.slug }));
+}
+
+export async function generateMetadata({ params }: AppDetailsPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const app = getMarketplaceApp(slug);
+  if (!app) return {};
+
+  const title = `${app.name} | Fabushi 应用市场`;
+  const description = `${app.subtitle}。${app.description}`;
+  const url = siteUrl(`/apps/${app.slug}`);
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    keywords: [app.name, app.englishName, ...app.tags, ...app.capabilities, "Fabushi Mini App"],
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Fabushi 应用市场",
+      locale: "zh_CN",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default async function AppDetailsPage({ params }: AppDetailsPageProps) {
+  const { slug } = await params;
+  const app = getMarketplaceApp(slug);
+  if (!app) notFound();
+
+  const url = siteUrl(`/apps/${app.slug}`);
+  const relatedApps = marketplaceApps
+    .filter((candidate) => candidate.id !== app.id)
+    .sort((left, right) => Number(right.category === app.category) - Number(left.category === app.category))
+    .slice(0, 3);
+  const faqs = [
+    {
+      question: `如何开始使用${app.name}？`,
+      answer: "可以直接点击“立即打开”试用，也可以先安装到“我的应用”，之后从 Fabushi 网页、桌面端或移动端继续使用。",
+    },
+    {
+      question: `${app.name}会申请哪些权限？`,
+      answer: `${app.permissions.join("；")}。涉及写入、外部系统或本地改动的操作会在执行前单独确认。`,
+    },
+    {
+      question: `${app.name}如何收费？`,
+      answer: `${app.pricing.label}。${app.pricing.detail}`,
+    },
+  ];
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareApplication",
+        "@id": `${url}#app`,
+        name: app.name,
+        alternateName: app.englishName,
+        description: app.description,
+        url,
+        applicationCategory: MARKETPLACE_CATEGORY_LABELS[app.category],
+        applicationSubCategory: app.tags,
+        operatingSystem: "Web, macOS, Windows, Linux, iOS, Android",
+        softwareVersion: app.version,
+        dateModified: app.updatedAt,
+        featureList: app.capabilities,
+        permissions: app.permissions.join("；"),
+        publisher: {
+          "@type": "Organization",
+          name: app.developer,
+          url: siteUrl("/"),
+        },
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "CNY",
+          description: app.pricing.detail,
+          availability: "https://schema.org/InStock",
+        },
+        potentialAction: {
+          "@type": "UseAction",
+          target: siteUrl(`/miniapps/${app.id}`),
+        },
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "应用市场", item: siteUrl("/") },
+          { "@type": "ListItem", position: 2, name: MARKETPLACE_CATEGORY_LABELS[app.category], item: siteUrl(`/?category=${app.category}`) },
+          { "@type": "ListItem", position: 3, name: app.name, item: url },
+        ],
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: faqs.map((faq) => ({
+          "@type": "Question",
+          name: faq.question,
+          acceptedAnswer: { "@type": "Answer", text: faq.answer },
+        })),
+      },
+    ],
+  };
+
+  return (
+    <div className={styles.detailShell}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <header className={styles.detailHeader}>
+        <div className={styles.detailHeaderInner}>
+          <a className={styles.detailBrand} href={siteHref("/")}>
+            <span className={styles.brandMark}>法</span>
+            <span>Fabushi 应用市场</span>
+          </a>
+          <nav className={styles.detailNav}>
+            <a href={siteHref("/")}>发现应用</a>
+            <a href={siteHref("/search")}>搜索内容</a>
+            <a href={siteHref("/miniapps/bot-father/commerce")}>开发者中心</a>
+            <a href={siteHref("/download")}>下载客户端</a>
+          </nav>
+        </div>
+      </header>
+
+      <main className={styles.detailMain}>
+        <nav className={styles.breadcrumbs} aria-label="面包屑">
+          <a href={siteHref("/")}>应用市场</a>
+          <ChevronRight />
+          <a href={siteHref(`/?category=${app.category}`)}>{MARKETPLACE_CATEGORY_LABELS[app.category]}</a>
+          <ChevronRight />
+          <span>{app.name}</span>
+        </nav>
+
+        <section className={styles.appHeroCard}>
+          <AppIcon label={app.icon} tone={app.tone} size="large" />
+          <div className={styles.appHeroCopy}>
+            <div className={styles.appHeroTitleLine}>
+              <h1>{app.name}</h1>
+              {app.verified ? (
+                <span className={styles.verified} title="已验证开发者" aria-label="已验证开发者">
+                  <Check />
+                </span>
+              ) : null}
+            </div>
+            <p className={styles.appHeroSubtitle}>{app.subtitle}</p>
+            <p className={styles.appHeroDescription}>{app.description}</p>
+            <div className={styles.appHeroDeveloper}>
+              <span>由 {app.developer} 开发</span>
+              <span className={styles.detailBadge}>已验证</span>
+              <span className={styles.detailBadge}>Mini App</span>
+              <span className={styles.detailBadge}>WebMCP</span>
+            </div>
+          </div>
+          <div className={styles.heroInstall}>
+            <AppInstallActions appId={app.id} appName={app.name} />
+            <small>{app.pricing.label} · 安装后可在所有 Fabushi 客户端继续</small>
+          </div>
+        </section>
+
+        <section className={styles.statsGrid} aria-label="应用信息">
+          <div className={styles.statItem}>
+            <small>分类</small>
+            <strong>{MARKETPLACE_CATEGORY_LABELS[app.category]}</strong>
+          </div>
+          <div className={styles.statItem}>
+            <small>版本</small>
+            <strong>v{app.version}</strong>
+          </div>
+          <div className={styles.statItem}>
+            <small>最近更新</small>
+            <strong>{app.updatedAt}</strong>
+          </div>
+          <div className={styles.statItem}>
+            <small>内容入口</small>
+            <strong>{app.content.length} 条可搜索内容</strong>
+          </div>
+        </section>
+
+        <div className={styles.detailGrid}>
+          <div className={styles.detailCard}>
+            <section className={styles.detailSection}>
+              <h2>像原生应用一样打开</h2>
+              <p>无需跳转到另一个网站或重新登录。应用在统一容器中全屏运行，同时保留平台导航、权限确认与跨端状态。</p>
+              <div className={styles.screenshotGrid} aria-label={`${app.name} 界面预览`}>
+                {app.highlights.map((highlight) => (
+                  <article key={highlight.title} className={styles.screenshotCard}>
+                    <strong>{highlight.title}</strong>
+                    <p>{highlight.description}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className={styles.detailSection}>
+              <h2>主要功能</h2>
+              <p>上架信息与实际运行能力使用同一份应用身份，避免“详情页写一套、应用里做另一套”。</p>
+              <div className={styles.featureGrid}>
+                {app.capabilities.map((capability, index) => (
+                  <article key={capability} className={styles.featureItem}>
+                    <strong>{capability}</strong>
+                    <p>{app.highlights[index % app.highlights.length]?.description}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className={styles.detailSection}>
+              <h2>内容级搜索入口</h2>
+              <p>应用不是只有一个商店页面。指南、模板、内容集和工作流都拥有稳定 URL，可被站内搜索、外部搜索引擎和 AI Agent 精确发现。</p>
+              <div className={styles.contentList}>
+                {app.content.map((item) => (
+                  <a
+                    key={item.id}
+                    className={styles.contentListItem}
+                    href={siteHref(`/apps/${app.slug}/content/${item.id}`)}
+                  >
+                    <span>
+                      <h3>{item.title}</h3>
+                      <p>{item.summary}</p>
+                    </span>
+                    <ArrowRight />
+                  </a>
+                ))}
+              </div>
+            </section>
+
+            <section className={styles.detailSection}>
+              <h2>常见问题</h2>
+              <div className={styles.faqList}>
+                {faqs.map((faq) => (
+                  <article key={faq.question} className={styles.faqItem}>
+                    <strong>{faq.question}</strong>
+                    <p>{faq.answer}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <aside>
+            <section className={styles.sidebarCard}>
+              <h2>应用信息</h2>
+              <div className={styles.sidebarRows}>
+                <div className={styles.sidebarRow}><span>开发者</span><strong>{app.developer}</strong></div>
+                <div className={styles.sidebarRow}><span>价格</span><strong>{app.pricing.label}</strong></div>
+                <div className={styles.sidebarRow}><span>版本</span><strong>{app.version}</strong></div>
+                <div className={styles.sidebarRow}><span>更新日期</span><strong>{app.updatedAt}</strong></div>
+              </div>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>权限说明</h3>
+              <p>只在需要时申请；写入、外部系统和本地改动会在执行前确认。</p>
+              <ul className={styles.list}>
+                {app.permissions.map((permission) => (
+                  <li key={permission}><LockKeyhole /> <span>{permission}</span></li>
+                ))}
+              </ul>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>能力与标签</h3>
+              <div className={styles.tagList}>
+                {app.tags.map((tag) => <span key={tag} className={styles.detailTag}>{tag}</span>)}
+              </div>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>可被 AI Agent 调用</h3>
+              <p>应用的 MCP 工具可映射为 WebMCP 网站工具，搜索、读取和操作使用同一能力定义。</p>
+              <ul className={styles.list}>
+                <li><Search /> <span>可发现的搜索入口</span></li>
+                <li><ShieldCheck /> <span>只读与写入权限分离</span></li>
+                <li><Sparkles /> <span>结构化工具结果</span></li>
+              </ul>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>更多同类应用</h3>
+              <div className={styles.contentList}>
+                {relatedApps.map((related) => (
+                  <a key={related.id} className={styles.contentListItem} href={siteHref(`/apps/${related.slug}`)}>
+                    <span>
+                      <h3>{related.name}</h3>
+                      <p>{related.subtitle}</p>
+                    </span>
+                    <ChevronRight />
+                  </a>
+                ))}
+              </div>
+            </section>
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -1,35 +1,33 @@
-import type { ReactNode } from "react";
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import { brand } from "@fabushi/shared";
 import { LocaleProvider } from "../components/locale-provider";
+import { MarketplaceWebMcp } from "../components/marketplace/marketplace-webmcp";
 import { siteUrl } from "../lib/site-url";
 import "./globals.css";
 
 const homeUrl = siteUrl("/");
-const siteTitle = `${brand.name} | 全球法布施 App 下载官网`;
+const siteTitle = `${brand.name} | Mini App、AI 工具与内容工作流市场`;
 const siteDescription =
-  "Fabushi 官网只服务 App 下载与安装转化，提供 iOS、Android 与桌面版下载入口、版本说明、安装支持、下载 FAQ 与基础隐私信息。";
+  "Fabushi 是可发现、可安装、可立即运行的 Mini App 市场，提供独立应用详情、内容级搜索入口、开发者分发资料与 WebMCP 网站工具。";
 
 export const metadata: Metadata = {
   title: siteTitle,
   description: siteDescription,
   keywords: [
     "Fabushi",
+    "应用市场",
+    "Mini App",
+    "AI 应用",
+    "MCP Apps",
+    "WebMCP",
+    "应用分发",
+    "内容级搜索",
+    "工作流",
+    "开发者平台",
     "法布施",
-    "全球法布施",
-    "App 下载",
-    "iOS 下载",
-    "Android 下载",
-    "macOS 下载",
-    "Windows 下载",
-    "Linux 下载",
-    "桌面版下载",
-    "TestFlight",
-    "APK 下载",
-    "下载 FAQ",
-    "安装支持",
   ],
-  applicationName: `${brand.name} Fabushi`,
+  applicationName: `${brand.name} 应用市场`,
   authors: [{ name: "Fabushi" }],
   creator: "Fabushi",
   publisher: "Fabushi",
@@ -37,13 +35,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: homeUrl,
   },
-  category: "utilities",
+  category: "software",
   manifest: siteUrl("/manifest.webmanifest"),
   openGraph: {
     title: siteTitle,
     description: siteDescription,
     url: homeUrl,
-    siteName: "Fabushi",
+    siteName: "Fabushi 应用市场",
     locale: "zh_CN",
     type: "website",
   },
@@ -68,7 +66,22 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="zh-CN" suppressHydrationWarning>
+      <head>
+        <link
+          rel="search"
+          type="application/opensearchdescription+xml"
+          title="Fabushi 应用与内容搜索"
+          href={siteUrl("/opensearch.xml")}
+        />
+        <link
+          rel="alternate"
+          type="application/json"
+          title="Fabushi 公开搜索索引"
+          href={siteUrl("/search-index.json")}
+        />
+      </head>
       <body>
+        <MarketplaceWebMcp />
         <LocaleProvider>{children}</LocaleProvider>
       </body>
     </html>

--- a/frontend/apps/web/src/app/manifest.ts
+++ b/frontend/apps/web/src/app/manifest.ts
@@ -5,12 +5,29 @@ export const dynamic = "force-static";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "法布施 Fabushi",
+    id: siteHref("/"),
+    name: "Fabushi 应用市场",
     short_name: "Fabushi",
-    description: "经文听诵、禅修冥想、法流视频与全球法布施。",
-    start_url: siteHref("/app"),
+    description: "发现、安装并运行 Mini App、AI 工具、指南、模板和工作流。",
+    start_url: siteHref("/"),
+    scope: siteHref("/"),
     display: "standalone",
-    background_color: "#05070d",
-    theme_color: "#101827",
+    background_color: "#000000",
+    theme_color: "#000000",
+    categories: ["business", "productivity", "utilities"],
+    shortcuts: [
+      {
+        name: "搜索应用与内容",
+        short_name: "搜索",
+        description: "搜索 Mini App、能力、指南、模板和工作流",
+        url: siteHref("/search"),
+      },
+      {
+        name: "打开大乘",
+        short_name: "大乘",
+        description: "进入 Fabushi 大乘工作台",
+        url: siteHref("/app"),
+      },
+    ],
   };
 }

--- a/frontend/apps/web/src/app/opensearch.xml/route.ts
+++ b/frontend/apps/web/src/app/opensearch.xml/route.ts
@@ -1,0 +1,22 @@
+import { siteUrl } from "../../lib/site-url";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const searchTemplate = `${siteUrl("/search")}?q={searchTerms}`.replace(/&/g, "&amp;");
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Fabushi</ShortName>
+  <Description>搜索 Fabushi Mini App、指南、模板和工作流</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Language>zh-CN</Language>
+  <Url type="text/html" template="${searchTemplate}" />
+</OpenSearchDescription>`;
+
+  return new Response(xml, {
+    headers: {
+      "content-type": "application/opensearchdescription+xml; charset=utf-8",
+      "cache-control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,210 +1,30 @@
 import type { Metadata } from "next";
-import { brand, contactChannels } from "@fabushi/shared";
-import { DownloadLink } from "../components/download-link";
-import { LocalizedText } from "../components/localized-text";
-import { SiteFooter } from "../components/site-footer";
-import { SiteHeader } from "../components/site-header";
-import {
-  FALLBACK_SCREENSHOTS,
-  getOfficialSiteReleaseCollection,
-  type OfficialSiteChannel,
-  type OfficialSiteScreenshots,
-} from "../lib/official-site-releases";
-import {
-  getUserFacingDescription,
-  getUserFacingStatus,
-} from "../lib/channel-display";
-import { siteHref, siteUrl } from "../lib/site-url";
+import { brand } from "@fabushi/shared";
+import { MarketplaceShell } from "../components/marketplace/marketplace-shell";
+import { marketplaceApps, marketplaceContent } from "../lib/marketplace";
+import { siteUrl } from "../lib/site-url";
 
-const SCREENSHOT_KEYS = [
-  "global-dharma",
-  "start-meditation",
-  "immersive-meditation",
-  "main-sutra",
-  "group-practice",
-  "global-donation",
-] as const;
-type ProductScreenshotKey = (typeof SCREENSHOT_KEYS)[number];
-
-interface ProductScreenshot {
-  titleZh: string;
-  titleEn: string;
-  descriptionZh: string;
-  descriptionEn: string;
-  screenshot: ProductScreenshotKey;
-  alt: string;
-}
-
-const HERO_MAIN_IMAGE_KEY: ProductScreenshotKey = "global-dharma";
-const HERO_SIDE_IMAGE_KEY: ProductScreenshotKey = "main-sutra";
 const homeUrl = siteUrl("/");
-const homeTitle = `全球法布施 App 下载官网 | ${brand.name}`;
+const homeTitle = "Fabushi 应用市场 | Mini App、AI 工具与内容工作流";
 const homeDescription =
-  "全球法布施是法布施大乘 App 的下载官网，集中展示下载入口、核心界面、版本说明、安装支持与下载 FAQ。";
-
-const APP_SCREENSHOTS: ProductScreenshot[] = [
-  {
-    titleZh: "全球法布施总览",
-    titleEn: "Global Dharma Overview",
-    descriptionZh: "把法布施、修行和听诵等核心功能收在同一套界面里。",
-    descriptionEn: "Keep giving, practice, and listening inside one core interface.",
-    screenshot: "global-dharma",
-    alt: "Fabushi global dharma overview screenshot",
-  },
-  {
-    titleZh: "开始禅修",
-    titleEn: "Start Meditation",
-    descriptionZh: "更轻地进入一次练习，不需要先做复杂设置。",
-    descriptionEn: "Enter a session lightly without a complex setup first.",
-    screenshot: "start-meditation",
-    alt: "Fabushi start meditation screenshot",
-  },
-  {
-    titleZh: "沉浸式练习",
-    titleEn: "Immersive Practice",
-    descriptionZh: "让一次安静练习更容易稳定留下来。",
-    descriptionEn: "Make a quiet session easier to sustain.",
-    screenshot: "immersive-meditation",
-    alt: "Fabushi immersive meditation screenshot",
-  },
-  {
-    titleZh: "主修功课",
-    titleEn: "Main Practice",
-    descriptionZh: "把当前最重要的功课固定在自己眼前。",
-    descriptionEn: "Keep the main practice path visible every day.",
-    screenshot: "main-sutra",
-    alt: "Fabushi main practice screenshot",
-  },
-  {
-    titleZh: "共修小组",
-    titleEn: "Group Practice",
-    descriptionZh: "把申请、加入和共修关系放回一条清楚的路径里。",
-    descriptionEn: "Keep applying, joining, and practicing together on one clear path.",
-    screenshot: "group-practice",
-    alt: "Fabushi group practice screenshot",
-  },
-  {
-    titleZh: "全球法布施入口",
-    titleEn: "Giving Entry",
-    descriptionZh: "把善意送往世界各地，而不是只停在本地。",
-    descriptionEn: "Let giving travel farther than one local circle.",
-    screenshot: "global-donation",
-    alt: "Fabushi global donation screenshot",
-  },
-] as const;
-
-const PRODUCT_BENEFITS = [
-  {
-    titleZh: "把修行入口留在手机里",
-    titleEn: "Keep practice close at hand",
-    descriptionZh: "禅修、听诵、佛经与日常节奏可以在同一个 App 里接起来，不需要来回切换很多工具。",
-    descriptionEn: "Meditation, listening, sutras, and daily rhythm stay in one app instead of across many tools.",
-  },
-  {
-    titleZh: "先看懂核心界面，再决定要不要下载",
-    titleEn: "See the product before you install",
-    descriptionZh: "首页直接把关键界面完整摆出来，让人先看清真实体验，而不是只看口号。",
-    descriptionEn: "The homepage shows the key screens up front so people can inspect the actual experience first.",
-  },
-  {
-    titleZh: "下载、支持与版本信息放在同一条线里",
-    titleEn: "Download, support, and release info stay together",
-    descriptionZh: "正式版、测试版、下载说明和支持方式都留在官网，不让安装过程变成找入口。",
-    descriptionEn: "Stable, beta, download notes, and support all stay on the site so installation does not turn into a hunt.",
-  },
-] as const;
-
-const HOME_FAQS = [
-  {
-    questionZh: "首页现在最适合先做什么？",
-    questionEn: "What is the homepage best for now?",
-    answerZh: "首页现在主要承担四件事：说明 App 是什么、促成下载、完整展示核心界面，以及给出最基础的支持与信任信息。非下载型栏目入口已经从官网主入口移除。",
-    answerEn: "The homepage now focuses on four jobs: explain the app, support download, show the core screens, and provide basic support and trust signals. Non-download sections have been removed from the main site entry.",
-  },
-  {
-    questionZh: "我应该从首页直接下载，还是先去下载页？",
-    questionEn: "Should I download from the homepage or open the download page first?",
-    answerZh: "如果你已经知道自己要安装，可以直接从首页进入下载；如果你还想看版本、R2 下载状态和更新说明，再继续进入独立下载页会更稳。",
-    answerEn: "If you already know you want to install, the homepage is enough to start. If you want version notes, R2 download status, and release details first, the dedicated download page is the steadier next step.",
-  },
-  {
-    questionZh: "官网为什么不再把首页做成资讯或内容门户？",
-    questionEn: "Why is the homepage no longer treated like a news or content portal?",
-    answerZh: "因为首页权重最高，也最直接影响下载转化。把资讯和学习类分流入口移除后，首页主体可以更专注地把产品说清楚、把下载链路做顺。",
-    answerEn: "Because the homepage carries the strongest authority and the clearest download intent. Once news and learning detours are removed, the homepage body can focus on product clarity and conversion.",
-  },
-] as const;
-
-function resolveScreenshot(screenshots: OfficialSiteScreenshots, key: ProductScreenshotKey) {
-  return screenshots[key] ?? FALLBACK_SCREENSHOTS[key];
-}
-
-function formatPublishedAt(value?: string) {
-  if (!value) {
-    return null;
-  }
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return date.toISOString().slice(0, 10);
-}
-
-function getChannelActionCopy(channel: OfficialSiteChannel) {
-  if (channel.platform === "iOS") {
-    return {
-      zh: channel.audience === "beta" ? "下载 iOS 测试版" : "下载 iOS 正式版",
-      en: channel.audience === "beta" ? "Download iOS Beta" : "Download iOS Stable",
-    };
-  }
-
-  if (channel.platform === "macOS") {
-    return {
-      zh: "下载 macOS 桌面版",
-      en: "Download macOS Desktop",
-    };
-  }
-
-  if (channel.platform === "Windows") {
-    return {
-      zh: "下载 Windows 桌面版",
-      en: "Download Windows Desktop",
-    };
-  }
-
-  if (channel.platform === "Linux") {
-    return {
-      zh: "下载 Linux 桌面版",
-      en: "Download Linux Desktop",
-    };
-  }
-
-  return {
-    zh: channel.audience === "beta" ? "下载 Android 测试版" : "下载 Android 正式版",
-    en: channel.audience === "beta" ? "Download Android Beta" : "Download Android Stable",
-  };
-}
+  "发现、安装并立即运行 Fabushi Mini App。像 Telegram Mini App 一样即开即用，像 Shopify App Store 一样可比较与分发，并为指南、模板和工作流提供内容级搜索入口。";
 
 export const metadata: Metadata = {
   title: homeTitle,
   description: homeDescription,
-  alternates: {
-    canonical: homeUrl,
-  },
+  alternates: { canonical: homeUrl },
   keywords: [
-    "全球法布施",
-    "法布施大乘",
-    "Fabushi app",
-    "佛教 app 下载",
-    "禅修 app",
-    "佛经听诵 app",
-    "iOS TestFlight",
-    "Android APK",
-    "macOS 下载",
-    "Windows 下载",
-    "Linux 下载",
+    "Fabushi",
+    "应用市场",
+    "Mini App",
+    "Telegram Mini App",
+    "AI 应用",
+    "MCP Apps",
+    "WebMCP",
+    "应用商店",
+    "内容搜索",
+    "工作流",
+    "开发者平台",
   ],
   openGraph: {
     title: homeTitle,
@@ -221,56 +41,63 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function HomePage() {
-  const releaseCollection = await getOfficialSiteReleaseCollection();
-  const screenshots = {
-    ...FALLBACK_SCREENSHOTS,
-    ...releaseCollection.screenshots,
-  };
-  const channels = [...releaseCollection.stableChannels, ...releaseCollection.betaChannels].slice(0, 2);
-  const supportEmail =
-    contactChannels.find((item) => item.href.startsWith("mailto:"))?.value ?? "support@ombhrum.com";
-  const latestRelease = releaseCollection.releases[0] ?? null;
-
+export default function HomePage() {
   const structuredData = {
     "@context": "https://schema.org",
     "@graph": [
       {
-        "@type": "WebPage",
-        name: "全球法布施首页",
+        "@type": "Organization",
+        "@id": `${homeUrl}#organization`,
+        name: brand.name,
+        alternateName: "Fabushi",
         url: homeUrl,
-        description: homeDescription,
-        inLanguage: "zh-CN",
-        isPartOf: {
-          "@type": "WebSite",
-          name: `${brand.name} Fabushi`,
-          url: homeUrl,
+      },
+      {
+        "@type": "WebSite",
+        "@id": `${homeUrl}#website`,
+        name: "Fabushi 应用市场",
+        url: homeUrl,
+        publisher: { "@id": `${homeUrl}#organization` },
+        potentialAction: {
+          "@type": "SearchAction",
+          target: {
+            "@type": "EntryPoint",
+            urlTemplate: `${siteUrl("/search")}?q={search_term_string}`,
+          },
+          "query-input": "required name=search_term_string",
         },
       },
       {
-        "@type": "Organization",
-        name: `${brand.name} Fabushi`,
-        url: homeUrl,
-        email: supportEmail,
-        description: "Fabushi offers meditation, listening, and global giving in one downloadable app.",
-      },
-      {
-        "@type": "SoftwareApplication",
-        name: `${brand.name} Fabushi`,
-        applicationCategory: "LifestyleApplication",
-        operatingSystem: "iOS, Android, macOS, Windows, Linux",
-        downloadUrl: siteUrl("/download"),
+        "@type": "CollectionPage",
+        "@id": `${homeUrl}#marketplace`,
+        name: homeTitle,
         description: homeDescription,
-        screenshot: APP_SCREENSHOTS.map((item) => siteUrl(resolveScreenshot(screenshots, item.screenshot))),
+        url: homeUrl,
+        isPartOf: { "@id": `${homeUrl}#website` },
+        mainEntity: {
+          "@type": "ItemList",
+          numberOfItems: marketplaceApps.length,
+          itemListElement: marketplaceApps.map((app, index) => ({
+            "@type": "ListItem",
+            position: index + 1,
+            url: siteUrl(`/apps/${app.slug}`),
+            name: app.name,
+          })),
+        },
       },
       {
-        "@type": "FAQPage",
-        mainEntity: HOME_FAQS.map((item) => ({
-          "@type": "Question",
-          name: item.questionZh,
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: item.answerZh,
+        "@type": "DataCatalog",
+        name: "Fabushi 内容级搜索索引",
+        description: `收录 ${marketplaceContent.length} 条指南、模板、内容集与工作流。`,
+        url: siteUrl("/search-index.json"),
+        dataset: marketplaceApps.map((app) => ({
+          "@type": "Dataset",
+          name: `${app.name} 内容目录`,
+          url: siteUrl(`/apps/${app.slug}`),
+          distribution: {
+            "@type": "DataDownload",
+            contentUrl: siteUrl("/search-index.json"),
+            encodingFormat: "application/json",
           },
         })),
       },
@@ -278,285 +105,12 @@ export default async function HomePage() {
   };
 
   return (
-    <main className="page-shell">
+    <>
       <script
         type="application/ld+json"
-        suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
-
-      <header className="hero">
-        <SiteHeader />
-        <div className="hero-grid">
-          <section className="hero-copy" aria-labelledby="home-title">
-            <div className="brand-kicker">
-              <img src={siteHref("/product/app-icon.png")} alt="" />
-              <span>
-                <LocalizedText zh="法布施大乘 App" en="Fabushi App" />
-              </span>
-            </div>
-            <h1 id="home-title">
-              <LocalizedText
-                zh={
-                  <>
-                    <span className="hero-title-line">全球</span>
-                    <span className="hero-title-line">法布施</span>
-                  </>
-                }
-                en="Global Dharma Sharing"
-              />
-            </h1>
-            <p className="hero-subtitle">
-              <LocalizedText
-                zh="用一个 App 连接经文听诵、禅修记录、法流学习与全球法布施。"
-                en="One app for sutra listening, meditation records, Dharma learning, and global giving."
-              />
-            </p>
-            <div className="hero-actions">
-              <a className="primary-action" href={siteHref("/download")}>
-                <LocalizedText zh="下载 App" en="Download App" />
-              </a>
-            </div>
-            <div className="release-pill-grid" aria-label="Quick service entry / 服务入口">
-              {channels.length > 0 ? (
-                channels.map((item) => {
-                  const statusCopy = getUserFacingStatus(item);
-                  const actionCopy = getChannelActionCopy(item);
-                  const publishedAt = formatPublishedAt(item.publishedAt);
-                  return (
-                    <DownloadLink
-                      key={`${item.audience}-${item.platform}`}
-                      className="release-pill"
-                      channel={item}
-                    >
-                      <span>{item.title}</span>
-                      <strong>
-                        <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
-                      </strong>
-                      {(item.version || publishedAt) && (
-                        <small>
-                          {item.version ? `v${item.version}` : ""}
-                          {item.version && publishedAt ? " · " : ""}
-                          {publishedAt ?? ""}
-                        </small>
-                      )}
-                      <em>
-                        <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
-                      </em>
-                    </DownloadLink>
-                  );
-                })
-              ) : (
-                <a className="release-pill" href={siteHref("/download")}>
-                  <span>
-                    <LocalizedText zh="App 下载" en="App Download" />
-                  </span>
-                  <strong>
-                    <LocalizedText zh="查看全部下载入口" en="See all download paths" />
-                  </strong>
-                </a>
-              )}
-            </div>
-          </section>
-
-          <section className="hero-visual" aria-label="Fabushi product preview">
-            <div className="phone-stack">
-              <div className="phone-frame main-phone poster-frame">
-                <img
-                  src={siteHref(resolveScreenshot(screenshots, HERO_MAIN_IMAGE_KEY))}
-                  alt="Fabushi homepage screenshot"
-                />
-              </div>
-              <div className="phone-frame side-phone poster-frame">
-                <img
-                  src={siteHref(resolveScreenshot(screenshots, HERO_SIDE_IMAGE_KEY))}
-                  alt="Fabushi feature preview screenshot"
-                />
-              </div>
-            </div>
-          </section>
-        </div>
-      </header>
-
-      <section className="band alt product-band" id="app-screenshots">
-        <div className="section-heading tight">
-          <p>
-            <LocalizedText zh="App 截图" en="App Screens" />
-          </p>
-          <h2>
-            <LocalizedText
-              zh="先把关键界面尽量完整地摆出来，让首页直接承担理解与转化。"
-              en="Show the key screens as fully as possible so the homepage carries both understanding and conversion."
-            />
-          </h2>
-        </div>
-        <div className="moment-grid showcase-grid">
-          {APP_SCREENSHOTS.map((item) => (
-            <article key={item.titleEn} className="moment-card guide-card">
-              <div className="moment-image">
-                <img
-                  src={siteHref(resolveScreenshot(screenshots, item.screenshot))}
-                  alt={item.alt}
-                  loading="lazy"
-                />
-              </div>
-              <h3>
-                <LocalizedText zh={item.titleZh} en={item.titleEn} />
-              </h3>
-              <p>
-                <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
-              </p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band" id="product-value">
-        <div className="section-heading tight">
-          <p>
-            <LocalizedText zh="产品说明" en="Product Value" />
-          </p>
-          <h2>
-            <LocalizedText
-              zh="首页只把最该知道的三件事讲清楚。"
-              en="Keep the homepage focused on the three things people most need to understand."
-            />
-          </h2>
-        </div>
-        <div className="editorial-list">
-          {PRODUCT_BENEFITS.map((item) => (
-            <article key={item.titleEn} className="editorial-row">
-              <span>
-                <LocalizedText zh="核心价值" en="Core Value" />
-              </span>
-              <div>
-                <strong>
-                  <LocalizedText zh={item.titleZh} en={item.titleEn} />
-                </strong>
-                <p>
-                  <LocalizedText zh={item.descriptionZh} en={item.descriptionEn} />
-                </p>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="band alt" id="service-entry">
-        <div className="section-heading tight">
-          <p>
-            <LocalizedText zh="下载与支持" en="Download and Support" />
-          </p>
-          <h2>
-            <LocalizedText
-              zh="把下载、版本、支持和最基础的信任信息放回同一个服务区。"
-              en="Keep download, release details, support, and the basic trust signals inside one service zone."
-            />
-          </h2>
-        </div>
-        <div className="platform-strip">
-          {channels.map((item) => {
-            const descriptionCopy = getUserFacingDescription(item);
-            const statusCopy = getUserFacingStatus(item);
-            const actionCopy = getChannelActionCopy(item);
-            const publishedAt = formatPublishedAt(item.publishedAt);
-            return (
-              <DownloadLink
-                key={`${item.audience}-${item.platform}`}
-                className="platform-row detailed"
-                channel={item}
-              >
-                <div>
-                  <span className="platform-name">{item.title}</span>
-                  <p>
-                    <LocalizedText zh={descriptionCopy.zh} en={descriptionCopy.en} />
-                  </p>
-                  {(item.version || publishedAt) && (
-                    <div className="platform-detail-line">
-                      {item.version ? <span>v{item.version}</span> : null}
-                      {publishedAt ? <span>{publishedAt}</span> : null}
-                    </div>
-                  )}
-                </div>
-                <div className="platform-meta">
-                  <strong>
-                    <LocalizedText zh={statusCopy.zh} en={statusCopy.en} />
-                  </strong>
-                  <span>
-                    <LocalizedText zh={actionCopy.zh} en={actionCopy.en} />
-                  </span>
-                </div>
-              </DownloadLink>
-            );
-          })}
-          <a className="platform-row accent-row" href={siteHref("/download")}>
-            <div>
-              <span className="platform-name">
-                <LocalizedText zh="全部下载入口" en="All Downloads" />
-              </span>
-              <p>
-                <LocalizedText zh="进入独立下载页，查看正式版、测试版、R2 下载状态和更新日志。" en="Open the dedicated download page for stable, beta, R2 download status, and release notes." />
-              </p>
-            </div>
-            <div className="platform-meta">
-              <strong>
-                <LocalizedText zh="下载页" en="Download Page" />
-              </strong>
-              <span>
-                <LocalizedText zh="进入" en="Open" />
-              </span>
-            </div>
-          </a>
-        </div>
-        <div className="note-grid">
-          <p>
-            <LocalizedText
-              zh={latestRelease ? `最近版本：${latestRelease.title}` : "最近版本与下载说明会同步更新到官网下载页。"}
-              en={latestRelease ? `Latest release: ${latestRelease.title}` : "Latest release notes stay synced on the official download page."}
-            />
-          </p>
-          <p>
-            <LocalizedText zh={`下载或安装遇到问题，可联系 ${supportEmail}。`} en={`If download or install fails, contact ${supportEmail}.`} />
-          </p>
-          <p>
-            <LocalizedText zh="隐私说明、下载 FAQ 和联系支持保留在官网主路径中，避免把下载流程分散出去。" en="Privacy, download FAQ, and support stay in the main path so the install flow does not get scattered." />
-          </p>
-        </div>
-      </section>
-
-      <section className="band faq-band" id="faq">
-        <div className="section-heading tight">
-          <p>FAQ</p>
-          <h2>
-            <LocalizedText
-              zh="只保留最直接影响下载理解的几个问题。"
-              en="Keep only the questions that most directly support understanding and download intent."
-            />
-          </h2>
-        </div>
-        <div className="faq-list">
-          {HOME_FAQS.map((item) => (
-            <details key={item.questionEn} className="faq-item">
-              <summary>
-                <LocalizedText zh={item.questionZh} en={item.questionEn} />
-              </summary>
-              <p>
-                <LocalizedText zh={item.answerZh} en={item.answerEn} />
-              </p>
-            </details>
-          ))}
-        </div>
-        <div className="inline-cta">
-          <a className="secondary-action" href={siteHref("/faq")}>
-            <LocalizedText zh="查看全部常见问题" en="View all FAQs" />
-          </a>
-          <a className="secondary-action" href={`mailto:${supportEmail}`}>
-            <LocalizedText zh="联系支持" en="Contact support" />
-          </a>
-        </div>
-      </section>
-
-      <SiteFooter />
-    </main>
+      <MarketplaceShell />
+    </>
   );
 }

--- a/frontend/apps/web/src/app/search-index.json/route.ts
+++ b/frontend/apps/web/src/app/search-index.json/route.ts
@@ -1,0 +1,51 @@
+import { MARKETPLACE_CATEGORY_LABELS, marketplaceApps } from "../../lib/marketplace";
+import { siteUrl } from "../../lib/site-url";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const index = {
+    schema: "fabushi.marketplace.search-index.v1",
+    generatedAt: "2026-08-27",
+    language: "zh-CN",
+    marketplaceUrl: siteUrl("/"),
+    searchUrlTemplate: `${siteUrl("/search")}?q={query}`,
+    apps: marketplaceApps.map((app) => ({
+      id: app.id,
+      slug: app.slug,
+      name: app.name,
+      englishName: app.englishName,
+      subtitle: app.subtitle,
+      description: app.description,
+      category: app.category,
+      categoryLabel: MARKETPLACE_CATEGORY_LABELS[app.category],
+      developer: app.developer,
+      verified: app.verified,
+      tags: app.tags,
+      capabilities: app.capabilities,
+      permissions: app.permissions,
+      pricing: app.pricing,
+      version: app.version,
+      updatedAt: app.updatedAt,
+      detailsUrl: siteUrl(`/apps/${app.slug}`),
+      launchUrl: siteUrl(`/miniapps/${app.id}`),
+      content: app.content.map((item) => ({
+        id: item.id,
+        type: item.type,
+        title: item.title,
+        summary: item.summary,
+        keywords: item.keywords,
+        updatedAt: item.updatedAt,
+        readingMinutes: item.readingMinutes,
+        url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
+      })),
+    })),
+  };
+
+  return Response.json(index, {
+    headers: {
+      "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      "content-language": "zh-CN",
+    },
+  });
+}

--- a/frontend/apps/web/src/app/search/page.tsx
+++ b/frontend/apps/web/src/app/search/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { MarketplaceSearch } from "../../components/marketplace/marketplace-search";
+import styles from "../../components/marketplace/marketplace.module.css";
+import { siteUrl } from "../../lib/site-url";
+
+const searchUrl = siteUrl("/search");
+
+export const metadata: Metadata = {
+  title: "搜索应用与内容 | Fabushi 应用市场",
+  description: "搜索 Fabushi Mini App、能力、指南、模板、内容集和工作流，并直接打开具体应用或内容入口。",
+  alternates: { canonical: searchUrl },
+  robots: {
+    index: false,
+    follow: true,
+  },
+  openGraph: {
+    title: "搜索应用与内容 | Fabushi 应用市场",
+    description: "搜索 Fabushi Mini App、能力、指南、模板、内容集和工作流。",
+    url: searchUrl,
+    siteName: "Fabushi 应用市场",
+    locale: "zh_CN",
+    type: "website",
+  },
+};
+
+function SearchFallback() {
+  return (
+    <div className={styles.searchPage}>
+      <main className={styles.searchPageInner}>
+        <div className={styles.emptyState}>
+          <span className={styles.emptyStateIcon}>法</span>
+          <h2>正在准备搜索</h2>
+          <p>应用和内容索引会在页面载入后立即可用。</p>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<SearchFallback />}>
+      <MarketplaceSearch />
+    </Suspense>
+  );
+}

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllArticles } from "../lib/content";
+import { marketplaceApps } from "../lib/marketplace";
 import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
@@ -53,7 +54,7 @@ const weeklyRoutes = new Set([
 ]);
 
 const routeLastModified: Partial<Record<(typeof staticRoutes)[number], string>> = {
-  "/": "2026-05-18",
+  "/": "2026-08-27",
   "/app": "2026-06-09",
   "/app/ai": "2026-06-09",
   "/download": "2026-05-18",
@@ -85,13 +86,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
       route === "/"
         ? 1
         : weeklyRoutes.has(route)
-          ? 0.9
+          ? 0.85
           : route === "/apply"
-            ? 0.85
+            ? 0.8
             : route === "/privacy"
-              ? 0.8
-              : 0.75,
+              ? 0.6
+              : 0.7,
   }));
+
+  const appPages: MetadataRoute.Sitemap = marketplaceApps.map((app) => ({
+    url: siteUrl(`/apps/${app.slug}`),
+    lastModified: app.updatedAt,
+    changeFrequency: "weekly",
+    priority: app.featured ? 0.95 : 0.9,
+  }));
+
+  const appContentPages: MetadataRoute.Sitemap = marketplaceApps.flatMap((app) =>
+    app.content.map((item) => ({
+      url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
+      lastModified: item.updatedAt,
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    })),
+  );
 
   const articlePages: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
     url: siteUrl(`/insights/${article.slug}`),
@@ -100,5 +117,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: article.featured ? 0.8 : 0.65,
   }));
 
-  return [...pages, ...articlePages];
+  return [...pages, ...appPages, ...appContentPages, ...articlePages];
 }

--- a/frontend/apps/web/src/components/marketplace/app-icon.tsx
+++ b/frontend/apps/web/src/components/marketplace/app-icon.tsx
@@ -1,0 +1,21 @@
+import type { MarketplaceIconTone } from "../../lib/marketplace";
+import styles from "./marketplace.module.css";
+
+type AppIconProps = {
+  label: string;
+  tone: MarketplaceIconTone;
+  size?: "small" | "medium" | "large";
+};
+
+export function AppIcon({ label, tone, size = "medium" }: AppIconProps) {
+  return (
+    <span
+      className={`${styles.appIcon} ${styles[`tone${tone[0].toUpperCase()}${tone.slice(1)}`]} ${
+        size === "small" ? styles.appIconSmall : size === "large" ? styles.appIconLarge : ""
+      }`}
+      aria-hidden="true"
+    >
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/frontend/apps/web/src/components/marketplace/app-install-actions.tsx
+++ b/frontend/apps/web/src/components/marketplace/app-install-actions.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Check, ExternalLink, Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { siteHref } from "../../lib/site-url";
+import styles from "./marketplace.module.css";
+
+const INSTALLED_KEY = "fabushi.installed-miniapps";
+const RECENT_KEY = "fabushi.marketplace.recent-apps.v1";
+
+function readList(key: string): string[] {
+  try {
+    const value = JSON.parse(window.localStorage.getItem(key) ?? "[]");
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export function AppInstallActions({ appId, appName }: { appId: string; appName: string }) {
+  const [installed, setInstalled] = useState(false);
+
+  useEffect(() => {
+    setInstalled(readList(INSTALLED_KEY).includes(appId));
+  }, [appId]);
+
+  const install = () => {
+    const next = [...new Set([...readList(INSTALLED_KEY), appId])];
+    window.localStorage.setItem(INSTALLED_KEY, JSON.stringify(next));
+    setInstalled(true);
+    window.dispatchEvent(new CustomEvent("fabushi:marketplace-installed", { detail: { ids: next } }));
+  };
+
+  const markOpened = () => {
+    const recent = readList(RECENT_KEY);
+    const next = [appId, ...recent.filter((id) => id !== appId)].slice(0, 8);
+    window.localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  };
+
+  return (
+    <>
+      <button
+        className={styles.detailPrimary}
+        type="button"
+        onClick={install}
+        disabled={installed}
+        aria-label={installed ? `${appName} 已安装` : `安装 ${appName}`}
+      >
+        {installed ? <Check /> : <Plus />}
+        {installed ? "已加入我的应用" : "安装应用"}
+      </button>
+      <a
+        className={styles.detailSecondary}
+        href={siteHref(`/miniapps/${appId}`)}
+        onClick={markOpened}
+      >
+        立即打开 <ExternalLink />
+      </a>
+    </>
+  );
+}

--- a/frontend/apps/web/src/components/marketplace/marketplace-search.tsx
+++ b/frontend/apps/web/src/components/marketplace/marketplace-search.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import {
+  ArrowLeft,
+  BookOpen,
+  Check,
+  ChevronRight,
+  Download,
+  ExternalLink,
+  Package,
+  Search,
+  X,
+} from "lucide-react";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  MARKETPLACE_CATEGORY_LABELS,
+  searchMarketplace,
+  type MarketplaceApp,
+  type MarketplaceContentItem,
+} from "../../lib/marketplace";
+import { siteHref } from "../../lib/site-url";
+import { AppIcon } from "./app-icon";
+import styles from "./marketplace.module.css";
+
+const INSTALLED_KEY = "fabushi.installed-miniapps";
+const RECENT_KEY = "fabushi.marketplace.recent-apps.v1";
+
+function readList(key: string): string[] {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(key) ?? "[]");
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function contentTypeLabel(type: MarketplaceContentItem["type"]) {
+  switch (type) {
+    case "guide":
+      return "指南";
+    case "template":
+      return "模板";
+    case "collection":
+      return "内容集";
+    case "workflow":
+      return "工作流";
+    case "release":
+      return "版本说明";
+  }
+}
+
+export function MarketplaceSearch() {
+  const searchParams = useSearchParams();
+  const initialQuery = searchParams.get("q")?.trim() ?? "";
+  const [query, setQuery] = useState(initialQuery);
+  const [submittedQuery, setSubmittedQuery] = useState(initialQuery);
+  const [installedIds, setInstalledIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    setInstalledIds(readList(INSTALLED_KEY));
+  }, []);
+
+  useEffect(() => {
+    const nextQuery = searchParams.get("q")?.trim() ?? "";
+    setQuery(nextQuery);
+    setSubmittedQuery(nextQuery);
+  }, [searchParams]);
+
+  const results = useMemo(() => searchMarketplace(submittedQuery), [submittedQuery]);
+  const installedSet = useMemo(() => new Set(installedIds), [installedIds]);
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalized = query.trim();
+    setSubmittedQuery(normalized);
+    const href = normalized ? siteHref(`/search?q=${encodeURIComponent(normalized)}`) : siteHref("/search");
+    window.history.replaceState(null, "", href);
+  };
+
+  const install = (app: MarketplaceApp) => {
+    const next = [...new Set([...installedIds, app.id])];
+    setInstalledIds(next);
+    window.localStorage.setItem(INSTALLED_KEY, JSON.stringify(next));
+    window.dispatchEvent(new CustomEvent("fabushi:marketplace-installed", { detail: { ids: next } }));
+  };
+
+  const markOpened = (app: MarketplaceApp) => {
+    const recent = readList(RECENT_KEY);
+    const next = [app.id, ...recent.filter((id) => id !== app.id)].slice(0, 8);
+    window.localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  };
+
+  const hasResults = results.apps.length > 0 || results.content.length > 0;
+
+  return (
+    <div className={styles.searchPage}>
+      <main className={styles.searchPageInner}>
+        <header className={styles.searchPageHeader}>
+          <a className={styles.iconButton} href={siteHref("/")} aria-label="返回应用市场">
+            <ArrowLeft />
+          </a>
+          <form className={styles.searchForm} role="search" onSubmit={submit}>
+            <Search />
+            <input
+              className={styles.searchInput}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="搜索应用、能力、指南、模板或工作流"
+              autoFocus
+              aria-label="搜索 Fabushi 应用和内容"
+            />
+            {query ? (
+              <button className={styles.searchClear} type="button" aria-label="清除搜索" onClick={() => setQuery("")}>
+                <X />
+              </button>
+            ) : null}
+          </form>
+        </header>
+
+        <section className={styles.searchSummary}>
+          <h1>{submittedQuery ? `“${submittedQuery}”的搜索结果` : "搜索 Fabushi"}</h1>
+          <p>
+            {submittedQuery
+              ? `${results.apps.length} 个应用，${results.content.length} 条内容级入口`
+              : "输入应用名、功能、主题或工作流关键词。每条内容都可以直接打开。"}
+          </p>
+        </section>
+
+        {results.apps.length ? (
+          <>
+            <div className={styles.sectionHeader}>
+              <div>
+                <h2>应用</h2>
+                <p>比较资料后安装，或直接打开试用</p>
+              </div>
+            </div>
+            <div className={styles.appFeed}>
+              {results.apps.map((app) => (
+                <article key={app.id} className={styles.appCard}>
+                  <AppIcon label={app.icon} tone={app.tone} />
+                  <div className={styles.appCardBody}>
+                    <div className={styles.appNameLine}>
+                      <a href={siteHref(`/apps/${app.slug}`)}>{app.name}</a>
+                      {app.verified ? <span className={styles.verified}><Check /></span> : null}
+                    </div>
+                    <div className={styles.developerLine}>
+                      {app.developer} · {MARKETPLACE_CATEGORY_LABELS[app.category]}
+                    </div>
+                    <p className={styles.appDescription}>{app.subtitle}</p>
+                    <div className={styles.appMeta}>
+                      {app.tags.slice(0, 3).map((tag) => (
+                        <span key={tag} className={styles.metaChip}>{tag}</span>
+                      ))}
+                    </div>
+                    <div className={styles.appCardActions}>
+                      {installedSet.has(app.id) ? (
+                        <a
+                          className={styles.primaryButton}
+                          href={siteHref(`/miniapps/${app.id}`)}
+                          onClick={() => markOpened(app)}
+                        >
+                          打开 <ExternalLink />
+                        </a>
+                      ) : (
+                        <button className={styles.primaryButton} type="button" onClick={() => install(app)}>
+                          安装 <Download />
+                        </button>
+                      )}
+                      <a className={styles.secondaryButton} href={siteHref(`/apps/${app.slug}`)}>
+                        查看详情 <ChevronRight />
+                      </a>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </>
+        ) : null}
+
+        {results.content.length ? (
+          <>
+            <div className={styles.sectionHeader}>
+              <div>
+                <h2>内容</h2>
+                <p>从搜索结果直接进入具体指南、模板和工作流</p>
+              </div>
+            </div>
+            <div className={styles.contentFeed}>
+              {results.content.map(({ app, item }) => (
+                <article key={`${app.id}:${item.id}`} className={styles.contentCard}>
+                  <span className={styles.contentType}><BookOpen /></span>
+                  <div>
+                    <h3><a href={siteHref(`/apps/${app.slug}/content/${item.id}`)}>{item.title}</a></h3>
+                    <p>{item.summary}</p>
+                    <div className={styles.contentMeta}>
+                      {app.name} · {contentTypeLabel(item.type)} · {item.readingMinutes} 分钟 · {item.updatedAt}
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </>
+        ) : null}
+
+        {!hasResults ? (
+          <div className={styles.emptyState}>
+            <span className={styles.emptyStateIcon}>{submittedQuery ? <Search /> : <Package />}</span>
+            <h2>{submittedQuery ? "没有找到匹配结果" : "从一个关键词开始"}</h2>
+            <p>
+              {submittedQuery
+                ? "尝试更短的关键词、应用名称、功能名称或内容主题。"
+                : "例如：WebMCP、内容发布、心经、磁盘清理、授权范围。"}
+            </p>
+          </div>
+        ) : null}
+      </main>
+    </div>
+  );
+}

--- a/frontend/apps/web/src/components/marketplace/marketplace-shell.tsx
+++ b/frontend/apps/web/src/components/marketplace/marketplace-shell.tsx
@@ -1,0 +1,604 @@
+"use client";
+
+import {
+  AppWindow,
+  BookOpen,
+  Check,
+  ChevronRight,
+  Code2,
+  Compass,
+  Download,
+  ExternalLink,
+  Home,
+  Layers3,
+  Package,
+  Plus,
+  Search,
+  ShieldCheck,
+  Sparkles,
+  User,
+  X,
+} from "lucide-react";
+import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  MARKETPLACE_CATEGORY_LABELS,
+  getMarketplaceApp,
+  marketplaceApps,
+  searchMarketplace,
+  type MarketplaceApp,
+  type MarketplaceCategory,
+} from "../../lib/marketplace";
+import { siteHref } from "../../lib/site-url";
+import { AppIcon } from "./app-icon";
+import styles from "./marketplace.module.css";
+
+const INSTALLED_KEY = "fabushi.installed-miniapps";
+const RECENT_KEY = "fabushi.marketplace.recent-apps.v1";
+
+type MarketplaceSection = "discover" | "installed" | "content";
+
+const categoryOrder: readonly MarketplaceCategory[] = [
+  "featured",
+  "automation",
+  "content",
+  "practice",
+  "developer",
+  "system",
+];
+
+function readStringArray(key: string): string[] {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(key) ?? "[]");
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function contentTypeLabel(type: MarketplaceApp["content"][number]["type"]) {
+  switch (type) {
+    case "guide":
+      return "指南";
+    case "template":
+      return "模板";
+    case "collection":
+      return "内容集";
+    case "workflow":
+      return "工作流";
+    case "release":
+      return "版本说明";
+  }
+}
+
+function AppFeedCard({
+  app,
+  installed,
+  onInstall,
+  onOpen,
+  onPreview,
+}: {
+  app: MarketplaceApp;
+  installed: boolean;
+  onInstall: (app: MarketplaceApp) => void;
+  onOpen: (app: MarketplaceApp) => void;
+  onPreview: (app: MarketplaceApp) => void;
+}) {
+  return (
+    <article className={styles.appCard}>
+      <AppIcon label={app.icon} tone={app.tone} />
+      <div className={styles.appCardBody}>
+        <div className={styles.appCardHeader}>
+          <div className={styles.appTitleRow}>
+            <div className={styles.appNameLine}>
+              <a href={siteHref(`/apps/${app.slug}`)}>{app.name}</a>
+              {app.verified ? (
+                <span className={styles.verified} title="已验证开发者" aria-label="已验证开发者">
+                  <Check />
+                </span>
+              ) : null}
+            </div>
+            <div className={styles.developerLine}>
+              {app.developer} · {MARKETPLACE_CATEGORY_LABELS[app.category]}
+            </div>
+          </div>
+        </div>
+        <p className={styles.appDescription}>{app.subtitle}</p>
+        <div className={styles.appMeta}>
+          <span className={styles.metaChip}>
+            <ShieldCheck /> 权限透明
+          </span>
+          <span className={styles.metaChip}>
+            <AppWindow /> Mini App
+          </span>
+          {app.tags.slice(0, 2).map((tag) => (
+            <span key={tag} className={styles.metaChip}>{tag}</span>
+          ))}
+        </div>
+        <div className={styles.appCardActions}>
+          {installed ? (
+            <a
+              className={styles.primaryButton}
+              href={siteHref(`/miniapps/${app.id}`)}
+              onClick={() => onOpen(app)}
+            >
+              打开 <ExternalLink />
+            </a>
+          ) : (
+            <button className={styles.primaryButton} type="button" onClick={() => onInstall(app)}>
+              安装 <Download />
+            </button>
+          )}
+          <button className={styles.secondaryButton} type="button" onClick={() => onPreview(app)}>
+            快速预览
+          </button>
+          <a className={styles.ghostButton} href={siteHref(`/apps/${app.slug}`)}>
+            详情 <ChevronRight />
+          </a>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function MarketplaceShell() {
+  const [section, setSection] = useState<MarketplaceSection>("discover");
+  const [category, setCategory] = useState<MarketplaceCategory>("featured");
+  const [query, setQuery] = useState("");
+  const [installedIds, setInstalledIds] = useState<string[]>([]);
+  const [recentIds, setRecentIds] = useState<string[]>([]);
+  const [previewId, setPreviewId] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setInstalledIds(readStringArray(INSTALLED_KEY));
+    setRecentIds(readStringArray(RECENT_KEY));
+
+    const params = new URLSearchParams(window.location.search);
+    const requestedCategory = params.get("category");
+    if (requestedCategory && categoryOrder.includes(requestedCategory as MarketplaceCategory)) {
+      setCategory(requestedCategory as MarketplaceCategory);
+    }
+    const requestedQuery = params.get("q")?.trim();
+    if (requestedQuery) setQuery(requestedQuery);
+  }, []);
+
+  useEffect(() => {
+    if (!previewId) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setPreviewId(null);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [previewId]);
+
+  const results = useMemo(() => searchMarketplace(query), [query]);
+  const installedSet = useMemo(() => new Set(installedIds), [installedIds]);
+  const previewApp = previewId ? getMarketplaceApp(previewId) : undefined;
+
+  const visibleApps = useMemo(() => {
+    let apps = results.apps;
+    if (!query.trim()) {
+      if (category === "featured") apps = apps.filter((app) => app.featured);
+      else apps = apps.filter((app) => app.category === category);
+    }
+    if (section === "installed") apps = apps.filter((app) => installedSet.has(app.id));
+    return apps;
+  }, [category, installedSet, query, results.apps, section]);
+
+  const showContent = section === "content" || Boolean(query.trim());
+  const visibleContent = results.content.slice(0, query.trim() ? 12 : 8);
+  const recentApps = recentIds
+    .map((id) => getMarketplaceApp(id))
+    .filter((app): app is MarketplaceApp => Boolean(app))
+    .slice(0, 4);
+
+  const saveInstalled = (ids: string[]) => {
+    const unique = [...new Set(ids)];
+    setInstalledIds(unique);
+    window.localStorage.setItem(INSTALLED_KEY, JSON.stringify(unique));
+    window.dispatchEvent(new CustomEvent("fabushi:marketplace-installed", { detail: { ids: unique } }));
+  };
+
+  const installApp = (app: MarketplaceApp) => {
+    saveInstalled([...installedIds, app.id]);
+  };
+
+  const markOpened = (app: MarketplaceApp) => {
+    const next = [app.id, ...recentIds.filter((id) => id !== app.id)].slice(0, 8);
+    setRecentIds(next);
+    window.localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  };
+
+  const submitSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalized = query.trim();
+    if (!normalized) {
+      searchRef.current?.focus();
+      return;
+    }
+    window.location.assign(siteHref(`/search?q=${encodeURIComponent(normalized)}`));
+  };
+
+  const focusSearch = () => {
+    setSection("discover");
+    window.setTimeout(() => searchRef.current?.focus(), 0);
+  };
+
+  const sectionTitle = query.trim()
+    ? `“${query.trim()}”的搜索结果`
+    : section === "installed"
+      ? "我的应用"
+      : section === "content"
+        ? "内容与工作流"
+        : category === "featured"
+          ? "本周精选"
+          : MARKETPLACE_CATEGORY_LABELS[category];
+
+  return (
+    <div className={styles.shell}>
+      <div className={styles.desktopGrid}>
+        <aside className={styles.leftRail} aria-label="主导航">
+          <a className={styles.brand} href={siteHref("/")} aria-label="Fabushi 应用市场首页">
+            <span className={styles.brandMark}>法</span>
+            <span className={styles.brandText}>
+              <strong>Fabushi</strong>
+              <small>Mini App Market</small>
+            </span>
+          </a>
+
+          <nav className={styles.navList}>
+            <button
+              className={`${styles.navButton} ${section === "discover" ? styles.navButtonActive : ""}`}
+              type="button"
+              onClick={() => setSection("discover")}
+            >
+              <Home /> <span>发现</span>
+            </button>
+            <button className={styles.navButton} type="button" onClick={focusSearch}>
+              <Search /> <span>搜索</span>
+            </button>
+            <button
+              className={`${styles.navButton} ${section === "installed" ? styles.navButtonActive : ""}`}
+              type="button"
+              onClick={() => setSection("installed")}
+            >
+              <Package /> <span>我的应用</span>
+            </button>
+            <button
+              className={`${styles.navButton} ${section === "content" ? styles.navButtonActive : ""}`}
+              type="button"
+              onClick={() => setSection("content")}
+            >
+              <BookOpen /> <span>内容入口</span>
+            </button>
+            <a className={styles.navLink} href={siteHref("/miniapps/bot-father/commerce")}>
+              <Code2 /> <span>开发者中心</span>
+            </a>
+          </nav>
+
+          <a className={styles.launchButton} href={siteHref("/app")}>打开大乘</a>
+
+          <a className={styles.profileCard} href={siteHref("/app")}>
+            <span className={styles.avatar}>普</span>
+            <span className={styles.profileCopy}>
+              <strong>我的 Fabushi</strong>
+              <small>{installedIds.length} 个已安装应用</small>
+            </span>
+          </a>
+        </aside>
+
+        <main className={styles.mainColumn}>
+          <header className={styles.stickyHeader}>
+            <span className={styles.headerTitle}>
+              <strong>应用市场</strong>
+              <small>发现、安装、立即运行</small>
+            </span>
+            <span className={styles.headerActions}>
+              <a className={styles.iconButton} href={siteHref("/miniapps/bot-father/commerce")} aria-label="开发者中心">
+                <Plus />
+              </a>
+              <a className={styles.iconButton} href={siteHref("/app")} aria-label="个人中心">
+                <User />
+              </a>
+            </span>
+          </header>
+
+          <section className={styles.hero}>
+            <p className={styles.heroEyebrow}>Apps that become tools</p>
+            <h1>安装一个应用，立即多一种能力。</h1>
+            <p>
+              像 Telegram Mini App 一样点开即用；像 Shopify App Store 一样可发现、可比较、可分发；每条内容都有独立搜索入口。
+            </p>
+            <div className={styles.heroBadges}>
+              <span className={styles.heroBadge}><Sparkles /> 即开即用</span>
+              <span className={styles.heroBadge}><ShieldCheck /> 权限逐项确认</span>
+              <span className={styles.heroBadge}><Layers3 /> WebMCP 可发现</span>
+            </div>
+          </section>
+
+          <form className={styles.searchForm} role="search" onSubmit={submitSearch}>
+            <Search />
+            <input
+              ref={searchRef}
+              className={styles.searchInput}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="搜索应用、能力、指南或工作流"
+              aria-label="搜索 Fabushi 应用与内容"
+            />
+            {query ? (
+              <button className={styles.searchClear} type="button" aria-label="清除搜索" onClick={() => setQuery("")}>
+                <X />
+              </button>
+            ) : null}
+          </form>
+
+          {section !== "content" ? (
+            <nav className={styles.categoryBar} aria-label="应用分类">
+              {categoryOrder.map((item) => (
+                <button
+                  key={item}
+                  className={`${styles.categoryButton} ${category === item ? styles.categoryButtonActive : ""}`}
+                  type="button"
+                  onClick={() => {
+                    setCategory(item);
+                    setSection("discover");
+                    window.history.replaceState(
+                      null,
+                      "",
+                      item === "featured" ? siteHref("/") : siteHref(`/?category=${item}`),
+                    );
+                  }}
+                >
+                  {MARKETPLACE_CATEGORY_LABELS[item]}
+                </button>
+              ))}
+            </nav>
+          ) : null}
+
+          <div className={styles.sectionHeader}>
+            <div>
+              <h2>{sectionTitle}</h2>
+              <p>
+                {section === "installed"
+                  ? `${visibleApps.length} 个应用已加入你的工作台`
+                  : query.trim()
+                    ? `${visibleApps.length} 个应用，${visibleContent.length} 条内容`
+                    : "应用运行在 Fabushi 的统一 Mini App 容器中"}
+              </p>
+            </div>
+            {query.trim() ? <a className={styles.sectionLink} href={siteHref(`/search?q=${encodeURIComponent(query.trim())}`)}>完整搜索</a> : null}
+          </div>
+
+          {section !== "content" ? (
+            visibleApps.length ? (
+              <div className={styles.appFeed}>
+                {visibleApps.map((app) => (
+                  <AppFeedCard
+                    key={app.id}
+                    app={app}
+                    installed={installedSet.has(app.id)}
+                    onInstall={installApp}
+                    onOpen={markOpened}
+                    onPreview={(candidate) => setPreviewId(candidate.id)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className={styles.emptyState}>
+                <span className={styles.emptyStateIcon}><Package /></span>
+                <h2>{section === "installed" ? "还没有安装应用" : "没有找到匹配应用"}</h2>
+                <p>{section === "installed" ? "从精选应用开始，安装后就会出现在这里。" : "换一个关键词或分类试试。"}</p>
+                {section === "installed" ? (
+                  <button className={styles.primaryButton} type="button" onClick={() => setSection("discover")}>发现应用</button>
+                ) : null}
+              </div>
+            )
+          ) : null}
+
+          {showContent ? (
+            <>
+              <div className={styles.sectionHeader}>
+                <div>
+                  <h2>内容级入口</h2>
+                  <p>指南、模板和工作流都能被搜索并直达</p>
+                </div>
+              </div>
+              {visibleContent.length ? (
+                <div className={styles.contentFeed}>
+                  {visibleContent.map(({ app, item }) => (
+                    <article key={`${app.id}:${item.id}`} className={styles.contentCard}>
+                      <span className={styles.contentType}><BookOpen /></span>
+                      <div>
+                        <h3>
+                          <a href={siteHref(`/apps/${app.slug}/content/${item.id}`)}>{item.title}</a>
+                        </h3>
+                        <p>{item.summary}</p>
+                        <div className={styles.contentMeta}>
+                          {app.name} · {contentTypeLabel(item.type)} · {item.readingMinutes} 分钟
+                        </div>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.emptyState}>
+                  <span className={styles.emptyStateIcon}><BookOpen /></span>
+                  <h2>没有找到匹配内容</h2>
+                  <p>尝试搜索具体主题、应用名、指南或工作流。</p>
+                </div>
+              )}
+            </>
+          ) : null}
+        </main>
+
+        <aside className={styles.rightRail} aria-label="发现更多">
+          <div className={styles.sideSearch}>
+            <form className={styles.searchForm} role="search" onSubmit={submitSearch}>
+              <Search />
+              <input
+                className={styles.searchInput}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="搜索市场"
+                aria-label="搜索市场"
+              />
+            </form>
+          </div>
+
+          {recentApps.length ? (
+            <section className={styles.sidePanel}>
+              <header className={styles.sidePanelHeader}>
+                <h2>最近打开</h2>
+                <p>在网页、桌面与移动端继续</p>
+              </header>
+              {recentApps.map((app) => (
+                <a
+                  key={app.id}
+                  className={styles.trendingItem}
+                  href={siteHref(`/miniapps/${app.id}`)}
+                  onClick={() => markOpened(app)}
+                >
+                  <span className={styles.trendingCopy}>
+                    <small>Mini App</small>
+                    <strong>{app.name}</strong>
+                    <span>{app.subtitle}</span>
+                  </span>
+                  <AppIcon label={app.icon} tone={app.tone} size="small" />
+                </a>
+              ))}
+            </section>
+          ) : null}
+
+          <section className={styles.sidePanel}>
+            <header className={styles.sidePanelHeader}>
+              <h2>正在流行</h2>
+              <p>基于市场内容、更新频率与功能完整度</p>
+            </header>
+            {marketplaceApps.slice(0, 5).map((app, index) => (
+              <a key={app.id} className={styles.trendingItem} href={siteHref(`/apps/${app.slug}`)}>
+                <span className={styles.trendingCopy}>
+                  <small>{index + 1} · {MARKETPLACE_CATEGORY_LABELS[app.category]}</small>
+                  <strong>{app.name}</strong>
+                  <span>{app.tags.slice(0, 2).join(" · ")}</span>
+                </span>
+                <AppIcon label={app.icon} tone={app.tone} size="small" />
+              </a>
+            ))}
+          </section>
+
+          <section className={styles.sidePanel}>
+            <header className={styles.sidePanelHeader}>
+              <h2>发布你的 Mini App</h2>
+              <p>提交应用资料、权限说明、内容入口与运行地址，通过同一身份覆盖网页和客户端。</p>
+            </header>
+            <div style={{ padding: "0 16px 16px" }}>
+              <a className={styles.primaryButton} href={siteHref("/miniapps/bot-father/commerce")}>
+                进入开发者中心 <Code2 />
+              </a>
+            </div>
+          </section>
+
+          <footer className={styles.sideFooter}>
+            <a href={siteHref("/privacy")}>隐私</a>
+            <a href={siteHref("/contact")}>支持</a>
+            <a href={siteHref("/download")}>客户端下载</a>
+            <a href={siteHref("/search")}>内容搜索</a>
+            <span>© 2026 Fabushi</span>
+          </footer>
+        </aside>
+      </div>
+
+      <nav className={styles.mobileNav} aria-label="移动端导航">
+        <button
+          className={`${styles.mobileNavButton} ${section === "discover" ? styles.mobileNavButtonActive : ""}`}
+          type="button"
+          onClick={() => setSection("discover")}
+        >
+          <Compass /> 发现
+        </button>
+        <button className={styles.mobileNavButton} type="button" onClick={focusSearch}>
+          <Search /> 搜索
+        </button>
+        <button
+          className={`${styles.mobileNavButton} ${section === "installed" ? styles.mobileNavButtonActive : ""}`}
+          type="button"
+          onClick={() => setSection("installed")}
+        >
+          <Package /> 应用
+        </button>
+        <a className={styles.mobileNavButton} href={siteHref("/app")}>
+          <User /> 我的
+        </a>
+      </nav>
+
+      {previewApp ? (
+        <div className={styles.previewBackdrop} role="presentation" onMouseDown={(event) => {
+          if (event.currentTarget === event.target) setPreviewId(null);
+        }}>
+          <section className={styles.previewPanel} role="dialog" aria-modal="true" aria-labelledby="preview-title">
+            <div className={styles.previewTop}>
+              <button className={styles.iconButton} type="button" aria-label="关闭预览" onClick={() => setPreviewId(null)}>
+                <X />
+              </button>
+            </div>
+            <div className={styles.previewHero}>
+              <AppIcon label={previewApp.icon} tone={previewApp.tone} size="large" />
+              <div>
+                <h2 id="preview-title">{previewApp.name}</h2>
+                <p>{previewApp.subtitle}</p>
+              </div>
+            </div>
+            <section className={styles.previewSection}>
+              <h3>关于这个应用</h3>
+              <p>{previewApp.description}</p>
+            </section>
+            <section className={styles.previewSection}>
+              <h3>核心体验</h3>
+              <div className={styles.highlightList}>
+                {previewApp.highlights.map((highlight) => (
+                  <article key={highlight.title} className={styles.highlightItem}>
+                    <strong>{highlight.title}</strong>
+                    <p>{highlight.description}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+            <section className={styles.previewSection}>
+              <h3>权限与价格</h3>
+              <p>{previewApp.permissions.join("；")}。</p>
+              <div className={styles.appMeta}>
+                <span className={styles.metaChip}>{previewApp.pricing.label}</span>
+                <span className={styles.metaChip}>v{previewApp.version}</span>
+                <span className={styles.metaChip}>{previewApp.content.length} 个内容入口</span>
+              </div>
+            </section>
+            <div className={styles.previewActions}>
+              <a className={styles.secondaryButton} href={siteHref(`/apps/${previewApp.slug}`)}>
+                完整详情
+              </a>
+              {installedSet.has(previewApp.id) ? (
+                <a
+                  className={styles.primaryButton}
+                  href={siteHref(`/miniapps/${previewApp.id}`)}
+                  onClick={() => markOpened(previewApp)}
+                >
+                  打开应用 <ExternalLink />
+                </a>
+              ) : (
+                <button className={styles.primaryButton} type="button" onClick={() => installApp(previewApp)}>
+                  安装应用 <Download />
+                </button>
+              )}
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/apps/web/src/components/marketplace/marketplace-webmcp.tsx
+++ b/frontend/apps/web/src/components/marketplace/marketplace-webmcp.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect } from "react";
+import { registerWebMcpTool } from "@fabushi/mcp-app-sdk";
+import {
+  MARKETPLACE_CATEGORY_LABELS,
+  getMarketplaceApp,
+  getMarketplaceContent,
+  marketplaceApps,
+  searchMarketplace,
+} from "../../lib/marketplace";
+import { siteUrl } from "../../lib/site-url";
+
+const INSTALLED_KEY = "fabushi.installed-miniapps";
+
+function asPositiveLimit(value: unknown, fallback = 10) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(30, Math.floor(parsed)));
+}
+
+function readInstalledApps() {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(INSTALLED_KEY) ?? "[]");
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function MarketplaceWebMcp() {
+  useEffect(() => {
+    const disposers = [
+      registerWebMcpTool({
+        name: "search_fabushi_marketplace",
+        title: "Search Fabushi apps and content",
+        description:
+          "Search the Fabushi Mini App marketplace across app names, capabilities, tags, guides, templates and workflows. Returns stable deep links for every result.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Search terms in Chinese or English." },
+            kind: {
+              type: "string",
+              enum: ["all", "apps", "content"],
+              description: "Optional result kind. Defaults to all.",
+            },
+            limit: { type: "number", minimum: 1, maximum: 30, description: "Maximum results per kind." },
+          },
+          required: ["query"],
+        },
+        execute: (input) => {
+          const query = typeof input.query === "string" ? input.query : "";
+          const kind = input.kind === "apps" || input.kind === "content" ? input.kind : "all";
+          const limit = asPositiveLimit(input.limit);
+          const results = searchMarketplace(query);
+          return {
+            query,
+            apps:
+              kind === "content"
+                ? []
+                : results.apps.slice(0, limit).map((app) => ({
+                    id: app.id,
+                    slug: app.slug,
+                    name: app.name,
+                    subtitle: app.subtitle,
+                    category: MARKETPLACE_CATEGORY_LABELS[app.category],
+                    tags: app.tags,
+                    detailsUrl: siteUrl(`/apps/${app.slug}`),
+                    launchUrl: siteUrl(`/miniapps/${app.id}`),
+                  })),
+            content:
+              kind === "apps"
+                ? []
+                : results.content.slice(0, limit).map(({ app, item }) => ({
+                    id: item.id,
+                    app: app.name,
+                    appSlug: app.slug,
+                    type: item.type,
+                    title: item.title,
+                    summary: item.summary,
+                    keywords: item.keywords,
+                    url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
+                  })),
+          };
+        },
+      }),
+      registerWebMcpTool({
+        name: "get_fabushi_app",
+        title: "Get a Fabushi app listing",
+        description:
+          "Get the complete public listing for a Fabushi Mini App, including capabilities, permissions, pricing, version, content entries and launch URL.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            slug: { type: "string", description: "The app slug or Mini App ID." },
+          },
+          required: ["slug"],
+        },
+        execute: (input) => {
+          const slug = typeof input.slug === "string" ? input.slug : "";
+          const app = getMarketplaceApp(slug);
+          if (!app) return { found: false, slug };
+          return {
+            found: true,
+            app: {
+              ...app,
+              categoryLabel: MARKETPLACE_CATEGORY_LABELS[app.category],
+              detailsUrl: siteUrl(`/apps/${app.slug}`),
+              launchUrl: siteUrl(`/miniapps/${app.id}`),
+              content: app.content.map((item) => ({
+                ...item,
+                url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
+              })),
+            },
+          };
+        },
+      }),
+      registerWebMcpTool({
+        name: "get_fabushi_content",
+        title: "Get Fabushi content by deep link ID",
+        description:
+          "Retrieve one public guide, template, collection, workflow or release entry from a Fabushi app using its stable app slug and content ID.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            appSlug: { type: "string", description: "The parent app slug." },
+            contentId: { type: "string", description: "The stable content ID." },
+          },
+          required: ["appSlug", "contentId"],
+        },
+        execute: (input) => {
+          const appSlug = typeof input.appSlug === "string" ? input.appSlug : "";
+          const contentId = typeof input.contentId === "string" ? input.contentId : "";
+          const result = getMarketplaceContent(appSlug, contentId);
+          if (!result) return { found: false, appSlug, contentId };
+          return {
+            found: true,
+            app: {
+              id: result.app.id,
+              slug: result.app.slug,
+              name: result.app.name,
+              detailsUrl: siteUrl(`/apps/${result.app.slug}`),
+              launchUrl: siteUrl(`/miniapps/${result.app.id}`),
+            },
+            content: {
+              ...result.item,
+              url: siteUrl(`/apps/${result.app.slug}/content/${result.item.id}`),
+            },
+          };
+        },
+      }),
+      registerWebMcpTool({
+        name: "install_fabushi_app",
+        title: "Install a Fabushi app",
+        description:
+          "Add a Fabushi Mini App to the current user's installed workspace. This changes local marketplace state and always asks the user for confirmation before writing.",
+        annotations: { readOnlyHint: false },
+        inputSchema: {
+          type: "object",
+          properties: {
+            slug: { type: "string", description: "The app slug or Mini App ID to install." },
+          },
+          required: ["slug"],
+        },
+        execute: (input) => {
+          const slug = typeof input.slug === "string" ? input.slug : "";
+          const app = getMarketplaceApp(slug);
+          if (!app) return { installed: false, error: "app_not_found", slug };
+
+          const installed = readInstalledApps();
+          if (installed.includes(app.id)) {
+            return {
+              installed: true,
+              alreadyInstalled: true,
+              appId: app.id,
+              launchUrl: siteUrl(`/miniapps/${app.id}`),
+            };
+          }
+
+          if (!window.confirm(`将 ${app.name} 安装到“我的应用”？`)) {
+            return { installed: false, cancelled: true, appId: app.id };
+          }
+
+          const next = [...new Set([...installed, app.id])];
+          window.localStorage.setItem(INSTALLED_KEY, JSON.stringify(next));
+          window.dispatchEvent(
+            new CustomEvent("fabushi:marketplace-installed", { detail: { ids: next } }),
+          );
+          return {
+            installed: true,
+            appId: app.id,
+            detailsUrl: siteUrl(`/apps/${app.slug}`),
+            launchUrl: siteUrl(`/miniapps/${app.id}`),
+          };
+        },
+      }),
+      registerWebMcpTool({
+        name: "list_fabushi_marketplace_categories",
+        title: "List Fabushi marketplace categories",
+        description: "List public Fabushi app categories and the apps currently available in each category.",
+        annotations: { readOnlyHint: true },
+        inputSchema: { type: "object", properties: {} },
+        execute: () => ({
+          categories: Object.entries(MARKETPLACE_CATEGORY_LABELS).map(([id, label]) => ({
+            id,
+            label,
+            apps:
+              id === "featured"
+                ? marketplaceApps.filter((app) => app.featured).map((app) => app.slug)
+                : marketplaceApps.filter((app) => app.category === id).map((app) => app.slug),
+          })),
+        }),
+      }),
+    ];
+
+    window.dispatchEvent(
+      new CustomEvent("fabushi:marketplace-webmcp-ready", {
+        detail: {
+          tools: [
+            "search_fabushi_marketplace",
+            "get_fabushi_app",
+            "get_fabushi_content",
+            "install_fabushi_app",
+            "list_fabushi_marketplace_categories",
+          ],
+        },
+      }),
+    );
+
+    return () => {
+      for (const dispose of disposers.reverse()) dispose();
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/apps/web/src/components/marketplace/marketplace.module.css
+++ b/frontend/apps/web/src/components/marketplace/marketplace.module.css
@@ -1,0 +1,1977 @@
+.shell {
+  --market-bg: #000;
+  --market-surface: #0b0b0c;
+  --market-surface-strong: #111214;
+  --market-surface-soft: #17181b;
+  --market-line: #242529;
+  --market-line-strong: #34363b;
+  --market-ink: #f7f9f9;
+  --market-muted: #8b98a5;
+  --market-blue: #1d9bf0;
+  --market-blue-soft: rgba(29, 155, 240, 0.14);
+  --market-green: #00ba7c;
+  --market-orange: #f59e0b;
+  min-height: 100svh;
+  background: var(--market-bg);
+  color: var(--market-ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.shell *,
+.detailShell * {
+  box-sizing: border-box;
+}
+
+.desktopGrid {
+  width: min(100%, 1380px);
+  min-height: 100svh;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 660px) 350px;
+}
+
+.leftRail {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100svh;
+  padding: 14px 18px 20px 22px;
+  border-right: 1px solid var(--market-line);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.brand {
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-radius: 999px;
+}
+
+.brand:hover {
+  background: rgba(239, 243, 244, 0.08);
+}
+
+.brandMark {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, #2aabee, #1d76d2 72%);
+  color: #fff;
+  font-weight: 900;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 10px 28px rgba(29, 155, 240, 0.25);
+}
+
+.brandText {
+  display: grid;
+  gap: 1px;
+}
+
+.brandText strong {
+  font-size: 1.02rem;
+  letter-spacing: -0.02em;
+}
+
+.brandText small {
+  color: var(--market-muted);
+  font-size: 0.72rem;
+}
+
+.navList {
+  display: grid;
+  gap: 8px;
+}
+
+.navButton,
+.navLink {
+  width: 100%;
+  min-height: 50px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--market-ink);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 1.1rem;
+  font-weight: 650;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.navButton:hover,
+.navLink:hover,
+.navButtonActive {
+  background: rgba(239, 243, 244, 0.1);
+}
+
+.navButtonActive {
+  color: #fff;
+}
+
+.navButton svg,
+.navLink svg {
+  width: 24px;
+  height: 24px;
+  stroke-width: 1.8;
+}
+
+.launchButton {
+  min-height: 52px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--market-blue);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  padding: 0 22px;
+  font-weight: 800;
+  font-size: 1rem;
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.launchButton:hover {
+  background: #1a8cd8;
+  transform: translateY(-1px);
+}
+
+.profileCard {
+  margin-top: auto;
+  padding: 12px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--market-ink);
+}
+
+.profileCard:hover {
+  background: rgba(239, 243, 244, 0.08);
+}
+
+.avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, #413b52, #21222a);
+  color: #fff;
+  font-weight: 800;
+}
+
+.profileCopy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.profileCopy strong,
+.profileCopy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profileCopy small {
+  color: var(--market-muted);
+}
+
+.mainColumn {
+  min-width: 0;
+  border-right: 1px solid var(--market-line);
+}
+
+.stickyHeader {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  min-height: 54px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--market-line);
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.headerTitle {
+  display: grid;
+  gap: 1px;
+}
+
+.headerTitle strong {
+  font-size: 1.05rem;
+}
+
+.headerTitle small {
+  color: var(--market-muted);
+  font-size: 0.74rem;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.iconButton {
+  width: 38px;
+  height: 38px;
+  border: 0;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  color: var(--market-ink);
+  cursor: pointer;
+}
+
+.iconButton:hover {
+  background: rgba(239, 243, 244, 0.1);
+}
+
+.iconButton svg {
+  width: 20px;
+  height: 20px;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 30px 22px 24px;
+  border-bottom: 1px solid var(--market-line);
+  background:
+    radial-gradient(circle at 86% 20%, rgba(29, 155, 240, 0.26), transparent 30%),
+    radial-gradient(circle at 18% 84%, rgba(126, 87, 194, 0.2), transparent 32%),
+    #050506;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  right: -90px;
+  top: -120px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+  box-shadow: 0 0 0 34px rgba(255, 255, 255, 0.025), 0 0 0 70px rgba(255, 255, 255, 0.018);
+  pointer-events: none;
+}
+
+.heroEyebrow {
+  position: relative;
+  z-index: 1;
+  margin: 0 0 10px;
+  color: #8bc9f1;
+  font-weight: 750;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 3.5rem);
+  line-height: 1.02;
+  letter-spacing: -0.055em;
+}
+
+.hero p {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+  margin: 14px 0 0;
+  color: #b9c3cc;
+  line-height: 1.6;
+}
+
+.heroBadges {
+  position: relative;
+  z-index: 1;
+  margin-top: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.heroBadge {
+  min-height: 30px;
+  padding: 0 11px;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #d7e0e6;
+  font-size: 0.78rem;
+}
+
+.heroBadge svg {
+  width: 14px;
+  height: 14px;
+  color: #6cc6ff;
+}
+
+.searchForm {
+  position: relative;
+  margin: 14px 16px 0;
+}
+
+.searchForm svg {
+  position: absolute;
+  left: 15px;
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  color: var(--market-muted);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  height: 46px;
+  padding: 0 44px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  outline: 0;
+  background: #202327;
+  color: var(--market-ink);
+  font: inherit;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.searchInput::placeholder {
+  color: #8b98a5;
+}
+
+.searchInput:focus {
+  border-color: var(--market-blue);
+  background: #000;
+}
+
+.searchClear {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--market-blue);
+  color: #fff;
+  transform: translateY(-50%);
+  cursor: pointer;
+}
+
+.searchClear svg {
+  position: static;
+  width: 16px;
+  height: 16px;
+  color: inherit;
+  transform: none;
+}
+
+.categoryBar {
+  position: sticky;
+  top: 54px;
+  z-index: 20;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--market-line);
+  background: rgba(0, 0, 0, 0.88);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.categoryBar::-webkit-scrollbar {
+  display: none;
+}
+
+.categoryButton {
+  flex: 0 0 auto;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--market-line-strong);
+  border-radius: 999px;
+  background: transparent;
+  color: #d8dde1;
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 650;
+}
+
+.categoryButton:hover,
+.categoryButtonActive {
+  border-color: #eff3f4;
+  background: #eff3f4;
+  color: #0f1419;
+}
+
+.sectionHeader {
+  padding: 20px 16px 12px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sectionHeader h2 {
+  margin: 0;
+  font-size: 1.22rem;
+  letter-spacing: -0.025em;
+}
+
+.sectionHeader p {
+  margin: 4px 0 0;
+  color: var(--market-muted);
+  font-size: 0.82rem;
+}
+
+.sectionLink {
+  color: var(--market-blue);
+  font-size: 0.84rem;
+}
+
+.appFeed {
+  border-top: 1px solid var(--market-line);
+}
+
+.appCard {
+  padding: 18px 16px;
+  border-bottom: 1px solid var(--market-line);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  transition: background 150ms ease;
+}
+
+.appCard:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.appCardBody {
+  min-width: 0;
+}
+
+.appCardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.appTitleRow {
+  min-width: 0;
+}
+
+.appNameLine {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.appNameLine a,
+.appNameLine strong {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+}
+
+.appNameLine a:hover {
+  text-decoration: underline;
+}
+
+.verified {
+  width: 16px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--market-blue);
+  color: #fff;
+}
+
+.verified svg {
+  width: 11px;
+  height: 11px;
+  stroke-width: 3;
+}
+
+.developerLine {
+  margin-top: 3px;
+  color: var(--market-muted);
+  font-size: 0.8rem;
+}
+
+.appDescription {
+  margin: 8px 0 0;
+  color: #d8dde1;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.appMeta {
+  margin-top: 11px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.metaChip {
+  min-height: 25px;
+  padding: 0 9px;
+  border: 1px solid var(--market-line);
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #aab4bc;
+  font-size: 0.72rem;
+}
+
+.metaChip svg {
+  width: 12px;
+  height: 12px;
+}
+
+.appCardActions {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.primaryButton,
+.secondaryButton,
+.ghostButton {
+  min-height: 36px;
+  padding: 0 15px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 750;
+  transition: transform 150ms ease, background 150ms ease, border-color 150ms ease;
+}
+
+.primaryButton {
+  border: 1px solid var(--market-blue);
+  background: var(--market-blue);
+  color: #fff;
+}
+
+.primaryButton:hover {
+  border-color: #1a8cd8;
+  background: #1a8cd8;
+  transform: translateY(-1px);
+}
+
+.secondaryButton {
+  border: 1px solid var(--market-line-strong);
+  background: transparent;
+  color: var(--market-ink);
+}
+
+.secondaryButton:hover {
+  border-color: #eff3f4;
+  background: rgba(239, 243, 244, 0.08);
+}
+
+.ghostButton {
+  border: 0;
+  background: transparent;
+  color: var(--market-blue);
+}
+
+.ghostButton:hover {
+  background: var(--market-blue-soft);
+}
+
+.primaryButton svg,
+.secondaryButton svg,
+.ghostButton svg {
+  width: 15px;
+  height: 15px;
+}
+
+.appIcon {
+  position: relative;
+  flex: 0 0 auto;
+  width: 58px;
+  height: 58px;
+  border-radius: 17px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  color: #fff;
+  font-size: 1.3rem;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16), 0 8px 22px rgba(0, 0, 0, 0.28);
+}
+
+.appIcon::before {
+  content: "";
+  position: absolute;
+  inset: -40% 34% 34% -40%;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.22);
+  filter: blur(5px);
+}
+
+.appIcon::after {
+  content: "";
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  right: -12px;
+  bottom: -12px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 50%;
+}
+
+.appIcon span {
+  position: relative;
+  z-index: 1;
+}
+
+.appIconSmall {
+  width: 44px;
+  height: 44px;
+  border-radius: 13px;
+  font-size: 1rem;
+}
+
+.appIconLarge {
+  width: 96px;
+  height: 96px;
+  border-radius: 26px;
+  font-size: 2.2rem;
+}
+
+.toneViolet { background: linear-gradient(145deg, #8b5cf6, #4c1d95); }
+.toneBlue { background: linear-gradient(145deg, #38bdf8, #1d4ed8); }
+.toneOrange { background: linear-gradient(145deg, #fb923c, #c2410c); }
+.toneGreen { background: linear-gradient(145deg, #34d399, #047857); }
+.tonePink { background: linear-gradient(145deg, #f472b6, #9d174d); }
+.toneCyan { background: linear-gradient(145deg, #22d3ee, #0e7490); }
+.toneYellow { background: linear-gradient(145deg, #facc15, #b45309); }
+.toneSlate { background: linear-gradient(145deg, #94a3b8, #334155); }
+
+.contentFeed {
+  display: grid;
+  border-top: 1px solid var(--market-line);
+}
+
+.contentCard {
+  padding: 16px;
+  border-bottom: 1px solid var(--market-line);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  transition: background 150ms ease;
+}
+
+.contentCard:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.contentType {
+  margin-top: 2px;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: var(--market-blue-soft);
+  color: #65bcf3;
+}
+
+.contentType svg {
+  width: 16px;
+  height: 16px;
+}
+
+.contentCard h3 {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.35;
+}
+
+.contentCard h3 a:hover {
+  text-decoration: underline;
+}
+
+.contentCard p {
+  margin: 5px 0 0;
+  color: var(--market-muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.contentMeta {
+  margin-top: 8px;
+  color: #65717c;
+  font-size: 0.73rem;
+}
+
+.emptyState {
+  padding: 64px 24px;
+  text-align: center;
+  border-top: 1px solid var(--market-line);
+}
+
+.emptyStateIcon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 14px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #15171a;
+  color: var(--market-muted);
+}
+
+.emptyStateIcon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emptyState h2 {
+  margin: 0;
+  font-size: 1.12rem;
+}
+
+.emptyState p {
+  max-width: 400px;
+  margin: 8px auto 0;
+  color: var(--market-muted);
+  line-height: 1.55;
+}
+
+.rightRail {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100svh;
+  padding: 12px 20px 24px 24px;
+  overflow-y: auto;
+}
+
+.sideSearch {
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  padding-bottom: 12px;
+  background: #000;
+}
+
+.sidePanel {
+  margin-bottom: 16px;
+  border: 1px solid var(--market-line);
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--market-surface);
+}
+
+.sidePanelHeader {
+  padding: 14px 16px 10px;
+}
+
+.sidePanelHeader h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  letter-spacing: -0.025em;
+}
+
+.sidePanelHeader p {
+  margin: 5px 0 0;
+  color: var(--market-muted);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.trendingItem {
+  padding: 12px 16px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.trendingItem:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.trendingCopy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.trendingCopy small {
+  color: var(--market-muted);
+  font-size: 0.72rem;
+}
+
+.trendingCopy strong {
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trendingCopy span {
+  color: #65717c;
+  font-size: 0.72rem;
+}
+
+.sideFooter {
+  padding: 2px 10px 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: #65717c;
+  font-size: 0.72rem;
+}
+
+.sideFooter a:hover {
+  text-decoration: underline;
+}
+
+.mobileNav {
+  display: none;
+}
+
+.previewBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  justify-content: flex-end;
+  animation: fadeIn 150ms ease;
+}
+
+.previewPanel {
+  width: min(100%, 520px);
+  height: 100%;
+  padding: 18px;
+  overflow-y: auto;
+  border-left: 1px solid var(--market-line-strong);
+  background: #08090a;
+  box-shadow: -26px 0 70px rgba(0, 0, 0, 0.46);
+  animation: slideIn 190ms ease;
+}
+
+.previewTop {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.previewHero {
+  padding: 12px 4px 20px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+}
+
+.previewHero h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.previewHero p {
+  margin: 6px 0 0;
+  color: var(--market-muted);
+  line-height: 1.45;
+}
+
+.previewSection {
+  padding: 18px 4px;
+  border-top: 1px solid var(--market-line);
+}
+
+.previewSection h3 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+.previewSection p {
+  margin: 0;
+  color: #c4ccd3;
+  line-height: 1.6;
+}
+
+.highlightList {
+  display: grid;
+  gap: 12px;
+}
+
+.highlightItem {
+  padding: 14px;
+  border: 1px solid var(--market-line);
+  border-radius: 14px;
+  background: #101114;
+}
+
+.highlightItem strong {
+  display: block;
+  font-size: 0.9rem;
+}
+
+.highlightItem p {
+  margin-top: 5px;
+  color: var(--market-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.previewActions {
+  position: sticky;
+  bottom: -18px;
+  padding: 14px 4px 18px;
+  background: linear-gradient(180deg, rgba(8, 9, 10, 0), #08090a 28%);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.previewActions .primaryButton,
+.previewActions .secondaryButton {
+  min-height: 44px;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideIn {
+  from { transform: translateX(26px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+/* Detail and content pages */
+.detailShell {
+  --detail-bg: #f6f6f7;
+  --detail-ink: #202223;
+  --detail-muted: #6d7175;
+  --detail-line: #dfe3e8;
+  --detail-card: #fff;
+  min-height: 100svh;
+  background: var(--detail-bg);
+  color: var(--detail-ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.detailHeader {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  height: 64px;
+  border-bottom: 1px solid var(--detail-line);
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.detailHeaderInner {
+  width: min(100% - 32px, 1180px);
+  height: 100%;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detailBrand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 850;
+}
+
+.detailBrand .brandMark {
+  width: 34px;
+  height: 34px;
+  border-radius: 11px;
+}
+
+.detailNav {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  color: var(--detail-muted);
+  font-size: 0.86rem;
+}
+
+.detailNav a:hover {
+  color: var(--detail-ink);
+}
+
+.detailMain {
+  width: min(100% - 32px, 1120px);
+  margin: 0 auto;
+  padding: 28px 0 72px;
+}
+
+.breadcrumbs {
+  margin-bottom: 22px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  color: var(--detail-muted);
+  font-size: 0.78rem;
+}
+
+.breadcrumbs a:hover {
+  color: #006fbb;
+  text-decoration: underline;
+}
+
+.breadcrumbs svg {
+  width: 13px;
+  height: 13px;
+}
+
+.appHeroCard {
+  padding: clamp(22px, 5vw, 42px);
+  border: 1px solid var(--detail-line);
+  border-radius: 22px;
+  background: var(--detail-card);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+}
+
+.appHeroCopy {
+  min-width: 0;
+}
+
+.appHeroTitleLine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.appHeroTitleLine h1 {
+  margin: 0;
+  color: #1a1c1d;
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  letter-spacing: -0.045em;
+}
+
+.appHeroCopy .verified {
+  width: 20px;
+  height: 20px;
+}
+
+.appHeroSubtitle {
+  margin: 8px 0 0;
+  color: #3f454a;
+  font-size: 1.03rem;
+  line-height: 1.5;
+}
+
+.appHeroDescription {
+  max-width: 690px;
+  margin: 13px 0 0;
+  color: var(--detail-muted);
+  line-height: 1.7;
+}
+
+.appHeroDeveloper {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--detail-muted);
+  font-size: 0.82rem;
+}
+
+.detailBadge {
+  min-height: 25px;
+  padding: 0 9px;
+  border: 1px solid var(--detail-line);
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  background: #f8f9fa;
+  color: #52585d;
+  font-size: 0.72rem;
+}
+
+.heroInstall {
+  min-width: 180px;
+  display: grid;
+  gap: 9px;
+}
+
+.heroInstall small {
+  color: var(--detail-muted);
+  font-size: 0.72rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.detailPrimary,
+.detailSecondary {
+  min-height: 44px;
+  padding: 0 18px;
+  border-radius: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  font-weight: 750;
+  font-size: 0.88rem;
+}
+
+.detailPrimary {
+  border: 1px solid #008060;
+  background: #008060;
+  color: #fff;
+}
+
+.detailPrimary:hover {
+  border-color: #006e52;
+  background: #006e52;
+}
+
+.detailPrimary:disabled {
+  border-color: #8c9196;
+  background: #8c9196;
+  cursor: default;
+  opacity: 0.78;
+}
+
+.detailSecondary {
+  border: 1px solid #babfc3;
+  background: #fff;
+  color: #202223;
+}
+
+.detailSecondary:hover {
+  background: #f1f2f3;
+}
+
+.detailPrimary svg,
+.detailSecondary svg {
+  width: 16px;
+  height: 16px;
+}
+
+.statsGrid {
+  margin: 18px 0 0;
+  border: 1px solid var(--detail-line);
+  border-radius: 16px;
+  background: var(--detail-card);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  overflow: hidden;
+}
+
+.statItem {
+  min-height: 96px;
+  padding: 18px;
+  border-right: 1px solid var(--detail-line);
+  display: grid;
+  align-content: center;
+  gap: 5px;
+}
+
+.statItem:last-child {
+  border-right: 0;
+}
+
+.statItem small {
+  color: var(--detail-muted);
+  font-size: 0.75rem;
+}
+
+.statItem strong {
+  font-size: 0.95rem;
+}
+
+.detailGrid {
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 18px;
+  align-items: start;
+}
+
+.detailCard {
+  border: 1px solid var(--detail-line);
+  border-radius: 16px;
+  background: var(--detail-card);
+  overflow: hidden;
+}
+
+.detailSection {
+  padding: 24px;
+  border-bottom: 1px solid var(--detail-line);
+}
+
+.detailSection:last-child {
+  border-bottom: 0;
+}
+
+.detailSection h2 {
+  margin: 0;
+  font-size: 1.18rem;
+  letter-spacing: -0.02em;
+}
+
+.detailSection > p {
+  margin: 9px 0 0;
+  color: var(--detail-muted);
+  line-height: 1.65;
+}
+
+.screenshotGrid {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.screenshotCard {
+  min-height: 290px;
+  padding: 20px;
+  border-radius: 16px;
+  overflow: hidden;
+  position: relative;
+  background: #0d1015;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.screenshotCard:nth-child(2) {
+  background: linear-gradient(155deg, #163048, #091018 70%);
+}
+
+.screenshotCard:nth-child(3) {
+  background: linear-gradient(155deg, #2d1f43, #0c0b10 70%);
+}
+
+.screenshotCard::before {
+  content: "";
+  position: absolute;
+  inset: 20px 18px 88px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px 22px 12px 12px;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.03)),
+    repeating-linear-gradient(180deg, transparent 0 23px, rgba(255, 255, 255, 0.07) 23px 24px);
+  box-shadow: inset 0 0 0 8px rgba(0, 0, 0, 0.18);
+}
+
+.screenshotCard strong,
+.screenshotCard p {
+  position: relative;
+  z-index: 1;
+}
+
+.screenshotCard strong {
+  font-size: 0.92rem;
+}
+
+.screenshotCard p {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.featureGrid {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.featureItem {
+  padding: 16px;
+  border: 1px solid var(--detail-line);
+  border-radius: 12px;
+  background: #fafbfb;
+}
+
+.featureItem strong {
+  display: block;
+  font-size: 0.9rem;
+}
+
+.featureItem p {
+  margin: 6px 0 0;
+  color: var(--detail-muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.list {
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 11px;
+}
+
+.list li {
+  display: flex;
+  gap: 9px;
+  color: #41474c;
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+.list li svg {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  color: #008060;
+}
+
+.contentList {
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.contentListItem {
+  padding: 14px;
+  border: 1px solid var(--detail-line);
+  border-radius: 12px;
+  background: #fff;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.contentListItem:hover {
+  border-color: #8c9196;
+}
+
+.contentListItem h3 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.contentListItem p {
+  margin: 5px 0 0;
+  color: var(--detail-muted);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.contentListItem svg {
+  width: 16px;
+  height: 16px;
+  color: var(--detail-muted);
+}
+
+.sidebarCard {
+  padding: 20px;
+  border: 1px solid var(--detail-line);
+  border-radius: 16px;
+  background: var(--detail-card);
+  margin-bottom: 14px;
+}
+
+.sidebarCard h2,
+.sidebarCard h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.sidebarCard p {
+  margin: 8px 0 0;
+  color: var(--detail-muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.sidebarRows {
+  margin-top: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.sidebarRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  color: var(--detail-muted);
+  font-size: 0.78rem;
+}
+
+.sidebarRow strong {
+  color: var(--detail-ink);
+  text-align: right;
+}
+
+.tagList {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.detailTag {
+  min-height: 27px;
+  padding: 0 9px;
+  border-radius: 999px;
+  background: #edf7f5;
+  color: #006e52;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+}
+
+.faqList {
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.faqItem {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--detail-line);
+}
+
+.faqItem:last-child {
+  border-bottom: 0;
+}
+
+.faqItem strong {
+  display: block;
+  font-size: 0.88rem;
+}
+
+.faqItem p {
+  margin: 7px 0 0;
+  color: var(--detail-muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.articleLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 760px) 300px;
+  gap: 24px;
+  align-items: start;
+}
+
+.articleCard {
+  padding: clamp(22px, 5vw, 44px);
+  border: 1px solid var(--detail-line);
+  border-radius: 18px;
+  background: #fff;
+}
+
+.articleEyebrow {
+  margin: 0 0 10px;
+  color: #008060;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.articleCard h1 {
+  margin: 0;
+  color: #191b1c;
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+}
+
+.articleSummary {
+  margin: 18px 0 0;
+  color: #4a5055;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.articleMeta {
+  margin: 18px 0 0;
+  padding: 14px 0;
+  border-top: 1px solid var(--detail-line);
+  border-bottom: 1px solid var(--detail-line);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  color: var(--detail-muted);
+  font-size: 0.78rem;
+}
+
+.articleMeta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.articleMeta svg {
+  width: 14px;
+  height: 14px;
+}
+
+.articleBody {
+  margin-top: 28px;
+  display: grid;
+  gap: 18px;
+}
+
+.articleBody p {
+  margin: 0;
+  color: #30363a;
+  font-size: 1rem;
+  line-height: 1.85;
+}
+
+.articleCallout {
+  margin-top: 26px;
+  padding: 18px;
+  border-left: 4px solid #008060;
+  border-radius: 0 12px 12px 0;
+  background: #edf7f5;
+}
+
+.articleCallout strong {
+  display: block;
+}
+
+.articleCallout p {
+  margin: 7px 0 0;
+  color: #4a5055;
+  line-height: 1.55;
+}
+
+.articleAppCard {
+  padding: 18px;
+  border: 1px solid var(--detail-line);
+  border-radius: 16px;
+  background: #fff;
+}
+
+.articleAppTop {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.articleAppTop h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.articleAppTop p {
+  margin: 4px 0 0;
+  color: var(--detail-muted);
+  font-size: 0.76rem;
+}
+
+.articleAppCard > p {
+  margin: 13px 0 0;
+  color: var(--detail-muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.articleAppActions {
+  margin-top: 14px;
+  display: grid;
+  gap: 8px;
+}
+
+.searchPage {
+  min-height: 100svh;
+  background: #000;
+  color: var(--market-ink);
+}
+
+.searchPageInner {
+  width: min(100%, 760px);
+  min-height: 100svh;
+  margin: 0 auto;
+  border-left: 1px solid var(--market-line);
+  border-right: 1px solid var(--market-line);
+}
+
+.searchPageHeader {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--market-line);
+  background: rgba(0, 0, 0, 0.88);
+  backdrop-filter: blur(16px);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.searchPageHeader .searchForm {
+  margin: 0;
+}
+
+.searchSummary {
+  padding: 22px 16px 12px;
+}
+
+.searchSummary h1 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.searchSummary p {
+  margin: 7px 0 0;
+  color: var(--market-muted);
+  font-size: 0.86rem;
+}
+
+@media (max-width: 1180px) {
+  .desktopGrid {
+    grid-template-columns: 90px minmax(0, 660px) 330px;
+  }
+
+  .leftRail {
+    padding-left: 12px;
+    padding-right: 12px;
+    align-items: center;
+  }
+
+  .brandText,
+  .navButton span,
+  .navLink span,
+  .profileCopy {
+    display: none;
+  }
+
+  .navButton,
+  .navLink {
+    width: 52px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .launchButton {
+    width: 52px;
+    padding: 0;
+    font-size: 0;
+  }
+
+  .launchButton::before {
+    content: "+";
+    font-size: 1.5rem;
+  }
+
+  .profileCard {
+    padding: 7px;
+  }
+}
+
+@media (max-width: 1000px) {
+  .desktopGrid {
+    width: min(100%, 760px);
+    grid-template-columns: 88px minmax(0, 1fr);
+  }
+
+  .rightRail {
+    display: none;
+  }
+
+  .mainColumn {
+    border-right: 0;
+  }
+
+  .detailGrid,
+  .articleLayout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .articleAside {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+  }
+}
+
+@media (max-width: 760px) {
+  .shell {
+    padding-bottom: 66px;
+  }
+
+  .desktopGrid {
+    width: 100%;
+    display: block;
+  }
+
+  .leftRail {
+    display: none;
+  }
+
+  .mainColumn {
+    width: 100%;
+  }
+
+  .stickyHeader {
+    min-height: 50px;
+  }
+
+  .categoryBar {
+    top: 50px;
+  }
+
+  .hero {
+    padding: 26px 18px 22px;
+  }
+
+  .hero h1 {
+    font-size: clamp(2rem, 12vw, 3.25rem);
+  }
+
+  .hero p {
+    font-size: 0.92rem;
+  }
+
+  .mobileNav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 80;
+    min-height: 62px;
+    padding: 7px 10px max(7px, env(safe-area-inset-bottom));
+    border-top: 1px solid var(--market-line);
+    background: rgba(0, 0, 0, 0.92);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .mobileNavButton {
+    border: 0;
+    background: transparent;
+    color: var(--market-muted);
+    display: grid;
+    justify-items: center;
+    align-content: center;
+    gap: 2px;
+    cursor: pointer;
+    font-size: 0.65rem;
+  }
+
+  .mobileNavButton svg {
+    width: 21px;
+    height: 21px;
+  }
+
+  .mobileNavButtonActive {
+    color: #fff;
+  }
+
+  .previewBackdrop {
+    align-items: flex-end;
+  }
+
+  .previewPanel {
+    width: 100%;
+    height: min(88svh, 760px);
+    border-left: 0;
+    border-top: 1px solid var(--market-line-strong);
+    border-radius: 22px 22px 0 0;
+    animation: sheetIn 190ms ease;
+  }
+
+  .previewPanel::before {
+    content: "";
+    display: block;
+    width: 44px;
+    height: 4px;
+    margin: -8px auto 8px;
+    border-radius: 999px;
+    background: #3b3e43;
+  }
+
+  .appHeroCard {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .heroInstall {
+    grid-column: 1 / -1;
+    min-width: 0;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .heroInstall small {
+    grid-column: 1 / -1;
+  }
+
+  .statsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .statItem:nth-child(2) {
+    border-right: 0;
+  }
+
+  .statItem:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--detail-line);
+  }
+
+  .screenshotGrid {
+    grid-template-columns: none;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(250px, 78vw);
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .featureGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .detailNav {
+    display: none;
+  }
+
+  .articleAside {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .appCard {
+    grid-template-columns: auto minmax(0, 1fr);
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .appCardHeader {
+    display: block;
+  }
+
+  .appCardActions {
+    gap: 7px;
+  }
+
+  .appCardActions .primaryButton,
+  .appCardActions .secondaryButton,
+  .appCardActions .ghostButton {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .appHeroCard {
+    grid-template-columns: 1fr;
+  }
+
+  .appHeroCard .appIconLarge {
+    width: 78px;
+    height: 78px;
+    border-radius: 22px;
+    font-size: 1.8rem;
+  }
+
+  .appHeroTitleLine h1 {
+    font-size: 2rem;
+  }
+
+  .heroInstall {
+    grid-template-columns: 1fr;
+  }
+
+  .heroInstall small {
+    grid-column: auto;
+  }
+
+  .statsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .statItem,
+  .statItem:nth-child(2) {
+    border-right: 0;
+    border-bottom: 1px solid var(--detail-line);
+  }
+
+  .statItem:last-child {
+    border-bottom: 0;
+  }
+
+  .contentListItem {
+    grid-template-columns: 1fr;
+  }
+
+  .contentListItem > svg {
+    display: none;
+  }
+
+  .articleCard {
+    padding: 24px 20px;
+  }
+
+  .articleCard h1 {
+    font-size: 2.15rem;
+  }
+}
+
+@keyframes sheetIn {
+  from { transform: translateY(30px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .previewBackdrop,
+  .previewPanel,
+  .primaryButton,
+  .launchButton {
+    animation: none;
+    transition: none;
+  }
+}

--- a/frontend/apps/web/src/lib/marketplace.ts
+++ b/frontend/apps/web/src/lib/marketplace.ts
@@ -1,0 +1,525 @@
+export type MarketplaceCategory =
+  | "featured"
+  | "automation"
+  | "content"
+  | "practice"
+  | "developer"
+  | "system";
+
+export type MarketplaceIconTone =
+  | "violet"
+  | "blue"
+  | "orange"
+  | "green"
+  | "pink"
+  | "cyan"
+  | "yellow"
+  | "slate";
+
+export interface MarketplaceContentItem {
+  id: string;
+  title: string;
+  summary: string;
+  body: readonly string[];
+  type: "guide" | "template" | "collection" | "workflow" | "release";
+  keywords: readonly string[];
+  updatedAt: string;
+  readingMinutes: number;
+}
+
+export interface MarketplaceApp {
+  id: string;
+  slug: string;
+  name: string;
+  englishName: string;
+  subtitle: string;
+  description: string;
+  category: Exclude<MarketplaceCategory, "featured">;
+  featured: boolean;
+  icon: string;
+  tone: MarketplaceIconTone;
+  developer: string;
+  verified: boolean;
+  tags: readonly string[];
+  capabilities: readonly string[];
+  highlights: readonly {
+    title: string;
+    description: string;
+  }[];
+  permissions: readonly string[];
+  pricing: {
+    label: string;
+    detail: string;
+  };
+  updatedAt: string;
+  version: string;
+  content: readonly MarketplaceContentItem[];
+}
+
+export const MARKETPLACE_CATEGORY_LABELS: Record<MarketplaceCategory, string> = {
+  featured: "精选",
+  automation: "自动化",
+  content: "内容与发布",
+  practice: "修行与学习",
+  developer: "开发者工具",
+  system: "系统工具",
+};
+
+export const marketplaceApps: readonly MarketplaceApp[] = [
+  {
+    id: "mahayana-assistant",
+    slug: "mahayana-assistant",
+    name: "大乘助手",
+    englishName: "Mahayana Assistant",
+    subtitle: "把复杂任务交给可调用工具的智能助手",
+    description:
+      "在一个对话入口里组织搜索、内容处理、发布与本地工具调用。既可以独立打开，也可以由其他 Fabushi Mini App 调用。",
+    category: "automation",
+    featured: true,
+    icon: "乘",
+    tone: "violet",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["AI 助手", "工作流", "MCP", "WebMCP"],
+    capabilities: ["多步骤任务", "工具调用", "结果卡片", "会话上下文"],
+    highlights: [
+      {
+        title: "像聊天一样开始",
+        description: "不需要先理解复杂配置，直接描述目标即可进入任务。",
+      },
+      {
+        title: "能力按需组合",
+        description: "从已安装的 Mini App 中选择工具，不把所有权限一次性打开。",
+      },
+      {
+        title: "网页与 Agent 共用",
+        description: "页面能力可通过 WebMCP 暴露给兼容浏览器中的智能体。",
+      },
+    ],
+    permissions: ["按调用确认外部工具", "本地会话存储", "可选网络访问"],
+    pricing: { label: "免费安装", detail: "部分模型或外部服务可能使用各自的账户额度。" },
+    updatedAt: "2026-08-27",
+    version: "1.0.0",
+    content: [
+      {
+        id: "first-agent-workflow",
+        title: "第一次创建可复用的 Agent 工作流",
+        summary: "从目标、输入、工具与验收条件四部分组织一条可重复执行的工作流。",
+        body: [
+          "先用一句话写清结果，而不是罗列操作步骤。一个好的目标应当能被独立验收。",
+          "把必须由用户提供的信息定义为输入，把搜索、处理、发布等动作定义为工具，把最终检查定义为验收条件。",
+          "首次运行建议保留逐步确认；流程稳定后，再把低风险只读步骤改为自动执行。",
+        ],
+        type: "guide",
+        keywords: ["Agent 工作流", "MCP", "自动化", "任务编排"],
+        updatedAt: "2026-08-27",
+        readingMinutes: 3,
+      },
+      {
+        id: "webmcp-site-tools",
+        title: "让网站能力同时服务人和 AI Agent",
+        summary: "使用 WebMCP 将页面中的搜索、查看与操作能力注册为结构化工具。",
+        body: [
+          "WebMCP 的核心不是给页面增加另一个聊天框，而是把现有功能用名称、说明和输入结构表达出来。",
+          "只读工具可以直接公开；会修改数据或影响外部系统的工具，应当在执行前显示明确确认。",
+          "Fabushi 会优先复用 Mini App 已有的 MCP 工具定义，避免网页端维护第二套命令映射。",
+        ],
+        type: "guide",
+        keywords: ["WebMCP", "网站工具", "AI Agent", "结构化操作"],
+        updatedAt: "2026-08-27",
+        readingMinutes: 4,
+      },
+    ],
+  },
+  {
+    id: "global-dharma",
+    slug: "global-dharma",
+    name: "全球法布施",
+    englishName: "Global Dharma",
+    subtitle: "管理法布施任务、内容与全球分发状态",
+    description:
+      "把法布施任务、内容素材、运行日志和分发状态集中在一个 Mini App 中，适合持续运营与协作。",
+    category: "practice",
+    featured: true,
+    icon: "法",
+    tone: "blue",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["法布施", "内容分发", "协作", "任务"],
+    capabilities: ["任务看板", "发布状态", "内容归档", "运行日志"],
+    highlights: [
+      { title: "统一任务入口", description: "从计划、执行到完成记录都留在同一个上下文中。" },
+      { title: "内容可被搜索", description: "每条内容都可以生成独立入口，便于搜索与外部分享。" },
+      { title: "跨端继续", description: "网页、桌面与移动端围绕同一 Mini App 身份衔接。" },
+    ],
+    permissions: ["读取任务与内容", "经确认后更新状态", "可选通知"],
+    pricing: { label: "免费安装", detail: "基础功能免费使用。" },
+    updatedAt: "2026-08-26",
+    version: "1.0.0",
+    content: [
+      {
+        id: "distribution-checklist",
+        title: "法布施内容分发检查清单",
+        summary: "发布前检查标题、来源、版权、目标平台和回链，减少重复返工。",
+        body: [
+          "确认标题能够独立表达内容主题，并保留真实来源与作者信息。",
+          "针对不同平台准备合适的摘要与封面，不把同一段文案机械复制到所有渠道。",
+          "发布后记录永久链接、发布时间和状态，确保后续能够追踪与更新。",
+        ],
+        type: "workflow",
+        keywords: ["法布施", "内容发布", "检查清单", "分发"],
+        updatedAt: "2026-08-26",
+        readingMinutes: 2,
+      },
+      {
+        id: "global-content-map",
+        title: "建立可搜索的全球内容地图",
+        summary: "为内容补充主题、语言、地区和来源字段，让搜索入口可以直达具体内容。",
+        body: [
+          "内容级搜索依赖稳定的内容 ID 和永久 URL，而不是只把所有资料堆在一个首页里。",
+          "主题、语言与地区是最基础的筛选维度；来源和更新时间则帮助用户判断内容是否适用。",
+          "内容页应提供清晰摘要、正文、所属应用和继续操作入口。",
+        ],
+        type: "guide",
+        keywords: ["内容搜索", "全球分发", "SEO", "内容地图"],
+        updatedAt: "2026-08-25",
+        readingMinutes: 3,
+      },
+    ],
+  },
+  {
+    id: "faliu-flashcards",
+    slug: "faliu-flashcards",
+    name: "法流记忆卡",
+    englishName: "Faliu Flashcards",
+    subtitle: "把经文拆成可以持续复习的记忆卡",
+    description:
+      "从法流内容建立记忆牌组，按学习节奏复习经文、偈颂与关键段落，并保留原文来源。",
+    category: "practice",
+    featured: true,
+    icon: "记",
+    tone: "cyan",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["记忆卡", "经文", "复习", "学习"],
+    capabilities: ["牌组创建", "间隔复习", "原文校对", "学习进度"],
+    highlights: [
+      { title: "一张卡只记一件事", description: "长段落会拆成更适合回忆的短单元。" },
+      { title: "保留原文", description: "答案与来源文本保持一致，方便随时核对。" },
+      { title: "从内容页直接开始", description: "搜索到经文内容后，可直接进入对应牌组。" },
+    ],
+    permissions: ["本地学习记录", "读取公开经文内容", "可选同步"],
+    pricing: { label: "免费安装", detail: "学习记录默认保存在当前设备。" },
+    updatedAt: "2026-08-24",
+    version: "1.0.0",
+    content: [
+      {
+        id: "heart-sutra-deck",
+        title: "《心经》记忆牌组使用说明",
+        summary: "用续句、挖空与段落结构三种卡片完成短经文的系统复习。",
+        body: [
+          "第一次学习时先完整阅读原文，再进入牌组，避免把卡片当作脱离上下文的碎片。",
+          "续句卡用于熟悉语序，挖空卡用于巩固关键词，段落卡用于记住整体结构。",
+          "答错后先查看来源文本，再决定是立即重试还是延后复习。",
+        ],
+        type: "collection",
+        keywords: ["心经", "记忆卡", "背诵", "法流"],
+        updatedAt: "2026-08-24",
+        readingMinutes: 3,
+      },
+      {
+        id: "spaced-repetition-basics",
+        title: "经文间隔复习的基础节奏",
+        summary: "根据回忆难度安排下一次复习，而不是每天机械重复全部卡片。",
+        body: [
+          "能够轻松回忆的卡片应当逐渐拉长间隔，把时间留给真正困难的内容。",
+          "短暂想不起来但看到提示后能恢复的卡片，可以保留在较短间隔内继续巩固。",
+          "持续答错通常说明卡片过长或提示不清晰，应当拆分或重写，而不是无限增加重复次数。",
+        ],
+        type: "guide",
+        keywords: ["间隔复习", "记忆法", "经文学习", "学习节奏"],
+        updatedAt: "2026-08-23",
+        readingMinutes: 3,
+      },
+    ],
+  },
+  {
+    id: "platform-publish",
+    slug: "platform-publish",
+    name: "平台发布",
+    englishName: "Platform Publish",
+    subtitle: "从一份内容生成多个平台的发布草稿",
+    description:
+      "集中管理待发布内容、平台适配草稿与发布记录。每次外部发布前都会明确展示目标平台与变更。",
+    category: "content",
+    featured: true,
+    icon: "发",
+    tone: "orange",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["发布", "多平台", "内容运营", "草稿"],
+    capabilities: ["多平台草稿", "发布预览", "状态追踪", "内容回链"],
+    highlights: [
+      { title: "先预览再发布", description: "所有外部写入操作都在发送前显示最终内容。" },
+      { title: "按平台适配", description: "标题、摘要、标签与长度可以针对渠道调整。" },
+      { title: "保留发布记录", description: "记录目标、时间、结果与永久链接。" },
+    ],
+    permissions: ["读取待发布内容", "经确认后写入外部平台", "保存发布记录"],
+    pricing: { label: "免费安装", detail: "外部平台账户与额度由用户自行管理。" },
+    updatedAt: "2026-08-22",
+    version: "1.0.0",
+    content: [
+      {
+        id: "cross-platform-template",
+        title: "跨平台发布模板",
+        summary: "用核心信息、平台版本和统一回链组织一次多渠道发布。",
+        body: [
+          "先写一份不受平台限制的核心信息，包含事实、价值和目标行动。",
+          "再为每个平台生成适合其阅读方式的版本，而不是简单截断同一段文字。",
+          "所有版本都应回到稳定的内容页，便于后续更新、统计与搜索收录。",
+        ],
+        type: "template",
+        keywords: ["发布模板", "多平台", "内容运营", "SEO"],
+        updatedAt: "2026-08-22",
+        readingMinutes: 2,
+      },
+      {
+        id: "release-notes-workflow",
+        title: "版本发布说明工作流",
+        summary: "把功能变化、影响范围、升级方式和已知问题组织成可复用发布说明。",
+        body: [
+          "发布说明首先回答发生了什么变化，再说明变化会影响谁。",
+          "升级步骤应当可以直接执行，并明确是否需要重新登录、迁移数据或更新权限。",
+          "已知问题必须与临时解决方案放在一起，避免只留下模糊警告。",
+        ],
+        type: "workflow",
+        keywords: ["版本说明", "发布", "更新", "工作流"],
+        updatedAt: "2026-08-21",
+        readingMinutes: 3,
+      },
+    ],
+  },
+  {
+    id: "bot-father",
+    slug: "bot-father",
+    name: "Bot Father",
+    englishName: "Bot Father",
+    subtitle: "创建、配置和管理你的 Mini App 与机器人",
+    description:
+      "管理 Mini App 身份、开发者归属、商品目录与平台映射，为后续分发和商业化提供统一入口。",
+    category: "developer",
+    featured: false,
+    icon: "B",
+    tone: "pink",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["Mini App", "机器人", "开发者", "商品"],
+    capabilities: ["应用注册", "开发者管理", "商品目录", "平台映射"],
+    highlights: [
+      { title: "一个稳定应用身份", description: "网页、移动端与外部平台使用同一个 Mini App ID。" },
+      { title: "目录与运行分离", description: "商品和分发信息独立于应用运行代码管理。" },
+      { title: "面向审核的资料", description: "集中维护名称、说明、权限与联系信息。" },
+    ],
+    permissions: ["开发者身份", "经确认后更新应用资料", "经确认后同步商品"],
+    pricing: { label: "开发者工具", detail: "创建应用免费，平台交易可能产生对应服务费用。" },
+    updatedAt: "2026-08-20",
+    version: "1.0.0",
+    content: [
+      {
+        id: "miniapp-listing-guide",
+        title: "Mini App 上架资料准备指南",
+        summary: "准备独特名称、清晰副标题、真实功能说明、权限用途和支持方式。",
+        body: [
+          "应用名称应当稳定且可识别，避免在不同页面使用互不相干的名称。",
+          "副标题要快速说明应用为谁解决什么问题，不要堆砌无关关键词。",
+          "权限说明必须对应实际功能；没有使用的权限不要提前申请。",
+        ],
+        type: "guide",
+        keywords: ["Mini App 上架", "应用资料", "应用商店", "开发者"],
+        updatedAt: "2026-08-20",
+        readingMinutes: 3,
+      },
+    ],
+  },
+  {
+    id: "hermes-installer",
+    slug: "hermes-installer",
+    name: "Hermes 安装器",
+    englishName: "Hermes Installer",
+    subtitle: "安装、启动并检查本地 Hermes 服务",
+    description:
+      "用可检查的步骤完成本地运行环境安装、启动与健康检查，并在发生问题时提供明确诊断。",
+    category: "system",
+    featured: false,
+    icon: "H",
+    tone: "green",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["Hermes", "安装", "本地服务", "诊断"],
+    capabilities: ["环境检查", "引导安装", "服务启动", "健康诊断"],
+    highlights: [
+      { title: "先检查再改动", description: "安装前展示缺失项和预计变更。" },
+      { title: "步骤可追踪", description: "每一步都有状态与错误说明。" },
+      { title: "失败可恢复", description: "保留诊断信息，支持从中断点继续。" },
+    ],
+    permissions: ["读取本地环境", "经确认后安装组件", "经确认后启动服务"],
+    pricing: { label: "免费安装", detail: "仅在支持的桌面环境中执行本地操作。" },
+    updatedAt: "2026-08-19",
+    version: "1.0.0",
+    content: [
+      {
+        id: "hermes-health-check",
+        title: "Hermes 服务健康检查",
+        summary: "从进程、端口、配置与日志四个维度定位本地服务无法启动的问题。",
+        body: [
+          "先确认进程是否存在，再检查预期端口是否监听，避免把网络问题误判为安装失败。",
+          "配置文件需要验证路径、格式和依赖地址；敏感值不应直接写入公开日志。",
+          "最后读取最近错误日志，并记录可复现步骤后再执行修复。",
+        ],
+        type: "workflow",
+        keywords: ["Hermes", "健康检查", "本地服务", "故障排查"],
+        updatedAt: "2026-08-19",
+        readingMinutes: 3,
+      },
+    ],
+  },
+  {
+    id: "chatgpt-auto-confirm",
+    slug: "chatgpt-auto-confirm",
+    name: "自动确认",
+    englishName: "Auto Confirm",
+    subtitle: "管理长任务中的授权、确认与执行队列",
+    description:
+      "在长时间运行的任务中识别需要人工决定的步骤，记录一次性确认，并避免历史授权错误阻塞新任务。",
+    category: "automation",
+    featured: false,
+    icon: "✓",
+    tone: "yellow",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["授权", "长任务", "队列", "自动化"],
+    capabilities: ["确认队列", "一次性授权", "状态审计", "任务续作"],
+    highlights: [
+      { title: "确认不会消失", description: "需要用户决定的步骤会集中显示并保留上下文。" },
+      { title: "授权有边界", description: "区分一次、当前任务与长期规则。" },
+      { title: "历史状态可审计", description: "避免旧记录永久锁定新的确认卡片。" },
+    ],
+    permissions: ["读取任务确认状态", "经确认后继续任务", "本地审计记录"],
+    pricing: { label: "免费安装", detail: "适合与大乘助手和开发工具配合使用。" },
+    updatedAt: "2026-08-18",
+    version: "1.0.0",
+    content: [
+      {
+        id: "approval-scope-guide",
+        title: "一次、当前任务与长期授权怎么选",
+        summary: "根据操作影响范围选择最小授权，避免为了方便永久放开高风险动作。",
+        body: [
+          "只对当前一步有把握时选择一次授权，后续同类操作仍会再次询问。",
+          "当前任务授权适合边界明确、步骤重复的流程，任务结束后自动失效。",
+          "长期规则只适合低风险、可逆并且输入范围稳定的操作。",
+        ],
+        type: "guide",
+        keywords: ["授权范围", "自动确认", "安全", "长任务"],
+        updatedAt: "2026-08-18",
+        readingMinutes: 3,
+      },
+    ],
+  },
+  {
+    id: "computer-cleaner",
+    slug: "computer-cleaner",
+    name: "电脑空间助手",
+    englishName: "Computer Space Assistant",
+    subtitle: "先分析空间占用，再安全清理可确认的内容",
+    description:
+      "扫描磁盘空间、解释主要占用来源，并把缓存、构建产物与用户文件明确分开，避免误删。",
+    category: "system",
+    featured: false,
+    icon: "净",
+    tone: "slate",
+    developer: "Fabushi",
+    verified: true,
+    tags: ["磁盘空间", "清理", "诊断", "安全"],
+    capabilities: ["空间分析", "大文件定位", "清理建议", "确认执行"],
+    highlights: [
+      { title: "先解释空间去哪了", description: "按目录和类型展示占用，而不是直接删除。" },
+      { title: "用户文件默认保护", description: "文档、照片和项目目录不会被自动处理。" },
+      { title: "每项清理可确认", description: "显示路径、大小与影响后再执行。" },
+    ],
+    permissions: ["只读扫描文件系统", "经确认后删除选中项", "不读取文件正文"],
+    pricing: { label: "免费安装", detail: "桌面端功能需要本地权限。" },
+    updatedAt: "2026-08-17",
+    version: "1.0.0",
+    content: [
+      {
+        id: "safe-disk-cleanup",
+        title: "安全清理磁盘空间的顺序",
+        summary: "先处理可重建缓存，再检查构建产物，最后才考虑大型用户文件。",
+        body: [
+          "第一步查看总体空间和最大目录，确认问题是系统缓存、开发缓存还是用户文件。",
+          "可重建缓存通常风险最低，但仍要确认相关应用已经关闭并了解重新下载成本。",
+          "用户文档、照片、数据库和项目源码不应自动删除；需要移动或归档时必须单独确认。",
+        ],
+        type: "guide",
+        keywords: ["磁盘清理", "Mac 空间", "缓存", "安全"],
+        updatedAt: "2026-08-17",
+        readingMinutes: 3,
+      },
+    ],
+  },
+] as const;
+
+export const marketplaceContent = marketplaceApps.flatMap((app) =>
+  app.content.map((item) => ({ app, item })),
+);
+
+export function getMarketplaceApp(slugOrId: string) {
+  return marketplaceApps.find((app) => app.slug === slugOrId || app.id === slugOrId);
+}
+
+export function getMarketplaceContent(appSlug: string, contentId: string) {
+  const app = getMarketplaceApp(appSlug);
+  if (!app) return undefined;
+  const item = app.content.find((candidate) => candidate.id === contentId);
+  return item ? { app, item } : undefined;
+}
+
+export function searchMarketplace(query: string) {
+  const normalizedQuery = query.trim().toLocaleLowerCase("zh-CN");
+  if (!normalizedQuery) {
+    return {
+      apps: marketplaceApps,
+      content: marketplaceContent,
+    };
+  }
+
+  const terms = normalizedQuery.split(/\s+/).filter(Boolean);
+  const containsAll = (values: readonly string[]) => {
+    const haystack = values.join(" ").toLocaleLowerCase("zh-CN");
+    return terms.every((term) => haystack.includes(term));
+  };
+
+  return {
+    apps: marketplaceApps.filter((app) =>
+      containsAll([
+        app.name,
+        app.englishName,
+        app.subtitle,
+        app.description,
+        MARKETPLACE_CATEGORY_LABELS[app.category],
+        ...app.tags,
+        ...app.capabilities,
+      ]),
+    ),
+    content: marketplaceContent.filter(({ app, item }) =>
+      containsAll([
+        app.name,
+        item.title,
+        item.summary,
+        item.type,
+        ...item.keywords,
+        ...item.body,
+      ]),
+    ),
+  };
+}


### PR DESCRIPTION
## 目标

将 Fabushi 官网首页升级为全新的应用市场，组合三类体验：

- Telegram Mini App：应用点开即用、独立全屏运行、安装后跨端继续
- Shopify App Store：独立应用详情、分类/标签、权限/定价、开发者资料与 SEO
- 内容级搜索：指南、模板、内容集和工作流拥有稳定内容 ID 与永久 URL

## 主要实现

- 新增 Twitter/X 风格的响应式三栏应用市场首页与移动端底部导航
- 新增 8 个首发应用、12 条内容级入口及统一搜索数据模型
- 新增 `/apps/[slug]` 应用详情页与 `/apps/[slug]/content/[contentId]` 内容页
- 新增 `/search`、`/search-index.json`、`/opensearch.xml`
- 将应用页和内容页加入 sitemap，并补充 SoftwareApplication、Article、FAQ、Breadcrumb 等 JSON-LD
- 新增全站 WebMCP 工具：搜索市场、读取应用、读取内容、安装应用、列出分类
- 安装状态复用现有 `fabushi.installed-miniapps`，与 Mahayana Host 的恢复流程互通
- 更新 PWA manifest 与全站 metadata

## 本地轻量检查

- `git diff --check`
- 8 个应用 ID 与现有 Mini App 静态路由完全一致
- 12 条内容 ID 唯一
- 搜索、应用查找、内容查找的 Node 轻量数据测试通过

完整 typecheck 与 Next 静态导出由 GitHub Actions 执行。