### PR TITLE
fix(web): 让 Web 与桌面共用 Telegram 式 Host UI

### DIFF
--- a/frontend/apps/web/src/app/apps/page.tsx
+++ b/frontend/apps/web/src/app/apps/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import { MarketplaceShell } from "../../components/marketplace/marketplace-shell";
+import { marketplaceApps, marketplaceContent } from "../../lib/marketplace";
+import { siteUrl } from "../../lib/site-url";
+
+const marketplaceUrl = siteUrl("/apps");
+const title = "Fabushi Mini Apps | 应用发现、安装与内容搜索";
+const description =
+  "发现、安装并运行 Fabushi Mini Apps。保留 Telegram 式即开即用体验，并提供应用详情、内容级 SEO、搜索索引与 WebMCP 入口。";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: marketplaceUrl },
+  keywords: [
+    "Fabushi",
+    "Mini Apps",
+    "应用市场",
+    "MCP Apps",
+    "WebMCP",
+    "应用分发",
+    "内容搜索",
+    "开发者平台",
+  ],
+  openGraph: {
+    title,
+    description,
+    url: marketplaceUrl,
+    siteName: "Fabushi",
+    locale: "zh_CN",
+    type: "website",
+  },
+};
+
+export default function MarketplacePage() {
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        "@id": `${marketplaceUrl}#marketplace`,
+        name: title,
+        description,
+        url: marketplaceUrl,
+        mainEntity: {
+          "@type": "ItemList",
+          numberOfItems: marketplaceApps.length,
+          itemListElement: marketplaceApps.map((app, index) => ({
+            "@type": "ListItem",
+            position: index + 1,
+            url: siteUrl(`/apps/${app.slug}`),
+            name: app.name,
+          })),
+        },
+      },
+      {
+        "@type": "DataCatalog",
+        name: "Fabushi 内容级搜索索引",
+        description: `收录 ${marketplaceContent.length} 条指南、模板、内容集与工作流。`,
+        url: siteUrl("/search-index.json"),
+        dataset: marketplaceApps.map((app) => ({
+          "@type": "Dataset",
+          name: `${app.name} 内容目录`,
+          url: siteUrl(`/apps/${app.slug}`),
+          distribution: {
+            "@type": "DataDownload",
+            contentUrl: siteUrl("/search-index.json"),
+            encodingFormat: "application/json",
+          },
+        })),
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <MarketplaceShell />
+    </>
+  );
+}

--- a/frontend/apps/web/src/app/host/host-client.tsx
+++ b/frontend/apps/web/src/app/host/host-client.tsx
@@ -105,6 +105,7 @@ import {
   type BotMarkShape,
   type BotMarkState,
 } from "./bot-mark";
+import { marketplaceApps as marketplaceCatalog } from "../../lib/marketplace";
 import { GroupAvatarStack, GroupChatPanel, GroupEditor } from "./group-chat-panel";
 import { AgentWorkflowPanel } from "./agent-workflow-panel";
 
@@ -137,57 +138,12 @@ function fileToBase64(file: File): Promise<string> {
   });
 }
 
-const marketplaceApps = [
-  {
-    id: "global-dharma",
-    title: "全球法布施",
-    description: "管理法布施任务、日志与部署状态",
-    glyph: "法",
-    tone: "violet",
-  },
-  {
-    id: "faliu-flashcards",
-    title: "法流记忆卡",
-    description: "创建经文牌组并安排复习",
-    glyph: "记",
-    tone: "blue",
-  },
-  {
-    id: "platform-publish",
-    title: "平台发布",
-    description: "创建草稿并发布到内容平台",
-    glyph: "发",
-    tone: "orange",
-  },
-  {
-    id: "hermes-installer",
-    title: "Hermes 安装器",
-    description: "安装、启动并检查本地服务",
-    glyph: "H",
-    tone: "green",
-  },
-  {
-    id: "bot-father",
-    title: "Bot Father",
-    description: "创建和管理自动化机器人",
-    glyph: "B",
-    tone: "pink",
-  },
-  {
-    id: "mahayana-assistant",
-    title: "大乘助手",
-    description: "使用 Mahayana Runtime 完成复杂任务",
-    glyph: "乘",
-    tone: "cyan",
-  },
-  {
-    id: "chatgpt-auto-confirm",
-    title: "自动确认",
-    description: "管理长任务授权与执行队列",
-    glyph: "✓",
-    tone: "yellow",
-  },
-] as const;
+const marketplaceApps = marketplaceCatalog.map((app) => ({
+  ...app,
+  title: app.name,
+  description: app.subtitle,
+  glyph: app.icon,
+}));
 
 type FeatureStates = Record<
   MahayanaHostFeatureId,
@@ -4096,6 +4052,10 @@ export default function HostClient() {
                         {installed ? <span className={styles.connectedDot} /> : null}
                       </div>
                       <p>{app.description}</p>
+                      <div className={styles.marketMeta}>
+                        <span>{app.developer}</span>
+                        <a href={`/apps/${app.slug}`}>详情 / 内容</a>
+                      </div>
                     </div>
                     <button
                       data-testid={app.id === defaultMiniAppId ? "install-miniapp" : `install-${app.id}`}

--- a/frontend/apps/web/src/app/host/host.module.css
+++ b/frontend/apps/web/src/app/host/host.module.css
@@ -2127,6 +2127,7 @@
 .pink { background: linear-gradient(145deg, #ff79aa, #c73a79); }
 .cyan { background: linear-gradient(145deg, #47d7de, #1b859d); }
 .yellow { background: linear-gradient(145deg, #f6c84f, #b88818); }
+.slate { background: linear-gradient(145deg, #8b97a7, #46515f); }
 
 .marketCopy {
   min-width: 0;
@@ -2149,6 +2150,24 @@
   font-size: 10px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.marketMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  color: var(--faint);
+  font-size: 9px;
+}
+
+.marketMeta a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.marketMeta a:hover {
+  text-decoration: underline;
 }
 
 .connectedDot {

--- a/frontend/apps/web/src/app/layout.tsx
+++ b/frontend/apps/web/src/app/layout.tsx
@@ -7,27 +7,27 @@ import { siteUrl } from "../lib/site-url";
 import "./globals.css";
 
 const homeUrl = siteUrl("/");
-const siteTitle = `${brand.name} | Mini App、AI 工具与内容工作流市场`;
+const siteTitle = `${brand.name} | 跨平台 Messenger、AI Agents 与 Mini Apps`;
 const siteDescription =
-  "Fabushi 是可发现、可安装、可立即运行的 Mini App 市场，提供独立应用详情、内容级搜索入口、开发者分发资料与 WebMCP 网站工具。";
+  "Fabushi 是跨平台 Messenger 与 AI Agent Host。Web、桌面与移动端保持一致的核心交互，并内置 Mini Apps、WebMCP、应用市场和内容级搜索。";
 
 export const metadata: Metadata = {
   title: siteTitle,
   description: siteDescription,
   keywords: [
     "Fabushi",
-    "应用市场",
+    "Messenger",
+    "AI Agent",
     "Mini App",
-    "AI 应用",
     "MCP Apps",
     "WebMCP",
+    "应用市场",
     "应用分发",
     "内容级搜索",
+    "跨平台",
     "工作流",
-    "开发者平台",
-    "法布施",
   ],
-  applicationName: `${brand.name} 应用市场`,
+  applicationName: brand.name,
   authors: [{ name: "Fabushi" }],
   creator: "Fabushi",
   publisher: "Fabushi",
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
     title: siteTitle,
     description: siteDescription,
     url: homeUrl,
-    siteName: "Fabushi 应用市场",
+    siteName: "Fabushi",
     locale: "zh_CN",
     type: "website",
   },

--- a/frontend/apps/web/src/app/manifest.ts
+++ b/frontend/apps/web/src/app/manifest.ts
@@ -6,27 +6,33 @@ export const dynamic = "force-static";
 export default function manifest(): MetadataRoute.Manifest {
   return {
     id: siteHref("/"),
-    name: "Fabushi 应用市场",
+    name: "Fabushi",
     short_name: "Fabushi",
-    description: "发现、安装并运行 Mini App、AI 工具、指南、模板和工作流。",
+    description: "跨平台 Messenger、AI Agents 与 Mini Apps Host，内置 WebMCP、应用发现和内容级搜索。",
     start_url: siteHref("/"),
     scope: siteHref("/"),
     display: "standalone",
     background_color: "#000000",
     theme_color: "#000000",
-    categories: ["business", "productivity", "utilities"],
+    categories: ["social", "productivity", "utilities"],
     shortcuts: [
+      {
+        name: "打开 Fabushi",
+        short_name: "聊天",
+        description: "进入 Fabushi Messenger 与 AI Agent Host",
+        url: siteHref("/"),
+      },
+      {
+        name: "Mini Apps",
+        short_name: "应用",
+        description: "发现、安装并打开 Fabushi Mini Apps",
+        url: siteHref("/apps"),
+      },
       {
         name: "搜索应用与内容",
         short_name: "搜索",
         description: "搜索 Mini App、能力、指南、模板和工作流",
         url: siteHref("/search"),
-      },
-      {
-        name: "打开大乘",
-        short_name: "大乘",
-        description: "进入 Fabushi 大乘工作台",
-        url: siteHref("/app"),
       },
     ],
   };

--- a/frontend/apps/web/src/app/page.tsx
+++ b/frontend/apps/web/src/app/page.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from "next";
 import { brand } from "@fabushi/shared";
-import { MarketplaceShell } from "../components/marketplace/marketplace-shell";
-import { marketplaceApps, marketplaceContent } from "../lib/marketplace";
+import HostClientEntry from "./host/host-client-entry";
 import { siteUrl } from "../lib/site-url";
 
 const homeUrl = siteUrl("/");
-const homeTitle = "Fabushi 应用市场 | Mini App、AI 工具与内容工作流";
+const homeTitle = "Fabushi | Telegram 式全平台 AI Messenger 与 Mini Apps";
 const homeDescription =
-  "发现、安装并立即运行 Fabushi Mini App。像 Telegram Mini App 一样即开即用，像 Shopify App Store 一样可比较与分发，并为指南、模板和工作流提供内容级搜索入口。";
+  "Fabushi Web 与桌面端共享同一 Host / Messenger 体验，并内置 Mini Apps、WebMCP、应用发现与内容级搜索。";
 
 export const metadata: Metadata = {
   title: homeTitle,
@@ -15,16 +14,14 @@ export const metadata: Metadata = {
   alternates: { canonical: homeUrl },
   keywords: [
     "Fabushi",
-    "应用市场",
+    "Telegram 式 Messenger",
     "Mini App",
-    "Telegram Mini App",
-    "AI 应用",
+    "AI Agent",
     "MCP Apps",
     "WebMCP",
-    "应用商店",
+    "应用市场",
     "内容搜索",
-    "工作流",
-    "开发者平台",
+    "跨平台",
   ],
   openGraph: {
     title: homeTitle,
@@ -55,7 +52,7 @@ export default function HomePage() {
       {
         "@type": "WebSite",
         "@id": `${homeUrl}#website`,
-        name: "Fabushi 应用市场",
+        name: "Fabushi",
         url: homeUrl,
         publisher: { "@id": `${homeUrl}#organization` },
         potentialAction: {
@@ -68,38 +65,20 @@ export default function HomePage() {
         },
       },
       {
-        "@type": "CollectionPage",
-        "@id": `${homeUrl}#marketplace`,
-        name: homeTitle,
-        description: homeDescription,
+        "@type": "WebApplication",
+        name: "Fabushi Web",
+        applicationCategory: "CommunicationApplication",
+        operatingSystem: "Web",
         url: homeUrl,
-        isPartOf: { "@id": `${homeUrl}#website` },
-        mainEntity: {
-          "@type": "ItemList",
-          numberOfItems: marketplaceApps.length,
-          itemListElement: marketplaceApps.map((app, index) => ({
-            "@type": "ListItem",
-            position: index + 1,
-            url: siteUrl(`/apps/${app.slug}`),
-            name: app.name,
-          })),
-        },
-      },
-      {
-        "@type": "DataCatalog",
-        name: "Fabushi 内容级搜索索引",
-        description: `收录 ${marketplaceContent.length} 条指南、模板、内容集与工作流。`,
-        url: siteUrl("/search-index.json"),
-        dataset: marketplaceApps.map((app) => ({
-          "@type": "Dataset",
-          name: `${app.name} 内容目录`,
-          url: siteUrl(`/apps/${app.slug}`),
-          distribution: {
-            "@type": "DataDownload",
-            contentUrl: siteUrl("/search-index.json"),
-            encodingFormat: "application/json",
-          },
-        })),
+        description: homeDescription,
+        featureList: [
+          "Messenger",
+          "AI Agents",
+          "Mini Apps",
+          "WebMCP",
+          "Marketplace",
+          "Content Search",
+        ],
       },
     ],
   };
@@ -110,7 +89,7 @@ export default function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
-      <MarketplaceShell />
+      <HostClientEntry />
     </>
   );
 }

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -7,6 +7,7 @@ export const dynamic = "force-static";
 
 const staticRoutes = [
   "/",
+  "/apps",
   "/app",
   "/app/ai",
   "/download",
@@ -33,6 +34,7 @@ const staticRoutes = [
 
 const weeklyRoutes = new Set([
   "/",
+  "/apps",
   "/app",
   "/app/ai",
   "/download",
@@ -55,6 +57,7 @@ const weeklyRoutes = new Set([
 
 const routeLastModified: Partial<Record<(typeof staticRoutes)[number], string>> = {
   "/": "2026-08-27",
+  "/apps": "2026-08-27",
   "/app": "2026-06-09",
   "/app/ai": "2026-06-09",
   "/download": "2026-05-18",
@@ -85,13 +88,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority:
       route === "/"
         ? 1
-        : weeklyRoutes.has(route)
-          ? 0.85
-          : route === "/apply"
-            ? 0.8
-            : route === "/privacy"
-              ? 0.6
-              : 0.7,
+        : route === "/apps"
+          ? 0.95
+          : weeklyRoutes.has(route)
+            ? 0.85
+            : route === "/apply"
+              ? 0.8
+              : route === "/privacy"
+                ? 0.6
+                : 0.7,
   }));
 
   const appPages: MetadataRoute.Sitemap = marketplaceApps.map((app) => ({

--- a/projects/telegram-fabushi-integration/CHANGELOG.md
+++ b/projects/telegram-fabushi-integration/CHANGELOG.md
@@ -8,3 +8,9 @@
 - 建立 M0–M14 路线图与 WBS 原子任务。
 - 建立验收追踪矩阵、风险登记、ADR、PR/Task/Status 模板。
 - 所有工程任务状态保持 `NOT_STARTED`，等待基于 Fabushi 仓库当前事实回填。
+
+## v1.1 — 2026-08-27
+
+- 明确 Telegram 式全平台 UI/功能一致性：Web 是完整 Fabushi Host，不是独立 Marketplace 产品。
+- Marketplace、SEO、内容搜索与 WebMCP 保留为主 Host 的扩展与公开分发能力。
+- Web 与桌面继续共享 HostClient，Host Marketplace 改用统一 Mini App catalog。

--- a/projects/telegram-fabushi-integration/docs/07-客户端架构与交互.md
+++ b/projects/telegram-fabushi-integration/docs/07-客户端架构与交互.md
@@ -2,16 +2,27 @@
 
 - **项目**：Fabushi Telegram 全量融合
 - **文档 ID**：DOC-07
-- **版本**：v1.0
+- **版本**：v1.1
 - **状态**：BASELINE
-- **基线日期**：2026-08-22
+- **基线日期**：2026-08-27
 - **源计划**：`../source/完整telegram融合进fabushi.txt`
 
-> 本文档由源计划结构化拆分而来。源计划未明确的管理字段会标记为“项目管理补充/待确认”，避免把推导内容冒充既有事实。
+> 本文档由源计划结构化拆分而来。2026-08-27 用户进一步明确：Fabushi 应主要参考 Telegram 的跨端产品方式，Web、桌面和移动端应保持同一产品身份、核心信息架构、主要 UI 语义和功能集合；平台差异只用于窗口尺寸、输入方式和原生系统能力适配。
 
-## Electron 桌面端
+## 全平台一致性基线
 
-桌面端需要完整实现 Telegram 类成熟 IM 的操作密度，但采用 Fabushi 设计语言。
+Fabushi Web 不是独立营销站或独立应用市场壳，而是完整 Fabushi 客户端。目标类似 Telegram Web / Desktop / Mobile：
+
+- 登录后的主导航、会话模型、搜索、聊天、Agents、Calls、Mini Apps、Settings 等核心能力保持一致。
+- 同一功能在不同平台使用相同的名称、信息架构、状态语义和主要操作路径。
+- 桌面与 Web 在技术允许时直接复用同一 UI surface；当前 `frontend/apps/host/src/main.tsx` 与 Web Host 共享 `host-client.tsx`。
+- iOS / Android 可以采用原生 SwiftUI / Compose 实现，但不应重新发明另一套产品结构；布局只按窄屏、触屏和系统能力做响应式/原生适配。
+- Mini App Marketplace、应用详情、内容级 SEO、WebMCP、公开搜索索引属于主产品新增能力，不得替代 Messenger / Host 主壳。
+- `/apps` 等公开页面用于无需登录的发现、分发和搜索引擎入口；用户进入主产品后，Marketplace 仍以 Mini Apps / 插件市场能力出现在同一 Host 中。
+
+## Electron / Web 主 Host
+
+桌面与 Web 需要完整实现 Telegram 类成熟 IM 的操作密度，并采用 Fabushi 设计语言和共享 Host surface。
 
 三栏基础布局：
 - 左：导航 + 会话列表
@@ -109,7 +120,9 @@ Android：
 
 要求：
 - 协议和消息状态机不在 Swift/Kotlin 重写。
-- UI 平台原生化，但行为由共享 domain contracts 保证一致。
+- UI 技术栈可以平台原生化，但产品信息架构、核心布局语义、功能集合和状态机必须与 Web / Desktop 保持一致。
+- 窄屏下允许把三栏折叠成分层导航；这属于响应式变化，不属于另一套产品 UI。
+- Mini App surface 可使用受控 WebView/WKWebView；主 Messenger 壳保持平台原生能力与共享 domain contracts。
 
 
 ============================================================

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -196,3 +196,11 @@
 - 版本基线统一为 `1.0.4`，Android/iOS build/version code = 2，desktop/mobile/iOS metadata 已对齐。
 - 实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 的 GitHub Actions 已全部通过：CI `33037215956`、Electron `33037215849`、Mahayana fast `33037215841`、Messaging `33037215905`、Native mobile catch-all `33037216132`、Vendor Isolation `33037215878`、GBF security `33037215815`、Commerce `33037215869`、Portfolio governance `33037215819`、Douyin MiniApp `33037215821`、Explicit automerge `33037215965`。
 - 当前仅进行最终治理同步；任务继续保持 `TESTING / IN_PROGRESS`。只有 final governance head required checks 全绿、PR #2169 经 protected `main` 合并、canonical-main 回读、exact-main packaged Electron/Android/iOS E2E 及截图/视频/trace/report evidence 全绿，并发布指向 accepted main SHA 的 GitHub Release 1.0.4 后，才允许改为 `COMPLETED / RELEASED`。
+
+## 2026-08-27 — Web Host / Telegram parity correction
+
+- 用户纠正 Web 产品方向：Web 不是独立 Marketplace 壳，而应像 Telegram Web 一样作为完整 Fabushi 客户端，与桌面/移动保持同一产品信息架构、核心 UI 语义和功能集合。
+- 当前分支 `codex/web-host-unify-20260827` 已将 `/` 恢复到共享 `HostClientEntry`；`frontend/apps/host/src/main.tsx` 与 Web 根入口继续复用同一 `host-client.tsx` surface。
+- 新增 Marketplace UI 保留到 `/apps`，应用详情、内容永久 URL、OpenSearch、search-index、Sitemap 与全局 WebMCP 均保留。
+- Host 内 Mini App 市场已改为复用 `lib/marketplace.ts` 唯一 catalog，消除第二份硬编码应用列表，并纳入第 8 个 `computer-cleaner`。
+- 本地结构检查与 `git diff --check` 已通过；完整 TypeScript/Next build 交由 GitHub Actions 验证。任务状态保持 `TESTING / IN_PROGRESS`，在 protected merge + canonical main readback + production deploy/runtime verification 前不得关闭。

--- a/projects/telegram-fabushi-integration/source/2026-08-27-web-host-telegram-parity.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-27-web-host-telegram-parity.md
@@ -1,0 +1,47 @@
+# 2026-08-27 — Web Host 与 Telegram 式全平台 UI 收敛
+
+## 用户纠正后的要求
+
+Fabushi Web 不是独立的“应用市场网站”。Web、桌面和移动客户端需要像 Telegram 一样，在不同平台上保持同一产品信息架构、核心 UI 语义和功能集合；平台只在窗口尺寸、原生系统能力和输入方式上做适配。
+
+本轮具体要求：
+
+- Web 根入口直接进入 Fabushi 主 Host / Messenger，而不是进入另一套市场首页。
+- 现有桌面 Host 与 Web 复用同一个 React Host surface，避免两套 UI 漂移。
+- 已新增的应用市场、应用详情、内容级 SEO、搜索索引、OpenSearch、Sitemap、WebMCP 能力全部保留。
+- 应用市场作为 Host 内原生“Mini Apps / 插件市场”能力继续存在，同时保留 `/apps`、`/apps/[slug]` 和内容永久 URL 作为公开分发与搜索入口。
+- WebMCP 是 Web/Mini App 前台 Agent 接口，不得要求用户进入独立市场壳后才能使用。
+- Marketplace 与 Host 使用同一份 Mini App catalog 和同一安装状态 key，避免重复配置和应用数量漂移。
+
+## Open-source-first 研究
+
+### Telegram Web K
+
+- 上游：`TelegramOrg/Telegram-web-k`
+- 许可证：GPL-3.0。
+- 本轮只学习产品架构和交互模式，不复制其受 GPL 约束的实现代码。
+- 采用的设计原则：一个主客户端 Shell 承载聊天、搜索、导航和扩展能力；Web 是完整客户端而不是营销站；响应式变化不改变产品身份和核心操作语义。
+- Fabushi 继续用自己的 React/Next.js Host、Mahayana contracts、Mini App sandbox 和 WebMCP bridge 实现这些原则。
+
+### 既有 Fabushi 基线
+
+- `frontend/apps/host/src/main.tsx` 已直接复用 `frontend/apps/web/src/app/host/host-client.tsx`，证明桌面 Host 与 Web Host 可以共享同一 UI surface。
+- 2026-08-27 的 WebMCP 升级要求仍有效：当前 Mini App 的前台工具由 WebMCP 暴露，后台长任务继续由 Rust/Native Runtime 承担。
+- 2026-08-25 的 Telegram-style Mini Apps Marketplace 要求仍有效：Marketplace 是主客户端中的发现/安装能力，而不是替代主客户端。
+
+## 实现计划
+
+1. 根路由 `/` 恢复为共享 HostClientEntry。
+2. 新市场完整页面迁移为 `/apps` 公开发现入口；应用详情与内容永久 URL 保持不变。
+3. Host 内插件市场复用 `lib/marketplace.ts` 作为 catalog，保留安装/打开行为，并增加公开详情入口。
+4. 全站 metadata / PWA manifest 改为产品优先，Marketplace/SEO/WebMCP 作为能力描述而不是产品主身份。
+5. 追加回归测试，保证 `/` 和 `/host` 都指向同一 Host surface，且 `/apps` 仍保留 marketplace surface。
+
+## 验收
+
+- `/` 与桌面 Host 复用同一个 HostClient 入口。
+- `/apps` 保留新市场 UI。
+- 8 个 Marketplace Mini Apps 均可在 Host 市场出现；不再由 Host 维护第二份硬编码清单。
+- WebMCP 仍由根 layout 全局挂载。
+- `/apps/[slug]`、`/apps/[slug]/content/[contentId]`、`/search-index.json`、`/opensearch.xml`、`/sitemap.xml` 保持可用。
+- TypeScript/typecheck/build 和相关 route/host tests 通过；PR 必须通过 protected merge queue 合入 canonical main。


### PR DESCRIPTION
## 目标

修正上一轮 Web Marketplace 方向：Fabushi Web 不再以独立市场壳作为根页面，而是像 Telegram Web 一样作为完整客户端，与桌面 Host 复用同一 UI surface。Marketplace / SEO / WebMCP 保留并融合进现有 Host。

## 主要改动

- `/` 恢复到共享 `HostClientEntry`，与 `frontend/apps/host/src/main.tsx` 共用 `host-client.tsx`。
- 新 Marketplace 完整 UI 保留到 `/apps`，不丢失上一轮设计和分发能力。
- Host 内 Mini App 市场改为复用 `lib/marketplace.ts` 唯一 catalog，消除第二份硬编码列表，并纳入 8 个应用（含 `computer-cleaner`）。
- Host 市场增加应用详情/内容入口，继续复用同一安装状态。
- 全站 WebMCP 仍由 root layout 全局挂载。
- PWA metadata / manifest 改为 Fabushi 客户端优先；`/apps`、应用详情、内容永久 URL、OpenSearch、search-index、sitemap 均保留。
- 更新 TFI 项目基线，明确 Web/Desktop/Mobile 的 Telegram 式 UI/功能一致性要求及 Telegram Web K 的 GPL-3.0 provenance 边界。

## 验收

- `git diff --check` 通过。
- 本地结构检查确认 `/` -> Host、`/apps` -> Marketplace、WebMCP 全局挂载、Marketplace catalog = 8 apps。
- 本地 `pnpm typecheck:host` 因当前 Mac 环境缺失可执行 `pnpm`/依赖安装路径未能启动；完整 typecheck / Next build 由 GitHub Actions 验证。

Project: FAB-P0001 / TFI