### PR TITLE
feat(mobile): dark inbox UI and 1.0.5 release

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.4",
-  "androidVersionCode": 2,
-  "iosBuildNumber": 2
+  "version": "1.0.5",
+  "androidVersionCode": 3,
+  "iosBuildNumber": 3
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Fabushi Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",

--- a/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
+++ b/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
@@ -19,14 +19,12 @@ class FabushiScreenTest {
     val compose = createComposeRule()
 
     @Test
-    fun coreControlsExposeStableSemanticsAndSearchCallback() {
-        var query by mutableStateOf("")
-        var searches = 0
+    fun homeMatchesConversationReferenceAndSearchesMessages() {
         compose.setContent {
             FabushiScreen(
-                state = MarketplaceUiState(message = "ready", query = query),
-                onQueryChange = { query = it },
-                onSearch = { searches += 1 },
+                state = MarketplaceUiState(),
+                onQueryChange = {},
+                onSearch = {},
                 onInstall = {},
                 onOpen = {},
                 onApprovePermissions = {},
@@ -35,26 +33,30 @@ class FabushiScreenTest {
         }
 
         compose.onNodeWithTag(TestTags.AppShell).assertIsDisplayed()
-        compose.onNodeWithTag(TestTags.RuntimeBadge).assertTextContains("Compose", substring = true)
-        compose.onNodeWithTag(TestTags.HostStatus).assertIsDisplayed()
-        compose.onNodeWithText("ready").assertIsDisplayed()
-        compose.onNodeWithTag(TestTags.SearchField).performTextInput("telegram")
-        compose.onNodeWithTag(TestTags.SearchButton).performClick()
+        compose.onNodeWithTag(TestTags.ProfileAvatar).assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.HomeSearchButton).assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.AddButton).assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.ConversationList).assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.ConversationRow).assertIsDisplayed()
+        compose.onNodeWithText("Chief of Staff").assertIsDisplayed()
 
-        assertEquals("telegram", query)
-        assertEquals(1, searches)
+        compose.onNodeWithTag(TestTags.HomeSearchButton).performClick()
+        compose.onNodeWithTag(TestTags.HomeSearchField).performTextInput("Chief")
+        compose.onNodeWithText("Chief of Staff").assertIsDisplayed()
     }
 
     @Test
-    fun pluginCardsExposeInstallAndWebMcpOpenControls() {
+    fun addMenuOpensMarketplaceAndKeepsMarketplaceCallbacks() {
+        var query by mutableStateOf("")
+        var searches = 0
         var installed: MarketplacePlugin? = null
         var opened: MarketplacePlugin? = null
         val plugin = MarketplacePlugin("example-plugin", "示例插件", "描述", "1.0.0")
         compose.setContent {
             FabushiScreen(
-                state = MarketplaceUiState(plugins = listOf(plugin)),
-                onQueryChange = {},
-                onSearch = {},
+                state = MarketplaceUiState(message = "ready", query = query, plugins = listOf(plugin)),
+                onQueryChange = { query = it },
+                onSearch = { searches += 1 },
                 onInstall = { installed = it },
                 onOpen = { opened = it },
                 onApprovePermissions = {},
@@ -62,12 +64,49 @@ class FabushiScreenTest {
             )
         }
 
+        compose.onNodeWithTag(TestTags.AddButton).performClick()
+        compose.onNodeWithTag(TestTags.MarketplaceEntry).assertIsDisplayed().performClick()
+        compose.onNodeWithTag(TestTags.RuntimeBadge).assertTextContains("Compose", substring = true)
+        compose.onNodeWithTag(TestTags.HostStatus).assertIsDisplayed()
+        compose.onNodeWithText("ready").assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.SearchField).performTextInput("telegram")
+        compose.onNodeWithTag(TestTags.SearchButton).performClick()
+        assertEquals("telegram", query)
+        assertEquals(1, searches)
+
         compose.onNodeWithTag(TestTags.plugin(plugin.pluginId)).assertIsDisplayed()
-        compose.onNodeWithText("示例插件").assertIsDisplayed()
         compose.onNodeWithTag(TestTags.open(plugin.pluginId)).assertIsDisplayed().performClick()
         assertEquals(plugin, opened)
         compose.onNodeWithTag(TestTags.install(plugin.pluginId)).assertIsDisplayed().performClick()
         assertEquals(plugin, installed)
+    }
+
+    @Test
+    fun availableUpdateAppearsOnHomeAndStartsInstall() {
+        var installRequests = 0
+        compose.setContent {
+            FabushiScreen(
+                state = MarketplaceUiState(),
+                onQueryChange = {},
+                onSearch = {},
+                onInstall = {},
+                onOpen = {},
+                onApprovePermissions = {},
+                onDenyPermissions = {},
+                updateState = AndroidUpdateUiState(
+                    phase = AndroidUpdatePhase.AVAILABLE,
+                    currentVersion = "1.0.4",
+                    availableVersion = "1.0.5",
+                    availableVersionCode = 3,
+                ),
+                onInstallUpdate = { installRequests += 1 },
+            )
+        }
+
+        compose.onNodeWithTag(TestTags.UpdateCard).assertIsDisplayed()
+        compose.onNodeWithText("发现新版本 1.0.5").assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.UpdateAction).performClick()
+        assertEquals(1, installRequests)
     }
 
     @Test

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -1,6 +1,11 @@
 package com.ombhrum.fabushi
 
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,29 +13,55 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 object TestTags {
     const val AppShell = "app-shell"
+    const val Home = "home"
+    const val ProfileAvatar = "profile-avatar"
+    const val HomeSearchButton = "home-search-button"
+    const val HomeSearchField = "home-search-field"
+    const val AddButton = "home-add-button"
+    const val ConversationList = "conversation-list"
+    const val ConversationRow = "conversation-chief-of-staff"
+    const val MarketplaceEntry = "marketplace-entry"
     const val RuntimeBadge = "runtime-badge"
     const val SearchField = "marketplace-search"
     const val SearchButton = "marketplace-search-submit"
@@ -44,6 +75,24 @@ object TestTags {
     fun install(id: String) = "install-$id"
     fun open(id: String) = "open-$id"
 }
+
+private enum class MobileDestination { HOME, MARKETPLACE }
+
+private data class ConversationSummary(
+    val id: String,
+    val title: String,
+    val preview: String,
+    val time: String,
+    val badge: String,
+)
+
+private val homeBackground = Color(0xFF0B0B0C)
+private val homeSurface = Color(0xFF151516)
+private val homeBorder = Color(0xFF29292B)
+private val homePrimaryText = Color(0xFFF3F3F4)
+private val homeSecondaryText = Color(0xFF8C8C91)
+private val homeAccent = Color(0xFFFFB21A)
+private val conversationAccent = Color(0xFFFF5A0A)
 
 @Composable
 fun FabushiScreen(
@@ -61,6 +110,8 @@ fun FabushiScreen(
     onCheckUpdate: () -> Unit = {},
     onInstallUpdate: () -> Unit = {},
 ) {
+    var destination by remember { mutableStateOf(MobileDestination.HOME) }
+
     state.permissionRequest?.let { request ->
         AlertDialog(
             modifier = Modifier.testTag(TestTags.PermissionDialog),
@@ -87,6 +138,367 @@ fun FabushiScreen(
         )
     }
 
+    when (destination) {
+        MobileDestination.HOME -> ConversationHome(
+            updateState = updateState,
+            onCheckUpdate = onCheckUpdate,
+            onInstallUpdate = onInstallUpdate,
+            onOpenMarketplace = { destination = MobileDestination.MARKETPLACE },
+        )
+        MobileDestination.MARKETPLACE -> MarketplaceContent(
+            state = state,
+            onQueryChange = onQueryChange,
+            onSearch = onSearch,
+            onInstall = onInstall,
+            onOpen = onOpen,
+            onBack = { destination = MobileDestination.HOME },
+        )
+    }
+}
+
+@Composable
+private fun ConversationHome(
+    updateState: AndroidUpdateUiState,
+    onCheckUpdate: () -> Unit,
+    onInstallUpdate: () -> Unit,
+    onOpenMarketplace: () -> Unit,
+) {
+    var showSearch by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+    var showAddMenu by remember { mutableStateOf(false) }
+    val conversations = remember {
+        mutableStateListOf(
+            ConversationSummary(
+                id = "chief-of-staff",
+                title = "Chief of Staff",
+                preview = "I can also pull in email, Slack, or other tools…",
+                time = "02:41",
+                badge = "••",
+            ),
+        )
+    }
+    val filteredConversations = conversations.filter { conversation ->
+        searchQuery.isBlank() ||
+            conversation.title.contains(searchQuery, ignoreCase = true) ||
+            conversation.preview.contains(searchQuery, ignoreCase = true)
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize().testTag(TestTags.AppShell),
+        containerColor = homeBackground,
+        contentColor = homePrimaryText,
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .testTag(TestTags.ConversationList),
+        ) {
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 20.dp, top = 10.dp, bottom = 18.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    ProfileAvatar()
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        CircularActionButton(
+                            tag = TestTags.HomeSearchButton,
+                            description = "搜索对话",
+                            onClick = { showSearch = !showSearch },
+                        ) { SearchGlyph() }
+                        Box {
+                            CircularActionButton(
+                                tag = TestTags.AddButton,
+                                description = "添加",
+                                onClick = { showAddMenu = true },
+                            ) { PlusGlyph() }
+                            DropdownMenu(
+                                expanded = showAddMenu,
+                                onDismissRequest = { showAddMenu = false },
+                                containerColor = homeSurface,
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("新建对话", color = homePrimaryText) },
+                                    onClick = {
+                                        showAddMenu = false
+                                        val next = conversations.size + 1
+                                        conversations.add(
+                                            0,
+                                            ConversationSummary(
+                                                id = "new-$next",
+                                                title = "新对话 $next",
+                                                preview = "开始一段新的对话",
+                                                time = "现在",
+                                                badge = "+",
+                                            ),
+                                        )
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    modifier = Modifier.testTag(TestTags.MarketplaceEntry),
+                                    text = { Text("插件市场", color = homePrimaryText) },
+                                    onClick = {
+                                        showAddMenu = false
+                                        onOpenMarketplace()
+                                    },
+                                )
+                                if (updateState.phase != AndroidUpdatePhase.DISABLED) {
+                                    DropdownMenuItem(
+                                        text = { Text("检查更新", color = homePrimaryText) },
+                                        onClick = {
+                                            showAddMenu = false
+                                            onCheckUpdate()
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (showSearch) {
+                item {
+                    OutlinedTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp, vertical = 2.dp)
+                            .testTag(TestTags.HomeSearchField),
+                        singleLine = true,
+                        placeholder = { Text("搜索消息", color = homeSecondaryText) },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = homePrimaryText,
+                            unfocusedTextColor = homePrimaryText,
+                            cursorColor = homeAccent,
+                            focusedBorderColor = Color(0xFF4A4A4E),
+                            unfocusedBorderColor = homeBorder,
+                            focusedContainerColor = homeSurface,
+                            unfocusedContainerColor = homeSurface,
+                        ),
+                        shape = RoundedCornerShape(16.dp),
+                    )
+                    Spacer(Modifier.height(10.dp))
+                }
+            }
+
+            if (shouldShowUpdateBanner(updateState.phase)) {
+                item {
+                    UpdateBanner(
+                        state = updateState,
+                        onCheckUpdate = onCheckUpdate,
+                        onInstallUpdate = onInstallUpdate,
+                    )
+                }
+            }
+
+            if (filteredConversations.isEmpty()) {
+                item {
+                    Text(
+                        "没有找到匹配的消息",
+                        color = homeSecondaryText,
+                        modifier = Modifier.padding(horizontal = 30.dp, vertical = 28.dp),
+                    )
+                }
+            } else {
+                items(filteredConversations, key = { it.id }) { conversation ->
+                    ConversationRow(conversation)
+                }
+            }
+
+            item { Spacer(Modifier.height(32.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun ProfileAvatar() {
+    Box(
+        modifier = Modifier
+            .size(56.dp)
+            .background(homeSurface, CircleShape)
+            .border(1.dp, homeBorder, CircleShape)
+            .testTag(TestTags.ProfileAvatar)
+            .semantics { contentDescription = "个人头像" },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("✦", color = homeAccent, fontSize = 34.sp, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+private fun CircularActionButton(
+    tag: String,
+    description: String,
+    onClick: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(54.dp)
+            .background(Color(0xFF101011), CircleShape)
+            .border(1.dp, homeBorder, CircleShape)
+            .clickable(onClick = onClick)
+            .testTag(tag)
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun SearchGlyph() {
+    Canvas(Modifier.size(24.dp)) {
+        val stroke = 2.2.dp.toPx()
+        drawCircle(
+            color = homePrimaryText,
+            radius = size.minDimension * 0.28f,
+            center = Offset(size.width * 0.43f, size.height * 0.42f),
+            style = Stroke(width = stroke),
+        )
+        drawLine(
+            color = homePrimaryText,
+            start = Offset(size.width * 0.63f, size.height * 0.63f),
+            end = Offset(size.width * 0.84f, size.height * 0.84f),
+            strokeWidth = stroke,
+        )
+    }
+}
+
+@Composable
+private fun PlusGlyph() {
+    Canvas(Modifier.size(25.dp)) {
+        val stroke = 2.dp.toPx()
+        drawLine(
+            color = homePrimaryText,
+            start = Offset(size.width * 0.5f, size.height * 0.14f),
+            end = Offset(size.width * 0.5f, size.height * 0.86f),
+            strokeWidth = stroke,
+        )
+        drawLine(
+            color = homePrimaryText,
+            start = Offset(size.width * 0.14f, size.height * 0.5f),
+            end = Offset(size.width * 0.86f, size.height * 0.5f),
+            strokeWidth = stroke,
+        )
+    }
+}
+
+@Composable
+private fun ConversationRow(conversation: ConversationSummary) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { }
+            .padding(start = 30.dp, end = 24.dp, top = 13.dp, bottom = 13.dp)
+            .then(if (conversation.id == "chief-of-staff") Modifier.testTag(TestTags.ConversationRow) else Modifier),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.size(54.dp).background(conversationAccent, CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(conversation.badge, color = Color(0xFF1A1009), fontWeight = FontWeight.Black, fontSize = 13.sp)
+        }
+        Column(
+            modifier = Modifier.weight(1f).padding(start = 18.dp, end = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(5.dp),
+        ) {
+            Text(
+                conversation.title,
+                color = homePrimaryText,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                conversation.preview,
+                color = homeSecondaryText,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Text(
+            conversation.time,
+            color = Color(0xFF56565B),
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+private fun shouldShowUpdateBanner(phase: AndroidUpdatePhase): Boolean = when (phase) {
+    AndroidUpdatePhase.AVAILABLE,
+    AndroidUpdatePhase.DOWNLOADING,
+    AndroidUpdatePhase.WAITING_FOR_PERMISSION,
+    AndroidUpdatePhase.INSTALLING,
+    AndroidUpdatePhase.ERROR -> true
+    else -> false
+}
+
+@Composable
+private fun UpdateBanner(
+    state: AndroidUpdateUiState,
+    onCheckUpdate: () -> Unit,
+    onInstallUpdate: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp).testTag(TestTags.UpdateCard),
+        colors = CardDefaults.cardColors(containerColor = homeSurface),
+        shape = RoundedCornerShape(18.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            val label = when (state.phase) {
+                AndroidUpdatePhase.AVAILABLE -> "发现新版本 ${state.availableVersion ?: ""}"
+                AndroidUpdatePhase.DOWNLOADING -> "正在下载更新 ${state.progressPercent ?: 0}%"
+                AndroidUpdatePhase.WAITING_FOR_PERMISSION -> "更新已下载，等待安装权限"
+                AndroidUpdatePhase.INSTALLING -> "系统安装器已打开"
+                AndroidUpdatePhase.ERROR -> "更新失败"
+                else -> "应用更新"
+            }
+            Text(label, color = homePrimaryText, fontWeight = FontWeight.SemiBold)
+            state.message?.takeIf { it.isNotBlank() }?.let {
+                Text(it, color = homeSecondaryText, style = MaterialTheme.typography.bodySmall)
+            }
+            if (state.phase == AndroidUpdatePhase.DOWNLOADING) {
+                val progress = (state.progressPercent ?: 0).coerceIn(0, 100) / 100f
+                LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
+            }
+            when (state.phase) {
+                AndroidUpdatePhase.AVAILABLE,
+                AndroidUpdatePhase.WAITING_FOR_PERMISSION,
+                AndroidUpdatePhase.INSTALLING -> Button(
+                    onClick = onInstallUpdate,
+                    modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateAction),
+                    colors = ButtonDefaults.buttonColors(containerColor = homeAccent, contentColor = Color.Black),
+                ) {
+                    Text(if (state.phase == AndroidUpdatePhase.AVAILABLE) "下载并安装" else "继续安装")
+                }
+                AndroidUpdatePhase.ERROR -> OutlinedButton(
+                    onClick = onCheckUpdate,
+                    modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateAction),
+                ) { Text("重新检查", color = homePrimaryText) }
+                else -> Unit
+            }
+        }
+    }
+}
+
+@Composable
+private fun MarketplaceContent(
+    state: MarketplaceUiState,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    onInstall: (MarketplacePlugin) -> Unit,
+    onOpen: (MarketplacePlugin) -> Unit,
+    onBack: () -> Unit,
+) {
     Scaffold(modifier = Modifier.fillMaxSize().testTag(TestTags.AppShell)) { padding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 20.dp),
@@ -103,60 +515,16 @@ fun FabushiScreen(
                         Text("MAHAYANA RUST HOST", style = MaterialTheme.typography.labelSmall)
                         Text("全球法布施", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Bold)
                     }
-                    Text(
-                        "Compose · Rust",
-                        modifier = Modifier.testTag(TestTags.RuntimeBadge).semantics { contentDescription = "Android native runtime" },
-                        style = MaterialTheme.typography.labelMedium,
-                    )
+                    OutlinedButton(onClick = onBack) { Text("返回消息") }
                 }
             }
 
-            if (updateState.phase != AndroidUpdatePhase.DISABLED) {
-                item {
-                    Card(modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateCard)) {
-                        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                            Text("应用更新", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                            Text(
-                                "当前版本 ${updateState.currentVersion} (${updateState.currentVersionCode})",
-                                style = MaterialTheme.typography.labelMedium,
-                            )
-                            val statusText = when (updateState.phase) {
-                                AndroidUpdatePhase.CHECKING -> "正在检查 GitHub Release…"
-                                AndroidUpdatePhase.UP_TO_DATE -> "已是最新版本"
-                                AndroidUpdatePhase.AVAILABLE -> "发现新版本 ${updateState.availableVersion} (${updateState.availableVersionCode})"
-                                AndroidUpdatePhase.DOWNLOADING -> "正在下载 ${updateState.progressPercent ?: 0}%"
-                                AndroidUpdatePhase.WAITING_FOR_PERMISSION -> "安装包已下载，等待安装权限"
-                                AndroidUpdatePhase.INSTALLING -> "系统安装器已打开"
-                                AndroidUpdatePhase.ERROR -> "更新检查或安装失败"
-                                AndroidUpdatePhase.DISABLED -> ""
-                            }
-                            if (statusText.isNotEmpty()) Text(statusText)
-                            updateState.message?.takeIf { it.isNotBlank() }?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
-                            if (updateState.phase == AndroidUpdatePhase.DOWNLOADING) {
-                                val progress = (updateState.progressPercent ?: 0).coerceIn(0, 100) / 100f
-                                LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
-                            }
-                            when (updateState.phase) {
-                                AndroidUpdatePhase.AVAILABLE,
-                                AndroidUpdatePhase.WAITING_FOR_PERMISSION,
-                                AndroidUpdatePhase.INSTALLING,
-                                -> Button(
-                                    onClick = onInstallUpdate,
-                                    modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateAction),
-                                ) {
-                                    Text(if (updateState.phase == AndroidUpdatePhase.AVAILABLE) "下载并安装" else "继续安装")
-                                }
-                                AndroidUpdatePhase.UP_TO_DATE,
-                                AndroidUpdatePhase.ERROR,
-                                -> OutlinedButton(
-                                    onClick = onCheckUpdate,
-                                    modifier = Modifier.fillMaxWidth().testTag(TestTags.UpdateAction),
-                                ) { Text("检查更新") }
-                                else -> Unit
-                            }
-                        }
-                    }
-                }
+            item {
+                Text(
+                    "Compose · Rust",
+                    modifier = Modifier.testTag(TestTags.RuntimeBadge).semantics { contentDescription = "Android native runtime" },
+                    style = MaterialTheme.typography.labelMedium,
+                )
             }
 
             item {

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -1,10 +1,214 @@
 import SwiftUI
 
+private enum MobileDestination {
+    case home
+    case marketplace
+}
+
+private struct ConversationSummary: Identifiable {
+    let id: String
+    let title: String
+    let preview: String
+    let time: String
+    let badge: String
+}
+
 struct ContentView: View {
     @Bindable var model: MarketplaceModel
     @State private var openedMiniApp: MarketplacePlugin?
+    @State private var destination: MobileDestination = .home
+    @State private var isSearching = false
+    @State private var homeQuery = ""
+    @State private var conversations: [ConversationSummary] = [
+        ConversationSummary(
+            id: "chief-of-staff",
+            title: "Chief of Staff",
+            preview: "I can also pull in email, Slack, or other tools…",
+            time: "02:41",
+            badge: "••"
+        )
+    ]
 
     var body: some View {
+        Group {
+            switch destination {
+            case .home:
+                homeView
+            case .marketplace:
+                marketplaceView
+            }
+        }
+        .fullScreenCover(item: $openedMiniApp) { plugin in
+            MiniAppWebMcpSurface(plugin: plugin, model: model)
+        }
+        .alert("插件权限", isPresented: Binding(
+            get: { model.permissionRequest != nil },
+            set: { if !$0 { model.denyPermissions() } }
+        )) {
+            Button("拒绝", role: .cancel) { model.denyPermissions() }
+                .accessibilityIdentifier("permission-deny")
+            Button("授权") { Task { await model.approvePermissions() } }
+                .accessibilityIdentifier("permission-approve")
+        } message: {
+            if let request = model.permissionRequest {
+                Text("\(request.pluginId) 请求以下权限：\n\(request.permissions.joined(separator: "\n"))")
+            }
+        }
+    }
+
+    private var homeView: some View {
+        ZStack {
+            Color(red: 0.043, green: 0.043, blue: 0.047).ignoresSafeArea()
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    HStack(spacing: 12) {
+                        avatar
+                        Spacer()
+                        circleButton(systemName: "magnifyingglass", identifier: "home-search-button") {
+                            withAnimation(.easeInOut(duration: 0.18)) { isSearching.toggle() }
+                        }
+                        Menu {
+                            Button("新建对话") { addConversation() }
+                            Button("插件市场") { destination = .marketplace }
+                                .accessibilityIdentifier("marketplace-entry")
+                        } label: {
+                            ZStack {
+                                Circle()
+                                    .fill(Color(red: 0.063, green: 0.063, blue: 0.067))
+                                    .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 1))
+                                Image(systemName: "plus")
+                                    .font(.system(size: 23, weight: .regular))
+                                    .foregroundStyle(.white)
+                            }
+                            .frame(width: 54, height: 54)
+                        }
+                        .accessibilityIdentifier("home-add-button")
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.top, 10)
+                    .padding(.bottom, 18)
+
+                    if isSearching {
+                        TextField("搜索消息", text: $homeQuery)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 16)
+                            .frame(height: 48)
+                            .background(Color(red: 0.082, green: 0.082, blue: 0.086), in: RoundedRectangle(cornerRadius: 16))
+                            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.12), lineWidth: 1))
+                            .padding(.horizontal, 20)
+                            .padding(.bottom, 10)
+                            .accessibilityIdentifier("home-search-field")
+                    }
+
+                    VStack(spacing: 0) {
+                        ForEach(filteredConversations) { conversation in
+                            conversationRow(conversation)
+                        }
+                        if filteredConversations.isEmpty {
+                            Text("没有找到匹配的消息")
+                                .foregroundStyle(Color.white.opacity(0.48))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 30)
+                                .padding(.vertical, 28)
+                        }
+                    }
+                    .accessibilityIdentifier("conversation-list")
+
+                    if let featureHostSmokeStatus = model.featureHostSmokeStatus {
+                        Text(featureHostSmokeStatus)
+                            .font(.caption2)
+                            .foregroundStyle(.clear)
+                            .accessibilityIdentifier("feature-host-smoke")
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("app-shell")
+    }
+
+    private var avatar: some View {
+        ZStack {
+            Circle()
+                .fill(Color(red: 0.082, green: 0.082, blue: 0.086))
+                .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 1))
+            Text("✦")
+                .font(.system(size: 34, weight: .bold))
+                .foregroundStyle(Color(red: 1.0, green: 0.70, blue: 0.10))
+        }
+        .frame(width: 56, height: 56)
+        .accessibilityLabel("个人头像")
+        .accessibilityIdentifier("profile-avatar")
+    }
+
+    private func circleButton(systemName: String, identifier: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .fill(Color(red: 0.063, green: 0.063, blue: 0.067))
+                    .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 1))
+                Image(systemName: systemName)
+                    .font(.system(size: 22, weight: .regular))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: 54, height: 54)
+        }
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func conversationRow(_ conversation: ConversationSummary) -> some View {
+        HStack(spacing: 0) {
+            ZStack {
+                Circle().fill(Color(red: 1.0, green: 0.35, blue: 0.04))
+                Text(conversation.badge)
+                    .font(.system(size: 13, weight: .black))
+                    .foregroundStyle(Color(red: 0.10, green: 0.06, blue: 0.03))
+            }
+            .frame(width: 54, height: 54)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(conversation.title)
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.96))
+                    .lineLimit(1)
+                Text(conversation.preview)
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.white.opacity(0.50))
+                    .lineLimit(1)
+            }
+            .padding(.leading, 18)
+
+            Spacer(minLength: 12)
+
+            Text(conversation.time)
+                .font(.system(size: 14))
+                .foregroundStyle(Color.white.opacity(0.30))
+        }
+        .padding(.leading, 30)
+        .padding(.trailing, 24)
+        .padding(.vertical, 13)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(conversation.id == "chief-of-staff" ? "conversation-chief-of-staff" : "conversation-\(conversation.id)")
+    }
+
+    private var filteredConversations: [ConversationSummary] {
+        guard !homeQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return conversations }
+        return conversations.filter {
+            $0.title.localizedCaseInsensitiveContains(homeQuery) || $0.preview.localizedCaseInsensitiveContains(homeQuery)
+        }
+    }
+
+    private func addConversation() {
+        let next = conversations.count + 1
+        conversations.insert(
+            ConversationSummary(id: "new-\(next)", title: "新对话 \(next)", preview: "开始一段新的对话", time: "现在", badge: "+"),
+            at: 0
+        )
+    }
+
+    private var marketplaceView: some View {
         NavigationStack {
             List {
                 Section {
@@ -22,7 +226,6 @@ struct ContentView: View {
                         .accessibilityElement(children: .contain)
                     }
                     .accessibilityElement(children: .contain)
-                    .accessibilityIdentifier("app-shell")
                 }
 
                 Section("本地插件市场") {
@@ -84,23 +287,12 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("法布施")
-            .refreshable { await model.refresh() }
-            .fullScreenCover(item: $openedMiniApp) { plugin in
-                MiniAppWebMcpSurface(plugin: plugin, model: model)
-            }
-            .alert("插件权限", isPresented: Binding(
-                get: { model.permissionRequest != nil },
-                set: { if !$0 { model.denyPermissions() } }
-            )) {
-                Button("拒绝", role: .cancel) { model.denyPermissions() }
-                    .accessibilityIdentifier("permission-deny")
-                Button("授权") { Task { await model.approvePermissions() } }
-                    .accessibilityIdentifier("permission-approve")
-            } message: {
-                if let request = model.permissionRequest {
-                    Text("\(request.pluginId) 请求以下权限：\n\(request.permissions.joined(separator: "\n"))")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("消息") { destination = .home }
                 }
             }
+            .refreshable { await model.refresh() }
         }
     }
 }

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -22,25 +22,32 @@ final class FabushiUITests: XCTestCase {
     }
 
     @MainActor
-    func testCoreControlsExposeStableAccessibilityIdentifiers() throws {
+    func testHomeMatchesConversationLayoutAndMarketplaceRemainsReachable() throws {
         let app = XCUIApplication()
         app.launch()
 
-        XCTAssertTrue(
-            app.descendants(matching: .any)["app-shell"].waitForExistence(timeout: 10)
-        )
-        XCTAssertTrue(
-            app.descendants(matching: .any)["runtime-badge"].waitForExistence(timeout: 5)
-        )
-        XCTAssertTrue(
-            app.descendants(matching: .any)["host-status"].waitForExistence(timeout: 5)
-        )
+        XCTAssertTrue(app.descendants(matching: .any)["app-shell"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["profile-avatar"].exists)
+        XCTAssertTrue(app.buttons["home-search-button"].exists)
+        XCTAssertTrue(app.buttons["home-add-button"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["conversation-list"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["conversation-chief-of-staff"].exists)
+
+        app.buttons["home-search-button"].tap()
+        let homeSearch = app.textFields["home-search-field"]
+        XCTAssertTrue(homeSearch.waitForExistence(timeout: 5))
+        homeSearch.tap()
+        homeSearch.typeText("Chief")
+        XCTAssertTrue(app.staticTexts["Chief of Staff"].exists)
+
+        openMarketplace(in: app)
+        XCTAssertTrue(app.descendants(matching: .any)["runtime-badge"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["host-status"].exists)
 
         let search = app.textFields["marketplace-search"]
         XCTAssertTrue(search.exists)
         search.tap()
         search.typeText("telegram")
-
         let submit = app.buttons["marketplace-search-submit"]
         XCTAssertTrue(submit.exists)
         submit.tap()
@@ -50,6 +57,7 @@ final class FabushiUITests: XCTestCase {
     func testMiniAppOpensAndClosesDedicatedWebMcpSurface() throws {
         let app = XCUIApplication()
         app.launch()
+        openMarketplace(in: app)
 
         let open = app.buttons["open-global-dharma"]
         XCTAssertTrue(open.waitForExistence(timeout: 15))
@@ -63,5 +71,15 @@ final class FabushiUITests: XCTestCase {
         XCTAssertTrue(close.exists)
         close.tap()
         XCTAssertTrue(surface.waitForNonExistence(timeout: 10))
+    }
+
+    @MainActor
+    private func openMarketplace(in app: XCUIApplication) {
+        let add = app.buttons["home-add-button"]
+        XCTAssertTrue(add.waitForExistence(timeout: 10))
+        add.tap()
+        let marketplace = app.buttons["marketplace-entry"]
+        XCTAssertTrue(marketplace.waitForExistence(timeout: 5))
+        marketplace.tap()
     }
 }

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 1.0.4
-        CURRENT_PROJECT_VERSION: 2
+        MARKETING_VERSION: 1.0.5
+        CURRENT_PROJECT_VERSION: 3
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'
     info:

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
## Summary
- Make the native mobile home screen a dark conversation inbox matching the supplied reference: profile avatar at top-left, search/add actions at top-right, and conversation rows below.
- Keep the existing plugin marketplace and MiniApp controls reachable from the add menu instead of removing them.
- Preserve Android GitHub self-update UX on the new home screen.
- Apply the same information architecture to Android Compose and iOS SwiftUI.
- Update native UI tests for inbox, search, marketplace navigation, MiniApp access, permissions, and Android update action.
- Bump the canonical app version to 1.0.5 (Android/iOS build metadata 3) and sync desktop/mobile package metadata required by the canonical version guard.

Release will only be dispatched from main after the repository's required Android source gates pass for the exact merged SHA.