### PR TITLE
docs(tfi): 记录 Web Host 生产交付证据

### DIFF
--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -204,3 +204,14 @@
 - 新增 Marketplace UI 保留到 `/apps`，应用详情、内容永久 URL、OpenSearch、search-index、Sitemap 与全局 WebMCP 均保留。
 - Host 内 Mini App 市场已改为复用 `lib/marketplace.ts` 唯一 catalog，消除第二份硬编码应用列表，并纳入第 8 个 `computer-cleaner`。
 - 本地结构检查与 `git diff --check` 已通过；完整 TypeScript/Next build 交由 GitHub Actions 验证。任务状态保持 `TESTING / IN_PROGRESS`，在 protected merge + canonical main readback + production deploy/runtime verification 前不得关闭。
+
+## 2026-08-27 — Web Host / Telegram parity delivered to production
+
+- 修正 PR #2174 已通过 protected merge queue 合入 canonical `main`；merge-group CI `33048054659` 成功，canonical main 回读为 `e91c90e6e2da0b5d72b89159a7e62dc206a8254f`。
+- Exact-main 正式站点流程 `33048155337` 成功：`Build official site` 与 `Deploy official site to Cloudflare Worker` 均为 success。
+- 生产 `https://fabushi.ombhrum.com/` 已恢复完整 Fabushi Host 产品入口；`/apps/` 保留 Marketplace 公开发现入口。根页 title 与 `/apps/` title 已分别验证为 Host 产品语义与 Marketplace 语义。
+- 生产 HTTP 验证通过：`/`、`/apps/`、`/apps/mahayana-assistant/`、`/apps/mahayana-assistant/content/webmcp-site-tools/`、`/search-index.json`、`/opensearch.xml`、`/sitemap.xml`、`/robots.txt` 均返回 200。
+- 搜索索引生产回读为 `fabushi.marketplace.search-index.v1`，共 8 个 Mini Apps / 12 个内容级条目；Sitemap 同时保留 `/apps/`、8 个应用详情和 12 个内容永久 URL。
+- Web 与桌面继续源码级复用同一 `host-client.tsx`；Host 内 Marketplace 与公开 Marketplace 统一使用 `lib/marketplace.ts` catalog，WebMCP 继续由 root layout 全局挂载。
+- Mac Computer Use 预检显示当前屏幕锁定（`screenLocked=true`），因此本轮没有把无法执行的桌面交互截图冒充为验收证据；尝试的独立 headless Chrome 进程已安全清理。该环境限制不影响 exact-main build/deploy 与生产 HTTP/runtime 路由验收。
+- 本项 Web Host 产品方向修正状态：`DELIVERED / PRODUCTION_VERIFIED`。后续视觉细节优化继续以“Telegram 式全平台一致”为基线，不再回到独立 Marketplace 根壳模型。


### PR DESCRIPTION
## TFI delivery evidence

记录 Web Host / Telegram parity 修正的 protected merge、canonical main、exact-main Cloudflare build/deploy 和生产 runtime 回读证据。

- PR #2174 merge-group CI: `33048054659` success
- canonical main: `e91c90e6e2da0b5d72b89159a7e62dc206a8254f`
- production workflow: `33048155337` success
- production `/`, `/apps/`, app detail/content, search-index, OpenSearch, sitemap, robots: HTTP 200
- search index: 8 Mini Apps / 12 content entries
- 明确记录 Mac 锁屏使 Computer Use 视觉交互验收不可执行，不伪造截图证据

仅更新 `FAB-P0001 / TFI` 项目状态记录，无产品代码改动。