### PR TITLE
feat(web): add AEO and AI app discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,8 @@ jobs:
             frontend-next-${{ runner.os }}-v1-${{ hashFiles('frontend/pnpm-lock.yaml') }}-
       - name: Typecheck frontend workspace
         run: pnpm typecheck
+      - name: Verify AI discovery contracts
+        run: pnpm --filter @fabushi/web test:ai-discovery
       - name: Build official web frontend
         run: pnpm build:web
 

--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "echo 'Skipping typecheck due to React 19 migration' && exit 0",
-    "typecheck:host": "tsc -p tsconfig.host.json --noEmit"
+    "typecheck:host": "tsc -p tsconfig.host.json --noEmit",
+    "test:ai-discovery": "node scripts/check-ai-discovery.mjs"
   },
   "dependencies": {
     "@fabushi/api-client": "workspace:*",

--- a/frontend/apps/web/scripts/check-ai-discovery.mjs
+++ b/frontend/apps/web/scripts/check-ai-discovery.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const webRoot = resolve(import.meta.dirname, "..");
+const read = (relativePath) => readFileSync(resolve(webRoot, relativePath), "utf8");
+
+const marketplace = read("src/lib/marketplace.ts");
+const discovery = read("src/lib/ai-discovery.ts");
+const webMcp = read("src/components/marketplace/marketplace-webmcp.tsx");
+const sitemap = read("src/app/sitemap.ts");
+const robots = read("src/app/robots.ts");
+const appPage = read("src/app/apps/[slug]/page.tsx");
+
+const appSlugs = [...marketplace.matchAll(/^    slug: "([^"]+)",$/gm)].map((match) => match[1]);
+const answerSlugs = [...discovery.matchAll(/^    slug: "([^"]+)",$/gm)].map((match) => match[1]);
+
+assert.ok(appSlugs.length >= 8, "the canonical Marketplace catalog must expose all public Mini Apps");
+assert.equal(new Set(appSlugs).size, appSlugs.length, "Marketplace app slugs must be unique");
+assert.equal(new Set(answerSlugs).size, answerSlugs.length, "answer intent slugs must be unique");
+assert.deepEqual(
+  new Set([...discovery.matchAll(/recommendedAppSlug: "([^"]+)"/g)].map((match) => match[1])),
+  new Set(appSlugs),
+  "answer intents must cover every catalog app exactly through catalog references",
+);
+
+for (const relativePath of [
+  "src/app/ai/apps.json/route.ts",
+  "src/app/ai/apps/[file]/route.ts",
+  "src/app/ai/content.json/route.ts",
+  "src/app/ai/answers.json/route.ts",
+  "src/app/llms.txt/route.ts",
+  "src/app/llms-full.txt/route.ts",
+  "src/app/answers/[slug]/page.tsx",
+]) {
+  assert.ok(existsSync(resolve(webRoot, relativePath)), `missing AI discovery route: ${relativePath}`);
+}
+
+assert.match(discovery, /from "\.\/marketplace"/, "AI discovery must derive from the canonical catalog");
+assert.match(discovery, /fabushi\.ai-discovery\.v1/, "AI feeds must expose a versioned schema");
+assert.match(discovery, /#app/, "app entities must use a stable #app identifier");
+assert.match(appPage, /appEntityId\(app\)/, "app JSON-LD must use the shared stable entity helper");
+assert.match(appPage, /"WebApplication"/, "app JSON-LD must identify the web application surface");
+
+for (const tool of ["recommend_fabushi_app", "get_app_capabilities"]) {
+  assert.match(webMcp, new RegExp(`name: "${tool}"`), `WebMCP is missing ${tool}`);
+}
+assert.match(webMcp, /serializeAppForAi/, "WebMCP discovery must reuse the machine app serializer");
+
+for (const bot of ["OAI-SearchBot", "ChatGPT-User", "Googlebot", "Bingbot"]) {
+  assert.match(robots, new RegExp(bot), `robots must explicitly allow ${bot}`);
+}
+
+assert.match(sitemap, /fabushiAnswerIntents/, "answer pages must be generated from the answer registry");
+assert.match(sitemap, /\/answers\//, "answer pages must be present in sitemap");
+assert.match(sitemap, /\/ai\/apps\.json/, "AI machine indexes must be present in sitemap");
+assert.match(sitemap, /\.slug}\.json/, "per-app machine records must be present in sitemap");
+
+console.log(
+  `AI discovery contract passed: ${appSlugs.length} apps, ${answerSlugs.length} answers, stable feeds and WebMCP tools.`,
+);

--- a/frontend/apps/web/src/app/ai/answers.json/route.ts
+++ b/frontend/apps/web/src/app/ai/answers.json/route.ts
@@ -1,0 +1,30 @@
+import {
+  AI_DISCOVERY_LANGUAGE,
+  AI_DISCOVERY_SCHEMA,
+  AI_DISCOVERY_UPDATED_AT,
+  fabushiAnswerIntents,
+  serializeAnswerForAi,
+} from "../../../lib/ai-discovery";
+import { siteUrl } from "../../../lib/site-url";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json(
+    {
+      "@context": "https://schema.org",
+      schema: `${AI_DISCOVERY_SCHEMA}.answers`,
+      generatedAt: AI_DISCOVERY_UPDATED_AT,
+      language: AI_DISCOVERY_LANGUAGE,
+      canonicalUrl: siteUrl("/ai/answers.json"),
+      count: fabushiAnswerIntents.length,
+      items: fabushiAnswerIntents.map(serializeAnswerForAi),
+    },
+    {
+      headers: {
+        "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+        "content-language": AI_DISCOVERY_LANGUAGE,
+      },
+    },
+  );
+}

--- a/frontend/apps/web/src/app/ai/apps.json/route.ts
+++ b/frontend/apps/web/src/app/ai/apps.json/route.ts
@@ -1,0 +1,30 @@
+import {
+  AI_DISCOVERY_LANGUAGE,
+  AI_DISCOVERY_SCHEMA,
+  AI_DISCOVERY_UPDATED_AT,
+  serializeAppForAi,
+} from "../../../lib/ai-discovery";
+import { marketplaceApps } from "../../../lib/marketplace";
+import { siteUrl } from "../../../lib/site-url";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json(
+    {
+      "@context": "https://schema.org",
+      schema: `${AI_DISCOVERY_SCHEMA}.apps`,
+      generatedAt: AI_DISCOVERY_UPDATED_AT,
+      language: AI_DISCOVERY_LANGUAGE,
+      canonicalUrl: siteUrl("/ai/apps.json"),
+      count: marketplaceApps.length,
+      items: marketplaceApps.map(serializeAppForAi),
+    },
+    {
+      headers: {
+        "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+        "content-language": AI_DISCOVERY_LANGUAGE,
+      },
+    },
+  );
+}

--- a/frontend/apps/web/src/app/ai/apps/[file]/route.ts
+++ b/frontend/apps/web/src/app/ai/apps/[file]/route.ts
@@ -1,0 +1,43 @@
+import {
+  AI_DISCOVERY_LANGUAGE,
+  AI_DISCOVERY_SCHEMA,
+  AI_DISCOVERY_UPDATED_AT,
+  serializeAppForAi,
+} from "../../../../lib/ai-discovery";
+import { getMarketplaceApp, marketplaceApps } from "../../../../lib/marketplace";
+
+export const dynamic = "force-static";
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return marketplaceApps.map((app) => ({ file: `${app.slug}.json` }));
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ file: string }> },
+) {
+  const { file } = await params;
+  const slug = file.endsWith(".json") ? file.slice(0, -5) : file;
+  const app = getMarketplaceApp(slug);
+
+  if (!app || file !== `${app.slug}.json`) {
+    return Response.json({ error: "app_not_found", slug }, { status: 404 });
+  }
+
+  return Response.json(
+    {
+      "@context": "https://schema.org",
+      schema: `${AI_DISCOVERY_SCHEMA}.app`,
+      generatedAt: AI_DISCOVERY_UPDATED_AT,
+      language: AI_DISCOVERY_LANGUAGE,
+      item: serializeAppForAi(app),
+    },
+    {
+      headers: {
+        "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+        "content-language": AI_DISCOVERY_LANGUAGE,
+      },
+    },
+  );
+}

--- a/frontend/apps/web/src/app/ai/content.json/route.ts
+++ b/frontend/apps/web/src/app/ai/content.json/route.ts
@@ -1,0 +1,30 @@
+import {
+  AI_DISCOVERY_LANGUAGE,
+  AI_DISCOVERY_SCHEMA,
+  AI_DISCOVERY_UPDATED_AT,
+  serializeContentForAi,
+} from "../../../lib/ai-discovery";
+import { siteUrl } from "../../../lib/site-url";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const items = serializeContentForAi();
+  return Response.json(
+    {
+      "@context": "https://schema.org",
+      schema: `${AI_DISCOVERY_SCHEMA}.content`,
+      generatedAt: AI_DISCOVERY_UPDATED_AT,
+      language: AI_DISCOVERY_LANGUAGE,
+      canonicalUrl: siteUrl("/ai/content.json"),
+      count: items.length,
+      items,
+    },
+    {
+      headers: {
+        "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+        "content-language": AI_DISCOVERY_LANGUAGE,
+      },
+    },
+  );
+}

--- a/frontend/apps/web/src/app/answers/[slug]/page.tsx
+++ b/frontend/apps/web/src/app/answers/[slug]/page.tsx
@@ -1,0 +1,265 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { ArrowRight, ChevronRight, ExternalLink, Search, Sparkles } from "lucide-react";
+import { AppIcon } from "../../../components/marketplace/app-icon";
+import { AppInstallActions } from "../../../components/marketplace/app-install-actions";
+import styles from "../../../components/marketplace/marketplace.module.css";
+import {
+  appEntityId,
+  appMachineUrl,
+  fabushiAnswerIntents,
+  getAnswerIntent,
+} from "../../../lib/ai-discovery";
+import { getMarketplaceApp } from "../../../lib/marketplace";
+import { siteHref, siteUrl } from "../../../lib/site-url";
+
+type AnswerPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return fabushiAnswerIntents.map((answer) => ({ slug: answer.slug }));
+}
+
+export async function generateMetadata({ params }: AnswerPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const answer = getAnswerIntent(slug);
+  if (!answer) return {};
+
+  const title = `${answer.question} | Fabushi Answers`;
+  const url = siteUrl(`/answers/${answer.slug}`);
+
+  return {
+    title,
+    description: answer.answer,
+    alternates: { canonical: url },
+    keywords: [...answer.keywords, "Fabushi Mini App", "AI 应用发现"],
+    openGraph: {
+      title,
+      description: answer.answer,
+      url,
+      siteName: "Fabushi",
+      locale: "zh_CN",
+      type: "article",
+      publishedTime: answer.updatedAt,
+      modifiedTime: answer.updatedAt,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: answer.answer,
+    },
+  };
+}
+
+export default async function AnswerPage({ params }: AnswerPageProps) {
+  const { slug } = await params;
+  const answer = getAnswerIntent(slug);
+  if (!answer) notFound();
+
+  const app = getMarketplaceApp(answer.recommendedAppSlug);
+  if (!app) notFound();
+
+  const url = siteUrl(`/answers/${answer.slug}`);
+  const relatedApps = answer.relatedAppSlugs
+    .map((appSlug) => getMarketplaceApp(appSlug))
+    .filter((candidate) => Boolean(candidate));
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "QAPage",
+        "@id": `${url}#page`,
+        url,
+        inLanguage: "zh-CN",
+        datePublished: answer.updatedAt,
+        dateModified: answer.updatedAt,
+        mainEntity: {
+          "@type": "Question",
+          "@id": `${url}#question`,
+          name: answer.question,
+          text: answer.question,
+          keywords: answer.keywords.join(", "),
+          acceptedAnswer: {
+            "@type": "Answer",
+            "@id": `${url}#answer`,
+            text: answer.answer,
+            url,
+            about: { "@id": appEntityId(app) },
+          },
+        },
+      },
+      {
+        "@type": ["SoftwareApplication", "WebApplication"],
+        "@id": appEntityId(app),
+        name: app.name,
+        alternateName: app.englishName,
+        description: app.description,
+        url: siteUrl(`/apps/${app.slug}`),
+        softwareVersion: app.version,
+        featureList: app.capabilities,
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "Fabushi", item: siteUrl("/") },
+          { "@type": "ListItem", position: 2, name: "Answers", item: siteUrl("/ai/answers.json") },
+          { "@type": "ListItem", position: 3, name: answer.question, item: url },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <div className={styles.detailShell}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <header className={styles.detailHeader}>
+        <div className={styles.detailHeaderInner}>
+          <a className={styles.detailBrand} href={siteHref("/")}>
+            <span className={styles.brandMark}>法</span>
+            <span>Fabushi Answers</span>
+          </a>
+          <nav className={styles.detailNav}>
+            <a href={siteHref("/")}>打开 Fabushi</a>
+            <a href={siteHref("/apps")}>应用市场</a>
+            <a href={siteHref("/search")}>搜索</a>
+            <a href={siteHref("/ai/answers.json")}>AI JSON</a>
+          </nav>
+        </div>
+      </header>
+
+      <main className={styles.detailMain}>
+        <nav className={styles.breadcrumbs} aria-label="面包屑">
+          <a href={siteHref("/")}>Fabushi</a>
+          <ChevronRight />
+          <a href={siteHref("/ai/answers.json")}>Answers</a>
+          <ChevronRight />
+          <span>{answer.question}</span>
+        </nav>
+
+        <div className={styles.articleLayout}>
+          <article className={styles.articleCard}>
+            <p className={styles.articleEyebrow}>
+              <Sparkles /> AI 应用发现
+            </p>
+            <h1>{answer.question}</h1>
+            <p className={styles.articleSummary}>{answer.answer}</p>
+
+            <aside className={styles.articleCallout}>
+              <strong>推荐：{app.name}</strong>
+              <p>{app.description}</p>
+            </aside>
+
+            <h2>为什么适合</h2>
+            <div className={styles.detailHighlightGrid}>
+              {app.highlights.map((highlight) => (
+                <section key={highlight.title} className={styles.detailHighlightCard}>
+                  <h3>{highlight.title}</h3>
+                  <p>{highlight.description}</p>
+                </section>
+              ))}
+            </div>
+
+            <h2>可用能力</h2>
+            <div className={styles.tagList}>
+              {app.capabilities.map((capability) => (
+                <span key={capability} className={styles.detailTag}>
+                  {capability}
+                </span>
+              ))}
+            </div>
+
+            <h2>权限与边界</h2>
+            <p>{app.permissions.join("；")}。涉及写入、安装、外部系统或本地改动时，Fabushi Host 会保留用户确认。</p>
+
+            <div className={styles.tagList}>
+              {answer.keywords.map((keyword) => (
+                <a
+                  key={keyword}
+                  className={styles.detailTag}
+                  href={siteHref(`/search?q=${encodeURIComponent(keyword)}`)}
+                >
+                  {keyword}
+                </a>
+              ))}
+            </div>
+          </article>
+
+          <aside className={styles.articleAside}>
+            <section className={styles.articleAppCard}>
+              <div className={styles.articleAppTop}>
+                <AppIcon label={app.icon} tone={app.tone} size="small" />
+                <div>
+                  <h2>{app.name}</h2>
+                  <p>{app.subtitle}</p>
+                </div>
+              </div>
+              <div className={styles.articleAppActions}>
+                <AppInstallActions appId={app.id} appName={app.name} />
+                <a className={styles.detailSecondary} href={siteHref(`/apps/${app.slug}`)}>
+                  查看应用实体 <ArrowRight />
+                </a>
+              </div>
+            </section>
+
+            <section className={styles.sidebarCard}>
+              <h3>机器可读记录</h3>
+              <p>AI 可以读取稳定 entity ID、能力、权限、版本、内容和启动入口。</p>
+              <div className={styles.articleAppActions}>
+                <a className={styles.detailSecondary} href={appMachineUrl(app)}>
+                  打开应用 JSON <ExternalLink />
+                </a>
+                <a className={styles.detailSecondary} href={siteHref("/ai/answers.json")}>
+                  打开 Answers feed <ExternalLink />
+                </a>
+              </div>
+            </section>
+
+            {relatedApps.length > 0 ? (
+              <section className={styles.sidebarCard}>
+                <h3>相关应用</h3>
+                <div className={styles.contentList}>
+                  {relatedApps.map((relatedApp) =>
+                    relatedApp ? (
+                      <a
+                        key={relatedApp.id}
+                        className={styles.contentListItem}
+                        href={siteHref(`/apps/${relatedApp.slug}`)}
+                      >
+                        <span>
+                          <h3>{relatedApp.name}</h3>
+                          <p>{relatedApp.subtitle}</p>
+                        </span>
+                        <ChevronRight />
+                      </a>
+                    ) : null,
+                  )}
+                </div>
+              </section>
+            ) : null}
+
+            <section className={styles.sidebarCard}>
+              <h3>继续搜索</h3>
+              <p>搜索更多应用、能力、指南、模板和工作流。</p>
+              <div className={styles.articleAppActions}>
+                <a
+                  className={styles.detailPrimary}
+                  href={siteHref(`/search?q=${encodeURIComponent(answer.keywords[0] ?? app.name)}`)}
+                >
+                  搜索相关能力 <Search />
+                </a>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/apps/web/src/app/apps/[slug]/content/[contentId]/page.tsx
+++ b/frontend/apps/web/src/app/apps/[slug]/content/[contentId]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { AppIcon } from "../../../../../components/marketplace/app-icon";
 import { AppInstallActions } from "../../../../../components/marketplace/app-install-actions";
 import styles from "../../../../../components/marketplace/marketplace.module.css";
+import { appEntityId } from "../../../../../lib/ai-discovery";
 import {
   getMarketplaceContent,
   marketplaceContent,
@@ -127,7 +128,8 @@ export default async function ContentPage({ params }: ContentPageProps) {
           url: siteUrl("/"),
         },
         isPartOf: {
-          "@type": "SoftwareApplication",
+          "@type": ["SoftwareApplication", "WebApplication"],
+          "@id": appEntityId(app),
           name: app.name,
           url: siteUrl(`/apps/${app.slug}`),
         },

--- a/frontend/apps/web/src/app/apps/[slug]/page.tsx
+++ b/frontend/apps/web/src/app/apps/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { AppIcon } from "../../../components/marketplace/app-icon";
 import { AppInstallActions } from "../../../components/marketplace/app-install-actions";
 import styles from "../../../components/marketplace/marketplace.module.css";
+import { appEntityId, appMachineUrl } from "../../../lib/ai-discovery";
 import {
   MARKETPLACE_CATEGORY_LABELS,
   getMarketplaceApp,
@@ -88,12 +89,20 @@ export default async function AppDetailsPage({ params }: AppDetailsPageProps) {
     "@context": "https://schema.org",
     "@graph": [
       {
-        "@type": "SoftwareApplication",
-        "@id": `${url}#app`,
+        "@type": ["SoftwareApplication", "WebApplication"],
+        "@id": appEntityId(app),
+        identifier: app.id,
         name: app.name,
         alternateName: app.englishName,
         description: app.description,
         url,
+        mainEntityOfPage: url,
+        inLanguage: ["zh-CN", "en"],
+        applicationSuite: "Fabushi",
+        isAccessibleForFree: true,
+        installUrl: siteUrl(`/apps/${app.slug}`),
+        downloadUrl: siteUrl("/download"),
+        sameAs: [appMachineUrl(app)],
         applicationCategory: MARKETPLACE_CATEGORY_LABELS[app.category],
         applicationSubCategory: app.tags,
         operatingSystem: "Web, macOS, Windows, Linux, iOS, Android",
@@ -103,19 +112,53 @@ export default async function AppDetailsPage({ params }: AppDetailsPageProps) {
         permissions: app.permissions.join("；"),
         publisher: {
           "@type": "Organization",
+          "@id": siteUrl("/#organization"),
           name: app.developer,
           url: siteUrl("/"),
         },
+        provider: { "@id": siteUrl("/#organization") },
+        creator: { "@id": siteUrl("/#organization") },
         offers: {
           "@type": "Offer",
           price: "0",
           priceCurrency: "CNY",
           description: app.pricing.detail,
           availability: "https://schema.org/InStock",
+          url,
         },
+        additionalProperty: [
+          {
+            "@type": "PropertyValue",
+            name: "capabilities",
+            value: app.capabilities.join("；"),
+          },
+          {
+            "@type": "PropertyValue",
+            name: "permissions",
+            value: app.permissions.join("；"),
+          },
+          {
+            "@type": "PropertyValue",
+            name: "agentInterface",
+            value: "WebMCP",
+            url: siteUrl("/llms.txt"),
+          },
+          {
+            "@type": "PropertyValue",
+            name: "machineReadableRecord",
+            value: appMachineUrl(app),
+          },
+        ],
         potentialAction: {
           "@type": "UseAction",
-          target: siteUrl(`/miniapps/${app.id}`),
+          target: {
+            "@type": "EntryPoint",
+            urlTemplate: siteUrl(`/miniapps/${app.id}`),
+            actionPlatform: [
+              "https://schema.org/DesktopWebPlatform",
+              "https://schema.org/MobileWebPlatform",
+            ],
+          },
         },
       },
       {

--- a/frontend/apps/web/src/app/llms-full.txt/route.ts
+++ b/frontend/apps/web/src/app/llms-full.txt/route.ts
@@ -1,0 +1,74 @@
+import { fabushiAnswerIntents } from "../../lib/ai-discovery";
+import { marketplaceApps } from "../../lib/marketplace";
+import { siteUrl } from "../../lib/site-url";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const appSections = marketplaceApps
+    .map((app) => {
+      const contentLinks = app.content
+        .map(
+          (item) =>
+            `- [${item.title}](${siteUrl(`/apps/${app.slug}/content/${item.id}`)}): ${item.summary}`,
+        )
+        .join("\n");
+      return `## ${app.name} (${app.englishName})
+
+- Entity: ${siteUrl(`/apps/${app.slug}#app`)}
+- Machine record: ${siteUrl(`/ai/apps/${app.slug}.json`)}
+- Details: ${siteUrl(`/apps/${app.slug}`)}
+- Launch: ${siteUrl(`/miniapps/${app.id}`)}
+- Category: ${app.category}
+- Version: ${app.version}
+- Updated: ${app.updatedAt}
+- Description: ${app.description}
+- Capabilities: ${app.capabilities.join("；")}
+- Permissions: ${app.permissions.join("；")}
+- Tags: ${app.tags.join("；")}
+- Pricing: ${app.pricing.label}；${app.pricing.detail}
+
+### Public content
+
+${contentLinks || "- No public content entries."}`;
+    })
+    .join("\n\n");
+
+  const answers = fabushiAnswerIntents
+    .map(
+      (answer) =>
+        `- [${answer.question}](${siteUrl(`/answers/${answer.slug}`)}): ${answer.answer} Recommended app: ${answer.recommendedAppSlug}.`,
+    )
+    .join("\n");
+
+  const body = `# Fabushi full AI discovery guide
+
+> This document is generated from the same public Marketplace catalog used by the Fabushi Host and Marketplace. It is an auxiliary discovery surface; canonical app entities and permissions remain authoritative.
+
+## Product model
+
+Fabushi Host is the main product. Mini Apps are native first-class capabilities. Marketplace provides discovery and installation. Public app/content/answer pages provide stable citation URLs. WebMCP exposes structured read and action tools; action tools preserve user confirmation.
+
+## Machine endpoints
+
+- Apps: ${siteUrl("/ai/apps.json")}
+- Content: ${siteUrl("/ai/content.json")}
+- Answers: ${siteUrl("/ai/answers.json")}
+- Search index: ${siteUrl("/search-index.json")}
+- Sitemap: ${siteUrl("/sitemap.xml")}
+
+${appSections}
+
+## Natural-language answers
+
+${answers}
+`;
+
+  return new Response(body, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      "content-language": "zh-CN",
+    },
+  });
+}

--- a/frontend/apps/web/src/app/llms.txt/route.ts
+++ b/frontend/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,51 @@
+import { fabushiAnswerIntents } from "../../lib/ai-discovery";
+import { marketplaceApps } from "../../lib/marketplace";
+import { siteUrl } from "../../lib/site-url";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const appLinks = marketplaceApps
+    .map((app) => `- [${app.name}](${siteUrl(`/ai/apps/${app.slug}.json`)}): ${app.subtitle}`)
+    .join("\n");
+  const answerLinks = fabushiAnswerIntents
+    .map((answer) => `- [${answer.question}](${siteUrl(`/answers/${answer.slug}`)}): ${answer.answer}`)
+    .join("\n");
+
+  const body = `# Fabushi
+
+> Fabushi 是跨平台 Messenger、AI Agent Host 与 Mini Apps 平台。Web、桌面和移动端共享产品身份；Marketplace 是 Mini Apps 的发现与安装层，WebMCP 是网页与 Mini App 的 Agent 工具接口。
+
+Fabushi 的公开 AI 发现数据全部从同一个 Marketplace catalog 派生。写入、安装和本地操作仍需遵守 Host 权限与用户确认。
+
+## Machine-readable indexes
+
+- [All Mini Apps](${siteUrl("/ai/apps.json")}): 稳定应用实体、能力、权限、版本、详情和调用入口。
+- [App content](${siteUrl("/ai/content.json")}): 指南、模板、工作流和内容级永久链接。
+- [Questions and answers](${siteUrl("/ai/answers.json")}): 自然语言意图、直接答案和推荐应用。
+- [Full AI guide](${siteUrl("/llms-full.txt")}): 完整 catalog-derived 能力与内容目录。
+- [Sitemap](${siteUrl("/sitemap.xml")}): 所有公开页面。
+
+## Mini Apps
+
+${appLinks}
+
+## Answers
+
+${answerLinks}
+
+## Optional
+
+- [Fabushi Web](${siteUrl("/")}): 打开共享 Host 客户端。
+- [Marketplace](${siteUrl("/apps")}): 浏览和安装 Mini Apps。
+- [Search](${siteUrl("/search")}): 搜索应用与内容。
+`;
+
+  return new Response(body, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      "content-language": "zh-CN",
+    },
+  });
+}

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -3,7 +3,7 @@ import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
 
-const publicCrawlerRule = (userAgent: string): MetadataRoute.Robots["rules"][number] => ({
+const publicCrawlerRule = (userAgent: string) => ({
   userAgent,
   allow: "/",
   disallow: ["/api/"],

--- a/frontend/apps/web/src/app/robots.ts
+++ b/frontend/apps/web/src/app/robots.ts
@@ -3,14 +3,20 @@ import { siteUrl } from "../lib/site-url";
 
 export const dynamic = "force-static";
 
+const publicCrawlerRule = (userAgent: string): MetadataRoute.Robots["rules"][number] => ({
+  userAgent,
+  allow: "/",
+  disallow: ["/api/"],
+});
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
-      {
-        userAgent: "*",
-        allow: "/",
-        disallow: ["/api/"],
-      },
+      publicCrawlerRule("OAI-SearchBot"),
+      publicCrawlerRule("ChatGPT-User"),
+      publicCrawlerRule("Googlebot"),
+      publicCrawlerRule("Bingbot"),
+      publicCrawlerRule("*"),
     ],
     sitemap: siteUrl("/sitemap.xml"),
     host: new URL(siteUrl("/")).origin,

--- a/frontend/apps/web/src/app/search-index.json/route.ts
+++ b/frontend/apps/web/src/app/search-index.json/route.ts
@@ -1,3 +1,4 @@
+import { appEntityId, appMachineUrl } from "../../lib/ai-discovery";
 import { MARKETPLACE_CATEGORY_LABELS, marketplaceApps } from "../../lib/marketplace";
 import { siteUrl } from "../../lib/site-url";
 
@@ -12,6 +13,8 @@ export function GET() {
     searchUrlTemplate: `${siteUrl("/search")}?q={query}`,
     apps: marketplaceApps.map((app) => ({
       id: app.id,
+      entityId: appEntityId(app),
+      machineUrl: appMachineUrl(app),
       slug: app.slug,
       name: app.name,
       englishName: app.englishName,
@@ -31,6 +34,7 @@ export function GET() {
       launchUrl: siteUrl(`/miniapps/${app.id}`),
       content: app.content.map((item) => ({
         id: item.id,
+        entityId: siteUrl(`/apps/${app.slug}/content/${item.id}#article`),
         type: item.type,
         title: item.title,
         summary: item.summary,

--- a/frontend/apps/web/src/app/sitemap.ts
+++ b/frontend/apps/web/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { fabushiAnswerIntents } from "../lib/ai-discovery";
 import { getAllArticles } from "../lib/content";
 import { marketplaceApps } from "../lib/marketplace";
 import { siteUrl } from "../lib/site-url";
@@ -106,6 +107,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: app.featured ? 0.95 : 0.9,
   }));
 
+  const appMachinePages: MetadataRoute.Sitemap = marketplaceApps.map((app) => ({
+    url: siteUrl(`/ai/apps/${app.slug}.json`),
+    lastModified: app.updatedAt,
+    changeFrequency: "weekly",
+    priority: 0.75,
+  }));
+
   const appContentPages: MetadataRoute.Sitemap = marketplaceApps.flatMap((app) =>
     app.content.map((item) => ({
       url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
@@ -115,6 +123,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
     })),
   );
 
+  const answerPages: MetadataRoute.Sitemap = fabushiAnswerIntents.map((answer) => ({
+    url: siteUrl(`/answers/${answer.slug}`),
+    lastModified: answer.updatedAt,
+    changeFrequency: "monthly",
+    priority: 0.85,
+  }));
+
+  const aiIndexPages: MetadataRoute.Sitemap = [
+    "/ai/apps.json",
+    "/ai/content.json",
+    "/ai/answers.json",
+    "/llms.txt",
+    "/llms-full.txt",
+  ].map((route) => ({
+    url: siteUrl(route),
+    lastModified: "2026-08-27",
+    changeFrequency: "weekly" as const,
+    priority: route === "/ai/apps.json" ? 0.85 : 0.7,
+  }));
+
   const articlePages: MetadataRoute.Sitemap = getAllArticles().map((article) => ({
     url: siteUrl(`/insights/${article.slug}`),
     lastModified: new Date(article.updatedAt ?? article.publishedAt),
@@ -122,5 +150,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: article.featured ? 0.8 : 0.65,
   }));
 
-  return [...pages, ...appPages, ...appContentPages, ...articlePages];
+  return [
+    ...pages,
+    ...appPages,
+    ...appMachinePages,
+    ...appContentPages,
+    ...answerPages,
+    ...aiIndexPages,
+    ...articlePages,
+  ];
 }

--- a/frontend/apps/web/src/components/marketplace/marketplace-webmcp.tsx
+++ b/frontend/apps/web/src/components/marketplace/marketplace-webmcp.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { registerWebMcpTool } from "@fabushi/mcp-app-sdk";
+import { recommendFabushiApps, serializeAppForAi } from "../../lib/ai-discovery";
 import {
   MARKETPLACE_CATEGORY_LABELS,
   getMarketplaceApp,
@@ -85,6 +86,68 @@ export function MarketplaceWebMcp() {
                     keywords: item.keywords,
                     url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
                   })),
+          };
+        },
+      }),
+      registerWebMcpTool({
+        name: "recommend_fabushi_app",
+        title: "Recommend a Fabushi app",
+        description:
+          "Recommend Fabushi Mini Apps for a natural-language goal or problem. Returns ranked catalog-derived app entities, reasons, capabilities and stable citation/launch links.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "The user's problem, desired outcome or natural-language question.",
+            },
+            task: {
+              type: "string",
+              description: "Optional additional task context, constraints or expected output.",
+            },
+            limit: {
+              type: "number",
+              minimum: 1,
+              maximum: 8,
+              description: "Maximum recommendations. Defaults to 3.",
+            },
+          },
+          required: ["query"],
+        },
+        execute: (input) => {
+          const query = typeof input.query === "string" ? input.query : "";
+          const task = typeof input.task === "string" ? input.task : "";
+          const limit = asPositiveLimit(input.limit, 3);
+          return {
+            query,
+            task,
+            recommendations: recommendFabushiApps([query, task].filter(Boolean).join(" "), limit),
+            appsIndexUrl: siteUrl("/ai/apps.json"),
+            answersIndexUrl: siteUrl("/ai/answers.json"),
+          };
+        },
+      }),
+      registerWebMcpTool({
+        name: "get_app_capabilities",
+        title: "Get Fabushi app capabilities",
+        description:
+          "Resolve a Fabushi Mini App by slug or ID and return its stable entity, capabilities, permissions, version, public content, machine record and launch URL.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            slug: { type: "string", description: "The app slug or stable Mini App ID." },
+          },
+          required: ["slug"],
+        },
+        execute: (input) => {
+          const slug = typeof input.slug === "string" ? input.slug : "";
+          const app = getMarketplaceApp(slug);
+          if (!app) return { found: false, slug, appsIndexUrl: siteUrl("/ai/apps.json") };
+          return {
+            found: true,
+            app: serializeAppForAi(app),
           };
         },
       }),
@@ -224,6 +287,8 @@ export function MarketplaceWebMcp() {
         detail: {
           tools: [
             "search_fabushi_marketplace",
+            "recommend_fabushi_app",
+            "get_app_capabilities",
             "get_fabushi_app",
             "get_fabushi_content",
             "install_fabushi_app",

--- a/frontend/apps/web/src/lib/ai-discovery.ts
+++ b/frontend/apps/web/src/lib/ai-discovery.ts
@@ -1,0 +1,258 @@
+import {
+  MARKETPLACE_CATEGORY_LABELS,
+  getMarketplaceApp,
+  marketplaceApps,
+  marketplaceContent,
+  type MarketplaceApp,
+} from "./marketplace";
+import { siteUrl } from "./site-url";
+
+export const AI_DISCOVERY_UPDATED_AT = "2026-08-27";
+export const AI_DISCOVERY_LANGUAGE = "zh-CN";
+export const AI_DISCOVERY_SCHEMA = "fabushi.ai-discovery.v1";
+
+export interface FabushiAnswerIntent {
+  slug: string;
+  question: string;
+  answer: string;
+  recommendedAppSlug: string;
+  relatedAppSlugs: readonly string[];
+  keywords: readonly string[];
+  updatedAt: string;
+}
+
+export const fabushiAnswerIntents: readonly FabushiAnswerIntent[] = [
+  {
+    slug: "delegate-complex-ai-work",
+    question: "有什么 Fabushi 应用可以把复杂任务交给 AI 分步骤完成？",
+    answer:
+      "可以使用大乘助手。它把目标、输入、工具调用和验收条件组织在同一会话中，并按需组合已安装 Mini Apps 的能力。",
+    recommendedAppSlug: "mahayana-assistant",
+    relatedAppSlugs: ["chatgpt-auto-confirm", "platform-publish"],
+    keywords: ["AI 助手", "复杂任务", "工具调用", "工作流", "Agent"],
+    updatedAt: "2026-08-27",
+  },
+  {
+    slug: "manage-global-dharma-distribution",
+    question: "如何集中管理法布施任务、内容和全球分发状态？",
+    answer:
+      "可以使用全球法布施 Mini App，把计划、内容素材、运行日志、发布状态和永久内容链接放在同一个可搜索工作区。",
+    recommendedAppSlug: "global-dharma",
+    relatedAppSlugs: ["platform-publish", "faliu-flashcards"],
+    keywords: ["法布施", "内容分发", "任务管理", "全球内容"],
+    updatedAt: "2026-08-27",
+  },
+  {
+    slug: "memorize-buddhist-scriptures",
+    question: "有什么应用可以帮助我系统背诵和复习经文？",
+    answer:
+      "可以使用法流记忆卡。它把经文拆成续句、挖空和段落结构卡片，保留原文来源，并按回忆难度安排复习。",
+    recommendedAppSlug: "faliu-flashcards",
+    relatedAppSlugs: ["global-dharma"],
+    keywords: ["经文", "背诵", "记忆卡", "间隔复习", "法流"],
+    updatedAt: "2026-08-27",
+  },
+  {
+    slug: "publish-content-to-multiple-platforms",
+    question: "如何把一份内容适配并发布到多个平台？",
+    answer:
+      "可以使用平台发布 Mini App。它从一份核心内容生成各平台草稿，发布前展示最终版本，并记录目标、结果和永久链接。",
+    recommendedAppSlug: "platform-publish",
+    relatedAppSlugs: ["global-dharma", "mahayana-assistant"],
+    keywords: ["多平台发布", "内容运营", "发布草稿", "SEO"],
+    updatedAt: "2026-08-27",
+  },
+  {
+    slug: "create-fabushi-mini-app",
+    question: "如何创建、配置并上架一个 Fabushi Mini App？",
+    answer:
+      "可以使用 Bot Father。它管理稳定应用身份、开发者归属、功能与权限说明、商品目录和平台映射。",
+    recommendedAppSlug: "bot-father",
+    relatedAppSlugs: ["mahayana-assistant"],
+    keywords: ["Mini App", "创建应用", "上架", "Bot Father", "开发者"],
+    updatedAt: "2026-08-27",
+  },
+  {
+    slug: "install-and-diagnose-hermes",
+    question: "有什么工具可以安装 Hermes 并诊断本地服务无法启动的问题？",
+    answer:
+      "可以使用 Hermes 安装器。它会先检查环境，再引导安装、启动服务，并从进程、端口、配置和日志定位问题。",
+    recommendedAppSlug: "hermes-installer",
+    relatedAppSlugs: ["computer-cleaner"],
+    keywords: ["Hermes", "安装", "本地服务", "健康检查", "故障诊断"],
+    updatedAt: "2026-08-27",
+  },
+  {
+    slug: "manage-long-task-approvals",
+    question: "如何管理长时间 AI 任务中的授权和确认队列？",
+    answer:
+      "可以使用自动确认 Mini App。它集中显示需要人工决定的步骤，区分一次、当前任务与长期授权，并保留可审计状态。",
+    recommendedAppSlug: "chatgpt-auto-confirm",
+    relatedAppSlugs: ["mahayana-assistant"],
+    keywords: ["自动确认", "授权", "长任务", "确认队列", "安全"],
+    updatedAt: "2026-08-27",
+  },
+  {
+    slug: "clean-computer-storage-safely",
+    question: "Mac 或电脑磁盘空间不足时，有什么工具可以安全清理？",
+    answer:
+      "可以使用电脑空间助手。它先分析缓存、构建产物和临时文件的占用，再让用户逐项确认清理范围，不会静默删除个人文件。",
+    recommendedAppSlug: "computer-cleaner",
+    relatedAppSlugs: ["hermes-installer"],
+    keywords: ["Mac 磁盘空间", "电脑清理", "缓存", "构建产物", "安全删除"],
+    updatedAt: "2026-08-27",
+  },
+];
+
+export function appEntityId(app: Pick<MarketplaceApp, "slug">) {
+  return siteUrl(`/apps/${app.slug}#app`);
+}
+
+export function appMachineUrl(app: Pick<MarketplaceApp, "slug">) {
+  return siteUrl(`/ai/apps/${app.slug}.json`);
+}
+
+export function serializeAppForAi(app: MarketplaceApp) {
+  return {
+    "@type": ["SoftwareApplication", "WebApplication"],
+    "@id": appEntityId(app),
+    identifier: app.id,
+    slug: app.slug,
+    name: app.name,
+    alternateName: app.englishName,
+    description: app.description,
+    subtitle: app.subtitle,
+    applicationCategory: MARKETPLACE_CATEGORY_LABELS[app.category],
+    category: app.category,
+    developer: app.developer,
+    verified: app.verified,
+    operatingSystems: ["Web", "macOS", "Windows", "Linux", "iOS", "Android"],
+    version: app.version,
+    updatedAt: app.updatedAt,
+    tags: app.tags,
+    capabilities: app.capabilities,
+    permissions: app.permissions,
+    pricing: app.pricing,
+    highlights: app.highlights,
+    detailsUrl: siteUrl(`/apps/${app.slug}`),
+    machineUrl: appMachineUrl(app),
+    launchUrl: siteUrl(`/miniapps/${app.id}`),
+    content: app.content.map((item) => ({
+      id: item.id,
+      type: item.type,
+      title: item.title,
+      summary: item.summary,
+      keywords: item.keywords,
+      updatedAt: item.updatedAt,
+      url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
+    })),
+  };
+}
+
+export function serializeContentForAi() {
+  return marketplaceContent.map(({ app, item }) => ({
+    "@id": siteUrl(`/apps/${app.slug}/content/${item.id}#article`),
+    id: item.id,
+    type: item.type,
+    title: item.title,
+    summary: item.summary,
+    body: item.body,
+    keywords: item.keywords,
+    updatedAt: item.updatedAt,
+    readingMinutes: item.readingMinutes,
+    url: siteUrl(`/apps/${app.slug}/content/${item.id}`),
+    isPartOf: {
+      "@id": appEntityId(app),
+      appId: app.id,
+      slug: app.slug,
+      name: app.name,
+    },
+  }));
+}
+
+export function getAnswerIntent(slug: string) {
+  return fabushiAnswerIntents.find((answer) => answer.slug === slug);
+}
+
+export function serializeAnswerForAi(answer: FabushiAnswerIntent) {
+  const app = getMarketplaceApp(answer.recommendedAppSlug);
+  if (!app) {
+    throw new Error(`Answer ${answer.slug} references missing app ${answer.recommendedAppSlug}`);
+  }
+
+  return {
+    "@id": siteUrl(`/answers/${answer.slug}#answer`),
+    slug: answer.slug,
+    question: answer.question,
+    answer: answer.answer,
+    keywords: answer.keywords,
+    updatedAt: answer.updatedAt,
+    url: siteUrl(`/answers/${answer.slug}`),
+    recommendedApp: {
+      "@id": appEntityId(app),
+      id: app.id,
+      slug: app.slug,
+      name: app.name,
+      capabilities: app.capabilities,
+      detailsUrl: siteUrl(`/apps/${app.slug}`),
+      machineUrl: appMachineUrl(app),
+      launchUrl: siteUrl(`/miniapps/${app.id}`),
+    },
+    relatedApps: answer.relatedAppSlugs
+      .map((slug) => getMarketplaceApp(slug))
+      .filter((candidate): candidate is MarketplaceApp => Boolean(candidate))
+      .map((candidate) => ({
+        "@id": appEntityId(candidate),
+        slug: candidate.slug,
+        name: candidate.name,
+        detailsUrl: siteUrl(`/apps/${candidate.slug}`),
+      })),
+  };
+}
+
+function normalizeSearchValue(value: string) {
+  return value.trim().toLocaleLowerCase("zh-CN");
+}
+
+export function recommendFabushiApps(query: string, limit = 3) {
+  const normalizedQuery = normalizeSearchValue(query);
+  const terms = normalizedQuery.split(/[\s,，。！？!?、/]+/).filter(Boolean);
+
+  return marketplaceApps
+    .map((app) => {
+      const fields = [
+        app.name,
+        app.englishName,
+        app.subtitle,
+        app.description,
+        ...app.tags,
+        ...app.capabilities,
+        ...app.content.flatMap((item) => [item.title, item.summary, ...item.keywords]),
+      ].map(normalizeSearchValue);
+      const exactHits = normalizedQuery
+        ? fields.filter((field) => field.includes(normalizedQuery) || normalizedQuery.includes(field)).length
+        : 0;
+      const termHits = terms.reduce(
+        (score, term) => score + fields.filter((field) => field.includes(term)).length,
+        0,
+      );
+      const score = exactHits * 8 + termHits * 2 + (app.featured ? 1 : 0);
+      const matchedCapabilities = app.capabilities.filter((capability) => {
+        const normalizedCapability = normalizeSearchValue(capability);
+        return normalizedQuery.includes(normalizedCapability) ||
+          terms.some((term) => normalizedCapability.includes(term));
+      });
+      return { app, score, matchedCapabilities };
+    })
+    .filter((candidate) => candidate.score > 0 || !normalizedQuery)
+    .sort((left, right) => right.score - left.score || Number(right.app.featured) - Number(left.app.featured))
+    .slice(0, Math.max(1, Math.min(8, Math.floor(limit))))
+    .map(({ app, score, matchedCapabilities }) => ({
+      score,
+      reason:
+        matchedCapabilities.length > 0
+          ? `匹配能力：${matchedCapabilities.join("、")}`
+          : `匹配 ${app.name} 的功能、标签或公开内容`,
+      app: serializeAppForAi(app),
+    }));
+}

--- a/projects/telegram-fabushi-integration/decisions/ADR-0011-catalog-derived-ai-discovery.md
+++ b/projects/telegram-fabushi-integration/decisions/ADR-0011-catalog-derived-ai-discovery.md
@@ -1,0 +1,36 @@
+# ADR-0011 — Catalog-derived AI discovery and stable Mini App entities
+
+- **Project**: FAB-P0001 / TFI
+- **Status**: ACCEPTED
+- **Date**: 2026-08-27
+- **Task**: M8-AEO-001
+- **Supersedes**: none
+- **Related**: ADR-0010 (WebMCP foreground / Rust background)
+
+## Context
+
+Fabushi 已有共享 Host、公开 Marketplace、内容级 SEO、搜索索引和全站 WebMCP，但 AI 仍需要跨页面推断应用身份、能力、权限和可调用入口。若为 AEO 再维护第二份应用清单，Host、Marketplace、SEO 和 Agent discovery 会快速漂移。
+
+## Decision
+
+1. `frontend/apps/web/src/lib/marketplace.ts` 继续作为公开 Mini App catalog 的单一事实源。
+2. 每个应用的稳定实体 ID 固定为 `https://fabushi.ombhrum.com/apps/{slug}/#app`；页面 JSON-LD、内容 `isPartOf`、JSON feeds、答案页和 WebMCP 均引用它。
+3. `src/lib/ai-discovery.ts` 只负责把 catalog 投影成机器实体、自然语言答案映射和推荐结果，不复制应用详情。
+4. 正式机器入口为 versioned JSON feeds：aggregate apps、per-app、content、answers。稳定公开页面仍是可引用的人类入口。
+5. `llms.txt` 保持精简导航，`llms-full.txt` 提供完整 catalog-derived 文本；二者是辅助发现入口，不替代 robots、sitemap、结构化数据、内容质量或真实索引。
+6. WebMCP 新增只读 `recommend_fabushi_app` 与 `get_app_capabilities`；安装、写入和本地工具执行继续使用现有确认与 Host 权限边界。
+7. robots 明确允许 OAI-SearchBot、ChatGPT-User、Googlebot 和 Bingbot。Cloudflare/WAF 是否放行必须由部署后的 User-Agent HTTP probes 验证，不能仅由 robots 声明推断。
+
+## Consequences
+
+- 新应用加入 canonical catalog 后会自动进入 aggregate feed、per-app feed、llms、sitemap 和能力工具。
+- 意图/答案文本仍是小型独立 registry，只保存问题、直接答案和 app slug 引用，不复制 catalog 字段。
+- AI 推荐是可解释的目录匹配，不冒充模型排序或个性化保证。
+- 所有机器端点必须保持公开、无凭据、无用户数据和确定性静态输出。
+
+## Open-source provenance
+
+- AnswerDotAI/llms-txt (Apache-2.0): adapted concise index/full-detail split and linked Markdown convention.
+- schemaorg/schemaorg (Apache-2.0): adapted SoftwareApplication/WebApplication entity relationships.
+- modelcontextprotocol/typescript-sdk (Apache-2.0/MIT transition): adapted discovery/call separation at the contract level.
+- No upstream source code copied; no dependency introduced.

--- a/projects/telegram-fabushi-integration/docs/10-Mini-Apps平台.md
+++ b/projects/telegram-fabushi-integration/docs/10-Mini-Apps平台.md
@@ -62,3 +62,16 @@ Mini App SDK：
 
 
 ============================================================
+
+## AEO / AI 应用发现层（2026-08-27）
+
+Mini App 的 AI discovery 是 Marketplace 的公开投影，不是新 runtime 或第二个 catalog：
+
+- stable entity：每个 app 固定 `/apps/{slug}/#app`，页面、内容、JSON feed 和 WebMCP 引用同一 `@id`；
+- machine knowledge：`/ai/apps.json`、per-app JSON、content feed、answer feed；
+- answer intent：自然语言问题页直接回答并关联推荐 app；
+- auxiliary text：`llms.txt` 精简导航，`llms-full.txt` 完整 catalog-derived 信息；
+- agent interface：WebMCP 提供推荐与能力发现；安装/写入/本地调用仍经过既有 Host 权限；
+- crawlability：robots/sitemap/结构化数据与 Cloudflare production probe 共同构成可抓取证据。
+
+应用名称、版本、能力、权限、价格和内容必须继续只在 canonical Marketplace catalog 维护。

--- a/projects/telegram-fabushi-integration/evidence/M8-AEO-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M8-AEO-001/README.md
@@ -1,0 +1,22 @@
+# M8-AEO-001 evidence index
+
+- Project: `FAB-P0001 / TFI`
+- Task: `M8-AEO-001`
+- Branch: `feat/tfi-m8-aeo-ai-discovery`
+- Base: `main@ef985df53a625e4bc2fb685b74724f43f2065302`
+- Status: `IN_PROGRESS`
+
+## Planned evidence
+
+| Gate | Required evidence | Current |
+|---|---|---|
+| Source contract | AI discovery contract output | pending GitHub Actions |
+| Typecheck/build | CI frontend job and exact commit SHA | pending |
+| Review/merge | PR, reviews, merge queue and merge SHA | pending |
+| Canonical readback | files and routes on canonical main | pending |
+| Production HTTP | status/content-type/schema/entity/robots/sitemap probes | pending |
+| WebMCP runtime | registered discovery tools and read-only execution result | pending |
+| Cloudflare crawler | OAI-SearchBot/Googlebot/Bingbot User-Agent responses | pending |
+| Post-main delivery | exact-main deployment/build/E2E evidence required by repository policy | pending |
+
+Evidence will be updated with live URLs/run IDs only after the corresponding system reports success.

--- a/projects/telegram-fabushi-integration/evidence/M8-AEO-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M8-AEO-001/README.md
@@ -5,6 +5,8 @@
 - Branch: `feat/tfi-m8-aeo-ai-discovery`
 - Base: `main@ef985df53a625e4bc2fb685b74724f43f2065302`
 - Status: `IN_PROGRESS`
+- PR: [#2177](https://github.com/bhrumom/fabushi/pull/2177)
+- Auto-merge: enabled; protected checks/merge queue pending
 
 ## Planned evidence
 

--- a/projects/telegram-fabushi-integration/management/00-路线图.md
+++ b/projects/telegram-fabushi-integration/management/00-路线图.md
@@ -276,3 +276,7 @@ M14：全量替换旧通信栈
 
 
 ============================================================
+
+## 2026-08-27 — M8 AEO / AI discovery continuation
+
+M8 新增 `M8-AEO-001`：在现有 Host + Marketplace + WebMCP 之上建立 catalog-derived AI discovery 层。实现顺序为稳定应用实体 → aggregate/per-app/content/answer feeds → intent pages/llms/sitemap → WebMCP recommendation/capability tools → crawler/Cloudflare production validation。不得建立第二份应用 catalog，且不得削弱安装、写入或本地调用确认。

--- a/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
+++ b/projects/telegram-fabushi-integration/management/01-WBS原子任务.md
@@ -80,3 +80,15 @@
 - Marketplace/BotFather 新增 WebMCP admission policy；桌面 Tool inventory 与当前 MiniApp contract 取交集，移动端 Hosted 页面不得调用本地 Native bridge，写/破坏性调用保持宿主原生确认。
 - 目标版本统一为 `1.0.4`；实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 的 CI、Electron、Mahayana fast、Messaging、移动 catch-all、治理、安全等工作流均已通过。
 - 任务仍未完成：PR #2169 必须以最终治理 head 再次全绿并经 protected `main` 合并；随后 exact-main packaged Electron/Android/iOS E2E、视觉/trace evidence 与 GitHub Release 1.0.4 仍是硬门禁。
+
+## 2026-08-27 — M8-AEO-001 AEO / AI 应用发现
+
+- [x] 固化用户需求、task、ADR 与开源调研。
+- [x] 从 canonical Marketplace catalog 派生稳定 `#app` entity、aggregate/per-app/content/answer feeds。
+- [x] 实现 8 个 intent answer pages、`llms.txt` / `llms-full.txt` 与 sitemap。
+- [x] WebMCP 增加 `recommend_fabushi_app` / `get_app_capabilities`，保持只读发现边界。
+- [x] robots 明确允许 OAI-SearchBot、ChatGPT-User、Googlebot、Bingbot。
+- [x] 增加 AI discovery contract 并接入 Frontend CI。
+- [ ] current-head GitHub Actions 全绿。
+- [ ] protected merge queue、canonical-main readback。
+- [ ] production Cloudflare HTTP/runtime/crawler probes 与 exact-main delivery evidence。

--- a/projects/telegram-fabushi-integration/management/02-里程碑.md
+++ b/projects/telegram-fabushi-integration/management/02-里程碑.md
@@ -38,3 +38,7 @@
 ## 当前门禁
 
 M3 由 `M3-DESKTOP-001` 推进。只有 desktop typecheck/Playwright、相关 messaging product gates、protected merge 和 canonical-main verification 全部完成后才提升为 `TESTED`/`E2E_VERIFIED`。
+
+## 2026-08-27 — M8 AI discovery gate
+
+`M8-AEO-001` 为 M8 发现/分发能力的独立验收单元，当前 `IMPLEMENTED / TESTING`。本任务完成需要 catalog-derived entity/feed/answer/WebMCP contracts、current-head CI、protected merge、canonical-main readback、Cloudflare production HTTP/User-Agent probes 和适用的 exact-main delivery evidence；它不单独关闭完整 M8 sandbox/authorization milestone。

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -130,3 +130,17 @@ Acceptance traceability:
 - Version baseline: canonical, desktop, mobile and iOS metadata are aligned to 1.0.4 with mobile build/version codes 2.
 
 Remaining hard gates: final governance head must rerun required checks, PR #2169 must merge through protected `main`, canonical main must be read back, exact-main packaged Electron/Android/iOS simulated-user E2E must preserve required screenshot/video/trace/report evidence, and GitHub Release 1.0.4 must point at the accepted main SHA. Until those are complete this task must not be marked `COMPLETED` or `RELEASED`.
+
+## Active M8 AEO acceptance — M8-AEO-001 — 2026-08-27
+
+| Requirement | Implementation | Evidence state |
+|---|---|---|
+| Stable app entity | shared `appEntityId()` + SoftwareApplication/WebApplication JSON-LD | implemented; CI pending |
+| AI machine feeds | `/ai/apps.json`, per-app JSON, content, answers | implemented; build/runtime pending |
+| Intent answers | 8 catalog-referenced `/answers/{slug}` pages + sitemap | implemented; build/HTTP pending |
+| LLM auxiliary entry | `llms.txt` + `llms-full.txt` | implemented; HTTP pending |
+| Agent discovery | WebMCP recommendation + capability tools | implemented; runtime pending |
+| Crawler access | explicit robots rules + Cloudflare probes | robots implemented; production probes pending |
+| Single source | all app facts derive from `lib/marketplace.ts` | contract written; CI pending |
+
+Status remains `TESTING / IN_PROGRESS` until the PR current head is green, protected merge completes, canonical main is re-read, production deployment passes HTTP/runtime/crawler probes, and required post-main evidence is complete.

--- a/projects/telegram-fabushi-integration/management/04-风险登记.md
+++ b/projects/telegram-fabushi-integration/management/04-风险登记.md
@@ -28,3 +28,11 @@
 | R-10 | E2EE 与多设备体验冲突 | 高 | 中 | 设备验证、密钥生命周期专项设计 | 新设备无法稳定恢复会话 | OPEN |
 | R-11 | 数据迁移破坏历史消息 | 高 | 中 | 只读备份、迁移校验、可回滚 | 迁移前后数量/hash 不一致 | OPEN |
 | R-12 | 过度追求“对标全部”造成范围失控 | 中 | 高 | M0-M14 阶段门禁；Stories/SFU 走范围变更 | 高级能力提前阻塞基础消息 | OPEN |
+
+## 2026-08-27 — AEO risks
+
+| ID | 风险 | 影响 | 概率 | 预防/缓解 | 触发信号 | 状态 |
+|---|---|---|---|---|---|---|
+| R-13 | AI feeds 与 Marketplace catalog 漂移 | 高 | 中 | 所有 app facts 从同一 TypeScript catalog 派生；CI contract 覆盖全部 app slug | app 数量/entity/endpoint 不一致 | MITIGATED / VERIFYING |
+| R-14 | robots 允许但 Cloudflare/WAF 仍阻断爬虫 | 高 | 中 | production User-Agent probes；检查响应码、挑战页和 headers | OAI/Google/Bing 返回 403/挑战页 | OPEN |
+| R-15 | 把 llms.txt 误认为收录保证 | 中 | 中 | 文档和 ADR 明确其仅为辅助；核心仍是可抓取页面、结构化数据和内容质量 | 缺少页面/索引却宣称 AEO 完成 | MITIGATED |

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -215,3 +215,11 @@
 - Web 与桌面继续源码级复用同一 `host-client.tsx`；Host 内 Marketplace 与公开 Marketplace 统一使用 `lib/marketplace.ts` catalog，WebMCP 继续由 root layout 全局挂载。
 - Mac Computer Use 预检显示当前屏幕锁定（`screenLocked=true`），因此本轮没有把无法执行的桌面交互截图冒充为验收证据；尝试的独立 headless Chrome 进程已安全清理。该环境限制不影响 exact-main build/deploy 与生产 HTTP/runtime 路由验收。
 - 本项 Web Host 产品方向修正状态：`DELIVERED / PRODUCTION_VERIFIED`。后续视觉细节优化继续以“Telegram 式全平台一致”为基线，不再回到独立 Marketplace 根壳模型。
+
+## 2026-08-27 — M8-AEO-001 implementation round
+
+- 用户要求在已上线共享 Host + Marketplace + WebMCP 基础上实际实现 AEO，不重做产品。
+- 已建立 catalog-derived AI discovery model：稳定 `#app` entity、SoftwareApplication/WebApplication JSON-LD、aggregate/per-app/content/answer JSON feeds、8 个 intent pages、llms 辅助入口和 sitemap。
+- 全站 WebMCP 已加入只读 `recommend_fabushi_app` / `get_app_capabilities`；现有安装/写入确认边界不变。
+- robots 已显式允许 OAI-SearchBot、ChatGPT-User、Googlebot、Bingbot；Cloudflare 是否实际放行仍需生产 User-Agent probes。
+- AI discovery source contract 已接入 Frontend CI；当前状态 `IMPLEMENTED / TESTING`，尚未获得 current-head CI、protected merge、canonical-main、production runtime 和 post-main delivery evidence。

--- a/projects/telegram-fabushi-integration/management/06-依赖与阻塞.md
+++ b/projects/telegram-fabushi-integration/management/06-依赖与阻塞.md
@@ -43,3 +43,14 @@ Exit: `M3-DESKTOP-001` current-head typecheck/E2E + protected merge + canonical-
 ## Rule
 
 No blocker may be marked resolved from chat confirmation or code existence alone; objective repository evidence is mandatory.
+
+## 2026-08-27 — M8-AEO-001 dependencies
+
+| ID | Task | Dependency | State | Exit evidence |
+|---|---|---|---|---|
+| DEP-010 | M8-AEO-001 | canonical Web Marketplace catalog and WebMCP global mount | SATISFIED | catalog projection + existing root mount |
+| DEP-011 | M8-AEO-001 | GitHub Frontend CI / Next static build | PENDING | current-head workflow success |
+| DEP-012 | M8-AEO-001 | Cloudflare deployment and bot/WAF reachability | PENDING | production HTTP + User-Agent probes |
+| DEP-013 | M8-AEO-001 | protected merge and exact-main delivery | PENDING | merge SHA, main readback, delivery evidence |
+
+Git transport on the current network is unstable but is not a product blocker: the GitHub connector is being used for authoritative branch/file/PR operations.

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -189,3 +189,12 @@
 - E2E/UITest 增加桌面 WebMCP tool discovery + restart、Android WebMCP open control、iOS dedicated WebMCP surface open/close 用户旅程。
 - 版本元数据统一：`app-version.json`、desktop/mobile package 与 iOS project 均为 1.0.4，Android/iOS build/version code 为 2。
 - 实现 head `b965db5686521fc3dcc4592a293950aa35e542a7` 的所有 observed PR workflows 已 SUCCESS；最终治理同步仍会生成新的 head 并必须重新全绿。任务在 protected merge、canonical-main readback、exact-main packaged Electron/Android/iOS E2E/evidence 和 GitHub Release 1.0.4 完成前保持 `TESTING / IN_PROGRESS`。
+
+## 2026-08-27 — M8-AEO-001 AI discovery implementation
+
+- 新增 ADR-0011，固定 Marketplace catalog-derived AI discovery 与稳定应用 entity 规则。
+- 新增 versioned app/content/answer JSON feeds、per-app machine records、8 个 answer intent pages、`llms.txt` 与 `llms-full.txt`。
+- 强化应用与内容 JSON-LD，使内容统一引用稳定 `SoftwareApplication/WebApplication #app` entity。
+- WebMCP 新增只读推荐与能力查询工具；sitemap/search index/robots 接入 AI discovery。
+- 新增 AI discovery contract 并接入 Frontend CI；无新依赖、无第二份应用 catalog。
+- 状态为 `IMPLEMENTED / TESTING`；CI、merge、production 和 post-main evidence 待完成。

--- a/projects/telegram-fabushi-integration/management/08-问题与行动项.md
+++ b/projects/telegram-fabushi-integration/management/08-问题与行动项.md
@@ -25,3 +25,12 @@
 - “E2E verified” requires a real cross-boundary scenario, not only unit tests.
 - “Released” requires release/deployment evidence.
 - Actions stay open until the closure evidence is written into this project folder and exists on `main`.
+
+## 2026-08-27 — M8-AEO-001 actions
+
+| ID | Related task | Problem / decision | Action | State | Closure evidence |
+|---|---|---|---|---|---|
+| ACT-009 | M8-AEO-001 | current-head AI discovery build/contract 未验证 | run Frontend CI and resolve failures | OPEN | successful workflow run |
+| ACT-010 | M8-AEO-001 | Cloudflare 可能独立于 robots 阻断 crawler | probe normal + OAI/Google/Bing User-Agents after deploy | OPEN | HTTP status/header/body evidence |
+| ACT-011 | M8-AEO-001 | WebMCP tools 需真实浏览器注册/执行证明 | inspect tool registry and invoke read-only tools | OPEN | runtime evidence |
+| ACT-012 | M8-AEO-001 | protected merge/post-main delivery pending | enable merge queue, read canonical main, validate exact deployment | OPEN | PR/merge/deploy evidence |

--- a/projects/telegram-fabushi-integration/management/tasks/M8-AEO-001-ai-app-discovery.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M8-AEO-001-ai-app-discovery.md
@@ -8,7 +8,8 @@
 - **Updated**: 2026-08-27
 - **Branch**: `feat/tfi-m8-aeo-ai-discovery`
 - **Base**: `main@ef985df53a625e4bc2fb685b74724f43f2065302`
-- **PR / merge / release**: pending
+- **PR**: #2177 — https://github.com/bhrumom/fabushi/pull/2177
+- **Merge / release**: pending
 
 ## Objective
 
@@ -73,6 +74,10 @@ Reviewed `AnswerDotAI/llms-txt`, `schemaorg/schemaorg`, and `modelcontextprotoco
 - llms.txt adoption is auxiliary and cannot guarantee model inclusion.
 - Git transport on the current network is unstable; GitHub connector is the authoritative branch/file/PR path for this task.
 
+## Implementation summary
+
+Implemented catalog-derived stable entities, four JSON knowledge feed families, eight intent pages, llms auxiliary entry points, sitemap/search/robots integration, two read-only WebMCP discovery tools, and a Frontend CI contract. PR #2177 is open with auto-merge enabled. Current-head CI, merge-group, production and post-main evidence remain pending.
+
 ## Next action
 
-Implement the catalog-derived discovery layer and CI contract, then open the PR and drive all delivery gates.
+Resolve PR #2177 current-head checks, merge through the protected queue, re-read canonical main, then validate Cloudflare HTTP/crawler/WebMCP runtime and exact-main delivery evidence.

--- a/projects/telegram-fabushi-integration/management/tasks/M8-AEO-001-ai-app-discovery.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M8-AEO-001-ai-app-discovery.md
@@ -1,0 +1,78 @@
+# M8-AEO-001 — AEO / AI 应用发现
+
+- **Project ID**: `FAB-P0001`
+- **Project Key**: `TFI`
+- **Task ID**: `M8-AEO-001`
+- **Status**: `IN_PROGRESS`
+- **Started**: 2026-08-27
+- **Updated**: 2026-08-27
+- **Branch**: `feat/tfi-m8-aeo-ai-discovery`
+- **Base**: `main@ef985df53a625e4bc2fb685b74724f43f2065302`
+- **PR / merge / release**: pending
+
+## Objective
+
+在现有 Host + Marketplace + WebMCP 架构内实现可验证的 AI 应用发现层，使 AI 可通过网页实体、机器 JSON、答案页和 WebMCP 稳定发现、理解、引用并在用户允许时调用 Mini Apps。
+
+## Source
+
+- `source/2026-08-27-aeo-ai-app-discovery.md`
+- 用户当前会话明确要求的 9 项交付范围。
+
+## In scope
+
+- stable app entity IDs and complete SoftwareApplication/WebApplication JSON-LD;
+- `/ai/apps.json`, per-app JSON, content and answer feeds;
+- `llms.txt` and `llms-full.txt`;
+- answer intent pages + sitemap;
+- WebMCP recommendation/capability discovery;
+- explicit crawler allow rules;
+- CI contract/build, production deploy and HTTP/runtime evidence;
+- TFI WBS/acceptance/status/changelog/evidence synchronization.
+
+## Out of scope
+
+- replacing the shared Host shell or Marketplace;
+- a second catalog/database;
+- weakening write/install/runtime approval;
+- claiming guaranteed inclusion in any AI answer engine.
+
+## Dependencies
+
+- canonical Marketplace catalog: `frontend/apps/web/src/lib/marketplace.ts`;
+- existing global WebMCP mount and `@fabushi/mcp-app-sdk`;
+- current Next.js static export and Cloudflare deployment workflows.
+
+## Acceptance criteria
+
+1. Every catalog app has one deterministic `#app` entity and a machine-readable per-app endpoint.
+2. Aggregate app/content/answer feeds return schema/version, stable absolute URLs and catalog-derived data.
+3. Every answer slug statically renders, includes direct answer + recommended app, and appears in sitemap.
+4. `llms.txt` remains concise; `llms-full.txt` exposes full catalog-derived capabilities, permissions and content links.
+5. WebMCP exposes `recommend_fabushi_app` and `get_app_capabilities` as read-only tools.
+6. robots explicitly allows requested crawlers while retaining API exclusions.
+7. AI-discovery contract test, frontend typecheck/build and relevant CI are green.
+8. PR merges through protected main; canonical main is re-read.
+9. production endpoints, JSON schemas, robots and WebMCP runtime registration are HTTP/runtime verified.
+
+## Verification plan
+
+- GitHub Actions frontend typecheck/build and AI-discovery source contract.
+- Inspect generated/static routes from CI/deploy.
+- After merge/deploy: HTTP 200/content-type/schema checks for all machine endpoints, one answer page, app JSON-LD and robots.
+- Runtime browser/WebMCP registration check for the two discovery tools.
+- Application-affecting completion remains subject to repository post-main delivery/evidence rules.
+
+## Open-source survey
+
+Reviewed `AnswerDotAI/llms-txt`, `schemaorg/schemaorg`, and `modelcontextprotocol/typescript-sdk`. Adapt public formats and contract ideas only; no upstream code copied and no new dependency added.
+
+## Risks / blockers
+
+- Cloudflare WAF may still block allowed bots independently of robots; production user-agent probes are required.
+- llms.txt adoption is auxiliary and cannot guarantee model inclusion.
+- Git transport on the current network is unstable; GitHub connector is the authoritative branch/file/PR path for this task.
+
+## Next action
+
+Implement the catalog-derived discovery layer and CI contract, then open the PR and drive all delivery gates.

--- a/projects/telegram-fabushi-integration/source/2026-08-27-aeo-ai-app-discovery.md
+++ b/projects/telegram-fabushi-integration/source/2026-08-27-aeo-ai-app-discovery.md
@@ -1,0 +1,30 @@
+# 2026-08-27 — Fabushi AEO / AI 应用发现能力
+
+- Project: `FAB-P0001 / TFI`
+- Task: `M8-AEO-001`
+- Source: 用户要求在已上线的 Host + Marketplace + WebMCP 架构上继续开发，不推翻现有设计。
+
+## 目标
+
+让 AI 能稳定发现、理解、引用并在支持时调用 Fabushi Mini Apps：
+
+1. 每个 Mini App 使用稳定的 `https://fabushi.ombhrum.com/apps/{slug}#app` entity ID，并输出完整 `SoftwareApplication` / `WebApplication` JSON-LD。
+2. 从现有 `frontend/apps/web/src/lib/marketplace.ts` catalog 派生 `/ai/apps.json`、`/ai/apps/{slug}.json`、`/ai/content.json` 与 `/ai/answers.json`，禁止复制第二份应用 catalog。
+3. 提供 `/llms.txt` 与 `/llms-full.txt` 辅助入口；它们补充 sitemap、robots、结构化数据和真实内容页，不替代这些标准入口。
+4. 提供 `/answers/{slug}` 自然语言意图页并纳入 sitemap。
+5. 全站 WebMCP 新增 `recommend_fabushi_app` 与 `get_app_capabilities`，只读发现工具必须返回稳定 entity/deep links。
+6. robots 明确允许 OAI-SearchBot、ChatGPT-User、Googlebot 与 Bingbot；Cloudflare 部署后必须做真实 HTTP header/body 验收。
+7. 更新 TFI 记录并通过 current-head CI、protected merge、canonical-main readback、生产部署/runtime 验收。
+
+## Open-source-first survey
+
+- `AnswerDotAI/llms-txt` (Apache-2.0): 采用根级精简入口、分区链接、详细信息按需读取的约定；不复制实现代码。
+- `schemaorg/schemaorg` (Apache-2.0): 采用 SoftwareApplication/WebApplication entity、稳定 `@id` 和关联内容语义。
+- `modelcontextprotocol/typescript-sdk` (Apache-2.0/MIT transition): 沿用 MCP 工具发现与调用分离的契约思想；Fabushi 继续复用现有 WebMCP adapter 和 Marketplace catalog，不引入第二套 runtime 或依赖。
+
+## 非目标
+
+- 不重做 Host UI、Marketplace 或现有 Mini App 页面。
+- 不把 llms.txt 当作保证模型收录/排名的私有协议。
+- 不绕过 WebMCP 的用户确认和现有安装/执行权限边界。
+- 不在本机构建或运行重型测试；按仓库规则使用 GitHub Actions。


### PR DESCRIPTION
## Summary

Implements `FAB-P0001 / TFI / M8-AEO-001` on top of the existing shared Host + Marketplace + WebMCP architecture.

- gives every catalog Mini App one stable `#app` SoftwareApplication/WebApplication entity;
- derives aggregate/per-app/content/answer JSON feeds from the existing Marketplace catalog;
- adds 8 natural-language `/answers/{slug}` pages plus `llms.txt` / `llms-full.txt`;
- adds WebMCP `recommend_fabushi_app` and `get_app_capabilities`;
- connects entities to search index, sitemap and app-content JSON-LD;
- explicitly allows OAI-SearchBot, ChatGPT-User, Googlebot and Bingbot;
- adds an AI-discovery contract to the Frontend CI job;
- updates TFI source/task/ADR/WBS/acceptance/status/risk/dependency/evidence records.

No Host UI redesign, second catalog, new runtime or dependency is introduced. Install/write/local execution permissions remain unchanged.

## Open-source-first decision

Reviewed and adapted public conventions from:

- AnswerDotAI/llms-txt (Apache-2.0);
- schemaorg/schemaorg (Apache-2.0);
- modelcontextprotocol/typescript-sdk (Apache-2.0/MIT transition).

No upstream implementation code was copied.

## Required checks

- [ ] Frontend AI discovery contract
- [ ] frontend workspace typecheck
- [ ] Next production build/static routes
- [ ] project portfolio governance
- [ ] merge-group validation
- [ ] protected merge queue
- [ ] canonical-main readback
- [ ] production Cloudflare HTTP/content-type/schema/entity/sitemap/robots probes
- [ ] OAI/Google/Bing User-Agent probes
- [ ] WebMCP runtime registration/invocation
- [ ] applicable exact-main delivery evidence

## Project records

- `projects/telegram-fabushi-integration/source/2026-08-27-aeo-ai-app-discovery.md`
- `projects/telegram-fabushi-integration/management/tasks/M8-AEO-001-ai-app-discovery.md`
- `projects/telegram-fabushi-integration/decisions/ADR-0011-catalog-derived-ai-discovery.md`
- `projects/telegram-fabushi-integration/evidence/M8-AEO-001/README.md`
