### PR TITLE
fix(release): unblock native iOS and Android gates

### DIFF
--- a/.github/workflows/native-mobile.yml
+++ b/.github/workflows/native-mobile.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Install cargo-ndk only when needed
         if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'
         shell: bash
-        run: cargo install cargo-ndk --locked
+        run: command -v cargo-ndk >/dev/null 2>&1 || cargo install cargo-ndk --locked
 
       - name: Save cargo-ndk immediately
         if: github.event_name != 'pull_request' && matrix.target == 'android' && steps.jni-cache.outputs.cache-hit != 'true' && steps.cargo-ndk-cache.outputs.cache-hit != 'true'

--- a/mobile/ios/FabushiTests/FabushiTests.swift
+++ b/mobile/ios/FabushiTests/FabushiTests.swift
@@ -7,7 +7,8 @@ final class FabushiTests: XCTestCase {
             pluginId: "example.plugin",
             displayName: "示例插件",
             description: "描述",
-            latestVersion: "1.0.0"
+            latestVersion: "1.0.0",
+            tools: []
         )
         XCTAssertEqual(plugin.id, "example.plugin")
         XCTAssertEqual(plugin.latestVersion, "1.0.0")


### PR DESCRIPTION
Fix exact-main native release blockers discovered after PR #2167:

- pass the new `tools` field in the iOS `MarketplacePlugin` unit-test fixture;
- reuse a preinstalled `cargo-ndk` binary instead of failing when the cache misses but the binary already exists.

Acceptance: native PR gate + CI pass, merge through protected merge queue, then rerun exact-main platform gates before release.