### PR TITLE
fix(release): make Android release cargo-ndk install idempotent

### DIFF
--- a/.github/workflows/native-android-release.yml
+++ b/.github/workflows/native-android-release.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Install cargo-ndk on cache miss
         if: steps.cargo-ndk-cache.outputs.cache-hit != 'true'
-        run: cargo install cargo-ndk --locked
+        run: command -v cargo-ndk >/dev/null 2>&1 || cargo install cargo-ndk --locked
 
       - name: Save cargo-ndk on cache miss
         if: steps.cargo-ndk-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/native-electron-release.yml
+++ b/.github/workflows/native-electron-release.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Install cargo-ndk on cache miss
         if: matrix.kind == 'android' && steps.release-cargo-ndk.outputs.cache-hit != 'true'
-        run: cargo install cargo-ndk --locked
+        run: command -v cargo-ndk >/dev/null 2>&1 || cargo install cargo-ndk --locked
 
       - name: Save cargo-ndk on cache miss
         if: matrix.kind == 'android' && steps.release-cargo-ndk.outputs.cache-hit != 'true'


### PR DESCRIPTION
Prevents the same preinstalled `cargo-ndk` collision fixed in the native quality gate from recurring in the cross-platform and standalone Android release workflows.

Acceptance: CI green, merge queue, then exact-main gates before dispatching all-platform release.