### PR TITLE
fix(release): align iOS signing credentials with Apple delivery

### DIFF
--- a/.github/workflows/native-electron-release.yml
+++ b/.github/workflows/native-electron-release.yml
@@ -199,7 +199,7 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.target == 'mac' && 'true' || 'false' }}
           FABUSHI_MACOS_NOTARIZE: ${{ matrix.target == 'mac' && '1' || '0' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID || vars.MACOS_APP_STORE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -211,7 +211,7 @@ jobs:
         shell: bash
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID || vars.MACOS_APP_STORE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -376,30 +376,33 @@ jobs:
         if: matrix.kind == 'ios'
         shell: bash
         env:
-          IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64 }}
-          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_CERTIFICATE_P12_BASE64: ${{ secrets.IOS_CERTIFICATE_P12_BASE64 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
-          test -n "$IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64"
+          test -n "$IOS_CERTIFICATE_P12_BASE64"
           test -n "$IOS_PROVISIONING_PROFILE_BASE64"
           cert="$RUNNER_TEMP/ios-distribution.p12"
           profile="$RUNNER_TEMP/Fabushi.mobileprovision"
           keychain="$RUNNER_TEMP/fabushi-signing.keychain-db"
-          printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode > "$cert"
+          printf '%s' "$IOS_CERTIFICATE_P12_BASE64" | base64 --decode > "$cert"
           printf '%s' "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile"
           security create-keychain -p actions "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p actions "$keychain"
-          security import "$cert" -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security import "$cert" -P "$IOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
           security set-key-partition-list -S apple-tool:,apple: -s -k actions "$keychain"
           security list-keychains -d user -s "$keychain" login.keychain-db
           security cms -D -i "$profile" > "$RUNNER_TEMP/profile.plist"
           profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$RUNNER_TEMP/profile.plist")"
           profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$RUNNER_TEMP/profile.plist")"
+          team_id="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$RUNNER_TEMP/profile.plist")"
+          test -n "$team_id"
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$profile" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
           echo "PROFILE_NAME=$profile_name" >> "$GITHUB_ENV"
+          echo "IOS_TEAM_ID=$team_id" >> "$GITHUB_ENV"
 
       - name: Generate Xcode project
         if: matrix.kind == 'ios'
@@ -409,8 +412,6 @@ jobs:
       - name: Archive native iOS application
         if: matrix.kind == 'ios'
         working-directory: mobile/ios
-        env:
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: >-
           xcodebuild archive
           -project Fabushi.xcodeproj
@@ -418,7 +419,7 @@ jobs:
           -configuration Release
           -destination 'generic/platform=iOS'
           -archivePath "$RUNNER_TEMP/Fabushi.xcarchive"
-          DEVELOPMENT_TEAM="$APPLE_TEAM_ID"
+          DEVELOPMENT_TEAM="$IOS_TEAM_ID"
           CODE_SIGN_STYLE=Manual
           CODE_SIGN_IDENTITY='Apple Distribution'
           PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME"
@@ -426,8 +427,6 @@ jobs:
       - name: Export signed iOS IPA
         if: matrix.kind == 'ios'
         shell: bash
-        env:
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: |
           cat > "$RUNNER_TEMP/ExportOptions.plist" <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
@@ -435,7 +434,7 @@ jobs:
           <plist version="1.0"><dict>
             <key>method</key><string>app-store-connect</string>
             <key>signingStyle</key><string>manual</string>
-            <key>teamID</key><string>${APPLE_TEAM_ID}</string>
+            <key>teamID</key><string>${IOS_TEAM_ID}</string>
             <key>provisioningProfiles</key><dict>
               <key>com.ombhrum.fabushi</key><string>${PROFILE_NAME}</string>
             </dict>


### PR DESCRIPTION
Align the cross-platform release workflow with the active Apple Store delivery credential contract:

- use the configured `IOS_CERTIFICATE_*` secrets;
- derive the iOS team ID from the provisioning profile instead of an absent repository variable;
- let macOS notarization fall back to the configured Mac App Store team variable.

Acceptance: delivery governance + CI green, merge queue, final exact-main gates, then all-platform release.