### PR TITLE
fix(release): unblock packaged desktop auth and iOS marketplace gates

### DIFF
--- a/.github/scripts/assert-electron-feature-host-bridge.sh
+++ b/.github/scripts/assert-electron-feature-host-bridge.sh
@@ -91,11 +91,11 @@ grep -Fq "ipcMain.handle('fabushi:open-system-settings'" "$main" || { echo "syst
 grep -Fq 'openSystemSettings(pane)' "$preload" || { echo "system settings preload bridge missing" >&2; exit 1; }
 grep -Fq 'windowFocused()' "$preload" || { echo "window focus preload bridge missing" >&2; exit 1; }
 
-if grep -Fq "import HostClient from '../../frontend/apps/web/src/app/host/host-client'" "$desktop_renderer" && grep -Fq '<HostClient />' "$desktop_renderer"; then
+if grep -Fq "import HostClient from '../../frontend/apps/web/src/app/host/host-client'" "$desktop_renderer" && grep -Eq '<HostClient([[:space:]][^>]*)? */>' "$desktop_renderer"; then
   :
 elif test -n "$desktop_shell" && test -f "$desktop_shell" \
   && grep -Fq "import HostClient from '../../frontend/apps/web/src/app/host/host-client'" "$desktop_shell" \
-  && grep -Fq '<HostClient />' "$desktop_shell"; then
+  && grep -Eq '<HostClient([[:space:]][^>]*)? */>' "$desktop_shell"; then
   :
 else
   echo "Canonical Electron renderer does not reuse and render the shared HostClient directly or through the approved Messenger shell" >&2

--- a/.github/workflows/google-play-delivery.yml
+++ b/.github/workflows/google-play-delivery.yml
@@ -176,7 +176,7 @@ jobs:
           shared-key: google-play-native-android-v1
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk --locked
+        run: command -v cargo-ndk >/dev/null 2>&1 || cargo install cargo-ndk --locked
 
       - name: Build native Mahayana Host JNI libraries
         working-directory: third_party/mahayana/mahayana-rs

--- a/desktop/src/messaging-shell-v2.tsx
+++ b/desktop/src/messaging-shell-v2.tsx
@@ -41,6 +41,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState, type FormEven
 import HostClient from '../../frontend/apps/web/src/app/host/host-client';
 import { BotMark, type BotMarkState } from '../../frontend/apps/web/src/app/host/bot-mark';
 import type {
+  AuthState,
   BotSummary,
   ConversationSummary,
   GroupSummary,
@@ -554,6 +555,10 @@ export default function DesktopShellV2() {
     }
   }, [authTransport]);
 
+  const handleHostAuthStateChange = useCallback((state: AuthState) => {
+    if (state.loggedIn) setAuthenticated(true);
+  }, []);
+
   useEffect(() => {
     if (localProjection) return;
     let closed = false;
@@ -607,7 +612,7 @@ export default function DesktopShellV2() {
       {showMessenger
         ? <MessengerWorkspace initialProjection={startupProjection} onLogout={() => resetToLogin(true)} />
         : showLogin
-          ? <HostClient />
+          ? <HostClient onAuthStateChange={handleHostAuthStateChange} />
           : <DesktopFastStartBootstrap />}
     </div>
   );

--- a/frontend/apps/web/src/app/host/host-client.tsx
+++ b/frontend/apps/web/src/app/host/host-client.tsx
@@ -379,7 +379,11 @@ interface ConfirmAction {
   action: () => void | Promise<void>;
 }
 
-export default function HostClient() {
+interface HostClientProps {
+  onAuthStateChange?: (state: AuthState) => void;
+}
+
+export default function HostClient({ onAuthStateChange }: HostClientProps = {}) {
   const screenshotMode = new URLSearchParams(window.location.search).get("screenshot");
   const screenshotHasMiniApp = screenshotMode === "miniapp";
   const screenshotComputerOpen = ["computer", "running", "miniapp"].includes(screenshotMode ?? "");
@@ -486,6 +490,9 @@ export default function HostClient() {
   const [loginError, setLoginError] = useState<string | null>(null);
   const [browserLoginAttempt, setBrowserLoginAttempt] = useState<BrowserLoginAttempt | null>(null);
   const [browserLoginWakeNonce, setBrowserLoginWakeNonce] = useState(0);
+  useEffect(() => {
+    if (authResolved && auth) onAuthStateChange?.(auth);
+  }, [auth, authResolved, onAuthStateChange]);
   const [onboardingStep, setOnboardingStep] = useState(() =>
     screenshotMode !== null || window.localStorage.getItem(ONBOARDING_COMPLETE_KEY) === "1"
       ? 3

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -293,6 +293,11 @@ struct ContentView: View {
                 }
             }
             .refreshable { await model.refresh() }
+            .task {
+                if model.plugins.isEmpty {
+                    await model.refresh()
+                }
+            }
         }
     }
 }

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -31,7 +31,7 @@ final class FabushiUITests: XCTestCase {
         XCTAssertTrue(app.buttons["home-search-button"].exists)
         XCTAssertTrue(app.buttons["home-add-button"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["conversation-list"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["conversation-chief-of-staff"].exists)
+        XCTAssertTrue(app.staticTexts["Chief of Staff"].waitForExistence(timeout: 5))
 
         app.buttons["home-search-button"].tap()
         let homeSearch = app.textFields["home-search-field"]


### PR DESCRIPTION
Final release-gate hotfix for exact-main SHA 08058642e39f088472d2f5a5252c44ad977cfe48.

Desktop:
- propagate the real HostClient authentication state to DesktopShellV2;
- remount Messenger immediately after browser login so packaged Linux/Windows/macOS E2E can continue.

iOS:
- retry marketplace discovery when the actual marketplace surface mounts with an empty catalog;
- assert the user-visible Chief of Staff row rather than a SwiftUI combined-container accessibility identifier;
- keep the real global-dharma WebMCP open/close UI acceptance unchanged.

Observed blockers:
- Electron desktop gate 33058702648: all packaged platforms reached browser-login completion but never remounted messenger-workspace.
- Native mobile gate 33058702823 attempts 1 and 2: Android green; iOS repeatedly failed on the visible conversation accessibility check and empty marketplace MiniApp list.

Acceptance: CI + native PR gate green, protected Merge Queue, then fresh exact-main desktop/mobile gates before any immutable release tag.