### PR TITLE
fix(host): preserve HostClient JSX component typing

### DIFF
--- a/frontend/apps/web/src/app/host/host-client.tsx
+++ b/frontend/apps/web/src/app/host/host-client.tsx
@@ -383,7 +383,7 @@ interface HostClientProps {
   onAuthStateChange?: (state: AuthState) => void;
 }
 
-export default function HostClient({ onAuthStateChange }: HostClientProps = {}) {
+export default function HostClient({ onAuthStateChange }: HostClientProps) {
   const screenshotMode = new URLSearchParams(window.location.search).get("screenshot");
   const screenshotHasMiniApp = screenshotMode === "miniapp";
   const screenshotComputerOpen = ["computer", "running", "miniapp"].includes(screenshotMode ?? "");


### PR DESCRIPTION
Exact-main Host fast E2E exposed a push-only TypeScript regression after PR #2182: `HostClientProps = {}` made the exported function parameter optional, so the standalone Host React type universe inferred `ComponentType<HostClientProps | undefined>` and rejected `<HostClient />`.

Remove the parameter default. Every field in `HostClientProps` is already optional, so JSX callers with no attributes remain valid while the component type stays `HostClientProps`.

Acceptance: Host fast E2E typecheck + CI + protected Merge Queue, then rerun exact-main platform gates.