### PR TITLE
docs(tfi): record standalone commerce main evidence

### DIFF
--- a/projects/telegram-fabushi-integration/evidence/M8-COMMERCE-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M8-COMMERCE-001/README.md
@@ -1,8 +1,11 @@
 # Evidence — M8-COMMERCE-001
 
 日期：2026-08-27
-状态：IN_PROGRESS / TESTING
-分支：`feat/tfi-m8-standalone-commerce`
+状态：IN_PROGRESS / DEPLOYMENT_BLOCKED
+实现 PR：`#2184`
+实现分支：`feat/tfi-m8-standalone-commerce`
+最终 PR head：`2cc126c10dc4d1320df98bf106679c273f5c19b3`
+canonical main SHA：`4d5fac6787c62ee881d65cfe212b2b4f15a80584`
 
 ## 已完成并有仓库证据
 
@@ -17,19 +20,31 @@
 - marketplace contract test：`ai-backend/test/standalone_commerce_miniapp.test.js`。
 - CI gate：`.github/workflows/standalone-commerce-site.yml`。
 
-## 运行证据待补
+## PR / CI / protected main evidence
 
-以下项目尚未形成真实 evidence，不得标记完成：
+- PR `#2184` final head：`2cc126c10dc4d1320df98bf106679c273f5c19b3`。
+- PR-head `Standalone commerce site` run `33064741725`：`success`；真实执行了 upstream materialize、依赖安装、Medusa backend build、storefront TypeScript check、production compose validation。
+- PR-head canonical `CI` run `33064741960`：`success`；Project portfolio governance 与 Developer Fiat Commerce 也为 `success`。
+- 仓库 ruleset `main-merge-queue` 强制 protected merge queue，required status 为 `CI result`，不能直接绕过。
+- PR 在 merge queue position 1 上创建 merge-group SHA `4d5fac6787c62ee881d65cfe212b2b4f15a80584`；merge-group CI run `33065058090` 的 `CI result` 和所有被选择的 jobs 均为 `success`。
+- PR 于 `2026-08-27T10:56:41Z` 合并。
+- canonical `main` 回读确认 HEAD 为 `4d5fac6787c62ee881d65cfe212b2b4f15a80584`，且 `ai-backend/src/standalone_commerce_miniapp.js` 与 `commerce/fabushi-store/upstream.lock.json` 可从该精确 SHA 读取。
 
-1. PR number / final head SHA / required checks。
-2. merge commit / canonical main SHA。
-3. `https://shop.ombhrum.com` HTTPS 200、页面截图/浏览器 trace。
-4. `https://shop.ombhrum.com/.well-known/fabushi.json` 200 + schema readback。
-5. `/api/fabushi/mcp` initialize、tools/list、search_products、create_cart、add_to_cart、prepare_checkout 测试。
-6. Fabushi production marketplace API 搜索并添加 `fabushi-store`。
-7. AI cart handoff 后浏览器 checkout 命中同一 cart 的 E2E。
-8. 若启用真实卡支付：真实/Provider sandbox purchase + webhook/order 状态证据；未配置时必须明确标识为非真实扣款环境。
+## 公网运行证据待补
+
+以下项目尚未形成真实 evidence，不得标记 RELEASED：
+
+1. `https://shop.ombhrum.com` HTTPS 200、页面截图/浏览器 trace。
+2. `https://shop.ombhrum.com/.well-known/fabushi.json` 200 + schema readback。
+3. `/api/fabushi/mcp` initialize、tools/list、search_products、create_cart、add_to_cart、prepare_checkout 测试。
+4. Fabushi production marketplace API 搜索并添加 `fabushi-store`。
+5. AI cart handoff 后浏览器 checkout 命中同一 cart 的 E2E。
+6. 若启用真实卡支付：真实/Provider sandbox purchase + webhook/order 状态证据；未配置时必须明确标识为非真实扣款环境。
 
 ## 当前部署阻塞记录
 
-本轮两次 Oracle VPS connector 调用均返回 HTTP 502（`vps_status` 与 `run_shell_command`），因此没有伪造 VPS 或公网部署结果。后续只在连接恢复并完成实际探针后更新本文件。
+- Oracle/grokbot VPS connector 本轮持续返回 HTTP 502（`vps_status` 与 `run_shell_command`），没有可验证生产主机执行通道。
+- 直接 DNS/HTTPS 探针显示 `shop.ombhrum.com` 与 `shop-api.ombhrum.com` 当前无法解析，因此不能宣称公网已经上线。
+- 本任务没有发现或注入真实 merchant payment-provider secret；真实卡扣款仍不得宣称可用。
+
+代码、市场模型、AI Commerce contract 和生产部署资产已经进入 `main`；任务保持 `IN_PROGRESS / DEPLOYMENT_BLOCKED`，直到上述公网证据闭环。

--- a/projects/telegram-fabushi-integration/management/tasks/M8-COMMERCE-001-standalone-commerce-miniapp.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M8-COMMERCE-001-standalone-commerce-miniapp.md
@@ -2,11 +2,12 @@
 
 - **Project**: FAB-P0001 / TFI
 - **Milestone**: M8 Mini Apps
-- **Status**: IN_PROGRESS / TESTING
+- **Status**: IN_PROGRESS / DEPLOYMENT_BLOCKED
 - **Source**: `../../source/2026-08-27-standalone-commerce-miniapp.md`
 - **Decision**: `../../decisions/ADR-0012-standalone-webapp-miniapp-commerce.md`
 - **Evidence**: `../../evidence/M8-COMMERCE-001/README.md`
-- **Branch**: `feat/tfi-m8-standalone-commerce`
+- **Implementation PR**: `#2184`
+- **Canonical main**: `4d5fac6787c62ee881d65cfe212b2b4f15a80584`
 
 ## 目标
 
@@ -61,14 +62,14 @@
 ### A6 — 质量与发布
 - [x] 增加 `standalone-commerce-site.yml` 上游 pin / manifest / compile / typecheck / compose 门禁。
 - [x] 增加 Fabushi marketplace contract test。
-- [ ] PR current-head required checks 全绿。
-- [ ] protected merge 到 `main`。
-- [ ] canonical-main readback。
+- [x] PR current-head required checks 全绿。
+- [x] protected merge 到 `main`。
+- [x] canonical-main readback。
 - [ ] exact-main 公网站点 + MCP + marketplace E2E evidence。
 
 ## 当前阻塞
 
-生产部署通道当前不可用：2026-08-27 本轮调用 Oracle VPS connector 连续返回 HTTP 502。没有可验证的生产主机执行证据，因此公网“已上线”仍保持未完成。真实支付 Provider 凭证也未在本任务中发现或注入。
+实现 PR `#2184` 已通过 PR-head CI、protected merge-group CI 并进入 canonical `main`。当前剩余阻塞全部在生产发布面：Oracle/grokbot VPS connector 持续返回 HTTP 502；`shop.ombhrum.com` 与 `shop-api.ombhrum.com` 当前 DNS 无法解析；真实支付 Provider secret 也没有在本任务中发现或注入。因此公网“已上线”和真实卡扣款都继续保持未完成。
 
 ## 完成定义
 


### PR DESCRIPTION
Superseded by the live production rollout. The intermediate pre-deployment evidence is intentionally not merged because M8-COMMERCE-001 has progressed beyond its blocker state; final evidence will record the actual deployed HTTPS/MCP/marketplace results after PR #2186 and production probes complete.