### PR TITLE
fix(mobile): make iOS WebMCP UI test scroll-safe and gate fail-closed

### DIFF
--- a/.github/workflows/native-mobile.yml
+++ b/.github/workflows/native-mobile.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"os":"ubuntu-latest","target":"android","check_name":"Native mobile result"}]' || '[{"os":"ubuntu-latest","target":"android","check_name":"Native mobile result"},{"os":"macos-15","target":"ios","check_name":"Native iOS"}]') }}
+        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"os":"ubuntu-latest","target":"android","check_name":"Native Android"}]' || '[{"os":"ubuntu-latest","target":"android","check_name":"Native Android"},{"os":"macos-15","target":"ios","check_name":"Native iOS"}]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
@@ -433,3 +433,22 @@ jobs:
           path: ${{ runner.temp }}/FabushiTests.xcresult
           if-no-files-found: warn
           retention-days: 14
+
+  result:
+    name: Native mobile result
+    if: always()
+    needs: platform
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every native mobile matrix job
+        shell: bash
+        env:
+          PLATFORM_RESULT: ${{ needs.platform.result }}
+        run: |
+          set -euo pipefail
+          if [ "$PLATFORM_RESULT" != 'success' ]; then
+            echo "Native mobile platform matrix ended with: $PLATFORM_RESULT" >&2
+            exit 1
+          fi
+          echo 'All required native mobile platform checks passed.' >> "$GITHUB_STEP_SUMMARY"

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -60,7 +60,10 @@ final class FabushiUITests: XCTestCase {
         openMarketplace(in: app)
 
         let open = app.buttons["open-global-dharma"]
-        XCTAssertTrue(open.waitForExistence(timeout: 15))
+        XCTAssertTrue(
+            scrollToElement(open, in: app),
+            "Expected global-dharma WebMCP open button after scrolling Marketplace"
+        )
         open.tap()
 
         let surface = app.descendants(matching: .any)["miniapp-webmcp-surface"]
@@ -81,5 +84,21 @@ final class FabushiUITests: XCTestCase {
         let marketplace = app.buttons["marketplace-entry"]
         XCTAssertTrue(marketplace.waitForExistence(timeout: 5))
         marketplace.tap()
+    }
+
+    @MainActor
+    private func scrollToElement(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 8) -> Bool {
+        if element.exists {
+            return true
+        }
+
+        for _ in 0..<maxSwipes {
+            app.swipeUp()
+            if element.waitForExistence(timeout: 1) {
+                return true
+            }
+        }
+
+        return element.exists
     }
 }


### PR DESCRIPTION
## Summary

- Fix the deterministic iOS UI test failure captured in main run `33065202864`: `global-dharma` is below the initial SwiftUI `List` viewport, so XCUI must scroll before asserting the open button exists.
- Keep the test strict with bounded scrolling and an explicit failure message; no timeout-only masking.
- Rename matrix children to `Native Android` / `Native iOS` and make `Native mobile result` a real final aggregator that fails unless the whole matrix succeeds.
- Preserve the PR fast path (Android/Linux-only static checks); main still runs Android + iOS heavy gates.

## Evidence

The failing `.xcresult` from canonical main SHA `4d5fac6787c62ee881d65cfe212b2b4f15a80584` shows the only failing logical case is `FabushiUITests.testMiniAppOpensAndClosesDedicatedWebMcpSurface()` at the `open-global-dharma` existence assertion. Its captured accessibility hierarchy shows the Marketplace and Rust Host are healthy, the list is at 0% scroll, and only the first plugin rows are instantiated in the accessibility tree.

Tracked under FAB-P0003 / FCM-009.