### PR TITLE
[automerge-force] fix(desktop): stabilize packaged auth and visual evidence

### DIFF
--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"os":"ubuntu-latest","label":"Linux","target":"linux","check_name":"Electron desktop result"}]' || '[{"os":"macos-15","label":"macOS","target":"mac","check_name":"Electron macOS"},{"os":"windows-latest","label":"Windows","target":"win","check_name":"Electron Windows"},{"os":"ubuntu-latest","label":"Linux","target":"linux","check_name":"Electron desktop result"}]') }}
+        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"os":"ubuntu-latest","label":"Linux","target":"linux","check_name":"Electron Linux"}]' || '[{"os":"macos-15","label":"macOS","target":"mac","check_name":"Electron macOS"},{"os":"windows-latest","label":"Windows","target":"win","check_name":"Electron Windows"},{"os":"ubuntu-latest","label":"Linux","target":"linux","check_name":"Electron Linux"}]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     steps:
@@ -86,7 +86,7 @@ jobs:
       - name: Run Electron main-process contract tests
         if: matrix.target == 'linux'
         shell: bash
-        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
+        run: node --test desktop/electron/edge-ipc.test.cjs desktop/electron/host-process.test.cjs desktop/electron/test-auth-session.test.cjs desktop/electron/native-capability-handlers.test.cjs desktop/electron/offline-asr.test.cjs
 
       - name: Verify renderer TypeScript
         if: matrix.target == 'linux'
@@ -359,3 +359,20 @@ jobs:
           path: desktop/release/**
           if-no-files-found: error
           retention-days: 90
+
+  result:
+    name: Electron desktop result
+    if: always()
+    needs: platform
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Electron desktop matrix job
+        shell: bash
+        env:
+          PLATFORM_RESULT: ${{ needs.platform.result }}
+        run: |
+          if [ "$PLATFORM_RESULT" != "success" ]; then
+            echo "Electron desktop matrix result=$PLATFORM_RESULT" >&2
+            exit 1
+          fi
+          echo 'Every Electron desktop matrix job succeeded.'

--- a/desktop/e2e/grok-visual-evidence.spec.ts
+++ b/desktop/e2e/grok-visual-evidence.spec.ts
@@ -1,5 +1,5 @@
 import { _electron as electron, expect, test, type Page } from '@playwright/test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -8,8 +8,16 @@ const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
 
 async function launchDesktopApp(appDataDir: string) {
+  const videoDir = path.join(
+    appRoot,
+    'test-results',
+    'visual-evidence-video',
+    `${process.platform}-${process.pid}-${Date.now()}`,
+  );
+  await mkdir(videoDir, { recursive: true });
   return electron.launch({
     ...(packagedExecutable ? { executablePath: packagedExecutable, args: [] } : { args: [appRoot] }),
+    recordVideo: { dir: videoDir },
     env: {
       ...process.env,
       FABUSHI_APP_DATA: appDataDir,
@@ -44,8 +52,14 @@ async function attachScreenshot(page: Page, name: string): Promise<void> {
   // separately by grok-motion-parity.spec.ts; screenshots freeze CSS animations so
   // Xvfb/Chromium never captures an arbitrary transition frame or waits forever on
   // continuously animated BotMark aura layers.
+  const screenshotPath = test.info().outputPath(`${name}.png`);
+  await page.screenshot({
+    path: screenshotPath,
+    animations: 'disabled',
+    fullPage: false,
+  });
   await test.info().attach(name, {
-    body: await page.screenshot({ animations: 'disabled', fullPage: false }),
+    path: screenshotPath,
     contentType: 'image/png',
   });
 }

--- a/desktop/electron/host-process.cjs
+++ b/desktop/electron/host-process.cjs
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const readline = require('node:readline');
+const { createTestAuthSession } = require('./test-auth-session.cjs');
 const { createTestPlatformAccount } = require('./test-platform-account.cjs');
 
 const PRODUCTION_PRODUCT_API_BASE_URL = 'https://api.ombhrum.com';
@@ -55,6 +56,9 @@ class MahayanaHostProcess {
     this.now = options.now ?? Date.now;
     this.fs = options.fs ?? fs;
     this.providerEnvironment = options.providerEnvironment ?? (() => ({}));
+    this.testAuthSession = this.env.FABUSHI_FEATURE_HOST_MODE === 'test'
+      ? createTestAuthSession({ app: this.app, fs: this.fs, now: this.now })
+      : null;
     this.testPlatformAccount = this.env.FABUSHI_FEATURE_HOST_MODE === 'test'
       ? createTestPlatformAccount({ app: this.app, fs: this.fs, now: this.now })
       : null;
@@ -228,6 +232,10 @@ class MahayanaHostProcess {
   }
 
   request(method, params = {}, timeoutMs = 120000) {
+    if (this.testAuthSession) {
+      const result = this.testAuthSession.request(method, params);
+      if (result !== null) return Promise.resolve(result);
+    }
     if (method === 'platform.request' && this.testPlatformAccount) {
       const result = this.testPlatformAccount.request(params);
       if (result) return Promise.resolve(result);

--- a/desktop/electron/test-auth-session.cjs
+++ b/desktop/electron/test-auth-session.cjs
@@ -1,0 +1,138 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const TEST_AUTH_FILE = 'test-auth-session.json';
+
+function cleanAuthState(value) {
+  if (!value || typeof value !== 'object' || value.loggedIn !== true) {
+    return { loggedIn: false, provider: 'test' };
+  }
+  const user = value.user && typeof value.user === 'object'
+    ? {
+        id: value.user.id,
+        username: value.user.username,
+        nickname: value.user.nickname,
+        email: value.user.email,
+        avatar: value.user.avatar,
+      }
+    : undefined;
+  return {
+    loggedIn: true,
+    provider: typeof value.provider === 'string' && value.provider ? value.provider : 'test',
+    ...(user ? { user } : {}),
+  };
+}
+
+function createTestAuthSession(options = {}) {
+  const app = options.app;
+  const fsImpl = options.fs ?? fs;
+  const now = options.now ?? Date.now;
+  if (!app?.getPath) throw new TypeError('test auth session requires an Electron app implementation');
+
+  const statePath = path.join(app.getPath('userData'), 'feature-host', TEST_AUTH_FILE);
+  let browserAttempt = null;
+  let oauthAttempt = null;
+  let sequence = 0;
+  let auth = readPersistedAuth();
+
+  function readPersistedAuth() {
+    try {
+      if (typeof fsImpl.readFileSync !== 'function') return { loggedIn: false, provider: 'test' };
+      return cleanAuthState(JSON.parse(fsImpl.readFileSync(statePath, 'utf8')));
+    } catch {
+      return { loggedIn: false, provider: 'test' };
+    }
+  }
+
+  function persistAuth(next) {
+    auth = cleanAuthState(next);
+    try {
+      if (typeof fsImpl.mkdirSync !== 'function' || typeof fsImpl.writeFileSync !== 'function') return;
+      fsImpl.mkdirSync(path.dirname(statePath), { recursive: true });
+      fsImpl.writeFileSync(statePath, `${JSON.stringify(auth)}\n`, { mode: 0o600 });
+    } catch {
+      // The E2E seam remains deterministic in memory with read-only test stubs.
+    }
+  }
+
+  function nextId(prefix) {
+    sequence += 1;
+    return `${prefix}-${sequence}`;
+  }
+
+  function request(method, params = {}) {
+    switch (method) {
+      case 'feature.auth.status':
+        return { ...auth, ...(auth.user ? { user: { ...auth.user } } : {}) };
+      case 'feature.auth.providers':
+        return [
+          { id: 'google', displayName: 'Google', enabled: true },
+          { id: 'apple', displayName: 'Apple', enabled: true },
+          { id: 'microsoft', displayName: 'Microsoft', enabled: true },
+          { id: 'github', displayName: 'GitHub', enabled: true },
+        ];
+      case 'feature.auth.browserStart': {
+        browserAttempt = {
+          attemptId: `browser-${nextId('attempt')}`,
+          loginUrl: 'about:blank#fabushi-test-browser-login',
+          expiresAt: Math.floor(now() / 1000) + 600,
+          pollAfterMs: 120,
+        };
+        return { ...browserAttempt };
+      }
+      case 'feature.auth.browserPoll': {
+        if (!browserAttempt || browserAttempt.attemptId !== String(params.attemptId ?? '')) return { status: 'expired' };
+        persistAuth({
+          loggedIn: true,
+          provider: 'browser',
+          user: { id: 'fast-e2e-browser-user', email: 'browser@example.test', nickname: 'Browser 测试用户' },
+        });
+        browserAttempt = null;
+        return { status: 'completed', provider: 'browser', auth: { ...auth, user: { ...auth.user } } };
+      }
+      case 'feature.auth.browserCancel':
+        if (!browserAttempt || browserAttempt.attemptId !== String(params.attemptId ?? '')) return { status: 'expired' };
+        browserAttempt = null;
+        return { status: 'cancelled' };
+      case 'feature.auth.browserReopen':
+        if (!browserAttempt || browserAttempt.attemptId !== String(params.attemptId ?? '')) return { status: 'expired' };
+        browserAttempt = { ...browserAttempt, loginUrl: 'about:blank#fabushi-test-browser-login', pollAfterMs: 120 };
+        return { ...browserAttempt, status: 'pending' };
+      case 'feature.auth.oauthStart': {
+        const provider = String(params.provider ?? '').trim();
+        if (!['google', 'apple', 'microsoft', 'github'].includes(provider)) throw new Error(`Unsupported test OAuth provider: ${provider || 'empty'}`);
+        oauthAttempt = {
+          attemptId: `oauth-${provider}-${nextId('attempt')}`,
+          provider,
+          authorizationUrl: `about:blank#fabushi-test-oauth-${provider}`,
+          expiresAt: Math.floor(now() / 1000) + 600,
+        };
+        return { ...oauthAttempt };
+      }
+      case 'feature.auth.oauthPoll': {
+        if (!oauthAttempt || oauthAttempt.attemptId !== String(params.attemptId ?? '')) return { status: 'expired' };
+        const provider = oauthAttempt.provider;
+        persistAuth({
+          loggedIn: true,
+          provider,
+          user: { id: `fast-e2e-${provider}`, email: `test@${provider}.example`, nickname: `${provider} 测试用户` },
+        });
+        oauthAttempt = null;
+        return { status: 'completed', auth: { ...auth, user: { ...auth.user } } };
+      }
+      case 'feature.auth.logout':
+        browserAttempt = null;
+        oauthAttempt = null;
+        persistAuth({ loggedIn: false, provider: 'test' });
+        return { ...auth };
+      default:
+        return null;
+    }
+  }
+
+  return Object.freeze({ request, statePath });
+}
+
+module.exports = { TEST_AUTH_FILE, createTestAuthSession };

--- a/desktop/electron/test-auth-session.test.cjs
+++ b/desktop/electron/test-auth-session.test.cjs
@@ -1,0 +1,83 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const fakeApp = {
+  isPackaged: true,
+  getPath(name) {
+    if (name !== 'userData') throw new Error(`unexpected path: ${name}`);
+    return '/tmp/fabushi-test-auth-session';
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function load(request, parent, isMain) {
+  if (request === 'electron') return { app: fakeApp };
+  return originalLoad.call(this, request, parent, isMain);
+};
+const { MahayanaHostProcess } = require('./host-process.cjs');
+Module._load = originalLoad;
+
+function memoryFs() {
+  const files = new Map();
+  return {
+    mkdirSync() {},
+    readFileSync(file) {
+      if (!files.has(file)) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+      return files.get(file);
+    },
+    writeFileSync(file, content) {
+      files.set(file, String(content));
+    },
+  };
+}
+
+test('packaged test browser auth is durable and never spawns the real Host', async () => {
+  const fs = memoryFs();
+  let spawnCount = 0;
+  const makeHost = () => new MahayanaHostProcess({
+    app: fakeApp,
+    env: { FABUSHI_FEATURE_HOST_MODE: 'test' },
+    fs,
+    now: () => 1_780_000_000_000,
+    spawn: () => {
+      spawnCount += 1;
+      throw new Error('test auth must not spawn the real Host');
+    },
+  });
+
+  const first = makeHost();
+  assert.deepEqual(await first.request('feature.auth.status'), { loggedIn: false, provider: 'test' });
+  const attempt = await first.request('feature.auth.browserStart');
+  assert.match(attempt.loginUrl, /^about:blank#fabushi-test-browser-login$/);
+  const completed = await first.request('feature.auth.browserPoll', { attemptId: attempt.attemptId });
+  assert.equal(completed.status, 'completed');
+  assert.equal(completed.auth.loggedIn, true);
+  assert.equal((await first.request('feature.auth.status')).loggedIn, true);
+  assert.equal(spawnCount, 0);
+
+  const restarted = makeHost();
+  assert.equal((await restarted.request('feature.auth.status')).loggedIn, true);
+  assert.equal(spawnCount, 0);
+
+  assert.deepEqual(await restarted.request('feature.auth.logout'), { loggedIn: false, provider: 'test' });
+  assert.deepEqual(await restarted.request('feature.auth.status'), { loggedIn: false, provider: 'test' });
+  assert.equal(spawnCount, 0);
+});
+
+test('production auth requests still use the real Host boundary', async () => {
+  let spawnCount = 0;
+  const host = new MahayanaHostProcess({
+    app: fakeApp,
+    env: {},
+    fs: { readFileSync() { throw new Error('missing'); } },
+    spawn: () => {
+      spawnCount += 1;
+      throw new Error('production boundary reached');
+    },
+  });
+  await assert.rejects(host.request('feature.auth.status'), /production boundary reached/);
+  assert.equal(spawnCount, 1);
+});

--- a/desktop/electron/test-auth-session.test.cjs
+++ b/desktop/electron/test-auth-session.test.cjs
@@ -72,6 +72,7 @@ test('production auth requests still use the real Host boundary', async () => {
   const host = new MahayanaHostProcess({
     app: fakeApp,
     env: {},
+    resourcesPath: '/tmp/fabushi-resources',
     fs: { readFileSync() { throw new Error('missing'); } },
     spawn: () => {
       spawnCount += 1;


### PR DESCRIPTION
## Summary
- make packaged Electron test-mode browser/OAuth auth state deterministic in the main-process Host boundary so `browserPoll` and follow-up `authStatus` cannot race each other
- persist the test auth state under the isolated E2E `userData` directory so restart-oriented journeys keep a coherent session
- add a main-process regression test proving test auth never spawns the production Host while production auth still does
- rename the Linux matrix child to `Electron Linux` and add an independent fail-closed `Electron desktop result` aggregate across the desktop matrix
- record a real Electron video for the packaged Grok visual-evidence journey and persist its checkpoint screenshots as standalone PNGs under `test-results`

## Evidence driving the patch
Current canonical-main Electron run 33070021462 failed on Linux, Windows, and macOS. Trace/log analysis shows Messenger can appear after browser login and then disappear because the shell's independent `authStatus()` probe still receives `loggedIn=false` from the real packaged Host. That clears account-scoped caches and returns the renderer to the login gate, causing the many downstream missing-peer/search/profile failures.

The current E2E artifacts contain traces but no standalone video and no standalone checkpoint PNGs. The visual-evidence test now records at the Electron launch boundary and writes screenshot files into the already-uploaded `desktop/test-results/**` tree.

## Why force-authorized automerge
This PR changes a protected workflow. `[automerge-force]` authorizes the repository's normal protected merge-queue automation; it does not bypass required checks or queue revalidation.