### PR TITLE
fix(ios): assert rendered WebMCP content in UI gate

### DIFF
--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -69,8 +69,16 @@ final class FabushiUITests: XCTestCase {
         let surface = app.descendants(matching: .any)["miniapp-webmcp-surface"]
         XCTAssertTrue(surface.waitForExistence(timeout: 10))
 
-        let webView = app.webViews["miniapp-webmcp-webview"]
-        XCTAssertTrue(webView.waitForExistence(timeout: 10), "Expected the dedicated WebMCP WKWebView")
+        // SwiftUI propagates the outer surface identifier onto the represented
+        // WKWebView in the XCTest accessibility tree. Assert the element type and
+        // the remotely-rendered page content rather than depending on the UIView's
+        // private identifier surviving that SwiftUI accessibility projection.
+        let webView = app.webViews["miniapp-webmcp-surface"]
+        XCTAssertTrue(webView.waitForExistence(timeout: 15), "Expected the dedicated WebMCP WKWebView")
+        XCTAssertTrue(
+            app.staticTexts["api.ombhrum.com"].waitForExistence(timeout: 15),
+            "Expected hosted WebMCP content to render inside the dedicated WKWebView"
+        )
 
         let close = app.buttons["miniapp-webmcp-close"]
         XCTAssertTrue(close.exists)


### PR DESCRIPTION
## Summary
- fix the iOS UI gate to query the WKWebView exactly as XCTest exposes it after SwiftUI accessibility projection
- verify hosted WebMCP content (`api.ombhrum.com`) is actually rendered in the remote WebContent process before closing the surface
- keep the real open/close user journey and existing XCTest screen recording intact

## Evidence driving the patch
Canonical-main native run 33070021458 failed at `FabushiUITests.testMiniAppOpensAndClosesDedicatedWebMcpSurface()` line 72. The xcresult accessibility tree shows the real element as `WebView, identifier: miniapp-webmcp-surface`, because the outer SwiftUI surface identifier is propagated onto the represented WKWebView. The same tree exposes remote WebContent descendants including `api.ombhrum.com`, the command text field, and the Send button.

The xcresult also contains a 27.99s H.264 XCTest screen recording (`kXCTAttachmentScreenRecording`, 7,982,428 bytes). Its final frame shows the fully-rendered Global Dharma WebMCP page and the native status `WebMCP 页面已打开`; therefore this is an observability-selector defect, not a product loading failure.