### PR TITLE
fix(ios): eliminate Swift 6 and deployment-target warnings

### DIFF
--- a/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
+++ b/mobile/ios/Fabushi/MiniAppWebMcpSurface.swift
@@ -145,7 +145,7 @@ private struct MiniAppWebView: UIViewRepresentable {
         func webView(
             _ webView: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction,
-            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
         ) {
             guard let url = navigationAction.request.url,
                   url.scheme == "https",

--- a/third_party/mahayana/mahayana-rs/.cargo/config.toml
+++ b/third_party/mahayana/mahayana-rs/.cargo/config.toml
@@ -1,0 +1,6 @@
+[env]
+# Keep Rust/C build-script outputs aligned with the native Xcode deployment
+# target. Apple toolchains otherwise stamp simulator objects with the runner SDK
+# default, which produces hundreds of newer-iOS-version linker warnings when the
+# app links at iOS 17.0.
+IPHONEOS_DEPLOYMENT_TARGET = { value = "17.0", force = false }

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host-mobile/Cargo.toml
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host-mobile/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.fabushi]
+ios-deployment-target = "17.0"
+
 [lib]
 name = "mahayana_app_host"
 crate-type = ["cdylib", "staticlib"]


### PR DESCRIPTION
## Summary
- make the WKNavigationDelegate decision handler match the current Swift 6/WebKit actor/sendability contract
- pin Cargo child processes to the same iOS 17.0 deployment target as the Xcode project
- version that deployment contract in `mahayana-app-host-mobile/Cargo.toml`, which is already part of the native static-library source hash, forcing the simulator archive to rebuild instead of reusing the old iOS 18.5-stamped cache

## Evidence driving the patch
The canonical iOS xcresult showed 111 warnings. One was the WebKit delegate `nearly matches optional requirement` warning. The remaining linker warnings were Rust static-library object files stamped for newer iOS Simulator 18.5 while Xcode links the app at iOS 17.0. The App Store device workflow already builds with `IPHONEOS_DEPLOYMENT_TARGET=17.0`; this patch makes the shared Cargo workspace enforce the same minimum consistently for simulator/device Rust and C build-script outputs.

## Acceptance
After protected merge, the exact-main Native iOS run must pass and its new xcresult must no longer contain the delegate warning or newer-iOS-simulator linker warning.