### PR TITLE
fix(desktop): restore single Rust Host authority and video evidence

### DIFF
--- a/desktop/e2e/grok-visual-evidence.spec.ts
+++ b/desktop/e2e/grok-visual-evidence.spec.ts
@@ -1,5 +1,5 @@
 import { _electron as electron, expect, test, type Page } from '@playwright/test';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -8,16 +8,8 @@ const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const packagedExecutable = process.env.FABUSHI_ELECTRON_EXECUTABLE?.trim() || null;
 
 async function launchDesktopApp(appDataDir: string) {
-  const videoDir = path.join(
-    appRoot,
-    'test-results',
-    'visual-evidence-video',
-    `${process.platform}-${process.pid}-${Date.now()}`,
-  );
-  await mkdir(videoDir, { recursive: true });
   return electron.launch({
     ...(packagedExecutable ? { executablePath: packagedExecutable, args: [] } : { args: [appRoot] }),
-    recordVideo: { dir: videoDir },
     env: {
       ...process.env,
       FABUSHI_APP_DATA: appDataDir,
@@ -28,7 +20,10 @@ async function launchDesktopApp(appDataDir: string) {
 }
 
 async function completeBrowserLogin(page: Page): Promise<void> {
-  await page.waitForLoadState('domcontentloaded');
+  // Electron's app:// renderer can already be interactive before Playwright observes a
+  // browser-style DOMContentLoaded transition. Product readiness is therefore defined
+  // by the actual visible gates, not by a navigation event that packaged Electron does
+  // not need to emit again.
   await expect.poll(async () => {
     for (const testId of ['onboarding-gate', 'login-gate', 'messenger-workspace']) {
       if (await page.getByTestId(testId).isVisible().catch(() => false)) return true;
@@ -50,8 +45,7 @@ async function completeBrowserLogin(page: Page): Promise<void> {
 async function attachScreenshot(page: Page, name: string): Promise<void> {
   // Visual evidence is intentionally deterministic. Motion behavior is verified
   // separately by grok-motion-parity.spec.ts; screenshots freeze CSS animations so
-  // Xvfb/Chromium never captures an arbitrary transition frame or waits forever on
-  // continuously animated BotMark aura layers.
+  // Xvfb/Chromium never captures an arbitrary transition frame.
   const screenshotPath = test.info().outputPath(`${name}.png`);
   await page.screenshot({
     path: screenshotPath,
@@ -67,10 +61,16 @@ async function attachScreenshot(page: Page, name: string): Promise<void> {
 test('capture Grok parity packaged visual evidence', async () => {
   const appDataDir = await mkdtemp(path.join(tmpdir(), 'fabushi-grok-visual-'));
   const app = await launchDesktopApp(appDataDir);
+  let page: Page | null = null;
+  let videoPath: string | null = null;
+  let screencastStarted = false;
 
   try {
-    const page = await app.firstWindow();
+    page = await app.firstWindow();
     await page.setViewportSize({ width: 1440, height: 900 });
+    videoPath = test.info().outputPath('grok-parity-user-journey.webm');
+    await page.screencast.start({ path: videoPath, size: { width: 1280, height: 800 } });
+    screencastStarted = true;
     await completeBrowserLogin(page);
 
     await expect(page.locator('body')).toHaveAttribute('data-fabushi-surface', 'grok-parity-v1');
@@ -100,6 +100,21 @@ test('capture Grok parity packaged visual evidence', async () => {
     await expect(page.getByText('收到：Grok parity visual evidence')).toBeVisible();
     await attachScreenshot(page, 'grok-parity-conversation-1440x900');
   } finally {
+    if (page && screencastStarted) {
+      await page.screencast.stop().catch(() => {});
+      if (videoPath) {
+        try {
+          await access(videoPath);
+          await test.info().attach('grok-parity-user-journey-video', {
+            path: videoPath,
+            contentType: 'video/webm',
+          });
+        } catch {
+          // The missing artifact will be visible in the uploaded diagnostics and is a
+          // test-evidence failure to investigate, not a reason to hide product failures.
+        }
+      }
+    }
     await app.close();
     await rm(appDataDir, { recursive: true, force: true });
   }

--- a/desktop/electron/host-process.cjs
+++ b/desktop/electron/host-process.cjs
@@ -5,7 +5,6 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const readline = require('node:readline');
-const { createTestAuthSession } = require('./test-auth-session.cjs');
 const { createTestPlatformAccount } = require('./test-platform-account.cjs');
 
 const PRODUCTION_PRODUCT_API_BASE_URL = 'https://api.ombhrum.com';
@@ -56,9 +55,6 @@ class MahayanaHostProcess {
     this.now = options.now ?? Date.now;
     this.fs = options.fs ?? fs;
     this.providerEnvironment = options.providerEnvironment ?? (() => ({}));
-    this.testAuthSession = this.env.FABUSHI_FEATURE_HOST_MODE === 'test'
-      ? createTestAuthSession({ app: this.app, fs: this.fs, now: this.now })
-      : null;
     this.testPlatformAccount = this.env.FABUSHI_FEATURE_HOST_MODE === 'test'
       ? createTestPlatformAccount({ app: this.app, fs: this.fs, now: this.now })
       : null;
@@ -232,10 +228,6 @@ class MahayanaHostProcess {
   }
 
   request(method, params = {}, timeoutMs = 120000) {
-    if (this.testAuthSession) {
-      const result = this.testAuthSession.request(method, params);
-      if (result !== null) return Promise.resolve(result);
-    }
     if (method === 'platform.request' && this.testPlatformAccount) {
       const result = this.testPlatformAccount.request(params);
       if (result) return Promise.resolve(result);

--- a/desktop/electron/test-auth-session.test.cjs
+++ b/desktop/electron/test-auth-session.test.cjs
@@ -1,7 +1,9 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 const Module = require('node:module');
+const { PassThrough } = require('node:stream');
 const test = require('node:test');
 
 const fakeApp = {
@@ -20,65 +22,105 @@ Module._load = function load(request, parent, isMain) {
 const { MahayanaHostProcess } = require('./host-process.cjs');
 Module._load = originalLoad;
 
-function memoryFs() {
-  const files = new Map();
-  return {
-    mkdirSync() {},
-    readFileSync(file) {
-      if (!files.has(file)) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
-      return files.get(file);
-    },
-    writeFileSync(file, content) {
-      files.set(file, String(content));
-    },
-  };
+class FakeChild extends EventEmitter {
+  constructor() {
+    super();
+    this.pid = 8801;
+    this.stdout = new PassThrough();
+    this.stderr = new PassThrough();
+    this.writes = [];
+    this.stdin = {
+      write: (data, callback) => {
+        this.writes.push(JSON.parse(String(data)));
+        queueMicrotask(() => callback?.(null));
+        return true;
+      },
+    };
+  }
+
+  latest() {
+    return this.writes.at(-1);
+  }
+
+  respond(result) {
+    const request = this.latest();
+    this.stdout.write(`${JSON.stringify({ id: request.id, ok: true, result })}\n`);
+  }
+
+  kill() {
+    this.emit('exit', 0, null);
+    return true;
+  }
 }
 
-test('packaged test browser auth is durable and never spawns the real Host', async () => {
-  const fs = memoryFs();
-  let spawnCount = 0;
-  const makeHost = () => new MahayanaHostProcess({
-    app: fakeApp,
-    env: { FABUSHI_FEATURE_HOST_MODE: 'test' },
-    fs,
-    now: () => 1_780_000_000_000,
-    spawn: () => {
-      spawnCount += 1;
-      throw new Error('test auth must not spawn the real Host');
-    },
-  });
-
-  const first = makeHost();
-  assert.deepEqual(await first.request('feature.auth.status'), { loggedIn: false, provider: 'test' });
-  const attempt = await first.request('feature.auth.browserStart');
-  assert.match(attempt.loginUrl, /^about:blank#fabushi-test-browser-login$/);
-  const completed = await first.request('feature.auth.browserPoll', { attemptId: attempt.attemptId });
-  assert.equal(completed.status, 'completed');
-  assert.equal(completed.auth.loggedIn, true);
-  assert.equal((await first.request('feature.auth.status')).loggedIn, true);
-  assert.equal(spawnCount, 0);
-
-  const restarted = makeHost();
-  assert.equal((await restarted.request('feature.auth.status')).loggedIn, true);
-  assert.equal(spawnCount, 0);
-
-  assert.deepEqual(await restarted.request('feature.auth.logout'), { loggedIn: false, provider: 'test' });
-  assert.deepEqual(await restarted.request('feature.auth.status'), { loggedIn: false, provider: 'test' });
-  assert.equal(spawnCount, 0);
-});
-
-test('production auth requests still use the real Host boundary', async () => {
+function makeHost(env = { FABUSHI_FEATURE_HOST_MODE: 'test' }) {
+  const child = new FakeChild();
   let spawnCount = 0;
   const host = new MahayanaHostProcess({
     app: fakeApp,
-    env: {},
+    env,
     resourcesPath: '/tmp/fabushi-resources',
     fs: { readFileSync() { throw new Error('missing'); } },
     spawn: () => {
       spawnCount += 1;
-      throw new Error('production boundary reached');
+      return child;
     },
   });
-  await assert.rejects(host.request('feature.auth.status'), /production boundary reached/);
-  assert.equal(spawnCount, 1);
+  return { host, child, spawnCount: () => spawnCount };
+}
+
+async function requestAndRespond(host, child, method, params, result) {
+  const pending = host.request(method, params);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(child.latest().method, method);
+  child.respond(result);
+  return pending;
+}
+
+test('test auth and runtime commands share one Rust Host generation', async () => {
+  const { host, child, spawnCount } = makeHost();
+
+  assert.deepEqual(
+    await requestAndRespond(host, child, 'feature.auth.status', {}, { loggedIn: false, provider: 'test' }),
+    { loggedIn: false, provider: 'test' },
+  );
+  const attempt = await requestAndRespond(host, child, 'feature.auth.browserStart', {}, {
+    attemptId: 'test-browser-login',
+    loginUrl: 'about:blank#fabushi-test-browser-login',
+    pollAfterMs: 120,
+  });
+  assert.equal(attempt.attemptId, 'test-browser-login');
+  const completed = await requestAndRespond(host, child, 'feature.auth.browserPoll', { attemptId: attempt.attemptId }, {
+    status: 'completed',
+    provider: 'browser',
+    auth: { loggedIn: true, provider: 'browser', user: { id: 'fast-e2e-browser-user' } },
+  });
+  assert.equal(completed.auth.loggedIn, true);
+  assert.equal((await requestAndRespond(host, child, 'feature.auth.status', {}, { loggedIn: true, provider: 'browser' })).loggedIn, true);
+
+  const accepted = await requestAndRespond(host, child, 'feature.execute', {
+    command: { type: 'conversation.list', requestId: 'conversation-list-test' },
+  }, { requestId: 'conversation-list-test' });
+  assert.equal(accepted.requestId, 'conversation-list-test');
+  const event = await requestAndRespond(host, child, 'feature.receive', { timeoutMs: 500 }, {
+    type: 'conversation.listed',
+    timestamp: '2026-08-27T00:00:00.000Z',
+    conversations: [{ id: 'codex:agent:assistant', title: '大乘助手', kind: 'codex', pinned: true, unreadCount: 0, updatedAtMs: 0 }],
+  });
+  assert.equal(event.type, 'conversation.listed');
+  assert.equal(event.conversations[0].id, 'codex:agent:assistant');
+  assert.equal(spawnCount(), 1);
+  assert.equal(host.health().generation, 1);
+  host.close();
+});
+
+test('production auth requests use the same real Host boundary', async () => {
+  const { host, child, spawnCount } = makeHost({});
+  const pending = host.request('feature.auth.status');
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(child.latest().method, 'feature.auth.status');
+  child.respond({ loggedIn: false });
+  assert.deepEqual(await pending, { loggedIn: false });
+  assert.equal(spawnCount(), 1);
+  host.close();
 });


### PR DESCRIPTION
## Summary
- remove the duplicate Node test-auth interception from `MahayanaHostProcess`; deterministic test auth now uses the same Rust FeatureHost authority as conversation, bot, and self-hosted messaging
- replace the regression test with a boundary test proving auth, conversation list, and runtime event polling share one Host generation
- switch the visual acceptance journey to Playwright 1.62 `page.screencast` so a concrete `.webm` is written into uploaded test results
- remove the browser-style `DOMContentLoaded` wait that Windows traces showed can time out after the packaged `app://` renderer is already visibly interactive

## Evidence
Exact-main Electron run 33083817108 showed login gate hiding and `messenger-workspace` appearing immediately, followed by a 45-second wait for `codex:agent:assistant`. Current Node test auth is intercepted before Rust while Rust messaging access requires its own authenticated session, splitting account authority across two state stores. Rust already implements deterministic durable test auth, so the duplicate Node seam is removed rather than adding another mock.

Linux/Windows artifacts also contained zero video files despite `recordVideo`; this change uses Playwright's explicit screencast path/stop lifecycle and keeps checkpoint PNGs in `desktop/test-results/**`.