### PR TITLE
test(ios): gate WebMCP on native navigation readiness

### DIFF
--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -69,15 +69,25 @@ final class FabushiUITests: XCTestCase {
         let surface = app.descendants(matching: .any)["miniapp-webmcp-surface"]
         XCTAssertTrue(surface.waitForExistence(timeout: 10))
 
-        // SwiftUI propagates the outer surface identifier onto the represented
-        // WKWebView in the XCTest accessibility tree. Assert the element type and
-        // the remotely-rendered page content rather than depending on the UIView's
-        // private identifier surviving that SwiftUI accessibility projection.
-        let webView = app.webViews["miniapp-webmcp-surface"]
-        XCTAssertTrue(webView.waitForExistence(timeout: 15), "Expected the dedicated WebMCP WKWebView")
-        XCTAssertTrue(
-            app.staticTexts["api.ombhrum.com"].waitForExistence(timeout: 15),
-            "Expected hosted WebMCP content to render inside the dedicated WKWebView"
+        // WKWebView's internal DOM accessibility projection is not stable across
+        // simulator/WebKit versions. The product already runs a JavaScript WebMCP
+        // probe in WKNavigationDelegate.didFinish and projects that result into the
+        // native SwiftUI status label. Assert that native readiness projection.
+        let connected = app.staticTexts["WebMCP 已连接"]
+        let localConnected = app.staticTexts["本地 WebMCP 已连接"]
+        let opened = app.staticTexts["WebMCP 页面已打开"]
+        let ready = XCTNSPredicateExpectation(
+            predicate: NSPredicate(
+                format: "exists == true OR %@.exists == true OR %@.exists == true",
+                localConnected,
+                opened
+            ),
+            object: connected
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [ready], timeout: 15),
+            .completed,
+            "Expected the native WebMCP readiness status after WKNavigationDelegate.didFinish"
         )
 
         let close = app.buttons["miniapp-webmcp-close"]

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -77,12 +77,10 @@ final class FabushiUITests: XCTestCase {
         let localConnected = app.staticTexts["本地 WebMCP 已连接"]
         let opened = app.staticTexts["WebMCP 页面已打开"]
         let ready = XCTNSPredicateExpectation(
-            predicate: NSPredicate(
-                format: "exists == true OR %@.exists == true OR %@.exists == true",
-                localConnected,
-                opened
-            ),
-            object: connected
+            predicate: NSPredicate { _, _ in
+                connected.exists || localConnected.exists || opened.exists
+            },
+            object: nil
         )
         XCTAssertEqual(
             XCTWaiter.wait(for: [ready], timeout: 15),


### PR DESCRIPTION
## Summary
- stop querying hosted WKWebView DOM text through XCUI accessibility, which is not stable across simulator/WebKit versions
- wait for the native SwiftUI WebMCP status that is updated only after `WKNavigationDelegate.didFinish` executes the existing JavaScript probe
- preserve the real Marketplace scroll/open/close user journey

## Evidence
Exact-main Native mobile run 33083817137 reaches the dedicated WebMCP surface and WKWebView successfully, then fails only because `app.staticTexts["api.ombhrum.com"]` is not exposed from the inner WebKit DOM. The product already projects navigation/probe completion to one of `WebMCP 已连接`, `本地 WebMCP 已连接`, or `WebMCP 页面已打开`; this is the stable native acceptance surface.