### PR TITLE
feat(agent): prefer event and connector driven Mahayana runs

### DIFF
--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "typecheck": "echo 'Skipping typecheck due to React 19 migration' && exit 0",
     "typecheck:host": "tsc -p tsconfig.host.json --noEmit",
-    "test:ai-discovery": "node scripts/check-ai-discovery.mjs"
+    "test:ai-discovery": "node scripts/check-ai-discovery.mjs",
+    "test:efficient-agent-policy": "node scripts/check-efficient-agent-policy.mjs"
   },
   "dependencies": {
     "@fabushi/api-client": "workspace:*",

--- a/frontend/apps/web/scripts/check-efficient-agent-policy.mjs
+++ b/frontend/apps/web/scripts/check-efficient-agent-policy.mjs
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+
+const [utils, host] = await Promise.all([
+  readFile(new URL("../src/lib/fabushi-runtime/agent-utils.ts", import.meta.url), "utf8"),
+  readFile(new URL("../src/app/host/host-client.tsx", import.meta.url), "utf8"),
+]);
+
+const requiredPolicySignals = [
+  "Prefer event-driven work over polling",
+  "Prefer connected Connector/MCP/API tools over browser or computer UI automation",
+  "report the blocker immediately",
+  "preserve approval requirements for destructive",
+];
+
+for (const signal of requiredPolicySignals) {
+  if (!utils.includes(signal)) throw new Error(`Missing efficient-run policy signal: ${signal}`);
+}
+
+if (!utils.includes("EFFICIENT_AGENT_RUN_POLICY")) {
+  throw new Error("Efficient-run policy must be a named reusable product contract");
+}
+if (!utils.includes("${EFFICIENT_AGENT_RUN_POLICY}")) {
+  throw new Error("Mode transition note must inject the efficient-run policy into every agent turn");
+}
+if (!host.includes("modeStatement: buildModeTransitionNote(")) {
+  throw new Error("Host chat dispatch must continue routing the mode statement to Mahayana");
+}
+if (!host.includes('kind: "event" as const') || !host.includes('kind: "schedule" as const')) {
+  throw new Error("Automation UI must retain both event and schedule triggers");
+}
+if (!host.includes('type: "connector.list"')) {
+  throw new Error("Host must continue discovering connectors for connector-first execution");
+}
+
+console.log("efficient agent run policy contract: ok");

--- a/frontend/apps/web/src/lib/fabushi-runtime/agent-utils.ts
+++ b/frontend/apps/web/src/lib/fabushi-runtime/agent-utils.ts
@@ -9,9 +9,23 @@ const MODE_LABELS: Readonly<Record<string, string>> = {
   multitask: "Multitask",
 };
 
+/**
+ * Product-level execution policy shared by every Mahayana chat turn.
+ *
+ * Keep this deliberately short: it is injected through modeStatement on every
+ * request, so it must steer tool choice without consuming a meaningful share
+ * of the model context window.
+ */
+export const EFFICIENT_AGENT_RUN_POLICY = [
+  "Prefer event-driven work over polling when an event source exists; use a schedule only when no reliable event can wake the task.",
+  "Prefer connected Connector/MCP/API tools over browser or computer UI automation when they can complete the same action.",
+  "If progress is blocked or you cannot make further useful progress, report the blocker immediately and state the exact human input or action needed.",
+  "Keep event filters narrow and preserve approval requirements for destructive, external, publish, send, delete, purchase, or production-changing actions.",
+].join(" ");
+
 export function buildModeTransitionNote(mode: string): string {
   const label = MODE_LABELS[mode] ?? (mode.trim() || "Agent");
-  return `Active mode: ${label}. Apply this mode to the current task from this point forward.`;
+  return `Active mode: ${label}. Apply this mode to the current task from this point forward. ${EFFICIENT_AGENT_RUN_POLICY}`;
 }
 
 export function normalizeAutomationSchedule(value: string): string {

--- a/projects/grok-bot-fabushi-integration/management/tasks/GBF-805-observable-parity-closure.md
+++ b/projects/grok-bot-fabushi-integration/management/tasks/GBF-805-observable-parity-closure.md
@@ -104,6 +104,25 @@ Use the pinned reconstructed baseline as an observable reference for Messenger t
 
 Provenance stays explicit: reimplement observable behavior and architecture in Fabushi-owned source. Do not wholesale vendor an unlicensed production renderer, brand assets or unknown-license resources.
 
+### 6. Efficient long-running Agent execution policy
+
+A later operating-guidance review added an efficiency requirement that maps directly onto existing Mahayana primitives without introducing another runtime.
+
+- Prefer event triggers over cron/polling whenever a reliable event source can wake the task.
+- Prefer connected Connector/MCP/API tools over browser/computer UI automation when they can perform the same action.
+- When the agent is stalled or cannot make further useful progress, surface the blocker immediately and request the exact human input/action needed instead of silently burning more turns.
+- Keep event filters narrow and preserve existing approvals for destructive/external/publish/send/delete/purchase/production-changing actions.
+- The rule is provider-neutral and injected through the existing `modeStatement` path for every Mahayana chat turn.
+
+Current implementation on `feat/gbf-efficient-agent-runs`:
+
+- `frontend/apps/web/src/lib/fabushi-runtime/agent-utils.ts` defines `EFFICIENT_AGENT_RUN_POLICY` and appends it to `buildModeTransitionNote`.
+- Existing `host-client.tsx` already sends `buildModeTransitionNote(...)` in every `chat.send`, so the policy reaches the canonical Mahayana runtime without a second tool router.
+- Existing event/schedule automation, connector discovery, MCP and approval contracts are retained rather than duplicated.
+- `frontend/apps/web/scripts/check-efficient-agent-policy.mjs` guards the four policy statements, mode-statement injection, event/schedule trigger availability and connector discovery.
+- Source analysis/provenance: `source/2026-08-27-efficient-agent-run-policy.md`.
+- PR/required CI/protected-main/post-main packaged evidence remains required before this slice is accepted as released.
+
 ## Manual changes in the active branch
 
 - Removed `.github/workflows/chatgpt-auto-confirm-task-dispatch.yml`.

--- a/projects/grok-bot-fabushi-integration/source/2026-08-27-efficient-agent-run-policy.md
+++ b/projects/grok-bot-fabushi-integration/source/2026-08-27-efficient-agent-run-policy.md
@@ -1,0 +1,55 @@
+# 2026-08-27 — Efficient Agent run policy from Grok Bot operating guidance
+
+## User request
+
+Review Eric Zakariasson's X post `2092642631344161258` together with `bhrum/grok-bot-0.18-reconstructed`, determine how the useful operating pattern maps to the reconstructed implementation, and bring the useful behavior into Fabushi/Mahayana.
+
+## External operating guidance
+
+The indexed X post recommends three concrete ways to make long-running Grok Bot plans more efficient:
+
+1. Prefer event triggers (for example Slack/GitHub/reaction events) when possible instead of waking on a cron when nothing changed.
+2. Ask the agent to notify the human as soon as it cannot make further progress or is stalled.
+3. Prefer connectors over browser automation when possible.
+
+Related Grok Bot guidance separates reusable HOW (skills) from WHEN (routines), recommends narrow triggers and evidence, and keeps high-impact actions behind approval.
+
+## Reconstructed-source findings
+
+Pinned reference remains `bhrum/grok-bot-0.18-reconstructed@a9f633e09d49a85829b8236331b9e21f7e612634` per the existing GBF clean-room boundary.
+
+Focused source inspection:
+
+- `source/node-agent-coordinator/routed-mcp-bridge.ts` exposes plugin tools through one provider-neutral MCP bridge. Tool discovery is centralized and each tool is annotated with read-only/destructive/idempotent/open-world hints before models see it.
+- `source/node-agent-coordinator/inference-router.ts` keeps one transcript/queue while routing different model providers through the same remote tool execution boundary. Claude uses the loopback MCP bridge while other routed providers can receive the same tools directly; tool execution returns through `executeRoutedMcpTool` rather than each provider inventing a separate browser path.
+
+The reusable architectural lesson is therefore not a new Grok runtime. It is a provider-neutral execution policy: prefer structured tool/connector paths, keep safety semantics centralized, and reserve browser/computer interaction for fallback cases.
+
+## Existing Fabushi capabilities
+
+Fabushi already has the necessary primitives on canonical main:
+
+- `AutomationTrigger` supports both schedule and event triggers.
+- Listener integrations cover GitHub, Git, Slack, Teams, Linear, Sentry and PagerDuty.
+- Connector/MCP tools are exposed through the single Mahayana Host boundary and retain approval requirements.
+- Teach/Workflow and Skill surfaces already cover reusable task instructions.
+- `host-client.tsx` routes `buildModeTransitionNote(...)` through `modeStatement` on each `chat.send`.
+
+The missing piece was a default run-policy statement that consistently instructs every Mahayana agent turn to use these primitives efficiently.
+
+## Implementation decision
+
+Add one short product-level `EFFICIENT_AGENT_RUN_POLICY` to `fabushi-runtime/agent-utils.ts` and inject it through the existing `buildModeTransitionNote` path. This keeps the policy provider-neutral and automatically reaches ordinary Agent turns without introducing another daemon, tool router or browser controller.
+
+The policy requires:
+
+- event-driven work over polling when a reliable event source exists;
+- connected Connector/MCP/API tools over browser/computer UI automation for equivalent actions;
+- immediate blocker escalation with the exact human input/action needed;
+- narrow event filters and preservation of approvals for destructive/external/publish/send/delete/purchase/production-changing actions.
+
+A lightweight contract check verifies that the policy remains injected into `modeStatement`, event + schedule triggers remain available, and connector discovery remains present.
+
+## Provenance
+
+No reconstructed Grok Bot source code, bundled renderer, installer, or unknown-license resource is copied into Fabushi. The implementation is a clean-room Fabushi-owned policy derived from observable architecture and operating guidance, consistent with the existing GBF source/provenance boundary.


### PR DESCRIPTION
## Summary

Implements the useful long-running Agent execution guidance from Eric Zakariasson's Grok Bot post using Fabushi's existing Mahayana primitives rather than adding another runtime.

- inject a short provider-neutral efficient-run policy into every Mahayana `modeStatement`
- prefer event-driven wakeups over polling when an event source exists
- prefer Connector/MCP/API tools over browser/computer automation for equivalent work
- require immediate blocker escalation with the exact human action/input needed
- preserve narrow triggers and approvals for high-impact actions
- add a contract check guarding the policy, event/schedule triggers, and connector discovery
- record clean-room source analysis under FAB-P0004 / GBF-805

## Reference analysis

The pinned `bhrum/grok-bot-0.18-reconstructed` source centralizes plugin tools in a provider-neutral routed MCP bridge and routes multiple providers through the same tool execution boundary. Fabushi already has event triggers, connectors/MCP, Teach/Workflow, and approval contracts; this PR makes the efficient route-selection behavior a default execution policy rather than duplicating those components.

No reconstructed renderer, installer, or unknown-license source is copied.

## Validation

- `pnpm --filter @fabushi/web test:efficient-agent-policy`
- `pnpm --filter @fabushi/web typecheck:host`
- normal repository CI/security/Electron gates required before merge

Project: FAB-P0004 / GBF-805