### PR TITLE
fix(mac): retry and verify secure Developer ID timestamps

### DIFF
--- a/.github/scripts/assert-native-electron-canonical.sh
+++ b/.github/scripts/assert-native-electron-canonical.sh
@@ -15,6 +15,10 @@ test -f .github/workflows/electron-desktop.yml || fail 'Electron desktop quality
 test -f .github/workflows/native-mobile.yml || fail 'native mobile quality workflow is missing'
 test -f .github/workflows/native-electron-release.yml || fail 'native Electron release workflow is missing'
 test -f .github/workflows/google-play-delivery.yml || fail 'native Android Google Play delivery workflow is missing'
+test -x .github/scripts/macos-codesign-wrapper/codesign || fail 'secure-timestamp codesign wrapper is missing or not executable'
+bash -n .github/scripts/macos-codesign-wrapper/codesign || fail 'secure-timestamp codesign wrapper has invalid shell syntax'
+grep -q 'Timestamp=' .github/scripts/macos-codesign-wrapper/codesign || fail 'codesign wrapper must verify the secure Timestamp field'
+grep -q 'GITHUB_PATH' .github/scripts/build-offline-asr-engine.mjs || fail 'macOS build must install the codesign wrapper for later signing steps'
 
 grep -q '"electron"' desktop/package.json || fail 'desktop does not declare Electron'
 grep -q 'mahayana-app-host-desktop' desktop/package.json || fail 'Electron must build the desktop-only Rust sidecar wrapper'

--- a/.github/scripts/build-offline-asr-engine.mjs
+++ b/.github/scripts/build-offline-asr-engine.mjs
@@ -6,6 +6,20 @@ import { fileURLToPath } from 'node:url';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '../..');
+
+function installMacosCodesignRetryWrapper() {
+  if (process.platform !== 'darwin' || process.env.GITHUB_ACTIONS !== 'true') return;
+  const githubPath = process.env.GITHUB_PATH?.trim();
+  if (!githubPath) throw new Error('GITHUB_PATH is required to install the macOS codesign retry wrapper');
+  const wrapperDir = path.join(scriptDir, 'macos-codesign-wrapper');
+  const wrapper = path.join(wrapperDir, 'codesign');
+  if (!fs.existsSync(wrapper)) throw new Error(`macOS codesign retry wrapper is missing: ${wrapper}`);
+  fs.appendFileSync(githubPath, `${wrapperDir}\n`, 'utf8');
+  console.log(`Installed macOS secure-timestamp codesign wrapper: ${wrapper}`);
+}
+
+installMacosCodesignRetryWrapper();
+
 const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'desktop/electron/offline-asr-engine.json'), 'utf8'));
 const source = manifest.whisperCpp;
 if (!source?.repository || !/^[0-9a-f]{40}$/i.test(source.commit ?? '')) {

--- a/.github/scripts/macos-codesign-wrapper/codesign
+++ b/.github/scripts/macos-codesign-wrapper/codesign
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+real_codesign="${FABUSHI_REAL_CODESIGN:-/usr/bin/codesign}"
+max_attempts="${FABUSHI_CODESIGN_MAX_ATTEMPTS:-4}"
+base_sleep_seconds="${FABUSHI_CODESIGN_RETRY_BASE_SECONDS:-3}"
+
+has_sign=0
+has_timestamp=0
+for arg in "$@"; do
+  case "$arg" in
+    --sign) has_sign=1 ;;
+    --timestamp|--timestamp=*) has_timestamp=1 ;;
+  esac
+done
+
+# Verification/display/ad-hoc calls must retain normal codesign behavior. Only
+# Developer-ID style signing requests that explicitly ask for a secure timestamp
+# need the bounded timestamp verification/retry loop below.
+if [ "$has_sign" -ne 1 ] || [ "$has_timestamp" -ne 1 ]; then
+  exec "$real_codesign" "$@"
+fi
+
+target="${!#}"
+attempt=1
+while [ "$attempt" -le "$max_attempts" ]; do
+  if "$real_codesign" "$@"; then
+    details="$($real_codesign --display --verbose=4 "$target" 2>&1 || true)"
+    if printf '%s\n' "$details" | grep -Eq '(^|[[:space:]])Timestamp='; then
+      printf 'codesign secure timestamp verified for %s on attempt %s/%s\n' "$target" "$attempt" "$max_attempts" >&2
+      exit 0
+    fi
+    printf 'codesign returned success but secure Timestamp= is missing for %s (attempt %s/%s)\n' "$target" "$attempt" "$max_attempts" >&2
+  else
+    printf 'codesign failed for %s (attempt %s/%s)\n' "$target" "$attempt" "$max_attempts" >&2
+  fi
+
+  if [ "$attempt" -lt "$max_attempts" ]; then
+    sleep_seconds=$((base_sleep_seconds * attempt))
+    printf 'retrying Developer ID timestamp signing in %ss\n' "$sleep_seconds" >&2
+    sleep "$sleep_seconds"
+  fi
+  attempt=$((attempt + 1))
+done
+
+printf 'Developer ID signing never produced a secure Timestamp= for %s after %s attempts\n' "$target" "$max_attempts" >&2
+exit 1


### PR DESCRIPTION
## Summary
- install a macOS-only `codesign` wrapper into GitHub Actions PATH before the existing native-payload signing step
- keep the existing Developer ID `--options runtime --timestamp` contract unchanged
- after each timestamped signing call, require `codesign --display --verbose=4` to contain the secure `Timestamp=` field
- retry transient timestamp-service misses with a bounded backoff and fail closed if no secure timestamp is produced
- guard wrapper executable/syntax/timestamp verification through the existing Electron architecture fast gate

## Evidence
Exact-main Electron macOS run 33083817108 imported the Developer ID identity and `codesign --timestamp` returned successfully, but strict verification reported `A timestamp was expected but was not found.` Apple TN3161 requires a secure timestamp for Developer ID and documents `Timestamp=` as the verification field. The wrapper therefore retries the same standards-compliant signing operation; it does not downgrade to unsigned/ad-hoc/no-timestamp output.

A local fake-codesign test verified the retry path: first signing response had only `Signed Time=`, second exposed `Timestamp=`, and the wrapper completed on attempt 2/4.