### PR TITLE
fix(release): close main delivery regressions

### DIFF
--- a/.github/workflows/fabushi-pay-production.yml
+++ b/.github/workflows/fabushi-pay-production.yml
@@ -126,26 +126,32 @@ jobs:
             /third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/payment_api.rs
             /third_party/mahayana/mahayana-rs/mahayana-pay-worker/**
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Require production payment configuration
         shell: bash
         run: |
           set -euo pipefail
           missing=()
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID ACCESS_TOKEN_PUBLIC_KEY_PEM APPLE_ISSUER_ID APPLE_KEY_ID GOOGLE_PLAY_SERVICE_ACCOUNT_JSON; do
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID APPLE_ISSUER_ID APPLE_KEY_ID GOOGLE_PLAY_SERVICE_ACCOUNT_JSON; do
             if [ -z "${!name:-}" ]; then missing+=("$name"); fi
           done
           if [ -z "${APPLE_PRIVATE_KEY:-}" ] && [ -z "${APP_STORE_CONNECT_API_KEY_BASE64:-}" ]; then
             missing+=("APPLE_PRIVATE_KEY or APP_STORE_CONNECT_API_KEY_BASE64")
           fi
+          if [ -z "${ACCESS_TOKEN_PUBLIC_KEY_PEM:-}" ]; then
+            existing_secret_names="$(npx --yes wrangler@latest secret list --env production --config wrangler.toml --format json | jq -r '.[].name' | sort -u)"
+            if ! grep -Fxq ACCESS_TOKEN_PUBLIC_KEY_PEM <<<"$existing_secret_names"; then
+              missing+=("ACCESS_TOKEN_PUBLIC_KEY_PEM (GitHub or existing production Worker secret)")
+            fi
+          fi
           if [ "${#missing[@]}" -ne 0 ]; then
             printf 'Missing Fabushi Pay production configuration: %s\n' "${missing[*]}" >&2
             exit 2
           fi
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
 
       - name: Set up Rust and wasm32
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/mahayana-staging-auth-repair.yml
+++ b/.github/workflows/mahayana-staging-auth-repair.yml
@@ -159,9 +159,10 @@ jobs:
           attempt_id="$(jq -er '.attemptId' <<<"$start")"
           poll_secret="$(jq -er '.pollSecret' <<<"$start")"
           login_url="$(jq -er '.loginUrl' <<<"$start")"
+          auth_public_base_url="https://api.ombhrum.com"
           case "$login_url" in
-            "$PLATFORM_URL/api/auth/browser/portal"*) ;;
-            *) echo "Browser login portal escaped staging origin: $login_url" >&2; exit 1 ;;
+            "$auth_public_base_url/api/auth/browser/portal"*) ;;
+            *) echo "Browser login portal escaped canonical auth origin: $login_url" >&2; exit 1 ;;
           esac
 
           poll_body="$(jq -cn --arg pollSecret "$poll_secret" '{pollSecret:$pollSecret}')"

--- a/desktop/e2e/grok-motion-parity.spec.ts
+++ b/desktop/e2e/grok-motion-parity.spec.ts
@@ -25,6 +25,10 @@ test('Grok parity motion layer exposes distinct state choreography', async () =>
 
   try {
     const page = await app.firstWindow();
+    await expect.poll(async () => page.evaluate(() =>
+      Array.from(document.styleSheets).some((candidate) =>
+        String(candidate.href ?? '').includes('grok-motion-parity.css'))),
+    { timeout: 10_000 }).toBe(true);
     const contract = await page.evaluate(() => {
       const sheet = Array.from(document.styleSheets).find((candidate) =>
         String(candidate.href ?? '').includes('grok-motion-parity.css'));

--- a/desktop/electron/main-lifecycle.test.cjs
+++ b/desktop/electron/main-lifecycle.test.cjs
@@ -11,3 +11,9 @@ test('desktop background presence remains production-only while E2E can shut dow
   assert.match(source, /if \(!backgroundPersistenceEnabled \|\| backgroundTray\) return;/);
   assert.match(source, /if \(!backgroundPersistenceEnabled\) app\.quit\(\);/);
 });
+
+test('runtime event pump yields between long-polls so renderer IPC cannot starve', () => {
+  const pump = source.slice(source.indexOf('function startHostEventPump()'), source.indexOf('function installIpcHandlers()'));
+  assert.match(pump, /if \(event\) broadcastMahayanaEvent\(event\);\s*\/\/ Yield after every receive[\s\S]*?await sleep\(10\);/);
+  assert.doesNotMatch(pump, /else await sleep\(10\);/);
+});

--- a/desktop/electron/main.cjs
+++ b/desktop/electron/main.cjs
@@ -803,7 +803,10 @@ function startHostEventPump() {
       try {
         const event = await host.request('feature.receive', { timeoutMs: 500 });
         if (event) broadcastMahayanaEvent(event);
-        else await sleep(10);
+        // Yield after every receive, including a non-empty event. The Rust Host
+        // processes requests serially; immediately enqueueing the next long-poll
+        // from this Promise continuation can starve renderer IPC such as auth.
+        await sleep(10);
       } catch (error) {
         if (hostEventPumpStopped) break;
         console.error('[mahayana-edge] runtime event pump failed', error);


### PR DESCRIPTION
## Summary

Closes the remaining post-merge release regressions observed on protected `main` after #2201:

- yield the Electron runtime event pump after every Rust Host receive so renderer auth IPC cannot be starved by back-to-back runtime events;
- wait for the external Grok motion stylesheet before reading its animation contract in black-box E2E;
- validate staging browser-login handoff against the canonical public auth origin (`https://api.ombhrum.com`) instead of the workers.dev execution origin;
- let Fabushi Pay reuse an already-provisioned Cloudflare `ACCESS_TOKEN_PUBLIC_KEY_PEM` secret, while remaining fail-closed if neither GitHub nor the production Worker has it.

## Local verification

- `node --check` for Electron main/lifecycle test
- Electron lifecycle + single-Rust-Host auth tests: 4/4 passed
- browser auth entry contract passed
- workflow YAML parsed successfully
- Grok motion keyframe markers present
- `git diff --check` passed

This PR intentionally keeps one Rust Host authority for both auth and runtime commands and does not weaken payment authentication or secret validation.