### PR TITLE
fix(ci): make interactive Runner MCP workflow dispatchable

### DIFF
--- a/.github/workflows/interactive-runner-mcp.yml
+++ b/.github/workflows/interactive-runner-mcp.yml
@@ -49,12 +49,12 @@ jobs:
       DEVICE_LEASE_SECONDS: '14400'
       FABUSHI_API_BASE_URL: ${{ vars.FABUSHI_API_BASE_URL || 'https://api.ombhrum.com' }}
       MAHAYANA_API_BASE_URL: ${{ vars.FABUSHI_API_BASE_URL || 'https://api.ombhrum.com' }}
-      FABUSHI_CI_SESSION_DIR: ${{ runner.temp }}/fabushi-interactive
-      FABUSHI_ACCOUNT_SESSION_FILE: ${{ runner.temp }}/fabushi-interactive/agent-account-session.json
-      FABUSHI_CI_ACCOUNT_SESSION_FILE: ${{ runner.temp }}/fabushi-interactive/app-account-session.json
-      FABUSHI_COMPUTER_POLICY_FILE: ${{ runner.temp }}/fabushi-interactive/computer-policy.json
-      FABUSHI_DEVICE_CALL_TRACE_FILE: ${{ runner.temp }}/fabushi-interactive/device-calls.jsonl
-      FABUSHI_APP_AGENT_DISCOVERY_FILE: ${{ runner.temp }}/fabushi-interactive/app-agent-bridge.json
+      FABUSHI_CI_SESSION_DIR: ${{ github.workspace }}/.fabushi-interactive
+      FABUSHI_ACCOUNT_SESSION_FILE: ${{ github.workspace }}/.fabushi-interactive/agent-account-session.json
+      FABUSHI_CI_ACCOUNT_SESSION_FILE: ${{ github.workspace }}/.fabushi-interactive/app-account-session.json
+      FABUSHI_COMPUTER_POLICY_FILE: ${{ github.workspace }}/.fabushi-interactive/computer-policy.json
+      FABUSHI_DEVICE_CALL_TRACE_FILE: ${{ github.workspace }}/.fabushi-interactive/device-calls.jsonl
+      FABUSHI_APP_AGENT_DISCOVERY_FILE: ${{ github.workspace }}/.fabushi-interactive/app-agent-bridge.json
       DISPLAY: ':99'
       GDK_BACKEND: x11
       NO_AT_BRIDGE: '0'
@@ -407,18 +407,18 @@ jobs:
         with:
           name: fabushi-interactive-runner-${{ github.run_id }}
           path: |
-            ${{ runner.temp }}/fabushi-interactive/status.json
-            ${{ runner.temp }}/fabushi-interactive/finish-requested.json
-            ${{ runner.temp }}/fabushi-interactive/remote-notes.jsonl
-            ${{ runner.temp }}/fabushi-interactive/device-calls.jsonl
-            ${{ runner.temp }}/fabushi-interactive/generated-regression.json
-            ${{ runner.temp }}/fabushi-interactive/live-session.mp4
-            ${{ runner.temp }}/fabushi-interactive/final-screen.png
-            ${{ runner.temp }}/fabushi-interactive/source-agent.log
-            ${{ runner.temp }}/fabushi-interactive/packaged-agent.log
-            ${{ runner.temp }}/fabushi-interactive/fabushi-app.log
-            ${{ runner.temp }}/fabushi-interactive/ffmpeg.log
-            ${{ runner.temp }}/fabushi-interactive/evidence-files.txt
+            ${{ github.workspace }}/.fabushi-interactive/status.json
+            ${{ github.workspace }}/.fabushi-interactive/finish-requested.json
+            ${{ github.workspace }}/.fabushi-interactive/remote-notes.jsonl
+            ${{ github.workspace }}/.fabushi-interactive/device-calls.jsonl
+            ${{ github.workspace }}/.fabushi-interactive/generated-regression.json
+            ${{ github.workspace }}/.fabushi-interactive/live-session.mp4
+            ${{ github.workspace }}/.fabushi-interactive/final-screen.png
+            ${{ github.workspace }}/.fabushi-interactive/source-agent.log
+            ${{ github.workspace }}/.fabushi-interactive/packaged-agent.log
+            ${{ github.workspace }}/.fabushi-interactive/fabushi-app.log
+            ${{ github.workspace }}/.fabushi-interactive/ffmpeg.log
+            ${{ github.workspace }}/.fabushi-interactive/evidence-files.txt
           if-no-files-found: warn
           retention-days: 30
 


### PR DESCRIPTION
Fix the protected-main interactive Runner MCP workflow so GitHub can create the job. The existing GBF-410 workflow declared `runner.temp` at job-level `env`, where the `runner` context is unavailable during workflow planning. This change uses the workspace-scoped private session directory consistently so the protected-main OIDC workflow can actually start and bring the Runner online for same-account ChatGPT MCP control.

Scope is intentionally limited to `.github/workflows/interactive-runner-mcp.yml`; the account-scoped OIDC, same-account authorization, short-lived CI session, packaged MCP takeover, evidence capture and `ci_session_finish` contract remain unchanged.