### PR TITLE
fix(ci): default interactive Runner to production MCP gateway

### DIFF
--- a/.github/workflows/interactive-runner-mcp.yml
+++ b/.github/workflows/interactive-runner-mcp.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       DEVICE_ID: gha-${{ github.run_id }}-${{ github.run_attempt }}-interactive
       DEVICE_NAME: Fabushi GitHub Actions ${{ github.run_id }}
-      DEVICE_GATEWAY_URL: ${{ inputs.gateway_url || vars.FABUSHI_REMOTE_MCP_DEVICE_GATEWAY_URL }}
+      DEVICE_GATEWAY_URL: ${{ inputs.gateway_url || vars.FABUSHI_REMOTE_MCP_DEVICE_GATEWAY_URL || 'wss://fabushi-mcp.ombhrum.com/agent' }}
       DEVICE_LEASE_SECONDS: '14400'
       FABUSHI_API_BASE_URL: ${{ vars.FABUSHI_API_BASE_URL || 'https://api.ombhrum.com' }}
       MAHAYANA_API_BASE_URL: ${{ vars.FABUSHI_API_BASE_URL || 'https://api.ombhrum.com' }}


### PR DESCRIPTION
Make the already-deployed production Fabushi MCP agent gateway the secure fallback for the protected-main interactive Runner workflow. This removes the repository-variable/manual-input configuration trap observed in live run 33289458763 while preserving explicit `gateway_url` and repository-variable overrides. The fallback remains the production `wss://.../agent` endpoint, and runtime validation still rejects non-WSS or non-`/agent` values.