### PR TITLE
chore(ci): reuse managed staging account for MCP Runner

### DIFF
--- a/.github/workflows/interactive-runner-account-mcp.yml
+++ b/.github/workflows/interactive-runner-account-mcp.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Sign the Runner into the dedicated Fabushi test account
         env:
-          FABUSHI_CI_TEST_USERNAME: ${{ secrets.FABUSHI_CI_TEST_USERNAME }}
-          FABUSHI_CI_TEST_PASSWORD: ${{ secrets.FABUSHI_CI_TEST_PASSWORD }}
+          FABUSHI_CI_TEST_USERNAME: ${{ secrets.FABUSHI_CI_TEST_USERNAME || secrets.STAGING_TEST_LOGIN }}
+          FABUSHI_CI_TEST_PASSWORD: ${{ secrets.FABUSHI_CI_TEST_PASSWORD || secrets.STAGING_TEST_PASSWORD }}
         run: node chatgpt-vps-control/scripts/login-ci-test-account.mjs
 
       - name: Copy the ordinary account session for the application


### PR DESCRIPTION
Allow the new account-scoped interactive Runner to use the dedicated MCP CI account secrets when present, otherwise fall back to the repository's existing protected staging test account secrets. This lets us verify same-Fabushi-account device discovery without exposing any credential value.