### PR TITLE
fix(auth): enable configured registration mail bridge

### DIFF
--- a/.github/scripts/deploy-auth-provider-bridge.sh
+++ b/.github/scripts/deploy-auth-provider-bridge.sh
@@ -63,6 +63,14 @@ for environment in development production; do
       cd "$LEGACY_DIR"
       printf '%s' "$bridge_secret" | npx --yes "wrangler@${WRANGLER_VERSION}" secret put AUTH_PROVIDER_BRIDGE_SECRET --env "$environment" >/dev/null
       printf '%s' "$PLATFORM_URL" | npx --yes "wrangler@${WRANGLER_VERSION}" secret put AUTH_PROVIDER_BRIDGE_RETURN_BASE --env "$environment" >/dev/null
+      # The public account system requires an actual registration path. If the
+      # deployed legacy Worker already has both self-hosted mail credentials,
+      # enable that capability explicitly. We still fail closed when either
+      # credential is absent, and the capability probe below verifies runtime
+      # configuration before publishing the bridge to the account Worker.
+      if [[ "$mail" == true ]]; then
+        printf '%s' 'true' | npx --yes "wrangler@${WRANGLER_VERSION}" secret put AUTH_SYSTEM_MAIL_ENABLED --env "$environment" >/dev/null
+      fi
     )
   fi
 done


### PR DESCRIPTION
The public Fabushi account/MCP flow is now direct, but production browser registration still reports email unavailable even though both legacy Worker environments have the managed system-mail URL/token secrets. The bridge deploy script currently preserves an old false `AUTH_SYSTEM_MAIL_ENABLED` value, so capability probing never publishes an email registration bridge.

When—and only when—the deployed legacy Worker already has URL, token, and enable-secret names, explicitly set `AUTH_SYSTEM_MAIL_ENABLED=true` before the authenticated capability probe. The bridge remains fail-closed if either credential is absent, and `mahayana-platform` receives a registration bridge URL only after the live capability probe returns `email=true`.