### PR TITLE
fix(auth): persist registration mail enablement

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -191,7 +191,6 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID }}
           AUTH_SYSTEM_MAIL_URL: ${{ secrets.AUTH_SYSTEM_MAIL_URL }}
           AUTH_SYSTEM_MAIL_TOKEN: ${{ secrets.AUTH_SYSTEM_MAIL_TOKEN }}
-          AUTH_SYSTEM_MAIL_ENABLED: ${{ secrets.AUTH_SYSTEM_MAIL_ENABLED }}
         shell: bash
         run: |
           set -euo pipefail
@@ -199,7 +198,8 @@ jobs:
           [ -n "${AUTH_SYSTEM_MAIL_TOKEN:-}" ]
           printf '%s' "$AUTH_SYSTEM_MAIL_URL" | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_URL --config wrangler.development.ci.toml --env development
           printf '%s' "$AUTH_SYSTEM_MAIL_TOKEN" | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_TOKEN --config wrangler.development.ci.toml --env development
-          printf '%s' "${AUTH_SYSTEM_MAIL_ENABLED:-false}" | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_ENABLED --config wrangler.development.ci.toml --env development
+          # URL + token are required immediately above, so keep registration email enabled on every deployment.
+          printf '%s' 'true' | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_ENABLED --config wrangler.development.ci.toml --env development
 
   staging-e2e:
     name: Staging API E2E and smoke gate
@@ -316,7 +316,6 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID || vars.CF_ACCOUNT_ID }}
           AUTH_SYSTEM_MAIL_URL: ${{ secrets.AUTH_SYSTEM_MAIL_URL }}
           AUTH_SYSTEM_MAIL_TOKEN: ${{ secrets.AUTH_SYSTEM_MAIL_TOKEN }}
-          AUTH_SYSTEM_MAIL_ENABLED: ${{ secrets.AUTH_SYSTEM_MAIL_ENABLED }}
         shell: bash
         run: |
           set -euo pipefail
@@ -324,7 +323,8 @@ jobs:
           [ -n "${AUTH_SYSTEM_MAIL_TOKEN:-}" ]
           printf '%s' "$AUTH_SYSTEM_MAIL_URL" | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_URL --env production
           printf '%s' "$AUTH_SYSTEM_MAIL_TOKEN" | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_TOKEN --env production
-          printf '%s' "${AUTH_SYSTEM_MAIL_ENABLED:-false}" | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_ENABLED --env production
+          # URL + token are required immediately above, so keep registration email enabled on every deployment.
+          printf '%s' 'true' | npx --yes wrangler@latest secret put AUTH_SYSTEM_MAIL_ENABLED --env production
       - name: Deploy production Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || vars.CLOUDFLARE_API_TOKEN || vars.CF_API_TOKEN }}


### PR DESCRIPTION
Keep public Fabushi email registration enabled across future full deployments. Both development and production deploy steps already fail if `AUTH_SYSTEM_MAIL_URL` or `AUTH_SYSTEM_MAIL_TOKEN` is missing; once those credentials are present, write `AUTH_SYSTEM_MAIL_ENABLED=true` rather than replaying a stale false toggle that can disable the registration bridge after a successful repair.