### PR TITLE
fix(ci): install xrandr for account Runner

### DIFF
--- a/.github/workflows/interactive-runner-account-mcp.yml
+++ b/.github/workflows/interactive-runner-account-mcp.yml
@@ -90,7 +90,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            xvfb xfwm4 x11-utils xdotool wmctrl ffmpeg dbus-x11 at-spi2-core libatk-adaptor python3-pyatspi
+            xvfb xfwm4 x11-utils x11-xserver-utils xdotool wmctrl ffmpeg dbus-x11 at-spi2-core libatk-adaptor python3-pyatspi
 
       - name: Start private X11 desktop
         shell: bash


### PR DESCRIPTION
## Summary
- install `x11-xserver-utils` in the account-bound interactive Linux Runner
- provide the `xrandr` executable required by Computer Use environment/state calls

## Verification
- lightweight diff and whitespace inspection only
- no local build or test run, per repository disk-safety policy
- GitHub Actions is the verification source of truth

This closes the final known Linux desktop dependency gap found during the real ChatGPT → Fabushi MCP → same-account Runner black-box test.