### PR TITLE
feat(ci): run packaged app with dedicated test account

### DIFF
--- a/.github/workflows/interactive-runner-account-mcp.yml
+++ b/.github/workflows/interactive-runner-account-mcp.yml
@@ -78,11 +78,11 @@ jobs:
           FABUSHI_CI_TEST_PASSWORD: ${{ secrets.FABUSHI_CI_TEST_PASSWORD }}
         run: node chatgpt-vps-control/scripts/login-ci-test-account.mjs
 
-      - name: Copy the ordinary account session for the application
+      - name: Export a bounded account session for the application
         shell: bash
         run: |
           set -euo pipefail
-          install -m 600 "$FABUSHI_ACCOUNT_SESSION_FILE" "$FABUSHI_CI_ACCOUNT_SESSION_FILE"
+          node chatgpt-vps-control/scripts/export-ci-app-account-session.mjs
 
       - name: Install private X11 desktop dependencies
         shell: bash

--- a/.github/workflows/interactive-runner-mcp.yml
+++ b/.github/workflows/interactive-runner-mcp.yml
@@ -11,6 +11,14 @@ on:
         description: Optional public wss://.../agent override for the Fabushi remote MCP device gateway
         required: false
         type: string
+      account_binding:
+        description: Fabushi account used for Runner discovery and the packaged application session
+        required: true
+        default: github-actor
+        type: choice
+        options:
+          - github-actor
+          - ci-test-account
       hold_minutes:
         description: Maximum live-control window after Fabushi becomes ready
         required: true
@@ -96,16 +104,19 @@ jobs:
             wss://*/agent) ;;
             *) echo 'FABUSHI_REMOTE_MCP_DEVICE_GATEWAY_URL or gateway_url must be wss://.../agent.' >&2; exit 1 ;;
           esac
-          test -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || { echo 'GitHub Actions OIDC request URL is unavailable.' >&2; exit 1; }
-          test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" || { echo 'GitHub Actions OIDC request token is unavailable.' >&2; exit 1; }
+          if [ '${{ inputs.account_binding }}' = 'github-actor' ]; then
+            test -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || { echo 'GitHub Actions OIDC request URL is unavailable.' >&2; exit 1; }
+            test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" || { echo 'GitHub Actions OIDC request token is unavailable.' >&2; exit 1; }
+          fi
           umask 077
           mkdir -p "$FABUSHI_CI_SESSION_DIR"
           cat > "$FABUSHI_COMPUTER_POLICY_FILE" <<'JSON'
           {"localExecution":true,"aiComputerControlEnabled":true,"localToolPermission":"always"}
           JSON
-          node .github/scripts/update-interactive-runner-status.mjs provisioning 'Preparing the temporary GitHub Actions desktop and GitHub-linked Fabushi account agent.'
+          node .github/scripts/update-interactive-runner-status.mjs provisioning 'Preparing the temporary GitHub Actions desktop and Fabushi account agent.'
 
       - name: Bind the Runner to the workflow actor's Fabushi account
+        if: inputs.account_binding == 'github-actor'
         shell: bash
         run: |
           set -euo pipefail
@@ -185,7 +196,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            xvfb xfwm4 x11-utils xdotool wmctrl ffmpeg dbus-x11 at-spi2-core \
+            xvfb xfwm4 x11-utils x11-xserver-utils xdotool wmctrl ffmpeg dbus-x11 at-spi2-core \
             libatk-adaptor python3-pyatspi libgtk-3-0 libnss3 libgbm1 libasound2t64 \
             pkg-config libclang-dev libxcb1-dev libxrandr-dev libxfixes-dev \
             libdbus-1-dev libpipewire-0.3-dev libwayland-dev libxkbcommon-dev \
@@ -215,6 +226,23 @@ jobs:
         working-directory: chatgpt-vps-control
         run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
 
+      - name: Bind the Runner to the dedicated Fabushi CI test account
+        if: inputs.account_binding == 'ci-test-account'
+        env:
+          FABUSHI_CI_TEST_USERNAME: ${{ secrets.FABUSHI_CI_TEST_USERNAME }}
+          FABUSHI_CI_TEST_PASSWORD: ${{ secrets.FABUSHI_CI_TEST_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node chatgpt-vps-control/scripts/login-ci-test-account.mjs
+          node chatgpt-vps-control/scripts/export-ci-app-account-session.mjs
+          account_ref="$(jq -er '.userId // .user.id // .username' "$FABUSHI_ACCOUNT_SESSION_FILE" | sha256sum | cut -c1-16)"
+          {
+            echo '- Runner account: dedicated Fabushi CI test account (identity redacted)'
+            echo "- Account reference: \`$account_ref\`"
+            echo '- Connect the `fabushi test` MCP with the same dedicated test account.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Bring the Runner online before the build
         shell: bash
         run: |
@@ -241,7 +269,11 @@ jobs:
             echo "- MCP URL: \`$mcp_url\`"
             echo "- Device ID: \`$DEVICE_ID\`"
             echo "- Runner URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            echo '- Connect ChatGPT with the same GitHub-linked Fabushi account, call `list_devices`, then select this device.'
+            if [ '${{ inputs.account_binding }}' = 'ci-test-account' ]; then
+              echo '- Connect the `fabushi test` MCP with the dedicated CI test account, call `list_devices`, then select this device.'
+            else
+              echo '- Connect ChatGPT with the same GitHub-linked Fabushi account, call `list_devices`, then select this device.'
+            fi
             echo '- Call `ci_session_status` while the package is building; after `appReady=true`, run live UI tests and finish with `ci_session_finish`.'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/chatgpt-vps-control/scripts/export-ci-app-account-session.mjs
+++ b/chatgpt-vps-control/scripts/export-ci-app-account-session.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+
+const MAX_SESSION_BYTES = 64 * 1024;
+const MAX_LIFETIME_SECONDS = 5 * 60 * 60;
+
+function required(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+function privateRunnerPath(value, runnerTemp, name) {
+  const path = resolve(value);
+  const root = resolve(runnerTemp);
+  if (!path.startsWith(`${root}${sep}`)) {
+    throw new Error(`${name} must live under RUNNER_TEMP.`);
+  }
+  return path;
+}
+
+function validCredential(value) {
+  return value.length >= 24 && value.length <= 16 * 1024 && !/\s/u.test(value);
+}
+
+if (process.env.GITHUB_ACTIONS !== "true") {
+  throw new Error("CI application sessions can be exported only inside GitHub Actions.");
+}
+
+const runnerTemp = required("RUNNER_TEMP");
+const sourcePath = privateRunnerPath(required("FABUSHI_ACCOUNT_SESSION_FILE"), runnerTemp, "FABUSHI_ACCOUNT_SESSION_FILE");
+const outputPath = privateRunnerPath(required("FABUSHI_CI_ACCOUNT_SESSION_FILE"), runnerTemp, "FABUSHI_CI_ACCOUNT_SESSION_FILE");
+if (sourcePath === outputPath) throw new Error("The source and application session paths must differ.");
+
+const deviceId = required("DEVICE_ID");
+const runId = required("GITHUB_RUN_ID");
+const runAttempt = required("GITHUB_RUN_ATTEMPT");
+if (!/^gha-[0-9]+-[0-9]+-interactive$/u.test(deviceId)) {
+  throw new Error("DEVICE_ID must be the protected interactive Runner id.");
+}
+if (!/^[0-9]+$/u.test(runId) || !/^[0-9]+$/u.test(runAttempt)) {
+  throw new Error("GitHub run identity is invalid.");
+}
+
+const sourceText = await readFile(sourcePath, "utf8");
+if (Buffer.byteLength(sourceText) > MAX_SESSION_BYTES) throw new Error("Fabushi account session is too large.");
+const source = JSON.parse(sourceText);
+const accessToken = String(source?.accessToken || "").trim();
+const refreshToken = String(source?.refreshToken || "").trim();
+const tokenType = String(source?.tokenType || "Bearer");
+const sourceDeviceId = String(source?.deviceId || "").trim();
+const username = String(source?.username || source?.user?.username || "").trim();
+const userId = String(source?.userId || source?.user?.id || "").trim();
+const nestedUserId = String(source?.user?.id || "").trim();
+const expiresAt = Number(source?.accessTokenExpiresAt || 0);
+const now = Math.floor(Date.now() / 1000);
+
+if (!validCredential(accessToken) || !validCredential(refreshToken)) {
+  throw new Error("The ordinary Fabushi account session is incomplete.");
+}
+if (tokenType !== "Bearer" || sourceDeviceId !== deviceId || !username || !userId || nestedUserId !== userId) {
+  throw new Error("The ordinary Fabushi account identity is inconsistent.");
+}
+if (!Number.isSafeInteger(expiresAt)
+    || expiresAt <= now + 30
+    || expiresAt > now + MAX_LIFETIME_SECONDS) {
+  throw new Error("The Fabushi access token is not valid for a bounded CI session.");
+}
+if (source?.ciRunner === true || source?.provider === "github-actions") {
+  throw new Error("Expected an ordinary refreshable Fabushi account session.");
+}
+
+const exported = {
+  accessToken,
+  tokenType: "Bearer",
+  accessTokenExpiresAt: expiresAt,
+  sessionId: `ci-runner:${runId}:${runAttempt}`,
+  deviceId,
+  username,
+  userId,
+  user: source.user,
+  provider: "github-actions",
+  ciRunner: true,
+};
+
+await mkdir(dirname(outputPath), { recursive: true, mode: 0o700 });
+const temporary = `${outputPath}.${process.pid}.tmp`;
+await writeFile(temporary, `${JSON.stringify(exported, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+await rename(temporary, outputPath);
+process.stdout.write("Exported a bounded refresh-token-free Fabushi application session.\n");

--- a/chatgpt-vps-control/tests/export-ci-app-account-session.test.js
+++ b/chatgpt-vps-control/tests/export-ci-app-account-session.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const script = new URL("../scripts/export-ci-app-account-session.mjs", import.meta.url);
+
+test("exports a bounded refresh-token-free application session", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "fabushi-ci-app-session-"));
+  const sourcePath = join(directory, "ordinary.json");
+  const outputPath = join(directory, "application.json");
+  const expiresAt = Math.floor(Date.now() / 1000) + 60 * 60;
+  await writeFile(sourcePath, JSON.stringify({
+    accessToken: "a".repeat(64),
+    refreshToken: "r".repeat(64),
+    tokenType: "Bearer",
+    accessTokenExpiresAt: expiresAt,
+    refreshTokenExpiresAt: expiresAt + 60 * 60,
+    sessionId: "ordinary-session",
+    deviceId: "gha-12345-1-interactive",
+    username: "test-user",
+    userId: "42",
+    user: { id: "42", username: "test-user" },
+    provider: "official",
+    ciRunner: false,
+  }));
+
+  await execFileAsync(process.execPath, [script.pathname], {
+    env: {
+      ...process.env,
+      GITHUB_ACTIONS: "true",
+      RUNNER_TEMP: directory,
+      GITHUB_RUN_ID: "12345",
+      GITHUB_RUN_ATTEMPT: "1",
+      DEVICE_ID: "gha-12345-1-interactive",
+      FABUSHI_ACCOUNT_SESSION_FILE: sourcePath,
+      FABUSHI_CI_ACCOUNT_SESSION_FILE: outputPath,
+    },
+  });
+
+  const exported = JSON.parse(await readFile(outputPath, "utf8"));
+  assert.equal(exported.provider, "github-actions");
+  assert.equal(exported.ciRunner, true);
+  assert.equal(exported.sessionId, "ci-runner:12345:1");
+  assert.equal(exported.deviceId, "gha-12345-1-interactive");
+  assert.equal(exported.accessTokenExpiresAt, expiresAt);
+  assert.equal(exported.refreshToken, undefined);
+  assert.equal((await stat(outputPath)).mode & 0o077, 0);
+});
+
+test("rejects export outside GitHub Actions", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "fabushi-ci-app-session-reject-"));
+  await assert.rejects(
+    execFileAsync(process.execPath, [script.pathname], {
+      env: { ...process.env, GITHUB_ACTIONS: "false", RUNNER_TEMP: directory },
+    }),
+    /CI application sessions can be exported only inside GitHub Actions/u,
+  );
+});

--- a/chatgpt-vps-control/tests/interactive-runner-account-binding.test.js
+++ b/chatgpt-vps-control/tests/interactive-runner-account-binding.test.js
@@ -5,11 +5,20 @@ import test from "node:test";
 const root = new URL("../../", import.meta.url);
 const read = (path) => readFile(new URL(path, root), "utf8");
 
-test("interactive Runner uses GitHub OIDC and no shared test-account credential", async () => {
+test("interactive Runner supports explicit protected account bindings", async () => {
   const workflow = await read(".github/workflows/interactive-runner-mcp.yml");
+  assert.match(workflow, /account_binding:/u);
+  assert.match(workflow, /default: github-actor/u);
+  assert.match(workflow, /- ci-test-account/u);
   assert.match(workflow, /id-token: write/u);
   assert.match(workflow, /audience=fabushi-ci-runner/u);
   assert.match(workflow, /\/v1\/ci\/runner-session/u);
+  assert.match(workflow, /if: inputs\.account_binding == 'github-actor'/u);
+  assert.match(workflow, /if: inputs\.account_binding == 'ci-test-account'/u);
+  assert.match(workflow, /secrets\.FABUSHI_CI_TEST_USERNAME/u);
+  assert.match(workflow, /secrets\.FABUSHI_CI_TEST_PASSWORD/u);
+  assert.match(workflow, /login-ci-test-account\.mjs/u);
+  assert.match(workflow, /export-ci-app-account-session\.mjs/u);
   assert.match(workflow, /FABUSHI_ACCOUNT_SESSION_FILE/u);
   assert.match(workflow, /FABUSHI_CI_ACCOUNT_SESSION_FILE/u);
   assert.match(workflow, /GitHub-linked Fabushi account/u);
@@ -17,6 +26,16 @@ test("interactive Runner uses GitHub OIDC and no shared test-account credential"
   assert.doesNotMatch(workflow, /MAHAYANA_TEST_ACCOUNT_TOKEN/u);
   assert.doesNotMatch(workflow, /FABUSHI_ACCOUNT_ACCESS_TOKEN/u);
   assert.doesNotMatch(workflow, /FABUSHI_CI_TEST_ACCOUNT_AUTOLOGIN/u);
+});
+
+test("account-bound source Runner exports only a short-lived app session", async () => {
+  const workflow = await read(".github/workflows/interactive-runner-account-mcp.yml");
+  assert.match(workflow, /login-ci-test-account\.mjs/u);
+  assert.match(workflow, /export-ci-app-account-session\.mjs/u);
+  assert.doesNotMatch(
+    workflow,
+    /install -m 600 "\$FABUSHI_ACCOUNT_SESSION_FILE" "\$FABUSHI_CI_ACCOUNT_SESSION_FILE"/u,
+  );
 });
 
 test("CI Runner token exchange is exact-repository, exact-workflow and linked-account scoped", async () => {


### PR DESCRIPTION
## Summary
- add an explicit `ci-test-account` binding mode to the packaged interactive Runner workflow
- keep the ordinary refreshable session only in the device agent and export a bounded, refresh-token-free application session
- install the `xrandr` runtime in the packaged interactive workflow
- harden the legacy account Runner to use the same bounded export
- add focused security contract tests for the exported session

## Evidence so far
- real `fabushi test` call on run 33346933085 verified Linux X11, `xrandr`, ffmpeg screenshot, and remote state capture on merge commit `5260646f6c89c09a402719b0b5bc99de352c3e93`
- that run also proved the old account workflow did not build or launch Fabushi, which this PR closes

## Verification
- lightweight diff/whitespace inspection passed
- the local machine has no Node runtime and repository policy forbids installing/building locally; GitHub Actions is the source of truth

After merge, dispatch `interactive-runner-mcp.yml` with `account_binding=ci-test-account`, control the resulting packaged Fabushi app through `@fabushi test`, and finish through `ci_session_finish`.