### PR TITLE
fix(ci): restore important mobile release gate

### DIFF
--- a/.github/workflows/delivery-governance-contract.yml
+++ b/.github/workflows/delivery-governance-contract.yml
@@ -93,6 +93,10 @@ jobs:
             grep -Fq -- '--latest=false' "$workflow"
           done
 
+          important_gate=.github/workflows/important-release-gate.yml
+          grep -Fq 'uses: ./.github/workflows/native-mobile.yml' "$important_gate"
+          ! grep -Fq 'android-real-device-e2e.yml' "$important_gate"
+
       - name: Validate narrow CODEOWNERS coverage
         shell: bash
         run: |

--- a/.github/workflows/important-release-gate.yml
+++ b/.github/workflows/important-release-gate.yml
@@ -11,14 +11,6 @@ on:
         required: false
         type: boolean
         default: false
-      device_model:
-        description: Firebase Test Lab physical device model
-        required: false
-        default: Pixel2
-      device_version:
-        description: Android API level for the physical device
-        required: false
-        default: '30'
 
 permissions:
   contents: write
@@ -28,19 +20,14 @@ env:
   RELEASE_TAG: ${{ github.event.inputs.tag }}
 
 jobs:
-  real-device-e2e:
-    uses: ./.github/workflows/android-real-device-e2e.yml
-    with:
-      device_model: ${{ github.event.inputs.device_model }}
-      device_version: ${{ github.event.inputs.device_version }}
-      device_locale: zh_CN
-      device_orientation: portrait
+  native-mobile-e2e:
+    uses: ./.github/workflows/native-mobile.yml
     secrets: inherit
 
   create-release:
-    name: Create GitHub release after real-device E2E
+    name: Create GitHub release after native mobile E2E
     runs-on: ubuntu-latest
-    needs: real-device-e2e
+    needs: native-mobile-e2e
     steps:
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- replace the deleted `android-real-device-e2e.yml` reusable workflow with the canonical reusable `native-mobile.yml` quality gate
- remove obsolete Firebase device inputs
- make release creation depend on Android + iOS native mobile verification
- add a governance contract that prevents the retired workflow reference from returning

## Verification
- lightweight YAML/diff inspection passed
- heavy Android/iOS verification remains GitHub Actions-only per repository policy