### PR TITLE
fix: unblock v1.0.6 desktop and Android release gates

### DIFF
--- a/desktop/e2e/credential-vault.spec.ts
+++ b/desktop/e2e/credential-vault.spec.ts
@@ -119,7 +119,8 @@ test('installed Credential Vault keeps plaintext opaque, stays usable with OS en
     await expect(savedRow).toContainText('https://api.example.com');
     await expect(page.locator('body')).not.toContainText(FIRST_CANARY);
     await expect(page.locator('body')).not.toContainText(CANCELLED_CANARY);
-    await expect(page.getByText(/显示.*密钥|查看.*密钥|Reveal Secret/i)).toHaveCount(0);
+    const revealSecretControls = page.locator('button, [role="button"], a').filter({ hasText: /显示.*密钥|查看.*密钥|Reveal Secret/i });
+    await expect(revealSecretControls).toHaveCount(0);
 
     const afterCreate = await listSecrets(page);
     const created = afterCreate.find((entry) => entry.name === SECRET_REF) as Record<string, any> | undefined;

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiAppAgentSurface.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiAppAgentSurface.kt
@@ -173,11 +173,12 @@ class FabushiAppAgentSurface(
     ): Assertion {
         val bounded = timeoutMilliseconds.coerceIn(100, 30_000)
         val satisfied = withTimeoutOrNull(bounded) {
-            while (true) {
-                val result = assertState(expectedScreen, agentId, role, name, state)
-                if (result.passed) return@withTimeoutOrNull result
+            var result = assertState(expectedScreen, agentId, role, name, state)
+            while (!result.passed) {
                 delay(100)
+                result = assertState(expectedScreen, agentId, role, name, state)
             }
+            result
         }
         return satisfied ?: assertState(expectedScreen, agentId, role, name, state)
     }

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.onDispose
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment


### PR DESCRIPTION
Unblocks the exact-main v1.0.6 delivery gates observed on main SHA 2b48d4d469d0fded7cd8d023210acd77e01415e4.

- Keep the Credential Vault no-plaintext-readback assertion, but scope the reveal-secret check to actual interactive controls so explanatory/ancestor text cannot false-positive on Windows/macOS packaged E2E.
- Fix Android `FabushiAppAgentSurface.waitFor` inference so `withTimeoutOrNull` returns `Assertion?` instead of `Any?`.
- Remove the invalid Compose `onDispose` import; `DisposableEffect` provides it in its receiver scope.

`git diff --check` passes. The changes are intentionally limited to the three failing release gates.