### PR TITLE
fix: make v1.0.6 release gates replayable

### DIFF
--- a/.github/workflows/native-electron-release.yml
+++ b/.github/workflows/native-electron-release.yml
@@ -79,6 +79,7 @@ jobs:
             'Electron desktop result' \
             'Electron macOS' \
             'Electron Windows' \
+            'Electron Linux' \
             'Native mobile result' \
             'Native iOS' \
             'Computer control security result' \

--- a/.github/workflows/platform-control-plane.yml
+++ b/.github/workflows/platform-control-plane.yml
@@ -66,7 +66,7 @@ jobs:
 
   deploy-production:
     name: Deploy production control plane
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: architecture
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
Unblocks the formal v1.0.6 five-platform release without weakening release safety.

- Allow Platform Control Plane production deployment to run from an explicit workflow_dispatch on protected main, so the exact release SHA can receive the required `Platform architecture` and `Deploy production control plane` checks even when path filters would otherwise skip them.
- Require `Electron Linux` explicitly in the immutable five-platform release gate alongside macOS, Windows, Android, and iOS.

This preserves all existing checks and makes the release gate reproducible rather than bypassed.