### PR TITLE
fix: unblock full-platform release gates

### DIFF
--- a/.github/scripts/assert-native-electron-canonical.sh
+++ b/.github/scripts/assert-native-electron-canonical.sh
@@ -31,9 +31,9 @@ python3 - <<'PY'
 import json
 from pathlib import Path
 
-canonical = json.loads(Path('app-version.json').read_text())['version']
-desktop = json.loads(Path('desktop/package.json').read_text())['version']
-mobile = json.loads(Path('mobile/package.json').read_text())['version']
+canonical = json.loads(Path('app-version.json').read_text(encoding='utf-8'))['version']
+desktop = json.loads(Path('desktop/package.json').read_text(encoding='utf-8'))['version']
+mobile = json.loads(Path('mobile/package.json').read_text(encoding='utf-8'))['version']
 if desktop != canonical or mobile != canonical:
     raise SystemExit(f'version drift: canonical={canonical} desktop={desktop} mobile={mobile}')
 PY

--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -157,6 +157,16 @@ jobs:
       release_version: ${{ steps.collect.outputs.version }}
       source_sha: ${{ needs.gate.outputs.source_sha }}
     steps:
+      - name: Checkout version policy sync script
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.gate.outputs.source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            app-version.json
+            .github/scripts/sync-app-version-policy.mjs
       - name: Download tested macOS package artifacts from exact Electron run
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary

- Check out the version-policy sync script and canonical app version in the post-main release job.
- Read the UTF-8 version manifests explicitly in the native Electron architecture gate so Windows runners do not use the locale codec.

## Verification

Heavy build and release verification remains in GitHub Actions. This PR intentionally contains only the two release-gate fixes.