### PR TITLE
ci: publish mobile packages from marked main gate [native-mobile-release-20260831]

### DIFF
--- a/.github/workflows/apple-store-delivery.yml
+++ b/.github/workflows/apple-store-delivery.yml
@@ -2,6 +2,11 @@ name: Apple Store delivery - Electron macOS and native iOS
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Native mobile quality gate
+    types: [completed]
+    branches: [main]
     inputs:
       source_ref:
         description: Git ref to build. Leave as main for the current production source.
@@ -37,6 +42,15 @@ permissions:
 
 jobs:
   resolve:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        contains(github.event.workflow_run.head_commit.message, '[native-mobile-release-20260831]')
+      )
     name: Resolve Apple release identity
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -51,13 +65,14 @@ jobs:
       - name: Checkout requested source
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.event.workflow_run.head_sha }}
           fetch-depth: 1
 
       - id: release
         name: Resolve version and selected platforms
         shell: bash
         env:
+          EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.app_version }}
           INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
           INPUT_TARGET: ${{ inputs.target }}
@@ -65,7 +80,14 @@ jobs:
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
           app_version="${INPUT_VERSION:-$(jq -r '.version' app-version.json)}"
-          build_number="${INPUT_BUILD_NUMBER:-$(date -u +'%Y.%-m.%-d')}"
+          target="${INPUT_TARGET:-ios}"
+          if [ -n "$INPUT_BUILD_NUMBER" ]; then
+            build_number="$INPUT_BUILD_NUMBER"
+          elif [ "$EVENT_NAME" = 'workflow_run' ]; then
+            build_number="$(date -u +'%Y.%-m.')$((3100 + GITHUB_RUN_NUMBER))"
+          else
+            build_number="$(date -u +'%Y.%-m.%-d')"
+          fi
 
           if ! [[ "$app_version" =~ ^[0-9]+([.][0-9]+){1,2}$ ]]; then
             echo "App version must contain two or three numeric components: $app_version" >&2
@@ -78,7 +100,7 @@ jobs:
 
           macos=false
           ios=false
-          case "$INPUT_TARGET" in
+          case "$target" in
             both) macos=true; ios=true ;;
             macos) macos=true ;;
             ios) ios=true ;;
@@ -92,11 +114,12 @@ jobs:
             echo "build_number=$build_number"
             echo "macos=$macos"
             echo "ios=$ios"
+            echo "release_target=$target"
             echo "release_tag=$release_tag"
           } >> "$GITHUB_OUTPUT"
 
           {
-            echo '## Apple Store manual delivery'
+            echo '## Apple Store delivery'
             echo
             echo "- Source: \`$source_sha\`"
             echo "- Version: \`$app_version\`"
@@ -114,7 +137,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
-          RELEASE_TARGET: ${{ inputs.target }}
+          RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
         run: bash .github/scripts/require-release-source-gates.sh
 
   macos-electron:
@@ -540,7 +563,7 @@ jobs:
   result:
     name: Apple Store delivery result
     needs: [resolve, macos-electron, ios-native]
-    if: always()
+    if: always() && needs.resolve.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:

--- a/.github/workflows/native-android-release.yml
+++ b/.github/workflows/native-android-release.yml
@@ -2,6 +2,11 @@ name: Native Android GitHub release
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Native mobile quality gate
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -14,6 +19,15 @@ concurrency:
 
 jobs:
   release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        contains(github.event.workflow_run.head_commit.message, '[native-mobile-release-20260831]')
+      )
     name: Build and publish signed Android APK
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -24,6 +38,7 @@ jobs:
       ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
     steps:
       - name: Require manual dispatch from main
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
@@ -35,7 +50,7 @@ jobs:
       - name: Checkout immutable main source
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
           fetch-depth: 1
           submodules: recursive
           persist-credentials: false
@@ -48,7 +63,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
           RELEASE_TARGET: android
         run: |
           set -euo pipefail
@@ -250,5 +265,5 @@ jobs:
           gh release create "$tag" "${assets[@]}" \
             --target '${{ steps.source.outputs.sha }}' \
             --title 'Fabushi Android ${{ steps.release.outputs.version_name }} (${{ steps.release.outputs.version_code }})' \
-            --notes 'Manual GitHub Android release from main after CI result and Native mobile result passed for the exact source SHA. The APK includes the GitHub self-update channel.' \
+            --notes 'GitHub Android release from main after CI result and Native mobile result passed for the exact source SHA. The APK includes the GitHub self-update channel.' \
             --latest=false


### PR DESCRIPTION
## Summary

- add a one-time, commit-marker-gated workflow_run path to the signed Android GitHub release
- add the same path to Apple Store delivery, defaulting to native iOS and pinning the exact mobile gate SHA
- keep existing manual dispatch behavior unchanged
- use a monotonic numeric Apple build number for the marked automatic run

The marker in this PR title causes the post-merge Native mobile quality gate to trigger the two exact-source mobile release workflows once. Ordinary future main pushes and ordinary workflow_dispatch runs are not affected.