### PR TITLE
fix: unblock exact-SHA Apple release retry [native-ios-release-retry-20260831]

### DIFF
--- a/.github/workflows/apple-store-delivery.yml
+++ b/.github/workflows/apple-store-delivery.yml
@@ -49,7 +49,7 @@ jobs:
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main' &&
-        contains(github.event.workflow_run.head_commit.message, '[native-mobile-release-20260831]')
+        contains(github.event.workflow_run.head_commit.message, '[native-ios-release-retry-20260831]')
       )
     name: Resolve Apple release identity
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
-          RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
+          RELEASE_TARGET: ${{ steps.release.outputs.release_target }}
         run: bash .github/scripts/require-release-source-gates.sh
 
   macos-electron:


### PR DESCRIPTION
## Summary

- fix the Apple release gate to read the resolve step's output within the same job
- change only the one-time retry marker so this merge triggers Apple again
- leave the already-running Android release path untouched

The previous Apple workflow stopped before any package build because its gate target was empty. This is a workflow-only correction.