### PR TITLE
ci: retrigger exact-SHA Apple release [native-ios-release-retry2-20260831]

### DIFF
--- a/.github/workflows/apple-store-delivery.yml
+++ b/.github/workflows/apple-store-delivery.yml
@@ -49,7 +49,7 @@ jobs:
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main' &&
-        contains(github.event.workflow_run.head_commit.message, '[native-ios-release-retry-20260831]')
+        contains(github.event.workflow_run.head_commit.message, '[native-ios-release-retry2-20260831]')
       )
     name: Resolve Apple release identity
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- update only the one-time Apple workflow_run marker
- put the marker in the commit message so squash merge preserves it
- trigger no Android release

This follows the already merged Apple gate-output fix in #2232.