### PR TITLE
ci: publish final same-SHA mobile packages [full-platform-release-final-20260831]

### DIFF
--- a/.github/workflows/apple-store-delivery.yml
+++ b/.github/workflows/apple-store-delivery.yml
@@ -69,7 +69,7 @@ jobs:
             if [ "$UPSTREAM_EVENT" = 'push' ] &&
                [ "$UPSTREAM_CONCLUSION" = 'success' ] &&
                [ "$UPSTREAM_BRANCH" = 'main' ] &&
-               [[ "$UPSTREAM_MESSAGE" == *"[native-ios-release-retry3-20260831]"* ]]; then
+               [[ "$UPSTREAM_MESSAGE" == *"[full-platform-release-final-20260831]"* ]]; then
               should_release=true
             fi
           fi

--- a/.github/workflows/native-android-release.yml
+++ b/.github/workflows/native-android-release.yml
@@ -26,7 +26,7 @@ jobs:
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main' &&
-        contains(github.event.workflow_run.head_commit.message, '[native-mobile-release-20260831]')
+        contains(github.event.workflow_run.head_commit.message, '[full-platform-release-final-20260831]')
       )
     name: Build and publish signed Android APK
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- use one final marker for both automatic Android and Apple release paths
- keep the robust Apple selector and exact workflow_run source pin
- publish both signed mobile packages from the same post-merge main SHA
- do not trigger either mobile release for ordinary future pushes

This is the final release orchestration change; the marker is present in both commits on this branch so squash merge preserves it.