### PR TITLE
fix(mobile): align iOS and Android chat UX with Telegram-style native flows

### DIFF
--- a/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
+++ b/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
@@ -3,6 +3,7 @@ package com.ombhrum.fabushi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -37,12 +38,10 @@ class FabushiScreenTest {
         compose.onNodeWithTag(TestTags.HomeSearchButton).assertIsDisplayed()
         compose.onNodeWithTag(TestTags.AddButton).assertIsDisplayed()
         compose.onNodeWithTag(TestTags.ConversationList).assertIsDisplayed()
-        compose.onNodeWithTag(TestTags.ConversationRow).assertIsDisplayed()
-        compose.onNodeWithText("Chief of Staff").assertIsDisplayed()
-
-        compose.onNodeWithTag(TestTags.HomeSearchButton).performClick()
-        compose.onNodeWithTag(TestTags.HomeSearchField).performTextInput("Chief")
-        compose.onNodeWithText("Chief of Staff").assertIsDisplayed()
+        compose.onNodeWithTag(TestTags.ConversationRow).assertDoesNotExist()
+        compose.onNodeWithTag(TestTags.AddButton).performClick()
+        compose.onNodeWithText("新对话 1").assertIsDisplayed()
+        compose.onNodeWithText("Chief of Staff").assertDoesNotExist()
     }
 
     @Test
@@ -64,7 +63,7 @@ class FabushiScreenTest {
             )
         }
 
-        compose.onNodeWithTag(TestTags.AddButton).performClick()
+        compose.onNodeWithTag(TestTags.ProfileAvatar).performClick()
         compose.onNodeWithTag(TestTags.MarketplaceEntry).assertIsDisplayed().performClick()
         compose.onNodeWithTag(TestTags.RuntimeBadge).assertTextContains("Compose", substring = true)
         compose.onNodeWithTag(TestTags.HostStatus).assertIsDisplayed()
@@ -95,7 +94,7 @@ class FabushiScreenTest {
             )
         }
 
-        compose.onNodeWithTag(TestTags.AddButton).performClick()
+        compose.onNodeWithTag(TestTags.ProfileAvatar).performClick()
         compose.onNodeWithTag(TestTags.RemoteComputerEntry).assertIsDisplayed().performClick()
         compose.onNodeWithTag(TestTags.RemoteComputerSurface).assertIsDisplayed()
         compose.onNodeWithTag(TestTags.RemoteComputerClose).assertIsDisplayed().performClick()
@@ -172,10 +171,10 @@ class FabushiScreenTest {
         compose.waitForIdle()
         var snapshot = surface.snapshot()
         assertEquals("home", snapshot.screen)
-        assertEquals(TestTags.AddButton, surface.find(agentId = TestTags.AddButton).single().agentId)
+        assertEquals(TestTags.ProfileAvatar, surface.find(agentId = TestTags.ProfileAvatar).single().agentId)
 
         compose.runOnIdle {
-            surface.action(snapshot.generation, TestTags.AddButton, "invoke")
+            surface.action(snapshot.generation, TestTags.ProfileAvatar, "invoke")
         }
         compose.waitForIdle()
         snapshot = surface.snapshot()

--- a/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
+++ b/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
@@ -40,7 +40,10 @@ class FabushiScreenTest {
         compose.onNodeWithTag(TestTags.ConversationList).assertIsDisplayed()
         compose.onNodeWithTag(TestTags.ConversationRow).assertDoesNotExist()
         compose.onNodeWithTag(TestTags.AddButton).performClick()
-        compose.onNodeWithText("新对话 1").assertIsDisplayed()
+        compose.onNodeWithText("新建私聊").assertIsDisplayed().performClick()
+        compose.onNodeWithTag(TestTags.ComposeName).performTextInput("测试联系人")
+        compose.onNodeWithTag(TestTags.ComposeCreate).performClick()
+        compose.onNodeWithText("测试联系人").assertIsDisplayed()
         compose.onNodeWithText("Chief of Staff").assertDoesNotExist()
     }
 

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -39,6 +40,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -64,6 +66,8 @@ object TestTags {
     const val AddButton = "home-add-button"
     const val ConversationList = "conversation-list"
     const val ConversationRow = "conversation-chief-of-staff"
+    const val ComposeName = "compose-name"
+    const val ComposeCreate = "compose-create"
     const val MarketplaceEntry = "marketplace-entry"
     const val RemoteComputerEntry = "remote-computer-entry"
     const val RemoteComputerSurface = "remote-computer-surface"
@@ -88,13 +92,26 @@ object TestTags {
 }
 
 private enum class MobileDestination { HOME, MARKETPLACE, REMOTE_COMPUTER }
+private enum class ConversationKind(val label: String) { DIRECT("私聊"), GROUP("群组"), CHANNEL("频道"), BOT("Bot") }
 
 private data class ConversationSummary(
     val id: String,
-    val title: String,
-    val preview: String,
-    val time: String,
+    var title: String,
+    var preview: String,
+    var time: String,
     val badge: String,
+    val kind: ConversationKind,
+    var unreadCount: Int = 0,
+    var isPinned: Boolean = false,
+    var isMuted: Boolean = false,
+    var isArchived: Boolean = false,
+)
+
+private data class ChatMessage(
+    val id: String,
+    val text: String,
+    val outgoing: Boolean,
+    val time: String,
 )
 
 private val homeBackground = Color(0xFF0B0B0C)
@@ -306,146 +323,148 @@ private fun ConversationHome(
 ) {
     var showSearch by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
+    var showComposeMenu by remember { mutableStateOf(false) }
+    var pendingKind by remember { mutableStateOf<ConversationKind?>(null) }
+    var composeName by remember { mutableStateOf("") }
     var selectedConversation by remember { mutableStateOf<ConversationSummary?>(null) }
     val conversations = remember { mutableStateListOf<ConversationSummary>() }
-    val filteredConversations = conversations.filter { conversation ->
-        searchQuery.isBlank() ||
-            conversation.title.contains(searchQuery, ignoreCase = true) ||
-            conversation.preview.contains(searchQuery, ignoreCase = true)
-    }
+    val messageStore = remember { mutableStateMapOf<String, List<ChatMessage>>() }
+    val filteredConversations = conversations
+        .filter { !it.isArchived }
+        .sortedWith(compareByDescending<ConversationSummary> { it.isPinned }.thenByDescending { it.time })
+        .filter { conversation -> searchQuery.isBlank() || conversation.title.contains(searchQuery, true) || conversation.preview.contains(searchQuery, true) }
 
-    if (selectedConversation != null) {
+    selectedConversation?.let { conversation ->
         ConversationDetail(
-            conversation = selectedConversation!!,
+            conversation = conversation,
+            messages = messageStore[conversation.id].orEmpty(),
             onBack = { selectedConversation = null },
+            onSend = { text ->
+                val next = ChatMessage(System.nanoTime().toString(), text, true, "现在")
+                messageStore[conversation.id] = messageStore[conversation.id].orEmpty() + next
+                val index = conversations.indexOfFirst { it.id == conversation.id }
+                if (index >= 0) {
+                    conversations[index] = conversations[index].copy(preview = text, time = "现在")
+                    selectedConversation = conversations[index]
+                }
+            },
+            onToggleMute = {
+                val index = conversations.indexOfFirst { it.id == conversation.id }
+                if (index >= 0) { conversations[index] = conversations[index].copy(isMuted = !conversations[index].isMuted); selectedConversation = conversations[index] }
+            },
+            onTogglePin = {
+                val index = conversations.indexOfFirst { it.id == conversation.id }
+                if (index >= 0) { conversations[index] = conversations[index].copy(isPinned = !conversations[index].isPinned); selectedConversation = conversations[index] }
+            },
+            onArchive = {
+                val index = conversations.indexOfFirst { it.id == conversation.id }
+                if (index >= 0) conversations[index] = conversations[index].copy(isArchived = true)
+                selectedConversation = null
+            },
         )
         return
+    }
+
+    if (pendingKind != null) {
+        AlertDialog(
+            onDismissRequest = { pendingKind = null; composeName = "" },
+            title = { Text("新建${pendingKind!!.label}") },
+            text = {
+                OutlinedTextField(value = composeName, onValueChange = { composeName = it }, modifier = Modifier.testTag(TestTags.ComposeName), singleLine = true, label = { Text("名称") })
+            },
+            confirmButton = {
+                Button(onClick = {
+                    val title = composeName.trim()
+                    if (title.isNotEmpty()) {
+                        val kind = pendingKind!!
+                        val conversation = ConversationSummary(
+                            id = "${kind.name.lowercase()}-${System.nanoTime()}", title = title,
+                            preview = "开始一段新的对话", time = "现在", badge = title.take(1).uppercase(), kind = kind,
+                        )
+                        conversations.add(0, conversation)
+                        pendingKind = null; composeName = ""; selectedConversation = conversation
+                    }
+                }, modifier = Modifier.testTag(TestTags.ComposeCreate), enabled = composeName.isNotBlank()) { Text("创建") }
+            },
+            dismissButton = { OutlinedButton(onClick = { pendingKind = null; composeName = "" }) { Text("取消") } },
+        )
     }
 
     Scaffold(
         modifier = Modifier.fillMaxSize().testTag(TestTags.AppShell),
         containerColor = homeBackground,
-        contentColor = homePrimaryText,
+        floatingActionButton = {
+            Box {
+                FloatingActionButton(
+                    onClick = { showComposeMenu = true },
+                    modifier = Modifier.testTag(TestTags.AddButton),
+                    containerColor = homeAccent,
+                    contentColor = Color.Black,
+                ) { PlusGlyph() }
+                DropdownMenu(expanded = showComposeMenu, onDismissRequest = { showComposeMenu = false }, containerColor = homeSurface) {
+                    ConversationKind.entries.forEach { kind ->
+                        DropdownMenuItem(text = { Text("新建${kind.label}", color = homePrimaryText) }, onClick = { showComposeMenu = false; pendingKind = kind })
+                    }
+                    DropdownMenuItem(text = { Text("联系人分组", color = homePrimaryText) }, onClick = { showComposeMenu = false })
+                }
+            }
+        },
     ) { padding ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .testTag(TestTags.ConversationList),
-        ) {
+        LazyColumn(Modifier.fillMaxSize().padding(padding).testTag(TestTags.ConversationList)) {
             item {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 24.dp, end = 20.dp, top = 10.dp, bottom = 18.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
+                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Box {
                         ProfileAvatar(onClick = { onShowAddMenuChange(true) })
-                        DropdownMenu(
-                            expanded = showAddMenu,
-                            onDismissRequest = { onShowAddMenuChange(false) },
-                            containerColor = homeSurface,
-                        ) {
-                            DropdownMenuItem(
-                                modifier = Modifier.testTag(TestTags.RemoteComputerEntry),
-                                text = { Text("我的电脑", color = homePrimaryText) },
-                                onClick = { onShowAddMenuChange(false); onOpenRemoteComputer() },
-                            )
-                            DropdownMenuItem(
-                                modifier = Modifier.testTag(TestTags.MarketplaceEntry),
-                                text = { Text("插件市场", color = homePrimaryText) },
-                                onClick = { onShowAddMenuChange(false); onOpenMarketplace() },
-                            )
-                            if (updateState.phase != AndroidUpdatePhase.DISABLED) {
-                                DropdownMenuItem(
-                                    text = { Text("检查更新", color = homePrimaryText) },
-                                    onClick = { onShowAddMenuChange(false); onCheckUpdate() },
-                                )
-                            }
+                        DropdownMenu(expanded = showAddMenu, onDismissRequest = { onShowAddMenuChange(false) }, containerColor = homeSurface) {
+                            DropdownMenuItem(text = { Text("聊天", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("联系人", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("Bots", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("群组", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("频道", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("通话", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("收藏", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("归档", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(text = { Text("文件夹", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false) })
+                            DropdownMenuItem(modifier = Modifier.testTag(TestTags.MarketplaceEntry), text = { Text("Mini Apps / 插件市场", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false); onOpenMarketplace() })
+                            DropdownMenuItem(modifier = Modifier.testTag(TestTags.RemoteComputerEntry), text = { Text("我的电脑", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false); onOpenRemoteComputer() })
+                            if (updateState.phase != AndroidUpdatePhase.DISABLED) DropdownMenuItem(text = { Text("检查更新", color = homePrimaryText) }, onClick = { onShowAddMenuChange(false); onCheckUpdate() })
                         }
                     }
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        CircularActionButton(
-                            tag = TestTags.HomeSearchButton,
-                            description = "搜索对话",
-                            onClick = { showSearch = !showSearch },
-                        ) { SearchGlyph() }
-                        CircularActionButton(
-                            tag = TestTags.AddButton,
-                            description = "新建对话",
-                            onClick = {
-                                val next = conversations.size + 1
-                                val conversation = ConversationSummary(
-                                    id = "new-$next",
-                                    title = "新对话 $next",
-                                    preview = "开始一段新的对话",
-                                    time = "现在",
-                                    badge = "✦",
-                                )
-                                conversations.add(0, conversation)
-                                selectedConversation = conversation
-                            },
-                        ) { PlusGlyph() }
-                    }
+                    Text("聊天", color = homePrimaryText, fontWeight = FontWeight.SemiBold, fontSize = 20.sp)
+                    CircularActionButton(TestTags.HomeSearchButton, if (showSearch) "关闭搜索" else "搜索对话", { showSearch = !showSearch; if (!showSearch) searchQuery = "" }) { SearchGlyph() }
                 }
             }
-
-            if (showSearch) {
-                item {
-                    OutlinedTextField(
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 20.dp, vertical = 2.dp)
-                            .testTag(TestTags.HomeSearchField),
-                        singleLine = true,
-                        placeholder = { Text("搜索消息", color = homeSecondaryText) },
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = homePrimaryText,
-                            unfocusedTextColor = homePrimaryText,
-                            cursorColor = homeAccent,
-                            focusedBorderColor = Color(0xFF4A4A4E),
-                            unfocusedBorderColor = homeBorder,
-                            focusedContainerColor = homeSurface,
-                            unfocusedContainerColor = homeSurface,
-                        ),
-                        shape = RoundedCornerShape(16.dp),
-                    )
-                    Spacer(Modifier.height(10.dp))
+            if (showSearch) item {
+                OutlinedTextField(
+                    value = searchQuery, onValueChange = { searchQuery = it },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp).testTag(TestTags.HomeSearchField),
+                    singleLine = true, placeholder = { Text("搜索", color = homeSecondaryText) },
+                    colors = OutlinedTextFieldDefaults.colors(focusedTextColor = homePrimaryText, unfocusedTextColor = homePrimaryText, focusedContainerColor = homeSurface, unfocusedContainerColor = homeSurface),
+                    shape = RoundedCornerShape(14.dp),
+                )
+            }
+            if (shouldShowUpdateBanner(updateState.phase)) item { UpdateBanner(updateState, onCheckUpdate, onInstallUpdate) }
+            if (conversations.any { it.isArchived } && searchQuery.isBlank()) item {
+                Row(Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Text("▣", color = homeSecondaryText); Text("已归档", color = homePrimaryText, modifier = Modifier.padding(start = 12.dp).weight(1f)); Text("${conversations.count { it.isArchived }}", color = homeSecondaryText)
                 }
             }
-
-            if (shouldShowUpdateBanner(updateState.phase)) {
-                item {
-                    UpdateBanner(
-                        state = updateState,
-                        onCheckUpdate = onCheckUpdate,
-                        onInstallUpdate = onInstallUpdate,
-                    )
+            if (filteredConversations.isEmpty()) item {
+                Column(Modifier.fillMaxWidth().padding(vertical = 88.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(if (searchQuery.isBlank()) "还没有对话" else "没有找到结果", color = homeSecondaryText, fontWeight = FontWeight.SemiBold)
+                    Text(if (searchQuery.isBlank()) "点击右下角写消息按钮开始聊天" else "尝试其他关键词", color = homeSecondaryText, style = MaterialTheme.typography.bodySmall)
                 }
+            } else items(filteredConversations, key = { it.id }) { conversation ->
+                ConversationRow(conversation, onClick = {
+                    val index = conversations.indexOfFirst { it.id == conversation.id }
+                    if (index >= 0) conversations[index] = conversations[index].copy(unreadCount = 0)
+                    selectedConversation = conversations.firstOrNull { it.id == conversation.id } ?: conversation
+                })
             }
-
-            if (filteredConversations.isEmpty()) {
-                item {
-                    Column(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 70.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Text(if (searchQuery.isBlank()) "还没有对话" else "没有找到匹配的消息", color = homeSecondaryText, fontWeight = FontWeight.SemiBold)
-                        Text(if (searchQuery.isBlank()) "点右上角写消息按钮开始新的对话" else "换个关键词试试", color = homeSecondaryText, style = MaterialTheme.typography.bodySmall)
-                    }
-                }
-            } else {
-                items(filteredConversations, key = { it.id }) { conversation ->
-                    ConversationRow(conversation, onClick = { selectedConversation = conversation })
-                }
-            }
-
-            item { Spacer(Modifier.height(32.dp)) }
+            item { Spacer(Modifier.height(88.dp)) }
         }
     }
 }
@@ -527,7 +546,17 @@ private fun PlusGlyph() {
 
 
 @Composable
-private fun ConversationDetail(conversation: ConversationSummary, onBack: () -> Unit) {
+private fun ConversationDetail(
+    conversation: ConversationSummary,
+    messages: List<ChatMessage>,
+    onBack: () -> Unit,
+    onSend: (String) -> Unit,
+    onToggleMute: () -> Unit,
+    onTogglePin: () -> Unit,
+    onArchive: () -> Unit,
+) {
+    var draft by remember(conversation.id) { mutableStateOf("") }
+    var showMenu by remember { mutableStateOf(false) }
     Scaffold(containerColor = homeBackground) { padding ->
         Column(Modifier.fillMaxSize().padding(padding)) {
             Row(
@@ -535,27 +564,56 @@ private fun ConversationDetail(conversation: ConversationSummary, onBack: () -> 
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text("‹", color = homePrimaryText, fontSize = 34.sp, modifier = Modifier.clickable(onClick = onBack).padding(8.dp))
-                Text(conversation.title, color = homePrimaryText, fontWeight = FontWeight.SemiBold, fontSize = 18.sp)
+                Column(Modifier.weight(1f)) {
+                    Text(conversation.title, color = homePrimaryText, fontWeight = FontWeight.SemiBold, fontSize = 18.sp)
+                    Text(conversation.kind.label, color = homeSecondaryText, style = MaterialTheme.typography.bodySmall)
+                }
+                Box {
+                    Text("⋯", color = homePrimaryText, fontSize = 28.sp, modifier = Modifier.clickable { showMenu = true }.padding(8.dp))
+                    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }, containerColor = homeSurface) {
+                        DropdownMenuItem(text = { Text(if (conversation.isMuted) "取消静音" else "静音", color = homePrimaryText) }, onClick = { showMenu = false; onToggleMute() })
+                        DropdownMenuItem(text = { Text(if (conversation.isPinned) "取消置顶" else "置顶", color = homePrimaryText) }, onClick = { showMenu = false; onTogglePin() })
+                        DropdownMenuItem(text = { Text("归档", color = homePrimaryText) }, onClick = { showMenu = false; onArchive() })
+                    }
+                }
             }
-            Spacer(Modifier.weight(1f))
-            Text(
-                "开始与 ${conversation.title} 对话",
-                color = homeSecondaryText,
-                modifier = Modifier.align(Alignment.CenterHorizontally).padding(24.dp),
-            )
-            Spacer(Modifier.weight(1f))
-            OutlinedTextField(
-                value = "",
-                onValueChange = {},
-                modifier = Modifier.fillMaxWidth().padding(12.dp),
-                placeholder = { Text("消息", color = homeSecondaryText) },
-                singleLine = true,
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedTextColor = homePrimaryText, unfocusedTextColor = homePrimaryText,
-                    focusedContainerColor = homeSurface, unfocusedContainerColor = homeSurface,
-                ),
-                shape = RoundedCornerShape(22.dp),
-            )
+            LazyColumn(Modifier.weight(1f).fillMaxWidth().padding(horizontal = 10.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (messages.isEmpty()) item {
+                    Text("开始与 ${conversation.title} 对话", color = homeSecondaryText, modifier = Modifier.fillMaxWidth().padding(top = 72.dp))
+                }
+                items(messages, key = { it.id }) { message ->
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = if (message.outgoing) Arrangement.End else Arrangement.Start) {
+                        Column(
+                            Modifier
+                                .fillMaxWidth(0.78f)
+                                .background(if (message.outgoing) homeAccent.copy(alpha = 0.18f) else homeSurface, RoundedCornerShape(16.dp))
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                        ) {
+                            Text(message.text, color = homePrimaryText)
+                            Text(if (message.outgoing) "${message.time}  ✓✓" else message.time, color = homeSecondaryText, style = MaterialTheme.typography.bodySmall, modifier = Modifier.align(Alignment.End))
+                        }
+                    }
+                }
+            }
+            Row(Modifier.fillMaxWidth().padding(8.dp), verticalAlignment = Alignment.Bottom) {
+                Text("⌕", color = homeSecondaryText, fontSize = 22.sp, modifier = Modifier.padding(10.dp))
+                OutlinedTextField(
+                    value = draft, onValueChange = { draft = it },
+                    modifier = Modifier.weight(1f), placeholder = { Text("消息", color = homeSecondaryText) },
+                    maxLines = 5,
+                    colors = OutlinedTextFieldDefaults.colors(focusedTextColor = homePrimaryText, unfocusedTextColor = homePrimaryText, focusedContainerColor = homeSurface, unfocusedContainerColor = homeSurface),
+                    shape = RoundedCornerShape(22.dp),
+                )
+                Text(
+                    if (draft.isBlank()) "●" else "➤",
+                    color = if (draft.isBlank()) homeSecondaryText else homeAccent,
+                    fontSize = 22.sp,
+                    modifier = Modifier.clickable {
+                        val text = draft.trim()
+                        if (text.isNotEmpty()) { onSend(text); draft = "" }
+                    }.padding(10.dp),
+                )
+            }
         }
     }
 }
@@ -567,7 +625,7 @@ private fun ConversationRow(conversation: ConversationSummary, onClick: () -> Un
             .fillMaxWidth()
             .clickable(onClick = onClick)
             .padding(start = 30.dp, end = 24.dp, top = 13.dp, bottom = 13.dp)
-            .then(if (conversation.id == "chief-of-staff") Modifier.testTag(TestTags.ConversationRow) else Modifier),
+            ,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
@@ -580,14 +638,14 @@ private fun ConversationRow(conversation: ConversationSummary, onClick: () -> Un
             modifier = Modifier.weight(1f).padding(start = 18.dp, end = 12.dp),
             verticalArrangement = Arrangement.spacedBy(5.dp),
         ) {
-            Text(
-                conversation.title,
-                color = homePrimaryText,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    conversation.title, color = homePrimaryText, style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f),
+                )
+                if (conversation.isMuted) Text("⌁", color = homeSecondaryText, fontSize = 12.sp)
+                if (conversation.isPinned) Text("⌖", color = homeSecondaryText, fontSize = 12.sp)
+            }
             Text(
                 conversation.preview,
                 color = homeSecondaryText,
@@ -596,11 +654,12 @@ private fun ConversationRow(conversation: ConversationSummary, onClick: () -> Un
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        Text(
-            conversation.time,
-            color = Color(0xFF56565B),
-            style = MaterialTheme.typography.bodySmall,
-        )
+        Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(5.dp)) {
+            Text(conversation.time, color = Color(0xFF56565B), style = MaterialTheme.typography.bodySmall)
+            if (conversation.unreadCount > 0) {
+                Text("${conversation.unreadCount}", color = Color.Black, fontWeight = FontWeight.Bold, fontSize = 11.sp, modifier = Modifier.background(homeAccent, CircleShape).padding(horizontal = 6.dp, vertical = 2.dp))
+            }
+        }
     }
 }
 

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -151,13 +151,8 @@ fun FabushiScreen(
             MobileDestination.HOME -> {
                 element(TestTags.AppShell, "application", "Fabushi")
                 element(TestTags.HomeSearchButton, "button", "搜索对话")
-                element(
-                    TestTags.AddButton,
-                    "button",
-                    "添加",
-                    action = FabushiAppAgentSurface.Action(setOf("invoke")) { showAddMenu = true },
-                )
-                element(TestTags.ConversationRow, "button", "Chief of Staff")
+                element(TestTags.ProfileAvatar, "button", "个人菜单", action = FabushiAppAgentSurface.Action(setOf("invoke")) { showAddMenu = true })
+                element(TestTags.AddButton, "button", "新建对话")
                 if (showAddMenu) {
                     element(
                         TestTags.MarketplaceEntry,
@@ -310,21 +305,20 @@ private fun ConversationHome(
 ) {
     var showSearch by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
-    val conversations = remember {
-        mutableStateListOf(
-            ConversationSummary(
-                id = "chief-of-staff",
-                title = "Chief of Staff",
-                preview = "I can also pull in email, Slack, or other tools…",
-                time = "02:41",
-                badge = "••",
-            ),
-        )
-    }
+    var selectedConversation by remember { mutableStateOf<ConversationSummary?>(null) }
+    val conversations = remember { mutableStateListOf<ConversationSummary>() }
     val filteredConversations = conversations.filter { conversation ->
         searchQuery.isBlank() ||
             conversation.title.contains(searchQuery, ignoreCase = true) ||
             conversation.preview.contains(searchQuery, ignoreCase = true)
+    }
+
+    if (selectedConversation != null) {
+        ConversationDetail(
+            conversation = selectedConversation!!,
+            onBack = { selectedConversation = null },
+        )
+        return
     }
 
     Scaffold(
@@ -346,68 +340,53 @@ private fun ConversationHome(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    ProfileAvatar()
+                    Box {
+                        ProfileAvatar(onClick = { onShowAddMenuChange(true) })
+                        DropdownMenu(
+                            expanded = showAddMenu,
+                            onDismissRequest = { onShowAddMenuChange(false) },
+                            containerColor = homeSurface,
+                        ) {
+                            DropdownMenuItem(
+                                modifier = Modifier.testTag(TestTags.RemoteComputerEntry),
+                                text = { Text("我的电脑", color = homePrimaryText) },
+                                onClick = { onShowAddMenuChange(false); onOpenRemoteComputer() },
+                            )
+                            DropdownMenuItem(
+                                modifier = Modifier.testTag(TestTags.MarketplaceEntry),
+                                text = { Text("插件市场", color = homePrimaryText) },
+                                onClick = { onShowAddMenuChange(false); onOpenMarketplace() },
+                            )
+                            if (updateState.phase != AndroidUpdatePhase.DISABLED) {
+                                DropdownMenuItem(
+                                    text = { Text("检查更新", color = homePrimaryText) },
+                                    onClick = { onShowAddMenuChange(false); onCheckUpdate() },
+                                )
+                            }
+                        }
+                    }
                     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                         CircularActionButton(
                             tag = TestTags.HomeSearchButton,
                             description = "搜索对话",
                             onClick = { showSearch = !showSearch },
                         ) { SearchGlyph() }
-                        Box {
-                            CircularActionButton(
-                                tag = TestTags.AddButton,
-                                description = "添加",
-                                onClick = { onShowAddMenuChange(true) },
-                            ) { PlusGlyph() }
-                            DropdownMenu(
-                                expanded = showAddMenu,
-                                onDismissRequest = { onShowAddMenuChange(false) },
-                                containerColor = homeSurface,
-                            ) {
-                                DropdownMenuItem(
-                                    text = { Text("新建对话", color = homePrimaryText) },
-                                    onClick = {
-                                        onShowAddMenuChange(false)
-                                        val next = conversations.size + 1
-                                        conversations.add(
-                                            0,
-                                            ConversationSummary(
-                                                id = "new-$next",
-                                                title = "新对话 $next",
-                                                preview = "开始一段新的对话",
-                                                time = "现在",
-                                                badge = "+",
-                                            ),
-                                        )
-                                    },
+                        CircularActionButton(
+                            tag = TestTags.AddButton,
+                            description = "新建对话",
+                            onClick = {
+                                val next = conversations.size + 1
+                                val conversation = ConversationSummary(
+                                    id = "new-$next",
+                                    title = "新对话 $next",
+                                    preview = "开始一段新的对话",
+                                    time = "现在",
+                                    badge = "✦",
                                 )
-                                DropdownMenuItem(
-                                    modifier = Modifier.testTag(TestTags.RemoteComputerEntry),
-                                    text = { Text("我的电脑", color = homePrimaryText) },
-                                    onClick = {
-                                        onShowAddMenuChange(false)
-                                        onOpenRemoteComputer()
-                                    },
-                                )
-                                DropdownMenuItem(
-                                    modifier = Modifier.testTag(TestTags.MarketplaceEntry),
-                                    text = { Text("插件市场", color = homePrimaryText) },
-                                    onClick = {
-                                        onShowAddMenuChange(false)
-                                        onOpenMarketplace()
-                                    },
-                                )
-                                if (updateState.phase != AndroidUpdatePhase.DISABLED) {
-                                    DropdownMenuItem(
-                                        text = { Text("检查更新", color = homePrimaryText) },
-                                        onClick = {
-                                            onShowAddMenuChange(false)
-                                            onCheckUpdate()
-                                        },
-                                    )
-                                }
-                            }
-                        }
+                                conversations.add(0, conversation)
+                                selectedConversation = conversation
+                            },
+                        ) { PlusGlyph() }
                     }
                 }
             }
@@ -450,15 +429,18 @@ private fun ConversationHome(
 
             if (filteredConversations.isEmpty()) {
                 item {
-                    Text(
-                        "没有找到匹配的消息",
-                        color = homeSecondaryText,
-                        modifier = Modifier.padding(horizontal = 30.dp, vertical = 28.dp),
-                    )
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 70.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(if (searchQuery.isBlank()) "还没有对话" else "没有找到匹配的消息", color = homeSecondaryText, fontWeight = FontWeight.SemiBold)
+                        Text(if (searchQuery.isBlank()) "点右上角写消息按钮开始新的对话" else "换个关键词试试", color = homeSecondaryText, style = MaterialTheme.typography.bodySmall)
+                    }
                 }
             } else {
                 items(filteredConversations, key = { it.id }) { conversation ->
-                    ConversationRow(conversation)
+                    ConversationRow(conversation, onClick = { selectedConversation = conversation })
                 }
             }
 
@@ -468,13 +450,14 @@ private fun ConversationHome(
 }
 
 @Composable
-private fun ProfileAvatar() {
+private fun ProfileAvatar(onClick: () -> Unit) {
     Box(
         modifier = Modifier
             .size(56.dp)
             .background(homeSurface, CircleShape)
             .border(1.dp, homeBorder, CircleShape)
             .testTag(TestTags.ProfileAvatar)
+            .clickable(onClick = onClick)
             .semantics { contentDescription = "个人头像" },
         contentAlignment = Alignment.Center,
     ) {
@@ -541,12 +524,47 @@ private fun PlusGlyph() {
     }
 }
 
+
 @Composable
-private fun ConversationRow(conversation: ConversationSummary) {
+private fun ConversationDetail(conversation: ConversationSummary, onBack: () -> Unit) {
+    Scaffold(containerColor = homeBackground) { padding ->
+        Column(Modifier.fillMaxSize().padding(padding)) {
+            Row(
+                Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("‹", color = homePrimaryText, fontSize = 34.sp, modifier = Modifier.clickable(onClick = onBack).padding(8.dp))
+                Text(conversation.title, color = homePrimaryText, fontWeight = FontWeight.SemiBold, fontSize = 18.sp)
+            }
+            Spacer(Modifier.weight(1f))
+            Text(
+                "开始与 ${conversation.title} 对话",
+                color = homeSecondaryText,
+                modifier = Modifier.align(Alignment.CenterHorizontally).padding(24.dp),
+            )
+            Spacer(Modifier.weight(1f))
+            OutlinedTextField(
+                value = "",
+                onValueChange = {},
+                modifier = Modifier.fillMaxWidth().padding(12.dp),
+                placeholder = { Text("消息", color = homeSecondaryText) },
+                singleLine = true,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = homePrimaryText, unfocusedTextColor = homePrimaryText,
+                    focusedContainerColor = homeSurface, unfocusedContainerColor = homeSurface,
+                ),
+                shape = RoundedCornerShape(22.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConversationRow(conversation: ConversationSummary, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { }
+            .clickable(onClick = onClick)
             .padding(start = 30.dp, end = 24.dp, top = 13.dp, bottom = 13.dp)
             .then(if (conversation.id == "chief-of-staff") Modifier.testTag(TestTags.ConversationRow) else Modifier),
         verticalAlignment = Alignment.CenterVertically,

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -21,15 +21,8 @@ struct ContentView: View {
     @State private var destination: MobileDestination = .home
     @State private var isSearching = false
     @State private var homeQuery = ""
-    @State private var conversations: [ConversationSummary] = [
-        ConversationSummary(
-            id: "chief-of-staff",
-            title: "Chief of Staff",
-            preview: "I can also pull in email, Slack, or other tools…",
-            time: "02:41",
-            badge: "••"
-        )
-    ]
+    @State private var selectedConversation: ConversationSummary?
+    @State private var conversations: [ConversationSummary] = []
 
     var body: some View {
         Group {
@@ -146,7 +139,7 @@ struct ContentView: View {
                         action: .init(allowed: ["setValue"]) { value in homeQuery = value ?? "" }
                     )
                 }
-                add("home-add-button", role: "button", name: "添加")
+                add("home-add-button", role: "button", name: "新建对话", action: .init(allowed: ["invoke"]) { _ in addConversation() })
                 add(
                     "marketplace-entry",
                     role: "menuitem",
@@ -159,7 +152,6 @@ struct ContentView: View {
                     name: "我的电脑",
                     action: .init(allowed: ["invoke"]) { _ in destination = .remoteComputer }
                 )
-                add("conversation-chief-of-staff", role: "button", name: "Chief of Staff")
             case .marketplace:
                 screen = "marketplace"
                 add(
@@ -236,29 +228,19 @@ struct ContentView: View {
             ScrollView {
                 LazyVStack(spacing: 0) {
                     HStack(spacing: 12) {
-                        avatar
-                        Spacer()
-                        circleButton(systemName: "magnifyingglass", identifier: "home-search-button") {
-                            withAnimation(.easeInOut(duration: 0.18)) { isSearching.toggle() }
-                        }
                         Menu {
-                            Button("新建对话") { addConversation() }
                             Button("我的电脑") { destination = .remoteComputer }
                                 .accessibilityIdentifier("remote-computer-entry")
                             Button("插件市场") { destination = .marketplace }
                                 .accessibilityIdentifier("marketplace-entry")
-                        } label: {
-                            ZStack {
-                                Circle()
-                                    .fill(Color(red: 0.063, green: 0.063, blue: 0.067))
-                                    .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 1))
-                                Image(systemName: "plus")
-                                    .font(.system(size: 23, weight: .regular))
-                                    .foregroundStyle(.white)
-                            }
-                            .frame(width: 54, height: 54)
+                        } label: { avatar }
+                        Spacer()
+                        circleButton(systemName: "magnifyingglass", identifier: "home-search-button") {
+                            withAnimation(.easeInOut(duration: 0.18)) { isSearching.toggle() }
                         }
-                        .accessibilityIdentifier("home-add-button")
+                        circleButton(systemName: "square.and.pencil", identifier: "home-add-button") {
+                            addConversation()
+                        }
                     }
                     .padding(.horizontal, 24)
                     .padding(.top, 10)
@@ -283,11 +265,17 @@ struct ContentView: View {
                             conversationRow(conversation)
                         }
                         if filteredConversations.isEmpty {
-                            Text("没有找到匹配的消息")
-                                .foregroundStyle(Color.white.opacity(0.48))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, 30)
-                                .padding(.vertical, 28)
+                            VStack(spacing: 10) {
+                                Image(systemName: "bubble.left.and.bubble.right")
+                                    .font(.system(size: 34, weight: .regular))
+                                Text(homeQuery.isEmpty ? "还没有对话" : "没有找到匹配的消息")
+                                    .font(.headline)
+                                Text(homeQuery.isEmpty ? "点右上角写消息按钮开始新的对话" : "换个关键词试试")
+                                    .font(.subheadline)
+                            }
+                            .foregroundStyle(Color.white.opacity(0.48))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 70)
                         }
                     }
                     .accessibilityIdentifier("conversation-list")
@@ -302,6 +290,33 @@ struct ContentView: View {
             }
         }
         .accessibilityIdentifier("app-shell")
+        .fullScreenCover(item: $selectedConversation) { conversation in
+            NavigationStack {
+                VStack(spacing: 0) {
+                    Spacer()
+                    Text("开始与 \(conversation.title) 对话")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    HStack(spacing: 10) {
+                        TextField("消息", text: .constant(""))
+                            .padding(.horizontal, 14)
+                            .frame(height: 44)
+                            .background(Color.secondary.opacity(0.12), in: Capsule())
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 34))
+                    }
+                    .padding()
+                }
+                .navigationTitle(conversation.title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("返回") { selectedConversation = nil }
+                    }
+                }
+            }
+        }
     }
 
     private var avatar: some View {
@@ -365,8 +380,10 @@ struct ContentView: View {
         .padding(.trailing, 24)
         .padding(.vertical, 13)
         .contentShape(Rectangle())
+        .onTapGesture { selectedConversation = conversation }
         .accessibilityElement(children: .combine)
-        .accessibilityIdentifier(conversation.id == "chief-of-staff" ? "conversation-chief-of-staff" : "conversation-\(conversation.id)")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("conversation-\(conversation.id)")
     }
 
     private var filteredConversations: [ConversationSummary] {
@@ -378,10 +395,9 @@ struct ContentView: View {
 
     private func addConversation() {
         let next = conversations.count + 1
-        conversations.insert(
-            ConversationSummary(id: "new-\(next)", title: "新对话 \(next)", preview: "开始一段新的对话", time: "现在", badge: "+"),
-            at: 0
-        )
+        let conversation = ConversationSummary(id: "new-\(next)", title: "新对话 \(next)", preview: "开始一段新的对话", time: "现在", badge: "✦")
+        conversations.insert(conversation, at: 0)
+        selectedConversation = conversation
     }
 
     private var marketplaceView: some View {

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -460,6 +460,7 @@ struct ContentView: View {
             Form {
                 Section {
                     TextField(kind == .direct ? "联系人名称" : "名称", text: $composeName)
+                        .accessibilityIdentifier("compose-name")
                     if kind == .channel { TextField("描述", text: $composeDescription, axis: .vertical) }
                 }
                 if kind == .group || kind == .bot {
@@ -470,7 +471,7 @@ struct ContentView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("取消") { composeKind = nil } }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("创建") { createConversation(kind: kind) }.disabled(composeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    Button("创建") { createConversation(kind: kind) }.accessibilityIdentifier("compose-create").disabled(composeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
         }

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -6,12 +6,86 @@ private enum MobileDestination {
     case remoteComputer
 }
 
-private struct ConversationSummary: Identifiable {
+private enum ConversationKind: String, Identifiable {
+    case direct
+    case group
+    case channel
+    case bot
+
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .direct: "私聊"
+        case .group: "群组"
+        case .channel: "频道"
+        case .bot: "Bot"
+        }
+    }
+    var symbol: String {
+        switch self {
+        case .direct: "person.fill"
+        case .group: "person.3.fill"
+        case .channel: "megaphone.fill"
+        case .bot: "sparkles"
+        }
+    }
+}
+
+private enum MobileSection: String, CaseIterable, Identifiable {
+    case chats, contacts, bots, groups, channels, calls, saved, archive, folders, miniapps, payments, settings
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .chats: "聊天"
+        case .contacts: "联系人"
+        case .bots: "Bots"
+        case .groups: "群组"
+        case .channels: "频道"
+        case .calls: "通话"
+        case .saved: "收藏"
+        case .archive: "归档"
+        case .folders: "文件夹"
+        case .miniapps: "Mini Apps"
+        case .payments: "支付"
+        case .settings: "设置"
+        }
+    }
+    var symbol: String {
+        switch self {
+        case .chats: "bubble.left.and.bubble.right.fill"
+        case .contacts: "person.2.fill"
+        case .bots: "sparkles"
+        case .groups: "person.3.fill"
+        case .channels: "megaphone.fill"
+        case .calls: "phone.fill"
+        case .saved: "bookmark.fill"
+        case .archive: "archivebox.fill"
+        case .folders: "folder.fill"
+        case .miniapps: "square.grid.2x2.fill"
+        case .payments: "wallet.bifold.fill"
+        case .settings: "gearshape.fill"
+        }
+    }
+}
+
+private struct ConversationSummary: Identifiable, Equatable {
     let id: String
-    let title: String
-    let preview: String
+    var title: String
+    var preview: String
+    var time: String
+    var badge: String
+    var kind: ConversationKind
+    var unreadCount: Int = 0
+    var isPinned: Bool = false
+    var isMuted: Bool = false
+    var isArchived: Bool = false
+}
+
+private struct ChatMessage: Identifiable, Equatable {
+    let id: String
+    let text: String
+    let isOutgoing: Bool
     let time: String
-    let badge: String
 }
 
 struct ContentView: View {
@@ -23,6 +97,14 @@ struct ContentView: View {
     @State private var homeQuery = ""
     @State private var selectedConversation: ConversationSummary?
     @State private var conversations: [ConversationSummary] = []
+    @State private var messagesByConversation: [String: [ChatMessage]] = [:]
+    @State private var messageDraft = ""
+    @State private var composeMenuPresented = false
+    @State private var composeKind: ConversationKind?
+    @State private var composeName = ""
+    @State private var composeDescription = ""
+    @State private var activeSection: MobileSection?
+    @State private var contactGroupsPresented = false
 
     var body: some View {
         Group {
@@ -139,7 +221,7 @@ struct ContentView: View {
                         action: .init(allowed: ["setValue"]) { value in homeQuery = value ?? "" }
                     )
                 }
-                add("home-add-button", role: "button", name: "新建对话", action: .init(allowed: ["invoke"]) { _ in addConversation() })
+                add("home-add-button", role: "button", name: "新建", action: .init(allowed: ["invoke"]) { _ in composeMenuPresented = true })
                 add(
                     "marketplace-entry",
                     role: "menuitem",
@@ -223,181 +305,319 @@ struct ContentView: View {
     }
 
     private var homeView: some View {
-        ZStack {
-            Color(red: 0.043, green: 0.043, blue: 0.047).ignoresSafeArea()
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    HStack(spacing: 12) {
-                        Menu {
-                            Button("我的电脑") { destination = .remoteComputer }
-                                .accessibilityIdentifier("remote-computer-entry")
-                            Button("插件市场") { destination = .marketplace }
-                                .accessibilityIdentifier("marketplace-entry")
-                        } label: { avatar }
-                        Spacer()
-                        circleButton(systemName: "magnifyingglass", identifier: "home-search-button") {
-                            withAnimation(.easeInOut(duration: 0.18)) { isSearching.toggle() }
-                        }
-                        circleButton(systemName: "square.and.pencil", identifier: "home-add-button") {
-                            addConversation()
-                        }
-                    }
-                    .padding(.horizontal, 24)
-                    .padding(.top, 10)
-                    .padding(.bottom, 18)
-
-                    if isSearching {
-                        TextField("搜索消息", text: $homeQuery)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 16)
-                            .frame(height: 48)
-                            .background(Color(red: 0.082, green: 0.082, blue: 0.086), in: RoundedRectangle(cornerRadius: 16))
-                            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.12), lineWidth: 1))
-                            .padding(.horizontal, 20)
-                            .padding(.bottom, 10)
+        NavigationStack {
+            ZStack(alignment: .bottomTrailing) {
+                Color(red: 0.043, green: 0.043, blue: 0.047).ignoresSafeArea()
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        if isSearching {
+                            HStack(spacing: 8) {
+                                Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                                TextField("搜索", text: $homeQuery)
+                                    .textInputAutocapitalization(.never)
+                                    .autocorrectionDisabled()
+                                    .foregroundStyle(.white)
+                                if !homeQuery.isEmpty {
+                                    Button { homeQuery = "" } label: { Image(systemName: "xmark.circle.fill") }
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .padding(.horizontal, 12)
+                            .frame(height: 40)
+                            .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
                             .accessibilityIdentifier("home-search-field")
-                    }
+                        }
 
-                    VStack(spacing: 0) {
+                        if !archivedConversations.isEmpty && homeQuery.isEmpty {
+                            HStack(spacing: 12) {
+                                Image(systemName: "archivebox.fill").foregroundStyle(.secondary)
+                                Text("已归档").font(.headline)
+                                Spacer()
+                                Text("\(archivedConversations.count)").foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 16).frame(height: 48)
+                        }
+
                         ForEach(filteredConversations) { conversation in
                             conversationRow(conversation)
+                                .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                                    Button {
+                                        mutateConversation(conversation.id) { $0.isPinned.toggle() }
+                                    } label: { Label(conversation.isPinned ? "取消置顶" : "置顶", systemImage: "pin.fill") }
+                                    .tint(.orange)
+                                }
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button {
+                                        mutateConversation(conversation.id) { $0.isArchived = true }
+                                    } label: { Label("归档", systemImage: "archivebox.fill") }
+                                    .tint(.blue)
+                                    Button {
+                                        mutateConversation(conversation.id) { $0.isMuted.toggle() }
+                                    } label: { Label(conversation.isMuted ? "取消静音" : "静音", systemImage: "speaker.slash.fill") }
+                                    .tint(.gray)
+                                }
                         }
+
                         if filteredConversations.isEmpty {
                             VStack(spacing: 10) {
-                                Image(systemName: "bubble.left.and.bubble.right")
-                                    .font(.system(size: 34, weight: .regular))
-                                Text(homeQuery.isEmpty ? "还没有对话" : "没有找到匹配的消息")
-                                    .font(.headline)
-                                Text(homeQuery.isEmpty ? "点右上角写消息按钮开始新的对话" : "换个关键词试试")
-                                    .font(.subheadline)
+                                Image(systemName: homeQuery.isEmpty ? "bubble.left.and.bubble.right" : "magnifyingglass")
+                                    .font(.system(size: 34))
+                                Text(homeQuery.isEmpty ? "还没有对话" : "没有找到结果").font(.headline)
+                                Text(homeQuery.isEmpty ? "点击写消息按钮开始聊天" : "尝试其他关键词").font(.subheadline)
                             }
-                            .foregroundStyle(Color.white.opacity(0.48))
+                            .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, 70)
+                            .padding(.top, 90)
+                        }
+
+                        if let featureHostSmokeStatus = model.featureHostSmokeStatus {
+                            Text(featureHostSmokeStatus).font(.caption2).foregroundStyle(.clear)
+                                .accessibilityIdentifier("feature-host-smoke")
                         }
                     }
-                    .accessibilityIdentifier("conversation-list")
+                }
+                .accessibilityIdentifier("conversation-list")
 
-                    if let featureHostSmokeStatus = model.featureHostSmokeStatus {
-                        Text(featureHostSmokeStatus)
-                            .font(.caption2)
-                            .foregroundStyle(.clear)
-                            .accessibilityIdentifier("feature-host-smoke")
-                    }
+                Button { composeMenuPresented = true } label: {
+                    Image(systemName: "square.and.pencil")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 56, height: 56)
+                        .background(Color.accentColor, in: Circle())
+                        .shadow(radius: 8, y: 4)
+                }
+                .padding(18)
+                .opacity(isSearching ? 0 : 1)
+                .allowsHitTesting(!isSearching)
+                .accessibilityIdentifier("home-add-button")
+            }
+            .navigationTitle("聊天")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Menu {
+                        ForEach(MobileSection.allCases) { section in
+                            Button { handleSection(section) } label: {
+                                Label(section.label, systemImage: section.symbol)
+                            }
+                        }
+                        Divider()
+                        Button { destination = .remoteComputer } label: { Label("我的电脑", systemImage: "desktopcomputer") }
+                        Button { destination = .marketplace } label: { Label("插件市场", systemImage: "shippingbox.fill") }
+                    } label: { avatar.frame(width: 34, height: 34) }
+                    .accessibilityIdentifier("profile-avatar")
+                }
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.18)) { isSearching.toggle() }
+                        if !isSearching { homeQuery = "" }
+                    } label: { Image(systemName: isSearching ? "xmark" : "magnifyingglass") }
+                    .accessibilityIdentifier("home-search-button")
+                    Button { composeMenuPresented = true } label: { Image(systemName: "square.and.pencil") }
+                        .accessibilityIdentifier("home-compose-nav")
                 }
             }
         }
+        .confirmationDialog("新建", isPresented: $composeMenuPresented, titleVisibility: .visible) {
+            Button("新建私聊") { startCompose(.direct) }
+            Button("新建群组") { startCompose(.group) }
+            Button("新建频道") { startCompose(.channel) }
+            Button("新建 Bot") { startCompose(.bot) }
+            Button("联系人分组") { contactGroupsPresented = true }
+            Button("取消", role: .cancel) {}
+        }
+        .sheet(item: $composeKind) { kind in composeSheet(kind) }
+        .sheet(isPresented: $contactGroupsPresented) { simpleSectionSheet(title: "联系人分组", symbol: "folder.fill") }
+        .sheet(item: $activeSection) { section in simpleSectionSheet(title: section.label, symbol: section.symbol) }
+        .fullScreenCover(item: $selectedConversation) { conversation in chatView(conversation) }
         .accessibilityIdentifier("app-shell")
-        .fullScreenCover(item: $selectedConversation) { conversation in
-            NavigationStack {
-                VStack(spacing: 0) {
-                    Spacer()
-                    Text("开始与 \(conversation.title) 对话")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    HStack(spacing: 10) {
-                        TextField("消息", text: .constant(""))
-                            .padding(.horizontal, 14)
-                            .frame(height: 44)
-                            .background(Color.secondary.opacity(0.12), in: Capsule())
-                        Image(systemName: "arrow.up.circle.fill")
-                            .font(.system(size: 34))
-                    }
-                    .padding()
+    }
+
+    private var visibleConversations: [ConversationSummary] {
+        conversations.filter { !$0.isArchived }
+            .sorted { lhs, rhs in lhs.isPinned != rhs.isPinned ? lhs.isPinned : lhs.time > rhs.time }
+    }
+
+    private var archivedConversations: [ConversationSummary] { conversations.filter(\.isArchived) }
+
+    private var filteredConversations: [ConversationSummary] {
+        let query = homeQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return visibleConversations }
+        return visibleConversations.filter { $0.title.localizedCaseInsensitiveContains(query) || $0.preview.localizedCaseInsensitiveContains(query) }
+    }
+
+    private func startCompose(_ kind: ConversationKind) {
+        composeName = ""
+        composeDescription = ""
+        composeKind = kind
+    }
+
+    @ViewBuilder
+    private func composeSheet(_ kind: ConversationKind) -> some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(kind == .direct ? "联系人名称" : "名称", text: $composeName)
+                    if kind == .channel { TextField("描述", text: $composeDescription, axis: .vertical) }
                 }
-                .navigationTitle(conversation.title)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button("返回") { selectedConversation = nil }
-                    }
+                if kind == .group || kind == .bot {
+                    Section("Fabushi") { Text(kind == .group ? "创建后可从统一 Bot/联系人目录添加成员。" : "创建后进入与桌面端相同的 Bot 配置流程。") }
+                }
+            }
+            .navigationTitle("新建\(kind.label)")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("取消") { composeKind = nil } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("创建") { createConversation(kind: kind) }.disabled(composeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
         }
+    }
+
+    private func createConversation(kind: ConversationKind) {
+        let title = composeName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let id = "\(kind.rawValue)-\(UUID().uuidString.lowercased())"
+        let conversation = ConversationSummary(id: id, title: title, preview: composeDescription.isEmpty ? "开始一段新的对话" : composeDescription, time: "现在", badge: String(title.prefix(1)).uppercased(), kind: kind)
+        conversations.insert(conversation, at: 0)
+        composeKind = nil
+        selectedConversation = conversation
+    }
+
+    private func mutateConversation(_ id: String, mutation: (inout ConversationSummary) -> Void) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        mutation(&conversations[index])
+        if selectedConversation?.id == id { selectedConversation = conversations[index] }
+    }
+
+    private func handleSection(_ section: MobileSection) {
+        switch section {
+        case .chats: activeSection = nil
+        case .miniapps: destination = .marketplace
+        default: activeSection = section
+        }
+    }
+
+    @ViewBuilder
+    private func simpleSectionSheet(title: String, symbol: String) -> some View {
+        NavigationStack {
+            ContentUnavailableView(title, systemImage: symbol, description: Text("此入口与桌面端共用同一业务能力；移动端采用 Telegram 式单栈导航。"))
+                .navigationTitle(title)
+                .toolbar { ToolbarItem(placement: .topBarLeading) { Button("完成") { activeSection = nil; contactGroupsPresented = false } } }
+        }
+    }
+
+    private func conversationRow(_ conversation: ConversationSummary) -> some View {
+        Button {
+            mutateConversation(conversation.id) { $0.unreadCount = 0 }
+            selectedConversation = conversations.first(where: { $0.id == conversation.id }) ?? conversation
+        } label: {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle().fill(Color.accentColor.opacity(0.85))
+                    Text(conversation.badge.isEmpty ? "✦" : conversation.badge).font(.headline).foregroundStyle(.white)
+                }.frame(width: 54, height: 54)
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 5) {
+                        Text(conversation.title).font(.system(size: 17, weight: .semibold)).foregroundStyle(.primary).lineLimit(1)
+                        if conversation.isMuted { Image(systemName: "speaker.slash.fill").font(.caption2).foregroundStyle(.secondary) }
+                        if conversation.isPinned { Image(systemName: "pin.fill").font(.caption2).foregroundStyle(.secondary) }
+                    }
+                    Text(conversation.preview).font(.system(size: 15)).foregroundStyle(.secondary).lineLimit(1)
+                }
+                Spacer(minLength: 8)
+                VStack(alignment: .trailing, spacing: 6) {
+                    Text(conversation.time).font(.caption).foregroundStyle(.secondary)
+                    if conversation.unreadCount > 0 {
+                        Text("\(conversation.unreadCount)").font(.caption2.bold()).foregroundStyle(.white)
+                            .padding(.horizontal, 6).frame(minWidth: 20, minHeight: 20).background(Color.accentColor, in: Capsule())
+                    }
+                }
+            }
+            .padding(.horizontal, 14).padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("conversation-\(conversation.id)")
+    }
+
+    @ViewBuilder
+    private func chatView(_ conversation: ConversationSummary) -> some View {
+        NavigationStack {
+            ZStack {
+                Color(red: 0.055, green: 0.06, blue: 0.07).ignoresSafeArea()
+                VStack(spacing: 0) {
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            LazyVStack(spacing: 8) {
+                                ForEach(messagesByConversation[conversation.id] ?? []) { message in
+                                    HStack {
+                                        if message.isOutgoing { Spacer(minLength: 56) }
+                                        VStack(alignment: .trailing, spacing: 3) {
+                                            Text(message.text).foregroundStyle(.primary).frame(maxWidth: .infinity, alignment: .leading)
+                                            HStack(spacing: 3) {
+                                                Text(message.time).font(.caption2).foregroundStyle(.secondary)
+                                                if message.isOutgoing { Image(systemName: "checkmark.checkmark").font(.caption2).foregroundStyle(.blue) }
+                                            }
+                                        }
+                                        .padding(.horizontal, 11).padding(.vertical, 7)
+                                        .background(message.isOutgoing ? Color.accentColor.opacity(0.20) : Color.white.opacity(0.10), in: RoundedRectangle(cornerRadius: 16))
+                                        if !message.isOutgoing { Spacer(minLength: 56) }
+                                    }.padding(.horizontal, 10).id(message.id)
+                                }
+                            }.padding(.vertical, 12)
+                        }
+                        .onChange(of: messagesByConversation[conversation.id]?.count ?? 0) { _, _ in
+                            if let id = messagesByConversation[conversation.id]?.last?.id { withAnimation { proxy.scrollTo(id, anchor: .bottom) } }
+                        }
+                    }
+                    HStack(alignment: .bottom, spacing: 8) {
+                        Menu {
+                            Button("照片或视频", systemImage: "photo") {}
+                            Button("文件", systemImage: "doc") {}
+                            Button("位置", systemImage: "location") {}
+                            Button("联系人", systemImage: "person.crop.circle") {}
+                        } label: { Image(systemName: "paperclip").font(.title3).frame(width: 36, height: 36) }
+                        TextField("消息", text: $messageDraft, axis: .vertical).lineLimit(1...5)
+                            .padding(.horizontal, 12).padding(.vertical, 9).background(Color.white.opacity(0.10), in: RoundedRectangle(cornerRadius: 18))
+                        Button { sendMessage(in: conversation) } label: {
+                            Image(systemName: messageDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "mic.fill" : "arrow.up")
+                                .font(.system(size: 18, weight: .bold)).foregroundStyle(.white).frame(width: 38, height: 38).background(Color.accentColor, in: Circle())
+                        }
+                    }.padding(.horizontal, 8).padding(.vertical, 7).background(.ultraThinMaterial)
+                }
+            }
+            .navigationTitle(conversation.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) { Button { selectedConversation = nil } label: { Image(systemName: "chevron.left") } }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button("搜索", systemImage: "magnifyingglass") {}
+                        Button(conversation.isMuted ? "取消静音" : "静音", systemImage: "speaker.slash") { mutateConversation(conversation.id) { $0.isMuted.toggle() } }
+                        Button(conversation.isPinned ? "取消置顶" : "置顶", systemImage: "pin") { mutateConversation(conversation.id) { $0.isPinned.toggle() } }
+                        Button("归档", systemImage: "archivebox") { mutateConversation(conversation.id) { $0.isArchived = true }; selectedConversation = nil }
+                    } label: { Image(systemName: "ellipsis.circle") }
+                }
+            }
+        }
+    }
+
+    private func sendMessage(in conversation: ConversationSummary) {
+        let text = messageDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        let now = Date.now.formatted(date: .omitted, time: .shortened)
+        messagesByConversation[conversation.id, default: []].append(ChatMessage(id: UUID().uuidString, text: text, isOutgoing: true, time: now))
+        messageDraft = ""
+        mutateConversation(conversation.id) { item in item.preview = text; item.time = "现在" }
     }
 
     private var avatar: some View {
         ZStack {
-            Circle()
-                .fill(Color(red: 0.082, green: 0.082, blue: 0.086))
-                .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 1))
-            Text("✦")
-                .font(.system(size: 34, weight: .bold))
-                .foregroundStyle(Color(red: 1.0, green: 0.70, blue: 0.10))
+            Circle().fill(Color.white.opacity(0.08))
+            Text("✦").font(.system(size: 22, weight: .bold)).foregroundStyle(.orange)
         }
-        .frame(width: 56, height: 56)
-        .accessibilityLabel("个人头像")
-        .accessibilityIdentifier("profile-avatar")
-    }
-
-    private func circleButton(systemName: String, identifier: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            ZStack {
-                Circle()
-                    .fill(Color(red: 0.063, green: 0.063, blue: 0.067))
-                    .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 1))
-                Image(systemName: systemName)
-                    .font(.system(size: 22, weight: .regular))
-                    .foregroundStyle(.white)
-            }
-            .frame(width: 54, height: 54)
-        }
-        .accessibilityIdentifier(identifier)
-    }
-
-    private func conversationRow(_ conversation: ConversationSummary) -> some View {
-        HStack(spacing: 0) {
-            ZStack {
-                Circle().fill(Color(red: 1.0, green: 0.35, blue: 0.04))
-                Text(conversation.badge)
-                    .font(.system(size: 13, weight: .black))
-                    .foregroundStyle(Color(red: 0.10, green: 0.06, blue: 0.03))
-            }
-            .frame(width: 54, height: 54)
-
-            VStack(alignment: .leading, spacing: 5) {
-                Text(conversation.title)
-                    .font(.system(size: 19, weight: .semibold))
-                    .foregroundStyle(Color.white.opacity(0.96))
-                    .lineLimit(1)
-                Text(conversation.preview)
-                    .font(.system(size: 16))
-                    .foregroundStyle(Color.white.opacity(0.50))
-                    .lineLimit(1)
-            }
-            .padding(.leading, 18)
-
-            Spacer(minLength: 12)
-
-            Text(conversation.time)
-                .font(.system(size: 14))
-                .foregroundStyle(Color.white.opacity(0.30))
-        }
-        .padding(.leading, 30)
-        .padding(.trailing, 24)
-        .padding(.vertical, 13)
-        .contentShape(Rectangle())
-        .onTapGesture { selectedConversation = conversation }
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(.isButton)
-        .accessibilityIdentifier("conversation-\(conversation.id)")
-    }
-
-    private var filteredConversations: [ConversationSummary] {
-        guard !homeQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return conversations }
-        return conversations.filter {
-            $0.title.localizedCaseInsensitiveContains(homeQuery) || $0.preview.localizedCaseInsensitiveContains(homeQuery)
-        }
-    }
-
-    private func addConversation() {
-        let next = conversations.count + 1
-        let conversation = ConversationSummary(id: "new-\(next)", title: "新对话 \(next)", preview: "开始一段新的对话", time: "现在", badge: "✦")
-        conversations.insert(conversation, at: 0)
-        selectedConversation = conversation
     }
 
     private var marketplaceView: some View {

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -33,8 +33,15 @@ final class FabushiUITests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["conversation-list"].exists)
         XCTAssertFalse(app.staticTexts["Chief of Staff"].exists)
         app.buttons["home-add-button"].tap()
-        XCTAssertTrue(app.navigationBars["新对话 1"].waitForExistence(timeout: 5))
-        app.buttons["返回"].tap()
+        let newDirect = app.buttons["新建私聊"]
+        XCTAssertTrue(newDirect.waitForExistence(timeout: 5))
+        newDirect.tap()
+        let composeName = app.textFields["compose-name"]
+        XCTAssertTrue(composeName.waitForExistence(timeout: 5))
+        composeName.tap()
+        composeName.typeText("测试联系人")
+        app.buttons["compose-create"].tap()
+        XCTAssertTrue(app.navigationBars["测试联系人"].waitForExistence(timeout: 5))
 
         openRemoteComputer(in: app)
         let remoteComputer = app.descendants(matching: .any)["remote-computer-surface"]

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -31,14 +31,10 @@ final class FabushiUITests: XCTestCase {
         XCTAssertTrue(app.buttons["home-search-button"].exists)
         XCTAssertTrue(app.buttons["home-add-button"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["conversation-list"].exists)
-        XCTAssertTrue(app.staticTexts["Chief of Staff"].waitForExistence(timeout: 5))
-
-        app.buttons["home-search-button"].tap()
-        let homeSearch = app.textFields["home-search-field"]
-        XCTAssertTrue(homeSearch.waitForExistence(timeout: 5))
-        homeSearch.tap()
-        homeSearch.typeText("Chief")
-        XCTAssertTrue(app.staticTexts["Chief of Staff"].exists)
+        XCTAssertFalse(app.staticTexts["Chief of Staff"].exists)
+        app.buttons["home-add-button"].tap()
+        XCTAssertTrue(app.navigationBars["新对话 1"].waitForExistence(timeout: 5))
+        app.buttons["返回"].tap()
 
         openRemoteComputer(in: app)
         let remoteComputer = app.descendants(matching: .any)["remote-computer-surface"]
@@ -118,9 +114,9 @@ final class FabushiUITests: XCTestCase {
 
     @MainActor
     private func openMarketplace(in app: XCUIApplication) {
-        let add = app.buttons["home-add-button"]
-        XCTAssertTrue(add.waitForExistence(timeout: 10))
-        add.tap()
+        let profile = app.descendants(matching: .any)["profile-avatar"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 10))
+        profile.tap()
         let marketplace = app.buttons["marketplace-entry"]
         XCTAssertTrue(marketplace.waitForExistence(timeout: 5))
         marketplace.tap()
@@ -128,9 +124,9 @@ final class FabushiUITests: XCTestCase {
 
     @MainActor
     private func openRemoteComputer(in app: XCUIApplication) {
-        let add = app.buttons["home-add-button"]
-        XCTAssertTrue(add.waitForExistence(timeout: 10))
-        add.tap()
+        let profile = app.descendants(matching: .any)["profile-avatar"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 10))
+        profile.tap()
         let remoteComputer = app.buttons["remote-computer-entry"]
         XCTAssertTrue(remoteComputer.waitForExistence(timeout: 5))
         remoteComputer.tap()


### PR DESCRIPTION
Fixes the mobile chat-list UX regression on both native clients.

- removes the hard-coded `Chief of Staff` pseudo-conversation
- makes conversation rows actually navigate instead of using an empty click handler
- makes the compose/new-chat action direct and consistent across iOS and Android
- moves marketplace / remote-computer utilities behind the profile menu instead of overloading the compose button
- adds a native conversation destination and empty-state treatment
- updates iOS/Android UI tests to guard against reintroducing the fixed fake bot and menu behavior

The interaction model follows Telegram's native chat-list hierarchy rather than copying Telegram branding/assets. CI should validate both native mobile gates.