### PR TITLE
fix(android): remove internal Compose weight import

### DIFF
--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape


### PR DESCRIPTION
Remove the accidental import of Compose's internal `weight` extension introduced by the mobile chat UX PR. The scoped `Modifier.weight(...)` calls remain valid; this restores Android compilation for the final main release path.