### PR TITLE
feat(mobile): share Telegram-style messaging state across iOS Android and desktop

### DIFF
--- a/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
+++ b/mobile/android/app/src/androidTest/java/com/ombhrum/fabushi/FabushiScreenTest.kt
@@ -40,10 +40,8 @@ class FabushiScreenTest {
         compose.onNodeWithTag(TestTags.ConversationList).assertIsDisplayed()
         compose.onNodeWithTag(TestTags.ConversationRow).assertDoesNotExist()
         compose.onNodeWithTag(TestTags.AddButton).performClick()
-        compose.onNodeWithText("新建私聊").assertIsDisplayed().performClick()
-        compose.onNodeWithTag(TestTags.ComposeName).performTextInput("测试联系人")
-        compose.onNodeWithTag(TestTags.ComposeCreate).performClick()
-        compose.onNodeWithText("测试联系人").assertIsDisplayed()
+        compose.onNodeWithText("新消息").assertIsDisplayed().performClick()
+        compose.onNodeWithText("暂无可用联系人").assertIsDisplayed()
         compose.onNodeWithText("Chief of Staff").assertDoesNotExist()
     }
 

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/FabushiScreen.kt
@@ -39,8 +39,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -92,28 +90,6 @@ object TestTags {
 }
 
 private enum class MobileDestination { HOME, MARKETPLACE, REMOTE_COMPUTER }
-private enum class ConversationKind(val label: String) { DIRECT("私聊"), GROUP("群组"), CHANNEL("频道"), BOT("Bot") }
-
-private data class ConversationSummary(
-    val id: String,
-    var title: String,
-    var preview: String,
-    var time: String,
-    val badge: String,
-    val kind: ConversationKind,
-    var unreadCount: Int = 0,
-    var isPinned: Boolean = false,
-    var isMuted: Boolean = false,
-    var isArchived: Boolean = false,
-)
-
-private data class ChatMessage(
-    val id: String,
-    val text: String,
-    val outgoing: Boolean,
-    val time: String,
-)
-
 private val homeBackground = Color(0xFF0B0B0C)
 private val homeSurface = Color(0xFF151516)
 private val homeBorder = Color(0xFF29292B)
@@ -137,6 +113,15 @@ fun FabushiScreen(
     ),
     onCheckUpdate: () -> Unit = {},
     onInstallUpdate: () -> Unit = {},
+    messagingState: MessagingUiState = MessagingUiState(),
+    onMessagingRefresh: () -> Unit = {},
+    onCreateDirect: (MessagingContact) -> Unit = {},
+    onCreateConversation: (ConversationKind, String, String) -> Unit = { _, _, _ -> },
+    onSendText: (String, String) -> Unit = { _, _ -> },
+    onSetPinned: (ConversationSummary, Boolean) -> Unit = { _, _ -> },
+    onSetArchived: (ConversationSummary, Boolean) -> Unit = { _, _ -> },
+    onSetMuted: (ConversationSummary, Boolean) -> Unit = { _, _ -> },
+    onMarkRead: (ConversationSummary) -> Unit = {},
     appAgentSurface: FabushiAppAgentSurface? = null,
 ) {
     var destination by remember { mutableStateOf(MobileDestination.HOME) }
@@ -296,6 +281,15 @@ fun FabushiScreen(
             onOpenRemoteComputer = { destination = MobileDestination.REMOTE_COMPUTER },
             showAddMenu = showAddMenu,
             onShowAddMenuChange = { showAddMenu = it },
+            messagingState = messagingState,
+            onMessagingRefresh = onMessagingRefresh,
+            onCreateDirect = onCreateDirect,
+            onCreateConversation = onCreateConversation,
+            onSendText = onSendText,
+            onSetPinned = onSetPinned,
+            onSetArchived = onSetArchived,
+            onSetMuted = onSetMuted,
+            onMarkRead = onMarkRead,
         )
         MobileDestination.MARKETPLACE -> MarketplaceContent(
             state = state,
@@ -320,47 +314,39 @@ private fun ConversationHome(
     onOpenRemoteComputer: () -> Unit,
     showAddMenu: Boolean,
     onShowAddMenuChange: (Boolean) -> Unit,
+    messagingState: MessagingUiState,
+    onMessagingRefresh: () -> Unit,
+    onCreateDirect: (MessagingContact) -> Unit,
+    onCreateConversation: (ConversationKind, String, String) -> Unit,
+    onSendText: (String, String) -> Unit,
+    onSetPinned: (ConversationSummary, Boolean) -> Unit,
+    onSetArchived: (ConversationSummary, Boolean) -> Unit,
+    onSetMuted: (ConversationSummary, Boolean) -> Unit,
+    onMarkRead: (ConversationSummary) -> Unit,
 ) {
     var showSearch by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
     var showComposeMenu by remember { mutableStateOf(false) }
+    var showContactPicker by remember { mutableStateOf(false) }
     var pendingKind by remember { mutableStateOf<ConversationKind?>(null) }
     var composeName by remember { mutableStateOf("") }
     var selectedConversation by remember { mutableStateOf<ConversationSummary?>(null) }
-    val conversations = remember { mutableStateListOf<ConversationSummary>() }
-    val messageStore = remember { mutableStateMapOf<String, List<ChatMessage>>() }
+    val conversations = messagingState.conversations
     val filteredConversations = conversations
         .filter { !it.isArchived }
         .sortedWith(compareByDescending<ConversationSummary> { it.isPinned }.thenByDescending { it.time })
         .filter { conversation -> searchQuery.isBlank() || conversation.title.contains(searchQuery, true) || conversation.preview.contains(searchQuery, true) }
 
-    selectedConversation?.let { conversation ->
+    selectedConversation?.let { selected ->
+        val conversation = conversations.firstOrNull { it.id == selected.id } ?: selected
         ConversationDetail(
             conversation = conversation,
-            messages = messageStore[conversation.id].orEmpty(),
+            messages = messagingState.messagesByConversation[conversation.id].orEmpty(),
             onBack = { selectedConversation = null },
-            onSend = { text ->
-                val next = ChatMessage(System.nanoTime().toString(), text, true, "现在")
-                messageStore[conversation.id] = messageStore[conversation.id].orEmpty() + next
-                val index = conversations.indexOfFirst { it.id == conversation.id }
-                if (index >= 0) {
-                    conversations[index] = conversations[index].copy(preview = text, time = "现在")
-                    selectedConversation = conversations[index]
-                }
-            },
-            onToggleMute = {
-                val index = conversations.indexOfFirst { it.id == conversation.id }
-                if (index >= 0) { conversations[index] = conversations[index].copy(isMuted = !conversations[index].isMuted); selectedConversation = conversations[index] }
-            },
-            onTogglePin = {
-                val index = conversations.indexOfFirst { it.id == conversation.id }
-                if (index >= 0) { conversations[index] = conversations[index].copy(isPinned = !conversations[index].isPinned); selectedConversation = conversations[index] }
-            },
-            onArchive = {
-                val index = conversations.indexOfFirst { it.id == conversation.id }
-                if (index >= 0) conversations[index] = conversations[index].copy(isArchived = true)
-                selectedConversation = null
-            },
+            onSend = { onSendText(conversation.id, it) },
+            onToggleMute = { onSetMuted(conversation, !conversation.isMuted) },
+            onTogglePin = { onSetPinned(conversation, !conversation.isPinned) },
+            onArchive = { onSetArchived(conversation, true); selectedConversation = null },
         )
         return
     }
@@ -377,12 +363,9 @@ private fun ConversationHome(
                     val title = composeName.trim()
                     if (title.isNotEmpty()) {
                         val kind = pendingKind!!
-                        val conversation = ConversationSummary(
-                            id = "${kind.name.lowercase()}-${System.nanoTime()}", title = title,
-                            preview = "开始一段新的对话", time = "现在", badge = title.take(1).uppercase(), kind = kind,
-                        )
-                        conversations.add(0, conversation)
-                        pendingKind = null; composeName = ""; selectedConversation = conversation
+                        onCreateConversation(kind, title, "")
+                        pendingKind = null
+                        composeName = ""
                     }
                 }, modifier = Modifier.testTag(TestTags.ComposeCreate), enabled = composeName.isNotBlank()) { Text("创建") }
             },
@@ -390,11 +373,35 @@ private fun ConversationHome(
         )
     }
 
+    LaunchedEffect(Unit) { onMessagingRefresh() }
+
+    if (showContactPicker) {
+        AlertDialog(
+            onDismissRequest = { showContactPicker = false },
+            title = { Text("新消息") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    if (messagingState.contacts.isEmpty()) Text("暂无可用联系人", color = homeSecondaryText)
+                    messagingState.contacts.take(20).forEach { contact ->
+                        Row(Modifier.fillMaxWidth().clickable { showContactPicker = false; onCreateDirect(contact) }.padding(vertical = 10.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Box(Modifier.size(40.dp).background(homeAccent, CircleShape), contentAlignment = Alignment.Center) { Text(contact.displayName.take(1).uppercase(), color = Color.Black, fontWeight = FontWeight.Bold) }
+                            Column(Modifier.padding(start = 12.dp)) {
+                                Text(contact.displayName, color = homePrimaryText)
+                                Text(contact.username?.let { "@$it" } ?: contact.kind, color = homeSecondaryText, style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = { OutlinedButton(onClick = { showContactPicker = false }) { Text("取消") } },
+        )
+    }
+
     Scaffold(
         modifier = Modifier.fillMaxSize().testTag(TestTags.AppShell),
         containerColor = homeBackground,
         floatingActionButton = {
-            Box {
+            if (!showSearch) Box {
                 FloatingActionButton(
                     onClick = { showComposeMenu = true },
                     modifier = Modifier.testTag(TestTags.AddButton),
@@ -402,9 +409,9 @@ private fun ConversationHome(
                     contentColor = Color.Black,
                 ) { PlusGlyph() }
                 DropdownMenu(expanded = showComposeMenu, onDismissRequest = { showComposeMenu = false }, containerColor = homeSurface) {
-                    ConversationKind.entries.forEach { kind ->
-                        DropdownMenuItem(text = { Text("新建${kind.label}", color = homePrimaryText) }, onClick = { showComposeMenu = false; pendingKind = kind })
-                    }
+                    DropdownMenuItem(text = { Text("新消息", color = homePrimaryText) }, onClick = { showComposeMenu = false; showContactPicker = true })
+                    DropdownMenuItem(text = { Text("新建群组", color = homePrimaryText) }, onClick = { showComposeMenu = false; pendingKind = ConversationKind.GROUP })
+                    DropdownMenuItem(text = { Text("新建频道", color = homePrimaryText) }, onClick = { showComposeMenu = false; pendingKind = ConversationKind.CHANNEL })
                     DropdownMenuItem(text = { Text("联系人分组", color = homePrimaryText) }, onClick = { showComposeMenu = false })
                 }
             }
@@ -459,9 +466,8 @@ private fun ConversationHome(
                 }
             } else items(filteredConversations, key = { it.id }) { conversation ->
                 ConversationRow(conversation, onClick = {
-                    val index = conversations.indexOfFirst { it.id == conversation.id }
-                    if (index >= 0) conversations[index] = conversations[index].copy(unreadCount = 0)
-                    selectedConversation = conversations.firstOrNull { it.id == conversation.id } ?: conversation
+                    selectedConversation = conversation
+                    onMarkRead(conversation)
                 })
             }
             item { Spacer(Modifier.height(88.dp)) }

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MainActivity.kt
@@ -28,7 +28,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             MaterialTheme {
                 val model: MarketplaceViewModel = viewModel()
+                val messagingModel: MessagingViewModel = viewModel()
                 val state by model.state.collectAsState()
+                val messagingState by messagingModel.state.collectAsState()
                 val updateState by updateModel.state.collectAsState()
                 var openedMiniApp by remember { mutableStateOf<MarketplacePlugin?>(null) }
                 LaunchedEffect(model) {
@@ -54,6 +56,15 @@ class MainActivity : ComponentActivity() {
                         updateState = updateState,
                         onCheckUpdate = { updateModel.checkForUpdates(force = true) },
                         onInstallUpdate = updateModel::downloadAndInstall,
+                        messagingState = messagingState,
+                        onMessagingRefresh = messagingModel::refresh,
+                        onCreateDirect = messagingModel::createDirect,
+                        onCreateConversation = messagingModel::createConversation,
+                        onSendText = messagingModel::sendText,
+                        onSetPinned = messagingModel::setPinned,
+                        onSetArchived = messagingModel::setArchived,
+                        onSetMuted = messagingModel::setMuted,
+                        onMarkRead = messagingModel::markRead,
                         appAgentSurface = appAgentSurface,
                     )
                 }

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/MessagingViewModel.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/MessagingViewModel.kt
@@ -1,0 +1,227 @@
+package com.ombhrum.fabushi
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.ombhrum.fabushi.core.MahayanaHost
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+enum class ConversationKind(val wire: String, val label: String) {
+    DIRECT("direct", "私聊"), GROUP("group", "群组"), CHANNEL("channel", "频道"),
+    SAVED_MESSAGES("savedMessages", "收藏"), SECRET("secret", "加密聊天"),
+}
+
+data class ConversationSummary(
+    val id: String,
+    val title: String,
+    val preview: String,
+    val time: String,
+    val badge: String,
+    val kind: ConversationKind,
+    val unreadCount: Int = 0,
+    val isPinned: Boolean = false,
+    val isMuted: Boolean = false,
+    val isArchived: Boolean = false,
+    val lastMessageId: String? = null,
+)
+
+data class MessagingContact(
+    val id: String,
+    val displayName: String,
+    val username: String?,
+    val kind: String,
+)
+
+data class ChatMessage(
+    val id: String,
+    val conversationId: String,
+    val text: String,
+    val outgoing: Boolean,
+    val time: String,
+)
+
+data class MessagingUiState(
+    val loading: Boolean = false,
+    val conversations: List<ConversationSummary> = emptyList(),
+    val contacts: List<MessagingContact> = emptyList(),
+    val messagesByConversation: Map<String, List<ChatMessage>> = emptyMap(),
+    val error: String? = null,
+)
+
+internal class MessagingViewModel(application: Application) : AndroidViewModel(application) {
+    private val host = MahayanaHost(application)
+    private val mutableState = MutableStateFlow(MessagingUiState())
+    val state: StateFlow<MessagingUiState> = mutableState.asStateFlow()
+    private var actorId = ""
+    private var displayName = "当前用户"
+    private val deviceId = "android:native"
+    private val sessionId = "account-session:android-native"
+
+    init { refresh() }
+
+    fun refresh() {
+        mutableState.value = mutableState.value.copy(loading = true)
+        viewModelScope.launch {
+            runCatching { withContext(Dispatchers.IO) { ensureIdentity(); execute(JSONObject().put("type", "sync").put("cursor", JSONObject.NULL).put("limit", 1000)) } }
+                .onSuccess { mutableState.value = mutableState.value.copy(loading = false, error = null) }
+                .onFailure { mutableState.value = mutableState.value.copy(loading = false, error = it.message) }
+        }
+    }
+
+    fun createDirect(contact: MessagingContact) {
+        viewModelScope.launch {
+            runCatching { withContext(Dispatchers.IO) {
+                ensureIdentity()
+                val now = System.currentTimeMillis()
+                val id = "direct:${UUID.randomUUID()}"
+                val participants = JSONArray()
+                    .put(JSONObject().put("actorId", actorId).put("role", "owner").put("joinedAtMs", now).put("mutedUntilMs", JSONObject.NULL))
+                    .put(JSONObject().put("actorId", contact.id).put("role", "member").put("joinedAtMs", now).put("mutedUntilMs", JSONObject.NULL))
+                val conversation = baseConversation(id, ConversationKind.DIRECT, contact.displayName, "", participants, now)
+                execute(JSONObject().put("type", "createConversation").put("conversation", conversation))
+            }}.onFailure { mutableState.value = mutableState.value.copy(error = it.message) }
+        }
+    }
+
+    fun createConversation(kind: ConversationKind, title: String, description: String = "") {
+        if (kind != ConversationKind.GROUP && kind != ConversationKind.CHANNEL) return
+        viewModelScope.launch {
+            runCatching { withContext(Dispatchers.IO) {
+                ensureIdentity()
+                val now = System.currentTimeMillis()
+                val id = "${kind.wire}:${UUID.randomUUID()}"
+                val participants = JSONArray().put(JSONObject().put("actorId", actorId).put("role", "owner").put("joinedAtMs", now).put("mutedUntilMs", JSONObject.NULL))
+                val conversation = baseConversation(id, kind, title.trim(), description.trim(), participants, now)
+                execute(JSONObject().put("type", "createConversation").put("conversation", conversation))
+            }}.onFailure { mutableState.value = mutableState.value.copy(error = it.message) }
+        }
+    }
+
+    fun sendText(conversationId: String, text: String) {
+        val value = text.trim(); if (value.isEmpty()) return
+        viewModelScope.launch {
+            runCatching { withContext(Dispatchers.IO) {
+                ensureIdentity()
+                execute(JSONObject().put("type", "sendMessage").put("conversationId", conversationId)
+                    .put("clientMessageId", "android:${UUID.randomUUID()}")
+                    .put("content", JSONObject().put("type", "text").put("data", JSONObject().put("text", JSONObject().put("text", value).put("entities", JSONArray()))))
+                    .put("replyToMessageId", JSONObject.NULL).put("threadRootMessageId", JSONObject.NULL).put("scheduledAtMs", JSONObject.NULL)
+                    .put("silent", false).put("protectedContent", false))
+            }}.onFailure { mutableState.value = mutableState.value.copy(error = it.message) }
+        }
+    }
+
+    fun setPinned(conversation: ConversationSummary, pinned: Boolean) = executeAsync(JSONObject().put("type", "pinConversation").put("conversationId", conversation.id).put("pinned", pinned))
+    fun setArchived(conversation: ConversationSummary, archived: Boolean) = executeAsync(JSONObject().put("type", "archiveConversation").put("conversationId", conversation.id).put("archived", archived))
+    fun setMuted(conversation: ConversationSummary, muted: Boolean) = executeAsync(JSONObject().put("type", "setConversationNotifications").put("conversationId", conversation.id).put("settings", JSONObject().put("mutedUntilMs", if (muted) Long.MAX_VALUE / 4 else JSONObject.NULL).put("sound", JSONObject.NULL).put("showPreview", true).put("notifyMentions", true)))
+    fun markRead(conversation: ConversationSummary) { conversation.lastMessageId?.let { executeAsync(JSONObject().put("type", "markRead").put("conversationId", conversation.id).put("messageId", it)) } }
+
+    private fun executeAsync(command: JSONObject) {
+        viewModelScope.launch { runCatching { withContext(Dispatchers.IO) { ensureIdentity(); execute(command) } }.onFailure { mutableState.value = mutableState.value.copy(error = it.message) } }
+    }
+
+    private fun ensureIdentity() {
+        if (actorId.isNotEmpty()) return
+        val auth = host.request("feature.auth.status")
+        auth.optJSONObject("user")?.let { displayName = it.optString("nickname").ifBlank { it.optString("username").ifBlank { displayName } } }
+        val access = host.request("feature.messaging.access.issue", JSONObject().put("deviceId", deviceId).put("sessionId", sessionId)
+            .put("scopes", JSONArray(listOf("messaging", "calls", "blobsRead", "blobsWrite", "payments", "miniApps"))))
+        actorId = access.optString("actorId")
+        check(actorId.isNotBlank()) { "Messaging identity is unavailable" }
+        execute(JSONObject().put("type", "upsertProfile").put("actor", JSONObject()
+            .put("id", actorId).put("kind", "human").put("displayName", displayName).put("username", JSONObject.NULL).put("avatarUrl", JSONObject.NULL).put("bio", JSONObject.NULL)
+            .put("capabilities", JSONArray(listOf("messages", "groups", "channels", "calls", "payments", "miniApps")))
+            .put("presence", JSONObject().put("status", "online").put("lastSeenAtMs", System.currentTimeMillis()).put("statusText", JSONObject.NULL)).put("verified", false)))
+    }
+
+    private fun execute(command: JSONObject) {
+        val requestId = "android-messaging-${UUID.randomUUID()}"
+        val envelope = JSONObject().put("protocolVersion", 2)
+            .put("context", JSONObject().put("requestId", requestId).put("deviceId", deviceId).put("actorId", actorId).put("sessionId", sessionId).put("sentAtMs", System.currentTimeMillis()))
+            .put("command", command)
+        val result = host.request("feature.messaging.execute", JSONObject().put("requestId", requestId).put("envelope", envelope))
+        apply(result.optJSONArray("envelopes") ?: JSONArray())
+    }
+
+    private fun apply(envelopes: JSONArray) {
+        var conversations = mutableState.value.conversations.toMutableList()
+        var contacts = mutableState.value.contacts
+        val messageMap = mutableState.value.messagesByConversation.mapValues { it.value.toMutableList() }.toMutableMap()
+        for (i in 0 until envelopes.length()) {
+            val event = envelopes.optJSONObject(i)?.optJSONObject("event") ?: continue
+            when (event.optString("type")) {
+                "syncBatch" -> {
+                    conversations = parseConversations(event.optJSONArray("conversations") ?: JSONArray()).toMutableList()
+                    contacts = parseContacts(event.optJSONArray("actors") ?: JSONArray())
+                    messageMap.clear()
+                    parseMessages(event.optJSONArray("messages") ?: JSONArray()).forEach { messageMap.getOrPut(it.conversationId) { mutableListOf() }.add(it) }
+                }
+                "conversationChanged" -> parseConversation(event.optJSONObject("conversation"))?.let { item ->
+                    val index = conversations.indexOfFirst { it.id == item.id }; if (index >= 0) conversations[index] = item else conversations.add(item)
+                }
+                "messageAdded", "messageChanged" -> parseMessage(event.optJSONObject("message"))?.let { item ->
+                    val list = messageMap.getOrPut(item.conversationId) { mutableListOf() }; val index = list.indexOfFirst { it.id == item.id }; if (index >= 0) list[index] = item else list.add(item)
+                }
+                "messagesDeleted" -> {
+                    val conversationId = event.optString("conversationId"); val ids = event.optJSONArray("messageIds")?.toStringSet().orEmpty(); messageMap[conversationId]?.removeAll { it.id in ids }
+                }
+            }
+        }
+        conversations = conversations.map { conversation ->
+            val last = messageMap[conversation.id]?.lastOrNull(); if (last == null) conversation else conversation.copy(preview = last.text, time = last.time)
+        }.toMutableList()
+        mutableState.value = mutableState.value.copy(conversations = conversations, contacts = contacts, messagesByConversation = messageMap.mapValues { it.value.toList() }, error = null)
+    }
+
+    private fun parseContacts(array: JSONArray) = buildList {
+        for (i in 0 until array.length()) {
+            val raw = array.optJSONObject(i) ?: continue
+            val id = raw.optString("id"); if (id.isBlank() || id == actorId) continue
+            val name = raw.optString("displayName"); if (name.isBlank()) continue
+            add(MessagingContact(id, name, raw.optString("username").takeIf { it.isNotBlank() }, raw.optString("kind", "human")))
+        }
+    }
+    private fun parseConversations(array: JSONArray) = buildList { for (i in 0 until array.length()) parseConversation(array.optJSONObject(i))?.let(::add) }
+    private fun parseMessages(array: JSONArray) = buildList { for (i in 0 until array.length()) parseMessage(array.optJSONObject(i))?.let(::add) }
+
+    private fun baseConversation(id: String, kind: ConversationKind, title: String, description: String, participants: JSONArray, now: Long): JSONObject =
+        JSONObject().put("id", id).put("kind", kind.wire).put("title", title)
+            .put("description", description.let { if (it.isBlank()) JSONObject.NULL else it }).put("avatarUrl", JSONObject.NULL).put("participants", participants)
+            .put("ownerId", actorId).put("lastMessageId", JSONObject.NULL).put("lastReadMessageId", JSONObject.NULL)
+            .put("unreadCount", 0).put("mentionCount", 0).put("pinnedMessageIds", JSONArray())
+            .put("notificationSettings", JSONObject().put("mutedUntilMs", JSONObject.NULL).put("sound", JSONObject.NULL).put("showPreview", true).put("notifyMentions", true))
+            .put("permissions", JSONObject().put("canSendMessages", true).put("canSendMedia", true).put("canSendPolls", true).put("canAddMembers", true).put("canPinMessages", true).put("canManageTopics", true).put("canManageCalls", true))
+            .put("historyVisibility", "allMembers").put("topics", JSONArray()).put("folderIds", JSONArray())
+            .put("archived", false).put("pinned", false).put("markedUnread", false).put("createdAtMs", now).put("updatedAtMs", now)
+
+    private fun parseConversation(raw: JSONObject?): ConversationSummary? {
+        raw ?: return null; val id = raw.optString("id"); val title = raw.optString("title"); if (id.isBlank() || title.isBlank()) return null
+        val kind = ConversationKind.entries.firstOrNull { it.wire == raw.optString("kind") } ?: ConversationKind.DIRECT
+        val mutedUntil = raw.optJSONObject("notificationSettings")?.optLong("mutedUntilMs", 0L) ?: 0L
+        return ConversationSummary(id, title, raw.optString("description"), timeLabel(raw.optLong("updatedAtMs")), title.take(1).uppercase().ifBlank { "✦" }, kind,
+            raw.optInt("unreadCount"), raw.optBoolean("pinned"), mutedUntil > System.currentTimeMillis(), raw.optBoolean("archived"), raw.optString("lastMessageId").takeIf { it.isNotBlank() })
+    }
+
+    private fun parseMessage(raw: JSONObject?): ChatMessage? {
+        raw ?: return null; val id = raw.optString("id"); val conversationId = raw.optString("conversationId"); val senderId = raw.optString("senderId"); if (id.isBlank() || conversationId.isBlank()) return null
+        val content = raw.optJSONObject("content") ?: JSONObject(); val text = when (content.optString("type")) {
+            "text" -> content.optJSONObject("data")?.optJSONObject("text")?.optString("text").orEmpty()
+            "photo" -> "🖼 图片"; "video" -> "🎬 视频"; "document" -> "📎 文件"; "location" -> "📍 位置"; "contact" -> "👤 联系人"; "invoice" -> "🧾 账单"; "miniApp" -> "▣ Mini App"; else -> "消息"
+        }
+        return ChatMessage(id, conversationId, text, senderId == actorId, timeLabel(raw.optLong("createdAtMs")))
+    }
+
+    private fun timeLabel(ms: Long): String = if (ms <= 0) "" else java.text.DateFormat.getTimeInstance(java.text.DateFormat.SHORT).format(java.util.Date(ms))
+
+    override fun onCleared() { host.close(); super.onCleared() }
+}
+
+private fun JSONArray.toStringSet(): Set<String> = buildSet { for (i in 0 until length()) optString(i).takeIf { it.isNotBlank() }?.let(::add) }

--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -6,31 +6,6 @@ private enum MobileDestination {
     case remoteComputer
 }
 
-private enum ConversationKind: String, Identifiable {
-    case direct
-    case group
-    case channel
-    case bot
-
-    var id: String { rawValue }
-    var label: String {
-        switch self {
-        case .direct: "私聊"
-        case .group: "群组"
-        case .channel: "频道"
-        case .bot: "Bot"
-        }
-    }
-    var symbol: String {
-        switch self {
-        case .direct: "person.fill"
-        case .group: "person.3.fill"
-        case .channel: "megaphone.fill"
-        case .bot: "sparkles"
-        }
-    }
-}
-
 private enum MobileSection: String, CaseIterable, Identifiable {
     case chats, contacts, bots, groups, channels, calls, saved, archive, folders, miniapps, payments, settings
     var id: String { rawValue }
@@ -68,36 +43,15 @@ private enum MobileSection: String, CaseIterable, Identifiable {
     }
 }
 
-private struct ConversationSummary: Identifiable, Equatable {
-    let id: String
-    var title: String
-    var preview: String
-    var time: String
-    var badge: String
-    var kind: ConversationKind
-    var unreadCount: Int = 0
-    var isPinned: Bool = false
-    var isMuted: Bool = false
-    var isArchived: Bool = false
-}
-
-private struct ChatMessage: Identifiable, Equatable {
-    let id: String
-    let text: String
-    let isOutgoing: Bool
-    let time: String
-}
-
 struct ContentView: View {
     @Bindable var model: MarketplaceModel
+    @Bindable var messaging: MessagingModel
     let appAgentSurface: FabushiAppAgentSurface
     @State private var openedMiniApp: MarketplacePlugin?
     @State private var destination: MobileDestination = .home
     @State private var isSearching = false
     @State private var homeQuery = ""
     @State private var selectedConversation: ConversationSummary?
-    @State private var conversations: [ConversationSummary] = []
-    @State private var messagesByConversation: [String: [ChatMessage]] = [:]
     @State private var messageDraft = ""
     @State private var composeMenuPresented = false
     @State private var composeKind: ConversationKind?
@@ -344,17 +298,17 @@ struct ContentView: View {
                             conversationRow(conversation)
                                 .swipeActions(edge: .leading, allowsFullSwipe: true) {
                                     Button {
-                                        mutateConversation(conversation.id) { $0.isPinned.toggle() }
+                                        Task { await messaging.setPinned(conversation.id, pinned: !conversation.isPinned) }
                                     } label: { Label(conversation.isPinned ? "取消置顶" : "置顶", systemImage: "pin.fill") }
                                     .tint(.orange)
                                 }
                                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                     Button {
-                                        mutateConversation(conversation.id) { $0.isArchived = true }
+                                        Task { await messaging.setArchived(conversation.id, archived: true) }
                                     } label: { Label("归档", systemImage: "archivebox.fill") }
                                     .tint(.blue)
                                     Button {
-                                        mutateConversation(conversation.id) { $0.isMuted.toggle() }
+                                        Task { await messaging.setMuted(conversation.id, muted: !conversation.isMuted) }
                                     } label: { Label(conversation.isMuted ? "取消静音" : "静音", systemImage: "speaker.slash.fill") }
                                     .tint(.gray)
                                 }
@@ -380,18 +334,6 @@ struct ContentView: View {
                 }
                 .accessibilityIdentifier("conversation-list")
 
-                Button { composeMenuPresented = true } label: {
-                    Image(systemName: "square.and.pencil")
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .frame(width: 56, height: 56)
-                        .background(Color.accentColor, in: Circle())
-                        .shadow(radius: 8, y: 4)
-                }
-                .padding(18)
-                .opacity(isSearching ? 0 : 1)
-                .allowsHitTesting(!isSearching)
-                .accessibilityIdentifier("home-add-button")
             }
             .navigationTitle("聊天")
             .navigationBarTitleDisplayMode(.inline)
@@ -416,31 +358,31 @@ struct ContentView: View {
                     } label: { Image(systemName: isSearching ? "xmark" : "magnifyingglass") }
                     .accessibilityIdentifier("home-search-button")
                     Button { composeMenuPresented = true } label: { Image(systemName: "square.and.pencil") }
-                        .accessibilityIdentifier("home-compose-nav")
+                        .accessibilityIdentifier("home-add-button")
                 }
             }
         }
         .confirmationDialog("新建", isPresented: $composeMenuPresented, titleVisibility: .visible) {
-            Button("新建私聊") { startCompose(.direct) }
+            Button("新消息") { activeSection = .contacts }
             Button("新建群组") { startCompose(.group) }
             Button("新建频道") { startCompose(.channel) }
-            Button("新建 Bot") { startCompose(.bot) }
             Button("联系人分组") { contactGroupsPresented = true }
             Button("取消", role: .cancel) {}
         }
         .sheet(item: $composeKind) { kind in composeSheet(kind) }
         .sheet(isPresented: $contactGroupsPresented) { simpleSectionSheet(title: "联系人分组", symbol: "folder.fill") }
-        .sheet(item: $activeSection) { section in simpleSectionSheet(title: section.label, symbol: section.symbol) }
+        .sheet(item: $activeSection) { section in sectionSheet(section) }
         .fullScreenCover(item: $selectedConversation) { conversation in chatView(conversation) }
         .accessibilityIdentifier("app-shell")
+        .task { await messaging.refresh() }
     }
 
     private var visibleConversations: [ConversationSummary] {
-        conversations.filter { !$0.isArchived }
+        messaging.conversations.filter { !$0.isArchived }
             .sorted { lhs, rhs in lhs.isPinned != rhs.isPinned ? lhs.isPinned : lhs.time > rhs.time }
     }
 
-    private var archivedConversations: [ConversationSummary] { conversations.filter(\.isArchived) }
+    private var archivedConversations: [ConversationSummary] { messaging.conversations.filter(\.isArchived) }
 
     private var filteredConversations: [ConversationSummary] {
         let query = homeQuery.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -463,8 +405,8 @@ struct ContentView: View {
                         .accessibilityIdentifier("compose-name")
                     if kind == .channel { TextField("描述", text: $composeDescription, axis: .vertical) }
                 }
-                if kind == .group || kind == .bot {
-                    Section("Fabushi") { Text(kind == .group ? "创建后可从统一 Bot/联系人目录添加成员。" : "创建后进入与桌面端相同的 Bot 配置流程。") }
+                if kind == .group {
+                    Section("Fabushi") { Text("创建后可从统一联系人与 Bot 目录添加成员。") }
                 }
             }
             .navigationTitle("新建\(kind.label)")
@@ -479,17 +421,16 @@ struct ContentView: View {
 
     private func createConversation(kind: ConversationKind) {
         let title = composeName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let id = "\(kind.rawValue)-\(UUID().uuidString.lowercased())"
-        let conversation = ConversationSummary(id: id, title: title, preview: composeDescription.isEmpty ? "开始一段新的对话" : composeDescription, time: "现在", badge: String(title.prefix(1)).uppercased(), kind: kind)
-        conversations.insert(conversation, at: 0)
-        composeKind = nil
-        selectedConversation = conversation
-    }
-
-    private func mutateConversation(_ id: String, mutation: (inout ConversationSummary) -> Void) {
-        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
-        mutation(&conversations[index])
-        if selectedConversation?.id == id { selectedConversation = conversations[index] }
+        let description = composeDescription
+        Task {
+            do {
+                let created = try await messaging.createConversation(kind: kind, title: title, description: description)
+                composeKind = nil
+                if let created { selectedConversation = created }
+            } catch {
+                model.message = "创建会话失败：\(error.localizedDescription)"
+            }
+        }
     }
 
     private func handleSection(_ section: MobileSection) {
@@ -497,6 +438,68 @@ struct ContentView: View {
         case .chats: activeSection = nil
         case .miniapps: destination = .marketplace
         default: activeSection = section
+        }
+    }
+
+    @ViewBuilder
+    private func sectionSheet(_ section: MobileSection) -> some View {
+        if section == .contacts || section == .bots {
+            NavigationStack {
+                List {
+                    let rows = section == .bots ? messaging.contacts.filter { $0.kind == "bot" || $0.kind == "assistant" } : messaging.contacts
+                    if rows.isEmpty {
+                        ContentUnavailableView(section.label, systemImage: section.symbol, description: Text("暂无可用联系人"))
+                    } else {
+                        ForEach(rows) { contact in
+                            Button {
+                                Task {
+                                    do {
+                                        if let conversation = try await messaging.createDirect(contact: contact) {
+                                            activeSection = nil
+                                            selectedConversation = conversation
+                                        }
+                                    } catch {
+                                        model.message = "创建私聊失败：\(error.localizedDescription)"
+                                    }
+                                }
+                            } label: {
+                                HStack(spacing: 12) {
+                                    ZStack {
+                                        Circle().fill(Color.accentColor)
+                                        Text(String(contact.displayName.prefix(1)).uppercased()).foregroundStyle(.white).fontWeight(.bold)
+                                    }.frame(width: 42, height: 42)
+                                    VStack(alignment: .leading) {
+                                        Text(contact.displayName).foregroundStyle(.primary)
+                                        Text(contact.username.map { "@\($0)" } ?? contact.kind).font(.caption).foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                .navigationTitle(section.label)
+                .toolbar { ToolbarItem(placement: .topBarLeading) { Button("完成") { activeSection = nil } } }
+            }
+        } else if section == .groups || section == .channels || section == .archive || section == .saved {
+            NavigationStack {
+                List {
+                    let rows = messaging.conversations.filter { conversation in
+                        switch section {
+                        case .groups: conversation.kind == .group && !conversation.isArchived
+                        case .channels: conversation.kind == .channel && !conversation.isArchived
+                        case .archive: conversation.isArchived
+                        case .saved: conversation.kind == .savedMessages
+                        default: false
+                        }
+                    }
+                    if rows.isEmpty { ContentUnavailableView(section.label, systemImage: section.symbol) }
+                    ForEach(rows) { conversation in conversationRow(conversation) }
+                }
+                .navigationTitle(section.label)
+                .toolbar { ToolbarItem(placement: .topBarLeading) { Button("完成") { activeSection = nil } } }
+            }
+        } else {
+            simpleSectionSheet(title: section.label, symbol: section.symbol)
         }
     }
 
@@ -511,8 +514,8 @@ struct ContentView: View {
 
     private func conversationRow(_ conversation: ConversationSummary) -> some View {
         Button {
-            mutateConversation(conversation.id) { $0.unreadCount = 0 }
-            selectedConversation = conversations.first(where: { $0.id == conversation.id }) ?? conversation
+            selectedConversation = conversation
+            Task { await messaging.markRead(conversation.id) }
         } label: {
             HStack(spacing: 12) {
                 ZStack {
@@ -552,7 +555,7 @@ struct ContentView: View {
                     ScrollViewReader { proxy in
                         ScrollView {
                             LazyVStack(spacing: 8) {
-                                ForEach(messagesByConversation[conversation.id] ?? []) { message in
+                                ForEach(messaging.messagesByConversation[conversation.id] ?? []) { message in
                                     HStack {
                                         if message.isOutgoing { Spacer(minLength: 56) }
                                         VStack(alignment: .trailing, spacing: 3) {
@@ -569,8 +572,8 @@ struct ContentView: View {
                                 }
                             }.padding(.vertical, 12)
                         }
-                        .onChange(of: messagesByConversation[conversation.id]?.count ?? 0) { _, _ in
-                            if let id = messagesByConversation[conversation.id]?.last?.id { withAnimation { proxy.scrollTo(id, anchor: .bottom) } }
+                        .onChange(of: messaging.messagesByConversation[conversation.id]?.count ?? 0) { _, _ in
+                            if let id = messaging.messagesByConversation[conversation.id]?.last?.id { withAnimation { proxy.scrollTo(id, anchor: .bottom) } }
                         }
                     }
                     HStack(alignment: .bottom, spacing: 8) {
@@ -596,9 +599,9 @@ struct ContentView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {
                         Button("搜索", systemImage: "magnifyingglass") {}
-                        Button(conversation.isMuted ? "取消静音" : "静音", systemImage: "speaker.slash") { mutateConversation(conversation.id) { $0.isMuted.toggle() } }
-                        Button(conversation.isPinned ? "取消置顶" : "置顶", systemImage: "pin") { mutateConversation(conversation.id) { $0.isPinned.toggle() } }
-                        Button("归档", systemImage: "archivebox") { mutateConversation(conversation.id) { $0.isArchived = true }; selectedConversation = nil }
+                        Button(conversation.isMuted ? "取消静音" : "静音", systemImage: "speaker.slash") { Task { await messaging.setMuted(conversation.id, muted: !conversation.isMuted) } }
+                        Button(conversation.isPinned ? "取消置顶" : "置顶", systemImage: "pin") { Task { await messaging.setPinned(conversation.id, pinned: !conversation.isPinned) } }
+                        Button("归档", systemImage: "archivebox") { Task { await messaging.setArchived(conversation.id, archived: true) }; selectedConversation = nil }
                     } label: { Image(systemName: "ellipsis.circle") }
                 }
             }
@@ -608,10 +611,11 @@ struct ContentView: View {
     private func sendMessage(in conversation: ConversationSummary) {
         let text = messageDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
-        let now = Date.now.formatted(date: .omitted, time: .shortened)
-        messagesByConversation[conversation.id, default: []].append(ChatMessage(id: UUID().uuidString, text: text, isOutgoing: true, time: now))
         messageDraft = ""
-        mutateConversation(conversation.id) { item in item.preview = text; item.time = "现在" }
+        Task {
+            do { try await messaging.sendText(conversationId: conversation.id, text: text) }
+            catch { model.message = "发送失败：\(error.localizedDescription)" }
+        }
     }
 
     private var avatar: some View {

--- a/mobile/ios/Fabushi/FabushiApp.swift
+++ b/mobile/ios/Fabushi/FabushiApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct FabushiApp: App {
     @State private var model: MarketplaceModel
     @State private var appAgentSurface: FabushiAppAgentSurface
+    @State private var messagingModel: MessagingModel
 
     init() {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -14,9 +15,9 @@ struct FabushiApp: App {
             #else
             let featureHostTest = false
             #endif
-            _model = State(initialValue: MarketplaceModel(
-                host: try MahayanaHost(appDataDirectory: base, featureHostTest: featureHostTest)
-            ))
+            let host = try MahayanaHost(appDataDirectory: base, featureHostTest: featureHostTest)
+            _model = State(initialValue: MarketplaceModel(host: host))
+            _messagingModel = State(initialValue: MessagingModel(host: host))
             _appAgentSurface = State(initialValue: FabushiAppAgentSurface())
         } catch {
             fatalError("Failed to initialize Mahayana Host: \(error)")
@@ -25,10 +26,11 @@ struct FabushiApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView(model: model, appAgentSurface: appAgentSurface)
+            ContentView(model: model, messaging: messagingModel, appAgentSurface: appAgentSurface)
                 .task {
                     await model.runFeatureHostSmokeIfRequested()
                     await model.refresh()
+                    await messagingModel.refresh()
                 }
                 .onOpenURL { url in
                     consumeDeepLink(url)

--- a/mobile/ios/Fabushi/MessagingModel.swift
+++ b/mobile/ios/Fabushi/MessagingModel.swift
@@ -1,0 +1,314 @@
+import Foundation
+import Observation
+
+internal enum ConversationKind: String, Identifiable, Sendable {
+    case direct
+    case group
+    case channel
+    case savedMessages
+    case secret
+
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .direct: "私聊"
+        case .group: "群组"
+        case .channel: "频道"
+        case .savedMessages: "收藏"
+        case .secret: "加密聊天"
+        }
+    }
+}
+
+internal struct ConversationSummary: Identifiable, Equatable, Sendable {
+    let id: String
+    var title: String
+    var preview: String
+    var time: String
+    var badge: String
+    var kind: ConversationKind
+    var unreadCount: Int
+    var isPinned: Bool
+    var isMuted: Bool
+    var isArchived: Bool
+    var lastMessageId: String?
+}
+
+internal struct MessagingContact: Identifiable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let username: String?
+    let kind: String
+}
+
+internal struct ChatMessage: Identifiable, Equatable, Sendable {
+    let id: String
+    let conversationId: String
+    let text: String
+    let isOutgoing: Bool
+    let time: String
+}
+
+@MainActor
+@Observable
+final class MessagingModel {
+    private(set) var conversations: [ConversationSummary] = []
+    private(set) var contacts: [MessagingContact] = []
+    private(set) var messagesByConversation: [String: [ChatMessage]] = [:]
+    private(set) var loading = false
+    private(set) var errorMessage: String?
+
+    private let host: MahayanaHost
+    private var actorId = ""
+    private var displayName = "当前用户"
+    private let deviceId = "ios:native"
+    private let sessionId = "account-session:ios-native"
+
+    init(host: MahayanaHost) {
+        self.host = host
+    }
+
+    func refresh() async {
+        loading = true
+        defer { loading = false }
+        do {
+            try await ensureIdentity()
+            _ = try await execute(command: ["type": "sync", "cursor": NSNull(), "limit": 1000])
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func createDirect(contact: MessagingContact) async throws -> ConversationSummary? {
+        try await ensureIdentity()
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        let id = "direct:\(UUID().uuidString.lowercased())"
+        let participants: [[String: Any]] = [
+            ["actorId": actorId, "role": "owner", "joinedAtMs": now, "mutedUntilMs": NSNull()],
+            ["actorId": contact.id, "role": "member", "joinedAtMs": now, "mutedUntilMs": NSNull()],
+        ]
+        let conversation = conversationPayload(id: id, kind: .direct, title: contact.displayName, description: "", participants: participants, now: now)
+        _ = try await execute(command: ["type": "createConversation", "conversation": conversation])
+        return conversations.first(where: { $0.id == id })
+    }
+
+    func createConversation(kind: ConversationKind, title: String, description: String = "") async throws -> ConversationSummary? {
+        guard kind == .group || kind == .channel else {
+            throw MahayanaHost.HostError.requestFailed("私聊请从联系人列表发起")
+        }
+        try await ensureIdentity()
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        let id = "\(kind.rawValue):\(UUID().uuidString.lowercased())"
+        let participants: [[String: Any]] = [["actorId": actorId, "role": "owner", "joinedAtMs": now, "mutedUntilMs": NSNull()]]
+        let conversation = conversationPayload(id: id, kind: kind, title: title.trimmingCharacters(in: .whitespacesAndNewlines), description: description, participants: participants, now: now)
+        _ = try await execute(command: ["type": "createConversation", "conversation": conversation])
+        return conversations.first(where: { $0.id == id })
+    }
+
+    func sendText(conversationId: String, text: String) async throws {
+        try await ensureIdentity()
+        let value = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        _ = try await execute(command: [
+            "type": "sendMessage",
+            "conversationId": conversationId,
+            "clientMessageId": "ios:\(UUID().uuidString.lowercased())",
+            "content": ["type": "text", "data": ["text": ["text": value, "entities": []]]],
+            "replyToMessageId": NSNull(),
+            "threadRootMessageId": NSNull(),
+            "scheduledAtMs": NSNull(),
+            "silent": false,
+            "protectedContent": false,
+        ])
+    }
+
+    func setPinned(_ conversationId: String, pinned: Bool) async {
+        try? await executeAfterIdentity(["type": "pinConversation", "conversationId": conversationId, "pinned": pinned])
+    }
+
+    func setArchived(_ conversationId: String, archived: Bool) async {
+        try? await executeAfterIdentity(["type": "archiveConversation", "conversationId": conversationId, "archived": archived])
+    }
+
+    func setMuted(_ conversationId: String, muted: Bool) async {
+        let until: Any = muted ? Int64.max / 4 : NSNull()
+        try? await executeAfterIdentity([
+            "type": "setConversationNotifications",
+            "conversationId": conversationId,
+            "settings": ["mutedUntilMs": until, "sound": NSNull(), "showPreview": true, "notifyMentions": true],
+        ])
+    }
+
+    func markRead(_ conversationId: String) async {
+        guard let last = conversations.first(where: { $0.id == conversationId })?.lastMessageId else { return }
+        try? await executeAfterIdentity(["type": "markRead", "conversationId": conversationId, "messageId": last])
+    }
+
+    private func executeAfterIdentity(_ command: [String: Any]) async throws {
+        try await ensureIdentity()
+        _ = try await execute(command: command)
+    }
+
+    private func ensureIdentity() async throws {
+        guard actorId.isEmpty else { return }
+        let auth = try await host.request(method: "feature.auth.status")
+        if let object = auth.value as? [String: Any], let user = object["user"] as? [String: Any] {
+            displayName = (user["nickname"] as? String) ?? (user["username"] as? String) ?? displayName
+        }
+        let access = try await host.request(
+            method: "feature.messaging.access.issue",
+            params: ["deviceId": deviceId, "sessionId": sessionId, "scopes": ["messaging", "calls", "blobsRead", "blobsWrite", "payments", "miniApps"]]
+        )
+        guard let object = access.value as? [String: Any], let resolvedActor = object["actorId"] as? String, !resolvedActor.isEmpty else {
+            throw MahayanaHost.HostError.invalidResponse
+        }
+        actorId = resolvedActor
+        _ = try await execute(command: [
+            "type": "upsertProfile",
+            "actor": [
+                "id": actorId,
+                "kind": "human",
+                "displayName": displayName,
+                "username": NSNull(),
+                "avatarUrl": NSNull(),
+                "bio": NSNull(),
+                "capabilities": ["messages", "groups", "channels", "calls", "payments", "miniApps"],
+                "presence": ["status": "online", "lastSeenAtMs": Int64(Date().timeIntervalSince1970 * 1000), "statusText": NSNull()],
+                "verified": false,
+            ],
+        ])
+    }
+
+    @discardableResult
+    private func execute(command: [String: Any]) async throws -> [[String: Any]] {
+        let requestId = "ios-messaging-\(UUID().uuidString.lowercased())"
+        let envelope: [String: Any] = [
+            "protocolVersion": 2,
+            "context": [
+                "requestId": requestId,
+                "deviceId": deviceId,
+                "actorId": actorId,
+                "sessionId": sessionId,
+                "sentAtMs": Int64(Date().timeIntervalSince1970 * 1000),
+            ],
+            "command": command,
+        ]
+        let result = try await host.request(method: "feature.messaging.execute", params: ["requestId": requestId, "envelope": envelope])
+        guard let root = result.value as? [String: Any], let envelopes = root["envelopes"] as? [[String: Any]] else {
+            throw MahayanaHost.HostError.invalidResponse
+        }
+        apply(envelopes)
+        return envelopes
+    }
+
+    private func apply(_ envelopes: [[String: Any]]) {
+        for envelope in envelopes {
+            guard let event = envelope["event"] as? [String: Any], let type = event["type"] as? String else { continue }
+            switch type {
+            case "syncBatch":
+                let rows = (event["conversations"] as? [[String: Any]] ?? []).compactMap(parseConversation)
+                conversations = rows
+                contacts = (event["actors"] as? [[String: Any]] ?? []).compactMap(parseContact)
+                let messages = (event["messages"] as? [[String: Any]] ?? []).compactMap(parseMessage)
+                messagesByConversation = Dictionary(grouping: messages, by: \.conversationId)
+            case "conversationChanged":
+                if let raw = event["conversation"] as? [String: Any], let conversation = parseConversation(raw) { upsert(conversation) }
+            case "messageAdded", "messageChanged":
+                if let raw = event["message"] as? [String: Any], let message = parseMessage(raw) {
+                    var list = messagesByConversation[message.conversationId] ?? []
+                    if let index = list.firstIndex(where: { $0.id == message.id }) { list[index] = message } else { list.append(message) }
+                    messagesByConversation[message.conversationId] = list.sorted { $0.time < $1.time }
+                }
+            case "messagesDeleted":
+                guard let id = event["conversationId"] as? String, let ids = event["messageIds"] as? [String] else { continue }
+                messagesByConversation[id]?.removeAll { ids.contains($0.id) }
+            default:
+                break
+            }
+        }
+        hydratePreviews()
+    }
+
+    private func upsert(_ conversation: ConversationSummary) {
+        if let index = conversations.firstIndex(where: { $0.id == conversation.id }) { conversations[index] = conversation }
+        else { conversations.append(conversation) }
+    }
+
+    private func hydratePreviews() {
+        for index in conversations.indices {
+            let conversation = conversations[index]
+            if let last = messagesByConversation[conversation.id]?.last {
+                conversations[index].preview = last.text
+                conversations[index].time = last.time
+            }
+        }
+    }
+
+    private func conversationPayload(id: String, kind: ConversationKind, title: String, description: String, participants: [[String: Any]], now: Int64) -> [String: Any] {
+        [
+            "id": id, "kind": kind.rawValue, "title": title,
+            "description": description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? NSNull() : description.trimmingCharacters(in: .whitespacesAndNewlines),
+            "avatarUrl": NSNull(), "participants": participants, "ownerId": actorId,
+            "lastMessageId": NSNull(), "lastReadMessageId": NSNull(), "unreadCount": 0, "mentionCount": 0, "pinnedMessageIds": [],
+            "notificationSettings": ["mutedUntilMs": NSNull(), "sound": NSNull(), "showPreview": true, "notifyMentions": true],
+            "permissions": ["canSendMessages": true, "canSendMedia": true, "canSendPolls": true, "canAddMembers": true, "canPinMessages": true, "canManageTopics": true, "canManageCalls": true],
+            "historyVisibility": "allMembers", "topics": [], "folderIds": [], "archived": false, "pinned": false, "markedUnread": false,
+            "createdAtMs": now, "updatedAtMs": now,
+        ]
+    }
+
+    private func parseContact(_ raw: [String: Any]) -> MessagingContact? {
+        guard let id = raw["id"] as? String, id != actorId, let name = raw["displayName"] as? String, !name.isEmpty else { return nil }
+        return MessagingContact(id: id, displayName: name, username: raw["username"] as? String, kind: raw["kind"] as? String ?? "human")
+    }
+
+    private func parseConversation(_ raw: [String: Any]) -> ConversationSummary? {
+        guard let id = raw["id"] as? String, let title = raw["title"] as? String else { return nil }
+        let kind = ConversationKind(rawValue: raw["kind"] as? String ?? "direct") ?? .direct
+        let mutedUntil = (raw["notificationSettings"] as? [String: Any])?["mutedUntilMs"] as? NSNumber
+        let updatedAt = (raw["updatedAtMs"] as? NSNumber)?.int64Value ?? 0
+        let initial = title.trimmingCharacters(in: .whitespacesAndNewlines).first.map { String($0).uppercased() } ?? "✦"
+        return ConversationSummary(
+            id: id,
+            title: title,
+            preview: (raw["description"] as? String) ?? "",
+            time: Self.timeLabel(updatedAt),
+            badge: initial,
+            kind: kind,
+            unreadCount: (raw["unreadCount"] as? NSNumber)?.intValue ?? 0,
+            isPinned: raw["pinned"] as? Bool ?? false,
+            isMuted: (mutedUntil?.int64Value ?? 0) > Int64(Date().timeIntervalSince1970 * 1000),
+            isArchived: raw["archived"] as? Bool ?? false,
+            lastMessageId: raw["lastMessageId"] as? String
+        )
+    }
+
+    private func parseMessage(_ raw: [String: Any]) -> ChatMessage? {
+        guard let id = raw["id"] as? String,
+              let conversationId = raw["conversationId"] as? String,
+              let senderId = raw["senderId"] as? String,
+              let content = raw["content"] as? [String: Any]
+        else { return nil }
+        let text: String
+        switch content["type"] as? String {
+        case "text": text = (((content["data"] as? [String: Any])?["text"] as? [String: Any])?["text"] as? String) ?? ""
+        case "photo": text = "🖼 图片"
+        case "video": text = "🎬 视频"
+        case "document": text = "📎 文件"
+        case "location": text = "📍 位置"
+        case "contact": text = "👤 联系人"
+        case "invoice": text = "🧾 账单"
+        case "miniApp": text = "▣ Mini App"
+        default: text = "消息"
+        }
+        let createdAt = (raw["createdAtMs"] as? NSNumber)?.int64Value ?? 0
+        return ChatMessage(id: id, conversationId: conversationId, text: text, isOutgoing: senderId == actorId, time: Self.timeLabel(createdAt))
+    }
+
+    private static func timeLabel(_ milliseconds: Int64) -> String {
+        guard milliseconds > 0 else { return "" }
+        let date = Date(timeIntervalSince1970: Double(milliseconds) / 1000)
+        return date.formatted(date: .omitted, time: .shortened)
+    }
+}

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -33,15 +33,11 @@ final class FabushiUITests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["conversation-list"].exists)
         XCTAssertFalse(app.staticTexts["Chief of Staff"].exists)
         app.buttons["home-add-button"].tap()
-        let newDirect = app.buttons["新建私聊"]
-        XCTAssertTrue(newDirect.waitForExistence(timeout: 5))
-        newDirect.tap()
-        let composeName = app.textFields["compose-name"]
-        XCTAssertTrue(composeName.waitForExistence(timeout: 5))
-        composeName.tap()
-        composeName.typeText("测试联系人")
-        app.buttons["compose-create"].tap()
-        XCTAssertTrue(app.navigationBars["测试联系人"].waitForExistence(timeout: 5))
+        let newMessage = app.buttons["新消息"]
+        XCTAssertTrue(newMessage.waitForExistence(timeout: 5))
+        newMessage.tap()
+        XCTAssertTrue(app.navigationBars["联系人"].waitForExistence(timeout: 5))
+        app.buttons["完成"].tap()
 
         openRemoteComputer(in: app)
         let remoteComputer = app.descendants(matching: .any)["remote-computer-surface"]

--- a/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-app-host/src/lib.rs
@@ -206,6 +206,7 @@ impl AppHost {
             "feature.plugin.active" => self.active_plugin(params),
             "feature.plugin.listInstalled" => self.list_installed_plugins(),
             "feature.plugin.uiDocument" => self.plugin_ui_document(params),
+            "feature.messaging.execute" => self.feature_messaging_execute(params),
             "feature.messaging.access.issue" => self.feature_messaging_access_issue(params),
             other => Err(AppHostError::InvalidRequest(format!(
                 "unknown feature method {other}"
@@ -256,6 +257,19 @@ impl AppHost {
             .interrupt(operation_id)
             .map_err(|error| AppHostError::Operation(error.to_string()))?;
         Ok(Value::Null)
+    }
+
+    fn feature_messaging_execute(&self, params: Value) -> Result<Value, AppHostError> {
+        let request_id = string_param(&params, "requestId")?.to_string();
+        let envelope = params
+            .get("envelope")
+            .cloned()
+            .ok_or_else(|| AppHostError::InvalidRequest("envelope is required".into()))?;
+        let envelopes = self
+            .feature
+            .execute_messaging_sync(request_id, envelope)
+            .map_err(|error| AppHostError::Operation(error.to_string()))?;
+        Ok(json!({"envelopes": envelopes}))
     }
 
     fn feature_messaging_access_issue(&self, params: Value) -> Result<Value, AppHostError> {

--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -1038,6 +1038,23 @@ impl FeatureHostController {
         request_id: String,
         envelope: Value,
     ) -> Result<CommandAccepted, FeatureHostError> {
+        self.execute_messaging_sync(request_id.clone(), envelope)?;
+        Ok(CommandAccepted {
+            request_id,
+            operation_id: None,
+        })
+    }
+
+    /// Executes one messaging envelope against the exact same persistent
+    /// `MessagingService` used by desktop and also returns the resulting server
+    /// envelopes to native shells. The envelopes are still projected onto the
+    /// regular FeatureHost event queue, so desktop/event-driven consumers retain
+    /// their existing behavior while iOS and Android can update synchronously.
+    pub fn execute_messaging_sync(
+        &self,
+        request_id: String,
+        envelope: Value,
+    ) -> Result<Vec<Value>, FeatureHostError> {
         static MESSAGING_IO_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let _io_guard = MESSAGING_IO_LOCK
             .get_or_init(|| Mutex::new(()))
@@ -1061,19 +1078,22 @@ impl FeatureHostController {
         let responses = service
             .handle(client_envelope, now_millis())
             .map_err(|error| FeatureHostError::Contract(error.to_string()))?;
+        let envelopes = responses
+            .into_iter()
+            .map(|response| {
+                serde_json::to_value(response)
+                    .map_err(|error| FeatureHostError::Contract(error.to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         let mut state = self.state()?;
-        for response in responses {
+        for envelope in &envelopes {
             state.events.push_back(HostEvent::MessagingEvent {
                 timestamp: timestamp(),
                 request_id: request_id.clone(),
-                envelope: serde_json::to_value(response)
-                    .map_err(|error| FeatureHostError::Contract(error.to_string()))?,
+                envelope: envelope.clone(),
             });
         }
-        Ok(CommandAccepted {
-            request_id,
-            operation_id: None,
-        })
+        Ok(envelopes)
     }
 
     fn execute_automation(


### PR DESCRIPTION
Continues the native mobile parity work after #2236 merged.

This increment removes the remaining mobile-only in-memory messaging model and routes iOS/Android through the same persistent Mahayana MessagingService used by desktop.

- adds synchronous native projection for `feature.messaging.execute` while preserving the existing FeatureHost event queue
- derives the same account-backed messaging actor identity on desktop/iOS/Android
- syncs conversations, actors/contacts and messages from the shared protocol v2 snapshot
- routes create group/channel, direct contact chat, text send, read, pin, mute and archive through the shared Rust runtime
- keeps Telegram-style platform-native compose placement: iOS navigation-bar compose, Android floating compose hidden during search
- changes “new message” to contact selection instead of creating synthetic named private chats
- keeps the hard-coded Chief of Staff pseudo-chat removed

Validation target: native mobile quality gate + repository CI. This PR is intentionally not a release trigger.