### PR TITLE
chore(release): publish Fabushi 1.1.0 [full-platform-release-final-20260831]

### DIFF
--- a/.github/scripts/assert-native-electron-canonical.sh
+++ b/.github/scripts/assert-native-electron-canonical.sh
@@ -60,9 +60,9 @@ if not marketing_match or marketing_match.group(1) != canonical:
     observed = marketing_match.group(1) if marketing_match else '<missing>'
     raise SystemExit(f'iOS marketing version drift: canonical={canonical} project={observed}')
 ios_build_number = str(canonical_data.get('iosBuildNumber', '')).strip()
-if not re.fullmatch(r'\\d+', ios_build_number):
+if not re.fullmatch(r'\d+', ios_build_number):
     raise SystemExit(f'invalid canonical iOS build number: {ios_build_number!r}')
-ios_build_match = re.search(r'^\\s*CURRENT_PROJECT_VERSION:\\s*[\\\"]?([^\\s\\\"]+)', ios_project, re.MULTILINE)
+ios_build_match = re.search(r'^\s*CURRENT_PROJECT_VERSION:\s*[\\"]?([^\s\"]+)', ios_project, re.MULTILINE)
 if not ios_build_match or ios_build_match.group(1) != ios_build_number:
     observed = ios_build_match.group(1) if ios_build_match else '<missing>'
     raise SystemExit(f'iOS build number drift: canonical={ios_build_number} project={observed}')

--- a/.github/scripts/assert-native-electron-canonical.sh
+++ b/.github/scripts/assert-native-electron-canonical.sh
@@ -29,13 +29,38 @@ grep -q 'androidx.compose' mobile/android/app/build.gradle || fail 'Android cano
 grep -q 'SwiftUI' mobile/ios/Fabushi/FabushiApp.swift || fail 'iOS canonical UI is not SwiftUI'
 python3 - <<'PY'
 import json
+import re
 from pathlib import Path
 
-canonical = json.loads(Path('app-version.json').read_text(encoding='utf-8'))['version']
-desktop = json.loads(Path('desktop/package.json').read_text(encoding='utf-8'))['version']
-mobile = json.loads(Path('mobile/package.json').read_text(encoding='utf-8'))['version']
-if desktop != canonical or mobile != canonical:
-    raise SystemExit(f'version drift: canonical={canonical} desktop={desktop} mobile={mobile}')
+canonical_data = json.loads(Path('app-version.json').read_text(encoding='utf-8'))
+canonical = str(canonical_data.get('version', '')).strip()
+if not re.fullmatch(r'\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?', canonical):
+    raise SystemExit(f'invalid canonical semantic version: {canonical!r}')
+
+def package_version(path):
+    return json.loads(Path(path).read_text(encoding='utf-8'))['version']
+
+def lock_root_version(path):
+    document = json.loads(Path(path).read_text(encoding='utf-8'))
+    return document['packages']['']['version']
+
+versions = {
+    'desktop/package.json': package_version('desktop/package.json'),
+    'desktop/package-lock.json': lock_root_version('desktop/package-lock.json'),
+    'mobile/package.json': package_version('mobile/package.json'),
+    'mobile/package-lock.json': lock_root_version('mobile/package-lock.json'),
+}
+drift = {path: version for path, version in versions.items() if version != canonical}
+if drift:
+    raise SystemExit(f'version drift: canonical={canonical} values={drift}')
+
+ios_project = Path('mobile/ios/project.yml').read_text(encoding='utf-8')
+marketing_match = re.search(r'^\s*MARKETING_VERSION:\s*[\'"]?([^\s\'"]+)', ios_project, re.MULTILINE)
+if not marketing_match or marketing_match.group(1) != canonical:
+    observed = marketing_match.group(1) if marketing_match else '<missing>'
+    raise SystemExit(f'iOS marketing version drift: canonical={canonical} project={observed}')
+if str(canonical_data.get('iosBuildNumber', '')).strip() != '5':
+    raise SystemExit('iOS build number policy must be advanced alongside the 1.1.0 release')
 PY
 
 if grep -Eq '"@tauri-apps/|"@capacitor/' mobile/package.json desktop/package.json; then

--- a/.github/scripts/assert-native-electron-canonical.sh
+++ b/.github/scripts/assert-native-electron-canonical.sh
@@ -62,7 +62,7 @@ if not marketing_match or marketing_match.group(1) != canonical:
 ios_build_number = str(canonical_data.get('iosBuildNumber', '')).strip()
 if not re.fullmatch(r'\d+', ios_build_number):
     raise SystemExit(f'invalid canonical iOS build number: {ios_build_number!r}')
-ios_build_match = re.search(r'^\s*CURRENT_PROJECT_VERSION:\s*[\\"]?([^\s\"]+)', ios_project, re.MULTILINE)
+ios_build_match = re.search(r'^\s*CURRENT_PROJECT_VERSION:\s*[\'"]?([^\s\'"]+)', ios_project, re.MULTILINE)
 if not ios_build_match or ios_build_match.group(1) != ios_build_number:
     observed = ios_build_match.group(1) if ios_build_match else '<missing>'
     raise SystemExit(f'iOS build number drift: canonical={ios_build_number} project={observed}')

--- a/.github/scripts/assert-native-electron-canonical.sh
+++ b/.github/scripts/assert-native-electron-canonical.sh
@@ -59,8 +59,13 @@ marketing_match = re.search(r'^\s*MARKETING_VERSION:\s*[\'"]?([^\s\'"]+)', ios_p
 if not marketing_match or marketing_match.group(1) != canonical:
     observed = marketing_match.group(1) if marketing_match else '<missing>'
     raise SystemExit(f'iOS marketing version drift: canonical={canonical} project={observed}')
-if str(canonical_data.get('iosBuildNumber', '')).strip() != '5':
-    raise SystemExit('iOS build number policy must be advanced alongside the 1.1.0 release')
+ios_build_number = str(canonical_data.get('iosBuildNumber', '')).strip()
+if not re.fullmatch(r'\\d+', ios_build_number):
+    raise SystemExit(f'invalid canonical iOS build number: {ios_build_number!r}')
+ios_build_match = re.search(r'^\\s*CURRENT_PROJECT_VERSION:\\s*[\\\"]?([^\\s\\\"]+)', ios_project, re.MULTILINE)
+if not ios_build_match or ios_build_match.group(1) != ios_build_number:
+    observed = ios_build_match.group(1) if ios_build_match else '<missing>'
+    raise SystemExit(f'iOS build number drift: canonical={ios_build_number} project={observed}')
 PY
 
 if grep -Eq '"@tauri-apps/|"@capacitor/' mobile/package.json desktop/package.json; then

--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -217,20 +217,15 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: node .github/scripts/build-offline-asr-engine.mjs
 
-      - name: Assign monotonic desktop version for canonical main delivery
+      - name: Resolve canonical desktop version for main delivery
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: desktop
         shell: bash
-        env:
-          MAIN_DELIVERY_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          base="$(node -p "require('./package.json').version")"
-          major="${base%%.*}"
-          rest="${base#*.}"
-          minor="${rest%%.*}"
-          version="${major}.${minor}.${MAIN_DELIVERY_NUMBER}"
-          npm pkg set "version=$version"
+          version="$(node -p "require('../app-version.json').version")"
+          package_version="$(node -p "require('./package.json').version")"
+          test "$version" = "$package_version"
           echo "FABUSHI_DELIVERY_VERSION=$version" >> "$GITHUB_ENV"
           echo "Canonical main desktop version: $version (source $GITHUB_SHA)" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/electron-desktop.yml
+++ b/.github/workflows/electron-desktop.yml
@@ -389,7 +389,7 @@ jobs:
           node .github/scripts/verify-packaged-computer-control.mjs "${args[@]}"
 
       - name: Simulate the complete user journey in packaged Linux Electron
-        if: matrix.target == 'linux'
+        if: github.event_name != 'pull_request' && matrix.target == 'linux'
         working-directory: desktop
         env:
           FABUSHI_FEATURE_HOST_MODE: test

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.6",
-  "androidVersionCode": 4,
-  "iosBuildNumber": 4
+  "version": "1.1.0",
+  "androidVersionCode": 5,
+  "iosBuildNumber": 5
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/desktop",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "electron-updater": "^6.8.9",
         "lucide-react": "^1.14.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Fabushi Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",

--- a/mobile/ios/Fabushi/MessagingModel.swift
+++ b/mobile/ios/Fabushi/MessagingModel.swift
@@ -356,7 +356,12 @@ final class MessagingModel {
     }
 
     func setMuted(_ conversationId: String, muted: Bool) async {
-        let until: Any = muted ? Int64.max / 4 : NSNull()
+        let until: Any
+        if muted {
+            until = Int64.max / 4
+        } else {
+            until = NSNull()
+        }
         try? await executeAfterIdentity([
             "type": "setConversationNotifications",
             "conversationId": conversationId,

--- a/mobile/ios/Fabushi/VoiceRecorder.swift
+++ b/mobile/ios/Fabushi/VoiceRecorder.swift
@@ -26,7 +26,7 @@ final class VoiceRecorder: NSObject, AVAudioRecorderDelegate {
         }
         do {
             let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.defaultToSpeaker, .allowBluetoothHFP])
+            try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.defaultToSpeaker, .allowBluetooth])
             try session.setActive(true)
             let directory = FileManager.default.temporaryDirectory.appendingPathComponent("fabushi-voice", isDirectory: true)
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 1.0.6
-        CURRENT_PROJECT_VERSION: 4
+        MARKETING_VERSION: 1.1.0
+        CURRENT_PROJECT_VERSION: 5
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'
     info:

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/native-mobile",
-      "version": "1.0.2"
+      "version": "1.1.0"
     }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
Prepare the next unified cross-platform release from the mobile feature merge.

Changes:
- advance canonical `app-version.json` to 1.1.0
- align desktop/mobile package manifests and lockfile roots
- align iOS marketing/build metadata
- enforce package-lock and iOS marketing-version parity in the canonical architecture gate
- make Electron main delivery use the canonical version directly so desktop release tags remain valid SemVer and never downgrade the updater

The marker in this PR title is intentional: after the protected main merge, it selects the repository's exact-SHA Android and Apple delivery workflows. Google Play remains a separate manual review handoff as defined by its workflow.