### PR TITLE
fix(ios): make profile menu accessibility unique [full-platform-release-final-20260831]

### DIFF
--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -378,6 +378,7 @@ struct ContentView: View {
                         Button { destination = .remoteComputer } label: { Label("我的电脑", systemImage: "desktopcomputer") }
                         Button { destination = .marketplace } label: { Label("插件市场", systemImage: "shippingbox.fill") }
                     } label: { avatar.frame(width: 34, height: 34) }
+                    .accessibilityElement(children: .ignore)
                     .accessibilityIdentifier("profile-avatar")
                 }
                 ToolbarItemGroup(placement: .topBarTrailing) {


### PR DESCRIPTION
## Summary

- collapse the SwiftUI profile Menu label into one accessibility element
- keep the `profile-avatar` identifier unique so the home and marketplace UI tests can open the menu deterministically
- keep the canonical Fabushi 1.1.0 version metadata unchanged

## Verification

- local build/test intentionally not run per repository storage-safety policy
- GitHub Actions must verify the iOS UI tests and full-platform delivery gates

The release marker is retained so the protected main merge can rerun the exact-SHA native Android and Apple delivery workflows after all quality gates pass.