### PR TITLE
fix(ios): collapse profile button accessibility children [full-platform-release-final-20260831]

### DIFF
--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -372,6 +372,7 @@ struct ContentView: View {
                     Button { profileMenuPresented = true } label: {
                         avatar.frame(width: 34, height: 34)
                     }
+                    .accessibilityElement(children: .ignore)
                     .accessibilityLabel("个人菜单")
                     .accessibilityIdentifier("profile-avatar")
                 }


### PR DESCRIPTION
## Summary

- collapse the profile toolbar button's SwiftUI label into one accessibility element
- preserve the explicit profile button and confirmation-dialog navigation introduced by the prior iOS fix
- keep the canonical Fabushi 1.1.0 version metadata unchanged

## Verification

- local build/test intentionally not run per repository storage-safety policy
- GitHub Actions must verify the iOS UI tests and full-platform delivery gates

The release marker is retained so the protected main merge can rerun the exact-SHA native Android and Apple delivery workflows after all quality gates pass.