### PR TITLE
fix(ios): use button-role selector for profile menu UI tests [full-platform-release-final-20260831]

### DIFF
--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -372,7 +372,6 @@ struct ContentView: View {
                     Button { profileMenuPresented = true } label: {
                         avatar.frame(width: 34, height: 34)
                     }
-                    .accessibilityElement(children: .ignore)
                     .accessibilityLabel("个人菜单")
                     .accessibilityIdentifier("profile-avatar")
                 }

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -27,7 +27,7 @@ final class FabushiUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.descendants(matching: .any)["app-shell"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.descendants(matching: .any)["profile-avatar"].exists)
+        XCTAssertTrue(app.buttons["profile-avatar"].exists)
         XCTAssertTrue(app.buttons["home-search-button"].exists)
         XCTAssertTrue(app.buttons["home-add-button"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["conversation-list"].exists)
@@ -117,7 +117,7 @@ final class FabushiUITests: XCTestCase {
 
     @MainActor
     private func openMarketplace(in app: XCUIApplication) {
-        let profile = app.descendants(matching: .any)["profile-avatar"]
+        let profile = app.buttons["profile-avatar"]
         XCTAssertTrue(profile.waitForExistence(timeout: 10))
         profile.tap()
         let marketplace = app.buttons["marketplace-entry"]
@@ -127,7 +127,7 @@ final class FabushiUITests: XCTestCase {
 
     @MainActor
     private func openRemoteComputer(in app: XCUIApplication) {
-        let profile = app.descendants(matching: .any)["profile-avatar"]
+        let profile = app.buttons["profile-avatar"]
         XCTAssertTrue(profile.waitForExistence(timeout: 10))
         profile.tap()
         let remoteComputer = app.buttons["remote-computer-entry"]


### PR DESCRIPTION
## Summary

- keep the explicit profile `Button` in the iOS accessibility tree
- make all profile-menu UI-test lookups use the actionable `.buttons` role
- avoid matching the SwiftUI toolbar container that reuses the identifier

## Verification

- local build/test intentionally not run per repository storage policy
- GitHub Actions must validate the iOS UI-test path and the full release gate
- canonical release source remains Fabushi 1.1.0 (Android version code 5, iOS build 5)

This is the final iOS UI-test selector repair for the full-platform release marker [full-platform-release-final-20260831].