### PR TITLE
test(ios): select confirmation dialog actions by label [full-platform-release-final-20260831]

### DIFF
--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -120,7 +120,7 @@ final class FabushiUITests: XCTestCase {
         let profile = app.buttons["profile-avatar"]
         XCTAssertTrue(profile.waitForExistence(timeout: 10))
         profile.tap()
-        let marketplace = app.buttons["marketplace-entry"]
+        let marketplace = app.buttons["插件市场"]
         XCTAssertTrue(marketplace.waitForExistence(timeout: 5))
         marketplace.tap()
     }
@@ -130,7 +130,7 @@ final class FabushiUITests: XCTestCase {
         let profile = app.buttons["profile-avatar"]
         XCTAssertTrue(profile.waitForExistence(timeout: 10))
         profile.tap()
-        let remoteComputer = app.buttons["remote-computer-entry"]
+        let remoteComputer = app.buttons["我的电脑"]
         XCTAssertTrue(remoteComputer.waitForExistence(timeout: 5))
         remoteComputer.tap()
     }


### PR DESCRIPTION
## Summary

- use the visible confirmation-dialog button labels for the iOS navigation helpers
- keep the product accessibility identifiers unchanged
- avoid relying on identifiers that SwiftUI does not expose for confirmation-dialog actions on the CI simulator

## Verification

- local build/test intentionally not run per repository storage policy
- GitHub Actions must validate the iOS UI-test path and the full release gate
- canonical release source remains Fabushi 1.1.0 (Android version code 5, iOS build 5)

This is a test-only follow-up for the full-platform release marker [full-platform-release-final-20260831].