### PR TITLE
fix(ios): make profile navigation sheet accessible in UI tests [full-platform-release-final-20260831]

### DIFF
--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -393,16 +393,42 @@ struct ContentView: View {
             Button("联系人分组") { contactGroupsPresented = true }
             Button("取消", role: .cancel) {}
         }
-        .confirmationDialog("导航", isPresented: $profileMenuPresented, titleVisibility: .visible) {
-            ForEach(MobileSection.allCases) { section in
-                Button(section.label) { handleSection(section) }
-                    .accessibilityIdentifier("profile-section-\(section.rawValue)")
+        .sheet(isPresented: $profileMenuPresented) {
+            NavigationStack {
+                List {
+                    Section("导航") {
+                        ForEach(MobileSection.allCases) { section in
+                            Button {
+                                profileMenuPresented = false
+                                handleSection(section)
+                            } label: {
+                                Label(section.label, systemImage: section.symbol)
+                            }
+                            .accessibilityIdentifier("profile-section-\(section.rawValue)")
+                        }
+                        Button {
+                            profileMenuPresented = false
+                            destination = .remoteComputer
+                        } label: {
+                            Label("我的电脑", systemImage: "desktopcomputer")
+                        }
+                        .accessibilityIdentifier("remote-computer-entry")
+                        Button {
+                            profileMenuPresented = false
+                            destination = .marketplace
+                        } label: {
+                            Label("插件市场", systemImage: "puzzlepiece.extension")
+                        }
+                        .accessibilityIdentifier("marketplace-entry")
+                    }
+                }
+                .navigationTitle("导航")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("取消") { profileMenuPresented = false }
+                    }
+                }
             }
-            Button("我的电脑") { destination = .remoteComputer }
-                .accessibilityIdentifier("remote-computer-entry")
-            Button("插件市场") { destination = .marketplace }
-                .accessibilityIdentifier("marketplace-entry")
-            Button("取消", role: .cancel) {}
         }
         .sheet(item: $composeKind) { kind in composeSheet(kind) }
         .sheet(isPresented: $contactGroupsPresented) { simpleSectionSheet(title: "联系人分组", symbol: "folder.fill") }

--- a/mobile/ios/FabushiUITests/FabushiUITests.swift
+++ b/mobile/ios/FabushiUITests/FabushiUITests.swift
@@ -120,7 +120,7 @@ final class FabushiUITests: XCTestCase {
         let profile = app.buttons["profile-avatar"]
         XCTAssertTrue(profile.waitForExistence(timeout: 10))
         profile.tap()
-        let marketplace = app.buttons["插件市场"]
+        let marketplace = app.buttons["marketplace-entry"]
         XCTAssertTrue(marketplace.waitForExistence(timeout: 5))
         marketplace.tap()
     }
@@ -130,7 +130,7 @@ final class FabushiUITests: XCTestCase {
         let profile = app.buttons["profile-avatar"]
         XCTAssertTrue(profile.waitForExistence(timeout: 10))
         profile.tap()
-        let remoteComputer = app.buttons["我的电脑"]
+        let remoteComputer = app.buttons["remote-computer-entry"]
         XCTAssertTrue(remoteComputer.waitForExistence(timeout: 5))
         remoteComputer.tap()
     }


### PR DESCRIPTION
## Summary

- replace the SwiftUI confirmation dialog used for profile navigation with an accessible navigation sheet
- keep stable accessibility identifiers on the actionable navigation buttons
- close the sheet before routing to Marketplace, Remote Computer, or a mobile section
- restore the iOS UI tests to assert the stable entry identifiers

## Verification

- local build/test intentionally not run per repository storage policy
- GitHub Actions must validate the iOS UI-test path and the full release gate
- canonical release source remains Fabushi 1.1.0 (Android version code 5, iOS build 5)

This is the final iOS profile-navigation accessibility repair for the full-platform release marker [full-platform-release-final-20260831].