### PR TITLE
fix(android): resolve GitHub release FileProvider merge [full-platform-release-final-20260831]

### DIFF
--- a/mobile/android/app/src/githubRelease/AndroidManifest.xml
+++ b/mobile/android/app/src/githubRelease/AndroidManifest.xml
@@ -1,16 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
-
-    <application>
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.updates"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/update_file_paths" />
-        </provider>
-    </application>
 </manifest>

--- a/mobile/android/app/src/main/java/com/ombhrum/fabushi/AndroidUpdateViewModel.kt
+++ b/mobile/android/app/src/main/java/com/ombhrum/fabushi/AndroidUpdateViewModel.kt
@@ -502,7 +502,7 @@ class AndroidUpdateViewModel(application: Application) : AndroidViewModel(applic
         awaitingInstallPermission = false
         val uri = FileProvider.getUriForFile(
             applicationContext,
-            "${applicationContext.packageName}.updates",
+            "${applicationContext.packageName}.media",
             apk,
         )
         val intent = Intent(Intent.ACTION_VIEW).apply {


### PR DESCRIPTION
## Summary

- remove the duplicate githubRelease FileProvider manifest overlay
- reuse the main `.media` provider for verified update APK installation
- keep `REQUEST_INSTALL_PACKAGES` enabled for the GitHub release variant
- preserve the existing cache path, which already covers the update staging directory

## Verification

- local build/test intentionally not run per repository storage policy
- GitHub Actions must validate Android release packaging and the full release gate
- canonical release source remains Fabushi 1.1.0 (Android version code 5, iOS build 5)

This fixes the manifest merger failure observed while publishing source SHA 99492640188c086e839ef8debef1002fe41d865a under the full-platform release marker [full-platform-release-final-20260831].