### PR TITLE
fix(release): recover immutable same-version desktop delivery

### DIFF
--- a/.github/workflows/macos-desktop-e2e.yml
+++ b/.github/workflows/macos-desktop-e2e.yml
@@ -73,11 +73,16 @@ jobs:
             echo "Resolved release is not a desktop release: $tag" | tee "$EVIDENCE_DIR/logs/01-release-metadata.log"
             exit 1
           fi
+          if [[ "$tag" =~ ^desktop-([0-9]+\.[0-9]+\.[0-9]+)(-[0-9a-fA-F]{12})?$ ]]; then
+            current_version="${BASH_REMATCH[1]}"
+          else
+            echo "Resolved desktop release does not contain a supported SemVer: $tag" | tee "$EVIDENCE_DIR/logs/01-release-metadata.log"
+            exit 1
+          fi
           gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json tagName,name,publishedAt,isPrerelease,assets,targetCommitish,url > "$EVIDENCE_DIR/json/release.json"
           jq -r '. | "Release: \(.tagName)\nName: \(.name)\nPublished: \(.publishedAt)\nPrerelease: \(.isPrerelease)\nURL: \(.url)\nAssets:\n" + ([.assets[].name] | map("- " + .) | join("\n"))' "$EVIDENCE_DIR/json/release.json" | tee "$EVIDENCE_DIR/logs/01-release-metadata.log"
 
-          current_version="${tag#desktop-}"
-          highest_version="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isDraft,isPrerelease --jq '.[] | select(.isDraft == false and .isPrerelease == false and (.tagName | startswith("desktop-"))) | .tagName' | sed 's/^desktop-//' | sort -V | tail -1)"
+          highest_version="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isDraft,isPrerelease --jq '.[] | select(.isDraft == false and .isPrerelease == false and (.tagName | test("^desktop-[0-9]+[.][0-9]+[.][0-9]+$"))) | .tagName' | sed 's/^desktop-//' | sort -V | tail -1)"
           is_highest=false
           if [ "$current_version" = "$highest_version" ]; then
             is_highest=true
@@ -135,7 +140,7 @@ jobs:
             if [ "$newest" = "$CURRENT_VERSION" ]; then
               previous_version="$candidate"
             fi
-          done < <(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isDraft,isPrerelease --jq '.[] | select(.isDraft == false and .isPrerelease == false and (.tagName | startswith("desktop-"))) | .tagName' | sed 's/^desktop-//' | sort -V)
+          done < <(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isDraft,isPrerelease --jq '.[] | select(.isDraft == false and .isPrerelease == false and (.tagName | test("^desktop-[0-9]+[.][0-9]+[.][0-9]+$"))) | .tagName' | sed 's/^desktop-//' | sort -V)
 
           if [ -z "$previous_version" ]; then
             echo "No lower desktop release found; updater compatibility smoke skipped." | tee "$EVIDENCE_DIR/logs/04-upgrade-compatibility.log"

--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -271,7 +271,22 @@ jobs:
           NATIVE_RUN_ID: ${{ needs.gate.outputs.native_run_id }}
         run: |
           set -euo pipefail
-          tag="desktop-$VERSION"
+          canonical_tag="desktop-$VERSION"
+          tag="$canonical_tag"
+
+          # A same-version published Release is immutable. This can happen when a
+          # prior exact-SHA desktop delivery completed before a follow-up Android/iOS
+          # fix reached the same release train. Keep the old Release untouched and
+          # publish a provenance-scoped recovery Release instead of overwriting it.
+          canonical_existing="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq ".[] | select(.tag_name == \"$canonical_tag\")" 2>/dev/null || true)"
+          if [ -n "$canonical_existing" ]; then
+            canonical_target="$(jq -r '.target_commitish' <<<"$canonical_existing")"
+            canonical_draft="$(jq -r '.draft' <<<"$canonical_existing")"
+            if [ "$canonical_draft" != true ] && [ "$canonical_target" != "$SOURCE_SHA" ]; then
+              tag="${canonical_tag}-${SOURCE_SHA:0:12}"
+              echo "Canonical Release $canonical_tag is immutable at $canonical_target; publishing recovery Release $tag."
+            fi
+          fi
           # Only canonical desktop-X.Y.Z releases participate in updater ordering.
           # Legacy desktop-v1.0.1-* tags sort after numeric SemVer under sort -V and
           # previously caused every new desktop Release to be published with make_latest=false.
@@ -289,6 +304,8 @@ jobs:
           Automated Fabushi desktop delivery from canonical main.
 
           - Source SHA: \`$SOURCE_SHA\`
+          - Release tag: \`$tag\`
+          - Canonical desktop tag: \`$canonical_tag\`
           - Electron packaged-user E2E run: \`$ELECTRON_RUN_ID\`
           - Native mobile simulated-user run: \`${NATIVE_RUN_ID:-unknown}\`
           - Desktop version: \`$VERSION\`


### PR DESCRIPTION
## Summary
- keep an already-published `desktop-X.Y.Z` Release immutable when a later exact-SHA delivery for the same version is required;
- publish a provenance-scoped recovery tag using the exact source SHA instead of overwriting the old Release;
- make the macOS release E2E resolve the base SemVer and compare only canonical desktop tags for updater ordering.

## Why
`desktop-1.1.0` was already published for the preceding exact-main SHA. The Android FileProvider repair then produced the final main SHA, and the existing immutable-release guard correctly refused to mutate the published desktop assets. This small workflow-only repair lets the final tested artifacts publish without deleting or mutating the prior Release.

## Verification
GitHub Actions must run the PR contract and the required merge-queue checks. After merge, the exact-main Electron/mobile gates and post-main delivery must publish a Release whose assets and site policy are bound to the final SHA.