### PR TITLE
docs(TFI): record unified mobile UI 1.1.0 release evidence

### DIFF
--- a/projects/telegram-fabushi-integration/FILE_INDEX.md
+++ b/projects/telegram-fabushi-integration/FILE_INDEX.md
@@ -98,3 +98,9 @@
 ## Maintenance rule
 
 This index describes the durable project structure on or intended for the authoritative project path. Task/evidence files created on implementation branches become canonical only after their PRs pass CI, merge through protected `main`, and are verified there.
+
+## 2026-09-01 release-train records
+
+- `management/tasks/M11-MOBILE-001-unified-mobile-ui-release.md`
+- `evidence/M11-MOBILE-001/README.md`
+- `management/changes/2026-09-01-unified-mobile-ui-release.md`

--- a/projects/telegram-fabushi-integration/PROJECT.yaml
+++ b/projects/telegram-fabushi-integration/PROJECT.yaml
@@ -51,3 +51,14 @@ governance:
   task_record_required_before_completion: true
   new_independent_workstream_requires_project_folder: true
   protected_merge_queue_required: true
+
+latest_release:
+  version: 1.1.0
+  date: 2026-09-01
+  release_train: M11-MOBILE-001
+  product_source_sha: 82ddb78653ecdc47c95bf1a372389adff9f24d09
+  release_control_sha: 3f7cddc0bc09802d9a3d142cab7f9a56c573c07c
+  desktop_tag: desktop-1.1.0-3f7cddc0bc09
+  android_tag: android-v1.1.0-262432005
+  apple_tag: apple-v1.1.0-2026.8.3133
+  evidence: projects/telegram-fabushi-integration/evidence/M11-MOBILE-001/README.md

--- a/projects/telegram-fabushi-integration/evidence/M11-MOBILE-001/README.md
+++ b/projects/telegram-fabushi-integration/evidence/M11-MOBILE-001/README.md
@@ -1,0 +1,52 @@
+# M11-MOBILE-001 — 统一移动端逻辑 UI / 1.1.0 发布证据
+
+- **Project**：`FAB-P0001 / TFI`
+- **验收范围**：统一移动端逻辑 UI、版本元数据、全平台构建/发布链路
+- **应用版本**：`1.1.0`
+- **证据日期**：2026-09-01
+
+## 主线与源码关系
+
+| 项目 | SHA / 结果 |
+|---|---|
+| 当前 canonical main | [`3f7cddc0bc09802d9a3d142cab7f9a56c573c07c`](https://github.com/bhrumom/fabushi/commit/3f7cddc0bc09802d9a3d142cab7f9a56c573c07c) |
+| 应用产品源码基线 | [`82ddb78653ecdc47c95bf1a372389adff9f24d09`](https://github.com/bhrumom/fabushi/commit/82ddb78653ecdc47c95bf1a372389adff9f24d09) |
+| 两者比较 | 仅 2 个发布 workflow 文件，0 个产品源码文件变化 |
+
+## PR 链
+
+- #2248–#2251：移动端逻辑 UI 主体。
+- #2252：1.1.0 / Android code 5 / iOS build 5 版本收敛。
+- #2253–#2260：iOS bridge、可见性、无障碍、profile 与导航 sheet。
+- #2261：Android FileProvider release manifest merge 修复。
+- #2262：同版本不可变桌面 Release recovery tag。
+
+## GitHub Actions
+
+- [CI 33436781726](https://github.com/bhrumom/fabushi/actions/runs/33436781726) — success。
+- [Native mobile quality gate 33436781683](https://github.com/bhrumom/fabushi/actions/runs/33436781683) — success。
+- [Electron desktop quality gate 33436781694](https://github.com/bhrumom/fabushi/actions/runs/33436781694) — success。
+- [Delivery governance 33436781731](https://github.com/bhrumom/fabushi/actions/runs/33436781731) — success。
+- [Post-main E2E Release delivery 33437994689](https://github.com/bhrumom/fabushi/actions/runs/33437994689) — success。
+- [Worker production deploy 33436811350](https://github.com/bhrumom/fabushi/actions/runs/33436811350) — success。
+- [Fabushi Pay production deploy 33436811361](https://github.com/bhrumom/fabushi/actions/runs/33436811361) — success。
+
+## Release 验收
+
+| 平台 | Release / 上传 | target | 结果 |
+|---|---|---|---|
+| Desktop | [`desktop-1.1.0-3f7cddc0bc09`](https://github.com/bhrumom/fabushi/releases/tag/desktop-1.1.0-3f7cddc0bc09) | `3f7cddc…` | published，19 个桌面/更新元数据资产 |
+| Android | [`android-v1.1.0-262432005`](https://github.com/bhrumom/fabushi/releases/tag/android-v1.1.0-262432005) | `82ddb786…` | APK、update JSON、SHA256 已发布 |
+| Apple | [`apple-v1.1.0-2026.8.3133`](https://github.com/bhrumom/fabushi/releases/tag/apple-v1.1.0-2026.8.3133) | `82ddb786…` | IPA 上传 App Store Connect 成功 |
+
+Apple 上传日志包含 `No errors validating archive` 与 `UPLOAD SUCCEEDED with no errors`。Android 工作流包含 Gradle `BUILD SUCCESSFUL`、版本/code 校验、签名校验与 GitHub Release 创建成功。
+
+## Official site
+
+- Post-main sync 将 `macos/stable`、`windows/stable`、`linux/stable` 全部更新为 `1.1.0+5`，三项 API 返回 `success: true`。
+
+## 未关闭项
+
+- 当前主线的自动 Android run [33438057062](https://github.com/bhrumom/fabushi/actions/runs/33438057062) 为 skipped；Apple run [33438057055](https://github.com/bhrumom/fabushi/actions/runs/33438057055) 的 resolve 阶段因同一 marker gate 跳过实际上传。由于 `3f7cddc…` 相对 `82ddb…` 只改发布 workflow，已发布移动端二进制仍与当前产品源码等价。
+- Android GitHub APK 不代表 Google Play 公共上架；Apple App Store Connect 接收不代表 App Review 已通过。
+- M11 全量 cross-device E2E、push sync、background recovery 仍保持 `IN_PROGRESS`，见 `management/wbs/M11.md` 与行动项 ACT-006。

--- a/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
+++ b/projects/telegram-fabushi-integration/management/03-验收追踪矩阵.md
@@ -28,7 +28,7 @@
 | Mini Apps | miniapp + Host bridge + WebMCP | M8 | TESTING | M8-CALL-001 core contract 已 TESTED；M8-MARKET-001 已实现；M8-WEBMCP-001 implementation head 已全绿，仍待 final governance head、protected merge、exact-main packaged/E2E/Release |
 | 支付 | payment/settlement/wallet | M9 | IMPLEMENTED | 需 sandbox E2E / webhook replay evidence |
 | 音视频 | realtime/signaling + desktop WebRTC | M10 | IMPLEMENTED | 需跨端/TURN/SFU/网络切换实测 |
-| 移动端共享 Core | native bridge / Host | M11 | IN_PROGRESS | 需 iOS/Android/Electron cross-device E2E |
+| 移动端共享 Core | native bridge / Host | M11 | IN_PROGRESS | M11-MOBILE-001 UI 发布列车已 RELEASED；完整 iOS/Android/Electron cross-device E2E、push sync、background recovery 仍待验收 |
 | 高级 IM | story/search/notification/community/message | M12 | IMPLEMENTED | 需逐项 E2E |
 | E2EE | secret_chat/access | M13 | IMPLEMENTED | 需密钥生命周期/服务端不可读安全验收 |
 | 旧栈移除 | legacy Telegram paths | M14 | NOT_STARTED | 待 M3-M13 replacement acceptance + dependency-zero |
@@ -144,3 +144,13 @@ Remaining hard gates: final governance head must rerun required checks, PR #2169
 | Single source | all app facts derive from `lib/marketplace.ts` | contract/CI verified |
 
 Status: `COMPLETED / PRODUCTION_VERIFIED`. PR-head, merge-group and exact-main CI passed; protected main merged at `a9f7c8e8a98a17fdbd2358232048607198069a0b`; official Worker/Mini Apps deploys and production HTTP/entity/WebMCP-registration/crawler probes are recorded in `evidence/M8-AEO-001/README.md`.
+
+
+## M11-MOBILE-001 release acceptance — 2026-09-01
+
+`M11-MOBILE-001` = `RELEASED` for the unified mobile logic UI and 1.1.0 delivery train. The broader M11 milestone remains `IN_PROGRESS`; this entry does not claim full cross-device shared-Core interoperability.
+
+- Product source SHA: `82ddb78653ecdc47c95bf1a372389adff9f24d09`.
+- Current release-control main: `3f7cddc0bc09802d9a3d142cab7f9a56c573c07c`; comparison shows only two release workflow files changed after the mobile product source.
+- Desktop: `desktop-1.1.0-3f7cddc0bc09` published; Android: `android-v1.1.0-262432005`; Apple: `apple-v1.1.0-2026.8.3133` uploaded to App Store Connect.
+- Full evidence: `evidence/M11-MOBILE-001/README.md`; task record: `management/tasks/M11-MOBILE-001-unified-mobile-ui-release.md`.

--- a/projects/telegram-fabushi-integration/management/05-状态报告.md
+++ b/projects/telegram-fabushi-integration/management/05-状态报告.md
@@ -4,7 +4,7 @@
 - **Project ID**：`FAB-P0001`
 - **Project Key**：`TFI`
 - **文档 ID**：MGMT-05
-- **版本**：v1.8
+- **版本**：v1.9
 - **状态**：LIVE
 - **基线日期**：2026-08-22
 
@@ -223,3 +223,12 @@
 - 全站 WebMCP 已加入只读 `recommend_fabushi_app` / `get_app_capabilities`；现有安装/写入确认边界不变。
 - robots 已显式允许 OAI-SearchBot、ChatGPT-User、Googlebot、Bingbot；生产 OAI-SearchBot、Googlebot、Bingbot probes 均返回 200。
 - AI discovery source contract 已接入 Frontend CI；PR-head/merge-group/exact-main CI、protected merge、canonical-main readback、official Worker/Mini Apps deploy、生产 HTTP/entity/sitemap/robots/WebMCP registration 均已取证。状态：`COMPLETED / PRODUCTION_VERIFIED`。
+
+
+## 2026-09-01 — M11-MOBILE-001 统一移动端逻辑 UI / 1.1.0 全平台交付
+
+- PR #2248–#2251 完成移动端逻辑 UI 主体；#2252 统一 1.1.0、Android code 5、iOS build 5；#2253–#2261 完成 iOS/Android 收尾修复；#2262 完成同版本不可变桌面 Release recovery 策略。
+- 当前 canonical `main` 为 `3f7cddc0bc09802d9a3d142cab7f9a56c573c07c`。CI `33436781726`、Native mobile `33436781683`、Electron `33436781694`、Delivery governance `33436781731`、post-main delivery `33437994689` 均 SUCCESS。
+- Desktop recovery Release `desktop-1.1.0-3f7cddc0bc09` 已发布并指向当前 main；官方站 macOS/Windows/Linux 版本策略已同步为 `1.1.0+5`。Android 与 Apple 的 1.1.0 产物已分别发布/上传，产品源码 target 为紧邻父提交 `82ddb786...`；该父提交到当前 main 仅有发布 workflow 变化，无产品代码差异。
+- 本次发布列车状态：`RELEASED`。M11 更广泛的 iOS/Android/Electron cross-device E2E、push sync、background recovery 仍为 `IN_PROGRESS`，ACT-006 保持 OPEN，不以 UI 发布证据冒充完整 M11 关闭。
+- 证据：`management/tasks/M11-MOBILE-001-unified-mobile-ui-release.md`、`evidence/M11-MOBILE-001/README.md`。

--- a/projects/telegram-fabushi-integration/management/07-变更日志.md
+++ b/projects/telegram-fabushi-integration/management/07-变更日志.md
@@ -198,3 +198,12 @@
 - WebMCP 新增只读推荐与能力查询工具；sitemap/search index/robots 接入 AI discovery。
 - 新增 AI discovery contract 并接入 Frontend CI；无新依赖、无第二份应用 catalog。
 - PR #2177 经 protected flow 合并为 `a9f7c8e8a98a17fdbd2358232048607198069a0b`；PR-head、merge-group、exact-main CI、official Worker/Mini Apps deploy 和生产 HTTP/entity/crawler/WebMCP-registration evidence 已完成。状态：`COMPLETED / PRODUCTION_VERIFIED`。
+
+
+## 2026-09-01 — M11-MOBILE-001 unified mobile logic UI / 1.1.0 full-platform delivery
+
+- PR #2248–#2251 landed the unified mobile logic UI work; #2252 aligned version `1.1.0`, Android code `5`, and iOS build `5`.
+- PR #2253–#2261 closed the iOS accessibility/profile/navigation and Android FileProvider release blockers; #2262 added immutable same-version desktop recovery publication.
+- Canonical main `3f7cddc0bc09802d9a3d142cab7f9a56c573c07c` passed CI `33436781726`, native mobile `33436781683`, Electron `33436781694`, delivery governance `33436781731`, post-main delivery `33437994689`, Worker `33436811350`, and Pay `33436811361`.
+- Published outputs: desktop `desktop-1.1.0-3f7cddc0bc09`; Android `android-v1.1.0-262432005`; Apple `apple-v1.1.0-2026.8.3133`. Android/Apple target the immediately preceding product SHA `82ddb...`; the only delta to current main is release workflow code.
+- Project status is `RELEASED` for this release train; broad M11 interoperability remains open.

--- a/projects/telegram-fabushi-integration/management/08-问题与行动项.md
+++ b/projects/telegram-fabushi-integration/management/08-问题与行动项.md
@@ -14,7 +14,7 @@
 | ACT-003 | M1.T02 | production messaging server still defaults to JSON | make SQLite default and migrate JSON once | IN_PROGRESS | #1990 CI + merge + main verification |
 | ACT-004 | M1.T01/T03/T04/T05/T07 | existing implementations are not reflected in stale M1 WBS | reconcile status using current all-target Rust and Electron Host-bridge evidence | OPEN | M1 acceptance report + WBS update |
 | ACT-005 | M2-M13 | broad implementation exists but evidence is uneven | execute stage-by-stage acceptance suites and promote only proven states | OPEN | stage evidence records |
-| ACT-006 | M11 | native cross-platform shared-core proof is incomplete | add/execute iOS/Android/Electron interoperability validation | OPEN | native CI/E2E evidence |
+| ACT-006 | M11 | native cross-platform shared-core proof is incomplete | add/execute iOS/Android/Electron interoperability validation | OPEN | Partial UI/release evidence: `evidence/M11-MOBILE-001/README.md`; full cross-device E2E still required |
 | ACT-007 | M14 | frozen Telegram runtime/provider crates remain | prove dependency zero, remove legacy stacks, verify no fallback | OPEN | removal PR + full CI/search evidence |
 | ACT-008 | Governance | project predates current enterprise folder standard | add ownership, blockers, action register and runbooks | IN_PROGRESS | TFI-GOV-002 merged to main |
 
@@ -34,3 +34,8 @@
 | ACT-010 | M8-AEO-001 | Cloudflare 可能独立于 robots 阻断 crawler | probe normal + OAI/Google/Bing User-Agents after deploy | CLOSED | OAI/Google/Bing 200 |
 | ACT-011 | M8-AEO-001 | WebMCP tools 需真实浏览器注册/执行证明 | inspect tool registry and invoke read-only tools | CLOSED WITH FOLLOW-UP | production registration/schema verified; harness invocation timeout recorded |
 | ACT-012 | M8-AEO-001 | protected merge/post-main delivery pending | enable merge queue, read canonical main, validate exact deployment | CLOSED | merge `a9f7c8e8`; Worker 33052308128 |
+
+
+## 2026-09-01 — M11-MOBILE-001 partial evidence
+
+The unified mobile UI release train is now recorded as released, but ACT-006 remains OPEN because the release artifacts do not prove full iOS/Android/Electron cross-device shared-Core interoperability, push sync, or background recovery.

--- a/projects/telegram-fabushi-integration/management/changes/2026-09-01-unified-mobile-ui-release.md
+++ b/projects/telegram-fabushi-integration/management/changes/2026-09-01-unified-mobile-ui-release.md
@@ -1,0 +1,30 @@
+# 2026-09-01 — 统一移动端逻辑 UI / 1.1.0 全平台交付变更
+
+- Project: `FAB-P0001 / TFI`
+- Release train: `M11-MOBILE-001`
+- Version: `1.1.0`
+
+## Summary
+
+统一移动端逻辑 UI 的剩余实现、iOS/Android 收尾修复、版本元数据与全平台交付链路已完成。桌面发布使用当前 main 的 recovery tag；移动端二进制使用紧邻父提交的产品源码基线，因该父提交到当前 main 只有发布 workflow 变化。
+
+## Change set
+
+- #2248–#2251: unified mobile logic UI implementation.
+- #2252: version metadata convergence.
+- #2253–#2260: iOS bridge/accessibility/profile/navigation fixes.
+- #2261: Android FileProvider release merge fix.
+- #2262: immutable same-version desktop release recovery.
+
+## Verification
+
+- Current main: `3f7cddc0bc09802d9a3d142cab7f9a56c573c07c`.
+- Product source: `82ddb78653ecdc47c95bf1a372389adff9f24d09`.
+- CI `33436781726`, native mobile `33436781683`, Electron `33436781694`, governance `33436781731`, post-main `33437994689`, Worker `33436811350`, Pay `33436811361`: SUCCESS.
+- Desktop Release: `desktop-1.1.0-3f7cddc0bc09`.
+- Android Release: `android-v1.1.0-262432005`.
+- Apple Release: `apple-v1.1.0-2026.8.3133`.
+
+## Scope note
+
+This change closes the UI/release train, not the full M11 cross-device interoperability milestone. ACT-006 remains open for shared-Core messaging, push sync, and background recovery proof.

--- a/projects/telegram-fabushi-integration/management/tasks/M11-MOBILE-001-unified-mobile-ui-release.md
+++ b/projects/telegram-fabushi-integration/management/tasks/M11-MOBILE-001-unified-mobile-ui-release.md
@@ -1,0 +1,47 @@
+# M11-MOBILE-001 — 统一移动端逻辑 UI 与 1.1.0 全平台交付
+
+- **Project ID**：`FAB-P0001`
+- **Project Key**：`TFI`
+- **状态**：`RELEASED`（本次发布列车）；M11 更广泛的跨端互通验收仍为 `IN_PROGRESS`
+- **更新时间**：2026-09-01
+
+## 目标
+
+完成统一移动端逻辑 UI 的剩余修复，统一 1.1.0 版本元数据，并通过 GitHub Actions 完成 Web/PWA、Electron、Android 与 Apple 交付。
+
+## 实施范围
+
+- PR #2248–#2251：移动端逻辑 UI 主体修复并合入主线。
+- PR #2252：1.1.0 版本、Android code 5、iOS build 5 与锁文件统一。
+- PR #2253–#2260：iOS bridge、可见性、无障碍、Profile 菜单、selector、对话框与导航 sheet 修复。
+- PR #2261：Android GitHub Release FileProvider manifest merge 修复。
+- PR #2262：在既有不可变 `desktop-1.1.0` 发布存在旧 target 时，增加同版本 recovery tag 发布策略。
+
+## 可追溯验证
+
+- 应用产品源码基线：`82ddb78653ecdc47c95bf1a372389adff9f24d09`。
+- 当前发布控制主线：`3f7cddc0bc09802d9a3d142cab7f9a56c573c07c`。
+- `82ddb... → 3f7c...` 仅包含 `.github/workflows/macos-desktop-e2e.yml` 与 `.github/workflows/post-main-delivery.yml`；没有产品代码变化。
+- 当前主线 CI：`33436781726`；移动端质量门：`33436781683`；Electron 桌面质量门：`33436781694`；交付治理：`33436781731`。
+- Post-main 交付：`33437994689`；Worker：`33436811350`；Fabushi Pay：`33436811361`。
+- Android 产物发布：`33434030555`；Apple 上传交付：`33434030571`。
+
+## 发布产物
+
+- 桌面：[`desktop-1.1.0-3f7cddc0bc09`](https://github.com/bhrumom/fabushi/releases/tag/desktop-1.1.0-3f7cddc0bc09)，target 为当前主线 `3f7c...`，非 draft、非 prerelease。
+- Android：[`android-v1.1.0-262432005`](https://github.com/bhrumom/fabushi/releases/tag/android-v1.1.0-262432005)，target 为产品源码基线 `82ddb...`，包含 APK、update manifest 与 SHA256。
+- Apple：[`apple-v1.1.0-2026.8.3133`](https://github.com/bhrumom/fabushi/releases/tag/apple-v1.1.0-2026.8.3133)，target 为产品源码基线 `82ddb...`，App Store Connect 上传成功并包含 IPA 与 SHA256。
+- 官方站版本策略已同步为 macOS/Windows/Linux `1.1.0+5`，同步结果均为 `success: true`。
+
+## 边界与后续
+
+- Android 交付是 GitHub APK 发布，不等同于 Google Play 公共商店审核通过；Apple 交付是 App Store Connect 接收，不等同于 App Review/公开上架完成。
+- 当前主线的自动移动发布因提交未带历史 `[full-platform-release-final-20260831]` 标记而跳过；已发布的 Android/Apple 产物来自紧邻父提交，且经比较确认无产品代码差异，因此不重复构建同一份应用。
+- 本记录只关闭本次统一移动端 UI 发布列车；M11.T01–T05 的完整 iOS/Android/Electron 跨设备互通、push sync 与 background recovery 仍须独立证据，不能由本次 UI 发布代替。
+
+## 证据位置
+
+- `../../evidence/M11-MOBILE-001/README.md`
+- `management/03-验收追踪矩阵.md`
+- `management/05-状态报告.md`
+- `management/07-变更日志.md`

--- a/projects/telegram-fabushi-integration/management/wbs/M11.md
+++ b/projects/telegram-fabushi-integration/management/wbs/M11.md
@@ -55,3 +55,8 @@
 - **证据位置**：待填写（commit / PR / CI run / release / test report）
 - **下一步**：领取后补充实现路径与测试名称。
 
+
+### M11-MOBILE-001 release-train note — 2026-09-01
+
+- The 1.1.0 unified mobile logic UI and native packaging/release path is recorded in `management/tasks/M11-MOBILE-001-unified-mobile-ui-release.md` and `evidence/M11-MOBILE-001/README.md`.
+- This evidence covers UI/bridge/package delivery only. It does not change M11.T01–T05 to `TESTED`: complete shared-Core cross-device messaging, push sync, and background recovery remain required.


### PR DESCRIPTION
## Summary

- record M11-MOBILE-001 unified mobile logic UI / 1.1.0 release train
- add task, change, acceptance, WBS, status, project metadata, and evidence records
- preserve the distinction between product source `82ddb786...` and current release-control main `3f7cddc...`
- document published Desktop, Android, and Apple artifacts plus Worker/Pay delivery evidence

This is an evidence and project-record update only; no product source files are changed.