### PR TITLE
ci: make official site Mahayana build self-contained

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -49,6 +49,8 @@ jobs:
             /scripts/build-mahayana-wasm.sh
             /scripts/build-official-miniapp-wasm.sh
             /third_party/mahayana/mahayana-rs/**
+            /third_party/mahayana/codex-rs/**
+            /native/mahayana-messaging/**
 
       - name: Set up Rust for the browser runtime
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Include the Mahayana WebAssembly build prerequisites in the official-site sparse checkout: the audited Codex compatibility sources and Fabushi messaging core. This fixes the post-merge v1.2.0 official-site deployment without changing runtime behavior.