### PR TITLE
fix(ios): await async browser login opens

### DIFF
--- a/.github/workflows/deploy-official-site-cloudflare.yml
+++ b/.github/workflows/deploy-official-site-cloudflare.yml
@@ -49,6 +49,8 @@ jobs:
             /scripts/build-mahayana-wasm.sh
             /scripts/build-official-miniapp-wasm.sh
             /third_party/mahayana/mahayana-rs/**
+            /third_party/mahayana/codex-rs/**
+            /native/mahayana-messaging/**
 
       - name: Set up Rust for the browser runtime
         uses: dtolnay/rust-toolchain@stable

--- a/mobile/ios/Fabushi/MarketplaceModel.swift
+++ b/mobile/ios/Fabushi/MarketplaceModel.swift
@@ -127,7 +127,7 @@ final class MarketplaceModel {
             browserLoginAttemptId = attemptId
             browserLoginURL = loginURL
             loginBusy = false
-            UIApplication.shared.open(loginURL, options: [:])
+            await UIApplication.shared.open(loginURL, options: [:])
             if loginURLString.hasPrefix("about:blank#fabushi-test-browser-login") {
                 await completeBrowserLogin(attemptId: attemptId)
             }
@@ -148,7 +148,7 @@ final class MarketplaceModel {
                   let loginURL = URL(string: loginURLString)
             else { throw MahayanaHost.HostError.invalidResponse }
             browserLoginURL = loginURL
-            UIApplication.shared.open(loginURL, options: [:])
+            await UIApplication.shared.open(loginURL, options: [:])
         } catch { loginError = error.localizedDescription }
     }
 


### PR DESCRIPTION
Fix the two Swift concurrency compile errors in MarketplaceModel by awaiting UIApplication.open from the async browser-login flows. No runtime behavior change beyond restoring the iOS build gate.