### PR TITLE
fix(ios): preserve nested UI test accessibility identifiers

### DIFF
--- a/mobile/ios/Fabushi/ContentView.swift
+++ b/mobile/ios/Fabushi/ContentView.swift
@@ -481,6 +481,7 @@ struct ContentView: View {
         .sheet(item: $activeSection) { section in sectionSheet(section) }
         .fullScreenCover(item: $selectedConversation) { conversation in chatView(conversation) }
         .fullScreenCover(isPresented: $agentChatPresented) { agentChatView }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("app-shell")
         .task { await messaging.refresh() }
     }
@@ -510,6 +511,7 @@ struct ContentView: View {
             }
             .padding(24)
         }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("mobile-onboarding")
     }
 
@@ -525,6 +527,7 @@ struct ContentView: View {
                 }
             }
         }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("mobile-auth-loading")
     }
 
@@ -559,6 +562,7 @@ struct ContentView: View {
             }
             .padding(24)
         }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("mobile-login")
     }
 


### PR DESCRIPTION
## What changed
- keep the root accessibility containers for onboarding, login/loading, and the authenticated app shell
- use `.accessibilityElement(children: .contain)` so nested buttons and status markers retain their own identifiers

## Why
The iOS UI snapshot showed the outer `mobile-onboarding` identifier replacing every nested identifier, so the simulator could not find the onboarding skip, browser login, smoke result, or authenticated shell controls.

## Verification
- `git diff --check` passed locally
- full iOS simulator and native-mobile validation are delegated to GitHub Actions per repository policy

Fixes the post-merge iOS gate for the Mahayana cross-platform release.