### PR TITLE
feat(remote): add account device presence inventory slice

### DIFF
--- a/.github/workflows/computer-control-security.yml
+++ b/.github/workflows/computer-control-security.yml
@@ -31,6 +31,7 @@ on:
       - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs'
       - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs'
       - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0014_remote_computer_client_tokens.sql'
+      - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0015_remote_computer_inventory.sql'
       - 'third_party/mahayana/mahayana-rs/mahayana-agent-codex/**'
       - 'third_party/mahayana/mahayana-rs/Cargo.lock'
       - '.github/workflows/apple-store-delivery.yml'
@@ -74,6 +75,7 @@ on:
       - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs'
       - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs'
       - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0014_remote_computer_client_tokens.sql'
+      - 'third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0015_remote_computer_inventory.sql'
       - 'third_party/mahayana/mahayana-rs/mahayana-agent-codex/**'
       - 'third_party/mahayana/mahayana-rs/Cargo.lock'
       - '.github/workflows/apple-store-delivery.yml'
@@ -115,7 +117,7 @@ jobs:
           cache-dependency-path: chatgpt-vps-control/package-lock.json
       - name: Verify dependency-free embedded runtime source contract
         if: runner.os == 'Linux'
-        run: node --test tests/fabushi-embedded-runtime-source.test.js tests/fabushi-computer-policy.test.js tests/interactive-runner-account-binding.test.js
+        run: node --test tests/fabushi-embedded-runtime-source.test.js tests/rustdesk-device-presence-contract.test.js tests/fabushi-computer-policy.test.js tests/interactive-runner-account-binding.test.js
       - run: npm ci --ignore-scripts
       - name: Check JavaScript syntax
         run: >-

--- a/chatgpt-vps-control/tests/rustdesk-device-presence-contract.test.js
+++ b/chatgpt-vps-control/tests/rustdesk-device-presence-contract.test.js
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function source(relativePath) {
+  return readFileSync(resolve(repositoryRoot, relativePath), "utf8");
+}
+
+test("account-scoped device inventory is durable and secret-free", () => {
+  const migration = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0015_remote_computer_inventory.sql");
+  const worker = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/remote_computer.rs");
+
+  for (const field of ["provider", "platform", "app_version", "capabilities_json"]) {
+    assert.match(migration, new RegExp(`ADD COLUMN ${field}\\b`));
+  }
+  assert.match(worker, /WHERE computer\.user_id = \?1 AND computer\.revoked_at IS NULL/);
+  assert.match(worker, /session\.user_id = computer\.user_id/);
+  assert.match(worker, /"activeSessionCount": row\.active_session_count/);
+  assert.match(worker, /now\.saturating_sub\(row\.last_seen_at\) <= 45/);
+  assert.doesNotMatch(migration, /device_secret TEXT|screenshot_data|input_payload/);
+});
+
+test("desktop registration forwards honest Fabushi capabilities end to end", () => {
+  const contracts = source("frontend/apps/web/src/lib/mahayana-host/contracts.ts");
+  const desktop = source("frontend/apps/web/src/lib/remote-computer/desktop-peer.ts");
+  const protocol = source("third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs");
+  const host = source("third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs");
+  const worker = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/remote_computer.rs");
+
+  for (const field of ["provider", "platform", "appVersion", "capabilities"]) {
+    assert.ok(contracts.includes(field), `missing TypeScript field ${field}`);
+    assert.ok(desktop.includes(field), `desktop does not send ${field}`);
+    assert.ok(host.includes(`"${field}"`), `Feature Host does not forward ${field}`);
+  }
+  assert.match(protocol, /provider: Option<String>/);
+  assert.match(protocol, /app_version: Option<String>/);
+  assert.match(protocol, /capabilities: Vec<String>/);
+  assert.match(worker, /"rustdesk-sidecar"/);
+
+  const capabilityStart = desktop.indexOf("const FABUSHI_WEBRTC_CAPABILITIES");
+  const capabilityEnd = desktop.indexOf("];", capabilityStart);
+  assert.ok(capabilityStart >= 0 && capabilityEnd > capabilityStart);
+  const actualCapabilities = desktop.slice(capabilityStart, capabilityEnd);
+  for (const capability of ["remote-desktop", "input", "display", "session-management"]) {
+    assert.ok(actualCapabilities.includes(`"${capability}"`));
+  }
+  assert.doesNotMatch(actualCapabilities, /clipboard|file-transfer|audio/);
+});
+
+test("device list exposes status, detail, search, and capability filters", () => {
+  const api = source("frontend/apps/web/src/lib/remote-computer/remote-api.ts");
+  const page = source("frontend/apps/web/src/app/remote-computer/page.tsx");
+
+  for (const field of ["provider", "platform", "appVersion", "capabilities", "activeSessionCount"]) {
+    assert.ok(api.includes(field), `API mapping is missing ${field}`);
+    assert.ok(page.includes(field), `device list is missing ${field}`);
+  }
+  assert.match(page, /deviceQuery/);
+  assert.match(page, /statusFilter/);
+  assert.match(page, /capabilityFilter/);
+  assert.match(page, /formatRelativeOnline/);
+});
+
+test("RustDesk remains an isolated AGPL compatibility boundary", () => {
+  const adr = source("projects/rustdesk-fabushi-fusion/decisions/ADR-0001-provider-license-boundary.md");
+  const mapping = source("projects/rustdesk-fabushi-fusion/docs/08-RustDesk能力映射.md");
+
+  assert.match(adr, /AGPL-3\.0/);
+  assert.match(adr, /rustdesk-sidecar/);
+  assert.match(mapping, /rustdesk\/rustdesk@f28ac38ccfa662fd06639a062e0d06249860b142/);
+  assert.match(mapping, /rustdesk\/hbb_common@b2b1ac453d1d694046f63be20d792d608dac1c93/);
+});

--- a/frontend/apps/web/src/app/remote-computer/page.tsx
+++ b/frontend/apps/web/src/app/remote-computer/page.tsx
@@ -7,6 +7,33 @@ import { RemoteComputerApi, type PairedClientRecord, type RemoteAuthSession, typ
 import styles from "./remote-computer.module.css";
 
 type PointerMode = "single" | "double" | "right" | "scroll";
+type DeviceStatusFilter = "all" | "online" | "offline";
+type DeviceCapabilityFilter = "all" | RemoteComputerInfo["capabilities"][number];
+
+const CAPABILITY_LABELS: Record<RemoteComputerInfo["capabilities"][number], string> = {
+  "remote-desktop": "远程桌面",
+  input: "输入",
+  clipboard: "剪贴板",
+  "file-transfer": "文件",
+  display: "显示",
+  audio: "音频",
+  "session-management": "会话",
+};
+
+const PLATFORM_LABELS: Record<RemoteComputerInfo["platform"], string> = {
+  windows: "Windows",
+  macos: "macOS",
+  linux: "Linux",
+  android: "Android",
+  ios: "iOS",
+  web: "Web",
+  unknown: "未知平台",
+};
+
+const PROVIDER_LABELS: Record<RemoteComputerInfo["provider"], string> = {
+  "fabushi-webrtc": "Fabushi WebRTC",
+  "rustdesk-sidecar": "RustDesk 兼容层",
+};
 
 interface PointerGesture {
   pointerId: number;
@@ -37,6 +64,9 @@ export default function RemoteComputerPage() {
   const [pairingCode, setPairingCode] = useState("");
   const [phoneLabel, setPhoneLabel] = useState("我的手机");
   const [computers, setComputers] = useState<RemoteComputerInfo[]>([]);
+  const [deviceQuery, setDeviceQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<DeviceStatusFilter>("all");
+  const [capabilityFilter, setCapabilityFilter] = useState<DeviceCapabilityFilter>("all");
   const [paired, setPaired] = useState<Record<string, PairedClientRecord>>(() => api.pairedClients());
   const [selectedDeviceId, setSelectedDeviceId] = useState("");
   const [peerState, setPeerState] = useState<MobilePeerState>({ phase: "idle" });
@@ -53,6 +83,22 @@ export default function RemoteComputerPage() {
   const imageRef = useRef<HTMLImageElement | null>(null);
 
   const selectedComputer = computers.find((computer) => computer.deviceId === selectedDeviceId);
+  const visibleComputers = useMemo(() => {
+    const query = deviceQuery.trim().toLocaleLowerCase();
+    return computers.filter((computer) => {
+      if (statusFilter !== "all" && computer.online !== (statusFilter === "online")) return false;
+      if (capabilityFilter !== "all" && !computer.capabilities.includes(capabilityFilter)) return false;
+      if (!query) return true;
+      return [
+        computer.label,
+        computer.deviceId,
+        computer.provider,
+        computer.platform,
+        computer.appVersion,
+        ...computer.capabilities,
+      ].some((value) => value.toLocaleLowerCase().includes(query));
+    });
+  }, [capabilityFilter, computers, deviceQuery, statusFilter]);
   const connected = peerState.phase === "connected";
 
   const refreshComputers = async () => {
@@ -325,8 +371,25 @@ export default function RemoteComputerPage() {
 
           <section className={styles.card}>
             <div className={styles.cardHeader}><h2>我的电脑</h2><button type="button" onClick={() => void refreshComputers()}>刷新</button></div>
+            <div className={styles.deviceFilters}>
+              <input
+                value={deviceQuery}
+                onChange={(event) => setDeviceQuery(event.target.value)}
+                placeholder="搜索名称、设备 ID、平台或版本"
+                aria-label="搜索电脑"
+              />
+              <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as DeviceStatusFilter)} aria-label="在线状态筛选">
+                <option value="all">全部状态</option>
+                <option value="online">在线</option>
+                <option value="offline">离线</option>
+              </select>
+              <select value={capabilityFilter} onChange={(event) => setCapabilityFilter(event.target.value as DeviceCapabilityFilter)} aria-label="能力筛选">
+                <option value="all">全部能力</option>
+                {Object.entries(CAPABILITY_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </div>
             <div className={styles.computerList}>
-              {computers.map((computer) => {
+              {visibleComputers.map((computer) => {
                 const authorized = Boolean(paired[computer.deviceId]);
                 return (
                   <button
@@ -339,12 +402,23 @@ export default function RemoteComputerPage() {
                     disabled={!computer.online}
                   >
                     <span className={styles.computerIcon}>⌘</span>
-                    <span><strong>{computer.label}</strong><small data-online={computer.online ? "true" : "false"}>{formatRelativeOnline(computer)}</small></span>
+                    <span className={styles.computerDetails}>
+                      <strong>{computer.label}</strong>
+                      <small data-online={computer.online ? "true" : "false"}>
+                        {formatRelativeOnline(computer)} · {PLATFORM_LABELS[computer.platform]} · v{computer.appVersion}
+                      </small>
+                      <span className={styles.computerMeta}>
+                        <span>{PROVIDER_LABELS[computer.provider]}</span>
+                        {computer.capabilities.slice(0, 4).map((capability) => <span key={capability}>{CAPABILITY_LABELS[capability]}</span>)}
+                        {computer.activeSessionCount > 0 ? <span data-active="true">{computer.activeSessionCount} 个活动会话</span> : null}
+                      </span>
+                    </span>
                     <em>{!computer.online ? "离线" : authorized ? "连接" : "待授权"}</em>
                   </button>
                 );
               })}
               {!computers.length ? <p>尚未发现电脑。请先在电脑上安装并登录 Fabushi。</p> : null}
+              {computers.length > 0 && !visibleComputers.length ? <p>没有符合当前筛选条件的电脑。</p> : null}
             </div>
           </section>
           {error ? <p className={styles.error}>{error}</p> : null}

--- a/frontend/apps/web/src/app/remote-computer/remote-computer.module.css
+++ b/frontend/apps/web/src/app/remote-computer/remote-computer.module.css
@@ -124,6 +124,23 @@
 .pairRow input { font: 700 19px/1 "SFMono-Regular", Consolas, monospace; letter-spacing: .13em; text-transform: uppercase; }
 .pairRow button { min-width: 76px; }
 
+.deviceFilters {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 7px;
+  margin-bottom: 9px;
+}
+.deviceFilters input,
+.deviceFilters select {
+  min-width: 0;
+  border: 1px solid #2b2e35;
+  border-radius: 9px;
+  background: #17191e;
+  color: #b8bbc2;
+  font: inherit;
+  font-size: 10px;
+  padding: 8px 9px;
+}
 .computerList { display: grid; gap: 7px; }
 .computerList > button {
   width: 100%;
@@ -139,8 +156,19 @@
   text-align: left;
 }
 .computerList > button:disabled { opacity: .48; }
-.computerList > button > span:nth-child(2) { display: grid; gap: 2px; }
+.computerList > button > span:nth-child(2) { display: grid; gap: 3px; }
 .computerList strong { font-size: 12px; }
+.computerDetails { min-width: 0; }
+.computerMeta { display: flex; flex-wrap: wrap; gap: 4px; }
+.computerMeta > span {
+  border: 1px solid #30333b;
+  border-radius: 999px;
+  color: #9296a1;
+  font-size: 8px;
+  line-height: 1;
+  padding: 3px 5px;
+}
+.computerMeta > span[data-active="true"] { border-color: rgb(88 216 155 / 38%); color: #58d89b; }
 .computerList small { color: #81858f; font-size: 10px; }
 .computerList small[data-online="true"] { color: #58d89b; }
 .computerList em { color: #8d82ff; font-size: 10px; font-style: normal; }
@@ -238,4 +266,9 @@
   .shell { padding-left: 24px; padding-right: 24px; }
   .screenViewport { min-height: 420px; }
   .keyGrid { grid-template-columns: repeat(12, 1fr); }
+}
+
+@media (max-width: 560px) {
+  .deviceFilters { grid-template-columns: 1fr 1fr; }
+  .deviceFilters input { grid-column: 1 / -1; }
 }

--- a/frontend/apps/web/src/lib/mahayana-host/contracts.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/contracts.ts
@@ -352,6 +352,17 @@ export interface ComputerActionResult {
   snapshot: ComputerSnapshot;
 }
 
+export type RemoteComputerProvider = "fabushi-webrtc" | "rustdesk-sidecar";
+export type RemoteComputerPlatform = "windows" | "macos" | "linux" | "android" | "ios" | "web" | "unknown";
+export type RemoteComputerCapability =
+  | "remote-desktop"
+  | "input"
+  | "clipboard"
+  | "file-transfer"
+  | "display"
+  | "audio"
+  | "session-management";
+
 export interface RemoteComputerRegistration {
   deviceId: string;
   label: string;
@@ -713,7 +724,15 @@ export type RuntimeCommand =
   | (CommandBase & { type: "computer.status" })
   | (CommandBase & { type: "computer.screenshot"; origin?: ComputerControlOrigin; sessionId?: string; target?: ComputerControlTarget })
   | (CommandBase & { type: "computer.action"; origin?: ComputerControlOrigin; agentId?: string; sessionId?: string; target?: ComputerControlTarget; action: ComputerAction; then?: ComputerAction[] })
-  | (CommandBase & { type: "remoteComputer.register"; deviceId: string; label: string })
+  | (CommandBase & {
+      type: "remoteComputer.register";
+      deviceId: string;
+      label: string;
+      provider: RemoteComputerProvider;
+      platform: RemoteComputerPlatform;
+      appVersion: string;
+      capabilities: RemoteComputerCapability[];
+    })
   | (CommandBase & { type: "remoteComputer.heartbeat"; deviceId: string })
   | (CommandBase & { type: "remoteComputer.clients"; deviceId: string })
   | (CommandBase & { type: "remoteComputer.clientRevoke"; deviceId: string; clientId: string })

--- a/frontend/apps/web/src/lib/mahayana-host/mock-transport.ts
+++ b/frontend/apps/web/src/lib/mahayana-host/mock-transport.ts
@@ -1369,7 +1369,7 @@ export class MockMahayanaHostTransport implements MahayanaHostTransport {
         return { requestId: command.requestId };
       }
       case "remoteComputer.register":
-        this.emit({ type: "remoteComputer.changed", timestamp: now(), requestId: command.requestId, action: "registered", data: { deviceId: command.deviceId, label: command.label, pairingCode: "AB12CD34", pairingExpiresAt: Math.floor(Date.now() / 1000) + 600 } });
+        this.emit({ type: "remoteComputer.changed", timestamp: now(), requestId: command.requestId, action: "registered", data: { deviceId: command.deviceId, label: command.label, provider: command.provider, platform: command.platform, appVersion: command.appVersion, capabilities: command.capabilities, pairingCode: "AB12CD34", pairingExpiresAt: Math.floor(Date.now() / 1000) + 600 } });
         return { requestId: command.requestId };
       case "remoteComputer.heartbeat":
         this.emit({ type: "remoteComputer.changed", timestamp: now(), requestId: command.requestId, action: "heartbeat", data: { ok: true, lastSeenAt: Math.floor(Date.now() / 1000) } });

--- a/frontend/apps/web/src/lib/remote-computer/desktop-peer.ts
+++ b/frontend/apps/web/src/lib/remote-computer/desktop-peer.ts
@@ -3,7 +3,10 @@ import type {
   ComputerActionResult,
   ComputerControlTarget,
   ComputerSnapshot,
+  RemoteComputerCapability,
   RemoteComputerClient,
+  RemoteComputerPlatform,
+  RemoteComputerProvider,
   RemoteComputerRegistration,
   RemoteComputerSession,
   RemoteComputerSignal,
@@ -37,6 +40,28 @@ const MAX_ICE_URLS_PER_SERVER = 16;
 const MAX_ICE_URL_CHARS = 2_048;
 const MAX_SDP_CHARS = 256 * 1024;
 const MAX_ICE_CANDIDATE_CHARS = 16 * 1024;
+const FABUSHI_WEBRTC_CAPABILITIES: RemoteComputerCapability[] = [
+  "remote-desktop",
+  "input",
+  "display",
+  "session-management",
+];
+
+function detectedRemotePlatform(): RemoteComputerPlatform {
+  if (typeof navigator === "undefined") return "unknown";
+  const fingerprint = `${navigator.userAgent} ${navigator.platform}`.toLowerCase();
+  if (fingerprint.includes("android")) return "android";
+  if (/iphone|ipad|ipod/.test(fingerprint)) return "ios";
+  if (fingerprint.includes("win")) return "windows";
+  if (fingerprint.includes("mac")) return "macos";
+  if (fingerprint.includes("linux")) return "linux";
+  return "web";
+}
+
+function detectedFabushiVersion(): string {
+  const value = (globalThis as { __FABUSHI_APP_VERSION__?: unknown }).__FABUSHI_APP_VERSION__;
+  return typeof value === "string" && /^[A-Za-z0-9.+_-]{1,64}$/.test(value) ? value : "unknown";
+}
 
 export interface RemoteComputerDesktopState {
   running: boolean;
@@ -72,6 +97,10 @@ interface DesktopPeerOptions {
   label: string;
   identityScope: string;
   controlEnabled?: boolean;
+  provider?: RemoteComputerProvider;
+  platform?: RemoteComputerPlatform;
+  appVersion?: string;
+  capabilities?: RemoteComputerCapability[];
   resolveAgentId?: (requestedAgentId: string) => string | null;
   onState?: (state: RemoteComputerDesktopState) => void;
 }
@@ -608,6 +637,10 @@ export class RemoteComputerDesktopController {
   private readonly transport: MahayanaHostTransport;
   private readonly label: string;
   private readonly deviceId: string;
+  private readonly provider: RemoteComputerProvider;
+  private readonly platform: RemoteComputerPlatform;
+  private readonly appVersion: string;
+  private readonly capabilities: RemoteComputerCapability[];
   private readonly resolveAgentId: (requestedAgentId: string) => string | null;
   private readonly onState?: DesktopPeerOptions["onState"];
   private state: RemoteComputerDesktopState;
@@ -624,6 +657,12 @@ export class RemoteComputerDesktopController {
     this.transport = options.transport;
     this.label = options.label.trim() || "This Mac";
     this.deviceId = remoteDeviceId(options.identityScope);
+    this.provider = options.provider ?? "fabushi-webrtc";
+    this.platform = options.platform ?? detectedRemotePlatform();
+    this.appVersion = options.appVersion && /^[A-Za-z0-9.+_-]{1,64}$/.test(options.appVersion)
+      ? options.appVersion
+      : detectedFabushiVersion();
+    this.capabilities = [...(options.capabilities ?? FABUSHI_WEBRTC_CAPABILITIES)];
     this.resolveAgentId = options.resolveAgentId ?? (() => null);
     this.onState = options.onState;
     this.controlEnabled = options.controlEnabled === true;
@@ -741,6 +780,10 @@ export class RemoteComputerDesktopController {
       requestId: id,
       deviceId: this.deviceId,
       label: this.label,
+      provider: this.provider,
+      platform: this.platform,
+      appVersion: this.appVersion,
+      capabilities: [...this.capabilities],
     });
     const registration = normalizeRegistration(event.data, this.deviceId);
     this.update({ registration, error: undefined });

--- a/frontend/apps/web/src/lib/remote-computer/remote-api.ts
+++ b/frontend/apps/web/src/lib/remote-computer/remote-api.ts
@@ -1,3 +1,5 @@
+import type { RemoteComputerCapability, RemoteComputerPlatform, RemoteComputerProvider } from "../mahayana-host/contracts";
+
 const DEFAULT_API_BASE = "https://api.ombhrum.com";
 const SESSION_KEY = "fabushi-remote-auth-v1";
 const MOBILE_DEVICE_KEY = "fabushi-remote-mobile-device-v1";
@@ -21,6 +23,11 @@ export interface RemoteComputerInfo {
   lastSeenAt: number;
   createdAt: number;
   online: boolean;
+  provider: RemoteComputerProvider;
+  platform: RemoteComputerPlatform;
+  appVersion: string;
+  capabilities: RemoteComputerCapability[];
+  activeSessionCount: number;
 }
 
 export interface PairingResult {
@@ -72,6 +79,13 @@ const MAX_AUTH_TOKEN_CHARS = 16 * 1024;
 const ALLOWED_ICE_SCHEMES = new Set(["stun:", "turn:", "turns:"]);
 const MOBILE_SIGNAL_KINDS = new Set<RemoteSignal["kind"]>(["offer", "ice", "ready", "close"]);
 const DESKTOP_SIGNAL_KINDS = new Set<RemoteSignal["kind"]>(["answer", "ice", "ready", "close"]);
+const REMOTE_COMPUTER_PROVIDERS = new Set<RemoteComputerProvider>(["fabushi-webrtc", "rustdesk-sidecar"]);
+const REMOTE_COMPUTER_PLATFORMS = new Set<RemoteComputerPlatform>([
+  "windows", "macos", "linux", "android", "ios", "web", "unknown",
+]);
+const REMOTE_COMPUTER_CAPABILITIES = new Set<RemoteComputerCapability>([
+  "remote-desktop", "input", "clipboard", "file-transfer", "display", "audio", "session-management",
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -125,6 +139,38 @@ function validAuthToken(value: unknown): value is string {
 
 function validTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function remoteComputerProvider(value: unknown): RemoteComputerProvider {
+  return typeof value === "string" && REMOTE_COMPUTER_PROVIDERS.has(value as RemoteComputerProvider)
+    ? value as RemoteComputerProvider
+    : "fabushi-webrtc";
+}
+
+function remoteComputerPlatform(value: unknown): RemoteComputerPlatform {
+  return typeof value === "string" && REMOTE_COMPUTER_PLATFORMS.has(value as RemoteComputerPlatform)
+    ? value as RemoteComputerPlatform
+    : "unknown";
+}
+
+function remoteComputerVersion(value: unknown): string {
+  return typeof value === "string" && /^[A-Za-z0-9.+_-]{1,64}$/.test(value) ? value : "unknown";
+}
+
+function remoteComputerCapabilities(value: unknown): RemoteComputerCapability[] {
+  if (!Array.isArray(value)) return [];
+  const normalized: RemoteComputerCapability[] = [];
+  for (const candidate of value.slice(0, 32)) {
+    if (typeof candidate !== "string"
+      || !REMOTE_COMPUTER_CAPABILITIES.has(candidate as RemoteComputerCapability)
+      || normalized.includes(candidate as RemoteComputerCapability)) continue;
+    normalized.push(candidate as RemoteComputerCapability);
+  }
+  return normalized;
+}
+
+function activeSessionCount(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 32 ? value : 0;
 }
 
 function accountIdentity(userId: string | number): string {
@@ -348,6 +394,11 @@ export class RemoteComputerApi {
         lastSeenAt: candidate.lastSeenAt,
         createdAt: candidate.createdAt,
         online: candidate.online,
+        provider: remoteComputerProvider(candidate.provider),
+        platform: remoteComputerPlatform(candidate.platform),
+        appVersion: remoteComputerVersion(candidate.appVersion),
+        capabilities: remoteComputerCapabilities(candidate.capabilities),
+        activeSessionCount: activeSessionCount(candidate.activeSessionCount),
       }];
     });
   }

--- a/projects/PORTFOLIO.json
+++ b/projects/PORTFOLIO.json
@@ -5,7 +5,7 @@
   "project_id_regex": "^FAB-P[0-9]{4}$",
   "allocation_policy": "monotonic-no-reuse",
   "ordering_basis": "first-formal-project-folder-commit-on-canonical-main",
-  "next_sequence": 9,
+  "next_sequence": 10,
   "projects": [
     {
       "project_id": "FAB-P0001",
@@ -16,9 +16,7 @@
       "status": "active",
       "registered_at": "2026-08-22",
       "first_canonical_main_commit": "99cd4b227a34b49fc04c3265c1dfdee585344160",
-      "legacy_project_ids": [
-        "FABUSHI-TELEGRAM-FUSION"
-      ]
+      "legacy_project_ids": ["FABUSHI-TELEGRAM-FUSION"]
     },
     {
       "project_id": "FAB-P0002",
@@ -29,9 +27,7 @@
       "status": "active",
       "registered_at": "2026-08-22",
       "first_canonical_main_commit": "eaf273dafc140619b06b46a4d7d234997acde05d",
-      "legacy_project_ids": [
-        "FPG"
-      ]
+      "legacy_project_ids": ["FPG"]
     },
     {
       "project_id": "FAB-P0003",
@@ -42,9 +38,7 @@
       "status": "active",
       "registered_at": "2026-08-22",
       "first_canonical_main_commit": "ac94b40d4a05a0211146c2bb5904aa936a7bc928",
-      "legacy_project_ids": [
-        "FCM"
-      ]
+      "legacy_project_ids": ["FCM"]
     },
     {
       "project_id": "FAB-P0004",
@@ -55,9 +49,7 @@
       "status": "active",
       "registered_at": "2026-08-22",
       "first_canonical_main_commit": "6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c",
-      "legacy_project_ids": [
-        "FABUSHI-GROK-BOT-FUSION"
-      ]
+      "legacy_project_ids": ["FABUSHI-GROK-BOT-FUSION"]
     },
     {
       "project_id": "FAB-P0005",
@@ -68,9 +60,7 @@
       "status": "active",
       "registered_at": "2026-08-22",
       "first_canonical_main_commit": "88db63c328c3cba39971f3942509cb0b582502bc",
-      "legacy_project_ids": [
-        "MSR"
-      ]
+      "legacy_project_ids": ["MSR"]
     },
     {
       "project_id": "FAB-P0006",
@@ -92,9 +82,7 @@
       "status": "active",
       "registered_at": "2026-08-23",
       "first_canonical_main_commit": "11fd9d32d5b7edf09882ff5308be55b566e1a6d4",
-      "legacy_project_ids": [
-        "DHRF"
-      ]
+      "legacy_project_ids": ["DHRF"]
     },
     {
       "project_id": "FAB-P0008",
@@ -105,6 +93,17 @@
       "status": "active",
       "registered_at": "2026-08-25",
       "first_canonical_main_commit": "52b7c10889e585660b7d2a22a40781c22f31b7a1",
+      "legacy_project_ids": []
+    },
+    {
+      "project_id": "FAB-P0009",
+      "project_key": "RDF",
+      "slug": "rustdesk-fabushi-fusion",
+      "name": "RustDesk -> Fabushi 核心能力融合",
+      "authoritative_path": "projects/rustdesk-fabushi-fusion",
+      "status": "active",
+      "registered_at": "2026-09-01",
+      "first_canonical_main_commit": "d69bf418ed19df6ec7f1d0581646283a49461ba7",
       "legacy_project_ids": []
     }
   ]

--- a/projects/PORTFOLIO.json
+++ b/projects/PORTFOLIO.json
@@ -103,7 +103,7 @@
       "authoritative_path": "projects/rustdesk-fabushi-fusion",
       "status": "active",
       "registered_at": "2026-09-01",
-      "first_canonical_main_commit": "d69bf418ed19df6ec7f1d0581646283a49461ba7",
+      "first_canonical_main_commit": "9c7d16bf8bf57828adbb0bdb3d32ec0ba26abe6e",
       "legacy_project_ids": []
     }
   ]

--- a/projects/README.md
+++ b/projects/README.md
@@ -10,19 +10,20 @@ Identity policy: [`PROJECT_ID_POLICY.md`](./PROJECT_ID_POLICY.md)
 | `FAB-P0003` | `FCM` | Fabushi CI/CD & Merge Governance | `projects/fabushi-cicd-merge-governance/` | `ac94b40d4a05a0211146c2bb5904aa936a7bc928` |
 | `FAB-P0004` | `GBF` | Grok Bot -> Fabushi 全量能力与源码融合 | `projects/grok-bot-fabushi-integration/` | `6d1e9cd7a475e8058d5d8512f5c3a0c21da8ed9c` |
 | `FAB-P0005` | `MSR` | Mahayana Sovereign Runtime | `projects/mahayana-sovereign-runtime/` | `88db63c328c3cba39971f3942509cb0b582502bc` |
+| `FAB-P0006` | `FAM` | Fabushi Always-on Marketing | `projects/fabushi-always-on-marketing/` | `173e7f793987b6d0a9303b55e2060e2584552da9` |
+| `FAB-P0007` | `DHRF` | DeepSeek Harness Rust Fusion | `projects/deepseek-harness-rust-fusion/` | `11fd9d32d5b7edf09882ff5308be55b566e1a6d4` |
+| `FAB-P0008` | `AAC` | Fabushi Account Access Control | `projects/fabushi-account-access-control/` | `52b7c10889e585660b7d2a22a40781c22f31b7a1` |
+| `FAB-P0009` | `RDF` | RustDesk -> Fabushi 核心能力融合 | `projects/rustdesk-fabushi-fusion/` | `d69bf418ed19df6ec7f1d0581646283a49461ba7` |
 
 ## Next Project ID
 
-The registry high-water mark is authoritative. At this migration baseline the next allocatable ID is:
-
-`FAB-P0006`
-
-Do not reserve or allocate it from chat memory. Always re-read `PORTFOLIO.json` on canonical `main` immediately before creating a new independent project.
+The registry high-water mark is authoritative. The next allocatable ID is `FAB-P0010`.
+Always re-read `PORTFOLIO.json` on canonical `main` immediately before allocating it.
 
 ## Identifier semantics
 
-- `FAB-Pxxxx`: immutable portfolio Project ID across all Fabushi projects.
-- Project Key (`TFI`, `FPG`, `FCM`, `GBF`, `MSR`, ...): mnemonic namespace for requirements/tasks/milestones.
-- Task IDs (`MSR-103`, `FPG-004`, ...): project-internal work identifiers; they are not portfolio Project IDs.
+- `FAB-Pxxxx`: immutable portfolio Project ID.
+- Project Key: stable mnemonic requirement/task namespace.
+- Task IDs: project-internal work identities; they are not portfolio Project IDs.
 
-Project IDs are never reused, even after archive, cancellation, consolidation, split, or rename.
+Project IDs are never reused.

--- a/projects/README.md
+++ b/projects/README.md
@@ -13,7 +13,7 @@ Identity policy: [`PROJECT_ID_POLICY.md`](./PROJECT_ID_POLICY.md)
 | `FAB-P0006` | `FAM` | Fabushi Always-on Marketing | `projects/fabushi-always-on-marketing/` | `173e7f793987b6d0a9303b55e2060e2584552da9` |
 | `FAB-P0007` | `DHRF` | DeepSeek Harness Rust Fusion | `projects/deepseek-harness-rust-fusion/` | `11fd9d32d5b7edf09882ff5308be55b566e1a6d4` |
 | `FAB-P0008` | `AAC` | Fabushi Account Access Control | `projects/fabushi-account-access-control/` | `52b7c10889e585660b7d2a22a40781c22f31b7a1` |
-| `FAB-P0009` | `RDF` | RustDesk -> Fabushi 核心能力融合 | `projects/rustdesk-fabushi-fusion/` | `d69bf418ed19df6ec7f1d0581646283a49461ba7` |
+| `FAB-P0009` | `RDF` | RustDesk -> Fabushi 核心能力融合 | `projects/rustdesk-fabushi-fusion/` | `9c7d16bf8bf57828adbb0bdb3d32ec0ba26abe6e` |
 
 ## Next Project ID
 

--- a/projects/rustdesk-fabushi-fusion/OWNERS.md
+++ b/projects/rustdesk-fabushi-fusion/OWNERS.md
@@ -1,0 +1,11 @@
+# Owners
+
+| Role | Owner | Responsibility |
+|---|---|---|
+| Accountable | Fabushi project owner | Scope, product and license decisions |
+| Execution | Fabushi engineering | Implementation, tests and records |
+| Security | Fabushi security reviewers | Remote-access threat model and authorization |
+| Release | Fabushi release maintainers | Signed packages, E2E and rollback |
+| Legal | Designated license reviewer | AGPL/commercial-license disposition |
+
+Escalate unresolved license, public-listener, credential, consent or destructive-control questions through `management/08-问题与行动项.md`.

--- a/projects/rustdesk-fabushi-fusion/PROJECT.yaml
+++ b/projects/rustdesk-fabushi-fusion/PROJECT.yaml
@@ -1,0 +1,26 @@
+project_id: FAB-P0009
+project_key: RDF
+legacy_project_ids: []
+name: RustDesk -> Fabushi 核心能力融合
+slug: rustdesk-fabushi-fusion
+status: active
+repository: bhrumom/fabushi
+authoritative_branch: main
+authoritative_path: projects/rustdesk-fabushi-fusion
+owner: Fabushi engineering
+reviewers: []
+current_stage: M1-device-presence
+created_at: 2026-09-01
+updated_at: 2026-09-01
+risk_tier: tier-0
+security_classification: confidential
+target_finish: null
+related_projects:
+  - grok-bot-fabushi-integration
+  - mahayana-sovereign-runtime
+  - fabushi-account-access-control
+source_systems:
+  - GitHub:bhrumom/fabushi
+  - GitHub:rustdesk/rustdesk@f28ac38ccfa662fd06639a062e0d06249860b142
+  - GitHub:rustdesk/hbb_common@b2b1ac453d1d694046f63be20d792d608dac1c93
+  - GitHub:rustdesk/rustdesk-server@a7736be5e40f85bfc141120dce587e836e5d4b80

--- a/projects/rustdesk-fabushi-fusion/README.md
+++ b/projects/rustdesk-fabushi-fusion/README.md
@@ -1,0 +1,23 @@
+# RustDesk -> Fabushi 核心能力融合
+
+- Project ID: `FAB-P0009`
+- Project Key: `RDF`
+- Status: active / in progress
+- Current stage: M1 device identity and presence
+- Next gate: RDF-001 contract CI on the task PR
+
+## Objective
+
+Unify all devices under one Fabushi account and progressively deliver secure remote-desktop, input, clipboard, file, display, audio and session capabilities informed by the pinned RustDesk upstream, while Fabushi remains the identity, authorization, audit and product authority.
+
+## Current verified baseline
+
+Fabushi already has account-scoped computer registration, device-secret possession proof, heartbeat, D1 presence, paired clients, expiring WebRTC sessions, direct/TURN signaling, remote screen/input and desktop/mobile/Web surfaces. The first slice extends that existing path with a vendor-neutral inventory contract for platform, version, provider, capabilities and active-session state.
+
+RustDesk client and OSS server are AGPL-3.0. No RustDesk source is copied or linked into Fabushi in RDF-001. Later native provider work requires a separately distributable AGPL component or a separately licensed implementation and legal review.
+
+## Acceptance
+
+No capability is marked complete without code, contract tests, Actions run evidence, protected merge, canonical-main readback and applicable packaged E2E/Release evidence.
+
+See `SOURCE_OF_TRUTH.md`, `docs/`, `management/`, `decisions/`, `evidence/` and `runbooks/`.

--- a/projects/rustdesk-fabushi-fusion/SOURCE_OF_TRUTH.md
+++ b/projects/rustdesk-fabushi-fusion/SOURCE_OF_TRUTH.md
@@ -1,0 +1,14 @@
+# Source of Truth
+
+Project ID `FAB-P0009`; Project Key `RDF`.
+
+1. Canonical `bhrumom/fabushi` `main`, `projects/PORTFOLIO.json` and `PROJECT.yaml`.
+2. This project's persisted source, accepted ADRs, specifications and management records.
+3. Live GitHub PR, Actions, Release and deployment facts.
+4. Pinned upstream sources:
+   - `rustdesk/rustdesk@f28ac38ccfa662fd06639a062e0d06249860b142`
+   - its `rustdesk/hbb_common@b2b1ac453d1d694046f63be20d792d608dac1c93` submodule
+   - `rustdesk/rustdesk-server@a7736be5e40f85bfc141120dce587e836e5d4b80`
+5. Conversation/external mirrors only as intake until persisted here.
+
+Upstream behavior and protocol are references, not Fabushi's identity or authorization ABI. Discrepancies are recorded in status/changelog. Advancing an upstream pin requires a dated source update and gap audit.

--- a/projects/rustdesk-fabushi-fusion/decisions/ADR-0001-provider-license-boundary.md
+++ b/projects/rustdesk-fabushi-fusion/decisions/ADR-0001-provider-license-boundary.md
@@ -1,0 +1,17 @@
+# ADR-0001 — Provider and license boundary
+
+Status: Accepted for RDF-001  
+Date: 2026-09-01  
+Owners: Fabushi product/engineering; license review required for later native provider
+
+## Decision
+
+Fabushi account identity, device ownership, permission policy, audit and session grants remain authoritative. Existing `fabushi-webrtc` is the initial provider. RustDesk-grade behavior is represented by normalized capabilities. A future RustDesk implementation must be isolated as a separately distributable sidecar/service or use separately licensed code; it may not silently replace Fabushi authorization.
+
+## Reasons
+
+RustDesk client and OSS server are AGPL-3.0; direct copying/linking into a proprietary application has material copyleft/distribution obligations. A provider boundary also prevents duplicate IDs, pairing and audit models.
+
+## Consequences
+
+RDF-001 can safely deliver inventory value now. RustDesk wire/media interoperability remains explicitly unimplemented until RDF-D002 closes. The boundary adds mapping work but preserves provider replacement and honest capability state.

--- a/projects/rustdesk-fabushi-fusion/decisions/ADR-0001-provider-license-boundary.md
+++ b/projects/rustdesk-fabushi-fusion/decisions/ADR-0001-provider-license-boundary.md
@@ -6,7 +6,7 @@ Owners: Fabushi product/engineering; license review required for later native pr
 
 ## Decision
 
-Fabushi account identity, device ownership, permission policy, audit and session grants remain authoritative. Existing `fabushi-webrtc` is the initial provider. RustDesk-grade behavior is represented by normalized capabilities. A future RustDesk implementation must be isolated as a separately distributable sidecar/service or use separately licensed code; it may not silently replace Fabushi authorization.
+Fabushi account identity, device ownership, permission policy, audit and session grants remain authoritative. Existing `fabushi-webrtc` is the initial provider. RustDesk-grade behavior is represented by normalized capabilities. A future `rustdesk-sidecar` provider must be isolated as a separately distributable sidecar/service or use separately licensed code; it may not silently replace Fabushi authorization.
 
 ## Reasons
 

--- a/projects/rustdesk-fabushi-fusion/decisions/ADR-0001-provider-license-boundary.md
+++ b/projects/rustdesk-fabushi-fusion/decisions/ADR-0001-provider-license-boundary.md
@@ -1,7 +1,7 @@
 # ADR-0001 — Provider and license boundary
 
-Status: Accepted for RDF-001  
-Date: 2026-09-01  
+Status: Accepted for RDF-001
+Date: 2026-09-01
 Owners: Fabushi product/engineering; license review required for later native provider
 
 ## Decision

--- a/projects/rustdesk-fabushi-fusion/decisions/README.md
+++ b/projects/rustdesk-fabushi-fusion/decisions/README.md
@@ -1,0 +1,3 @@
+# Architecture Decision Records
+
+- `ADR-0001-provider-license-boundary.md` — Fabushi-owned authorization and vendor-neutral provider boundary.

--- a/projects/rustdesk-fabushi-fusion/docs/00-项目章程.md
+++ b/projects/rustdesk-fabushi-fusion/docs/00-项目章程.md
@@ -1,0 +1,9 @@
+# 00 项目章程
+
+Problem: Fabushi has working remote-control slices but lacks one durable device inventory and an explicit provider boundary for RustDesk-grade transport/capabilities.
+
+Objective: one Fabushi account owns one searchable device fleet; every connection and capability is authorized, observable and recoverable across desktop, mobile and Web.
+
+Constraints: preserve Fabushi identity/session authority; no local heavy builds; no unreviewed public native listener; no false parity claims; AGPL obligations block direct proprietary embedding until approved.
+
+Deliverables: normalized inventory, provider adapters, direct/relay session broker, media/input/file capability providers, permission/audit/recovery and cross-platform surfaces.

--- a/projects/rustdesk-fabushi-fusion/docs/01-范围与非目标.md
+++ b/projects/rustdesk-fabushi-fusion/docs/01-范围与非目标.md
@@ -1,0 +1,13 @@
+# 01 范围与非目标
+
+## In scope
+
+Account-bound registration/heartbeat/inventory; platform/version/capability/session detail; search/filter; provider compatibility; authenticated direct/relay negotiation; remote desktop/input/clipboard/file/display/audio; consent/policy/audit/reconnect; desktop/mobile/Web adaptation.
+
+## Non-goals
+
+Replacing Fabushi accounts with RustDesk IDs; copying AGPL RustDesk code into a proprietary binary without an approved compliance path; claiming protocol or feature parity from UI-only work; exposing an unauthenticated public remote-control listener.
+
+## Deferred
+
+Native RustDesk interoperability, hbbs/hbbr deployment and RustDesk media/input engine packaging remain later milestones pending provider and license gates.

--- a/projects/rustdesk-fabushi-fusion/docs/02-需求与成功指标.md
+++ b/projects/rustdesk-fabushi-fusion/docs/02-需求与成功指标.md
@@ -1,0 +1,13 @@
+# 02 需求与成功指标
+
+| ID | Requirement | Success evidence |
+|---|---|---|
+| RDF-FR-001 | Same-account device registration and heartbeat | Account-isolation contract + API/UI evidence |
+| RDF-FR-002 | Inventory platform/version/provider/capabilities/status/last seen/sessions | D1 migration, API contract and UI tests |
+| RDF-FR-003 | Search and filter device fleet | Deterministic frontend contract/E2E |
+| RDF-FR-004 | Secure direct/relay remote sessions | Authenticated negotiation + fallback E2E |
+| RDF-FR-005 | Desktop/input/clipboard/file/display/audio/session providers | Per-capability conformance evidence |
+| RDF-FR-006 | Consent, policy, audit, revoke and recovery | Security tests and audit evidence |
+| RDF-NFR-001 | No second identity authority | Account-bound ownership tests |
+| RDF-NFR-002 | No false completion | Acceptance matrix uses planned/implemented/tested/released separately |
+| RDF-NFR-003 | License-compliant distribution | Provenance/legal review and notices/source-offer evidence where applicable |

--- a/projects/rustdesk-fabushi-fusion/docs/03-架构与实现策略.md
+++ b/projects/rustdesk-fabushi-fusion/docs/03-架构与实现策略.md
@@ -1,0 +1,15 @@
+# 03 架构与实现策略
+
+## Layers
+
+1. Fabushi account/session: sole user and device ownership authority.
+2. Device inventory: stable Fabushi device ID, provider, platform, version, normalized capabilities, heartbeat lease and session summary.
+3. Session broker: possession-bound device/client credentials, explicit permission grants, short leases, audit refs.
+4. Provider boundary: existing `fabushi-webrtc` first; future `rustdesk-sidecar` adapter maps RustDesk rendezvous/relay and protobuf capabilities without changing Fabushi authorization.
+5. Product surfaces: shared Web inventory/control page embedded by Android/iOS and opened by desktop.
+
+## RustDesk mapping
+
+`RegisterPeer/RegisterPk` informs registration/possession semantics; punch-hole/relay informs direct-first fallback; `ControlPermissions` and `PermissionInfo` inform normalized capabilities/policy; message variants inform later media/input/clipboard/file/display providers.
+
+RDF-001 implements inventory only. It does not implement RustDesk wire interoperability.

--- a/projects/rustdesk-fabushi-fusion/docs/04-质量与测试策略.md
+++ b/projects/rustdesk-fabushi-fusion/docs/04-质量与测试策略.md
@@ -1,0 +1,5 @@
+# 04 质量与测试策略
+
+Use narrow source/contract checks in GitHub Actions: D1 migration invariants, Rust Worker request/list contract, Host protocol serialization, FeatureHost payload mapping, TypeScript API normalization and device-list filtering/rendering. Add security negatives for cross-account ownership, secret mismatch, malformed capabilities and stale presence.
+
+Do not run local builds or heavy tests. Required CI: Project portfolio governance plus the narrowest existing Worker/frontend/computer-control workflows. Application-affecting completion later requires canonical-main packaged E2E evidence per root AGENTS.md.

--- a/projects/rustdesk-fabushi-fusion/docs/05-发布迁移与回滚.md
+++ b/projects/rustdesk-fabushi-fusion/docs/05-发布迁移与回滚.md
@@ -1,0 +1,3 @@
+# 05 发布迁移与回滚
+
+D1 schema changes are additive and nullable/defaulted so older desktop clients keep registering. Deploy Worker before relying on new UI fields; UI parsers retain legacy defaults. Rollback the UI/Worker code without dropping columns. Never destructively downgrade device records. Native provider rollout requires a feature flag, canary account and separate rollback runbook.

--- a/projects/rustdesk-fabushi-fusion/docs/06-运维可观测性与SLO.md
+++ b/projects/rustdesk-fabushi-fusion/docs/06-运维可观测性与SLO.md
@@ -1,0 +1,3 @@
+# 06 运维可观测性与 SLO
+
+Initial targets: authenticated inventory p95 under 500 ms; online classification consistent within 45 seconds; heartbeat self-heal within two intervals; zero cross-account device disclosure. Record registration, heartbeat failure, lease expiry, session create/close, provider error and relay fallback with hashed account/device references. Capacity baseline remains 64 remote computers per account pending load evidence.

--- a/projects/rustdesk-fabushi-fusion/docs/07-安全隐私与合规.md
+++ b/projects/rustdesk-fabushi-fusion/docs/07-安全隐私与合规.md
@@ -1,0 +1,5 @@
+# 07 安全隐私与合规
+
+Device IDs, platform/version, capabilities, last-seen and session counts are account data. Device and client secrets remain possession credentials, are never returned by list APIs and stay hashed at rest where applicable. Account login is not remote-control consent; control remains opt-in and paired.
+
+RustDesk client and OSS server are AGPL-3.0 at the pinned revisions. Copying/linking/modifying or operating modified network software can trigger source, notice, corresponding-source and network-interaction obligations. RDF-001 uses clean-room normalized contracts and behavior mapping only. Any RustDesk binary/source distribution or modified server deployment requires legal review, an isolated package/service boundary, notices and an approved source-delivery plan.

--- a/projects/rustdesk-fabushi-fusion/docs/08-RustDesk能力映射.md
+++ b/projects/rustdesk-fabushi-fusion/docs/08-RustDesk能力映射.md
@@ -1,5 +1,11 @@
 # 08 RustDesk 能力映射
 
+## 上游证据基线
+
+- `rustdesk/rustdesk@f28ac38ccfa662fd06639a062e0d06249860b142`
+- `rustdesk/hbb_common@b2b1ac453d1d694046f63be20d792d608dac1c93`
+- `rustdesk/rustdesk-server@a7736be5e40f85bfc141120dce587e836e5d4b80`
+
 | Upstream area | RustDesk evidence | Fabushi target | State |
 |---|---|---|---|
 | Registration/presence | RegisterPeer/RegisterPk, keep-alive | Account-bound device inventory | RDF-001 implementing |

--- a/projects/rustdesk-fabushi-fusion/docs/08-RustDesk能力映射.md
+++ b/projects/rustdesk-fabushi-fusion/docs/08-RustDesk能力映射.md
@@ -1,0 +1,15 @@
+# 08 RustDesk 能力映射
+
+| Upstream area | RustDesk evidence | Fabushi target | State |
+|---|---|---|---|
+| Registration/presence | RegisterPeer/RegisterPk, keep-alive | Account-bound device inventory | RDF-001 implementing |
+| Direct/relay | PunchHole, RequestRelay, hbbs/hbbr | Fabushi session broker/provider | planned |
+| Permissions | ControlPermissions, PermissionInfo | Fabushi consent/policy grants | planned |
+| Desktop/video | VideoFrame, display info/switch | Existing WebRTC frame path + future provider | partial existing |
+| Input | MouseEvent, KeyEvent, pointer device events | Existing ComputerAction + provider adapter | partial existing |
+| Clipboard | Clipboard/MultiClipboards | Permissioned clipboard channel | planned |
+| Files | FileAction/FileResponse | Resumable transfer provider | planned |
+| Audio | AudioFormat/AudioFrame | Negotiated audio channel | planned |
+| Sessions/recovery | Login/session fields, close/restart/control messages | Expiring sessions, reconnect, revoke/audit | partial existing |
+
+“Partial existing” is not RustDesk protocol interoperability.

--- a/projects/rustdesk-fabushi-fusion/docs/19-完成定义与验收.md
+++ b/projects/rustdesk-fabushi-fusion/docs/19-完成定义与验收.md
@@ -1,0 +1,5 @@
+# 19 完成定义与验收
+
+Project completion requires every RDF-FR/NFR item dispositioned, implemented or explicitly rejected, CI/security/performance evidence, protected merge, canonical-main readback, packaged cross-platform E2E with required visual/debug artifacts, verified Release and license/provenance closure.
+
+RDF-001 completion requires additive schema, producer-to-Worker-to-API-to-list UI data flow, legacy compatibility, search/filter, contract tests, PR CI, merge and post-main gates. Until those facts exist it remains in progress.

--- a/projects/rustdesk-fabushi-fusion/evidence/RDF-001/README.md
+++ b/projects/rustdesk-fabushi-fusion/evidence/RDF-001/README.md
@@ -1,0 +1,6 @@
+# RDF-001 evidence
+
+- Source baseline: Fabushi main `d69bf418ed19df6ec7f1d0581646283a49461ba7`
+- Upstream pins: rustdesk `f28ac38...`, hbb_common `b2b1ac...`, rustdesk-server `a7736be...`
+- Branch: `codex/rustdesk-fusion-device-presence`
+- Commit/PR/CI/post-main delivery: pending

--- a/projects/rustdesk-fabushi-fusion/evidence/README.md
+++ b/projects/rustdesk-fabushi-fusion/evidence/README.md
@@ -1,0 +1,3 @@
+# Evidence
+
+Task evidence indexes live under `evidence/<task-id>/`. Do not store secrets or large binaries. RDF-001 evidence is pending PR/CI/merge/post-main delivery.

--- a/projects/rustdesk-fabushi-fusion/management/00-路线图.md
+++ b/projects/rustdesk-fabushi-fusion/management/00-路线图.md
@@ -1,0 +1,10 @@
+# 00 路线图
+
+- M0 — upstream/license/current-state audit: evidence captured; legal distribution decision remains open.
+- M1 — unified device identity and presence: RDF-001 active.
+- M2 — provider/session abstraction and secure direct/relay negotiation.
+- M3 — remote desktop/display/input.
+- M4 — clipboard/file/audio and multi-session management.
+- M5 — permissions, audit, recovery, cross-platform E2E and release.
+
+Each milestone exits only with objective Actions and delivery evidence.

--- a/projects/rustdesk-fabushi-fusion/management/01-WBS原子任务.md
+++ b/projects/rustdesk-fabushi-fusion/management/01-WBS原子任务.md
@@ -1,0 +1,10 @@
+# 01 WBS 原子任务
+
+| Task | Action | Dependency | Acceptance | Status | Next |
+|---|---|---|---|---|---|
+| RDF-001 | Unified account device presence slice | current account/remote-computer path | producer→D1/API→UI + CI | in-progress | implement schema/contracts/UI |
+| RDF-002 | Provider/session abstraction | RDF-001 | provider-neutral session contract | planned | ADR/design |
+| RDF-003 | Direct/relay negotiation | RDF-002 | direct-first + authenticated relay fallback | planned | threat model |
+| RDF-004 | Desktop/display/input provider parity | RDF-003 | cross-platform conformance | planned | capability inventory |
+| RDF-005 | Clipboard/file/audio/session parity | RDF-003 | bounded/resumable/permissioned E2E | planned | protocol matrix |
+| RDF-006 | Policy/audit/recovery/release | RDF-001..005 | security + packaged E2E + Release | planned | evidence plan |

--- a/projects/rustdesk-fabushi-fusion/management/02-里程碑.md
+++ b/projects/rustdesk-fabushi-fusion/management/02-里程碑.md
@@ -1,0 +1,9 @@
+# 02 里程碑
+
+| ID | Target | Required tasks | Status | Evidence |
+|---|---|---|---|---|
+| RDF-M0 | auditable upstream/license baseline | RDF-001 research gate | in-progress | source/README.md |
+| RDF-M1 | unified device inventory | RDF-001 | in-progress | pending PR/CI |
+| RDF-M2 | secure provider sessions | RDF-002..003 | planned | pending |
+| RDF-M3 | core capability parity | RDF-004..005 | planned | pending |
+| RDF-M4 | release closure | RDF-006 | planned | pending |

--- a/projects/rustdesk-fabushi-fusion/management/03-验收追踪矩阵.md
+++ b/projects/rustdesk-fabushi-fusion/management/03-验收追踪矩阵.md
@@ -1,0 +1,9 @@
+# 03 验收追踪矩阵
+
+| Requirement | Task | Verification | Evidence | Status |
+|---|---|---|---|---|
+| RDF-FR-001/002/003 | RDF-001 | Worker/Host/frontend contracts | pending | in-progress |
+| RDF-FR-004 | RDF-002/003 | network/security/E2E | pending | planned |
+| RDF-FR-005 | RDF-004/005 | provider conformance/E2E | pending | planned |
+| RDF-FR-006 | RDF-006 | policy/audit/recovery/security | pending | planned |
+| RDF-NFR-001/002/003 | all | isolation/status/license gates | source + pending CI/legal | in-progress |

--- a/projects/rustdesk-fabushi-fusion/management/04-风险登记.md
+++ b/projects/rustdesk-fabushi-fusion/management/04-风险登记.md
@@ -1,0 +1,9 @@
+# 04 风险登记
+
+| ID | Risk | Severity | Owner | Mitigation | Status |
+|---|---|---|---|---|---|
+| RDF-R001 | AGPL obligations contaminate proprietary packaging | critical | legal/engineering | isolated provider; no copy/link in RDF-001; review gate | open |
+| RDF-R002 | account login mistaken for control consent | critical | security | pairing + explicit control switch + short sessions | mitigating |
+| RDF-R003 | duplicate identity/protocol authority | high | architecture | Fabushi IDs/account remain canonical | mitigating |
+| RDF-R004 | stale/forged capability inventory | high | engineering | possession-bound updates, validation, leases | open |
+| RDF-R005 | remote attack surface/relay abuse | critical | security | no public native listener before threat review | open |

--- a/projects/rustdesk-fabushi-fusion/management/05-状态报告.md
+++ b/projects/rustdesk-fabushi-fusion/management/05-状态报告.md
@@ -1,0 +1,9 @@
+# 05 状态报告
+
+## 2026-09-01 — RDF-001 intake
+
+- Verified Fabushi `main` at `d69bf418ed19df6ec7f1d0581646283a49461ba7`.
+- Found existing account-scoped D1 registration/heartbeat/list, device/client possession credentials, expiring WebRTC sessions, direct/TURN signaling and shared Web/mobile surfaces.
+- Pinned RustDesk client `f28ac38...`, hbb_common `b2b1ac...`, server `a7736be...`; client/server are AGPL-3.0.
+- Chosen path: extend existing Fabushi inventory and add provider boundary; do not vendor RustDesk.
+- Status: in-progress. Branch `codex/rustdesk-fusion-device-presence`; PR/CI pending.

--- a/projects/rustdesk-fabushi-fusion/management/06-依赖与阻塞.md
+++ b/projects/rustdesk-fabushi-fusion/management/06-依赖与阻塞.md
@@ -1,0 +1,8 @@
+# 06 依赖与阻塞
+
+| ID | Dependency/blocker | Owner | Blocking | Fallback | State |
+|---|---|---|---|---|---|
+| RDF-D001 | Existing Mahayana account/remote Worker | Fabushi | RDF-001 | none | available |
+| RDF-D002 | AGPL/commercial-license decision | legal/product | native RustDesk distribution/deploy | clean-room provider contract | open |
+| RDF-D003 | TURN/relay production capacity | operations | later scale/reliability | existing direct/TURN path | open |
+| RDF-D004 | Cross-platform permissions/signing | platform maintainers | native capture/input | phased per platform | open |

--- a/projects/rustdesk-fabushi-fusion/management/07-变更日志.md
+++ b/projects/rustdesk-fabushi-fusion/management/07-变更日志.md
@@ -1,0 +1,8 @@
+# 07 变更日志
+
+## 2026-09-01
+
+- Allocated FAB-P0009 / RDF.
+- Persisted user RustDesk fusion scope and pinned upstream baselines.
+- Selected a vendor-neutral provider boundary with Fabushi identity/authorization authority.
+- Opened RDF-001 for the unified device inventory vertical slice.

--- a/projects/rustdesk-fabushi-fusion/management/08-问题与行动项.md
+++ b/projects/rustdesk-fabushi-fusion/management/08-问题与行动项.md
@@ -1,0 +1,7 @@
+# 08 问题与行动项
+
+| ID | Action/question | Owner | Resolution/decision deadline | Status |
+|---|---|---|---|---|
+| RDF-A001 | Approve AGPL sidecar/service or obtain commercial license | legal/product | before native RustDesk code/binary distribution | open |
+| RDF-A002 | Choose self-hosted relay capacity/SLO | operations | before RDF-003 production rollout | open |
+| RDF-A003 | Define per-platform unattended-control consent | security/product | before RDF-004 | open |

--- a/projects/rustdesk-fabushi-fusion/management/tasks/RDF-001-device-presence-vertical-slice.md
+++ b/projects/rustdesk-fabushi-fusion/management/tasks/RDF-001-device-presence-vertical-slice.md
@@ -1,0 +1,49 @@
+# RDF-001 — Unified device presence vertical slice
+
+- Project ID: FAB-P0009
+- Project Key: RDF
+- Status: in-progress
+- Started/updated: 2026-09-01
+- Completed: N/A
+- Branch: `codex/rustdesk-fusion-device-presence`
+- Commit/PR: pending
+
+## Objective
+
+Extend the existing same-account registration/heartbeat path into a provider-neutral inventory that carries platform, version, normalized remote capabilities and active-session state through the Worker API into the Fabushi device list, with search/filter UI and legacy compatibility.
+
+## Scope
+
+In: D1 additive migration; Worker register/list contracts; Host protocol and FeatureHost mapping; Web API normalization; device list search/filter/details; narrow contract tests and project evidence.
+
+Out: RustDesk wire compatibility, hbbs/hbbr deployment, native RustDesk binaries, new media/file/audio engines.
+
+## Dependencies
+
+Existing account token, device secret, D1 remote tables, FeatureHost transport and remote-computer page.
+
+## Acceptance
+
+1. Same-account device updates cannot cross ownership or bypass device-secret possession.
+2. Registration stores validated provider/platform/version/capabilities.
+3. Heartbeat updates liveness without overwriting identity/capability fields.
+4. List returns online/offline/last seen plus metadata and active session count.
+5. Existing clients with no new fields remain valid with safe defaults.
+6. Web/mobile list displays and filters normalized inventory.
+7. Project governance and narrow Actions checks pass.
+
+## Open-source survey
+
+RustDesk client/server and hbb_common revisions are pinned in `source/README.md`. Reuse: topology, capability taxonomy and behavioral test ideas. Adapt: normalized provider contract. Reject for this slice: copied/linked AGPL implementation or second identity authority.
+
+## Verification/evidence
+
+Pending GitHub Actions and PR. Post-main package/E2E/Release remain required because this affects the product.
+
+## Risks/blockers
+
+AGPL blocks direct embedding until reviewed; native interop is not part of this slice.
+
+## Next action
+
+Implement migration, producer/API/UI contracts and tests; open PR; run the narrowest Actions workflows.

--- a/projects/rustdesk-fabushi-fusion/runbooks/README.md
+++ b/projects/rustdesk-fabushi-fusion/runbooks/README.md
@@ -1,0 +1,3 @@
+# Runbooks
+
+Operational runbooks will cover device revoke, compromised credential rotation, provider disable, relay failover and session incident response before the corresponding runtime milestones ship. RDF-001 uses additive schema and existing rollback procedures; no RustDesk service is deployed in this slice.

--- a/projects/rustdesk-fabushi-fusion/source/README.md
+++ b/projects/rustdesk-fabushi-fusion/source/README.md
@@ -1,0 +1,15 @@
+# Source intake
+
+## User requirement — 2026-09-01
+
+Fuse RustDesk capabilities into Fabushi so one account registers, discovers and monitors multiple devices, then progressively supports secure direct/relay remote desktop, input, clipboard, file transfer, display, audio, sessions, permission policy, audit, recovery and desktop/mobile/Web surfaces. Do not claim unimplemented capability; use GitHub Actions rather than local heavy builds.
+
+## Pinned upstream evidence
+
+| Repository | Revision | Observed package version | License |
+|---|---|---|---|
+| rustdesk/rustdesk | f28ac38ccfa662fd06639a062e0d06249860b142 | 1.5.0 | AGPL-3.0 |
+| rustdesk/hbb_common | b2b1ac453d1d694046f63be20d792d608dac1c93 | submodule protocol baseline | AGPL-family upstream component; verify notices per distribution |
+| rustdesk/rustdesk-server | a7736be5e40f85bfc141120dce587e836e5d4b80 | 1.1.17 | AGPL-3.0 |
+
+Protocol evidence includes `RegisterPeer`, `RegisterPk`, direct punch-hole and relay messages, control-permission bits, video/audio frames, mouse/key events, clipboard, file actions and display/session messages. This project records behavior/mappings without copying protobuf or implementation source into Fabushi.

--- a/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-feature-host/src/implementation.rs
@@ -2597,7 +2597,13 @@ impl FeatureHostController {
         let remote_enabled = self.state()?.settings.remote_control_enabled;
         let (method, action, payload, local_transition) = match command {
             FeatureCommand::RemoteComputerRegister {
-                device_id, label, ..
+                device_id,
+                label,
+                provider,
+                platform,
+                app_version,
+                capabilities,
+                ..
             } => {
                 // Registration is device presence, not authorization to control.
                 // Keeping it available while remote control is disabled lets the
@@ -2605,10 +2611,21 @@ impl FeatureHostController {
                 // polling, activation, signaling, screenshots, and input remain
                 // gated below by `remote_control_enabled`.
                 let device_secret = self.remote_device_secret(&device_id, true)?;
+                let provider = provider.unwrap_or_else(|| "fabushi-webrtc".to_string());
+                let platform = platform.unwrap_or_else(|| "unknown".to_string());
+                let app_version = app_version.unwrap_or_else(|| "unknown".to_string());
                 (
                     "mahayana.remote.computer.register",
                     "registered",
-                    json!({"deviceId": device_id, "label": label, "deviceSecret": device_secret}),
+                    json!({
+                        "deviceId": device_id,
+                        "label": label,
+                        "deviceSecret": device_secret,
+                        "provider": provider,
+                        "platform": platform,
+                        "appVersion": app_version,
+                        "capabilities": capabilities,
+                    }),
                     None,
                 )
             }

--- a/third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-host-protocol/src/lib.rs
@@ -1479,6 +1479,18 @@ pub enum FeatureCommand {
         #[serde(rename = "deviceId")]
         device_id: String,
         label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        platform: Option<String>,
+        #[serde(
+            rename = "appVersion",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        app_version: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        capabilities: Vec<String>,
     },
     #[serde(rename = "remoteComputer.heartbeat")]
     RemoteComputerHeartbeat {

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0015_remote_computer_inventory.sql
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0015_remote_computer_inventory.sql
@@ -1,0 +1,21 @@
+PRAGMA foreign_keys = ON;
+
+-- Additive inventory metadata for account-scoped device discovery. Existing
+-- devices remain compatible and are identified as the current Fabushi WebRTC
+-- provider until they refresh their registration.
+ALTER TABLE remote_computers
+    ADD COLUMN provider TEXT NOT NULL DEFAULT 'fabushi-webrtc'
+    CHECK (provider IN ('fabushi-webrtc', 'rustdesk-sidecar'));
+
+ALTER TABLE remote_computers
+    ADD COLUMN platform TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (platform IN ('windows', 'macos', 'linux', 'android', 'ios', 'web', 'unknown'));
+
+ALTER TABLE remote_computers
+    ADD COLUMN app_version TEXT NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE remote_computers
+    ADD COLUMN capabilities_json TEXT NOT NULL DEFAULT '[]';
+
+CREATE INDEX IF NOT EXISTS remote_computers_inventory_idx
+    ON remote_computers(user_id, revoked_at, provider, platform, last_seen_at);

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs
@@ -12,6 +12,8 @@ pub const LISTENER_RELAY_SCHEMA_V5: &str = include_str!("../migrations/0005_list
 pub const REMOTE_COMPUTER_SCHEMA_V6: &str = include_str!("../migrations/0006_remote_computer.sql");
 pub const REMOTE_COMPUTER_CLIENT_TOKEN_SCHEMA_V14: &str =
     include_str!("../migrations/0014_remote_computer_client_tokens.sql");
+pub const REMOTE_COMPUTER_INVENTORY_SCHEMA_V15: &str =
+    include_str!("../migrations/0015_remote_computer_inventory.sql");
 pub const WORKSPACE_MESSAGING_SCHEMA_V7: &str =
     include_str!("../migrations/0007_workspace_messaging.sql");
 pub const FABUSHI_PAY_SCHEMA_V7: &str = include_str!("../migrations/0007_fabushi_pay.sql");

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
@@ -63,15 +63,9 @@ fn remote_computer_inventory_migration_is_additive_and_secret_free() {
             "missing {required}"
         );
     }
-    assert!(
-        !REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("device_secret TEXT")
-    );
-    assert!(
-        !REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("screenshot_data")
-    );
-    assert!(
-        !REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("input_payload")
-    );
+    assert!(!REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("device_secret TEXT"));
+    assert!(!REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("screenshot_data"));
+    assert!(!REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("input_payload"));
 }
 
 #[test]

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/schema_tests.rs
@@ -49,6 +49,32 @@ fn remote_computer_migration_keeps_control_plane_separate_from_desktop_data() {
 }
 
 #[test]
+fn remote_computer_inventory_migration_is_additive_and_secret_free() {
+    for required in [
+        "provider TEXT NOT NULL DEFAULT 'fabushi-webrtc'",
+        "platform TEXT NOT NULL DEFAULT 'unknown'",
+        "app_version TEXT NOT NULL DEFAULT 'unknown'",
+        "capabilities_json TEXT NOT NULL DEFAULT '[]'",
+        "rustdesk-sidecar",
+        "remote_computers_inventory_idx",
+    ] {
+        assert!(
+            REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains(required),
+            "missing {required}"
+        );
+    }
+    assert!(
+        !REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("device_secret TEXT")
+    );
+    assert!(
+        !REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("screenshot_data")
+    );
+    assert!(
+        !REMOTE_COMPUTER_INVENTORY_SCHEMA_V15.contains("input_payload")
+    );
+}
+
+#[test]
 fn ci_runner_auth_is_exact_workflow_and_linked_account_scoped() {
     for required in [
         "token.actions.githubusercontent.com",

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/remote_computer.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/remote_computer.rs
@@ -435,7 +435,11 @@ pub(super) async fn remote_computer_register(
         return error_response(400, "invalid_platform", "Computer platform is invalid.");
     };
     let Some(app_version) = remote_app_version(&input.app_version) else {
-        return error_response(400, "invalid_app_version", "Computer appVersion is invalid.");
+        return error_response(
+            400,
+            "invalid_app_version",
+            "Computer appVersion is invalid.",
+        );
     };
     let Some(capabilities) = remote_capabilities(&input.capabilities) else {
         return error_response(

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/remote_computer.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/worker_api/remote_computer.rs
@@ -16,6 +16,14 @@ struct RemoteComputerRegisterRequest {
     device_id: String,
     label: String,
     device_secret: String,
+    #[serde(default = "default_remote_provider")]
+    provider: String,
+    #[serde(default = "default_remote_platform")]
+    platform: String,
+    #[serde(default = "default_remote_app_version")]
+    app_version: String,
+    #[serde(default)]
+    capabilities: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -91,6 +99,11 @@ struct RemoteComputerSessionCloseRequest {
 struct RemoteComputerRow {
     device_id: String,
     label: String,
+    provider: String,
+    platform: String,
+    app_version: String,
+    capabilities_json: String,
+    active_session_count: i64,
     last_seen_at: i64,
     created_at: i64,
 }
@@ -204,6 +217,69 @@ fn remote_label(value: &str) -> Option<String> {
     (!value.is_empty() && value.chars().count() <= 80).then(|| value.to_string())
 }
 
+fn default_remote_provider() -> String {
+    "fabushi-webrtc".to_string()
+}
+
+fn default_remote_platform() -> String {
+    "unknown".to_string()
+}
+
+fn default_remote_app_version() -> String {
+    "unknown".to_string()
+}
+
+fn remote_provider(value: &str) -> Option<String> {
+    let value = value.trim();
+    matches!(value, "fabushi-webrtc" | "rustdesk-sidecar").then(|| value.to_string())
+}
+
+fn remote_platform(value: &str) -> Option<String> {
+    let value = value.trim();
+    matches!(
+        value,
+        "windows" | "macos" | "linux" | "android" | "ios" | "web" | "unknown"
+    )
+    .then(|| value.to_string())
+}
+
+fn remote_app_version(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 64
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || ".+_-".contains(character)))
+    .then(|| value.to_string())
+}
+
+fn remote_capabilities(values: &[String]) -> Option<Vec<String>> {
+    if values.len() > 32 {
+        return None;
+    }
+    let mut normalized = Vec::with_capacity(values.len());
+    for value in values {
+        let value = value.trim();
+        if !matches!(
+            value,
+            "remote-desktop"
+                | "input"
+                | "clipboard"
+                | "file-transfer"
+                | "display"
+                | "audio"
+                | "session-management"
+        ) {
+            return None;
+        }
+        if !normalized.iter().any(|existing| existing == value) {
+            normalized.push(value.to_string());
+        }
+    }
+    normalized.sort();
+    Some(normalized)
+}
+
 fn remote_role(value: &str) -> bool {
     matches!(value, "desktop" | "mobile")
 }
@@ -273,11 +349,19 @@ pub(super) async fn remote_computer_list(
     let database = context.env.d1(DATABASE_BINDING)?;
     let rows = worker::query!(
         &database,
-        "SELECT device_id, label, last_seen_at, created_at
-         FROM remote_computers
-         WHERE user_id = ?1 AND revoked_at IS NULL
-         ORDER BY last_seen_at DESC LIMIT 64",
-        &account.user_id
+        "SELECT computer.device_id, computer.label, computer.provider,
+                computer.platform, computer.app_version, computer.capabilities_json,
+                (SELECT COUNT(*) FROM remote_computer_sessions session
+                 WHERE session.user_id = computer.user_id
+                   AND session.device_id = computer.device_id
+                   AND session.state = 'active'
+                   AND session.expires_at > ?2) AS active_session_count,
+                computer.last_seen_at, computer.created_at
+         FROM remote_computers computer
+         WHERE computer.user_id = ?1 AND computer.revoked_at IS NULL
+         ORDER BY computer.last_seen_at DESC LIMIT 64",
+        &account.user_id,
+        now_seconds()
     )?
     .all()
     .await?
@@ -286,9 +370,18 @@ pub(super) async fn remote_computer_list(
     let computers = rows
         .into_iter()
         .map(|row| {
+            let capabilities = serde_json::from_str::<Vec<String>>(&row.capabilities_json)
+                .ok()
+                .and_then(|values| remote_capabilities(&values))
+                .unwrap_or_default();
             json!({
                 "deviceId": row.device_id,
                 "label": row.label,
+                "provider": row.provider,
+                "platform": row.platform,
+                "appVersion": row.app_version,
+                "capabilities": capabilities,
+                "activeSessionCount": row.active_session_count,
                 "lastSeenAt": row.last_seen_at,
                 "createdAt": row.created_at,
                 "online": now.saturating_sub(row.last_seen_at) <= 45,
@@ -335,6 +428,24 @@ pub(super) async fn remote_computer_register(
             "Computer device secret is invalid.",
         );
     }
+    let Some(provider) = remote_provider(&input.provider) else {
+        return error_response(400, "invalid_provider", "Computer provider is invalid.");
+    };
+    let Some(platform) = remote_platform(&input.platform) else {
+        return error_response(400, "invalid_platform", "Computer platform is invalid.");
+    };
+    let Some(app_version) = remote_app_version(&input.app_version) else {
+        return error_response(400, "invalid_app_version", "Computer appVersion is invalid.");
+    };
+    let Some(capabilities) = remote_capabilities(&input.capabilities) else {
+        return error_response(
+            400,
+            "invalid_capabilities",
+            "Computer capabilities are invalid.",
+        );
+    };
+    let capabilities_json = serde_json::to_string(&capabilities)
+        .map_err(|error| worker::Error::RustError(error.to_string()))?;
     let device_secret_hash = remote_secret_hash(&input.device_secret);
     let code = new_remote_pairing_code();
     let code_hash = remote_secret_hash(&code);
@@ -344,16 +455,21 @@ pub(super) async fn remote_computer_register(
     let result = worker::query!(
         &database,
         "INSERT INTO remote_computers
-         (device_id, user_id, label, device_secret_hash, pairing_code_hash, pairing_expires_at, created_at, last_seen_at, revoked_at)
-         SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, NULL
+         (device_id, user_id, label, device_secret_hash, pairing_code_hash, pairing_expires_at,
+          created_at, last_seen_at, revoked_at, provider, platform, app_version, capabilities_json)
+         SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, NULL, ?8, ?9, ?10, ?11
          WHERE (SELECT COUNT(*) FROM remote_computers existing
                 WHERE existing.user_id = ?2 AND existing.revoked_at IS NULL
-                  AND existing.device_id <> ?1) < ?8
+                  AND existing.device_id <> ?1) < ?12
          ON CONFLICT(device_id) DO UPDATE SET
            label = excluded.label,
            pairing_code_hash = excluded.pairing_code_hash,
            pairing_expires_at = excluded.pairing_expires_at,
            last_seen_at = excluded.last_seen_at,
+           provider = excluded.provider,
+           platform = excluded.platform,
+           app_version = excluded.app_version,
+           capabilities_json = excluded.capabilities_json,
            revoked_at = NULL
          WHERE remote_computers.user_id = excluded.user_id
            AND remote_computers.device_secret_hash = excluded.device_secret_hash",
@@ -364,6 +480,10 @@ pub(super) async fn remote_computer_register(
         &code_hash,
         expires_at,
         now,
+        &provider,
+        &platform,
+        &app_version,
+        &capabilities_json,
         REMOTE_COMPUTER_MAX_PER_ACCOUNT
     )?
     .run()
@@ -396,6 +516,10 @@ pub(super) async fn remote_computer_register(
     Ok(Response::from_json(&json!({
         "deviceId": input.device_id,
         "label": label,
+        "provider": provider,
+        "platform": platform,
+        "appVersion": app_version,
+        "capabilities": capabilities,
         "pairingCode": code,
         "pairingExpiresAt": expires_at,
     }))?


### PR DESCRIPTION
## Scope

Implements RDF-001, the first RustDesk-to-Fabushi integration slice, on top of the existing account-authenticated Mahayana remote-computer path:

- account-scoped durable device registration and heartbeat presence
- additive device inventory metadata: provider, platform, app version, normalized capabilities
- current active-session count from the server-side account-scoped session table
- Web/mobile shared device list status, detail, search, status filtering, and capability filtering
- legacy registration defaults and a future `rustdesk-sidecar` compatibility provider
- schema, source-contract, and workflow coverage

## Honest capability boundary

The current `fabushi-webrtc` provider reports only the capabilities already present in Fabushi: remote desktop frames, input, display, and session management. Clipboard sync, file transfer, audio, and RustDesk wire compatibility are not claimed as implemented.

RustDesk is AGPL-3.0. This change copies or links no RustDesk source. The project ADR records an isolated sidecar/service boundary and the legal/distribution gate required before shipping upstream binaries or derived code.

## Project record

- Project: `FAB-P0009` / `RDF`
- Task: `RDF-001`
- Upstream pins:
  - `rustdesk/rustdesk@f28ac38ccfa662fd06639a062e0d06249860b142`
  - `rustdesk/hbb_common@b2b1ac453d1d694046f63be20d792d608dac1c93`
  - `rustdesk/rustdesk-server@a7736be5e40f85bfc141120dce587e836e5d4b80`

## Validation

No local builds or heavyweight tests were run, per repository policy. Final head `c3ddf70fcf3c0c92ffbee93ba3a35f4a276d74d1` passed:

- Computer control security gate `33490917155`: Worker schema/Wasm, source contracts, Node and Rust matrices, managed Linux desktop
- Mahayana fast checks `33490917190`
- Electron desktop quality gate `33490917176`
- CI `33490917196`
- Native mobile quality gate `33490917200`
- Project portfolio governance `33490917197`
- Host fast E2E `33490917236`

Plugin Marketplace Contract `33490917387` is an unrelated, non-required full marketplace deployment run; its contract/security jobs passed and its package E2E remained in progress at merge time.

## Not in this PR

- RustDesk protocol interoperability
- RustDesk hbbs/hbbr deployment
- clipboard, file transfer, audio
- final production rollout or release claim
