### PR TITLE
feat(remote): bind control sessions to registered provider

### DIFF
--- a/chatgpt-vps-control/tests/rustdesk-provider-session-contract.test.js
+++ b/chatgpt-vps-control/tests/rustdesk-provider-session-contract.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function source(relativePath) {
+  return readFileSync(resolve(repositoryRoot, relativePath), "utf8");
+}
+
+test("remote sessions persist the registered device provider", () => {
+  const migration = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0016_remote_computer_session_provider.sql");
+  const inventory = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0015_remote_computer_inventory.sql");
+
+  assert.match(migration, /ADD COLUMN provider TEXT NOT NULL DEFAULT 'fabushi-webrtc'/);
+  assert.match(migration, /CHECK \(provider IN \('fabushi-webrtc', 'rustdesk-sidecar'\)\)/);
+  assert.match(migration, /FROM remote_computers AS computer/);
+  assert.match(migration, /computer\.device_id = NEW\.device_id/);
+  assert.match(migration, /computer\.user_id = NEW\.user_id/);
+  assert.match(migration, /remote session provider is immutable/);
+  assert.match(migration, /remote_computer_sessions_provider_idx/);
+  assert.match(inventory, /rustdesk-sidecar/);
+});
+
+test("provider binding remains control-plane metadata only", () => {
+  const migration = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0016_remote_computer_session_provider.sql");
+  const workerLib = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs");
+
+  assert.match(workerLib, /REMOTE_COMPUTER_SESSION_PROVIDER_SCHEMA_V16/);
+  assert.match(workerLib, /0016_remote_computer_session_provider\.sql/);
+  assert.doesNotMatch(migration, /device_secret TEXT|client_token TEXT|mobile_token TEXT|screenshot_data|input_payload|clipboard_payload|file_payload|audio_payload/);
+});
+
+test("RDF-002 does not claim the RustDesk transport exists yet", () => {
+  const readme = source("projects/rustdesk-fabushi-fusion/README.md");
+  const wbs = source("projects/rustdesk-fabushi-fusion/management/01-WBS原子任务.md");
+
+  assert.match(readme, /Current stage: M2 provider\/session abstraction/);
+  assert.match(readme, /RustDesk sidecar transport is not implemented yet/);
+  assert.match(wbs, /RDF-002 \| Provider\/session abstraction/);
+  assert.match(wbs, /in-progress/);
+});

--- a/chatgpt-vps-control/tests/rustdesk-provider-session-contract.test.js
+++ b/chatgpt-vps-control/tests/rustdesk-provider-session-contract.test.js
@@ -14,11 +14,13 @@ test("remote sessions persist the registered device provider", () => {
   const migration = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0016_remote_computer_session_provider.sql");
   const inventory = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0015_remote_computer_inventory.sql");
 
-  assert.match(migration, /ADD COLUMN provider TEXT NOT NULL DEFAULT 'fabushi-webrtc'/);
+  assert.match(migration, /ADD COLUMN provider TEXT/);
   assert.match(migration, /CHECK \(provider IN \('fabushi-webrtc', 'rustdesk-sidecar'\)\)/);
+  assert.match(migration, /WHEN NEW\.provider IS NULL/);
   assert.match(migration, /FROM remote_computers AS computer/);
   assert.match(migration, /computer\.device_id = NEW\.device_id/);
   assert.match(migration, /computer\.user_id = NEW\.user_id/);
+  assert.match(migration, /OLD\.provider IS NOT NULL/);
   assert.match(migration, /remote session provider is immutable/);
   assert.match(migration, /remote_computer_sessions_provider_idx/);
   assert.match(inventory, /rustdesk-sidecar/);

--- a/projects/rustdesk-fabushi-fusion/README.md
+++ b/projects/rustdesk-fabushi-fusion/README.md
@@ -3,8 +3,8 @@
 - Project ID: `FAB-P0009`
 - Project Key: `RDF`
 - Status: active / in progress
-- Current stage: M1 device identity and presence
-- Next gate: RDF-001 contract CI on the task PR
+- Current stage: M2 provider/session abstraction
+- Next gate: RDF-002 contract CI on the task PR
 
 ## Objective
 
@@ -12,9 +12,13 @@ Unify all devices under one Fabushi account and progressively deliver secure rem
 
 ## Current verified baseline
 
-Fabushi already has account-scoped computer registration, device-secret possession proof, heartbeat, D1 presence, paired clients, expiring WebRTC sessions, direct/TURN signaling, remote screen/input and desktop/mobile/Web surfaces. The first slice extends that existing path with a vendor-neutral inventory contract for platform, version, provider, capabilities and active-session state.
+RDF-001 is merged and CI-verified: Fabushi has account-scoped computer registration, device-secret possession proof, heartbeat, D1 presence, paired clients, expiring WebRTC sessions, direct/TURN signaling, remote screen/input and desktop/mobile/Web surfaces. The device inventory exposes provider, platform, app version, normalized capabilities and active-session state.
 
-RustDesk client and OSS server are AGPL-3.0. No RustDesk source is copied or linked into Fabushi in RDF-001. Later native provider work requires a separately distributable AGPL component or a separately licensed implementation and legal review.
+RDF-002 is now in progress. The current slice makes the selected transport provider durable session metadata: D1 binds each newly-created remote session to the provider registered by that account/device and makes that provider immutable for the life of the session. This establishes a provider-neutral server-side compatibility boundary without creating a second identity or authorization system.
+
+RustDesk sidecar transport is not implemented yet. No RustDesk wire-protocol, hbbs/hbbr deployment, clipboard, file-transfer, or audio completion is claimed by this slice.
+
+RustDesk client and OSS server are AGPL-3.0. No RustDesk source is copied or linked into Fabushi in RDF-001/RDF-002. Later native provider work requires a separately distributable AGPL component or a separately licensed implementation and legal review.
 
 ## Acceptance
 

--- a/projects/rustdesk-fabushi-fusion/management/01-WBS原子任务.md
+++ b/projects/rustdesk-fabushi-fusion/management/01-WBS原子任务.md
@@ -2,8 +2,8 @@
 
 | Task | Action | Dependency | Acceptance | Status | Next |
 |---|---|---|---|---|---|
-| RDF-001 | Unified account device presence slice | current account/remote-computer path | producer→D1/API→UI + CI | in-progress | implement schema/contracts/UI |
-| RDF-002 | Provider/session abstraction | RDF-001 | provider-neutral session contract | planned | ADR/design |
+| RDF-001 | Unified account device presence slice | current account/remote-computer path | producer→D1/API→UI + CI | complete | merged PR #2272 + CI evidence |
+| RDF-002 | Provider/session abstraction | RDF-001 | provider-neutral session contract | in-progress | persist provider on sessions; expose transport contract next |
 | RDF-003 | Direct/relay negotiation | RDF-002 | direct-first + authenticated relay fallback | planned | threat model |
 | RDF-004 | Desktop/display/input provider parity | RDF-003 | cross-platform conformance | planned | capability inventory |
 | RDF-005 | Clipboard/file/audio/session parity | RDF-003 | bounded/resumable/permissioned E2E | planned | protocol matrix |

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0016_remote_computer_session_provider.sql
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0016_remote_computer_session_provider.sql
@@ -2,11 +2,10 @@
 -- This remains additive: existing fabushi-webrtc sessions keep working, while a future
 -- rustdesk-sidecar transport can share the same Fabushi identity/authorization/session rows.
 ALTER TABLE remote_computer_sessions
-    ADD COLUMN provider TEXT NOT NULL DEFAULT 'fabushi-webrtc'
+    ADD COLUMN provider TEXT
     CHECK (provider IN ('fabushi-webrtc', 'rustdesk-sidecar'));
 
--- Backfill from the authoritative account-scoped device inventory instead of trusting
--- the historical default.
+-- Backfill from the authoritative account-scoped device inventory.
 UPDATE remote_computer_sessions
 SET provider = COALESCE(
     (SELECT computer.provider
@@ -14,14 +13,16 @@ SET provider = COALESCE(
      WHERE computer.device_id = remote_computer_sessions.device_id
        AND computer.user_id = remote_computer_sessions.user_id),
     'fabushi-webrtc'
-);
+)
+WHERE provider IS NULL;
 
--- Existing Worker code does not yet pass a provider in INSERT. Bind it atomically after
--- insertion from the registered computer so the session never derives provider choice
--- from an untrusted mobile client.
+-- Existing Worker code does not yet pass a provider in INSERT. New rows begin with NULL
+-- and are bound during the same INSERT statement's trigger execution from the registered
+-- computer, so the controlling client never chooses the transport provider.
 CREATE TRIGGER IF NOT EXISTS remote_computer_session_provider_bind_after_insert
 AFTER INSERT ON remote_computer_sessions
 FOR EACH ROW
+WHEN NEW.provider IS NULL
 BEGIN
     UPDATE remote_computer_sessions
     SET provider = COALESCE(
@@ -34,12 +35,13 @@ BEGIN
     WHERE session_id = NEW.session_id;
 END;
 
--- A session's transport provider is immutable and must continue to match its registered
--- device. Provider changes require a new session, which preserves auditability.
+-- The one NULL -> bound-provider transition above is initialization. Any later provider
+-- mutation is rejected, preserving the provider chosen from the device registration for
+-- the lifetime of the session.
 CREATE TRIGGER IF NOT EXISTS remote_computer_session_provider_immutable
 BEFORE UPDATE OF provider ON remote_computer_sessions
 FOR EACH ROW
-WHEN NEW.provider <> OLD.provider
+WHEN OLD.provider IS NOT NULL AND NEW.provider IS NOT OLD.provider
 BEGIN
     SELECT RAISE(ABORT, 'remote session provider is immutable');
 END;

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0016_remote_computer_session_provider.sql
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0016_remote_computer_session_provider.sql
@@ -1,0 +1,48 @@
+-- RDF-002: bind every control session to the provider declared by the registered device.
+-- This remains additive: existing fabushi-webrtc sessions keep working, while a future
+-- rustdesk-sidecar transport can share the same Fabushi identity/authorization/session rows.
+ALTER TABLE remote_computer_sessions
+    ADD COLUMN provider TEXT NOT NULL DEFAULT 'fabushi-webrtc'
+    CHECK (provider IN ('fabushi-webrtc', 'rustdesk-sidecar'));
+
+-- Backfill from the authoritative account-scoped device inventory instead of trusting
+-- the historical default.
+UPDATE remote_computer_sessions
+SET provider = COALESCE(
+    (SELECT computer.provider
+     FROM remote_computers AS computer
+     WHERE computer.device_id = remote_computer_sessions.device_id
+       AND computer.user_id = remote_computer_sessions.user_id),
+    'fabushi-webrtc'
+);
+
+-- Existing Worker code does not yet pass a provider in INSERT. Bind it atomically after
+-- insertion from the registered computer so the session never derives provider choice
+-- from an untrusted mobile client.
+CREATE TRIGGER IF NOT EXISTS remote_computer_session_provider_bind_after_insert
+AFTER INSERT ON remote_computer_sessions
+FOR EACH ROW
+BEGIN
+    UPDATE remote_computer_sessions
+    SET provider = COALESCE(
+        (SELECT computer.provider
+         FROM remote_computers AS computer
+         WHERE computer.device_id = NEW.device_id
+           AND computer.user_id = NEW.user_id),
+        'fabushi-webrtc'
+    )
+    WHERE session_id = NEW.session_id;
+END;
+
+-- A session's transport provider is immutable and must continue to match its registered
+-- device. Provider changes require a new session, which preserves auditability.
+CREATE TRIGGER IF NOT EXISTS remote_computer_session_provider_immutable
+BEFORE UPDATE OF provider ON remote_computer_sessions
+FOR EACH ROW
+WHEN NEW.provider <> OLD.provider
+BEGIN
+    SELECT RAISE(ABORT, 'remote session provider is immutable');
+END;
+
+CREATE INDEX IF NOT EXISTS remote_computer_sessions_provider_idx
+    ON remote_computer_sessions(user_id, device_id, provider, state, expires_at);

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs
@@ -14,6 +14,8 @@ pub const REMOTE_COMPUTER_CLIENT_TOKEN_SCHEMA_V14: &str =
     include_str!("../migrations/0014_remote_computer_client_tokens.sql");
 pub const REMOTE_COMPUTER_INVENTORY_SCHEMA_V15: &str =
     include_str!("../migrations/0015_remote_computer_inventory.sql");
+pub const REMOTE_COMPUTER_SESSION_PROVIDER_SCHEMA_V16: &str =
+    include_str!("../migrations/0016_remote_computer_session_provider.sql");
 pub const WORKSPACE_MESSAGING_SCHEMA_V7: &str =
     include_str!("../migrations/0007_workspace_messaging.sql");
 pub const FABUSHI_PAY_SCHEMA_V7: &str = include_str!("../migrations/0007_fabushi_pay.sql");


### PR DESCRIPTION
## Scope

Continues FAB-P0009 / RDF after the merged RDF-001 device-presence slice.

This is the first RDF-002 provider/session abstraction increment:

- add D1 migration `0016_remote_computer_session_provider.sql`
- persist a provider on every remote-control session
- bind new sessions from the authoritative account-scoped registered computer, not from mobile input
- make a session's provider immutable for its lifetime
- index sessions by account/device/provider/state
- expose the migration to Rust schema/source tests
- add a dedicated RustDesk provider-session source contract test
- update project/WBS state without claiming unimplemented RustDesk transport capabilities

## Security / architecture boundary

Fabushi remains the identity, authorization, pairing, session and audit authority. This slice does not create a RustDesk account/session system and does not trust the controlling client to select a provider.

## Honest capability boundary

Implemented here: durable provider binding for control sessions and compatibility-layer contract groundwork.

Not implemented here: RustDesk wire-protocol interoperability, hbbs/hbbr deployment, RustDesk sidecar execution, clipboard sync, file transfer, audio, final direct/relay provider negotiation, or release completion.

## Verification

No capability is considered complete until GitHub Actions passes. The branch includes source-contract coverage for the new migration and project-state assertions.