### PR TITLE
feat(remote): persist provider transport negotiation contract

### DIFF
--- a/chatgpt-vps-control/tests/rustdesk-transport-contract.test.js
+++ b/chatgpt-vps-control/tests/rustdesk-transport-contract.test.js
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const source = (relativePath) => readFileSync(resolve(repositoryRoot, relativePath), "utf8");
+
+test("transport negotiation is durable and provider-neutral", () => {
+  const migration = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0017_remote_computer_transport_contract.sql");
+  assert.match(migration, /route_policy TEXT NOT NULL DEFAULT 'direct-first'/);
+  assert.match(migration, /selected_route TEXT/);
+  assert.match(migration, /selected_route IN \('direct', 'relay'\)/);
+  assert.match(migration, /relay_region TEXT/);
+  assert.match(migration, /remote_computer_sessions_transport_idx/);
+  assert.doesNotMatch(migration, /hbbs_password|hbbr_password|device_secret TEXT|client_token TEXT|mobile_token TEXT/);
+});
+
+test("relay-only policy cannot downgrade to direct", () => {
+  const migration = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0017_remote_computer_transport_contract.sql");
+  assert.match(migration, /remote_computer_session_route_policy_guard/);
+  assert.match(migration, /NEW\.selected_route = 'direct'/);
+  assert.match(migration, /OLD\.route_policy = 'relay-only'/);
+  assert.match(migration, /relay-only session cannot select direct route/);
+});
+
+test("closed sessions cannot be assigned a new route", () => {
+  const migration = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0017_remote_computer_transport_contract.sql");
+  const workerLib = source("third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs");
+  assert.match(migration, /remote_computer_session_route_requires_live_session/);
+  assert.match(migration, /OLD\.state = 'closed'/);
+  assert.match(workerLib, /REMOTE_COMPUTER_TRANSPORT_CONTRACT_SCHEMA_V17/);
+  assert.match(workerLib, /0017_remote_computer_transport_contract\.sql/);
+});

--- a/projects/rustdesk-fabushi-fusion/README.md
+++ b/projects/rustdesk-fabushi-fusion/README.md
@@ -3,8 +3,8 @@
 - Project ID: `FAB-P0009`
 - Project Key: `RDF`
 - Status: active / in progress
-- Current stage: M2 provider/session abstraction
-- Next gate: RDF-002 contract CI on the task PR
+- Current stage: M2 provider/session abstraction -> M3 transport contract
+- Next gate: transport-contract CI, then Worker API route negotiation
 
 ## Objective
 
@@ -14,7 +14,9 @@ Unify all devices under one Fabushi account and progressively deliver secure rem
 
 RDF-001 is merged and CI-verified: Fabushi has account-scoped computer registration, device-secret possession proof, heartbeat, D1 presence, paired clients, expiring WebRTC sessions, direct/TURN signaling, remote screen/input and desktop/mobile/Web surfaces. The device inventory exposes provider, platform, app version, normalized capabilities and active-session state.
 
-RDF-002 is now in progress. The current slice makes the selected transport provider durable session metadata: D1 binds each newly-created remote session to the provider registered by that account/device and makes that provider immutable for the life of the session. This establishes a provider-neutral server-side compatibility boundary without creating a second identity or authorization system.
+RDF-002 provider binding is CI-verified on PR #2275 and queued behind the protected merge queue. It makes the selected transport provider durable session metadata: D1 binds each newly-created remote session to the provider registered by that account/device and makes that provider immutable for the life of the session.
+
+The next additive transport-contract slice persists server-authoritative route policy (`direct-first` or `relay-only`), selected route (`direct` or `relay`), relay region and transport update time. Database guards prevent relay-only sessions from selecting direct transport and prevent closed sessions from receiving a new route. This is compatibility-layer groundwork for RDF-003; the Worker negotiation endpoint and RustDesk sidecar execution are not yet implemented.
 
 RustDesk sidecar transport is not implemented yet. No RustDesk wire-protocol, hbbs/hbbr deployment, clipboard, file-transfer, or audio completion is claimed by this slice.
 

--- a/projects/rustdesk-fabushi-fusion/management/01-WBS原子任务.md
+++ b/projects/rustdesk-fabushi-fusion/management/01-WBS原子任务.md
@@ -3,8 +3,8 @@
 | Task | Action | Dependency | Acceptance | Status | Next |
 |---|---|---|---|---|---|
 | RDF-001 | Unified account device presence slice | current account/remote-computer path | producer→D1/API→UI + CI | complete | merged PR #2272 + CI evidence |
-| RDF-002 | Provider/session abstraction | RDF-001 | provider-neutral session contract | in-progress | persist provider on sessions; expose transport contract next |
-| RDF-003 | Direct/relay negotiation | RDF-002 | direct-first + authenticated relay fallback | planned | threat model |
+| RDF-002 | Provider/session abstraction | RDF-001 | provider-neutral session contract | in-progress | provider binding CI-verified on #2275; merge queue + transport metadata contract |
+| RDF-003 | Direct/relay negotiation | RDF-002 | direct-first + authenticated relay fallback | in-progress | durable route policy/selection schema; Worker negotiation API next |
 | RDF-004 | Desktop/display/input provider parity | RDF-003 | cross-platform conformance | planned | capability inventory |
 | RDF-005 | Clipboard/file/audio/session parity | RDF-003 | bounded/resumable/permissioned E2E | planned | protocol matrix |
 | RDF-006 | Policy/audit/recovery/release | RDF-001..005 | security + packaged E2E + Release | planned | evidence plan |

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0017_remote_computer_transport_contract.sql
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/migrations/0017_remote_computer_transport_contract.sql
@@ -1,0 +1,40 @@
+-- RDF-002/RDF-003 boundary: durable provider-neutral transport negotiation metadata.
+-- Fabushi remains the account/session authority. A provider implementation may later
+-- realize these choices through WebRTC or an isolated RustDesk-compatible sidecar.
+ALTER TABLE remote_computer_sessions
+    ADD COLUMN route_policy TEXT NOT NULL DEFAULT 'direct-first'
+    CHECK (route_policy IN ('direct-first', 'relay-only'));
+
+ALTER TABLE remote_computer_sessions
+    ADD COLUMN selected_route TEXT
+    CHECK (selected_route IS NULL OR selected_route IN ('direct', 'relay'));
+
+ALTER TABLE remote_computer_sessions
+    ADD COLUMN relay_region TEXT;
+
+ALTER TABLE remote_computer_sessions
+    ADD COLUMN transport_updated_at INTEGER;
+
+-- A controlling client must not be able to rewrite the provider selected from the
+-- registered device. Route choice is intentionally separate from provider identity.
+CREATE TRIGGER IF NOT EXISTS remote_computer_session_route_requires_live_session
+BEFORE UPDATE OF selected_route ON remote_computer_sessions
+FOR EACH ROW
+WHEN NEW.selected_route IS NOT NULL
+ AND (OLD.state = 'closed' OR OLD.expires_at <= CAST(strftime('%s','now') AS INTEGER))
+BEGIN
+    SELECT RAISE(ABORT, 'cannot select transport route for closed session');
+END;
+
+-- Direct-first sessions may settle on direct or relay. Relay-only sessions cannot be
+-- rewritten to direct, which provides the persistence invariant needed by policy gates.
+CREATE TRIGGER IF NOT EXISTS remote_computer_session_route_policy_guard
+BEFORE UPDATE OF selected_route ON remote_computer_sessions
+FOR EACH ROW
+WHEN NEW.selected_route = 'direct' AND OLD.route_policy = 'relay-only'
+BEGIN
+    SELECT RAISE(ABORT, 'relay-only session cannot select direct route');
+END;
+
+CREATE INDEX IF NOT EXISTS remote_computer_sessions_transport_idx
+    ON remote_computer_sessions(user_id, device_id, provider, route_policy, selected_route, state, expires_at);

--- a/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-platform-worker/src/lib.rs
@@ -16,6 +16,8 @@ pub const REMOTE_COMPUTER_INVENTORY_SCHEMA_V15: &str =
     include_str!("../migrations/0015_remote_computer_inventory.sql");
 pub const REMOTE_COMPUTER_SESSION_PROVIDER_SCHEMA_V16: &str =
     include_str!("../migrations/0016_remote_computer_session_provider.sql");
+pub const REMOTE_COMPUTER_TRANSPORT_CONTRACT_SCHEMA_V17: &str =
+    include_str!("../migrations/0017_remote_computer_transport_contract.sql");
 pub const WORKSPACE_MESSAGING_SCHEMA_V7: &str =
     include_str!("../migrations/0007_workspace_messaging.sql");
 pub const FABUSHI_PAY_SCHEMA_V7: &str = include_str!("../migrations/0007_fabushi_pay.sql");


### PR DESCRIPTION
## Scope

Continues FAB-P0009 / RDF from the CI-verified provider/session binding slice.

This increment adds the durable server-side transport contract needed before wiring direct/relay negotiation:

- D1 migration `0017_remote_computer_transport_contract.sql`
- server-owned route policy (`direct-first` / `relay-only`)
- selected route (`direct` / `relay`), relay region and transport update metadata
- database guards preventing relay-only -> direct downgrade and route selection on closed sessions
- Rust schema exposure
- dedicated source-contract tests
- project/WBS update without claiming RustDesk transport completion

## Honest boundary

This PR does **not** implement RustDesk wire compatibility, hbbs/hbbr, sidecar execution, clipboard, file transfer, audio, or packaged release completion. Worker route-negotiation APIs and provider execution remain to be implemented and verified.

## Verification

No capability will be marked complete until GitHub Actions passes and protected merge/canonical-main readback succeeds.