### PR TITLE
fix(release): unify macOS and iOS TestFlight delivery

### DIFF
--- a/.github/scripts/check-publish-cd-release.sh
+++ b/.github/scripts/check-publish-cd-release.sh
@@ -99,6 +99,8 @@ for forbidden in (
 
 for required in (
     'workflow_dispatch',
+    'workflow_run',
+    'target="${INPUT_TARGET:-both}"',
     'Build and upload Electron macOS MAS package',
     'Build and upload native iOS IPA',
     'upload-app-store-connect.sh',
@@ -109,6 +111,9 @@ for required in (
 ):
     if required not in apple_store_workflow:
         missing.append(f'Apple Store workflow missing: {required}')
+
+if apple_store_workflow.count('run: bash .github/scripts/upload-app-store-connect.sh') != 2:
+    missing.append('Apple Store workflow must route both macOS and iOS through the shared App Store Connect uploader')
 
 for forbidden in (
     'flutter build',

--- a/.github/workflows/apple-store-delivery.yml
+++ b/.github/workflows/apple-store-delivery.yml
@@ -96,7 +96,7 @@ jobs:
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
           app_version="${INPUT_VERSION:-$(jq -r '.version' app-version.json)}"
-          target="${INPUT_TARGET:-ios}"
+          target="${INPUT_TARGET:-both}"
           if [ -n "$INPUT_BUILD_NUMBER" ]; then
             build_number="$INPUT_BUILD_NUMBER"
           elif [ "$EVENT_NAME" = 'workflow_run' ]; then


### PR DESCRIPTION
## Summary
- Make automatic Apple Store Delivery default to `both` instead of silently falling back to iOS-only when triggered by `workflow_run`.
- Keep macOS MAS and native iOS packaging platform-specific, but require both paths to use the same shared `upload-app-store-connect.sh` App Store Connect uploader.
- Extend the release contract guardrail so future changes cannot regress the automatic dual-platform behavior.

## Root cause
The manual dispatch UI already defaulted `target` to `both`, but the automatic `workflow_run` path has no workflow inputs and resolved `target="${INPUT_TARGET:-ios}"`. That made marked automatic releases select iOS only. Separately, the latest macOS upload had previously been rejected by App Store Connect because the embedded runtime carried a source-level `native/macos/Info.plist` that Apple treated as a nested bundle; that packaging issue was already fixed on `main` by #2278.

## Validation
- `git diff --check` — pass
- `bash -n .github/scripts/check-publish-cd-release.sh` — pass
- targeted Apple delivery contract — pass: manual default `both`, automatic fallback `both`, macOS+iOS jobs present, exactly two calls to the shared App Store Connect uploader, platform selectors present

The monolithic repository guardrail currently reports unrelated pre-existing contract failures outside this change; those are not introduced by this PR.