### PR TITLE
chore(release): publish mobile auth fix as 1.2.3

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.2",
-  "androidVersionCode": 8,
-  "iosBuildNumber": 8
+  "version": "1.2.3",
+  "androidVersionCode": 9,
+  "iosBuildNumber": 9
 }

--- a/docs/projects/mobile-auth-20260902/README.md
+++ b/docs/projects/mobile-auth-20260902/README.md
@@ -13,7 +13,7 @@ Make Fabushi mobile authentication behave like a native mobile sign-in flow: a m
 - iOS/Android browser starts are identified to the account service as `mobile`.
 - A local auth secrets file that can no longer be decrypted is quarantined and treated as signed out so a fresh browser login can recreate the session; managed/requested secrets are not reset.
 - Native and shared-host CI gates pass before merge.
-- Version is advanced to 1.2.2 and the merged source is delivered through the existing iOS/TestFlight and Google Play workflows, with the auth worker deployed from the same canonical source.
+- Version is advanced to 1.2.3 and the merged source is delivered through the existing iOS/TestFlight and Google Play workflows, with the auth worker deployed from the same canonical source.
 
 ## Evidence
 

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 1.2.2
-        CURRENT_PROJECT_VERSION: 8
+        MARKETING_VERSION: 1.2.3
+        CURRENT_PROJECT_VERSION: 9
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'
     info:

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/native-mobile",
-      "version": "1.2.2"
+      "version": "1.2.3"
     }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
The mobile authentication fix merged in #2280 landed after an existing 1.2.2 store delivery had already been published from an earlier source SHA. This follow-up advances the canonical native-mobile release to 1.2.3 so the fixed in-app authentication flow is shipped as a genuinely new version rather than reusing the existing 1.2.2 identity.

Changes are version metadata only:
- app/mobile version 1.2.3
- Android baseline versionCode 9 (store workflow will allocate a monotonic production code)
- iOS baseline build 9 (store delivery will use a monotonic App Store build number)
- task acceptance record updated to 1.2.3

Per repository policy, authoritative verification remains GitHub Actions.