### PR TITLE
fix(release): align native release gates and prepare 1.2.5

### DIFF
--- a/.github/workflows/native-electron-release.yml
+++ b/.github/workflows/native-electron-release.yml
@@ -83,8 +83,8 @@ jobs:
             'Native mobile result' \
             'Native iOS' \
             'Computer control security result' \
-            'Platform architecture' \
-            'Deploy production control plane'; do
+            'Canonical architecture guardrails' \
+            'Resolve Worker source and deployment impact'; do
             conclusion="$(printf '%s' "$checks_json" | jq -r --arg required "$required" '[.[].check_runs[] | select(.name == $required)] | sort_by(.started_at // .created_at // "") | last | .conclusion // "missing"')"
             if [ "$conclusion" != success ]; then
               echo "Required release gate '$required' is $conclusion for $tagged_sha." >&2

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.4",
-  "androidVersionCode": 10,
-  "iosBuildNumber": 10
+  "version": "1.2.5",
+  "androidVersionCode": 11,
+  "iosBuildNumber": 11
 }

--- a/chatgpt-vps-control/tests/fabushi-embedded-runtime-source.test.js
+++ b/chatgpt-vps-control/tests/fabushi-embedded-runtime-source.test.js
@@ -384,8 +384,8 @@ test("the exact-main platform deployment is recoverable and smokes remote-contro
   const release = source(".github/workflows/native-electron-release.yml");
   for (const gate of [
     "Computer control security result",
-    "Platform architecture",
-    "Deploy production control plane",
+    "Canonical architecture guardrails",
+    "Resolve Worker source and deployment impact",
   ]) assert.ok(release.includes(gate), `unified release is missing ${gate}`);
   assert.match(release, /git merge-base --is-ancestor/);
   assert.match(release, /test "\$RELEASE_TAG" = "v\$version"/);

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/desktop",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "electron-updater": "^6.8.9",
         "lucide-react": "^1.14.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Fabushi Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",

--- a/fabushi/CHANGELOG.md
+++ b/fabushi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 更新日志
 
+## [1.2.5] - 2026-09-02
+
+### 发布门禁修复
+- 修复原生全平台正式发布工作流中的过期检查名称，改为验证当前主线实际存在且成功的 `Canonical architecture guardrails` 与 `Resolve Worker source and deployment impact` 门禁。
+- 统一桌面、Android、iOS 正式版本为 `1.2.5`，Android/iOS 构建号提升至 `11`，避免复用已冻结的 `1.2.4` 发布源。
+- 保留 1.2.4 安装升级 E2E 修复，并要求最终 Release 继续从受保护主线的 exact SHA 构建。
+
+---
+
 ## [1.2.4] - 2026-09-02
 
 ### 发布与升级验证

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 1.2.4
-        CURRENT_PROJECT_VERSION: 10
+        MARKETING_VERSION: 1.2.5
+        CURRENT_PROJECT_VERSION: 11
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'
     info:

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/native-mobile",
-      "version": "1.2.4"
+      "version": "1.2.5"
     }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
## Summary
- replace stale native-release gate names with the current protected-main checks: `Canonical architecture guardrails` and `Resolve Worker source and deployment impact`
- retain exact-tag/main ancestry and all existing CI/platform/security checks
- advance the canonical release train to 1.2.5 / mobile build 11 because v1.2.4 is already frozen
- record the release-gate correction in the changelog

## Root cause
The v1.2.4 native all-platform release failed before any platform build because `.github/workflows/native-electron-release.yml` still required `Platform architecture` and `Deploy production control plane`, neither of which exists on the final main SHA. The current successful checks are `Canonical architecture guardrails` and `Resolve Worker source and deployment impact`.

## Validation
- `node --check .github/scripts/verify-release-updater-ui.mjs`
- `.github/scripts/assert-native-electron-canonical.sh`
- `git diff --check`