### PR TITLE
fix(ios): leave login gate after browser auth

### DIFF
--- a/mobile/ios/Fabushi/MarketplaceModel.swift
+++ b/mobile/ios/Fabushi/MarketplaceModel.swift
@@ -108,8 +108,8 @@ final class MarketplaceModel {
         }
     }
 
-    private func applyAuth(_ object: [String: Any]?) {
-        loggedIn = object?["loggedIn"] as? Bool ?? false
+    private func applyAuth(_ object: [String: Any]?, defaultLoggedIn: Bool = false) {
+        loggedIn = object?["loggedIn"] as? Bool ?? defaultLoggedIn
         guard let user = object?["user"] as? [String: Any] else {
             accountName = "Fabushi"
             accountEmail = ""
@@ -392,7 +392,11 @@ final class MarketplaceModel {
             }
             switch status {
             case "completed":
-                if let auth = object["auth"] as? [String: Any] { applyAuth(auth) } else { loggedIn = true }
+                if let auth = object["auth"] as? [String: Any] {
+                    applyAuth(auth, defaultLoggedIn: true)
+                } else {
+                    loggedIn = true
+                }
                 browserLoginAttemptId = nil
                 browserLoginURL = nil
                 webAuthenticationSession = nil

--- a/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
+++ b/third_party/mahayana/mahayana-rs/mahayana-product/src/lib.rs
@@ -3004,6 +3004,7 @@ fn typed_session(
     );
     output.insert("provider".to_string(), Value::String(provider.to_string()));
     output.insert("sessionStored".to_string(), Value::Bool(session_stored));
+    output.insert("loggedIn".to_string(), Value::Bool(session_stored));
     strip_credentials(&mut output);
     Ok(Value::Object(output))
 }
@@ -3551,6 +3552,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(session["sessionStored"], true);
+        assert_eq!(session["loggedIn"], true);
         assert_eq!(session["user"]["username"], "tester");
         assert!(session.get("token").is_none());
         assert!(session.get("accessToken").is_none());


### PR DESCRIPTION
## Problem
Production browser authentication completes successfully, but iOS stays on the Fabushi login gate and shows “继续登录”.

## Root cause
`mahayana-product` returned the completed browser session as `auth` without a `loggedIn` field. iOS `applyAuth` treated a missing field as `false`, while Android already defaults a completed browser login to logged in.

## Fix
- Make UI-safe typed sessions explicitly expose `loggedIn` based on whether credentials were successfully stored.
- Make iOS completed-browser-login handling default to logged in when the completion payload is terminal-successful, so the client is backward-compatible with older host payloads.
- Add a Rust regression assertion for the typed session contract.

## Verification
- `git diff --check` passed locally (lightweight only).
- Heavy/native verification will run in GitHub Actions per repository policy.