### PR TITLE
fix(release): Fabushi 1.2.11 check pagination [full-platform-release]

### DIFF
--- a/.github/workflows/post-main-delivery.yml
+++ b/.github/workflows/post-main-delivery.yml
@@ -50,6 +50,8 @@ jobs:
           grep -F 'github.event.workflow_run.head_sha' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'Native mobile result' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'Native iOS' .github/workflows/post-main-delivery.yml >/dev/null
+          grep -F -- '--paginate --slurp' .github/workflows/post-main-delivery.yml >/dev/null
+          grep -F 'map(.check_runs) | add' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'run-id:' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'needs.gate.outputs.electron_run_id' .github/workflows/post-main-delivery.yml >/dev/null
           grep -F 'fabushi-delivery-mac.json' .github/workflows/post-main-delivery.yml >/dev/null
@@ -108,7 +110,9 @@ jobs:
           native_run_id=''
           required_checks=('Native mobile result' 'Native iOS')
           while [ "$SECONDS" -lt "$deadline" ]; do
-            checks="$(gh api -H 'Accept: application/vnd.github+json' "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA/check-runs?per_page=100")"
+            # A busy main SHA can have more than 100 check-runs. Fetch every page so
+            # release gating cannot miss successful native checks outside page one.
+            checks="$(gh api --paginate --slurp -H 'Accept: application/vnd.github+json' "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA/check-runs?per_page=100" | jq '{check_runs: (map(.check_runs) | add)}')"
             all_done=true
             for required in "${required_checks[@]}"; do
               status="$(jq -r --arg required "$required" '[.check_runs[] | select(.name == $required)] | sort_by(.started_at) | last | .status // "missing"' <<<"$checks")"

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.10",
-  "androidVersionCode": 16,
-  "iosBuildNumber": 16
+  "version": "1.2.11",
+  "androidVersionCode": 17,
+  "iosBuildNumber": 17
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/desktop",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "dependencies": {
         "electron-updater": "^6.8.9",
         "lucide-react": "^1.14.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Fabushi Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",

--- a/fabushi/CHANGELOG.md
+++ b/fabushi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 更新日志
 
+## [1.2.11] - 2026-09-02
+
+### 正式发布门禁分页修复
+- 修复 `post-main-delivery` 在同一主线提交拥有超过 100 个 check-runs 时只读取第一页、从而漏掉已成功的 `Native mobile result` / `Native iOS` 并错误等待的问题；现通过 GitHub API 分页聚合全部检查后再执行 exact-SHA 门禁。
+- 将桌面、Android 与 iOS 产品版本统一提升到 `1.2.11`，Android `versionCode` 与 iOS `CURRENT_PROJECT_VERSION` 统一提升到 `17`，避免复用已经启动外部交付的 `1.2.10` 发布身份。
+- 重新从修复后的受保护 `main` 执行桌面 macOS/Windows/Linux、Android/iOS 商店交付、生产部署、不可变 GitHub Release、安装及上一正式版本升级验证；重型构建和测试继续仅由 GitHub Actions 执行。
+
+---
+
 ## [1.2.10] - 2026-09-02
 
 ### 全新正式版本发布

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 1.2.10
-        CURRENT_PROJECT_VERSION: 16
+        MARKETING_VERSION: 1.2.11
+        CURRENT_PROJECT_VERSION: 17
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'
     info:

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/native-mobile",
-      "version": "1.2.10"
+      "version": "1.2.11"
     }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
## Summary
- fix `post-main-delivery` exact-SHA gating so commits with more than 100 check-runs paginate and aggregate every check page before resolving `Native mobile result` / `Native iOS`
- add contract assertions for the pagination invariant
- bump desktop, Android and iOS to Fabushi 1.2.11; Android `versionCode` and iOS build number to 17
- add 1.2.11 changelog entry and rerun the existing formal full-platform release train

## Why
The 1.2.10 main SHA had successful Electron and native mobile quality gates, but post-main delivery only read the first 100 check-runs while the SHA had more than 100. The required successful native checks were outside page one, so the release controller waited even though the platform gates had passed.

## Local lightweight validation
- `git diff --check`
- YAML parse of `.github/workflows/post-main-delivery.yml`
- `node --check .github/scripts/verify-release-updater-ui.mjs`
- desktop/mobile package versions resolve to 1.2.11

Heavy builds, tests, signing, packaging and delivery remain GitHub Actions-only.