### PR TITLE
fix(security): patch fast-uri and prepare 1.2.13 [full-platform-release]

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.12",
-  "androidVersionCode": 18,
-  "iosBuildNumber": 18
+  "version": "1.2.13",
+  "androidVersionCode": 19,
+  "iosBuildNumber": 19
 }

--- a/chatgpt-vps-control/package-lock.json
+++ b/chatgpt-vps-control/package-lock.json
@@ -446,9 +446,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/desktop",
-      "version": "1.2.12",
+      "version": "1.2.13",
       "dependencies": {
         "electron-updater": "^6.8.9",
         "lucide-react": "^1.14.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/desktop",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Fabushi Electron desktop client",
   "homepage": "https://fabushi.ombhrum.com/",
   "author": "bhrumom",

--- a/fabushi/CHANGELOG.md
+++ b/fabushi/CHANGELOG.md
@@ -1,5 +1,15 @@
 # 更新日志
 
+## [1.2.13] - 2026-09-03
+
+### 生产依赖安全修复与全平台正式重发
+- 将 `chatgpt-vps-control` 生产依赖树中的 `fast-uri` 从受当前高危主机混淆/SSRF 公告影响的 `3.1.5` 更新到已修复的 `3.1.6`，并要求 GitHub Actions 重新执行 `npm audit --omit=dev` 安全门禁。
+- 桌面、Android 与 iOS 产品版本统一提升到 `1.2.13`，Android `versionCode` 与 iOS `CURRENT_PROJECT_VERSION` 统一提升到 `19`，确保所有正式渠道使用全新且严格递增的发布身份。
+- 本轮已审阅当前开放 PR #2287；该 RustDesk 融合开发线仍由自身 WBS 标记为未完成，继续隔离在专用分支，不提前并入正式发布主线。正式发布仅以 canonical `main` 为来源。
+- 继续使用仓库现有 exact-main GitHub Actions 完成桌面 macOS/Windows/Linux、Android/iOS、Apple/Google Play 渠道、生产部署、不可变 GitHub Release、全新安装与上一正式版本升级验收；重型构建和测试仅在 GitHub Actions 执行。
+
+---
+
 ## [1.2.12] - 2026-09-02
 
 ### 生产依赖安全修复与正式重发

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.lifestyle
         SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/Fabushi/Fabushi-Bridging-Header.h
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: 1.2.12
-        CURRENT_PROJECT_VERSION: 18
+        MARKETING_VERSION: 1.2.13
+        CURRENT_PROJECT_VERSION: 19
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: '1,2'
     info:

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabushi/native-mobile",
-      "version": "1.2.12"
+      "version": "1.2.13"
     }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabushi/native-mobile",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "private": true,
   "description": "Native iOS (SwiftUI) and Android (Jetpack Compose) shells backed by the Mahayana Rust Host.",
   "scripts": {


### PR DESCRIPTION
## 正式发布范围
- 以 canonical `main@5313b35fc6819e676e8b149ff05f024b52b723dc` 为唯一来源准备全新 1.2.13 正式版本。
- 将生产依赖 `fast-uri` 从 3.1.5 更新到已修复的 3.1.6，重新执行生产依赖审计。
- 统一桌面/Android/iOS 产品版本到 1.2.13，Android versionCode 与 iOS CURRENT_PROJECT_VERSION 到 19，并同步更新日志。
- 保留 `[full-platform-release]` 标记，合并后由现有 exact-main CI/CD 触发桌面、Android/iOS、Apple/Google Play、生产部署、Release 资产及安装/升级验收。

## PR intake
当前另一个开放 PR #2287 是明确的 Draft/WIP RustDesk 融合开发线，其自身 WBS 仍将 RDF-004 标记为 in-progress、RDF-005/006 标记为 planned，因此不提前并入正式发布 lane；已针对其发现的安全/CI 问题在其专用分支修复并继续由 Actions 验证。

## 验证策略
重型构建、测试、安全审计、打包、商店交付与安装/升级验证全部使用 GitHub Actions；本地仅执行 tree/diff 一致性检查。