### PR TITLE
feat(msr): fuse task-oriented OpenBot and Hermes delivery primitives

### DIFF
--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/Models.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/Models.swift
@@ -178,6 +178,19 @@ struct AutomationTask: Codable {
   var reviewFeedback: String?
   var reviewedAt: String?
   var continuationDepth: Int?
+  // Authoritative per-turn timing and continuation state. Wall-clock fields
+  // are persisted for diagnostics, while monotonic nanoseconds are used for
+  // the 20-minute policy so clock adjustments cannot change Chat rotation.
+  var turnStartedAt: String? = nil
+  var turnEndedAt: String? = nil
+  var turnStartedMonotonicNanoseconds: UInt64? = nil
+  var turnEndedMonotonicNanoseconds: UInt64? = nil
+  var thinkingDurationSeconds: Double? = nil
+  var turnThinkingSeconds: Double? = nil
+  var chatConversationId: String? = nil
+  var sameChatFollowUpCount: Int? = nil
+  var newChatContinuationCount: Int? = nil
+  var nextTurnContinuationAction: String? = nil
   var reportFingerprints: [String]?
   var lastActivitySignature: String?
   var lastProgressAt: String?

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueTurnContinuationPolicy.swift
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/native/QueueTurnContinuationPolicy.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+let queueSameChatThinkingLimitSeconds: UInt64 = 1_200
+let queueMaxSameChatFollowUps = 2
+
+struct QueueTurnTiming: Codable, Equatable {
+  var turnStartedAt: String
+  var turnEndedAt: String?
+  var turnStartedMonotonicNanoseconds: UInt64
+  var turnEndedMonotonicNanoseconds: UInt64?
+  var thinkingDurationSeconds: Double?
+  var turnThinkingSeconds: Double?
+  var chatConversationId: String?
+  var sameChatFollowUpCount: Int
+  var newChatContinuationCount: Int
+}
+
+enum QueueTurnContinuationAction: String, Codable {
+  case sameChatFollowUp
+  case newChat
+}
+
+func monotonicDurationSeconds(start: UInt64, end: UInt64) -> Double {
+  guard end >= start else { return 0 }
+  return Double(end - start) / 1_000_000_000
+}
+
+func finishQueueTurnTiming(
+  _ timing: inout QueueTurnTiming,
+  endedAt: String,
+  monotonicNanoseconds: UInt64
+) {
+  timing.turnEndedAt = endedAt
+  timing.turnEndedMonotonicNanoseconds = monotonicNanoseconds
+  let seconds = monotonicDurationSeconds(
+    start: timing.turnStartedMonotonicNanoseconds,
+    end: monotonicNanoseconds
+  )
+  timing.thinkingDurationSeconds = seconds
+  timing.turnThinkingSeconds = seconds
+}
+
+func queueTurnContinuationAction(
+  taskComplete: Bool,
+  timing: QueueTurnTiming
+) -> QueueTurnContinuationAction? {
+  guard !taskComplete else { return nil }
+  let duration = timing.turnThinkingSeconds ?? timing.thinkingDurationSeconds ?? 0
+  if duration < Double(queueSameChatThinkingLimitSeconds),
+     timing.sameChatFollowUpCount < queueMaxSameChatFollowUps {
+    return .sameChatFollowUp
+  }
+  return .newChat
+}
+
+func recordQueueTurnContinuation(
+  _ action: QueueTurnContinuationAction,
+  timing: inout QueueTurnTiming
+) {
+  switch action {
+  case .sameChatFollowUp:
+    timing.sameChatFollowUpCount += 1
+  case .newChat:
+    timing.newChatContinuationCount += 1
+    timing.sameChatFollowUpCount = 0
+  }
+}
+
+func queueSameChatContinuationPrompt() -> String {
+  "继续完成原目标、检查已落盘进度、不要只总结"
+}

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/ACCEPTANCE.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/ACCEPTANCE.md
@@ -1,0 +1,17 @@
+# ACCEPTANCE
+
+- [ ] A real multi-step Bot task streams ordered lifecycle/tool events and reaches a durable terminal state.
+- [ ] Pause/stop/resume/redirect work from desktop and Web against the same canonical run.
+- [ ] Tool policy, approval and audit are enforced; credentials are absent from transcripts/audit.
+- [ ] File, URL, runnable HTML/MiniApp and patch/PR/release deliveries produce durable delivery records/cards with open/download and retry behavior.
+- [ ] Restart/history recovery reconstructs steps, tool output, approvals/errors and delivery cards.
+- [ ] Background/scheduled and subagent work remains correlated with the parent run.
+- [ ] Queue state persists turnStartedAt, turnEndedAt, thinkingDurationSeconds/turnThinkingSeconds, Chat conversation ID, same-chat follow-up count and new-chat continuation count.
+- [ ] Queue uses monotonic duration measurement and exactly enforces: unfinished + duration <1200s + same-chat follow-ups <2 => same Chat continuation; otherwise new Chat.
+- [ ] Tests cover timer behavior, two same-chat continuations, >=1200s rollover, third-round rollover and abnormal recovery; CI is green.
+- [ ] Task is registered in actions-inbox.json and can resume from revision/digest.
+- [ ] PR is merged to canonical main and read back.
+- [ ] Exact-main packaged desktop/Web and affected platform E2E gates are green with required evidence artifacts.
+- [ ] Version/changelog updated and a GitHub Release/tag/assets target the accepted main SHA.
+
+A plan, draft PR, source-only test or unpublished build does not satisfy acceptance.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/ARCHITECTURE.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/ARCHITECTURE.md
@@ -1,0 +1,22 @@
+# Architecture
+
+## Single runtime
+`Mahayana Agent Runtime` remains the only executor. New capability is expressed through its canonical run-event stream and stores, not through an embedded OpenBot/Hermes runtime.
+
+## Canonical event families
+- lifecycle: goal, plan, step.started/progress/completed/failed, run.paused/resumed/stopped/completed/failed
+- tools: tool.requested/approval-required/started/output/completed/failed
+- delegation: subagent.started/progress/completed/failed
+- delivery: artifact.created/updated/failed and delivery.ready/opened/retry-requested/failed
+- control: redirect.requested/applied and takeover.requested/acquired/released
+
+Every event carries conversationId, runId, sequence, timestamp and correlation identifiers. Desktop/Web projections are rebuildable from canonical state.
+
+## Governance
+All side effects route through Fabushi's existing policy/approval/audit boundary. Policy resolves before execution; audit records decision and result while redacting secrets. Human takeover suspends conflicting Bot actions.
+
+## Persistence and recovery
+Run, step, tool, approval, artifact and delivery records are durable. Resume uses idempotency/correlation keys and never repeats a committed side effect. Context compression and memory/skills are inputs to the existing runtime rather than an alternate loop.
+
+## Queue supervisor
+chatgpt-auto-confirm records wall-clock turnStartedAt/turnEndedAt plus monotonic duration, Chat conversation ID, same-chat follow-up count and new-chat continuation count. For unfinished turns shorter than 1200 seconds, it sends at most two audited follow-ups in the same Chat. After two follow-ups, or after any >=1200-second turn, it rolls to a fresh Chat carrying only durable task/revision/workspace/PR/Actions evidence and remaining work.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/PRD.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/PRD.md
@@ -1,0 +1,19 @@
+# PRD — task-oriented Bot delivery
+
+## User outcome
+A Bot conversation is a durable work session rather than a one-shot answer. The user sees ordered steps, streamed reasoning-safe progress summaries and tool events, approvals, errors, artifacts and completion. Work can be paused, stopped, resumed or redirected and remains coherent across desktop and Web.
+
+## Requirements
+1. Reuse the single Mahayana Agent runtime and existing MiniApp/Artifact/StepTracker/Sandbox boundaries.
+2. Persist conversation/run/step/tool/approval/artifact/delivery state and recover it after restart.
+3. Tool actions pass the existing policy/approval/audit boundary; secrets are never emitted in transcripts or audit payloads.
+4. Delivery is first-class: files, URLs, runnable HTML/MiniApps, patches/PRs and releases produce artifact/delivery events, durable records, open/download cards and retryable failures.
+5. Desktop and Web consume the same canonical event/state model for live progress, pause/stop/resume/redirect, approvals/errors and delivery cards.
+6. Background/scheduled tasks and subagents reuse existing scheduler/runtime primitives and retain parent/child correlation.
+7. chatgpt-auto-confirm persists per-turn timing and continuation audit and enforces the two same-chat follow-ups / 1200-second rollover rule using a monotonic clock for duration measurement.
+
+## Non-goals
+- No second agent executor.
+- No wholesale OpenBot/Hermes source import.
+- No credential capture in task history.
+- No static mock as acceptance evidence.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/README.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/README.md
@@ -1,0 +1,17 @@
+# OpenBot + Hermes Agent delivery
+
+Task ID: `openbot-hermes-agent-delivery-20260903`
+Project: `FAB-P0005 / MSR`
+Revision: 1
+Status: in progress
+
+## Goal
+Fuse compatible OpenBot and Hermes Agent capabilities into Fabushi's existing Mahayana Agent runtime without introducing a competing executor. Deliver durable task-oriented Bot conversations, governed tool execution, resumable work, artifact delivery, and consistent desktop/Web state.
+
+## Pinned upstream research
+- CopilotKit/OpenBot `257c1280d684089be9adb0b35cce262efc7064bf` — MIT.
+- NousResearch/hermes-agent `593aa74c6182ce2e5e23bc102daaaae71710c05d` — MIT.
+
+OpenBot informs coworker identity/workspace, policy-first action gateway, audit/watch/takeover, durable threads and component delivery. Hermes informs streaming terminal/tool output, interruption/redirection, recovery/compression, memory/skills, scheduled/background work, subagent parallelism and cross-entry continuity. Designs are adapted behind Fabushi boundaries; upstream code is not wholesale copied.
+
+See PRD.md, ARCHITECTURE.md, TASK.md and ACCEPTANCE.md.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/TASK.md
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/TASK.md
@@ -1,0 +1,12 @@
+# TASK
+
+1. Inventory existing Mahayana run/event/artifact/delivery and desktop/Web projections; map upstream ideas to existing boundaries.
+2. Extend canonical Bot run/delivery contracts only where gaps exist; persist and stream lifecycle/tool/approval/error/delegation/artifact/delivery/control events.
+3. Wire desktop and Web to the same state for live progress and controls; preserve historical recovery.
+4. Implement delivery cards and retry/open/download actions over canonical artifact/delivery records.
+5. Extend chatgpt-auto-confirm durable queue state with per-turn wall timestamps, monotonic durations, conversation ID, same-chat follow-up count and new-chat continuation count.
+6. Implement/test continuation policy: <1200 seconds + follow-ups <2 => same Chat; otherwise fresh Chat; abnormal renderer recovery remains idempotent and auditable.
+7. Add CI regression coverage and task-specific E2E evidence.
+8. Merge through main, run exact-main packaged/E2E gates, bump version/changelog as required and publish a GitHub Release traceable to the accepted main SHA.
+
+No item is complete without objective GitHub evidence.

--- a/.agents/plugins/plugins/chatgpt-auto-confirm/test/queue-turn-continuation-policy.test.mjs
+++ b/.agents/plugins/plugins/chatgpt-auto-confirm/test/queue-turn-continuation-policy.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const pluginRoot = fileURLToPath(new URL('..', import.meta.url));
+const policyPath = join(pluginRoot, 'native', 'QueueTurnContinuationPolicy.swift');
+
+test('queue turn continuation policy uses monotonic timing and rolls chat after two follow-ups or 1200 seconds', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'queue-turn-policy-'));
+  const driverPath = join(directory, 'main.swift');
+  const binaryPath = join(directory, 'policy-test');
+  try {
+    writeFileSync(driverPath, `import Foundation
+
+func timing(_ seconds: Double, _ followUps: Int) -> QueueTurnTiming {
+  QueueTurnTiming(
+    turnStartedAt: "2026-09-03T00:00:00Z",
+    turnEndedAt: "2026-09-03T00:00:01Z",
+    turnStartedMonotonicNanoseconds: 10,
+    turnEndedMonotonicNanoseconds: UInt64(10 + seconds * 1_000_000_000),
+    thinkingDurationSeconds: seconds,
+    turnThinkingSeconds: seconds,
+    chatConversationId: "chat-1",
+    sameChatFollowUpCount: followUps,
+    newChatContinuationCount: 0
+  )
+}
+
+guard queueTurnContinuationAction(taskComplete: false, timing: timing(1199, 0)) == .sameChatFollowUp else { exit(1) }
+guard queueTurnContinuationAction(taskComplete: false, timing: timing(1199, 1)) == .sameChatFollowUp else { exit(2) }
+guard queueTurnContinuationAction(taskComplete: false, timing: timing(1199, 2)) == .newChat else { exit(3) }
+guard queueTurnContinuationAction(taskComplete: false, timing: timing(1200, 0)) == .newChat else { exit(4) }
+guard queueTurnContinuationAction(taskComplete: true, timing: timing(1, 0)) == nil else { exit(5) }
+
+var measured = timing(0, 0)
+measured.turnStartedMonotonicNanoseconds = 1_000_000_000
+finishQueueTurnTiming(&measured, endedAt: "wall-clock-can-jump", monotonicNanoseconds: 3_500_000_000)
+guard measured.turnThinkingSeconds == 2.5 else { exit(6) }
+
+var counters = timing(30, 1)
+recordQueueTurnContinuation(.sameChatFollowUp, timing: &counters)
+guard counters.sameChatFollowUpCount == 2 else { exit(7) }
+recordQueueTurnContinuation(.newChat, timing: &counters)
+guard counters.sameChatFollowUpCount == 0 && counters.newChatContinuationCount == 1 else { exit(8) }
+guard queueSameChatContinuationPrompt() == "继续完成原目标、检查已落盘进度、不要只总结" else { exit(9) }
+print("queue-turn-policy-ok")
+`);
+    execFileSync('xcrun', ['swiftc', policyPath, driverPath, '-o', binaryPath], { stdio: 'pipe' });
+    assert.equal(execFileSync(binaryPath, { encoding: 'utf8' }).trim(), 'queue-turn-policy-ok');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/projects/mahayana-sovereign-runtime/management/tasks/MSR-401-openbot-hermes-agent-delivery.md
+++ b/projects/mahayana-sovereign-runtime/management/tasks/MSR-401-openbot-hermes-agent-delivery.md
@@ -1,0 +1,18 @@
+# MSR-401 — OpenBot + Hermes Agent delivery fusion
+
+Status: in progress
+Task ID: `openbot-hermes-agent-delivery-20260903`
+
+## Objective
+Upgrade Fabushi's existing Mahayana Agent runtime into a durable task-oriented Bot delivery experience by adapting proven ideas from OpenBot and Hermes Agent without creating a second executor.
+
+## Open-source-first evidence
+- CopilotKit/OpenBot pinned at `257c1280d684089be9adb0b35cce262efc7064bf`, MIT. Reuse/adapt concepts: per-Bot identity/workspace, policy-first action gateway, audit, watch/takeover, durable threads and component responses.
+- NousResearch/hermes-agent pinned at `593aa74c6182ce2e5e23bc102daaaae71710c05d`, MIT. Reuse/adapt concepts: streamed tool output, interruption/redirection, recovery/context compression, memory/skills, cron/background work, subagent parallelism and cross-entry continuity.
+- Decision: adapt architecture and behavior behind Fabushi's existing runtime, policy, approval, artifact and UI boundaries. Do not import either runtime wholesale.
+
+## Durable task definition
+`.agents/plugins/plugins/chatgpt-auto-confirm/tasks/openbot-hermes-agent-delivery-20260903/`
+
+## Completion gate
+Only merged canonical main + required exact-main CI/E2E evidence + published release may move this record to complete.


### PR DESCRIPTION
## Governed project
FAB-P0005 / MSR, task `openbot-hermes-agent-delivery-20260903`.

## Current slice
- pins and records MIT OpenBot/Hermes upstream research
- creates durable task definition and MSR work item
- introduces monotonic per-turn timing/continuation policy primitive
- adds regression coverage for <1200s same-Chat continuation, two-follow-up limit, >=1200s new-Chat rollover and counter reset

## Still required before ready
Integrate timing state into AutomationTask/QueueWorker/QueueMonitoring, register actions-inbox, complete canonical run/delivery events and desktop/Web projections, run CI/E2E, merge and publish a verified release. This PR remains draft until those gates are objectively complete.